### PR TITLE
[clang-format][docs] Fix grammar in AllowShortFunctionsOnASingleLine

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.md
+++ b/clang/docs/ClangFormatStyleOptions.md
@@ -1949,7 +1949,7 @@ the configuration (without a prefix: `Auto`).
 
   - `InlineOnly`
     Only merge functions defined inside a class. Same as `inline`,
-    except it does not implies `empty`: i.e. top level empty functions
+    except it does not imply `empty`: i.e. top level empty functions
     are not merged either. See `Inline` of `ShortFunctionStyle`.
 
     ```c++

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -840,7 +840,7 @@ struct FormatStyle {
   ///
   /// * `InlineOnly`
   ///   Only merge functions defined inside a class. Same as `inline`,
-  ///   except it does not implies `empty`: i.e. top level empty functions
+  ///   except it does not imply `empty`: i.e. top level empty functions
   ///   are not merged either. See `Inline` of `ShortFunctionStyle`.
   ///   \code
   ///     class Foo {


### PR DESCRIPTION
## Summary

The `InlineOnly` description said "does not implies `empty`". Change to "does not imply".

Updated both `Format.h` (source of the style option docs) and `ClangFormatStyleOptions.md`.

Fixes #195326

Assisted-by: Grok (xAI)