### PR TITLE
[SPIRV] Cleanup includes in SPIRVSubtarget.h

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.h
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.h
@@ -22,7 +22,7 @@
 #include "llvm/CodeGen/GlobalISel/CallLowering.h"
 #include "llvm/CodeGen/GlobalISel/InstructionSelector.h"
 #include "llvm/CodeGen/GlobalISel/LegalizerInfo.h"
-#include "llvm/CodeGen/SelectionDAGTargetInfo.h"
+#include "llvm/CodeGen/RegisterBankInfo.h"
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/Module.h"


### PR DESCRIPTION
This makes some cleanup for NewPM porting easier for RegBankSelect.
SPIRVSubtarget currently transitively depends in RegisterBankInfo.h from
RegBankSelect.h, which we want to remove. Also remove an unused include
while at it.
