### PR TITLE
clang/AMDGPU: Use feature bitset for xnack/sramecc queries

### DIFF
--- a/clang/lib/Basic/TargetID.cpp
+++ b/clang/lib/Basic/TargetID.cpp
@@ -29,11 +29,12 @@ getAllPossibleAMDGPUTargetIDFeatures(const llvm::Triple &T,
   llvm::AMDGPU::GPUKind ProcKind = llvm::AMDGPU::parseArchAMDGCN(Proc);
   if (ProcKind == llvm::AMDGPU::GK_NONE)
     return Ret;
-  unsigned Features = llvm::AMDGPU::getArchAttrAMDGCN(ProcKind);
-  if (Features & llvm::AMDGPU::FEATURE_SRAMECC)
+  const llvm::AMDGPU::AMDGPUFeatureBitset &Features =
+      llvm::AMDGPU::getFeatureBitset(ProcKind);
+  if (Features.test(llvm::AMDGPU::FEAT_SRAMECC_SUPPORT))
     Ret.push_back("sramecc");
   // Only allow xnack in target ID if the processor supports on/off modes.
-  if (Features & llvm::AMDGPU::FEATURE_XNACK_ON_OFF_MODES)
+  if (Features.test(llvm::AMDGPU::FEAT_XNACK_ON_OFF_MODES))
     Ret.push_back("xnack");
   return Ret;
 }

--- a/clang/lib/Basic/Targets/AMDGPU.cpp
+++ b/clang/lib/Basic/Targets/AMDGPU.cpp
@@ -197,7 +197,7 @@ AMDGPUTargetInfo::AMDGPUTargetInfo(const llvm::Triple &Triple,
                                             Triple.getSubArch())
                                       : llvm::AMDGPU::parseArchAMDGCN(Opts.CPU))
                   : llvm::AMDGPU::parseArchR600(Opts.CPU)),
-      GPUFeatures(Triple.isAMDGCN() ? llvm::AMDGPU::getArchAttrAMDGCN(GPUKind)
+      GPUFeatures(Triple.isAMDGCN() ? llvm::AMDGPU::FEATURE_NONE
                                     : llvm::AMDGPU::getArchAttrR600(GPUKind)) {
   resetDataLayout();
 

--- a/clang/lib/Basic/Targets/AMDGPU.h
+++ b/clang/lib/Basic/Targets/AMDGPU.h
@@ -282,7 +282,7 @@ public:
   bool setCPU(StringRef Name) override {
     if (getTriple().isAMDGCN()) {
       GPUKind = llvm::AMDGPU::parseArchAMDGCN(Name);
-      GPUFeatures = llvm::AMDGPU::getArchAttrAMDGCN(GPUKind);
+      GPUFeatures = llvm::AMDGPU::FEATURE_NONE;
       return llvm::AMDGPU::isCPUValidForSubArch(getTriple().getSubArch(),
                                                 GPUKind) &&
              !llvm::AMDGPU::isPseudoTarget(GPUKind);

--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -1364,11 +1364,12 @@ static bool isXnackAvailable(const llvm::Triple &TT, llvm::StringRef TargetID) {
     return false;
   llvm::StringRef Processor = getProcessorFromTargetID(TT, TargetID);
   llvm::AMDGPU::GPUKind ProcKind = llvm::AMDGPU::parseArchAMDGCN(Processor);
-  unsigned Features = llvm::AMDGPU::getArchAttrAMDGCN(ProcKind);
+  const llvm::AMDGPU::AMDGPUFeatureBitset &Features =
+      llvm::AMDGPU::getFeatureBitset(ProcKind);
 
   // If processor has xnack but doesn't support on/off modes, xnack is always on
-  bool XnackAlwaysOn = (Features & llvm::AMDGPU::FEATURE_XNACK) &&
-                       !(Features & llvm::AMDGPU::FEATURE_XNACK_ON_OFF_MODES);
+  bool XnackAlwaysOn = Features.test(llvm::AMDGPU::FEAT_XNACK_SUPPORT) &&
+                       !Features.test(llvm::AMDGPU::FEAT_XNACK_ON_OFF_MODES);
   if (XnackAlwaysOn)
     return true;
 

--- a/llvm/lib/Target/AMDGPU/AMDGPU.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.td
@@ -3131,7 +3131,8 @@ def AMDGPUFrontendVisibleFeatures {
   FeatureVMemToLDSLoad, FeatureVmemPrefInsts, FeatureWMMA128bInsts,
   FeatureWMMA256bInsts, FeatureWMMAN16Insts, FeatureXF32Insts,
   FeatureWavefrontSize32, FeatureWavefrontSize64, FeatureSupportsWGP,
-  FeatureSupportsWave32, FeatureFastFMAF32, FeatureFastDenormalF32
+  FeatureSupportsWave32, FeatureFastFMAF32, FeatureFastDenormalF32,
+  FeatureSupportsXNACK, FeatureSupportsSRAMECC, FeatureXNACKOnOffModes
   ];
 }
 

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -437,8 +437,9 @@ StringRef AMDGPU::getCanonicalArchName(const Triple &T, StringRef Arch) {
 // FIXME: This is hacky, we shouldn't have mismatches between the bitset and
 // feature string map.
 static const AMDGPUFeatureBitset FrontendOnlyFeatures = {
-    FEAT_FAST_FMAF, FEAT_FAST_DENORMAL_F32, FEAT_SUPPORTS_WAVE32,
-    FEAT_SUPPORTS_WGP};
+    FEAT_FAST_FMAF,         FEAT_FAST_DENORMAL_F32, FEAT_SUPPORTS_WAVE32,
+    FEAT_SUPPORTS_WGP,      FEAT_XNACK_SUPPORT,     FEAT_SRAMECC_SUPPORT,
+    FEAT_XNACK_ON_OFF_MODES};
 
 // Add a GPU's features (minus the frontend-only ones) to \p Features. With \p
 // Overwrite false, existing entries are kept so user -mattr overrides win.


### PR DESCRIPTION
Complete the conversion of clang from the manual ArchAttr field
to the generated feature bitset.

Co-authored-by: Claude (Claude-Opus-4.8)