### PR TITLE
lldb: Linux: empty Ptrace.h pollyfill

### DIFF
--- a/lldb/include/lldb/Host/linux/Ptrace.h
+++ b/lldb/include/lldb/Host/linux/Ptrace.h
@@ -13,55 +13,6 @@
 
 #include <sys/ptrace.h>
 
-#ifndef __GLIBC__
-typedef int __ptrace_request;
-#endif
-
-#define DEBUG_PTRACE_MAXBYTES 20
-
 // Support ptrace extensions even when compiled without required kernel support
-#ifndef PTRACE_GETREGS
-#define PTRACE_GETREGS 12
-#endif
-#ifndef PTRACE_SETREGS
-#define PTRACE_SETREGS 13
-#endif
-#ifndef PTRACE_GETFPREGS
-#define PTRACE_GETFPREGS 14
-#endif
-#ifndef PTRACE_SETFPREGS
-#define PTRACE_SETFPREGS 15
-#endif
-#ifndef PTRACE_GETREGSET
-#define PTRACE_GETREGSET 0x4204
-#endif
-#ifndef PTRACE_SETREGSET
-#define PTRACE_SETREGSET 0x4205
-#endif
-
-#ifndef PTRACE_GET_THREAD_AREA
-#ifdef __arm__
-// Arm has a different value, see arch/arm/include/uapi/asm/ptrace.h.
-#define PTRACE_GET_THREAD_AREA 22
-#else
-#define PTRACE_GET_THREAD_AREA 25
-#endif // __arm__
-#endif // PTRACE_GET_THREAD_AREA
-
-#ifndef PTRACE_ARCH_PRCTL
-#define PTRACE_ARCH_PRCTL 30
-#endif
-#ifndef ARCH_GET_FS
-#define ARCH_SET_GS 0x1001
-#define ARCH_SET_FS 0x1002
-#define ARCH_GET_FS 0x1003
-#define ARCH_GET_GS 0x1004
-#endif
-#ifndef PTRACE_PEEKMTETAGS
-#define PTRACE_PEEKMTETAGS 33
-#endif
-#ifndef PTRACE_POKEMTETAGS
-#define PTRACE_POKEMTETAGS 34
-#endif
 
 #endif // liblldb_Host_linux_Ptrace_h_

--- a/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
@@ -63,6 +63,22 @@
 #define HWCAP2_MTE (1 << 18)
 #endif
 
+#ifndef PTRACE_SETREGS
+#define PTRACE_SETREGS 13
+#endif
+
+#ifndef PTRACE_SETFPREGS
+#define PTRACE_SETFPREGS 15
+#endif
+
+#ifndef PTRACE_GETREGSET
+#define PTRACE_GETREGSET 0x4204
+#endif
+
+#ifndef PTRACE_SETREGSET
+#define PTRACE_SETREGSET 0x4205
+#endif
+
 using namespace lldb;
 using namespace lldb_private;
 using namespace lldb_private::process_linux;
