### PR TITLE
[MLGO][CMake] Scope TensorFlow-AOT include usage

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1259,9 +1259,10 @@ if (NOT TENSORFLOW_AOT_PATH STREQUAL "")
   set(TENSORFLOW_AOT_COMPILER
     "${TENSORFLOW_AOT_PATH}/../../../../bin/saved_model_cli"
     CACHE PATH "Path to the Tensorflow AOT compiler")
-  include_directories(${TENSORFLOW_AOT_PATH}/include)
   add_subdirectory(${TENSORFLOW_AOT_PATH}/xla_aot_runtime_src
     ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/tf_runtime)
+  target_include_directories(tf_xla_runtime PUBLIC
+    $<BUILD_INTERFACE:${TENSORFLOW_AOT_PATH}/include>)
   install(TARGETS tf_xla_runtime EXPORT LLVMExports
     ARCHIVE DESTINATION lib${LLVM_LIBDIR_SUFFIX} COMPONENT tf_xla_runtime)
   install(TARGETS tf_xla_runtime EXPORT LLVMDevelopmentExports

--- a/llvm/cmake/modules/TensorFlowCompile.cmake
+++ b/llvm/cmake/modules/TensorFlowCompile.cmake
@@ -113,6 +113,6 @@ function(tf_find_and_compile model default_url default_path test_model_generator
 
   set(GeneratedMLSources ${GeneratedMLSources} ${GENERATED_OBJS} ${GENERATED_HEADERS} PARENT_SCOPE)
   set(MLDeps ${MLDeps} tf_xla_runtime PARENT_SCOPE)
-  set(MLLinkDeps ${MLLinkDeps} tf_xla_runtime PARENT_SCOPE)
+  set(MLLinkDeps ${MLLinkDeps} PRIVATE tf_xla_runtime PARENT_SCOPE)
   add_compile_definitions(LLVM_HAVE_TF_AOT_${fname_allcaps})
 endfunction()


### PR DESCRIPTION
## Summary

`TENSORFLOW_AOT_PATH` currently adds TensorFlow's include directory with directory-wide `include_directories()`. This exposes TensorFlow's bundled third-party headers to unrelated LLVM targets.

One concrete failure occurs when remote clangd is enabled: TensorFlow's bundled Protobuf headers can shadow the Protobuf installation selected for clangd's generated remote-index sources.

Replace the directory-wide include with a usage requirement on `tf_xla_runtime`. Make the runtime dependency private to MLGO-owning libraries, so those owners retain the TensorFlow headers they need while unrelated targets do not inherit them. The runtime remains a link-only dependency for final static linkers.

Fixes #218032.

## Validation

- A standalone synthetic `TENSORFLOW_AOT_PATH` fixture reproduced the header leak on upstream main.
- Before the change, `clangdRemoteIndexProto` inherited the synthetic TensorFlow include and failed at its poison Protobuf header.
- After the change, TensorFlow headers were absent from every clangd remote-index compilation, including generated Protobuf sources and their client, server, and monitor consumers.
- `clangdRemoteIndexProto` and `clangd-index-server-monitor` built successfully.
- In a full build with a real TensorFlow-AOT inliner model, `LLVMAnalysis`  retained the TensorFlow include required by its generated model header.
- The exported `tf_xla_runtime` dependency became link-only.
- `clangd` built with the gRPC feature enabled.

The standalone reproducer and before/after evidence are shown in the issue; no in-tree CMake test is included because I did not find an existing harness for top-level external-package usage-requirement isolation.

This change was developed with assistance from GitHub Copilot. I reviewed and validated the implementation and reproduction evidence.