### PR TITLE
[mlir][acc] Update par_dims format for reduction combine

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
@@ -118,7 +118,8 @@ def OpenACC_ReductionCombineOp: OpenACC_Op<"reduction_combine",
     decisions (such as generate an atomic update). E.g.
 
     ```
-      acc.reduction_combine %src into %dest <addi> : memref<i32>
+      acc.reduction_combine %src into %dest <addi>
+          par_dims(#acc<par_dims[thread_x]>) : memref<i32>
     ```
 
     Might lower to something similar to
@@ -140,11 +141,28 @@ def OpenACC_ReductionCombineOp: OpenACC_Op<"reduction_combine",
 
   let arguments = (ins OpenACC_AnyPointerOrMappableType:$destMemref,
                        OpenACC_AnyPointerOrMappableType:$srcMemref,
-                       OpenACC_ReductionOperatorAttr:$reductionOperator);
+                       OpenACC_ReductionOperatorAttr:$reductionOperator,
+                       OptionalAttr<OpenACC_GPUParallelDimsAttr>:$par_dims);
   
   let assemblyFormat = [{
-    $srcMemref `into` $destMemref $reductionOperator `:` type($destMemref) attr-dict
+    $srcMemref `into` $destMemref $reductionOperator
+    (`par_dims` `(` qualified($par_dims)^ `)`)?
+    `:` type($destMemref) attr-dict
   }];
+  let builders = [
+    OpBuilder<(ins "::mlir::Value":$destMemref,
+                   "::mlir::Value":$srcMemref,
+                   "::mlir::acc::ReductionOperatorAttr":$reductionOperator), [{
+      build($_builder, $_state, destMemref, srcMemref, reductionOperator,
+            nullptr);
+    }]>,
+    OpBuilder<(ins "::mlir::Value":$destMemref,
+                   "::mlir::Value":$srcMemref,
+                   "::mlir::acc::ReductionOperator":$reductionOperator), [{
+      build($_builder, $_state, destMemref, srcMemref, reductionOperator,
+            nullptr);
+    }]>,
+  ];
 }
 
 //===----------------------------------------------------------------------===//
