### PR TITLE
[AMDGPU] Add FastMathFlags::intersectValue helper for rsq ninf/nsz fix

### DIFF
--- a/llvm/include/llvm/IR/FMF.h
+++ b/llvm/include/llvm/IR/FMF.h
@@ -125,6 +125,13 @@ public:
     const unsigned ValueMask = NoNaNs | NoInfs | NoSignedZeros;
     return FastMathFlags(ValueMask & (LHS.Flags | RHS.Flags));
   }
+
+  /// Intersect value flags
+  static inline FastMathFlags intersectValue(FastMathFlags LHS,
+                                             FastMathFlags RHS) {
+    const unsigned ValueMask = NoNaNs | NoInfs | NoSignedZeros;
+    return FastMathFlags(ValueMask & LHS.Flags & RHS.Flags);
+  }
 };
 
 inline FastMathFlags operator|(FastMathFlags LHS, FastMathFlags RHS) {

--- a/llvm/lib/Target/AMDGPU/AMDGPUCodeGenPrepare.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCodeGenPrepare.cpp
@@ -746,8 +746,9 @@ Value *AMDGPUCodeGenPrepareImpl::optimizeWithRsq(
     // sqrt: sqrt's ninf/nsz don't say anything about the quotient.
     IRBuilder<>::FastMathFlagGuard Guard(Builder);
     FastMathFlags NewFMF = DivFMF | SqrtFMF;
-    NewFMF.setNoInfs(DivFMF.noInfs() && SqrtFMF.noInfs());
-    NewFMF.setNoSignedZeros(DivFMF.noSignedZeros() && SqrtFMF.noSignedZeros());
+    FastMathFlags ValueFMF = FastMathFlags::intersectValue(DivFMF, SqrtFMF);
+    NewFMF.setNoInfs(ValueFMF.noInfs());
+    NewFMF.setNoSignedZeros(ValueFMF.noSignedZeros());
     Builder.setFastMathFlags(NewFMF);
 
     if (Den->getType()->isFloatTy()) {


### PR DESCRIPTION
Follow-up on https://github.com/llvm/llvm-project/pull/217599 