### PR TITLE
[mlir:linalg:py] Undo unintentional type narrowing from #214539.

### DIFF
--- a/mlir/python/mlir/dialects/transform/structured.py
+++ b/mlir/python/mlir/dialects/transform/structured.py
@@ -549,8 +549,8 @@ class TileUsingForOp(TileUsingForOp):
         loop_types: Union[Type, List[Type]],
         target: Union[Operation, Value],
         *,
-        sizes: MixedValues = None,
-        interchange: MixedValues = None,
+        sizes: MixedValues | DynamicIndexList | None = None,
+        interchange: MixedValues | None = None,
         loc=None,
         ip=None,
     ):
@@ -561,8 +561,8 @@ class TileUsingForOp(TileUsingForOp):
         self,
         target: Union[Operation, Value, OpView],
         *,
-        sizes: MixedValues = None,
-        interchange: MixedValues = None,
+        sizes: MixedValues | DynamicIndexList | None = None,
+        interchange: MixedValues | None = None,
         loc=None,
         ip=None,
     ):
@@ -573,8 +573,8 @@ class TileUsingForOp(TileUsingForOp):
         loop_types_or_target: Union[Type, List[Type], Operation, Value],
         target_or_none: Optional[Union[Operation, Value, OpView]] = None,
         *,
-        sizes: MixedValues = None,
-        interchange: MixedValues = None,
+        sizes: MixedValues | DynamicIndexList | None = None,
+        interchange: MixedValues | None = None,
         loc=None,
         ip=None,
     ):


### PR DESCRIPTION
This PR undoes the (presumably) unintenional type narrowing in the Python overloads of the `TileUsingForOp` transform op introduced in #214539. Previously, the overloads accepted `DynamicIndexList` as well
as `None` which the constructors they forward to still accept. The new type signature, however, did not allow them anymore (even though it used `= None` as default value). The PR, thus, simple adds back the two types.