### PR TITLE
[docs] Fix CMAKE_CROSSCOMPILING spelling in HowToCrossCompileLLVM

### DIFF
--- a/llvm/docs/HowToCrossCompileLLVM.md
+++ b/llvm/docs/HowToCrossCompileLLVM.md
@@ -118,7 +118,7 @@ important:
 
 - `CMAKE_SYSTEM_NAME`: Perhaps surprisingly, explicitly setting this
   variable [causes CMake to set
-  CMAKE_CROSSCOMPIILING](https://cmake.org/cmake/help/latest/variable/CMAKE_CROSSCOMPILING.html#variable:CMAKE_CROSSCOMPILING).
+  CMAKE_CROSSCOMPILING](https://cmake.org/cmake/help/latest/variable/CMAKE_CROSSCOMPILING.html#variable:CMAKE_CROSSCOMPILING).
 - `CMAKE_{C,CXX}_COMPILER_TARGET`: This will be used to set the
   `--target` argument to `clang`. The triple should match the triple used
   within the sysroot (i.e. `$SYSROOT/usr/lib/$TARGET` should exist).


### PR DESCRIPTION
## Summary

The HowToCrossCompileLLVM option list spelled the CMake variable as `CMAKE_CROSSCOMPIILING` (extra I). The linked CMake docs use `CMAKE_CROSSCOMPILING`.

Assisted-by: Grok (xAI)