### PR TITLE
[libc++] Enable _LIBCPP_HAS_TRIVIAL_MUTEX_DESTRUCTION for Bionic

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -266,10 +266,8 @@ typedef __char32_t char32_t;
 // pthread_mutex_destroy can allow the kernel to release resources.
 // See https://llvm.org/D64298 for details.
 //
-// TODO(EricWF): Enable this optimization on Bionic after speaking to their
-//               respective stakeholders.
 // clang-format off
-#  if (_LIBCPP_HAS_THREAD_API_PTHREAD && defined(__GLIBC__)) ||                                                        \
+#  if (_LIBCPP_HAS_THREAD_API_PTHREAD && (defined(__GLIBC__) || defined(__BIONIC__))) ||                                \
       (_LIBCPP_HAS_THREAD_API_C11 && defined(__Fuchsia__)) ||                                                          \
        _LIBCPP_HAS_THREAD_API_WIN32
 // clang-format on


### PR DESCRIPTION
As mentioned in the comment, pthread_mutex_destory is a nop for regular mutexes for Bionic, like glibc. We can enable
_LIBCPP_HAS_TRIVIAL_MUTEX_DESTRUCTION for Bionic causing std::mutex to have trivial destructors. This change prevents compilers from registering exit-time destructors for global/static mutexes exit-time crashes and silencing warnings under -Wexit-time-destructors.

Fixes: https://github.com/android/ndk/issues/1261