### PR TITLE
[lldb] Create mock type systems in array for deterministic order

### DIFF
--- a/lldb/unittests/Target/ScratchTypeSystemTest.cpp
+++ b/lldb/unittests/Target/ScratchTypeSystemTest.cpp
@@ -110,10 +110,12 @@ TEST_F(TestTypeSystemMap, GetScratchTypeSystemsIsOrderedByLanguage) {
   // order in memory is then the reverse of the order of the languages, and an
   // implementation that deduplicates by sorting on pointer identity returns the
   // two the wrong way round.
-  g_fortran90_type_system =
-      std::make_shared<MockTypeSystem>(lldb::eLanguageTypeFortran90);
-  g_fortran77_type_system =
-      std::make_shared<MockTypeSystem>(lldb::eLanguageTypeFortran77);
+  std::shared_ptr<MockTypeSystem[]> mocks(new MockTypeSystem[2]{
+      MockTypeSystem(lldb::eLanguageTypeFortran90),
+      MockTypeSystem(lldb::eLanguageTypeFortran77),
+  });
+  g_fortran90_type_system = std::shared_ptr<MockTypeSystem>(mocks, &mocks[0]);
+  g_fortran77_type_system = std::shared_ptr<MockTypeSystem>(mocks, &mocks[1]);
   ASSERT_LT(g_fortran90_type_system.get(), g_fortran77_type_system.get());
 
   LanguageSet fortran77;


### PR DESCRIPTION
To fix the occasional test failure from #217789: Instead of using two random heap allocations for the type systems, allocate them in an array once and create aliases to the elements (similar to what David suggested in https://github.com/llvm/llvm-project/pull/217789#issuecomment-5372708193). The array allocation is destroyed when the last (aliased) shared pointer is destroyed.