### PR TITLE
[LLVMABI] Align RecordType::isEmpty() with Clang's isEmptyRecord()

### DIFF
--- a/clang/lib/CodeGen/QualTypeMapper.cpp
+++ b/clang/lib/CodeGen/QualTypeMapper.cpp
@@ -388,25 +388,32 @@ QualTypeMapper::convertCXXRecordType(const CXXRecordDecl *RD) {
   SmallVector<llvm::abi::FieldInfo, 16> Fields;
   SmallVector<llvm::abi::FieldInfo, 8> BaseClasses;
   SmallVector<llvm::abi::FieldInfo, 8> VirtualBaseClasses;
+  SmallVector<llvm::abi::FieldInfo, 4> DirectVirtualBaseClasses;
 
   // Add vtable pointer for polymorphic classes
   if (RD->isPolymorphic()) {
     const llvm::abi::Type *VtablePointer =
         createPointerTypeForPointee(ASTCtx.VoidPtrTy);
-    Fields.emplace_back(VtablePointer, 0);
+    Fields.emplace_back(VtablePointer, 0, /*IsBitField=*/false,
+                        /*BitFieldWidth=*/0, /*IsUnnamedBitField=*/false,
+                        /*HasNoUniqueAddress=*/false,
+                        /*IsVTablePointer=*/true);
   }
 
   for (const auto &Base : RD->bases()) {
-    if (Base.isVirtual())
-      continue;
-
     const RecordType *BaseRT = Base.getType()->castAs<RecordType>();
-    const llvm::abi::Type *BaseType = convertType(Base.getType());
-    uint64_t BaseOffset =
-        Layout.getBaseClassOffset(BaseRT->getAsCXXRecordDecl()).getQuantity() *
-        8;
-
-    BaseClasses.emplace_back(BaseType, BaseOffset);
+    const CXXRecordDecl *BaseDecl = BaseRT->getAsCXXRecordDecl();
+    if (Base.isVirtual()) {
+      const llvm::abi::Type *BaseType = convertType(Base.getType());
+      uint64_t BaseOffset =
+          Layout.getVBaseClassOffset(BaseDecl).getQuantity() * 8;
+      DirectVirtualBaseClasses.emplace_back(BaseType, BaseOffset);
+    } else {
+      const llvm::abi::Type *BaseType = convertType(Base.getType());
+      uint64_t BaseOffset =
+          Layout.getBaseClassOffset(BaseDecl).getQuantity() * 8;
+      BaseClasses.emplace_back(BaseType, BaseOffset);
+    }
   }
 
   for (const auto &VBase : RD->vbases()) {
@@ -439,9 +446,9 @@ QualTypeMapper::convertCXXRecordType(const CXXRecordDecl *RD) {
   if (RD->hasFlexibleArrayMember())
     RecFlags |= llvm::abi::RecordFlags::HasFlexibleArrayMember;
 
-  return Builder.getRecordType(Fields, Size, Alignment,
-                               llvm::abi::StructPacking::Default, BaseClasses,
-                               VirtualBaseClasses, RecFlags);
+  return Builder.getRecordType(
+      Fields, Size, Alignment, llvm::abi::StructPacking::Default, BaseClasses,
+      VirtualBaseClasses, RecFlags, DirectVirtualBaseClasses);
 }
 
 /// Converts enumeration types to their underlying integer representations.
@@ -568,8 +575,9 @@ void QualTypeMapper::computeFieldInfo(
       IsUnnamedBitField = FD->isUnnamedBitField();
     }
 
+    bool HasNoUniqueAddress = FD->hasAttr<NoUniqueAddressAttr>();
     Fields.emplace_back(FieldType, OffsetInBits, IsBitField, BitFieldWidth,
-                        IsUnnamedBitField);
+                        IsUnnamedBitField, HasNoUniqueAddress);
     ++FieldIndex;
   }
 }

