### PR TITLE
[clang][test] Fix misspelled FileCheck prefix in static-init-3.cpp

### DIFF
--- a/clang/test/CodeGenCXX/static-init-3.cpp
+++ b/clang/test/CodeGenCXX/static-init-3.cpp
@@ -17,7 +17,7 @@ struct X1
 };
 
 // CHECK: @_ZN2X1I2X2I1BEE8instanceE = linkonce_odr global ptr null, align 8
-// CHECJ: @_ZN2X1I2X2I1AEE8instanceE = linkonce_odr global ptr null, align 8
+// CHECK: @_ZN2X1I2X2I1AEE8instanceE = linkonce_odr global ptr null, align 8
 template<class T> T & X1<T>::instance = X1<T>::get();
 
 class A { };


### PR DESCRIPTION
`clang/test/CodeGenCXX/static-init-3.cpp` uses `FileCheck %s` (prefix `CHECK`) but the second instance line was `// CHECJ:`. That prefix is undefined, so the check never ran.

Fixes one of the misspelled prefixes listed in #94108.

Assisted-by: Grok (xAI)