### PR TITLE
Check stack are register context in ThreadPlanCallFunction::DoTakedown

### DIFF
--- a/lldb/source/Target/ThreadPlanCallFunction.cpp
+++ b/lldb/source/Target/ThreadPlanCallFunction.cpp
@@ -207,7 +207,7 @@ void ThreadPlanCallFunction::DoTakedown(bool success) {
     m_takedown_done = true;
     RegisterContextSP reg_ctx_sp = thread.GetRegisterContext();
     if (reg_ctx_sp)
-      m_stop_address = thread.GetRegisterContext()->GetPC();
+      m_stop_address = reg_ctx_sp->GetPC();
     else
       m_stop_address = LLDB_INVALID_ADDRESS;
 

--- a/lldb/source/Target/ThreadPlanCallFunction.cpp
+++ b/lldb/source/Target/ThreadPlanCallFunction.cpp
@@ -205,8 +205,12 @@ void ThreadPlanCallFunction::DoTakedown(bool success) {
               "0x%4.4" PRIx64 ", m_valid: %d complete: %d.\n",
               static_cast<void *>(this), m_tid, m_valid, IsPlanComplete());
     m_takedown_done = true;
-    m_stop_address =
-        thread.GetStackFrameAtIndex(0)->GetRegisterContext()->GetPC();
+    RegisterContextSP reg_ctx_sp = thread.GetRegisterContext();
+    if (reg_ctx_sp)
+      m_stop_address = thread.GetRegisterContext()->GetPC();
+    else
+      m_stop_address = LLDB_INVALID_ADDRESS;
+
     m_real_stop_info_sp = GetPrivateStopInfo();
     if (!thread.RestoreRegisterStateFromCheckpoint(m_stored_thread_state)) {
       LLDB_LOGF(log,


### PR DESCRIPTION
I get a couple of crashes a year in ThreadPlanCallFunction::DoTakedown on the line where we get the PC from the thread.  It looks like the RegisterContext (or maybe GetStackFrameAtIndex(0)) are returning null.

The crashes are when the UI calls UnwindInnermostFrame so I know that thread has to be valid.  So the only possibilities I can think of are that we couldn't reconstruct the stack frame at index 0 or its register context.  I don't know how that would happen, but there's no harm in being more careful accessing the register context.