### PR TITLE
[libc++] Implement C++29 Bit Permutations P3104R6

### DIFF
--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -238,6 +238,7 @@ set(files
   __bit/bit_reverse.h
   __bit/bit_repeat.h
   __bit/bit_compress.h
+  __bit/bit_expand.h
   __bit/blsr.h
   __bit/byteswap.h
   __bit/countl.h

--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -237,6 +237,7 @@ set(files
   __bit/bit_width.h
   __bit/bit_reverse.h
   __bit/bit_repeat.h
+  __bit/bit_compress.h
   __bit/blsr.h
   __bit/byteswap.h
   __bit/countl.h

--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -232,13 +232,13 @@ set(files
   __atomic/to_gcc_order.h
   __bit/bit_cast.h
   __bit/bit_ceil.h
-  __bit/bit_floor.h
-  __bit/bit_log2.h
-  __bit/bit_width.h
-  __bit/bit_reverse.h
-  __bit/bit_repeat.h
   __bit/bit_compress.h
   __bit/bit_expand.h
+  __bit/bit_floor.h
+  __bit/bit_log2.h
+  __bit/bit_repeat.h
+  __bit/bit_reverse.h
+  __bit/bit_width.h
   __bit/blsr.h
   __bit/byteswap.h
   __bit/countl.h

--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -235,6 +235,7 @@ set(files
   __bit/bit_floor.h
   __bit/bit_log2.h
   __bit/bit_width.h
+  __bit/bit_reverse.h
   __bit/blsr.h
   __bit/byteswap.h
   __bit/countl.h

--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -236,6 +236,7 @@ set(files
   __bit/bit_log2.h
   __bit/bit_width.h
   __bit/bit_reverse.h
+  __bit/bit_repeat.h
   __bit/blsr.h
   __bit/byteswap.h
   __bit/countl.h

--- a/libcxx/include/__bit/bit_compress.h
+++ b/libcxx/include/__bit/bit_compress.h
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___BIT_BIT_COMPRESS_H
+#define _LIBCPP___BIT_BIT_COMPRESS_H
+
+#include <__config>
+#include <__type_traits/integer_traits.h>
+
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#  pragma GCC system_header
+#endif
+
+#if _LIBCPP_STD_VER >= 29
+
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+template <__unsigned_integer _Tp>
+_LIBCPP_HIDE_FROM_ABI constexpr _Tp bit_compress(_Tp __t, _Tp __m) noexcept {
+  return __builtin_elementwise_pext(__t, __m);
+}
+
+_LIBCPP_END_NAMESPACE_STD
+
+#endif // _LIBCPP_STD_VER >= 29
+
+#endif // _LIBCPP___BIT_BIT_COMPRESS_H

--- a/libcxx/include/__bit/bit_expand.h
+++ b/libcxx/include/__bit/bit_expand.h
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___BIT_BIT_EXPAND_H
+#define _LIBCPP___BIT_BIT_EXPAND_H
+
+#include <__config>
+#include <__type_traits/integer_traits.h>
+
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#  pragma GCC system_header
+#endif
+
+#if _LIBCPP_STD_VER >= 29
+
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+template <__unsigned_integer _Tp>
+_LIBCPP_HIDE_FROM_ABI constexpr _Tp bit_expand(_Tp __t, _Tp __m) noexcept {
+  return __builtin_elementwise_pdep(__t, __m);
+}
+
+_LIBCPP_END_NAMESPACE_STD
+
+#endif // _LIBCPP_STD_VER >= 29
+
+#endif // _LIBCPP___BIT_BIT_EXPAND_H

--- a/libcxx/include/__bit/bit_repeat.h
+++ b/libcxx/include/__bit/bit_repeat.h
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___BIT_BIT_REPEAT_H
+#define _LIBCPP___BIT_BIT_REPEAT_H
+
+#include <__config>
+#include <__type_traits/integer_traits.h>
+#include <limits>
+
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#  pragma GCC system_header
+#endif
+
+#if _LIBCPP_STD_VER >= 29
+
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+template <__unsigned_integer _Tp>
+_LIBCPP_HIDE_FROM_ABI constexpr _Tp bit_repeat(_Tp __t, int __l) {
+  _Tp __res = 0;
+  for (int __i = 0; __i < numeric_limits<_Tp>::digits; ++__i) {
+    __res |= ((__t >> (__i % __l)) & 1) << __i;
+  }
+  return __res;
+}
+
+_LIBCPP_END_NAMESPACE_STD
+
+#endif // _LIBCPP_STD_VER >= 29
+
+#endif // _LIBCPP___BIT_BIT_REPEAT_H

--- a/libcxx/include/__bit/bit_reverse.h
+++ b/libcxx/include/__bit/bit_reverse.h
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___BIT_BIT_REVERSE_H
+#define _LIBCPP___BIT_BIT_REVERSE_H
+
+#include <__config>
+#include <__type_traits/integer_traits.h>
+
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#  pragma GCC system_header
+#endif
+
+#if _LIBCPP_STD_VER >= 29
+
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+template <__unsigned_integer _Tp>
+_LIBCPP_HIDE_FROM_ABI constexpr _Tp bit_reverse(_Tp __t) noexcept {
+  return __builtin_elementwise_bitreverse(__t);
+}
+
+_LIBCPP_END_NAMESPACE_STD
+
+#endif // _LIBCPP_STD_VER >= 29
+
+#endif // _LIBCPP___BIT_BIT_REVERSE_H

--- a/libcxx/include/bit
+++ b/libcxx/include/bit
@@ -86,6 +86,7 @@ namespace std {
 
 #  if _LIBCPP_STD_VER >= 29
 #    include <__bit/bit_compress.h>
+#    include <__bit/bit_expand.h>
 #    include <__bit/bit_repeat.h>
 #    include <__bit/bit_reverse.h>
 #  endif

--- a/libcxx/include/bit
+++ b/libcxx/include/bit
@@ -85,6 +85,7 @@ namespace std {
 #  endif
 
 #  if _LIBCPP_STD_VER >= 29
+#    include <__bit/bit_compress.h>
 #    include <__bit/bit_repeat.h>
 #    include <__bit/bit_reverse.h>
 #  endif

--- a/libcxx/include/bit
+++ b/libcxx/include/bit
@@ -84,6 +84,10 @@ namespace std {
 #    include <__bit/byteswap.h>
 #  endif
 
+#  if _LIBCPP_STD_VER >= 29
+#    include <__bit/bit_reverse.h>
+#  endif
+
 #  include <version>
 
 #  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/bit
+++ b/libcxx/include/bit
@@ -85,6 +85,7 @@ namespace std {
 #  endif
 
 #  if _LIBCPP_STD_VER >= 29
+#    include <__bit/bit_repeat.h>
 #    include <__bit/bit_reverse.h>
 #  endif
 

--- a/libcxx/include/module.modulemap.in
+++ b/libcxx/include/module.modulemap.in
@@ -923,6 +923,7 @@ module std {
     module bit_log2         { header "__bit/bit_log2.h" }
     module bit_width        { header "__bit/bit_width.h" }
     module bit_reverse      { header "__bit/bit_reverse.h" }
+    module bit_repeat       { header "__bit/bit_repeat.h" }
     module blsr             { header "__bit/blsr.h" }
     module byteswap         { header "__bit/byteswap.h" }
     module countl           { header "__bit/countl.h" }

--- a/libcxx/include/module.modulemap.in
+++ b/libcxx/include/module.modulemap.in
@@ -925,6 +925,7 @@ module std {
     module bit_reverse      { header "__bit/bit_reverse.h" }
     module bit_repeat       { header "__bit/bit_repeat.h" }
     module bit_compress     { header "__bit/bit_compress.h" }
+    module bit_expand       { header "__bit/bit_expand.h" }
     module blsr             { header "__bit/blsr.h" }
     module byteswap         { header "__bit/byteswap.h" }
     module countl           { header "__bit/countl.h" }

--- a/libcxx/include/module.modulemap.in
+++ b/libcxx/include/module.modulemap.in
@@ -922,6 +922,7 @@ module std {
     module bit_floor        { header "__bit/bit_floor.h" }
     module bit_log2         { header "__bit/bit_log2.h" }
     module bit_width        { header "__bit/bit_width.h" }
+    module bit_reverse      { header "__bit/bit_reverse.h" }
     module blsr             { header "__bit/blsr.h" }
     module byteswap         { header "__bit/byteswap.h" }
     module countl           { header "__bit/countl.h" }

--- a/libcxx/include/module.modulemap.in
+++ b/libcxx/include/module.modulemap.in
@@ -924,6 +924,7 @@ module std {
     module bit_width        { header "__bit/bit_width.h" }
     module bit_reverse      { header "__bit/bit_reverse.h" }
     module bit_repeat       { header "__bit/bit_repeat.h" }
+    module bit_compress     { header "__bit/bit_compress.h" }
     module blsr             { header "__bit/blsr.h" }
     module byteswap         { header "__bit/byteswap.h" }
     module countl           { header "__bit/countl.h" }

--- a/libcxx/modules/std/bit.inc
+++ b/libcxx/modules/std/bit.inc
@@ -38,6 +38,7 @@ export namespace std {
 
 #if _LIBCPP_STD_VER >= 29
   // [bit.permute], permutation
+  using std::bit_compress;
   using std::bit_repeat;
   using std::bit_reverse;
 #endif

--- a/libcxx/modules/std/bit.inc
+++ b/libcxx/modules/std/bit.inc
@@ -35,4 +35,10 @@ export namespace std {
 
   // [bit.endian], endian
   using std::endian;
+
+#if _LIBCPP_STD_VER >= 29
+  // [bit.permute], permutation
+  using std::bit_reverse;
+#endif
+
 } // namespace std

--- a/libcxx/modules/std/bit.inc
+++ b/libcxx/modules/std/bit.inc
@@ -39,6 +39,7 @@ export namespace std {
 #if _LIBCPP_STD_VER >= 29
   // [bit.permute], permutation
   using std::bit_compress;
+  using std::bit_expand;
   using std::bit_repeat;
   using std::bit_reverse;
 #endif

--- a/libcxx/modules/std/bit.inc
+++ b/libcxx/modules/std/bit.inc
@@ -38,6 +38,7 @@ export namespace std {
 
 #if _LIBCPP_STD_VER >= 29
   // [bit.permute], permutation
+  using std::bit_repeat;
   using std::bit_reverse;
 #endif
 


### PR DESCRIPTION
Implement C++29 Bit Permutations (P3104R6) which adds the functions: ``bit_reverse``, ``bit_repeat``, ``bit_compress``, ``bit_expand``.
Resolves https://github.com/llvm/llvm-project/issues/204404