### PR TITLE
[LLVMABI][AARCH64] Handle BitInt arguments and return value

### DIFF
--- a/clang/test/CodeGen/AArch64/abi-classify-arg-types.c
+++ b/clang/test/CodeGen/AArch64/abi-classify-arg-types.c
@@ -1,15 +1,15 @@
-// RUN: %clang_cc1 -triple arm64-apple-ios7.0 -target-abi darwinpcs -fenable-matrix -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,DARWIN,LONG64
-// RUN: %clang_cc1 -triple arm64-apple-ios7.0 -target-abi darwinpcs -fenable-matrix -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,DARWIN,LONG64 --implicit-check-not="not yet implemented"
-// RUN: %clang_cc1 -triple arm64_32-apple-ios7.0 -target-abi darwinpcs -fenable-matrix -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,DARWIN,LONG32
-// RUN: %clang_cc1 -triple arm64_32-apple-ios7.0 -target-abi darwinpcs -fenable-matrix -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,DARWIN,LONG32 --implicit-check-not="not yet implemented"
-// RUN: %clang_cc1 -triple aarch64-linux-gnu -fenable-matrix -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG64
-// RUN: %clang_cc1 -triple aarch64-linux-gnu -fenable-matrix -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG64 --implicit-check-not="not yet implemented"
-// RUN: %clang_cc1 -triple aarch64_be-linux-gnu -fenable-matrix -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG64
-// RUN: %clang_cc1 -triple aarch64_be-linux-gnu -fenable-matrix -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG64 --implicit-check-not="not yet implemented"
-// RUN: %clang_cc1 -triple aarch64-pc-windows-msvc -fenable-matrix -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG32
-// RUN: %clang_cc1 -triple aarch64-pc-windows-msvc -fenable-matrix -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG32 --implicit-check-not="not yet implemented"
-// RUN: %clang_cc1 -triple arm64ec-pc-windows-msvc -fenable-matrix -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG32
-// RUN: %clang_cc1 -triple arm64ec-pc-windows-msvc -fenable-matrix -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG32 --implicit-check-not="not yet implemented"
+// RUN: %clang_cc1 -triple arm64-apple-ios7.0 -target-abi darwinpcs -fenable-matrix -fexperimental-max-bitint-width=1024 -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,DARWIN,LONG64
+// RUN: %clang_cc1 -triple arm64-apple-ios7.0 -target-abi darwinpcs -fenable-matrix -fexperimental-max-bitint-width=1024 -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,DARWIN,LONG64 --implicit-check-not="not yet implemented"
+// RUN: %clang_cc1 -triple arm64_32-apple-ios7.0 -target-abi darwinpcs -fenable-matrix -fexperimental-max-bitint-width=1024 -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,DARWIN,LONG32
+// RUN: %clang_cc1 -triple arm64_32-apple-ios7.0 -target-abi darwinpcs -fenable-matrix -fexperimental-max-bitint-width=1024 -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,DARWIN,LONG32 --implicit-check-not="not yet implemented"
+// RUN: %clang_cc1 -triple aarch64-linux-gnu -fenable-matrix -fexperimental-max-bitint-width=1024 -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG64
+// RUN: %clang_cc1 -triple aarch64-linux-gnu -fenable-matrix -fexperimental-max-bitint-width=1024 -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG64 --implicit-check-not="not yet implemented"
+// RUN: %clang_cc1 -triple aarch64_be-linux-gnu -fenable-matrix -fexperimental-max-bitint-width=1024 -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG64
+// RUN: %clang_cc1 -triple aarch64_be-linux-gnu -fenable-matrix -fexperimental-max-bitint-width=1024 -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG64 --implicit-check-not="not yet implemented"
+// RUN: %clang_cc1 -triple aarch64-pc-windows-msvc -fenable-matrix -fexperimental-max-bitint-width=1024 -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG32
+// RUN: %clang_cc1 -triple aarch64-pc-windows-msvc -fenable-matrix -fexperimental-max-bitint-width=1024 -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG32 --implicit-check-not="not yet implemented"
+// RUN: %clang_cc1 -triple arm64ec-pc-windows-msvc -fenable-matrix -fexperimental-max-bitint-width=1024 -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG32
+// RUN: %clang_cc1 -triple arm64ec-pc-windows-msvc -fenable-matrix -fexperimental-max-bitint-width=1024 -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG32 --implicit-check-not="not yet implemented"
 
 // This test is verifying that the LLVM ABI library classifies argument types in
 // the same way that Clang does without the library.
