### PR TITLE
[lldb][debugserver] Handle breakpoint prior to addr in RemoveTrapsFromBuffer

### DIFF
--- a/lldb/tools/debugserver/source/DNBBreakpoint.cpp
+++ b/lldb/tools/debugserver/source/DNBBreakpoint.cpp
@@ -171,9 +171,18 @@ void DNBBreakpointList::DisableAll() {
 
 void DNBBreakpointList::RemoveTrapsFromBuffer(nub_addr_t addr, nub_size_t size,
                                               void *p) const {
+  if (m_breakpoints.empty())
+    return;
+
   uint8_t *buf = (uint8_t *)p;
   const_iterator end = m_breakpoints.end();
   const_iterator pos = m_breakpoints.lower_bound(addr);
+
+  // lower_bound finds a breakpoint starting >= addr. The breakpoint prior to
+  // that may start before addr but extend beyond it, so it must be checked too.
+  if (pos != m_breakpoints.begin())
+    --pos;
+
   while (pos != end && (pos->first < (addr + size))) {
     nub_addr_t intersect_addr;
     nub_size_t intersect_size;


### PR DESCRIPTION
Fixes #217840

lower_bound finds the first breakpoint that starts >= addr. There might be a breakpoint before that which starts before addr but extends past addr. Therefore it might need to be patched out of the buffer.

This fix is intentionally minimal as I don't have a Mac to test it in.

A proper fix would reuse FindBreakpointsThatOverlapRange, which also has this bug but is getting fixed. The problem with that is that RemoveTrapsFromBuffer is const, and FindBreakpointsThatOverlapRange returns non const pointers to the breakpoints.

Not super complex to fix but more than I want to do at a distance.