### PR TITLE
[RISCV] Use the value type rather than the pointer type of a global when determining if an allocation granule makes sense.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
+++ b/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
@@ -1330,7 +1330,7 @@ void RISCVAsmPrinter::emitMachineConstantPoolValue(
 MaybeAlign
 RISCVAsmPrinter::getRequiredGlobalAlignmentGranule(const GlobalVariable &GV) {
   const MCSubtargetInfo &MCSTI = TM.getMCSubtargetInfo();
-  if (!GV.getType()->isSized())
+  if (!GV.getValueType()->isSized())
     return std::nullopt;
 
   uint64_t Size = GV.getGlobalSize(getDataLayout());


### PR DESCRIPTION
Further attempt to fix RISCV stage2 failure introduced by f6ea145aa8e89631ae04f72df32580b20256d40c.
