### PR TITLE
[flang][openacc] Recurse into OpenACC constructs when matching labeled DO

### DIFF
--- a/flang/lib/Parser/tools.cpp
+++ b/flang/lib/Parser/tools.cpp
@@ -223,6 +223,8 @@ std::optional<Label> GetFinalLabel(const Block &x) {
     const ExecutionPartConstruct &last{x.back()};
     if (auto *omp{Unwrap<OpenMPConstruct>(last)}) {
       return GetFinalLabel(*omp);
+    } else if (auto *acc{Unwrap<OpenACCConstruct>(last)}) {
+      return GetFinalLabel(*acc);
     } else if (auto *doLoop{Unwrap<DoConstruct>(last)}) {
       return GetFinalLabel(std::get<Block>(doLoop->t));
     } else {

--- a/flang/test/Parser/acc-label-do.f90
+++ b/flang/test/Parser/acc-label-do.f90
@@ -48,6 +48,23 @@ subroutine nested_shared_label(a, n)
 !$acc end kernels
 end
 
+! Same, with three levels of nesting: the label of the innermost loop is
+! reached through two OpenACC LOOP constructs.
+
+subroutine triple_shared_label(a, c, n, k)
+  integer :: i, j, m, n, k
+  real :: a(n), c(n,k)
+!$acc kernels
+!$acc loop independent
+  do 250 m = 1, n
+!$acc loop independent
+    do 250 j = 1, k
+!$acc loop gang vector
+      do 250 i = 1, n
+250     a(i) = a(i) + c(i,j)
+!$acc end kernels
+end
+
 !UNPARSE: SUBROUTINE nested_shared_label (a, n)
 !UNPARSE: !$ACC KERNELS
 !UNPARSE: !$ACC LOOP INDEPENDENT
@@ -81,3 +98,18 @@ end
 !PARSE-TREE: | | | | | | | EndDoStmt ->
 !PARSE-TREE: | | | | EndDoStmt ->
 !PARSE-TREE: | AccEndBlockDirective -> AccBlockDirective -> llvm::acc::Directive = kernels
+
+!UNPARSE: SUBROUTINE triple_shared_label (a, c, n, k)
+!UNPARSE: !$ACC KERNELS
+!UNPARSE: !$ACC LOOP INDEPENDENT
+!UNPARSE:  DO m=1_4,n
+!UNPARSE: !$ACC LOOP INDEPENDENT
+!UNPARSE:   DO j=1_4,k
+!UNPARSE: !$ACC LOOP GANG VECTOR
+!UNPARSE:    DO i=1_4,n
+!UNPARSE:     250
+!UNPARSE:    END DO
+!UNPARSE:   END DO
+!UNPARSE:  END DO
+!UNPARSE: !$ACC END KERNELS
+!UNPARSE: END SUBROUTINE


### PR DESCRIPTION
GetFinalLabel() already walked an OpenACC loop or combined construct to
find a shared terminating label, but the Block walker did not recurse
into nested OpenACC constructs. Three labeled DO loops that share one
terminator, each associated with its own !$acc loop, then failed with
"Label is not in DO loop scope".

Look through OpenACCConstruct in GetFinalLabel(const Block &) the same
way OpenMP constructs are already handled.