### PR TITLE
[CIR] Pack struct layouts with a _BitInt > 64 bits

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -88,6 +88,10 @@ def CIR_IntType : CIR_Type<"Int", "int", [
       return isFundamentalUIntType(*this);
     }
 
+    /// Returns the width of this type as lowered to LLVM-IR. This only differs
+    /// from the int-size for bit-int types greater than 64 bits.
+    uint64_t storageBitwidth(const mlir::DataLayout &dataLayout) const;
+
     /// Returns a minimum bitwidth of cir::IntType
     static unsigned minBitwidth() { return 1; }
     /// Returns a maximum bitwidth of cir::IntType.

--- a/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
@@ -140,7 +140,6 @@ struct CIRRecordLowering final {
       return CharUnits::fromQuantity(intTy.storageBitwidth(dataLayout.layout) /
                                      8);
     return CharUnits::fromQuantity(dataLayout.layout.getTypeSize(Ty));
-
   }
   CharUnits getSizeInBits(mlir::Type ty) {
     return CharUnits::fromQuantity(dataLayout.layout.getTypeSizeInBits(ty));

--- a/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
@@ -132,13 +132,36 @@ struct CIRRecordLowering final {
   void calculateZeroInit();
 
   CharUnits getSize(mlir::Type Ty) {
+    auto intTy = mlir::dyn_cast<cir::IntType>(Ty);
+    // Just like with getAlignment, the storage size of a bitint is the
+    // full-memory layout (adjusted for alignment), not just its width. So we
+    // have to special case that here too.
+    if (intTy && intTy.isBitInt())
+      return CharUnits::fromQuantity(intTy.storageBitwidth(dataLayout.layout) /
+                                     8);
     return CharUnits::fromQuantity(dataLayout.layout.getTypeSize(Ty));
+
   }
   CharUnits getSizeInBits(mlir::Type ty) {
     return CharUnits::fromQuantity(dataLayout.layout.getTypeSizeInBits(ty));
   }
-  CharUnits getAlignment(mlir::Type Ty) {
-    return CharUnits::fromQuantity(dataLayout.layout.getTypeABIAlignment(Ty));
+
+  CharUnits getAlignment(mlir::Type ty) {
+    CharUnits abiAlign =
+        CharUnits::fromQuantity(dataLayout.layout.getTypeABIAlignment(ty));
+    auto intTy = mlir::dyn_cast<cir::IntType>(ty);
+    if (!intTy || !intTy.isBitInt())
+      return abiAlign;
+
+    // _BitInt gets lowered to an LLVM-IR type of its size, which is going to
+    // have an incorrect alignment in LLVM if >64 bits. So we report THAT
+    // alignment here so that it gets laid out in a way that requires
+    // padding/packing to set the type alignments correctly.
+
+    mlir::Type storageTy = mlir::IntegerType::get(
+        intTy.getContext(), intTy.storageBitwidth(dataLayout.layout));
+    return CharUnits::fromQuantity(
+        dataLayout.layout.getTypeABIAlignment(storageTy));
   }
 
   bool isZeroInitializable(const FieldDecl *fd) {

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -1016,6 +1016,14 @@ uint64_t IntType::getABIAlignment(const mlir::DataLayout &dataLayout,
   return std::max(alignBits / 8, static_cast<uint64_t>(1));
 }
 
+uint64_t IntType::storageBitwidth(const mlir::DataLayout &dataLayout) const {
+  if (!isBitInt())
+    return getWidth();
+
+  uint64_t alignBits = getABIAlignment(dataLayout, {}) * 8;
+  return llvm::alignTo(getWidth(), alignBits);
+}
+
 mlir::LogicalResult
 IntType::verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
                 unsigned width, bool isSigned, bool isBitInt) {

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -76,15 +76,6 @@ mlir::Type elementTypeIfVector(mlir::Type type) {
 }
 } // namespace
 
-/// In-memory storage width in bits for a _BitInt(N): N rounded up to the type's
-/// ABI alignment.  This equals sizeof(_BitInt(N)) * 8 on the default target
-/// (e.g. _BitInt(6) -> 8, _BitInt(17) -> 32, _BitInt(128) -> 128).
-static unsigned getBitIntMemoryStorageBits(cir::IntType ty,
-                                           const mlir::DataLayout &dataLayout) {
-  uint64_t alignBits = ty.getABIAlignment(dataLayout, {}) * 8;
-  return llvm::alignTo(ty.getWidth(), alignBits);
-}
-
 /// A _BitInt(N) whose padded storage integer iM has a larger alloc size than
 /// its M/8 store size is laid out by clang as a byte array, not a plain integer
 /// (e.g. _BitInt(129) -> i192 with alloc size 32 != store size 24).  That
@@ -94,7 +85,7 @@ static bool isSplitStorageBitInt(cir::IntType ty,
                                  const mlir::DataLayout &dataLayout) {
   if (!ty.isBitInt())
     return false;
-  unsigned storageBits = getBitIntMemoryStorageBits(ty, dataLayout);
+  uint64_t storageBits = ty.storageBitwidth(dataLayout);
   auto storageTy = mlir::IntegerType::get(ty.getContext(), storageBits);
   uint64_t storeSize = storageBits / 8;
   uint64_t allocSize =
@@ -133,7 +124,7 @@ static mlir::Type convertTypeForMemory(const mlir::TypeConverter &converter,
     if (isSplitStorageBitInt(intTy, dataLayout))
       return {};
     return mlir::IntegerType::get(
-        type.getContext(), getBitIntMemoryStorageBits(intTy, dataLayout));
+        type.getContext(), intTy.storageBitwidth(dataLayout));
   }
 
   return converter.convertType(type);
@@ -179,7 +170,7 @@ static mlir::Value
 castBitIntMemoryStorage(mlir::ConversionPatternRewriter &rewriter,
                         const mlir::DataLayout &dataLayout, cir::IntType intTy,
                         mlir::Value value, bool toMemory) {
-  unsigned storageBits = getBitIntMemoryStorageBits(intTy, dataLayout);
+  uint64_t storageBits = intTy.storageBitwidth(dataLayout);
   if (storageBits == intTy.getWidth())
     return value;
   unsigned dstBits = toMemory ? storageBits : intTy.getWidth();

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -123,8 +123,8 @@ static mlir::Type convertTypeForMemory(const mlir::TypeConverter &converter,
       intTy && intTy.isBitInt()) {
     if (isSplitStorageBitInt(intTy, dataLayout))
       return {};
-    return mlir::IntegerType::get(
-        type.getContext(), intTy.storageBitwidth(dataLayout));
+    return mlir::IntegerType::get(type.getContext(),
+                                  intTy.storageBitwidth(dataLayout));
   }
 
   return converter.convertType(type);

--- a/clang/test/CIR/CodeGen/bitint-struct-layout.c
+++ b/clang/test/CIR/CodeGen/bitint-struct-layout.c
@@ -1,0 +1,85 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+struct Last65 {
+  int i;
+  _BitInt(65) bi;
+};
+// CIR-DAG: !rec_Last65 = !cir.struct<"Last65" packed {data !s32i, pad !cir.array<!u8i x 4>, data !cir.int<s, 65, bitint>}>
+// LLVMCIR-DAG: %struct.Last65 = type <{ i32, [4 x i8], i128 }>
+
+struct Last127 {
+  int i;
+  _BitInt(127) bi;
+};
+// CIR-DAG: !rec_Last127 = !cir.struct<"Last127" packed {data !s32i, pad !cir.array<!u8i x 4>, data !cir.int<s, 127, bitint>}>
+// LLVM-DAG: %struct.Last127 = type <{ i32, [4 x i8], i128 }>
+
+struct Last128 {
+  int i;
+  _BitInt(128) bi;
+};
+// CIR-DAG: !rec_Last128 = !cir.struct<"Last128" packed {data !s32i, pad !cir.array<!u8i x 4>, data !s128i_bitint}>
+// LLVM-DAG: %struct.Last128 = type <{ i32, [4 x i8], i128 }>
+
+struct First65 {
+  _BitInt(65) bi;
+  int i;
+};
+// CIR-DAG: !rec_First65 = !cir.struct<"First65" packed {data !cir.int<s, 65, bitint>, data !s32i, pad !cir.array<!u8i x 4>}>
+// LLVM-DAG: %struct.First65 = type <{ i128, i32, [4 x i8] }>
+
+struct First127 {
+  _BitInt(127) bi;
+  int i;
+};
+// CIR-DAG: !rec_First127 = !cir.struct<"First127" packed {data !cir.int<s, 127, bitint>, data !s32i, pad !cir.array<!u8i x 4>}>
+// LLVM-DAG: %struct.First127 = type <{ i128, i32, [4 x i8] }>
+
+struct First128 {
+  _BitInt(128) bi;
+  int i;
+};
+// CIR-DAG: !rec_First128 = !cir.struct<"First128" packed {data !s128i_bitint, data !s32i, pad !cir.array<!u8i x 4>}>
+// LLVM-DAG: %struct.First128 = type <{ i128, i32, [4 x i8] }>
+
+struct Middle65 {
+  char c;
+  _BitInt(65) bi;
+  int i;
+};
+// CIR-DAG: !rec_Middle65 = !cir.struct<"Middle65" packed {data !s8i, pad !cir.array<!u8i x 7>, data !cir.int<s, 65, bitint>, data !s32i, pad !cir.array<!u8i x 4>}>
+// LLVM-DAG: %struct.Middle65 = type <{ i8, [7 x i8], i128, i32, [4 x i8] }>
+
+struct Middle127 {
+  char c;
+  _BitInt(127) bi;
+  int i;
+};
+// CIR-DAG: !rec_Middle127 = !cir.struct<"Middle127" packed {data !s8i, pad !cir.array<!u8i x 7>, data !cir.int<s, 127, bitint>, data !s32i, pad !cir.array<!u8i x 4>}>
+// LLVM-DAG: %struct.Middle127 = type <{ i8, [7 x i8], i128, i32, [4 x i8] }>
+
+struct Middle128 {
+  char c;
+  _BitInt(128) bi;
+  int i;
+};
+// CIR-DAG: !rec_Middle128 = !cir.struct<"Middle128" packed {data !s8i, pad !cir.array<!u8i x 7>, data !s128i_bitint, data !s32i, pad !cir.array<!u8i x 4>}>
+// LLVM-DAG: %struct.Middle128 = type <{ i8, [7 x i8], i128, i32, [4 x i8] }>
+
+// Force emit.
+struct Last65 l65[2];
+struct Last127 l127[2];
+struct Last128 l128[2];
+
+struct First65 f65[2];
+struct First127 f127[2];
+struct First128 f128[2];
+
+struct Middle65 m65[2];
+struct Middle127 m127[2];
+struct Middle128 m128[2];


### PR DESCRIPTION
A _BitInt>64 bits will have a storage type with an incorrect alignment. The only way to get that to work correctly is to 'pack' the struct, auto adding the padding.  This patch changes the alignment calculation for these types in a way that will cause us to detect the difference in alignment, and do this layout properly during RecordLayoutBuilder.

Additionally, we make a corresponding change to the size, so that its storage type gets laid out correctly.