### PR TITLE
[GISel] Remove SPIRVInstructionSelect

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/InstructionSelect.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/InstructionSelect.h
@@ -41,10 +41,11 @@ public:
   void getAnalysisUsage(AnalysisUsage &AU) const override;
 
   MachineFunctionProperties getRequiredProperties() const override {
-    return MachineFunctionProperties()
-        .setIsSSA()
-        .setLegalized()
-        .setRegBankSelected();
+    MachineFunctionProperties RequiredProperties;
+    RequiredProperties.setIsSSA().setLegalized();
+    if (RequireRegBankSelection)
+      RequiredProperties.setRegBankSelected();
+    return RequiredProperties;
   }
 
   MachineFunctionProperties getSetProperties() const override {
@@ -52,7 +53,7 @@ public:
   }
 
   InstructionSelect(CodeGenOptLevel OL = CodeGenOptLevel::Default,
-                    char &PassID = ID);
+                    bool RequireRegBankSelection = true, char &PassID = ID);
 
   bool runOnMachineFunction(MachineFunction &MF) override;
   bool selectMachineFunction(MachineFunction &MF);
@@ -67,6 +68,7 @@ protected:
   ProfileSummaryInfo *PSI = nullptr;
 
   CodeGenOptLevel OptLevel = CodeGenOptLevel::None;
+  bool RequireRegBankSelection = true;
 
   bool selectInstr(MachineInstr &MI);
 };

--- a/llvm/lib/CodeGen/GlobalISel/InstructionSelect.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/InstructionSelect.cpp
@@ -63,8 +63,10 @@ INITIALIZE_PASS_END(InstructionSelect, DEBUG_TYPE,
                     "Select target instructions out of generic instructions",
                     false, false)
 
-InstructionSelect::InstructionSelect(CodeGenOptLevel OL, char &PassID)
-    : MachineFunctionPass(PassID), OptLevel(OL) {}
+InstructionSelect::InstructionSelect(CodeGenOptLevel OL,
+                                     bool RequireRegBankSelection, char &PassID)
+    : MachineFunctionPass(PassID), OptLevel(OL),
+      RequireRegBankSelection(RequireRegBankSelection) {}
 
 /// This class observes instruction insertions/removals.
 /// InstructionSelect stores an iterator of the instruction prior to the one

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -41,6 +41,7 @@
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Pass.h"
 #include "llvm/Passes/PassBuilder.h"
+#include "llvm/Support/CodeGen.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Target/TargetOptions.h"
 #include "llvm/Transforms/IPO/ExpandVariadics.h"
@@ -285,19 +286,8 @@ static cl::opt<bool> SPVEnableNonSemanticDI(
              "instructions"),
     cl::Optional, cl::init(false));
 
-namespace {
-// A custom subclass of InstructionSelect, which is mostly the same except from
-// not requiring RegBankSelect to occur previously.
-class SPIRVInstructionSelect : public InstructionSelect {
-  // We don't use register banks, so unset the requirement for them
-  MachineFunctionProperties getRequiredProperties() const override {
-    return InstructionSelect::getRequiredProperties().resetRegBankSelected();
-  }
-};
-} // namespace
-
 // Add the custom SPIRVInstructionSelect from above.
 bool SPIRVPassConfig::addGlobalInstructionSelect() {
-  addPass(new SPIRVInstructionSelect());
+  addPass(new InstructionSelect(CodeGenOptLevel::Default, false));
   return false;
 }

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -288,6 +288,7 @@ static cl::opt<bool> SPVEnableNonSemanticDI(
 
 // Add the custom SPIRVInstructionSelect from above.
 bool SPIRVPassConfig::addGlobalInstructionSelect() {
-  addPass(new InstructionSelect(CodeGenOptLevel::Default, false));
+  addPass(new InstructionSelect(CodeGenOptLevel::Default,
+                                /*RequireRegBankSelection=*/false));
   return false;
 }


### PR DESCRIPTION
This subclass only existed to remove the need for MFs to have the
RegBankSelected property coming into InstructionSelect. The NewPM plays
much less nicely with pass inheritance, so change this to an option
specified as a parameter in the InstructionSelect constructor to avoid
inheritance so the future NewPM port can have the ~same API for
creation.

The usage of CodeGenOptLevel::Default matches the existing behavior,
although is probably wrong. That should be fixed in a separate patch
though.
