### PR TITLE
[libc] Make remainder functions use the emulated float128 type

### DIFF
--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -463,6 +463,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminl
     libc.src.math.fmod
     libc.src.math.fmodf
+    libc.src.math.fmodf128
     libc.src.math.fmodl
     libc.src.math.fmul
     libc.src.math.fmull
@@ -772,7 +773,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.faddf128
     libc.src.math.fdivf128
     libc.src.math.ffmaf128
-    libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128
     libc.src.math.fromfpf128

--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -463,6 +463,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminl
     libc.src.math.fmod
     libc.src.math.fmodf
+    libc.src.math.fmodf128
     libc.src.math.fmodl
     libc.src.math.fmul
     libc.src.math.fmull
@@ -562,6 +563,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.powf
     libc.src.math.remainder
     libc.src.math.remainderf
+    libc.src.math.remainderf128
     libc.src.math.remainderl
     libc.src.math.remquo
     libc.src.math.remquof
@@ -773,7 +775,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.faddf128
     libc.src.math.fdivf128
     libc.src.math.ffmaf128
-    libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128
     libc.src.math.fromfpf128
@@ -787,7 +788,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
-    libc.src.math.remainderf128
     libc.src.math.remquof128
     libc.src.math.scalblnf128
     libc.src.math.scalbnf128

--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -562,6 +562,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.powf
     libc.src.math.remainder
     libc.src.math.remainderf
+    libc.src.math.remainderf128
     libc.src.math.remainderl
     libc.src.math.remquo
     libc.src.math.remquof
@@ -786,7 +787,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
-    libc.src.math.remainderf128
     libc.src.math.remquof128
     libc.src.math.scalblnf128
     libc.src.math.scalbnf128

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -574,6 +574,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.powf
     libc.src.math.remainder
     libc.src.math.remainderf
+    libc.src.math.remainderf128
     libc.src.math.remainderl
     libc.src.math.remquo
     libc.src.math.remquof
@@ -797,7 +798,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
-    libc.src.math.remainderf128
     libc.src.math.remquof128
     libc.src.math.scalblnf128
     libc.src.math.scalbnf128

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -475,6 +475,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminl
     libc.src.math.fmod
     libc.src.math.fmodf
+    libc.src.math.fmodf128
     libc.src.math.fmodl
     libc.src.math.fmul
     libc.src.math.fmull
@@ -574,6 +575,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.powf
     libc.src.math.remainder
     libc.src.math.remainderf
+    libc.src.math.remainderf128
     libc.src.math.remainderl
     libc.src.math.remquo
     libc.src.math.remquof
@@ -784,7 +786,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.faddf128
     libc.src.math.fdivf128
     libc.src.math.ffmaf128
-    libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128
     libc.src.math.fromfpf128
@@ -798,7 +799,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
-    libc.src.math.remainderf128
     libc.src.math.remquof128
     libc.src.math.scalblnf128
     libc.src.math.scalbnf128

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -475,6 +475,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminl
     libc.src.math.fmod
     libc.src.math.fmodf
+    libc.src.math.fmodf128
     libc.src.math.fmodl
     libc.src.math.fmul
     libc.src.math.fmull
@@ -783,7 +784,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.faddf128
     libc.src.math.fdivf128
     libc.src.math.ffmaf128
-    libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128
     libc.src.math.fromfpf128

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -570,6 +570,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.powf
     libc.src.math.remainder
     libc.src.math.remainderf
+    libc.src.math.remainderf128
     libc.src.math.remainderl
     libc.src.math.remquo
     libc.src.math.remquof
@@ -794,7 +795,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
-    libc.src.math.remainderf128
     libc.src.math.remquof128
     libc.src.math.scalblnf128
     libc.src.math.scalbnf128

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -472,6 +472,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmod
     libc.src.math.fmodf
     # libc.src.math.fmodl
+    libc.src.math.fmodf128
     libc.src.math.fmul
     libc.src.math.fmull
     libc.src.math.frexp
@@ -570,6 +571,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.powf
     libc.src.math.remainder
     libc.src.math.remainderf
+    libc.src.math.remainderf128
     libc.src.math.remainderl
     libc.src.math.remquo
     libc.src.math.remquof
@@ -781,7 +783,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.faddf128
     libc.src.math.fdivf128
     libc.src.math.ffmaf128
-    # libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128
     libc.src.math.fromfpf128
@@ -795,7 +796,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
-    libc.src.math.remainderf128
     libc.src.math.remquof128
     libc.src.math.scalblnf128
     libc.src.math.scalbnf128

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -471,6 +471,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminl
     libc.src.math.fmod
     libc.src.math.fmodf
+    libc.src.math.fmodf128
     # libc.src.math.fmodl
     libc.src.math.fmul
     libc.src.math.fmull
@@ -780,7 +781,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.faddf128
     libc.src.math.fdivf128
     libc.src.math.ffmaf128
-    # libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128
     libc.src.math.fromfpf128

--- a/libc/config/darwin/aarch64/entrypoints.txt
+++ b/libc/config/darwin/aarch64/entrypoints.txt
@@ -282,6 +282,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminl
     libc.src.math.fmod
     libc.src.math.fmodf
+    libc.src.math.fmodf128
     libc.src.math.fmodl
     libc.src.math.fmul
     libc.src.math.fmull
@@ -381,6 +382,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.powf
     libc.src.math.remainder
     libc.src.math.remainderf
+    libc.src.math.remainderf128
     libc.src.math.remainderl
     libc.src.math.remquo
     libc.src.math.remquof
@@ -593,7 +595,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.faddf128
     libc.src.math.fdivf128
     libc.src.math.ffmaf128
-    libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128
     libc.src.math.fromfpf128
@@ -607,7 +608,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
-    libc.src.math.remainderf128
     libc.src.math.remquof128
     libc.src.math.scalblnf128
     libc.src.math.scalbnf128

--- a/libc/config/darwin/aarch64/entrypoints.txt
+++ b/libc/config/darwin/aarch64/entrypoints.txt
@@ -381,6 +381,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.powf
     libc.src.math.remainder
     libc.src.math.remainderf
