### PR TITLE
[GISel] Fix link error when dylib is enabled

### DIFF
--- a/llvm/unittests/CodeGen/GlobalISel/CMakeLists.txt
+++ b/llvm/unittests/CodeGen/GlobalISel/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(LLVM_LINK_COMPONENTS
   ${LLVM_TARGETS_TO_BUILD}
+  Analysis
   AsmParser
   CodeGen
   CodeGenTypes

--- a/llvm/utils/gn/secondary/llvm/unittests/CodeGen/GlobalISel/BUILD.gn
+++ b/llvm/utils/gn/secondary/llvm/unittests/CodeGen/GlobalISel/BUILD.gn
@@ -2,6 +2,7 @@ import("//third-party/unittest/unittest.gni")
 
 unittest("GlobalISelTests") {
   deps = [
+    "//llvm/lib/Analysis",
     "//llvm/lib/CodeGen",
     "//llvm/lib/CodeGen/GlobalISel",
     "//llvm/lib/CodeGen/MIRParser",


### PR DESCRIPTION
This is to fix link error caused by e21cfc08414e.
