### PR TITLE
IR: Intersect and drop the addrspacecast nonnull flag

### DIFF
--- a/llvm/docs/LangRef.md
+++ b/llvm/docs/LangRef.md
@@ -13273,7 +13273,8 @@ If `value` is of the {ref}`byte type <t_byte>`:
 ##### Syntax:
 
 ```
-<result> = addrspacecast <pty> <ptrval> to <pty2>       ; yields pty2
+<result> = addrspacecast <pty> <ptrval> to <pty2>          ; yields pty2
+<result> = addrspacecast nonnull <pty> <ptrval> to <pty2>  ; yields pty2
 ```
 
 ##### Overview:
@@ -13309,6 +13310,10 @@ should yield the original bit pattern).
 
 Which address space casts are supported depends on the target. Unsupported
 address space casts return {ref}`poison <poisonvalues>`.
+
+The optional `nonnull` flag asserts that `ptrval` is not the null value of
+its source address space; if it is, the result is
+{ref}`poison <poisonvalues>`.
 
 ##### Example:
 

--- a/llvm/include/llvm/Bitcode/LLVMBitCodes.h
+++ b/llvm/include/llvm/Bitcode/LLVMBitCodes.h
@@ -573,6 +573,9 @@ enum PossiblyExactOperatorOptionalFlags { PEO_EXACT = 0 };
 /// PossiblyDisjointInst's SubclassOptionalData contents.
 enum PossiblyDisjointInstOptionalFlags { PDI_DISJOINT = 0 };
 
+/// Flags for serializing AddrSpaceCastInst's SubclassOptionalData contents.
+enum AddrSpaceCastInstOptionalFlags { ASCI_NON_NULL = 0 };
+
 /// Mark to distinguish metadata from value in an operator bundle.
 enum MetadataOperandBundleValueMarker { OB_METADATA = 0x80000000 };
 

--- a/llvm/include/llvm/IR/IRBuilder.h
+++ b/llvm/include/llvm/IR/IRBuilder.h
@@ -2255,9 +2255,16 @@ public:
     return CreateCast(Instruction::BitCast, V, DestTy, Name);
   }
 
