### PR TITLE
[clang-format] Honor new lines before // clang-format on

### DIFF
--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -1637,6 +1637,8 @@ static auto computeNewlines(const AnnotatedLine &Line,
                             const SmallVectorImpl<AnnotatedLine *> &Lines,
                             const FormatStyle &Style) {
   const auto &RootToken = *Line.First;
+  if (RootToken.Finalized || isClangFormatOn(RootToken.TokenText))
+    return RootToken.NewlinesBefore;
   auto Newlines =
       std::min(RootToken.NewlinesBefore, Style.MaxEmptyLinesToKeep + 1);
   // Remove empty lines before "}" where applicable.

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -1637,7 +1637,7 @@ static auto computeNewlines(const AnnotatedLine &Line,
                             const SmallVectorImpl<AnnotatedLine *> &Lines,
                             const FormatStyle &Style) {
   const auto &RootToken = *Line.First;
-  if (RootToken.Finalized || isClangFormatOn(RootToken.TokenText))
+  if (isClangFormatOn(RootToken.TokenText))
     return RootToken.NewlinesBefore;
   auto Newlines =
       std::min(RootToken.NewlinesBefore, Style.MaxEmptyLinesToKeep + 1);

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -22422,9 +22422,9 @@ TEST_F(FormatTest, DisableRegions) {
                  "// clang-format on");
 
   verifyNoChange("// clang-format off\n"
-                 "int i;\n"
                  "\n"
                  "\n"
+                 " int  i ;\n"
                  "\n"
                  "\n"
                  "// clang-format on");

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -22420,6 +22420,14 @@ TEST_F(FormatTest, DisableRegions) {
                  " #endif\n"
                  "#endif\n"
                  "// clang-format on");
+
+  verifyNoChange("// clang-format off\n"
+                 "int i;\n"
+                 "\n"
+                 "\n"
+                 "\n"
+                 "\n"
+                 "// clang-format on");
 }
 
 TEST_F(FormatTest, OneLineFormatOffRegex) {


### PR DESCRIPTION
Fixes #217872.