### PR TITLE
[MLIR][FPL] Fix dark shadow of Fourier-Motzkin

### DIFF
--- a/mlir/lib/Analysis/Presburger/IntegerRelation.cpp
+++ b/mlir/lib/Analysis/Presburger/IntegerRelation.cpp
@@ -2124,7 +2124,7 @@ void IntegerRelation::fourierMotzkinEliminate(unsigned pos, bool darkShadow,
       if (darkShadow) {
         // The dark shadow is a convex subset of the exact integer shadow. If
         // there is a point here, it proves the existence of a solution.
-        ineq[ineq.size() - 1] += lbCoeff * ubCoeff - lbCoeff - ubCoeff + 1;
+        ineq[ineq.size() - 1] -= lbCoeff * ubCoeff - lbCoeff - ubCoeff + 1;
       }
       // TODO: we need to have a way to add inequalities in-place in
       // IntegerRelation instead of creating and copying over.

--- a/mlir/unittests/Analysis/Presburger/IntegerRelationTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/IntegerRelationTest.cpp
@@ -777,3 +777,35 @@ TEST(IntegerRelationTest, isFullDim) {
   rel = parseRelationFromSet("(x): (-1 >= 0)", 1);
   EXPECT_FALSE(rel.isFullDim());
 }
+
+namespace {
+/// Exposes the protected Fourier-Motzkin elimination so that the dark shadow
+/// variant can be tested.
+class DarkShadowTestRelation : public IntegerRelation {
+public:
+  DarkShadowTestRelation(const IntegerRelation &rel) : IntegerRelation(rel) {}
+  using IntegerRelation::fourierMotzkinEliminate;
+};
+} // namespace
+
+TEST(IntegerRelationTest, fourierMotzkinDarkShadow) {
+  // The dark shadow is a convex integer subset of the exact integer shadow.
+  //
+  // Consider the relation 2*i == j + 1, i.e. j + 1 <= 2i <= j + 1.
+  // Eliminating i, the rational shadow is the entire j-line, but the exact
+  // integer shadow is "j is odd".
+  IntegerRelation parsed =
+      parseRelationFromSet("(j, i) : (2*i - j - 1 >= 0, -2*i + j + 1 >= 0)", 2);
+
+  // The rational shadow should contain j = 0.
+  DarkShadowTestRelation rationalShadow = parsed;
+  rationalShadow.fourierMotzkinEliminate(/*pos=*/1, /*darkShadow=*/false);
+  rationalShadow.addEquality({1, 0});
+  EXPECT_FALSE(rationalShadow.isIntegerEmpty());
+
+  // The dark shadow must not contain j = 0.
+  DarkShadowTestRelation darkShadow = parsed;
+  darkShadow.fourierMotzkinEliminate(/*pos=*/1, /*darkShadow=*/true);
+  darkShadow.addEquality({1, 0});
+  EXPECT_TRUE(darkShadow.isIntegerEmpty());
+}


### PR DESCRIPTION
Currently, the Omega test is of the opposite sign.

Suppose we are eliminating `x`. For `ax >= l` and `bx <= u` (a, b positive), the Omega test says that if `au - bl >= (a-1)(b-1)` then there must be an integer solution. But in FPL it actually generates `au - bl + (a-1)(b-1) >= 0`, which is the opposite.

This PR fixes it.