### PR TITLE
ARM: Read the ABI from the "target-abi" module flag

### DIFF
--- a/llvm/include/llvm/Target/TargetMachine.h
+++ b/llvm/include/llvm/Target/TargetMachine.h
@@ -138,10 +138,15 @@ public:
   StringRef getTargetFeatureString() const { return TargetFS; }
   void setTargetFeatureString(StringRef FS) { TargetFS = std::string(FS); }
 
-  /// Returns the effective target ABI name. Reads the "target-abi" module flag
-  /// if present, otherwise the -target-abi option. Emits an error if both are
-  /// present and disagree.
+  /// Returns the effective target ABI name: the "target-abi" module flag if
+  /// present, otherwise the -target-abi option. This is a pure query; call
+  /// verifyOptionsConsistency once per module to diagnose a conflict.
   StringRef getTargetABIName(const Module &M) const;
+
+  /// Diagnoses command-line codegen options that conflict with the
+  /// corresponding module flags (e.g. -target-abi vs the "target-abi" module
+  /// flag). Intended to be called once per module.
+  void verifyOptionsConsistency(const Module &M) const;
 
   /// Virtual method implemented by subclasses that returns a reference to that
   /// target's TargetSubtargetInfo-derived member variable.

--- a/llvm/lib/CodeGen/MachineModuleInfo.cpp
+++ b/llvm/lib/CodeGen/MachineModuleInfo.cpp
@@ -218,6 +218,7 @@ bool MachineModuleInfoWrapperPass::doInitialization(Module &M) {
         Ctx.diagnose(
             DiagnosticInfoSrcMgr(SMD, M.getName(), IsInlineAsm, LocCookie));
       });
+  MMI.getTarget().verifyOptionsConsistency(M);
   return false;
 }
 
@@ -242,5 +243,6 @@ MachineModuleAnalysis::run(Module &M, ModuleAnalysisManager &) {
         Ctx.diagnose(
             DiagnosticInfoSrcMgr(SMD, M.getName(), IsInlineAsm, LocCookie));
       });
+  MMI.getTarget().verifyOptionsConsistency(M);
   return Result(MMI);
 }

--- a/llvm/lib/Target/ARM/ARMAsmPrinter.cpp
+++ b/llvm/lib/Target/ARM/ARMAsmPrinter.cpp
@@ -699,8 +699,9 @@ void ARMAsmPrinter::emitAttributes() {
   const ARMBaseTargetMachine &ATM =
       static_cast<const ARMBaseTargetMachine &>(TM);
   FloatABI::ABIType FloatABI = ATM.getFloatABI(*MMI->getModule());
+  ARM::ARMABI ABI = ATM.getEffectiveABI(*MMI->getModule());
   const ARMSubtarget STI(TT, std::string(CPU), ArchFS, ATM,
-                         ATM.isLittleEndian(), FloatABI);
+                         ATM.isLittleEndian(), FloatABI, ABI);
 
   // Emit build attributes for the available hardware.
   ATS.emitTargetAttributes(STI);
