### PR TITLE
[clang][objc] Add ObjCPropertyRefExpr::getReceiverInterface

### DIFF
--- a/clang/include/clang/AST/ExprObjC.h
+++ b/clang/include/clang/AST/ExprObjC.h
@@ -807,6 +807,18 @@ public:
   /// Determine the type of the base, regardless of the kind of receiver.
   QualType getReceiverType(const ASTContext &ctx) const;
 
+  /// Retrieve the Objective-C interface to which the message implied by this
+  /// property reference is being directed, if known.
+  ///
+  /// This routine cross-cuts all of the different kinds of message
+  /// sends to determine what the underlying (statically known) type
+  /// of the receiver will be; use \c isObjectReceiver(), \c isSuperReceiver(),
+  /// and \c isClassReceiver() to determine whether the message is a class or an
+  /// instance method, whether it is a send to super or not, etc.
+  ///
+  /// \returns The Objective-C interface if known, otherwise nullptr.
+  ObjCInterfaceDecl *getReceiverInterface() const;
+
   SourceLocation getBeginLoc() const LLVM_READONLY {
     return isObjectReceiver() ? getBase()->getBeginLoc()
                               : getReceiverLocation();

--- a/clang/lib/AST/ExprObjC.cpp
+++ b/clang/lib/AST/ExprObjC.cpp
@@ -113,6 +113,26 @@ QualType ObjCPropertyRefExpr::getReceiverType(const ASTContext &ctx) const {
   return getBase()->getType();
 }
 
+ObjCInterfaceDecl *ObjCPropertyRefExpr::getReceiverInterface() const {
+  if (isClassReceiver())
+    return getClassReceiver();
+
+  if (isSuperReceiver()) {
+    QualType SuperTy = getSuperReceiverType();
+    if (const auto *ObjCPtr = SuperTy->getAs<ObjCObjectPointerType>())
+      return ObjCPtr->getInterfaceDecl();
+    if (const auto *ObjCTy = SuperTy->getAs<ObjCObjectType>())
+      return ObjCTy->getInterface();
+    return nullptr;
+  }
+
+  if (const ObjCObjectPointerType *Ptr =
+          getBase()->getType()->getAs<ObjCObjectPointerType>())
+    return Ptr->getInterfaceDecl();
+
+  return nullptr;
+}
+
 ObjCMessageExpr::ObjCMessageExpr(QualType T, ExprValueKind VK,
                                  SourceLocation LBracLoc,
                                  SourceLocation SuperLoc, bool IsInstanceSuper,

--- a/clang/lib/Sema/SemaPseudoObject.cpp
+++ b/clang/lib/Sema/SemaPseudoObject.cpp
@@ -32,7 +32,9 @@
 #include "clang/Sema/SemaPseudoObject.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/ExprObjC.h"
+#include "clang/AST/TypeBase.h"
 #include "clang/Basic/CharInfo.h"
+#include "clang/Basic/IdentifierTable.h"
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Sema/Initialization.h"
 #include "clang/Sema/ScopeInfo.h"
@@ -550,38 +552,26 @@ PseudoOpBuilder::buildIncDecOperation(Scope *Sc, SourceLocation opcLoc,
 /// Look up a method in the receiver type of an Objective-C property
 /// reference.
 static ObjCMethodDecl *LookupMethodInReceiverType(Sema &S, Selector sel,
-                                            const ObjCPropertyRefExpr *PRE) {
-  if (PRE->isObjectReceiver()) {
-    const ObjCObjectPointerType *PT =
-      PRE->getBase()->getType()->castAs<ObjCObjectPointerType>();
-
+                                                  ObjCPropertyRefExpr *PRE) {
+  QualType ReceiverType = PRE->getReceiverType(S.Context);
+  if (const auto *PT = ReceiverType->getAs<ObjCObjectPointerType>()) {
     // Special case for 'self' in class method implementations.
-    if (PT->isObjCClassType() &&
-        S.ObjC().isSelfExpr(const_cast<Expr *>(PRE->getBase()))) {
-      // This cast is safe because isSelfExpr is only true within
-      // methods.
-      ObjCMethodDecl *method =
-        cast<ObjCMethodDecl>(S.CurContext->getNonClosureAncestor());
+    if (PT->isObjCClassType() && PRE->isObjectReceiver() &&
+        S.ObjC().isSelfExpr(PRE->getBase())) {
+      // This cast is safe because isSelfExpr is only true within methods.
+      auto *method =
+          cast<ObjCMethodDecl>(S.CurContext->getNonClosureAncestor());
       return S.ObjC().LookupMethodInObjectType(
           sel, S.Context.getObjCInterfaceType(method->getClassInterface()),
-          /*instance*/ false);
+          /*instance=*/false);
     }
 
-    return S.ObjC().LookupMethodInObjectType(sel, PT->getPointeeType(), true);
+    return S.ObjC().LookupMethodInObjectType(sel, PT->getPointeeType(),
+                                             /*instance=*/true);
   }
 
-  if (PRE->isSuperReceiver()) {
-    if (const ObjCObjectPointerType *PT =
-        PRE->getSuperReceiverType()->getAs<ObjCObjectPointerType>())
-      return S.ObjC().LookupMethodInObjectType(sel, PT->getPointeeType(), true);
-
-    return S.ObjC().LookupMethodInObjectType(sel, PRE->getSuperReceiverType(),
-                                             false);
-  }
-
-  assert(PRE->isClassReceiver() && "Invalid expression");
-  QualType IT = S.Context.getObjCInterfaceType(PRE->getClassReceiver());
-  return S.ObjC().LookupMethodInObjectType(sel, IT, false);
+  return S.ObjC().LookupMethodInObjectType(sel, ReceiverType,
+                                           /*instance=*/false);
 }
 
 bool ObjCPropertyOpBuilder::isWeakProperty() const {

--- a/clang/unittests/AST/ASTExprTest.cpp
+++ b/clang/unittests/AST/ASTExprTest.cpp
@@ -12,13 +12,18 @@
 
 #include "ASTPrint.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclObjC.h"
 #include "clang/AST/Expr.h"
+#include "clang/AST/ExprObjC.h"
 #include "clang/AST/IgnoreExpr.h"
 #include "clang/AST/OpenACCClause.h"
+#include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/StmtOpenACC.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/Tooling/Tooling.h"
 #include "gtest/gtest.h"
+#include <vector>
 
 using namespace clang;
 
@@ -396,4 +401,66 @@ TEST(ASTExpr, IsKnownToHaveBooleanValue) {
   ExpectKnown("from_bitfield2", false, false);
   ExpectKnown("from_bitint1", false, true);
   ExpectKnown("from_bitint2", false, false);
+}
+
+TEST(ASTExpr, ObjCPropertyRefExprReceiverInterface) {
+  auto AST = tooling::buildASTFromCodeWithArgs(
+      R"objc(
+    @protocol Proto
+    @property int protoProp;
+    @end
+
+    __attribute__((objc_root_class))
+    @interface Base
+    @property (class) int classProp;
+    @property int instanceProp;
+    @end
+
+    @interface Derived : Base
+    @property int derivedProp;
+    @end
+
+    @implementation Derived
+    - (void)test:(id<Proto>)untyped {
+      // These must stay in order.
+      (void)Base.classProp;
+      (void)self.derivedProp;
+      (void)super.instanceProp;
+      (void)untyped.protoProp;
+    }
+    @end
+  )objc",
+      {"-x", "objective-c"}, "input.m");
+  ASSERT_TRUE(AST);
+
+  struct Visitor : RecursiveASTVisitor<Visitor> {
+    std::vector<const ObjCPropertyRefExpr *> PropRefs;
+    bool VisitObjCPropertyRefExpr(const ObjCPropertyRefExpr *E) {
+      PropRefs.push_back(E);
+      return true;
+    }
+  } V;
+  V.TraverseDecl(AST->getASTContext().getTranslationUnitDecl());
+
+  ASSERT_EQ(V.PropRefs.size(), 4u);
+
+  const ObjCPropertyRefExpr *ClassRef = V.PropRefs[0];
+  EXPECT_TRUE(ClassRef->isClassReceiver());
+  ASSERT_NE(ClassRef->getReceiverInterface(), nullptr);
+  EXPECT_EQ(ClassRef->getReceiverInterface()->getNameAsString(), "Base");
+
+  const ObjCPropertyRefExpr *ObjectRef = V.PropRefs[1];
+  EXPECT_TRUE(ObjectRef->isObjectReceiver());
+  ASSERT_NE(ObjectRef->getReceiverInterface(), nullptr);
+  EXPECT_EQ(ObjectRef->getReceiverInterface()->getNameAsString(), "Derived");
+
+  const ObjCPropertyRefExpr *SuperRef = V.PropRefs[2];
+  EXPECT_TRUE(SuperRef->isSuperReceiver());
+  ASSERT_NE(SuperRef->getReceiverInterface(), nullptr);
+  EXPECT_EQ(SuperRef->getReceiverInterface()->getNameAsString(), "Base");
+
+  const ObjCPropertyRefExpr *UntypedRef = V.PropRefs[3];
+  // id<Proto> are considered object receivers.
+  EXPECT_TRUE(UntypedRef->isObjectReceiver());
+  EXPECT_EQ(UntypedRef->getReceiverInterface(), nullptr);
 }


### PR DESCRIPTION
This change introduces `ObjCPropertyRefExpr::getReceiverInterface()` to determine the underlying `ObjCInterfaceDecl` of a property reference's receiver, regardless of whether it is a class, super, or object receiver.
This is semantically equivalent to `ObjCMessageExpr::getReceiverInterface()` on which it is based.
It's used to simplify `LookupMethodInReceiverType` in `SemaPseudoObject.cpp`, and the change adds corresponding unit tests. 
I intend to use this function in my Objective-C support for include cleaner (I wasn't just refactoring for fun).