### PR TITLE
[AMDGPU] Fix FDOT2 fold for non-constant lane indices

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -18369,7 +18369,7 @@ SDValue SITargetLowering::performFMACombine(SDNode *N,
       return SDValue();
 
     if (!isa<ConstantSDNode>(Idx1) || !isa<ConstantSDNode>(Idx2) ||
-        Op1.getConstantOperandVal(1) == FMAOp1.getConstantOperandVal(1))
+        Idx1 == Idx2)
       return SDValue();
 
     if (Vec1 == Vec2 || Vec3 == Vec4)

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -18365,9 +18365,11 @@ SDValue SITargetLowering::performFMACombine(SDNode *N,
     SDValue Vec4 = FMAOp2.getOperand(0);
     SDValue Idx2 = FMAOp1.getOperand(1);
 
-    if (Idx1 != Op2.getOperand(1) || Idx2 != FMAOp2.getOperand(1) ||
-        // Idx1 and Idx2 cannot be the same.
-        Idx1 == Idx2)
+    if (Idx1 != Op2.getOperand(1) || Idx2 != FMAOp2.getOperand(1))
+      return SDValue();
+
+    if (!isa<ConstantSDNode>(Idx1) || !isa<ConstantSDNode>(Idx2) ||
+        Op1.getConstantOperandVal(1) == FMAOp1.getConstantOperandVal(1))
       return SDValue();
 
     if (Vec1 == Vec2 || Vec3 == Vec4)

--- a/llvm/test/CodeGen/AMDGPU/fdot2.ll
+++ b/llvm/test/CodeGen/AMDGPU/fdot2.ll
@@ -493,4 +493,70 @@ define amdgpu_kernel void @dotproduct_f16_f32_afn(<2 x half> %a, <2 x half> %b, 
   ret void
 }
 
+; fdot2 hardwires lanes 0/1, so it must not fold when %i == %j at runtime.
+; GCN-LABEL: {{^}}Var_Idx_NotAdotproductContract
+; GFX906-DENORM-CONTRACT-NOT: v_dot2
+; GFX906-DENORM-CONTRACT: v_fma_mix_f32
+; GFX90A-PS-NOT: v_dot2
+; GFX90A-PS: v_fma_mix_f32
+define amdgpu_kernel void @Var_Idx_NotAdotproductContract(ptr addrspace(1) %src1,
+                                                          ptr addrspace(1) %src2,
+                                                          ptr addrspace(1) nocapture %dst,
+                                                          i32 %i, i32 %j) {
+entry:
+  %src1.vec = load <2 x half>, ptr addrspace(1) %src1
+  %src2.vec = load <2 x half>, ptr addrspace(1) %src2
+
+  %src1.eli = extractelement <2 x half> %src1.vec, i32 %i
+  %csrc1.eli = fpext half %src1.eli to float
+  %src2.eli = extractelement <2 x half> %src2.vec, i32 %i
+  %csrc2.eli = fpext half %src2.eli to float
+
+  %src1.elj = extractelement <2 x half> %src1.vec, i32 %j
+  %csrc1.elj = fpext half %src1.elj to float
+  %src2.elj = extractelement <2 x half> %src2.vec, i32 %j
+  %csrc2.elj = fpext half %src2.elj to float
+
+  %mul2 = fmul contract float %csrc1.elj, %csrc2.elj
+  %mul1 = fmul contract float %csrc1.eli, %csrc2.eli
+  %acc = load float, ptr addrspace(1) %dst, align 4
+  %acc1 = fadd contract float %mul2, %acc
+  %acc2 = fadd contract float %mul1, %acc1
+  store float %acc2, ptr addrspace(1) %dst, align 4
+  ret void
+}
+
+; A mix of a constant and a variable index must not fold either.
+; GCN-LABEL: {{^}}Mixed_Idx_NotAdotproductContract
+; GFX906-DENORM-CONTRACT-NOT: v_dot2
+; GFX906-DENORM-CONTRACT: v_fma_mix_f32
+; GFX90A-PS-NOT: v_dot2
+; GFX90A-PS: v_fma_mix_f32
+define amdgpu_kernel void @Mixed_Idx_NotAdotproductContract(ptr addrspace(1) %src1,
+                                                             ptr addrspace(1) %src2,
+                                                             ptr addrspace(1) nocapture %dst,
+                                                             i32 %j) {
+entry:
+  %src1.vec = load <2 x half>, ptr addrspace(1) %src1
+  %src2.vec = load <2 x half>, ptr addrspace(1) %src2
+
+  %src1.el0 = extractelement <2 x half> %src1.vec, i32 0
+  %csrc1.el0 = fpext half %src1.el0 to float
+  %src2.el0 = extractelement <2 x half> %src2.vec, i32 0
+  %csrc2.el0 = fpext half %src2.el0 to float
+
+  %src1.elj = extractelement <2 x half> %src1.vec, i32 %j
+  %csrc1.elj = fpext half %src1.elj to float
+  %src2.elj = extractelement <2 x half> %src2.vec, i32 %j
+  %csrc2.elj = fpext half %src2.elj to float
+
+  %mul2 = fmul contract float %csrc1.elj, %csrc2.elj
+  %mul1 = fmul contract float %csrc1.el0, %csrc2.el0
+  %acc = load float, ptr addrspace(1) %dst, align 4
+  %acc1 = fadd contract float %mul2, %acc
+  %acc2 = fadd contract float %mul1, %acc1
+  store float %acc2, ptr addrspace(1) %dst, align 4
+  ret void
+}
+
 attributes #0 = { denormal_fpenv(float: dynamic) }

--- a/llvm/test/CodeGen/AMDGPU/fdot2.ll
+++ b/llvm/test/CodeGen/AMDGPU/fdot2.ll
@@ -499,31 +499,22 @@ define amdgpu_kernel void @dotproduct_f16_f32_afn(<2 x half> %a, <2 x half> %b, 
 ; GFX906-DENORM-CONTRACT: v_fma_mix_f32
 ; GFX90A-PS-NOT: v_dot2
 ; GFX90A-PS: v_fma_mix_f32
-define amdgpu_kernel void @Var_Idx_NotAdotproductContract(ptr addrspace(1) %src1,
-                                                          ptr addrspace(1) %src2,
-                                                          ptr addrspace(1) nocapture %dst,
-                                                          i32 %i, i32 %j) {
-entry:
-  %src1.vec = load <2 x half>, ptr addrspace(1) %src1
-  %src2.vec = load <2 x half>, ptr addrspace(1) %src2
-
-  %src1.eli = extractelement <2 x half> %src1.vec, i32 %i
+define float @Var_Idx_NotAdotproductContract(<2 x half> %src1, <2 x half> %src2, float %acc, i32 %i, i32 %j) {
+  %src1.eli = extractelement <2 x half> %src1, i32 %i
   %csrc1.eli = fpext half %src1.eli to float
-  %src2.eli = extractelement <2 x half> %src2.vec, i32 %i
+  %src2.eli = extractelement <2 x half> %src2, i32 %i
   %csrc2.eli = fpext half %src2.eli to float
 
-  %src1.elj = extractelement <2 x half> %src1.vec, i32 %j
+  %src1.elj = extractelement <2 x half> %src1, i32 %j
   %csrc1.elj = fpext half %src1.elj to float
-  %src2.elj = extractelement <2 x half> %src2.vec, i32 %j
+  %src2.elj = extractelement <2 x half> %src2, i32 %j
   %csrc2.elj = fpext half %src2.elj to float
 
   %mul2 = fmul contract float %csrc1.elj, %csrc2.elj
   %mul1 = fmul contract float %csrc1.eli, %csrc2.eli
-  %acc = load float, ptr addrspace(1) %dst, align 4
   %acc1 = fadd contract float %mul2, %acc
   %acc2 = fadd contract float %mul1, %acc1
-  store float %acc2, ptr addrspace(1) %dst, align 4
-  ret void
+  ret float %acc2
 }
 
 ; A mix of a constant and a variable index must not fold either.
@@ -532,31 +523,22 @@ entry:
 ; GFX906-DENORM-CONTRACT: v_fma_mix_f32
 ; GFX90A-PS-NOT: v_dot2
 ; GFX90A-PS: v_fma_mix_f32
-define amdgpu_kernel void @Mixed_Idx_NotAdotproductContract(ptr addrspace(1) %src1,
-                                                             ptr addrspace(1) %src2,
-                                                             ptr addrspace(1) nocapture %dst,
-                                                             i32 %j) {
-entry:
-  %src1.vec = load <2 x half>, ptr addrspace(1) %src1
-  %src2.vec = load <2 x half>, ptr addrspace(1) %src2
-
-  %src1.el0 = extractelement <2 x half> %src1.vec, i32 0
+define float @Mixed_Idx_NotAdotproductContract(<2 x half> %src1, <2 x half> %src2, float %acc, i32 %j) {
+  %src1.el0 = extractelement <2 x half> %src1, i32 0
   %csrc1.el0 = fpext half %src1.el0 to float
-  %src2.el0 = extractelement <2 x half> %src2.vec, i32 0
+  %src2.el0 = extractelement <2 x half> %src2, i32 0
   %csrc2.el0 = fpext half %src2.el0 to float
 
-  %src1.elj = extractelement <2 x half> %src1.vec, i32 %j
+  %src1.elj = extractelement <2 x half> %src1, i32 %j
   %csrc1.elj = fpext half %src1.elj to float
-  %src2.elj = extractelement <2 x half> %src2.vec, i32 %j
+  %src2.elj = extractelement <2 x half> %src2, i32 %j
   %csrc2.elj = fpext half %src2.elj to float
 
   %mul2 = fmul contract float %csrc1.elj, %csrc2.elj
   %mul1 = fmul contract float %csrc1.el0, %csrc2.el0
-  %acc = load float, ptr addrspace(1) %dst, align 4
   %acc1 = fadd contract float %mul2, %acc
   %acc2 = fadd contract float %mul1, %acc1
-  store float %acc2, ptr addrspace(1) %dst, align 4
-  ret void
+  ret float %acc2
 }
 
 attributes #0 = { denormal_fpenv(float: dynamic) }


### PR DESCRIPTION
The fold only checked that the two lane index nodes were not the same SDValue, but distinct nodes can still be equal at runtime, silently picking the wrong lanes

Require both indices to be constant and distinct