### PR TITLE
[AArch64] Add tests for trunc nsw smin combine. NFC

### DIFF
--- a/llvm/test/CodeGen/AArch64/qmovn.ll
+++ b/llvm/test/CodeGen/AArch64/qmovn.ll
@@ -206,7 +206,7 @@ entry:
   ret <2 x i32> %t
 }
 
-; Test the (concat_vectors (X), (trunc(smin(smax(Y, -2^n), 2^n-1))) pattern.
+; Test the (concat_vectors (X), (trunc(smin(smax(Y, -2^n), 2^n-1)))) pattern.
 
 define <16 x i8> @signed_minmax_v8i16_to_v16i8(<8 x i8> %x, <8 x i16> %y) {
 ; CHECK-LABEL: signed_minmax_v8i16_to_v16i8:
@@ -250,7 +250,7 @@ entry:
   ret <4 x i32> %shuffle
 }
 
-; Test the (concat_vectors (X), (trunc(smax(smin(Y, 2^n-1), -2^n))) pattern.
+; Test the (concat_vectors (X), (trunc(smax(smin(Y, 2^n-1), -2^n)))) pattern.
 
 define <16 x i8> @signed_maxmin_v8i16_to_v16i8(<8 x i8> %x, <8 x i16> %y) {
 ; CHECK-LABEL: signed_maxmin_v8i16_to_v16i8:
@@ -335,7 +335,7 @@ entry:
   ret <4 x i32> %shuffle
 }
 
-; Test the (concat_vectors (X), (trunc(umin(smax(Y, 0), 2^n))))) pattern.
+; Test the (concat_vectors (X), (trunc(umin(smax(Y, 0), 2^n)))) pattern.
 
 define <16 x i8> @us_maxmin_v8i16_to_v16i8(<8 x i8> %x, <8 x i16> %y) {
 ; CHECK-LABEL: us_maxmin_v8i16_to_v16i8:
@@ -379,7 +379,7 @@ entry:
   ret <4 x i32> %shuffle
 }
 
-; Test the (concat_vectors (X), (trunc(smin(smax(Y, 0), 2^n))))) pattern.
+; Test the (concat_vectors (X), (trunc(smin(smax(Y, 0), 2^n)))) pattern.
 
 define <16 x i8> @sminsmax_range_unsigned_i16_to_i8(<8 x i8> %x, <8 x i16> %y) {
 ; CHECK-LABEL: sminsmax_range_unsigned_i16_to_i8:
@@ -425,7 +425,7 @@ entry:
 
 
 
-; Test the (concat_vectors (X), (trunc(smin(smax(Y, -2^n), 2^n-1))) pattern.
+; Test the larger (trunc(smin(smax(Y, -2^n), 2^n-1))) pattern.
 
 define <16 x i8> @signed_minmax_v16i16_to_v16i8(<16 x i16> %y) {
 ; CHECK-LABEL: signed_minmax_v16i16_to_v16i8:
@@ -466,7 +466,7 @@ entry:
   ret <4 x i32> %trunc
 }
 
-; Test the (concat_vectors (X), (trunc(smax(smin(Y, 2^n-1), -2^n))) pattern.
+; Test the larger (trunc(smax(smin(Y, 2^n-1), -2^n))) pattern.
 
 define <16 x i8> @signed_maxmin_v16i16_to_v16i8(<16 x i16> %y) {
 ; CHECK-LABEL: signed_maxmin_v16i16_to_v16i8:
@@ -507,7 +507,7 @@ entry:
   ret <4 x i32> %trunc
 }
 
-; Test the (concat_vectors (X), (trunc(umin(Y, 2^n)))) pattern.
+; Test the larger (trunc(umin(Y, 2^n))) pattern.
 
 define <16 x i8> @unsigned_v16i16_to_v16i8(<16 x i16> %y) {
 ; CHECK-LABEL: unsigned_v16i16_to_v16i8:
@@ -545,7 +545,7 @@ entry:
   ret <4 x i32> %trunc
 }
 
-; Test the (concat_vectors (X), (trunc(umin(smax(Y, 0), 2^n))))) pattern.
+; Test the larger (trunc(umin(smax(Y, 0), 2^n)))) pattern.
 
 define <16 x i8> @us_maxmin_v16i16_to_v16i8(<16 x i16> %y) {
 ; CHECK-LABEL: us_maxmin_v16i16_to_v16i8:
@@ -586,7 +586,7 @@ entry:
   ret <4 x i32> %trunc
 }
 
-; Test the (concat_vectors (X), (trunc(smin(smax(Y, 0), 2^n))))) pattern.
+; Test the larger (trunc(smin(smax(Y, 0), 2^n))) pattern.
 
 define <16 x i8> @sminsmax_range_unsig16ed_i16_to_i8(<16 x i16> %y) {
 ; CHECK-LABEL: sminsmax_range_unsig16ed_i16_to_i8:
@@ -624,6 +624,80 @@ entry:
   %smax = call <4 x i64> @llvm.smax.v4i64(<4 x i64> %y, <4 x i64> zeroinitializer)
   %smin = call <4 x i64> @llvm.smin.v4i64(<4 x i64> %smax, <4 x i64> <i64 4294967295, i64 4294967295, i64 4294967295, i64 4294967295>)
   %trunc = trunc <4 x i64> %smin to <4 x i32>
+  ret <4 x i32> %trunc
+}
+
+; Test the trunc nsw trunc(smin(smax(Y, -2^n), 2^n-1)) pattern.
+
+define <16 x i8> @signed_minnsw_v16i16_to_v16i8(<16 x i16> %y) {
+; CHECK-SD-LABEL: signed_minnsw_v16i16_to_v16i8:
+; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    movi v2.8h, #127
+; CHECK-SD-NEXT:    smin v1.8h, v1.8h, v2.8h
+; CHECK-SD-NEXT:    smin v0.8h, v0.8h, v2.8h
+; CHECK-SD-NEXT:    uzp1 v0.16b, v0.16b, v1.16b
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: signed_minnsw_v16i16_to_v16i8:
+; CHECK-GI:       // %bb.0: // %entry
+; CHECK-GI-NEXT:    movi v2.8h, #127
+; CHECK-GI-NEXT:    smin v0.8h, v0.8h, v2.8h
+; CHECK-GI-NEXT:    smin v1.8h, v1.8h, v2.8h
+; CHECK-GI-NEXT:    uzp1 v0.16b, v0.16b, v1.16b
+; CHECK-GI-NEXT:    ret
+entry:
+  %min = call <16 x i16> @llvm.smin.v16i16(<16 x i16> %y, <16 x i16> <i16 127, i16 127, i16 127, i16 127, i16 127, i16 127, i16 127, i16 127, i16 127, i16 127, i16 127, i16 127, i16 127, i16 127, i16 127, i16 127>)
+  %trunc = trunc nsw <16 x i16> %min to <16 x i8>
+  ret <16 x i8> %trunc
+}
+
+define <8 x i16> @signed_minnsw_v8i32_to_v8i16(<8 x i32> %y) {
+; CHECK-SD-LABEL: signed_minnsw_v8i32_to_v8i16:
+; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    movi v2.4s, #127, msl #8
+; CHECK-SD-NEXT:    smin v1.4s, v1.4s, v2.4s
+; CHECK-SD-NEXT:    smin v0.4s, v0.4s, v2.4s
+; CHECK-SD-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: signed_minnsw_v8i32_to_v8i16:
+; CHECK-GI:       // %bb.0: // %entry
+; CHECK-GI-NEXT:    movi v2.4s, #127, msl #8
+; CHECK-GI-NEXT:    smin v0.4s, v0.4s, v2.4s
+; CHECK-GI-NEXT:    smin v1.4s, v1.4s, v2.4s
+; CHECK-GI-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
+; CHECK-GI-NEXT:    ret
+entry:
+  %min = call <8 x i32> @llvm.smin.v8i32(<8 x i32> %y, <8 x i32> <i32 32767, i32 32767, i32 32767, i32 32767, i32 32767, i32 32767, i32 32767, i32 32767>)
+  %trunc = trunc nsw <8 x i32> %min to <8 x i16>
+  ret <8 x i16> %trunc
+}
+
+define <4 x i32> @signed_minnsw_v4i64_to_v4i32(<4 x i64> %y) {
+; CHECK-SD-LABEL: signed_minnsw_v4i64_to_v4i32:
+; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    mov w8, #2147483647 // =0x7fffffff
+; CHECK-SD-NEXT:    dup v2.2d, x8
+; CHECK-SD-NEXT:    cmgt v3.2d, v2.2d, v1.2d
+; CHECK-SD-NEXT:    cmgt v4.2d, v2.2d, v0.2d
+; CHECK-SD-NEXT:    bif v1.16b, v2.16b, v3.16b
+; CHECK-SD-NEXT:    bif v0.16b, v2.16b, v4.16b
+; CHECK-SD-NEXT:    uzp1 v0.4s, v0.4s, v1.4s
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: signed_minnsw_v4i64_to_v4i32:
+; CHECK-GI:       // %bb.0: // %entry
+; CHECK-GI-NEXT:    adrp x8, .LCPI47_0
+; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI47_0]
+; CHECK-GI-NEXT:    cmgt v3.2d, v2.2d, v0.2d
+; CHECK-GI-NEXT:    cmgt v4.2d, v2.2d, v1.2d
+; CHECK-GI-NEXT:    bif v0.16b, v2.16b, v3.16b
+; CHECK-GI-NEXT:    bif v1.16b, v2.16b, v4.16b
+; CHECK-GI-NEXT:    uzp1 v0.4s, v0.4s, v1.4s
+; CHECK-GI-NEXT:    ret
+entry:
+  %min = call <4 x i64> @llvm.smin.v4i64(<4 x i64> %y, <4 x i64> <i64 2147483647, i64 2147483647, i64 2147483647, i64 2147483647>)
+  %trunc = trunc nsw <4 x i64> %min to <4 x i32>
   ret <4 x i32> %trunc
 }
 