@@ -131,7 +147,8 @@ static void MaybeLogLaunchInfo(const ProcessLaunchInfo &info) {
 
 static void DisplayBytes(StreamString &s, void *bytes, uint32_t count) {
   uint8_t *ptr = (uint8_t *)bytes;
-  const uint32_t loop_count = std::min<uint32_t>(DEBUG_PTRACE_MAXBYTES, count);
+  constexpr uint32_t kDebugPTraceMaxBytes = 20;
+  const uint32_t loop_count = std::min<uint32_t>(kDebugPTraceMaxBytes, count);
   for (uint32_t i = 0; i < loop_count; i++) {
     s.Printf("[%x]", *ptr);
     ptr++;

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux.cpp
@@ -15,7 +15,32 @@
 #include "lldb/Host/common/NativeThreadProtocol.h"
 #include "lldb/Host/linux/Ptrace.h"
 #include "lldb/Utility/RegisterValue.h"
+
 #include <sys/uio.h>
+
+#ifndef PTRACE_GETREGS
+#define PTRACE_GETREGS 12
+#endif
+
+#ifndef PTRACE_SETREGS
+#define PTRACE_SETREGS 13
+#endif
+
+#ifndef PTRACE_GETFPREGS
+#define PTRACE_GETFPREGS 14
+#endif
+
+#ifndef PTRACE_SETFPREGS
+#define PTRACE_SETFPREGS 15
+#endif
+
+#ifndef PTRACE_GETREGSET
+#define PTRACE_GETREGSET 0x4204
+#endif
+
+#ifndef PTRACE_SETREGSET
+#define PTRACE_SETREGSET 0x4205
+#endif
 
 using namespace lldb_private;
 using namespace lldb_private::process_linux;

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm.cpp
@@ -46,6 +46,10 @@
 #define PTRACE_TYPE_ARG4 void *
 #endif
 
+#ifndef PTRACE_GET_THREAD_AREA
+#define PTRACE_GET_THREAD_AREA 22
+#endif
+
 using namespace lldb;
 using namespace lldb_private;
 using namespace lldb_private::process_linux;

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.cpp
@@ -53,6 +53,18 @@
 #define HWCAP2_POE (1ULL << 63)
 #endif
 
+#ifndef PTRACE_GETREGSET
+#define PTRACE_GETREGSET 0x4204
+#endif
+
+#ifndef PTRACE_PEEKMTETAGS
+#define PTRACE_PEEKMTETAGS 33
+#endif
+
+#ifndef PTRACE_POKEMTETAGS
+#define PTRACE_POKEMTETAGS 34
+#endif
+
 using namespace lldb;
 using namespace lldb_private;
 using namespace lldb_private::process_linux;

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64dbreg.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64dbreg.cpp
@@ -17,6 +17,14 @@
 #include <elf.h>
 #include <sys/uio.h>
 
+#ifndef PTRACE_GETREGSET
+#define PTRACE_GETREGSET 0x4204
+#endif
+
+#ifndef PTRACE_SETREGSET
+#define PTRACE_SETREGSET 0x4205
+#endif
+
 using namespace lldb;
 using namespace lldb_private;
 using namespace lldb_private::process_linux;

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_loongarch64.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_loongarch64.cpp
@@ -26,6 +26,14 @@
 // struct iovec definition
 #include <sys/uio.h>
 
+#ifndef PTRACE_GETREGSET
+#define PTRACE_GETREGSET 0x4204
+#endif
+
+#ifndef PTRACE_SETREGSET
+#define PTRACE_SETREGSET 0x4205
+#endif
+
 // LoongArch SIMD eXtension registers
 #ifndef NT_LOONGARCH_LSX
 #define NT_LOONGARCH_LSX 0xa02

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_riscv64.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_riscv64.cpp
@@ -26,6 +26,10 @@
 #include <sys/ptrace.h>
 #include <sys/uio.h>
 
+#ifndef PTRACE_GETREGSET
+#define PTRACE_GETREGSET 0x4204
+#endif
+
 using namespace lldb;
 using namespace lldb_private;
 using namespace lldb_private::process_linux;

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_x86.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_x86.cpp
@@ -9,6 +9,7 @@
 #if defined(__i386__) || defined(__x86_64__)
 
 #include "NativeRegisterContextLinux_x86.h"
+
 #include "Plugins/Process/Linux/NativeProcessLinux.h"
 #include "Plugins/Process/Linux/NativeThreadLinux.h"
 #include "Plugins/Process/Utility/RegisterContextLinux_i386.h"
@@ -19,11 +20,16 @@
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/RegisterValue.h"
 #include "lldb/Utility/Status.h"
+
 #include <algorithm>
 #include <asm/ldt.h>
 #include <cpuid.h>
 #include <linux/elf.h>
 #include <optional>
+
+#ifndef PTRACE_GET_THREAD_AREA
+#define PTRACE_GET_THREAD_AREA 25
+#endif
 
 // Newer toolchains define __get_cpuid_count in cpuid.h, but some
 // older-but-still-supported ones (e.g. gcc 5.4.0) don't, so we


### PR DESCRIPTION
As the comment in sources alludes to:

> System includes - They have to be included after framework includes because
> they define some macros which collide with variable names in other modules.
  
Mixing includes of sys/ptrace.h with other headers can lead to conflicts
that cause i386 lldb-server builds to fail when build against bionic.

Prepare to remove this header outright.

Link: https://github.com/llvm/llvm-project/pull/217435
Link: https://github.com/llvm/llvm-project/issues/217413
Link: https://lore.kernel.org/llvm/20260821-ptrace_uapi-v1-1-3de8638a29f2@google.com/
