### PR TITLE
[lldb][lldb-server] Fix compilation on 32-bit

### DIFF
--- a/lldb/source/Host/common/NativeProcessProtocol.cpp
+++ b/lldb/source/Host/common/NativeProcessProtocol.cpp
@@ -676,7 +676,8 @@ Status NativeProcessProtocol::WriteMemory(lldb::addr_t addr, const void *buf,
     // If the address is before a breakpoint site, write up to the site, or to
     // the end of the write. Whichever comes first.
     if (addr < sbp_addr) {
-      const size_t to_write = std::min(size, size_t{sbp_addr - addr});
+      const size_t to_write =
+          std::min(static_cast<addr_t>(size), sbp_addr - addr);
       size_t part_bytes_written = 0;
       error = DoWriteMemory(addr, byte_buf, to_write, part_bytes_written);
       bytes_written += part_bytes_written;


### PR DESCRIPTION
Fixes #217348 / a132493da2f60a08cc66c75fa0dd12ccb3fe9c26

NativeProcessProtocol.cpp:679:53:
error: non-constant-expression cannot be narrowed from type 'unsigned long long' to 'size_t' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
  679 |       const size_t to_write = std::min(size, size_t{sbp_addr - addr});
      |                                                     ^~~~~~~~~~~~~~~

On 32-bit, size_t is 32-bit but addr_t is still a 64-bit type.

sbp_addr and addr are addr_t, so it makes more sense to cast size to that. Which is a widening on 32-bit and a nop on 64-bit.