### PR TITLE
[BOLT] Avoid large gaps in DSO file layout

### DIFF
--- a/bolt/lib/Rewrite/CMakeLists.txt
+++ b/bolt/lib/Rewrite/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
   JITLink
   MC
   Object
+  ObjCopy
   Support
   DWARFLinker
   DWARFLinkerClassic

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -48,6 +48,10 @@
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSymbol.h"
 #include "llvm/MC/TargetRegistry.h"
+#include "llvm/ObjCopy/CommonConfig.h"
+#include "llvm/ObjCopy/ELF/ELFConfig.h"
+#include "llvm/ObjCopy/ELF/ELFObjcopy.h"
+#include "llvm/Object/Binary.h"
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Support/Alignment.h"
 #include "llvm/Support/Casting.h"
@@ -101,6 +105,11 @@ static cl::opt<bool>
     AllowStripped("allow-stripped",
                   cl::desc("allow processing of stripped binaries"), cl::Hidden,
                   cl::cat(BoltCategory));
+
+static cl::opt<bool> CompactOutput(
+    "compact-output",
+    cl::desc("repack the output ELF to remove gaps and stale section data"),
+    cl::init(false), cl::cat(BoltCategory));
 
 static cl::opt<bool> ForceToDataRelocations(
     "force-data-relocations",
@@ -5012,6 +5021,30 @@ void RewriteInstance::patchELFPHDRTable(ELFObjectFile<ELFT> *File) {
 
 namespace {
 
+Error compactELFOutput(StringRef Filename) {
+  Expected<OwningBinary<Binary>> BinaryOrErr = createBinary(Filename);
+  if (!BinaryOrErr)
+    return createFileError(Filename, BinaryOrErr.takeError());
+
+  OwningBinary<Binary> OutputBinary = std::move(*BinaryOrErr);
+  auto *ELFObj = dyn_cast<ELFObjectFileBase>(OutputBinary.getBinary());
+  if (!ELFObj)
+    return createStringError(errc::executable_format_error,
+                             "output is not an ELF file");
+
+  objcopy::CommonConfig Config;
+  Config.InputFilename = Filename;
+  Config.OutputFilename = Filename;
+  objcopy::ELFConfig ELFConfig;
+
+  // writeToOutput writes through a temporary file and atomically replaces the
+  // original. OutputBinary keeps the old file contents alive until ObjCopy is
+  // done reading them.
+  return writeToOutput(Filename, [&](raw_ostream &OS) {
+    return objcopy::elf::executeObjcopyOnBinary(Config, ELFConfig, *ELFObj, OS);
+  });
+}
+
 /// Write padding to \p OS such that its current \p Offset becomes aligned
 /// at \p Alignment. Return new (aligned) offset.
 uint64_t appendPadding(raw_pwrite_stream &OS, uint64_t Offset,
@@ -6755,6 +6788,17 @@ void RewriteInstance::rewriteFile() {
   }
 
   Out->keep();
+
+  // ObjCopy has to reopen the completed file. Destroy the output stream first
+  // so all buffered data is flushed and its file descriptor is closed.
+  Out.reset();
+
+  if (opts::CompactOutput) {
+    check_error(compactELFOutput(opts::OutputFilename),
+                "failed to compact output ELF");
+    BC->outs() << "BOLT-INFO: binary has been compacted \n";
+  }
+
   EC = sys::fs::setPermissions(
       opts::OutputFilename,
       static_cast<sys::fs::perms>(sys::fs::perms::all_all &

--- a/bolt/test/X86/dynsym-pwrite.test
+++ b/bolt/test/X86/dynsym-pwrite.test
@@ -5,9 +5,18 @@
 # REQUIRES: system-linux
 
 # RUN: yaml2obj %s -o %t.so
-# RUN: llvm-bolt %t.so -o %t.so.bolt 2>&1 | FileCheck %s
+# RUN: llvm-bolt %t.so -o %t.so.bolt --compact-output 2>&1 | FileCheck %s
+# RUN: llvm-readelf -dW %t.so.bolt 2>&1 | FileCheck %s --check-prefix=DYNAMIC --implicit-check-not=warning:
+# RUN: llvm-readelf -SW %t.so.bolt | FileCheck %s --check-prefix=SECTIONS
 
 # CHECK-NOT: We don't support extending the stream
+# CHECK: BOLT-INFO: non-allocatable section .debug_gap
+
+# DYNAMIC: Dynamic section
+# DYNAMIC: (SYMTAB) 0x2100
+
+# SECTIONS-NOT: .debug_gap
+# SECTIONS: .dynamic DYNAMIC 0000000000002000 002000
 
 --- !ELF
 FileHeader:
@@ -21,7 +30,7 @@ ProgramHeaders:
     VAddr:           0x1000
     Align:           0x1000
     FirstSec:        .text
-    LastSec:         .eh_frame
+    LastSec:         .load_metadata
   - Type:            PT_LOAD
     Flags:           [ PF_R, PF_W ]
     VAddr:           0x2000
@@ -33,34 +42,37 @@ ProgramHeaders:
     VAddr:           0x2000
     FirstSec:        .dynamic
     LastSec:         .dynamic
-  - Type:            PT_GNU_EH_FRAME
-    Flags:           [ PF_R ]
-    VAddr:           0x1010
-    FirstSec:        .eh_frame_hdr
-    LastSec:         .eh_frame_hdr
 Sections:
   - Name:            .text
     Type:            SHT_PROGBITS
     Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
     Address:         0x1000
     AddressAlign:    0x1000
+    Offset:          0x1000
     Content:         'C3' # ret
     Size:            0x1
-  - Name:            .eh_frame_hdr
+  # Non-allocatable contents inside a PT_LOAD are part of the loadable image
+  # and must not be diagnosed as removable file padding.
+  - Name:            .load_metadata
     Type:            SHT_PROGBITS
-    Flags:           [ SHF_ALLOC ]
-    Address:         0x1010
-    Content:         '011B033B0C00000001000000F0FFFFFF28000000'
-  - Name:            .eh_frame
+    Address:         0x1008
+    AddressAlign:    0x1
+    Offset:          0x1008
+    Content:         '00'
+  # Model a valid but unusual linker layout with a non-allocatable section
+  # placed before a later PT_LOAD file image.
+  - Name:            .debug_gap
     Type:            SHT_PROGBITS
-    Flags:           [ SHF_ALLOC ]
-    Address:         0x1020
-    Content:         '1400000000000000017A5200017810011B0C070890010000140000001C000000C0FFFFFF010000000000000000000000'
+    AddressAlign:    0x1
+    Offset:          0x1009
+    Size:            0x100000
   - Name:            .dynamic
     Type:            SHT_DYNAMIC
     Flags:           [ SHF_ALLOC, SHF_WRITE ]
     Address:         0x2000
     AddressAlign:    0x1000
+    Link:            .dynstr
+    Offset:          0x102000
     Entries:
       - Tag:             DT_SYMTAB
         Value:           0x2100
@@ -70,10 +82,12 @@ Sections:
     Type:            SHT_STRTAB
     Flags:           [ SHF_ALLOC ]
     Address:         0x2050
+    Offset:          0x102050
   - Name:            .dynsym
     Type:            SHT_DYNSYM
     Flags:           [ SHF_ALLOC ]
     Address:         0x2100
+    Offset:          0x102100
     Link:            .dynstr
 DynamicSymbols:
   - Name:            _DYNAMIC

--- a/bolt/test/X86/dynsym-pwrite.test
+++ b/bolt/test/X86/dynsym-pwrite.test
@@ -10,7 +10,7 @@
 # RUN: llvm-readelf -SW %t.so.bolt | FileCheck %s --check-prefix=SECTIONS
 
 # CHECK-NOT: We don't support extending the stream
-# CHECK: BOLT-INFO: non-allocatable section .debug_gap
+# CHECK: BOLT-INFO: binary has been compacted
 
 # DYNAMIC: Dynamic section
 # DYNAMIC: (SYMTAB) 0x2100


### PR DESCRIPTION
BOLT can leave a large orphan region in the output file not associated with any ELF section/segment when the the input binary contains allocatable bytes placed after non-allocatable bytes (the usual order is alloc first, non-alloc later, but that is not always the case). In such cases BOLT will rebuild the non-allocatable bytes in a new area of the file and leave the old ones still intact as a byproduct of copying all bytes from input up util the last allocatable byte.

This change uses a compact file layout for the output while preserving the virtual addresses and alignment requirements of loadable segments. It avoids extending the output to a high file offset when the intervening range contains no section data.
```
bloaty ./lib/libc.so.6
    FILE SIZE        VM SIZE    
  35.9%  4.62Mi   0.0%       0    .debug_info
  22.2%  2.85Mi   0.0%       0    .debug_loc
  13.0%  1.67Mi   0.0%       0    .debug_line
  11.3%  1.45Mi  73.8%  1.45Mi    .text
   5.7%   749Ki   0.0%       0    .debug_abbrev
   3.7%   486Ki   0.0%       0    .debug_ranges
   1.5%   194Ki   0.0%       0    .symtab
   1.4%   183Ki   0.0%       0    .debug_str
   1.1%   148Ki   7.4%   148Ki    .rodata
   1.0%   126Ki   6.3%   126Ki    .eh_frame
   0.7%  94.6Ki   0.0%       0    .strtab
   0.6%  81.6Ki   0.0%       0    .debug_aranges
   0.4%  55.5Ki   2.8%  55.5Ki    .dynsym
   0.4%  48.2Ki   1.8%  36.4Ki    [57 Others]
   0.3%  39.3Ki   2.0%  39.3Ki    [LOAD #1 [R]]
   0.2%  30.2Ki   1.5%  30.2Ki    .rela.dyn
   0.2%  24.3Ki   1.2%  24.3Ki    .eh_frame_hdr
   0.2%  24.2Ki   1.2%  24.2Ki    .dynstr
   0.0%       0   0.8%  15.7Ki    .bss
   0.1%  15.2Ki   0.8%  15.2Ki    .gnu.hash
   0.1%  13.2Ki   0.7%  13.2Ki    .hash
 100.0%  12.9Mi 100.0%  1.97Mi    TOTAL
```
After BOLT
```
bloaty ./lib/libc.so.6.bolt
    FILE SIZE        VM SIZE    
  48.8%  12.0Mi   0.0%       0    [Unmapped]
  19.0%  4.68Mi   0.0%       0    .debug_info
  11.7%  2.89Mi   0.0%       0    .debug_loc
   6.5%  1.62Mi   0.0%       0    .debug_line
   5.9%  1.45Mi  65.0%  1.45Mi    .text
   2.2%   555Ki   0.0%       0    .debug_ranges
   0.8%   200Ki   0.0%       0    .symtab
   0.7%   183Ki   0.0%       0    .debug_str
   0.6%   148Ki   6.5%   148Ki    .bolt.org.rodata
   0.5%   136Ki   6.0%   136Ki    .eh_frame
   0.5%   126Ki   5.5%   126Ki    .bolt.org.eh_frame
   0.4%   109Ki   4.8%   109Ki    .bolt.text
   0.4%   106Ki   4.6%   106Ki    [64 Others]
   0.4%   105Ki   0.0%       0    .note.bolt_bat
   0.4%   101Ki   0.0%       0    .debug_aranges
   0.4%   101Ki   0.0%       0    .strtab
   0.2%  55.5Ki   2.4%  55.5Ki    .dynsym
   0.2%  39.3Ki   1.7%  39.3Ki    [LOAD #1 [R]]
   0.1%  30.2Ki   1.3%  30.2Ki    .rela.dyn
   0.1%  25.4Ki   1.1%  25.4Ki    .eh_frame_hdr
   0.1%  24.3Ki   1.1%  24.3Ki    .bolt.org.eh_frame_hdr
 100.0%  24.7Mi 100.0%  2.24Mi    TOTAL
 ```
```text
                              FILE SIZE       VM SIZE
Input libc.so.6:               12.9 MiB        1.97 MiB
BOLT output:                   24.7 MiB        2.24 MiB
BOLT output [Unmapped]:        12.0 MiB             0
```
fixed BOLT
```
$ bloaty ./lib/libc.so.6.bolt
    FILE SIZE        VM SIZE    
 --------------  -------------- 
  37.5%  4.68Mi   0.0%       0    .debug_info
  23.1%  2.89Mi   0.0%       0    .debug_loc
  13.3%  1.66Mi   0.0%       0    .debug_line
  11.6%  1.45Mi  68.6%  1.45Mi    .text
   4.3%   550Ki   0.0%       0    .debug_ranges
   1.5%   193Ki   0.0%       0    .symtab
   1.4%   183Ki   0.0%       0    .debug_str
   1.2%   148Ki   6.8%   148Ki    .rodata
   1.0%   126Ki   5.8%   126Ki    .eh_frame
   1.0%   126Ki   5.8%   126Ki    .bolt.org.eh_frame
   0.8%  99.4Ki   0.0%       0    .debug_aranges
   0.7%  94.0Ki   0.0%       0    .strtab
   0.6%  82.3Ki   3.0%  65.7Ki    [62 Others]
   0.4%  55.5Ki   2.6%  55.5Ki    .dynsym
   0.4%  46.2Ki   0.0%       0    [Unmapped]
   0.3%  39.3Ki   1.8%  39.3Ki    [LOAD #1 [R]]
   0.2%  30.2Ki   1.4%  30.2Ki    .rela.dyn
   0.2%  24.3Ki   1.1%  24.3Ki    .eh_frame_hdr
   0.2%  24.3Ki   1.1%  24.3Ki    .bolt.org.eh_frame_hdr
   0.2%  24.2Ki   1.1%  24.2Ki    .dynstr
   0.0%       0   0.7%  15.7Ki    .bss
 100.0%  12.5Mi 100.0%  2.12Mi    TOTAL
```