### PR TITLE
[DWARFLinker] Fix getContaingFile typo (NFC)

### DIFF
--- a/llvm/lib/DWARFLinker/Parallel/DIEAttributeCloner.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DIEAttributeCloner.cpp
@@ -33,8 +33,8 @@ void DIEAttributeCloner::clone() {
       DWARFDataExtractor(DIECopy, Data.isLittleEndian(), Data.getAddressSize());
 
   // Modify the copy with relocated addresses.
-  InUnit.getContaingFile().Addresses->applyValidRelocs(DIECopy, Offset,
-                                                       Data.isLittleEndian());
+  InUnit.getContainingFile().Addresses->applyValidRelocs(DIECopy, Offset,
+                                                         Data.isLittleEndian());
 
   // Reset the Offset to 0 as we will be working on the local copy of
   // the data.
@@ -312,7 +312,7 @@ size_t DIEAttributeCloner::cloneScalarAttr(
   case dwarf::DW_AT_macro_info: {
     if (std::optional<uint64_t> Offset = Val.getAsSectionOffset()) {
       const DWARFDebugMacro *Macro =
-          InUnit.getContaingFile().Dwarf->getDebugMacinfo();
+          InUnit.getContainingFile().Dwarf->getDebugMacinfo();
       if (Macro == nullptr || !Macro->hasEntryForOffset(*Offset))
         return 0;
 
@@ -326,7 +326,7 @@ size_t DIEAttributeCloner::cloneScalarAttr(
   case dwarf::DW_AT_macros: {
     if (std::optional<uint64_t> Offset = Val.getAsSectionOffset()) {
       const DWARFDebugMacro *Macro =
-          InUnit.getContaingFile().Dwarf->getDebugMacro();
+          InUnit.getContainingFile().Dwarf->getDebugMacro();
       if (Macro == nullptr || !Macro->hasEntryForOffset(*Offset))
         return 0;
 
@@ -712,7 +712,7 @@ uint64_t DIEAttributeCloner::constrainHighPC(uint64_t HighPC, bool IsLength) {
   if (!LowPC)
     return HighPC;
   uint64_t Constrained =
-      InUnit.getContaingFile().Addresses->constrainCodeRangeHighPC(
+      InUnit.getContainingFile().Addresses->constrainCodeRangeHighPC(
           *LowPC, IsLength ? *LowPC + HighPC : HighPC, *FuncAddressAdjustment);
   return IsLength ? Constrained - *LowPC : Constrained;
 }

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.cpp
@@ -929,7 +929,7 @@ Error CompileUnit::cloneAndEmitDebugMacro() {
   if (std::optional<uint64_t> MacroAttr =
           dwarf::toSectionOffset(OrigUnitDie.find(dwarf::DW_AT_macros))) {
     if (const DWARFDebugMacro *Table =
-            getContaingFile().Dwarf->getDebugMacro()) {
+            getContainingFile().Dwarf->getDebugMacro()) {
       emitMacroTableImpl(Table, *MacroAttr, true);
     }
   }
@@ -938,7 +938,7 @@ Error CompileUnit::cloneAndEmitDebugMacro() {
   if (std::optional<uint64_t> MacroAttr =
           dwarf::toSectionOffset(OrigUnitDie.find(dwarf::DW_AT_macro_info))) {
     if (const DWARFDebugMacro *Table =
-            getContaingFile().Dwarf->getDebugMacinfo()) {
+            getContainingFile().Dwarf->getDebugMacinfo()) {
       emitMacroTableImpl(Table, *MacroAttr, false);
     }
   }
@@ -1398,7 +1398,7 @@ DIE *CompileUnit::createPlainDIEandCloneAttributes(
   if (InputDieEntry->getTag() == dwarf::DW_TAG_subprogram) {
     // Get relocation adjustment value for the current function.
     FuncAddressAdjustment =
-        getContaingFile().Addresses->getSubprogramRelocAdjustment(
+        getContainingFile().Addresses->getSubprogramRelocAdjustment(
             getDIE(InputDieEntry), false);
   } else if (InputDieEntry->getTag() == dwarf::DW_TAG_label) {
     // Get relocation adjustment value for the current label.
@@ -1412,7 +1412,7 @@ DIE *CompileUnit::createPlainDIEandCloneAttributes(
   } else if (InputDieEntry->getTag() == dwarf::DW_TAG_variable) {
     // Get relocation adjustment value for the current variable.
     std::pair<bool, std::optional<int64_t>> LocExprAddrAndRelocAdjustment =
-        getContaingFile().Addresses->getVariableRelocAdjustment(
+        getContainingFile().Addresses->getVariableRelocAdjustment(
             getDIE(InputDieEntry), false);
 
     HasLocationExpressionAddress = LocExprAddrAndRelocAdjustment.first;
@@ -1570,7 +1570,7 @@ TypeEntry *CompileUnit::createTypeDIEandCloneAttributes(
 
 Error CompileUnit::cloneAndEmitLineTable(const Triple &TargetTriple) {
   const DWARFDebugLine::LineTable *InputLineTable =
-      getContaingFile().Dwarf->getLineTableForUnit(&getOrigUnit());
+      getContainingFile().Dwarf->getLineTableForUnit(&getOrigUnit());
   if (InputLineTable == nullptr) {
     if (getOrigUnit().getUnitDIE().find(dwarf::DW_AT_stmt_list))
       warn("cann't load line table.");

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.h
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.h
@@ -112,7 +112,7 @@ public:
   StringEntry *getFileName(unsigned FileIdx, StringPool &GlobalStrings);
 
   /// Returns DWARFFile containing this compile unit.
-  const DWARFFile &getContaingFile() const { return File; }
+  const DWARFFile &getContainingFile() const { return File; }
 
   /// Set deterministic priority for type DIE allocation ordering.
   /// Lower priority values win when multiple CUs race to define the same type.

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.cpp
@@ -704,7 +704,7 @@ void DWARFLinkerImpl::LinkContext::linkSingleCompileUnit(
           // Clone input compile unit.
           if (CU.isClangModule() ||
               GlobalData.getOptions().UpdateIndexTablesOnly ||
-              CU.getContaingFile().Addresses->hasValidRelocs()) {
+              CU.getContainingFile().Addresses->hasValidRelocs()) {
             if (Error Err = CU.cloneAndEmit(GlobalData.getTargetTriple(),
                                             ArtificialTypeUnit))
               return std::move(Err);

--- a/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
@@ -879,7 +879,7 @@ bool DependencyTracker::isLiveVariableEntry(const UnitEntryPairTy &Entry,
       // don't want a static variable in a function to force us to keep the
       // enclosing function, unless requested explicitly.
       std::pair<bool, std::optional<int64_t>> LocExprAddrAndRelocAdjustment =
-          Entry.CU->getContaingFile().Addresses->getVariableRelocAdjustment(
+          Entry.CU->getContainingFile().Addresses->getVariableRelocAdjustment(
               DIE, Entry.CU->getGlobalData().getOptions().Verbose);
 
       if (LocExprAddrAndRelocAdjustment.first)
@@ -917,7 +917,7 @@ bool DependencyTracker::isLiveSubprogramEntry(const UnitEntryPairTy &Entry) {
     Info.setHasAnAddress();
 
     RelocAdjustment =
-        Entry.CU->getContaingFile().Addresses->getSubprogramRelocAdjustment(
+        Entry.CU->getContainingFile().Addresses->getSubprogramRelocAdjustment(
             DIE, Verbose);
     if (!RelocAdjustment)
       return false;
@@ -958,9 +958,8 @@ bool DependencyTracker::isLiveSubprogramEntry(const UnitEntryPairTy &Entry) {
           Entry.CU->getOrigUnit().getUnitDIE().find(dwarf::DW_AT_language), 0);
       if (Language == dwarf::DW_LANG_Mips_Assembler ||
           Language == dwarf::DW_LANG_Assembly) {
-        if (auto Range =
-                Entry.CU->getContaingFile().Addresses->getSymbolRangeForAddress(
-                    *LowPc))
+        if (auto Range = Entry.CU->getContainingFile()
+                             .Addresses->getSymbolRangeForAddress(*LowPc))
           Entry.CU->addFunctionRange(Range->LowPC, Range->HighPC,
                                      *RelocAdjustment);
       }
@@ -977,7 +976,7 @@ bool DependencyTracker::isLiveSubprogramEntry(const UnitEntryPairTy &Entry) {
 
   Entry.CU->addFunctionRange(
       *LowPc,
-      Entry.CU->getContaingFile().Addresses->constrainCodeRangeHighPC(
+      Entry.CU->getContainingFile().Addresses->constrainCodeRangeHighPC(
           *LowPc, *HighPc, *RelocAdjustment),
       *RelocAdjustment);
   return true;


### PR DESCRIPTION
Rename CompileUnit::getContaingFile to getContainingFile and update its call sites in the parallel DWARF linker.