### PR TITLE
[libc++] Use https for lnt submissions

### DIFF
--- a/.github/workflows/libcxx-benchmark-commit.yml
+++ b/.github/workflows/libcxx-benchmark-commit.yml
@@ -42,7 +42,7 @@ on:
         description: 'The URL of the LNT instance to submit to'
         required: false
         type: string
-        default: http://lnt.llvm.org
+        default: https://lnt.llvm.org
 
 jobs:
   # Determine which configuration to run based on the `lnt-machine` input.

--- a/libcxx/utils/ci/lnt/README.md
+++ b/libcxx/utils/ci/lnt/README.md
@@ -37,7 +37,7 @@ select-anchor-commits --since 2023-01-02 --every week > anchor-commits.txt
 
 # What is missing from LNT (we want at least 3 samples for each commit).
 plan-benchmarks --commit-list anchor-commits.txt                                \
-                --lnt-url http://lnt.llvm.org --test-suite libcxx               \
+                --lnt-url https://lnt.llvm.org --test-suite libcxx              \
                 --machine <machine> --samples 3 > plan.jsonl
 
 # Request the corresponding workflow runs, at most 4 at a time to be a good citizen.

--- a/libcxx/utils/ci/lnt/machines.json
+++ b/libcxx/utils/ci/lnt/machines.json
@@ -11,7 +11,7 @@
       "every": "week",
       "samples": 3,
       "max-in-flight": 4,
-      "lnt-url": "http://lnt.llvm.org"
+      "lnt-url": "https://lnt.llvm.org"
     }
   },
   {
@@ -25,7 +25,7 @@
       "every": "week",
       "samples": 3,
       "max-in-flight": 8,
-      "lnt-url": "http://lnt.llvm.org"
+      "lnt-url": "https://lnt.llvm.org"
     }
   }
 ]


### PR DESCRIPTION
Trying to submit through http doesn't work anymore, which breaks all the submission jobs.