### PR TITLE
[libc++] Temporarily increase the number of extra attempts for the benchmark cron

### DIFF
--- a/.github/workflows/libcxx-benchmark-cron.yml
+++ b/.github/workflows/libcxx-benchmark-cron.yml
@@ -167,4 +167,4 @@ jobs:
           fi
 
           libcxx/utils/ci/lnt/dispatch-benchmarks --work-items plan.jsonl --lnt-url "${LNT_URL}"  \
-                                                  --max-in-flight "${MAX_IN_FLIGHT}" "${dry_run[@]}"
+                                                  --max-in-flight "${MAX_IN_FLIGHT}" "${dry_run[@]}" --extra-attempts 6


### PR DESCRIPTION
We've had instability on lnt.llvm.org lately due to bots crawling the server without it being a CDN and it going down. We also enabled https from the user to the Fastly CDN, which led to some jobs failing since they were trying to submit using http instead of https.

All of this resulted in a few commits reaching their number of max attempts without having 3 samples each. To make up for the missing runs in LNT, this patch temporarily increases the extra attempts so the system will submit jobs for the missing data automatically.

We should be able to revert this patch in roughly 1 day once the missing commits have data.