### PR TITLE
[llc] Register pass plugin callbacks with the new pass manager

### DIFF
--- a/llvm/test/Feature/codegen-plugin-passes.mir
+++ b/llvm/test/Feature/codegen-plugin-passes.mir
@@ -1,0 +1,17 @@
+# Check that llc registers a loaded plugin's PassBuilder callbacks, so that a
+# pass provided by the plugin can be named in -passes.
+# REQUIRES: x86-registered-target, plugins, examples
+# UNSUPPORTED: target={{.*windows.*}}
+# Plugins are currently broken on AIX, at least in the CI.
+# XFAIL: target={{.*}}-aix{{.*}}
+# RUN: llc -mtriple=x86_64-- %loadnewpmbye -passes=goodbye -wave-goodbye %s -o /dev/null 2>&1 | FileCheck %s
+# RUN: llc -mtriple=x86_64-- %loadnewpmbye -passes=goodbye --print-pipeline-passes -filetype=null %s | FileCheck %s --check-prefix=PIPELINE
+
+# CHECK: Bye: somefunk
+# PIPELINE: function((anonymous namespace)::Bye)
+---
+name:            somefunk
+body: |
+  bb.0:
+    RET 0
+...

--- a/llvm/tools/llc/NewPMDriver.cpp
+++ b/llvm/tools/llc/NewPMDriver.cpp
@@ -35,6 +35,7 @@
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/StandardInstrumentations.h"
+#include "llvm/Plugins/PassPlugin.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Error.h"
@@ -92,7 +93,7 @@ int llvm::compileModuleWithNewPM(
     std::unique_ptr<TargetMachine> Target, std::unique_ptr<ToolOutputFile> Out,
     std::unique_ptr<ToolOutputFile> DwoOut, LLVMContext &Context,
     const TargetLibraryInfoImpl &TLII, VerifierKind VK, StringRef PassPipeline,
-    CodeGenFileType FileType) {
+    ArrayRef<PassPlugin> PassPlugins, CodeGenFileType FileType) {
 
   if (!PassPipeline.empty() && TargetPassConfig::hasLimitedCodeGenPipeline()) {
     WithColor::error(errs(), Arg0)
@@ -140,6 +141,8 @@ int llvm::compileModuleWithNewPM(
   MAM.registerPass([&] { return MachineModuleAnalysis(MMI); });
 
   PassBuilder PB(Target.get(), PipelineTuningOptions(), std::nullopt, &PIC);
+  for (auto &PassPlugin : PassPlugins)
+    PassPlugin.registerPassBuilderCallbacks(PB);
   PB.registerModuleAnalyses(MAM);
   PB.registerCGSCCAnalyses(CGAM);
   PB.registerFunctionAnalyses(FAM);

--- a/llvm/tools/llc/NewPMDriver.h
+++ b/llvm/tools/llc/NewPMDriver.h
@@ -19,12 +19,14 @@
 #ifndef LLVM_TOOLS_LLC_NEWPMDRIVER_H
 #define LLVM_TOOLS_LLC_NEWPMDRIVER_H
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/IR/DiagnosticHandler.h"
 #include "llvm/Support/CodeGen.h"
 #include <memory>
 
 namespace llvm {
 class Module;
+class PassPlugin;
 class TargetLibraryInfoImpl;
 class TargetMachine;
 class ToolOutputFile;
@@ -37,14 +39,12 @@ struct LLCDiagnosticHandler : public DiagnosticHandler {
   bool handleDiagnostics(const DiagnosticInfo &DI) override;
 };
 
-int compileModuleWithNewPM(StringRef Arg0, std::unique_ptr<Module> M,
-                           std::unique_ptr<MIRParser> MIR,
-                           std::unique_ptr<TargetMachine> Target,
-                           std::unique_ptr<ToolOutputFile> Out,
-                           std::unique_ptr<ToolOutputFile> DwoOut,
-                           LLVMContext &Context,
-                           const TargetLibraryInfoImpl &TLII, VerifierKind VK,
-                           StringRef PassPipeline, CodeGenFileType FileType);
+int compileModuleWithNewPM(
+    StringRef Arg0, std::unique_ptr<Module> M, std::unique_ptr<MIRParser> MIR,
+    std::unique_ptr<TargetMachine> Target, std::unique_ptr<ToolOutputFile> Out,
+    std::unique_ptr<ToolOutputFile> DwoOut, LLVMContext &Context,
+    const TargetLibraryInfoImpl &TLII, VerifierKind VK, StringRef PassPipeline,
+    ArrayRef<PassPlugin> PassPlugins, CodeGenFileType FileType);
 } // namespace llvm
 
 #endif

--- a/llvm/tools/llc/llc.cpp
+++ b/llvm/tools/llc/llc.cpp
@@ -755,10 +755,10 @@ static int compileModule(char **argv, SmallVectorImpl<PassPlugin> &PluginList,
       (Target->shouldDefaultToNewPM() &&
        !(EnableNewPassManager.getNumOccurrences() && !EnableNewPassManager) &&
        getRunPassNames().empty())) {
-    return compileModuleWithNewPM(argv[0], std::move(M), std::move(MIR),
-                                  std::move(Target), std::move(Out),
-                                  std::move(DwoOut), Context, TLII, VK,
-                                  PassPipeline, codegen::getFileType());
+    return compileModuleWithNewPM(
+        argv[0], std::move(M), std::move(MIR), std::move(Target),
+        std::move(Out), std::move(DwoOut), Context, TLII, VK, PassPipeline,
+        PluginList, codegen::getFileType());
   }
 
   // Build up all of the passes that we want to do to the module.


### PR DESCRIPTION
llc loads the libraries given to `--load-pass-plugin`, but only ever invokes their
`PreCodeGenCallback`; the plugins' `PassBuilder` callbacks are never registered, so a pass
provided by a plugin cannot be named in `-passes`. Register them in the new PM driver,
matching what opt does in `llvm/tools/opt/NewPMDriver.cpp`.

This is visible with LLVM's own example plugin, which opt accepts and llc rejects:

    $ opt -load-pass-plugin=lib/Bye.so -passes=goodbye -disable-output f.ll
    $ llc -load-pass-plugin=lib/Bye.so -passes=goodbye f.mir -o /dev/null
    unknown pass name 'goodbye'

Claude Code helped me navigate the codebase.
