### PR TITLE
[mlir][acc] Update par_dims format after strict property assembly format

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
@@ -170,7 +170,7 @@ def OpenACC_ReductionAccumulateOp
       }
     } {acc.par_dims = #acc<par_dims[thread_x]>}
     acc.reduction_accumulate %partial to %private <add>
-        : i32 -> memref<i32> <{par_dims = #acc<par_dims[thread_x]>}>
+        par_dims(#acc<par_dims[thread_x]>) : i32 -> memref<i32>
     acc.reduction_combine %private into %shared <add> : memref<i32>
         {acc.par_dims = #acc<par_dims[thread_x]>}
     ```
@@ -182,8 +182,9 @@ def OpenACC_ReductionAccumulateOp
                        OpenACC_ReductionOperatorAttr:$reductionOperator,
                        OpenACC_GPUParallelDimsAttr:$par_dims);
   let assemblyFormat = [{
-    $value `to` $memref $reductionOperator `:` type($value) `->`
-    type($memref) prop-dict attr-dict
+    $value `to` $memref $reductionOperator
+    `par_dims` `(` qualified($par_dims) `)` `:` type($value) `->`
+    type($memref) attr-dict
   }];
   let hasVerifier = 1;
 }
@@ -206,8 +207,8 @@ def OpenACC_ReductionAccumulateArrayOp
                        OpenACC_ReductionOperatorAttr:$reductionOperator,
                        OpenACC_GPUParallelDimsAttr:$par_dims);
   let assemblyFormat = [{
-    $memref `bounds` `(` $bounds `)` $reductionOperator `:`
-    type($memref) prop-dict attr-dict
+    $memref `bounds` `(` $bounds `)` $reductionOperator
+    `par_dims` `(` qualified($par_dims) `)` `:` type($memref) attr-dict
   }];
   let hasVerifier = 1;
 }
@@ -319,14 +320,16 @@ def OpenACC_PrivatizeOp : OpenACC_Op<"privatize", []> {
     Optional `index` operands supply dynamic sizes when the privatized shape
     depends on SSA values (for example `memref<?xi32>` row lengths).
 
-    The optional `acc.par_dims` attribute records which GPU parallel dimensions
+    The optional `par_dims` attribute records which GPU parallel dimensions
     participate in the privatization.
   }];
   let arguments = (ins Variadic<Index>:$dynamicSizes,
                        OptionalAttr<OpenACC_GPUParallelDimsAttr>:$par_dims);
   let results = (outs OpenACC_PrivateType:$result);
   let assemblyFormat = [{
-    (`(` $dynamicSizes^ `)`)? (`[` qualified($par_dims)^ `]`)? attr-dict `:` functional-type(operands, results)
+    (`(` $dynamicSizes^ `)`)?
+    (`par_dims` `(` qualified($par_dims)^ `)`)?
+    attr-dict `:` functional-type(operands, results)
   }];
   let builders = [
     OpBuilder<(ins "::mlir::Type":$resultType,

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-barrier-gang-private-init.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-barrier-gang-private-init.mlir
@@ -18,7 +18,7 @@ func.func @test_gang_private_init_barrier(%arg0: memref<100x100xf32>) {
   %13 = acc.par_width %c10 par_dim(#acc.par_dim<block_x>)
   %14 = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment dataOperands(%12 : memref<100x100xf32>) {
-    %15 = acc.privatize [#acc<par_dims[block_x]>] : () -> !acc.private_type<memref<8xf32>>
+    %15 = acc.privatize par_dims(#acc<par_dims[block_x]>) : () -> !acc.private_type<memref<8xf32>>
     acc.compute_region launch(%arg1 = %13, %arg2 = %14) ins(%arg10 = %12, %arg11 = %15) : (memref<100x100xf32>, !acc.private_type<memref<8xf32>>) {
       %c8_b = arith.constant 8 : index
       %c100_b = arith.constant 100 : index
@@ -71,7 +71,7 @@ func.func @test_thread_private_init_no_barrier(%arg0: memref<100x100xf32>) {
   %13 = acc.par_width %c10 par_dim(#acc.par_dim<block_x>)
   %14 = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment dataOperands(%12 : memref<100x100xf32>) {
-    %15 = acc.privatize [#acc<par_dims[block_x, thread_x]>] : () -> !acc.private_type<memref<8xf32>>
+    %15 = acc.privatize par_dims(#acc<par_dims[block_x, thread_x]>) : () -> !acc.private_type<memref<8xf32>>
     acc.compute_region launch(%arg1 = %13, %arg2 = %14) ins(%arg10 = %12, %arg11 = %15) : (memref<100x100xf32>, !acc.private_type<memref<8xf32>>) {
       %c8_b = arith.constant 8 : index
       %c100_b = arith.constant 100 : index

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-private-local-gang-redundant.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-private-local-gang-redundant.mlir
@@ -18,7 +18,7 @@ func.func @gang_redundant_worker_private() {
   %0 = acc.par_width %c4 par_dim(#acc.par_dim<block_x>)
   %1 = acc.par_width %c4 par_dim(#acc.par_dim<thread_y>)
   %2 = acc.par_width %c1 par_dim(#acc.par_dim<thread_x>)
-  %3 = acc.privatize [#acc<par_dims[thread_y]>] : () -> !acc.private_type<memref<1xi32>>
+  %3 = acc.privatize par_dims(#acc<par_dims[thread_y]>) : () -> !acc.private_type<memref<1xi32>>
   acc.kernel_environment {
     acc.compute_region launch(%arg0 = %0, %arg1 = %1, %arg2 = %2) ins(%arg10 = %3) : (!acc.private_type<memref<1xi32>>) {
       %loc = acc.private_local %arg10 : (!acc.private_type<memref<1xi32>>) -> memref<1xi32>

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-privatize-threadprivate.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-privatize-threadprivate.mlir
@@ -1,7 +1,7 @@
 // RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(acc-cg-to-gpu))" | FileCheck %s
 
 // CHECK-LABEL: func.func @threadprivate
-// CHECK:       acc.privatize [#acc<par_dims[thread_x]>] : () -> !acc.private_type<memref<i32>>
+// CHECK:       acc.privatize par_dims(#acc<par_dims[thread_x]>) : () -> !acc.private_type<memref<i32>>
 // CHECK:       gpu.launch
 // CHECK:         memref.alloca() : memref<i32>
 // CHECK-NOT:     acc.gpu_shared_memory
@@ -10,7 +10,7 @@ func.func @threadprivate(%host: memref<i32>) {
   %c99 = arith.constant 99 : i32
   memref.store %c99, %host[] : memref<i32>
   %init = memref.load %host[] : memref<i32>
-  %priv = acc.privatize [#acc<par_dims[thread_x]>] : () -> !acc.private_type<memref<i32>>
+  %priv = acc.privatize par_dims(#acc<par_dims[thread_x]>) : () -> !acc.private_type<memref<i32>>
 
   acc.compute_region ins(%priv_in = %priv, %init_in = %init) :
       (!acc.private_type<memref<i32>>, i32) {
@@ -39,7 +39,7 @@ func.func @dynamic_threadprivate(%n: index) {
   %c128 = arith.constant 128 : index
   %bx = acc.par_width %c4 par_dim(#acc.par_dim<block_x>)
   %tx = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
-  %private = acc.privatize(%n) [#acc<par_dims[block_x, thread_x]>]
+  %private = acc.privatize(%n) par_dims(#acc<par_dims[block_x, thread_x]>)
       : (index) -> !acc.private_type<memref<?xi32>>
 
   acc.compute_region launch(%kbx = %bx, %ktx = %tx)

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-array-shared.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-array-shared.mlir
@@ -46,7 +46,7 @@ func.func @array_reduction_shared(%arg0: memref<8192xi32>) {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       %b = acc.bounds extent(%c8192 : index)
-      acc.reduction_accumulate_array %2 bounds(%b) <add> : memref<8192xi32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
+      acc.reduction_accumulate_array %2 bounds(%b) <add> par_dims(#acc<par_dims[block_x, thread_x]>) : memref<8192xi32>
       acc.reduction_combine_region %2 into %arg2 : memref<8192xi32> {
         scf.for %i = %c0 to %c8192 step %c1 {
           %3 = memref.load %2[%i] : memref<8192xi32>
@@ -102,7 +102,7 @@ func.func @array_reduction_shared_partitioned(%arg0: memref<8192xi32>) {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       %b = acc.bounds extent(%c8192 : index)
-      acc.reduction_accumulate_array %2 bounds(%b) <add> : memref<8192xi32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
+      acc.reduction_accumulate_array %2 bounds(%b) <add> par_dims(#acc<par_dims[block_x, thread_x]>) : memref<8192xi32>
       acc.reduction_combine_region %2 into %arg2 : memref<8192xi32> {
         scf.for %i = %c0 to %c8192 step %c1 {
           %3 = memref.load %2[%i] : memref<8192xi32>
@@ -138,7 +138,7 @@ func.func @array_reduction_gang_storage_thread_accum(%arg0: memref<4xi32>) {
     %bx = acc.par_width %c2 par_dim(#acc.par_dim<block_x>)
     %wy = acc.par_width %c4 par_dim(#acc.par_dim<thread_y>)
     %tx = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
-    %private = acc.privatize [#acc<par_dims[block_x]>] : () -> !acc.private_type<memref<4xi32>>
+    %private = acc.privatize par_dims(#acc<par_dims[block_x]>) : () -> !acc.private_type<memref<4xi32>>
     acc.compute_region launch(%kbx = %bx, %kwy = %wy, %ktx = %tx) ins(%arg2 = %0, %priv = %private) : (memref<4xi32>, !acc.private_type<memref<4xi32>>) {
       %c0 = arith.constant 0 : index
       %c1 = arith.constant 1 : index
@@ -157,7 +157,7 @@ func.func @array_reduction_gang_storage_thread_accum(%arg0: memref<4xi32>) {
           scf.reduce
         } {acc.par_dims = #acc<par_dims[thread_y]>}
         %b = acc.bounds extent(%c4_idx : index)
-        acc.reduction_accumulate_array %local bounds(%b) <add> : memref<4xi32> <{par_dims = #acc<par_dims[thread_y]>}>
+        acc.reduction_accumulate_array %local bounds(%b) <add> par_dims(#acc<par_dims[thread_y]>) : memref<4xi32>
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       acc.yield

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-array.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-array.mlir
@@ -47,7 +47,7 @@ func.func @array_reduction(%arg0: memref<2xi32>) {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       %b = acc.bounds extent(%c2 : index)
-      acc.reduction_accumulate_array %2 bounds(%b) <add> : memref<2xi32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
+      acc.reduction_accumulate_array %2 bounds(%b) <add> par_dims(#acc<par_dims[block_x, thread_x]>) : memref<2xi32>
       acc.reduction_combine_region %2 into %arg2 : memref<2xi32> {
         scf.for %i = %c0 to %c2 step %c1 {
           %3 = memref.load %2[%i] : memref<2xi32>
@@ -77,7 +77,7 @@ func.func @array_reduction_small_shared() {
     %shared = memref.alloc() : memref<2xi32>
     %bounds = acc.bounds extent(%c2 : index)
     acc.reduction_accumulate_array %shared bounds(%bounds) <add>
-        : memref<2xi32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
+        par_dims(#acc<par_dims[block_x, thread_x]>) : memref<2xi32>
     memref.dealloc %shared : memref<2xi32>
     acc.yield
   } {origin = "acc.parallel"}
@@ -105,7 +105,7 @@ func.func @array_reduction_strided_extent() {
     %bounds = acc.bounds lowerbound(%c1_b : index) extent(%c3 : index)
         stride(%c2 : index)
     acc.reduction_accumulate_array %local bounds(%bounds) <add>
-        : memref<8xi32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
+        par_dims(#acc<par_dims[block_x, thread_x]>) : memref<8xi32>
     acc.yield
   } {origin = "acc.parallel"}
   return
@@ -128,8 +128,7 @@ func.func @array_reduction_dynamic_par_dims(%buf: memref<?xi32>, %n: index) {
         : memref<?xi32> to memref<?xi32, strided<[1]>>
     %bounds = acc.bounds extent(%ext : index)
     acc.reduction_accumulate_array %view bounds(%bounds) <add>
-        : memref<?xi32, strided<[1]>>
-        <{par_dims = #acc<par_dims[block_x, thread_x]>}>
+        par_dims(#acc<par_dims[block_x, thread_x]>) : memref<?xi32, strided<[1]>>
     acc.yield
   } {origin = "acc.parallel"}
   return
@@ -153,12 +152,12 @@ func.func @rank_two_array_reduction() {
   %c128 = arith.constant 128 : index
   %bx = acc.par_width %c1 par_dim(#acc.par_dim<block_x>)
   %tx = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
-  %private = acc.privatize [#acc<par_dims[block_x, thread_x]>] : () -> !acc.private_type<memref<2x3xi32>>
+  %private = acc.privatize par_dims(#acc<par_dims[block_x, thread_x]>) : () -> !acc.private_type<memref<2x3xi32>>
   acc.compute_region launch(%kbx = %bx, %ktx = %tx) ins(%arg0 = %private) : (!acc.private_type<memref<2x3xi32>>) {
     %c6 = arith.constant 6 : index
     %local = acc.private_local %arg0 {acc.par_dims = #acc<par_dims[block_x, thread_x]>} : (!acc.private_type<memref<2x3xi32>>) -> memref<2x3xi32>
     %bounds = acc.bounds extent(%c6 : index)
-    acc.reduction_accumulate_array %local bounds(%bounds) <add> : memref<2x3xi32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
+    acc.reduction_accumulate_array %local bounds(%bounds) <add> par_dims(#acc<par_dims[block_x, thread_x]>) : memref<2x3xi32>
     acc.yield
   } {origin = "acc.parallel"}
   return
@@ -185,12 +184,12 @@ func.func @rank_three_array_reduction() {
   %c128 = arith.constant 128 : index
   %bx = acc.par_width %c1 par_dim(#acc.par_dim<block_x>)
   %tx = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
-  %private = acc.privatize [#acc<par_dims[block_x, thread_x]>] : () -> !acc.private_type<memref<2x2x2xi32>>
+  %private = acc.privatize par_dims(#acc<par_dims[block_x, thread_x]>) : () -> !acc.private_type<memref<2x2x2xi32>>
   acc.compute_region launch(%kbx = %bx, %ktx = %tx) ins(%arg0 = %private) : (!acc.private_type<memref<2x2x2xi32>>) {
     %c8 = arith.constant 8 : index
     %local = acc.private_local %arg0 {acc.par_dims = #acc<par_dims[block_x, thread_x]>} : (!acc.private_type<memref<2x2x2xi32>>) -> memref<2x2x2xi32>
     %bounds = acc.bounds extent(%c8 : index)
-    acc.reduction_accumulate_array %local bounds(%bounds) <add> : memref<2x2x2xi32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
+    acc.reduction_accumulate_array %local bounds(%bounds) <add> par_dims(#acc<par_dims[block_x, thread_x]>) : memref<2x2x2xi32>
     acc.yield
   } {origin = "acc.parallel"}
   return
@@ -218,7 +217,7 @@ func.func @dynamic_rank_two_array_reduction(
     %c2 = arith.constant 2 : index
     %extent = arith.muli %c2, %arg1 : index
     %bounds = acc.bounds extent(%extent : index)
-    acc.reduction_accumulate_array %arg0 bounds(%bounds) <add> : memref<2x?xi32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
+    acc.reduction_accumulate_array %arg0 bounds(%bounds) <add> par_dims(#acc<par_dims[block_x, thread_x]>) : memref<2x?xi32>
     acc.yield
   } {origin = "acc.parallel"}
   return
@@ -249,8 +248,7 @@ func.func @rank_two_partial_bounds_strided_layout() {
     %bounds = acc.bounds lowerbound(%lb : index) extent(%extent : index)
         stride(%step : index)
     acc.reduction_accumulate_array %local bounds(%bounds) <add>
-        : memref<3x4xi32, strided<[8, 2]>>
-        <{par_dims = #acc<par_dims[block_x, thread_x]>}>
+        par_dims(#acc<par_dims[block_x, thread_x]>) : memref<3x4xi32, strided<[8, 2]>>
     acc.yield
   } {origin = "acc.parallel"}
   return
@@ -272,7 +270,7 @@ func.func @partial_thread_x_reduction() {
     %local = memref.alloca() : memref<2xi32>
     %bounds = acc.bounds extent(%c2 : index)
     acc.reduction_accumulate_array %local bounds(%bounds) <add>
-        : memref<2xi32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
+        par_dims(#acc<par_dims[block_x, thread_x]>) : memref<2xi32>
     acc.yield
   } {origin = "acc.parallel"}
   return
@@ -291,8 +289,7 @@ func.func @thread_y_reduction_still_aligned() {
     %c0_i32 = arith.constant 0 : i32
     %local = memref.alloca() : memref<i32>
     acc.reduction_accumulate %c0_i32 to %local <add>
-        : i32 -> memref<i32>
-        <{par_dims = #acc<par_dims[block_x, thread_y]>}>
+        par_dims(#acc<par_dims[block_x, thread_y]>) : i32 -> memref<i32>
     acc.yield
   } {origin = "acc.parallel"}
   return
@@ -316,8 +313,7 @@ func.func @thread_x_reduction_with_thread_y_width() {
     %c0_i32 = arith.constant 0 : i32
     %local = memref.alloca() : memref<i32>
     acc.reduction_accumulate %c0_i32 to %local <add>
-        : i32 -> memref<i32>
-        <{par_dims = #acc<par_dims[block_x, thread_x]>}>
+        par_dims(#acc<par_dims[block_x, thread_x]>) : i32 -> memref<i32>
     acc.yield
   } {origin = "acc.parallel"}
   return
@@ -341,8 +337,7 @@ func.func @thread_x_reduction_with_thread_z_width() {
     %c0_i32 = arith.constant 0 : i32
     %local = memref.alloca() : memref<i32>
     acc.reduction_accumulate %c0_i32 to %local <add>
-        : i32 -> memref<i32>
-        <{par_dims = #acc<par_dims[block_x, thread_x]>}>
+        par_dims(#acc<par_dims[block_x, thread_x]>) : i32 -> memref<i32>
     acc.yield
   } {origin = "acc.parallel"}
   return
@@ -372,7 +367,7 @@ func.func @thread_only_array_reduction_single_block() {
     }
     %bounds = acc.bounds extent(%c8 : index)
     acc.reduction_accumulate_array %local bounds(%bounds) <add>
-        : memref<8xi32> <{par_dims = #acc<par_dims[thread_x]>}>
+        par_dims(#acc<par_dims[thread_x]>) : memref<8xi32>
     acc.yield
   } {origin = "acc.parallel"}
   return

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-block-combine-no-reload.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-block-combine-no-reload.mlir
@@ -47,7 +47,7 @@ module attributes {gpu.container_module} {
               scf.reduce.return %sum : i32
             }
           } {acc.par_dims = #acc<par_dims[sequential]>}
-          acc.reduction_accumulate %inner_red to %a_slot <add> : i32 -> memref<i32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
+          acc.reduction_accumulate %inner_red to %a_slot <add> par_dims(#acc<par_dims[block_x, thread_x]>) : i32 -> memref<i32>
           scf.reduce
         } {acc.par_dims = #acc<par_dims[thread_x]>}
         scf.reduce

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-combine-region-private-dest.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-combine-region-private-dest.mlir
@@ -21,8 +21,8 @@ func.func @combine_region_private_dest(%arg: memref<i32>) {
   %c128 = arith.constant 128 : index
   %bx = acc.par_width %c1_pw par_dim(#acc.par_dim<block_x>)
   %tx = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
-  %pv_outer = acc.privatize {acc.par_dims = #acc<par_dims[block_x, thread_x]>} : () -> !acc.private_type<memref<i32>>
-  %pv_inner = acc.privatize {acc.par_dims = #acc<par_dims[block_x, thread_x]>} : () -> !acc.private_type<memref<i32>>
+  %pv_outer = acc.privatize par_dims(#acc<par_dims[block_x, thread_x]>) : () -> !acc.private_type<memref<i32>>
+  %pv_inner = acc.privatize par_dims(#acc<par_dims[block_x, thread_x]>) : () -> !acc.private_type<memref<i32>>
   acc.compute_region launch(%kbx = %bx, %ktx = %tx) ins(%a_res = %arg, %po = %pv_outer, %pi = %pv_inner) : (memref<i32>, !acc.private_type<memref<i32>>, !acc.private_type<memref<i32>>) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
@@ -49,7 +49,7 @@ func.func @combine_region_private_dest(%arg: memref<i32>) {
             memref.store %c1_i32, %inner[] : memref<i32>
           }
           %v = memref.load %inner[] : memref<i32>
-          acc.reduction_accumulate %v to %inner <add> : i32 -> memref<i32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
+          acc.reduction_accumulate %v to %inner <add> par_dims(#acc<par_dims[block_x, thread_x]>) : i32 -> memref<i32>
           acc.predicate_region {
             acc.reduction_combine_region %inner into %outer : memref<i32> {
               %la = memref.load %outer[] : memref<i32>
@@ -62,7 +62,7 @@ func.func @combine_region_private_dest(%arg: memref<i32>) {
           scf.reduce
         } {acc.par_dims = #acc<par_dims[sequential]>}
         %ov = memref.load %outer[] : memref<i32>
-        acc.reduction_accumulate %ov to %outer <add> : i32 -> memref<i32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
+        acc.reduction_accumulate %ov to %outer <add> par_dims(#acc<par_dims[block_x, thread_x]>) : i32 -> memref<i32>
         scf.reduce
       } {acc.par_dims = #acc<par_dims[thread_x]>}
       scf.reduce

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-routine-worker-call-with-thread-y-reduction.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-routine-worker-call-with-thread-y-reduction.mlir
@@ -62,7 +62,7 @@ module attributes {gpu.container_module} {
               scf.reduce.return %sum : i32
             }
           } {acc.par_dims = #acc<par_dims[sequential]>}
-          acc.reduction_accumulate %loop_red to %out_priv <add> : i32 -> memref<i32> <{par_dims = #acc<par_dims[thread_y]>}>
+          acc.reduction_accumulate %loop_red to %out_priv <add> par_dims(#acc<par_dims[thread_y]>) : i32 -> memref<i32>
           scf.reduce
         } {acc.par_dims = #acc<par_dims[thread_y]>}
         scf.reduce

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine-mixed-scope.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine-mixed-scope.mlir
@@ -10,7 +10,7 @@ func.func @mixed_scope_worker_reduction_combine(
   %thread_y = acc.par_width %c4 par_dim(#acc.par_dim<thread_y>)
   %thread_x = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
-    %private = acc.privatize [#acc<par_dims[thread_y]>]
+    %private = acc.privatize par_dims(#acc<par_dims[thread_y]>)
         : () -> !acc.private_type<memref<i32>>
     // expected-error@+1 {{failed to legalize operation 'acc.compute_region' that was explicitly marked illegal}}
     acc.compute_region launch(%by = %block_y, %ty = %thread_y, %tx = %thread_x)
@@ -50,7 +50,7 @@ func.func @worker_combine_with_single_store(%result: memref<i32>) {
   %thread_y = acc.par_width %c4 par_dim(#acc.par_dim<thread_y>)
   %thread_x = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
-    %private = acc.privatize [#acc<par_dims[thread_y]>]
+    %private = acc.privatize par_dims(#acc<par_dims[thread_y]>)
         : () -> !acc.private_type<memref<i32>>
     // expected-error@+1 {{failed to legalize operation 'acc.compute_region' that was explicitly marked illegal}}
     acc.compute_region launch(%by = %block_y, %ty = %thread_y, %tx = %thread_x)
@@ -90,7 +90,7 @@ func.func @worker_combine_with_atomic_update(%result: memref<i32>) {
   %thread_y = acc.par_width %c4 par_dim(#acc.par_dim<thread_y>)
   %thread_x = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
-    %private = acc.privatize [#acc<par_dims[thread_y]>]
+    %private = acc.privatize par_dims(#acc<par_dims[thread_y]>)
         : () -> !acc.private_type<memref<i32>>
     // expected-error@+1 {{failed to legalize operation 'acc.compute_region' that was explicitly marked illegal}}
     acc.compute_region launch(%by = %block_y, %ty = %thread_y, %tx = %thread_x)

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine.mlir
@@ -19,7 +19,7 @@ func.func @worker_reduction_combine(%result: memref<i32>) {
   %thread_y = acc.par_width %c4 par_dim(#acc.par_dim<thread_y>)
   %thread_x = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
-    %private = acc.privatize [#acc<par_dims[thread_y]>]
+    %private = acc.privatize par_dims(#acc<par_dims[thread_y]>)
         : () -> !acc.private_type<memref<i32>>
     acc.compute_region launch(%by = %block_y, %ty = %thread_y, %tx = %thread_x)
         ins(%private_arg = %private, %result_arg = %result)
@@ -63,7 +63,7 @@ func.func @worker_reduction_combine_region(%result: memref<i32>) {
   %thread_y = acc.par_width %c4 par_dim(#acc.par_dim<thread_y>)
   %thread_x = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
-    %private = acc.privatize [#acc<par_dims[thread_y]>]
+    %private = acc.privatize par_dims(#acc<par_dims[thread_y]>)
         : () -> !acc.private_type<memref<i32>>
     acc.compute_region launch(%by = %block_y, %ty = %thread_y, %tx = %thread_x)
         ins(%private_arg = %private, %result_arg = %result)
@@ -113,7 +113,7 @@ func.func @nested_worker_reduction_combines(
   %thread_y = acc.par_width %c4 par_dim(#acc.par_dim<thread_y>)
   %thread_x = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
-    %private = acc.privatize [#acc<par_dims[thread_y]>]
+    %private = acc.privatize par_dims(#acc<par_dims[thread_y]>)
         : () -> !acc.private_type<memref<i32>>
     acc.compute_region launch(%by = %block_y, %ty = %thread_y, %tx = %thread_x)
         ins(%private_arg = %private, %other_arg = %other,
@@ -161,7 +161,7 @@ func.func @worker_combine_in_scf_if(%result: memref<i32>) {
   %thread_y = acc.par_width %c4 par_dim(#acc.par_dim<thread_y>)
   %thread_x = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
-    %private = acc.privatize [#acc<par_dims[thread_y]>]
+    %private = acc.privatize par_dims(#acc<par_dims[thread_y]>)
         : () -> !acc.private_type<memref<i32>>
     acc.compute_region launch(%by = %block_y, %ty = %thread_y, %tx = %thread_x)
         ins(%private_arg = %private, %result_arg = %result)

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-private.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-private.mlir
@@ -12,7 +12,7 @@ func.func @worker_reduction_private() {
   %worker = acc.par_width %c4 par_dim(#acc.par_dim<thread_y>)
   %vector = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
-    %private = acc.privatize [#acc<par_dims[thread_y]>] : () -> !acc.private_type<memref<i32>>
+    %private = acc.privatize par_dims(#acc<par_dims[thread_y]>) : () -> !acc.private_type<memref<i32>>
     acc.compute_region launch(%bx = %block, %wy = %worker, %vx = %vector)
         ins(%private_arg = %private) : (!acc.private_type<memref<i32>>) {
       %c0 = arith.constant 0 : index
@@ -29,7 +29,7 @@ func.func @worker_reduction_private() {
           } {acc.par_dims = #acc<par_dims[thread_y]>}
           %value = memref.load %local[] : memref<i32>
           acc.reduction_accumulate %value to %local <add>
-              : i32 -> memref<i32> <{par_dims = #acc<par_dims[thread_y]>}>
+              par_dims(#acc<par_dims[thread_y]>) : i32 -> memref<i32>
           scf.reduce
         } {acc.par_dims = #acc<par_dims[sequential]>}
         scf.reduce

--- a/mlir/test/Dialect/OpenACC/invalid-cg.mlir
+++ b/mlir/test/Dialect/OpenACC/invalid-cg.mlir
@@ -45,7 +45,7 @@ func.func @reduction_accumulate_invalid_operator() {
   %partial = arith.constant 1.0 : f32
   %private = memref.alloca() : memref<f32>
   acc.reduction_accumulate %partial to %private <addi>
-      : f32 -> memref<f32> <{par_dims = #acc<par_dims[thread_x]>}>
+      par_dims(#acc<par_dims[thread_x]>) : f32 -> memref<f32>
   // expected-error@-2 {{expected ::mlir::acc::ReductionOperator to be one of}}
   // expected-error@-3 {{failed to parse OpenACC_ReductionOperatorAttr}}
   return
@@ -58,7 +58,7 @@ func.func @reduction_accumulate_type_mismatch() {
   %private_i32 = memref.alloca() : memref<i32>
   // expected-error@+1 {{pointer-like element type must match value type}}
   acc.reduction_accumulate %wrong_ty to %private_i32 <add>
-      : f32 -> memref<i32> <{par_dims = #acc<par_dims[thread_x]>}>
+      par_dims(#acc<par_dims[thread_x]>) : f32 -> memref<i32>
   return
 }
 
@@ -69,7 +69,7 @@ func.func @reduction_accumulate_empty_par_dims() {
   %private4 = memref.alloca() : memref<i32>
   // expected-error@+1 {{par_dims must specify at least one parallel dimension}}
   acc.reduction_accumulate %partial3 to %private4 <add>
-      : i32 -> memref<i32> <{par_dims = #acc<par_dims[]>}>
+      par_dims(#acc<par_dims[]>) : i32 -> memref<i32>
   return
 }
 
@@ -77,7 +77,7 @@ func.func @reduction_accumulate_empty_par_dims() {
 
 func.func @reduction_accumulate_array_invalid_operator(%private: memref<4xi32>, %bounds: !acc.data_bounds_ty) {
   acc.reduction_accumulate_array %private bounds(%bounds) <addi>
-      : memref<4xi32> <{par_dims = #acc<par_dims[thread_x]>}>
+      par_dims(#acc<par_dims[thread_x]>) : memref<4xi32>
   // expected-error@-2 {{expected ::mlir::acc::ReductionOperator to be one of}}
   // expected-error@-3 {{failed to parse OpenACC_ReductionOperatorAttr}}
   return
@@ -88,7 +88,7 @@ func.func @reduction_accumulate_array_invalid_operator(%private: memref<4xi32>, 
 func.func @reduction_accumulate_array_empty_par_dims(%private: memref<4xi32>, %bounds: !acc.data_bounds_ty) {
   // expected-error@+1 {{par_dims must specify at least one parallel dimension}}
   acc.reduction_accumulate_array %private bounds(%bounds) <add>
-      : memref<4xi32> <{par_dims = #acc<par_dims[]>}>
+      par_dims(#acc<par_dims[]>) : memref<4xi32>
   return
 }
 

--- a/mlir/test/Dialect/OpenACC/ops-cg-privatization.mlir
+++ b/mlir/test/Dialect/OpenACC/ops-cg-privatization.mlir
@@ -35,7 +35,7 @@ func.func @privatize_with_par_dims_attr() {
   %c1 = arith.constant 1 : index
   %c8 = arith.constant 8 : index
   %c128 = arith.constant 128 : index
-  %h = acc.privatize [#acc<par_dims[block_x, thread_x]>] : () -> !acc.private_type<memref<i32>>
+  %h = acc.privatize par_dims(#acc<par_dims[block_x, thread_x]>) : () -> !acc.private_type<memref<i32>>
   scf.parallel (%bx, %tx) = (%c0, %c0) to (%c8, %c128) step (%c1, %c1) {
     %loc = acc.private_local %h : (!acc.private_type<memref<i32>>) -> memref<i32>
     %z = arith.constant 0 : i32
@@ -44,7 +44,7 @@ func.func @privatize_with_par_dims_attr() {
   } {acc.par_dims = #acc<par_dims[block_x, thread_x]>}
   return
 }
-// CHECK-DAG: %[[H2:.*]] = acc.privatize [#acc<par_dims[block_x, thread_x]>] : () -> !acc.private_type<memref<i32>>
+// CHECK-DAG: %[[H2:.*]] = acc.privatize par_dims(#acc<par_dims[block_x, thread_x]>) : () -> !acc.private_type<memref<i32>>
 // CHECK: %{{.*}} = acc.private_local %[[H2]] : (!acc.private_type<memref<i32>>) -> memref<i32>
 
 // -----
@@ -74,7 +74,7 @@ func.func @privatize_dynamic_and_par_dims(%rows : index, %cols : index) {
   %c1 = arith.constant 1 : index
   %c4 = arith.constant 4 : index
   %c16 = arith.constant 16 : index
-  %h = acc.privatize(%rows, %cols) [#acc<par_dims[block_x, thread_x]>] : (index, index) -> !acc.private_type<memref<?x?xi32>>
+  %h = acc.privatize(%rows, %cols) par_dims(#acc<par_dims[block_x, thread_x]>) : (index, index) -> !acc.private_type<memref<?x?xi32>>
   scf.parallel (%bx, %tx) = (%c0, %c0) to (%c4, %c16) step (%c1, %c1) {
     %tile = acc.private_local %h : (!acc.private_type<memref<?x?xi32>>) -> memref<?x?xi32>
     %z = arith.constant 0 : i32
@@ -83,7 +83,7 @@ func.func @privatize_dynamic_and_par_dims(%rows : index, %cols : index) {
   } {acc.par_dims = #acc<par_dims[block_x, thread_x]>}
   return
 }
-// CHECK: acc.privatize(%{{.*}}, %{{.*}}) [#acc<par_dims[block_x, thread_x]>] : (index, index) -> !acc.private_type<memref<?x?xi32>>
+// CHECK: acc.privatize(%{{.*}}, %{{.*}}) par_dims(#acc<par_dims[block_x, thread_x]>) : (index, index) -> !acc.private_type<memref<?x?xi32>>
 
 // -----
 
@@ -94,7 +94,7 @@ func.func @privatize_inside_compute_region(%data : memref<64xf32>) {
     %c64_kw = arith.constant 64 : index
     %w = acc.par_width %c64_kw par_dim(#acc.par_dim<thread_x>)
     acc.compute_region launch(%lw = %w) ins(%d = %copy) : (memref<64xf32>) {
-      %priv = acc.privatize [#acc<par_dims[thread_x]>] : () -> !acc.private_type<memref<f32>>
+      %priv = acc.privatize par_dims(#acc<par_dims[thread_x]>) : () -> !acc.private_type<memref<f32>>
       %c0 = arith.constant 0 : index
       %c1 = arith.constant 1 : index
       %ub = arith.constant 64 : index
@@ -112,7 +112,7 @@ func.func @privatize_inside_compute_region(%data : memref<64xf32>) {
 }
 // CHECK: acc.kernel_environment
 // CHECK: acc.compute_region
-// CHECK: acc.privatize [#acc<par_dims[thread_x]>] : () -> !acc.private_type<memref<f32>>
+// CHECK: acc.privatize par_dims(#acc<par_dims[thread_x]>) : () -> !acc.private_type<memref<f32>>
 // CHECK: acc.private_local
 // CHECK: memref.load %{{.*}}[%{{.*}}] : memref<64xf32>
 // CHECK: } {origin = "acc.parallel"}

--- a/mlir/test/Dialect/OpenACC/ops-cg.mlir
+++ b/mlir/test/Dialect/OpenACC/ops-cg.mlir
@@ -314,7 +314,7 @@ func.func @parallel_reduction_pattern(%data: memref<8xi32>, %shared: memref<i32>
     }
   } {acc.par_dims = #acc<par_dims[thread_x]>}
   acc.reduction_accumulate %partial to %private <add>
-      : i32 -> memref<i32> <{par_dims = #acc<par_dims[thread_x]>}>
+      par_dims(#acc<par_dims[thread_x]>) : i32 -> memref<i32>
   acc.reduction_combine %private into %shared <add> : memref<i32>
       {acc.par_dims = #acc<par_dims[thread_x]>}
   return
@@ -322,7 +322,7 @@ func.func @parallel_reduction_pattern(%data: memref<8xi32>, %shared: memref<i32>
 // CHECK: memref.alloca() {acc.par_dims = #acc<par_dims[thread_x]>}
 // CHECK: scf.parallel
 // CHECK: scf.reduce
-// CHECK: acc.reduction_accumulate %{{.*}} to %{{.*}} <add> : i32 -> memref<i32> <{par_dims = #acc<par_dims[thread_x]>}>
+// CHECK: acc.reduction_accumulate %{{.*}} to %{{.*}} <add> par_dims(#acc<par_dims[thread_x]>) : i32 -> memref<i32>
 // CHECK: acc.reduction_combine %{{.*}} into %{{.*}} <add> : memref<i32> {acc.par_dims = #acc<par_dims[thread_x]>}
 
 // -----
@@ -330,29 +330,29 @@ func.func @parallel_reduction_pattern(%data: memref<8xi32>, %shared: memref<i32>
 // CHECK-LABEL: func @reduction_accumulate_thread_x
 func.func @reduction_accumulate_thread_x(%partial: f32, %private: memref<f32>) {
   acc.reduction_accumulate %partial to %private <add>
-      : f32 -> memref<f32> <{par_dims = #acc<par_dims[thread_x]>}>
+      par_dims(#acc<par_dims[thread_x]>) : f32 -> memref<f32>
   return
 }
-// CHECK: acc.reduction_accumulate %{{.*}} to %{{.*}} <add> : f32 -> memref<f32> <{par_dims = #acc<par_dims[thread_x]>}>
+// CHECK: acc.reduction_accumulate %{{.*}} to %{{.*}} <add> par_dims(#acc<par_dims[thread_x]>) : f32 -> memref<f32>
 
 // -----
 
 // CHECK-LABEL: func @reduction_accumulate_block_thread
 func.func @reduction_accumulate_block_thread(%partial: i32, %private: memref<i32>) {
   acc.reduction_accumulate %partial to %private <add>
-      : i32 -> memref<i32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
+      par_dims(#acc<par_dims[block_x, thread_x]>) : i32 -> memref<i32>
   return
 }
-// CHECK: acc.reduction_accumulate %{{.*}} to %{{.*}} <add> : i32 -> memref<i32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
+// CHECK: acc.reduction_accumulate %{{.*}} to %{{.*}} <add> par_dims(#acc<par_dims[block_x, thread_x]>) : i32 -> memref<i32>
 
 // -----
 
 // CHECK-LABEL: func @reduction_accumulate_array
 func.func @reduction_accumulate_array(%private: memref<4xi32>, %bounds: !acc.data_bounds_ty) {
-  acc.reduction_accumulate_array %private bounds(%bounds) <add> : memref<4xi32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
+  acc.reduction_accumulate_array %private bounds(%bounds) <add> par_dims(#acc<par_dims[block_x, thread_x]>) : memref<4xi32>
   return
 }
-// CHECK: acc.reduction_accumulate_array  %{{.*}} bounds(%{{.*}}) <add> : memref<4xi32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
+// CHECK: acc.reduction_accumulate_array  %{{.*}} bounds(%{{.*}}) <add> par_dims(#acc<par_dims[block_x, thread_x]>) : memref<4xi32>
 
 // -----
 


### PR DESCRIPTION
This makes the assembly format of par_dims explicit so that it gets handled similarly to other acc IR and appears before the types.