### PR TITLE
[CIR] Support LNot for Vector of bool

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1052,9 +1052,8 @@ mlir::Value CIRAttrToValue::visitCirAttr(cir::VTableAttr vtableArr) {
 /// ZeroAttr visitor.
 mlir::Value CIRAttrToValue::visitCirAttr(cir::ZeroAttr attr) {
   mlir::Location loc = parentOp->getLoc();
-  mlir::DataLayout layout(parentOp->getParentOfType<mlir::ModuleOp>());
-  return mlir::LLVM::ZeroOp::create(
-      rewriter, loc, convertTypeForMemory(*converter, layout, attr.getType()));
+  mlir::Type llvmTy = converter->convertType(attr.getType());
+  return mlir::LLVM::ZeroOp::create(rewriter, loc, llvmTy);
 }
 
 // This class handles rewriting initializer attributes for types that do not

--- a/clang/test/CIR/CodeGen/vector-bool.cpp
+++ b/clang/test/CIR/CodeGen/vector-bool.cpp
@@ -333,3 +333,23 @@ void vec_bool_compare() {
 // SHARED: %[[LE:.*]] = icmp ule <8 x i1> %[[TMP_A_VEC]], %[[TMP_B_VEC]]
 // SHARED: %[[LE_I8:.*]] = bitcast <8 x i1> %[[LE]] to i8
 // SHARED: store i8 %[[LE_I8]], ptr %[[LE_ADDR]], align 1
+
+void vec_bool_logical_not() {
+  v8b a;
+  v8b b = !a;
+}
+
+// CIR: %[[A_ADDR:.*]] = cir.alloca "a" {{.*}} : !cir.ptr<!cir.vector<8 x !cir.bool>>
+// CIR: %[[B_ADDR:.*]] = cir.alloca "b" {{.*}} init : !cir.ptr<!cir.vector<8 x !cir.bool>>
+// CIR: %[[TMP_A:.*]] = cir.load {{.*}} %[[A_ADDR]] : !cir.ptr<!cir.vector<8 x !cir.bool>>, !cir.vector<8 x !cir.bool>
+// CIR: %[[CONST_0_VEC:.*]] = cir.const #cir.zero : !cir.vector<8 x !cir.bool>
+// CIR: %[[RESULT:.*]] = cir.vec.cmp(eq, %[[TMP_A]], %[[CONST_0_VEC]]) : !cir.vector<8 x !cir.bool>, !cir.vector<8 x !cir.bool>
+// CIR: cir.store {{.*}} %[[RESULT]], %[[B_ADDR]] : !cir.vector<8 x !cir.bool>, !cir.ptr<!cir.vector<8 x !cir.bool>>
+
+// SHARED: %[[A_ADDR:.*]] = alloca i8, align 1
+// SHARED: %[[B_ADDR:.*]] = alloca i8, align 1
+// SHARED: %[[TMP_A:.*]] = load i8, ptr %[[A_ADDR]], align 1
+// SHARED: %[[TMP_A_VEC:.*]] = bitcast i8 %[[TMP_A]] to <8 x i1>
+// SHARED: %[[RESULT:.*]] = icmp eq <8 x i1> %[[TMP_A_VEC]], zeroinitializer
+// SHARED: %[[RESULT_I8:.*]] = bitcast <8 x i1> %[[RESULT]] to i8
+// SHARED: store i8 %[[RESULT_I8]], ptr %[[B_ADDR]], align 1


### PR DESCRIPTION
Support Vector of bool type in logical not op and remove using convertTypeForMemory in ZeroAttr, as we don't want to convert the type of attr from vec of bool to iN because it either will be used in Vector op or will be assigned to vector of bool value after it bitcasted to vector of bool.

All other branches of convertTypeForMemory are unused for ZeroAttr because for Int/BitInt and Bool we use the default value 0 or false directly, but not ZeroAttr