### PR TITLE
[TLI] Return LibFunc from TargetLibraryInfo::getLibFunc

### DIFF
--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.h
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.h
@@ -100,6 +100,8 @@ class TargetLibraryInfoImpl {
     AvailableArray[F/4] |= State << 2*(F&3);
   }
   AvailabilityState getState(LibFunc F) const {
+    if (F == NotLibFunc)
+      return Unavailable;
     return static_cast<AvailabilityState>((AvailableArray[F/4] >> 2*(F&3)) & 3);
   }
 
@@ -127,22 +129,24 @@ public:
 
   /// Searches for a particular function name.
   ///
-  /// If it is one of the known library functions, return true and set F to the
-  /// corresponding value.
-  LLVM_ABI bool getLibFunc(StringRef funcName, LibFunc &F) const;
+  /// Returns the corresponding LibFunc if it is one of the known library
+  /// functions, and NotLibFunc otherwise.
+  LLVM_ABI LibFunc getLibFunc(StringRef funcName) const;
 
   /// Searches for a particular function name, also checking that its type is
   /// valid for the library function matching that name.
   ///
-  /// If it is one of the known library functions, return true and set F to the
-  /// corresponding value.
+  /// Returns the corresponding LibFunc if it is one of the known library
+  /// functions, and NotLibFunc otherwise.
   ///
   /// FDecl is assumed to have a parent Module when using this function.
-  LLVM_ABI bool getLibFunc(const Function &FDecl, LibFunc &F) const;
+  LLVM_ABI LibFunc getLibFunc(const Function &FDecl) const;
 
   /// Searches for a function name using an Instruction \p Opcode.
   /// Currently, only the frem instruction is supported.
