### PR TITLE
[libsycl][Unit][NFC] Fix another unused capture warning

### DIFF
--- a/libsycl/unittests/mock/helpers.cpp
+++ b/libsycl/unittests/mock/helpers.cpp
@@ -309,7 +309,7 @@ void mock::MockLiboffload::initDefault() {
         return OL_SUCCESS;
       });
   ON_CALL(*this, olMemPrefetch)
-      .WillByDefault([this](ol_queue_handle_t Queue, size_t Count,
+      .WillByDefault([](ol_queue_handle_t Queue, size_t Count,
                             const void **Mems, const size_t *Sizes,
                             ol_mem_migration_flags_t Flags) -> ol_result_t {
         EXPECT_NE(Queue, nullptr);

--- a/libsycl/unittests/mock/helpers.cpp
+++ b/libsycl/unittests/mock/helpers.cpp
@@ -310,8 +310,8 @@ void mock::MockLiboffload::initDefault() {
       });
   ON_CALL(*this, olMemPrefetch)
       .WillByDefault([](ol_queue_handle_t Queue, size_t Count,
-                            const void **Mems, const size_t *Sizes,
-                            ol_mem_migration_flags_t Flags) -> ol_result_t {
+                        const void **Mems, const size_t *Sizes,
+                        ol_mem_migration_flags_t Flags) -> ol_result_t {
         EXPECT_NE(Queue, nullptr);
         EXPECT_EQ(Count, 1);
         EXPECT_NE(Mems, nullptr);


### PR DESCRIPTION
A follow up for https://github.com/llvm/llvm-project/pull/217418 to align the changes from https://github.com/llvm/llvm-project/pull/212104 with it.