@@ -681,13 +755,13 @@ define <4 x i16> @sminsmax_range_signed_i64_to_i16(<2 x i16> %x, <2 x i64> %y) {
 ;
 ; CHECK-GI-LABEL: sminsmax_range_signed_i64_to_i16:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    adrp x8, .LCPI46_1
+; CHECK-GI-NEXT:    adrp x8, .LCPI49_1
 ; CHECK-GI-NEXT:    uzp1 v0.4h, v0.4h, v0.4h
-; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI46_1]
-; CHECK-GI-NEXT:    adrp x8, .LCPI46_0
+; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI49_1]
+; CHECK-GI-NEXT:    adrp x8, .LCPI49_0
 ; CHECK-GI-NEXT:    cmgt v3.2d, v1.2d, v2.2d
 ; CHECK-GI-NEXT:    bif v1.16b, v2.16b, v3.16b
-; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI46_0]
+; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI49_0]
 ; CHECK-GI-NEXT:    cmgt v3.2d, v2.2d, v1.2d
 ; CHECK-GI-NEXT:    bif v1.16b, v2.16b, v3.16b
 ; CHECK-GI-NEXT:    xtn v1.2s, v1.2d

--- a/llvm/test/CodeGen/AArch64/saturating-vec-smull.ll
+++ b/llvm/test/CodeGen/AArch64/saturating-vec-smull.ll
@@ -27,10 +27,10 @@ define <2 x i16> @saturating_2xi16(<2 x i16> %a, <2 x i16> %b) {
 ; CHECK-GI-NEXT:    ret
   %as = sext <2 x i16> %a to <2 x i32>
   %bs = sext <2 x i16> %b to <2 x i32>
-  %m = mul <2 x i32> %bs, %as
+  %m = mul nsw <2 x i32> %bs, %as
   %sh = ashr <2 x i32> %m, splat (i32 15)
-  %ma = tail call <2 x i32> @llvm.smin.v4i32(<2 x i32> %sh, <2 x i32> splat (i32 32767))
-  %t = trunc <2 x i32> %ma to <2 x i16>
+  %ma = tail call <2 x i32> @llvm.smin.v2i32(<2 x i32> %sh, <2 x i32> splat (i32 32767))
+  %t = trunc nsw <2 x i32> %ma to <2 x i16>
   ret <2 x i16> %t
 }
 
