### PR TITLE
[ARM] Adjust profitability check on and(anyext, c) -> zext(and) transfor…

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -13807,6 +13807,11 @@ static SDValue PerformADDVecReduce(SDNode *N, SelectionDAG &DAG,
   return SDValue();
 }
 
+bool ARMTargetLowering::isNarrowingProfitable(SDNode *N, EVT SrcVT,
+                                              EVT DestVT) const {
+  return isTypeLegal(DestVT) && DestVT.isVector();
+}
+
 bool
 ARMTargetLowering::isDesirableToCommuteWithShift(const SDNode *N,
                                                  CombineLevel Level) const {

--- a/llvm/lib/Target/ARM/ARMISelLowering.h
+++ b/llvm/lib/Target/ARM/ARMISelLowering.h
@@ -469,6 +469,8 @@ class VectorType;
     Align getABIAlignmentForCallingConv(Type *ArgTy,
                                         const DataLayout &DL) const override;
 
+    bool isNarrowingProfitable(SDNode *N, EVT SrcVT, EVT DestVT) const override;
+
     bool isDesirableToCommuteWithShift(const SDNode *N,
                                        CombineLevel Level) const override;
 

--- a/llvm/test/CodeGen/ARM/bool-ext-inc.ll
+++ b/llvm/test/CodeGen/ARM/bool-ext-inc.ll
@@ -16,10 +16,9 @@ define <4 x i32> @sext_inc_vec(<4 x i1> %x) {
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    vmov.i16 d16, #0x1
 ; CHECK-NEXT:    vmov d17, r0, r1
-; CHECK-NEXT:    veor d16, d17, d16
-; CHECK-NEXT:    vmov.i32 q9, #0x1
+; CHECK-NEXT:    veor d17, d17, d16
+; CHECK-NEXT:    vand d16, d17, d16
 ; CHECK-NEXT:    vmovl.u16 q8, d16
-; CHECK-NEXT:    vand q8, q8, q9
 ; CHECK-NEXT:    vmov r0, r1, d16
 ; CHECK-NEXT:    vmov r2, r3, d17
 ; CHECK-NEXT:    mov pc, lr


### PR DESCRIPTION
Extends the check done in commit 8a34f9d for ARM. A basic version of isNarrowingProfitable is added for ARM to allow vector types to fold providing that the result type is legal.
