### PR TITLE
[mlir][affine] Fix replaceAllMemRefUsesWith failing on memref.load/store 

### DIFF
--- a/mlir/lib/Dialect/Affine/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/Affine/Utils/Utils.cpp
@@ -1357,7 +1357,8 @@ LogicalResult mlir::affine::replaceAllMemRefUsesWith(
     // Check if the memref was used in a non-dereferencing context. It is fine
     // for the memref to be used in a non-dereferencing way outside of the
     // region where this replacement is happening. Note: memref.load/store are
-    // dereferencing ops even though they don't implement AffineMapAccessInterface.
+    // dereferencing ops even though they don't implement
+    // AffineMapAccessInterface.
     if (!isDereferencingOp(user)) {
       if (!allowNonDereferencingOps) {
         LLVM_DEBUG(

--- a/mlir/lib/Dialect/Affine/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/Affine/Utils/Utils.cpp
@@ -1356,8 +1356,9 @@ LogicalResult mlir::affine::replaceAllMemRefUsesWith(
 
     // Check if the memref was used in a non-dereferencing context. It is fine
     // for the memref to be used in a non-dereferencing way outside of the
-    // region where this replacement is happening.
-    if (!isa<AffineMapAccessInterface>(*user)) {
+    // region where this replacement is happening. Note: memref.load/store are
+    // dereferencing ops even though they don't implement AffineMapAccessInterface.
+    if (!isDereferencingOp(user)) {
       if (!allowNonDereferencingOps) {
         LLVM_DEBUG(
             llvm::dbgs()

--- a/mlir/lib/Dialect/Affine/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/Affine/Utils/Utils.cpp
@@ -1356,8 +1356,9 @@ LogicalResult mlir::affine::replaceAllMemRefUsesWith(
 
     // Check if the memref was used in a non-dereferencing context. It is fine
     // for the memref to be used in a non-dereferencing way outside of the
-    // region where this replacement is happening. Note: memref.load/store are
-    // dereferencing ops even though they don't implement AffineMapAccessInterface.
+    // region where this replacement is happening.
+    // NOTE: memref.load/store are dereferencing ops even
+    // though they don't implement AffineMapAccessInterface.
     if (!isDereferencingOp(user)) {
       if (!allowNonDereferencingOps) {
         LLVM_DEBUG(

--- a/mlir/test/Dialect/Affine/affine-data-copy.mlir
+++ b/mlir/test/Dialect/Affine/affine-data-copy.mlir
@@ -495,3 +495,32 @@ func.func @multiple_blocks(%arg0: index) -> memref<1x2x1xi32> {
 ^bb3:  // pred: ^bb1
   return %1 : memref<1x2x1xi32>
 }
+
+// -----
+
+// Test that memref.store on the same memref as affine.load/store doesn't
+// cause replaceAllMemRefUsesWith to fail. Before the fix, memref.store
+// (which doesn't implement AffineMapAccessInterface) caused the entire
+// memref replacement to fail silently, leaving the fast buffer uninitialized.
+
+memref.global "private" @__constant_4xi32 : memref<4xi32> = dense<[3, -7, 11, -13]>
+
+// CHECK-LABEL:   func.func @memref_store_with_affine_access() -> i32 {
+// CHECK:           %[[ALLOC:.*]] = memref.alloc() : memref<1xi32>
+// CHECK:           affine.for
+// CHECK:             affine.store %{{.*}}, %[[ALLOC]]
+// CHECK:             memref.store %{{.*}}, %[[ALLOC]]
+// CHECK:           affine.load %[[ALLOC]]
+// CHECK:           memref.dealloc %[[ALLOC]]
+// CHECK:         }
+func.func @memref_store_with_affine_access() -> i32 {
+  %c0 = arith.constant 0 : index
+  %c100_i32 = arith.constant 100 : i32
+  %0 = memref.get_global @__constant_4xi32 : memref<4xi32>
+  affine.for %arg0 = 0 to 4 {
+    affine.store %c100_i32, %0[0] : memref<4xi32>
+    memref.store %c100_i32, %0[%c0] : memref<4xi32>
+  }
+  %1 = affine.load %0[0] : memref<4xi32>
+  return %1 : i32
+}

--- a/mlir/test/Dialect/Affine/affine-data-copy.mlir
+++ b/mlir/test/Dialect/Affine/affine-data-copy.mlir
@@ -498,11 +498,6 @@ func.func @multiple_blocks(%arg0: index) -> memref<1x2x1xi32> {
 
 // -----
 
-// Test that memref.store on the same memref as affine.load/store doesn't
-// cause replaceAllMemRefUsesWith to fail. Before the fix, memref.store
-// (which doesn't implement AffineMapAccessInterface) caused the entire
-// memref replacement to fail silently, leaving the fast buffer uninitialized.
-
 memref.global "private" @__constant_4xi32 : memref<4xi32> = dense<[3, -7, 11, -13]>
 
 // CHECK-LABEL:   func.func @memref_store_with_affine_access() -> i32 {


### PR DESCRIPTION
memref.load/memref.store are dereferencing ops but don't implement AffineMapAccessInterface. The check `!isa<AffineMapAccessInterface>(user)` in `replaceAllMemRefUsesWith` incorrectly treats them as non-dereferencing and returns failure, causing the entire memref replacement to be skipped. This leaves fast buffers uninitialized in affine-data-copy-generate.
Use isDereferencingOp(user) instead, which already covers memref::LoadOp/memref::StoreOp. Fixes #217538.

Assisted-by: GLM-5.1