### PR TITLE
[RISCV] Support Packed Multiply High Accumulate

### DIFF
--- a/clang/include/clang/Basic/BuiltinsRISCV.td
+++ b/clang/include/clang/Basic/BuiltinsRISCV.td
@@ -255,6 +255,14 @@ def pmulhru_u16x2 : RISCVBuiltin<"_Vector<2, unsigned short>(_Vector<2, unsigned
 def pmulhsu_i16x2 : RISCVBuiltin<"_Vector<2, short>(_Vector<2, short>, _Vector<2, unsigned short>)">;
 def pmulhrsu_i16x2 : RISCVBuiltin<"_Vector<2, short>(_Vector<2, short>, _Vector<2, unsigned short>)">;
 
+// Packed Multiply High Accumulate (32-bit)
+def pmhacc_i16x2 : RISCVBuiltin<"_Vector<2, short>(_Vector<2, short>, _Vector<2, short>, _Vector<2, short>)">;
+def pmhracc_i16x2 : RISCVBuiltin<"_Vector<2, short>(_Vector<2, short>, _Vector<2, short>, _Vector<2, short>)">;
+def pmhaccu_u16x2 : RISCVBuiltin<"_Vector<2, unsigned short>(_Vector<2, unsigned short>, _Vector<2, unsigned short>, _Vector<2, unsigned short>)">;
+def pmhraccu_u16x2 : RISCVBuiltin<"_Vector<2, unsigned short>(_Vector<2, unsigned short>, _Vector<2, unsigned short>, _Vector<2, unsigned short>)">;
+def pmhaccsu_i16x2 : RISCVBuiltin<"_Vector<2, short>(_Vector<2, short>, _Vector<2, short>, _Vector<2, unsigned short>)">;
+def pmhraccsu_i16x2 : RISCVBuiltin<"_Vector<2, short>(_Vector<2, short>, _Vector<2, short>, _Vector<2, unsigned short>)">;
+
 // Packed Multiply High (64-bit)
 def pmulh_i16x4 : RISCVBuiltin<"_Vector<4, short>(_Vector<4, short>, _Vector<4, short>)">;
 def pmulh_i32x2 : RISCVBuiltin<"_Vector<2, int>(_Vector<2, int>, _Vector<2, int>)">;
@@ -268,6 +276,20 @@ def pmulhsu_i16x4 : RISCVBuiltin<"_Vector<4, short>(_Vector<4, short>, _Vector<4
 def pmulhsu_i32x2 : RISCVBuiltin<"_Vector<2, int>(_Vector<2, int>, _Vector<2, unsigned int>)">;
 def pmulhrsu_i16x4 : RISCVBuiltin<"_Vector<4, short>(_Vector<4, short>, _Vector<4, unsigned short>)">;
 def pmulhrsu_i32x2 : RISCVBuiltin<"_Vector<2, int>(_Vector<2, int>, _Vector<2, unsigned int>)">;
+
+// Packed Multiply High Accumulate (64-bit)
+def pmhacc_i16x4 : RISCVBuiltin<"_Vector<4, short>(_Vector<4, short>, _Vector<4, short>, _Vector<4, short>)">;
+def pmhacc_i32x2 : RISCVBuiltin<"_Vector<2, int>(_Vector<2, int>, _Vector<2, int>, _Vector<2, int>)">;
+def pmhracc_i16x4 : RISCVBuiltin<"_Vector<4, short>(_Vector<4, short>, _Vector<4, short>, _Vector<4, short>)">;
+def pmhracc_i32x2 : RISCVBuiltin<"_Vector<2, int>(_Vector<2, int>, _Vector<2, int>, _Vector<2, int>)">;
+def pmhaccu_u16x4 : RISCVBuiltin<"_Vector<4, unsigned short>(_Vector<4, unsigned short>, _Vector<4, unsigned short>, _Vector<4, unsigned short>)">;
+def pmhaccu_u32x2 : RISCVBuiltin<"_Vector<2, unsigned int>(_Vector<2, unsigned int>, _Vector<2, unsigned int>, _Vector<2, unsigned int>)">;
+def pmhraccu_u16x4 : RISCVBuiltin<"_Vector<4, unsigned short>(_Vector<4, unsigned short>, _Vector<4, unsigned short>, _Vector<4, unsigned short>)">;
+def pmhraccu_u32x2 : RISCVBuiltin<"_Vector<2, unsigned int>(_Vector<2, unsigned int>, _Vector<2, unsigned int>, _Vector<2, unsigned int>)">;
+def pmhaccsu_i16x4 : RISCVBuiltin<"_Vector<4, short>(_Vector<4, short>, _Vector<4, short>, _Vector<4, unsigned short>)">;
+def pmhaccsu_i32x2 : RISCVBuiltin<"_Vector<2, int>(_Vector<2, int>, _Vector<2, int>, _Vector<2, unsigned int>)">;
+def pmhraccsu_i16x4 : RISCVBuiltin<"_Vector<4, short>(_Vector<4, short>, _Vector<4, short>, _Vector<4, unsigned short>)">;
+def pmhraccsu_i32x2 : RISCVBuiltin<"_Vector<2, int>(_Vector<2, int>, _Vector<2, int>, _Vector<2, unsigned int>)">;
 
 // Packed Absolute Difference Sum (32-bit)
 def pabdsumu_u8x4_u32 : RISCVBuiltin<"unsigned int(_Vector<4, unsigned char>, _Vector<4, unsigned char>)">;

--- a/clang/lib/CodeGen/TargetBuiltins/RISCV.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/RISCV.cpp
@@ -1278,6 +1278,25 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
   case RISCV::BI__builtin_riscv_pmulhrsu_i16x2:
   case RISCV::BI__builtin_riscv_pmulhrsu_i16x4:
   case RISCV::BI__builtin_riscv_pmulhrsu_i32x2:
+  // Packed Multiply High Accumulate
+  case RISCV::BI__builtin_riscv_pmhacc_i16x2:
+  case RISCV::BI__builtin_riscv_pmhacc_i16x4:
+  case RISCV::BI__builtin_riscv_pmhacc_i32x2:
+  case RISCV::BI__builtin_riscv_pmhracc_i16x2:
+  case RISCV::BI__builtin_riscv_pmhracc_i16x4:
+  case RISCV::BI__builtin_riscv_pmhracc_i32x2:
+  case RISCV::BI__builtin_riscv_pmhaccu_u16x2:
+  case RISCV::BI__builtin_riscv_pmhaccu_u16x4:
+  case RISCV::BI__builtin_riscv_pmhaccu_u32x2:
+  case RISCV::BI__builtin_riscv_pmhraccu_u16x2:
+  case RISCV::BI__builtin_riscv_pmhraccu_u16x4:
+  case RISCV::BI__builtin_riscv_pmhraccu_u32x2:
+  case RISCV::BI__builtin_riscv_pmhaccsu_i16x2:
+  case RISCV::BI__builtin_riscv_pmhaccsu_i16x4:
+  case RISCV::BI__builtin_riscv_pmhaccsu_i32x2:
+  case RISCV::BI__builtin_riscv_pmhraccsu_i16x2:
+  case RISCV::BI__builtin_riscv_pmhraccsu_i16x4:
+  case RISCV::BI__builtin_riscv_pmhraccsu_i32x2:
   // Packed Saturating Absolute Value
   case RISCV::BI__builtin_riscv_psabs_i8x4:
   case RISCV::BI__builtin_riscv_psabs_i16x2:
@@ -1411,6 +1430,36 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
     case RISCV::BI__builtin_riscv_pmulhrsu_i16x4:
     case RISCV::BI__builtin_riscv_pmulhrsu_i32x2:
       ID = Intrinsic::riscv_pmulhrsu;
