### PR TITLE
[LLDB] Update DIL assignment to respect ValueObject::CanSetValue

### DIFF
--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -971,6 +971,10 @@ llvm::Expected<lldb::ValueObjectSP>
 Interpreter::EvaluateAssignment(lldb::ValueObjectSP lhs,
                                 lldb::ValueObjectSP rhs, uint32_t location) {
 
+  // Verify that lhs can accept an assignment.
+  if (llvm::Error err = lhs->CanSetValue())
+    return err;
+
   auto all_ok =
       VerifyAssignmentTypes(lhs->GetCompilerType(), rhs->GetCompilerType());
   if (!all_ok)

--- a/lldb/test/API/commands/frame/var-dil/expr/Assignment/TestFrameVarDILAssign.py
+++ b/lldb/test/API/commands/frame/var-dil/expr/Assignment/TestFrameVarDILAssign.py
@@ -26,7 +26,7 @@ class TestFrameVarDILAssignment(TestBase):
         self.expect(
             "frame variable '1 = 1'",
             error=True,
-            substrs=["Not allowed to change the value of a constant"],
+            substrs=["value is not in a writable location"],
         )
 
         # Assigning to an int var


### PR DESCRIPTION
This will prevent DIL from allowing users to try to assign new values in cases where that could lead to incorrect behavior.