@@ -171,8 +189,8 @@ def OpenACC_ReductionAccumulateOp
     } {acc.par_dims = #acc<par_dims[thread_x]>}
     acc.reduction_accumulate %partial to %private <add>
         par_dims(#acc<par_dims[thread_x]>) : i32 -> memref<i32>
-    acc.reduction_combine %private into %shared <add> : memref<i32>
-        {acc.par_dims = #acc<par_dims[thread_x]>}
+    acc.reduction_combine %private into %shared <add>
+        par_dims(#acc<par_dims[thread_x]>) : memref<i32>
     ```
   }];
   let arguments = (ins AnyTypeOf<[AnyInteger, AnyFloat, AnyComplex]>:$value,

--- a/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsCG.cpp
+++ b/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsCG.cpp
@@ -164,7 +164,8 @@ void removeParDim(SmallVector<GPUParallelDimAttr> &parDims,
 }
 
 #define ACC_OP_WITH_PAR_DIMS_LIST                                              \
-  PrivatizeOp, ReductionAccumulateOp, ReductionAccumulateArrayOp
+  PrivatizeOp, ReductionAccumulateOp, ReductionAccumulateArrayOp,              \
+      ReductionCombineOp
 
 GPUParallelDimsAttr getParDimsAttr(Operation *op) {
   return llvm::TypeSwitch<Operation *, GPUParallelDimsAttr>(op)

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-block-combine-no-reload.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-block-combine-no-reload.mlir
@@ -53,7 +53,7 @@ module attributes {gpu.container_module} {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       acc.predicate_region {
-        acc.reduction_combine %a_slot into %a_res <add> : memref<i32> {acc.par_dims = #acc<par_dims[block_x, thread_x]>}
+        acc.reduction_combine %a_slot into %a_res <add> par_dims(#acc<par_dims[block_x, thread_x]>) : memref<i32>
       }
       acc.yield
     } {kernel_func_name = @test_block_combine_no_reload_kernel, kernel_module_name = @cuda_device_mod, origin = "acc.parallel"}

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine-mixed-scope.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine-mixed-scope.mlir
@@ -28,11 +28,9 @@ func.func @mixed_scope_worker_reduction_combine(
           scf.reduce
         } {acc.par_dims = #acc<par_dims[thread_y]>}
         acc.predicate_region {
-          acc.reduction_combine %local into %result_arg <add> : memref<i32>
-              {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
+          acc.reduction_combine %local into %result_arg <add> par_dims(#acc<par_dims[block_y, thread_y]>) : memref<i32>
           // expected-error@+1 {{operations in the same predicate region require incompatible ThreadY predication}}
-          acc.reduction_combine %other_arg into %result_arg <add> : memref<i32>
-              {acc.par_dims = #acc<par_dims[block_y, thread_x]>}
+          acc.reduction_combine %other_arg into %result_arg <add> par_dims(#acc<par_dims[block_y, thread_x]>) : memref<i32>
         }
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_y]>}
@@ -71,8 +69,7 @@ func.func @worker_combine_with_single_store(%result: memref<i32>) {
         acc.predicate_region {
           // expected-error@+1 {{operations in the same predicate region require incompatible ThreadY predication}}
           memref.store %c7_i32, %selected[] : memref<i32>
-          acc.reduction_combine %local into %result_arg <add> : memref<i32>
-              {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
+          acc.reduction_combine %local into %result_arg <add> par_dims(#acc<par_dims[block_y, thread_y]>) : memref<i32>
         }
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_y]>}
@@ -109,8 +106,7 @@ func.func @worker_combine_with_atomic_update(%result: memref<i32>) {
             %next = arith.addi %current, %c1_i32 : i32
             acc.yield %next : i32
           }
-          acc.reduction_combine %local into %result_arg <add> : memref<i32>
-              {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
+          acc.reduction_combine %local into %result_arg <add> par_dims(#acc<par_dims[block_y, thread_y]>) : memref<i32>
         }
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_y]>}

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine.mlir
@@ -36,8 +36,7 @@ func.func @worker_reduction_combine(%result: memref<i32>) {
         } {acc.par_dims = #acc<par_dims[thread_y]>}
         acc.predicate_region {
           %unused = memref.load %result_arg[] : memref<i32>
-          acc.reduction_combine %local into %result_arg <add> : memref<i32>
-              {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
+          acc.reduction_combine %local into %result_arg <add> par_dims(#acc<par_dims[block_y, thread_y]>) : memref<i32>
         }
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_y]>}
@@ -131,12 +130,10 @@ func.func @nested_worker_reduction_combines(
         } {acc.par_dims = #acc<par_dims[thread_y]>}
         acc.predicate_region {
           acc.predicate_region {
-            acc.reduction_combine %local into %result_arg <add> : memref<i32>
-                {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
+            acc.reduction_combine %local into %result_arg <add> par_dims(#acc<par_dims[block_y, thread_y]>) : memref<i32>
           }
           acc.predicate_region {
-            acc.reduction_combine %other_arg into %result_arg <add> : memref<i32>
-                {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
+            acc.reduction_combine %other_arg into %result_arg <add> par_dims(#acc<par_dims[block_y, thread_y]>) : memref<i32>
           }
         }
         scf.reduce
@@ -174,8 +171,7 @@ func.func @worker_combine_in_scf_if(%result: memref<i32>) {
             : (!acc.private_type<memref<i32>>) -> memref<i32>
         acc.predicate_region {
           scf.if %true {
-            acc.reduction_combine %local into %result_arg <add> : memref<i32>
-                {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
+            acc.reduction_combine %local into %result_arg <add> par_dims(#acc<par_dims[block_y, thread_y]>) : memref<i32>
           }
         }
         scf.reduce

--- a/mlir/test/Dialect/OpenACC/ops-cg.mlir
+++ b/mlir/test/Dialect/OpenACC/ops-cg.mlir
@@ -315,15 +315,14 @@ func.func @parallel_reduction_pattern(%data: memref<8xi32>, %shared: memref<i32>
   } {acc.par_dims = #acc<par_dims[thread_x]>}
   acc.reduction_accumulate %partial to %private <add>
       par_dims(#acc<par_dims[thread_x]>) : i32 -> memref<i32>
-  acc.reduction_combine %private into %shared <add> : memref<i32>
-      {acc.par_dims = #acc<par_dims[thread_x]>}
+  acc.reduction_combine %private into %shared <add> par_dims(#acc<par_dims[thread_x]>) : memref<i32>
   return
 }
 // CHECK: memref.alloca() {acc.par_dims = #acc<par_dims[thread_x]>}
 // CHECK: scf.parallel
 // CHECK: scf.reduce
 // CHECK: acc.reduction_accumulate %{{.*}} to %{{.*}} <add> par_dims(#acc<par_dims[thread_x]>) : i32 -> memref<i32>
-// CHECK: acc.reduction_combine %{{.*}} into %{{.*}} <add> : memref<i32> {acc.par_dims = #acc<par_dims[thread_x]>}
+// CHECK: acc.reduction_combine %{{.*}} into %{{.*}} <add> par_dims(#acc<par_dims[thread_x]>) : memref<i32>
 
 // -----
 


### PR DESCRIPTION
For consistency after https://github.com/llvm/llvm-project/pull/217643 this MR adds par_dims as inherent attribute to reduction_combine as was intended. And thus ensures consistency in IR printing of this attribute.