@@ -93,3 +93,20 @@ typedef union {
 } tu_ptr_t __attribute__((transparent_union));
 void arg_transparent_union_ptr(tu_ptr_t tu) {}
 // CHECK: define{{.*}} void @arg_transparent_union_ptr(ptr %{{.*}})
+
+void arg_bitint7(_BitInt(7) x) {}
+// AAPCS: define{{.*}} void @arg_bitint7(i7 noundef %{{.*}})
+// DARWIN: define{{.*}} void @arg_bitint7(i7 noundef signext %{{.*}})
+
+void arg_ubitint7(unsigned _BitInt(7) x) {}
+// AAPCS: define{{.*}} void @arg_ubitint7(i7 noundef %{{.*}})
+// DARWIN: define{{.*}} void @arg_ubitint7(i7 noundef zeroext %{{.*}})
+
+void arg_bitint65(_BitInt(65) x) {}
+// CHECK: define{{.*}} void @arg_bitint65(i65 noundef %{{.*}})
+
+void arg_bitint128(_BitInt(128) x) {}
+// CHECK: define{{.*}} void @arg_bitint128(i128 noundef %{{.*}})
+
+void arg_bitint129(_BitInt(129) x) {}
+// CHECK: define{{.*}} void @arg_bitint129(ptr nofree noundef align 16 dead_on_return dereferenceable(32) %{{.*}})

