### PR TITLE
[clang-repl] Add CLANG_ENABLE_EMUTLS_GET_ADDRESS cmake option

### DIFF
--- a/clang/CMakeLists.txt
+++ b/clang/CMakeLists.txt
@@ -220,6 +220,14 @@ if( CLANG_HAVE_DLFCN_H )
   cmake_pop_check_state()
 endif()
 
+include(CheckCXXSourceCompiles)
+check_cxx_source_compiles("
+  extern \"C\" void *__emutls_get_address(void *);
+  int main() {
+    return __emutls_get_address((void *)0) != (void *)0;
+  }
+" CLANG_HAVE_EMUTLS_GET_ADDRESS)
+
 set(CLANG_RESOURCE_DIR "" CACHE STRING
   "Relative directory from the Clang binary to its resource files.")
 

--- a/clang/include/clang/Config/config.h.cmake
+++ b/clang/include/clang/Config/config.h.cmake
@@ -95,4 +95,7 @@
 /* Enable the experimental new constant interpreter by default */
 #cmakedefine01 CLANG_USE_EXPERIMENTAL_CONST_INTERP
 
+/* Define if __emutls_get_address is available in the compiler runtime */
+#cmakedefine01 CLANG_HAVE_EMUTLS_GET_ADDRESS
+
 #endif

--- a/clang/lib/Interpreter/IncrementalExecutor.cpp
+++ b/clang/lib/Interpreter/IncrementalExecutor.cpp
@@ -17,6 +17,7 @@
 #endif // __EMSCRIPTEN__
 
 #include "clang/Basic/TargetInfo.h"
+#include "clang/Config/config.h"
 #include "clang/Driver/Compilation.h"
 #include "clang/Driver/Driver.h"
 #include "clang/Driver/ToolChain.h"
@@ -70,13 +71,10 @@
 // in a static archive and nothing else references it, it is never linked in and
 // ORC's process-symbol lookup cannot resolve it. Referencing it here
 // force-links the archive member so it is present regardless of how the host
-// provides it. Excluded where an emulated-TLS runtime is not guaranteed on the
-// link line, so the reference would fail to link: non-Unix (MSVC has no such
-// runtime), Emscripten (the wasm executor below does not use this JIT path),
-// and AIX / z/OS (whose runtimes may not provide the symbol). On those hosts
-// thread_locals instead rely on process-symbol lookup, unchanged from before.
-#if defined(LLVM_ON_UNIX) && !defined(__EMSCRIPTEN__) && !defined(_AIX) &&     \
-    !defined(__MVS__) && !defined(__FreeBSD__)
+// provides it. Defined if available at configure time
+// (CLANG_HAVE_EMUTLS_GET_ADDRESS). When unavailable, thread_locals instead rely
+// on process-symbol lookup.
+#if CLANG_HAVE_EMUTLS_GET_ADDRESS
 extern "C" void *__emutls_get_address(void *);
 static void *getEmuTLSGetAddressPtr() {
   return reinterpret_cast<void *>(&__emutls_get_address);

--- a/llvm/utils/gn/secondary/clang/include/clang/Config/BUILD.gn
+++ b/llvm/utils/gn/secondary/clang/include/clang/Config/BUILD.gn
@@ -32,6 +32,7 @@ write_cmake_config("Config") {
     "CLANG_SYSTEMZ_DEFAULT_ARCH=z10",
     "PPC_LINUX_DEFAULT_IEEELONGDOUBLE=",
     "CLANG_USE_EXPERIMENTAL_CONST_INTERP=",
+    "CLANG_HAVE_EMUTLS_GET_ADDRESS=",
   ]
 
   if (clang_enable_static_analyzer) {

--- a/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
@@ -1948,6 +1948,7 @@ cc_library(
         ":ast",
         ":basic",
         ":codegen",
+        ":config",
         ":driver",
         ":edit",
         ":frontend",

--- a/utils/bazel/llvm-project-overlay/clang/include/clang/Config/config.h
+++ b/utils/bazel/llvm-project-overlay/clang/include/clang/Config/config.h
@@ -105,6 +105,9 @@
 /* Enable the experimental new constant interpreter by default */
 #define CLANG_USE_EXPERIMENTAL_CONST_INTERP 0
 
+/* Define if __emutls_get_address is available in the compiler runtime */
+#define CLANG_HAVE_EMUTLS_GET_ADDRESS 0
+
 /* Directly provide definitions here behind platform preprocessor definitions.
  * The preprocessor conditions are sufficient to handle all of the configuration
  * on platforms targeted by Bazel, and defining these here more faithfully


### PR DESCRIPTION
Guard the extern "C" declaration and reference to __emutls_get_address in IncrementalExecutor.cpp behind a new CMake option CLANG_ENABLE_EMUTLS_GET_ADDRESS, which is OFF by default.

This prevents link errors in environments/runtimes where __emutls_get_address is not available.

Replace all other guards with the new cmake option.