### PR TITLE
[clang-tidy][docs] Document identifier-naming option fallbacks

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-naming.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-naming.rst
@@ -27,6 +27,18 @@ Many configuration options are available, in order to be able to create
 different rules for different kinds of identifiers. In general, the rules are
 falling back to a more generic rule if the specific case is not configured.
 
+For template parameters, the more specific kinds fall back to
+``TemplateParameter`` when unset:
+
+- ``TypeTemplateParameter`` -> ``TemplateParameter``
+- ``ValueTemplateParameter`` -> ``TemplateParameter``
+- ``TemplateTemplateParameter`` -> ``TemplateParameter``
+
+Other kinds have similar fallback chains (for example a ``public static
+constexpr`` method tries ``ConstexprMethod``, then ``ConstexprFunction``,
+``ClassMethod``, ``PublicMethod``, ``Method``, then ``Function``). The first
+configured kind in that order is used.
+
 The naming of virtual methods is reported where they occur in the base class,
 but not where they are overridden, as it can't be fixed locally there.
 This also applies for pseudo-override patterns like CRTP.


### PR DESCRIPTION
## Summary

`readability-identifier-naming` already falls back from specific kinds to more generic ones, but the docs did not list those chains. Contributors had to read `IdentifierNamingCheck.cpp` to know that e.g. `TypeTemplateParameter` falls back to `TemplateParameter`.

This documents the template-parameter fallbacks (verified in `findStyleKind`) and the method precedence order from the same function.

Fixes #170008

Assisted-by: Grok (xAI)