### PR TITLE
[AMDGPU] Set "preserved" bits in register bitmask for all VGPRs and S…

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUCallingConv.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCallingConv.td
@@ -197,3 +197,7 @@ def AMDGPU_AllVectorRegs : RegMask<
 def AMDGPU_AllAllocatableSRegs : RegMask<
   (add (sequence "SGPR%u", 0, 105), VCC_LO, VCC_HI)
 >;
+
+def AMDGPU_AllGPRs : RegMask<
+  (add AMDGPU_AllVGPRs, AMDGPU_AllAllocatableSRegs)
+>;

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
@@ -461,7 +461,7 @@ const uint32_t *SIRegisterInfo::getCallPreservedMask(const MachineFunction &MF,
   case CallingConv::AMDGPU_CS_ChainPreserve:
     // Calls to these functions never return, so we can pretend everything is
     // preserved.
-    return AMDGPU_AllVGPRs_RegMask;
+    return AMDGPU_AllGPRs_RegMask;
   default:
     return nullptr;
   }


### PR DESCRIPTION
…GPRs for amdgpu_cs_chain and amdgpu_cs_chain_preserve calling conventions.

The SIRegisterInfo::getCallPreservedMask() function now sets "preserved" bits for all VGPRs if the calling convention is AMDGPU_CS_Chain or AMDGPU_CS_ChainPreserve, and bits for SGPRs remain unset. As a result, LLVM generates DW_CFA_undefined instructions in DWARF frame data for all SGPR registers.
This change adds setting "preserved" bits for all SGPRs as well.