### PR TITLE
[VectorCombine] Propagate profile metadata when combining selects

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -33,6 +33,7 @@
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/PatternMatch.h"
+#include "llvm/IR/ProfDataUtils.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/KnownBits.h"
 #include "llvm/Support/MathExtras.h"
@@ -6092,8 +6093,9 @@ bool VectorCombine::foldDeinterleaveInterleavePair(Instruction &I) {
       return Builder.CreateCmp(Cmp->getPredicate(), NewOperands[0],
                                NewOperands[1]);
     if (isa<SelectInst>(NarrowInst))
-      return Builder.CreateSelect(NewOperands[0], NewOperands[1],
-                                  NewOperands[2]);
+      return Builder.CreateSelect(
+          NewOperands[0], NewOperands[1], NewOperands[2], /*Name=*/"",
+          ProfcheckDisableMetadataFixes ? nullptr : NarrowInst);
     if (isa<FreezeInst>(NarrowInst))
       return Builder.CreateFreeze(NewOperands[0]);
     if (auto *II = dyn_cast<IntrinsicInst>(NarrowInst))

--- a/llvm/test/Transforms/VectorCombine/deinterleave-interleave-pairs.ll
+++ b/llvm/test/Transforms/VectorCombine/deinterleave-interleave-pairs.ll
@@ -397,7 +397,7 @@ define <4 x i32> @deinterleave2_select_scalar_condition_interleave2(
 ; CHECK-LABEL: define <4 x i32> @deinterleave2_select_scalar_condition_interleave2(
 ; CHECK-SAME: <4 x i32> [[V:%.*]], i32 [[X:%.*]], i32 [[Y:%.*]]) {
 ; CHECK-NEXT:    [[COND:%.*]] = icmp eq i32 [[X]], [[Y]]
-; CHECK-NEXT:    [[R:%.*]] = select i1 [[COND]], <4 x i32> [[V]], <4 x i32> splat (i32 7)
+; CHECK-NEXT:    [[R:%.*]] = select i1 [[COND]], <4 x i32> [[V]], <4 x i32> splat (i32 7), !prof [[PROF1:![0-9]+]]
 ; CHECK-NEXT:    ret <4 x i32> [[R]]
 ;
   <4 x i32> %v, i32 %x, i32 %y) {
@@ -405,8 +405,8 @@ define <4 x i32> @deinterleave2_select_scalar_condition_interleave2(
   %d = call { <2 x i32>, <2 x i32> } @llvm.vector.deinterleave2.v4i32(<4 x i32> %v)
   %f0 = extractvalue { <2 x i32>, <2 x i32> } %d, 0
   %f1 = extractvalue { <2 x i32>, <2 x i32> } %d, 1
-  %u0 = select i1 %cond, <2 x i32> %f0, <2 x i32> splat (i32 7)
-  %u1 = select i1 %cond, <2 x i32> %f1, <2 x i32> splat (i32 7)
+  %u0 = select i1 %cond, <2 x i32> %f0, <2 x i32> splat (i32 7), !prof !1
+  %u1 = select i1 %cond, <2 x i32> %f1, <2 x i32> splat (i32 7), !prof !1
   %r = call <4 x i32> @llvm.vector.interleave2.v4i32(<2 x i32> %u0, <2 x i32> %u1)
   ret <4 x i32> %r
 }
@@ -712,6 +712,10 @@ else:
   ret <vscale x 16 x i16> zeroinitializer
 }
 
+!0 = !{!"function_entry_count", i64 1000}
+!1 = !{!"branch_weights", i32 2, i32 3}
+
 ;.
 ; CHECK: [[META0]] = !{float 2.500000e+00}
+; CHECK: [[PROF1]] = !{!"branch_weights", i32 2, i32 3}
 ;.

--- a/llvm/utils/profcheck-xfail.txt
+++ b/llvm/utils/profcheck-xfail.txt
@@ -125,5 +125,4 @@ Transforms/TailCallElim/inf-recursion.ll
 Transforms/Util/control-flow-hub-finalize-same-succ-crash.ll
 Transforms/Util/libcalls-opt-remarks.ll
 Transforms/Util/lowerswitch.ll
-Transforms/VectorCombine/deinterleave-interleave-pairs.ll
 tools/opt/mtune.ll


### PR DESCRIPTION
Note: In foldDeinterleaveInterleavePair when the condition is scalar all instructions within a step have the same condition, so propagating from NarrowInst works.