--- a/clang/test/CodeGen/AArch64/abi-classify-return-types.c
+++ b/clang/test/CodeGen/AArch64/abi-classify-return-types.c
@@ -1,15 +1,15 @@
-// RUN: %clang_cc1 -triple arm64-apple-ios7.0 -target-abi darwinpcs -fenable-matrix -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,DARWIN,LONG64
-// RUN: %clang_cc1 -triple arm64-apple-ios7.0 -target-abi darwinpcs -fenable-matrix -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,DARWIN,LONG64 --implicit-check-not="not yet implemented"
-// RUN: %clang_cc1 -triple arm64_32-apple-ios7.0 -target-abi darwinpcs -fenable-matrix -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,DARWIN,LONG32
-// RUN: %clang_cc1 -triple arm64_32-apple-ios7.0 -target-abi darwinpcs -fenable-matrix -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,DARWIN,LONG32 --implicit-check-not="not yet implemented"
-// RUN: %clang_cc1 -triple aarch64-linux-gnu -fenable-matrix -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG64
-// RUN: %clang_cc1 -triple aarch64-linux-gnu -fenable-matrix -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG64 --implicit-check-not="not yet implemented"
-// RUN: %clang_cc1 -triple aarch64_be-linux-gnu -fenable-matrix -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG64
-// RUN: %clang_cc1 -triple aarch64_be-linux-gnu -fenable-matrix -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG64 --implicit-check-not="not yet implemented"
-// RUN: %clang_cc1 -triple aarch64-pc-windows-msvc -fenable-matrix -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG32
-// RUN: %clang_cc1 -triple aarch64-pc-windows-msvc -fenable-matrix -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG32 --implicit-check-not="not yet implemented"
-// RUN: %clang_cc1 -triple arm64ec-pc-windows-msvc -fenable-matrix -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG32
-// RUN: %clang_cc1 -triple arm64ec-pc-windows-msvc -fenable-matrix -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG32 --implicit-check-not="not yet implemented"
+// RUN: %clang_cc1 -triple arm64-apple-ios7.0 -target-abi darwinpcs -fenable-matrix -fexperimental-max-bitint-width=1024 -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,DARWIN,LONG64
+// RUN: %clang_cc1 -triple arm64-apple-ios7.0 -target-abi darwinpcs -fenable-matrix -fexperimental-max-bitint-width=1024 -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,DARWIN,LONG64 --implicit-check-not="not yet implemented"
+// RUN: %clang_cc1 -triple arm64_32-apple-ios7.0 -target-abi darwinpcs -fenable-matrix -fexperimental-max-bitint-width=1024 -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,DARWIN,LONG32
+// RUN: %clang_cc1 -triple arm64_32-apple-ios7.0 -target-abi darwinpcs -fenable-matrix -fexperimental-max-bitint-width=1024 -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,DARWIN,LONG32 --implicit-check-not="not yet implemented"
+// RUN: %clang_cc1 -triple aarch64-linux-gnu -fenable-matrix -fexperimental-max-bitint-width=1024 -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG64
+// RUN: %clang_cc1 -triple aarch64-linux-gnu -fenable-matrix -fexperimental-max-bitint-width=1024 -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG64 --implicit-check-not="not yet implemented"
+// RUN: %clang_cc1 -triple aarch64_be-linux-gnu -fenable-matrix -fexperimental-max-bitint-width=1024 -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG64
+// RUN: %clang_cc1 -triple aarch64_be-linux-gnu -fenable-matrix -fexperimental-max-bitint-width=1024 -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG64 --implicit-check-not="not yet implemented"
+// RUN: %clang_cc1 -triple aarch64-pc-windows-msvc -fenable-matrix -fexperimental-max-bitint-width=1024 -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG32
+// RUN: %clang_cc1 -triple aarch64-pc-windows-msvc -fenable-matrix -fexperimental-max-bitint-width=1024 -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG32 --implicit-check-not="not yet implemented"
+// RUN: %clang_cc1 -triple arm64ec-pc-windows-msvc -fenable-matrix -fexperimental-max-bitint-width=1024 -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG32
+// RUN: %clang_cc1 -triple arm64ec-pc-windows-msvc -fenable-matrix -fexperimental-max-bitint-width=1024 -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,AAPCS,LONG32 --implicit-check-not="not yet implemented"
 
 // This test is verifying that the LLVM ABI library classifies return types in
 // the same way that Clang does without the library.
@@ -69,3 +69,20 @@ void* ret_void_ptr() { return &gi; }
 typedef float fx2x2_t __attribute__((matrix_type(2, 2)));
 fx2x2_t ret_matrix() { return (fx2x2_t){1.0f, 2.0f, 3.0f, 4.0f}; }
 // CHECK: define{{.*}} <4 x float> @ret_matrix
+
+_BitInt(7) ret_bitint7(void) { return 0; }
+// AAPCS: define{{.*}} i7 @ret_bitint7
+// DARWIN: define{{.*}} signext i7 @ret_bitint7
+
+unsigned _BitInt(7) ret_ubitint7(void) { return 0; }
+// AAPCS: define{{.*}} i7 @ret_ubitint7
+// DARWIN: define{{.*}} zeroext i7 @ret_ubitint7
+
+_BitInt(65) ret_bitint65(void) { return 0; }
+// CHECK: define{{.*}} i65 @ret_bitint65
+
+_BitInt(128) ret_bitint128(void) { return 0; }
+// CHECK: define{{.*}} i128 @ret_bitint128
+
+_BitInt(129) ret_bitint129(void) { return 0; }
+// CHECK: define{{.*}} void @ret_bitint129(ptr dead_on_unwind noalias writable sret(i256) align 16 %{{.*}})

