### PR TITLE
[libc++][tests] Enable 'simd_unary.pass.cpp' test for Armv7 Linux targets.

### DIFF
--- a/libcxx/test/std/experimental/simd/simd.class/simd_unary.pass.cpp
+++ b/libcxx/test/std/experimental/simd/simd.class/simd_unary.pass.cpp
@@ -8,10 +8,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14
 
-// FIXME: The following issue occurs on Windows to Armv7 Ubuntu Linux:
-//   Assertion failed: N->getValueType(0) == MVT::v1i1 && "Expected v1i1 type"
-// XFAIL: target=armv7-unknown-linux-gnueabihf
-
 // FIXME: This should work with -flax-vector-conversions=none
 // ADDITIONAL_COMPILE_FLAGS(clang): -flax-vector-conversions=integer
 // ADDITIONAL_COMPILE_FLAGS(apple-clang): -flax-vector-conversions=integer


### PR DESCRIPTION
Remove test's XFAIL for the `armv7-unknown-linux-gnueabihf` target because the ARM codegen has been fixed and does not crash with the assert anymore.