### PR TITLE
[Transforms] Remove dead declarations

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
+++ b/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
@@ -233,7 +233,6 @@ private:
   // Match orphan IR functions to unused top-level profile entries by demangled
   // basename, without requiring a matched caller in the call graph.
   void matchFunctionsWithoutProfileByBasename();
-  void reportOrPersistProfileStats();
 };
 } // end namespace llvm
 #endif // LLVM_TRANSFORMS_IPO_SAMPLEPROFILEMATCHER_H

--- a/llvm/include/llvm/Transforms/Utils/SimplifyLibCalls.h
+++ b/llvm/include/llvm/Transforms/Utils/SimplifyLibCalls.h
@@ -169,7 +169,6 @@ private:
   Value *optimizeStrCpy(CallInst *CI, IRBuilderBase &B);
   Value *optimizeStpCpy(CallInst *CI, IRBuilderBase &B);
   Value *optimizeStrLCpy(CallInst *CI, IRBuilderBase &B);
-  Value *optimizeStrNCpy(CallInst *CI, IRBuilderBase &B);
   Value *optimizeStrLen(CallInst *CI, IRBuilderBase &B);
   Value *optimizeStrNLen(CallInst *CI, IRBuilderBase &B);
   Value *optimizeStrPBrk(CallInst *CI, IRBuilderBase &B);


### PR DESCRIPTION
reportOrPersistProfileStats: Added on March 28, 2024 in commit
1d99d7a6f841de594b38936a4a73866b23a8b105 without a corresponding
function definition.

optimizeStrNCpy: The corresponding function definition was removed on
September 27, 2022 in commit e80e134c77bb093370a3e4fee41ebe8710e3564d.
