### PR TITLE
[SystemZ][z/OS] Fix crash when personality function is null

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -1609,13 +1609,13 @@ void SystemZAsmPrinter::calculatePPA1() {
     const Function *Per = dyn_cast<Function>(
         MF->getFunction().getPersonalityFn()->stripPointerCasts());
     PersonalityRoutine = Per ? MF->getTarget().getSymbol(Per) : nullptr;
-    assert(PersonalityRoutine && "Missing personality routine");
-
-    GCCEH = MF->getContext().getOrCreateSymbol(Twine("GCC_except_table") +
-                                               Twine(MF->getFunctionNumber()));
-    PersonalityADADisp = ADATable.insert(PersonalityRoutine,
-                                         SystemZII::MO_ADA_INDIRECT_FUNC_DESC);
-    GCCEHADADisp = ADATable.insert(GCCEH, SystemZII::MO_ADA_DATA_SYMBOL_ADDR);
+    if (PersonalityRoutine) {
+      GCCEH = MF->getContext().getOrCreateSymbol(
+          Twine("GCC_except_table") + Twine(MF->getFunctionNumber()));
+      PersonalityADADisp = ADATable.insert(
+          PersonalityRoutine, SystemZII::MO_ADA_INDIRECT_FUNC_DESC);
+      GCCEHADADisp = ADATable.insert(GCCEH, SystemZII::MO_ADA_DATA_SYMBOL_ADDR);
+    }
   }
 
   // Get the name of the function, with suffix _.

--- a/llvm/test/CodeGen/SystemZ/zos-no-personality.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-no-personality.ll
@@ -1,0 +1,19 @@
+; RUN: llc -mtriple s390x-zos < %s | FileCheck %s
+
+define { ptr, i32 } @foo() personality ptr null {
+  invoke void null(ptr null, ptr null)
+          to label %1 unwind label %2
+
+1:
+  ret { ptr, i32 } zeroinitializer
+
+2:
+  %3 = landingpad { ptr, i32 }
+          catch ptr null
+  ret { ptr, i32 } %3
+}
+
+; CHECK: foo DS 0H
+; CHECK-NOT: .gcc_exception_table.foo
+; CHECK: L#PPA1_foo_0 DS 0H
+; CHECK-NOT: *   Bit 3: 1 = C++ EH block


### PR DESCRIPTION
When the personality function is specified as `null`, then the current code triggers an assertion. The correct behaviour, like on Linux, is to not emit the DWARF EH data and the reference to the personality function.