### PR TITLE
[AMDGPU] Update the comment regarding opsel[0] for v_cvt_sr_fp8/bf8_f16, NFC

### DIFF
--- a/llvm/lib/Target/AMDGPU/VOP3Instructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP3Instructions.td
@@ -1849,7 +1849,8 @@ let SubtargetPredicate = isGFX1250Plus in {
     defm V_CVT_SR_PK_F16_F32 : VOP3Inst<"v_cvt_sr_pk_f16_f32", VOP3_Profile<VOP_V2F16_F32_F32_I32>, int_amdgcn_cvt_sr_pk_f16_f32>;
 
     // These instructions have non-standard use of op_sel. They are using bits 2 and 3 of opsel
-    // to select a byte in the vdst. Bits 0 and 1 are unused.
+    // to select a byte in the vdst. Bit 1 must be zero, and bit 0 can be non-zero to select
+    // the high 16-bits of src0.
     let Constraints = "$vdst = $vdst_in", SubtargetPredicate = HasF16FP8ConversionInsts in {
       defm V_CVT_SR_FP8_F16 : VOP3Inst_t16_with_profiles<"v_cvt_sr_fp8_f16", VOP3_CVT_SR_F8_F16_Profile,
                                                           VOP3_CVT_SR_F8_F16_True16_Profile, VOP3_CVT_SR_F8_F16_Fake16_Profile>;


### PR DESCRIPTION
To be consistent with the actual implementation, OPSEL[0] can be non-zero
 to select high 16-bit of src0.