### PR TITLE
[RISCV]  Avoid fatal error for SiFive CLIC preemptible frame pointers

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -595,6 +595,9 @@ features cannot lower the translation-unit ABI level;
 - Added a new warning when the same interrupt type is specified more than
   once in a RISC-V `interrupt` attribute.
 
+- SiFive CLIC preemptible interrupt handlers now diagnose unsupported frame
+  pointers instead of producing a backend fatal error.
+
 - Added `-march=native` for better compatibility with ARM, AArch64, and X86. This
   option will be treated like `-mcpu=native` if `-mcpu` is not present. If
   `-mcpu` is present, the ISA will be selected from the host CPU and the tune

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -26239,8 +26239,9 @@ SDValue RISCVTargetLowering::LowerFormalArguments(
       reportFatalUsageError("'rnmi' interrupt kind requires Srnmi extension");
     const TargetFrameLowering *TFI = Subtarget.getFrameLowering();
     if (Kind.starts_with("SiFive-CLIC-preemptible") && TFI->hasFP(MF))
-      reportFatalUsageError("'SiFive-CLIC-preemptible' interrupt kinds cannot "
-                            "have a frame pointer");
+      Func.getContext().diagnose(DiagnosticInfoUnsupported{
+          Func, "'SiFive-CLIC-preemptible' interrupt kinds cannot have a frame "
+                "pointer; consider compiling with '-fomit-frame-pointer'"});
   }
 
   EVT PtrVT = getPointerTy(DAG.getDataLayout());

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -26240,8 +26240,9 @@ SDValue RISCVTargetLowering::LowerFormalArguments(
     const TargetFrameLowering *TFI = Subtarget.getFrameLowering();
     if (Kind.starts_with("SiFive-CLIC-preemptible") && TFI->hasFP(MF))
       Func.getContext().diagnose(DiagnosticInfoUnsupported{
-          Func, "'SiFive-CLIC-preemptible' interrupt kinds cannot have a frame "
-                "pointer; consider compiling with '-fomit-frame-pointer'"});
+          Func,
+          "'SiFive-CLIC-preemptible' interrupt functions cannot have a frame "
+          "pointer"});
   }
 
   EVT PtrVT = getPointerTy(DAG.getDataLayout());

--- a/llvm/test/CodeGen/RISCV/sifive-interrupt-attr-err.ll
+++ b/llvm/test/CodeGen/RISCV/sifive-interrupt-attr-err.ll
@@ -5,7 +5,7 @@
 
 ;; Test that these report regular errors.
 
-; CHECK: error: <unknown>:0:0: in function preemptible void (): 'SiFive-CLIC-preemptible' interrupt kinds cannot have a frame pointer; consider compiling with '-fomit-frame-pointer'
+; CHECK: error: <unknown>:0:0: in function preemptible void (): 'SiFive-CLIC-preemptible' interrupt functions cannot have a frame pointer
 
 define void @preemptible() "interrupt"="SiFive-CLIC-preemptible" "frame-pointer"="all" {
   ret void

--- a/llvm/test/CodeGen/RISCV/sifive-interrupt-attr-err.ll
+++ b/llvm/test/CodeGen/RISCV/sifive-interrupt-attr-err.ll
@@ -3,9 +3,9 @@
 ; RUN: not llc -mtriple riscv64-unknown-elf -mattr=+experimental-xsfmclic -o - %s 2>&1 \
 ; RUN:   | FileCheck %s
 
-;; Test that these report fatal errors.
+;; Test that these report regular errors.
 
-; CHECK: LLVM ERROR: 'SiFive-CLIC-preemptible' interrupt kinds cannot have a frame pointer
+; CHECK: error: <unknown>:0:0: in function preemptible void (): 'SiFive-CLIC-preemptible' interrupt kinds cannot have a frame pointer; consider compiling with '-fomit-frame-pointer'
 
 define void @preemptible() "interrupt"="SiFive-CLIC-preemptible" "frame-pointer"="all" {
   ret void


### PR DESCRIPTION
SiFive CLIC `preemptible` interrupt handlers currently use `s0` to preserve `mcause` and cannot be generated with a frame pointer. At `-O0`, Clang enables frame pointers by default, causing the fatal error to produce a backend crash report.

This commit switches to `DiagnosticInfoUnsupported` to emit a regular source-located error and suggest considering `-fomit-frame-pointer`.

This does not change the existing code generation restriction.

Fixes https://github.com/llvm/llvm-project/issues/217936