--- a/clang/test/CodeGen/X86/x86_64-empty-cxx-member-abi.cpp
+++ b/clang/test/CodeGen/X86/x86_64-empty-cxx-member-abi.cpp
@@ -1,0 +1,35 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -emit-llvm -fexperimental-abi-lowering %s -o - | FileCheck %s
+
+typedef float V4F __attribute__((vector_size(16)));
+
+struct Empty {};
+
+extern "C" {
+
+union VecAndEmpty {
+  V4F v;
+  Empty e;
+};
+
+void take_vec_and_empty(union VecAndEmpty u);
+void call_vec_and_empty(union VecAndEmpty u) { take_vec_and_empty(u); }
+// CHECK-DAG: declare void @take_vec_and_empty(<2 x double>)
+
+union VecAndEmpty ret_vec_and_empty(void);
+void call_ret_vec_and_empty(void) { ret_vec_and_empty(); }
+// CHECK-DAG: declare <2 x double> @ret_vec_and_empty()
+
+struct VecNoUniqueAddress {
+  V4F v;
+  [[no_unique_address]] Empty e;
+};
+
+void take_vec_nua(VecNoUniqueAddress s);
+void call_vec_nua(VecNoUniqueAddress s) { take_vec_nua(s); }
+// CHECK-DAG: declare void @take_vec_nua(<4 x float>)
+
+VecNoUniqueAddress ret_vec_nua(void);
+void call_ret_vec_nua(void) { ret_vec_nua(); }
+// CHECK-DAG: declare <4 x float> @ret_vec_nua()
+}

--- a/llvm/include/llvm/ABI/Types.h
+++ b/llvm/include/llvm/ABI/Types.h
@@ -237,13 +237,18 @@ struct FieldInfo {
   uint64_t BitFieldWidth;
   bool IsBitField;
   bool IsUnnamedBitfield;
+  bool HasNoUniqueAddress;
+  bool IsVTablePointer;
 
   FieldInfo(const Type *FieldType, uint64_t OffsetInBits = 0,
             bool IsBitField = false, uint64_t BitFieldWidth = 0,
-            bool IsUnnamedBitField = false)
+            bool IsUnnamedBitField = false, bool HasNoUniqueAddress = false,
+            bool IsVTablePointer = false)
       : FieldType(FieldType), OffsetInBits(OffsetInBits),
         BitFieldWidth(BitFieldWidth), IsBitField(IsBitField),
-        IsUnnamedBitfield(IsUnnamedBitField) {}
+        IsUnnamedBitfield(IsUnnamedBitField),
+        HasNoUniqueAddress(HasNoUniqueAddress),
+        IsVTablePointer(IsVTablePointer) {}
 
   LLVM_ABI bool isEmpty() const;
 };
@@ -266,17 +271,20 @@ private:
   ArrayRef<FieldInfo> Fields;
   ArrayRef<FieldInfo> BaseClasses;
   ArrayRef<FieldInfo> VirtualBaseClasses;
+  ArrayRef<FieldInfo> DirectVirtualBaseClasses;
   StructPacking Packing;
   RecordFlags Flags;
 
 public:
   RecordType(ArrayRef<FieldInfo> StructFields, ArrayRef<FieldInfo> Bases,
-             ArrayRef<FieldInfo> VBases, TypeSize Size, Align Align,
+             ArrayRef<FieldInfo> VBases, ArrayRef<FieldInfo> DirectVBases,
+             TypeSize Size, Align Align,
              StructPacking Pack = StructPacking::Default,
              RecordFlags RecFlags = RecordFlags::None)
       : Type(TypeKind::Record, Size, Align), Fields(StructFields),
-        BaseClasses(Bases), VirtualBaseClasses(VBases), Packing(Pack),
-        Flags(RecFlags) {}
+        BaseClasses(Bases), VirtualBaseClasses(VBases),
+        DirectVirtualBaseClasses(DirectVBases), Packing(Pack), Flags(RecFlags) {
+  }
   uint32_t getNumFields() const { return Fields.size(); }
   StructPacking getPacking() const { return Packing; }
 
@@ -300,6 +308,9 @@ public:
   uint32_t getNumVirtualBaseClasses() const {
     return VirtualBaseClasses.size();
   }
+  uint32_t getNumDirectVirtualBaseClasses() const {
+    return DirectVirtualBaseClasses.size();
+  }
   bool isTransparentUnion() const {
     return static_cast<unsigned>(Flags & RecordFlags::IsTransparent) != 0;
   }
@@ -307,6 +318,9 @@ public:
   ArrayRef<FieldInfo> getBaseClasses() const { return BaseClasses; }
   ArrayRef<FieldInfo> getVirtualBaseClasses() const {
     return VirtualBaseClasses;
+  }
+  ArrayRef<FieldInfo> getDirectVirtualBaseClasses() const {
+    return DirectVirtualBaseClasses;
   }
 
   LLVM_ABI bool isEmpty() const;
@@ -372,12 +386,13 @@ public:
         VectorType(ElementType, NumElements, Align);
   }
 
