### PR TITLE
[llvm-exegesis] Fix host CPU dependency in snippet-generator-seed test

### DIFF
--- a/llvm/test/tools/llvm-exegesis/X86/snippet-generator-seed.test
+++ b/llvm/test/tools/llvm-exegesis/X86/snippet-generator-seed.test
@@ -3,14 +3,14 @@
 # Check that the snippet we generate is exactly the same between runs when we
 # use a fixed RNG seed.
 
-# RUN: llvm-exegesis -mtriple=x86_64-unknown-unknown -mode=latency -opcode-name=ADD64rr --benchmark-phase=prepare-snippet -random-generator-seed=5 | FileCheck %s
+# RUN: llvm-exegesis -mtriple=x86_64-unknown-unknown -mcpu=x86-64 -mode=latency -opcode-name=ADD64rr --benchmark-phase=prepare-snippet -random-generator-seed=5 | FileCheck %s
 
 # CHECK: ---
 # CHECK: mode:            latency
 # CHECK: key:
 # CHECK:   instructions:
-# CHECK:     - 'ADD64rr RCX RCX RAX'
+# CHECK:     - 'ADD64rr RCX RCX R15'
 # CHECK:   config:          ''
 # CHECK:   register_initial_values:
 # CHECK:     - 'RCX=0x0'
-# CHECK:     - 'RAX=0x0'
+# CHECK:     - 'R15=0x0'


### PR DESCRIPTION
The snippet-generator-seed test did not specify an explicit `-mcpu`, causing llvm-exegesis to infer the host CPU. On non-Intel hosts (e.g. Zen 3), the generated snippet with random seed 5 uses R15 instead of RAX, causing the test to fail.

Explicitly specify `-mcpu=x86-64` like the other X86 exegesis tests and update the expected output to match.

Assisted-by: Antigravity with Gemini