### PR TITLE
[RISCV][NFC] Rename create*LegacyPass functions

### DIFF
--- a/llvm/lib/Target/RISCV/RISCV.h
+++ b/llvm/lib/Target/RISCV/RISCV.h
@@ -48,8 +48,8 @@ void initializeRISCVIndirectBranchTrackingPass(PassRegistry &);
 FunctionPass *createRISCVLandingPadSetupPass();
 void initializeRISCVLandingPadSetupPass(PassRegistry &);
 
-FunctionPass *createRISCVISelDag(RISCVTargetMachine &TM,
-                                 CodeGenOptLevel OptLevel);
+FunctionPass *createRISCVISelDagLegacyPass(RISCVTargetMachine &TM,
+                                           CodeGenOptLevel OptLevel);
 
 class RISCVISelDAGToDAGPass : public SelectionDAGISelPass {
 public:
@@ -118,7 +118,7 @@ public:
   RISCVZacasABIFixPass(const RISCVTargetMachine *TM) : TM(TM) {}
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
 };
-FunctionPass *createRISCVZacasABIFixPass();
+FunctionPass *createRISCVZacasABIFixLegacyPass();
 void initializeRISCVZacasABIFixLegacyPass(PassRegistry &);
 
 InstructionSelector *

--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -5099,8 +5099,8 @@ bool RISCVDAGToDAGISel::doPeepholeNoRegPassThru() {
 
 // This pass converts a legalized DAG into a RISCV-specific DAG, ready
 // for instruction scheduling.
-FunctionPass *llvm::createRISCVISelDag(RISCVTargetMachine &TM,
-                                       CodeGenOptLevel OptLevel) {
+FunctionPass *llvm::createRISCVISelDagLegacyPass(RISCVTargetMachine &TM,
+                                                 CodeGenOptLevel OptLevel) {
   return new RISCVDAGToDAGISelLegacy(TM, OptLevel);
 }
 

--- a/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
@@ -468,7 +468,7 @@ bool RISCVPassConfig::addRegAssignAndRewriteOptimized() {
 
 void RISCVPassConfig::addIRPasses() {
   addPass(createAtomicExpandLegacyPass());
-  addPass(createRISCVZacasABIFixPass());
+  addPass(createRISCVZacasABIFixLegacyPass());
 
   if (getOptLevel() != CodeGenOptLevel::None) {
     if (EnableLoopDataPrefetch)
@@ -517,7 +517,7 @@ void RISCVPassConfig::addCodeGenPrepare() {
 }
 
 bool RISCVPassConfig::addInstSelector() {
-  addPass(createRISCVISelDag(getRISCVTargetMachine(), getOptLevel()));
+  addPass(createRISCVISelDagLegacyPass(getRISCVTargetMachine(), getOptLevel()));
 
   return false;
 }

--- a/llvm/lib/Target/RISCV/RISCVZacasABIFix.cpp
+++ b/llvm/lib/Target/RISCV/RISCVZacasABIFix.cpp
@@ -101,7 +101,7 @@ INITIALIZE_PASS_END(RISCVZacasABIFixLegacy, DEBUG_TYPE, PASS_NAME, false, false)
 
 char RISCVZacasABIFixLegacy::ID = 0;
 
-FunctionPass *llvm::createRISCVZacasABIFixPass() {
+FunctionPass *llvm::createRISCVZacasABIFixLegacyPass() {
   return new RISCVZacasABIFixLegacy();
 }
 


### PR DESCRIPTION
This is to clarify which functions are creating legacy passes rather than NewPM passes.