-  LLVM_ABI bool getLibFunc(unsigned int Opcode, Type *Ty, LibFunc &F) const;
+  ///
+  /// Returns NotLibFunc if there is no matching library function.
+  LLVM_ABI LibFunc getLibFunc(unsigned int Opcode, Type *Ty) const;
 
   /// Forces a function to be marked as unavailable.
   void setUnavailable(LibFunc F) {
@@ -286,7 +290,6 @@ public:
       disableAllFunctions();
     else {
       // Disable individual libc/libm calls in TargetLibraryInfo.
-      LibFunc LF;
       AttributeSet FnAttrs = (*F)->getAttributes().getFnAttrs();
       for (const Attribute &Attr : FnAttrs) {
         if (!Attr.isStringAttribute())
@@ -294,7 +297,7 @@ public:
         auto AttrStr = Attr.getKindAsString();
         if (!AttrStr.consume_front("no-builtin-"))
           continue;
-        if (getLibFunc(AttrStr, LF))
+        if (LibFunc LF = getLibFunc(AttrStr); LF != NotLibFunc)
           setUnavailable(LF);
       }
     }
@@ -328,27 +331,30 @@ public:
 
   /// Searches for a particular function name.
   ///
-  /// If it is one of the known library functions, return true and set F to the
-  /// corresponding value.
-  bool getLibFunc(StringRef funcName, LibFunc &F) const {
-    return Impl->getLibFunc(funcName, F);
+  /// Returns the corresponding LibFunc if it is one of the known library
+  /// functions, and NotLibFunc otherwise.
+  LibFunc getLibFunc(StringRef funcName) const {
+    return Impl->getLibFunc(funcName);
   }
 
-  bool getLibFunc(const Function &FDecl, LibFunc &F) const {
-    return Impl->getLibFunc(FDecl, F);
+  LibFunc getLibFunc(const Function &FDecl) const {
+    return Impl->getLibFunc(FDecl);
   }
 
-  /// If a callbase does not have the 'nobuiltin' attribute, return if the
-  /// called function is a known library function and set F to that function.
-  bool getLibFunc(const CallBase &CB, LibFunc &F) const {
-    return !CB.isNoBuiltin() && CB.getCalledFunction() &&
-           getLibFunc(*(CB.getCalledFunction()), F);
+  /// If a callbase does not have the 'nobuiltin' attribute, return the library
+  /// function the callee is, and NotLibFunc otherwise.
+  LibFunc getLibFunc(const CallBase &CB) const {
+    if (CB.isNoBuiltin() || !CB.getCalledFunction())
+      return NotLibFunc;
+    return getLibFunc(*CB.getCalledFunction());
   }
 
   /// Searches for a function name using an Instruction \p Opcode.
   /// Currently, only the frem instruction is supported.
-  bool getLibFunc(unsigned int Opcode, Type *Ty, LibFunc &F) const {
-    return Impl->getLibFunc(Opcode, Ty, F);
+  ///
+  /// Returns NotLibFunc if there is no matching library function.
+  LibFunc getLibFunc(unsigned int Opcode, Type *Ty) const {
+    return Impl->getLibFunc(Opcode, Ty);
   }
 
   /// Disables all builtins.

--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.h
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.h
@@ -297,7 +297,7 @@ public:
         auto AttrStr = Attr.getKindAsString();
         if (!AttrStr.consume_front("no-builtin-"))
           continue;
-        if (LibFunc LF = getLibFunc(AttrStr); LF != NotLibFunc)
+        if (LibFunc LF = getLibFunc(AttrStr))
           setUnavailable(LF);
       }
     }

--- a/llvm/lib/Analysis/BranchProbabilityInfo.cpp
+++ b/llvm/lib/Analysis/BranchProbabilityInfo.cpp
@@ -892,7 +892,7 @@ bool BPIConstruction::calcZeroHeuristics(const BasicBlock *BB,
   if (TLI)
     if (CallInst *Call = dyn_cast<CallInst>(CI->getOperand(0)))
       if (Function *CalledFn = Call->getCalledFunction())
-        TLI->getLibFunc(*CalledFn, Func);
+        Func = TLI->getLibFunc(*CalledFn);
 
   bool Likely;
   if (Func == LibFunc_strcasecmp ||

--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -2645,9 +2645,8 @@ static Constant *ConstantFoldScalarCall1(StringRef Name,
         return GetConstantFoldFPValue128(Result, Ty);
       }
 
-      LibFunc Fp128Func = NotLibFunc;
-      if (TLI && TLI->getLibFunc(Name, Fp128Func) && TLI->has(Fp128Func) &&
-          Fp128Func == LibFunc_logl)
+      if (TLI && TLI->getLibFunc(Name) == LibFunc_logl &&
+          TLI->has(LibFunc_logl))
         return ConstantFoldFP128(logf128, Op->getValueAPF(), Ty);
     }
 #endif
@@ -3021,8 +3020,8 @@ static Constant *ConstantFoldScalarCall1(StringRef Name,
     if (!TLI)
       return nullptr;
 
-    LibFunc Func = NotLibFunc;
-    if (!TLI->getLibFunc(Name, Func))
+    LibFunc Func = TLI->getLibFunc(Name);
+    if (Func == NotLibFunc)
       return nullptr;
 
     switch (Func) {
@@ -3368,8 +3367,8 @@ static Constant *ConstantFoldLibCall2(StringRef Name, Type *Ty,
   if (!TLI)
     return nullptr;
 
-  LibFunc Func = NotLibFunc;
-  if (!TLI->getLibFunc(Name, Func))
+  LibFunc Func = TLI->getLibFunc(Name);
+  if (Func == NotLibFunc)
     return nullptr;
 
   const auto *Op1 = dyn_cast<ConstantFP>(Operands[0]);
@@ -4742,8 +4741,7 @@ Constant *llvm::ConstantFoldCall(const CallBase *Call, Function *F,
   if (IID == Intrinsic::not_intrinsic) {
     if (!TLI)
       return nullptr;
-    LibFunc LibF;
-    if (!TLI->getLibFunc(*F, LibF))
+    if (TLI->getLibFunc(*F) == NotLibFunc)
       return nullptr;
   }
 
@@ -4782,8 +4780,11 @@ bool llvm::isMathLibCallNoop(const CallBase *Call,
   if (!F)
     return false;
 
-  LibFunc Func;
-  if (!TLI || !TLI->getLibFunc(*F, Func))
+  if (!TLI)
+    return false;
+
+  LibFunc Func = TLI->getLibFunc(*F);
+  if (Func == NotLibFunc)
     return false;
 
   if (Call->arg_size() == 1) {

--- a/llvm/lib/Analysis/InlineCost.cpp
+++ b/llvm/lib/Analysis/InlineCost.cpp
@@ -2437,8 +2437,11 @@ bool CallAnalyzer::simplifyCallSite(Function *F, CallBase &Call) {
 
 bool CallAnalyzer::isLoweredToCall(Function *F, CallBase &Call) {
   const TargetLibraryInfo *TLI = GetTLI ? &GetTLI(*F) : nullptr;
-  LibFunc LF;
-  if (!TLI || !TLI->getLibFunc(*F, LF) || !TLI->has(LF))
+  if (!TLI)
+    return TTI.isLoweredToCall(F);
+
+  LibFunc LF = TLI->getLibFunc(*F);
+  if (!TLI->has(LF))
     return TTI.isLoweredToCall(F);
 
   switch (LF) {

--- a/llvm/lib/Analysis/LazyCallGraph.cpp
+++ b/llvm/lib/Analysis/LazyCallGraph.cpp
@@ -142,12 +142,10 @@ LLVM_DUMP_METHOD void LazyCallGraph::Node::dump() const {
 #endif
 
 static bool isKnownLibFunction(Function &F, TargetLibraryInfo &TLI) {
-  LibFunc LF;
-
   // Either this is a normal library function or a "vectorizable"
   // function.  Not using the VFDatabase here because this query
   // is related only to libraries handled via the TLI.
-  return TLI.getLibFunc(F, LF) ||
+  return TLI.getLibFunc(F) != NotLibFunc ||
          TLI.isKnownVectorFunctionInLibrary(F.getName());
 }
 

--- a/llvm/lib/Analysis/MemoryBuiltins.cpp
+++ b/llvm/lib/Analysis/MemoryBuiltins.cpp
@@ -180,8 +180,11 @@ getAllocationDataForFunction(const Function *Callee, AllocType AllocTy,
     return std::nullopt;
 
   // Make sure that the function is available.
-  LibFunc TLIFn;
-  if (!TLI || !TLI->getLibFunc(*Callee, TLIFn) || !TLI->has(TLIFn))
+  if (!TLI)
+    return std::nullopt;
+
+  LibFunc TLIFn = TLI->getLibFunc(*Callee);
+  if (!TLI->has(TLIFn))
     return std::nullopt;
 
   const auto *Iter = find_if(AllocationFnData,
@@ -492,8 +495,8 @@ getFreeFunctionDataForFunction(const Function *Callee, const LibFunc TLIFn) {
 std::optional<StringRef>
 llvm::getAllocationFamily(const Value *I, const TargetLibraryInfo *TLI) {
   if (const Function *Callee = getCalledFunction(I)) {
-    LibFunc TLIFn;
-    if (TLI && TLI->getLibFunc(*Callee, TLIFn) && TLI->has(TLIFn)) {
+    LibFunc TLIFn = TLI ? TLI->getLibFunc(*Callee) : NotLibFunc;
+    if (TLIFn != NotLibFunc && TLI->has(TLIFn)) {
       // Callee is some known library function.
       const auto AllocData =
           getAllocationDataForFunction(Callee, AnyAlloc, TLI);
@@ -537,8 +540,8 @@ bool llvm::isLibFreeFunction(const Function *F, const LibFunc TLIFn) {
 
 Value *llvm::getFreedOperand(const CallBase *CB, const TargetLibraryInfo *TLI) {
   if (const Function *Callee = getCalledFunction(CB)) {
-    LibFunc TLIFn;
-    if (TLI && TLI->getLibFunc(*Callee, TLIFn) && TLI->has(TLIFn) &&
+    LibFunc TLIFn = TLI ? TLI->getLibFunc(*Callee) : NotLibFunc;
+    if (TLIFn != NotLibFunc && TLI->has(TLIFn) &&
         isLibFreeFunction(Callee, TLIFn)) {
       // All currently supported free functions free the first argument.
       return CB->getArgOperand(0);
@@ -1098,9 +1101,11 @@ OffsetSpan ObjectSizeOffsetVisitor::findLoadOffsetRange(
       if (!Callee)
         return Unknown();
 
-      LibFunc TLIFn;
-      if (!TLI || !TLI->getLibFunc(*CB->getCalledFunction(), TLIFn) ||
-          !TLI->has(TLIFn))
+      if (!TLI)
+        return Unknown();
+
+      LibFunc TLIFn = TLI->getLibFunc(*CB->getCalledFunction());
+      if (!TLI->has(TLIFn))
         return Unknown();
 
       // TODO: There's probably more interesting case to support here.

--- a/llvm/lib/Analysis/MemoryLocation.cpp
+++ b/llvm/lib/Analysis/MemoryLocation.cpp
@@ -327,8 +327,8 @@ MemoryLocation MemoryLocation::getForArgument(const CallBase *Call,
   // for memcpy/memset.  This is particularly important because the
   // LoopIdiomRecognizer likes to turn loops into calls to memset_pattern16
   // whenever possible.
-  LibFunc F;
-  if (TLI && TLI->getLibFunc(*Call, F) && TLI->has(F)) {
+  LibFunc F = TLI ? TLI->getLibFunc(*Call) : NotLibFunc;
+  if (F != NotLibFunc && TLI->has(F)) {
     switch (F) {
     case LibFunc_strcpy:
     case LibFunc_strcat:

--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -972,19 +972,17 @@ buildIndexMap(const llvm::StringTable &StandardNames) {
   return Indices;
 }
 
-bool TargetLibraryInfoImpl::getLibFunc(StringRef funcName, LibFunc &F) const {
+LibFunc TargetLibraryInfoImpl::getLibFunc(StringRef funcName) const {
   funcName = sanitizeFunctionName(funcName);
   if (funcName.empty())
-    return false;
+    return NotLibFunc;
 
   static const DenseMap<StringRef, LibFunc> Indices =
       buildIndexMap(StandardNamesStrTable);
 
-  if (auto Loc = Indices.find(funcName); Loc != Indices.end()) {
-    F = Loc->second;
-    return true;
-  }
-  return false;
+  if (auto Loc = Indices.find(funcName); Loc != Indices.end())
+    return Loc->second;
+  return NotLibFunc;
 }
 
 // Return true if ArgTy matches Ty.
@@ -1188,35 +1186,34 @@ bool TargetLibraryInfoImpl::isValidProtoForLibFunc(const FunctionType &FTy,
   return Idx == NumParams + 1 && !FTy.isFunctionVarArg();
 }
 
-bool TargetLibraryInfoImpl::getLibFunc(const Function &FDecl,
-                                       LibFunc &F) const {
+LibFunc TargetLibraryInfoImpl::getLibFunc(const Function &FDecl) const {
   // Intrinsics don't overlap w/libcalls; if our module has a large number of
   // intrinsics, this ends up being an interesting compile time win since we
   // avoid string normalization and comparison.
-  if (FDecl.isIntrinsic()) return false;
+  if (FDecl.isIntrinsic())
+    return NotLibFunc;
 
   const Module *M = FDecl.getParent();
   assert(M && "Expecting FDecl to be connected to a Module.");
 
   if (FDecl.LibFuncCache == Function::UnknownLibFunc)
-    if (!getLibFunc(FDecl.getName(), FDecl.LibFuncCache))
-      FDecl.LibFuncCache = NotLibFunc;
+    FDecl.LibFuncCache = getLibFunc(FDecl.getName());
 
   if (FDecl.LibFuncCache == NotLibFunc)
-    return false;
+    return NotLibFunc;
 
-  F = FDecl.LibFuncCache;
-  return isValidProtoForLibFunc(*FDecl.getFunctionType(), F, *M);
+  if (!isValidProtoForLibFunc(*FDecl.getFunctionType(), FDecl.LibFuncCache, *M))
+    return NotLibFunc;
+
+  return FDecl.LibFuncCache;
 }
 
-bool TargetLibraryInfoImpl::getLibFunc(unsigned int Opcode, Type *Ty,
-                                       LibFunc &F) const {
+LibFunc TargetLibraryInfoImpl::getLibFunc(unsigned int Opcode, Type *Ty) const {
   // Must be a frem instruction with float or double arguments.
   if (Opcode != Instruction::FRem || (!Ty->isDoubleTy() && !Ty->isFloatTy()))
-    return false;
+    return NotLibFunc;
 
-  F = Ty->isDoubleTy() ? LibFunc_fmod : LibFunc_fmodf;
-  return true;
+  return Ty->isDoubleTy() ? LibFunc_fmod : LibFunc_fmodf;
 }
 
 void TargetLibraryInfoImpl::disableAllFunctions() {

--- a/llvm/lib/Analysis/TargetTransformInfo.cpp
+++ b/llvm/lib/Analysis/TargetTransformInfo.cpp
@@ -1020,9 +1020,8 @@ InstructionCost TargetTransformInfo::getArithmeticInstrCost(
   // ReplaceWithVecLib pass.
   if (TLibInfo && Opcode == Instruction::FRem) {
     VectorType *VecTy = dyn_cast<VectorType>(Ty);
-    LibFunc Func;
-    if (VecTy &&
-        TLibInfo->getLibFunc(Instruction::FRem, Ty->getScalarType(), Func) &&
+    LibFunc Func = TLibInfo->getLibFunc(Instruction::FRem, Ty->getScalarType());
+    if (VecTy && Func != NotLibFunc &&
         TLibInfo->isFunctionVectorizable(TLibInfo->getName(Func),
                                          VecTy->getElementCount()))
       return getCallInstrCost(nullptr, VecTy, {VecTy, VecTy}, CostKind);

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -4681,9 +4681,11 @@ Intrinsic::ID llvm::getIntrinsicForCallSite(const CallBase &CB,
   // We are going to infer semantics of a library function based on mapping it
   // to an LLVM intrinsic. Check that the library function is available from
   // this callbase and in this environment.
-  LibFunc Func;
-  if (F->hasLocalLinkage() || !TLI || !TLI->getLibFunc(CB, Func) ||
-      !CB.onlyReadsMemory())
+  if (F->hasLocalLinkage() || !TLI || !CB.onlyReadsMemory())
+    return Intrinsic::not_intrinsic;
+
+  LibFunc Func = TLI->getLibFunc(CB);
+  if (Func == NotLibFunc)
     return Intrinsic::not_intrinsic;
 
   switch (Func) {

--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -2920,10 +2920,9 @@ static bool isIntrinsicOrLFToBeTailCalled(const TargetLibraryInfo *TLInfo,
       return false;
     }
 
-  LibFunc LF;
   Function *Callee = CI->getCalledFunction();
-  if (Callee && TLInfo && TLInfo->getLibFunc(*Callee, LF))
-    switch (LF) {
+  if (Callee && TLInfo)
+    switch (TLInfo->getLibFunc(*Callee)) {
     case LibFunc_strcpy:
     case LibFunc_strncpy:
     case LibFunc_strcat:

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -9807,9 +9807,10 @@ void SelectionDAGBuilder::visitCall(const CallInst &I) {
     // some reason.
     // This code should not handle libcalls that are already canonicalized to
     // intrinsics by the middle-end.
-    LibFunc Func;
-    if (!I.isNoBuiltin() && !F->hasLocalLinkage() && F->hasName() &&
-        LibInfo->getLibFunc(*F, Func) && LibInfo->hasOptimizedCodeGen(Func)) {
+    LibFunc Func = !I.isNoBuiltin() && !F->hasLocalLinkage() && F->hasName()
+                       ? LibInfo->getLibFunc(*F)
+                       : NotLibFunc;
+    if (LibInfo->hasOptimizedCodeGen(Func)) {
       switch (Func) {
       default: break;
       case LibFunc_bcmp:

--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -661,8 +661,7 @@ Expected<std::unique_ptr<InputFile>> InputFile::create(MemoryBufferRef Object) {
 bool InputFile::Symbol::isLibcall(
     const TargetLibraryInfo &TLI,
     const RTLIB::RuntimeLibcallsInfo &Libcalls) const {
-  LibFunc F;
-  if (TLI.getLibFunc(IRName, F) && TLI.has(F))
+  if (TLI.has(TLI.getLibFunc(IRName)))
     return true;
   return Libcalls.getSupportedLibcallImpl(IRName) != RTLIB::Unsupported;
 }

--- a/llvm/lib/Target/WebAssembly/WebAssemblyMemIntrinsicResults.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyMemIntrinsicResults.cpp
@@ -184,8 +184,7 @@ bool WebAssemblyMemIntrinsicResultsImpl::optimizeCall(
   if (!CallReturnsInput)
     return false;
 
-  LibFunc Func;
-  if (!LibInfo->getLibFunc(Name, Func))
+  if (LibInfo->getLibFunc(Name) == NotLibFunc)
     return false;
 
   Register FromReg = MI.getOperand(2).getReg();

--- a/llvm/lib/Target/WebAssembly/WebAssemblyPeephole.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyPeephole.cpp
@@ -152,8 +152,7 @@ static bool peephole(MachineFunction &MF, TargetLibraryInfo &LibInfo,
         if (Op1.isSymbol()) {
           StringRef Name(Op1.getSymbolName());
           if (Name == MemcpyName || Name == MemmoveName || Name == MemsetName) {
-            LibFunc Func;
-            if (LibInfo.getLibFunc(Name, Func)) {
+            if (LibInfo.getLibFunc(Name) != NotLibFunc) {
               const auto &Op2 = MI.getOperand(2);
               if (!Op2.isReg())
                 report_fatal_error("Peephole: call to builtin function with "

--- a/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombine.cpp
+++ b/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombine.cpp
@@ -2110,9 +2110,8 @@ static bool foldLibCalls(Instruction &I, TargetTransformInfo &TTI,
   if (!CalledFunc)
     return false;
 
-  LibFunc LF;
-  if (!TLI.getLibFunc(*CalledFunc, LF) ||
-      !isLibFuncEmittable(CI->getModule(), &TLI, LF))
+  LibFunc LF = TLI.getLibFunc(*CalledFunc);
+  if (!isLibFuncEmittable(CI->getModule(), &TLI, LF))
     return false;
 
   DomTreeUpdater DTU(&DT, DomTreeUpdater::UpdateStrategy::Lazy);

--- a/llvm/lib/Transforms/IPO/Attributor.cpp
+++ b/llvm/lib/Transforms/IPO/Attributor.cpp
@@ -2427,7 +2427,6 @@ void Attributor::identifyDeadInternalFunctions() {
       isModulePass()
           ? nullptr
           : getInfoCache().getTargetLibraryInfoForFunction(*Functions.back());
-  LibFunc LF;
 
   // Identify dead internal functions and delete them. This happens outside
   // the other fixpoint analysis as we might treat potentially dead functions
@@ -2436,7 +2435,8 @@ void Attributor::identifyDeadInternalFunctions() {
 
   SmallVector<Function *, 8> InternalFns;
   for (Function *F : Functions)
-    if (F->hasLocalLinkage() && (isModulePass() || !TLI->getLibFunc(*F, LF)))
+    if (F->hasLocalLinkage() &&
+        (isModulePass() || TLI->getLibFunc(*F) == NotLibFunc))
       InternalFns.push_back(F);
 
   SmallPtrSet<Function *, 8> LiveInternalFns;

--- a/llvm/lib/Transforms/IPO/GlobalOpt.cpp
+++ b/llvm/lib/Transforms/IPO/GlobalOpt.cpp
@@ -2375,8 +2375,7 @@ FindAtExitLibFunc(Module &M,
   TLI = &GetTLI(*Fn);
 
   // Make sure that the function has the correct prototype.
-  LibFunc F;
-  if (!TLI->getLibFunc(*Fn, F) || F != Func)
+  if (TLI->getLibFunc(*Fn) != Func)
     return nullptr;
 
   return Fn;

--- a/llvm/lib/Transforms/IPO/ModuleInliner.cpp
+++ b/llvm/lib/Transforms/IPO/ModuleInliner.cpp
@@ -84,12 +84,10 @@ InlineAdvisor &ModuleInlinerPass::getAdvisor(const ModuleAnalysisManager &MAM,
 }
 
 static bool isKnownLibFunction(Function &F, TargetLibraryInfo &TLI) {
-  LibFunc LF;
-
   // Either this is a normal library function or a "vectorizable"
   // function.  Not using the VFDatabase here because this query
   // is related only to libraries handled via the TLI.
-  return TLI.getLibFunc(F, LF) ||
+  return TLI.getLibFunc(F) != NotLibFunc ||
          TLI.isKnownVectorFunctionInLibrary(F.getName());
 }
 

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -3782,10 +3782,9 @@ isAllocSiteRemovable(Instruction *AI, SmallVectorImpl<Instruction *> &Users,
                  Alignment->isPowerOf2() && Size->urem(*Alignment).isZero();
         };
         auto *CB = dyn_cast<CallBase>(AI);
-        LibFunc TheLibFunc;
-        if (CB && TLI.getLibFunc(*CB->getCalledFunction(), TheLibFunc) &&
-            TLI.has(TheLibFunc) && TheLibFunc == LibFunc_aligned_alloc &&
-            !AlignmentAndSizeKnownValid(CB))
+        if (CB &&
+            TLI.getLibFunc(*CB->getCalledFunction()) == LibFunc_aligned_alloc &&
+            TLI.has(LibFunc_aligned_alloc) && !AlignmentAndSizeKnownValid(CB))
           return std::nullopt;
         Users.emplace_back(I);
         continue;
@@ -4167,8 +4166,7 @@ Instruction *InstCombinerImpl::visitFree(CallInst &FI, Value *Op) {
   // 'operator delete'; there is no 'operator delete' symbol for which we are
   // permitted to invent a call, even if we're passing in a null pointer.
   if (MinimizeSize) {
-    LibFunc Func;
-    if (TLI.getLibFunc(FI, Func) && TLI.has(Func) && Func == LibFunc_free)
+    if (TLI.getLibFunc(FI) == LibFunc_free && TLI.has(LibFunc_free))
       if (Instruction *I = tryToMoveFreeBeforeNullTest(FI, DL))
         return I;
   }

--- a/llvm/lib/Transforms/Instrumentation/AllocToken.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AllocToken.cpp
@@ -399,8 +399,8 @@ AllocToken::shouldInstrumentCall(const CallBase &CB,
   // Ignore nobuiltin of the CallBase, so that we can cover nobuiltin libcalls
   // if requested via isInstrumentableLibFunc(). Note that isAllocationFn() is
   // returning false for nobuiltin calls.
-  LibFunc Func;
-  if (TLI.getLibFunc(*Callee, Func)) {
+  LibFunc Func = TLI.getLibFunc(*Callee);
+  if (Func != NotLibFunc) {
     if (isInstrumentableLibFunc(Func, CB, TLI))
       return Func;
   } else if (Options.Extended && CB.getMetadata(LLVMContext::MD_alloc_token)) {

--- a/llvm/lib/Transforms/Instrumentation/DataFlowSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/DataFlowSanitizer.cpp
@@ -3349,8 +3349,8 @@ void DFSanVisitor::visitCallBase(CallBase &CB) {
   if (F == DFSF.DFS.DFSanVarargWrapperFn.getCallee()->stripPointerCasts())
     return;
 
-  LibFunc LF;
-  if (DFSF.TLI.getLibFunc(CB, LF)) {
+  LibFunc LF = DFSF.TLI.getLibFunc(CB);
+  if (LF != NotLibFunc) {
     // libatomic.a functions need to have special handling because there isn't
     // a good way to intercept them or compile the library with
     // instrumentation.

--- a/llvm/lib/Transforms/Instrumentation/GCOVProfiling.cpp
+++ b/llvm/lib/Transforms/Instrumentation/GCOVProfiling.cpp
@@ -616,8 +616,8 @@ bool GCOVProfiler::AddFlushBeforeForkAndExec() {
     for (auto &I : instructions(F)) {
       if (CallInst *CI = dyn_cast<CallInst>(&I)) {
         if (Function *Callee = CI->getCalledFunction()) {
-          LibFunc LF;
-          if (TLI->getLibFunc(*Callee, LF)) {
+          LibFunc LF = TLI->getLibFunc(*Callee);
+          if (LF != NotLibFunc) {
             if (LF == LibFunc_fork) {
 #if !defined(_WIN32)
               Forks.push_back(CI);

--- a/llvm/lib/Transforms/Instrumentation/MemProfUse.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemProfUse.cpp
@@ -183,8 +183,8 @@ static bool isAllocationWithHotColdVariant(const Function *Callee,
                                            const TargetLibraryInfo &TLI) {
   if (!Callee)
     return false;
-  LibFunc Func;
-  if (!TLI.getLibFunc(*Callee, Func))
+  LibFunc Func = TLI.getLibFunc(*Callee);
+  if (Func == NotLibFunc)
     return false;
   switch (Func) {
   case LibFunc_Znwm:

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -7539,8 +7539,8 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
         visitInstruction(CB);
       return;
     }
-    LibFunc LF;
-    if (TLI->getLibFunc(CB, LF)) {
+    LibFunc LF = TLI->getLibFunc(CB);
+    if (LF != NotLibFunc) {
       // libatomic.a functions need to have special handling because there isn't
       // a good way to intercept them or compile the library with
       // instrumentation.

--- a/llvm/lib/Transforms/Instrumentation/NumericalStabilitySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/NumericalStabilitySanitizer.cpp
@@ -811,9 +811,9 @@ static bool shouldCheckArgs(CallBase &CI, const TargetLibraryInfo &TLI,
     return false;
 
   const auto ID = Fn->getIntrinsicID();
-  LibFunc LFunc = LibFunc::NotLibFunc;
+  LibFunc LFunc = TLI.getLibFunc(*Fn);
   // Always check args of unknown functions.
-  if (ID == Intrinsic::ID() && !TLI.getLibFunc(*Fn, LFunc))
+  if (ID == Intrinsic::ID() && LFunc == NotLibFunc)
     return true;
 
   // Do not check args of an `fabs` call that is used for a comparison.
@@ -856,8 +856,7 @@ void NumericalStabilitySanitizer::populateShadowStack(
 
   // Do not create shadow stacks for intrinsics/known lib funcs.
   if (Function *Fn = CI.getCalledFunction()) {
-    LibFunc LFunc;
-    if (Fn->isIntrinsic() || TLI.getLibFunc(*Fn, LFunc))
+    if (Fn->isIntrinsic() || TLI.getLibFunc(*Fn) != NotLibFunc)
       return;
   }
 
@@ -1532,8 +1531,8 @@ const KnownIntrinsic::WidenedIntrinsic *KnownIntrinsic::widen(StringRef Name) {
 // Returns the name of the LLVM intrinsic corresponding to the given function.
 static const char *getIntrinsicFromLibfunc(Function &Fn, Type *VT,
                                            const TargetLibraryInfo &TLI) {
-  LibFunc LFunc;
-  if (!TLI.getLibFunc(Fn, LFunc))
+  LibFunc LFunc = TLI.getLibFunc(Fn);
+  if (LFunc == NotLibFunc)
     return nullptr;
 
   if (const char *Name = KnownIntrinsic::get(LFunc))

--- a/llvm/lib/Transforms/Instrumentation/PGOMemOPSizeOpt.cpp
+++ b/llvm/lib/Transforms/Instrumentation/PGOMemOPSizeOpt.cpp
@@ -146,31 +146,19 @@ struct MemOp {
     return false;
   }
   bool isMemcmp(TargetLibraryInfo &TLI) {
-    LibFunc Func;
-    if (asMI() == nullptr && TLI.getLibFunc(*asCI(), Func) &&
-        Func == LibFunc_memcmp) {
-      return true;
-    }
-    return false;
+    return asMI() == nullptr && TLI.getLibFunc(*asCI()) == LibFunc_memcmp;
   }
   bool isBcmp(TargetLibraryInfo &TLI) {
-    LibFunc Func;
-    if (asMI() == nullptr && TLI.getLibFunc(*asCI(), Func) &&
-        Func == LibFunc_bcmp) {
-      return true;
-    }
-    return false;
+    return asMI() == nullptr && TLI.getLibFunc(*asCI()) == LibFunc_bcmp;
   }
   const char *getName(TargetLibraryInfo &TLI) {
     if (auto MI = asMI())
       return getMIName(MI);
-    LibFunc Func;
-    if (TLI.getLibFunc(*asCI(), Func)) {
-      if (Func == LibFunc_memcmp)
-        return "memcmp";
-      if (Func == LibFunc_bcmp)
-        return "bcmp";
-    }
+    LibFunc Func = TLI.getLibFunc(*asCI());
+    if (Func == LibFunc_memcmp)
+      return "memcmp";
+    if (Func == LibFunc_bcmp)
+      return "bcmp";
     llvm_unreachable("Must be MemIntrinsic or memcmp/bcmp CallInst");
     return nullptr;
   }
@@ -207,9 +195,8 @@ public:
   }
 
   void visitCallInst(CallInst &CI) {
-    LibFunc Func;
-    if (TLI.getLibFunc(CI, Func) &&
-        (Func == LibFunc_memcmp || Func == LibFunc_bcmp) &&
+    LibFunc Func = TLI.getLibFunc(CI);
+    if ((Func == LibFunc_memcmp || Func == LibFunc_bcmp) &&
         !isa<ConstantInt>(CI.getArgOperand(2))) {
       WorkList.push_back(MemOp(&CI));
     }

--- a/llvm/lib/Transforms/Instrumentation/ValueProfilePlugins.inc
+++ b/llvm/lib/Transforms/Instrumentation/ValueProfilePlugins.inc
@@ -58,9 +58,8 @@ public:
     auto *F = CI.getCalledFunction();
     if (!F)
       return;
-    LibFunc Func;
-    if (TLI.getLibFunc(CI, Func) &&
-        (Func == LibFunc_memcmp || Func == LibFunc_bcmp)) {
+    LibFunc Func = TLI.getLibFunc(CI);
+    if (Func == LibFunc_memcmp || Func == LibFunc_bcmp) {
       Value *Length = CI.getArgOperand(2);
       // Not instrument constant length calls.
       if (isa<ConstantInt>(Length))

--- a/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
@@ -1239,9 +1239,8 @@ DSEState::DSEState(Function &F, AliasAnalysis &AA, MemorySSA &MSSA,
 LocationSize DSEState::strengthenLocationSize(const Instruction *I,
                                               LocationSize Size) const {
   if (auto *CB = dyn_cast<CallBase>(I)) {
-    LibFunc F;
-    if (TLI.getLibFunc(*CB, F) && TLI.has(F) &&
-        (F == LibFunc_memset_chk || F == LibFunc_memcpy_chk)) {
+    LibFunc F = TLI.getLibFunc(*CB);
+    if (TLI.has(F) && (F == LibFunc_memset_chk || F == LibFunc_memcpy_chk)) {
       // Use the precise location size specified by the 3rd argument
       // for determining KillingI overwrites DeadLoc if it is a memset_chk
       // instruction. memset_chk will write either the amount specified as 3rd
@@ -2294,10 +2293,9 @@ bool DSEState::tryFoldIntoCalloc(MemoryDef *Def, const Value *DefUO) {
   auto *InnerCallee = Malloc->getCalledFunction();
   if (!InnerCallee)
     return false;
-  LibFunc Func = NotLibFunc;
+  LibFunc Func = TLI.getLibFunc(*InnerCallee);
   StringRef ZeroedVariantName;
-  if (!TLI.getLibFunc(*InnerCallee, Func) || !TLI.has(Func) ||
-      Func != LibFunc_malloc) {
+  if (Func != LibFunc_malloc || !TLI.has(Func)) {
     Attribute Attr = Malloc->getFnAttr("alloc-variant-zeroed");
     if (!Attr.isValid())
       return false;

--- a/llvm/lib/Transforms/Scalar/ExpandMemCmp.cpp
+++ b/llvm/lib/Transforms/Scalar/ExpandMemCmp.cpp
@@ -977,9 +977,8 @@ static PreservedAnalyses runImpl(Function &F, const TargetLibraryInfo *TLI,
   SmallVector<std::pair<CallInst *, LibFunc>, 8> MemCmpCalls;
   for (Instruction &I : instructions(F)) {
     if (auto *CI = dyn_cast<CallInst>(&I)) {
-      LibFunc Func;
-      if (TLI->getLibFunc(*CI, Func) &&
-          (Func == LibFunc_memcmp || Func == LibFunc_bcmp))
+      LibFunc Func = TLI->getLibFunc(*CI);
+      if (Func == LibFunc_memcmp || Func == LibFunc_bcmp)
         MemCmpCalls.push_back({CI, Func});
     }
   }

--- a/llvm/lib/Transforms/Scalar/PartiallyInlineLibCalls.cpp
+++ b/llvm/lib/Transforms/Scalar/PartiallyInlineLibCalls.cpp
@@ -145,9 +145,11 @@ static bool runPartiallyInlineLibCalls(Function &F, TargetLibraryInfo *TLI,
 
       // Skip if function either has local linkage or is not a known library
       // function.
-      LibFunc LF;
-      if (CalledFunc->hasLocalLinkage() ||
-          !TLI->getLibFunc(*CalledFunc, LF) || !TLI->has(LF))
+      if (CalledFunc->hasLocalLinkage())
+        continue;
+
+      LibFunc LF = TLI->getLibFunc(*CalledFunc);
+      if (!TLI->has(LF))
         continue;
 
       switch (LF) {

--- a/llvm/lib/Transforms/Utils/BuildLibCalls.cpp
+++ b/llvm/lib/Transforms/Utils/BuildLibCalls.cpp
@@ -335,8 +335,8 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Module *M, StringRef Name,
 
 bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
                                          const TargetLibraryInfo &TLI) {
-  LibFunc TheLibFunc;
-  if (!(TLI.getLibFunc(F, TheLibFunc) && TLI.has(TheLibFunc)))
+  LibFunc TheLibFunc = TLI.getLibFunc(F);
+  if (!TLI.has(TheLibFunc))
     return false;
 
   bool Changed = false;
@@ -1600,9 +1600,7 @@ bool llvm::isLibFuncEmittable(const Module *M, const TargetLibraryInfo *TLI,
 
 bool llvm::isLibFuncEmittable(const Module *M, const TargetLibraryInfo *TLI,
                               StringRef Name) {
-  LibFunc TheLibFunc;
-  return TLI->getLibFunc(Name, TheLibFunc) &&
-         isLibFuncEmittable(M, TLI, TheLibFunc);
+  return isLibFuncEmittable(M, TLI, TLI->getLibFunc(Name));
 }
 
 bool llvm::hasFloatFn(const Module *M, const TargetLibraryInfo *TLI, Type *Ty,
@@ -1947,10 +1945,8 @@ Value *llvm::emitUnaryFloatFnCall(Value *Op, const TargetLibraryInfo *TLI,
   SmallString<20> NameBuffer;
   appendTypeSuffix(Op, Name, NameBuffer);
 
-  LibFunc TheLibFunc;
-  TLI->getLibFunc(Name, TheLibFunc);
-
-  return emitUnaryFloatFnCallHelper(Op, TheLibFunc, Name, B, Attrs, TLI);
+  return emitUnaryFloatFnCallHelper(Op, TLI->getLibFunc(Name), Name, B, Attrs,
+                                    TLI);
 }
 
 Value *llvm::emitUnaryFloatFnCall(Value *Op, const TargetLibraryInfo *TLI,
@@ -2000,10 +1996,8 @@ Value *llvm::emitBinaryFloatFnCall(Value *Op1, Value *Op2,
   SmallString<20> NameBuffer;
   appendTypeSuffix(Op1, Name, NameBuffer);
 
-  LibFunc TheLibFunc;
-  TLI->getLibFunc(Name, TheLibFunc);
-
-  return emitBinaryFloatFnCallHelper(Op1, Op2, TheLibFunc, Name, B, Attrs, TLI);
+  return emitBinaryFloatFnCallHelper(Op1, Op2, TLI->getLibFunc(Name), Name, B,
+                                     Attrs, TLI);
 }
 
 Value *llvm::emitBinaryFloatFnCall(Value *Op1, Value *Op2,

--- a/llvm/lib/Transforms/Utils/LibCallsShrinkWrap.cpp
+++ b/llvm/lib/Transforms/Utils/LibCallsShrinkWrap.cpp
@@ -291,11 +291,12 @@ void LibCallsShrinkWrap::checkCandidate(CallInst &CI) {
   if (!CI.use_empty())
     return;
 
-  LibFunc Func;
   Function *Callee = CI.getCalledFunction();
   if (!Callee)
     return;
-  if (!TLI.getLibFunc(*Callee, Func) || !TLI.has(Func))
+
+  LibFunc Func = TLI.getLibFunc(*Callee);
+  if (!TLI.has(Func))
     return;
 
   if (CI.arg_empty())
@@ -485,11 +486,10 @@ void LibCallsShrinkWrap::shrinkWrapCI(CallInst *CI, Value *Cond) {
 
 // Perform the transformation to a single candidate.
 bool LibCallsShrinkWrap::perform(CallInst *CI) {
-  LibFunc Func;
   Function *Callee = CI->getCalledFunction();
   assert(Callee && "perform() should apply to a non-empty callee");
-  TLI.getLibFunc(*Callee, Func);
-  assert(Func && "perform() is not expecting an empty function");
+  LibFunc Func = TLI.getLibFunc(*Callee);
+  assert(Func != NotLibFunc && "perform() is not expecting an empty function");
 
   if (performCallDomainErrorOnly(CI, Func) || performCallRangeErrorOnly(CI, Func))
     return true;

--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -3355,12 +3355,7 @@ bool llvm::callsGCLeafFunction(const CallBase *Call,
   // Lib calls can be materialized by some passes, and won't be
   // marked as 'gc-leaf-function.' All available Libcalls are
   // GC-leaf.
-  LibFunc LF;
-  if (TLI.getLibFunc(*Call, LF)) {
-    return TLI.has(LF);
-  }
-
-  return false;
+  return TLI.has(TLI.getLibFunc(*Call));
 }
 
 void llvm::copyNonnullMetadata(const LoadInst &OldLI, MDNode *N,
@@ -3919,9 +3914,8 @@ bool llvm::recognizeBSwapOrBitReverseIdiom(
 void llvm::maybeMarkSanitizerLibraryCallNoBuiltin(
     CallInst *CI, const TargetLibraryInfo *TLI) {
   Function *F = CI->getCalledFunction();
-  LibFunc Func;
   if (F && !F->hasLocalLinkage() && F->hasName() &&
-      TLI->getLibFunc(F->getName(), Func) && TLI->hasOptimizedCodeGen(Func) &&
+      TLI->hasOptimizedCodeGen(TLI->getLibFunc(F->getName())) &&
       !F->doesNotAccessMemory())
     CI->addFnAttr(Attribute::NoBuiltin);
 }

--- a/llvm/lib/Transforms/Utils/MemoryOpRemark.cpp
+++ b/llvm/lib/Transforms/Utils/MemoryOpRemark.cpp
@@ -51,8 +51,8 @@ bool MemoryOpRemark::canHandle(const Instruction *I, const TargetLibraryInfo &TL
     if (!CF->hasName())
       return false;
 
-    LibFunc LF;
-    bool KnownLibCall = TLI.getLibFunc(*CF, LF) && TLI.has(LF);
+    LibFunc LF = TLI.getLibFunc(*CF);
+    bool KnownLibCall = TLI.has(LF);
     if (!KnownLibCall)
       return false;
 
@@ -248,8 +248,8 @@ void MemoryOpRemark::visitCall(const CallInst &CI) {
   if (!F)
     return visitUnknown(CI);
 
-  LibFunc LF;
-  bool KnownLibCall = TLI.getLibFunc(*F, LF) && TLI.has(LF);
+  LibFunc LF = TLI.getLibFunc(*F);
+  bool KnownLibCall = TLI.has(LF);
   auto R = makeRemark(RemarkPass.data(), remarkName(RK_Call), &CI);
   visitCallee(F, KnownLibCall, *R);
   visitKnownLibCall(CI, LF, *R);

--- a/llvm/lib/Transforms/Utils/MetaRenamer.cpp
+++ b/llvm/lib/Transforms/Utils/MetaRenamer.cpp
@@ -157,10 +157,9 @@ void MetaRename(Module &M,
   // Leave library functions alone because their presence or absence could
   // affect the behavior of other passes.
   auto ExcludeLibFuncs = [&](Function &F) {
-    LibFunc Tmp;
     StringRef Name = F.getName();
     return F.isIntrinsic() || (!Name.empty() && Name[0] == 1) ||
-           GetTLI(F).getLibFunc(F, Tmp) ||
+           GetTLI(F).getLibFunc(F) != NotLibFunc ||
            IsNameExcluded(Name, ExcludedFuncPrefixes);
   };
 

--- a/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
@@ -1745,8 +1745,8 @@ Value *LibCallSimplifier::maybeOptimizeNoBuiltinOperatorNew(CallInst *CI,
   Function *Callee = CI->getCalledFunction();
   if (!Callee)
     return nullptr;
-  LibFunc Func;
-  if (!TLI->getLibFunc(*Callee, Func))
+  LibFunc Func = TLI->getLibFunc(*Callee);
+  if (Func == NotLibFunc)
     return nullptr;
   switch (Func) {
   case LibFunc_Znwm:
@@ -2186,11 +2186,10 @@ Value *LibCallSimplifier::replacePowWithExp(CallInst *Pow, IRBuilderBase &B) {
   // TODO: Handle exp10() when more targets have it available.
   CallInst *BaseFn = dyn_cast<CallInst>(Base);
   if (BaseFn && BaseFn->hasOneUse() && BaseFn->isFast() && Pow->isFast()) {
-    LibFunc LibFn;
-
     Function *CalleeFn = BaseFn->getCalledFunction();
-    if (CalleeFn && TLI->getLibFunc(CalleeFn->getName(), LibFn) &&
-        isLibFuncEmittable(M, TLI, LibFn)) {
+    LibFunc LibFn =
+        CalleeFn ? TLI->getLibFunc(CalleeFn->getName()) : NotLibFunc;
+    if (isLibFuncEmittable(M, TLI, LibFn)) {
       StringRef ExpName;
       Intrinsic::ID ID;
       Value *ExpFn;
@@ -2605,7 +2604,8 @@ Value *LibCallSimplifier::optimizeLog(CallInst *Log, IRBuilderBase &B) {
   LibFunc LogLb, ExpLb, Exp2Lb, Exp10Lb, PowLb;
 
   // This is only applicable to log(), log2(), log10().
-  if (TLI->getLibFunc(LogNm, LogLb)) {
+  LogLb = TLI->getLibFunc(LogNm);
+  if (LogLb != NotLibFunc) {
     switch (LogLb) {
     case LibFunc_logf:
       LogID = Intrinsic::log;
@@ -2721,8 +2721,7 @@ Value *LibCallSimplifier::optimizeLog(CallInst *Log, IRBuilderBase &B) {
   B.setFastMathFlags(FastMathFlags::getFast());
 
   Intrinsic::ID ArgID = Arg->getIntrinsicID();
-  LibFunc ArgLb = NotLibFunc;
-  TLI->getLibFunc(*Arg, ArgLb);
+  LibFunc ArgLb = TLI->getLibFunc(*Arg);
 
   // log(pow(x,y)) -> y*log(x)
   AttributeList NoAttrs;
@@ -2777,12 +2776,12 @@ Value *LibCallSimplifier::mergeSqrtToExp(CallInst *CI, IRBuilderBase &B) {
   if (!Arg || !Arg->hasAllowReassoc() || !Arg->hasOneUse())
     return nullptr;
   Intrinsic::ID ArgID = Arg->getIntrinsicID();
-  LibFunc ArgLb = NotLibFunc;
-  TLI->getLibFunc(*Arg, ArgLb);
+  LibFunc ArgLb = TLI->getLibFunc(*Arg);
 
   LibFunc SqrtLb, ExpLb, Exp2Lb, Exp10Lb;
 
-  if (TLI->getLibFunc(SqrtFn->getName(), SqrtLb))
+  SqrtLb = TLI->getLibFunc(SqrtFn->getName());
+  if (SqrtLb != NotLibFunc)
     switch (SqrtLb) {
     case LibFunc_sqrtf:
       ExpLb = LibFunc_expf;
@@ -2951,10 +2950,9 @@ Value *LibCallSimplifier::optimizeTrigInversionPairs(CallInst *CI,
   // sinh(asinh(x)) -> x
   // asinh(sinh(x)) -> x
   // cosh(acosh(x)) -> x
-  LibFunc Func;
   Function *F = OpC->getCalledFunction();
-  if (F && TLI->getLibFunc(F->getName(), Func) &&
-      isLibFuncEmittable(M, TLI, Func)) {
+  LibFunc Func = F ? TLI->getLibFunc(F->getName()) : NotLibFunc;
+  if (isLibFuncEmittable(M, TLI, Func)) {
     LibFunc inverseFunc = llvm::StringSwitch<LibFunc>(Callee->getName())
                               .Case("tan", LibFunc_atan)
                               .Case("atanh", LibFunc_tanh)
@@ -3010,8 +3008,7 @@ static bool insertSinCosCall(IRBuilderBase &B, Function *OrigCallee, Value *Arg,
 
   if (!isLibFuncEmittable(M, TLI, Name))
     return false;
-  LibFunc TheLibFunc;
-  TLI->getLibFunc(Name, TheLibFunc);
+  LibFunc TheLibFunc = TLI->getLibFunc(Name);
   FunctionCallee Callee = getOrInsertLibFunc(
       M, *TLI, TheLibFunc, OrigCallee->getAttributes(), ResTy, ArgTy);
 
@@ -3163,10 +3160,8 @@ void LibCallSimplifier::classifyArgUse(
 
   Module *M = CI->getModule();
   Function *Callee = CI->getCalledFunction();
-  LibFunc Func;
-  if (!Callee || !TLI->getLibFunc(*Callee, Func) ||
-      !isLibFuncEmittable(M, TLI, Func) ||
-      !isTrigLibCall(CI))
+  LibFunc Func = Callee ? TLI->getLibFunc(*Callee) : NotLibFunc;
+  if (!isLibFuncEmittable(M, TLI, Func) || !isTrigLibCall(CI))
     return;
 
   if (IsFloat) {
@@ -3943,11 +3938,11 @@ bool LibCallSimplifier::hasFloatVersion(const Module *M, StringRef FuncName) {
 Value *LibCallSimplifier::optimizeStringMemoryLibCall(CallInst *CI,
                                                       IRBuilderBase &Builder) {
   Module *M = CI->getModule();
-  LibFunc Func;
   Function *Callee = CI->getCalledFunction();
+  LibFunc Func = TLI->getLibFunc(*Callee);
 
   // Check for string/memory library functions.
-  if (TLI->getLibFunc(*Callee, Func) && isLibFuncEmittable(M, TLI, Func)) {
+  if (isLibFuncEmittable(M, TLI, Func)) {
     // Make sure we never change the calling convention.
     assert(
         (ignoreCallingConv(Func) ||
@@ -4236,8 +4231,8 @@ Value *LibCallSimplifier::optimizeCall(CallInst *CI, IRBuilderBase &Builder) {
     return maybeOptimizeNoBuiltinOperatorNew(CI, Builder);
   }
 
-  LibFunc Func;
   Function *Callee = CI->getCalledFunction();
+  LibFunc Func = TLI->getLibFunc(*Callee);
   bool IsCallingConvC = TargetLibraryInfoImpl::isCallingConvCCompatible(CI);
 
   SmallVector<OperandBundleDef, 2> OpBundles;
@@ -4297,7 +4292,7 @@ Value *LibCallSimplifier::optimizeCall(CallInst *CI, IRBuilderBase &Builder) {
     return SimplifiedFortifiedCI;
 
   // Then check for known library functions.
-  if (TLI->getLibFunc(*Callee, Func) && isLibFuncEmittable(M, TLI, Func)) {
+  if (isLibFuncEmittable(M, TLI, Func)) {
     // We never change the calling convention.
     if (!ignoreCallingConv(Func) && !IsCallingConvC)
       return nullptr;
@@ -4684,7 +4679,6 @@ Value *FortifiedLibCallSimplifier::optimizeCall(CallInst *CI,
   //
   // PR23093.
 
-  LibFunc Func;
   Function *Callee = CI->getCalledFunction();
   bool IsCallingConvC = TargetLibraryInfoImpl::isCallingConvCCompatible(CI);
 
@@ -4696,7 +4690,8 @@ Value *FortifiedLibCallSimplifier::optimizeCall(CallInst *CI,
 
   // First, check that this is a known library functions and that the prototype
   // is correct.
-  if (!TLI->getLibFunc(*Callee, Func))
+  LibFunc Func = TLI->getLibFunc(*Callee);
+  if (Func == NotLibFunc)
     return nullptr;
 
   // We never change the calling convention.

--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
@@ -936,11 +936,10 @@ bool LoopVectorizationLegality::canVectorizeInstr(Instruction &I) {
         (!VFDatabase::getMappings(*CI).empty() || isTLIScalarize(*TLI, *CI)))) {
     // If the call is a recognized math libary call, it is likely that
     // we can vectorize it given loosened floating-point constraints.
-    LibFunc Func;
     bool IsMathLibCall =
         TLI && CI->getCalledFunction() && CI->getType()->isFloatingPointTy() &&
-        TLI->getLibFunc(CI->getCalledFunction()->getName(), Func) &&
-        TLI->hasOptimizedCodeGen(Func);
+        TLI->hasOptimizedCodeGen(
+            TLI->getLibFunc(CI->getCalledFunction()->getName()));
 
     if (IsMathLibCall) {
       // TODO: Ideally, we should not use clang-specific language here,

--- a/llvm/test/Analysis/BranchProbabilityInfo/libfunc_call.ll
+++ b/llvm/test/Analysis/BranchProbabilityInfo/libfunc_call.ll
@@ -1,11 +1,12 @@
 ; RUN: opt < %s -passes='print<branch-prob>' -disable-output 2>&1 | FileCheck %s
+target datalayout = "e-p:32:32"
 
 declare i32 @strcmp(ptr, ptr)
 declare i32 @strncmp(ptr, ptr, i32)
 declare i32 @strcasecmp(ptr, ptr)
 declare i32 @strncasecmp(ptr, ptr, i32)
-declare i32 @memcmp(ptr, ptr)
-declare i32 @bcmp(ptr, ptr)
+declare i32 @memcmp(ptr, ptr, i32)
+declare i32 @bcmp(ptr, ptr, i32)
 declare i32 @nonstrcmp(ptr, ptr)
 
 
@@ -194,7 +195,7 @@ exit:
 define i32 @test_memcmp_sgt(ptr %p, ptr %q) {
 ; CHECK: Printing analysis {{.*}} for function 'test_memcmp_sgt'
 entry:
-  %val = call i32 @memcmp(ptr %p, ptr %q)
+  %val = call i32 @memcmp(ptr %p, ptr %q, i32 4)
   %cond = icmp sgt i32 %val, 0
   br i1 %cond, label %then, label %else
 ; CHECK: edge %entry -> %then probability is 0x40000000 / 0x80000000 = 50.00%
@@ -288,7 +289,7 @@ exit:
 define i32 @test_bcmp_eq(ptr %p, ptr %q) {
 ; CHECK: Printing analysis {{.*}} for function 'test_bcmp_eq'
 entry:
-  %val = call i32 @bcmp(ptr %p, ptr %q)
+  %val = call i32 @bcmp(ptr %p, ptr %q, i32 4)
   %cond = icmp eq i32 %val, 0
   br i1 %cond, label %then, label %else
 ; CHECK: edge %entry -> %then probability is 0x30000000 / 0x80000000 = 37.50%
@@ -310,7 +311,7 @@ exit:
 define i32 @test_bcmp_eq5(ptr %p, ptr %q) {
 ; CHECK: Printing analysis {{.*}} for function 'test_bcmp_eq5'
 entry:
-  %val = call i32 @bcmp(ptr %p, ptr %q)
+  %val = call i32 @bcmp(ptr %p, ptr %q, i32 4)
   %cond = icmp eq i32 %val, 5
   br i1 %cond, label %then, label %else
 ; CHECK: edge %entry -> %then probability is 0x30000000 / 0x80000000 = 37.50%
@@ -334,7 +335,7 @@ exit:
 define i32 @test_bcmp_ne(ptr %p, ptr %q) {
 ; CHECK: Printing analysis {{.*}} for function 'test_bcmp_ne'
 entry:
-  %val = call i32 @bcmp(ptr %p, ptr %q)
+  %val = call i32 @bcmp(ptr %p, ptr %q, i32 4)
   %cond = icmp ne i32 %val, 0
   br i1 %cond, label %then, label %else
 ; CHECK: edge %entry -> %then probability is 0x50000000 / 0x80000000 = 62.50%

--- a/llvm/tools/llubi/lib/Interpreter.cpp
+++ b/llvm/tools/llubi/lib/Interpreter.cpp
@@ -1895,10 +1895,9 @@ public:
 
   AnyValue callLibFunc(CallBase &CB, Function *ResolvedCallee,
                        ArrayRef<AnyValue> CalleeArgs) {
-    LibFunc LF;
+    LibFunc LF = CurrentFrame->TLI.getLibFunc(*ResolvedCallee);
     // Respect nobuiltin attributes on call site.
-    if (CB.isNoBuiltin() ||
-        !CurrentFrame->TLI.getLibFunc(*ResolvedCallee, LF)) {
+    if (CB.isNoBuiltin() || LF == NotLibFunc) {
       Handler.onUnrecognizedInstruction(CB);
       setFailed();
       return AnyValue();

--- a/llvm/tools/opt/optdriver.cpp
+++ b/llvm/tools/opt/optdriver.cpp
@@ -734,9 +734,8 @@ optMain(int argc, char **argv,
     TLII.disableAllFunctions();
   else {
     // Disable individual builtin functions in TargetLibraryInfo.
-    LibFunc F;
     for (const std::string &FuncName : DisableBuiltins) {
-      if (TLII.getLibFunc(FuncName, F))
+      if (LibFunc F = TLII.getLibFunc(FuncName); F != NotLibFunc)
         TLII.setUnavailable(F);
       else {
         errs() << argv[0] << ": cannot disable nonexistent builtin function "
@@ -746,7 +745,7 @@ optMain(int argc, char **argv,
     }
 
     for (const std::string &FuncName : EnableBuiltins) {
-      if (TLII.getLibFunc(FuncName, F))
+      if (LibFunc F = TLII.getLibFunc(FuncName); F != NotLibFunc)
         TLII.setAvailable(F);
       else {
         errs() << argv[0] << ": cannot enable nonexistent builtin function "

--- a/llvm/tools/opt/optdriver.cpp
+++ b/llvm/tools/opt/optdriver.cpp
@@ -735,7 +735,7 @@ optMain(int argc, char **argv,
   else {
     // Disable individual builtin functions in TargetLibraryInfo.
     for (const std::string &FuncName : DisableBuiltins) {
-      if (LibFunc F = TLII.getLibFunc(FuncName); F != NotLibFunc)
+      if (LibFunc F = TLII.getLibFunc(FuncName))
         TLII.setUnavailable(F);
       else {
         errs() << argv[0] << ": cannot disable nonexistent builtin function "
@@ -745,7 +745,7 @@ optMain(int argc, char **argv,
     }
 
     for (const std::string &FuncName : EnableBuiltins) {
-      if (LibFunc F = TLII.getLibFunc(FuncName); F != NotLibFunc)
+      if (LibFunc F = TLII.getLibFunc(FuncName))
         TLII.setAvailable(F);
       else {
         errs() << argv[0] << ": cannot enable nonexistent builtin function "

--- a/llvm/unittests/Analysis/TargetLibraryInfoTest.cpp
+++ b/llvm/unittests/Analysis/TargetLibraryInfoTest.cpp
@@ -47,8 +47,7 @@ protected:
     if (!FDecl)
       return ::testing::AssertionFailure() << ExpectedLFName << " not found";
 
-    LibFunc F;
-    if (!TLI.getLibFunc(*FDecl, F))
+    if (TLI.getLibFunc(*FDecl) == NotLibFunc)
       return ::testing::AssertionFailure() << ExpectedLFName << " invalid";
 
     return ::testing::AssertionSuccess() << ExpectedLFName << " is LibFunc";
@@ -721,8 +720,8 @@ protected:
 
   /// Returns the TLI function name for the given \p Opcode and type \p Ty.
   StringRef getScalarName(unsigned int Opcode, Type *Ty) {
-    LibFunc Func;
-    if (!TLI->getLibFunc(Opcode, Ty, Func))
+    LibFunc Func = TLI->getLibFunc(Opcode, Ty);
+    if (Func == NotLibFunc)
       return "";
     return TLI->getName(Func);
   }


### PR DESCRIPTION
getLibFunc returned a bool and wrote the result to a LibFunc output argument, which is only set when the lookup succeeds. Callers that ignored the result read an uninitialized LibFunc, and a few in-tree callers did exactly that.

Return the LibFunc instead, and NotLibFunc when the name is not a known library function, so there is no way to get an uninitialized value out of it.

Assisted-by: Opus