### PR TITLE
clang: Emit "target-abi" module flag for ARM

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1472,6 +1472,17 @@ void CodeGenModule::Release() {
   }
 
   llvm::Triple T = Context.getTargetInfo().getTriple();
+
+  // TODO: This should probably be just generally emitted for non-empty ABI
+  // names. LoongArch actively consumes the flag, but it is excluded here.
+  // Other targets have no apparent need for the ABI name, but set a non-empty
+  // value.
+  if (StringRef ABIStr = Target.getABI();
+      !ABIStr.empty() && (T.isARM() || T.isThumb() || T.isRISCV())) {
+    getModule().addModuleFlag(llvm::Module::Error, "target-abi",
+                              llvm::MDString::get(VMContext, ABIStr));
+  }
+
   if (T.isARM() || T.isThumb()) {
     // The minimum width of an enum in bytes
     uint32_t EnumWidth = Context.getLangOpts().ShortEnums ? 1 : 4;
@@ -1479,10 +1490,7 @@ void CodeGenModule::Release() {
   }
 
   if (T.isRISCV()) {
-    StringRef ABIStr = Target.getABI();
     llvm::LLVMContext &Ctx = TheModule.getContext();
-    getModule().addModuleFlag(llvm::Module::Error, "target-abi",
-                              llvm::MDString::get(Ctx, ABIStr));
 
     // Add the canonical ISA string as metadata so the backend can set the ELF
     // attributes correctly. We use AppendUnique so LTO will keep all of the

--- a/clang/test/CodeGen/arm-target-abi-module-flag.c
+++ b/clang/test/CodeGen/arm-target-abi-module-flag.c
@@ -1,0 +1,19 @@
+// Check that clang emits the "target-abi" module flag for ARM/Thumb using the
+// target ABI string.
+
+// Default ABIs (no -target-abi override).
+// RUN: %clang_cc1 -triple armv7-linux-gnueabihf -emit-llvm -o - %s | FileCheck --check-prefix=AAPCS-LINUX %s
+// RUN: %clang_cc1 -triple armv7-none-eabi -emit-llvm -o - %s | FileCheck --check-prefix=AAPCS %s
+// RUN: %clang_cc1 -triple armv7-apple-darwin -emit-llvm -o - %s | FileCheck --check-prefix=APCS-GNU %s
+// RUN: %clang_cc1 -triple armv7k-apple-watchos -emit-llvm -o - %s | FileCheck --check-prefix=AAPCS16 %s
+// RUN: %clang_cc1 -triple thumbv7-linux-gnueabihf -emit-llvm -o - %s | FileCheck --check-prefix=AAPCS-LINUX %s
+
+// Explicit -target-abi override differing from the triple default.
+// RUN: %clang_cc1 -triple armv7-linux-gnueabihf -target-abi apcs-gnu -emit-llvm -o - %s | FileCheck --check-prefix=APCS-GNU %s
+
+// AAPCS-LINUX: !{i32 1, !"target-abi", !"aapcs-linux"}
+// AAPCS: !{i32 1, !"target-abi", !"aapcs"}
+// APCS-GNU: !{i32 1, !"target-abi", !"apcs-gnu"}
+// AAPCS16: !{i32 1, !"target-abi", !"aapcs16"}
+
+int x;

--- a/clang/test/CodeGen/ubsan-function-sugared.cpp
+++ b/clang/test/CodeGen/ubsan-function-sugared.cpp
@@ -10,7 +10,7 @@ auto fun() {}
 
 // GNU-LABEL:  define{{.*}} void @_Z6callerv()
 // MSVC-LABEL: define{{.*}} void @"?caller@@YAXXZ"()
-// ARM:   call ptr @llvm.ptrmask.p0.i32(ptr {{.*}}, i32 -2), !nosanitize !5
+// ARM:   call ptr @llvm.ptrmask.p0.i32(ptr {{.*}}, i32 -2), !nosanitize !{{[0-9]+}}
 // CHECK: getelementptr <{ i32, i32 }>, ptr {{.*}}, i32 -1, i32 0, !nosanitize
 // CHECK: load i32, ptr {{.*}}, align {{.*}}, !nosanitize
 // CHECK: icmp eq i32 {{.*}}, -1056584962, !nosanitize

--- a/clang/test/CodeGen/ubsan-function.cpp
+++ b/clang/test/CodeGen/ubsan-function.cpp
@@ -13,7 +13,7 @@ void fun() {}
 
 // GNU-LABEL:  define{{.*}} void @_Z6callerPFvvE(ptr noundef %f)
 // MSVC-LABEL: define{{.*}} void @"?caller@@YAXP6AXXZ@Z"(ptr noundef %f)
-// ARM:   call ptr @llvm.ptrmask.p0.i32(ptr {{.*}}, i32 -2), !nosanitize !6
+// ARM:   call ptr @llvm.ptrmask.p0.i32(ptr {{.*}}, i32 -2), !nosanitize !{{[0-9]+}}
 // AUTH:  %[[STRIPPED:.*]] = ptrtoint ptr {{.*}} to i64, !nosanitize
 // AUTH:  call i64 @llvm.ptrauth.auth(i64 %[[STRIPPED]], i32 0, i64 0), !nosanitize
 // CHECK: getelementptr <{ i32, i32 }>, ptr {{.*}}, i32 -1, i32 0, !nosanitize


### PR DESCRIPTION
Previously only RISCV emitted the "target-abi" module flag.
We probably should just generally emit this for non-empty ABI names
but that's a broader behavior change. I'm also confused because the
clang side defines a non-empty value for many targets with no apparent
use in llvm.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>