### PR TITLE
[M68k] Fix build after RegBankSelect rename

### DIFF
--- a/llvm/lib/Target/M68k/M68kTargetMachine.cpp
+++ b/llvm/lib/Target/M68k/M68kTargetMachine.cpp
@@ -154,7 +154,7 @@ bool M68kPassConfig::addLegalizeMachineIR() {
 }
 
 bool M68kPassConfig::addRegBankSelect() {
-  addPass(new RegBankSelect());
+  addPass(new RegBankSelectLegacy());
   return false;
 }
 


### PR DESCRIPTION
Broken by 732d8413c69b57a10de1beb1964a57a9264b23b9.

Fixes https://lab.llvm.org/buildbot/#/builders/27/builds/3872.