### PR TITLE
AMDGPU: Deprecate getArchAttrAMDGCN

### DIFF
--- a/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
+++ b/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
@@ -161,7 +161,11 @@ LLVM_ABI StringRef getCanonicalArchName(const Triple &T, StringRef Arch);
 LLVM_ABI GPUKind parseArchAMDGCN(StringRef CPU);
 LLVM_ABI GPUKind parseArchR600(StringRef CPU);
 LLVM_ABI GPUKind getGPUKindFromSubArch(Triple::SubArchType SubArch);
+/// \deprecated Use getFeatureBitset and test the relevant FEAT_* bits instead.
+/// The legacy ArchFeatureKind bitfield is being removed.
+LLVM_DEPRECATED("use getFeatureBitset instead", "getFeatureBitset")
 LLVM_ABI unsigned getArchAttrAMDGCN(GPUKind AK);
+LLVM_DEPRECATED("use getFeatureBitset instead", "getFeatureBitset")
 LLVM_ABI unsigned getArchAttrAMDGCN(Triple::SubArchType SubArch);
 LLVM_ABI R600FeatureKind getArchAttrR600(GPUKind AK);
 

--- a/llvm/lib/Target/AMDGPU/AMDGPU.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.td
@@ -3132,7 +3132,8 @@ def AMDGPUFrontendVisibleFeatures {
   FeatureWMMA256bInsts, FeatureWMMAN16Insts, FeatureXF32Insts,
   FeatureWavefrontSize32, FeatureWavefrontSize64, FeatureSupportsWGP,
   FeatureSupportsWave32, FeatureFastFMAF32, FeatureFastDenormalF32,
-  FeatureSupportsXNACK, FeatureSupportsSRAMECC, FeatureXNACKOnOffModes
+  FeatureSupportsXNACK, FeatureSupportsSRAMECC, FeatureXNACKOnOffModes,
+  FeatureSGPRInitBug
   ];
 }
 

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -310,7 +310,8 @@ unsigned AMDGPU::getArchAttrAMDGCN(GPUKind AK) {
 }
 
 unsigned AMDGPU::getArchAttrAMDGCN(Triple::SubArchType SubArch) {
-  return getArchAttrAMDGCN(getGPUKindFromSubArch(SubArch));
+  const GPUInfo *Info = getAMDGPUInfo(getGPUKindFromSubArch(SubArch));
+  return Info ? Info->ArchFeatures : FEATURE_NONE;
 }
 
 R600FeatureKind AMDGPU::getArchAttrR600(GPUKind AK) {

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -381,7 +381,7 @@ unsigned AMDGPU::getTotalNumSGPRs(Triple::SubArchType SubArch) {
 }
 
 unsigned AMDGPU::getAddressableNumSGPRs(GPUKind AK) {
-  if (getArchAttrAMDGCN(AK) & FEATURE_SGPR_INIT_BUG)
+  if (getFeatureBitset(AK).test(FEAT_SGPR_INIT_BUG))
     return FIXED_NUM_SGPRS_FOR_INIT_BUG;
 
   IsaVersion Version = getIsaVersion(getSubArch(AK));
@@ -393,7 +393,7 @@ unsigned AMDGPU::getAddressableNumSGPRs(GPUKind AK) {
 }
 
 unsigned AMDGPU::getAddressableNumSGPRs(Triple::SubArchType SubArch) {
-  if (getArchAttrAMDGCN(SubArch) & FEATURE_SGPR_INIT_BUG)
+  if (getFeatureBitset(getGPUKindFromSubArch(SubArch)).test(FEAT_SGPR_INIT_BUG))
     return FIXED_NUM_SGPRS_FOR_INIT_BUG;
 
   IsaVersion Version = getIsaVersion(SubArch);
@@ -606,12 +606,13 @@ static GPUKind getGPUKindFromTargetID(const Triple &TT, StringRef TargetIDStr) {
 static bool computeTargetIDFeatures(GPUKind Arch, StringRef TargetIDStr,
                                     TargetIDSetting &XnackSetting,
                                     TargetIDSetting &SramEccSetting) {
-  unsigned ArchAttr = getArchAttrAMDGCN(Arch);
-  XnackSetting = (ArchAttr & FEATURE_XNACK_ON_OFF_MODES)
+  const AMDGPUFeatureBitset &Features = getFeatureBitset(Arch);
+  XnackSetting = Features.test(FEAT_XNACK_ON_OFF_MODES)
                      ? TargetIDSetting::Any
                      : TargetIDSetting::Unsupported;
-  SramEccSetting = (ArchAttr & FEATURE_SRAMECC) ? TargetIDSetting::Any
-                                                : TargetIDSetting::Unsupported;
+  SramEccSetting = Features.test(FEAT_SRAMECC_SUPPORT)
+                       ? TargetIDSetting::Any
+                       : TargetIDSetting::Unsupported;
 
   // The first component is the processor; the rest are feature modifiers of the
   // form "<feature><+|->".

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -2798,6 +2798,10 @@ TEST(TargetParserTest, testAMDGPUgetFeatureBitset) {
   EXPECT_TRUE(GFX900.test(AMDGPU::FEAT_WAVEFRONTSIZE64));
   EXPECT_FALSE(GFX900.test(AMDGPU::FEAT_WAVEFRONTSIZE32));
 
+  EXPECT_TRUE(AMDGPU::getFeatureBitset(AMDGPU::GK_GFX802)
+                  .test(AMDGPU::FEAT_SGPR_INIT_BUG));
+  EXPECT_FALSE(GFX900.test(AMDGPU::FEAT_SGPR_INIT_BUG));
+
   // An unknown kind yields an empty bitset.
   EXPECT_EQ(AMDGPU::getFeatureBitset(AMDGPU::GK_NONE).count(), 0u);
 


### PR DESCRIPTION
The legacy ArchFeatureKind bitfield returned by getArchAttrAMDGCN is being
replaced by getFeatureBitset (FEAT_* bits). All in-tree callers have been
migrated, so mark both overloads LLVM_DEPRECATED to steer out of tree code
to the bitset API before the accessor is removed.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>