### PR TITLE
[AMDGPU] Use references for PhiLoweringHelper MF, DT and PDT. NFC.

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUGlobalISelDivergenceLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUGlobalISelDivergenceLowering.cpp
@@ -55,8 +55,8 @@ public:
 
 class DivergenceLoweringHelper : public AMDGPU::PhiLoweringHelper {
 public:
-  DivergenceLoweringHelper(MachineFunction *MF, MachineDominatorTree *DT,
-                           MachinePostDominatorTree *PDT,
+  DivergenceLoweringHelper(MachineFunction &MF, MachineDominatorTree &DT,
+                           MachinePostDominatorTree &PDT,
                            MachineUniformityInfo *MUI);
 
 private:
@@ -84,9 +84,9 @@ public:
 };
 
 DivergenceLoweringHelper::DivergenceLoweringHelper(
-    MachineFunction *MF, MachineDominatorTree *DT,
-    MachinePostDominatorTree *PDT, MachineUniformityInfo *MUI)
-    : PhiLoweringHelper(MF, DT, PDT), MUI(MUI), B(*MF) {}
+    MachineFunction &MF, MachineDominatorTree &DT,
+    MachinePostDominatorTree &PDT, MachineUniformityInfo *MUI)
+    : PhiLoweringHelper(MF, DT, PDT), MUI(MUI), B(MF) {}
 
 // _(s1) -> SReg_32/64(s1)
 void DivergenceLoweringHelper::markAsLaneMask(Register DstReg) const {
@@ -108,7 +108,7 @@ void DivergenceLoweringHelper::getCandidatesForLowering(
   // Add divergent i1 G_PHIs to the list. Only consider G_PHI instructions,
   // not PHI instructions that may have been created by earlier lowering stages
   // (e.g., lowerTemporalDivergenceI1).
-  for (MachineBasicBlock &MBB : *MF) {
+  for (MachineBasicBlock &MBB : MF) {
     for (MachineInstr &MI : MBB.phis()) {
       if (MI.getOpcode() != TargetOpcode::G_PHI)
         continue;
@@ -205,7 +205,7 @@ void replaceUsesOfRegInInstWith(Register Reg, MachineInstr *Inst,
 }
 
 bool DivergenceLoweringHelper::lowerTemporalDivergence() {
-  AMDGPU::IntrinsicLaneMaskAnalyzer ILMA(*MF);
+  AMDGPU::IntrinsicLaneMaskAnalyzer ILMA(MF);
   DenseMap<Register, Register> TDCache;
 
   for (auto [Reg, UseInst, _] : MUI->getTemporalDivergenceList()) {
@@ -236,7 +236,7 @@ bool DivergenceLoweringHelper::lowerTemporalDivergence() {
 bool DivergenceLoweringHelper::lowerTemporalDivergenceI1() {
   MachineRegisterInfo::VRegAttrs BoolS1 = {ST->getBoolRC(), LLT::scalar(1)};
   initializeLaneMaskRegisterAttributes(BoolS1);
-  MachineSSAUpdater SSAUpdater(*MF);
+  MachineSSAUpdater SSAUpdater(MF);
 
   const auto &CInfo = MUI->getCycleInfo();
 
@@ -295,7 +295,7 @@ bool DivergenceLoweringHelper::lowerTemporalDivergenceI1() {
 static bool runDivergenceLowering(MachineFunction &MF, MachineDominatorTree &DT,
                                   MachinePostDominatorTree &PDT,
                                   MachineUniformityInfo &MUI) {
-  DivergenceLoweringHelper Helper(&MF, &DT, &PDT, &MUI);
+  DivergenceLoweringHelper Helper(MF, DT, PDT, &MUI);
 
   bool Changed = false;
   // Temporal divergence lowering needs to inspect list of instructions used

--- a/llvm/lib/Target/AMDGPU/SILowerI1Copies.cpp
+++ b/llvm/lib/Target/AMDGPU/SILowerI1Copies.cpp
@@ -38,8 +38,8 @@ namespace {
 
 class Vreg1LoweringHelper : public AMDGPU::PhiLoweringHelper {
 public:
-  Vreg1LoweringHelper(MachineFunction *MF, MachineDominatorTree *DT,
-                      MachinePostDominatorTree *PDT);
+  Vreg1LoweringHelper(MachineFunction &MF, MachineDominatorTree &DT,
+                      MachinePostDominatorTree &PDT);
 
 private:
   DenseSet<Register> ConstrainRegs;
@@ -67,9 +67,9 @@ public:
   }
 };
 
-Vreg1LoweringHelper::Vreg1LoweringHelper(MachineFunction *MF,
-                                         MachineDominatorTree *DT,
-                                         MachinePostDominatorTree *PDT)
+Vreg1LoweringHelper::Vreg1LoweringHelper(MachineFunction &MF,
+                                         MachineDominatorTree &DT,
+                                         MachinePostDominatorTree &PDT)
     : PhiLoweringHelper(MF, DT, PDT) {}
 
 bool Vreg1LoweringHelper::cleanConstrainRegs(bool Changed) {
@@ -406,7 +406,7 @@ bool Vreg1LoweringHelper::lowerCopiesFromI1() {
   bool Changed = false;
   SmallVector<MachineInstr *, 4> DeadCopies;
 
-  for (MachineBasicBlock &MBB : *MF) {
+  for (MachineBasicBlock &MBB : MF) {
     for (MachineInstr &MI : MBB) {
       if (MI.getOpcode() != AMDGPU::COPY)
         continue;
@@ -445,12 +445,12 @@ bool Vreg1LoweringHelper::lowerCopiesFromI1() {
   return Changed;
 }
 
-AMDGPU::PhiLoweringHelper::PhiLoweringHelper(MachineFunction *MF,
-                                             MachineDominatorTree *DT,
-                                             MachinePostDominatorTree *PDT)
-    : MF(MF), DT(DT), PDT(PDT), ST(&MF->getSubtarget<GCNSubtarget>()),
+AMDGPU::PhiLoweringHelper::PhiLoweringHelper(MachineFunction &MF,
+                                             MachineDominatorTree &DT,
+                                             MachinePostDominatorTree &PDT)
+    : MF(MF), DT(DT), PDT(PDT), ST(&MF.getSubtarget<GCNSubtarget>()),
       LMC(&AMDGPU::LaneMaskConstants::get(*ST)) {
-  MRI = &MF->getRegInfo();
+  MRI = &MF.getRegInfo();
 
   TII = ST->getInstrInfo();
 }
@@ -466,8 +466,8 @@ void AMDGPU::PhiLoweringHelper::mergeIncomingLaneMasks(
   // constant folding.
   // Incoming with smaller DFSNumIn goes first, DFSNumIn is 0 for entry block.
   llvm::sort(Incomings, [this](Incoming LHS, Incoming RHS) {
-    return DT->getNode(LHS.Block)->getDFSNumIn() <
-           DT->getNode(RHS.Block)->getDFSNumIn();
+    return DT.getNode(LHS.Block)->getDFSNumIn() <
+           DT.getNode(RHS.Block)->getDFSNumIn();
   });
 
   // Values in a loop that are observed outside the loop receive a simple but
@@ -476,7 +476,7 @@ void AMDGPU::PhiLoweringHelper::mergeIncomingLaneMasks(
   for (MachineInstr &Use : MRI->use_instructions(DstReg))
     DomBlocks.push_back(Use.getParent());
 
-  MachineBasicBlock *PostDomBound = PDT->findNearestCommonDominator(DomBlocks);
+  MachineBasicBlock *PostDomBound = PDT.findNearestCommonDominator(DomBlocks);
 
   // FIXME: This fails to find irreducible cycles. If we have a def (other
   // than a constant) in a pair of blocks that end up looping back to each
@@ -547,10 +547,10 @@ bool AMDGPU::PhiLoweringHelper::lowerPhis() {
   if (Vreg1Phis.empty())
     return false;
 
-  LoopFinder LF(*DT, *PDT);
-  PhiIncomingAnalysis PIA(*PDT, TII);
+  LoopFinder LF(DT, PDT);
+  PhiIncomingAnalysis PIA(PDT, TII);
 
-  DT->updateDFSNumbers();
+  DT.updateDFSNumbers();
   for (MachineInstr *MI : Vreg1Phis) {
     MachineBasicBlock &MBB = *MI->getParent();
     LLVM_DEBUG(dbgs() << "Lower PHI: " << *MI);
@@ -565,7 +565,7 @@ bool AMDGPU::PhiLoweringHelper::lowerPhis() {
     PhiRegisters.insert(DstReg);
 #endif
 
-    MachineIDFSSAUpdater SSAUpdater(*DT, *MF, DstReg);
+    MachineIDFSSAUpdater SSAUpdater(DT, MF, DstReg);
     mergeIncomingLaneMasks(DstReg, MBB, Incomings, SSAUpdater, LF, PIA);
 
     Register NewReg = SSAUpdater.getValueInMiddleOfBlock(&MBB);
@@ -581,10 +581,10 @@ bool AMDGPU::PhiLoweringHelper::lowerPhis() {
 
 bool Vreg1LoweringHelper::lowerCopiesToI1() {
   bool Changed = false;
-  AMDGPU::LoopFinder LF(*DT, *PDT);
+  AMDGPU::LoopFinder LF(DT, PDT);
   SmallVector<MachineInstr *, 4> DeadCopies;
 
-  for (MachineBasicBlock &MBB : *MF) {
+  for (MachineBasicBlock &MBB : MF) {
     LF.initialize(MBB);
 
     for (MachineInstr &MI : MBB) {
@@ -635,10 +635,10 @@ bool Vreg1LoweringHelper::lowerCopiesToI1() {
         DomBlocks.push_back(Use.getParent());
 
       MachineBasicBlock *PostDomBound =
-          PDT->findNearestCommonDominator(DomBlocks);
+          PDT.findNearestCommonDominator(DomBlocks);
       unsigned FoundLoopLevel = LF.findLoop(PostDomBound);
       if (FoundLoopLevel) {
-        MachineIDFSSAUpdater SSAUpdater(*DT, *MF, DstReg);
+        MachineIDFSSAUpdater SSAUpdater(DT, MF, DstReg);
         SSAUpdater.addUseBlock(&MBB);
         SSAUpdater.addAvailableValue(&MBB, DstReg);
         LF.addLoopEntries(FoundLoopLevel, SSAUpdater, *MRI, LaneMaskRegAttrs);
@@ -744,7 +744,7 @@ void Vreg1LoweringHelper::markAsLaneMask(Register DstReg) const {
 
 void Vreg1LoweringHelper::getCandidatesForLowering(
     SmallVectorImpl<MachineInstr *> &Vreg1Phis) const {
-  for (MachineBasicBlock &MBB : *MF) {
+  for (MachineBasicBlock &MBB : MF) {
     for (MachineInstr &MI : MBB.phis()) {
       if (isVreg1(MI.getOperand(0).getReg()))
         Vreg1Phis.push_back(&MI);
@@ -861,7 +861,7 @@ static bool runFixI1Copies(MachineFunction &MF, MachineDominatorTree &MDT,
   if (MF.getProperties().hasSelected())
     return false;
 
-  Vreg1LoweringHelper Helper(&MF, &MDT, &MPDT);
+  Vreg1LoweringHelper Helper(MF, MDT, MPDT);
   bool Changed = false;
   Changed |= Helper.lowerCopiesFromI1();
   Changed |= Helper.lowerPhis();

--- a/llvm/lib/Target/AMDGPU/SILowerI1Copies.h
+++ b/llvm/lib/Target/AMDGPU/SILowerI1Copies.h
@@ -41,15 +41,15 @@ Register createLaneMaskReg(MachineRegisterInfo *MRI,
 
 class PhiLoweringHelper {
 public:
-  PhiLoweringHelper(MachineFunction *MF, MachineDominatorTree *DT,
-                    MachinePostDominatorTree *PDT);
+  PhiLoweringHelper(MachineFunction &MF, MachineDominatorTree &DT,
+                    MachinePostDominatorTree &PDT);
   virtual ~PhiLoweringHelper() = default;
 
 protected:
   bool IsWave32 = false;
-  MachineFunction *MF = nullptr;
-  MachineDominatorTree *DT = nullptr;
-  MachinePostDominatorTree *PDT = nullptr;
+  MachineFunction &MF;
+  MachineDominatorTree &DT;
+  MachinePostDominatorTree &PDT;
   MachineRegisterInfo *MRI = nullptr;
   const GCNSubtarget *ST = nullptr;
   const SIInstrInfo *TII = nullptr;


### PR DESCRIPTION
These fields were never nullptr. Likewise for its derived classes
Vreg1LoweringHelper and DivergenceLoweringHelper.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
