### PR TITLE
[libc++] Give the LNT tooling its own requirements.txt

### DIFF
--- a/.github/workflows/libcxx-benchmark-commit.yml
+++ b/.github/workflows/libcxx-benchmark-commit.yml
@@ -144,7 +144,7 @@ jobs:
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install -r libcxx/utils/requirements.txt
+          pip install -r libcxx/utils/ci/lnt/requirements.txt
 
       - name: Run the benchmarks
         env:

--- a/.github/workflows/libcxx-benchmark-cron.yml
+++ b/.github/workflows/libcxx-benchmark-cron.yml
@@ -126,10 +126,10 @@ jobs:
         with:
           python-version: '3.14'
           cache: pip
-          cache-dependency-path: libcxx/utils/requirements.txt
+          cache-dependency-path: libcxx/utils/ci/lnt/requirements.txt
 
       - name: Install dependencies
-        run: pip install -r libcxx/utils/requirements.txt
+        run: pip install -r libcxx/utils/ci/lnt/requirements.txt
 
       - name: Determine anchor commits
         if: ${{ steps.restore-anchors.outputs.cache-hit != 'true' }}

--- a/libcxx/utils/ci/lnt/dispatch-benchmarks
+++ b/libcxx/utils/ci/lnt/dispatch-benchmarks
@@ -326,7 +326,7 @@ def main(argv: List[str]) -> int:
                     'Results are submitted to LNT unless this is a dry run. That is not optional: '
                     'results that are not recorded anywhere would be requested again on every '
                     'invocation, forever.',
-        epilog='This script depends on the modules listed in `libcxx/utils/requirements.txt`.',
+        epilog='This script depends on the modules listed in `libcxx/utils/ci/lnt/requirements.txt`.',
         formatter_class=HelpFormatter)
     parser.add_argument('--work-items', type=argparse.FileType('r'), default=sys.stdin,
         help='A file containing the plan, one JSON object per line. By default, this is read from '

--- a/libcxx/utils/ci/lnt/plan-benchmarks
+++ b/libcxx/utils/ci/lnt/plan-benchmarks
@@ -122,7 +122,7 @@ def main(argv: List[str]) -> int:
                     'Each line of the produced plan carries the commit to benchmark, the machine the '
                     'plan is about, how many runs the commit already has and how many it should end '
                     'up with, and a human-readable reason.',
-        epilog='This script depends on the modules listed in `libcxx/utils/requirements.txt`.',
+        epilog='This script depends on the modules listed in `libcxx/utils/ci/lnt/requirements.txt`.',
         formatter_class=HelpFormatter)
     parser.add_argument('--commit-list', type=argparse.FileType('r'), default=sys.stdin,
         help='A file of whitespace separated commits for which benchmark data is desired. By default, '

--- a/libcxx/utils/ci/lnt/requirements.txt
+++ b/libcxx/utils/ci/lnt/requirements.txt
@@ -1,0 +1,3 @@
+llvm-lnt
+PyGithub
+tabulate

--- a/libcxx/utils/ci/lnt/run-benchmarks
+++ b/libcxx/utils/ci/lnt/run-benchmarks
@@ -70,7 +70,7 @@ def main(argv):
     parser = argparse.ArgumentParser(
         prog='run-benchmarks',
         description='Benchmark libc++ at the given commit and produce a LNT JSON report.',
-        epilog='This script depends on the modules listed in `libcxx/utils/requirements.txt`.')
+        epilog='This script depends on the modules listed in `libcxx/utils/ci/lnt/requirements.txt`.')
     parser.add_argument('--benchmark-commit', type=str, required=True,
         help='The SHA representing the version of the library to benchmark.')
     parser.add_argument('--test-suite-commit', type=str, required=True,
@@ -136,7 +136,7 @@ def main(argv):
     if args.build_dir is not None and args.build_dir.exists():
         sys.exit(f'error: build directory {args.build_dir} already exists; not overwriting it')
     if shutil.which('lnt') is None:
-        sys.exit('error: cannot find `lnt`; install libcxx/utils/requirements.txt')
+        sys.exit('error: cannot find `lnt`; install libcxx/utils/ci/lnt/requirements.txt')
 
     with contextlib.ExitStack() as stack:
         # The build artifacts are kept in --build-dir when it is given, and stored in a temporary directory

--- a/libcxx/utils/ci/lnt/select-anchor-commits
+++ b/libcxx/utils/ci/lnt/select-anchor-commits
@@ -142,7 +142,7 @@ def main(argv: List[str]) -> int:
                     'produce the same commits. This makes it possible to recompute the list in '
                     'a reproducible fashion, which is useful when e.g. re-generating historical '
                     'performance data after a configuration change.',
-        epilog='This script depends on the modules listed in `libcxx/utils/requirements.txt`.',
+        epilog='This script depends on the modules listed in `libcxx/utils/ci/lnt/requirements.txt`.',
         formatter_class=HelpFormatter)
     parser.add_argument('--since', type=date, required=True,
         help='Only select commits on or after this date (UTC). Selection starts at the first '

--- a/libcxx/utils/ci/lnt/submit-benchmarks
+++ b/libcxx/utils/ci/lnt/submit-benchmarks
@@ -18,7 +18,7 @@ def main(argv):
     parser = argparse.ArgumentParser(
         prog='submit-benchmarks',
         description='Submit a LNT JSON report to a LNT server.',
-        epilog='This script depends on the modules listed in `libcxx/utils/requirements.txt`.')
+        epilog='This script depends on the modules listed in `libcxx/utils/ci/lnt/requirements.txt`.')
     parser.add_argument('report', type=pathlib.Path,
         help='Path to the LNT JSON report to submit.')
     parser.add_argument('--lnt-url', type=str, required=True,

--- a/libcxx/utils/requirements.txt
+++ b/libcxx/utils/requirements.txt
@@ -1,11 +1,9 @@
+-r ci/lnt/requirements.txt
 click
 GitPython
-llvm-lnt
 numpy
 pandas
 plotly
-PyGithub
 scipy
 statsmodels
-tabulate
 tqdm


### PR DESCRIPTION
The LNT tooling alone has way fewer dependencies. Using a smaller requirements.txt should speed up the "request historical benchmark data" cron job that runs every 30 minutes and needs to install them.