### PR TITLE
[bazel][libc] Remove LIBC_FULL_BUILD-only dependencies (again)

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -1468,18 +1468,13 @@ libc_support_library(
     name = "__support_libc_assert",
     hdrs = ["src/__support/libc_assert.h"],
     deps = [
-        ":__support_integer_to_string",
         ":__support_macros_attributes",
         ":__support_macros_config",
         ":__support_macros_hardening",
         ":__support_macros_macro_utils",
         ":__support_macros_optimization",
         ":__support_macros_properties_os",
-        ":__support_osutil_exit_hdrs",
-    ] + select({
-        "@platforms//os:emscripten": [],
-        "//conditions:default": [":__support_osutil_io"],
-    }),
+    ],
 )
 
 libc_support_library(

--- a/utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl
@@ -66,7 +66,7 @@ def libc_test(
         copts = copts + _FULL_BUILD_COPTS
 
         # Temporarily disable full_build tests (currently broken) to unblock CI.
-        tags = tags + ["manual", "notap"]
+        tags = tags + ["manual", "nobuildkite", "notap"]
     cc_test(
         name = name,
         local_defines = local_defines + _TEST_DEFINES + LIBC_CONFIGURE_OPTIONS,


### PR DESCRIPTION
Fixes #216346.

Add "nobuildkite" tag to tests that depend on libc full build, so that the change wouldn't break CI this time.