### PR TITLE
Reland "[flang][FIRToSCF] Recompute a typed induction variable in closed form (#217051)"

### DIFF
--- a/flang/lib/Optimizer/Transforms/FIRToSCF.cpp
+++ b/flang/lib/Optimizer/Transforms/FIRToSCF.cpp
@@ -54,7 +54,7 @@ struct DoLoopConversion : public mlir::OpRewritePattern<fir::DoLoopOp> {
     mlir::Value step = doLoopOp.getStep();
     bool hasTypedIV = !low.getType().isIndex();
     mlir::SmallVector<mlir::Value> iterArgs;
-    if (hasTypedIV || hasFinalValue)
+    if (hasFinalValue)
       iterArgs.push_back(low);
     iterArgs.append(doLoopOp.getIterOperands().begin(),
                     doLoopOp.getIterOperands().end());
@@ -104,18 +104,24 @@ struct DoLoopConversion : public mlir::OpRewritePattern<fir::DoLoopOp> {
 
     rewriter.setInsertionPointToStart(&scfLoopBody);
     mlir::Value iv;
-    if (hasTypedIV) {
+    if (hasTypedIV && hasFinalValue) {
       iv = scfLoopLikeOp.getRegionIterArgs().front();
     } else {
-      iv = mlir::arith::MulIOp::create(
-          rewriter, loc, scfLoopLikeOp.getSingleInductionVar().value(), step);
-      iv = mlir::arith::AddIOp::create(rewriter, loc, low, iv);
+      mlir::Value canonicalIV = scfLoopLikeOp.getSingleInductionVar().value();
+      if (hasTypedIV)
+        canonicalIV =
+            fir::ConvertOp::create(rewriter, loc, low.getType(), canonicalIV);
+      // Keep the no-wrap flags the stepped increment carried, so a narrow IV
+      // still folds into an affine recurrence.
+      iv = mlir::arith::MulIOp::create(rewriter, loc, canonicalIV, step,
+                                       iofAttr);
+      iv = mlir::arith::AddIOp::create(rewriter, loc, low, iv, iofAttr);
     }
     mlir::Value firIV = doLoopOp.getInductionVar();
     firIV.replaceAllUsesWith(iv);
 
     mlir::Value finalValue;
-    if (hasTypedIV) {
+    if (hasTypedIV && hasFinalValue) {
       finalValue =
           mlir::arith::AddIOp::create(rewriter, loc, iv, step, iofAttr);
     } else if (hasFinalValue) {
@@ -134,23 +140,21 @@ struct DoLoopConversion : public mlir::OpRewritePattern<fir::DoLoopOp> {
             mlir::arith::AddIOp::create(rewriter, loc, iv, step, iofAttr);
     }
 
-    if (hasTypedIV || hasFinalValue || !results.empty()) {
+    if (hasFinalValue || !results.empty()) {
       rewriter.setInsertionPointToEnd(&scfLoopBody);
       llvm::SmallVector<mlir::Value> yieldOperands;
-      if (hasTypedIV || hasFinalValue) {
+      if (hasFinalValue) {
         yieldOperands.push_back(finalValue);
-      }
-      if (hasFinalValue)
         llvm::append_range(yieldOperands, results.drop_front());
-      else
+      } else {
         llvm::append_range(yieldOperands, results);
+      }
       mlir::scf::YieldOp::create(rewriter, resultOp->getLoc(), yieldOperands);
     }
     rewriter.replaceAllUsesWith(
         doLoopOp.getRegionIterArgs(),
-        hasTypedIV || hasFinalValue
-            ? scfLoopLikeOp.getRegionIterArgs().drop_front()
-            : scfLoopLikeOp.getRegionIterArgs());
+        hasFinalValue ? scfLoopLikeOp.getRegionIterArgs().drop_front()
+                      : scfLoopLikeOp.getRegionIterArgs());
 
     // Copy loop annotations from the fir.do_loop to scf loop op.
     if (auto ann = doLoopOp.getLoopAnnotation())
@@ -161,10 +165,7 @@ struct DoLoopConversion : public mlir::OpRewritePattern<fir::DoLoopOp> {
     if (auto parDims = doLoopOp->getAttr(mlir::acc::GPUParallelDimsAttr::name))
       scfLoopOp->setAttr(mlir::acc::GPUParallelDimsAttr::name, parDims);
 
-    mlir::ValueRange scfResults = scfLoopOp->getResults();
-    if (hasTypedIV && !hasFinalValue)
-      scfResults = scfResults.drop_front();
-    rewriter.replaceOp(doLoopOp, scfResults);
+    rewriter.replaceOp(doLoopOp, scfLoopOp->getResults());
     return mlir::success();
   }
 

--- a/flang/test/Fir/FirToSCF/do-extra.fir
+++ b/flang/test/Fir/FirToSCF/do-extra.fir
@@ -72,7 +72,7 @@ func.func @implied_do_in_acc_serial(%arg0: !fir.ref<!fir.array<4xi32>> {fir.bind
 // CHECK:       [[ADD:%[0-9]+]] = arith.addi [[SUB]], %c1 : index
 // CHECK:       [[DIV:%[0-9]+]] = arith.divsi [[ADD]], %c1 : index
 // CHECK:       [[FOR:%[0-9]+]] = scf.for %{{.*}} = %{{.*}} to [[DIV]] step %{{.*}} iter_args(%{{.*}} = %c1) -> (index) {
-// CHECK:       [[IV:%[0-9]+]] = arith.addi %c1, {{.*}} : index
+// CHECK:       [[IV:%[0-9]+]] = arith.addi %c1, {{.*}} overflow<nsw> : index
 // CHECK:       fir.convert [[IV]] : (index) -> i32
 // CHECK:       scf.yield
 
@@ -135,8 +135,8 @@ func.func @mv_(%arg0: !fir.ref<!fir.array<3xi32>> {fir.bindc_name = "a", llvm.no
 // CHECK:           %[[C0:.*]] = arith.constant 0 : index
 // CHECK:           %[[C1:.*]] = arith.constant 1 : index
 // CHECK:           scf.for %{{.*}} = %[[C0]] to %[[VAL_2]] step %[[C1]] iter_args(%{{.*}} = %[[ARG0]]) -> (index) {
-// CHECK:             %[[MUL:.*]] = arith.muli %{{.*}}, %[[ARG2]] : index
-// CHECK:             %[[ADD0:.*]] = arith.addi %[[ARG0]], %[[MUL]] : index
+// CHECK:             %[[MUL:.*]] = arith.muli %{{.*}}, %[[ARG2]] overflow<nsw> : index
+// CHECK:             %[[ADD0:.*]] = arith.addi %[[ARG0]], %[[MUL]] overflow<nsw> : index
 // CHECK:             %[[ADD1:.*]] = arith.addi %[[ADD0]], %[[ARG2]] overflow<nsw> : index
 // CHECK:             scf.yield %[[ADD1]] : index
 // CHECK:           }

--- a/flang/test/Fir/FirToSCF/do-loop.fir
+++ b/flang/test/Fir/FirToSCF/do-loop.fir
@@ -13,8 +13,8 @@
 // CHECK:           %[[VAL_7:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_8:.*]] = arith.constant 1 : index
 // CHECK:           scf.for %[[VAL_9:.*]] = %[[VAL_7]] to %[[VAL_6]] step %[[VAL_8]] {
-// CHECK:             %[[VAL_10:.*]] = arith.muli %[[VAL_9]], %[[VAL_0]] : index
-// CHECK:             %[[VAL_11:.*]] = arith.addi %[[VAL_0]], %[[VAL_10]] : index
+// CHECK:             %[[VAL_10:.*]] = arith.muli %[[VAL_9]], %[[VAL_0]] overflow<nsw> : index
+// CHECK:             %[[VAL_11:.*]] = arith.addi %[[VAL_0]], %[[VAL_10]] overflow<nsw> : index
 // CHECK:             %[[VAL_12:.*]] = fir.array_coor %[[ARG0]](%[[VAL_2]]) %[[VAL_11]] : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>, index) -> !fir.ref<i32>
 // CHECK:             fir.store %[[VAL_3]] to %[[VAL_12]] : !fir.ref<i32>
 // CHECK:           }
@@ -34,6 +34,8 @@ func.func @simple_loop(%arg0: !fir.ref<!fir.array<100xi32>>) {
 
 // -----
 
+// A typed induction variable is recomputed in closed form from the canonical
+// induction variable, so it adds neither an iter_arg nor a loop result.
 // CHECK-LABEL: func.func @typed_loop(
 // CHECK-SAME: %[[LB:.*]]: i32, %[[UB:.*]]: i32, %[[STEP:.*]]: i32,
 // CHECK-SAME: %[[ADDR:.*]]: !fir.ref<i32>) {
@@ -45,14 +47,78 @@ func.func @simple_loop(%arg0: !fir.ref<!fir.array<100xi32>>) {
 // CHECK: %[[TRIP:.*]] = arith.divsi %[[DISTANCE]], %[[STEP_IDX]] : index
 // CHECK: %[[C0:.*]] = arith.constant 0 : index
 // CHECK: %[[C1:.*]] = arith.constant 1 : index
-// CHECK: scf.for %{{.*}} = %[[C0]] to %[[TRIP]] step %[[C1]] iter_args(%[[IV:.*]] = %[[LB]]) -> (i32) {
-// CHECK:   %[[NEXT:.*]] = arith.addi %[[IV]], %[[STEP]] overflow<nsw> : i32
+// CHECK: scf.for %[[I:.*]] = %[[C0]] to %[[TRIP]] step %[[C1]] {
+// CHECK:   %[[I_TYPED:.*]] = fir.convert %[[I]] : (index) -> i32
+// CHECK:   %[[SCALED:.*]] = arith.muli %[[I_TYPED]], %[[STEP]] overflow<nsw> : i32
+// CHECK:   %[[IV:.*]] = arith.addi %[[LB]], %[[SCALED]] overflow<nsw> : i32
 // CHECK:   fir.store %[[IV]] to %[[ADDR]] : !fir.ref<i32>
-// CHECK:   scf.yield %[[NEXT]] : i32
 // CHECK: }
+// CHECK-NOT: iter_args
 func.func @typed_loop(%lb: i32, %ub: i32, %step: i32,
                       %addr: !fir.ref<i32>) {
   fir.do_loop %iv = %lb to %ub step %step : i32 {
+    fir.store %iv to %addr : !fir.ref<i32>
+  }
+  return
+}
+
+// -----
+
+// Only the loop's own iter_args survive; the typed IV does not add one.
+// CHECK-LABEL: func.func @typed_loop_iter_args(
+// CHECK: %[[C0:.*]] = arith.constant 0 : i32
+// CHECK: %[[C1:.*]] = arith.constant 1 : i32
+// CHECK: %[[TRIP:.*]] = arith.divsi
+// CHECK: %[[C0_IDX:.*]] = arith.constant 0 : index
+// CHECK: %[[C1_IDX:.*]] = arith.constant 1 : index
+// CHECK: %[[RES:.*]] = scf.for %[[I:.*]] = %[[C0_IDX]] to %[[TRIP]] step %[[C1_IDX]] iter_args(%[[ACC:.*]] = %[[C0]]) -> (i32) {
+// CHECK:   %[[I_TYPED:.*]] = fir.convert %[[I]] : (index) -> i32
+// CHECK:   %[[SCALED:.*]] = arith.muli %[[I_TYPED]], %[[C1]] overflow<nsw> : i32
+// CHECK:   %[[IV:.*]] = arith.addi %[[C1]], %[[SCALED]] overflow<nsw> : i32
+// CHECK:   %[[SUM:.*]] = arith.addi %[[ACC]], %[[IV]] : i32
+// CHECK:   scf.yield %[[SUM]] : i32
+// CHECK: }
+// CHECK: return %[[RES]] : i32
+func.func @typed_loop_iter_args(%addr: !fir.ref<i32>) -> i32 {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c10_i32 = arith.constant 10 : i32
+  %r = fir.do_loop %iv = %c1_i32 to %c10_i32 step %c1_i32 iter_args(%acc = %c0_i32) -> (i32) : i32 {
+    %v = arith.addi %acc, %iv : i32
+    fir.result %v : i32
+  }
+  return %r : i32
+}
+
+// -----
+
+// A negative step is handled by the same closed form, so it does not need an
+// iter_arg either.
+// CHECK-LABEL: func.func @typed_loop_negative_step(
+// CHECK-SAME: %[[ADDR:.*]]: !fir.ref<i32>) {
+// CHECK: %[[C1:.*]] = arith.constant 1 : i32
+// CHECK: %[[C10:.*]] = arith.constant 10 : i32
+// CHECK: %[[CM1:.*]] = arith.constant -1 : i32
+// CHECK: %[[LB_IDX:.*]] = fir.convert %[[C10]] : (i32) -> index
+// CHECK: %[[UB_IDX:.*]] = fir.convert %[[C1]] : (i32) -> index
+// CHECK: %[[STEP_IDX:.*]] = fir.convert %[[CM1]] : (i32) -> index
+// CHECK: %[[DIFF:.*]] = arith.subi %[[UB_IDX]], %[[LB_IDX]] : index
+// CHECK: %[[DISTANCE:.*]] = arith.addi %[[DIFF]], %[[STEP_IDX]] : index
+// CHECK: %[[TRIP:.*]] = arith.divsi %[[DISTANCE]], %[[STEP_IDX]] : index
+// CHECK: %[[C0:.*]] = arith.constant 0 : index
+// CHECK: %[[C1_IDX:.*]] = arith.constant 1 : index
+// CHECK: scf.for %[[I:.*]] = %[[C0]] to %[[TRIP]] step %[[C1_IDX]] {
+// CHECK:   %[[I_TYPED:.*]] = fir.convert %[[I]] : (index) -> i32
+// CHECK:   %[[SCALED:.*]] = arith.muli %[[I_TYPED]], %[[CM1]] overflow<nsw> : i32
+// CHECK:   %[[IV:.*]] = arith.addi %[[C10]], %[[SCALED]] overflow<nsw> : i32
+// CHECK:   fir.store %[[IV]] to %[[ADDR]] : !fir.ref<i32>
+// CHECK: }
+// CHECK-NOT: iter_args
+func.func @typed_loop_negative_step(%addr: !fir.ref<i32>) {
+  %c1_i32 = arith.constant 1 : i32
+  %c10_i32 = arith.constant 10 : i32
+  %cm1_i32 = arith.constant -1 : i32
+  fir.do_loop %iv = %c10_i32 to %c1_i32 step %cm1_i32 : i32 {
     fir.store %iv to %addr : !fir.ref<i32>
   }
   return
@@ -73,8 +139,8 @@ func.func @typed_loop(%lb: i32, %ub: i32, %step: i32,
 // CHECK:           %[[VAL_8:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_9:.*]] = arith.constant 1 : index
 // CHECK:           scf.for %[[VAL_10:.*]] = %[[VAL_8]] to %[[VAL_7]] step %[[VAL_9]] {
-// CHECK:             %[[VAL_11:.*]] = arith.muli %[[VAL_10]], %[[VAL_2]] : index
-// CHECK:             %[[VAL_12:.*]] = arith.addi %[[VAL_0]], %[[VAL_11]] : index
+// CHECK:             %[[VAL_11:.*]] = arith.muli %[[VAL_10]], %[[VAL_2]] overflow<nsw> : index
+// CHECK:             %[[VAL_12:.*]] = arith.addi %[[VAL_0]], %[[VAL_11]] overflow<nsw> : index
 // CHECK:             %[[VAL_13:.*]] = fir.array_coor %[[ARG0]](%[[VAL_3]]) %[[VAL_12]] : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>, index) -> !fir.ref<i32>
 // CHECK:             fir.store %[[VAL_4]] to %[[VAL_13]] : !fir.ref<i32>
 // CHECK:           }
@@ -108,8 +174,8 @@ func.func @loop_with_negtive_step(%arg0: !fir.ref<!fir.array<100xi32>>) {
 // CHECK:           %[[VAL_7:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_8:.*]] = arith.constant 1 : index
 // CHECK:           %[[VAL_9:.*]] = scf.for %[[VAL_10:.*]] = %[[VAL_7]] to %[[VAL_6]] step %[[VAL_8]] iter_args(%[[VAL_11:.*]] = %[[VAL_1]]) -> (i32) {
-// CHECK:             %[[VAL_12:.*]] = arith.muli %[[VAL_10]], %[[VAL_0]] : index
-// CHECK:             %[[VAL_13:.*]] = arith.addi %[[VAL_0]], %[[VAL_12]] : index
+// CHECK:             %[[VAL_12:.*]] = arith.muli %[[VAL_10]], %[[VAL_0]] overflow<nsw> : index
+// CHECK:             %[[VAL_13:.*]] = arith.addi %[[VAL_0]], %[[VAL_12]] overflow<nsw> : index
 // CHECK:             %[[VAL_14:.*]] = fir.array_coor %[[ARG0]](%[[VAL_3]]) %[[VAL_13]] : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>, index) -> !fir.ref<i32>
 // CHECK:             %[[VAL_15:.*]] = fir.load %[[VAL_14]] : !fir.ref<i32>
 // CHECK:             %[[VAL_16:.*]] = arith.addi %[[VAL_11]], %[[VAL_15]] : i32
@@ -149,8 +215,8 @@ func.func @loop_with_results(%arg0: !fir.ref<!fir.array<100xi32>>, %arg1: !fir.r
 // CHECK:           %[[VAL_8:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_9:.*]] = arith.constant 1 : index
 // CHECK:           %[[VAL_10:.*]]:2 = scf.for %[[VAL_11:.*]] = %[[VAL_8]] to %[[VAL_7]] step %[[VAL_9]] iter_args(%[[VAL_12:.*]] = %[[VAL_0]], %[[VAL_13:.*]] = %[[VAL_1]]) -> (index, i32) {
-// CHECK:             %[[VAL_14:.*]] = arith.muli %[[VAL_11]], %[[VAL_0]] : index
-// CHECK:             %[[VAL_15:.*]] = arith.addi %[[VAL_0]], %[[VAL_14]] : index
+// CHECK:             %[[VAL_14:.*]] = arith.muli %[[VAL_11]], %[[VAL_0]] overflow<nsw> : index
+// CHECK:             %[[VAL_15:.*]] = arith.addi %[[VAL_0]], %[[VAL_14]] overflow<nsw> : index
 // CHECK:             %[[VAL_16:.*]] = fir.array_coor %[[ARG0]](%[[VAL_4]]) %[[VAL_15]] : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>, index) -> !fir.ref<i32>
 // CHECK:             %[[VAL_17:.*]] = fir.load %[[VAL_16]] : !fir.ref<i32>
 // CHECK:             %[[VAL_18:.*]] = arith.addi %[[VAL_15]], %[[VAL_0]] overflow<nsw> : index
@@ -244,8 +310,8 @@ func.func @loop_with_final_value_and_result() {
 // CHECK:           %[[CONSTANT_4:.*]] = arith.constant 1 : index
 // PARALLEL:        scf.parallel (%[[VAL_0:.*]]) = (%[[CONSTANT_3]]) to (%[[DIVSI_0]]) step (%[[CONSTANT_4]]) {
 // NO-PARALLEL:     scf.for %[[VAL_0:.*]] = %[[CONSTANT_3]] to %[[DIVSI_0]] step %[[CONSTANT_4]] {
-// CHECK:             %[[MULI_0:.*]] = arith.muli %[[VAL_0]], %[[CONSTANT_0]] : index
-// CHECK:             %[[ADDI_1:.*]] = arith.addi %[[CONSTANT_0]], %[[MULI_0]] : index
+// CHECK:             %[[MULI_0:.*]] = arith.muli %[[VAL_0]], %[[CONSTANT_0]] overflow<nsw> : index
+// CHECK:             %[[ADDI_1:.*]] = arith.addi %[[CONSTANT_0]], %[[MULI_0]] overflow<nsw> : index
 // CHECK:             %[[ARRAY_COOR_0:.*]] = fir.array_coor %[[ARG0]](%[[SHAPE_0]]) %[[ADDI_1]] : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>, index) -> !fir.ref<i32>
 // CHECK:             fir.store %[[CONSTANT_2]] to %[[ARRAY_COOR_0]] : !fir.ref<i32>
 // PARALLEL:          scf.reduce
@@ -282,8 +348,8 @@ func.func @loop_with_unordered_attr(%arg0: !fir.ref<!fir.array<100xi32>>) {
 // CHECK:           %[[VAL_8:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_9:.*]] = arith.constant 1 : index
 // CHECK:           scf.for %[[VAL_10:.*]] = %[[VAL_8]] to %[[VAL_7]] step %[[VAL_9]] {
-// CHECK:             %[[VAL_11:.*]] = arith.muli %[[VAL_10]], %[[VAL_0]] : index
-// CHECK:             %[[VAL_12:.*]] = arith.addi %[[VAL_0]], %[[VAL_11]] : index
+// CHECK:             %[[VAL_11:.*]] = arith.muli %[[VAL_10]], %[[VAL_0]] overflow<nsw> : index
+// CHECK:             %[[VAL_12:.*]] = arith.addi %[[VAL_0]], %[[VAL_11]] overflow<nsw> : index
 // CHECK:             %[[VAL_13:.*]] = fir.array_coor %[[ARG0]](%[[VAL_4]]) %[[VAL_12]] : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>, index) -> !fir.ref<i32>
 // CHECK:             %[[VAL_14:.*]] = fir.load %[[VAL_13]] : !fir.ref<i32>
 // CHECK:             %[[VAL_15:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
@@ -326,16 +392,16 @@ func.func @loop_with_attribute(%arg0: !fir.ref<!fir.array<100xi32>>, %arg1: !fir
 // CHECK:           %[[VAL_7:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_8:.*]] = arith.constant 1 : index
 // CHECK:           scf.for %[[VAL_9:.*]] = %[[VAL_7]] to %[[VAL_6]] step %[[VAL_8]] {
-// CHECK:             %[[VAL_10:.*]] = arith.muli %[[VAL_9]], %[[VAL_0]] : index
-// CHECK:             %[[VAL_11:.*]] = arith.addi %[[VAL_0]], %[[VAL_10]] : index
+// CHECK:             %[[VAL_10:.*]] = arith.muli %[[VAL_9]], %[[VAL_0]] overflow<nsw> : index
+// CHECK:             %[[VAL_11:.*]] = arith.addi %[[VAL_0]], %[[VAL_10]] overflow<nsw> : index
 // CHECK:             %[[VAL_12:.*]] = arith.subi %[[VAL_2]], %[[VAL_0]] : index
 // CHECK:             %[[VAL_13:.*]] = arith.addi %[[VAL_12]], %[[VAL_0]] : index
 // CHECK:             %[[VAL_14:.*]] = arith.divsi %[[VAL_13]], %[[VAL_0]] : index
 // CHECK:             %[[VAL_15:.*]] = arith.constant 0 : index
 // CHECK:             %[[VAL_16:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_17:.*]] = %[[VAL_15]] to %[[VAL_14]] step %[[VAL_16]] {
-// CHECK:               %[[VAL_18:.*]] = arith.muli %[[VAL_17]], %[[VAL_0]] : index
-// CHECK:               %[[VAL_19:.*]] = arith.addi %[[VAL_0]], %[[VAL_18]] : index
+// CHECK:               %[[VAL_18:.*]] = arith.muli %[[VAL_17]], %[[VAL_0]] overflow<nsw> : index
+// CHECK:               %[[VAL_19:.*]] = arith.addi %[[VAL_0]], %[[VAL_18]] overflow<nsw> : index
 // CHECK:               %[[VAL_20:.*]] = fir.array_coor %[[ARG0]](%[[VAL_3]]) %[[VAL_19]], %[[VAL_11]] : (!fir.ref<!fir.array<100x100xi32>>, !fir.shape<2>, index, index) -> !fir.ref<i32>
 // CHECK:               fir.store %[[VAL_1]] to %[[VAL_20]] : !fir.ref<i32>
 // CHECK:             }

--- a/flang/test/Fir/FirToSCF/normalize.fir
+++ b/flang/test/Fir/FirToSCF/normalize.fir
@@ -20,8 +20,8 @@
 // CHECK-NEXT:  [[ADD:%[0-9]+]] = arith.addi [[SUB]], [[STEP]] : index
 // CHECK-NEXT:  [[DIV:%[0-9]+]] = arith.divsi [[ADD]], [[STEP]] : index
 // CHECK:       scf.for %arg4 = %c0{{.*}} to [[DIV]] step %c1{{.*}}
-// CHECK-NEXT:    [[IVMUL:%[0-9]+]] = arith.muli %arg4, [[STEP]] : index
-// CHECK-NEXT:    [[IVADD:%[0-9]+]] = arith.addi [[LB]], [[IVMUL]] : index
+// CHECK-NEXT:    [[IVMUL:%[0-9]+]] = arith.muli %arg4, [[STEP]] overflow<nsw> : index
+// CHECK-NEXT:    [[IVADD:%[0-9]+]] = arith.addi [[LB]], [[IVMUL]] overflow<nsw> : index
 // CHECK-NEXT:    memref.store [[IVADD]], %arg3[]
 
 func.func @unknown_step_(%arg0: i64, %arg1: i64, %arg2: i64, %arg3: memref<index>) {
@@ -52,8 +52,8 @@ func.func @unknown_step_(%arg0: i64, %arg1: i64, %arg2: i64, %arg3: memref<index
 // CHECK-NEXT:  [[ADD:%[0-9]+]] = arith.addi [[SUB]], [[STEP]] : index
 // CHECK-NEXT:  [[DIV:%[0-9]+]] = arith.divsi [[ADD]], [[STEP]] : index
 // CHECK:       scf.for %arg1 = %c0{{.*}} to [[DIV]] step %c1{{.*}}
-// CHECK-NEXT:    [[IVMUL:%[0-9]+]] = arith.muli %arg1, [[STEP]] : index
-// CHECK-NEXT:    [[IVADD:%[0-9]+]] = arith.addi [[LB]], [[IVMUL]] : index
+// CHECK-NEXT:    [[IVMUL:%[0-9]+]] = arith.muli %arg1, [[STEP]] overflow<nsw> : index
+// CHECK-NEXT:    [[IVADD:%[0-9]+]] = arith.addi [[LB]], [[IVMUL]] overflow<nsw> : index
 // CHECK-NEXT:    memref.store [[IVADD]], %arg0[]
 
 func.func @negative_step_(%arg0: memref<index>) {


### PR DESCRIPTION
Reverts llvm/llvm-project#217654

The original PR revealed a bug in our internal project, which is already fixed. Reland it without any change.