### PR TITLE
[Mips] Use ELF binding when expanding PIC la

### DIFF
--- a/llvm/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
+++ b/llvm/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
@@ -2959,12 +2959,11 @@ bool MipsAsmParser::loadAndAddSymbolAddress(const MCExpr *SymExpr,
     }
 
     bool IsPtr64 = ABI.ArePtrs64bit();
-    bool IsLocalSym =
-        Res.getAddSym()->isTemporary() ||
-        (getContext().isELF()
-             ? static_cast<const MCSymbolELF *>(Res.getAddSym())->getBinding() ==
-                   ELF::STB_LOCAL
-             : Res.getAddSym()->isInSection());
+    bool IsLocalSym = Res.getAddSym()->isTemporary() ||
+                      (getContext().isELF()
+                           ? static_cast<const MCSymbolELF *>(Res.getAddSym())
+                                     ->getBinding() == ELF::STB_LOCAL
+                           : Res.getAddSym()->isInSection());
     // For O32, "$"-prefixed symbols are recognized as temporary while
     // .L-prefixed symbols are not (InternalSymbolPrefix is "$"). Recognize ".L"
     // manually.

--- a/llvm/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
+++ b/llvm/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
@@ -2960,10 +2960,11 @@ bool MipsAsmParser::loadAndAddSymbolAddress(const MCExpr *SymExpr,
 
     bool IsPtr64 = ABI.ArePtrs64bit();
     bool IsLocalSym =
-        Res.getAddSym()->isInSection() || Res.getAddSym()->isTemporary() ||
-        (getContext().isELF() &&
-         static_cast<const MCSymbolELF *>(Res.getAddSym())->getBinding() ==
-             ELF::STB_LOCAL);
+        Res.getAddSym()->isTemporary() ||
+        (getContext().isELF()
+             ? static_cast<const MCSymbolELF *>(Res.getAddSym())->getBinding() ==
+                   ELF::STB_LOCAL
+             : Res.getAddSym()->isInSection());
     // For O32, "$"-prefixed symbols are recognized as temporary while
     // .L-prefixed symbols are not (InternalSymbolPrefix is "$"). Recognize ".L"
     // manually.

--- a/llvm/test/MC/Mips/macro-la-pic-defined-global.s
+++ b/llvm/test/MC/Mips/macro-la-pic-defined-global.s
@@ -1,0 +1,44 @@
+# RUN: llvm-mc %s -triple=mips-unknown-linux -mcpu=mips32r2 \
+# RUN:   -filetype=obj -o - | llvm-readobj -r - | FileCheck --check-prefix=O32 %s
+# RUN: llvm-mc %s -triple=mips-unknown-linux -mcpu=mips32r2 -mattr=+xgot \
+# RUN:   -filetype=obj -o - | llvm-readobj -r - | FileCheck --check-prefix=XGOT %s
+# RUN: llvm-mc %s -triple=mipsn32 -mcpu=mips64r2 \
+# RUN:   -filetype=obj -o - | llvm-readobj -r - | FileCheck --check-prefix=N32 %s
+
+.option pic2
+
+.data
+.globl global_symbol
+global_symbol:
+  .word 0
+
+.local local_symbol
+local_symbol:
+  .word 0
+
+.text
+la $5, global_symbol
+la $25, global_symbol
+la $6, local_symbol
+
+# O32:      Section {{.*}} .rel.text {
+# O32-NEXT:   0x0 R_MIPS_GOT16 global_symbol
+# O32-NEXT:   0x4 R_MIPS_CALL16 global_symbol
+# O32-NEXT:   0x8 R_MIPS_GOT16 .data
+# O32-NEXT:   0xC R_MIPS_LO16 .data
+# O32-NEXT: }
+
+# XGOT:      Section {{.*}} .rel.text {
+# XGOT-NEXT:   0x0 R_MIPS_GOT_HI16 global_symbol
+# XGOT-NEXT:   0x8 R_MIPS_GOT_LO16 global_symbol
+# XGOT-NEXT:   0xC R_MIPS_CALL_HI16 global_symbol
+# XGOT-NEXT:   0x14 R_MIPS_CALL_LO16 global_symbol
+# XGOT-NEXT:   0x18 R_MIPS_GOT16 .data
+# XGOT-NEXT:   0x1C R_MIPS_LO16 .data
+# XGOT-NEXT: }
+
+# N32:      Section {{.*}} .rela.text {
+# N32-NEXT:   0x0 R_MIPS_GOT_DISP global_symbol 0x0
+# N32-NEXT:   0x4 R_MIPS_CALL16 global_symbol 0x0
+# N32-NEXT:   0x8 R_MIPS_GOT_DISP local_symbol 0x0
+# N32-NEXT: }


### PR DESCRIPTION
A symbol already assigned to a section is not necessarily local. Use ELF symbol binding when expanding PIC `la`, retaining the existing section-based fallback for non-ELF targets, so defined default-visible globals use the correct global GOT form.

Adds `llvm/test/MC/Mips/macro-la-pic-defined-global.s` covering global, local, and `$25` call-register expansions.

Fixes #217371