### PR TITLE
[RISCV] Fix stage2 bootstrap crash caused by f6ea145aa8e89631ae04f72df32580b20256d40c

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
+++ b/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
@@ -1330,6 +1330,9 @@ void RISCVAsmPrinter::emitMachineConstantPoolValue(
 MaybeAlign
 RISCVAsmPrinter::getRequiredGlobalAlignmentGranule(const GlobalVariable &GV) {
   const MCSubtargetInfo &MCSTI = TM.getMCSubtargetInfo();
+  if (!GV.getType()->isSized())
+    return std::nullopt;
+
   uint64_t Size = GV.getGlobalSize(getDataLayout());
   if (MCSTI.hasFeature(RISCV::FeatureVendorXCheriot))
     return CHERIoTCapabilityFormat::getRequiredAlignment(Size);


### PR DESCRIPTION
It's not possible to compute an allocation granule for an unsized type.
