### PR TITLE
[RISCV] Use SDValue::getValueType() instead of SDNode:getValueType(0). NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -10634,7 +10634,7 @@ SDValue RISCVTargetLowering::lowerSELECT(SDValue Op, SelectionDAG &DAG) const {
       }
       if ((FalseVal - TrueVal).isPowerOf2() && TrueVal.isSignedIntN(12)) {
         SDValue Log2 = DAG.getConstant((FalseVal - TrueVal).logBase2(), DL, VT);
-        CondV = DAG.getLogicalNOT(DL, CondV, CondV->getValueType(0));
+        CondV = DAG.getLogicalNOT(DL, CondV, CondV.getValueType());
         SDValue BitDiff = DAG.getNode(ISD::SHL, DL, VT, CondV, Log2);
         return DAG.getNode(ISD::ADD, DL, VT, TrueV, BitDiff);
       }


### PR DESCRIPTION
We don't know that the condition is using result 0 so we should use the result number from the SDValue.

NFC because I don't know of a node that can get here with multiple results where result 0 would have a different type than result 1 while result 1 is a boolean value. Type legalization to XLenVT prevents this.