### PR TITLE
[PluginLoader] Drop legacy -load option from llc

### DIFF
--- a/llvm/docs/CommandGuide/llc.rst
+++ b/llvm/docs/CommandGuide/llc.rst
@@ -151,12 +151,6 @@ End-user Options
  Record the amount of time needed for each pass and print a report to standard
  error.
 
-.. option:: --load=<dso_path>
-
- Dynamically load ``dso_path`` (a path to a dynamically shared object) that
- implements an LLVM target.  This will permit the target name to be used with
- the :option:`-march` option so that code can be generated for that target.
-
 .. option:: -meabi=[default|gnu|4|5]
 
  Specify which EABI version should conform to.  Valid EABI versions are *gnu*,

--- a/llvm/test/Other/codegen-plugin-loading.ll
+++ b/llvm/test/Other/codegen-plugin-loading.ll
@@ -1,4 +1,4 @@
-; RUN: llc -load %llvmshlibdir/CGTestPlugin%pluginext %s -o - | FileCheck %s
+; RUN: llc -load-pass-plugin %llvmshlibdir/CGTestPlugin%pluginext %s -o - | FileCheck %s
 ; REQUIRES: native, system-linux, llvm-dylib
 
 ; CHECK: CodeGen Test Pass running on main

--- a/llvm/tools/llc/llc.cpp
+++ b/llvm/tools/llc/llc.cpp
@@ -49,7 +49,6 @@
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/PGOOptions.h"
 #include "llvm/Support/Path.h"
-#include "llvm/Support/PluginLoader.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/TimeProfiler.h"

--- a/llvm/unittests/CodeGen/CGPluginTest/Plugin/Plugin.cpp
+++ b/llvm/unittests/CodeGen/CGPluginTest/Plugin/Plugin.cpp
@@ -10,6 +10,7 @@
 
 #include <llvm/CodeGen/Passes.h>
 #include <llvm/CodeGen/TargetPassConfig.h>
+#include <llvm/Plugins/PassPlugin.h>
 #include <llvm/Target/RegisterTargetPassConfigCallback.h>
 
 using namespace llvm;
@@ -23,4 +24,13 @@ namespace {
 
 __attribute__((constructor)) static void initCodeGenPlugin() {
   initializeCodeGenTestPass(*PassRegistry::getPassRegistry());
+}
+
+// We use -load-pass-plugin to specify and load the plugin shared-lib, but not
+// the actual pass-plugin interface. This isn't available in the codegen
+// pipeline, as it doesn't use the New PassManager.
+extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, "CGTestPlugin", LLVM_VERSION_STRING, nullptr,
+          nullptr};
 }


### PR DESCRIPTION
Pass plugin loading in Codegen is the last remaining use-case for the legacy `-load` option in llc. We can drop it, if we switch the respective test to `-load-pass-plugin`. We use the option only to load the plugin shared-lib. The actual pass-plugin interface remains unavailable for the codegen pipeline, as it doesn't use the New PassManager.