+    libc.src.math.remainderf128
     libc.src.math.remainderl
     libc.src.math.remquo
     libc.src.math.remquof
@@ -606,7 +607,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
-    libc.src.math.remainderf128
     libc.src.math.remquof128
     libc.src.math.scalblnf128
     libc.src.math.scalbnf128

--- a/libc/config/darwin/aarch64/entrypoints.txt
+++ b/libc/config/darwin/aarch64/entrypoints.txt
@@ -282,6 +282,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminl
     libc.src.math.fmod
     libc.src.math.fmodf
+    libc.src.math.fmodf128
     libc.src.math.fmodl
     libc.src.math.fmul
     libc.src.math.fmull
@@ -592,7 +593,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.faddf128
     libc.src.math.fdivf128
     libc.src.math.ffmaf128
-    libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128
     libc.src.math.fromfpf128

--- a/libc/config/darwin/x86_64/entrypoints.txt
+++ b/libc/config/darwin/x86_64/entrypoints.txt
@@ -174,6 +174,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     #libc.src.math.fminl
     #libc.src.math.fmod
     #libc.src.math.fmodf
+    #libc.src.math.fmodf128
     #libc.src.math.frexp
     #libc.src.math.frexpf
     #libc.src.math.frexpl
@@ -234,6 +235,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     #libc.src.math.nextupf128
     #libc.src.math.remainderf
     #libc.src.math.remainder
+    #libc.src.math.remainderf128
     #libc.src.math.remainderl
     #libc.src.math.remquof
     #libc.src.math.remquo

--- a/libc/config/darwin/x86_64/entrypoints.txt
+++ b/libc/config/darwin/x86_64/entrypoints.txt
@@ -234,6 +234,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     #libc.src.math.nexttowardl
     #libc.src.math.nextupf128
     #libc.src.math.remainderf
+    #libc.src.math.remainderf128
     #libc.src.math.remainder
     #libc.src.math.remainderl
     #libc.src.math.remquof

--- a/libc/config/darwin/x86_64/entrypoints.txt
+++ b/libc/config/darwin/x86_64/entrypoints.txt
@@ -174,6 +174,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     #libc.src.math.fminl
     #libc.src.math.fmod
     #libc.src.math.fmodf
+    #libc.src.math.fmodf128
     #libc.src.math.frexp
     #libc.src.math.frexpf
     #libc.src.math.frexpl

--- a/libc/config/freebsd/x86_64/entrypoints.txt
+++ b/libc/config/freebsd/x86_64/entrypoints.txt
@@ -214,6 +214,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminimum_mag_num
     libc.src.math.fminimum_mag_numf
     libc.src.math.fminimum_mag_numl
+    libc.src.math.fmodf128
     libc.src.math.fmul
     libc.src.math.fmod
     libc.src.math.fmodf
@@ -285,6 +286,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.powf
     libc.src.math.remainderf
     libc.src.math.remainder
+    libc.src.math.remainderf128
     libc.src.math.remainderl
     libc.src.math.remquof
     libc.src.math.remquo
@@ -533,7 +535,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.faddf128
     libc.src.math.fdivf128
     libc.src.math.ffmaf128
-    libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128
     libc.src.math.fromfpf128
@@ -547,7 +548,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
-    libc.src.math.remainderf128
     libc.src.math.remquof128
     libc.src.math.scalblnf128
     libc.src.math.scalbnf128

--- a/libc/config/freebsd/x86_64/entrypoints.txt
+++ b/libc/config/freebsd/x86_64/entrypoints.txt
@@ -284,6 +284,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.pow
     libc.src.math.powf
     libc.src.math.remainderf
+    libc.src.math.remainderf128
     libc.src.math.remainder
     libc.src.math.remainderl
     libc.src.math.remquof
@@ -545,7 +546,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
-    libc.src.math.remainderf128
     libc.src.math.remquof128
     libc.src.math.scalblnf128
     libc.src.math.scalbnf128

--- a/libc/config/freebsd/x86_64/entrypoints.txt
+++ b/libc/config/freebsd/x86_64/entrypoints.txt
@@ -217,6 +217,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmul
     libc.src.math.fmod
     libc.src.math.fmodf
+    libc.src.math.fmodf128
     libc.src.math.fmodl
     libc.src.math.frexp
     libc.src.math.frexpf
@@ -531,7 +532,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.faddf128
     libc.src.math.fdivf128
     libc.src.math.ffmaf128
-    libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128
     libc.src.math.fromfpf128

--- a/libc/config/gpu/amdgpu/entrypoints.txt
+++ b/libc/config/gpu/amdgpu/entrypoints.txt
@@ -505,6 +505,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.powf
     libc.src.math.remainder
     libc.src.math.remainderf
+    libc.src.math.remainderf128
     libc.src.math.remainderl
     libc.src.math.remquo
     libc.src.math.remquof

--- a/libc/config/gpu/amdgpu/entrypoints.txt
+++ b/libc/config/gpu/amdgpu/entrypoints.txt
@@ -410,6 +410,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminl
     libc.src.math.fmod
     libc.src.math.fmodf
+    libc.src.math.fmodf128
     libc.src.math.fmodl
     libc.src.math.fmul
     libc.src.math.fmull

--- a/libc/config/gpu/amdgpu/entrypoints.txt
+++ b/libc/config/gpu/amdgpu/entrypoints.txt
@@ -410,6 +410,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminl
     libc.src.math.fmod
     libc.src.math.fmodf
+    libc.src.math.fmodf128
     libc.src.math.fmodl
     libc.src.math.fmul
     libc.src.math.fmull
@@ -505,6 +506,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.powf
     libc.src.math.remainder
     libc.src.math.remainderf
+    libc.src.math.remainderf128
     libc.src.math.remainderl
     libc.src.math.remquo
     libc.src.math.remquof

--- a/libc/config/gpu/nvptx/entrypoints.txt
+++ b/libc/config/gpu/nvptx/entrypoints.txt
@@ -406,6 +406,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminl
     libc.src.math.fmod
     libc.src.math.fmodf
+    libc.src.math.fmodf128
     libc.src.math.fmodl
     libc.src.math.fmul
     libc.src.math.fmull
