### PR TITLE
[ADT] Remove default argument from FoldingSetBase constructor (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/FoldingSet.h
+++ b/llvm/include/llvm/ADT/FoldingSet.h
@@ -307,7 +307,7 @@ protected:
   /// is greater than twice the number of buckets.
   unsigned NumNodes;
 
-  LLVM_ABI explicit FoldingSetBase(unsigned Log2InitSize = 6);
+  LLVM_ABI explicit FoldingSetBase(unsigned Log2InitSize);
   LLVM_ABI FoldingSetBase(FoldingSetBase &&Arg);
   LLVM_ABI FoldingSetBase &operator=(FoldingSetBase &&RHS);
   LLVM_ABI ~FoldingSetBase();


### PR DESCRIPTION
FoldingSetBase is never default-constructed directly; its subclasses and
helpers always pass Log2InitSize explicitly.

Assisted-by: Antigravity
