### PR TITLE
[AMDGPU] Remove redundant register alignment check for _Align1 operands

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -5392,29 +5392,6 @@ bool SIInstrInfo::verifyInstruction(const MachineInstr &MI,
     if (!Reg)
       continue;
 
-    // FIXME: Ideally we would have separate instruction definitions with the
-    // aligned register constraint.
-    // FIXME: We do not verify inline asm operands, but custom inline asm
-    // verification is broken anyway
-    if (ST.needsAlignedVGPRs() && Opcode != AMDGPU::AV_MOV_B64_IMM_PSEUDO &&
-        Opcode != AMDGPU::V_MOV_B64_PSEUDO && !isSpill(MI)) {
-      const TargetRegisterClass *RC = RI.getRegClassForReg(MRI, Reg);
-      if (RI.hasVectorRegisters(RC) && MO.getSubReg()) {
-        if (const TargetRegisterClass *SubRC =
-                RI.getSubRegisterClass(RC, MO.getSubReg())) {
-          RC = RI.getCompatibleSubRegClass(RC, SubRC, MO.getSubReg());
-          if (RC)
-            RC = SubRC;
-        }
-      }
-
-      // Check that this is the aligned version of the class.
-      if (!RC || !RI.isProperlyAlignedRC(*RC)) {
-        ErrInfo = "Subtarget requires even aligned vector registers";
-        return false;
-      }
-    }
-
     if (RegClass != -1) {
       if (Reg.isVirtual())
         continue;

--- a/llvm/test/CodeGen/AMDGPU/verify-ds-gws-align.mir
+++ b/llvm/test/CodeGen/AMDGPU/verify-ds-gws-align.mir
@@ -3,27 +3,49 @@
 
 # GFX90A-ERR: *** Bad machine code: Subtarget requires even aligned vector registers for DS_GWS instructions ***
 # GFX90A-ERR: DS_GWS_INIT killed %0.sub1:areg_128_align2, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+# GFX90A-ERR: *** Bad machine code: Illegal virtual register for instruction ***
+# GFX90A-ERR: DS_GWS_INIT killed %0.sub1:areg_128_align2, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
 # GFX90A-ERR: *** Bad machine code: Subtarget requires even aligned vector registers for DS_GWS instructions ***
+# GFX90A-ERR: DS_GWS_INIT killed %0.sub3:areg_128_align2, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+# GFX90A-ERR: *** Bad machine code: Illegal virtual register for instruction ***
 # GFX90A-ERR: DS_GWS_INIT killed %0.sub3:areg_128_align2, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
 # GFX90A-ERR: *** Bad machine code: Subtarget requires even aligned vector registers for DS_GWS instructions ***
 # GFX90A-ERR: DS_GWS_SEMA_BR killed %1.sub1:vreg_64_align2, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+# GFX90A-ERR: *** Bad machine code: Illegal virtual register for instruction ***
+# GFX90A-ERR: DS_GWS_SEMA_BR killed %1.sub1:vreg_64_align2, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
 # GFX90A-ERR: *** Bad machine code: Subtarget requires even aligned vector registers for DS_GWS instructions ***
+# GFX90A-ERR: DS_GWS_BARRIER killed %2.sub0:vreg_64, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+# GFX90A-ERR: *** Bad machine code: Illegal virtual register for instruction ***
 # GFX90A-ERR: DS_GWS_BARRIER killed %2.sub0:vreg_64, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
 # GFX90A-ERR: *** Bad machine code: Subtarget requires even aligned vector registers for DS_GWS instructions ***
 # GFX90A-ERR: DS_GWS_INIT killed %3:vgpr_32, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
-# GFX90A-ERR: *** Bad machine code: Illegal physical register for instruction ***
+# GFX90A-ERR: *** Bad machine code: Illegal virtual register for instruction ***
+# GFX90A-ERR: DS_GWS_INIT killed %3:vgpr_32, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+# GFX90A-ERR: *** Bad machine code: Operand has incorrect register class. ***
 # GFX90A-ERR: DS_GWS_INIT $vgpr1, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
 # GFX90A-ERR: *** Bad machine code: Illegal physical register for instruction ***
+# GFX90A-ERR: DS_GWS_INIT $vgpr1, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+# GFX90A-ERR: *** Bad machine code: Operand has incorrect register class. ***
 # GFX90A-ERR: DS_GWS_INIT $agpr1, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
-# GFX90A-ERR: *** Bad machine code: Subtarget requires even aligned vector registers ***
+# GFX90A-ERR: *** Bad machine code: Illegal physical register for instruction ***
+# GFX90A-ERR: DS_GWS_INIT $agpr1, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+# GFX90A-ERR: *** Bad machine code: Operand has incorrect register class. ***
+# GFX90A-ERR: DS_GWS_INIT $vgpr1_vgpr2, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+# GFX90A-ERR: *** Bad machine code: Illegal physical register for instruction ***
+# GFX90A-ERR: DS_GWS_INIT $vgpr1_vgpr2, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+# GFX90A-ERR: *** Bad machine code: Operand has incorrect register class. ***
+# GFX90A-ERR: DS_GWS_INIT $agpr3_agpr4, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+# GFX90A-ERR: *** Bad machine code: Illegal physical register for instruction ***
+# GFX90A-ERR: DS_GWS_INIT $agpr3_agpr4, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+# GFX90A-ERR: *** Bad machine code: Subtarget requires even aligned vector registers for DS_GWS instructions ***
 # GFX90A-ERR: DS_GWS_INIT %4:vreg_64, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
 # GFX90A-ERR: *** Bad machine code: Illegal virtual register for instruction ***
 # GFX90A-ERR: DS_GWS_INIT %4:vreg_64, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
-# GFX90A-ERR: *** Bad machine code: Subtarget requires even aligned vector registers ***
+# GFX90A-ERR: *** Bad machine code: Subtarget requires even aligned vector registers for DS_GWS instructions ***
 # GFX90A-ERR: DS_GWS_INIT %5:areg_64, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
 # GFX90A-ERR: *** Bad machine code: Illegal virtual register for instruction ***
 # GFX90A-ERR: DS_GWS_INIT %5:areg_64, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
-# GFX90A-ERR: *** Bad machine code: Subtarget requires even aligned vector registers ***
+# GFX90A-ERR: *** Bad machine code: Subtarget requires even aligned vector registers for DS_GWS instructions ***
 # GFX90A-ERR: DS_GWS_INIT %6:av_64, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
 # GFX90A-ERR: *** Bad machine code: Illegal virtual register for instruction ***
 # GFX90A-ERR: DS_GWS_INIT %6:av_64, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")

--- a/llvm/test/CodeGen/AMDGPU/verify-gfx90a-aligned-vgprs.mir
+++ b/llvm/test/CodeGen/AMDGPU/verify-gfx90a-aligned-vgprs.mir
@@ -62,90 +62,135 @@ body:            |
     %5:vreg_128_align2 = IMPLICIT_DEF
 
     ; Check virtual register uses
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: GLOBAL_STORE_DWORDX2 %0:vreg_64_align2, %1:vreg_64, 0, 0, implicit $exec
     GLOBAL_STORE_DWORDX2 %0, %1, 0, 0, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: GLOBAL_STORE_DWORDX3 %0:vreg_64_align2, %2:vreg_96, 0, 0, implicit $exec
     GLOBAL_STORE_DWORDX3 %0, %2, 0, 0, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: GLOBAL_STORE_DWORDX4 %0:vreg_64_align2, %3:vreg_128, 0, 0, implicit $exec
     GLOBAL_STORE_DWORDX4 %0, %3, 0, 0, implicit $exec
 
     ; Check virtual registers with subregisters
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: GLOBAL_STORE_DWORDX2 %0:vreg_64_align2, %3.sub0_sub1:vreg_128, 0, 0, implicit $exec
     GLOBAL_STORE_DWORDX2 %0, %3.sub0_sub1, 0, 0, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: GLOBAL_STORE_DWORDX2 %0:vreg_64_align2, %3.sub2_sub3:vreg_128, 0, 0, implicit $exec
     GLOBAL_STORE_DWORDX2 %0, %3.sub2_sub3, 0, 0, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: GLOBAL_STORE_DWORDX2 %0:vreg_64_align2, %3.sub1_sub2:vreg_128, 0, 0, implicit $exec
     GLOBAL_STORE_DWORDX2 %0, %3.sub1_sub2, 0, 0, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: GLOBAL_STORE_DWORDX2 %0:vreg_64_align2, %5.sub1_sub2:vreg_128_align2, 0, 0, implicit $exec
     GLOBAL_STORE_DWORDX2 %0, %5.sub1_sub2, 0, 0, implicit $exec
 
     ; Check physical register uses
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
+    ; CHECK: *** Bad machine code: Operand has incorrect register class. ***
+    ; CHECK: - instruction: GLOBAL_STORE_DWORDX2 $vgpr0_vgpr1, $vgpr3_vgpr4, 0, 0, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal physical register for instruction ***
+    ; CHECK: - instruction: GLOBAL_STORE_DWORDX2 $vgpr0_vgpr1, $vgpr3_vgpr4, 0, 0, implicit $exec
     GLOBAL_STORE_DWORDX2 $vgpr0_vgpr1, $vgpr3_vgpr4, 0, 0, implicit $exec
+    ; CHECK: *** Bad machine code: Operand has incorrect register class. ***
+    ; CHECK: - instruction: GLOBAL_STORE_DWORDX3 $vgpr0_vgpr1, $vgpr3_vgpr4_vgpr5, 0, 0, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal physical register for instruction ***
+    ; CHECK: - instruction: GLOBAL_STORE_DWORDX3 $vgpr0_vgpr1, $vgpr3_vgpr4_vgpr5, 0, 0, implicit $exec
     GLOBAL_STORE_DWORDX3 $vgpr0_vgpr1, $vgpr3_vgpr4_vgpr5, 0, 0, implicit $exec
+    ; CHECK: *** Bad machine code: Operand has incorrect register class. ***
+    ; CHECK: - instruction: GLOBAL_STORE_DWORDX4 $vgpr0_vgpr1, $vgpr3_vgpr4_vgpr5_vgpr6, 0, 0, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal physical register for instruction ***
+    ; CHECK: - instruction: GLOBAL_STORE_DWORDX4 $vgpr0_vgpr1, $vgpr3_vgpr4_vgpr5_vgpr6, 0, 0, implicit $exec
     GLOBAL_STORE_DWORDX4 $vgpr0_vgpr1, $vgpr3_vgpr4_vgpr5_vgpr6, 0, 0, implicit $exec
 
     ; Check virtual register defs
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: %6:vreg_64 = GLOBAL_LOAD_DWORDX2 %0:vreg_64_align2, 0, 0, implicit $exec
     %6:vreg_64 = GLOBAL_LOAD_DWORDX2 %0, 0, 0, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: %7:vreg_96 = GLOBAL_LOAD_DWORDX3 %0:vreg_64_align2, 0, 0, implicit $exec
     %7:vreg_96 = GLOBAL_LOAD_DWORDX3 %0, 0, 0, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: %8:vreg_128 = GLOBAL_LOAD_DWORDX4 %0:vreg_64_align2, 0, 0, implicit $exec
     %8:vreg_128 = GLOBAL_LOAD_DWORDX4 %0, 0, 0, implicit $exec
 
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
+    ; CHECK: *** Bad machine code: Operand has incorrect register class. ***
+    ; CHECK: - instruction: $vgpr1_vgpr2 = GLOBAL_LOAD_DWORDX2 %0:vreg_64_align2, 0, 0, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal physical register for instruction ***
+    ; CHECK: - instruction: $vgpr1_vgpr2 = GLOBAL_LOAD_DWORDX2 %0:vreg_64_align2, 0, 0, implicit $exec
     $vgpr1_vgpr2 = GLOBAL_LOAD_DWORDX2 %0, 0, 0, implicit $exec
+    ; CHECK: *** Bad machine code: Operand has incorrect register class. ***
+    ; CHECK: - instruction: $vgpr1_vgpr2_vgpr3 = GLOBAL_LOAD_DWORDX3 %0:vreg_64_align2, 0, 0, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal physical register for instruction ***
+    ; CHECK: - instruction: $vgpr1_vgpr2_vgpr3 = GLOBAL_LOAD_DWORDX3 %0:vreg_64_align2, 0, 0, implicit $exec
     $vgpr1_vgpr2_vgpr3 = GLOBAL_LOAD_DWORDX3 %0, 0, 0, implicit $exec
+    ; CHECK: *** Bad machine code: Operand has incorrect register class. ***
+    ; CHECK: - instruction: $vgpr1_vgpr2_vgpr3_vgpr4 = GLOBAL_LOAD_DWORDX4 %0:vreg_64_align2, 0, 0, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal physical register for instruction ***
+    ; CHECK: - instruction: $vgpr1_vgpr2_vgpr3_vgpr4 = GLOBAL_LOAD_DWORDX4 %0:vreg_64_align2, 0, 0, implicit $exec
     $vgpr1_vgpr2_vgpr3_vgpr4 = GLOBAL_LOAD_DWORDX4 %0, 0, 0, implicit $exec
 
     ; Check AGPRs
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
     %9:vgpr_32 = IMPLICIT_DEF
     %10:areg_64 = IMPLICIT_DEF
     %11:areg_128_align2 = IMPLICIT_DEF
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: DS_WRITE_B64_gfx9 %9:vgpr_32, %10:areg_64, 0, 0, implicit $exec
     DS_WRITE_B64_gfx9 %9, %10, 0, 0, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: DS_WRITE_B64_gfx9 %9:vgpr_32, %11.sub1_sub2:areg_128_align2, 0, 0, implicit $exec
     DS_WRITE_B64_gfx9 %9, %11.sub1_sub2, 0, 0, implicit $exec
 
     ; Check aligned vgprs for FP32 Packed Math instructions.
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
     %12:vreg_64 = IMPLICIT_DEF
     %13:vreg_64_align2 = IMPLICIT_DEF
     %14:areg_96_align2 = IMPLICIT_DEF
+    ; CHECK: *** Bad machine code: Operand has incorrect register class. ***
+    ; CHECK: - instruction: $vgpr3_vgpr4 = V_PK_MOV_B32 8, 0, 8, 0, 0, 0, 0, 0, 0, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal physical register for instruction ***
+    ; CHECK: - instruction: $vgpr3_vgpr4 = V_PK_MOV_B32 8, 0, 8, 0, 0, 0, 0, 0, 0, implicit $exec
     $vgpr3_vgpr4 = V_PK_MOV_B32 8, 0, 8, 0, 0, 0, 0, 0, 0, implicit $exec
-    $vgpr0_vgpr1 = V_PK_ADD_F32 0, %12, 11, %13, 0, 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: $vgpr0_vgpr1 = V_PK_ADD_F32 0, %12:vreg_64, 11, %13:vreg_64_align2, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
+    $vgpr0_vgpr1 = V_PK_ADD_F32 0, %12, 11, %13, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: $vgpr0_vgpr1 = V_PK_ADD_F32 0, %13:vreg_64_align2, 11, %12:vreg_64, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
     $vgpr0_vgpr1 = V_PK_ADD_F32 0, %13, 11, %12, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: $vgpr0_vgpr1 = V_PK_ADD_F32 0, %13:vreg_64_align2, 11, %14.sub1_sub2:areg_96_align2, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
     $vgpr0_vgpr1 = V_PK_ADD_F32 0, %13, 11, %14.sub1_sub2, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
-    $vgpr0_vgpr1 = V_PK_ADD_F32 0, %14.sub1_sub2, 11, %13, 0, 0, 0, 0, implicit $mode, implicit $exec
-    $vgpr0_vgpr1 = V_PK_MUL_F32 0, %12, 11, %13, 0, 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: $vgpr0_vgpr1 = V_PK_ADD_F32 0, %14.sub1_sub2:areg_96_align2, 11, %13:vreg_64_align2, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
+    $vgpr0_vgpr1 = V_PK_ADD_F32 0, %14.sub1_sub2, 11, %13, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: $vgpr0_vgpr1 = V_PK_MUL_F32 0, %12:vreg_64, 11, %13:vreg_64_align2, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
+    $vgpr0_vgpr1 = V_PK_MUL_F32 0, %12, 11, %13, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: $vgpr0_vgpr1 = V_PK_MUL_F32 0, %13:vreg_64_align2, 11, %12:vreg_64, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
     $vgpr0_vgpr1 = V_PK_MUL_F32 0, %13, 11, %12, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: $vgpr0_vgpr1 = V_PK_MUL_F32 0, %13:vreg_64_align2, 11, %14.sub1_sub2:areg_96_align2, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
     $vgpr0_vgpr1 = V_PK_MUL_F32 0, %13, 11, %14.sub1_sub2, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
-    $vgpr0_vgpr1 = V_PK_MUL_F32 0, %14.sub1_sub2, 11, %13, 0, 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: $vgpr0_vgpr1 = V_PK_MUL_F32 0, %14.sub1_sub2:areg_96_align2, 11, %13:vreg_64_align2, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
+    $vgpr0_vgpr1 = V_PK_MUL_F32 0, %14.sub1_sub2, 11, %13, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: $vgpr0_vgpr1 = nofpexcept V_PK_FMA_F32 8, %12:vreg_64, 8, %13:vreg_64_align2, 11, %14.sub0_sub1:areg_96_align2, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: $vgpr0_vgpr1 = nofpexcept V_PK_FMA_F32 8, %12:vreg_64, 8, %13:vreg_64_align2, 11, %14.sub0_sub1:areg_96_align2, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
     $vgpr0_vgpr1 = nofpexcept V_PK_FMA_F32 8, %12, 8, %13, 11, %14.sub0_sub1, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: $vgpr0_vgpr1 = nofpexcept V_PK_FMA_F32 8, %13:vreg_64_align2, 8, %12:vreg_64, 11, %14.sub0_sub1:areg_96_align2, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: $vgpr0_vgpr1 = nofpexcept V_PK_FMA_F32 8, %13:vreg_64_align2, 8, %12:vreg_64, 11, %14.sub0_sub1:areg_96_align2, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
     $vgpr0_vgpr1 = nofpexcept V_PK_FMA_F32 8, %13, 8, %12, 11, %14.sub0_sub1, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: $vgpr0_vgpr1 = nofpexcept V_PK_FMA_F32 8, %13:vreg_64_align2, 8, %13:vreg_64_align2, 11, %14.sub1_sub2:areg_96_align2, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
     $vgpr0_vgpr1 = nofpexcept V_PK_FMA_F32 8, %13, 8, %13, 11, %14.sub1_sub2, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
 ...
 
 # FIXME: Inline asm is not verified
 # ; Check inline asm
-# ; XCHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-# ; XCHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-# ; XCHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
 # INLINEASM &"; use $0 ", sideeffect attdialect, reguse, $vgpr1_vgpr2
 # INLINEASM &"; use $0 ", sideeffect attdialect, reguse, %4
 # INLINEASM &"; use $0 ", sideeffect attdialect, reguse, %5.sub1_sub2

--- a/llvm/test/MachineVerifier/AMDGPU/unsupported-subreg-index-aligned-vgpr-check.mir
+++ b/llvm/test/MachineVerifier/AMDGPU/unsupported-subreg-index-aligned-vgpr-check.mir
@@ -21,10 +21,6 @@ body:             |
     ; CHECK-NEXT: - operand 1:   %1.sub16_sub17_sub18_sub19:vreg_512_align2
     ; CHECK-NEXT: Register class VReg_512_Align2 does not support subreg index sub16_sub17_sub18_sub19
 
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
-    ; CHECK-NEXT: - function:    uses_invalid_subregister_for_regclass
-    ; CHECK-NEXT: - basic block: %bb.0
-    ; CHECK-NEXT: - instruction: GLOBAL_STORE_DWORDX4_SADDR %0:vgpr_32, %2.sub16_sub17_sub18_sub19:vreg_512, undef $sgpr8_sgpr9, 80, 0, implicit $exec :: (store (s128), addrspace 1)
     GLOBAL_STORE_DWORDX4_SADDR %0, %1.sub16_sub17_sub18_sub19, undef $sgpr8_sgpr9, 80, 0, implicit $exec :: (store (s128), addrspace 1)
 
     ; Test with unaligned class

--- a/llvm/test/MachineVerifier/AMDGPU/unsupported-unaligned-vgpr-check-vsrc-operand.mir
+++ b/llvm/test/MachineVerifier/AMDGPU/unsupported-unaligned-vgpr-check-vsrc-operand.mir
@@ -9,12 +9,14 @@ body:             |
   bb.0:
     liveins: $vgpr1_vgpr2
 
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
+    ; CHECK: *** Bad machine code: Operand has incorrect register class. ***
     ; CHECK: - instruction: $vcc = V_CMP_NE_U64_e64 0, $vgpr1_vgpr2, implicit $exec
     ; CHECK: *** Bad machine code: Illegal physical register for instruction ***
+    ; CHECK: - instruction: $vcc = V_CMP_NE_U64_e64 0, $vgpr1_vgpr2, implicit $exec
     $vcc = V_CMP_NE_U64_e64 0, $vgpr1_vgpr2, implicit $exec
 
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
+    ; CHECK: *** Bad machine code: Operand has incorrect register class. ***
+    ; CHECK: - instruction: V_CMP_NE_U64_e32 0, $vgpr1_vgpr2, implicit-def $vcc, implicit $exec
     ; CHECK: *** Bad machine code: Illegal physical register for instruction ***
     ; CHECK: - instruction: V_CMP_NE_U64_e32 0, $vgpr1_vgpr2, implicit-def $vcc, implicit $exec
     V_CMP_NE_U64_e32 0, $vgpr1_vgpr2, implicit-def $vcc, implicit $exec
@@ -23,12 +25,12 @@ body:             |
     %1:vgpr_32 = V_MOV_B32_e32 1, implicit $exec
     %2:vreg_64 = IMPLICIT_DEF
 
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
     ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: %3:areg_128_align2 = V_MFMA_F32_4X4X1F32_e64 %0:vgpr_32, %1:vgpr_32, %2:vreg_64, 0, 0, 0, implicit $mode, implicit $exec
     %3:areg_128_align2 = V_MFMA_F32_4X4X1F32_e64 %0, %1, %2, 0, 0, 0, implicit $mode, implicit $exec
     %4:vreg_64 = IMPLICIT_DEF
 
-    ; CHECK: *** Bad machine code: Subtarget requires even aligned vector registers ***
     ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK: - instruction: %5:vreg_128_align2 = V_MFMA_F32_4X4X1F32_vgprcd_e64 %0:vgpr_32, %1:vgpr_32, %4:vreg_64, 0, 0, 0, implicit $mode, implicit $exec
     %5:vreg_128_align2 = V_MFMA_F32_4X4X1F32_vgprcd_e64 %0, %1, %4, 0, 0, 0, implicit $mode, implicit $exec
 ...

--- a/llvm/test/MachineVerifier/AMDGPU/verify-align1-operands-gfx1250.mir
+++ b/llvm/test/MachineVerifier/AMDGPU/verify-align1-operands-gfx1250.mir
@@ -1,0 +1,34 @@
+# RUN: llc -mtriple=amdgpu12.50 -run-pass=none -o /dev/null %s
+
+# ds_load_tr6_b96 and global_load_tr6_b96 declare VGPROp_96_Align1, which is the
+# unaligned VReg_96 class. They accept unaligned tuples, so these
+# functions should pass verification.
+# See also verify-align1-operands.mir for ds_read_b96_tr_b6 on gfx950.
+
+---
+name: ds_load_tr6_b96_unaligned
+body:             |
+  bb.0:
+    $vgpr0 = IMPLICIT_DEF
+    $vgpr1_vgpr2_vgpr3 = DS_LOAD_TR6_B96 $vgpr0, 0, 0, implicit $exec
+    S_ENDPGM 0
+...
+
+---
+name: global_load_tr6_b96_unaligned
+body:             |
+  bb.0:
+    $vgpr4_vgpr5 = IMPLICIT_DEF
+    $vgpr1_vgpr2_vgpr3 = GLOBAL_LOAD_TR6_B96 $vgpr4_vgpr5, 0, 0, implicit $exec
+    S_ENDPGM 0
+...
+
+# Aligned tuples remain valid.
+---
+name: ds_load_tr6_b96_aligned
+body:             |
+  bb.0:
+    $vgpr0 = IMPLICIT_DEF
+    $vgpr2_vgpr3_vgpr4 = DS_LOAD_TR6_B96 $vgpr0, 0, 0, implicit $exec
+    S_ENDPGM 0
+...

--- a/llvm/test/MachineVerifier/AMDGPU/verify-align1-operands.mir
+++ b/llvm/test/MachineVerifier/AMDGPU/verify-align1-operands.mir
@@ -1,0 +1,44 @@
+# RUN: llc -mtriple=amdgpu9.50 -run-pass=none -o /dev/null %s
+
+# Instructions which declare an _Align1 operand register class can accept
+# unaligned tuples. ds_read_b96_tr_b6 declares AVLdSt_96_Align1, which resolves
+# to an unaligned register class in every HwMode, so these functions should pass
+# verification. The other two _Align1 instructions are covered by
+# verify-align1-operands-gfx1250.mir.
+
+---
+name: ds_read_b96_tr_b6_unaligned_vgpr
+body:             |
+  bb.0:
+    $vgpr0 = IMPLICIT_DEF
+    $vgpr1_vgpr2_vgpr3 = DS_READ_B96_TR_B6 $vgpr0, 32, 0, implicit $exec
+    S_ENDPGM 0
+...
+
+---
+name: ds_read_b96_tr_b6_unaligned_agpr
+body:             |
+  bb.0:
+    $vgpr0 = IMPLICIT_DEF
+    $agpr1_agpr2_agpr3 = DS_READ_B96_TR_B6 $vgpr0, 32, 0, implicit $exec
+    S_ENDPGM 0
+...
+
+---
+name: ds_read_b96_tr_b6_unaligned_vreg
+body:             |
+  bb.0:
+    %0:vgpr_32 = IMPLICIT_DEF
+    %1:vreg_96 = DS_READ_B96_TR_B6 %0, 32, 0, implicit $exec
+    S_ENDPGM 0
+...
+
+# Aligned tuples remain valid.
+---
+name: ds_read_b96_tr_b6_aligned
+body:             |
+  bb.0:
+    $vgpr0 = IMPLICIT_DEF
+    $vgpr2_vgpr3_vgpr4 = DS_READ_B96_TR_B6 $vgpr0, 32, 0, implicit $exec
+    S_ENDPGM 0
+...


### PR DESCRIPTION
verifyInstruction rejected vector tuples not in an even-aligned register
class, even when the instruction did not require aligned registers. This
incorrectly rejected ds_read_b96_tr_b6, ds_load_tr6_b96, and
global_load_tr6_b96, whose _Align1 operand classes allow unaligned
tuples.

The check is redundant: MachineVerifier already validates registers
against their TableGen operand classes, and alignment is encoded in
those classes.

All existing alignment tests continue to reject invalid inputs, with
check lines updated for the new diagnostics. No generated code changes,
since the check is reachable only through MachineVerifier.

Also fixed four V_PK_ADD_F32/V_PK_MUL_F32 inputs in
verify-gfx90a-aligned-vgprs.mir that were missing an operand.
Previously, the redundant check returned early and prevented these
errors from being diagnosed.

Related to #129199

Assisted by Claude Opus 5
