### PR TITLE
[Clang][Sema] Don't warn on accessing virtual base from abstract class

### DIFF
--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -4158,8 +4158,13 @@ namespace {
     }
 
     llvm::SmallPtrSet<QualType, 4> UninitializedBaseClasses;
-    for (const auto &I : RD->bases())
+    for (const auto &I : RD->bases()) {
+      // Virtual bases are initialized from the most derived class, so an
+      // abstract base class constructor can assume it to be initialized.
+      if (I.isVirtual() && RD->isAbstract())
+        continue;
       UninitializedBaseClasses.insert(I.getType().getCanonicalType());
+    }
 
     if (UninitializedFields.empty() && UninitializedBaseClasses.empty())
       return;

--- a/clang/test/SemaCXX/uninitialized.cpp
+++ b/clang/test/SemaCXX/uninitialized.cpp
@@ -1411,6 +1411,8 @@ struct B : public A {
 
   B(int (*)[4]) : A(foo()) {}
   // expected-warning@-1 {{base_class_access::A' is uninitialized when used here to access 'base_class_access::A::foo'}}
+
+  virtual void f() = 0;
 };
 
 struct C {
@@ -1426,6 +1428,22 @@ struct D : public C, public A {
 
   D(int (*)[4]) : C(foo()) {}
   // expected-warning@-1 {{base_class_access::A' is uninitialized when used here to access 'base_class_access::A::foo'}}
+};
+
+struct E : public virtual A {
+  E(int (*)[3]) : A(i) {}
+  // expected-warning@-1 {{base class 'base_class_access::A' is uninitialized when used here to access 'base_class_access::A::i'}}
+
+  E(int (*)[4]) : A(foo()) {}
+  // expected-warning@-1 {{base_class_access::A' is uninitialized when used here to access 'base_class_access::A::foo'}}
+};
+
+// Accessing virtual base class members from an abstract class is fine.
+struct F : public virtual A, public C {
+  F(int (*)[3]) : C(i) {}
+  F(int (*)[4]) : C(foo()) {}
+
+  virtual void f() = 0;
 };
 
 }


### PR DESCRIPTION
Virtual bases are initialized by the most derived class, and they come before non-virtual base class initializers. So an abstract class can assume that virtual bases are already initialized by the time their constructor runs.

It seems that the warning generally doesn't take indirect bases into account, otherwise this would become a bit more complicated.

Fixes #204858.