-  const RecordType *getRecordType(ArrayRef<FieldInfo> Fields, TypeSize Size,
-                                  Align Align,
-                                  StructPacking Pack = StructPacking::Default,
-                                  ArrayRef<FieldInfo> BaseClasses = {},
-                                  ArrayRef<FieldInfo> VirtualBaseClasses = {},
-                                  RecordFlags RecFlags = RecordFlags::None) {
+  const RecordType *
+  getRecordType(ArrayRef<FieldInfo> Fields, TypeSize Size, Align Align,
+                StructPacking Pack = StructPacking::Default,
+                ArrayRef<FieldInfo> BaseClasses = {},
+                ArrayRef<FieldInfo> VirtualBaseClasses = {},
+                RecordFlags RecFlags = RecordFlags::None,
+                ArrayRef<FieldInfo> DirectVirtualBaseClasses = {}) {
     FieldInfo *FieldArray = Allocator.Allocate<FieldInfo>(Fields.size());
     std::copy(Fields.begin(), Fields.end(), FieldArray);
 
@@ -394,12 +409,23 @@ public:
                 VBaseArray);
     }
 
+    FieldInfo *DirectVBaseArray = nullptr;
+    if (!DirectVirtualBaseClasses.empty()) {
+      DirectVBaseArray =
+          Allocator.Allocate<FieldInfo>(DirectVirtualBaseClasses.size());
+      std::copy(DirectVirtualBaseClasses.begin(),
+                DirectVirtualBaseClasses.end(), DirectVBaseArray);
+    }
+
     ArrayRef<FieldInfo> FieldsRef(FieldArray, Fields.size());
     ArrayRef<FieldInfo> BasesRef(BaseArray, BaseClasses.size());
     ArrayRef<FieldInfo> VBasesRef(VBaseArray, VirtualBaseClasses.size());
+    ArrayRef<FieldInfo> DirectVBasesRef(DirectVBaseArray,
+                                        DirectVirtualBaseClasses.size());
 
     return new (Allocator.Allocate<RecordType>())
