### PR TITLE
[lldb][Fortran] Add Fortran language plugin to LLDB

### DIFF
--- a/lldb/include/lldb/Target/Language.h
+++ b/lldb/include/lldb/Target/Language.h
@@ -443,6 +443,8 @@ public:
   /// Equivalent to \c LanguageIsC||LanguageIsObjC||LanguageIsCPlusPlus.
   static bool LanguageIsCFamily(lldb::LanguageType language);
 
+  static bool LanguageIsFortran(lldb::LanguageType language);
+
   static bool LanguageIsPascal(lldb::LanguageType language);
 
   // return the primary language, so if LanguageIsC(l), return eLanguageTypeC,

--- a/lldb/source/Plugins/Language/CMakeLists.txt
+++ b/lldb/source/Plugins/Language/CMakeLists.txt
@@ -7,3 +7,6 @@ set_property(DIRECTORY PROPERTY LLDB_TOLERATED_PLUGIN_DEPENDENCIES
 add_subdirectory(CPlusPlus)
 add_subdirectory(ObjC)
 add_subdirectory(ObjCPlusPlus)
+if(LLDB_ENABLE_FORTRAN)
+  add_subdirectory(Fortran)
+endif()

--- a/lldb/source/Plugins/Language/Fortran/CMakeLists.txt
+++ b/lldb/source/Plugins/Language/Fortran/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_lldb_library(lldbPluginFortranLanguage PLUGIN
+  FortranLanguage.cpp
+
+  LINK_LIBS
+    lldbCore
+    lldbDataFormatters
+    lldbExpression
+    lldbHost
+    lldbSymbol
+    lldbTarget
+    lldbUtility
+)

--- a/lldb/source/Plugins/Language/Fortran/FortranLanguage.cpp
+++ b/lldb/source/Plugins/Language/Fortran/FortranLanguage.cpp
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements the Fortran language Plugin.
+///
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ADT/StringRef.h"
+
+#include "FortranLanguage.h"
+
+#include "lldb/Core/PluginManager.h"
+
+#include "Plugins/TypeSystem/Fortran/TypeSystemFortran.h"
+
+using namespace llvm;
+using namespace lldb;
+using namespace lldb_private;
+using namespace lldb_private::formatters;
+
+LLDB_PLUGIN_DEFINE(FortranLanguage)
+
+void FortranLanguage::Initialize() {
+  PluginManager::RegisterPlugin(GetPluginNameStatic(), "Fortran Language",
+                                CreateInstance);
+}
+
+void FortranLanguage::Terminate() {
+  PluginManager::UnregisterPlugin(CreateInstance);
+}
+
+StringRef FortranLanguage::GetPluginNameStatic() {
+  static llvm::StringRef g_name("fortran");
+  return g_name;
+}
+
+//------------------------------------------------------------------
+// PluginInterface protocol
+//------------------------------------------------------------------
+StringRef FortranLanguage::GetPluginName() { return GetPluginNameStatic(); }
+
+uint32_t FortranLanguage::GetPluginVersion() { return 1; }
+
+Language *FortranLanguage::CreateInstance(LanguageType language) {
+  if (Language::LanguageIsFortran(language)) {
+    return new FortranLanguage();
+  }
+  return nullptr;
+}
+
+bool FortranLanguage::IsSourceFile(StringRef file_path) const {
+  const auto suffixes = {".f90", ".f", ".f95", ".f03", ".f08", ".f18"};
+  for (auto suffix : suffixes) {
+    if (file_path.ends_with_insensitive(suffix))
+      return true;
+  }
+  return false;
+}

--- a/lldb/source/Plugins/Language/Fortran/FortranLanguage.h
+++ b/lldb/source/Plugins/Language/Fortran/FortranLanguage.h
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file defines the Fortran language Plugin.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SOURCE_PLUGINS_LANGUAGE_FORTRAN_FORTRANLANGUAGE_H
+#define LLDB_SOURCE_PLUGINS_LANGUAGE_FORTRAN_FORTRANLANGUAGE_H
+#include "lldb/Target/Language.h"
+
+#include "llvm/ADT/StringRef.h"
+
+#include "lldb/Target/Language.h"
+#include "lldb/Utility/ConstString.h"
+#include "lldb/lldb-private.h"
+
+namespace lldb_private {
+
+class FortranLanguage : public Language {
+public:
+  FortranLanguage() = default;
+
+  ~FortranLanguage() override = default;
+
+  lldb::LanguageType GetLanguageType() const override {
+    return lldb::eLanguageTypeFortran90;
+  }
+  //------------------------------------------------------------------
+  // Static Functions
+  //------------------------------------------------------------------
+  static void Initialize();
+
+  static void Terminate();
+
+  static lldb_private::Language *CreateInstance(lldb::LanguageType language);
+
+  static llvm::StringRef GetPluginNameStatic();
+
+  //------------------------------------------------------------------
+  // PluginInterface protocol
+  //------------------------------------------------------------------
+  llvm::StringRef GetPluginName() override;
+
+  uint32_t GetPluginVersion();
+
+  bool IsSourceFile(llvm::StringRef file_path) const override;
+};
+
+}; // namespace lldb_private
+
+#endif // LLDB_SOURCE_PLUGINS_LANGUAGE_FORTRAN_FORTRANLANGUAGE_H

--- a/lldb/source/Target/Language.cpp
+++ b/lldb/source/Target/Language.cpp
@@ -396,6 +396,20 @@ bool Language::LanguageIsCFamily(LanguageType language) {
   }
 }
 
