### PR TITLE
[ProfCheck] Temporarily opt out new VectorCombine test

### DIFF
--- a/llvm/utils/profcheck-xfail.txt
+++ b/llvm/utils/profcheck-xfail.txt
@@ -125,4 +125,5 @@ Transforms/TailCallElim/inf-recursion.ll
 Transforms/Util/control-flow-hub-finalize-same-succ-crash.ll
 Transforms/Util/libcalls-opt-remarks.ll
 Transforms/Util/lowerswitch.ll
+Transforms/VectorCombine/deinterleave-interleave-pairs.ll
 tools/opt/mtune.ll


### PR DESCRIPTION
Introduced in #211022, disable for now while it gets fixed.