### PR TITLE
[lit] Remove unused lit.util.memoize

### DIFF
--- a/llvm/utils/lit/lit/util.py
+++ b/llvm/utils/lit/lit/util.py
@@ -451,21 +451,6 @@ def killProcessAndChildren(pid):
             pass
 
 
-def memoize(f):
-    cache = {}  # Unbounded
-
-    def make_key(args, kwargs):
-        return args, tuple(kwargs.items())
-
-    def memoized(*args, **kwargs):
-        key = make_key(args, kwargs)
-        if key not in cache:
-            cache[key] = f(*args, **kwargs)
-        return cache[key]
-
-    return memoized
-
-
 @functools.lru_cache(maxsize=None)
 def runCommandCached(lit_config, cmd, allow_failure, **kwargs):
     """


### PR DESCRIPTION
Both callers of memoize (_caching_re_compile in TestRunner.py,
runCommandCached in util.py) were switched to functools.lru_cache.
memoize has no remaining callers, so this removes it.

Depends on #217757