+      break;
+    case RISCV::BI__builtin_riscv_pmhacc_i16x2:
+    case RISCV::BI__builtin_riscv_pmhacc_i16x4:
+    case RISCV::BI__builtin_riscv_pmhacc_i32x2:
+      ID = Intrinsic::riscv_pmhacc;
+      break;
+    case RISCV::BI__builtin_riscv_pmhracc_i16x2:
+    case RISCV::BI__builtin_riscv_pmhracc_i16x4:
+    case RISCV::BI__builtin_riscv_pmhracc_i32x2:
+      ID = Intrinsic::riscv_pmhracc;
+      break;
+    case RISCV::BI__builtin_riscv_pmhaccu_u16x2:
+    case RISCV::BI__builtin_riscv_pmhaccu_u16x4:
+    case RISCV::BI__builtin_riscv_pmhaccu_u32x2:
+      ID = Intrinsic::riscv_pmhaccu;
+      break;
+    case RISCV::BI__builtin_riscv_pmhraccu_u16x2:
+    case RISCV::BI__builtin_riscv_pmhraccu_u16x4:
+    case RISCV::BI__builtin_riscv_pmhraccu_u32x2:
+      ID = Intrinsic::riscv_pmhraccu;
+      break;
+    case RISCV::BI__builtin_riscv_pmhaccsu_i16x2:
+    case RISCV::BI__builtin_riscv_pmhaccsu_i16x4:
+    case RISCV::BI__builtin_riscv_pmhaccsu_i32x2:
+      ID = Intrinsic::riscv_pmhaccsu;
+      break;
+    case RISCV::BI__builtin_riscv_pmhraccsu_i16x2:
+    case RISCV::BI__builtin_riscv_pmhraccsu_i16x4:
+    case RISCV::BI__builtin_riscv_pmhraccsu_i32x2:
+      ID = Intrinsic::riscv_pmhraccsu;
       break;
     case RISCV::BI__builtin_riscv_psabs_i8x4:
     case RISCV::BI__builtin_riscv_psabs_i16x2:

--- a/clang/lib/Headers/riscv_packed_simd.h
+++ b/clang/lib/Headers/riscv_packed_simd.h
@@ -78,14 +78,14 @@ typedef uint32_t uint32x2_t __attribute__((__vector_size__(8)));
   }
 
 #define __packed_ternary_builtin(name, ty, builtin)                            \
-  static __inline__ ty __DEFAULT_FN_ATTRS __riscv_##name(                      \
-      ty __rd, ty __rs1, ty __rs2) {                                           \
+  static __inline__ ty __DEFAULT_FN_ATTRS __riscv_##name(ty __rd, ty __rs1,    \
+                                                         ty __rs2) {           \
     return builtin(__rd, __rs1, __rs2);                                        \
   }
 
 #define __packed_ternary_builtin_mixed(name, rty, ty1, ty2, builtin)           \
-  static __inline__ rty __DEFAULT_FN_ATTRS __riscv_##name(                     \
-      rty __rd, ty1 __rs1, ty2 __rs2) {                                        \
+  static __inline__ rty __DEFAULT_FN_ATTRS __riscv_##name(rty __rd, ty1 __rs1, \
+                                                          ty2 __rs2) {         \
     return builtin(__rd, __rs1, __rs2);                                        \
   }
 

--- a/clang/lib/Headers/riscv_packed_simd.h
+++ b/clang/lib/Headers/riscv_packed_simd.h
@@ -77,6 +77,18 @@ typedef uint32_t uint32x2_t __attribute__((__vector_size__(8)));
     return builtin(__rs1, __rs2);                                              \
   }
 
+#define __packed_ternary_builtin(name, ty, builtin)                            \
+  static __inline__ ty __DEFAULT_FN_ATTRS __riscv_##name(                      \
+      ty __rd, ty __rs1, ty __rs2) {                                           \
+    return builtin(__rd, __rs1, __rs2);                                        \
+  }
+
+#define __packed_ternary_builtin_mixed(name, rty, ty1, ty2, builtin)           \
+  static __inline__ rty __DEFAULT_FN_ATTRS __riscv_##name(                     \
+      rty __rd, ty1 __rs1, ty2 __rs2) {                                        \
+    return builtin(__rd, __rs1, __rs2);                                        \
+  }
+
 #define __packed_sh1add(name, ty)                                              \
   static __inline__ ty __DEFAULT_FN_ATTRS __riscv_##name(ty __rs1, ty __rs2) { \
     return (__rs1 << 1) + __rs2;                                               \
