### PR TITLE
[clang][bytecode] Fix crash when dynamic_cast'ing a root pointer

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -2246,15 +2246,16 @@ bool DynamicCast(InterpState &S, CodePtr OpPC, const Type *DestTypePtr,
     if (R.valid()) {
       Result = Iter.atField(*R.Offset);
       break;
-    } else if (R.Ambiguous) {
+    }
+    if (R.Ambiguous) {
       Ambiguous = true;
       break;
     }
 
-    // This moves us DOWN the type hierarchy.
-    Iter = Iter.getBase();
     if (Iter.isRoot() || !Iter.isBaseClass())
       break;
+    // This moves us DOWN the type hierarchy.
+    Iter = Iter.getBase();
   }
 
   if (Ambiguous)

--- a/clang/test/AST/ByteCode/dynamic-cast.cpp
+++ b/clang/test/AST/ByteCode/dynamic-cast.cpp
@@ -352,3 +352,18 @@ namespace VirtualBase {
   }
   static_assert(test());
 }
+
+namespace RootPtr {
+  struct S {
+    constexpr virtual int foo() { return 0; }
+  };
+
+  struct T {};
+
+  struct U : virtual T {
+    constexpr S *bar() const { return (S *)this; } // both-note {{cast that performs the conversions of a reinterpret_cast is not allowed in a constant expression}}
+  };
+  constexpr U u;
+  static_assert(dynamic_cast<T *>(u.bar())); // both-error {{not an integral constant expression}} \
+                                             // both-note {{in call to}}
+}


### PR DESCRIPTION
We can't call getBase(), so move the isRoot() check before.