### PR TITLE
[libc++] Do not define std::nothrow with VCRuntime ABI

### DIFF
--- a/libcxx/src/new_helpers.cpp
+++ b/libcxx/src/new_helpers.cpp
@@ -11,9 +11,9 @@
 
 namespace std { // purposefully not versioned
 
-#ifndef __GLIBCXX__
+#if !defined(__GLIBCXX__) && !defined(_LIBCPP_ABI_VCRUNTIME)
 const nothrow_t nothrow{};
-#endif
+#endif // !defined(__GLIBCXX__) && !defined(_LIBCPP_ABI_VCRUNTIME)
 
 #ifndef LIBSTDCXX
 

--- a/libcxx/test/libcxx/vendor/clang-cl/static-lib-nothrow.sh.cpp
+++ b/libcxx/test/libcxx/vendor/clang-cl/static-lib-nothrow.sh.cpp
@@ -1,0 +1,16 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: target={{.+}}-windows-msvc
+
+// The VCRuntime library owns std::nothrow when libc++ uses its ABI. Defining
+// the object in libc++.lib as well makes whole-archive links fail with a
+// duplicate symbol.
+
+// RUN: llvm-nm --defined-only "%{lib-dir}/libc++.lib" | not grep -F '?nothrow@std@@3Unothrow_t@1@B'
+// RUN: llvm-nm --defined-only "%{lib-dir}/libc++.lib" | grep -F '?__throw_bad_alloc@std@@YAXXZ'


### PR DESCRIPTION
Avoid defining `std::nothrow` in libc++ when `_LIBCPP_ABI_VCRUNTIME` is enabled.

VCRuntime already owns and provides `std::nothrow`, just as it owns the global new/delete ABI. 

Assisted-by: codex (for the test)