### PR TITLE
[Bazel] Configure Windows targets by CPU and compiler

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -324,6 +324,33 @@ config_setting(
 )
 
 config_setting(
+    name = "is_aarch64_windows_clang_mingw",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:windows",
+    ],
+    flag_values = {"@rules_cc//cc/compiler:compiler": "clang"},
+)
+
+config_setting(
+    name = "is_aarch64_windows_clang_cl",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:windows",
+    ],
+    flag_values = {"@rules_cc//cc/compiler:compiler": "clang-cl"},
+)
+
+config_setting(
+    name = "is_aarch64_windows_msvc",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:windows",
+    ],
+    flag_values = {"@rules_cc//cc/compiler:compiler": "msvc-cl"},
+)
+
+config_setting(
     name = "is_x86_64_windows_clang_mingw",
     constraint_values = [
         "@platforms//cpu:x86_64",

--- a/utils/bazel/llvm-project-overlay/llvm/config.bzl
+++ b/utils/bazel/llvm-project-overlay/llvm/config.bzl
@@ -133,6 +133,10 @@ builtin_thread_pointer = select({
 
 # TODO: We should split out host vs. target here.
 llvm_config_defines = os_defines + builtin_thread_pointer + select({
+    Label("//llvm:is_aarch64_windows_clang_mingw"): native_arch_defines("AArch64", "aarch64-w64-windows-gnu"),
+    Label("//llvm:is_aarch64_windows_clang_cl"): native_arch_defines("AArch64", "aarch64-pc-windows-msvc"),
+    Label("//llvm:is_aarch64_windows_msvc"): native_arch_defines("AArch64", "aarch64-pc-windows-msvc"),
+    Label("//llvm:is_x86_64_windows_clang_mingw"): native_arch_defines("X86", "x86_64-w64-windows-gnu"),
     Label("//llvm:darwin_arm64"): native_arch_defines("AArch64", "arm64-apple-darwin"),
     Label("//llvm:darwin_x86_64"): native_arch_defines("X86", "x86_64-unknown-darwin"),
     Label("//llvm:linux_aarch64"): native_arch_defines("AArch64", "aarch64-unknown-linux-gnu"),


### PR DESCRIPTION
## Summary

- add Windows AArch64 configuration settings for clang/MinGW, clang-cl, and msvc-cl
- select AArch64 native initializer symbols and compiler-appropriate host/default triples
- select the GNU triple for x86_64 MinGW while preserving the existing generic Windows fallback

## Motivation

This came out while implementing full windows cross compilation from Linux using Bazel and the hermetic-llvm project.

The Bazel overlay currently selects LLVM's native architecture and triples using only the Windows OS constraint. As a result, every Windows target receives X86 native initializer symbols and the `x86_64-pc-win32` host/default triple, including Windows AArch64 builds.

Make the Windows cases sensitive to both target CPU and compiler. The triples mirror `llvm/cmake/modules/GetHostTriple.cmake`: `aarch64-pc-windows-msvc` for ARM64 MSVC-compatible builds and `aarch64-w64-windows-gnu` / `x86_64-w64-windows-gnu` for MinGW.

Assisted by: codex