### PR TITLE
[Mips] Mark immediate branch macros as having delay slots

### DIFF
--- a/llvm/lib/Target/Mips/MipsInstrInfo.td
+++ b/llvm/lib/Target/Mips/MipsInstrInfo.td
@@ -3025,7 +3025,7 @@ def BLEUL: CondBranchPseudo<"bleul">, ISA_MIPS2_NOT_32R6_64R6;
 def BGEUL: CondBranchPseudo<"bgeul">, ISA_MIPS2_NOT_32R6_64R6;
 def BGTUL: CondBranchPseudo<"bgtul">, ISA_MIPS2_NOT_32R6_64R6;
 
-let isCTI = 1 in
+let hasDelaySlot = 1, isCTI = 1 in
 class CondBranchImmPseudo<string instr_asm> :
   MipsAsmPseudoInst<(outs), (ins GPR32Opnd:$rs, ConstantImm64:$imm, brtarget:$offset),
                     !strconcat(instr_asm, "\t$rs, $imm, $offset")>;

--- a/llvm/test/MC/Mips/macro-bcc-imm-delay-slot.s
+++ b/llvm/test/MC/Mips/macro-bcc-imm-delay-slot.s
@@ -1,0 +1,33 @@
+# RUN: llvm-mc %s -triple=mipsel -mcpu=mips32r2 -filetype=obj -o - | \
+# RUN:   llvm-objdump -d -z - | FileCheck %s
+
+.text
+.set reorder
+reorder:
+  blt $9, -1022, target
+  bne $25, $zero, target
+  nop
+
+.set noreorder
+noreorder:
+  blt $9, -1022, target
+  bne $25, $zero, target
+  nop
+
+target:
+  nop
+
+# CHECK-LABEL: <reorder>:
+# CHECK-NEXT:    addiu $1, $zero, -0x3fe
+# CHECK-NEXT:    slt $1, $9, $1
+# CHECK-NEXT:    bnez $1,
+# CHECK-NEXT:    nop
+# CHECK-NEXT:    bnez $25,
+# CHECK-NEXT:    nop
+
+# CHECK-LABEL: <noreorder>:
+# CHECK-NEXT:    addiu $1, $zero, -0x3fe
+# CHECK-NEXT:    slt $1, $9, $1
+# CHECK-NEXT:    bnez $1,
+# CHECK-NEXT:    bnez $25,
+# CHECK-NEXT:    nop


### PR DESCRIPTION
Immediate conditional branch macros expand to real branches with delay slots, but their pseudo-instruction definitions did not carry `hasDelaySlot`. Mark them consistently with the register forms so IAS inserts a delay-slot `nop` under `.set reorder`.

Adds `llvm/test/MC/Mips/macro-bcc-imm-delay-slot.s` covering reordered and non-reordered expansion.

Fixes #217368