### PR TITLE
[GISel] Fix -Wunused-function in release builds

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/RegBankSelect.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/RegBankSelect.cpp
@@ -485,7 +485,8 @@ protected:
     LLVM_ABI void print(raw_ostream &OS) const;
 
     /// Overload the stream operator for easy debug printing.
-    friend raw_ostream &operator<<(raw_ostream &OS, const MappingCost &Cost) {
+    [[maybe_unused]] friend raw_ostream &operator<<(raw_ostream &OS,
+                                                    const MappingCost &Cost) {
       Cost.print(OS);
       return OS;
     }


### PR DESCRIPTION
This operator is only used in DEBUG builds. Exposed by 732d8413c69b57a10de1beb1964a57a9264b23b9 which moved the Impl class into an anonymous namespace in the source file which allowed the compiler to reason about usage.

Fixes https://lab.llvm.org/buildbot/#/builders/228/builds/8620