### PR TITLE
[bazel][mlir] Fix lit.site.cfg substitution for MLIR_RUN_ARM_NEON_TESTS

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/test/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/test/BUILD.bazel
@@ -53,7 +53,7 @@ lit_expand_template(
         "@MLIR_ENABLE_VULKAN_RUNNER@": "0",
         "@MLIR_ENABLE_XEVM_CONVERSIONS@": "0",
         "@MLIR_INCLUDE_INTEGRATION_TESTS@": "0",
-        "@MLIR_RUN_ARM_I8MM_TESTS@": "0",
+        "@MLIR_RUN_ARM_NEON_TESTS@": "0",
         "@MLIR_RUN_ARM_SME_TESTS@": "0",
         "@MLIR_RUN_ARM_SVE_TESTS@": "0",
         "@MLIR_RUN_CUDA_SM80_LT_TESTS@": "0",


### PR DESCRIPTION
Follow-up to ee0f7ff7e697 which renamed MLIR_RUN_ARM_I8MM_TESTS to MLIR_RUN_ARM_NEON_TESTS in lit.site.cfg.py.in.