### PR TITLE
 [llvm-objcopy] Stream ELF output to reduce peak memory usage

### DIFF
--- a/llvm/lib/ObjCopy/ELF/ELFObject.cpp
+++ b/llvm/lib/ObjCopy/ELF/ELFObject.cpp
@@ -16,10 +16,12 @@
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/MC/MCELFExtras.h"
 #include "llvm/MC/MCTargetOptions.h"
+#include "llvm/Support/CheckedArithmetic.h"
 #include "llvm/Support/Compression.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -33,10 +35,131 @@ using namespace llvm::objcopy::elf;
 using namespace llvm::object;
 using namespace llvm::support;
 
-template <class ELFT> void ELFWriter<ELFT>::writePhdr(const Segment &Seg) {
-  uint8_t *B = reinterpret_cast<uint8_t *>(Buf->getBufferStart()) +
-               Obj.ProgramHdrSegment.Offset + Seg.Index * sizeof(Elf_Phdr);
-  Elf_Phdr &Phdr = *reinterpret_cast<Elf_Phdr *>(B);
+namespace {
+
+class raw_elf_buffer_ostream : public raw_ostream {
+  char *Buffer;
+  [[maybe_unused]] uint64_t Capacity;
+  uint64_t Position = 0;
+
+  void write_impl(const char *Ptr, size_t Size) override {
+    assert(Size <= Capacity - Position && "write exceeds output buffer");
+    std::memcpy(Buffer + Position, Ptr, Size);
+    Position += Size;
+  }
+
+  uint64_t current_pos() const override { return Position; }
+
+public:
+  raw_elf_buffer_ostream(char *Buffer, uint64_t Capacity)
+      : Buffer(Buffer), Capacity(Capacity) {
+    SetUnbuffered();
+  }
+
+  ~raw_elf_buffer_ostream() override { flush(); }
+};
+
+class raw_elf_stream_ostream : public raw_ostream {
+  raw_fd_stream &Stream;
+  uint64_t Position = 0;
+
+  void write_impl(const char *Ptr, size_t Size) override {
+    if (!Stream.has_error())
+      Stream.write(Ptr, Size);
+    Position += Size;
+  }
+
+  uint64_t current_pos() const override { return Position; }
+
+public:
+  explicit raw_elf_stream_ostream(raw_fd_stream &Stream) : Stream(Stream) {
+    SetUnbuffered();
+  }
+
+  ~raw_elf_stream_ostream() override { flush(); }
+};
+
+class ELFBufferWriterOutput final : public ELFWriterOutput {
+  WritableMemoryBuffer &Buffer;
+
+public:
+  explicit ELFBufferWriterOutput(WritableMemoryBuffer &Buffer)
+      : Buffer(Buffer) {}
+
+  void writeAt(uint64_t Offset,
+               function_ref<void(raw_ostream &)> Write) override {
+    assert(Offset <= Buffer.getBufferSize() && "invalid output offset");
+    raw_elf_buffer_ostream Out(Buffer.getBufferStart() + Offset,
+                               Buffer.getBufferSize() - Offset);
+    Write(Out);
+  }
+
+  Error finalize() override { return Error::success(); }
+};
+
+class ELFStreamWriterOutput final : public ELFWriterOutput {
+  raw_fd_stream &Stream;
+  uint64_t StartOffset;
+
+public:
+  ELFStreamWriterOutput(raw_fd_stream &Stream, uint64_t StartOffset)
+      : Stream(Stream), StartOffset(StartOffset) {}
+
+  void writeAt(uint64_t Offset,
+               function_ref<void(raw_ostream &)> Write) override {
+    if (Stream.has_error())
+      return;
+
+    uint64_t Position = Stream.tell();
+    Stream.seek(StartOffset + Offset);
+    if (Stream.has_error())
+      return;
+
+    raw_elf_stream_ostream Out(Stream);
+    Write(Out);
+    Stream.flush();
+    if (Stream.has_error())
+      return;
+    Stream.seek(Position);
+  }
+
+  Error finalize() override { return Stream.takeError(); }
+};
+
+template <class T> void writeObject(raw_ostream &Out, const T &Value) {
+  Out.write(reinterpret_cast<const char *>(&Value), sizeof(Value));
+}
+
+} // namespace
+
+void ELFWriterOutput::write(ArrayRef<uint8_t> Data, uint64_t Offset) {
+  if (Data.empty())
+    return;
+  writeAt(Offset, [&](raw_ostream &Out) {
+    Out.write(reinterpret_cast<const char *>(Data.data()), Data.size());
+  });
+}
+
+void ELFWriterOutput::writeZeros(uint64_t Offset, uint64_t Size) {
+  if (!Size)
+    return;
+
+  // raw_ostream::write_zeros accepts an unsigned count and is intended for
+  // small padding. ELF sections can be much larger, so write a reusable larger
+  // block while consuming the 64-bit section size.
+  static constexpr char Zeros[64 * 1024] = {};
+  writeAt(Offset, [&](raw_ostream &Out) {
+    while (Size) {
+      size_t ChunkSize = std::min<uint64_t>(Size, sizeof(Zeros));
+      Out.write(Zeros, ChunkSize);
+      Size -= ChunkSize;
+    }
+  });
+}
+
+template <class ELFT>
+void ELFWriter<ELFT>::writePhdr(raw_ostream &Out, const Segment &Seg) {
+  Elf_Phdr Phdr = {};
   Phdr.p_type = Seg.Type;
   Phdr.p_flags = Seg.Flags;
   Phdr.p_offset = Seg.Offset;
@@ -45,6 +168,7 @@ template <class ELFT> void ELFWriter<ELFT>::writePhdr(const Segment &Seg) {
   Phdr.p_filesz = Seg.FileSize;
   Phdr.p_memsz = Seg.MemSize;
   Phdr.p_align = Seg.Align;
+  writeObject(Out, Phdr);
 }
 
 Error SectionBase::removeSectionReferences(
@@ -63,10 +187,9 @@ void SectionBase::replaceSectionReferences(
     const DenseMap<SectionBase *, SectionBase *> &) {}
 void SectionBase::onRemove() {}
 
-template <class ELFT> void ELFWriter<ELFT>::writeShdr(const SectionBase &Sec) {
-  uint8_t *B =
-      reinterpret_cast<uint8_t *>(Buf->getBufferStart()) + Sec.HeaderOffset;
-  Elf_Shdr &Shdr = *reinterpret_cast<Elf_Shdr *>(B);
+template <class ELFT>
+void ELFWriter<ELFT>::writeShdr(raw_ostream &Out, const SectionBase &Sec) {
+  Elf_Shdr Shdr = {};
   Shdr.sh_name = Sec.NameIndex;
   Shdr.sh_type = Sec.Type;
   Shdr.sh_flags = Sec.Flags;
@@ -77,6 +200,7 @@ template <class ELFT> void ELFWriter<ELFT>::writeShdr(const SectionBase &Sec) {
   Shdr.sh_info = Sec.Info;
   Shdr.sh_addralign = Sec.Align;
   Shdr.sh_entsize = Sec.EntrySize;
+  writeObject(Out, Shdr);
 }
 
 template <class ELFT> Error ELFSectionSizer<ELFT>::visit(Section &) {
@@ -183,9 +307,29 @@ Error BinarySectionWriter::visit(const GroupSection &Sec) {
                            "cannot write '" + Sec.Name + "' out to binary");
 }
 
-void SectionWriter::writeSectionContents(ArrayRef<uint8_t> Data,
-                                         uint64_t Offset) {
+void BinarySectionWriter::writeSectionContents(ArrayRef<uint8_t> Data,
+                                               uint64_t Offset) {
   llvm::copy(Data, Out.getBufferStart() + Offset);
+}
+
+template <class ELFT>
+void ELFSectionWriter<ELFT>::writeSectionContents(ArrayRef<uint8_t> Data,
+                                                  uint64_t Offset) {
+  Out.write(Data, Offset);
+}
+
+void BinarySectionWriter::writeSectionContents(
+    uint64_t Offset, function_ref<void(raw_ostream &)> Write) {
+  assert(Offset <= Out.getBufferSize() && "invalid output offset");
+  raw_elf_buffer_ostream Stream(Out.getBufferStart() + Offset,
+                                Out.getBufferSize() - Offset);
+  Write(Stream);
+}
+
+template <class ELFT>
+void ELFSectionWriter<ELFT>::writeSectionContents(
+    uint64_t Offset, function_ref<void(raw_ostream &)> Write) {
+  Out.writeAt(Offset, Write);
 }
 
 Error SectionWriter::visit(const Section &Sec) {
@@ -549,10 +693,11 @@ Error ELFSectionWriter<ELFT>::visit(const CompressedSection &Sec) {
   }
   Chdr.ch_size = Sec.DecompressedSize;
   Chdr.ch_addralign = Sec.DecompressedAlign;
-  writeSectionContents(
-      ArrayRef(reinterpret_cast<const uint8_t *>(&Chdr), sizeof(Chdr)),
-      Sec.Offset);
-  writeSectionContents(Sec.CompressedData, Sec.Offset + sizeof(Chdr));
+  writeSectionContents(Sec.Offset, [&](raw_ostream &Out) {
+    writeObject(Out, Chdr);
+    Out.write(reinterpret_cast<const char *>(Sec.CompressedData.data()),
+              Sec.CompressedData.size());
+  });
   return Error::success();
 }
 
@@ -600,8 +745,8 @@ void StringTableSection::prepareForLayout() {
 }
 
 Error SectionWriter::visit(const StringTableSection &Sec) {
-  Sec.StrTabBuilder.write(reinterpret_cast<uint8_t *>(Out.getBufferStart()) +
-                          Sec.Offset);
+  writeSectionContents(Sec.Offset,
+                       [&](raw_ostream &Out) { Sec.StrTabBuilder.write(Out); });
   return Error::success();
 }
 
@@ -615,14 +760,12 @@ Error StringTableSection::accept(MutableSectionVisitor &Visitor) {
 
 template <class ELFT>
 Error ELFSectionWriter<ELFT>::visit(const SectionIndexSection &Sec) {
-  SmallVector<Elf_Word, 0> Indexes;
-  Indexes.reserve(Sec.Indexes.size());
-  for (uint32_t Index : Sec.Indexes)
-    Indexes.emplace_back(Index);
-  writeSectionContents(
-      ArrayRef(reinterpret_cast<const uint8_t *>(Indexes.data()),
-               Indexes.size() * sizeof(Elf_Word)),
-      Sec.Offset);
+  writeSectionContents(Sec.Offset, [&](raw_ostream &Out) {
+    for (uint32_t Index : Sec.Indexes) {
+      const Elf_Word Word{Index};
+      writeObject(Out, Word);
+    }
+  });
   return Error::success();
 }
 
@@ -868,18 +1011,19 @@ Expected<Symbol *> SymbolTableSection::getSymbolByIndex(uint32_t Index) {
 
 template <class ELFT>
 Error ELFSectionWriter<ELFT>::visit(const SymbolTableSection &Sec) {
-  Elf_Sym *Sym = reinterpret_cast<Elf_Sym *>(Out.getBufferStart() + Sec.Offset);
-  // Loop though symbols setting each entry of the symbol table.
-  for (const std::unique_ptr<Symbol> &Symbol : Sec.Symbols) {
-    Sym->st_name = Symbol->NameIndex;
-    Sym->st_value = Symbol->Value;
-    Sym->st_size = Symbol->Size;
-    Sym->st_other = Symbol->Visibility;
-    Sym->setBinding(Symbol->Binding);
-    Sym->setType(Symbol->Type);
-    Sym->st_shndx = Symbol->getShndx();
-    ++Sym;
-  }
+  writeSectionContents(Sec.Offset, [&](raw_ostream &Out) {
+    for (const std::unique_ptr<Symbol> &Symbol : Sec.Symbols) {
+      Elf_Sym Sym = {};
+      Sym.st_name = Symbol->NameIndex;
+      Sym.st_value = Symbol->Value;
+      Sym.st_size = Symbol->Size;
+      Sym.st_other = Symbol->Visibility;
+      Sym.setBinding(Symbol->Binding);
+      Sym.setType(Symbol->Type);
+      Sym.st_shndx = Symbol->getShndx();
+      writeObject(Out, Sym);
+    }
+  });
   return Error::success();
 }
 
@@ -977,30 +1121,35 @@ static void setAddend(Elf_Rel_Impl<ELFT, true> &Rela, uint64_t Addend) {
   Rela.r_addend = Addend;
 }
 
-template <class RelRange, class T>
-static void writeRel(const RelRange &Relocations, T *Buf, bool IsMips64EL) {
+template <class T, class RelRange>
+static void writeRel(raw_ostream &Out, const RelRange &Relocations,
+                     bool IsMips64EL) {
   for (const auto &Reloc : Relocations) {
-    Buf->r_offset = Reloc.Offset;
-    setAddend(*Buf, Reloc.Addend);
-    Buf->setSymbolAndType(Reloc.RelocSymbol ? Reloc.RelocSymbol->Index : 0,
-                          Reloc.Type, IsMips64EL);
-    ++Buf;
+    T Value = {};
+    Value.r_offset = Reloc.Offset;
+    setAddend(Value, Reloc.Addend);
+    Value.setSymbolAndType(Reloc.RelocSymbol ? Reloc.RelocSymbol->Index : 0,
+                           Reloc.Type, IsMips64EL);
+    writeObject(Out, Value);
   }
 }
 
 template <class ELFT>
 Error ELFSectionWriter<ELFT>::visit(const RelocationSection &Sec) {
-  uint8_t *Buf = reinterpret_cast<uint8_t *>(Out.getBufferStart()) + Sec.Offset;
   if (Sec.Type == SHT_CREL) {
     auto Content = encodeCrel<ELFT::Is64Bits>(Sec.Relocations);
-    memcpy(Buf, Content.data(), Content.size());
-  } else if (Sec.Type == SHT_REL) {
-    writeRel(Sec.Relocations, reinterpret_cast<Elf_Rel *>(Buf),
-             Sec.getObject().IsMips64EL);
-  } else {
-    writeRel(Sec.Relocations, reinterpret_cast<Elf_Rela *>(Buf),
-             Sec.getObject().IsMips64EL);
+    writeSectionContents(
+        ArrayRef(reinterpret_cast<const uint8_t *>(Content.data()),
+                 Content.size()),
+        Sec.Offset);
+    return Error::success();
   }
+  writeSectionContents(Sec.Offset, [&](raw_ostream &Out) {
+    if (Sec.Type == SHT_REL)
+      writeRel<Elf_Rel>(Out, Sec.Relocations, Sec.getObject().IsMips64EL);
+    else
+      writeRel<Elf_Rela>(Out, Sec.Relocations, Sec.getObject().IsMips64EL);
+  });
   return Error::success();
 }
 
@@ -1185,15 +1334,12 @@ GnuDebugLinkSection::GnuDebugLinkSection(StringRef File,
 
 template <class ELFT>
 Error ELFSectionWriter<ELFT>::visit(const GnuDebugLinkSection &Sec) {
-  unsigned char *Buf =
-      reinterpret_cast<uint8_t *>(Out.getBufferStart()) + Sec.Offset;
-  Elf_Word *CRC =
-      reinterpret_cast<Elf_Word *>(Buf + Sec.Size - sizeof(Elf_Word));
-  *CRC = Sec.CRC32;
-  writeSectionContents(
-      ArrayRef(reinterpret_cast<const uint8_t *>(Sec.FileName.data()),
-               Sec.FileName.size()),
-      Sec.Offset);
+  const Elf_Word CRC{Sec.CRC32};
+  writeSectionContents(Sec.Offset, [&](raw_ostream &Out) {
+    Out << Sec.FileName;
+    Out.write_zeros(Sec.Size - Sec.FileName.size() - sizeof(CRC));
+    writeObject(Out, CRC);
+  });
   return Error::success();
 }
 
@@ -1207,11 +1353,15 @@ Error GnuDebugLinkSection::accept(MutableSectionVisitor &Visitor) {
 
 template <class ELFT>
 Error ELFSectionWriter<ELFT>::visit(const GroupSection &Sec) {
-  ELF::Elf32_Word *Buf =
-      reinterpret_cast<ELF::Elf32_Word *>(Out.getBufferStart() + Sec.Offset);
-  endian::write32<ELFT::Endianness>(Buf++, Sec.FlagWord);
-  for (SectionBase *S : Sec.GroupMembers)
-    endian::write32<ELFT::Endianness>(Buf++, S->Index);
+  writeSectionContents(Sec.Offset, [&](raw_ostream &Out) {
+    uint8_t Data[sizeof(ELF::Elf32_Word)];
+    endian::write32<ELFT::Endianness>(Data, Sec.FlagWord);
+    Out.write(reinterpret_cast<const char *>(Data), sizeof(Data));
+    for (SectionBase *S : Sec.GroupMembers) {
+      endian::write32<ELFT::Endianness>(Data, S->Index);
+      Out.write(reinterpret_cast<const char *>(Data), sizeof(Data));
+    }
+  });
   return Error::success();
 }
 
@@ -2031,8 +2181,7 @@ Expected<std::unique_ptr<Object>> ELFReader::create(bool EnsureSymtab) const {
 }
 
 template <class ELFT> void ELFWriter<ELFT>::writeEhdr() {
-  Elf_Ehdr &Ehdr = *reinterpret_cast<Elf_Ehdr *>(Buf->getBufferStart());
-  std::fill(Ehdr.e_ident, Ehdr.e_ident + 16, 0);
+  Elf_Ehdr Ehdr = {};
   Ehdr.e_ident[EI_MAG0] = 0x7f;
   Ehdr.e_ident[EI_MAG1] = 'E';
   Ehdr.e_ident[EI_MAG2] = 'L';
@@ -2085,40 +2234,35 @@ template <class ELFT> void ELFWriter<ELFT>::writeEhdr() {
     Ehdr.e_shnum = 0;
     Ehdr.e_shstrndx = 0;
   }
+  Output->write(
+      ArrayRef(reinterpret_cast<const uint8_t *>(&Ehdr), sizeof(Ehdr)), 0);
 }
 
 template <class ELFT> void ELFWriter<ELFT>::writePhdrs() {
-  for (auto &Seg : Obj.segments())
-    writePhdr(Seg);
+  if (Obj.segments().empty())
+    return;
+  Output->writeAt(Obj.ProgramHdrSegment.Offset, [&](raw_ostream &Out) {
+    for (const Segment &Seg : Obj.segments())
+      writePhdr(Out, Seg);
+  });
 }
 
 template <class ELFT> void ELFWriter<ELFT>::writeShdrs() {
-  // This reference serves to write the dummy section header at the begining
-  // of the file. It is not used for anything else
-  Elf_Shdr &Shdr =
-      *reinterpret_cast<Elf_Shdr *>(Buf->getBufferStart() + Obj.SHOff);
-  Shdr.sh_name = 0;
-  Shdr.sh_type = SHT_NULL;
-  Shdr.sh_flags = 0;
-  Shdr.sh_addr = 0;
-  Shdr.sh_offset = 0;
-  // See writeEhdr for why we do this.
-  uint64_t Shnum = Obj.sections().size() + 1;
-  if (Shnum >= SHN_LORESERVE)
-    Shdr.sh_size = Shnum;
-  else
-    Shdr.sh_size = 0;
-  // See writeEhdr for why we do this.
-  if (Obj.SectionNames != nullptr && Obj.SectionNames->Index >= SHN_LORESERVE)
-    Shdr.sh_link = Obj.SectionNames->Index;
-  else
-    Shdr.sh_link = 0;
-  Shdr.sh_info = 0;
-  Shdr.sh_addralign = 0;
-  Shdr.sh_entsize = 0;
+  Output->writeAt(Obj.SHOff, [&](raw_ostream &Out) {
+    Elf_Shdr Shdr = {};
+    Shdr.sh_type = SHT_NULL;
+    // See writeEhdr for why we do this.
+    uint64_t Shnum = Obj.sections().size() + 1;
+    if (Shnum >= SHN_LORESERVE)
+      Shdr.sh_size = Shnum;
+    // See writeEhdr for why we do this.
+    if (Obj.SectionNames != nullptr && Obj.SectionNames->Index >= SHN_LORESERVE)
+      Shdr.sh_link = Obj.SectionNames->Index;
+    writeObject(Out, Shdr);
 
-  for (SectionBase &Sec : Obj.sections())
-    writeShdr(Sec);
+    for (const SectionBase &Sec : Obj.sections())
+      writeShdr(Out, Sec);
+  });
 }
 
 template <class ELFT> Error ELFWriter<ELFT>::writeSectionData() {
@@ -2136,8 +2280,7 @@ template <class ELFT> Error ELFWriter<ELFT>::writeSectionData() {
 template <class ELFT> void ELFWriter<ELFT>::writeSegmentData() {
   for (Segment &Seg : Obj.segments()) {
     size_t Size = std::min<size_t>(Seg.FileSize, Seg.getContents().size());
-    std::memcpy(Buf->getBufferStart() + Seg.Offset, Seg.getContents().data(),
-                Size);
+    Output->write(Seg.getContents().take_front(Size), Seg.Offset);
   }
 
   for (const auto &it : Obj.getUpdatedSections()) {
@@ -2148,7 +2291,7 @@ template <class ELFT> void ELFWriter<ELFT>::writeSegmentData() {
     assert(Parent && "This section should've been part of a segment.");
     uint64_t Offset =
         Sec->OriginalOffset - Parent->OriginalOffset + Parent->Offset;
-    llvm::copy(Data, Buf->getBufferStart() + Offset);
+    Output->write(Data, Offset);
   }
 
   // Iterate over removed sections and overwrite their old data with zeroes.
@@ -2158,7 +2301,7 @@ template <class ELFT> void ELFWriter<ELFT>::writeSegmentData() {
       continue;
     uint64_t Offset =
         Sec.OriginalOffset - Parent->OriginalOffset + Parent->Offset;
-    std::memset(Buf->getBufferStart() + Offset, 0, Sec.Size);
+    Output->writeZeros(Offset, Sec.Size);
   }
 }
 
@@ -2569,9 +2712,11 @@ template <class ELFT> Error ELFWriter<ELFT>::write() {
   if (WriteSectionHeaders)
     writeShdrs();
 
-  // TODO: Implement direct writing to the output stream (without intermediate
-  // memory buffer Buf).
-  Out.write(Buf->getBufferStart(), Buf->getBufferSize());
+  if (Error E = Output->finalize())
+    return E;
+
+  if (Buf)
+    Out.write(Buf->getBufferStart(), Buf->getBufferSize());
   return Error::success();
 }
 
@@ -2700,13 +2845,38 @@ template <class ELFT> Error ELFWriter<ELFT>::finalize() {
   }
 
   size_t TotalSize = totalSize();
-  Buf = WritableMemoryBuffer::getNewMemBuffer(TotalSize);
-  if (!Buf)
-    return createStringError(errc::not_enough_memory,
-                             "failed to allocate memory buffer of " +
-                                 Twine::utohexstr(TotalSize) + " bytes");
+  auto *Stream = dyn_cast<raw_fd_stream>(&Out);
+  if (Stream && Stream->supportsSeeking() && Stream->isRegularFile()) {
+    uint64_t StartOffset = Stream->tell();
+    std::optional<uint64_t> EndOffset =
+        checkedAddUnsigned(StartOffset, static_cast<uint64_t>(TotalSize));
+    if (!EndOffset)
+      return createStringError(errc::file_too_large,
+                               "output exceeds the addressable file range");
+    // Discard existing contents after the current position, then extend the
+    // file so unwritten output ranges read as zero without materializing them.
+    if (Error E = Stream->resize(StartOffset))
+      return E;
+    if (TotalSize) {
+      if (Error E = Stream->resize(*EndOffset))
+        return E;
+    }
+    // raw_pwrite_stream only supports overwriting existing data, so advance
+    // the stream position before writing data out of order.
+    Stream->seek(*EndOffset);
+    if (Error E = Stream->takeError())
+      return E;
+    Output = std::make_unique<ELFStreamWriterOutput>(*Stream, StartOffset);
+  } else {
+    Buf = WritableMemoryBuffer::getNewMemBuffer(TotalSize);
+    if (!Buf)
+      return createStringError(errc::not_enough_memory,
+                               "failed to allocate memory buffer of " +
+                                   Twine::utohexstr(TotalSize) + " bytes");
+    Output = std::make_unique<ELFBufferWriterOutput>(*Buf);
+  }
 
-  SecWriter = std::make_unique<ELFSectionWriter<ELFT>>(*Buf);
+  SecWriter = std::make_unique<ELFSectionWriter<ELFT>>(*Output);
   return Error::success();
 }
 

--- a/llvm/lib/ObjCopy/ELF/ELFObject.cpp
+++ b/llvm/lib/ObjCopy/ELF/ELFObject.cpp
@@ -16,10 +16,13 @@
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/MC/MCELFExtras.h"
 #include "llvm/MC/MCTargetOptions.h"
+#include "llvm/Support/CheckedArithmetic.h"
 #include "llvm/Support/Compression.h"
 #include "llvm/Support/Endian.h"
+#include "llvm/Support/EndianStream.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -33,10 +36,87 @@ using namespace llvm::objcopy::elf;
 using namespace llvm::object;
 using namespace llvm::support;
 
-template <class ELFT> void ELFWriter<ELFT>::writePhdr(const Segment &Seg) {
-  uint8_t *B = reinterpret_cast<uint8_t *>(Buf->getBufferStart()) +
-               Obj.ProgramHdrSegment.Offset + Seg.Index * sizeof(Elf_Phdr);
-  Elf_Phdr &Phdr = *reinterpret_cast<Elf_Phdr *>(B);
+namespace {
+
+template <class T> void writeObject(raw_ostream &Out, const T &Value) {
+  Out.write(reinterpret_cast<const char *>(&Value), sizeof(Value));
+}
+
+} // namespace
+
+Error ELFWriterOutput::reserve(uint64_t Size) {
+  auto *FD = dyn_cast<raw_fd_stream>(&Dest);
+  if (FD && FD->supportsSeeking() && FD->isRegularFile()) {
+    Start = FD->tell();
+    std::optional<uint64_t> Last = checkedAddUnsigned(Start, Size);
+    if (!Last)
+      return createStringError(errc::file_too_large,
+                               "output exceeds the addressable file range");
+    // Discard existing contents after the current position, then extend the
+    // file so unwritten ranges read as zero without materializing them.
+    if (Error E = FD->resize(Start))
+      return E;
+    if (Error E = FD->resize(*Last))
+      return E;
+    Stream = FD;
+    End = *Last;
+    return Error::success();
+  }
+
+  Buf = WritableMemoryBuffer::getNewMemBuffer(Size);
+  if (!Buf)
+    return createStringError(errc::not_enough_memory,
+                             "failed to allocate memory buffer of " +
+                                 Twine::utohexstr(Size) + " bytes");
+  BufStream.reset({Buf->getBufferStart(), Buf->getBufferSize()});
+  return Error::success();
+}
+
+raw_ostream &ELFWriterOutput::streamAt(uint64_t Offset) {
+  if (!Stream) {
+    BufStream.seek(Offset);
+    return BufStream;
+  }
+  if (!Stream->has_error())
+    Stream->seek(Start + Offset);
+  return *Stream;
+}
+
+void ELFWriterOutput::write(ArrayRef<uint8_t> Data, uint64_t Offset) {
+  if (!Data.empty())
+    streamAt(Offset).write(reinterpret_cast<const char *>(Data.data()),
+                           Data.size());
+}
+
+void ELFWriterOutput::writeZeros(uint64_t Offset, uint64_t Size) {
+  if (!Size)
+    return;
+  // raw_ostream::write_zeros writes in 16-byte units, which is too small for
+  // section-sized runs. Fill from a scratch block instead.
+  SmallVector<char, 0> Zeros(std::min<uint64_t>(Size, 64 * 1024));
+  raw_ostream &Out = streamAt(Offset);
+  while (Size) {
+    size_t Chunk = std::min<uint64_t>(Size, Zeros.size());
+    Out.write(Zeros.data(), Chunk);
+    Size -= Chunk;
+  }
+}
+
+Error ELFWriterOutput::finalize() {
+  if (!Stream) {
+    Dest.write(Buf->getBufferStart(), Buf->getBufferSize());
+    return Error::success();
+  }
+  // Leave the stream positioned past the object, as a writer that appended to
+  // it would.
+  if (!Stream->has_error())
+    Stream->seek(End);
+  return Stream->takeError();
+}
+
+template <class ELFT>
+void ELFWriter<ELFT>::writePhdr(raw_ostream &Out, const Segment &Seg) {
+  Elf_Phdr Phdr = {};
   Phdr.p_type = Seg.Type;
   Phdr.p_flags = Seg.Flags;
   Phdr.p_offset = Seg.Offset;
@@ -45,6 +125,7 @@ template <class ELFT> void ELFWriter<ELFT>::writePhdr(const Segment &Seg) {
   Phdr.p_filesz = Seg.FileSize;
   Phdr.p_memsz = Seg.MemSize;
   Phdr.p_align = Seg.Align;
+  writeObject(Out, Phdr);
 }
 
 Error SectionBase::removeSectionReferences(
@@ -63,10 +144,9 @@ void SectionBase::replaceSectionReferences(
     const DenseMap<SectionBase *, SectionBase *> &) {}
 void SectionBase::onRemove() {}
 
-template <class ELFT> void ELFWriter<ELFT>::writeShdr(const SectionBase &Sec) {
-  uint8_t *B =
-      reinterpret_cast<uint8_t *>(Buf->getBufferStart()) + Sec.HeaderOffset;
-  Elf_Shdr &Shdr = *reinterpret_cast<Elf_Shdr *>(B);
+template <class ELFT>
+void ELFWriter<ELFT>::writeShdr(raw_ostream &Out, const SectionBase &Sec) {
+  Elf_Shdr Shdr = {};
   Shdr.sh_name = Sec.NameIndex;
   Shdr.sh_type = Sec.Type;
   Shdr.sh_flags = Sec.Flags;
@@ -77,6 +157,7 @@ template <class ELFT> void ELFWriter<ELFT>::writeShdr(const SectionBase &Sec) {
   Shdr.sh_info = Sec.Info;
   Shdr.sh_addralign = Sec.Align;
   Shdr.sh_entsize = Sec.EntrySize;
+  writeObject(Out, Shdr);
 }
 
 template <class ELFT> Error ELFSectionSizer<ELFT>::visit(Section &) {
@@ -181,11 +262,6 @@ Error BinarySectionWriter::visit(const GnuDebugLinkSection &Sec) {
 Error BinarySectionWriter::visit(const GroupSection &Sec) {
   return createStringError(errc::operation_not_permitted,
                            "cannot write '" + Sec.Name + "' out to binary");
-}
-
-void SectionWriter::writeSectionContents(ArrayRef<uint8_t> Data,
-                                         uint64_t Offset) {
-  llvm::copy(Data, Out.getBufferStart() + Offset);
 }
 
 Error SectionWriter::visit(const Section &Sec) {
@@ -549,10 +625,10 @@ Error ELFSectionWriter<ELFT>::visit(const CompressedSection &Sec) {
   }
   Chdr.ch_size = Sec.DecompressedSize;
   Chdr.ch_addralign = Sec.DecompressedAlign;
-  writeSectionContents(
-      ArrayRef(reinterpret_cast<const uint8_t *>(&Chdr), sizeof(Chdr)),
-      Sec.Offset);
-  writeSectionContents(Sec.CompressedData, Sec.Offset + sizeof(Chdr));
+  raw_ostream &Out = streamAt(Sec.Offset);
+  writeObject(Out, Chdr);
+  Out.write(reinterpret_cast<const char *>(Sec.CompressedData.data()),
+            Sec.CompressedData.size());
   return Error::success();
 }
 
@@ -600,8 +676,7 @@ void StringTableSection::prepareForLayout() {
 }
 
 Error SectionWriter::visit(const StringTableSection &Sec) {
-  Sec.StrTabBuilder.write(reinterpret_cast<uint8_t *>(Out.getBufferStart()) +
-                          Sec.Offset);
+  Sec.StrTabBuilder.write(streamAt(Sec.Offset));
   return Error::success();
 }
 
@@ -615,14 +690,8 @@ Error StringTableSection::accept(MutableSectionVisitor &Visitor) {
 
 template <class ELFT>
 Error ELFSectionWriter<ELFT>::visit(const SectionIndexSection &Sec) {
-  SmallVector<Elf_Word, 0> Indexes;
-  Indexes.reserve(Sec.Indexes.size());
-  for (uint32_t Index : Sec.Indexes)
-    Indexes.emplace_back(Index);
-  writeSectionContents(
-      ArrayRef(reinterpret_cast<const uint8_t *>(Indexes.data()),
-               Indexes.size() * sizeof(Elf_Word)),
-      Sec.Offset);
+  support::endian::write_array<uint32_t>(streamAt(Sec.Offset), Sec.Indexes,
+                                         ELFT::Endianness);
   return Error::success();
 }
 
@@ -868,17 +937,17 @@ Expected<Symbol *> SymbolTableSection::getSymbolByIndex(uint32_t Index) {
 
 template <class ELFT>
 Error ELFSectionWriter<ELFT>::visit(const SymbolTableSection &Sec) {
-  Elf_Sym *Sym = reinterpret_cast<Elf_Sym *>(Out.getBufferStart() + Sec.Offset);
-  // Loop though symbols setting each entry of the symbol table.
+  raw_ostream &Out = streamAt(Sec.Offset);
   for (const std::unique_ptr<Symbol> &Symbol : Sec.Symbols) {
-    Sym->st_name = Symbol->NameIndex;
-    Sym->st_value = Symbol->Value;
-    Sym->st_size = Symbol->Size;
-    Sym->st_other = Symbol->Visibility;
-    Sym->setBinding(Symbol->Binding);
-    Sym->setType(Symbol->Type);
-    Sym->st_shndx = Symbol->getShndx();
-    ++Sym;
+    Elf_Sym Sym = {};
+    Sym.st_name = Symbol->NameIndex;
+    Sym.st_value = Symbol->Value;
+    Sym.st_size = Symbol->Size;
+    Sym.st_other = Symbol->Visibility;
+    Sym.setBinding(Symbol->Binding);
+    Sym.setType(Symbol->Type);
+    Sym.st_shndx = Symbol->getShndx();
+    writeObject(Out, Sym);
   }
   return Error::success();
 }
@@ -977,30 +1046,34 @@ static void setAddend(Elf_Rel_Impl<ELFT, true> &Rela, uint64_t Addend) {
   Rela.r_addend = Addend;
 }
 
-template <class RelRange, class T>
-static void writeRel(const RelRange &Relocations, T *Buf, bool IsMips64EL) {
+template <class T, class RelRange>
+static void writeRel(raw_ostream &Out, const RelRange &Relocations,
+                     bool IsMips64EL) {
   for (const auto &Reloc : Relocations) {
-    Buf->r_offset = Reloc.Offset;
-    setAddend(*Buf, Reloc.Addend);
-    Buf->setSymbolAndType(Reloc.RelocSymbol ? Reloc.RelocSymbol->Index : 0,
-                          Reloc.Type, IsMips64EL);
-    ++Buf;
+    T Value = {};
+    Value.r_offset = Reloc.Offset;
+    setAddend(Value, Reloc.Addend);
+    Value.setSymbolAndType(Reloc.RelocSymbol ? Reloc.RelocSymbol->Index : 0,
+                           Reloc.Type, IsMips64EL);
+    writeObject(Out, Value);
   }
 }
 
 template <class ELFT>
 Error ELFSectionWriter<ELFT>::visit(const RelocationSection &Sec) {
-  uint8_t *Buf = reinterpret_cast<uint8_t *>(Out.getBufferStart()) + Sec.Offset;
   if (Sec.Type == SHT_CREL) {
     auto Content = encodeCrel<ELFT::Is64Bits>(Sec.Relocations);
-    memcpy(Buf, Content.data(), Content.size());
-  } else if (Sec.Type == SHT_REL) {
-    writeRel(Sec.Relocations, reinterpret_cast<Elf_Rel *>(Buf),
-             Sec.getObject().IsMips64EL);
-  } else {
-    writeRel(Sec.Relocations, reinterpret_cast<Elf_Rela *>(Buf),
-             Sec.getObject().IsMips64EL);
+    writeSectionContents(
+        ArrayRef(reinterpret_cast<const uint8_t *>(Content.data()),
+                 Content.size()),
+        Sec.Offset);
+    return Error::success();
   }
+  raw_ostream &Out = streamAt(Sec.Offset);
+  if (Sec.Type == SHT_REL)
+    writeRel<Elf_Rel>(Out, Sec.Relocations, Sec.getObject().IsMips64EL);
+  else
+    writeRel<Elf_Rela>(Out, Sec.Relocations, Sec.getObject().IsMips64EL);
   return Error::success();
 }
 
@@ -1185,15 +1258,10 @@ GnuDebugLinkSection::GnuDebugLinkSection(StringRef File,
 
 template <class ELFT>
 Error ELFSectionWriter<ELFT>::visit(const GnuDebugLinkSection &Sec) {
-  unsigned char *Buf =
-      reinterpret_cast<uint8_t *>(Out.getBufferStart()) + Sec.Offset;
-  Elf_Word *CRC =
-      reinterpret_cast<Elf_Word *>(Buf + Sec.Size - sizeof(Elf_Word));
-  *CRC = Sec.CRC32;
-  writeSectionContents(
-      ArrayRef(reinterpret_cast<const uint8_t *>(Sec.FileName.data()),
-               Sec.FileName.size()),
-      Sec.Offset);
+  raw_ostream &Out = streamAt(Sec.Offset);
+  Out << Sec.FileName;
+  Out.write_zeros(Sec.Size - Sec.FileName.size() - sizeof(Elf_Word));
+  support::endian::write<uint32_t>(Out, Sec.CRC32, ELFT::Endianness);
   return Error::success();
 }
 
@@ -1207,11 +1275,10 @@ Error GnuDebugLinkSection::accept(MutableSectionVisitor &Visitor) {
 
 template <class ELFT>
 Error ELFSectionWriter<ELFT>::visit(const GroupSection &Sec) {
-  ELF::Elf32_Word *Buf =
-      reinterpret_cast<ELF::Elf32_Word *>(Out.getBufferStart() + Sec.Offset);
-  endian::write32<ELFT::Endianness>(Buf++, Sec.FlagWord);
+  support::endian::Writer W(streamAt(Sec.Offset), ELFT::Endianness);
+  W.write<ELF::Elf32_Word>(Sec.FlagWord);
   for (SectionBase *S : Sec.GroupMembers)
-    endian::write32<ELFT::Endianness>(Buf++, S->Index);
+    W.write<ELF::Elf32_Word>(S->Index);
   return Error::success();
 }
 
@@ -2031,8 +2098,7 @@ Expected<std::unique_ptr<Object>> ELFReader::create(bool EnsureSymtab) const {
 }
 
 template <class ELFT> void ELFWriter<ELFT>::writeEhdr() {
-  Elf_Ehdr &Ehdr = *reinterpret_cast<Elf_Ehdr *>(Buf->getBufferStart());
-  std::fill(Ehdr.e_ident, Ehdr.e_ident + 16, 0);
+  Elf_Ehdr Ehdr = {};
   Ehdr.e_ident[EI_MAG0] = 0x7f;
   Ehdr.e_ident[EI_MAG1] = 'E';
   Ehdr.e_ident[EI_MAG2] = 'L';
@@ -2085,40 +2151,32 @@ template <class ELFT> void ELFWriter<ELFT>::writeEhdr() {
     Ehdr.e_shnum = 0;
     Ehdr.e_shstrndx = 0;
   }
+  writeObject(Output->streamAt(0), Ehdr);
 }
 
 template <class ELFT> void ELFWriter<ELFT>::writePhdrs() {
-  for (auto &Seg : Obj.segments())
-    writePhdr(Seg);
+  if (Obj.segments().empty())
+    return;
+  raw_ostream &Out = Output->streamAt(Obj.ProgramHdrSegment.Offset);
+  for (const Segment &Seg : Obj.segments())
+    writePhdr(Out, Seg);
 }
 
 template <class ELFT> void ELFWriter<ELFT>::writeShdrs() {
-  // This reference serves to write the dummy section header at the begining
-  // of the file. It is not used for anything else
-  Elf_Shdr &Shdr =
-      *reinterpret_cast<Elf_Shdr *>(Buf->getBufferStart() + Obj.SHOff);
-  Shdr.sh_name = 0;
+  raw_ostream &Out = Output->streamAt(Obj.SHOff);
+  Elf_Shdr Shdr = {};
   Shdr.sh_type = SHT_NULL;
-  Shdr.sh_flags = 0;
-  Shdr.sh_addr = 0;
-  Shdr.sh_offset = 0;
   // See writeEhdr for why we do this.
   uint64_t Shnum = Obj.sections().size() + 1;
   if (Shnum >= SHN_LORESERVE)
     Shdr.sh_size = Shnum;
-  else
-    Shdr.sh_size = 0;
   // See writeEhdr for why we do this.
   if (Obj.SectionNames != nullptr && Obj.SectionNames->Index >= SHN_LORESERVE)
     Shdr.sh_link = Obj.SectionNames->Index;
-  else
-    Shdr.sh_link = 0;
-  Shdr.sh_info = 0;
-  Shdr.sh_addralign = 0;
-  Shdr.sh_entsize = 0;
+  writeObject(Out, Shdr);
 
-  for (SectionBase &Sec : Obj.sections())
-    writeShdr(Sec);
+  for (const SectionBase &Sec : Obj.sections())
+    writeShdr(Out, Sec);
 }
 
 template <class ELFT> Error ELFWriter<ELFT>::writeSectionData() {
@@ -2136,8 +2194,7 @@ template <class ELFT> Error ELFWriter<ELFT>::writeSectionData() {
 template <class ELFT> void ELFWriter<ELFT>::writeSegmentData() {
   for (Segment &Seg : Obj.segments()) {
     size_t Size = std::min<size_t>(Seg.FileSize, Seg.getContents().size());
-    std::memcpy(Buf->getBufferStart() + Seg.Offset, Seg.getContents().data(),
-                Size);
+    Output->write(Seg.getContents().take_front(Size), Seg.Offset);
   }
 
   for (const auto &it : Obj.getUpdatedSections()) {
@@ -2148,7 +2205,7 @@ template <class ELFT> void ELFWriter<ELFT>::writeSegmentData() {
     assert(Parent && "This section should've been part of a segment.");
     uint64_t Offset =
         Sec->OriginalOffset - Parent->OriginalOffset + Parent->Offset;
-    llvm::copy(Data, Buf->getBufferStart() + Offset);
+    Output->write(Data, Offset);
   }
 
   // Iterate over removed sections and overwrite their old data with zeroes.
@@ -2158,7 +2215,7 @@ template <class ELFT> void ELFWriter<ELFT>::writeSegmentData() {
       continue;
     uint64_t Offset =
         Sec.OriginalOffset - Parent->OriginalOffset + Parent->Offset;
-    std::memset(Buf->getBufferStart() + Offset, 0, Sec.Size);
+    Output->writeZeros(Offset, Sec.Size);
   }
 }
 
@@ -2569,10 +2626,7 @@ template <class ELFT> Error ELFWriter<ELFT>::write() {
   if (WriteSectionHeaders)
     writeShdrs();
 
-  // TODO: Implement direct writing to the output stream (without intermediate
-  // memory buffer Buf).
-  Out.write(Buf->getBufferStart(), Buf->getBufferSize());
-  return Error::success();
+  return Output->finalize();
 }
 
 static Error removeUnneededSections(Object &Obj) {
@@ -2699,14 +2753,11 @@ template <class ELFT> Error ELFWriter<ELFT>::finalize() {
     Sec.finalize();
   }
 
-  size_t TotalSize = totalSize();
-  Buf = WritableMemoryBuffer::getNewMemBuffer(TotalSize);
-  if (!Buf)
-    return createStringError(errc::not_enough_memory,
-                             "failed to allocate memory buffer of " +
-                                 Twine::utohexstr(TotalSize) + " bytes");
+  Output.emplace(Out);
+  if (Error E = Output->reserve(totalSize()))
+    return E;
 
-  SecWriter = std::make_unique<ELFSectionWriter<ELFT>>(*Buf);
+  SecWriter = std::make_unique<ELFSectionWriter<ELFT>>(*Output);
   return Error::success();
 }
 

--- a/llvm/lib/ObjCopy/ELF/ELFObject.h
+++ b/llvm/lib/ObjCopy/ELF/ELFObject.h
@@ -28,6 +28,7 @@
 
 namespace llvm {
 enum class DebugCompressionType;
+class raw_fd_stream;
 namespace objcopy {
 namespace elf {
 
@@ -46,6 +47,18 @@ class DecompressedSection;
 class Segment;
 class Object;
 struct Symbol;
+
+class ELFWriterOutput {
+public:
+  virtual ~ELFWriterOutput() = default;
+
+  virtual void writeAt(uint64_t Offset,
+                       function_ref<void(raw_ostream &)> Write) = 0;
+  virtual Error finalize() = 0;
+
+  void write(ArrayRef<uint8_t> Data, uint64_t Offset);
+  void writeZeros(uint64_t Offset, uint64_t Size);
+};
 
 class SectionTableRef {
   ArrayRef<std::unique_ptr<SectionBase>> Sections;
@@ -106,8 +119,11 @@ public:
 
 class SectionWriter : public SectionVisitor {
 protected:
-  WritableMemoryBuffer &Out;
-  virtual void writeSectionContents(ArrayRef<uint8_t> Data, uint64_t Offset);
+  virtual void writeSectionContents(ArrayRef<uint8_t> Data,
+                                    uint64_t Offset) = 0;
+  virtual void
+  writeSectionContents(uint64_t Offset,
+                       function_ref<void(raw_ostream &)> Write) = 0;
 
 public:
   ~SectionWriter() override = default;
@@ -123,8 +139,6 @@ public:
   Error visit(const SectionIndexSection &Sec) override = 0;
   Error visit(const CompressedSection &Sec) override = 0;
   Error visit(const DecompressedSection &Sec) override = 0;
-
-  explicit SectionWriter(WritableMemoryBuffer &Buf) : Out(Buf) {}
 };
 
 template <class ELFT> class ELFSectionWriter : public SectionWriter {
@@ -133,6 +147,11 @@ private:
   using Elf_Rel = typename ELFT::Rel;
   using Elf_Rela = typename ELFT::Rela;
   using Elf_Sym = typename ELFT::Sym;
+
+  ELFWriterOutput &Out;
+  void writeSectionContents(ArrayRef<uint8_t> Data, uint64_t Offset) override;
+  void writeSectionContents(uint64_t Offset,
+                            function_ref<void(raw_ostream &)> Write) override;
 
 public:
   ~ELFSectionWriter() override = default;
@@ -144,7 +163,7 @@ public:
   Error visit(const CompressedSection &Sec) override;
   Error visit(const DecompressedSection &Sec) override;
 
-  explicit ELFSectionWriter(WritableMemoryBuffer &Buf) : SectionWriter(Buf) {}
+  explicit ELFSectionWriter(ELFWriterOutput &Out) : Out(Out) {}
 };
 
 template <class ELFT> class ELFSectionSizer : public MutableSectionVisitor {
@@ -180,6 +199,12 @@ public:
   template <class ELFT> friend class ELFSectionSizer;
 
 class BinarySectionWriter : public SectionWriter {
+protected:
+  WritableMemoryBuffer &Out;
+  void writeSectionContents(ArrayRef<uint8_t> Data, uint64_t Offset) override;
+  void writeSectionContents(uint64_t Offset,
+                            function_ref<void(raw_ostream &)> Write) override;
+
 public:
   ~BinarySectionWriter() override = default;
 
@@ -191,8 +216,7 @@ public:
   Error visit(const CompressedSection &Sec) override;
   Error visit(const DecompressedSection &Sec) override;
 
-  explicit BinarySectionWriter(WritableMemoryBuffer &Buf)
-      : SectionWriter(Buf) {}
+  explicit BinarySectionWriter(WritableMemoryBuffer &Buf) : Out(Buf) {}
 };
 
 using IHexLineData = SmallVector<char, 64>;
@@ -332,8 +356,8 @@ private:
   void initEhdrSegment();
 
   void writeEhdr();
-  void writePhdr(const Segment &Seg);
-  void writeShdr(const SectionBase &Sec);
+  void writePhdr(raw_ostream &Out, const Segment &Seg);
+  void writeShdr(raw_ostream &Out, const SectionBase &Sec);
 
   void writePhdrs();
   void writeShdrs();
@@ -342,6 +366,7 @@ private:
 
   void assignOffsets();
 
+  std::unique_ptr<ELFWriterOutput> Output;
   std::unique_ptr<ELFSectionWriter<ELFT>> SecWriter;
 
   size_t totalSize() const;

--- a/llvm/lib/ObjCopy/ELF/ELFObject.h
+++ b/llvm/lib/ObjCopy/ELF/ELFObject.h
@@ -19,10 +19,13 @@
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/FileOutputBuffer.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/raw_ostream.h"
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <set>
 #include <vector>
 
@@ -46,6 +49,60 @@ class DecompressedSection;
 class Segment;
 class Object;
 struct Symbol;
+
+/// A raw_ostream over a fixed memory range that can be repositioned.
+class raw_range_ostream : public raw_ostream {
+  MutableArrayRef<char> Data;
+  uint64_t Position = 0;
+
+  void write_impl(const char *Ptr, size_t Size) override {
+    assert(Size <= Data.size() - Position && "write exceeds output range");
+    std::memcpy(Data.data() + Position, Ptr, Size);
+    Position += Size;
+  }
+
+  uint64_t current_pos() const override { return Position; }
+
+public:
+  raw_range_ostream() { SetUnbuffered(); }
+
+  void reset(MutableArrayRef<char> D) {
+    Data = D;
+    Position = 0;
+  }
+
+  void seek(uint64_t Offset) {
+    assert(Offset <= Data.size() && "invalid output offset");
+    Position = Offset;
+  }
+};
+
+/// Destination of the ELF writer's output. Ranges are written out of order, so
+/// the object is either built in a memory buffer that finalize() copies to
+/// Dest, or, when Dest is a seekable regular file, written to that file in
+/// place.
+class ELFWriterOutput {
+  raw_ostream &Dest;
+  std::unique_ptr<WritableMemoryBuffer> Buf;
+  raw_range_ostream BufStream;
+  raw_fd_stream *Stream = nullptr;
+  uint64_t Start = 0;
+  uint64_t End = 0;
+
+public:
+  explicit ELFWriterOutput(raw_ostream &Dest) : Dest(Dest) {}
+
+  /// Reserves Size bytes for the object. Unwritten ranges read as zero.
+  Error reserve(uint64_t Size);
+
+  /// Returns a stream positioned Offset bytes into the object. The previous
+  /// result is invalidated.
+  raw_ostream &streamAt(uint64_t Offset);
+
+  void write(ArrayRef<uint8_t> Data, uint64_t Offset);
+  void writeZeros(uint64_t Offset, uint64_t Size);
+  Error finalize();
+};
 
 class SectionTableRef {
   ArrayRef<std::unique_ptr<SectionBase>> Sections;
@@ -106,8 +163,15 @@ public:
 
 class SectionWriter : public SectionVisitor {
 protected:
-  WritableMemoryBuffer &Out;
-  virtual void writeSectionContents(ArrayRef<uint8_t> Data, uint64_t Offset);
+  /// Returns a stream positioned at Offset in the output. The previous result
+  /// is invalidated.
+  virtual raw_ostream &streamAt(uint64_t Offset) = 0;
+
+  void writeSectionContents(ArrayRef<uint8_t> Data, uint64_t Offset) {
+    if (!Data.empty())
+      streamAt(Offset).write(reinterpret_cast<const char *>(Data.data()),
+                             Data.size());
+  }
 
 public:
   ~SectionWriter() override = default;
@@ -123,8 +187,6 @@ public:
   Error visit(const SectionIndexSection &Sec) override = 0;
   Error visit(const CompressedSection &Sec) override = 0;
   Error visit(const DecompressedSection &Sec) override = 0;
-
-  explicit SectionWriter(WritableMemoryBuffer &Buf) : Out(Buf) {}
 };
 
 template <class ELFT> class ELFSectionWriter : public SectionWriter {
@@ -133,6 +195,11 @@ private:
   using Elf_Rel = typename ELFT::Rel;
   using Elf_Rela = typename ELFT::Rela;
   using Elf_Sym = typename ELFT::Sym;
+
+  ELFWriterOutput &Out;
+  raw_ostream &streamAt(uint64_t Offset) override {
+    return Out.streamAt(Offset);
+  }
 
 public:
   ~ELFSectionWriter() override = default;
@@ -144,7 +211,7 @@ public:
   Error visit(const CompressedSection &Sec) override;
   Error visit(const DecompressedSection &Sec) override;
 
-  explicit ELFSectionWriter(WritableMemoryBuffer &Buf) : SectionWriter(Buf) {}
+  explicit ELFSectionWriter(ELFWriterOutput &Out) : Out(Out) {}
 };
 
 template <class ELFT> class ELFSectionSizer : public MutableSectionVisitor {
@@ -180,6 +247,14 @@ public:
   template <class ELFT> friend class ELFSectionSizer;
 
 class BinarySectionWriter : public SectionWriter {
+protected:
+  WritableMemoryBuffer &Out;
+  raw_range_ostream Stream;
+  raw_ostream &streamAt(uint64_t Offset) override {
+    Stream.seek(Offset);
+    return Stream;
+  }
+
 public:
   ~BinarySectionWriter() override = default;
 
@@ -191,8 +266,9 @@ public:
   Error visit(const CompressedSection &Sec) override;
   Error visit(const DecompressedSection &Sec) override;
 
-  explicit BinarySectionWriter(WritableMemoryBuffer &Buf)
-      : SectionWriter(Buf) {}
+  explicit BinarySectionWriter(WritableMemoryBuffer &Buf) : Out(Buf) {
+    Stream.reset({Buf.getBufferStart(), Buf.getBufferSize()});
+  }
 };
 
 using IHexLineData = SmallVector<char, 64>;
@@ -332,8 +408,8 @@ private:
   void initEhdrSegment();
 
   void writeEhdr();
-  void writePhdr(const Segment &Seg);
-  void writeShdr(const SectionBase &Sec);
+  void writePhdr(raw_ostream &Out, const Segment &Seg);
+  void writeShdr(raw_ostream &Out, const SectionBase &Sec);
 
   void writePhdrs();
   void writeShdrs();
@@ -342,6 +418,7 @@ private:
 
   void assignOffsets();
 
+  std::optional<ELFWriterOutput> Output;
   std::unique_ptr<ELFSectionWriter<ELFT>> SecWriter;
 
   size_t totalSize() const;

--- a/llvm/unittests/ObjCopy/ObjCopyTest.cpp
+++ b/llvm/unittests/ObjCopy/ObjCopyTest.cpp
@@ -11,7 +11,10 @@
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/ObjectYAML/yaml2obj.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/FileUtilities.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/raw_ostream.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
 
@@ -216,6 +219,65 @@ TEST(CopySimpleInMemoryFile, ELF) {
 
   copySimpleInMemoryFileImpl(SimpleFileELFYAML,
                              [](const Binary &File) { return File.isELF(); });
+}
+
+TEST(CopySimpleInMemoryFile, ELFFileStreamMatchesBufferedOutput) {
+  SmallVector<char> Storage;
+  Expected<std::unique_ptr<ObjectFile>> Obj =
+      createObjectFileFromYamlDescription(
+          SimpleFileELFYAML, Storage,
+          [](const Binary &File) { return File.isELF(); });
+  ASSERT_THAT_EXPECTED(Obj, Succeeded());
+
+  ConfigManager Config;
+  Config.Common.OutputFilename = "a.out";
+  SmallVector<char> ExpectedData;
+  raw_svector_ostream ExpectedOut(ExpectedData);
+  ASSERT_THAT_ERROR(objcopy::executeObjcopyOnBinary(Config, **Obj, ExpectedOut),
+                    Succeeded());
+
+  SmallString<64> Path;
+  int FD;
+  ASSERT_FALSE(sys::fs::createTemporaryFile("objcopy", "elf", FD, Path));
+  FileRemover Cleanup(Path);
+  StringRef Prefix = "prefix";
+  {
+    raw_fd_stream Out(FD, true);
+    Out << Prefix << std::string(ExpectedData.size() + 16, '\xff');
+    Out.seek(Prefix.size());
+    ASSERT_THAT_ERROR(objcopy::executeObjcopyOnBinary(Config, **Obj, Out),
+                      Succeeded());
+  }
+
+  ErrorOr<std::unique_ptr<MemoryBuffer>> Output = MemoryBuffer::getFile(Path);
+  ASSERT_TRUE(Output);
+  std::string Expected(Prefix);
+  Expected.append(ExpectedData.begin(), ExpectedData.end());
+  EXPECT_EQ((*Output)->getBuffer(), Expected);
+}
+
+TEST(CopySimpleInMemoryFile, ELFFileStreamReturnsWriteErrors) {
+  SmallVector<char> Storage;
+  Expected<std::unique_ptr<ObjectFile>> Obj =
+      createObjectFileFromYamlDescription(
+          SimpleFileELFYAML, Storage,
+          [](const Binary &File) { return File.isELF(); });
+  ASSERT_THAT_EXPECTED(Obj, Succeeded());
+
+  SmallString<64> Path;
+  int FD;
+  ASSERT_FALSE(sys::fs::createTemporaryFile("objcopy", "elf", FD, Path));
+  FileRemover Cleanup(Path);
+  {
+    raw_fd_ostream Out(FD, true);
+  }
+  ASSERT_FALSE(sys::fs::openFileForRead(Path, FD));
+
+  ConfigManager Config;
+  Config.Common.OutputFilename = "a.out";
+  raw_fd_stream Out(FD, true);
+  EXPECT_THAT_ERROR(objcopy::executeObjcopyOnBinary(Config, **Obj, Out),
+                    Failed());
 }
 
 TEST(CopySimpleInMemoryFile, MachO) {


### PR DESCRIPTION
## Motivation

At Meta, we use `llvm-objcopy` after we build our software with [buck2](https://buck2.build/) to stamp build information (i.e. `build-id` , date, author etc..) We do this post-build rather than during the build to make sure out build artifacts are nearly all bit-reproducible .

We cave some pretty massive binaries and we noticed that the memory requirements for `llvm-objcopy` are 1:1 with the filesize.
We would like to improve upon the memory use of `llvm-objcopy` to save a lot of memory on the stamping steps, which have the really unfortunate property of sometimes running massively parallel, swamping host memory use and causing OOMs.

The original change here is was done by @jtbraun and I am helping him upstream this.

## Change

llvm-objcopy currently materializes the entire ELF output in a memory buffer before writing it to disk. For very large
binaries, this adds memory usage approximately proportional to the output size. When many stamping operations run
concurrently, the resulting memory pressure can cause host OOMs.

This change writes ELF output directly to seekable regular files using offset writes. Buffered output remains in use for stdout and other non-seekable streams.

The implementation remains at the ELF level because ELF, COFF, Mach-O, and Wasm have separate object writers and layout logic.


## Benchmark

I tested a no-op copy of a synthetic ELF containing a 1 GiB payload. The results below are the medians of three warm-cache runs measured with GNU time: 

| | Before | After |
|---|---|---|
| **Peak RSS** | 2,102,916 KiB | 1,053,844 KiB |
| **Wall time** | 1.06 s | 0.77 s |

This reduces peak RSS by 49.9%. The before and after outputs were byte-identical.

I also tested a real 1.2 GiB ELF build artifact:

| | Before | After |
|---|---|---|
| **Peak RSS** | 3.12 GiB | 2.01 GiB |
| **Wall time** | 2.74 s | 2.36 s |

Those outputs were also byte-identical.

Ran the benchmark on "smaller inputs" as well to make sure that it doesn't regress the common case:

| Input | Copies per trial | Buffered RSS | Streaming RSS | Buffered time | Streaming time |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **10 MiB** | 10 | 26.3 MiB | 15.6 MiB | 0.14 s | 0.11 s |
| **100 MiB** | 3 | 210.6 MiB | 107.7 MiB | 0.32 s | 0.23 s |

The outputs were byte-identical. These measurements were collected on Linux. I have not collected Windows performance numbers, so I do not want to make a performance claim there.

**Note to reviewers**:
This PR is organized as three commits so the preparatory refactoring and error propagation can be reviewed separately from the streaming implementation.  

This follows the same general motivation as #192112, which replaced buffered llvm-dwp output with direct ELF writing to reduce memory pressure.

This change was developed with assistance from OpenAI Codex. Each commit includes an Assisted-by: OpenAI Codex trailer following the AI policy.

**Feedback applied**
* Output errors are sticky: after the underlying stream records an error, subsequent low-level writes become no-ops and the error is reported once when writing finishes.
* The buffered and file-backed implementations are hidden behind a common output interface. (no `dyn_cast`)
* Regenerated ELF data, including headers, symbols, and relocations, is serialized sequentially after seeking once to the relevant output range.
* Small benchmark included with a note that it is Linux only.
