### PR TITLE
[libclc] Fix remainder calculation in clc_remquo for subnormals

### DIFF
--- a/libclc/clc/lib/generic/math/clc_remquo_stret.inc
+++ b/libclc/clc/lib/generic/math/clc_remquo_stret.inc
@@ -127,7 +127,7 @@ __clc_remquo_stret(__CLC_GENTYPE x, __CLC_GENTYPE y) {
                            ? (__CLC_CHARN)1
                            : (__CLC_CHARN)-1;
 
-    __CLC_GENTYPE t = __clc_mad(y, -__CLC_CONVERT_GENTYPE(qsgn), x);
+    __CLC_GENTYPE t = qsgn > 0 ? (x - y) : (x + y);
     ret = c ? t : __clc_flush_if_daz(x);
     q7 = c ? qsgn : 0;
 


### PR DESCRIPTION
The remainder t was previously computed using:

    __CLC_GENTYPE t = __clc_mad(y, -__CLC_CONVERT_GENTYPE(qsgn), x);

Multiplying y by -qsgn (+-1.0) introduces an unnecessary intermediate multiplication step. On platforms or execution modes where subnormals are flushed to zero computing `y * -qsgn` can prematurely flush a subnormal `y` to zero, resulting in `0.0 + x = x` instead of computing the subtraction `x - y` (or `x + y`).

Replace `__clc_mad` with a direct addition/subtraction based on the sign of the quotient:

    __CLC_GENTYPE t = qsgn > 0 ? (x - y) : (x + y);

This avoids multiplication by +-1.0, eliminates unwanted subnormal flushing on intermediate products in FTZ modes, and computes the exact remainder.