### PR TITLE
[CIR][OpenCL] Preserve OpenCL source languages in CIR

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -79,7 +79,9 @@ class CIR_UnitAttr<string name, string attrMnemonic, list<Trait> traits = []>
 
 def CIR_SourceLanguage : CIR_I32EnumAttr<"SourceLanguage", "source language", [
   I32EnumAttrCase<"C", 1, "c">,
-  I32EnumAttrCase<"CXX", 2, "cxx">
+  I32EnumAttrCase<"CXX", 2, "cxx">,
+  I32EnumAttrCase<"OpenCLC", 3, "opencl_c">,
+  I32EnumAttrCase<"OpenCLCXX", 4, "opencl_cxx">
 ]> {
   // The enum attr class is defined in `CIR_SourceLanguageAttr` below,
   // so that it can define extra class methods.
@@ -98,6 +100,10 @@ def CIR_SourceLanguageAttr : CIR_EnumAttr<CIR_SourceLanguage, "lang"> {
     module attributes {cir.lang = cir.lang<c>} {}
     // Module compiled from C++.
     module attributes {cir.lang = cir.lang<cxx>} {}
+    // Module compiled from OpenCL C.
+    module attributes {cir.lang = cir.lang<opencl_c>} {}
+    // Module compiled from C++ for OpenCL.
+    module attributes {cir.lang = cir.lang<opencl_cxx>} {}
     ```
 
     Module source language attribute name is `cir.lang` is defined by
@@ -107,6 +113,8 @@ def CIR_SourceLanguageAttr : CIR_EnumAttr<CIR_SourceLanguage, "lang"> {
   let extraClassDeclaration = [{
     bool isC() const { return getValue() == SourceLanguage::C; }
     bool isCXX() const { return getValue() == SourceLanguage::CXX; }
+    bool isOpenCLC() const { return getValue() == SourceLanguage::OpenCLC; }
+    bool isOpenCLCXX() const { return getValue() == SourceLanguage::OpenCLCXX; }
   }];
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -963,6 +963,10 @@ std::optional<cir::SourceLanguage> CIRGenModule::getCIRSourceLanguage() const {
   using CIRLang = cir::SourceLanguage;
   auto opts = getLangOpts();
 
+  if (opts.OpenCLCPlusPlus)
+    return CIRLang::OpenCLCXX;
+  if (opts.OpenCL)
+    return CIRLang::OpenCLC;
   if (opts.CPlusPlus)
     return CIRLang::CXX;
   if (opts.C99 || opts.C11 || opts.C17 || opts.C23 || opts.C2y ||

--- a/clang/test/CIR/CodeGenOpenCL/source-language.cl
+++ b/clang/test/CIR/CodeGenOpenCL/source-language.cl
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -cl-std=CL3.0 -fclangir -emit-cir -triple spirv64-unknown-unknown %s -o - | FileCheck --check-prefix=CL30-CIR %s
+// RUN: %clang_cc1 -x clcpp -cl-std=CLC++ -fclangir -emit-cir -triple spirv64-unknown-unknown %s -o - | FileCheck --check-prefix=CLCXX-CIR %s
+
+// CL30-CIR: cir.lang = #cir.lang<opencl_c>
+// CLCXX-CIR: cir.lang = #cir.lang<opencl_cxx>
+
+__kernel void lang_marker(__global int *out) {
+  out[0] = 1;
+}

--- a/clang/test/CIR/IR/module.cir
+++ b/clang/test/CIR/IR/module.cir
@@ -1,11 +1,19 @@
 // RUN: cir-opt %s -split-input-file --verify-roundtrip | FileCheck %s
 
-// Should parse and print C source language attribute.
-module attributes {cir.lang = #cir.lang<c>} { }
 // CHECK: module attributes {cir.lang = #cir.lang<c>}
+module attributes {cir.lang = #cir.lang<c>} { }
 
 // -----
 
-// Should parse and print C++ source language attribute.
-module attributes {cir.lang = #cir.lang<cxx>} { }
 // CHECK: module attributes {cir.lang = #cir.lang<cxx>}
+module attributes {cir.lang = #cir.lang<cxx>} { }
+
+// -----
+
+// CHECK: module attributes {cir.lang = #cir.lang<opencl_c>}
+module attributes {cir.lang = #cir.lang<opencl_c>} { }
+
+// -----
+
+// CHECK: module attributes {cir.lang = #cir.lang<opencl_cxx>}
+module attributes {cir.lang = #cir.lang<opencl_cxx>} { }


### PR DESCRIPTION
Represent OpenCL C and C++ for OpenCL source languages in CIR module attributes. Emit the source language from CIRGen so later lowering can distinguish OpenCL language modes without reconstructing them from target metadata.

Assisted-by: Codex / GPT-5.6 Sol