@@ -808,7 +809,7 @@ void ARMAsmPrinter::emitAttributes() {
   ATS.emitAttribute(ARMBuildAttrs::ABI_align_preserved, 1);
 
   // Hard float.  Use both S and D registers and conform to AAPCS-VFP.
-  if (getTM().isAAPCS_ABI() && STI.isTargetHardFloat())
+  if (STI.isAAPCS_ABI() && STI.isTargetHardFloat())
     ATS.emitAttribute(ARMBuildAttrs::ABI_VFP_args, ARMBuildAttrs::HardFPAAPCS);
 
   // FIXME: To support emitting this build attribute as GCC does, the

--- a/llvm/lib/Target/ARM/ARMFastISel.cpp
+++ b/llvm/lib/Target/ARM/ARMFastISel.cpp
@@ -1896,7 +1896,7 @@ CCAssignFn *ARMFastISel::CCAssignFnForCall(CallingConv::ID CC,
     report_fatal_error("Unsupported calling convention");
   case CallingConv::Fast:
     if (Subtarget->hasFPRegs() && !isVarArg) {
-      if (!TM.isAAPCS_ABI())
+      if (!Subtarget->isAAPCS_ABI())
         return (Return ? RetFastCC_ARM_APCS : FastCC_ARM_APCS);
       // For AAPCS ABI targets, just use VFP variant of the calling convention.
       return (Return ? RetCC_ARM_AAPCS_VFP : CC_ARM_AAPCS_VFP);
@@ -1905,7 +1905,7 @@ CCAssignFn *ARMFastISel::CCAssignFnForCall(CallingConv::ID CC,
   case CallingConv::C:
   case CallingConv::CXX_FAST_TLS:
     // Use target triple & subtarget features to do actual dispatch.
-    if (TM.isAAPCS_ABI()) {
+    if (Subtarget->isAAPCS_ABI()) {
       if (Subtarget->hasFPRegs() && Subtarget->isTargetHardFloat() && !isVarArg)
         return (Return ? RetCC_ARM_AAPCS_VFP: CC_ARM_AAPCS_VFP);
       else

--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -1706,7 +1706,7 @@ ARMTargetLowering::getEffectiveCallingConv(CallingConv::ID CC,
     return isVarArg ? CallingConv::ARM_AAPCS : CallingConv::ARM_AAPCS_VFP;
   case CallingConv::C:
   case CallingConv::Tail:
-    if (!getTM().isAAPCS_ABI())
+    if (!Subtarget->isAAPCS_ABI())
       return CallingConv::ARM_APCS;
     else if (Subtarget->isTargetHardFloat() && !isVarArg)
       return CallingConv::ARM_AAPCS_VFP;
@@ -1714,7 +1714,7 @@ ARMTargetLowering::getEffectiveCallingConv(CallingConv::ID CC,
       return CallingConv::ARM_AAPCS;
   case CallingConv::Fast:
   case CallingConv::CXX_FAST_TLS:
-    if (!getTM().isAAPCS_ABI()) {
+    if (!Subtarget->isAAPCS_ABI()) {
       if (Subtarget->hasFPRegs() && !Subtarget->isThumb1Only() && !isVarArg)
         return CallingConv::Fast;
       return CallingConv::ARM_APCS;

--- a/llvm/lib/Target/ARM/ARMSubtarget.cpp
+++ b/llvm/lib/Target/ARM/ARMSubtarget.cpp
@@ -89,12 +89,13 @@ ARMFrameLowering *ARMSubtarget::initializeFrameLowering(StringRef CPU,
 ARMSubtarget::ARMSubtarget(const Triple &TT, const std::string &CPU,
                            const std::string &FS,
                            const ARMBaseTargetMachine &TM, bool IsLittle,
-                           FloatABI::ABIType FloatABI, bool MinSize,
-                           DenormalMode DM)
+                           FloatABI::ABIType FloatABI, ARM::ARMABI ABI,
+                           bool MinSize, DenormalMode DM)
     : ARMGenSubtargetInfo(TT, CPU, /*TuneCPU*/ CPU, FS),
       UseMulOps(UseFusedMulOps), CPUString(CPU), OptMinSize(MinSize),
       IsLittle(IsLittle), DM(DM), TargetTriple(TT), Options(TM.Options), TM(TM),
-      FloatABIType(FloatABI), FrameLowering(initializeFrameLowering(CPU, FS)),
+      FloatABIType(FloatABI), ABI(ABI),
+      FrameLowering(initializeFrameLowering(CPU, FS)),
       // At this point initializeSubtargetDependencies has been called so
       // we can query directly.
       InstrInfo(isThumb1Only() ? (ARMBaseInstrInfo *)new Thumb1InstrInfo(*this)
@@ -333,9 +334,9 @@ void ARMSubtarget::initSubtargetFeatures(StringRef CPU, StringRef FS) {
   if (isTargetWindows())
     NoARM = true;
 
-  if (TM.isAAPCS_ABI())
+  if (isAAPCS_ABI())
     stackAlignment = Align(8);
-  if (TM.isAAPCS16_ABI())
+  if (isAAPCS16_ABI())
     stackAlignment = Align(16);
 
   // FIXME: Completely disable sibcall for Thumb1 since ThumbRegisterInfo::

--- a/llvm/lib/Target/ARM/ARMSubtarget.h
+++ b/llvm/lib/Target/ARM/ARMSubtarget.h
@@ -31,6 +31,7 @@
 #include "llvm/MC/MCSchedule.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Target/TargetOptions.h"
+#include "llvm/TargetParser/ARMTargetParser.h"
 #include "llvm/TargetParser/Triple.h"
 #include <bitset>
 #include <memory>
@@ -209,14 +210,17 @@ protected:
   /// The floating-point ABI in effect for this subtarget.
   FloatABI::ABIType FloatABIType;
 
+  /// The ABI in effect.
+  const ARM::ARMABI ABI;
+
 public:
   /// This constructor initializes the data members to match that
   /// of the specified triple.
   ///
   ARMSubtarget(const Triple &TT, const std::string &CPU, const std::string &FS,
                const ARMBaseTargetMachine &TM, bool IsLittle,
-               FloatABI::ABIType FloatABI, bool MinSize = false,
-               DenormalMode DM = DenormalMode::getIEEE());
+               FloatABI::ABIType FloatABI, ARM::ARMABI ABI,
+               bool MinSize = false, DenormalMode DM = DenormalMode::getIEEE());
 
   /// getMaxInlineSizeThreshold - Returns the maximum memset / memcpy size
   /// that still makes it profitable to inline the call.
@@ -375,6 +379,12 @@ public:
 
   /// Returns true if the subtarget uses the hard floating-point ABI.
   bool isTargetHardFloat() const { return FloatABIType == FloatABI::Hard; }
+
+  bool isAPCS_ABI() const { return ABI == ARM::ARM_ABI_APCS; }
+  bool isAAPCS_ABI() const {
+    return ABI == ARM::ARM_ABI_AAPCS || ABI == ARM::ARM_ABI_AAPCS16;
+  }
+  bool isAAPCS16_ABI() const { return ABI == ARM::ARM_ABI_AAPCS16; }
 
   bool isReadTPSoft() const {
     return !(isReadTPTPIDRURW() || isReadTPTPIDRURO() || isReadTPTPIDRPRW());

--- a/llvm/lib/Target/ARM/ARMTargetMachine.cpp
+++ b/llvm/lib/Target/ARM/ARMTargetMachine.cpp
@@ -247,6 +247,13 @@ FloatABI::ABIType ARMBaseTargetMachine::getFloatABI(const Module &M) const {
   return M.getTargetTriple().getDefaultFloatABI();
 }
 
+ARM::ARMABI ARMBaseTargetMachine::getEffectiveABI(const Module &M) const {
+  // Consistency of "target-abi" and -target-abi is validated elsewhere.
+  if (const auto *MD = cast_or_null<MDString>(M.getModuleFlag("target-abi")))
+    return ARM::computeTargetABI(TargetTriple, MD->getString());
+  return TargetABI;
+}
+
 const ARMSubtarget *
 ARMBaseTargetMachine::getSubtargetImpl(const Function &F) const {
   Attribute CPUAttr = F.getFnAttribute("target-cpu");
@@ -283,10 +290,13 @@ ARMBaseTargetMachine::getSubtargetImpl(const Function &F) const {
   // registers, but no floating-point hardware (mve+nofp)
   Key += FloatABI == FloatABI::Hard ? "+hard-float-abi" : "+soft-float-abi";
 
+  ARM::ARMABI ABI = getEffectiveABI(*F.getParent());
+  Key += "+abi=" + std::to_string((int)ABI);
+
   auto &I = SubtargetMap[Key];
   if (!I) {
     I = std::make_unique<ARMSubtarget>(TargetTriple, CPU, FS, *this, isLittle,
-                                       FloatABI, F.hasMinSize(), DM);
+                                       FloatABI, ABI, F.hasMinSize(), DM);
 
     if (!I->isThumb() && !I->hasARMOps())
       F.getContext().emitError("Function '" + F.getName() + "' uses ARM "

--- a/llvm/lib/Target/ARM/ARMTargetMachine.h
+++ b/llvm/lib/Target/ARM/ARMTargetMachine.h
@@ -57,6 +57,11 @@ public:
   /// explicit -target-abi=aapcs16 forces the hard-float ABI.
   FloatABI::ABIType getFloatABI(const Module &M) const;
 
+  /// Returns the ABI in effect for \p M: the "target-abi" module flag if
+  /// present, otherwise the legacy -target-abi option; falling back to the
+  /// TargetMachine-level ABI computed at construction.
+  ARM::ARMABI getEffectiveABI(const Module &M) const;
+
   TargetTransformInfo getTargetTransformInfo(const Function &F) const override;
 
   // Pass Pipeline Configuration

--- a/llvm/lib/Target/TargetMachine.cpp
+++ b/llvm/lib/Target/TargetMachine.cpp
@@ -331,18 +331,22 @@ std::pair<int, int> TargetMachine::parseBinutilsVersion(StringRef Version) {
 }
 
 StringRef TargetMachine::getTargetABIName(const Module &M) const {
+  if (const auto *MD = cast_or_null<MDString>(M.getModuleFlag("target-abi")))
+    return MD->getString();
+  return Options.MCOptions.getABIName();
+}
+
+void TargetMachine::verifyOptionsConsistency(const Module &M) const {
+  // The "target-abi" module flag must agree with the -target-abi option.
   StringRef OptionABI = Options.MCOptions.getABIName();
-  const auto *MD = cast_or_null<MDString>(M.getModuleFlag("target-abi"));
-  if (!MD)
-    return OptionABI;
-
-  StringRef ModuleABI = MD->getString();
-  if (!OptionABI.empty() && OptionABI != ModuleABI) {
-    M.getContext().emitError("-target-abi option != target-abi module flag");
-    return "";
+  if (!OptionABI.empty()) {
+    if (const auto *MD =
+            cast_or_null<MDString>(M.getModuleFlag("target-abi"))) {
+      if (OptionABI != MD->getString())
+        M.getContext().emitError(
+            "-target-abi option != target-abi module flag");
+    }
   }
-
-  return ModuleABI;
 }
 
 const MCSubtargetInfo &TargetMachine::getMCSubtargetInfo(StringRef CPU,

--- a/llvm/test/CodeGen/ARM/module-target-abi.ll
+++ b/llvm/test/CodeGen/ARM/module-target-abi.ll
@@ -1,0 +1,30 @@
+; The "target-abi" module flag selects the ABI used for codegen. APCS uses
+; 4-byte stack alignment while AAPCS uses 8-byte alignment, which is observable
+; in the emitted prologue. The flag drives this with no -target-abi option.
+; RUN: split-file %s %t
+; RUN: llc -mtriple=armv7-none-eabi -filetype=asm < %t/apcs.ll | FileCheck %s --check-prefix=APCS
+; RUN: llc -mtriple=armv7-none-eabi -filetype=asm < %t/aapcs.ll | FileCheck %s --check-prefix=AAPCS
+
+;--- apcs.ll
+; APCS: push {lr}
+; APCS: sub sp, sp, #4
+declare void @use(ptr)
+define void @f() {
+  %a = alloca i32
+  call void @use(ptr %a)
+  ret void
+}
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"target-abi", !"apcs"}
+
+;--- aapcs.ll
+; AAPCS: push {r11, lr}
+; AAPCS: sub sp, sp, #8
+declare void @use(ptr)
+define void @f() {
+  %a = alloca i32
+  call void @use(ptr %a)
+  ret void
+}
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"target-abi", !"aapcs"}

--- a/llvm/test/CodeGen/ARM/target-abi-module-flag-conflict.ll
+++ b/llvm/test/CodeGen/ARM/target-abi-module-flag-conflict.ll
@@ -1,0 +1,21 @@
+; Check that a "target-abi" module flag conflicting with the
+; -target-abi command-line option is diagnosed once.
+; RUN: not llc -mtriple=armv7-none-eabi -target-abi=aapcs -filetype=null < %s 2>&1 \
+; RUN:   | FileCheck %s -implicit-check-not=error:
+
+; CHECK: error: -target-abi option != target-abi module flag
+define float @f1(float %x) #0 {
+  %r = fadd float %x, %x
+  ret float %r
+}
+
+define float @f2(float %x) #1 {
+  %r = fadd float %x, %x
+  ret float %r
+}
+
+attributes #0 = { "target-cpu"="cortex-a8" }
+attributes #1 = { "target-cpu"="cortex-a15" }
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"target-abi", !"apcs"}

--- a/llvm/test/CodeGen/RISCV/module-target-abi-conflict.ll
+++ b/llvm/test/CodeGen/RISCV/module-target-abi-conflict.ll
@@ -1,0 +1,24 @@
+; A "target-abi" module flag that conflicts with the -target-abi
+; command-line option is an error, which should be diagnosed exactly
+; once
+
+; RUN: not llc -target-abi=lp64d -filetype=null < %s 2>&1 | FileCheck %s -implicit-check-not=error:
+; RUN: not llc -enable-new-pm -target-abi=lp64d -filetype=null < %s 2>&1 | FileCheck %s -implicit-check-not=error:
+
+; CHECK: error: -target-abi option != target-abi module flag
+
+target triple = "riscv64"
+
+define void @f1() #0 {
+  ret void
+}
+
+define void @f2() #1 {
+  ret void
+}
+
+attributes #0 = { "target-cpu"="generic-rv64" }
+attributes #1 = { "target-cpu"="rocket-rv64" }
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"target-abi", !"lp64"}

--- a/llvm/unittests/Target/ARM/InstSizes.cpp
+++ b/llvm/unittests/Target/ARM/InstSizes.cpp
@@ -88,7 +88,8 @@ TEST(InstSizes, PseudoInst) {
   ARMSubtarget ST(TM->getTargetTriple(), std::string(TM->getTargetCPU()),
                   std::string(TM->getTargetFeatureString()),
                   *static_cast<const ARMBaseTargetMachine *>(TM.get()), false,
-                  TM->getTargetTriple().getDefaultFloatABI());
+                  TM->getTargetTriple().getDefaultFloatABI(),
+                  ARM::computeTargetABI(TM->getTargetTriple()));
   const ARMBaseInstrInfo *II = ST.getInstrInfo();
 
   auto cmpInstSize = [](const ARMBaseInstrInfo &II, MachineFunction &MF,

--- a/llvm/unittests/Target/ARM/MachineInstrTest.cpp
+++ b/llvm/unittests/Target/ARM/MachineInstrTest.cpp
@@ -89,7 +89,8 @@ TEST(MachineInstructionDoubleWidthResult, IsCorrect) {
   ARMSubtarget ST(TM->getTargetTriple(), std::string(TM->getTargetCPU()),
                   std::string(TM->getTargetFeatureString()),
                   *static_cast<const ARMBaseTargetMachine *>(TM.get()), false,
-                  TM->getTargetTriple().getDefaultFloatABI());
+                  TM->getTargetTriple().getDefaultFloatABI(),
+                  ARM::computeTargetABI(TM->getTargetTriple()));
   const ARMBaseInstrInfo *TII = ST.getInstrInfo();
   auto MII = TM->getMCInstrInfo();
 
@@ -246,7 +247,8 @@ TEST(MachineInstructionHorizontalReduction, IsCorrect) {
   ARMSubtarget ST(TM->getTargetTriple(), std::string(TM->getTargetCPU()),
                   std::string(TM->getTargetFeatureString()),
                   *static_cast<const ARMBaseTargetMachine *>(TM.get()), false,
-                  TM->getTargetTriple().getDefaultFloatABI());
+                  TM->getTargetTriple().getDefaultFloatABI(),
+                  ARM::computeTargetABI(TM->getTargetTriple()));
   const ARMBaseInstrInfo *TII = ST.getInstrInfo();
   auto MII = TM->getMCInstrInfo();
 
@@ -346,7 +348,8 @@ TEST(MachineInstructionRetainsPreviousHalfElement, IsCorrect) {
   ARMSubtarget ST(TM->getTargetTriple(), std::string(TM->getTargetCPU()),
                   std::string(TM->getTargetFeatureString()),
                   *static_cast<const ARMBaseTargetMachine *>(TM.get()), false,
-                  TM->getTargetTriple().getDefaultFloatABI());
+                  TM->getTargetTriple().getDefaultFloatABI(),
+                  ARM::computeTargetABI(TM->getTargetTriple()));
   const ARMBaseInstrInfo *TII = ST.getInstrInfo();
   auto MII = TM->getMCInstrInfo();
 
@@ -1053,7 +1056,8 @@ TEST(MachineInstrValidTailPredication, IsCorrect) {
   ARMSubtarget ST(TM->getTargetTriple(), std::string(TM->getTargetCPU()),
                   std::string(TM->getTargetFeatureString()),
                   *static_cast<const ARMBaseTargetMachine *>(TM.get()), false,
-                  TM->getTargetTriple().getDefaultFloatABI());
+                  TM->getTargetTriple().getDefaultFloatABI(),
+                  ARM::computeTargetABI(TM->getTargetTriple()));
 
   auto MII = TM->getMCInstrInfo();
   for (unsigned i = 0; i < ARM::INSTRUCTION_LIST_END; ++i) {
@@ -1197,7 +1201,8 @@ TEST(MachineInstr, HasSideEffects) {
   ARMSubtarget ST(TM->getTargetTriple(), std::string(TM->getTargetCPU()),
                   std::string(TM->getTargetFeatureString()),
                   *static_cast<const ARMBaseTargetMachine *>(TM.get()), false,
-                  TM->getTargetTriple().getDefaultFloatABI());
+                  TM->getTargetTriple().getDefaultFloatABI(),
+                  ARM::computeTargetABI(TM->getTargetTriple()));
   const ARMBaseInstrInfo *TII = ST.getInstrInfo();
   auto MII = TM->getMCInstrInfo();
 
@@ -2078,7 +2083,8 @@ TEST(MachineInstr, MVEVecSize) {
   ARMSubtarget ST(TM->getTargetTriple(), std::string(TM->getTargetCPU()),
                   std::string(TM->getTargetFeatureString()),
                   *static_cast<const ARMBaseTargetMachine *>(TM.get()), false,
-                  TM->getTargetTriple().getDefaultFloatABI());
+                  TM->getTargetTriple().getDefaultFloatABI(),
+                  ARM::computeTargetABI(TM->getTargetTriple()));
 
   auto MII = TM->getMCInstrInfo();
   for (unsigned i = 0; i < ARM::INSTRUCTION_LIST_END; ++i) {


### PR DESCRIPTION
This module flag is already used by RISCV, but ARM ignored it and
still exclusively relied on the -target-abi global option.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>