@@ -50,10 +50,10 @@ define <4 x i16> @saturating_4xi16(<4 x i16> %a, <4 x i16> %b) {
 ; CHECK-GI-NEXT:    ret
   %as = sext <4 x i16> %a to <4 x i32>
   %bs = sext <4 x i16> %b to <4 x i32>
-  %m = mul <4 x i32> %bs, %as
+  %m = mul nsw <4 x i32> %bs, %as
   %sh = ashr <4 x i32> %m, splat (i32 15)
   %ma = tail call <4 x i32> @llvm.smin.v4i32(<4 x i32> %sh, <4 x i32> splat (i32 32767))
-  %t = trunc <4 x i32> %ma to <4 x i16>
+  %t = trunc nsw <4 x i32> %ma to <4 x i16>
   ret <4 x i16> %t
 }
 
@@ -76,10 +76,10 @@ define <8 x i16> @saturating_8xi16(<8 x i16> %a, <8 x i16> %b) {
 ; CHECK-GI-NEXT:    ret
   %as = sext <8 x i16> %a to <8 x i32>
   %bs = sext <8 x i16> %b to <8 x i32>
-  %m = mul <8 x i32> %bs, %as
+  %m = mul nsw <8 x i32> %bs, %as
   %sh = ashr <8 x i32> %m, splat (i32 15)
   %ma = tail call <8 x i32> @llvm.smin.v8i32(<8 x i32> %sh, <8 x i32> splat (i32 32767))
-  %t = trunc <8 x i32> %ma to <8 x i16>
+  %t = trunc nsw <8 x i32> %ma to <8 x i16>
   ret <8 x i16> %t
 }
 
