### PR TITLE
[libc++] Disable the wmemchr optimization in std::find on Apple platforms

### DIFF
--- a/libcxx/include/__algorithm/find.h
+++ b/libcxx/include/__algorithm/find.h
@@ -126,7 +126,9 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp* __find(_Tp* __first, _T
       return __ret;
     return __last;
   }
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+  // wmemchr is very slow on apple platforms - we can do significantly better on our own.
+  // TODO: Remove this special-case once Apple's wmemchr is fixed.
+#  if _LIBCPP_HAS_WIDE_CHARACTERS && !defined(__APPLE__)
   else if constexpr (sizeof(_Tp) == sizeof(wchar_t) && _LIBCPP_ALIGNOF(_Tp) >= _LIBCPP_ALIGNOF(wchar_t)) {
     if (auto __ret = std::__constexpr_wmemchr(__first, __value, __last - __first))
       return __ret;

--- a/libcxx/include/module.modulemap.in
+++ b/libcxx/include/module.modulemap.in
@@ -413,7 +413,10 @@ module std {
     module find_if_not                            { header "__algorithm/find_if_not.h" }
     module find_if                                { header "__algorithm/find_if.h" }
     module find_segment_if                        { header "__algorithm/find_segment_if.h" }
-    module find                                   { header "__algorithm/find.h" }
+    module find                                   {
+      header "__algorithm/find.h"
+      export std.algorithm.simd_utils // TODO: Workaround for https://llvm.org/PR120108
+    }
     module for_each_n                             { header "__algorithm/for_each_n.h" }
     module for_each_n_segment                     { header "__algorithm/for_each_n_segment.h" }
     module for_each_segment                       { header "__algorithm/for_each_segment.h" }
@@ -1701,7 +1704,7 @@ module std {
     module noexcept_move_assign_container     { header "__memory/noexcept_move_assign_container.h" }
     module out_ptr                            { header "__memory/out_ptr.h" }
     module pointer_traits                     { header "__memory/pointer_traits.h" }
-    module pstl                               { header "__memory/pstl.h" }    
+    module pstl                               { header "__memory/pstl.h" }
     module ranges_construct_at                { header "__memory/ranges_construct_at.h" }
     module ranges_destroy                     { header "__memory/ranges_destroy.h" }
     module ranges_uninitialized_algorithms {


### PR DESCRIPTION
`wmemchr` on Apple platforms is incredibly slow. We can do significantly better by just implementing it on our own.

Fixes #205840