### PR TITLE
[SPIRV] Add support for @llvm.lrint.* and @llvm.llrint.* intrinsics

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -491,6 +491,12 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
       .legalForCartesianProduct(allFloatScalarsAndVectors,
                                 allIntScalarsAndVectors);
 
+  // lrint/llrint round using the current rounding mode, which for
+  // unconstrained FP operations is round-to-nearest-even. The generic
+  // lowering expands them into G_FRINT + G_FPTOSI, which are selected as
+  // OpenCL.std rint / GLSL.std.450 RoundEven followed by OpConvertFToS.
+  getActionDefinitionsBuilder({G_INTRINSIC_LRINT, G_INTRINSIC_LLRINT}).lower();
+
   // FP conversions.
   getActionDefinitionsBuilder({G_FPTRUNC, G_FPEXT})
       .legalForCartesianProduct(allFloatScalarsAndVectors);

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/llrint.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/llrint.ll
@@ -1,0 +1,100 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefixes=CHECK,OCL
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s --check-prefixes=CHECK,VK
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val %}
+
+; OCL:           [[set:%[0-9]+]] = OpExtInstImport "OpenCL.std"
+; VK:            [[set:%[0-9]+]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG:     [[f32:%[0-9]+]] = OpTypeFloat 32
+; CHECK-DAG:     [[i32:%[0-9]+]] = OpTypeInt 32 0
+; CHECK-DAG:     [[f64:%[0-9]+]] = OpTypeFloat 64
+; CHECK-DAG:     [[i64:%[0-9]+]] = OpTypeInt 64 0
+; CHECK-DAG:     [[vecf32:%[0-9]+]] = OpTypeVector [[f32]]
+; CHECK-DAG:     [[veci32:%[0-9]+]] = OpTypeVector [[i32]]
+; CHECK-DAG:     [[vecf64:%[0-9]+]] = OpTypeVector [[f64]]
+; CHECK-DAG:     [[veci64:%[0-9]+]] = OpTypeVector [[i64]]
+
+; The generic lowering expands the intrinsic into G_FRINT + G_FPTOSI, which
+; select to OpenCL.std rint / GLSL.std.450 RoundEven followed by OpConvertFToS.
+; OCL:        [[rounded_i32_f32:%[0-9]+]] = OpExtInst [[f32]] [[set]] rint %[[#]]
+; VK:         [[rounded_i32_f32:%[0-9]+]] = OpExtInst [[f32]] [[set]] RoundEven %[[#]]
+; CHECK-NEXT:      %[[#]] = OpConvertFToS [[i32]] [[rounded_i32_f32]]
+; OCL:        [[rounded_i32_f64:%[0-9]+]] = OpExtInst [[f64]] [[set]] rint %[[#]]
+; VK:         [[rounded_i32_f64:%[0-9]+]] = OpExtInst [[f64]] [[set]] RoundEven %[[#]]
+; CHECK-NEXT:      %[[#]] = OpConvertFToS [[i32]] [[rounded_i32_f64]]
+; OCL:        [[rounded_i64_f32:%[0-9]+]] = OpExtInst [[f32]] [[set]] rint %[[#]]
+; VK:         [[rounded_i64_f32:%[0-9]+]] = OpExtInst [[f32]] [[set]] RoundEven %[[#]]
+; CHECK-NEXT:      %[[#]] = OpConvertFToS [[i64]] [[rounded_i64_f32]]
+; OCL:        [[rounded_i64_f64:%[0-9]+]] = OpExtInst [[f64]] [[set]] rint %[[#]]
+; VK:         [[rounded_i64_f64:%[0-9]+]] = OpExtInst [[f64]] [[set]] RoundEven %[[#]]
+; CHECK-NEXT:      %[[#]] = OpConvertFToS [[i64]] [[rounded_i64_f64]]
+; OCL:        [[rounded_v4i32_f32:%[0-9]+]] = OpExtInst [[vecf32]] [[set]] rint %[[#]]
+; VK:         [[rounded_v4i32_f32:%[0-9]+]] = OpExtInst [[vecf32]] [[set]] RoundEven %[[#]]
+; CHECK-NEXT:      %[[#]] = OpConvertFToS [[veci32]] [[rounded_v4i32_f32]]
+; OCL:        [[rounded_v4i32_f64:%[0-9]+]] = OpExtInst [[vecf64]] [[set]] rint %[[#]]
+; VK:         [[rounded_v4i32_f64:%[0-9]+]] = OpExtInst [[vecf64]] [[set]] RoundEven %[[#]]
+; CHECK-NEXT:      %[[#]] = OpConvertFToS [[veci32]] [[rounded_v4i32_f64]]
+; OCL:        [[rounded_v4i64_f32:%[0-9]+]] = OpExtInst [[vecf32]] [[set]] rint %[[#]]
+; VK:         [[rounded_v4i64_f32:%[0-9]+]] = OpExtInst [[vecf32]] [[set]] RoundEven %[[#]]
+; CHECK-NEXT:      %[[#]] = OpConvertFToS [[veci64]] [[rounded_v4i64_f32]]
+; OCL:        [[rounded_v4i64_f64:%[0-9]+]] = OpExtInst [[vecf64]] [[set]] rint %[[#]]
+; VK:         [[rounded_v4i64_f64:%[0-9]+]] = OpExtInst [[vecf64]] [[set]] RoundEven %[[#]]
+; CHECK-NEXT:      %[[#]] = OpConvertFToS [[veci64]] [[rounded_v4i64_f64]]
+
+define spir_func i32 @test_llrint_i32_f32(float %arg0) {
+entry:
+  %0 = call i32 @llvm.llrint.i32.f32(float %arg0)
+  ret i32 %0
+}
+
+define spir_func i32 @test_llrint_i32_f64(double %arg0) {
+entry:
+  %0 = call i32 @llvm.llrint.i32.f64(double %arg0)
+  ret i32 %0
+}
+
+define spir_func i64 @test_llrint_i64_f32(float %arg0) {
+entry:
+  %0 = call i64 @llvm.llrint.i64.f32(float %arg0)
+  ret i64 %0
+}
+
+define spir_func i64 @test_llrint_i64_f64(double %arg0) {
+entry:
+  %0 = call i64 @llvm.llrint.i64.f64(double %arg0)
+  ret i64 %0
+}
+
+define spir_func <4 x i32> @test_llrint_v4i32_f32(<4 x float> %arg0) {
+entry:
+  %0 = call <4 x i32> @llvm.llrint.v4i32.f32(<4 x float> %arg0)
+  ret <4 x i32> %0
+}
+
+define spir_func <4 x i32> @test_llrint_v4i32_f64(<4 x double> %arg0) {
+entry:
+  %0 = call <4 x i32> @llvm.llrint.v4i32.f64(<4 x double> %arg0)
+  ret <4 x i32> %0
+}
+
+define spir_func <4 x i64> @test_llrint_v4i64_f32(<4 x float> %arg0) {
+entry:
+  %0 = call <4 x i64> @llvm.llrint.v4i64.f32(<4 x float> %arg0)
+  ret <4 x i64> %0
+}
+
+define spir_func <4 x i64> @test_llrint_v4i64_f64(<4 x double> %arg0) {
+entry:
+  %0 = call <4 x i64> @llvm.llrint.v4i64.f64(<4 x double> %arg0)
+  ret <4 x i64> %0
+}
+
+declare i32 @llvm.llrint.i32.f32(float)
+declare i32 @llvm.llrint.i32.f64(double)
+declare i64 @llvm.llrint.i64.f32(float)
+declare i64 @llvm.llrint.i64.f64(double)
+
+declare <4 x i32> @llvm.llrint.v4i32.f32(<4 x float>)
+declare <4 x i32> @llvm.llrint.v4i32.f64(<4 x double>)
+declare <4 x i64> @llvm.llrint.v4i64.f32(<4 x float>)
+declare <4 x i64> @llvm.llrint.v4i64.f64(<4 x double>)

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/lrint.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/lrint.ll
@@ -1,0 +1,100 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefixes=CHECK,OCL
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s --check-prefixes=CHECK,VK
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val %}
+
+; OCL:           [[set:%[0-9]+]] = OpExtInstImport "OpenCL.std"
+; VK:            [[set:%[0-9]+]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG:     [[f32:%[0-9]+]] = OpTypeFloat 32
+; CHECK-DAG:     [[i32:%[0-9]+]] = OpTypeInt 32 0
+; CHECK-DAG:     [[f64:%[0-9]+]] = OpTypeFloat 64
+; CHECK-DAG:     [[i64:%[0-9]+]] = OpTypeInt 64 0
+; CHECK-DAG:     [[vecf32:%[0-9]+]] = OpTypeVector [[f32]]
+; CHECK-DAG:     [[veci32:%[0-9]+]] = OpTypeVector [[i32]]
+; CHECK-DAG:     [[vecf64:%[0-9]+]] = OpTypeVector [[f64]]
+; CHECK-DAG:     [[veci64:%[0-9]+]] = OpTypeVector [[i64]]
+
+; The generic lowering expands the intrinsic into G_FRINT + G_FPTOSI, which
+; select to OpenCL.std rint / GLSL.std.450 RoundEven followed by OpConvertFToS.
+; OCL:        [[rounded_i32_f32:%[0-9]+]] = OpExtInst [[f32]] [[set]] rint %[[#]]
+; VK:         [[rounded_i32_f32:%[0-9]+]] = OpExtInst [[f32]] [[set]] RoundEven %[[#]]
+; CHECK-NEXT:      %[[#]] = OpConvertFToS [[i32]] [[rounded_i32_f32]]
+; OCL:        [[rounded_i32_f64:%[0-9]+]] = OpExtInst [[f64]] [[set]] rint %[[#]]
+; VK:         [[rounded_i32_f64:%[0-9]+]] = OpExtInst [[f64]] [[set]] RoundEven %[[#]]
+; CHECK-NEXT:      %[[#]] = OpConvertFToS [[i32]] [[rounded_i32_f64]]
+; OCL:        [[rounded_i64_f32:%[0-9]+]] = OpExtInst [[f32]] [[set]] rint %[[#]]
+; VK:         [[rounded_i64_f32:%[0-9]+]] = OpExtInst [[f32]] [[set]] RoundEven %[[#]]
+; CHECK-NEXT:      %[[#]] = OpConvertFToS [[i64]] [[rounded_i64_f32]]
+; OCL:        [[rounded_i64_f64:%[0-9]+]] = OpExtInst [[f64]] [[set]] rint %[[#]]
+; VK:         [[rounded_i64_f64:%[0-9]+]] = OpExtInst [[f64]] [[set]] RoundEven %[[#]]
+; CHECK-NEXT:      %[[#]] = OpConvertFToS [[i64]] [[rounded_i64_f64]]
+; OCL:        [[rounded_v4i32_f32:%[0-9]+]] = OpExtInst [[vecf32]] [[set]] rint %[[#]]
+; VK:         [[rounded_v4i32_f32:%[0-9]+]] = OpExtInst [[vecf32]] [[set]] RoundEven %[[#]]
+; CHECK-NEXT:      %[[#]] = OpConvertFToS [[veci32]] [[rounded_v4i32_f32]]
+; OCL:        [[rounded_v4i32_f64:%[0-9]+]] = OpExtInst [[vecf64]] [[set]] rint %[[#]]
+; VK:         [[rounded_v4i32_f64:%[0-9]+]] = OpExtInst [[vecf64]] [[set]] RoundEven %[[#]]
+; CHECK-NEXT:      %[[#]] = OpConvertFToS [[veci32]] [[rounded_v4i32_f64]]
+; OCL:        [[rounded_v4i64_f32:%[0-9]+]] = OpExtInst [[vecf32]] [[set]] rint %[[#]]
+; VK:         [[rounded_v4i64_f32:%[0-9]+]] = OpExtInst [[vecf32]] [[set]] RoundEven %[[#]]
+; CHECK-NEXT:      %[[#]] = OpConvertFToS [[veci64]] [[rounded_v4i64_f32]]
+; OCL:        [[rounded_v4i64_f64:%[0-9]+]] = OpExtInst [[vecf64]] [[set]] rint %[[#]]
+; VK:         [[rounded_v4i64_f64:%[0-9]+]] = OpExtInst [[vecf64]] [[set]] RoundEven %[[#]]
+; CHECK-NEXT:      %[[#]] = OpConvertFToS [[veci64]] [[rounded_v4i64_f64]]
+
+define spir_func i32 @test_lrint_i32_f32(float %arg0) {
+entry:
+  %0 = call i32 @llvm.lrint.i32.f32(float %arg0)
+  ret i32 %0
+}
+
+define spir_func i32 @test_lrint_i32_f64(double %arg0) {
+entry:
+  %0 = call i32 @llvm.lrint.i32.f64(double %arg0)
+  ret i32 %0
+}
+
+define spir_func i64 @test_lrint_i64_f32(float %arg0) {
+entry:
+  %0 = call i64 @llvm.lrint.i64.f32(float %arg0)
+  ret i64 %0
+}
+
+define spir_func i64 @test_lrint_i64_f64(double %arg0) {
+entry:
+  %0 = call i64 @llvm.lrint.i64.f64(double %arg0)
+  ret i64 %0
+}
+
+define spir_func <4 x i32> @test_lrint_v4i32_f32(<4 x float> %arg0) {
+entry:
+  %0 = call <4 x i32> @llvm.lrint.v4i32.f32(<4 x float> %arg0)
+  ret <4 x i32> %0
+}
+
+define spir_func <4 x i32> @test_lrint_v4i32_f64(<4 x double> %arg0) {
+entry:
+  %0 = call <4 x i32> @llvm.lrint.v4i32.f64(<4 x double> %arg0)
+  ret <4 x i32> %0
+}
+
+define spir_func <4 x i64> @test_lrint_v4i64_f32(<4 x float> %arg0) {
+entry:
+  %0 = call <4 x i64> @llvm.lrint.v4i64.f32(<4 x float> %arg0)
+  ret <4 x i64> %0
+}
+
+define spir_func <4 x i64> @test_lrint_v4i64_f64(<4 x double> %arg0) {
+entry:
+  %0 = call <4 x i64> @llvm.lrint.v4i64.f64(<4 x double> %arg0)
+  ret <4 x i64> %0
+}
+
+declare i32 @llvm.lrint.i32.f32(float)
+declare i32 @llvm.lrint.i32.f64(double)
+declare i64 @llvm.lrint.i64.f32(float)
+declare i64 @llvm.lrint.i64.f64(double)
+
+declare <4 x i32> @llvm.lrint.v4i32.f32(<4 x float>)
+declare <4 x i32> @llvm.lrint.v4i32.f64(<4 x double>)
+declare <4 x i64> @llvm.lrint.v4i64.f32(<4 x float>)
+declare <4 x i64> @llvm.lrint.v4i64.f64(<4 x double>)


### PR DESCRIPTION
The SPIR-V backend never marked `G_INTRINSIC_LRINT` or `G_INTRINSIC_LLRINT` legal, so `llc` aborted on valid IR containing `llvm.lrint` or `llvm.llrint`:

```
LLVM ERROR: unable to legalize instruction: %5:id(s32) = G_INTRINSIC_LRINT %0:fid(s32) (in function: test_lrint_i32_f32)
```

That is a hard abort out of the legalizer, not a diagnostic, so a frontend or a JIT has no way to recover from it. This completes the lround/llround support added in #129240, which left the lrint/llrint pair unhandled.

The fix routes both opcodes through the generic lowering:

```c++
getActionDefinitionsBuilder({G_INTRINSIC_LRINT, G_INTRINSIC_LLRINT}).lower();
```

`LegalizerHelper` expands them into `G_FRINT` followed by `G_FPTOSI`. Both are already legal and selectable for SPIR-V, so the emitted module is `OpExtInst OpenCL.std rint` (or `OpExtInst GLSL.std.450 RoundEven` on Vulkan targets) followed by `OpConvertFToS`. That is the same shape `G_LROUND` and `G_LLROUND` already produce, with round to nearest even in place of round half away from zero.

One design trade-off is worth surfacing so a reviewer does not have to rediscover it. Using `.lower()` reuses the shared generic expansion, whereas the adjacent `G_LROUND` and `G_LLROUND` are handled by a dedicated arm in `SPIRVInstructionSelector.cpp`. I also implemented the symmetric variant (legalize `G_INTRINSIC_LRINT` and `G_INTRINSIC_LLRINT` with `legalForCartesianProduct` next to `G_LROUND`/`G_LLROUND`, and extend that selector arm to pick `CL::rint` and `GL::RoundEven`), built it, and compared the output: the emitted SPIR-V is byte identical for every case in both new tests across `spirv64-unknown-unknown`, `spirv32-unknown-unknown` and `spirv-unknown-vulkan`, and the CodeGen/SPIRV suite is equally green. Since the two produce the same module, I kept the smaller one. Happy to switch to the selector arm if reviewers prefer symmetry with the neighboring code.

On semantics: OpenCL `rint` and GLSL `RoundEven` are round to nearest even, which is exactly what LLVM assumes for unconstrained FP. `LegalizerHelper.cpp` says so in the `G_FRINT` case immediately above the lrint lowering: "Since round even is the assumed rounding mode for unconstrained FP operations, rint and roundeven are the same operation." LangRef says `llvm.lrint` "returns the same values as the libm `lrint` functions would", and libm `lrint` honors the dynamic rounding mode set through `fesetround`. SPIR-V has no equivalent dynamic rounding mode for these operations, so the distinction does not arise for the unconstrained intrinsic. Anything that genuinely needs a non default rounding mode has to use `llvm.experimental.constrained.lrint`, a separate opcode that this change does not touch.

Two new tests, `llvm/test/CodeGen/SPIRV/llvm-intrinsics/lrint.ll` and `llrint.ll`, are modeled on the existing `lround.ll` and `llround.ll`. They cover `i32` and `i64` results from `float` and `double` sources plus the `<4 x ...>` vector forms, and each file pins both extended instruction sets: the OpenCL run asserts `OpenCL.std rint`, the Vulkan run asserts `GLSL.std.450 RoundEven`, and the `OpConvertFToS` that follows is asserted by a shared `CHECK-NEXT` on both paths. The Vulkan RUN line is deliberate: selection here goes through the shared `LegalizerHelper` expansion rather than a SPIR-V specific selector arm, so without it a future change to generic `G_FRINT` handling could silently swap `RoundEven` for `Round` with no test failing. Both files fail at the parent commit on both triples, with the same `unable to legalize instruction` error (the virtual register number differs between triples).

One caveat so as not to overclaim: the `spirv-val` RUN lines are guarded by `%if spirv-tools` and are skipped in a build configured without SPIRV-Tools, which is how I built here. I ran them manually against SPIRV-Tools v2025.2 instead, and all four modules validate. The CodeGen/SPIRV lit suite is otherwise green: 1201 tests, 1198 passed, 3 unsupported, 0 failures.