@@ -502,6 +503,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.powf
     libc.src.math.remainder
     libc.src.math.remainderf
+    libc.src.math.remainderf128
     libc.src.math.remainderl
     libc.src.math.remquo
     libc.src.math.remquof

--- a/libc/config/gpu/nvptx/entrypoints.txt
+++ b/libc/config/gpu/nvptx/entrypoints.txt
@@ -502,6 +502,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.powf
     libc.src.math.remainder
     libc.src.math.remainderf
+    libc.src.math.remainderf128
     libc.src.math.remainderl
     libc.src.math.remquo
     libc.src.math.remquof

--- a/libc/config/gpu/nvptx/entrypoints.txt
+++ b/libc/config/gpu/nvptx/entrypoints.txt
@@ -406,6 +406,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminl
     libc.src.math.fmod
     libc.src.math.fmodf
+    libc.src.math.fmodf128
     libc.src.math.fmodl
     libc.src.math.fmul
     libc.src.math.fmull

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -628,6 +628,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminl
     libc.src.math.fmod
     libc.src.math.fmodf
+    libc.src.math.fmodf128
     libc.src.math.fmodl
     libc.src.math.fmul
     libc.src.math.fmull
@@ -931,7 +932,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.faddf128
     libc.src.math.fdivf128
     libc.src.math.ffmaf128
-    libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128
     libc.src.math.fromfpf128

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -727,6 +727,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.powf
     libc.src.math.remainder
     libc.src.math.remainderf
+    libc.src.math.remainderf128
     libc.src.math.remainderl
     libc.src.math.remquo
     libc.src.math.remquof
@@ -945,7 +946,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
-    libc.src.math.remainderf128
     libc.src.math.remquof128
     libc.src.math.scalblnf128
     libc.src.math.scalbnf128

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -643,6 +643,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminl
     libc.src.math.fmod
     libc.src.math.fmodf
+    libc.src.math.fmodf128
     libc.src.math.fmodl
     libc.src.math.fmul
     libc.src.math.fmull
@@ -742,6 +743,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.powf
     libc.src.math.remainder
     libc.src.math.remainderf
+    libc.src.math.remainderf128
     libc.src.math.remainderl
     libc.src.math.remquo
     libc.src.math.remquof
@@ -947,7 +949,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.faddf128
     libc.src.math.fdivf128
     libc.src.math.ffmaf128
-    libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128
     libc.src.math.fromfpf128
@@ -961,7 +962,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
-    libc.src.math.remainderf128
     libc.src.math.remquof128
     libc.src.math.scalblnf128
     libc.src.math.scalbnf128

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -541,6 +541,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.powf
     libc.src.math.remainder
     libc.src.math.remainderf
+    libc.src.math.remainderf128
     libc.src.math.remainderl
     libc.src.math.remquo
     libc.src.math.remquof

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -455,6 +455,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminl
     libc.src.math.fmod
     libc.src.math.fmodf
+    libc.src.math.fmodf128
     libc.src.math.fmul
     libc.src.math.frexp
     libc.src.math.frexpf

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -468,6 +468,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminl
     libc.src.math.fmod
     libc.src.math.fmodf
+    libc.src.math.fmodf128
     libc.src.math.fmul
     libc.src.math.frexp
     libc.src.math.frexpf
@@ -554,6 +555,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.powf
     libc.src.math.remainder
     libc.src.math.remainderf
+    libc.src.math.remainderf128
     libc.src.math.remainderl
     libc.src.math.remquo
     libc.src.math.remquof

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -697,6 +697,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminl
     libc.src.math.fmod
     libc.src.math.fmodf
+    libc.src.math.fmodf128
     libc.src.math.fmodl
     libc.src.math.fmul
     libc.src.math.fmull
@@ -1017,7 +1018,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.faddf128
     libc.src.math.fdivf128
     libc.src.math.ffmaf128
-    libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128
     libc.src.math.fromfpf128

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -796,6 +796,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.powf
     libc.src.math.remainder
     libc.src.math.remainderf
+    libc.src.math.remainderf128
     libc.src.math.remainderl
     libc.src.math.remquo
     libc.src.math.remquof
@@ -1031,7 +1032,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
-    libc.src.math.remainderf128
     libc.src.math.remquof128
     libc.src.math.scalblnf128
     libc.src.math.scalbnf128

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -712,6 +712,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminl
     libc.src.math.fmod
     libc.src.math.fmodf
+    libc.src.math.fmodf128
     libc.src.math.fmodl
     libc.src.math.fmul
     libc.src.math.fmull
@@ -811,6 +812,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.powf
     libc.src.math.remainder
     libc.src.math.remainderf
+    libc.src.math.remainderf128
     libc.src.math.remainderl
     libc.src.math.remquo
     libc.src.math.remquof
@@ -1033,7 +1035,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.faddf128
     libc.src.math.fdivf128
     libc.src.math.ffmaf128
-    libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128
     libc.src.math.fromfpf128
@@ -1047,7 +1048,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
-    libc.src.math.remainderf128
     libc.src.math.remquof128
     libc.src.math.scalblnf128
     libc.src.math.scalbnf128

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -805,6 +805,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.powf
     libc.src.math.remainder
     libc.src.math.remainderf
+    libc.src.math.remainderf128
     libc.src.math.remainderl
     libc.src.math.remquo
     libc.src.math.remquof
@@ -1040,7 +1041,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
-    libc.src.math.remainderf128
     libc.src.math.remquof128
     libc.src.math.scalblnf128
     libc.src.math.scalbnf128

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -706,6 +706,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminl
     libc.src.math.fmod
     libc.src.math.fmodf
+    libc.src.math.fmodf128
     libc.src.math.fmodl
     libc.src.math.fmul
     libc.src.math.fmull
@@ -1026,7 +1027,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.faddf128
     libc.src.math.fdivf128
     libc.src.math.ffmaf128
-    libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128
     libc.src.math.fromfpf128

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -721,6 +721,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminl
     libc.src.math.fmod
     libc.src.math.fmodf
+    libc.src.math.fmodf128
     libc.src.math.fmodl
     libc.src.math.fmul
     libc.src.math.fmull
@@ -820,6 +821,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.powf
     libc.src.math.remainder
     libc.src.math.remainderf
