### PR TITLE
[AMDGPU] Fix misleading GFX1300 prefix

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/v_ashr_pk.ll
+++ b/llvm/test/CodeGen/AMDGPU/v_ashr_pk.ll
@@ -2,8 +2,8 @@
 ; RUN: llc -mtriple=amdgpu9.50 < %s | FileCheck -check-prefixes=GFX950 %s
 ; RUN: llc -mtriple=amdgpu12.50 -mattr=+real-true16 < %s | FileCheck -check-prefixes=GFX1250-TRUE16 %s
 ; RUN: llc -mtriple=amdgpu12.50 -mattr=-real-true16 < %s | FileCheck -check-prefixes=GFX1250-FAKE16 %s
-; RUN: llc -mtriple=amdgpu13.10 -mattr=+real-true16 < %s | FileCheck -check-prefixes=GFX1300-TRUE16 %s
-; RUN: llc -mtriple=amdgpu13.10 -mattr=-real-true16 < %s | FileCheck -check-prefixes=GFX1300-FAKE16 %s
+; RUN: llc -mtriple=amdgpu13.10 -mattr=+real-true16 < %s | FileCheck -check-prefixes=GFX13-TRUE16 %s
+; RUN: llc -mtriple=amdgpu13.10 -mattr=-real-true16 < %s | FileCheck -check-prefixes=GFX13-FAKE16 %s
 define amdgpu_kernel void @v_ashr_pk_i8_i32(ptr addrspace(1) %out, i32 %src0, i32 %src1, i32 %src2) #0 {
 ; GFX950-LABEL: v_ashr_pk_i8_i32:
 ; GFX950:       ; %bb.0:
