### PR TITLE
[DWARFLinker] Erase the type ref patch list with the section data

### DIFF
--- a/llvm/lib/DWARFLinker/Parallel/OutputSections.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/OutputSections.cpp
@@ -66,6 +66,7 @@ void SectionDescriptor::clearAllSectionData() {
   ListDebugDieRefPatch.erase();
   ListDebugULEB128DieRefPatch.erase();
   ListDebugOffsetPatch.erase();
+  ListDebugDieTypeRefPatch.erase();
   ListDebugType2TypeDieRefPatch.erase();
   ListDebugTypeDeclFilePatch.erase();
   ListDebugTypeLineStrPatch.erase();


### PR DESCRIPTION
SectionDescriptor::clearAllSectionData drops every patch list but ListDebugDieTypeRefPatch. maybeResetToLoadedStage calls eraseSections() on a unit which is already past Stage::Cloned, so that list outlives the section content it points into and is then applied to the offsets of the re-cloned content.