### PR TITLE
[IR] Remove dead declarations

### DIFF
--- a/llvm/include/llvm/IR/DebugProgramInstruction.h
+++ b/llvm/include/llvm/IR/DebugProgramInstruction.h
@@ -555,10 +555,6 @@ public:
   LLVM_ABI DbgVariableIntrinsic *
   createDebugIntrinsic(Module *M, Instruction *InsertBefore) const;
 
-  /// Handle changes to the location of the Value(s) that we refer to happening
-  /// "under our feet".
-  LLVM_ABI void handleChangedLocation(Metadata *NewLocation);
-
   LLVM_ABI void print(raw_ostream &O, bool IsForDebug = false) const;
   LLVM_ABI void print(raw_ostream &ROS, ModuleSlotTracker &MST,
                       bool IsForDebug) const;

--- a/llvm/include/llvm/IR/ModuleSummaryIndex.h
+++ b/llvm/include/llvm/IR/ModuleSummaryIndex.h
@@ -353,8 +353,6 @@ struct ValueInfo {
 
   /// Checks if all copies are eligible for auto-hiding (have flag set).
   LLVM_ABI bool canAutoHide() const;
-
-  LLVM_ABI bool noRenameOnPromotion() const;
 };
 
 inline raw_ostream &operator<<(raw_ostream &OS, const ValueInfo &VI) {


### PR DESCRIPTION
handleChangedLocation: The corresponding function definition was
removed on January 16, 2024 in commit
d499df02a2508641d67918d7dc41b2e01a4a4114.

noRenameOnPromotion: Added on February 28, 2026 in commit
3e05ab6322cbf2a96362dcacb5907ba519fe552d without a corresponding
function definition.