@@ -101,10 +101,10 @@ define <2 x i32> @saturating_2xi32(<2 x i32> %a, <2 x i32> %b) {
 ; CHECK-GI-NEXT:    ret
   %as = sext <2 x i32> %a to <2 x i64>
   %bs = sext <2 x i32> %b to <2 x i64>
-  %m = mul <2 x i64> %bs, %as
+  %m = mul nsw <2 x i64> %bs, %as
   %sh = ashr <2 x i64> %m, splat (i64 31)
-  %ma = tail call <2 x i64> @llvm.smin.v8i64(<2 x i64> %sh, <2 x i64> splat (i64 2147483647))
-  %t = trunc <2 x i64> %ma to <2 x i32>
+  %ma = tail call <2 x i64> @llvm.smin.v2i64(<2 x i64> %sh, <2 x i64> splat (i64 2147483647))
+  %t = trunc nsw <2 x i64> %ma to <2 x i32>
   ret <2 x i32> %t
 }
 
@@ -130,10 +130,10 @@ define <4 x i32> @saturating_4xi32(<4 x i32> %a, <4 x i32> %b) {
 ; CHECK-GI-NEXT:    ret
   %as = sext <4 x i32> %a to <4 x i64>
   %bs = sext <4 x i32> %b to <4 x i64>
-  %m = mul <4 x i64> %bs, %as
+  %m = mul nsw <4 x i64> %bs, %as
   %sh = ashr <4 x i64> %m, splat (i64 31)
   %ma = tail call <4 x i64> @llvm.smin.v4i64(<4 x i64> %sh, <4 x i64> splat (i64 2147483647))
-  %t = trunc <4 x i64> %ma to <4 x i32>
+  %t = trunc nsw <4 x i64> %ma to <4 x i32>
   ret <4 x i32> %t
 }
 
@@ -169,10 +169,10 @@ define <8 x i32> @saturating_8xi32(<8 x i32> %a, <8 x i32> %b) {
 ; CHECK-GI-NEXT:    ret
   %as = sext <8 x i32> %a to <8 x i64>
   %bs = sext <8 x i32> %b to <8 x i64>
-  %m = mul <8 x i64> %bs, %as
+  %m = mul nsw <8 x i64> %bs, %as
   %sh = ashr <8 x i64> %m, splat (i64 31)
   %ma = tail call <8 x i64> @llvm.smin.v8i64(<8 x i64> %sh, <8 x i64> splat (i64 2147483647))
-  %t = trunc <8 x i64> %ma to <8 x i32>
+  %t = trunc nsw <8 x i64> %ma to <8 x i32>
   ret <8 x i32> %t
 }
 
@@ -194,9 +194,9 @@ define <2 x i64> @saturating_2xi32_2xi64(<2 x i32> %a, <2 x i32> %b) {
 ; CHECK-GI-NEXT:    ret
   %as = sext <2 x i32> %a to <2 x i64>
   %bs = sext <2 x i32> %b to <2 x i64>
-  %m = mul <2 x i64> %bs, %as
+  %m = mul nsw <2 x i64> %bs, %as
   %sh = ashr <2 x i64> %m, splat (i64 31)
-  %ma = tail call <2 x i64> @llvm.smin.v8i64(<2 x i64> %sh, <2 x i64> splat (i64 2147483647))
+  %ma = tail call <2 x i64> @llvm.smin.v2i64(<2 x i64> %sh, <2 x i64> splat (i64 2147483647))
   ret <2 x i64> %ma
 }
 
