### PR TITLE
[XRay] Select profiling mode with the hyphenated name

### DIFF
--- a/compiler-rt/lib/xray/xray_profiling.cpp
+++ b/compiler-rt/lib/xray/xray_profiling.cpp
@@ -507,7 +507,7 @@ bool profilingDynamicInitializer() XRAY_NEVER_INSTRUMENT {
   }
 
   if (!internal_strcmp(flags()->xray_mode, "xray-profiling"))
-    __xray_log_select_mode("xray_profiling");
+    __xray_log_select_mode("xray-profiling");
   return true;
 }
 


### PR DESCRIPTION
## Summary

`__xray_log_register_mode` registers `"xray-profiling"`, matching the basic and FDR loggers. The dynamic initializer then called `__xray_log_select_mode("xray_profiling")` (underscore), so the mode was never selected when `xray_mode=xray-profiling`.

This only changes the select-mode string to `"xray-profiling"`.

Fixes #88761

Assisted-by: Grok (xAI)