### PR TITLE
AMDGPU: Fix null dereference folding a redundant AND with an undef source

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
@@ -1905,6 +1905,8 @@ bool SIFoldOperandsImpl::tryFoldRedundantAND(MachineInstr &ChildMI) const {
     return false;
 
   MachineInstr *ParentMI = MRI->getVRegDef(ChildResult->Reg);
+  if (!ParentMI)
+    return false;
 
   int64_t ParentMask = 0;
   std::optional<ANDMaskResult> ParentResult = getANDMaskRegOperand(*ParentMI);

--- a/llvm/test/CodeGen/AMDGPU/redundant-and.mir
+++ b/llvm/test/CodeGen/AMDGPU/redundant-and.mir
@@ -2567,3 +2567,45 @@ body:             |
     %2:sreg_32 = S_AND_B32 %1:sreg_32, 127, implicit-def dead $scc
     S_ENDPGM 0, implicit %2:sreg_32
 ...
+
+---
+name:            no_fold_redundant_and_undef_src
+tracksRegLiveness: true
+
+body:             |
+  bb.0:
+    ; GFX8-LABEL: name: no_fold_redundant_and_undef_src
+    ; GFX8: [[S_AND_B32_:%[0-9]+]]:sreg_32 = S_AND_B32 undef %1:sreg_32, 127, implicit-def dead $scc
+    ; GFX8-NEXT: S_ENDPGM 0, implicit [[S_AND_B32_]]
+    ;
+    ; GFX9-LABEL: name: no_fold_redundant_and_undef_src
+    ; GFX9: [[S_AND_B32_:%[0-9]+]]:sreg_32 = S_AND_B32 undef %1:sreg_32, 127, implicit-def dead $scc
+    ; GFX9-NEXT: S_ENDPGM 0, implicit [[S_AND_B32_]]
+    ;
+    ; GFX10-LABEL: name: no_fold_redundant_and_undef_src
+    ; GFX10: [[S_AND_B32_:%[0-9]+]]:sreg_32 = S_AND_B32 undef %1:sreg_32, 127, implicit-def dead $scc
+    ; GFX10-NEXT: S_ENDPGM 0, implicit [[S_AND_B32_]]
+    %0:sreg_32 = S_AND_B32 undef %1:sreg_32, 127, implicit-def dead $scc
+    S_ENDPGM 0, implicit %0:sreg_32
+...
+
+---
+name:            no_fold_redundant_and_undef_src_commuted
+tracksRegLiveness: true
+
+body:             |
+  bb.0:
+    ; GFX8-LABEL: name: no_fold_redundant_and_undef_src_commuted
+    ; GFX8: [[S_AND_B32_:%[0-9]+]]:sreg_32 = S_AND_B32 127, undef %1:sreg_32, implicit-def dead $scc
+    ; GFX8-NEXT: S_ENDPGM 0, implicit [[S_AND_B32_]]
+    ;
+    ; GFX9-LABEL: name: no_fold_redundant_and_undef_src_commuted
+    ; GFX9: [[S_AND_B32_:%[0-9]+]]:sreg_32 = S_AND_B32 127, undef %1:sreg_32, implicit-def dead $scc
+    ; GFX9-NEXT: S_ENDPGM 0, implicit [[S_AND_B32_]]
+    ;
+    ; GFX10-LABEL: name: no_fold_redundant_and_undef_src_commuted
+    ; GFX10: [[S_AND_B32_:%[0-9]+]]:sreg_32 = S_AND_B32 127, undef %1:sreg_32, implicit-def dead $scc
+    ; GFX10-NEXT: S_ENDPGM 0, implicit [[S_AND_B32_]]
+    %0:sreg_32 = S_AND_B32 127, undef %1:sreg_32, implicit-def dead $scc
+    S_ENDPGM 0, implicit %0:sreg_32
+...


### PR DESCRIPTION
Co-Authored-By: Claude claude-opus-4.8 <noreply@anthropic.com>