### PR TITLE
[RISCV] Order stack objects by access density

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
@@ -2884,8 +2884,7 @@ void RISCVFrameLowering::orderFrameObjects(
     Sorting.push_back(Obj);
   }
 
-  // Count static references to each frame index. This provides an access
-  // density heuristic without requiring profile data.
+  // Count the number of uses for each object.
   for (const MachineBasicBlock &MBB : MF) {
     for (const MachineInstr &MI : MBB) {
       if (MI.isDebugInstr())

--- a/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
@@ -2864,6 +2864,7 @@ void RISCVFrameLowering::orderFrameObjects(
   // non-default-stack-ID or other special objects to ObjectsToAllocate, so
   // the objects seen here are safe to reorder.
   const MachineFrameInfo &MFI = MF.getFrameInfo();
+  const RISCVRegisterInfo *RI = STI.getRegisterInfo();
 
   DenseMap<int, unsigned> Index;
   SmallVector<RISCVFrameSortingObject> Sorting;
@@ -2917,7 +2918,7 @@ void RISCVFrameLowering::orderFrameObjects(
   // Ordinary local objects in a non-realigned FP frame are addressed from the
   // opposite end of the allocation order. Reverse the SP/BP-oriented order so
   // high-density objects are close to FP instead.
-  if (!STI.getRegisterInfo()->hasStackRealignment(MF) && hasFP(MF))
+  if (!RI->hasStackRealignment(MF) && hasFP(MF))
     std::reverse(ObjectsToAllocate.begin(), ObjectsToAllocate.end());
 }
 

--- a/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
@@ -15,6 +15,8 @@
 #include "MCTargetDesc/RISCVMCTargetDesc.h"
 #include "RISCVMachineFunctionInfo.h"
 #include "RISCVSubtarget.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/CodeGen/CFIInstBuilder.h"
 #include "llvm/CodeGen/LivePhysRegs.h"
@@ -2844,6 +2846,77 @@ void RISCVFrameLowering::inlineStackProbe(MachineFunction &MF,
       MBBI->eraseFromParent();
     }
   }
+}
+
+namespace {
+/// Bookkeeping record used while ordering local stack objects by access
+/// density. One record is created for each frame index passed to
+/// orderFrameObjects().
+struct RISCVFrameSortingObject {
+  int ObjectIndex;
+  uint64_t ObjectSize;
+  Align ObjectAlign;
+  uint64_t NumUses = 0;
+};
+} // end anonymous namespace
+
+void RISCVFrameLowering::orderFrameObjects(
+    const MachineFunction &MF, SmallVectorImpl<int> &ObjectsToAllocate) const {
+  // PEI has already removed callee-saved, dead, stack-protector, EH and other
+  // special objects from ObjectsToAllocate. The remaining objects are safe to
+  // reorder.
+  const MachineFrameInfo &MFI = MF.getFrameInfo();
+
+  DenseMap<int, unsigned> Index;
+  SmallVector<RISCVFrameSortingObject, 0> Sorting;
+  Sorting.reserve(ObjectsToAllocate.size());
+
+  for (int FI : ObjectsToAllocate) {
+    int64_t Size = MFI.getObjectSize(FI);
+    RISCVFrameSortingObject Obj{
+        FI, Size > 0 ? static_cast<uint64_t>(Size) : 1,
+        MFI.getObjectAlign(FI)};
+    Index[FI] = Sorting.size();
+    Sorting.push_back(Obj);
+  }
+
+  // Count static references to each frame index. This provides an access
+  // density heuristic without requiring profile data.
+  for (const MachineBasicBlock &MBB : MF) {
+    for (const MachineInstr &MI : MBB) {
+      if (MI.isDebugInstr())
+        continue;
+      for (const MachineOperand &MO : MI.operands()) {
+        if (!MO.isFI())
+          continue;
+        auto It = Index.find(MO.getIndex());
+        if (It != Index.end())
+          ++Sorting[It->second].NumUses;
+      }
+    }
+  }
+
+  // Sort by NumUses / ObjectSize using cross multiplication. High-density
+  // objects are placed at the end of the list, which puts them closest to SP
+  // or BP when PEI allocates objects on the downward-growing stack.
+  llvm::stable_sort(
+      Sorting, [](const RISCVFrameSortingObject &A,
+                  const RISCVFrameSortingObject &B) {
+        uint64_t DensityA = A.NumUses * B.ObjectSize;
+        uint64_t DensityB = B.NumUses * A.ObjectSize;
+        if (DensityA != DensityB)
+          return DensityA < DensityB;
+        return A.ObjectAlign < B.ObjectAlign;
+      });
+
+  for (auto [Idx, Obj] : llvm::enumerate(Sorting))
+    ObjectsToAllocate[Idx] = Obj.ObjectIndex;
+
+  // Ordinary local objects in a non-realigned FP frame are addressed from the
+  // opposite end of the allocation order. Reverse the SP/BP-oriented order so
+  // high-density objects are close to FP instead.
+  if (!STI.getRegisterInfo()->hasStackRealignment(MF) && hasFP(MF))
+    std::reverse(ObjectsToAllocate.begin(), ObjectsToAllocate.end());
 }
 
 int RISCVFrameLowering::getInitialCFAOffset(const MachineFunction &MF) const {

--- a/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
@@ -2873,9 +2873,8 @@ void RISCVFrameLowering::orderFrameObjects(
 
   for (int FI : ObjectsToAllocate) {
     int64_t Size = MFI.getObjectSize(FI);
-    RISCVFrameSortingObject Obj{
-        FI, Size > 0 ? static_cast<uint64_t>(Size) : 1,
-        MFI.getObjectAlign(FI)};
+    RISCVFrameSortingObject Obj{FI, Size > 0 ? static_cast<uint64_t>(Size) : 1,
+                                MFI.getObjectAlign(FI)};
     Index[FI] = Sorting.size();
     Sorting.push_back(Obj);
   }
@@ -2899,15 +2898,14 @@ void RISCVFrameLowering::orderFrameObjects(
   // Sort by NumUses / ObjectSize using cross multiplication. High-density
   // objects are placed at the end of the list, which puts them closest to SP
   // or BP when PEI allocates objects on the downward-growing stack.
-  llvm::stable_sort(
-      Sorting, [](const RISCVFrameSortingObject &A,
-                  const RISCVFrameSortingObject &B) {
-        uint64_t DensityA = A.NumUses * B.ObjectSize;
-        uint64_t DensityB = B.NumUses * A.ObjectSize;
-        if (DensityA != DensityB)
-          return DensityA < DensityB;
-        return A.ObjectAlign < B.ObjectAlign;
-      });
+  llvm::stable_sort(Sorting, [](const RISCVFrameSortingObject &A,
+                                const RISCVFrameSortingObject &B) {
+    uint64_t DensityA = A.NumUses * B.ObjectSize;
+    uint64_t DensityB = B.NumUses * A.ObjectSize;
+    if (DensityA != DensityB)
+      return DensityA < DensityB;
+    return A.ObjectAlign < B.ObjectAlign;
+  });
 
   for (auto [Idx, Obj] : llvm::enumerate(Sorting))
     ObjectsToAllocate[Idx] = Obj.ObjectIndex;

--- a/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
@@ -15,8 +15,6 @@
 #include "MCTargetDesc/RISCVMCTargetDesc.h"
 #include "RISCVMachineFunctionInfo.h"
 #include "RISCVSubtarget.h"
-#include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/CodeGen/CFIInstBuilder.h"
 #include "llvm/CodeGen/LivePhysRegs.h"
@@ -2862,18 +2860,25 @@ struct RISCVFrameSortingObject {
 
 void RISCVFrameLowering::orderFrameObjects(
     const MachineFunction &MF, SmallVectorImpl<int> &ObjectsToAllocate) const {
-  // PEI has already removed callee-saved, dead, stack-protector, EH and other
-  // special objects from ObjectsToAllocate. The remaining objects are safe to
-  // reorder.
+  // PEI never adds callee-saved, dead, stack-protector, EH, scavenging,
+  // non-default-stack-ID or other special objects to ObjectsToAllocate, so
+  // the objects seen here are safe to reorder.
   const MachineFrameInfo &MFI = MF.getFrameInfo();
 
   DenseMap<int, unsigned> Index;
-  SmallVector<RISCVFrameSortingObject, 0> Sorting;
+  SmallVector<RISCVFrameSortingObject> Sorting;
   Sorting.reserve(ObjectsToAllocate.size());
 
   for (int FI : ObjectsToAllocate) {
+    assert(MFI.getStackID(FI) == TargetStackID::Default &&
+           "Only default stack objects should be reordered");
+    // Variable-sized objects report a size of zero. Give them a non-zero
+    // sentinel so the density comparison below does not degenerate. Their
+    // placement does not matter much in practice: they occupy no space in
+    // the static frame and are addressed by adjusting SP at runtime rather
+    // than through a frame index offset.
     int64_t Size = MFI.getObjectSize(FI);
-    RISCVFrameSortingObject Obj{FI, Size > 0 ? static_cast<uint64_t>(Size) : 1,
+    RISCVFrameSortingObject Obj{FI, Size > 0 ? static_cast<uint64_t>(Size) : 4,
                                 MFI.getObjectAlign(FI)};
     Index[FI] = Sorting.size();
     Sorting.push_back(Obj);

--- a/llvm/lib/Target/RISCV/RISCVFrameLowering.h
+++ b/llvm/lib/Target/RISCV/RISCVFrameLowering.h
@@ -85,6 +85,12 @@ public:
     return StackId != TargetStackID::ScalableVector;
   }
 
+  // Order local stack objects by access density so frequently accessed objects
+  // are placed close to the stack addressing base. This hook is only called by
+  // PEI when optimizing and StackSymbolOrdering is enabled.
+  void orderFrameObjects(const MachineFunction &MF,
+                         SmallVectorImpl<int> &ObjectsToAllocate) const override;
+
   void allocateStack(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI,
                      MachineFunction &MF, uint64_t Offset,
                      uint64_t RealStackSize, bool EmitCFI, bool NeedProbe,

--- a/llvm/lib/Target/RISCV/RISCVFrameLowering.h
+++ b/llvm/lib/Target/RISCV/RISCVFrameLowering.h
@@ -88,8 +88,9 @@ public:
   // Order local stack objects by access density so frequently accessed objects
   // are placed close to the stack addressing base. This hook is only called by
   // PEI when optimizing and StackSymbolOrdering is enabled.
-  void orderFrameObjects(const MachineFunction &MF,
-                         SmallVectorImpl<int> &ObjectsToAllocate) const override;
+  void
+  orderFrameObjects(const MachineFunction &MF,
+                    SmallVectorImpl<int> &ObjectsToAllocate) const override;
 
   void allocateStack(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI,
                      MachineFunction &MF, uint64_t Offset,

--- a/llvm/test/CodeGen/RISCV/GlobalISel/vararg.ll
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/vararg.ll
@@ -533,8 +533,8 @@ define i64 @va2(ptr %fmt, ...) nounwind {
 ; RV32D-ILP32:       # %bb.0:
 ; RV32D-ILP32-NEXT:    addi sp, sp, -48
 ; RV32D-ILP32-NEXT:    addi a0, sp, 20
-; RV32D-ILP32-NEXT:    sw a0, 12(sp)
-; RV32D-ILP32-NEXT:    lw a0, 12(sp)
+; RV32D-ILP32-NEXT:    sw a0, 4(sp)
+; RV32D-ILP32-NEXT:    lw a0, 4(sp)
 ; RV32D-ILP32-NEXT:    sw a1, 20(sp)
 ; RV32D-ILP32-NEXT:    sw a2, 24(sp)
 ; RV32D-ILP32-NEXT:    sw a3, 28(sp)
@@ -546,10 +546,10 @@ define i64 @va2(ptr %fmt, ...) nounwind {
 ; RV32D-ILP32-NEXT:    andi a1, a1, -8
 ; RV32D-ILP32-NEXT:    fld fa5, 0(a1)
 ; RV32D-ILP32-NEXT:    addi a0, a0, 15
-; RV32D-ILP32-NEXT:    sw a0, 12(sp)
-; RV32D-ILP32-NEXT:    fsd fa5, 0(sp)
-; RV32D-ILP32-NEXT:    lw a0, 0(sp)
-; RV32D-ILP32-NEXT:    lw a1, 4(sp)
+; RV32D-ILP32-NEXT:    sw a0, 4(sp)
+; RV32D-ILP32-NEXT:    fsd fa5, 8(sp)
+; RV32D-ILP32-NEXT:    lw a0, 8(sp)
+; RV32D-ILP32-NEXT:    lw a1, 12(sp)
 ; RV32D-ILP32-NEXT:    addi sp, sp, 48
 ; RV32D-ILP32-NEXT:    ret
 ;
@@ -557,8 +557,8 @@ define i64 @va2(ptr %fmt, ...) nounwind {
 ; RV32D-ILP32F:       # %bb.0:
 ; RV32D-ILP32F-NEXT:    addi sp, sp, -48
 ; RV32D-ILP32F-NEXT:    addi a0, sp, 20
-; RV32D-ILP32F-NEXT:    sw a0, 12(sp)
-; RV32D-ILP32F-NEXT:    lw a0, 12(sp)
+; RV32D-ILP32F-NEXT:    sw a0, 4(sp)
+; RV32D-ILP32F-NEXT:    lw a0, 4(sp)
 ; RV32D-ILP32F-NEXT:    sw a1, 20(sp)
 ; RV32D-ILP32F-NEXT:    sw a2, 24(sp)
 ; RV32D-ILP32F-NEXT:    sw a3, 28(sp)
@@ -570,10 +570,10 @@ define i64 @va2(ptr %fmt, ...) nounwind {
 ; RV32D-ILP32F-NEXT:    andi a1, a1, -8
 ; RV32D-ILP32F-NEXT:    fld fa5, 0(a1)
 ; RV32D-ILP32F-NEXT:    addi a0, a0, 15
-; RV32D-ILP32F-NEXT:    sw a0, 12(sp)
-; RV32D-ILP32F-NEXT:    fsd fa5, 0(sp)
-; RV32D-ILP32F-NEXT:    lw a0, 0(sp)
-; RV32D-ILP32F-NEXT:    lw a1, 4(sp)
+; RV32D-ILP32F-NEXT:    sw a0, 4(sp)
+; RV32D-ILP32F-NEXT:    fsd fa5, 8(sp)
+; RV32D-ILP32F-NEXT:    lw a0, 8(sp)
+; RV32D-ILP32F-NEXT:    lw a1, 12(sp)
 ; RV32D-ILP32F-NEXT:    addi sp, sp, 48
 ; RV32D-ILP32F-NEXT:    ret
 ;
@@ -581,8 +581,8 @@ define i64 @va2(ptr %fmt, ...) nounwind {
 ; RV32D-ILP32D:       # %bb.0:
 ; RV32D-ILP32D-NEXT:    addi sp, sp, -48
 ; RV32D-ILP32D-NEXT:    addi a0, sp, 20
-; RV32D-ILP32D-NEXT:    sw a0, 12(sp)
-; RV32D-ILP32D-NEXT:    lw a0, 12(sp)
+; RV32D-ILP32D-NEXT:    sw a0, 4(sp)
+; RV32D-ILP32D-NEXT:    lw a0, 4(sp)
 ; RV32D-ILP32D-NEXT:    sw a1, 20(sp)
 ; RV32D-ILP32D-NEXT:    sw a2, 24(sp)
 ; RV32D-ILP32D-NEXT:    sw a3, 28(sp)
@@ -594,10 +594,10 @@ define i64 @va2(ptr %fmt, ...) nounwind {
 ; RV32D-ILP32D-NEXT:    andi a1, a1, -8
 ; RV32D-ILP32D-NEXT:    fld fa5, 0(a1)
 ; RV32D-ILP32D-NEXT:    addi a0, a0, 15
-; RV32D-ILP32D-NEXT:    sw a0, 12(sp)
-; RV32D-ILP32D-NEXT:    fsd fa5, 0(sp)
-; RV32D-ILP32D-NEXT:    lw a0, 0(sp)
-; RV32D-ILP32D-NEXT:    lw a1, 4(sp)
+; RV32D-ILP32D-NEXT:    sw a0, 4(sp)
+; RV32D-ILP32D-NEXT:    fsd fa5, 8(sp)
+; RV32D-ILP32D-NEXT:    lw a0, 8(sp)
+; RV32D-ILP32D-NEXT:    lw a1, 12(sp)
 ; RV32D-ILP32D-NEXT:    addi sp, sp, 48
 ; RV32D-ILP32D-NEXT:    ret
 ;
@@ -876,8 +876,8 @@ define i64 @va3(i32 %a, i64 %b, ...) nounwind {
 ; RV32D-ILP32:       # %bb.0:
 ; RV32D-ILP32-NEXT:    addi sp, sp, -48
 ; RV32D-ILP32-NEXT:    addi a0, sp, 28
-; RV32D-ILP32-NEXT:    sw a0, 20(sp)
-; RV32D-ILP32-NEXT:    lw a0, 20(sp)
+; RV32D-ILP32-NEXT:    sw a0, 12(sp)
+; RV32D-ILP32-NEXT:    lw a0, 12(sp)
 ; RV32D-ILP32-NEXT:    sw a3, 28(sp)
 ; RV32D-ILP32-NEXT:    sw a4, 32(sp)
 ; RV32D-ILP32-NEXT:    sw a5, 36(sp)
@@ -887,10 +887,10 @@ define i64 @va3(i32 %a, i64 %b, ...) nounwind {
 ; RV32D-ILP32-NEXT:    andi a3, a3, -8
 ; RV32D-ILP32-NEXT:    fld fa5, 0(a3)
 ; RV32D-ILP32-NEXT:    addi a0, a0, 15
-; RV32D-ILP32-NEXT:    sw a0, 20(sp)
-; RV32D-ILP32-NEXT:    fsd fa5, 8(sp)
-; RV32D-ILP32-NEXT:    lw a3, 8(sp)
-; RV32D-ILP32-NEXT:    lw a4, 12(sp)
+; RV32D-ILP32-NEXT:    sw a0, 12(sp)
+; RV32D-ILP32-NEXT:    fsd fa5, 16(sp)
+; RV32D-ILP32-NEXT:    lw a3, 16(sp)
+; RV32D-ILP32-NEXT:    lw a4, 20(sp)
 ; RV32D-ILP32-NEXT:    add a0, a1, a3
 ; RV32D-ILP32-NEXT:    sltu a1, a0, a3
 ; RV32D-ILP32-NEXT:    add a2, a2, a4
@@ -902,8 +902,8 @@ define i64 @va3(i32 %a, i64 %b, ...) nounwind {
 ; RV32D-ILP32F:       # %bb.0:
 ; RV32D-ILP32F-NEXT:    addi sp, sp, -48
 ; RV32D-ILP32F-NEXT:    addi a0, sp, 28
-; RV32D-ILP32F-NEXT:    sw a0, 20(sp)
-; RV32D-ILP32F-NEXT:    lw a0, 20(sp)
+; RV32D-ILP32F-NEXT:    sw a0, 12(sp)
+; RV32D-ILP32F-NEXT:    lw a0, 12(sp)
 ; RV32D-ILP32F-NEXT:    sw a3, 28(sp)
 ; RV32D-ILP32F-NEXT:    sw a4, 32(sp)
 ; RV32D-ILP32F-NEXT:    sw a5, 36(sp)
@@ -913,10 +913,10 @@ define i64 @va3(i32 %a, i64 %b, ...) nounwind {
 ; RV32D-ILP32F-NEXT:    andi a3, a3, -8
 ; RV32D-ILP32F-NEXT:    fld fa5, 0(a3)
 ; RV32D-ILP32F-NEXT:    addi a0, a0, 15
-; RV32D-ILP32F-NEXT:    sw a0, 20(sp)
-; RV32D-ILP32F-NEXT:    fsd fa5, 8(sp)
-; RV32D-ILP32F-NEXT:    lw a3, 8(sp)
-; RV32D-ILP32F-NEXT:    lw a4, 12(sp)
+; RV32D-ILP32F-NEXT:    sw a0, 12(sp)
+; RV32D-ILP32F-NEXT:    fsd fa5, 16(sp)
+; RV32D-ILP32F-NEXT:    lw a3, 16(sp)
+; RV32D-ILP32F-NEXT:    lw a4, 20(sp)
 ; RV32D-ILP32F-NEXT:    add a0, a1, a3
 ; RV32D-ILP32F-NEXT:    sltu a1, a0, a3
 ; RV32D-ILP32F-NEXT:    add a2, a2, a4
@@ -928,8 +928,8 @@ define i64 @va3(i32 %a, i64 %b, ...) nounwind {
 ; RV32D-ILP32D:       # %bb.0:
 ; RV32D-ILP32D-NEXT:    addi sp, sp, -48
 ; RV32D-ILP32D-NEXT:    addi a0, sp, 28
-; RV32D-ILP32D-NEXT:    sw a0, 20(sp)
-; RV32D-ILP32D-NEXT:    lw a0, 20(sp)
+; RV32D-ILP32D-NEXT:    sw a0, 12(sp)
+; RV32D-ILP32D-NEXT:    lw a0, 12(sp)
 ; RV32D-ILP32D-NEXT:    sw a3, 28(sp)
 ; RV32D-ILP32D-NEXT:    sw a4, 32(sp)
 ; RV32D-ILP32D-NEXT:    sw a5, 36(sp)
@@ -939,10 +939,10 @@ define i64 @va3(i32 %a, i64 %b, ...) nounwind {
 ; RV32D-ILP32D-NEXT:    andi a3, a3, -8
 ; RV32D-ILP32D-NEXT:    fld fa5, 0(a3)
 ; RV32D-ILP32D-NEXT:    addi a0, a0, 15
-; RV32D-ILP32D-NEXT:    sw a0, 20(sp)
-; RV32D-ILP32D-NEXT:    fsd fa5, 8(sp)
-; RV32D-ILP32D-NEXT:    lw a3, 8(sp)
-; RV32D-ILP32D-NEXT:    lw a4, 12(sp)
+; RV32D-ILP32D-NEXT:    sw a0, 12(sp)
+; RV32D-ILP32D-NEXT:    fsd fa5, 16(sp)
+; RV32D-ILP32D-NEXT:    lw a3, 16(sp)
+; RV32D-ILP32D-NEXT:    lw a4, 20(sp)
 ; RV32D-ILP32D-NEXT:    add a0, a1, a3
 ; RV32D-ILP32D-NEXT:    sltu a1, a0, a3
 ; RV32D-ILP32D-NEXT:    add a2, a2, a4
@@ -1226,35 +1226,35 @@ define iXLen @va4_va_copy(i32 %argno, ...) nounwind {
 ; RV32-NEXT:    sw a5, 52(sp)
 ; RV32-NEXT:    sw a6, 56(sp)
 ; RV32-NEXT:    sw a7, 60(sp)
-; RV32-NEXT:    sw a0, 16(sp)
-; RV32-NEXT:    lw a0, 16(sp)
+; RV32-NEXT:    sw a0, 12(sp)
+; RV32-NEXT:    lw a0, 12(sp)
 ; RV32-NEXT:    addi a0, a0, 3
 ; RV32-NEXT:    li s0, -4
 ; RV32-NEXT:    and a0, a0, s0
 ; RV32-NEXT:    addi a1, a0, 4
-; RV32-NEXT:    sw a1, 16(sp)
-; RV32-NEXT:    lw a1, 16(sp)
-; RV32-NEXT:    lw s1, 0(a0)
 ; RV32-NEXT:    sw a1, 12(sp)
-; RV32-NEXT:    lw a0, 12(sp)
-; RV32-NEXT:    call notdead
+; RV32-NEXT:    lw a1, 12(sp)
+; RV32-NEXT:    lw s1, 0(a0)
+; RV32-NEXT:    sw a1, 16(sp)
 ; RV32-NEXT:    lw a0, 16(sp)
+; RV32-NEXT:    call notdead
+; RV32-NEXT:    lw a0, 12(sp)
 ; RV32-NEXT:    addi a0, a0, 3
 ; RV32-NEXT:    and a0, a0, s0
 ; RV32-NEXT:    addi a1, a0, 4
-; RV32-NEXT:    sw a1, 16(sp)
-; RV32-NEXT:    lw a1, 16(sp)
+; RV32-NEXT:    sw a1, 12(sp)
+; RV32-NEXT:    lw a1, 12(sp)
 ; RV32-NEXT:    addi a1, a1, 3
 ; RV32-NEXT:    and a1, a1, s0
 ; RV32-NEXT:    addi a2, a1, 4
 ; RV32-NEXT:    lw a0, 0(a0)
-; RV32-NEXT:    sw a2, 16(sp)
-; RV32-NEXT:    lw a2, 16(sp)
+; RV32-NEXT:    sw a2, 12(sp)
+; RV32-NEXT:    lw a2, 12(sp)
 ; RV32-NEXT:    addi a2, a2, 3
 ; RV32-NEXT:    andi a2, a2, -4
 ; RV32-NEXT:    addi a3, a2, 4
 ; RV32-NEXT:    lw a1, 0(a1)
-; RV32-NEXT:    sw a3, 16(sp)
+; RV32-NEXT:    sw a3, 12(sp)
 ; RV32-NEXT:    lw a2, 0(a2)
 ; RV32-NEXT:    add a0, a0, s1
 ; RV32-NEXT:    add a1, a1, a2
@@ -1279,38 +1279,38 @@ define iXLen @va4_va_copy(i32 %argno, ...) nounwind {
 ; RV64-NEXT:    sd a5, 88(sp)
 ; RV64-NEXT:    sd a6, 96(sp)
 ; RV64-NEXT:    sd a7, 104(sp)
-; RV64-NEXT:    sd a0, 16(sp)
-; RV64-NEXT:    ld a0, 16(sp)
+; RV64-NEXT:    sd a0, 8(sp)
+; RV64-NEXT:    ld a0, 8(sp)
 ; RV64-NEXT:    addi a0, a0, 7
 ; RV64-NEXT:    li s0, -8
 ; RV64-NEXT:    and a0, a0, s0
 ; RV64-NEXT:    addi a1, a0, 8
-; RV64-NEXT:    sd a1, 16(sp)
-; RV64-NEXT:    ld a1, 16(sp)
-; RV64-NEXT:    ld s1, 0(a0)
 ; RV64-NEXT:    sd a1, 8(sp)
-; RV64-NEXT:    lw a0, 12(sp)
-; RV64-NEXT:    lwu a1, 8(sp)
+; RV64-NEXT:    ld a1, 8(sp)
+; RV64-NEXT:    ld s1, 0(a0)
+; RV64-NEXT:    sd a1, 16(sp)
+; RV64-NEXT:    lw a0, 20(sp)
+; RV64-NEXT:    lwu a1, 16(sp)
 ; RV64-NEXT:    slli a0, a0, 32
 ; RV64-NEXT:    or a0, a0, a1
 ; RV64-NEXT:    call notdead
-; RV64-NEXT:    ld a0, 16(sp)
+; RV64-NEXT:    ld a0, 8(sp)
 ; RV64-NEXT:    addi a0, a0, 7
 ; RV64-NEXT:    and a0, a0, s0
 ; RV64-NEXT:    addi a1, a0, 8
-; RV64-NEXT:    sd a1, 16(sp)
-; RV64-NEXT:    ld a1, 16(sp)
+; RV64-NEXT:    sd a1, 8(sp)
+; RV64-NEXT:    ld a1, 8(sp)
 ; RV64-NEXT:    addi a1, a1, 7
 ; RV64-NEXT:    and a1, a1, s0
 ; RV64-NEXT:    addi a2, a1, 8
 ; RV64-NEXT:    ld a0, 0(a0)
-; RV64-NEXT:    sd a2, 16(sp)
-; RV64-NEXT:    ld a2, 16(sp)
+; RV64-NEXT:    sd a2, 8(sp)
+; RV64-NEXT:    ld a2, 8(sp)
 ; RV64-NEXT:    addi a2, a2, 7
 ; RV64-NEXT:    andi a2, a2, -8
 ; RV64-NEXT:    addi a3, a2, 8
 ; RV64-NEXT:    ld a1, 0(a1)
-; RV64-NEXT:    sd a3, 16(sp)
+; RV64-NEXT:    sd a3, 8(sp)
 ; RV64-NEXT:    ld a2, 0(a2)
 ; RV64-NEXT:    add a0, a0, s1
 ; RV64-NEXT:    add a1, a1, a2
@@ -1655,8 +1655,8 @@ define i32 @va_large_stack(ptr %fmt, ...) {
 ; RV32-WITHFP-NEXT:    addi a0, a0, -1728
 ; RV32-WITHFP-NEXT:    sub sp, sp, a0
 ; RV32-WITHFP-NEXT:    addi a0, s0, 4
-; RV32-WITHFP-NEXT:    sw a0, 0(sp)
-; RV32-WITHFP-NEXT:    lw a0, 0(sp)
+; RV32-WITHFP-NEXT:    sw a0, -16(s0)
+; RV32-WITHFP-NEXT:    lw a0, -16(s0)
 ; RV32-WITHFP-NEXT:    sw a1, 4(s0)
 ; RV32-WITHFP-NEXT:    sw a2, 8(s0)
 ; RV32-WITHFP-NEXT:    sw a3, 12(s0)
@@ -1665,7 +1665,7 @@ define i32 @va_large_stack(ptr %fmt, ...) {
 ; RV32-WITHFP-NEXT:    sw a5, 20(s0)
 ; RV32-WITHFP-NEXT:    sw a6, 24(s0)
 ; RV32-WITHFP-NEXT:    sw a7, 28(s0)
-; RV32-WITHFP-NEXT:    sw a1, 0(sp)
+; RV32-WITHFP-NEXT:    sw a1, -16(s0)
 ; RV32-WITHFP-NEXT:    lw a0, 0(a0)
 ; RV32-WITHFP-NEXT:    lui a1, 24414
 ; RV32-WITHFP-NEXT:    addi a1, a1, -1728
@@ -1693,10 +1693,10 @@ define i32 @va_large_stack(ptr %fmt, ...) {
 ; RV64-WITHFP-NEXT:    addi a0, a0, -1680
 ; RV64-WITHFP-NEXT:    sub sp, sp, a0
 ; RV64-WITHFP-NEXT:    addi a0, s0, 8
-; RV64-WITHFP-NEXT:    mv t0, sp
-; RV64-WITHFP-NEXT:    sd a0, 0(sp)
+; RV64-WITHFP-NEXT:    addi t0, s0, -32
+; RV64-WITHFP-NEXT:    sd a0, -32(s0)
 ; RV64-WITHFP-NEXT:    lw a0, 4(t0)
-; RV64-WITHFP-NEXT:    lwu t0, 0(sp)
+; RV64-WITHFP-NEXT:    lwu t0, -32(s0)
 ; RV64-WITHFP-NEXT:    slli a0, a0, 32
 ; RV64-WITHFP-NEXT:    or a0, a0, t0
 ; RV64-WITHFP-NEXT:    sd a1, 8(s0)
@@ -1708,8 +1708,8 @@ define i32 @va_large_stack(ptr %fmt, ...) {
 ; RV64-WITHFP-NEXT:    sd a6, 48(s0)
 ; RV64-WITHFP-NEXT:    sd a7, 56(s0)
 ; RV64-WITHFP-NEXT:    srli a2, a1, 32
-; RV64-WITHFP-NEXT:    sw a1, 0(sp)
-; RV64-WITHFP-NEXT:    sw a2, 4(sp)
+; RV64-WITHFP-NEXT:    sw a1, -32(s0)
+; RV64-WITHFP-NEXT:    sw a2, -28(s0)
 ; RV64-WITHFP-NEXT:    lw a0, 0(a0)
 ; RV64-WITHFP-NEXT:    lui a1, 24414
 ; RV64-WITHFP-NEXT:    addi a1, a1, -1680
@@ -1778,14 +1778,14 @@ define iXLen @va_vprintf(ptr %fmt, ptr %arg_start) {
 ; RV32-WITHFP-NEXT:    .cfi_offset s0, -8
 ; RV32-WITHFP-NEXT:    addi s0, sp, 16
 ; RV32-WITHFP-NEXT:    .cfi_def_cfa s0, 0
-; RV32-WITHFP-NEXT:    sw a1, 4(sp)
-; RV32-WITHFP-NEXT:    lw a0, 4(sp)
-; RV32-WITHFP-NEXT:    sw a0, 0(sp)
+; RV32-WITHFP-NEXT:    sw a1, 0(sp)
 ; RV32-WITHFP-NEXT:    lw a0, 0(sp)
+; RV32-WITHFP-NEXT:    sw a0, 4(sp)
+; RV32-WITHFP-NEXT:    lw a0, 4(sp)
 ; RV32-WITHFP-NEXT:    addi a0, a0, 3
 ; RV32-WITHFP-NEXT:    andi a0, a0, -4
 ; RV32-WITHFP-NEXT:    addi a1, a0, 4
-; RV32-WITHFP-NEXT:    sw a1, 0(sp)
+; RV32-WITHFP-NEXT:    sw a1, 4(sp)
 ; RV32-WITHFP-NEXT:    lw a0, 0(a0)
 ; RV32-WITHFP-NEXT:    .cfi_def_cfa sp, 16
 ; RV32-WITHFP-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
@@ -1806,14 +1806,14 @@ define iXLen @va_vprintf(ptr %fmt, ptr %arg_start) {
 ; RV64-WITHFP-NEXT:    .cfi_offset s0, -16
 ; RV64-WITHFP-NEXT:    addi s0, sp, 32
 ; RV64-WITHFP-NEXT:    .cfi_def_cfa s0, 0
-; RV64-WITHFP-NEXT:    sd a1, 8(sp)
-; RV64-WITHFP-NEXT:    ld a0, 8(sp)
-; RV64-WITHFP-NEXT:    sd a0, 0(sp)
+; RV64-WITHFP-NEXT:    sd a1, 0(sp)
 ; RV64-WITHFP-NEXT:    ld a0, 0(sp)
+; RV64-WITHFP-NEXT:    sd a0, 8(sp)
+; RV64-WITHFP-NEXT:    ld a0, 8(sp)
 ; RV64-WITHFP-NEXT:    addi a0, a0, 7
 ; RV64-WITHFP-NEXT:    andi a0, a0, -8
 ; RV64-WITHFP-NEXT:    addi a1, a0, 8
-; RV64-WITHFP-NEXT:    sd a1, 0(sp)
+; RV64-WITHFP-NEXT:    sd a1, 8(sp)
 ; RV64-WITHFP-NEXT:    ld a0, 0(a0)
 ; RV64-WITHFP-NEXT:    .cfi_def_cfa sp, 32
 ; RV64-WITHFP-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload

--- a/llvm/test/CodeGen/RISCV/GlobalISel/wide-scalar-shift-by-byte-multiple-legalization.ll
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/wide-scalar-shift-by-byte-multiple-legalization.ll
@@ -3015,7 +3015,7 @@ define void @lshr_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    slli t2, t2, 8
 ; RV32I-NEXT:    or t1, s0, t1
 ; RV32I-NEXT:    or a3, t3, t0
-; RV32I-NEXT:    sw a5, 4(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    beqz a7, .LBB12_4
 ; RV32I-NEXT:  # %bb.3:
 ; RV32I-NEXT:    li s0, 0
@@ -3098,10 +3098,10 @@ define void @lshr_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    slli s6, s5, 16
 ; RV32I-NEXT:    li a5, 4
 ; RV32I-NEXT:    sll s2, t1, s3
-; RV32I-NEXT:    sw s2, 8(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s2, 4(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    beqz t5, .LBB12_19
 ; RV32I-NEXT:  # %bb.18:
-; RV32I-NEXT:    lw t2, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t2, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB12_19:
 ; RV32I-NEXT:    lbu s2, 28(a0)
 ; RV32I-NEXT:    slli s8, s8, 8
@@ -3162,7 +3162,7 @@ define void @lshr_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    mv s4, s0
 ; RV32I-NEXT:    beqz a4, .LBB12_32
 ; RV32I-NEXT:  .LBB12_36:
-; RV32I-NEXT:    sw s4, 4(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s4, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    li s0, 0
 ; RV32I-NEXT:    beqz t5, .LBB12_33
 ; RV32I-NEXT:  .LBB12_37:
@@ -3240,7 +3240,7 @@ define void @lshr_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    li s0, 0
 ; RV32I-NEXT:    beqz t5, .LBB12_44
 ; RV32I-NEXT:  .LBB12_63:
-; RV32I-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s0, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    li a5, 3
 ; RV32I-NEXT:    beq a7, a5, .LBB12_45
 ; RV32I-NEXT:    j .LBB12_46
@@ -3315,7 +3315,7 @@ define void @lshr_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    li t4, 0
 ; RV32I-NEXT:    beqz t5, .LBB12_73
 ; RV32I-NEXT:  .LBB12_87:
-; RV32I-NEXT:    lw t4, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t4, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne a7, s4, .LBB12_74
 ; RV32I-NEXT:  .LBB12_88:
 ; RV32I-NEXT:    or t3, s10, t4
@@ -3358,7 +3358,7 @@ define void @lshr_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    li t4, 0
 ; RV32I-NEXT:    beqz t5, .LBB12_100
 ; RV32I-NEXT:  .LBB12_99:
-; RV32I-NEXT:    lw t4, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t4, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB12_100:
 ; RV32I-NEXT:    beq a7, s1, .LBB12_113
 ; RV32I-NEXT:  # %bb.101:
@@ -3433,7 +3433,7 @@ define void @lshr_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    li t3, 0
 ; RV32I-NEXT:    beqz t5, .LBB12_111
 ; RV32I-NEXT:  .LBB12_123:
-; RV32I-NEXT:    lw t3, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bnez a7, .LBB12_112
 ; RV32I-NEXT:  .LBB12_124:
 ; RV32I-NEXT:    or t3, s10, t3
@@ -3628,7 +3628,7 @@ define void @lshr_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    mv t3, t4
 ; RV32I-NEXT:  .LBB12_185:
 ; RV32I-NEXT:    li t4, 0
-; RV32I-NEXT:    lw a5, 4(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne a7, t5, .LBB12_201
 ; RV32I-NEXT:  # %bb.186:
 ; RV32I-NEXT:    li t3, 0
@@ -4153,7 +4153,7 @@ define void @lshr_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) noun
 ; RV32I-NEXT:    slli t2, t2, 8
 ; RV32I-NEXT:    or t1, s0, t1
 ; RV32I-NEXT:    or a3, t3, t0
-; RV32I-NEXT:    sw a5, 4(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    beqz a7, .LBB13_4
 ; RV32I-NEXT:  # %bb.3:
 ; RV32I-NEXT:    li s0, 0
@@ -4236,10 +4236,10 @@ define void @lshr_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) noun
 ; RV32I-NEXT:    slli s6, s5, 16
 ; RV32I-NEXT:    li a5, 4
 ; RV32I-NEXT:    sll s2, t1, s3
-; RV32I-NEXT:    sw s2, 8(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s2, 4(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    beqz t5, .LBB13_19
 ; RV32I-NEXT:  # %bb.18:
-; RV32I-NEXT:    lw t2, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t2, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB13_19:
 ; RV32I-NEXT:    lbu s2, 28(a0)
 ; RV32I-NEXT:    slli s8, s8, 8
@@ -4300,7 +4300,7 @@ define void @lshr_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) noun
 ; RV32I-NEXT:    mv s4, s0
 ; RV32I-NEXT:    beqz a4, .LBB13_32
 ; RV32I-NEXT:  .LBB13_36:
-; RV32I-NEXT:    sw s4, 4(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s4, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    li s0, 0
 ; RV32I-NEXT:    beqz t5, .LBB13_33
 ; RV32I-NEXT:  .LBB13_37:
@@ -4378,7 +4378,7 @@ define void @lshr_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) noun
 ; RV32I-NEXT:    li s0, 0
 ; RV32I-NEXT:    beqz t5, .LBB13_44
 ; RV32I-NEXT:  .LBB13_63:
-; RV32I-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s0, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    li a5, 3
 ; RV32I-NEXT:    beq a7, a5, .LBB13_45
 ; RV32I-NEXT:    j .LBB13_46
@@ -4453,7 +4453,7 @@ define void @lshr_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) noun
 ; RV32I-NEXT:    li t4, 0
 ; RV32I-NEXT:    beqz t5, .LBB13_73
 ; RV32I-NEXT:  .LBB13_87:
-; RV32I-NEXT:    lw t4, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t4, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne a7, s4, .LBB13_74
 ; RV32I-NEXT:  .LBB13_88:
 ; RV32I-NEXT:    or t3, s10, t4
@@ -4496,7 +4496,7 @@ define void @lshr_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) noun
 ; RV32I-NEXT:    li t4, 0
 ; RV32I-NEXT:    beqz t5, .LBB13_100
 ; RV32I-NEXT:  .LBB13_99:
-; RV32I-NEXT:    lw t4, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t4, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB13_100:
 ; RV32I-NEXT:    beq a7, s1, .LBB13_113
 ; RV32I-NEXT:  # %bb.101:
@@ -4571,7 +4571,7 @@ define void @lshr_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) noun
 ; RV32I-NEXT:    li t3, 0
 ; RV32I-NEXT:    beqz t5, .LBB13_111
 ; RV32I-NEXT:  .LBB13_123:
-; RV32I-NEXT:    lw t3, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bnez a7, .LBB13_112
 ; RV32I-NEXT:  .LBB13_124:
 ; RV32I-NEXT:    or t3, s10, t3
@@ -4766,7 +4766,7 @@ define void @lshr_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) noun
 ; RV32I-NEXT:    mv t3, t4
 ; RV32I-NEXT:  .LBB13_185:
 ; RV32I-NEXT:    li t4, 0
-; RV32I-NEXT:    lw a5, 4(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne a7, t5, .LBB13_201
 ; RV32I-NEXT:  # %bb.186:
 ; RV32I-NEXT:    li t3, 0
@@ -5291,7 +5291,7 @@ define void @lshr_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) no
 ; RV32I-NEXT:    slli t2, t2, 8
 ; RV32I-NEXT:    or t1, s0, t1
 ; RV32I-NEXT:    or a3, t3, t0
-; RV32I-NEXT:    sw a5, 4(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    beqz a7, .LBB14_4
 ; RV32I-NEXT:  # %bb.3:
 ; RV32I-NEXT:    li s0, 0
@@ -5374,10 +5374,10 @@ define void @lshr_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) no
 ; RV32I-NEXT:    slli s6, s5, 16
 ; RV32I-NEXT:    li a5, 4
 ; RV32I-NEXT:    sll s2, t1, s3
-; RV32I-NEXT:    sw s2, 8(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s2, 4(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    beqz t5, .LBB14_19
 ; RV32I-NEXT:  # %bb.18:
-; RV32I-NEXT:    lw t2, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t2, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB14_19:
 ; RV32I-NEXT:    lbu s2, 28(a0)
 ; RV32I-NEXT:    slli s8, s8, 8
@@ -5438,7 +5438,7 @@ define void @lshr_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) no
 ; RV32I-NEXT:    mv s4, s0
 ; RV32I-NEXT:    beqz a4, .LBB14_32
 ; RV32I-NEXT:  .LBB14_36:
-; RV32I-NEXT:    sw s4, 4(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s4, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    li s0, 0
 ; RV32I-NEXT:    beqz t5, .LBB14_33
 ; RV32I-NEXT:  .LBB14_37:
@@ -5516,7 +5516,7 @@ define void @lshr_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) no
 ; RV32I-NEXT:    li s0, 0
 ; RV32I-NEXT:    beqz t5, .LBB14_44
 ; RV32I-NEXT:  .LBB14_63:
-; RV32I-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s0, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    li a5, 3
 ; RV32I-NEXT:    beq a7, a5, .LBB14_45
 ; RV32I-NEXT:    j .LBB14_46
@@ -5591,7 +5591,7 @@ define void @lshr_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) no
 ; RV32I-NEXT:    li t4, 0
 ; RV32I-NEXT:    beqz t5, .LBB14_73
 ; RV32I-NEXT:  .LBB14_87:
-; RV32I-NEXT:    lw t4, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t4, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne a7, s4, .LBB14_74
 ; RV32I-NEXT:  .LBB14_88:
 ; RV32I-NEXT:    or t3, s10, t4
@@ -5634,7 +5634,7 @@ define void @lshr_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) no
 ; RV32I-NEXT:    li t4, 0
 ; RV32I-NEXT:    beqz t5, .LBB14_100
 ; RV32I-NEXT:  .LBB14_99:
-; RV32I-NEXT:    lw t4, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t4, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB14_100:
 ; RV32I-NEXT:    beq a7, s1, .LBB14_113
 ; RV32I-NEXT:  # %bb.101:
@@ -5709,7 +5709,7 @@ define void @lshr_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) no
 ; RV32I-NEXT:    li t3, 0
 ; RV32I-NEXT:    beqz t5, .LBB14_111
 ; RV32I-NEXT:  .LBB14_123:
-; RV32I-NEXT:    lw t3, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bnez a7, .LBB14_112
 ; RV32I-NEXT:  .LBB14_124:
 ; RV32I-NEXT:    or t3, s10, t3
@@ -5904,7 +5904,7 @@ define void @lshr_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) no
 ; RV32I-NEXT:    mv t3, t4
 ; RV32I-NEXT:  .LBB14_185:
 ; RV32I-NEXT:    li t4, 0
-; RV32I-NEXT:    lw a5, 4(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne a7, t5, .LBB14_201
 ; RV32I-NEXT:  # %bb.186:
 ; RV32I-NEXT:    li t3, 0
@@ -6530,7 +6530,7 @@ define void @shl_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:  # %bb.35:
 ; RV32I-NEXT:    mv a6, t0
 ; RV32I-NEXT:  .LBB15_36:
-; RV32I-NEXT:    sw a6, 4(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 24(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    li t0, 0
 ; RV32I-NEXT:    or a6, t2, a3
 ; RV32I-NEXT:    srl s1, a7, s2
@@ -6606,13 +6606,13 @@ define void @shl_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    li t0, 0
 ; RV32I-NEXT:    or a7, t2, a3
 ; RV32I-NEXT:    srl a3, a6, s2
-; RV32I-NEXT:    sw a3, 24(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 0(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    beqz t5, .LBB15_59
 ; RV32I-NEXT:  # %bb.58:
-; RV32I-NEXT:    lw t0, 24(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t0, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB15_59:
 ; RV32I-NEXT:    sll a3, a7, a1
-; RV32I-NEXT:    sw a3, 20(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    beqz a4, .LBB15_64
 ; RV32I-NEXT:  # %bb.60:
 ; RV32I-NEXT:    li a6, 0
@@ -6686,13 +6686,13 @@ define void @shl_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    li t0, 0
 ; RV32I-NEXT:    or a6, t2, a3
 ; RV32I-NEXT:    srl a3, a7, s2
-; RV32I-NEXT:    sw a3, 16(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 4(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    beqz t5, .LBB15_82
 ; RV32I-NEXT:  # %bb.81:
-; RV32I-NEXT:    lw t0, 16(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t0, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB15_82:
 ; RV32I-NEXT:    sll a3, a6, a1
-; RV32I-NEXT:    sw a3, 8(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 12(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    beqz a4, .LBB15_88
 ; RV32I-NEXT:  # %bb.83:
 ; RV32I-NEXT:    li a7, 0
@@ -6720,7 +6720,7 @@ define void @shl_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB15_90
 ; RV32I-NEXT:  .LBB15_89:
-; RV32I-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB15_90:
 ; RV32I-NEXT:    beq a4, s7, .LBB15_109
 ; RV32I-NEXT:  # %bb.91:
@@ -6753,7 +6753,7 @@ define void @shl_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:  # %bb.100:
 ; RV32I-NEXT:    mv a7, t0
 ; RV32I-NEXT:  .LBB15_101:
-; RV32I-NEXT:    sw s9, 12(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s9, 16(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    li t0, 0
 ; RV32I-NEXT:    lbu t3, 20(a0)
 ; RV32I-NEXT:    or t2, t2, a3
@@ -6777,7 +6777,7 @@ define void @shl_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    mv t1, a6
 ; RV32I-NEXT:  .LBB15_107:
 ; RV32I-NEXT:    sll a3, t0, a1
-; RV32I-NEXT:    sw a3, 0(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 20(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    beqz a4, .LBB15_114
 ; RV32I-NEXT:  # %bb.108:
 ; RV32I-NEXT:    li t1, 0
@@ -6785,7 +6785,7 @@ define void @shl_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    bnez t5, .LBB15_115
 ; RV32I-NEXT:    j .LBB15_116
 ; RV32I-NEXT:  .LBB15_109:
-; RV32I-NEXT:    lw a7, 20(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or a7, a7, a3
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB15_92
@@ -6809,7 +6809,7 @@ define void @shl_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB15_116
 ; RV32I-NEXT:  .LBB15_115:
-; RV32I-NEXT:    lw a3, 16(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB15_116:
 ; RV32I-NEXT:    beq a4, s7, .LBB15_136
 ; RV32I-NEXT:  # %bb.117:
@@ -6876,15 +6876,15 @@ define void @shl_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    bnez t5, .LBB15_143
 ; RV32I-NEXT:    j .LBB15_144
 ; RV32I-NEXT:  .LBB15_136:
-; RV32I-NEXT:    lw a7, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or t1, a7, a3
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB15_118
 ; RV32I-NEXT:  .LBB15_137:
-; RV32I-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne a4, s8, .LBB15_119
 ; RV32I-NEXT:  .LBB15_138:
-; RV32I-NEXT:    lw a7, 20(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or t1, a7, a3
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB15_120
@@ -6892,7 +6892,7 @@ define void @shl_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    mv a3, s1
 ; RV32I-NEXT:    bne a4, t6, .LBB15_121
 ; RV32I-NEXT:  .LBB15_140:
-; RV32I-NEXT:    lw a7, 12(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 16(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or t1, a7, a3
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB15_122
@@ -6924,7 +6924,7 @@ define void @shl_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:  .LBB15_150:
 ; RV32I-NEXT:    bne a4, s3, .LBB15_152
 ; RV32I-NEXT:  .LBB15_151:
-; RV32I-NEXT:    lw a7, 12(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 16(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or t3, a7, a3
 ; RV32I-NEXT:  .LBB15_152:
 ; RV32I-NEXT:    li a7, 1
@@ -6980,23 +6980,23 @@ define void @shl_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    bnez t5, .LBB15_173
 ; RV32I-NEXT:    j .LBB15_174
 ; RV32I-NEXT:  .LBB15_166:
-; RV32I-NEXT:    lw a7, 0(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 20(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or t3, a7, a3
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB15_146
 ; RV32I-NEXT:  .LBB15_167:
-; RV32I-NEXT:    lw a3, 16(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne a4, s8, .LBB15_147
 ; RV32I-NEXT:  .LBB15_168:
-; RV32I-NEXT:    lw a7, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or t3, a7, a3
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB15_148
 ; RV32I-NEXT:  .LBB15_169:
-; RV32I-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne a4, t6, .LBB15_149
 ; RV32I-NEXT:  .LBB15_170:
-; RV32I-NEXT:    lw a7, 20(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or t3, a7, a3
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB15_150
@@ -7056,7 +7056,7 @@ define void @shl_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    sb a4, 1(a2)
 ; RV32I-NEXT:    sb a3, 2(a2)
 ; RV32I-NEXT:    sb a6, 3(a2)
-; RV32I-NEXT:    lw a6, 4(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 24(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli a3, a6, 16
 ; RV32I-NEXT:    and a4, a6, a1
 ; RV32I-NEXT:    srli a4, a4, 8
@@ -7136,23 +7136,23 @@ define void @shl_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    mv a3, a6
 ; RV32I-NEXT:    bne a4, s7, .LBB15_177
 ; RV32I-NEXT:  .LBB15_191:
-; RV32I-NEXT:    lw a6, 0(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 20(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or t2, a6, a3
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB15_178
 ; RV32I-NEXT:  .LBB15_192:
-; RV32I-NEXT:    lw a3, 16(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne a4, s8, .LBB15_179
 ; RV32I-NEXT:  .LBB15_193:
-; RV32I-NEXT:    lw a6, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or t2, a6, a3
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB15_180
 ; RV32I-NEXT:  .LBB15_194:
-; RV32I-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne a4, s3, .LBB15_181
 ; RV32I-NEXT:  .LBB15_195:
-; RV32I-NEXT:    lw a6, 20(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or t2, a6, a3
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB15_182
@@ -7160,7 +7160,7 @@ define void @shl_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    mv a3, s1
 ; RV32I-NEXT:    bne a4, t6, .LBB15_183
 ; RV32I-NEXT:  .LBB15_197:
-; RV32I-NEXT:    lw a6, 12(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 16(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or t2, a6, a3
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB15_184
@@ -7728,13 +7728,13 @@ define void @shl_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) nounw
 ; RV32I-NEXT:    li t0, 0
 ; RV32I-NEXT:    or a7, t2, a3
 ; RV32I-NEXT:    srl a3, a6, s2
-; RV32I-NEXT:    sw a3, 24(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    beqz t5, .LBB16_59
 ; RV32I-NEXT:  # %bb.58:
-; RV32I-NEXT:    lw t0, 24(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t0, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB16_59:
 ; RV32I-NEXT:    sll a3, a7, a1
-; RV32I-NEXT:    sw a3, 20(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 16(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    beqz a4, .LBB16_64
 ; RV32I-NEXT:  # %bb.60:
 ; RV32I-NEXT:    li a6, 0
@@ -7808,13 +7808,13 @@ define void @shl_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) nounw
 ; RV32I-NEXT:    li t0, 0
 ; RV32I-NEXT:    or a6, t2, a3
 ; RV32I-NEXT:    srl a3, a7, s2
-; RV32I-NEXT:    sw a3, 16(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 12(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    beqz t5, .LBB16_82
 ; RV32I-NEXT:  # %bb.81:
-; RV32I-NEXT:    lw t0, 16(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t0, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB16_82:
 ; RV32I-NEXT:    sll a3, a6, a1
-; RV32I-NEXT:    sw a3, 12(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 20(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    beqz a4, .LBB16_88
 ; RV32I-NEXT:  # %bb.83:
 ; RV32I-NEXT:    li a7, 0
@@ -7842,7 +7842,7 @@ define void @shl_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) nounw
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB16_90
 ; RV32I-NEXT:  .LBB16_89:
-; RV32I-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB16_90:
 ; RV32I-NEXT:    beq a4, s9, .LBB16_109
 ; RV32I-NEXT:  # %bb.91:
@@ -7906,7 +7906,7 @@ define void @shl_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) nounw
 ; RV32I-NEXT:    bnez t5, .LBB16_115
 ; RV32I-NEXT:    j .LBB16_116
 ; RV32I-NEXT:  .LBB16_109:
-; RV32I-NEXT:    lw a7, 20(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 16(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or a7, a7, a3
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB16_92
@@ -7931,7 +7931,7 @@ define void @shl_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) nounw
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB16_116
 ; RV32I-NEXT:  .LBB16_115:
-; RV32I-NEXT:    lw a3, 16(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB16_116:
 ; RV32I-NEXT:    li t2, 1
 ; RV32I-NEXT:    beq a4, t2, .LBB16_136
@@ -7960,7 +7960,7 @@ define void @shl_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) nounw
 ; RV32I-NEXT:  # %bb.125:
 ; RV32I-NEXT:    mv t2, t1
 ; RV32I-NEXT:  .LBB16_126:
-; RV32I-NEXT:    sw s10, 8(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s10, 24(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    li t1, 0
 ; RV32I-NEXT:    lbu t3, 25(a0)
 ; RV32I-NEXT:    lbu a3, 26(a0)
@@ -8004,15 +8004,15 @@ define void @shl_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) nounw
 ; RV32I-NEXT:    li t3, 0
 ; RV32I-NEXT:    j .LBB16_143
 ; RV32I-NEXT:  .LBB16_136:
-; RV32I-NEXT:    lw t1, 12(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 20(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or t1, t1, a3
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB16_118
 ; RV32I-NEXT:  .LBB16_137:
-; RV32I-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne a4, t6, .LBB16_119
 ; RV32I-NEXT:  .LBB16_138:
-; RV32I-NEXT:    lw t1, 20(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 16(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or t1, t1, a3
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB16_120
@@ -8108,19 +8108,19 @@ define void @shl_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) nounw
 ; RV32I-NEXT:    bnez t5, .LBB16_174
 ; RV32I-NEXT:    j .LBB16_175
 ; RV32I-NEXT:  .LBB16_166:
-; RV32I-NEXT:    lw a3, 16(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne a4, t6, .LBB16_149
 ; RV32I-NEXT:  .LBB16_167:
-; RV32I-NEXT:    lw t3, 12(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 20(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or t3, t3, a3
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB16_150
 ; RV32I-NEXT:  .LBB16_168:
-; RV32I-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    li t6, 3
 ; RV32I-NEXT:    bne a4, t6, .LBB16_151
 ; RV32I-NEXT:  .LBB16_169:
-; RV32I-NEXT:    lw t3, 20(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 16(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or t3, t3, a3
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB16_152
@@ -8128,7 +8128,7 @@ define void @shl_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) nounw
 ; RV32I-NEXT:    mv a3, a5
 ; RV32I-NEXT:    bne a4, s8, .LBB16_153
 ; RV32I-NEXT:  .LBB16_171:
-; RV32I-NEXT:    lw t3, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 24(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or t3, t3, a3
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB16_154
@@ -8273,18 +8273,18 @@ define void @shl_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) nounw
 ; RV32I-NEXT:    beq a4, s8, .LBB16_178
 ; RV32I-NEXT:    j .LBB16_179
 ; RV32I-NEXT:  .LBB16_193:
-; RV32I-NEXT:    lw a3, 16(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne a4, a6, .LBB16_181
 ; RV32I-NEXT:  .LBB16_194:
-; RV32I-NEXT:    lw a6, 12(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 20(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or t2, a6, a3
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB16_182
 ; RV32I-NEXT:  .LBB16_195:
-; RV32I-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne a4, s3, .LBB16_183
 ; RV32I-NEXT:  .LBB16_196:
-; RV32I-NEXT:    lw a6, 20(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 16(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or t2, a6, a3
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB16_184
@@ -8292,7 +8292,7 @@ define void @shl_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) nounw
 ; RV32I-NEXT:    mv a3, a5
 ; RV32I-NEXT:    bne a4, t6, .LBB16_185
 ; RV32I-NEXT:  .LBB16_198:
-; RV32I-NEXT:    lw a5, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 24(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or t2, a5, a3
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB16_186
@@ -8788,10 +8788,10 @@ define void @shl_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) nou
 ; RV32I-NEXT:    li t0, 0
 ; RV32I-NEXT:    or a5, a5, a3
 ; RV32I-NEXT:    srl a3, a7, s2
-; RV32I-NEXT:    sw a3, 24(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    beqz t5, .LBB17_38
 ; RV32I-NEXT:  # %bb.37:
-; RV32I-NEXT:    lw t0, 24(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t0, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB17_38:
 ; RV32I-NEXT:    sll s7, a5, a1
 ; RV32I-NEXT:    beqz a4, .LBB17_42
@@ -8861,10 +8861,10 @@ define void @shl_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) nou
 ; RV32I-NEXT:    li t0, 0
 ; RV32I-NEXT:    or a7, t2, a3
 ; RV32I-NEXT:    srl a3, a5, s2
-; RV32I-NEXT:    sw a3, 20(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 12(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    beqz t5, .LBB17_59
 ; RV32I-NEXT:  # %bb.58:
-; RV32I-NEXT:    lw t0, 20(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t0, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB17_59:
 ; RV32I-NEXT:    sll a3, a7, a1
 ; RV32I-NEXT:    sw a3, 16(sp) # 4-byte Folded Spill
@@ -8892,7 +8892,7 @@ define void @shl_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) nou
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB17_66
 ; RV32I-NEXT:  .LBB17_65:
-; RV32I-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB17_66:
 ; RV32I-NEXT:    beq a4, s4, .LBB17_84
 ; RV32I-NEXT:  # %bb.67:
@@ -8973,7 +8973,7 @@ define void @shl_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) nou
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB17_90
 ; RV32I-NEXT:  .LBB17_89:
-; RV32I-NEXT:    lw a3, 20(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB17_90:
 ; RV32I-NEXT:    beq a4, s4, .LBB17_110
 ; RV32I-NEXT:  # %bb.91:
@@ -9010,8 +9010,8 @@ define void @shl_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) nou
 ; RV32I-NEXT:  # %bb.101:
 ; RV32I-NEXT:    mv a7, t0
 ; RV32I-NEXT:  .LBB17_102:
-; RV32I-NEXT:    sw s9, 8(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    sw s3, 12(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s9, 20(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s3, 24(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    li t0, 0
 ; RV32I-NEXT:    lbu t3, 20(a0)
 ; RV32I-NEXT:    or t2, t2, a3
@@ -9047,7 +9047,7 @@ define void @shl_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) nou
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB17_92
 ; RV32I-NEXT:  .LBB17_111:
-; RV32I-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne a4, t6, .LBB17_93
 ; RV32I-NEXT:  .LBB17_112:
 ; RV32I-NEXT:    or a7, s7, a3
@@ -9082,14 +9082,14 @@ define void @shl_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) nou
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB17_124
 ; RV32I-NEXT:  # %bb.123:
-; RV32I-NEXT:    lw a3, 12(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB17_124:
 ; RV32I-NEXT:    li s4, 3
 ; RV32I-NEXT:    li s8, 2
 ; RV32I-NEXT:    li t2, 4
 ; RV32I-NEXT:    bne a4, t2, .LBB17_126
 ; RV32I-NEXT:  # %bb.125:
-; RV32I-NEXT:    lw t1, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 20(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or t1, t1, a3
 ; RV32I-NEXT:  .LBB17_126:
 ; RV32I-NEXT:    lbu t6, 27(a0)
@@ -9142,7 +9142,7 @@ define void @shl_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) nou
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB17_118
 ; RV32I-NEXT:  .LBB17_139:
-; RV32I-NEXT:    lw a3, 20(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne a4, t6, .LBB17_119
 ; RV32I-NEXT:  .LBB17_140:
 ; RV32I-NEXT:    lw t1, 16(sp) # 4-byte Folded Reload
@@ -9150,7 +9150,7 @@ define void @shl_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) nou
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB17_120
 ; RV32I-NEXT:  .LBB17_141:
-; RV32I-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    beq a4, s8, .LBB17_121
 ; RV32I-NEXT:    j .LBB17_122
 ; RV32I-NEXT:  .LBB17_142:
@@ -9183,7 +9183,7 @@ define void @shl_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) nou
 ; RV32I-NEXT:  .LBB17_152:
 ; RV32I-NEXT:    bne a4, t6, .LBB17_154
 ; RV32I-NEXT:  .LBB17_153:
-; RV32I-NEXT:    lw t3, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 20(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or t3, t3, a3
 ; RV32I-NEXT:  .LBB17_154:
 ; RV32I-NEXT:    lbu t6, 31(a0)
@@ -9240,7 +9240,7 @@ define void @shl_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) nou
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB17_148
 ; RV32I-NEXT:  .LBB17_167:
-; RV32I-NEXT:    lw a3, 20(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne a4, s4, .LBB17_149
 ; RV32I-NEXT:  .LBB17_168:
 ; RV32I-NEXT:    lw t3, 16(sp) # 4-byte Folded Reload
@@ -9248,7 +9248,7 @@ define void @shl_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) nou
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB17_150
 ; RV32I-NEXT:  .LBB17_169:
-; RV32I-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    li s0, 4
 ; RV32I-NEXT:    bne a4, s0, .LBB17_151
 ; RV32I-NEXT:  .LBB17_170:
@@ -9256,7 +9256,7 @@ define void @shl_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) nou
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB17_152
 ; RV32I-NEXT:  .LBB17_171:
-; RV32I-NEXT:    lw a3, 12(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    beq a4, t6, .LBB17_153
 ; RV32I-NEXT:    j .LBB17_154
 ; RV32I-NEXT:  .LBB17_172:
@@ -9401,7 +9401,7 @@ define void @shl_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) nou
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB17_181
 ; RV32I-NEXT:  .LBB17_194:
-; RV32I-NEXT:    lw a3, 20(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne a4, s3, .LBB17_182
 ; RV32I-NEXT:  .LBB17_195:
 ; RV32I-NEXT:    lw a5, 16(sp) # 4-byte Folded Reload
@@ -9409,17 +9409,17 @@ define void @shl_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) nou
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB17_183
 ; RV32I-NEXT:  .LBB17_196:
-; RV32I-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne a4, s0, .LBB17_184
 ; RV32I-NEXT:  .LBB17_197:
 ; RV32I-NEXT:    or t2, s7, a3
 ; RV32I-NEXT:    li a3, 0
 ; RV32I-NEXT:    beqz t5, .LBB17_185
 ; RV32I-NEXT:  .LBB17_198:
-; RV32I-NEXT:    lw a3, 12(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne a4, t6, .LBB17_186
 ; RV32I-NEXT:  .LBB17_199:
-; RV32I-NEXT:    lw a5, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 20(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or t2, a5, a3
 ; RV32I-NEXT:    li a3, 7
 ; RV32I-NEXT:    beq a4, a3, .LBB17_187
@@ -9893,10 +9893,10 @@ define void @ashr_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    slli s8, s8, 16
 ; RV32I-NEXT:    li s6, 4
 ; RV32I-NEXT:    sll s9, a0, s3
-; RV32I-NEXT:    sw s9, 0(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s9, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    beqz t4, .LBB18_19
 ; RV32I-NEXT:  # %bb.18:
-; RV32I-NEXT:    lw s7, 0(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB18_19:
 ; RV32I-NEXT:    srl ra, t2, a5
 ; RV32I-NEXT:    or t3, s8, t3
@@ -9924,10 +9924,10 @@ define void @ashr_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    li s6, 0
 ; RV32I-NEXT:    li s9, 6
 ; RV32I-NEXT:    sll s10, a1, s3
-; RV32I-NEXT:    sw s10, 8(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s10, 0(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    beqz t4, .LBB18_28
 ; RV32I-NEXT:  # %bb.27:
-; RV32I-NEXT:    lw s6, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s6, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB18_28:
 ; RV32I-NEXT:    mv s10, a3
 ; RV32I-NEXT:    srl s7, t3, a5
@@ -10050,7 +10050,7 @@ define void @ashr_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    li s2, 0
 ; RV32I-NEXT:    beqz t4, .LBB18_47
 ; RV32I-NEXT:  .LBB18_70:
-; RV32I-NEXT:    lw s2, 0(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s2, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    li s10, 3
 ; RV32I-NEXT:    beq t0, s10, .LBB18_48
 ; RV32I-NEXT:    j .LBB18_49
@@ -10062,7 +10062,7 @@ define void @ashr_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    li s2, 0
 ; RV32I-NEXT:    beqz t4, .LBB18_52
 ; RV32I-NEXT:  .LBB18_73:
-; RV32I-NEXT:    lw s2, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s2, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    beq t0, s8, .LBB18_53
 ; RV32I-NEXT:    j .LBB18_54
 ; RV32I-NEXT:  .LBB18_74:
@@ -10127,7 +10127,7 @@ define void @ashr_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    li s0, 0
 ; RV32I-NEXT:    beqz t4, .LBB18_78
 ; RV32I-NEXT:  .LBB18_97:
-; RV32I-NEXT:    lw s0, 0(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne t0, s4, .LBB18_79
 ; RV32I-NEXT:  .LBB18_98:
 ; RV32I-NEXT:    or a6, ra, s0
@@ -10141,7 +10141,7 @@ define void @ashr_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    li s0, 0
 ; RV32I-NEXT:    beqz t4, .LBB18_82
 ; RV32I-NEXT:  .LBB18_101:
-; RV32I-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s0, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne t0, s10, .LBB18_83
 ; RV32I-NEXT:  .LBB18_102:
 ; RV32I-NEXT:    or a6, s9, s0
@@ -10200,7 +10200,7 @@ define void @ashr_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    bnez t4, .LBB18_135
 ; RV32I-NEXT:    j .LBB18_136
 ; RV32I-NEXT:  .LBB18_121:
-; RV32I-NEXT:    lw t5, 0(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t5, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne t0, s0, .LBB18_108
 ; RV32I-NEXT:  .LBB18_122:
 ; RV32I-NEXT:    or a6, ra, t5
@@ -10214,7 +10214,7 @@ define void @ashr_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    li t5, 0
 ; RV32I-NEXT:    beqz t4, .LBB18_111
 ; RV32I-NEXT:  .LBB18_125:
-; RV32I-NEXT:    lw t5, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t5, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne t0, s1, .LBB18_112
 ; RV32I-NEXT:  .LBB18_126:
 ; RV32I-NEXT:    or a6, s9, t5
@@ -10243,7 +10243,7 @@ define void @ashr_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    li a6, 0
 ; RV32I-NEXT:    beqz t4, .LBB18_119
 ; RV32I-NEXT:  .LBB18_133:
-; RV32I-NEXT:    lw a6, 0(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bnez t0, .LBB18_120
 ; RV32I-NEXT:  .LBB18_134:
 ; RV32I-NEXT:    or a6, ra, a6
@@ -10292,7 +10292,7 @@ define void @ashr_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    li t5, 0
 ; RV32I-NEXT:    beqz t4, .LBB18_138
 ; RV32I-NEXT:  .LBB18_150:
-; RV32I-NEXT:    lw t5, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t5, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne t0, s4, .LBB18_139
 ; RV32I-NEXT:  .LBB18_151:
 ; RV32I-NEXT:    or a6, s9, t5
@@ -10332,7 +10332,7 @@ define void @ashr_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    li t5, 0
 ; RV32I-NEXT:    beqz t4, .LBB18_162
 ; RV32I-NEXT:  .LBB18_161:
-; RV32I-NEXT:    lw t5, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t5, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB18_162:
 ; RV32I-NEXT:    beq t0, s0, .LBB18_174
 ; RV32I-NEXT:  # %bb.163:
@@ -10402,7 +10402,7 @@ define void @ashr_32bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; RV32I-NEXT:    li a6, 0
 ; RV32I-NEXT:    beqz t4, .LBB18_172
 ; RV32I-NEXT:  .LBB18_183:
-; RV32I-NEXT:    lw a6, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bnez t0, .LBB18_173
 ; RV32I-NEXT:  .LBB18_184:
 ; RV32I-NEXT:    or a6, s9, a6
@@ -11074,10 +11074,10 @@ define void @ashr_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) noun
 ; RV32I-NEXT:    slli s8, s8, 16
 ; RV32I-NEXT:    li s6, 4
 ; RV32I-NEXT:    sll s9, a0, s3
-; RV32I-NEXT:    sw s9, 0(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s9, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    beqz t4, .LBB19_19
 ; RV32I-NEXT:  # %bb.18:
-; RV32I-NEXT:    lw s7, 0(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB19_19:
 ; RV32I-NEXT:    srl ra, t2, a5
 ; RV32I-NEXT:    or t3, s8, t3
@@ -11105,10 +11105,10 @@ define void @ashr_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) noun
 ; RV32I-NEXT:    li s6, 0
 ; RV32I-NEXT:    li s9, 6
 ; RV32I-NEXT:    sll s10, a1, s3
-; RV32I-NEXT:    sw s10, 8(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s10, 0(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    beqz t4, .LBB19_28
 ; RV32I-NEXT:  # %bb.27:
-; RV32I-NEXT:    lw s6, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s6, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB19_28:
 ; RV32I-NEXT:    mv s10, a3
 ; RV32I-NEXT:    srl s7, t3, a5
@@ -11231,7 +11231,7 @@ define void @ashr_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) noun
 ; RV32I-NEXT:    li s2, 0
 ; RV32I-NEXT:    beqz t4, .LBB19_47
 ; RV32I-NEXT:  .LBB19_70:
-; RV32I-NEXT:    lw s2, 0(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s2, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    li s10, 3
 ; RV32I-NEXT:    beq t0, s10, .LBB19_48
 ; RV32I-NEXT:    j .LBB19_49
@@ -11243,7 +11243,7 @@ define void @ashr_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) noun
 ; RV32I-NEXT:    li s2, 0
 ; RV32I-NEXT:    beqz t4, .LBB19_52
 ; RV32I-NEXT:  .LBB19_73:
-; RV32I-NEXT:    lw s2, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s2, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    beq t0, s8, .LBB19_53
 ; RV32I-NEXT:    j .LBB19_54
 ; RV32I-NEXT:  .LBB19_74:
@@ -11308,7 +11308,7 @@ define void @ashr_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) noun
 ; RV32I-NEXT:    li s0, 0
 ; RV32I-NEXT:    beqz t4, .LBB19_78
 ; RV32I-NEXT:  .LBB19_97:
-; RV32I-NEXT:    lw s0, 0(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne t0, s4, .LBB19_79
 ; RV32I-NEXT:  .LBB19_98:
 ; RV32I-NEXT:    or a6, ra, s0
@@ -11322,7 +11322,7 @@ define void @ashr_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) noun
 ; RV32I-NEXT:    li s0, 0
 ; RV32I-NEXT:    beqz t4, .LBB19_82
 ; RV32I-NEXT:  .LBB19_101:
-; RV32I-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s0, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne t0, s10, .LBB19_83
 ; RV32I-NEXT:  .LBB19_102:
 ; RV32I-NEXT:    or a6, s9, s0
@@ -11381,7 +11381,7 @@ define void @ashr_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) noun
 ; RV32I-NEXT:    bnez t4, .LBB19_135
 ; RV32I-NEXT:    j .LBB19_136
 ; RV32I-NEXT:  .LBB19_121:
-; RV32I-NEXT:    lw t5, 0(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t5, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne t0, s0, .LBB19_108
 ; RV32I-NEXT:  .LBB19_122:
 ; RV32I-NEXT:    or a6, ra, t5
@@ -11395,7 +11395,7 @@ define void @ashr_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) noun
 ; RV32I-NEXT:    li t5, 0
 ; RV32I-NEXT:    beqz t4, .LBB19_111
 ; RV32I-NEXT:  .LBB19_125:
-; RV32I-NEXT:    lw t5, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t5, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne t0, s1, .LBB19_112
 ; RV32I-NEXT:  .LBB19_126:
 ; RV32I-NEXT:    or a6, s9, t5
@@ -11424,7 +11424,7 @@ define void @ashr_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) noun
 ; RV32I-NEXT:    li a6, 0
 ; RV32I-NEXT:    beqz t4, .LBB19_119
 ; RV32I-NEXT:  .LBB19_133:
-; RV32I-NEXT:    lw a6, 0(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bnez t0, .LBB19_120
 ; RV32I-NEXT:  .LBB19_134:
 ; RV32I-NEXT:    or a6, ra, a6
@@ -11473,7 +11473,7 @@ define void @ashr_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) noun
 ; RV32I-NEXT:    li t5, 0
 ; RV32I-NEXT:    beqz t4, .LBB19_138
 ; RV32I-NEXT:  .LBB19_150:
-; RV32I-NEXT:    lw t5, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t5, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne t0, s4, .LBB19_139
 ; RV32I-NEXT:  .LBB19_151:
 ; RV32I-NEXT:    or a6, s9, t5
@@ -11513,7 +11513,7 @@ define void @ashr_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) noun
 ; RV32I-NEXT:    li t5, 0
 ; RV32I-NEXT:    beqz t4, .LBB19_162
 ; RV32I-NEXT:  .LBB19_161:
-; RV32I-NEXT:    lw t5, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t5, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB19_162:
 ; RV32I-NEXT:    beq t0, s0, .LBB19_174
 ; RV32I-NEXT:  # %bb.163:
@@ -11583,7 +11583,7 @@ define void @ashr_32bytes_wordOff(ptr %src.ptr, ptr %wordOff.ptr, ptr %dst) noun
 ; RV32I-NEXT:    li a6, 0
 ; RV32I-NEXT:    beqz t4, .LBB19_172
 ; RV32I-NEXT:  .LBB19_183:
-; RV32I-NEXT:    lw a6, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bnez t0, .LBB19_173
 ; RV32I-NEXT:  .LBB19_184:
 ; RV32I-NEXT:    or a6, s9, a6
@@ -12255,10 +12255,10 @@ define void @ashr_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) no
 ; RV32I-NEXT:    slli s8, s8, 16
 ; RV32I-NEXT:    li s6, 4
 ; RV32I-NEXT:    sll s9, a0, s3
-; RV32I-NEXT:    sw s9, 0(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s9, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    beqz t4, .LBB20_19
 ; RV32I-NEXT:  # %bb.18:
-; RV32I-NEXT:    lw s7, 0(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB20_19:
 ; RV32I-NEXT:    srl ra, t2, a5
 ; RV32I-NEXT:    or t3, s8, t3
@@ -12286,10 +12286,10 @@ define void @ashr_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) no
 ; RV32I-NEXT:    li s6, 0
 ; RV32I-NEXT:    li s9, 6
 ; RV32I-NEXT:    sll s10, a1, s3
-; RV32I-NEXT:    sw s10, 8(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s10, 0(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    beqz t4, .LBB20_28
 ; RV32I-NEXT:  # %bb.27:
-; RV32I-NEXT:    lw s6, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s6, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB20_28:
 ; RV32I-NEXT:    mv s10, a3
 ; RV32I-NEXT:    srl s7, t3, a5
@@ -12412,7 +12412,7 @@ define void @ashr_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) no
 ; RV32I-NEXT:    li s2, 0
 ; RV32I-NEXT:    beqz t4, .LBB20_47
 ; RV32I-NEXT:  .LBB20_70:
-; RV32I-NEXT:    lw s2, 0(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s2, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    li s10, 3
 ; RV32I-NEXT:    beq t0, s10, .LBB20_48
 ; RV32I-NEXT:    j .LBB20_49
@@ -12424,7 +12424,7 @@ define void @ashr_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) no
 ; RV32I-NEXT:    li s2, 0
 ; RV32I-NEXT:    beqz t4, .LBB20_52
 ; RV32I-NEXT:  .LBB20_73:
-; RV32I-NEXT:    lw s2, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s2, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    beq t0, s8, .LBB20_53
 ; RV32I-NEXT:    j .LBB20_54
 ; RV32I-NEXT:  .LBB20_74:
@@ -12489,7 +12489,7 @@ define void @ashr_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) no
 ; RV32I-NEXT:    li s0, 0
 ; RV32I-NEXT:    beqz t4, .LBB20_78
 ; RV32I-NEXT:  .LBB20_97:
-; RV32I-NEXT:    lw s0, 0(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne t0, s4, .LBB20_79
 ; RV32I-NEXT:  .LBB20_98:
 ; RV32I-NEXT:    or a6, ra, s0
@@ -12503,7 +12503,7 @@ define void @ashr_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) no
 ; RV32I-NEXT:    li s0, 0
 ; RV32I-NEXT:    beqz t4, .LBB20_82
 ; RV32I-NEXT:  .LBB20_101:
-; RV32I-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s0, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne t0, s10, .LBB20_83
 ; RV32I-NEXT:  .LBB20_102:
 ; RV32I-NEXT:    or a6, s9, s0
@@ -12562,7 +12562,7 @@ define void @ashr_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) no
 ; RV32I-NEXT:    bnez t4, .LBB20_135
 ; RV32I-NEXT:    j .LBB20_136
 ; RV32I-NEXT:  .LBB20_121:
-; RV32I-NEXT:    lw t5, 0(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t5, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne t0, s0, .LBB20_108
 ; RV32I-NEXT:  .LBB20_122:
 ; RV32I-NEXT:    or a6, ra, t5
@@ -12576,7 +12576,7 @@ define void @ashr_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) no
 ; RV32I-NEXT:    li t5, 0
 ; RV32I-NEXT:    beqz t4, .LBB20_111
 ; RV32I-NEXT:  .LBB20_125:
-; RV32I-NEXT:    lw t5, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t5, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne t0, s1, .LBB20_112
 ; RV32I-NEXT:  .LBB20_126:
 ; RV32I-NEXT:    or a6, s9, t5
@@ -12605,7 +12605,7 @@ define void @ashr_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) no
 ; RV32I-NEXT:    li a6, 0
 ; RV32I-NEXT:    beqz t4, .LBB20_119
 ; RV32I-NEXT:  .LBB20_133:
-; RV32I-NEXT:    lw a6, 0(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bnez t0, .LBB20_120
 ; RV32I-NEXT:  .LBB20_134:
 ; RV32I-NEXT:    or a6, ra, a6
@@ -12654,7 +12654,7 @@ define void @ashr_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) no
 ; RV32I-NEXT:    li t5, 0
 ; RV32I-NEXT:    beqz t4, .LBB20_138
 ; RV32I-NEXT:  .LBB20_150:
-; RV32I-NEXT:    lw t5, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t5, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bne t0, s4, .LBB20_139
 ; RV32I-NEXT:  .LBB20_151:
 ; RV32I-NEXT:    or a6, s9, t5
@@ -12694,7 +12694,7 @@ define void @ashr_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) no
 ; RV32I-NEXT:    li t5, 0
 ; RV32I-NEXT:    beqz t4, .LBB20_162
 ; RV32I-NEXT:  .LBB20_161:
-; RV32I-NEXT:    lw t5, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t5, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:  .LBB20_162:
 ; RV32I-NEXT:    beq t0, s0, .LBB20_174
 ; RV32I-NEXT:  # %bb.163:
@@ -12764,7 +12764,7 @@ define void @ashr_32bytes_dwordOff(ptr %src.ptr, ptr %dwordOff.ptr, ptr %dst) no
 ; RV32I-NEXT:    li a6, 0
 ; RV32I-NEXT:    beqz t4, .LBB20_172
 ; RV32I-NEXT:  .LBB20_183:
-; RV32I-NEXT:    lw a6, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    bnez t0, .LBB20_173
 ; RV32I-NEXT:  .LBB20_184:
 ; RV32I-NEXT:    or a6, s9, a6

--- a/llvm/test/CodeGen/RISCV/bitint-fp-conv-200.ll
+++ b/llvm/test/CodeGen/RISCV/bitint-fp-conv-200.ll
@@ -809,25 +809,25 @@ define void @test_bitint_200_to_float(ptr %in, ptr %out) nounwind {
 ; RV32-NEXT:    li t5, 174
 ; RV32-NEXT:    zext.b t6, a7
 ; RV32-NEXT:    sub a7, t5, t0
-; RV32-NEXT:    sw zero, 112(sp)
-; RV32-NEXT:    sw zero, 116(sp)
-; RV32-NEXT:    sw zero, 120(sp)
-; RV32-NEXT:    sw zero, 124(sp)
-; RV32-NEXT:    sw zero, 96(sp)
-; RV32-NEXT:    sw zero, 100(sp)
-; RV32-NEXT:    sw zero, 104(sp)
-; RV32-NEXT:    sw zero, 108(sp)
+; RV32-NEXT:    sw zero, 48(sp)
+; RV32-NEXT:    sw zero, 52(sp)
+; RV32-NEXT:    sw zero, 56(sp)
+; RV32-NEXT:    sw zero, 60(sp)
+; RV32-NEXT:    sw zero, 32(sp)
+; RV32-NEXT:    sw zero, 36(sp)
+; RV32-NEXT:    sw zero, 40(sp)
+; RV32-NEXT:    sw zero, 44(sp)
 ; RV32-NEXT:    srli t5, a7, 3
-; RV32-NEXT:    sw a4, 80(sp)
-; RV32-NEXT:    sw a3, 84(sp)
-; RV32-NEXT:    sw t6, 88(sp)
-; RV32-NEXT:    sw zero, 92(sp)
+; RV32-NEXT:    sw a4, 16(sp)
+; RV32-NEXT:    sw a3, 20(sp)
+; RV32-NEXT:    sw t6, 24(sp)
+; RV32-NEXT:    sw zero, 28(sp)
 ; RV32-NEXT:    andi t5, t5, 28
-; RV32-NEXT:    addi s0, sp, 64
-; RV32-NEXT:    sw t4, 64(sp)
-; RV32-NEXT:    sw t3, 68(sp)
-; RV32-NEXT:    sw a6, 72(sp)
-; RV32-NEXT:    sw a5, 76(sp)
+; RV32-NEXT:    mv s0, sp
+; RV32-NEXT:    sw t4, 0(sp)
+; RV32-NEXT:    sw t3, 4(sp)
+; RV32-NEXT:    sw a6, 8(sp)
+; RV32-NEXT:    sw a5, 12(sp)
 ; RV32-NEXT:    add t5, s0, t5
 ; RV32-NEXT:    lw s0, 4(t5)
 ; RV32-NEXT:    lw s1, 8(t5)
@@ -837,24 +837,24 @@ define void @test_bitint_200_to_float(ptr %in, ptr %out) nounwind {
 ; RV32-NEXT:    srl s2, s0, a7
 ; RV32-NEXT:    slli s1, s1, 1
 ; RV32-NEXT:    addi t0, t0, 26
-; RV32-NEXT:    sw zero, 16(sp)
-; RV32-NEXT:    sw zero, 20(sp)
-; RV32-NEXT:    sw zero, 24(sp)
-; RV32-NEXT:    sw zero, 28(sp)
-; RV32-NEXT:    sw zero, 0(sp)
-; RV32-NEXT:    sw zero, 4(sp)
-; RV32-NEXT:    sw zero, 8(sp)
-; RV32-NEXT:    sw zero, 12(sp)
-; RV32-NEXT:    sw t4, 32(sp)
-; RV32-NEXT:    sw t3, 36(sp)
-; RV32-NEXT:    sw a6, 40(sp)
-; RV32-NEXT:    sw a5, 44(sp)
+; RV32-NEXT:    sw zero, 80(sp)
+; RV32-NEXT:    sw zero, 84(sp)
+; RV32-NEXT:    sw zero, 88(sp)
+; RV32-NEXT:    sw zero, 92(sp)
+; RV32-NEXT:    sw zero, 64(sp)
+; RV32-NEXT:    sw zero, 68(sp)
+; RV32-NEXT:    sw zero, 72(sp)
+; RV32-NEXT:    sw zero, 76(sp)
+; RV32-NEXT:    sw t4, 96(sp)
+; RV32-NEXT:    sw t3, 100(sp)
+; RV32-NEXT:    sw a6, 104(sp)
+; RV32-NEXT:    sw a5, 108(sp)
 ; RV32-NEXT:    srli a5, t0, 3
 ; RV32-NEXT:    andi a5, a5, 28
-; RV32-NEXT:    addi a6, sp, 32
-; RV32-NEXT:    sw a4, 48(sp)
-; RV32-NEXT:    sw a3, 52(sp)
-; RV32-NEXT:    sw t6, 56(sp)
+; RV32-NEXT:    addi a6, sp, 96
+; RV32-NEXT:    sw a4, 112(sp)
+; RV32-NEXT:    sw a3, 116(sp)
+; RV32-NEXT:    sw t6, 120(sp)
 ; RV32-NEXT:    sub a3, a6, a5
 ; RV32-NEXT:    sll a4, s1, t5
 ; RV32-NEXT:    lw a5, 16(a3)
@@ -1211,7 +1211,7 @@ define void @test_float_to_bitint_200(ptr %in, ptr %out) nounwind {
 ; RV32-NEXT:    srai s1, a2, 31
 ; RV32-NEXT:    slli a2, a2, 9
 ; RV32-NEXT:    zext.b a1, s1
-; RV32-NEXT:    sw a1, 120(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a1, 88(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    srli a2, a2, 9
 ; RV32-NEXT:    lui a1, 2048
 ; RV32-NEXT:    li a3, 149
@@ -1227,7 +1227,7 @@ define void @test_float_to_bitint_200(ptr %in, ptr %out) nounwind {
 ; RV32-NEXT:    mv a2, s10
 ; RV32-NEXT:    li a3, 0
 ; RV32-NEXT:    call __muldi3
-; RV32-NEXT:    sw a0, 116(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    mv s2, a1
 ; RV32-NEXT:    li a0, 0
 ; RV32-NEXT:    li a1, 0
@@ -1243,7 +1243,7 @@ define void @test_float_to_bitint_200(ptr %in, ptr %out) nounwind {
 ; RV32-NEXT:    li a3, 0
 ; RV32-NEXT:    call __muldi3
 ; RV32-NEXT:    add s2, a0, s2
-; RV32-NEXT:    sw s2, 112(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s2, 72(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    sltu a0, s2, a0
 ; RV32-NEXT:    add a0, a1, a0
 ; RV32-NEXT:    add s2, s3, a0
@@ -1280,14 +1280,14 @@ define void @test_float_to_bitint_200(ptr %in, ptr %out) nounwind {
 ; RV32-NEXT:    add s7, s4, s7
 ; RV32-NEXT:    add a2, a0, s6
 ; RV32-NEXT:    add s8, a2, s8
-; RV32-NEXT:    sw s7, 108(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s7, 8(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    sltu s4, s7, s4
 ; RV32-NEXT:    add s8, s8, s4
 ; RV32-NEXT:    beq s8, a2, .LBB2_5
 ; RV32-NEXT:  # %bb.4: # %fp-to-i-if-exp.small
 ; RV32-NEXT:    sltu s4, s8, a2
 ; RV32-NEXT:  .LBB2_5: # %fp-to-i-if-exp.small
-; RV32-NEXT:    sw s8, 104(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s8, 4(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    sltu a3, s6, s3
 ; RV32-NEXT:    sltu a0, a2, a0
 ; RV32-NEXT:    add s6, s2, a3
@@ -1349,7 +1349,7 @@ define void @test_float_to_bitint_200(ptr %in, ptr %out) nounwind {
 ; RV32-NEXT:    mv s1, a0
 ; RV32-NEXT:    mv a0, s5
 ; RV32-NEXT:    li a1, 0
-; RV32-NEXT:    lw a2, 120(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a2, 88(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    # implicit-def: $x13
 ; RV32-NEXT:    call __muldi3
 ; RV32-NEXT:    add a0, s1, a0
@@ -1387,19 +1387,19 @@ define void @test_float_to_bitint_200(ptr %in, ptr %out) nounwind {
 ; RV32-NEXT:    lw a6, 12(a1)
 ; RV32-NEXT:    xori a2, a2, 31
 ; RV32-NEXT:    lw t1, 24(a1)
-; RV32-NEXT:    sw t1, 64(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw t1, 116(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    lw a1, 28(a1)
-; RV32-NEXT:    sw a1, 68(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a1, 120(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    srli a1, a0, 1
-; RV32-NEXT:    sw t0, 76(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw t0, 128(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    sll t0, t0, a7
-; RV32-NEXT:    sw t0, 100(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw t0, 0(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    srl s7, a1, a2
 ; RV32-NEXT:    sll a0, a0, a7
-; RV32-NEXT:    sw a0, 108(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    srli a0, a6, 1
 ; RV32-NEXT:    srl a0, a0, a2
-; RV32-NEXT:    sw a0, 104(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    srli a0, a5, 1
 ; RV32-NEXT:    sll a1, a6, a7
 ; RV32-NEXT:    srl a0, a0, a2
@@ -1410,10 +1410,10 @@ define void @test_float_to_bitint_200(ptr %in, ptr %out) nounwind {
 ; RV32-NEXT:    or s9, a1, a0
 ; RV32-NEXT:    srli a0, a3, 1
 ; RV32-NEXT:    sll a1, a4, a7
-; RV32-NEXT:    sw a2, 72(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a2, 124(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    srl a0, a0, a2
 ; RV32-NEXT:    or s5, a1, a0
-; RV32-NEXT:    sw a7, 80(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a7, 132(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    sll s6, a3, a7
 ; RV32-NEXT:    mv a0, s5
 ; RV32-NEXT:    li a1, 0
@@ -1427,23 +1427,23 @@ define void @test_float_to_bitint_200(ptr %in, ptr %out) nounwind {
 ; RV32-NEXT:    mv a2, s10
 ; RV32-NEXT:    li a3, 0
 ; RV32-NEXT:    call __muldi3
-; RV32-NEXT:    sw a0, 116(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    add s4, s2, a1
 ; RV32-NEXT:    sltu a0, s4, s2
 ; RV32-NEXT:    add s3, s3, a0
-; RV32-NEXT:    sw s6, 124(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s6, 20(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    mv a0, s6
 ; RV32-NEXT:    li a1, 0
 ; RV32-NEXT:    mv a2, s1
 ; RV32-NEXT:    li a3, 0
 ; RV32-NEXT:    call __muldi3
 ; RV32-NEXT:    add s4, a0, s4
-; RV32-NEXT:    sw s4, 112(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s4, 72(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    sltu a0, s4, a0
 ; RV32-NEXT:    add a0, a1, a0
 ; RV32-NEXT:    add s2, s3, a0
 ; RV32-NEXT:    sltu s3, s2, s3
-; RV32-NEXT:    sw s5, 132(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s5, 28(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    mv a0, s5
 ; RV32-NEXT:    li a1, 0
 ; RV32-NEXT:    mv a2, s1
@@ -1460,7 +1460,7 @@ define void @test_float_to_bitint_200(ptr %in, ptr %out) nounwind {
 ; RV32-NEXT:    call __muldi3
 ; RV32-NEXT:    mv s4, a0
 ; RV32-NEXT:    mv s6, a1
-; RV32-NEXT:    sw s8, 128(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s8, 24(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    mv a0, s8
 ; RV32-NEXT:    li a1, 0
 ; RV32-NEXT:    mv a2, s10
@@ -1469,7 +1469,7 @@ define void @test_float_to_bitint_200(ptr %in, ptr %out) nounwind {
 ; RV32-NEXT:    mv s10, a0
 ; RV32-NEXT:    mv s2, a1
 ; RV32-NEXT:    add s3, a0, s6
-; RV32-NEXT:    sw s9, 96(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s9, 84(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    mv a0, s9
 ; RV32-NEXT:    li a1, 0
 ; RV32-NEXT:    mv a2, s1
@@ -1484,38 +1484,38 @@ define void @test_float_to_bitint_200(ptr %in, ptr %out) nounwind {
 ; RV32-NEXT:  # %bb.9: # %fp-to-i-if-exp.large
 ; RV32-NEXT:    sltu s6, s11, a2
 ; RV32-NEXT:  .LBB2_10: # %fp-to-i-if-exp.large
-; RV32-NEXT:    lw a3, 100(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a3, 0(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    or a3, a3, s7
-; RV32-NEXT:    sw a3, 92(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a3, 80(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    sltu a3, s3, s10
 ; RV32-NEXT:    sltu a0, a2, a0
 ; RV32-NEXT:    add a3, s2, a3
 ; RV32-NEXT:    add a0, a1, a0
-; RV32-NEXT:    lw a1, 108(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw a2, 104(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a2, 4(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    or a1, a1, a2
-; RV32-NEXT:    sw a1, 100(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw a3, 88(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a1, 0(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a3, 16(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    add s2, a3, a0
-; RV32-NEXT:    lw a0, 128(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    li a1, 0
 ; RV32-NEXT:    mv a2, s1
 ; RV32-NEXT:    li a3, 0
 ; RV32-NEXT:    call __muldi3
-; RV32-NEXT:    sw a1, 60(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s2, 84(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a1, 68(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s2, 12(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    add s2, a0, s2
-; RV32-NEXT:    sw s2, 56(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s2, 64(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    add s4, s2, s6
-; RV32-NEXT:    lw a0, 132(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    li a1, 0
 ; RV32-NEXT:    mv a2, s1
 ; RV32-NEXT:    li a3, 0
 ; RV32-NEXT:    call __muldi3
 ; RV32-NEXT:    mv s6, a0
 ; RV32-NEXT:    mv s3, a1
-; RV32-NEXT:    lw s2, 124(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw s2, 20(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    mv a0, s2
 ; RV32-NEXT:    li a1, 0
 ; RV32-NEXT:    mv a2, s1
@@ -1531,68 +1531,68 @@ define void @test_float_to_bitint_200(ptr %in, ptr %out) nounwind {
 ; RV32-NEXT:    add s5, s8, s5
 ; RV32-NEXT:    add a2, a0, s9
 ; RV32-NEXT:    add s11, a2, s11
-; RV32-NEXT:    sw s5, 108(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s5, 8(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    sltu s5, s5, s8
 ; RV32-NEXT:    add s11, s11, s5
 ; RV32-NEXT:    beq s11, a2, .LBB2_12
 ; RV32-NEXT:  # %bb.11: # %fp-to-i-if-exp.large
 ; RV32-NEXT:    sltu s5, s11, a2
 ; RV32-NEXT:  .LBB2_12: # %fp-to-i-if-exp.large
-; RV32-NEXT:    sw s11, 104(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s11, 4(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    sltu a3, s9, s6
 ; RV32-NEXT:    sltu a0, a2, a0
 ; RV32-NEXT:    add s9, s3, a3
 ; RV32-NEXT:    add a0, a1, a0
 ; RV32-NEXT:    add s6, s9, a0
-; RV32-NEXT:    lw a0, 132(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    li a1, 0
 ; RV32-NEXT:    mv a2, s1
 ; RV32-NEXT:    li a3, 0
 ; RV32-NEXT:    call __muldi3
 ; RV32-NEXT:    mv s8, a0
-; RV32-NEXT:    sw a1, 40(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a1, 48(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    add s3, a0, s6
 ; RV32-NEXT:    add s2, s3, s5
 ; RV32-NEXT:    add s7, s4, s2
-; RV32-NEXT:    lw s11, 96(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw s11, 84(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    mv a0, s11
 ; RV32-NEXT:    li a1, 0
 ; RV32-NEXT:    mv a2, s1
 ; RV32-NEXT:    li a3, 0
 ; RV32-NEXT:    call __muldi3
-; RV32-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw a1, 36(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a1, 44(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    add s5, a0, s7
 ; RV32-NEXT:    ori a0, s1, 1
 ; RV32-NEXT:    li a1, 0
-; RV32-NEXT:    lw a2, 100(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a2, 0(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    li a3, 0
 ; RV32-NEXT:    call __muldi3
 ; RV32-NEXT:    mv s10, a0
-; RV32-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a1, 40(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    li a1, 0
-; RV32-NEXT:    lw a2, 124(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a2, 20(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    li a3, 0
 ; RV32-NEXT:    call __muldi3
 ; RV32-NEXT:    mv a4, a0
-; RV32-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw a1, 44(sp) # 4-byte Folded Spill
-; RV32-NEXT:    lw a3, 56(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
+; RV32-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a1, 52(sp) # 4-byte Folded Spill
+; RV32-NEXT:    lw a3, 64(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    sltu a0, a3, a0
 ; RV32-NEXT:    add a4, a4, s10
-; RV32-NEXT:    sw a4, 4(sp) # 4-byte Folded Spill
-; RV32-NEXT:    lw a1, 88(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw a2, 84(sp) # 4-byte Folded Reload
+; RV32-NEXT:    sw a4, 32(sp) # 4-byte Folded Spill
+; RV32-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a2, 12(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    sltu a1, a2, a1
 ; RV32-NEXT:    add s10, s5, a4
-; RV32-NEXT:    lw a2, 60(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a2, 68(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    add a1, a2, a1
 ; RV32-NEXT:    sltu a2, s4, a3
 ; RV32-NEXT:    add a0, a0, a2
 ; RV32-NEXT:    sltu a2, s6, s9
-; RV32-NEXT:    lw a3, 40(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a3, 48(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    add a2, a3, a2
 ; RV32-NEXT:    sltu a3, s3, s8
 ; RV32-NEXT:    sltu a4, s2, s3
@@ -1603,121 +1603,121 @@ define void @test_float_to_bitint_200(ptr %in, ptr %out) nounwind {
 ; RV32-NEXT:    mv s4, a0
 ; RV32-NEXT:    add a2, a0, a2
 ; RV32-NEXT:    sltu s7, s10, s5
-; RV32-NEXT:    sw s6, 84(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s6, 12(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    add s6, a2, s6
-; RV32-NEXT:    lw a0, 128(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    li a1, 0
 ; RV32-NEXT:    mv a2, s1
 ; RV32-NEXT:    li a3, 0
 ; RV32-NEXT:    call __muldi3
-; RV32-NEXT:    sw a1, 40(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
-; RV32-NEXT:    lw s3, 36(sp) # 4-byte Folded Reload
+; RV32-NEXT:    sw a1, 48(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a0, 112(sp) # 4-byte Folded Spill
+; RV32-NEXT:    lw s3, 44(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    add s3, a0, s3
 ; RV32-NEXT:    mv a0, s11
 ; RV32-NEXT:    li a1, 0
 ; RV32-NEXT:    mv a2, s1
 ; RV32-NEXT:    li a3, 0
 ; RV32-NEXT:    call __muldi3
-; RV32-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s3, 24(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a1, 100(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s3, 104(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a0, 96(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    add s3, a0, s3
-; RV32-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    sltu s5, s5, a0
 ; RV32-NEXT:    add s2, s3, s5
 ; RV32-NEXT:    add s2, s2, s6
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    li a1, 0
-; RV32-NEXT:    lw a2, 132(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a2, 28(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    li a3, 0
 ; RV32-NEXT:    call __muldi3
 ; RV32-NEXT:    mv s9, a0
-; RV32-NEXT:    sw a1, 60(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a1, 68(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    li a1, 0
-; RV32-NEXT:    lw a2, 124(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a2, 20(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    li a3, 0
 ; RV32-NEXT:    call __muldi3
-; RV32-NEXT:    sw a1, 52(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
-; RV32-NEXT:    lw a1, 44(sp) # 4-byte Folded Reload
+; RV32-NEXT:    sw a1, 60(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
+; RV32-NEXT:    lw a1, 52(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    add a0, a0, a1
-; RV32-NEXT:    sw s9, 56(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s9, 64(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    add s9, s9, a0
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    li a1, 0
-; RV32-NEXT:    lw a2, 100(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a2, 0(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    li a3, 0
 ; RV32-NEXT:    call __muldi3
-; RV32-NEXT:    sw a1, 36(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
-; RV32-NEXT:    lw s8, 20(sp) # 4-byte Folded Reload
+; RV32-NEXT:    sw a1, 44(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a0, 108(sp) # 4-byte Folded Spill
+; RV32-NEXT:    lw s8, 40(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    add s8, a0, s8
 ; RV32-NEXT:    ori a0, s1, 1
 ; RV32-NEXT:    li a1, 0
-; RV32-NEXT:    lw a2, 92(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a2, 80(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    li a3, 0
 ; RV32-NEXT:    call __muldi3
-; RV32-NEXT:    lw a2, 8(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw a3, 4(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a2, 36(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a3, 32(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    sltu a2, a3, a2
-; RV32-NEXT:    sw s8, 20(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s8, 40(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    add a0, a0, s8
-; RV32-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    add s8, s9, a0
 ; RV32-NEXT:    mv a6, a2
 ; RV32-NEXT:    add s8, s8, a2
-; RV32-NEXT:    sw s7, 88(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s7, 16(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    add s11, s8, s7
 ; RV32-NEXT:    add s11, s2, s11
-; RV32-NEXT:    sw a1, 0(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a1, 92(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    beq s11, s2, .LBB2_14
 ; RV32-NEXT:  # %bb.13: # %fp-to-i-if-exp.large
 ; RV32-NEXT:    sltu a0, s11, s2
-; RV32-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32-NEXT:  .LBB2_14: # %fp-to-i-if-exp.large
-; RV32-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a0, 128(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    srli a0, a0, 1
-; RV32-NEXT:    lw a2, 64(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a2, 116(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    srli a1, a2, 1
 ; RV32-NEXT:    beq s2, s3, .LBB2_16
 ; RV32-NEXT:  # %bb.15: # %fp-to-i-if-exp.large
 ; RV32-NEXT:    sltu s5, s2, s3
 ; RV32-NEXT:  .LBB2_16: # %fp-to-i-if-exp.large
-; RV32-NEXT:    lw a4, 80(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a4, 132(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    sll a2, a2, a4
-; RV32-NEXT:    lw a5, 72(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a5, 124(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    srl a3, a0, a5
-; RV32-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a0, 120(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    sll a0, a0, a4
 ; RV32-NEXT:    srl a1, a1, a5
 ; RV32-NEXT:    mv s7, a6
 ; RV32-NEXT:    beq s6, s4, .LBB2_18
 ; RV32-NEXT:  # %bb.17: # %fp-to-i-if-exp.large
 ; RV32-NEXT:    sltu a4, s6, s4
-; RV32-NEXT:    sw a4, 84(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a4, 12(sp) # 4-byte Folded Spill
 ; RV32-NEXT:  .LBB2_18: # %fp-to-i-if-exp.large
 ; RV32-NEXT:    or s2, a2, a3
-; RV32-NEXT:    lw a2, 32(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a2, 112(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a3, 104(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    sltu a2, a3, a2
-; RV32-NEXT:    lw a3, 12(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a3, 96(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    sltu a3, s3, a3
-; RV32-NEXT:    lw a4, 40(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a4, 48(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    add a2, a4, a2
-; RV32-NEXT:    lw a4, 16(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a4, 100(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    add a3, a4, a3
 ; RV32-NEXT:    or s3, a0, a1
 ; RV32-NEXT:    add s4, a2, a3
-; RV32-NEXT:    lw a0, 128(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    li a1, 0
 ; RV32-NEXT:    mv a2, s1
 ; RV32-NEXT:    li a3, 0
 ; RV32-NEXT:    call __muldi3
-; RV32-NEXT:    lw a1, 84(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    add a0, a0, a1
 ; RV32-NEXT:    add a0, a0, s5
 ; RV32-NEXT:    add s5, a0, s4
@@ -1725,8 +1725,8 @@ define void @test_float_to_bitint_200(ptr %in, ptr %out) nounwind {
 ; RV32-NEXT:  # %bb.19: # %fp-to-i-if-exp.large
 ; RV32-NEXT:    sltu s7, s8, s9
 ; RV32-NEXT:  .LBB2_20: # %fp-to-i-if-exp.large
-; RV32-NEXT:    lw a0, 100(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s6, 92(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a0, 0(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw s6, 80(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    mv a1, s6
 ; RV32-NEXT:    mv a2, s1
 ; RV32-NEXT:    mv a3, s1
@@ -1737,15 +1737,15 @@ define void @test_float_to_bitint_200(ptr %in, ptr %out) nounwind {
 ; RV32-NEXT:    ori a2, s1, 1
 ; RV32-NEXT:    mv a3, s1
 ; RV32-NEXT:    call __muldi3
-; RV32-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw a2, 20(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a1, 108(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a2, 40(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    sltu a1, a2, a1
-; RV32-NEXT:    lw a2, 8(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw a3, 4(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a2, 36(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a3, 32(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    sltu a2, a3, a2
-; RV32-NEXT:    lw a3, 36(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a3, 44(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    add a1, a3, a1
-; RV32-NEXT:    lw a3, 0(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a3, 92(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    add a2, a3, a2
 ; RV32-NEXT:    add s4, a0, s4
 ; RV32-NEXT:    add s2, a1, a2
@@ -1756,25 +1756,25 @@ define void @test_float_to_bitint_200(ptr %in, ptr %out) nounwind {
 ; RV32-NEXT:    call __muldi3
 ; RV32-NEXT:    add a0, a0, s4
 ; RV32-NEXT:    add s3, a0, s2
-; RV32-NEXT:    lw a0, 96(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw a1, 128(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    mv a2, s1
 ; RV32-NEXT:    mv a3, s1
 ; RV32-NEXT:    call __muldi3
 ; RV32-NEXT:    mv s2, a0
-; RV32-NEXT:    lw a0, 124(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s6, 132(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw s6, 28(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    mv a1, s6
-; RV32-NEXT:    lw a2, 120(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a2, 88(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    call __muldi3
-; RV32-NEXT:    lw a1, 56(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a1, 64(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    sltu a1, s9, a1
-; RV32-NEXT:    lw a2, 48(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw a3, 44(sp) # 4-byte Folded Reload
-; RV32-NEXT:    sltu a2, a3, a2
-; RV32-NEXT:    lw a3, 60(sp) # 4-byte Folded Reload
-; RV32-NEXT:    add a1, a3, a1
+; RV32-NEXT:    lw a2, 56(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    lw a3, 52(sp) # 4-byte Folded Reload
+; RV32-NEXT:    sltu a2, a3, a2
+; RV32-NEXT:    lw a3, 68(sp) # 4-byte Folded Reload
+; RV32-NEXT:    add a1, a3, a1
+; RV32-NEXT:    lw a3, 60(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    add a2, a3, a2
 ; RV32-NEXT:    add s2, s2, a0
 ; RV32-NEXT:    add s4, a2, a1
@@ -1783,7 +1783,7 @@ define void @test_float_to_bitint_200(ptr %in, ptr %out) nounwind {
 ; RV32-NEXT:    mv a2, s6
 ; RV32-NEXT:    li a3, 0
 ; RV32-NEXT:    call __muldi3
-; RV32-NEXT:    lw a1, 88(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    add s5, s5, a1
 ; RV32-NEXT:    add a0, a0, s2
 ; RV32-NEXT:    add a0, a0, s4
@@ -1792,10 +1792,10 @@ define void @test_float_to_bitint_200(ptr %in, ptr %out) nounwind {
 ; RV32-NEXT:    add a0, s5, a0
 ; RV32-NEXT:  .LBB2_21: # %fp-to-i-cleanup
 ; RV32-NEXT:    zext.b a0, a0
-; RV32-NEXT:    lw a1, 116(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw a2, 112(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw a3, 108(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw a4, 104(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a1, 76(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a2, 72(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a4, 4(sp) # 4-byte Folded Reload
 ; RV32-NEXT:  .LBB2_22: # %fp-to-i-cleanup
 ; RV32-NEXT:    sw a1, 0(s0)
 ; RV32-NEXT:    sw a2, 4(s0)

--- a/llvm/test/CodeGen/RISCV/callee-saved-gprs.ll
+++ b/llvm/test/CodeGen/RISCV/callee-saved-gprs.ll
@@ -313,17 +313,17 @@ define void @callee() {
 ; RV32I-WITH-FP-NEXT:    lui a0, %hi(var)
 ; RV32I-WITH-FP-NEXT:    addi a0, a0, %lo(var)
 ; RV32I-WITH-FP-NEXT:    lw a1, 0(a0)
-; RV32I-WITH-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a1, 4(a0)
-; RV32I-WITH-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a1, 8(a0)
-; RV32I-WITH-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a1, 12(a0)
-; RV32I-WITH-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a1, 16(a0)
-; RV32I-WITH-FP-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a1, 20(a0)
 ; RV32I-WITH-FP-NEXT:    sw a1, 4(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a1, 4(a0)
+; RV32I-WITH-FP-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a1, 8(a0)
+; RV32I-WITH-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a1, 12(a0)
+; RV32I-WITH-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a1, 16(a0)
+; RV32I-WITH-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a1, 20(a0)
+; RV32I-WITH-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a7, 24(a0)
 ; RV32I-WITH-FP-NEXT:    lw t0, 28(a0)
 ; RV32I-WITH-FP-NEXT:    lw t1, 32(a0)
@@ -376,17 +376,17 @@ define void @callee() {
 ; RV32I-WITH-FP-NEXT:    sw t1, 32(a0)
 ; RV32I-WITH-FP-NEXT:    sw t0, 28(a0)
 ; RV32I-WITH-FP-NEXT:    sw a7, 24(a0)
-; RV32I-WITH-FP-NEXT:    lw a1, 4(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a1, 20(a0)
-; RV32I-WITH-FP-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a1, 16(a0)
-; RV32I-WITH-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a1, 12(a0)
-; RV32I-WITH-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a1, 8(a0)
-; RV32I-WITH-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a1, 4(a0)
 ; RV32I-WITH-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a1, 20(a0)
+; RV32I-WITH-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a1, 16(a0)
+; RV32I-WITH-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a1, 12(a0)
+; RV32I-WITH-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a1, 8(a0)
+; RV32I-WITH-FP-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a1, 4(a0)
+; RV32I-WITH-FP-NEXT:    lw a1, 4(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a1, 0(a0)
 ; RV32I-WITH-FP-NEXT:    .cfi_def_cfa sp, 80
 ; RV32I-WITH-FP-NEXT:    lw ra, 76(sp) # 4-byte Folded Reload
@@ -549,17 +549,17 @@ define void @callee() {
 ; RV32IZCMP-WITH-FP-NEXT:    lui a0, %hi(var)
 ; RV32IZCMP-WITH-FP-NEXT:    addi a0, a0, %lo(var)
 ; RV32IZCMP-WITH-FP-NEXT:    lw a1, 0(a0)
-; RV32IZCMP-WITH-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a1, 4(a0)
-; RV32IZCMP-WITH-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a1, 8(a0)
-; RV32IZCMP-WITH-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a1, 12(a0)
-; RV32IZCMP-WITH-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a1, 16(a0)
-; RV32IZCMP-WITH-FP-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a1, 20(a0)
 ; RV32IZCMP-WITH-FP-NEXT:    sw a1, 4(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a1, 4(a0)
+; RV32IZCMP-WITH-FP-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a1, 8(a0)
+; RV32IZCMP-WITH-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a1, 12(a0)
+; RV32IZCMP-WITH-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a1, 16(a0)
+; RV32IZCMP-WITH-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a1, 20(a0)
+; RV32IZCMP-WITH-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a7, 24(a0)
 ; RV32IZCMP-WITH-FP-NEXT:    lw t0, 28(a0)
 ; RV32IZCMP-WITH-FP-NEXT:    lw t1, 32(a0)
@@ -612,17 +612,17 @@ define void @callee() {
 ; RV32IZCMP-WITH-FP-NEXT:    sw t1, 32(a0)
 ; RV32IZCMP-WITH-FP-NEXT:    sw t0, 28(a0)
 ; RV32IZCMP-WITH-FP-NEXT:    sw a7, 24(a0)
-; RV32IZCMP-WITH-FP-NEXT:    lw a1, 4(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a1, 20(a0)
-; RV32IZCMP-WITH-FP-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a1, 16(a0)
-; RV32IZCMP-WITH-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a1, 12(a0)
-; RV32IZCMP-WITH-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a1, 8(a0)
-; RV32IZCMP-WITH-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a1, 4(a0)
 ; RV32IZCMP-WITH-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a1, 20(a0)
+; RV32IZCMP-WITH-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a1, 16(a0)
+; RV32IZCMP-WITH-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a1, 12(a0)
+; RV32IZCMP-WITH-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a1, 8(a0)
+; RV32IZCMP-WITH-FP-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a1, 4(a0)
+; RV32IZCMP-WITH-FP-NEXT:    lw a1, 4(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a1, 0(a0)
 ; RV32IZCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 80
 ; RV32IZCMP-WITH-FP-NEXT:    lw ra, 76(sp) # 4-byte Folded Reload
@@ -922,17 +922,17 @@ define void @callee() {
 ; RV64I-WITH-FP-NEXT:    lui a0, %hi(var)
 ; RV64I-WITH-FP-NEXT:    addi a0, a0, %lo(var)
 ; RV64I-WITH-FP-NEXT:    lw a1, 0(a0)
-; RV64I-WITH-FP-NEXT:    sd a1, 48(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a1, 4(a0)
-; RV64I-WITH-FP-NEXT:    sd a1, 40(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a1, 8(a0)
-; RV64I-WITH-FP-NEXT:    sd a1, 32(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a1, 12(a0)
-; RV64I-WITH-FP-NEXT:    sd a1, 24(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a1, 16(a0)
-; RV64I-WITH-FP-NEXT:    sd a1, 16(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a1, 20(a0)
 ; RV64I-WITH-FP-NEXT:    sd a1, 8(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a1, 4(a0)
+; RV64I-WITH-FP-NEXT:    sd a1, 16(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a1, 8(a0)
+; RV64I-WITH-FP-NEXT:    sd a1, 24(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a1, 12(a0)
+; RV64I-WITH-FP-NEXT:    sd a1, 32(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a1, 16(a0)
+; RV64I-WITH-FP-NEXT:    sd a1, 40(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a1, 20(a0)
+; RV64I-WITH-FP-NEXT:    sd a1, 48(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a7, 24(a0)
 ; RV64I-WITH-FP-NEXT:    lw t0, 28(a0)
 ; RV64I-WITH-FP-NEXT:    lw t1, 32(a0)
@@ -985,17 +985,17 @@ define void @callee() {
 ; RV64I-WITH-FP-NEXT:    sw t1, 32(a0)
 ; RV64I-WITH-FP-NEXT:    sw t0, 28(a0)
 ; RV64I-WITH-FP-NEXT:    sw a7, 24(a0)
-; RV64I-WITH-FP-NEXT:    ld a1, 8(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a1, 20(a0)
-; RV64I-WITH-FP-NEXT:    ld a1, 16(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a1, 16(a0)
-; RV64I-WITH-FP-NEXT:    ld a1, 24(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a1, 12(a0)
-; RV64I-WITH-FP-NEXT:    ld a1, 32(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a1, 8(a0)
-; RV64I-WITH-FP-NEXT:    ld a1, 40(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a1, 4(a0)
 ; RV64I-WITH-FP-NEXT:    ld a1, 48(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a1, 20(a0)
+; RV64I-WITH-FP-NEXT:    ld a1, 40(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a1, 16(a0)
+; RV64I-WITH-FP-NEXT:    ld a1, 32(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a1, 12(a0)
+; RV64I-WITH-FP-NEXT:    ld a1, 24(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a1, 8(a0)
+; RV64I-WITH-FP-NEXT:    ld a1, 16(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a1, 4(a0)
+; RV64I-WITH-FP-NEXT:    ld a1, 8(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a1, 0(a0)
 ; RV64I-WITH-FP-NEXT:    .cfi_def_cfa sp, 160
 ; RV64I-WITH-FP-NEXT:    ld ra, 152(sp) # 8-byte Folded Reload
@@ -1158,17 +1158,17 @@ define void @callee() {
 ; RV64IZCMP-WITH-FP-NEXT:    lui a0, %hi(var)
 ; RV64IZCMP-WITH-FP-NEXT:    addi a0, a0, %lo(var)
 ; RV64IZCMP-WITH-FP-NEXT:    lw a1, 0(a0)
-; RV64IZCMP-WITH-FP-NEXT:    sd a1, 48(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a1, 4(a0)
-; RV64IZCMP-WITH-FP-NEXT:    sd a1, 40(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a1, 8(a0)
-; RV64IZCMP-WITH-FP-NEXT:    sd a1, 32(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a1, 12(a0)
-; RV64IZCMP-WITH-FP-NEXT:    sd a1, 24(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a1, 16(a0)
-; RV64IZCMP-WITH-FP-NEXT:    sd a1, 16(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a1, 20(a0)
 ; RV64IZCMP-WITH-FP-NEXT:    sd a1, 8(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a1, 4(a0)
+; RV64IZCMP-WITH-FP-NEXT:    sd a1, 16(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a1, 8(a0)
+; RV64IZCMP-WITH-FP-NEXT:    sd a1, 24(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a1, 12(a0)
+; RV64IZCMP-WITH-FP-NEXT:    sd a1, 32(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a1, 16(a0)
+; RV64IZCMP-WITH-FP-NEXT:    sd a1, 40(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a1, 20(a0)
+; RV64IZCMP-WITH-FP-NEXT:    sd a1, 48(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a7, 24(a0)
 ; RV64IZCMP-WITH-FP-NEXT:    lw t0, 28(a0)
 ; RV64IZCMP-WITH-FP-NEXT:    lw t1, 32(a0)
@@ -1221,17 +1221,17 @@ define void @callee() {
 ; RV64IZCMP-WITH-FP-NEXT:    sw t1, 32(a0)
 ; RV64IZCMP-WITH-FP-NEXT:    sw t0, 28(a0)
 ; RV64IZCMP-WITH-FP-NEXT:    sw a7, 24(a0)
-; RV64IZCMP-WITH-FP-NEXT:    ld a1, 8(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a1, 20(a0)
-; RV64IZCMP-WITH-FP-NEXT:    ld a1, 16(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a1, 16(a0)
-; RV64IZCMP-WITH-FP-NEXT:    ld a1, 24(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a1, 12(a0)
-; RV64IZCMP-WITH-FP-NEXT:    ld a1, 32(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a1, 8(a0)
-; RV64IZCMP-WITH-FP-NEXT:    ld a1, 40(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a1, 4(a0)
 ; RV64IZCMP-WITH-FP-NEXT:    ld a1, 48(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a1, 20(a0)
+; RV64IZCMP-WITH-FP-NEXT:    ld a1, 40(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a1, 16(a0)
+; RV64IZCMP-WITH-FP-NEXT:    ld a1, 32(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a1, 12(a0)
+; RV64IZCMP-WITH-FP-NEXT:    ld a1, 24(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a1, 8(a0)
+; RV64IZCMP-WITH-FP-NEXT:    ld a1, 16(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a1, 4(a0)
+; RV64IZCMP-WITH-FP-NEXT:    ld a1, 8(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a1, 0(a0)
 ; RV64IZCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 160
 ; RV64IZCMP-WITH-FP-NEXT:    ld ra, 152(sp) # 8-byte Folded Reload
@@ -1408,16 +1408,16 @@ define void @callee() {
 ; RV32I-ZILSD-WITH-FP-NEXT:    addi a0, a0, %lo(var)
 ; RV32I-ZILSD-WITH-FP-NEXT:    lw a1, 0(a0)
 ; RV32I-ZILSD-WITH-FP-NEXT:    lw a2, 4(a0)
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a2, 16(sp) # 4-byte Folded Spill
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a2, 4(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 0(sp) # 4-byte Folded Spill
 ; RV32I-ZILSD-WITH-FP-NEXT:    lw a1, 8(a0)
 ; RV32I-ZILSD-WITH-FP-NEXT:    lw a2, 12(a0)
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a2, 8(sp) # 4-byte Folded Spill
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a2, 12(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
 ; RV32I-ZILSD-WITH-FP-NEXT:    lw a1, 16(a0)
 ; RV32I-ZILSD-WITH-FP-NEXT:    lw a2, 20(a0)
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a2, 0(sp) # 4-byte Folded Spill
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 4(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a2, 20(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
 ; RV32I-ZILSD-WITH-FP-NEXT:    ld t1, 24(a0)
 ; RV32I-ZILSD-WITH-FP-NEXT:    ld t3, 32(a0)
 ; RV32I-ZILSD-WITH-FP-NEXT:    ld t5, 40(a0)
@@ -1459,17 +1459,17 @@ define void @callee() {
 ; RV32I-ZILSD-WITH-FP-NEXT:    sw t3, 32(a0)
 ; RV32I-ZILSD-WITH-FP-NEXT:    sw t2, 28(a0)
 ; RV32I-ZILSD-WITH-FP-NEXT:    sw t1, 24(a0)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a1, 0(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 20(a0)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a1, 4(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 16(a0)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 12(a0)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 8(a0)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 4(a0)
 ; RV32I-ZILSD-WITH-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 20(a0)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 16(a0)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 12(a0)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 8(a0)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a1, 4(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 4(a0)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a1, 0(sp) # 4-byte Folded Reload
 ; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 0(a0)
 ; RV32I-ZILSD-WITH-FP-NEXT:    .cfi_def_cfa sp, 80
 ; RV32I-ZILSD-WITH-FP-NEXT:    lw ra, 76(sp) # 4-byte Folded Reload
@@ -2026,49 +2026,49 @@ define void @caller() {
 ; RV32I-WITH-FP-NEXT:    lui s1, %hi(var)
 ; RV32I-WITH-FP-NEXT:    addi s1, s1, %lo(var)
 ; RV32I-WITH-FP-NEXT:    lw a0, 0(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a0, 4(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a0, 8(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a0, 12(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a0, 16(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a0, 20(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a0, 24(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a0, 28(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a0, 32(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a0, 36(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a0, 40(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a0, 44(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a0, 48(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a0, 52(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a0, 56(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a0, 60(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a0, 64(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a0, 68(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a0, 72(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a0, 76(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a0, 80(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
-; RV32I-WITH-FP-NEXT:    lw a0, 84(s1)
 ; RV32I-WITH-FP-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a0, 4(s1)
+; RV32I-WITH-FP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a0, 8(s1)
+; RV32I-WITH-FP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a0, 12(s1)
+; RV32I-WITH-FP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a0, 16(s1)
+; RV32I-WITH-FP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a0, 20(s1)
+; RV32I-WITH-FP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a0, 24(s1)
+; RV32I-WITH-FP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a0, 28(s1)
+; RV32I-WITH-FP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a0, 32(s1)
+; RV32I-WITH-FP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a0, 36(s1)
+; RV32I-WITH-FP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a0, 40(s1)
+; RV32I-WITH-FP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a0, 44(s1)
+; RV32I-WITH-FP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a0, 48(s1)
+; RV32I-WITH-FP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a0, 52(s1)
+; RV32I-WITH-FP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a0, 56(s1)
+; RV32I-WITH-FP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a0, 60(s1)
+; RV32I-WITH-FP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a0, 64(s1)
+; RV32I-WITH-FP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a0, 68(s1)
+; RV32I-WITH-FP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a0, 72(s1)
+; RV32I-WITH-FP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a0, 76(s1)
+; RV32I-WITH-FP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a0, 80(s1)
+; RV32I-WITH-FP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    lw a0, 84(s1)
+; RV32I-WITH-FP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw s4, 88(s1)
 ; RV32I-WITH-FP-NEXT:    lw s5, 92(s1)
 ; RV32I-WITH-FP-NEXT:    lw s6, 96(s1)
@@ -2090,49 +2090,49 @@ define void @caller() {
 ; RV32I-WITH-FP-NEXT:    sw s6, 96(s1)
 ; RV32I-WITH-FP-NEXT:    sw s5, 92(s1)
 ; RV32I-WITH-FP-NEXT:    sw s4, 88(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a0, 84(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a0, 80(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a0, 76(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a0, 72(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a0, 68(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a0, 64(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a0, 60(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a0, 56(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a0, 52(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a0, 48(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a0, 44(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a0, 40(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a0, 36(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a0, 32(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a0, 28(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a0, 24(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a0, 20(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a0, 16(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a0, 12(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a0, 8(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
-; RV32I-WITH-FP-NEXT:    sw a0, 4(s1)
 ; RV32I-WITH-FP-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a0, 84(s1)
+; RV32I-WITH-FP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a0, 80(s1)
+; RV32I-WITH-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a0, 76(s1)
+; RV32I-WITH-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a0, 72(s1)
+; RV32I-WITH-FP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a0, 68(s1)
+; RV32I-WITH-FP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a0, 64(s1)
+; RV32I-WITH-FP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a0, 60(s1)
+; RV32I-WITH-FP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a0, 56(s1)
+; RV32I-WITH-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a0, 52(s1)
+; RV32I-WITH-FP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a0, 48(s1)
+; RV32I-WITH-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a0, 44(s1)
+; RV32I-WITH-FP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a0, 40(s1)
+; RV32I-WITH-FP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a0, 36(s1)
+; RV32I-WITH-FP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a0, 32(s1)
+; RV32I-WITH-FP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a0, 28(s1)
+; RV32I-WITH-FP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a0, 24(s1)
+; RV32I-WITH-FP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a0, 20(s1)
+; RV32I-WITH-FP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a0, 16(s1)
+; RV32I-WITH-FP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a0, 12(s1)
+; RV32I-WITH-FP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a0, 8(s1)
+; RV32I-WITH-FP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    sw a0, 4(s1)
+; RV32I-WITH-FP-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a0, 0(s1)
 ; RV32I-WITH-FP-NEXT:    .cfi_def_cfa sp, 144
 ; RV32I-WITH-FP-NEXT:    lw ra, 140(sp) # 4-byte Folded Reload
@@ -2332,49 +2332,49 @@ define void @caller() {
 ; RV32IZCMP-WITH-FP-NEXT:    lui s1, %hi(var)
 ; RV32IZCMP-WITH-FP-NEXT:    addi s1, s1, %lo(var)
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 0(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 4(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 8(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 12(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 16(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 20(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 24(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 28(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 32(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 36(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 40(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 44(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 48(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 52(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 56(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 60(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 64(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 68(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 72(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 76(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 80(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 84(s1)
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 4(s1)
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 8(s1)
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 12(s1)
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 16(s1)
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 20(s1)
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 24(s1)
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 28(s1)
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 32(s1)
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 36(s1)
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 40(s1)
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 44(s1)
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 48(s1)
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 52(s1)
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 56(s1)
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 60(s1)
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 64(s1)
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 68(s1)
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 72(s1)
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 76(s1)
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 80(s1)
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 84(s1)
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw s4, 88(s1)
 ; RV32IZCMP-WITH-FP-NEXT:    lw s5, 92(s1)
 ; RV32IZCMP-WITH-FP-NEXT:    lw s6, 96(s1)
@@ -2396,49 +2396,49 @@ define void @caller() {
 ; RV32IZCMP-WITH-FP-NEXT:    sw s6, 96(s1)
 ; RV32IZCMP-WITH-FP-NEXT:    sw s5, 92(s1)
 ; RV32IZCMP-WITH-FP-NEXT:    sw s4, 88(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 84(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 80(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 76(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 72(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 68(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 64(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 60(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 56(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 52(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 48(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 44(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 40(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 36(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 32(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 28(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 24(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 20(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 16(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 12(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 8(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 4(s1)
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 84(s1)
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 80(s1)
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 76(s1)
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 72(s1)
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 68(s1)
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 64(s1)
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 60(s1)
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 56(s1)
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 52(s1)
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 48(s1)
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 44(s1)
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 40(s1)
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 36(s1)
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 32(s1)
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 28(s1)
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 24(s1)
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 20(s1)
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 16(s1)
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 12(s1)
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 8(s1)
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 4(s1)
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 0(s1)
 ; RV32IZCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 144
 ; RV32IZCMP-WITH-FP-NEXT:    lw ra, 140(sp) # 4-byte Folded Reload
@@ -2824,49 +2824,49 @@ define void @caller() {
 ; RV64I-WITH-FP-NEXT:    lui s1, %hi(var)
 ; RV64I-WITH-FP-NEXT:    addi s1, s1, %lo(var)
 ; RV64I-WITH-FP-NEXT:    lw a0, 0(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, 176(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a0, 4(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, 168(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a0, 8(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, 160(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a0, 12(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, 152(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a0, 16(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, 144(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a0, 20(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, 136(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a0, 24(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, 128(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a0, 28(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, 120(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a0, 32(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, 112(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a0, 36(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, 104(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a0, 40(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, 96(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a0, 44(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, 88(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a0, 48(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, 80(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a0, 52(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, 72(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a0, 56(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, 64(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a0, 60(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, 56(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a0, 64(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a0, 68(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a0, 72(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a0, 76(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a0, 80(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
-; RV64I-WITH-FP-NEXT:    lw a0, 84(s1)
 ; RV64I-WITH-FP-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a0, 4(s1)
+; RV64I-WITH-FP-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a0, 8(s1)
+; RV64I-WITH-FP-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a0, 12(s1)
+; RV64I-WITH-FP-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a0, 16(s1)
+; RV64I-WITH-FP-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a0, 20(s1)
+; RV64I-WITH-FP-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a0, 24(s1)
+; RV64I-WITH-FP-NEXT:    sd a0, 56(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a0, 28(s1)
+; RV64I-WITH-FP-NEXT:    sd a0, 64(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a0, 32(s1)
+; RV64I-WITH-FP-NEXT:    sd a0, 72(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a0, 36(s1)
+; RV64I-WITH-FP-NEXT:    sd a0, 80(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a0, 40(s1)
+; RV64I-WITH-FP-NEXT:    sd a0, 88(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a0, 44(s1)
+; RV64I-WITH-FP-NEXT:    sd a0, 96(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a0, 48(s1)
+; RV64I-WITH-FP-NEXT:    sd a0, 104(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a0, 52(s1)
+; RV64I-WITH-FP-NEXT:    sd a0, 112(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a0, 56(s1)
+; RV64I-WITH-FP-NEXT:    sd a0, 120(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a0, 60(s1)
+; RV64I-WITH-FP-NEXT:    sd a0, 128(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a0, 64(s1)
+; RV64I-WITH-FP-NEXT:    sd a0, 136(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a0, 68(s1)
+; RV64I-WITH-FP-NEXT:    sd a0, 144(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a0, 72(s1)
+; RV64I-WITH-FP-NEXT:    sd a0, 152(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a0, 76(s1)
+; RV64I-WITH-FP-NEXT:    sd a0, 160(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a0, 80(s1)
+; RV64I-WITH-FP-NEXT:    sd a0, 168(sp) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    lw a0, 84(s1)
+; RV64I-WITH-FP-NEXT:    sd a0, 176(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw s4, 88(s1)
 ; RV64I-WITH-FP-NEXT:    lw s5, 92(s1)
 ; RV64I-WITH-FP-NEXT:    lw s6, 96(s1)
@@ -2888,49 +2888,49 @@ define void @caller() {
 ; RV64I-WITH-FP-NEXT:    sw s6, 96(s1)
 ; RV64I-WITH-FP-NEXT:    sw s5, 92(s1)
 ; RV64I-WITH-FP-NEXT:    sw s4, 88(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a0, 84(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a0, 80(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a0, 76(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a0, 72(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a0, 68(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, 48(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a0, 64(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, 56(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a0, 60(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, 64(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a0, 56(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, 72(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a0, 52(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, 80(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a0, 48(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, 88(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a0, 44(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, 96(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a0, 40(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, 104(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a0, 36(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, 112(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a0, 32(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, 120(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a0, 28(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, 128(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a0, 24(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, 136(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a0, 20(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, 144(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a0, 16(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, 152(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a0, 12(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, 160(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a0, 8(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, 168(sp) # 8-byte Folded Reload
-; RV64I-WITH-FP-NEXT:    sw a0, 4(s1)
 ; RV64I-WITH-FP-NEXT:    ld a0, 176(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a0, 84(s1)
+; RV64I-WITH-FP-NEXT:    ld a0, 168(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a0, 80(s1)
+; RV64I-WITH-FP-NEXT:    ld a0, 160(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a0, 76(s1)
+; RV64I-WITH-FP-NEXT:    ld a0, 152(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a0, 72(s1)
+; RV64I-WITH-FP-NEXT:    ld a0, 144(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a0, 68(s1)
+; RV64I-WITH-FP-NEXT:    ld a0, 136(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a0, 64(s1)
+; RV64I-WITH-FP-NEXT:    ld a0, 128(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a0, 60(s1)
+; RV64I-WITH-FP-NEXT:    ld a0, 120(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a0, 56(s1)
+; RV64I-WITH-FP-NEXT:    ld a0, 112(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a0, 52(s1)
+; RV64I-WITH-FP-NEXT:    ld a0, 104(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a0, 48(s1)
+; RV64I-WITH-FP-NEXT:    ld a0, 96(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a0, 44(s1)
+; RV64I-WITH-FP-NEXT:    ld a0, 88(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a0, 40(s1)
+; RV64I-WITH-FP-NEXT:    ld a0, 80(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a0, 36(s1)
+; RV64I-WITH-FP-NEXT:    ld a0, 72(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a0, 32(s1)
+; RV64I-WITH-FP-NEXT:    ld a0, 64(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a0, 28(s1)
+; RV64I-WITH-FP-NEXT:    ld a0, 56(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a0, 24(s1)
+; RV64I-WITH-FP-NEXT:    ld a0, 48(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a0, 20(s1)
+; RV64I-WITH-FP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a0, 16(s1)
+; RV64I-WITH-FP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a0, 12(s1)
+; RV64I-WITH-FP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a0, 8(s1)
+; RV64I-WITH-FP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    sw a0, 4(s1)
+; RV64I-WITH-FP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a0, 0(s1)
 ; RV64I-WITH-FP-NEXT:    .cfi_def_cfa sp, 288
 ; RV64I-WITH-FP-NEXT:    ld ra, 280(sp) # 8-byte Folded Reload
@@ -3130,49 +3130,49 @@ define void @caller() {
 ; RV64IZCMP-WITH-FP-NEXT:    lui s1, %hi(var)
 ; RV64IZCMP-WITH-FP-NEXT:    addi s1, s1, %lo(var)
 ; RV64IZCMP-WITH-FP-NEXT:    lw a0, 0(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, 176(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a0, 4(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, 168(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a0, 8(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, 160(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a0, 12(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, 152(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a0, 16(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, 144(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a0, 20(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, 136(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a0, 24(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, 128(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a0, 28(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, 120(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a0, 32(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, 112(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a0, 36(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, 104(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a0, 40(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, 96(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a0, 44(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, 88(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a0, 48(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, 80(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a0, 52(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, 72(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a0, 56(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, 64(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a0, 60(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, 56(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a0, 64(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a0, 68(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a0, 72(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a0, 76(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a0, 80(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
-; RV64IZCMP-WITH-FP-NEXT:    lw a0, 84(s1)
 ; RV64IZCMP-WITH-FP-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a0, 4(s1)
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a0, 8(s1)
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a0, 12(s1)
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a0, 16(s1)
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a0, 20(s1)
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a0, 24(s1)
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 56(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a0, 28(s1)
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 64(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a0, 32(s1)
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 72(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a0, 36(s1)
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 80(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a0, 40(s1)
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 88(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a0, 44(s1)
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 96(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a0, 48(s1)
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 104(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a0, 52(s1)
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 112(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a0, 56(s1)
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 120(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a0, 60(s1)
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 128(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a0, 64(s1)
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 136(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a0, 68(s1)
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 144(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a0, 72(s1)
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 152(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a0, 76(s1)
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 160(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a0, 80(s1)
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 168(sp) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    lw a0, 84(s1)
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 176(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw s4, 88(s1)
 ; RV64IZCMP-WITH-FP-NEXT:    lw s5, 92(s1)
 ; RV64IZCMP-WITH-FP-NEXT:    lw s6, 96(s1)
@@ -3194,49 +3194,49 @@ define void @caller() {
 ; RV64IZCMP-WITH-FP-NEXT:    sw s6, 96(s1)
 ; RV64IZCMP-WITH-FP-NEXT:    sw s5, 92(s1)
 ; RV64IZCMP-WITH-FP-NEXT:    sw s4, 88(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a0, 84(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a0, 80(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a0, 76(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a0, 72(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a0, 68(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, 48(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a0, 64(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, 56(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a0, 60(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, 64(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a0, 56(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, 72(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a0, 52(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, 80(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a0, 48(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, 88(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a0, 44(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, 96(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a0, 40(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, 104(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a0, 36(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, 112(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a0, 32(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, 120(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a0, 28(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, 128(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a0, 24(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, 136(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a0, 20(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, 144(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a0, 16(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, 152(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a0, 12(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, 160(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a0, 8(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, 168(sp) # 8-byte Folded Reload
-; RV64IZCMP-WITH-FP-NEXT:    sw a0, 4(s1)
 ; RV64IZCMP-WITH-FP-NEXT:    ld a0, 176(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a0, 84(s1)
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 168(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a0, 80(s1)
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 160(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a0, 76(s1)
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 152(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a0, 72(s1)
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 144(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a0, 68(s1)
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 136(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a0, 64(s1)
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 128(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a0, 60(s1)
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 120(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a0, 56(s1)
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 112(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a0, 52(s1)
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 104(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a0, 48(s1)
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 96(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a0, 44(s1)
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 88(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a0, 40(s1)
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 80(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a0, 36(s1)
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 72(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a0, 32(s1)
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 64(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a0, 28(s1)
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 56(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a0, 24(s1)
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 48(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a0, 20(s1)
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a0, 16(s1)
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a0, 12(s1)
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a0, 8(s1)
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    sw a0, 4(s1)
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a0, 0(s1)
 ; RV64IZCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 288
 ; RV64IZCMP-WITH-FP-NEXT:    ld ra, 280(sp) # 8-byte Folded Reload
@@ -3441,38 +3441,38 @@ define void @caller() {
 ; RV32I-ZILSD-WITH-FP-NEXT:    lui s1, %hi(var)
 ; RV32I-ZILSD-WITH-FP-NEXT:    addi s1, s1, %lo(var)
 ; RV32I-ZILSD-WITH-FP-NEXT:    ld a0, 0(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 80(sp) # 4-byte Folded Spill
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 4(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 0(sp) # 4-byte Folded Spill
 ; RV32I-ZILSD-WITH-FP-NEXT:    ld a0, 8(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 72(sp) # 4-byte Folded Spill
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32I-ZILSD-WITH-FP-NEXT:    ld a0, 16(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 64(sp) # 4-byte Folded Spill
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32I-ZILSD-WITH-FP-NEXT:    ld a0, 24(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 56(sp) # 4-byte Folded Spill
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; RV32I-ZILSD-WITH-FP-NEXT:    ld a0, 32(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 48(sp) # 4-byte Folded Spill
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 36(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
 ; RV32I-ZILSD-WITH-FP-NEXT:    ld a0, 40(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 40(sp) # 4-byte Folded Spill
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 44(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
 ; RV32I-ZILSD-WITH-FP-NEXT:    ld a0, 48(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 32(sp) # 4-byte Folded Spill
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 52(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
 ; RV32I-ZILSD-WITH-FP-NEXT:    ld a0, 56(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 60(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
 ; RV32I-ZILSD-WITH-FP-NEXT:    ld a0, 64(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 68(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
 ; RV32I-ZILSD-WITH-FP-NEXT:    ld a0, 72(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 76(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
 ; RV32I-ZILSD-WITH-FP-NEXT:    ld a0, 80(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 0(sp) # 4-byte Folded Spill
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a1, 84(sp) # 4-byte Folded Spill
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
 ; RV32I-ZILSD-WITH-FP-NEXT:    ld s10, 88(s1)
 ; RV32I-ZILSD-WITH-FP-NEXT:    ld s8, 96(s1)
 ; RV32I-ZILSD-WITH-FP-NEXT:    ld s6, 104(s1)
@@ -3489,49 +3489,49 @@ define void @caller() {
 ; RV32I-ZILSD-WITH-FP-NEXT:    sw s8, 96(s1)
 ; RV32I-ZILSD-WITH-FP-NEXT:    sw s11, 92(s1)
 ; RV32I-ZILSD-WITH-FP-NEXT:    sw s10, 88(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 0(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 84(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 80(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 76(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 72(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 68(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 64(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 60(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 56(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 52(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 48(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 44(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 40(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 36(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 32(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 28(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 24(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 20(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 16(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 12(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 8(s1)
-; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
-; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 4(s1)
 ; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 84(s1)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 80(s1)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 76(s1)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 72(s1)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 68(s1)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 64(s1)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 60(s1)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 56(s1)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 52(s1)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 48(s1)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 44(s1)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 40(s1)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 36(s1)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 32(s1)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 28(s1)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 24(s1)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 20(s1)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 16(s1)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 12(s1)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 8(s1)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
+; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 4(s1)
+; RV32I-ZILSD-WITH-FP-NEXT:    lw a0, 0(sp) # 4-byte Folded Reload
 ; RV32I-ZILSD-WITH-FP-NEXT:    sw a0, 0(s1)
 ; RV32I-ZILSD-WITH-FP-NEXT:    .cfi_def_cfa sp, 144
 ; RV32I-ZILSD-WITH-FP-NEXT:    lw ra, 140(sp) # 4-byte Folded Reload

--- a/llvm/test/CodeGen/RISCV/calling-conv-ilp32-ilp32f-ilp32d-common.ll
+++ b/llvm/test/CodeGen/RISCV/calling-conv-ilp32-ilp32f-ilp32d-common.ll
@@ -269,17 +269,17 @@ define i32 @caller_large_scalars() nounwind {
 ; RV32I-WITHFP-NEXT:    sw s0, 40(sp) # 4-byte Folded Spill
 ; RV32I-WITHFP-NEXT:    addi s0, sp, 48
 ; RV32I-WITHFP-NEXT:    lui a0, 524272
-; RV32I-WITHFP-NEXT:    sw zero, 0(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 16(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 20(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 24(sp)
+; RV32I-WITHFP-NEXT:    sw a0, 28(sp)
+; RV32I-WITHFP-NEXT:    li a2, 1
+; RV32I-WITHFP-NEXT:    mv a0, sp
+; RV32I-WITHFP-NEXT:    addi a1, sp, 16
+; RV32I-WITHFP-NEXT:    sw a2, 0(sp)
 ; RV32I-WITHFP-NEXT:    sw zero, 4(sp)
 ; RV32I-WITHFP-NEXT:    sw zero, 8(sp)
-; RV32I-WITHFP-NEXT:    sw a0, 12(sp)
-; RV32I-WITHFP-NEXT:    li a2, 1
-; RV32I-WITHFP-NEXT:    addi a0, sp, 24
-; RV32I-WITHFP-NEXT:    mv a1, sp
-; RV32I-WITHFP-NEXT:    sw a2, 24(sp)
-; RV32I-WITHFP-NEXT:    sw zero, 28(sp)
-; RV32I-WITHFP-NEXT:    sw zero, 32(sp)
-; RV32I-WITHFP-NEXT:    sw zero, 36(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 12(sp)
 ; RV32I-WITHFP-NEXT:    call callee_large_scalars
 ; RV32I-WITHFP-NEXT:    lw ra, 44(sp) # 4-byte Folded Reload
 ; RV32I-WITHFP-NEXT:    lw s0, 40(sp) # 4-byte Folded Reload
@@ -386,15 +386,15 @@ define i32 @caller_large_scalars_exhausted_regs() nounwind {
 ; RV32I-WITHFP-NEXT:    sw ra, 60(sp) # 4-byte Folded Spill
 ; RV32I-WITHFP-NEXT:    sw s0, 56(sp) # 4-byte Folded Spill
 ; RV32I-WITHFP-NEXT:    addi s0, sp, 64
-; RV32I-WITHFP-NEXT:    addi a0, sp, 16
+; RV32I-WITHFP-NEXT:    addi a0, sp, 32
 ; RV32I-WITHFP-NEXT:    li a1, 9
 ; RV32I-WITHFP-NEXT:    sw a1, 0(sp)
 ; RV32I-WITHFP-NEXT:    sw a0, 4(sp)
 ; RV32I-WITHFP-NEXT:    lui a0, 524272
-; RV32I-WITHFP-NEXT:    sw zero, 16(sp)
-; RV32I-WITHFP-NEXT:    sw zero, 20(sp)
-; RV32I-WITHFP-NEXT:    sw zero, 24(sp)
-; RV32I-WITHFP-NEXT:    sw a0, 28(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 32(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 36(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 40(sp)
+; RV32I-WITHFP-NEXT:    sw a0, 44(sp)
 ; RV32I-WITHFP-NEXT:    li t0, 8
 ; RV32I-WITHFP-NEXT:    li a0, 1
 ; RV32I-WITHFP-NEXT:    li a1, 2
@@ -403,11 +403,11 @@ define i32 @caller_large_scalars_exhausted_regs() nounwind {
 ; RV32I-WITHFP-NEXT:    li a4, 5
 ; RV32I-WITHFP-NEXT:    li a5, 6
 ; RV32I-WITHFP-NEXT:    li a6, 7
-; RV32I-WITHFP-NEXT:    addi a7, sp, 40
-; RV32I-WITHFP-NEXT:    sw t0, 40(sp)
-; RV32I-WITHFP-NEXT:    sw zero, 44(sp)
-; RV32I-WITHFP-NEXT:    sw zero, 48(sp)
-; RV32I-WITHFP-NEXT:    sw zero, 52(sp)
+; RV32I-WITHFP-NEXT:    addi a7, sp, 16
+; RV32I-WITHFP-NEXT:    sw t0, 16(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 20(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 24(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 28(sp)
 ; RV32I-WITHFP-NEXT:    call callee_large_scalars_exhausted_regs
 ; RV32I-WITHFP-NEXT:    lw ra, 60(sp) # 4-byte Folded Reload
 ; RV32I-WITHFP-NEXT:    lw s0, 56(sp) # 4-byte Folded Reload
@@ -580,15 +580,15 @@ define i32 @caller_large_struct() nounwind {
 ; RV32I-WITHFP-NEXT:    li a1, 2
 ; RV32I-WITHFP-NEXT:    li a2, 3
 ; RV32I-WITHFP-NEXT:    li a3, 4
-; RV32I-WITHFP-NEXT:    sw a0, 24(sp)
-; RV32I-WITHFP-NEXT:    sw a1, 28(sp)
-; RV32I-WITHFP-NEXT:    sw a2, 32(sp)
-; RV32I-WITHFP-NEXT:    sw a3, 36(sp)
 ; RV32I-WITHFP-NEXT:    sw a0, 8(sp)
 ; RV32I-WITHFP-NEXT:    sw a1, 12(sp)
 ; RV32I-WITHFP-NEXT:    sw a2, 16(sp)
 ; RV32I-WITHFP-NEXT:    sw a3, 20(sp)
-; RV32I-WITHFP-NEXT:    addi a0, sp, 8
+; RV32I-WITHFP-NEXT:    sw a0, 24(sp)
+; RV32I-WITHFP-NEXT:    sw a1, 28(sp)
+; RV32I-WITHFP-NEXT:    sw a2, 32(sp)
+; RV32I-WITHFP-NEXT:    sw a3, 36(sp)
+; RV32I-WITHFP-NEXT:    addi a0, sp, 24
 ; RV32I-WITHFP-NEXT:    call callee_large_struct
 ; RV32I-WITHFP-NEXT:    lw ra, 44(sp) # 4-byte Folded Reload
 ; RV32I-WITHFP-NEXT:    lw s0, 40(sp) # 4-byte Folded Reload

--- a/llvm/test/CodeGen/RISCV/calling-conv-ilp32e.ll
+++ b/llvm/test/CodeGen/RISCV/calling-conv-ilp32e.ll
@@ -2255,15 +2255,15 @@ define i32 @caller_large_struct() {
 ; ILP32E-WITHFP-NEXT:    li a1, 2
 ; ILP32E-WITHFP-NEXT:    li a2, 3
 ; ILP32E-WITHFP-NEXT:    li a3, 4
-; ILP32E-WITHFP-NEXT:    sw a0, 16(sp)
-; ILP32E-WITHFP-NEXT:    sw a1, 20(sp)
-; ILP32E-WITHFP-NEXT:    sw a2, 24(sp)
-; ILP32E-WITHFP-NEXT:    sw a3, 28(sp)
 ; ILP32E-WITHFP-NEXT:    sw a0, 0(sp)
 ; ILP32E-WITHFP-NEXT:    sw a1, 4(sp)
 ; ILP32E-WITHFP-NEXT:    sw a2, 8(sp)
 ; ILP32E-WITHFP-NEXT:    sw a3, 12(sp)
-; ILP32E-WITHFP-NEXT:    mv a0, sp
+; ILP32E-WITHFP-NEXT:    sw a0, 16(sp)
+; ILP32E-WITHFP-NEXT:    sw a1, 20(sp)
+; ILP32E-WITHFP-NEXT:    sw a2, 24(sp)
+; ILP32E-WITHFP-NEXT:    sw a3, 28(sp)
+; ILP32E-WITHFP-NEXT:    addi a0, sp, 16
 ; ILP32E-WITHFP-NEXT:    call callee_large_struct
 ; ILP32E-WITHFP-NEXT:    .cfi_def_cfa sp, 40
 ; ILP32E-WITHFP-NEXT:    lw ra, 36(sp) # 4-byte Folded Reload
@@ -2313,15 +2313,15 @@ define i32 @caller_large_struct() {
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a1, 2
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a2, 3
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a3, 4
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a0, 16(sp)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a1, 20(sp)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a2, 24(sp)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a3, 28(sp)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a0, 0(sp)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a1, 4(sp)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a2, 8(sp)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a3, 12(sp)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    mv a0, sp
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a0, 16(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a1, 20(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a2, 24(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a3, 28(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi a0, sp, 16
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call callee_large_struct
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa sp, 40
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, 32

--- a/llvm/test/CodeGen/RISCV/clmul.ll
+++ b/llvm/test/CodeGen/RISCV/clmul.ll
@@ -5458,7 +5458,7 @@ define i64 @clmul_i64(i64 %a, i64 %b) nounwind {
 ; RV32IM-NEXT:    sw s10, 32(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    sw s11, 28(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    sw a3, 24(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    lui a4, 16
 ; RV32IM-NEXT:    srli a5, a2, 8
 ; RV32IM-NEXT:    addi t0, a4, -256
@@ -5593,10 +5593,10 @@ define i64 @clmul_i64(i64 %a, i64 %b) nounwind {
 ; RV32IM-NEXT:    and a1, a1, a3
 ; RV32IM-NEXT:    slli a0, a0, 1
 ; RV32IM-NEXT:    or a0, a1, a0
-; RV32IM-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mv a7, a4
 ; RV32IM-NEXT:    and t0, a2, a4
-; RV32IM-NEXT:    lw a6, 16(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a6, 8(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a0, a6, a5
 ; RV32IM-NEXT:    and t1, a2, a5
 ; RV32IM-NEXT:    and a1, a6, a4
@@ -5637,9 +5637,9 @@ define i64 @clmul_i64(i64 %a, i64 %b) nounwind {
 ; RV32IM-NEXT:    and a1, t5, t3
 ; RV32IM-NEXT:    and s0, a0, s11
 ; RV32IM-NEXT:    or a0, t4, a3
-; RV32IM-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a1, a1, s0
-; RV32IM-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a3, a0, a4
 ; RV32IM-NEXT:    lw a4, 20(sp) # 4-byte Folded Reload
@@ -5688,11 +5688,11 @@ define i64 @clmul_i64(i64 %a, i64 %b) nounwind {
 ; RV32IM-NEXT:    and a3, a3, s1
 ; RV32IM-NEXT:    or a5, s3, t6
 ; RV32IM-NEXT:    or a3, a4, a3
-; RV32IM-NEXT:    lw a4, 16(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 8(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s0, 12(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    or s0, a4, s0
 ; RV32IM-NEXT:    or a3, a5, a3
-; RV32IM-NEXT:    lw a4, 12(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 16(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a4, a4, 1
 ; RV32IM-NEXT:    xor a3, a3, s0
 ; RV32IM-NEXT:    mul a5, a1, t0
@@ -5835,7 +5835,7 @@ define i64 @clmul_i64(i64 %a, i64 %b) nounwind {
 ; RV32IMZBS-NEXT:    sw s10, 32(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    sw s11, 28(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    sw a3, 24(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    lui a4, 16
 ; RV32IMZBS-NEXT:    srli a5, a2, 8
 ; RV32IMZBS-NEXT:    addi t0, a4, -256
@@ -5970,10 +5970,10 @@ define i64 @clmul_i64(i64 %a, i64 %b) nounwind {
 ; RV32IMZBS-NEXT:    and a1, a1, a3
 ; RV32IMZBS-NEXT:    slli a0, a0, 1
 ; RV32IMZBS-NEXT:    or a0, a1, a0
-; RV32IMZBS-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mv a7, a4
 ; RV32IMZBS-NEXT:    and t0, a2, a4
-; RV32IMZBS-NEXT:    lw a6, 16(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a6, 8(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a0, a6, a5
 ; RV32IMZBS-NEXT:    and t1, a2, a5
 ; RV32IMZBS-NEXT:    and a1, a6, a4
@@ -6014,9 +6014,9 @@ define i64 @clmul_i64(i64 %a, i64 %b) nounwind {
 ; RV32IMZBS-NEXT:    and a1, t5, t3
 ; RV32IMZBS-NEXT:    and s0, a0, s11
 ; RV32IMZBS-NEXT:    or a0, t4, a3
-; RV32IMZBS-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a1, a1, s0
-; RV32IMZBS-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a3, a0, a4
 ; RV32IMZBS-NEXT:    lw a4, 20(sp) # 4-byte Folded Reload
@@ -6065,11 +6065,11 @@ define i64 @clmul_i64(i64 %a, i64 %b) nounwind {
 ; RV32IMZBS-NEXT:    and a3, a3, s1
 ; RV32IMZBS-NEXT:    or a5, s3, t6
 ; RV32IMZBS-NEXT:    or a3, a4, a3
-; RV32IMZBS-NEXT:    lw a4, 16(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 8(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s0, 12(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    or s0, a4, s0
 ; RV32IMZBS-NEXT:    or a3, a5, a3
-; RV32IMZBS-NEXT:    lw a4, 12(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 16(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a4, a4, 1
 ; RV32IMZBS-NEXT:    xor a3, a3, s0
 ; RV32IMZBS-NEXT:    mul a5, a1, t0
@@ -6227,7 +6227,7 @@ define i64 @clmul_i64(i64 %a, i64 %b) nounwind {
 ; RV32IMZVBC-NEXT:    sw s10, 32(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    sw s11, 28(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    sw a3, 24(sp) # 4-byte Folded Spill
-; RV32IMZVBC-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    lui a4, 16
 ; RV32IMZVBC-NEXT:    srli a5, a2, 8
 ; RV32IMZVBC-NEXT:    addi t0, a4, -256
@@ -6362,10 +6362,10 @@ define i64 @clmul_i64(i64 %a, i64 %b) nounwind {
 ; RV32IMZVBC-NEXT:    and a1, a1, a3
 ; RV32IMZVBC-NEXT:    slli a0, a0, 1
 ; RV32IMZVBC-NEXT:    or a0, a1, a0
-; RV32IMZVBC-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mv a7, a4
 ; RV32IMZVBC-NEXT:    and t0, a2, a4
-; RV32IMZVBC-NEXT:    lw a6, 16(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a6, 8(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a0, a6, a5
 ; RV32IMZVBC-NEXT:    and t1, a2, a5
 ; RV32IMZVBC-NEXT:    and a1, a6, a4
@@ -6406,9 +6406,9 @@ define i64 @clmul_i64(i64 %a, i64 %b) nounwind {
 ; RV32IMZVBC-NEXT:    and a1, t5, t3
 ; RV32IMZVBC-NEXT:    and s0, a0, s11
 ; RV32IMZVBC-NEXT:    or a0, t4, a3
-; RV32IMZVBC-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    or a1, a1, s0
-; RV32IMZVBC-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a3, a0, a4
 ; RV32IMZVBC-NEXT:    lw a4, 20(sp) # 4-byte Folded Reload
@@ -6457,11 +6457,11 @@ define i64 @clmul_i64(i64 %a, i64 %b) nounwind {
 ; RV32IMZVBC-NEXT:    and a3, a3, s1
 ; RV32IMZVBC-NEXT:    or a5, s3, t6
 ; RV32IMZVBC-NEXT:    or a3, a4, a3
-; RV32IMZVBC-NEXT:    lw a4, 16(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 8(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s0, 12(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    or s0, a4, s0
 ; RV32IMZVBC-NEXT:    or a3, a5, a3
-; RV32IMZVBC-NEXT:    lw a4, 12(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 16(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    srli a4, a4, 1
 ; RV32IMZVBC-NEXT:    xor a3, a3, s0
 ; RV32IMZVBC-NEXT:    mul a5, a1, t0
@@ -8253,7 +8253,7 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    .cfi_offset s9, -44
 ; RV32I-NEXT:    .cfi_offset s10, -48
 ; RV32I-NEXT:    .cfi_offset s11, -52
-; RV32I-NEXT:    sw a0, 300(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 440(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lw s10, 4(a1)
 ; RV32I-NEXT:    lw a0, 8(a1)
 ; RV32I-NEXT:    lw a4, 0(a2)
@@ -8265,9 +8265,9 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    slli a7, a4, 31
 ; RV32I-NEXT:    or a2, a5, a2
 ; RV32I-NEXT:    srai a5, a6, 31
-; RV32I-NEXT:    sw a5, 368(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 72(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srai a6, a7, 31
-; RV32I-NEXT:    sw a6, 364(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 68(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a5, a2
 ; RV32I-NEXT:    and a5, a6, a0
 ; RV32I-NEXT:    xor a2, a5, a2
@@ -8276,13 +8276,13 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    or a5, a6, a5
 ; RV32I-NEXT:    slli a6, a4, 29
 ; RV32I-NEXT:    srai t1, a6, 31
-; RV32I-NEXT:    sw t1, 360(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t1, 64(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli a6, s10, 29
 ; RV32I-NEXT:    slli a7, a0, 3
 ; RV32I-NEXT:    slli t0, a4, 28
 ; RV32I-NEXT:    or a6, a7, a6
 ; RV32I-NEXT:    srai a7, t0, 31
-; RV32I-NEXT:    sw a7, 356(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 60(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, t1, a5
 ; RV32I-NEXT:    and a6, a7, a6
 ; RV32I-NEXT:    xor a5, a5, a6
@@ -8291,21 +8291,21 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    slli t0, a4, 27
 ; RV32I-NEXT:    or a6, a7, a6
 ; RV32I-NEXT:    srai a7, t0, 31
-; RV32I-NEXT:    sw a7, 352(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 56(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a6, a7, a6
 ; RV32I-NEXT:    srli a7, s10, 27
 ; RV32I-NEXT:    slli t0, a0, 5
 ; RV32I-NEXT:    slli t1, a4, 26
 ; RV32I-NEXT:    or a7, t0, a7
 ; RV32I-NEXT:    srai t0, t1, 31
-; RV32I-NEXT:    sw t0, 348(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 52(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a7, t0, a7
 ; RV32I-NEXT:    srli t0, s10, 26
 ; RV32I-NEXT:    slli t1, a0, 6
 ; RV32I-NEXT:    slli t2, a4, 25
 ; RV32I-NEXT:    or t0, t1, t0
 ; RV32I-NEXT:    srai t1, t2, 31
-; RV32I-NEXT:    sw t1, 344(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t1, 48(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a6, a6, a7
 ; RV32I-NEXT:    and a7, t1, t0
 ; RV32I-NEXT:    xor a2, a2, a5
@@ -8316,13 +8316,13 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    or a5, a6, a5
 ; RV32I-NEXT:    slli a6, a4, 24
 ; RV32I-NEXT:    srai t1, a6, 31
-; RV32I-NEXT:    sw t1, 340(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t1, 44(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli a6, s10, 24
 ; RV32I-NEXT:    slli a7, a0, 8
 ; RV32I-NEXT:    slli t0, a4, 23
 ; RV32I-NEXT:    or a6, a7, a6
 ; RV32I-NEXT:    srai a7, t0, 31
-; RV32I-NEXT:    sw a7, 336(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 40(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, t1, a5
 ; RV32I-NEXT:    and a6, a7, a6
 ; RV32I-NEXT:    xor a5, a5, a6
@@ -8331,14 +8331,14 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    slli t0, a4, 22
 ; RV32I-NEXT:    or a6, a7, a6
 ; RV32I-NEXT:    srai a7, t0, 31
-; RV32I-NEXT:    sw a7, 332(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 36(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a6, a7, a6
 ; RV32I-NEXT:    srli a7, s10, 22
 ; RV32I-NEXT:    slli t0, a0, 10
 ; RV32I-NEXT:    slli t1, a4, 21
 ; RV32I-NEXT:    or a7, t0, a7
 ; RV32I-NEXT:    srai t0, t1, 31
-; RV32I-NEXT:    sw t0, 328(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 32(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a5, a5, a6
 ; RV32I-NEXT:    and a6, t0, a7
 ; RV32I-NEXT:    xor a5, a5, a6
@@ -8347,21 +8347,21 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    slli t0, a4, 20
 ; RV32I-NEXT:    or a6, a7, a6
 ; RV32I-NEXT:    srai a7, t0, 31
-; RV32I-NEXT:    sw a7, 324(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 28(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a6, a7, a6
 ; RV32I-NEXT:    srli a7, s10, 20
 ; RV32I-NEXT:    slli t0, a0, 12
 ; RV32I-NEXT:    slli t1, a4, 19
 ; RV32I-NEXT:    or a7, t0, a7
 ; RV32I-NEXT:    srai t0, t1, 31
-; RV32I-NEXT:    sw t0, 320(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 24(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a7, t0, a7
 ; RV32I-NEXT:    srli t0, s10, 19
 ; RV32I-NEXT:    slli t1, a0, 13
 ; RV32I-NEXT:    slli t2, a4, 18
 ; RV32I-NEXT:    or t0, t1, t0
 ; RV32I-NEXT:    srai t1, t2, 31
-; RV32I-NEXT:    sw t1, 316(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t1, 20(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a6, a6, a7
 ; RV32I-NEXT:    and a7, t1, t0
 ; RV32I-NEXT:    xor a6, a6, a7
@@ -8370,14 +8370,14 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    slli t1, a4, 17
 ; RV32I-NEXT:    or a7, t0, a7
 ; RV32I-NEXT:    srai t2, t1, 31
-; RV32I-NEXT:    sw t2, 400(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t2, 104(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli t0, s10, 17
 ; RV32I-NEXT:    slli t1, a0, 15
 ; RV32I-NEXT:    or t0, t1, t0
 ; RV32I-NEXT:    slli t1, a4, 16
 ; RV32I-NEXT:    and a7, t2, a7
 ; RV32I-NEXT:    srai t1, t1, 31
-; RV32I-NEXT:    sw t1, 396(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t1, 100(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a6, a6, a7
 ; RV32I-NEXT:    and a7, t1, t0
 ; RV32I-NEXT:    xor a2, a2, a5
@@ -8392,9 +8392,9 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    or a7, t0, a7
 ; RV32I-NEXT:    slli t0, a4, 14
 ; RV32I-NEXT:    srai a6, a6, 31
-; RV32I-NEXT:    sw a6, 392(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 96(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srai t0, t0, 31
-; RV32I-NEXT:    sw t0, 388(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 92(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a6, a5
 ; RV32I-NEXT:    and a6, t0, a7
 ; RV32I-NEXT:    srli a7, s10, 14
@@ -8406,11 +8406,11 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    or a7, t0, a7
 ; RV32I-NEXT:    slli t0, a4, 13
 ; RV32I-NEXT:    srai t1, t0, 31
-; RV32I-NEXT:    sw t1, 384(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t1, 88(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t0, a4, 12
 ; RV32I-NEXT:    and a6, t1, a6
 ; RV32I-NEXT:    srai t0, t0, 31
-; RV32I-NEXT:    sw t0, 380(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 84(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a5, a5, a6
 ; RV32I-NEXT:    and a6, t0, a7
 ; RV32I-NEXT:    srli a7, s10, 12
@@ -8422,11 +8422,11 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    or a7, t0, a7
 ; RV32I-NEXT:    slli t0, a4, 11
 ; RV32I-NEXT:    srai t1, t0, 31
-; RV32I-NEXT:    sw t1, 376(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t1, 80(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t0, a4, 10
 ; RV32I-NEXT:    and a6, t1, a6
 ; RV32I-NEXT:    srai t0, t0, 31
-; RV32I-NEXT:    sw t0, 372(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 76(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a5, a5, a6
 ; RV32I-NEXT:    and a6, t0, a7
 ; RV32I-NEXT:    srli a7, s10, 10
@@ -8441,15 +8441,15 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    slli t2, a0, 24
 ; RV32I-NEXT:    or t1, t2, t1
 ; RV32I-NEXT:    srai t0, t0, 31
-; RV32I-NEXT:    sw t0, 440(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 144(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a6, t0, a6
 ; RV32I-NEXT:    slli t0, a4, 8
 ; RV32I-NEXT:    srai t2, t0, 31
-; RV32I-NEXT:    sw t2, 436(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t2, 140(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t0, a4, 7
 ; RV32I-NEXT:    and a7, t2, a7
 ; RV32I-NEXT:    srai t0, t0, 31
-; RV32I-NEXT:    sw t0, 432(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 136(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a6, a6, a7
 ; RV32I-NEXT:    and a7, t0, t1
 ; RV32I-NEXT:    srli t0, s10, 7
@@ -8461,11 +8461,11 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    or t0, t1, t0
 ; RV32I-NEXT:    slli t1, a4, 6
 ; RV32I-NEXT:    srai t2, t1, 31
-; RV32I-NEXT:    sw t2, 428(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t2, 132(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t1, a4, 5
 ; RV32I-NEXT:    and a7, t2, a7
 ; RV32I-NEXT:    srai t1, t1, 31
-; RV32I-NEXT:    sw t1, 424(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t1, 128(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a6, a6, a7
 ; RV32I-NEXT:    and a7, t1, t0
 ; RV32I-NEXT:    srli t0, s10, 5
@@ -8477,11 +8477,11 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    or t0, t1, t0
 ; RV32I-NEXT:    slli t1, a4, 4
 ; RV32I-NEXT:    srai t2, t1, 31
-; RV32I-NEXT:    sw t2, 420(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t2, 124(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t1, a4, 3
 ; RV32I-NEXT:    and a7, t2, a7
 ; RV32I-NEXT:    srai t1, t1, 31
-; RV32I-NEXT:    sw t1, 416(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t1, 120(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a6, a6, a7
 ; RV32I-NEXT:    and a7, t1, t0
 ; RV32I-NEXT:    xor a2, a2, a5
@@ -8495,9 +8495,9 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    slli t0, a4, 2
 ; RV32I-NEXT:    slli t1, a4, 1
 ; RV32I-NEXT:    srai t0, t0, 31
-; RV32I-NEXT:    sw t0, 412(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 116(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srai t1, t1, 31
-; RV32I-NEXT:    sw t1, 408(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t1, 112(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a6, t0, a6
 ; RV32I-NEXT:    and a7, t1, a7
 ; RV32I-NEXT:    xor a2, a2, a5
@@ -8507,11 +8507,11 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    or a6, a0, a6
 ; RV32I-NEXT:    lw a0, 0(a1)
 ; RV32I-NEXT:    srai a4, a4, 31
-; RV32I-NEXT:    sw a4, 404(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 108(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, s2, 31
 ; RV32I-NEXT:    and a4, a4, a6
 ; RV32I-NEXT:    srai a1, a1, 31
-; RV32I-NEXT:    sw a1, 296(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 4(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a4, a5, a4
 ; RV32I-NEXT:    and a1, a1, s10
 ; RV32I-NEXT:    slli a5, s10, 1
@@ -8521,13 +8521,13 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    slli a4, s10, 2
 ; RV32I-NEXT:    srli a5, a0, 30
 ; RV32I-NEXT:    or a7, a5, a4
-; RV32I-NEXT:    sw a7, 152(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 296(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, s2, 30
 ; RV32I-NEXT:    srai a5, a4, 31
-; RV32I-NEXT:    sw a5, 292(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 436(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, s2, 29
 ; RV32I-NEXT:    srai a6, a4, 31
-; RV32I-NEXT:    sw a6, 288(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 432(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a5, t1
 ; RV32I-NEXT:    xor a1, a1, a4
 ; RV32I-NEXT:    and a4, a6, a7
@@ -8535,17 +8535,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    srli a6, a0, 29
 ; RV32I-NEXT:    xor a1, a1, a4
 ; RV32I-NEXT:    or t0, a6, a5
-; RV32I-NEXT:    sw t0, 168(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 312(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli a4, a0, 28
 ; RV32I-NEXT:    slli a5, s10, 4
 ; RV32I-NEXT:    or a7, a5, a4
-; RV32I-NEXT:    sw a7, 172(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 316(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, s2, 28
 ; RV32I-NEXT:    srai a5, a4, 31
-; RV32I-NEXT:    sw a5, 284(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 428(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, s2, 27
 ; RV32I-NEXT:    srai a6, a4, 31
-; RV32I-NEXT:    sw a6, 280(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 424(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a5, t0
 ; RV32I-NEXT:    xor a1, a1, a4
 ; RV32I-NEXT:    and a4, a6, a7
@@ -8556,19 +8556,19 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    slli a4, s10, 6
 ; RV32I-NEXT:    srli a5, a0, 26
 ; RV32I-NEXT:    or t2, a5, a4
-; RV32I-NEXT:    sw t2, 148(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t2, 292(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, s2, 26
 ; RV32I-NEXT:    slli a5, s10, 7
 ; RV32I-NEXT:    srli a6, a0, 25
 ; RV32I-NEXT:    or s4, a6, a5
 ; RV32I-NEXT:    srai a6, a4, 31
-; RV32I-NEXT:    sw a6, 276(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 420(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, s2, 25
 ; RV32I-NEXT:    slli a5, s2, 24
 ; RV32I-NEXT:    srai t0, a4, 31
-; RV32I-NEXT:    sw t0, 268(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 412(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srai a7, a5, 31
-; RV32I-NEXT:    sw a7, 272(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 416(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a6, s3
 ; RV32I-NEXT:    and a5, t0, t2
 ; RV32I-NEXT:    xor a4, a4, a5
@@ -8580,13 +8580,13 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    slli a5, s10, 9
 ; RV32I-NEXT:    srli a6, a0, 23
 ; RV32I-NEXT:    or t0, a6, a5
-; RV32I-NEXT:    sw t0, 164(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 308(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, s2, 23
 ; RV32I-NEXT:    srai a6, a5, 31
-; RV32I-NEXT:    sw a6, 264(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 408(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, s2, 22
 ; RV32I-NEXT:    srai a7, a5, 31
-; RV32I-NEXT:    sw a7, 260(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 404(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a6, a3
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    and a5, a7, t0
@@ -8594,17 +8594,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    srli a7, a0, 22
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    or t0, a7, a6
-; RV32I-NEXT:    sw t0, 144(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 288(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, s10, 11
 ; RV32I-NEXT:    srli a6, a0, 21
 ; RV32I-NEXT:    or t2, a6, a5
-; RV32I-NEXT:    sw t2, 132(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t2, 276(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, s2, 21
 ; RV32I-NEXT:    srai a6, a5, 31
-; RV32I-NEXT:    sw a6, 256(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 400(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, s2, 20
 ; RV32I-NEXT:    srai a7, a5, 31
-; RV32I-NEXT:    sw a7, 252(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 396(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a6, t0
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    and a5, a7, t2
@@ -8612,17 +8612,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    srli a7, a0, 20
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    or t0, a7, a6
-; RV32I-NEXT:    sw t0, 120(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 264(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, s10, 13
 ; RV32I-NEXT:    srli a6, a0, 19
 ; RV32I-NEXT:    or t2, a6, a5
-; RV32I-NEXT:    sw t2, 112(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t2, 256(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, s2, 19
 ; RV32I-NEXT:    srai a6, a5, 31
-; RV32I-NEXT:    sw a6, 248(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 392(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, s2, 18
 ; RV32I-NEXT:    srai a7, a5, 31
-; RV32I-NEXT:    sw a7, 244(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 388(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a6, t0
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    and a5, a7, t2
@@ -8634,32 +8634,32 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    slli a5, s10, 15
 ; RV32I-NEXT:    srli a6, a0, 17
 ; RV32I-NEXT:    or a7, a4, a2
-; RV32I-NEXT:    sw a7, 104(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 248(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    or a5, a6, a5
-; RV32I-NEXT:    sw a5, 140(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 284(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, s2, 17
 ; RV32I-NEXT:    slli a4, s2, 16
 ; RV32I-NEXT:    srai a2, a2, 31
-; RV32I-NEXT:    sw a2, 240(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 384(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srai a4, a4, 31
-; RV32I-NEXT:    sw a4, 236(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 380(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a7
 ; RV32I-NEXT:    and a4, a4, a5
 ; RV32I-NEXT:    srli a5, a0, 16
 ; RV32I-NEXT:    slli a6, s10, 16
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    or a7, a6, a5
-; RV32I-NEXT:    sw a7, 128(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 272(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli a4, a0, 15
 ; RV32I-NEXT:    slli a5, s10, 17
 ; RV32I-NEXT:    or t0, a5, a4
-; RV32I-NEXT:    sw t0, 116(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 260(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, s2, 15
 ; RV32I-NEXT:    srai a5, a4, 31
-; RV32I-NEXT:    sw a5, 232(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 376(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, s2, 14
 ; RV32I-NEXT:    srai a6, a4, 31
-; RV32I-NEXT:    sw a6, 228(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 372(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a5, a7
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    and a4, a6, t0
@@ -8667,17 +8667,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    slli a6, s10, 18
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    or t0, a6, a5
-; RV32I-NEXT:    sw t0, 108(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 252(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli a4, a0, 13
 ; RV32I-NEXT:    slli a5, s10, 19
 ; RV32I-NEXT:    or a7, a5, a4
-; RV32I-NEXT:    sw a7, 160(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 304(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, s2, 13
 ; RV32I-NEXT:    srai a5, a4, 31
-; RV32I-NEXT:    sw a5, 224(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 368(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, s2, 12
 ; RV32I-NEXT:    srai a6, a4, 31
-; RV32I-NEXT:    sw a6, 220(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 364(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a5, t0
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    and a4, a6, a7
@@ -8685,17 +8685,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    slli a6, s10, 20
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    or t0, a6, a5
-; RV32I-NEXT:    sw t0, 100(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 244(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli a4, a0, 11
 ; RV32I-NEXT:    slli a5, s10, 21
 ; RV32I-NEXT:    or a7, a5, a4
-; RV32I-NEXT:    sw a7, 156(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 300(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, s2, 11
 ; RV32I-NEXT:    srai a5, a4, 31
-; RV32I-NEXT:    sw a5, 216(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 360(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, s2, 10
 ; RV32I-NEXT:    srai a6, a4, 31
-; RV32I-NEXT:    sw a6, 212(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 356(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a5, t0
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    and a4, a6, a7
@@ -8703,17 +8703,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    slli a6, s10, 22
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    or a7, a6, a5
-; RV32I-NEXT:    sw a7, 136(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 280(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli a4, a0, 9
 ; RV32I-NEXT:    slli a5, s10, 23
 ; RV32I-NEXT:    or t0, a5, a4
-; RV32I-NEXT:    sw t0, 124(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 268(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, s2, 9
 ; RV32I-NEXT:    srai a5, a4, 31
-; RV32I-NEXT:    sw a5, 200(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 344(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, s2, 8
 ; RV32I-NEXT:    srai a6, a4, 31
-; RV32I-NEXT:    sw a6, 196(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 340(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a5, a7
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    and a4, a6, t0
@@ -8721,7 +8721,7 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    srli a6, a0, 8
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    or t2, a6, a5
-; RV32I-NEXT:    sw t2, 96(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t2, 240(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli a4, a0, 7
 ; RV32I-NEXT:    slli a5, s10, 25
 ; RV32I-NEXT:    or t3, a5, a4
@@ -8730,13 +8730,13 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    slli a6, s10, 26
 ; RV32I-NEXT:    or t5, a6, a5
 ; RV32I-NEXT:    srai a7, a4, 31
-; RV32I-NEXT:    sw a7, 188(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 332(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, s2, 6
 ; RV32I-NEXT:    slli a5, s2, 5
 ; RV32I-NEXT:    srai t0, a4, 31
-; RV32I-NEXT:    sw t0, 184(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 328(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srai a6, a5, 31
-; RV32I-NEXT:    sw a6, 204(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 348(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a7, t2
 ; RV32I-NEXT:    and a5, t0, t3
 ; RV32I-NEXT:    xor a4, a4, a5
@@ -8750,10 +8750,10 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    or t2, a6, a5
 ; RV32I-NEXT:    slli a5, s2, 4
 ; RV32I-NEXT:    srai a7, a5, 31
-; RV32I-NEXT:    sw a7, 176(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 320(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, s2, 3
 ; RV32I-NEXT:    srai a6, a5, 31
-; RV32I-NEXT:    sw a6, 192(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 336(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a7, t4
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    and a5, a6, t2
@@ -8766,10 +8766,10 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    or s1, a6, a5
 ; RV32I-NEXT:    slli a5, s2, 2
 ; RV32I-NEXT:    srai a7, a5, 31
-; RV32I-NEXT:    sw a7, 180(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 324(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, s2, 1
 ; RV32I-NEXT:    srai a6, a5, 31
-; RV32I-NEXT:    sw a6, 208(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 352(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a7, t6
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    and a5, a6, s1
@@ -8822,120 +8822,120 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    slli a5, s11, 23
 ; RV32I-NEXT:    srai a5, a5, 31
 ; RV32I-NEXT:    slli a6, a0, 8
-; RV32I-NEXT:    sw a6, 92(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 236(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    and a4, a5, a6
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    slli a4, s11, 22
 ; RV32I-NEXT:    srai a4, a4, 31
 ; RV32I-NEXT:    slli a5, a0, 9
-; RV32I-NEXT:    sw a5, 88(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 232(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a4, a5
 ; RV32I-NEXT:    slli a5, s11, 21
 ; RV32I-NEXT:    srai a5, a5, 31
 ; RV32I-NEXT:    slli a6, a0, 10
-; RV32I-NEXT:    sw a6, 84(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 228(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    and a4, a5, a6
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    slli a4, s11, 20
 ; RV32I-NEXT:    srai a4, a4, 31
 ; RV32I-NEXT:    slli a5, a0, 11
-; RV32I-NEXT:    sw a5, 80(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 224(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a4, a5
 ; RV32I-NEXT:    slli a5, s11, 19
 ; RV32I-NEXT:    srai a5, a5, 31
 ; RV32I-NEXT:    slli a6, a0, 12
-; RV32I-NEXT:    sw a6, 76(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 220(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    and a4, a5, a6
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    slli a4, s11, 18
 ; RV32I-NEXT:    srai a4, a4, 31
 ; RV32I-NEXT:    slli a5, a0, 13
-; RV32I-NEXT:    sw a5, 72(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 216(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a4, a5
 ; RV32I-NEXT:    slli a5, s11, 17
 ; RV32I-NEXT:    srai a5, a5, 31
 ; RV32I-NEXT:    slli a6, a0, 14
-; RV32I-NEXT:    sw a6, 64(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 208(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    and a4, a5, a6
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    slli a4, s11, 16
 ; RV32I-NEXT:    srai a4, a4, 31
 ; RV32I-NEXT:    slli a5, a0, 15
-; RV32I-NEXT:    sw a5, 60(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 204(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a4, a5
 ; RV32I-NEXT:    slli a5, s11, 15
 ; RV32I-NEXT:    srai a5, a5, 31
 ; RV32I-NEXT:    slli a6, a0, 16
-; RV32I-NEXT:    sw a6, 304(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a5, a6
 ; RV32I-NEXT:    slli a6, s11, 14
 ; RV32I-NEXT:    srai a6, a6, 31
 ; RV32I-NEXT:    slli s0, a0, 17
-; RV32I-NEXT:    sw s0, 56(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s0, 200(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    and a5, a6, s0
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    slli a5, s11, 13
 ; RV32I-NEXT:    srai a5, a5, 31
 ; RV32I-NEXT:    slli a6, a0, 18
-; RV32I-NEXT:    sw a6, 48(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 192(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a5, a6
 ; RV32I-NEXT:    slli a6, s11, 12
 ; RV32I-NEXT:    srai a6, a6, 31
 ; RV32I-NEXT:    slli s0, a0, 19
-; RV32I-NEXT:    sw s0, 40(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s0, 184(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    and a5, a6, s0
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    slli a5, s11, 11
 ; RV32I-NEXT:    srai a5, a5, 31
 ; RV32I-NEXT:    slli a6, a0, 20
-; RV32I-NEXT:    sw a6, 32(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 176(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a5, a6
 ; RV32I-NEXT:    slli a6, s11, 10
 ; RV32I-NEXT:    srai a6, a6, 31
 ; RV32I-NEXT:    slli s0, a0, 21
-; RV32I-NEXT:    sw s0, 16(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s0, 160(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    and a5, a6, s0
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    slli a5, s11, 9
 ; RV32I-NEXT:    srai a5, a5, 31
 ; RV32I-NEXT:    slli a6, a0, 22
-; RV32I-NEXT:    sw a6, 308(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 12(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a5, a6
 ; RV32I-NEXT:    slli a6, s11, 8
 ; RV32I-NEXT:    srai a6, a6, 31
 ; RV32I-NEXT:    slli s0, a0, 23
-; RV32I-NEXT:    sw s0, 312(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s0, 16(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    and a5, a6, s0
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    slli a5, s11, 7
 ; RV32I-NEXT:    srai a5, a5, 31
 ; RV32I-NEXT:    slli a6, a0, 24
-; RV32I-NEXT:    sw a6, 36(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 180(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a5, a6
 ; RV32I-NEXT:    slli a6, s11, 6
 ; RV32I-NEXT:    srai a6, a6, 31
 ; RV32I-NEXT:    slli s0, a0, 25
-; RV32I-NEXT:    sw s0, 24(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s0, 168(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    and a5, a6, s0
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    slli a5, s11, 5
 ; RV32I-NEXT:    srai a5, a5, 31
 ; RV32I-NEXT:    slli a6, a0, 26
-; RV32I-NEXT:    sw a6, 20(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 164(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a5, a6
 ; RV32I-NEXT:    slli a6, s11, 4
 ; RV32I-NEXT:    srai s0, a6, 31
 ; RV32I-NEXT:    slli a6, a0, 27
-; RV32I-NEXT:    sw a6, 28(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 172(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    and a5, s0, a6
 ; RV32I-NEXT:    xor s0, a1, a2
@@ -8945,371 +8945,371 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32I-NEXT:    srai a1, a1, 31
 ; RV32I-NEXT:    srai a2, a2, 31
 ; RV32I-NEXT:    slli a6, a0, 28
-; RV32I-NEXT:    sw a6, 12(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 156(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, a0, 29
-; RV32I-NEXT:    sw a5, 44(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 188(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a1, a1, a6
 ; RV32I-NEXT:    and a2, a2, a5
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    slli a2, s11, 1
 ; RV32I-NEXT:    srai a5, a2, 31
 ; RV32I-NEXT:    slli a2, a0, 30
-; RV32I-NEXT:    sw a2, 52(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 196(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a5, a2
 ; RV32I-NEXT:    slli a5, a0, 31
-; RV32I-NEXT:    sw a5, 68(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 212(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    and a2, s11, a5
 ; RV32I-NEXT:    xor a4, s0, a4
-; RV32I-NEXT:    sw a4, 8(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 152(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a1, a1, a2
-; RV32I-NEXT:    sw a1, 4(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a1, 368(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a1, 148(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a1, 72(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, t1
-; RV32I-NEXT:    lw a2, 364(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 68(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a2, s10
-; RV32I-NEXT:    lw a4, 152(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 360(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 296(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 64(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a5, a4
-; RV32I-NEXT:    lw t1, 168(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 356(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 312(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 60(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, a5, t1
 ; RV32I-NEXT:    xor a1, a2, a1
 ; RV32I-NEXT:    xor a2, a4, s10
-; RV32I-NEXT:    lw a4, 172(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 352(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 316(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 56(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a5, a4
-; RV32I-NEXT:    lw a5, 348(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 52(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, a5, s3
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw a5, 148(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 344(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 292(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 48(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, a6, a5
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    xor a2, a4, s10
-; RV32I-NEXT:    lw a4, 340(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 44(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, s4
-; RV32I-NEXT:    lw a5, 336(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 40(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, a5, a3
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s0, 164(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 332(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s0, 308(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 36(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, a5, s0
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw a5, 144(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 328(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 288(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 32(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, a6, a5
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    xor a2, a4, s10
-; RV32I-NEXT:    lw a4, 132(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 324(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 276(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 28(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a5, a4
-; RV32I-NEXT:    lw a5, 120(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 320(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 264(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 24(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, a6, a5
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw a5, 112(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 316(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 256(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 20(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, a6, a5
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw a5, 104(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 400(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 248(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 104(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, a6, a5
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw a5, 140(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 396(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s10, a6, a5
-; RV32I-NEXT:    xor a1, a1, a2
-; RV32I-NEXT:    xor a2, a4, s10
-; RV32I-NEXT:    lw a4, 392(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 128(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a4, a4, a5
-; RV32I-NEXT:    lw a5, 388(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 116(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s10, a5, a6
-; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw a5, 384(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 108(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s10, a5, a6
-; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 160(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 380(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s10, a5, s10
-; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw a5, 376(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 284(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw a6, 100(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s10, a6, a5
+; RV32I-NEXT:    xor a1, a1, a2
+; RV32I-NEXT:    xor a2, a4, s10
+; RV32I-NEXT:    lw a4, 96(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 272(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a4, a4, a5
+; RV32I-NEXT:    lw a5, 92(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 260(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, a5, a6
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 156(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 372(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 88(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 252(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s10, a5, a6
+; RV32I-NEXT:    xor a4, a4, s10
+; RV32I-NEXT:    lw s10, 304(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 84(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s10, a5, s10
+; RV32I-NEXT:    xor a4, a4, s10
+; RV32I-NEXT:    lw a5, 80(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 244(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s10, a5, a6
+; RV32I-NEXT:    xor a4, a4, s10
+; RV32I-NEXT:    lw s10, 300(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 76(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, a5, s10
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    xor a2, a4, s10
-; RV32I-NEXT:    lw a4, 440(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 136(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 144(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 280(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, a5
-; RV32I-NEXT:    lw s10, 436(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 124(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 140(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 268(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, a5
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 432(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 96(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 136(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 240(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, a5
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 428(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 132(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, t3
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 424(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 128(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, t5
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 420(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 124(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, t4
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 416(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 120(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, t2
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    xor a2, a4, s10
-; RV32I-NEXT:    lw a4, 412(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 116(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, t6
-; RV32I-NEXT:    lw s10, 408(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 112(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, s1
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 404(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 108(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, t0
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 296(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, a0
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 292(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 436(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    mv a5, s5
 ; RV32I-NEXT:    and s10, s10, s5
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 288(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 432(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    mv t0, s6
 ; RV32I-NEXT:    and s10, s10, s6
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 284(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 428(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, a7
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 280(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 424(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    mv t2, s7
 ; RV32I-NEXT:    and s10, s10, s7
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    xor a2, a4, s10
-; RV32I-NEXT:    lw a4, 276(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 420(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    mv a6, s8
 ; RV32I-NEXT:    and a4, a4, s8
-; RV32I-NEXT:    lw s10, 268(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 412(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    mv t1, s9
 ; RV32I-NEXT:    and s10, s10, s9
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 272(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 416(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    mv s0, ra
 ; RV32I-NEXT:    and s10, s10, ra
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 264(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t3, 92(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 408(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 236(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, t3
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 260(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t4, 88(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 404(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t4, 232(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, t4
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 256(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t5, 84(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 400(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t5, 228(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, t5
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 252(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s11, 80(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 396(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s11, 224(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, s11
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 248(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s4, 76(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 392(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s4, 220(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, s4
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 244(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s3, 72(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 388(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s3, 216(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, s3
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    xor a2, a4, s10
-; RV32I-NEXT:    lw a4, 240(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t6, 64(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 384(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t6, 208(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, t6
-; RV32I-NEXT:    lw s10, 236(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s1, 60(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 380(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s1, 204(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, s1
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 232(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a3, 304(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 376(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, a3
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 228(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s5, 56(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 372(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s5, 200(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, s5
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 224(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s6, 48(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 368(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s6, 192(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, s6
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 220(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s7, 40(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 364(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 184(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, s7
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 216(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s8, 32(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 360(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s8, 176(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, s8
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 212(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s9, 16(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 356(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s9, 160(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, s9
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 200(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw ra, 308(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 344(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, ra
 ; RV32I-NEXT:    xor a4, a4, s10
-; RV32I-NEXT:    lw s10, 196(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw ra, 312(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 340(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 16(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, s10, ra
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    xor a2, a4, s10
-; RV32I-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a4, 4(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 152(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 148(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    xor a3, a3, a4
-; RV32I-NEXT:    sw a3, 296(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 4(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor s10, a1, a2
-; RV32I-NEXT:    lw a1, 368(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 72(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, a5
-; RV32I-NEXT:    lw a2, 364(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 68(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a0, a2, a0
-; RV32I-NEXT:    lw a2, 188(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw ra, 36(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 332(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 180(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a2, ra
-; RV32I-NEXT:    lw a4, 184(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 328(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 168(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, a3
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    xor a0, a0, a1
-; RV32I-NEXT:    lw a1, 360(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 64(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, t0
-; RV32I-NEXT:    lw a4, 356(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 60(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, a7
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a4, 204(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a7, 20(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 348(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 164(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, a7
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    xor a0, a0, a1
-; RV32I-NEXT:    lw a1, 352(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 56(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, t2
-; RV32I-NEXT:    lw a4, 348(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 52(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, a6
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a4, 344(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 48(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, t1
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a4, 176(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 28(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 320(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 172(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, a6
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    xor a0, a0, a1
-; RV32I-NEXT:    lw a1, 340(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 44(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, s0
-; RV32I-NEXT:    lw a4, 336(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 40(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, t3
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a4, 332(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 36(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, t4
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a4, 328(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 32(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, t5
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a4, 192(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 12(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 336(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 156(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, t1
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    xor a0, a0, a1
-; RV32I-NEXT:    lw a1, 324(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, s11
-; RV32I-NEXT:    lw a4, 320(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 24(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, s4
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a4, 316(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 20(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, s3
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a4, 400(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 104(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, t6
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a4, 396(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 100(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, s1
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a4, 180(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t0, 44(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 324(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t0, 188(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, t0
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    xor a0, a0, a1
-; RV32I-NEXT:    lw a1, 392(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a4, 304(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 96(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, a4
-; RV32I-NEXT:    lw a4, 388(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 92(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, s5
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a4, 384(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 88(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, s6
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a4, 380(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 84(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, s7
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a4, 376(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 80(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, s8
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a4, 372(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 76(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, s9
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a4, 208(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t2, 52(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 352(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t2, 196(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, t2
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    xor a0, a0, a1
-; RV32I-NEXT:    lw a1, 440(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a4, 308(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 144(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, a4
-; RV32I-NEXT:    lw a4, 436(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 312(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 140(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 16(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, a5
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a4, 432(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 136(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, ra
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a4, 428(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 132(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, a3
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a4, 424(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 128(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, a7
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a4, 420(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 124(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, a6
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a4, 416(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 120(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, t1
-; RV32I-NEXT:    lw a5, 412(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 116(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a7, a5, t0
-; RV32I-NEXT:    lw a5, 408(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 112(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, a5, t2
 ; RV32I-NEXT:    xor a1, a1, a4
 ; RV32I-NEXT:    xor a4, a7, a6
-; RV32I-NEXT:    lw a6, 68(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 212(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, s2, a6
-; RV32I-NEXT:    lw a5, 404(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 108(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, a6
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    xor a0, a0, a4
 ; RV32I-NEXT:    xor a1, s10, a2
-; RV32I-NEXT:    lw a2, 300(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 440(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    sw a0, 0(a2)
 ; RV32I-NEXT:    sw a1, 4(a2)
-; RV32I-NEXT:    lw a0, 296(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    sw a0, 8(a2)
 ; RV32I-NEXT:    lw ra, 492(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw s0, 488(sp) # 4-byte Folded Reload
@@ -10339,7 +10339,7 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    .cfi_offset s9, -44
 ; RV32IM-NEXT:    .cfi_offset s10, -48
 ; RV32IM-NEXT:    .cfi_offset s11, -52
-; RV32IM-NEXT:    sw a0, 300(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 440(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    lw s10, 4(a1)
 ; RV32IM-NEXT:    lw a0, 8(a1)
 ; RV32IM-NEXT:    lw a4, 0(a2)
@@ -10351,9 +10351,9 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    slli a7, a4, 31
 ; RV32IM-NEXT:    or a2, a5, a2
 ; RV32IM-NEXT:    srai a5, a6, 31
-; RV32IM-NEXT:    sw a5, 368(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a5, 72(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srai a6, a7, 31
-; RV32IM-NEXT:    sw a6, 364(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 68(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a2, a5, a2
 ; RV32IM-NEXT:    and a5, a6, a0
 ; RV32IM-NEXT:    xor a2, a5, a2
@@ -10362,13 +10362,13 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    or a5, a6, a5
 ; RV32IM-NEXT:    slli a6, a4, 29
 ; RV32IM-NEXT:    srai t1, a6, 31
-; RV32IM-NEXT:    sw t1, 360(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t1, 64(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srli a6, s10, 29
 ; RV32IM-NEXT:    slli a7, a0, 3
 ; RV32IM-NEXT:    slli t0, a4, 28
 ; RV32IM-NEXT:    or a6, a7, a6
 ; RV32IM-NEXT:    srai a7, t0, 31
-; RV32IM-NEXT:    sw a7, 356(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 60(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a5, t1, a5
 ; RV32IM-NEXT:    and a6, a7, a6
 ; RV32IM-NEXT:    xor a5, a5, a6
@@ -10377,21 +10377,21 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    slli t0, a4, 27
 ; RV32IM-NEXT:    or a6, a7, a6
 ; RV32IM-NEXT:    srai a7, t0, 31
-; RV32IM-NEXT:    sw a7, 352(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 56(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a6, a7, a6
 ; RV32IM-NEXT:    srli a7, s10, 27
 ; RV32IM-NEXT:    slli t0, a0, 5
 ; RV32IM-NEXT:    slli t1, a4, 26
 ; RV32IM-NEXT:    or a7, t0, a7
 ; RV32IM-NEXT:    srai t0, t1, 31
-; RV32IM-NEXT:    sw t0, 348(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t0, 52(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a7, t0, a7
 ; RV32IM-NEXT:    srli t0, s10, 26
 ; RV32IM-NEXT:    slli t1, a0, 6
 ; RV32IM-NEXT:    slli t2, a4, 25
 ; RV32IM-NEXT:    or t0, t1, t0
 ; RV32IM-NEXT:    srai t1, t2, 31
-; RV32IM-NEXT:    sw t1, 344(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t1, 48(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a6, a6, a7
 ; RV32IM-NEXT:    and a7, t1, t0
 ; RV32IM-NEXT:    xor a2, a2, a5
@@ -10402,13 +10402,13 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    or a5, a6, a5
 ; RV32IM-NEXT:    slli a6, a4, 24
 ; RV32IM-NEXT:    srai t1, a6, 31
-; RV32IM-NEXT:    sw t1, 340(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t1, 44(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srli a6, s10, 24
 ; RV32IM-NEXT:    slli a7, a0, 8
 ; RV32IM-NEXT:    slli t0, a4, 23
 ; RV32IM-NEXT:    or a6, a7, a6
 ; RV32IM-NEXT:    srai a7, t0, 31
-; RV32IM-NEXT:    sw a7, 336(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 40(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a5, t1, a5
 ; RV32IM-NEXT:    and a6, a7, a6
 ; RV32IM-NEXT:    xor a5, a5, a6
@@ -10417,14 +10417,14 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    slli t0, a4, 22
 ; RV32IM-NEXT:    or a6, a7, a6
 ; RV32IM-NEXT:    srai a7, t0, 31
-; RV32IM-NEXT:    sw a7, 332(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 36(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a6, a7, a6
 ; RV32IM-NEXT:    srli a7, s10, 22
 ; RV32IM-NEXT:    slli t0, a0, 10
 ; RV32IM-NEXT:    slli t1, a4, 21
 ; RV32IM-NEXT:    or a7, t0, a7
 ; RV32IM-NEXT:    srai t0, t1, 31
-; RV32IM-NEXT:    sw t0, 328(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t0, 32(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a5, a5, a6
 ; RV32IM-NEXT:    and a6, t0, a7
 ; RV32IM-NEXT:    xor a5, a5, a6
@@ -10433,21 +10433,21 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    slli t0, a4, 20
 ; RV32IM-NEXT:    or a6, a7, a6
 ; RV32IM-NEXT:    srai a7, t0, 31
-; RV32IM-NEXT:    sw a7, 324(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 28(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a6, a7, a6
 ; RV32IM-NEXT:    srli a7, s10, 20
 ; RV32IM-NEXT:    slli t0, a0, 12
 ; RV32IM-NEXT:    slli t1, a4, 19
 ; RV32IM-NEXT:    or a7, t0, a7
 ; RV32IM-NEXT:    srai t0, t1, 31
-; RV32IM-NEXT:    sw t0, 320(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t0, 24(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a7, t0, a7
 ; RV32IM-NEXT:    srli t0, s10, 19
 ; RV32IM-NEXT:    slli t1, a0, 13
 ; RV32IM-NEXT:    slli t2, a4, 18
 ; RV32IM-NEXT:    or t0, t1, t0
 ; RV32IM-NEXT:    srai t1, t2, 31
-; RV32IM-NEXT:    sw t1, 316(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t1, 20(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a6, a6, a7
 ; RV32IM-NEXT:    and a7, t1, t0
 ; RV32IM-NEXT:    xor a6, a6, a7
@@ -10456,14 +10456,14 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    slli t1, a4, 17
 ; RV32IM-NEXT:    or a7, t0, a7
 ; RV32IM-NEXT:    srai t2, t1, 31
-; RV32IM-NEXT:    sw t2, 400(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t2, 104(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srli t0, s10, 17
 ; RV32IM-NEXT:    slli t1, a0, 15
 ; RV32IM-NEXT:    or t0, t1, t0
 ; RV32IM-NEXT:    slli t1, a4, 16
 ; RV32IM-NEXT:    and a7, t2, a7
 ; RV32IM-NEXT:    srai t1, t1, 31
-; RV32IM-NEXT:    sw t1, 396(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t1, 100(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a6, a6, a7
 ; RV32IM-NEXT:    and a7, t1, t0
 ; RV32IM-NEXT:    xor a2, a2, a5
@@ -10478,9 +10478,9 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    or a7, t0, a7
 ; RV32IM-NEXT:    slli t0, a4, 14
 ; RV32IM-NEXT:    srai a6, a6, 31
-; RV32IM-NEXT:    sw a6, 392(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 96(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srai t0, t0, 31
-; RV32IM-NEXT:    sw t0, 388(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t0, 92(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a5, a6, a5
 ; RV32IM-NEXT:    and a6, t0, a7
 ; RV32IM-NEXT:    srli a7, s10, 14
@@ -10492,11 +10492,11 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    or a7, t0, a7
 ; RV32IM-NEXT:    slli t0, a4, 13
 ; RV32IM-NEXT:    srai t1, t0, 31
-; RV32IM-NEXT:    sw t1, 384(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t1, 88(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli t0, a4, 12
 ; RV32IM-NEXT:    and a6, t1, a6
 ; RV32IM-NEXT:    srai t0, t0, 31
-; RV32IM-NEXT:    sw t0, 380(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t0, 84(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a5, a5, a6
 ; RV32IM-NEXT:    and a6, t0, a7
 ; RV32IM-NEXT:    srli a7, s10, 12
@@ -10508,11 +10508,11 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    or a7, t0, a7
 ; RV32IM-NEXT:    slli t0, a4, 11
 ; RV32IM-NEXT:    srai t1, t0, 31
-; RV32IM-NEXT:    sw t1, 376(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t1, 80(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli t0, a4, 10
 ; RV32IM-NEXT:    and a6, t1, a6
 ; RV32IM-NEXT:    srai t0, t0, 31
-; RV32IM-NEXT:    sw t0, 372(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t0, 76(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a5, a5, a6
 ; RV32IM-NEXT:    and a6, t0, a7
 ; RV32IM-NEXT:    srli a7, s10, 10
@@ -10527,15 +10527,15 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    slli t2, a0, 24
 ; RV32IM-NEXT:    or t1, t2, t1
 ; RV32IM-NEXT:    srai t0, t0, 31
-; RV32IM-NEXT:    sw t0, 440(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t0, 144(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a6, t0, a6
 ; RV32IM-NEXT:    slli t0, a4, 8
 ; RV32IM-NEXT:    srai t2, t0, 31
-; RV32IM-NEXT:    sw t2, 436(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t2, 140(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli t0, a4, 7
 ; RV32IM-NEXT:    and a7, t2, a7
 ; RV32IM-NEXT:    srai t0, t0, 31
-; RV32IM-NEXT:    sw t0, 432(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t0, 136(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a6, a6, a7
 ; RV32IM-NEXT:    and a7, t0, t1
 ; RV32IM-NEXT:    srli t0, s10, 7
@@ -10547,11 +10547,11 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    or t0, t1, t0
 ; RV32IM-NEXT:    slli t1, a4, 6
 ; RV32IM-NEXT:    srai t2, t1, 31
-; RV32IM-NEXT:    sw t2, 428(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t2, 132(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli t1, a4, 5
 ; RV32IM-NEXT:    and a7, t2, a7
 ; RV32IM-NEXT:    srai t1, t1, 31
-; RV32IM-NEXT:    sw t1, 424(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t1, 128(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a6, a6, a7
 ; RV32IM-NEXT:    and a7, t1, t0
 ; RV32IM-NEXT:    srli t0, s10, 5
@@ -10563,11 +10563,11 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    or t0, t1, t0
 ; RV32IM-NEXT:    slli t1, a4, 4
 ; RV32IM-NEXT:    srai t2, t1, 31
-; RV32IM-NEXT:    sw t2, 420(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t2, 124(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli t1, a4, 3
 ; RV32IM-NEXT:    and a7, t2, a7
 ; RV32IM-NEXT:    srai t1, t1, 31
-; RV32IM-NEXT:    sw t1, 416(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t1, 120(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a6, a6, a7
 ; RV32IM-NEXT:    and a7, t1, t0
 ; RV32IM-NEXT:    xor a2, a2, a5
@@ -10581,9 +10581,9 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    slli t0, a4, 2
 ; RV32IM-NEXT:    slli t1, a4, 1
 ; RV32IM-NEXT:    srai t0, t0, 31
-; RV32IM-NEXT:    sw t0, 412(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t0, 116(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srai t1, t1, 31
-; RV32IM-NEXT:    sw t1, 408(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t1, 112(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a6, t0, a6
 ; RV32IM-NEXT:    and a7, t1, a7
 ; RV32IM-NEXT:    xor a2, a2, a5
@@ -10593,11 +10593,11 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    or a6, a0, a6
 ; RV32IM-NEXT:    lw a0, 0(a1)
 ; RV32IM-NEXT:    srai a4, a4, 31
-; RV32IM-NEXT:    sw a4, 404(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a4, 108(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a1, s2, 31
 ; RV32IM-NEXT:    and a4, a4, a6
 ; RV32IM-NEXT:    srai a1, a1, 31
-; RV32IM-NEXT:    sw a1, 296(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 4(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a4, a5, a4
 ; RV32IM-NEXT:    and a1, a1, s10
 ; RV32IM-NEXT:    slli a5, s10, 1
@@ -10607,13 +10607,13 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    slli a4, s10, 2
 ; RV32IM-NEXT:    srli a5, a0, 30
 ; RV32IM-NEXT:    or a7, a5, a4
-; RV32IM-NEXT:    sw a7, 152(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 296(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a4, s2, 30
 ; RV32IM-NEXT:    srai a5, a4, 31
-; RV32IM-NEXT:    sw a5, 292(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a5, 436(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a4, s2, 29
 ; RV32IM-NEXT:    srai a6, a4, 31
-; RV32IM-NEXT:    sw a6, 288(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 432(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a4, a5, t1
 ; RV32IM-NEXT:    xor a1, a1, a4
 ; RV32IM-NEXT:    and a4, a6, a7
@@ -10621,17 +10621,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    srli a6, a0, 29
 ; RV32IM-NEXT:    xor a1, a1, a4
 ; RV32IM-NEXT:    or t0, a6, a5
-; RV32IM-NEXT:    sw t0, 168(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t0, 312(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srli a4, a0, 28
 ; RV32IM-NEXT:    slli a5, s10, 4
 ; RV32IM-NEXT:    or a7, a5, a4
-; RV32IM-NEXT:    sw a7, 172(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 316(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a4, s2, 28
 ; RV32IM-NEXT:    srai a5, a4, 31
-; RV32IM-NEXT:    sw a5, 284(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a5, 428(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a4, s2, 27
 ; RV32IM-NEXT:    srai a6, a4, 31
-; RV32IM-NEXT:    sw a6, 280(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 424(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a4, a5, t0
 ; RV32IM-NEXT:    xor a1, a1, a4
 ; RV32IM-NEXT:    and a4, a6, a7
@@ -10642,19 +10642,19 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    slli a4, s10, 6
 ; RV32IM-NEXT:    srli a5, a0, 26
 ; RV32IM-NEXT:    or t2, a5, a4
-; RV32IM-NEXT:    sw t2, 148(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t2, 292(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a4, s2, 26
 ; RV32IM-NEXT:    slli a5, s10, 7
 ; RV32IM-NEXT:    srli a6, a0, 25
 ; RV32IM-NEXT:    or s4, a6, a5
 ; RV32IM-NEXT:    srai a6, a4, 31
-; RV32IM-NEXT:    sw a6, 276(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 420(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a4, s2, 25
 ; RV32IM-NEXT:    slli a5, s2, 24
 ; RV32IM-NEXT:    srai t0, a4, 31
-; RV32IM-NEXT:    sw t0, 268(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t0, 412(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srai a7, a5, 31
-; RV32IM-NEXT:    sw a7, 272(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 416(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a4, a6, s3
 ; RV32IM-NEXT:    and a5, t0, t2
 ; RV32IM-NEXT:    xor a4, a4, a5
@@ -10666,13 +10666,13 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    slli a5, s10, 9
 ; RV32IM-NEXT:    srli a6, a0, 23
 ; RV32IM-NEXT:    or t0, a6, a5
-; RV32IM-NEXT:    sw t0, 164(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t0, 308(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a5, s2, 23
 ; RV32IM-NEXT:    srai a6, a5, 31
-; RV32IM-NEXT:    sw a6, 264(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 408(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a5, s2, 22
 ; RV32IM-NEXT:    srai a7, a5, 31
-; RV32IM-NEXT:    sw a7, 260(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 404(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a5, a6, a3
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    and a5, a7, t0
@@ -10680,17 +10680,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    srli a7, a0, 22
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    or t0, a7, a6
-; RV32IM-NEXT:    sw t0, 144(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t0, 288(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a5, s10, 11
 ; RV32IM-NEXT:    srli a6, a0, 21
 ; RV32IM-NEXT:    or t2, a6, a5
-; RV32IM-NEXT:    sw t2, 132(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t2, 276(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a5, s2, 21
 ; RV32IM-NEXT:    srai a6, a5, 31
-; RV32IM-NEXT:    sw a6, 256(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 400(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a5, s2, 20
 ; RV32IM-NEXT:    srai a7, a5, 31
-; RV32IM-NEXT:    sw a7, 252(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 396(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a5, a6, t0
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    and a5, a7, t2
@@ -10698,17 +10698,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    srli a7, a0, 20
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    or t0, a7, a6
-; RV32IM-NEXT:    sw t0, 120(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t0, 264(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a5, s10, 13
 ; RV32IM-NEXT:    srli a6, a0, 19
 ; RV32IM-NEXT:    or t2, a6, a5
-; RV32IM-NEXT:    sw t2, 112(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t2, 256(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a5, s2, 19
 ; RV32IM-NEXT:    srai a6, a5, 31
-; RV32IM-NEXT:    sw a6, 248(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 392(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a5, s2, 18
 ; RV32IM-NEXT:    srai a7, a5, 31
-; RV32IM-NEXT:    sw a7, 244(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 388(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a5, a6, t0
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    and a5, a7, t2
@@ -10720,32 +10720,32 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    slli a5, s10, 15
 ; RV32IM-NEXT:    srli a6, a0, 17
 ; RV32IM-NEXT:    or a7, a4, a2
-; RV32IM-NEXT:    sw a7, 104(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 248(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a5, a6, a5
-; RV32IM-NEXT:    sw a5, 140(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a5, 284(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a2, s2, 17
 ; RV32IM-NEXT:    slli a4, s2, 16
 ; RV32IM-NEXT:    srai a2, a2, 31
-; RV32IM-NEXT:    sw a2, 240(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a2, 384(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srai a4, a4, 31
-; RV32IM-NEXT:    sw a4, 236(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a4, 380(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a2, a2, a7
 ; RV32IM-NEXT:    and a4, a4, a5
 ; RV32IM-NEXT:    srli a5, a0, 16
 ; RV32IM-NEXT:    slli a6, s10, 16
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    or a7, a6, a5
-; RV32IM-NEXT:    sw a7, 128(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 272(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srli a4, a0, 15
 ; RV32IM-NEXT:    slli a5, s10, 17
 ; RV32IM-NEXT:    or t0, a5, a4
-; RV32IM-NEXT:    sw t0, 116(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t0, 260(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a4, s2, 15
 ; RV32IM-NEXT:    srai a5, a4, 31
-; RV32IM-NEXT:    sw a5, 232(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a5, 376(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a4, s2, 14
 ; RV32IM-NEXT:    srai a6, a4, 31
-; RV32IM-NEXT:    sw a6, 228(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 372(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a4, a5, a7
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    and a4, a6, t0
@@ -10753,17 +10753,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    slli a6, s10, 18
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    or t0, a6, a5
-; RV32IM-NEXT:    sw t0, 108(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t0, 252(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srli a4, a0, 13
 ; RV32IM-NEXT:    slli a5, s10, 19
 ; RV32IM-NEXT:    or a7, a5, a4
-; RV32IM-NEXT:    sw a7, 160(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 304(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a4, s2, 13
 ; RV32IM-NEXT:    srai a5, a4, 31
-; RV32IM-NEXT:    sw a5, 224(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a5, 368(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a4, s2, 12
 ; RV32IM-NEXT:    srai a6, a4, 31
-; RV32IM-NEXT:    sw a6, 220(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 364(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a4, a5, t0
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    and a4, a6, a7
@@ -10771,17 +10771,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    slli a6, s10, 20
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    or t0, a6, a5
-; RV32IM-NEXT:    sw t0, 100(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t0, 244(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srli a4, a0, 11
 ; RV32IM-NEXT:    slli a5, s10, 21
 ; RV32IM-NEXT:    or a7, a5, a4
-; RV32IM-NEXT:    sw a7, 156(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 300(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a4, s2, 11
 ; RV32IM-NEXT:    srai a5, a4, 31
-; RV32IM-NEXT:    sw a5, 216(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a5, 360(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a4, s2, 10
 ; RV32IM-NEXT:    srai a6, a4, 31
-; RV32IM-NEXT:    sw a6, 212(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 356(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a4, a5, t0
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    and a4, a6, a7
@@ -10789,17 +10789,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    slli a6, s10, 22
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    or a7, a6, a5
-; RV32IM-NEXT:    sw a7, 136(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 280(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srli a4, a0, 9
 ; RV32IM-NEXT:    slli a5, s10, 23
 ; RV32IM-NEXT:    or t0, a5, a4
-; RV32IM-NEXT:    sw t0, 124(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t0, 268(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a4, s2, 9
 ; RV32IM-NEXT:    srai a5, a4, 31
-; RV32IM-NEXT:    sw a5, 200(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a5, 344(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a4, s2, 8
 ; RV32IM-NEXT:    srai a6, a4, 31
-; RV32IM-NEXT:    sw a6, 196(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 340(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a4, a5, a7
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    and a4, a6, t0
@@ -10807,7 +10807,7 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    srli a6, a0, 8
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    or t2, a6, a5
-; RV32IM-NEXT:    sw t2, 96(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t2, 240(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srli a4, a0, 7
 ; RV32IM-NEXT:    slli a5, s10, 25
 ; RV32IM-NEXT:    or t3, a5, a4
@@ -10816,13 +10816,13 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    slli a6, s10, 26
 ; RV32IM-NEXT:    or t5, a6, a5
 ; RV32IM-NEXT:    srai a7, a4, 31
-; RV32IM-NEXT:    sw a7, 188(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 332(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a4, s2, 6
 ; RV32IM-NEXT:    slli a5, s2, 5
 ; RV32IM-NEXT:    srai t0, a4, 31
-; RV32IM-NEXT:    sw t0, 184(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t0, 328(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srai a6, a5, 31
-; RV32IM-NEXT:    sw a6, 204(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 348(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a4, a7, t2
 ; RV32IM-NEXT:    and a5, t0, t3
 ; RV32IM-NEXT:    xor a4, a4, a5
@@ -10836,10 +10836,10 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    or t2, a6, a5
 ; RV32IM-NEXT:    slli a5, s2, 4
 ; RV32IM-NEXT:    srai a7, a5, 31
-; RV32IM-NEXT:    sw a7, 176(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 320(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a5, s2, 3
 ; RV32IM-NEXT:    srai a6, a5, 31
-; RV32IM-NEXT:    sw a6, 192(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 336(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a5, a7, t4
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    and a5, a6, t2
@@ -10852,10 +10852,10 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    or s1, a6, a5
 ; RV32IM-NEXT:    slli a5, s2, 2
 ; RV32IM-NEXT:    srai a7, a5, 31
-; RV32IM-NEXT:    sw a7, 180(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 324(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a5, s2, 1
 ; RV32IM-NEXT:    srai a6, a5, 31
-; RV32IM-NEXT:    sw a6, 208(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 352(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a5, a7, t6
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    and a5, a6, s1
@@ -10908,120 +10908,120 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    slli a5, s11, 23
 ; RV32IM-NEXT:    srai a5, a5, 31
 ; RV32IM-NEXT:    slli a6, a0, 8
-; RV32IM-NEXT:    sw a6, 92(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 236(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    and a4, a5, a6
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    slli a4, s11, 22
 ; RV32IM-NEXT:    srai a4, a4, 31
 ; RV32IM-NEXT:    slli a5, a0, 9
-; RV32IM-NEXT:    sw a5, 88(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a5, 232(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a4, a4, a5
 ; RV32IM-NEXT:    slli a5, s11, 21
 ; RV32IM-NEXT:    srai a5, a5, 31
 ; RV32IM-NEXT:    slli a6, a0, 10
-; RV32IM-NEXT:    sw a6, 84(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 228(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    and a4, a5, a6
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    slli a4, s11, 20
 ; RV32IM-NEXT:    srai a4, a4, 31
 ; RV32IM-NEXT:    slli a5, a0, 11
-; RV32IM-NEXT:    sw a5, 80(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a5, 224(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a4, a4, a5
 ; RV32IM-NEXT:    slli a5, s11, 19
 ; RV32IM-NEXT:    srai a5, a5, 31
 ; RV32IM-NEXT:    slli a6, a0, 12
-; RV32IM-NEXT:    sw a6, 76(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 220(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    and a4, a5, a6
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    slli a4, s11, 18
 ; RV32IM-NEXT:    srai a4, a4, 31
 ; RV32IM-NEXT:    slli a5, a0, 13
-; RV32IM-NEXT:    sw a5, 72(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a5, 216(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a4, a4, a5
 ; RV32IM-NEXT:    slli a5, s11, 17
 ; RV32IM-NEXT:    srai a5, a5, 31
 ; RV32IM-NEXT:    slli a6, a0, 14
-; RV32IM-NEXT:    sw a6, 64(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 208(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    and a4, a5, a6
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    slli a4, s11, 16
 ; RV32IM-NEXT:    srai a4, a4, 31
 ; RV32IM-NEXT:    slli a5, a0, 15
-; RV32IM-NEXT:    sw a5, 60(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a5, 204(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a4, a4, a5
 ; RV32IM-NEXT:    slli a5, s11, 15
 ; RV32IM-NEXT:    srai a5, a5, 31
 ; RV32IM-NEXT:    slli a6, a0, 16
-; RV32IM-NEXT:    sw a6, 304(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 8(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a5, a5, a6
 ; RV32IM-NEXT:    slli a6, s11, 14
 ; RV32IM-NEXT:    srai a6, a6, 31
 ; RV32IM-NEXT:    slli s0, a0, 17
-; RV32IM-NEXT:    sw s0, 56(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s0, 200(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    and a5, a6, s0
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    slli a5, s11, 13
 ; RV32IM-NEXT:    srai a5, a5, 31
 ; RV32IM-NEXT:    slli a6, a0, 18
-; RV32IM-NEXT:    sw a6, 48(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 192(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a5, a5, a6
 ; RV32IM-NEXT:    slli a6, s11, 12
 ; RV32IM-NEXT:    srai a6, a6, 31
 ; RV32IM-NEXT:    slli s0, a0, 19
-; RV32IM-NEXT:    sw s0, 40(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s0, 184(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    and a5, a6, s0
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    slli a5, s11, 11
 ; RV32IM-NEXT:    srai a5, a5, 31
 ; RV32IM-NEXT:    slli a6, a0, 20
-; RV32IM-NEXT:    sw a6, 32(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 176(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a5, a5, a6
 ; RV32IM-NEXT:    slli a6, s11, 10
 ; RV32IM-NEXT:    srai a6, a6, 31
 ; RV32IM-NEXT:    slli s0, a0, 21
-; RV32IM-NEXT:    sw s0, 16(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s0, 160(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    and a5, a6, s0
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    slli a5, s11, 9
 ; RV32IM-NEXT:    srai a5, a5, 31
 ; RV32IM-NEXT:    slli a6, a0, 22
-; RV32IM-NEXT:    sw a6, 308(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 12(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a5, a5, a6
 ; RV32IM-NEXT:    slli a6, s11, 8
 ; RV32IM-NEXT:    srai a6, a6, 31
 ; RV32IM-NEXT:    slli s0, a0, 23
-; RV32IM-NEXT:    sw s0, 312(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s0, 16(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    and a5, a6, s0
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    slli a5, s11, 7
 ; RV32IM-NEXT:    srai a5, a5, 31
 ; RV32IM-NEXT:    slli a6, a0, 24
-; RV32IM-NEXT:    sw a6, 36(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 180(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a5, a5, a6
 ; RV32IM-NEXT:    slli a6, s11, 6
 ; RV32IM-NEXT:    srai a6, a6, 31
 ; RV32IM-NEXT:    slli s0, a0, 25
-; RV32IM-NEXT:    sw s0, 24(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s0, 168(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    and a5, a6, s0
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    slli a5, s11, 5
 ; RV32IM-NEXT:    srai a5, a5, 31
 ; RV32IM-NEXT:    slli a6, a0, 26
-; RV32IM-NEXT:    sw a6, 20(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 164(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a5, a5, a6
 ; RV32IM-NEXT:    slli a6, s11, 4
 ; RV32IM-NEXT:    srai s0, a6, 31
 ; RV32IM-NEXT:    slli a6, a0, 27
-; RV32IM-NEXT:    sw a6, 28(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 172(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    and a5, s0, a6
 ; RV32IM-NEXT:    xor s0, a1, a2
@@ -11031,371 +11031,371 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IM-NEXT:    srai a1, a1, 31
 ; RV32IM-NEXT:    srai a2, a2, 31
 ; RV32IM-NEXT:    slli a6, a0, 28
-; RV32IM-NEXT:    sw a6, 12(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 156(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a5, a0, 29
-; RV32IM-NEXT:    sw a5, 44(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a5, 188(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a1, a1, a6
 ; RV32IM-NEXT:    and a2, a2, a5
 ; RV32IM-NEXT:    xor a1, a1, a2
 ; RV32IM-NEXT:    slli a2, s11, 1
 ; RV32IM-NEXT:    srai a5, a2, 31
 ; RV32IM-NEXT:    slli a2, a0, 30
-; RV32IM-NEXT:    sw a2, 52(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a2, 196(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a2, a5, a2
 ; RV32IM-NEXT:    slli a5, a0, 31
-; RV32IM-NEXT:    sw a5, 68(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a5, 212(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a1, a1, a2
 ; RV32IM-NEXT:    and a2, s11, a5
 ; RV32IM-NEXT:    xor a4, s0, a4
-; RV32IM-NEXT:    sw a4, 8(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a4, 152(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a1, a1, a2
-; RV32IM-NEXT:    sw a1, 4(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    lw a1, 368(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    sw a1, 148(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    lw a1, 72(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, t1
-; RV32IM-NEXT:    lw a2, 364(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a2, 68(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a2, a2, s10
-; RV32IM-NEXT:    lw a4, 152(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a5, 360(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 296(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 64(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a5, a4
-; RV32IM-NEXT:    lw t1, 168(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a5, 356(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t1, 312(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 60(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, a5, t1
 ; RV32IM-NEXT:    xor a1, a2, a1
 ; RV32IM-NEXT:    xor a2, a4, s10
-; RV32IM-NEXT:    lw a4, 172(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a5, 352(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 316(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 56(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a5, a4
-; RV32IM-NEXT:    lw a5, 348(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 52(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, a5, s3
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw a5, 148(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a6, 344(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 292(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a6, 48(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, a6, a5
 ; RV32IM-NEXT:    xor a1, a1, a2
 ; RV32IM-NEXT:    xor a2, a4, s10
-; RV32IM-NEXT:    lw a4, 340(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 44(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, s4
-; RV32IM-NEXT:    lw a5, 336(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 40(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, a5, a3
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s0, 164(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a5, 332(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s0, 308(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 36(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, a5, s0
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw a5, 144(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a6, 328(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 288(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a6, 32(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, a6, a5
 ; RV32IM-NEXT:    xor a1, a1, a2
 ; RV32IM-NEXT:    xor a2, a4, s10
-; RV32IM-NEXT:    lw a4, 132(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a5, 324(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 276(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 28(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a5, a4
-; RV32IM-NEXT:    lw a5, 120(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a6, 320(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 264(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a6, 24(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, a6, a5
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw a5, 112(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a6, 316(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 256(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a6, 20(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, a6, a5
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw a5, 104(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a6, 400(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 248(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a6, 104(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, a6, a5
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw a5, 140(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a6, 396(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    and s10, a6, a5
-; RV32IM-NEXT:    xor a1, a1, a2
-; RV32IM-NEXT:    xor a2, a4, s10
-; RV32IM-NEXT:    lw a4, 392(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a5, 128(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    and a4, a4, a5
-; RV32IM-NEXT:    lw a5, 388(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a6, 116(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    and s10, a5, a6
-; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw a5, 384(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a6, 108(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    and s10, a5, a6
-; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 160(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a5, 380(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    and s10, a5, s10
-; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw a5, 376(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 284(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    lw a6, 100(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    and s10, a6, a5
+; RV32IM-NEXT:    xor a1, a1, a2
+; RV32IM-NEXT:    xor a2, a4, s10
+; RV32IM-NEXT:    lw a4, 96(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 272(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    and a4, a4, a5
+; RV32IM-NEXT:    lw a5, 92(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a6, 260(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, a5, a6
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 156(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a5, 372(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 88(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a6, 252(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    and s10, a5, a6
+; RV32IM-NEXT:    xor a4, a4, s10
+; RV32IM-NEXT:    lw s10, 304(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 84(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    and s10, a5, s10
+; RV32IM-NEXT:    xor a4, a4, s10
+; RV32IM-NEXT:    lw a5, 80(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a6, 244(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    and s10, a5, a6
+; RV32IM-NEXT:    xor a4, a4, s10
+; RV32IM-NEXT:    lw s10, 300(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 76(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, a5, s10
 ; RV32IM-NEXT:    xor a1, a1, a2
 ; RV32IM-NEXT:    xor a2, a4, s10
-; RV32IM-NEXT:    lw a4, 440(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a5, 136(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 144(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 280(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, a5
-; RV32IM-NEXT:    lw s10, 436(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a5, 124(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 140(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 268(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, a5
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 432(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a5, 96(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 136(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 240(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, a5
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 428(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 132(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, t3
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 424(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 128(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, t5
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 420(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 124(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, t4
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 416(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 120(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, t2
 ; RV32IM-NEXT:    xor a1, a1, a2
 ; RV32IM-NEXT:    xor a2, a4, s10
-; RV32IM-NEXT:    lw a4, 412(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 116(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, t6
-; RV32IM-NEXT:    lw s10, 408(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 112(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, s1
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 404(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 108(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, t0
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 296(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 4(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, a0
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 292(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 436(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mv a5, s5
 ; RV32IM-NEXT:    and s10, s10, s5
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 288(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 432(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mv t0, s6
 ; RV32IM-NEXT:    and s10, s10, s6
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 284(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 428(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, a7
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 280(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 424(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mv t2, s7
 ; RV32IM-NEXT:    and s10, s10, s7
 ; RV32IM-NEXT:    xor a1, a1, a2
 ; RV32IM-NEXT:    xor a2, a4, s10
-; RV32IM-NEXT:    lw a4, 276(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 420(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mv a6, s8
 ; RV32IM-NEXT:    and a4, a4, s8
-; RV32IM-NEXT:    lw s10, 268(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 412(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mv t1, s9
 ; RV32IM-NEXT:    and s10, s10, s9
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 272(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 416(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mv s0, ra
 ; RV32IM-NEXT:    and s10, s10, ra
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 264(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw t3, 92(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 408(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t3, 236(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, t3
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 260(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw t4, 88(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 404(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t4, 232(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, t4
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 256(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw t5, 84(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 400(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t5, 228(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, t5
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 252(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s11, 80(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 396(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s11, 224(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, s11
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 248(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s4, 76(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 392(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s4, 220(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, s4
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 244(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s3, 72(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 388(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s3, 216(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, s3
 ; RV32IM-NEXT:    xor a1, a1, a2
 ; RV32IM-NEXT:    xor a2, a4, s10
-; RV32IM-NEXT:    lw a4, 240(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw t6, 64(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 384(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t6, 208(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, t6
-; RV32IM-NEXT:    lw s10, 236(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s1, 60(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 380(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s1, 204(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, s1
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 232(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a3, 304(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 376(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, a3
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 228(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s5, 56(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 372(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s5, 200(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, s5
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 224(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s6, 48(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 368(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s6, 192(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, s6
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 220(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s7, 40(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 364(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s7, 184(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, s7
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 216(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s8, 32(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 360(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s8, 176(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, s8
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 212(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s9, 16(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 356(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s9, 160(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, s9
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 200(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw ra, 308(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 344(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, ra
 ; RV32IM-NEXT:    xor a4, a4, s10
-; RV32IM-NEXT:    lw s10, 196(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw ra, 312(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 340(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw ra, 16(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, s10, ra
 ; RV32IM-NEXT:    xor a1, a1, a2
 ; RV32IM-NEXT:    xor a2, a4, s10
-; RV32IM-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a4, 4(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 152(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 148(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    xor a3, a3, a4
-; RV32IM-NEXT:    sw a3, 296(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a3, 4(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor s10, a1, a2
-; RV32IM-NEXT:    lw a1, 368(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a1, 72(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, a5
-; RV32IM-NEXT:    lw a2, 364(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a2, 68(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a0, a2, a0
-; RV32IM-NEXT:    lw a2, 188(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw ra, 36(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a2, 332(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw ra, 180(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a2, a2, ra
-; RV32IM-NEXT:    lw a4, 184(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 328(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 168(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, a3
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    xor a0, a0, a1
-; RV32IM-NEXT:    lw a1, 360(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a1, 64(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, t0
-; RV32IM-NEXT:    lw a4, 356(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 60(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, a7
 ; RV32IM-NEXT:    xor a1, a1, a4
-; RV32IM-NEXT:    lw a4, 204(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a7, 20(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 348(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a7, 164(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, a7
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    xor a0, a0, a1
-; RV32IM-NEXT:    lw a1, 352(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a1, 56(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, t2
-; RV32IM-NEXT:    lw a4, 348(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 52(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, a6
 ; RV32IM-NEXT:    xor a1, a1, a4
-; RV32IM-NEXT:    lw a4, 344(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 48(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, t1
 ; RV32IM-NEXT:    xor a1, a1, a4
-; RV32IM-NEXT:    lw a4, 176(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a6, 28(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 320(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a6, 172(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, a6
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    xor a0, a0, a1
-; RV32IM-NEXT:    lw a1, 340(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a1, 44(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, s0
-; RV32IM-NEXT:    lw a4, 336(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 40(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, t3
 ; RV32IM-NEXT:    xor a1, a1, a4
-; RV32IM-NEXT:    lw a4, 332(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 36(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, t4
 ; RV32IM-NEXT:    xor a1, a1, a4
-; RV32IM-NEXT:    lw a4, 328(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 32(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, t5
 ; RV32IM-NEXT:    xor a1, a1, a4
-; RV32IM-NEXT:    lw a4, 192(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw t1, 12(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 336(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t1, 156(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, t1
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    xor a0, a0, a1
-; RV32IM-NEXT:    lw a1, 324(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, s11
-; RV32IM-NEXT:    lw a4, 320(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 24(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, s4
 ; RV32IM-NEXT:    xor a1, a1, a4
-; RV32IM-NEXT:    lw a4, 316(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 20(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, s3
 ; RV32IM-NEXT:    xor a1, a1, a4
-; RV32IM-NEXT:    lw a4, 400(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 104(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, t6
 ; RV32IM-NEXT:    xor a1, a1, a4
-; RV32IM-NEXT:    lw a4, 396(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 100(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, s1
 ; RV32IM-NEXT:    xor a1, a1, a4
-; RV32IM-NEXT:    lw a4, 180(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw t0, 44(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 324(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t0, 188(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, t0
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    xor a0, a0, a1
-; RV32IM-NEXT:    lw a1, 392(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a4, 304(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a1, 96(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 8(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, a4
-; RV32IM-NEXT:    lw a4, 388(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 92(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, s5
 ; RV32IM-NEXT:    xor a1, a1, a4
-; RV32IM-NEXT:    lw a4, 384(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 88(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, s6
 ; RV32IM-NEXT:    xor a1, a1, a4
-; RV32IM-NEXT:    lw a4, 380(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 84(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, s7
 ; RV32IM-NEXT:    xor a1, a1, a4
-; RV32IM-NEXT:    lw a4, 376(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 80(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, s8
 ; RV32IM-NEXT:    xor a1, a1, a4
-; RV32IM-NEXT:    lw a4, 372(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 76(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, s9
 ; RV32IM-NEXT:    xor a1, a1, a4
-; RV32IM-NEXT:    lw a4, 208(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw t2, 52(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 352(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t2, 196(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, t2
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    xor a0, a0, a1
-; RV32IM-NEXT:    lw a1, 440(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a4, 308(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a1, 144(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 12(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, a4
-; RV32IM-NEXT:    lw a4, 436(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a5, 312(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 140(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 16(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, a5
 ; RV32IM-NEXT:    xor a1, a1, a4
-; RV32IM-NEXT:    lw a4, 432(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 136(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, ra
 ; RV32IM-NEXT:    xor a1, a1, a4
-; RV32IM-NEXT:    lw a4, 428(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 132(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, a3
 ; RV32IM-NEXT:    xor a1, a1, a4
-; RV32IM-NEXT:    lw a4, 424(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 128(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, a7
 ; RV32IM-NEXT:    xor a1, a1, a4
-; RV32IM-NEXT:    lw a4, 420(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 124(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, a6
 ; RV32IM-NEXT:    xor a1, a1, a4
-; RV32IM-NEXT:    lw a4, 416(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 120(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, t1
-; RV32IM-NEXT:    lw a5, 412(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 116(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a7, a5, t0
-; RV32IM-NEXT:    lw a5, 408(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 112(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a6, a5, t2
 ; RV32IM-NEXT:    xor a1, a1, a4
 ; RV32IM-NEXT:    xor a4, a7, a6
-; RV32IM-NEXT:    lw a6, 68(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a6, 212(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a3, s2, a6
-; RV32IM-NEXT:    lw a5, 404(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 108(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a5, a5, a6
 ; RV32IM-NEXT:    xor a0, a0, a1
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    xor a2, a2, a3
 ; RV32IM-NEXT:    xor a0, a0, a4
 ; RV32IM-NEXT:    xor a1, s10, a2
-; RV32IM-NEXT:    lw a2, 300(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a2, 440(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    sw a0, 0(a2)
 ; RV32IM-NEXT:    sw a1, 4(a2)
-; RV32IM-NEXT:    lw a0, 296(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    sw a0, 8(a2)
 ; RV32IM-NEXT:    lw ra, 492(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    lw s0, 488(sp) # 4-byte Folded Reload
@@ -12425,7 +12425,7 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    .cfi_offset s9, -44
 ; RV32IMZBS-NEXT:    .cfi_offset s10, -48
 ; RV32IMZBS-NEXT:    .cfi_offset s11, -52
-; RV32IMZBS-NEXT:    sw a0, 300(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 440(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    lw s10, 4(a1)
 ; RV32IMZBS-NEXT:    lw a0, 8(a1)
 ; RV32IMZBS-NEXT:    lw a4, 0(a2)
@@ -12437,9 +12437,9 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    slli a7, a4, 31
 ; RV32IMZBS-NEXT:    or a2, a5, a2
 ; RV32IMZBS-NEXT:    srai a5, a6, 31
-; RV32IMZBS-NEXT:    sw a5, 368(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a5, 72(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srai a6, a7, 31
-; RV32IMZBS-NEXT:    sw a6, 364(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 68(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a2, a5, a2
 ; RV32IMZBS-NEXT:    and a5, a6, a0
 ; RV32IMZBS-NEXT:    xor a2, a5, a2
@@ -12448,13 +12448,13 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    or a5, a6, a5
 ; RV32IMZBS-NEXT:    slli a6, a4, 29
 ; RV32IMZBS-NEXT:    srai t1, a6, 31
-; RV32IMZBS-NEXT:    sw t1, 360(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t1, 64(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srli a6, s10, 29
 ; RV32IMZBS-NEXT:    slli a7, a0, 3
 ; RV32IMZBS-NEXT:    slli t0, a4, 28
 ; RV32IMZBS-NEXT:    or a6, a7, a6
 ; RV32IMZBS-NEXT:    srai a7, t0, 31
-; RV32IMZBS-NEXT:    sw a7, 356(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 60(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a5, t1, a5
 ; RV32IMZBS-NEXT:    and a6, a7, a6
 ; RV32IMZBS-NEXT:    xor a5, a5, a6
@@ -12463,21 +12463,21 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    slli t0, a4, 27
 ; RV32IMZBS-NEXT:    or a6, a7, a6
 ; RV32IMZBS-NEXT:    srai a7, t0, 31
-; RV32IMZBS-NEXT:    sw a7, 352(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 56(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a6, a7, a6
 ; RV32IMZBS-NEXT:    srli a7, s10, 27
 ; RV32IMZBS-NEXT:    slli t0, a0, 5
 ; RV32IMZBS-NEXT:    slli t1, a4, 26
 ; RV32IMZBS-NEXT:    or a7, t0, a7
 ; RV32IMZBS-NEXT:    srai t0, t1, 31
-; RV32IMZBS-NEXT:    sw t0, 348(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t0, 52(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a7, t0, a7
 ; RV32IMZBS-NEXT:    srli t0, s10, 26
 ; RV32IMZBS-NEXT:    slli t1, a0, 6
 ; RV32IMZBS-NEXT:    slli t2, a4, 25
 ; RV32IMZBS-NEXT:    or t0, t1, t0
 ; RV32IMZBS-NEXT:    srai t1, t2, 31
-; RV32IMZBS-NEXT:    sw t1, 344(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t1, 48(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a6, a6, a7
 ; RV32IMZBS-NEXT:    and a7, t1, t0
 ; RV32IMZBS-NEXT:    xor a2, a2, a5
@@ -12488,13 +12488,13 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    or a5, a6, a5
 ; RV32IMZBS-NEXT:    slli a6, a4, 24
 ; RV32IMZBS-NEXT:    srai t1, a6, 31
-; RV32IMZBS-NEXT:    sw t1, 340(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t1, 44(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srli a6, s10, 24
 ; RV32IMZBS-NEXT:    slli a7, a0, 8
 ; RV32IMZBS-NEXT:    slli t0, a4, 23
 ; RV32IMZBS-NEXT:    or a6, a7, a6
 ; RV32IMZBS-NEXT:    srai a7, t0, 31
-; RV32IMZBS-NEXT:    sw a7, 336(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 40(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a5, t1, a5
 ; RV32IMZBS-NEXT:    and a6, a7, a6
 ; RV32IMZBS-NEXT:    xor a5, a5, a6
@@ -12503,14 +12503,14 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    slli t0, a4, 22
 ; RV32IMZBS-NEXT:    or a6, a7, a6
 ; RV32IMZBS-NEXT:    srai a7, t0, 31
-; RV32IMZBS-NEXT:    sw a7, 332(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 36(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a6, a7, a6
 ; RV32IMZBS-NEXT:    srli a7, s10, 22
 ; RV32IMZBS-NEXT:    slli t0, a0, 10
 ; RV32IMZBS-NEXT:    slli t1, a4, 21
 ; RV32IMZBS-NEXT:    or a7, t0, a7
 ; RV32IMZBS-NEXT:    srai t0, t1, 31
-; RV32IMZBS-NEXT:    sw t0, 328(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t0, 32(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a5, a5, a6
 ; RV32IMZBS-NEXT:    and a6, t0, a7
 ; RV32IMZBS-NEXT:    xor a5, a5, a6
@@ -12519,21 +12519,21 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    slli t0, a4, 20
 ; RV32IMZBS-NEXT:    or a6, a7, a6
 ; RV32IMZBS-NEXT:    srai a7, t0, 31
-; RV32IMZBS-NEXT:    sw a7, 324(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 28(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a6, a7, a6
 ; RV32IMZBS-NEXT:    srli a7, s10, 20
 ; RV32IMZBS-NEXT:    slli t0, a0, 12
 ; RV32IMZBS-NEXT:    slli t1, a4, 19
 ; RV32IMZBS-NEXT:    or a7, t0, a7
 ; RV32IMZBS-NEXT:    srai t0, t1, 31
-; RV32IMZBS-NEXT:    sw t0, 320(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t0, 24(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a7, t0, a7
 ; RV32IMZBS-NEXT:    srli t0, s10, 19
 ; RV32IMZBS-NEXT:    slli t1, a0, 13
 ; RV32IMZBS-NEXT:    slli t2, a4, 18
 ; RV32IMZBS-NEXT:    or t0, t1, t0
 ; RV32IMZBS-NEXT:    srai t1, t2, 31
-; RV32IMZBS-NEXT:    sw t1, 316(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t1, 20(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a6, a6, a7
 ; RV32IMZBS-NEXT:    and a7, t1, t0
 ; RV32IMZBS-NEXT:    xor a6, a6, a7
@@ -12542,14 +12542,14 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    slli t1, a4, 17
 ; RV32IMZBS-NEXT:    or a7, t0, a7
 ; RV32IMZBS-NEXT:    srai t2, t1, 31
-; RV32IMZBS-NEXT:    sw t2, 400(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t2, 104(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srli t0, s10, 17
 ; RV32IMZBS-NEXT:    slli t1, a0, 15
 ; RV32IMZBS-NEXT:    or t0, t1, t0
 ; RV32IMZBS-NEXT:    slli t1, a4, 16
 ; RV32IMZBS-NEXT:    and a7, t2, a7
 ; RV32IMZBS-NEXT:    srai t1, t1, 31
-; RV32IMZBS-NEXT:    sw t1, 396(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t1, 100(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a6, a6, a7
 ; RV32IMZBS-NEXT:    and a7, t1, t0
 ; RV32IMZBS-NEXT:    xor a2, a2, a5
@@ -12564,9 +12564,9 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    or a7, t0, a7
 ; RV32IMZBS-NEXT:    slli t0, a4, 14
 ; RV32IMZBS-NEXT:    srai a6, a6, 31
-; RV32IMZBS-NEXT:    sw a6, 392(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 96(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srai t0, t0, 31
-; RV32IMZBS-NEXT:    sw t0, 388(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t0, 92(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a5, a6, a5
 ; RV32IMZBS-NEXT:    and a6, t0, a7
 ; RV32IMZBS-NEXT:    srli a7, s10, 14
@@ -12578,11 +12578,11 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    or a7, t0, a7
 ; RV32IMZBS-NEXT:    slli t0, a4, 13
 ; RV32IMZBS-NEXT:    srai t1, t0, 31
-; RV32IMZBS-NEXT:    sw t1, 384(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t1, 88(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli t0, a4, 12
 ; RV32IMZBS-NEXT:    and a6, t1, a6
 ; RV32IMZBS-NEXT:    srai t0, t0, 31
-; RV32IMZBS-NEXT:    sw t0, 380(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t0, 84(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a5, a5, a6
 ; RV32IMZBS-NEXT:    and a6, t0, a7
 ; RV32IMZBS-NEXT:    srli a7, s10, 12
@@ -12594,11 +12594,11 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    or a7, t0, a7
 ; RV32IMZBS-NEXT:    slli t0, a4, 11
 ; RV32IMZBS-NEXT:    srai t1, t0, 31
-; RV32IMZBS-NEXT:    sw t1, 376(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t1, 80(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli t0, a4, 10
 ; RV32IMZBS-NEXT:    and a6, t1, a6
 ; RV32IMZBS-NEXT:    srai t0, t0, 31
-; RV32IMZBS-NEXT:    sw t0, 372(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t0, 76(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a5, a5, a6
 ; RV32IMZBS-NEXT:    and a6, t0, a7
 ; RV32IMZBS-NEXT:    srli a7, s10, 10
@@ -12613,15 +12613,15 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    slli t2, a0, 24
 ; RV32IMZBS-NEXT:    or t1, t2, t1
 ; RV32IMZBS-NEXT:    srai t0, t0, 31
-; RV32IMZBS-NEXT:    sw t0, 440(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t0, 144(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a6, t0, a6
 ; RV32IMZBS-NEXT:    slli t0, a4, 8
 ; RV32IMZBS-NEXT:    srai t2, t0, 31
-; RV32IMZBS-NEXT:    sw t2, 436(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t2, 140(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli t0, a4, 7
 ; RV32IMZBS-NEXT:    and a7, t2, a7
 ; RV32IMZBS-NEXT:    srai t0, t0, 31
-; RV32IMZBS-NEXT:    sw t0, 432(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t0, 136(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a6, a6, a7
 ; RV32IMZBS-NEXT:    and a7, t0, t1
 ; RV32IMZBS-NEXT:    srli t0, s10, 7
@@ -12633,11 +12633,11 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    or t0, t1, t0
 ; RV32IMZBS-NEXT:    slli t1, a4, 6
 ; RV32IMZBS-NEXT:    srai t2, t1, 31
-; RV32IMZBS-NEXT:    sw t2, 428(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t2, 132(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli t1, a4, 5
 ; RV32IMZBS-NEXT:    and a7, t2, a7
 ; RV32IMZBS-NEXT:    srai t1, t1, 31
-; RV32IMZBS-NEXT:    sw t1, 424(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t1, 128(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a6, a6, a7
 ; RV32IMZBS-NEXT:    and a7, t1, t0
 ; RV32IMZBS-NEXT:    srli t0, s10, 5
@@ -12649,11 +12649,11 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    or t0, t1, t0
 ; RV32IMZBS-NEXT:    slli t1, a4, 4
 ; RV32IMZBS-NEXT:    srai t2, t1, 31
-; RV32IMZBS-NEXT:    sw t2, 420(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t2, 124(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli t1, a4, 3
 ; RV32IMZBS-NEXT:    and a7, t2, a7
 ; RV32IMZBS-NEXT:    srai t1, t1, 31
-; RV32IMZBS-NEXT:    sw t1, 416(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t1, 120(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a6, a6, a7
 ; RV32IMZBS-NEXT:    and a7, t1, t0
 ; RV32IMZBS-NEXT:    xor a2, a2, a5
@@ -12667,9 +12667,9 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    slli t0, a4, 2
 ; RV32IMZBS-NEXT:    slli t1, a4, 1
 ; RV32IMZBS-NEXT:    srai t0, t0, 31
-; RV32IMZBS-NEXT:    sw t0, 412(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t0, 116(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srai t1, t1, 31
-; RV32IMZBS-NEXT:    sw t1, 408(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t1, 112(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a6, t0, a6
 ; RV32IMZBS-NEXT:    and a7, t1, a7
 ; RV32IMZBS-NEXT:    xor a2, a2, a5
@@ -12679,11 +12679,11 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    or a6, a0, a6
 ; RV32IMZBS-NEXT:    lw a0, 0(a1)
 ; RV32IMZBS-NEXT:    srai a4, a4, 31
-; RV32IMZBS-NEXT:    sw a4, 404(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a4, 108(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a1, s2, 31
 ; RV32IMZBS-NEXT:    and a4, a4, a6
 ; RV32IMZBS-NEXT:    srai a1, a1, 31
-; RV32IMZBS-NEXT:    sw a1, 296(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 4(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a4, a5, a4
 ; RV32IMZBS-NEXT:    and a1, a1, s10
 ; RV32IMZBS-NEXT:    slli a5, s10, 1
@@ -12693,13 +12693,13 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    slli a4, s10, 2
 ; RV32IMZBS-NEXT:    srli a5, a0, 30
 ; RV32IMZBS-NEXT:    or a7, a5, a4
-; RV32IMZBS-NEXT:    sw a7, 152(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 296(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a4, s2, 30
 ; RV32IMZBS-NEXT:    srai a5, a4, 31
-; RV32IMZBS-NEXT:    sw a5, 292(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a5, 436(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a4, s2, 29
 ; RV32IMZBS-NEXT:    srai a6, a4, 31
-; RV32IMZBS-NEXT:    sw a6, 288(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 432(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a4, a5, t1
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
 ; RV32IMZBS-NEXT:    and a4, a6, a7
@@ -12707,17 +12707,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    srli a6, a0, 29
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
 ; RV32IMZBS-NEXT:    or t0, a6, a5
-; RV32IMZBS-NEXT:    sw t0, 168(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t0, 312(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srli a4, a0, 28
 ; RV32IMZBS-NEXT:    slli a5, s10, 4
 ; RV32IMZBS-NEXT:    or a7, a5, a4
-; RV32IMZBS-NEXT:    sw a7, 172(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 316(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a4, s2, 28
 ; RV32IMZBS-NEXT:    srai a5, a4, 31
-; RV32IMZBS-NEXT:    sw a5, 284(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a5, 428(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a4, s2, 27
 ; RV32IMZBS-NEXT:    srai a6, a4, 31
-; RV32IMZBS-NEXT:    sw a6, 280(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 424(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a4, a5, t0
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
 ; RV32IMZBS-NEXT:    and a4, a6, a7
@@ -12728,19 +12728,19 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    slli a4, s10, 6
 ; RV32IMZBS-NEXT:    srli a5, a0, 26
 ; RV32IMZBS-NEXT:    or t2, a5, a4
-; RV32IMZBS-NEXT:    sw t2, 148(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t2, 292(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a4, s2, 26
 ; RV32IMZBS-NEXT:    slli a5, s10, 7
 ; RV32IMZBS-NEXT:    srli a6, a0, 25
 ; RV32IMZBS-NEXT:    or s4, a6, a5
 ; RV32IMZBS-NEXT:    srai a6, a4, 31
-; RV32IMZBS-NEXT:    sw a6, 276(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 420(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a4, s2, 25
 ; RV32IMZBS-NEXT:    slli a5, s2, 24
 ; RV32IMZBS-NEXT:    srai t0, a4, 31
-; RV32IMZBS-NEXT:    sw t0, 268(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t0, 412(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srai a7, a5, 31
-; RV32IMZBS-NEXT:    sw a7, 272(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 416(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a4, a6, s3
 ; RV32IMZBS-NEXT:    and a5, t0, t2
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
@@ -12752,13 +12752,13 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    slli a5, s10, 9
 ; RV32IMZBS-NEXT:    srli a6, a0, 23
 ; RV32IMZBS-NEXT:    or t0, a6, a5
-; RV32IMZBS-NEXT:    sw t0, 164(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t0, 308(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a5, s2, 23
 ; RV32IMZBS-NEXT:    srai a6, a5, 31
-; RV32IMZBS-NEXT:    sw a6, 264(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 408(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a5, s2, 22
 ; RV32IMZBS-NEXT:    srai a7, a5, 31
-; RV32IMZBS-NEXT:    sw a7, 260(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 404(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a5, a6, a3
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    and a5, a7, t0
@@ -12766,17 +12766,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    srli a7, a0, 22
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    or t0, a7, a6
-; RV32IMZBS-NEXT:    sw t0, 144(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t0, 288(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a5, s10, 11
 ; RV32IMZBS-NEXT:    srli a6, a0, 21
 ; RV32IMZBS-NEXT:    or t2, a6, a5
-; RV32IMZBS-NEXT:    sw t2, 132(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t2, 276(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a5, s2, 21
 ; RV32IMZBS-NEXT:    srai a6, a5, 31
-; RV32IMZBS-NEXT:    sw a6, 256(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 400(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a5, s2, 20
 ; RV32IMZBS-NEXT:    srai a7, a5, 31
-; RV32IMZBS-NEXT:    sw a7, 252(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 396(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a5, a6, t0
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    and a5, a7, t2
@@ -12784,17 +12784,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    srli a7, a0, 20
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    or t0, a7, a6
-; RV32IMZBS-NEXT:    sw t0, 120(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t0, 264(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a5, s10, 13
 ; RV32IMZBS-NEXT:    srli a6, a0, 19
 ; RV32IMZBS-NEXT:    or t2, a6, a5
-; RV32IMZBS-NEXT:    sw t2, 112(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t2, 256(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a5, s2, 19
 ; RV32IMZBS-NEXT:    srai a6, a5, 31
-; RV32IMZBS-NEXT:    sw a6, 248(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 392(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a5, s2, 18
 ; RV32IMZBS-NEXT:    srai a7, a5, 31
-; RV32IMZBS-NEXT:    sw a7, 244(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 388(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a5, a6, t0
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    and a5, a7, t2
@@ -12806,32 +12806,32 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    slli a5, s10, 15
 ; RV32IMZBS-NEXT:    srli a6, a0, 17
 ; RV32IMZBS-NEXT:    or a7, a4, a2
-; RV32IMZBS-NEXT:    sw a7, 104(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 248(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a5, a6, a5
-; RV32IMZBS-NEXT:    sw a5, 140(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a5, 284(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a2, s2, 17
 ; RV32IMZBS-NEXT:    slli a4, s2, 16
 ; RV32IMZBS-NEXT:    srai a2, a2, 31
-; RV32IMZBS-NEXT:    sw a2, 240(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a2, 384(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srai a4, a4, 31
-; RV32IMZBS-NEXT:    sw a4, 236(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a4, 380(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a2, a2, a7
 ; RV32IMZBS-NEXT:    and a4, a4, a5
 ; RV32IMZBS-NEXT:    srli a5, a0, 16
 ; RV32IMZBS-NEXT:    slli a6, s10, 16
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    or a7, a6, a5
-; RV32IMZBS-NEXT:    sw a7, 128(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 272(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srli a4, a0, 15
 ; RV32IMZBS-NEXT:    slli a5, s10, 17
 ; RV32IMZBS-NEXT:    or t0, a5, a4
-; RV32IMZBS-NEXT:    sw t0, 116(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t0, 260(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a4, s2, 15
 ; RV32IMZBS-NEXT:    srai a5, a4, 31
-; RV32IMZBS-NEXT:    sw a5, 232(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a5, 376(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a4, s2, 14
 ; RV32IMZBS-NEXT:    srai a6, a4, 31
-; RV32IMZBS-NEXT:    sw a6, 228(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 372(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a4, a5, a7
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    and a4, a6, t0
@@ -12839,17 +12839,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    slli a6, s10, 18
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    or t0, a6, a5
-; RV32IMZBS-NEXT:    sw t0, 108(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t0, 252(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srli a4, a0, 13
 ; RV32IMZBS-NEXT:    slli a5, s10, 19
 ; RV32IMZBS-NEXT:    or a7, a5, a4
-; RV32IMZBS-NEXT:    sw a7, 160(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 304(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a4, s2, 13
 ; RV32IMZBS-NEXT:    srai a5, a4, 31
-; RV32IMZBS-NEXT:    sw a5, 224(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a5, 368(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a4, s2, 12
 ; RV32IMZBS-NEXT:    srai a6, a4, 31
-; RV32IMZBS-NEXT:    sw a6, 220(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 364(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a4, a5, t0
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    and a4, a6, a7
@@ -12857,17 +12857,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    slli a6, s10, 20
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    or t0, a6, a5
-; RV32IMZBS-NEXT:    sw t0, 100(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t0, 244(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srli a4, a0, 11
 ; RV32IMZBS-NEXT:    slli a5, s10, 21
 ; RV32IMZBS-NEXT:    or a7, a5, a4
-; RV32IMZBS-NEXT:    sw a7, 156(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 300(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a4, s2, 11
 ; RV32IMZBS-NEXT:    srai a5, a4, 31
-; RV32IMZBS-NEXT:    sw a5, 216(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a5, 360(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a4, s2, 10
 ; RV32IMZBS-NEXT:    srai a6, a4, 31
-; RV32IMZBS-NEXT:    sw a6, 212(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 356(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a4, a5, t0
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    and a4, a6, a7
@@ -12875,17 +12875,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    slli a6, s10, 22
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    or a7, a6, a5
-; RV32IMZBS-NEXT:    sw a7, 136(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 280(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srli a4, a0, 9
 ; RV32IMZBS-NEXT:    slli a5, s10, 23
 ; RV32IMZBS-NEXT:    or t0, a5, a4
-; RV32IMZBS-NEXT:    sw t0, 124(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t0, 268(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a4, s2, 9
 ; RV32IMZBS-NEXT:    srai a5, a4, 31
-; RV32IMZBS-NEXT:    sw a5, 200(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a5, 344(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a4, s2, 8
 ; RV32IMZBS-NEXT:    srai a6, a4, 31
-; RV32IMZBS-NEXT:    sw a6, 196(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 340(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a4, a5, a7
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    and a4, a6, t0
@@ -12893,7 +12893,7 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    srli a6, a0, 8
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    or t2, a6, a5
-; RV32IMZBS-NEXT:    sw t2, 96(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t2, 240(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srli a4, a0, 7
 ; RV32IMZBS-NEXT:    slli a5, s10, 25
 ; RV32IMZBS-NEXT:    or t3, a5, a4
@@ -12902,13 +12902,13 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    slli a6, s10, 26
 ; RV32IMZBS-NEXT:    or t5, a6, a5
 ; RV32IMZBS-NEXT:    srai a7, a4, 31
-; RV32IMZBS-NEXT:    sw a7, 188(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 332(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a4, s2, 6
 ; RV32IMZBS-NEXT:    slli a5, s2, 5
 ; RV32IMZBS-NEXT:    srai t0, a4, 31
-; RV32IMZBS-NEXT:    sw t0, 184(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t0, 328(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srai a6, a5, 31
-; RV32IMZBS-NEXT:    sw a6, 204(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 348(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a4, a7, t2
 ; RV32IMZBS-NEXT:    and a5, t0, t3
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
@@ -12922,10 +12922,10 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    or t2, a6, a5
 ; RV32IMZBS-NEXT:    slli a5, s2, 4
 ; RV32IMZBS-NEXT:    srai a7, a5, 31
-; RV32IMZBS-NEXT:    sw a7, 176(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 320(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a5, s2, 3
 ; RV32IMZBS-NEXT:    srai a6, a5, 31
-; RV32IMZBS-NEXT:    sw a6, 192(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 336(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a5, a7, t4
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    and a5, a6, t2
@@ -12938,10 +12938,10 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    or s1, a6, a5
 ; RV32IMZBS-NEXT:    slli a5, s2, 2
 ; RV32IMZBS-NEXT:    srai a7, a5, 31
-; RV32IMZBS-NEXT:    sw a7, 180(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 324(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a5, s2, 1
 ; RV32IMZBS-NEXT:    srai a6, a5, 31
-; RV32IMZBS-NEXT:    sw a6, 208(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 352(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a5, a7, t6
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    and a5, a6, s1
@@ -12994,120 +12994,120 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    slli a5, s11, 23
 ; RV32IMZBS-NEXT:    srai a5, a5, 31
 ; RV32IMZBS-NEXT:    slli a6, a0, 8
-; RV32IMZBS-NEXT:    sw a6, 92(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 236(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    and a4, a5, a6
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    slli a4, s11, 22
 ; RV32IMZBS-NEXT:    srai a4, a4, 31
 ; RV32IMZBS-NEXT:    slli a5, a0, 9
-; RV32IMZBS-NEXT:    sw a5, 88(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a5, 232(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a4, a4, a5
 ; RV32IMZBS-NEXT:    slli a5, s11, 21
 ; RV32IMZBS-NEXT:    srai a5, a5, 31
 ; RV32IMZBS-NEXT:    slli a6, a0, 10
-; RV32IMZBS-NEXT:    sw a6, 84(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 228(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    and a4, a5, a6
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    slli a4, s11, 20
 ; RV32IMZBS-NEXT:    srai a4, a4, 31
 ; RV32IMZBS-NEXT:    slli a5, a0, 11
-; RV32IMZBS-NEXT:    sw a5, 80(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a5, 224(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a4, a4, a5
 ; RV32IMZBS-NEXT:    slli a5, s11, 19
 ; RV32IMZBS-NEXT:    srai a5, a5, 31
 ; RV32IMZBS-NEXT:    slli a6, a0, 12
-; RV32IMZBS-NEXT:    sw a6, 76(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 220(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    and a4, a5, a6
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    slli a4, s11, 18
 ; RV32IMZBS-NEXT:    srai a4, a4, 31
 ; RV32IMZBS-NEXT:    slli a5, a0, 13
-; RV32IMZBS-NEXT:    sw a5, 72(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a5, 216(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a4, a4, a5
 ; RV32IMZBS-NEXT:    slli a5, s11, 17
 ; RV32IMZBS-NEXT:    srai a5, a5, 31
 ; RV32IMZBS-NEXT:    slli a6, a0, 14
-; RV32IMZBS-NEXT:    sw a6, 64(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 208(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    and a4, a5, a6
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    slli a4, s11, 16
 ; RV32IMZBS-NEXT:    srai a4, a4, 31
 ; RV32IMZBS-NEXT:    slli a5, a0, 15
-; RV32IMZBS-NEXT:    sw a5, 60(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a5, 204(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a4, a4, a5
 ; RV32IMZBS-NEXT:    slli a5, s11, 15
 ; RV32IMZBS-NEXT:    srai a5, a5, 31
 ; RV32IMZBS-NEXT:    slli a6, a0, 16
-; RV32IMZBS-NEXT:    sw a6, 304(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 8(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a5, a5, a6
 ; RV32IMZBS-NEXT:    slli a6, s11, 14
 ; RV32IMZBS-NEXT:    srai a6, a6, 31
 ; RV32IMZBS-NEXT:    slli s0, a0, 17
-; RV32IMZBS-NEXT:    sw s0, 56(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s0, 200(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    and a5, a6, s0
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    slli a5, s11, 13
 ; RV32IMZBS-NEXT:    srai a5, a5, 31
 ; RV32IMZBS-NEXT:    slli a6, a0, 18
-; RV32IMZBS-NEXT:    sw a6, 48(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 192(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a5, a5, a6
 ; RV32IMZBS-NEXT:    slli a6, s11, 12
 ; RV32IMZBS-NEXT:    srai a6, a6, 31
 ; RV32IMZBS-NEXT:    slli s0, a0, 19
-; RV32IMZBS-NEXT:    sw s0, 40(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s0, 184(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    and a5, a6, s0
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    slli a5, s11, 11
 ; RV32IMZBS-NEXT:    srai a5, a5, 31
 ; RV32IMZBS-NEXT:    slli a6, a0, 20
-; RV32IMZBS-NEXT:    sw a6, 32(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 176(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a5, a5, a6
 ; RV32IMZBS-NEXT:    slli a6, s11, 10
 ; RV32IMZBS-NEXT:    srai a6, a6, 31
 ; RV32IMZBS-NEXT:    slli s0, a0, 21
-; RV32IMZBS-NEXT:    sw s0, 16(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s0, 160(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    and a5, a6, s0
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    slli a5, s11, 9
 ; RV32IMZBS-NEXT:    srai a5, a5, 31
 ; RV32IMZBS-NEXT:    slli a6, a0, 22
-; RV32IMZBS-NEXT:    sw a6, 308(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 12(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a5, a5, a6
 ; RV32IMZBS-NEXT:    slli a6, s11, 8
 ; RV32IMZBS-NEXT:    srai a6, a6, 31
 ; RV32IMZBS-NEXT:    slli s0, a0, 23
-; RV32IMZBS-NEXT:    sw s0, 312(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s0, 16(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    and a5, a6, s0
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    slli a5, s11, 7
 ; RV32IMZBS-NEXT:    srai a5, a5, 31
 ; RV32IMZBS-NEXT:    slli a6, a0, 24
-; RV32IMZBS-NEXT:    sw a6, 36(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 180(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a5, a5, a6
 ; RV32IMZBS-NEXT:    slli a6, s11, 6
 ; RV32IMZBS-NEXT:    srai a6, a6, 31
 ; RV32IMZBS-NEXT:    slli s0, a0, 25
-; RV32IMZBS-NEXT:    sw s0, 24(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s0, 168(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    and a5, a6, s0
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    slli a5, s11, 5
 ; RV32IMZBS-NEXT:    srai a5, a5, 31
 ; RV32IMZBS-NEXT:    slli a6, a0, 26
-; RV32IMZBS-NEXT:    sw a6, 20(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 164(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a5, a5, a6
 ; RV32IMZBS-NEXT:    slli a6, s11, 4
 ; RV32IMZBS-NEXT:    srai s0, a6, 31
 ; RV32IMZBS-NEXT:    slli a6, a0, 27
-; RV32IMZBS-NEXT:    sw a6, 28(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 172(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    and a5, s0, a6
 ; RV32IMZBS-NEXT:    xor s0, a1, a2
@@ -13117,371 +13117,371 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZBS-NEXT:    srai a1, a1, 31
 ; RV32IMZBS-NEXT:    srai a2, a2, 31
 ; RV32IMZBS-NEXT:    slli a6, a0, 28
-; RV32IMZBS-NEXT:    sw a6, 12(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 156(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a5, a0, 29
-; RV32IMZBS-NEXT:    sw a5, 44(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a5, 188(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a1, a1, a6
 ; RV32IMZBS-NEXT:    and a2, a2, a5
 ; RV32IMZBS-NEXT:    xor a1, a1, a2
 ; RV32IMZBS-NEXT:    slli a2, s11, 1
 ; RV32IMZBS-NEXT:    srai a5, a2, 31
 ; RV32IMZBS-NEXT:    slli a2, a0, 30
-; RV32IMZBS-NEXT:    sw a2, 52(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a2, 196(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a2, a5, a2
 ; RV32IMZBS-NEXT:    slli a5, a0, 31
-; RV32IMZBS-NEXT:    sw a5, 68(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a5, 212(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a1, a1, a2
 ; RV32IMZBS-NEXT:    and a2, s11, a5
 ; RV32IMZBS-NEXT:    xor a4, s0, a4
-; RV32IMZBS-NEXT:    sw a4, 8(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a4, 152(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a1, a1, a2
-; RV32IMZBS-NEXT:    sw a1, 4(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    lw a1, 368(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    sw a1, 148(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    lw a1, 72(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, t1
-; RV32IMZBS-NEXT:    lw a2, 364(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a2, 68(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a2, a2, s10
-; RV32IMZBS-NEXT:    lw a4, 152(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a5, 360(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 296(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 64(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a5, a4
-; RV32IMZBS-NEXT:    lw t1, 168(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a5, 356(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t1, 312(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 60(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, a5, t1
 ; RV32IMZBS-NEXT:    xor a1, a2, a1
 ; RV32IMZBS-NEXT:    xor a2, a4, s10
-; RV32IMZBS-NEXT:    lw a4, 172(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a5, 352(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 316(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 56(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a5, a4
-; RV32IMZBS-NEXT:    lw a5, 348(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 52(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, a5, s3
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw a5, 148(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a6, 344(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 292(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a6, 48(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, a6, a5
 ; RV32IMZBS-NEXT:    xor a1, a1, a2
 ; RV32IMZBS-NEXT:    xor a2, a4, s10
-; RV32IMZBS-NEXT:    lw a4, 340(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 44(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, s4
-; RV32IMZBS-NEXT:    lw a5, 336(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 40(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, a5, a3
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s0, 164(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a5, 332(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s0, 308(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 36(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, a5, s0
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw a5, 144(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a6, 328(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 288(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a6, 32(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, a6, a5
 ; RV32IMZBS-NEXT:    xor a1, a1, a2
 ; RV32IMZBS-NEXT:    xor a2, a4, s10
-; RV32IMZBS-NEXT:    lw a4, 132(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a5, 324(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 276(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 28(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a5, a4
-; RV32IMZBS-NEXT:    lw a5, 120(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a6, 320(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 264(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a6, 24(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, a6, a5
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw a5, 112(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a6, 316(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 256(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a6, 20(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, a6, a5
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw a5, 104(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a6, 400(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 248(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a6, 104(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, a6, a5
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw a5, 140(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a6, 396(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    and s10, a6, a5
-; RV32IMZBS-NEXT:    xor a1, a1, a2
-; RV32IMZBS-NEXT:    xor a2, a4, s10
-; RV32IMZBS-NEXT:    lw a4, 392(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a5, 128(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    and a4, a4, a5
-; RV32IMZBS-NEXT:    lw a5, 388(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a6, 116(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    and s10, a5, a6
-; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw a5, 384(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a6, 108(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    and s10, a5, a6
-; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 160(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a5, 380(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    and s10, a5, s10
-; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw a5, 376(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 284(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    lw a6, 100(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    and s10, a6, a5
+; RV32IMZBS-NEXT:    xor a1, a1, a2
+; RV32IMZBS-NEXT:    xor a2, a4, s10
+; RV32IMZBS-NEXT:    lw a4, 96(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 272(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    and a4, a4, a5
+; RV32IMZBS-NEXT:    lw a5, 92(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a6, 260(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, a5, a6
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 156(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a5, 372(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 88(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a6, 252(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    and s10, a5, a6
+; RV32IMZBS-NEXT:    xor a4, a4, s10
+; RV32IMZBS-NEXT:    lw s10, 304(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 84(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    and s10, a5, s10
+; RV32IMZBS-NEXT:    xor a4, a4, s10
+; RV32IMZBS-NEXT:    lw a5, 80(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a6, 244(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    and s10, a5, a6
+; RV32IMZBS-NEXT:    xor a4, a4, s10
+; RV32IMZBS-NEXT:    lw s10, 300(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 76(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, a5, s10
 ; RV32IMZBS-NEXT:    xor a1, a1, a2
 ; RV32IMZBS-NEXT:    xor a2, a4, s10
-; RV32IMZBS-NEXT:    lw a4, 440(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a5, 136(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 144(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 280(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, a5
-; RV32IMZBS-NEXT:    lw s10, 436(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a5, 124(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 140(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 268(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, a5
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 432(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a5, 96(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 136(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 240(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, a5
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 428(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 132(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, t3
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 424(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 128(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, t5
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 420(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 124(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, t4
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 416(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 120(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, t2
 ; RV32IMZBS-NEXT:    xor a1, a1, a2
 ; RV32IMZBS-NEXT:    xor a2, a4, s10
-; RV32IMZBS-NEXT:    lw a4, 412(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 116(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, t6
-; RV32IMZBS-NEXT:    lw s10, 408(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 112(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, s1
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 404(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 108(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, t0
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 296(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 4(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, a0
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 292(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 436(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mv a5, s5
 ; RV32IMZBS-NEXT:    and s10, s10, s5
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 288(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 432(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mv t0, s6
 ; RV32IMZBS-NEXT:    and s10, s10, s6
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 284(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 428(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, a7
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 280(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 424(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mv t2, s7
 ; RV32IMZBS-NEXT:    and s10, s10, s7
 ; RV32IMZBS-NEXT:    xor a1, a1, a2
 ; RV32IMZBS-NEXT:    xor a2, a4, s10
-; RV32IMZBS-NEXT:    lw a4, 276(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 420(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mv a6, s8
 ; RV32IMZBS-NEXT:    and a4, a4, s8
-; RV32IMZBS-NEXT:    lw s10, 268(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 412(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mv t1, s9
 ; RV32IMZBS-NEXT:    and s10, s10, s9
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 272(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 416(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mv s0, ra
 ; RV32IMZBS-NEXT:    and s10, s10, ra
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 264(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw t3, 92(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 408(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t3, 236(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, t3
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 260(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw t4, 88(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 404(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t4, 232(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, t4
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 256(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw t5, 84(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 400(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t5, 228(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, t5
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 252(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s11, 80(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 396(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s11, 224(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, s11
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 248(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s4, 76(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 392(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s4, 220(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, s4
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 244(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s3, 72(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 388(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s3, 216(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, s3
 ; RV32IMZBS-NEXT:    xor a1, a1, a2
 ; RV32IMZBS-NEXT:    xor a2, a4, s10
-; RV32IMZBS-NEXT:    lw a4, 240(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw t6, 64(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 384(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t6, 208(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, t6
-; RV32IMZBS-NEXT:    lw s10, 236(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s1, 60(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 380(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s1, 204(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, s1
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 232(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a3, 304(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 376(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, a3
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 228(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s5, 56(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 372(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s5, 200(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, s5
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 224(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s6, 48(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 368(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s6, 192(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, s6
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 220(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s7, 40(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 364(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s7, 184(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, s7
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 216(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s8, 32(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 360(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s8, 176(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, s8
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 212(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s9, 16(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 356(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s9, 160(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, s9
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 200(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw ra, 308(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 344(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, ra
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
-; RV32IMZBS-NEXT:    lw s10, 196(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw ra, 312(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 340(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw ra, 16(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, s10, ra
 ; RV32IMZBS-NEXT:    xor a1, a1, a2
 ; RV32IMZBS-NEXT:    xor a2, a4, s10
-; RV32IMZBS-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a4, 4(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 152(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 148(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    xor a3, a3, a4
-; RV32IMZBS-NEXT:    sw a3, 296(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a3, 4(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor s10, a1, a2
-; RV32IMZBS-NEXT:    lw a1, 368(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a1, 72(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, a5
-; RV32IMZBS-NEXT:    lw a2, 364(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a2, 68(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a0, a2, a0
-; RV32IMZBS-NEXT:    lw a2, 188(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw ra, 36(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a2, 332(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw ra, 180(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a2, a2, ra
-; RV32IMZBS-NEXT:    lw a4, 184(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 328(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 168(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, a3
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    xor a0, a0, a1
-; RV32IMZBS-NEXT:    lw a1, 360(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a1, 64(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, t0
-; RV32IMZBS-NEXT:    lw a4, 356(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 60(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, a7
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
-; RV32IMZBS-NEXT:    lw a4, 204(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a7, 20(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 348(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a7, 164(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, a7
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    xor a0, a0, a1
-; RV32IMZBS-NEXT:    lw a1, 352(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a1, 56(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, t2
-; RV32IMZBS-NEXT:    lw a4, 348(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 52(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, a6
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
-; RV32IMZBS-NEXT:    lw a4, 344(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 48(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, t1
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
-; RV32IMZBS-NEXT:    lw a4, 176(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a6, 28(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 320(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a6, 172(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, a6
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    xor a0, a0, a1
-; RV32IMZBS-NEXT:    lw a1, 340(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a1, 44(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, s0
-; RV32IMZBS-NEXT:    lw a4, 336(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 40(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, t3
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
-; RV32IMZBS-NEXT:    lw a4, 332(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 36(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, t4
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
-; RV32IMZBS-NEXT:    lw a4, 328(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 32(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, t5
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
-; RV32IMZBS-NEXT:    lw a4, 192(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw t1, 12(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 336(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t1, 156(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, t1
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    xor a0, a0, a1
-; RV32IMZBS-NEXT:    lw a1, 324(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, s11
-; RV32IMZBS-NEXT:    lw a4, 320(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 24(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, s4
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
-; RV32IMZBS-NEXT:    lw a4, 316(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 20(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, s3
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
-; RV32IMZBS-NEXT:    lw a4, 400(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 104(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, t6
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
-; RV32IMZBS-NEXT:    lw a4, 396(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 100(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, s1
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
-; RV32IMZBS-NEXT:    lw a4, 180(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw t0, 44(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 324(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t0, 188(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, t0
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    xor a0, a0, a1
-; RV32IMZBS-NEXT:    lw a1, 392(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a4, 304(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a1, 96(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 8(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, a4
-; RV32IMZBS-NEXT:    lw a4, 388(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 92(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, s5
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
-; RV32IMZBS-NEXT:    lw a4, 384(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 88(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, s6
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
-; RV32IMZBS-NEXT:    lw a4, 380(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 84(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, s7
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
-; RV32IMZBS-NEXT:    lw a4, 376(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 80(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, s8
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
-; RV32IMZBS-NEXT:    lw a4, 372(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 76(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, s9
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
-; RV32IMZBS-NEXT:    lw a4, 208(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw t2, 52(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 352(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t2, 196(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, t2
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    xor a0, a0, a1
-; RV32IMZBS-NEXT:    lw a1, 440(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a4, 308(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a1, 144(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 12(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, a4
-; RV32IMZBS-NEXT:    lw a4, 436(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a5, 312(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 140(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 16(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, a5
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
-; RV32IMZBS-NEXT:    lw a4, 432(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 136(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, ra
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
-; RV32IMZBS-NEXT:    lw a4, 428(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 132(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, a3
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
-; RV32IMZBS-NEXT:    lw a4, 424(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 128(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, a7
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
-; RV32IMZBS-NEXT:    lw a4, 420(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 124(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, a6
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
-; RV32IMZBS-NEXT:    lw a4, 416(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 120(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, t1
-; RV32IMZBS-NEXT:    lw a5, 412(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 116(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a7, a5, t0
-; RV32IMZBS-NEXT:    lw a5, 408(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 112(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a6, a5, t2
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
 ; RV32IMZBS-NEXT:    xor a4, a7, a6
-; RV32IMZBS-NEXT:    lw a6, 68(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a6, 212(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a3, s2, a6
-; RV32IMZBS-NEXT:    lw a5, 404(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 108(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a5, a5, a6
 ; RV32IMZBS-NEXT:    xor a0, a0, a1
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    xor a2, a2, a3
 ; RV32IMZBS-NEXT:    xor a0, a0, a4
 ; RV32IMZBS-NEXT:    xor a1, s10, a2
-; RV32IMZBS-NEXT:    lw a2, 300(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a2, 440(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    sw a0, 0(a2)
 ; RV32IMZBS-NEXT:    sw a1, 4(a2)
-; RV32IMZBS-NEXT:    lw a0, 296(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    sw a0, 8(a2)
 ; RV32IMZBS-NEXT:    lw ra, 492(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    lw s0, 488(sp) # 4-byte Folded Reload
@@ -14698,7 +14698,7 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    .cfi_offset s9, -44
 ; RV32IMZVBC-NEXT:    .cfi_offset s10, -48
 ; RV32IMZVBC-NEXT:    .cfi_offset s11, -52
-; RV32IMZVBC-NEXT:    sw a0, 300(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a0, 440(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    lw s10, 4(a1)
 ; RV32IMZVBC-NEXT:    lw a0, 8(a1)
 ; RV32IMZVBC-NEXT:    lw a4, 0(a2)
@@ -14710,9 +14710,9 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    slli a7, a4, 31
 ; RV32IMZVBC-NEXT:    or a2, a5, a2
 ; RV32IMZVBC-NEXT:    srai a5, a6, 31
-; RV32IMZVBC-NEXT:    sw a5, 368(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a5, 72(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    srai a6, a7, 31
-; RV32IMZVBC-NEXT:    sw a6, 364(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 68(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a2, a5, a2
 ; RV32IMZVBC-NEXT:    and a5, a6, a0
 ; RV32IMZVBC-NEXT:    xor a2, a5, a2
@@ -14721,13 +14721,13 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    or a5, a6, a5
 ; RV32IMZVBC-NEXT:    slli a6, a4, 29
 ; RV32IMZVBC-NEXT:    srai t1, a6, 31
-; RV32IMZVBC-NEXT:    sw t1, 360(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t1, 64(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    srli a6, s10, 29
 ; RV32IMZVBC-NEXT:    slli a7, a0, 3
 ; RV32IMZVBC-NEXT:    slli t0, a4, 28
 ; RV32IMZVBC-NEXT:    or a6, a7, a6
 ; RV32IMZVBC-NEXT:    srai a7, t0, 31
-; RV32IMZVBC-NEXT:    sw a7, 356(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 60(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a5, t1, a5
 ; RV32IMZVBC-NEXT:    and a6, a7, a6
 ; RV32IMZVBC-NEXT:    xor a5, a5, a6
@@ -14736,21 +14736,21 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    slli t0, a4, 27
 ; RV32IMZVBC-NEXT:    or a6, a7, a6
 ; RV32IMZVBC-NEXT:    srai a7, t0, 31
-; RV32IMZVBC-NEXT:    sw a7, 352(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 56(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a6, a7, a6
 ; RV32IMZVBC-NEXT:    srli a7, s10, 27
 ; RV32IMZVBC-NEXT:    slli t0, a0, 5
 ; RV32IMZVBC-NEXT:    slli t1, a4, 26
 ; RV32IMZVBC-NEXT:    or a7, t0, a7
 ; RV32IMZVBC-NEXT:    srai t0, t1, 31
-; RV32IMZVBC-NEXT:    sw t0, 348(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t0, 52(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a7, t0, a7
 ; RV32IMZVBC-NEXT:    srli t0, s10, 26
 ; RV32IMZVBC-NEXT:    slli t1, a0, 6
 ; RV32IMZVBC-NEXT:    slli t2, a4, 25
 ; RV32IMZVBC-NEXT:    or t0, t1, t0
 ; RV32IMZVBC-NEXT:    srai t1, t2, 31
-; RV32IMZVBC-NEXT:    sw t1, 344(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t1, 48(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a6, a6, a7
 ; RV32IMZVBC-NEXT:    and a7, t1, t0
 ; RV32IMZVBC-NEXT:    xor a2, a2, a5
@@ -14761,13 +14761,13 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    or a5, a6, a5
 ; RV32IMZVBC-NEXT:    slli a6, a4, 24
 ; RV32IMZVBC-NEXT:    srai t1, a6, 31
-; RV32IMZVBC-NEXT:    sw t1, 340(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t1, 44(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    srli a6, s10, 24
 ; RV32IMZVBC-NEXT:    slli a7, a0, 8
 ; RV32IMZVBC-NEXT:    slli t0, a4, 23
 ; RV32IMZVBC-NEXT:    or a6, a7, a6
 ; RV32IMZVBC-NEXT:    srai a7, t0, 31
-; RV32IMZVBC-NEXT:    sw a7, 336(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 40(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a5, t1, a5
 ; RV32IMZVBC-NEXT:    and a6, a7, a6
 ; RV32IMZVBC-NEXT:    xor a5, a5, a6
@@ -14776,14 +14776,14 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    slli t0, a4, 22
 ; RV32IMZVBC-NEXT:    or a6, a7, a6
 ; RV32IMZVBC-NEXT:    srai a7, t0, 31
-; RV32IMZVBC-NEXT:    sw a7, 332(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 36(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a6, a7, a6
 ; RV32IMZVBC-NEXT:    srli a7, s10, 22
 ; RV32IMZVBC-NEXT:    slli t0, a0, 10
 ; RV32IMZVBC-NEXT:    slli t1, a4, 21
 ; RV32IMZVBC-NEXT:    or a7, t0, a7
 ; RV32IMZVBC-NEXT:    srai t0, t1, 31
-; RV32IMZVBC-NEXT:    sw t0, 328(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t0, 32(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a5, a5, a6
 ; RV32IMZVBC-NEXT:    and a6, t0, a7
 ; RV32IMZVBC-NEXT:    xor a5, a5, a6
@@ -14792,21 +14792,21 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    slli t0, a4, 20
 ; RV32IMZVBC-NEXT:    or a6, a7, a6
 ; RV32IMZVBC-NEXT:    srai a7, t0, 31
-; RV32IMZVBC-NEXT:    sw a7, 324(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 28(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a6, a7, a6
 ; RV32IMZVBC-NEXT:    srli a7, s10, 20
 ; RV32IMZVBC-NEXT:    slli t0, a0, 12
 ; RV32IMZVBC-NEXT:    slli t1, a4, 19
 ; RV32IMZVBC-NEXT:    or a7, t0, a7
 ; RV32IMZVBC-NEXT:    srai t0, t1, 31
-; RV32IMZVBC-NEXT:    sw t0, 320(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t0, 24(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a7, t0, a7
 ; RV32IMZVBC-NEXT:    srli t0, s10, 19
 ; RV32IMZVBC-NEXT:    slli t1, a0, 13
 ; RV32IMZVBC-NEXT:    slli t2, a4, 18
 ; RV32IMZVBC-NEXT:    or t0, t1, t0
 ; RV32IMZVBC-NEXT:    srai t1, t2, 31
-; RV32IMZVBC-NEXT:    sw t1, 316(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t1, 20(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a6, a6, a7
 ; RV32IMZVBC-NEXT:    and a7, t1, t0
 ; RV32IMZVBC-NEXT:    xor a6, a6, a7
@@ -14815,14 +14815,14 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    slli t1, a4, 17
 ; RV32IMZVBC-NEXT:    or a7, t0, a7
 ; RV32IMZVBC-NEXT:    srai t2, t1, 31
-; RV32IMZVBC-NEXT:    sw t2, 400(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t2, 104(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    srli t0, s10, 17
 ; RV32IMZVBC-NEXT:    slli t1, a0, 15
 ; RV32IMZVBC-NEXT:    or t0, t1, t0
 ; RV32IMZVBC-NEXT:    slli t1, a4, 16
 ; RV32IMZVBC-NEXT:    and a7, t2, a7
 ; RV32IMZVBC-NEXT:    srai t1, t1, 31
-; RV32IMZVBC-NEXT:    sw t1, 396(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t1, 100(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a6, a6, a7
 ; RV32IMZVBC-NEXT:    and a7, t1, t0
 ; RV32IMZVBC-NEXT:    xor a2, a2, a5
@@ -14837,9 +14837,9 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    or a7, t0, a7
 ; RV32IMZVBC-NEXT:    slli t0, a4, 14
 ; RV32IMZVBC-NEXT:    srai a6, a6, 31
-; RV32IMZVBC-NEXT:    sw a6, 392(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 96(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    srai t0, t0, 31
-; RV32IMZVBC-NEXT:    sw t0, 388(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t0, 92(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a5, a6, a5
 ; RV32IMZVBC-NEXT:    and a6, t0, a7
 ; RV32IMZVBC-NEXT:    srli a7, s10, 14
@@ -14851,11 +14851,11 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    or a7, t0, a7
 ; RV32IMZVBC-NEXT:    slli t0, a4, 13
 ; RV32IMZVBC-NEXT:    srai t1, t0, 31
-; RV32IMZVBC-NEXT:    sw t1, 384(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t1, 88(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli t0, a4, 12
 ; RV32IMZVBC-NEXT:    and a6, t1, a6
 ; RV32IMZVBC-NEXT:    srai t0, t0, 31
-; RV32IMZVBC-NEXT:    sw t0, 380(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t0, 84(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a5, a5, a6
 ; RV32IMZVBC-NEXT:    and a6, t0, a7
 ; RV32IMZVBC-NEXT:    srli a7, s10, 12
@@ -14867,11 +14867,11 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    or a7, t0, a7
 ; RV32IMZVBC-NEXT:    slli t0, a4, 11
 ; RV32IMZVBC-NEXT:    srai t1, t0, 31
-; RV32IMZVBC-NEXT:    sw t1, 376(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t1, 80(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli t0, a4, 10
 ; RV32IMZVBC-NEXT:    and a6, t1, a6
 ; RV32IMZVBC-NEXT:    srai t0, t0, 31
-; RV32IMZVBC-NEXT:    sw t0, 372(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t0, 76(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a5, a5, a6
 ; RV32IMZVBC-NEXT:    and a6, t0, a7
 ; RV32IMZVBC-NEXT:    srli a7, s10, 10
@@ -14886,15 +14886,15 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    slli t2, a0, 24
 ; RV32IMZVBC-NEXT:    or t1, t2, t1
 ; RV32IMZVBC-NEXT:    srai t0, t0, 31
-; RV32IMZVBC-NEXT:    sw t0, 440(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t0, 144(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a6, t0, a6
 ; RV32IMZVBC-NEXT:    slli t0, a4, 8
 ; RV32IMZVBC-NEXT:    srai t2, t0, 31
-; RV32IMZVBC-NEXT:    sw t2, 436(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t2, 140(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli t0, a4, 7
 ; RV32IMZVBC-NEXT:    and a7, t2, a7
 ; RV32IMZVBC-NEXT:    srai t0, t0, 31
-; RV32IMZVBC-NEXT:    sw t0, 432(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t0, 136(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a6, a6, a7
 ; RV32IMZVBC-NEXT:    and a7, t0, t1
 ; RV32IMZVBC-NEXT:    srli t0, s10, 7
@@ -14906,11 +14906,11 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    or t0, t1, t0
 ; RV32IMZVBC-NEXT:    slli t1, a4, 6
 ; RV32IMZVBC-NEXT:    srai t2, t1, 31
-; RV32IMZVBC-NEXT:    sw t2, 428(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t2, 132(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli t1, a4, 5
 ; RV32IMZVBC-NEXT:    and a7, t2, a7
 ; RV32IMZVBC-NEXT:    srai t1, t1, 31
-; RV32IMZVBC-NEXT:    sw t1, 424(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t1, 128(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a6, a6, a7
 ; RV32IMZVBC-NEXT:    and a7, t1, t0
 ; RV32IMZVBC-NEXT:    srli t0, s10, 5
@@ -14922,11 +14922,11 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    or t0, t1, t0
 ; RV32IMZVBC-NEXT:    slli t1, a4, 4
 ; RV32IMZVBC-NEXT:    srai t2, t1, 31
-; RV32IMZVBC-NEXT:    sw t2, 420(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t2, 124(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli t1, a4, 3
 ; RV32IMZVBC-NEXT:    and a7, t2, a7
 ; RV32IMZVBC-NEXT:    srai t1, t1, 31
-; RV32IMZVBC-NEXT:    sw t1, 416(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t1, 120(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a6, a6, a7
 ; RV32IMZVBC-NEXT:    and a7, t1, t0
 ; RV32IMZVBC-NEXT:    xor a2, a2, a5
@@ -14940,9 +14940,9 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    slli t0, a4, 2
 ; RV32IMZVBC-NEXT:    slli t1, a4, 1
 ; RV32IMZVBC-NEXT:    srai t0, t0, 31
-; RV32IMZVBC-NEXT:    sw t0, 412(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t0, 116(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    srai t1, t1, 31
-; RV32IMZVBC-NEXT:    sw t1, 408(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t1, 112(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a6, t0, a6
 ; RV32IMZVBC-NEXT:    and a7, t1, a7
 ; RV32IMZVBC-NEXT:    xor a2, a2, a5
@@ -14952,11 +14952,11 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    or a6, a0, a6
 ; RV32IMZVBC-NEXT:    lw a0, 0(a1)
 ; RV32IMZVBC-NEXT:    srai a4, a4, 31
-; RV32IMZVBC-NEXT:    sw a4, 404(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a4, 108(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a1, s2, 31
 ; RV32IMZVBC-NEXT:    and a4, a4, a6
 ; RV32IMZVBC-NEXT:    srai a1, a1, 31
-; RV32IMZVBC-NEXT:    sw a1, 296(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a1, 4(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a4, a5, a4
 ; RV32IMZVBC-NEXT:    and a1, a1, s10
 ; RV32IMZVBC-NEXT:    slli a5, s10, 1
@@ -14966,13 +14966,13 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    slli a4, s10, 2
 ; RV32IMZVBC-NEXT:    srli a5, a0, 30
 ; RV32IMZVBC-NEXT:    or a7, a5, a4
-; RV32IMZVBC-NEXT:    sw a7, 152(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 296(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a4, s2, 30
 ; RV32IMZVBC-NEXT:    srai a5, a4, 31
-; RV32IMZVBC-NEXT:    sw a5, 292(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a5, 436(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a4, s2, 29
 ; RV32IMZVBC-NEXT:    srai a6, a4, 31
-; RV32IMZVBC-NEXT:    sw a6, 288(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 432(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a4, a5, t1
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
 ; RV32IMZVBC-NEXT:    and a4, a6, a7
@@ -14980,17 +14980,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    srli a6, a0, 29
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
 ; RV32IMZVBC-NEXT:    or t0, a6, a5
-; RV32IMZVBC-NEXT:    sw t0, 168(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t0, 312(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    srli a4, a0, 28
 ; RV32IMZVBC-NEXT:    slli a5, s10, 4
 ; RV32IMZVBC-NEXT:    or a7, a5, a4
-; RV32IMZVBC-NEXT:    sw a7, 172(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 316(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a4, s2, 28
 ; RV32IMZVBC-NEXT:    srai a5, a4, 31
-; RV32IMZVBC-NEXT:    sw a5, 284(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a5, 428(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a4, s2, 27
 ; RV32IMZVBC-NEXT:    srai a6, a4, 31
-; RV32IMZVBC-NEXT:    sw a6, 280(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 424(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a4, a5, t0
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
 ; RV32IMZVBC-NEXT:    and a4, a6, a7
@@ -15001,19 +15001,19 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    slli a4, s10, 6
 ; RV32IMZVBC-NEXT:    srli a5, a0, 26
 ; RV32IMZVBC-NEXT:    or t2, a5, a4
-; RV32IMZVBC-NEXT:    sw t2, 148(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t2, 292(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a4, s2, 26
 ; RV32IMZVBC-NEXT:    slli a5, s10, 7
 ; RV32IMZVBC-NEXT:    srli a6, a0, 25
 ; RV32IMZVBC-NEXT:    or s4, a6, a5
 ; RV32IMZVBC-NEXT:    srai a6, a4, 31
-; RV32IMZVBC-NEXT:    sw a6, 276(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 420(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a4, s2, 25
 ; RV32IMZVBC-NEXT:    slli a5, s2, 24
 ; RV32IMZVBC-NEXT:    srai t0, a4, 31
-; RV32IMZVBC-NEXT:    sw t0, 268(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t0, 412(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    srai a7, a5, 31
-; RV32IMZVBC-NEXT:    sw a7, 272(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 416(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a4, a6, s3
 ; RV32IMZVBC-NEXT:    and a5, t0, t2
 ; RV32IMZVBC-NEXT:    xor a4, a4, a5
@@ -15025,13 +15025,13 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    slli a5, s10, 9
 ; RV32IMZVBC-NEXT:    srli a6, a0, 23
 ; RV32IMZVBC-NEXT:    or t0, a6, a5
-; RV32IMZVBC-NEXT:    sw t0, 164(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t0, 308(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a5, s2, 23
 ; RV32IMZVBC-NEXT:    srai a6, a5, 31
-; RV32IMZVBC-NEXT:    sw a6, 264(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 408(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a5, s2, 22
 ; RV32IMZVBC-NEXT:    srai a7, a5, 31
-; RV32IMZVBC-NEXT:    sw a7, 260(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 404(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a5, a6, a3
 ; RV32IMZVBC-NEXT:    xor a4, a4, a5
 ; RV32IMZVBC-NEXT:    and a5, a7, t0
@@ -15039,17 +15039,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    srli a7, a0, 22
 ; RV32IMZVBC-NEXT:    xor a4, a4, a5
 ; RV32IMZVBC-NEXT:    or t0, a7, a6
-; RV32IMZVBC-NEXT:    sw t0, 144(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t0, 288(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a5, s10, 11
 ; RV32IMZVBC-NEXT:    srli a6, a0, 21
 ; RV32IMZVBC-NEXT:    or t2, a6, a5
-; RV32IMZVBC-NEXT:    sw t2, 132(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t2, 276(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a5, s2, 21
 ; RV32IMZVBC-NEXT:    srai a6, a5, 31
-; RV32IMZVBC-NEXT:    sw a6, 256(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 400(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a5, s2, 20
 ; RV32IMZVBC-NEXT:    srai a7, a5, 31
-; RV32IMZVBC-NEXT:    sw a7, 252(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 396(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a5, a6, t0
 ; RV32IMZVBC-NEXT:    xor a4, a4, a5
 ; RV32IMZVBC-NEXT:    and a5, a7, t2
@@ -15057,17 +15057,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    srli a7, a0, 20
 ; RV32IMZVBC-NEXT:    xor a4, a4, a5
 ; RV32IMZVBC-NEXT:    or t0, a7, a6
-; RV32IMZVBC-NEXT:    sw t0, 120(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t0, 264(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a5, s10, 13
 ; RV32IMZVBC-NEXT:    srli a6, a0, 19
 ; RV32IMZVBC-NEXT:    or t2, a6, a5
-; RV32IMZVBC-NEXT:    sw t2, 112(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t2, 256(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a5, s2, 19
 ; RV32IMZVBC-NEXT:    srai a6, a5, 31
-; RV32IMZVBC-NEXT:    sw a6, 248(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 392(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a5, s2, 18
 ; RV32IMZVBC-NEXT:    srai a7, a5, 31
-; RV32IMZVBC-NEXT:    sw a7, 244(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 388(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a5, a6, t0
 ; RV32IMZVBC-NEXT:    xor a4, a4, a5
 ; RV32IMZVBC-NEXT:    and a5, a7, t2
@@ -15079,32 +15079,32 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    slli a5, s10, 15
 ; RV32IMZVBC-NEXT:    srli a6, a0, 17
 ; RV32IMZVBC-NEXT:    or a7, a4, a2
-; RV32IMZVBC-NEXT:    sw a7, 104(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 248(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    or a5, a6, a5
-; RV32IMZVBC-NEXT:    sw a5, 140(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a5, 284(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a2, s2, 17
 ; RV32IMZVBC-NEXT:    slli a4, s2, 16
 ; RV32IMZVBC-NEXT:    srai a2, a2, 31
-; RV32IMZVBC-NEXT:    sw a2, 240(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a2, 384(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    srai a4, a4, 31
-; RV32IMZVBC-NEXT:    sw a4, 236(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a4, 380(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a2, a2, a7
 ; RV32IMZVBC-NEXT:    and a4, a4, a5
 ; RV32IMZVBC-NEXT:    srli a5, a0, 16
 ; RV32IMZVBC-NEXT:    slli a6, s10, 16
 ; RV32IMZVBC-NEXT:    xor a2, a2, a4
 ; RV32IMZVBC-NEXT:    or a7, a6, a5
-; RV32IMZVBC-NEXT:    sw a7, 128(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 272(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    srli a4, a0, 15
 ; RV32IMZVBC-NEXT:    slli a5, s10, 17
 ; RV32IMZVBC-NEXT:    or t0, a5, a4
-; RV32IMZVBC-NEXT:    sw t0, 116(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t0, 260(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a4, s2, 15
 ; RV32IMZVBC-NEXT:    srai a5, a4, 31
-; RV32IMZVBC-NEXT:    sw a5, 232(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a5, 376(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a4, s2, 14
 ; RV32IMZVBC-NEXT:    srai a6, a4, 31
-; RV32IMZVBC-NEXT:    sw a6, 228(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 372(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a4, a5, a7
 ; RV32IMZVBC-NEXT:    xor a2, a2, a4
 ; RV32IMZVBC-NEXT:    and a4, a6, t0
@@ -15112,17 +15112,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    slli a6, s10, 18
 ; RV32IMZVBC-NEXT:    xor a2, a2, a4
 ; RV32IMZVBC-NEXT:    or t0, a6, a5
-; RV32IMZVBC-NEXT:    sw t0, 108(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t0, 252(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    srli a4, a0, 13
 ; RV32IMZVBC-NEXT:    slli a5, s10, 19
 ; RV32IMZVBC-NEXT:    or a7, a5, a4
-; RV32IMZVBC-NEXT:    sw a7, 160(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 304(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a4, s2, 13
 ; RV32IMZVBC-NEXT:    srai a5, a4, 31
-; RV32IMZVBC-NEXT:    sw a5, 224(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a5, 368(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a4, s2, 12
 ; RV32IMZVBC-NEXT:    srai a6, a4, 31
-; RV32IMZVBC-NEXT:    sw a6, 220(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 364(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a4, a5, t0
 ; RV32IMZVBC-NEXT:    xor a2, a2, a4
 ; RV32IMZVBC-NEXT:    and a4, a6, a7
@@ -15130,17 +15130,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    slli a6, s10, 20
 ; RV32IMZVBC-NEXT:    xor a2, a2, a4
 ; RV32IMZVBC-NEXT:    or t0, a6, a5
-; RV32IMZVBC-NEXT:    sw t0, 100(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t0, 244(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    srli a4, a0, 11
 ; RV32IMZVBC-NEXT:    slli a5, s10, 21
 ; RV32IMZVBC-NEXT:    or a7, a5, a4
-; RV32IMZVBC-NEXT:    sw a7, 156(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 300(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a4, s2, 11
 ; RV32IMZVBC-NEXT:    srai a5, a4, 31
-; RV32IMZVBC-NEXT:    sw a5, 216(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a5, 360(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a4, s2, 10
 ; RV32IMZVBC-NEXT:    srai a6, a4, 31
-; RV32IMZVBC-NEXT:    sw a6, 212(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 356(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a4, a5, t0
 ; RV32IMZVBC-NEXT:    xor a2, a2, a4
 ; RV32IMZVBC-NEXT:    and a4, a6, a7
@@ -15148,17 +15148,17 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    slli a6, s10, 22
 ; RV32IMZVBC-NEXT:    xor a2, a2, a4
 ; RV32IMZVBC-NEXT:    or a7, a6, a5
-; RV32IMZVBC-NEXT:    sw a7, 136(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 280(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    srli a4, a0, 9
 ; RV32IMZVBC-NEXT:    slli a5, s10, 23
 ; RV32IMZVBC-NEXT:    or t0, a5, a4
-; RV32IMZVBC-NEXT:    sw t0, 124(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t0, 268(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a4, s2, 9
 ; RV32IMZVBC-NEXT:    srai a5, a4, 31
-; RV32IMZVBC-NEXT:    sw a5, 200(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a5, 344(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a4, s2, 8
 ; RV32IMZVBC-NEXT:    srai a6, a4, 31
-; RV32IMZVBC-NEXT:    sw a6, 196(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 340(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a4, a5, a7
 ; RV32IMZVBC-NEXT:    xor a2, a2, a4
 ; RV32IMZVBC-NEXT:    and a4, a6, t0
@@ -15166,7 +15166,7 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    srli a6, a0, 8
 ; RV32IMZVBC-NEXT:    xor a2, a2, a4
 ; RV32IMZVBC-NEXT:    or t2, a6, a5
-; RV32IMZVBC-NEXT:    sw t2, 96(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t2, 240(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    srli a4, a0, 7
 ; RV32IMZVBC-NEXT:    slli a5, s10, 25
 ; RV32IMZVBC-NEXT:    or t3, a5, a4
@@ -15175,13 +15175,13 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    slli a6, s10, 26
 ; RV32IMZVBC-NEXT:    or t5, a6, a5
 ; RV32IMZVBC-NEXT:    srai a7, a4, 31
-; RV32IMZVBC-NEXT:    sw a7, 188(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 332(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a4, s2, 6
 ; RV32IMZVBC-NEXT:    slli a5, s2, 5
 ; RV32IMZVBC-NEXT:    srai t0, a4, 31
-; RV32IMZVBC-NEXT:    sw t0, 184(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t0, 328(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    srai a6, a5, 31
-; RV32IMZVBC-NEXT:    sw a6, 204(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 348(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a4, a7, t2
 ; RV32IMZVBC-NEXT:    and a5, t0, t3
 ; RV32IMZVBC-NEXT:    xor a4, a4, a5
@@ -15195,10 +15195,10 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    or t2, a6, a5
 ; RV32IMZVBC-NEXT:    slli a5, s2, 4
 ; RV32IMZVBC-NEXT:    srai a7, a5, 31
-; RV32IMZVBC-NEXT:    sw a7, 176(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 320(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a5, s2, 3
 ; RV32IMZVBC-NEXT:    srai a6, a5, 31
-; RV32IMZVBC-NEXT:    sw a6, 192(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 336(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a5, a7, t4
 ; RV32IMZVBC-NEXT:    xor a4, a4, a5
 ; RV32IMZVBC-NEXT:    and a5, a6, t2
@@ -15211,10 +15211,10 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    or s1, a6, a5
 ; RV32IMZVBC-NEXT:    slli a5, s2, 2
 ; RV32IMZVBC-NEXT:    srai a7, a5, 31
-; RV32IMZVBC-NEXT:    sw a7, 180(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 324(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a5, s2, 1
 ; RV32IMZVBC-NEXT:    srai a6, a5, 31
-; RV32IMZVBC-NEXT:    sw a6, 208(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 352(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a5, a7, t6
 ; RV32IMZVBC-NEXT:    xor a4, a4, a5
 ; RV32IMZVBC-NEXT:    and a5, a6, s1
@@ -15267,120 +15267,120 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    slli a5, s11, 23
 ; RV32IMZVBC-NEXT:    srai a5, a5, 31
 ; RV32IMZVBC-NEXT:    slli a6, a0, 8
-; RV32IMZVBC-NEXT:    sw a6, 92(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 236(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a2, a2, a4
 ; RV32IMZVBC-NEXT:    and a4, a5, a6
 ; RV32IMZVBC-NEXT:    xor a2, a2, a4
 ; RV32IMZVBC-NEXT:    slli a4, s11, 22
 ; RV32IMZVBC-NEXT:    srai a4, a4, 31
 ; RV32IMZVBC-NEXT:    slli a5, a0, 9
-; RV32IMZVBC-NEXT:    sw a5, 88(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a5, 232(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a4, a4, a5
 ; RV32IMZVBC-NEXT:    slli a5, s11, 21
 ; RV32IMZVBC-NEXT:    srai a5, a5, 31
 ; RV32IMZVBC-NEXT:    slli a6, a0, 10
-; RV32IMZVBC-NEXT:    sw a6, 84(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 228(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a2, a2, a4
 ; RV32IMZVBC-NEXT:    and a4, a5, a6
 ; RV32IMZVBC-NEXT:    xor a2, a2, a4
 ; RV32IMZVBC-NEXT:    slli a4, s11, 20
 ; RV32IMZVBC-NEXT:    srai a4, a4, 31
 ; RV32IMZVBC-NEXT:    slli a5, a0, 11
-; RV32IMZVBC-NEXT:    sw a5, 80(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a5, 224(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a4, a4, a5
 ; RV32IMZVBC-NEXT:    slli a5, s11, 19
 ; RV32IMZVBC-NEXT:    srai a5, a5, 31
 ; RV32IMZVBC-NEXT:    slli a6, a0, 12
-; RV32IMZVBC-NEXT:    sw a6, 76(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 220(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a2, a2, a4
 ; RV32IMZVBC-NEXT:    and a4, a5, a6
 ; RV32IMZVBC-NEXT:    xor a2, a2, a4
 ; RV32IMZVBC-NEXT:    slli a4, s11, 18
 ; RV32IMZVBC-NEXT:    srai a4, a4, 31
 ; RV32IMZVBC-NEXT:    slli a5, a0, 13
-; RV32IMZVBC-NEXT:    sw a5, 72(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a5, 216(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a4, a4, a5
 ; RV32IMZVBC-NEXT:    slli a5, s11, 17
 ; RV32IMZVBC-NEXT:    srai a5, a5, 31
 ; RV32IMZVBC-NEXT:    slli a6, a0, 14
-; RV32IMZVBC-NEXT:    sw a6, 64(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 208(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a2, a2, a4
 ; RV32IMZVBC-NEXT:    and a4, a5, a6
 ; RV32IMZVBC-NEXT:    xor a2, a2, a4
 ; RV32IMZVBC-NEXT:    slli a4, s11, 16
 ; RV32IMZVBC-NEXT:    srai a4, a4, 31
 ; RV32IMZVBC-NEXT:    slli a5, a0, 15
-; RV32IMZVBC-NEXT:    sw a5, 60(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a5, 204(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a4, a4, a5
 ; RV32IMZVBC-NEXT:    slli a5, s11, 15
 ; RV32IMZVBC-NEXT:    srai a5, a5, 31
 ; RV32IMZVBC-NEXT:    slli a6, a0, 16
-; RV32IMZVBC-NEXT:    sw a6, 304(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 8(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a5, a5, a6
 ; RV32IMZVBC-NEXT:    slli a6, s11, 14
 ; RV32IMZVBC-NEXT:    srai a6, a6, 31
 ; RV32IMZVBC-NEXT:    slli s0, a0, 17
-; RV32IMZVBC-NEXT:    sw s0, 56(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s0, 200(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a4, a4, a5
 ; RV32IMZVBC-NEXT:    and a5, a6, s0
 ; RV32IMZVBC-NEXT:    xor a4, a4, a5
 ; RV32IMZVBC-NEXT:    slli a5, s11, 13
 ; RV32IMZVBC-NEXT:    srai a5, a5, 31
 ; RV32IMZVBC-NEXT:    slli a6, a0, 18
-; RV32IMZVBC-NEXT:    sw a6, 48(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 192(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a5, a5, a6
 ; RV32IMZVBC-NEXT:    slli a6, s11, 12
 ; RV32IMZVBC-NEXT:    srai a6, a6, 31
 ; RV32IMZVBC-NEXT:    slli s0, a0, 19
-; RV32IMZVBC-NEXT:    sw s0, 40(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s0, 184(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a4, a4, a5
 ; RV32IMZVBC-NEXT:    and a5, a6, s0
 ; RV32IMZVBC-NEXT:    xor a4, a4, a5
 ; RV32IMZVBC-NEXT:    slli a5, s11, 11
 ; RV32IMZVBC-NEXT:    srai a5, a5, 31
 ; RV32IMZVBC-NEXT:    slli a6, a0, 20
-; RV32IMZVBC-NEXT:    sw a6, 32(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 176(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a5, a5, a6
 ; RV32IMZVBC-NEXT:    slli a6, s11, 10
 ; RV32IMZVBC-NEXT:    srai a6, a6, 31
 ; RV32IMZVBC-NEXT:    slli s0, a0, 21
-; RV32IMZVBC-NEXT:    sw s0, 16(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s0, 160(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a4, a4, a5
 ; RV32IMZVBC-NEXT:    and a5, a6, s0
 ; RV32IMZVBC-NEXT:    xor a4, a4, a5
 ; RV32IMZVBC-NEXT:    slli a5, s11, 9
 ; RV32IMZVBC-NEXT:    srai a5, a5, 31
 ; RV32IMZVBC-NEXT:    slli a6, a0, 22
-; RV32IMZVBC-NEXT:    sw a6, 308(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 12(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a5, a5, a6
 ; RV32IMZVBC-NEXT:    slli a6, s11, 8
 ; RV32IMZVBC-NEXT:    srai a6, a6, 31
 ; RV32IMZVBC-NEXT:    slli s0, a0, 23
-; RV32IMZVBC-NEXT:    sw s0, 312(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s0, 16(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a4, a4, a5
 ; RV32IMZVBC-NEXT:    and a5, a6, s0
 ; RV32IMZVBC-NEXT:    xor a4, a4, a5
 ; RV32IMZVBC-NEXT:    slli a5, s11, 7
 ; RV32IMZVBC-NEXT:    srai a5, a5, 31
 ; RV32IMZVBC-NEXT:    slli a6, a0, 24
-; RV32IMZVBC-NEXT:    sw a6, 36(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 180(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a5, a5, a6
 ; RV32IMZVBC-NEXT:    slli a6, s11, 6
 ; RV32IMZVBC-NEXT:    srai a6, a6, 31
 ; RV32IMZVBC-NEXT:    slli s0, a0, 25
-; RV32IMZVBC-NEXT:    sw s0, 24(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s0, 168(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a4, a4, a5
 ; RV32IMZVBC-NEXT:    and a5, a6, s0
 ; RV32IMZVBC-NEXT:    xor a4, a4, a5
 ; RV32IMZVBC-NEXT:    slli a5, s11, 5
 ; RV32IMZVBC-NEXT:    srai a5, a5, 31
 ; RV32IMZVBC-NEXT:    slli a6, a0, 26
-; RV32IMZVBC-NEXT:    sw a6, 20(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 164(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a5, a5, a6
 ; RV32IMZVBC-NEXT:    slli a6, s11, 4
 ; RV32IMZVBC-NEXT:    srai s0, a6, 31
 ; RV32IMZVBC-NEXT:    slli a6, a0, 27
-; RV32IMZVBC-NEXT:    sw a6, 28(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 172(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a4, a4, a5
 ; RV32IMZVBC-NEXT:    and a5, s0, a6
 ; RV32IMZVBC-NEXT:    xor s0, a1, a2
@@ -15390,371 +15390,371 @@ define i96 @clmul_i96(i96 %x, i96 %y) {
 ; RV32IMZVBC-NEXT:    srai a1, a1, 31
 ; RV32IMZVBC-NEXT:    srai a2, a2, 31
 ; RV32IMZVBC-NEXT:    slli a6, a0, 28
-; RV32IMZVBC-NEXT:    sw a6, 12(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 156(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a5, a0, 29
-; RV32IMZVBC-NEXT:    sw a5, 44(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a5, 188(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a1, a1, a6
 ; RV32IMZVBC-NEXT:    and a2, a2, a5
 ; RV32IMZVBC-NEXT:    xor a1, a1, a2
 ; RV32IMZVBC-NEXT:    slli a2, s11, 1
 ; RV32IMZVBC-NEXT:    srai a5, a2, 31
 ; RV32IMZVBC-NEXT:    slli a2, a0, 30
-; RV32IMZVBC-NEXT:    sw a2, 52(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a2, 196(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a2, a5, a2
 ; RV32IMZVBC-NEXT:    slli a5, a0, 31
-; RV32IMZVBC-NEXT:    sw a5, 68(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a5, 212(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a1, a1, a2
 ; RV32IMZVBC-NEXT:    and a2, s11, a5
 ; RV32IMZVBC-NEXT:    xor a4, s0, a4
-; RV32IMZVBC-NEXT:    sw a4, 8(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a4, 152(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a1, a1, a2
-; RV32IMZVBC-NEXT:    sw a1, 4(sp) # 4-byte Folded Spill
-; RV32IMZVBC-NEXT:    lw a1, 368(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    sw a1, 148(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    lw a1, 72(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a1, a1, t1
-; RV32IMZVBC-NEXT:    lw a2, 364(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a2, 68(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a2, a2, s10
-; RV32IMZVBC-NEXT:    lw a4, 152(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a5, 360(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 296(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 64(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a5, a4
-; RV32IMZVBC-NEXT:    lw t1, 168(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a5, 356(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t1, 312(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 60(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, a5, t1
 ; RV32IMZVBC-NEXT:    xor a1, a2, a1
 ; RV32IMZVBC-NEXT:    xor a2, a4, s10
-; RV32IMZVBC-NEXT:    lw a4, 172(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a5, 352(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 316(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 56(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a5, a4
-; RV32IMZVBC-NEXT:    lw a5, 348(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 52(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, a5, s3
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw a5, 148(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a6, 344(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 292(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a6, 48(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, a6, a5
 ; RV32IMZVBC-NEXT:    xor a1, a1, a2
 ; RV32IMZVBC-NEXT:    xor a2, a4, s10
-; RV32IMZVBC-NEXT:    lw a4, 340(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 44(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, s4
-; RV32IMZVBC-NEXT:    lw a5, 336(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 40(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, a5, a3
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s0, 164(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a5, 332(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s0, 308(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 36(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, a5, s0
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw a5, 144(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a6, 328(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 288(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a6, 32(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, a6, a5
 ; RV32IMZVBC-NEXT:    xor a1, a1, a2
 ; RV32IMZVBC-NEXT:    xor a2, a4, s10
-; RV32IMZVBC-NEXT:    lw a4, 132(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a5, 324(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 276(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 28(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a5, a4
-; RV32IMZVBC-NEXT:    lw a5, 120(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a6, 320(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 264(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a6, 24(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, a6, a5
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw a5, 112(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a6, 316(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 256(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a6, 20(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, a6, a5
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw a5, 104(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a6, 400(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 248(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a6, 104(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, a6, a5
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw a5, 140(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a6, 396(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    and s10, a6, a5
-; RV32IMZVBC-NEXT:    xor a1, a1, a2
-; RV32IMZVBC-NEXT:    xor a2, a4, s10
-; RV32IMZVBC-NEXT:    lw a4, 392(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a5, 128(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    and a4, a4, a5
-; RV32IMZVBC-NEXT:    lw a5, 388(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a6, 116(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    and s10, a5, a6
-; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw a5, 384(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a6, 108(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    and s10, a5, a6
-; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 160(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a5, 380(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    and s10, a5, s10
-; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw a5, 376(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 284(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    lw a6, 100(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    and s10, a6, a5
+; RV32IMZVBC-NEXT:    xor a1, a1, a2
+; RV32IMZVBC-NEXT:    xor a2, a4, s10
+; RV32IMZVBC-NEXT:    lw a4, 96(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 272(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    and a4, a4, a5
+; RV32IMZVBC-NEXT:    lw a5, 92(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a6, 260(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, a5, a6
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 156(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a5, 372(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 88(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a6, 252(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    and s10, a5, a6
+; RV32IMZVBC-NEXT:    xor a4, a4, s10
+; RV32IMZVBC-NEXT:    lw s10, 304(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 84(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    and s10, a5, s10
+; RV32IMZVBC-NEXT:    xor a4, a4, s10
+; RV32IMZVBC-NEXT:    lw a5, 80(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a6, 244(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    and s10, a5, a6
+; RV32IMZVBC-NEXT:    xor a4, a4, s10
+; RV32IMZVBC-NEXT:    lw s10, 300(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 76(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, a5, s10
 ; RV32IMZVBC-NEXT:    xor a1, a1, a2
 ; RV32IMZVBC-NEXT:    xor a2, a4, s10
-; RV32IMZVBC-NEXT:    lw a4, 440(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a5, 136(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 144(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 280(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, a5
-; RV32IMZVBC-NEXT:    lw s10, 436(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a5, 124(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 140(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 268(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, a5
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 432(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a5, 96(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 136(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 240(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, a5
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 428(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 132(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, t3
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 424(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 128(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, t5
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 420(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 124(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, t4
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 416(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 120(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, t2
 ; RV32IMZVBC-NEXT:    xor a1, a1, a2
 ; RV32IMZVBC-NEXT:    xor a2, a4, s10
-; RV32IMZVBC-NEXT:    lw a4, 412(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 116(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, t6
-; RV32IMZVBC-NEXT:    lw s10, 408(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 112(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, s1
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 404(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 108(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, t0
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 296(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 4(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, a0
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 292(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 436(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mv a5, s5
 ; RV32IMZVBC-NEXT:    and s10, s10, s5
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 288(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 432(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mv t0, s6
 ; RV32IMZVBC-NEXT:    and s10, s10, s6
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 284(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 428(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, a7
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 280(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 424(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mv t2, s7
 ; RV32IMZVBC-NEXT:    and s10, s10, s7
 ; RV32IMZVBC-NEXT:    xor a1, a1, a2
 ; RV32IMZVBC-NEXT:    xor a2, a4, s10
-; RV32IMZVBC-NEXT:    lw a4, 276(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 420(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mv a6, s8
 ; RV32IMZVBC-NEXT:    and a4, a4, s8
-; RV32IMZVBC-NEXT:    lw s10, 268(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 412(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mv t1, s9
 ; RV32IMZVBC-NEXT:    and s10, s10, s9
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 272(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 416(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mv s0, ra
 ; RV32IMZVBC-NEXT:    and s10, s10, ra
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 264(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw t3, 92(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 408(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t3, 236(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, t3
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 260(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw t4, 88(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 404(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t4, 232(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, t4
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 256(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw t5, 84(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 400(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t5, 228(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, t5
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 252(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw s11, 80(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 396(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s11, 224(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, s11
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 248(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw s4, 76(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 392(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s4, 220(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, s4
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 244(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw s3, 72(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 388(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s3, 216(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, s3
 ; RV32IMZVBC-NEXT:    xor a1, a1, a2
 ; RV32IMZVBC-NEXT:    xor a2, a4, s10
-; RV32IMZVBC-NEXT:    lw a4, 240(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw t6, 64(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 384(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t6, 208(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, t6
-; RV32IMZVBC-NEXT:    lw s10, 236(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw s1, 60(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 380(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s1, 204(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, s1
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 232(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a3, 304(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 376(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, a3
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 228(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw s5, 56(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 372(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s5, 200(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, s5
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 224(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw s6, 48(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 368(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s6, 192(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, s6
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 220(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw s7, 40(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 364(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s7, 184(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, s7
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 216(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw s8, 32(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 360(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s8, 176(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, s8
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 212(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw s9, 16(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 356(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s9, 160(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, s9
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 200(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw ra, 308(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 344(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, ra
 ; RV32IMZVBC-NEXT:    xor a4, a4, s10
-; RV32IMZVBC-NEXT:    lw s10, 196(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw ra, 312(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 340(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw ra, 16(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, s10, ra
 ; RV32IMZVBC-NEXT:    xor a1, a1, a2
 ; RV32IMZVBC-NEXT:    xor a2, a4, s10
-; RV32IMZVBC-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a4, 4(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 152(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 148(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    xor a3, a3, a4
-; RV32IMZVBC-NEXT:    sw a3, 296(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a3, 4(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor s10, a1, a2
-; RV32IMZVBC-NEXT:    lw a1, 368(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a1, 72(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a1, a1, a5
-; RV32IMZVBC-NEXT:    lw a2, 364(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a2, 68(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a0, a2, a0
-; RV32IMZVBC-NEXT:    lw a2, 188(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw ra, 36(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a2, 332(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw ra, 180(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a2, a2, ra
-; RV32IMZVBC-NEXT:    lw a4, 184(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 328(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 168(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, a3
 ; RV32IMZVBC-NEXT:    xor a2, a2, a4
 ; RV32IMZVBC-NEXT:    xor a0, a0, a1
-; RV32IMZVBC-NEXT:    lw a1, 360(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a1, 64(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a1, a1, t0
-; RV32IMZVBC-NEXT:    lw a4, 356(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 60(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, a7
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
-; RV32IMZVBC-NEXT:    lw a4, 204(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a7, 20(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 348(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a7, 164(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, a7
 ; RV32IMZVBC-NEXT:    xor a2, a2, a4
 ; RV32IMZVBC-NEXT:    xor a0, a0, a1
-; RV32IMZVBC-NEXT:    lw a1, 352(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a1, 56(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a1, a1, t2
-; RV32IMZVBC-NEXT:    lw a4, 348(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 52(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, a6
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
-; RV32IMZVBC-NEXT:    lw a4, 344(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 48(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, t1
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
-; RV32IMZVBC-NEXT:    lw a4, 176(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a6, 28(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 320(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a6, 172(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, a6
 ; RV32IMZVBC-NEXT:    xor a2, a2, a4
 ; RV32IMZVBC-NEXT:    xor a0, a0, a1
-; RV32IMZVBC-NEXT:    lw a1, 340(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a1, 44(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a1, a1, s0
-; RV32IMZVBC-NEXT:    lw a4, 336(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 40(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, t3
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
-; RV32IMZVBC-NEXT:    lw a4, 332(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 36(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, t4
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
-; RV32IMZVBC-NEXT:    lw a4, 328(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 32(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, t5
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
-; RV32IMZVBC-NEXT:    lw a4, 192(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw t1, 12(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 336(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t1, 156(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, t1
 ; RV32IMZVBC-NEXT:    xor a2, a2, a4
 ; RV32IMZVBC-NEXT:    xor a0, a0, a1
-; RV32IMZVBC-NEXT:    lw a1, 324(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a1, a1, s11
-; RV32IMZVBC-NEXT:    lw a4, 320(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 24(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, s4
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
-; RV32IMZVBC-NEXT:    lw a4, 316(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 20(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, s3
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
-; RV32IMZVBC-NEXT:    lw a4, 400(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 104(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, t6
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
-; RV32IMZVBC-NEXT:    lw a4, 396(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 100(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, s1
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
-; RV32IMZVBC-NEXT:    lw a4, 180(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw t0, 44(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 324(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t0, 188(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, t0
 ; RV32IMZVBC-NEXT:    xor a2, a2, a4
 ; RV32IMZVBC-NEXT:    xor a0, a0, a1
-; RV32IMZVBC-NEXT:    lw a1, 392(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a4, 304(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a1, 96(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 8(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a1, a1, a4
-; RV32IMZVBC-NEXT:    lw a4, 388(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 92(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, s5
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
-; RV32IMZVBC-NEXT:    lw a4, 384(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 88(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, s6
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
-; RV32IMZVBC-NEXT:    lw a4, 380(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 84(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, s7
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
-; RV32IMZVBC-NEXT:    lw a4, 376(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 80(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, s8
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
-; RV32IMZVBC-NEXT:    lw a4, 372(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 76(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, s9
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
-; RV32IMZVBC-NEXT:    lw a4, 208(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw t2, 52(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 352(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t2, 196(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, t2
 ; RV32IMZVBC-NEXT:    xor a2, a2, a4
 ; RV32IMZVBC-NEXT:    xor a0, a0, a1
-; RV32IMZVBC-NEXT:    lw a1, 440(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a4, 308(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a1, 144(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 12(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a1, a1, a4
-; RV32IMZVBC-NEXT:    lw a4, 436(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a5, 312(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 140(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 16(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, a5
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
-; RV32IMZVBC-NEXT:    lw a4, 432(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 136(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, ra
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
-; RV32IMZVBC-NEXT:    lw a4, 428(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 132(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, a3
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
-; RV32IMZVBC-NEXT:    lw a4, 424(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 128(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, a7
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
-; RV32IMZVBC-NEXT:    lw a4, 420(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 124(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, a6
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
-; RV32IMZVBC-NEXT:    lw a4, 416(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 120(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, t1
-; RV32IMZVBC-NEXT:    lw a5, 412(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 116(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a7, a5, t0
-; RV32IMZVBC-NEXT:    lw a5, 408(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 112(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a6, a5, t2
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
 ; RV32IMZVBC-NEXT:    xor a4, a7, a6
-; RV32IMZVBC-NEXT:    lw a6, 68(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a6, 212(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a3, s2, a6
-; RV32IMZVBC-NEXT:    lw a5, 404(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 108(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a5, a5, a6
 ; RV32IMZVBC-NEXT:    xor a0, a0, a1
 ; RV32IMZVBC-NEXT:    xor a4, a4, a5
 ; RV32IMZVBC-NEXT:    xor a2, a2, a3
 ; RV32IMZVBC-NEXT:    xor a0, a0, a4
 ; RV32IMZVBC-NEXT:    xor a1, s10, a2
-; RV32IMZVBC-NEXT:    lw a2, 300(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a2, 440(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    sw a0, 0(a2)
 ; RV32IMZVBC-NEXT:    sw a1, 4(a2)
-; RV32IMZVBC-NEXT:    lw a0, 296(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    sw a0, 8(a2)
 ; RV32IMZVBC-NEXT:    lw ra, 492(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    lw s0, 488(sp) # 4-byte Folded Reload
@@ -15838,20 +15838,20 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    .cfi_offset s10, -48
 ; RV32I-NEXT:    .cfi_offset s11, -52
 ; RV32I-NEXT:    mv t5, a2
-; RV32I-NEXT:    sw a0, 284(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 824(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lw a5, 4(a1)
-; RV32I-NEXT:    sw a5, 544(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 608(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui a0, 16
 ; RV32I-NEXT:    lw s4, 8(a1)
 ; RV32I-NEXT:    lw a3, 12(a1)
-; RV32I-NEXT:    sw a3, 276(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 388(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi a2, a0, -256
 ; RV32I-NEXT:    lui t4, 16
 ; RV32I-NEXT:    srli a0, a5, 8
 ; RV32I-NEXT:    srli a3, a5, 24
 ; RV32I-NEXT:    and a4, a5, a2
 ; RV32I-NEXT:    slli a5, a5, 24
-; RV32I-NEXT:    sw a5, 644(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 696(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a0, a0, a2
 ; RV32I-NEXT:    slli a4, a4, 8
 ; RV32I-NEXT:    or a0, a0, a3
@@ -15884,17 +15884,17 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    srli a3, t2, 24
 ; RV32I-NEXT:    and a4, t2, a2
 ; RV32I-NEXT:    slli a5, t2, 24
-; RV32I-NEXT:    sw a5, 824(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 176(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, a4, 8
 ; RV32I-NEXT:    or a0, a0, a3
 ; RV32I-NEXT:    or a3, a5, a4
 ; RV32I-NEXT:    or a0, a3, a0
 ; RV32I-NEXT:    lw s6, 8(t5)
 ; RV32I-NEXT:    lw a3, 12(t5)
-; RV32I-NEXT:    sw a3, 272(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 384(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli a3, a0, 4
 ; RV32I-NEXT:    and a3, a3, s11
-; RV32I-NEXT:    sw a6, 280(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 820(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli a4, a6, 8
 ; RV32I-NEXT:    and a0, a0, s11
 ; RV32I-NEXT:    and a4, a4, a2
@@ -15922,7 +15922,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    and a3, a3, s5
 ; RV32I-NEXT:    and a4, a4, s5
 ; RV32I-NEXT:    slli s0, a3, 1
-; RV32I-NEXT:    sw s0, 820(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s0, 0(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a5, t6
 ; RV32I-NEXT:    or s0, a4, s0
 ; RV32I-NEXT:    and a0, a0, t6
@@ -16186,7 +16186,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    and a5, t4, a2
 ; RV32I-NEXT:    slli a5, a5, 8
 ; RV32I-NEXT:    slli a6, t4, 24
-; RV32I-NEXT:    sw a6, 296(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 396(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a0, a0, 8
 ; RV32I-NEXT:    or a5, a6, a5
 ; RV32I-NEXT:    or a0, a4, a0
@@ -16216,12 +16216,12 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    andi a3, s0, 1
 ; RV32I-NEXT:    addi a4, a1, -1
-; RV32I-NEXT:    sw a4, 816(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 172(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a1, a3
 ; RV32I-NEXT:    addi a3, a1, -1
-; RV32I-NEXT:    sw a3, 812(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 168(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, t1, 1
-; RV32I-NEXT:    sw a1, 640(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 228(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a1, a4, a1
 ; RV32I-NEXT:    and a3, a3, t1
 ; RV32I-NEXT:    xor a1, a3, a1
@@ -16229,37 +16229,37 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    andi a4, s0, 8
 ; RV32I-NEXT:    addi a5, a3, -1
-; RV32I-NEXT:    sw a5, 808(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 164(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a3, a4
 ; RV32I-NEXT:    addi a6, a3, -1
-; RV32I-NEXT:    sw a6, 804(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 160(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, t1, 2
-; RV32I-NEXT:    sw a3, 636(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 224(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a5, a3
 ; RV32I-NEXT:    slli a4, t1, 3
-; RV32I-NEXT:    sw a4, 632(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 220(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a6, a4
 ; RV32I-NEXT:    andi a5, s0, 16
 ; RV32I-NEXT:    xor a3, a3, a4
 ; RV32I-NEXT:    seqz a4, a5
 ; RV32I-NEXT:    addi a6, a4, -1
-; RV32I-NEXT:    sw a6, 800(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 156(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a4, s0, 32
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    andi a5, s0, 64
 ; RV32I-NEXT:    addi a7, a4, -1
-; RV32I-NEXT:    sw a7, 796(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 152(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a4, a5
 ; RV32I-NEXT:    addi t0, a4, -1
-; RV32I-NEXT:    sw t0, 792(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 148(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, t1, 4
-; RV32I-NEXT:    sw a4, 628(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 692(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a6, a4
 ; RV32I-NEXT:    slli a5, t1, 5
-; RV32I-NEXT:    sw a5, 624(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 688(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a7, a5
 ; RV32I-NEXT:    slli a6, t1, 6
-; RV32I-NEXT:    sw a6, 620(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 684(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    and a5, t0, a6
 ; RV32I-NEXT:    xor a1, a1, a3
@@ -16275,13 +16275,13 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    addi a5, a3, -1
-; RV32I-NEXT:    sw a5, 788(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 144(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi a6, a4, -1
-; RV32I-NEXT:    sw a6, 784(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 140(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, t1, 7
-; RV32I-NEXT:    sw a3, 616(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 680(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, t1, 8
-; RV32I-NEXT:    sw a4, 612(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 676(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a5, a3
 ; RV32I-NEXT:    and a4, a6, a4
 ; RV32I-NEXT:    xor a3, a3, a4
@@ -16289,41 +16289,41 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    andi a5, s0, 1024
 ; RV32I-NEXT:    addi a6, a4, -1
-; RV32I-NEXT:    sw a6, 780(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 136(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a4, a5
 ; RV32I-NEXT:    addi a7, a4, -1
-; RV32I-NEXT:    sw a7, 776(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 132(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, t1, 9
-; RV32I-NEXT:    sw a4, 608(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 672(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a6, a4
 ; RV32I-NEXT:    slli a5, t1, 10
-; RV32I-NEXT:    sw a5, 604(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 668(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a3, a3, a4
 ; RV32I-NEXT:    and a4, a7, a5
 ; RV32I-NEXT:    xor a3, a3, a4
 ; RV32I-NEXT:    and a4, s0, s10
-; RV32I-NEXT:    sw s10, 288(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s10, 180(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    seqz a3, a4
 ; RV32I-NEXT:    addi a5, a3, -1
-; RV32I-NEXT:    sw a5, 768(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 124(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, s0, s2
 ; RV32I-NEXT:    lui ra, 1
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    and a4, s0, s3
 ; RV32I-NEXT:    addi a6, a3, -1
-; RV32I-NEXT:    sw a6, 764(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 120(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a3, a4
 ; RV32I-NEXT:    addi a7, a3, -1
-; RV32I-NEXT:    sw a7, 760(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 116(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, t1, 11
-; RV32I-NEXT:    sw a3, 600(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 664(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a5, a3
 ; RV32I-NEXT:    slli a4, t1, 12
-; RV32I-NEXT:    sw a4, 596(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 660(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a6, a4
 ; RV32I-NEXT:    slli a5, t1, 13
-; RV32I-NEXT:    sw a5, 592(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 656(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a3, a3, a4
 ; RV32I-NEXT:    and a4, a7, a5
 ; RV32I-NEXT:    xor a3, a3, a4
@@ -16332,26 +16332,26 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    and a5, s0, s7
 ; RV32I-NEXT:    addi a6, a4, -1
-; RV32I-NEXT:    sw a6, 756(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 112(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a4, a5
 ; RV32I-NEXT:    addi a7, a4, -1
-; RV32I-NEXT:    sw a7, 752(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 108(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, t1, 14
-; RV32I-NEXT:    sw a4, 588(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 652(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a6, a4
 ; RV32I-NEXT:    slli a5, t1, 15
-; RV32I-NEXT:    sw a5, 584(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 648(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a3, a3, a4
 ; RV32I-NEXT:    and a4, a7, a5
 ; RV32I-NEXT:    xor a3, a3, a4
 ; RV32I-NEXT:    addi a5, s8, 1364
-; RV32I-NEXT:    sw a5, 700(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 56(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli a4, a0, 1
 ; RV32I-NEXT:    and a0, a0, s5
 ; RV32I-NEXT:    and a4, a4, a5
 ; RV32I-NEXT:    slli a0, a0, 1
 ; RV32I-NEXT:    or a0, a4, a0
-; RV32I-NEXT:    sw a0, 772(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 128(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a0, a1, a3
 ; RV32I-NEXT:    lui a1, 16
 ; RV32I-NEXT:    and a1, s0, a1
@@ -16362,13 +16362,13 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    addi a4, a1, -1
-; RV32I-NEXT:    sw a4, 748(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 104(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi a5, a3, -1
-; RV32I-NEXT:    sw a5, 744(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 100(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, t1, 16
-; RV32I-NEXT:    sw a1, 580(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 644(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, t1, 17
-; RV32I-NEXT:    sw a3, 576(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 640(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a1, a4, a1
 ; RV32I-NEXT:    and a3, a5, a3
 ; RV32I-NEXT:    xor a1, a1, a3
@@ -16379,15 +16379,15 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    and a4, s0, a4
 ; RV32I-NEXT:    lui s7, 128
 ; RV32I-NEXT:    addi a5, a3, -1
-; RV32I-NEXT:    sw a5, 740(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 96(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a3, a4
 ; RV32I-NEXT:    addi a6, a3, -1
-; RV32I-NEXT:    sw a6, 736(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 92(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, t1, 18
-; RV32I-NEXT:    sw a3, 572(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 636(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a5, a3
 ; RV32I-NEXT:    slli a4, t1, 19
-; RV32I-NEXT:    sw a4, 568(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 632(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    and a3, a6, a4
 ; RV32I-NEXT:    xor a1, a1, a3
@@ -16397,21 +16397,21 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    lui a4, 1024
 ; RV32I-NEXT:    and a4, s0, a4
 ; RV32I-NEXT:    addi a5, a3, -1
-; RV32I-NEXT:    sw a5, 724(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 80(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a3, a4
 ; RV32I-NEXT:    addi a6, a3, -1
-; RV32I-NEXT:    sw a6, 732(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 88(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, s0, s1
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    slli a4, t1, 20
-; RV32I-NEXT:    sw a4, 556(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 620(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi a7, a3, -1
-; RV32I-NEXT:    sw a7, 728(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 84(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a5, a4
 ; RV32I-NEXT:    slli a4, t1, 22
-; RV32I-NEXT:    sw a4, 564(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 628(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, t1, 23
-; RV32I-NEXT:    sw a5, 560(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 624(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a6, a4
 ; RV32I-NEXT:    and a5, a7, a5
 ; RV32I-NEXT:    xor a1, a1, a3
@@ -16423,13 +16423,13 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    seqz a5, a5
 ; RV32I-NEXT:    addi a7, a3, -1
-; RV32I-NEXT:    sw a7, 716(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 72(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi a6, a5, -1
-; RV32I-NEXT:    sw a6, 720(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 76(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, t1, 21
-; RV32I-NEXT:    sw a3, 548(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 612(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, t1, 24
-; RV32I-NEXT:    sw a5, 552(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 616(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a7, a3
 ; RV32I-NEXT:    and a5, a6, a5
 ; RV32I-NEXT:    xor a1, a1, a3
@@ -16441,21 +16441,21 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    lui a5, 16384
 ; RV32I-NEXT:    and a5, s0, a5
 ; RV32I-NEXT:    addi a7, a3, -1
-; RV32I-NEXT:    sw a7, 712(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 68(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a3, a5
 ; RV32I-NEXT:    addi t0, a3, -1
-; RV32I-NEXT:    sw t0, 708(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 64(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, t1, 25
-; RV32I-NEXT:    sw a3, 540(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 604(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a7, a3
 ; RV32I-NEXT:    slli a5, t1, 26
-; RV32I-NEXT:    sw a5, 536(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 600(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a3, a4, a3
 ; RV32I-NEXT:    and a4, t0, a5
 ; RV32I-NEXT:    xor a1, a0, a1
 ; RV32I-NEXT:    xor a3, a3, a4
 ; RV32I-NEXT:    srli a0, a6, 8
-; RV32I-NEXT:    sw a2, 652(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a6, a2
 ; RV32I-NEXT:    and a0, a0, a2
 ; RV32I-NEXT:    slli a4, a4, 8
@@ -16469,17 +16469,17 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    srli a5, a0, 4
 ; RV32I-NEXT:    addi a2, a4, -1
-; RV32I-NEXT:    sw a2, 704(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 60(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a5, s11
 ; RV32I-NEXT:    and a0, a0, s11
 ; RV32I-NEXT:    slli a5, t1, 27
-; RV32I-NEXT:    sw a5, 532(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 596(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a0, a0, 4
 ; RV32I-NEXT:    and a5, a2, a5
 ; RV32I-NEXT:    xor a3, a3, a5
 ; RV32I-NEXT:    or a0, a4, a0
 ; RV32I-NEXT:    srli a4, a0, 2
-; RV32I-NEXT:    sw t6, 648(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t6, 4(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a0, a0, t6
 ; RV32I-NEXT:    and a4, a4, t6
 ; RV32I-NEXT:    slli a0, a0, 2
@@ -16489,28 +16489,28 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    srli a5, a0, 1
 ; RV32I-NEXT:    addi a2, a4, -1
-; RV32I-NEXT:    sw a2, 696(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    sw s5, 656(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 52(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s5, 12(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a5, s5
 ; RV32I-NEXT:    and a0, a0, s5
 ; RV32I-NEXT:    slli a5, t1, 28
-; RV32I-NEXT:    sw a5, 528(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 592(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, a0, 1
 ; RV32I-NEXT:    and a0, a2, a5
 ; RV32I-NEXT:    xor a3, a3, a0
 ; RV32I-NEXT:    or a0, a4, t3
 ; RV32I-NEXT:    xor a1, a1, a3
-; RV32I-NEXT:    sw a1, 680(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 36(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a1, a0, 2
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    andi a3, a0, 1
 ; RV32I-NEXT:    addi a4, a1, -1
-; RV32I-NEXT:    sw a4, 524(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 588(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a1, a3
 ; RV32I-NEXT:    addi a3, a1, -1
-; RV32I-NEXT:    sw a3, 520(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 584(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, t2, 1
-; RV32I-NEXT:    sw a1, 692(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 48(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a1, a4, a1
 ; RV32I-NEXT:    and a3, a3, t2
 ; RV32I-NEXT:    xor a2, a3, a1
@@ -16518,37 +16518,37 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    andi a4, a0, 8
 ; RV32I-NEXT:    addi a5, a3, -1
-; RV32I-NEXT:    sw a5, 516(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 580(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a3, a4
 ; RV32I-NEXT:    addi a4, a3, -1
-; RV32I-NEXT:    sw a4, 512(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 576(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, t2, 2
-; RV32I-NEXT:    sw a3, 688(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 44(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a5, a3
 ; RV32I-NEXT:    slli a1, t2, 3
-; RV32I-NEXT:    sw a1, 684(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 40(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a4, a1
 ; RV32I-NEXT:    andi a5, a0, 16
 ; RV32I-NEXT:    xor a3, a3, a4
 ; RV32I-NEXT:    seqz a4, a5
 ; RV32I-NEXT:    addi a1, a4, -1
-; RV32I-NEXT:    sw a1, 500(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 564(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a4, a0, 32
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    andi a5, a0, 64
 ; RV32I-NEXT:    addi a7, a4, -1
-; RV32I-NEXT:    sw a7, 496(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 560(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a4, a5
 ; RV32I-NEXT:    addi a4, a4, -1
-; RV32I-NEXT:    sw a4, 492(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 556(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, t2, 4
-; RV32I-NEXT:    sw a5, 668(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 24(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a1, a1, a5
 ; RV32I-NEXT:    slli a5, t2, 5
-; RV32I-NEXT:    sw a5, 664(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 20(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a7, a5
 ; RV32I-NEXT:    slli t6, t2, 6
-; RV32I-NEXT:    sw t6, 660(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t6, 16(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a7, a1, a5
 ; RV32I-NEXT:    and a5, a4, t6
 ; RV32I-NEXT:    xor a1, a2, a3
@@ -16558,13 +16558,13 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    seqz a5, a5
 ; RV32I-NEXT:    addi a3, a3, -1
-; RV32I-NEXT:    sw a3, 488(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 552(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi a5, a5, -1
-; RV32I-NEXT:    sw a5, 484(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 548(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, t2, 7
-; RV32I-NEXT:    sw a2, 380(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 216(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a7, t2, 8
-; RV32I-NEXT:    sw a7, 376(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 212(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a3, a2
 ; RV32I-NEXT:    and a5, a5, a7
 ; RV32I-NEXT:    xor a3, a3, a5
@@ -16572,15 +16572,15 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a5, a5
 ; RV32I-NEXT:    andi a7, a0, 1024
 ; RV32I-NEXT:    addi a2, a5, -1
-; RV32I-NEXT:    sw a2, 480(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 544(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a5, a7
 ; RV32I-NEXT:    addi a7, a5, -1
-; RV32I-NEXT:    sw a7, 476(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 540(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, t2, 9
-; RV32I-NEXT:    sw a5, 372(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 208(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a2, a5
 ; RV32I-NEXT:    slli a2, t2, 10
-; RV32I-NEXT:    sw a2, 368(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 204(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a3, a3, a5
 ; RV32I-NEXT:    and a5, a7, a2
 ; RV32I-NEXT:    xor a1, a1, a4
@@ -16592,14 +16592,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    seqz a5, a5
 ; RV32I-NEXT:    addi a2, a4, -1
-; RV32I-NEXT:    sw a2, 676(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 32(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi a7, a5, -1
-; RV32I-NEXT:    sw a7, 672(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 28(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, t1, 29
-; RV32I-NEXT:    sw a4, 508(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 572(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, t1, 30
-; RV32I-NEXT:    sw t1, 384(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    sw a5, 504(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t1, 448(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 568(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a2, a4
 ; RV32I-NEXT:    and a5, a7, a5
 ; RV32I-NEXT:    xor a4, a4, a5
@@ -16609,13 +16609,13 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    seqz a5, a5
 ; RV32I-NEXT:    addi a3, a3, -1
-; RV32I-NEXT:    sw a3, 468(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 532(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi a5, a5, -1
-; RV32I-NEXT:    sw a5, 464(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 528(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, t2, 11
-; RV32I-NEXT:    sw a2, 364(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 200(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a7, t2, 12
-; RV32I-NEXT:    sw a7, 360(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 196(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a3, a2
 ; RV32I-NEXT:    and a5, a5, a7
 ; RV32I-NEXT:    xor a3, a3, a5
@@ -16624,32 +16624,32 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a5, a5
 ; RV32I-NEXT:    and a7, a0, s3
 ; RV32I-NEXT:    addi a2, a5, -1
-; RV32I-NEXT:    sw a2, 460(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 524(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a5, a7
 ; RV32I-NEXT:    addi a7, a5, -1
-; RV32I-NEXT:    sw a7, 456(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 520(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, t2, 13
-; RV32I-NEXT:    sw a5, 356(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 192(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a2, a5
 ; RV32I-NEXT:    slli a2, t2, 14
-; RV32I-NEXT:    sw a2, 352(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 188(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a3, a3, a5
 ; RV32I-NEXT:    and a5, a7, a2
 ; RV32I-NEXT:    xor a3, a3, a5
-; RV32I-NEXT:    lw a5, 820(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli a5, a5, 31
 ; RV32I-NEXT:    seqz a5, a5
 ; RV32I-NEXT:    lui a2, 8
 ; RV32I-NEXT:    and a7, a0, a2
 ; RV32I-NEXT:    addi t6, a5, -1
-; RV32I-NEXT:    sw t6, 820(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t6, 0(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a5, a7
 ; RV32I-NEXT:    addi a5, a5, -1
-; RV32I-NEXT:    sw a5, 452(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 516(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a7, t2, 15
-; RV32I-NEXT:    sw a7, 348(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 184(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, t1, 31
-; RV32I-NEXT:    sw a2, 472(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 536(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a5, a7
 ; RV32I-NEXT:    xor a3, a3, a5
 ; RV32I-NEXT:    and a5, t6, a2
@@ -16660,9 +16660,9 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    addi a3, a3, -1
-; RV32I-NEXT:    sw a3, 448(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 512(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi a4, a4, -1
-; RV32I-NEXT:    sw a4, 444(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 508(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s9, t2, 16
 ; RV32I-NEXT:    slli s10, t2, 17
 ; RV32I-NEXT:    and a3, a3, s9
@@ -16673,10 +16673,10 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    and a5, a0, s7
 ; RV32I-NEXT:    addi a2, a4, -1
-; RV32I-NEXT:    sw a2, 440(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 504(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a4, a5
 ; RV32I-NEXT:    addi a5, a4, -1
-; RV32I-NEXT:    sw a5, 436(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 500(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s8, t2, 18
 ; RV32I-NEXT:    and a4, a2, s8
 ; RV32I-NEXT:    slli s7, t2, 19
@@ -16688,10 +16688,10 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    and a5, a0, s1
 ; RV32I-NEXT:    addi a2, a4, -1
-; RV32I-NEXT:    sw a2, 432(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 496(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a4, a5
 ; RV32I-NEXT:    addi a5, a4, -1
-; RV32I-NEXT:    sw a5, 428(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 492(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s3, t2, 20
 ; RV32I-NEXT:    and a4, a2, s3
 ; RV32I-NEXT:    slli s5, t2, 21
@@ -16703,13 +16703,13 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    xor t1, a1, a3
 ; RV32I-NEXT:    seqz a1, a4
 ; RV32I-NEXT:    addi a2, a1, -1
-; RV32I-NEXT:    sw a2, 424(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 488(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui a1, 2048
 ; RV32I-NEXT:    and a1, a0, a1
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    and a3, a0, s2
 ; RV32I-NEXT:    addi a4, a1, -1
-; RV32I-NEXT:    sw a4, 420(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 484(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a1, a3
 ; RV32I-NEXT:    slli s2, t2, 22
 ; RV32I-NEXT:    slli s1, t2, 23
@@ -16717,14 +16717,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    and a4, a4, s1
 ; RV32I-NEXT:    xor a3, a3, a4
 ; RV32I-NEXT:    addi a1, a1, -1
-; RV32I-NEXT:    sw a1, 416(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw s0, 824(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a1, 480(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw s0, 176(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, s0
 ; RV32I-NEXT:    and a4, a0, t5
 ; RV32I-NEXT:    xor a1, a3, a1
 ; RV32I-NEXT:    seqz a3, a4
 ; RV32I-NEXT:    addi a3, a3, -1
-; RV32I-NEXT:    sw a3, 412(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 476(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t6, t2, 25
 ; RV32I-NEXT:    and a3, a3, t6
 ; RV32I-NEXT:    lui a4, 16384
@@ -16732,14 +16732,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    seqz a3, a4
 ; RV32I-NEXT:    addi a3, a3, -1
-; RV32I-NEXT:    sw a3, 408(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 472(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t5, t2, 26
 ; RV32I-NEXT:    and a3, a3, t5
 ; RV32I-NEXT:    and a4, a0, t0
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    seqz a3, a4
 ; RV32I-NEXT:    addi a3, a3, -1
-; RV32I-NEXT:    sw a3, 404(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 468(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t0, t2, 27
 ; RV32I-NEXT:    and a3, a3, t0
 ; RV32I-NEXT:    lui a4, 65536
@@ -16747,7 +16747,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    xor a2, a1, a3
 ; RV32I-NEXT:    seqz a3, a4
 ; RV32I-NEXT:    addi a3, a3, -1
-; RV32I-NEXT:    sw a3, 400(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 464(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a7, t2, 28
 ; RV32I-NEXT:    and a3, a3, a7
 ; RV32I-NEXT:    lui a1, 131072
@@ -16755,16 +16755,16 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    addi a3, a1, -1
-; RV32I-NEXT:    sw a3, 396(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 460(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui a1, 262144
 ; RV32I-NEXT:    and a0, a0, a1
 ; RV32I-NEXT:    seqz a0, a0
 ; RV32I-NEXT:    srli a1, t3, 31
 ; RV32I-NEXT:    addi a4, a0, -1
-; RV32I-NEXT:    sw a4, 388(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 452(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a0, a1
 ; RV32I-NEXT:    addi a0, a0, -1
-; RV32I-NEXT:    sw a0, 392(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 456(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, t2, 29
 ; RV32I-NEXT:    and a5, a3, t3
 ; RV32I-NEXT:    slli a3, t2, 30
@@ -16774,124 +16774,124 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    and a1, a0, a4
 ; RV32I-NEXT:    xor a2, t1, a2
 ; RV32I-NEXT:    xor a1, a5, a1
-; RV32I-NEXT:    lw a0, 680(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    xor a0, a0, ra
 ; RV32I-NEXT:    xor ra, a2, a1
-; RV32I-NEXT:    lw a1, 816(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a2, 692(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 172(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 48(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, a2
-; RV32I-NEXT:    lw a2, 812(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 168(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a2, t2
-; RV32I-NEXT:    lw a5, 808(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 688(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 164(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 44(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, a5, t1
-; RV32I-NEXT:    lw a5, 804(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t2, 684(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 160(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t2, 40(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t2, a5, t2
 ; RV32I-NEXT:    xor a1, a2, a1
 ; RV32I-NEXT:    xor a2, t1, t2
-; RV32I-NEXT:    lw a5, 800(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 668(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 156(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 24(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, a5, t1
-; RV32I-NEXT:    lw a5, 796(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t2, 664(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 152(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t2, 20(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t2, a5, t2
 ; RV32I-NEXT:    xor t1, t1, t2
-; RV32I-NEXT:    lw a5, 792(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t2, 660(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 148(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t2, 16(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t2, a5, t2
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    xor a2, t1, t2
-; RV32I-NEXT:    lw a5, 788(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 380(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 144(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 216(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, a5, t1
-; RV32I-NEXT:    lw a5, 784(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t2, 376(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 140(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t2, 212(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t2, a5, t2
 ; RV32I-NEXT:    xor t1, t1, t2
-; RV32I-NEXT:    lw a5, 780(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t2, 372(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 136(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t2, 208(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t2, a5, t2
 ; RV32I-NEXT:    xor t1, t1, t2
-; RV32I-NEXT:    lw a5, 776(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t2, 368(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 132(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t2, 204(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t2, a5, t2
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    xor a2, t1, t2
-; RV32I-NEXT:    lw a5, 768(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 364(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 124(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 200(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, a5, t1
-; RV32I-NEXT:    lw a5, 764(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t2, 360(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 120(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t2, 196(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t2, a5, t2
 ; RV32I-NEXT:    xor t1, t1, t2
-; RV32I-NEXT:    lw a5, 760(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t2, 356(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 116(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t2, 192(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t2, a5, t2
 ; RV32I-NEXT:    xor t1, t1, t2
-; RV32I-NEXT:    lw a5, 756(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t2, 352(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 112(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t2, 188(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t2, a5, t2
 ; RV32I-NEXT:    xor t1, t1, t2
-; RV32I-NEXT:    lw a5, 752(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t2, 348(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 108(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t2, 184(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t2, a5, t2
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    xor a2, t1, t2
-; RV32I-NEXT:    lw a5, 748(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 104(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, a5, s9
-; RV32I-NEXT:    lw a5, 744(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 100(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t2, a5, s10
 ; RV32I-NEXT:    xor t1, t1, t2
-; RV32I-NEXT:    lw a5, 740(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 96(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t2, a5, s8
 ; RV32I-NEXT:    xor t1, t1, t2
-; RV32I-NEXT:    lw a5, 736(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 92(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t2, a5, s7
 ; RV32I-NEXT:    xor t1, t1, t2
-; RV32I-NEXT:    lw a5, 724(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 80(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t2, a5, s3
 ; RV32I-NEXT:    xor t1, t1, t2
-; RV32I-NEXT:    lw a5, 716(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 72(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t2, a5, s5
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    xor a2, t1, t2
 ; RV32I-NEXT:    xor a0, ra, a0
 ; RV32I-NEXT:    xor a1, a1, a2
-; RV32I-NEXT:    lw a2, 732(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 88(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a2, s2
-; RV32I-NEXT:    lw a5, 728(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 84(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, a5, s1
 ; RV32I-NEXT:    xor a2, a2, t1
-; RV32I-NEXT:    lw a5, 720(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 76(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, a5, s0
 ; RV32I-NEXT:    xor a2, a2, t1
-; RV32I-NEXT:    lw a5, 712(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 68(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, a5, t6
 ; RV32I-NEXT:    xor a2, a2, t1
-; RV32I-NEXT:    lw a5, 708(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 64(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, a5, t5
 ; RV32I-NEXT:    xor a2, a2, t1
-; RV32I-NEXT:    lw a5, 704(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 60(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t0, a5, t0
 ; RV32I-NEXT:    xor a2, a2, t0
-; RV32I-NEXT:    lw a5, 696(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 52(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a7, a5, a7
 ; RV32I-NEXT:    xor a2, a2, a7
-; RV32I-NEXT:    lw a5, 772(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 128(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli a7, a5, 1
 ; RV32I-NEXT:    xor a0, a7, a0
 ; RV32I-NEXT:    xor a1, a1, a2
-; RV32I-NEXT:    lw a2, 676(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 32(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a2, t3
-; RV32I-NEXT:    lw a5, 672(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 28(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a5, a3
 ; RV32I-NEXT:    xor a2, a2, a3
-; RV32I-NEXT:    lw a3, 820(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a4
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    srli a3, a0, 8
-; RV32I-NEXT:    lw a5, 652(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a5
 ; RV32I-NEXT:    srli a4, a0, 24
 ; RV32I-NEXT:    or a3, a3, a4
@@ -16922,7 +16922,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    or a0, a2, a0
 ; RV32I-NEXT:    or a1, a3, a1
 ; RV32I-NEXT:    srli a2, a0, 2
-; RV32I-NEXT:    lw a4, 648(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a0, a0, a4
 ; RV32I-NEXT:    and a2, a2, a4
 ; RV32I-NEXT:    slli a0, a0, 2
@@ -16932,30 +16932,30 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    slli a1, a1, 2
 ; RV32I-NEXT:    or a0, a2, a0
 ; RV32I-NEXT:    or a3, a3, a1
-; RV32I-NEXT:    sw a3, 268(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 816(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli a1, a0, 1
-; RV32I-NEXT:    lw a2, 656(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a0, a0, a2
-; RV32I-NEXT:    lw a2, 700(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 56(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, a2
 ; RV32I-NEXT:    slli a0, a0, 1
 ; RV32I-NEXT:    or a0, a1, a0
 ; RV32I-NEXT:    srli a1, a3, 1
-; RV32I-NEXT:    sw a1, 264(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 812(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli a0, a0, 1
 ; RV32I-NEXT:    slli a1, a1, 31
 ; RV32I-NEXT:    or a0, a0, a1
-; RV32I-NEXT:    sw a0, 208(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 340(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a0, a6, 2
 ; RV32I-NEXT:    seqz a0, a0
 ; RV32I-NEXT:    andi a1, a6, 1
 ; RV32I-NEXT:    addi a2, a0, -1
-; RV32I-NEXT:    sw a2, 760(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 116(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a0, a1
 ; RV32I-NEXT:    addi a1, a0, -1
-; RV32I-NEXT:    sw a1, 756(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 112(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a0, s4, 1
-; RV32I-NEXT:    sw a0, 244(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 376(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a0, a2, a0
 ; RV32I-NEXT:    and a1, a1, s4
 ; RV32I-NEXT:    xor a0, a1, a0
@@ -16963,37 +16963,37 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    andi a2, a6, 8
 ; RV32I-NEXT:    addi a3, a1, -1
-; RV32I-NEXT:    sw a3, 744(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 100(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a1, a2
 ; RV32I-NEXT:    addi a2, a1, -1
-; RV32I-NEXT:    sw a2, 740(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 96(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, s4, 2
-; RV32I-NEXT:    sw a1, 240(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 372(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a1, a3, a1
 ; RV32I-NEXT:    slli a3, s4, 3
-; RV32I-NEXT:    sw a3, 248(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 380(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a3
 ; RV32I-NEXT:    andi a3, a6, 16
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi a4, a2, -1
-; RV32I-NEXT:    sw a4, 300(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 400(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a2, a6, 32
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    andi a3, a6, 64
 ; RV32I-NEXT:    addi a5, a2, -1
-; RV32I-NEXT:    sw a5, 728(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 84(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi a7, a2, -1
-; RV32I-NEXT:    sw a7, 720(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 76(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, s4, 4
-; RV32I-NEXT:    sw a2, 216(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 348(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a4, a2
 ; RV32I-NEXT:    slli a3, s4, 5
-; RV32I-NEXT:    sw a3, 232(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 364(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a5, a3
 ; RV32I-NEXT:    slli a4, s4, 6
-; RV32I-NEXT:    sw a4, 236(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 368(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    and a3, a7, a4
 ; RV32I-NEXT:    xor a0, a0, a1
@@ -17003,56 +17003,56 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    andi a2, a6, 256
 ; RV32I-NEXT:    addi a3, a1, -1
-; RV32I-NEXT:    sw a3, 712(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 68(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a1, a2
 ; RV32I-NEXT:    addi a2, a1, -1
-; RV32I-NEXT:    sw a2, 708(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 64(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, s4, 7
-; RV32I-NEXT:    sw a1, 224(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 356(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a1, a3, a1
 ; RV32I-NEXT:    slli a3, s4, 8
-; RV32I-NEXT:    sw a3, 220(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 352(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a3
 ; RV32I-NEXT:    andi a3, a6, 512
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi a2, a2, -1
-; RV32I-NEXT:    sw a2, 704(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 60(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, s4, 9
-; RV32I-NEXT:    sw a3, 228(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 360(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a3
 ; RV32I-NEXT:    andi a3, a6, 1024
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi a2, a2, -1
-; RV32I-NEXT:    sw a2, 824(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 176(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, s4, 10
-; RV32I-NEXT:    sw a3, 212(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 344(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a3
-; RV32I-NEXT:    lw s11, 288(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s11, 180(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a6, s11
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi a4, a2, -1
-; RV32I-NEXT:    sw a4, 820(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 0(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui a2, 1
 ; RV32I-NEXT:    and a2, a6, a2
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    lui s8, 2
 ; RV32I-NEXT:    and a3, a6, s8
 ; RV32I-NEXT:    addi a7, a2, -1
-; RV32I-NEXT:    sw a7, 816(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 172(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi t1, a2, -1
-; RV32I-NEXT:    sw t1, 812(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t1, 168(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, s4, 11
-; RV32I-NEXT:    sw a2, 184(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 796(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a4, a2
 ; RV32I-NEXT:    slli a3, s4, 12
-; RV32I-NEXT:    sw a3, 200(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 332(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a7, a3
 ; RV32I-NEXT:    slli a4, s4, 13
-; RV32I-NEXT:    sw a4, 204(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 336(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    and a3, t1, a4
 ; RV32I-NEXT:    xor a2, a2, a3
@@ -17062,15 +17062,15 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    lui t6, 8
 ; RV32I-NEXT:    and a4, a6, t6
 ; RV32I-NEXT:    addi a7, a3, -1
-; RV32I-NEXT:    sw a7, 808(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 164(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a3, a4
 ; RV32I-NEXT:    addi a4, a3, -1
-; RV32I-NEXT:    sw a4, 804(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 160(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, s4, 14
-; RV32I-NEXT:    sw a3, 192(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 324(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a7, a3
 ; RV32I-NEXT:    slli a5, s4, 15
-; RV32I-NEXT:    sw a5, 196(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 328(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    and a3, a4, a5
 ; RV32I-NEXT:    xor a0, a0, a1
@@ -17082,13 +17082,13 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    addi a1, a1, -1
-; RV32I-NEXT:    sw a1, 800(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 156(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi a3, a3, -1
-; RV32I-NEXT:    sw a3, 796(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 152(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, s4, 16
-; RV32I-NEXT:    sw a5, 176(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 788(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, s4, 17
-; RV32I-NEXT:    sw a4, 188(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 320(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a1, a1, a5
 ; RV32I-NEXT:    and a3, a3, a4
 ; RV32I-NEXT:    xor a1, a1, a3
@@ -17098,15 +17098,15 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    lui s3, 128
 ; RV32I-NEXT:    and a4, a6, s3
 ; RV32I-NEXT:    addi t2, a3, -1
-; RV32I-NEXT:    sw t2, 792(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t2, 148(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a3, a4
 ; RV32I-NEXT:    addi a4, a3, -1
-; RV32I-NEXT:    sw a4, 788(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 144(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, s4, 18
-; RV32I-NEXT:    sw a3, 164(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 776(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, t2, a3
 ; RV32I-NEXT:    slli a5, s4, 19
-; RV32I-NEXT:    sw a5, 180(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 792(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    and a3, a4, a5
 ; RV32I-NEXT:    xor a1, a1, a3
@@ -17116,15 +17116,15 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    lui t1, 512
 ; RV32I-NEXT:    and a4, a6, t1
 ; RV32I-NEXT:    addi t2, a3, -1
-; RV32I-NEXT:    sw t2, 784(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t2, 140(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a3, a4
 ; RV32I-NEXT:    addi a4, a3, -1
-; RV32I-NEXT:    sw a4, 780(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 136(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, s4, 20
-; RV32I-NEXT:    sw a3, 152(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 764(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, t2, a3
 ; RV32I-NEXT:    slli a5, s4, 21
-; RV32I-NEXT:    sw a5, 172(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 784(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    and a3, a4, a5
 ; RV32I-NEXT:    xor a0, a0, a2
@@ -17136,84 +17136,84 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    lui ra, 2048
 ; RV32I-NEXT:    and a2, a6, ra
 ; RV32I-NEXT:    addi a3, a1, -1
-; RV32I-NEXT:    sw a3, 776(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 132(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a1, a2
 ; RV32I-NEXT:    addi a2, a1, -1
-; RV32I-NEXT:    sw a2, 772(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 128(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, s4, 22
-; RV32I-NEXT:    sw a1, 140(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 752(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a1, a3, a1
 ; RV32I-NEXT:    slli a0, s4, 23
-; RV32I-NEXT:    sw a0, 168(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 780(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a0
 ; RV32I-NEXT:    lui a7, 4096
 ; RV32I-NEXT:    and a3, a6, a7
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi a2, a2, -1
-; RV32I-NEXT:    sw a2, 768(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 124(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s9, s4, 24
 ; RV32I-NEXT:    and a2, a2, s9
-; RV32I-NEXT:    sw s9, 136(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s9, 748(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui t2, 8192
 ; RV32I-NEXT:    and a3, a6, t2
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi a2, a2, -1
-; RV32I-NEXT:    sw a2, 764(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 120(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a0, s4, 25
-; RV32I-NEXT:    sw a0, 160(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 772(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a0
 ; RV32I-NEXT:    lui s0, 16384
 ; RV32I-NEXT:    and a3, a6, s0
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi a2, a2, -1
-; RV32I-NEXT:    sw a2, 752(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 108(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a0, s4, 26
-; RV32I-NEXT:    sw a0, 148(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 760(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a0
 ; RV32I-NEXT:    lui a0, 32768
 ; RV32I-NEXT:    and a3, a6, a0
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi a2, a2, -1
-; RV32I-NEXT:    sw a2, 748(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 104(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a0, s4, 27
-; RV32I-NEXT:    sw a0, 156(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 768(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a0
 ; RV32I-NEXT:    lui s7, 65536
 ; RV32I-NEXT:    and a3, a6, s7
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi a2, a2, -1
-; RV32I-NEXT:    sw a2, 736(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 92(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a0, s4, 28
-; RV32I-NEXT:    sw a0, 144(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 756(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a0
 ; RV32I-NEXT:    lui a0, 131072
 ; RV32I-NEXT:    and a3, a6, a0
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi a0, a2, -1
-; RV32I-NEXT:    sw a0, 732(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui a2, 262144
 ; RV32I-NEXT:    and a2, a6, a2
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    srli a3, a6, 31
 ; RV32I-NEXT:    addi a4, a2, -1
-; RV32I-NEXT:    sw a4, 724(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 80(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi a2, a2, -1
-; RV32I-NEXT:    sw a2, 716(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 72(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, s4, 29
-; RV32I-NEXT:    sw a3, 256(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 804(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a0, a0, a3
 ; RV32I-NEXT:    slli a3, s4, 30
-; RV32I-NEXT:    sw a3, 252(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 800(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a4, a3
 ; RV32I-NEXT:    slli a6, s4, 31
-; RV32I-NEXT:    sw a6, 260(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 808(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a4, a0, a3
 ; RV32I-NEXT:    and a3, a2, a6
 ; RV32I-NEXT:    xor a0, a5, a1
@@ -17223,12 +17223,12 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a0, a0
 ; RV32I-NEXT:    andi a1, s6, 1
 ; RV32I-NEXT:    addi a3, a0, -1
-; RV32I-NEXT:    sw a3, 124(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 316(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a0, a1
 ; RV32I-NEXT:    addi a1, a0, -1
-; RV32I-NEXT:    sw a1, 120(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 312(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a0, t4, 1
-; RV32I-NEXT:    sw a0, 380(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 216(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a0, a3, a0
 ; RV32I-NEXT:    and a1, a1, t4
 ; RV32I-NEXT:    xor a2, a1, a0
@@ -17236,37 +17236,37 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    andi a3, s6, 8
 ; RV32I-NEXT:    addi a4, a1, -1
-; RV32I-NEXT:    sw a4, 116(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 308(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a1, a3
 ; RV32I-NEXT:    addi a5, a1, -1
-; RV32I-NEXT:    sw a5, 112(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 304(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, t4, 2
-; RV32I-NEXT:    sw a1, 376(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 212(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a1, a4, a1
 ; RV32I-NEXT:    slli a3, t4, 3
-; RV32I-NEXT:    sw a3, 372(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 208(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a5, a3
 ; RV32I-NEXT:    andi a4, s6, 16
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    seqz a3, a4
 ; RV32I-NEXT:    addi a5, a3, -1
-; RV32I-NEXT:    sw a5, 108(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 300(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a3, s6, 32
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    andi a4, s6, 64
 ; RV32I-NEXT:    addi a0, a3, -1
-; RV32I-NEXT:    sw a0, 96(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 292(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a3, a4
 ; RV32I-NEXT:    addi a6, a3, -1
-; RV32I-NEXT:    sw a6, 100(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 296(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, t4, 4
-; RV32I-NEXT:    sw a3, 368(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 204(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a5, a3
 ; RV32I-NEXT:    slli a4, t4, 5
-; RV32I-NEXT:    sw a4, 364(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 200(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a0, a4
 ; RV32I-NEXT:    slli a5, t4, 6
-; RV32I-NEXT:    sw a5, 360(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 196(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a3, a3, a4
 ; RV32I-NEXT:    and a4, a6, a5
 ; RV32I-NEXT:    xor a0, a2, a1
@@ -17276,54 +17276,54 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    andi a3, s6, 256
 ; RV32I-NEXT:    addi a2, a1, -1
-; RV32I-NEXT:    sw a2, 92(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 288(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a1, a3
 ; RV32I-NEXT:    addi a4, a1, -1
-; RV32I-NEXT:    sw a4, 88(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 284(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, t4, 7
-; RV32I-NEXT:    sw a1, 356(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 192(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a1, a2, a1
 ; RV32I-NEXT:    slli a3, t4, 8
-; RV32I-NEXT:    sw a3, 352(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 188(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a4, a3
 ; RV32I-NEXT:    andi a4, s6, 512
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    seqz a3, a4
 ; RV32I-NEXT:    addi a2, a3, -1
-; RV32I-NEXT:    sw a2, 84(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 280(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, t4, 9
-; RV32I-NEXT:    sw a3, 348(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 184(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a2, a3
 ; RV32I-NEXT:    andi a4, s6, 1024
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    seqz a3, a4
 ; RV32I-NEXT:    addi a2, a3, -1
-; RV32I-NEXT:    sw a2, 80(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 276(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, t4, 10
-; RV32I-NEXT:    sw a3, 344(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 444(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a2, a3
 ; RV32I-NEXT:    and a4, s6, s11
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    seqz a3, a4
 ; RV32I-NEXT:    addi a2, a3, -1
-; RV32I-NEXT:    sw a2, 76(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 272(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui a3, 1
 ; RV32I-NEXT:    and a3, s6, a3
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    and a4, s6, s8
 ; RV32I-NEXT:    addi a5, a3, -1
-; RV32I-NEXT:    sw a5, 68(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 264(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a3, a4
 ; RV32I-NEXT:    addi a6, a3, -1
-; RV32I-NEXT:    sw a6, 72(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 268(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, t4, 11
-; RV32I-NEXT:    sw a3, 340(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 440(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a2, a3
 ; RV32I-NEXT:    slli a4, t4, 12
-; RV32I-NEXT:    sw a4, 696(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 52(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a5, a4
 ; RV32I-NEXT:    slli a5, t4, 13
-; RV32I-NEXT:    sw a5, 336(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 436(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a3, a3, a4
 ; RV32I-NEXT:    and a4, a6, a5
 ; RV32I-NEXT:    xor a3, a3, a4
@@ -17332,15 +17332,15 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    and a5, s6, t6
 ; RV32I-NEXT:    addi a6, a4, -1
-; RV32I-NEXT:    sw a6, 60(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 256(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a4, a5
 ; RV32I-NEXT:    addi a2, a4, -1
-; RV32I-NEXT:    sw a2, 64(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 260(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, t4, 14
-; RV32I-NEXT:    sw a4, 332(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 432(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a6, a4
 ; RV32I-NEXT:    slli a5, t4, 15
-; RV32I-NEXT:    sw a5, 328(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 428(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a3, a3, a4
 ; RV32I-NEXT:    and a4, a2, a5
 ; RV32I-NEXT:    xor a0, a0, a1
@@ -17353,46 +17353,46 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz t6, a1
 ; RV32I-NEXT:    addi t6, t6, -1
 ; RV32I-NEXT:    slli a1, t4, 16
-; RV32I-NEXT:    sw a1, 324(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 424(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a1, s1, a1
 ; RV32I-NEXT:    slli a3, t4, 17
-; RV32I-NEXT:    sw a3, 320(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 420(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, t6, a3
 ; RV32I-NEXT:    and a4, s6, t5
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    seqz t5, a4
 ; RV32I-NEXT:    addi t5, t5, -1
 ; RV32I-NEXT:    slli a3, t4, 18
-; RV32I-NEXT:    sw a3, 316(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 416(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, t5, a3
 ; RV32I-NEXT:    and a4, s6, s3
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    seqz s3, a4
 ; RV32I-NEXT:    addi s3, s3, -1
-; RV32I-NEXT:    sw s3, 48(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s3, 252(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, t4, 19
-; RV32I-NEXT:    sw a3, 312(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 412(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, s3, a3
 ; RV32I-NEXT:    and a4, s6, s2
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    seqz t3, a4
 ; RV32I-NEXT:    addi t3, t3, -1
 ; RV32I-NEXT:    slli a3, t4, 20
-; RV32I-NEXT:    sw a3, 692(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 48(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, t3, a3
 ; RV32I-NEXT:    and a4, s6, t1
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    seqz t1, a4
 ; RV32I-NEXT:    addi t1, t1, -1
 ; RV32I-NEXT:    slli a3, t4, 21
-; RV32I-NEXT:    sw a3, 688(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 44(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, t1, a3
 ; RV32I-NEXT:    and a4, s6, t0
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    seqz a3, a4
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    addi a2, a3, -1
-; RV32I-NEXT:    sw a2, 32(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 248(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a1, s6, ra
 ; RV32I-NEXT:    and a3, s6, a7
 ; RV32I-NEXT:    seqz a7, a1
@@ -17400,28 +17400,28 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    addi a7, a7, -1
 ; RV32I-NEXT:    addi t0, t0, -1
 ; RV32I-NEXT:    slli a1, t4, 22
-; RV32I-NEXT:    sw a1, 308(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 408(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, t4, 23
-; RV32I-NEXT:    sw a4, 684(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 40(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a1, a2, a1
 ; RV32I-NEXT:    and a3, a7, a4
 ; RV32I-NEXT:    xor a1, a1, a3
-; RV32I-NEXT:    lw ra, 296(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 396(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, t0, ra
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    and a3, s6, t2
 ; RV32I-NEXT:    seqz a5, a3
 ; RV32I-NEXT:    and a3, s6, s0
 ; RV32I-NEXT:    addi a5, a5, -1
-; RV32I-NEXT:    sw a5, 28(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 244(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a4, a3
 ; RV32I-NEXT:    addi a4, a4, -1
-; RV32I-NEXT:    sw a4, 24(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 240(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, t4, 25
-; RV32I-NEXT:    sw a3, 304(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 404(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a5, a3
 ; RV32I-NEXT:    slli a6, t4, 26
-; RV32I-NEXT:    sw a6, 680(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 36(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    and a3, a4, a6
 ; RV32I-NEXT:    xor a1, a1, a3
@@ -17430,21 +17430,21 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz s2, a3
 ; RV32I-NEXT:    and a3, s6, s7
 ; RV32I-NEXT:    addi s2, s2, -1
-; RV32I-NEXT:    sw s2, 20(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s2, 236(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz s0, a3
 ; RV32I-NEXT:    addi s0, s0, -1
-; RV32I-NEXT:    sw s0, 16(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s0, 232(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, t4, 27
-; RV32I-NEXT:    sw a3, 676(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 32(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, s2, a3
 ; RV32I-NEXT:    slli a6, t4, 28
-; RV32I-NEXT:    sw a6, 672(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 28(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    and a3, s0, a6
 ; RV32I-NEXT:    xor a1, a1, a3
-; RV32I-NEXT:    sw s4, 132(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s4, 744(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli a3, s4, 8
-; RV32I-NEXT:    lw a5, 652(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a5
 ; RV32I-NEXT:    and a6, s4, a5
 ; RV32I-NEXT:    slli a6, a6, 8
@@ -17467,15 +17467,15 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    slli a0, a0, 4
 ; RV32I-NEXT:    mv s2, t4
 ; RV32I-NEXT:    slli a3, t4, 29
-; RV32I-NEXT:    sw a3, 668(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 24(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t2, t4, 30
-; RV32I-NEXT:    sw t2, 664(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t2, 20(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a6, s3, a3
 ; RV32I-NEXT:    and s7, s11, t2
 ; RV32I-NEXT:    xor a6, a6, s7
 ; RV32I-NEXT:    or a0, a1, a0
 ; RV32I-NEXT:    srli a1, a0, 2
-; RV32I-NEXT:    lw t2, 648(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t2, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a0, a0, t2
 ; RV32I-NEXT:    and a1, a1, t2
 ; RV32I-NEXT:    slli a0, a0, 2
@@ -17484,143 +17484,143 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a0, a0
 ; RV32I-NEXT:    srli s7, a1, 1
 ; RV32I-NEXT:    addi s0, a0, -1
-; RV32I-NEXT:    lw a4, 656(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, a4
 ; RV32I-NEXT:    and a1, a1, a4
 ; RV32I-NEXT:    slli a0, t4, 31
-; RV32I-NEXT:    sw t4, 292(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    sw a0, 660(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t4, 392(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, a1, 1
 ; RV32I-NEXT:    and s8, s0, a0
 ; RV32I-NEXT:    xor a6, a6, s8
 ; RV32I-NEXT:    or a1, s7, a1
 ; RV32I-NEXT:    xor a6, s4, a6
 ; RV32I-NEXT:    slli s4, a1, 1
-; RV32I-NEXT:    lw a0, 524(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 588(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, a0, s4
-; RV32I-NEXT:    lw a0, 520(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 584(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a0, a1
 ; RV32I-NEXT:    xor a2, a6, s10
 ; RV32I-NEXT:    xor a6, s7, s4
 ; RV32I-NEXT:    slli s4, a1, 2
 ; RV32I-NEXT:    slli s7, a1, 3
-; RV32I-NEXT:    lw a0, 516(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 580(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, a0, s4
-; RV32I-NEXT:    lw a0, 512(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 576(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a0, s7
 ; RV32I-NEXT:    xor s4, s4, s7
 ; RV32I-NEXT:    slli s7, a1, 4
-; RV32I-NEXT:    lw a0, 500(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 564(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a0, s7
 ; RV32I-NEXT:    slli s8, a1, 5
-; RV32I-NEXT:    lw a0, 496(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 560(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s8, a0, s8
 ; RV32I-NEXT:    slli s10, a1, 6
 ; RV32I-NEXT:    xor s7, s7, s8
-; RV32I-NEXT:    lw a0, 492(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 556(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s8, a0, s10
 ; RV32I-NEXT:    xor a6, a6, s4
 ; RV32I-NEXT:    xor s4, s7, s8
-; RV32I-NEXT:    lw a0, 208(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 340(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    xor a0, a0, a2
-; RV32I-NEXT:    sw a0, 208(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 340(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a2, a6, s4
 ; RV32I-NEXT:    slli a6, a1, 7
 ; RV32I-NEXT:    slli s4, a1, 8
-; RV32I-NEXT:    lw a0, 488(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 552(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, a0, a6
-; RV32I-NEXT:    lw a0, 484(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 548(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, a0, s4
 ; RV32I-NEXT:    xor a6, a6, s4
 ; RV32I-NEXT:    slli s4, a1, 9
-; RV32I-NEXT:    lw a0, 480(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 544(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, a0, s4
 ; RV32I-NEXT:    slli s7, a1, 10
 ; RV32I-NEXT:    xor a6, a6, s4
-; RV32I-NEXT:    lw a0, 476(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 540(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, a0, s7
 ; RV32I-NEXT:    xor a6, a6, s4
 ; RV32I-NEXT:    slli s4, a1, 11
-; RV32I-NEXT:    lw a0, 468(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 532(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, a0, s4
 ; RV32I-NEXT:    slli s7, a1, 12
-; RV32I-NEXT:    lw a0, 464(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 528(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a0, s7
 ; RV32I-NEXT:    slli s8, a1, 13
 ; RV32I-NEXT:    xor s4, s4, s7
-; RV32I-NEXT:    lw a0, 460(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 524(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a0, s8
 ; RV32I-NEXT:    xor s4, s4, s7
 ; RV32I-NEXT:    slli s7, a1, 14
-; RV32I-NEXT:    lw a0, 456(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 520(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a0, s7
 ; RV32I-NEXT:    slli s8, a1, 15
 ; RV32I-NEXT:    xor s4, s4, s7
-; RV32I-NEXT:    lw a0, 452(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 516(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a0, s8
 ; RV32I-NEXT:    xor a2, a2, a6
 ; RV32I-NEXT:    xor a6, s4, s7
 ; RV32I-NEXT:    slli s4, a1, 16
 ; RV32I-NEXT:    slli s7, a1, 17
-; RV32I-NEXT:    lw a0, 448(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 512(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, a0, s4
-; RV32I-NEXT:    lw a0, 444(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 508(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a0, s7
 ; RV32I-NEXT:    xor s4, s4, s7
 ; RV32I-NEXT:    slli s7, a1, 18
-; RV32I-NEXT:    lw a0, 440(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 504(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a0, s7
 ; RV32I-NEXT:    slli s8, a1, 19
 ; RV32I-NEXT:    xor s4, s4, s7
-; RV32I-NEXT:    lw a0, 436(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 500(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a0, s8
 ; RV32I-NEXT:    xor s4, s4, s7
 ; RV32I-NEXT:    slli s7, a1, 20
-; RV32I-NEXT:    lw a0, 432(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 496(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a0, s7
 ; RV32I-NEXT:    slli s8, a1, 21
 ; RV32I-NEXT:    xor s4, s4, s7
-; RV32I-NEXT:    lw a0, 428(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 492(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a0, s8
 ; RV32I-NEXT:    xor a2, a2, a6
 ; RV32I-NEXT:    xor a6, s4, s7
 ; RV32I-NEXT:    xor a2, a2, a6
 ; RV32I-NEXT:    slli a6, a1, 22
-; RV32I-NEXT:    lw a0, 424(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 488(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, a0, a6
 ; RV32I-NEXT:    slli s4, a1, 23
-; RV32I-NEXT:    lw a0, 420(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 484(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, a0, s4
 ; RV32I-NEXT:    slli s7, a1, 24
 ; RV32I-NEXT:    xor a6, a6, s4
-; RV32I-NEXT:    lw a0, 416(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 480(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, a0, s7
 ; RV32I-NEXT:    xor a6, a6, s4
 ; RV32I-NEXT:    slli s4, a1, 25
-; RV32I-NEXT:    lw a0, 412(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 476(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, a0, s4
 ; RV32I-NEXT:    slli s7, a1, 26
 ; RV32I-NEXT:    xor a6, a6, s4
-; RV32I-NEXT:    lw a0, 408(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 472(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, a0, s7
 ; RV32I-NEXT:    xor a6, a6, s4
 ; RV32I-NEXT:    slli s4, a1, 27
-; RV32I-NEXT:    lw a0, 404(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 468(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, a0, s4
 ; RV32I-NEXT:    slli s7, a1, 28
 ; RV32I-NEXT:    xor a6, a6, s4
-; RV32I-NEXT:    lw a0, 400(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 464(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, a0, s7
 ; RV32I-NEXT:    xor a6, a6, s4
 ; RV32I-NEXT:    slli s4, a1, 29
-; RV32I-NEXT:    lw a0, 396(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 460(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, a0, s4
 ; RV32I-NEXT:    slli s7, a1, 30
-; RV32I-NEXT:    lw a0, 388(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 452(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a0, s7
 ; RV32I-NEXT:    slli a1, a1, 31
 ; RV32I-NEXT:    xor s4, s4, s7
-; RV32I-NEXT:    lw a0, 392(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 456(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a0, a1
 ; RV32I-NEXT:    xor a2, a2, a6
 ; RV32I-NEXT:    xor a1, s4, a1
@@ -17665,9 +17665,9 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz t4, t4
 ; RV32I-NEXT:    addi a6, a6, -1
 ; RV32I-NEXT:    addi t4, t4, -1
-; RV32I-NEXT:    lw s4, 640(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s4, 228(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, a6, s4
-; RV32I-NEXT:    lw a0, 384(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 448(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t4, t4, a0
 ; RV32I-NEXT:    xor a6, t4, a6
 ; RV32I-NEXT:    andi t4, s8, 4
@@ -17675,28 +17675,28 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    andi s4, s8, 8
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    seqz s4, s4
-; RV32I-NEXT:    lw s7, 636(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 224(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t4, t4, s7
 ; RV32I-NEXT:    addi s4, s4, -1
-; RV32I-NEXT:    lw s7, 632(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 220(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s4, s7
 ; RV32I-NEXT:    andi s7, s8, 16
 ; RV32I-NEXT:    xor t4, t4, s4
 ; RV32I-NEXT:    seqz s4, s7
 ; RV32I-NEXT:    xor a6, a6, t4
 ; RV32I-NEXT:    addi s4, s4, -1
-; RV32I-NEXT:    lw t4, 628(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t4, 692(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t4, s4, t4
 ; RV32I-NEXT:    andi s4, s8, 32
 ; RV32I-NEXT:    seqz s4, s4
 ; RV32I-NEXT:    andi s7, s8, 64
 ; RV32I-NEXT:    addi s4, s4, -1
 ; RV32I-NEXT:    seqz s7, s7
-; RV32I-NEXT:    lw a0, 624(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 688(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s4, a0
 ; RV32I-NEXT:    addi s7, s7, -1
 ; RV32I-NEXT:    xor t4, t4, s4
-; RV32I-NEXT:    lw a0, 620(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 684(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s7, a0
 ; RV32I-NEXT:    xor t4, t4, s4
 ; RV32I-NEXT:    andi s4, s8, 128
@@ -17704,30 +17704,30 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz t4, s4
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    andi s4, s8, 256
-; RV32I-NEXT:    lw a0, 616(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 680(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t4, t4, a0
 ; RV32I-NEXT:    seqz s4, s4
 ; RV32I-NEXT:    addi s4, s4, -1
 ; RV32I-NEXT:    andi s7, s8, 512
-; RV32I-NEXT:    lw a0, 612(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 676(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s4, a0
 ; RV32I-NEXT:    seqz s7, s7
 ; RV32I-NEXT:    xor t4, t4, s4
 ; RV32I-NEXT:    addi s7, s7, -1
-; RV32I-NEXT:    lw a0, 608(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 672(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s7, a0
 ; RV32I-NEXT:    andi s7, s8, 1024
 ; RV32I-NEXT:    xor t4, t4, s4
 ; RV32I-NEXT:    seqz s4, s7
 ; RV32I-NEXT:    addi s4, s4, -1
-; RV32I-NEXT:    lw t2, 288(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t2, 180(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s8, t2
-; RV32I-NEXT:    lw a0, 604(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 668(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s4, a0
 ; RV32I-NEXT:    seqz s7, s7
 ; RV32I-NEXT:    xor t4, t4, s4
 ; RV32I-NEXT:    addi s7, s7, -1
-; RV32I-NEXT:    lw a0, 600(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 664(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s7, a0
 ; RV32I-NEXT:    lui a0, 1
 ; RV32I-NEXT:    and s7, s8, a0
@@ -17736,11 +17736,11 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    and s10, s8, a0
 ; RV32I-NEXT:    addi s7, s7, -1
 ; RV32I-NEXT:    seqz s10, s10
-; RV32I-NEXT:    lw a0, 596(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 660(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, a0
 ; RV32I-NEXT:    addi s10, s10, -1
 ; RV32I-NEXT:    xor s4, s4, s7
-; RV32I-NEXT:    lw a0, 592(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 656(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s10, a0
 ; RV32I-NEXT:    xor s4, s4, s7
 ; RV32I-NEXT:    lui a0, 4
@@ -17750,11 +17750,11 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    and s10, s8, a0
 ; RV32I-NEXT:    addi s7, s7, -1
 ; RV32I-NEXT:    seqz s10, s10
-; RV32I-NEXT:    lw a0, 588(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 652(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, a0
 ; RV32I-NEXT:    addi s10, s10, -1
 ; RV32I-NEXT:    xor s4, s4, s7
-; RV32I-NEXT:    lw a0, 584(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 648(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s10, a0
 ; RV32I-NEXT:    xor a6, a6, t4
 ; RV32I-NEXT:    xor t4, s4, s7
@@ -17766,9 +17766,9 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz s7, s7
 ; RV32I-NEXT:    addi s4, s4, -1
 ; RV32I-NEXT:    addi s7, s7, -1
-; RV32I-NEXT:    lw a0, 580(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 644(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s4, a0
-; RV32I-NEXT:    lw a0, 576(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 640(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, a0
 ; RV32I-NEXT:    xor s4, s4, s7
 ; RV32I-NEXT:    lui a0, 64
@@ -17778,11 +17778,11 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    and s10, s8, a0
 ; RV32I-NEXT:    addi s7, s7, -1
 ; RV32I-NEXT:    seqz s10, s10
-; RV32I-NEXT:    lw a0, 572(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 636(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, a0
 ; RV32I-NEXT:    addi s10, s10, -1
 ; RV32I-NEXT:    xor s4, s4, s7
-; RV32I-NEXT:    lw a0, 568(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 632(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s10, a0
 ; RV32I-NEXT:    xor s4, s4, s7
 ; RV32I-NEXT:    lui a0, 256
@@ -17792,11 +17792,11 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    and s10, s8, a0
 ; RV32I-NEXT:    addi s7, s7, -1
 ; RV32I-NEXT:    seqz s10, s10
-; RV32I-NEXT:    lw a0, 556(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 620(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, a0
 ; RV32I-NEXT:    addi s10, s10, -1
 ; RV32I-NEXT:    xor s4, s4, s7
-; RV32I-NEXT:    lw a0, 548(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 612(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s10, a0
 ; RV32I-NEXT:    xor a6, a6, t4
 ; RV32I-NEXT:    xor t4, s4, s7
@@ -17808,10 +17808,10 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    and s4, s8, a0
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    seqz s4, s4
-; RV32I-NEXT:    lw a0, 564(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 628(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t4, t4, a0
 ; RV32I-NEXT:    addi s4, s4, -1
-; RV32I-NEXT:    lw a0, 560(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 624(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s4, a0
 ; RV32I-NEXT:    lui s10, 4096
 ; RV32I-NEXT:    and s7, s8, s10
@@ -17820,12 +17820,12 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    addi s4, s4, -1
 ; RV32I-NEXT:    lui a0, 8192
 ; RV32I-NEXT:    and s7, s8, a0
-; RV32I-NEXT:    lw a0, 552(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 616(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s4, a0
 ; RV32I-NEXT:    seqz s7, s7
 ; RV32I-NEXT:    xor t4, t4, s4
 ; RV32I-NEXT:    addi s7, s7, -1
-; RV32I-NEXT:    lw a0, 540(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 604(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s7, a0
 ; RV32I-NEXT:    lui a0, 16384
 ; RV32I-NEXT:    and s7, s8, a0
@@ -17834,12 +17834,12 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    addi s4, s4, -1
 ; RV32I-NEXT:    lui a0, 32768
 ; RV32I-NEXT:    and s7, s8, a0
-; RV32I-NEXT:    lw a0, 536(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 600(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s4, a0
 ; RV32I-NEXT:    seqz s7, s7
 ; RV32I-NEXT:    xor t4, t4, s4
 ; RV32I-NEXT:    addi s7, s7, -1
-; RV32I-NEXT:    lw a0, 532(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 596(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s7, a0
 ; RV32I-NEXT:    lui a0, 65536
 ; RV32I-NEXT:    and s7, s8, a0
@@ -17848,12 +17848,12 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    addi s4, s4, -1
 ; RV32I-NEXT:    lui a0, 131072
 ; RV32I-NEXT:    and s7, s8, a0
-; RV32I-NEXT:    lw a0, 528(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 592(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s4, a0
 ; RV32I-NEXT:    seqz s7, s7
 ; RV32I-NEXT:    xor t4, t4, s4
 ; RV32I-NEXT:    addi s7, s7, -1
-; RV32I-NEXT:    lw a0, 508(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 572(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s7, a0
 ; RV32I-NEXT:    lui a0, 262144
 ; RV32I-NEXT:    and s7, s8, a0
@@ -17861,11 +17861,11 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    srli a2, a2, 31
 ; RV32I-NEXT:    addi s7, s7, -1
 ; RV32I-NEXT:    seqz a2, a2
-; RV32I-NEXT:    lw a0, 504(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 568(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, a0
 ; RV32I-NEXT:    addi a2, a2, -1
 ; RV32I-NEXT:    xor s4, s4, s7
-; RV32I-NEXT:    lw a0, 472(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 536(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a2, a0
 ; RV32I-NEXT:    xor a6, a6, t4
 ; RV32I-NEXT:    xor a2, s4, a2
@@ -17891,45 +17891,45 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    or a2, a2, a6
 ; RV32I-NEXT:    srli a6, a1, 1
 ; RV32I-NEXT:    and a1, a1, a4
-; RV32I-NEXT:    lw a0, 700(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, a6, a0
 ; RV32I-NEXT:    slli a1, a1, 1
 ; RV32I-NEXT:    or a1, a6, a1
 ; RV32I-NEXT:    srli a6, a2, 4
-; RV32I-NEXT:    sw s5, 104(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s5, 736(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a6, a6, s5
 ; RV32I-NEXT:    and a2, a2, s5
 ; RV32I-NEXT:    slli a2, a2, 4
-; RV32I-NEXT:    lw s5, 544(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s5, 608(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    slli a3, s5, 1
-; RV32I-NEXT:    sw a3, 128(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a5, 124(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a3, 740(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a5, 316(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t4, a5, a3
-; RV32I-NEXT:    lw a3, 120(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 312(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, a3, s5
 ; RV32I-NEXT:    or a2, a6, a2
 ; RV32I-NEXT:    xor a6, s4, t4
 ; RV32I-NEXT:    slli a3, s5, 2
-; RV32I-NEXT:    sw a3, 124(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 316(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s4, s5, 3
-; RV32I-NEXT:    sw s4, 120(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a5, 116(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw s4, 312(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a5, 308(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t4, a5, a3
-; RV32I-NEXT:    lw a3, 112(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 304(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, a3, s4
 ; RV32I-NEXT:    xor t4, t4, s4
 ; RV32I-NEXT:    slli a3, s5, 4
-; RV32I-NEXT:    sw a3, 116(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a5, 108(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a3, 308(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a5, 300(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, a5, a3
 ; RV32I-NEXT:    slli a3, s5, 5
-; RV32I-NEXT:    sw a3, 112(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a5, 96(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a3, 304(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a5, 292(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a5, a3
 ; RV32I-NEXT:    slli a3, s5, 6
-; RV32I-NEXT:    sw a3, 108(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 300(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor s4, s4, s7
-; RV32I-NEXT:    lw a5, 100(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 296(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a5, a3
 ; RV32I-NEXT:    xor a6, a6, t4
 ; RV32I-NEXT:    xor t4, s4, s7
@@ -17940,70 +17940,70 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    or a2, s4, a2
 ; RV32I-NEXT:    xor a6, a6, t4
 ; RV32I-NEXT:    slli a3, s5, 7
-; RV32I-NEXT:    sw a3, 100(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 296(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s4, s5, 8
-; RV32I-NEXT:    sw s4, 96(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a5, 92(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw s4, 292(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a5, 288(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t4, a5, a3
-; RV32I-NEXT:    lw a3, 88(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 284(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, a3, s4
 ; RV32I-NEXT:    xor t4, t4, s4
 ; RV32I-NEXT:    slli a3, s5, 9
-; RV32I-NEXT:    sw a3, 92(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a5, 84(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a3, 288(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a5, 280(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, a5, a3
 ; RV32I-NEXT:    slli a3, s5, 10
-; RV32I-NEXT:    sw a3, 88(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 284(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor t4, t4, s4
-; RV32I-NEXT:    lw a5, 80(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 276(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, a5, a3
 ; RV32I-NEXT:    xor t4, t4, s4
 ; RV32I-NEXT:    slli a3, s5, 11
-; RV32I-NEXT:    sw a3, 84(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a5, 76(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a3, 280(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a5, 272(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, a5, a3
 ; RV32I-NEXT:    slli a3, s5, 12
-; RV32I-NEXT:    sw a3, 80(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a5, 68(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a3, 276(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a5, 264(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a5, a3
 ; RV32I-NEXT:    slli a3, s5, 13
-; RV32I-NEXT:    sw a3, 76(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 272(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor s4, s4, s7
-; RV32I-NEXT:    lw a5, 72(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 268(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a5, a3
 ; RV32I-NEXT:    xor s4, s4, s7
 ; RV32I-NEXT:    slli a3, s5, 14
-; RV32I-NEXT:    sw a3, 72(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a5, 60(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a3, 268(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a5, 256(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a5, a3
 ; RV32I-NEXT:    slli a3, s5, 15
-; RV32I-NEXT:    sw a3, 68(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 264(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor s4, s4, s7
-; RV32I-NEXT:    lw a5, 64(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 260(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a5, a3
 ; RV32I-NEXT:    xor a6, a6, t4
 ; RV32I-NEXT:    xor t4, s4, s7
 ; RV32I-NEXT:    slli a3, s5, 16
-; RV32I-NEXT:    sw a3, 64(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 260(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s4, s5, 17
-; RV32I-NEXT:    sw s4, 60(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s4, 256(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and s1, s1, a3
 ; RV32I-NEXT:    and t6, t6, s4
 ; RV32I-NEXT:    xor t6, s1, t6
 ; RV32I-NEXT:    slli a3, s5, 18
-; RV32I-NEXT:    sw a3, 56(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 732(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t5, t5, a3
 ; RV32I-NEXT:    slli a3, s5, 19
-; RV32I-NEXT:    sw a3, 52(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 728(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor t5, t6, t5
-; RV32I-NEXT:    lw a5, 48(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 252(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t6, a5, a3
 ; RV32I-NEXT:    xor t5, t5, t6
 ; RV32I-NEXT:    slli a3, s5, 20
-; RV32I-NEXT:    sw a3, 48(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 252(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t3, t3, a3
 ; RV32I-NEXT:    slli a3, s5, 21
-; RV32I-NEXT:    sw a3, 44(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 724(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor t3, t5, t3
 ; RV32I-NEXT:    and t1, t1, a3
 ; RV32I-NEXT:    xor a6, a6, t4
@@ -18015,59 +18015,59 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    or a2, t3, a2
 ; RV32I-NEXT:    xor a6, a6, t1
 ; RV32I-NEXT:    slli a0, s5, 22
-; RV32I-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 720(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, s5, 23
-; RV32I-NEXT:    sw a3, 36(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a4, 32(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a3, 716(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a4, 248(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, a4, a0
 ; RV32I-NEXT:    and a7, a7, a3
 ; RV32I-NEXT:    xor a7, t1, a7
-; RV32I-NEXT:    lw t1, 644(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 696(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t0, t0, t1
 ; RV32I-NEXT:    xor a7, a7, t0
 ; RV32I-NEXT:    slli a0, s5, 25
-; RV32I-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a5, 28(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a0, 248(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a5, 244(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, a0
 ; RV32I-NEXT:    slli a0, s5, 26
-; RV32I-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 244(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a5, a7, a5
-; RV32I-NEXT:    lw a4, 24(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 240(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, a0
 ; RV32I-NEXT:    xor a4, a5, a4
 ; RV32I-NEXT:    slli a0, s5, 27
-; RV32I-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a5, 20(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a0, 240(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a5, 236(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, a0
 ; RV32I-NEXT:    slli a0, s5, 28
-; RV32I-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 236(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a5, 16(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 232(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, a0
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    slli a0, s5, 29
-; RV32I-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 232(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, s3, a0
 ; RV32I-NEXT:    slli a0, s5, 30
-; RV32I-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 712(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, s11, a0
 ; RV32I-NEXT:    slli a0, s5, 31
-; RV32I-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 708(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a3, a3, a5
 ; RV32I-NEXT:    and a0, s0, a0
 ; RV32I-NEXT:    xor a4, a6, a4
 ; RV32I-NEXT:    xor a0, a3, a0
 ; RV32I-NEXT:    xor a1, a2, a1
-; RV32I-NEXT:    sw a1, 4(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 704(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a0, a4, a0
-; RV32I-NEXT:    lw a6, 272(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 384(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    andi a1, a6, 2
 ; RV32I-NEXT:    andi a2, a6, 1
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    addi a1, a1, -1
 ; RV32I-NEXT:    addi a2, a2, -1
-; RV32I-NEXT:    lw a3, 380(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 216(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, a3
 ; RV32I-NEXT:    and a2, a2, s2
 ; RV32I-NEXT:    xor a1, a2, a1
@@ -18076,28 +18076,28 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    andi a3, a6, 8
 ; RV32I-NEXT:    addi a2, a2, -1
 ; RV32I-NEXT:    seqz a3, a3
-; RV32I-NEXT:    lw a4, 376(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 212(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a2, a4
 ; RV32I-NEXT:    addi a3, a3, -1
-; RV32I-NEXT:    lw a4, 372(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 208(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a4
 ; RV32I-NEXT:    andi a4, a6, 16
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    seqz a3, a4
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    addi a3, a3, -1
-; RV32I-NEXT:    lw a2, 368(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 204(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a3, a2
 ; RV32I-NEXT:    andi a3, a6, 32
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    andi a4, a6, 64
 ; RV32I-NEXT:    addi a3, a3, -1
 ; RV32I-NEXT:    seqz a4, a4
-; RV32I-NEXT:    lw a5, 364(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 200(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a5
 ; RV32I-NEXT:    addi a4, a4, -1
 ; RV32I-NEXT:    xor a2, a2, a3
-; RV32I-NEXT:    lw a3, 360(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 196(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a4, a3
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    andi a3, a6, 128
@@ -18105,17 +18105,17 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi a2, a2, -1
 ; RV32I-NEXT:    andi a3, a6, 256
-; RV32I-NEXT:    lw a4, 356(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 192(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a2, a4
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    addi a3, a3, -1
 ; RV32I-NEXT:    andi a4, a6, 512
-; RV32I-NEXT:    lw a5, 352(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 188(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a5
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    addi a4, a4, -1
-; RV32I-NEXT:    lw a3, 348(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 184(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a4, a3
 ; RV32I-NEXT:    andi a4, a6, 1024
 ; RV32I-NEXT:    xor a2, a2, a3
@@ -18123,12 +18123,12 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    addi a3, a3, -1
 ; RV32I-NEXT:    mv t1, t2
 ; RV32I-NEXT:    and a4, a6, t2
-; RV32I-NEXT:    lw a5, 344(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 444(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a5
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    addi a4, a4, -1
-; RV32I-NEXT:    lw a3, 340(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 440(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a4, a3
 ; RV32I-NEXT:    lui t2, 1
 ; RV32I-NEXT:    and a4, a6, t2
@@ -18137,11 +18137,11 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    and a5, a6, t3
 ; RV32I-NEXT:    addi a4, a4, -1
 ; RV32I-NEXT:    seqz a5, a5
-; RV32I-NEXT:    lw a7, 696(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 52(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, a7
 ; RV32I-NEXT:    addi a5, a5, -1
 ; RV32I-NEXT:    xor a3, a3, a4
-; RV32I-NEXT:    lw a4, 336(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 436(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a5, a4
 ; RV32I-NEXT:    xor a3, a3, a4
 ; RV32I-NEXT:    lui t4, 4
@@ -18151,11 +18151,11 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    and a5, a6, t5
 ; RV32I-NEXT:    addi a4, a4, -1
 ; RV32I-NEXT:    seqz a5, a5
-; RV32I-NEXT:    lw a7, 332(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 432(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, a7
 ; RV32I-NEXT:    addi a5, a5, -1
 ; RV32I-NEXT:    xor a3, a3, a4
-; RV32I-NEXT:    lw a4, 328(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 428(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a5, a4
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    xor a3, a3, a4
@@ -18167,10 +18167,10 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    and a3, a6, s3
 ; RV32I-NEXT:    addi a2, a2, -1
 ; RV32I-NEXT:    seqz a3, a3
-; RV32I-NEXT:    lw a4, 324(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 424(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a2, a4
 ; RV32I-NEXT:    addi a3, a3, -1
-; RV32I-NEXT:    lw a4, 320(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 420(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a4
 ; RV32I-NEXT:    lui s5, 64
 ; RV32I-NEXT:    and a4, a6, s5
@@ -18179,12 +18179,12 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    addi a3, a3, -1
 ; RV32I-NEXT:    lui a4, 128
 ; RV32I-NEXT:    and a4, a6, a4
-; RV32I-NEXT:    lw a5, 316(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 416(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a5
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    addi a4, a4, -1
-; RV32I-NEXT:    lw a3, 312(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 412(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a4, a3
 ; RV32I-NEXT:    lui a4, 256
 ; RV32I-NEXT:    and a4, a6, a4
@@ -18194,19 +18194,19 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    addi a3, a3, -1
 ; RV32I-NEXT:    lui a4, 512
 ; RV32I-NEXT:    and a4, a6, a4
-; RV32I-NEXT:    lw a5, 692(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 48(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a5
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    addi a4, a4, -1
-; RV32I-NEXT:    lw a3, 688(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 44(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a4, a3
 ; RV32I-NEXT:    and a4, a6, s6
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    seqz a3, a4
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    addi a3, a3, -1
-; RV32I-NEXT:    lw a2, 308(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 408(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a3, a2
 ; RV32I-NEXT:    lui a3, 2048
 ; RV32I-NEXT:    and a3, a6, a3
@@ -18214,7 +18214,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    and a4, a6, s10
 ; RV32I-NEXT:    addi a3, a3, -1
 ; RV32I-NEXT:    seqz a4, a4
-; RV32I-NEXT:    lw a5, 684(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 40(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a5
 ; RV32I-NEXT:    addi a4, a4, -1
 ; RV32I-NEXT:    xor a2, a2, a3
@@ -18228,11 +18228,11 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    and a4, a6, a4
 ; RV32I-NEXT:    addi a3, a3, -1
 ; RV32I-NEXT:    seqz a4, a4
-; RV32I-NEXT:    lw a5, 304(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 404(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a5
 ; RV32I-NEXT:    addi a4, a4, -1
 ; RV32I-NEXT:    xor a2, a2, a3
-; RV32I-NEXT:    lw a3, 680(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 36(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a4, a3
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    lui a3, 32768
@@ -18242,11 +18242,11 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    and a4, a6, a4
 ; RV32I-NEXT:    addi a3, a3, -1
 ; RV32I-NEXT:    seqz a4, a4
-; RV32I-NEXT:    lw a5, 676(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 32(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a5
 ; RV32I-NEXT:    addi a4, a4, -1
 ; RV32I-NEXT:    xor a2, a2, a3
-; RV32I-NEXT:    lw a3, 672(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 28(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a4, a3
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    lui a3, 131072
@@ -18256,42 +18256,42 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    addi a2, a2, -1
 ; RV32I-NEXT:    lui a3, 262144
 ; RV32I-NEXT:    and a3, a6, a3
-; RV32I-NEXT:    lw a4, 668(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 24(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a2, a4
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    addi a3, a3, -1
 ; RV32I-NEXT:    srli a4, a6, 31
-; RV32I-NEXT:    lw a5, 664(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 20(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a5
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    addi a4, a4, -1
-; RV32I-NEXT:    lw a3, 660(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 16(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a4, a3
-; RV32I-NEXT:    lw t0, 276(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t0, 388(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    slli a4, t0, 1
-; RV32I-NEXT:    lw a5, 760(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 116(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a5, a4
-; RV32I-NEXT:    lw a5, 756(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 112(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, t0
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    xor a4, a5, a4
 ; RV32I-NEXT:    slli a3, t0, 2
 ; RV32I-NEXT:    slli a5, t0, 3
-; RV32I-NEXT:    lw a6, 744(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 100(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a6, a3
-; RV32I-NEXT:    lw a6, 740(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 96(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a6, a5
 ; RV32I-NEXT:    xor a3, a3, a5
 ; RV32I-NEXT:    slli a5, t0, 4
-; RV32I-NEXT:    lw s6, 300(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s6, 400(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, s6, a5
 ; RV32I-NEXT:    slli a6, t0, 5
-; RV32I-NEXT:    lw a7, 728(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 84(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, a7, a6
 ; RV32I-NEXT:    slli a7, t0, 6
 ; RV32I-NEXT:    xor a5, a5, a6
-; RV32I-NEXT:    lw a6, 720(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 76(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, a6, a7
 ; RV32I-NEXT:    xor a3, a4, a3
 ; RV32I-NEXT:    xor a4, a5, a6
@@ -18299,150 +18299,150 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    xor a3, a3, a4
 ; RV32I-NEXT:    slli a2, t0, 7
 ; RV32I-NEXT:    slli a4, t0, 8
-; RV32I-NEXT:    lw a5, 712(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 68(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a5, a2
-; RV32I-NEXT:    lw a5, 708(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 64(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a5, a4
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    slli a4, t0, 9
-; RV32I-NEXT:    lw a5, 704(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 60(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a5, a4
 ; RV32I-NEXT:    slli a5, t0, 10
 ; RV32I-NEXT:    xor a2, a2, a4
-; RV32I-NEXT:    lw a4, 824(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 176(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, a5
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    slli a4, t0, 11
-; RV32I-NEXT:    lw a5, 820(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a5, a4
 ; RV32I-NEXT:    slli a5, t0, 12
-; RV32I-NEXT:    lw a6, 816(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 172(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a6, a5
 ; RV32I-NEXT:    slli a6, t0, 13
 ; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a5, 812(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 168(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, a6
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    slli a5, t0, 14
-; RV32I-NEXT:    lw a6, 808(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 164(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a6, a5
 ; RV32I-NEXT:    slli a6, t0, 15
 ; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a5, 804(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 160(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, a6
 ; RV32I-NEXT:    xor a2, a3, a2
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    xor a0, a1, a0
-; RV32I-NEXT:    sw a0, 0(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 700(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    slli a0, t0, 16
 ; RV32I-NEXT:    slli a1, t0, 17
-; RV32I-NEXT:    lw a3, 800(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 156(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a0, a3, a0
-; RV32I-NEXT:    lw a3, 796(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 152(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a3, a1
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    slli a1, t0, 18
-; RV32I-NEXT:    lw a3, 792(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 148(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a3, a1
 ; RV32I-NEXT:    slli a3, t0, 19
 ; RV32I-NEXT:    xor a0, a0, a1
-; RV32I-NEXT:    lw a1, 788(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 144(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, a3
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    slli a1, t0, 20
-; RV32I-NEXT:    lw a3, 784(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 140(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a3, a1
 ; RV32I-NEXT:    slli a3, t0, 21
 ; RV32I-NEXT:    xor a0, a0, a1
-; RV32I-NEXT:    lw a1, 780(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 136(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, a3
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    slli a1, t0, 22
-; RV32I-NEXT:    lw a3, 776(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 132(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a3, a1
 ; RV32I-NEXT:    slli a3, t0, 23
-; RV32I-NEXT:    lw a4, 772(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 128(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a4, a3
 ; RV32I-NEXT:    slli a4, t0, 24
 ; RV32I-NEXT:    xor a1, a1, a3
-; RV32I-NEXT:    lw a3, 768(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 124(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a4
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    slli a3, t0, 25
-; RV32I-NEXT:    lw a4, 764(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 120(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a4, a3
 ; RV32I-NEXT:    slli a4, t0, 26
 ; RV32I-NEXT:    xor a1, a1, a3
-; RV32I-NEXT:    lw a3, 752(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 108(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a4
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    slli a3, t0, 27
-; RV32I-NEXT:    lw a4, 748(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 104(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a4, a3
 ; RV32I-NEXT:    slli a4, t0, 28
 ; RV32I-NEXT:    xor a1, a1, a3
-; RV32I-NEXT:    lw a3, 736(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 92(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a4
 ; RV32I-NEXT:    xor a0, a2, a0
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    xor s8, a0, a1
 ; RV32I-NEXT:    slli a0, t0, 29
-; RV32I-NEXT:    lw a1, 732(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 88(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a0, a1, a0
 ; RV32I-NEXT:    slli a1, t0, 30
-; RV32I-NEXT:    lw a2, 724(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 80(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a2, a1
 ; RV32I-NEXT:    slli a2, t0, 31
 ; RV32I-NEXT:    xor a0, a0, a1
-; RV32I-NEXT:    lw a1, 716(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 72(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, a2
 ; RV32I-NEXT:    xor ra, a0, a1
-; RV32I-NEXT:    lw s7, 280(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 820(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    andi a0, s7, 2
 ; RV32I-NEXT:    seqz a0, a0
 ; RV32I-NEXT:    andi a1, s7, 1
 ; RV32I-NEXT:    addi a2, a0, -1
-; RV32I-NEXT:    sw a2, 276(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 388(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a0, a1
-; RV32I-NEXT:    lw a1, 244(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 376(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a2, a1
 ; RV32I-NEXT:    addi a2, a0, -1
-; RV32I-NEXT:    sw a2, 272(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a0, 132(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a2, 384(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a0, 744(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a0, a2, a0
 ; RV32I-NEXT:    andi a2, s7, 4
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    seqz a1, a2
 ; RV32I-NEXT:    addi a3, a1, -1
-; RV32I-NEXT:    sw a3, 244(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 376(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a1, s7, 8
-; RV32I-NEXT:    lw a2, 240(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 372(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a3, a2
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    addi a4, a1, -1
-; RV32I-NEXT:    sw a4, 240(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 372(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a1, s7, 16
-; RV32I-NEXT:    lw a3, 248(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 380(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a4, a3
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    addi a3, a1, -1
-; RV32I-NEXT:    sw a3, 248(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a1, 216(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a3, 380(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a1, 348(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a3, a1
 ; RV32I-NEXT:    andi a3, s7, 32
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    andi a4, s7, 64
 ; RV32I-NEXT:    addi a5, a3, -1
-; RV32I-NEXT:    sw a5, 216(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 348(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a3, a4
-; RV32I-NEXT:    lw a4, 232(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 364(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a5, a4
 ; RV32I-NEXT:    addi a5, a3, -1
-; RV32I-NEXT:    sw a5, 232(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 364(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a3, 236(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 368(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a5, a3
 ; RV32I-NEXT:    xor a0, a0, a2
 ; RV32I-NEXT:    xor a1, a1, a3
@@ -18451,48 +18451,48 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    andi a2, s7, 256
 ; RV32I-NEXT:    addi a3, a1, -1
-; RV32I-NEXT:    sw a3, 236(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 368(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a1, a2
-; RV32I-NEXT:    lw a2, 224(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 356(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a3, a2
 ; RV32I-NEXT:    addi a3, a1, -1
-; RV32I-NEXT:    sw a3, 224(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a1, 220(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a3, 356(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a1, 352(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a3, a1
 ; RV32I-NEXT:    andi a3, s7, 512
 ; RV32I-NEXT:    xor a1, a2, a1
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi a4, a2, -1
-; RV32I-NEXT:    sw a4, 220(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 352(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a2, s7, 1024
-; RV32I-NEXT:    lw a3, 228(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 360(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a4, a3
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    addi a3, a2, -1
-; RV32I-NEXT:    sw a3, 228(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a2, 212(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a3, 360(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a2, 344(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a3, a2
 ; RV32I-NEXT:    and a3, s7, t1
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    seqz s9, a3
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    addi s9, s9, -1
-; RV32I-NEXT:    sw s9, 288(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a1, 184(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw s9, 180(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a1, 796(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, s9, a1
 ; RV32I-NEXT:    and a2, s7, t2
 ; RV32I-NEXT:    seqz s4, a2
 ; RV32I-NEXT:    and a2, s7, t3
 ; RV32I-NEXT:    addi s4, s4, -1
-; RV32I-NEXT:    sw s4, 212(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s4, 344(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz s1, a2
-; RV32I-NEXT:    lw a2, 200(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 332(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, s4, a2
 ; RV32I-NEXT:    addi s1, s1, -1
-; RV32I-NEXT:    sw s1, 200(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s1, 332(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a1, a1, a2
-; RV32I-NEXT:    lw a2, 204(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 336(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, s1, a2
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    and a2, s7, t4
@@ -18500,11 +18500,11 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    and a2, s7, t5
 ; RV32I-NEXT:    addi s4, t6, -1
 ; RV32I-NEXT:    seqz t4, a2
-; RV32I-NEXT:    lw a2, 192(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 324(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, s4, a2
 ; RV32I-NEXT:    addi s1, t4, -1
 ; RV32I-NEXT:    xor a1, a1, a2
-; RV32I-NEXT:    lw a2, 196(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 328(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, s1, a2
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    and a2, s7, s0
@@ -18512,17 +18512,17 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz t3, a2
 ; RV32I-NEXT:    addi t6, t3, -1
 ; RV32I-NEXT:    and a0, s7, s3
-; RV32I-NEXT:    lw a1, 176(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 788(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, t6, a1
 ; RV32I-NEXT:    seqz a7, a0
 ; RV32I-NEXT:    addi t4, a7, -1
 ; RV32I-NEXT:    and a0, s7, s5
-; RV32I-NEXT:    lw a2, 188(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 320(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, t4, a2
 ; RV32I-NEXT:    seqz a6, a0
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    addi t3, a6, -1
-; RV32I-NEXT:    lw a0, 164(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 776(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a0, t3, a0
 ; RV32I-NEXT:    lui a2, 128
 ; RV32I-NEXT:    and a2, s7, a2
@@ -18530,29 +18530,29 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz a5, a2
 ; RV32I-NEXT:    addi a7, a5, -1
 ; RV32I-NEXT:    and a1, s7, s11
-; RV32I-NEXT:    lw a2, 180(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 792(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a7, a2
 ; RV32I-NEXT:    seqz s0, a1
 ; RV32I-NEXT:    xor a0, a0, a2
 ; RV32I-NEXT:    addi s0, s0, -1
-; RV32I-NEXT:    sw s0, 204(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a1, 152(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw s0, 336(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a1, 764(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, s0, a1
 ; RV32I-NEXT:    lui a2, 512
 ; RV32I-NEXT:    and a2, s7, a2
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    seqz s3, a2
 ; RV32I-NEXT:    addi s3, s3, -1
-; RV32I-NEXT:    sw s3, 192(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s3, 324(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui a1, 1024
 ; RV32I-NEXT:    and a1, s7, a1
-; RV32I-NEXT:    lw a2, 172(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 784(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, s3, a2
 ; RV32I-NEXT:    seqz a3, a1
 ; RV32I-NEXT:    xor t5, a0, a2
 ; RV32I-NEXT:    addi a3, a3, -1
-; RV32I-NEXT:    sw a3, 196(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a0, 140(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a3, 328(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a0, 752(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a0, a3, a0
 ; RV32I-NEXT:    lui a1, 2048
 ; RV32I-NEXT:    and a1, s7, a1
@@ -18560,12 +18560,12 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    and a1, s7, s10
 ; RV32I-NEXT:    addi t0, t0, -1
 ; RV32I-NEXT:    seqz t2, a1
-; RV32I-NEXT:    lw a1, 168(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 780(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, t0, a1
 ; RV32I-NEXT:    addi t2, t2, -1
-; RV32I-NEXT:    sw t2, 188(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t2, 320(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a0, a0, a1
-; RV32I-NEXT:    lw a1, 136(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 748(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, t2, a1
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    and a1, s7, s2
@@ -18574,11 +18574,11 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    and a1, s7, a1
 ; RV32I-NEXT:    addi a5, a4, -1
 ; RV32I-NEXT:    seqz a1, a1
-; RV32I-NEXT:    lw a2, 160(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 772(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a5, a2
 ; RV32I-NEXT:    addi a4, a1, -1
 ; RV32I-NEXT:    xor a0, a0, a2
-; RV32I-NEXT:    lw a2, 148(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 760(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a4, a2
 ; RV32I-NEXT:    xor s2, a0, a2
 ; RV32I-NEXT:    lui a0, 32768
@@ -18589,127 +18589,127 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    mv a1, s7
 ; RV32I-NEXT:    addi a3, a2, -1
 ; RV32I-NEXT:    seqz a0, a0
-; RV32I-NEXT:    lw a2, 156(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 768(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a3, a2
 ; RV32I-NEXT:    addi a2, a0, -1
 ; RV32I-NEXT:    xor s2, s2, s7
-; RV32I-NEXT:    lw a0, 144(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 756(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a2, a0
 ; RV32I-NEXT:    xor t5, t1, t5
 ; RV32I-NEXT:    xor s2, s2, s7
 ; RV32I-NEXT:    xor t1, s8, ra
 ; RV32I-NEXT:    xor t5, t5, s2
-; RV32I-NEXT:    lw a0, 640(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s2, 524(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 228(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s2, 588(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s2, s2, a0
-; RV32I-NEXT:    lw a0, 520(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t2, 384(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 584(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t2, 448(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s5, a0, t2
-; RV32I-NEXT:    lw a0, 636(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s7, 516(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 224(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 580(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, a0
-; RV32I-NEXT:    lw a0, 632(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s8, 512(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 220(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s8, 576(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s8, s8, a0
 ; RV32I-NEXT:    xor s2, s5, s2
 ; RV32I-NEXT:    xor s5, s7, s8
-; RV32I-NEXT:    lw a0, 628(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s7, 500(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 692(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 564(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, a0
-; RV32I-NEXT:    lw a0, 624(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s8, 496(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 688(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s8, 560(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s8, s8, a0
+; RV32I-NEXT:    xor s7, s7, s8
+; RV32I-NEXT:    lw a0, 684(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s8, 556(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s8, s8, a0
+; RV32I-NEXT:    xor s2, s2, s5
+; RV32I-NEXT:    xor s5, s7, s8
+; RV32I-NEXT:    lw a0, 680(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 552(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s7, s7, a0
+; RV32I-NEXT:    lw a0, 676(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s8, 548(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s8, s8, a0
+; RV32I-NEXT:    xor s7, s7, s8
+; RV32I-NEXT:    lw a0, 672(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s8, 544(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s8, s8, a0
+; RV32I-NEXT:    xor s7, s7, s8
+; RV32I-NEXT:    lw a0, 668(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s8, 540(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s8, s8, a0
+; RV32I-NEXT:    xor s2, s2, s5
+; RV32I-NEXT:    xor s5, s7, s8
+; RV32I-NEXT:    lw a0, 664(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 532(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s7, s7, a0
+; RV32I-NEXT:    lw a0, 660(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s8, 528(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s8, s8, a0
+; RV32I-NEXT:    xor s7, s7, s8
+; RV32I-NEXT:    lw a0, 656(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s8, 524(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s8, s8, a0
+; RV32I-NEXT:    xor s7, s7, s8
+; RV32I-NEXT:    lw a0, 652(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s8, 520(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s8, s8, a0
+; RV32I-NEXT:    xor s7, s7, s8
+; RV32I-NEXT:    lw a0, 648(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s8, 516(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s8, s8, a0
+; RV32I-NEXT:    xor s2, s2, s5
+; RV32I-NEXT:    xor s5, s7, s8
+; RV32I-NEXT:    lw a0, 644(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 512(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s7, s7, a0
+; RV32I-NEXT:    lw a0, 640(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s8, 508(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s8, s8, a0
+; RV32I-NEXT:    xor s7, s7, s8
+; RV32I-NEXT:    lw a0, 636(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s8, 504(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s8, s8, a0
+; RV32I-NEXT:    xor s7, s7, s8
+; RV32I-NEXT:    lw a0, 632(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s8, 500(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s8, s8, a0
 ; RV32I-NEXT:    xor s7, s7, s8
 ; RV32I-NEXT:    lw a0, 620(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s8, 496(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s8, s8, a0
+; RV32I-NEXT:    xor s7, s7, s8
+; RV32I-NEXT:    lw a0, 612(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw s8, 492(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s8, s8, a0
 ; RV32I-NEXT:    xor s2, s2, s5
 ; RV32I-NEXT:    xor s5, s7, s8
-; RV32I-NEXT:    lw a0, 616(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 628(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw s7, 488(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, a0
-; RV32I-NEXT:    lw a0, 612(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 624(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw s8, 484(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s8, s8, a0
 ; RV32I-NEXT:    xor s7, s7, s8
-; RV32I-NEXT:    lw a0, 608(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 616(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw s8, 480(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s8, s8, a0
 ; RV32I-NEXT:    xor s7, s7, s8
 ; RV32I-NEXT:    lw a0, 604(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw s8, 476(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s8, s8, a0
-; RV32I-NEXT:    xor s2, s2, s5
-; RV32I-NEXT:    xor s5, s7, s8
+; RV32I-NEXT:    xor s7, s7, s8
 ; RV32I-NEXT:    lw a0, 600(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s7, 468(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s7, s7, a0
+; RV32I-NEXT:    lw t2, 472(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s8, t2, a0
+; RV32I-NEXT:    xor s7, s7, s8
 ; RV32I-NEXT:    lw a0, 596(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s8, 464(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s8, s8, a0
+; RV32I-NEXT:    lw t2, 468(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s8, t2, a0
 ; RV32I-NEXT:    xor s7, s7, s8
 ; RV32I-NEXT:    lw a0, 592(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s8, 460(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s8, s8, a0
-; RV32I-NEXT:    xor s7, s7, s8
-; RV32I-NEXT:    lw a0, 588(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s8, 456(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s8, s8, a0
-; RV32I-NEXT:    xor s7, s7, s8
-; RV32I-NEXT:    lw a0, 584(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s8, 452(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s8, s8, a0
-; RV32I-NEXT:    xor s2, s2, s5
-; RV32I-NEXT:    xor s5, s7, s8
-; RV32I-NEXT:    lw a0, 580(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s7, 448(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s7, s7, a0
-; RV32I-NEXT:    lw a0, 576(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s8, 444(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s8, s8, a0
-; RV32I-NEXT:    xor s7, s7, s8
-; RV32I-NEXT:    lw a0, 572(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s8, 440(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s8, s8, a0
-; RV32I-NEXT:    xor s7, s7, s8
-; RV32I-NEXT:    lw a0, 568(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s8, 436(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s8, s8, a0
-; RV32I-NEXT:    xor s7, s7, s8
-; RV32I-NEXT:    lw a0, 556(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s8, 432(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s8, s8, a0
-; RV32I-NEXT:    xor s7, s7, s8
-; RV32I-NEXT:    lw a0, 548(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s8, 428(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s8, s8, a0
-; RV32I-NEXT:    xor s2, s2, s5
-; RV32I-NEXT:    xor s5, s7, s8
-; RV32I-NEXT:    lw a0, 564(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s7, 424(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s7, s7, a0
-; RV32I-NEXT:    lw a0, 560(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s8, 420(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s8, s8, a0
-; RV32I-NEXT:    xor s7, s7, s8
-; RV32I-NEXT:    lw a0, 552(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s8, 416(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s8, s8, a0
-; RV32I-NEXT:    xor s7, s7, s8
-; RV32I-NEXT:    lw a0, 540(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s8, 412(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s8, s8, a0
-; RV32I-NEXT:    xor s7, s7, s8
-; RV32I-NEXT:    lw a0, 536(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t2, 408(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s8, t2, a0
-; RV32I-NEXT:    xor s7, s7, s8
-; RV32I-NEXT:    lw a0, 532(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t2, 404(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s8, t2, a0
-; RV32I-NEXT:    xor s7, s7, s8
-; RV32I-NEXT:    lw a0, 528(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t2, 400(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t2, 464(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s8, t2, a0
 ; RV32I-NEXT:    xor s2, s2, s5
 ; RV32I-NEXT:    xor s5, s7, s8
@@ -18720,37 +18720,37 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    seqz s7, s7
 ; RV32I-NEXT:    seqz ra, s8
 ; RV32I-NEXT:    addi s7, s7, -1
-; RV32I-NEXT:    sw s7, 640(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s7, 228(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi ra, ra, -1
-; RV32I-NEXT:    sw ra, 636(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a0, 256(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw ra, 224(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a0, 804(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, a0
-; RV32I-NEXT:    lw a0, 252(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 800(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, ra, a0
 ; RV32I-NEXT:    xor s7, s7, s10
 ; RV32I-NEXT:    xor s2, s2, s5
-; RV32I-NEXT:    lw a0, 508(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t2, 396(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 572(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t2, 460(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s5, t2, a0
-; RV32I-NEXT:    lw a0, 504(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t2, 388(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 568(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t2, 452(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s10, t2, a0
 ; RV32I-NEXT:    xor s5, s5, s10
 ; RV32I-NEXT:    srli s10, a1, 31
-; RV32I-NEXT:    lw a0, 472(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 392(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 536(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 456(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s11, a1, a0
 ; RV32I-NEXT:    seqz s10, s10
 ; RV32I-NEXT:    xor s5, s5, s11
 ; RV32I-NEXT:    addi s10, s10, -1
-; RV32I-NEXT:    sw s10, 632(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s10, 220(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor s2, s2, s5
-; RV32I-NEXT:    lw a0, 260(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 808(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s5, s10, a0
 ; RV32I-NEXT:    xor s5, s7, s5
 ; RV32I-NEXT:    srli s7, s2, 8
 ; RV32I-NEXT:    xor t5, t5, s5
-; RV32I-NEXT:    lw a0, 652(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s5, s7, a0
 ; RV32I-NEXT:    and s7, s2, a0
 ; RV32I-NEXT:    srli s11, s2, 24
@@ -18760,24 +18760,24 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    or s2, s2, s7
 ; RV32I-NEXT:    xor t1, t5, t1
 ; RV32I-NEXT:    or t5, s2, s5
-; RV32I-NEXT:    lw a0, 0(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 700(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    xor t1, a0, t1
 ; RV32I-NEXT:    srli s2, t5, 4
-; RV32I-NEXT:    lw a0, 104(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 736(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s2, s2, a0
 ; RV32I-NEXT:    and t5, t5, a0
-; RV32I-NEXT:    lw a0, 700(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 264(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 812(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s5, a1, a0
-; RV32I-NEXT:    lw a1, 268(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t2, 656(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 816(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t2, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a1, t2
 ; RV32I-NEXT:    slli s7, s7, 1
 ; RV32I-NEXT:    slli t5, t5, 4
 ; RV32I-NEXT:    or s5, s5, s7
 ; RV32I-NEXT:    or t5, s2, t5
 ; RV32I-NEXT:    srli s2, t5, 2
-; RV32I-NEXT:    lw a1, 648(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t5, t5, a1
 ; RV32I-NEXT:    and s2, s2, a1
 ; RV32I-NEXT:    slli t5, t5, 2
@@ -18787,375 +18787,375 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32I-NEXT:    srli s2, t5, 1
 ; RV32I-NEXT:    and s2, s2, a0
 ; RV32I-NEXT:    and t5, t5, t2
-; RV32I-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 704(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli s5, a0, 1
 ; RV32I-NEXT:    slli s7, t5, 1
 ; RV32I-NEXT:    xor a0, t1, s5
-; RV32I-NEXT:    sw a0, 700(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    or a0, s2, s7
-; RV32I-NEXT:    sw a0, 656(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a0, 128(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 760(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a0, 740(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 116(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s2, a1, a0
-; RV32I-NEXT:    lw a0, 544(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 756(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 608(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 112(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s5, a1, a0
-; RV32I-NEXT:    lw a0, 124(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 744(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 316(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 100(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a1, a0
-; RV32I-NEXT:    lw a0, 120(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 740(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 312(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 96(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s11, a1, a0
 ; RV32I-NEXT:    xor s2, s5, s2
 ; RV32I-NEXT:    xor s5, s7, s11
-; RV32I-NEXT:    lw a0, 116(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 308(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s6, a0
-; RV32I-NEXT:    lw a0, 112(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 728(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 304(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 84(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s11, a1, a0
+; RV32I-NEXT:    xor s7, s7, s11
+; RV32I-NEXT:    lw a0, 300(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 76(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s11, a1, a0
+; RV32I-NEXT:    xor s2, s2, s5
+; RV32I-NEXT:    xor s5, s7, s11
+; RV32I-NEXT:    lw a0, 296(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 68(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s7, a1, a0
+; RV32I-NEXT:    lw a0, 292(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 64(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s11, a1, a0
+; RV32I-NEXT:    xor s7, s7, s11
+; RV32I-NEXT:    lw a0, 288(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 60(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s11, a1, a0
+; RV32I-NEXT:    xor s7, s7, s11
+; RV32I-NEXT:    lw a0, 176(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 284(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s11, a0, a1
+; RV32I-NEXT:    xor s2, s2, s5
+; RV32I-NEXT:    xor s5, s7, s11
+; RV32I-NEXT:    lw a0, 0(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 280(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s7, a0, a1
+; RV32I-NEXT:    lw a0, 172(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 276(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s11, a0, a1
+; RV32I-NEXT:    xor s7, s7, s11
+; RV32I-NEXT:    lw a0, 168(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 272(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s11, a0, a1
+; RV32I-NEXT:    xor s7, s7, s11
+; RV32I-NEXT:    lw a0, 164(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 268(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s11, a0, a1
+; RV32I-NEXT:    xor s7, s7, s11
+; RV32I-NEXT:    lw a0, 160(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 264(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s11, a0, a1
+; RV32I-NEXT:    xor s2, s2, s5
+; RV32I-NEXT:    xor s5, s7, s11
+; RV32I-NEXT:    lw a0, 156(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 260(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s7, a0, a1
+; RV32I-NEXT:    lw a0, 152(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 256(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s11, a0, a1
+; RV32I-NEXT:    xor s7, s7, s11
+; RV32I-NEXT:    lw a0, 148(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 732(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s11, a0, a1
+; RV32I-NEXT:    xor s7, s7, s11
+; RV32I-NEXT:    lw a0, 144(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 728(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s11, a0, a1
+; RV32I-NEXT:    xor s7, s7, s11
+; RV32I-NEXT:    lw a0, 140(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 252(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s11, a0, a1
+; RV32I-NEXT:    xor s7, s7, s11
+; RV32I-NEXT:    lw a0, 136(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 724(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s11, a0, a1
+; RV32I-NEXT:    xor s2, s2, s5
+; RV32I-NEXT:    xor s5, s7, s11
+; RV32I-NEXT:    lw a0, 132(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 720(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s7, a0, a1
+; RV32I-NEXT:    lw a0, 128(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 716(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s11, a0, a1
+; RV32I-NEXT:    xor s7, s7, s11
+; RV32I-NEXT:    lw a0, 696(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 124(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s11, a1, a0
+; RV32I-NEXT:    xor s7, s7, s11
+; RV32I-NEXT:    lw a0, 120(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 248(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s11, a0, a1
 ; RV32I-NEXT:    xor s7, s7, s11
 ; RV32I-NEXT:    lw a0, 108(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 720(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s11, a1, a0
-; RV32I-NEXT:    xor s2, s2, s5
-; RV32I-NEXT:    xor s5, s7, s11
-; RV32I-NEXT:    lw a0, 100(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 712(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s7, a1, a0
-; RV32I-NEXT:    lw a0, 96(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 708(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s11, a1, a0
+; RV32I-NEXT:    lw a1, 244(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s11, a0, a1
+; RV32I-NEXT:    xor s7, s7, s11
+; RV32I-NEXT:    lw a0, 104(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 240(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s11, a0, a1
 ; RV32I-NEXT:    xor s7, s7, s11
 ; RV32I-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 704(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s11, a1, a0
-; RV32I-NEXT:    xor s7, s7, s11
-; RV32I-NEXT:    lw a0, 824(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 88(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 236(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s11, a0, a1
 ; RV32I-NEXT:    xor s2, s2, s5
 ; RV32I-NEXT:    xor s5, s7, s11
-; RV32I-NEXT:    lw a0, 820(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 84(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 232(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a0, a1
-; RV32I-NEXT:    lw a0, 816(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 80(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 712(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s11, a0, a1
 ; RV32I-NEXT:    xor s7, s7, s11
-; RV32I-NEXT:    lw a0, 812(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 76(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s11, a0, a1
-; RV32I-NEXT:    xor s7, s7, s11
-; RV32I-NEXT:    lw a0, 808(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 72(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s11, a0, a1
-; RV32I-NEXT:    xor s7, s7, s11
-; RV32I-NEXT:    lw a0, 804(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 68(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s11, a0, a1
-; RV32I-NEXT:    xor s2, s2, s5
-; RV32I-NEXT:    xor s5, s7, s11
-; RV32I-NEXT:    lw a0, 800(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 64(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s7, a0, a1
-; RV32I-NEXT:    lw a0, 796(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 60(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s11, a0, a1
-; RV32I-NEXT:    xor s7, s7, s11
-; RV32I-NEXT:    lw a0, 792(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 56(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s11, a0, a1
-; RV32I-NEXT:    xor s7, s7, s11
-; RV32I-NEXT:    lw a0, 788(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 52(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s11, a0, a1
-; RV32I-NEXT:    xor s7, s7, s11
-; RV32I-NEXT:    lw a0, 784(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 48(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s11, a0, a1
-; RV32I-NEXT:    xor s7, s7, s11
-; RV32I-NEXT:    lw a0, 780(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 44(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s11, a0, a1
-; RV32I-NEXT:    xor s2, s2, s5
-; RV32I-NEXT:    xor s5, s7, s11
-; RV32I-NEXT:    lw a0, 776(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 40(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s7, a0, a1
-; RV32I-NEXT:    lw a0, 772(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 36(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s11, a0, a1
-; RV32I-NEXT:    xor s7, s7, s11
-; RV32I-NEXT:    lw a0, 644(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 768(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s11, a1, a0
-; RV32I-NEXT:    xor s7, s7, s11
-; RV32I-NEXT:    lw a0, 764(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 32(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s11, a0, a1
-; RV32I-NEXT:    xor s7, s7, s11
-; RV32I-NEXT:    lw a0, 752(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s11, a0, a1
-; RV32I-NEXT:    xor s7, s7, s11
-; RV32I-NEXT:    lw a0, 748(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s11, a0, a1
-; RV32I-NEXT:    xor s7, s7, s11
-; RV32I-NEXT:    lw a0, 736(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s11, a0, a1
-; RV32I-NEXT:    xor s2, s2, s5
-; RV32I-NEXT:    xor s5, s7, s11
-; RV32I-NEXT:    lw a0, 732(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s7, a0, a1
-; RV32I-NEXT:    lw a0, 724(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s11, a0, a1
-; RV32I-NEXT:    xor s7, s7, s11
-; RV32I-NEXT:    lw a0, 716(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 708(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s11, a0, a1
 ; RV32I-NEXT:    xor a0, s2, s5
-; RV32I-NEXT:    sw a0, 652(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a0, s7, s11
-; RV32I-NEXT:    sw a0, 648(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw t1, 380(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a0, 276(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw t1, 216(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 388(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s5, a0, t1
-; RV32I-NEXT:    lw a0, 292(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 272(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 392(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 384(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s11, a1, a0
-; RV32I-NEXT:    lw t2, 376(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a0, 244(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t2, 212(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 376(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a0, t2
-; RV32I-NEXT:    lw t5, 372(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a0, 240(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t5, 208(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 372(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a0, a0, t5
 ; RV32I-NEXT:    xor s5, s11, s5
 ; RV32I-NEXT:    xor a0, a1, a0
-; RV32I-NEXT:    lw s0, 368(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 248(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s0, 204(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 380(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, s0
-; RV32I-NEXT:    lw s2, 364(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s3, 216(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s2, 200(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s3, 348(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s11, s3, s2
 ; RV32I-NEXT:    xor a1, a1, s11
-; RV32I-NEXT:    lw s3, 360(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s6, 232(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s3, 196(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s6, 364(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s11, s6, s3
 ; RV32I-NEXT:    xor a0, s5, a0
 ; RV32I-NEXT:    xor a1, a1, s11
-; RV32I-NEXT:    lw s6, 356(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s5, 236(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s6, 192(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s5, 368(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s5, s5, s6
-; RV32I-NEXT:    lw s7, 352(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s8, 224(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 188(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s8, 356(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s11, s8, s7
 ; RV32I-NEXT:    xor s5, s5, s11
-; RV32I-NEXT:    lw s8, 348(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s10, 220(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s8, 184(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 352(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s11, s10, s8
 ; RV32I-NEXT:    xor s5, s5, s11
-; RV32I-NEXT:    lw s10, 344(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s11, 228(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s10, 444(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s11, 360(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s11, s11, s10
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a1, s5, s11
-; RV32I-NEXT:    lw ra, 340(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s5, 288(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 440(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s5, 180(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s5, s5, ra
-; RV32I-NEXT:    lw s11, 696(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s9, 212(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s11, 52(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s9, 344(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s11, s9, s11
 ; RV32I-NEXT:    xor s5, s5, s11
-; RV32I-NEXT:    lw s11, 336(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s9, 200(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s11, 436(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s9, 332(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s9, s9, s11
 ; RV32I-NEXT:    xor s5, s5, s9
-; RV32I-NEXT:    lw s9, 332(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s9, 432(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s4, s9
 ; RV32I-NEXT:    xor s4, s5, s4
-; RV32I-NEXT:    lw s5, 328(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s5, 428(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s1, s1, s5
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a1, s4, s1
-; RV32I-NEXT:    lw s1, 324(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s1, 424(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t6, t6, s1
-; RV32I-NEXT:    lw s4, 320(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s4, 420(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t4, t4, s4
 ; RV32I-NEXT:    xor t4, t6, t4
-; RV32I-NEXT:    lw t6, 316(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t6, 416(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t3, t3, t6
 ; RV32I-NEXT:    xor t3, t4, t3
-; RV32I-NEXT:    lw t4, 312(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t4, 412(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a7, a7, t4
 ; RV32I-NEXT:    xor a7, t3, a7
-; RV32I-NEXT:    lw t3, 692(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 204(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 48(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 336(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t3, a6, t3
 ; RV32I-NEXT:    xor a7, a7, t3
-; RV32I-NEXT:    lw t3, 688(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 192(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 44(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 324(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t3, a6, t3
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a1, a7, t3
-; RV32I-NEXT:    lw t3, 308(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 196(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 408(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 328(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, a6, t3
-; RV32I-NEXT:    lw a7, 684(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 40(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a7, t0, a7
 ; RV32I-NEXT:    xor a6, a6, a7
-; RV32I-NEXT:    lw t0, 296(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a7, 188(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t0, 396(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 320(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a7, a7, t0
 ; RV32I-NEXT:    xor a6, a6, a7
-; RV32I-NEXT:    lw a7, 304(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 404(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, a7
 ; RV32I-NEXT:    xor a5, a6, a5
-; RV32I-NEXT:    lw a6, 680(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 36(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, a6
 ; RV32I-NEXT:    xor a4, a5, a4
-; RV32I-NEXT:    lw a5, 676(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 32(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a5
 ; RV32I-NEXT:    xor a3, a4, a3
-; RV32I-NEXT:    lw a4, 672(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 28(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a2, a4
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a2, a3, a2
-; RV32I-NEXT:    lw a1, 668(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a3, 640(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 228(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a3, a1
-; RV32I-NEXT:    lw a3, 664(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a4, 636(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 20(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 224(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a4, a3
 ; RV32I-NEXT:    xor a1, a1, a3
-; RV32I-NEXT:    lw a3, 660(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a4, 632(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 16(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 220(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a4, a3
 ; RV32I-NEXT:    xor a2, a0, a2
 ; RV32I-NEXT:    xor a1, a1, a3
-; RV32I-NEXT:    lw a0, 652(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a3, 648(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    xor a0, a0, a3
 ; RV32I-NEXT:    xor a1, a2, a1
-; RV32I-NEXT:    lw a2, 760(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 116(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a2, t1
-; RV32I-NEXT:    lw a3, 292(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a4, 756(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 392(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 112(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a4, a3
-; RV32I-NEXT:    lw a4, 744(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 100(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, t2
-; RV32I-NEXT:    lw a5, 740(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 96(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, t5
 ; RV32I-NEXT:    xor a2, a3, a2
 ; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a3, 300(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 400(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, s0
-; RV32I-NEXT:    lw a5, 728(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 84(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, s2
 ; RV32I-NEXT:    xor a3, a3, a5
-; RV32I-NEXT:    lw a5, 720(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 76(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, s3
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    xor a3, a3, a5
-; RV32I-NEXT:    lw a4, 712(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 68(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, s6
-; RV32I-NEXT:    lw a5, 708(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 64(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, s7
 ; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a5, 704(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 60(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, s8
 ; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a5, 824(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 176(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, s10
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a3, 820(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 0(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, ra
-; RV32I-NEXT:    lw a5, 816(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 696(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 172(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 52(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, a6
 ; RV32I-NEXT:    xor a3, a3, a5
-; RV32I-NEXT:    lw a5, 812(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 168(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, s11
 ; RV32I-NEXT:    xor a3, a3, a5
-; RV32I-NEXT:    lw a5, 808(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 164(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, s9
 ; RV32I-NEXT:    xor a3, a3, a5
-; RV32I-NEXT:    lw a5, 804(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 160(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, s5
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    xor a3, a3, a5
-; RV32I-NEXT:    lw a4, 800(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 156(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, s1
-; RV32I-NEXT:    lw a5, 796(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 152(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, s4
 ; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a5, 792(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 148(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, t6
 ; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a5, 788(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 144(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, t4
 ; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a5, 784(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 692(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 140(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 48(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, a6
 ; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a5, 780(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 688(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 136(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 44(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, a6
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a3, 776(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 132(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, t3
-; RV32I-NEXT:    lw a5, 772(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 684(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 128(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 40(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, a6
 ; RV32I-NEXT:    xor a3, a3, a5
-; RV32I-NEXT:    lw a5, 768(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 124(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, t0
 ; RV32I-NEXT:    xor a3, a3, a5
-; RV32I-NEXT:    lw a5, 764(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 120(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, a7
 ; RV32I-NEXT:    xor a3, a3, a5
-; RV32I-NEXT:    lw a5, 752(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 680(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 108(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 36(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, a6
 ; RV32I-NEXT:    xor a3, a3, a5
-; RV32I-NEXT:    lw a5, 748(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 676(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 104(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 32(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, a6
 ; RV32I-NEXT:    xor a3, a3, a5
-; RV32I-NEXT:    lw a5, 736(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 672(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 92(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 28(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, a6
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    xor a3, a3, a5
 ; RV32I-NEXT:    xor a0, a1, a0
 ; RV32I-NEXT:    xor a2, a2, a3
-; RV32I-NEXT:    lw a1, 732(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a3, 668(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 88(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, a3
-; RV32I-NEXT:    lw a3, 724(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a4, 664(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 80(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 20(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a4
 ; RV32I-NEXT:    xor a1, a1, a3
-; RV32I-NEXT:    lw a3, 716(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a4, 660(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 72(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 16(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a4
 ; RV32I-NEXT:    xor a1, a1, a3
-; RV32I-NEXT:    lw a3, 656(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli a3, a3, 1
 ; RV32I-NEXT:    xor a0, a3, a0
 ; RV32I-NEXT:    xor a1, a2, a1
-; RV32I-NEXT:    lw a2, 284(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 824(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    sw a1, 0(a2)
 ; RV32I-NEXT:    sw a0, 4(a2)
-; RV32I-NEXT:    lw a0, 208(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 340(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    sw a0, 8(a2)
-; RV32I-NEXT:    lw a0, 700(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    sw a0, 12(a2)
 ; RV32I-NEXT:    lw ra, 876(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw s0, 872(sp) # 4-byte Folded Reload
@@ -19243,7 +19243,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    and t1, a3, a5
 ; RV64I-NEXT:    slli t1, t1, 40
 ; RV64I-NEXT:    slli a0, a3, 56
-; RV64I-NEXT:    sd a0, 944(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 1032(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    or t1, a0, t1
 ; RV64I-NEXT:    lui t2, 61681
 ; RV64I-NEXT:    or t0, t1, t0
@@ -19373,7 +19373,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    li t5, 1
 ; RV64I-NEXT:    addi s2, s2, -1
 ; RV64I-NEXT:    slli a0, t5, 11
-; RV64I-NEXT:    sd a0, 424(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 64(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and s1, s2, s1
 ; RV64I-NEXT:    and s2, t4, a0
 ; RV64I-NEXT:    xor s0, s0, s1
@@ -19525,7 +19525,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    seqz s1, s2
 ; RV64I-NEXT:    addi s1, s1, -1
 ; RV64I-NEXT:    slli a0, t5, 33
-; RV64I-NEXT:    sd a0, 408(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 56(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli s2, t2, 32
 ; RV64I-NEXT:    and s3, t4, a0
 ; RV64I-NEXT:    and s1, s1, s2
@@ -19556,7 +19556,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    slli s2, t2, 36
 ; RV64I-NEXT:    and s1, s1, s2
 ; RV64I-NEXT:    slli a0, t5, 37
-; RV64I-NEXT:    sd a0, 400(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    xor s0, s0, s1
 ; RV64I-NEXT:    and s1, t4, a0
 ; RV64I-NEXT:    xor t6, t6, s0
@@ -19577,14 +19577,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    addi s2, s2, -1
 ; RV64I-NEXT:    slli s1, t2, 39
 ; RV64I-NEXT:    slli a0, t5, 40
-; RV64I-NEXT:    sd a0, 392(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and s1, s2, s1
 ; RV64I-NEXT:    and s2, t4, a0
 ; RV64I-NEXT:    xor s0, s0, s1
 ; RV64I-NEXT:    seqz s1, s2
 ; RV64I-NEXT:    addi s1, s1, -1
 ; RV64I-NEXT:    slli a0, t5, 41
-; RV64I-NEXT:    sd a0, 384(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli s2, t2, 40
 ; RV64I-NEXT:    and s3, t4, a0
 ; RV64I-NEXT:    and s1, s1, s2
@@ -19593,14 +19593,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    addi s2, s2, -1
 ; RV64I-NEXT:    slli s1, t2, 41
 ; RV64I-NEXT:    slli a0, t5, 42
-; RV64I-NEXT:    sd a0, 376(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and s1, s2, s1
 ; RV64I-NEXT:    and s2, t4, a0
 ; RV64I-NEXT:    xor s0, s0, s1
 ; RV64I-NEXT:    seqz s1, s2
 ; RV64I-NEXT:    addi s1, s1, -1
 ; RV64I-NEXT:    slli a0, t5, 43
-; RV64I-NEXT:    sd a0, 368(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 504(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli s2, t2, 42
 ; RV64I-NEXT:    and s3, t4, a0
 ; RV64I-NEXT:    and s1, s1, s2
@@ -19609,14 +19609,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    addi s2, s2, -1
 ; RV64I-NEXT:    slli s1, t2, 43
 ; RV64I-NEXT:    slli a0, t5, 44
-; RV64I-NEXT:    sd a0, 360(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 496(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and s1, s2, s1
 ; RV64I-NEXT:    and s2, t4, a0
 ; RV64I-NEXT:    xor s0, s0, s1
 ; RV64I-NEXT:    seqz s1, s2
 ; RV64I-NEXT:    addi s1, s1, -1
 ; RV64I-NEXT:    slli a0, t5, 45
-; RV64I-NEXT:    sd a0, 352(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 488(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli s2, t2, 44
 ; RV64I-NEXT:    and s3, t4, a0
 ; RV64I-NEXT:    and s1, s1, s2
@@ -19627,12 +19627,12 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    and s1, s2, s3
 ; RV64I-NEXT:    xor s0, s0, s1
 ; RV64I-NEXT:    slli a0, t5, 46
-; RV64I-NEXT:    sd a0, 336(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 472(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    xor t6, t6, s0
 ; RV64I-NEXT:    and s0, t4, a0
 ; RV64I-NEXT:    seqz s0, s0
 ; RV64I-NEXT:    slli a0, t5, 47
-; RV64I-NEXT:    sd a0, 344(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 480(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    addi s0, s0, -1
 ; RV64I-NEXT:    and s1, t4, a0
 ; RV64I-NEXT:    seqz s1, s1
@@ -19641,14 +19641,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    addi s1, s1, -1
 ; RV64I-NEXT:    slli s2, t2, 47
 ; RV64I-NEXT:    slli a0, t5, 48
-; RV64I-NEXT:    sd a0, 328(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 464(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and s1, s1, s2
 ; RV64I-NEXT:    and s2, t4, a0
 ; RV64I-NEXT:    xor s0, s0, s1
 ; RV64I-NEXT:    seqz s1, s2
 ; RV64I-NEXT:    addi s1, s1, -1
 ; RV64I-NEXT:    slli a0, t5, 49
-; RV64I-NEXT:    sd a0, 320(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 456(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli s2, t2, 48
 ; RV64I-NEXT:    and s3, t4, a0
 ; RV64I-NEXT:    and s1, s1, s2
@@ -19657,14 +19657,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    addi s2, s2, -1
 ; RV64I-NEXT:    slli s1, t2, 49
 ; RV64I-NEXT:    slli a0, t5, 50
-; RV64I-NEXT:    sd a0, 1000(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 112(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and s1, s2, s1
 ; RV64I-NEXT:    and s2, t4, a0
 ; RV64I-NEXT:    xor s0, s0, s1
 ; RV64I-NEXT:    seqz s1, s2
 ; RV64I-NEXT:    addi s1, s1, -1
 ; RV64I-NEXT:    slli a0, t5, 51
-; RV64I-NEXT:    sd a0, 1040(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli s2, t2, 50
 ; RV64I-NEXT:    and s3, t4, a0
 ; RV64I-NEXT:    and s1, s1, s2
@@ -19673,14 +19673,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    addi s2, s2, -1
 ; RV64I-NEXT:    slli s1, t2, 51
 ; RV64I-NEXT:    slli a0, t5, 52
-; RV64I-NEXT:    sd a0, 1032(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 144(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and s1, s2, s1
 ; RV64I-NEXT:    and s2, t4, a0
 ; RV64I-NEXT:    xor s0, s0, s1
 ; RV64I-NEXT:    seqz s1, s2
 ; RV64I-NEXT:    addi s1, s1, -1
 ; RV64I-NEXT:    slli a0, t5, 53
-; RV64I-NEXT:    sd a0, 1024(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 136(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli s2, t2, 52
 ; RV64I-NEXT:    and s3, t4, a0
 ; RV64I-NEXT:    and s1, s1, s2
@@ -19689,14 +19689,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    addi s2, s2, -1
 ; RV64I-NEXT:    slli s1, t2, 53
 ; RV64I-NEXT:    slli a0, t5, 54
-; RV64I-NEXT:    sd a0, 1016(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 128(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and s1, s2, s1
 ; RV64I-NEXT:    and s2, t4, a0
 ; RV64I-NEXT:    xor s0, s0, s1
 ; RV64I-NEXT:    seqz s1, s2
 ; RV64I-NEXT:    addi s1, s1, -1
 ; RV64I-NEXT:    slli a0, t5, 55
-; RV64I-NEXT:    sd a0, 1008(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 120(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli s2, t2, 54
 ; RV64I-NEXT:    and s3, t4, a0
 ; RV64I-NEXT:    and s1, s1, s2
@@ -19707,19 +19707,19 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    slli s7, t5, 56
 ; RV64I-NEXT:    and s1, s2, s1
 ; RV64I-NEXT:    and s2, t4, s7
-; RV64I-NEXT:    sd s7, 304(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd s7, 440(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    xor s0, s0, s1
 ; RV64I-NEXT:    seqz s1, s2
 ; RV64I-NEXT:    addi s1, s1, -1
 ; RV64I-NEXT:    slli a0, t5, 57
-; RV64I-NEXT:    sd a0, 288(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 424(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli s2, t2, 56
 ; RV64I-NEXT:    and s3, t4, a0
 ; RV64I-NEXT:    and s1, s1, s2
 ; RV64I-NEXT:    seqz s2, s3
 ; RV64I-NEXT:    addi s2, s2, -1
 ; RV64I-NEXT:    slli a0, t5, 58
-; RV64I-NEXT:    sd a0, 992(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 104(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli s3, t2, 57
 ; RV64I-NEXT:    and s4, t4, a0
 ; RV64I-NEXT:    and s2, s2, s3
@@ -19728,14 +19728,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    addi s3, s3, -1
 ; RV64I-NEXT:    slli s2, t2, 58
 ; RV64I-NEXT:    slli a0, t5, 59
-; RV64I-NEXT:    sd a0, 984(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 96(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and s2, s3, s2
 ; RV64I-NEXT:    and s3, t4, a0
 ; RV64I-NEXT:    xor s1, s1, s2
 ; RV64I-NEXT:    seqz s2, s3
 ; RV64I-NEXT:    addi s2, s2, -1
 ; RV64I-NEXT:    slli a0, t5, 60
-; RV64I-NEXT:    sd a0, 976(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 88(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli s3, t2, 59
 ; RV64I-NEXT:    and s4, t4, a0
 ; RV64I-NEXT:    and s2, s2, s3
@@ -19744,14 +19744,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    addi s3, s3, -1
 ; RV64I-NEXT:    slli s2, t2, 60
 ; RV64I-NEXT:    slli a0, t5, 61
-; RV64I-NEXT:    sd a0, 960(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 72(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and s2, s3, s2
 ; RV64I-NEXT:    and s3, t4, a0
 ; RV64I-NEXT:    xor s1, s1, s2
 ; RV64I-NEXT:    seqz s2, s3
 ; RV64I-NEXT:    addi s2, s2, -1
 ; RV64I-NEXT:    slli t5, t5, 62
-; RV64I-NEXT:    sd t5, 968(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd t5, 80(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and t4, t4, t5
 ; RV64I-NEXT:    slli t5, t2, 61
 ; RV64I-NEXT:    and t5, s2, t5
@@ -19807,27 +19807,27 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    slli a4, a4, 1
 ; RV64I-NEXT:    seqz a6, a6
 ; RV64I-NEXT:    or a4, a5, a4
-; RV64I-NEXT:    sd a4, 952(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a4, 1040(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    addi a6, a6, -1
-; RV64I-NEXT:    sd a6, 936(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a6, 1024(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a4, a1, 1
 ; RV64I-NEXT:    andi a5, a2, 1
 ; RV64I-NEXT:    and a4, a6, a4
 ; RV64I-NEXT:    seqz a5, a5
 ; RV64I-NEXT:    addi a0, a5, -1
-; RV64I-NEXT:    sd a0, 928(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 1016(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    andi a5, a2, 4
 ; RV64I-NEXT:    seqz a5, a5
 ; RV64I-NEXT:    and a6, a0, a1
 ; RV64I-NEXT:    xor a4, a6, a4
 ; RV64I-NEXT:    addi a0, a5, -1
-; RV64I-NEXT:    sd a0, 920(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 1008(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a5, a1, 2
 ; RV64I-NEXT:    andi a6, a2, 8
 ; RV64I-NEXT:    and a5, a0, a5
 ; RV64I-NEXT:    seqz a6, a6
 ; RV64I-NEXT:    addi a0, a6, -1
-; RV64I-NEXT:    sd a0, 912(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 1000(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 3
 ; RV64I-NEXT:    and a6, a0, a6
 ; RV64I-NEXT:    andi a7, a2, 16
@@ -19835,20 +19835,20 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    xor a4, a4, a5
 ; RV64I-NEXT:    addi a0, a6, -1
-; RV64I-NEXT:    sd a0, 904(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 992(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a5, a1, 4
 ; RV64I-NEXT:    andi a6, a2, 32
 ; RV64I-NEXT:    and a5, a0, a5
 ; RV64I-NEXT:    seqz a6, a6
 ; RV64I-NEXT:    addi a0, a6, -1
-; RV64I-NEXT:    sd a0, 896(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 984(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 5
 ; RV64I-NEXT:    and a6, a0, a6
 ; RV64I-NEXT:    andi a7, a2, 64
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a0, a6, -1
-; RV64I-NEXT:    sd a0, 888(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 976(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 6
 ; RV64I-NEXT:    and a6, a0, a6
 ; RV64I-NEXT:    andi a7, a2, 128
@@ -19856,43 +19856,43 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    xor a4, a4, a5
 ; RV64I-NEXT:    addi a0, a6, -1
-; RV64I-NEXT:    sd a0, 880(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 968(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a5, a1, 7
 ; RV64I-NEXT:    andi a6, a2, 256
 ; RV64I-NEXT:    and a5, a0, a5
 ; RV64I-NEXT:    seqz a6, a6
 ; RV64I-NEXT:    addi a0, a6, -1
-; RV64I-NEXT:    sd a0, 872(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 960(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 8
 ; RV64I-NEXT:    and a6, a0, a6
 ; RV64I-NEXT:    andi a7, a2, 512
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a0, a6, -1
-; RV64I-NEXT:    sd a0, 864(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 952(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 9
 ; RV64I-NEXT:    and a6, a0, a6
 ; RV64I-NEXT:    andi a7, a2, 1024
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a0, a6, -1
-; RV64I-NEXT:    sd a0, 856(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 944(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 10
 ; RV64I-NEXT:    and a6, a0, a6
-; RV64I-NEXT:    ld a0, 424(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a0, 64(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a7, a2, a0
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    xor a4, a4, a5
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 848(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 936(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a5, a1, 11
 ; RV64I-NEXT:    lui a6, 1
 ; RV64I-NEXT:    and a6, a2, a6
 ; RV64I-NEXT:    and a5, a7, a5
 ; RV64I-NEXT:    seqz a6, a6
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 840(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 928(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 12
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    lui a7, 2
@@ -19900,7 +19900,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 832(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 920(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 13
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    lui a7, 4
@@ -19909,14 +19909,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    xor a4, a4, a5
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 824(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 912(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a5, a1, 14
 ; RV64I-NEXT:    lui a6, 8
 ; RV64I-NEXT:    and a6, a2, a6
 ; RV64I-NEXT:    and a5, a7, a5
 ; RV64I-NEXT:    seqz a6, a6
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 816(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 904(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 15
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    lui a7, 16
@@ -19924,7 +19924,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 808(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 896(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 16
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    lui a7, 32
@@ -19932,7 +19932,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 800(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 888(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 17
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    lui a7, 64
@@ -19940,7 +19940,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 792(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 880(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 18
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    lui a7, 128
@@ -19949,14 +19949,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    xor a4, a4, a5
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 784(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 872(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a5, a1, 19
 ; RV64I-NEXT:    lui a6, 256
 ; RV64I-NEXT:    and a6, a2, a6
 ; RV64I-NEXT:    and a5, a7, a5
 ; RV64I-NEXT:    seqz a6, a6
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 776(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 864(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 20
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    lui a7, 512
@@ -19964,7 +19964,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 768(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 856(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 21
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    lui a7, 1024
@@ -19972,7 +19972,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 760(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 848(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 22
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    lui a7, 2048
@@ -19980,7 +19980,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 752(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 840(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 23
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    lui a7, 4096
@@ -19988,7 +19988,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 744(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 832(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 24
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    lui a7, 8192
@@ -19997,14 +19997,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    xor a4, a4, a5
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 736(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 824(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a5, a1, 25
 ; RV64I-NEXT:    lui a6, 16384
 ; RV64I-NEXT:    and a6, a2, a6
 ; RV64I-NEXT:    and a5, a7, a5
 ; RV64I-NEXT:    seqz a6, a6
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 728(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 816(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 26
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    lui a7, 32768
@@ -20012,7 +20012,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 720(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 808(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 27
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    lui a7, 65536
@@ -20020,7 +20020,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 712(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 800(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 28
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    lui a7, 131072
@@ -20028,7 +20028,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 704(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 792(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 29
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    lui a7, 262144
@@ -20036,14 +20036,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 696(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 784(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 30
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    sraiw a7, a2, 31
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 688(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 776(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 31
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    and a7, a2, s6
@@ -20051,50 +20051,50 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    xor a4, a4, a5
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 680(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 768(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a5, a1, 32
-; RV64I-NEXT:    ld t0, 408(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld t0, 56(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a6, a2, t0
 ; RV64I-NEXT:    and a5, a7, a5
 ; RV64I-NEXT:    seqz a6, a6
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 672(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 760(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 33
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    and a7, a2, s10
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 664(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 752(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 34
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    and a7, a2, s11
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 656(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 744(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 35
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    and a7, a2, ra
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 648(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 736(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 36
 ; RV64I-NEXT:    and a6, a7, a6
-; RV64I-NEXT:    ld t1, 400(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld t1, 48(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a7, a2, t1
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 640(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 728(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 37
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    and a7, a2, s9
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 632(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 720(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 38
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    and a7, a2, s8
@@ -20102,190 +20102,190 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    xor a4, a4, a5
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 624(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 712(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a5, a1, 39
-; RV64I-NEXT:    ld t2, 392(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld t2, 40(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a6, a2, t2
 ; RV64I-NEXT:    and a5, a7, a5
 ; RV64I-NEXT:    seqz a6, a6
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 616(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 704(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 40
 ; RV64I-NEXT:    and a6, a7, a6
-; RV64I-NEXT:    ld t3, 384(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld t3, 32(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a7, a2, t3
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 608(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 696(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 41
 ; RV64I-NEXT:    and a6, a7, a6
-; RV64I-NEXT:    ld t4, 376(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld t4, 24(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a7, a2, t4
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 600(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 688(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 42
 ; RV64I-NEXT:    and a6, a7, a6
-; RV64I-NEXT:    ld t5, 368(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld t5, 504(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a7, a2, t5
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 592(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 680(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 43
 ; RV64I-NEXT:    and a6, a7, a6
-; RV64I-NEXT:    ld t6, 360(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld t6, 496(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a7, a2, t6
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 584(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 672(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 44
 ; RV64I-NEXT:    and a6, a7, a6
-; RV64I-NEXT:    ld s0, 352(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s0, 488(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a7, a2, s0
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 576(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 664(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 45
 ; RV64I-NEXT:    and a6, a7, a6
-; RV64I-NEXT:    ld s1, 336(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s1, 472(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a7, a2, s1
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 568(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 656(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 46
 ; RV64I-NEXT:    and a6, a7, a6
-; RV64I-NEXT:    ld s3, 344(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 480(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a7, a2, s3
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    xor a4, a4, a5
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 560(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 648(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a5, a1, 47
-; RV64I-NEXT:    ld s2, 328(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s2, 464(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a6, a2, s2
 ; RV64I-NEXT:    and a5, a7, a5
 ; RV64I-NEXT:    seqz a6, a6
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 552(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 640(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 48
 ; RV64I-NEXT:    and a6, a7, a6
-; RV64I-NEXT:    ld s4, 320(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s4, 456(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a7, a2, s4
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 544(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 632(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 49
 ; RV64I-NEXT:    and a6, a7, a6
-; RV64I-NEXT:    ld a7, 1000(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a7, 112(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a7, a2, a7
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 536(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 624(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 50
 ; RV64I-NEXT:    and a6, a7, a6
-; RV64I-NEXT:    ld a7, 1040(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a7, 16(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a7, a2, a7
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 528(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 616(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 51
 ; RV64I-NEXT:    and a6, a7, a6
-; RV64I-NEXT:    ld a7, 1032(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a7, 144(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a7, a2, a7
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 520(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 608(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 52
 ; RV64I-NEXT:    and a6, a7, a6
-; RV64I-NEXT:    ld a7, 1024(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a7, 136(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a7, a2, a7
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 512(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 600(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 53
 ; RV64I-NEXT:    and a6, a7, a6
-; RV64I-NEXT:    ld a7, 1016(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a7, 128(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a7, a2, a7
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 504(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 592(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 54
 ; RV64I-NEXT:    and a6, a7, a6
-; RV64I-NEXT:    ld a7, 1008(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a7, 120(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a7, a2, a7
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    addi a7, a6, -1
-; RV64I-NEXT:    sd a7, 496(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a7, 584(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a1, 55
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    and a7, a2, s7
 ; RV64I-NEXT:    xor a5, a5, a6
 ; RV64I-NEXT:    seqz a6, a7
 ; RV64I-NEXT:    xor a4, a4, a5
-; RV64I-NEXT:    sd a4, 416(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a4, 512(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    addi a6, a6, -1
-; RV64I-NEXT:    sd a6, 488(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a6, 576(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a4, a1, 56
-; RV64I-NEXT:    ld a7, 288(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a7, 424(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a5, a2, a7
 ; RV64I-NEXT:    and a4, a6, a4
 ; RV64I-NEXT:    seqz a5, a5
 ; RV64I-NEXT:    addi a6, a5, -1
-; RV64I-NEXT:    sd a6, 480(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a6, 568(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a5, a1, 57
 ; RV64I-NEXT:    and a5, a6, a5
-; RV64I-NEXT:    ld a6, 992(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a6, 104(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a6, a2, a6
 ; RV64I-NEXT:    xor a4, a4, a5
 ; RV64I-NEXT:    seqz a5, a6
 ; RV64I-NEXT:    addi a6, a5, -1
-; RV64I-NEXT:    sd a6, 472(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a6, 560(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a5, a1, 58
 ; RV64I-NEXT:    and a5, a6, a5
-; RV64I-NEXT:    ld a6, 984(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a6, 96(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a6, a2, a6
 ; RV64I-NEXT:    xor a4, a4, a5
 ; RV64I-NEXT:    seqz a5, a6
 ; RV64I-NEXT:    addi a6, a5, -1
-; RV64I-NEXT:    sd a6, 464(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a6, 552(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a5, a1, 59
 ; RV64I-NEXT:    and a5, a6, a5
-; RV64I-NEXT:    ld a6, 976(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a6, 88(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a6, a2, a6
 ; RV64I-NEXT:    xor a4, a4, a5
 ; RV64I-NEXT:    seqz a5, a6
 ; RV64I-NEXT:    addi a6, a5, -1
-; RV64I-NEXT:    sd a6, 456(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a6, 544(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a5, a1, 60
 ; RV64I-NEXT:    and a5, a6, a5
-; RV64I-NEXT:    ld a6, 960(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a6, 72(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a6, a2, a6
 ; RV64I-NEXT:    xor a4, a4, a5
 ; RV64I-NEXT:    seqz a5, a6
 ; RV64I-NEXT:    addi a6, a5, -1
-; RV64I-NEXT:    sd a6, 448(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a6, 536(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a5, a1, 61
 ; RV64I-NEXT:    and a5, a6, a5
-; RV64I-NEXT:    ld a6, 968(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a6, 80(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a6, a2, a6
 ; RV64I-NEXT:    xor a4, a4, a5
 ; RV64I-NEXT:    seqz a5, a6
 ; RV64I-NEXT:    addi a6, a5, -1
-; RV64I-NEXT:    sd a6, 440(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a6, 528(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a5, a1, 62
 ; RV64I-NEXT:    and a5, a6, a5
 ; RV64I-NEXT:    srli a2, a2, 63
@@ -20293,7 +20293,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    seqz a2, a2
 ; RV64I-NEXT:    slli a1, a1, 63
 ; RV64I-NEXT:    addi a2, a2, -1
-; RV64I-NEXT:    sd a2, 432(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a2, 520(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a1, a2, a1
 ; RV64I-NEXT:    andi a2, s5, 2
 ; RV64I-NEXT:    seqz a2, a2
@@ -20302,11 +20302,11 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    seqz a5, a5
 ; RV64I-NEXT:    addi a5, a5, -1
 ; RV64I-NEXT:    slli a6, a3, 1
-; RV64I-NEXT:    sd a6, 312(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a6, 448(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a2, a2, a6
 ; RV64I-NEXT:    and a5, a5, a3
 ; RV64I-NEXT:    xor a1, a4, a1
-; RV64I-NEXT:    sd a1, 296(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a1, 432(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    xor a2, a5, a2
 ; RV64I-NEXT:    andi a1, s5, 4
 ; RV64I-NEXT:    andi a4, s5, 8
@@ -20315,9 +20315,9 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    addi a1, a1, -1
 ; RV64I-NEXT:    addi a4, a4, -1
 ; RV64I-NEXT:    slli a5, a3, 2
-; RV64I-NEXT:    sd a5, 280(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a5, 416(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    slli a6, a3, 3
-; RV64I-NEXT:    sd a6, 272(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a6, 408(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a1, a1, a5
 ; RV64I-NEXT:    and a4, a4, a6
 ; RV64I-NEXT:    xor a1, a1, a4
@@ -20328,17 +20328,17 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    andi a4, s5, 32
 ; RV64I-NEXT:    seqz a4, a4
 ; RV64I-NEXT:    slli a5, a3, 4
-; RV64I-NEXT:    sd a5, 264(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a5, 400(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a2, a2, a5
 ; RV64I-NEXT:    addi a4, a4, -1
 ; RV64I-NEXT:    slli a6, a3, 5
-; RV64I-NEXT:    sd a6, 256(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a6, 392(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    andi a5, s5, 64
 ; RV64I-NEXT:    and a4, a4, a6
 ; RV64I-NEXT:    seqz a5, a5
 ; RV64I-NEXT:    addi a5, a5, -1
 ; RV64I-NEXT:    slli a6, a3, 6
-; RV64I-NEXT:    sd a6, 248(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a6, 384(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    xor a2, a2, a4
 ; RV64I-NEXT:    and a4, a5, a6
 ; RV64I-NEXT:    xor a2, a2, a4
@@ -20349,24 +20349,24 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    andi a4, s5, 256
 ; RV64I-NEXT:    seqz a4, a4
 ; RV64I-NEXT:    slli a5, a3, 7
-; RV64I-NEXT:    sd a5, 240(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a5, 376(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a2, a2, a5
 ; RV64I-NEXT:    addi a4, a4, -1
 ; RV64I-NEXT:    slli a6, a3, 8
-; RV64I-NEXT:    sd a6, 232(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a6, 368(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    andi a5, s5, 512
 ; RV64I-NEXT:    and a4, a4, a6
 ; RV64I-NEXT:    seqz a5, a5
 ; RV64I-NEXT:    xor a2, a2, a4
 ; RV64I-NEXT:    addi a5, a5, -1
 ; RV64I-NEXT:    slli a6, a3, 9
-; RV64I-NEXT:    sd a6, 224(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a6, 360(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    andi a4, s5, 1024
 ; RV64I-NEXT:    and a5, a5, a6
 ; RV64I-NEXT:    seqz a4, a4
 ; RV64I-NEXT:    addi a4, a4, -1
 ; RV64I-NEXT:    slli a6, a3, 10
-; RV64I-NEXT:    sd a6, 216(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a6, 352(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    xor a2, a2, a5
 ; RV64I-NEXT:    and a4, a4, a6
 ; RV64I-NEXT:    xor a2, a2, a4
@@ -20378,18 +20378,18 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    and a4, s5, a0
 ; RV64I-NEXT:    seqz a4, a4
 ; RV64I-NEXT:    slli a0, a3, 11
-; RV64I-NEXT:    sd a0, 424(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 64(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a2, a2, a0
 ; RV64I-NEXT:    addi a4, a4, -1
 ; RV64I-NEXT:    lui a5, 2
 ; RV64I-NEXT:    and a5, s5, a5
 ; RV64I-NEXT:    slli a0, a3, 12
-; RV64I-NEXT:    sd a0, 208(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 344(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a4, a4, a0
 ; RV64I-NEXT:    seqz a5, a5
 ; RV64I-NEXT:    addi a5, a5, -1
 ; RV64I-NEXT:    slli a0, a3, 13
-; RV64I-NEXT:    sd a0, 200(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 336(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    xor a2, a2, a4
 ; RV64I-NEXT:    and a4, a5, a0
 ; RV64I-NEXT:    xor a2, a2, a4
@@ -20402,13 +20402,13 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    and a4, s5, a4
 ; RV64I-NEXT:    seqz a4, a4
 ; RV64I-NEXT:    slli a0, a3, 14
-; RV64I-NEXT:    sd a0, 192(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 328(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a2, a2, a0
 ; RV64I-NEXT:    addi a4, a4, -1
 ; RV64I-NEXT:    lui a5, 16
 ; RV64I-NEXT:    and a5, s5, a5
 ; RV64I-NEXT:    slli a0, a3, 15
-; RV64I-NEXT:    sd a0, 184(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 320(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a4, a4, a0
 ; RV64I-NEXT:    seqz a5, a5
 ; RV64I-NEXT:    xor a2, a2, a4
@@ -20416,7 +20416,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    lui a0, 32
 ; RV64I-NEXT:    and a4, s5, a0
 ; RV64I-NEXT:    slli a0, a3, 16
-; RV64I-NEXT:    sd a0, 176(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 312(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a5, a5, a0
 ; RV64I-NEXT:    seqz a4, a4
 ; RV64I-NEXT:    xor a2, a2, a5
@@ -20424,12 +20424,12 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    lui a5, 64
 ; RV64I-NEXT:    and a5, s5, a5
 ; RV64I-NEXT:    slli a0, a3, 17
-; RV64I-NEXT:    sd a0, 168(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 304(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a4, a4, a0
 ; RV64I-NEXT:    seqz a5, a5
 ; RV64I-NEXT:    addi a5, a5, -1
 ; RV64I-NEXT:    slli a0, a3, 18
-; RV64I-NEXT:    sd a0, 160(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 296(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    xor a2, a2, a4
 ; RV64I-NEXT:    and a4, a5, a0
 ; RV64I-NEXT:    xor a2, a2, a4
@@ -20442,13 +20442,13 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    and a4, s5, a4
 ; RV64I-NEXT:    seqz a4, a4
 ; RV64I-NEXT:    slli a0, a3, 19
-; RV64I-NEXT:    sd a0, 152(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 288(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a2, a2, a0
 ; RV64I-NEXT:    addi a4, a4, -1
 ; RV64I-NEXT:    lui a5, 512
 ; RV64I-NEXT:    and a5, s5, a5
 ; RV64I-NEXT:    slli a0, a3, 20
-; RV64I-NEXT:    sd a0, 144(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 280(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a4, a4, a0
 ; RV64I-NEXT:    seqz a5, a5
 ; RV64I-NEXT:    xor a2, a2, a4
@@ -20456,7 +20456,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    lui a4, 1024
 ; RV64I-NEXT:    and a4, s5, a4
 ; RV64I-NEXT:    slli a0, a3, 21
-; RV64I-NEXT:    sd a0, 136(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 272(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a5, a5, a0
 ; RV64I-NEXT:    seqz a4, a4
 ; RV64I-NEXT:    xor a2, a2, a5
@@ -20464,7 +20464,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    lui a5, 2048
 ; RV64I-NEXT:    and a5, s5, a5
 ; RV64I-NEXT:    slli a0, a3, 22
-; RV64I-NEXT:    sd a0, 128(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 264(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a4, a4, a0
 ; RV64I-NEXT:    seqz a5, a5
 ; RV64I-NEXT:    xor a2, a2, a4
@@ -20472,12 +20472,12 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    lui a4, 4096
 ; RV64I-NEXT:    and a4, s5, a4
 ; RV64I-NEXT:    slli a0, a3, 23
-; RV64I-NEXT:    sd a0, 120(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 256(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a5, a5, a0
 ; RV64I-NEXT:    seqz a4, a4
 ; RV64I-NEXT:    addi a4, a4, -1
 ; RV64I-NEXT:    slli a0, a3, 24
-; RV64I-NEXT:    sd a0, 112(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 248(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    xor a2, a2, a5
 ; RV64I-NEXT:    and a4, a4, a0
 ; RV64I-NEXT:    xor a2, a2, a4
@@ -20490,13 +20490,13 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    and a4, s5, a4
 ; RV64I-NEXT:    seqz a4, a4
 ; RV64I-NEXT:    slli a0, a3, 25
-; RV64I-NEXT:    sd a0, 104(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 240(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a2, a2, a0
 ; RV64I-NEXT:    addi a4, a4, -1
 ; RV64I-NEXT:    lui a5, 32768
 ; RV64I-NEXT:    and a5, s5, a5
 ; RV64I-NEXT:    slli a0, a3, 26
-; RV64I-NEXT:    sd a0, 96(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 232(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a4, a4, a0
 ; RV64I-NEXT:    seqz a5, a5
 ; RV64I-NEXT:    xor a2, a2, a4
@@ -20504,7 +20504,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    lui a4, 65536
 ; RV64I-NEXT:    and a4, s5, a4
 ; RV64I-NEXT:    slli a0, a3, 27
-; RV64I-NEXT:    sd a0, 88(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 224(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a5, a5, a0
 ; RV64I-NEXT:    seqz a4, a4
 ; RV64I-NEXT:    xor a2, a2, a5
@@ -20512,7 +20512,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    lui a0, 131072
 ; RV64I-NEXT:    and a5, s5, a0
 ; RV64I-NEXT:    slli a0, a3, 28
-; RV64I-NEXT:    sd a0, 80(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 216(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a4, a4, a0
 ; RV64I-NEXT:    seqz a5, a5
 ; RV64I-NEXT:    xor a2, a2, a4
@@ -20520,19 +20520,19 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    lui a4, 262144
 ; RV64I-NEXT:    and a4, s5, a4
 ; RV64I-NEXT:    slli a0, a3, 29
-; RV64I-NEXT:    sd a0, 72(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 208(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a5, a5, a0
 ; RV64I-NEXT:    seqz a4, a4
 ; RV64I-NEXT:    xor a2, a2, a5
 ; RV64I-NEXT:    addi a4, a4, -1
 ; RV64I-NEXT:    slli a0, a3, 30
-; RV64I-NEXT:    sd a0, 64(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 200(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    sraiw a5, s5, 31
 ; RV64I-NEXT:    and a4, a4, a0
 ; RV64I-NEXT:    seqz a5, a5
 ; RV64I-NEXT:    addi a5, a5, -1
 ; RV64I-NEXT:    slli a0, a3, 31
-; RV64I-NEXT:    sd a0, 56(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 192(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    xor a2, a2, a4
 ; RV64I-NEXT:    and a4, a5, a0
 ; RV64I-NEXT:    xor a2, a2, a4
@@ -20543,45 +20543,45 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    and a4, s5, t0
 ; RV64I-NEXT:    seqz a4, a4
 ; RV64I-NEXT:    slli a0, a3, 32
-; RV64I-NEXT:    sd a0, 408(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 56(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a2, a2, a0
 ; RV64I-NEXT:    addi a4, a4, -1
 ; RV64I-NEXT:    and a5, s5, s10
 ; RV64I-NEXT:    slli a0, a3, 33
-; RV64I-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 184(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a4, a4, a0
 ; RV64I-NEXT:    seqz a5, a5
 ; RV64I-NEXT:    xor a2, a2, a4
 ; RV64I-NEXT:    addi a5, a5, -1
 ; RV64I-NEXT:    and a4, s5, s11
 ; RV64I-NEXT:    slli a0, a3, 34
-; RV64I-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 176(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a5, a5, a0
 ; RV64I-NEXT:    seqz a4, a4
 ; RV64I-NEXT:    xor a2, a2, a5
 ; RV64I-NEXT:    addi a4, a4, -1
 ; RV64I-NEXT:    and a5, s5, ra
 ; RV64I-NEXT:    slli a0, a3, 35
-; RV64I-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 168(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a4, a4, a0
 ; RV64I-NEXT:    seqz a5, a5
 ; RV64I-NEXT:    xor a2, a2, a4
 ; RV64I-NEXT:    addi a5, a5, -1
 ; RV64I-NEXT:    and a4, s5, t1
 ; RV64I-NEXT:    slli a0, a3, 36
-; RV64I-NEXT:    sd a0, 400(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a5, a5, a0
 ; RV64I-NEXT:    seqz a4, a4
 ; RV64I-NEXT:    xor a2, a2, a5
 ; RV64I-NEXT:    addi a4, a4, -1
 ; RV64I-NEXT:    and a5, s5, s9
 ; RV64I-NEXT:    slli a0, a3, 37
-; RV64I-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 160(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a4, a4, a0
 ; RV64I-NEXT:    seqz a5, a5
 ; RV64I-NEXT:    addi a5, a5, -1
 ; RV64I-NEXT:    slli a0, a3, 38
-; RV64I-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 152(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    xor a2, a2, a4
 ; RV64I-NEXT:    and a4, a5, a0
 ; RV64I-NEXT:    xor a2, a2, a4
@@ -20592,19 +20592,19 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    and a4, s5, t2
 ; RV64I-NEXT:    seqz a4, a4
 ; RV64I-NEXT:    slli a0, a3, 39
-; RV64I-NEXT:    sd a0, 392(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a2, a2, a0
 ; RV64I-NEXT:    addi a4, a4, -1
 ; RV64I-NEXT:    and a5, s5, t3
 ; RV64I-NEXT:    slli a0, a3, 40
-; RV64I-NEXT:    sd a0, 384(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a4, a4, a0
 ; RV64I-NEXT:    seqz a5, a5
 ; RV64I-NEXT:    xor a2, a2, a4
 ; RV64I-NEXT:    addi a5, a5, -1
 ; RV64I-NEXT:    and a4, s5, t4
 ; RV64I-NEXT:    slli a0, a3, 41
-; RV64I-NEXT:    sd a0, 376(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    and a5, a5, a0
 ; RV64I-NEXT:    seqz a4, a4
 ; RV64I-NEXT:    xor a2, a2, a5
@@ -20651,42 +20651,42 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    seqz a4, a4
 ; RV64I-NEXT:    xor a1, a1, a2
 ; RV64I-NEXT:    addi a4, a4, -1
-; RV64I-NEXT:    ld a0, 1000(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a0, 112(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a2, s5, a0
 ; RV64I-NEXT:    slli s6, a3, 49
 ; RV64I-NEXT:    and a4, a4, s6
 ; RV64I-NEXT:    seqz a2, a2
 ; RV64I-NEXT:    xor a1, a1, a4
 ; RV64I-NEXT:    addi a2, a2, -1
-; RV64I-NEXT:    ld a0, 1040(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a4, s5, a0
 ; RV64I-NEXT:    slli s2, a3, 50
 ; RV64I-NEXT:    and a2, a2, s2
 ; RV64I-NEXT:    seqz a4, a4
 ; RV64I-NEXT:    xor a1, a1, a2
 ; RV64I-NEXT:    addi a4, a4, -1
-; RV64I-NEXT:    ld a0, 1032(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a0, 144(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a2, s5, a0
 ; RV64I-NEXT:    slli s1, a3, 51
 ; RV64I-NEXT:    and a4, a4, s1
 ; RV64I-NEXT:    seqz a2, a2
 ; RV64I-NEXT:    xor a1, a1, a4
 ; RV64I-NEXT:    addi a2, a2, -1
-; RV64I-NEXT:    ld a0, 1024(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a0, 136(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a4, s5, a0
 ; RV64I-NEXT:    slli s0, a3, 52
 ; RV64I-NEXT:    and a2, a2, s0
 ; RV64I-NEXT:    seqz a4, a4
 ; RV64I-NEXT:    xor a1, a1, a2
 ; RV64I-NEXT:    addi a4, a4, -1
-; RV64I-NEXT:    ld a0, 1016(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a0, 128(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a2, s5, a0
 ; RV64I-NEXT:    slli t5, a3, 53
 ; RV64I-NEXT:    and a4, a4, t5
 ; RV64I-NEXT:    seqz a2, a2
 ; RV64I-NEXT:    xor a1, a1, a4
 ; RV64I-NEXT:    addi a2, a2, -1
-; RV64I-NEXT:    ld a0, 1008(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a0, 120(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a4, s5, a0
 ; RV64I-NEXT:    slli t4, a3, 54
 ; RV64I-NEXT:    and a2, a2, t4
@@ -20696,44 +20696,44 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    xor a1, a1, a2
 ; RV64I-NEXT:    and a2, a4, t3
 ; RV64I-NEXT:    xor t2, a1, a2
-; RV64I-NEXT:    ld a0, 304(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a0, 440(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a1, s5, a0
 ; RV64I-NEXT:    seqz a1, a1
 ; RV64I-NEXT:    and a2, s5, a7
 ; RV64I-NEXT:    addi a1, a1, -1
 ; RV64I-NEXT:    seqz a2, a2
-; RV64I-NEXT:    ld t6, 944(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld t6, 1032(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a1, a1, t6
 ; RV64I-NEXT:    addi a2, a2, -1
-; RV64I-NEXT:    ld a0, 992(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a0, 104(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a4, s5, a0
 ; RV64I-NEXT:    slli t1, a3, 57
 ; RV64I-NEXT:    and a2, a2, t1
 ; RV64I-NEXT:    seqz a4, a4
 ; RV64I-NEXT:    xor a1, a1, a2
 ; RV64I-NEXT:    addi a4, a4, -1
-; RV64I-NEXT:    ld a0, 984(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a0, 96(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a2, s5, a0
 ; RV64I-NEXT:    slli t0, a3, 58
 ; RV64I-NEXT:    and a4, a4, t0
 ; RV64I-NEXT:    seqz a2, a2
 ; RV64I-NEXT:    xor a1, a1, a4
 ; RV64I-NEXT:    addi a2, a2, -1
-; RV64I-NEXT:    ld a0, 976(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a0, 88(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a4, s5, a0
 ; RV64I-NEXT:    slli a7, a3, 59
 ; RV64I-NEXT:    and a2, a2, a7
 ; RV64I-NEXT:    seqz a4, a4
 ; RV64I-NEXT:    xor a1, a1, a2
 ; RV64I-NEXT:    addi a2, a4, -1
-; RV64I-NEXT:    ld a0, 960(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a0, 72(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a0, s5, a0
 ; RV64I-NEXT:    slli a6, a3, 60
 ; RV64I-NEXT:    and a2, a2, a6
 ; RV64I-NEXT:    seqz a0, a0
 ; RV64I-NEXT:    xor a2, a1, a2
 ; RV64I-NEXT:    addi a1, a0, -1
-; RV64I-NEXT:    ld a0, 968(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a0, 80(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a0, s5, a0
 ; RV64I-NEXT:    slli a5, a3, 61
 ; RV64I-NEXT:    and a1, a1, a5
@@ -20750,245 +20750,245 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV64I-NEXT:    and a2, s5, a1
 ; RV64I-NEXT:    xor t2, s3, t2
 ; RV64I-NEXT:    xor a0, a0, a2
-; RV64I-NEXT:    ld a2, 416(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s3, 296(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a2, 512(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 432(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    xor a2, a2, s3
-; RV64I-NEXT:    sd a2, 1040(sp) # 8-byte Folded Spill
+; RV64I-NEXT:    sd a2, 16(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    xor t2, t2, a0
-; RV64I-NEXT:    ld a0, 936(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld a2, 312(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a0, 1024(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a2, 448(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a0, a0, a2
-; RV64I-NEXT:    ld a2, 928(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a2, 1016(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a2, a2, a3
-; RV64I-NEXT:    ld a3, 920(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s3, 280(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a3, 1008(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 416(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a3, a3, s3
-; RV64I-NEXT:    ld s3, 912(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 272(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 1000(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 408(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s5, s3, s5
 ; RV64I-NEXT:    xor a0, a2, a0
 ; RV64I-NEXT:    xor a2, a3, s5
-; RV64I-NEXT:    ld a3, 904(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s3, 264(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a3, 992(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 400(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a3, a3, s3
+; RV64I-NEXT:    ld s3, 984(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 392(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    and s5, s3, s5
+; RV64I-NEXT:    xor a3, a3, s5
+; RV64I-NEXT:    ld s3, 976(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 384(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    and s5, s3, s5
+; RV64I-NEXT:    xor a0, a0, a2
+; RV64I-NEXT:    xor a2, a3, s5
+; RV64I-NEXT:    ld a3, 968(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 376(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    and a3, a3, s3
+; RV64I-NEXT:    ld s3, 960(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 368(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    and s5, s3, s5
+; RV64I-NEXT:    xor a3, a3, s5
+; RV64I-NEXT:    ld s3, 952(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 360(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    and s5, s3, s5
+; RV64I-NEXT:    xor a3, a3, s5
+; RV64I-NEXT:    ld s3, 944(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 352(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    and s5, s3, s5
+; RV64I-NEXT:    xor a0, a0, a2
+; RV64I-NEXT:    xor a2, a3, s5
+; RV64I-NEXT:    ld a3, 936(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 64(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    and a3, a3, s3
+; RV64I-NEXT:    ld s3, 928(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 344(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    and s5, s3, s5
+; RV64I-NEXT:    xor a3, a3, s5
+; RV64I-NEXT:    ld s3, 920(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 336(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    and s5, s3, s5
+; RV64I-NEXT:    xor a0, a0, a2
+; RV64I-NEXT:    xor a2, a3, s5
+; RV64I-NEXT:    ld a3, 912(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 328(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    and a3, a3, s3
+; RV64I-NEXT:    ld s3, 904(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 320(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    and s5, s3, s5
+; RV64I-NEXT:    xor a3, a3, s5
 ; RV64I-NEXT:    ld s3, 896(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 256(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 312(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s5, s3, s5
 ; RV64I-NEXT:    xor a3, a3, s5
 ; RV64I-NEXT:    ld s3, 888(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 304(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    and s5, s3, s5
+; RV64I-NEXT:    xor a3, a3, s5
+; RV64I-NEXT:    ld s3, 880(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 296(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    and s5, s3, s5
+; RV64I-NEXT:    xor a0, a0, a2
+; RV64I-NEXT:    xor a2, a3, s5
+; RV64I-NEXT:    ld a3, 872(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 288(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    and a3, a3, s3
+; RV64I-NEXT:    ld s3, 864(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 280(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    and s5, s3, s5
+; RV64I-NEXT:    xor a3, a3, s5
+; RV64I-NEXT:    ld s3, 856(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 272(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    and s5, s3, s5
+; RV64I-NEXT:    xor a3, a3, s5
+; RV64I-NEXT:    ld s3, 848(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 264(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    and s5, s3, s5
+; RV64I-NEXT:    xor a3, a3, s5
+; RV64I-NEXT:    ld s3, 840(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 256(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    and s5, s3, s5
+; RV64I-NEXT:    xor a3, a3, s5
+; RV64I-NEXT:    ld s3, 832(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    ld s5, 248(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s5, s3, s5
 ; RV64I-NEXT:    xor a0, a0, a2
 ; RV64I-NEXT:    xor a2, a3, s5
-; RV64I-NEXT:    ld a3, 880(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a3, 824(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    ld s3, 240(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a3, a3, s3
-; RV64I-NEXT:    ld s3, 872(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 816(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    ld s5, 232(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s5, s3, s5
 ; RV64I-NEXT:    xor a3, a3, s5
-; RV64I-NEXT:    ld s3, 864(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 808(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    ld s5, 224(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s5, s3, s5
 ; RV64I-NEXT:    xor a3, a3, s5
-; RV64I-NEXT:    ld s3, 856(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 216(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    and s5, s3, s5
-; RV64I-NEXT:    xor a0, a0, a2
-; RV64I-NEXT:    xor a2, a3, s5
-; RV64I-NEXT:    ld a3, 848(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s3, 424(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    and a3, a3, s3
-; RV64I-NEXT:    ld s3, 840(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 208(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    and s5, s3, s5
-; RV64I-NEXT:    xor a3, a3, s5
-; RV64I-NEXT:    ld s3, 832(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 200(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    and s5, s3, s5
-; RV64I-NEXT:    xor a0, a0, a2
-; RV64I-NEXT:    xor a2, a3, s5
-; RV64I-NEXT:    ld a3, 824(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s3, 192(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    and a3, a3, s3
-; RV64I-NEXT:    ld s3, 816(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 184(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    and s5, s3, s5
-; RV64I-NEXT:    xor a3, a3, s5
-; RV64I-NEXT:    ld s3, 808(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 176(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    and s5, s3, s5
-; RV64I-NEXT:    xor a3, a3, s5
 ; RV64I-NEXT:    ld s3, 800(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 168(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 216(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s5, s3, s5
 ; RV64I-NEXT:    xor a3, a3, s5
 ; RV64I-NEXT:    ld s3, 792(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 160(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 208(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    and s5, s3, s5
+; RV64I-NEXT:    xor a3, a3, s5
+; RV64I-NEXT:    ld s3, 784(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 200(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    and s5, s3, s5
+; RV64I-NEXT:    xor a3, a3, s5
+; RV64I-NEXT:    ld s3, 776(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 192(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s5, s3, s5
 ; RV64I-NEXT:    xor a0, a0, a2
 ; RV64I-NEXT:    xor a2, a3, s5
-; RV64I-NEXT:    ld a3, 784(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s3, 152(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a3, 768(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 56(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a3, a3, s3
-; RV64I-NEXT:    ld s3, 776(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 144(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    and s5, s3, s5
-; RV64I-NEXT:    xor a3, a3, s5
-; RV64I-NEXT:    ld s3, 768(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 136(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    and s5, s3, s5
-; RV64I-NEXT:    xor a3, a3, s5
 ; RV64I-NEXT:    ld s3, 760(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 128(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 184(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s5, s3, s5
 ; RV64I-NEXT:    xor a3, a3, s5
 ; RV64I-NEXT:    ld s3, 752(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 120(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 176(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s5, s3, s5
 ; RV64I-NEXT:    xor a3, a3, s5
 ; RV64I-NEXT:    ld s3, 744(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 112(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    and s5, s3, s5
-; RV64I-NEXT:    xor a0, a0, a2
-; RV64I-NEXT:    xor a2, a3, s5
-; RV64I-NEXT:    ld a3, 736(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s3, 104(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    and a3, a3, s3
-; RV64I-NEXT:    ld s3, 728(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 96(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 168(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s5, s3, s5
 ; RV64I-NEXT:    xor a3, a3, s5
-; RV64I-NEXT:    ld s3, 720(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 88(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    and s5, s3, s5
-; RV64I-NEXT:    xor a3, a3, s5
-; RV64I-NEXT:    ld s3, 712(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 80(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    and s5, s3, s5
-; RV64I-NEXT:    xor a3, a3, s5
-; RV64I-NEXT:    ld s3, 704(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 72(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    and s5, s3, s5
-; RV64I-NEXT:    xor a3, a3, s5
-; RV64I-NEXT:    ld s3, 696(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 64(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    and s5, s3, s5
-; RV64I-NEXT:    xor a3, a3, s5
-; RV64I-NEXT:    ld s3, 688(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 56(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    and s5, s3, s5
-; RV64I-NEXT:    xor a0, a0, a2
-; RV64I-NEXT:    xor a2, a3, s5
-; RV64I-NEXT:    ld a3, 680(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s3, 408(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    and a3, a3, s3
-; RV64I-NEXT:    ld s3, 672(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 736(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    ld s5, 48(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s5, s3, s5
 ; RV64I-NEXT:    xor a3, a3, s5
-; RV64I-NEXT:    ld s3, 664(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 40(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 728(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 160(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s5, s3, s5
 ; RV64I-NEXT:    xor a3, a3, s5
-; RV64I-NEXT:    ld s3, 656(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 720(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s5, 152(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    and s5, s3, s5
+; RV64I-NEXT:    xor a0, a0, a2
+; RV64I-NEXT:    xor a2, a3, s5
+; RV64I-NEXT:    ld a3, 712(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 40(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    and a3, a3, s3
+; RV64I-NEXT:    ld s3, 704(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    ld s5, 32(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s5, s3, s5
 ; RV64I-NEXT:    xor a3, a3, s5
-; RV64I-NEXT:    ld s3, 648(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 400(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    and s5, s3, s5
-; RV64I-NEXT:    xor a3, a3, s5
-; RV64I-NEXT:    ld s3, 640(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 696(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    ld s5, 24(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s5, s3, s5
 ; RV64I-NEXT:    xor a3, a3, s5
-; RV64I-NEXT:    ld s3, 632(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 16(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    and s5, s3, s5
-; RV64I-NEXT:    xor a0, a0, a2
-; RV64I-NEXT:    xor a2, a3, s5
-; RV64I-NEXT:    ld a3, 624(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s3, 392(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    and a3, a3, s3
-; RV64I-NEXT:    ld s3, 616(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 384(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    and s5, s3, s5
-; RV64I-NEXT:    xor a3, a3, s5
-; RV64I-NEXT:    ld s3, 608(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    ld s5, 376(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    and s5, s3, s5
-; RV64I-NEXT:    xor a3, a3, s5
-; RV64I-NEXT:    ld s3, 600(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 688(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s5, s3, ra
 ; RV64I-NEXT:    xor a3, a3, s5
-; RV64I-NEXT:    ld s3, 592(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 680(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s5, s3, s11
 ; RV64I-NEXT:    xor a3, a3, s5
-; RV64I-NEXT:    ld s3, 584(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 672(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s5, s3, s10
 ; RV64I-NEXT:    xor a3, a3, s5
-; RV64I-NEXT:    ld s3, 576(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 664(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s5, s3, s9
 ; RV64I-NEXT:    xor a3, a3, s5
-; RV64I-NEXT:    ld s3, 568(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 656(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s5, s3, s8
 ; RV64I-NEXT:    xor a0, a0, a2
 ; RV64I-NEXT:    xor a2, a3, s5
-; RV64I-NEXT:    ld a3, 560(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a3, 648(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a3, a3, s7
-; RV64I-NEXT:    ld s3, 552(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 640(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s4, s3, s4
 ; RV64I-NEXT:    xor a3, a3, s4
-; RV64I-NEXT:    ld s3, 544(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 632(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s3, s3, s6
 ; RV64I-NEXT:    xor a3, a3, s3
-; RV64I-NEXT:    ld s3, 536(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s3, 624(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s2, s3, s2
 ; RV64I-NEXT:    xor a3, a3, s2
-; RV64I-NEXT:    ld s2, 528(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s2, 616(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s1, s2, s1
 ; RV64I-NEXT:    xor a3, a3, s1
-; RV64I-NEXT:    ld s1, 520(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s1, 608(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and s0, s1, s0
 ; RV64I-NEXT:    xor a3, a3, s0
-; RV64I-NEXT:    ld s0, 512(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld s0, 600(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and t5, s0, t5
 ; RV64I-NEXT:    xor a3, a3, t5
-; RV64I-NEXT:    ld t5, 504(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld t5, 592(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and t4, t5, t4
 ; RV64I-NEXT:    xor a3, a3, t4
-; RV64I-NEXT:    ld t4, 496(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld t4, 584(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and t3, t4, t3
 ; RV64I-NEXT:    xor a0, a0, a2
 ; RV64I-NEXT:    xor a2, a3, t3
-; RV64I-NEXT:    ld a3, 1040(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a3, 16(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    xor a3, t2, a3
 ; RV64I-NEXT:    xor a0, a0, a2
-; RV64I-NEXT:    ld a2, 488(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a2, 576(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a2, a2, t6
-; RV64I-NEXT:    ld t2, 480(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld t2, 568(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and t1, t2, t1
 ; RV64I-NEXT:    xor a2, a2, t1
-; RV64I-NEXT:    ld t1, 472(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld t1, 560(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and t0, t1, t0
 ; RV64I-NEXT:    xor a2, a2, t0
-; RV64I-NEXT:    ld t0, 464(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld t0, 552(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a7, t0, a7
 ; RV64I-NEXT:    xor a2, a2, a7
-; RV64I-NEXT:    ld a7, 456(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a7, 544(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a6, a7, a6
 ; RV64I-NEXT:    xor a2, a2, a6
-; RV64I-NEXT:    ld a6, 448(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a6, 536(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a5, a6, a5
 ; RV64I-NEXT:    xor a2, a2, a5
-; RV64I-NEXT:    ld a5, 440(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a5, 528(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a4, a5, a4
 ; RV64I-NEXT:    xor a2, a2, a4
-; RV64I-NEXT:    ld a4, 432(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a4, 520(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    and a1, a4, a1
 ; RV64I-NEXT:    xor a2, a2, a1
-; RV64I-NEXT:    ld a1, 952(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    ld a1, 1040(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    srli a1, a1, 1
 ; RV64I-NEXT:    xor a1, a1, a3
 ; RV64I-NEXT:    xor a0, a0, a2
@@ -21052,16 +21052,16 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    .cfi_offset s9, -44
 ; RV32IM-NEXT:    .cfi_offset s10, -48
 ; RV32IM-NEXT:    .cfi_offset s11, -52
-; RV32IM-NEXT:    sw a2, 144(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a2, 12(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mv a6, a1
-; RV32IM-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 184(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    lw a5, 4(a2)
-; RV32IM-NEXT:    sw a5, 76(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a5, 100(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    lui a0, 16
 ; RV32IM-NEXT:    lw a1, 8(a2)
-; RV32IM-NEXT:    sw a1, 148(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 64(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    lw a1, 12(a2)
-; RV32IM-NEXT:    sw a1, 68(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 32(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    addi t0, a0, -256
 ; RV32IM-NEXT:    srli a0, a5, 8
 ; RV32IM-NEXT:    srli a3, a5, 24
@@ -21093,7 +21093,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    and a3, a3, s10
 ; RV32IM-NEXT:    slli a0, a0, 1
 ; RV32IM-NEXT:    or a5, a3, a0
-; RV32IM-NEXT:    sw a5, 132(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a5, 60(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srli a0, a5, 8
 ; RV32IM-NEXT:    and a0, a0, t0
 ; RV32IM-NEXT:    srli a3, a5, 24
@@ -21103,19 +21103,19 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    or a0, a0, a3
 ; RV32IM-NEXT:    or a4, a5, a4
 ; RV32IM-NEXT:    or a0, a4, a0
-; RV32IM-NEXT:    sw a6, 156(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 4(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    lw a7, 4(a6)
 ; RV32IM-NEXT:    srli a3, a0, 4
 ; RV32IM-NEXT:    and a3, a3, t5
 ; RV32IM-NEXT:    and a0, a0, t5
 ; RV32IM-NEXT:    slli a0, a0, 4
 ; RV32IM-NEXT:    lw a2, 8(a6)
-; RV32IM-NEXT:    sw a2, 40(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a2, 88(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    lw a2, 12(a6)
-; RV32IM-NEXT:    sw a2, 72(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a2, 96(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a0, a3, a0
 ; RV32IM-NEXT:    srli a3, a0, 2
-; RV32IM-NEXT:    sw a7, 64(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 92(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srli a4, a7, 8
 ; RV32IM-NEXT:    and a3, a3, t4
 ; RV32IM-NEXT:    and a4, a4, t0
@@ -21145,7 +21145,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    slli a4, a4, 1
 ; RV32IM-NEXT:    srli a5, a0, 1
 ; RV32IM-NEXT:    or t1, a3, a4
-; RV32IM-NEXT:    sw t1, 124(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t1, 56(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a3, a5, s10
 ; RV32IM-NEXT:    srli a4, t1, 8
 ; RV32IM-NEXT:    and a0, a0, s10
@@ -21233,7 +21233,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    slli a3, a3, 8
 ; RV32IM-NEXT:    or a1, a1, a2
 ; RV32IM-NEXT:    or a3, a0, a3
-; RV32IM-NEXT:    lw a0, 156(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    lw a0, 0(a0)
 ; RV32IM-NEXT:    or a1, a3, a1
 ; RV32IM-NEXT:    srli a2, a1, 4
@@ -21244,7 +21244,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    srli a2, a1, 2
 ; RV32IM-NEXT:    and a2, a2, t4
 ; RV32IM-NEXT:    and a1, a1, t4
-; RV32IM-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srli a3, a0, 8
 ; RV32IM-NEXT:    slli a1, a1, 2
 ; RV32IM-NEXT:    and a3, a3, t0
@@ -21268,7 +21268,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    slli a2, a2, 2
 ; RV32IM-NEXT:    lui s11, 349525
 ; RV32IM-NEXT:    addi s11, s11, 1364
-; RV32IM-NEXT:    sw s11, 156(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s11, 4(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a2, a3, a2
 ; RV32IM-NEXT:    srli a3, a2, 1
 ; RV32IM-NEXT:    and a2, a2, s10
@@ -21277,15 +21277,15 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    and a1, a1, s10
 ; RV32IM-NEXT:    mv ra, s10
 ; RV32IM-NEXT:    or a2, a3, a2
-; RV32IM-NEXT:    sw a7, 164(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    lw a0, 132(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    sw a7, 72(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and t1, a0, a7
-; RV32IM-NEXT:    sw t2, 184(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t2, 36(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and s7, a2, t2
 ; RV32IM-NEXT:    and t2, a0, t2
 ; RV32IM-NEXT:    and a3, a2, a7
 ; RV32IM-NEXT:    and s0, a0, s1
-; RV32IM-NEXT:    sw t3, 168(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t3, 76(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and t6, a0, t3
 ; RV32IM-NEXT:    and t3, a2, t3
 ; RV32IM-NEXT:    and s10, a2, s1
@@ -21300,23 +21300,23 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    mul s4, t3, t6
 ; RV32IM-NEXT:    mul s5, s10, t2
 ; RV32IM-NEXT:    mul s6, s7, t2
-; RV32IM-NEXT:    sw t2, 120(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t2, 52(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mv a0, s7
-; RV32IM-NEXT:    sw s7, 140(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s7, 136(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul s7, t1, t6
-; RV32IM-NEXT:    sw t1, 136(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t1, 132(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul s8, t3, a7
-; RV32IM-NEXT:    sw a7, 96(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    sw t3, 132(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 8(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t3, 60(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul s9, s10, s0
 ; RV32IM-NEXT:    sw s10, 128(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a4, a4, s11
 ; RV32IM-NEXT:    slli a1, a1, 1
 ; RV32IM-NEXT:    or a1, a4, a1
-; RV32IM-NEXT:    sw a1, 116(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 48(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a2, a3, a2
 ; RV32IM-NEXT:    xor a3, a5, a6
-; RV32IM-NEXT:    lw a1, 144(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    lw a1, 0(a1)
 ; RV32IM-NEXT:    xor a4, s3, s2
 ; RV32IM-NEXT:    xor a5, s4, s5
@@ -21325,13 +21325,13 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    xor a3, s7, s6
 ; RV32IM-NEXT:    xor a5, s8, s9
 ; RV32IM-NEXT:    srli a6, a1, 8
-; RV32IM-NEXT:    sw t0, 176(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t0, 20(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and s2, a1, t0
 ; RV32IM-NEXT:    and a6, a6, t0
 ; RV32IM-NEXT:    slli s2, s2, 8
 ; RV32IM-NEXT:    mul s3, a0, t6
 ; RV32IM-NEXT:    mul s4, t1, s0
-; RV32IM-NEXT:    sw a1, 144(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srli s5, a1, 24
 ; RV32IM-NEXT:    slli s6, a1, 24
 ; RV32IM-NEXT:    or a6, a6, s5
@@ -21341,41 +21341,41 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    mul a6, t3, t2
 ; RV32IM-NEXT:    mul s2, s10, a7
 ; RV32IM-NEXT:    srli s5, a5, 4
-; RV32IM-NEXT:    sw t5, 180(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t5, 24(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a5, a5, t5
 ; RV32IM-NEXT:    and s5, s5, t5
 ; RV32IM-NEXT:    slli a5, a5, 4
 ; RV32IM-NEXT:    xor s3, s4, s3
 ; RV32IM-NEXT:    or a5, s5, a5
 ; RV32IM-NEXT:    srli s4, a5, 2
-; RV32IM-NEXT:    sw t4, 152(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t4, 104(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a5, a5, t4
 ; RV32IM-NEXT:    and s4, s4, t4
 ; RV32IM-NEXT:    slli a5, a5, 2
 ; RV32IM-NEXT:    xor a6, a6, s2
 ; RV32IM-NEXT:    or a5, s4, a5
 ; RV32IM-NEXT:    srli s2, a5, 1
-; RV32IM-NEXT:    sw ra, 172(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw ra, 16(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a5, a5, ra
 ; RV32IM-NEXT:    and s2, s2, ra
 ; RV32IM-NEXT:    slli a5, a5, 1
 ; RV32IM-NEXT:    xor a6, s3, a6
 ; RV32IM-NEXT:    or a5, s2, a5
-; RV32IM-NEXT:    lw t1, 184(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t1, 36(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a0, a2, t1
-; RV32IM-NEXT:    sw a0, 92(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    lw t0, 164(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    lw t0, 72(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s10, a4, t0
-; RV32IM-NEXT:    lw t5, 168(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t5, 76(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s3, a3, t5
 ; RV32IM-NEXT:    mv a1, s1
-; RV32IM-NEXT:    sw s1, 160(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s1, 68(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and s1, a6, s1
 ; RV32IM-NEXT:    and t4, a5, t0
 ; RV32IM-NEXT:    and a3, a5, t1
 ; RV32IM-NEXT:    and a6, a5, a1
 ; RV32IM-NEXT:    and a0, a5, t5
-; RV32IM-NEXT:    lw a7, 124(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a7, 56(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s4, a7, t1
 ; RV32IM-NEXT:    and s2, a7, t0
 ; RV32IM-NEXT:    and a2, a7, t5
@@ -21383,17 +21383,17 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    mul t2, s4, t4
 ; RV32IM-NEXT:    mul s5, s2, a3
 ; RV32IM-NEXT:    mul s6, a2, a6
-; RV32IM-NEXT:    sw a0, 112(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 124(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul s7, a7, a0
 ; RV32IM-NEXT:    mul s8, s4, a6
 ; RV32IM-NEXT:    mv a1, a6
-; RV32IM-NEXT:    sw a6, 108(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 120(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul s9, s2, t4
-; RV32IM-NEXT:    sw t4, 100(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t4, 112(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul s11, a2, a0
 ; RV32IM-NEXT:    mul ra, a7, a3
 ; RV32IM-NEXT:    mul t3, s4, a3
-; RV32IM-NEXT:    sw a3, 104(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a3, 116(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul t0, s2, a0
 ; RV32IM-NEXT:    mul t1, a2, t4
 ; RV32IM-NEXT:    mul a5, a7, a6
@@ -21401,7 +21401,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    mul a4, s2, a1
 ; RV32IM-NEXT:    mul a1, a2, a3
 ; RV32IM-NEXT:    mul a0, a7, t4
-; RV32IM-NEXT:    lw a3, 92(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 44(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    or s10, s10, a3
 ; RV32IM-NEXT:    or s1, s3, s1
 ; RV32IM-NEXT:    xor t2, s5, t2
@@ -21416,24 +21416,24 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    xor a0, a1, a0
 ; RV32IM-NEXT:    xor a1, t0, a5
 ; RV32IM-NEXT:    xor a0, a3, a0
-; RV32IM-NEXT:    lw s9, 184(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s9, 36(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a3, t2, s9
-; RV32IM-NEXT:    lw s11, 164(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s11, 72(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, s3, s11
 ; RV32IM-NEXT:    mv s8, t5
 ; RV32IM-NEXT:    and a1, a1, t5
-; RV32IM-NEXT:    lw t5, 160(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t5, 68(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a0, a0, t5
 ; RV32IM-NEXT:    or a3, a4, a3
 ; RV32IM-NEXT:    or a0, a1, a0
 ; RV32IM-NEXT:    or a1, s10, s1
 ; RV32IM-NEXT:    or a0, a3, a0
 ; RV32IM-NEXT:    xor a0, a0, a1
-; RV32IM-NEXT:    lw a1, 116(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a1, 48(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a1, a1, 1
 ; RV32IM-NEXT:    xor a0, a1, a0
 ; RV32IM-NEXT:    srli a1, a0, 8
-; RV32IM-NEXT:    lw t3, 176(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t3, 20(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, t3
 ; RV32IM-NEXT:    srli a3, a0, 24
 ; RV32IM-NEXT:    and a4, a0, t3
@@ -21441,10 +21441,10 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    slli a4, a4, 8
 ; RV32IM-NEXT:    or a0, a1, a3
 ; RV32IM-NEXT:    or s3, a5, a4
-; RV32IM-NEXT:    lw s6, 96(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s6, 8(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a1, s4, s6
 ; RV32IM-NEXT:    mul a3, s4, s0
-; RV32IM-NEXT:    lw s7, 120(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s7, 52(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a4, s4, s7
 ; RV32IM-NEXT:    mul a5, s4, t6
 ; RV32IM-NEXT:    mul a6, s2, s7
@@ -21482,7 +21482,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    or a2, a4, a2
 ; RV32IM-NEXT:    or a1, a1, a2
 ; RV32IM-NEXT:    srli a2, a0, 4
-; RV32IM-NEXT:    lw a5, 180(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 24(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a2, a2, a5
 ; RV32IM-NEXT:    and a0, a0, a5
 ; RV32IM-NEXT:    slli a0, a0, 4
@@ -21496,50 +21496,50 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    or a2, a2, a3
 ; RV32IM-NEXT:    or a1, a1, a4
 ; RV32IM-NEXT:    srli a3, a0, 2
-; RV32IM-NEXT:    lw a4, 152(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 104(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a0, a0, a4
 ; RV32IM-NEXT:    and a3, a3, a4
 ; RV32IM-NEXT:    slli a0, a0, 2
 ; RV32IM-NEXT:    or a0, a3, a0
 ; RV32IM-NEXT:    or a1, a1, a2
 ; RV32IM-NEXT:    srli a2, a0, 1
-; RV32IM-NEXT:    lw a3, 172(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 16(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a7, a0, a3
-; RV32IM-NEXT:    lw a0, 156(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a0, a2, a0
-; RV32IM-NEXT:    sw a0, 96(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a2, a7, 1
 ; RV32IM-NEXT:    srli a0, a1, 4
 ; RV32IM-NEXT:    and a1, a1, a5
 ; RV32IM-NEXT:    and a0, a0, a5
 ; RV32IM-NEXT:    slli a1, a1, 4
-; RV32IM-NEXT:    lw a3, 144(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 12(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s9, a3, s11
-; RV32IM-NEXT:    sw s9, 116(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s9, 48(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mv a4, t1
 ; RV32IM-NEXT:    and s8, a3, t1
-; RV32IM-NEXT:    sw s8, 124(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s8, 56(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mv a7, t5
 ; RV32IM-NEXT:    and t1, a3, t5
 ; RV32IM-NEXT:    and s3, a3, a6
-; RV32IM-NEXT:    sw s3, 144(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    lw ra, 40(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    sw s3, 12(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    lw ra, 88(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s2, ra, a4
-; RV32IM-NEXT:    sw s2, 44(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s2, 164(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and t4, ra, s11
-; RV32IM-NEXT:    sw t4, 60(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t4, 180(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul a3, s2, s9
 ; RV32IM-NEXT:    mul a4, t4, s8
 ; RV32IM-NEXT:    and s4, ra, a6
 ; RV32IM-NEXT:    mv s10, a6
-; RV32IM-NEXT:    sw s4, 56(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s4, 176(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and s6, ra, t5
-; RV32IM-NEXT:    sw s6, 52(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s6, 172(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul a5, s4, t1
 ; RV32IM-NEXT:    mul a6, s6, s3
 ; RV32IM-NEXT:    mul t0, s2, t1
 ; RV32IM-NEXT:    mv s5, t1
-; RV32IM-NEXT:    sw t1, 120(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t1, 52(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul t1, t4, s9
 ; RV32IM-NEXT:    mul t2, s4, s3
 ; RV32IM-NEXT:    mul t3, s6, s8
@@ -21551,9 +21551,9 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    mul s3, t4, s5
 ; RV32IM-NEXT:    mul s5, s4, s8
 ; RV32IM-NEXT:    mul s8, s6, s9
-; RV32IM-NEXT:    lw t4, 96(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t4, 8(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    or a2, t4, a2
-; RV32IM-NEXT:    sw a2, 36(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a2, 84(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a0, a0, a1
 ; RV32IM-NEXT:    xor a3, a4, a3
 ; RV32IM-NEXT:    xor a1, a5, a6
@@ -21567,23 +21567,23 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    xor a5, s5, s8
 ; RV32IM-NEXT:    xor a3, a3, s0
 ; RV32IM-NEXT:    xor a4, a4, a5
-; RV32IM-NEXT:    lw s7, 184(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s7, 36(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, s7
 ; RV32IM-NEXT:    and a2, a2, s11
 ; RV32IM-NEXT:    and a3, a3, s10
 ; RV32IM-NEXT:    and a4, a4, a7
 ; RV32IM-NEXT:    or a1, a2, a1
-; RV32IM-NEXT:    sw a1, 32(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a5, a3, a4
 ; RV32IM-NEXT:    srli a4, a0, 2
-; RV32IM-NEXT:    lw a3, 152(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 104(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a6, a0, a3
-; RV32IM-NEXT:    lw a2, 84(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a2, 40(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a2, s7
 ; RV32IM-NEXT:    and t4, a2, s11
 ; RV32IM-NEXT:    and a0, a2, s10
 ; RV32IM-NEXT:    and a2, a2, a7
-; RV32IM-NEXT:    lw t3, 148(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t3, 64(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s4, t3, s11
 ; RV32IM-NEXT:    and s9, t3, s7
 ; RV32IM-NEXT:    mul t0, a1, s4
@@ -21597,27 +21597,27 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    mul s1, a0, t5
 ; RV32IM-NEXT:    mul s5, a2, s9
 ; RV32IM-NEXT:    mul s8, a1, s9
-; RV32IM-NEXT:    sw s9, 20(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s9, 156(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mv a7, a1
-; RV32IM-NEXT:    sw a1, 96(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul s10, t4, t5
-; RV32IM-NEXT:    sw t5, 4(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    sw t4, 92(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t5, 140(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t4, 44(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul a1, a0, s4
-; RV32IM-NEXT:    sw s4, 16(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s4, 152(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mv s2, a0
-; RV32IM-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 108(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mv s6, s3
-; RV32IM-NEXT:    sw s3, 24(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s3, 80(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul a0, a2, s3
-; RV32IM-NEXT:    sw a2, 84(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a2, 40(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a4, a4, a3
 ; RV32IM-NEXT:    slli a6, a6, 2
 ; RV32IM-NEXT:    or s3, a4, a6
-; RV32IM-NEXT:    sw s3, 48(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    lw a4, 32(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    sw s3, 168(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    lw a4, 28(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    or a4, a4, a5
-; RV32IM-NEXT:    sw a4, 32(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a4, 28(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a4, t1, t0
 ; RV32IM-NEXT:    xor a5, t2, t3
 ; RV32IM-NEXT:    xor a6, s0, t6
@@ -21633,7 +21633,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    mul a5, a7, t5
 ; RV32IM-NEXT:    mul a6, t4, s6
 ; RV32IM-NEXT:    srli t0, ra, 8
-; RV32IM-NEXT:    lw a1, 176(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and t1, ra, a1
 ; RV32IM-NEXT:    and t0, t0, a1
 ; RV32IM-NEXT:    slli t1, t1, 8
@@ -21646,7 +21646,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    xor a5, a6, a5
 ; RV32IM-NEXT:    or a6, t1, t0
 ; RV32IM-NEXT:    srli t0, a6, 4
-; RV32IM-NEXT:    lw a1, 180(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a6, a6, a1
 ; RV32IM-NEXT:    and t0, t0, a1
 ; RV32IM-NEXT:    slli a6, a6, 4
@@ -21659,12 +21659,12 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    slli a6, a6, 2
 ; RV32IM-NEXT:    xor a5, a5, t1
 ; RV32IM-NEXT:    or a6, t0, a6
-; RV32IM-NEXT:    lw a1, 168(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a1, 76(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a0, a0, a1
-; RV32IM-NEXT:    lw s6, 160(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s6, 68(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a5, a5, s6
 ; RV32IM-NEXT:    srli t0, a6, 1
-; RV32IM-NEXT:    lw a3, 172(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 16(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a6, a6, a3
 ; RV32IM-NEXT:    and t0, t0, a3
 ; RV32IM-NEXT:    slli a6, a6, 1
@@ -21678,14 +21678,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    mv s11, a1
 ; RV32IM-NEXT:    and s5, a5, s6
 ; RV32IM-NEXT:    srli s9, s3, 1
-; RV32IM-NEXT:    sw s9, 40(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    lw t4, 100(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    sw s9, 88(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    lw t4, 112(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a5, a4, t4
-; RV32IM-NEXT:    lw s2, 104(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s2, 116(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t0, a6, s2
-; RV32IM-NEXT:    lw s7, 108(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s7, 120(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t1, t6, s7
-; RV32IM-NEXT:    lw a2, 112(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a2, 124(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t2, s5, a2
 ; RV32IM-NEXT:    mul t3, a4, s7
 ; RV32IM-NEXT:    mul t5, a6, t4
@@ -21695,14 +21695,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    mul s10, a6, a2
 ; RV32IM-NEXT:    mul a7, t6, t4
 ; RV32IM-NEXT:    mul a1, s5, s7
-; RV32IM-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a0, a0, 1
 ; RV32IM-NEXT:    slli s9, s9, 31
 ; RV32IM-NEXT:    or a0, a0, s9
-; RV32IM-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    sw a0, 148(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    xor a0, a3, a0
-; RV32IM-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 144(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a0, t0, a5
 ; RV32IM-NEXT:    xor a3, t1, t2
 ; RV32IM-NEXT:    xor a5, t5, t3
@@ -21713,9 +21713,9 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    xor a1, a7, a1
 ; RV32IM-NEXT:    mul a7, a4, a2
 ; RV32IM-NEXT:    mul a4, a6, s7
-; RV32IM-NEXT:    lw t2, 148(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t2, 64(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a6, t2, 8
-; RV32IM-NEXT:    lw s8, 176(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s8, 20(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and t0, t2, s8
 ; RV32IM-NEXT:    and a6, a6, s8
 ; RV32IM-NEXT:    slli t0, t0, 8
@@ -21728,7 +21728,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    mul a6, t6, s2
 ; RV32IM-NEXT:    mul t0, s5, t4
 ; RV32IM-NEXT:    srli t1, a1, 4
-; RV32IM-NEXT:    lw s9, 180(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s9, 24(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, s9
 ; RV32IM-NEXT:    and t1, t1, s9
 ; RV32IM-NEXT:    slli a1, a1, 4
@@ -21742,24 +21742,24 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    xor a6, a6, t0
 ; RV32IM-NEXT:    or a1, a4, a1
 ; RV32IM-NEXT:    srli a4, a1, 1
-; RV32IM-NEXT:    lw a7, 172(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a7, 16(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, a7
 ; RV32IM-NEXT:    and a4, a4, a7
 ; RV32IM-NEXT:    slli a1, a1, 1
 ; RV32IM-NEXT:    xor a2, a2, a6
 ; RV32IM-NEXT:    or a1, a4, a1
-; RV32IM-NEXT:    lw s2, 164(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s2, 72(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a1, s2
 ; RV32IM-NEXT:    and a6, a1, ra
 ; RV32IM-NEXT:    mv s0, s6
 ; RV32IM-NEXT:    and t0, a1, s6
 ; RV32IM-NEXT:    mv s7, s11
 ; RV32IM-NEXT:    and a1, a1, s11
-; RV32IM-NEXT:    lw s5, 140(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s5, 136(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t1, s5, a4
-; RV32IM-NEXT:    lw s1, 136(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s1, 132(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t2, s1, a6
-; RV32IM-NEXT:    lw s4, 132(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s4, 60(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t3, s4, t0
 ; RV32IM-NEXT:    lw s6, 128(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t5, s6, a1
@@ -21843,7 +21843,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    or a1, a3, a1
 ; RV32IM-NEXT:    srli a2, a0, 1
 ; RV32IM-NEXT:    and a0, a0, a7
-; RV32IM-NEXT:    lw a4, 156(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 4(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a2, a2, a4
 ; RV32IM-NEXT:    slli a0, a0, 1
 ; RV32IM-NEXT:    srli a3, a1, 1
@@ -21852,24 +21852,24 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    slli a1, a1, 1
 ; RV32IM-NEXT:    or a0, a2, a0
 ; RV32IM-NEXT:    or a1, a3, a1
-; RV32IM-NEXT:    lw a2, 64(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a2, 92(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a2, ra
 ; RV32IM-NEXT:    and s2, a2, s2
 ; RV32IM-NEXT:    and t5, a2, s7
 ; RV32IM-NEXT:    and s3, a2, s10
-; RV32IM-NEXT:    lw a6, 4(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a6, 140(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a2, s3, a6
-; RV32IM-NEXT:    sw s3, 64(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s3, 92(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul a3, t5, a6
-; RV32IM-NEXT:    sw s2, 36(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s2, 84(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul a5, s2, a6
-; RV32IM-NEXT:    sw a4, 32(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a4, 28(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul a6, a4, a6
-; RV32IM-NEXT:    lw t6, 16(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t6, 152(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a7, a4, t6
-; RV32IM-NEXT:    lw s0, 20(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s0, 156(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t0, s2, s0
-; RV32IM-NEXT:    lw t4, 24(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t4, 80(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t1, t5, t4
 ; RV32IM-NEXT:    mul t2, a4, t4
 ; RV32IM-NEXT:    mul t3, s2, t6
@@ -21877,16 +21877,16 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    mul s5, s3, t4
 ; RV32IM-NEXT:    mul t4, s2, t4
 ; RV32IM-NEXT:    mul s8, a4, s0
-; RV32IM-NEXT:    sw t5, 28(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t5, 160(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul s9, t5, t6
 ; RV32IM-NEXT:    mul s2, t5, s0
 ; RV32IM-NEXT:    mul s3, s3, t6
-; RV32IM-NEXT:    lw a4, 12(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw t5, 8(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 148(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t5, 144(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    xor a4, a4, t5
-; RV32IM-NEXT:    sw a4, 148(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a4, 64(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a0, a1, a0
-; RV32IM-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a0, t0, a7
 ; RV32IM-NEXT:    xor a1, t1, a2
 ; RV32IM-NEXT:    xor a2, t3, t2
@@ -21906,18 +21906,18 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    and a1, a1, s7
 ; RV32IM-NEXT:    mv s0, s10
 ; RV32IM-NEXT:    and a3, a3, s10
-; RV32IM-NEXT:    lw t1, 68(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t1, 32(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a5, t1, s11
 ; RV32IM-NEXT:    and a6, t1, ra
 ; RV32IM-NEXT:    and a7, t1, s10
 ; RV32IM-NEXT:    and t0, t1, s7
-; RV32IM-NEXT:    lw t6, 84(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t6, 40(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t1, t6, t0
-; RV32IM-NEXT:    lw t5, 88(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t5, 108(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t2, t5, t0
-; RV32IM-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t3, a0, t0
-; RV32IM-NEXT:    lw s10, 96(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 8(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t0, s10, t0
 ; RV32IM-NEXT:    mul t4, s10, a5
 ; RV32IM-NEXT:    mul s1, a0, a6
@@ -21951,18 +21951,18 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    and a5, a5, s0
 ; RV32IM-NEXT:    or a1, a4, a3
 ; RV32IM-NEXT:    or a3, a0, a5
-; RV32IM-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 96(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a0, ra
 ; RV32IM-NEXT:    and a5, a0, s11
 ; RV32IM-NEXT:    and a6, a0, s7
 ; RV32IM-NEXT:    and a7, a0, s0
-; RV32IM-NEXT:    lw t6, 116(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t6, 48(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t0, a4, t6
-; RV32IM-NEXT:    lw a0, 120(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t1, a4, a0
-; RV32IM-NEXT:    lw s11, 124(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s11, 56(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t2, a4, s11
-; RV32IM-NEXT:    lw s5, 144(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s5, 12(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a4, a4, s5
 ; RV32IM-NEXT:    mul t3, a5, s11
 ; RV32IM-NEXT:    mul t4, a6, a0
@@ -21978,7 +21978,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    mul a7, a7, t6
 ; RV32IM-NEXT:    or ra, t5, a2
 ; RV32IM-NEXT:    or a1, a1, a3
-; RV32IM-NEXT:    sw a1, 68(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 32(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a1, t3, t0
 ; RV32IM-NEXT:    xor a2, t4, s1
 ; RV32IM-NEXT:    xor t0, s2, t1
@@ -21998,24 +21998,24 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    and a0, a0, s0
 ; RV32IM-NEXT:    or t6, a2, a1
 ; RV32IM-NEXT:    or a6, a4, a0
-; RV32IM-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 100(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a0, s4
 ; RV32IM-NEXT:    mv s11, s4
 ; RV32IM-NEXT:    and s7, a0, s6
 ; RV32IM-NEXT:    and a7, a0, s0
 ; RV32IM-NEXT:    and a5, a0, a3
 ; RV32IM-NEXT:    mv s6, a3
-; RV32IM-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    sw a4, 72(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    lw a0, 164(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    sw a4, 96(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul t0, a0, a4
 ; RV32IM-NEXT:    mul t1, a0, a7
 ; RV32IM-NEXT:    mul t2, a0, s7
 ; RV32IM-NEXT:    mul t3, a0, a5
-; RV32IM-NEXT:    lw a2, 60(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a2, 180(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t4, a2, s7
-; RV32IM-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 176(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t5, a0, a7
-; RV32IM-NEXT:    lw a3, 52(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 172(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul s1, a3, a5
 ; RV32IM-NEXT:    mul s2, a2, a4
 ; RV32IM-NEXT:    mul s3, a0, a5
@@ -22026,11 +22026,11 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    mul a2, a3, a7
 ; RV32IM-NEXT:    mul a1, a0, s7
 ; RV32IM-NEXT:    mul a0, a3, a4
-; RV32IM-NEXT:    lw a3, 68(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 32(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    xor a3, a3, ra
-; RV32IM-NEXT:    sw a3, 76(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a3, 100(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a3, t6, a6
-; RV32IM-NEXT:    sw a3, 68(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a3, 32(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a6, t4, t0
 ; RV32IM-NEXT:    xor t0, t5, s1
 ; RV32IM-NEXT:    xor t1, s2, t1
@@ -22043,20 +22043,20 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    xor a0, a1, a0
 ; RV32IM-NEXT:    xor a1, t0, a2
 ; RV32IM-NEXT:    xor a6, t2, a0
-; RV32IM-NEXT:    lw a0, 140(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s9, 100(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 136(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s9, 112(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul ra, a0, s9
-; RV32IM-NEXT:    lw s10, 108(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 120(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t0, a0, s10
-; RV32IM-NEXT:    lw a3, 104(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 116(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t2, a0, a3
-; RV32IM-NEXT:    lw s0, 112(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s0, 124(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t3, a0, s0
 ; RV32IM-NEXT:    lw s3, 128(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t4, s3, s0
-; RV32IM-NEXT:    lw s5, 132(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s5, 60(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t5, s5, s0
-; RV32IM-NEXT:    lw a0, 136(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 132(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul s0, a0, s0
 ; RV32IM-NEXT:    mul s1, a0, a3
 ; RV32IM-NEXT:    mul s2, s3, a3
@@ -22067,12 +22067,12 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    mul a3, a0, s10
 ; RV32IM-NEXT:    mul s10, s3, s10
 ; RV32IM-NEXT:    mul a0, s3, s9
-; RV32IM-NEXT:    lw a2, 184(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a2, 36(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and t6, t6, a2
 ; RV32IM-NEXT:    and t1, t1, s11
 ; RV32IM-NEXT:    mv s3, s6
 ; RV32IM-NEXT:    and a1, a1, s6
-; RV32IM-NEXT:    lw s6, 160(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s6, 68(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a6, a6, s6
 ; RV32IM-NEXT:    or t1, t1, t6
 ; RV32IM-NEXT:    or a1, a1, a6
@@ -22097,12 +22097,12 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    or a0, t0, a0
 ; RV32IM-NEXT:    or a1, t1, a1
 ; RV32IM-NEXT:    or a0, a2, a0
-; RV32IM-NEXT:    lw a2, 68(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a2, 32(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    xor a1, a1, a2
 ; RV32IM-NEXT:    srli a2, a0, 8
-; RV32IM-NEXT:    lw a3, 76(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 100(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    xor a1, a3, a1
-; RV32IM-NEXT:    lw a3, 176(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 20(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a2, a2, a3
 ; RV32IM-NEXT:    and a6, a0, a3
 ; RV32IM-NEXT:    srli t0, a0, 24
@@ -22111,16 +22111,16 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    or a2, a2, t0
 ; RV32IM-NEXT:    or a0, a0, a6
 ; RV32IM-NEXT:    or a0, a0, a2
-; RV32IM-NEXT:    lw a2, 48(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw t0, 172(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a2, 168(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t0, 16(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a2, a2, t0
-; RV32IM-NEXT:    lw a3, 40(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a4, 156(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 88(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 4(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a6, a3, a4
 ; RV32IM-NEXT:    slli a2, a2, 1
 ; RV32IM-NEXT:    or a2, a6, a2
 ; RV32IM-NEXT:    srli a6, a0, 4
-; RV32IM-NEXT:    lw a3, 180(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a6, a6, a3
 ; RV32IM-NEXT:    and a0, a0, a3
 ; RV32IM-NEXT:    srli a2, a2, 1
@@ -22128,11 +22128,11 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    xor a1, a2, a1
 ; RV32IM-NEXT:    or a0, a6, a0
 ; RV32IM-NEXT:    srli a2, a0, 2
-; RV32IM-NEXT:    lw a3, 152(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 104(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a0, a0, a3
 ; RV32IM-NEXT:    and a2, a2, a3
 ; RV32IM-NEXT:    slli a0, a0, 2
-; RV32IM-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 80(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a6, a3, 1
 ; RV32IM-NEXT:    or a0, a2, a0
 ; RV32IM-NEXT:    srli a2, a0, 1
@@ -22140,20 +22140,20 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    and a2, a2, a4
 ; RV32IM-NEXT:    slli t0, a0, 1
 ; RV32IM-NEXT:    xor a0, a1, a6
-; RV32IM-NEXT:    sw a0, 180(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a0, a2, t0
-; RV32IM-NEXT:    sw a0, 176(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    lw s8, 116(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a4, 32(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    lw s8, 48(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 28(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a1, a4, s8
-; RV32IM-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw t1, 124(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t1, 56(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a2, a0, t1
-; RV32IM-NEXT:    lw s9, 120(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s5, 28(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s9, 52(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s5, 160(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a6, s5, s9
-; RV32IM-NEXT:    lw a3, 64(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw ra, 144(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 92(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t0, a3, ra
 ; RV32IM-NEXT:    mul t2, a4, s9
 ; RV32IM-NEXT:    mul t3, a0, s8
@@ -22175,29 +22175,29 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    xor a2, a6, t0
 ; RV32IM-NEXT:    xor a6, s0, t6
 ; RV32IM-NEXT:    xor t0, s1, s2
-; RV32IM-NEXT:    lw s11, 184(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s11, 36(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, s11
-; RV32IM-NEXT:    lw t4, 164(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t4, 72(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a2, a2, t4
 ; RV32IM-NEXT:    xor t2, s4, s3
 ; RV32IM-NEXT:    xor t3, s5, s6
 ; RV32IM-NEXT:    xor a6, a6, t0
 ; RV32IM-NEXT:    xor t0, t2, t3
-; RV32IM-NEXT:    lw a0, 168(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a6, a6, a0
 ; RV32IM-NEXT:    and t0, t0, s10
 ; RV32IM-NEXT:    or a1, a2, a1
-; RV32IM-NEXT:    sw a1, 172(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a0, a6, t0
-; RV32IM-NEXT:    sw a0, 156(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    lw a0, 96(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a3, 72(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 96(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a6, a0, a3
-; RV32IM-NEXT:    lw s6, 92(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s6, 44(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t0, s6, s7
-; RV32IM-NEXT:    lw s10, 88(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 108(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t2, s10, a7
-; RV32IM-NEXT:    lw s5, 84(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s5, 40(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t3, s5, a5
 ; RV32IM-NEXT:    mul a2, a0, a7
 ; RV32IM-NEXT:    mul t5, s6, a3
@@ -22231,14 +22231,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    mul a7, s6, t1
 ; RV32IM-NEXT:    mul t2, s7, s9
 ; RV32IM-NEXT:    mul t3, s5, ra
-; RV32IM-NEXT:    lw s4, 168(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s4, 76(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a5, a5, s4
-; RV32IM-NEXT:    lw s3, 160(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s3, 68(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a3, a3, s3
 ; RV32IM-NEXT:    or a6, t0, a6
 ; RV32IM-NEXT:    or a3, a5, a3
-; RV32IM-NEXT:    lw a1, 172(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a2, 156(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a2, 4(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    or a1, a1, a2
 ; RV32IM-NEXT:    or a2, a6, a3
 ; RV32IM-NEXT:    mul a3, a0, s9
@@ -22272,16 +22272,16 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IM-NEXT:    and a2, a2, s4
 ; RV32IM-NEXT:    and a4, a4, s3
 ; RV32IM-NEXT:    or a2, a2, a4
-; RV32IM-NEXT:    lw a4, 176(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 20(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a4, a4, 1
 ; RV32IM-NEXT:    xor a1, a4, a1
 ; RV32IM-NEXT:    or a2, a3, a2
-; RV32IM-NEXT:    lw a3, 80(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 184(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    sw a2, 0(a3)
 ; RV32IM-NEXT:    sw a1, 4(a3)
-; RV32IM-NEXT:    lw a1, 148(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a1, 64(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    sw a1, 8(a3)
-; RV32IM-NEXT:    lw a0, 180(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    sw a0, 12(a3)
 ; RV32IM-NEXT:    lw ra, 236(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    lw s0, 232(sp) # 4-byte Folded Reload
@@ -22719,16 +22719,16 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    .cfi_offset s9, -44
 ; RV32IMZBS-NEXT:    .cfi_offset s10, -48
 ; RV32IMZBS-NEXT:    .cfi_offset s11, -52
-; RV32IMZBS-NEXT:    sw a2, 144(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a2, 12(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mv a6, a1
-; RV32IMZBS-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 184(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    lw a5, 4(a2)
-; RV32IMZBS-NEXT:    sw a5, 76(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a5, 100(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    lui a0, 16
 ; RV32IMZBS-NEXT:    lw a1, 8(a2)
-; RV32IMZBS-NEXT:    sw a1, 148(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 64(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    lw a1, 12(a2)
-; RV32IMZBS-NEXT:    sw a1, 68(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 32(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    addi t0, a0, -256
 ; RV32IMZBS-NEXT:    srli a0, a5, 8
 ; RV32IMZBS-NEXT:    srli a3, a5, 24
@@ -22760,7 +22760,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    and a3, a3, s10
 ; RV32IMZBS-NEXT:    slli a0, a0, 1
 ; RV32IMZBS-NEXT:    or a5, a3, a0
-; RV32IMZBS-NEXT:    sw a5, 132(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a5, 60(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srli a0, a5, 8
 ; RV32IMZBS-NEXT:    and a0, a0, t0
 ; RV32IMZBS-NEXT:    srli a3, a5, 24
@@ -22770,19 +22770,19 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    or a0, a0, a3
 ; RV32IMZBS-NEXT:    or a4, a5, a4
 ; RV32IMZBS-NEXT:    or a0, a4, a0
-; RV32IMZBS-NEXT:    sw a6, 156(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 4(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    lw a7, 4(a6)
 ; RV32IMZBS-NEXT:    srli a3, a0, 4
 ; RV32IMZBS-NEXT:    and a3, a3, t5
 ; RV32IMZBS-NEXT:    and a0, a0, t5
 ; RV32IMZBS-NEXT:    slli a0, a0, 4
 ; RV32IMZBS-NEXT:    lw a2, 8(a6)
-; RV32IMZBS-NEXT:    sw a2, 40(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a2, 88(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    lw a2, 12(a6)
-; RV32IMZBS-NEXT:    sw a2, 72(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a2, 96(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a0, a3, a0
 ; RV32IMZBS-NEXT:    srli a3, a0, 2
-; RV32IMZBS-NEXT:    sw a7, 64(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 92(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srli a4, a7, 8
 ; RV32IMZBS-NEXT:    and a3, a3, t4
 ; RV32IMZBS-NEXT:    and a4, a4, t0
@@ -22812,7 +22812,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    slli a4, a4, 1
 ; RV32IMZBS-NEXT:    srli a5, a0, 1
 ; RV32IMZBS-NEXT:    or t1, a3, a4
-; RV32IMZBS-NEXT:    sw t1, 124(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t1, 56(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a3, a5, s10
 ; RV32IMZBS-NEXT:    srli a4, t1, 8
 ; RV32IMZBS-NEXT:    and a0, a0, s10
@@ -22900,7 +22900,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    slli a3, a3, 8
 ; RV32IMZBS-NEXT:    or a1, a1, a2
 ; RV32IMZBS-NEXT:    or a3, a0, a3
-; RV32IMZBS-NEXT:    lw a0, 156(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    lw a0, 0(a0)
 ; RV32IMZBS-NEXT:    or a1, a3, a1
 ; RV32IMZBS-NEXT:    srli a2, a1, 4
@@ -22911,7 +22911,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    srli a2, a1, 2
 ; RV32IMZBS-NEXT:    and a2, a2, t4
 ; RV32IMZBS-NEXT:    and a1, a1, t4
-; RV32IMZBS-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srli a3, a0, 8
 ; RV32IMZBS-NEXT:    slli a1, a1, 2
 ; RV32IMZBS-NEXT:    and a3, a3, t0
@@ -22935,7 +22935,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    slli a2, a2, 2
 ; RV32IMZBS-NEXT:    lui s11, 349525
 ; RV32IMZBS-NEXT:    addi s11, s11, 1364
-; RV32IMZBS-NEXT:    sw s11, 156(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s11, 4(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a2, a3, a2
 ; RV32IMZBS-NEXT:    srli a3, a2, 1
 ; RV32IMZBS-NEXT:    and a2, a2, s10
@@ -22944,15 +22944,15 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    and a1, a1, s10
 ; RV32IMZBS-NEXT:    mv ra, s10
 ; RV32IMZBS-NEXT:    or a2, a3, a2
-; RV32IMZBS-NEXT:    sw a7, 164(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    lw a0, 132(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    sw a7, 72(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and t1, a0, a7
-; RV32IMZBS-NEXT:    sw t2, 184(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t2, 36(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and s7, a2, t2
 ; RV32IMZBS-NEXT:    and t2, a0, t2
 ; RV32IMZBS-NEXT:    and a3, a2, a7
 ; RV32IMZBS-NEXT:    and s0, a0, s1
-; RV32IMZBS-NEXT:    sw t3, 168(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t3, 76(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and t6, a0, t3
 ; RV32IMZBS-NEXT:    and t3, a2, t3
 ; RV32IMZBS-NEXT:    and s10, a2, s1
@@ -22967,23 +22967,23 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    mul s4, t3, t6
 ; RV32IMZBS-NEXT:    mul s5, s10, t2
 ; RV32IMZBS-NEXT:    mul s6, s7, t2
-; RV32IMZBS-NEXT:    sw t2, 120(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t2, 52(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mv a0, s7
-; RV32IMZBS-NEXT:    sw s7, 140(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s7, 136(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul s7, t1, t6
-; RV32IMZBS-NEXT:    sw t1, 136(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t1, 132(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul s8, t3, a7
-; RV32IMZBS-NEXT:    sw a7, 96(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    sw t3, 132(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 8(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t3, 60(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul s9, s10, s0
 ; RV32IMZBS-NEXT:    sw s10, 128(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a4, a4, s11
 ; RV32IMZBS-NEXT:    slli a1, a1, 1
 ; RV32IMZBS-NEXT:    or a1, a4, a1
-; RV32IMZBS-NEXT:    sw a1, 116(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 48(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a2, a3, a2
 ; RV32IMZBS-NEXT:    xor a3, a5, a6
-; RV32IMZBS-NEXT:    lw a1, 144(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    lw a1, 0(a1)
 ; RV32IMZBS-NEXT:    xor a4, s3, s2
 ; RV32IMZBS-NEXT:    xor a5, s4, s5
@@ -22992,13 +22992,13 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    xor a3, s7, s6
 ; RV32IMZBS-NEXT:    xor a5, s8, s9
 ; RV32IMZBS-NEXT:    srli a6, a1, 8
-; RV32IMZBS-NEXT:    sw t0, 176(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t0, 20(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and s2, a1, t0
 ; RV32IMZBS-NEXT:    and a6, a6, t0
 ; RV32IMZBS-NEXT:    slli s2, s2, 8
 ; RV32IMZBS-NEXT:    mul s3, a0, t6
 ; RV32IMZBS-NEXT:    mul s4, t1, s0
-; RV32IMZBS-NEXT:    sw a1, 144(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srli s5, a1, 24
 ; RV32IMZBS-NEXT:    slli s6, a1, 24
 ; RV32IMZBS-NEXT:    or a6, a6, s5
@@ -23008,41 +23008,41 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    mul a6, t3, t2
 ; RV32IMZBS-NEXT:    mul s2, s10, a7
 ; RV32IMZBS-NEXT:    srli s5, a5, 4
-; RV32IMZBS-NEXT:    sw t5, 180(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t5, 24(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a5, a5, t5
 ; RV32IMZBS-NEXT:    and s5, s5, t5
 ; RV32IMZBS-NEXT:    slli a5, a5, 4
 ; RV32IMZBS-NEXT:    xor s3, s4, s3
 ; RV32IMZBS-NEXT:    or a5, s5, a5
 ; RV32IMZBS-NEXT:    srli s4, a5, 2
-; RV32IMZBS-NEXT:    sw t4, 152(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t4, 104(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a5, a5, t4
 ; RV32IMZBS-NEXT:    and s4, s4, t4
 ; RV32IMZBS-NEXT:    slli a5, a5, 2
 ; RV32IMZBS-NEXT:    xor a6, a6, s2
 ; RV32IMZBS-NEXT:    or a5, s4, a5
 ; RV32IMZBS-NEXT:    srli s2, a5, 1
-; RV32IMZBS-NEXT:    sw ra, 172(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw ra, 16(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a5, a5, ra
 ; RV32IMZBS-NEXT:    and s2, s2, ra
 ; RV32IMZBS-NEXT:    slli a5, a5, 1
 ; RV32IMZBS-NEXT:    xor a6, s3, a6
 ; RV32IMZBS-NEXT:    or a5, s2, a5
-; RV32IMZBS-NEXT:    lw t1, 184(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t1, 36(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a0, a2, t1
-; RV32IMZBS-NEXT:    sw a0, 92(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    lw t0, 164(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    lw t0, 72(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s10, a4, t0
-; RV32IMZBS-NEXT:    lw t5, 168(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t5, 76(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s3, a3, t5
 ; RV32IMZBS-NEXT:    mv a1, s1
-; RV32IMZBS-NEXT:    sw s1, 160(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s1, 68(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and s1, a6, s1
 ; RV32IMZBS-NEXT:    and t4, a5, t0
 ; RV32IMZBS-NEXT:    and a3, a5, t1
 ; RV32IMZBS-NEXT:    and a6, a5, a1
 ; RV32IMZBS-NEXT:    and a0, a5, t5
-; RV32IMZBS-NEXT:    lw a7, 124(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a7, 56(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s4, a7, t1
 ; RV32IMZBS-NEXT:    and s2, a7, t0
 ; RV32IMZBS-NEXT:    and a2, a7, t5
@@ -23050,17 +23050,17 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    mul t2, s4, t4
 ; RV32IMZBS-NEXT:    mul s5, s2, a3
 ; RV32IMZBS-NEXT:    mul s6, a2, a6
-; RV32IMZBS-NEXT:    sw a0, 112(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 124(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul s7, a7, a0
 ; RV32IMZBS-NEXT:    mul s8, s4, a6
 ; RV32IMZBS-NEXT:    mv a1, a6
-; RV32IMZBS-NEXT:    sw a6, 108(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 120(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul s9, s2, t4
-; RV32IMZBS-NEXT:    sw t4, 100(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t4, 112(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul s11, a2, a0
 ; RV32IMZBS-NEXT:    mul ra, a7, a3
 ; RV32IMZBS-NEXT:    mul t3, s4, a3
-; RV32IMZBS-NEXT:    sw a3, 104(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a3, 116(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul t0, s2, a0
 ; RV32IMZBS-NEXT:    mul t1, a2, t4
 ; RV32IMZBS-NEXT:    mul a5, a7, a6
@@ -23068,7 +23068,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    mul a4, s2, a1
 ; RV32IMZBS-NEXT:    mul a1, a2, a3
 ; RV32IMZBS-NEXT:    mul a0, a7, t4
-; RV32IMZBS-NEXT:    lw a3, 92(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 44(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    or s10, s10, a3
 ; RV32IMZBS-NEXT:    or s1, s3, s1
 ; RV32IMZBS-NEXT:    xor t2, s5, t2
@@ -23083,24 +23083,24 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    xor a0, a1, a0
 ; RV32IMZBS-NEXT:    xor a1, t0, a5
 ; RV32IMZBS-NEXT:    xor a0, a3, a0
-; RV32IMZBS-NEXT:    lw s9, 184(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s9, 36(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a3, t2, s9
-; RV32IMZBS-NEXT:    lw s11, 164(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s11, 72(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, s3, s11
 ; RV32IMZBS-NEXT:    mv s8, t5
 ; RV32IMZBS-NEXT:    and a1, a1, t5
-; RV32IMZBS-NEXT:    lw t5, 160(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t5, 68(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a0, a0, t5
 ; RV32IMZBS-NEXT:    or a3, a4, a3
 ; RV32IMZBS-NEXT:    or a0, a1, a0
 ; RV32IMZBS-NEXT:    or a1, s10, s1
 ; RV32IMZBS-NEXT:    or a0, a3, a0
 ; RV32IMZBS-NEXT:    xor a0, a0, a1
-; RV32IMZBS-NEXT:    lw a1, 116(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a1, 48(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a1, a1, 1
 ; RV32IMZBS-NEXT:    xor a0, a1, a0
 ; RV32IMZBS-NEXT:    srli a1, a0, 8
-; RV32IMZBS-NEXT:    lw t3, 176(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t3, 20(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, t3
 ; RV32IMZBS-NEXT:    srli a3, a0, 24
 ; RV32IMZBS-NEXT:    and a4, a0, t3
@@ -23108,10 +23108,10 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    slli a4, a4, 8
 ; RV32IMZBS-NEXT:    or a0, a1, a3
 ; RV32IMZBS-NEXT:    or s3, a5, a4
-; RV32IMZBS-NEXT:    lw s6, 96(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s6, 8(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a1, s4, s6
 ; RV32IMZBS-NEXT:    mul a3, s4, s0
-; RV32IMZBS-NEXT:    lw s7, 120(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s7, 52(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a4, s4, s7
 ; RV32IMZBS-NEXT:    mul a5, s4, t6
 ; RV32IMZBS-NEXT:    mul a6, s2, s7
@@ -23149,7 +23149,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    or a2, a4, a2
 ; RV32IMZBS-NEXT:    or a1, a1, a2
 ; RV32IMZBS-NEXT:    srli a2, a0, 4
-; RV32IMZBS-NEXT:    lw a5, 180(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 24(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a2, a2, a5
 ; RV32IMZBS-NEXT:    and a0, a0, a5
 ; RV32IMZBS-NEXT:    slli a0, a0, 4
@@ -23163,50 +23163,50 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    or a2, a2, a3
 ; RV32IMZBS-NEXT:    or a1, a1, a4
 ; RV32IMZBS-NEXT:    srli a3, a0, 2
-; RV32IMZBS-NEXT:    lw a4, 152(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 104(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a0, a0, a4
 ; RV32IMZBS-NEXT:    and a3, a3, a4
 ; RV32IMZBS-NEXT:    slli a0, a0, 2
 ; RV32IMZBS-NEXT:    or a0, a3, a0
 ; RV32IMZBS-NEXT:    or a1, a1, a2
 ; RV32IMZBS-NEXT:    srli a2, a0, 1
-; RV32IMZBS-NEXT:    lw a3, 172(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 16(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a7, a0, a3
-; RV32IMZBS-NEXT:    lw a0, 156(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a0, a2, a0
-; RV32IMZBS-NEXT:    sw a0, 96(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a2, a7, 1
 ; RV32IMZBS-NEXT:    srli a0, a1, 4
 ; RV32IMZBS-NEXT:    and a1, a1, a5
 ; RV32IMZBS-NEXT:    and a0, a0, a5
 ; RV32IMZBS-NEXT:    slli a1, a1, 4
-; RV32IMZBS-NEXT:    lw a3, 144(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 12(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s9, a3, s11
-; RV32IMZBS-NEXT:    sw s9, 116(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s9, 48(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mv a4, t1
 ; RV32IMZBS-NEXT:    and s8, a3, t1
-; RV32IMZBS-NEXT:    sw s8, 124(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s8, 56(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mv a7, t5
 ; RV32IMZBS-NEXT:    and t1, a3, t5
 ; RV32IMZBS-NEXT:    and s3, a3, a6
-; RV32IMZBS-NEXT:    sw s3, 144(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    lw ra, 40(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    sw s3, 12(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    lw ra, 88(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s2, ra, a4
-; RV32IMZBS-NEXT:    sw s2, 44(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s2, 164(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and t4, ra, s11
-; RV32IMZBS-NEXT:    sw t4, 60(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t4, 180(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul a3, s2, s9
 ; RV32IMZBS-NEXT:    mul a4, t4, s8
 ; RV32IMZBS-NEXT:    and s4, ra, a6
 ; RV32IMZBS-NEXT:    mv s10, a6
-; RV32IMZBS-NEXT:    sw s4, 56(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s4, 176(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and s6, ra, t5
-; RV32IMZBS-NEXT:    sw s6, 52(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s6, 172(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul a5, s4, t1
 ; RV32IMZBS-NEXT:    mul a6, s6, s3
 ; RV32IMZBS-NEXT:    mul t0, s2, t1
 ; RV32IMZBS-NEXT:    mv s5, t1
-; RV32IMZBS-NEXT:    sw t1, 120(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t1, 52(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul t1, t4, s9
 ; RV32IMZBS-NEXT:    mul t2, s4, s3
 ; RV32IMZBS-NEXT:    mul t3, s6, s8
@@ -23218,9 +23218,9 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    mul s3, t4, s5
 ; RV32IMZBS-NEXT:    mul s5, s4, s8
 ; RV32IMZBS-NEXT:    mul s8, s6, s9
-; RV32IMZBS-NEXT:    lw t4, 96(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t4, 8(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    or a2, t4, a2
-; RV32IMZBS-NEXT:    sw a2, 36(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a2, 84(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a0, a0, a1
 ; RV32IMZBS-NEXT:    xor a3, a4, a3
 ; RV32IMZBS-NEXT:    xor a1, a5, a6
@@ -23234,23 +23234,23 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    xor a5, s5, s8
 ; RV32IMZBS-NEXT:    xor a3, a3, s0
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
-; RV32IMZBS-NEXT:    lw s7, 184(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s7, 36(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, s7
 ; RV32IMZBS-NEXT:    and a2, a2, s11
 ; RV32IMZBS-NEXT:    and a3, a3, s10
 ; RV32IMZBS-NEXT:    and a4, a4, a7
 ; RV32IMZBS-NEXT:    or a1, a2, a1
-; RV32IMZBS-NEXT:    sw a1, 32(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a5, a3, a4
 ; RV32IMZBS-NEXT:    srli a4, a0, 2
-; RV32IMZBS-NEXT:    lw a3, 152(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 104(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a6, a0, a3
-; RV32IMZBS-NEXT:    lw a2, 84(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a2, 40(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a2, s7
 ; RV32IMZBS-NEXT:    and t4, a2, s11
 ; RV32IMZBS-NEXT:    and a0, a2, s10
 ; RV32IMZBS-NEXT:    and a2, a2, a7
-; RV32IMZBS-NEXT:    lw t3, 148(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t3, 64(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s4, t3, s11
 ; RV32IMZBS-NEXT:    and s9, t3, s7
 ; RV32IMZBS-NEXT:    mul t0, a1, s4
@@ -23264,27 +23264,27 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    mul s1, a0, t5
 ; RV32IMZBS-NEXT:    mul s5, a2, s9
 ; RV32IMZBS-NEXT:    mul s8, a1, s9
-; RV32IMZBS-NEXT:    sw s9, 20(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s9, 156(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mv a7, a1
-; RV32IMZBS-NEXT:    sw a1, 96(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul s10, t4, t5
-; RV32IMZBS-NEXT:    sw t5, 4(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    sw t4, 92(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t5, 140(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t4, 44(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul a1, a0, s4
-; RV32IMZBS-NEXT:    sw s4, 16(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s4, 152(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mv s2, a0
-; RV32IMZBS-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 108(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mv s6, s3
-; RV32IMZBS-NEXT:    sw s3, 24(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s3, 80(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul a0, a2, s3
-; RV32IMZBS-NEXT:    sw a2, 84(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a2, 40(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a4, a4, a3
 ; RV32IMZBS-NEXT:    slli a6, a6, 2
 ; RV32IMZBS-NEXT:    or s3, a4, a6
-; RV32IMZBS-NEXT:    sw s3, 48(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    lw a4, 32(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    sw s3, 168(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    lw a4, 28(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    or a4, a4, a5
-; RV32IMZBS-NEXT:    sw a4, 32(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a4, 28(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a4, t1, t0
 ; RV32IMZBS-NEXT:    xor a5, t2, t3
 ; RV32IMZBS-NEXT:    xor a6, s0, t6
@@ -23300,7 +23300,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    mul a5, a7, t5
 ; RV32IMZBS-NEXT:    mul a6, t4, s6
 ; RV32IMZBS-NEXT:    srli t0, ra, 8
-; RV32IMZBS-NEXT:    lw a1, 176(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and t1, ra, a1
 ; RV32IMZBS-NEXT:    and t0, t0, a1
 ; RV32IMZBS-NEXT:    slli t1, t1, 8
@@ -23313,7 +23313,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    xor a5, a6, a5
 ; RV32IMZBS-NEXT:    or a6, t1, t0
 ; RV32IMZBS-NEXT:    srli t0, a6, 4
-; RV32IMZBS-NEXT:    lw a1, 180(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a6, a6, a1
 ; RV32IMZBS-NEXT:    and t0, t0, a1
 ; RV32IMZBS-NEXT:    slli a6, a6, 4
@@ -23326,12 +23326,12 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    slli a6, a6, 2
 ; RV32IMZBS-NEXT:    xor a5, a5, t1
 ; RV32IMZBS-NEXT:    or a6, t0, a6
-; RV32IMZBS-NEXT:    lw a1, 168(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a1, 76(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a0, a0, a1
-; RV32IMZBS-NEXT:    lw s6, 160(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s6, 68(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a5, a5, s6
 ; RV32IMZBS-NEXT:    srli t0, a6, 1
-; RV32IMZBS-NEXT:    lw a3, 172(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 16(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a6, a6, a3
 ; RV32IMZBS-NEXT:    and t0, t0, a3
 ; RV32IMZBS-NEXT:    slli a6, a6, 1
@@ -23345,14 +23345,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    mv s11, a1
 ; RV32IMZBS-NEXT:    and s5, a5, s6
 ; RV32IMZBS-NEXT:    srli s9, s3, 1
-; RV32IMZBS-NEXT:    sw s9, 40(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    lw t4, 100(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    sw s9, 88(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    lw t4, 112(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a5, a4, t4
-; RV32IMZBS-NEXT:    lw s2, 104(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s2, 116(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t0, a6, s2
-; RV32IMZBS-NEXT:    lw s7, 108(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s7, 120(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t1, t6, s7
-; RV32IMZBS-NEXT:    lw a2, 112(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a2, 124(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t2, s5, a2
 ; RV32IMZBS-NEXT:    mul t3, a4, s7
 ; RV32IMZBS-NEXT:    mul t5, a6, t4
@@ -23362,14 +23362,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    mul s10, a6, a2
 ; RV32IMZBS-NEXT:    mul a7, t6, t4
 ; RV32IMZBS-NEXT:    mul a1, s5, s7
-; RV32IMZBS-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a0, a0, 1
 ; RV32IMZBS-NEXT:    slli s9, s9, 31
 ; RV32IMZBS-NEXT:    or a0, a0, s9
-; RV32IMZBS-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    sw a0, 148(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    xor a0, a3, a0
-; RV32IMZBS-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 144(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a0, t0, a5
 ; RV32IMZBS-NEXT:    xor a3, t1, t2
 ; RV32IMZBS-NEXT:    xor a5, t5, t3
@@ -23380,9 +23380,9 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    xor a1, a7, a1
 ; RV32IMZBS-NEXT:    mul a7, a4, a2
 ; RV32IMZBS-NEXT:    mul a4, a6, s7
-; RV32IMZBS-NEXT:    lw t2, 148(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t2, 64(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a6, t2, 8
-; RV32IMZBS-NEXT:    lw s8, 176(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s8, 20(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and t0, t2, s8
 ; RV32IMZBS-NEXT:    and a6, a6, s8
 ; RV32IMZBS-NEXT:    slli t0, t0, 8
@@ -23395,7 +23395,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    mul a6, t6, s2
 ; RV32IMZBS-NEXT:    mul t0, s5, t4
 ; RV32IMZBS-NEXT:    srli t1, a1, 4
-; RV32IMZBS-NEXT:    lw s9, 180(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s9, 24(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, s9
 ; RV32IMZBS-NEXT:    and t1, t1, s9
 ; RV32IMZBS-NEXT:    slli a1, a1, 4
@@ -23409,24 +23409,24 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    xor a6, a6, t0
 ; RV32IMZBS-NEXT:    or a1, a4, a1
 ; RV32IMZBS-NEXT:    srli a4, a1, 1
-; RV32IMZBS-NEXT:    lw a7, 172(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a7, 16(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, a7
 ; RV32IMZBS-NEXT:    and a4, a4, a7
 ; RV32IMZBS-NEXT:    slli a1, a1, 1
 ; RV32IMZBS-NEXT:    xor a2, a2, a6
 ; RV32IMZBS-NEXT:    or a1, a4, a1
-; RV32IMZBS-NEXT:    lw s2, 164(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s2, 72(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a1, s2
 ; RV32IMZBS-NEXT:    and a6, a1, ra
 ; RV32IMZBS-NEXT:    mv s0, s6
 ; RV32IMZBS-NEXT:    and t0, a1, s6
 ; RV32IMZBS-NEXT:    mv s7, s11
 ; RV32IMZBS-NEXT:    and a1, a1, s11
-; RV32IMZBS-NEXT:    lw s5, 140(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s5, 136(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t1, s5, a4
-; RV32IMZBS-NEXT:    lw s1, 136(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s1, 132(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t2, s1, a6
-; RV32IMZBS-NEXT:    lw s4, 132(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s4, 60(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t3, s4, t0
 ; RV32IMZBS-NEXT:    lw s6, 128(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t5, s6, a1
@@ -23510,7 +23510,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    or a1, a3, a1
 ; RV32IMZBS-NEXT:    srli a2, a0, 1
 ; RV32IMZBS-NEXT:    and a0, a0, a7
-; RV32IMZBS-NEXT:    lw a4, 156(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 4(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a2, a2, a4
 ; RV32IMZBS-NEXT:    slli a0, a0, 1
 ; RV32IMZBS-NEXT:    srli a3, a1, 1
@@ -23519,24 +23519,24 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    slli a1, a1, 1
 ; RV32IMZBS-NEXT:    or a0, a2, a0
 ; RV32IMZBS-NEXT:    or a1, a3, a1
-; RV32IMZBS-NEXT:    lw a2, 64(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a2, 92(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a2, ra
 ; RV32IMZBS-NEXT:    and s2, a2, s2
 ; RV32IMZBS-NEXT:    and t5, a2, s7
 ; RV32IMZBS-NEXT:    and s3, a2, s10
-; RV32IMZBS-NEXT:    lw a6, 4(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a6, 140(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a2, s3, a6
-; RV32IMZBS-NEXT:    sw s3, 64(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s3, 92(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul a3, t5, a6
-; RV32IMZBS-NEXT:    sw s2, 36(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s2, 84(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul a5, s2, a6
-; RV32IMZBS-NEXT:    sw a4, 32(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a4, 28(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul a6, a4, a6
-; RV32IMZBS-NEXT:    lw t6, 16(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t6, 152(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a7, a4, t6
-; RV32IMZBS-NEXT:    lw s0, 20(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s0, 156(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t0, s2, s0
-; RV32IMZBS-NEXT:    lw t4, 24(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t4, 80(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t1, t5, t4
 ; RV32IMZBS-NEXT:    mul t2, a4, t4
 ; RV32IMZBS-NEXT:    mul t3, s2, t6
@@ -23544,16 +23544,16 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    mul s5, s3, t4
 ; RV32IMZBS-NEXT:    mul t4, s2, t4
 ; RV32IMZBS-NEXT:    mul s8, a4, s0
-; RV32IMZBS-NEXT:    sw t5, 28(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t5, 160(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul s9, t5, t6
 ; RV32IMZBS-NEXT:    mul s2, t5, s0
 ; RV32IMZBS-NEXT:    mul s3, s3, t6
-; RV32IMZBS-NEXT:    lw a4, 12(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw t5, 8(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 148(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t5, 144(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    xor a4, a4, t5
-; RV32IMZBS-NEXT:    sw a4, 148(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a4, 64(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a0, a1, a0
-; RV32IMZBS-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a0, t0, a7
 ; RV32IMZBS-NEXT:    xor a1, t1, a2
 ; RV32IMZBS-NEXT:    xor a2, t3, t2
@@ -23573,18 +23573,18 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    and a1, a1, s7
 ; RV32IMZBS-NEXT:    mv s0, s10
 ; RV32IMZBS-NEXT:    and a3, a3, s10
-; RV32IMZBS-NEXT:    lw t1, 68(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t1, 32(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a5, t1, s11
 ; RV32IMZBS-NEXT:    and a6, t1, ra
 ; RV32IMZBS-NEXT:    and a7, t1, s10
 ; RV32IMZBS-NEXT:    and t0, t1, s7
-; RV32IMZBS-NEXT:    lw t6, 84(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t6, 40(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t1, t6, t0
-; RV32IMZBS-NEXT:    lw t5, 88(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t5, 108(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t2, t5, t0
-; RV32IMZBS-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t3, a0, t0
-; RV32IMZBS-NEXT:    lw s10, 96(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 8(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t0, s10, t0
 ; RV32IMZBS-NEXT:    mul t4, s10, a5
 ; RV32IMZBS-NEXT:    mul s1, a0, a6
@@ -23618,18 +23618,18 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    and a5, a5, s0
 ; RV32IMZBS-NEXT:    or a1, a4, a3
 ; RV32IMZBS-NEXT:    or a3, a0, a5
-; RV32IMZBS-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 96(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a0, ra
 ; RV32IMZBS-NEXT:    and a5, a0, s11
 ; RV32IMZBS-NEXT:    and a6, a0, s7
 ; RV32IMZBS-NEXT:    and a7, a0, s0
-; RV32IMZBS-NEXT:    lw t6, 116(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t6, 48(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t0, a4, t6
-; RV32IMZBS-NEXT:    lw a0, 120(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t1, a4, a0
-; RV32IMZBS-NEXT:    lw s11, 124(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s11, 56(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t2, a4, s11
-; RV32IMZBS-NEXT:    lw s5, 144(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s5, 12(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a4, a4, s5
 ; RV32IMZBS-NEXT:    mul t3, a5, s11
 ; RV32IMZBS-NEXT:    mul t4, a6, a0
@@ -23645,7 +23645,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    mul a7, a7, t6
 ; RV32IMZBS-NEXT:    or ra, t5, a2
 ; RV32IMZBS-NEXT:    or a1, a1, a3
-; RV32IMZBS-NEXT:    sw a1, 68(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 32(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a1, t3, t0
 ; RV32IMZBS-NEXT:    xor a2, t4, s1
 ; RV32IMZBS-NEXT:    xor t0, s2, t1
@@ -23665,24 +23665,24 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    and a0, a0, s0
 ; RV32IMZBS-NEXT:    or t6, a2, a1
 ; RV32IMZBS-NEXT:    or a6, a4, a0
-; RV32IMZBS-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 100(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a0, s4
 ; RV32IMZBS-NEXT:    mv s11, s4
 ; RV32IMZBS-NEXT:    and s7, a0, s6
 ; RV32IMZBS-NEXT:    and a7, a0, s0
 ; RV32IMZBS-NEXT:    and a5, a0, a3
 ; RV32IMZBS-NEXT:    mv s6, a3
-; RV32IMZBS-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    sw a4, 72(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    lw a0, 164(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    sw a4, 96(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul t0, a0, a4
 ; RV32IMZBS-NEXT:    mul t1, a0, a7
 ; RV32IMZBS-NEXT:    mul t2, a0, s7
 ; RV32IMZBS-NEXT:    mul t3, a0, a5
-; RV32IMZBS-NEXT:    lw a2, 60(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a2, 180(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t4, a2, s7
-; RV32IMZBS-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 176(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t5, a0, a7
-; RV32IMZBS-NEXT:    lw a3, 52(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 172(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul s1, a3, a5
 ; RV32IMZBS-NEXT:    mul s2, a2, a4
 ; RV32IMZBS-NEXT:    mul s3, a0, a5
@@ -23693,11 +23693,11 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    mul a2, a3, a7
 ; RV32IMZBS-NEXT:    mul a1, a0, s7
 ; RV32IMZBS-NEXT:    mul a0, a3, a4
-; RV32IMZBS-NEXT:    lw a3, 68(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 32(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    xor a3, a3, ra
-; RV32IMZBS-NEXT:    sw a3, 76(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a3, 100(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a3, t6, a6
-; RV32IMZBS-NEXT:    sw a3, 68(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a3, 32(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a6, t4, t0
 ; RV32IMZBS-NEXT:    xor t0, t5, s1
 ; RV32IMZBS-NEXT:    xor t1, s2, t1
@@ -23710,20 +23710,20 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    xor a0, a1, a0
 ; RV32IMZBS-NEXT:    xor a1, t0, a2
 ; RV32IMZBS-NEXT:    xor a6, t2, a0
-; RV32IMZBS-NEXT:    lw a0, 140(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s9, 100(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 136(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s9, 112(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul ra, a0, s9
-; RV32IMZBS-NEXT:    lw s10, 108(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 120(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t0, a0, s10
-; RV32IMZBS-NEXT:    lw a3, 104(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 116(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t2, a0, a3
-; RV32IMZBS-NEXT:    lw s0, 112(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s0, 124(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t3, a0, s0
 ; RV32IMZBS-NEXT:    lw s3, 128(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t4, s3, s0
-; RV32IMZBS-NEXT:    lw s5, 132(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s5, 60(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t5, s5, s0
-; RV32IMZBS-NEXT:    lw a0, 136(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 132(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul s0, a0, s0
 ; RV32IMZBS-NEXT:    mul s1, a0, a3
 ; RV32IMZBS-NEXT:    mul s2, s3, a3
@@ -23734,12 +23734,12 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    mul a3, a0, s10
 ; RV32IMZBS-NEXT:    mul s10, s3, s10
 ; RV32IMZBS-NEXT:    mul a0, s3, s9
-; RV32IMZBS-NEXT:    lw a2, 184(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a2, 36(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and t6, t6, a2
 ; RV32IMZBS-NEXT:    and t1, t1, s11
 ; RV32IMZBS-NEXT:    mv s3, s6
 ; RV32IMZBS-NEXT:    and a1, a1, s6
-; RV32IMZBS-NEXT:    lw s6, 160(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s6, 68(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a6, a6, s6
 ; RV32IMZBS-NEXT:    or t1, t1, t6
 ; RV32IMZBS-NEXT:    or a1, a1, a6
@@ -23764,12 +23764,12 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    or a0, t0, a0
 ; RV32IMZBS-NEXT:    or a1, t1, a1
 ; RV32IMZBS-NEXT:    or a0, a2, a0
-; RV32IMZBS-NEXT:    lw a2, 68(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a2, 32(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    xor a1, a1, a2
 ; RV32IMZBS-NEXT:    srli a2, a0, 8
-; RV32IMZBS-NEXT:    lw a3, 76(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 100(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    xor a1, a3, a1
-; RV32IMZBS-NEXT:    lw a3, 176(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 20(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a2, a2, a3
 ; RV32IMZBS-NEXT:    and a6, a0, a3
 ; RV32IMZBS-NEXT:    srli t0, a0, 24
@@ -23778,16 +23778,16 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    or a2, a2, t0
 ; RV32IMZBS-NEXT:    or a0, a0, a6
 ; RV32IMZBS-NEXT:    or a0, a0, a2
-; RV32IMZBS-NEXT:    lw a2, 48(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw t0, 172(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a2, 168(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t0, 16(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a2, a2, t0
-; RV32IMZBS-NEXT:    lw a3, 40(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a4, 156(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 88(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 4(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a6, a3, a4
 ; RV32IMZBS-NEXT:    slli a2, a2, 1
 ; RV32IMZBS-NEXT:    or a2, a6, a2
 ; RV32IMZBS-NEXT:    srli a6, a0, 4
-; RV32IMZBS-NEXT:    lw a3, 180(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a6, a6, a3
 ; RV32IMZBS-NEXT:    and a0, a0, a3
 ; RV32IMZBS-NEXT:    srli a2, a2, 1
@@ -23795,11 +23795,11 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    xor a1, a2, a1
 ; RV32IMZBS-NEXT:    or a0, a6, a0
 ; RV32IMZBS-NEXT:    srli a2, a0, 2
-; RV32IMZBS-NEXT:    lw a3, 152(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 104(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a0, a0, a3
 ; RV32IMZBS-NEXT:    and a2, a2, a3
 ; RV32IMZBS-NEXT:    slli a0, a0, 2
-; RV32IMZBS-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 80(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a6, a3, 1
 ; RV32IMZBS-NEXT:    or a0, a2, a0
 ; RV32IMZBS-NEXT:    srli a2, a0, 1
@@ -23807,20 +23807,20 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    and a2, a2, a4
 ; RV32IMZBS-NEXT:    slli t0, a0, 1
 ; RV32IMZBS-NEXT:    xor a0, a1, a6
-; RV32IMZBS-NEXT:    sw a0, 180(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a0, a2, t0
-; RV32IMZBS-NEXT:    sw a0, 176(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    lw s8, 116(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a4, 32(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    lw s8, 48(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 28(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a1, a4, s8
-; RV32IMZBS-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw t1, 124(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t1, 56(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a2, a0, t1
-; RV32IMZBS-NEXT:    lw s9, 120(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s5, 28(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s9, 52(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s5, 160(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a6, s5, s9
-; RV32IMZBS-NEXT:    lw a3, 64(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw ra, 144(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 92(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t0, a3, ra
 ; RV32IMZBS-NEXT:    mul t2, a4, s9
 ; RV32IMZBS-NEXT:    mul t3, a0, s8
@@ -23842,29 +23842,29 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    xor a2, a6, t0
 ; RV32IMZBS-NEXT:    xor a6, s0, t6
 ; RV32IMZBS-NEXT:    xor t0, s1, s2
-; RV32IMZBS-NEXT:    lw s11, 184(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s11, 36(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, s11
-; RV32IMZBS-NEXT:    lw t4, 164(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t4, 72(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a2, a2, t4
 ; RV32IMZBS-NEXT:    xor t2, s4, s3
 ; RV32IMZBS-NEXT:    xor t3, s5, s6
 ; RV32IMZBS-NEXT:    xor a6, a6, t0
 ; RV32IMZBS-NEXT:    xor t0, t2, t3
-; RV32IMZBS-NEXT:    lw a0, 168(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a6, a6, a0
 ; RV32IMZBS-NEXT:    and t0, t0, s10
 ; RV32IMZBS-NEXT:    or a1, a2, a1
-; RV32IMZBS-NEXT:    sw a1, 172(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a0, a6, t0
-; RV32IMZBS-NEXT:    sw a0, 156(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    lw a0, 96(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a3, 72(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 96(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a6, a0, a3
-; RV32IMZBS-NEXT:    lw s6, 92(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s6, 44(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t0, s6, s7
-; RV32IMZBS-NEXT:    lw s10, 88(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 108(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t2, s10, a7
-; RV32IMZBS-NEXT:    lw s5, 84(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s5, 40(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t3, s5, a5
 ; RV32IMZBS-NEXT:    mul a2, a0, a7
 ; RV32IMZBS-NEXT:    mul t5, s6, a3
@@ -23898,14 +23898,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    mul a7, s6, t1
 ; RV32IMZBS-NEXT:    mul t2, s7, s9
 ; RV32IMZBS-NEXT:    mul t3, s5, ra
-; RV32IMZBS-NEXT:    lw s4, 168(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s4, 76(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a5, a5, s4
-; RV32IMZBS-NEXT:    lw s3, 160(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s3, 68(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a3, a3, s3
 ; RV32IMZBS-NEXT:    or a6, t0, a6
 ; RV32IMZBS-NEXT:    or a3, a5, a3
-; RV32IMZBS-NEXT:    lw a1, 172(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a2, 156(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a2, 4(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    or a1, a1, a2
 ; RV32IMZBS-NEXT:    or a2, a6, a3
 ; RV32IMZBS-NEXT:    mul a3, a0, s9
@@ -23939,16 +23939,16 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZBS-NEXT:    and a2, a2, s4
 ; RV32IMZBS-NEXT:    and a4, a4, s3
 ; RV32IMZBS-NEXT:    or a2, a2, a4
-; RV32IMZBS-NEXT:    lw a4, 176(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 20(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a4, a4, 1
 ; RV32IMZBS-NEXT:    xor a1, a4, a1
 ; RV32IMZBS-NEXT:    or a2, a3, a2
-; RV32IMZBS-NEXT:    lw a3, 80(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 184(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    sw a2, 0(a3)
 ; RV32IMZBS-NEXT:    sw a1, 4(a3)
-; RV32IMZBS-NEXT:    lw a1, 148(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a1, 64(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    sw a1, 8(a3)
-; RV32IMZBS-NEXT:    lw a0, 180(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    sw a0, 12(a3)
 ; RV32IMZBS-NEXT:    lw ra, 236(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    lw s0, 232(sp) # 4-byte Folded Reload
@@ -24597,16 +24597,16 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    .cfi_offset s9, -44
 ; RV32IMZVBC-NEXT:    .cfi_offset s10, -48
 ; RV32IMZVBC-NEXT:    .cfi_offset s11, -52
-; RV32IMZVBC-NEXT:    sw a2, 144(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a2, 12(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mv a6, a1
-; RV32IMZVBC-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a0, 184(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    lw a5, 4(a2)
-; RV32IMZVBC-NEXT:    sw a5, 76(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a5, 100(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    lui a0, 16
 ; RV32IMZVBC-NEXT:    lw a1, 8(a2)
-; RV32IMZVBC-NEXT:    sw a1, 148(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a1, 64(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    lw a1, 12(a2)
-; RV32IMZVBC-NEXT:    sw a1, 68(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a1, 32(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    addi t0, a0, -256
 ; RV32IMZVBC-NEXT:    srli a0, a5, 8
 ; RV32IMZVBC-NEXT:    srli a3, a5, 24
@@ -24638,7 +24638,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    and a3, a3, s10
 ; RV32IMZVBC-NEXT:    slli a0, a0, 1
 ; RV32IMZVBC-NEXT:    or a5, a3, a0
-; RV32IMZVBC-NEXT:    sw a5, 132(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a5, 60(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    srli a0, a5, 8
 ; RV32IMZVBC-NEXT:    and a0, a0, t0
 ; RV32IMZVBC-NEXT:    srli a3, a5, 24
@@ -24648,19 +24648,19 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    or a0, a0, a3
 ; RV32IMZVBC-NEXT:    or a4, a5, a4
 ; RV32IMZVBC-NEXT:    or a0, a4, a0
-; RV32IMZVBC-NEXT:    sw a6, 156(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 4(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    lw a7, 4(a6)
 ; RV32IMZVBC-NEXT:    srli a3, a0, 4
 ; RV32IMZVBC-NEXT:    and a3, a3, t5
 ; RV32IMZVBC-NEXT:    and a0, a0, t5
 ; RV32IMZVBC-NEXT:    slli a0, a0, 4
 ; RV32IMZVBC-NEXT:    lw a2, 8(a6)
-; RV32IMZVBC-NEXT:    sw a2, 40(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a2, 88(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    lw a2, 12(a6)
-; RV32IMZVBC-NEXT:    sw a2, 72(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a2, 96(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    or a0, a3, a0
 ; RV32IMZVBC-NEXT:    srli a3, a0, 2
-; RV32IMZVBC-NEXT:    sw a7, 64(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 92(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    srli a4, a7, 8
 ; RV32IMZVBC-NEXT:    and a3, a3, t4
 ; RV32IMZVBC-NEXT:    and a4, a4, t0
@@ -24690,7 +24690,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    slli a4, a4, 1
 ; RV32IMZVBC-NEXT:    srli a5, a0, 1
 ; RV32IMZVBC-NEXT:    or t1, a3, a4
-; RV32IMZVBC-NEXT:    sw t1, 124(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t1, 56(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a3, a5, s10
 ; RV32IMZVBC-NEXT:    srli a4, t1, 8
 ; RV32IMZVBC-NEXT:    and a0, a0, s10
@@ -24778,7 +24778,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    slli a3, a3, 8
 ; RV32IMZVBC-NEXT:    or a1, a1, a2
 ; RV32IMZVBC-NEXT:    or a3, a0, a3
-; RV32IMZVBC-NEXT:    lw a0, 156(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    lw a0, 0(a0)
 ; RV32IMZVBC-NEXT:    or a1, a3, a1
 ; RV32IMZVBC-NEXT:    srli a2, a1, 4
@@ -24789,7 +24789,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    srli a2, a1, 2
 ; RV32IMZVBC-NEXT:    and a2, a2, t4
 ; RV32IMZVBC-NEXT:    and a1, a1, t4
-; RV32IMZVBC-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    srli a3, a0, 8
 ; RV32IMZVBC-NEXT:    slli a1, a1, 2
 ; RV32IMZVBC-NEXT:    and a3, a3, t0
@@ -24813,7 +24813,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    slli a2, a2, 2
 ; RV32IMZVBC-NEXT:    lui s11, 349525
 ; RV32IMZVBC-NEXT:    addi s11, s11, 1364
-; RV32IMZVBC-NEXT:    sw s11, 156(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s11, 4(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    or a2, a3, a2
 ; RV32IMZVBC-NEXT:    srli a3, a2, 1
 ; RV32IMZVBC-NEXT:    and a2, a2, s10
@@ -24822,15 +24822,15 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    and a1, a1, s10
 ; RV32IMZVBC-NEXT:    mv ra, s10
 ; RV32IMZVBC-NEXT:    or a2, a3, a2
-; RV32IMZVBC-NEXT:    sw a7, 164(sp) # 4-byte Folded Spill
-; RV32IMZVBC-NEXT:    lw a0, 132(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    sw a7, 72(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and t1, a0, a7
-; RV32IMZVBC-NEXT:    sw t2, 184(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t2, 36(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and s7, a2, t2
 ; RV32IMZVBC-NEXT:    and t2, a0, t2
 ; RV32IMZVBC-NEXT:    and a3, a2, a7
 ; RV32IMZVBC-NEXT:    and s0, a0, s1
-; RV32IMZVBC-NEXT:    sw t3, 168(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t3, 76(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and t6, a0, t3
 ; RV32IMZVBC-NEXT:    and t3, a2, t3
 ; RV32IMZVBC-NEXT:    and s10, a2, s1
@@ -24845,23 +24845,23 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    mul s4, t3, t6
 ; RV32IMZVBC-NEXT:    mul s5, s10, t2
 ; RV32IMZVBC-NEXT:    mul s6, s7, t2
-; RV32IMZVBC-NEXT:    sw t2, 120(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t2, 52(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mv a0, s7
-; RV32IMZVBC-NEXT:    sw s7, 140(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s7, 136(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul s7, t1, t6
-; RV32IMZVBC-NEXT:    sw t1, 136(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t1, 132(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul s8, t3, a7
-; RV32IMZVBC-NEXT:    sw a7, 96(sp) # 4-byte Folded Spill
-; RV32IMZVBC-NEXT:    sw t3, 132(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 8(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t3, 60(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul s9, s10, s0
 ; RV32IMZVBC-NEXT:    sw s10, 128(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a4, a4, s11
 ; RV32IMZVBC-NEXT:    slli a1, a1, 1
 ; RV32IMZVBC-NEXT:    or a1, a4, a1
-; RV32IMZVBC-NEXT:    sw a1, 116(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a1, 48(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a2, a3, a2
 ; RV32IMZVBC-NEXT:    xor a3, a5, a6
-; RV32IMZVBC-NEXT:    lw a1, 144(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    lw a1, 0(a1)
 ; RV32IMZVBC-NEXT:    xor a4, s3, s2
 ; RV32IMZVBC-NEXT:    xor a5, s4, s5
@@ -24870,13 +24870,13 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    xor a3, s7, s6
 ; RV32IMZVBC-NEXT:    xor a5, s8, s9
 ; RV32IMZVBC-NEXT:    srli a6, a1, 8
-; RV32IMZVBC-NEXT:    sw t0, 176(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t0, 20(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and s2, a1, t0
 ; RV32IMZVBC-NEXT:    and a6, a6, t0
 ; RV32IMZVBC-NEXT:    slli s2, s2, 8
 ; RV32IMZVBC-NEXT:    mul s3, a0, t6
 ; RV32IMZVBC-NEXT:    mul s4, t1, s0
-; RV32IMZVBC-NEXT:    sw a1, 144(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    srli s5, a1, 24
 ; RV32IMZVBC-NEXT:    slli s6, a1, 24
 ; RV32IMZVBC-NEXT:    or a6, a6, s5
@@ -24886,41 +24886,41 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    mul a6, t3, t2
 ; RV32IMZVBC-NEXT:    mul s2, s10, a7
 ; RV32IMZVBC-NEXT:    srli s5, a5, 4
-; RV32IMZVBC-NEXT:    sw t5, 180(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t5, 24(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a5, a5, t5
 ; RV32IMZVBC-NEXT:    and s5, s5, t5
 ; RV32IMZVBC-NEXT:    slli a5, a5, 4
 ; RV32IMZVBC-NEXT:    xor s3, s4, s3
 ; RV32IMZVBC-NEXT:    or a5, s5, a5
 ; RV32IMZVBC-NEXT:    srli s4, a5, 2
-; RV32IMZVBC-NEXT:    sw t4, 152(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t4, 104(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a5, a5, t4
 ; RV32IMZVBC-NEXT:    and s4, s4, t4
 ; RV32IMZVBC-NEXT:    slli a5, a5, 2
 ; RV32IMZVBC-NEXT:    xor a6, a6, s2
 ; RV32IMZVBC-NEXT:    or a5, s4, a5
 ; RV32IMZVBC-NEXT:    srli s2, a5, 1
-; RV32IMZVBC-NEXT:    sw ra, 172(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw ra, 16(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a5, a5, ra
 ; RV32IMZVBC-NEXT:    and s2, s2, ra
 ; RV32IMZVBC-NEXT:    slli a5, a5, 1
 ; RV32IMZVBC-NEXT:    xor a6, s3, a6
 ; RV32IMZVBC-NEXT:    or a5, s2, a5
-; RV32IMZVBC-NEXT:    lw t1, 184(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t1, 36(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a0, a2, t1
-; RV32IMZVBC-NEXT:    sw a0, 92(sp) # 4-byte Folded Spill
-; RV32IMZVBC-NEXT:    lw t0, 164(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    lw t0, 72(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s10, a4, t0
-; RV32IMZVBC-NEXT:    lw t5, 168(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t5, 76(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s3, a3, t5
 ; RV32IMZVBC-NEXT:    mv a1, s1
-; RV32IMZVBC-NEXT:    sw s1, 160(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s1, 68(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and s1, a6, s1
 ; RV32IMZVBC-NEXT:    and t4, a5, t0
 ; RV32IMZVBC-NEXT:    and a3, a5, t1
 ; RV32IMZVBC-NEXT:    and a6, a5, a1
 ; RV32IMZVBC-NEXT:    and a0, a5, t5
-; RV32IMZVBC-NEXT:    lw a7, 124(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a7, 56(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s4, a7, t1
 ; RV32IMZVBC-NEXT:    and s2, a7, t0
 ; RV32IMZVBC-NEXT:    and a2, a7, t5
@@ -24928,17 +24928,17 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    mul t2, s4, t4
 ; RV32IMZVBC-NEXT:    mul s5, s2, a3
 ; RV32IMZVBC-NEXT:    mul s6, a2, a6
-; RV32IMZVBC-NEXT:    sw a0, 112(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a0, 124(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul s7, a7, a0
 ; RV32IMZVBC-NEXT:    mul s8, s4, a6
 ; RV32IMZVBC-NEXT:    mv a1, a6
-; RV32IMZVBC-NEXT:    sw a6, 108(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 120(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul s9, s2, t4
-; RV32IMZVBC-NEXT:    sw t4, 100(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t4, 112(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul s11, a2, a0
 ; RV32IMZVBC-NEXT:    mul ra, a7, a3
 ; RV32IMZVBC-NEXT:    mul t3, s4, a3
-; RV32IMZVBC-NEXT:    sw a3, 104(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a3, 116(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul t0, s2, a0
 ; RV32IMZVBC-NEXT:    mul t1, a2, t4
 ; RV32IMZVBC-NEXT:    mul a5, a7, a6
@@ -24946,7 +24946,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    mul a4, s2, a1
 ; RV32IMZVBC-NEXT:    mul a1, a2, a3
 ; RV32IMZVBC-NEXT:    mul a0, a7, t4
-; RV32IMZVBC-NEXT:    lw a3, 92(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 44(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    or s10, s10, a3
 ; RV32IMZVBC-NEXT:    or s1, s3, s1
 ; RV32IMZVBC-NEXT:    xor t2, s5, t2
@@ -24961,24 +24961,24 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    xor a0, a1, a0
 ; RV32IMZVBC-NEXT:    xor a1, t0, a5
 ; RV32IMZVBC-NEXT:    xor a0, a3, a0
-; RV32IMZVBC-NEXT:    lw s9, 184(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s9, 36(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a3, t2, s9
-; RV32IMZVBC-NEXT:    lw s11, 164(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s11, 72(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, s3, s11
 ; RV32IMZVBC-NEXT:    mv s8, t5
 ; RV32IMZVBC-NEXT:    and a1, a1, t5
-; RV32IMZVBC-NEXT:    lw t5, 160(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t5, 68(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a0, a0, t5
 ; RV32IMZVBC-NEXT:    or a3, a4, a3
 ; RV32IMZVBC-NEXT:    or a0, a1, a0
 ; RV32IMZVBC-NEXT:    or a1, s10, s1
 ; RV32IMZVBC-NEXT:    or a0, a3, a0
 ; RV32IMZVBC-NEXT:    xor a0, a0, a1
-; RV32IMZVBC-NEXT:    lw a1, 116(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a1, 48(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    srli a1, a1, 1
 ; RV32IMZVBC-NEXT:    xor a0, a1, a0
 ; RV32IMZVBC-NEXT:    srli a1, a0, 8
-; RV32IMZVBC-NEXT:    lw t3, 176(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t3, 20(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a1, a1, t3
 ; RV32IMZVBC-NEXT:    srli a3, a0, 24
 ; RV32IMZVBC-NEXT:    and a4, a0, t3
@@ -24986,10 +24986,10 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    slli a4, a4, 8
 ; RV32IMZVBC-NEXT:    or a0, a1, a3
 ; RV32IMZVBC-NEXT:    or s3, a5, a4
-; RV32IMZVBC-NEXT:    lw s6, 96(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s6, 8(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul a1, s4, s6
 ; RV32IMZVBC-NEXT:    mul a3, s4, s0
-; RV32IMZVBC-NEXT:    lw s7, 120(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s7, 52(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul a4, s4, s7
 ; RV32IMZVBC-NEXT:    mul a5, s4, t6
 ; RV32IMZVBC-NEXT:    mul a6, s2, s7
@@ -25027,7 +25027,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    or a2, a4, a2
 ; RV32IMZVBC-NEXT:    or a1, a1, a2
 ; RV32IMZVBC-NEXT:    srli a2, a0, 4
-; RV32IMZVBC-NEXT:    lw a5, 180(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 24(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a2, a2, a5
 ; RV32IMZVBC-NEXT:    and a0, a0, a5
 ; RV32IMZVBC-NEXT:    slli a0, a0, 4
@@ -25041,50 +25041,50 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    or a2, a2, a3
 ; RV32IMZVBC-NEXT:    or a1, a1, a4
 ; RV32IMZVBC-NEXT:    srli a3, a0, 2
-; RV32IMZVBC-NEXT:    lw a4, 152(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 104(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a0, a0, a4
 ; RV32IMZVBC-NEXT:    and a3, a3, a4
 ; RV32IMZVBC-NEXT:    slli a0, a0, 2
 ; RV32IMZVBC-NEXT:    or a0, a3, a0
 ; RV32IMZVBC-NEXT:    or a1, a1, a2
 ; RV32IMZVBC-NEXT:    srli a2, a0, 1
-; RV32IMZVBC-NEXT:    lw a3, 172(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 16(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a7, a0, a3
-; RV32IMZVBC-NEXT:    lw a0, 156(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a0, a2, a0
-; RV32IMZVBC-NEXT:    sw a0, 96(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a2, a7, 1
 ; RV32IMZVBC-NEXT:    srli a0, a1, 4
 ; RV32IMZVBC-NEXT:    and a1, a1, a5
 ; RV32IMZVBC-NEXT:    and a0, a0, a5
 ; RV32IMZVBC-NEXT:    slli a1, a1, 4
-; RV32IMZVBC-NEXT:    lw a3, 144(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 12(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s9, a3, s11
-; RV32IMZVBC-NEXT:    sw s9, 116(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s9, 48(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mv a4, t1
 ; RV32IMZVBC-NEXT:    and s8, a3, t1
-; RV32IMZVBC-NEXT:    sw s8, 124(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s8, 56(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mv a7, t5
 ; RV32IMZVBC-NEXT:    and t1, a3, t5
 ; RV32IMZVBC-NEXT:    and s3, a3, a6
-; RV32IMZVBC-NEXT:    sw s3, 144(sp) # 4-byte Folded Spill
-; RV32IMZVBC-NEXT:    lw ra, 40(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    sw s3, 12(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    lw ra, 88(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s2, ra, a4
-; RV32IMZVBC-NEXT:    sw s2, 44(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s2, 164(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and t4, ra, s11
-; RV32IMZVBC-NEXT:    sw t4, 60(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t4, 180(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul a3, s2, s9
 ; RV32IMZVBC-NEXT:    mul a4, t4, s8
 ; RV32IMZVBC-NEXT:    and s4, ra, a6
 ; RV32IMZVBC-NEXT:    mv s10, a6
-; RV32IMZVBC-NEXT:    sw s4, 56(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s4, 176(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and s6, ra, t5
-; RV32IMZVBC-NEXT:    sw s6, 52(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s6, 172(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul a5, s4, t1
 ; RV32IMZVBC-NEXT:    mul a6, s6, s3
 ; RV32IMZVBC-NEXT:    mul t0, s2, t1
 ; RV32IMZVBC-NEXT:    mv s5, t1
-; RV32IMZVBC-NEXT:    sw t1, 120(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t1, 52(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul t1, t4, s9
 ; RV32IMZVBC-NEXT:    mul t2, s4, s3
 ; RV32IMZVBC-NEXT:    mul t3, s6, s8
@@ -25096,9 +25096,9 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    mul s3, t4, s5
 ; RV32IMZVBC-NEXT:    mul s5, s4, s8
 ; RV32IMZVBC-NEXT:    mul s8, s6, s9
-; RV32IMZVBC-NEXT:    lw t4, 96(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t4, 8(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    or a2, t4, a2
-; RV32IMZVBC-NEXT:    sw a2, 36(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a2, 84(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    or a0, a0, a1
 ; RV32IMZVBC-NEXT:    xor a3, a4, a3
 ; RV32IMZVBC-NEXT:    xor a1, a5, a6
@@ -25112,23 +25112,23 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    xor a5, s5, s8
 ; RV32IMZVBC-NEXT:    xor a3, a3, s0
 ; RV32IMZVBC-NEXT:    xor a4, a4, a5
-; RV32IMZVBC-NEXT:    lw s7, 184(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s7, 36(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a1, a1, s7
 ; RV32IMZVBC-NEXT:    and a2, a2, s11
 ; RV32IMZVBC-NEXT:    and a3, a3, s10
 ; RV32IMZVBC-NEXT:    and a4, a4, a7
 ; RV32IMZVBC-NEXT:    or a1, a2, a1
-; RV32IMZVBC-NEXT:    sw a1, 32(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    or a5, a3, a4
 ; RV32IMZVBC-NEXT:    srli a4, a0, 2
-; RV32IMZVBC-NEXT:    lw a3, 152(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 104(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a6, a0, a3
-; RV32IMZVBC-NEXT:    lw a2, 84(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a2, 40(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a1, a2, s7
 ; RV32IMZVBC-NEXT:    and t4, a2, s11
 ; RV32IMZVBC-NEXT:    and a0, a2, s10
 ; RV32IMZVBC-NEXT:    and a2, a2, a7
-; RV32IMZVBC-NEXT:    lw t3, 148(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t3, 64(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s4, t3, s11
 ; RV32IMZVBC-NEXT:    and s9, t3, s7
 ; RV32IMZVBC-NEXT:    mul t0, a1, s4
@@ -25142,27 +25142,27 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    mul s1, a0, t5
 ; RV32IMZVBC-NEXT:    mul s5, a2, s9
 ; RV32IMZVBC-NEXT:    mul s8, a1, s9
-; RV32IMZVBC-NEXT:    sw s9, 20(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s9, 156(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mv a7, a1
-; RV32IMZVBC-NEXT:    sw a1, 96(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul s10, t4, t5
-; RV32IMZVBC-NEXT:    sw t5, 4(sp) # 4-byte Folded Spill
-; RV32IMZVBC-NEXT:    sw t4, 92(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t5, 140(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t4, 44(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul a1, a0, s4
-; RV32IMZVBC-NEXT:    sw s4, 16(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s4, 152(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mv s2, a0
-; RV32IMZVBC-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a0, 108(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mv s6, s3
-; RV32IMZVBC-NEXT:    sw s3, 24(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s3, 80(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul a0, a2, s3
-; RV32IMZVBC-NEXT:    sw a2, 84(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a2, 40(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a4, a4, a3
 ; RV32IMZVBC-NEXT:    slli a6, a6, 2
 ; RV32IMZVBC-NEXT:    or s3, a4, a6
-; RV32IMZVBC-NEXT:    sw s3, 48(sp) # 4-byte Folded Spill
-; RV32IMZVBC-NEXT:    lw a4, 32(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    sw s3, 168(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    lw a4, 28(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    or a4, a4, a5
-; RV32IMZVBC-NEXT:    sw a4, 32(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a4, 28(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a4, t1, t0
 ; RV32IMZVBC-NEXT:    xor a5, t2, t3
 ; RV32IMZVBC-NEXT:    xor a6, s0, t6
@@ -25178,7 +25178,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    mul a5, a7, t5
 ; RV32IMZVBC-NEXT:    mul a6, t4, s6
 ; RV32IMZVBC-NEXT:    srli t0, ra, 8
-; RV32IMZVBC-NEXT:    lw a1, 176(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and t1, ra, a1
 ; RV32IMZVBC-NEXT:    and t0, t0, a1
 ; RV32IMZVBC-NEXT:    slli t1, t1, 8
@@ -25191,7 +25191,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    xor a5, a6, a5
 ; RV32IMZVBC-NEXT:    or a6, t1, t0
 ; RV32IMZVBC-NEXT:    srli t0, a6, 4
-; RV32IMZVBC-NEXT:    lw a1, 180(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a6, a6, a1
 ; RV32IMZVBC-NEXT:    and t0, t0, a1
 ; RV32IMZVBC-NEXT:    slli a6, a6, 4
@@ -25204,12 +25204,12 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    slli a6, a6, 2
 ; RV32IMZVBC-NEXT:    xor a5, a5, t1
 ; RV32IMZVBC-NEXT:    or a6, t0, a6
-; RV32IMZVBC-NEXT:    lw a1, 168(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a1, 76(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a0, a0, a1
-; RV32IMZVBC-NEXT:    lw s6, 160(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s6, 68(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a5, a5, s6
 ; RV32IMZVBC-NEXT:    srli t0, a6, 1
-; RV32IMZVBC-NEXT:    lw a3, 172(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 16(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a6, a6, a3
 ; RV32IMZVBC-NEXT:    and t0, t0, a3
 ; RV32IMZVBC-NEXT:    slli a6, a6, 1
@@ -25223,14 +25223,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    mv s11, a1
 ; RV32IMZVBC-NEXT:    and s5, a5, s6
 ; RV32IMZVBC-NEXT:    srli s9, s3, 1
-; RV32IMZVBC-NEXT:    sw s9, 40(sp) # 4-byte Folded Spill
-; RV32IMZVBC-NEXT:    lw t4, 100(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    sw s9, 88(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    lw t4, 112(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul a5, a4, t4
-; RV32IMZVBC-NEXT:    lw s2, 104(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s2, 116(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t0, a6, s2
-; RV32IMZVBC-NEXT:    lw s7, 108(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s7, 120(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t1, t6, s7
-; RV32IMZVBC-NEXT:    lw a2, 112(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a2, 124(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t2, s5, a2
 ; RV32IMZVBC-NEXT:    mul t3, a4, s7
 ; RV32IMZVBC-NEXT:    mul t5, a6, t4
@@ -25240,14 +25240,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    mul s10, a6, a2
 ; RV32IMZVBC-NEXT:    mul a7, t6, t4
 ; RV32IMZVBC-NEXT:    mul a1, s5, s7
-; RV32IMZVBC-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    srli a0, a0, 1
 ; RV32IMZVBC-NEXT:    slli s9, s9, 31
 ; RV32IMZVBC-NEXT:    or a0, a0, s9
-; RV32IMZVBC-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
-; RV32IMZVBC-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    sw a0, 148(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    xor a0, a3, a0
-; RV32IMZVBC-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a0, 144(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a0, t0, a5
 ; RV32IMZVBC-NEXT:    xor a3, t1, t2
 ; RV32IMZVBC-NEXT:    xor a5, t5, t3
@@ -25258,9 +25258,9 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    xor a1, a7, a1
 ; RV32IMZVBC-NEXT:    mul a7, a4, a2
 ; RV32IMZVBC-NEXT:    mul a4, a6, s7
-; RV32IMZVBC-NEXT:    lw t2, 148(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t2, 64(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    srli a6, t2, 8
-; RV32IMZVBC-NEXT:    lw s8, 176(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s8, 20(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and t0, t2, s8
 ; RV32IMZVBC-NEXT:    and a6, a6, s8
 ; RV32IMZVBC-NEXT:    slli t0, t0, 8
@@ -25273,7 +25273,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    mul a6, t6, s2
 ; RV32IMZVBC-NEXT:    mul t0, s5, t4
 ; RV32IMZVBC-NEXT:    srli t1, a1, 4
-; RV32IMZVBC-NEXT:    lw s9, 180(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s9, 24(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a1, a1, s9
 ; RV32IMZVBC-NEXT:    and t1, t1, s9
 ; RV32IMZVBC-NEXT:    slli a1, a1, 4
@@ -25287,24 +25287,24 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    xor a6, a6, t0
 ; RV32IMZVBC-NEXT:    or a1, a4, a1
 ; RV32IMZVBC-NEXT:    srli a4, a1, 1
-; RV32IMZVBC-NEXT:    lw a7, 172(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a7, 16(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a1, a1, a7
 ; RV32IMZVBC-NEXT:    and a4, a4, a7
 ; RV32IMZVBC-NEXT:    slli a1, a1, 1
 ; RV32IMZVBC-NEXT:    xor a2, a2, a6
 ; RV32IMZVBC-NEXT:    or a1, a4, a1
-; RV32IMZVBC-NEXT:    lw s2, 164(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s2, 72(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a1, s2
 ; RV32IMZVBC-NEXT:    and a6, a1, ra
 ; RV32IMZVBC-NEXT:    mv s0, s6
 ; RV32IMZVBC-NEXT:    and t0, a1, s6
 ; RV32IMZVBC-NEXT:    mv s7, s11
 ; RV32IMZVBC-NEXT:    and a1, a1, s11
-; RV32IMZVBC-NEXT:    lw s5, 140(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s5, 136(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t1, s5, a4
-; RV32IMZVBC-NEXT:    lw s1, 136(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s1, 132(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t2, s1, a6
-; RV32IMZVBC-NEXT:    lw s4, 132(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s4, 60(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t3, s4, t0
 ; RV32IMZVBC-NEXT:    lw s6, 128(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t5, s6, a1
@@ -25388,7 +25388,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    or a1, a3, a1
 ; RV32IMZVBC-NEXT:    srli a2, a0, 1
 ; RV32IMZVBC-NEXT:    and a0, a0, a7
-; RV32IMZVBC-NEXT:    lw a4, 156(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 4(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a2, a2, a4
 ; RV32IMZVBC-NEXT:    slli a0, a0, 1
 ; RV32IMZVBC-NEXT:    srli a3, a1, 1
@@ -25397,24 +25397,24 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    slli a1, a1, 1
 ; RV32IMZVBC-NEXT:    or a0, a2, a0
 ; RV32IMZVBC-NEXT:    or a1, a3, a1
-; RV32IMZVBC-NEXT:    lw a2, 64(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a2, 92(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a2, ra
 ; RV32IMZVBC-NEXT:    and s2, a2, s2
 ; RV32IMZVBC-NEXT:    and t5, a2, s7
 ; RV32IMZVBC-NEXT:    and s3, a2, s10
-; RV32IMZVBC-NEXT:    lw a6, 4(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a6, 140(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul a2, s3, a6
-; RV32IMZVBC-NEXT:    sw s3, 64(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s3, 92(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul a3, t5, a6
-; RV32IMZVBC-NEXT:    sw s2, 36(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s2, 84(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul a5, s2, a6
-; RV32IMZVBC-NEXT:    sw a4, 32(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a4, 28(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul a6, a4, a6
-; RV32IMZVBC-NEXT:    lw t6, 16(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t6, 152(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul a7, a4, t6
-; RV32IMZVBC-NEXT:    lw s0, 20(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s0, 156(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t0, s2, s0
-; RV32IMZVBC-NEXT:    lw t4, 24(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t4, 80(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t1, t5, t4
 ; RV32IMZVBC-NEXT:    mul t2, a4, t4
 ; RV32IMZVBC-NEXT:    mul t3, s2, t6
@@ -25422,16 +25422,16 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    mul s5, s3, t4
 ; RV32IMZVBC-NEXT:    mul t4, s2, t4
 ; RV32IMZVBC-NEXT:    mul s8, a4, s0
-; RV32IMZVBC-NEXT:    sw t5, 28(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t5, 160(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul s9, t5, t6
 ; RV32IMZVBC-NEXT:    mul s2, t5, s0
 ; RV32IMZVBC-NEXT:    mul s3, s3, t6
-; RV32IMZVBC-NEXT:    lw a4, 12(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw t5, 8(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 148(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t5, 144(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    xor a4, a4, t5
-; RV32IMZVBC-NEXT:    sw a4, 148(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a4, 64(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a0, a1, a0
-; RV32IMZVBC-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a0, t0, a7
 ; RV32IMZVBC-NEXT:    xor a1, t1, a2
 ; RV32IMZVBC-NEXT:    xor a2, t3, t2
@@ -25451,18 +25451,18 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    and a1, a1, s7
 ; RV32IMZVBC-NEXT:    mv s0, s10
 ; RV32IMZVBC-NEXT:    and a3, a3, s10
-; RV32IMZVBC-NEXT:    lw t1, 68(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t1, 32(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a5, t1, s11
 ; RV32IMZVBC-NEXT:    and a6, t1, ra
 ; RV32IMZVBC-NEXT:    and a7, t1, s10
 ; RV32IMZVBC-NEXT:    and t0, t1, s7
-; RV32IMZVBC-NEXT:    lw t6, 84(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t6, 40(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t1, t6, t0
-; RV32IMZVBC-NEXT:    lw t5, 88(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t5, 108(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t2, t5, t0
-; RV32IMZVBC-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t3, a0, t0
-; RV32IMZVBC-NEXT:    lw s10, 96(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 8(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t0, s10, t0
 ; RV32IMZVBC-NEXT:    mul t4, s10, a5
 ; RV32IMZVBC-NEXT:    mul s1, a0, a6
@@ -25496,18 +25496,18 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    and a5, a5, s0
 ; RV32IMZVBC-NEXT:    or a1, a4, a3
 ; RV32IMZVBC-NEXT:    or a3, a0, a5
-; RV32IMZVBC-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a0, 96(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a0, ra
 ; RV32IMZVBC-NEXT:    and a5, a0, s11
 ; RV32IMZVBC-NEXT:    and a6, a0, s7
 ; RV32IMZVBC-NEXT:    and a7, a0, s0
-; RV32IMZVBC-NEXT:    lw t6, 116(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t6, 48(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t0, a4, t6
-; RV32IMZVBC-NEXT:    lw a0, 120(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t1, a4, a0
-; RV32IMZVBC-NEXT:    lw s11, 124(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s11, 56(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t2, a4, s11
-; RV32IMZVBC-NEXT:    lw s5, 144(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s5, 12(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul a4, a4, s5
 ; RV32IMZVBC-NEXT:    mul t3, a5, s11
 ; RV32IMZVBC-NEXT:    mul t4, a6, a0
@@ -25523,7 +25523,7 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    mul a7, a7, t6
 ; RV32IMZVBC-NEXT:    or ra, t5, a2
 ; RV32IMZVBC-NEXT:    or a1, a1, a3
-; RV32IMZVBC-NEXT:    sw a1, 68(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a1, 32(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a1, t3, t0
 ; RV32IMZVBC-NEXT:    xor a2, t4, s1
 ; RV32IMZVBC-NEXT:    xor t0, s2, t1
@@ -25543,24 +25543,24 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    and a0, a0, s0
 ; RV32IMZVBC-NEXT:    or t6, a2, a1
 ; RV32IMZVBC-NEXT:    or a6, a4, a0
-; RV32IMZVBC-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a0, 100(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a0, s4
 ; RV32IMZVBC-NEXT:    mv s11, s4
 ; RV32IMZVBC-NEXT:    and s7, a0, s6
 ; RV32IMZVBC-NEXT:    and a7, a0, s0
 ; RV32IMZVBC-NEXT:    and a5, a0, a3
 ; RV32IMZVBC-NEXT:    mv s6, a3
-; RV32IMZVBC-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    sw a4, 72(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    lw a0, 164(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    sw a4, 96(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul t0, a0, a4
 ; RV32IMZVBC-NEXT:    mul t1, a0, a7
 ; RV32IMZVBC-NEXT:    mul t2, a0, s7
 ; RV32IMZVBC-NEXT:    mul t3, a0, a5
-; RV32IMZVBC-NEXT:    lw a2, 60(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a2, 180(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t4, a2, s7
-; RV32IMZVBC-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a0, 176(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t5, a0, a7
-; RV32IMZVBC-NEXT:    lw a3, 52(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 172(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul s1, a3, a5
 ; RV32IMZVBC-NEXT:    mul s2, a2, a4
 ; RV32IMZVBC-NEXT:    mul s3, a0, a5
@@ -25571,11 +25571,11 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    mul a2, a3, a7
 ; RV32IMZVBC-NEXT:    mul a1, a0, s7
 ; RV32IMZVBC-NEXT:    mul a0, a3, a4
-; RV32IMZVBC-NEXT:    lw a3, 68(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 32(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    xor a3, a3, ra
-; RV32IMZVBC-NEXT:    sw a3, 76(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a3, 100(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    or a3, t6, a6
-; RV32IMZVBC-NEXT:    sw a3, 68(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a3, 32(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a6, t4, t0
 ; RV32IMZVBC-NEXT:    xor t0, t5, s1
 ; RV32IMZVBC-NEXT:    xor t1, s2, t1
@@ -25588,20 +25588,20 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    xor a0, a1, a0
 ; RV32IMZVBC-NEXT:    xor a1, t0, a2
 ; RV32IMZVBC-NEXT:    xor a6, t2, a0
-; RV32IMZVBC-NEXT:    lw a0, 140(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw s9, 100(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a0, 136(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s9, 112(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul ra, a0, s9
-; RV32IMZVBC-NEXT:    lw s10, 108(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 120(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t0, a0, s10
-; RV32IMZVBC-NEXT:    lw a3, 104(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 116(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t2, a0, a3
-; RV32IMZVBC-NEXT:    lw s0, 112(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s0, 124(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t3, a0, s0
 ; RV32IMZVBC-NEXT:    lw s3, 128(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t4, s3, s0
-; RV32IMZVBC-NEXT:    lw s5, 132(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s5, 60(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t5, s5, s0
-; RV32IMZVBC-NEXT:    lw a0, 136(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a0, 132(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul s0, a0, s0
 ; RV32IMZVBC-NEXT:    mul s1, a0, a3
 ; RV32IMZVBC-NEXT:    mul s2, s3, a3
@@ -25612,12 +25612,12 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    mul a3, a0, s10
 ; RV32IMZVBC-NEXT:    mul s10, s3, s10
 ; RV32IMZVBC-NEXT:    mul a0, s3, s9
-; RV32IMZVBC-NEXT:    lw a2, 184(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a2, 36(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and t6, t6, a2
 ; RV32IMZVBC-NEXT:    and t1, t1, s11
 ; RV32IMZVBC-NEXT:    mv s3, s6
 ; RV32IMZVBC-NEXT:    and a1, a1, s6
-; RV32IMZVBC-NEXT:    lw s6, 160(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s6, 68(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a6, a6, s6
 ; RV32IMZVBC-NEXT:    or t1, t1, t6
 ; RV32IMZVBC-NEXT:    or a1, a1, a6
@@ -25642,12 +25642,12 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    or a0, t0, a0
 ; RV32IMZVBC-NEXT:    or a1, t1, a1
 ; RV32IMZVBC-NEXT:    or a0, a2, a0
-; RV32IMZVBC-NEXT:    lw a2, 68(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a2, 32(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    xor a1, a1, a2
 ; RV32IMZVBC-NEXT:    srli a2, a0, 8
-; RV32IMZVBC-NEXT:    lw a3, 76(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 100(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    xor a1, a3, a1
-; RV32IMZVBC-NEXT:    lw a3, 176(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 20(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a2, a2, a3
 ; RV32IMZVBC-NEXT:    and a6, a0, a3
 ; RV32IMZVBC-NEXT:    srli t0, a0, 24
@@ -25656,16 +25656,16 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    or a2, a2, t0
 ; RV32IMZVBC-NEXT:    or a0, a0, a6
 ; RV32IMZVBC-NEXT:    or a0, a0, a2
-; RV32IMZVBC-NEXT:    lw a2, 48(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw t0, 172(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a2, 168(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t0, 16(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a2, a2, t0
-; RV32IMZVBC-NEXT:    lw a3, 40(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a4, 156(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 88(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 4(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a6, a3, a4
 ; RV32IMZVBC-NEXT:    slli a2, a2, 1
 ; RV32IMZVBC-NEXT:    or a2, a6, a2
 ; RV32IMZVBC-NEXT:    srli a6, a0, 4
-; RV32IMZVBC-NEXT:    lw a3, 180(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a6, a6, a3
 ; RV32IMZVBC-NEXT:    and a0, a0, a3
 ; RV32IMZVBC-NEXT:    srli a2, a2, 1
@@ -25673,11 +25673,11 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    xor a1, a2, a1
 ; RV32IMZVBC-NEXT:    or a0, a6, a0
 ; RV32IMZVBC-NEXT:    srli a2, a0, 2
-; RV32IMZVBC-NEXT:    lw a3, 152(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 104(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a0, a0, a3
 ; RV32IMZVBC-NEXT:    and a2, a2, a3
 ; RV32IMZVBC-NEXT:    slli a0, a0, 2
-; RV32IMZVBC-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 80(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    srli a6, a3, 1
 ; RV32IMZVBC-NEXT:    or a0, a2, a0
 ; RV32IMZVBC-NEXT:    srli a2, a0, 1
@@ -25685,20 +25685,20 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    and a2, a2, a4
 ; RV32IMZVBC-NEXT:    slli t0, a0, 1
 ; RV32IMZVBC-NEXT:    xor a0, a1, a6
-; RV32IMZVBC-NEXT:    sw a0, 180(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    or a0, a2, t0
-; RV32IMZVBC-NEXT:    sw a0, 176(sp) # 4-byte Folded Spill
-; RV32IMZVBC-NEXT:    lw s8, 116(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a4, 32(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    lw s8, 48(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 28(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul a1, a4, s8
-; RV32IMZVBC-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw t1, 124(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t1, 56(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul a2, a0, t1
-; RV32IMZVBC-NEXT:    lw s9, 120(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw s5, 28(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s9, 52(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s5, 160(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul a6, s5, s9
-; RV32IMZVBC-NEXT:    lw a3, 64(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw ra, 144(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 92(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t0, a3, ra
 ; RV32IMZVBC-NEXT:    mul t2, a4, s9
 ; RV32IMZVBC-NEXT:    mul t3, a0, s8
@@ -25720,29 +25720,29 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    xor a2, a6, t0
 ; RV32IMZVBC-NEXT:    xor a6, s0, t6
 ; RV32IMZVBC-NEXT:    xor t0, s1, s2
-; RV32IMZVBC-NEXT:    lw s11, 184(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s11, 36(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a1, a1, s11
-; RV32IMZVBC-NEXT:    lw t4, 164(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t4, 72(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a2, a2, t4
 ; RV32IMZVBC-NEXT:    xor t2, s4, s3
 ; RV32IMZVBC-NEXT:    xor t3, s5, s6
 ; RV32IMZVBC-NEXT:    xor a6, a6, t0
 ; RV32IMZVBC-NEXT:    xor t0, t2, t3
-; RV32IMZVBC-NEXT:    lw a0, 168(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a6, a6, a0
 ; RV32IMZVBC-NEXT:    and t0, t0, s10
 ; RV32IMZVBC-NEXT:    or a1, a2, a1
-; RV32IMZVBC-NEXT:    sw a1, 172(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    or a0, a6, t0
-; RV32IMZVBC-NEXT:    sw a0, 156(sp) # 4-byte Folded Spill
-; RV32IMZVBC-NEXT:    lw a0, 96(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a3, 72(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 96(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul a6, a0, a3
-; RV32IMZVBC-NEXT:    lw s6, 92(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s6, 44(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t0, s6, s7
-; RV32IMZVBC-NEXT:    lw s10, 88(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s10, 108(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t2, s10, a7
-; RV32IMZVBC-NEXT:    lw s5, 84(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s5, 40(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t3, s5, a5
 ; RV32IMZVBC-NEXT:    mul a2, a0, a7
 ; RV32IMZVBC-NEXT:    mul t5, s6, a3
@@ -25776,14 +25776,14 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    mul a7, s6, t1
 ; RV32IMZVBC-NEXT:    mul t2, s7, s9
 ; RV32IMZVBC-NEXT:    mul t3, s5, ra
-; RV32IMZVBC-NEXT:    lw s4, 168(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s4, 76(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a5, a5, s4
-; RV32IMZVBC-NEXT:    lw s3, 160(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s3, 68(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a3, a3, s3
 ; RV32IMZVBC-NEXT:    or a6, t0, a6
 ; RV32IMZVBC-NEXT:    or a3, a5, a3
-; RV32IMZVBC-NEXT:    lw a1, 172(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw a2, 156(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a2, 4(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    or a1, a1, a2
 ; RV32IMZVBC-NEXT:    or a2, a6, a3
 ; RV32IMZVBC-NEXT:    mul a3, a0, s9
@@ -25817,16 +25817,16 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 ; RV32IMZVBC-NEXT:    and a2, a2, s4
 ; RV32IMZVBC-NEXT:    and a4, a4, s3
 ; RV32IMZVBC-NEXT:    or a2, a2, a4
-; RV32IMZVBC-NEXT:    lw a4, 176(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 20(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    srli a4, a4, 1
 ; RV32IMZVBC-NEXT:    xor a1, a4, a1
 ; RV32IMZVBC-NEXT:    or a2, a3, a2
-; RV32IMZVBC-NEXT:    lw a3, 80(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 184(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    sw a2, 0(a3)
 ; RV32IMZVBC-NEXT:    sw a1, 4(a3)
-; RV32IMZVBC-NEXT:    lw a1, 148(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a1, 64(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    sw a1, 8(a3)
-; RV32IMZVBC-NEXT:    lw a0, 180(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    sw a0, 12(a3)
 ; RV32IMZVBC-NEXT:    lw ra, 236(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    lw s0, 232(sp) # 4-byte Folded Reload
@@ -25912,7 +25912,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    mv t6, a4
 ; RV32I-NEXT:    mv t2, a2
 ; RV32I-NEXT:    mv s6, a1
-; RV32I-NEXT:    sw a0, 480(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 488(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui a1, 16
 ; RV32I-NEXT:    srli a0, a2, 8
 ; RV32I-NEXT:    addi s10, a1, -256
@@ -25923,7 +25923,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    and a1, a2, s10
 ; RV32I-NEXT:    slli a1, a1, 8
 ; RV32I-NEXT:    slli a2, a2, 24
-; RV32I-NEXT:    sw a2, 476(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 196(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    or a1, a2, a1
 ; RV32I-NEXT:    lui a4, 61681
 ; RV32I-NEXT:    or a0, a1, a0
@@ -25952,7 +25952,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    srli a4, t1, 24
 ; RV32I-NEXT:    and a5, t1, s10
 ; RV32I-NEXT:    slli a6, t1, 24
-; RV32I-NEXT:    sw a6, 468(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 192(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, a5, 8
 ; RV32I-NEXT:    or a1, a1, a4
 ; RV32I-NEXT:    or a4, a6, a5
@@ -25989,7 +25989,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    and a4, a4, s0
 ; RV32I-NEXT:    and a6, a6, s0
 ; RV32I-NEXT:    slli a4, a4, 1
-; RV32I-NEXT:    sw a4, 464(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 4(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    or a1, a5, a1
 ; RV32I-NEXT:    or s2, a6, a4
 ; RV32I-NEXT:    srli a4, a1, 1
@@ -26259,7 +26259,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    and a6, s6, s10
 ; RV32I-NEXT:    slli a6, a6, 8
 ; RV32I-NEXT:    slli a2, s6, 24
-; RV32I-NEXT:    sw a2, 472(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 484(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, a1, 2
 ; RV32I-NEXT:    or a6, a2, a6
 ; RV32I-NEXT:    or a1, a5, a1
@@ -26270,7 +26270,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    slli a4, a4, 4
 ; RV32I-NEXT:    or a4, a5, a4
 ; RV32I-NEXT:    addi a2, a0, 1364
-; RV32I-NEXT:    sw a2, 484(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli a0, a1, 1
 ; RV32I-NEXT:    and a1, a1, s0
 ; RV32I-NEXT:    and a0, a0, a2
@@ -26280,7 +26280,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    and a5, a5, s7
 ; RV32I-NEXT:    slli a4, a4, 2
 ; RV32I-NEXT:    or a0, a0, a1
-; RV32I-NEXT:    sw a0, 372(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 100(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    or a4, a5, a4
 ; RV32I-NEXT:    srli a0, a4, 1
 ; RV32I-NEXT:    and a1, a4, s0
@@ -26291,12 +26291,12 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    seqz a0, a0
 ; RV32I-NEXT:    andi a4, s2, 1
 ; RV32I-NEXT:    addi a1, a0, -1
-; RV32I-NEXT:    sw a1, 400(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 128(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a0, a4
 ; RV32I-NEXT:    addi a4, a0, -1
-; RV32I-NEXT:    sw a4, 396(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 124(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a0, a2, 1
-; RV32I-NEXT:    sw a0, 460(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 188(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a0, a1, a0
 ; RV32I-NEXT:    and a4, a4, a2
 ; RV32I-NEXT:    xor a0, a4, a0
@@ -26304,37 +26304,37 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    andi a5, s2, 8
 ; RV32I-NEXT:    addi a6, a4, -1
-; RV32I-NEXT:    sw a6, 384(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 112(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a4, a5
 ; RV32I-NEXT:    addi a5, a4, -1
-; RV32I-NEXT:    sw a5, 380(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 108(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, a2, 2
-; RV32I-NEXT:    sw a1, 456(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 184(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a6, a1
 ; RV32I-NEXT:    slli a1, a2, 3
-; RV32I-NEXT:    sw a1, 452(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 180(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a5, a1
 ; RV32I-NEXT:    andi a6, s2, 16
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    seqz a5, a6
 ; RV32I-NEXT:    addi a7, a5, -1
-; RV32I-NEXT:    sw a7, 360(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 88(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a5, s2, 32
 ; RV32I-NEXT:    seqz a5, a5
 ; RV32I-NEXT:    andi a6, s2, 64
 ; RV32I-NEXT:    addi t0, a5, -1
-; RV32I-NEXT:    sw t0, 356(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 84(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a5, a6
 ; RV32I-NEXT:    addi t3, a5, -1
-; RV32I-NEXT:    sw t3, 352(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t3, 80(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, a2, 4
-; RV32I-NEXT:    sw a1, 448(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 176(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a7, a1
 ; RV32I-NEXT:    slli a1, a2, 5
-; RV32I-NEXT:    sw a1, 444(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 172(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a6, t0, a1
 ; RV32I-NEXT:    slli a1, a2, 6
-; RV32I-NEXT:    sw a1, 440(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 168(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a5, a5, a6
 ; RV32I-NEXT:    and a6, t3, a1
 ; RV32I-NEXT:    xor a0, a0, a4
@@ -26344,56 +26344,56 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    andi a5, s2, 256
 ; RV32I-NEXT:    addi a6, a4, -1
-; RV32I-NEXT:    sw a6, 344(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 72(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a4, a5
 ; RV32I-NEXT:    addi a5, a4, -1
-; RV32I-NEXT:    sw a5, 340(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 68(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, a2, 7
-; RV32I-NEXT:    sw a1, 436(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 164(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a6, a1
 ; RV32I-NEXT:    slli a1, a2, 8
-; RV32I-NEXT:    sw a1, 432(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 160(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a5, a1
 ; RV32I-NEXT:    andi a6, s2, 512
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    seqz a5, a6
 ; RV32I-NEXT:    addi a5, a5, -1
-; RV32I-NEXT:    sw a5, 328(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 56(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, a2, 9
-; RV32I-NEXT:    sw a1, 428(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 156(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a5, a1
 ; RV32I-NEXT:    andi a6, s2, 1024
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    seqz a5, a6
 ; RV32I-NEXT:    addi a5, a5, -1
-; RV32I-NEXT:    sw a5, 320(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 48(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, a2, 10
-; RV32I-NEXT:    sw a1, 424(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 152(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a5, a1
-; RV32I-NEXT:    sw s3, 288(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s3, 16(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a6, s2, s3
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    seqz a5, a6
 ; RV32I-NEXT:    addi a7, a5, -1
-; RV32I-NEXT:    sw a7, 308(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 36(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui s1, 1
 ; RV32I-NEXT:    and a5, s2, s1
 ; RV32I-NEXT:    seqz a5, a5
 ; RV32I-NEXT:    lui s8, 2
 ; RV32I-NEXT:    and a6, s2, s8
 ; RV32I-NEXT:    addi t0, a5, -1
-; RV32I-NEXT:    sw t0, 304(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 32(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a5, a6
 ; RV32I-NEXT:    addi t4, a5, -1
-; RV32I-NEXT:    sw t4, 300(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t4, 28(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, a2, 11
-; RV32I-NEXT:    sw a1, 420(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 148(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a7, a1
 ; RV32I-NEXT:    slli a1, a2, 12
-; RV32I-NEXT:    sw a1, 416(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 144(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a6, t0, a1
 ; RV32I-NEXT:    slli a1, a2, 13
-; RV32I-NEXT:    sw a1, 412(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 140(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a5, a5, a6
 ; RV32I-NEXT:    and a6, t4, a1
 ; RV32I-NEXT:    xor a5, a5, a6
@@ -26403,15 +26403,15 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    lui a1, 8
 ; RV32I-NEXT:    and a7, s2, a1
 ; RV32I-NEXT:    addi t0, a6, -1
-; RV32I-NEXT:    sw t0, 296(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 24(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a6, a7
 ; RV32I-NEXT:    addi a7, a6, -1
-; RV32I-NEXT:    sw a7, 292(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 20(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, a2, 14
-; RV32I-NEXT:    sw a1, 408(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 136(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a6, t0, a1
 ; RV32I-NEXT:    slli a1, a2, 15
-; RV32I-NEXT:    sw a1, 404(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 132(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a5, a5, a6
 ; RV32I-NEXT:    and a6, a7, a1
 ; RV32I-NEXT:    xor a0, a0, a4
@@ -26422,75 +26422,75 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    and a5, s2, s11
 ; RV32I-NEXT:    addi a6, a4, -1
-; RV32I-NEXT:    sw a6, 284(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 12(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a4, a5
 ; RV32I-NEXT:    addi a5, a4, -1
-; RV32I-NEXT:    sw a5, 280(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 480(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, a2, 16
-; RV32I-NEXT:    sw a1, 392(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 120(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a6, a1
 ; RV32I-NEXT:    slli a1, a2, 17
-; RV32I-NEXT:    sw a1, 388(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 116(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a5, a1
 ; RV32I-NEXT:    and a6, s2, s9
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    seqz a5, a6
 ; RV32I-NEXT:    addi a5, a5, -1
-; RV32I-NEXT:    sw a5, 276(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 476(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, a2, 18
-; RV32I-NEXT:    sw a1, 376(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 104(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a5, a1
 ; RV32I-NEXT:    and a6, s2, t5
 ; RV32I-NEXT:    lui s9, 128
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    seqz a5, a6
 ; RV32I-NEXT:    addi a5, a5, -1
-; RV32I-NEXT:    sw a5, 272(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 472(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, a2, 19
-; RV32I-NEXT:    sw a1, 368(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 96(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a5, a1
 ; RV32I-NEXT:    lui a1, 256
 ; RV32I-NEXT:    and a6, s2, a1
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    seqz a5, a6
 ; RV32I-NEXT:    addi a5, a5, -1
-; RV32I-NEXT:    sw a5, 264(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 464(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, a2, 20
-; RV32I-NEXT:    sw a1, 364(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 92(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a5, a1
 ; RV32I-NEXT:    lui a1, 512
 ; RV32I-NEXT:    and a6, s2, a1
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    seqz a5, a6
 ; RV32I-NEXT:    addi a5, a5, -1
-; RV32I-NEXT:    sw a5, 260(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 460(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, a2, 21
-; RV32I-NEXT:    sw a1, 348(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 76(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a5, a1
 ; RV32I-NEXT:    lui a1, 1024
 ; RV32I-NEXT:    and a6, s2, a1
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    seqz a5, a6
 ; RV32I-NEXT:    addi a7, a5, -1
-; RV32I-NEXT:    sw a7, 252(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 452(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui a1, 2048
 ; RV32I-NEXT:    and a5, s2, a1
 ; RV32I-NEXT:    seqz a5, a5
 ; RV32I-NEXT:    lui a1, 4096
 ; RV32I-NEXT:    and a6, s2, a1
 ; RV32I-NEXT:    addi t0, a5, -1
-; RV32I-NEXT:    sw t0, 248(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 448(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a5, a6
 ; RV32I-NEXT:    addi t4, a5, -1
-; RV32I-NEXT:    sw t4, 244(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t4, 444(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, a2, 22
-; RV32I-NEXT:    sw a1, 336(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 64(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a7, a1
 ; RV32I-NEXT:    slli a1, a2, 23
-; RV32I-NEXT:    sw a1, 332(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 60(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a6, t0, a1
 ; RV32I-NEXT:    slli a1, a2, 24
-; RV32I-NEXT:    sw a1, 324(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 52(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a5, a5, a6
 ; RV32I-NEXT:    and a6, t4, a1
 ; RV32I-NEXT:    xor a5, a5, a6
@@ -26499,21 +26499,21 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    and a7, s2, ra
 ; RV32I-NEXT:    addi t0, a6, -1
-; RV32I-NEXT:    sw t0, 240(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 440(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a6, a7
 ; RV32I-NEXT:    addi a7, a6, -1
-; RV32I-NEXT:    sw a7, 236(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 436(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, a2, 25
-; RV32I-NEXT:    sw a1, 316(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 44(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a6, t0, a1
 ; RV32I-NEXT:    slli a1, a2, 26
-; RV32I-NEXT:    sw a1, 312(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 40(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a5, a5, a6
 ; RV32I-NEXT:    and a6, a7, a1
 ; RV32I-NEXT:    xor a4, a0, a4
 ; RV32I-NEXT:    xor a0, a5, a6
 ; RV32I-NEXT:    srli a5, a3, 8
-; RV32I-NEXT:    sw s10, 168(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s10, 368(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a6, a3, s10
 ; RV32I-NEXT:    and a5, a5, s10
 ; RV32I-NEXT:    slli a6, a6, 8
@@ -26527,11 +26527,11 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    srli a7, a5, 4
 ; RV32I-NEXT:    addi t0, a6, -1
-; RV32I-NEXT:    sw t0, 224(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 424(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a6, a7, s5
 ; RV32I-NEXT:    and a5, a5, s5
 ; RV32I-NEXT:    slli a1, a2, 27
-; RV32I-NEXT:    sw a1, 268(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 468(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, a5, 4
 ; RV32I-NEXT:    and a7, t0, a1
 ; RV32I-NEXT:    xor a0, a0, a7
@@ -26546,28 +26546,28 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    srli a7, a5, 1
 ; RV32I-NEXT:    addi t0, a6, -1
-; RV32I-NEXT:    sw t0, 212(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    sw s0, 488(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 412(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s0, 200(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a6, a7, s0
 ; RV32I-NEXT:    and a5, a5, s0
 ; RV32I-NEXT:    slli a1, a2, 28
-; RV32I-NEXT:    sw a1, 256(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 456(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t4, a5, 1
 ; RV32I-NEXT:    and a5, t0, a1
 ; RV32I-NEXT:    xor a5, a0, a5
 ; RV32I-NEXT:    or a0, a6, t4
 ; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    sw a4, 132(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 332(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a4, a0, 2
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    andi a5, a0, 1
 ; RV32I-NEXT:    addi a1, a4, -1
-; RV32I-NEXT:    sw a1, 232(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 432(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a4, a5
 ; RV32I-NEXT:    addi a5, a4, -1
-; RV32I-NEXT:    sw a5, 228(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 428(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, t1, 1
-; RV32I-NEXT:    sw a4, 156(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 356(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a4, a1, a4
 ; RV32I-NEXT:    and a5, a5, t1
 ; RV32I-NEXT:    xor a4, a5, a4
@@ -26575,37 +26575,37 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    seqz a5, a5
 ; RV32I-NEXT:    andi a6, a0, 8
 ; RV32I-NEXT:    addi a1, a5, -1
-; RV32I-NEXT:    sw a1, 220(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 420(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a5, a6
 ; RV32I-NEXT:    addi a6, a5, -1
-; RV32I-NEXT:    sw a6, 216(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 416(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, t1, 2
-; RV32I-NEXT:    sw a5, 144(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 344(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a1, a5
 ; RV32I-NEXT:    slli a1, t1, 3
-; RV32I-NEXT:    sw a1, 136(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 336(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a6, a6, a1
 ; RV32I-NEXT:    andi a7, a0, 16
 ; RV32I-NEXT:    xor a5, a5, a6
 ; RV32I-NEXT:    seqz a6, a7
 ; RV32I-NEXT:    addi a1, a6, -1
-; RV32I-NEXT:    sw a1, 200(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 400(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a6, a0, 32
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    andi a7, a0, 64
 ; RV32I-NEXT:    addi t0, a6, -1
-; RV32I-NEXT:    sw t0, 196(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 396(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a6, a7
 ; RV32I-NEXT:    addi s0, a6, -1
-; RV32I-NEXT:    sw s0, 192(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s0, 392(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a6, t1, 4
-; RV32I-NEXT:    sw a6, 112(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 312(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a6, a1, a6
 ; RV32I-NEXT:    slli a1, t1, 5
-; RV32I-NEXT:    sw a1, 108(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 308(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a7, t0, a1
 ; RV32I-NEXT:    slli a1, t1, 6
-; RV32I-NEXT:    sw a1, 104(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 304(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a6, a6, a7
 ; RV32I-NEXT:    and a7, s0, a1
 ; RV32I-NEXT:    xor a4, a4, a5
@@ -26615,13 +26615,13 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    seqz a7, a7
 ; RV32I-NEXT:    addi a6, a6, -1
-; RV32I-NEXT:    sw a6, 188(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 388(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi a7, a7, -1
-; RV32I-NEXT:    sw a7, 184(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 384(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, t1, 7
-; RV32I-NEXT:    sw a1, 92(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 292(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t0, t1, 8
-; RV32I-NEXT:    sw t0, 88(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 288(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a6, a6, a1
 ; RV32I-NEXT:    and a7, a7, t0
 ; RV32I-NEXT:    xor a6, a6, a7
@@ -26629,15 +26629,15 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    seqz a7, a7
 ; RV32I-NEXT:    andi t0, a0, 1024
 ; RV32I-NEXT:    addi a1, a7, -1
-; RV32I-NEXT:    sw a1, 180(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 380(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a7, t0
 ; RV32I-NEXT:    addi t0, a7, -1
-; RV32I-NEXT:    sw t0, 176(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 376(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a7, t1, 9
-; RV32I-NEXT:    sw a7, 76(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 276(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a7, a1, a7
 ; RV32I-NEXT:    slli a1, t1, 10
-; RV32I-NEXT:    sw a1, 72(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 272(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a6, a6, a7
 ; RV32I-NEXT:    and a7, t0, a1
 ; RV32I-NEXT:    xor a4, a4, a5
@@ -26649,13 +26649,13 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    seqz a7, a7
 ; RV32I-NEXT:    addi t0, a6, -1
-; RV32I-NEXT:    sw t0, 128(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 328(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi s0, a7, -1
-; RV32I-NEXT:    sw s0, 124(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s0, 324(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a6, a2, 29
-; RV32I-NEXT:    sw a6, 208(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 408(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a7, a2, 30
-; RV32I-NEXT:    sw a7, 204(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 404(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a6, t0, a6
 ; RV32I-NEXT:    and a7, s0, a7
 ; RV32I-NEXT:    xor a6, a6, a7
@@ -26665,13 +26665,13 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    seqz a5, a5
 ; RV32I-NEXT:    seqz a7, a7
 ; RV32I-NEXT:    addi a5, a5, -1
-; RV32I-NEXT:    sw a5, 164(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 364(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi a7, a7, -1
-; RV32I-NEXT:    sw a7, 160(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 360(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t0, t1, 11
-; RV32I-NEXT:    sw t0, 44(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 244(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s0, t1, 12
-; RV32I-NEXT:    sw s0, 40(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s0, 240(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a5, t0
 ; RV32I-NEXT:    and a7, a7, s0
 ; RV32I-NEXT:    xor a5, a5, a7
@@ -26679,50 +26679,50 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    seqz a7, a7
 ; RV32I-NEXT:    and t0, a0, t3
 ; RV32I-NEXT:    addi t3, a7, -1
-; RV32I-NEXT:    sw t3, 152(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t3, 352(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a7, t0
 ; RV32I-NEXT:    addi t0, a7, -1
-; RV32I-NEXT:    sw t0, 148(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 348(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a7, t1, 13
-; RV32I-NEXT:    sw a7, 28(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 228(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a7, t3, a7
 ; RV32I-NEXT:    slli t3, t1, 14
-; RV32I-NEXT:    sw t3, 24(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t3, 224(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a5, a5, a7
 ; RV32I-NEXT:    and a7, t0, t3
 ; RV32I-NEXT:    xor a5, a5, a7
-; RV32I-NEXT:    lw a7, 464(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli a7, a7, 31
 ; RV32I-NEXT:    seqz a7, a7
 ; RV32I-NEXT:    lui t0, 8
 ; RV32I-NEXT:    and t0, a0, t0
 ; RV32I-NEXT:    addi t3, a7, -1
-; RV32I-NEXT:    sw t3, 56(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t3, 256(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a7, t0
 ; RV32I-NEXT:    addi a7, a7, -1
-; RV32I-NEXT:    sw a7, 140(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 340(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s0, t1, 15
-; RV32I-NEXT:    sw s0, 20(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s0, 220(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t0, a2, 31
-; RV32I-NEXT:    sw t0, 172(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 372(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a7, a7, s0
 ; RV32I-NEXT:    xor a5, a5, a7
 ; RV32I-NEXT:    and a7, t3, t0
 ; RV32I-NEXT:    xor a6, a6, a7
-; RV32I-NEXT:    sw a6, 464(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 4(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    and a5, a0, s4
 ; RV32I-NEXT:    and a6, a0, s11
 ; RV32I-NEXT:    seqz a5, a5
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    addi a5, a5, -1
-; RV32I-NEXT:    sw a5, 120(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 320(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi a6, a6, -1
-; RV32I-NEXT:    sw a6, 116(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 316(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a7, t1, 16
-; RV32I-NEXT:    sw a7, 12(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 212(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t0, t1, 17
-; RV32I-NEXT:    sw t0, 8(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 208(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a5, a7
 ; RV32I-NEXT:    and a6, a6, t0
 ; RV32I-NEXT:    xor a5, a5, a6
@@ -26731,14 +26731,14 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    and a7, a0, s9
 ; RV32I-NEXT:    addi t0, a6, -1
-; RV32I-NEXT:    sw t0, 100(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 300(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a6, a7
 ; RV32I-NEXT:    addi a7, a6, -1
-; RV32I-NEXT:    sw a7, 96(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 296(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s11, t1, 18
 ; RV32I-NEXT:    and a6, t0, s11
 ; RV32I-NEXT:    slli t0, t1, 19
-; RV32I-NEXT:    sw t0, 4(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 204(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a5, a5, a6
 ; RV32I-NEXT:    and a6, a7, t0
 ; RV32I-NEXT:    xor a5, a5, a6
@@ -26748,10 +26748,10 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    lui a7, 512
 ; RV32I-NEXT:    and a7, a0, a7
 ; RV32I-NEXT:    addi t0, a6, -1
-; RV32I-NEXT:    sw t0, 84(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 284(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a6, a7
 ; RV32I-NEXT:    addi a7, a6, -1
-; RV32I-NEXT:    sw a7, 80(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 280(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s9, t1, 20
 ; RV32I-NEXT:    and a6, t0, s9
 ; RV32I-NEXT:    slli s8, t1, 21
@@ -26763,14 +26763,14 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    xor t3, a4, a5
 ; RV32I-NEXT:    seqz a4, a6
 ; RV32I-NEXT:    addi a6, a4, -1
-; RV32I-NEXT:    sw a6, 68(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 268(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui a4, 2048
 ; RV32I-NEXT:    and a4, a0, a4
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    lui a5, 4096
 ; RV32I-NEXT:    and a5, a0, a5
 ; RV32I-NEXT:    addi a7, a4, -1
-; RV32I-NEXT:    sw a7, 64(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 264(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a4, a5
 ; RV32I-NEXT:    slli s3, t1, 22
 ; RV32I-NEXT:    slli s4, t1, 23
@@ -26778,15 +26778,15 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    and a6, a7, s4
 ; RV32I-NEXT:    xor a5, a5, a6
 ; RV32I-NEXT:    addi a4, a4, -1
-; RV32I-NEXT:    sw a4, 60(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw s2, 468(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a4, 260(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw s2, 192(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, s2
 ; RV32I-NEXT:    lui a6, 8192
 ; RV32I-NEXT:    and a6, a0, a6
 ; RV32I-NEXT:    xor a4, a5, a4
 ; RV32I-NEXT:    seqz a5, a6
 ; RV32I-NEXT:    addi a5, a5, -1
-; RV32I-NEXT:    sw a5, 52(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 252(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t1, 25
 ; RV32I-NEXT:    and a5, a5, s1
 ; RV32I-NEXT:    lui a6, 16384
@@ -26794,28 +26794,28 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    seqz a5, a6
 ; RV32I-NEXT:    addi a5, a5, -1
-; RV32I-NEXT:    sw a5, 48(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 248(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s0, t1, 26
 ; RV32I-NEXT:    and a5, a5, s0
 ; RV32I-NEXT:    and a6, a0, t5
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    seqz a5, a6
 ; RV32I-NEXT:    addi a5, a5, -1
-; RV32I-NEXT:    sw a5, 36(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 236(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t5, t1, 27
 ; RV32I-NEXT:    and a5, a5, t5
 ; RV32I-NEXT:    and a6, a0, s10
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    seqz a5, a6
 ; RV32I-NEXT:    addi a5, a5, -1
-; RV32I-NEXT:    sw a5, 32(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 232(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t0, t1, 28
 ; RV32I-NEXT:    and a5, a5, t0
 ; RV32I-NEXT:    and s10, a0, a1
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    seqz a5, s10
 ; RV32I-NEXT:    addi a5, a5, -1
-; RV32I-NEXT:    sw a5, 16(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 216(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a0, a0, ra
 ; RV32I-NEXT:    seqz s10, a0
 ; RV32I-NEXT:    srli a0, t4, 31
@@ -26831,16 +26831,16 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    and a1, ra, a5
 ; RV32I-NEXT:    xor a4, t3, a4
 ; RV32I-NEXT:    xor a0, a0, a1
-; RV32I-NEXT:    lw a1, 132(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t3, 464(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 332(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    xor a1, a1, t3
 ; RV32I-NEXT:    xor a0, a4, a0
 ; RV32I-NEXT:    xor a0, a0, a1
-; RV32I-NEXT:    lw a1, 372(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 100(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli a1, a1, 1
 ; RV32I-NEXT:    xor a0, a1, a0
 ; RV32I-NEXT:    srli a1, a0, 8
-; RV32I-NEXT:    lw t4, 168(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t4, 368(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, t4
 ; RV32I-NEXT:    srli a4, a0, 24
 ; RV32I-NEXT:    and t3, a0, t4
@@ -26860,237 +26860,237 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    slli a0, a0, 2
 ; RV32I-NEXT:    or a0, a1, a0
 ; RV32I-NEXT:    srli a1, a0, 1
-; RV32I-NEXT:    lw a4, 488(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 200(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a0, a0, a4
-; RV32I-NEXT:    lw a4, 484(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, a4
 ; RV32I-NEXT:    slli a0, a0, 1
 ; RV32I-NEXT:    or a0, a1, a0
-; RV32I-NEXT:    sw a0, 464(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a0, 400(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 156(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a0, 128(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 356(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a0, a0, a1
-; RV32I-NEXT:    lw a1, 396(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 124(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, t1
-; RV32I-NEXT:    lw a4, 384(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 144(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 112(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 344(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, t1
-; RV32I-NEXT:    lw t1, 380(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t3, 136(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 108(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 336(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, t1, t3
 ; RV32I-NEXT:    xor a0, a1, a0
 ; RV32I-NEXT:    xor a1, a4, t1
-; RV32I-NEXT:    lw a4, 360(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 112(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 88(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 312(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, t1
-; RV32I-NEXT:    lw t1, 356(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t3, 108(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 84(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 308(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, t1, t3
 ; RV32I-NEXT:    xor a4, a4, t1
-; RV32I-NEXT:    lw t1, 352(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t3, 104(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 80(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 304(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, t1, t3
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a1, a4, t1
-; RV32I-NEXT:    lw a4, 344(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 92(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a4, a4, t1
-; RV32I-NEXT:    lw t1, 340(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t3, 88(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and t1, t1, t3
-; RV32I-NEXT:    xor a4, a4, t1
-; RV32I-NEXT:    lw t1, 328(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t3, 76(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and t1, t1, t3
-; RV32I-NEXT:    xor a4, a4, t1
-; RV32I-NEXT:    lw t1, 320(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t3, 72(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and t1, t1, t3
-; RV32I-NEXT:    xor a0, a0, a1
-; RV32I-NEXT:    xor a1, a4, t1
-; RV32I-NEXT:    lw a4, 308(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 44(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a4, a4, t1
-; RV32I-NEXT:    lw t1, 304(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t3, 40(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and t1, t1, t3
-; RV32I-NEXT:    xor a4, a4, t1
-; RV32I-NEXT:    lw t1, 300(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t3, 28(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and t1, t1, t3
-; RV32I-NEXT:    xor a4, a4, t1
-; RV32I-NEXT:    lw t1, 296(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t3, 24(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and t1, t1, t3
-; RV32I-NEXT:    xor a4, a4, t1
+; RV32I-NEXT:    lw a4, 72(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw t1, 292(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t3, 20(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a4, a4, t1
+; RV32I-NEXT:    lw t1, 68(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 288(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and t1, t1, t3
+; RV32I-NEXT:    xor a4, a4, t1
+; RV32I-NEXT:    lw t1, 56(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 276(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and t1, t1, t3
+; RV32I-NEXT:    xor a4, a4, t1
+; RV32I-NEXT:    lw t1, 48(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 272(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, t1, t3
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a1, a4, t1
-; RV32I-NEXT:    lw a4, 284(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 12(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 36(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 244(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, t1
-; RV32I-NEXT:    lw t1, 280(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t3, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 32(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 240(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, t1, t3
 ; RV32I-NEXT:    xor a4, a4, t1
-; RV32I-NEXT:    lw t1, 276(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 28(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 228(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and t1, t1, t3
+; RV32I-NEXT:    xor a4, a4, t1
+; RV32I-NEXT:    lw t1, 24(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 224(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and t1, t1, t3
+; RV32I-NEXT:    xor a4, a4, t1
+; RV32I-NEXT:    lw t1, 20(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 220(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and t1, t1, t3
+; RV32I-NEXT:    xor a0, a0, a1
+; RV32I-NEXT:    xor a1, a4, t1
+; RV32I-NEXT:    lw a4, 12(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 212(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a4, a4, t1
+; RV32I-NEXT:    lw t1, 480(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 208(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and t1, t1, t3
+; RV32I-NEXT:    xor a4, a4, t1
+; RV32I-NEXT:    lw t1, 476(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, t1, s11
 ; RV32I-NEXT:    xor a4, a4, t1
-; RV32I-NEXT:    lw t1, 272(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t3, 4(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 472(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 204(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, t1, t3
 ; RV32I-NEXT:    xor a4, a4, t1
-; RV32I-NEXT:    lw t1, 264(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 464(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, t1, s9
 ; RV32I-NEXT:    xor a4, a4, t1
-; RV32I-NEXT:    lw t1, 260(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 460(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, t1, s8
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a1, a4, t1
-; RV32I-NEXT:    lw a4, 252(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 452(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, s3
-; RV32I-NEXT:    lw t1, 248(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 448(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, t1, s4
 ; RV32I-NEXT:    xor a4, a4, t1
-; RV32I-NEXT:    lw t1, 244(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 444(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, t1, s2
 ; RV32I-NEXT:    xor a4, a4, t1
-; RV32I-NEXT:    lw t1, 240(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 440(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, t1, s1
 ; RV32I-NEXT:    xor a4, a4, t1
-; RV32I-NEXT:    lw t1, 236(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 436(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, t1, s0
 ; RV32I-NEXT:    xor a4, a4, t1
-; RV32I-NEXT:    lw t1, 224(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 424(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, t1, t5
 ; RV32I-NEXT:    xor a4, a4, t1
-; RV32I-NEXT:    lw t1, 212(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 412(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t0, t1, t0
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a1, a4, t0
-; RV32I-NEXT:    lw a4, 128(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 328(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, a7
-; RV32I-NEXT:    lw a7, 124(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 324(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, a7, a6
 ; RV32I-NEXT:    xor a4, a4, a6
-; RV32I-NEXT:    lw a6, 56(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 256(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a6, a5
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a1, 460(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 232(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 188(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 432(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a5, a1
-; RV32I-NEXT:    lw a5, 228(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 428(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a5, a2
-; RV32I-NEXT:    lw a5, 456(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 220(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 184(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 420(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a6, a5
-; RV32I-NEXT:    lw a6, 452(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a7, 216(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 180(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 416(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, a7, a6
 ; RV32I-NEXT:    xor a1, a2, a1
 ; RV32I-NEXT:    xor a2, a5, a6
-; RV32I-NEXT:    lw a5, 448(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 200(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 176(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 400(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a6, a5
-; RV32I-NEXT:    lw a6, 444(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a7, 196(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 172(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 396(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, a7, a6
 ; RV32I-NEXT:    xor a5, a5, a6
-; RV32I-NEXT:    lw a6, 440(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a7, 192(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 168(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 392(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, a7, a6
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    xor a2, a5, a6
-; RV32I-NEXT:    lw a5, 436(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 188(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a5, a6, a5
-; RV32I-NEXT:    lw a6, 432(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a7, 184(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a6, a7, a6
-; RV32I-NEXT:    xor a5, a5, a6
-; RV32I-NEXT:    lw a6, 428(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a7, 180(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a6, a7, a6
-; RV32I-NEXT:    xor a5, a5, a6
-; RV32I-NEXT:    lw a6, 424(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a7, 176(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a6, a7, a6
-; RV32I-NEXT:    xor a1, a1, a2
-; RV32I-NEXT:    xor a2, a5, a6
-; RV32I-NEXT:    lw a5, 420(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 164(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a5, a6, a5
-; RV32I-NEXT:    lw a6, 416(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a7, 160(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a6, a7, a6
-; RV32I-NEXT:    xor a5, a5, a6
-; RV32I-NEXT:    lw a6, 412(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a7, 152(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a6, a7, a6
-; RV32I-NEXT:    xor a5, a5, a6
-; RV32I-NEXT:    lw a6, 408(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a7, 148(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a6, a7, a6
-; RV32I-NEXT:    xor a5, a5, a6
-; RV32I-NEXT:    lw a6, 404(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a7, 140(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a6, a7, a6
-; RV32I-NEXT:    xor a1, a1, a2
-; RV32I-NEXT:    xor a2, a5, a6
-; RV32I-NEXT:    lw a5, 392(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 120(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a5, a6, a5
+; RV32I-NEXT:    lw a5, 164(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw a6, 388(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a7, 116(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a5, a6, a5
+; RV32I-NEXT:    lw a6, 160(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 384(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, a7, a6
 ; RV32I-NEXT:    xor a5, a5, a6
-; RV32I-NEXT:    lw a6, 376(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a7, 100(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 156(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 380(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, a7, a6
 ; RV32I-NEXT:    xor a5, a5, a6
-; RV32I-NEXT:    lw a6, 368(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a7, 96(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 152(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 376(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, a7, a6
-; RV32I-NEXT:    xor a5, a5, a6
+; RV32I-NEXT:    xor a1, a1, a2
+; RV32I-NEXT:    xor a2, a5, a6
+; RV32I-NEXT:    lw a5, 148(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw a6, 364(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a7, 84(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a5, a6, a5
+; RV32I-NEXT:    lw a6, 144(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 360(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, a7, a6
 ; RV32I-NEXT:    xor a5, a5, a6
-; RV32I-NEXT:    lw a6, 348(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a7, 80(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 140(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 352(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a6, a7, a6
+; RV32I-NEXT:    xor a5, a5, a6
+; RV32I-NEXT:    lw a6, 136(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 348(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a6, a7, a6
+; RV32I-NEXT:    xor a5, a5, a6
+; RV32I-NEXT:    lw a6, 132(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 340(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a6, a7, a6
+; RV32I-NEXT:    xor a1, a1, a2
+; RV32I-NEXT:    xor a2, a5, a6
+; RV32I-NEXT:    lw a5, 120(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 320(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a5, a6, a5
+; RV32I-NEXT:    lw a6, 116(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 316(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a6, a7, a6
+; RV32I-NEXT:    xor a5, a5, a6
+; RV32I-NEXT:    lw a6, 104(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 300(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a6, a7, a6
+; RV32I-NEXT:    xor a5, a5, a6
+; RV32I-NEXT:    lw a6, 96(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 296(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a6, a7, a6
+; RV32I-NEXT:    xor a5, a5, a6
+; RV32I-NEXT:    lw a6, 92(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 284(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a6, a7, a6
+; RV32I-NEXT:    xor a5, a5, a6
+; RV32I-NEXT:    lw a6, 76(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 280(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, a7, a6
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    xor a2, a5, a6
 ; RV32I-NEXT:    xor a0, a0, a4
 ; RV32I-NEXT:    xor a1, a1, a2
-; RV32I-NEXT:    lw a2, 336(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a4, 68(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a2, a4, a2
-; RV32I-NEXT:    lw a4, 332(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 64(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a4, a5, a4
-; RV32I-NEXT:    xor a2, a2, a4
-; RV32I-NEXT:    lw a4, 324(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 60(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a4, a5, a4
-; RV32I-NEXT:    xor a2, a2, a4
-; RV32I-NEXT:    lw a4, 316(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 52(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a4, a5, a4
-; RV32I-NEXT:    xor a2, a2, a4
-; RV32I-NEXT:    lw a4, 312(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 48(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a4, a5, a4
-; RV32I-NEXT:    xor a2, a2, a4
+; RV32I-NEXT:    lw a2, 64(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw a4, 268(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 36(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a2, a4, a2
+; RV32I-NEXT:    lw a4, 60(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 264(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a5, a4
 ; RV32I-NEXT:    xor a2, a2, a4
-; RV32I-NEXT:    lw a4, 256(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 32(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 52(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 260(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a4, a5, a4
+; RV32I-NEXT:    xor a2, a2, a4
+; RV32I-NEXT:    lw a4, 44(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 252(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a4, a5, a4
+; RV32I-NEXT:    xor a2, a2, a4
+; RV32I-NEXT:    lw a4, 40(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 248(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a4, a5, a4
+; RV32I-NEXT:    xor a2, a2, a4
+; RV32I-NEXT:    lw a4, 468(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 236(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a4, a5, a4
+; RV32I-NEXT:    xor a2, a2, a4
+; RV32I-NEXT:    lw a4, 456(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 232(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a5, a4
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    srli a4, a0, 8
@@ -27098,13 +27098,13 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    srli a5, a0, 24
 ; RV32I-NEXT:    or a4, a4, a5
 ; RV32I-NEXT:    xor a1, a1, a2
-; RV32I-NEXT:    lw a2, 208(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 16(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 408(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 216(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a5, a2
-; RV32I-NEXT:    lw a5, 204(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 404(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, s10, a5
 ; RV32I-NEXT:    xor a2, a2, a5
-; RV32I-NEXT:    lw a5, 172(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 372(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, ra, a5
 ; RV32I-NEXT:    xor a2, a2, a5
 ; RV32I-NEXT:    and a5, a0, t4
@@ -27137,37 +27137,37 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    and a2, a2, s7
 ; RV32I-NEXT:    slli a0, a0, 2
 ; RV32I-NEXT:    or a0, a2, a0
-; RV32I-NEXT:    sw a0, 468(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 192(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli a0, a1, 2
 ; RV32I-NEXT:    and a0, a0, s7
 ; RV32I-NEXT:    and a1, a1, s7
 ; RV32I-NEXT:    slli a1, a1, 2
 ; RV32I-NEXT:    andi a2, a3, 2
 ; RV32I-NEXT:    or a4, a0, a1
-; RV32I-NEXT:    sw a4, 444(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 172(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a0, a2
 ; RV32I-NEXT:    addi a2, a0, -1
-; RV32I-NEXT:    sw a2, 460(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 188(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a0, a3, 1
 ; RV32I-NEXT:    seqz a0, a0
 ; RV32I-NEXT:    slli a1, t2, 1
 ; RV32I-NEXT:    and a1, a2, a1
 ; RV32I-NEXT:    addi a2, a0, -1
-; RV32I-NEXT:    sw a2, 456(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 184(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli a0, a4, 1
 ; RV32I-NEXT:    and a2, a2, t2
-; RV32I-NEXT:    lw a4, 484(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a0, a0, a4
-; RV32I-NEXT:    sw a0, 448(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 176(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a1, a2, a1
 ; RV32I-NEXT:    andi a0, a3, 4
 ; RV32I-NEXT:    andi a2, a3, 8
 ; RV32I-NEXT:    seqz a0, a0
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    addi a4, a0, -1
-; RV32I-NEXT:    sw a4, 484(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi a5, a2, -1
-; RV32I-NEXT:    sw a5, 452(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 180(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a0, t2, 2
 ; RV32I-NEXT:    slli a2, t2, 3
 ; RV32I-NEXT:    and a0, a4, a0
@@ -27177,19 +27177,19 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    xor a0, a1, a0
 ; RV32I-NEXT:    seqz a1, a2
 ; RV32I-NEXT:    addi a4, a1, -1
-; RV32I-NEXT:    sw a4, 440(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 168(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a1, a3, 32
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    slli a2, t2, 4
 ; RV32I-NEXT:    and a2, a4, a2
 ; RV32I-NEXT:    addi a5, a1, -1
-; RV32I-NEXT:    sw a5, 436(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 164(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, t2, 5
 ; RV32I-NEXT:    andi a4, a3, 64
 ; RV32I-NEXT:    and a1, a5, a1
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    addi a5, a4, -1
-; RV32I-NEXT:    sw a5, 432(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 160(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, t2, 6
 ; RV32I-NEXT:    xor a1, a2, a1
 ; RV32I-NEXT:    and a2, a5, a4
@@ -27198,50 +27198,50 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    seqz a1, a2
 ; RV32I-NEXT:    addi a4, a1, -1
-; RV32I-NEXT:    sw a4, 428(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 156(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a1, a3, 256
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    slli a2, t2, 7
 ; RV32I-NEXT:    and a2, a4, a2
 ; RV32I-NEXT:    addi a5, a1, -1
-; RV32I-NEXT:    sw a5, 424(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 152(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, t2, 8
 ; RV32I-NEXT:    andi a4, a3, 512
 ; RV32I-NEXT:    and a1, a5, a1
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    xor a1, a2, a1
 ; RV32I-NEXT:    addi a5, a4, -1
-; RV32I-NEXT:    sw a5, 420(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 148(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, t2, 9
 ; RV32I-NEXT:    andi a4, a3, 1024
 ; RV32I-NEXT:    and a2, a5, a2
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    addi a5, a4, -1
-; RV32I-NEXT:    sw a5, 416(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 144(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, t2, 10
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    and a2, a5, a4
 ; RV32I-NEXT:    xor a1, a1, a2
-; RV32I-NEXT:    lw s5, 288(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s5, 16(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a3, s5
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    seqz a1, a2
 ; RV32I-NEXT:    addi a4, a1, -1
-; RV32I-NEXT:    sw a4, 412(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 140(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui s2, 1
 ; RV32I-NEXT:    and a1, a3, s2
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    slli a2, t2, 11
 ; RV32I-NEXT:    and a2, a4, a2
 ; RV32I-NEXT:    addi a5, a1, -1
-; RV32I-NEXT:    sw a5, 408(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 136(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, t2, 12
 ; RV32I-NEXT:    lui s7, 2
 ; RV32I-NEXT:    and a4, a3, s7
 ; RV32I-NEXT:    and a1, a5, a1
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    addi a5, a4, -1
-; RV32I-NEXT:    sw a5, 404(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 132(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, t2, 13
 ; RV32I-NEXT:    xor a1, a2, a1
 ; RV32I-NEXT:    and a2, a5, a4
@@ -27251,14 +27251,14 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    seqz a1, a2
 ; RV32I-NEXT:    addi a4, a1, -1
-; RV32I-NEXT:    sw a4, 400(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 128(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui s9, 8
 ; RV32I-NEXT:    and a1, a3, s9
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    slli a2, t2, 14
 ; RV32I-NEXT:    and a2, a4, a2
 ; RV32I-NEXT:    addi a5, a1, -1
-; RV32I-NEXT:    sw a5, 396(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 124(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, t2, 15
 ; RV32I-NEXT:    lui s8, 16
 ; RV32I-NEXT:    and a4, a3, s8
@@ -27266,7 +27266,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    xor a1, a2, a1
 ; RV32I-NEXT:    addi a5, a4, -1
-; RV32I-NEXT:    sw a5, 392(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 120(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, t2, 16
 ; RV32I-NEXT:    lui s3, 32
 ; RV32I-NEXT:    and a4, a3, s3
@@ -27274,14 +27274,14 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    addi a5, a4, -1
-; RV32I-NEXT:    sw a5, 388(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 116(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, t2, 17
 ; RV32I-NEXT:    lui a7, 64
 ; RV32I-NEXT:    and a4, a3, a7
 ; RV32I-NEXT:    and a2, a5, a2
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    addi a5, a4, -1
-; RV32I-NEXT:    sw a5, 384(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 112(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a4, t2, 18
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    and a2, a5, a4
@@ -27291,14 +27291,14 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    seqz a1, a2
 ; RV32I-NEXT:    addi a4, a1, -1
-; RV32I-NEXT:    sw a4, 380(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 108(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui t1, 256
 ; RV32I-NEXT:    and a1, a3, t1
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    slli a2, t2, 19
 ; RV32I-NEXT:    and a2, a4, a2
 ; RV32I-NEXT:    addi a5, a1, -1
-; RV32I-NEXT:    sw a5, 376(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 104(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, t2, 20
 ; RV32I-NEXT:    lui t3, 512
 ; RV32I-NEXT:    and a4, a3, t3
@@ -27306,7 +27306,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    xor a1, a2, a1
 ; RV32I-NEXT:    addi a5, a4, -1
-; RV32I-NEXT:    sw a5, 372(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 100(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, t2, 21
 ; RV32I-NEXT:    lui t4, 1024
 ; RV32I-NEXT:    and a4, a3, t4
@@ -27314,7 +27314,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    addi a5, a4, -1
-; RV32I-NEXT:    sw a5, 368(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 96(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, t2, 22
 ; RV32I-NEXT:    lui t5, 2048
 ; RV32I-NEXT:    and a4, a3, t5
@@ -27322,7 +27322,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    addi a5, a4, -1
-; RV32I-NEXT:    sw a5, 364(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 92(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, t2, 23
 ; RV32I-NEXT:    lui s0, 4096
 ; RV32I-NEXT:    and a4, a3, s0
@@ -27330,8 +27330,8 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    addi a4, a4, -1
-; RV32I-NEXT:    sw a4, 360(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lw a2, 476(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a4, 88(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    lw a2, 196(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a4, a2
 ; RV32I-NEXT:    lui s1, 8192
 ; RV32I-NEXT:    and a4, a3, s1
@@ -27339,14 +27339,14 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    seqz a2, a4
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    addi a4, a2, -1
-; RV32I-NEXT:    sw a4, 476(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 196(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, t2, 25
 ; RV32I-NEXT:    lui a5, 16384
 ; RV32I-NEXT:    and a2, a3, a5
 ; RV32I-NEXT:    and a1, a4, a1
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    addi a4, a2, -1
-; RV32I-NEXT:    sw a4, 356(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 84(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, t2, 26
 ; RV32I-NEXT:    and a2, a4, a2
 ; RV32I-NEXT:    lui a6, 32768
@@ -27354,7 +27354,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    seqz a2, a4
 ; RV32I-NEXT:    addi a4, a2, -1
-; RV32I-NEXT:    sw a4, 352(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 80(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, t2, 27
 ; RV32I-NEXT:    and a2, a4, a2
 ; RV32I-NEXT:    lui a4, 65536
@@ -27362,7 +27362,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    seqz a2, a4
 ; RV32I-NEXT:    addi a4, a2, -1
-; RV32I-NEXT:    sw a4, 348(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 76(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, t2, 28
 ; RV32I-NEXT:    and a2, a4, a2
 ; RV32I-NEXT:    lui a4, 131072
@@ -27370,7 +27370,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    seqz a2, a4
 ; RV32I-NEXT:    addi a4, a2, -1
-; RV32I-NEXT:    sw a4, 344(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 72(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, t2, 29
 ; RV32I-NEXT:    and a2, a4, a2
 ; RV32I-NEXT:    lui a4, 262144
@@ -27378,7 +27378,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    seqz a2, a4
 ; RV32I-NEXT:    addi a4, a2, -1
-; RV32I-NEXT:    sw a4, 340(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 68(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, t2, 30
 ; RV32I-NEXT:    and a2, a4, a2
 ; RV32I-NEXT:    srli a3, a3, 31
@@ -27386,16 +27386,16 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    slli t2, t2, 31
 ; RV32I-NEXT:    addi a2, a2, -1
-; RV32I-NEXT:    sw a2, 336(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 64(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, t2
 ; RV32I-NEXT:    andi a3, t6, 2
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    xor a0, a0, a1
-; RV32I-NEXT:    sw a0, 328(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi a2, a2, -1
 ; RV32I-NEXT:    slli a1, s6, 1
-; RV32I-NEXT:    sw a1, 332(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 60(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a0, t6, 1
 ; RV32I-NEXT:    and a1, a2, a1
 ; RV32I-NEXT:    seqz a0, a0
@@ -27406,13 +27406,13 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    addi a2, a2, -1
 ; RV32I-NEXT:    slli a3, s6, 2
-; RV32I-NEXT:    sw a3, 324(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 52(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a1, t6, 8
 ; RV32I-NEXT:    and a2, a2, a3
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    addi a1, a1, -1
 ; RV32I-NEXT:    slli a3, s6, 3
-; RV32I-NEXT:    sw a3, 320(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 48(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a1, a1, a3
 ; RV32I-NEXT:    andi a3, t6, 16
 ; RV32I-NEXT:    xor a1, a2, a1
@@ -27420,20 +27420,20 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    addi a2, a2, -1
 ; RV32I-NEXT:    slli a3, s6, 4
-; RV32I-NEXT:    sw a3, 316(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 44(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a1, t6, 32
 ; RV32I-NEXT:    and a2, a2, a3
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    addi a1, a1, -1
 ; RV32I-NEXT:    slli a3, s6, 5
-; RV32I-NEXT:    sw a3, 312(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 40(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a1, a1, a3
 ; RV32I-NEXT:    andi a3, t6, 64
 ; RV32I-NEXT:    xor a1, a2, a1
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi a2, a2, -1
 ; RV32I-NEXT:    slli a3, s6, 6
-; RV32I-NEXT:    sw a3, 308(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 36(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a3
 ; RV32I-NEXT:    andi a3, t6, 128
 ; RV32I-NEXT:    xor a1, a1, a2
@@ -27441,27 +27441,27 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    addi a2, a2, -1
 ; RV32I-NEXT:    slli a3, s6, 7
-; RV32I-NEXT:    sw a3, 304(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 32(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a1, t6, 256
 ; RV32I-NEXT:    and a2, a2, a3
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    addi a1, a1, -1
 ; RV32I-NEXT:    slli a3, s6, 8
-; RV32I-NEXT:    sw a3, 300(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 28(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a1, a1, a3
 ; RV32I-NEXT:    andi a3, t6, 512
 ; RV32I-NEXT:    xor a1, a2, a1
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi a2, a2, -1
 ; RV32I-NEXT:    slli a3, s6, 9
-; RV32I-NEXT:    sw a3, 296(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 24(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a3
 ; RV32I-NEXT:    andi a3, t6, 1024
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi a2, a2, -1
 ; RV32I-NEXT:    slli a3, s6, 10
-; RV32I-NEXT:    sw a3, 292(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 20(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a3
 ; RV32I-NEXT:    and a3, t6, s5
 ; RV32I-NEXT:    xor a1, a1, a2
@@ -27470,12 +27470,12 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    addi a2, a2, -1
 ; RV32I-NEXT:    and a1, t6, s2
 ; RV32I-NEXT:    slli a3, s6, 11
-; RV32I-NEXT:    sw a3, 288(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 16(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a3
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    addi a1, a1, -1
 ; RV32I-NEXT:    slli a3, s6, 12
-; RV32I-NEXT:    sw a3, 284(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 12(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a1, a1, a3
 ; RV32I-NEXT:    and a3, t6, s7
 ; RV32I-NEXT:    xor a1, a2, a1
@@ -27547,7 +27547,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    and a3, a3, s3
 ; RV32I-NEXT:    addi a4, a4, -1
 ; RV32I-NEXT:    xor a1, a1, a3
-; RV32I-NEXT:    lw t0, 472(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t0, 484(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a4, t0
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    and a3, t6, s1
@@ -27595,18 +27595,18 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    and a4, a4, s0
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a2, 488(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a3, 444(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 200(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 172(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a2
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    slli a3, a3, 1
-; RV32I-NEXT:    lw a1, 448(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 176(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or a1, a1, a3
-; RV32I-NEXT:    lw a5, 328(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 56(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    xor a5, a0, a5
-; RV32I-NEXT:    lw a3, 464(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli a3, a3, 1
-; RV32I-NEXT:    lw a0, 468(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 192(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli t6, a0, 1
 ; RV32I-NEXT:    srli a1, a1, 1
 ; RV32I-NEXT:    slli a4, t6, 31
@@ -27614,116 +27614,116 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32I-NEXT:    xor a4, a1, a5
 ; RV32I-NEXT:    and a3, t6, a2
 ; RV32I-NEXT:    and a2, a0, a2
-; RV32I-NEXT:    lw a0, 460(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 332(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 188(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 60(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t6, a0, a1
-; RV32I-NEXT:    lw a0, 456(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 184(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s6, a0, s6
-; RV32I-NEXT:    lw a0, 484(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 324(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 52(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a0, a1
-; RV32I-NEXT:    lw a0, 452(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 320(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 180(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 48(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a0, a0, a5
 ; RV32I-NEXT:    xor t6, s6, t6
 ; RV32I-NEXT:    xor a0, a1, a0
-; RV32I-NEXT:    lw a1, 440(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 316(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 168(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 44(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, a5
-; RV32I-NEXT:    lw a5, 436(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s6, 312(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 164(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s6, 40(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s6, a5, s6
 ; RV32I-NEXT:    xor a1, a1, s6
-; RV32I-NEXT:    lw a5, 432(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s6, 308(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 160(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s6, 36(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s6, a5, s6
 ; RV32I-NEXT:    xor a0, t6, a0
 ; RV32I-NEXT:    xor a1, a1, s6
-; RV32I-NEXT:    lw a5, 428(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t6, 304(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 156(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t6, 32(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t6, a5, t6
-; RV32I-NEXT:    lw a5, 424(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s6, 300(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 152(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s6, 28(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s6, a5, s6
 ; RV32I-NEXT:    xor t6, t6, s6
-; RV32I-NEXT:    lw a5, 420(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s6, 296(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 148(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s6, 24(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s6, a5, s6
 ; RV32I-NEXT:    xor t6, t6, s6
-; RV32I-NEXT:    lw a5, 416(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s6, 292(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 144(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s6, 20(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s6, a5, s6
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a1, t6, s6
-; RV32I-NEXT:    lw a5, 412(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t6, 288(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 140(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t6, 16(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t6, a5, t6
-; RV32I-NEXT:    lw a5, 408(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s6, 284(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 136(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s6, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s6, a5, s6
 ; RV32I-NEXT:    xor t6, t6, s6
-; RV32I-NEXT:    lw a5, 404(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 132(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s6, a5, ra
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a1, t6, s6
-; RV32I-NEXT:    lw a5, 400(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 128(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t6, a5, s11
-; RV32I-NEXT:    lw a5, 396(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 124(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s6, a5, s10
 ; RV32I-NEXT:    xor t6, t6, s6
-; RV32I-NEXT:    lw a5, 392(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 120(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s6, a5, s9
 ; RV32I-NEXT:    xor t6, t6, s6
-; RV32I-NEXT:    lw a5, 388(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 116(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s5, a5, s5
 ; RV32I-NEXT:    xor t6, t6, s5
-; RV32I-NEXT:    lw a5, 384(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 112(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, a5, s4
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a1, t6, s4
-; RV32I-NEXT:    lw a5, 380(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 108(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t6, a5, s8
-; RV32I-NEXT:    lw a5, 376(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 104(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s2, a5, s2
 ; RV32I-NEXT:    xor t6, t6, s2
-; RV32I-NEXT:    lw a5, 372(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 100(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t3, a5, t3
 ; RV32I-NEXT:    xor t3, t6, t3
-; RV32I-NEXT:    lw a5, 368(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 96(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, a5, t1
 ; RV32I-NEXT:    xor t1, t3, t1
-; RV32I-NEXT:    lw a5, 364(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 92(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, s3
 ; RV32I-NEXT:    xor a5, t1, a5
-; RV32I-NEXT:    lw t1, 360(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 88(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, t1, t0
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a1, a5, t1
-; RV32I-NEXT:    lw a5, 476(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 196(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, s1
-; RV32I-NEXT:    lw t0, 356(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t0, 84(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, t0, a6
 ; RV32I-NEXT:    xor a5, a5, a6
-; RV32I-NEXT:    lw a6, 352(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 80(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, a6, a7
 ; RV32I-NEXT:    xor a5, a5, a6
-; RV32I-NEXT:    lw a6, 348(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 76(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, a6, t4
 ; RV32I-NEXT:    xor a5, a5, a6
-; RV32I-NEXT:    lw a6, 344(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 72(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, a6, t5
 ; RV32I-NEXT:    xor a5, a5, a6
-; RV32I-NEXT:    lw a6, 340(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 68(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, a6, t2
 ; RV32I-NEXT:    xor a5, a5, a6
-; RV32I-NEXT:    lw a6, 336(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 64(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, a6, s0
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a1, a5, a6
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    slli a2, a2, 1
 ; RV32I-NEXT:    or a2, a3, a2
-; RV32I-NEXT:    lw a1, 480(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 488(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    sw a0, 0(a1)
 ; RV32I-NEXT:    sw a4, 4(a1)
 ; RV32I-NEXT:    srli a2, a2, 1
@@ -28853,12 +28853,12 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IM-NEXT:    .cfi_offset s9, -44
 ; RV32IM-NEXT:    .cfi_offset s10, -48
 ; RV32IM-NEXT:    .cfi_offset s11, -52
-; RV32IM-NEXT:    sw a3, 112(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a3, 24(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mv a3, a2
 ; RV32IM-NEXT:    mv t2, a1
-; RV32IM-NEXT:    sw a0, 96(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 120(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    lui a0, 16
-; RV32IM-NEXT:    sw a4, 92(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a4, 32(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srli a1, a4, 8
 ; RV32IM-NEXT:    addi t3, a0, -256
 ; RV32IM-NEXT:    and a0, a1, t3
@@ -28890,7 +28890,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IM-NEXT:    and a2, a2, t5
 ; RV32IM-NEXT:    slli a1, a1, 1
 ; RV32IM-NEXT:    or a7, a2, a1
-; RV32IM-NEXT:    sw a7, 72(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 8(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srli a1, a7, 8
 ; RV32IM-NEXT:    and a1, a1, t3
 ; RV32IM-NEXT:    srli a2, a7, 24
@@ -28906,7 +28906,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IM-NEXT:    slli a1, a1, 4
 ; RV32IM-NEXT:    or a1, a2, a1
 ; RV32IM-NEXT:    srli a2, a1, 2
-; RV32IM-NEXT:    sw a3, 88(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a3, 16(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srli a6, a3, 8
 ; RV32IM-NEXT:    and a2, a2, s2
 ; RV32IM-NEXT:    and a6, a6, t3
@@ -28936,7 +28936,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IM-NEXT:    slli a2, a2, 1
 ; RV32IM-NEXT:    srli a7, a1, 1
 ; RV32IM-NEXT:    or t1, a6, a2
-; RV32IM-NEXT:    sw t1, 80(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t1, 12(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a2, a7, t5
 ; RV32IM-NEXT:    srli a6, t1, 8
 ; RV32IM-NEXT:    and a1, a1, t5
@@ -29035,7 +29035,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IM-NEXT:    srli a1, a0, 2
 ; RV32IM-NEXT:    and a1, a1, s2
 ; RV32IM-NEXT:    and a0, a0, s2
-; RV32IM-NEXT:    sw t2, 84(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t2, 116(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srli a2, t2, 8
 ; RV32IM-NEXT:    slli a0, a0, 2
 ; RV32IM-NEXT:    and a2, a2, t3
@@ -29059,7 +29059,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IM-NEXT:    slli a1, a1, 2
 ; RV32IM-NEXT:    lui t2, 349525
 ; RV32IM-NEXT:    addi a7, t2, 1364
-; RV32IM-NEXT:    sw a7, 76(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 28(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a1, a2, a1
 ; RV32IM-NEXT:    srli a2, a1, 1
 ; RV32IM-NEXT:    and a1, a1, t5
@@ -29067,18 +29067,18 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IM-NEXT:    slli a1, a1, 1
 ; RV32IM-NEXT:    and t6, a0, t5
 ; RV32IM-NEXT:    or a1, a2, a1
-; RV32IM-NEXT:    lw a3, 72(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mv a2, s5
-; RV32IM-NEXT:    sw s5, 100(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s5, 44(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and s4, a3, s5
-; RV32IM-NEXT:    sw a6, 120(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 40(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a0, a1, a6
 ; RV32IM-NEXT:    and s5, a3, a6
 ; RV32IM-NEXT:    and a2, a1, a2
 ; RV32IM-NEXT:    mul a6, a0, s4
 ; RV32IM-NEXT:    mul a4, a2, s5
 ; RV32IM-NEXT:    and a5, a3, t4
-; RV32IM-NEXT:    sw t1, 116(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t1, 36(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and s0, a1, t1
 ; RV32IM-NEXT:    and s9, a3, t1
 ; RV32IM-NEXT:    and s1, a1, t4
@@ -29092,21 +29092,21 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IM-NEXT:    mul s10, s0, s9
 ; RV32IM-NEXT:    mul s11, s1, s5
 ; RV32IM-NEXT:    mul ra, a0, s5
-; RV32IM-NEXT:    sw s5, 44(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s5, 88(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mv t2, a0
-; RV32IM-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 112(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul a2, a2, s9
-; RV32IM-NEXT:    sw t1, 64(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t1, 108(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul a1, s0, s4
-; RV32IM-NEXT:    sw s4, 40(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    sw s0, 60(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s4, 84(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s0, 104(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul a0, s1, s7
-; RV32IM-NEXT:    sw s7, 8(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    sw s1, 72(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s7, 52(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s1, 8(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and t0, t0, a7
 ; RV32IM-NEXT:    slli a7, t6, 1
 ; RV32IM-NEXT:    or a7, t0, a7
-; RV32IM-NEXT:    sw a7, 52(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 96(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a4, a4, a6
 ; RV32IM-NEXT:    xor a3, a3, a5
 ; RV32IM-NEXT:    xor a5, s8, s6
@@ -29115,9 +29115,9 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IM-NEXT:    xor a4, a5, a6
 ; RV32IM-NEXT:    xor a2, a2, ra
 ; RV32IM-NEXT:    xor a0, a1, a0
-; RV32IM-NEXT:    lw s8, 112(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s8, 24(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a1, s8, 8
-; RV32IM-NEXT:    sw t3, 36(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t3, 80(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a5, s8, t3
 ; RV32IM-NEXT:    and a1, a1, t3
 ; RV32IM-NEXT:    slli a5, a5, 8
@@ -29132,58 +29132,58 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IM-NEXT:    mul a2, s0, s5
 ; RV32IM-NEXT:    mul a5, s1, s4
 ; RV32IM-NEXT:    srli s6, a1, 4
-; RV32IM-NEXT:    sw s3, 104(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s3, 20(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a1, a1, s3
 ; RV32IM-NEXT:    and s6, s6, s3
 ; RV32IM-NEXT:    slli a1, a1, 4
 ; RV32IM-NEXT:    xor a6, t0, a6
 ; RV32IM-NEXT:    or a1, s6, a1
 ; RV32IM-NEXT:    srli t0, a1, 2
-; RV32IM-NEXT:    sw s2, 56(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s2, 100(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a1, a1, s2
 ; RV32IM-NEXT:    and t0, t0, s2
 ; RV32IM-NEXT:    slli a1, a1, 2
 ; RV32IM-NEXT:    xor a2, a2, a5
 ; RV32IM-NEXT:    or a1, t0, a1
 ; RV32IM-NEXT:    srli a5, a1, 1
-; RV32IM-NEXT:    sw t5, 108(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t5, 48(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a1, a1, t5
 ; RV32IM-NEXT:    and a5, a5, t5
 ; RV32IM-NEXT:    slli a1, a1, 1
 ; RV32IM-NEXT:    xor a2, a6, a2
 ; RV32IM-NEXT:    or a1, a5, a1
-; RV32IM-NEXT:    lw s4, 120(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s4, 40(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and t2, a3, s4
-; RV32IM-NEXT:    lw s5, 100(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s5, 44(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a3, a4, s5
-; RV32IM-NEXT:    sw a3, 32(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    lw t1, 116(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    sw a3, 76(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    lw t1, 36(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a0, a0, t1
-; RV32IM-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mv s1, t4
 ; RV32IM-NEXT:    and a0, a2, t4
-; RV32IM-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a4, a1, s5
 ; RV32IM-NEXT:    and s8, a1, s4
 ; RV32IM-NEXT:    and s10, a1, t4
 ; RV32IM-NEXT:    and s11, a1, t1
-; RV32IM-NEXT:    lw a3, 80(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 12(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a0, a3, s4
 ; RV32IM-NEXT:    and a1, a3, s5
 ; RV32IM-NEXT:    and a2, a3, t1
 ; RV32IM-NEXT:    and s3, a3, t4
 ; RV32IM-NEXT:    mul a3, a0, a4
-; RV32IM-NEXT:    sw a3, 80(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    mul a3, a1, s8
-; RV32IM-NEXT:    sw a3, 20(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    mul a3, a2, s10
-; RV32IM-NEXT:    sw a3, 16(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    mul a3, s3, s11
 ; RV32IM-NEXT:    sw a3, 12(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    mul a3, a1, s8
+; RV32IM-NEXT:    sw a3, 64(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    mul a3, a2, s10
+; RV32IM-NEXT:    sw a3, 60(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    mul a3, s3, s11
+; RV32IM-NEXT:    sw a3, 56(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul s6, a0, s10
 ; RV32IM-NEXT:    mul s0, a1, a4
 ; RV32IM-NEXT:    mv a3, a4
-; RV32IM-NEXT:    sw a4, 48(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a4, 92(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul t6, a2, s11
 ; RV32IM-NEXT:    mul t5, s3, s8
 ; RV32IM-NEXT:    mul t4, a0, s8
@@ -29194,16 +29194,16 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IM-NEXT:    mul a5, a1, s10
 ; RV32IM-NEXT:    mul a4, a2, s8
 ; RV32IM-NEXT:    mul a3, s3, a3
-; RV32IM-NEXT:    lw t1, 32(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t1, 76(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    or t2, t1, t2
-; RV32IM-NEXT:    lw t1, 28(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw ra, 24(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t1, 72(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw ra, 68(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    or t1, t1, ra
-; RV32IM-NEXT:    lw ra, 80(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s2, 20(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s2, 64(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    xor ra, s2, ra
-; RV32IM-NEXT:    lw s2, 16(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s7, 12(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s2, 60(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s7, 56(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    xor s2, s2, s7
 ; RV32IM-NEXT:    xor s0, s0, s6
 ; RV32IM-NEXT:    xor t5, t6, t5
@@ -29217,7 +29217,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IM-NEXT:    xor a3, a5, a3
 ; RV32IM-NEXT:    and a5, t6, s4
 ; RV32IM-NEXT:    and a6, t5, s5
-; RV32IM-NEXT:    lw s4, 116(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s4, 36(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, s4
 ; RV32IM-NEXT:    and a3, a3, s1
 ; RV32IM-NEXT:    mv s6, s1
@@ -29226,11 +29226,11 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IM-NEXT:    or a4, t2, t1
 ; RV32IM-NEXT:    or a3, a5, a3
 ; RV32IM-NEXT:    xor a3, a3, a4
-; RV32IM-NEXT:    lw a4, 52(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 96(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a4, a4, 1
 ; RV32IM-NEXT:    xor a3, a4, a3
 ; RV32IM-NEXT:    srli a4, a3, 8
-; RV32IM-NEXT:    lw s2, 36(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s2, 80(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, s2
 ; RV32IM-NEXT:    srli a5, a3, 24
 ; RV32IM-NEXT:    and a6, a3, s2
@@ -29240,16 +29240,16 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IM-NEXT:    or a3, a3, a6
 ; RV32IM-NEXT:    or a3, a3, a4
 ; RV32IM-NEXT:    srli a4, a3, 4
-; RV32IM-NEXT:    lw a5, 104(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 20(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a3, a3, a5
 ; RV32IM-NEXT:    and a4, a4, a5
 ; RV32IM-NEXT:    slli a3, a3, 4
 ; RV32IM-NEXT:    or ra, a4, a3
-; RV32IM-NEXT:    lw s0, 40(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s0, 84(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a3, a0, s0
-; RV32IM-NEXT:    lw s1, 44(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s1, 88(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a4, a1, s1
-; RV32IM-NEXT:    lw s7, 8(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s7, 52(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a5, a2, s7
 ; RV32IM-NEXT:    mul a6, s3, s9
 ; RV32IM-NEXT:    mul a7, a0, s7
@@ -29277,9 +29277,9 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IM-NEXT:    xor a2, a2, s0
 ; RV32IM-NEXT:    srli a1, ra, 2
 ; RV32IM-NEXT:    xor a0, a0, a2
-; RV32IM-NEXT:    lw s0, 56(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s0, 100(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, s0
-; RV32IM-NEXT:    lw s7, 120(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s7, 40(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a2, a3, s7
 ; RV32IM-NEXT:    mv s1, s5
 ; RV32IM-NEXT:    and a3, a4, s5
@@ -29297,27 +29297,27 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IM-NEXT:    and a2, a2, s2
 ; RV32IM-NEXT:    srli a3, a0, 24
 ; RV32IM-NEXT:    and a4, a0, s2
-; RV32IM-NEXT:    lw t3, 68(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s4, 48(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t3, 112(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s4, 92(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a5, t3, s4
-; RV32IM-NEXT:    lw t4, 64(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t4, 108(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a6, t4, s8
-; RV32IM-NEXT:    lw t5, 60(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t5, 104(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a7, t5, s10
-; RV32IM-NEXT:    lw t6, 72(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t6, 8(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t0, t6, s11
 ; RV32IM-NEXT:    slli a0, a0, 24
 ; RV32IM-NEXT:    slli a4, a4, 8
 ; RV32IM-NEXT:    or a2, a2, a3
 ; RV32IM-NEXT:    or a0, a0, a4
 ; RV32IM-NEXT:    srli a3, a1, 1
-; RV32IM-NEXT:    lw s3, 108(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s3, 48(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, s3
-; RV32IM-NEXT:    lw ra, 76(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a3, a3, ra
 ; RV32IM-NEXT:    slli a1, a1, 1
 ; RV32IM-NEXT:    or a1, a3, a1
-; RV32IM-NEXT:    sw a1, 80(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a0, a0, a2
 ; RV32IM-NEXT:    xor a1, a6, a5
 ; RV32IM-NEXT:    xor a2, a7, t0
@@ -29337,7 +29337,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IM-NEXT:    xor a3, a4, a3
 ; RV32IM-NEXT:    xor a2, a5, a6
 ; RV32IM-NEXT:    srli a4, a0, 4
-; RV32IM-NEXT:    lw s6, 104(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s6, 20(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, s6
 ; RV32IM-NEXT:    xor a2, a3, a2
 ; RV32IM-NEXT:    and a1, a1, s7
@@ -29378,9 +29378,9 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IM-NEXT:    srli a2, a1, 2
 ; RV32IM-NEXT:    and a2, a2, s0
 ; RV32IM-NEXT:    and a1, a1, s0
-; RV32IM-NEXT:    lw a5, 112(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 24(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and t0, a5, s1
-; RV32IM-NEXT:    lw a3, 88(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 16(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a6, a3, s7
 ; RV32IM-NEXT:    and t3, a5, s7
 ; RV32IM-NEXT:    and a7, a3, s1
@@ -29402,14 +29402,14 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IM-NEXT:    slli a0, a0, 2
 ; RV32IM-NEXT:    slli a1, a1, 2
 ; RV32IM-NEXT:    or a0, a4, a0
-; RV32IM-NEXT:    sw a0, 112(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a1, a2, a1
 ; RV32IM-NEXT:    srli a0, a1, 1
 ; RV32IM-NEXT:    and a1, a1, s3
 ; RV32IM-NEXT:    and a0, a0, ra
-; RV32IM-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    slli a1, a1, 1
-; RV32IM-NEXT:    sw a1, 88(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a0, t1, s9
 ; RV32IM-NEXT:    xor s0, s0, s1
 ; RV32IM-NEXT:    xor a1, s4, s2
@@ -29417,26 +29417,26 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IM-NEXT:    xor a0, a0, s0
 ; RV32IM-NEXT:    xor a1, a1, a4
 ; RV32IM-NEXT:    and a0, a0, s7
-; RV32IM-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mv a2, s8
 ; RV32IM-NEXT:    and t1, a1, s8
 ; RV32IM-NEXT:    mul s0, a6, t3
 ; RV32IM-NEXT:    mul s1, a7, t2
-; RV32IM-NEXT:    sw t0, 104(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t0, 20(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul s2, t5, t0
 ; RV32IM-NEXT:    mul s4, t6, t4
 ; RV32IM-NEXT:    mul a6, a6, t2
 ; RV32IM-NEXT:    mul a7, a7, t4
 ; RV32IM-NEXT:    mul s5, t5, t3
 ; RV32IM-NEXT:    mul s6, t6, t0
-; RV32IM-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s8, a0, s8
 ; RV32IM-NEXT:    mv a5, a2
 ; RV32IM-NEXT:    and s9, a0, s7
 ; RV32IM-NEXT:    and s10, a0, a3
 ; RV32IM-NEXT:    mv a1, s11
 ; RV32IM-NEXT:    and s11, a0, s11
-; RV32IM-NEXT:    lw a2, 84(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a2, 116(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and t5, a2, s7
 ; RV32IM-NEXT:    and a4, a2, a5
 ; RV32IM-NEXT:    and a0, a2, a1
@@ -29445,13 +29445,13 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IM-NEXT:    mul t0, a4, s9
 ; RV32IM-NEXT:    mul t6, a0, s10
 ; RV32IM-NEXT:    mul a2, a5, s11
-; RV32IM-NEXT:    lw s3, 88(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s7, 76(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s3, 16(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s7, 28(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    or s3, s7, s3
-; RV32IM-NEXT:    sw s3, 92(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    lw s3, 72(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    sw s3, 32(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    lw s3, 8(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    or t1, t1, s3
-; RV32IM-NEXT:    sw t1, 88(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t1, 16(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor s0, s1, s0
 ; RV32IM-NEXT:    xor t1, s2, s4
 ; RV32IM-NEXT:    xor a6, a7, a6
@@ -29482,37 +29482,37 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IM-NEXT:    xor a3, a3, s0
 ; RV32IM-NEXT:    xor a7, s3, s2
 ; RV32IM-NEXT:    xor t1, s4, s5
-; RV32IM-NEXT:    lw t6, 80(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t6, 12(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli t6, t6, 1
 ; RV32IM-NEXT:    xor s0, s10, s6
-; RV32IM-NEXT:    lw t0, 112(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t0, 24(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli s1, t0, 1
 ; RV32IM-NEXT:    xor s2, s9, s8
 ; RV32IM-NEXT:    slli s3, s1, 31
-; RV32IM-NEXT:    lw s7, 120(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s7, 40(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a2, a2, s7
-; RV32IM-NEXT:    lw s11, 100(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s11, 44(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a3, a3, s11
 ; RV32IM-NEXT:    xor a7, a7, t1
 ; RV32IM-NEXT:    xor t1, s0, s2
-; RV32IM-NEXT:    lw ra, 116(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw ra, 36(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a7, a7, ra
 ; RV32IM-NEXT:    and t1, t1, a1
 ; RV32IM-NEXT:    mv s10, a1
 ; RV32IM-NEXT:    or a2, a3, a2
 ; RV32IM-NEXT:    or a3, a7, t1
-; RV32IM-NEXT:    lw a1, 88(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    or a6, a1, a6
 ; RV32IM-NEXT:    or a2, a2, a3
-; RV32IM-NEXT:    lw a3, 92(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 32(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a3, a3, 1
 ; RV32IM-NEXT:    xor s0, a2, a6
 ; RV32IM-NEXT:    or t6, t6, s3
 ; RV32IM-NEXT:    xor s0, a3, s0
-; RV32IM-NEXT:    lw a2, 108(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a2, 48(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s1, s1, a2
 ; RV32IM-NEXT:    and a2, t0, a2
-; RV32IM-NEXT:    lw a1, 104(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a3, t5, a1
 ; RV32IM-NEXT:    mul a6, a4, t3
 ; RV32IM-NEXT:    mul a7, a0, t4
@@ -29550,7 +29550,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IM-NEXT:    or a0, a3, a0
 ; RV32IM-NEXT:    slli a2, a2, 1
 ; RV32IM-NEXT:    or a2, s1, a2
-; RV32IM-NEXT:    lw a1, 96(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a1, 120(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    sw a0, 0(a1)
 ; RV32IM-NEXT:    sw s0, 4(a1)
 ; RV32IM-NEXT:    srli a2, a2, 1
@@ -29907,12 +29907,12 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZBS-NEXT:    .cfi_offset s9, -44
 ; RV32IMZBS-NEXT:    .cfi_offset s10, -48
 ; RV32IMZBS-NEXT:    .cfi_offset s11, -52
-; RV32IMZBS-NEXT:    sw a3, 112(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a3, 24(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mv a3, a2
 ; RV32IMZBS-NEXT:    mv t2, a1
-; RV32IMZBS-NEXT:    sw a0, 96(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 120(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    lui a0, 16
-; RV32IMZBS-NEXT:    sw a4, 92(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a4, 32(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srli a1, a4, 8
 ; RV32IMZBS-NEXT:    addi t3, a0, -256
 ; RV32IMZBS-NEXT:    and a0, a1, t3
@@ -29944,7 +29944,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZBS-NEXT:    and a2, a2, t5
 ; RV32IMZBS-NEXT:    slli a1, a1, 1
 ; RV32IMZBS-NEXT:    or a7, a2, a1
-; RV32IMZBS-NEXT:    sw a7, 72(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 8(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srli a1, a7, 8
 ; RV32IMZBS-NEXT:    and a1, a1, t3
 ; RV32IMZBS-NEXT:    srli a2, a7, 24
@@ -29960,7 +29960,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZBS-NEXT:    slli a1, a1, 4
 ; RV32IMZBS-NEXT:    or a1, a2, a1
 ; RV32IMZBS-NEXT:    srli a2, a1, 2
-; RV32IMZBS-NEXT:    sw a3, 88(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a3, 16(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srli a6, a3, 8
 ; RV32IMZBS-NEXT:    and a2, a2, s2
 ; RV32IMZBS-NEXT:    and a6, a6, t3
@@ -29990,7 +29990,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZBS-NEXT:    slli a2, a2, 1
 ; RV32IMZBS-NEXT:    srli a7, a1, 1
 ; RV32IMZBS-NEXT:    or t1, a6, a2
-; RV32IMZBS-NEXT:    sw t1, 80(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t1, 12(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a2, a7, t5
 ; RV32IMZBS-NEXT:    srli a6, t1, 8
 ; RV32IMZBS-NEXT:    and a1, a1, t5
@@ -30089,7 +30089,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZBS-NEXT:    srli a1, a0, 2
 ; RV32IMZBS-NEXT:    and a1, a1, s2
 ; RV32IMZBS-NEXT:    and a0, a0, s2
-; RV32IMZBS-NEXT:    sw t2, 84(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t2, 116(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srli a2, t2, 8
 ; RV32IMZBS-NEXT:    slli a0, a0, 2
 ; RV32IMZBS-NEXT:    and a2, a2, t3
@@ -30113,7 +30113,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZBS-NEXT:    slli a1, a1, 2
 ; RV32IMZBS-NEXT:    lui t2, 349525
 ; RV32IMZBS-NEXT:    addi a7, t2, 1364
-; RV32IMZBS-NEXT:    sw a7, 76(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 28(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a1, a2, a1
 ; RV32IMZBS-NEXT:    srli a2, a1, 1
 ; RV32IMZBS-NEXT:    and a1, a1, t5
@@ -30121,18 +30121,18 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZBS-NEXT:    slli a1, a1, 1
 ; RV32IMZBS-NEXT:    and t6, a0, t5
 ; RV32IMZBS-NEXT:    or a1, a2, a1
-; RV32IMZBS-NEXT:    lw a3, 72(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mv a2, s5
-; RV32IMZBS-NEXT:    sw s5, 100(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s5, 44(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and s4, a3, s5
-; RV32IMZBS-NEXT:    sw a6, 120(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 40(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a0, a1, a6
 ; RV32IMZBS-NEXT:    and s5, a3, a6
 ; RV32IMZBS-NEXT:    and a2, a1, a2
 ; RV32IMZBS-NEXT:    mul a6, a0, s4
 ; RV32IMZBS-NEXT:    mul a4, a2, s5
 ; RV32IMZBS-NEXT:    and a5, a3, t4
-; RV32IMZBS-NEXT:    sw t1, 116(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t1, 36(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and s0, a1, t1
 ; RV32IMZBS-NEXT:    and s9, a3, t1
 ; RV32IMZBS-NEXT:    and s1, a1, t4
@@ -30146,21 +30146,21 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZBS-NEXT:    mul s10, s0, s9
 ; RV32IMZBS-NEXT:    mul s11, s1, s5
 ; RV32IMZBS-NEXT:    mul ra, a0, s5
-; RV32IMZBS-NEXT:    sw s5, 44(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s5, 88(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mv t2, a0
-; RV32IMZBS-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 112(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul a2, a2, s9
-; RV32IMZBS-NEXT:    sw t1, 64(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t1, 108(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul a1, s0, s4
-; RV32IMZBS-NEXT:    sw s4, 40(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    sw s0, 60(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s4, 84(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s0, 104(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul a0, s1, s7
-; RV32IMZBS-NEXT:    sw s7, 8(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    sw s1, 72(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s7, 52(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s1, 8(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and t0, t0, a7
 ; RV32IMZBS-NEXT:    slli a7, t6, 1
 ; RV32IMZBS-NEXT:    or a7, t0, a7
-; RV32IMZBS-NEXT:    sw a7, 52(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 96(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a4, a4, a6
 ; RV32IMZBS-NEXT:    xor a3, a3, a5
 ; RV32IMZBS-NEXT:    xor a5, s8, s6
@@ -30169,9 +30169,9 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZBS-NEXT:    xor a4, a5, a6
 ; RV32IMZBS-NEXT:    xor a2, a2, ra
 ; RV32IMZBS-NEXT:    xor a0, a1, a0
-; RV32IMZBS-NEXT:    lw s8, 112(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s8, 24(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a1, s8, 8
-; RV32IMZBS-NEXT:    sw t3, 36(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t3, 80(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a5, s8, t3
 ; RV32IMZBS-NEXT:    and a1, a1, t3
 ; RV32IMZBS-NEXT:    slli a5, a5, 8
@@ -30186,58 +30186,58 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZBS-NEXT:    mul a2, s0, s5
 ; RV32IMZBS-NEXT:    mul a5, s1, s4
 ; RV32IMZBS-NEXT:    srli s6, a1, 4
-; RV32IMZBS-NEXT:    sw s3, 104(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s3, 20(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a1, a1, s3
 ; RV32IMZBS-NEXT:    and s6, s6, s3
 ; RV32IMZBS-NEXT:    slli a1, a1, 4
 ; RV32IMZBS-NEXT:    xor a6, t0, a6
 ; RV32IMZBS-NEXT:    or a1, s6, a1
 ; RV32IMZBS-NEXT:    srli t0, a1, 2
-; RV32IMZBS-NEXT:    sw s2, 56(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s2, 100(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a1, a1, s2
 ; RV32IMZBS-NEXT:    and t0, t0, s2
 ; RV32IMZBS-NEXT:    slli a1, a1, 2
 ; RV32IMZBS-NEXT:    xor a2, a2, a5
 ; RV32IMZBS-NEXT:    or a1, t0, a1
 ; RV32IMZBS-NEXT:    srli a5, a1, 1
-; RV32IMZBS-NEXT:    sw t5, 108(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t5, 48(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a1, a1, t5
 ; RV32IMZBS-NEXT:    and a5, a5, t5
 ; RV32IMZBS-NEXT:    slli a1, a1, 1
 ; RV32IMZBS-NEXT:    xor a2, a6, a2
 ; RV32IMZBS-NEXT:    or a1, a5, a1
-; RV32IMZBS-NEXT:    lw s4, 120(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s4, 40(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and t2, a3, s4
-; RV32IMZBS-NEXT:    lw s5, 100(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s5, 44(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a3, a4, s5
-; RV32IMZBS-NEXT:    sw a3, 32(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    lw t1, 116(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    sw a3, 76(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    lw t1, 36(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a0, a0, t1
-; RV32IMZBS-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mv s1, t4
 ; RV32IMZBS-NEXT:    and a0, a2, t4
-; RV32IMZBS-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a4, a1, s5
 ; RV32IMZBS-NEXT:    and s8, a1, s4
 ; RV32IMZBS-NEXT:    and s10, a1, t4
 ; RV32IMZBS-NEXT:    and s11, a1, t1
-; RV32IMZBS-NEXT:    lw a3, 80(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 12(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a0, a3, s4
 ; RV32IMZBS-NEXT:    and a1, a3, s5
 ; RV32IMZBS-NEXT:    and a2, a3, t1
 ; RV32IMZBS-NEXT:    and s3, a3, t4
 ; RV32IMZBS-NEXT:    mul a3, a0, a4
-; RV32IMZBS-NEXT:    sw a3, 80(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    mul a3, a1, s8
-; RV32IMZBS-NEXT:    sw a3, 20(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    mul a3, a2, s10
-; RV32IMZBS-NEXT:    sw a3, 16(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    mul a3, s3, s11
 ; RV32IMZBS-NEXT:    sw a3, 12(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    mul a3, a1, s8
+; RV32IMZBS-NEXT:    sw a3, 64(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    mul a3, a2, s10
+; RV32IMZBS-NEXT:    sw a3, 60(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    mul a3, s3, s11
+; RV32IMZBS-NEXT:    sw a3, 56(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul s6, a0, s10
 ; RV32IMZBS-NEXT:    mul s0, a1, a4
 ; RV32IMZBS-NEXT:    mv a3, a4
-; RV32IMZBS-NEXT:    sw a4, 48(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a4, 92(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul t6, a2, s11
 ; RV32IMZBS-NEXT:    mul t5, s3, s8
 ; RV32IMZBS-NEXT:    mul t4, a0, s8
@@ -30248,16 +30248,16 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZBS-NEXT:    mul a5, a1, s10
 ; RV32IMZBS-NEXT:    mul a4, a2, s8
 ; RV32IMZBS-NEXT:    mul a3, s3, a3
-; RV32IMZBS-NEXT:    lw t1, 32(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t1, 76(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    or t2, t1, t2
-; RV32IMZBS-NEXT:    lw t1, 28(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw ra, 24(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t1, 72(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw ra, 68(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    or t1, t1, ra
-; RV32IMZBS-NEXT:    lw ra, 80(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s2, 20(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s2, 64(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    xor ra, s2, ra
-; RV32IMZBS-NEXT:    lw s2, 16(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s7, 12(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s2, 60(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s7, 56(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    xor s2, s2, s7
 ; RV32IMZBS-NEXT:    xor s0, s0, s6
 ; RV32IMZBS-NEXT:    xor t5, t6, t5
@@ -30271,7 +30271,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZBS-NEXT:    xor a3, a5, a3
 ; RV32IMZBS-NEXT:    and a5, t6, s4
 ; RV32IMZBS-NEXT:    and a6, t5, s5
-; RV32IMZBS-NEXT:    lw s4, 116(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s4, 36(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, s4
 ; RV32IMZBS-NEXT:    and a3, a3, s1
 ; RV32IMZBS-NEXT:    mv s6, s1
@@ -30280,11 +30280,11 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZBS-NEXT:    or a4, t2, t1
 ; RV32IMZBS-NEXT:    or a3, a5, a3
 ; RV32IMZBS-NEXT:    xor a3, a3, a4
-; RV32IMZBS-NEXT:    lw a4, 52(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 96(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a4, a4, 1
 ; RV32IMZBS-NEXT:    xor a3, a4, a3
 ; RV32IMZBS-NEXT:    srli a4, a3, 8
-; RV32IMZBS-NEXT:    lw s2, 36(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s2, 80(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, s2
 ; RV32IMZBS-NEXT:    srli a5, a3, 24
 ; RV32IMZBS-NEXT:    and a6, a3, s2
@@ -30294,16 +30294,16 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZBS-NEXT:    or a3, a3, a6
 ; RV32IMZBS-NEXT:    or a3, a3, a4
 ; RV32IMZBS-NEXT:    srli a4, a3, 4
-; RV32IMZBS-NEXT:    lw a5, 104(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 20(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a3, a3, a5
 ; RV32IMZBS-NEXT:    and a4, a4, a5
 ; RV32IMZBS-NEXT:    slli a3, a3, 4
 ; RV32IMZBS-NEXT:    or ra, a4, a3
-; RV32IMZBS-NEXT:    lw s0, 40(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s0, 84(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a3, a0, s0
-; RV32IMZBS-NEXT:    lw s1, 44(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s1, 88(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a4, a1, s1
-; RV32IMZBS-NEXT:    lw s7, 8(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s7, 52(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a5, a2, s7
 ; RV32IMZBS-NEXT:    mul a6, s3, s9
 ; RV32IMZBS-NEXT:    mul a7, a0, s7
@@ -30331,9 +30331,9 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZBS-NEXT:    xor a2, a2, s0
 ; RV32IMZBS-NEXT:    srli a1, ra, 2
 ; RV32IMZBS-NEXT:    xor a0, a0, a2
-; RV32IMZBS-NEXT:    lw s0, 56(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s0, 100(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, s0
-; RV32IMZBS-NEXT:    lw s7, 120(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s7, 40(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a2, a3, s7
 ; RV32IMZBS-NEXT:    mv s1, s5
 ; RV32IMZBS-NEXT:    and a3, a4, s5
@@ -30351,27 +30351,27 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZBS-NEXT:    and a2, a2, s2
 ; RV32IMZBS-NEXT:    srli a3, a0, 24
 ; RV32IMZBS-NEXT:    and a4, a0, s2
-; RV32IMZBS-NEXT:    lw t3, 68(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s4, 48(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t3, 112(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s4, 92(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a5, t3, s4
-; RV32IMZBS-NEXT:    lw t4, 64(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t4, 108(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a6, t4, s8
-; RV32IMZBS-NEXT:    lw t5, 60(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t5, 104(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a7, t5, s10
-; RV32IMZBS-NEXT:    lw t6, 72(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t6, 8(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t0, t6, s11
 ; RV32IMZBS-NEXT:    slli a0, a0, 24
 ; RV32IMZBS-NEXT:    slli a4, a4, 8
 ; RV32IMZBS-NEXT:    or a2, a2, a3
 ; RV32IMZBS-NEXT:    or a0, a0, a4
 ; RV32IMZBS-NEXT:    srli a3, a1, 1
-; RV32IMZBS-NEXT:    lw s3, 108(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s3, 48(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, s3
-; RV32IMZBS-NEXT:    lw ra, 76(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a3, a3, ra
 ; RV32IMZBS-NEXT:    slli a1, a1, 1
 ; RV32IMZBS-NEXT:    or a1, a3, a1
-; RV32IMZBS-NEXT:    sw a1, 80(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a0, a0, a2
 ; RV32IMZBS-NEXT:    xor a1, a6, a5
 ; RV32IMZBS-NEXT:    xor a2, a7, t0
@@ -30391,7 +30391,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZBS-NEXT:    xor a3, a4, a3
 ; RV32IMZBS-NEXT:    xor a2, a5, a6
 ; RV32IMZBS-NEXT:    srli a4, a0, 4
-; RV32IMZBS-NEXT:    lw s6, 104(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s6, 20(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, s6
 ; RV32IMZBS-NEXT:    xor a2, a3, a2
 ; RV32IMZBS-NEXT:    and a1, a1, s7
@@ -30432,9 +30432,9 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZBS-NEXT:    srli a2, a1, 2
 ; RV32IMZBS-NEXT:    and a2, a2, s0
 ; RV32IMZBS-NEXT:    and a1, a1, s0
-; RV32IMZBS-NEXT:    lw a5, 112(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 24(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and t0, a5, s1
-; RV32IMZBS-NEXT:    lw a3, 88(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 16(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a6, a3, s7
 ; RV32IMZBS-NEXT:    and t3, a5, s7
 ; RV32IMZBS-NEXT:    and a7, a3, s1
@@ -30456,14 +30456,14 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZBS-NEXT:    slli a0, a0, 2
 ; RV32IMZBS-NEXT:    slli a1, a1, 2
 ; RV32IMZBS-NEXT:    or a0, a4, a0
-; RV32IMZBS-NEXT:    sw a0, 112(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a1, a2, a1
 ; RV32IMZBS-NEXT:    srli a0, a1, 1
 ; RV32IMZBS-NEXT:    and a1, a1, s3
 ; RV32IMZBS-NEXT:    and a0, a0, ra
-; RV32IMZBS-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    slli a1, a1, 1
-; RV32IMZBS-NEXT:    sw a1, 88(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a0, t1, s9
 ; RV32IMZBS-NEXT:    xor s0, s0, s1
 ; RV32IMZBS-NEXT:    xor a1, s4, s2
@@ -30471,26 +30471,26 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZBS-NEXT:    xor a0, a0, s0
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
 ; RV32IMZBS-NEXT:    and a0, a0, s7
-; RV32IMZBS-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mv a2, s8
 ; RV32IMZBS-NEXT:    and t1, a1, s8
 ; RV32IMZBS-NEXT:    mul s0, a6, t3
 ; RV32IMZBS-NEXT:    mul s1, a7, t2
-; RV32IMZBS-NEXT:    sw t0, 104(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t0, 20(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul s2, t5, t0
 ; RV32IMZBS-NEXT:    mul s4, t6, t4
 ; RV32IMZBS-NEXT:    mul a6, a6, t2
 ; RV32IMZBS-NEXT:    mul a7, a7, t4
 ; RV32IMZBS-NEXT:    mul s5, t5, t3
 ; RV32IMZBS-NEXT:    mul s6, t6, t0
-; RV32IMZBS-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s8, a0, s8
 ; RV32IMZBS-NEXT:    mv a5, a2
 ; RV32IMZBS-NEXT:    and s9, a0, s7
 ; RV32IMZBS-NEXT:    and s10, a0, a3
 ; RV32IMZBS-NEXT:    mv a1, s11
 ; RV32IMZBS-NEXT:    and s11, a0, s11
-; RV32IMZBS-NEXT:    lw a2, 84(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a2, 116(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and t5, a2, s7
 ; RV32IMZBS-NEXT:    and a4, a2, a5
 ; RV32IMZBS-NEXT:    and a0, a2, a1
@@ -30499,13 +30499,13 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZBS-NEXT:    mul t0, a4, s9
 ; RV32IMZBS-NEXT:    mul t6, a0, s10
 ; RV32IMZBS-NEXT:    mul a2, a5, s11
-; RV32IMZBS-NEXT:    lw s3, 88(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s7, 76(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s3, 16(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s7, 28(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    or s3, s7, s3
-; RV32IMZBS-NEXT:    sw s3, 92(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    lw s3, 72(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    sw s3, 32(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    lw s3, 8(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    or t1, t1, s3
-; RV32IMZBS-NEXT:    sw t1, 88(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t1, 16(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor s0, s1, s0
 ; RV32IMZBS-NEXT:    xor t1, s2, s4
 ; RV32IMZBS-NEXT:    xor a6, a7, a6
@@ -30536,37 +30536,37 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZBS-NEXT:    xor a3, a3, s0
 ; RV32IMZBS-NEXT:    xor a7, s3, s2
 ; RV32IMZBS-NEXT:    xor t1, s4, s5
-; RV32IMZBS-NEXT:    lw t6, 80(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t6, 12(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli t6, t6, 1
 ; RV32IMZBS-NEXT:    xor s0, s10, s6
-; RV32IMZBS-NEXT:    lw t0, 112(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t0, 24(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli s1, t0, 1
 ; RV32IMZBS-NEXT:    xor s2, s9, s8
 ; RV32IMZBS-NEXT:    slli s3, s1, 31
-; RV32IMZBS-NEXT:    lw s7, 120(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s7, 40(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a2, a2, s7
-; RV32IMZBS-NEXT:    lw s11, 100(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s11, 44(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a3, a3, s11
 ; RV32IMZBS-NEXT:    xor a7, a7, t1
 ; RV32IMZBS-NEXT:    xor t1, s0, s2
-; RV32IMZBS-NEXT:    lw ra, 116(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw ra, 36(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a7, a7, ra
 ; RV32IMZBS-NEXT:    and t1, t1, a1
 ; RV32IMZBS-NEXT:    mv s10, a1
 ; RV32IMZBS-NEXT:    or a2, a3, a2
 ; RV32IMZBS-NEXT:    or a3, a7, t1
-; RV32IMZBS-NEXT:    lw a1, 88(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    or a6, a1, a6
 ; RV32IMZBS-NEXT:    or a2, a2, a3
-; RV32IMZBS-NEXT:    lw a3, 92(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 32(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a3, a3, 1
 ; RV32IMZBS-NEXT:    xor s0, a2, a6
 ; RV32IMZBS-NEXT:    or t6, t6, s3
 ; RV32IMZBS-NEXT:    xor s0, a3, s0
-; RV32IMZBS-NEXT:    lw a2, 108(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a2, 48(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s1, s1, a2
 ; RV32IMZBS-NEXT:    and a2, t0, a2
-; RV32IMZBS-NEXT:    lw a1, 104(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a3, t5, a1
 ; RV32IMZBS-NEXT:    mul a6, a4, t3
 ; RV32IMZBS-NEXT:    mul a7, a0, t4
@@ -30604,7 +30604,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZBS-NEXT:    or a0, a3, a0
 ; RV32IMZBS-NEXT:    slli a2, a2, 1
 ; RV32IMZBS-NEXT:    or a2, s1, a2
-; RV32IMZBS-NEXT:    lw a1, 96(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a1, 120(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    sw a0, 0(a1)
 ; RV32IMZBS-NEXT:    sw s0, 4(a1)
 ; RV32IMZBS-NEXT:    srli a2, a2, 1
@@ -31129,12 +31129,12 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZVBC-NEXT:    .cfi_offset s9, -44
 ; RV32IMZVBC-NEXT:    .cfi_offset s10, -48
 ; RV32IMZVBC-NEXT:    .cfi_offset s11, -52
-; RV32IMZVBC-NEXT:    sw a3, 112(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a3, 24(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mv a3, a2
 ; RV32IMZVBC-NEXT:    mv t2, a1
-; RV32IMZVBC-NEXT:    sw a0, 96(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a0, 120(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    lui a0, 16
-; RV32IMZVBC-NEXT:    sw a4, 92(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a4, 32(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    srli a1, a4, 8
 ; RV32IMZVBC-NEXT:    addi t3, a0, -256
 ; RV32IMZVBC-NEXT:    and a0, a1, t3
@@ -31166,7 +31166,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZVBC-NEXT:    and a2, a2, t5
 ; RV32IMZVBC-NEXT:    slli a1, a1, 1
 ; RV32IMZVBC-NEXT:    or a7, a2, a1
-; RV32IMZVBC-NEXT:    sw a7, 72(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 8(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    srli a1, a7, 8
 ; RV32IMZVBC-NEXT:    and a1, a1, t3
 ; RV32IMZVBC-NEXT:    srli a2, a7, 24
@@ -31182,7 +31182,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZVBC-NEXT:    slli a1, a1, 4
 ; RV32IMZVBC-NEXT:    or a1, a2, a1
 ; RV32IMZVBC-NEXT:    srli a2, a1, 2
-; RV32IMZVBC-NEXT:    sw a3, 88(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a3, 16(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    srli a6, a3, 8
 ; RV32IMZVBC-NEXT:    and a2, a2, s2
 ; RV32IMZVBC-NEXT:    and a6, a6, t3
@@ -31212,7 +31212,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZVBC-NEXT:    slli a2, a2, 1
 ; RV32IMZVBC-NEXT:    srli a7, a1, 1
 ; RV32IMZVBC-NEXT:    or t1, a6, a2
-; RV32IMZVBC-NEXT:    sw t1, 80(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t1, 12(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a2, a7, t5
 ; RV32IMZVBC-NEXT:    srli a6, t1, 8
 ; RV32IMZVBC-NEXT:    and a1, a1, t5
@@ -31311,7 +31311,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZVBC-NEXT:    srli a1, a0, 2
 ; RV32IMZVBC-NEXT:    and a1, a1, s2
 ; RV32IMZVBC-NEXT:    and a0, a0, s2
-; RV32IMZVBC-NEXT:    sw t2, 84(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t2, 116(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    srli a2, t2, 8
 ; RV32IMZVBC-NEXT:    slli a0, a0, 2
 ; RV32IMZVBC-NEXT:    and a2, a2, t3
@@ -31335,7 +31335,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZVBC-NEXT:    slli a1, a1, 2
 ; RV32IMZVBC-NEXT:    lui t2, 349525
 ; RV32IMZVBC-NEXT:    addi a7, t2, 1364
-; RV32IMZVBC-NEXT:    sw a7, 76(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 28(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    or a1, a2, a1
 ; RV32IMZVBC-NEXT:    srli a2, a1, 1
 ; RV32IMZVBC-NEXT:    and a1, a1, t5
@@ -31343,18 +31343,18 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZVBC-NEXT:    slli a1, a1, 1
 ; RV32IMZVBC-NEXT:    and t6, a0, t5
 ; RV32IMZVBC-NEXT:    or a1, a2, a1
-; RV32IMZVBC-NEXT:    lw a3, 72(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mv a2, s5
-; RV32IMZVBC-NEXT:    sw s5, 100(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s5, 44(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and s4, a3, s5
-; RV32IMZVBC-NEXT:    sw a6, 120(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a6, 40(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a0, a1, a6
 ; RV32IMZVBC-NEXT:    and s5, a3, a6
 ; RV32IMZVBC-NEXT:    and a2, a1, a2
 ; RV32IMZVBC-NEXT:    mul a6, a0, s4
 ; RV32IMZVBC-NEXT:    mul a4, a2, s5
 ; RV32IMZVBC-NEXT:    and a5, a3, t4
-; RV32IMZVBC-NEXT:    sw t1, 116(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t1, 36(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and s0, a1, t1
 ; RV32IMZVBC-NEXT:    and s9, a3, t1
 ; RV32IMZVBC-NEXT:    and s1, a1, t4
@@ -31368,21 +31368,21 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZVBC-NEXT:    mul s10, s0, s9
 ; RV32IMZVBC-NEXT:    mul s11, s1, s5
 ; RV32IMZVBC-NEXT:    mul ra, a0, s5
-; RV32IMZVBC-NEXT:    sw s5, 44(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s5, 88(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mv t2, a0
-; RV32IMZVBC-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a0, 112(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul a2, a2, s9
-; RV32IMZVBC-NEXT:    sw t1, 64(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t1, 108(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul a1, s0, s4
-; RV32IMZVBC-NEXT:    sw s4, 40(sp) # 4-byte Folded Spill
-; RV32IMZVBC-NEXT:    sw s0, 60(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s4, 84(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s0, 104(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul a0, s1, s7
-; RV32IMZVBC-NEXT:    sw s7, 8(sp) # 4-byte Folded Spill
-; RV32IMZVBC-NEXT:    sw s1, 72(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s7, 52(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s1, 8(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and t0, t0, a7
 ; RV32IMZVBC-NEXT:    slli a7, t6, 1
 ; RV32IMZVBC-NEXT:    or a7, t0, a7
-; RV32IMZVBC-NEXT:    sw a7, 52(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a7, 96(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a4, a4, a6
 ; RV32IMZVBC-NEXT:    xor a3, a3, a5
 ; RV32IMZVBC-NEXT:    xor a5, s8, s6
@@ -31391,9 +31391,9 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZVBC-NEXT:    xor a4, a5, a6
 ; RV32IMZVBC-NEXT:    xor a2, a2, ra
 ; RV32IMZVBC-NEXT:    xor a0, a1, a0
-; RV32IMZVBC-NEXT:    lw s8, 112(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s8, 24(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    srli a1, s8, 8
-; RV32IMZVBC-NEXT:    sw t3, 36(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t3, 80(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a5, s8, t3
 ; RV32IMZVBC-NEXT:    and a1, a1, t3
 ; RV32IMZVBC-NEXT:    slli a5, a5, 8
@@ -31408,58 +31408,58 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZVBC-NEXT:    mul a2, s0, s5
 ; RV32IMZVBC-NEXT:    mul a5, s1, s4
 ; RV32IMZVBC-NEXT:    srli s6, a1, 4
-; RV32IMZVBC-NEXT:    sw s3, 104(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s3, 20(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a1, a1, s3
 ; RV32IMZVBC-NEXT:    and s6, s6, s3
 ; RV32IMZVBC-NEXT:    slli a1, a1, 4
 ; RV32IMZVBC-NEXT:    xor a6, t0, a6
 ; RV32IMZVBC-NEXT:    or a1, s6, a1
 ; RV32IMZVBC-NEXT:    srli t0, a1, 2
-; RV32IMZVBC-NEXT:    sw s2, 56(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw s2, 100(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a1, a1, s2
 ; RV32IMZVBC-NEXT:    and t0, t0, s2
 ; RV32IMZVBC-NEXT:    slli a1, a1, 2
 ; RV32IMZVBC-NEXT:    xor a2, a2, a5
 ; RV32IMZVBC-NEXT:    or a1, t0, a1
 ; RV32IMZVBC-NEXT:    srli a5, a1, 1
-; RV32IMZVBC-NEXT:    sw t5, 108(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t5, 48(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a1, a1, t5
 ; RV32IMZVBC-NEXT:    and a5, a5, t5
 ; RV32IMZVBC-NEXT:    slli a1, a1, 1
 ; RV32IMZVBC-NEXT:    xor a2, a6, a2
 ; RV32IMZVBC-NEXT:    or a1, a5, a1
-; RV32IMZVBC-NEXT:    lw s4, 120(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s4, 40(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and t2, a3, s4
-; RV32IMZVBC-NEXT:    lw s5, 100(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s5, 44(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a3, a4, s5
-; RV32IMZVBC-NEXT:    sw a3, 32(sp) # 4-byte Folded Spill
-; RV32IMZVBC-NEXT:    lw t1, 116(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    sw a3, 76(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    lw t1, 36(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a0, a0, t1
-; RV32IMZVBC-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mv s1, t4
 ; RV32IMZVBC-NEXT:    and a0, a2, t4
-; RV32IMZVBC-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    and a4, a1, s5
 ; RV32IMZVBC-NEXT:    and s8, a1, s4
 ; RV32IMZVBC-NEXT:    and s10, a1, t4
 ; RV32IMZVBC-NEXT:    and s11, a1, t1
-; RV32IMZVBC-NEXT:    lw a3, 80(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 12(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a0, a3, s4
 ; RV32IMZVBC-NEXT:    and a1, a3, s5
 ; RV32IMZVBC-NEXT:    and a2, a3, t1
 ; RV32IMZVBC-NEXT:    and s3, a3, t4
 ; RV32IMZVBC-NEXT:    mul a3, a0, a4
-; RV32IMZVBC-NEXT:    sw a3, 80(sp) # 4-byte Folded Spill
-; RV32IMZVBC-NEXT:    mul a3, a1, s8
-; RV32IMZVBC-NEXT:    sw a3, 20(sp) # 4-byte Folded Spill
-; RV32IMZVBC-NEXT:    mul a3, a2, s10
-; RV32IMZVBC-NEXT:    sw a3, 16(sp) # 4-byte Folded Spill
-; RV32IMZVBC-NEXT:    mul a3, s3, s11
 ; RV32IMZVBC-NEXT:    sw a3, 12(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    mul a3, a1, s8
+; RV32IMZVBC-NEXT:    sw a3, 64(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    mul a3, a2, s10
+; RV32IMZVBC-NEXT:    sw a3, 60(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    mul a3, s3, s11
+; RV32IMZVBC-NEXT:    sw a3, 56(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul s6, a0, s10
 ; RV32IMZVBC-NEXT:    mul s0, a1, a4
 ; RV32IMZVBC-NEXT:    mv a3, a4
-; RV32IMZVBC-NEXT:    sw a4, 48(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a4, 92(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul t6, a2, s11
 ; RV32IMZVBC-NEXT:    mul t5, s3, s8
 ; RV32IMZVBC-NEXT:    mul t4, a0, s8
@@ -31470,16 +31470,16 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZVBC-NEXT:    mul a5, a1, s10
 ; RV32IMZVBC-NEXT:    mul a4, a2, s8
 ; RV32IMZVBC-NEXT:    mul a3, s3, a3
-; RV32IMZVBC-NEXT:    lw t1, 32(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t1, 76(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    or t2, t1, t2
-; RV32IMZVBC-NEXT:    lw t1, 28(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw ra, 24(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t1, 72(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw ra, 68(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    or t1, t1, ra
-; RV32IMZVBC-NEXT:    lw ra, 80(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw s2, 20(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s2, 64(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    xor ra, s2, ra
-; RV32IMZVBC-NEXT:    lw s2, 16(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw s7, 12(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s2, 60(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s7, 56(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    xor s2, s2, s7
 ; RV32IMZVBC-NEXT:    xor s0, s0, s6
 ; RV32IMZVBC-NEXT:    xor t5, t6, t5
@@ -31493,7 +31493,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZVBC-NEXT:    xor a3, a5, a3
 ; RV32IMZVBC-NEXT:    and a5, t6, s4
 ; RV32IMZVBC-NEXT:    and a6, t5, s5
-; RV32IMZVBC-NEXT:    lw s4, 116(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s4, 36(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, s4
 ; RV32IMZVBC-NEXT:    and a3, a3, s1
 ; RV32IMZVBC-NEXT:    mv s6, s1
@@ -31502,11 +31502,11 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZVBC-NEXT:    or a4, t2, t1
 ; RV32IMZVBC-NEXT:    or a3, a5, a3
 ; RV32IMZVBC-NEXT:    xor a3, a3, a4
-; RV32IMZVBC-NEXT:    lw a4, 52(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a4, 96(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    srli a4, a4, 1
 ; RV32IMZVBC-NEXT:    xor a3, a4, a3
 ; RV32IMZVBC-NEXT:    srli a4, a3, 8
-; RV32IMZVBC-NEXT:    lw s2, 36(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s2, 80(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, s2
 ; RV32IMZVBC-NEXT:    srli a5, a3, 24
 ; RV32IMZVBC-NEXT:    and a6, a3, s2
@@ -31516,16 +31516,16 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZVBC-NEXT:    or a3, a3, a6
 ; RV32IMZVBC-NEXT:    or a3, a3, a4
 ; RV32IMZVBC-NEXT:    srli a4, a3, 4
-; RV32IMZVBC-NEXT:    lw a5, 104(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 20(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a3, a3, a5
 ; RV32IMZVBC-NEXT:    and a4, a4, a5
 ; RV32IMZVBC-NEXT:    slli a3, a3, 4
 ; RV32IMZVBC-NEXT:    or ra, a4, a3
-; RV32IMZVBC-NEXT:    lw s0, 40(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s0, 84(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul a3, a0, s0
-; RV32IMZVBC-NEXT:    lw s1, 44(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s1, 88(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul a4, a1, s1
-; RV32IMZVBC-NEXT:    lw s7, 8(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s7, 52(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul a5, a2, s7
 ; RV32IMZVBC-NEXT:    mul a6, s3, s9
 ; RV32IMZVBC-NEXT:    mul a7, a0, s7
@@ -31553,9 +31553,9 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZVBC-NEXT:    xor a2, a2, s0
 ; RV32IMZVBC-NEXT:    srli a1, ra, 2
 ; RV32IMZVBC-NEXT:    xor a0, a0, a2
-; RV32IMZVBC-NEXT:    lw s0, 56(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s0, 100(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a1, a1, s0
-; RV32IMZVBC-NEXT:    lw s7, 120(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s7, 40(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a2, a3, s7
 ; RV32IMZVBC-NEXT:    mv s1, s5
 ; RV32IMZVBC-NEXT:    and a3, a4, s5
@@ -31573,27 +31573,27 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZVBC-NEXT:    and a2, a2, s2
 ; RV32IMZVBC-NEXT:    srli a3, a0, 24
 ; RV32IMZVBC-NEXT:    and a4, a0, s2
-; RV32IMZVBC-NEXT:    lw t3, 68(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw s4, 48(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t3, 112(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s4, 92(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul a5, t3, s4
-; RV32IMZVBC-NEXT:    lw t4, 64(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t4, 108(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul a6, t4, s8
-; RV32IMZVBC-NEXT:    lw t5, 60(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t5, 104(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul a7, t5, s10
-; RV32IMZVBC-NEXT:    lw t6, 72(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t6, 8(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul t0, t6, s11
 ; RV32IMZVBC-NEXT:    slli a0, a0, 24
 ; RV32IMZVBC-NEXT:    slli a4, a4, 8
 ; RV32IMZVBC-NEXT:    or a2, a2, a3
 ; RV32IMZVBC-NEXT:    or a0, a0, a4
 ; RV32IMZVBC-NEXT:    srli a3, a1, 1
-; RV32IMZVBC-NEXT:    lw s3, 108(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s3, 48(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a1, a1, s3
-; RV32IMZVBC-NEXT:    lw ra, 76(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a3, a3, ra
 ; RV32IMZVBC-NEXT:    slli a1, a1, 1
 ; RV32IMZVBC-NEXT:    or a1, a3, a1
-; RV32IMZVBC-NEXT:    sw a1, 80(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    or a0, a0, a2
 ; RV32IMZVBC-NEXT:    xor a1, a6, a5
 ; RV32IMZVBC-NEXT:    xor a2, a7, t0
@@ -31613,7 +31613,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZVBC-NEXT:    xor a3, a4, a3
 ; RV32IMZVBC-NEXT:    xor a2, a5, a6
 ; RV32IMZVBC-NEXT:    srli a4, a0, 4
-; RV32IMZVBC-NEXT:    lw s6, 104(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s6, 20(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a4, a4, s6
 ; RV32IMZVBC-NEXT:    xor a2, a3, a2
 ; RV32IMZVBC-NEXT:    and a1, a1, s7
@@ -31654,9 +31654,9 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZVBC-NEXT:    srli a2, a1, 2
 ; RV32IMZVBC-NEXT:    and a2, a2, s0
 ; RV32IMZVBC-NEXT:    and a1, a1, s0
-; RV32IMZVBC-NEXT:    lw a5, 112(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a5, 24(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and t0, a5, s1
-; RV32IMZVBC-NEXT:    lw a3, 88(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 16(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a6, a3, s7
 ; RV32IMZVBC-NEXT:    and t3, a5, s7
 ; RV32IMZVBC-NEXT:    and a7, a3, s1
@@ -31678,14 +31678,14 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZVBC-NEXT:    slli a0, a0, 2
 ; RV32IMZVBC-NEXT:    slli a1, a1, 2
 ; RV32IMZVBC-NEXT:    or a0, a4, a0
-; RV32IMZVBC-NEXT:    sw a0, 112(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    or a1, a2, a1
 ; RV32IMZVBC-NEXT:    srli a0, a1, 1
 ; RV32IMZVBC-NEXT:    and a1, a1, s3
 ; RV32IMZVBC-NEXT:    and a0, a0, ra
-; RV32IMZVBC-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    slli a1, a1, 1
-; RV32IMZVBC-NEXT:    sw a1, 88(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor a0, t1, s9
 ; RV32IMZVBC-NEXT:    xor s0, s0, s1
 ; RV32IMZVBC-NEXT:    xor a1, s4, s2
@@ -31693,26 +31693,26 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZVBC-NEXT:    xor a0, a0, s0
 ; RV32IMZVBC-NEXT:    xor a1, a1, a4
 ; RV32IMZVBC-NEXT:    and a0, a0, s7
-; RV32IMZVBC-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mv a2, s8
 ; RV32IMZVBC-NEXT:    and t1, a1, s8
 ; RV32IMZVBC-NEXT:    mul s0, a6, t3
 ; RV32IMZVBC-NEXT:    mul s1, a7, t2
-; RV32IMZVBC-NEXT:    sw t0, 104(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t0, 20(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    mul s2, t5, t0
 ; RV32IMZVBC-NEXT:    mul s4, t6, t4
 ; RV32IMZVBC-NEXT:    mul a6, a6, t2
 ; RV32IMZVBC-NEXT:    mul a7, a7, t4
 ; RV32IMZVBC-NEXT:    mul s5, t5, t3
 ; RV32IMZVBC-NEXT:    mul s6, t6, t0
-; RV32IMZVBC-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s8, a0, s8
 ; RV32IMZVBC-NEXT:    mv a5, a2
 ; RV32IMZVBC-NEXT:    and s9, a0, s7
 ; RV32IMZVBC-NEXT:    and s10, a0, a3
 ; RV32IMZVBC-NEXT:    mv a1, s11
 ; RV32IMZVBC-NEXT:    and s11, a0, s11
-; RV32IMZVBC-NEXT:    lw a2, 84(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a2, 116(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and t5, a2, s7
 ; RV32IMZVBC-NEXT:    and a4, a2, a5
 ; RV32IMZVBC-NEXT:    and a0, a2, a1
@@ -31721,13 +31721,13 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZVBC-NEXT:    mul t0, a4, s9
 ; RV32IMZVBC-NEXT:    mul t6, a0, s10
 ; RV32IMZVBC-NEXT:    mul a2, a5, s11
-; RV32IMZVBC-NEXT:    lw s3, 88(sp) # 4-byte Folded Reload
-; RV32IMZVBC-NEXT:    lw s7, 76(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s3, 16(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s7, 28(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    or s3, s7, s3
-; RV32IMZVBC-NEXT:    sw s3, 92(sp) # 4-byte Folded Spill
-; RV32IMZVBC-NEXT:    lw s3, 72(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    sw s3, 32(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    lw s3, 8(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    or t1, t1, s3
-; RV32IMZVBC-NEXT:    sw t1, 88(sp) # 4-byte Folded Spill
+; RV32IMZVBC-NEXT:    sw t1, 16(sp) # 4-byte Folded Spill
 ; RV32IMZVBC-NEXT:    xor s0, s1, s0
 ; RV32IMZVBC-NEXT:    xor t1, s2, s4
 ; RV32IMZVBC-NEXT:    xor a6, a7, a6
@@ -31758,37 +31758,37 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZVBC-NEXT:    xor a3, a3, s0
 ; RV32IMZVBC-NEXT:    xor a7, s3, s2
 ; RV32IMZVBC-NEXT:    xor t1, s4, s5
-; RV32IMZVBC-NEXT:    lw t6, 80(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t6, 12(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    srli t6, t6, 1
 ; RV32IMZVBC-NEXT:    xor s0, s10, s6
-; RV32IMZVBC-NEXT:    lw t0, 112(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw t0, 24(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    srli s1, t0, 1
 ; RV32IMZVBC-NEXT:    xor s2, s9, s8
 ; RV32IMZVBC-NEXT:    slli s3, s1, 31
-; RV32IMZVBC-NEXT:    lw s7, 120(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s7, 40(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a2, a2, s7
-; RV32IMZVBC-NEXT:    lw s11, 100(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw s11, 44(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a3, a3, s11
 ; RV32IMZVBC-NEXT:    xor a7, a7, t1
 ; RV32IMZVBC-NEXT:    xor t1, s0, s2
-; RV32IMZVBC-NEXT:    lw ra, 116(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw ra, 36(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and a7, a7, ra
 ; RV32IMZVBC-NEXT:    and t1, t1, a1
 ; RV32IMZVBC-NEXT:    mv s10, a1
 ; RV32IMZVBC-NEXT:    or a2, a3, a2
 ; RV32IMZVBC-NEXT:    or a3, a7, t1
-; RV32IMZVBC-NEXT:    lw a1, 88(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    or a6, a1, a6
 ; RV32IMZVBC-NEXT:    or a2, a2, a3
-; RV32IMZVBC-NEXT:    lw a3, 92(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a3, 32(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    srli a3, a3, 1
 ; RV32IMZVBC-NEXT:    xor s0, a2, a6
 ; RV32IMZVBC-NEXT:    or t6, t6, s3
 ; RV32IMZVBC-NEXT:    xor s0, a3, s0
-; RV32IMZVBC-NEXT:    lw a2, 108(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a2, 48(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    and s1, s1, a2
 ; RV32IMZVBC-NEXT:    and a2, t0, a2
-; RV32IMZVBC-NEXT:    lw a1, 104(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    mul a3, t5, a1
 ; RV32IMZVBC-NEXT:    mul a6, a4, t3
 ; RV32IMZVBC-NEXT:    mul a7, a0, t4
@@ -31826,7 +31826,7 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 ; RV32IMZVBC-NEXT:    or a0, a3, a0
 ; RV32IMZVBC-NEXT:    slli a2, a2, 1
 ; RV32IMZVBC-NEXT:    or a2, s1, a2
-; RV32IMZVBC-NEXT:    lw a1, 96(sp) # 4-byte Folded Reload
+; RV32IMZVBC-NEXT:    lw a1, 120(sp) # 4-byte Folded Reload
 ; RV32IMZVBC-NEXT:    sw a0, 0(a1)
 ; RV32IMZVBC-NEXT:    sw s0, 4(a1)
 ; RV32IMZVBC-NEXT:    srli a2, a2, 1
@@ -33051,8 +33051,8 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    sw s9, 468(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    sw s10, 464(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    sw s11, 460(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    sw a3, 452(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    sw a2, 448(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 456(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 452(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lw a5, 0(a0)
 ; RV32I-NEXT:    lui a2, 16
 ; RV32I-NEXT:    lw t3, 4(a0)
@@ -33067,7 +33067,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    slli a3, a3, 8
 ; RV32I-NEXT:    or a0, a0, a2
 ; RV32I-NEXT:    slli a2, a5, 24
-; RV32I-NEXT:    sw a2, 456(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    or a2, a2, a3
 ; RV32I-NEXT:    lui a3, 61681
 ; RV32I-NEXT:    or a0, a2, a0
@@ -33349,7 +33349,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    slli t5, t5, 2
 ; RV32I-NEXT:    or t5, t6, t5
 ; RV32I-NEXT:    addi a0, t4, 1364
-; RV32I-NEXT:    sw a0, 212(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli t4, t5, 1
 ; RV32I-NEXT:    and t4, t4, a0
 ; RV32I-NEXT:    and t5, t5, s10
@@ -33358,24 +33358,24 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz t6, t6
 ; RV32I-NEXT:    andi s1, t2, 1
 ; RV32I-NEXT:    addi a1, t6, -1
-; RV32I-NEXT:    sw a1, 444(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 448(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz t6, s1
 ; RV32I-NEXT:    addi t1, t6, -1
-; RV32I-NEXT:    sw t1, 440(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t1, 444(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t6, t3, 1
 ; RV32I-NEXT:    and t6, a1, t6
 ; RV32I-NEXT:    and s1, t1, t3
 ; RV32I-NEXT:    or a1, t4, t5
-; RV32I-NEXT:    sw a1, 436(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 440(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor t4, s1, t6
 ; RV32I-NEXT:    andi t5, t2, 4
 ; RV32I-NEXT:    andi t6, t2, 8
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    seqz t6, t6
 ; RV32I-NEXT:    addi a1, t5, -1
-; RV32I-NEXT:    sw a1, 432(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 436(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi t1, t6, -1
-; RV32I-NEXT:    sw t1, 428(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t1, 432(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t5, t3, 2
 ; RV32I-NEXT:    slli t6, t3, 3
 ; RV32I-NEXT:    and t5, a1, t5
@@ -33385,19 +33385,19 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    xor t4, t4, t5
 ; RV32I-NEXT:    seqz t5, t6
 ; RV32I-NEXT:    addi a1, t5, -1
-; RV32I-NEXT:    sw a1, 424(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 428(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi t5, t2, 32
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    slli t6, t3, 4
 ; RV32I-NEXT:    and t6, a1, t6
 ; RV32I-NEXT:    addi a1, t5, -1
-; RV32I-NEXT:    sw a1, 420(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 424(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t5, t3, 5
 ; RV32I-NEXT:    andi s1, t2, 64
 ; RV32I-NEXT:    and t5, a1, t5
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    addi a1, s1, -1
-; RV32I-NEXT:    sw a1, 416(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 420(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t3, 6
 ; RV32I-NEXT:    xor t5, t6, t5
 ; RV32I-NEXT:    and t6, a1, s1
@@ -33406,26 +33406,26 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    xor t4, t4, t5
 ; RV32I-NEXT:    seqz t5, t6
 ; RV32I-NEXT:    addi a1, t5, -1
-; RV32I-NEXT:    sw a1, 412(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 416(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi t5, t2, 256
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    slli t6, t3, 7
 ; RV32I-NEXT:    and t6, a1, t6
 ; RV32I-NEXT:    addi a1, t5, -1
-; RV32I-NEXT:    sw a1, 408(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 412(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t5, t3, 8
 ; RV32I-NEXT:    andi s1, t2, 512
 ; RV32I-NEXT:    and t5, a1, t5
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    xor t5, t6, t5
 ; RV32I-NEXT:    addi a1, s1, -1
-; RV32I-NEXT:    sw a1, 404(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 408(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t6, t3, 9
 ; RV32I-NEXT:    andi s1, t2, 1024
 ; RV32I-NEXT:    and t6, a1, t6
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    addi a1, s1, -1
-; RV32I-NEXT:    sw a1, 400(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 404(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t3, 10
 ; RV32I-NEXT:    xor t5, t5, t6
 ; RV32I-NEXT:    and t6, a1, s1
@@ -33434,14 +33434,14 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    xor t4, t4, t5
 ; RV32I-NEXT:    seqz t5, t6
 ; RV32I-NEXT:    addi a1, t5, -1
-; RV32I-NEXT:    sw a1, 396(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 400(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui s11, 1
 ; RV32I-NEXT:    and t5, t2, s11
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    slli t6, t3, 11
 ; RV32I-NEXT:    and t6, a1, t6
 ; RV32I-NEXT:    addi a1, t5, -1
-; RV32I-NEXT:    sw a1, 392(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 396(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t5, t3, 12
 ; RV32I-NEXT:    lui s2, 2
 ; RV32I-NEXT:    and s1, t2, s2
@@ -33449,7 +33449,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    xor t5, t6, t5
 ; RV32I-NEXT:    addi a1, s1, -1
-; RV32I-NEXT:    sw a1, 388(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 392(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t6, t3, 13
 ; RV32I-NEXT:    lui s3, 4
 ; RV32I-NEXT:    and s1, t2, s3
@@ -33457,14 +33457,14 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    xor t5, t5, t6
 ; RV32I-NEXT:    addi a1, s1, -1
-; RV32I-NEXT:    sw a1, 384(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 388(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t6, t3, 14
 ; RV32I-NEXT:    lui s4, 8
 ; RV32I-NEXT:    and s1, t2, s4
 ; RV32I-NEXT:    and t6, a1, t6
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    addi a1, s1, -1
-; RV32I-NEXT:    sw a1, 380(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 384(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t3, 15
 ; RV32I-NEXT:    xor t5, t5, t6
 ; RV32I-NEXT:    and t6, a1, s1
@@ -33474,14 +33474,14 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    xor t4, t4, t5
 ; RV32I-NEXT:    seqz t5, t6
 ; RV32I-NEXT:    addi a1, t5, -1
-; RV32I-NEXT:    sw a1, 376(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 380(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui s5, 32
 ; RV32I-NEXT:    and t5, t2, s5
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    slli t6, t3, 16
 ; RV32I-NEXT:    and t6, a1, t6
 ; RV32I-NEXT:    addi a1, t5, -1
-; RV32I-NEXT:    sw a1, 372(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 376(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t5, t3, 17
 ; RV32I-NEXT:    lui s6, 64
 ; RV32I-NEXT:    and s1, t2, s6
@@ -33489,7 +33489,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    xor t5, t6, t5
 ; RV32I-NEXT:    addi a1, s1, -1
-; RV32I-NEXT:    sw a1, 368(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 372(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t6, t3, 18
 ; RV32I-NEXT:    lui ra, 128
 ; RV32I-NEXT:    and s1, t2, ra
@@ -33497,7 +33497,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    xor t5, t5, t6
 ; RV32I-NEXT:    addi a1, s1, -1
-; RV32I-NEXT:    sw a1, 364(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 368(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t6, t3, 19
 ; RV32I-NEXT:    lui t1, 256
 ; RV32I-NEXT:    and s1, t2, t1
@@ -33505,14 +33505,14 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    xor t5, t5, t6
 ; RV32I-NEXT:    addi a1, s1, -1
-; RV32I-NEXT:    sw a1, 360(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 364(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t6, t3, 20
 ; RV32I-NEXT:    lui a0, 512
 ; RV32I-NEXT:    and s1, t2, a0
 ; RV32I-NEXT:    and t6, a1, t6
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    addi a1, s1, -1
-; RV32I-NEXT:    sw a1, 356(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 360(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t3, 21
 ; RV32I-NEXT:    xor t5, t5, t6
 ; RV32I-NEXT:    and t6, a1, s1
@@ -33522,14 +33522,14 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    xor t4, t4, t5
 ; RV32I-NEXT:    seqz t5, t6
 ; RV32I-NEXT:    addi a1, t5, -1
-; RV32I-NEXT:    sw a1, 352(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 356(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui a0, 2048
 ; RV32I-NEXT:    and t5, t2, a0
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    slli t6, t3, 22
 ; RV32I-NEXT:    and t6, a1, t6
 ; RV32I-NEXT:    addi a1, t5, -1
-; RV32I-NEXT:    sw a1, 348(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 352(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t5, t3, 23
 ; RV32I-NEXT:    lui a0, 4096
 ; RV32I-NEXT:    and s1, t2, a0
@@ -33537,7 +33537,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    xor t5, t6, t5
 ; RV32I-NEXT:    addi a1, s1, -1
-; RV32I-NEXT:    sw a1, 344(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 348(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t6, t3, 24
 ; RV32I-NEXT:    lui s0, 8192
 ; RV32I-NEXT:    and s1, t2, s0
@@ -33545,7 +33545,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    xor t5, t5, t6
 ; RV32I-NEXT:    addi s1, s1, -1
-; RV32I-NEXT:    sw s1, 340(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s1, 344(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t6, t3, 25
 ; RV32I-NEXT:    lui a1, 16384
 ; RV32I-NEXT:    and a0, t2, a1
@@ -33553,7 +33553,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz s1, a0
 ; RV32I-NEXT:    xor t5, t5, t6
 ; RV32I-NEXT:    addi a0, s1, -1
-; RV32I-NEXT:    sw a0, 336(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 340(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t6, t3, 26
 ; RV32I-NEXT:    lui s1, 32768
 ; RV32I-NEXT:    and s1, t2, s1
@@ -33561,14 +33561,14 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    xor t5, t5, t6
 ; RV32I-NEXT:    addi a0, s1, -1
-; RV32I-NEXT:    sw a0, 332(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 336(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t6, t3, 27
 ; RV32I-NEXT:    lui s1, 65536
 ; RV32I-NEXT:    and s1, t2, s1
 ; RV32I-NEXT:    and t6, a0, t6
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    addi a0, s1, -1
-; RV32I-NEXT:    sw a0, 328(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 332(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t3, 28
 ; RV32I-NEXT:    xor t5, t5, t6
 ; RV32I-NEXT:    and t6, a0, s1
@@ -33578,21 +33578,21 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    xor t4, t4, t5
 ; RV32I-NEXT:    seqz t5, t6
 ; RV32I-NEXT:    addi a0, t5, -1
-; RV32I-NEXT:    sw a0, 324(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 328(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui t5, 262144
 ; RV32I-NEXT:    and t5, t2, t5
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    slli t6, t3, 29
 ; RV32I-NEXT:    and t6, a0, t6
 ; RV32I-NEXT:    addi a0, t5, -1
-; RV32I-NEXT:    sw a0, 320(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 324(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli t2, t2, 31
 ; RV32I-NEXT:    slli t5, t3, 30
 ; RV32I-NEXT:    and t5, a0, t5
 ; RV32I-NEXT:    seqz t2, t2
 ; RV32I-NEXT:    slli t3, t3, 31
 ; RV32I-NEXT:    addi a0, t2, -1
-; RV32I-NEXT:    sw a0, 316(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 320(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor t2, t6, t5
 ; RV32I-NEXT:    and t3, a0, t3
 ; RV32I-NEXT:    xor t2, t2, t3
@@ -33603,7 +33603,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    addi t5, t5, -1
 ; RV32I-NEXT:    slli a0, a5, 1
-; RV32I-NEXT:    sw a0, 312(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 316(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t3, t3, a0
 ; RV32I-NEXT:    and t5, t5, a5
 ; RV32I-NEXT:    xor s1, t4, t2
@@ -33615,9 +33615,9 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    addi t3, t3, -1
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli a0, a5, 2
-; RV32I-NEXT:    sw a0, 308(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 312(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t5, a5, 3
-; RV32I-NEXT:    sw t5, 304(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t5, 308(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t3, t3, a0
 ; RV32I-NEXT:    and t4, t4, t5
 ; RV32I-NEXT:    xor t3, t3, t4
@@ -33628,17 +33628,17 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    andi t4, a2, 32
 ; RV32I-NEXT:    seqz t4, t4
 ; RV32I-NEXT:    slli a0, a5, 4
-; RV32I-NEXT:    sw a0, 300(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 304(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t3, t3, a0
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli a0, a5, 5
-; RV32I-NEXT:    sw a0, 296(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 300(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi t5, a2, 64
 ; RV32I-NEXT:    and t4, t4, a0
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    addi t5, t5, -1
 ; RV32I-NEXT:    slli a0, a5, 6
-; RV32I-NEXT:    sw a0, 292(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 296(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor t3, t3, t4
 ; RV32I-NEXT:    and t4, t5, a0
 ; RV32I-NEXT:    xor t3, t3, t4
@@ -33649,24 +33649,24 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    andi t4, a2, 256
 ; RV32I-NEXT:    seqz t4, t4
 ; RV32I-NEXT:    slli a0, a5, 7
-; RV32I-NEXT:    sw a0, 288(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 292(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t3, t3, a0
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli a0, a5, 8
-; RV32I-NEXT:    sw a0, 284(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 288(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi t5, a2, 512
 ; RV32I-NEXT:    and t4, t4, a0
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    xor t3, t3, t4
 ; RV32I-NEXT:    addi t5, t5, -1
 ; RV32I-NEXT:    slli a0, a5, 9
-; RV32I-NEXT:    sw a0, 280(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 284(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi t4, a2, 1024
 ; RV32I-NEXT:    and t5, t5, a0
 ; RV32I-NEXT:    seqz t4, t4
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli a0, a5, 10
-; RV32I-NEXT:    sw a0, 276(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 280(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor t3, t3, t5
 ; RV32I-NEXT:    and t4, t4, a0
 ; RV32I-NEXT:    xor t3, t3, t4
@@ -33677,31 +33677,31 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    and t4, a2, s11
 ; RV32I-NEXT:    seqz t4, t4
 ; RV32I-NEXT:    slli a0, a5, 11
-; RV32I-NEXT:    sw a0, 272(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 276(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t3, t3, a0
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli a0, a5, 12
-; RV32I-NEXT:    sw a0, 268(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 272(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t5, a2, s2
 ; RV32I-NEXT:    and t4, t4, a0
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    xor t3, t3, t4
 ; RV32I-NEXT:    addi t5, t5, -1
 ; RV32I-NEXT:    slli a0, a5, 13
-; RV32I-NEXT:    sw a0, 264(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 268(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t4, a2, s3
 ; RV32I-NEXT:    and t5, t5, a0
 ; RV32I-NEXT:    seqz t4, t4
 ; RV32I-NEXT:    xor t3, t3, t5
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli a0, a5, 14
-; RV32I-NEXT:    sw a0, 260(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 264(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t5, a2, s4
 ; RV32I-NEXT:    and t4, t4, a0
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    addi t5, t5, -1
 ; RV32I-NEXT:    slli a0, a5, 15
-; RV32I-NEXT:    sw a0, 256(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 260(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor t3, t3, t4
 ; RV32I-NEXT:    and t4, t5, a0
 ; RV32I-NEXT:    xor t3, t3, t4
@@ -33713,32 +33713,32 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    and t4, a2, s5
 ; RV32I-NEXT:    seqz t4, t4
 ; RV32I-NEXT:    slli a0, a5, 16
-; RV32I-NEXT:    sw a0, 252(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 256(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t3, t3, a0
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli a0, a5, 17
-; RV32I-NEXT:    sw a0, 248(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 252(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t5, a2, s6
 ; RV32I-NEXT:    and t4, t4, a0
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    xor t3, t3, t4
 ; RV32I-NEXT:    addi t5, t5, -1
 ; RV32I-NEXT:    slli a0, a5, 18
-; RV32I-NEXT:    sw a0, 244(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 248(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t4, a2, ra
 ; RV32I-NEXT:    and t5, t5, a0
 ; RV32I-NEXT:    seqz t4, t4
 ; RV32I-NEXT:    xor t3, t3, t5
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli a0, a5, 19
-; RV32I-NEXT:    sw a0, 240(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 244(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t5, a2, t1
 ; RV32I-NEXT:    and t4, t4, a0
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    xor t3, t3, t4
 ; RV32I-NEXT:    addi t5, t5, -1
 ; RV32I-NEXT:    slli a0, a5, 20
-; RV32I-NEXT:    sw a0, 236(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 240(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui t1, 512
 ; RV32I-NEXT:    and t4, a2, t1
 ; RV32I-NEXT:    and t5, t5, a0
@@ -33746,7 +33746,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    xor t3, t3, t5
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli a0, a5, 21
-; RV32I-NEXT:    sw a0, 232(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 236(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui t1, 1024
 ; RV32I-NEXT:    and t5, a2, t1
 ; RV32I-NEXT:    and t4, t4, a0
@@ -33754,14 +33754,14 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    xor t3, t3, t4
 ; RV32I-NEXT:    addi t5, t5, -1
 ; RV32I-NEXT:    slli a0, a5, 22
-; RV32I-NEXT:    sw a0, 228(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 232(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui t1, 2048
 ; RV32I-NEXT:    and t4, a2, t1
 ; RV32I-NEXT:    and t5, t5, a0
 ; RV32I-NEXT:    seqz t4, t4
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli a0, a5, 23
-; RV32I-NEXT:    sw a0, 224(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 228(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t4, t4, a0
 ; RV32I-NEXT:    lui a0, 4096
 ; RV32I-NEXT:    and t6, a2, a0
@@ -33769,20 +33769,20 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz t5, t6
 ; RV32I-NEXT:    addi t5, t5, -1
 ; RV32I-NEXT:    and t6, a2, s0
-; RV32I-NEXT:    lw t1, 456(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t5, t5, t1
 ; RV32I-NEXT:    seqz t6, t6
 ; RV32I-NEXT:    xor t4, t4, t5
 ; RV32I-NEXT:    addi t6, t6, -1
 ; RV32I-NEXT:    slli a0, a5, 25
-; RV32I-NEXT:    sw a0, 220(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 224(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t5, a2, a1
 ; RV32I-NEXT:    lui t1, 16384
 ; RV32I-NEXT:    and t6, t6, a0
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    addi t5, t5, -1
 ; RV32I-NEXT:    slli a0, a5, 26
-; RV32I-NEXT:    sw a0, 216(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 220(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor t4, t4, t6
 ; RV32I-NEXT:    and t5, t5, a0
 ; RV32I-NEXT:    xor t2, t2, t3
@@ -33801,7 +33801,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    slli t6, t6, 8
 ; RV32I-NEXT:    slli s2, s2, 8
 ; RV32I-NEXT:    slli a1, a4, 24
-; RV32I-NEXT:    sw a1, 204(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 212(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s3, t0, 24
 ; RV32I-NEXT:    or s2, s3, s2
 ; RV32I-NEXT:    or t6, a1, t6
@@ -33850,7 +33850,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz s4, s4
 ; RV32I-NEXT:    addi s4, s4, -1
 ; RV32I-NEXT:    slli s5, a5, 27
-; RV32I-NEXT:    sw s5, 208(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s5, 216(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and s3, s3, s5
 ; RV32I-NEXT:    and s4, s4, t4
 ; RV32I-NEXT:    xor t5, t5, s3
@@ -34054,7 +34054,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz t4, t4
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli a1, a5, 28
-; RV32I-NEXT:    sw a1, 200(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 208(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t4, t4, a1
 ; RV32I-NEXT:    srli t6, t3, 8
 ; RV32I-NEXT:    xor t4, t5, t4
@@ -34076,9 +34076,9 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    addi t3, t3, -1
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli a0, a5, 29
-; RV32I-NEXT:    sw a0, 196(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 204(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t5, a5, 30
-; RV32I-NEXT:    sw t5, 192(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t5, 200(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t3, t3, a0
 ; RV32I-NEXT:    and t4, t4, t5
 ; RV32I-NEXT:    xor t3, t3, t4
@@ -34089,7 +34089,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz a0, a0
 ; RV32I-NEXT:    addi a0, a0, -1
 ; RV32I-NEXT:    slli t1, a5, 31
-; RV32I-NEXT:    sw t1, 188(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t1, 196(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a0, a0, t1
 ; RV32I-NEXT:    slli a2, a2, 4
 ; RV32I-NEXT:    xor a0, t3, a0
@@ -34101,33 +34101,33 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    xor a0, t2, a0
 ; RV32I-NEXT:    or a2, a3, a2
 ; RV32I-NEXT:    xor a0, a0, s1
-; RV32I-NEXT:    sw a0, 148(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 156(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli a0, a2, 1
-; RV32I-NEXT:    lw a3, 212(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a0, a0, a3
-; RV32I-NEXT:    sw a0, 140(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 148(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a0, t0, 2
 ; RV32I-NEXT:    seqz a0, a0
 ; RV32I-NEXT:    andi a3, t0, 1
 ; RV32I-NEXT:    addi t1, a0, -1
-; RV32I-NEXT:    sw t1, 212(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t1, 4(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a0, a3
 ; RV32I-NEXT:    addi a3, a0, -1
-; RV32I-NEXT:    sw a3, 184(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 192(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a0, a7, 1
 ; RV32I-NEXT:    and a0, t1, a0
 ; RV32I-NEXT:    and a3, a3, a7
 ; RV32I-NEXT:    and a1, a2, s10
-; RV32I-NEXT:    sw a1, 124(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 132(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a0, a3, a0
 ; RV32I-NEXT:    andi a2, t0, 4
 ; RV32I-NEXT:    andi a3, t0, 8
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    addi a1, a2, -1
-; RV32I-NEXT:    sw a1, 180(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 188(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi a6, a3, -1
-; RV32I-NEXT:    sw a6, 176(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 184(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, a7, 2
 ; RV32I-NEXT:    slli a3, a7, 3
 ; RV32I-NEXT:    and a2, a1, a2
@@ -34137,19 +34137,19 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    xor a0, a0, a2
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi a1, a2, -1
-; RV32I-NEXT:    sw a1, 172(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 180(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a2, t0, 32
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    slli a3, a7, 4
 ; RV32I-NEXT:    and a3, a1, a3
 ; RV32I-NEXT:    addi a1, a2, -1
-; RV32I-NEXT:    sw a1, 168(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 176(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, a7, 5
 ; RV32I-NEXT:    andi a6, t0, 64
 ; RV32I-NEXT:    and a2, a1, a2
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    addi a1, a6, -1
-; RV32I-NEXT:    sw a1, 164(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 172(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a6, a7, 6
 ; RV32I-NEXT:    xor a2, a3, a2
 ; RV32I-NEXT:    and a3, a1, a6
@@ -34158,26 +34158,26 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    xor a0, a0, a2
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi a1, a2, -1
-; RV32I-NEXT:    sw a1, 160(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 168(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a2, t0, 256
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    slli a3, a7, 7
 ; RV32I-NEXT:    and a3, a1, a3
 ; RV32I-NEXT:    addi a1, a2, -1
-; RV32I-NEXT:    sw a1, 156(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 164(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, a7, 8
 ; RV32I-NEXT:    andi a6, t0, 512
 ; RV32I-NEXT:    and a2, a1, a2
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    xor a2, a3, a2
 ; RV32I-NEXT:    addi a1, a6, -1
-; RV32I-NEXT:    sw a1, 152(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 160(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, a7, 9
 ; RV32I-NEXT:    andi a6, t0, 1024
 ; RV32I-NEXT:    and a3, a1, a3
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    addi a1, a6, -1
-; RV32I-NEXT:    sw a1, 144(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 152(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a6, a7, 10
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    and a3, a1, a6
@@ -34186,14 +34186,14 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    xor a0, a0, a2
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi a1, a2, -1
-; RV32I-NEXT:    sw a1, 136(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 144(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui s8, 1
 ; RV32I-NEXT:    and a2, t0, s8
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    slli a3, a7, 11
 ; RV32I-NEXT:    and a3, a1, a3
 ; RV32I-NEXT:    addi a1, a2, -1
-; RV32I-NEXT:    sw a1, 132(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 140(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, a7, 12
 ; RV32I-NEXT:    lui s6, 2
 ; RV32I-NEXT:    and a6, t0, s6
@@ -34201,7 +34201,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    xor a2, a3, a2
 ; RV32I-NEXT:    addi a1, a6, -1
-; RV32I-NEXT:    sw a1, 128(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 136(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, a7, 13
 ; RV32I-NEXT:    lui s5, 4
 ; RV32I-NEXT:    and a6, t0, s5
@@ -34209,14 +34209,14 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    addi a1, a6, -1
-; RV32I-NEXT:    sw a1, 120(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 128(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, a7, 14
 ; RV32I-NEXT:    lui s4, 8
 ; RV32I-NEXT:    and a6, t0, s4
 ; RV32I-NEXT:    and a3, a1, a3
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    addi a1, a6, -1
-; RV32I-NEXT:    sw a1, 116(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 124(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a6, a7, 15
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    and a3, a1, a6
@@ -34226,14 +34226,14 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    xor a0, a0, a2
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi a1, a2, -1
-; RV32I-NEXT:    sw a1, 112(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 120(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui s2, 32
 ; RV32I-NEXT:    and a2, t0, s2
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    slli a3, a7, 16
 ; RV32I-NEXT:    and a3, a1, a3
 ; RV32I-NEXT:    addi a1, a2, -1
-; RV32I-NEXT:    sw a1, 108(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 116(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, a7, 17
 ; RV32I-NEXT:    lui s3, 64
 ; RV32I-NEXT:    and a6, t0, s3
@@ -34241,7 +34241,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    xor a2, a3, a2
 ; RV32I-NEXT:    addi a1, a6, -1
-; RV32I-NEXT:    sw a1, 104(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 112(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, a7, 18
 ; RV32I-NEXT:    lui s0, 128
 ; RV32I-NEXT:    and a6, t0, s0
@@ -34249,7 +34249,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    addi a1, a6, -1
-; RV32I-NEXT:    sw a1, 100(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 108(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, a7, 19
 ; RV32I-NEXT:    lui t6, 256
 ; RV32I-NEXT:    and a6, t0, t6
@@ -34257,14 +34257,14 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    addi a1, a6, -1
-; RV32I-NEXT:    sw a1, 96(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 104(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, a7, 20
 ; RV32I-NEXT:    lui t5, 512
 ; RV32I-NEXT:    and a6, t0, t5
 ; RV32I-NEXT:    and a3, a1, a3
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    addi a1, a6, -1
-; RV32I-NEXT:    sw a1, 92(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 100(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a6, a7, 21
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    and a3, a1, a6
@@ -34274,14 +34274,14 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    xor a0, a0, a2
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi a1, a2, -1
-; RV32I-NEXT:    sw a1, 88(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 96(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui t2, 2048
 ; RV32I-NEXT:    and a2, t0, t2
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    slli a3, a7, 22
 ; RV32I-NEXT:    and a3, a1, a3
 ; RV32I-NEXT:    addi a1, a2, -1
-; RV32I-NEXT:    sw a1, 84(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 92(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, a7, 23
 ; RV32I-NEXT:    lui t3, 4096
 ; RV32I-NEXT:    and a6, t0, t3
@@ -34289,7 +34289,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    xor a2, a3, a2
 ; RV32I-NEXT:    addi a1, a6, -1
-; RV32I-NEXT:    sw a1, 80(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 88(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, a7, 24
 ; RV32I-NEXT:    lui t4, 8192
 ; RV32I-NEXT:    and a6, t0, t4
@@ -34297,7 +34297,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    addi s10, a6, -1
-; RV32I-NEXT:    sw s10, 76(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s10, 84(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, a7, 25
 ; RV32I-NEXT:    lui a1, 16384
 ; RV32I-NEXT:    and a6, t0, a1
@@ -34305,7 +34305,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    addi s10, a6, -1
-; RV32I-NEXT:    sw s10, 72(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s10, 80(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, a7, 26
 ; RV32I-NEXT:    lui a1, 32768
 ; RV32I-NEXT:    and a6, t0, a1
@@ -34313,14 +34313,14 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    addi s10, a6, -1
-; RV32I-NEXT:    sw s10, 68(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s10, 76(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a3, a7, 27
 ; RV32I-NEXT:    lui a1, 65536
 ; RV32I-NEXT:    and a6, t0, a1
 ; RV32I-NEXT:    and a3, s10, a3
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    addi a1, a6, -1
-; RV32I-NEXT:    sw a1, 64(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 72(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a6, a7, 28
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    and a3, a1, a6
@@ -34330,20 +34330,20 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    xor a0, a0, a2
 ; RV32I-NEXT:    seqz a2, a3
 ; RV32I-NEXT:    addi a6, a2, -1
-; RV32I-NEXT:    sw a6, 60(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 68(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, t0, ra
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    slli a3, a7, 29
 ; RV32I-NEXT:    and a3, a6, a3
 ; RV32I-NEXT:    addi s10, a2, -1
-; RV32I-NEXT:    sw s10, 56(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s10, 64(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli a2, t0, 31
 ; RV32I-NEXT:    slli a6, a7, 30
 ; RV32I-NEXT:    and a6, s10, a6
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    slli a7, a7, 31
 ; RV32I-NEXT:    addi t0, a2, -1
-; RV32I-NEXT:    sw t0, 52(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 60(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a2, a3, a6
 ; RV32I-NEXT:    and a3, t0, a7
 ; RV32I-NEXT:    xor a2, a2, a3
@@ -34354,7 +34354,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    addi a6, a6, -1
 ; RV32I-NEXT:    slli a7, a4, 1
-; RV32I-NEXT:    sw a7, 48(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 56(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a3, a7
 ; RV32I-NEXT:    and a6, a6, a4
 ; RV32I-NEXT:    xor t0, a0, a2
@@ -34366,9 +34366,9 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    addi a2, a2, -1
 ; RV32I-NEXT:    addi a3, a3, -1
 ; RV32I-NEXT:    slli a6, a4, 2
-; RV32I-NEXT:    sw a6, 44(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 52(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a7, a4, 3
-; RV32I-NEXT:    sw a7, 40(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 48(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a6
 ; RV32I-NEXT:    and a3, a3, a7
 ; RV32I-NEXT:    xor a2, a2, a3
@@ -34379,17 +34379,17 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    andi a3, s7, 32
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    slli a6, a4, 4
-; RV32I-NEXT:    sw a6, 36(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 44(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a6
 ; RV32I-NEXT:    addi a3, a3, -1
 ; RV32I-NEXT:    slli a7, a4, 5
-; RV32I-NEXT:    sw a7, 32(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 40(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a6, s7, 64
 ; RV32I-NEXT:    and a3, a3, a7
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    addi a6, a6, -1
 ; RV32I-NEXT:    slli a7, a4, 6
-; RV32I-NEXT:    sw a7, 28(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 36(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    and a3, a6, a7
 ; RV32I-NEXT:    xor a2, a2, a3
@@ -34400,24 +34400,24 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    andi a3, s7, 256
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    slli a6, a4, 7
-; RV32I-NEXT:    sw a6, 24(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 32(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a6
 ; RV32I-NEXT:    addi a3, a3, -1
 ; RV32I-NEXT:    slli a7, a4, 8
-; RV32I-NEXT:    sw a7, 20(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 28(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a6, s7, 512
 ; RV32I-NEXT:    and a3, a3, a7
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    addi a6, a6, -1
 ; RV32I-NEXT:    slli a7, a4, 9
-; RV32I-NEXT:    sw a7, 16(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 24(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a3, s7, 1024
 ; RV32I-NEXT:    and a6, a6, a7
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    addi a3, a3, -1
 ; RV32I-NEXT:    slli a7, a4, 10
-; RV32I-NEXT:    sw a7, 12(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 20(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a2, a2, a6
 ; RV32I-NEXT:    and a3, a3, a7
 ; RV32I-NEXT:    xor a2, a2, a3
@@ -34428,12 +34428,12 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    and a3, s7, s8
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    slli a6, a4, 11
-; RV32I-NEXT:    sw a6, 8(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 16(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a6
 ; RV32I-NEXT:    addi a3, a3, -1
 ; RV32I-NEXT:    and a6, s7, s6
 ; RV32I-NEXT:    slli a7, a4, 12
-; RV32I-NEXT:    sw a7, 4(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 12(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a3, a7
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    xor a2, a2, a3
@@ -34504,7 +34504,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    xor a0, a0, a3
 ; RV32I-NEXT:    addi a6, a6, -1
-; RV32I-NEXT:    lw s0, 204(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s0, 212(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a6, s0
 ; RV32I-NEXT:    and a6, s7, t4
 ; RV32I-NEXT:    xor a0, a0, a3
@@ -34553,45 +34553,49 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    xor a1, a2, a1
 ; RV32I-NEXT:    xor a0, a0, a6
 ; RV32I-NEXT:    xor a0, a1, a0
-; RV32I-NEXT:    lw a1, 124(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 132(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    slli a1, a1, 1
-; RV32I-NEXT:    lw a2, 140(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 148(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or a1, a2, a1
 ; RV32I-NEXT:    xor a0, a0, t0
-; RV32I-NEXT:    lw a2, 436(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 440(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli a2, a2, 1
 ; RV32I-NEXT:    srli a1, a1, 1
-; RV32I-NEXT:    lw a6, 148(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 156(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    xor a6, a2, a6
 ; RV32I-NEXT:    xor t0, a1, a0
-; RV32I-NEXT:    lw a0, 444(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 312(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 448(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 316(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a0, a0, a1
-; RV32I-NEXT:    lw a1, 440(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 444(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, a5
-; RV32I-NEXT:    lw a2, 432(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 308(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 436(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 312(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a2, a5
-; RV32I-NEXT:    lw a2, 428(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s7, 304(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 432(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 308(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a2, s7
 ; RV32I-NEXT:    xor a0, a1, a0
 ; RV32I-NEXT:    xor a1, a5, s7
-; RV32I-NEXT:    lw a2, 424(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 300(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 428(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 304(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a2, a5
+; RV32I-NEXT:    lw a2, 424(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 300(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s7, a2, s7
+; RV32I-NEXT:    xor a5, a5, s7
 ; RV32I-NEXT:    lw a2, 420(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw s7, 296(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a2, s7
-; RV32I-NEXT:    xor a5, a5, s7
-; RV32I-NEXT:    lw a2, 416(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s7, 292(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s7, a2, s7
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a1, a5, s7
-; RV32I-NEXT:    lw a2, 412(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 288(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 416(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 292(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a2, a5
+; RV32I-NEXT:    lw a2, 412(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 288(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s7, a2, s7
+; RV32I-NEXT:    xor a5, a5, s7
 ; RV32I-NEXT:    lw a2, 408(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw s7, 284(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a2, s7
@@ -34599,15 +34603,15 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    lw a2, 404(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw s7, 280(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a2, s7
-; RV32I-NEXT:    xor a5, a5, s7
-; RV32I-NEXT:    lw a2, 400(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s7, 276(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s7, a2, s7
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a1, a5, s7
-; RV32I-NEXT:    lw a2, 396(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 272(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 400(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 276(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a2, a5
+; RV32I-NEXT:    lw a2, 396(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 272(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s7, a2, s7
+; RV32I-NEXT:    xor a5, a5, s7
 ; RV32I-NEXT:    lw a2, 392(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw s7, 268(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a2, s7
@@ -34619,15 +34623,15 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    lw a2, 384(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw s7, 260(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a2, s7
-; RV32I-NEXT:    xor a5, a5, s7
-; RV32I-NEXT:    lw a2, 380(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s7, 256(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s7, a2, s7
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a1, a5, s7
-; RV32I-NEXT:    lw a2, 376(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 252(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 380(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 256(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a2, a5
+; RV32I-NEXT:    lw a2, 376(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 252(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s7, a2, s7
+; RV32I-NEXT:    xor a5, a5, s7
 ; RV32I-NEXT:    lw a2, 372(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw s7, 248(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a2, s7
@@ -34643,22 +34647,22 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    lw a2, 360(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw s7, 236(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a2, s7
-; RV32I-NEXT:    xor a5, a5, s7
-; RV32I-NEXT:    lw a2, 356(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s7, 232(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s7, a2, s7
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a1, a5, s7
-; RV32I-NEXT:    lw a2, 352(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 228(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 356(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 232(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a2, a5
-; RV32I-NEXT:    lw a2, 348(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s7, 224(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 352(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 228(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a2, s7
 ; RV32I-NEXT:    xor a5, a5, s7
-; RV32I-NEXT:    lw a2, 456(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s7, 344(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 348(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, a2
+; RV32I-NEXT:    xor a5, a5, s7
+; RV32I-NEXT:    lw a2, 344(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 224(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s7, a2, s7
 ; RV32I-NEXT:    xor a5, a5, s7
 ; RV32I-NEXT:    lw a2, 340(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw s7, 220(sp) # 4-byte Folded Reload
@@ -34671,138 +34675,134 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32I-NEXT:    lw a2, 332(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw s7, 208(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a2, s7
-; RV32I-NEXT:    xor a5, a5, s7
-; RV32I-NEXT:    lw a2, 328(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s7, 200(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s7, a2, s7
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a5, a5, s7
-; RV32I-NEXT:    lw a1, 324(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a2, 196(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 328(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 204(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, a2
-; RV32I-NEXT:    lw a2, 320(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s7, 192(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 324(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 200(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a2, s7
 ; RV32I-NEXT:    xor a1, a1, s7
-; RV32I-NEXT:    lw a2, 316(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s7, 188(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 320(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 196(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a2, s7
 ; RV32I-NEXT:    xor a5, a0, a5
 ; RV32I-NEXT:    xor a2, a1, s7
-; RV32I-NEXT:    lw a0, 212(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 48(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 56(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a0, a1
-; RV32I-NEXT:    lw a0, 184(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 192(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a0, a4
-; RV32I-NEXT:    lw a0, 180(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s7, 44(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 188(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 52(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, a0, s7
-; RV32I-NEXT:    lw a0, 176(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw ra, 40(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 184(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 48(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a0, a0, ra
 ; RV32I-NEXT:    xor a1, a4, a1
 ; RV32I-NEXT:    xor a0, s7, a0
-; RV32I-NEXT:    lw a4, 172(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s7, 36(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 180(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 44(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, s7
-; RV32I-NEXT:    lw s7, 168(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw ra, 32(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 176(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 40(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, ra
 ; RV32I-NEXT:    xor a4, a4, s7
-; RV32I-NEXT:    lw s7, 164(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 172(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 36(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, ra
 ; RV32I-NEXT:    xor a0, a1, a0
 ; RV32I-NEXT:    xor a1, a4, s7
-; RV32I-NEXT:    lw a4, 160(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s7, 24(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 168(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 32(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, s7
-; RV32I-NEXT:    lw s7, 156(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw ra, 20(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 164(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s7, s7, ra
+; RV32I-NEXT:    xor a4, a4, s7
+; RV32I-NEXT:    lw s7, 160(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 24(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, ra
 ; RV32I-NEXT:    xor a4, a4, s7
 ; RV32I-NEXT:    lw s7, 152(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw ra, 16(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s7, s7, ra
-; RV32I-NEXT:    xor a4, a4, s7
-; RV32I-NEXT:    lw s7, 144(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 20(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, ra
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a1, a4, s7
-; RV32I-NEXT:    lw a4, 136(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s7, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 144(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 16(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, s7
-; RV32I-NEXT:    lw s7, 132(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw ra, 4(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 140(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, ra
 ; RV32I-NEXT:    xor a4, a4, s7
-; RV32I-NEXT:    lw s7, 128(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 136(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, s11
 ; RV32I-NEXT:    xor a4, a4, s7
-; RV32I-NEXT:    lw s7, 120(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 128(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, s10
 ; RV32I-NEXT:    xor a4, a4, s7
-; RV32I-NEXT:    lw s7, 116(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 124(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, s9
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a1, a4, s7
-; RV32I-NEXT:    lw a4, 112(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 120(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, s8
-; RV32I-NEXT:    lw s7, 108(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 116(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s5, s7, s5
 ; RV32I-NEXT:    xor a4, a4, s5
-; RV32I-NEXT:    lw s5, 104(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s5, 112(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s5, s4
 ; RV32I-NEXT:    xor a4, a4, s4
-; RV32I-NEXT:    lw s4, 100(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s4, 108(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s3, s4, s3
 ; RV32I-NEXT:    xor a4, a4, s3
-; RV32I-NEXT:    lw s3, 96(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s3, 104(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s2, s3, s2
 ; RV32I-NEXT:    xor a4, a4, s2
-; RV32I-NEXT:    lw s2, 92(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s2, 100(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s1, s2, s1
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a4, a4, s1
-; RV32I-NEXT:    lw a1, 88(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 96(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, s6
-; RV32I-NEXT:    lw s1, 84(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s1, 92(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t6, s1, t6
 ; RV32I-NEXT:    xor a1, a1, t6
-; RV32I-NEXT:    lw t6, 80(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t6, 88(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t6, t6, s0
 ; RV32I-NEXT:    xor a1, a1, t6
-; RV32I-NEXT:    lw t6, 76(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t6, 84(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t5, t6, t5
 ; RV32I-NEXT:    xor a1, a1, t5
-; RV32I-NEXT:    lw t5, 72(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t5, 80(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t4, t5, t4
 ; RV32I-NEXT:    xor a1, a1, t4
-; RV32I-NEXT:    lw t4, 68(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t4, 76(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t3, t4, t3
 ; RV32I-NEXT:    xor a1, a1, t3
-; RV32I-NEXT:    lw t3, 64(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 72(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t2, t3, t2
 ; RV32I-NEXT:    xor a0, a0, a4
 ; RV32I-NEXT:    xor a1, a1, t2
-; RV32I-NEXT:    lw a4, 60(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 68(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, t1
-; RV32I-NEXT:    lw t1, 56(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 64(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a7, t1, a7
 ; RV32I-NEXT:    xor a4, a4, a7
-; RV32I-NEXT:    lw a7, 52(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 60(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a7, a3
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a3, a4, a3
 ; RV32I-NEXT:    xor a2, a5, a2
 ; RV32I-NEXT:    xor a0, a0, a3
-; RV32I-NEXT:    lw a1, 448(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 452(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    sw a2, 0(a1)
 ; RV32I-NEXT:    sw a6, 4(a1)
 ; RV32I-NEXT:    sw a0, 8(a1)
 ; RV32I-NEXT:    sw t0, 12(a1)
-; RV32I-NEXT:    lw a1, 452(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 456(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    sw a2, 0(a1)
 ; RV32I-NEXT:    sw a6, 4(a1)
 ; RV32I-NEXT:    sw a0, 8(a1)
@@ -35742,24 +35742,24 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    sw s9, 132(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    sw s10, 128(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    sw s11, 124(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    sw a3, 96(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    sw a2, 92(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a3, 120(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a2, 116(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    lw a2, 0(a1)
 ; RV32IM-NEXT:    lui a3, 16
 ; RV32IM-NEXT:    lw a4, 4(a1)
-; RV32IM-NEXT:    sw a4, 108(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a4, 16(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    lw a4, 8(a1)
-; RV32IM-NEXT:    sw a4, 116(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a4, 12(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    lw a1, 12(a1)
-; RV32IM-NEXT:    sw a1, 88(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 112(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    addi s2, a3, -256
 ; RV32IM-NEXT:    srli a1, a2, 8
 ; RV32IM-NEXT:    lw s4, 0(a0)
 ; RV32IM-NEXT:    lw s8, 4(a0)
 ; RV32IM-NEXT:    lw a3, 8(a0)
-; RV32IM-NEXT:    sw a3, 120(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a3, 24(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    lw a0, 12(a0)
-; RV32IM-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a1, a1, s2
 ; RV32IM-NEXT:    srli a0, a2, 24
 ; RV32IM-NEXT:    and a3, a2, s2
@@ -35811,7 +35811,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    or a1, a0, a1
 ; RV32IM-NEXT:    addi s3, a3, 273
 ; RV32IM-NEXT:    srli a3, a1, 1
-; RV32IM-NEXT:    sw a7, 112(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 20(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a3, a3, a7
 ; RV32IM-NEXT:    and a1, a1, a7
 ; RV32IM-NEXT:    slli a1, a1, 1
@@ -35890,7 +35890,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    mul s8, a6, t3
 ; RV32IM-NEXT:    mul s9, a7, t6
 ; RV32IM-NEXT:    mul s10, a2, a1
-; RV32IM-NEXT:    sw a1, 72(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 100(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a0, a0, a3
 ; RV32IM-NEXT:    srli a3, a0, 4
 ; RV32IM-NEXT:    and a0, a0, s0
@@ -35905,12 +35905,12 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    xor a3, a3, a5
 ; RV32IM-NEXT:    xor a5, t0, t1
 ; RV32IM-NEXT:    mul t0, a4, a1
-; RV32IM-NEXT:    sw t6, 80(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t6, 108(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul a4, a4, t6
 ; RV32IM-NEXT:    mul t1, a6, t6
-; RV32IM-NEXT:    sw t4, 76(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t4, 104(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul a6, a6, t4
-; RV32IM-NEXT:    sw t3, 68(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t3, 96(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul t2, a7, t3
 ; RV32IM-NEXT:    mul s6, a2, t4
 ; RV32IM-NEXT:    mul a7, a7, a1
@@ -35932,21 +35932,21 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    xor a2, a4, a2
 ; RV32IM-NEXT:    and a3, a0, s5
 ; RV32IM-NEXT:    and a6, a2, ra
-; RV32IM-NEXT:    lw a0, 108(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and t6, a0, s3
-; RV32IM-NEXT:    sw t6, 44(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t6, 28(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and s0, a0, s7
 ; RV32IM-NEXT:    and a4, a0, ra
-; RV32IM-NEXT:    sw a4, 48(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a4, 32(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and s1, a0, s5
-; RV32IM-NEXT:    sw s1, 40(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s1, 84(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and t4, s4, s7
 ; RV32IM-NEXT:    and a1, s4, s3
-; RV32IM-NEXT:    sw a1, 108(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a0, s4, s5
-; RV32IM-NEXT:    sw a0, 104(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a5, s4, ra
-; RV32IM-NEXT:    sw a5, 100(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a5, 48(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul a7, t4, t6
 ; RV32IM-NEXT:    mul t0, a1, s0
 ; RV32IM-NEXT:    mul t1, a0, a4
@@ -35959,24 +35959,24 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    or a3, a3, a6
 ; RV32IM-NEXT:    lui a0, 349525
 ; RV32IM-NEXT:    addi a6, a0, 1364
-; RV32IM-NEXT:    sw a6, 60(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 40(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srli a0, s8, 1
-; RV32IM-NEXT:    lw a5, 112(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 20(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s8, s8, a5
 ; RV32IM-NEXT:    and a0, a0, a6
 ; RV32IM-NEXT:    slli s8, s8, 1
 ; RV32IM-NEXT:    or a0, a0, s8
-; RV32IM-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 92(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a0, t3, a3
-; RV32IM-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a0, t0, a7
 ; RV32IM-NEXT:    xor a3, t1, t2
 ; RV32IM-NEXT:    xor a4, a4, s10
 ; RV32IM-NEXT:    xor a1, a2, a1
 ; RV32IM-NEXT:    xor a0, a0, a3
-; RV32IM-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor s8, a4, a1
-; RV32IM-NEXT:    lw a7, 116(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a7, 12(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a1, a7, 8
 ; RV32IM-NEXT:    and a2, a7, s2
 ; RV32IM-NEXT:    and a1, a1, s2
@@ -35985,9 +35985,9 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    slli a7, a7, 24
 ; RV32IM-NEXT:    or a1, a1, a4
 ; RV32IM-NEXT:    or a2, a7, a2
-; RV32IM-NEXT:    lw t1, 120(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t1, 24(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a4, t1, 8
-; RV32IM-NEXT:    sw s2, 32(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s2, 76(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a7, t1, s2
 ; RV32IM-NEXT:    and a4, a4, s2
 ; RV32IM-NEXT:    slli a7, a7, 8
@@ -35998,7 +35998,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    or a1, a2, a1
 ; RV32IM-NEXT:    or a2, a7, a4
 ; RV32IM-NEXT:    srli a4, a1, 4
-; RV32IM-NEXT:    sw s11, 28(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s11, 72(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a1, a1, s11
 ; RV32IM-NEXT:    and a4, a4, s11
 ; RV32IM-NEXT:    slli a1, a1, 4
@@ -36009,7 +36009,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    or a1, a4, a1
 ; RV32IM-NEXT:    or a2, a7, a2
 ; RV32IM-NEXT:    srli a4, a1, 2
-; RV32IM-NEXT:    sw t5, 24(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t5, 68(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a1, a1, t5
 ; RV32IM-NEXT:    and a4, a4, t5
 ; RV32IM-NEXT:    slli a1, a1, 2
@@ -36047,10 +36047,10 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    mul s0, a2, a1
 ; RV32IM-NEXT:    mul s2, t3, a1
 ; RV32IM-NEXT:    mul s3, t2, a1
-; RV32IM-NEXT:    sw t4, 52(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t4, 88(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul t6, t4, s1
-; RV32IM-NEXT:    lw a1, 108(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a5, 40(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 84(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t1, a1, a5
 ; RV32IM-NEXT:    mul a6, t2, a7
 ; RV32IM-NEXT:    mul a3, t3, t0
@@ -36061,7 +36061,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    mul t2, t2, t0
 ; RV32IM-NEXT:    mul t0, a2, t0
 ; RV32IM-NEXT:    mul a4, a2, a4
-; RV32IM-NEXT:    lw a2, 36(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a2, 80(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a2, a2, s7
 ; RV32IM-NEXT:    and s8, s8, s9
 ; RV32IM-NEXT:    or a2, s8, a2
@@ -36076,11 +36076,11 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    xor a6, t3, t0
 ; RV32IM-NEXT:    xor t0, t2, s4
 ; RV32IM-NEXT:    xor a4, a7, a4
-; RV32IM-NEXT:    lw t2, 104(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s0, 44(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t2, 52(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s0, 28(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a7, t2, s0
-; RV32IM-NEXT:    lw t3, 100(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw t6, 48(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t3, 48(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t6, 32(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t1, t3, t6
 ; RV32IM-NEXT:    xor a3, a3, a6
 ; RV32IM-NEXT:    xor a4, t0, a4
@@ -36099,7 +36099,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    xor a1, s8, a1
 ; RV32IM-NEXT:    srli a5, a0, 8
 ; RV32IM-NEXT:    xor a6, t0, a6
-; RV32IM-NEXT:    lw a7, 32(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a7, 76(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a5, a5, a7
 ; RV32IM-NEXT:    and a7, a0, a7
 ; RV32IM-NEXT:    srli t0, a0, 24
@@ -36111,7 +36111,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    or a0, a0, a5
 ; RV32IM-NEXT:    xor a3, a6, a3
 ; RV32IM-NEXT:    srli a4, a0, 4
-; RV32IM-NEXT:    lw a5, 28(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 72(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, a5
 ; RV32IM-NEXT:    and a0, a0, a5
 ; RV32IM-NEXT:    and a1, a1, ra
@@ -36119,7 +36119,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    and a3, a3, s11
 ; RV32IM-NEXT:    or a0, a4, a0
 ; RV32IM-NEXT:    srli a4, a0, 2
-; RV32IM-NEXT:    lw a5, 24(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 68(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a0, a0, a5
 ; RV32IM-NEXT:    and a4, a4, a5
 ; RV32IM-NEXT:    slli a0, a0, 2
@@ -36127,15 +36127,15 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    or a4, a4, a0
 ; RV32IM-NEXT:    or a1, a2, a1
 ; RV32IM-NEXT:    srli a0, a4, 1
-; RV32IM-NEXT:    lw a2, 56(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a2, 36(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    xor a1, a1, a2
-; RV32IM-NEXT:    sw a1, 56(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    lw a1, 60(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    sw a1, 36(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    lw a1, 40(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a0, a0, a1
-; RV32IM-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    lw a3, 116(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    lw a3, 12(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a6, a3, s9
-; RV32IM-NEXT:    lw a5, 84(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 44(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mv s5, s7
 ; RV32IM-NEXT:    and a1, a5, s7
 ; RV32IM-NEXT:    and t0, a3, s7
@@ -36154,11 +36154,11 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    mul t3, a5, s0
 ; RV32IM-NEXT:    mul t4, a1, s3
 ; RV32IM-NEXT:    mul t5, a2, s7
-; RV32IM-NEXT:    sw s7, 44(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s7, 28(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul t6, a3, s0
 ; RV32IM-NEXT:    mul s6, a5, t0
 ; RV32IM-NEXT:    mul s8, a1, t0
-; RV32IM-NEXT:    sw t0, 48(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t0, 32(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul s9, a2, s0
 ; RV32IM-NEXT:    mul s10, a3, s7
 ; RV32IM-NEXT:    mul s11, a5, s3
@@ -36168,7 +36168,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    mul a5, a5, s7
 ; RV32IM-NEXT:    xor a6, t1, a6
 ; RV32IM-NEXT:    xor t1, t2, t3
-; RV32IM-NEXT:    lw t0, 112(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t0, 20(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, t0
 ; RV32IM-NEXT:    xor a6, a6, t1
 ; RV32IM-NEXT:    xor t1, t5, t4
@@ -36181,28 +36181,28 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    xor a3, a3, a5
 ; RV32IM-NEXT:    xor a1, a1, a3
 ; RV32IM-NEXT:    slli a4, a4, 1
-; RV32IM-NEXT:    sw a4, 116(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a4, 12(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a2, a6, s5
 ; RV32IM-NEXT:    mv a5, a0
 ; RV32IM-NEXT:    and a3, t1, a0
 ; RV32IM-NEXT:    and a4, t2, ra
 ; RV32IM-NEXT:    and a1, a1, s1
 ; RV32IM-NEXT:    or a2, a3, a2
-; RV32IM-NEXT:    sw a2, 112(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a2, 20(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a1, a4, a1
-; RV32IM-NEXT:    sw a1, 84(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    sw a1, 44(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    lw a0, 112(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a0, a5
-; RV32IM-NEXT:    sw a5, 16(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a5, 60(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a6, a0, s5
 ; RV32IM-NEXT:    and t3, a0, s1
 ; RV32IM-NEXT:    and t4, a0, ra
-; RV32IM-NEXT:    lw a0, 120(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and t2, a0, s5
 ; RV32IM-NEXT:    and t1, a0, a5
 ; RV32IM-NEXT:    and a2, a0, ra
 ; RV32IM-NEXT:    and a3, a0, s1
-; RV32IM-NEXT:    sw s1, 20(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s1, 64(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul s7, a3, t4
 ; RV32IM-NEXT:    mul t6, a2, t4
 ; RV32IM-NEXT:    mul s6, t1, t4
@@ -36219,11 +36219,11 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    mul a7, a2, a4
 ; RV32IM-NEXT:    mul a6, a2, a6
 ; RV32IM-NEXT:    mul a4, a3, a4
-; RV32IM-NEXT:    lw t4, 60(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s9, 116(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t4, 40(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s9, 12(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    or t4, t4, s9
-; RV32IM-NEXT:    lw s9, 112(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s4, 84(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s9, 20(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s4, 44(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    or s9, s9, s4
 ; RV32IM-NEXT:    xor s8, s10, s8
 ; RV32IM-NEXT:    xor s4, s11, s7
@@ -36238,34 +36238,34 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    xor a1, a1, a5
 ; RV32IM-NEXT:    xor a4, a7, a4
 ; RV32IM-NEXT:    and a5, t6, s5
-; RV32IM-NEXT:    sw s5, 12(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    lw t0, 16(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    sw s5, 56(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    lw t0, 60(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a0, a0, t0
 ; RV32IM-NEXT:    and a1, a1, s2
 ; RV32IM-NEXT:    and a4, a4, s1
 ; RV32IM-NEXT:    or a0, a0, a5
 ; RV32IM-NEXT:    or a1, a1, a4
-; RV32IM-NEXT:    lw a4, 64(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 92(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a4, a4, 1
 ; RV32IM-NEXT:    or a0, a0, a1
 ; RV32IM-NEXT:    srli a1, t4, 1
 ; RV32IM-NEXT:    xor a5, a0, s9
-; RV32IM-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    xor a0, a4, a0
-; RV32IM-NEXT:    sw a0, 116(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a1, a1, a5
-; RV32IM-NEXT:    sw a1, 120(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    lw ra, 68(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s10, 52(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    lw ra, 96(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 88(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul s1, s10, ra
-; RV32IM-NEXT:    lw s11, 72(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s8, 108(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s11, 100(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s8, 16(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a1, s8, s11
-; RV32IM-NEXT:    lw s9, 76(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw t6, 104(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s9, 104(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t6, 52(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a4, t6, s9
-; RV32IM-NEXT:    lw s6, 80(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a0, 100(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s6, 108(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a7, a0, s6
 ; RV32IM-NEXT:    mul a5, s10, s9
 ; RV32IM-NEXT:    mul t3, s8, ra
@@ -36296,13 +36296,13 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    xor a7, t0, t3
 ; RV32IM-NEXT:    mv a6, s2
 ; RV32IM-NEXT:    and a5, a5, s2
-; RV32IM-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a7, a7, a0
 ; RV32IM-NEXT:    or a1, a4, a1
 ; RV32IM-NEXT:    or a4, a5, a7
-; RV32IM-NEXT:    lw s7, 44(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s7, 28(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a5, t2, s7
-; RV32IM-NEXT:    lw s1, 48(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s1, 32(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a7, t1, s1
 ; RV32IM-NEXT:    mul t0, a2, s3
 ; RV32IM-NEXT:    mul t3, a3, s0
@@ -36324,7 +36324,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    xor t3, t6, s4
 ; RV32IM-NEXT:    xor a5, a5, a7
 ; RV32IM-NEXT:    xor a7, t0, t3
-; RV32IM-NEXT:    lw t0, 12(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t0, 56(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a5, a5, t0
 ; RV32IM-NEXT:    and a7, a7, s5
 ; RV32IM-NEXT:    xor t0, s8, s6
@@ -36339,14 +36339,14 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IM-NEXT:    or a2, a3, a2
 ; RV32IM-NEXT:    or a1, a1, a4
 ; RV32IM-NEXT:    or a2, a5, a2
-; RV32IM-NEXT:    lw a3, 92(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 116(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    sw a1, 0(a3)
-; RV32IM-NEXT:    lw a4, 116(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 12(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    sw a4, 4(a3)
 ; RV32IM-NEXT:    sw a2, 8(a3)
-; RV32IM-NEXT:    lw a0, 120(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    sw a0, 12(a3)
-; RV32IM-NEXT:    lw a3, 96(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 120(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    sw a1, 0(a3)
 ; RV32IM-NEXT:    sw a4, 4(a3)
 ; RV32IM-NEXT:    sw a2, 8(a3)
@@ -36511,24 +36511,24 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    sw s9, 132(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    sw s10, 128(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    sw s11, 124(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    sw a3, 96(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    sw a2, 92(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a3, 120(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a2, 116(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    lw a2, 0(a1)
 ; RV32IMZBS-NEXT:    lui a3, 16
 ; RV32IMZBS-NEXT:    lw a4, 4(a1)
-; RV32IMZBS-NEXT:    sw a4, 108(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a4, 16(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    lw a4, 8(a1)
-; RV32IMZBS-NEXT:    sw a4, 116(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a4, 12(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    lw a1, 12(a1)
-; RV32IMZBS-NEXT:    sw a1, 88(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 112(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    addi s2, a3, -256
 ; RV32IMZBS-NEXT:    srli a1, a2, 8
 ; RV32IMZBS-NEXT:    lw s4, 0(a0)
 ; RV32IMZBS-NEXT:    lw s8, 4(a0)
 ; RV32IMZBS-NEXT:    lw a3, 8(a0)
-; RV32IMZBS-NEXT:    sw a3, 120(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a3, 24(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    lw a0, 12(a0)
-; RV32IMZBS-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a1, a1, s2
 ; RV32IMZBS-NEXT:    srli a0, a2, 24
 ; RV32IMZBS-NEXT:    and a3, a2, s2
@@ -36580,7 +36580,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    or a1, a0, a1
 ; RV32IMZBS-NEXT:    addi s3, a3, 273
 ; RV32IMZBS-NEXT:    srli a3, a1, 1
-; RV32IMZBS-NEXT:    sw a7, 112(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 20(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a3, a3, a7
 ; RV32IMZBS-NEXT:    and a1, a1, a7
 ; RV32IMZBS-NEXT:    slli a1, a1, 1
@@ -36659,7 +36659,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    mul s8, a6, t3
 ; RV32IMZBS-NEXT:    mul s9, a7, t6
 ; RV32IMZBS-NEXT:    mul s10, a2, a1
-; RV32IMZBS-NEXT:    sw a1, 72(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 100(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a0, a0, a3
 ; RV32IMZBS-NEXT:    srli a3, a0, 4
 ; RV32IMZBS-NEXT:    and a0, a0, s0
@@ -36674,12 +36674,12 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    xor a3, a3, a5
 ; RV32IMZBS-NEXT:    xor a5, t0, t1
 ; RV32IMZBS-NEXT:    mul t0, a4, a1
-; RV32IMZBS-NEXT:    sw t6, 80(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t6, 108(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul a4, a4, t6
 ; RV32IMZBS-NEXT:    mul t1, a6, t6
-; RV32IMZBS-NEXT:    sw t4, 76(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t4, 104(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul a6, a6, t4
-; RV32IMZBS-NEXT:    sw t3, 68(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t3, 96(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul t2, a7, t3
 ; RV32IMZBS-NEXT:    mul s6, a2, t4
 ; RV32IMZBS-NEXT:    mul a7, a7, a1
@@ -36701,21 +36701,21 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    xor a2, a4, a2
 ; RV32IMZBS-NEXT:    and a3, a0, s5
 ; RV32IMZBS-NEXT:    and a6, a2, ra
-; RV32IMZBS-NEXT:    lw a0, 108(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and t6, a0, s3
-; RV32IMZBS-NEXT:    sw t6, 44(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t6, 28(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and s0, a0, s7
 ; RV32IMZBS-NEXT:    and a4, a0, ra
-; RV32IMZBS-NEXT:    sw a4, 48(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a4, 32(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and s1, a0, s5
-; RV32IMZBS-NEXT:    sw s1, 40(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s1, 84(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and t4, s4, s7
 ; RV32IMZBS-NEXT:    and a1, s4, s3
-; RV32IMZBS-NEXT:    sw a1, 108(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a0, s4, s5
-; RV32IMZBS-NEXT:    sw a0, 104(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a5, s4, ra
-; RV32IMZBS-NEXT:    sw a5, 100(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a5, 48(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul a7, t4, t6
 ; RV32IMZBS-NEXT:    mul t0, a1, s0
 ; RV32IMZBS-NEXT:    mul t1, a0, a4
@@ -36728,24 +36728,24 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    or a3, a3, a6
 ; RV32IMZBS-NEXT:    lui a0, 349525
 ; RV32IMZBS-NEXT:    addi a6, a0, 1364
-; RV32IMZBS-NEXT:    sw a6, 60(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 40(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srli a0, s8, 1
-; RV32IMZBS-NEXT:    lw a5, 112(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 20(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s8, s8, a5
 ; RV32IMZBS-NEXT:    and a0, a0, a6
 ; RV32IMZBS-NEXT:    slli s8, s8, 1
 ; RV32IMZBS-NEXT:    or a0, a0, s8
-; RV32IMZBS-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 92(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a0, t3, a3
-; RV32IMZBS-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a0, t0, a7
 ; RV32IMZBS-NEXT:    xor a3, t1, t2
 ; RV32IMZBS-NEXT:    xor a4, a4, s10
 ; RV32IMZBS-NEXT:    xor a1, a2, a1
 ; RV32IMZBS-NEXT:    xor a0, a0, a3
-; RV32IMZBS-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor s8, a4, a1
-; RV32IMZBS-NEXT:    lw a7, 116(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a7, 12(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a1, a7, 8
 ; RV32IMZBS-NEXT:    and a2, a7, s2
 ; RV32IMZBS-NEXT:    and a1, a1, s2
@@ -36754,9 +36754,9 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    slli a7, a7, 24
 ; RV32IMZBS-NEXT:    or a1, a1, a4
 ; RV32IMZBS-NEXT:    or a2, a7, a2
-; RV32IMZBS-NEXT:    lw t1, 120(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t1, 24(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a4, t1, 8
-; RV32IMZBS-NEXT:    sw s2, 32(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s2, 76(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a7, t1, s2
 ; RV32IMZBS-NEXT:    and a4, a4, s2
 ; RV32IMZBS-NEXT:    slli a7, a7, 8
@@ -36767,7 +36767,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    or a1, a2, a1
 ; RV32IMZBS-NEXT:    or a2, a7, a4
 ; RV32IMZBS-NEXT:    srli a4, a1, 4
-; RV32IMZBS-NEXT:    sw s11, 28(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s11, 72(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a1, a1, s11
 ; RV32IMZBS-NEXT:    and a4, a4, s11
 ; RV32IMZBS-NEXT:    slli a1, a1, 4
@@ -36778,7 +36778,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    or a1, a4, a1
 ; RV32IMZBS-NEXT:    or a2, a7, a2
 ; RV32IMZBS-NEXT:    srli a4, a1, 2
-; RV32IMZBS-NEXT:    sw t5, 24(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t5, 68(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a1, a1, t5
 ; RV32IMZBS-NEXT:    and a4, a4, t5
 ; RV32IMZBS-NEXT:    slli a1, a1, 2
@@ -36816,10 +36816,10 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    mul s0, a2, a1
 ; RV32IMZBS-NEXT:    mul s2, t3, a1
 ; RV32IMZBS-NEXT:    mul s3, t2, a1
-; RV32IMZBS-NEXT:    sw t4, 52(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t4, 88(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul t6, t4, s1
-; RV32IMZBS-NEXT:    lw a1, 108(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a5, 40(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 84(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t1, a1, a5
 ; RV32IMZBS-NEXT:    mul a6, t2, a7
 ; RV32IMZBS-NEXT:    mul a3, t3, t0
@@ -36830,7 +36830,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    mul t2, t2, t0
 ; RV32IMZBS-NEXT:    mul t0, a2, t0
 ; RV32IMZBS-NEXT:    mul a4, a2, a4
-; RV32IMZBS-NEXT:    lw a2, 36(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a2, 80(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a2, a2, s7
 ; RV32IMZBS-NEXT:    and s8, s8, s9
 ; RV32IMZBS-NEXT:    or a2, s8, a2
@@ -36845,11 +36845,11 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    xor a6, t3, t0
 ; RV32IMZBS-NEXT:    xor t0, t2, s4
 ; RV32IMZBS-NEXT:    xor a4, a7, a4
-; RV32IMZBS-NEXT:    lw t2, 104(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s0, 44(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t2, 52(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s0, 28(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a7, t2, s0
-; RV32IMZBS-NEXT:    lw t3, 100(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw t6, 48(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t3, 48(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t6, 32(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t1, t3, t6
 ; RV32IMZBS-NEXT:    xor a3, a3, a6
 ; RV32IMZBS-NEXT:    xor a4, t0, a4
@@ -36868,7 +36868,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    xor a1, s8, a1
 ; RV32IMZBS-NEXT:    srli a5, a0, 8
 ; RV32IMZBS-NEXT:    xor a6, t0, a6
-; RV32IMZBS-NEXT:    lw a7, 32(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a7, 76(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a5, a5, a7
 ; RV32IMZBS-NEXT:    and a7, a0, a7
 ; RV32IMZBS-NEXT:    srli t0, a0, 24
@@ -36880,7 +36880,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    or a0, a0, a5
 ; RV32IMZBS-NEXT:    xor a3, a6, a3
 ; RV32IMZBS-NEXT:    srli a4, a0, 4
-; RV32IMZBS-NEXT:    lw a5, 28(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 72(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, a5
 ; RV32IMZBS-NEXT:    and a0, a0, a5
 ; RV32IMZBS-NEXT:    and a1, a1, ra
@@ -36888,7 +36888,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    and a3, a3, s11
 ; RV32IMZBS-NEXT:    or a0, a4, a0
 ; RV32IMZBS-NEXT:    srli a4, a0, 2
-; RV32IMZBS-NEXT:    lw a5, 24(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 68(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a0, a0, a5
 ; RV32IMZBS-NEXT:    and a4, a4, a5
 ; RV32IMZBS-NEXT:    slli a0, a0, 2
@@ -36896,15 +36896,15 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    or a4, a4, a0
 ; RV32IMZBS-NEXT:    or a1, a2, a1
 ; RV32IMZBS-NEXT:    srli a0, a4, 1
-; RV32IMZBS-NEXT:    lw a2, 56(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a2, 36(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    xor a1, a1, a2
-; RV32IMZBS-NEXT:    sw a1, 56(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    lw a1, 60(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    sw a1, 36(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    lw a1, 40(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a0, a0, a1
-; RV32IMZBS-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    lw a3, 116(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    lw a3, 12(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a6, a3, s9
-; RV32IMZBS-NEXT:    lw a5, 84(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 44(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mv s5, s7
 ; RV32IMZBS-NEXT:    and a1, a5, s7
 ; RV32IMZBS-NEXT:    and t0, a3, s7
@@ -36923,11 +36923,11 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    mul t3, a5, s0
 ; RV32IMZBS-NEXT:    mul t4, a1, s3
 ; RV32IMZBS-NEXT:    mul t5, a2, s7
-; RV32IMZBS-NEXT:    sw s7, 44(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s7, 28(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul t6, a3, s0
 ; RV32IMZBS-NEXT:    mul s6, a5, t0
 ; RV32IMZBS-NEXT:    mul s8, a1, t0
-; RV32IMZBS-NEXT:    sw t0, 48(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t0, 32(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul s9, a2, s0
 ; RV32IMZBS-NEXT:    mul s10, a3, s7
 ; RV32IMZBS-NEXT:    mul s11, a5, s3
@@ -36937,7 +36937,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    mul a5, a5, s7
 ; RV32IMZBS-NEXT:    xor a6, t1, a6
 ; RV32IMZBS-NEXT:    xor t1, t2, t3
-; RV32IMZBS-NEXT:    lw t0, 112(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t0, 20(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, t0
 ; RV32IMZBS-NEXT:    xor a6, a6, t1
 ; RV32IMZBS-NEXT:    xor t1, t5, t4
@@ -36950,28 +36950,28 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    xor a3, a3, a5
 ; RV32IMZBS-NEXT:    xor a1, a1, a3
 ; RV32IMZBS-NEXT:    slli a4, a4, 1
-; RV32IMZBS-NEXT:    sw a4, 116(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a4, 12(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a2, a6, s5
 ; RV32IMZBS-NEXT:    mv a5, a0
 ; RV32IMZBS-NEXT:    and a3, t1, a0
 ; RV32IMZBS-NEXT:    and a4, t2, ra
 ; RV32IMZBS-NEXT:    and a1, a1, s1
 ; RV32IMZBS-NEXT:    or a2, a3, a2
-; RV32IMZBS-NEXT:    sw a2, 112(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a2, 20(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a1, a4, a1
-; RV32IMZBS-NEXT:    sw a1, 84(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    sw a1, 44(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    lw a0, 112(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a0, a5
-; RV32IMZBS-NEXT:    sw a5, 16(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a5, 60(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a6, a0, s5
 ; RV32IMZBS-NEXT:    and t3, a0, s1
 ; RV32IMZBS-NEXT:    and t4, a0, ra
-; RV32IMZBS-NEXT:    lw a0, 120(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and t2, a0, s5
 ; RV32IMZBS-NEXT:    and t1, a0, a5
 ; RV32IMZBS-NEXT:    and a2, a0, ra
 ; RV32IMZBS-NEXT:    and a3, a0, s1
-; RV32IMZBS-NEXT:    sw s1, 20(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s1, 64(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul s7, a3, t4
 ; RV32IMZBS-NEXT:    mul t6, a2, t4
 ; RV32IMZBS-NEXT:    mul s6, t1, t4
@@ -36988,11 +36988,11 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    mul a7, a2, a4
 ; RV32IMZBS-NEXT:    mul a6, a2, a6
 ; RV32IMZBS-NEXT:    mul a4, a3, a4
-; RV32IMZBS-NEXT:    lw t4, 60(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s9, 116(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t4, 40(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s9, 12(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    or t4, t4, s9
-; RV32IMZBS-NEXT:    lw s9, 112(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s4, 84(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s9, 20(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s4, 44(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    or s9, s9, s4
 ; RV32IMZBS-NEXT:    xor s8, s10, s8
 ; RV32IMZBS-NEXT:    xor s4, s11, s7
@@ -37007,34 +37007,34 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    xor a1, a1, a5
 ; RV32IMZBS-NEXT:    xor a4, a7, a4
 ; RV32IMZBS-NEXT:    and a5, t6, s5
-; RV32IMZBS-NEXT:    sw s5, 12(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    lw t0, 16(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    sw s5, 56(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    lw t0, 60(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a0, a0, t0
 ; RV32IMZBS-NEXT:    and a1, a1, s2
 ; RV32IMZBS-NEXT:    and a4, a4, s1
 ; RV32IMZBS-NEXT:    or a0, a0, a5
 ; RV32IMZBS-NEXT:    or a1, a1, a4
-; RV32IMZBS-NEXT:    lw a4, 64(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 92(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a4, a4, 1
 ; RV32IMZBS-NEXT:    or a0, a0, a1
 ; RV32IMZBS-NEXT:    srli a1, t4, 1
 ; RV32IMZBS-NEXT:    xor a5, a0, s9
-; RV32IMZBS-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    xor a0, a4, a0
-; RV32IMZBS-NEXT:    sw a0, 116(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a1, a1, a5
-; RV32IMZBS-NEXT:    sw a1, 120(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    lw ra, 68(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s10, 52(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    lw ra, 96(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 88(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul s1, s10, ra
-; RV32IMZBS-NEXT:    lw s11, 72(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s8, 108(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s11, 100(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s8, 16(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a1, s8, s11
-; RV32IMZBS-NEXT:    lw s9, 76(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw t6, 104(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s9, 104(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t6, 52(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a4, t6, s9
-; RV32IMZBS-NEXT:    lw s6, 80(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a0, 100(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s6, 108(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a7, a0, s6
 ; RV32IMZBS-NEXT:    mul a5, s10, s9
 ; RV32IMZBS-NEXT:    mul t3, s8, ra
@@ -37065,13 +37065,13 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    xor a7, t0, t3
 ; RV32IMZBS-NEXT:    mv a6, s2
 ; RV32IMZBS-NEXT:    and a5, a5, s2
-; RV32IMZBS-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a7, a7, a0
 ; RV32IMZBS-NEXT:    or a1, a4, a1
 ; RV32IMZBS-NEXT:    or a4, a5, a7
-; RV32IMZBS-NEXT:    lw s7, 44(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s7, 28(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a5, t2, s7
-; RV32IMZBS-NEXT:    lw s1, 48(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s1, 32(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a7, t1, s1
 ; RV32IMZBS-NEXT:    mul t0, a2, s3
 ; RV32IMZBS-NEXT:    mul t3, a3, s0
@@ -37093,7 +37093,7 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    xor t3, t6, s4
 ; RV32IMZBS-NEXT:    xor a5, a5, a7
 ; RV32IMZBS-NEXT:    xor a7, t0, t3
-; RV32IMZBS-NEXT:    lw t0, 12(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t0, 56(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a5, a5, t0
 ; RV32IMZBS-NEXT:    and a7, a7, s5
 ; RV32IMZBS-NEXT:    xor t0, s8, s6
@@ -37108,14 +37108,14 @@ define void @commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %p
 ; RV32IMZBS-NEXT:    or a2, a3, a2
 ; RV32IMZBS-NEXT:    or a1, a1, a4
 ; RV32IMZBS-NEXT:    or a2, a5, a2
-; RV32IMZBS-NEXT:    lw a3, 92(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 116(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    sw a1, 0(a3)
-; RV32IMZBS-NEXT:    lw a4, 116(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 12(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    sw a4, 4(a3)
 ; RV32IMZBS-NEXT:    sw a2, 8(a3)
-; RV32IMZBS-NEXT:    lw a0, 120(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    sw a0, 12(a3)
-; RV32IMZBS-NEXT:    lw a3, 96(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 120(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    sw a1, 0(a3)
 ; RV32IMZBS-NEXT:    sw a4, 4(a3)
 ; RV32IMZBS-NEXT:    sw a2, 8(a3)
@@ -37337,8 +37337,8 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    sw s9, 500(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    sw s10, 496(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    sw s11, 492(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    sw a3, 456(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    sw a2, 452(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 460(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 456(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lw a4, 0(a0)
 ; RV32I-NEXT:    lui a2, 16
 ; RV32I-NEXT:    lw t3, 4(a0)
@@ -37353,7 +37353,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    slli a5, a5, 8
 ; RV32I-NEXT:    or a0, a0, a2
 ; RV32I-NEXT:    slli a2, a4, 24
-; RV32I-NEXT:    sw a2, 460(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    or a2, a2, a5
 ; RV32I-NEXT:    lui a5, 61681
 ; RV32I-NEXT:    or a0, a2, a0
@@ -37636,7 +37636,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    slli t5, t5, 2
 ; RV32I-NEXT:    or t5, t6, t5
 ; RV32I-NEXT:    addi a0, t4, 1364
-; RV32I-NEXT:    sw a0, 216(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli t4, t5, 1
 ; RV32I-NEXT:    and t4, t4, a0
 ; RV32I-NEXT:    and t5, t5, t0
@@ -37645,24 +37645,24 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz t6, t6
 ; RV32I-NEXT:    andi s1, t2, 1
 ; RV32I-NEXT:    addi a3, t6, -1
-; RV32I-NEXT:    sw a3, 448(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 452(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz t6, s1
 ; RV32I-NEXT:    addi t1, t6, -1
-; RV32I-NEXT:    sw t1, 444(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t1, 448(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t6, t3, 1
 ; RV32I-NEXT:    and t6, a3, t6
 ; RV32I-NEXT:    and s1, t1, t3
 ; RV32I-NEXT:    or a3, t4, t5
-; RV32I-NEXT:    sw a3, 440(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 444(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor t4, s1, t6
 ; RV32I-NEXT:    andi t5, t2, 4
 ; RV32I-NEXT:    andi t6, t2, 8
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    seqz t6, t6
 ; RV32I-NEXT:    addi a3, t5, -1
-; RV32I-NEXT:    sw a3, 436(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 440(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi t1, t6, -1
-; RV32I-NEXT:    sw t1, 432(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t1, 436(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t5, t3, 2
 ; RV32I-NEXT:    slli t6, t3, 3
 ; RV32I-NEXT:    and t5, a3, t5
@@ -37672,19 +37672,19 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    xor t4, t4, t5
 ; RV32I-NEXT:    seqz t5, t6
 ; RV32I-NEXT:    addi a3, t5, -1
-; RV32I-NEXT:    sw a3, 428(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 432(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi t5, t2, 32
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    slli t6, t3, 4
 ; RV32I-NEXT:    and t6, a3, t6
 ; RV32I-NEXT:    addi a3, t5, -1
-; RV32I-NEXT:    sw a3, 424(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 428(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t5, t3, 5
 ; RV32I-NEXT:    andi s1, t2, 64
 ; RV32I-NEXT:    and t5, a3, t5
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    addi a3, s1, -1
-; RV32I-NEXT:    sw a3, 420(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 424(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t3, 6
 ; RV32I-NEXT:    xor t5, t6, t5
 ; RV32I-NEXT:    and t6, a3, s1
@@ -37693,26 +37693,26 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    xor t4, t4, t5
 ; RV32I-NEXT:    seqz t5, t6
 ; RV32I-NEXT:    addi a3, t5, -1
-; RV32I-NEXT:    sw a3, 416(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 420(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi t5, t2, 256
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    slli t6, t3, 7
 ; RV32I-NEXT:    and t6, a3, t6
 ; RV32I-NEXT:    addi a3, t5, -1
-; RV32I-NEXT:    sw a3, 412(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 416(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t5, t3, 8
 ; RV32I-NEXT:    andi s1, t2, 512
 ; RV32I-NEXT:    and t5, a3, t5
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    xor t5, t6, t5
 ; RV32I-NEXT:    addi a3, s1, -1
-; RV32I-NEXT:    sw a3, 408(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 412(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t6, t3, 9
 ; RV32I-NEXT:    andi s1, t2, 1024
 ; RV32I-NEXT:    and t6, a3, t6
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    addi a3, s1, -1
-; RV32I-NEXT:    sw a3, 404(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 408(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t3, 10
 ; RV32I-NEXT:    xor t5, t5, t6
 ; RV32I-NEXT:    and t6, a3, s1
@@ -37721,21 +37721,21 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    xor t4, t4, t5
 ; RV32I-NEXT:    seqz t5, t6
 ; RV32I-NEXT:    addi a3, t5, -1
-; RV32I-NEXT:    sw a3, 400(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 404(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui s0, 1
 ; RV32I-NEXT:    and t5, t2, s0
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    slli t6, t3, 11
 ; RV32I-NEXT:    and t6, a3, t6
 ; RV32I-NEXT:    addi a3, t5, -1
-; RV32I-NEXT:    sw a3, 396(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 400(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t5, t3, 12
 ; RV32I-NEXT:    and s1, t2, s10
 ; RV32I-NEXT:    and t5, a3, t5
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    xor t5, t6, t5
 ; RV32I-NEXT:    addi a3, s1, -1
-; RV32I-NEXT:    sw a3, 392(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 396(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t6, t3, 13
 ; RV32I-NEXT:    lui s2, 4
 ; RV32I-NEXT:    and s1, t2, s2
@@ -37743,14 +37743,14 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    xor t5, t5, t6
 ; RV32I-NEXT:    addi a3, s1, -1
-; RV32I-NEXT:    sw a3, 388(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 392(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t6, t3, 14
 ; RV32I-NEXT:    lui s3, 8
 ; RV32I-NEXT:    and s1, t2, s3
 ; RV32I-NEXT:    and t6, a3, t6
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    addi a3, s1, -1
-; RV32I-NEXT:    sw a3, 384(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 388(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t3, 15
 ; RV32I-NEXT:    xor t5, t5, t6
 ; RV32I-NEXT:    and t6, a3, s1
@@ -37760,14 +37760,14 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    xor t4, t4, t5
 ; RV32I-NEXT:    seqz t5, t6
 ; RV32I-NEXT:    addi a3, t5, -1
-; RV32I-NEXT:    sw a3, 380(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 384(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui s4, 32
 ; RV32I-NEXT:    and t5, t2, s4
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    slli t6, t3, 16
 ; RV32I-NEXT:    and t6, a3, t6
 ; RV32I-NEXT:    addi a3, t5, -1
-; RV32I-NEXT:    sw a3, 376(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 380(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t5, t3, 17
 ; RV32I-NEXT:    lui s5, 64
 ; RV32I-NEXT:    and s1, t2, s5
@@ -37775,7 +37775,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    xor t5, t6, t5
 ; RV32I-NEXT:    addi a3, s1, -1
-; RV32I-NEXT:    sw a3, 372(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 376(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t6, t3, 18
 ; RV32I-NEXT:    lui s6, 128
 ; RV32I-NEXT:    and s1, t2, s6
@@ -37783,7 +37783,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    xor t5, t5, t6
 ; RV32I-NEXT:    addi a3, s1, -1
-; RV32I-NEXT:    sw a3, 368(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 372(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t6, t3, 19
 ; RV32I-NEXT:    lui ra, 256
 ; RV32I-NEXT:    and s1, t2, ra
@@ -37791,14 +37791,14 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    xor t5, t5, t6
 ; RV32I-NEXT:    addi a3, s1, -1
-; RV32I-NEXT:    sw a3, 364(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 368(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t6, t3, 20
 ; RV32I-NEXT:    lui a0, 512
 ; RV32I-NEXT:    and s1, t2, a0
 ; RV32I-NEXT:    and t6, a3, t6
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    addi a3, s1, -1
-; RV32I-NEXT:    sw a3, 360(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 364(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t3, 21
 ; RV32I-NEXT:    xor t5, t5, t6
 ; RV32I-NEXT:    and t6, a3, s1
@@ -37808,14 +37808,14 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    xor t4, t4, t5
 ; RV32I-NEXT:    seqz t5, t6
 ; RV32I-NEXT:    addi a3, t5, -1
-; RV32I-NEXT:    sw a3, 356(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 360(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui a0, 2048
 ; RV32I-NEXT:    and t5, t2, a0
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    slli t6, t3, 22
 ; RV32I-NEXT:    and t6, a3, t6
 ; RV32I-NEXT:    addi a3, t5, -1
-; RV32I-NEXT:    sw a3, 352(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 356(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t5, t3, 23
 ; RV32I-NEXT:    lui a0, 4096
 ; RV32I-NEXT:    and s1, t2, a0
@@ -37823,7 +37823,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    xor t5, t6, t5
 ; RV32I-NEXT:    addi t1, s1, -1
-; RV32I-NEXT:    sw t1, 348(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t1, 352(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t6, t3, 24
 ; RV32I-NEXT:    lui a3, 8192
 ; RV32I-NEXT:    and s1, t2, a3
@@ -37831,7 +37831,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    xor t5, t5, t6
 ; RV32I-NEXT:    addi s1, s1, -1
-; RV32I-NEXT:    sw s1, 344(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s1, 348(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t6, t3, 25
 ; RV32I-NEXT:    lui t1, 16384
 ; RV32I-NEXT:    and a0, t2, t1
@@ -37839,7 +37839,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz s1, a0
 ; RV32I-NEXT:    xor t5, t5, t6
 ; RV32I-NEXT:    addi a0, s1, -1
-; RV32I-NEXT:    sw a0, 340(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 344(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t6, t3, 26
 ; RV32I-NEXT:    lui s1, 32768
 ; RV32I-NEXT:    and s1, t2, s1
@@ -37847,14 +37847,14 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    xor t5, t5, t6
 ; RV32I-NEXT:    addi a0, s1, -1
-; RV32I-NEXT:    sw a0, 336(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 340(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t6, t3, 27
 ; RV32I-NEXT:    lui s1, 65536
 ; RV32I-NEXT:    and s1, t2, s1
 ; RV32I-NEXT:    and t6, a0, t6
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    addi a0, s1, -1
-; RV32I-NEXT:    sw a0, 332(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 336(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t3, 28
 ; RV32I-NEXT:    xor t5, t5, t6
 ; RV32I-NEXT:    and t6, a0, s1
@@ -37864,21 +37864,21 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    xor t4, t4, t5
 ; RV32I-NEXT:    seqz t5, t6
 ; RV32I-NEXT:    addi a0, t5, -1
-; RV32I-NEXT:    sw a0, 328(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 332(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui t5, 262144
 ; RV32I-NEXT:    and t5, t2, t5
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    slli t6, t3, 29
 ; RV32I-NEXT:    and t6, a0, t6
 ; RV32I-NEXT:    addi a0, t5, -1
-; RV32I-NEXT:    sw a0, 324(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 328(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli t2, t2, 31
 ; RV32I-NEXT:    slli t5, t3, 30
 ; RV32I-NEXT:    and t5, a0, t5
 ; RV32I-NEXT:    seqz t2, t2
 ; RV32I-NEXT:    slli t3, t3, 31
 ; RV32I-NEXT:    addi a0, t2, -1
-; RV32I-NEXT:    sw a0, 320(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 324(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor t2, t6, t5
 ; RV32I-NEXT:    and t3, a0, t3
 ; RV32I-NEXT:    xor t2, t2, t3
@@ -37889,7 +37889,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    addi t5, t5, -1
 ; RV32I-NEXT:    slli a0, a4, 1
-; RV32I-NEXT:    sw a0, 316(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 320(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t3, t3, a0
 ; RV32I-NEXT:    and t5, t5, a4
 ; RV32I-NEXT:    xor s1, t4, t2
@@ -37901,9 +37901,9 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    addi t3, t3, -1
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli a0, a4, 2
-; RV32I-NEXT:    sw a0, 312(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 316(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t5, a4, 3
-; RV32I-NEXT:    sw t5, 308(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t5, 312(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t3, t3, a0
 ; RV32I-NEXT:    and t4, t4, t5
 ; RV32I-NEXT:    xor t3, t3, t4
@@ -37914,17 +37914,17 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    andi t4, a2, 32
 ; RV32I-NEXT:    seqz t4, t4
 ; RV32I-NEXT:    slli a0, a4, 4
-; RV32I-NEXT:    sw a0, 304(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 308(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t3, t3, a0
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli a0, a4, 5
-; RV32I-NEXT:    sw a0, 300(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 304(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi t5, a2, 64
 ; RV32I-NEXT:    and t4, t4, a0
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    addi t5, t5, -1
 ; RV32I-NEXT:    slli a0, a4, 6
-; RV32I-NEXT:    sw a0, 296(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 300(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor t3, t3, t4
 ; RV32I-NEXT:    and t4, t5, a0
 ; RV32I-NEXT:    xor t3, t3, t4
@@ -37935,24 +37935,24 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    andi t4, a2, 256
 ; RV32I-NEXT:    seqz t4, t4
 ; RV32I-NEXT:    slli a0, a4, 7
-; RV32I-NEXT:    sw a0, 292(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 296(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t3, t3, a0
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli a0, a4, 8
-; RV32I-NEXT:    sw a0, 288(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 292(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi t5, a2, 512
 ; RV32I-NEXT:    and t4, t4, a0
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    xor t3, t3, t4
 ; RV32I-NEXT:    addi t5, t5, -1
 ; RV32I-NEXT:    slli a0, a4, 9
-; RV32I-NEXT:    sw a0, 284(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 288(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi t4, a2, 1024
 ; RV32I-NEXT:    and t5, t5, a0
 ; RV32I-NEXT:    seqz t4, t4
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli a0, a4, 10
-; RV32I-NEXT:    sw a0, 280(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 284(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor t3, t3, t5
 ; RV32I-NEXT:    and t4, t4, a0
 ; RV32I-NEXT:    xor t3, t3, t4
@@ -37964,11 +37964,11 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    and t4, a2, s0
 ; RV32I-NEXT:    seqz t4, t4
 ; RV32I-NEXT:    slli t5, a4, 11
-; RV32I-NEXT:    sw t5, 276(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t5, 280(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t3, t3, t5
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli t6, a4, 12
-; RV32I-NEXT:    sw t6, 272(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t6, 276(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui s0, 2
 ; RV32I-NEXT:    and t5, a2, s0
 ; RV32I-NEXT:    and t4, t4, t6
@@ -37976,20 +37976,20 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    xor t3, t3, t4
 ; RV32I-NEXT:    addi t5, t5, -1
 ; RV32I-NEXT:    slli t6, a4, 13
-; RV32I-NEXT:    sw t6, 268(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t6, 272(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t4, a2, s2
 ; RV32I-NEXT:    and t5, t5, t6
 ; RV32I-NEXT:    seqz t4, t4
 ; RV32I-NEXT:    xor t3, t3, t5
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli t6, a4, 14
-; RV32I-NEXT:    sw t6, 264(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t6, 268(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t5, a2, s3
 ; RV32I-NEXT:    and t4, t4, t6
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    addi t5, t5, -1
 ; RV32I-NEXT:    slli t6, a4, 15
-; RV32I-NEXT:    sw t6, 260(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t6, 264(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor t3, t3, t4
 ; RV32I-NEXT:    and t4, t5, t6
 ; RV32I-NEXT:    xor t3, t3, t4
@@ -38001,32 +38001,32 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    lui s10, 32
 ; RV32I-NEXT:    seqz t4, t4
 ; RV32I-NEXT:    slli t5, a4, 16
-; RV32I-NEXT:    sw t5, 256(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t5, 260(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t3, t3, t5
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli t6, a4, 17
-; RV32I-NEXT:    sw t6, 252(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t6, 256(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t5, a2, s5
 ; RV32I-NEXT:    and t4, t4, t6
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    xor t3, t3, t4
 ; RV32I-NEXT:    addi t5, t5, -1
 ; RV32I-NEXT:    slli t6, a4, 18
-; RV32I-NEXT:    sw t6, 248(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t6, 252(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t4, a2, s6
 ; RV32I-NEXT:    and t5, t5, t6
 ; RV32I-NEXT:    seqz t4, t4
 ; RV32I-NEXT:    xor t3, t3, t5
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli t6, a4, 19
-; RV32I-NEXT:    sw t6, 244(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t6, 248(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t5, a2, ra
 ; RV32I-NEXT:    and t4, t4, t6
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    xor t3, t3, t4
 ; RV32I-NEXT:    addi t5, t5, -1
 ; RV32I-NEXT:    slli t6, a4, 20
-; RV32I-NEXT:    sw t6, 240(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t6, 244(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui t4, 512
 ; RV32I-NEXT:    and t4, a2, t4
 ; RV32I-NEXT:    and t5, t5, t6
@@ -38034,7 +38034,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    xor t3, t3, t5
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli t6, a4, 21
-; RV32I-NEXT:    sw t6, 236(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t6, 240(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui t5, 1024
 ; RV32I-NEXT:    and t5, a2, t5
 ; RV32I-NEXT:    and t4, t4, t6
@@ -38042,14 +38042,14 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    xor t3, t3, t4
 ; RV32I-NEXT:    addi t5, t5, -1
 ; RV32I-NEXT:    slli t6, a4, 22
-; RV32I-NEXT:    sw t6, 232(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t6, 236(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui t4, 2048
 ; RV32I-NEXT:    and t4, a2, t4
 ; RV32I-NEXT:    and t5, t5, t6
 ; RV32I-NEXT:    seqz t4, t4
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli t6, a4, 23
-; RV32I-NEXT:    sw t6, 228(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t6, 232(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t4, t4, t6
 ; RV32I-NEXT:    lui t6, 4096
 ; RV32I-NEXT:    and t6, a2, t6
@@ -38057,19 +38057,19 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz t5, t6
 ; RV32I-NEXT:    addi t5, t5, -1
 ; RV32I-NEXT:    and t6, a2, a3
-; RV32I-NEXT:    lw a3, 460(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t5, t5, a3
 ; RV32I-NEXT:    seqz t6, t6
 ; RV32I-NEXT:    xor t4, t4, t5
 ; RV32I-NEXT:    addi t6, t6, -1
 ; RV32I-NEXT:    slli a3, a4, 25
-; RV32I-NEXT:    sw a3, 224(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 228(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t5, a2, t1
 ; RV32I-NEXT:    and t6, t6, a3
 ; RV32I-NEXT:    seqz t5, t5
 ; RV32I-NEXT:    addi t5, t5, -1
 ; RV32I-NEXT:    slli a3, a4, 26
-; RV32I-NEXT:    sw a3, 220(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 224(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor t4, t4, t6
 ; RV32I-NEXT:    and t5, t5, a3
 ; RV32I-NEXT:    xor t2, t2, t3
@@ -38088,7 +38088,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    slli t6, t6, 8
 ; RV32I-NEXT:    slli s2, s2, 8
 ; RV32I-NEXT:    slli a3, s7, 24
-; RV32I-NEXT:    sw a3, 208(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 216(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s3, a7, 24
 ; RV32I-NEXT:    or s2, s3, s2
 ; RV32I-NEXT:    or t6, a3, t6
@@ -38137,7 +38137,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz s4, s4
 ; RV32I-NEXT:    addi s4, s4, -1
 ; RV32I-NEXT:    slli s5, a4, 27
-; RV32I-NEXT:    sw s5, 212(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s5, 220(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and s3, s3, s5
 ; RV32I-NEXT:    and s4, s4, t4
 ; RV32I-NEXT:    xor t5, t5, s3
@@ -38342,7 +38342,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz t4, t4
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli a0, a4, 28
-; RV32I-NEXT:    sw a0, 204(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 212(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t4, t4, a0
 ; RV32I-NEXT:    srli t6, t3, 8
 ; RV32I-NEXT:    xor t4, t5, t4
@@ -38364,9 +38364,9 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    addi t3, t3, -1
 ; RV32I-NEXT:    addi t4, t4, -1
 ; RV32I-NEXT:    slli a0, a4, 29
-; RV32I-NEXT:    sw a0, 200(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 208(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t5, a4, 30
-; RV32I-NEXT:    sw t5, 196(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t5, 204(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t3, t3, a0
 ; RV32I-NEXT:    and t4, t4, t5
 ; RV32I-NEXT:    xor t3, t3, t4
@@ -38377,7 +38377,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz a0, a0
 ; RV32I-NEXT:    addi a0, a0, -1
 ; RV32I-NEXT:    slli t1, a4, 31
-; RV32I-NEXT:    sw t1, 192(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t1, 200(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a0, a0, t1
 ; RV32I-NEXT:    slli a2, a2, 4
 ; RV32I-NEXT:    xor a0, t3, a0
@@ -38389,33 +38389,33 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    xor a0, t2, a0
 ; RV32I-NEXT:    or a2, a5, a2
 ; RV32I-NEXT:    xor a0, a0, s1
-; RV32I-NEXT:    sw a0, 152(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 160(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli a0, a2, 1
-; RV32I-NEXT:    lw a5, 216(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 4(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a0, a0, a5
-; RV32I-NEXT:    sw a0, 144(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 152(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a0, a7, 2
 ; RV32I-NEXT:    seqz a0, a0
 ; RV32I-NEXT:    andi a5, a7, 1
 ; RV32I-NEXT:    addi t1, a0, -1
-; RV32I-NEXT:    sw t1, 216(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t1, 4(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    seqz a0, a5
 ; RV32I-NEXT:    addi a5, a0, -1
-; RV32I-NEXT:    sw a5, 188(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 196(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a0, a6, 1
 ; RV32I-NEXT:    and a0, t1, a0
 ; RV32I-NEXT:    and a5, a5, a6
 ; RV32I-NEXT:    and a2, a2, t0
-; RV32I-NEXT:    sw a2, 128(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 136(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a0, a5, a0
 ; RV32I-NEXT:    andi a2, a7, 4
 ; RV32I-NEXT:    andi a5, a7, 8
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    seqz a5, a5
 ; RV32I-NEXT:    addi a3, a2, -1
-; RV32I-NEXT:    sw a3, 184(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 192(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi t0, a5, -1
-; RV32I-NEXT:    sw t0, 180(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 188(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, a6, 2
 ; RV32I-NEXT:    slli a5, a6, 3
 ; RV32I-NEXT:    and a2, a3, a2
@@ -38425,19 +38425,19 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    xor a0, a0, a2
 ; RV32I-NEXT:    seqz a2, a5
 ; RV32I-NEXT:    addi a3, a2, -1
-; RV32I-NEXT:    sw a3, 176(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 184(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a2, a7, 32
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    slli a5, a6, 4
 ; RV32I-NEXT:    and a5, a3, a5
 ; RV32I-NEXT:    addi a3, a2, -1
-; RV32I-NEXT:    sw a3, 172(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 180(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, a6, 5
 ; RV32I-NEXT:    andi t0, a7, 64
 ; RV32I-NEXT:    and a2, a3, a2
 ; RV32I-NEXT:    seqz t0, t0
 ; RV32I-NEXT:    addi a3, t0, -1
-; RV32I-NEXT:    sw a3, 168(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 176(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t0, a6, 6
 ; RV32I-NEXT:    xor a2, a5, a2
 ; RV32I-NEXT:    and a5, a3, t0
@@ -38446,26 +38446,26 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    xor a0, a0, a2
 ; RV32I-NEXT:    seqz a2, a5
 ; RV32I-NEXT:    addi a3, a2, -1
-; RV32I-NEXT:    sw a3, 164(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 172(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a2, a7, 256
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    slli a5, a6, 7
 ; RV32I-NEXT:    and a5, a3, a5
 ; RV32I-NEXT:    addi a3, a2, -1
-; RV32I-NEXT:    sw a3, 160(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 168(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, a6, 8
 ; RV32I-NEXT:    andi t0, a7, 512
 ; RV32I-NEXT:    and a2, a3, a2
 ; RV32I-NEXT:    seqz t0, t0
 ; RV32I-NEXT:    xor a2, a5, a2
 ; RV32I-NEXT:    addi a3, t0, -1
-; RV32I-NEXT:    sw a3, 156(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 164(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, a6, 9
 ; RV32I-NEXT:    andi t0, a7, 1024
 ; RV32I-NEXT:    and a5, a3, a5
 ; RV32I-NEXT:    seqz t0, t0
 ; RV32I-NEXT:    addi a3, t0, -1
-; RV32I-NEXT:    sw a3, 148(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 156(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t0, a6, 10
 ; RV32I-NEXT:    xor a2, a2, a5
 ; RV32I-NEXT:    and a5, a3, t0
@@ -38474,14 +38474,14 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    xor a0, a0, a2
 ; RV32I-NEXT:    seqz a2, a5
 ; RV32I-NEXT:    addi a3, a2, -1
-; RV32I-NEXT:    sw a3, 140(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 148(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui s6, 1
 ; RV32I-NEXT:    and a2, a7, s6
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    slli a5, a6, 11
 ; RV32I-NEXT:    and a5, a3, a5
 ; RV32I-NEXT:    addi a3, a2, -1
-; RV32I-NEXT:    sw a3, 136(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 144(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, a6, 12
 ; RV32I-NEXT:    lui t1, 2
 ; RV32I-NEXT:    and t0, a7, t1
@@ -38489,7 +38489,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz t0, t0
 ; RV32I-NEXT:    xor a2, a5, a2
 ; RV32I-NEXT:    addi a3, t0, -1
-; RV32I-NEXT:    sw a3, 132(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 140(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, a6, 13
 ; RV32I-NEXT:    lui s5, 4
 ; RV32I-NEXT:    and t0, a7, s5
@@ -38497,14 +38497,14 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz t0, t0
 ; RV32I-NEXT:    xor a2, a2, a5
 ; RV32I-NEXT:    addi a3, t0, -1
-; RV32I-NEXT:    sw a3, 124(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 132(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, a6, 14
 ; RV32I-NEXT:    lui s4, 8
 ; RV32I-NEXT:    and t0, a7, s4
 ; RV32I-NEXT:    and a5, a3, a5
 ; RV32I-NEXT:    seqz t0, t0
 ; RV32I-NEXT:    addi a3, t0, -1
-; RV32I-NEXT:    sw a3, 120(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 128(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t0, a6, 15
 ; RV32I-NEXT:    xor a2, a2, a5
 ; RV32I-NEXT:    and a5, a3, t0
@@ -38514,14 +38514,14 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    xor a0, a0, a2
 ; RV32I-NEXT:    seqz a2, a5
 ; RV32I-NEXT:    addi a3, a2, -1
-; RV32I-NEXT:    sw a3, 116(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 124(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui s2, 32
 ; RV32I-NEXT:    and a2, a7, s2
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    slli a5, a6, 16
 ; RV32I-NEXT:    and a5, a3, a5
 ; RV32I-NEXT:    addi a3, a2, -1
-; RV32I-NEXT:    sw a3, 112(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 120(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, a6, 17
 ; RV32I-NEXT:    lui s3, 64
 ; RV32I-NEXT:    and t0, a7, s3
@@ -38529,7 +38529,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz t0, t0
 ; RV32I-NEXT:    xor a2, a5, a2
 ; RV32I-NEXT:    addi a3, t0, -1
-; RV32I-NEXT:    sw a3, 108(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 116(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, a6, 18
 ; RV32I-NEXT:    lui s0, 128
 ; RV32I-NEXT:    and t0, a7, s0
@@ -38537,7 +38537,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz t0, t0
 ; RV32I-NEXT:    xor a2, a2, a5
 ; RV32I-NEXT:    addi a3, t0, -1
-; RV32I-NEXT:    sw a3, 104(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 112(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, a6, 19
 ; RV32I-NEXT:    lui t6, 256
 ; RV32I-NEXT:    and t0, a7, t6
@@ -38545,14 +38545,14 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz t0, t0
 ; RV32I-NEXT:    xor a2, a2, a5
 ; RV32I-NEXT:    addi a3, t0, -1
-; RV32I-NEXT:    sw a3, 100(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 108(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, a6, 20
 ; RV32I-NEXT:    lui t5, 512
 ; RV32I-NEXT:    and t0, a7, t5
 ; RV32I-NEXT:    and a5, a3, a5
 ; RV32I-NEXT:    seqz t0, t0
 ; RV32I-NEXT:    addi a3, t0, -1
-; RV32I-NEXT:    sw a3, 96(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 104(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t0, a6, 21
 ; RV32I-NEXT:    xor a2, a2, a5
 ; RV32I-NEXT:    and a5, a3, t0
@@ -38562,14 +38562,14 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    xor a0, a0, a2
 ; RV32I-NEXT:    seqz a2, a5
 ; RV32I-NEXT:    addi a3, a2, -1
-; RV32I-NEXT:    sw a3, 92(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 100(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui t3, 2048
 ; RV32I-NEXT:    and a2, a7, t3
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    slli a5, a6, 22
 ; RV32I-NEXT:    and a5, a3, a5
 ; RV32I-NEXT:    addi a3, a2, -1
-; RV32I-NEXT:    sw a3, 88(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 96(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, a6, 23
 ; RV32I-NEXT:    lui t4, 4096
 ; RV32I-NEXT:    and t0, a7, t4
@@ -38577,7 +38577,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz t0, t0
 ; RV32I-NEXT:    xor a2, a5, a2
 ; RV32I-NEXT:    addi s8, t0, -1
-; RV32I-NEXT:    sw s8, 84(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s8, 92(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, a6, 24
 ; RV32I-NEXT:    lui a3, 8192
 ; RV32I-NEXT:    and t0, a7, a3
@@ -38585,7 +38585,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz t0, t0
 ; RV32I-NEXT:    xor a2, a2, a5
 ; RV32I-NEXT:    addi s8, t0, -1
-; RV32I-NEXT:    sw s8, 80(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s8, 88(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, a6, 25
 ; RV32I-NEXT:    lui a3, 16384
 ; RV32I-NEXT:    and t0, a7, a3
@@ -38593,7 +38593,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz t0, t0
 ; RV32I-NEXT:    xor a2, a2, a5
 ; RV32I-NEXT:    addi s8, t0, -1
-; RV32I-NEXT:    sw s8, 76(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s8, 84(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, a6, 26
 ; RV32I-NEXT:    lui a3, 32768
 ; RV32I-NEXT:    and t0, a7, a3
@@ -38601,13 +38601,13 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz t0, t0
 ; RV32I-NEXT:    xor a2, a2, a5
 ; RV32I-NEXT:    addi s8, t0, -1
-; RV32I-NEXT:    sw s8, 72(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s8, 80(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a5, a6, 27
 ; RV32I-NEXT:    and t0, a7, ra
 ; RV32I-NEXT:    and a5, s8, a5
 ; RV32I-NEXT:    seqz t0, t0
 ; RV32I-NEXT:    addi s8, t0, -1
-; RV32I-NEXT:    sw s8, 68(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s8, 76(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t0, a6, 28
 ; RV32I-NEXT:    xor a2, a2, a5
 ; RV32I-NEXT:    and a5, s8, t0
@@ -38616,20 +38616,20 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    xor a0, a0, a2
 ; RV32I-NEXT:    seqz a2, a5
 ; RV32I-NEXT:    addi t0, a2, -1
-; RV32I-NEXT:    sw t0, 64(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 72(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a7, s11
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    slli a5, a6, 29
 ; RV32I-NEXT:    and a5, t0, a5
 ; RV32I-NEXT:    addi t0, a2, -1
-; RV32I-NEXT:    sw t0, 60(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 68(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli a2, a7, 31
 ; RV32I-NEXT:    slli a7, a6, 30
 ; RV32I-NEXT:    and a7, t0, a7
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    slli a6, a6, 31
 ; RV32I-NEXT:    addi t0, a2, -1
-; RV32I-NEXT:    sw t0, 56(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t0, 64(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a2, a5, a7
 ; RV32I-NEXT:    and a5, t0, a6
 ; RV32I-NEXT:    xor a2, a2, a5
@@ -38640,11 +38640,11 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    addi a6, a6, -1
 ; RV32I-NEXT:    slli a7, s7, 1
-; RV32I-NEXT:    sw a7, 52(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 60(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a5, a7
 ; RV32I-NEXT:    and a6, a6, s7
 ; RV32I-NEXT:    xor a0, a0, a2
-; RV32I-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a0, a6, a5
 ; RV32I-NEXT:    andi a2, a1, 4
 ; RV32I-NEXT:    andi a5, a1, 8
@@ -38653,9 +38653,9 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    addi a2, a2, -1
 ; RV32I-NEXT:    addi a5, a5, -1
 ; RV32I-NEXT:    slli a6, s7, 2
-; RV32I-NEXT:    sw a6, 48(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 56(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a7, s7, 3
-; RV32I-NEXT:    sw a7, 44(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 52(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a6
 ; RV32I-NEXT:    and a5, a5, a7
 ; RV32I-NEXT:    xor a2, a2, a5
@@ -38666,17 +38666,17 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    andi a5, a1, 32
 ; RV32I-NEXT:    seqz a5, a5
 ; RV32I-NEXT:    slli a6, s7, 4
-; RV32I-NEXT:    sw a6, 40(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 48(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a6
 ; RV32I-NEXT:    addi a5, a5, -1
 ; RV32I-NEXT:    slli a7, s7, 5
-; RV32I-NEXT:    sw a7, 36(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 44(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a6, a1, 64
 ; RV32I-NEXT:    and a5, a5, a7
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    addi a6, a6, -1
 ; RV32I-NEXT:    slli a7, s7, 6
-; RV32I-NEXT:    sw a7, 32(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 40(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a2, a2, a5
 ; RV32I-NEXT:    and a5, a6, a7
 ; RV32I-NEXT:    xor a2, a2, a5
@@ -38687,24 +38687,24 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    andi a5, a1, 256
 ; RV32I-NEXT:    seqz a5, a5
 ; RV32I-NEXT:    slli a6, s7, 7
-; RV32I-NEXT:    sw a6, 28(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 36(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a6
 ; RV32I-NEXT:    addi a5, a5, -1
 ; RV32I-NEXT:    slli a7, s7, 8
-; RV32I-NEXT:    sw a7, 24(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 32(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a6, a1, 512
 ; RV32I-NEXT:    and a5, a5, a7
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    xor a2, a2, a5
 ; RV32I-NEXT:    addi a6, a6, -1
 ; RV32I-NEXT:    slli a7, s7, 9
-; RV32I-NEXT:    sw a7, 20(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 28(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a5, a1, 1024
 ; RV32I-NEXT:    and a6, a6, a7
 ; RV32I-NEXT:    seqz a5, a5
 ; RV32I-NEXT:    addi a5, a5, -1
 ; RV32I-NEXT:    slli a7, s7, 10
-; RV32I-NEXT:    sw a7, 16(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 24(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a2, a2, a6
 ; RV32I-NEXT:    and a5, a5, a7
 ; RV32I-NEXT:    xor a2, a2, a5
@@ -38715,12 +38715,12 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    and a5, a1, s6
 ; RV32I-NEXT:    seqz a5, a5
 ; RV32I-NEXT:    slli a6, s7, 11
-; RV32I-NEXT:    sw a6, 12(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a6, 20(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a6
 ; RV32I-NEXT:    addi a5, a5, -1
 ; RV32I-NEXT:    and a6, a1, t1
 ; RV32I-NEXT:    slli a7, s7, 12
-; RV32I-NEXT:    sw a7, 8(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 16(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a5, a5, a7
 ; RV32I-NEXT:    seqz a6, a6
 ; RV32I-NEXT:    xor a2, a2, a5
@@ -38791,7 +38791,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    seqz a5, a5
 ; RV32I-NEXT:    xor a0, a0, a2
 ; RV32I-NEXT:    addi a5, a5, -1
-; RV32I-NEXT:    lw t5, 208(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t5, 216(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a5, t5
 ; RV32I-NEXT:    lui a5, 8192
 ; RV32I-NEXT:    and a5, a1, a5
@@ -38841,46 +38841,50 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    xor a0, s0, a0
 ; RV32I-NEXT:    xor a1, a2, a1
 ; RV32I-NEXT:    xor a0, a0, a1
-; RV32I-NEXT:    lw a1, 128(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 136(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    slli a1, a1, 1
-; RV32I-NEXT:    lw a2, 144(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 152(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    or a1, a2, a1
-; RV32I-NEXT:    lw a2, 4(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    xor a0, a0, a2
-; RV32I-NEXT:    lw a2, 440(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 444(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli a2, a2, 1
 ; RV32I-NEXT:    srli a1, a1, 1
-; RV32I-NEXT:    lw s0, 152(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s0, 160(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    xor s0, a2, s0
 ; RV32I-NEXT:    xor s1, a1, a0
-; RV32I-NEXT:    lw a0, 448(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a1, 316(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 452(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 320(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a0, a0, a1
-; RV32I-NEXT:    lw a1, 444(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 448(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, a4
-; RV32I-NEXT:    lw a2, 436(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a3, 312(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 440(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 316(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a2, a3
-; RV32I-NEXT:    lw a3, 432(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a4, 308(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 436(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 312(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a3, a4
 ; RV32I-NEXT:    xor a0, a1, a0
 ; RV32I-NEXT:    xor a2, a2, a4
-; RV32I-NEXT:    lw a1, 428(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a3, 304(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 432(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 308(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, a3
+; RV32I-NEXT:    lw a3, 428(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 304(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a4, a3, a4
+; RV32I-NEXT:    xor a1, a1, a4
 ; RV32I-NEXT:    lw a3, 424(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw a4, 300(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a3, a4
-; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a3, 420(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a4, 296(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a4, a3, a4
 ; RV32I-NEXT:    xor a0, a0, a2
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a2, 416(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a3, 292(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 420(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 296(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a2, a3
+; RV32I-NEXT:    lw a3, 416(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 292(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a4, a3, a4
+; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    lw a3, 412(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw a4, 288(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a3, a4
@@ -38888,15 +38892,15 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    lw a3, 408(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw a4, 284(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a3, a4
-; RV32I-NEXT:    xor a2, a2, a4
-; RV32I-NEXT:    lw a3, 404(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a4, 280(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a4, a3, a4
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a2, a2, a4
-; RV32I-NEXT:    lw a1, 400(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a3, 276(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 404(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 280(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, a3
+; RV32I-NEXT:    lw a3, 400(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 276(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a4, a3, a4
+; RV32I-NEXT:    xor a1, a1, a4
 ; RV32I-NEXT:    lw a3, 396(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw a4, 272(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a3, a4
@@ -38908,15 +38912,15 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    lw a3, 388(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw a4, 264(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a3, a4
-; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a3, 384(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a4, 260(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a4, a3, a4
 ; RV32I-NEXT:    xor a0, a0, a2
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a2, 380(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a3, 256(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 384(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 260(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a2, a3
+; RV32I-NEXT:    lw a3, 380(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 256(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a4, a3, a4
+; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    lw a3, 376(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw a4, 252(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a3, a4
@@ -38932,22 +38936,22 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    lw a3, 364(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw a4, 240(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a3, a4
-; RV32I-NEXT:    xor a2, a2, a4
-; RV32I-NEXT:    lw a3, 360(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a4, 236(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a4, a3, a4
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a2, a2, a4
-; RV32I-NEXT:    lw a1, 356(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a3, 232(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 360(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 236(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, a3
-; RV32I-NEXT:    lw a3, 352(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a4, 228(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 356(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 232(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a3, a4
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a3, 460(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a4, 348(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 352(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, a3
+; RV32I-NEXT:    xor a1, a1, a4
+; RV32I-NEXT:    lw a3, 348(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 228(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a4, a3, a4
 ; RV32I-NEXT:    xor a1, a1, a4
 ; RV32I-NEXT:    lw a3, 344(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw a4, 224(sp) # 4-byte Folded Reload
@@ -38960,133 +38964,129 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    lw a3, 336(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw a4, 212(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a3, a4
-; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a3, 332(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a4, 204(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a4, a3, a4
 ; RV32I-NEXT:    xor a3, a0, a2
 ; RV32I-NEXT:    xor a1, a1, a4
-; RV32I-NEXT:    lw a0, 328(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a2, 200(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 332(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 208(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a0, a2
-; RV32I-NEXT:    lw a0, 324(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a4, 196(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 328(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 204(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a0, a4
 ; RV32I-NEXT:    xor a2, a2, a4
-; RV32I-NEXT:    lw a0, 320(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a4, 192(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 324(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 200(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a0, a0, a4
 ; RV32I-NEXT:    xor a4, a3, a1
 ; RV32I-NEXT:    xor a0, a2, a0
-; RV32I-NEXT:    lw a1, 216(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a2, 52(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 4(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 60(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, a2
-; RV32I-NEXT:    lw a2, 188(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 196(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a2, s7
+; RV32I-NEXT:    lw a3, 192(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 56(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a3, a3, s7
+; RV32I-NEXT:    lw s7, 188(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 52(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s7, s7, ra
+; RV32I-NEXT:    xor a1, a2, a1
+; RV32I-NEXT:    xor a2, a3, s7
 ; RV32I-NEXT:    lw a3, 184(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw s7, 48(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, s7
 ; RV32I-NEXT:    lw s7, 180(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw ra, 44(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, ra
-; RV32I-NEXT:    xor a1, a2, a1
-; RV32I-NEXT:    xor a2, a3, s7
-; RV32I-NEXT:    lw a3, 176(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s7, 40(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a3, a3, s7
-; RV32I-NEXT:    lw s7, 172(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw ra, 36(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s7, s7, ra
 ; RV32I-NEXT:    xor a3, a3, s7
+; RV32I-NEXT:    lw s7, 176(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 40(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s7, s7, ra
+; RV32I-NEXT:    xor a1, a1, a2
+; RV32I-NEXT:    xor a2, a3, s7
+; RV32I-NEXT:    lw a3, 172(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 36(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a3, a3, s7
 ; RV32I-NEXT:    lw s7, 168(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw ra, 32(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, ra
-; RV32I-NEXT:    xor a1, a1, a2
-; RV32I-NEXT:    xor a2, a3, s7
-; RV32I-NEXT:    lw a3, 164(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s7, 28(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a3, a3, s7
-; RV32I-NEXT:    lw s7, 160(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw ra, 24(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    xor a3, a3, s7
+; RV32I-NEXT:    lw s7, 164(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, ra
 ; RV32I-NEXT:    xor a3, a3, s7
 ; RV32I-NEXT:    lw s7, 156(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw ra, 20(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s7, s7, ra
-; RV32I-NEXT:    xor a3, a3, s7
-; RV32I-NEXT:    lw s7, 148(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw ra, 16(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 24(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, ra
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    xor a2, a3, s7
-; RV32I-NEXT:    lw a3, 140(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s7, 12(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 148(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 20(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, s7
-; RV32I-NEXT:    lw s7, 136(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw ra, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 144(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 16(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, ra
 ; RV32I-NEXT:    xor a3, a3, s7
-; RV32I-NEXT:    lw s7, 132(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 140(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, s11
 ; RV32I-NEXT:    xor a3, a3, s7
-; RV32I-NEXT:    lw s7, 124(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 132(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, s10
 ; RV32I-NEXT:    xor a3, a3, s7
-; RV32I-NEXT:    lw s7, 120(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 128(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s7, s7, s9
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    xor a2, a3, s7
-; RV32I-NEXT:    lw a3, 116(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 124(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, s8
-; RV32I-NEXT:    lw s7, 112(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s7, 120(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s5, s7, s5
 ; RV32I-NEXT:    xor a3, a3, s5
-; RV32I-NEXT:    lw s5, 108(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s5, 116(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s5, s4
 ; RV32I-NEXT:    xor a3, a3, s4
-; RV32I-NEXT:    lw s4, 104(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s4, 112(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s3, s4, s3
 ; RV32I-NEXT:    xor a3, a3, s3
-; RV32I-NEXT:    lw s3, 100(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s3, 108(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s2, s3, s2
 ; RV32I-NEXT:    xor a3, a3, s2
-; RV32I-NEXT:    lw s2, 96(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s2, 104(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t6, s2, t6
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    xor a2, a3, t6
-; RV32I-NEXT:    lw a3, 92(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 100(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, s6
-; RV32I-NEXT:    lw t6, 88(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t6, 96(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t4, t6, t4
 ; RV32I-NEXT:    xor a3, a3, t4
-; RV32I-NEXT:    lw t4, 84(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t4, 92(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t4, t4, t5
 ; RV32I-NEXT:    xor a3, a3, t4
-; RV32I-NEXT:    lw t4, 80(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t4, 88(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t3, t4, t3
 ; RV32I-NEXT:    xor a3, a3, t3
-; RV32I-NEXT:    lw t3, 76(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 84(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t2, t3, t2
 ; RV32I-NEXT:    xor a3, a3, t2
-; RV32I-NEXT:    lw t2, 72(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t2, 80(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, t2, t1
 ; RV32I-NEXT:    xor a3, a3, t1
-; RV32I-NEXT:    lw t1, 68(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 76(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t0, t1, t0
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    xor a2, a3, t0
-; RV32I-NEXT:    lw a3, 64(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 72(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a7
-; RV32I-NEXT:    lw a7, 60(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 68(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a6, a7, a6
 ; RV32I-NEXT:    xor a3, a3, a6
-; RV32I-NEXT:    lw a6, 56(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 64(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a6, a5
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    xor a3, a3, a5
 ; RV32I-NEXT:    xor s2, a4, a0
 ; RV32I-NEXT:    xor s3, a1, a3
-; RV32I-NEXT:    lw a0, 452(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 456(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    sw s2, 0(a0)
 ; RV32I-NEXT:    sw s0, 4(a0)
 ; RV32I-NEXT:    sw s3, 8(a0)
@@ -39097,7 +39097,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32I-NEXT:    sw s3, 472(sp)
 ; RV32I-NEXT:    sw s1, 476(sp)
 ; RV32I-NEXT:    call vector_use
-; RV32I-NEXT:    lw a0, 456(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 460(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    sw s2, 0(a0)
 ; RV32I-NEXT:    sw s0, 4(a0)
 ; RV32I-NEXT:    sw s3, 8(a0)
@@ -40040,24 +40040,24 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    sw s9, 164(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    sw s10, 160(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    sw s11, 156(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    sw a3, 100(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    sw a2, 96(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a3, 124(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a2, 120(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    lw a2, 0(a1)
 ; RV32IM-NEXT:    lui a3, 16
 ; RV32IM-NEXT:    lw a4, 4(a1)
-; RV32IM-NEXT:    sw a4, 112(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a4, 8(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    lw a4, 8(a1)
-; RV32IM-NEXT:    sw a4, 120(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a4, 16(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    lw a1, 12(a1)
-; RV32IM-NEXT:    sw a1, 92(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 116(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    addi s2, a3, -256
 ; RV32IM-NEXT:    srli a1, a2, 8
 ; RV32IM-NEXT:    lw s4, 0(a0)
 ; RV32IM-NEXT:    lw s8, 4(a0)
 ; RV32IM-NEXT:    lw a3, 8(a0)
-; RV32IM-NEXT:    sw a3, 124(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a3, 20(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    lw a0, 12(a0)
-; RV32IM-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a0, a1, s2
 ; RV32IM-NEXT:    srli a1, a2, 24
 ; RV32IM-NEXT:    and a3, a2, s2
@@ -40109,7 +40109,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    or a1, a0, a1
 ; RV32IM-NEXT:    addi s3, a3, 273
 ; RV32IM-NEXT:    srli a3, a1, 1
-; RV32IM-NEXT:    sw a6, 116(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a6, 12(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a3, a3, a6
 ; RV32IM-NEXT:    and a1, a1, a6
 ; RV32IM-NEXT:    slli a1, a1, 1
@@ -40187,7 +40187,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    mul s8, a6, t2
 ; RV32IM-NEXT:    mul s9, a7, t5
 ; RV32IM-NEXT:    mul s10, a2, a0
-; RV32IM-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 104(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a1, a4, a1
 ; RV32IM-NEXT:    srli a4, a1, 4
 ; RV32IM-NEXT:    and a1, a1, s0
@@ -40202,12 +40202,12 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    xor a5, t0, t1
 ; RV32IM-NEXT:    mul t0, a3, a0
-; RV32IM-NEXT:    sw t5, 84(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t5, 112(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul a3, a3, t5
 ; RV32IM-NEXT:    mul t1, a6, t5
-; RV32IM-NEXT:    sw t3, 80(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t3, 108(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul a6, a6, t3
-; RV32IM-NEXT:    sw t2, 72(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t2, 100(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul t6, a7, t2
 ; RV32IM-NEXT:    mul s6, a2, t3
 ; RV32IM-NEXT:    mul a7, a7, a0
@@ -40228,21 +40228,21 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    xor a2, a3, a2
 ; RV32IM-NEXT:    and a0, a1, s7
 ; RV32IM-NEXT:    and a6, a2, t4
-; RV32IM-NEXT:    lw a1, 112(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and t2, a1, s3
-; RV32IM-NEXT:    sw t2, 48(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t2, 88(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and t5, a1, s5
 ; RV32IM-NEXT:    and t3, a1, t4
-; RV32IM-NEXT:    sw t3, 52(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t3, 24(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and s0, a1, s7
-; RV32IM-NEXT:    sw s0, 44(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s0, 84(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a3, s4, s5
 ; RV32IM-NEXT:    and a2, s4, s3
-; RV32IM-NEXT:    sw a2, 112(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a2, 8(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a1, s4, s7
-; RV32IM-NEXT:    sw a1, 108(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 44(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a4, s4, t4
-; RV32IM-NEXT:    sw a4, 104(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a4, 40(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul a7, a3, t2
 ; RV32IM-NEXT:    mul t0, a2, t5
 ; RV32IM-NEXT:    mul t1, a1, t3
@@ -40256,25 +40256,25 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    or a6, a0, a6
 ; RV32IM-NEXT:    lui a0, 349525
 ; RV32IM-NEXT:    addi a4, a0, 1364
-; RV32IM-NEXT:    sw a4, 64(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a4, 32(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srli a0, s8, 1
-; RV32IM-NEXT:    lw t5, 116(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t5, 12(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s8, s8, t5
 ; RV32IM-NEXT:    and a0, a0, a4
 ; RV32IM-NEXT:    slli s8, s8, 1
 ; RV32IM-NEXT:    or a0, a0, s8
-; RV32IM-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 96(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a0, a5, a6
-; RV32IM-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a0, t0, a7
 ; RV32IM-NEXT:    xor a5, t1, t6
 ; RV32IM-NEXT:    xor a3, a3, s10
 ; RV32IM-NEXT:    xor a1, a2, a1
 ; RV32IM-NEXT:    xor a0, a0, a5
-; RV32IM-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a1, a3, a1
-; RV32IM-NEXT:    sw a1, 36(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    lw a3, 120(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    sw a1, 76(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    lw a3, 16(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a0, a3, 8
 ; RV32IM-NEXT:    and a1, a3, s2
 ; RV32IM-NEXT:    and a0, a0, s2
@@ -40283,9 +40283,9 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    slli a3, a3, 24
 ; RV32IM-NEXT:    or a0, a0, a2
 ; RV32IM-NEXT:    or a1, a3, a1
-; RV32IM-NEXT:    lw t0, 124(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t0, 20(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a2, t0, 8
-; RV32IM-NEXT:    sw s2, 32(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s2, 72(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a3, t0, s2
 ; RV32IM-NEXT:    and a2, a2, s2
 ; RV32IM-NEXT:    slli a3, a3, 8
@@ -40296,7 +40296,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    or a0, a1, a0
 ; RV32IM-NEXT:    or a2, a3, a2
 ; RV32IM-NEXT:    srli a1, a0, 4
-; RV32IM-NEXT:    sw ra, 28(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw ra, 68(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a0, a0, ra
 ; RV32IM-NEXT:    and a1, a1, ra
 ; RV32IM-NEXT:    slli a0, a0, 4
@@ -40307,7 +40307,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    or a0, a1, a0
 ; RV32IM-NEXT:    or a2, a3, a2
 ; RV32IM-NEXT:    srli a1, a0, 2
-; RV32IM-NEXT:    sw s1, 24(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s1, 64(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a0, a0, s1
 ; RV32IM-NEXT:    and a1, a1, s1
 ; RV32IM-NEXT:    slli a0, a0, 2
@@ -40346,11 +40346,11 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    mul s2, s8, a0
 ; RV32IM-NEXT:    mul s3, t6, a0
 ; RV32IM-NEXT:    mv t0, t3
-; RV32IM-NEXT:    sw t3, 56(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t3, 92(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mv s1, t2
 ; RV32IM-NEXT:    mul t3, t3, t2
-; RV32IM-NEXT:    lw a4, 112(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw t4, 44(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 8(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t4, 84(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a6, a4, t4
 ; RV32IM-NEXT:    mul t1, t6, a3
 ; RV32IM-NEXT:    mul a5, s8, a7
@@ -40361,9 +40361,9 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    mul t6, t6, a7
 ; RV32IM-NEXT:    mul a7, a2, a7
 ; RV32IM-NEXT:    mul a2, a2, a1
-; RV32IM-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a0, a0, s10
-; RV32IM-NEXT:    lw a1, 36(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a1, 76(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, s9
 ; RV32IM-NEXT:    or a1, a1, a0
 ; RV32IM-NEXT:    xor a0, a6, t3
@@ -40377,11 +40377,11 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    xor a6, s8, a7
 ; RV32IM-NEXT:    xor a7, t6, s4
 ; RV32IM-NEXT:    xor a2, t5, a2
-; RV32IM-NEXT:    lw t2, 108(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s0, 48(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t2, 44(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s0, 88(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t5, t2, s0
-; RV32IM-NEXT:    lw t3, 104(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw t6, 52(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t3, 40(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t6, 24(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t1, t3, t6
 ; RV32IM-NEXT:    xor a5, a5, a6
 ; RV32IM-NEXT:    xor a2, a7, a2
@@ -40400,7 +40400,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    xor a0, a0, a4
 ; RV32IM-NEXT:    srli a4, a2, 8
 ; RV32IM-NEXT:    xor a6, a7, a6
-; RV32IM-NEXT:    lw a7, 32(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a7, 72(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, a7
 ; RV32IM-NEXT:    and a7, a2, a7
 ; RV32IM-NEXT:    srli t0, a2, 24
@@ -40412,7 +40412,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    or a2, a2, a4
 ; RV32IM-NEXT:    xor a3, a6, a3
 ; RV32IM-NEXT:    srli a4, a2, 4
-; RV32IM-NEXT:    lw a5, 28(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 68(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, a5
 ; RV32IM-NEXT:    and a2, a2, a5
 ; RV32IM-NEXT:    and a0, a0, s7
@@ -40420,7 +40420,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    and a3, a3, ra
 ; RV32IM-NEXT:    or a2, a4, a2
 ; RV32IM-NEXT:    srli a4, a2, 2
-; RV32IM-NEXT:    lw a5, 24(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 64(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a2, a2, a5
 ; RV32IM-NEXT:    and a4, a4, a5
 ; RV32IM-NEXT:    slli a2, a2, 2
@@ -40428,15 +40428,15 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    or a2, a4, a2
 ; RV32IM-NEXT:    or a0, a1, a0
 ; RV32IM-NEXT:    srli a1, a2, 1
-; RV32IM-NEXT:    lw a3, 60(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 28(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    xor a0, a0, a3
-; RV32IM-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a0, a1, a0
-; RV32IM-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    lw a4, 120(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    lw a4, 16(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and t1, a4, s9
-; RV32IM-NEXT:    lw a5, 88(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 36(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a0, a5, s10
 ; RV32IM-NEXT:    and s3, a4, s10
 ; RV32IM-NEXT:    mv s5, s10
@@ -40452,7 +40452,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    mul t3, a5, t6
 ; RV32IM-NEXT:    mul t4, a0, s2
 ; RV32IM-NEXT:    mul t5, a1, t1
-; RV32IM-NEXT:    sw t1, 52(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t1, 24(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul s0, a4, t6
 ; RV32IM-NEXT:    mul s6, a5, s3
 ; RV32IM-NEXT:    mul s8, a0, s3
@@ -40465,7 +40465,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    mul a5, a5, t1
 ; RV32IM-NEXT:    xor a6, t0, a6
 ; RV32IM-NEXT:    xor t0, t2, t3
-; RV32IM-NEXT:    lw t1, 116(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t1, 12(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a2, a2, t1
 ; RV32IM-NEXT:    xor a6, a6, t0
 ; RV32IM-NEXT:    xor t0, t5, t4
@@ -40478,31 +40478,31 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    xor a0, a0, a4
 ; RV32IM-NEXT:    slli a2, a2, 1
-; RV32IM-NEXT:    sw a2, 120(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a2, 16(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a1, a6, s5
 ; RV32IM-NEXT:    and a2, t0, a3
 ; RV32IM-NEXT:    and a4, t2, s7
 ; RV32IM-NEXT:    and a0, a0, ra
 ; RV32IM-NEXT:    or a1, a2, a1
-; RV32IM-NEXT:    sw a1, 116(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a0, a4, a0
-; RV32IM-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    lw a0, 116(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a0, a3
-; RV32IM-NEXT:    sw s5, 12(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s5, 52(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a6, a0, s5
 ; RV32IM-NEXT:    mv s6, ra
 ; RV32IM-NEXT:    and t2, a0, ra
-; RV32IM-NEXT:    sw s7, 16(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s7, 56(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and t3, a0, s7
-; RV32IM-NEXT:    lw a0, 124(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s0, a0, s5
 ; RV32IM-NEXT:    and t0, a0, a3
 ; RV32IM-NEXT:    mv s5, a3
-; RV32IM-NEXT:    sw a3, 8(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a3, 48(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a2, a0, s7
 ; RV32IM-NEXT:    and a5, a0, ra
-; RV32IM-NEXT:    sw ra, 20(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw ra, 60(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul s4, a5, t3
 ; RV32IM-NEXT:    mul t5, a2, t3
 ; RV32IM-NEXT:    mul s7, t0, t3
@@ -40519,11 +40519,11 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    mul a7, a2, a4
 ; RV32IM-NEXT:    mul a6, a2, a6
 ; RV32IM-NEXT:    mul a4, a5, a4
-; RV32IM-NEXT:    lw t3, 64(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s9, 120(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t3, 32(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s9, 16(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    or t3, t3, s9
-; RV32IM-NEXT:    lw s9, 116(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s1, 88(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s9, 12(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s1, 36(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    or s9, s9, s1
 ; RV32IM-NEXT:    xor s8, s10, s8
 ; RV32IM-NEXT:    xor s4, s11, s4
@@ -40537,34 +40537,34 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    xor a4, a6, a4
 ; RV32IM-NEXT:    xor a1, a1, a3
 ; RV32IM-NEXT:    xor a3, a7, a4
-; RV32IM-NEXT:    lw s7, 12(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s7, 52(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, t5, s7
 ; RV32IM-NEXT:    and a0, a0, s5
-; RV32IM-NEXT:    lw s1, 16(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s1, 56(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, s1
 ; RV32IM-NEXT:    and a3, a3, s6
 ; RV32IM-NEXT:    or a0, a0, a4
 ; RV32IM-NEXT:    or a1, a1, a3
-; RV32IM-NEXT:    lw a3, 68(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 96(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a3, a3, 1
 ; RV32IM-NEXT:    or a0, a0, a1
 ; RV32IM-NEXT:    srli a1, t3, 1
 ; RV32IM-NEXT:    xor a0, a0, s9
-; RV32IM-NEXT:    lw a4, 60(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 28(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    xor s9, a3, a4
 ; RV32IM-NEXT:    xor a0, a1, a0
-; RV32IM-NEXT:    sw a0, 124(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    lw ra, 72(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s10, 56(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    lw ra, 100(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 92(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul s8, s10, ra
-; RV32IM-NEXT:    lw s11, 76(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s4, 112(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s11, 104(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s4, 8(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a0, s4, s11
-; RV32IM-NEXT:    lw s6, 80(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw t3, 108(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s6, 108(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t3, 44(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul s5, t3, s6
-; RV32IM-NEXT:    lw t5, 84(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a6, 104(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t5, 112(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a6, 40(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a3, a6, t5
 ; RV32IM-NEXT:    mul a4, s10, s6
 ; RV32IM-NEXT:    mul a1, s4, ra
@@ -40585,7 +40585,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    xor a0, a0, a3
 ; RV32IM-NEXT:    xor a1, a1, a4
 ; RV32IM-NEXT:    and a0, a0, s7
-; RV32IM-NEXT:    lw s8, 8(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s8, 48(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, s8
 ; RV32IM-NEXT:    xor a3, t5, a7
 ; RV32IM-NEXT:    xor a4, s10, s6
@@ -40595,11 +40595,11 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    xor a4, a6, a7
 ; RV32IM-NEXT:    mv s6, s1
 ; RV32IM-NEXT:    and a3, a3, s1
-; RV32IM-NEXT:    lw s5, 20(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s5, 60(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, s5
 ; RV32IM-NEXT:    or a0, a1, a0
 ; RV32IM-NEXT:    or a3, a3, a4
-; RV32IM-NEXT:    lw s1, 52(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s1, 24(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a1, s0, s1
 ; RV32IM-NEXT:    mul a4, t0, s3
 ; RV32IM-NEXT:    mul a6, a2, s2
@@ -40636,11 +40636,11 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    or a2, a5, a2
 ; RV32IM-NEXT:    or s0, a0, a3
 ; RV32IM-NEXT:    or s1, a1, a2
-; RV32IM-NEXT:    lw a0, 96(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 120(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    sw s0, 0(a0)
 ; RV32IM-NEXT:    sw s9, 4(a0)
 ; RV32IM-NEXT:    sw s1, 8(a0)
-; RV32IM-NEXT:    lw s2, 124(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s2, 20(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    sw s2, 12(a0)
 ; RV32IM-NEXT:    addi a0, sp, 128
 ; RV32IM-NEXT:    sw s0, 128(sp)
@@ -40648,7 +40648,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IM-NEXT:    sw s1, 136(sp)
 ; RV32IM-NEXT:    sw s2, 140(sp)
 ; RV32IM-NEXT:    call vector_use
-; RV32IM-NEXT:    lw a0, 100(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 124(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    sw s0, 0(a0)
 ; RV32IM-NEXT:    sw s9, 4(a0)
 ; RV32IM-NEXT:    sw s1, 8(a0)
@@ -40819,24 +40819,24 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    sw s9, 164(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    sw s10, 160(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    sw s11, 156(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    sw a3, 100(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    sw a2, 96(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a3, 124(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a2, 120(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    lw a2, 0(a1)
 ; RV32IMZBS-NEXT:    lui a3, 16
 ; RV32IMZBS-NEXT:    lw a4, 4(a1)
-; RV32IMZBS-NEXT:    sw a4, 112(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a4, 8(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    lw a4, 8(a1)
-; RV32IMZBS-NEXT:    sw a4, 120(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a4, 16(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    lw a1, 12(a1)
-; RV32IMZBS-NEXT:    sw a1, 92(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 116(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    addi s2, a3, -256
 ; RV32IMZBS-NEXT:    srli a1, a2, 8
 ; RV32IMZBS-NEXT:    lw s4, 0(a0)
 ; RV32IMZBS-NEXT:    lw s8, 4(a0)
 ; RV32IMZBS-NEXT:    lw a3, 8(a0)
-; RV32IMZBS-NEXT:    sw a3, 124(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a3, 20(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    lw a0, 12(a0)
-; RV32IMZBS-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a0, a1, s2
 ; RV32IMZBS-NEXT:    srli a1, a2, 24
 ; RV32IMZBS-NEXT:    and a3, a2, s2
@@ -40888,7 +40888,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    or a1, a0, a1
 ; RV32IMZBS-NEXT:    addi s3, a3, 273
 ; RV32IMZBS-NEXT:    srli a3, a1, 1
-; RV32IMZBS-NEXT:    sw a6, 116(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a6, 12(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a3, a3, a6
 ; RV32IMZBS-NEXT:    and a1, a1, a6
 ; RV32IMZBS-NEXT:    slli a1, a1, 1
@@ -40966,7 +40966,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    mul s8, a6, t2
 ; RV32IMZBS-NEXT:    mul s9, a7, t5
 ; RV32IMZBS-NEXT:    mul s10, a2, a0
-; RV32IMZBS-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 104(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a1, a4, a1
 ; RV32IMZBS-NEXT:    srli a4, a1, 4
 ; RV32IMZBS-NEXT:    and a1, a1, s0
@@ -40981,12 +40981,12 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    xor a5, t0, t1
 ; RV32IMZBS-NEXT:    mul t0, a3, a0
-; RV32IMZBS-NEXT:    sw t5, 84(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t5, 112(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul a3, a3, t5
 ; RV32IMZBS-NEXT:    mul t1, a6, t5
-; RV32IMZBS-NEXT:    sw t3, 80(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t3, 108(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul a6, a6, t3
-; RV32IMZBS-NEXT:    sw t2, 72(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t2, 100(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul t6, a7, t2
 ; RV32IMZBS-NEXT:    mul s6, a2, t3
 ; RV32IMZBS-NEXT:    mul a7, a7, a0
@@ -41007,21 +41007,21 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    xor a2, a3, a2
 ; RV32IMZBS-NEXT:    and a0, a1, s7
 ; RV32IMZBS-NEXT:    and a6, a2, t4
-; RV32IMZBS-NEXT:    lw a1, 112(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and t2, a1, s3
-; RV32IMZBS-NEXT:    sw t2, 48(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t2, 88(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and t5, a1, s5
 ; RV32IMZBS-NEXT:    and t3, a1, t4
-; RV32IMZBS-NEXT:    sw t3, 52(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t3, 24(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and s0, a1, s7
-; RV32IMZBS-NEXT:    sw s0, 44(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s0, 84(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a3, s4, s5
 ; RV32IMZBS-NEXT:    and a2, s4, s3
-; RV32IMZBS-NEXT:    sw a2, 112(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a2, 8(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a1, s4, s7
-; RV32IMZBS-NEXT:    sw a1, 108(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 44(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a4, s4, t4
-; RV32IMZBS-NEXT:    sw a4, 104(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a4, 40(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul a7, a3, t2
 ; RV32IMZBS-NEXT:    mul t0, a2, t5
 ; RV32IMZBS-NEXT:    mul t1, a1, t3
@@ -41035,25 +41035,25 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    or a6, a0, a6
 ; RV32IMZBS-NEXT:    lui a0, 349525
 ; RV32IMZBS-NEXT:    addi a4, a0, 1364
-; RV32IMZBS-NEXT:    sw a4, 64(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a4, 32(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srli a0, s8, 1
-; RV32IMZBS-NEXT:    lw t5, 116(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t5, 12(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s8, s8, t5
 ; RV32IMZBS-NEXT:    and a0, a0, a4
 ; RV32IMZBS-NEXT:    slli s8, s8, 1
 ; RV32IMZBS-NEXT:    or a0, a0, s8
-; RV32IMZBS-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 96(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a0, a5, a6
-; RV32IMZBS-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a0, t0, a7
 ; RV32IMZBS-NEXT:    xor a5, t1, t6
 ; RV32IMZBS-NEXT:    xor a3, a3, s10
 ; RV32IMZBS-NEXT:    xor a1, a2, a1
 ; RV32IMZBS-NEXT:    xor a0, a0, a5
-; RV32IMZBS-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a1, a3, a1
-; RV32IMZBS-NEXT:    sw a1, 36(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    lw a3, 120(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    sw a1, 76(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    lw a3, 16(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a0, a3, 8
 ; RV32IMZBS-NEXT:    and a1, a3, s2
 ; RV32IMZBS-NEXT:    and a0, a0, s2
@@ -41062,9 +41062,9 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    slli a3, a3, 24
 ; RV32IMZBS-NEXT:    or a0, a0, a2
 ; RV32IMZBS-NEXT:    or a1, a3, a1
-; RV32IMZBS-NEXT:    lw t0, 124(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t0, 20(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a2, t0, 8
-; RV32IMZBS-NEXT:    sw s2, 32(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s2, 72(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a3, t0, s2
 ; RV32IMZBS-NEXT:    and a2, a2, s2
 ; RV32IMZBS-NEXT:    slli a3, a3, 8
@@ -41075,7 +41075,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    or a0, a1, a0
 ; RV32IMZBS-NEXT:    or a2, a3, a2
 ; RV32IMZBS-NEXT:    srli a1, a0, 4
-; RV32IMZBS-NEXT:    sw ra, 28(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw ra, 68(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a0, a0, ra
 ; RV32IMZBS-NEXT:    and a1, a1, ra
 ; RV32IMZBS-NEXT:    slli a0, a0, 4
@@ -41086,7 +41086,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    or a0, a1, a0
 ; RV32IMZBS-NEXT:    or a2, a3, a2
 ; RV32IMZBS-NEXT:    srli a1, a0, 2
-; RV32IMZBS-NEXT:    sw s1, 24(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s1, 64(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a0, a0, s1
 ; RV32IMZBS-NEXT:    and a1, a1, s1
 ; RV32IMZBS-NEXT:    slli a0, a0, 2
@@ -41125,11 +41125,11 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    mul s2, s8, a0
 ; RV32IMZBS-NEXT:    mul s3, t6, a0
 ; RV32IMZBS-NEXT:    mv t0, t3
-; RV32IMZBS-NEXT:    sw t3, 56(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t3, 92(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mv s1, t2
 ; RV32IMZBS-NEXT:    mul t3, t3, t2
-; RV32IMZBS-NEXT:    lw a4, 112(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw t4, 44(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 8(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t4, 84(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a6, a4, t4
 ; RV32IMZBS-NEXT:    mul t1, t6, a3
 ; RV32IMZBS-NEXT:    mul a5, s8, a7
@@ -41140,9 +41140,9 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    mul t6, t6, a7
 ; RV32IMZBS-NEXT:    mul a7, a2, a7
 ; RV32IMZBS-NEXT:    mul a2, a2, a1
-; RV32IMZBS-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a0, a0, s10
-; RV32IMZBS-NEXT:    lw a1, 36(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a1, 76(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, s9
 ; RV32IMZBS-NEXT:    or a1, a1, a0
 ; RV32IMZBS-NEXT:    xor a0, a6, t3
@@ -41156,11 +41156,11 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    xor a6, s8, a7
 ; RV32IMZBS-NEXT:    xor a7, t6, s4
 ; RV32IMZBS-NEXT:    xor a2, t5, a2
-; RV32IMZBS-NEXT:    lw t2, 108(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s0, 48(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t2, 44(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s0, 88(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t5, t2, s0
-; RV32IMZBS-NEXT:    lw t3, 104(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw t6, 52(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t3, 40(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t6, 24(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t1, t3, t6
 ; RV32IMZBS-NEXT:    xor a5, a5, a6
 ; RV32IMZBS-NEXT:    xor a2, a7, a2
@@ -41179,7 +41179,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    xor a0, a0, a4
 ; RV32IMZBS-NEXT:    srli a4, a2, 8
 ; RV32IMZBS-NEXT:    xor a6, a7, a6
-; RV32IMZBS-NEXT:    lw a7, 32(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a7, 72(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, a7
 ; RV32IMZBS-NEXT:    and a7, a2, a7
 ; RV32IMZBS-NEXT:    srli t0, a2, 24
@@ -41191,7 +41191,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    or a2, a2, a4
 ; RV32IMZBS-NEXT:    xor a3, a6, a3
 ; RV32IMZBS-NEXT:    srli a4, a2, 4
-; RV32IMZBS-NEXT:    lw a5, 28(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 68(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, a5
 ; RV32IMZBS-NEXT:    and a2, a2, a5
 ; RV32IMZBS-NEXT:    and a0, a0, s7
@@ -41199,7 +41199,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    and a3, a3, ra
 ; RV32IMZBS-NEXT:    or a2, a4, a2
 ; RV32IMZBS-NEXT:    srli a4, a2, 2
-; RV32IMZBS-NEXT:    lw a5, 24(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 64(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a2, a2, a5
 ; RV32IMZBS-NEXT:    and a4, a4, a5
 ; RV32IMZBS-NEXT:    slli a2, a2, 2
@@ -41207,15 +41207,15 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    or a2, a4, a2
 ; RV32IMZBS-NEXT:    or a0, a1, a0
 ; RV32IMZBS-NEXT:    srli a1, a2, 1
-; RV32IMZBS-NEXT:    lw a3, 60(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 28(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    xor a0, a0, a3
-; RV32IMZBS-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a0, a1, a0
-; RV32IMZBS-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    lw a4, 120(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    lw a4, 16(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and t1, a4, s9
-; RV32IMZBS-NEXT:    lw a5, 88(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 36(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a0, a5, s10
 ; RV32IMZBS-NEXT:    and s3, a4, s10
 ; RV32IMZBS-NEXT:    mv s5, s10
@@ -41231,7 +41231,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    mul t3, a5, t6
 ; RV32IMZBS-NEXT:    mul t4, a0, s2
 ; RV32IMZBS-NEXT:    mul t5, a1, t1
-; RV32IMZBS-NEXT:    sw t1, 52(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t1, 24(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul s0, a4, t6
 ; RV32IMZBS-NEXT:    mul s6, a5, s3
 ; RV32IMZBS-NEXT:    mul s8, a0, s3
@@ -41244,7 +41244,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    mul a5, a5, t1
 ; RV32IMZBS-NEXT:    xor a6, t0, a6
 ; RV32IMZBS-NEXT:    xor t0, t2, t3
-; RV32IMZBS-NEXT:    lw t1, 116(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t1, 12(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a2, a2, t1
 ; RV32IMZBS-NEXT:    xor a6, a6, t0
 ; RV32IMZBS-NEXT:    xor t0, t5, t4
@@ -41257,31 +41257,31 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    xor a0, a0, a4
 ; RV32IMZBS-NEXT:    slli a2, a2, 1
-; RV32IMZBS-NEXT:    sw a2, 120(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a2, 16(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a1, a6, s5
 ; RV32IMZBS-NEXT:    and a2, t0, a3
 ; RV32IMZBS-NEXT:    and a4, t2, s7
 ; RV32IMZBS-NEXT:    and a0, a0, ra
 ; RV32IMZBS-NEXT:    or a1, a2, a1
-; RV32IMZBS-NEXT:    sw a1, 116(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a0, a4, a0
-; RV32IMZBS-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    lw a0, 116(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a0, a3
-; RV32IMZBS-NEXT:    sw s5, 12(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s5, 52(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a6, a0, s5
 ; RV32IMZBS-NEXT:    mv s6, ra
 ; RV32IMZBS-NEXT:    and t2, a0, ra
-; RV32IMZBS-NEXT:    sw s7, 16(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s7, 56(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and t3, a0, s7
-; RV32IMZBS-NEXT:    lw a0, 124(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s0, a0, s5
 ; RV32IMZBS-NEXT:    and t0, a0, a3
 ; RV32IMZBS-NEXT:    mv s5, a3
-; RV32IMZBS-NEXT:    sw a3, 8(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a3, 48(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a2, a0, s7
 ; RV32IMZBS-NEXT:    and a5, a0, ra
-; RV32IMZBS-NEXT:    sw ra, 20(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw ra, 60(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul s4, a5, t3
 ; RV32IMZBS-NEXT:    mul t5, a2, t3
 ; RV32IMZBS-NEXT:    mul s7, t0, t3
@@ -41298,11 +41298,11 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    mul a7, a2, a4
 ; RV32IMZBS-NEXT:    mul a6, a2, a6
 ; RV32IMZBS-NEXT:    mul a4, a5, a4
-; RV32IMZBS-NEXT:    lw t3, 64(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s9, 120(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t3, 32(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s9, 16(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    or t3, t3, s9
-; RV32IMZBS-NEXT:    lw s9, 116(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s1, 88(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s9, 12(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s1, 36(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    or s9, s9, s1
 ; RV32IMZBS-NEXT:    xor s8, s10, s8
 ; RV32IMZBS-NEXT:    xor s4, s11, s4
@@ -41316,34 +41316,34 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    xor a4, a6, a4
 ; RV32IMZBS-NEXT:    xor a1, a1, a3
 ; RV32IMZBS-NEXT:    xor a3, a7, a4
-; RV32IMZBS-NEXT:    lw s7, 12(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s7, 52(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, t5, s7
 ; RV32IMZBS-NEXT:    and a0, a0, s5
-; RV32IMZBS-NEXT:    lw s1, 16(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s1, 56(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, s1
 ; RV32IMZBS-NEXT:    and a3, a3, s6
 ; RV32IMZBS-NEXT:    or a0, a0, a4
 ; RV32IMZBS-NEXT:    or a1, a1, a3
-; RV32IMZBS-NEXT:    lw a3, 68(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 96(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a3, a3, 1
 ; RV32IMZBS-NEXT:    or a0, a0, a1
 ; RV32IMZBS-NEXT:    srli a1, t3, 1
 ; RV32IMZBS-NEXT:    xor a0, a0, s9
-; RV32IMZBS-NEXT:    lw a4, 60(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 28(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    xor s9, a3, a4
 ; RV32IMZBS-NEXT:    xor a0, a1, a0
-; RV32IMZBS-NEXT:    sw a0, 124(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    lw ra, 72(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s10, 56(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    lw ra, 100(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 92(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul s8, s10, ra
-; RV32IMZBS-NEXT:    lw s11, 76(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s4, 112(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s11, 104(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s4, 8(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a0, s4, s11
-; RV32IMZBS-NEXT:    lw s6, 80(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw t3, 108(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s6, 108(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t3, 44(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul s5, t3, s6
-; RV32IMZBS-NEXT:    lw t5, 84(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a6, 104(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t5, 112(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a6, 40(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a3, a6, t5
 ; RV32IMZBS-NEXT:    mul a4, s10, s6
 ; RV32IMZBS-NEXT:    mul a1, s4, ra
@@ -41364,7 +41364,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    xor a0, a0, a3
 ; RV32IMZBS-NEXT:    xor a1, a1, a4
 ; RV32IMZBS-NEXT:    and a0, a0, s7
-; RV32IMZBS-NEXT:    lw s8, 8(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s8, 48(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, s8
 ; RV32IMZBS-NEXT:    xor a3, t5, a7
 ; RV32IMZBS-NEXT:    xor a4, s10, s6
@@ -41374,11 +41374,11 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    xor a4, a6, a7
 ; RV32IMZBS-NEXT:    mv s6, s1
 ; RV32IMZBS-NEXT:    and a3, a3, s1
-; RV32IMZBS-NEXT:    lw s5, 20(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s5, 60(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, s5
 ; RV32IMZBS-NEXT:    or a0, a1, a0
 ; RV32IMZBS-NEXT:    or a3, a3, a4
-; RV32IMZBS-NEXT:    lw s1, 52(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s1, 24(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a1, s0, s1
 ; RV32IMZBS-NEXT:    mul a4, t0, s3
 ; RV32IMZBS-NEXT:    mul a6, a2, s2
@@ -41415,11 +41415,11 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    or a2, a5, a2
 ; RV32IMZBS-NEXT:    or s0, a0, a3
 ; RV32IMZBS-NEXT:    or s1, a1, a2
-; RV32IMZBS-NEXT:    lw a0, 96(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 120(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    sw s0, 0(a0)
 ; RV32IMZBS-NEXT:    sw s9, 4(a0)
 ; RV32IMZBS-NEXT:    sw s1, 8(a0)
-; RV32IMZBS-NEXT:    lw s2, 124(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s2, 20(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    sw s2, 12(a0)
 ; RV32IMZBS-NEXT:    addi a0, sp, 128
 ; RV32IMZBS-NEXT:    sw s0, 128(sp)
@@ -41427,7 +41427,7 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 ; RV32IMZBS-NEXT:    sw s1, 136(sp)
 ; RV32IMZBS-NEXT:    sw s2, 140(sp)
 ; RV32IMZBS-NEXT:    call vector_use
-; RV32IMZBS-NEXT:    lw a0, 100(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 124(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    sw s0, 0(a0)
 ; RV32IMZBS-NEXT:    sw s9, 4(a0)
 ; RV32IMZBS-NEXT:    sw s1, 8(a0)

--- a/llvm/test/CodeGen/RISCV/clmulh.ll
+++ b/llvm/test/CodeGen/RISCV/clmulh.ll
@@ -2920,15 +2920,15 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    sw s9, 244(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    sw s10, 240(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    sw s11, 236(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    sw a3, 228(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    sw a2, 224(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 232(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 228(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    mv t1, a0
 ; RV32I-NEXT:    lw a0, 4(a1)
 ; RV32I-NEXT:    lui a2, 16
 ; RV32I-NEXT:    lw a3, 8(a1)
-; RV32I-NEXT:    sw a3, 216(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 212(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lw a3, 12(a1)
-; RV32I-NEXT:    sw a3, 208(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 204(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi s4, a2, -256
 ; RV32I-NEXT:    lui t4, 16
 ; RV32I-NEXT:    srli a2, a0, 8
@@ -2972,9 +2972,9 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    or a2, a5, a4
 ; RV32I-NEXT:    lw a4, 4(t1)
 ; RV32I-NEXT:    lw a5, 8(t1)
-; RV32I-NEXT:    sw a5, 220(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 216(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lw a5, 12(t1)
-; RV32I-NEXT:    sw a5, 204(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    or a0, a2, a0
 ; RV32I-NEXT:    srli a2, a0, 4
 ; RV32I-NEXT:    and a0, a0, s3
@@ -3300,7 +3300,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    or a4, a4, a2
 ; RV32I-NEXT:    or a2, a5, a1
 ; RV32I-NEXT:    addi a3, a3, 1364
-; RV32I-NEXT:    sw a3, 232(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 220(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli a1, a4, 1
 ; RV32I-NEXT:    and a1, a1, a3
 ; RV32I-NEXT:    and a3, a4, s9
@@ -3317,7 +3317,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    and a4, a6, a4
 ; RV32I-NEXT:    and a5, a5, a2
 ; RV32I-NEXT:    or a1, a1, a3
-; RV32I-NEXT:    sw a1, 212(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 208(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a4, a5, a4
 ; RV32I-NEXT:    andi a1, a0, 4
 ; RV32I-NEXT:    andi a3, a0, 8
@@ -3661,7 +3661,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    addi a4, a4, -1
 ; RV32I-NEXT:    slli a5, t0, 13
-; RV32I-NEXT:    sw a5, 8(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 224(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a0, t6
 ; RV32I-NEXT:    and a4, a4, a5
 ; RV32I-NEXT:    seqz a3, a3
@@ -3787,7 +3787,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    xor a0, a2, a0
 ; RV32I-NEXT:    xor a0, a0, a1
-; RV32I-NEXT:    lw a1, 212(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 208(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli a1, a1, 1
 ; RV32I-NEXT:    xor a0, a1, a0
 ; RV32I-NEXT:    srli a1, a0, 8
@@ -3811,11 +3811,11 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    or a0, a1, a0
 ; RV32I-NEXT:    srli a1, a0, 1
 ; RV32I-NEXT:    and a0, a0, s9
-; RV32I-NEXT:    lw a2, 232(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 220(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, a2
 ; RV32I-NEXT:    slli a0, a0, 1
 ; RV32I-NEXT:    or a0, a1, a0
-; RV32I-NEXT:    sw a0, 212(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 208(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lw a0, 196(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw a1, 60(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a0, a0, a1
@@ -3865,7 +3865,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    and a3, a3, a6
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    lw a3, 144(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a6, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 224(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a6
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    lw a3, 140(sp) # 4-byte Folded Reload
@@ -3920,7 +3920,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    and a3, a3, ra
 ; RV32I-NEXT:    xor t4, a0, a1
 ; RV32I-NEXT:    xor a1, a2, a3
-; RV32I-NEXT:    lw a4, 208(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 204(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli a0, a4, 8
 ; RV32I-NEXT:    and a2, a4, s4
 ; RV32I-NEXT:    and a0, a0, s4
@@ -3932,7 +3932,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a0, a0, t3
 ; RV32I-NEXT:    or a2, a2, a3
-; RV32I-NEXT:    lw a6, 204(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a6, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli a3, a6, 8
 ; RV32I-NEXT:    and a4, a6, s4
 ; RV32I-NEXT:    and a3, a3, s4
@@ -3973,7 +3973,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    and a2, a2, s9
 ; RV32I-NEXT:    and a5, a5, s9
 ; RV32I-NEXT:    slli a2, a2, 1
-; RV32I-NEXT:    sw a2, 204(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    or t1, a5, a2
 ; RV32I-NEXT:    srli a2, a3, 24
 ; RV32I-NEXT:    or a2, a4, a2
@@ -3988,7 +3988,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    and a6, a3, s4
 ; RV32I-NEXT:    slli a6, a6, 8
 ; RV32I-NEXT:    slli a7, a3, 24
-; RV32I-NEXT:    sw a7, 208(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a7, 204(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    or a4, a5, a4
 ; RV32I-NEXT:    or a5, a7, a6
 ; RV32I-NEXT:    srli a6, a4, 4
@@ -4249,7 +4249,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    or a2, a2, a4
 ; RV32I-NEXT:    sw a2, 200(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    or a0, a1, a0
-; RV32I-NEXT:    lw a5, 216(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 212(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli a1, a5, 8
 ; RV32I-NEXT:    and a2, a5, s4
 ; RV32I-NEXT:    and a1, a1, s4
@@ -4280,7 +4280,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    slli a1, a1, 2
 ; RV32I-NEXT:    or a1, a2, a1
 ; RV32I-NEXT:    srli a2, a0, 1
-; RV32I-NEXT:    lw a4, 232(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 220(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a2, a4
 ; RV32I-NEXT:    and a0, a0, s9
 ; RV32I-NEXT:    slli a0, a0, 1
@@ -4294,7 +4294,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz a2, a2
 ; RV32I-NEXT:    or a0, a0, a1
 ; RV32I-NEXT:    addi a4, a2, -1
-; RV32I-NEXT:    sw a4, 216(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 212(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, a0, 1
 ; RV32I-NEXT:    andi a2, t1, 1
 ; RV32I-NEXT:    and a1, a4, a1
@@ -4501,7 +4501,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    and a5, a7, a6
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a7, 220(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a7, 216(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli a2, a7, 8
 ; RV32I-NEXT:    and a5, a7, s4
 ; RV32I-NEXT:    and a2, a2, s4
@@ -4520,7 +4520,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz a1, a1
 ; RV32I-NEXT:    seqz a4, a4
 ; RV32I-NEXT:    addi a5, a1, -1
-; RV32I-NEXT:    sw a5, 220(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 216(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi a6, a4, -1
 ; RV32I-NEXT:    sw a6, 72(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, a0, 29
@@ -4538,7 +4538,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    and a1, a1, s2
 ; RV32I-NEXT:    slli a2, a2, 2
 ; RV32I-NEXT:    or a1, a1, a2
-; RV32I-NEXT:    lw a2, 204(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli a2, a2, 31
 ; RV32I-NEXT:    slli a5, a0, 31
 ; RV32I-NEXT:    seqz a0, a2
@@ -4547,7 +4547,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    and a2, a2, s9
 ; RV32I-NEXT:    slli ra, a1, 1
 ; RV32I-NEXT:    addi a1, a0, -1
-; RV32I-NEXT:    sw a1, 204(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    or a0, a2, ra
 ; RV32I-NEXT:    and a2, a1, a5
 ; RV32I-NEXT:    andi a5, a0, 2
@@ -4715,7 +4715,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz a5, a5
 ; RV32I-NEXT:    xor a2, a2, a4
 ; RV32I-NEXT:    addi a5, a5, -1
-; RV32I-NEXT:    lw t4, 208(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t4, 204(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a5, t4
 ; RV32I-NEXT:    lui a5, 8192
 ; RV32I-NEXT:    and a5, a0, a5
@@ -4804,7 +4804,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    slli a0, a0, 4
 ; RV32I-NEXT:    or s10, a2, a1
 ; RV32I-NEXT:    or a0, a4, a0
-; RV32I-NEXT:    lw a1, 216(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 212(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw a2, 68(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a1, a1, a2
 ; RV32I-NEXT:    lw a2, 192(sp) # 4-byte Folded Reload
@@ -4903,13 +4903,13 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    and a4, a4, t0
 ; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    xor a2, a2, a4
-; RV32I-NEXT:    lw a3, 220(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 216(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a7
 ; RV32I-NEXT:    lw a4, 72(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, a6
 ; RV32I-NEXT:    xor a1, a1, a2
 ; RV32I-NEXT:    xor a3, a3, a4
-; RV32I-NEXT:    lw a2, 204(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a2, a5
 ; RV32I-NEXT:    srli a4, a0, 2
 ; RV32I-NEXT:    xor a2, a3, a2
@@ -4926,7 +4926,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    slli a4, a4, 8
 ; RV32I-NEXT:    or a2, a2, a3
 ; RV32I-NEXT:    or a1, a1, a4
-; RV32I-NEXT:    lw a3, 212(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 208(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli a3, a3, 1
 ; RV32I-NEXT:    or a1, a1, a2
 ; RV32I-NEXT:    srli a2, a1, 4
@@ -4935,7 +4935,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    slli a1, a1, 4
 ; RV32I-NEXT:    srli a4, a0, 1
 ; RV32I-NEXT:    or a1, a2, a1
-; RV32I-NEXT:    lw a2, 232(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 220(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a2, a4, a2
 ; RV32I-NEXT:    srli a4, a1, 2
 ; RV32I-NEXT:    srli a5, s10, 1
@@ -4962,12 +4962,12 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    or a1, a2, a1
 ; RV32I-NEXT:    srli a4, a4, 1
 ; RV32I-NEXT:    srli a1, a1, 1
-; RV32I-NEXT:    lw a2, 224(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 228(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    sw a3, 0(a2)
 ; RV32I-NEXT:    sw a4, 4(a2)
 ; RV32I-NEXT:    sw a0, 8(a2)
 ; RV32I-NEXT:    sw a1, 12(a2)
-; RV32I-NEXT:    lw a2, 228(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 232(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    sw a3, 0(a2)
 ; RV32I-NEXT:    sw a4, 4(a2)
 ; RV32I-NEXT:    sw a0, 8(a2)
@@ -6159,17 +6159,17 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    sw s9, 116(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    sw s10, 112(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    sw s11, 108(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    sw a3, 76(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    sw a2, 72(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a3, 104(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a2, 100(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mv s3, a1
 ; RV32IM-NEXT:    mv a1, a0
-; RV32IM-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    lw a4, 4(a0)
 ; RV32IM-NEXT:    lui a5, 16
 ; RV32IM-NEXT:    lw a0, 8(a0)
-; RV32IM-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    lw a0, 12(a1)
-; RV32IM-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    addi s0, a5, -256
 ; RV32IM-NEXT:    srli a6, a4, 8
 ; RV32IM-NEXT:    srli a7, a4, 24
@@ -6216,9 +6216,9 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    and t0, t0, t4
 ; RV32IM-NEXT:    slli t0, t0, 4
 ; RV32IM-NEXT:    lw a1, 8(s3)
-; RV32IM-NEXT:    sw a1, 64(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 36(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    lw a1, 12(s3)
-; RV32IM-NEXT:    sw a1, 56(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 32(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or t0, t2, t0
 ; RV32IM-NEXT:    srli t2, t0, 2
 ; RV32IM-NEXT:    srli t3, t1, 8
@@ -6276,7 +6276,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    or t1, t1, t0
 ; RV32IM-NEXT:    addi s8, t2, 273
 ; RV32IM-NEXT:    srli t2, t1, 1
-; RV32IM-NEXT:    sw a0, 104(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and t2, t2, a0
 ; RV32IM-NEXT:    and t1, t1, a0
 ; RV32IM-NEXT:    slli t1, t1, 1
@@ -6366,7 +6366,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    srli a3, a0, 2
 ; RV32IM-NEXT:    or a1, a1, a2
 ; RV32IM-NEXT:    srli a2, a1, 1
-; RV32IM-NEXT:    lw s6, 104(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s6, 24(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, s6
 ; RV32IM-NEXT:    and a2, a2, s6
 ; RV32IM-NEXT:    slli a1, a1, 1
@@ -6385,12 +6385,12 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    srli a3, a0, 1
 ; RV32IM-NEXT:    lui a1, 349525
 ; RV32IM-NEXT:    addi a1, a1, 1364
-; RV32IM-NEXT:    sw a1, 100(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 48(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a0, a0, s6
 ; RV32IM-NEXT:    and a3, a3, a1
 ; RV32IM-NEXT:    slli a0, a0, 1
 ; RV32IM-NEXT:    or a0, a3, a0
-; RV32IM-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 96(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a0, a7, a6
 ; RV32IM-NEXT:    and ra, s5, t1
 ; RV32IM-NEXT:    and a3, a2, t3
@@ -6404,14 +6404,14 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    mul s8, a2, s1
 ; RV32IM-NEXT:    mul s9, a4, s1
 ; RV32IM-NEXT:    mv s5, s1
-; RV32IM-NEXT:    sw s1, 36(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s1, 92(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul s10, a5, a1
 ; RV32IM-NEXT:    mv s1, a1
-; RV32IM-NEXT:    sw a1, 48(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    sw s2, 32(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s2, 88(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul s11, a3, s2
 ; RV32IM-NEXT:    mv a1, ra
-; RV32IM-NEXT:    sw ra, 44(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw ra, 28(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul ra, a2, ra
 ; RV32IM-NEXT:    mul a4, a4, s1
 ; RV32IM-NEXT:    mul a5, a5, a1
@@ -6420,7 +6420,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    xor a6, a6, a7
 ; RV32IM-NEXT:    xor a7, t5, t0
 ; RV32IM-NEXT:    xor t0, s7, s8
-; RV32IM-NEXT:    lw a1, 60(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    lw t5, 0(a1)
 ; RV32IM-NEXT:    xor a0, a0, a6
 ; RV32IM-NEXT:    xor a6, a7, t0
@@ -6430,7 +6430,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    xor a4, a5, a4
 ; RV32IM-NEXT:    xor a2, a3, a2
 ; RV32IM-NEXT:    srli a3, t5, 8
-; RV32IM-NEXT:    sw s0, 84(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s0, 56(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a3, a3, s0
 ; RV32IM-NEXT:    srli a5, t5, 24
 ; RV32IM-NEXT:    or a3, a3, a5
@@ -6439,17 +6439,17 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    slli t5, t5, 24
 ; RV32IM-NEXT:    or a5, t5, a5
 ; RV32IM-NEXT:    and a0, a0, t2
-; RV32IM-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    and a0, a6, s3
 ; RV32IM-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    and a0, a6, s3
+; RV32IM-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a3, a5, a3
 ; RV32IM-NEXT:    srli a5, a3, 4
-; RV32IM-NEXT:    sw t4, 88(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t4, 60(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a3, a3, t4
 ; RV32IM-NEXT:    and a5, a5, t4
 ; RV32IM-NEXT:    slli a3, a3, 4
 ; RV32IM-NEXT:    and a0, a7, t3
-; RV32IM-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a3, a5, a3
 ; RV32IM-NEXT:    srli a5, a3, 2
 ; RV32IM-NEXT:    and a3, a3, s4
@@ -6463,7 +6463,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    slli a3, a3, 1
 ; RV32IM-NEXT:    mv t4, t1
 ; RV32IM-NEXT:    and a0, a2, t1
-; RV32IM-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a3, a4, a3
 ; RV32IM-NEXT:    and a4, a3, s3
 ; RV32IM-NEXT:    mv s0, t2
@@ -6471,10 +6471,10 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    and a6, a3, t1
 ; RV32IM-NEXT:    and a3, a3, t3
 ; RV32IM-NEXT:    and s10, t6, t2
-; RV32IM-NEXT:    sw t2, 96(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t2, 44(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and s9, t6, s3
 ; RV32IM-NEXT:    and s8, t6, t3
-; RV32IM-NEXT:    sw t3, 92(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t3, 64(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and s7, t6, t1
 ; RV32IM-NEXT:    mul s5, s7, a3
 ; RV32IM-NEXT:    mul s2, s8, a3
@@ -6492,11 +6492,11 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    mul a3, s8, a4
 ; RV32IM-NEXT:    mul a5, s8, a5
 ; RV32IM-NEXT:    mul a4, s7, a4
-; RV32IM-NEXT:    lw s11, 60(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s6, 20(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s11, 20(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s6, 76(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    or s11, s6, s11
-; RV32IM-NEXT:    lw s6, 16(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s6, 72(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw ra, 68(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    or s6, s6, ra
 ; RV32IM-NEXT:    xor t5, t6, t5
 ; RV32IM-NEXT:    xor a7, a7, s5
@@ -6519,12 +6519,12 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    or a1, a1, a3
 ; RV32IM-NEXT:    or a2, s11, s6
 ; RV32IM-NEXT:    or a0, a0, a1
-; RV32IM-NEXT:    lw a1, 40(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a1, 96(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a1, a1, 1
 ; RV32IM-NEXT:    xor a0, a0, a2
 ; RV32IM-NEXT:    xor a0, a1, a0
 ; RV32IM-NEXT:    srli a1, a0, 8
-; RV32IM-NEXT:    lw s0, 84(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s0, 56(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, s0
 ; RV32IM-NEXT:    srli a2, a0, 24
 ; RV32IM-NEXT:    and a3, a0, s0
@@ -6534,7 +6534,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    or a0, a0, a3
 ; RV32IM-NEXT:    or a0, a0, a1
 ; RV32IM-NEXT:    srli a1, a0, 4
-; RV32IM-NEXT:    lw ra, 88(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw ra, 60(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a0, a0, ra
 ; RV32IM-NEXT:    and a1, a1, ra
 ; RV32IM-NEXT:    slli a0, a0, 4
@@ -6543,13 +6543,13 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    and a0, a0, s4
 ; RV32IM-NEXT:    and a1, a1, s4
 ; RV32IM-NEXT:    slli a0, a0, 2
-; RV32IM-NEXT:    lw t3, 32(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t3, 88(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a2, s10, t3
-; RV32IM-NEXT:    lw s1, 36(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s1, 92(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a3, s9, s1
-; RV32IM-NEXT:    lw t6, 44(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t6, 28(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a4, s8, t6
-; RV32IM-NEXT:    lw s2, 48(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s2, 12(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a5, s7, s2
 ; RV32IM-NEXT:    mul a6, s10, t6
 ; RV32IM-NEXT:    mul a7, s9, t3
@@ -6557,13 +6557,13 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    mul t1, s7, s1
 ; RV32IM-NEXT:    or a0, a1, a0
 ; RV32IM-NEXT:    srli a1, a0, 1
-; RV32IM-NEXT:    lw s11, 104(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s11, 24(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a0, a0, s11
-; RV32IM-NEXT:    lw t2, 100(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t2, 48(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, t2
 ; RV32IM-NEXT:    slli a0, a0, 1
 ; RV32IM-NEXT:    or a0, a1, a0
-; RV32IM-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a2, a3, a2
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    xor a1, a7, a6
@@ -6572,7 +6572,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    mul a6, s9, s2
 ; RV32IM-NEXT:    xor a2, a2, a4
 ; RV32IM-NEXT:    xor s6, a1, a3
-; RV32IM-NEXT:    lw a7, 52(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a7, 16(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a1, a7, 8
 ; RV32IM-NEXT:    and a3, a7, s0
 ; RV32IM-NEXT:    and a1, a1, s0
@@ -6621,7 +6621,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    and a1, a1, ra
 ; RV32IM-NEXT:    and a3, a3, ra
 ; RV32IM-NEXT:    slli a3, a3, 4
-; RV32IM-NEXT:    lw a6, 56(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a6, 32(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a4, a6, 8
 ; RV32IM-NEXT:    or a1, a1, a3
 ; RV32IM-NEXT:    and a3, a4, s0
@@ -6651,7 +6651,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    slli a3, a3, 1
 ; RV32IM-NEXT:    slli a1, a1, 2
 ; RV32IM-NEXT:    or a7, a4, a3
-; RV32IM-NEXT:    sw a7, 56(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a7, 32(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a1, a5, a1
 ; RV32IM-NEXT:    srli a3, a7, 8
 ; RV32IM-NEXT:    srli a4, a1, 1
@@ -6685,11 +6685,11 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    or a3, a5, a3
 ; RV32IM-NEXT:    mv s8, s5
 ; RV32IM-NEXT:    and s5, a1, s5
-; RV32IM-NEXT:    lw s11, 96(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s11, 44(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a3, s11
 ; RV32IM-NEXT:    and a5, a1, s11
 ; RV32IM-NEXT:    and a6, a1, t4
-; RV32IM-NEXT:    lw s4, 92(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s4, 64(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, s4
 ; RV32IM-NEXT:    and a7, a3, s8
 ; RV32IM-NEXT:    and t0, a3, s4
@@ -6761,7 +6761,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    or a1, a1, a6
 ; RV32IM-NEXT:    mv a2, ra
 ; RV32IM-NEXT:    and a4, a4, ra
-; RV32IM-NEXT:    sw a4, 52(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a4, 16(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a1, a1, a5
 ; RV32IM-NEXT:    srli a4, a1, 4
 ; RV32IM-NEXT:    and a1, a1, ra
@@ -6770,10 +6770,10 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    and s4, a3, ra
 ; RV32IM-NEXT:    or a1, a4, a1
 ; RV32IM-NEXT:    slli s4, s4, 4
-; RV32IM-NEXT:    sw s4, 48(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s4, 12(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srli a3, a1, 2
 ; RV32IM-NEXT:    and a3, a3, s3
-; RV32IM-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a4, a0, 8
 ; RV32IM-NEXT:    and a1, a1, s3
 ; RV32IM-NEXT:    and a4, a4, s0
@@ -6792,7 +6792,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    or a1, a3, a1
 ; RV32IM-NEXT:    or a4, a5, a4
 ; RV32IM-NEXT:    srli a3, a4, 2
-; RV32IM-NEXT:    sw s3, 28(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s3, 84(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a4, a4, s3
 ; RV32IM-NEXT:    and a3, a3, s3
 ; RV32IM-NEXT:    slli a4, a4, 2
@@ -6811,7 +6811,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    and a6, a3, s8
 ; RV32IM-NEXT:    mul a7, a4, t5
 ; RV32IM-NEXT:    mul t0, a6, s3
-; RV32IM-NEXT:    sw s10, 80(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s10, 52(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and s2, t6, s10
 ; RV32IM-NEXT:    and t1, a3, t2
 ; RV32IM-NEXT:    and s1, t6, t2
@@ -6826,17 +6826,17 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    mul s9, a4, s3
 ; RV32IM-NEXT:    mul s10, a6, s1
 ; RV32IM-NEXT:    mul s11, t1, t5
-; RV32IM-NEXT:    sw t5, 64(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t5, 36(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul ra, a3, s2
-; RV32IM-NEXT:    lw a0, 100(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a5, a5, a0
 ; RV32IM-NEXT:    slli a1, a1, 1
-; RV32IM-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw s5, 48(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s5, 12(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    or a0, a0, s5
-; RV32IM-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a1, a5, a1
-; RV32IM-NEXT:    sw a1, 48(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a1, t0, a7
 ; RV32IM-NEXT:    xor a5, t2, t3
 ; RV32IM-NEXT:    xor a7, s6, t4
@@ -6848,7 +6848,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    xor a7, a7, t0
 ; RV32IM-NEXT:    mul a4, a4, s1
 ; RV32IM-NEXT:    mul a6, a6, s2
-; RV32IM-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli t0, a0, 8
 ; RV32IM-NEXT:    and t0, t0, s0
 ; RV32IM-NEXT:    srli t2, a0, 24
@@ -6859,12 +6859,12 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    slli t2, t2, 8
 ; RV32IM-NEXT:    slli t3, a0, 24
 ; RV32IM-NEXT:    or t2, t3, t2
-; RV32IM-NEXT:    lw s5, 96(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s5, 44(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a0, a1, s5
-; RV32IM-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and s8, a5, s4
 ; RV32IM-NEXT:    and a0, a7, t6
-; RV32IM-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a1, a6, a4
 ; RV32IM-NEXT:    or a4, t2, t0
 ; RV32IM-NEXT:    srli a5, a4, 4
@@ -6874,29 +6874,29 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    xor a3, t1, a3
 ; RV32IM-NEXT:    or a4, a5, a4
 ; RV32IM-NEXT:    srli a5, a4, 2
-; RV32IM-NEXT:    lw s9, 28(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s9, 84(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, s9
 ; RV32IM-NEXT:    and a5, a5, s9
 ; RV32IM-NEXT:    slli a4, a4, 2
 ; RV32IM-NEXT:    xor a1, a1, a3
 ; RV32IM-NEXT:    or a4, a5, a4
 ; RV32IM-NEXT:    srli a3, a4, 1
-; RV32IM-NEXT:    lw a0, 104(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, a0
 ; RV32IM-NEXT:    and a3, a3, a0
 ; RV32IM-NEXT:    slli a4, a4, 1
-; RV32IM-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s7, a1, a0
 ; RV32IM-NEXT:    or a3, a3, a4
 ; RV32IM-NEXT:    mv t1, s4
 ; RV32IM-NEXT:    and a4, a3, s4
-; RV32IM-NEXT:    lw a2, 56(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a2, 32(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and t4, a2, s5
 ; RV32IM-NEXT:    and a5, a3, s5
 ; RV32IM-NEXT:    and a6, a3, a0
 ; RV32IM-NEXT:    and a3, a3, t6
 ; RV32IM-NEXT:    and s6, a2, s4
-; RV32IM-NEXT:    sw s4, 24(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s4, 80(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and s4, a2, t6
 ; RV32IM-NEXT:    and t6, a2, a0
 ; RV32IM-NEXT:    mul s5, t6, a3
@@ -6915,9 +6915,9 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    mul a2, s4, a4
 ; RV32IM-NEXT:    mul a5, s4, a5
 ; RV32IM-NEXT:    mul a4, t6, a4
-; RV32IM-NEXT:    lw s0, 68(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s0, 40(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    or s8, s8, s0
-; RV32IM-NEXT:    lw s0, 44(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s0, 28(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    or s7, s0, s7
 ; RV32IM-NEXT:    xor t2, t3, t2
 ; RV32IM-NEXT:    xor t3, s10, s5
@@ -6931,27 +6931,27 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    xor a4, a5, a4
 ; RV32IM-NEXT:    xor a1, a1, a2
 ; RV32IM-NEXT:    xor a3, a3, a4
-; RV32IM-NEXT:    lw s11, 96(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s11, 44(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a2, t0, s11
 ; RV32IM-NEXT:    and a0, a0, t1
-; RV32IM-NEXT:    lw ra, 92(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw ra, 64(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, ra
-; RV32IM-NEXT:    lw s10, 80(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s10, 52(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a3, a3, s10
 ; RV32IM-NEXT:    or a0, a0, a2
 ; RV32IM-NEXT:    or a1, a1, a3
 ; RV32IM-NEXT:    or a2, s8, s7
 ; RV32IM-NEXT:    or a0, a0, a1
-; RV32IM-NEXT:    lw a1, 48(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a1, a1, 1
 ; RV32IM-NEXT:    xor a0, a0, a2
-; RV32IM-NEXT:    lw a3, 52(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 16(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a2, a3, 2
 ; RV32IM-NEXT:    xor a0, a1, a0
 ; RV32IM-NEXT:    and a1, a2, s9
 ; RV32IM-NEXT:    srli a2, a0, 8
 ; RV32IM-NEXT:    and a3, a3, s9
-; RV32IM-NEXT:    lw s7, 84(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s7, 56(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a2, a2, s7
 ; RV32IM-NEXT:    srli a4, a0, 24
 ; RV32IM-NEXT:    and a5, a0, s7
@@ -6961,13 +6961,13 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    or a0, a0, a5
 ; RV32IM-NEXT:    slli a3, a3, 2
 ; RV32IM-NEXT:    or a0, a0, a2
-; RV32IM-NEXT:    lw t5, 64(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t5, 36(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a4, t4, t5
 ; RV32IM-NEXT:    mul a5, s6, s3
 ; RV32IM-NEXT:    mul a6, s4, s2
 ; RV32IM-NEXT:    mul a7, t6, s1
 ; RV32IM-NEXT:    srli a2, a0, 4
-; RV32IM-NEXT:    lw s5, 88(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s5, 60(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a0, a0, s5
 ; RV32IM-NEXT:    and t0, a2, s5
 ; RV32IM-NEXT:    slli a0, a0, 4
@@ -6992,7 +6992,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    xor a1, a1, a3
 ; RV32IM-NEXT:    and a3, a4, s11
-; RV32IM-NEXT:    lw a4, 24(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 80(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, a4
 ; RV32IM-NEXT:    xor a4, a7, a6
 ; RV32IM-NEXT:    xor a5, t2, t3
@@ -7018,7 +7018,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    slli a5, a5, 8
 ; RV32IM-NEXT:    or a3, a3, a4
 ; RV32IM-NEXT:    or a1, a1, a5
-; RV32IM-NEXT:    lw a4, 60(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 20(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a4, a4, 1
 ; RV32IM-NEXT:    or a1, a1, a3
 ; RV32IM-NEXT:    srli a3, a1, 4
@@ -7027,14 +7027,14 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    slli a1, a1, 4
 ; RV32IM-NEXT:    srli a5, a0, 1
 ; RV32IM-NEXT:    or a1, a3, a1
-; RV32IM-NEXT:    lw a3, 100(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 48(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a3, a5, a3
 ; RV32IM-NEXT:    srli a5, a1, 2
 ; RV32IM-NEXT:    srli a6, a2, 1
 ; RV32IM-NEXT:    and a5, a5, s9
 ; RV32IM-NEXT:    and a1, a1, s9
 ; RV32IM-NEXT:    slli a7, a6, 31
-; RV32IM-NEXT:    lw t0, 104(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t0, 24(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a0, a0, t0
 ; RV32IM-NEXT:    slli a1, a1, 2
 ; RV32IM-NEXT:    slli a0, a0, 1
@@ -7055,12 +7055,12 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    or a1, a3, a1
 ; RV32IM-NEXT:    srli a2, a2, 1
 ; RV32IM-NEXT:    srli a1, a1, 1
-; RV32IM-NEXT:    lw a3, 72(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 100(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    sw a4, 0(a3)
 ; RV32IM-NEXT:    sw a2, 4(a3)
 ; RV32IM-NEXT:    sw a0, 8(a3)
 ; RV32IM-NEXT:    sw a1, 12(a3)
-; RV32IM-NEXT:    lw a3, 76(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 104(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    sw a4, 0(a3)
 ; RV32IM-NEXT:    sw a2, 4(a3)
 ; RV32IM-NEXT:    sw a0, 8(a3)
@@ -7478,17 +7478,17 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    sw s9, 116(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    sw s10, 112(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    sw s11, 108(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    sw a3, 76(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    sw a2, 72(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a3, 104(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a2, 100(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mv s3, a1
 ; RV32IMZBS-NEXT:    mv a1, a0
-; RV32IMZBS-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    lw a4, 4(a0)
 ; RV32IMZBS-NEXT:    lui a5, 16
 ; RV32IMZBS-NEXT:    lw a0, 8(a0)
-; RV32IMZBS-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    lw a0, 12(a1)
-; RV32IMZBS-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    addi s0, a5, -256
 ; RV32IMZBS-NEXT:    srli a6, a4, 8
 ; RV32IMZBS-NEXT:    srli a7, a4, 24
@@ -7535,9 +7535,9 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    and t0, t0, t4
 ; RV32IMZBS-NEXT:    slli t0, t0, 4
 ; RV32IMZBS-NEXT:    lw a1, 8(s3)
-; RV32IMZBS-NEXT:    sw a1, 64(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 36(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    lw a1, 12(s3)
-; RV32IMZBS-NEXT:    sw a1, 56(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 32(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or t0, t2, t0
 ; RV32IMZBS-NEXT:    srli t2, t0, 2
 ; RV32IMZBS-NEXT:    srli t3, t1, 8
@@ -7595,7 +7595,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    or t1, t1, t0
 ; RV32IMZBS-NEXT:    addi s8, t2, 273
 ; RV32IMZBS-NEXT:    srli t2, t1, 1
-; RV32IMZBS-NEXT:    sw a0, 104(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and t2, t2, a0
 ; RV32IMZBS-NEXT:    and t1, t1, a0
 ; RV32IMZBS-NEXT:    slli t1, t1, 1
@@ -7685,7 +7685,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    srli a3, a0, 2
 ; RV32IMZBS-NEXT:    or a1, a1, a2
 ; RV32IMZBS-NEXT:    srli a2, a1, 1
-; RV32IMZBS-NEXT:    lw s6, 104(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s6, 24(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, s6
 ; RV32IMZBS-NEXT:    and a2, a2, s6
 ; RV32IMZBS-NEXT:    slli a1, a1, 1
@@ -7704,12 +7704,12 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    srli a3, a0, 1
 ; RV32IMZBS-NEXT:    lui a1, 349525
 ; RV32IMZBS-NEXT:    addi a1, a1, 1364
-; RV32IMZBS-NEXT:    sw a1, 100(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 48(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a0, a0, s6
 ; RV32IMZBS-NEXT:    and a3, a3, a1
 ; RV32IMZBS-NEXT:    slli a0, a0, 1
 ; RV32IMZBS-NEXT:    or a0, a3, a0
-; RV32IMZBS-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 96(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a0, a7, a6
 ; RV32IMZBS-NEXT:    and ra, s5, t1
 ; RV32IMZBS-NEXT:    and a3, a2, t3
@@ -7723,14 +7723,14 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    mul s8, a2, s1
 ; RV32IMZBS-NEXT:    mul s9, a4, s1
 ; RV32IMZBS-NEXT:    mv s5, s1
-; RV32IMZBS-NEXT:    sw s1, 36(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s1, 92(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul s10, a5, a1
 ; RV32IMZBS-NEXT:    mv s1, a1
-; RV32IMZBS-NEXT:    sw a1, 48(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    sw s2, 32(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s2, 88(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul s11, a3, s2
 ; RV32IMZBS-NEXT:    mv a1, ra
-; RV32IMZBS-NEXT:    sw ra, 44(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw ra, 28(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul ra, a2, ra
 ; RV32IMZBS-NEXT:    mul a4, a4, s1
 ; RV32IMZBS-NEXT:    mul a5, a5, a1
@@ -7739,7 +7739,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    xor a6, a6, a7
 ; RV32IMZBS-NEXT:    xor a7, t5, t0
 ; RV32IMZBS-NEXT:    xor t0, s7, s8
-; RV32IMZBS-NEXT:    lw a1, 60(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    lw t5, 0(a1)
 ; RV32IMZBS-NEXT:    xor a0, a0, a6
 ; RV32IMZBS-NEXT:    xor a6, a7, t0
@@ -7749,7 +7749,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    xor a4, a5, a4
 ; RV32IMZBS-NEXT:    xor a2, a3, a2
 ; RV32IMZBS-NEXT:    srli a3, t5, 8
-; RV32IMZBS-NEXT:    sw s0, 84(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s0, 56(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a3, a3, s0
 ; RV32IMZBS-NEXT:    srli a5, t5, 24
 ; RV32IMZBS-NEXT:    or a3, a3, a5
@@ -7758,17 +7758,17 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    slli t5, t5, 24
 ; RV32IMZBS-NEXT:    or a5, t5, a5
 ; RV32IMZBS-NEXT:    and a0, a0, t2
-; RV32IMZBS-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    and a0, a6, s3
 ; RV32IMZBS-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    and a0, a6, s3
+; RV32IMZBS-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a3, a5, a3
 ; RV32IMZBS-NEXT:    srli a5, a3, 4
-; RV32IMZBS-NEXT:    sw t4, 88(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t4, 60(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a3, a3, t4
 ; RV32IMZBS-NEXT:    and a5, a5, t4
 ; RV32IMZBS-NEXT:    slli a3, a3, 4
 ; RV32IMZBS-NEXT:    and a0, a7, t3
-; RV32IMZBS-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a3, a5, a3
 ; RV32IMZBS-NEXT:    srli a5, a3, 2
 ; RV32IMZBS-NEXT:    and a3, a3, s4
@@ -7782,7 +7782,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    slli a3, a3, 1
 ; RV32IMZBS-NEXT:    mv t4, t1
 ; RV32IMZBS-NEXT:    and a0, a2, t1
-; RV32IMZBS-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a3, a4, a3
 ; RV32IMZBS-NEXT:    and a4, a3, s3
 ; RV32IMZBS-NEXT:    mv s0, t2
@@ -7790,10 +7790,10 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    and a6, a3, t1
 ; RV32IMZBS-NEXT:    and a3, a3, t3
 ; RV32IMZBS-NEXT:    and s10, t6, t2
-; RV32IMZBS-NEXT:    sw t2, 96(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t2, 44(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and s9, t6, s3
 ; RV32IMZBS-NEXT:    and s8, t6, t3
-; RV32IMZBS-NEXT:    sw t3, 92(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t3, 64(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and s7, t6, t1
 ; RV32IMZBS-NEXT:    mul s5, s7, a3
 ; RV32IMZBS-NEXT:    mul s2, s8, a3
@@ -7811,11 +7811,11 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    mul a3, s8, a4
 ; RV32IMZBS-NEXT:    mul a5, s8, a5
 ; RV32IMZBS-NEXT:    mul a4, s7, a4
-; RV32IMZBS-NEXT:    lw s11, 60(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s6, 20(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s11, 20(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s6, 76(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    or s11, s6, s11
-; RV32IMZBS-NEXT:    lw s6, 16(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s6, 72(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw ra, 68(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    or s6, s6, ra
 ; RV32IMZBS-NEXT:    xor t5, t6, t5
 ; RV32IMZBS-NEXT:    xor a7, a7, s5
@@ -7838,12 +7838,12 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    or a1, a1, a3
 ; RV32IMZBS-NEXT:    or a2, s11, s6
 ; RV32IMZBS-NEXT:    or a0, a0, a1
-; RV32IMZBS-NEXT:    lw a1, 40(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a1, 96(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a1, a1, 1
 ; RV32IMZBS-NEXT:    xor a0, a0, a2
 ; RV32IMZBS-NEXT:    xor a0, a1, a0
 ; RV32IMZBS-NEXT:    srli a1, a0, 8
-; RV32IMZBS-NEXT:    lw s0, 84(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s0, 56(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, s0
 ; RV32IMZBS-NEXT:    srli a2, a0, 24
 ; RV32IMZBS-NEXT:    and a3, a0, s0
@@ -7853,7 +7853,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    or a0, a0, a3
 ; RV32IMZBS-NEXT:    or a0, a0, a1
 ; RV32IMZBS-NEXT:    srli a1, a0, 4
-; RV32IMZBS-NEXT:    lw ra, 88(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw ra, 60(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a0, a0, ra
 ; RV32IMZBS-NEXT:    and a1, a1, ra
 ; RV32IMZBS-NEXT:    slli a0, a0, 4
@@ -7862,13 +7862,13 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    and a0, a0, s4
 ; RV32IMZBS-NEXT:    and a1, a1, s4
 ; RV32IMZBS-NEXT:    slli a0, a0, 2
-; RV32IMZBS-NEXT:    lw t3, 32(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t3, 88(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a2, s10, t3
-; RV32IMZBS-NEXT:    lw s1, 36(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s1, 92(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a3, s9, s1
-; RV32IMZBS-NEXT:    lw t6, 44(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t6, 28(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a4, s8, t6
-; RV32IMZBS-NEXT:    lw s2, 48(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s2, 12(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a5, s7, s2
 ; RV32IMZBS-NEXT:    mul a6, s10, t6
 ; RV32IMZBS-NEXT:    mul a7, s9, t3
@@ -7876,13 +7876,13 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    mul t1, s7, s1
 ; RV32IMZBS-NEXT:    or a0, a1, a0
 ; RV32IMZBS-NEXT:    srli a1, a0, 1
-; RV32IMZBS-NEXT:    lw s11, 104(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s11, 24(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a0, a0, s11
-; RV32IMZBS-NEXT:    lw t2, 100(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t2, 48(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, t2
 ; RV32IMZBS-NEXT:    slli a0, a0, 1
 ; RV32IMZBS-NEXT:    or a0, a1, a0
-; RV32IMZBS-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a2, a3, a2
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    xor a1, a7, a6
@@ -7891,7 +7891,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    mul a6, s9, s2
 ; RV32IMZBS-NEXT:    xor a2, a2, a4
 ; RV32IMZBS-NEXT:    xor s6, a1, a3
-; RV32IMZBS-NEXT:    lw a7, 52(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a7, 16(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a1, a7, 8
 ; RV32IMZBS-NEXT:    and a3, a7, s0
 ; RV32IMZBS-NEXT:    and a1, a1, s0
@@ -7940,7 +7940,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    and a1, a1, ra
 ; RV32IMZBS-NEXT:    and a3, a3, ra
 ; RV32IMZBS-NEXT:    slli a3, a3, 4
-; RV32IMZBS-NEXT:    lw a6, 56(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a6, 32(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a4, a6, 8
 ; RV32IMZBS-NEXT:    or a1, a1, a3
 ; RV32IMZBS-NEXT:    and a3, a4, s0
@@ -7970,7 +7970,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    slli a3, a3, 1
 ; RV32IMZBS-NEXT:    slli a1, a1, 2
 ; RV32IMZBS-NEXT:    or a7, a4, a3
-; RV32IMZBS-NEXT:    sw a7, 56(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a7, 32(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a1, a5, a1
 ; RV32IMZBS-NEXT:    srli a3, a7, 8
 ; RV32IMZBS-NEXT:    srli a4, a1, 1
@@ -8004,11 +8004,11 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    or a3, a5, a3
 ; RV32IMZBS-NEXT:    mv s8, s5
 ; RV32IMZBS-NEXT:    and s5, a1, s5
-; RV32IMZBS-NEXT:    lw s11, 96(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s11, 44(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a3, s11
 ; RV32IMZBS-NEXT:    and a5, a1, s11
 ; RV32IMZBS-NEXT:    and a6, a1, t4
-; RV32IMZBS-NEXT:    lw s4, 92(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s4, 64(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, s4
 ; RV32IMZBS-NEXT:    and a7, a3, s8
 ; RV32IMZBS-NEXT:    and t0, a3, s4
@@ -8080,7 +8080,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    or a1, a1, a6
 ; RV32IMZBS-NEXT:    mv a2, ra
 ; RV32IMZBS-NEXT:    and a4, a4, ra
-; RV32IMZBS-NEXT:    sw a4, 52(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a4, 16(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a1, a1, a5
 ; RV32IMZBS-NEXT:    srli a4, a1, 4
 ; RV32IMZBS-NEXT:    and a1, a1, ra
@@ -8089,10 +8089,10 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    and s4, a3, ra
 ; RV32IMZBS-NEXT:    or a1, a4, a1
 ; RV32IMZBS-NEXT:    slli s4, s4, 4
-; RV32IMZBS-NEXT:    sw s4, 48(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s4, 12(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srli a3, a1, 2
 ; RV32IMZBS-NEXT:    and a3, a3, s3
-; RV32IMZBS-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a4, a0, 8
 ; RV32IMZBS-NEXT:    and a1, a1, s3
 ; RV32IMZBS-NEXT:    and a4, a4, s0
@@ -8111,7 +8111,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    or a1, a3, a1
 ; RV32IMZBS-NEXT:    or a4, a5, a4
 ; RV32IMZBS-NEXT:    srli a3, a4, 2
-; RV32IMZBS-NEXT:    sw s3, 28(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s3, 84(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a4, a4, s3
 ; RV32IMZBS-NEXT:    and a3, a3, s3
 ; RV32IMZBS-NEXT:    slli a4, a4, 2
@@ -8130,7 +8130,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    and a6, a3, s8
 ; RV32IMZBS-NEXT:    mul a7, a4, t5
 ; RV32IMZBS-NEXT:    mul t0, a6, s3
-; RV32IMZBS-NEXT:    sw s10, 80(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s10, 52(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and s2, t6, s10
 ; RV32IMZBS-NEXT:    and t1, a3, t2
 ; RV32IMZBS-NEXT:    and s1, t6, t2
@@ -8145,17 +8145,17 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    mul s9, a4, s3
 ; RV32IMZBS-NEXT:    mul s10, a6, s1
 ; RV32IMZBS-NEXT:    mul s11, t1, t5
-; RV32IMZBS-NEXT:    sw t5, 64(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t5, 36(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul ra, a3, s2
-; RV32IMZBS-NEXT:    lw a0, 100(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a5, a5, a0
 ; RV32IMZBS-NEXT:    slli a1, a1, 1
-; RV32IMZBS-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw s5, 48(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s5, 12(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    or a0, a0, s5
-; RV32IMZBS-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a1, a5, a1
-; RV32IMZBS-NEXT:    sw a1, 48(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a1, t0, a7
 ; RV32IMZBS-NEXT:    xor a5, t2, t3
 ; RV32IMZBS-NEXT:    xor a7, s6, t4
@@ -8167,7 +8167,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    xor a7, a7, t0
 ; RV32IMZBS-NEXT:    mul a4, a4, s1
 ; RV32IMZBS-NEXT:    mul a6, a6, s2
-; RV32IMZBS-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli t0, a0, 8
 ; RV32IMZBS-NEXT:    and t0, t0, s0
 ; RV32IMZBS-NEXT:    srli t2, a0, 24
@@ -8178,12 +8178,12 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    slli t2, t2, 8
 ; RV32IMZBS-NEXT:    slli t3, a0, 24
 ; RV32IMZBS-NEXT:    or t2, t3, t2
-; RV32IMZBS-NEXT:    lw s5, 96(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s5, 44(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a0, a1, s5
-; RV32IMZBS-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and s8, a5, s4
 ; RV32IMZBS-NEXT:    and a0, a7, t6
-; RV32IMZBS-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a1, a6, a4
 ; RV32IMZBS-NEXT:    or a4, t2, t0
 ; RV32IMZBS-NEXT:    srli a5, a4, 4
@@ -8193,29 +8193,29 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    xor a3, t1, a3
 ; RV32IMZBS-NEXT:    or a4, a5, a4
 ; RV32IMZBS-NEXT:    srli a5, a4, 2
-; RV32IMZBS-NEXT:    lw s9, 28(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s9, 84(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, s9
 ; RV32IMZBS-NEXT:    and a5, a5, s9
 ; RV32IMZBS-NEXT:    slli a4, a4, 2
 ; RV32IMZBS-NEXT:    xor a1, a1, a3
 ; RV32IMZBS-NEXT:    or a4, a5, a4
 ; RV32IMZBS-NEXT:    srli a3, a4, 1
-; RV32IMZBS-NEXT:    lw a0, 104(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, a0
 ; RV32IMZBS-NEXT:    and a3, a3, a0
 ; RV32IMZBS-NEXT:    slli a4, a4, 1
-; RV32IMZBS-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s7, a1, a0
 ; RV32IMZBS-NEXT:    or a3, a3, a4
 ; RV32IMZBS-NEXT:    mv t1, s4
 ; RV32IMZBS-NEXT:    and a4, a3, s4
-; RV32IMZBS-NEXT:    lw a2, 56(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a2, 32(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and t4, a2, s5
 ; RV32IMZBS-NEXT:    and a5, a3, s5
 ; RV32IMZBS-NEXT:    and a6, a3, a0
 ; RV32IMZBS-NEXT:    and a3, a3, t6
 ; RV32IMZBS-NEXT:    and s6, a2, s4
-; RV32IMZBS-NEXT:    sw s4, 24(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s4, 80(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and s4, a2, t6
 ; RV32IMZBS-NEXT:    and t6, a2, a0
 ; RV32IMZBS-NEXT:    mul s5, t6, a3
@@ -8234,9 +8234,9 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    mul a2, s4, a4
 ; RV32IMZBS-NEXT:    mul a5, s4, a5
 ; RV32IMZBS-NEXT:    mul a4, t6, a4
-; RV32IMZBS-NEXT:    lw s0, 68(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s0, 40(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    or s8, s8, s0
-; RV32IMZBS-NEXT:    lw s0, 44(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s0, 28(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    or s7, s0, s7
 ; RV32IMZBS-NEXT:    xor t2, t3, t2
 ; RV32IMZBS-NEXT:    xor t3, s10, s5
@@ -8250,27 +8250,27 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    xor a4, a5, a4
 ; RV32IMZBS-NEXT:    xor a1, a1, a2
 ; RV32IMZBS-NEXT:    xor a3, a3, a4
-; RV32IMZBS-NEXT:    lw s11, 96(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s11, 44(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a2, t0, s11
 ; RV32IMZBS-NEXT:    and a0, a0, t1
-; RV32IMZBS-NEXT:    lw ra, 92(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw ra, 64(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, ra
-; RV32IMZBS-NEXT:    lw s10, 80(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s10, 52(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a3, a3, s10
 ; RV32IMZBS-NEXT:    or a0, a0, a2
 ; RV32IMZBS-NEXT:    or a1, a1, a3
 ; RV32IMZBS-NEXT:    or a2, s8, s7
 ; RV32IMZBS-NEXT:    or a0, a0, a1
-; RV32IMZBS-NEXT:    lw a1, 48(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a1, a1, 1
 ; RV32IMZBS-NEXT:    xor a0, a0, a2
-; RV32IMZBS-NEXT:    lw a3, 52(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 16(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a2, a3, 2
 ; RV32IMZBS-NEXT:    xor a0, a1, a0
 ; RV32IMZBS-NEXT:    and a1, a2, s9
 ; RV32IMZBS-NEXT:    srli a2, a0, 8
 ; RV32IMZBS-NEXT:    and a3, a3, s9
-; RV32IMZBS-NEXT:    lw s7, 84(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s7, 56(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a2, a2, s7
 ; RV32IMZBS-NEXT:    srli a4, a0, 24
 ; RV32IMZBS-NEXT:    and a5, a0, s7
@@ -8280,13 +8280,13 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    or a0, a0, a5
 ; RV32IMZBS-NEXT:    slli a3, a3, 2
 ; RV32IMZBS-NEXT:    or a0, a0, a2
-; RV32IMZBS-NEXT:    lw t5, 64(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t5, 36(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a4, t4, t5
 ; RV32IMZBS-NEXT:    mul a5, s6, s3
 ; RV32IMZBS-NEXT:    mul a6, s4, s2
 ; RV32IMZBS-NEXT:    mul a7, t6, s1
 ; RV32IMZBS-NEXT:    srli a2, a0, 4
-; RV32IMZBS-NEXT:    lw s5, 88(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s5, 60(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a0, a0, s5
 ; RV32IMZBS-NEXT:    and t0, a2, s5
 ; RV32IMZBS-NEXT:    slli a0, a0, 4
@@ -8311,7 +8311,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    xor a1, a1, a3
 ; RV32IMZBS-NEXT:    and a3, a4, s11
-; RV32IMZBS-NEXT:    lw a4, 24(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 80(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, a4
 ; RV32IMZBS-NEXT:    xor a4, a7, a6
 ; RV32IMZBS-NEXT:    xor a5, t2, t3
@@ -8337,7 +8337,7 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    slli a5, a5, 8
 ; RV32IMZBS-NEXT:    or a3, a3, a4
 ; RV32IMZBS-NEXT:    or a1, a1, a5
-; RV32IMZBS-NEXT:    lw a4, 60(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 20(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a4, a4, 1
 ; RV32IMZBS-NEXT:    or a1, a1, a3
 ; RV32IMZBS-NEXT:    srli a3, a1, 4
@@ -8346,14 +8346,14 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    slli a1, a1, 4
 ; RV32IMZBS-NEXT:    srli a5, a0, 1
 ; RV32IMZBS-NEXT:    or a1, a3, a1
-; RV32IMZBS-NEXT:    lw a3, 100(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 48(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a3, a5, a3
 ; RV32IMZBS-NEXT:    srli a5, a1, 2
 ; RV32IMZBS-NEXT:    srli a6, a2, 1
 ; RV32IMZBS-NEXT:    and a5, a5, s9
 ; RV32IMZBS-NEXT:    and a1, a1, s9
 ; RV32IMZBS-NEXT:    slli a7, a6, 31
-; RV32IMZBS-NEXT:    lw t0, 104(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t0, 24(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a0, a0, t0
 ; RV32IMZBS-NEXT:    slli a1, a1, 2
 ; RV32IMZBS-NEXT:    slli a0, a0, 1
@@ -8374,12 +8374,12 @@ define void @commutative_clmulh_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    or a1, a3, a1
 ; RV32IMZBS-NEXT:    srli a2, a2, 1
 ; RV32IMZBS-NEXT:    srli a1, a1, 1
-; RV32IMZBS-NEXT:    lw a3, 72(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 100(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    sw a4, 0(a3)
 ; RV32IMZBS-NEXT:    sw a2, 4(a3)
 ; RV32IMZBS-NEXT:    sw a0, 8(a3)
 ; RV32IMZBS-NEXT:    sw a1, 12(a3)
-; RV32IMZBS-NEXT:    lw a3, 76(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 104(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    sw a4, 0(a3)
 ; RV32IMZBS-NEXT:    sw a2, 4(a3)
 ; RV32IMZBS-NEXT:    sw a0, 8(a3)

--- a/llvm/test/CodeGen/RISCV/clmulr.ll
+++ b/llvm/test/CodeGen/RISCV/clmulr.ll
@@ -2919,13 +2919,13 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    sw s9, 484(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    sw s10, 480(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    sw s11, 476(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    sw a3, 468(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    sw a2, 464(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 472(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 468(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    mv t2, a0
 ; RV32I-NEXT:    lw a2, 4(a1)
 ; RV32I-NEXT:    lui a4, 16
 ; RV32I-NEXT:    lw a0, 8(a1)
-; RV32I-NEXT:    sw a0, 340(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lw s10, 12(a1)
 ; RV32I-NEXT:    addi s8, a4, -256
 ; RV32I-NEXT:    srli a5, a2, 8
@@ -2963,13 +2963,13 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    srli t0, t1, 24
 ; RV32I-NEXT:    and t3, t1, s8
 ; RV32I-NEXT:    slli a3, t1, 24
-; RV32I-NEXT:    sw a3, 472(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 24(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, t3, 8
 ; RV32I-NEXT:    or t0, a2, t0
 ; RV32I-NEXT:    or t3, a3, t3
 ; RV32I-NEXT:    lw t4, 4(t2)
 ; RV32I-NEXT:    lw a2, 8(t2)
-; RV32I-NEXT:    sw a2, 460(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 20(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lw s9, 12(t2)
 ; RV32I-NEXT:    or t0, t3, t0
 ; RV32I-NEXT:    srli t3, t0, 4
@@ -3297,25 +3297,25 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz s0, s0
 ; RV32I-NEXT:    or t6, t0, t6
 ; RV32I-NEXT:    addi a2, s0, -1
-; RV32I-NEXT:    sw a2, 456(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 464(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t0, t6, 1
 ; RV32I-NEXT:    andi s0, t4, 1
 ; RV32I-NEXT:    and t0, a2, t0
 ; RV32I-NEXT:    seqz s0, s0
 ; RV32I-NEXT:    addi a2, s0, -1
-; RV32I-NEXT:    sw a2, 452(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 460(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi s0, t4, 4
 ; RV32I-NEXT:    seqz s0, s0
 ; RV32I-NEXT:    and s1, a2, t6
 ; RV32I-NEXT:    xor t0, s1, t0
 ; RV32I-NEXT:    addi a2, s0, -1
-; RV32I-NEXT:    sw a2, 448(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 456(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s0, t6, 2
 ; RV32I-NEXT:    andi s1, t4, 8
 ; RV32I-NEXT:    and s0, a2, s0
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    addi a2, s1, -1
-; RV32I-NEXT:    sw a2, 444(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 452(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t6, 3
 ; RV32I-NEXT:    and s1, a2, s1
 ; RV32I-NEXT:    andi s2, t4, 16
@@ -3323,20 +3323,20 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz s1, s2
 ; RV32I-NEXT:    xor t0, t0, s0
 ; RV32I-NEXT:    addi a2, s1, -1
-; RV32I-NEXT:    sw a2, 440(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 448(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s0, t6, 4
 ; RV32I-NEXT:    andi s1, t4, 32
 ; RV32I-NEXT:    and s0, a2, s0
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    addi a2, s1, -1
-; RV32I-NEXT:    sw a2, 436(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 444(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t6, 5
 ; RV32I-NEXT:    and s1, a2, s1
 ; RV32I-NEXT:    andi s2, t4, 64
 ; RV32I-NEXT:    xor s0, s0, s1
 ; RV32I-NEXT:    seqz s1, s2
 ; RV32I-NEXT:    addi a2, s1, -1
-; RV32I-NEXT:    sw a2, 432(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 440(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t6, 6
 ; RV32I-NEXT:    and s1, a2, s1
 ; RV32I-NEXT:    andi s2, t4, 128
@@ -3344,27 +3344,27 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz s1, s2
 ; RV32I-NEXT:    xor t0, t0, s0
 ; RV32I-NEXT:    addi a2, s1, -1
-; RV32I-NEXT:    sw a2, 428(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 436(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s0, t6, 7
 ; RV32I-NEXT:    andi s1, t4, 256
 ; RV32I-NEXT:    and s0, a2, s0
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    addi a2, s1, -1
-; RV32I-NEXT:    sw a2, 424(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 432(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t6, 8
 ; RV32I-NEXT:    and s1, a2, s1
 ; RV32I-NEXT:    andi s2, t4, 512
 ; RV32I-NEXT:    xor s0, s0, s1
 ; RV32I-NEXT:    seqz s1, s2
 ; RV32I-NEXT:    addi a2, s1, -1
-; RV32I-NEXT:    sw a2, 420(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 428(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t6, 9
 ; RV32I-NEXT:    and s1, a2, s1
 ; RV32I-NEXT:    andi s2, t4, 1024
 ; RV32I-NEXT:    xor s0, s0, s1
 ; RV32I-NEXT:    seqz s1, s2
 ; RV32I-NEXT:    addi a2, s1, -1
-; RV32I-NEXT:    sw a2, 416(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 424(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t6, 10
 ; RV32I-NEXT:    and s1, a2, s1
 ; RV32I-NEXT:    and s2, t4, s11
@@ -3372,20 +3372,20 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz s1, s2
 ; RV32I-NEXT:    xor t0, t0, s0
 ; RV32I-NEXT:    addi a5, s1, -1
-; RV32I-NEXT:    sw a5, 412(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 420(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s0, t6, 11
 ; RV32I-NEXT:    and s1, t4, a4
 ; RV32I-NEXT:    and s0, a5, s0
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    addi a5, s1, -1
-; RV32I-NEXT:    sw a5, 408(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 416(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t6, 12
 ; RV32I-NEXT:    and s1, a5, s1
 ; RV32I-NEXT:    and s2, t4, a3
 ; RV32I-NEXT:    xor s0, s0, s1
 ; RV32I-NEXT:    seqz s1, s2
 ; RV32I-NEXT:    addi a3, s1, -1
-; RV32I-NEXT:    sw a3, 404(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 412(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t6, 13
 ; RV32I-NEXT:    and s1, a3, s1
 ; RV32I-NEXT:    lui s4, 4
@@ -3393,7 +3393,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    xor s0, s0, s1
 ; RV32I-NEXT:    seqz s1, s2
 ; RV32I-NEXT:    addi a3, s1, -1
-; RV32I-NEXT:    sw a3, 400(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 408(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t6, 14
 ; RV32I-NEXT:    and s1, a3, s1
 ; RV32I-NEXT:    lui s5, 8
@@ -3401,7 +3401,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    xor s0, s0, s1
 ; RV32I-NEXT:    seqz s1, s2
 ; RV32I-NEXT:    addi a3, s1, -1
-; RV32I-NEXT:    sw a3, 396(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 404(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t6, 15
 ; RV32I-NEXT:    and s1, a3, s1
 ; RV32I-NEXT:    and s2, t4, a0
@@ -3409,35 +3409,35 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz s1, s2
 ; RV32I-NEXT:    xor t0, t0, s0
 ; RV32I-NEXT:    addi a3, s1, -1
-; RV32I-NEXT:    sw a3, 392(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 400(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s0, t6, 16
 ; RV32I-NEXT:    lui a0, 32
 ; RV32I-NEXT:    and s1, t4, a0
 ; RV32I-NEXT:    and s0, a3, s0
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    addi a3, s1, -1
-; RV32I-NEXT:    sw a3, 388(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 396(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t6, 17
 ; RV32I-NEXT:    and s1, a3, s1
 ; RV32I-NEXT:    and s2, t4, s6
 ; RV32I-NEXT:    xor s0, s0, s1
 ; RV32I-NEXT:    seqz s1, s2
 ; RV32I-NEXT:    addi a3, s1, -1
-; RV32I-NEXT:    sw a3, 384(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 392(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t6, 18
 ; RV32I-NEXT:    and s1, a3, s1
 ; RV32I-NEXT:    and s2, t4, t5
 ; RV32I-NEXT:    xor s0, s0, s1
 ; RV32I-NEXT:    seqz s1, s2
 ; RV32I-NEXT:    addi a3, s1, -1
-; RV32I-NEXT:    sw a3, 380(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 388(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t6, 19
 ; RV32I-NEXT:    and s1, a3, s1
 ; RV32I-NEXT:    and s2, t4, ra
 ; RV32I-NEXT:    xor s0, s0, s1
 ; RV32I-NEXT:    seqz s1, s2
 ; RV32I-NEXT:    addi a3, s1, -1
-; RV32I-NEXT:    sw a3, 376(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 384(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t6, 20
 ; RV32I-NEXT:    and s1, a3, s1
 ; RV32I-NEXT:    lui a0, 512
@@ -3445,7 +3445,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    xor s0, s0, s1
 ; RV32I-NEXT:    seqz s1, s2
 ; RV32I-NEXT:    addi a3, s1, -1
-; RV32I-NEXT:    sw a3, 372(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 380(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t6, 21
 ; RV32I-NEXT:    and s1, a3, s1
 ; RV32I-NEXT:    lui a0, 1024
@@ -3453,14 +3453,14 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    xor s0, s0, s1
 ; RV32I-NEXT:    seqz s1, s2
 ; RV32I-NEXT:    addi a3, s1, -1
-; RV32I-NEXT:    sw a3, 368(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 376(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui a0, 2048
 ; RV32I-NEXT:    and s1, t4, a0
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    slli s2, t6, 22
 ; RV32I-NEXT:    and s2, a3, s2
 ; RV32I-NEXT:    addi a3, s1, -1
-; RV32I-NEXT:    sw a3, 364(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 372(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s1, t6, 23
 ; RV32I-NEXT:    lui a0, 4096
 ; RV32I-NEXT:    and s3, t4, a0
@@ -3468,7 +3468,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz s3, s3
 ; RV32I-NEXT:    xor s1, s2, s1
 ; RV32I-NEXT:    addi a3, s3, -1
-; RV32I-NEXT:    sw a3, 360(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 368(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s2, t6, 24
 ; RV32I-NEXT:    lui ra, 8192
 ; RV32I-NEXT:    and s3, t4, ra
@@ -3476,7 +3476,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz s3, s3
 ; RV32I-NEXT:    xor s1, s1, s2
 ; RV32I-NEXT:    addi a3, s3, -1
-; RV32I-NEXT:    sw a3, 356(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 364(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s2, t6, 25
 ; RV32I-NEXT:    lui s6, 16384
 ; RV32I-NEXT:    and s3, t4, s6
@@ -3484,7 +3484,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz s3, s3
 ; RV32I-NEXT:    xor s1, s1, s2
 ; RV32I-NEXT:    addi a3, s3, -1
-; RV32I-NEXT:    sw a3, 352(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a3, 360(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s2, t6, 26
 ; RV32I-NEXT:    lui t5, 32768
 ; RV32I-NEXT:    and s3, t4, t5
@@ -3492,14 +3492,14 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz s3, s3
 ; RV32I-NEXT:    xor s1, s1, s2
 ; RV32I-NEXT:    addi s3, s3, -1
-; RV32I-NEXT:    sw s3, 348(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s3, 356(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s2, t6, 27
 ; RV32I-NEXT:    lui a5, 65536
 ; RV32I-NEXT:    and a0, t4, a5
 ; RV32I-NEXT:    and s2, s3, s2
 ; RV32I-NEXT:    seqz s3, a0
 ; RV32I-NEXT:    addi a0, s3, -1
-; RV32I-NEXT:    sw a0, 344(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 352(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli s3, t6, 28
 ; RV32I-NEXT:    xor s1, s1, s2
 ; RV32I-NEXT:    and s2, a0, s3
@@ -3513,7 +3513,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    and t2, t2, t0
 ; RV32I-NEXT:    slli a1, a1, 1
 ; RV32I-NEXT:    or a1, t2, a1
-; RV32I-NEXT:    sw a1, 200(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor s0, s0, s1
 ; RV32I-NEXT:    srli t2, a0, 8
 ; RV32I-NEXT:    and s1, a0, s8
@@ -3530,9 +3530,9 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    seqz t4, t4
 ; RV32I-NEXT:    addi s1, s1, -1
-; RV32I-NEXT:    sw s1, 336(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw s1, 348(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi t4, t4, -1
-; RV32I-NEXT:    sw t4, 332(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t4, 344(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a1, t6, 29
 ; RV32I-NEXT:    slli a0, t6, 30
 ; RV32I-NEXT:    and a1, s1, a1
@@ -3553,7 +3553,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz t2, t2
 ; RV32I-NEXT:    slli t6, t6, 31
 ; RV32I-NEXT:    addi a1, t2, -1
-; RV32I-NEXT:    sw a1, 328(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 340(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli t2, a0, 1
 ; RV32I-NEXT:    and a0, a0, a6
 ; RV32I-NEXT:    and t2, t2, a6
@@ -3568,7 +3568,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz t6, t6
 ; RV32I-NEXT:    addi t6, t6, -1
 ; RV32I-NEXT:    slli a1, t1, 1
-; RV32I-NEXT:    sw a1, 324(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 336(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t4, t4, a1
 ; RV32I-NEXT:    and t6, t6, t1
 ; RV32I-NEXT:    xor s3, s0, t3
@@ -3580,9 +3580,9 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    addi t6, t6, -1
 ; RV32I-NEXT:    addi s0, s0, -1
 ; RV32I-NEXT:    slli a1, t1, 2
-; RV32I-NEXT:    sw a1, 320(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 332(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, t1, 3
-; RV32I-NEXT:    sw a2, 316(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 328(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t6, t6, a1
 ; RV32I-NEXT:    and s0, s0, a2
 ; RV32I-NEXT:    xor t6, t6, s0
@@ -3593,17 +3593,17 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    andi s0, t2, 32
 ; RV32I-NEXT:    seqz s0, s0
 ; RV32I-NEXT:    slli a1, t1, 4
-; RV32I-NEXT:    sw a1, 312(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 324(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t6, t6, a1
 ; RV32I-NEXT:    addi s0, s0, -1
 ; RV32I-NEXT:    slli a1, t1, 5
-; RV32I-NEXT:    sw a1, 308(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 320(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi s1, t2, 64
 ; RV32I-NEXT:    and s0, s0, a1
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    addi s1, s1, -1
 ; RV32I-NEXT:    slli a1, t1, 6
-; RV32I-NEXT:    sw a1, 304(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 316(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor t6, t6, s0
 ; RV32I-NEXT:    and s0, s1, a1
 ; RV32I-NEXT:    xor t6, t6, s0
@@ -3614,24 +3614,24 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    andi s0, t2, 256
 ; RV32I-NEXT:    seqz s0, s0
 ; RV32I-NEXT:    slli a1, t1, 7
-; RV32I-NEXT:    sw a1, 300(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 312(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t6, t6, a1
 ; RV32I-NEXT:    addi s0, s0, -1
 ; RV32I-NEXT:    slli a1, t1, 8
-; RV32I-NEXT:    sw a1, 296(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 308(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi s1, t2, 512
 ; RV32I-NEXT:    and s0, s0, a1
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    xor t6, t6, s0
 ; RV32I-NEXT:    addi s1, s1, -1
 ; RV32I-NEXT:    slli a1, t1, 9
-; RV32I-NEXT:    sw a1, 292(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 304(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi s0, t2, 1024
 ; RV32I-NEXT:    and s1, s1, a1
 ; RV32I-NEXT:    seqz s0, s0
 ; RV32I-NEXT:    addi s0, s0, -1
 ; RV32I-NEXT:    slli a1, t1, 10
-; RV32I-NEXT:    sw a1, 288(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 300(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor t6, t6, s1
 ; RV32I-NEXT:    and s0, s0, a1
 ; RV32I-NEXT:    xor t6, t6, s0
@@ -3643,11 +3643,11 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    and s0, t2, a4
 ; RV32I-NEXT:    seqz s0, s0
 ; RV32I-NEXT:    slli a2, t1, 11
-; RV32I-NEXT:    sw a2, 284(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 296(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t6, t6, a2
 ; RV32I-NEXT:    addi s0, s0, -1
 ; RV32I-NEXT:    slli a2, t1, 12
-; RV32I-NEXT:    sw a2, 280(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 292(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui t3, 2
 ; RV32I-NEXT:    and s1, t2, t3
 ; RV32I-NEXT:    and s0, s0, a2
@@ -3655,20 +3655,20 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    xor t6, t6, s0
 ; RV32I-NEXT:    addi s1, s1, -1
 ; RV32I-NEXT:    slli a2, t1, 13
-; RV32I-NEXT:    sw a2, 276(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 288(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and s0, t2, s4
 ; RV32I-NEXT:    and s1, s1, a2
 ; RV32I-NEXT:    seqz s0, s0
 ; RV32I-NEXT:    xor t6, t6, s1
 ; RV32I-NEXT:    addi s0, s0, -1
 ; RV32I-NEXT:    slli a2, t1, 14
-; RV32I-NEXT:    sw a2, 272(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 284(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and s1, t2, s5
 ; RV32I-NEXT:    and s0, s0, a2
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    addi s1, s1, -1
 ; RV32I-NEXT:    slli a2, t1, 15
-; RV32I-NEXT:    sw a2, 268(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 280(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor t6, t6, s0
 ; RV32I-NEXT:    and s0, s1, a2
 ; RV32I-NEXT:    xor t6, t6, s0
@@ -3681,11 +3681,11 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    and s0, t2, a4
 ; RV32I-NEXT:    seqz s0, s0
 ; RV32I-NEXT:    slli a2, t1, 16
-; RV32I-NEXT:    sw a2, 264(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 276(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t6, t6, a2
 ; RV32I-NEXT:    addi s0, s0, -1
 ; RV32I-NEXT:    slli a2, t1, 17
-; RV32I-NEXT:    sw a2, 260(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 272(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui s1, 64
 ; RV32I-NEXT:    and s1, t2, s1
 ; RV32I-NEXT:    and s0, s0, a2
@@ -3693,7 +3693,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    xor t6, t6, s0
 ; RV32I-NEXT:    addi s1, s1, -1
 ; RV32I-NEXT:    slli a2, t1, 18
-; RV32I-NEXT:    sw a2, 256(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 268(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui s0, 128
 ; RV32I-NEXT:    and s0, t2, s0
 ; RV32I-NEXT:    and s1, s1, a2
@@ -3701,7 +3701,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    xor t6, t6, s1
 ; RV32I-NEXT:    addi s0, s0, -1
 ; RV32I-NEXT:    slli a2, t1, 19
-; RV32I-NEXT:    sw a2, 252(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 264(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui s1, 256
 ; RV32I-NEXT:    and s1, t2, s1
 ; RV32I-NEXT:    and s0, s0, a2
@@ -3709,14 +3709,14 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    xor t6, t6, s0
 ; RV32I-NEXT:    addi s1, s1, -1
 ; RV32I-NEXT:    slli a2, t1, 20
-; RV32I-NEXT:    sw a2, 248(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 260(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui s0, 512
 ; RV32I-NEXT:    and s0, t2, s0
 ; RV32I-NEXT:    and s1, s1, a2
 ; RV32I-NEXT:    seqz s0, s0
 ; RV32I-NEXT:    addi s0, s0, -1
 ; RV32I-NEXT:    slli a2, t1, 21
-; RV32I-NEXT:    sw a2, 244(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 256(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor t6, t6, s1
 ; RV32I-NEXT:    and s0, s0, a2
 ; RV32I-NEXT:    xor t6, t6, s0
@@ -3729,18 +3729,18 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    and s0, t2, a2
 ; RV32I-NEXT:    seqz s0, s0
 ; RV32I-NEXT:    slli a2, t1, 22
-; RV32I-NEXT:    sw a2, 240(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 252(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t6, t6, a2
 ; RV32I-NEXT:    addi s0, s0, -1
 ; RV32I-NEXT:    slli a2, t1, 23
-; RV32I-NEXT:    sw a2, 236(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 248(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    lui s1, 4096
 ; RV32I-NEXT:    and s1, t2, s1
 ; RV32I-NEXT:    and s0, s0, a2
 ; RV32I-NEXT:    seqz s1, s1
 ; RV32I-NEXT:    xor t6, t6, s0
 ; RV32I-NEXT:    addi s1, s1, -1
-; RV32I-NEXT:    lw s0, 472(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s0, 24(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s0, s1, s0
 ; RV32I-NEXT:    and s1, t2, ra
 ; RV32I-NEXT:    lui s11, 8192
@@ -3748,7 +3748,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz s0, s1
 ; RV32I-NEXT:    addi s0, s0, -1
 ; RV32I-NEXT:    slli a2, t1, 25
-; RV32I-NEXT:    sw a2, 232(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 244(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and s0, s0, a2
 ; RV32I-NEXT:    and s1, t2, s6
 ; RV32I-NEXT:    lui ra, 16384
@@ -3756,21 +3756,21 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz s0, s1
 ; RV32I-NEXT:    addi s0, s0, -1
 ; RV32I-NEXT:    slli a2, t1, 26
-; RV32I-NEXT:    sw a2, 228(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 240(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and s0, s0, a2
 ; RV32I-NEXT:    and s1, t2, t5
 ; RV32I-NEXT:    xor t6, t6, s0
 ; RV32I-NEXT:    seqz s0, s1
 ; RV32I-NEXT:    addi s0, s0, -1
 ; RV32I-NEXT:    slli a2, t1, 27
-; RV32I-NEXT:    sw a2, 224(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 236(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and s0, s0, a2
 ; RV32I-NEXT:    and s1, t2, a5
 ; RV32I-NEXT:    xor t6, t6, s0
 ; RV32I-NEXT:    seqz s0, s1
 ; RV32I-NEXT:    addi s0, s0, -1
 ; RV32I-NEXT:    slli a2, t1, 28
-; RV32I-NEXT:    sw a2, 220(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 232(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and s0, s0, a2
 ; RV32I-NEXT:    and s1, t2, s2
 ; RV32I-NEXT:    xor t6, t6, s0
@@ -3779,17 +3779,17 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    and t2, t2, a3
 ; RV32I-NEXT:    seqz t2, t2
 ; RV32I-NEXT:    slli a2, t1, 29
-; RV32I-NEXT:    sw a2, 216(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 228(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and s0, s0, a2
 ; RV32I-NEXT:    addi t2, t2, -1
 ; RV32I-NEXT:    srli a0, a0, 31
 ; RV32I-NEXT:    slli a2, t1, 30
-; RV32I-NEXT:    sw a2, 212(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 224(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t2, t2, a2
 ; RV32I-NEXT:    seqz a0, a0
 ; RV32I-NEXT:    addi a0, a0, -1
 ; RV32I-NEXT:    slli a2, t1, 31
-; RV32I-NEXT:    sw a2, 208(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 220(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor t2, s0, t2
 ; RV32I-NEXT:    and a0, a0, a2
 ; RV32I-NEXT:    xor t4, t4, t6
@@ -3844,7 +3844,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    and a0, a0, a6
 ; RV32I-NEXT:    and t2, t2, a6
 ; RV32I-NEXT:    slli a0, a0, 1
-; RV32I-NEXT:    sw a0, 148(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    or a0, t2, a0
 ; RV32I-NEXT:    srli t2, s4, 24
 ; RV32I-NEXT:    or a2, a2, t2
@@ -3859,7 +3859,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    and t6, s4, s8
 ; RV32I-NEXT:    slli t6, t6, 8
 ; RV32I-NEXT:    slli t5, s4, 24
-; RV32I-NEXT:    sw t5, 204(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t5, 216(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    or t2, t4, t2
 ; RV32I-NEXT:    or t4, t5, t6
 ; RV32I-NEXT:    srli t6, t2, 4
@@ -4102,11 +4102,11 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    xor a2, t4, a2
 ; RV32I-NEXT:    xor a3, a3, s3
 ; RV32I-NEXT:    xor a2, t2, a2
-; RV32I-NEXT:    lw a1, 200(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli a1, a1, 1
 ; RV32I-NEXT:    srli t2, a2, 8
 ; RV32I-NEXT:    xor a1, a1, a3
-; RV32I-NEXT:    sw a1, 152(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 168(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a1, t2, s8
 ; RV32I-NEXT:    srli a3, a2, 24
 ; RV32I-NEXT:    and t2, a2, s8
@@ -4114,7 +4114,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    slli t2, t2, 8
 ; RV32I-NEXT:    or a1, a1, a3
 ; RV32I-NEXT:    or a2, a2, t2
-; RV32I-NEXT:    lw t5, 340(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t5, 16(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli a3, t5, 8
 ; RV32I-NEXT:    and t2, t5, s8
 ; RV32I-NEXT:    and a3, a3, s8
@@ -4155,25 +4155,25 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz t2, t2
 ; RV32I-NEXT:    or a1, t0, a1
 ; RV32I-NEXT:    addi a4, t2, -1
-; RV32I-NEXT:    sw a4, 340(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 16(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t0, a1, 1
 ; RV32I-NEXT:    andi t2, a0, 1
 ; RV32I-NEXT:    and t0, a4, t0
 ; RV32I-NEXT:    seqz t2, t2
 ; RV32I-NEXT:    addi a4, t2, -1
-; RV32I-NEXT:    sw a4, 200(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 12(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi t2, a0, 4
 ; RV32I-NEXT:    seqz t2, t2
 ; RV32I-NEXT:    and t3, a4, a1
 ; RV32I-NEXT:    xor t0, t3, t0
 ; RV32I-NEXT:    addi a4, t2, -1
-; RV32I-NEXT:    sw a4, 196(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 212(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t2, a1, 2
 ; RV32I-NEXT:    andi t3, a0, 8
 ; RV32I-NEXT:    and t2, a4, t2
 ; RV32I-NEXT:    seqz t3, t3
 ; RV32I-NEXT:    addi a4, t3, -1
-; RV32I-NEXT:    sw a4, 192(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 208(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, a1, 3
 ; RV32I-NEXT:    and t3, a4, t3
 ; RV32I-NEXT:    andi t4, a0, 16
@@ -4181,20 +4181,20 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz t3, t4
 ; RV32I-NEXT:    xor t0, t0, t2
 ; RV32I-NEXT:    addi a4, t3, -1
-; RV32I-NEXT:    sw a4, 188(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 204(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t2, a1, 4
 ; RV32I-NEXT:    andi t3, a0, 32
 ; RV32I-NEXT:    and t2, a4, t2
 ; RV32I-NEXT:    seqz t3, t3
 ; RV32I-NEXT:    addi a4, t3, -1
-; RV32I-NEXT:    sw a4, 184(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 200(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, a1, 5
 ; RV32I-NEXT:    and t3, a4, t3
 ; RV32I-NEXT:    andi t4, a0, 64
 ; RV32I-NEXT:    xor t2, t2, t3
 ; RV32I-NEXT:    seqz t3, t4
 ; RV32I-NEXT:    addi a4, t3, -1
-; RV32I-NEXT:    sw a4, 180(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 196(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, a1, 6
 ; RV32I-NEXT:    and t3, a4, t3
 ; RV32I-NEXT:    andi t4, a0, 128
@@ -4202,27 +4202,27 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz t3, t4
 ; RV32I-NEXT:    xor t0, t0, t2
 ; RV32I-NEXT:    addi a4, t3, -1
-; RV32I-NEXT:    sw a4, 176(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 192(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t2, a1, 7
 ; RV32I-NEXT:    andi t3, a0, 256
 ; RV32I-NEXT:    and t2, a4, t2
 ; RV32I-NEXT:    seqz t3, t3
 ; RV32I-NEXT:    addi a4, t3, -1
-; RV32I-NEXT:    sw a4, 172(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 188(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, a1, 8
 ; RV32I-NEXT:    and t3, a4, t3
 ; RV32I-NEXT:    andi t4, a0, 512
 ; RV32I-NEXT:    xor t2, t2, t3
 ; RV32I-NEXT:    seqz t3, t4
 ; RV32I-NEXT:    addi a4, t3, -1
-; RV32I-NEXT:    sw a4, 168(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 184(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, a1, 9
 ; RV32I-NEXT:    and t3, a4, t3
 ; RV32I-NEXT:    andi t4, a0, 1024
 ; RV32I-NEXT:    xor t2, t2, t3
 ; RV32I-NEXT:    seqz t3, t4
 ; RV32I-NEXT:    addi a4, t3, -1
-; RV32I-NEXT:    sw a4, 164(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 180(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, a1, 10
 ; RV32I-NEXT:    and t3, a4, t3
 ; RV32I-NEXT:    and t4, a0, s6
@@ -4230,21 +4230,21 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz t3, t4
 ; RV32I-NEXT:    xor t0, t0, t2
 ; RV32I-NEXT:    addi a4, t3, -1
-; RV32I-NEXT:    sw a4, 160(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 176(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t2, a1, 11
 ; RV32I-NEXT:    lui s11, 1
 ; RV32I-NEXT:    and t3, a0, s11
 ; RV32I-NEXT:    and t2, a4, t2
 ; RV32I-NEXT:    seqz t3, t3
 ; RV32I-NEXT:    addi a4, t3, -1
-; RV32I-NEXT:    sw a4, 156(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 172(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, a1, 12
 ; RV32I-NEXT:    and t3, a4, t3
 ; RV32I-NEXT:    and t4, a0, s10
 ; RV32I-NEXT:    xor t2, t2, t3
 ; RV32I-NEXT:    seqz t3, t4
 ; RV32I-NEXT:    addi a4, t3, -1
-; RV32I-NEXT:    sw a4, 144(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 164(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, a1, 13
 ; RV32I-NEXT:    and t3, a4, t3
 ; RV32I-NEXT:    lui ra, 4
@@ -4252,7 +4252,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    xor t2, t2, t3
 ; RV32I-NEXT:    seqz t3, t4
 ; RV32I-NEXT:    addi a4, t3, -1
-; RV32I-NEXT:    sw a4, 140(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 160(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, a1, 14
 ; RV32I-NEXT:    and t3, a4, t3
 ; RV32I-NEXT:    lui s3, 8
@@ -4260,7 +4260,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    xor t2, t2, t3
 ; RV32I-NEXT:    seqz t3, t4
 ; RV32I-NEXT:    addi a4, t3, -1
-; RV32I-NEXT:    sw a4, 136(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 156(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, a1, 15
 ; RV32I-NEXT:    and t3, a4, t3
 ; RV32I-NEXT:    and t4, a0, s9
@@ -4268,14 +4268,14 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz t3, t4
 ; RV32I-NEXT:    xor t0, t0, t2
 ; RV32I-NEXT:    addi a4, t3, -1
-; RV32I-NEXT:    sw a4, 132(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 152(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t2, a1, 16
 ; RV32I-NEXT:    and t3, a0, s5
 ; RV32I-NEXT:    lui s9, 32
 ; RV32I-NEXT:    and t2, a4, t2
 ; RV32I-NEXT:    seqz t3, t3
 ; RV32I-NEXT:    addi a4, t3, -1
-; RV32I-NEXT:    sw a4, 128(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 148(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, a1, 17
 ; RV32I-NEXT:    and t3, a4, t3
 ; RV32I-NEXT:    lui t5, 64
@@ -4283,7 +4283,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    xor t2, t2, t3
 ; RV32I-NEXT:    seqz t3, t4
 ; RV32I-NEXT:    addi t4, t3, -1
-; RV32I-NEXT:    sw t4, 124(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t4, 144(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, a1, 18
 ; RV32I-NEXT:    and t3, t4, t3
 ; RV32I-NEXT:    lui t6, 128
@@ -4291,7 +4291,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    xor t2, t2, t3
 ; RV32I-NEXT:    seqz t3, t4
 ; RV32I-NEXT:    addi t4, t3, -1
-; RV32I-NEXT:    sw t4, 120(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t4, 140(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, a1, 19
 ; RV32I-NEXT:    and t3, t4, t3
 ; RV32I-NEXT:    lui s1, 256
@@ -4299,7 +4299,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    xor t2, t2, t3
 ; RV32I-NEXT:    seqz t3, t4
 ; RV32I-NEXT:    addi t4, t3, -1
-; RV32I-NEXT:    sw t4, 116(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t4, 136(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, a1, 20
 ; RV32I-NEXT:    and t3, t4, t3
 ; RV32I-NEXT:    lui s5, 512
@@ -4307,7 +4307,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    xor t2, t2, t3
 ; RV32I-NEXT:    seqz t3, t4
 ; RV32I-NEXT:    addi t4, t3, -1
-; RV32I-NEXT:    sw t4, 112(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t4, 132(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, a1, 21
 ; RV32I-NEXT:    and t3, t4, t3
 ; RV32I-NEXT:    lui a4, 1024
@@ -4316,14 +4316,14 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz t3, t4
 ; RV32I-NEXT:    xor t0, t0, t2
 ; RV32I-NEXT:    addi t4, t3, -1
-; RV32I-NEXT:    sw t4, 108(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t4, 128(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t2, a1, 22
 ; RV32I-NEXT:    lui s2, 2048
 ; RV32I-NEXT:    and t3, a0, s2
 ; RV32I-NEXT:    and t2, t4, t2
 ; RV32I-NEXT:    seqz t3, t3
 ; RV32I-NEXT:    addi t4, t3, -1
-; RV32I-NEXT:    sw t4, 104(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t4, 124(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, a1, 23
 ; RV32I-NEXT:    and t3, t4, t3
 ; RV32I-NEXT:    lui s0, 4096
@@ -4331,14 +4331,14 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    xor t2, t2, t3
 ; RV32I-NEXT:    seqz t3, t4
 ; RV32I-NEXT:    addi t4, t3, -1
-; RV32I-NEXT:    sw t4, 100(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t4, 120(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, a1, 24
 ; RV32I-NEXT:    and t3, t4, t3
 ; RV32I-NEXT:    and t4, a0, a5
 ; RV32I-NEXT:    xor t2, t2, t3
 ; RV32I-NEXT:    seqz t3, t4
 ; RV32I-NEXT:    addi a5, t3, -1
-; RV32I-NEXT:    sw a5, 96(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 116(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, a1, 25
 ; RV32I-NEXT:    and t3, a5, t3
 ; RV32I-NEXT:    lui a5, 16384
@@ -4346,7 +4346,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    xor t2, t2, t3
 ; RV32I-NEXT:    seqz t3, t4
 ; RV32I-NEXT:    addi a5, t3, -1
-; RV32I-NEXT:    sw a5, 92(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 112(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, a1, 26
 ; RV32I-NEXT:    and t3, a5, t3
 ; RV32I-NEXT:    lui a4, 32768
@@ -4354,7 +4354,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    xor t2, t2, t3
 ; RV32I-NEXT:    seqz t3, t4
 ; RV32I-NEXT:    addi a5, t3, -1
-; RV32I-NEXT:    sw a5, 88(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 108(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, a1, 27
 ; RV32I-NEXT:    and t3, a5, t3
 ; RV32I-NEXT:    lui a5, 65536
@@ -4362,16 +4362,16 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    xor t2, t2, t3
 ; RV32I-NEXT:    seqz t3, t4
 ; RV32I-NEXT:    addi a5, t3, -1
-; RV32I-NEXT:    sw a5, 84(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a5, 104(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t3, a1, 28
 ; RV32I-NEXT:    and a2, a2, a6
 ; RV32I-NEXT:    and t3, a5, t3
 ; RV32I-NEXT:    xor t2, t2, t3
 ; RV32I-NEXT:    slli a2, a2, 1
 ; RV32I-NEXT:    or a2, a3, a2
-; RV32I-NEXT:    sw a2, 32(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 52(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a4, t0, t2
-; RV32I-NEXT:    lw t3, 460(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t3, 20(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli a3, t3, 8
 ; RV32I-NEXT:    and t0, t3, s8
 ; RV32I-NEXT:    and a3, a3, s8
@@ -4387,9 +4387,9 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz t2, t2
 ; RV32I-NEXT:    seqz a0, a0
 ; RV32I-NEXT:    addi t4, t2, -1
-; RV32I-NEXT:    sw t4, 460(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t4, 20(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi a0, a0, -1
-; RV32I-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a0, 100(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli a2, a1, 29
 ; RV32I-NEXT:    slli t2, a1, 30
 ; RV32I-NEXT:    and a2, t4, a2
@@ -4401,7 +4401,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    and a3, a3, a7
 ; RV32I-NEXT:    slli a0, a0, 4
 ; RV32I-NEXT:    or a0, a3, a0
-; RV32I-NEXT:    lw a3, 148(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli a3, a3, 31
 ; RV32I-NEXT:    srli t0, a0, 2
 ; RV32I-NEXT:    and a0, a0, s7
@@ -4411,7 +4411,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    slli a1, a1, 31
 ; RV32I-NEXT:    addi a2, a3, -1
-; RV32I-NEXT:    sw a2, 148(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    srli a3, a0, 1
 ; RV32I-NEXT:    and t0, a0, a6
 ; RV32I-NEXT:    and a0, a3, a6
@@ -4426,11 +4426,11 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz t2, t2
 ; RV32I-NEXT:    addi t2, t2, -1
 ; RV32I-NEXT:    slli a2, s4, 1
-; RV32I-NEXT:    sw a2, 76(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a2, 96(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a3, a2
 ; RV32I-NEXT:    and t2, t2, s4
 ; RV32I-NEXT:    xor a1, a4, a1
-; RV32I-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a1, t2, a3
 ; RV32I-NEXT:    andi a2, a0, 4
 ; RV32I-NEXT:    andi a3, a0, 8
@@ -4439,9 +4439,9 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    addi a2, a2, -1
 ; RV32I-NEXT:    addi a3, a3, -1
 ; RV32I-NEXT:    slli a4, s4, 2
-; RV32I-NEXT:    sw a4, 72(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 92(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    slli t2, s4, 3
-; RV32I-NEXT:    sw t2, 68(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw t2, 88(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a4
 ; RV32I-NEXT:    and a3, a3, t2
 ; RV32I-NEXT:    xor a2, a2, a3
@@ -4452,17 +4452,17 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    andi a3, a0, 32
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    slli a4, s4, 4
-; RV32I-NEXT:    sw a4, 64(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 84(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a4
 ; RV32I-NEXT:    addi a3, a3, -1
 ; RV32I-NEXT:    slli a4, s4, 5
-; RV32I-NEXT:    sw a4, 60(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 80(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi t2, a0, 64
 ; RV32I-NEXT:    and a3, a3, a4
 ; RV32I-NEXT:    seqz t2, t2
 ; RV32I-NEXT:    addi t2, t2, -1
 ; RV32I-NEXT:    slli a4, s4, 6
-; RV32I-NEXT:    sw a4, 56(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 76(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    and a3, t2, a4
 ; RV32I-NEXT:    xor a2, a2, a3
@@ -4473,24 +4473,24 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    andi a3, a0, 256
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    slli a4, s4, 7
-; RV32I-NEXT:    sw a4, 52(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 72(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a4
 ; RV32I-NEXT:    addi a3, a3, -1
 ; RV32I-NEXT:    slli a4, s4, 8
-; RV32I-NEXT:    sw a4, 48(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 68(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi t2, a0, 512
 ; RV32I-NEXT:    and a3, a3, a4
 ; RV32I-NEXT:    seqz t2, t2
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    addi t2, t2, -1
 ; RV32I-NEXT:    slli a4, s4, 9
-; RV32I-NEXT:    sw a4, 44(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 64(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    andi a3, a0, 1024
 ; RV32I-NEXT:    and t2, t2, a4
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    addi a3, a3, -1
 ; RV32I-NEXT:    slli a4, s4, 10
-; RV32I-NEXT:    sw a4, 40(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 60(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a2, a2, t2
 ; RV32I-NEXT:    and a3, a3, a4
 ; RV32I-NEXT:    xor a2, a2, a3
@@ -4501,31 +4501,31 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    and a3, a0, s11
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    slli a4, s4, 11
-; RV32I-NEXT:    sw a4, 36(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 56(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a4
 ; RV32I-NEXT:    addi a3, a3, -1
 ; RV32I-NEXT:    and t2, a0, s10
 ; RV32I-NEXT:    slli a4, s4, 12
-; RV32I-NEXT:    sw a4, 28(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 48(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a3, a4
 ; RV32I-NEXT:    seqz t2, t2
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    addi t2, t2, -1
 ; RV32I-NEXT:    and a3, a0, ra
 ; RV32I-NEXT:    slli a4, s4, 13
-; RV32I-NEXT:    sw a4, 24(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 44(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and t2, t2, a4
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    xor a2, a2, t2
 ; RV32I-NEXT:    addi a3, a3, -1
 ; RV32I-NEXT:    and t2, a0, s3
 ; RV32I-NEXT:    slli a4, s4, 14
-; RV32I-NEXT:    sw a4, 20(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 40(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a3, a3, a4
 ; RV32I-NEXT:    seqz t2, t2
 ; RV32I-NEXT:    addi t2, t2, -1
 ; RV32I-NEXT:    slli a4, s4, 15
-; RV32I-NEXT:    sw a4, 16(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 36(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    and a3, t2, a4
 ; RV32I-NEXT:    xor a2, a2, a3
@@ -4537,7 +4537,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    and a3, a0, s9
 ; RV32I-NEXT:    seqz a3, a3
 ; RV32I-NEXT:    slli a4, s4, 16
-; RV32I-NEXT:    sw a4, 12(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    sw a4, 32(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    and a2, a2, a4
 ; RV32I-NEXT:    addi a3, a3, -1
 ; RV32I-NEXT:    and t2, a0, t5
@@ -4583,7 +4583,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    seqz t2, t2
 ; RV32I-NEXT:    xor a2, a2, a3
 ; RV32I-NEXT:    addi t2, t2, -1
-; RV32I-NEXT:    lw s1, 204(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s1, 216(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, t2, s1
 ; RV32I-NEXT:    lui a1, 8192
 ; RV32I-NEXT:    and t2, a0, a1
@@ -4633,12 +4633,12 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    xor a2, a4, a2
 ; RV32I-NEXT:    xor a0, a0, a1
 ; RV32I-NEXT:    xor a0, a2, a0
-; RV32I-NEXT:    lw a4, 152(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 168(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli a1, a4, 8
-; RV32I-NEXT:    lw a2, 8(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 28(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    xor a0, a0, a2
 ; RV32I-NEXT:    and a1, a1, s8
-; RV32I-NEXT:    lw a2, 32(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a2, 52(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    srli a2, a2, 1
 ; RV32I-NEXT:    srli a3, a4, 24
 ; RV32I-NEXT:    or a5, a1, a3
@@ -4687,244 +4687,244 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    slli a0, a0, 1
 ; RV32I-NEXT:    or a1, a2, a1
 ; RV32I-NEXT:    or a2, a3, a0
-; RV32I-NEXT:    lw a0, 456(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a3, 324(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a0, 464(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 336(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a0, a0, a3
-; RV32I-NEXT:    lw a3, 452(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 460(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, t1
-; RV32I-NEXT:    lw a4, 448(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 320(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 456(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 332(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, a5
-; RV32I-NEXT:    lw a5, 444(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 316(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 452(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 328(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, t1
 ; RV32I-NEXT:    xor a0, a3, a0
 ; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a3, 440(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 312(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 448(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 324(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a5
-; RV32I-NEXT:    lw a5, 436(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 308(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 444(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 320(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, t1
 ; RV32I-NEXT:    xor a3, a3, a5
-; RV32I-NEXT:    lw a5, 432(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 304(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 440(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 316(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, t1
 ; RV32I-NEXT:    xor a0, a0, a4
 ; RV32I-NEXT:    xor a3, a3, a5
-; RV32I-NEXT:    lw a4, 428(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 300(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 436(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 312(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, a5
+; RV32I-NEXT:    lw a5, 432(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 308(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a5, a5, t1
+; RV32I-NEXT:    xor a4, a4, a5
+; RV32I-NEXT:    lw a5, 428(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 304(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a5, a5, t1
+; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    lw a5, 424(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 296(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a5, a5, t1
-; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a5, 420(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 292(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a5, a5, t1
-; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a5, 416(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 288(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 300(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, t1
 ; RV32I-NEXT:    xor a0, a0, a3
 ; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a3, 412(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 284(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 420(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 296(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a5
+; RV32I-NEXT:    lw a5, 416(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 292(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a5, a5, t1
+; RV32I-NEXT:    xor a3, a3, a5
+; RV32I-NEXT:    lw a5, 412(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 288(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a5, a5, t1
+; RV32I-NEXT:    xor a3, a3, a5
 ; RV32I-NEXT:    lw a5, 408(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 280(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 284(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, t1
 ; RV32I-NEXT:    xor a3, a3, a5
 ; RV32I-NEXT:    lw a5, 404(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 276(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a5, a5, t1
-; RV32I-NEXT:    xor a3, a3, a5
-; RV32I-NEXT:    lw a5, 400(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 272(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a5, a5, t1
-; RV32I-NEXT:    xor a3, a3, a5
-; RV32I-NEXT:    lw a5, 396(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 268(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 280(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, t1
 ; RV32I-NEXT:    xor a0, a0, a4
 ; RV32I-NEXT:    xor a3, a3, a5
-; RV32I-NEXT:    lw a4, 392(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 264(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 400(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 276(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, a5
+; RV32I-NEXT:    lw a5, 396(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 272(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a5, a5, t1
+; RV32I-NEXT:    xor a4, a4, a5
+; RV32I-NEXT:    lw a5, 392(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 268(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a5, a5, t1
+; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    lw a5, 388(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 260(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 264(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, t1
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    lw a5, 384(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 256(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 260(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, t1
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    lw a5, 380(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 252(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a5, a5, t1
-; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a5, 376(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 248(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a5, a5, t1
-; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a5, 372(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 244(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 256(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, t1
 ; RV32I-NEXT:    xor a0, a0, a3
 ; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a3, 368(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 240(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 376(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 252(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a5
+; RV32I-NEXT:    lw a5, 372(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 248(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a5, a5, t1
+; RV32I-NEXT:    xor a3, a3, a5
+; RV32I-NEXT:    lw a5, 24(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 368(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a5, t1, a5
+; RV32I-NEXT:    xor a3, a3, a5
 ; RV32I-NEXT:    lw a5, 364(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 244(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a5, a5, t1
+; RV32I-NEXT:    xor a3, a3, a5
+; RV32I-NEXT:    lw a5, 360(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 240(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a5, a5, t1
+; RV32I-NEXT:    xor a3, a3, a5
+; RV32I-NEXT:    lw a5, 356(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw t1, 236(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, t1
 ; RV32I-NEXT:    xor a3, a3, a5
-; RV32I-NEXT:    lw a5, 472(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 360(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a5, t1, a5
-; RV32I-NEXT:    xor a3, a3, a5
-; RV32I-NEXT:    lw a5, 356(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 232(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a5, a5, t1
-; RV32I-NEXT:    xor a3, a3, a5
 ; RV32I-NEXT:    lw a5, 352(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 228(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a5, a5, t1
-; RV32I-NEXT:    xor a3, a3, a5
-; RV32I-NEXT:    lw a5, 348(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 224(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a5, a5, t1
-; RV32I-NEXT:    xor a3, a3, a5
-; RV32I-NEXT:    lw a5, 344(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 220(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 232(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, t1
 ; RV32I-NEXT:    xor a0, a0, a4
 ; RV32I-NEXT:    xor a3, a3, a5
-; RV32I-NEXT:    lw a4, 336(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a5, 216(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 348(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 228(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, a5
-; RV32I-NEXT:    lw a5, 332(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 212(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 344(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 224(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, t1
 ; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a5, 328(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw t1, 208(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 340(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 220(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, t1
 ; RV32I-NEXT:    xor t1, a0, a3
 ; RV32I-NEXT:    xor a0, a4, a5
-; RV32I-NEXT:    lw a3, 340(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw a4, 76(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a3, 16(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 96(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a3, a3, a4
-; RV32I-NEXT:    lw a4, 200(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, s4
-; RV32I-NEXT:    lw a5, 196(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s4, 72(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 212(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s4, 92(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, s4
-; RV32I-NEXT:    lw s4, 192(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw ra, 68(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s4, 208(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 88(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s4, ra
 ; RV32I-NEXT:    xor a3, a4, a3
 ; RV32I-NEXT:    xor a4, a5, s4
-; RV32I-NEXT:    lw a5, 188(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s4, 64(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 204(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s4, 84(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, s4
+; RV32I-NEXT:    lw s4, 200(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 80(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s4, s4, ra
+; RV32I-NEXT:    xor a5, a5, s4
+; RV32I-NEXT:    lw s4, 196(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 76(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s4, s4, ra
+; RV32I-NEXT:    xor a3, a3, a4
+; RV32I-NEXT:    xor a4, a5, s4
+; RV32I-NEXT:    lw a5, 192(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s4, 72(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and a5, a5, s4
+; RV32I-NEXT:    lw s4, 188(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 68(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    and s4, s4, ra
+; RV32I-NEXT:    xor a5, a5, s4
 ; RV32I-NEXT:    lw s4, 184(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw ra, 60(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 64(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s4, ra
 ; RV32I-NEXT:    xor a5, a5, s4
 ; RV32I-NEXT:    lw s4, 180(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw ra, 56(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 60(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s4, ra
 ; RV32I-NEXT:    xor a3, a3, a4
 ; RV32I-NEXT:    xor a4, a5, s4
 ; RV32I-NEXT:    lw a5, 176(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s4, 52(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s4, 56(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, s4
 ; RV32I-NEXT:    lw s4, 172(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw ra, 48(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s4, ra
 ; RV32I-NEXT:    xor a5, a5, s4
-; RV32I-NEXT:    lw s4, 168(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s4, 164(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw ra, 44(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s4, ra
 ; RV32I-NEXT:    xor a5, a5, s4
-; RV32I-NEXT:    lw s4, 164(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s4, 160(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw ra, 40(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s4, ra
-; RV32I-NEXT:    xor a3, a3, a4
-; RV32I-NEXT:    xor a4, a5, s4
-; RV32I-NEXT:    lw a5, 160(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s4, 36(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and a5, a5, s4
+; RV32I-NEXT:    xor a5, a5, s4
 ; RV32I-NEXT:    lw s4, 156(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s4, s4, ra
-; RV32I-NEXT:    xor a5, a5, s4
-; RV32I-NEXT:    lw s4, 144(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw ra, 24(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s4, s4, ra
-; RV32I-NEXT:    xor a5, a5, s4
-; RV32I-NEXT:    lw s4, 140(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw ra, 20(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    and s4, s4, ra
-; RV32I-NEXT:    xor a5, a5, s4
-; RV32I-NEXT:    lw s4, 136(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw ra, 16(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw ra, 36(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s4, ra
 ; RV32I-NEXT:    xor a3, a3, a4
 ; RV32I-NEXT:    xor a4, a5, s4
-; RV32I-NEXT:    lw a5, 132(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    lw s4, 12(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 152(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s4, 32(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, s4
-; RV32I-NEXT:    lw s4, 128(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s4, 148(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s4, s11
 ; RV32I-NEXT:    xor a5, a5, s4
-; RV32I-NEXT:    lw s4, 124(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s4, 144(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s4, s10
 ; RV32I-NEXT:    xor a5, a5, s4
-; RV32I-NEXT:    lw s4, 120(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s4, 140(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s4, s9
 ; RV32I-NEXT:    xor a5, a5, s4
-; RV32I-NEXT:    lw s4, 116(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s4, 136(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s4, s4, s6
 ; RV32I-NEXT:    xor a5, a5, s4
-; RV32I-NEXT:    lw s4, 112(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw s4, 132(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and s3, s4, s3
 ; RV32I-NEXT:    xor a3, a3, a4
 ; RV32I-NEXT:    xor a4, a5, s3
 ; RV32I-NEXT:    xor a0, t1, a0
 ; RV32I-NEXT:    xor a3, a3, a4
-; RV32I-NEXT:    lw a4, 108(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 128(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, s5
-; RV32I-NEXT:    lw a5, 104(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 124(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, s2
 ; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a5, 100(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 120(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, s1
 ; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a5, 96(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 116(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, s0
 ; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a5, 92(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 112(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, t6
 ; RV32I-NEXT:    xor a4, a4, a5
-; RV32I-NEXT:    lw a5, 88(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a5, 108(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a5, a5, t5
 ; RV32I-NEXT:    xor a4, a4, a5
 ; RV32I-NEXT:    srli a5, a0, 8
-; RV32I-NEXT:    lw t1, 84(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 104(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, t1, t4
 ; RV32I-NEXT:    and a5, a5, s8
 ; RV32I-NEXT:    xor a4, a4, t1
 ; RV32I-NEXT:    srli t1, a0, 24
 ; RV32I-NEXT:    or a5, a5, t1
 ; RV32I-NEXT:    xor a3, a3, a4
-; RV32I-NEXT:    lw a4, 460(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 20(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and a4, a4, t3
-; RV32I-NEXT:    lw t1, 80(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 100(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t1, t1, t2
 ; RV32I-NEXT:    xor a4, a4, t1
-; RV32I-NEXT:    lw t1, 148(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw t1, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    and t0, t1, t0
 ; RV32I-NEXT:    xor a4, a4, t0
 ; RV32I-NEXT:    and t0, a0, s8
@@ -4972,12 +4972,12 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32I-NEXT:    slli a3, a3, 1
 ; RV32I-NEXT:    or a0, a5, a0
 ; RV32I-NEXT:    or a3, a4, a3
-; RV32I-NEXT:    lw a4, 464(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 468(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    sw a1, 0(a4)
 ; RV32I-NEXT:    sw a0, 4(a4)
 ; RV32I-NEXT:    sw a2, 8(a4)
 ; RV32I-NEXT:    sw a3, 12(a4)
-; RV32I-NEXT:    lw a4, 468(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    lw a4, 472(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    sw a1, 0(a4)
 ; RV32I-NEXT:    sw a0, 4(a4)
 ; RV32I-NEXT:    sw a2, 8(a4)
@@ -6167,17 +6167,17 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    sw s9, 116(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    sw s10, 112(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    sw s11, 108(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    sw a3, 84(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    sw a2, 80(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a3, 104(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a2, 100(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mv s11, a1
 ; RV32IM-NEXT:    mv a1, a0
-; RV32IM-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    lw a2, 4(a0)
 ; RV32IM-NEXT:    lui a3, 16
 ; RV32IM-NEXT:    lw a0, 8(a0)
-; RV32IM-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    lw a0, 12(a1)
-; RV32IM-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    addi s2, a3, -256
 ; RV32IM-NEXT:    srli a3, a2, 8
 ; RV32IM-NEXT:    srli a5, a2, 24
@@ -6224,9 +6224,9 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    and a2, a2, s9
 ; RV32IM-NEXT:    slli a2, a2, 4
 ; RV32IM-NEXT:    lw a0, 8(s11)
-; RV32IM-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    lw a0, 12(s11)
-; RV32IM-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a2, t0, a2
 ; RV32IM-NEXT:    srli t0, a2, 2
 ; RV32IM-NEXT:    srli t1, a3, 8
@@ -6258,7 +6258,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    slli a3, a3, 1
 ; RV32IM-NEXT:    srli t1, a2, 1
 ; RV32IM-NEXT:    or t3, t0, a3
-; RV32IM-NEXT:    sw t3, 36(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t3, 32(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a3, t1, s7
 ; RV32IM-NEXT:    srli t0, t3, 8
 ; RV32IM-NEXT:    and a2, a2, s7
@@ -6386,7 +6386,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    and t5, s1, t1
 ; RV32IM-NEXT:    and t0, a1, t2
 ; RV32IM-NEXT:    and s1, s1, t2
-; RV32IM-NEXT:    sw s1, 72(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s1, 96(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a1, a1, t1
 ; RV32IM-NEXT:    mv ra, t1
 ; RV32IM-NEXT:    mul t4, t0, t5
@@ -6406,11 +6406,11 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    xor a6, t4, s3
 ; RV32IM-NEXT:    mul a7, a2, s10
 ; RV32IM-NEXT:    mv a3, s10
-; RV32IM-NEXT:    sw s10, 60(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s10, 88(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul s3, a5, s1
 ; RV32IM-NEXT:    mul s10, t0, t1
-; RV32IM-NEXT:    sw t1, 56(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    sw t5, 68(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t1, 84(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t5, 92(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul s11, a1, t5
 ; RV32IM-NEXT:    mul a2, a2, s1
 ; RV32IM-NEXT:    mul a5, a5, t5
@@ -6421,7 +6421,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    and a0, a0, t6
 ; RV32IM-NEXT:    and a6, a6, t3
 ; RV32IM-NEXT:    or t4, a6, a0
-; RV32IM-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    lw a0, 0(a0)
 ; RV32IM-NEXT:    xor a6, s3, a7
 ; RV32IM-NEXT:    xor a7, s10, s11
@@ -6456,14 +6456,14 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    and a2, a2, s7
 ; RV32IM-NEXT:    slli a0, a0, 1
 ; RV32IM-NEXT:    mv a3, ra
-; RV32IM-NEXT:    sw ra, 96(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw ra, 64(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and s10, a1, ra
 ; RV32IM-NEXT:    or a0, a2, a0
 ; RV32IM-NEXT:    and ra, a0, t3
 ; RV32IM-NEXT:    and s5, a0, t6
 ; RV32IM-NEXT:    and s6, a0, a3
 ; RV32IM-NEXT:    and a6, a0, t2
-; RV32IM-NEXT:    lw a2, 36(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a2, 32(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s1, a2, t6
 ; RV32IM-NEXT:    mv s4, t6
 ; RV32IM-NEXT:    and t6, a2, t3
@@ -6480,7 +6480,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    or s10, t0, s10
 ; RV32IM-NEXT:    lui s3, 349525
 ; RV32IM-NEXT:    addi s3, s3, 1364
-; RV32IM-NEXT:    sw s3, 32(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s3, 28(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srli t0, a4, 1
 ; RV32IM-NEXT:    and a4, a4, s7
 ; RV32IM-NEXT:    and t0, t0, s3
@@ -6495,7 +6495,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    xor a0, a1, a0
 ; RV32IM-NEXT:    xor a1, a4, a5
 ; RV32IM-NEXT:    xor a3, a2, a0
-; RV32IM-NEXT:    lw a5, 48(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 8(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a0, a5, 8
 ; RV32IM-NEXT:    and a2, a5, s2
 ; RV32IM-NEXT:    and a0, a0, s2
@@ -6505,20 +6505,20 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    or a0, a0, a4
 ; RV32IM-NEXT:    or a2, a5, a2
 ; RV32IM-NEXT:    mul a4, s1, s5
-; RV32IM-NEXT:    sw s1, 28(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s1, 76(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul a5, t6, a6
 ; RV32IM-NEXT:    mv a7, t6
-; RV32IM-NEXT:    sw t6, 44(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t6, 36(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a1, a1, s4
 ; RV32IM-NEXT:    mv t4, s4
 ; RV32IM-NEXT:    and a3, a3, t3
 ; RV32IM-NEXT:    or a1, a3, a1
-; RV32IM-NEXT:    sw a1, 48(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a0, a2, a0
 ; RV32IM-NEXT:    mul a1, t1, ra
-; RV32IM-NEXT:    sw t1, 40(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t1, 80(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul a2, t5, s6
-; RV32IM-NEXT:    sw t5, 36(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t5, 32(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    srli a3, a0, 4
 ; RV32IM-NEXT:    and a0, a0, s9
 ; RV32IM-NEXT:    and a3, a3, s9
@@ -6538,7 +6538,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    xor a1, a4, a1
 ; RV32IM-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or s11, a2, a0
-; RV32IM-NEXT:    lw a4, 52(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 12(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a0, a4, 8
 ; RV32IM-NEXT:    and a1, a4, s2
 ; RV32IM-NEXT:    and a0, a0, s2
@@ -6582,7 +6582,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    or a1, a2, a1
 ; RV32IM-NEXT:    or a0, a4, a0
 ; RV32IM-NEXT:    srli a2, a1, 4
-; RV32IM-NEXT:    sw s9, 88(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s9, 56(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a1, a1, s9
 ; RV32IM-NEXT:    and a2, a2, s9
 ; RV32IM-NEXT:    slli a1, a1, 4
@@ -6593,7 +6593,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    or a1, a2, a1
 ; RV32IM-NEXT:    or a0, a4, a0
 ; RV32IM-NEXT:    srli a2, a1, 2
-; RV32IM-NEXT:    sw s0, 100(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s0, 48(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a1, a1, s0
 ; RV32IM-NEXT:    and a2, a2, s0
 ; RV32IM-NEXT:    slli a1, a1, 2
@@ -6604,7 +6604,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    or a1, a2, a1
 ; RV32IM-NEXT:    or a0, a4, a0
 ; RV32IM-NEXT:    srli a2, a1, 1
-; RV32IM-NEXT:    sw s7, 104(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s7, 52(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a1, a1, s7
 ; RV32IM-NEXT:    and a2, a2, s7
 ; RV32IM-NEXT:    slli a1, a1, 1
@@ -6615,7 +6615,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    or a1, a2, a1
 ; RV32IM-NEXT:    or a0, a4, a0
 ; RV32IM-NEXT:    mul a2, s1, a6
-; RV32IM-NEXT:    sw a2, 52(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a2, 12(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul s4, a7, s6
 ; RV32IM-NEXT:    mul s10, t1, s5
 ; RV32IM-NEXT:    mul s3, t5, ra
@@ -6623,7 +6623,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    and s5, a1, t3
 ; RV32IM-NEXT:    mv s7, t4
 ; RV32IM-NEXT:    and s6, a1, t4
-; RV32IM-NEXT:    lw s0, 96(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s0, 64(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and s8, a1, s0
 ; RV32IM-NEXT:    mv s1, t2
 ; RV32IM-NEXT:    and a2, a1, t2
@@ -6647,7 +6647,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    mul a1, a3, s5
 ; RV32IM-NEXT:    mul a3, a3, s6
 ; RV32IM-NEXT:    mul a0, a0, s5
-; RV32IM-NEXT:    lw s5, 52(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s5, 12(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    xor s4, s4, s5
 ; RV32IM-NEXT:    xor s3, s10, s3
 ; RV32IM-NEXT:    xor t0, t0, t5
@@ -6677,7 +6677,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    and a1, a1, s0
 ; RV32IM-NEXT:    or a1, a2, a1
 ; RV32IM-NEXT:    srli a2, a0, 8
-; RV32IM-NEXT:    lw a3, 48(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    or a1, a3, a1
 ; RV32IM-NEXT:    and a2, a2, s2
 ; RV32IM-NEXT:    srli a3, a0, 24
@@ -6690,12 +6690,12 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    xor a0, a1, a0
 ; RV32IM-NEXT:    or a2, a4, a2
 ; RV32IM-NEXT:    srli a1, a2, 4
-; RV32IM-NEXT:    lw s9, 88(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s9, 56(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a2, a2, s9
 ; RV32IM-NEXT:    and a1, a1, s9
 ; RV32IM-NEXT:    slli a2, a2, 4
 ; RV32IM-NEXT:    or a1, a1, a2
-; RV32IM-NEXT:    lw a4, 64(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 40(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a2, a4, 8
 ; RV32IM-NEXT:    and a2, a2, s2
 ; RV32IM-NEXT:    srli a3, a4, 24
@@ -6707,7 +6707,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    srli a4, a1, 2
 ; RV32IM-NEXT:    lw a5, 24(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a6, a5, 1
-; RV32IM-NEXT:    lw a5, 100(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 48(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, a5
 ; RV32IM-NEXT:    and a1, a1, a5
 ; RV32IM-NEXT:    or a2, a3, a2
@@ -6725,7 +6725,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    sw t2, 16(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    or a2, a3, a2
 ; RV32IM-NEXT:    srli a1, a2, 1
-; RV32IM-NEXT:    lw a3, 104(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a3, 52(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a2, a2, a3
 ; RV32IM-NEXT:    and a1, a1, a3
 ; RV32IM-NEXT:    slli a2, a2, 1
@@ -6746,9 +6746,9 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    mul t2, a7, s0
 ; RV32IM-NEXT:    mul t3, a1, s6
 ; RV32IM-NEXT:    xor s5, a6, a0
-; RV32IM-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a0, a3, a0
-; RV32IM-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul a6, a2, s0
 ; RV32IM-NEXT:    mv a0, t5
 ; RV32IM-NEXT:    mul t5, a4, t5
@@ -6756,12 +6756,12 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    mul s4, a1, s10
 ; RV32IM-NEXT:    mul s7, a2, s10
 ; RV32IM-NEXT:    mv a3, s10
-; RV32IM-NEXT:    sw s10, 48(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s10, 8(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul s10, a4, s6
-; RV32IM-NEXT:    sw s6, 64(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s6, 40(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul s11, a7, a0
 ; RV32IM-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
-; RV32IM-NEXT:    sw s0, 52(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s0, 12(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mul ra, a1, s0
 ; RV32IM-NEXT:    xor t0, t1, t0
 ; RV32IM-NEXT:    xor t1, t2, t3
@@ -6782,9 +6782,9 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    xor a6, t1, t2
 ; RV32IM-NEXT:    xor a2, a4, a2
 ; RV32IM-NEXT:    xor a1, a7, a1
-; RV32IM-NEXT:    lw t1, 76(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t1, 44(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    srli a4, t1, 8
-; RV32IM-NEXT:    sw s2, 92(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw s2, 60(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and a7, t1, s2
 ; RV32IM-NEXT:    and a4, a4, s2
 ; RV32IM-NEXT:    slli a7, a7, 8
@@ -6803,12 +6803,12 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    or ra, a4, a1
 ; RV32IM-NEXT:    or a2, a6, a2
 ; RV32IM-NEXT:    srli a4, a2, 2
-; RV32IM-NEXT:    lw a0, 100(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a2, a2, a0
 ; RV32IM-NEXT:    and a4, a4, a0
 ; RV32IM-NEXT:    slli a2, a2, 2
 ; RV32IM-NEXT:    or a2, a4, a2
-; RV32IM-NEXT:    lw a0, 104(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    lw a4, 16(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a4, a4, a0
 ; RV32IM-NEXT:    srli a6, a2, 1
@@ -6825,10 +6825,10 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    and t0, a2, s8
 ; RV32IM-NEXT:    and a2, a2, s1
 ; RV32IM-NEXT:    and s11, t6, t4
-; RV32IM-NEXT:    sw t4, 8(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw t4, 68(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and s10, t6, a0
 ; RV32IM-NEXT:    mv s8, a0
-; RV32IM-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    and s9, t6, s1
 ; RV32IM-NEXT:    and s7, t6, a5
 ; RV32IM-NEXT:    mv t6, a5
@@ -6848,7 +6848,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    mul a3, s9, a6
 ; RV32IM-NEXT:    mul a7, s9, a7
 ; RV32IM-NEXT:    mul a6, s7, a6
-; RV32IM-NEXT:    lw s2, 32(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s2, 28(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    or s6, s2, s6
 ; RV32IM-NEXT:    lw s2, 20(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    or ra, s2, ra
@@ -6874,7 +6874,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    or a0, a0, a1
 ; RV32IM-NEXT:    srli a1, s5, 8
 ; RV32IM-NEXT:    xor a0, a0, ra
-; RV32IM-NEXT:    lw a5, 92(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 60(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, a5
 ; RV32IM-NEXT:    srli a2, s6, 1
 ; RV32IM-NEXT:    srli a3, s5, 24
@@ -6895,7 +6895,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    or a1, a2, a1
 ; RV32IM-NEXT:    or a0, a0, a3
 ; RV32IM-NEXT:    srli a2, a1, 4
-; RV32IM-NEXT:    lw s1, 88(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s1, 56(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, s1
 ; RV32IM-NEXT:    and a2, a2, s1
 ; RV32IM-NEXT:    slli a1, a1, 4
@@ -6906,7 +6906,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    or a1, a2, a1
 ; RV32IM-NEXT:    or a0, a3, a0
 ; RV32IM-NEXT:    srli a2, a1, 2
-; RV32IM-NEXT:    lw t6, 100(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t6, 48(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, t6
 ; RV32IM-NEXT:    and a2, a2, t6
 ; RV32IM-NEXT:    slli a1, a1, 2
@@ -6916,20 +6916,20 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    slli a0, a0, 2
 ; RV32IM-NEXT:    or a1, a2, a1
 ; RV32IM-NEXT:    or a3, a3, a0
-; RV32IM-NEXT:    lw s2, 56(sp) # 4-byte Folded Reload
-; RV32IM-NEXT:    lw a5, 28(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s2, 84(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a5, 76(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul s8, a5, s2
-; RV32IM-NEXT:    lw t5, 68(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t5, 92(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a2, a5, t5
-; RV32IM-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a4, a5, a0
-; RV32IM-NEXT:    lw t0, 72(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw t0, 96(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a5, a5, t0
-; RV32IM-NEXT:    lw s6, 36(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s6, 32(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a6, s6, t0
-; RV32IM-NEXT:    lw s0, 40(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s0, 80(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul a7, s0, t0
-; RV32IM-NEXT:    lw s4, 44(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s4, 36(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t0, s4, t0
 ; RV32IM-NEXT:    mul t1, s4, a0
 ; RV32IM-NEXT:    mul t2, s6, a0
@@ -6942,7 +6942,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    mul s5, s6, a0
 ; RV32IM-NEXT:    mul s6, s6, s2
 ; RV32IM-NEXT:    srli ra, a1, 1
-; RV32IM-NEXT:    lw s2, 104(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s2, 52(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a1, a1, s2
 ; RV32IM-NEXT:    and ra, ra, s2
 ; RV32IM-NEXT:    slli a1, a1, 1
@@ -6952,7 +6952,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    slli a3, a3, 1
 ; RV32IM-NEXT:    or a1, ra, a1
 ; RV32IM-NEXT:    or a0, a0, a3
-; RV32IM-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
+; RV32IM-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    xor a3, t1, s8
 ; RV32IM-NEXT:    xor a6, t5, a6
 ; RV32IM-NEXT:    xor a2, s3, a2
@@ -6965,23 +6965,23 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    xor a7, t3, s6
 ; RV32IM-NEXT:    lw s3, 24(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t0, s11, s3
-; RV32IM-NEXT:    lw s0, 48(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t1, s10, s0
-; RV32IM-NEXT:    lw s5, 52(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s5, 12(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t2, s9, s5
-; RV32IM-NEXT:    lw s4, 64(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s4, 40(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    mul t3, s7, s4
 ; RV32IM-NEXT:    xor a4, a4, a6
 ; RV32IM-NEXT:    xor a5, a5, a7
-; RV32IM-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a3, a3, a0
-; RV32IM-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw ra, 72(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a2, a2, ra
 ; RV32IM-NEXT:    mul a6, s11, s5
 ; RV32IM-NEXT:    mul a7, s10, s3
 ; RV32IM-NEXT:    mv s6, t4
 ; RV32IM-NEXT:    and a4, a4, t4
-; RV32IM-NEXT:    lw s8, 96(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw s8, 64(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a5, a5, s8
 ; RV32IM-NEXT:    or a2, a2, a3
 ; RV32IM-NEXT:    or a4, a4, a5
@@ -7004,7 +7004,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    xor a4, a4, a5
 ; RV32IM-NEXT:    srli a5, a2, 8
 ; RV32IM-NEXT:    xor a4, a6, a4
-; RV32IM-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    and a5, a5, a0
 ; RV32IM-NEXT:    and a4, a4, ra
 ; RV32IM-NEXT:    srli a6, a2, 24
@@ -7064,13 +7064,13 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IM-NEXT:    slli a3, a3, 1
 ; RV32IM-NEXT:    or a2, a5, a2
 ; RV32IM-NEXT:    or a3, a4, a3
-; RV32IM-NEXT:    lw a4, 80(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 100(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    sw a1, 0(a4)
 ; RV32IM-NEXT:    sw a2, 4(a4)
-; RV32IM-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    sw a0, 8(a4)
 ; RV32IM-NEXT:    sw a3, 12(a4)
-; RV32IM-NEXT:    lw a4, 84(sp) # 4-byte Folded Reload
+; RV32IM-NEXT:    lw a4, 104(sp) # 4-byte Folded Reload
 ; RV32IM-NEXT:    sw a1, 0(a4)
 ; RV32IM-NEXT:    sw a2, 4(a4)
 ; RV32IM-NEXT:    sw a0, 8(a4)
@@ -7486,17 +7486,17 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    sw s9, 116(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    sw s10, 112(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    sw s11, 108(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    sw a3, 84(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    sw a2, 80(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a3, 104(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a2, 100(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mv s11, a1
 ; RV32IMZBS-NEXT:    mv a1, a0
-; RV32IMZBS-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    lw a2, 4(a0)
 ; RV32IMZBS-NEXT:    lui a3, 16
 ; RV32IMZBS-NEXT:    lw a0, 8(a0)
-; RV32IMZBS-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    lw a0, 12(a1)
-; RV32IMZBS-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    addi s2, a3, -256
 ; RV32IMZBS-NEXT:    srli a3, a2, 8
 ; RV32IMZBS-NEXT:    srli a5, a2, 24
@@ -7543,9 +7543,9 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    and a2, a2, s9
 ; RV32IMZBS-NEXT:    slli a2, a2, 4
 ; RV32IMZBS-NEXT:    lw a0, 8(s11)
-; RV32IMZBS-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    lw a0, 12(s11)
-; RV32IMZBS-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a2, t0, a2
 ; RV32IMZBS-NEXT:    srli t0, a2, 2
 ; RV32IMZBS-NEXT:    srli t1, a3, 8
@@ -7577,7 +7577,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    slli a3, a3, 1
 ; RV32IMZBS-NEXT:    srli t1, a2, 1
 ; RV32IMZBS-NEXT:    or t3, t0, a3
-; RV32IMZBS-NEXT:    sw t3, 36(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t3, 32(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a3, t1, s7
 ; RV32IMZBS-NEXT:    srli t0, t3, 8
 ; RV32IMZBS-NEXT:    and a2, a2, s7
@@ -7705,7 +7705,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    and t5, s1, t1
 ; RV32IMZBS-NEXT:    and t0, a1, t2
 ; RV32IMZBS-NEXT:    and s1, s1, t2
-; RV32IMZBS-NEXT:    sw s1, 72(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s1, 96(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a1, a1, t1
 ; RV32IMZBS-NEXT:    mv ra, t1
 ; RV32IMZBS-NEXT:    mul t4, t0, t5
@@ -7725,11 +7725,11 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    xor a6, t4, s3
 ; RV32IMZBS-NEXT:    mul a7, a2, s10
 ; RV32IMZBS-NEXT:    mv a3, s10
-; RV32IMZBS-NEXT:    sw s10, 60(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s10, 88(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul s3, a5, s1
 ; RV32IMZBS-NEXT:    mul s10, t0, t1
-; RV32IMZBS-NEXT:    sw t1, 56(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    sw t5, 68(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t1, 84(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t5, 92(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul s11, a1, t5
 ; RV32IMZBS-NEXT:    mul a2, a2, s1
 ; RV32IMZBS-NEXT:    mul a5, a5, t5
@@ -7740,7 +7740,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    and a0, a0, t6
 ; RV32IMZBS-NEXT:    and a6, a6, t3
 ; RV32IMZBS-NEXT:    or t4, a6, a0
-; RV32IMZBS-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    lw a0, 0(a0)
 ; RV32IMZBS-NEXT:    xor a6, s3, a7
 ; RV32IMZBS-NEXT:    xor a7, s10, s11
@@ -7775,14 +7775,14 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    and a2, a2, s7
 ; RV32IMZBS-NEXT:    slli a0, a0, 1
 ; RV32IMZBS-NEXT:    mv a3, ra
-; RV32IMZBS-NEXT:    sw ra, 96(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw ra, 64(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and s10, a1, ra
 ; RV32IMZBS-NEXT:    or a0, a2, a0
 ; RV32IMZBS-NEXT:    and ra, a0, t3
 ; RV32IMZBS-NEXT:    and s5, a0, t6
 ; RV32IMZBS-NEXT:    and s6, a0, a3
 ; RV32IMZBS-NEXT:    and a6, a0, t2
-; RV32IMZBS-NEXT:    lw a2, 36(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a2, 32(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s1, a2, t6
 ; RV32IMZBS-NEXT:    mv s4, t6
 ; RV32IMZBS-NEXT:    and t6, a2, t3
@@ -7799,7 +7799,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    or s10, t0, s10
 ; RV32IMZBS-NEXT:    lui s3, 349525
 ; RV32IMZBS-NEXT:    addi s3, s3, 1364
-; RV32IMZBS-NEXT:    sw s3, 32(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s3, 28(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srli t0, a4, 1
 ; RV32IMZBS-NEXT:    and a4, a4, s7
 ; RV32IMZBS-NEXT:    and t0, t0, s3
@@ -7814,7 +7814,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    xor a0, a1, a0
 ; RV32IMZBS-NEXT:    xor a1, a4, a5
 ; RV32IMZBS-NEXT:    xor a3, a2, a0
-; RV32IMZBS-NEXT:    lw a5, 48(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 8(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a0, a5, 8
 ; RV32IMZBS-NEXT:    and a2, a5, s2
 ; RV32IMZBS-NEXT:    and a0, a0, s2
@@ -7824,20 +7824,20 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    or a0, a0, a4
 ; RV32IMZBS-NEXT:    or a2, a5, a2
 ; RV32IMZBS-NEXT:    mul a4, s1, s5
-; RV32IMZBS-NEXT:    sw s1, 28(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s1, 76(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul a5, t6, a6
 ; RV32IMZBS-NEXT:    mv a7, t6
-; RV32IMZBS-NEXT:    sw t6, 44(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t6, 36(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a1, a1, s4
 ; RV32IMZBS-NEXT:    mv t4, s4
 ; RV32IMZBS-NEXT:    and a3, a3, t3
 ; RV32IMZBS-NEXT:    or a1, a3, a1
-; RV32IMZBS-NEXT:    sw a1, 48(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a0, a2, a0
 ; RV32IMZBS-NEXT:    mul a1, t1, ra
-; RV32IMZBS-NEXT:    sw t1, 40(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t1, 80(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul a2, t5, s6
-; RV32IMZBS-NEXT:    sw t5, 36(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t5, 32(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    srli a3, a0, 4
 ; RV32IMZBS-NEXT:    and a0, a0, s9
 ; RV32IMZBS-NEXT:    and a3, a3, s9
@@ -7857,7 +7857,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    xor a1, a4, a1
 ; RV32IMZBS-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or s11, a2, a0
-; RV32IMZBS-NEXT:    lw a4, 52(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 12(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a0, a4, 8
 ; RV32IMZBS-NEXT:    and a1, a4, s2
 ; RV32IMZBS-NEXT:    and a0, a0, s2
@@ -7901,7 +7901,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    or a1, a2, a1
 ; RV32IMZBS-NEXT:    or a0, a4, a0
 ; RV32IMZBS-NEXT:    srli a2, a1, 4
-; RV32IMZBS-NEXT:    sw s9, 88(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s9, 56(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a1, a1, s9
 ; RV32IMZBS-NEXT:    and a2, a2, s9
 ; RV32IMZBS-NEXT:    slli a1, a1, 4
@@ -7912,7 +7912,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    or a1, a2, a1
 ; RV32IMZBS-NEXT:    or a0, a4, a0
 ; RV32IMZBS-NEXT:    srli a2, a1, 2
-; RV32IMZBS-NEXT:    sw s0, 100(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s0, 48(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a1, a1, s0
 ; RV32IMZBS-NEXT:    and a2, a2, s0
 ; RV32IMZBS-NEXT:    slli a1, a1, 2
@@ -7923,7 +7923,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    or a1, a2, a1
 ; RV32IMZBS-NEXT:    or a0, a4, a0
 ; RV32IMZBS-NEXT:    srli a2, a1, 1
-; RV32IMZBS-NEXT:    sw s7, 104(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s7, 52(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a1, a1, s7
 ; RV32IMZBS-NEXT:    and a2, a2, s7
 ; RV32IMZBS-NEXT:    slli a1, a1, 1
@@ -7934,7 +7934,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    or a1, a2, a1
 ; RV32IMZBS-NEXT:    or a0, a4, a0
 ; RV32IMZBS-NEXT:    mul a2, s1, a6
-; RV32IMZBS-NEXT:    sw a2, 52(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a2, 12(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul s4, a7, s6
 ; RV32IMZBS-NEXT:    mul s10, t1, s5
 ; RV32IMZBS-NEXT:    mul s3, t5, ra
@@ -7942,7 +7942,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    and s5, a1, t3
 ; RV32IMZBS-NEXT:    mv s7, t4
 ; RV32IMZBS-NEXT:    and s6, a1, t4
-; RV32IMZBS-NEXT:    lw s0, 96(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s0, 64(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and s8, a1, s0
 ; RV32IMZBS-NEXT:    mv s1, t2
 ; RV32IMZBS-NEXT:    and a2, a1, t2
@@ -7966,7 +7966,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    mul a1, a3, s5
 ; RV32IMZBS-NEXT:    mul a3, a3, s6
 ; RV32IMZBS-NEXT:    mul a0, a0, s5
-; RV32IMZBS-NEXT:    lw s5, 52(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s5, 12(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    xor s4, s4, s5
 ; RV32IMZBS-NEXT:    xor s3, s10, s3
 ; RV32IMZBS-NEXT:    xor t0, t0, t5
@@ -7996,7 +7996,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    and a1, a1, s0
 ; RV32IMZBS-NEXT:    or a1, a2, a1
 ; RV32IMZBS-NEXT:    srli a2, a0, 8
-; RV32IMZBS-NEXT:    lw a3, 48(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    or a1, a3, a1
 ; RV32IMZBS-NEXT:    and a2, a2, s2
 ; RV32IMZBS-NEXT:    srli a3, a0, 24
@@ -8009,12 +8009,12 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    xor a0, a1, a0
 ; RV32IMZBS-NEXT:    or a2, a4, a2
 ; RV32IMZBS-NEXT:    srli a1, a2, 4
-; RV32IMZBS-NEXT:    lw s9, 88(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s9, 56(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a2, a2, s9
 ; RV32IMZBS-NEXT:    and a1, a1, s9
 ; RV32IMZBS-NEXT:    slli a2, a2, 4
 ; RV32IMZBS-NEXT:    or a1, a1, a2
-; RV32IMZBS-NEXT:    lw a4, 64(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 40(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a2, a4, 8
 ; RV32IMZBS-NEXT:    and a2, a2, s2
 ; RV32IMZBS-NEXT:    srli a3, a4, 24
@@ -8026,7 +8026,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    srli a4, a1, 2
 ; RV32IMZBS-NEXT:    lw a5, 24(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a6, a5, 1
-; RV32IMZBS-NEXT:    lw a5, 100(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 48(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, a5
 ; RV32IMZBS-NEXT:    and a1, a1, a5
 ; RV32IMZBS-NEXT:    or a2, a3, a2
@@ -8044,7 +8044,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    sw t2, 16(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    or a2, a3, a2
 ; RV32IMZBS-NEXT:    srli a1, a2, 1
-; RV32IMZBS-NEXT:    lw a3, 104(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a3, 52(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a2, a2, a3
 ; RV32IMZBS-NEXT:    and a1, a1, a3
 ; RV32IMZBS-NEXT:    slli a2, a2, 1
@@ -8065,9 +8065,9 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    mul t2, a7, s0
 ; RV32IMZBS-NEXT:    mul t3, a1, s6
 ; RV32IMZBS-NEXT:    xor s5, a6, a0
-; RV32IMZBS-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a0, a3, a0
-; RV32IMZBS-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul a6, a2, s0
 ; RV32IMZBS-NEXT:    mv a0, t5
 ; RV32IMZBS-NEXT:    mul t5, a4, t5
@@ -8075,12 +8075,12 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    mul s4, a1, s10
 ; RV32IMZBS-NEXT:    mul s7, a2, s10
 ; RV32IMZBS-NEXT:    mv a3, s10
-; RV32IMZBS-NEXT:    sw s10, 48(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s10, 8(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul s10, a4, s6
-; RV32IMZBS-NEXT:    sw s6, 64(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s6, 40(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul s11, a7, a0
 ; RV32IMZBS-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
-; RV32IMZBS-NEXT:    sw s0, 52(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s0, 12(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mul ra, a1, s0
 ; RV32IMZBS-NEXT:    xor t0, t1, t0
 ; RV32IMZBS-NEXT:    xor t1, t2, t3
@@ -8101,9 +8101,9 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    xor a6, t1, t2
 ; RV32IMZBS-NEXT:    xor a2, a4, a2
 ; RV32IMZBS-NEXT:    xor a1, a7, a1
-; RV32IMZBS-NEXT:    lw t1, 76(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t1, 44(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    srli a4, t1, 8
-; RV32IMZBS-NEXT:    sw s2, 92(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw s2, 60(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and a7, t1, s2
 ; RV32IMZBS-NEXT:    and a4, a4, s2
 ; RV32IMZBS-NEXT:    slli a7, a7, 8
@@ -8122,12 +8122,12 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    or ra, a4, a1
 ; RV32IMZBS-NEXT:    or a2, a6, a2
 ; RV32IMZBS-NEXT:    srli a4, a2, 2
-; RV32IMZBS-NEXT:    lw a0, 100(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a2, a2, a0
 ; RV32IMZBS-NEXT:    and a4, a4, a0
 ; RV32IMZBS-NEXT:    slli a2, a2, 2
 ; RV32IMZBS-NEXT:    or a2, a4, a2
-; RV32IMZBS-NEXT:    lw a0, 104(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    lw a4, 16(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a4, a4, a0
 ; RV32IMZBS-NEXT:    srli a6, a2, 1
@@ -8144,10 +8144,10 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    and t0, a2, s8
 ; RV32IMZBS-NEXT:    and a2, a2, s1
 ; RV32IMZBS-NEXT:    and s11, t6, t4
-; RV32IMZBS-NEXT:    sw t4, 8(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw t4, 68(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and s10, t6, a0
 ; RV32IMZBS-NEXT:    mv s8, a0
-; RV32IMZBS-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    and s9, t6, s1
 ; RV32IMZBS-NEXT:    and s7, t6, a5
 ; RV32IMZBS-NEXT:    mv t6, a5
@@ -8167,7 +8167,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    mul a3, s9, a6
 ; RV32IMZBS-NEXT:    mul a7, s9, a7
 ; RV32IMZBS-NEXT:    mul a6, s7, a6
-; RV32IMZBS-NEXT:    lw s2, 32(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s2, 28(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    or s6, s2, s6
 ; RV32IMZBS-NEXT:    lw s2, 20(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    or ra, s2, ra
@@ -8193,7 +8193,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    or a0, a0, a1
 ; RV32IMZBS-NEXT:    srli a1, s5, 8
 ; RV32IMZBS-NEXT:    xor a0, a0, ra
-; RV32IMZBS-NEXT:    lw a5, 92(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 60(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, a5
 ; RV32IMZBS-NEXT:    srli a2, s6, 1
 ; RV32IMZBS-NEXT:    srli a3, s5, 24
@@ -8214,7 +8214,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    or a1, a2, a1
 ; RV32IMZBS-NEXT:    or a0, a0, a3
 ; RV32IMZBS-NEXT:    srli a2, a1, 4
-; RV32IMZBS-NEXT:    lw s1, 88(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s1, 56(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, s1
 ; RV32IMZBS-NEXT:    and a2, a2, s1
 ; RV32IMZBS-NEXT:    slli a1, a1, 4
@@ -8225,7 +8225,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    or a1, a2, a1
 ; RV32IMZBS-NEXT:    or a0, a3, a0
 ; RV32IMZBS-NEXT:    srli a2, a1, 2
-; RV32IMZBS-NEXT:    lw t6, 100(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t6, 48(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, t6
 ; RV32IMZBS-NEXT:    and a2, a2, t6
 ; RV32IMZBS-NEXT:    slli a1, a1, 2
@@ -8235,20 +8235,20 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    slli a0, a0, 2
 ; RV32IMZBS-NEXT:    or a1, a2, a1
 ; RV32IMZBS-NEXT:    or a3, a3, a0
-; RV32IMZBS-NEXT:    lw s2, 56(sp) # 4-byte Folded Reload
-; RV32IMZBS-NEXT:    lw a5, 28(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s2, 84(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a5, 76(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul s8, a5, s2
-; RV32IMZBS-NEXT:    lw t5, 68(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t5, 92(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a2, a5, t5
-; RV32IMZBS-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a4, a5, a0
-; RV32IMZBS-NEXT:    lw t0, 72(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw t0, 96(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a5, a5, t0
-; RV32IMZBS-NEXT:    lw s6, 36(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s6, 32(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a6, s6, t0
-; RV32IMZBS-NEXT:    lw s0, 40(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s0, 80(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul a7, s0, t0
-; RV32IMZBS-NEXT:    lw s4, 44(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s4, 36(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t0, s4, t0
 ; RV32IMZBS-NEXT:    mul t1, s4, a0
 ; RV32IMZBS-NEXT:    mul t2, s6, a0
@@ -8261,7 +8261,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    mul s5, s6, a0
 ; RV32IMZBS-NEXT:    mul s6, s6, s2
 ; RV32IMZBS-NEXT:    srli ra, a1, 1
-; RV32IMZBS-NEXT:    lw s2, 104(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s2, 52(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a1, a1, s2
 ; RV32IMZBS-NEXT:    and ra, ra, s2
 ; RV32IMZBS-NEXT:    slli a1, a1, 1
@@ -8271,7 +8271,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    slli a3, a3, 1
 ; RV32IMZBS-NEXT:    or a1, ra, a1
 ; RV32IMZBS-NEXT:    or a0, a0, a3
-; RV32IMZBS-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
+; RV32IMZBS-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    xor a3, t1, s8
 ; RV32IMZBS-NEXT:    xor a6, t5, a6
 ; RV32IMZBS-NEXT:    xor a2, s3, a2
@@ -8284,23 +8284,23 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    xor a7, t3, s6
 ; RV32IMZBS-NEXT:    lw s3, 24(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t0, s11, s3
-; RV32IMZBS-NEXT:    lw s0, 48(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t1, s10, s0
-; RV32IMZBS-NEXT:    lw s5, 52(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s5, 12(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t2, s9, s5
-; RV32IMZBS-NEXT:    lw s4, 64(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s4, 40(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    mul t3, s7, s4
 ; RV32IMZBS-NEXT:    xor a4, a4, a6
 ; RV32IMZBS-NEXT:    xor a5, a5, a7
-; RV32IMZBS-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a3, a3, a0
-; RV32IMZBS-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw ra, 72(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a2, a2, ra
 ; RV32IMZBS-NEXT:    mul a6, s11, s5
 ; RV32IMZBS-NEXT:    mul a7, s10, s3
 ; RV32IMZBS-NEXT:    mv s6, t4
 ; RV32IMZBS-NEXT:    and a4, a4, t4
-; RV32IMZBS-NEXT:    lw s8, 96(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw s8, 64(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a5, a5, s8
 ; RV32IMZBS-NEXT:    or a2, a2, a3
 ; RV32IMZBS-NEXT:    or a4, a4, a5
@@ -8323,7 +8323,7 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    xor a4, a4, a5
 ; RV32IMZBS-NEXT:    srli a5, a2, 8
 ; RV32IMZBS-NEXT:    xor a4, a6, a4
-; RV32IMZBS-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    and a5, a5, a0
 ; RV32IMZBS-NEXT:    and a4, a4, ra
 ; RV32IMZBS-NEXT:    srli a6, a2, 24
@@ -8383,13 +8383,13 @@ define void @commutative_clmulr_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0, ptr %
 ; RV32IMZBS-NEXT:    slli a3, a3, 1
 ; RV32IMZBS-NEXT:    or a2, a5, a2
 ; RV32IMZBS-NEXT:    or a3, a4, a3
-; RV32IMZBS-NEXT:    lw a4, 80(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 100(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    sw a1, 0(a4)
 ; RV32IMZBS-NEXT:    sw a2, 4(a4)
-; RV32IMZBS-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    sw a0, 8(a4)
 ; RV32IMZBS-NEXT:    sw a3, 12(a4)
-; RV32IMZBS-NEXT:    lw a4, 84(sp) # 4-byte Folded Reload
+; RV32IMZBS-NEXT:    lw a4, 104(sp) # 4-byte Folded Reload
 ; RV32IMZBS-NEXT:    sw a1, 0(a4)
 ; RV32IMZBS-NEXT:    sw a2, 4(a4)
 ; RV32IMZBS-NEXT:    sw a0, 8(a4)

--- a/llvm/test/CodeGen/RISCV/di-assignment-tracking-vector.ll
+++ b/llvm/test/CodeGen/RISCV/di-assignment-tracking-vector.ll
@@ -10,7 +10,7 @@
 ; CHECK-LABEL: foo:
 ; CHECK-NEXT:  .Lfunc_begin0:
 ; CHECK:       # %bb.0
-; CHECK:         addi    a2, sp, 48
+; CHECK:         addi    a2, sp, 56
 ; CHECK-NEXT:    #DEBUG_VALUE: foo:i <- [DW_OP_deref] $x11
 ; CHECK-NEXT:    #DEBUG_VALUE: foo:j <- [DW_OP_deref] $x11
 ; CHECK:         vsse32.v

--- a/llvm/test/CodeGen/RISCV/double-stack-spill-restore.ll
+++ b/llvm/test/CodeGen/RISCV/double-stack-spill-restore.ll
@@ -13,26 +13,26 @@ define double @func(double %d, i32 %n) nounwind {
 ; RV32IFD:       # %bb.0: # %entry
 ; RV32IFD-NEXT:    addi sp, sp, -32
 ; RV32IFD-NEXT:    sw ra, 28(sp) # 4-byte Folded Spill
-; RV32IFD-NEXT:    sw a0, 16(sp)
-; RV32IFD-NEXT:    sw a1, 20(sp)
-; RV32IFD-NEXT:    fld fa5, 16(sp)
+; RV32IFD-NEXT:    sw a0, 8(sp)
+; RV32IFD-NEXT:    sw a1, 12(sp)
+; RV32IFD-NEXT:    fld fa5, 8(sp)
 ; RV32IFD-NEXT:    beqz a2, .LBB0_2
 ; RV32IFD-NEXT:  # %bb.1: # %if.else
 ; RV32IFD-NEXT:    addi a2, a2, -1
-; RV32IFD-NEXT:    fsd fa5, 16(sp)
-; RV32IFD-NEXT:    lw a0, 16(sp)
-; RV32IFD-NEXT:    lw a1, 20(sp)
-; RV32IFD-NEXT:    fsd fa5, 8(sp) # 8-byte Folded Spill
+; RV32IFD-NEXT:    fsd fa5, 8(sp)
+; RV32IFD-NEXT:    lw a0, 8(sp)
+; RV32IFD-NEXT:    lw a1, 12(sp)
+; RV32IFD-NEXT:    fsd fa5, 16(sp) # 8-byte Folded Spill
 ; RV32IFD-NEXT:    call func
-; RV32IFD-NEXT:    sw a0, 16(sp)
-; RV32IFD-NEXT:    sw a1, 20(sp)
-; RV32IFD-NEXT:    fld fa5, 16(sp)
-; RV32IFD-NEXT:    fld fa4, 8(sp) # 8-byte Folded Reload
+; RV32IFD-NEXT:    sw a0, 8(sp)
+; RV32IFD-NEXT:    sw a1, 12(sp)
+; RV32IFD-NEXT:    fld fa5, 8(sp)
+; RV32IFD-NEXT:    fld fa4, 16(sp) # 8-byte Folded Reload
 ; RV32IFD-NEXT:    fadd.d fa5, fa5, fa4
 ; RV32IFD-NEXT:  .LBB0_2: # %return
-; RV32IFD-NEXT:    fsd fa5, 16(sp)
-; RV32IFD-NEXT:    lw a0, 16(sp)
-; RV32IFD-NEXT:    lw a1, 20(sp)
+; RV32IFD-NEXT:    fsd fa5, 8(sp)
+; RV32IFD-NEXT:    lw a0, 8(sp)
+; RV32IFD-NEXT:    lw a1, 12(sp)
 ; RV32IFD-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload
 ; RV32IFD-NEXT:    addi sp, sp, 32
 ; RV32IFD-NEXT:    ret

--- a/llvm/test/CodeGen/RISCV/emit-x8-as-fp.ll
+++ b/llvm/test/CodeGen/RISCV/emit-x8-as-fp.ll
@@ -19,10 +19,10 @@ define signext i32 @add(i32 %0, i32 %1) #0 {
 ; RV32I-DEFAULT-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
 ; RV32I-DEFAULT-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; RV32I-DEFAULT-NEXT:    addi s0, sp, 16
-; RV32I-DEFAULT-NEXT:    sw a0, 4(sp)
-; RV32I-DEFAULT-NEXT:    sw a1, 0(sp)
-; RV32I-DEFAULT-NEXT:    lw a0, 4(sp)
-; RV32I-DEFAULT-NEXT:    lw a1, 0(sp)
+; RV32I-DEFAULT-NEXT:    sw a0, 0(sp)
+; RV32I-DEFAULT-NEXT:    sw a1, 4(sp)
+; RV32I-DEFAULT-NEXT:    lw a0, 0(sp)
+; RV32I-DEFAULT-NEXT:    lw a1, 4(sp)
 ; RV32I-DEFAULT-NEXT:    add a0, a0, a1
 ; RV32I-DEFAULT-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; RV32I-DEFAULT-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
@@ -35,10 +35,10 @@ define signext i32 @add(i32 %0, i32 %1) #0 {
 ; RV64I-DEFAULT-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
 ; RV64I-DEFAULT-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
 ; RV64I-DEFAULT-NEXT:    addi s0, sp, 32
-; RV64I-DEFAULT-NEXT:    sw a0, 12(sp)
-; RV64I-DEFAULT-NEXT:    sw a1, 8(sp)
-; RV64I-DEFAULT-NEXT:    lw a0, 12(sp)
-; RV64I-DEFAULT-NEXT:    lw a1, 8(sp)
+; RV64I-DEFAULT-NEXT:    sw a0, 8(sp)
+; RV64I-DEFAULT-NEXT:    sw a1, 12(sp)
+; RV64I-DEFAULT-NEXT:    lw a0, 8(sp)
+; RV64I-DEFAULT-NEXT:    lw a1, 12(sp)
 ; RV64I-DEFAULT-NEXT:    addw a0, a0, a1
 ; RV64I-DEFAULT-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
 ; RV64I-DEFAULT-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
@@ -51,10 +51,10 @@ define signext i32 @add(i32 %0, i32 %1) #0 {
 ; RV32I-EMIT-FP-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
 ; RV32I-EMIT-FP-NEXT:    sw fp, 8(sp) # 4-byte Folded Spill
 ; RV32I-EMIT-FP-NEXT:    addi fp, sp, 16
-; RV32I-EMIT-FP-NEXT:    sw a0, 4(sp)
-; RV32I-EMIT-FP-NEXT:    sw a1, 0(sp)
-; RV32I-EMIT-FP-NEXT:    lw a0, 4(sp)
-; RV32I-EMIT-FP-NEXT:    lw a1, 0(sp)
+; RV32I-EMIT-FP-NEXT:    sw a0, 0(sp)
+; RV32I-EMIT-FP-NEXT:    sw a1, 4(sp)
+; RV32I-EMIT-FP-NEXT:    lw a0, 0(sp)
+; RV32I-EMIT-FP-NEXT:    lw a1, 4(sp)
 ; RV32I-EMIT-FP-NEXT:    add a0, a0, a1
 ; RV32I-EMIT-FP-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; RV32I-EMIT-FP-NEXT:    lw fp, 8(sp) # 4-byte Folded Reload
@@ -67,10 +67,10 @@ define signext i32 @add(i32 %0, i32 %1) #0 {
 ; RV64I-EMIT-FP-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
 ; RV64I-EMIT-FP-NEXT:    sd fp, 16(sp) # 8-byte Folded Spill
 ; RV64I-EMIT-FP-NEXT:    addi fp, sp, 32
-; RV64I-EMIT-FP-NEXT:    sw a0, 12(sp)
-; RV64I-EMIT-FP-NEXT:    sw a1, 8(sp)
-; RV64I-EMIT-FP-NEXT:    lw a0, 12(sp)
-; RV64I-EMIT-FP-NEXT:    lw a1, 8(sp)
+; RV64I-EMIT-FP-NEXT:    sw a0, 8(sp)
+; RV64I-EMIT-FP-NEXT:    sw a1, 12(sp)
+; RV64I-EMIT-FP-NEXT:    lw a0, 8(sp)
+; RV64I-EMIT-FP-NEXT:    lw a1, 12(sp)
 ; RV64I-EMIT-FP-NEXT:    addw a0, a0, a1
 ; RV64I-EMIT-FP-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
 ; RV64I-EMIT-FP-NEXT:    ld fp, 16(sp) # 8-byte Folded Reload
@@ -83,10 +83,10 @@ define signext i32 @add(i32 %0, i32 %1) #0 {
 ; RV32I-NUMERIC-NEXT:    sw x1, 12(x2) # 4-byte Folded Spill
 ; RV32I-NUMERIC-NEXT:    sw x8, 8(x2) # 4-byte Folded Spill
 ; RV32I-NUMERIC-NEXT:    addi x8, x2, 16
-; RV32I-NUMERIC-NEXT:    sw x10, 4(x2)
-; RV32I-NUMERIC-NEXT:    sw x11, 0(x2)
-; RV32I-NUMERIC-NEXT:    lw x10, 4(x2)
-; RV32I-NUMERIC-NEXT:    lw x11, 0(x2)
+; RV32I-NUMERIC-NEXT:    sw x10, 0(x2)
+; RV32I-NUMERIC-NEXT:    sw x11, 4(x2)
+; RV32I-NUMERIC-NEXT:    lw x10, 0(x2)
+; RV32I-NUMERIC-NEXT:    lw x11, 4(x2)
 ; RV32I-NUMERIC-NEXT:    add x10, x10, x11
 ; RV32I-NUMERIC-NEXT:    lw x1, 12(x2) # 4-byte Folded Reload
 ; RV32I-NUMERIC-NEXT:    lw x8, 8(x2) # 4-byte Folded Reload
@@ -99,10 +99,10 @@ define signext i32 @add(i32 %0, i32 %1) #0 {
 ; RV64I-NUMERIC-NEXT:    sd x1, 24(x2) # 8-byte Folded Spill
 ; RV64I-NUMERIC-NEXT:    sd x8, 16(x2) # 8-byte Folded Spill
 ; RV64I-NUMERIC-NEXT:    addi x8, x2, 32
-; RV64I-NUMERIC-NEXT:    sw x10, 12(x2)
-; RV64I-NUMERIC-NEXT:    sw x11, 8(x2)
-; RV64I-NUMERIC-NEXT:    lw x10, 12(x2)
-; RV64I-NUMERIC-NEXT:    lw x11, 8(x2)
+; RV64I-NUMERIC-NEXT:    sw x10, 8(x2)
+; RV64I-NUMERIC-NEXT:    sw x11, 12(x2)
+; RV64I-NUMERIC-NEXT:    lw x10, 8(x2)
+; RV64I-NUMERIC-NEXT:    lw x11, 12(x2)
 ; RV64I-NUMERIC-NEXT:    addw x10, x10, x11
 ; RV64I-NUMERIC-NEXT:    ld x1, 24(x2) # 8-byte Folded Reload
 ; RV64I-NUMERIC-NEXT:    ld x8, 16(x2) # 8-byte Folded Reload

--- a/llvm/test/CodeGen/RISCV/forced-atomics.ll
+++ b/llvm/test/CodeGen/RISCV/forced-atomics.ll
@@ -4597,13 +4597,13 @@ define i128 @rmw128(ptr %p) nounwind {
 ; RV32-NEXT:    mv s1, a1
 ; RV32-NEXT:    mv s0, a0
 ; RV32-NEXT:    li a0, 16
-; RV32-NEXT:    addi a2, sp, 16
+; RV32-NEXT:    mv a2, sp
 ; RV32-NEXT:    li a3, 0
 ; RV32-NEXT:    call __atomic_load
-; RV32-NEXT:    lw a2, 16(sp)
-; RV32-NEXT:    lw a3, 20(sp)
-; RV32-NEXT:    lw a4, 24(sp)
-; RV32-NEXT:    lw a1, 28(sp)
+; RV32-NEXT:    lw a2, 0(sp)
+; RV32-NEXT:    lw a3, 4(sp)
+; RV32-NEXT:    lw a4, 8(sp)
+; RV32-NEXT:    lw a1, 12(sp)
 ; RV32-NEXT:  .LBB62_1: # %atomicrmw.start
 ; RV32-NEXT:    # =>This Inner Loop Header: Depth=1
 ; RV32-NEXT:    addi a0, a2, 1
@@ -4613,26 +4613,26 @@ define i128 @rmw128(ptr %p) nounwind {
 ; RV32-NEXT:    seqz a6, a6
 ; RV32-NEXT:    add a6, a4, a6
 ; RV32-NEXT:    sltu a7, a6, a4
-; RV32-NEXT:    sw a2, 16(sp)
-; RV32-NEXT:    sw a3, 20(sp)
-; RV32-NEXT:    sw a4, 24(sp)
-; RV32-NEXT:    sw a1, 28(sp)
-; RV32-NEXT:    add a1, a1, a7
-; RV32-NEXT:    sw a0, 0(sp)
-; RV32-NEXT:    sw a5, 4(sp)
-; RV32-NEXT:    sw a6, 8(sp)
+; RV32-NEXT:    sw a2, 0(sp)
+; RV32-NEXT:    sw a3, 4(sp)
+; RV32-NEXT:    sw a4, 8(sp)
 ; RV32-NEXT:    sw a1, 12(sp)
+; RV32-NEXT:    add a1, a1, a7
+; RV32-NEXT:    sw a0, 16(sp)
+; RV32-NEXT:    sw a5, 20(sp)
+; RV32-NEXT:    sw a6, 24(sp)
+; RV32-NEXT:    sw a1, 28(sp)
 ; RV32-NEXT:    li a0, 16
-; RV32-NEXT:    addi a2, sp, 16
-; RV32-NEXT:    mv a3, sp
+; RV32-NEXT:    mv a2, sp
+; RV32-NEXT:    addi a3, sp, 16
 ; RV32-NEXT:    li a4, 5
 ; RV32-NEXT:    li a5, 5
 ; RV32-NEXT:    mv a1, s1
 ; RV32-NEXT:    call __atomic_compare_exchange
-; RV32-NEXT:    lw a2, 16(sp)
-; RV32-NEXT:    lw a3, 20(sp)
-; RV32-NEXT:    lw a4, 24(sp)
-; RV32-NEXT:    lw a1, 28(sp)
+; RV32-NEXT:    lw a2, 0(sp)
+; RV32-NEXT:    lw a3, 4(sp)
+; RV32-NEXT:    lw a4, 8(sp)
+; RV32-NEXT:    lw a1, 12(sp)
 ; RV32-NEXT:    beqz a0, .LBB62_1
 ; RV32-NEXT:  # %bb.2: # %atomicrmw.end
 ; RV32-NEXT:    sw a2, 0(s0)
@@ -4667,25 +4667,25 @@ define i128 @cmpxchg128(ptr %p) nounwind {
 ; RV32-NEXT:    sw ra, 44(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    sw s0, 40(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    mv s0, a0
-; RV32-NEXT:    sw zero, 24(sp)
-; RV32-NEXT:    sw zero, 28(sp)
-; RV32-NEXT:    sw zero, 32(sp)
-; RV32-NEXT:    sw zero, 36(sp)
-; RV32-NEXT:    li a0, 1
-; RV32-NEXT:    sw a0, 8(sp)
+; RV32-NEXT:    sw zero, 8(sp)
 ; RV32-NEXT:    sw zero, 12(sp)
 ; RV32-NEXT:    sw zero, 16(sp)
 ; RV32-NEXT:    sw zero, 20(sp)
+; RV32-NEXT:    li a0, 1
+; RV32-NEXT:    sw a0, 24(sp)
+; RV32-NEXT:    sw zero, 28(sp)
+; RV32-NEXT:    sw zero, 32(sp)
+; RV32-NEXT:    sw zero, 36(sp)
 ; RV32-NEXT:    li a0, 16
-; RV32-NEXT:    addi a2, sp, 24
-; RV32-NEXT:    addi a3, sp, 8
+; RV32-NEXT:    addi a2, sp, 8
+; RV32-NEXT:    addi a3, sp, 24
 ; RV32-NEXT:    li a4, 5
 ; RV32-NEXT:    li a5, 5
 ; RV32-NEXT:    call __atomic_compare_exchange
-; RV32-NEXT:    lw a0, 24(sp)
-; RV32-NEXT:    lw a1, 28(sp)
-; RV32-NEXT:    lw a2, 32(sp)
-; RV32-NEXT:    lw a3, 36(sp)
+; RV32-NEXT:    lw a0, 8(sp)
+; RV32-NEXT:    lw a1, 12(sp)
+; RV32-NEXT:    lw a2, 16(sp)
+; RV32-NEXT:    lw a3, 20(sp)
 ; RV32-NEXT:    sw a0, 0(s0)
 ; RV32-NEXT:    sw a1, 4(s0)
 ; RV32-NEXT:    sw a2, 8(s0)

--- a/llvm/test/CodeGen/RISCV/frame-base-addr-reuse.mir
+++ b/llvm/test/CodeGen/RISCV/frame-base-addr-reuse.mir
@@ -1,18 +1,24 @@
 # REQUIRES: asserts
 #
-# RUN: llc -mtriple=riscv64 \
+# RUN: llc -mtriple=riscv64 -stack-symbol-ordering=0 \
 # RUN:   -run-pass=prolog-epilog -run-pass=machine-latecleanup -o - %s \
 # RUN:   | FileCheck -check-prefix=RV64 %s
-# RUN: llc -mtriple=riscv64 \
+# RUN: llc -mtriple=riscv64 -stack-symbol-ordering=0 \
 # RUN:   -run-pass=prolog-epilog -run-pass=machine-latecleanup \
 # RUN:   -run-pass=riscv-post-ra-expand-pseudo -o - %s \
 # RUN:   | FileCheck -check-prefix=RV64-EXPAND %s
-# RUN: llc -mtriple=riscv32 \
+# RUN: llc -mtriple=riscv32 -stack-symbol-ordering=0 \
 # RUN:   -run-pass=prolog-epilog -run-pass=machine-latecleanup -o - %s \
 # RUN:   | FileCheck -check-prefix=RV32 %s
 #
 # Test that identical large stack-frame base address materializations are
 # deduplicated by MachineLateInstrsCleanup via PseudoAddUpperImm.
+#
+# Stack symbol ordering is disabled so that the frame layout under test stays
+# fixed. This test covers PseudoAddUpperImm emission and CSE, not the frame
+# object placement policy: with the default density-based ordering the small
+# hot slots move next to SP, their offsets fold into the load/store immediate,
+# and no base address needs materializing at all.
 
 --- |
   define void @test_same_region() nounwind { ret void }

--- a/llvm/test/CodeGen/RISCV/idiv_large.ll
+++ b/llvm/test/CodeGen/RISCV/idiv_large.ll
@@ -1042,17 +1042,17 @@ define i129 @udiv_i129(i129 %x, i129 %y) nounwind {
 ; RV32-NEXT:    lw t2, 16(a2)
 ; RV32-NEXT:    lw a6, 0(a2)
 ; RV32-NEXT:    lw a2, 12(a2)
-; RV32-NEXT:    sw a2, 20(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw a4, 28(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a2, 0(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a4, 8(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    slli a2, a4, 31
 ; RV32-NEXT:    srli a4, a5, 1
 ; RV32-NEXT:    addi t5, a0, 1365
 ; RV32-NEXT:    or a0, a4, a2
 ; RV32-NEXT:    addi t4, a3, 819
 ; RV32-NEXT:    lui a2, 61681
-; RV32-NEXT:    sw a5, 16(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a5, 12(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    slli a3, a5, 31
-; RV32-NEXT:    sw a6, 24(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a6, 4(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    srli a4, a6, 1
 ; RV32-NEXT:    addi t3, a2, -241
 ; RV32-NEXT:    or a6, a4, a3
@@ -1114,13 +1114,13 @@ define i129 @udiv_i129(i129 %x, i129 %y) nounwind {
 ; RV32-NEXT:    add a2, a2, a3
 ; RV32-NEXT:    srli t0, a2, 24
 ; RV32-NEXT:  .LBB3_3: # %_udiv-special-cases
-; RV32-NEXT:    lw a5, 20(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a5, 0(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    srli a2, a5, 1
 ; RV32-NEXT:    slli a4, t2, 31
 ; RV32-NEXT:    slli a5, a5, 31
-; RV32-NEXT:    lw a3, 24(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a3, 4(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    slli a3, a3, 31
-; RV32-NEXT:    lw a7, 28(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a7, 8(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    srli a7, a7, 1
 ; RV32-NEXT:    li s1, 64
 ; RV32-NEXT:    bnez a3, .LBB3_5
@@ -1426,16 +1426,16 @@ define i129 @udiv_i129(i129 %x, i129 %y) nounwind {
 ; RV32-NEXT:  .LBB3_28: # %_udiv-special-cases
 ; RV32-NEXT:    andi s11, a1, 1
 ; RV32-NEXT:    andi s4, t2, 1
-; RV32-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s1, 24(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw s1, 4(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    or s1, s1, a1
 ; RV32-NEXT:    or a1, a7, a6
 ; RV32-NEXT:    bnez s5, .LBB3_30
 ; RV32-NEXT:  # %bb.29: # %_udiv-special-cases
 ; RV32-NEXT:    mv a4, a3
 ; RV32-NEXT:  .LBB3_30: # %_udiv-special-cases
-; RV32-NEXT:    lw a2, 16(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw a3, 20(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a2, 12(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a3, 0(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    or s6, a2, a3
 ; RV32-NEXT:    or a5, s1, s4
 ; RV32-NEXT:    or a2, t0, t1
@@ -1494,8 +1494,8 @@ define i129 @udiv_i129(i129 %x, i129 %y) nounwind {
 ; RV32-NEXT:    or t6, t6, s2
 ; RV32-NEXT:    beqz t6, .LBB3_55
 ; RV32-NEXT:  # %bb.40: # %udiv-bb1
-; RV32-NEXT:    sw s4, 36(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s7, 0(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s4, 16(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s7, 24(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    addi a1, a0, 1
 ; RV32-NEXT:    seqz a2, a1
 ; RV32-NEXT:    add t2, t2, a2
@@ -1606,34 +1606,34 @@ define i129 @udiv_i129(i129 %x, i129 %y) nounwind {
 ; RV32-NEXT:    srl a2, a2, a1
 ; RV32-NEXT:    snez a3, a3
 ; RV32-NEXT:    slli a5, a5, 1
-; RV32-NEXT:    lw a4, 36(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a4, 16(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    add a3, a4, a3
 ; RV32-NEXT:    sll a4, a5, t0
 ; RV32-NEXT:    not a3, a3
 ; RV32-NEXT:    or s6, a2, a4
 ; RV32-NEXT:    andi a3, a3, 1
-; RV32-NEXT:    sw a3, 12(sp) # 4-byte Folded Spill
-; RV32-NEXT:    lw a5, 24(sp) # 4-byte Folded Reload
+; RV32-NEXT:    sw a3, 36(sp) # 4-byte Folded Spill
+; RV32-NEXT:    lw a5, 4(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    seqz a2, a5
-; RV32-NEXT:    lw a4, 16(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a4, 12(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    or a3, a5, a4
 ; RV32-NEXT:    sub a6, a4, a2
 ; RV32-NEXT:    seqz a2, a3
-; RV32-NEXT:    lw a3, 28(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a3, 8(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    sub a4, a3, a2
-; RV32-NEXT:    sw a4, 32(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a4, 20(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    sltu a2, a3, a2
-; RV32-NEXT:    lw a3, 20(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a3, 0(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    sub s4, a3, a2
 ; RV32-NEXT:    addi a5, a5, -1
-; RV32-NEXT:    sw a5, 4(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw a6, 8(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a5, 28(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw a6, 32(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    mv t1, t5
 ; RV32-NEXT:    j .LBB3_43
 ; RV32-NEXT:  .LBB3_42: # %udiv-do-while
 ; RV32-NEXT:    # in Loop: Header=BB3_43 Depth=1
 ; RV32-NEXT:    mv s8, s7
-; RV32-NEXT:    lw a7, 28(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a7, 8(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    and a7, s1, a7
 ; RV32-NEXT:    xor ra, a3, s11
 ; RV32-NEXT:    xor t0, a0, a7
@@ -1665,7 +1665,7 @@ define i129 @udiv_i129(i129 %x, i129 %y) nounwind {
 ; RV32-NEXT:    sub a3, a3, t0
 ; RV32-NEXT:    sub s11, a3, a5
 ; RV32-NEXT:    sub a2, s5, a2
-; RV32-NEXT:    lw a7, 36(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a7, 16(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    or a3, a1, a7
 ; RV32-NEXT:    or a5, t2, t3
 ; RV32-NEXT:    sub s5, a2, a6
@@ -1691,7 +1691,7 @@ define i129 @udiv_i129(i129 %x, i129 %y) nounwind {
 ; RV32-NEXT:    li s8, 0
 ; RV32-NEXT:    li s9, 0
 ; RV32-NEXT:    li s10, 0
-; RV32-NEXT:    lw a6, 8(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a6, 32(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    beqz a2, .LBB3_54
 ; RV32-NEXT:  .LBB3_43: # %udiv-do-while
 ; RV32-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -1707,11 +1707,11 @@ define i129 @udiv_i129(i129 %x, i129 %y) nounwind {
 ; RV32-NEXT:    sltu a2, s4, a3
 ; RV32-NEXT:    j .LBB3_46
 ; RV32-NEXT:  .LBB3_45: # in Loop: Header=BB3_43 Depth=1
-; RV32-NEXT:    lw a2, 32(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a2, 20(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    sltu a2, a2, a0
 ; RV32-NEXT:  .LBB3_46: # %udiv-do-while
 ; RV32-NEXT:    # in Loop: Header=BB3_43 Depth=1
-; RV32-NEXT:    sw t4, 36(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw t4, 16(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    srli a4, s6, 31
 ; RV32-NEXT:    slli s5, s5, 1
 ; RV32-NEXT:    or s5, s5, a4
@@ -1725,13 +1725,13 @@ define i129 @udiv_i129(i129 %x, i129 %y) nounwind {
 ; RV32-NEXT:    sltu a4, a6, s5
 ; RV32-NEXT:    j .LBB3_49
 ; RV32-NEXT:  .LBB3_48: # in Loop: Header=BB3_43 Depth=1
-; RV32-NEXT:    lw a4, 4(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a4, 28(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    sltu a4, a4, s6
 ; RV32-NEXT:  .LBB3_49: # %udiv-do-while
 ; RV32-NEXT:    # in Loop: Header=BB3_43 Depth=1
 ; RV32-NEXT:    mv s3, s10
 ; RV32-NEXT:    mv t5, s1
-; RV32-NEXT:    lw a5, 32(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a5, 20(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    xor a5, a5, a0
 ; RV32-NEXT:    xor a6, s4, a3
 ; RV32-NEXT:    or a5, a5, a6
@@ -1743,17 +1743,17 @@ define i129 @udiv_i129(i129 %x, i129 %y) nounwind {
 ; RV32-NEXT:    # in Loop: Header=BB3_43 Depth=1
 ; RV32-NEXT:    mv s10, s9
 ; RV32-NEXT:    srli a2, s11, 31
-; RV32-NEXT:    lw a5, 12(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a5, 36(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    sub a2, a5, a2
 ; RV32-NEXT:    sub a2, a2, a4
 ; RV32-NEXT:    slli a2, a2, 31
 ; RV32-NEXT:    srai s1, a2, 31
-; RV32-NEXT:    lw a2, 20(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a2, 0(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    and s11, s1, a2
 ; RV32-NEXT:    mv s9, s8
-; RV32-NEXT:    lw a4, 24(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a4, 4(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    and a4, s1, a4
-; RV32-NEXT:    lw a2, 16(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw a2, 12(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    and a2, s1, a2
 ; RV32-NEXT:    sltu a6, s6, a4
 ; RV32-NEXT:    mv a5, a6
@@ -1778,7 +1778,7 @@ define i129 @udiv_i129(i129 %x, i129 %y) nounwind {
 ; RV32-NEXT:    slli t6, t6, 1
 ; RV32-NEXT:    srli a5, t1, 31
 ; RV32-NEXT:    or t4, s1, t6
-; RV32-NEXT:    lw s7, 0(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw s7, 24(sp) # 4-byte Folded Reload
 ; RV32-NEXT:  .LBB3_55: # %udiv-end
 ; RV32-NEXT:    sw t4, 0(s7)
 ; RV32-NEXT:    sw a2, 4(s7)

--- a/llvm/test/CodeGen/RISCV/ipra.ll
+++ b/llvm/test/CodeGen/RISCV/ipra.ll
@@ -95,8 +95,8 @@ define internal void @foobar(ptr %live_throughout.0.val) norecurse nounwind {
 ; RV64-WITHFP-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
 ; RV64-WITHFP-NEXT:    addi s0, sp, 64
 ; RV64-WITHFP-NEXT:    mv a1, a0
-; RV64-WITHFP-NEXT:    addi a0, sp, 16
-; RV64-WITHFP-NEXT:    addi a2, sp, 12
+; RV64-WITHFP-NEXT:    addi a0, sp, 8
+; RV64-WITHFP-NEXT:    addi a2, sp, 44
 ; RV64-WITHFP-NEXT:    call bmp_iter_set_init
 ; RV64-WITHFP-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
 ; RV64-WITHFP-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
@@ -110,8 +110,8 @@ define internal void @foobar(ptr %live_throughout.0.val) norecurse nounwind {
 ; RV32-WITHFP-NEXT:    sw s0, 40(sp) # 4-byte Folded Spill
 ; RV32-WITHFP-NEXT:    addi s0, sp, 48
 ; RV32-WITHFP-NEXT:    mv a1, a0
-; RV32-WITHFP-NEXT:    addi a0, sp, 16
-; RV32-WITHFP-NEXT:    addi a2, sp, 12
+; RV32-WITHFP-NEXT:    addi a0, sp, 8
+; RV32-WITHFP-NEXT:    addi a2, sp, 36
 ; RV32-WITHFP-NEXT:    call bmp_iter_set_init
 ; RV32-WITHFP-NEXT:    lw ra, 44(sp) # 4-byte Folded Reload
 ; RV32-WITHFP-NEXT:    lw s0, 40(sp) # 4-byte Folded Reload

--- a/llvm/test/CodeGen/RISCV/llvm.frexp.ll
+++ b/llvm/test/CodeGen/RISCV/llvm.frexp.ll
@@ -1552,19 +1552,19 @@ define { fp128, i32 } @test_frexp_f128_i32(fp128 %a) nounwind {
 ; RV32IFD-NEXT:    lw a5, 8(a1)
 ; RV32IFD-NEXT:    lw a6, 12(a1)
 ; RV32IFD-NEXT:    mv s0, a0
-; RV32IFD-NEXT:    addi a0, sp, 16
-; RV32IFD-NEXT:    mv a1, sp
-; RV32IFD-NEXT:    addi a2, sp, 36
-; RV32IFD-NEXT:    sw a3, 0(sp)
-; RV32IFD-NEXT:    sw a4, 4(sp)
-; RV32IFD-NEXT:    sw a5, 8(sp)
-; RV32IFD-NEXT:    sw a6, 12(sp)
+; RV32IFD-NEXT:    addi a0, sp, 24
+; RV32IFD-NEXT:    addi a1, sp, 8
+; RV32IFD-NEXT:    addi a2, sp, 4
+; RV32IFD-NEXT:    sw a3, 8(sp)
+; RV32IFD-NEXT:    sw a4, 12(sp)
+; RV32IFD-NEXT:    sw a5, 16(sp)
+; RV32IFD-NEXT:    sw a6, 20(sp)
 ; RV32IFD-NEXT:    call frexpl
-; RV32IFD-NEXT:    lw a0, 16(sp)
-; RV32IFD-NEXT:    lw a1, 20(sp)
-; RV32IFD-NEXT:    lw a2, 24(sp)
-; RV32IFD-NEXT:    lw a3, 36(sp)
-; RV32IFD-NEXT:    lw a4, 28(sp)
+; RV32IFD-NEXT:    lw a0, 24(sp)
+; RV32IFD-NEXT:    lw a1, 28(sp)
+; RV32IFD-NEXT:    lw a2, 32(sp)
+; RV32IFD-NEXT:    lw a3, 4(sp)
+; RV32IFD-NEXT:    lw a4, 36(sp)
 ; RV32IFD-NEXT:    sw a0, 0(s0)
 ; RV32IFD-NEXT:    sw a1, 4(s0)
 ; RV32IFD-NEXT:    sw a2, 8(s0)
@@ -1605,19 +1605,19 @@ define { fp128, i32 } @test_frexp_f128_i32(fp128 %a) nounwind {
 ; RV32IZFINXZDINX-NEXT:    lw a5, 8(a1)
 ; RV32IZFINXZDINX-NEXT:    lw a6, 12(a1)
 ; RV32IZFINXZDINX-NEXT:    mv s0, a0
-; RV32IZFINXZDINX-NEXT:    addi a0, sp, 16
-; RV32IZFINXZDINX-NEXT:    mv a1, sp
-; RV32IZFINXZDINX-NEXT:    addi a2, sp, 36
-; RV32IZFINXZDINX-NEXT:    sw a3, 0(sp)
-; RV32IZFINXZDINX-NEXT:    sw a4, 4(sp)
-; RV32IZFINXZDINX-NEXT:    sw a5, 8(sp)
-; RV32IZFINXZDINX-NEXT:    sw a6, 12(sp)
+; RV32IZFINXZDINX-NEXT:    addi a0, sp, 24
+; RV32IZFINXZDINX-NEXT:    addi a1, sp, 8
+; RV32IZFINXZDINX-NEXT:    addi a2, sp, 4
+; RV32IZFINXZDINX-NEXT:    sw a3, 8(sp)
+; RV32IZFINXZDINX-NEXT:    sw a4, 12(sp)
+; RV32IZFINXZDINX-NEXT:    sw a5, 16(sp)
+; RV32IZFINXZDINX-NEXT:    sw a6, 20(sp)
 ; RV32IZFINXZDINX-NEXT:    call frexpl
-; RV32IZFINXZDINX-NEXT:    lw a0, 16(sp)
-; RV32IZFINXZDINX-NEXT:    lw a1, 20(sp)
-; RV32IZFINXZDINX-NEXT:    lw a2, 24(sp)
-; RV32IZFINXZDINX-NEXT:    lw a3, 36(sp)
-; RV32IZFINXZDINX-NEXT:    lw a4, 28(sp)
+; RV32IZFINXZDINX-NEXT:    lw a0, 24(sp)
+; RV32IZFINXZDINX-NEXT:    lw a1, 28(sp)
+; RV32IZFINXZDINX-NEXT:    lw a2, 32(sp)
+; RV32IZFINXZDINX-NEXT:    lw a3, 4(sp)
+; RV32IZFINXZDINX-NEXT:    lw a4, 36(sp)
 ; RV32IZFINXZDINX-NEXT:    sw a0, 0(s0)
 ; RV32IZFINXZDINX-NEXT:    sw a1, 4(s0)
 ; RV32IZFINXZDINX-NEXT:    sw a2, 8(s0)
@@ -1658,19 +1658,19 @@ define { fp128, i32 } @test_frexp_f128_i32(fp128 %a) nounwind {
 ; RV32I-NEXT:    lw a5, 8(a1)
 ; RV32I-NEXT:    lw a6, 12(a1)
 ; RV32I-NEXT:    mv s0, a0
-; RV32I-NEXT:    addi a0, sp, 16
-; RV32I-NEXT:    mv a1, sp
-; RV32I-NEXT:    addi a2, sp, 36
-; RV32I-NEXT:    sw a3, 0(sp)
-; RV32I-NEXT:    sw a4, 4(sp)
-; RV32I-NEXT:    sw a5, 8(sp)
-; RV32I-NEXT:    sw a6, 12(sp)
+; RV32I-NEXT:    addi a0, sp, 24
+; RV32I-NEXT:    addi a1, sp, 8
+; RV32I-NEXT:    addi a2, sp, 4
+; RV32I-NEXT:    sw a3, 8(sp)
+; RV32I-NEXT:    sw a4, 12(sp)
+; RV32I-NEXT:    sw a5, 16(sp)
+; RV32I-NEXT:    sw a6, 20(sp)
 ; RV32I-NEXT:    call frexpl
-; RV32I-NEXT:    lw a0, 16(sp)
-; RV32I-NEXT:    lw a1, 20(sp)
-; RV32I-NEXT:    lw a2, 24(sp)
-; RV32I-NEXT:    lw a3, 36(sp)
-; RV32I-NEXT:    lw a4, 28(sp)
+; RV32I-NEXT:    lw a0, 24(sp)
+; RV32I-NEXT:    lw a1, 28(sp)
+; RV32I-NEXT:    lw a2, 32(sp)
+; RV32I-NEXT:    lw a3, 4(sp)
+; RV32I-NEXT:    lw a4, 36(sp)
 ; RV32I-NEXT:    sw a0, 0(s0)
 ; RV32I-NEXT:    sw a1, 4(s0)
 ; RV32I-NEXT:    sw a2, 8(s0)
@@ -1843,13 +1843,13 @@ define i32 @test_frexp_f128_i32_only_use_exp(fp128 %a) nounwind {
 ; RV32IFD-NEXT:    lw a6, 12(a0)
 ; RV32IFD-NEXT:    addi a0, sp, 24
 ; RV32IFD-NEXT:    addi a1, sp, 8
-; RV32IFD-NEXT:    addi a2, sp, 40
+; RV32IFD-NEXT:    addi a2, sp, 4
 ; RV32IFD-NEXT:    sw a3, 8(sp)
 ; RV32IFD-NEXT:    sw a4, 12(sp)
 ; RV32IFD-NEXT:    sw a5, 16(sp)
 ; RV32IFD-NEXT:    sw a6, 20(sp)
 ; RV32IFD-NEXT:    call frexpl
-; RV32IFD-NEXT:    lw a0, 40(sp)
+; RV32IFD-NEXT:    lw a0, 4(sp)
 ; RV32IFD-NEXT:    lw ra, 44(sp) # 4-byte Folded Reload
 ; RV32IFD-NEXT:    addi sp, sp, 48
 ; RV32IFD-NEXT:    ret
@@ -1875,13 +1875,13 @@ define i32 @test_frexp_f128_i32_only_use_exp(fp128 %a) nounwind {
 ; RV32IZFINXZDINX-NEXT:    lw a6, 12(a0)
 ; RV32IZFINXZDINX-NEXT:    addi a0, sp, 24
 ; RV32IZFINXZDINX-NEXT:    addi a1, sp, 8
-; RV32IZFINXZDINX-NEXT:    addi a2, sp, 40
+; RV32IZFINXZDINX-NEXT:    addi a2, sp, 4
 ; RV32IZFINXZDINX-NEXT:    sw a3, 8(sp)
 ; RV32IZFINXZDINX-NEXT:    sw a4, 12(sp)
 ; RV32IZFINXZDINX-NEXT:    sw a5, 16(sp)
 ; RV32IZFINXZDINX-NEXT:    sw a6, 20(sp)
 ; RV32IZFINXZDINX-NEXT:    call frexpl
-; RV32IZFINXZDINX-NEXT:    lw a0, 40(sp)
+; RV32IZFINXZDINX-NEXT:    lw a0, 4(sp)
 ; RV32IZFINXZDINX-NEXT:    lw ra, 44(sp) # 4-byte Folded Reload
 ; RV32IZFINXZDINX-NEXT:    addi sp, sp, 48
 ; RV32IZFINXZDINX-NEXT:    ret
@@ -1907,13 +1907,13 @@ define i32 @test_frexp_f128_i32_only_use_exp(fp128 %a) nounwind {
 ; RV32I-NEXT:    lw a6, 12(a0)
 ; RV32I-NEXT:    addi a0, sp, 24
 ; RV32I-NEXT:    addi a1, sp, 8
-; RV32I-NEXT:    addi a2, sp, 40
+; RV32I-NEXT:    addi a2, sp, 4
 ; RV32I-NEXT:    sw a3, 8(sp)
 ; RV32I-NEXT:    sw a4, 12(sp)
 ; RV32I-NEXT:    sw a5, 16(sp)
 ; RV32I-NEXT:    sw a6, 20(sp)
 ; RV32I-NEXT:    call frexpl
-; RV32I-NEXT:    lw a0, 40(sp)
+; RV32I-NEXT:    lw a0, 4(sp)
 ; RV32I-NEXT:    lw ra, 44(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    addi sp, sp, 48
 ; RV32I-NEXT:    ret

--- a/llvm/test/CodeGen/RISCV/llvm.sincos.ll
+++ b/llvm/test/CodeGen/RISCV/llvm.sincos.ll
@@ -102,23 +102,23 @@ define { fp128, fp128 } @test_sincos_f128(fp128 %a) nounwind {
 ; RV32-NEXT:    lw a6, 8(a1)
 ; RV32-NEXT:    lw a7, 12(a1)
 ; RV32-NEXT:    mv s0, a0
-; RV32-NEXT:    addi a0, sp, 24
+; RV32-NEXT:    addi a0, sp, 56
 ; RV32-NEXT:    addi a1, sp, 8
-; RV32-NEXT:    addi a2, sp, 56
-; RV32-NEXT:    addi a3, sp, 40
+; RV32-NEXT:    addi a2, sp, 40
+; RV32-NEXT:    addi a3, sp, 24
 ; RV32-NEXT:    sw a4, 8(sp)
 ; RV32-NEXT:    sw a5, 12(sp)
 ; RV32-NEXT:    sw a6, 16(sp)
 ; RV32-NEXT:    sw a7, 20(sp)
 ; RV32-NEXT:    call sincosl
-; RV32-NEXT:    lw a0, 40(sp)
-; RV32-NEXT:    lw a1, 44(sp)
-; RV32-NEXT:    lw a2, 48(sp)
-; RV32-NEXT:    lw a3, 52(sp)
-; RV32-NEXT:    lw a4, 56(sp)
-; RV32-NEXT:    lw a5, 60(sp)
-; RV32-NEXT:    lw a6, 64(sp)
-; RV32-NEXT:    lw a7, 68(sp)
+; RV32-NEXT:    lw a0, 24(sp)
+; RV32-NEXT:    lw a1, 28(sp)
+; RV32-NEXT:    lw a2, 32(sp)
+; RV32-NEXT:    lw a3, 36(sp)
+; RV32-NEXT:    lw a4, 40(sp)
+; RV32-NEXT:    lw a5, 44(sp)
+; RV32-NEXT:    lw a6, 48(sp)
+; RV32-NEXT:    lw a7, 52(sp)
 ; RV32-NEXT:    sw a0, 16(s0)
 ; RV32-NEXT:    sw a1, 20(s0)
 ; RV32-NEXT:    sw a2, 24(s0)

--- a/llvm/test/CodeGen/RISCV/pr58286.ll
+++ b/llvm/test/CodeGen/RISCV/pr58286.ll
@@ -25,11 +25,7 @@ define void @func() {
 ; RV64I-NEXT:    lw t4, %lo(var)(a0)
 ; RV64I-NEXT:    lw t5, %lo(var)(a0)
 ; RV64I-NEXT:    lw t6, %lo(var)(a0)
-; RV64I-NEXT:    sd s0, 0(sp) # 8-byte Folded Spill
-; RV64I-NEXT:    lui s0, 1
-; RV64I-NEXT:    add s0, sp, s0
-; RV64I-NEXT:    sw a1, 12(s0)
-; RV64I-NEXT:    ld s0, 0(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    sw a1, 12(sp)
 ; RV64I-NEXT:    sw a1, %lo(var)(a0)
 ; RV64I-NEXT:    sw a2, %lo(var)(a0)
 ; RV64I-NEXT:    sw a3, %lo(var)(a0)
@@ -71,11 +67,7 @@ define void @func() {
 ; RV32I-NEXT:    lw t4, %lo(var)(a0)
 ; RV32I-NEXT:    lw t5, %lo(var)(a0)
 ; RV32I-NEXT:    lw t6, %lo(var)(a0)
-; RV32I-NEXT:    sw s0, 0(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lui s0, 1
-; RV32I-NEXT:    add s0, sp, s0
-; RV32I-NEXT:    sw a1, 12(s0)
-; RV32I-NEXT:    lw s0, 0(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a1, 12(sp)
 ; RV32I-NEXT:    sw a1, %lo(var)(a0)
 ; RV32I-NEXT:    sw a2, %lo(var)(a0)
 ; RV32I-NEXT:    sw a3, %lo(var)(a0)
@@ -160,11 +152,7 @@ define void @shrink_wrap(i1 %c) {
 ; RV64I-NEXT:    lw t4, %lo(var)(a0)
 ; RV64I-NEXT:    lw t5, %lo(var)(a0)
 ; RV64I-NEXT:    lw t6, %lo(var)(a0)
-; RV64I-NEXT:    sd s0, 0(sp) # 8-byte Folded Spill
-; RV64I-NEXT:    lui s0, 1
-; RV64I-NEXT:    add s0, sp, s0
-; RV64I-NEXT:    sw a1, 12(s0)
-; RV64I-NEXT:    ld s0, 0(sp) # 8-byte Folded Reload
+; RV64I-NEXT:    sw a1, 12(sp)
 ; RV64I-NEXT:    sw a1, %lo(var)(a0)
 ; RV64I-NEXT:    sw a2, %lo(var)(a0)
 ; RV64I-NEXT:    sw a3, %lo(var)(a0)
@@ -210,11 +198,7 @@ define void @shrink_wrap(i1 %c) {
 ; RV32I-NEXT:    lw t4, %lo(var)(a0)
 ; RV32I-NEXT:    lw t5, %lo(var)(a0)
 ; RV32I-NEXT:    lw t6, %lo(var)(a0)
-; RV32I-NEXT:    sw s0, 0(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    lui s0, 1
-; RV32I-NEXT:    add s0, sp, s0
-; RV32I-NEXT:    sw a1, 12(s0)
-; RV32I-NEXT:    lw s0, 0(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    sw a1, 12(sp)
 ; RV32I-NEXT:    sw a1, %lo(var)(a0)
 ; RV32I-NEXT:    sw a2, %lo(var)(a0)
 ; RV32I-NEXT:    sw a3, %lo(var)(a0)

--- a/llvm/test/CodeGen/RISCV/qci-interrupt-attr.ll
+++ b/llvm/test/CodeGen/RISCV/qci-interrupt-attr.ll
@@ -1184,17 +1184,17 @@ define void @test_spill_nest() "interrupt"="qci-nest" {
 ; QCI-FP-NEXT:    lui a0, %hi(var)
 ; QCI-FP-NEXT:    addi a0, a0, %lo(var)
 ; QCI-FP-NEXT:    lw a1, 0(a0)
-; QCI-FP-NEXT:    sw a1, 32(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a1, 4(a0)
-; QCI-FP-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a1, 8(a0)
-; QCI-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a1, 12(a0)
-; QCI-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a1, 16(a0)
-; QCI-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a1, 20(a0)
 ; QCI-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a1, 4(a0)
+; QCI-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a1, 8(a0)
+; QCI-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a1, 12(a0)
+; QCI-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a1, 16(a0)
+; QCI-FP-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a1, 20(a0)
+; QCI-FP-NEXT:    sw a1, 32(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a7, 24(a0)
 ; QCI-FP-NEXT:    lw t0, 28(a0)
 ; QCI-FP-NEXT:    lw t1, 32(a0)
@@ -1247,17 +1247,17 @@ define void @test_spill_nest() "interrupt"="qci-nest" {
 ; QCI-FP-NEXT:    sw t1, 32(a0)
 ; QCI-FP-NEXT:    sw t0, 28(a0)
 ; QCI-FP-NEXT:    sw a7, 24(a0)
-; QCI-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a1, 20(a0)
-; QCI-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a1, 16(a0)
-; QCI-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a1, 12(a0)
-; QCI-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a1, 8(a0)
-; QCI-FP-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a1, 4(a0)
 ; QCI-FP-NEXT:    lw a1, 32(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a1, 20(a0)
+; QCI-FP-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a1, 16(a0)
+; QCI-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a1, 12(a0)
+; QCI-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a1, 8(a0)
+; QCI-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a1, 4(a0)
+; QCI-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a1, 0(a0)
 ; QCI-FP-NEXT:    .cfi_def_cfa sp, 176
 ; QCI-FP-NEXT:    lw s1, 76(sp) # 4-byte Folded Reload
@@ -1574,17 +1574,17 @@ define void @test_spill_nest() "interrupt"="qci-nest" {
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lui a0, %hi(var)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    addi a0, a0, %lo(var)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 0(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 4(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 8(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 12(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 16(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 20(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 4(a0)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 8(a0)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 12(a0)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 16(a0)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 20(a0)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a7, 24(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw t0, 28(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw t1, 32(a0)
@@ -1637,17 +1637,17 @@ define void @test_spill_nest() "interrupt"="qci-nest" {
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw t1, 32(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw t0, 28(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a7, 24(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 20(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 16(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 12(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 8(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 4(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 20(a0)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 16(a0)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 12(a0)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 8(a0)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 4(a0)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 0(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    .cfi_def_cfa sp, 192
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    qc.cm.pop {ra, s0-s11}, 96
@@ -1866,17 +1866,17 @@ define void @test_spill_nonest() "interrupt"="qci-nonest" {
 ; QCI-FP-NEXT:    lui a0, %hi(var)
 ; QCI-FP-NEXT:    addi a0, a0, %lo(var)
 ; QCI-FP-NEXT:    lw a1, 0(a0)
-; QCI-FP-NEXT:    sw a1, 32(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a1, 4(a0)
-; QCI-FP-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a1, 8(a0)
-; QCI-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a1, 12(a0)
-; QCI-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a1, 16(a0)
-; QCI-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a1, 20(a0)
 ; QCI-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a1, 4(a0)
+; QCI-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a1, 8(a0)
+; QCI-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a1, 12(a0)
+; QCI-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a1, 16(a0)
+; QCI-FP-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a1, 20(a0)
+; QCI-FP-NEXT:    sw a1, 32(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a7, 24(a0)
 ; QCI-FP-NEXT:    lw t0, 28(a0)
 ; QCI-FP-NEXT:    lw t1, 32(a0)
@@ -1929,17 +1929,17 @@ define void @test_spill_nonest() "interrupt"="qci-nonest" {
 ; QCI-FP-NEXT:    sw t1, 32(a0)
 ; QCI-FP-NEXT:    sw t0, 28(a0)
 ; QCI-FP-NEXT:    sw a7, 24(a0)
-; QCI-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a1, 20(a0)
-; QCI-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a1, 16(a0)
-; QCI-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a1, 12(a0)
-; QCI-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a1, 8(a0)
-; QCI-FP-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a1, 4(a0)
 ; QCI-FP-NEXT:    lw a1, 32(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a1, 20(a0)
+; QCI-FP-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a1, 16(a0)
+; QCI-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a1, 12(a0)
+; QCI-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a1, 8(a0)
+; QCI-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a1, 4(a0)
+; QCI-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a1, 0(a0)
 ; QCI-FP-NEXT:    .cfi_def_cfa sp, 176
 ; QCI-FP-NEXT:    lw s1, 76(sp) # 4-byte Folded Reload
@@ -2256,17 +2256,17 @@ define void @test_spill_nonest() "interrupt"="qci-nonest" {
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lui a0, %hi(var)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    addi a0, a0, %lo(var)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 0(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 4(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 8(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 12(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 16(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 20(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 4(a0)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 8(a0)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 12(a0)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 16(a0)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 20(a0)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a7, 24(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw t0, 28(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw t1, 32(a0)
@@ -2319,17 +2319,17 @@ define void @test_spill_nonest() "interrupt"="qci-nonest" {
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw t1, 32(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw t0, 28(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a7, 24(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 20(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 16(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 12(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 8(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 4(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 20(a0)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 16(a0)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 12(a0)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 8(a0)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 4(a0)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 0(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    .cfi_def_cfa sp, 192
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    qc.cm.pop {ra, s0-s11}, 96
@@ -2592,49 +2592,49 @@ define void @test_spill_call_nest() "interrupt"="qci-nest" {
 ; QCI-FP-NEXT:    lui s1, %hi(var)
 ; QCI-FP-NEXT:    addi s1, s1, %lo(var)
 ; QCI-FP-NEXT:    lw a0, 0(s1)
-; QCI-FP-NEXT:    sw a0, 96(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 4(s1)
-; QCI-FP-NEXT:    sw a0, 92(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 8(s1)
-; QCI-FP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 12(s1)
-; QCI-FP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 16(s1)
-; QCI-FP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 20(s1)
-; QCI-FP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 24(s1)
-; QCI-FP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 28(s1)
-; QCI-FP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 32(s1)
-; QCI-FP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 36(s1)
-; QCI-FP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 40(s1)
-; QCI-FP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 44(s1)
-; QCI-FP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 48(s1)
-; QCI-FP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 52(s1)
-; QCI-FP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 56(s1)
-; QCI-FP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 60(s1)
-; QCI-FP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 64(s1)
-; QCI-FP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 68(s1)
-; QCI-FP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 72(s1)
-; QCI-FP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 76(s1)
-; QCI-FP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 80(s1)
-; QCI-FP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 84(s1)
 ; QCI-FP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 4(s1)
+; QCI-FP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 8(s1)
+; QCI-FP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 12(s1)
+; QCI-FP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 16(s1)
+; QCI-FP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 20(s1)
+; QCI-FP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 24(s1)
+; QCI-FP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 28(s1)
+; QCI-FP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 32(s1)
+; QCI-FP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 36(s1)
+; QCI-FP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 40(s1)
+; QCI-FP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 44(s1)
+; QCI-FP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 48(s1)
+; QCI-FP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 52(s1)
+; QCI-FP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 56(s1)
+; QCI-FP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 60(s1)
+; QCI-FP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 64(s1)
+; QCI-FP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 68(s1)
+; QCI-FP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 72(s1)
+; QCI-FP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 76(s1)
+; QCI-FP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 80(s1)
+; QCI-FP-NEXT:    sw a0, 92(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 84(s1)
+; QCI-FP-NEXT:    sw a0, 96(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw s4, 88(s1)
 ; QCI-FP-NEXT:    lw s5, 92(s1)
 ; QCI-FP-NEXT:    lw s6, 96(s1)
@@ -2667,49 +2667,49 @@ define void @test_spill_call_nest() "interrupt"="qci-nest" {
 ; QCI-FP-NEXT:    sw s6, 96(s1)
 ; QCI-FP-NEXT:    sw s5, 92(s1)
 ; QCI-FP-NEXT:    sw s4, 88(s1)
-; QCI-FP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 84(s1)
-; QCI-FP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 80(s1)
-; QCI-FP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 76(s1)
-; QCI-FP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 72(s1)
-; QCI-FP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 68(s1)
-; QCI-FP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 64(s1)
-; QCI-FP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 60(s1)
-; QCI-FP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 56(s1)
-; QCI-FP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 52(s1)
-; QCI-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 48(s1)
-; QCI-FP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 44(s1)
-; QCI-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 40(s1)
-; QCI-FP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 36(s1)
-; QCI-FP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 32(s1)
-; QCI-FP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 28(s1)
-; QCI-FP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 24(s1)
-; QCI-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 20(s1)
-; QCI-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 16(s1)
-; QCI-FP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 12(s1)
-; QCI-FP-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 8(s1)
-; QCI-FP-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 4(s1)
 ; QCI-FP-NEXT:    lw a0, 96(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 84(s1)
+; QCI-FP-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 80(s1)
+; QCI-FP-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 76(s1)
+; QCI-FP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 72(s1)
+; QCI-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 68(s1)
+; QCI-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 64(s1)
+; QCI-FP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 60(s1)
+; QCI-FP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 56(s1)
+; QCI-FP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 52(s1)
+; QCI-FP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 48(s1)
+; QCI-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 44(s1)
+; QCI-FP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 40(s1)
+; QCI-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 36(s1)
+; QCI-FP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 32(s1)
+; QCI-FP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 28(s1)
+; QCI-FP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 24(s1)
+; QCI-FP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 20(s1)
+; QCI-FP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 16(s1)
+; QCI-FP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 12(s1)
+; QCI-FP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 8(s1)
+; QCI-FP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 4(s1)
+; QCI-FP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 0(s1)
 ; QCI-FP-NEXT:    .cfi_def_cfa sp, 240
 ; QCI-FP-NEXT:    lw s1, 140(sp) # 4-byte Folded Reload
@@ -3124,49 +3124,49 @@ define void @test_spill_call_nest() "interrupt"="qci-nest" {
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lui s1, %hi(var)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    addi s1, s1, %lo(var)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 0(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 92(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 4(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 8(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 12(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 16(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 20(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 24(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 28(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 32(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 36(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 40(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 44(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 48(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 52(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 56(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 60(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 64(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 68(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 72(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 76(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 80(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 84(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 4(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 8(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 12(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 16(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 20(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 24(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 28(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 32(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 36(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 40(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 44(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 48(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 52(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 56(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 60(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 64(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 68(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 72(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 76(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 80(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 84(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 92(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw s4, 88(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw s5, 92(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw s6, 96(s1)
@@ -3199,49 +3199,49 @@ define void @test_spill_call_nest() "interrupt"="qci-nest" {
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw s6, 96(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw s5, 92(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw s4, 88(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 84(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 80(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 76(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 72(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 68(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 64(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 60(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 56(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 52(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 48(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 44(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 40(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 36(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 32(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 28(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 24(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 20(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 16(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 12(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 8(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 4(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 84(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 80(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 76(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 72(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 68(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 64(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 60(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 56(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 52(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 48(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 44(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 40(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 36(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 32(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 28(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 24(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 20(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 16(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 12(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 8(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 4(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 0(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    .cfi_def_cfa sp, 256
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    addi sp, sp, 48
@@ -3508,49 +3508,49 @@ define void @test_spill_call_nonest() "interrupt"="qci-nonest" {
 ; QCI-FP-NEXT:    lui s1, %hi(var)
 ; QCI-FP-NEXT:    addi s1, s1, %lo(var)
 ; QCI-FP-NEXT:    lw a0, 0(s1)
-; QCI-FP-NEXT:    sw a0, 96(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 4(s1)
-; QCI-FP-NEXT:    sw a0, 92(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 8(s1)
-; QCI-FP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 12(s1)
-; QCI-FP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 16(s1)
-; QCI-FP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 20(s1)
-; QCI-FP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 24(s1)
-; QCI-FP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 28(s1)
-; QCI-FP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 32(s1)
-; QCI-FP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 36(s1)
-; QCI-FP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 40(s1)
-; QCI-FP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 44(s1)
-; QCI-FP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 48(s1)
-; QCI-FP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 52(s1)
-; QCI-FP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 56(s1)
-; QCI-FP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 60(s1)
-; QCI-FP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 64(s1)
-; QCI-FP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 68(s1)
-; QCI-FP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 72(s1)
-; QCI-FP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 76(s1)
-; QCI-FP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 80(s1)
-; QCI-FP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
-; QCI-FP-NEXT:    lw a0, 84(s1)
 ; QCI-FP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 4(s1)
+; QCI-FP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 8(s1)
+; QCI-FP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 12(s1)
+; QCI-FP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 16(s1)
+; QCI-FP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 20(s1)
+; QCI-FP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 24(s1)
+; QCI-FP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 28(s1)
+; QCI-FP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 32(s1)
+; QCI-FP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 36(s1)
+; QCI-FP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 40(s1)
+; QCI-FP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 44(s1)
+; QCI-FP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 48(s1)
+; QCI-FP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 52(s1)
+; QCI-FP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 56(s1)
+; QCI-FP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 60(s1)
+; QCI-FP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 64(s1)
+; QCI-FP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 68(s1)
+; QCI-FP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 72(s1)
+; QCI-FP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 76(s1)
+; QCI-FP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 80(s1)
+; QCI-FP-NEXT:    sw a0, 92(sp) # 4-byte Folded Spill
+; QCI-FP-NEXT:    lw a0, 84(s1)
+; QCI-FP-NEXT:    sw a0, 96(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw s4, 88(s1)
 ; QCI-FP-NEXT:    lw s5, 92(s1)
 ; QCI-FP-NEXT:    lw s6, 96(s1)
@@ -3583,49 +3583,49 @@ define void @test_spill_call_nonest() "interrupt"="qci-nonest" {
 ; QCI-FP-NEXT:    sw s6, 96(s1)
 ; QCI-FP-NEXT:    sw s5, 92(s1)
 ; QCI-FP-NEXT:    sw s4, 88(s1)
-; QCI-FP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 84(s1)
-; QCI-FP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 80(s1)
-; QCI-FP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 76(s1)
-; QCI-FP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 72(s1)
-; QCI-FP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 68(s1)
-; QCI-FP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 64(s1)
-; QCI-FP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 60(s1)
-; QCI-FP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 56(s1)
-; QCI-FP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 52(s1)
-; QCI-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 48(s1)
-; QCI-FP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 44(s1)
-; QCI-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 40(s1)
-; QCI-FP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 36(s1)
-; QCI-FP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 32(s1)
-; QCI-FP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 28(s1)
-; QCI-FP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 24(s1)
-; QCI-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 20(s1)
-; QCI-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 16(s1)
-; QCI-FP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 12(s1)
-; QCI-FP-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 8(s1)
-; QCI-FP-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
-; QCI-FP-NEXT:    sw a0, 4(s1)
 ; QCI-FP-NEXT:    lw a0, 96(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 84(s1)
+; QCI-FP-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 80(s1)
+; QCI-FP-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 76(s1)
+; QCI-FP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 72(s1)
+; QCI-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 68(s1)
+; QCI-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 64(s1)
+; QCI-FP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 60(s1)
+; QCI-FP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 56(s1)
+; QCI-FP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 52(s1)
+; QCI-FP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 48(s1)
+; QCI-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 44(s1)
+; QCI-FP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 40(s1)
+; QCI-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 36(s1)
+; QCI-FP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 32(s1)
+; QCI-FP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 28(s1)
+; QCI-FP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 24(s1)
+; QCI-FP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 20(s1)
+; QCI-FP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 16(s1)
+; QCI-FP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 12(s1)
+; QCI-FP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 8(s1)
+; QCI-FP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
+; QCI-FP-NEXT:    sw a0, 4(s1)
+; QCI-FP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 0(s1)
 ; QCI-FP-NEXT:    .cfi_def_cfa sp, 240
 ; QCI-FP-NEXT:    lw s1, 140(sp) # 4-byte Folded Reload
@@ -4040,49 +4040,49 @@ define void @test_spill_call_nonest() "interrupt"="qci-nonest" {
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lui s1, %hi(var)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    addi s1, s1, %lo(var)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 0(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 92(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 4(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 8(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 12(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 16(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 20(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 24(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 28(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 32(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 36(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 40(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 44(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 48(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 52(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 56(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 60(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 64(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 68(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 72(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 76(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 80(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 84(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 4(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 8(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 12(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 16(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 20(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 24(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 28(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 32(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 36(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 40(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 44(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 48(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 52(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 56(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 60(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 64(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 68(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 72(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 76(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 80(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 84(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 92(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw s4, 88(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw s5, 92(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw s6, 96(s1)
@@ -4115,49 +4115,49 @@ define void @test_spill_call_nonest() "interrupt"="qci-nonest" {
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw s6, 96(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw s5, 92(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw s4, 88(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 84(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 80(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 76(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 72(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 68(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 64(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 60(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 56(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 52(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 48(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 44(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 40(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 36(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 32(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 28(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 24(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 20(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 16(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 12(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 8(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 4(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 84(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 80(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 76(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 72(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 68(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 64(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 60(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 56(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 52(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 48(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 44(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 40(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 36(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 32(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 28(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 24(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 20(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 16(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 12(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 8(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 4(s1)
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 0(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    .cfi_def_cfa sp, 256
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    addi sp, sp, 48

--- a/llvm/test/CodeGen/RISCV/riscv-scavenge-crash-2nd-pass-rv32.mir
+++ b/llvm/test/CodeGen/RISCV/riscv-scavenge-crash-2nd-pass-rv32.mir
@@ -62,9 +62,11 @@ body:             |
     ; CHECK-NEXT: $x10 = frame-setup LUI 2
     ; CHECK-NEXT: $x10 = frame-setup ADDI killed $x10, -1168
     ; CHECK-NEXT: $x2 = frame-setup SUB $x2, killed $x10
-    ; CHECK-NEXT: renamable $x10 = ADDI $x8, -440
-    ; CHECK-NEXT: $x11 = PseudoAddUpperImm $x8, 1048574
-    ; CHECK-NEXT: $x11 = LW killed $x11, 1420
+    ; CHECK-NEXT: $x10 = LUI 1
+    ; CHECK-NEXT: $x10 = ADDI killed $x10, 752
+    ; CHECK-NEXT: $x10 = SUB $x8, killed $x10
+    ; CHECK-NEXT: $x11 = PseudoAddUpperImm $x8, 1048575
+    ; CHECK-NEXT: $x11 = LW killed $x11, 1836
     ; CHECK-NEXT: renamable $x12 = LW undef renamable $x10, 1
     ; CHECK-NEXT: renamable $x13 = LW undef renamable $x10, 9
     ; CHECK-NEXT: renamable $x14 = LW undef renamable $x10, 13
@@ -92,7 +94,7 @@ body:             |
     ; CHECK-NEXT: renamable $x1 = LW undef renamable $x10, 105
     ; CHECK-NEXT: SW killed $x11, $x8, -56 :: (store (s32) into %stack.17)
     ; CHECK-NEXT: $x11 = PseudoAddUpperImm $x8, 1048575
-    ; CHECK-NEXT: SW $x10, killed $x11, -472
+    ; CHECK-NEXT: SW $x10, killed $x11, -368
     ; CHECK-NEXT: $x11 = LW $x8, -56 :: (load (s32) from %stack.17)
     ; CHECK-NEXT: SW killed renamable $x1, undef renamable $x11, 105
     ; CHECK-NEXT: SW killed renamable $x27, undef renamable $x11, 101

--- a/llvm/test/CodeGen/RISCV/rv64-stackmap.ll
+++ b/llvm/test/CodeGen/RISCV/rv64-stackmap.ll
@@ -51,7 +51,7 @@
 ; CHECK-NEXT:   .quad   -1
 ; CHECK-NEXT:   .quad   1
 ; CHECK-NEXT:   .quad   floats
-; CHECK-NEXT:   .quad   32
+; CHECK-NEXT:   .quad   16
 ; CHECK-NEXT:   .quad   1
 
 ; Num LargeConstants

--- a/llvm/test/CodeGen/RISCV/rvv/access-fixed-objects-by-rvv.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/access-fixed-objects-by-rvv.ll
@@ -7,9 +7,9 @@ define <vscale x 1 x i64> @access_fixed_object(ptr %val) {
 ; RV64IV:       # %bb.0:
 ; RV64IV-NEXT:    addi sp, sp, -528
 ; RV64IV-NEXT:    .cfi_def_cfa_offset 528
-; RV64IV-NEXT:    addi a1, sp, 8
+; RV64IV-NEXT:    addi a1, sp, 16
 ; RV64IV-NEXT:    vl1re64.v v8, (a1)
-; RV64IV-NEXT:    ld a1, 520(sp)
+; RV64IV-NEXT:    ld a1, 8(sp)
 ; RV64IV-NEXT:    sd a1, 0(a0)
 ; RV64IV-NEXT:    addi sp, sp, 528
 ; RV64IV-NEXT:    .cfi_def_cfa_offset 0
@@ -30,11 +30,11 @@ define <vscale x 1 x i64> @access_fixed_and_vector_objects(ptr %val) {
 ; RV64IV-NEXT:    csrr a0, vlenb
 ; RV64IV-NEXT:    sub sp, sp, a0
 ; RV64IV-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0x90, 0x04, 0x22, 0x11, 0x01, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 528 + 1 * vlenb
-; RV64IV-NEXT:    ld a0, 520(sp)
+; RV64IV-NEXT:    ld a0, 8(sp)
 ; RV64IV-NEXT:    addi a1, sp, 528
 ; RV64IV-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; RV64IV-NEXT:    vle64.v v8, (a1)
-; RV64IV-NEXT:    addi a0, sp, 8
+; RV64IV-NEXT:    addi a0, sp, 16
 ; RV64IV-NEXT:    vle64.v v9, (a0)
 ; RV64IV-NEXT:    vadd.vv v8, v9, v8
 ; RV64IV-NEXT:    csrr a0, vlenb
@@ -76,11 +76,11 @@ define <vscale x 1 x i64> @probe_fixed_and_vector_objects(ptr %val, <vscale x 1 
 ; RV64IV-NEXT:    .cfi_def_cfa_register sp
 ; RV64IV-NEXT:    sub sp, sp, t1
 ; RV64IV-NEXT:    .cfi_escape 0x0f, 0x0e, 0x72, 0x00, 0x11, 0x90, 0x04, 0x22, 0x11, 0x01, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 528 + 1 * vlenb
-; RV64IV-NEXT:    ld a0, 520(sp)
+; RV64IV-NEXT:    ld a0, 8(sp)
 ; RV64IV-NEXT:    addi a1, sp, 528
 ; RV64IV-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; RV64IV-NEXT:    vle64.v v9, (a1)
-; RV64IV-NEXT:    addi a0, sp, 8
+; RV64IV-NEXT:    addi a0, sp, 16
 ; RV64IV-NEXT:    vle64.v v10, (a0)
 ; RV64IV-NEXT:    vsetvli zero, zero, e64, m1, tu, ma
 ; RV64IV-NEXT:    vadd.vv v8, v10, v9

--- a/llvm/test/CodeGen/RISCV/rvv/debug-info-rvv-dbg-value.mir
+++ b/llvm/test/CodeGen/RISCV/rvv/debug-info-rvv-dbg-value.mir
@@ -33,10 +33,10 @@
 # CHECK5-PLUS: : DW_OP_breg2 X2+32)
 # CHECK5-PLUS: DW_AT_type {{.*}}vbool1_t
 
-# CHECK0-MINUS: : DW_OP_breg8 X8-40)
+# CHECK0-MINUS: : DW_OP_breg8 X8-48)
 # CHECK0-MINUS: DW_AT_type {{.*}}int32_t
 #
-# CHECK1-MINUS: : DW_OP_breg8 X8-48)
+# CHECK1-MINUS: : DW_OP_breg8 X8-40)
 # CHECK1-MINUS: DW_AT_type {{.*}}int32_t
 #
 # CHECK2-MINUS: : DW_OP_breg8 X8-48, DW_OP_lit1, DW_OP_bregx VLENB+0, DW_OP_mul, DW_OP_minus)

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-emergency-slot.mir
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-emergency-slot.mir
@@ -11,10 +11,10 @@
   ; CHECK-NEXT:    addi sp, sp, -48
   ; CHECK-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
   ; CHECK-NEXT:    sd a0, 32(sp)
-  ; CHECK-NEXT:    sd a0, 16(sp)
+  ; CHECK-NEXT:    sd a0, 24(sp)
   ; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, mu
   ; CHECK-NEXT:    sd a1, 0(sp) # 8-byte Folded Spill
-  ; CHECK-NEXT:    addi a1, sp, 24
+  ; CHECK-NEXT:    addi a1, sp, 16
   ; CHECK-NEXT:    vs1r.v v25, (a1) # vscale x 8-byte Folded Spill
   ; CHECK-NEXT:    ld a1, 0(sp) # 8-byte Folded Reload
   ; CHECK-NEXT:    call fixedlen_vector_spillslot

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-fpowi.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-fpowi.ll
@@ -614,48 +614,48 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV32-NEXT:    mv s1, a0
 ; RV32-NEXT:    addi a0, sp, 256
 ; RV32-NEXT:    vs4r.v v8, (a0) # vscale x 32-byte Folded Spill
-; RV32-NEXT:    addi a0, sp, 64
+; RV32-NEXT:    addi a0, sp, 128
 ; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; RV32-NEXT:    vse32.v v8, (a0)
-; RV32-NEXT:    flw fa0, 124(sp)
+; RV32-NEXT:    flw fa0, 188(sp)
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 188(sp)
-; RV32-NEXT:    flw fa0, 120(sp)
+; RV32-NEXT:    fsw fa0, 124(sp)
+; RV32-NEXT:    flw fa0, 184(sp)
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 184(sp)
-; RV32-NEXT:    flw fa0, 116(sp)
+; RV32-NEXT:    fsw fa0, 120(sp)
+; RV32-NEXT:    flw fa0, 180(sp)
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 180(sp)
-; RV32-NEXT:    flw fa0, 112(sp)
+; RV32-NEXT:    fsw fa0, 116(sp)
+; RV32-NEXT:    flw fa0, 176(sp)
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 176(sp)
-; RV32-NEXT:    flw fa0, 108(sp)
+; RV32-NEXT:    fsw fa0, 112(sp)
+; RV32-NEXT:    flw fa0, 172(sp)
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 172(sp)
-; RV32-NEXT:    flw fa0, 104(sp)
+; RV32-NEXT:    fsw fa0, 108(sp)
+; RV32-NEXT:    flw fa0, 168(sp)
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 168(sp)
-; RV32-NEXT:    flw fa0, 100(sp)
+; RV32-NEXT:    fsw fa0, 104(sp)
+; RV32-NEXT:    flw fa0, 164(sp)
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 164(sp)
-; RV32-NEXT:    flw fa0, 96(sp)
+; RV32-NEXT:    fsw fa0, 100(sp)
+; RV32-NEXT:    flw fa0, 160(sp)
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 160(sp)
+; RV32-NEXT:    fsw fa0, 96(sp)
 ; RV32-NEXT:    addi a0, sp, 256
 ; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV32-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
 ; RV32-NEXT:    vfmv.f.s fa0, v8
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 128(sp)
+; RV32-NEXT:    fsw fa0, 64(sp)
 ; RV32-NEXT:    addi a0, sp, 256
 ; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV32-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
@@ -663,7 +663,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV32-NEXT:    vfmv.f.s fa0, v8
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 140(sp)
+; RV32-NEXT:    fsw fa0, 76(sp)
 ; RV32-NEXT:    addi a0, sp, 256
 ; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV32-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
@@ -671,7 +671,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV32-NEXT:    vfmv.f.s fa0, v8
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 136(sp)
+; RV32-NEXT:    fsw fa0, 72(sp)
 ; RV32-NEXT:    addi a0, sp, 256
 ; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV32-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
@@ -679,7 +679,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV32-NEXT:    vfmv.f.s fa0, v8
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 132(sp)
+; RV32-NEXT:    fsw fa0, 68(sp)
 ; RV32-NEXT:    addi a0, sp, 256
 ; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV32-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
@@ -687,7 +687,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV32-NEXT:    vfmv.f.s fa0, v8
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 156(sp)
+; RV32-NEXT:    fsw fa0, 92(sp)
 ; RV32-NEXT:    addi a0, sp, 256
 ; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV32-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
@@ -695,7 +695,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV32-NEXT:    vfmv.f.s fa0, v8
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 152(sp)
+; RV32-NEXT:    fsw fa0, 88(sp)
 ; RV32-NEXT:    addi a0, sp, 256
 ; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV32-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
@@ -703,7 +703,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV32-NEXT:    vfmv.f.s fa0, v8
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    fsw fa0, 148(sp)
+; RV32-NEXT:    fsw fa0, 84(sp)
 ; RV32-NEXT:    addi a0, sp, 256
 ; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV32-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
@@ -711,8 +711,8 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV32-NEXT:    vfmv.f.s fa0, v8
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
-; RV32-NEXT:    addi a0, sp, 128
-; RV32-NEXT:    fsw fa0, 144(sp)
+; RV32-NEXT:    addi a0, sp, 64
+; RV32-NEXT:    fsw fa0, 80(sp)
 ; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; RV32-NEXT:    vle32.v v8, (a0)
 ; RV32-NEXT:    addi sp, s0, -272
@@ -735,49 +735,49 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV64-NEXT:    andi sp, sp, -64
 ; RV64-NEXT:    addi a1, sp, 240
 ; RV64-NEXT:    vs4r.v v8, (a1) # vscale x 32-byte Folded Spill
-; RV64-NEXT:    addi a1, sp, 64
+; RV64-NEXT:    addi a1, sp, 128
 ; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; RV64-NEXT:    vse32.v v8, (a1)
-; RV64-NEXT:    flw fa0, 124(sp)
+; RV64-NEXT:    flw fa0, 188(sp)
 ; RV64-NEXT:    sext.w s1, a0
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 188(sp)
-; RV64-NEXT:    flw fa0, 120(sp)
+; RV64-NEXT:    fsw fa0, 124(sp)
+; RV64-NEXT:    flw fa0, 184(sp)
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 184(sp)
-; RV64-NEXT:    flw fa0, 116(sp)
+; RV64-NEXT:    fsw fa0, 120(sp)
+; RV64-NEXT:    flw fa0, 180(sp)
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 180(sp)
-; RV64-NEXT:    flw fa0, 112(sp)
+; RV64-NEXT:    fsw fa0, 116(sp)
+; RV64-NEXT:    flw fa0, 176(sp)
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 176(sp)
-; RV64-NEXT:    flw fa0, 108(sp)
+; RV64-NEXT:    fsw fa0, 112(sp)
+; RV64-NEXT:    flw fa0, 172(sp)
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 172(sp)
-; RV64-NEXT:    flw fa0, 104(sp)
+; RV64-NEXT:    fsw fa0, 108(sp)
+; RV64-NEXT:    flw fa0, 168(sp)
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 168(sp)
-; RV64-NEXT:    flw fa0, 100(sp)
+; RV64-NEXT:    fsw fa0, 104(sp)
+; RV64-NEXT:    flw fa0, 164(sp)
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 164(sp)
-; RV64-NEXT:    flw fa0, 96(sp)
+; RV64-NEXT:    fsw fa0, 100(sp)
+; RV64-NEXT:    flw fa0, 160(sp)
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 160(sp)
+; RV64-NEXT:    fsw fa0, 96(sp)
 ; RV64-NEXT:    addi a0, sp, 240
 ; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV64-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
 ; RV64-NEXT:    vfmv.f.s fa0, v8
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 128(sp)
+; RV64-NEXT:    fsw fa0, 64(sp)
 ; RV64-NEXT:    addi a0, sp, 240
 ; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV64-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
@@ -785,7 +785,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV64-NEXT:    vfmv.f.s fa0, v8
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 140(sp)
+; RV64-NEXT:    fsw fa0, 76(sp)
 ; RV64-NEXT:    addi a0, sp, 240
 ; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV64-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
@@ -793,7 +793,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV64-NEXT:    vfmv.f.s fa0, v8
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 136(sp)
+; RV64-NEXT:    fsw fa0, 72(sp)
 ; RV64-NEXT:    addi a0, sp, 240
 ; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV64-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
@@ -801,7 +801,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV64-NEXT:    vfmv.f.s fa0, v8
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 132(sp)
+; RV64-NEXT:    fsw fa0, 68(sp)
 ; RV64-NEXT:    addi a0, sp, 240
 ; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV64-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
@@ -809,7 +809,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV64-NEXT:    vfmv.f.s fa0, v8
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 156(sp)
+; RV64-NEXT:    fsw fa0, 92(sp)
 ; RV64-NEXT:    addi a0, sp, 240
 ; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV64-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
@@ -817,7 +817,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV64-NEXT:    vfmv.f.s fa0, v8
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 152(sp)
+; RV64-NEXT:    fsw fa0, 88(sp)
 ; RV64-NEXT:    addi a0, sp, 240
 ; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV64-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
@@ -825,7 +825,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV64-NEXT:    vfmv.f.s fa0, v8
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    fsw fa0, 148(sp)
+; RV64-NEXT:    fsw fa0, 84(sp)
 ; RV64-NEXT:    addi a0, sp, 240
 ; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV64-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
@@ -833,8 +833,8 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV64-NEXT:    vfmv.f.s fa0, v8
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
-; RV64-NEXT:    addi a0, sp, 128
-; RV64-NEXT:    fsw fa0, 144(sp)
+; RV64-NEXT:    addi a0, sp, 64
+; RV64-NEXT:    fsw fa0, 80(sp)
 ; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; RV64-NEXT:    vle32.v v8, (a0)
 ; RV64-NEXT:    addi sp, s0, -272
@@ -1103,32 +1103,32 @@ define <8 x double> @powi_v8f64(<8 x double> %x, i32 %y) nounwind {
 ; RV32-NEXT:    mv s1, a0
 ; RV32-NEXT:    addi a0, sp, 256
 ; RV32-NEXT:    vs4r.v v8, (a0) # vscale x 32-byte Folded Spill
-; RV32-NEXT:    addi a0, sp, 64
+; RV32-NEXT:    addi a0, sp, 128
 ; RV32-NEXT:    vsetivli zero, 8, e64, m4, ta, ma
 ; RV32-NEXT:    vse64.v v8, (a0)
-; RV32-NEXT:    fld fa0, 120(sp)
+; RV32-NEXT:    fld fa0, 184(sp)
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powidf2
-; RV32-NEXT:    fsd fa0, 184(sp)
-; RV32-NEXT:    fld fa0, 112(sp)
+; RV32-NEXT:    fsd fa0, 120(sp)
+; RV32-NEXT:    fld fa0, 176(sp)
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powidf2
-; RV32-NEXT:    fsd fa0, 176(sp)
-; RV32-NEXT:    fld fa0, 104(sp)
+; RV32-NEXT:    fsd fa0, 112(sp)
+; RV32-NEXT:    fld fa0, 168(sp)
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powidf2
-; RV32-NEXT:    fsd fa0, 168(sp)
-; RV32-NEXT:    fld fa0, 96(sp)
+; RV32-NEXT:    fsd fa0, 104(sp)
+; RV32-NEXT:    fld fa0, 160(sp)
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powidf2
-; RV32-NEXT:    fsd fa0, 160(sp)
+; RV32-NEXT:    fsd fa0, 96(sp)
 ; RV32-NEXT:    addi a0, sp, 256
 ; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV32-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
 ; RV32-NEXT:    vfmv.f.s fa0, v8
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powidf2
-; RV32-NEXT:    fsd fa0, 128(sp)
+; RV32-NEXT:    fsd fa0, 64(sp)
 ; RV32-NEXT:    addi a0, sp, 256
 ; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV32-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
@@ -1136,7 +1136,7 @@ define <8 x double> @powi_v8f64(<8 x double> %x, i32 %y) nounwind {
 ; RV32-NEXT:    vfmv.f.s fa0, v8
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powidf2
-; RV32-NEXT:    fsd fa0, 136(sp)
+; RV32-NEXT:    fsd fa0, 72(sp)
 ; RV32-NEXT:    addi a0, sp, 256
 ; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV32-NEXT:    vsetivli zero, 1, e64, m2, ta, ma
@@ -1144,7 +1144,7 @@ define <8 x double> @powi_v8f64(<8 x double> %x, i32 %y) nounwind {
 ; RV32-NEXT:    vfmv.f.s fa0, v8
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powidf2
-; RV32-NEXT:    fsd fa0, 152(sp)
+; RV32-NEXT:    fsd fa0, 88(sp)
 ; RV32-NEXT:    addi a0, sp, 256
 ; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV32-NEXT:    vsetivli zero, 1, e64, m2, ta, ma
@@ -1152,8 +1152,8 @@ define <8 x double> @powi_v8f64(<8 x double> %x, i32 %y) nounwind {
 ; RV32-NEXT:    vfmv.f.s fa0, v8
 ; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powidf2
-; RV32-NEXT:    addi a0, sp, 128
-; RV32-NEXT:    fsd fa0, 144(sp)
+; RV32-NEXT:    addi a0, sp, 64
+; RV32-NEXT:    fsd fa0, 80(sp)
 ; RV32-NEXT:    vsetivli zero, 8, e64, m4, ta, ma
 ; RV32-NEXT:    vle64.v v8, (a0)
 ; RV32-NEXT:    addi sp, s0, -272
@@ -1176,33 +1176,33 @@ define <8 x double> @powi_v8f64(<8 x double> %x, i32 %y) nounwind {
 ; RV64-NEXT:    andi sp, sp, -64
 ; RV64-NEXT:    addi a1, sp, 240
 ; RV64-NEXT:    vs4r.v v8, (a1) # vscale x 32-byte Folded Spill
-; RV64-NEXT:    addi a1, sp, 64
+; RV64-NEXT:    addi a1, sp, 128
 ; RV64-NEXT:    vsetivli zero, 8, e64, m4, ta, ma
 ; RV64-NEXT:    vse64.v v8, (a1)
-; RV64-NEXT:    fld fa0, 120(sp)
+; RV64-NEXT:    fld fa0, 184(sp)
 ; RV64-NEXT:    sext.w s1, a0
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powidf2
-; RV64-NEXT:    fsd fa0, 184(sp)
-; RV64-NEXT:    fld fa0, 112(sp)
+; RV64-NEXT:    fsd fa0, 120(sp)
+; RV64-NEXT:    fld fa0, 176(sp)
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powidf2
-; RV64-NEXT:    fsd fa0, 176(sp)
-; RV64-NEXT:    fld fa0, 104(sp)
+; RV64-NEXT:    fsd fa0, 112(sp)
+; RV64-NEXT:    fld fa0, 168(sp)
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powidf2
-; RV64-NEXT:    fsd fa0, 168(sp)
-; RV64-NEXT:    fld fa0, 96(sp)
+; RV64-NEXT:    fsd fa0, 104(sp)
+; RV64-NEXT:    fld fa0, 160(sp)
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powidf2
-; RV64-NEXT:    fsd fa0, 160(sp)
+; RV64-NEXT:    fsd fa0, 96(sp)
 ; RV64-NEXT:    addi a0, sp, 240
 ; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV64-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
 ; RV64-NEXT:    vfmv.f.s fa0, v8
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powidf2
-; RV64-NEXT:    fsd fa0, 128(sp)
+; RV64-NEXT:    fsd fa0, 64(sp)
 ; RV64-NEXT:    addi a0, sp, 240
 ; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV64-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
@@ -1210,7 +1210,7 @@ define <8 x double> @powi_v8f64(<8 x double> %x, i32 %y) nounwind {
 ; RV64-NEXT:    vfmv.f.s fa0, v8
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powidf2
-; RV64-NEXT:    fsd fa0, 136(sp)
+; RV64-NEXT:    fsd fa0, 72(sp)
 ; RV64-NEXT:    addi a0, sp, 240
 ; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV64-NEXT:    vsetivli zero, 1, e64, m2, ta, ma
@@ -1218,7 +1218,7 @@ define <8 x double> @powi_v8f64(<8 x double> %x, i32 %y) nounwind {
 ; RV64-NEXT:    vfmv.f.s fa0, v8
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powidf2
-; RV64-NEXT:    fsd fa0, 152(sp)
+; RV64-NEXT:    fsd fa0, 88(sp)
 ; RV64-NEXT:    addi a0, sp, 240
 ; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV64-NEXT:    vsetivli zero, 1, e64, m2, ta, ma
@@ -1226,8 +1226,8 @@ define <8 x double> @powi_v8f64(<8 x double> %x, i32 %y) nounwind {
 ; RV64-NEXT:    vfmv.f.s fa0, v8
 ; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powidf2
-; RV64-NEXT:    addi a0, sp, 128
-; RV64-NEXT:    fsd fa0, 144(sp)
+; RV64-NEXT:    addi a0, sp, 64
+; RV64-NEXT:    fsd fa0, 80(sp)
 ; RV64-NEXT:    vsetivli zero, 8, e64, m4, ta, ma
 ; RV64-NEXT:    vle64.v v8, (a0)
 ; RV64-NEXT:    addi sp, s0, -272

--- a/llvm/test/CodeGen/RISCV/rvv/localvar.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/localvar.ll
@@ -292,11 +292,11 @@ define void @local_var_m2_with_bp(i64 %n) {
 ; RV64IV-NEXT:    add s2, s1, s2
 ; RV64IV-NEXT:    addi s2, s2, 224
 ; RV64IV-NEXT:    call notdead2
-; RV64IV-NEXT:    lw zero, 124(s1)
+; RV64IV-NEXT:    lw zero, 220(s1)
 ; RV64IV-NEXT:    vl2r.v v8, (s2)
 ; RV64IV-NEXT:    addi a0, s1, 224
 ; RV64IV-NEXT:    vl2r.v v8, (a0)
-; RV64IV-NEXT:    lw zero, 120(s1)
+; RV64IV-NEXT:    lw zero, 216(s1)
 ; RV64IV-NEXT:    addi sp, s0, -256
 ; RV64IV-NEXT:    .cfi_def_cfa sp, 256
 ; RV64IV-NEXT:    ld ra, 248(sp) # 8-byte Folded Reload

--- a/llvm/test/CodeGen/RISCV/rvv/no-reserved-frame.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/no-reserved-frame.ll
@@ -19,21 +19,21 @@ define signext i32 @foo(i32 signext %aa) #0 {
 ; CHECK-NEXT:    sub sp, sp, a1
 ; CHECK-NEXT:    andi sp, sp, -16
 ; CHECK-NEXT:    mv s1, sp
-; CHECK-NEXT:    lw t0, 44(s1)
-; CHECK-NEXT:    lw a2, 40(s1)
-; CHECK-NEXT:    lw a3, 36(s1)
-; CHECK-NEXT:    lw a4, 32(s1)
-; CHECK-NEXT:    lw a5, 28(s1)
-; CHECK-NEXT:    lw a6, 24(s1)
-; CHECK-NEXT:    lw a7, 20(s1)
-; CHECK-NEXT:    lw a1, 16(s1)
-; CHECK-NEXT:    lw t1, 12(s1)
-; CHECK-NEXT:    lw t2, 8(s1)
+; CHECK-NEXT:    lw t0, 48(s1)
+; CHECK-NEXT:    lw a2, 44(s1)
+; CHECK-NEXT:    lw a3, 40(s1)
+; CHECK-NEXT:    lw a4, 36(s1)
+; CHECK-NEXT:    lw a5, 32(s1)
+; CHECK-NEXT:    lw a6, 28(s1)
+; CHECK-NEXT:    lw a7, 24(s1)
+; CHECK-NEXT:    lw a1, 20(s1)
+; CHECK-NEXT:    lw t1, 16(s1)
+; CHECK-NEXT:    lw t2, 12(s1)
 ; CHECK-NEXT:    sw a0, 52(s1)
-; CHECK-NEXT:    sw a0, 48(s1)
+; CHECK-NEXT:    sw a0, 8(s1)
 ; CHECK-NEXT:    addi sp, sp, -32
 ; CHECK-NEXT:    sd a1, 0(sp)
-; CHECK-NEXT:    addi a1, s1, 48
+; CHECK-NEXT:    addi a1, s1, 8
 ; CHECK-NEXT:    mv a0, t0
 ; CHECK-NEXT:    sd t1, 8(sp)
 ; CHECK-NEXT:    sd t2, 16(sp)

--- a/llvm/test/CodeGen/RISCV/rvv/rvv-out-arguments.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/rvv-out-arguments.ll
@@ -14,22 +14,22 @@ define dso_local void @lots_args(i32 signext %x0, i32 signext %x1, <vscale x 16 
 ; CHECK-NEXT:    sub sp, sp, t0
 ; CHECK-NEXT:    ld t0, 8(s0)
 ; CHECK-NEXT:    ld t1, 0(s0)
-; CHECK-NEXT:    sw a0, -28(s0)
-; CHECK-NEXT:    sw a1, -32(s0)
+; CHECK-NEXT:    sw a0, -64(s0)
+; CHECK-NEXT:    sw a1, -60(s0)
 ; CHECK-NEXT:    csrr a0, vlenb
 ; CHECK-NEXT:    slli a0, a0, 3
 ; CHECK-NEXT:    sub a0, s0, a0
 ; CHECK-NEXT:    addi a0, a0, -64
 ; CHECK-NEXT:    vsetvli a1, zero, e32, m8, ta, ma
 ; CHECK-NEXT:    vse32.v v8, (a0)
-; CHECK-NEXT:    sw a2, -36(s0)
-; CHECK-NEXT:    sw a3, -40(s0)
-; CHECK-NEXT:    sw a4, -44(s0)
-; CHECK-NEXT:    sw a5, -48(s0)
-; CHECK-NEXT:    sw a6, -52(s0)
-; CHECK-NEXT:    sw a7, -56(s0)
-; CHECK-NEXT:    sw t1, -60(s0)
-; CHECK-NEXT:    sw t0, -64(s0)
+; CHECK-NEXT:    sw a2, -56(s0)
+; CHECK-NEXT:    sw a3, -52(s0)
+; CHECK-NEXT:    sw a4, -48(s0)
+; CHECK-NEXT:    sw a5, -44(s0)
+; CHECK-NEXT:    sw a6, -40(s0)
+; CHECK-NEXT:    sw a7, -36(s0)
+; CHECK-NEXT:    sw t1, -32(s0)
+; CHECK-NEXT:    sw t0, -28(s0)
 ; CHECK-NEXT:    addi sp, s0, -64
 ; CHECK-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
 ; CHECK-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
@@ -72,14 +72,14 @@ define dso_local signext i32 @main() #0 {
 ; CHECK-NEXT:    csrr a0, vlenb
 ; CHECK-NEXT:    slli a0, a0, 3
 ; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    sw zero, -36(s0)
+; CHECK-NEXT:    sw zero, -84(s0)
 ; CHECK-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
 ; CHECK-NEXT:    vmv.v.i v8, 0
-; CHECK-NEXT:    addi a0, s0, -64
+; CHECK-NEXT:    addi a0, s0, -112
 ; CHECK-NEXT:    vse64.v v8, (a0)
 ; CHECK-NEXT:    vsetivli a1, 4, e32, m8, ta, ma
-; CHECK-NEXT:    sd a1, -72(s0)
-; CHECK-NEXT:    ld a1, -72(s0)
+; CHECK-NEXT:    sd a1, -80(s0)
+; CHECK-NEXT:    ld a1, -80(s0)
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, ta, ma
 ; CHECK-NEXT:    vle32.v v8, (a0)
 ; CHECK-NEXT:    csrr s1, vlenb
@@ -89,44 +89,44 @@ define dso_local signext i32 @main() #0 {
 ; CHECK-NEXT:    vsetvli a0, zero, e32, m8, ta, ma
 ; CHECK-NEXT:    vse32.v v8, (s1)
 ; CHECK-NEXT:    li a0, 1
-; CHECK-NEXT:    sw a0, -76(s0)
-; CHECK-NEXT:    sw a0, -80(s0)
-; CHECK-NEXT:    sw a0, -84(s0)
-; CHECK-NEXT:    sw a0, -88(s0)
-; CHECK-NEXT:    sw a0, -92(s0)
-; CHECK-NEXT:    sw a0, -96(s0)
-; CHECK-NEXT:    sw a0, -100(s0)
-; CHECK-NEXT:    sw a0, -104(s0)
-; CHECK-NEXT:    sw a0, -108(s0)
-; CHECK-NEXT:    sw a0, -112(s0)
-; CHECK-NEXT:    lw a0, -76(s0)
-; CHECK-NEXT:    lw a1, -80(s0)
+; CHECK-NEXT:    sw a0, -72(s0)
+; CHECK-NEXT:    sw a0, -68(s0)
+; CHECK-NEXT:    sw a0, -64(s0)
+; CHECK-NEXT:    sw a0, -60(s0)
+; CHECK-NEXT:    sw a0, -56(s0)
+; CHECK-NEXT:    sw a0, -52(s0)
+; CHECK-NEXT:    sw a0, -48(s0)
+; CHECK-NEXT:    sw a0, -44(s0)
+; CHECK-NEXT:    sw a0, -40(s0)
+; CHECK-NEXT:    sw a0, -36(s0)
+; CHECK-NEXT:    lw a0, -72(s0)
+; CHECK-NEXT:    lw a1, -68(s0)
 ; CHECK-NEXT:    vle32.v v8, (s1)
-; CHECK-NEXT:    lw a2, -84(s0)
-; CHECK-NEXT:    lw a3, -88(s0)
-; CHECK-NEXT:    lw a4, -92(s0)
-; CHECK-NEXT:    lw a5, -96(s0)
-; CHECK-NEXT:    lw a6, -100(s0)
-; CHECK-NEXT:    lw a7, -104(s0)
-; CHECK-NEXT:    lw t0, -108(s0)
-; CHECK-NEXT:    lw t1, -112(s0)
+; CHECK-NEXT:    lw a2, -64(s0)
+; CHECK-NEXT:    lw a3, -60(s0)
+; CHECK-NEXT:    lw a4, -56(s0)
+; CHECK-NEXT:    lw a5, -52(s0)
+; CHECK-NEXT:    lw a6, -48(s0)
+; CHECK-NEXT:    lw a7, -44(s0)
+; CHECK-NEXT:    lw t0, -40(s0)
+; CHECK-NEXT:    lw t1, -36(s0)
 ; CHECK-NEXT:    addi sp, sp, -16
 ; CHECK-NEXT:    sd t1, 8(sp)
 ; CHECK-NEXT:    sd t0, 0(sp)
 ; CHECK-NEXT:    call lots_args
 ; CHECK-NEXT:    addi sp, sp, 16
-; CHECK-NEXT:    lw a0, -76(s0)
-; CHECK-NEXT:    lw a1, -80(s0)
+; CHECK-NEXT:    lw a0, -72(s0)
+; CHECK-NEXT:    lw a1, -68(s0)
 ; CHECK-NEXT:    vsetvli a2, zero, e32, m8, ta, ma
 ; CHECK-NEXT:    vle32.v v8, (s1)
-; CHECK-NEXT:    lw a2, -84(s0)
-; CHECK-NEXT:    lw a3, -88(s0)
-; CHECK-NEXT:    lw a4, -92(s0)
-; CHECK-NEXT:    lw a5, -96(s0)
-; CHECK-NEXT:    lw a6, -100(s0)
-; CHECK-NEXT:    lw a7, -104(s0)
-; CHECK-NEXT:    lw t0, -108(s0)
-; CHECK-NEXT:    lw t1, -112(s0)
+; CHECK-NEXT:    lw a2, -64(s0)
+; CHECK-NEXT:    lw a3, -60(s0)
+; CHECK-NEXT:    lw a4, -56(s0)
+; CHECK-NEXT:    lw a5, -52(s0)
+; CHECK-NEXT:    lw a6, -48(s0)
+; CHECK-NEXT:    lw a7, -44(s0)
+; CHECK-NEXT:    lw t0, -40(s0)
+; CHECK-NEXT:    lw t1, -36(s0)
 ; CHECK-NEXT:    addi sp, sp, -16
 ; CHECK-NEXT:    sd t1, 8(sp)
 ; CHECK-NEXT:    sd t0, 0(sp)

--- a/llvm/test/CodeGen/RISCV/rvv/vector-deinterleave-fixed.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vector-deinterleave-fixed.ll
@@ -231,38 +231,38 @@ define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(
 ; RV32-NEXT:    sw s0, 632(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    addi s0, sp, 640
 ; RV32-NEXT:    andi sp, sp, -128
-; RV32-NEXT:    addi a1, sp, 252
+; RV32-NEXT:    addi a1, sp, 60
 ; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
 ; RV32-NEXT:    vse32.v v23, (a1)
-; RV32-NEXT:    addi a1, sp, 248
+; RV32-NEXT:    addi a1, sp, 56
 ; RV32-NEXT:    vse32.v v22, (a1)
-; RV32-NEXT:    addi a1, sp, 244
+; RV32-NEXT:    addi a1, sp, 52
 ; RV32-NEXT:    vse32.v v21, (a1)
-; RV32-NEXT:    addi a1, sp, 240
+; RV32-NEXT:    addi a1, sp, 48
 ; RV32-NEXT:    vse32.v v20, (a1)
-; RV32-NEXT:    addi a1, sp, 236
+; RV32-NEXT:    addi a1, sp, 44
 ; RV32-NEXT:    vse32.v v19, (a1)
-; RV32-NEXT:    addi a1, sp, 232
+; RV32-NEXT:    addi a1, sp, 40
 ; RV32-NEXT:    vse32.v v18, (a1)
-; RV32-NEXT:    addi a1, sp, 228
+; RV32-NEXT:    addi a1, sp, 36
 ; RV32-NEXT:    vse32.v v17, (a1)
-; RV32-NEXT:    addi a1, sp, 224
+; RV32-NEXT:    addi a1, sp, 32
 ; RV32-NEXT:    vse32.v v16, (a1)
-; RV32-NEXT:    addi a1, sp, 220
+; RV32-NEXT:    addi a1, sp, 28
 ; RV32-NEXT:    vse32.v v15, (a1)
-; RV32-NEXT:    addi a1, sp, 216
+; RV32-NEXT:    addi a1, sp, 24
 ; RV32-NEXT:    vse32.v v14, (a1)
-; RV32-NEXT:    addi a1, sp, 212
+; RV32-NEXT:    addi a1, sp, 20
 ; RV32-NEXT:    vse32.v v13, (a1)
-; RV32-NEXT:    addi a1, sp, 208
+; RV32-NEXT:    addi a1, sp, 16
 ; RV32-NEXT:    vse32.v v12, (a1)
-; RV32-NEXT:    addi a1, sp, 204
+; RV32-NEXT:    addi a1, sp, 12
 ; RV32-NEXT:    vse32.v v11, (a1)
-; RV32-NEXT:    addi a1, sp, 200
+; RV32-NEXT:    addi a1, sp, 8
 ; RV32-NEXT:    vse32.v v10, (a1)
-; RV32-NEXT:    addi a1, sp, 196
+; RV32-NEXT:    addi a1, sp, 4
 ; RV32-NEXT:    vse32.v v9, (a1)
-; RV32-NEXT:    addi a1, sp, 192
+; RV32-NEXT:    mv a1, sp
 ; RV32-NEXT:    vse32.v v8, (a1)
 ; RV32-NEXT:    addi a2, a0, 64
 ; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
@@ -276,20 +276,20 @@ define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(
 ; RV32-NEXT:    vse32.v v8, (a3)
 ; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; RV32-NEXT:    vle32.v v8, (a0)
-; RV32-NEXT:    addi a3, sp, 64
+; RV32-NEXT:    addi a3, sp, 128
 ; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; RV32-NEXT:    vse32.v v8, (a3)
 ; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; RV32-NEXT:    vle32.v v12, (a1)
 ; RV32-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
 ; RV32-NEXT:    vslidedown.vi v16, v12, 8
-; RV32-NEXT:    mv a1, sp
+; RV32-NEXT:    addi a1, sp, 64
 ; RV32-NEXT:    vslidedown.vi v8, v8, 8
 ; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; RV32-NEXT:    vse32.v v12, (a1)
-; RV32-NEXT:    addi a3, sp, 32
-; RV32-NEXT:    vse32.v v16, (a3)
 ; RV32-NEXT:    addi a3, sp, 96
+; RV32-NEXT:    vse32.v v16, (a3)
+; RV32-NEXT:    addi a3, sp, 160
 ; RV32-NEXT:    vse32.v v8, (a3)
 ; RV32-NEXT:    lw a0, 112(a0)
 ; RV32-NEXT:    sw a0, 432(sp)
@@ -297,10 +297,10 @@ define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(
 ; RV32-NEXT:    vle32.v v8, (a2)
 ; RV32-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
 ; RV32-NEXT:    vslidedown.vi v12, v8, 8
-; RV32-NEXT:    addi a0, sp, 128
+; RV32-NEXT:    addi a0, sp, 192
 ; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; RV32-NEXT:    vse32.v v8, (a0)
-; RV32-NEXT:    addi a0, sp, 160
+; RV32-NEXT:    addi a0, sp, 224
 ; RV32-NEXT:    vse32.v v12, (a0)
 ; RV32-NEXT:    vlseg3e32.v v20, (a3)
 ; RV32-NEXT:    vlseg3e32.v v12, (a1)
@@ -329,37 +329,37 @@ define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(
 ; RV64-NEXT:    addi a1, a0, 112
 ; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
 ; RV64-NEXT:    vle32.v v24, (a1)
-; RV64-NEXT:    addi a1, sp, 252
+; RV64-NEXT:    addi a1, sp, 60
 ; RV64-NEXT:    vse32.v v23, (a1)
-; RV64-NEXT:    addi a1, sp, 248
+; RV64-NEXT:    addi a1, sp, 56
 ; RV64-NEXT:    vse32.v v22, (a1)
-; RV64-NEXT:    addi a1, sp, 244
+; RV64-NEXT:    addi a1, sp, 52
 ; RV64-NEXT:    vse32.v v21, (a1)
-; RV64-NEXT:    addi a1, sp, 240
+; RV64-NEXT:    addi a1, sp, 48
 ; RV64-NEXT:    vse32.v v20, (a1)
-; RV64-NEXT:    addi a1, sp, 236
+; RV64-NEXT:    addi a1, sp, 44
 ; RV64-NEXT:    vse32.v v19, (a1)
-; RV64-NEXT:    addi a1, sp, 232
+; RV64-NEXT:    addi a1, sp, 40
 ; RV64-NEXT:    vse32.v v18, (a1)
-; RV64-NEXT:    addi a1, sp, 228
+; RV64-NEXT:    addi a1, sp, 36
 ; RV64-NEXT:    vse32.v v17, (a1)
-; RV64-NEXT:    addi a1, sp, 224
+; RV64-NEXT:    addi a1, sp, 32
 ; RV64-NEXT:    vse32.v v16, (a1)
-; RV64-NEXT:    addi a1, sp, 220
+; RV64-NEXT:    addi a1, sp, 28
 ; RV64-NEXT:    vse32.v v15, (a1)
-; RV64-NEXT:    addi a1, sp, 216
+; RV64-NEXT:    addi a1, sp, 24
 ; RV64-NEXT:    vse32.v v14, (a1)
-; RV64-NEXT:    addi a1, sp, 212
+; RV64-NEXT:    addi a1, sp, 20
 ; RV64-NEXT:    vse32.v v13, (a1)
-; RV64-NEXT:    addi a1, sp, 208
+; RV64-NEXT:    addi a1, sp, 16
 ; RV64-NEXT:    vse32.v v12, (a1)
-; RV64-NEXT:    addi a1, sp, 204
+; RV64-NEXT:    addi a1, sp, 12
 ; RV64-NEXT:    vse32.v v11, (a1)
-; RV64-NEXT:    addi a1, sp, 200
+; RV64-NEXT:    addi a1, sp, 8
 ; RV64-NEXT:    vse32.v v10, (a1)
-; RV64-NEXT:    addi a1, sp, 196
+; RV64-NEXT:    addi a1, sp, 4
 ; RV64-NEXT:    vse32.v v9, (a1)
-; RV64-NEXT:    addi a1, sp, 192
+; RV64-NEXT:    mv a1, sp
 ; RV64-NEXT:    vse32.v v8, (a1)
 ; RV64-NEXT:    addi a2, a0, 64
 ; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
@@ -376,29 +376,29 @@ define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(
 ; RV64-NEXT:    vse32.v v24, (a3)
 ; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; RV64-NEXT:    vle32.v v8, (a0)
-; RV64-NEXT:    addi a0, sp, 64
+; RV64-NEXT:    addi a0, sp, 128
 ; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; RV64-NEXT:    vse32.v v8, (a0)
 ; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; RV64-NEXT:    vle32.v v12, (a1)
 ; RV64-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
 ; RV64-NEXT:    vslidedown.vi v16, v12, 8
-; RV64-NEXT:    mv a0, sp
+; RV64-NEXT:    addi a0, sp, 64
 ; RV64-NEXT:    vslidedown.vi v8, v8, 8
 ; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; RV64-NEXT:    vse32.v v12, (a0)
-; RV64-NEXT:    addi a1, sp, 32
-; RV64-NEXT:    vse32.v v16, (a1)
 ; RV64-NEXT:    addi a1, sp, 96
+; RV64-NEXT:    vse32.v v16, (a1)
+; RV64-NEXT:    addi a1, sp, 160
 ; RV64-NEXT:    vse32.v v8, (a1)
 ; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; RV64-NEXT:    vle32.v v8, (a2)
 ; RV64-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
 ; RV64-NEXT:    vslidedown.vi v12, v8, 8
-; RV64-NEXT:    addi a2, sp, 128
+; RV64-NEXT:    addi a2, sp, 192
 ; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; RV64-NEXT:    vse32.v v8, (a2)
-; RV64-NEXT:    addi a2, sp, 160
+; RV64-NEXT:    addi a2, sp, 224
 ; RV64-NEXT:    vse32.v v12, (a2)
 ; RV64-NEXT:    vlseg3e32.v v20, (a1)
 ; RV64-NEXT:    vlseg3e32.v v12, (a0)
@@ -427,37 +427,37 @@ define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(
 ; ZVZIP-NEXT:    addi a1, a0, 112
 ; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
 ; ZVZIP-NEXT:    vle32.v v24, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 252
+; ZVZIP-NEXT:    addi a1, sp, 60
 ; ZVZIP-NEXT:    vse32.v v23, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 248
+; ZVZIP-NEXT:    addi a1, sp, 56
 ; ZVZIP-NEXT:    vse32.v v22, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 244
+; ZVZIP-NEXT:    addi a1, sp, 52
 ; ZVZIP-NEXT:    vse32.v v21, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 240
+; ZVZIP-NEXT:    addi a1, sp, 48
 ; ZVZIP-NEXT:    vse32.v v20, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 236
+; ZVZIP-NEXT:    addi a1, sp, 44
 ; ZVZIP-NEXT:    vse32.v v19, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 232
+; ZVZIP-NEXT:    addi a1, sp, 40
 ; ZVZIP-NEXT:    vse32.v v18, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 228
+; ZVZIP-NEXT:    addi a1, sp, 36
 ; ZVZIP-NEXT:    vse32.v v17, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 224
+; ZVZIP-NEXT:    addi a1, sp, 32
 ; ZVZIP-NEXT:    vse32.v v16, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 220
+; ZVZIP-NEXT:    addi a1, sp, 28
 ; ZVZIP-NEXT:    vse32.v v15, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 216
+; ZVZIP-NEXT:    addi a1, sp, 24
 ; ZVZIP-NEXT:    vse32.v v14, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 212
+; ZVZIP-NEXT:    addi a1, sp, 20
 ; ZVZIP-NEXT:    vse32.v v13, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 208
+; ZVZIP-NEXT:    addi a1, sp, 16
 ; ZVZIP-NEXT:    vse32.v v12, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 204
+; ZVZIP-NEXT:    addi a1, sp, 12
 ; ZVZIP-NEXT:    vse32.v v11, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 200
+; ZVZIP-NEXT:    addi a1, sp, 8
 ; ZVZIP-NEXT:    vse32.v v10, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 196
+; ZVZIP-NEXT:    addi a1, sp, 4
 ; ZVZIP-NEXT:    vse32.v v9, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 192
+; ZVZIP-NEXT:    mv a1, sp
 ; ZVZIP-NEXT:    vse32.v v8, (a1)
 ; ZVZIP-NEXT:    addi a2, a0, 64
 ; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
@@ -474,29 +474,29 @@ define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(
 ; ZVZIP-NEXT:    vse32.v v24, (a3)
 ; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; ZVZIP-NEXT:    vle32.v v8, (a0)
-; ZVZIP-NEXT:    addi a0, sp, 64
+; ZVZIP-NEXT:    addi a0, sp, 128
 ; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; ZVZIP-NEXT:    vse32.v v8, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; ZVZIP-NEXT:    vle32.v v12, (a1)
 ; ZVZIP-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
 ; ZVZIP-NEXT:    vslidedown.vi v16, v12, 8
-; ZVZIP-NEXT:    mv a0, sp
+; ZVZIP-NEXT:    addi a0, sp, 64
 ; ZVZIP-NEXT:    vslidedown.vi v8, v8, 8
 ; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; ZVZIP-NEXT:    vse32.v v12, (a0)
-; ZVZIP-NEXT:    addi a1, sp, 32
-; ZVZIP-NEXT:    vse32.v v16, (a1)
 ; ZVZIP-NEXT:    addi a1, sp, 96
+; ZVZIP-NEXT:    vse32.v v16, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 160
 ; ZVZIP-NEXT:    vse32.v v8, (a1)
 ; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; ZVZIP-NEXT:    vle32.v v8, (a2)
 ; ZVZIP-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
 ; ZVZIP-NEXT:    vslidedown.vi v12, v8, 8
-; ZVZIP-NEXT:    addi a2, sp, 128
+; ZVZIP-NEXT:    addi a2, sp, 192
 ; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; ZVZIP-NEXT:    vse32.v v8, (a2)
-; ZVZIP-NEXT:    addi a2, sp, 160
+; ZVZIP-NEXT:    addi a2, sp, 224
 ; ZVZIP-NEXT:    vse32.v v12, (a2)
 ; ZVZIP-NEXT:    vlseg3e32.v v20, (a1)
 ; ZVZIP-NEXT:    vlseg3e32.v v12, (a0)

--- a/llvm/test/CodeGen/RISCV/spill-fill-fold.ll
+++ b/llvm/test/CodeGen/RISCV/spill-fill-fold.ll
@@ -290,13 +290,13 @@ define double @spill_i64_to_double(i64 %a) nounwind {
 ; RV32ID-NEXT:    fsd fs9, 40(sp) # 8-byte Folded Spill
 ; RV32ID-NEXT:    fsd fs10, 32(sp) # 8-byte Folded Spill
 ; RV32ID-NEXT:    fsd fs11, 24(sp) # 8-byte Folded Spill
-; RV32ID-NEXT:    sw a0, 16(sp)
-; RV32ID-NEXT:    sw a1, 20(sp)
-; RV32ID-NEXT:    fld fa5, 16(sp)
-; RV32ID-NEXT:    fsd fa5, 8(sp) # 8-byte Folded Spill
+; RV32ID-NEXT:    sw a0, 8(sp)
+; RV32ID-NEXT:    sw a1, 12(sp)
+; RV32ID-NEXT:    fld fa5, 8(sp)
+; RV32ID-NEXT:    fsd fa5, 16(sp) # 8-byte Folded Spill
 ; RV32ID-NEXT:    #APP
 ; RV32ID-NEXT:    #NO_APP
-; RV32ID-NEXT:    fld fa0, 8(sp) # 8-byte Folded Reload
+; RV32ID-NEXT:    fld fa0, 16(sp) # 8-byte Folded Reload
 ; RV32ID-NEXT:    lw ra, 172(sp) # 4-byte Folded Reload
 ; RV32ID-NEXT:    lw s0, 168(sp) # 4-byte Folded Reload
 ; RV32ID-NEXT:    lw s1, 164(sp) # 4-byte Folded Reload
@@ -935,13 +935,13 @@ define i64 @fill_double_to_i64(double %a) nounwind {
 ; RV32ID-NEXT:    fsd fs9, 40(sp) # 8-byte Folded Spill
 ; RV32ID-NEXT:    fsd fs10, 32(sp) # 8-byte Folded Spill
 ; RV32ID-NEXT:    fsd fs11, 24(sp) # 8-byte Folded Spill
-; RV32ID-NEXT:    fsd fa0, 8(sp) # 8-byte Folded Spill
+; RV32ID-NEXT:    fsd fa0, 16(sp) # 8-byte Folded Spill
 ; RV32ID-NEXT:    #APP
 ; RV32ID-NEXT:    #NO_APP
-; RV32ID-NEXT:    fld fa5, 8(sp) # 8-byte Folded Reload
-; RV32ID-NEXT:    fsd fa5, 16(sp)
-; RV32ID-NEXT:    lw a0, 16(sp)
-; RV32ID-NEXT:    lw a1, 20(sp)
+; RV32ID-NEXT:    fld fa5, 16(sp) # 8-byte Folded Reload
+; RV32ID-NEXT:    fsd fa5, 8(sp)
+; RV32ID-NEXT:    lw a0, 8(sp)
+; RV32ID-NEXT:    lw a1, 12(sp)
 ; RV32ID-NEXT:    lw ra, 172(sp) # 4-byte Folded Reload
 ; RV32ID-NEXT:    lw s0, 168(sp) # 4-byte Folded Reload
 ; RV32ID-NEXT:    lw s1, 164(sp) # 4-byte Folded Reload

--- a/llvm/test/CodeGen/RISCV/stack-offset-large.ll
+++ b/llvm/test/CodeGen/RISCV/stack-offset-large.ll
@@ -24,11 +24,8 @@ define void @stack_bigger_than_32bit() {
 ; RV64-NEXT:    addiw a0, a0, -2000
 ; RV64-NEXT:    sub sp, sp, a0
 ; RV64-NEXT:    .cfi_def_cfa_offset 2147483680
-; RV64-NEXT:    li a0, 1
-; RV64-NEXT:    slli a0, a0, 31
-; RV64-NEXT:    addi a0, a0, 8
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    addi a1, sp, 8
+; RV64-NEXT:    addi a0, sp, 8
+; RV64-NEXT:    addi a1, sp, 24
 ; RV64-NEXT:    call inspect
 ; RV64-NEXT:    lui a0, 524288
 ; RV64-NEXT:    addiw a0, a0, -2000
@@ -57,15 +54,12 @@ define void @stack_bigger_than_32bit_unsigned() {
 ; RV64-NEXT:    addi a0, a0, -2000
 ; RV64-NEXT:    sub sp, sp, a0
 ; RV64-NEXT:    .cfi_def_cfa_offset 4294967328
-; RV64-NEXT:    li a0, 1
-; RV64-NEXT:    slli a0, a0, 32
-; RV64-NEXT:    addi a0, a0, 8
-; RV64-NEXT:    add a0, sp, a0
+; RV64-NEXT:    addi a0, sp, 8
 ; RV64-NEXT:    li a1, 1
 ; RV64-NEXT:    slli a1, a1, 31
-; RV64-NEXT:    addi a1, a1, 8
+; RV64-NEXT:    addi a1, a1, 24
 ; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a2, sp, 8
+; RV64-NEXT:    addi a2, sp, 24
 ; RV64-NEXT:    call inspect
 ; RV64-NEXT:    li a0, 1
 ; RV64-NEXT:    slli a0, a0, 32
@@ -142,11 +136,8 @@ define void @rvv_frame_obj() {
 ; RV64-NEXT:    slli a0, a0, 1
 ; RV64-NEXT:    sub sp, sp, a0
 ; RV64-NEXT:    .cfi_escape 0x0f, 0x11, 0x72, 0x00, 0x11, 0xb0, 0x80, 0x80, 0x80, 0x08, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 2147483696 + 2 * vlenb
-; RV64-NEXT:    li a0, 1
-; RV64-NEXT:    slli a0, a0, 31
-; RV64-NEXT:    addi a0, a0, 8
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    addi a1, sp, 8
+; RV64-NEXT:    addi a0, sp, 8
+; RV64-NEXT:    addi a1, sp, 24
 ; RV64-NEXT:    csrr a2, vlenb
 ; RV64-NEXT:    add a2, sp, a2
 ; RV64-NEXT:    li a3, 1
@@ -200,11 +191,8 @@ define <vscale x 1 x i64> @rvv_spill(<vscale x 1 x i64> %vector) {
 ; RV64-NEXT:    vs1r.v v8, (a0) # vscale x 8-byte Folded Spill
 ; RV64-NEXT:    #APP
 ; RV64-NEXT:    #NO_APP
-; RV64-NEXT:    li a0, 1
-; RV64-NEXT:    slli a0, a0, 31
-; RV64-NEXT:    addi a0, a0, 24
-; RV64-NEXT:    add a0, sp, a0
-; RV64-NEXT:    addi a1, sp, 24
+; RV64-NEXT:    addi a0, sp, 24
+; RV64-NEXT:    addi a1, sp, 40
 ; RV64-NEXT:    call inspect
 ; RV64-NEXT:    li a0, 1
 ; RV64-NEXT:    slli a0, a0, 31

--- a/llvm/test/CodeGen/RISCV/stack-offset.ll
+++ b/llvm/test/CodeGen/RISCV/stack-offset.ll
@@ -13,33 +13,29 @@
 declare void @inspect(...)
 
 define void @test() {
-; RV32I-LABEL: test:
-; RV32I:       # %bb.0:
-; RV32I-NEXT:    addi sp, sp, -2032
-; RV32I-NEXT:    .cfi_def_cfa_offset 2032
-; RV32I-NEXT:    sw ra, 2028(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    .cfi_offset ra, -4
-; RV32I-NEXT:    addi sp, sp, -2048
-; RV32I-NEXT:    addi sp, sp, -1120
-; RV32I-NEXT:    .cfi_def_cfa_offset 5200
-; RV32I-NEXT:    addi a0, sp, 12
-; RV32I-NEXT:    addi a1, sp, 2047
-; RV32I-NEXT:    addi a1, a1, 13
-; RV32I-NEXT:    lui a2, 1
-; RV32I-NEXT:    addi a2, a2, 12
-; RV32I-NEXT:    add a2, sp, a2
-; RV32I-NEXT:    lui a3, 1
-; RV32I-NEXT:    addi a3, a3, 1036
-; RV32I-NEXT:    add a3, sp, a3
-; RV32I-NEXT:    call inspect
-; RV32I-NEXT:    addi sp, sp, 2032
-; RV32I-NEXT:    addi sp, sp, 1136
-; RV32I-NEXT:    .cfi_def_cfa_offset 2032
-; RV32I-NEXT:    lw ra, 2028(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    .cfi_restore ra
-; RV32I-NEXT:    addi sp, sp, 2032
-; RV32I-NEXT:    .cfi_def_cfa_offset 0
-; RV32I-NEXT:    ret
+; RV32-LABEL: test:
+; RV32:       # %bb.0:
+; RV32-NEXT:    addi sp, sp, -2032
+; RV32-NEXT:    .cfi_def_cfa_offset 2032
+; RV32-NEXT:    sw ra, 2028(sp) # 4-byte Folded Spill
+; RV32-NEXT:    .cfi_offset ra, -4
+; RV32-NEXT:    addi sp, sp, -2048
+; RV32-NEXT:    addi sp, sp, -1120
+; RV32-NEXT:    .cfi_def_cfa_offset 5200
+; RV32-NEXT:    addi a0, sp, 1100
+; RV32-NEXT:    addi a1, sp, 2047
+; RV32-NEXT:    addi a1, a1, 1101
+; RV32-NEXT:    addi a2, sp, 76
+; RV32-NEXT:    addi a3, sp, 12
+; RV32-NEXT:    call inspect
+; RV32-NEXT:    addi sp, sp, 2032
+; RV32-NEXT:    addi sp, sp, 1136
+; RV32-NEXT:    .cfi_def_cfa_offset 2032
+; RV32-NEXT:    lw ra, 2028(sp) # 4-byte Folded Reload
+; RV32-NEXT:    .cfi_restore ra
+; RV32-NEXT:    addi sp, sp, 2032
+; RV32-NEXT:    .cfi_def_cfa_offset 0
+; RV32-NEXT:    ret
 ;
 ; RV32XQCILIA-LABEL: test:
 ; RV32XQCILIA:       # %bb.0:
@@ -49,10 +45,10 @@ define void @test() {
 ; RV32XQCILIA-NEXT:    .cfi_offset ra, -4
 ; RV32XQCILIA-NEXT:    qc.e.addi sp, sp, -3168
 ; RV32XQCILIA-NEXT:    .cfi_def_cfa_offset 5200
-; RV32XQCILIA-NEXT:    addi a0, sp, 12
-; RV32XQCILIA-NEXT:    qc.e.addi a1, sp, 2060
-; RV32XQCILIA-NEXT:    qc.e.addi a2, sp, 4108
-; RV32XQCILIA-NEXT:    qc.e.addi a3, sp, 5132
+; RV32XQCILIA-NEXT:    addi a0, sp, 1100
+; RV32XQCILIA-NEXT:    qc.e.addi a1, sp, 3148
+; RV32XQCILIA-NEXT:    addi a2, sp, 76
+; RV32XQCILIA-NEXT:    addi a3, sp, 12
 ; RV32XQCILIA-NEXT:    call inspect
 ; RV32XQCILIA-NEXT:    qc.e.addi sp, sp, 3168
 ; RV32XQCILIA-NEXT:    .cfi_def_cfa_offset 2032
@@ -62,85 +58,29 @@ define void @test() {
 ; RV32XQCILIA-NEXT:    .cfi_def_cfa_offset 0
 ; RV32XQCILIA-NEXT:    ret
 ;
-; RV32ZBA-LABEL: test:
-; RV32ZBA:       # %bb.0:
-; RV32ZBA-NEXT:    addi sp, sp, -2032
-; RV32ZBA-NEXT:    .cfi_def_cfa_offset 2032
-; RV32ZBA-NEXT:    sw ra, 2028(sp) # 4-byte Folded Spill
-; RV32ZBA-NEXT:    .cfi_offset ra, -4
-; RV32ZBA-NEXT:    addi sp, sp, -2048
-; RV32ZBA-NEXT:    addi sp, sp, -1120
-; RV32ZBA-NEXT:    .cfi_def_cfa_offset 5200
-; RV32ZBA-NEXT:    addi a0, sp, 12
-; RV32ZBA-NEXT:    addi a1, sp, 2047
-; RV32ZBA-NEXT:    addi a1, a1, 13
-; RV32ZBA-NEXT:    li a2, 1027
-; RV32ZBA-NEXT:    sh2add a2, a2, sp
-; RV32ZBA-NEXT:    li a3, 1283
-; RV32ZBA-NEXT:    sh2add a3, a3, sp
-; RV32ZBA-NEXT:    call inspect
-; RV32ZBA-NEXT:    addi sp, sp, 2032
-; RV32ZBA-NEXT:    addi sp, sp, 1136
-; RV32ZBA-NEXT:    .cfi_def_cfa_offset 2032
-; RV32ZBA-NEXT:    lw ra, 2028(sp) # 4-byte Folded Reload
-; RV32ZBA-NEXT:    .cfi_restore ra
-; RV32ZBA-NEXT:    addi sp, sp, 2032
-; RV32ZBA-NEXT:    .cfi_def_cfa_offset 0
-; RV32ZBA-NEXT:    ret
-;
-; RV64I-LABEL: test:
-; RV64I:       # %bb.0:
-; RV64I-NEXT:    addi sp, sp, -2032
-; RV64I-NEXT:    .cfi_def_cfa_offset 2032
-; RV64I-NEXT:    sd ra, 2024(sp) # 8-byte Folded Spill
-; RV64I-NEXT:    .cfi_offset ra, -8
-; RV64I-NEXT:    addi sp, sp, -2048
-; RV64I-NEXT:    addi sp, sp, -1120
-; RV64I-NEXT:    .cfi_def_cfa_offset 5200
-; RV64I-NEXT:    addi a0, sp, 8
-; RV64I-NEXT:    addi a1, sp, 2047
-; RV64I-NEXT:    addi a1, a1, 9
-; RV64I-NEXT:    lui a2, 1
-; RV64I-NEXT:    addi a2, a2, 8
-; RV64I-NEXT:    add a2, sp, a2
-; RV64I-NEXT:    lui a3, 1
-; RV64I-NEXT:    addi a3, a3, 1032
-; RV64I-NEXT:    add a3, sp, a3
-; RV64I-NEXT:    call inspect
-; RV64I-NEXT:    addi sp, sp, 2032
-; RV64I-NEXT:    addi sp, sp, 1136
-; RV64I-NEXT:    .cfi_def_cfa_offset 2032
-; RV64I-NEXT:    ld ra, 2024(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    .cfi_restore ra
-; RV64I-NEXT:    addi sp, sp, 2032
-; RV64I-NEXT:    .cfi_def_cfa_offset 0
-; RV64I-NEXT:    ret
-;
-; RV64ZBA-LABEL: test:
-; RV64ZBA:       # %bb.0:
-; RV64ZBA-NEXT:    addi sp, sp, -2032
-; RV64ZBA-NEXT:    .cfi_def_cfa_offset 2032
-; RV64ZBA-NEXT:    sd ra, 2024(sp) # 8-byte Folded Spill
-; RV64ZBA-NEXT:    .cfi_offset ra, -8
-; RV64ZBA-NEXT:    addi sp, sp, -2048
-; RV64ZBA-NEXT:    addi sp, sp, -1120
-; RV64ZBA-NEXT:    .cfi_def_cfa_offset 5200
-; RV64ZBA-NEXT:    addi a0, sp, 8
-; RV64ZBA-NEXT:    addi a1, sp, 2047
-; RV64ZBA-NEXT:    addi a1, a1, 9
-; RV64ZBA-NEXT:    li a2, 513
-; RV64ZBA-NEXT:    sh3add a2, a2, sp
-; RV64ZBA-NEXT:    li a3, 641
-; RV64ZBA-NEXT:    sh3add a3, a3, sp
-; RV64ZBA-NEXT:    call inspect
-; RV64ZBA-NEXT:    addi sp, sp, 2032
-; RV64ZBA-NEXT:    addi sp, sp, 1136
-; RV64ZBA-NEXT:    .cfi_def_cfa_offset 2032
-; RV64ZBA-NEXT:    ld ra, 2024(sp) # 8-byte Folded Reload
-; RV64ZBA-NEXT:    .cfi_restore ra
-; RV64ZBA-NEXT:    addi sp, sp, 2032
-; RV64ZBA-NEXT:    .cfi_def_cfa_offset 0
-; RV64ZBA-NEXT:    ret
+; RV64-LABEL: test:
+; RV64:       # %bb.0:
+; RV64-NEXT:    addi sp, sp, -2032
+; RV64-NEXT:    .cfi_def_cfa_offset 2032
+; RV64-NEXT:    sd ra, 2024(sp) # 8-byte Folded Spill
+; RV64-NEXT:    .cfi_offset ra, -8
+; RV64-NEXT:    addi sp, sp, -2048
+; RV64-NEXT:    addi sp, sp, -1120
+; RV64-NEXT:    .cfi_def_cfa_offset 5200
+; RV64-NEXT:    addi a0, sp, 1096
+; RV64-NEXT:    addi a1, sp, 2047
+; RV64-NEXT:    addi a1, a1, 1097
+; RV64-NEXT:    addi a2, sp, 72
+; RV64-NEXT:    addi a3, sp, 8
+; RV64-NEXT:    call inspect
+; RV64-NEXT:    addi sp, sp, 2032
+; RV64-NEXT:    addi sp, sp, 1136
+; RV64-NEXT:    .cfi_def_cfa_offset 2032
+; RV64-NEXT:    ld ra, 2024(sp) # 8-byte Folded Reload
+; RV64-NEXT:    .cfi_restore ra
+; RV64-NEXT:    addi sp, sp, 2032
+; RV64-NEXT:    .cfi_def_cfa_offset 0
+; RV64-NEXT:    ret
   %p4 = alloca [64 x i8], align 1
   %p3 = alloca [1024 x i8], align 1
   %p2 = alloca [2048 x i8], align 1
@@ -150,28 +90,26 @@ define void @test() {
 }
 
 define void @align_8() {
-; RV32I-LABEL: align_8:
-; RV32I:       # %bb.0:
-; RV32I-NEXT:    addi sp, sp, -2032
-; RV32I-NEXT:    .cfi_def_cfa_offset 2032
-; RV32I-NEXT:    sw ra, 2028(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    .cfi_offset ra, -4
-; RV32I-NEXT:    addi sp, sp, -2048
-; RV32I-NEXT:    addi sp, sp, -32
-; RV32I-NEXT:    .cfi_def_cfa_offset 4112
-; RV32I-NEXT:    addi a0, sp, 7
-; RV32I-NEXT:    lui a1, 1
-; RV32I-NEXT:    addi a1, a1, 8
-; RV32I-NEXT:    add a1, sp, a1
-; RV32I-NEXT:    call inspect
-; RV32I-NEXT:    addi sp, sp, 2032
-; RV32I-NEXT:    addi sp, sp, 48
-; RV32I-NEXT:    .cfi_def_cfa_offset 2032
-; RV32I-NEXT:    lw ra, 2028(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    .cfi_restore ra
-; RV32I-NEXT:    addi sp, sp, 2032
-; RV32I-NEXT:    .cfi_def_cfa_offset 0
-; RV32I-NEXT:    ret
+; RV32-LABEL: align_8:
+; RV32:       # %bb.0:
+; RV32-NEXT:    addi sp, sp, -2032
+; RV32-NEXT:    .cfi_def_cfa_offset 2032
+; RV32-NEXT:    sw ra, 2028(sp) # 4-byte Folded Spill
+; RV32-NEXT:    .cfi_offset ra, -4
+; RV32-NEXT:    addi sp, sp, -2048
+; RV32-NEXT:    addi sp, sp, -32
+; RV32-NEXT:    .cfi_def_cfa_offset 4112
+; RV32-NEXT:    addi a0, sp, 11
+; RV32-NEXT:    addi a1, sp, 8
+; RV32-NEXT:    call inspect
+; RV32-NEXT:    addi sp, sp, 2032
+; RV32-NEXT:    addi sp, sp, 48
+; RV32-NEXT:    .cfi_def_cfa_offset 2032
+; RV32-NEXT:    lw ra, 2028(sp) # 4-byte Folded Reload
+; RV32-NEXT:    .cfi_restore ra
+; RV32-NEXT:    addi sp, sp, 2032
+; RV32-NEXT:    .cfi_def_cfa_offset 0
+; RV32-NEXT:    ret
 ;
 ; RV32XQCILIA-LABEL: align_8:
 ; RV32XQCILIA:       # %bb.0:
@@ -181,8 +119,8 @@ define void @align_8() {
 ; RV32XQCILIA-NEXT:    .cfi_offset ra, -4
 ; RV32XQCILIA-NEXT:    qc.e.addi sp, sp, -3856
 ; RV32XQCILIA-NEXT:    .cfi_def_cfa_offset 4112
-; RV32XQCILIA-NEXT:    addi a0, sp, 7
-; RV32XQCILIA-NEXT:    qc.e.addi a1, sp, 4104
+; RV32XQCILIA-NEXT:    addi a0, sp, 11
+; RV32XQCILIA-NEXT:    addi a1, sp, 8
 ; RV32XQCILIA-NEXT:    call inspect
 ; RV32XQCILIA-NEXT:    qc.e.addi sp, sp, 3856
 ; RV32XQCILIA-NEXT:    .cfi_def_cfa_offset 256
@@ -192,72 +130,26 @@ define void @align_8() {
 ; RV32XQCILIA-NEXT:    .cfi_def_cfa_offset 0
 ; RV32XQCILIA-NEXT:    ret
 ;
-; RV32ZBA-LABEL: align_8:
-; RV32ZBA:       # %bb.0:
-; RV32ZBA-NEXT:    addi sp, sp, -2032
-; RV32ZBA-NEXT:    .cfi_def_cfa_offset 2032
-; RV32ZBA-NEXT:    sw ra, 2028(sp) # 4-byte Folded Spill
-; RV32ZBA-NEXT:    .cfi_offset ra, -4
-; RV32ZBA-NEXT:    addi sp, sp, -2048
-; RV32ZBA-NEXT:    addi sp, sp, -32
-; RV32ZBA-NEXT:    .cfi_def_cfa_offset 4112
-; RV32ZBA-NEXT:    addi a0, sp, 7
-; RV32ZBA-NEXT:    li a1, 513
-; RV32ZBA-NEXT:    sh3add a1, a1, sp
-; RV32ZBA-NEXT:    call inspect
-; RV32ZBA-NEXT:    addi sp, sp, 2032
-; RV32ZBA-NEXT:    addi sp, sp, 48
-; RV32ZBA-NEXT:    .cfi_def_cfa_offset 2032
-; RV32ZBA-NEXT:    lw ra, 2028(sp) # 4-byte Folded Reload
-; RV32ZBA-NEXT:    .cfi_restore ra
-; RV32ZBA-NEXT:    addi sp, sp, 2032
-; RV32ZBA-NEXT:    .cfi_def_cfa_offset 0
-; RV32ZBA-NEXT:    ret
-;
-; RV64I-LABEL: align_8:
-; RV64I:       # %bb.0:
-; RV64I-NEXT:    addi sp, sp, -2032
-; RV64I-NEXT:    .cfi_def_cfa_offset 2032
-; RV64I-NEXT:    sd ra, 2024(sp) # 8-byte Folded Spill
-; RV64I-NEXT:    .cfi_offset ra, -8
-; RV64I-NEXT:    addi sp, sp, -2048
-; RV64I-NEXT:    addi sp, sp, -48
-; RV64I-NEXT:    .cfi_def_cfa_offset 4128
-; RV64I-NEXT:    addi a0, sp, 15
-; RV64I-NEXT:    lui a1, 1
-; RV64I-NEXT:    addi a1, a1, 16
-; RV64I-NEXT:    add a1, sp, a1
-; RV64I-NEXT:    call inspect
-; RV64I-NEXT:    addi sp, sp, 2032
-; RV64I-NEXT:    addi sp, sp, 64
-; RV64I-NEXT:    .cfi_def_cfa_offset 2032
-; RV64I-NEXT:    ld ra, 2024(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    .cfi_restore ra
-; RV64I-NEXT:    addi sp, sp, 2032
-; RV64I-NEXT:    .cfi_def_cfa_offset 0
-; RV64I-NEXT:    ret
-;
-; RV64ZBA-LABEL: align_8:
-; RV64ZBA:       # %bb.0:
-; RV64ZBA-NEXT:    addi sp, sp, -2032
-; RV64ZBA-NEXT:    .cfi_def_cfa_offset 2032
-; RV64ZBA-NEXT:    sd ra, 2024(sp) # 8-byte Folded Spill
-; RV64ZBA-NEXT:    .cfi_offset ra, -8
-; RV64ZBA-NEXT:    addi sp, sp, -2048
-; RV64ZBA-NEXT:    addi sp, sp, -48
-; RV64ZBA-NEXT:    .cfi_def_cfa_offset 4128
-; RV64ZBA-NEXT:    addi a0, sp, 15
-; RV64ZBA-NEXT:    li a1, 514
-; RV64ZBA-NEXT:    sh3add a1, a1, sp
-; RV64ZBA-NEXT:    call inspect
-; RV64ZBA-NEXT:    addi sp, sp, 2032
-; RV64ZBA-NEXT:    addi sp, sp, 64
-; RV64ZBA-NEXT:    .cfi_def_cfa_offset 2032
-; RV64ZBA-NEXT:    ld ra, 2024(sp) # 8-byte Folded Reload
-; RV64ZBA-NEXT:    .cfi_restore ra
-; RV64ZBA-NEXT:    addi sp, sp, 2032
-; RV64ZBA-NEXT:    .cfi_def_cfa_offset 0
-; RV64ZBA-NEXT:    ret
+; RV64-LABEL: align_8:
+; RV64:       # %bb.0:
+; RV64-NEXT:    addi sp, sp, -2032
+; RV64-NEXT:    .cfi_def_cfa_offset 2032
+; RV64-NEXT:    sd ra, 2024(sp) # 8-byte Folded Spill
+; RV64-NEXT:    .cfi_offset ra, -8
+; RV64-NEXT:    addi sp, sp, -2048
+; RV64-NEXT:    addi sp, sp, -48
+; RV64-NEXT:    .cfi_def_cfa_offset 4128
+; RV64-NEXT:    addi a0, sp, 23
+; RV64-NEXT:    addi a1, sp, 16
+; RV64-NEXT:    call inspect
+; RV64-NEXT:    addi sp, sp, 2032
+; RV64-NEXT:    addi sp, sp, 64
+; RV64-NEXT:    .cfi_def_cfa_offset 2032
+; RV64-NEXT:    ld ra, 2024(sp) # 8-byte Folded Reload
+; RV64-NEXT:    .cfi_restore ra
+; RV64-NEXT:    addi sp, sp, 2032
+; RV64-NEXT:    .cfi_def_cfa_offset 0
+; RV64-NEXT:    ret
   %p2 = alloca i8, align 8
   %p1 = alloca [4097 x i8], align 1
   call void (...) @inspect(ptr %p1, ptr %p2)
@@ -265,28 +157,26 @@ define void @align_8() {
 }
 
 define void @align_4() {
-; RV32I-LABEL: align_4:
-; RV32I:       # %bb.0:
-; RV32I-NEXT:    addi sp, sp, -2032
-; RV32I-NEXT:    .cfi_def_cfa_offset 2032
-; RV32I-NEXT:    sw ra, 2028(sp) # 4-byte Folded Spill
-; RV32I-NEXT:    .cfi_offset ra, -4
-; RV32I-NEXT:    addi sp, sp, -2048
-; RV32I-NEXT:    addi sp, sp, -32
-; RV32I-NEXT:    .cfi_def_cfa_offset 4112
-; RV32I-NEXT:    addi a0, sp, 7
-; RV32I-NEXT:    lui a1, 1
-; RV32I-NEXT:    addi a1, a1, 8
-; RV32I-NEXT:    add a1, sp, a1
-; RV32I-NEXT:    call inspect
-; RV32I-NEXT:    addi sp, sp, 2032
-; RV32I-NEXT:    addi sp, sp, 48
-; RV32I-NEXT:    .cfi_def_cfa_offset 2032
-; RV32I-NEXT:    lw ra, 2028(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    .cfi_restore ra
-; RV32I-NEXT:    addi sp, sp, 2032
-; RV32I-NEXT:    .cfi_def_cfa_offset 0
-; RV32I-NEXT:    ret
+; RV32-LABEL: align_4:
+; RV32:       # %bb.0:
+; RV32-NEXT:    addi sp, sp, -2032
+; RV32-NEXT:    .cfi_def_cfa_offset 2032
+; RV32-NEXT:    sw ra, 2028(sp) # 4-byte Folded Spill
+; RV32-NEXT:    .cfi_offset ra, -4
+; RV32-NEXT:    addi sp, sp, -2048
+; RV32-NEXT:    addi sp, sp, -32
+; RV32-NEXT:    .cfi_def_cfa_offset 4112
+; RV32-NEXT:    addi a0, sp, 11
+; RV32-NEXT:    addi a1, sp, 8
+; RV32-NEXT:    call inspect
+; RV32-NEXT:    addi sp, sp, 2032
+; RV32-NEXT:    addi sp, sp, 48
+; RV32-NEXT:    .cfi_def_cfa_offset 2032
+; RV32-NEXT:    lw ra, 2028(sp) # 4-byte Folded Reload
+; RV32-NEXT:    .cfi_restore ra
+; RV32-NEXT:    addi sp, sp, 2032
+; RV32-NEXT:    .cfi_def_cfa_offset 0
+; RV32-NEXT:    ret
 ;
 ; RV32XQCILIA-LABEL: align_4:
 ; RV32XQCILIA:       # %bb.0:
@@ -296,8 +186,8 @@ define void @align_4() {
 ; RV32XQCILIA-NEXT:    .cfi_offset ra, -4
 ; RV32XQCILIA-NEXT:    qc.e.addi sp, sp, -3856
 ; RV32XQCILIA-NEXT:    .cfi_def_cfa_offset 4112
-; RV32XQCILIA-NEXT:    addi a0, sp, 7
-; RV32XQCILIA-NEXT:    qc.e.addi a1, sp, 4104
+; RV32XQCILIA-NEXT:    addi a0, sp, 11
+; RV32XQCILIA-NEXT:    addi a1, sp, 8
 ; RV32XQCILIA-NEXT:    call inspect
 ; RV32XQCILIA-NEXT:    qc.e.addi sp, sp, 3856
 ; RV32XQCILIA-NEXT:    .cfi_def_cfa_offset 256
@@ -307,72 +197,26 @@ define void @align_4() {
 ; RV32XQCILIA-NEXT:    .cfi_def_cfa_offset 0
 ; RV32XQCILIA-NEXT:    ret
 ;
-; RV32ZBA-LABEL: align_4:
-; RV32ZBA:       # %bb.0:
-; RV32ZBA-NEXT:    addi sp, sp, -2032
-; RV32ZBA-NEXT:    .cfi_def_cfa_offset 2032
-; RV32ZBA-NEXT:    sw ra, 2028(sp) # 4-byte Folded Spill
-; RV32ZBA-NEXT:    .cfi_offset ra, -4
-; RV32ZBA-NEXT:    addi sp, sp, -2048
-; RV32ZBA-NEXT:    addi sp, sp, -32
-; RV32ZBA-NEXT:    .cfi_def_cfa_offset 4112
-; RV32ZBA-NEXT:    addi a0, sp, 7
-; RV32ZBA-NEXT:    li a1, 513
-; RV32ZBA-NEXT:    sh3add a1, a1, sp
-; RV32ZBA-NEXT:    call inspect
-; RV32ZBA-NEXT:    addi sp, sp, 2032
-; RV32ZBA-NEXT:    addi sp, sp, 48
-; RV32ZBA-NEXT:    .cfi_def_cfa_offset 2032
-; RV32ZBA-NEXT:    lw ra, 2028(sp) # 4-byte Folded Reload
-; RV32ZBA-NEXT:    .cfi_restore ra
-; RV32ZBA-NEXT:    addi sp, sp, 2032
-; RV32ZBA-NEXT:    .cfi_def_cfa_offset 0
-; RV32ZBA-NEXT:    ret
-;
-; RV64I-LABEL: align_4:
-; RV64I:       # %bb.0:
-; RV64I-NEXT:    addi sp, sp, -2032
-; RV64I-NEXT:    .cfi_def_cfa_offset 2032
-; RV64I-NEXT:    sd ra, 2024(sp) # 8-byte Folded Spill
-; RV64I-NEXT:    .cfi_offset ra, -8
-; RV64I-NEXT:    addi sp, sp, -2048
-; RV64I-NEXT:    addi sp, sp, -48
-; RV64I-NEXT:    .cfi_def_cfa_offset 4128
-; RV64I-NEXT:    addi a0, sp, 19
-; RV64I-NEXT:    lui a1, 1
-; RV64I-NEXT:    addi a1, a1, 20
-; RV64I-NEXT:    add a1, sp, a1
-; RV64I-NEXT:    call inspect
-; RV64I-NEXT:    addi sp, sp, 2032
-; RV64I-NEXT:    addi sp, sp, 64
-; RV64I-NEXT:    .cfi_def_cfa_offset 2032
-; RV64I-NEXT:    ld ra, 2024(sp) # 8-byte Folded Reload
-; RV64I-NEXT:    .cfi_restore ra
-; RV64I-NEXT:    addi sp, sp, 2032
-; RV64I-NEXT:    .cfi_def_cfa_offset 0
-; RV64I-NEXT:    ret
-;
-; RV64ZBA-LABEL: align_4:
-; RV64ZBA:       # %bb.0:
-; RV64ZBA-NEXT:    addi sp, sp, -2032
-; RV64ZBA-NEXT:    .cfi_def_cfa_offset 2032
-; RV64ZBA-NEXT:    sd ra, 2024(sp) # 8-byte Folded Spill
-; RV64ZBA-NEXT:    .cfi_offset ra, -8
-; RV64ZBA-NEXT:    addi sp, sp, -2048
-; RV64ZBA-NEXT:    addi sp, sp, -48
-; RV64ZBA-NEXT:    .cfi_def_cfa_offset 4128
-; RV64ZBA-NEXT:    addi a0, sp, 19
-; RV64ZBA-NEXT:    li a1, 1029
-; RV64ZBA-NEXT:    sh2add a1, a1, sp
-; RV64ZBA-NEXT:    call inspect
-; RV64ZBA-NEXT:    addi sp, sp, 2032
-; RV64ZBA-NEXT:    addi sp, sp, 64
-; RV64ZBA-NEXT:    .cfi_def_cfa_offset 2032
-; RV64ZBA-NEXT:    ld ra, 2024(sp) # 8-byte Folded Reload
-; RV64ZBA-NEXT:    .cfi_restore ra
-; RV64ZBA-NEXT:    addi sp, sp, 2032
-; RV64ZBA-NEXT:    .cfi_def_cfa_offset 0
-; RV64ZBA-NEXT:    ret
+; RV64-LABEL: align_4:
+; RV64:       # %bb.0:
+; RV64-NEXT:    addi sp, sp, -2032
+; RV64-NEXT:    .cfi_def_cfa_offset 2032
+; RV64-NEXT:    sd ra, 2024(sp) # 8-byte Folded Spill
+; RV64-NEXT:    .cfi_offset ra, -8
+; RV64-NEXT:    addi sp, sp, -2048
+; RV64-NEXT:    addi sp, sp, -48
+; RV64-NEXT:    .cfi_def_cfa_offset 4128
+; RV64-NEXT:    addi a0, sp, 23
+; RV64-NEXT:    addi a1, sp, 20
+; RV64-NEXT:    call inspect
+; RV64-NEXT:    addi sp, sp, 2032
+; RV64-NEXT:    addi sp, sp, 64
+; RV64-NEXT:    .cfi_def_cfa_offset 2032
+; RV64-NEXT:    ld ra, 2024(sp) # 8-byte Folded Reload
+; RV64-NEXT:    .cfi_restore ra
+; RV64-NEXT:    addi sp, sp, 2032
+; RV64-NEXT:    .cfi_def_cfa_offset 0
+; RV64-NEXT:    ret
   %p2 = alloca i8, align 4
   %p1 = alloca [4097 x i8], align 1
   call void (...) @inspect(ptr %p1, ptr %p2)
@@ -389,10 +233,8 @@ define void @align_2() {
 ; RV32-NEXT:    addi sp, sp, -2048
 ; RV32-NEXT:    addi sp, sp, -32
 ; RV32-NEXT:    .cfi_def_cfa_offset 4112
-; RV32-NEXT:    addi a0, sp, 9
-; RV32-NEXT:    lui a1, 1
-; RV32-NEXT:    addi a1, a1, 10
-; RV32-NEXT:    add a1, sp, a1
+; RV32-NEXT:    addi a0, sp, 11
+; RV32-NEXT:    addi a1, sp, 10
 ; RV32-NEXT:    call inspect
 ; RV32-NEXT:    addi sp, sp, 2032
 ; RV32-NEXT:    addi sp, sp, 48
@@ -411,8 +253,8 @@ define void @align_2() {
 ; RV32XQCILIA-NEXT:    .cfi_offset ra, -4
 ; RV32XQCILIA-NEXT:    qc.e.addi sp, sp, -3856
 ; RV32XQCILIA-NEXT:    .cfi_def_cfa_offset 4112
-; RV32XQCILIA-NEXT:    addi a0, sp, 9
-; RV32XQCILIA-NEXT:    qc.e.addi a1, sp, 4106
+; RV32XQCILIA-NEXT:    addi a0, sp, 11
+; RV32XQCILIA-NEXT:    addi a1, sp, 10
 ; RV32XQCILIA-NEXT:    call inspect
 ; RV32XQCILIA-NEXT:    qc.e.addi sp, sp, 3856
 ; RV32XQCILIA-NEXT:    .cfi_def_cfa_offset 256
@@ -431,10 +273,8 @@ define void @align_2() {
 ; RV64-NEXT:    addi sp, sp, -2048
 ; RV64-NEXT:    addi sp, sp, -48
 ; RV64-NEXT:    .cfi_def_cfa_offset 4128
-; RV64-NEXT:    addi a0, sp, 21
-; RV64-NEXT:    lui a1, 1
-; RV64-NEXT:    addi a1, a1, 22
-; RV64-NEXT:    add a1, sp, a1
+; RV64-NEXT:    addi a0, sp, 23
+; RV64-NEXT:    addi a1, sp, 22
 ; RV64-NEXT:    call inspect
 ; RV64-NEXT:    addi sp, sp, 2032
 ; RV64-NEXT:    addi sp, sp, 64
@@ -461,10 +301,8 @@ define void @align_1() {
 ; RV32-NEXT:    addi sp, sp, -2048
 ; RV32-NEXT:    addi sp, sp, -32
 ; RV32-NEXT:    .cfi_def_cfa_offset 4112
-; RV32-NEXT:    addi a0, sp, 10
-; RV32-NEXT:    lui a1, 1
-; RV32-NEXT:    addi a1, a1, 11
-; RV32-NEXT:    add a1, sp, a1
+; RV32-NEXT:    addi a0, sp, 11
+; RV32-NEXT:    addi a1, sp, 10
 ; RV32-NEXT:    call inspect
 ; RV32-NEXT:    addi sp, sp, 2032
 ; RV32-NEXT:    addi sp, sp, 48
@@ -483,8 +321,8 @@ define void @align_1() {
 ; RV32XQCILIA-NEXT:    .cfi_offset ra, -4
 ; RV32XQCILIA-NEXT:    qc.e.addi sp, sp, -3856
 ; RV32XQCILIA-NEXT:    .cfi_def_cfa_offset 4112
-; RV32XQCILIA-NEXT:    addi a0, sp, 10
-; RV32XQCILIA-NEXT:    qc.e.addi a1, sp, 4107
+; RV32XQCILIA-NEXT:    addi a0, sp, 11
+; RV32XQCILIA-NEXT:    addi a1, sp, 10
 ; RV32XQCILIA-NEXT:    call inspect
 ; RV32XQCILIA-NEXT:    qc.e.addi sp, sp, 3856
 ; RV32XQCILIA-NEXT:    .cfi_def_cfa_offset 256
@@ -503,10 +341,8 @@ define void @align_1() {
 ; RV64-NEXT:    addi sp, sp, -2048
 ; RV64-NEXT:    addi sp, sp, -48
 ; RV64-NEXT:    .cfi_def_cfa_offset 4128
-; RV64-NEXT:    addi a0, sp, 22
-; RV64-NEXT:    lui a1, 1
-; RV64-NEXT:    addi a1, a1, 23
-; RV64-NEXT:    add a1, sp, a1
+; RV64-NEXT:    addi a0, sp, 23
+; RV64-NEXT:    addi a1, sp, 22
 ; RV64-NEXT:    call inspect
 ; RV64-NEXT:    addi sp, sp, 2032
 ; RV64-NEXT:    addi sp, sp, 64
@@ -532,10 +368,8 @@ define void @align_1_lui() {
 ; RV32-NEXT:    lui a0, 1
 ; RV32-NEXT:    sub sp, sp, a0
 ; RV32-NEXT:    .cfi_def_cfa_offset 6128
-; RV32-NEXT:    addi a0, sp, 8
-; RV32-NEXT:    lui a1, 1
-; RV32-NEXT:    addi a1, a1, 2027
-; RV32-NEXT:    add a1, sp, a1
+; RV32-NEXT:    addi a0, sp, 9
+; RV32-NEXT:    addi a1, sp, 8
 ; RV32-NEXT:    call inspect
 ; RV32-NEXT:    lui a0, 1
 ; RV32-NEXT:    add sp, sp, a0
@@ -554,8 +388,8 @@ define void @align_1_lui() {
 ; RV32XQCILIA-NEXT:    .cfi_offset ra, -4
 ; RV32XQCILIA-NEXT:    qc.e.addi sp, sp, -4096
 ; RV32XQCILIA-NEXT:    .cfi_def_cfa_offset 6128
-; RV32XQCILIA-NEXT:    addi a0, sp, 8
-; RV32XQCILIA-NEXT:    qc.e.addi a1, sp, 6123
+; RV32XQCILIA-NEXT:    addi a0, sp, 9
+; RV32XQCILIA-NEXT:    addi a1, sp, 8
 ; RV32XQCILIA-NEXT:    call inspect
 ; RV32XQCILIA-NEXT:    lui a0, 1
 ; RV32XQCILIA-NEXT:    add sp, sp, a0
@@ -576,10 +410,8 @@ define void @align_1_lui() {
 ; RV64I-NEXT:    addi a0, a0, 16
 ; RV64I-NEXT:    sub sp, sp, a0
 ; RV64I-NEXT:    .cfi_def_cfa_offset 6144
-; RV64I-NEXT:    addi a0, sp, 20
-; RV64I-NEXT:    lui a1, 1
-; RV64I-NEXT:    addi a1, a1, 2039
-; RV64I-NEXT:    add a1, sp, a1
+; RV64I-NEXT:    addi a0, sp, 21
+; RV64I-NEXT:    addi a1, sp, 20
 ; RV64I-NEXT:    call inspect
 ; RV64I-NEXT:    lui a0, 1
 ; RV64I-NEXT:    addi a0, a0, 16
@@ -600,10 +432,8 @@ define void @align_1_lui() {
 ; RV64ZBA-NEXT:    li a0, -514
 ; RV64ZBA-NEXT:    sh3add sp, a0, sp
 ; RV64ZBA-NEXT:    .cfi_def_cfa_offset 6144
-; RV64ZBA-NEXT:    addi a0, sp, 20
-; RV64ZBA-NEXT:    lui a1, 1
-; RV64ZBA-NEXT:    addi a1, a1, 2039
-; RV64ZBA-NEXT:    add a1, sp, a1
+; RV64ZBA-NEXT:    addi a0, sp, 21
+; RV64ZBA-NEXT:    addi a1, sp, 20
 ; RV64ZBA-NEXT:    call inspect
 ; RV64ZBA-NEXT:    li a0, 514
 ; RV64ZBA-NEXT:    sh3add sp, a0, sp
@@ -618,3 +448,6 @@ define void @align_1_lui() {
   call void (...) @inspect(ptr %p1, ptr %p2)
   ret void
 }
+;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
+; RV32I: {{.*}}
+; RV32ZBA: {{.*}}

--- a/llvm/test/CodeGen/RISCV/stack-slot-size.ll
+++ b/llvm/test/CodeGen/RISCV/stack-slot-size.ll
@@ -19,15 +19,15 @@ define i32 @caller129() nounwind {
 ; RV32I-NEXT:    addi sp, sp, -32
 ; RV32I-NEXT:    sw ra, 28(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    li a0, 42
-; RV32I-NEXT:    sw a0, 24(sp)
-; RV32I-NEXT:    sw zero, 16(sp)
-; RV32I-NEXT:    mv a0, sp
-; RV32I-NEXT:    sw zero, 0(sp)
-; RV32I-NEXT:    sw zero, 4(sp)
+; RV32I-NEXT:    sw a0, 4(sp)
+; RV32I-NEXT:    sw zero, 24(sp)
+; RV32I-NEXT:    addi a0, sp, 8
 ; RV32I-NEXT:    sw zero, 8(sp)
 ; RV32I-NEXT:    sw zero, 12(sp)
+; RV32I-NEXT:    sw zero, 16(sp)
+; RV32I-NEXT:    sw zero, 20(sp)
 ; RV32I-NEXT:    call callee129
-; RV32I-NEXT:    lw a0, 24(sp)
+; RV32I-NEXT:    lw a0, 4(sp)
 ; RV32I-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    addi sp, sp, 32
 ; RV32I-NEXT:    ret
@@ -37,13 +37,13 @@ define i32 @caller129() nounwind {
 ; RV64I-NEXT:    addi sp, sp, -48
 ; RV64I-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    li a0, 42
-; RV64I-NEXT:    sw a0, 36(sp)
-; RV64I-NEXT:    mv a0, sp
-; RV64I-NEXT:    sd zero, 0(sp)
-; RV64I-NEXT:    sd zero, 8(sp)
+; RV64I-NEXT:    sw a0, 12(sp)
+; RV64I-NEXT:    addi a0, sp, 16
 ; RV64I-NEXT:    sd zero, 16(sp)
+; RV64I-NEXT:    sd zero, 24(sp)
+; RV64I-NEXT:    sd zero, 32(sp)
 ; RV64I-NEXT:    call callee129
-; RV64I-NEXT:    lw a0, 36(sp)
+; RV64I-NEXT:    lw a0, 12(sp)
 ; RV64I-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    addi sp, sp, 48
 ; RV64I-NEXT:    ret
@@ -60,15 +60,15 @@ define i32 @caller160() nounwind {
 ; RV32I-NEXT:    addi sp, sp, -32
 ; RV32I-NEXT:    sw ra, 28(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    li a0, 42
-; RV32I-NEXT:    sw a0, 24(sp)
-; RV32I-NEXT:    sw zero, 16(sp)
-; RV32I-NEXT:    mv a0, sp
-; RV32I-NEXT:    sw zero, 0(sp)
-; RV32I-NEXT:    sw zero, 4(sp)
+; RV32I-NEXT:    sw a0, 4(sp)
+; RV32I-NEXT:    sw zero, 24(sp)
+; RV32I-NEXT:    addi a0, sp, 8
 ; RV32I-NEXT:    sw zero, 8(sp)
 ; RV32I-NEXT:    sw zero, 12(sp)
+; RV32I-NEXT:    sw zero, 16(sp)
+; RV32I-NEXT:    sw zero, 20(sp)
 ; RV32I-NEXT:    call callee160
-; RV32I-NEXT:    lw a0, 24(sp)
+; RV32I-NEXT:    lw a0, 4(sp)
 ; RV32I-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    addi sp, sp, 32
 ; RV32I-NEXT:    ret
@@ -78,13 +78,13 @@ define i32 @caller160() nounwind {
 ; RV64I-NEXT:    addi sp, sp, -48
 ; RV64I-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    li a0, 42
-; RV64I-NEXT:    sw a0, 36(sp)
-; RV64I-NEXT:    mv a0, sp
-; RV64I-NEXT:    sd zero, 0(sp)
-; RV64I-NEXT:    sd zero, 8(sp)
+; RV64I-NEXT:    sw a0, 12(sp)
+; RV64I-NEXT:    addi a0, sp, 16
 ; RV64I-NEXT:    sd zero, 16(sp)
+; RV64I-NEXT:    sd zero, 24(sp)
+; RV64I-NEXT:    sd zero, 32(sp)
 ; RV64I-NEXT:    call callee160
-; RV64I-NEXT:    lw a0, 36(sp)
+; RV64I-NEXT:    lw a0, 12(sp)
 ; RV64I-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    addi sp, sp, 48
 ; RV64I-NEXT:    ret
@@ -98,21 +98,21 @@ define i32 @caller160() nounwind {
 define i32 @caller161() nounwind {
 ; RV32I-LABEL: caller161:
 ; RV32I:       # %bb.0:
-; RV32I-NEXT:    addi sp, sp, -32
-; RV32I-NEXT:    sw ra, 28(sp) # 4-byte Folded Spill
+; RV32I-NEXT:    addi sp, sp, -48
+; RV32I-NEXT:    sw ra, 44(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    li a0, 42
-; RV32I-NEXT:    sw a0, 24(sp)
+; RV32I-NEXT:    sw a0, 12(sp)
+; RV32I-NEXT:    sw zero, 32(sp)
+; RV32I-NEXT:    sw zero, 36(sp)
+; RV32I-NEXT:    addi a0, sp, 16
 ; RV32I-NEXT:    sw zero, 16(sp)
 ; RV32I-NEXT:    sw zero, 20(sp)
-; RV32I-NEXT:    mv a0, sp
-; RV32I-NEXT:    sw zero, 0(sp)
-; RV32I-NEXT:    sw zero, 4(sp)
-; RV32I-NEXT:    sw zero, 8(sp)
-; RV32I-NEXT:    sw zero, 12(sp)
+; RV32I-NEXT:    sw zero, 24(sp)
+; RV32I-NEXT:    sw zero, 28(sp)
 ; RV32I-NEXT:    call callee161
-; RV32I-NEXT:    lw a0, 24(sp)
-; RV32I-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload
-; RV32I-NEXT:    addi sp, sp, 32
+; RV32I-NEXT:    lw a0, 12(sp)
+; RV32I-NEXT:    lw ra, 44(sp) # 4-byte Folded Reload
+; RV32I-NEXT:    addi sp, sp, 48
 ; RV32I-NEXT:    ret
 ;
 ; RV64I-LABEL: caller161:
@@ -120,13 +120,13 @@ define i32 @caller161() nounwind {
 ; RV64I-NEXT:    addi sp, sp, -48
 ; RV64I-NEXT:    sd ra, 40(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    li a0, 42
-; RV64I-NEXT:    sw a0, 36(sp)
-; RV64I-NEXT:    mv a0, sp
-; RV64I-NEXT:    sd zero, 0(sp)
-; RV64I-NEXT:    sd zero, 8(sp)
+; RV64I-NEXT:    sw a0, 12(sp)
+; RV64I-NEXT:    addi a0, sp, 16
 ; RV64I-NEXT:    sd zero, 16(sp)
+; RV64I-NEXT:    sd zero, 24(sp)
+; RV64I-NEXT:    sd zero, 32(sp)
 ; RV64I-NEXT:    call callee161
-; RV64I-NEXT:    lw a0, 36(sp)
+; RV64I-NEXT:    lw a0, 12(sp)
 ; RV64I-NEXT:    ld ra, 40(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    addi sp, sp, 48
 ; RV64I-NEXT:    ret

--- a/llvm/test/CodeGen/RISCV/stack-symbol-ordering.mir
+++ b/llvm/test/CodeGen/RISCV/stack-symbol-ordering.mir
@@ -1,0 +1,67 @@
+# RUN: llc %s -mtriple=riscv64 -O2 \
+# RUN:   -start-before=prolog-epilog -verify-machineinstrs -o - \
+# RUN:   | FileCheck %s --check-prefix=SP
+# RUN: llc %s -mtriple=riscv64 -O2 \
+# RUN:   -frame-pointer=all -start-before=prolog-epilog \
+# RUN:   -verify-machineinstrs -o - | FileCheck %s --check-prefix=FP
+
+# The 4-byte slot is referenced twelve times and the 2000-byte cold slot only once.
+# Declare the hot slot first so the original PEI order puts it away from SP.
+# Density sorting moves the hot slot to the tail of the allocation order, which
+# places it closest to SP. FP-relative locals require reversing that order so
+# the hot slot is instead near FP.
+
+--- |
+  define void @test() {
+  entry:
+    ret void
+  }
+...
+---
+name:            test
+alignment:       2
+tracksRegLiveness: true
+frameInfo:
+  maxAlignment:    16
+stack:
+  - { id: 0, type: spill-slot, size: 4, alignment: 4 }
+  - { id: 1, type: spill-slot, size: 2000, alignment: 16 }
+machineFunctionInfo: {}
+body:             |
+  bb.0.entry:
+    liveins: $x10
+
+    ; Hot slot: six stores and six loads.
+    SW $x10, %stack.0, 0 :: (store (s32) into %stack.0)
+    $x11 = LW %stack.0, 0 :: (load (s32) from %stack.0)
+    SW $x10, %stack.0, 0 :: (store (s32) into %stack.0)
+    $x11 = LW %stack.0, 0 :: (load (s32) from %stack.0)
+    SW $x10, %stack.0, 0 :: (store (s32) into %stack.0)
+    $x11 = LW %stack.0, 0 :: (load (s32) from %stack.0)
+    SW $x10, %stack.0, 0 :: (store (s32) into %stack.0)
+    $x11 = LW %stack.0, 0 :: (load (s32) from %stack.0)
+    SW $x10, %stack.0, 0 :: (store (s32) into %stack.0)
+    $x11 = LW %stack.0, 0 :: (load (s32) from %stack.0)
+    SW $x10, %stack.0, 0 :: (store (s32) into %stack.0)
+    $x11 = LW %stack.0, 0 :: (load (s32) from %stack.0)
+
+    ; Cold slot: one reference, but large enough to separate the objects.
+    SW $x10, %stack.1, 0 :: (store (s32) into %stack.1)
+    PseudoRET
+
+# SP-LABEL: test:
+# SP:       addi sp, sp, -2016
+# SP:       sw a0, 12(sp)
+# SP:       lw a1, 12(sp)
+# SP:       sw a0, 12(sp)
+# SP:       lw a1, 12(sp)
+
+# FP-LABEL: test:
+# FP:       addi s0, sp, 2032
+# FP-NEXT: .cfi_def_cfa s0, 0
+# FP-NEXT: sw a0, -28(s0)
+# FP-NEXT: lw a1, -28(s0)
+# FP-NEXT: sw a0, -28(s0)
+# FP-NEXT: lw a1, -28(s0)
+# FP-NEXT: sw a0, -28(s0)
+# FP-NEXT: lw a1, -28(s0)

--- a/llvm/test/CodeGen/RISCV/vararg.ll
+++ b/llvm/test/CodeGen/RISCV/vararg.ll
@@ -1883,24 +1883,24 @@ define i32 @va4_va_copy(i32 %argno, ...) nounwind {
 ; ILP32-ILP32F-FPELIM-NEXT:    sw a3, 28(sp)
 ; ILP32-ILP32F-FPELIM-NEXT:    sw a4, 32(sp)
 ; ILP32-ILP32F-FPELIM-NEXT:    addi a0, sp, 24
-; ILP32-ILP32F-FPELIM-NEXT:    sw a0, 4(sp)
 ; ILP32-ILP32F-FPELIM-NEXT:    sw a0, 0(sp)
+; ILP32-ILP32F-FPELIM-NEXT:    sw a0, 4(sp)
 ; ILP32-ILP32F-FPELIM-NEXT:    call notdead
-; ILP32-ILP32F-FPELIM-NEXT:    lw a0, 4(sp)
+; ILP32-ILP32F-FPELIM-NEXT:    lw a0, 0(sp)
 ; ILP32-ILP32F-FPELIM-NEXT:    addi a0, a0, 3
 ; ILP32-ILP32F-FPELIM-NEXT:    andi a0, a0, -4
 ; ILP32-ILP32F-FPELIM-NEXT:    addi a1, a0, 4
 ; ILP32-ILP32F-FPELIM-NEXT:    addi a2, a0, 7
-; ILP32-ILP32F-FPELIM-NEXT:    sw a1, 4(sp)
+; ILP32-ILP32F-FPELIM-NEXT:    sw a1, 0(sp)
 ; ILP32-ILP32F-FPELIM-NEXT:    andi a2, a2, -4
 ; ILP32-ILP32F-FPELIM-NEXT:    lw a0, 0(a0)
 ; ILP32-ILP32F-FPELIM-NEXT:    addi a1, a2, 7
 ; ILP32-ILP32F-FPELIM-NEXT:    addi a3, a2, 4
 ; ILP32-ILP32F-FPELIM-NEXT:    andi a1, a1, -4
-; ILP32-ILP32F-FPELIM-NEXT:    sw a3, 4(sp)
+; ILP32-ILP32F-FPELIM-NEXT:    sw a3, 0(sp)
 ; ILP32-ILP32F-FPELIM-NEXT:    addi a3, a1, 4
 ; ILP32-ILP32F-FPELIM-NEXT:    lw a2, 0(a2)
-; ILP32-ILP32F-FPELIM-NEXT:    sw a3, 4(sp)
+; ILP32-ILP32F-FPELIM-NEXT:    sw a3, 0(sp)
 ; ILP32-ILP32F-FPELIM-NEXT:    lw a1, 0(a1)
 ; ILP32-ILP32F-FPELIM-NEXT:    add a0, a0, s0
 ; ILP32-ILP32F-FPELIM-NEXT:    add a0, a0, a2
@@ -1968,24 +1968,24 @@ define i32 @va4_va_copy(i32 %argno, ...) nounwind {
 ; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    sw a3, 28(sp)
 ; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    sw a4, 32(sp)
 ; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    addi a0, sp, 24
-; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    sw a0, 4(sp)
 ; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    sw a0, 0(sp)
+; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    sw a0, 4(sp)
 ; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    call notdead
-; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    lw a0, 4(sp)
+; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    lw a0, 0(sp)
 ; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    addi a0, a0, 3
 ; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    andi a0, a0, -4
 ; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    addi a1, a0, 4
 ; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    addi a2, a0, 7
-; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    sw a1, 4(sp)
+; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    sw a1, 0(sp)
 ; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    andi a2, a2, -4
 ; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    lw a0, 0(a0)
 ; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    addi a1, a2, 7
 ; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    addi a3, a2, 4
 ; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    andi a1, a1, -4
-; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    sw a3, 4(sp)
+; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    sw a3, 0(sp)
 ; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    addi a3, a1, 4
 ; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    lw a2, 0(a2)
-; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    sw a3, 4(sp)
+; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    sw a3, 0(sp)
 ; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    lw a1, 0(a1)
 ; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    add a0, a0, s0
 ; RV32D-ILP32-ILP32F-ILP32D-FPELIM-NEXT:    add a0, a0, a2
@@ -2007,24 +2007,24 @@ define i32 @va4_va_copy(i32 %argno, ...) nounwind {
 ; ILP32E-FPELIM-NEXT:    sw a3, 28(sp)
 ; ILP32E-FPELIM-NEXT:    sw a4, 32(sp)
 ; ILP32E-FPELIM-NEXT:    addi a0, sp, 24
-; ILP32E-FPELIM-NEXT:    sw a0, 4(sp)
 ; ILP32E-FPELIM-NEXT:    sw a0, 0(sp)
+; ILP32E-FPELIM-NEXT:    sw a0, 4(sp)
 ; ILP32E-FPELIM-NEXT:    call notdead
-; ILP32E-FPELIM-NEXT:    lw a0, 4(sp)
+; ILP32E-FPELIM-NEXT:    lw a0, 0(sp)
 ; ILP32E-FPELIM-NEXT:    addi a0, a0, 3
 ; ILP32E-FPELIM-NEXT:    andi a0, a0, -4
 ; ILP32E-FPELIM-NEXT:    addi a1, a0, 4
 ; ILP32E-FPELIM-NEXT:    addi a2, a0, 7
-; ILP32E-FPELIM-NEXT:    sw a1, 4(sp)
+; ILP32E-FPELIM-NEXT:    sw a1, 0(sp)
 ; ILP32E-FPELIM-NEXT:    andi a2, a2, -4
 ; ILP32E-FPELIM-NEXT:    lw a0, 0(a0)
 ; ILP32E-FPELIM-NEXT:    addi a1, a2, 7
 ; ILP32E-FPELIM-NEXT:    addi a3, a2, 4
 ; ILP32E-FPELIM-NEXT:    andi a1, a1, -4
-; ILP32E-FPELIM-NEXT:    sw a3, 4(sp)
+; ILP32E-FPELIM-NEXT:    sw a3, 0(sp)
 ; ILP32E-FPELIM-NEXT:    addi a3, a1, 4
 ; ILP32E-FPELIM-NEXT:    lw a2, 0(a2)
-; ILP32E-FPELIM-NEXT:    sw a3, 4(sp)
+; ILP32E-FPELIM-NEXT:    sw a3, 0(sp)
 ; ILP32E-FPELIM-NEXT:    lw a1, 0(a1)
 ; ILP32E-FPELIM-NEXT:    add a0, a0, s0
 ; ILP32E-FPELIM-NEXT:    add a0, a0, a2
@@ -2090,24 +2090,24 @@ define i32 @va4_va_copy(i32 %argno, ...) nounwind {
 ; LP64-LP64F-LP64D-FPELIM-NEXT:    sd a3, 56(sp)
 ; LP64-LP64F-LP64D-FPELIM-NEXT:    sd a4, 64(sp)
 ; LP64-LP64F-LP64D-FPELIM-NEXT:    addi a0, sp, 48
-; LP64-LP64F-LP64D-FPELIM-NEXT:    sd a0, 8(sp)
 ; LP64-LP64F-LP64D-FPELIM-NEXT:    sd a0, 0(sp)
+; LP64-LP64F-LP64D-FPELIM-NEXT:    sd a0, 8(sp)
 ; LP64-LP64F-LP64D-FPELIM-NEXT:    call notdead
-; LP64-LP64F-LP64D-FPELIM-NEXT:    ld a0, 8(sp)
+; LP64-LP64F-LP64D-FPELIM-NEXT:    ld a0, 0(sp)
 ; LP64-LP64F-LP64D-FPELIM-NEXT:    addi a0, a0, 3
 ; LP64-LP64F-LP64D-FPELIM-NEXT:    andi a0, a0, -4
 ; LP64-LP64F-LP64D-FPELIM-NEXT:    addi a1, a0, 8
 ; LP64-LP64F-LP64D-FPELIM-NEXT:    addi a2, a0, 11
-; LP64-LP64F-LP64D-FPELIM-NEXT:    sd a1, 8(sp)
+; LP64-LP64F-LP64D-FPELIM-NEXT:    sd a1, 0(sp)
 ; LP64-LP64F-LP64D-FPELIM-NEXT:    andi a2, a2, -4
 ; LP64-LP64F-LP64D-FPELIM-NEXT:    ld a0, 0(a0)
 ; LP64-LP64F-LP64D-FPELIM-NEXT:    addi a1, a2, 11
 ; LP64-LP64F-LP64D-FPELIM-NEXT:    addi a3, a2, 8
 ; LP64-LP64F-LP64D-FPELIM-NEXT:    andi a1, a1, -4
-; LP64-LP64F-LP64D-FPELIM-NEXT:    sd a3, 8(sp)
+; LP64-LP64F-LP64D-FPELIM-NEXT:    sd a3, 0(sp)
 ; LP64-LP64F-LP64D-FPELIM-NEXT:    addi a3, a1, 8
 ; LP64-LP64F-LP64D-FPELIM-NEXT:    ld a2, 0(a2)
-; LP64-LP64F-LP64D-FPELIM-NEXT:    sd a3, 8(sp)
+; LP64-LP64F-LP64D-FPELIM-NEXT:    sd a3, 0(sp)
 ; LP64-LP64F-LP64D-FPELIM-NEXT:    ld a1, 0(a1)
 ; LP64-LP64F-LP64D-FPELIM-NEXT:    add a0, a0, s0
 ; LP64-LP64F-LP64D-FPELIM-NEXT:    add a0, a0, a2
@@ -2173,24 +2173,24 @@ define i32 @va4_va_copy(i32 %argno, ...) nounwind {
 ; LP64E-FPELIM-NEXT:    sd a3, 56(sp)
 ; LP64E-FPELIM-NEXT:    sd a4, 64(sp)
 ; LP64E-FPELIM-NEXT:    addi a0, sp, 48
-; LP64E-FPELIM-NEXT:    sd a0, 8(sp)
 ; LP64E-FPELIM-NEXT:    sd a0, 0(sp)
+; LP64E-FPELIM-NEXT:    sd a0, 8(sp)
 ; LP64E-FPELIM-NEXT:    call notdead
-; LP64E-FPELIM-NEXT:    ld a0, 8(sp)
+; LP64E-FPELIM-NEXT:    ld a0, 0(sp)
 ; LP64E-FPELIM-NEXT:    addi a0, a0, 3
 ; LP64E-FPELIM-NEXT:    andi a0, a0, -4
 ; LP64E-FPELIM-NEXT:    addi a1, a0, 8
 ; LP64E-FPELIM-NEXT:    addi a2, a0, 11
-; LP64E-FPELIM-NEXT:    sd a1, 8(sp)
+; LP64E-FPELIM-NEXT:    sd a1, 0(sp)
 ; LP64E-FPELIM-NEXT:    andi a2, a2, -4
 ; LP64E-FPELIM-NEXT:    ld a0, 0(a0)
 ; LP64E-FPELIM-NEXT:    addi a1, a2, 11
 ; LP64E-FPELIM-NEXT:    addi a3, a2, 8
 ; LP64E-FPELIM-NEXT:    andi a1, a1, -4
-; LP64E-FPELIM-NEXT:    sd a3, 8(sp)
+; LP64E-FPELIM-NEXT:    sd a3, 0(sp)
 ; LP64E-FPELIM-NEXT:    addi a3, a1, 8
 ; LP64E-FPELIM-NEXT:    ld a2, 0(a2)
-; LP64E-FPELIM-NEXT:    sd a3, 8(sp)
+; LP64E-FPELIM-NEXT:    sd a3, 0(sp)
 ; LP64E-FPELIM-NEXT:    ld a1, 0(a1)
 ; LP64E-FPELIM-NEXT:    add a0, a0, s0
 ; LP64E-FPELIM-NEXT:    add a0, a0, a2
@@ -2855,7 +2855,7 @@ define i32 @va_large_stack(ptr %fmt, ...) {
 ; ILP32-ILP32F-WITHFP-NEXT:    sw a3, 12(s0)
 ; ILP32-ILP32F-WITHFP-NEXT:    addi a1, s0, 8
 ; ILP32-ILP32F-WITHFP-NEXT:    sw a4, 16(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a1, 0(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a1, -16(s0)
 ; ILP32-ILP32F-WITHFP-NEXT:    lui a1, 24414
 ; ILP32-ILP32F-WITHFP-NEXT:    addi a1, a1, -1728
 ; ILP32-ILP32F-WITHFP-NEXT:    add sp, sp, a1
@@ -2950,7 +2950,7 @@ define i32 @va_large_stack(ptr %fmt, ...) {
 ; ILP32E-WITHFP-NEXT:    sw a3, 12(s0)
 ; ILP32E-WITHFP-NEXT:    addi a1, s0, 8
 ; ILP32E-WITHFP-NEXT:    sw a4, 16(s0)
-; ILP32E-WITHFP-NEXT:    sw a1, 0(sp)
+; ILP32E-WITHFP-NEXT:    sw a1, -16(s0)
 ; ILP32E-WITHFP-NEXT:    lui a1, 24414
 ; ILP32E-WITHFP-NEXT:    addi a1, a1, -1748
 ; ILP32E-WITHFP-NEXT:    add sp, sp, a1
@@ -3008,7 +3008,7 @@ define i32 @va_large_stack(ptr %fmt, ...) {
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    sub sp, sp, a0
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a0, s0, 12
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, 8(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a0, 0(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a0, -32(s0)
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    lw a0, 8(s0)
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a5, 40(s0)
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a6, 48(s0)
@@ -3071,7 +3071,7 @@ define i32 @va_large_stack(ptr %fmt, ...) {
 ; LP64E-WITHFP-NEXT:    sub sp, sp, a0
 ; LP64E-WITHFP-NEXT:    addi a0, s0, 12
 ; LP64E-WITHFP-NEXT:    sd a1, 8(s0)
-; LP64E-WITHFP-NEXT:    sd a0, 0(sp)
+; LP64E-WITHFP-NEXT:    sd a0, -32(s0)
 ; LP64E-WITHFP-NEXT:    lw a0, 8(s0)
 ; LP64E-WITHFP-NEXT:    sd a5, 40(s0)
 ; LP64E-WITHFP-NEXT:    sd a2, 16(s0)

--- a/llvm/test/CodeGen/RISCV/varargs-with-fp-and-second-adj.ll
+++ b/llvm/test/CodeGen/RISCV/varargs-with-fp-and-second-adj.ll
@@ -23,8 +23,8 @@ define dso_local void @_Z3fooPKcz(ptr noundef %0, ...) "frame-pointer"="all" {
 ; RV64V-NEXT:    sd a3, 24(s0)
 ; RV64V-NEXT:    sd a4, 32(s0)
 ; RV64V-NEXT:    addi a1, s0, 8
-; RV64V-NEXT:    sd a0, -32(s0)
-; RV64V-NEXT:    sd a1, -40(s0)
+; RV64V-NEXT:    sd a0, -40(s0)
+; RV64V-NEXT:    sd a1, -32(s0)
 ; RV64V-NEXT:    addi sp, s0, -432
 ; RV64V-NEXT:    .cfi_def_cfa sp, 496
 ; RV64V-NEXT:    ld ra, 424(sp) # 8-byte Folded Reload

--- a/llvm/test/CodeGen/RISCV/xqccmp-callee-saved-gprs.ll
+++ b/llvm/test/CodeGen/RISCV/xqccmp-callee-saved-gprs.ll
@@ -130,17 +130,17 @@ define void @callee() {
 ; RV32IXQCCMP-WITH-FP-NEXT:    lui a0, %hi(var)
 ; RV32IXQCCMP-WITH-FP-NEXT:    addi a0, a0, %lo(var)
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 0(a0)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 4(a0)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 8(a0)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 12(a0)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 16(a0)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 20(a0)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 4(a0)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 8(a0)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 12(a0)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 16(a0)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 20(a0)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a7, 24(a0)
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw t0, 28(a0)
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw t1, 32(a0)
@@ -193,17 +193,17 @@ define void @callee() {
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw t1, 32(a0)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw t0, 28(a0)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a7, 24(a0)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 20(a0)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 16(a0)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 12(a0)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 8(a0)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 4(a0)
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 20(a0)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 16(a0)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 12(a0)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 8(a0)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 4(a0)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 0(a0)
 ; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 96
 ; RV32IXQCCMP-WITH-FP-NEXT:    qc.cm.popret {ra, s0-s11}, 96
@@ -324,17 +324,17 @@ define void @callee() {
 ; RV64IXQCCMP-WITH-FP-NEXT:    lui a0, %hi(var)
 ; RV64IXQCCMP-WITH-FP-NEXT:    addi a0, a0, %lo(var)
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a1, 0(a0)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, 40(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a1, 4(a0)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, 32(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a1, 8(a0)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, 24(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a1, 12(a0)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, 16(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a1, 16(a0)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, 8(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a1, 20(a0)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, 0(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a1, 4(a0)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, 8(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a1, 8(a0)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, 16(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a1, 12(a0)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, 24(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a1, 16(a0)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, 32(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a1, 20(a0)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, 40(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a7, 24(a0)
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw t0, 28(a0)
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw t1, 32(a0)
@@ -387,17 +387,17 @@ define void @callee() {
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw t1, 32(a0)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw t0, 28(a0)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a7, 24(a0)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a1, 0(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a1, 20(a0)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a1, 8(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a1, 16(a0)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a1, 16(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a1, 12(a0)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a1, 24(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a1, 8(a0)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a1, 32(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a1, 4(a0)
 ; RV64IXQCCMP-WITH-FP-NEXT:    ld a1, 40(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a1, 20(a0)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a1, 32(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a1, 16(a0)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a1, 24(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a1, 12(a0)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a1, 16(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a1, 8(a0)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a1, 8(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a1, 4(a0)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a1, 0(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a1, 0(a0)
 ; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 160
 ; RV64IXQCCMP-WITH-FP-NEXT:    qc.cm.popret {ra, s0-s11}, 160
@@ -565,49 +565,49 @@ define void @caller() {
 ; RV32IXQCCMP-WITH-FP-NEXT:    lui s1, %hi(var)
 ; RV32IXQCCMP-WITH-FP-NEXT:    addi s1, s1, %lo(var)
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 0(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 92(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 4(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 8(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 12(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 16(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 20(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 24(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 28(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 32(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 36(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 40(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 44(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 48(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 52(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 56(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 60(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 64(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 68(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 72(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 76(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 80(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 84(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 4(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 8(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 12(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 16(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 20(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 24(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 28(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 32(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 36(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 40(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 44(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 48(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 52(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 56(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 60(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 64(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 68(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 72(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 76(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 80(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 84(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 92(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw s4, 88(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw s5, 92(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw s6, 96(s1)
@@ -629,49 +629,49 @@ define void @caller() {
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw s6, 96(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw s5, 92(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw s4, 88(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 84(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 80(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 76(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 72(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 68(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 64(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 60(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 56(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 52(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 48(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 44(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 40(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 36(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 32(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 28(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 24(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 20(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 16(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 12(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 8(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 4(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 84(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 80(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 76(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 72(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 68(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 64(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 60(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 56(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 52(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 48(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 44(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 40(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 36(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 32(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 28(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 24(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 20(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 16(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 12(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 8(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 4(s1)
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 0(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 160
 ; RV32IXQCCMP-WITH-FP-NEXT:    addi sp, sp, 48
@@ -833,49 +833,49 @@ define void @caller() {
 ; RV64IXQCCMP-WITH-FP-NEXT:    lui s1, %hi(var)
 ; RV64IXQCCMP-WITH-FP-NEXT:    addi s1, s1, %lo(var)
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 0(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 168(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 4(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 160(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 8(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 152(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 12(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 144(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 16(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 136(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 20(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 128(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 24(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 120(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 28(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 112(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 32(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 104(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 36(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 96(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 40(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 88(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 44(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 80(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 48(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 72(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 52(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 64(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 56(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 56(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 60(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 64(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 68(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 72(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 76(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 80(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 84(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 0(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 4(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 8(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 12(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 16(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 20(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 24(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 28(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 56(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 32(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 64(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 36(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 72(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 40(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 80(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 44(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 88(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 48(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 96(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 52(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 104(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 56(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 112(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 60(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 120(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 64(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 128(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 68(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 136(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 72(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 144(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 76(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 152(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 80(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 160(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 84(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 168(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw s4, 88(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw s5, 92(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw s6, 96(s1)
@@ -897,49 +897,49 @@ define void @caller() {
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw s6, 96(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw s5, 92(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw s4, 88(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 0(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 84(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 80(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 76(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 72(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 68(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 64(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 48(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 60(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 56(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 56(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 64(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 52(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 72(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 48(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 80(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 44(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 88(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 40(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 96(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 36(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 104(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 32(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 112(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 28(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 120(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 24(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 128(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 20(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 136(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 16(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 144(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 12(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 152(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 8(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 160(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 4(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 168(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 84(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 160(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 80(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 152(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 76(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 144(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 72(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 136(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 68(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 128(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 64(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 120(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 60(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 112(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 56(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 104(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 52(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 96(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 48(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 88(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 44(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 80(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 40(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 72(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 36(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 64(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 32(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 56(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 28(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 48(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 24(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 20(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 16(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 12(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 8(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 4(s1)
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 0(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 0(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 288
 ; RV64IXQCCMP-WITH-FP-NEXT:    addi sp, sp, 128

--- a/llvm/test/CodeGen/RISCV/xqccmp-push-pop-popret.ll
+++ b/llvm/test/CodeGen/RISCV/xqccmp-push-pop-popret.ll
@@ -2488,17 +2488,17 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV32IXQCCMP-FP-NEXT:    lui a0, %hi(var_test_irq)
 ; RV32IXQCCMP-FP-NEXT:    addi a0, a0, %lo(var_test_irq)
 ; RV32IXQCCMP-FP-NEXT:    lw a1, 0(a0)
-; RV32IXQCCMP-FP-NEXT:    sw a1, 32(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    lw a1, 4(a0)
-; RV32IXQCCMP-FP-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    lw a1, 8(a0)
-; RV32IXQCCMP-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    lw a1, 12(a0)
-; RV32IXQCCMP-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    lw a1, 16(a0)
-; RV32IXQCCMP-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    lw a1, 20(a0)
 ; RV32IXQCCMP-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    lw a1, 4(a0)
+; RV32IXQCCMP-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    lw a1, 8(a0)
+; RV32IXQCCMP-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    lw a1, 12(a0)
+; RV32IXQCCMP-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    lw a1, 16(a0)
+; RV32IXQCCMP-FP-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    lw a1, 20(a0)
+; RV32IXQCCMP-FP-NEXT:    sw a1, 32(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-FP-NEXT:    lw a7, 24(a0)
 ; RV32IXQCCMP-FP-NEXT:    lw t0, 28(a0)
 ; RV32IXQCCMP-FP-NEXT:    lw t1, 32(a0)
@@ -2551,17 +2551,17 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV32IXQCCMP-FP-NEXT:    sw t1, 32(a0)
 ; RV32IXQCCMP-FP-NEXT:    sw t0, 28(a0)
 ; RV32IXQCCMP-FP-NEXT:    sw a7, 24(a0)
-; RV32IXQCCMP-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    sw a1, 20(a0)
-; RV32IXQCCMP-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    sw a1, 16(a0)
-; RV32IXQCCMP-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    sw a1, 12(a0)
-; RV32IXQCCMP-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    sw a1, 8(a0)
-; RV32IXQCCMP-FP-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    sw a1, 4(a0)
 ; RV32IXQCCMP-FP-NEXT:    lw a1, 32(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    sw a1, 20(a0)
+; RV32IXQCCMP-FP-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    sw a1, 16(a0)
+; RV32IXQCCMP-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    sw a1, 12(a0)
+; RV32IXQCCMP-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    sw a1, 8(a0)
+; RV32IXQCCMP-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    sw a1, 4(a0)
+; RV32IXQCCMP-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-FP-NEXT:    sw a1, 0(a0)
 ; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 160
 ; RV32IXQCCMP-FP-NEXT:    lw t0, 92(sp) # 4-byte Folded Reload
@@ -2666,17 +2666,17 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV64IXQCCMP-FP-NEXT:    lui a0, %hi(var_test_irq)
 ; RV64IXQCCMP-FP-NEXT:    addi a0, a0, %lo(var_test_irq)
 ; RV64IXQCCMP-FP-NEXT:    lw a1, 0(a0)
-; RV64IXQCCMP-FP-NEXT:    sd a1, 48(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    lw a1, 4(a0)
-; RV64IXQCCMP-FP-NEXT:    sd a1, 40(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    lw a1, 8(a0)
-; RV64IXQCCMP-FP-NEXT:    sd a1, 32(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    lw a1, 12(a0)
-; RV64IXQCCMP-FP-NEXT:    sd a1, 24(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    lw a1, 16(a0)
-; RV64IXQCCMP-FP-NEXT:    sd a1, 16(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    lw a1, 20(a0)
 ; RV64IXQCCMP-FP-NEXT:    sd a1, 8(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    lw a1, 4(a0)
+; RV64IXQCCMP-FP-NEXT:    sd a1, 16(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    lw a1, 8(a0)
+; RV64IXQCCMP-FP-NEXT:    sd a1, 24(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    lw a1, 12(a0)
+; RV64IXQCCMP-FP-NEXT:    sd a1, 32(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    lw a1, 16(a0)
+; RV64IXQCCMP-FP-NEXT:    sd a1, 40(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    lw a1, 20(a0)
+; RV64IXQCCMP-FP-NEXT:    sd a1, 48(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-FP-NEXT:    lw a7, 24(a0)
 ; RV64IXQCCMP-FP-NEXT:    lw t0, 28(a0)
 ; RV64IXQCCMP-FP-NEXT:    lw t1, 32(a0)
@@ -2729,17 +2729,17 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV64IXQCCMP-FP-NEXT:    sw t1, 32(a0)
 ; RV64IXQCCMP-FP-NEXT:    sw t0, 28(a0)
 ; RV64IXQCCMP-FP-NEXT:    sw a7, 24(a0)
-; RV64IXQCCMP-FP-NEXT:    ld a1, 8(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    sw a1, 20(a0)
-; RV64IXQCCMP-FP-NEXT:    ld a1, 16(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    sw a1, 16(a0)
-; RV64IXQCCMP-FP-NEXT:    ld a1, 24(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    sw a1, 12(a0)
-; RV64IXQCCMP-FP-NEXT:    ld a1, 32(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    sw a1, 8(a0)
-; RV64IXQCCMP-FP-NEXT:    ld a1, 40(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    sw a1, 4(a0)
 ; RV64IXQCCMP-FP-NEXT:    ld a1, 48(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    sw a1, 20(a0)
+; RV64IXQCCMP-FP-NEXT:    ld a1, 40(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    sw a1, 16(a0)
+; RV64IXQCCMP-FP-NEXT:    ld a1, 32(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    sw a1, 12(a0)
+; RV64IXQCCMP-FP-NEXT:    ld a1, 24(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    sw a1, 8(a0)
+; RV64IXQCCMP-FP-NEXT:    ld a1, 16(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    sw a1, 4(a0)
+; RV64IXQCCMP-FP-NEXT:    ld a1, 8(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-FP-NEXT:    sw a1, 0(a0)
 ; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 288
 ; RV64IXQCCMP-FP-NEXT:    ld t0, 168(sp) # 8-byte Folded Reload
@@ -3355,17 +3355,17 @@ define void @callee_no_irq() {
 ; RV32IXQCCMP-FP-NEXT:    lui a0, %hi(var_test_irq)
 ; RV32IXQCCMP-FP-NEXT:    addi a0, a0, %lo(var_test_irq)
 ; RV32IXQCCMP-FP-NEXT:    lw a1, 0(a0)
-; RV32IXQCCMP-FP-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    lw a1, 4(a0)
-; RV32IXQCCMP-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    lw a1, 8(a0)
-; RV32IXQCCMP-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    lw a1, 12(a0)
-; RV32IXQCCMP-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    lw a1, 16(a0)
-; RV32IXQCCMP-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
-; RV32IXQCCMP-FP-NEXT:    lw a1, 20(a0)
 ; RV32IXQCCMP-FP-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    lw a1, 4(a0)
+; RV32IXQCCMP-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    lw a1, 8(a0)
+; RV32IXQCCMP-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    lw a1, 12(a0)
+; RV32IXQCCMP-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    lw a1, 16(a0)
+; RV32IXQCCMP-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    lw a1, 20(a0)
+; RV32IXQCCMP-FP-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-FP-NEXT:    lw a7, 24(a0)
 ; RV32IXQCCMP-FP-NEXT:    lw t0, 28(a0)
 ; RV32IXQCCMP-FP-NEXT:    lw t1, 32(a0)
@@ -3418,17 +3418,17 @@ define void @callee_no_irq() {
 ; RV32IXQCCMP-FP-NEXT:    sw t1, 32(a0)
 ; RV32IXQCCMP-FP-NEXT:    sw t0, 28(a0)
 ; RV32IXQCCMP-FP-NEXT:    sw a7, 24(a0)
-; RV32IXQCCMP-FP-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    sw a1, 20(a0)
-; RV32IXQCCMP-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    sw a1, 16(a0)
-; RV32IXQCCMP-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    sw a1, 12(a0)
-; RV32IXQCCMP-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    sw a1, 8(a0)
-; RV32IXQCCMP-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
-; RV32IXQCCMP-FP-NEXT:    sw a1, 4(a0)
 ; RV32IXQCCMP-FP-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    sw a1, 20(a0)
+; RV32IXQCCMP-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    sw a1, 16(a0)
+; RV32IXQCCMP-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    sw a1, 12(a0)
+; RV32IXQCCMP-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    sw a1, 8(a0)
+; RV32IXQCCMP-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    sw a1, 4(a0)
+; RV32IXQCCMP-FP-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-FP-NEXT:    sw a1, 0(a0)
 ; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 96
 ; RV32IXQCCMP-FP-NEXT:    qc.cm.popret {ra, s0-s11}, 96
@@ -3454,17 +3454,17 @@ define void @callee_no_irq() {
 ; RV64IXQCCMP-FP-NEXT:    lui a0, %hi(var_test_irq)
 ; RV64IXQCCMP-FP-NEXT:    addi a0, a0, %lo(var_test_irq)
 ; RV64IXQCCMP-FP-NEXT:    lw a1, 0(a0)
-; RV64IXQCCMP-FP-NEXT:    sd a1, 40(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    lw a1, 4(a0)
-; RV64IXQCCMP-FP-NEXT:    sd a1, 32(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    lw a1, 8(a0)
-; RV64IXQCCMP-FP-NEXT:    sd a1, 24(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    lw a1, 12(a0)
-; RV64IXQCCMP-FP-NEXT:    sd a1, 16(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    lw a1, 16(a0)
-; RV64IXQCCMP-FP-NEXT:    sd a1, 8(sp) # 8-byte Folded Spill
-; RV64IXQCCMP-FP-NEXT:    lw a1, 20(a0)
 ; RV64IXQCCMP-FP-NEXT:    sd a1, 0(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    lw a1, 4(a0)
+; RV64IXQCCMP-FP-NEXT:    sd a1, 8(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    lw a1, 8(a0)
+; RV64IXQCCMP-FP-NEXT:    sd a1, 16(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    lw a1, 12(a0)
+; RV64IXQCCMP-FP-NEXT:    sd a1, 24(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    lw a1, 16(a0)
+; RV64IXQCCMP-FP-NEXT:    sd a1, 32(sp) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    lw a1, 20(a0)
+; RV64IXQCCMP-FP-NEXT:    sd a1, 40(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-FP-NEXT:    lw a7, 24(a0)
 ; RV64IXQCCMP-FP-NEXT:    lw t0, 28(a0)
 ; RV64IXQCCMP-FP-NEXT:    lw t1, 32(a0)
@@ -3517,17 +3517,17 @@ define void @callee_no_irq() {
 ; RV64IXQCCMP-FP-NEXT:    sw t1, 32(a0)
 ; RV64IXQCCMP-FP-NEXT:    sw t0, 28(a0)
 ; RV64IXQCCMP-FP-NEXT:    sw a7, 24(a0)
-; RV64IXQCCMP-FP-NEXT:    ld a1, 0(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    sw a1, 20(a0)
-; RV64IXQCCMP-FP-NEXT:    ld a1, 8(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    sw a1, 16(a0)
-; RV64IXQCCMP-FP-NEXT:    ld a1, 16(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    sw a1, 12(a0)
-; RV64IXQCCMP-FP-NEXT:    ld a1, 24(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    sw a1, 8(a0)
-; RV64IXQCCMP-FP-NEXT:    ld a1, 32(sp) # 8-byte Folded Reload
-; RV64IXQCCMP-FP-NEXT:    sw a1, 4(a0)
 ; RV64IXQCCMP-FP-NEXT:    ld a1, 40(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    sw a1, 20(a0)
+; RV64IXQCCMP-FP-NEXT:    ld a1, 32(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    sw a1, 16(a0)
+; RV64IXQCCMP-FP-NEXT:    ld a1, 24(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    sw a1, 12(a0)
+; RV64IXQCCMP-FP-NEXT:    ld a1, 16(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    sw a1, 8(a0)
+; RV64IXQCCMP-FP-NEXT:    ld a1, 8(sp) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    sw a1, 4(a0)
+; RV64IXQCCMP-FP-NEXT:    ld a1, 0(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-FP-NEXT:    sw a1, 0(a0)
 ; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 160
 ; RV64IXQCCMP-FP-NEXT:    qc.cm.popret {ra, s0-s11}, 160

--- a/llvm/test/CodeGen/RISCV/xqcilo-xqcilia-frame-index.ll
+++ b/llvm/test/CodeGen/RISCV/xqcilo-xqcilia-frame-index.ll
@@ -82,8 +82,8 @@ define i32 @bare_fi_high_frame() nounwind {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    qc.e.addi sp, sp, -8208
 ; CHECK-NEXT:    c.li a0, 1
-; CHECK-NEXT:    c.swsp a0, 12(sp)
-; CHECK-NEXT:    qc.e.lw a0, 8204(sp)
+; CHECK-NEXT:    c.swsp a0, 16(sp)
+; CHECK-NEXT:    c.lwsp a0, 12(sp)
 ; CHECK-NEXT:    qc.e.addi sp, sp, 8208
 ; CHECK-NEXT:    c.jr ra
   %small = alloca i32
@@ -100,8 +100,8 @@ define void @bare_fi_high_frame_store(i32 %x) nounwind {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    qc.e.addi sp, sp, -8208
 ; CHECK-NEXT:    c.li a1, 1
-; CHECK-NEXT:    c.swsp a1, 12(sp)
-; CHECK-NEXT:    qc.e.sw a0, 8204(sp)
+; CHECK-NEXT:    c.swsp a1, 16(sp)
+; CHECK-NEXT:    c.swsp a0, 12(sp)
 ; CHECK-NEXT:    qc.e.addi sp, sp, 8208
 ; CHECK-NEXT:    c.jr ra
   %small = alloca i32

--- a/llvm/test/CodeGen/RISCV/zdinx-large-spill.mir
+++ b/llvm/test/CodeGen/RISCV/zdinx-large-spill.mir
@@ -12,32 +12,22 @@
   ; CHECK-NEXT:    addi sp, sp, -2048
   ; CHECK-NEXT:    addi sp, sp, -32
   ; CHECK-NEXT:    .cfi_def_cfa_offset 2080
-  ; CHECK-NEXT:    lui t0, 1
-  ; CHECK-NEXT:    add t0, sp, t0
-  ; CHECK-NEXT:    sw a0, -2024(t0) # 4-byte Folded Spill
-  ; CHECK-NEXT:    sw a1, -2020(t0) # 4-byte Folded Spill
-  ; CHECK-NEXT:    lui a0, 1
-  ; CHECK-NEXT:    add a0, sp, a0
-  ; CHECK-NEXT:    sw a2, -2032(a0) # 4-byte Folded Spill
-  ; CHECK-NEXT:    sw a3, -2028(a0) # 4-byte Folded Spill
-  ; CHECK-NEXT:    sw a4, -2040(a0) # 4-byte Folded Spill
-  ; CHECK-NEXT:    sw a5, -2036(a0) # 4-byte Folded Spill
-  ; CHECK-NEXT:    addi a0, sp, 2044
-  ; CHECK-NEXT:    sw a6, 0(a0) # 4-byte Folded Spill
-  ; CHECK-NEXT:    sw a7, 4(a0) # 4-byte Folded Spill
-  ; CHECK-NEXT:    lui a0, 1
-  ; CHECK-NEXT:    add a0, sp, a0
-  ; CHECK-NEXT:    lw a1, -2020(a0) # 4-byte Folded Reload
-  ; CHECK-NEXT:    lw a0, -2024(a0) # 4-byte Folded Reload
-  ; CHECK-NEXT:    lui a0, 1
-  ; CHECK-NEXT:    add a0, sp, a0
-  ; CHECK-NEXT:    lw a2, -2032(a0) # 4-byte Folded Reload
-  ; CHECK-NEXT:    lw a3, -2028(a0) # 4-byte Folded Reload
-  ; CHECK-NEXT:    lw a4, -2040(a0) # 4-byte Folded Reload
-  ; CHECK-NEXT:    lw a5, -2036(a0) # 4-byte Folded Reload
-  ; CHECK-NEXT:    addi a0, sp, 2044
-  ; CHECK-NEXT:    lw a6, 0(a0) # 4-byte Folded Reload
-  ; CHECK-NEXT:    lw a7, 4(a0) # 4-byte Folded Reload
+  ; CHECK-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
+  ; CHECK-NEXT:    sw a1, 44(sp) # 4-byte Folded Spill
+  ; CHECK-NEXT:    sw a2, 32(sp) # 4-byte Folded Spill
+  ; CHECK-NEXT:    sw a3, 36(sp) # 4-byte Folded Spill
+  ; CHECK-NEXT:    sw a4, 24(sp) # 4-byte Folded Spill
+  ; CHECK-NEXT:    sw a5, 28(sp) # 4-byte Folded Spill
+  ; CHECK-NEXT:    sw a6, 16(sp) # 4-byte Folded Spill
+  ; CHECK-NEXT:    sw a7, 20(sp) # 4-byte Folded Spill
+  ; CHECK-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
+  ; CHECK-NEXT:    lw a1, 44(sp) # 4-byte Folded Reload
+  ; CHECK-NEXT:    lw a2, 32(sp) # 4-byte Folded Reload
+  ; CHECK-NEXT:    lw a3, 36(sp) # 4-byte Folded Reload
+  ; CHECK-NEXT:    lw a4, 24(sp) # 4-byte Folded Reload
+  ; CHECK-NEXT:    lw a5, 28(sp) # 4-byte Folded Reload
+  ; CHECK-NEXT:    lw a6, 16(sp) # 4-byte Folded Reload
+  ; CHECK-NEXT:    lw a7, 20(sp) # 4-byte Folded Reload
   ; CHECK-NEXT:    addi sp, sp, 2032
   ; CHECK-NEXT:    addi sp, sp, 48
   ; CHECK-NEXT:    .cfi_def_cfa_offset 0

--- a/llvm/test/CodeGen/RISCV/zilsd-spill.ll
+++ b/llvm/test/CodeGen/RISCV/zilsd-spill.ll
@@ -74,17 +74,17 @@ define i64 @cmpxchg_i64_monotonic_monotonic(ptr %ptr, i64 %cmp, i64 %val) nounwi
   ; RV32I-ZILSD-NEXT:   frame-setup SD_RV32 killed $x26_x27, $x2, 24 :: (store (s64) into %stack.8)
   ; RV32I-ZILSD-NEXT:   renamable $x17 = COPY $x12
   ; RV32I-ZILSD-NEXT:   renamable $x16 = COPY $x11
-  ; RV32I-ZILSD-NEXT:   SD_RV32 killed renamable $x16_x17, $x2, 16 :: (store (s64) into %ir.1)
-  ; RV32I-ZILSD-NEXT:   $x11 = ADDI $x2, 16
+  ; RV32I-ZILSD-NEXT:   SD_RV32 killed renamable $x16_x17, $x2, 8 :: (store (s64) into %ir.1)
+  ; RV32I-ZILSD-NEXT:   $x11 = ADDI $x2, 8
   ; RV32I-ZILSD-NEXT:   $x12 = COPY killed renamable $x13
   ; RV32I-ZILSD-NEXT:   $x13 = COPY killed renamable $x14
   ; RV32I-ZILSD-NEXT:   $x14 = COPY $x0
   ; RV32I-ZILSD-NEXT:   $x15 = COPY $x0
   ; RV32I-ZILSD-NEXT:   PseudoCALL target-flags(riscv-call) @__atomic_compare_exchange_8, csr_ilp32_lp64, implicit-def dead $x1, implicit $x10, implicit $x11, implicit $x12, implicit $x13, implicit $x14, implicit $x15, implicit-def $x2, implicit-def dead $x10
-  ; RV32I-ZILSD-NEXT:   renamable $x10_x11 = LD_RV32 $x2, 16 :: (dereferenceable load (s64) from %ir.1)
-  ; RV32I-ZILSD-NEXT:   PseudoRV32ZdinxSD killed renamable $x10_x11, $x2, 8 :: (store (s64) into %stack.1, align 4)
+  ; RV32I-ZILSD-NEXT:   renamable $x10_x11 = LD_RV32 $x2, 8 :: (dereferenceable load (s64) from %ir.1)
+  ; RV32I-ZILSD-NEXT:   PseudoRV32ZdinxSD killed renamable $x10_x11, $x2, 16 :: (store (s64) into %stack.1, align 4)
   ; RV32I-ZILSD-NEXT:   INLINEASM &"", sideeffect attdialect, clobber, implicit-def dead early-clobber $x6, clobber, implicit-def dead early-clobber $x7, clobber, implicit-def dead early-clobber $x8, clobber, implicit-def dead early-clobber $x9, clobber, implicit-def dead early-clobber $x10, clobber, implicit-def dead early-clobber $x11, clobber, implicit-def dead early-clobber $x12, clobber, implicit-def dead early-clobber $x13, clobber, implicit-def dead early-clobber $x14, clobber, implicit-def dead early-clobber $x15, clobber, implicit-def dead early-clobber $x16, clobber, implicit-def dead early-clobber $x17, clobber, implicit-def dead early-clobber $x18, clobber, implicit-def dead early-clobber $x19, clobber, implicit-def dead early-clobber $x20, clobber, implicit-def dead early-clobber $x21, clobber, implicit-def dead early-clobber $x22, clobber, implicit-def dead early-clobber $x23, clobber, implicit-def dead early-clobber $x24, clobber, implicit-def dead early-clobber $x25, clobber, implicit-def dead early-clobber $x26, clobber, implicit-def dead early-clobber $x27, clobber, implicit-def dead early-clobber $x28, clobber, implicit-def dead early-clobber $x29, clobber, implicit-def dead early-clobber $x31
-  ; RV32I-ZILSD-NEXT:   renamable $x12_x13 = PseudoRV32ZdinxLD $x2, 8 :: (load (s64) from %stack.1, align 4)
+  ; RV32I-ZILSD-NEXT:   renamable $x12_x13 = PseudoRV32ZdinxLD $x2, 16 :: (load (s64) from %stack.1, align 4)
   ; RV32I-ZILSD-NEXT:   renamable $x10 = ADD renamable $x12, renamable $x12
   ; RV32I-ZILSD-NEXT:   renamable $x11 = SLTU renamable $x10, renamable $x12
   ; RV32I-ZILSD-NEXT:   renamable $x12 = ADD killed renamable $x13, renamable $x13
@@ -113,17 +113,17 @@ define i64 @cmpxchg_i64_monotonic_monotonic(ptr %ptr, i64 %cmp, i64 %val) nounwi
   ; RV32I-ZILSD-UNALIGNED-NEXT:   frame-setup SD_RV32 killed $x26_x27, $x2, 28 :: (store (s64) into %stack.8, align 1)
   ; RV32I-ZILSD-UNALIGNED-NEXT:   renamable $x17 = COPY $x12
   ; RV32I-ZILSD-UNALIGNED-NEXT:   renamable $x16 = COPY $x11
-  ; RV32I-ZILSD-UNALIGNED-NEXT:   SD_RV32 killed renamable $x16_x17, $x2, 16 :: (store (s64) into %ir.1)
-  ; RV32I-ZILSD-UNALIGNED-NEXT:   $x11 = ADDI $x2, 16
+  ; RV32I-ZILSD-UNALIGNED-NEXT:   SD_RV32 killed renamable $x16_x17, $x2, 8 :: (store (s64) into %ir.1)
+  ; RV32I-ZILSD-UNALIGNED-NEXT:   $x11 = ADDI $x2, 8
   ; RV32I-ZILSD-UNALIGNED-NEXT:   $x12 = COPY killed renamable $x13
   ; RV32I-ZILSD-UNALIGNED-NEXT:   $x13 = COPY killed renamable $x14
   ; RV32I-ZILSD-UNALIGNED-NEXT:   $x14 = COPY $x0
   ; RV32I-ZILSD-UNALIGNED-NEXT:   $x15 = COPY $x0
   ; RV32I-ZILSD-UNALIGNED-NEXT:   PseudoCALL target-flags(riscv-call) @__atomic_compare_exchange_8, csr_ilp32_lp64, implicit-def dead $x1, implicit $x10, implicit $x11, implicit $x12, implicit $x13, implicit $x14, implicit $x15, implicit-def $x2, implicit-def dead $x10
-  ; RV32I-ZILSD-UNALIGNED-NEXT:   renamable $x10_x11 = LD_RV32 $x2, 16 :: (dereferenceable load (s64) from %ir.1)
-  ; RV32I-ZILSD-UNALIGNED-NEXT:   SD_RV32 killed renamable $x10_x11, $x2, 8 :: (store (s64) into %stack.1, align 4)
+  ; RV32I-ZILSD-UNALIGNED-NEXT:   renamable $x10_x11 = LD_RV32 $x2, 8 :: (dereferenceable load (s64) from %ir.1)
+  ; RV32I-ZILSD-UNALIGNED-NEXT:   SD_RV32 killed renamable $x10_x11, $x2, 20 :: (store (s64) into %stack.1, align 4)
   ; RV32I-ZILSD-UNALIGNED-NEXT:   INLINEASM &"", sideeffect attdialect, clobber, implicit-def dead early-clobber $x6, clobber, implicit-def dead early-clobber $x7, clobber, implicit-def dead early-clobber $x8, clobber, implicit-def dead early-clobber $x9, clobber, implicit-def dead early-clobber $x10, clobber, implicit-def dead early-clobber $x11, clobber, implicit-def dead early-clobber $x12, clobber, implicit-def dead early-clobber $x13, clobber, implicit-def dead early-clobber $x14, clobber, implicit-def dead early-clobber $x15, clobber, implicit-def dead early-clobber $x16, clobber, implicit-def dead early-clobber $x17, clobber, implicit-def dead early-clobber $x18, clobber, implicit-def dead early-clobber $x19, clobber, implicit-def dead early-clobber $x20, clobber, implicit-def dead early-clobber $x21, clobber, implicit-def dead early-clobber $x22, clobber, implicit-def dead early-clobber $x23, clobber, implicit-def dead early-clobber $x24, clobber, implicit-def dead early-clobber $x25, clobber, implicit-def dead early-clobber $x26, clobber, implicit-def dead early-clobber $x27, clobber, implicit-def dead early-clobber $x28, clobber, implicit-def dead early-clobber $x29, clobber, implicit-def dead early-clobber $x31
-  ; RV32I-ZILSD-UNALIGNED-NEXT:   renamable $x12_x13 = LD_RV32 $x2, 8 :: (load (s64) from %stack.1, align 4)
+  ; RV32I-ZILSD-UNALIGNED-NEXT:   renamable $x12_x13 = LD_RV32 $x2, 20 :: (load (s64) from %stack.1, align 4)
   ; RV32I-ZILSD-UNALIGNED-NEXT:   renamable $x10 = ADD renamable $x12, renamable $x12
   ; RV32I-ZILSD-UNALIGNED-NEXT:   renamable $x11 = SLTU renamable $x10, renamable $x12
   ; RV32I-ZILSD-UNALIGNED-NEXT:   renamable $x12 = ADD killed renamable $x13, renamable $x13
@@ -152,17 +152,17 @@ define i64 @cmpxchg_i64_monotonic_monotonic(ptr %ptr, i64 %cmp, i64 %val) nounwi
   ; RV32I-ZILSD-4BYTEALIGN-NEXT:   frame-setup SD_RV32 killed $x26_x27, $x2, 28 :: (store (s64) into %stack.8, align 4)
   ; RV32I-ZILSD-4BYTEALIGN-NEXT:   renamable $x17 = COPY $x12
   ; RV32I-ZILSD-4BYTEALIGN-NEXT:   renamable $x16 = COPY $x11
-  ; RV32I-ZILSD-4BYTEALIGN-NEXT:   SD_RV32 killed renamable $x16_x17, $x2, 16 :: (store (s64) into %ir.1)
-  ; RV32I-ZILSD-4BYTEALIGN-NEXT:   $x11 = ADDI $x2, 16
+  ; RV32I-ZILSD-4BYTEALIGN-NEXT:   SD_RV32 killed renamable $x16_x17, $x2, 8 :: (store (s64) into %ir.1)
+  ; RV32I-ZILSD-4BYTEALIGN-NEXT:   $x11 = ADDI $x2, 8
   ; RV32I-ZILSD-4BYTEALIGN-NEXT:   $x12 = COPY killed renamable $x13
   ; RV32I-ZILSD-4BYTEALIGN-NEXT:   $x13 = COPY killed renamable $x14
   ; RV32I-ZILSD-4BYTEALIGN-NEXT:   $x14 = COPY $x0
   ; RV32I-ZILSD-4BYTEALIGN-NEXT:   $x15 = COPY $x0
   ; RV32I-ZILSD-4BYTEALIGN-NEXT:   PseudoCALL target-flags(riscv-call) @__atomic_compare_exchange_8, csr_ilp32_lp64, implicit-def dead $x1, implicit $x10, implicit $x11, implicit $x12, implicit $x13, implicit $x14, implicit $x15, implicit-def $x2, implicit-def dead $x10
-  ; RV32I-ZILSD-4BYTEALIGN-NEXT:   renamable $x10_x11 = LD_RV32 $x2, 16 :: (dereferenceable load (s64) from %ir.1)
-  ; RV32I-ZILSD-4BYTEALIGN-NEXT:   SD_RV32 killed renamable $x10_x11, $x2, 8 :: (store (s64) into %stack.1, align 4)
+  ; RV32I-ZILSD-4BYTEALIGN-NEXT:   renamable $x10_x11 = LD_RV32 $x2, 8 :: (dereferenceable load (s64) from %ir.1)
+  ; RV32I-ZILSD-4BYTEALIGN-NEXT:   SD_RV32 killed renamable $x10_x11, $x2, 20 :: (store (s64) into %stack.1, align 4)
   ; RV32I-ZILSD-4BYTEALIGN-NEXT:   INLINEASM &"", sideeffect attdialect, clobber, implicit-def dead early-clobber $x6, clobber, implicit-def dead early-clobber $x7, clobber, implicit-def dead early-clobber $x8, clobber, implicit-def dead early-clobber $x9, clobber, implicit-def dead early-clobber $x10, clobber, implicit-def dead early-clobber $x11, clobber, implicit-def dead early-clobber $x12, clobber, implicit-def dead early-clobber $x13, clobber, implicit-def dead early-clobber $x14, clobber, implicit-def dead early-clobber $x15, clobber, implicit-def dead early-clobber $x16, clobber, implicit-def dead early-clobber $x17, clobber, implicit-def dead early-clobber $x18, clobber, implicit-def dead early-clobber $x19, clobber, implicit-def dead early-clobber $x20, clobber, implicit-def dead early-clobber $x21, clobber, implicit-def dead early-clobber $x22, clobber, implicit-def dead early-clobber $x23, clobber, implicit-def dead early-clobber $x24, clobber, implicit-def dead early-clobber $x25, clobber, implicit-def dead early-clobber $x26, clobber, implicit-def dead early-clobber $x27, clobber, implicit-def dead early-clobber $x28, clobber, implicit-def dead early-clobber $x29, clobber, implicit-def dead early-clobber $x31
-  ; RV32I-ZILSD-4BYTEALIGN-NEXT:   renamable $x12_x13 = LD_RV32 $x2, 8 :: (load (s64) from %stack.1, align 4)
+  ; RV32I-ZILSD-4BYTEALIGN-NEXT:   renamable $x12_x13 = LD_RV32 $x2, 20 :: (load (s64) from %stack.1, align 4)
   ; RV32I-ZILSD-4BYTEALIGN-NEXT:   renamable $x10 = ADD renamable $x12, renamable $x12
   ; RV32I-ZILSD-4BYTEALIGN-NEXT:   renamable $x11 = SLTU renamable $x10, renamable $x12
   ; RV32I-ZILSD-4BYTEALIGN-NEXT:   renamable $x12 = ADD killed renamable $x13, renamable $x13


### PR DESCRIPTION
## Problem

RISC-V scalar load/store instructions use a signed 12-bit base offset, so stack accesses can be encoded directly only within the range `[-2048, 2047]`. For frame offsets outside this range, additional instructions such as `LUI + ADD` are required to materialize the stack address, increasing the cost of stack accesses.

The RISC-V backend currently does not override `TargetFrameLowering::orderFrameObjects()`. As a result, ordinary local stack objects passed to this hook retain their original allocation order, which is unrelated to how frequently they are accessed. This can place frequently accessed spill slots far from the effective stack base, while colder or larger objects occupy the limited small-offset region that can be addressed directly.

## Solution

Override `RISCVFrameLowering::orderFrameObjects()` to order local stack objects by access density (`NumUses / ObjectSize`). Frequently accessed, smaller objects are placed closer to the effective stack base so that more hot accesses fit within the 12-bit stack offset range. The heuristic follows the existing X86 stack object ordering strategy.

Assisted by LLM. All changes were manually verified.

## Key changes

- `llvm/lib/Target/RISCV/RISCVFrameLowering.h`
  Declare the `orderFrameObjects()` override for RISC-V.
- `llvm/lib/Target/RISCV/RISCVFrameLowering.cpp`
  Implement access-density-based ordering for local stack objects, including FP-relative layout handling.
- `llvm/test/CodeGen/RISCV/stack-symbol-ordering.mir`
  Add focused coverage for both SP-relative and FP-relative stack layouts.
- Existing RISC-V CodeGen tests
  Update affected `CHECK` expectations where local stack object offsets change due to the new ordering.

## Performance

SPEC CPU2026 `709.cactus_r` on SpaceMiT K3: **+15%**
