### PR TITLE
[Support] Support seekable temporary output streams

### DIFF
--- a/llvm/include/llvm/Support/raw_ostream.h
+++ b/llvm/include/llvm/Support/raw_ostream.h
@@ -31,6 +31,7 @@
 namespace llvm {
 
 class Duration;
+class Error;
 class formatv_object_base;
 class FormattedString;
 class FormattedNumber;
@@ -575,6 +576,9 @@ public:
   ///
   void clear_error() { EC = std::error_code(); }
 
+  /// Return and clear any output error recorded by this stream.
+  Error takeError();
+
   /// Locks the underlying file.
   ///
   /// @returns RAII object that releases the lock upon leaving the scope, if the
@@ -647,6 +651,9 @@ public:
   /// advanced by this number. On error, -1 is returned, use error() to get the
   /// error code.
   LLVM_ABI ssize_t read(char *Ptr, size_t Size);
+
+  /// Resize the underlying file to \p Size bytes.
+  LLVM_ABI Error resize(uint64_t Size);
 
   /// Check if \p OS is a pointer of type raw_fd_stream*.
   LLVM_ABI static bool classof(const raw_ostream *OS);

--- a/llvm/lib/Support/raw_ostream.cpp
+++ b/llvm/lib/Support/raw_ostream.cpp
@@ -62,6 +62,26 @@
 
 using namespace llvm;
 
+namespace {
+// raw_ostream records I/O failures out of band. Use a distinct ErrorInfo type
+// so callers can propagate them as Error values and add file context without
+// altering errors returned by the output callback.
+class RawOstreamError : public ErrorInfo<RawOstreamError> {
+public:
+  static char ID;
+
+  explicit RawOstreamError(std::error_code EC) : EC(EC) {}
+
+  void log(raw_ostream &OS) const override { OS << EC.message(); }
+  std::error_code convertToErrorCode() const override { return EC; }
+
+private:
+  std::error_code EC;
+};
+} // namespace
+
+char RawOstreamError::ID;
+
 raw_ostream::~raw_ostream() {
   // raw_ostream's subclasses should take care to flush the buffer
   // in their destructors.
@@ -664,6 +684,14 @@ raw_fd_ostream::~raw_fd_ostream() {
                           error().message());
 }
 
+Error raw_fd_ostream::takeError() {
+  if (!has_error())
+    return Error::success();
+  Error E = make_error<RawOstreamError>(error());
+  clear_error();
+  return E;
+}
+
 #if defined(_WIN32)
 // The most reliable way to print unicode in a Windows console is with
 // WriteConsoleW. To use that, first transcode from UTF-8 to UTF-16. This
@@ -933,6 +961,15 @@ ssize_t raw_fd_stream::read(char *Ptr, size_t Size) {
   return Ret;
 }
 
+Error raw_fd_stream::resize(uint64_t Size) {
+  flush();
+  if (has_error())
+    return takeError();
+  if (std::error_code EC = sys::fs::resize_file(get_fd(), Size))
+    return make_error<RawOstreamError>(EC);
+  return Error::success();
+}
+
 bool raw_fd_stream::classof(const raw_ostream *OS) {
   return OS->get_kind() == OStreamKind::OK_FDStream;
 }
@@ -1027,14 +1064,22 @@ Error llvm::writeToOutput(StringRef OutputFileName,
   }
 #endif
 
-  raw_fd_ostream Out(Temp->FD, false);
+  Error E = handleErrors(
+      [&]() -> Error {
+        raw_fd_stream Out(Temp->FD, false);
+        Error WriteError = Write(Out);
+        Out.flush();
+        return joinErrors(std::move(WriteError), Out.takeError());
+      }(),
+      [&](std::unique_ptr<RawOstreamError> StreamError) {
+        return createFileError(OutputFileName, Error(std::move(StreamError)));
+      });
 
-  if (Error E = Write(Out)) {
+  if (E) {
     if (Error DiscardError = Temp->discard())
       return joinErrors(std::move(E), std::move(DiscardError));
     return E;
   }
-  Out.flush();
 
   return Temp->keep(OutputFileName);
 }

--- a/llvm/unittests/Support/raw_ostream_test.cpp
+++ b/llvm/unittests/Support/raw_ostream_test.cpp
@@ -572,6 +572,72 @@ TEST(raw_ostreamTest, writeToOutputFile) {
   checkFileData(Path, "HelloWorld");
 }
 
+TEST(raw_ostreamTest, writeToOutputErrorPreservesDestination) {
+  SmallString<64> Path;
+  int FD;
+  ASSERT_FALSE(sys::fs::createTemporaryFile("foo", "bar", FD, Path));
+  FileRemover Cleanup(Path);
+  {
+    raw_fd_ostream Out(FD, true);
+    Out << "Original";
+  }
+
+  std::string ErrorMessage =
+      toString(createFileError(Path, make_error_code(errc::invalid_argument)));
+  EXPECT_THAT_ERROR(writeToOutput(Path,
+                                  [](raw_ostream &Out) -> Error {
+                                    static_cast<raw_fd_stream &>(Out).seek(
+                                        UINT64_MAX);
+                                    return Error::success();
+                                  }),
+                    FailedWithMessage(ErrorMessage));
+  checkFileData(Path, "Original");
+}
+
+TEST(raw_ostreamTest, writeToOutputReturnedStreamErrorPreservesDestination) {
+  SmallString<64> Path;
+  int FD;
+  ASSERT_FALSE(sys::fs::createTemporaryFile("foo", "bar", FD, Path));
+  FileRemover Cleanup(Path);
+  {
+    raw_fd_ostream Out(FD, true);
+    Out << "Original";
+  }
+
+  std::string ErrorMessage =
+      toString(createFileError(Path, make_error_code(errc::invalid_argument)));
+  EXPECT_THAT_ERROR(writeToOutput(Path,
+                                  [](raw_ostream &Out) -> Error {
+                                    auto &Stream =
+                                        static_cast<raw_fd_stream &>(Out);
+                                    Stream.seek(UINT64_MAX);
+                                    return Stream.takeError();
+                                  }),
+                    FailedWithMessage(ErrorMessage));
+  checkFileData(Path, "Original");
+}
+
+TEST(raw_ostreamTest, writeToOutputCallbackErrorPreservesDestination) {
+  SmallString<64> Path;
+  int FD;
+  ASSERT_FALSE(sys::fs::createTemporaryFile("foo", "bar", FD, Path));
+  FileRemover Cleanup(Path);
+  {
+    raw_fd_ostream Out(FD, true);
+    Out << "Original";
+  }
+
+  EXPECT_THAT_ERROR(writeToOutput(Path,
+                                  [](raw_ostream &Out) -> Error {
+                                    Out << "Replacement";
+                                    return createStringError(
+                                        errc::invalid_argument,
+                                        "callback failed");
+                                  }),
+                    FailedWithMessage("callback failed"));
+  checkFileData(Path, "Original");
+}
+
 #ifdef __MVS__
 TEST(raw_ostreamTest, writeToOutputFileEncoding) {
   // Create the temp file with that has ISO8859-1 encoding


### PR DESCRIPTION
## Motivation

 `llvm::writeToOutput` writes through a temporary file and only replaces the destination after the callback succeeds. The callback currently receives a `raw_fd_ostream`, which does not provide the seekable read/write interface needed by clients that want to construct an output file directly.

It is also possible for a `raw_ostream` operation to record an error without returning it through the callback's `Error`.

## Change

This change uses `raw_fd_stream` for the temporary output passed to the callback. This allows the callback to seek within the temporary file and resize it while retaining the existing atomic replacement behavior.

Additionally:

  - `raw_fd_ostream::takeError()` to convert and clear a recorded stream error.
  - `raw_fd_stream::resize()` to resize the underlying file.
  - A final flush and error check after the callback completes.

Errors returned by the callback and errors recorded by the output stream are combined. If either operation fails, the temporary file is discarded and an existing destination remains unchanged.