@@ -54,33 +54,33 @@ define amdgpu_kernel void @v_ashr_pk_i8_i32(ptr addrspace(1) %out, i32 %src0, i3
 ; GFX1250-FAKE16-NEXT:    global_store_b16 v1, v0, s[6:7]
 ; GFX1250-FAKE16-NEXT:    s_endpgm
 ;
-; GFX1300-TRUE16-LABEL: v_ashr_pk_i8_i32:
-; GFX1300-TRUE16:       ; %bb.0:
-; GFX1300-TRUE16-NEXT:    s_clause 0x1
-; GFX1300-TRUE16-NEXT:    s_load_b96 s[0:2], s[4:5], 0x2c nv
-; GFX1300-TRUE16-NEXT:    s_load_b64 s[4:5], s[4:5], 0x24 nv
-; GFX1300-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
-; GFX1300-TRUE16-NEXT:    s_wait_kmcnt 0x0
-; GFX1300-TRUE16-NEXT:    s_and_b32 s2, s2, 31
-; GFX1300-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1300-TRUE16-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1300-TRUE16-NEXT:    v_ashr_pk_i8_i32 v0.l, s0, s1, v0
-; GFX1300-TRUE16-NEXT:    global_store_b16 v1, v0, s[4:5]
-; GFX1300-TRUE16-NEXT:    s_endpgm
+; GFX13-TRUE16-LABEL: v_ashr_pk_i8_i32:
+; GFX13-TRUE16:       ; %bb.0:
+; GFX13-TRUE16-NEXT:    s_clause 0x1
+; GFX13-TRUE16-NEXT:    s_load_b96 s[0:2], s[4:5], 0x2c nv
+; GFX13-TRUE16-NEXT:    s_load_b64 s[4:5], s[4:5], 0x24 nv
+; GFX13-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX13-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX13-TRUE16-NEXT:    s_and_b32 s2, s2, 31
+; GFX13-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX13-TRUE16-NEXT:    v_mov_b32_e32 v0, s2
+; GFX13-TRUE16-NEXT:    v_ashr_pk_i8_i32 v0.l, s0, s1, v0
+; GFX13-TRUE16-NEXT:    global_store_b16 v1, v0, s[4:5]
+; GFX13-TRUE16-NEXT:    s_endpgm
 ;
-; GFX1300-FAKE16-LABEL: v_ashr_pk_i8_i32:
-; GFX1300-FAKE16:       ; %bb.0:
-; GFX1300-FAKE16-NEXT:    s_clause 0x1
-; GFX1300-FAKE16-NEXT:    s_load_b96 s[0:2], s[4:5], 0x2c nv
-; GFX1300-FAKE16-NEXT:    s_load_b64 s[4:5], s[4:5], 0x24 nv
-; GFX1300-FAKE16-NEXT:    v_mov_b32_e32 v1, 0
-; GFX1300-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX1300-FAKE16-NEXT:    s_and_b32 s2, s2, 31
-; GFX1300-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1300-FAKE16-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1300-FAKE16-NEXT:    v_ashr_pk_i8_i32 v0, s0, s1, v0
-; GFX1300-FAKE16-NEXT:    global_store_b16 v1, v0, s[4:5]
-; GFX1300-FAKE16-NEXT:    s_endpgm
+; GFX13-FAKE16-LABEL: v_ashr_pk_i8_i32:
+; GFX13-FAKE16:       ; %bb.0:
+; GFX13-FAKE16-NEXT:    s_clause 0x1
+; GFX13-FAKE16-NEXT:    s_load_b96 s[0:2], s[4:5], 0x2c nv
+; GFX13-FAKE16-NEXT:    s_load_b64 s[4:5], s[4:5], 0x24 nv
+; GFX13-FAKE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX13-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX13-FAKE16-NEXT:    s_and_b32 s2, s2, 31
+; GFX13-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX13-FAKE16-NEXT:    v_mov_b32_e32 v0, s2
+; GFX13-FAKE16-NEXT:    v_ashr_pk_i8_i32 v0, s0, s1, v0
+; GFX13-FAKE16-NEXT:    global_store_b16 v1, v0, s[4:5]
+; GFX13-FAKE16-NEXT:    s_endpgm
   %insert.0 = insertelement <2 x i32> poison, i32 %src0, i64 0
   %build_vector = insertelement <2 x i32> %insert.0, i32 %src1, i64 1
   %src2.clamp = and i32 %src2, 31
@@ -145,33 +145,33 @@ define amdgpu_kernel void @v_ashr_pk_u8_i32(ptr addrspace(1) %out, i32 %src0, i3
 ; GFX1250-FAKE16-NEXT:    global_store_b16 v1, v0, s[6:7]
 ; GFX1250-FAKE16-NEXT:    s_endpgm
 ;
-; GFX1300-TRUE16-LABEL: v_ashr_pk_u8_i32:
-; GFX1300-TRUE16:       ; %bb.0:
-; GFX1300-TRUE16-NEXT:    s_clause 0x1
-; GFX1300-TRUE16-NEXT:    s_load_b96 s[0:2], s[4:5], 0x2c nv
-; GFX1300-TRUE16-NEXT:    s_load_b64 s[4:5], s[4:5], 0x24 nv
-; GFX1300-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
-; GFX1300-TRUE16-NEXT:    s_wait_kmcnt 0x0
-; GFX1300-TRUE16-NEXT:    s_and_b32 s2, s2, 31
-; GFX1300-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1300-TRUE16-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1300-TRUE16-NEXT:    v_ashr_pk_u8_i32 v0.l, s0, s1, v0
-; GFX1300-TRUE16-NEXT:    global_store_b16 v1, v0, s[4:5]
-; GFX1300-TRUE16-NEXT:    s_endpgm
+; GFX13-TRUE16-LABEL: v_ashr_pk_u8_i32:
+; GFX13-TRUE16:       ; %bb.0:
+; GFX13-TRUE16-NEXT:    s_clause 0x1
+; GFX13-TRUE16-NEXT:    s_load_b96 s[0:2], s[4:5], 0x2c nv
+; GFX13-TRUE16-NEXT:    s_load_b64 s[4:5], s[4:5], 0x24 nv
+; GFX13-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX13-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX13-TRUE16-NEXT:    s_and_b32 s2, s2, 31
+; GFX13-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX13-TRUE16-NEXT:    v_mov_b32_e32 v0, s2
+; GFX13-TRUE16-NEXT:    v_ashr_pk_u8_i32 v0.l, s0, s1, v0
+; GFX13-TRUE16-NEXT:    global_store_b16 v1, v0, s[4:5]
+; GFX13-TRUE16-NEXT:    s_endpgm
 ;
-; GFX1300-FAKE16-LABEL: v_ashr_pk_u8_i32:
-; GFX1300-FAKE16:       ; %bb.0:
-; GFX1300-FAKE16-NEXT:    s_clause 0x1
-; GFX1300-FAKE16-NEXT:    s_load_b96 s[0:2], s[4:5], 0x2c nv
-; GFX1300-FAKE16-NEXT:    s_load_b64 s[4:5], s[4:5], 0x24 nv
-; GFX1300-FAKE16-NEXT:    v_mov_b32_e32 v1, 0
-; GFX1300-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX1300-FAKE16-NEXT:    s_and_b32 s2, s2, 31
-; GFX1300-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1300-FAKE16-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1300-FAKE16-NEXT:    v_ashr_pk_u8_i32 v0, s0, s1, v0
-; GFX1300-FAKE16-NEXT:    global_store_b16 v1, v0, s[4:5]
-; GFX1300-FAKE16-NEXT:    s_endpgm
+; GFX13-FAKE16-LABEL: v_ashr_pk_u8_i32:
+; GFX13-FAKE16:       ; %bb.0:
+; GFX13-FAKE16-NEXT:    s_clause 0x1
+; GFX13-FAKE16-NEXT:    s_load_b96 s[0:2], s[4:5], 0x2c nv
+; GFX13-FAKE16-NEXT:    s_load_b64 s[4:5], s[4:5], 0x24 nv
+; GFX13-FAKE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX13-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX13-FAKE16-NEXT:    s_and_b32 s2, s2, 31
+; GFX13-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX13-FAKE16-NEXT:    v_mov_b32_e32 v0, s2
+; GFX13-FAKE16-NEXT:    v_ashr_pk_u8_i32 v0, s0, s1, v0
+; GFX13-FAKE16-NEXT:    global_store_b16 v1, v0, s[4:5]
+; GFX13-FAKE16-NEXT:    s_endpgm
   %insert.0 = insertelement <2 x i32> poison, i32 %src0, i64 0
   %build_vector = insertelement <2 x i32> %insert.0, i32 %src1, i64 1
   %src2.clamp = and i32 %src2, 31


### PR DESCRIPTION
gfx1300 is not a valid AMDGPU subtarget.