-  Value *CreateAddrSpaceCast(Value *V, Type *DestTy,
-                             const Twine &Name = "") {
-    return CreateCast(Instruction::AddrSpaceCast, V, DestTy, Name);
+  Value *CreateAddrSpaceCast(Value *V, Type *DestTy, const Twine &Name = "",
+                             bool IsNonNull = false) {
+    if (V->getType() == DestTy)
+      return V;
+    if (Value *Folded = Folder.FoldCast(Instruction::AddrSpaceCast, V, DestTy))
+      return Folded;
+    Instruction *I = Insert(new AddrSpaceCastInst(V, DestTy), Name);
+    if (IsNonNull)
+      cast<AddrSpaceCastInst>(I)->setNonNull();
+    return I;
   }
 
   Value *CreateZExtOrBitCast(Value *V, Type *DestTy, const Twine &Name = "") {

--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -5197,6 +5197,8 @@ protected:
   LLVM_ABI AddrSpaceCastInst *cloneImpl() const;
 
 public:
+  enum { NonNull = (1 << 0) };
+
   /// Constructor with insert-before-instruction semantics
   LLVM_ABI AddrSpaceCastInst(
       Value *S,                  ///< The value to be casted
@@ -5213,6 +5215,14 @@ public:
   static bool classof(const Value *V) {
     return isa<Instruction>(V) && classof(cast<Instruction>(V));
   }
+
+  void setNonNull(bool B = true) {
+    SubclassOptionalData = (SubclassOptionalData & ~NonNull) | (B * NonNull);
+  }
+
+  /// Test whether the source is known not to be the null value of its
+  /// address space.
+  bool hasNonNull() const { return (SubclassOptionalData & NonNull) != 0; }
 
   /// Gets the pointer operand.
   Value *getPointerOperand() {

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -7787,9 +7787,16 @@ int LLParser::parseInstruction(Instruction *&Inst, BasicBlock *BB,
       cast<TruncInst>(Inst)->setHasNoSignedWrap(true);
     return false;
   }
+  case lltok::kw_addrspacecast: {
+    bool NonNull = EatIfPresent(lltok::kw_nonnull);
+    if (parseCast(Inst, PFS, KeywordVal))
+      return true;
+    if (NonNull)
+      cast<AddrSpaceCastInst>(Inst)->setNonNull();
+    return false;
+  }
   case lltok::kw_sext:
   case lltok::kw_bitcast:
-  case lltok::kw_addrspacecast:
   case lltok::kw_fptoui:
   case lltok::kw_fptosi:
   case lltok::kw_inttoptr:

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -5368,6 +5368,9 @@ Error BitcodeReader::parseFunctionBody(Function *F) {
             cast<TruncInst>(I)->setHasNoUnsignedWrap(true);
           if (Record[OpNum] & (1 << bitc::TIO_NO_SIGNED_WRAP))
             cast<TruncInst>(I)->setHasNoSignedWrap(true);
+        } else if (Opc == Instruction::AddrSpaceCast) {
+          if (Record[OpNum] & (1 << bitc::ASCI_NON_NULL))
+            cast<AddrSpaceCastInst>(I)->setNonNull(true);
         }
         if (isa<FPMathOperator>(I)) {
           uint64_t Flags = Record[OpNum];

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -1859,6 +1859,9 @@ static uint64_t getOptimizationFlags(const Value *V) {
   } else if (const auto *ICmp = dyn_cast<ICmpInst>(V)) {
     if (ICmp->hasSameSign())
       Flags |= 1 << bitc::ICMP_SAME_SIGN;
+  } else if (const auto *ASC = dyn_cast<AddrSpaceCastInst>(V)) {
+    if (ASC->hasNonNull())
+      Flags |= 1 << bitc::ASCI_NON_NULL;
   }
 
   return Flags;

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -1533,6 +1533,9 @@ static void writeOptimizationInfo(raw_ostream &Out, const User *U) {
   } else if (const auto *ICmp = dyn_cast<ICmpInst>(U)) {
     if (ICmp->hasSameSign())
       Out << " samesign";
+  } else if (const auto *ASC = dyn_cast<AddrSpaceCastInst>(U)) {
+    if (ASC->hasNonNull())
+      Out << " nonnull";
   }
 }
 

--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -463,6 +463,10 @@ void Instruction::dropPoisonGeneratingFlags() {
     cast<ICmpInst>(this)->setSameSign(false);
     break;
 
+  case Instruction::AddrSpaceCast:
+    cast<AddrSpaceCastInst>(this)->setNonNull(false);
+    break;
+
   case Instruction::Call: {
     if (auto *II = dyn_cast<IntrinsicInst>(this)) {
       switch (II->getIntrinsicID()) {
@@ -754,6 +758,14 @@ void Instruction::copyIRFlags(const Value *V, bool IncludeWrapFlags) {
   if (auto *SrcICmp = dyn_cast<ICmpInst>(V))
     if (auto *DestICmp = dyn_cast<ICmpInst>(this))
       DestICmp->setSameSign(SrcICmp->hasSameSign());
+
+  if (auto *SrcASC = dyn_cast<AddrSpaceCastInst>(V))
+    if (auto *DestASC = dyn_cast<AddrSpaceCastInst>(this)) {
+      assert(DestASC->getSrcAddressSpace() == SrcASC->getSrcAddressSpace() &&
+             "nonull flag cannot be safely preserved with different source "
+             "address spaces");
+      DestASC->setNonNull(SrcASC->hasNonNull());
+    }
 }
 
 void Instruction::andIRFlags(const Value *V) {
@@ -799,6 +811,14 @@ void Instruction::andIRFlags(const Value *V) {
   if (auto *SrcICmp = dyn_cast<ICmpInst>(V))
     if (auto *DestICmp = dyn_cast<ICmpInst>(this))
       DestICmp->setSameSign(DestICmp->hasSameSign() && SrcICmp->hasSameSign());
+
+  if (auto *SrcASC = dyn_cast<AddrSpaceCastInst>(V))
+    if (auto *DestASC = dyn_cast<AddrSpaceCastInst>(this)) {
+      assert(DestASC->getSrcAddressSpace() == SrcASC->getSrcAddressSpace() &&
+             "nonull flag cannot be safely preserved with different source "
+             "address spaces");
+      DestASC->setNonNull(DestASC->hasNonNull() && SrcASC->hasNonNull());
+    }
 }
 
 const char *Instruction::getOpcodeName(unsigned OpCode) {

--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -475,6 +475,10 @@ void Instruction::dropPoisonGeneratingFlags() {
     cast<ICmpInst>(this)->setSameSign(false);
     break;
 
+  case Instruction::AddrSpaceCast:
+    cast<AddrSpaceCastInst>(this)->setNonNull(false);
+    break;
+
   case Instruction::Call: {
     if (auto *II = dyn_cast<IntrinsicInst>(this)) {
       switch (II->getIntrinsicID()) {
@@ -766,6 +770,14 @@ void Instruction::copyIRFlags(const Value *V, bool IncludeWrapFlags) {
   if (auto *SrcICmp = dyn_cast<ICmpInst>(V))
     if (auto *DestICmp = dyn_cast<ICmpInst>(this))
       DestICmp->setSameSign(SrcICmp->hasSameSign());
+
+  if (auto *SrcASC = dyn_cast<AddrSpaceCastInst>(V))
+    if (auto *DestASC = dyn_cast<AddrSpaceCastInst>(this)) {
+      assert(DestASC->getSrcAddressSpace() == SrcASC->getSrcAddressSpace() &&
+             "nonull flag cannot be safely preserved with different source "
+             "address spaces");
+      DestASC->setNonNull(SrcASC->hasNonNull());
+    }
 }
 
 void Instruction::andIRFlags(const Value *V) {
@@ -811,6 +823,14 @@ void Instruction::andIRFlags(const Value *V) {
   if (auto *SrcICmp = dyn_cast<ICmpInst>(V))
     if (auto *DestICmp = dyn_cast<ICmpInst>(this))
       DestICmp->setSameSign(DestICmp->hasSameSign() && SrcICmp->hasSameSign());
+
+  if (auto *SrcASC = dyn_cast<AddrSpaceCastInst>(V))
+    if (auto *DestASC = dyn_cast<AddrSpaceCastInst>(this)) {
+      assert(DestASC->getSrcAddressSpace() == SrcASC->getSrcAddressSpace() &&
+             "nonull flag cannot be safely preserved with different source "
+             "address spaces");
+      DestASC->setNonNull(DestASC->hasNonNull() && SrcASC->hasNonNull());
+    }
 }
 
 const char *Instruction::getOpcodeName(unsigned OpCode) {

--- a/llvm/lib/IR/Operator.cpp
+++ b/llvm/lib/IR/Operator.cpp
@@ -54,6 +54,10 @@ bool Operator::hasPoisonGeneratingFlags() const {
     return false;
   case Instruction::ICmp:
     return cast<ICmpInst>(this)->hasSameSign();
+  case Instruction::AddrSpaceCast:
+    if (auto *ASC = dyn_cast<AddrSpaceCastInst>(this))
+      return ASC->hasNonNull();
+    return false;
   case Instruction::Call:
     if (auto *II = dyn_cast<IntrinsicInst>(this)) {
       switch (II->getIntrinsicID()) {

--- a/llvm/test/Assembler/flags.ll
+++ b/llvm/test/Assembler/flags.ll
@@ -293,6 +293,18 @@ define i1 @test_icmp_samesign(i32 %a, i32 %b) {
   ret i1 %res
 }
 
+define ptr @test_addrspacecast_nonnull(ptr addrspace(1) %a) {
+; CHECK: %res = addrspacecast nonnull ptr addrspace(1) %a to ptr
+  %res = addrspacecast nonnull ptr addrspace(1) %a to ptr
+  ret ptr %res
+}
+
+define <2 x ptr> @test_addrspacecast_nonnull_vector(<2 x ptr addrspace(1)> %a) {
+; CHECK: %res = addrspacecast nonnull <2 x ptr addrspace(1)> %a to <2 x ptr>
+  %res = addrspacecast nonnull <2 x ptr addrspace(1)> %a to <2 x ptr>
+  ret <2 x ptr> %res
+}
+
 define <2 x i1> @test_icmp_samesign2(<2 x i32> %a, <2 x i32> %b) {
   ; CHECK: %res = icmp samesign ult <2 x i32> %a, %b
   %res = icmp samesign ult <2 x i32> %a, %b

--- a/llvm/test/Bitcode/compatibility.ll
+++ b/llvm/test/Bitcode/compatibility.ll
@@ -1712,7 +1712,7 @@ define void @instructions.memops(ptr %base) {
 }
 
 ; Instructions -- Conversion Operations
-define void @instructions.conversions() {
+define void @instructions.conversions(ptr %pop) {
   trunc i32 -1 to i1
   ; CHECK: trunc i32 -1 to i1
   zext i32 -1 to i64
@@ -1747,6 +1747,8 @@ define void @instructions.conversions() {
   ; CHECK: bitcast i32 0 to i32
   addrspacecast ptr null to ptr addrspace(1)
   ; CHECK: addrspacecast ptr null to ptr addrspace(1)
+  addrspacecast nonnull ptr %pop to ptr addrspace(1)
+  ; CHECK: addrspacecast nonnull ptr %pop to ptr addrspace(1)
 
   ret void
 }

--- a/llvm/test/Bitcode/flags.ll
+++ b/llvm/test/Bitcode/flags.ll
@@ -7,7 +7,7 @@
 ; Make sure the flags are serialized/deserialized properly for both
 ; forward and backward references.
 
-define void @foo() nounwind {
+define void @foo(ptr addrspace(1) %p, <2 x ptr addrspace(1)> %pv) nounwind {
 entry:
   br label %first
 
@@ -32,6 +32,9 @@ second:                                           ; preds = %first
   %tv = trunc <2 x i32> %aa to <2 x i16>
   %ii = icmp samesign ult i32 %a, %z
   %iv = icmp samesign ult <2 x i32> %aa, %aa
+  %an = addrspacecast nonnull ptr addrspace(1) %p to ptr
+  %ap = addrspacecast ptr addrspace(1) %p to ptr
+  %anv = addrspacecast nonnull <2 x ptr addrspace(1)> %pv to <2 x ptr>
   unreachable
 
 first:                                                    ; preds = %entry
@@ -57,5 +60,6 @@ first:                                                    ; preds = %entry
   %ttv = trunc <2 x i32> %aa to <2 x i16>
   %icm = icmp samesign ult i32 %a, %zz
   %icv = icmp samesign ult <2 x i32> %aa, %aa
+  %ann = addrspacecast nonnull ptr addrspace(1) %p to ptr
   br label %second
 }

--- a/llvm/test/Transforms/EarlyCSE/flags.ll
+++ b/llvm/test/Transforms/EarlyCSE/flags.ll
@@ -112,3 +112,47 @@ define i32 @load_undef_noundef(ptr %p) {
   %v = load i32, ptr %p, !noundef !{}
   ret i32 %v
 }
+
+define void @addrspacecast_both_nonnull(ptr addrspace(1) %p) {
+; CHECK-LABEL: @addrspacecast_both_nonnull(
+; CHECK-NEXT:    [[C1:%.*]] = addrspacecast nonnull ptr addrspace(1) [[P:%.*]] to ptr
+; CHECK-NEXT:    call void @use.ptr(i32 0, ptr [[C1]])
+; CHECK-NEXT:    call void @use.ptr(i32 1, ptr [[C1]])
+; CHECK-NEXT:    ret void
+;
+  %c1 = addrspacecast nonnull ptr addrspace(1) %p to ptr
+  call void @use.ptr(i32 0, ptr %c1)
+  %c2 = addrspacecast nonnull ptr addrspace(1) %p to ptr
+  call void @use.ptr(i32 1, ptr %c2)
+  ret void
+}
+
+define void @addrspacecast_first_nonnull(ptr addrspace(1) %p) {
+; CHECK-LABEL: @addrspacecast_first_nonnull(
+; CHECK-NEXT:    [[C1:%.*]] = addrspacecast ptr addrspace(1) [[P:%.*]] to ptr
+; CHECK-NEXT:    call void @use.ptr(i32 0, ptr [[C1]])
+; CHECK-NEXT:    call void @use.ptr(i32 1, ptr [[C1]])
+; CHECK-NEXT:    ret void
+;
+  %c1 = addrspacecast nonnull ptr addrspace(1) %p to ptr
+  call void @use.ptr(i32 0, ptr %c1)
+  %c2 = addrspacecast ptr addrspace(1) %p to ptr
+  call void @use.ptr(i32 1, ptr %c2)
+  ret void
+}
+
+define void @addrspacecast_vector_first_nonnull(<2 x ptr addrspace(1)> %p) {
+; CHECK-LABEL: @addrspacecast_vector_first_nonnull(
+; CHECK-NEXT:    [[C1:%.*]] = addrspacecast <2 x ptr addrspace(1)> [[P:%.*]] to <2 x ptr>
+; CHECK-NEXT:    call void @use.vec(i32 0, <2 x ptr> [[C1]])
+; CHECK-NEXT:    call void @use.vec(i32 1, <2 x ptr> [[C1]])
+; CHECK-NEXT:    ret void
+;
+  %c1 = addrspacecast nonnull <2 x ptr addrspace(1)> %p to <2 x ptr>
+  call void @use.vec(i32 0, <2 x ptr> %c1)
+  %c2 = addrspacecast <2 x ptr addrspace(1)> %p to <2 x ptr>
+  call void @use.vec(i32 1, <2 x ptr> %c2)
+  ret void
+}
+
+declare void @use.vec(i32, <2 x ptr>) memory(read)

--- a/llvm/test/Transforms/InferAddressSpaces/AMDGPU/infer-addrspacecast.ll
+++ b/llvm/test/Transforms/InferAddressSpaces/AMDGPU/infer-addrspacecast.ll
@@ -53,3 +53,22 @@ define void @multiuse_addrspacecast_gep_addrspacecast(ptr addrspace(3) %ptr) {
   store i32 8, ptr addrspace(3) %asc1, align 8
   ret void
 }
+
+; nonnull is dropped when the cast is rebuilt on the sunk select operand.
+; CHECK-LABEL: @rebuilt_addrspacecast_drops_nonnull(
+; CHECK: %sel = select i1 %c, ptr addrspace(3) %p, ptr addrspace(3) %q
+; CHECK-NEXT: %1 = addrspacecast ptr addrspace(3) %sel to ptr
+; CHECK-NOT: nonnull
+; CHECK-NEXT: call void @use_flat(ptr %1)
+; CHECK-NEXT: %v = load i32, ptr addrspace(3) %sel, align 4
+; CHECK-NEXT: ret i32 %v
+define i32 @rebuilt_addrspacecast_drops_nonnull(i1 %c, ptr addrspace(3) %p, ptr addrspace(3) %q) {
+  %pf = addrspacecast nonnull ptr addrspace(3) %p to ptr
+  %qf = addrspacecast nonnull ptr addrspace(3) %q to ptr
+  %sel = select i1 %c, ptr %pf, ptr %qf
+  call void @use_flat(ptr %sel)
+  %v = load i32, ptr %sel
+  ret i32 %v
+}
+
+declare void @use_flat(ptr)

--- a/llvm/test/Transforms/InstCombine/addrspacecast.ll
+++ b/llvm/test/Transforms/InstCombine/addrspacecast.ll
@@ -241,3 +241,43 @@ define void @constant_fold_gep_inttoptr() #0 {
   store i32 7, ptr addrspace(4) %cast
   ret void
 }
+
+; Collapsing a cast-of-cast keeps the innermost source (%p in
+; addrspace(3)).  Only nonnull on the innermost cast refers to that
+; source. Here the flag is on the outer cast (asserting the
+; addrspace(0) intermediate), so it cannot carry over to the merged
+; addrspace(3) -> addrspace(1) cast.
+define ptr addrspace(1) @collapsed_castcast_outer_nonnull(ptr addrspace(3) %p) {
+; CHECK-LABEL: @collapsed_castcast_outer_nonnull(
+; CHECK-NEXT:    [[B:%.*]] = addrspacecast ptr addrspace(3) [[P:%.*]] to ptr addrspace(1)
+; CHECK-NEXT:    ret ptr addrspace(1) [[B]]
+;
+  %a = addrspacecast ptr addrspace(3) %p to ptr
+  %b = addrspacecast nonnull ptr %a to ptr addrspace(1)
+  ret ptr addrspace(1) %b
+}
+
+; The innermost cast's nonnull asserts %p (addrspace(3)) is non-null,
+; which is exactly the source of the merged cast.
+; TODO: preserve nonnull on the merged cast.
+define ptr addrspace(1) @collapsed_castcast_inner_nonnull(ptr addrspace(3) %p) {
+; CHECK-LABEL: @collapsed_castcast_inner_nonnull(
+; CHECK-NEXT:    [[B:%.*]] = addrspacecast ptr addrspace(3) [[P:%.*]] to ptr addrspace(1)
+; CHECK-NEXT:    ret ptr addrspace(1) [[B]]
+;
+  %a = addrspacecast nonnull ptr addrspace(3) %p to ptr
+  %b = addrspacecast ptr %a to ptr addrspace(1)
+  ret ptr addrspace(1) %b
+}
+
+; Same as @collapsed_castcast_inner_nonnull with vectors of pointers.
+; TODO: preserve nonnull on the merged cast.
+define <2 x ptr addrspace(1)> @collapsed_castcast_inner_nonnull_vec(<2 x ptr addrspace(3)> %p) {
+; CHECK-LABEL: @collapsed_castcast_inner_nonnull_vec(
+; CHECK-NEXT:    [[B:%.*]] = addrspacecast <2 x ptr addrspace(3)> [[P:%.*]] to <2 x ptr addrspace(1)>
+; CHECK-NEXT:    ret <2 x ptr addrspace(1)> [[B]]
+;
+  %a = addrspacecast nonnull <2 x ptr addrspace(3)> %p to <2 x ptr>
+  %b = addrspacecast <2 x ptr> %a to <2 x ptr addrspace(1)>
+  ret <2 x ptr addrspace(1)> %b
+}

--- a/llvm/test/Transforms/SimplifyCFG/HoistCode.ll
+++ b/llvm/test/Transforms/SimplifyCFG/HoistCode.ll
@@ -214,6 +214,36 @@ F:
   ret i16 %z2
 }
 
+define ptr @hoist_addrspacecast_flags_preserve(i1 %C, ptr addrspace(1) %p) {
+; CHECK-LABEL: @hoist_addrspacecast_flags_preserve(
+; CHECK-NEXT:  common.ret:
+; CHECK-NEXT:    [[Z1:%.*]] = addrspacecast nonnull ptr addrspace(1) [[P:%.*]] to ptr
+; CHECK-NEXT:    ret ptr [[Z1]]
+;
+  br i1 %C, label %T, label %F
+T:
+  %z1 = addrspacecast nonnull ptr addrspace(1) %p to ptr
+  ret ptr %z1
+F:
+  %z2 = addrspacecast nonnull ptr addrspace(1) %p to ptr
+  ret ptr %z2
+}
+
+define ptr @hoist_addrspacecast_flags_drop(i1 %C, ptr addrspace(1) %p) {
+; CHECK-LABEL: @hoist_addrspacecast_flags_drop(
+; CHECK-NEXT:  common.ret:
+; CHECK-NEXT:    [[Z1:%.*]] = addrspacecast ptr addrspace(1) [[P:%.*]] to ptr
+; CHECK-NEXT:    ret ptr [[Z1]]
+;
+  br i1 %C, label %T, label %F
+T:
+  %z1 = addrspacecast ptr addrspace(1) %p to ptr
+  ret ptr %z1
+F:
+  %z2 = addrspacecast nonnull ptr addrspace(1) %p to ptr
+  ret ptr %z2
+}
+
 define ptr @hoist_gep_flags_both_nuw(i1 %C, ptr %p) {
 ; CHECK-LABEL: @hoist_gep_flags_both_nuw(
 ; CHECK-NEXT:  common.ret:

--- a/llvm/unittests/IR/InstructionsTest.cpp
+++ b/llvm/unittests/IR/InstructionsTest.cpp
@@ -861,6 +861,27 @@ TEST_F(ModuleWithFunctionTest, DropPoisonGeneratingFlags) {
     GI->dropPoisonGeneratingFlags();
     ASSERT_FALSE(GI->isInBounds());
   }
+
+  {
+    Value *Ptr = B.CreateIntToPtr(Arg0, B.getPtrTy(1));
+    auto *ASC = cast<AddrSpaceCastInst>(
+        B.CreateAddrSpaceCast(Ptr, B.getPtrTy(), "", /*IsNonNull*/ true));
+    EXPECT_TRUE(ASC->hasNonNull());
+    EXPECT_TRUE(ASC->hasPoisonGeneratingFlags());
+    ASC->dropPoisonGeneratingFlags();
+    EXPECT_FALSE(ASC->hasNonNull());
+    EXPECT_FALSE(ASC->hasPoisonGeneratingFlags());
+  }
+
+  {
+    // A ConstantExpr addrspacecast is an Operator but not an
+    // AddrSpaceCastInst; hasPoisonGeneratingFlags() must not assume the
+    // instruction subclass.
+    Constant *NullPtr = Constant::getNullValue(B.getPtrTy(1));
+    auto *CE =
+        cast<Operator>(ConstantExpr::getAddrSpaceCast(NullPtr, B.getPtrTy()));
+    EXPECT_FALSE(CE->hasPoisonGeneratingFlags());
+  }
 }
 
 TEST(InstructionsTest, GEPIndices) {


### PR DESCRIPTION
Teach the flag-propagation controls about the nonnull flag
on addrspacecast.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>