+    libc.src.math.remainderf128
     libc.src.math.remainderl
     libc.src.math.remquo
     libc.src.math.remquof
@@ -1042,7 +1044,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.faddf128
     libc.src.math.fdivf128
     libc.src.math.ffmaf128
-    libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128
     libc.src.math.fromfpf128
@@ -1056,7 +1057,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
-    libc.src.math.remainderf128
     libc.src.math.remquof128
     libc.src.math.scalblnf128
     libc.src.math.scalbnf128

--- a/libc/config/windows/entrypoints.txt
+++ b/libc/config/windows/entrypoints.txt
@@ -247,6 +247,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminimum_mag_num
     libc.src.math.fminimum_mag_numf
     libc.src.math.fminimum_mag_numl
+    libc.src.math.fmodf128
     libc.src.math.fmul
     libc.src.math.fmod
     libc.src.math.fmodf
@@ -318,6 +319,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.powf
     libc.src.math.remainderf
     libc.src.math.remainder
+    libc.src.math.remainderf128
     libc.src.math.remainderl
     libc.src.math.remquof
     libc.src.math.remquo

--- a/libc/config/windows/entrypoints.txt
+++ b/libc/config/windows/entrypoints.txt
@@ -250,6 +250,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmul
     libc.src.math.fmod
     libc.src.math.fmodf
+    libc.src.math.fmodf128
     libc.src.math.fmodl
     libc.src.math.frexp
     libc.src.math.frexpf

--- a/libc/config/windows/entrypoints.txt
+++ b/libc/config/windows/entrypoints.txt
@@ -317,6 +317,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.pow
     libc.src.math.powf
     libc.src.math.remainderf
+    libc.src.math.remainderf128
     libc.src.math.remainder
     libc.src.math.remainderl
     libc.src.math.remquof

--- a/libc/shared/math/fmodf128.h
+++ b/libc/shared/math/fmodf128.h
@@ -9,10 +9,6 @@
 #ifndef LLVM_LIBC_SHARED_MATH_FMODF128_H
 #define LLVM_LIBC_SHARED_MATH_FMODF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
 #include "shared/libc_common.h"
 #include "src/__support/math/fmodf128.h"
 
@@ -23,7 +19,5 @@ using math::fmodf128;
 
 } // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SHARED_MATH_FMODF128_H

--- a/libc/shared/math/remainderf128.h
+++ b/libc/shared/math/remainderf128.h
@@ -9,10 +9,6 @@
 #ifndef LLVM_LIBC_SHARED_MATH_REMAINDERF128_H
 #define LLVM_LIBC_SHARED_MATH_REMAINDERF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
 #include "shared/libc_common.h"
 #include "src/__support/math/remainderf128.h"
 
@@ -23,7 +19,5 @@ using math::remainderf128;
 
 } // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SHARED_MATH_REMAINDERF128_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -1426,7 +1426,7 @@ add_header_library(
   HDRS
     fmodf128.h
   DEPENDS
-    libc.include.llvm-libc-types.float128
+    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.generic.fmod
     libc.src.__support.macros.config
 )

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -2298,7 +2298,7 @@ add_header_library(
   HDRS
     remainderf128.h
   DEPENDS
-    libc.include.llvm-libc-types.float128
+    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.division_and_remainder_operations
     libc.src.__support.macros.config
 )

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -1426,7 +1426,7 @@ add_header_library(
   HDRS
     fmodf128.h
   DEPENDS
-    libc.include.llvm-libc-types.float128
+    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.generic.fmod
     libc.src.__support.macros.config
 )
@@ -2298,8 +2298,8 @@ add_header_library(
   HDRS
     remainderf128.h
   DEPENDS
-    libc.include.llvm-libc-types.float128
     libc.src.__support.FPUtil.division_and_remainder_operations
+    libc.src.__support.FPUtil.float128
     libc.src.__support.macros.config
 )
 

