### PR TITLE
[flang][driver] Honour the toolchain default DWARF version

### DIFF
--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -251,7 +251,7 @@ void Flang::addDebugOptions(const llvm::opt::ArgList &Args, const JobAction &JA,
     DebugInfoKind = llvm::codegenoptions::NoDebugInfo;
   }
   addDebugInfoKind(CmdArgs, DebugInfoKind);
-  // Pass the DWARF version on when debug information is being generated, or
+  // Pass on the DWARF version when debug information is being generated, or
   // when -gdwarf-N names a version. Leaving it out means the version stays
   // unset and the backend falls back to dwarf::DWARF_VERSION (4) instead of
   // honouring toolchain default like clang does.

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -251,7 +251,14 @@ void Flang::addDebugOptions(const llvm::opt::ArgList &Args, const JobAction &JA,
     DebugInfoKind = llvm::codegenoptions::NoDebugInfo;
   }
   addDebugInfoKind(CmdArgs, DebugInfoKind);
-  if (hasDwarfNArg) {
+  // Pass the DWARF version on when debug information is being generated, or
+  // when -gdwarf-N names a version. Leaving it out means the version stays
+  // unset and the backend falls back to dwarf::DWARF_VERSION (4) instead of
+  // honouring toolchain default like clang does.
+  //
+  // Note that both conditions are needed to match clang for cases like
+  // "-gdwarf-5 -g0".
+  if (hasDwarfNArg || DebugInfoKind != llvm::codegenoptions::NoDebugInfo) {
     const unsigned DwarfVersion = getDwarfVersion(getToolChain(), Args);
     CmdArgs.push_back(
         Args.MakeArgString("-dwarf-version=" + Twine(DwarfVersion)));

--- a/flang/test/Driver/flang-dwarf-version.f90
+++ b/flang/test/Driver/flang-dwarf-version.f90
@@ -1,60 +1,60 @@
 // RUN: %if !target={{.*aix.*}} %{ \
-// RUN: %flang -### -S %s -g -gdwarf-5  2>&1 \
+// RUN: %flang -### %s -g -gdwarf-5  2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-DWARF5 %s \
 // RUN: %}
 
 // RUN: %if !target={{.*aix.*}} %{ \
-// RUN: %flang -### -S %s -gdwarf-5  2>&1 \
+// RUN: %flang -### %s -gdwarf-5  2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-DWARF5 %s \
 // RUN: %}
 
 // RUN: %if !target={{.*aix.*}} %{ \
-// RUN: %flang -### -S %s -g1 -gdwarf-5  2>&1 \
+// RUN: %flang -### %s -g1 -gdwarf-5  2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-WITH-G1-DWARF5 %s \
 // RUN: %}
 
-// RUN: %flang -### -S %s -gdwarf-4  2>&1 \
+// RUN: %flang -### %s -gdwarf-4  2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-DWARF4 %s
-// RUN: %flang -### -S %s -gdwarf-3  2>&1 \
+// RUN: %flang -### %s -gdwarf-3  2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-DWARF3 %s
-// RUN: %flang -### -S %s -gdwarf-2  2>&1 \
+// RUN: %flang -### %s -gdwarf-2  2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-DWARF2 %s
 
 // Without an explicit -gdwarf-N, the toolchain default DWARF version is used.
 
 // Linux.
-// RUN: %flang -### -S %s -g --target=x86_64-unknown-linux-gnu 2>&1 \
+// RUN: %flang -### %s -g --target=x86_64-unknown-linux-gnu 2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-DWARF5 %s
-// RUN: %flang -### -S %s -g1 --target=x86_64-unknown-linux-gnu 2>&1 \
+// RUN: %flang -### %s -g1 --target=x86_64-unknown-linux-gnu 2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-WITH-G1-DWARF5 %s
 
 // Android always uses DWARF 4.
-// RUN: %flang -### -S %s -g --target=aarch64-unknown-linux-android21 2>&1 \
+// RUN: %flang -### %s -g --target=aarch64-unknown-linux-android21 2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-DWARF4 %s
 
 // Darwin derives the version from the OS version rather than using a constant.
-// RUN: %flang -### -S %s -g --target=x86_64-apple-macosx15 2>&1 \
+// RUN: %flang -### %s -g --target=x86_64-apple-macosx15 2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-DWARF5 %s
-// RUN: %flang -### -S %s -g --target=x86_64-apple-macosx10.10 2>&1 \
+// RUN: %flang -### %s -g --target=x86_64-apple-macosx10.10 2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-DWARF2 %s
 
 // AIX.
-// RUN: %flang -### -S %s -g --target=powerpc64-ibm-aix 2>&1 \
+// RUN: %flang -### %s -g --target=powerpc64-ibm-aix 2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-DWARF3 %s
 
 // OpenBSD.
-// RUN: %flang -### -S %s -g --target=x86_64-unknown-openbsd 2>&1 \
+// RUN: %flang -### %s -g --target=x86_64-unknown-openbsd 2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-DWARF2 %s
 
 // No debug info requested means no DWARF version is passed at all.
-// RUN: %flang -### -S %s 2>&1 \
+// RUN: %flang -### %s 2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-NO-DWARF %s
-// RUN: %flang -### -S %s -g0 2>&1 \
+// RUN: %flang -### %s -g0 2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-NO-DWARF %s
 
 // A version named explicitly is still passed on when debug info is switched
 // off, as clang does.
-// RUN: %flang -### -S %s -gdwarf-5 -g0 --target=x86_64-unknown-linux-gnu 2>&1 \
+// RUN: %flang -### %s -gdwarf-5 -g0 --target=x86_64-unknown-linux-gnu 2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-DWARF5-G0 %s
 
 // CHECK-DWARF5: -debug-info-kind=standalone

--- a/flang/test/Driver/flang-dwarf-version.f90
+++ b/flang/test/Driver/flang-dwarf-version.f90
@@ -20,6 +20,43 @@
 // RUN: %flang -### -S %s -gdwarf-2  2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-DWARF2 %s
 
+// Without an explicit -gdwarf-N, the toolchain default DWARF version is used.
+
+// Linux.
+// RUN: %flang -### -S %s -g --target=x86_64-unknown-linux-gnu 2>&1 \
+// RUN:             | FileCheck --check-prefix=CHECK-DWARF5 %s
+// RUN: %flang -### -S %s -g1 --target=x86_64-unknown-linux-gnu 2>&1 \
+// RUN:             | FileCheck --check-prefix=CHECK-WITH-G1-DWARF5 %s
+
+// Android always uses DWARF 4.
+// RUN: %flang -### -S %s -g --target=aarch64-unknown-linux-android21 2>&1 \
+// RUN:             | FileCheck --check-prefix=CHECK-DWARF4 %s
+
+// Darwin derives the version from the OS version rather than using a constant.
+// RUN: %flang -### -S %s -g --target=x86_64-apple-macosx15 2>&1 \
+// RUN:             | FileCheck --check-prefix=CHECK-DWARF5 %s
+// RUN: %flang -### -S %s -g --target=x86_64-apple-macosx10.10 2>&1 \
+// RUN:             | FileCheck --check-prefix=CHECK-DWARF2 %s
+
+// AIX.
+// RUN: %flang -### -S %s -g --target=powerpc64-ibm-aix 2>&1 \
+// RUN:             | FileCheck --check-prefix=CHECK-DWARF3 %s
+
+// OpenBSD.
+// RUN: %flang -### -S %s -g --target=x86_64-unknown-openbsd 2>&1 \
+// RUN:             | FileCheck --check-prefix=CHECK-DWARF2 %s
+
+// No debug info requested means no DWARF version is passed at all.
+// RUN: %flang -### -S %s 2>&1 \
+// RUN:             | FileCheck --check-prefix=CHECK-NO-DWARF %s
+// RUN: %flang -### -S %s -g0 2>&1 \
+// RUN:             | FileCheck --check-prefix=CHECK-NO-DWARF %s
+
+// A version named explicitly is still passed on when debug info is switched
+// off, as clang does.
+// RUN: %flang -### -S %s -gdwarf-5 -g0 --target=x86_64-unknown-linux-gnu 2>&1 \
+// RUN:             | FileCheck --check-prefix=CHECK-DWARF5-G0 %s
+
 // CHECK-DWARF5: -debug-info-kind=standalone
 // CHECK-DWARF5-SAME: -dwarf-version=5
 
@@ -31,3 +68,7 @@
 // CHECK-DWARF3: -dwarf-version=3
 
 // CHECK-DWARF2: -dwarf-version=2
+
+// CHECK-NO-DWARF-NOT: -dwarf-version=
+
+// CHECK-DWARF5-G0: -dwarf-version=5


### PR DESCRIPTION
The driver only rendered -dwarf-version= when the user named a version explicitly with -gdwarf-N. With plain -g the option was omitted, and the backend fell back to dwarf::DWARF_VERSION. As a result `flang -g` always produced DWARF 4 while `clang -g` produced the toolchain default for the same target..

The fix is to generate the "-dwarf-version" flag when either the debug information is enabled or an explicit -gdwarf-N is given.

