### PR TITLE
[mlir][Ptr] Don't assert when the default memory space isn't a MemorySpaceAttrInterface

### DIFF
--- a/mlir/lib/Dialect/Ptr/IR/PtrTypes.cpp
+++ b/mlir/lib/Dialect/Ptr/IR/PtrTypes.cpp
@@ -94,7 +94,7 @@ bool PtrType::areCompatible(DataLayoutEntryListRef oldLayout,
 
 uint64_t PtrType::getABIAlignment(const DataLayout &dataLayout,
                                   DataLayoutEntryListRef params) const {
-  auto defaultMemorySpace = llvm::cast_if_present<MemorySpaceAttrInterface>(
+  auto defaultMemorySpace = llvm::dyn_cast_if_present<MemorySpaceAttrInterface>(
       dataLayout.getDefaultMemorySpace());
   if (SpecAttr spec = getPointerSpec(params, *this, defaultMemorySpace))
     return spec.getAbi() / kBitsInByte;
@@ -105,7 +105,7 @@ uint64_t PtrType::getABIAlignment(const DataLayout &dataLayout,
 std::optional<uint64_t>
 PtrType::getIndexBitwidth(const DataLayout &dataLayout,
                           DataLayoutEntryListRef params) const {
-  auto defaultMemorySpace = llvm::cast_if_present<MemorySpaceAttrInterface>(
+  auto defaultMemorySpace = llvm::dyn_cast_if_present<MemorySpaceAttrInterface>(
       dataLayout.getDefaultMemorySpace());
   if (SpecAttr spec = getPointerSpec(params, *this, defaultMemorySpace)) {
     return spec.getIndex() == SpecAttr::kOptionalSpecValue ? spec.getSize()
@@ -117,7 +117,7 @@ PtrType::getIndexBitwidth(const DataLayout &dataLayout,
 
 llvm::TypeSize PtrType::getTypeSizeInBits(const DataLayout &dataLayout,
                                           DataLayoutEntryListRef params) const {
-  auto defaultMemorySpace = llvm::cast_if_present<MemorySpaceAttrInterface>(
+  auto defaultMemorySpace = llvm::dyn_cast_if_present<MemorySpaceAttrInterface>(
       dataLayout.getDefaultMemorySpace());
   if (SpecAttr spec = getPointerSpec(params, *this, defaultMemorySpace))
     return llvm::TypeSize::getFixed(spec.getSize());
@@ -129,7 +129,7 @@ llvm::TypeSize PtrType::getTypeSizeInBits(const DataLayout &dataLayout,
 
 uint64_t PtrType::getPreferredAlignment(const DataLayout &dataLayout,
                                         DataLayoutEntryListRef params) const {
-  auto defaultMemorySpace = llvm::cast_if_present<MemorySpaceAttrInterface>(
+  auto defaultMemorySpace = llvm::dyn_cast_if_present<MemorySpaceAttrInterface>(
       dataLayout.getDefaultMemorySpace());
   if (SpecAttr spec = getPointerSpec(params, *this, defaultMemorySpace))
     return spec.getPreferred() / kBitsInByte;

--- a/mlir/test/Dialect/Ptr/layout.mlir
+++ b/mlir/test/Dialect/Ptr/layout.mlir
@@ -151,11 +151,8 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<
 // -----
 
 // Regression test for https://github.com/llvm/llvm-project/issues/217170:
-// the default memory space in the data layout does not have to implement
-// `MemorySpaceAttrInterface` (e.g. it may be a plain integer attribute).
-// Querying a pointer type whose memory space differs from that default
-// memory space used to crash instead of falling back to the default
-// pointer spec.
+// querying the ptr layout caused a crash when the default memory space was not
+// a `MemorySpaceAttrInterface` (e.g. a plain `i32` attr).
 module attributes { dlti.dl_spec = #dlti.dl_spec<"dlti.default_memory_space" = 7 : ui64>} {
   // CHECK-LABEL: @non_memory_space_default
   func.func @non_memory_space_default() {

--- a/mlir/test/Dialect/Ptr/layout.mlir
+++ b/mlir/test/Dialect/Ptr/layout.mlir
@@ -147,3 +147,25 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<
     return
   }
 }
+
+// -----
+
+// Regression test for https://github.com/llvm/llvm-project/issues/217170:
+// the default memory space in the data layout does not have to implement
+// `MemorySpaceAttrInterface` (e.g. it may be a plain integer attribute).
+// Querying a pointer type whose memory space differs from that default
+// memory space used to crash instead of falling back to the default
+// pointer spec.
+module attributes { dlti.dl_spec = #dlti.dl_spec<"dlti.default_memory_space" = 7 : ui64>} {
+  // CHECK-LABEL: @non_memory_space_default
+  func.func @non_memory_space_default() {
+    // CHECK: alignment = 1
+    // CHECK: bitsize = 64
+    // CHECK: default_memory_space = 7 : ui64
+    // CHECK: index = 64
+    // CHECK: preferred = 1
+    // CHECK: size = 8
+    "test.data_layout_query"() : () -> !ptr.ptr<#test.const_memory_space<4>>
+    return
+  }
+}


### PR DESCRIPTION
`PtrType`'s `DataLayoutTypeInterface`/`DataLayoutInterface` methods
used `cast_if_present<MemorySpaceAttrInterface>` on the data layout's
default memory space attribute, which asserts if that attribute is
non-null but does not implement `MemorySpaceAttrInterface` (e.g. a
plain `IntegerAttr` set via `dlti.default_memory_space`). The callers
already handle a null `MemorySpaceAttrInterface` gracefully by
falling back to the generic default pointer layout, so this switches
to `dyn_cast_if_present` to take that path instead of asserting.

Verified: reverting this fix reproduces the reported crash; with the
fix, `mlir-opt --test-data-layout-query` on the reported reproducer
succeeds, and `mlir/test/Dialect/Ptr/layout.mlir` passes.

Fixes #217170

🤖 Generated with [Claude Code](https://claude.com/claude-code)