--- a/libc/src/__support/math/fmodf128.h
+++ b/libc/src/__support/math/fmodf128.h
@@ -9,23 +9,20 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_FMODF128_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_FMODF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/FPUtil/generic/FMod.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 namespace math {
 
-LIBC_INLINE constexpr float128 fmodf128(float128 x, float128 y) {
-  return fputil::generic::FMod<float128>::eval(x, y);
+using LIBC_NAMESPACE::fputil::Float128;
+
+LIBC_INLINE constexpr Float128 fmodf128(Float128 x, Float128 y) {
+  return fputil::generic::FMod<Float128>::eval(x, y);
 }
 
 } // namespace math
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SRC___SUPPORT_MATH_FMODF128_H

--- a/libc/src/__support/math/remainderf128.h
+++ b/libc/src/__support/math/remainderf128.h
@@ -9,24 +9,21 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_REMAINDERF128_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_REMAINDERF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
 #include "src/__support/FPUtil/DivisionAndRemainderOperations.h"
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 namespace math {
 
-LIBC_INLINE constexpr float128 remainderf128(float128 x, float128 y) {
+using LIBC_NAMESPACE::fputil::Float128;
+
+LIBC_INLINE constexpr Float128 remainderf128(Float128 x, Float128 y) {
   int quotient{};
   return fputil::remquo(x, y, quotient);
 }
 
 } // namespace math
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SRC___SUPPORT_MATH_REMAINDERF128_H

--- a/libc/src/math/fmodf128.h
+++ b/libc/src/math/fmodf128.h
@@ -9,10 +9,15 @@
 #ifndef LLVM_LIBC_SRC_MATH_FMODF128_H
 #define LLVM_LIBC_SRC_MATH_FMODF128_H
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/types.h"
 
 namespace LIBC_NAMESPACE_DECL {
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 float128 fmodf128(float128 x, float128 y);
 

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -2854,6 +2854,7 @@ add_entrypoint_object(
   HDRS
     ../remainderf128.h
   DEPENDS
+    libc.src.__support.CPP.bit
     libc.src.__support.math.remainderf128
 )
 
@@ -3475,6 +3476,7 @@ add_entrypoint_object(
   HDRS
     ../fmodf128.h
   DEPENDS
+    libc.src.__support.CPP.bit
     libc.src.__support.math.fmodf128
 )
 

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -3462,6 +3462,7 @@ add_entrypoint_object(
   HDRS
     ../fmodf128.h
   DEPENDS
+    libc.src.__support.CPP.bit
     libc.src.__support.math.fmodf128
 )
 

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -2841,6 +2841,7 @@ add_entrypoint_object(
   HDRS
     ../remainderf128.h
   DEPENDS
+    libc.src.__support.CPP.bit
     libc.src.__support.math.remainderf128
 )
 

--- a/libc/src/math/generic/fmodf128.cpp
+++ b/libc/src/math/generic/fmodf128.cpp
@@ -7,12 +7,16 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/fmodf128.h"
+#include "src/__support/CPP/bit.h"
 #include "src/__support/math/fmodf128.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
+using LIBC_NAMESPACE::fputil::Float128;
+
 LLVM_LIBC_FUNCTION(float128, fmodf128, (float128 x, float128 y)) {
-  return math::fmodf128(x, y);
+  return cpp::bit_cast<float128>(
+      math::fmodf128(cpp::bit_cast<Float128>(x), cpp::bit_cast<Float128>(y)));
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/generic/remainderf128.cpp
+++ b/libc/src/math/generic/remainderf128.cpp
@@ -7,12 +7,16 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/remainderf128.h"
+#include "src/__support/CPP/bit.h"
 #include "src/__support/math/remainderf128.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
+using LIBC_NAMESPACE::fputil::Float128;
+
 LLVM_LIBC_FUNCTION(float128, remainderf128, (float128 x, float128 y)) {
-  return math::remainderf128(x, y);
+  return cpp::bit_cast<float128>(math::remainderf128(
+      cpp::bit_cast<Float128>(x), cpp::bit_cast<Float128>(y)));
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/remainderf128.h
+++ b/libc/src/math/remainderf128.h
@@ -9,10 +9,15 @@
 #ifndef LLVM_LIBC_SRC_MATH_REMAINDERF128_H
 #define LLVM_LIBC_SRC_MATH_REMAINDERF128_H
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/types.h"
 
 namespace LIBC_NAMESPACE_DECL {
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 float128 remainderf128(float128 x, float128 y);
 

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -381,6 +381,8 @@ static_assert(0 == LIBC_NAMESPACE::shared::isnanl(0.0L));
 //===----------------------------------------------------------------------===//
 
 static_assert(Float128(0.0) == LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
+static_assert(0 ==
+              LIBC_NAMESPACE::shared::fmodf128(Float128(4.0), Float128(2.0)));
 static_assert(Float128(0.0) ==
               LIBC_NAMESPACE::shared::copysignf128(Float128(0.0),
                                                    Float128(0.0)));
@@ -480,8 +482,6 @@ constexpr float128 TOTALORDERMAGF128_Y = float128(0.0);
 static_assert(1 ==
               LIBC_NAMESPACE::shared::totalordermagf128(&TOTALORDERMAGF128_X,
                                                         &TOTALORDERMAGF128_Y));
-static_assert(0 ==
-              LIBC_NAMESPACE::shared::fmodf128(float128(4.0), float128(2.0)));
 static_assert(float128(0.0) == [] {
   float128 iptr{};
   return LIBC_NAMESPACE::shared::modff128(float128(0.0), &iptr);

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -381,6 +381,9 @@ static_assert(0 == LIBC_NAMESPACE::shared::isnanl(0.0L));
 //===----------------------------------------------------------------------===//
 
 static_assert(Float128(0.0) == LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
+static_assert(float128(0.0) ==
+              LIBC_NAMESPACE::shared::remainderf128(Float128(1.0),
+                                                    Float128(1.0)));
 static_assert(0 ==
               LIBC_NAMESPACE::shared::fmodf128(Float128(4.0), Float128(2.0)));
 static_assert(Float128(0.0) ==
@@ -486,9 +489,6 @@ static_assert(float128(0.0) == [] {
   float128 iptr{};
   return LIBC_NAMESPACE::shared::modff128(float128(0.0), &iptr);
 }());
-static_assert(float128(0.0) ==
-              LIBC_NAMESPACE::shared::remainderf128(float128(1.0),
-                                                    float128(1.0)));
 static_assert(float128(0.0) == [] {
   int exp{};
   return LIBC_NAMESPACE::shared::remquof128(float128(1.0), float128(1.0), &exp);

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -381,11 +381,6 @@ static_assert(0 == LIBC_NAMESPACE::shared::isnanl(0.0L));
 //===----------------------------------------------------------------------===//
 
 static_assert(Float128(0.0) == LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
-static_assert(float128(0.0) ==
-              LIBC_NAMESPACE::shared::remainderf128(Float128(1.0),
-                                                    Float128(1.0)));
-static_assert(0 ==
-              LIBC_NAMESPACE::shared::fmodf128(Float128(4.0), Float128(2.0)));
 static_assert(Float128(0.0) ==
               LIBC_NAMESPACE::shared::copysignf128(Float128(0.0),
                                                    Float128(0.0)));
@@ -423,6 +418,8 @@ static_assert(Float128(0.0) ==
 static_assert(Float128(0.0) ==
               LIBC_NAMESPACE::shared::fminimum_numf128(Float128(0.0),
                                                        Float128(0.0)));
+static_assert(Float128(0.0) ==
+              LIBC_NAMESPACE::shared::fmodf128(Float128(4.0), Float128(2.0)));
 static_assert(1 == LIBC_NAMESPACE::shared::iscanonicalf128(Float128(0.0)));
 static_assert(0 == LIBC_NAMESPACE::shared::isnanf128(Float128(0.0)));
 static_assert(0.0 == LIBC_NAMESPACE::shared::issignalingf128(Float128(0.0)));
@@ -438,6 +435,9 @@ static_assert(Float128(0.0) ==
 static_assert(Float128(0.0) ==
               LIBC_NAMESPACE::shared::nextafterf128(Float128(0.0),
                                                     Float128(0.0)));
+static_assert(Float128(0.0) ==
+              LIBC_NAMESPACE::shared::remainderf128(Float128(1.0),
+                                                    Float128(1.0)));
 static_assert(Float128(0.0) ==
               LIBC_NAMESPACE::shared::roundf128(Float128(0.0)));
 static_assert(Float128(0.0) ==
@@ -485,10 +485,15 @@ constexpr float128 TOTALORDERMAGF128_Y = float128(0.0);
 static_assert(1 ==
               LIBC_NAMESPACE::shared::totalordermagf128(&TOTALORDERMAGF128_X,
                                                         &TOTALORDERMAGF128_Y));
+static_assert(float128(0.0) ==
+              LIBC_NAMESPACE::shared::fmodf128(float128(4.0), float128(2.0)));
 static_assert(float128(0.0) == [] {
   float128 iptr{};
   return LIBC_NAMESPACE::shared::modff128(float128(0.0), &iptr);
 }());
+static_assert(float128(0.0) ==
+              LIBC_NAMESPACE::shared::remainderf128(float128(1.0),
+                                                    float128(1.0)));
 static_assert(float128(0.0) == [] {
   int exp{};
   return LIBC_NAMESPACE::shared::remquof128(float128(1.0), float128(1.0), &exp);
@@ -587,7 +592,7 @@ constexpr bfloat16 TOTALORDERMAGBF16_Y = bfloat16(0.0);
 static_assert(1 ==
               LIBC_NAMESPACE::shared::totalordermagbf16(&TOTALORDERMAGBF16_X,
                                                         &TOTALORDERMAGBF16_Y));
-static_assert(0 ==
+static_assert(bfloat16(0.0) ==
               LIBC_NAMESPACE::shared::fmodbf16(bfloat16(4.0), bfloat16(2.0)));
 static_assert(bfloat16(0.0) == [] {
   bfloat16 iptr{};

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -440,7 +440,7 @@ static_assert(LIBC_NAMESPACE::fputil::FPBits<Float128>::min_subnormal(
 static_assert(
     LIBC_NAMESPACE::fputil::FPBits<Float128>::min_subnormal().get_val() ==
     LIBC_NAMESPACE::shared::nextupf128(Float128(0.0)));
-static_assert(float128(0.0) ==
+static_assert(Float128(0.0) ==
               LIBC_NAMESPACE::shared::remainderf128(Float128(1.0),
                                                     Float128(1.0)));
 static_assert(Float128(0.0) == LIBC_NAMESPACE::shared::rintf128(Float128(0.0)));

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -419,6 +419,8 @@ static_assert(Float128(0.0) ==
 static_assert(Float128(0.0) ==
               LIBC_NAMESPACE::shared::fminimum_numf128(Float128(0.0),
                                                        Float128(0.0)));
+static_assert(0 ==
+              LIBC_NAMESPACE::shared::fmodf128(Float128(4.0), Float128(2.0)));
 static_assert(1 == LIBC_NAMESPACE::shared::iscanonicalf128(Float128(0.0)));
 static_assert(0 == LIBC_NAMESPACE::shared::isnanf128(Float128(0.0)));
 static_assert(0.0 == LIBC_NAMESPACE::shared::issignalingf128(Float128(0.0)));
@@ -438,6 +440,9 @@ static_assert(LIBC_NAMESPACE::fputil::FPBits<Float128>::min_subnormal(
 static_assert(
     LIBC_NAMESPACE::fputil::FPBits<Float128>::min_subnormal().get_val() ==
     LIBC_NAMESPACE::shared::nextupf128(Float128(0.0)));
+static_assert(float128(0.0) ==
+              LIBC_NAMESPACE::shared::remainderf128(Float128(1.0),
+                                                    Float128(1.0)));
 static_assert(Float128(0.0) == LIBC_NAMESPACE::shared::rintf128(Float128(0.0)));
 static_assert(Float128(0.0) ==
               LIBC_NAMESPACE::shared::roundevenf128(Float128(0.0)));
@@ -488,15 +493,10 @@ constexpr float128 TOTALORDERMAGF128_Y = float128(0.0);
 static_assert(1 ==
               LIBC_NAMESPACE::shared::totalordermagf128(&TOTALORDERMAGF128_X,
                                                         &TOTALORDERMAGF128_Y));
-static_assert(0 ==
-              LIBC_NAMESPACE::shared::fmodf128(float128(4.0), float128(2.0)));
 static_assert(float128(0.0) == [] {
   float128 iptr{};
   return LIBC_NAMESPACE::shared::modff128(float128(0.0), &iptr);
 }());
-static_assert(float128(0.0) ==
-              LIBC_NAMESPACE::shared::remainderf128(float128(1.0),
-                                                    float128(1.0)));
 static_assert(float128(0.0) == [] {
   int exp{};
   return LIBC_NAMESPACE::shared::remquof128(float128(1.0), float128(1.0), &exp);

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -419,7 +419,7 @@ static_assert(Float128(0.0) ==
 static_assert(Float128(0.0) ==
               LIBC_NAMESPACE::shared::fminimum_numf128(Float128(0.0),
                                                        Float128(0.0)));
-static_assert(0 ==
+static_assert(Float128(0) ==
               LIBC_NAMESPACE::shared::fmodf128(Float128(4.0), Float128(2.0)));
 static_assert(1 == LIBC_NAMESPACE::shared::iscanonicalf128(Float128(0.0)));
 static_assert(0 == LIBC_NAMESPACE::shared::isnanf128(Float128(0.0)));

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -587,9 +587,6 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
   EXPECT_FP_EQ(Float128(0.0),
                LIBC_NAMESPACE::shared::atan2f128(Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
-  EXPECT_FP_EQ(float128(0.0), LIBC_NAMESPACE::shared::remainderf128(
-                                  Float128(1.0), Float128(1.0)));
-  LIBC_NAMESPACE::shared::fmodf128(Float128(1.0), Float128(1.0));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::copysignf128(
                                   Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::fabsf128(Float128(0.0)));
@@ -616,6 +613,8 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
                                   Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::fminimum_numf128(
                                   Float128(0.0), Float128(0.0)));
+  EXPECT_FP_EQ(Float128(0.0),
+               LIBC_NAMESPACE::shared::fmodf128(Float128(1.0), Float128(1.0)));
   EXPECT_EQ(1, LIBC_NAMESPACE::shared::iscanonicalf128(Float128(0.0)));
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::isnanf128(Float128(0.0)));
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::issignalingf128(Float128(0.0)));
@@ -630,6 +629,8 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
   EXPECT_FP_EQ(neg_min_denormal,
                LIBC_NAMESPACE::shared::nextdownf128(Float128(0.0)));
   EXPECT_FP_EQ(min_denormal, LIBC_NAMESPACE::shared::nextupf128(Float128(0.0)));
+  EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::remainderf128(
+                                  Float128(1.0), Float128(1.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::rintf128(Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0),
                LIBC_NAMESPACE::shared::roundevenf128(Float128(0.0)));
@@ -737,10 +738,14 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
   float128 totalordermagf128_y = float128(0.0);
   EXPECT_EQ(1, LIBC_NAMESPACE::shared::totalordermagf128(&totalordermagf128_x,
                                                          &totalordermagf128_y));
+  EXPECT_FP_EQ(float128(0.0),
+               LIBC_NAMESPACE::shared::fmodf128(float128(1.0), float128(1.0)));
   float128 modff128_iptr = float128(0.0);
   EXPECT_FP_EQ(float128(0.0),
                LIBC_NAMESPACE::shared::modff128(float128(0.0), &modff128_iptr));
   EXPECT_FP_EQ(float128(0.0), modff128_iptr);
+  EXPECT_FP_EQ(float128(0.0), LIBC_NAMESPACE::shared::remainderf128(
+                                  float128(1.0), float128(1.0)));
   int remquof128_exp = 0;
   EXPECT_FP_EQ(float128(0.0),
                LIBC_NAMESPACE::shared::remquof128(float128(1.0), float128(1.0),
@@ -864,7 +869,8 @@ TEST(LlvmLibcSharedMathTest, AllBFloat16) {
   bfloat16 totalordermagbf16_y = bfloat16(0.0);
   EXPECT_EQ(1, LIBC_NAMESPACE::shared::totalordermagbf16(&totalordermagbf16_x,
                                                          &totalordermagbf16_y));
-  LIBC_NAMESPACE::shared::fmodbf16(bfloat16(1.0), bfloat16(1.0));
+  EXPECT_FP_EQ(bfloat16(0.0),
+               LIBC_NAMESPACE::shared::fmodbf16(bfloat16(1.0), bfloat16(1.0)));
   bfloat16 modfbf16_iptr = bfloat16(0.0);
   EXPECT_FP_EQ(bfloat16(0.0),
                LIBC_NAMESPACE::shared::modfbf16(bfloat16(0.0), &modfbf16_iptr));

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -587,6 +587,8 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
   EXPECT_FP_EQ(Float128(0.0),
                LIBC_NAMESPACE::shared::atan2f128(Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
+  EXPECT_FP_EQ(float128(0.0), LIBC_NAMESPACE::shared::remainderf128(
+                                  Float128(1.0), Float128(1.0)));
   LIBC_NAMESPACE::shared::fmodf128(Float128(1.0), Float128(1.0));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::copysignf128(
                                   Float128(0.0), Float128(0.0)));
@@ -739,8 +741,6 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
   EXPECT_FP_EQ(float128(0.0),
                LIBC_NAMESPACE::shared::modff128(float128(0.0), &modff128_iptr));
   EXPECT_FP_EQ(float128(0.0), modff128_iptr);
-  EXPECT_FP_EQ(float128(0.0), LIBC_NAMESPACE::shared::remainderf128(
-                                  float128(1.0), float128(1.0)));
   int remquof128_exp = 0;
   EXPECT_FP_EQ(float128(0.0),
                LIBC_NAMESPACE::shared::remquof128(float128(1.0), float128(1.0),

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -703,9 +703,6 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
                                                          float128(0.0)));
   EXPECT_FP_EQ(float128(0.0), setpayloadsigf128_res);
 
-  float128 neg_min_denormal = FPBits::min_subnormal(Sign::NEG).get_val();
-  float128 min_denormal = FPBits::min_subnormal(Sign ::POS).get_val();
-
 #ifdef LIBC_TYPES_HAS_FLOAT16
   EXPECT_FP_EQ(10.0f16, LIBC_NAMESPACE::shared::f16fmaf128(
                             float128(2.0), float128(3.0), float128(4.0)));

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -587,6 +587,7 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
   EXPECT_FP_EQ(Float128(0.0),
                LIBC_NAMESPACE::shared::atan2f128(Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
+  LIBC_NAMESPACE::shared::fmodf128(Float128(1.0), Float128(1.0));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::copysignf128(
                                   Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::fabsf128(Float128(0.0)));
@@ -734,7 +735,6 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
   float128 totalordermagf128_y = float128(0.0);
   EXPECT_EQ(1, LIBC_NAMESPACE::shared::totalordermagf128(&totalordermagf128_x,
                                                          &totalordermagf128_y));
-  LIBC_NAMESPACE::shared::fmodf128(float128(1.0), float128(1.0));
   float128 modff128_iptr = float128(0.0);
   EXPECT_FP_EQ(float128(0.0),
                LIBC_NAMESPACE::shared::modff128(float128(0.0), &modff128_iptr));

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -587,6 +587,7 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
   EXPECT_FP_EQ(Float128(0.0),
                LIBC_NAMESPACE::shared::atan2f128(Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
+  LIBC_NAMESPACE::shared::fmodf128(Float128(1.0), Float128(1.0));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::copysignf128(
                                   Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::fabsf128(Float128(0.0)));
@@ -627,6 +628,8 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
   EXPECT_FP_EQ(neg_min_denormal,
                LIBC_NAMESPACE::shared::nextdownf128(Float128(0.0)));
   EXPECT_FP_EQ(min_denormal, LIBC_NAMESPACE::shared::nextupf128(Float128(0.0)));
+  EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::remainderf128(
+                                  Float128(1.0), Float128(1.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::rintf128(Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0),
                LIBC_NAMESPACE::shared::roundevenf128(Float128(0.0)));
@@ -737,13 +740,10 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
   float128 totalordermagf128_y = float128(0.0);
   EXPECT_EQ(1, LIBC_NAMESPACE::shared::totalordermagf128(&totalordermagf128_x,
                                                          &totalordermagf128_y));
-  LIBC_NAMESPACE::shared::fmodf128(float128(1.0), float128(1.0));
   float128 modff128_iptr = float128(0.0);
   EXPECT_FP_EQ(float128(0.0),
                LIBC_NAMESPACE::shared::modff128(float128(0.0), &modff128_iptr));
   EXPECT_FP_EQ(float128(0.0), modff128_iptr);
-  EXPECT_FP_EQ(float128(0.0), LIBC_NAMESPACE::shared::remainderf128(
-                                  float128(1.0), float128(1.0)));
   int remquof128_exp = 0;
   EXPECT_FP_EQ(float128(0.0),
                LIBC_NAMESPACE::shared::remquof128(float128(1.0), float128(1.0),

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -587,7 +587,8 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
   EXPECT_FP_EQ(Float128(0.0),
                LIBC_NAMESPACE::shared::atan2f128(Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
-  EXPECT_FP_EQ(Float128(0),LIBC_NAMESPACE::shared::fmodf128(Float128(1.0), Float128(1.0)));
+  EXPECT_FP_EQ(Float128(0),
+               LIBC_NAMESPACE::shared::fmodf128(Float128(1.0), Float128(1.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::copysignf128(
                                   Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::fabsf128(Float128(0.0)));

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -587,7 +587,7 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
   EXPECT_FP_EQ(Float128(0.0),
                LIBC_NAMESPACE::shared::atan2f128(Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
-  LIBC_NAMESPACE::shared::fmodf128(Float128(1.0), Float128(1.0));
+  EXPECT_FP_EQ(Float128(0),LIBC_NAMESPACE::shared::fmodf128(Float128(1.0), Float128(1.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::copysignf128(
                                   Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::fabsf128(Float128(0.0)));

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -4695,6 +4695,7 @@ add_fp_unittest(
   DEPENDS
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
+    libc.src.__support.FPUtil.float128
     libc.src.math.fmodf128
     libc.src.__support.FPUtil.fenv_impl
   # FIXME: Currently fails on the GPU build.

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -4704,10 +4704,11 @@ add_fp_unittest(
   HDRS
     FModTest.h
   DEPENDS
+    libc.src.math.fmodf128
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
-    libc.src.math.fmodf128
     libc.src.__support.FPUtil.fenv_impl
+    libc.src.__support.FPUtil.float128
   # FIXME: Currently fails on the GPU build.
 )
 

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -4704,9 +4704,9 @@ add_fp_unittest(
   HDRS
     FModTest.h
   DEPENDS
-    libc.src.math.fmodf128
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
+    libc.src.math.fmodf128
     libc.src.__support.FPUtil.fenv_impl
     libc.src.__support.FPUtil.float128
   # FIXME: Currently fails on the GPU build.

--- a/libc/test/src/math/smoke/fmodf128_test.cpp
+++ b/libc/test/src/math/smoke/fmodf128_test.cpp
@@ -8,6 +8,11 @@
 
 #include "FModTest.h"
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/math/fmodf128.h"
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 LIST_FMOD_TESTS(float128, LIBC_NAMESPACE::fmodf128)

--- a/libc/test/src/math/smoke/fmodf128_test.cpp
+++ b/libc/test/src/math/smoke/fmodf128_test.cpp
@@ -7,7 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "FModTest.h"
+#include "src/__support/FPUtil/float128.h"
 
 #include "src/math/fmodf128.h"
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 LIST_FMOD_TESTS(float128, LIBC_NAMESPACE::fmodf128)

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -5973,9 +5973,9 @@ libc_support_library(
     name = "__support_math_fmodf128",
     hdrs = ["src/__support/math/fmodf128.h"],
     deps = [
+        ":__support_fputil_float128",
         ":__support_fputil_generic_fmod",
         ":__support_macros_config",
-        ":llvm_libc_types_float128",
     ],
 )
 
@@ -6836,8 +6836,8 @@ libc_support_library(
     hdrs = ["src/__support/math/remainderf128.h"],
     deps = [
         ":__support_fputil_division_and_remainder_operations",
+        ":__support_fputil_float128",
         ":__support_macros_config",
-        ":llvm_libc_types_float128",
     ],
 )
 
@@ -12301,6 +12301,8 @@ libc_math_function(
 libc_math_function(
     name = "fmodf128",
     additional_deps = [
+        ":__support_cpp_bit",
+        ":__support_fputil_float128",
         ":__support_math_fmodf128",
     ],
 )
@@ -13304,6 +13306,8 @@ libc_math_function(
 libc_math_function(
     name = "remainderf128",
     additional_deps = [
+        ":__support_cpp_bit",
+        ":__support_fputil_float128",
         ":__support_math_remainderf128",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -5948,9 +5948,9 @@ libc_support_library(
     name = "__support_math_fmodf128",
     hdrs = ["src/__support/math/fmodf128.h"],
     deps = [
+        ":__support_fputil_float128",
         ":__support_fputil_generic_fmod",
         ":__support_macros_config",
-        ":llvm_libc_types_float128",
     ],
 )
 
@@ -12239,6 +12239,8 @@ libc_math_function(
 libc_math_function(
     name = "fmodf128",
     additional_deps = [
+        ":__support_cpp_bit",
+        ":__support_fputil_float128",
         ":__support_math_fmodf128",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -6811,8 +6811,8 @@ libc_support_library(
     hdrs = ["src/__support/math/remainderf128.h"],
     deps = [
         ":__support_fputil_division_and_remainder_operations",
+        ":__support_fputil_float128",
         ":__support_macros_config",
-        ":llvm_libc_types_float128",
     ],
 )
 
@@ -13239,6 +13239,8 @@ libc_math_function(
 libc_math_function(
     name = "remainderf128",
     additional_deps = [
+        ":__support_cpp_bit",
+        ":__support_fputil_float128",
         ":__support_math_remainderf128",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
@@ -839,6 +839,9 @@ math_test(
 math_test(
     name = "fmodf128",
     hdrs = ["FModTest.h"],
+    deps = [
+        "//libc:__support_fputil_float128",
+    ],
 )
 
 math_test(


### PR DESCRIPTION
* fmodf128
* remainderf128