### PR TITLE
workflows/release-binaries: Install Wix on Windows ARM64

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -291,6 +291,14 @@ jobs:
         release_dir=`find "$BUILD_PREFIX/build" -iname 'stage2-bins'`
         mv "$release_dir/$RELEASE_BINARY_FILENAME" .
 
+    # Wix is not installed by default on Windows ARM64
+    - name: Install Wix (Windows ARM64)
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      run: |
+        choco install wixtoolset
+        # Add wix install directory to PATH.
+        Split-Path (Get-ChildItem -Path "C:\" -Filter candle.exe -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1).FullName
+
     - name: Build Windows
       id: build-windows
       if: runner.os == 'Windows'

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -295,7 +295,7 @@ jobs:
     - name: Install Wix (Windows ARM64)
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       run: |
-        choco install wixtoolset
+        choco install wixtoolset --version 3.14.1.20250415
         # Add wix install directory to PATH.
         Split-Path (Get-ChildItem -Path "C:\" -Filter candle.exe -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1).FullName
 


### PR DESCRIPTION
Wix is used for generating the installer and is not installed by default on Windows ARM64.