### PR TITLE
[SystemZ] Use scheduling model for load latency

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZTargetTransformInfo.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZTargetTransformInfo.cpp
@@ -17,6 +17,7 @@
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/CodeGen/BasicTTIImpl.h"
 #include "llvm/CodeGen/TargetLowering.h"
+#include "llvm/CodeGen/TargetSchedule.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/IntrinsicInst.h"
@@ -1384,10 +1385,32 @@ InstructionCost SystemZTTIImpl::getMemoryOpCost(unsigned Opcode, Type *Src,
                                                 const Instruction *I) const {
   assert(!Src->isVoidTy() && "Invalid type");
 
-  // FIXME: Load latency isn't handled here
-  if (Opcode == Instruction::Load && CostKind == TTI::TCK_Latency)
-    return BaseT::getMemoryOpCost(Opcode, Src, Alignment, AddressSpace,
-                                  CostKind, OpInfo, I);
+  if (Opcode == Instruction::Load && CostKind == TTI::TCK_Latency) {
+    // How many machine loads does this IR load actually legalize to?
+    std::pair<InstructionCost, MVT> LT = getTypeLegalizationCost(Src);
+
+    // Pick a real SystemZ load opcode representative of the legalized
+    // type/width, and ask this subtarget's scheduling model for its
+    // latency.
+    unsigned RepOpc;
+    if (Src->isVectorTy()) {
+      RepOpc = SystemZ::VL;
+    } else if (Src->isFloatingPointTy()) {
+      RepOpc = (LT.second == MVT::f32) ? SystemZ::LE : SystemZ::LD;
+    } else {
+      unsigned BW = Src->getScalarSizeInBits();
+      RepOpc = (BW <= 8)  ? SystemZ::LLC
+             : (BW <= 16) ? SystemZ::LLH
+             : (BW <= 32) ? SystemZ::L
+             :              SystemZ::LG;
+    }
+
+    TargetSchedModel SchedModel;
+    SchedModel.init(ST);
+    unsigned LoadLatency = SchedModel.computeInstrLatency(RepOpc);
+
+    return LT.first * LoadLatency;
+  }
 
   // TODO: Handle other cost kinds.
   if (CostKind != TTI::TCK_RecipThroughput)

--- a/llvm/test/Analysis/CostModel/SystemZ/load-latency.ll
+++ b/llvm/test/Analysis/CostModel/SystemZ/load-latency.ll
@@ -8,12 +8,56 @@
 ; RUN:   -mtriple=systemz-unknown -mcpu=z17 -disable-output 2>&1 \
 ; RUN:   | FileCheck %s --check-prefix=Z17
 
+define i8 @load_i8(ptr %p) {
+entry:
+  %x = load i8, ptr %p
+  ret i8 %x
+}
+
+define i16 @load_i16(ptr %p) {
+entry:
+  %x = load i16, ptr %p
+  ret i16 %x
+}
+
+define i32 @load_i32(ptr %p) {
+entry:
+  %x = load i32, ptr %p
+  ret i32 %x
+}
+
 define i64 @load_i64(ptr %p) {
 entry:
   %x = load i64, ptr %p
   ret i64 %x
 }
 
+define i128 @load_i128(ptr %p) {
+entry:
+  %x = load i128, ptr %p
+  ret i128 %x
+}
+
+define <8 x i32> @load_v8i32(ptr %p) {
+entry:
+  %x = load <8 x i32>, ptr %p
+  ret <8 x i32> %x
+}
+
+; Z13: Cost Model: Found an estimated cost of 4 for instruction:   %x = load i8, ptr %p, align 1
+; Z13: Cost Model: Found an estimated cost of 4 for instruction:   %x = load i16, ptr %p, align 2
+; Z13: Cost Model: Found an estimated cost of 4 for instruction:   %x = load i32, ptr %p, align 4
 ; Z13: Cost Model: Found an estimated cost of 4 for instruction:   %x = load i64, ptr %p, align 8
+; Z13: Cost Model: Found an estimated cost of 8 for instruction:   %x = load <8 x i32>, ptr %p, align 32
+
+; Z15: Cost Model: Found an estimated cost of 4 for instruction:   %x = load i8, ptr %p, align 1
+; Z15: Cost Model: Found an estimated cost of 4 for instruction:   %x = load i16, ptr %p, align 2
+; Z15: Cost Model: Found an estimated cost of 4 for instruction:   %x = load i32, ptr %p, align 4
 ; Z15: Cost Model: Found an estimated cost of 4 for instruction:   %x = load i64, ptr %p, align 8
+; Z15: Cost Model: Found an estimated cost of 8 for instruction:   %x = load <8 x i32>, ptr %p, align 32
+
+; Z17: Cost Model: Found an estimated cost of 4 for instruction:   %x = load i8, ptr %p, align 1
+; Z17: Cost Model: Found an estimated cost of 4 for instruction:   %x = load i16, ptr %p, align 2
+; Z17: Cost Model: Found an estimated cost of 4 for instruction:   %x = load i32, ptr %p, align 4
 ; Z17: Cost Model: Found an estimated cost of 4 for instruction:   %x = load i64, ptr %p, align 8
+; Z17: Cost Model: Found an estimated cost of 8 for instruction:   %x = load <8 x i32>, ptr %p, align 32

--- a/llvm/test/Analysis/CostModel/SystemZ/load-latency.ll
+++ b/llvm/test/Analysis/CostModel/SystemZ/load-latency.ll
@@ -1,0 +1,19 @@
+; RUN: opt < %s -passes="print<cost-model>" -cost-kind=latency \
+; RUN:   -mtriple=systemz-unknown -mcpu=z13 -disable-output 2>&1 \
+; RUN:   | FileCheck %s --check-prefix=Z13
+; RUN: opt < %s -passes="print<cost-model>" -cost-kind=latency \
+; RUN:   -mtriple=systemz-unknown -mcpu=z15 -disable-output 2>&1 \
+; RUN:   | FileCheck %s --check-prefix=Z15
+; RUN: opt < %s -passes="print<cost-model>" -cost-kind=latency \
+; RUN:   -mtriple=systemz-unknown -mcpu=z17 -disable-output 2>&1 \
+; RUN:   | FileCheck %s --check-prefix=Z17
+
+define i64 @load_i64(ptr %p) {
+entry:
+  %x = load i64, ptr %p
+  ret i64 %x
+}
+
+; Z13: Cost Model: Found an estimated cost of 4 for instruction:   %x = load i64, ptr %p, align 8
+; Z15: Cost Model: Found an estimated cost of 4 for instruction:   %x = load i64, ptr %p, align 8
+; Z17: Cost Model: Found an estimated cost of 4 for instruction:   %x = load i64, ptr %p, align 8


### PR DESCRIPTION
### Summary
Previously, `SystemZTTIImpl::getMemoryOpCost` fell back to `BasicTTIImplBase` which returns a hardcoded constant regardless of type or subtarget. This PR addresses the `FIXME` comment by using SystemZ's actual scheduling model instead.

- Use the SystemZ scheduling model to estimate load latency
- Uses the original IR type to select a representative SystemZ load opcode
- Handles both scalar and vector loads
- Uses `getTypeLegalizationCost()` to account for legalized load operations.

### Testing
Added regression tests to test for latency of i8, i16, i32, i64, and <8 x i32> on `z13`, `z15`, and `z17`.

#### AI Disclosure
Assisted by ChatGPT (GPT-5.6 Luna). Final code reviewed by author.