### PR TITLE
[lldb][test] Fix 64-bit register assumption in wrapped frame test

### DIFF
--- a/lldb/test/API/functionalities/scripted_frame_provider/wrapped_frame_register_context/frame_provider.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/wrapped_frame_register_context/frame_provider.py
@@ -45,7 +45,10 @@ class WrappedFrame(ScriptedFrame):
         for reg_set in self._frame.registers:
             if "general purpose" in reg_set.name.lower():
                 for reg in reg_set:
-                    regs[reg.name] = int(reg.value, 16) if reg.value else 0
+                    regs[reg.name] = (
+                        int(reg.value, 16) if reg.value else 0,
+                        reg.GetByteSize(),
+                    )
                 break
         if not regs:
             return None
@@ -58,9 +61,22 @@ class WrappedFrame(ScriptedFrame):
             # uses. The register info carries that alias in "alt-name".
             if entry["name"] in regs:
                 return regs[entry["name"]]
-            return regs.get(entry.get("alt-name", ""), 0)
 
-        return struct.pack(f"{len(info)}Q", *(read(r) for r in info))
+            try:
+                return regs[entry["alt-name"]]
+            except KeyError:
+                return 0, entry["bitsize"] // 8
+
+        struct_format = ""
+        struct_data = []
+        sizes = {1: "B", 2: "H", 4: "I", 8: "Q"}
+
+        for reg in info:
+            value, size = read(reg)
+            struct_format += sizes[size]
+            struct_data.append(value)
+
+        return struct.pack(struct_format, *struct_data)
 
 
 class WrapVariablesProvider(ScriptedFrameProvider):


### PR DESCRIPTION
Added in #216840 / b0e9c530b5f0206de4a4f59f6728dbd5f10a5ca2.

This is failing on our downstream Arm 32-bit Linux bot:
```
* thread #1, name = 'a.out', stop reason = breakpoint 1.1
  * frame #0: 0x013d0630 a.out`compute(a=<unavailable>, b=<unavailable>) at main.c:3:10 [synthetic]
    frame #1: 0x013d065c a.out`main at main.c:6:25
    frame #2: 0xea2b739a libc.so.6`
    frame #3: 0xea2b743e libc.so.6`__libc_start_main + 94
    frame #4: 0x013d0538 a.out`_start + 40

Expecting sub string: "compute(a=3, b=4)" (was not found)
```
I have not had time to reproduce it locally, but I did notice that the test packs a struct of registers using `Q` (8 bytes) regardless of register size.

https://docs.python.org/3/library/struct.html#format-characters

Which probably works because most targets have 64-bit GPRs and any non-64-bit registers don't take part in debug info lookups.

By using the actual register sizes we can fix the test on 32-bit. I've tested this on x86_64, AArch64 and Arm-32-bit Linux.