@@ -253,10 +253,10 @@ define <6 x i16> @saturating_6xi16(<6 x i16> %a, <6 x i16> %b) {
 ; CHECK-GI-NEXT:    ret
   %as = sext <6 x i16> %a to <6 x i32>
   %bs = sext <6 x i16> %b to <6 x i32>
-  %m = mul <6 x i32> %bs, %as
+  %m = mul nsw <6 x i32> %bs, %as
   %sh = ashr <6 x i32> %m, splat (i32 15)
   %ma = tail call <6 x i32> @llvm.smin.v6i32(<6 x i32> %sh, <6 x i32> splat (i32 32767))
-  %t = trunc <6 x i32> %ma to <6 x i16>
+  %t = trunc nsw <6 x i32> %ma to <6 x i16>
   ret <6 x i16> %t
 }
 
@@ -271,10 +271,10 @@ define <4 x i16> @unsupported_saturation_value_v4i16(<4 x i16> %a, <4 x i16> %b)
 ; CHECK-NEXT:    ret
   %as = sext <4 x i16> %a to <4 x i32>
   %bs = sext <4 x i16> %b to <4 x i32>
-  %m = mul <4 x i32> %bs, %as
+  %m = mul nsw <4 x i32> %bs, %as
   %sh = ashr <4 x i32> %m, splat (i32 15)
   %ma = tail call <4 x i32> @llvm.smin.v4i32(<4 x i32> %sh, <4 x i32> splat (i32 42))
-  %t = trunc <4 x i32> %ma to <4 x i16>
+  %t = trunc nsw <4 x i32> %ma to <4 x i16>
   ret <4 x i16> %t
 }
 
@@ -289,7 +289,7 @@ define <4 x i16> @unsupported_shift_value_v4i16(<4 x i16> %a, <4 x i16> %b) {
 ; CHECK-NEXT:    ret
   %as = sext <4 x i16> %a to <4 x i32>
   %bs = sext <4 x i16> %b to <4 x i32>
-  %m = mul <4 x i32> %bs, %as
+  %m = mul nsw <4 x i32> %bs, %as
   %sh = ashr <4 x i32> %m, splat (i32 3)
   %ma = tail call <4 x i32> @llvm.smin.v4i32(<4 x i32> %sh, <4 x i32> splat (i32 32767))
   %t = trunc <4 x i32> %ma to <4 x i16>
@@ -307,10 +307,10 @@ define <2 x i16> @extend_to_illegal_type(<2 x i16> %a, <2 x i16> %b) {
 ; CHECK-NEXT:    ret
   %as = sext <2 x i16> %a to <2 x i48>
   %bs = sext <2 x i16> %b to <2 x i48>
-  %m = mul <2 x i48> %bs, %as
+  %m = mul nsw <2 x i48> %bs, %as
   %sh = ashr <2 x i48> %m, splat (i48 15)
-  %ma = tail call <2 x i48> @llvm.smin.v4i32(<2 x i48> %sh, <2 x i48> splat (i48 32767))
-  %t = trunc <2 x i48> %ma to <2 x i16>
+  %ma = tail call <2 x i48> @llvm.smin.v2i48(<2 x i48> %sh, <2 x i48> splat (i48 32767))
+  %t = trunc nsw <2 x i48> %ma to <2 x i16>
   ret <2 x i16> %t
 }
 
@@ -365,9 +365,9 @@ define <1 x i16> @saturating_1xi16(<1 x i16> %a, <1 x i16> %b) {
 ; CHECK-GI-NEXT:    ret
   %as = sext <1 x i16> %a to <1 x i32>
   %bs = sext <1 x i16> %b to <1 x i32>
-  %m = mul <1 x i32> %bs, %as
+  %m = mul nsw <1 x i32> %bs, %as
   %sh = ashr <1 x i32> %m, splat (i32 15)
   %ma = tail call <1 x i32> @llvm.smin.v1i32(<1 x i32> %sh, <1 x i32> splat (i32 32767))
-  %t = trunc <1 x i32> %ma to <1 x i16>
+  %t = trunc nsw <1 x i32> %ma to <1 x i16>
   ret <1 x i16> %t
 }


### PR DESCRIPTION
The qmov.ll test was cleaned up a little, and the saturating-vec-smull.ll was
updated with flags expected to be generated from the -O2 pipeline.