### PR TITLE
[clang][bytecode][NFC] Don't check enum completeness in canClassify()

### DIFF
--- a/clang/lib/AST/ByteCode/Context.h
+++ b/clang/lib/AST/ByteCode/Context.h
@@ -141,8 +141,8 @@ public:
         T->isVectorType())
       return false;
 
-    if (const auto *D = T->getAsEnumDecl())
-      return D->isComplete();
+    if (T->isEnumeralType())
+      return true;
 
     return classify(T) != std::nullopt;
   }


### PR DESCRIPTION
This is not important here, only later in classify().