### PR TITLE
[libc] Add struct sigevent definition and proxy header.

### DIFF
--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -431,7 +431,6 @@ add_proxy_header_library(
     struct_sigevent.h
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-types.struct_sigevent
-    libc.include.signal
 )
 
 add_proxy_header_library(

--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -426,6 +426,15 @@ add_proxy_header_library(
 )
 
 add_proxy_header_library(
+  struct_sigevent
+  HDRS
+    struct_sigevent.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.struct_sigevent
+    libc.include.signal
+)
+
+add_proxy_header_library(
   FILE
   HDRS
     FILE.h

--- a/libc/hdr/types/struct_sigevent.h
+++ b/libc/hdr/types/struct_sigevent.h
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Proxy for struct sigevent.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_TYPES_STRUCT_SIGEVENT_H
+#define LLVM_LIBC_HDR_TYPES_STRUCT_SIGEVENT_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/struct_sigevent.h"
+
+#else
+
+#include <signal.h>
+
+#endif // LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_STRUCT_SIGEVENT_H

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -420,6 +420,7 @@ add_header_macro(
     .llvm-libc-types.sigset_t
     .llvm-libc-types.stack_t
     .llvm-libc-types.struct_sigaction
+    .llvm-libc-types.struct_sigevent
     .llvm-libc-types.union_sigval
 )
 

--- a/libc/include/llvm-libc-macros/linux/signal-macros.h
+++ b/libc/include/llvm-libc-macros/linux/signal-macros.h
@@ -155,4 +155,10 @@
 #define SI_ASYNCNL (-60) // Async name lookup completion
 #define SI_KERNEL 128    // Sent by the kernel
 
+// `sigev_notify` values for `struct sigevent`.
+#define SIGEV_SIGNAL 0
+#define SIGEV_NONE 1
+#define SIGEV_THREAD 2
+#define SIGEV_THREAD_ID 4
+
 #endif // LLVM_LIBC_MACROS_LINUX_SIGNAL_MACROS_H

--- a/libc/include/llvm-libc-types/CMakeLists.txt
+++ b/libc/include/llvm-libc-types/CMakeLists.txt
@@ -205,6 +205,7 @@ add_header(__jmp_buf HDR __jmp_buf.h DEPENDS .sigset_t)
 add_header(jmp_buf HDR jmp_buf.h DEPENDS .__jmp_buf)
 add_header(sigjmp_buf HDR sigjmp_buf.h DEPENDS .__jmp_buf)
 add_header(struct_sigaction HDR struct_sigaction.h DEPENDS .sigset_t .siginfo_t)
+add_header(struct_sigevent HDR struct_sigevent.h DEPENDS .union_sigval .pthread_attr_t .pid_t)
 add_header(struct_timespec HDR struct_timespec.h DEPENDS .time_t)
 add_header(
   struct_stat

--- a/libc/include/llvm-libc-types/struct_sigevent.h
+++ b/libc/include/llvm-libc-types/struct_sigevent.h
@@ -25,7 +25,9 @@ struct sigevent {
   union sigval sigev_value;
   void (*sigev_notify_function)(union sigval);
   pthread_attr_t *sigev_notify_attributes;
+#ifdef __linux__
   pid_t sigev_notify_thread_id;
+#endif
 };
 
 #endif // LLVM_LIBC_TYPES_STRUCT_SIGEVENT_H

--- a/libc/include/llvm-libc-types/struct_sigevent.h
+++ b/libc/include/llvm-libc-types/struct_sigevent.h
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of struct sigevent type.
+/// https://man7.org/linux/man-pages/man3/sigevent.3type.html
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_STRUCT_SIGEVENT_H
+#define LLVM_LIBC_TYPES_STRUCT_SIGEVENT_H
+
+#include "pid_t.h"
+#include "pthread_attr_t.h"
+#include "union_sigval.h"
+
+struct sigevent {
+  int sigev_notify;
+  int sigev_signo;
+  union sigval sigev_value;
+  void (*sigev_notify_function)(union sigval);
+  pthread_attr_t *sigev_notify_attributes;
+  pid_t sigev_notify_thread_id;
+};
+
+#endif // LLVM_LIBC_TYPES_STRUCT_SIGEVENT_H

--- a/libc/include/signal.yaml
+++ b/libc/include/signal.yaml
@@ -20,6 +20,14 @@ macros:
     macro_header: signal-macros.h
   - macro_name: SIG_IGN
     macro_header: signal-macros.h
+  - macro_name: SIGEV_SIGNAL
+    macro_header: signal-macros.h
+  - macro_name: SIGEV_NONE
+    macro_header: signal-macros.h
+  - macro_name: SIGEV_THREAD
+    macro_header: signal-macros.h
+  - macro_name: SIGEV_THREAD_ID
+    macro_header: signal-macros.h
 types:
   - type_name: pid_t
   - type_name: sig_atomic_t
@@ -33,6 +41,7 @@ types:
   - type_name: sigset_t
   - type_name: stack_t
   - type_name: struct_sigaction
+  - type_name: struct_sigevent
   - type_name: union_sigval
 enums: []
 objects: []

--- a/libc/include/time.yaml
+++ b/libc/include/time.yaml
@@ -19,7 +19,6 @@ types:
   - type_name: size_t
   - type_name: locale_t
   - type_name: tm_gmtoff_t
-  - type_name: struct_sigevent
 enums: []
 objects: []
 functions:

--- a/libc/include/time.yaml
+++ b/libc/include/time.yaml
@@ -19,6 +19,7 @@ types:
   - type_name: size_t
   - type_name: locale_t
   - type_name: tm_gmtoff_t
+  - type_name: struct_sigevent
 enums: []
 objects: []
 functions:


### PR DESCRIPTION
Definition follows the standard POSIX layout from: https://man7.org/linux/man-pages/man3/sigevent.3type.html