### PR TITLE
[mlir][affine] Fix inverted epilogue check in affineForOpBodySkew

### DIFF
--- a/mlir/lib/Dialect/Affine/Utils/LoopUtils.cpp
+++ b/mlir/lib/Dialect/Affine/Utils/LoopUtils.cpp
@@ -352,7 +352,7 @@ LogicalResult mlir::affine::affineForOpBodySkew(AffineForOp forOp,
 
   if (unrollPrologueEpilogue && prologue)
     (void)loopUnrollFull(prologue);
-  if (unrollPrologueEpilogue && !epilogue && epilogue != prologue)
+  if (unrollPrologueEpilogue && epilogue && epilogue != prologue)
     (void)loopUnrollFull(epilogue);
 
   return success();


### PR DESCRIPTION
**bug/functional incorrectness**:
when `unrollPrologueEpilogue` is enabled, `affineForOpBodySkew` aims to fully unroll both the generated prologue and epilogue.  The epilogue condition incorrectly checks `!epilogue`, may be causing valid epilogues to be skipped and passing a null operation to `loopUnrollFull.`

**trivial fix:**
replace the condition with `epilogue && epilogue != prologue`.  So that , a valid epilogue is unrolled exactly once.
