### PR TITLE
[ORC] Move simple lookupAndRecordAddrs uses to lookupAndApply

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/COFFPlatform.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/COFFPlatform.cpp
@@ -683,22 +683,19 @@ Error COFFPlatform::runBootstrapSubsectionInitializers(JDBootstrapState &BState,
 Error COFFPlatform::bootstrapCOFFRuntime(JITDylib &PlatformJD) {
   // Lookup of runtime symbols causes the collection of initializers if
   // it's static linking setting.
-  if (auto Err = lookupAndRecordAddrs(
-          ES, LookupKind::Static, makeJITDylibSearchOrder(&PlatformJD),
-          {
-              {ES.intern("__orc_rt_coff_platform_bootstrap"),
-               &orc_rt_coff_platform_bootstrap},
-              {ES.intern("__orc_rt_coff_platform_shutdown"),
-               &orc_rt_coff_platform_shutdown},
-              {ES.intern("__orc_rt_coff_register_jitdylib"),
-               &orc_rt_coff_register_jitdylib},
-              {ES.intern("__orc_rt_coff_deregister_jitdylib"),
-               &orc_rt_coff_deregister_jitdylib},
-              {ES.intern("__orc_rt_coff_register_object_sections"),
-               &orc_rt_coff_register_object_sections},
-              {ES.intern("__orc_rt_coff_deregister_object_sections"),
-               &orc_rt_coff_deregister_object_sections},
-          }))
+  if (auto Err = lookupAndApply(
+          PlatformJD, {recordAddr("__orc_rt_coff_platform_bootstrap",
+                                  &orc_rt_coff_platform_bootstrap),
+                       recordAddr("__orc_rt_coff_platform_shutdown",
+                                  &orc_rt_coff_platform_shutdown),
+                       recordAddr("__orc_rt_coff_register_jitdylib",
+                                  &orc_rt_coff_register_jitdylib),
+                       recordAddr("__orc_rt_coff_deregister_jitdylib",
+                                  &orc_rt_coff_deregister_jitdylib),
+                       recordAddr("__orc_rt_coff_register_object_sections",
+                                  &orc_rt_coff_register_object_sections),
+                       recordAddr("__orc_rt_coff_deregister_object_sections",
+                                  &orc_rt_coff_deregister_object_sections)}))
     return Err;
 
   // Call bootstrap functions

--- a/llvm/lib/ExecutionEngine/Orc/COFFVCRuntimeSupport.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/COFFVCRuntimeSupport.cpp
@@ -12,7 +12,6 @@
 #include "llvm/ExecutionEngine/Orc/CallProxiesSPS.h"
 #include "llvm/ExecutionEngine/Orc/ExecutionUtils.h"
 #include "llvm/ExecutionEngine/Orc/LookupAndApply.h"
-#include "llvm/ExecutionEngine/Orc/LookupAndRecordAddrs.h"
 #include "llvm/ExecutionEngine/Orc/RecordProxy.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/WindowsDriver/MSVCPaths.h"
@@ -115,15 +114,14 @@ Error COFFVCRuntimeBootstrapper::initializeStaticVCRuntime(JITDylib &JD) {
   ExecutorAddr jit_scrt_initialize, jit_scrt_dllmain_before_initialize_c,
       jit_scrt_initialize_type_info,
       jit_scrt_initialize_default_local_stdio_options;
-  if (auto Err = lookupAndRecordAddrs(
-          ES, LookupKind::Static, makeJITDylibSearchOrder(&JD),
-          {{ES.intern("__scrt_initialize_crt"), &jit_scrt_initialize},
-           {ES.intern("__scrt_dllmain_before_initialize_c"),
-            &jit_scrt_dllmain_before_initialize_c},
-           {ES.intern("?__scrt_initialize_type_info@@YAXXZ"),
-            &jit_scrt_initialize_type_info},
-           {ES.intern("__scrt_initialize_default_local_stdio_options"),
-            &jit_scrt_initialize_default_local_stdio_options}}))
+  if (auto Err = lookupAndApply(
+          JD, {recordAddr("__scrt_initialize_crt", &jit_scrt_initialize),
+               recordAddr("__scrt_dllmain_before_initialize_c",
+                          &jit_scrt_dllmain_before_initialize_c),
+               recordAddr("?__scrt_initialize_type_info@@YAXXZ",
+                          &jit_scrt_initialize_type_info),
+               recordAddr("__scrt_initialize_default_local_stdio_options",
+                          &jit_scrt_initialize_default_local_stdio_options)}))
     return Err;
 
   CallInt32VoidProxy CallInt32Void;

--- a/llvm/lib/ExecutionEngine/Orc/Debugging/PerfSupportPlugin.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Debugging/PerfSupportPlugin.cpp
@@ -13,7 +13,7 @@
 #include "llvm/ExecutionEngine/Orc/Debugging/PerfSupportPlugin.h"
 
 #include "llvm/ExecutionEngine/Orc/Debugging/DebugInfoSupport.h"
-#include "llvm/ExecutionEngine/Orc/LookupAndRecordAddrs.h"
+#include "llvm/ExecutionEngine/Orc/LookupAndApply.h"
 #include "llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h"
 
 #define DEBUG_TYPE "orc"
@@ -289,13 +289,11 @@ PerfSupportPlugin::Create(ExecutorProcessControl &EPC, JITDylib &JD,
         "Perf support only available for ELF LinkGraphs!",
         inconvertibleErrorCode());
   }
-  auto &ES = EPC.getExecutionSession();
   ExecutorAddr StartAddr, EndAddr, ImplAddr;
-  if (auto Err = lookupAndRecordAddrs(
-          ES, LookupKind::Static, makeJITDylibSearchOrder({&JD}),
-          {{ES.intern(RegisterPerfStartSymbolName), &StartAddr},
-           {ES.intern(RegisterPerfEndSymbolName), &EndAddr},
-           {ES.intern(RegisterPerfImplSymbolName), &ImplAddr}}))
+  if (auto Err = lookupAndApply(
+          JD, {recordAddr(RegisterPerfStartSymbolName, &StartAddr),
+               recordAddr(RegisterPerfEndSymbolName, &EndAddr),
+               recordAddr(RegisterPerfImplSymbolName, &ImplAddr)}))
     return std::move(Err);
   return std::make_unique<PerfSupportPlugin>(EPC, StartAddr, EndAddr, ImplAddr,
                                              EmitDebugInfo, EmitUnwindInfo);

--- a/llvm/lib/ExecutionEngine/Orc/ReOptimizeLayer.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/ReOptimizeLayer.cpp
@@ -1,5 +1,5 @@
 #include "llvm/ExecutionEngine/Orc/ReOptimizeLayer.h"
-#include "llvm/ExecutionEngine/Orc/LookupAndRecordAddrs.h"
+#include "llvm/ExecutionEngine/Orc/LookupAndApply.h"
 #include "llvm/ExecutionEngine/Orc/Mangling.h"
 #include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 
@@ -96,11 +96,10 @@ Error ReOptimizeLayer::addOrcRTLiteSupport(JITDylib &PlatformJD,
   Builder.SetInsertPoint(Entry);
 
   ExecutorAddr JITDispatchSym, JITDispatchCtxSym;
-  if (auto Err = lookupAndRecordAddrs(
-          ES, LookupKind::Static,
-          makeJITDylibSearchOrder(&ES.getBootstrapJITDylib()),
-          {{ES.intern(rt::DispatchName), &JITDispatchSym},
-           {ES.intern(rt::DispatchCtxName), &JITDispatchCtxSym}}))
+  if (auto Err =
+          lookupAndApply(ES.getBootstrapJITDylib(),
+                         {recordAddr(rt::DispatchName, &JITDispatchSym),
+                          recordAddr(rt::DispatchCtxName, &JITDispatchCtxSym)}))
     return Err;
 
   Type *IntPtrTy = DL.getIntPtrType(*Ctx);


### PR DESCRIPTION
Mechanical conversions in ReOptimizeLayer, PerfSupportPlugin, COFFVCRuntimeSupport and COFFPlatform::bootstrapCOFFRuntime: each (name, ExecutorAddr *) pair becomes a recordAddr.

NFCI.