### PR TITLE
[NFC] Mark truncated-profile.test unsupported on zos, similar to existing tests that use printf

### DIFF
--- a/llvm/test/tools/llvm-profdata/truncated-profile.test
+++ b/llvm/test/tools/llvm-profdata/truncated-profile.test
@@ -1,3 +1,8 @@
+// On z/OS, ebcdic output from printf is converted into utf-8 as
+// the output being redirected, causing the magic bytes to be incorrect.
+// TODO: use a builtin version of printf
+UNSUPPORTED: system-zos
+
 // Magic
 RUN: printf '\201rforpl\377' > %t.profraw
 // Version (11 = 0o13)


### PR DESCRIPTION
follow up to #211281