### PR TITLE
[lldb] Consume the located result by rvalue reference (NFC)

### DIFF
--- a/lldb/source/Core/DynamicLoader.cpp
+++ b/lldb/source/Core/DynamicLoader.cpp
@@ -278,7 +278,7 @@ PrepareSearch(Target &target, DynamicLoader::BinarySpec &bin_spec) {
 
 /// The module is not registered with the Target until LoadBinaryInTarget.
 static void FinishSearch(DynamicLoader::BinarySpec &bin_spec,
-                         llvm::Expected<SymbolLocator::Result> located) {
+                         llvm::Expected<SymbolLocator::Result> &&located) {
   if (!located) {
     // Loading a binary that was never found already reports that, so a bare
     // not-found error would only say it a second time. Any other error says


### PR DESCRIPTION
FinishSearch consumes the Expected it is handed, either taking the error out of it or moving what the search found into the binary spec, and its caller already hands over ownership with an explicit move. Taking it by value move constructs 1.5 kB for nothing, where the signature can say the same thing and copy nothing.

Reported by Coverity (CID 1685297).

Assisted-by: Claude