### PR TITLE
[clang] Make the _BitInt literal suffix a pedantic-only extension

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -265,6 +265,11 @@ features cannot lower the translation-unit ABI level;
   initialization, while not diagnosing parameters passed to the selected
   allocation function or promise constructor. (#GH217501)
 
+- The `wb` and `uwb` `_BitInt` literal suffixes are no longer diagnosed by default
+  before C23. They stay in `-Wc23-extensions` and are still reported under
+  `-pedantic` or when that group is enabled explicitly, matching how the `_BitInt`
+  type itself is already handled.
+
 - Fixed bug in `-Wdocumentation` so that it correctly handles explicit
   function template instantiations (#64087).
 

--- a/clang/include/clang/Basic/DiagnosticCommonKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCommonKinds.td
@@ -237,7 +237,7 @@ def err_size_t_literal_too_large: Error<
 def ext_cxx_bitint_suffix : Extension<
   "'_BitInt' suffix for literals is a Clang extension">,
   InGroup<BitIntExtension>;
-def ext_c23_bitint_suffix : ExtWarn<
+def ext_c23_bitint_suffix : Extension<
   "'_BitInt' suffix for literals is a C23 extension">,
   InGroup<C23>;
 def warn_c23_compat_bitint_suffix : Warning<

--- a/clang/test/AST/ByteCode/c.c
+++ b/clang/test/AST/ByteCode/c.c
@@ -417,11 +417,11 @@ void callReturnsComplex(void) {
   c = returnsComplex(0.); // all-warning {{passing arguments to 'returnsComplex' without a prototype is deprecated in all versions of C and is not supported in C23}}
 }
 
-int complexMul[2 * (22222222222wb + 2i) == 2]; // all-warning {{'_BitInt' suffix for literals is a C23 extension}} \
+int complexMul[2 * (22222222222wb + 2i) == 2]; // pedantic-warning {{'_BitInt' suffix for literals is a C23 extension}} \
                                                // pedantic-warning {{imaginary constants are a C2y extension}} \
                                                // all-warning {{variable length array folded to constant array as an extension}}
 
-int complexDiv[2 / (22222222222wb + 2i) == 2]; // all-warning {{'_BitInt' suffix for literals is a C23 extension}} \
+int complexDiv[2 / (22222222222wb + 2i) == 2]; // pedantic-warning {{'_BitInt' suffix for literals is a C23 extension}} \
                                                // pedantic-warning {{imaginary constants are a C2y extension}} \
                                                // all-warning {{variable length array folded to constant array as an extension}}
 

--- a/clang/test/AST/ByteCode/complex.c
+++ b/clang/test/AST/ByteCode/complex.c
@@ -29,4 +29,6 @@ void testComplexFloat(_Atomic(_Complex float) *fp) {
   *fp = f;
 }
 
-void ZeroNeedsAlloc() { 9999999999999999999wb / 1wbi; } // both-warning 2{{'_BitInt' suffix for literals is a C23 extension}}
+// The RUN lines above pass no -pedantic, so the C23 '_BitInt' suffix extension
+// is not diagnosed here.
+void ZeroNeedsAlloc() { 9999999999999999999wb / 1wbi; }

--- a/clang/test/Lexer/bitint-constants-compat.c
+++ b/clang/test/Lexer/bitint-constants-compat.c
@@ -1,4 +1,11 @@
-// RUN: %clang_cc1 -std=c17 -fsyntax-only -verify=ext -Wno-unused %s
+// The suffix is a C23 extension, diagnosed like the other members of
+// -Wc23-extensions: silent by default, reported under -pedantic or when the
+// group is enabled explicitly.  GNU C modes behave the same as ISO ones.
+// RUN: %clang_cc1 -std=c17 -fsyntax-only -verify=ext -Wc23-extensions -Wno-unused %s
+// RUN: %clang_cc1 -std=c17 -fsyntax-only -verify=ext -pedantic -Wno-unused -Wno-comment %s
+// RUN: %clang_cc1 -std=c17 -fsyntax-only -verify=quiet -Wno-unused %s
+// RUN: %clang_cc1 -std=gnu17 -fsyntax-only -verify=ext -pedantic -Wno-unused -Wno-comment %s
+// RUN: %clang_cc1 -std=gnu17 -fsyntax-only -verify=quiet -Wno-unused %s
 // RUN: %clang_cc1 -std=c2x -fsyntax-only -verify=compat -Wpre-c2x-compat -Wno-unused %s
 // RUN: %clang_cc1 -fsyntax-only -verify=cpp -Wbit-int-extension -Wno-unused -x c++ %s
 
@@ -8,6 +15,7 @@
 #endif
 
 #if 18446744073709551615__uwb // ext-error {{invalid suffix '__uwb' on integer constant}} \
+                               quiet-error {{invalid suffix '__uwb' on integer constant}} \
                                compat-error {{invalid suffix '__uwb' on integer constant}} \
                                cpp-warning {{'_BitInt' suffix for literals is a Clang extension}}
 #endif
@@ -18,6 +26,7 @@ void func(void) {
                              cpp-error {{invalid suffix 'wb' on integer constant}}
 
   18446744073709551615__wb; // ext-error {{invalid suffix '__wb' on integer constant}} \
+                             quiet-error {{invalid suffix '__wb' on integer constant}} \
                              compat-error {{invalid suffix '__wb' on integer constant}} \
                              cpp-warning {{'_BitInt' suffix for literals is a Clang extension}}
 }


### PR DESCRIPTION
Clang diagnoses the `wb`/`uwb` `_BitInt` literal suffixes before C23 with
`ext_c23_bitint_suffix`, an `ExtWarn`, so `0uwb` warns by default and is an error
under `-Werror`.

Nothing else about the feature is reported that eagerly. `ext_bit_int`, which covers
the `_BitInt` type the suffix names, is an `Extension` and only fires under
`-pedantic` or `-Wbit-int-extension`:

```
DiagnosticParseKinds.td:1816   ext_bit_int            Extension   InGroup<BitIntExtension>   # the type
DiagnosticCommonKinds.td:240   ext_c23_bitint_suffix  ExtWarn     InGroup<C23>               # the suffix
```

So `-std=c11` accepts `_BitInt(8)` silently but warns on `0uwb`. Within
`-Wc23-extensions`, 7 of the 14 diagnostics are already `Extension`
(`ext_c_nullptr`, `ext_c_empty_initializer`, `ext_binary_literal`,
`ext_c23_enum_fixed_underlying_type`, `warn_ext_c23_attributes`,
`ext_type_defined_in_offsetof`, `ext_c23_enum_value_not_int`), so the `ExtWarn` here
is the outlier.

This downgrades it to `Extension`. The diagnostic stays in `-Wc23-extensions`, so
`-pedantic` and an explicit `-Wc23-extensions` both still report it; only the
default-on behaviour goes away.

It also brings clang in line with GCC, which accepts the suffixes before C23 and
reports them only under `-pedantic`. GCC treats the C23 features it accepts early
the same way and does not vary this by `-std=gnuNN` versus `-std=cNN`. Measured
against gcc 15.3.0, counting only the suffix diagnostic:

| | GCC | this PR | before |
|---|---|---|---|
| `-std=c11` | silent | silent | warns |
| `-std=c11 -pedantic` | warns | warns | warns |
| `-std=gnu11` | silent | silent | warns |
| `-std=gnu11 -pedantic` | warns | warns | warns |
| explicit warning flag | warns | warns | warns |

`clang/test/Lexer/bitint-constants-compat.c` gains RUN lines for `-pedantic`, for an
explicit `-Wc23-extensions`, and for the silent default, each in both a strict ISO
and a GNU C mode. `clang/test/AST/ByteCode/c.c` expectations move to the `pedantic`
prefix, and `clang/test/AST/ByteCode/complex.c` passes no `-pedantic`, so its two
warnings go away. Reverting just the `.td` line fails all three. `check-clang` is
otherwise clean.

An earlier version of this PR instead added a GNU-mode-specific diagnostic. That was
based on a mistaken reading of GCC, which does not distinguish GNU from ISO modes
here, and it has been dropped.

Assisted-by: Claude Code

https://claude.ai/code/session_017E6rrFLf931hXtTjemNhbi