+bool Language::LanguageIsFortran(LanguageType language) {
+  switch (language) {
+  case eLanguageTypeFortran77:
+  case eLanguageTypeFortran90:
+  case eLanguageTypeFortran95:
+  case eLanguageTypeFortran03:
+  case eLanguageTypeFortran08:
+  case eLanguageTypeFortran18:
+    return true;
+  default:
+    return false;
+  }
+}
+
 bool Language::LanguageIsPascal(LanguageType language) {
   switch (language) {
   case eLanguageTypePascal83:

--- a/lldb/unittests/Language/CMakeLists.txt
+++ b/lldb/unittests/Language/CMakeLists.txt
@@ -1,3 +1,6 @@
 add_subdirectory(CPlusPlus)
 add_subdirectory(CLanguages)
 add_subdirectory(ObjC)
+if(LLDB_ENABLE_FORTRAN)  
+  add_subdirectory(Fortran)
+endif()

--- a/lldb/unittests/Language/Fortran/CMakeLists.txt
+++ b/lldb/unittests/Language/Fortran/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_lldb_unittest(LanguageFortranLanguageTests
+  FortranLanguageTest.cpp
+
+  LINK_LIBS
+    lldbPluginFortranLanguage
+)

--- a/lldb/unittests/Language/Fortran/FortranLanguageTest.cpp
+++ b/lldb/unittests/Language/Fortran/FortranLanguageTest.cpp
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file tests the Fortran Plugin features.
+///
+//===----------------------------------------------------------------------===//
+
+#include "Plugins/Language/Fortran/FortranLanguage.h"
+#include "TestingSupport/SubsystemRAII.h"
+#include "lldb/lldb-enumerations.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using namespace lldb_private;
+
+/// Returns the name of the LLDB plugin for the given language or an empty
+/// string if there is no fitting plugin.
+static llvm::StringRef GetPluginName(lldb::LanguageType language) {
+  Language *language_plugin = Language::FindPlugin(language);
+  if (language_plugin)
+    return language_plugin->GetPluginName();
+  return "";
+}
+
+TEST(FortranLanguage, LookupFortranLanguageByLanguageType) {
+  SubsystemRAII<FortranLanguage> langs;
+
+  EXPECT_EQ(GetPluginName(lldb::eLanguageTypeFortran77), "fortran");
+  EXPECT_EQ(GetPluginName(lldb::eLanguageTypeFortran90), "fortran");
+  EXPECT_EQ(GetPluginName(lldb::eLanguageTypeFortran95), "fortran");
+  EXPECT_EQ(GetPluginName(lldb::eLanguageTypeFortran03), "fortran");
+  EXPECT_EQ(GetPluginName(lldb::eLanguageTypeFortran08), "fortran");
+  EXPECT_EQ(GetPluginName(lldb::eLanguageTypeFortran18), "fortran");
+}


### PR DESCRIPTION
**Closed in favour of other PR**
This PR adds the Plugin necessary for LLDB to recognise Fortran.
Subsequent PRs will add the TypeSystem and the DWARFASTParser for Fortran.

Changes:
- Adds Fortran language Plugin.
- Adds LanguageIsFortran function to the Language class to help identify Fortran.

Testing:
- Check if language Plugin is registered.

 Part of the Add Fortran support to LLDB GSoC 2026 project.