### PR TITLE
[ADT] Fix and clarify FoldingSet::reserve

### DIFF
--- a/llvm/include/llvm/ADT/FoldingSet.h
+++ b/llvm/include/llvm/ADT/FoldingSet.h
@@ -377,9 +377,8 @@ protected:
   // The below methods are protected to encourage subclasses to provide a more
   // type-safe API.
 
-  /// Increase the number of buckets such that adding the \p EltCount th node
-  /// won't cause a rebucket operation. reserve is permitted to allocate more
-  /// space than requested by EltCount.
+  /// Grow the number of buckets so that we can hold at least \p EltCount
+  /// nodes before rebucketing. May allocate more space than requested.
   LLVM_ABI void reserve(unsigned EltCount, const FoldingSetInfo &Info);
 
   /// Remove a node from the folding set, returning true if one
@@ -505,9 +504,8 @@ public:
   const_iterator begin() const { return const_iterator(Buckets); }
   const_iterator end() const { return const_iterator(Buckets + NumBuckets); }
 
-  /// Increase the number of buckets such that adding the \p EltCount th node
-  /// won't cause a rebucket operation. reserve is permitted to allocate more
-  /// space than requested by EltCount.
+  /// Grow the number of buckets so that we can hold at least \p EltCount
+  /// nodes before rebucketing. May allocate more space than requested.
   void reserve(unsigned EltCount) {
     FoldingSetBase::reserve(EltCount, getFoldingSetInfo());
   }

--- a/llvm/lib/Support/FoldingSet.cpp
+++ b/llvm/lib/Support/FoldingSet.cpp
@@ -248,7 +248,7 @@ void FoldingSetBase::reserve(unsigned EltCount, const FoldingSetInfo &Info) {
   // This will give us somewhere between EltCount / 2 and
   // EltCount buckets.  This puts us in the load factor
   // range of 1.0 - 2.0.
-  if (EltCount < capacity())
+  if (EltCount <= capacity())
     return;
   GrowBucketCount(llvm::bit_floor(EltCount), Info);
 }

--- a/llvm/unittests/ADT/FoldingSet.cpp
+++ b/llvm/unittests/ADT/FoldingSet.cpp
@@ -185,15 +185,22 @@ TEST(FoldingSetTest, ClearOnNonEmpty) {
 
 TEST(FoldingSetTest, CapacityLargerThanReserve) {
   FoldingSet<TrivialPair> Trivial;
-  auto OldCapacity = Trivial.capacity();
+  unsigned OldCapacity = Trivial.capacity();
   Trivial.reserve(OldCapacity + 1);
   EXPECT_GE(Trivial.capacity(), OldCapacity + 1);
 }
 
 TEST(FoldingSetTest, SmallReserveChangesNothing) {
   FoldingSet<TrivialPair> Trivial;
-  auto OldCapacity = Trivial.capacity();
+  unsigned OldCapacity = Trivial.capacity();
   Trivial.reserve(OldCapacity - 1);
+  EXPECT_EQ(Trivial.capacity(), OldCapacity);
+}
+
+TEST(FoldingSetTest, ReserveExactCapacity) {
+  FoldingSet<TrivialPair> Trivial;
+  unsigned OldCapacity = Trivial.capacity();
+  Trivial.reserve(OldCapacity);
   EXPECT_EQ(Trivial.capacity(), OldCapacity);
 }
 


### PR DESCRIPTION
This patch fixes an off-by-one comparison in FoldingSetBase::reserve.
Without this patch, calling reserve(capacity()) allocates more buckets
even though the table can already hold capacity() nodes without
rebucketing. Changing '<' to '<=' correctly treats requests up to the
existing capacity as a no-op.

In addition, this patch clarifies the comments for reserve() by
replacing the awkward ordinal with a simple element count.

Assisted-by: Antigravity
