### PR TITLE
[CodeGen] Stop scanning RegMasks after reaching their intersection

### DIFF
--- a/llvm/include/llvm/CodeGen/LiveIntervals.h
+++ b/llvm/include/llvm/CodeGen/LiveIntervals.h
@@ -20,6 +20,7 @@
 #define LLVM_CODEGEN_LIVEINTERVALS_H
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/IndexedMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/CodeGen/LiveInterval.h"
@@ -41,7 +42,6 @@ namespace llvm {
 
 LLVM_ABI extern cl::opt<bool> UseSegmentSetForPhysRegs;
 
-class BitVector;
 class MachineBlockFrequencyInfo;
 class MachineDominatorTree;
 class MachineFunction;
@@ -94,9 +94,8 @@ class LiveIntervals {
   /// block.
   SmallVector<std::pair<unsigned, unsigned>, 8> RegMaskBlocks;
 
-  /// The register mask pointer shared by every RegMaskBits entry, or nullptr
-  /// when the function uses more than one mask pointer.
-  const uint32_t *SingleRegMask = nullptr;
+  /// The registers preserved by every register mask in the function.
+  BitVector RegMaskIntersection;
 
   /// Keeps a live range set for each register unit to track fixed physreg
   /// interference.

--- a/llvm/include/llvm/CodeGen/LiveIntervals.h
+++ b/llvm/include/llvm/CodeGen/LiveIntervals.h
@@ -94,6 +94,10 @@ class LiveIntervals {
   /// block.
   SmallVector<std::pair<unsigned, unsigned>, 8> RegMaskBlocks;
 
+  /// The register mask pointer shared by every RegMaskBits entry, or nullptr
+  /// when the function uses more than one mask pointer.
+  const uint32_t *SingleRegMask = nullptr;
+
   /// Keeps a live range set for each register unit to track fixed physreg
   /// interference.
   SmallVector<LiveRange *, 0> RegUnitRanges;

--- a/llvm/lib/CodeGen/LiveIntervals.cpp
+++ b/llvm/lib/CodeGen/LiveIntervals.cpp
@@ -147,7 +147,7 @@ void LiveIntervals::clear() {
   RegMaskSlots.clear();
   RegMaskBits.clear();
   RegMaskBlocks.clear();
-  SingleRegMask = nullptr;
+  RegMaskIntersection.clear();
 
   for (LiveRange *LR : RegUnitRanges)
     delete LR;
@@ -250,6 +250,13 @@ void LiveIntervals::computeVirtRegs() {
 
 void LiveIntervals::computeRegMasks() {
   RegMaskBlocks.resize(MF->getNumBlockIDs());
+  RegMaskIntersection.resize(TRI->getNumRegs(), true);
+
+  auto addRegMask = [&](SlotIndex Slot, const uint32_t *Mask) {
+    RegMaskSlots.push_back(Slot);
+    RegMaskBits.push_back(Mask);
+    RegMaskIntersection.clearBitsNotInMask(Mask);
+  };
 
   // Find all instructions with regmask operands.
   for (const MachineBasicBlock &MBB : *MF) {
@@ -257,26 +264,22 @@ void LiveIntervals::computeRegMasks() {
     RMB.first = RegMaskSlots.size();
 
     // Some block starts, such as EH funclets, create masks.
-    if (const uint32_t *Mask = MBB.getBeginClobberMask(TRI)) {
-      RegMaskSlots.push_back(Indexes->getMBBStartIdx(&MBB));
-      RegMaskBits.push_back(Mask);
-    }
+    if (const uint32_t *Mask = MBB.getBeginClobberMask(TRI))
+      addRegMask(Indexes->getMBBStartIdx(&MBB), Mask);
 
     // Unwinders may clobber additional registers.
     // FIXME: This functionality can possibly be merged into
     // MachineBasicBlock::getBeginClobberMask().
     if (MBB.isEHPad())
-      if (auto *Mask = TRI->getCustomEHPadPreservedMask(*MBB.getParent())) {
-        RegMaskSlots.push_back(Indexes->getMBBStartIdx(&MBB));
-        RegMaskBits.push_back(Mask);
-      }
+      if (auto *Mask = TRI->getCustomEHPadPreservedMask(*MBB.getParent()))
+        addRegMask(Indexes->getMBBStartIdx(&MBB), Mask);
 
     for (const MachineInstr &MI : MBB) {
       for (const MachineOperand &MO : MI.operands()) {
         if (!MO.isRegMask())
           continue;
-        RegMaskSlots.push_back(Indexes->getInstructionIndex(MI).getRegSlot());
-        RegMaskBits.push_back(MO.getRegMask());
+        addRegMask(Indexes->getInstructionIndex(MI).getRegSlot(),
+                   MO.getRegMask());
       }
     }
 
@@ -285,23 +288,11 @@ void LiveIntervals::computeRegMasks() {
     // half-open.
     if (const uint32_t *Mask = MBB.getEndClobberMask(TRI)) {
       assert(!MBB.empty() && "empty return block?");
-      RegMaskSlots.push_back(
-          Indexes->getInstructionIndex(MBB.back()).getRegSlot());
-      RegMaskBits.push_back(Mask);
+      addRegMask(Indexes->getInstructionIndex(MBB.back()).getRegSlot(), Mask);
     }
 
     // Compute the number of register mask instructions in this block.
     RMB.second = RegMaskSlots.size() - RMB.first;
-  }
-
-  if (!RegMaskBits.empty()) {
-    SingleRegMask = RegMaskBits.front();
-    for (const uint32_t *Mask : RegMaskBits) {
-      if (Mask != SingleRegMask) {
-        SingleRegMask = nullptr;
-        break;
-      }
-    }
   }
 }
 
@@ -1034,16 +1025,16 @@ bool LiveIntervals::checkRegMaskInterference(const LiveInterval &LI,
   bool Found = false;
   // Utility to union regmasks.
   auto unionBitMask = [&](unsigned Idx) {
-      if (!Found) {
-        // This is the first overlap. Initialize UsableRegs to all ones.
-        UsableRegs.clear();
-        UsableRegs.resize(TRI->getNumRegs(), true);
-        Found = true;
-      }
-      // Remove usable registers clobbered by this mask.
-      UsableRegs.clearBitsNotInMask(Bits[Idx]);
-      // Reapplying the same mask cannot change UsableRegs.
-      return SingleRegMask != nullptr;
+    if (!Found) {
+      // This is the first overlap. Initialize UsableRegs to all ones.
+      UsableRegs.clear();
+      UsableRegs.resize(TRI->getNumRegs(), true);
+      Found = true;
+    }
+    // Remove usable registers clobbered by this mask.
+    UsableRegs.clearBitsNotInMask(Bits[Idx]);
+    // No remaining mask can change an already fully intersected result.
+    return UsableRegs == RegMaskIntersection;
   };
   while (true) {
     assert(*SlotI >= LiveI->start);

--- a/llvm/lib/CodeGen/LiveIntervals.cpp
+++ b/llvm/lib/CodeGen/LiveIntervals.cpp
@@ -147,6 +147,7 @@ void LiveIntervals::clear() {
   RegMaskSlots.clear();
   RegMaskBits.clear();
   RegMaskBlocks.clear();
+  SingleRegMask = nullptr;
 
   for (LiveRange *LR : RegUnitRanges)
     delete LR;
@@ -291,6 +292,16 @@ void LiveIntervals::computeRegMasks() {
 
     // Compute the number of register mask instructions in this block.
     RMB.second = RegMaskSlots.size() - RMB.first;
+  }
+
+  if (!RegMaskBits.empty()) {
+    SingleRegMask = RegMaskBits.front();
+    for (const uint32_t *Mask : RegMaskBits) {
+      if (Mask != SingleRegMask) {
+        SingleRegMask = nullptr;
+        break;
+      }
+    }
   }
 }
 
@@ -1031,21 +1042,26 @@ bool LiveIntervals::checkRegMaskInterference(const LiveInterval &LI,
       }
       // Remove usable registers clobbered by this mask.
       UsableRegs.clearBitsNotInMask(Bits[Idx]);
+      // Reapplying the same mask cannot change UsableRegs.
+      return SingleRegMask != nullptr;
   };
   while (true) {
     assert(*SlotI >= LiveI->start);
     // Loop over all slots overlapping this segment.
     while (*SlotI < LiveI->end) {
       // *SlotI overlaps LI. Collect mask bits.
-      unionBitMask(SlotI - Slots.begin());
+      if (unionBitMask(SlotI - Slots.begin()))
+        return true;
       if (++SlotI == SlotE)
         return Found;
     }
     // If segment ends with live-through use we need to collect its regmask.
-    if (*SlotI == LiveI->end)
+    if (*SlotI == LiveI->end) {
       if (MachineInstr *MI = getInstructionFromIndex(*SlotI))
         if (hasLiveThroughUse(MI, LI.reg()))
-          unionBitMask(SlotI++ - Slots.begin());
+          if (unionBitMask(SlotI++ - Slots.begin()))
+            return true;
+    }
     // *SlotI is beyond the current LI segment.
     // Special advance implementation to not miss next LiveI->end.
     if (++LiveI == LiveE || SlotI == SlotE || *SlotI > LI.endIndex())


### PR DESCRIPTION
Compute the function-wide RegMask intersection while collecting the masks.
In checkRegMaskInterference, stop once UsableRegs reaches this intersection, since no remaining mask can change the result. Queries that do not reach it retain the existing full scan.

This [reduces instructions](https://llvm-compile-time-tracker.com/compare.php?from=bc0c028fa5a3e8a76bc432f5b22d1ee4883acaca&to=93b2f60a6f093acd65ec814afadf3ca1f601b5bb&stat=instructions:u) by 0.05-0.07% across optimized CTMark configurations and by 0.03% for the Clang build. Greedy RA time decreases by 16.63% on an ASan-instrumented protobuf workload, with identical object output.