@@ -728,6 +740,14 @@ __packed_binary_builtin(pmulhru_u16x2, uint16x2_t, __builtin_riscv_pmulhru_u16x2
 __packed_binary_builtin_mixed(pmulhsu_i16x2, int16x2_t, int16x2_t, uint16x2_t, __builtin_riscv_pmulhsu_i16x2)
 __packed_binary_builtin_mixed(pmulhrsu_i16x2, int16x2_t, int16x2_t, uint16x2_t, __builtin_riscv_pmulhrsu_i16x2)
 
+/* Packed Multiply High Accumulate (32-bit) */
+__packed_ternary_builtin(pmhacc_i16x2, int16x2_t, __builtin_riscv_pmhacc_i16x2)
+__packed_ternary_builtin(pmhracc_i16x2, int16x2_t, __builtin_riscv_pmhracc_i16x2)
+__packed_ternary_builtin(pmhaccu_u16x2, uint16x2_t, __builtin_riscv_pmhaccu_u16x2)
+__packed_ternary_builtin(pmhraccu_u16x2, uint16x2_t, __builtin_riscv_pmhraccu_u16x2)
+__packed_ternary_builtin_mixed(pmhaccsu_i16x2, int16x2_t, int16x2_t, uint16x2_t, __builtin_riscv_pmhaccsu_i16x2)
+__packed_ternary_builtin_mixed(pmhraccsu_i16x2, int16x2_t, int16x2_t, uint16x2_t, __builtin_riscv_pmhraccsu_i16x2)
+
 /* Packed Multiply High (64-bit) */
 __packed_binary_builtin(pmulh_i16x4, int16x4_t, __builtin_riscv_pmulh_i16x4)
 __packed_binary_builtin(pmulh_i32x2, int32x2_t, __builtin_riscv_pmulh_i32x2)
@@ -741,6 +761,20 @@ __packed_binary_builtin_mixed(pmulhsu_i16x4, int16x4_t, int16x4_t, uint16x4_t, _
 __packed_binary_builtin_mixed(pmulhsu_i32x2, int32x2_t, int32x2_t, uint32x2_t, __builtin_riscv_pmulhsu_i32x2)
 __packed_binary_builtin_mixed(pmulhrsu_i16x4, int16x4_t, int16x4_t, uint16x4_t, __builtin_riscv_pmulhrsu_i16x4)
 __packed_binary_builtin_mixed(pmulhrsu_i32x2, int32x2_t, int32x2_t, uint32x2_t, __builtin_riscv_pmulhrsu_i32x2)
+
+/* Packed Multiply High Accumulate (64-bit) */
+__packed_ternary_builtin(pmhacc_i16x4, int16x4_t, __builtin_riscv_pmhacc_i16x4)
+__packed_ternary_builtin(pmhacc_i32x2, int32x2_t, __builtin_riscv_pmhacc_i32x2)
+__packed_ternary_builtin(pmhracc_i16x4, int16x4_t, __builtin_riscv_pmhracc_i16x4)
+__packed_ternary_builtin(pmhracc_i32x2, int32x2_t, __builtin_riscv_pmhracc_i32x2)
+__packed_ternary_builtin(pmhaccu_u16x4, uint16x4_t, __builtin_riscv_pmhaccu_u16x4)
+__packed_ternary_builtin(pmhaccu_u32x2, uint32x2_t, __builtin_riscv_pmhaccu_u32x2)
+__packed_ternary_builtin(pmhraccu_u16x4, uint16x4_t, __builtin_riscv_pmhraccu_u16x4)
+__packed_ternary_builtin(pmhraccu_u32x2, uint32x2_t, __builtin_riscv_pmhraccu_u32x2)
+__packed_ternary_builtin_mixed(pmhaccsu_i16x4, int16x4_t, int16x4_t, uint16x4_t, __builtin_riscv_pmhaccsu_i16x4)
+__packed_ternary_builtin_mixed(pmhaccsu_i32x2, int32x2_t, int32x2_t, uint32x2_t, __builtin_riscv_pmhaccsu_i32x2)
+__packed_ternary_builtin_mixed(pmhraccsu_i16x4, int16x4_t, int16x4_t, uint16x4_t, __builtin_riscv_pmhraccsu_i16x4)
+__packed_ternary_builtin_mixed(pmhraccsu_i32x2, int32x2_t, int32x2_t, uint32x2_t, __builtin_riscv_pmhraccsu_i32x2)
 
 /* Packed Absolute Difference Sum (32-bit) */
 __packed_abdsum(pabdsumu_u8x4_u32, uint32_t, uint8x4_t, __builtin_riscv_pabdsumu_u8x4_u32)
@@ -900,6 +934,8 @@ __packed_reinterpret(u32x2_i32x2, int32x2_t, uint32x2_t)
 #undef __packed_unary_op
 #undef __packed_binary_builtin
 #undef __packed_binary_builtin_mixed
+#undef __packed_ternary_builtin
+#undef __packed_ternary_builtin_mixed
 #undef __packed_sh1add
 #undef __packed_sh1sadd
 #undef __packed_cmp

--- a/cross-project-tests/intrinsic-header-tests/riscv_packed_simd.c
+++ b/cross-project-tests/intrinsic-header-tests/riscv_packed_simd.c
@@ -2502,6 +2502,136 @@ int32x2_t test_pmulhrsu_i32x2(int32x2_t rs1, uint32x2_t rs2) {
   return __riscv_pmulhrsu_i32x2(rs1, rs2);
 }
 
+// CHECK-LABEL: test_pmhacc_i16x2:
+// CHECK:       pmhacc.h
+int16x2_t test_pmhacc_i16x2(int16x2_t rd, int16x2_t rs1, int16x2_t rs2) {
+  return __riscv_pmhacc_i16x2(rd, rs1, rs2);
+}
+
+// CHECK-LABEL: test_pmhracc_i16x2:
+// CHECK:       pmhracc.h
+int16x2_t test_pmhracc_i16x2(int16x2_t rd, int16x2_t rs1, int16x2_t rs2) {
+  return __riscv_pmhracc_i16x2(rd, rs1, rs2);
+}
+
+// CHECK-LABEL: test_pmhaccu_u16x2:
+// CHECK:       pmhaccu.h
+uint16x2_t test_pmhaccu_u16x2(uint16x2_t rd, uint16x2_t rs1,
+                              uint16x2_t rs2) {
+  return __riscv_pmhaccu_u16x2(rd, rs1, rs2);
+}
+
+// CHECK-LABEL: test_pmhraccu_u16x2:
+// CHECK:       pmhraccu.h
+uint16x2_t test_pmhraccu_u16x2(uint16x2_t rd, uint16x2_t rs1,
+                               uint16x2_t rs2) {
+  return __riscv_pmhraccu_u16x2(rd, rs1, rs2);
+}
+
+// CHECK-LABEL: test_pmhaccsu_i16x2:
+// CHECK:       pmhaccsu.h
+int16x2_t test_pmhaccsu_i16x2(int16x2_t rd, int16x2_t rs1,
+                              uint16x2_t rs2) {
+  return __riscv_pmhaccsu_i16x2(rd, rs1, rs2);
+}
+
+// CHECK-LABEL: test_pmhraccsu_i16x2:
+// CHECK:       pmhraccsu.h
+int16x2_t test_pmhraccsu_i16x2(int16x2_t rd, int16x2_t rs1,
+                               uint16x2_t rs2) {
+  return __riscv_pmhraccsu_i16x2(rd, rs1, rs2);
+}
+
+// CHECK-LABEL: test_pmhacc_i16x4:
+// RV32-COUNT-2: pmhacc.h
+// RV64:         pmhacc.h
+int16x4_t test_pmhacc_i16x4(int16x4_t rd, int16x4_t rs1, int16x4_t rs2) {
+  return __riscv_pmhacc_i16x4(rd, rs1, rs2);
+}
+
+// CHECK-LABEL: test_pmhracc_i16x4:
+// RV32-COUNT-2: pmhracc.h
+// RV64:         pmhracc.h
+int16x4_t test_pmhracc_i16x4(int16x4_t rd, int16x4_t rs1, int16x4_t rs2) {
+  return __riscv_pmhracc_i16x4(rd, rs1, rs2);
+}
+
+// CHECK-LABEL: test_pmhaccu_u16x4:
+// RV32-COUNT-2: pmhaccu.h
+// RV64:         pmhaccu.h
+uint16x4_t test_pmhaccu_u16x4(uint16x4_t rd, uint16x4_t rs1,
+                              uint16x4_t rs2) {
+  return __riscv_pmhaccu_u16x4(rd, rs1, rs2);
+}
+
+// CHECK-LABEL: test_pmhraccu_u16x4:
+// RV32-COUNT-2: pmhraccu.h
+// RV64:         pmhraccu.h
+uint16x4_t test_pmhraccu_u16x4(uint16x4_t rd, uint16x4_t rs1,
+                               uint16x4_t rs2) {
+  return __riscv_pmhraccu_u16x4(rd, rs1, rs2);
+}
+
+// CHECK-LABEL: test_pmhaccsu_i16x4:
+// RV32-COUNT-2: pmhaccsu.h
+// RV64:         pmhaccsu.h
+int16x4_t test_pmhaccsu_i16x4(int16x4_t rd, int16x4_t rs1,
+                              uint16x4_t rs2) {
+  return __riscv_pmhaccsu_i16x4(rd, rs1, rs2);
+}
+
+// CHECK-LABEL: test_pmhraccsu_i16x4:
+// RV32-COUNT-2: pmhraccsu.h
+// RV64:         pmhraccsu.h
+int16x4_t test_pmhraccsu_i16x4(int16x4_t rd, int16x4_t rs1,
+                               uint16x4_t rs2) {
+  return __riscv_pmhraccsu_i16x4(rd, rs1, rs2);
+}
+
+// CHECK-LABEL: test_pmhacc_i32x2:
+// RV32-COUNT-2: mhacc
+// RV64:         pmhacc.w
+int32x2_t test_pmhacc_i32x2(int32x2_t rd, int32x2_t rs1, int32x2_t rs2) {
+  return __riscv_pmhacc_i32x2(rd, rs1, rs2);
+}
+
+// CHECK-LABEL: test_pmhracc_i32x2:
+// RV32-COUNT-2: mhracc
+// RV64:         pmhracc.w
+int32x2_t test_pmhracc_i32x2(int32x2_t rd, int32x2_t rs1, int32x2_t rs2) {
+  return __riscv_pmhracc_i32x2(rd, rs1, rs2);
+}
+
+// CHECK-LABEL: test_pmhaccu_u32x2:
+// RV32-COUNT-2: mhaccu
+// RV64:         pmhaccu.w
+uint32x2_t test_pmhaccu_u32x2(uint32x2_t rd, uint32x2_t rs1,
+                              uint32x2_t rs2) {
+  return __riscv_pmhaccu_u32x2(rd, rs1, rs2);
+}
+
+// CHECK-LABEL: test_pmhraccu_u32x2:
+// RV32-COUNT-2: mhraccu
+// RV64:         pmhraccu.w
+uint32x2_t test_pmhraccu_u32x2(uint32x2_t rd, uint32x2_t rs1,
+                               uint32x2_t rs2) {
+  return __riscv_pmhraccu_u32x2(rd, rs1, rs2);
+}
+
+// CHECK-LABEL: test_pmhaccsu_i32x2:
+// RV32-COUNT-2: mhaccsu
+// RV64:         pmhaccsu.w
+int32x2_t test_pmhaccsu_i32x2(int32x2_t rd, int32x2_t rs1, uint32x2_t rs2) {
+  return __riscv_pmhaccsu_i32x2(rd, rs1, rs2);
+}
+
+// CHECK-LABEL: test_pmhraccsu_i32x2:
+// RV32-COUNT-2: mhraccsu
+// RV64:         pmhraccsu.w
+int32x2_t test_pmhraccsu_i32x2(int32x2_t rd, int32x2_t rs1, uint32x2_t rs2) {
+  return __riscv_pmhraccsu_i32x2(rd, rs1, rs2);
+}
+
 // CHECK-LABEL: test_prev_i8x4:
 // CHECK:       rev8
 int8x4_t test_prev_i8x4(int8x4_t a) { return __riscv_prev_i8x4(a); }

--- a/cross-project-tests/intrinsic-header-tests/riscv_packed_simd.c
+++ b/cross-project-tests/intrinsic-header-tests/riscv_packed_simd.c
@@ -2516,29 +2516,25 @@ int16x2_t test_pmhracc_i16x2(int16x2_t rd, int16x2_t rs1, int16x2_t rs2) {
 
 // CHECK-LABEL: test_pmhaccu_u16x2:
 // CHECK:       pmhaccu.h
-uint16x2_t test_pmhaccu_u16x2(uint16x2_t rd, uint16x2_t rs1,
-                              uint16x2_t rs2) {
+uint16x2_t test_pmhaccu_u16x2(uint16x2_t rd, uint16x2_t rs1, uint16x2_t rs2) {
   return __riscv_pmhaccu_u16x2(rd, rs1, rs2);
 }
 
 // CHECK-LABEL: test_pmhraccu_u16x2:
 // CHECK:       pmhraccu.h
-uint16x2_t test_pmhraccu_u16x2(uint16x2_t rd, uint16x2_t rs1,
-                               uint16x2_t rs2) {
+uint16x2_t test_pmhraccu_u16x2(uint16x2_t rd, uint16x2_t rs1, uint16x2_t rs2) {
   return __riscv_pmhraccu_u16x2(rd, rs1, rs2);
 }
 
 // CHECK-LABEL: test_pmhaccsu_i16x2:
 // CHECK:       pmhaccsu.h
-int16x2_t test_pmhaccsu_i16x2(int16x2_t rd, int16x2_t rs1,
-                              uint16x2_t rs2) {
+int16x2_t test_pmhaccsu_i16x2(int16x2_t rd, int16x2_t rs1, uint16x2_t rs2) {
   return __riscv_pmhaccsu_i16x2(rd, rs1, rs2);
 }
 
 // CHECK-LABEL: test_pmhraccsu_i16x2:
 // CHECK:       pmhraccsu.h
-int16x2_t test_pmhraccsu_i16x2(int16x2_t rd, int16x2_t rs1,
-                               uint16x2_t rs2) {
+int16x2_t test_pmhraccsu_i16x2(int16x2_t rd, int16x2_t rs1, uint16x2_t rs2) {
   return __riscv_pmhraccsu_i16x2(rd, rs1, rs2);
 }
 
@@ -2559,32 +2555,28 @@ int16x4_t test_pmhracc_i16x4(int16x4_t rd, int16x4_t rs1, int16x4_t rs2) {
 // CHECK-LABEL: test_pmhaccu_u16x4:
 // RV32-COUNT-2: pmhaccu.h
 // RV64:         pmhaccu.h
-uint16x4_t test_pmhaccu_u16x4(uint16x4_t rd, uint16x4_t rs1,
-                              uint16x4_t rs2) {
+uint16x4_t test_pmhaccu_u16x4(uint16x4_t rd, uint16x4_t rs1, uint16x4_t rs2) {
   return __riscv_pmhaccu_u16x4(rd, rs1, rs2);
 }
 
 // CHECK-LABEL: test_pmhraccu_u16x4:
 // RV32-COUNT-2: pmhraccu.h
 // RV64:         pmhraccu.h
-uint16x4_t test_pmhraccu_u16x4(uint16x4_t rd, uint16x4_t rs1,
-                               uint16x4_t rs2) {
+uint16x4_t test_pmhraccu_u16x4(uint16x4_t rd, uint16x4_t rs1, uint16x4_t rs2) {
   return __riscv_pmhraccu_u16x4(rd, rs1, rs2);
 }
 
 // CHECK-LABEL: test_pmhaccsu_i16x4:
 // RV32-COUNT-2: pmhaccsu.h
 // RV64:         pmhaccsu.h
-int16x4_t test_pmhaccsu_i16x4(int16x4_t rd, int16x4_t rs1,
-                              uint16x4_t rs2) {
+int16x4_t test_pmhaccsu_i16x4(int16x4_t rd, int16x4_t rs1, uint16x4_t rs2) {
   return __riscv_pmhaccsu_i16x4(rd, rs1, rs2);
 }
 
 // CHECK-LABEL: test_pmhraccsu_i16x4:
 // RV32-COUNT-2: pmhraccsu.h
 // RV64:         pmhraccsu.h
-int16x4_t test_pmhraccsu_i16x4(int16x4_t rd, int16x4_t rs1,
-                               uint16x4_t rs2) {
+int16x4_t test_pmhraccsu_i16x4(int16x4_t rd, int16x4_t rs1, uint16x4_t rs2) {
   return __riscv_pmhraccsu_i16x4(rd, rs1, rs2);
 }
 
@@ -2605,16 +2597,14 @@ int32x2_t test_pmhracc_i32x2(int32x2_t rd, int32x2_t rs1, int32x2_t rs2) {
 // CHECK-LABEL: test_pmhaccu_u32x2:
 // RV32-COUNT-2: mhaccu
 // RV64:         pmhaccu.w
-uint32x2_t test_pmhaccu_u32x2(uint32x2_t rd, uint32x2_t rs1,
-                              uint32x2_t rs2) {
+uint32x2_t test_pmhaccu_u32x2(uint32x2_t rd, uint32x2_t rs1, uint32x2_t rs2) {
   return __riscv_pmhaccu_u32x2(rd, rs1, rs2);
 }
 
 // CHECK-LABEL: test_pmhraccu_u32x2:
 // RV32-COUNT-2: mhraccu
 // RV64:         pmhraccu.w
-uint32x2_t test_pmhraccu_u32x2(uint32x2_t rd, uint32x2_t rs1,
-                               uint32x2_t rs2) {
+uint32x2_t test_pmhraccu_u32x2(uint32x2_t rd, uint32x2_t rs1, uint32x2_t rs2) {
   return __riscv_pmhraccu_u32x2(rd, rs1, rs2);
 }
 

--- a/llvm/include/llvm/IR/IntrinsicsRISCV.td
+++ b/llvm/include/llvm/IR/IntrinsicsRISCV.td
@@ -2117,6 +2117,14 @@ class RVPBinaryIntrinsic
   def int_riscv_pmulhsu  : RVPBinaryIntrinsic;
   def int_riscv_pmulhrsu : RVPBinaryIntrinsic;
 
+  // Packed Multiply High Accumulate.
+  def int_riscv_pmhacc    : RVPTernaryIntrinsic;
+  def int_riscv_pmhracc   : RVPTernaryIntrinsic;
+  def int_riscv_pmhaccu   : RVPTernaryIntrinsic;
+  def int_riscv_pmhraccu  : RVPTernaryIntrinsic;
+  def int_riscv_pmhaccsu  : RVPTernaryIntrinsic;
+  def int_riscv_pmhraccsu : RVPTernaryIntrinsic;
+
   // Packed Absolute Difference Sum.
   def int_riscv_pabdsumu
       : DefaultAttrsIntrinsic<[llvm_anyint_ty],

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -12134,6 +12134,26 @@ static unsigned getRVPMulHighOpcode(unsigned IntNo) {
   }
 }
 
+static unsigned getRVPMulHighAccumulateOpcode(unsigned IntNo) {
+  switch (IntNo) {
+  default:
+    llvm_unreachable(
+        "Unexpected RISC-V packed multiply high accumulate intrinsic");
+  case Intrinsic::riscv_pmhacc:
+    return RISCVISD::PMHACC;
+  case Intrinsic::riscv_pmhracc:
+    return RISCVISD::PMHRACC;
+  case Intrinsic::riscv_pmhaccu:
+    return RISCVISD::PMHACCU;
+  case Intrinsic::riscv_pmhraccu:
+    return RISCVISD::PMHRACCU;
+  case Intrinsic::riscv_pmhaccsu:
+    return RISCVISD::PMHACCSU;
+  case Intrinsic::riscv_pmhraccsu:
+    return RISCVISD::PMHRACCSU;
+  }
+}
+
 SDValue RISCVTargetLowering::LowerINTRINSIC_WO_CHAIN(SDValue Op,
                                                      SelectionDAG &DAG) const {
   unsigned IntNo = Op.getConstantOperandVal(0);
@@ -12485,6 +12505,45 @@ SDValue RISCVTargetLowering::LowerINTRINSIC_WO_CHAIN(SDValue Op,
     }
 
     return DAG.getNode(Opc, DL, VT, Op.getOperand(1), Op.getOperand(2));
+  }
+  case Intrinsic::riscv_pmhacc:
+  case Intrinsic::riscv_pmhracc:
+  case Intrinsic::riscv_pmhaccu:
+  case Intrinsic::riscv_pmhraccu:
+  case Intrinsic::riscv_pmhaccsu:
+  case Intrinsic::riscv_pmhraccsu: {
+    EVT VT = Op.getValueType();
+    unsigned MulOpc = getRVPMulHighAccumulateOpcode(IntNo);
+    SDValue Rd = Op.getOperand(1);
+    SDValue Rs1 = Op.getOperand(2);
+    SDValue Rs2 = Op.getOperand(3);
+
+    // RV32 has no single instruction for 64-bit packed multiply high
+    // accumulate. Split v4i16 into two v2i16 packed operations, and split
+    // v2i32 into scalar i32 operations.
+    if (!Subtarget.is64Bit() && VT == MVT::v4i16) {
+      auto [RdLo, RdHi] = DAG.SplitVector(Rd, DL);
+      auto [Rs1Lo, Rs1Hi] = DAG.SplitVector(Rs1, DL);
+      auto [Rs2Lo, Rs2Hi] = DAG.SplitVector(Rs2, DL);
+      SDValue Lo =
+          DAG.getNode(MulOpc, DL, MVT::v2i16, RdLo, Rs1Lo, Rs2Lo);
+      SDValue Hi =
+          DAG.getNode(MulOpc, DL, MVT::v2i16, RdHi, Rs1Hi, Rs2Hi);
+      return DAG.getNode(ISD::CONCAT_VECTORS, DL, VT, Lo, Hi);
+    }
+
+    if (!Subtarget.is64Bit() && VT == MVT::v2i32) {
+      auto Extract = [&](SDValue V, unsigned Idx) {
+        return DAG.getExtractVectorElt(DL, MVT::i32, V, Idx);
+      };
+      SDValue Lo = DAG.getNode(MulOpc, DL, MVT::i32, Extract(Rd, 0),
+                                Extract(Rs1, 0), Extract(Rs2, 0));
+      SDValue Hi = DAG.getNode(MulOpc, DL, MVT::i32, Extract(Rd, 1),
+                                Extract(Rs1, 1), Extract(Rs2, 1));
+      return DAG.getNode(ISD::BUILD_VECTOR, DL, VT, Lo, Hi);
+    }
+
+    return DAG.getNode(MulOpc, DL, VT, Rd, Rs1, Rs2);
   }
   case Intrinsic::riscv_pmerge: {
     EVT VT = Op.getValueType();
@@ -16551,6 +16610,30 @@ void RISCVTargetLowering::ReplaceNodeResults(SDNode *N,
                           DAG.getValueType(MVT::v4i8));
       else
         Res = lowerPZExt(Src, DL, DAG, Subtarget);
+      Results.push_back(DAG.getExtractSubvector(DL, VT, Res, 0));
+      return;
+    }
+    case Intrinsic::riscv_pmhacc:
+    case Intrinsic::riscv_pmhracc:
+    case Intrinsic::riscv_pmhaccu:
+    case Intrinsic::riscv_pmhraccu:
+    case Intrinsic::riscv_pmhaccsu:
+    case Intrinsic::riscv_pmhraccsu: {
+      EVT VT = N->getValueType(0);
+      if (!Subtarget.is64Bit() || VT != MVT::v2i16)
+        return;
+
+      EVT WideVT = MVT::v4i16;
+      SDValue Undef = DAG.getUNDEF(VT);
+      SDValue Rd = DAG.getNode(ISD::CONCAT_VECTORS, DL, WideVT,
+                               N->getOperand(1), Undef);
+      SDValue Rs1 = DAG.getNode(ISD::CONCAT_VECTORS, DL, WideVT,
+                                N->getOperand(2), Undef);
+      SDValue Rs2 = DAG.getNode(ISD::CONCAT_VECTORS, DL, WideVT,
+                                N->getOperand(3), Undef);
+      SDValue Res =
+          DAG.getNode(getRVPMulHighAccumulateOpcode(IntNo), DL, WideVT, Rd,
+                      Rs1, Rs2);
       Results.push_back(DAG.getExtractSubvector(DL, VT, Res, 0));
       return;
     }

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -12140,17 +12140,17 @@ static unsigned getRVPMulHighAccumulateOpcode(unsigned IntNo) {
     llvm_unreachable(
         "Unexpected RISC-V packed multiply high accumulate intrinsic");
   case Intrinsic::riscv_pmhacc:
-    return RISCVISD::PMHACC;
+    return RISCVISD::MHACC;
   case Intrinsic::riscv_pmhracc:
-    return RISCVISD::PMHRACC;
+    return RISCVISD::MHRACC;
   case Intrinsic::riscv_pmhaccu:
-    return RISCVISD::PMHACCU;
+    return RISCVISD::MHACCU;
   case Intrinsic::riscv_pmhraccu:
-    return RISCVISD::PMHRACCU;
+    return RISCVISD::MHRACCU;
   case Intrinsic::riscv_pmhaccsu:
-    return RISCVISD::PMHACCSU;
+    return RISCVISD::MHACCSU;
   case Intrinsic::riscv_pmhraccsu:
-    return RISCVISD::PMHRACCSU;
+    return RISCVISD::MHRACCSU;
   }
 }
 

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -12525,10 +12525,8 @@ SDValue RISCVTargetLowering::LowerINTRINSIC_WO_CHAIN(SDValue Op,
       auto [RdLo, RdHi] = DAG.SplitVector(Rd, DL);
       auto [Rs1Lo, Rs1Hi] = DAG.SplitVector(Rs1, DL);
       auto [Rs2Lo, Rs2Hi] = DAG.SplitVector(Rs2, DL);
-      SDValue Lo =
-          DAG.getNode(MulOpc, DL, MVT::v2i16, RdLo, Rs1Lo, Rs2Lo);
-      SDValue Hi =
-          DAG.getNode(MulOpc, DL, MVT::v2i16, RdHi, Rs1Hi, Rs2Hi);
+      SDValue Lo = DAG.getNode(MulOpc, DL, MVT::v2i16, RdLo, Rs1Lo, Rs2Lo);
+      SDValue Hi = DAG.getNode(MulOpc, DL, MVT::v2i16, RdHi, Rs1Hi, Rs2Hi);
       return DAG.getNode(ISD::CONCAT_VECTORS, DL, VT, Lo, Hi);
     }
 
@@ -12537,9 +12535,9 @@ SDValue RISCVTargetLowering::LowerINTRINSIC_WO_CHAIN(SDValue Op,
         return DAG.getExtractVectorElt(DL, MVT::i32, V, Idx);
       };
       SDValue Lo = DAG.getNode(MulOpc, DL, MVT::i32, Extract(Rd, 0),
-                                Extract(Rs1, 0), Extract(Rs2, 0));
+                               Extract(Rs1, 0), Extract(Rs2, 0));
       SDValue Hi = DAG.getNode(MulOpc, DL, MVT::i32, Extract(Rd, 1),
-                                Extract(Rs1, 1), Extract(Rs2, 1));
+                               Extract(Rs1, 1), Extract(Rs2, 1));
       return DAG.getNode(ISD::BUILD_VECTOR, DL, VT, Lo, Hi);
     }
 
@@ -16625,15 +16623,14 @@ void RISCVTargetLowering::ReplaceNodeResults(SDNode *N,
 
       EVT WideVT = MVT::v4i16;
       SDValue Undef = DAG.getUNDEF(VT);
-      SDValue Rd = DAG.getNode(ISD::CONCAT_VECTORS, DL, WideVT,
-                               N->getOperand(1), Undef);
-      SDValue Rs1 = DAG.getNode(ISD::CONCAT_VECTORS, DL, WideVT,
-                                N->getOperand(2), Undef);
-      SDValue Rs2 = DAG.getNode(ISD::CONCAT_VECTORS, DL, WideVT,
-                                N->getOperand(3), Undef);
-      SDValue Res =
-          DAG.getNode(getRVPMulHighAccumulateOpcode(IntNo), DL, WideVT, Rd,
-                      Rs1, Rs2);
+      SDValue Rd =
+          DAG.getNode(ISD::CONCAT_VECTORS, DL, WideVT, N->getOperand(1), Undef);
+      SDValue Rs1 =
+          DAG.getNode(ISD::CONCAT_VECTORS, DL, WideVT, N->getOperand(2), Undef);
+      SDValue Rs2 =
+          DAG.getNode(ISD::CONCAT_VECTORS, DL, WideVT, N->getOperand(3), Undef);
+      SDValue Res = DAG.getNode(getRVPMulHighAccumulateOpcode(IntNo), DL,
+                                WideVT, Rd, Rs1, Rs2);
       Results.push_back(DAG.getExtractSubvector(DL, VT, Res, 0));
       return;
     }

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -1778,6 +1778,10 @@ class PatAbdSumAcc<SDPatternOperator OpNode, RVInst Inst, ValueType VecVT>
     : Pat<(XLenVT (OpNode (XLenVT GPR:$rd), (VecVT GPR:$rs1), (VecVT GPR:$rs2))),
           (Inst GPR:$rd, GPR:$rs1, GPR:$rs2)>;
 
+class PatGprGprGpr<SDPatternOperator OpNode, RVInst Inst, ValueType VT>
+    : Pat<(VT (OpNode (VT GPR:$rd), (VT GPR:$rs1), (VT GPR:$rs2))),
+          (Inst GPR:$rd, GPR:$rs1, GPR:$rs2)>;
+
 class PatGprPairImm<SDPatternOperator OpNode, RVInst Inst,
                     SDPatternOperator ImmType, ValueType vt>
     : Pat<(vt (OpNode (vt GPRPair:$rs1), ImmType:$imm)),
@@ -1886,6 +1890,18 @@ def riscv_asubu : RVSDNode<"ASUBU", SDTIntBinOp>;
 def riscv_mulhr : RVSDNode<"MULHR", SDTIntBinOp>;
 def riscv_mulhru : RVSDNode<"MULHRU", SDTIntBinOp>;
 def riscv_mulhrsu : RVSDNode<"MULHRSU", SDTIntBinOp>;
+
+def SDT_RISCVSameTernary : SDTypeProfile<1, 3, [SDTCisSameAs<0, 1>,
+                                                SDTCisSameAs<0, 2>,
+                                                SDTCisSameAs<0, 3>]>;
+
+// Packed multiply high accumulate operations.
+def riscv_pmhacc    : RVSDNode<"PMHACC", SDT_RISCVSameTernary>;
+def riscv_pmhracc   : RVSDNode<"PMHRACC", SDT_RISCVSameTernary>;
+def riscv_pmhaccu   : RVSDNode<"PMHACCU", SDT_RISCVSameTernary>;
+def riscv_pmhraccu  : RVSDNode<"PMHRACCU", SDT_RISCVSameTernary>;
+def riscv_pmhaccsu  : RVSDNode<"PMHACCSU", SDT_RISCVSameTernary>;
+def riscv_pmhraccsu : RVSDNode<"PMHRACCSU", SDT_RISCVSameTernary>;
 
 // "Q-format" multiplication
 def riscv_mulq  : RVSDNode<"MULQ",  SDTIntBinOp>;
@@ -2126,6 +2142,14 @@ let Predicates = [HasStdExtP] in {
   def : PatGprGpr<riscv_mulhru, PMULHRU_H, XLenVecI16VT>;
   def : PatGprGpr<riscv_mulhrsu, PMULHRSU_H, XLenVecI16VT>;
 
+  // 16-bit multiply high accumulate patterns
+  def : PatGprGprGpr<riscv_pmhacc, PMHACC_H, XLenVecI16VT>;
+  def : PatGprGprGpr<riscv_pmhracc, PMHRACC_H, XLenVecI16VT>;
+  def : PatGprGprGpr<riscv_pmhaccu, PMHACCU_H, XLenVecI16VT>;
+  def : PatGprGprGpr<riscv_pmhraccu, PMHRACCU_H, XLenVecI16VT>;
+  def : PatGprGprGpr<riscv_pmhaccsu, PMHACCSU_H, XLenVecI16VT>;
+  def : PatGprGprGpr<riscv_pmhraccsu, PMHRACCSU_H, XLenVecI16VT>;
+
   // 16-bit "Q-format" multiplication patterns
   def : PatGprGpr<riscv_mulq, PMULQ_H, XLenVecI16VT>;
   def : PatGprGpr<riscv_mulqr, PMULQR_H, XLenVecI16VT>;
@@ -2239,6 +2263,14 @@ let append Predicates = [IsRV32] in {
   def : PatGprGpr<riscv_mulhr, MULHR, i32>;
   def : PatGprGpr<riscv_mulhru, MULHRU, i32>;
   def : PatGprGpr<riscv_mulhrsu, MULHRSU, i32>;
+
+  // 32-bit multiply high accumulate patterns
+  def : PatGprGprGpr<riscv_pmhacc, MHACC, i32>;
+  def : PatGprGprGpr<riscv_pmhracc, MHRACC, i32>;
+  def : PatGprGprGpr<riscv_pmhaccu, MHACCU, i32>;
+  def : PatGprGprGpr<riscv_pmhraccu, MHRACCU, i32>;
+  def : PatGprGprGpr<riscv_pmhaccsu, MHACCSU, i32>;
+  def : PatGprGprGpr<riscv_pmhraccsu, MHRACCSU, i32>;
 
   // 32-bit "Q-format" multiplication patterns
   def : PatGprGpr<riscv_mulq, MULQ, i32>;
@@ -2775,6 +2807,14 @@ let append Predicates = [IsRV64] in {
   def : PatGprGpr<riscv_mulhr, PMULHR_W, v2i32>;
   def : PatGprGpr<riscv_mulhru, PMULHRU_W, v2i32>;
   def : PatGprGpr<riscv_mulhrsu, PMULHRSU_W, v2i32>;
+
+  // 32-bit multiply high accumulate patterns
+  def : PatGprGprGpr<riscv_pmhacc, PMHACC_W, v2i32>;
+  def : PatGprGprGpr<riscv_pmhracc, PMHRACC_W, v2i32>;
+  def : PatGprGprGpr<riscv_pmhaccu, PMHACCU_W, v2i32>;
+  def : PatGprGprGpr<riscv_pmhraccu, PMHRACCU_W, v2i32>;
+  def : PatGprGprGpr<riscv_pmhaccsu, PMHACCSU_W, v2i32>;
+  def : PatGprGprGpr<riscv_pmhraccsu, PMHRACCSU_W, v2i32>;
 
   // 32-bit "Q-format" multiplication patterns
   def : PatGprGpr<riscv_mulq, PMULQ_W, v2i32>;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -1895,13 +1895,13 @@ def SDT_RISCVSameTernary : SDTypeProfile<1, 3, [SDTCisSameAs<0, 1>,
                                                 SDTCisSameAs<0, 2>,
                                                 SDTCisSameAs<0, 3>]>;
 
-// Packed multiply high accumulate operations.
-def riscv_pmhacc    : RVSDNode<"PMHACC", SDT_RISCVSameTernary>;
-def riscv_pmhracc   : RVSDNode<"PMHRACC", SDT_RISCVSameTernary>;
-def riscv_pmhaccu   : RVSDNode<"PMHACCU", SDT_RISCVSameTernary>;
-def riscv_pmhraccu  : RVSDNode<"PMHRACCU", SDT_RISCVSameTernary>;
-def riscv_pmhaccsu  : RVSDNode<"PMHACCSU", SDT_RISCVSameTernary>;
-def riscv_pmhraccsu : RVSDNode<"PMHRACCSU", SDT_RISCVSameTernary>;
+// Multiply high accumulate operations.
+def riscv_mhacc    : RVSDNode<"MHACC", SDT_RISCVSameTernary>;
+def riscv_mhracc   : RVSDNode<"MHRACC", SDT_RISCVSameTernary>;
+def riscv_mhaccu   : RVSDNode<"MHACCU", SDT_RISCVSameTernary>;
+def riscv_mhraccu  : RVSDNode<"MHRACCU", SDT_RISCVSameTernary>;
+def riscv_mhaccsu  : RVSDNode<"MHACCSU", SDT_RISCVSameTernary>;
+def riscv_mhraccsu : RVSDNode<"MHRACCSU", SDT_RISCVSameTernary>;
 
 // "Q-format" multiplication
 def riscv_mulq  : RVSDNode<"MULQ",  SDTIntBinOp>;
@@ -2143,12 +2143,12 @@ let Predicates = [HasStdExtP] in {
   def : PatGprGpr<riscv_mulhrsu, PMULHRSU_H, XLenVecI16VT>;
 
   // 16-bit multiply high accumulate patterns
-  def : PatGprGprGpr<riscv_pmhacc, PMHACC_H, XLenVecI16VT>;
-  def : PatGprGprGpr<riscv_pmhracc, PMHRACC_H, XLenVecI16VT>;
-  def : PatGprGprGpr<riscv_pmhaccu, PMHACCU_H, XLenVecI16VT>;
-  def : PatGprGprGpr<riscv_pmhraccu, PMHRACCU_H, XLenVecI16VT>;
-  def : PatGprGprGpr<riscv_pmhaccsu, PMHACCSU_H, XLenVecI16VT>;
-  def : PatGprGprGpr<riscv_pmhraccsu, PMHRACCSU_H, XLenVecI16VT>;
+  def : PatGprGprGpr<riscv_mhacc, PMHACC_H, XLenVecI16VT>;
+  def : PatGprGprGpr<riscv_mhracc, PMHRACC_H, XLenVecI16VT>;
+  def : PatGprGprGpr<riscv_mhaccu, PMHACCU_H, XLenVecI16VT>;
+  def : PatGprGprGpr<riscv_mhraccu, PMHRACCU_H, XLenVecI16VT>;
+  def : PatGprGprGpr<riscv_mhaccsu, PMHACCSU_H, XLenVecI16VT>;
+  def : PatGprGprGpr<riscv_mhraccsu, PMHRACCSU_H, XLenVecI16VT>;
 
   // 16-bit "Q-format" multiplication patterns
   def : PatGprGpr<riscv_mulq, PMULQ_H, XLenVecI16VT>;
@@ -2265,12 +2265,12 @@ let append Predicates = [IsRV32] in {
   def : PatGprGpr<riscv_mulhrsu, MULHRSU, i32>;
 
   // 32-bit multiply high accumulate patterns
-  def : PatGprGprGpr<riscv_pmhacc, MHACC, i32>;
-  def : PatGprGprGpr<riscv_pmhracc, MHRACC, i32>;
-  def : PatGprGprGpr<riscv_pmhaccu, MHACCU, i32>;
-  def : PatGprGprGpr<riscv_pmhraccu, MHRACCU, i32>;
-  def : PatGprGprGpr<riscv_pmhaccsu, MHACCSU, i32>;
-  def : PatGprGprGpr<riscv_pmhraccsu, MHRACCSU, i32>;
+  def : PatGprGprGpr<riscv_mhacc, MHACC, i32>;
+  def : PatGprGprGpr<riscv_mhracc, MHRACC, i32>;
+  def : PatGprGprGpr<riscv_mhaccu, MHACCU, i32>;
+  def : PatGprGprGpr<riscv_mhraccu, MHRACCU, i32>;
+  def : PatGprGprGpr<riscv_mhaccsu, MHACCSU, i32>;
+  def : PatGprGprGpr<riscv_mhraccsu, MHRACCSU, i32>;
 
   // 32-bit "Q-format" multiplication patterns
   def : PatGprGpr<riscv_mulq, MULQ, i32>;
@@ -2809,12 +2809,12 @@ let append Predicates = [IsRV64] in {
   def : PatGprGpr<riscv_mulhrsu, PMULHRSU_W, v2i32>;
 
   // 32-bit multiply high accumulate patterns
-  def : PatGprGprGpr<riscv_pmhacc, PMHACC_W, v2i32>;
-  def : PatGprGprGpr<riscv_pmhracc, PMHRACC_W, v2i32>;
-  def : PatGprGprGpr<riscv_pmhaccu, PMHACCU_W, v2i32>;
-  def : PatGprGprGpr<riscv_pmhraccu, PMHRACCU_W, v2i32>;
-  def : PatGprGprGpr<riscv_pmhaccsu, PMHACCSU_W, v2i32>;
-  def : PatGprGprGpr<riscv_pmhraccsu, PMHRACCSU_W, v2i32>;
+  def : PatGprGprGpr<riscv_mhacc, PMHACC_W, v2i32>;
+  def : PatGprGprGpr<riscv_mhracc, PMHRACC_W, v2i32>;
+  def : PatGprGprGpr<riscv_mhaccu, PMHACCU_W, v2i32>;
+  def : PatGprGprGpr<riscv_mhraccu, PMHRACCU_W, v2i32>;
+  def : PatGprGprGpr<riscv_mhaccsu, PMHACCSU_W, v2i32>;
+  def : PatGprGprGpr<riscv_mhraccsu, PMHRACCSU_W, v2i32>;
 
   // 32-bit "Q-format" multiplication patterns
   def : PatGprGpr<riscv_mulq, PMULQ_W, v2i32>;

--- a/llvm/test/CodeGen/RISCV/rvp-simd-32.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-simd-32.ll
@@ -2800,6 +2800,61 @@ define <2 x i16> @test_pmulhrsu_v2i16(<2 x i16> %rs1, <2 x i16> %rs2) {
   ret <2 x i16> %res
 }
 
+; Packed multiply high accumulate
+define <2 x i16> @test_pmhacc_v2i16(<2 x i16> %rd, <2 x i16> %rs1, <2 x i16> %rs2) {
+; CHECK-LABEL: test_pmhacc_v2i16:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    pmhacc.h a0, a1, a2
+; CHECK-NEXT:    ret
+  %res = call <2 x i16> @llvm.riscv.pmhacc.v2i16(<2 x i16> %rd, <2 x i16> %rs1, <2 x i16> %rs2)
+  ret <2 x i16> %res
+}
+
+define <2 x i16> @test_pmhracc_v2i16(<2 x i16> %rd, <2 x i16> %rs1, <2 x i16> %rs2) {
+; CHECK-LABEL: test_pmhracc_v2i16:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    pmhracc.h a0, a1, a2
+; CHECK-NEXT:    ret
+  %res = call <2 x i16> @llvm.riscv.pmhracc.v2i16(<2 x i16> %rd, <2 x i16> %rs1, <2 x i16> %rs2)
+  ret <2 x i16> %res
+}
+
+define <2 x i16> @test_pmhaccu_v2i16(<2 x i16> %rd, <2 x i16> %rs1, <2 x i16> %rs2) {
+; CHECK-LABEL: test_pmhaccu_v2i16:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    pmhaccu.h a0, a1, a2
+; CHECK-NEXT:    ret
+  %res = call <2 x i16> @llvm.riscv.pmhaccu.v2i16(<2 x i16> %rd, <2 x i16> %rs1, <2 x i16> %rs2)
+  ret <2 x i16> %res
+}
+
+define <2 x i16> @test_pmhraccu_v2i16(<2 x i16> %rd, <2 x i16> %rs1, <2 x i16> %rs2) {
+; CHECK-LABEL: test_pmhraccu_v2i16:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    pmhraccu.h a0, a1, a2
+; CHECK-NEXT:    ret
+  %res = call <2 x i16> @llvm.riscv.pmhraccu.v2i16(<2 x i16> %rd, <2 x i16> %rs1, <2 x i16> %rs2)
+  ret <2 x i16> %res
+}
+
+define <2 x i16> @test_pmhaccsu_v2i16(<2 x i16> %rd, <2 x i16> %rs1, <2 x i16> %rs2) {
+; CHECK-LABEL: test_pmhaccsu_v2i16:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    pmhaccsu.h a0, a1, a2
+; CHECK-NEXT:    ret
+  %res = call <2 x i16> @llvm.riscv.pmhaccsu.v2i16(<2 x i16> %rd, <2 x i16> %rs1, <2 x i16> %rs2)
+  ret <2 x i16> %res
+}
+
+define <2 x i16> @test_pmhraccsu_v2i16(<2 x i16> %rd, <2 x i16> %rs1, <2 x i16> %rs2) {
+; CHECK-LABEL: test_pmhraccsu_v2i16:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    pmhraccsu.h a0, a1, a2
+; CHECK-NEXT:    ret
+  %res = call <2 x i16> @llvm.riscv.pmhraccsu.v2i16(<2 x i16> %rd, <2 x i16> %rs1, <2 x i16> %rs2)
+  ret <2 x i16> %res
+}
+
 ; Packed absolute difference sum
 define i32 @test_pabdsumu_u8x4_u32(<4 x i8> %a, <4 x i8> %b) {
 ; RV32-LABEL: test_pabdsumu_u8x4_u32:

--- a/llvm/test/CodeGen/RISCV/rvp-simd-64.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-simd-64.ll
@@ -6147,6 +6147,187 @@ define <2 x i32> @test_pmulhrsu_v2i32(<2 x i32> %rs1, <2 x i32> %rs2) {
   ret <2 x i32> %res
 }
 
+; Packed multiply high accumulate
+define <4 x i16> @test_pmhacc_v4i16(<4 x i16> %rd, <4 x i16> %rs1, <4 x i16> %rs2) {
+; RV32-LABEL: test_pmhacc_v4i16:
+; RV32:       # %bb.0:
+; RV32-NEXT:    pmhacc.h a1, a3, a5
+; RV32-NEXT:    pmhacc.h a0, a2, a4
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: test_pmhacc_v4i16:
+; RV64:       # %bb.0:
+; RV64-NEXT:    pmhacc.h a0, a1, a2
+; RV64-NEXT:    ret
+  %res = call <4 x i16> @llvm.riscv.pmhacc.v4i16(<4 x i16> %rd, <4 x i16> %rs1, <4 x i16> %rs2)
+  ret <4 x i16> %res
+}
+
+define <4 x i16> @test_pmhracc_v4i16(<4 x i16> %rd, <4 x i16> %rs1, <4 x i16> %rs2) {
+; RV32-LABEL: test_pmhracc_v4i16:
+; RV32:       # %bb.0:
+; RV32-NEXT:    pmhracc.h a1, a3, a5
+; RV32-NEXT:    pmhracc.h a0, a2, a4
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: test_pmhracc_v4i16:
+; RV64:       # %bb.0:
+; RV64-NEXT:    pmhracc.h a0, a1, a2
+; RV64-NEXT:    ret
+  %res = call <4 x i16> @llvm.riscv.pmhracc.v4i16(<4 x i16> %rd, <4 x i16> %rs1, <4 x i16> %rs2)
+  ret <4 x i16> %res
+}
+
+define <4 x i16> @test_pmhaccu_v4i16(<4 x i16> %rd, <4 x i16> %rs1, <4 x i16> %rs2) {
+; RV32-LABEL: test_pmhaccu_v4i16:
+; RV32:       # %bb.0:
+; RV32-NEXT:    pmhaccu.h a1, a3, a5
+; RV32-NEXT:    pmhaccu.h a0, a2, a4
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: test_pmhaccu_v4i16:
+; RV64:       # %bb.0:
+; RV64-NEXT:    pmhaccu.h a0, a1, a2
+; RV64-NEXT:    ret
+  %res = call <4 x i16> @llvm.riscv.pmhaccu.v4i16(<4 x i16> %rd, <4 x i16> %rs1, <4 x i16> %rs2)
+  ret <4 x i16> %res
+}
+
+define <4 x i16> @test_pmhraccu_v4i16(<4 x i16> %rd, <4 x i16> %rs1, <4 x i16> %rs2) {
+; RV32-LABEL: test_pmhraccu_v4i16:
+; RV32:       # %bb.0:
+; RV32-NEXT:    pmhraccu.h a1, a3, a5
+; RV32-NEXT:    pmhraccu.h a0, a2, a4
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: test_pmhraccu_v4i16:
+; RV64:       # %bb.0:
+; RV64-NEXT:    pmhraccu.h a0, a1, a2
+; RV64-NEXT:    ret
+  %res = call <4 x i16> @llvm.riscv.pmhraccu.v4i16(<4 x i16> %rd, <4 x i16> %rs1, <4 x i16> %rs2)
+  ret <4 x i16> %res
+}
+
+define <4 x i16> @test_pmhaccsu_v4i16(<4 x i16> %rd, <4 x i16> %rs1, <4 x i16> %rs2) {
+; RV32-LABEL: test_pmhaccsu_v4i16:
+; RV32:       # %bb.0:
+; RV32-NEXT:    pmhaccsu.h a1, a3, a5
+; RV32-NEXT:    pmhaccsu.h a0, a2, a4
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: test_pmhaccsu_v4i16:
+; RV64:       # %bb.0:
+; RV64-NEXT:    pmhaccsu.h a0, a1, a2
+; RV64-NEXT:    ret
+  %res = call <4 x i16> @llvm.riscv.pmhaccsu.v4i16(<4 x i16> %rd, <4 x i16> %rs1, <4 x i16> %rs2)
+  ret <4 x i16> %res
+}
+
+define <4 x i16> @test_pmhraccsu_v4i16(<4 x i16> %rd, <4 x i16> %rs1, <4 x i16> %rs2) {
+; RV32-LABEL: test_pmhraccsu_v4i16:
+; RV32:       # %bb.0:
+; RV32-NEXT:    pmhraccsu.h a1, a3, a5
+; RV32-NEXT:    pmhraccsu.h a0, a2, a4
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: test_pmhraccsu_v4i16:
+; RV64:       # %bb.0:
+; RV64-NEXT:    pmhraccsu.h a0, a1, a2
+; RV64-NEXT:    ret
+  %res = call <4 x i16> @llvm.riscv.pmhraccsu.v4i16(<4 x i16> %rd, <4 x i16> %rs1, <4 x i16> %rs2)
+  ret <4 x i16> %res
+}
+
+define <2 x i32> @test_pmhacc_v2i32(<2 x i32> %rd, <2 x i32> %rs1, <2 x i32> %rs2) {
+; RV32-LABEL: test_pmhacc_v2i32:
+; RV32:       # %bb.0:
+; RV32-NEXT:    mhacc a1, a3, a5
+; RV32-NEXT:    mhacc a0, a2, a4
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: test_pmhacc_v2i32:
+; RV64:       # %bb.0:
+; RV64-NEXT:    pmhacc.w a0, a1, a2
+; RV64-NEXT:    ret
+  %res = call <2 x i32> @llvm.riscv.pmhacc.v2i32(<2 x i32> %rd, <2 x i32> %rs1, <2 x i32> %rs2)
+  ret <2 x i32> %res
+}
+
+define <2 x i32> @test_pmhracc_v2i32(<2 x i32> %rd, <2 x i32> %rs1, <2 x i32> %rs2) {
+; RV32-LABEL: test_pmhracc_v2i32:
+; RV32:       # %bb.0:
+; RV32-NEXT:    mhracc a1, a3, a5
+; RV32-NEXT:    mhracc a0, a2, a4
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: test_pmhracc_v2i32:
+; RV64:       # %bb.0:
+; RV64-NEXT:    pmhracc.w a0, a1, a2
+; RV64-NEXT:    ret
+  %res = call <2 x i32> @llvm.riscv.pmhracc.v2i32(<2 x i32> %rd, <2 x i32> %rs1, <2 x i32> %rs2)
+  ret <2 x i32> %res
+}
+
+define <2 x i32> @test_pmhaccu_v2i32(<2 x i32> %rd, <2 x i32> %rs1, <2 x i32> %rs2) {
+; RV32-LABEL: test_pmhaccu_v2i32:
+; RV32:       # %bb.0:
+; RV32-NEXT:    mhaccu a1, a3, a5
+; RV32-NEXT:    mhaccu a0, a2, a4
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: test_pmhaccu_v2i32:
+; RV64:       # %bb.0:
+; RV64-NEXT:    pmhaccu.w a0, a1, a2
+; RV64-NEXT:    ret
+  %res = call <2 x i32> @llvm.riscv.pmhaccu.v2i32(<2 x i32> %rd, <2 x i32> %rs1, <2 x i32> %rs2)
+  ret <2 x i32> %res
+}
+
+define <2 x i32> @test_pmhraccu_v2i32(<2 x i32> %rd, <2 x i32> %rs1, <2 x i32> %rs2) {
+; RV32-LABEL: test_pmhraccu_v2i32:
+; RV32:       # %bb.0:
+; RV32-NEXT:    mhraccu a1, a3, a5
+; RV32-NEXT:    mhraccu a0, a2, a4
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: test_pmhraccu_v2i32:
+; RV64:       # %bb.0:
+; RV64-NEXT:    pmhraccu.w a0, a1, a2
+; RV64-NEXT:    ret
+  %res = call <2 x i32> @llvm.riscv.pmhraccu.v2i32(<2 x i32> %rd, <2 x i32> %rs1, <2 x i32> %rs2)
+  ret <2 x i32> %res
+}
+
+define <2 x i32> @test_pmhaccsu_v2i32(<2 x i32> %rd, <2 x i32> %rs1, <2 x i32> %rs2) {
+; RV32-LABEL: test_pmhaccsu_v2i32:
+; RV32:       # %bb.0:
+; RV32-NEXT:    mhaccsu a1, a3, a5
+; RV32-NEXT:    mhaccsu a0, a2, a4
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: test_pmhaccsu_v2i32:
+; RV64:       # %bb.0:
+; RV64-NEXT:    pmhaccsu.w a0, a1, a2
+; RV64-NEXT:    ret
+  %res = call <2 x i32> @llvm.riscv.pmhaccsu.v2i32(<2 x i32> %rd, <2 x i32> %rs1, <2 x i32> %rs2)
+  ret <2 x i32> %res
+}
+
+define <2 x i32> @test_pmhraccsu_v2i32(<2 x i32> %rd, <2 x i32> %rs1, <2 x i32> %rs2) {
+; RV32-LABEL: test_pmhraccsu_v2i32:
+; RV32:       # %bb.0:
+; RV32-NEXT:    mhraccsu a1, a3, a5
+; RV32-NEXT:    mhraccsu a0, a2, a4
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: test_pmhraccsu_v2i32:
+; RV64:       # %bb.0:
+; RV64-NEXT:    pmhraccsu.w a0, a1, a2
+; RV64-NEXT:    ret
+  %res = call <2 x i32> @llvm.riscv.pmhraccsu.v2i32(<2 x i32> %rd, <2 x i32> %rs1, <2 x i32> %rs2)
+  ret <2 x i32> %res
+}
+
 ; Packed absolute difference sum
 define i32 @test_pabdsumu_u8x8_u32(<8 x i8> %a, <8 x i8> %b) {
 ; RV32-LABEL: test_pabdsumu_u8x8_u32:


### PR DESCRIPTION
This patch adds the packed multiply high accumulate intrinsics and corresponding codegen. See also https://github.com/riscv/riscv-p-spec/blob/master/P-ext-intrinsics.adoc#packed-multiply-high-accumulate.