### PR TITLE
[Bazel] Use MSVC spelling for trapping math

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -1481,6 +1481,8 @@ cc_library(
         ],
     ) + ["include/llvm-c/Analysis.h"],
     copts = llvm_copts + select({
+        ":is_windows_clang_cl": ["/fp:except"],
+        ":is_windows_msvc": ["/fp:except"],
         "@platforms//os:emscripten": [],
         "//conditions:default": ["-ftrapping-math"],
     }),


### PR DESCRIPTION
Use `/fp:except` for clang-cl and MSVC, matching [the CMake build](https://github.com/llvm/llvm-project/blob/da24a7e95694fcb4a1e78d81824cd6bb3d3cd0f6/llvm/lib/Analysis/CMakeLists.txt#L37-L49). Emscripten and other compiler behavior is unchanged.
