### PR TITLE
[JITLink] Skip SHF_COMPRESSED sections when building the ELF link graph

### DIFF
--- a/llvm/lib/ExecutionEngine/JITLink/ELFLinkGraphBuilder.h
+++ b/llvm/lib/ExecutionEngine/JITLink/ELFLinkGraphBuilder.h
@@ -349,6 +349,19 @@ template <typename ELFT> Error ELFLinkGraphBuilder<ELFT>::graphifySections() {
       continue;
     }
 
+    // Skip compressed sections: JITLink does not support them. The section
+    // content is compressed, while relocation offsets refer to the
+    // uncompressed data, so relocations cannot be applied to the block
+    // content.
+    if (Sec.sh_flags & ELF::SHF_COMPRESSED) {
+      LLVM_DEBUG({
+        dbgs() << "    " << SecIndex << ": \"" << *Name
+               << "\" is compressed: "
+                  "No graph section will be created.\n";
+      });
+      continue;
+    }
+
     LLVM_DEBUG({
       dbgs() << "    " << SecIndex << ": Creating section for \"" << *Name
              << "\"\n";
@@ -620,6 +633,10 @@ Error ELFLinkGraphBuilder<ELFT>::forEachRelaRelocation(
     LLVM_DEBUG(dbgs() << "    skipped (fixup section excluded explicitly)\n\n");
     return Error::success();
   }
+  if ((*FixupSection)->sh_flags & ELF::SHF_COMPRESSED) {
+    LLVM_DEBUG(dbgs() << "    skipped (compressed fixup section)\n\n");
+    return Error::success();
+  }
 
   // Lookup the link-graph node corresponding to the target section name.
   auto *BlockToFix = getGraphBlock(RelSect.sh_info);
@@ -668,6 +685,10 @@ Error ELFLinkGraphBuilder<ELFT>::forEachRelRelocation(
   }
   if (excludeSection(**FixupSection)) {
     LLVM_DEBUG(dbgs() << "    skipped (fixup section excluded explicitly)\n\n");
+    return Error::success();
+  }
+  if ((*FixupSection)->sh_flags & ELF::SHF_COMPRESSED) {
+    LLVM_DEBUG(dbgs() << "    skipped (compressed fixup section)\n\n");
     return Error::success();
   }
 

--- a/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_compressed_debug_sections.yaml
+++ b/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_compressed_debug_sections.yaml
@@ -1,0 +1,74 @@
+# REQUIRES: asserts
+# RUN: yaml2obj -o %t.o %s
+# RUN: llvm-jitlink -num-threads=0 -debug-only=jitlink -noexec %t.o 2>&1 \
+# RUN:              | FileCheck %s
+#
+# Check that SHF_COMPRESSED sections are skipped when building the link
+# graph. JITLink does not support compressed sections: the section content
+# stored in the file is compressed, while relocation offsets refer to the
+# uncompressed data. Applying such relocations to a block built from the
+# compressed content would write out of bounds.
+
+# CHECK: ".debug_addr" is compressed: No graph section will be created.
+# CHECK: .debug_addr:
+# CHECK-NEXT: skipped (compressed fixup section)
+
+---
+!ELF
+FileHeader:
+  Class: ELFCLASS64
+  Data: ELFDATA2LSB
+  Type: ET_REL
+  Machine: EM_X86_64
+  SectionHeaderStringTable: .strtab
+Sections:
+  - Name: .text
+    Type: SHT_PROGBITS
+    Flags: [SHF_ALLOC, SHF_EXECINSTR]
+    AddressAlign: 0x10
+    Content: C3662E0F1F84000000000090
+  - Name: .debug_addr
+    Type: SHT_PROGBITS
+    Flags: [SHF_COMPRESSED]
+    AddressAlign: 0x1
+    # Elf_Chdr header followed by (fake) compressed payload. The file-level
+    # content of a compressed section is only 0x1A bytes, while relocations
+    # into it refer to offsets in the uncompressed data.
+    Content: 04000000000000000800000000000000010000000000000078563412
+  - Name: .rela.debug_addr
+    Type: SHT_RELA
+    Flags: [SHF_INFO_LINK]
+    Link: .symtab
+    AddressAlign: 0x8
+    Info: .debug_addr
+    Relocations:
+      - Offset: 0x40
+        Symbol: foo
+        Type: R_X86_64_64
+  - Name: .note.GNU-stack
+    Type: SHT_PROGBITS
+    AddressAlign: 0x1
+  - Type: SectionHeaderTable
+    Sections:
+      - Name: .strtab
+      - Name: .text
+      - Name: .debug_addr
+      - Name: .rela.debug_addr
+      - Name: .note.GNU-stack
+      - Name: .symtab
+Symbols:
+  - Name: .text
+    Type: STT_SECTION
+    Section: .text
+  - Name: foo
+    Type: STT_FUNC
+    Section: .text
+    Binding: STB_GLOBAL
+    Size: 0x6
+  - Name: main
+    Type: STT_FUNC
+    Section: .text
+    Binding: STB_GLOBAL
+    Value: 0x6
+    Size: 0x6
+...


### PR DESCRIPTION
JITLink does not support SHF_COMPRESSED sections: the bytes stored in the file are the compressed payload, while relocation offsets refer to the uncompressed data. Creating a graph block from the compressed content and applying such relocations writes out of bounds of the block, corrupting the heap.

Skip SHF_COMPRESSED sections when creating the link graph, and ignore relocations whose fixup section is compressed, mirroring the existing handling of debug sections.

Assisted-by: DeepSeek v4 Flash