### PR TITLE
[lit] Use functools.lru_cache instead of lit.util.memoize

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import enum
+import functools
 import io
 import os
 import pathlib
@@ -1438,7 +1439,7 @@ def getDefaultSubstitutions(test, tmpDir, tmpBase, normalize_slashes=False):
     return substitutions
 
 
-@lit.util.memoize  # Intentionally unbounded: see applySubstitutions
+@functools.lru_cache(maxsize=None)  # Intentionally unbounded: see applySubstitutions
 def _caching_re_compile(r):
     return re.compile(r)
 

--- a/llvm/utils/lit/lit/util.py
+++ b/llvm/utils/lit/lit/util.py
@@ -1,4 +1,5 @@
 import errno
+import functools
 import itertools
 import math
 import numbers
@@ -460,7 +461,7 @@ def memoize(f):
     return memoized
 
 
-@memoize
+@functools.lru_cache(maxsize=None)
 def runCommandCached(lit_config, cmd, allow_failure, **kwargs):
     """
     Run a command with subprocess.run, with a cache global to this llvm-lit invocation


### PR DESCRIPTION
lit.util.memoize builds a (args, tuple(kwargs.items())) key and does two
dict lookups per call. functools.lru_cache has a faster path that uses a
single positional argument directly as the key, so it does one lookup
instead of two and skips the tuple construction.

Profiling lit with Scalene and comparing the two implementations on
test suites showed the lru_cache version is faster for
_caching_re_compile.

runCommandCached takes multiple positional and keyword arguments, so it
does not hit lru_cache's single-argument fast path, but the swap removes
one more caller of the hand-rolled memoize implementation. memoize
itself is now unused and will be removed in a follow-up.