### PR TITLE
[BOLT][test] Allow uninstantiated tests when no matching targets are enabled

### DIFF
--- a/bolt/unittests/Core/BinaryContext.cpp
+++ b/bolt/unittests/Core/BinaryContext.cpp
@@ -270,3 +270,7 @@ TEST_P(BinaryContextTester, BaseAddressSegmentsSmallerThanAlignment) {
   ASSERT_TRUE(BaseAddress.has_value());
   ASSERT_EQ(*BaseAddress, 0xaaaaaaaa0000ULL);
 }
+
+#if !defined(X86_AVAILABLE) && !defined(AARCH64_AVAILABLE)
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(BinaryContextTester);
+#endif // !defined(X86_AVAILABLE) && !defined(AARCH64_AVAILABLE)

--- a/bolt/unittests/Core/MCPlusBuilder.cpp
+++ b/bolt/unittests/Core/MCPlusBuilder.cpp
@@ -993,3 +993,7 @@ TEST_P(MCPlusBuilderTester, Annotation) {
   ASSERT_DEATH(BC->MIB->addEHInfo(Inst, MCPlus::MCLandingPad(LPSymbol, Value)),
                "annotation value out of range");
 }
+
+#if !defined(X86_AVAILABLE) && !defined(AARCH64_AVAILABLE)
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(MCPlusBuilderTester);
+#endif // !defined(X86_AVAILABLE) && !defined(AARCH64_AVAILABLE)

--- a/bolt/unittests/Core/MemoryMaps.cpp
+++ b/bolt/unittests/Core/MemoryMaps.cpp
@@ -176,3 +176,7 @@ TEST_P(MemoryMapsTester, MultipleSegmentsMismatchedBaseAddress) {
       "Base address on multiple segment mappings should match");
   sys::fs::remove(Path);
 }
+
+#if !defined(X86_AVAILABLE) && !defined(AARCH64_AVAILABLE)
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(MemoryMapsTester);
+#endif // !defined(X86_AVAILABLE) && !defined(AARCH64_AVAILABLE)

--- a/bolt/unittests/Profile/PerfScripts.cpp
+++ b/bolt/unittests/Profile/PerfScripts.cpp
@@ -240,3 +240,7 @@ TEST_P(PerfScriptTestHelper, ParseAndCheckFileHeader) {
   // should be 'size == 3' after the parsing this dummy MainEvents.
   parseAndCheckPerfScriptProfile(Buffer, Pid, 3);
 }
+
+#if !defined(X86_AVAILABLE) && !defined(AARCH64_AVAILABLE)
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(PerfScriptTestHelper);
+#endif // !defined(X86_AVAILABLE) && !defined(AARCH64_AVAILABLE)


### PR DESCRIPTION
When neither X86 nor AArch64 is enabled, e.g. when only enabling the RISCV target, `check-bolt-unit` triggers GTest's uninstantiated suite errors on the following cases:

```plain-text
BOLT-Unit :: Core/./CoreTests/GoogleTestVerification/UninstantiatedParameterizedTestSuite<BinaryContextTester>
BOLT-Unit :: Core/./CoreTests/GoogleTestVerification/UninstantiatedParameterizedTestSuite<MCPlusBuilderTester>
BOLT-Unit :: Core/./CoreTests/GoogleTestVerification/UninstantiatedParameterizedTestSuite<MemoryMapsTester>
BOLT-Unit :: Profile/./ProfileTests/GoogleTestVerification/UninstantiatedParameterizedTestSuite<PerfScriptTestHelper>
```

... which looks like the following:

```plain-text
********************                                                                                                                                                20:28 [95/2055]
FAIL: BOLT-Unit :: Core/./CoreTests/6/9 (7 of 12)
******************** TEST 'BOLT-Unit :: Core/./CoreTests/6/9' FAILED ********************
Script(shard):
--
GTEST_OUTPUT=json:/home/csmantle/workspace/llvm-project/build/tools/bolt/unittests/Core/./CoreTests-BOLT-Unit-718646-6-9.json GTEST_SHUFFLE=0 GTEST_TOTAL_SHARDS=9 GTEST_SHARD_INDE
X=6 /home/csmantle/workspace/llvm-project/build/tools/bolt/unittests/Core/./CoreTests
--

Script:
--
/home/csmantle/workspace/llvm-project/build/tools/bolt/unittests/Core/./CoreTests --gtest_filter=GoogleTestVerification.UninstantiatedParameterizedTestSuite<BinaryContextTester>
--
/home/csmantle/workspace/llvm-project/bolt/unittests/Core/BinaryContext.cpp:211: Failure
Parameterized test suite BinaryContextTester is defined via TEST_P, but never instantiated. None of the test cases will run. Either no INSTANTIATE_TEST_SUITE_P is provided or the
only ones provided expand to nothing.

Ideally, TEST_P definitions should only ever be included as part of binaries that intend to use them. (As opposed to, for example, being placed in a library that may be linked in
to get other utilities.)

To suppress this error for this test suite, insert the following line (in a non-header) in the namespace it is defined in:

GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(BinaryContextTester);


/home/csmantle/workspace/llvm-project/bolt/unittests/Core/BinaryContext.cpp:211
Parameterized test suite BinaryContextTester is defined via TEST_P, but never instantiated. None of the test cases will run. Either no INSTANTIATE_TEST_SUITE_P is provided or the
only ones provided expand to nothing.

Ideally, TEST_P definitions should only ever be included as part of binaries that intend to use them. (As opposed to, for example, being placed in a library that may be linked in
to get other utilities.)

To suppress this error for this test suite, insert the following line (in a non-header) in the namespace it is defined in:

GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(BinaryContextTester);
```

Add gated `GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST` to suppress such warnings until appropriate tests have been implemented.