-        RecordType(FieldsRef, BasesRef, VBasesRef, Size, Align, Pack, RecFlags);
+        RecordType(FieldsRef, BasesRef, VBasesRef, DirectVBasesRef, Size, Align,
+                   Pack, RecFlags);
   }
 
   const RecordType *getUnionType(ArrayRef<FieldInfo> Fields, TypeSize Size,
@@ -409,17 +435,17 @@ public:
     FieldInfo *FieldArray = Allocator.Allocate<FieldInfo>(Fields.size());
 
     for (size_t I = 0, E = Fields.size(); I != E; ++I) {
-      const FieldInfo &Field = Fields[I];
-      new (&FieldArray[I])
-          FieldInfo(Field.FieldType, 0, Field.IsBitField, Field.BitFieldWidth,
-                    Field.IsUnnamedBitfield);
+      FieldInfo Field = Fields[I];
+      Field.OffsetInBits = 0;
+      new (&FieldArray[I]) FieldInfo(Field);
     }
 
     ArrayRef<FieldInfo> FieldsRef(FieldArray, Fields.size());
 
     return new (Allocator.Allocate<RecordType>())
         RecordType(FieldsRef, ArrayRef<FieldInfo>(), ArrayRef<FieldInfo>(),
-                   Size, Align, Pack, RecFlags | RecordFlags::IsUnion);
+                   ArrayRef<FieldInfo>(), Size, Align, Pack,
+                   RecFlags | RecordFlags::IsUnion);
   }
 
   const ComplexType *getComplexType(const Type *ElementType, Align Align) {

--- a/llvm/lib/ABI/Types.cpp
+++ b/llvm/lib/ABI/Types.cpp
@@ -13,17 +13,26 @@ using namespace llvm;
 using namespace llvm::abi;
 
 bool RecordType::isEmpty() const {
-  if (hasFlexibleArrayMember() || isPolymorphic() ||
-      getNumVirtualBaseClasses() != 0)
+  if (hasFlexibleArrayMember())
     return false;
 
-  for (const FieldInfo &Base : getBaseClasses()) {
+  auto BaseIsEmpty = [](const FieldInfo &Base) {
     const auto *BaseRT = dyn_cast<RecordType>(Base.FieldType);
-    if (!BaseRT || !BaseRT->isEmpty())
+    return BaseRT && BaseRT->isEmpty();
+  };
+
+  // Direct virtual bases are not included in the base class list.
+  for (const FieldInfo &Base : getBaseClasses())
+    if (!BaseIsEmpty(Base))
       return false;
-  }
+  for (const FieldInfo &Base : getDirectVirtualBaseClasses())
+    if (!BaseIsEmpty(Base))
+      return false;
 
   for (const FieldInfo &FI : getFields()) {
+    // Don't treat vtable pointers as a source field for emptiness.
+    if (FI.IsVTablePointer)
+      continue;
     if (!FI.isEmpty())
       return false;
   }
@@ -63,18 +72,25 @@ RecordType::getElementContainingOffset(unsigned OffsetInBits) const {
 bool FieldInfo::isEmpty() const {
   if (IsUnnamedBitfield)
     return true;
-  if (IsBitField && BitFieldWidth == 0)
-    return true;
 
   const Type *Ty = FieldType;
+  bool WasArray = false;
   while (const auto *AT = dyn_cast<ArrayType>(Ty)) {
-    if (AT->getNumElements() != 1)
-      break;
+    // Constant arrays of zero length always count as empty.
+    if (AT->getNumElements() == 0)
+      return true;
     Ty = AT->getElementType();
+    WasArray = true;
   }
 
-  if (const auto *RT = dyn_cast<RecordType>(Ty))
-    return RT->isEmpty();
+  const auto *RT = dyn_cast<RecordType>(Ty);
+  if (!RT)
+    return false;
 
-  return Ty->isZeroSize();
+  // C++ record fields are never empty unless [[no_unique_address]] applies.
+  // That exception does not apply to arrays of C++ empty records.
+  if (RT->isCXXRecord() && (WasArray || !HasNoUniqueAddress))
+    return false;
+
+  return RT->isEmpty();
 }

--- a/llvm/unittests/ABI/CMakeLists.txt
+++ b/llvm/unittests/ABI/CMakeLists.txt
@@ -6,4 +6,5 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_unittest(ABITests
   AArch64TargetInfoTest.cpp
+  TypesTest.cpp
   )

--- a/llvm/unittests/ABI/TypesTest.cpp
+++ b/llvm/unittests/ABI/TypesTest.cpp
@@ -1,0 +1,125 @@
+//===- TypesTest.cpp - ABI type emptiness unit tests ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ABI/Types.h"
+#include "llvm/Support/Alignment.h"
+#include "llvm/Support/Allocator.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/TypeSize.h"
+#include "gtest/gtest.h"
+
+using llvm::Align;
+using llvm::TypeSize;
+using llvm::abi::FieldInfo;
+using llvm::abi::RecordFlags;
+using llvm::abi::RecordType;
+using llvm::abi::StructPacking;
+using llvm::abi::TypeBuilder;
+
+namespace {
+
+class ABITypesTest : public ::testing::Test {
+protected:
+  llvm::BumpPtrAllocator Alloc;
+  TypeBuilder TB;
+
+  ABITypesTest() : TB(Alloc) {}
+
+  const RecordType *makeRecord(llvm::ArrayRef<FieldInfo> Fields,
+                               uint64_t SizeBits, RecordFlags Flags,
+                               llvm::ArrayRef<FieldInfo> Bases = {},
+                               llvm::ArrayRef<FieldInfo> DirectVBases = {}) {
+    return TB.getRecordType(Fields, TypeSize::getFixed(SizeBits), Align(1),
+                            StructPacking::Default, Bases, /*VBases=*/{}, Flags,
+                            DirectVBases);
+  }
+};
+
+TEST_F(ABITypesTest, EmptyCRecord) {
+  const RecordType *Empty = makeRecord({}, 0, RecordFlags::CanPassInRegisters);
+  EXPECT_TRUE(Empty->isEmpty());
+}
+
+TEST_F(ABITypesTest, NestedEmptyCRecordField) {
+  const RecordType *Empty = makeRecord({}, 8, RecordFlags::CanPassInRegisters);
+  const RecordType *Nested =
+      makeRecord({FieldInfo(Empty, 0)}, 8, RecordFlags::CanPassInRegisters);
+  EXPECT_TRUE(Nested->isEmpty());
+}
+
+TEST_F(ABITypesTest, CXXNestedEmptyFieldRequiresNoUniqueAddress) {
+  RecordFlags CXXFlags = static_cast<RecordFlags>(
+      RecordFlags::CanPassInRegisters | RecordFlags::IsCXXRecord);
+  const RecordType *Empty = makeRecord({}, 8, CXXFlags);
+
+  const RecordType *WithoutNUA = makeRecord({FieldInfo(Empty, 0)}, 8, CXXFlags);
+  EXPECT_FALSE(WithoutNUA->isEmpty());
+
+  FieldInfo NUAField(Empty, 0, /*IsBitField=*/false, /*BitFieldWidth=*/0,
+                     /*IsUnnamedBitField=*/false,
+                     /*HasNoUniqueAddress=*/true);
+  const RecordType *WithNUA = makeRecord({NUAField}, 8, CXXFlags);
+  EXPECT_TRUE(WithNUA->isEmpty());
+}
+
+TEST_F(ABITypesTest, ArrayOfEmptyRecords) {
+  RecordFlags CFlags = RecordFlags::CanPassInRegisters;
+  RecordFlags CXXFlags = static_cast<RecordFlags>(
+      RecordFlags::CanPassInRegisters | RecordFlags::IsCXXRecord);
+  const RecordType *EmptyC = makeRecord({}, 8, CFlags);
+  const RecordType *EmptyCXX = makeRecord({}, 8, CXXFlags);
+  const llvm::abi::Type *ArrC = TB.getArrayType(EmptyC, 2, 16);
+  const llvm::abi::Type *ArrCXX = TB.getArrayType(EmptyCXX, 2, 16);
+  const llvm::abi::Type *ZeroArrCXX = TB.getArrayType(EmptyCXX, 0, 0);
+
+  EXPECT_TRUE(makeRecord({FieldInfo(ArrC, 0)}, 16, CFlags)->isEmpty());
+  EXPECT_FALSE(makeRecord({FieldInfo(ArrCXX, 0)}, 16, CXXFlags)->isEmpty());
+  EXPECT_TRUE(makeRecord({FieldInfo(ZeroArrCXX, 0)}, 0, CXXFlags)->isEmpty());
+}
+
+TEST_F(ABITypesTest, BitfieldsAndFlexibleArrays) {
+  const llvm::abi::Type *I32 = TB.getIntegerType(32, Align(4), /*Signed=*/true);
+  FieldInfo Unnamed(I32, 0, /*IsBitField=*/true, /*BitFieldWidth=*/3,
+                    /*IsUnnamedBitField=*/true);
+  FieldInfo NamedZero(I32, 0, /*IsBitField=*/true, /*BitFieldWidth=*/0);
+
+  EXPECT_TRUE(
+      makeRecord({Unnamed}, 8, RecordFlags::CanPassInRegisters)->isEmpty());
+  EXPECT_FALSE(
+      makeRecord({NamedZero}, 8, RecordFlags::CanPassInRegisters)->isEmpty());
+  EXPECT_FALSE(
+      makeRecord({}, 0, RecordFlags::HasFlexibleArrayMember)->isEmpty());
+}
+
+TEST_F(ABITypesTest, DirectVirtualBasesAndVTablePointer) {
+  RecordFlags CXXFlags = static_cast<RecordFlags>(
+      RecordFlags::CanPassInRegisters | RecordFlags::IsCXXRecord);
+  const RecordType *Empty = makeRecord({}, 8, CXXFlags);
+  const RecordType *IntField = makeRecord(
+      {FieldInfo(TB.getIntegerType(32, Align(4), /*Signed=*/true), 0)}, 32,
+      CXXFlags);
+  const llvm::abi::Type *VPtr = TB.getPointerType(64, Align(8));
+  FieldInfo VTable(VPtr, 0, /*IsBitField=*/false, /*BitFieldWidth=*/0,
+                   /*IsUnnamedBitField=*/false,
+                   /*HasNoUniqueAddress=*/false,
+                   /*IsVTablePointer=*/true);
+
+  EXPECT_TRUE(makeRecord({}, 8, CXXFlags, /*Bases=*/{},
+                         /*DirectVBases=*/{FieldInfo(Empty, 0)})
+                  ->isEmpty());
+  EXPECT_FALSE(makeRecord({}, 32, CXXFlags, /*Bases=*/{},
+                          /*DirectVBases=*/{FieldInfo(IntField, 0)})
+                   ->isEmpty());
+  EXPECT_TRUE(makeRecord({VTable}, 64,
+                         static_cast<RecordFlags>(CXXFlags |
+                                                  RecordFlags::IsPolymorphic),
+                         {FieldInfo(Empty, 0)})
+                  ->isEmpty());
+}
+
+} // namespace

--- a/llvm/utils/gn/secondary/llvm/unittests/ABI/BUILD.gn
+++ b/llvm/utils/gn/secondary/llvm/unittests/ABI/BUILD.gn
@@ -6,5 +6,8 @@ unittest("ABITests") {
     "//llvm/lib/IR",
     "//llvm/lib/Support",
   ]
-  sources = [ "AArch64TargetInfoTest.cpp" ]
+  sources = [
+    "AArch64TargetInfoTest.cpp",
+    "TypesTest.cpp",
+  ]
 }


### PR DESCRIPTION
While working on empty record handling for AArch64, I stumbled across a couple of differences between the LLVM ABI library's `RecordType::isEmpty()` and Clang's `CodeGen::isEmptyRecord()`. Testing verified this led to observable differences in classification when using the ABI library.

This change updates the ABI library's empty record handling to match Clang.

Assisted-by: Cursor / various models