### PR TITLE
[Support] Disable CFI on typed Allocate to unconstructed storage

### DIFF
--- a/llvm/include/llvm/Support/Allocator.h
+++ b/llvm/include/llvm/Support/Allocator.h
@@ -450,7 +450,8 @@ public:
   }
 
   /// Allocate space for an array of objects without constructing them.
-  T *Allocate(size_t num = 1) {
+  // CFI: typed pointer to unconstructed storage for placement-new.
+  LLVM_NO_SANITIZE("cfi") T *Allocate(size_t num = 1) {
     // Slabs are max_align_t-aligned and every size is a multiple of alignof(T),
     // so the bump pointer is already alignof(T)-aligned. Request alignment 1 so
     // the fast path skips realigning CurPtr; over-aligned T still needs it.

--- a/llvm/include/llvm/Support/AllocatorBase.h
+++ b/llvm/include/llvm/Support/AllocatorBase.h
@@ -73,7 +73,8 @@ public:
   // core methods.
 
   /// Allocate space for a sequence of objects without constructing them.
-  template <typename T> T *Allocate(size_t Num = 1) {
+  // CFI: typed pointer to unconstructed storage for placement-new.
+  template <typename T> LLVM_NO_SANITIZE("cfi") T *Allocate(size_t Num = 1) {
     return static_cast<T *>(Allocate(Num * sizeof(T), alignof(T)));
   }
 


### PR DESCRIPTION
## Summary
- `AllocatorBase::Allocate<T>()` / `SpecificBumpPtrAllocator::Allocate()` return a typed pointer to unconstructed storage for placement-new.
- Under `-fsanitize=cfi`, `cfi-unrelated-cast` checks that pointer as if it were already a live object and traps (`ud1`) before the constructor runs (e.g. `MachineFunctionInfo::create` in a CFI+ThinLTO `llc`).
- Disable CFI on those allocate helpers, matching the libc++ `_LIBCPP_NO_CFI` pattern for the same class of false positive.

Fixes #217818

## Test plan
- [x] Rebuild CFI-instrumented `llc` (ThinLTO + `-fsanitize=cfi`)
- [x] `llvm-lit -sv llvm/test/Analysis/CostModel/AArch64/free-widening-casts.ll` → Passed
- [x] Direct repro no longer SIGILL:
  `llc free-widening-casts.ll -mtriple=aarch64--linux-gnu -o /tmp/out.s`
- [ ] `ninja check-llvm` on CFI build (failures drop substantially; remaining fails are unrelated)


Made with [Cursor](https://cursor.com)