### PR TITLE
[libc++] Pin down macOS 26.5 and arm64 in the LNT machines

### DIFF
--- a/libcxx/utils/ci/lnt/machines.json
+++ b/libcxx/utils/ci/lnt/machines.json
@@ -1,7 +1,7 @@
 [
   {
     "lnt-machine": "macos-26.5-arm64-20260812",
-    "runner": ["self-hosted", "macOS", "apple-runners"],
+    "runner": ["self-hosted", "macOS", "26.5", "ARM64", "apple-runners"],
     "cxx": "clang++",
     "running-on": "macos",
     "xcode-version": "26.5",


### PR DESCRIPTION
Matching the exact OS version and architecture is obviously important to get results that can be compared from commit to commit. Hence, pin down the OS version. This became necessary since some macOS 26.5.2 runners have been introduced in the pool, and LNT submissions would fail (which is good) when the OS version was mismatched.