### PR TITLE
[ARM] Name caller and callee in unsupported hard-float calling convention error message

### DIFF
--- a/clang/test/CodeGen/arm-eabihf-no-fpregs.c
+++ b/clang/test/CodeGen/arm-eabihf-no-fpregs.c
@@ -1,0 +1,35 @@
+// REQUIRES: arm-registered-target
+// RUN: not %clang --target=armv7r-none-eabihf -g -c %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=DEBUG
+// RUN: not %clang --target=armv7r-none-eabihf -c %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=NODEBUG
+
+// DEBUG: arm-eabihf-no-fpregs.c:12:1: error: calling convention is hard-float, but floating-point registers are unavailable
+// DEBUG-NEXT{LITERAL}:    12 | void hard_fn(void) {}
+// DEBUG-NEXT{LITERAL}:      | ^
+// NODEBUG: arm-eabihf-no-fpregs.c:12:6: error: calling convention is hard-float, but floating-point registers are unavailable
+// NODEBUG-NEXT{LITERAL}:    12 | void hard_fn(void) {}
+// NODEBUG-NEXT{LITERAL}:      |      ^
+__attribute__((target("no-fpregs")))
+void hard_fn(void) {}
+
+// DEBUG: arm-eabihf-no-fpregs.c:23:3: error: 'soft_to_hard' calls 'hard_callee', which expects a hard-float calling convention, but floating-point registers are unavailable
+// DEBUG-NEXT{LITERAL}:    23 |   hard_callee();
+// DEBUG-NEXT{LITERAL}:      |   ^
+// NODEBUG: arm-eabihf-no-fpregs.c:21:6: error: 'soft_to_hard' calls 'hard_callee', which expects a hard-float calling convention, but floating-point registers are unavailable
+// NODEBUG-NEXT{LITERAL}:    21 | void soft_to_hard(void) {
+// NODEBUG-NEXT{LITERAL}:      |      ^
+__attribute__((target("no-fpregs"), pcs("aapcs")))
+void soft_to_hard(void) {
+  extern void hard_callee(void);
+  hard_callee();
+}
+
+// DEBUG: arm-eabihf-no-fpregs.c:34:3: error: 'soft_to_indirect' makes an indirect call that expects a hard-float calling convention, but floating-point registers are unavailable
+// DEBUG-NEXT{LITERAL}:    34 |   p();
+// DEBUG-NEXT{LITERAL}:      |   ^
+// NODEBUG: arm-eabihf-no-fpregs.c:33:6: error: 'soft_to_indirect' makes an indirect call that expects a hard-float calling convention, but floating-point registers are unavailable
+// NODEBUG-NEXT{LITERAL}:    33 | void soft_to_indirect(void (*p)(void)) {
+// NODEBUG-NEXT{LITERAL}:      |      ^
+__attribute__((target("no-fpregs"), pcs("aapcs")))
+void soft_to_indirect(void (*p)(void)) {
+  p();
+}

--- a/llvm/lib/Target/ARM/ARMTargetMachine.cpp
+++ b/llvm/lib/Target/ARM/ARMTargetMachine.cpp
@@ -221,8 +221,10 @@ MachineFunctionInfo *ARMBaseTargetMachine::createMachineFunctionInfo(
           const Function *Callee = CB->getCalledFunction();
           F.getContext().diagnose(DiagnosticInfoUnsupported(
               F,
-              (Callee ? Twine("call to '") + Callee->getName() + "'"
-                      : Twine("indirect call")) +
+              (Callee ? Twine("'") + F.getName() + "' calls '" +
+                            Callee->getName() + "', which"
+                      : Twine("'") + F.getName() +
+                            "' makes an indirect call that") +
                   " expects a hard-float calling convention" +
                   FPRegsUnavailableMsg,
               CB->getDebugLoc()));

--- a/llvm/test/CodeGen/ARM/eabihf-no-fpregs.ll
+++ b/llvm/test/CodeGen/ARM/eabihf-no-fpregs.ll
@@ -20,15 +20,15 @@ define void @variadic(...) {
   ret void
 }
 
-; CHECK: error: {{.*}} in function soft_to_hard {{.*}}: call to 'hard_callee' expects a hard-float calling convention, but floating-point registers are unavailable
-; CHECK: error: {{.*}} call to 'hard_callee2' expects a hard-float calling convention, but floating-point registers are unavailable
+; CHECK: error: {{.*}} in function soft_to_hard {{.*}}: 'soft_to_hard' calls 'hard_callee', which expects a hard-float calling convention, but floating-point registers are unavailable
+; CHECK: error: {{.*}} 'soft_to_hard' calls 'hard_callee2', which expects a hard-float calling convention, but floating-point registers are unavailable
 define arm_aapcscc void @soft_to_hard() {
   call arm_aapcs_vfpcc void @hard_callee()
   call arm_aapcs_vfpcc void @hard_callee2()
   ret void
 }
 
-; EABIHF: error: {{.*}} in function soft_to_default_hard {{.*}}: call to 'default_callee' expects a hard-float calling convention, but floating-point registers are unavailable
+; EABIHF: error: {{.*}} in function soft_to_default_hard {{.*}}: 'soft_to_default_hard' calls 'default_callee', which expects a hard-float calling convention, but floating-point registers are unavailable
 define arm_aapcscc void @soft_to_default_hard() {
   call void @default_callee()
   ret void


### PR DESCRIPTION
Add a clang test for the diagnostic output covering cases with and without debuginfo.