### PR TITLE
[mlir][Shard] Compare all-reduce properties when simplifying

### DIFF
--- a/mlir/include/mlir/Dialect/Shard/Transforms/Simplify.h
+++ b/mlir/include/mlir/Dialect/Shard/Transforms/Simplify.h
@@ -82,10 +82,7 @@ void populateAllReduceEndomorphismSimplifyPatterns(RewritePatternSet &patterns,
 
     auto refAllReduceOp = llvm::dyn_cast<AllReduceOp>(referenceOp.value());
     auto refType = cast<ShapedType>(refAllReduceOp.getResult().getType());
-    return refAllReduceOp.getGridAttr() == allReduceOp.getGridAttr() &&
-           refAllReduceOp.getGridAxesAttr() == allReduceOp.getGridAxesAttr() &&
-           refAllReduceOp.getReductionAttr() ==
-               allReduceOp.getReductionAttr() &&
+    return refAllReduceOp.getProperties() == allReduceOp.getProperties() &&
            refAllReduceOp->getDiscardableAttrDictionary() ==
                allReduceOp->getDiscardableAttrDictionary() &&
            inType.getElementType() == refType.getElementType();


### PR DESCRIPTION
Compare the generated properties structs instead of listing each inherent attribute individually. This preserves the original equality semantics when new properties are added.

Follow-up to  #217233

Assisted-by: Codex