--- a/llvm/lib/ABI/Targets/AArch64.cpp
+++ b/llvm/lib/ABI/Targets/AArch64.cpp
@@ -72,13 +72,12 @@ ArgInfo AArch64TargetInfo::classifyReturnType(const Type *RetTy,
 
   if (!passAsAggregateType(RetTy)) {
     if (const auto *IntTy = dyn_cast<IntegerType>(RetTy)) {
-      if (IntTy->isBitInt()) {
-        reportNYI("BitInt return type handling");
-        return ArgInfo::getDirect();
-      }
-      if (isPromotableInteger(IntTy) && isDarwinPCS()) {
+      if (IntTy->isBitInt())
+        if (RetTy->getSizeInBits().getFixedValue() > 128)
+          return getNaturalAlignIndirect(RetTy);
+
+      if (isPromotableInteger(IntTy) && isDarwinPCS())
         return ArgInfo::getExtend(IntTy);
-      }
     }
 
     // Everything not handled above is returned directly.
@@ -103,13 +102,12 @@ ArgInfo AArch64TargetInfo::classifyArgumentType(
 
   if (!passAsAggregateType(Ty)) {
     if (const auto *IntTy = dyn_cast<IntegerType>(Ty)) {
-      if (IntTy->isBitInt()) {
-        reportNYI("BitInt argument type handling");
-        return ArgInfo::getDirect();
-      }
-      if (isPromotableInteger(IntTy) && isDarwinPCS()) {
+      if (IntTy->isBitInt())
+        if (Ty->getSizeInBits().getFixedValue() > 128)
+          return getNaturalAlignIndirect(Ty, /*ByVal=*/false);
+
+      if (isPromotableInteger(IntTy) && isDarwinPCS())
         return ArgInfo::getExtend(IntTy);
-      }
     }
 
     // TODO: Legal vector types will update NSRN or NPRN.

--- a/llvm/unittests/ABI/AArch64TargetInfoTest.cpp
+++ b/llvm/unittests/ABI/AArch64TargetInfoTest.cpp
@@ -43,6 +43,11 @@ protected:
   const ABIType *Ptr;
   const ABIType *Void;
   const ABIType *Matrix;
+  const ABIType *BitInt7;
+  const ABIType *UBitInt7;
+  const ABIType *BitInt65;
+  const ABIType *BitInt128;
+  const ABIType *BitInt129;
 
   AArch64TargetInfoTest()
       : TB(Alloc), Bool(TB.getIntegerType(1, llvm::Align(1), /*Signed=*/false)),
@@ -58,7 +63,17 @@ protected:
         F64(TB.getFloatType(llvm::APFloat::IEEEdouble(), llvm::Align(8))),
         Ptr(TB.getPointerType(64, llvm::Align(8))), Void(TB.getVoidType()),
         Matrix(TB.getArrayType(F32, /*NumElements=*/4, /*SizeInBits=*/128,
-                               /*IsMatrixType=*/true)) {}
+                               /*IsMatrixType=*/true)),
+        BitInt7(TB.getIntegerType(7, llvm::Align(1), /*Signed=*/true,
+                                  /*IsBitInt=*/true)),
+        UBitInt7(TB.getIntegerType(7, llvm::Align(1), /*Signed=*/false,
+                                   /*IsBitInt=*/true)),
+        BitInt65(TB.getIntegerType(65, llvm::Align(16), /*Signed=*/true,
+                                   /*IsBitInt=*/true)),
+        BitInt128(TB.getIntegerType(128, llvm::Align(16), /*Signed=*/true,
+                                    /*IsBitInt=*/true)),
+        BitInt129(TB.getIntegerType(129, llvm::Align(16), /*Signed=*/true,
+                                    /*IsBitInt=*/true)) {}
 };
 
 static void expectUncoercedDirect(const ArgInfo &Info) {
@@ -71,6 +86,13 @@ static void expectExtendInteger(const ArgInfo &Info, const ABIType *Ty,
   EXPECT_TRUE(Info.isExtend());
   EXPECT_EQ(Info.isSignExt(), IsSigned);
   EXPECT_EQ(Info.getCoerceToType(), Ty);
+}
+
+static void expectAlignedIndirect(const ArgInfo &Info, llvm::Align Align,
+                                  bool ByVal = false) {
+  EXPECT_TRUE(Info.isIndirect());
+  EXPECT_EQ(Info.getIndirectAlign(), Align);
+  EXPECT_EQ(Info.getIndirectByVal(), ByVal);
 }
 
 TEST_F(AArch64TargetInfoTest, ClassifyReturnVoidIsIgnore) {
@@ -143,6 +165,64 @@ TEST_F(AArch64TargetInfoTest, ClassifyReturnScalarsDirectAAPCSSoft) {
   }
 }
 
+// _BitInt types no wider than 128 bits are returned directly under AAPCS.
+// Wider _BitInt types are returned indirectly.
+TEST_F(AArch64TargetInfoTest, ClassifyReturnBitIntAAPCS) {
+  std::unique_ptr<TargetInfo> TI =
+      createAArch64TargetInfo(TB, AArch64ABIKind::AAPCS);
+
+  for (const ABIType *RetTy : {BitInt7, UBitInt7, BitInt65, BitInt128}) {
+    std::unique_ptr<FunctionInfo> FI =
+        FunctionInfo::create(llvm::CallingConv::C, RetTy, {});
+    FI->getReturnInfo() = ArgInfo::getIgnore();
+    TI->computeInfo(*FI);
+    expectUncoercedDirect(FI->getReturnInfo());
+  }
+
+  std::unique_ptr<FunctionInfo> FI =
+      FunctionInfo::create(llvm::CallingConv::C, BitInt129, {});
+  FI->getReturnInfo() = ArgInfo::getIgnore();
+  TI->computeInfo(*FI);
+  expectAlignedIndirect(FI->getReturnInfo(), llvm::Align(16), /*ByVal=*/true);
+}
+
+// DarwinPCS extends promotable _BitInt returns. Other _BitInt types no wider
+// than 128 bits are returned directly. Wider _BitInt types are returned
+// indirectly.
+TEST_F(AArch64TargetInfoTest, ClassifyReturnBitIntDarwin) {
+  std::unique_ptr<TargetInfo> TI =
+      createAArch64TargetInfo(TB, AArch64ABIKind::DarwinPCS);
+
+  for (const ABIType *RetTy : {BitInt65, BitInt128}) {
+    std::unique_ptr<FunctionInfo> FI =
+        FunctionInfo::create(llvm::CallingConv::C, RetTy, {});
+    FI->getReturnInfo() = ArgInfo::getIgnore();
+    TI->computeInfo(*FI);
+    expectUncoercedDirect(FI->getReturnInfo());
+  }
+
+  {
+    std::unique_ptr<FunctionInfo> FI =
+        FunctionInfo::create(llvm::CallingConv::C, BitInt7, {});
+    FI->getReturnInfo() = ArgInfo::getIgnore();
+    TI->computeInfo(*FI);
+    expectExtendInteger(FI->getReturnInfo(), BitInt7, /*IsSigned=*/true);
+  }
+  {
+    std::unique_ptr<FunctionInfo> FI =
+        FunctionInfo::create(llvm::CallingConv::C, UBitInt7, {});
+    FI->getReturnInfo() = ArgInfo::getIgnore();
+    TI->computeInfo(*FI);
+    expectExtendInteger(FI->getReturnInfo(), UBitInt7, /*IsSigned=*/false);
+  }
+
+  std::unique_ptr<FunctionInfo> FI =
+      FunctionInfo::create(llvm::CallingConv::C, BitInt129, {});
+  FI->getReturnInfo() = ArgInfo::getIgnore();
+  TI->computeInfo(*FI);
+  expectAlignedIndirect(FI->getReturnInfo(), llvm::Align(16), /*ByVal=*/true);
+}
+
 // Non-aggregate scalars, matrix types, and promotable integers take the Direct
 // return path under Win64.
 TEST_F(AArch64TargetInfoTest, ClassifyReturnScalarsDirectWin64) {
@@ -210,6 +290,60 @@ TEST_F(AArch64TargetInfoTest, ClassifyArgumentScalarsDirectAAPCSSoft) {
     TI->computeInfo(*FI);
     expectUncoercedDirect(FI->getArgInfo(0).Info);
   }
+}
+
+// _BitInt types no wider than 128 bits are passed directly under AAPCS.
+// Wider _BitInt types are passed indirectly without byval.
+TEST_F(AArch64TargetInfoTest, ClassifyArgumentBitIntAAPCS) {
+  std::unique_ptr<TargetInfo> TI =
+      createAArch64TargetInfo(TB, AArch64ABIKind::AAPCS);
+
+  for (const ABIType *ArgTy : {BitInt7, UBitInt7, BitInt65, BitInt128}) {
+    std::unique_ptr<FunctionInfo> FI =
+        FunctionInfo::create(llvm::CallingConv::C, Void, {ArgTy});
+    TI->computeInfo(*FI);
+    expectUncoercedDirect(FI->getArgInfo(0).Info);
+  }
+
+  std::unique_ptr<FunctionInfo> FI =
+      FunctionInfo::create(llvm::CallingConv::C, Void, {BitInt129});
+  TI->computeInfo(*FI);
+  expectAlignedIndirect(FI->getArgInfo(0).Info, llvm::Align(16),
+                        /*ByVal=*/false);
+}
+
+// DarwinPCS extends promotable _BitInt arguments. Other _BitInt types no
+// wider than 128 bits are passed directly. Wider _BitInt types are passed
+// indirectly without byval.
+TEST_F(AArch64TargetInfoTest, ClassifyArgumentBitIntDarwin) {
+  std::unique_ptr<TargetInfo> TI =
+      createAArch64TargetInfo(TB, AArch64ABIKind::DarwinPCS);
+
+  for (const ABIType *ArgTy : {BitInt65, BitInt128}) {
+    std::unique_ptr<FunctionInfo> FI =
+        FunctionInfo::create(llvm::CallingConv::C, Void, {ArgTy});
+    TI->computeInfo(*FI);
+    expectUncoercedDirect(FI->getArgInfo(0).Info);
+  }
+
+  {
+    std::unique_ptr<FunctionInfo> FI =
+        FunctionInfo::create(llvm::CallingConv::C, Void, {BitInt7});
+    TI->computeInfo(*FI);
+    expectExtendInteger(FI->getArgInfo(0).Info, BitInt7, /*IsSigned=*/true);
+  }
+  {
+    std::unique_ptr<FunctionInfo> FI =
+        FunctionInfo::create(llvm::CallingConv::C, Void, {UBitInt7});
+    TI->computeInfo(*FI);
+    expectExtendInteger(FI->getArgInfo(0).Info, UBitInt7, /*IsSigned=*/false);
+  }
+
+  std::unique_ptr<FunctionInfo> FI =
+      FunctionInfo::create(llvm::CallingConv::C, Void, {BitInt129});
+  TI->computeInfo(*FI);
+  expectAlignedIndirect(FI->getArgInfo(0).Info, llvm::Align(16),
+                        /*ByVal=*/false);
 }
 
 // Non-aggregate scalars, matrix types, and promotable integers take the Direct


### PR DESCRIPTION
This adds AArch64 handling in the LLVM ABI library for BitInt arguments and return values. BitInt types smaller than 128 bits are passed directly (or extended in the case of DarwinPCS), and BitInt types larger than 128 bits are passed by reference.

Assisted-by: Cursor / Grok 4.6 (test generation)