### PR TITLE
[DWARFLinker] Simplify clang module unit bookkeeping (NFC)

### DIFF
--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.cpp
@@ -46,19 +46,6 @@ DWARFLinkerImpl::LinkContext::LinkContext(LinkingGlobalData &GlobalData,
   }
 }
 
-DWARFLinkerImpl::LinkContext::RefModuleUnit::RefModuleUnit(
-    DWARFFile &File, std::unique_ptr<CompileUnit> Unit)
-    : File(File), Unit(std::move(Unit)) {}
-
-DWARFLinkerImpl::LinkContext::RefModuleUnit::RefModuleUnit(
-    LinkContext::RefModuleUnit &&Other)
-    : File(Other.File), Unit(std::move(Other.Unit)) {}
-
-void DWARFLinkerImpl::LinkContext::addModulesCompileUnit(
-    LinkContext::RefModuleUnit &&Unit) {
-  ModulesCompileUnits.emplace_back(std::move(Unit));
-}
-
 void DWARFLinkerImpl::addObjectFile(DWARFFile &File, ObjFileLoaderTy Loader,
                                     CompileUnitHandlerTy OnCUDieLoaded) {
   ObjectContexts.emplace_back(std::make_unique<LinkContext>(
@@ -156,10 +143,10 @@ Error DWARFLinkerImpl::link() {
     // language, so they have to be part of this scan as well. A module unit
     // can be the only ODR unit of a link, and any unit which deduplicates
     // types requires the artificial type unit to exist.
-    for (const LinkContext::RefModuleUnit &Module :
+    for (const std::unique_ptr<CompileUnit> &Module :
          Context->ModulesCompileUnits) {
       if (!Language) {
-        if (std::optional<uint16_t> LangVal = Module.Unit->getLanguage())
+        if (std::optional<uint16_t> LangVal = Module->getLanguage())
           if (isODRLanguage(*LangVal))
             Language = *LangVal;
       }
@@ -223,9 +210,9 @@ Error DWARFLinkerImpl::link() {
   if (DWARFLinkerBase::SwiftInterfacesMapTy *SwiftInterfaces =
           GlobalData.Options.ParseableSwiftInterfaces) {
     for (std::unique_ptr<LinkContext> &Context : ObjectContexts) {
-      for (LinkContext::RefModuleUnit &ModuleUnit :
+      for (std::unique_ptr<CompileUnit> &ModuleUnit :
            Context->ModulesCompileUnits)
-        ModuleUnit.Unit->mergeSwiftInterfaces(*SwiftInterfaces);
+        ModuleUnit->mergeSwiftInterfaces(*SwiftInterfaces);
       for (std::unique_ptr<CompileUnit> &CU : Context->CompileUnits)
         CU->mergeSwiftInterfaces(*SwiftInterfaces);
     }
@@ -483,9 +470,9 @@ Error DWARFLinkerImpl::LinkContext::loadClangModule(
   }
 
   if (Unit) {
-    ModulesCompileUnits.emplace_back(RefModuleUnit{*ErrOrObj, std::move(Unit)});
+    ModulesCompileUnits.emplace_back(std::move(Unit));
     // Preload line table, as it can't be loaded asynchronously.
-    ModulesCompileUnits.back().Unit->loadLineTable();
+    ModulesCompileUnits.back()->loadLineTable();
   }
 
   return Error::success();
@@ -502,14 +489,18 @@ Error DWARFLinkerImpl::LinkContext::link(TypeUnit *ArtificialTypeUnit) {
 
   // Assign deterministic priorities to module CUs for type DIE allocation.
   uint64_t LocalCUIdx = 0;
-  for (auto &Mod : ModulesCompileUnits) {
-    if (Error E = Mod.Unit->setPriority(ObjectFileIdx, LocalCUIdx++))
+  for (std::unique_ptr<CompileUnit> &Mod : ModulesCompileUnits) {
+    if (Error E = Mod->setPriority(ObjectFileIdx, LocalCUIdx++))
       return E;
   }
 
   // Link modules compile units first.
-  parallelForEach(ModulesCompileUnits, [&](RefModuleUnit &RefModule) {
-    linkSingleCompileUnit(*RefModule.Unit, ArtificialTypeUnit);
+  parallelForEach(ModulesCompileUnits, [&](std::unique_ptr<CompileUnit> &Mod) {
+    // A module unit describes DIEs which no address reaches, so nothing marks
+    // it inter-connected and the inter-connected loops below, which iterate
+    // CompileUnits alone, would never advance it.
+    assert(!Mod->isInterconnectedCU() && "module unit is inter-connected");
+    linkSingleCompileUnit(*Mod, ArtificialTypeUnit);
   });
 
   // Check for live relocations. If there is no any live relocation then we
@@ -1178,9 +1169,10 @@ void DWARFLinkerImpl::forEachObjectSectionsSet(
 
   // Then all modules(before regular compilation units).
   for (const std::unique_ptr<LinkContext> &Context : ObjectContexts)
-    for (LinkContext::RefModuleUnit &ModuleUnit : Context->ModulesCompileUnits)
-      if (ModuleUnit.Unit->getStage() != CompileUnit::Stage::Skipped)
-        SectionsSetHandler(*ModuleUnit.Unit);
+    for (std::unique_ptr<CompileUnit> &ModuleUnit :
+         Context->ModulesCompileUnits)
+      if (ModuleUnit->getStage() != CompileUnit::Stage::Skipped)
+        SectionsSetHandler(*ModuleUnit);
 
   // Finally all compilation units.
   for (const std::unique_ptr<LinkContext> &Context : ObjectContexts) {
@@ -1201,9 +1193,10 @@ void DWARFLinkerImpl::forEachCompileAndTypeUnit(
 
   // Enumerate module units.
   for (const std::unique_ptr<LinkContext> &Context : ObjectContexts)
-    for (LinkContext::RefModuleUnit &ModuleUnit : Context->ModulesCompileUnits)
-      if (ModuleUnit.Unit->getStage() != CompileUnit::Stage::Skipped)
-        UnitHandler(ModuleUnit.Unit.get());
+    for (std::unique_ptr<CompileUnit> &ModuleUnit :
+         Context->ModulesCompileUnits)
+      if (ModuleUnit->getStage() != CompileUnit::Stage::Skipped)
+        UnitHandler(ModuleUnit.get());
 
   // Enumerate compile units.
   for (const std::unique_ptr<LinkContext> &Context : ObjectContexts)
@@ -1216,9 +1209,10 @@ void DWARFLinkerImpl::forEachCompileUnit(
     function_ref<void(CompileUnit *CU)> UnitHandler) {
   // Enumerate module units.
   for (const std::unique_ptr<LinkContext> &Context : ObjectContexts)
-    for (LinkContext::RefModuleUnit &ModuleUnit : Context->ModulesCompileUnits)
-      if (ModuleUnit.Unit->getStage() != CompileUnit::Stage::Skipped)
-        UnitHandler(ModuleUnit.Unit.get());
+    for (std::unique_ptr<CompileUnit> &ModuleUnit :
+         Context->ModulesCompileUnits)
+      if (ModuleUnit->getStage() != CompileUnit::Stage::Skipped)
+        UnitHandler(ModuleUnit.get());
 
   // Enumerate compile units.
   for (const std::unique_ptr<LinkContext> &Context : ObjectContexts)

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.h
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.h
@@ -158,18 +158,6 @@ protected:
   struct LinkContext : public OutputSections {
     using UnitListTy = SmallVector<std::unique_ptr<CompileUnit>>;
 
-    /// Keep information for referenced clang module: already loaded DWARF info
-    /// of the clang module and a CompileUnit of the module.
-    struct RefModuleUnit {
-      RefModuleUnit(DWARFFile &File, std::unique_ptr<CompileUnit> Unit);
-      RefModuleUnit(RefModuleUnit &&Other);
-      RefModuleUnit(const RefModuleUnit &) = delete;
-
-      DWARFFile &File;
-      std::unique_ptr<CompileUnit> Unit;
-    };
-    using ModuleUnitListTy = SmallVector<RefModuleUnit>;
-
     /// Object file descriptor.
     DWARFFile &InputDWARFFile;
 
@@ -177,7 +165,7 @@ protected:
     UnitListTy CompileUnits;
 
     /// Set of Compile Units for modules.
-    ModuleUnitListTy ModulesCompileUnits;
+    UnitListTy ModulesCompileUnits;
 
     /// Index of this object file in the link order (used for deterministic
     /// type DIE allocation).
@@ -231,9 +219,6 @@ protected:
                           const std::string &PCMFile,
                           CompileUnitHandlerTy OnCUDieLoaded,
                           unsigned Indent = 0);
-
-    /// Add Compile Unit corresponding to the module.
-    void addModulesCompileUnit(RefModuleUnit &&Unit);
 
     /// Computes the total size of the debug info.
     uint64_t getInputDebugInfoSize() const {
@@ -406,9 +391,9 @@ protected:
   /// Unique ID for compile unit.
   std::atomic<size_t> UniqueUnitID;
 
-  /// Mapping the PCM filename to the DwoId.
+  /// Mapping the PCM filename to the DwoId. Only ever touched from
+  /// addObjectFile(), which runs serially, so it needs no synchronization.
   StringMap<uint64_t> ClangModules;
-  std::mutex ClangModulesMutex;
 
   /// Type unit.
   std::unique_ptr<TypeUnit> ArtificialTypeUnit;


### PR DESCRIPTION
RefModuleUnit paired a DWARFFile reference with a CompileUnit, but the reference was never read and duplicates CompileUnit::getContaingFile(), so ModulesCompileUnits becomes a plain UnitListTy. Its addModulesCompileUnit() accessor has no callers, and DWARFLinkerImpl::ClangModulesMutex is declared but never locked, which is correct because addObjectFile() is the only writer of ClangModules and runs serially. Document that instead.

Assert that no module unit is inter-connected. The inter-connected loops in LinkContext::link iterate CompileUnits alone, so a module unit which got marked would strand at Stage::Loaded and never be cloned, with the gate at the top of linkSingleCompileUnit hiding it.

Assisted-by: Claude