### PR TITLE
[LoopSafety] Cache whether block is guaranteed to execute (NFC)

### DIFF
--- a/llvm/include/llvm/Analysis/MustExecute.h
+++ b/llvm/include/llvm/Analysis/MustExecute.h
@@ -61,6 +61,10 @@ class LoopSafetyInfo {
   // Used to update funclet bundle operands.
   DenseMap<BasicBlock *, ColorVector> BlockColors;
 
+  // Cache whether (the start of) this block is guaranteed to execute if the
+  // loop is entered.
+  mutable DenseMap<const BasicBlock *, bool> GuaranteedToExecute;
+
 protected:
   /// Computes block colors.
   LLVM_ABI void computeBlockColors(const Loop *CurLoop);
@@ -85,6 +89,10 @@ public:
   LLVM_ABI bool allLoopPathsLeadToBlock(const Loop *CurLoop,
                                         const BasicBlock *BB,
                                         const DominatorTree *DT) const;
+
+  LLVM_ABI bool allLoopPathsLeadToBlockImpl(const Loop *CurLoop,
+                                            const BasicBlock *BB,
+                                            const DominatorTree *DT) const;
 
   /// Computes safety information for a loop checks loop body & header for
   /// the possibility of may throw exception, it takes LoopSafetyInfo and loop

--- a/llvm/lib/Analysis/MustExecute.cpp
+++ b/llvm/lib/Analysis/MustExecute.cpp
@@ -204,6 +204,14 @@ bool LoopSafetyInfo::allLoopPathsLeadToBlock(const Loop *CurLoop,
   if (BB == CurLoop->getHeader())
     return true;
 
+  auto [It, Inserted] = GuaranteedToExecute.try_emplace(BB, false);
+  if (Inserted)
+    It->second = allLoopPathsLeadToBlockImpl(CurLoop, BB, DT);
+  return It->second;
+}
+
+bool LoopSafetyInfo::allLoopPathsLeadToBlockImpl(
+    const Loop *CurLoop, const BasicBlock *BB, const DominatorTree *DT) const {
   // Collect all transitive predecessors of BB in the same loop. This set will
   // be a subset of the blocks within the loop.
   SmallPtrSet<const BasicBlock *, 4> Predecessors;


### PR DESCRIPTION
To avoid doing the CFG walk multiple times if instructions from the same block are queried.

This is for an upcoming change that does more isGuaranteedToExecute() queries.