### PR TITLE
[bazel] Select Windows GNU BLAKE3 assembly for clang-cl

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -332,6 +332,15 @@ config_setting(
     flag_values = {"@rules_cc//cc/compiler:compiler": "clang"},
 )
 
+config_setting(
+    name = "is_x86_64_windows_clang_cl",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:windows",
+    ],
+    flag_values = {"@rules_cc//cc/compiler:compiler": "clang-cl"},
+)
+
 BLAKE3_x86_64_ASM_SOURCE_PATTERNS = [
     "lib/Support/BLAKE3/blake3_avx2_x86-64_%s.S",
     "lib/Support/BLAKE3/blake3_avx512_x86-64_%s.S",
@@ -343,6 +352,10 @@ filegroup(
     name = "blake3_x86_64_asm",
     srcs = select({
         ":is_x86_64_windows_clang_mingw": [
+            pattern % "windows_gnu"
+            for pattern in BLAKE3_x86_64_ASM_SOURCE_PATTERNS
+        ],
+        ":is_x86_64_windows_clang_cl": [
             pattern % "windows_gnu"
             for pattern in BLAKE3_x86_64_ASM_SOURCE_PATTERNS
         ],


### PR DESCRIPTION
## Motivation

This PR is motivated by ongoing work of providing a fully hermetic clang-cl bazel toolchain built for windows with the MSVC runtime.

The LLVM Bazel overlay does not select a Windows-compatible BLAKE3 assembly source set for an x86_64 Windows target compiled with the rules_cc `clang-cl` compiler dialect.

The `windows_gnu.S` name can be misleading here. "GNU" describes the assembly syntax accepted by GNU-style assemblers and Clang's integrated assembler; it does **not** mean that the implementation uses the MinGW ABI or runtime. These files implement the Microsoft x64 calling convention and are intended to produce Windows COFF objects.

A hermetic clang-cl toolchain can therefore assemble the GNU-syntax Windows sources directly. Selecting the MASM-syntax `windows_msvc.asm` files instead would require a separately declared MASM tool such as `ml64.exe`, which this compiler route does not provide.

LLVM's CMake build makes the same distinction indirectly: its `MSVC` branch first enables the separate `ASM_MASM` language and then selects `windows_msvc.asm`; its other Windows assembler branch selects `windows_gnu.S`. The MASM choice is therefore contingent on an available MASM assembler, not inherent to every compiler targeting the MSVC ABI.

## Tests

- Compiled each selected `windows_gnu.S` file with LLVM clang-cl 22.1.8 targeting `x86_64-pc-windows-msvc`; all four outputs were AMD64 COFF objects and defined the expected SSE2, SSE4.1, AVX2, and AVX-512 BLAKE3 symbols.
- Inspected the selected assembly: it uses the Microsoft x64 argument registers and preserves the required Windows-nonvolatile general-purpose and XMM registers.
- Confirmed the corresponding `windows_msvc.asm` inputs are not accepted by this clang-cl-only route. They require a separately declared MASM assembler.
- A downstream full x86_64 Windows LLVM build linked successfully with this source selection. The identical baseline reached the final link with undefined BLAKE3 SIMD dispatch symbols.

Assisted by: codex