### PR TITLE
clang: Use the context printing policy in TemplateDiff

### DIFF
--- a/clang/lib/AST/ASTDiagnostic.cpp
+++ b/clang/lib/AST/ASTDiagnostic.cpp
@@ -2119,7 +2119,7 @@ public:
                QualType ToType, bool PrintTree, bool PrintFromType,
                bool ElideType, bool ShowColor)
     : Context(Context),
-      Policy(Context.getLangOpts()),
+      Policy(Context.getPrintingPolicy()),
       ElideType(ElideType),
       PrintTree(PrintTree),
       ShowColor(ShowColor),

--- a/clang/lib/AST/ASTDiagnostic.cpp
+++ b/clang/lib/AST/ASTDiagnostic.cpp
@@ -2114,21 +2114,15 @@ class TemplateDiff {
   }
 
 public:
-
   TemplateDiff(raw_ostream &OS, ASTContext &Context, QualType FromType,
                QualType ToType, bool PrintTree, bool PrintFromType,
                bool ElideType, bool ShowColor)
-    : Context(Context),
-      Policy(Context.getPrintingPolicy()),
-      ElideType(ElideType),
-      PrintTree(PrintTree),
-      ShowColor(ShowColor),
-      // When printing a single type, the FromType is the one printed.
-      FromTemplateType(PrintFromType ? FromType : ToType),
-      ToTemplateType(PrintFromType ? ToType : FromType),
-      OS(OS),
-      IsBold(false) {
-  }
+      : Context(Context), Policy(Context.getPrintingPolicy()),
+        ElideType(ElideType), PrintTree(PrintTree), ShowColor(ShowColor),
+        // When printing a single type, the FromType is the one printed.
+        FromTemplateType(PrintFromType ? FromType : ToType),
+        ToTemplateType(PrintFromType ? ToType : FromType), OS(OS),
+        IsBold(false) {}
 
   /// DiffTemplate - Start the template type diffing.
   void DiffTemplate() {

--- a/clang/test/SemaCXX/cxx2a-nttp-printing.cpp
+++ b/clang/test/SemaCXX/cxx2a-nttp-printing.cpp
@@ -7,8 +7,8 @@ template <int N> struct Str {
 
 template <Str V> class ASCII {};
 
-void Foo(ASCII<"this nontype template argument is too long to print">); // expected-note {{no known conversion from 'ASCII<Str<43>{"this nontype template argument is too long"}>' to 'ASCII<Str<52>{"this nontype template argument is too long to print"}>'}}
-void Bar(ASCII<"this nttp argument is too short">);                     // expected-note {{no known conversion from 'ASCII<Str<14>{{119, 97, 105, 116, 32, 97, 32, 115, 27, 99, 111, 110, 100, 0}}>' to 'ASCII<Str<32>{"this nttp argument is too short"}>'}}
+void Foo(ASCII<"this nontype template argument is too long to print">); // expected-note {{no known conversion from 'ASCII<Str<43>{"this nontype template argument is [...]"}>' to 'ASCII<Str<52>{"this nontype template argument is [...]"}>'}}
+void Bar(ASCII<"this nttp argument is too short">);                     // expected-note {{no known conversion from 'ASCII<Str<14>{{119, 97, 105, 116, 32, 97, 32, 115, 27, 99, ...}}>' to 'ASCII<Str<32>{"this nttp argument is too short"}>'}}
 void Meow(ASCII<"what|">);                                              // expected-note {{no known conversion from 'ASCII<Str<8>{"what??!"}>' to 'ASCII<Str<6>{"what|"}>' for 1st argument}}
 
 void test_ascii() {


### PR DESCRIPTION
TemplateDiff made a new PrintingPolicy instead of using ASTContext's. Sema::getPrintingPolicy() tweaks ASTContext's, sema template diffing didn't pick up those changes.

Sema::getPrintingPolicy() does two things:

1. Something for bool vs _Bool for C (where template diffing doesn't apply)

2. Set EntireContentsOfLargeArray to false

Before this patch, the latter had no effect in diff mode, meaning we the same type printed differently in a diagnostic depending on if used template diffing. Now they're consistent.

(This made no difference before https://reviews.llvm.org/D115031, which probably just forgot to update this call site.)