### PR TITLE
[AMDGPU] Add custom lowering for E5M3 path for packed convert instructions through `convert.{to|from}.arbitrary.fp`

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -1056,7 +1056,8 @@ SITargetLowering::SITargetLowering(const TargetMachine &TM,
     setOperationAction({ISD::FEXP2, ISD::FLOG2, ISD::FSQRT}, MVT::bf16, Legal);
   }
 
-  if (Subtarget->hasOCPFP8ConversionInsts()) {
+  if (Subtarget->hasOCPFP8ConversionInsts() ||
+      (Subtarget->hasFP8ConversionInsts() && Subtarget->hasFP8E5M3Insts())) {
     setOperationAction(ISD::CONVERT_FROM_ARBITRARY_FP, {MVT::f32, MVT::v2f32},
                        Custom);
     setOperationAction(ISD::CONVERT_FROM_ARBITRARY_FP, MVT::v2i8, Custom);
@@ -11014,16 +11015,42 @@ SDValue SITargetLowering::lowerFromFP8(SDValue Op, bool IsBF8,
 SDValue
 SITargetLowering::LowerCONVERT_FROM_ARBITRARY_FP(SDValue Op,
                                                  SelectionDAG &DAG) const {
-  // Only handle OCP FP8 formats (E4M3FN, E5M2). FNUZ formats that are supported
-  // by gfx942 fall through to the generic expansion.
+  // Handle the OCP FP8 formats (E4M3FN, E5M2) and unsigned E5M3 on subtargets
+  // with matching HW conversions. Other formats use the generic expansion.
   APFloatBase::Semantics FPSemantic =
       static_cast<APFloatBase::Semantics>(Op.getConstantOperandVal(1));
+  const bool IsE5M3 = FPSemantic == APFloatBase::S_Float8E5M3FNU;
   if (FPSemantic != APFloatBase::S_Float8E4M3FN &&
-      FPSemantic != APFloatBase::S_Float8E5M2)
+      FPSemantic != APFloatBase::S_Float8E5M2 &&
+      !(IsE5M3 && Subtarget->hasFP8ConversionInsts() &&
+        Subtarget->hasFP8E5M3Insts()))
     return SDValue();
   const bool IsBF8 = FPSemantic == APFloatBase::S_Float8E5M2;
 
   EVT DstVT = Op.getValueType();
+  if (IsE5M3) {
+    if (DstVT.getScalarType() != MVT::f32)
+      return SDValue();
+
+    SDLoc SL(Op);
+    SDValue Src = Op.getOperand(0);
+    assert((!DstVT.isVector() || DstVT == MVT::v2f32) &&
+           "only the v2f32 vector result is custom lowered");
+
+    if (DstVT.isVector())
+      Src = DAG.getNode(ISD::BITCAST, SL, MVT::i16, Src);
+    Src = DAG.getAnyExtOrTrunc(Src, SL, MVT::i32);
+
+    auto ConvertByte = [&](unsigned ByteSel) {
+      return DAG.getNode(AMDGPUISD::CVT_F32_FP8_E5M3, SL, MVT::f32, Src,
+                         DAG.getTargetConstant(ByteSel, SL, MVT::i32));
+    };
+
+    if (!DstVT.isVector())
+      return ConvertByte(0);
+    return DAG.getBuildVector(DstVT, SL, {ConvertByte(0), ConvertByte(1)});
+  }
+
   if (!DstVT.isVector()) {
     SDValue Src = Op.getOperand(0);
     if (Src.getValueType() != MVT::i32) {
@@ -11041,7 +11068,7 @@ SITargetLowering::LowerCONVERT_FROM_ARBITRARY_FP(SDValue Op,
   return SDValue();
 }
 
-SDValue SITargetLowering::lowerToFP8(SDValue Op, bool IsBF8,
+SDValue SITargetLowering::lowerToFP8(SDValue Op, bool IsBF8, bool IsE5M3,
                                      SelectionDAG &DAG) const {
   SDLoc SL(Op);
   SDValue Src = Op.getOperand(0);
@@ -11059,7 +11086,9 @@ SDValue SITargetLowering::lowerToFP8(SDValue Op, bool IsBF8,
     return DAG.getNode(ISD::BITCAST, SL, ResVT, Bytes);
   }
 
-  unsigned Opc = IsBF8 ? AMDGPUISD::CVT_PK_BF8_F32 : AMDGPUISD::CVT_PK_FP8_F32;
+  unsigned Opc = IsBF8    ? AMDGPUISD::CVT_PK_BF8_F32
+                 : IsE5M3 ? AMDGPUISD::CVT_PK_FP8_F32_E5M3
+                          : AMDGPUISD::CVT_PK_FP8_F32;
   SDValue PoisonI32 = DAG.getPOISON(MVT::i32);
   SDValue WordSel = DAG.getTargetConstant(0, SL, MVT::i1);
 
@@ -11081,32 +11110,38 @@ SDValue SITargetLowering::lowerToFP8(SDValue Op, bool IsBF8,
 SDValue
 SITargetLowering::LowerCONVERT_TO_ARBITRARY_FP(SDValue Op,
                                                SelectionDAG &DAG) const {
-  // Only the OCP fp8 formats E4M3FN and E5M2 map to HW conversions, everything
-  // else uses the generic expansion.
+  // The OCP FP8 formats (E4M3FN, E5M2) and unsigned E5M3 map to HW conversions
+  // on subtargets that support them. Everything else uses generic expansion.
   APFloatBase::Semantics Sem =
       static_cast<APFloatBase::Semantics>(Op.getConstantOperandVal(1));
-  if (Sem != APFloatBase::S_Float8E4M3FN && Sem != APFloatBase::S_Float8E5M2)
+  const bool IsE5M3 = Sem == APFloatBase::S_Float8E5M3FNU;
+  if (Sem != APFloatBase::S_Float8E4M3FN && Sem != APFloatBase::S_Float8E5M2 &&
+      !(IsE5M3 && Subtarget->hasFP8ConversionInsts() &&
+        Subtarget->hasFP8E5M3Insts()))
     return SDValue();
   bool IsBF8 = Sem == APFloatBase::S_Float8E5M2;
 
-  // The packed HW conversions round to nearest-even and never saturate.
+  // The HW conversions only support nearest-even. The OCP conversions do not
+  // saturate. The unsigned E5M3 conversion always clamps out-of-range inputs,
+  // which also refines the non-saturating form where those inputs are poison.
   if (static_cast<RoundingMode>(Op.getConstantOperandVal(2)) !=
       RoundingMode::NearestTiesToEven)
     return SDValue();
-  if (Op.getConstantOperandVal(3) != 0)
+  if (!IsE5M3 && Op.getConstantOperandVal(3) != 0)
     return SDValue();
 
   EVT SrcEltVT = Op.getOperand(0).getValueType().getScalarType();
   // The f32 form is built here rather than by a tablegen pattern because the
   // HW result is i32 while the node result is i16 after the i8 promotion.
   if (SrcEltVT == MVT::f32)
-    return lowerToFP8(Op, IsBF8, DAG);
-  if (SrcEltVT == MVT::f16 && Subtarget->hasF16FP8ConversionInsts()) {
+    return lowerToFP8(Op, IsBF8, IsE5M3, DAG);
+  if (!IsE5M3 && SrcEltVT == MVT::f16 &&
+      Subtarget->hasF16FP8ConversionInsts()) {
     // A scalar conversion is selected from the generic node by tablegen, only
     // the illegal v2i8 result type needs lowering here.
     if (!Op.getValueType().isVector())
       return Op;
-    return lowerToFP8(Op, IsBF8, DAG);
+    return lowerToFP8(Op, IsBF8, false, DAG);
   }
   return SDValue();
 }

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -1056,8 +1056,9 @@ SITargetLowering::SITargetLowering(const TargetMachine &TM,
     setOperationAction({ISD::FEXP2, ISD::FLOG2, ISD::FSQRT}, MVT::bf16, Legal);
   }
 
-  if (Subtarget->hasOCPFP8ConversionInsts() ||
-      (Subtarget->hasFP8ConversionInsts() && Subtarget->hasFP8E5M3Insts())) {
+  const bool HasE5M3ConversionInsts =
+      Subtarget->hasFP8ConversionInsts() && Subtarget->hasFP8E5M3Insts();
+  if (Subtarget->hasOCPFP8ConversionInsts() || HasE5M3ConversionInsts) {
     setOperationAction(ISD::CONVERT_FROM_ARBITRARY_FP, {MVT::f32, MVT::v2f32},
                        Custom);
     setOperationAction(ISD::CONVERT_FROM_ARBITRARY_FP, MVT::v2i8, Custom);
@@ -11019,13 +11020,14 @@ SITargetLowering::LowerCONVERT_FROM_ARBITRARY_FP(SDValue Op,
   // with matching HW conversions. Other formats use the generic expansion.
   APFloatBase::Semantics FPSemantic =
       static_cast<APFloatBase::Semantics>(Op.getConstantOperandVal(1));
-  const bool IsE5M3 = FPSemantic == APFloatBase::S_Float8E5M3FNU;
-  if (FPSemantic != APFloatBase::S_Float8E4M3FN &&
-      FPSemantic != APFloatBase::S_Float8E5M2 &&
-      !(IsE5M3 && Subtarget->hasFP8ConversionInsts() &&
-        Subtarget->hasFP8E5M3Insts()))
-    return SDValue();
+  const bool IsFP8 = FPSemantic == APFloatBase::S_Float8E4M3FN;
   const bool IsBF8 = FPSemantic == APFloatBase::S_Float8E5M2;
+  const bool IsE5M3 = FPSemantic == APFloatBase::S_Float8E5M3FNU;
+  const bool HasE5M3ConversionInsts =
+      Subtarget->hasFP8ConversionInsts() && Subtarget->hasFP8E5M3Insts();
+  const bool IsSupported = IsFP8 || IsBF8 || (IsE5M3 && HasE5M3ConversionInsts);
+  if (!IsSupported)
+    return SDValue();
 
   EVT DstVT = Op.getValueType();
   if (IsE5M3) {
@@ -11114,12 +11116,14 @@ SITargetLowering::LowerCONVERT_TO_ARBITRARY_FP(SDValue Op,
   // on subtargets that support them. Everything else uses generic expansion.
   APFloatBase::Semantics Sem =
       static_cast<APFloatBase::Semantics>(Op.getConstantOperandVal(1));
+  const bool IsFP8 = Sem == APFloatBase::S_Float8E4M3FN;
+  const bool IsBF8 = Sem == APFloatBase::S_Float8E5M2;
   const bool IsE5M3 = Sem == APFloatBase::S_Float8E5M3FNU;
-  if (Sem != APFloatBase::S_Float8E4M3FN && Sem != APFloatBase::S_Float8E5M2 &&
-      !(IsE5M3 && Subtarget->hasFP8ConversionInsts() &&
-        Subtarget->hasFP8E5M3Insts()))
+  const bool HasE5M3ConversionInsts =
+      Subtarget->hasFP8ConversionInsts() && Subtarget->hasFP8E5M3Insts();
+  const bool IsSupported = IsFP8 || IsBF8 || (IsE5M3 && HasE5M3ConversionInsts);
+  if (!IsSupported)
     return SDValue();
-  bool IsBF8 = Sem == APFloatBase::S_Float8E5M2;
 
   // The HW conversions only support nearest-even. The OCP conversions do not
   // saturate. The unsigned E5M3 conversion always clamps out-of-range inputs,

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.h
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.h
@@ -108,7 +108,8 @@ private:
   SDValue LowerCONVERT_FROM_ARBITRARY_FP(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerFromFP8(SDValue Op, bool IsBF8, SelectionDAG &DAG) const;
   SDValue LowerCONVERT_TO_ARBITRARY_FP(SDValue Op, SelectionDAG &DAG) const;
-  SDValue lowerToFP8(SDValue Op, bool IsBF8, SelectionDAG &DAG) const;
+  SDValue lowerToFP8(SDValue Op, bool IsBF8, bool IsE5M3,
+                     SelectionDAG &DAG) const;
 
   // The raw.tbuffer and struct.tbuffer intrinsics have two offset args: offset
   // (the offset that is included in bounds checking and swizzling, to be split

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.td
@@ -331,6 +331,10 @@ def cvt_from_fp8 : PatFrag<(ops node:$src),
 def cvt_from_bf8 : PatFrag<(ops node:$src),
                            (convert_from_arbitrary_fp node:$src, Float8E5M2)>;
 
+def AMDGPUcvt_f32_fp8_e5m3 : SDNode<"AMDGPUISD::CVT_F32_FP8_E5M3",
+  SDTypeProfile<1, 2, [SDTCisVT<0, f32>, SDTCisVT<1, i32>,
+                       SDTCisVT<2, i32>]>>;
+
 // The packed HW conversions round to nearest-even and never saturate, so only
 // those forms of convert_to_arbitrary_fp are matched here.
 def cvt_to_fp8 : PatFrag<(ops node:$src),
@@ -359,6 +363,9 @@ def cvt_pk_f16_bf8 : PatFrags<(ops node:$src),
 def AMDGPUcvt_pk_fp8_f32 : SDNode<"AMDGPUISD::CVT_PK_FP8_F32",
   SDTypeProfile<1, 4, [SDTCisVT<0, i32>, SDTCisVT<1, f32>, SDTCisVT<2, f32>,
                        SDTCisVT<3, i32>, SDTCisVT<4, i1>]>>;
+def AMDGPUcvt_pk_fp8_f32_e5m3 : SDNode<"AMDGPUISD::CVT_PK_FP8_F32_E5M3",
+  SDTypeProfile<1, 4, [SDTCisVT<0, i32>, SDTCisVT<1, f32>, SDTCisVT<2, f32>,
+                       SDTCisVT<3, i32>, SDTCisVT<4, i1>]>>;
 def AMDGPUcvt_pk_bf8_f32 : SDNode<"AMDGPUISD::CVT_PK_BF8_F32",
   SDTypeProfile<1, 4, [SDTCisVT<0, i32>, SDTCisVT<1, f32>, SDTCisVT<2, f32>,
                        SDTCisVT<3, i32>, SDTCisVT<4, i1>]>>;
@@ -370,6 +377,9 @@ def AMDGPUcvt_pk_bf8_f16 : SDNode<"AMDGPUISD::CVT_PK_BF8_F16",
 def cvt_pk_fp8_f32 : PatFrags<(ops node:$src0, node:$src1, node:$old, node:$sel),
   [(int_amdgcn_cvt_pk_fp8_f32 node:$src0, node:$src1, node:$old, node:$sel),
    (AMDGPUcvt_pk_fp8_f32 node:$src0, node:$src1, node:$old, node:$sel)]>;
+def cvt_pk_fp8_f32_e5m3 : PatFrags<(ops node:$src0, node:$src1, node:$old, node:$sel),
+  [(int_amdgcn_cvt_pk_fp8_f32_e5m3 node:$src0, node:$src1, node:$old, node:$sel),
+   (AMDGPUcvt_pk_fp8_f32_e5m3 node:$src0, node:$src1, node:$old, node:$sel)]>;
 def cvt_pk_bf8_f32 : PatFrags<(ops node:$src0, node:$src1, node:$old, node:$sel),
   [(int_amdgcn_cvt_pk_bf8_f32 node:$src0, node:$src1, node:$old, node:$sel),
    (AMDGPUcvt_pk_bf8_f32 node:$src0, node:$src1, node:$old, node:$sel)]>;

--- a/llvm/lib/Target/AMDGPU/VOP1Instructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP1Instructions.td
@@ -816,6 +816,8 @@ let SubtargetPredicate = HasCvtFP8ByteSelE5M3 in {
                (V_CVT_F32_FP8_gfx1250_e64 $src0, DSTCLAMP.NONE, (as_i32timm $byte_sel))>;
   def : GCNPat<(int_amdgcn_cvt_f32_fp8_e5m3 i32:$src0, timm:$byte_sel),
                (V_CVT_F32_FP8_gfx1250_e64 $src0, DSTCLAMP.ENABLE, (as_i32timm $byte_sel))>;
+  def : GCNPat<(AMDGPUcvt_f32_fp8_e5m3 i32:$src0, timm:$byte_sel),
+               (V_CVT_F32_FP8_gfx1250_e64 $src0, DSTCLAMP.ENABLE, (as_i32timm $byte_sel))>;
 }
 
 let SubtargetPredicate = HasCvtFP8ByteSel in

--- a/llvm/lib/Target/AMDGPU/VOP3Instructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP3Instructions.td
@@ -906,7 +906,7 @@ let True16Predicate = UseFakeTrue16Insts in {
   def : Cvt_PK_F8_F32_Pat<cvt_pk_bf8_f32, Index, V_CVT_PK_BF8_F32_fake16_e64>;
   let OtherPredicates = [HasFP8ConversionInsts, HasFP8E5M3Insts] in {
     def : Cvt_PK_F8_F32_E5M3_Pat<cvt_pk_fp8_f32,                 Index, V_CVT_PK_FP8_F32_gfx1250_fake16_e64, DSTCLAMP.NONE>;
-    def : Cvt_PK_F8_F32_E5M3_Pat<int_amdgcn_cvt_pk_fp8_f32_e5m3, Index, V_CVT_PK_FP8_F32_gfx1250_fake16_e64, DSTCLAMP.ENABLE>;
+    def : Cvt_PK_F8_F32_E5M3_Pat<cvt_pk_fp8_f32_e5m3,            Index, V_CVT_PK_FP8_F32_gfx1250_fake16_e64, DSTCLAMP.ENABLE>;
   }
 }
 }
@@ -916,7 +916,7 @@ defm : Cvt_PK_F8_F32_t16_Pat<cvt_pk_fp8_f32, V_CVT_PK_FP8_F32_t16_e64>;
 defm : Cvt_PK_F8_F32_t16_Pat<cvt_pk_bf8_f32, V_CVT_PK_BF8_F32_t16_e64>;
   let OtherPredicates = [HasFP8ConversionInsts, HasFP8E5M3Insts] in {
     defm : Cvt_PK_F8_F32_E5M3_t16_Pat<cvt_pk_fp8_f32,                 V_CVT_PK_FP8_F32_gfx1250_t16_e64, DSTCLAMP.NONE>;
-    defm : Cvt_PK_F8_F32_E5M3_t16_Pat<int_amdgcn_cvt_pk_fp8_f32_e5m3, V_CVT_PK_FP8_F32_gfx1250_t16_e64, DSTCLAMP.ENABLE>;
+    defm : Cvt_PK_F8_F32_E5M3_t16_Pat<cvt_pk_fp8_f32_e5m3,            V_CVT_PK_FP8_F32_gfx1250_t16_e64, DSTCLAMP.ENABLE>;
   }
 }
 

--- a/llvm/test/CodeGen/AMDGPU/arbitrary-fp-to-float-fp8-hw.ll
+++ b/llvm/test/CodeGen/AMDGPU/arbitrary-fp-to-float-fp8-hw.ll
@@ -3,7 +3,8 @@
 ; RUN: llc < %s -mtriple=amdgpu11.70-amd-amdhsa | FileCheck -check-prefix=GFX1170 %s
 ; RUN: llc < %s -mtriple=amdgpu12.50-amd-amdhsa | FileCheck -check-prefix=GFX1250 %s
 
-; llvm.convert.from.arbitrary.fp on FP8ConversionInsts targets with OCP FP8.
+; llvm.convert.from.arbitrary.fp on FP8ConversionInsts targets with OCP FP8,
+; plus E5M3FNU on GFX1250.
 
 ; Scalar Float8E5M2
 define float @from_bf8_dynamic(i8 %x) {
@@ -254,3 +255,461 @@ define <3 x float> @v3_from_fp8(<3 x i8> %x) {
   ret <3 x float> %r
 }
 
+; E5M3FNU is selected by the clamp encoding bit on GFX1250.
+define float @from_e5m3fnu_f32(i8 %x) {
+; GFX950-LABEL: from_e5m3fnu_f32:
+; GFX950:       ; %bb.0:
+; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX950-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX950-NEXT:    v_and_b32_e32 v1, 7, v0
+; GFX950-NEXT:    v_ffbh_u32_e32 v2, v1
+; GFX950-NEXT:    v_sub_u32_e32 v3, 31, v2
+; GFX950-NEXT:    v_lshlrev_b32_e64 v3, v3, 1
+; GFX950-NEXT:    v_bitop3_b32 v3, v0, v3, 7 bitop3:0x6c
+; GFX950-NEXT:    v_add_u32_e32 v4, -8, v2
+; GFX950-NEXT:    v_lshlrev_b32_e32 v3, v4, v3
+; GFX950-NEXT:    v_sub_u32_e32 v2, 0x8d, v2
+; GFX950-NEXT:    v_lshl_or_b32 v2, v2, 23, v3
+; GFX950-NEXT:    v_bfe_u32 v0, v0, 3, 5
+; GFX950-NEXT:    v_lshlrev_b32_e32 v3, 20, v1
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v1
+; GFX950-NEXT:    v_cmp_eq_u32_e64 s[0:1], 0, v0
+; GFX950-NEXT:    v_lshl_or_b32 v3, v0, 23, v3
+; GFX950-NEXT:    v_add_u32_e32 v3, 0x38000000, v3
+; GFX950-NEXT:    s_and_b64 vcc, s[0:1], vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
+; GFX950-NEXT:    v_or_b32_e32 v3, v0, v1
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
+; GFX950-NEXT:    v_cmp_eq_u32_e64 s[0:1], 31, v0
+; GFX950-NEXT:    v_mov_b32_e32 v0, 0x7fc00000
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
+; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, 7, v1
+; GFX950-NEXT:    s_and_b64 vcc, s[0:1], vcc
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX950-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1170-LABEL: from_e5m3fnu_f32:
+; GFX1170:       ; %bb.0:
+; GFX1170-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1170-NEXT:    v_cvt_u32_u16_e32 v0, v0.l
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1170-NEXT:    v_and_b32_e32 v1, 7, v0
+; GFX1170-NEXT:    v_bfe_u32 v0, v0, 3, 5
+; GFX1170-NEXT:    v_clz_i32_u32_e32 v2, v1
+; GFX1170-NEXT:    v_lshlrev_b32_e32 v5, 20, v1
+; GFX1170-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v1
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1170-NEXT:    v_cmp_eq_u32_e64 s0, 0, v0
+; GFX1170-NEXT:    v_sub_nc_u32_e32 v3, 31, v2
+; GFX1170-NEXT:    v_add_nc_u32_e32 v4, -8, v2
+; GFX1170-NEXT:    v_sub_nc_u32_e32 v2, 0x8d, v2
+; GFX1170-NEXT:    s_and_b32 vcc_lo, s0, vcc_lo
+; GFX1170-NEXT:    v_cmp_eq_u32_e64 s0, 31, v0
+; GFX1170-NEXT:    v_lshlrev_b32_e64 v3, v3, 1
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1170-NEXT:    v_xor_b32_e32 v3, v1, v3
+; GFX1170-NEXT:    v_lshlrev_b32_e32 v3, v4, v3
+; GFX1170-NEXT:    v_lshl_or_b32 v4, v0, 23, v5
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1170-NEXT:    v_lshl_or_b32 v2, v2, 23, v3
+; GFX1170-NEXT:    v_add_nc_u32_e32 v3, 0x38000000, v4
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(VALU_DEP_2)
+; GFX1170-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc_lo
+; GFX1170-NEXT:    v_or_b32_e32 v4, v0, v1
+; GFX1170-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 7, v1
+; GFX1170-NEXT:    v_cmp_ne_u32_e64 s1, 0, v4
+; GFX1170-NEXT:    s_and_b32 s0, s0, vcc_lo
+; GFX1170-NEXT:    v_cndmask_b32_e64 v0, 0, v2, s1
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1170-NEXT:    v_cndmask_b32_e64 v0, v0, 0x7fc00000, s0
+; GFX1170-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1250-LABEL: from_e5m3fnu_f32:
+; GFX1250:       ; %bb.0:
+; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-NEXT:    v_cvt_f32_fp8_e64 v0, v0 clamp
+; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
+  %r = call float @llvm.convert.from.arbitrary.fp.f32.i8(i8 %x, metadata !"Float8E5M3FNU")
+  ret float %r
+}
+
+define <2 x float> @v2_from_e5m3fnu(<2 x i8> %x) {
+; GFX950-LABEL: v2_from_e5m3fnu:
+; GFX950:       ; %bb.0:
+; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX950-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX950-NEXT:    v_and_b32_e32 v2, 7, v0
+; GFX950-NEXT:    v_ffbh_u32_e32 v3, v2
+; GFX950-NEXT:    v_sub_u32_e32 v4, 31, v3
+; GFX950-NEXT:    v_lshlrev_b32_e64 v4, v4, 1
+; GFX950-NEXT:    v_bitop3_b32 v4, v0, v4, 7 bitop3:0x6c
+; GFX950-NEXT:    v_add_u32_e32 v5, -8, v3
+; GFX950-NEXT:    v_lshlrev_b32_e32 v4, v5, v4
+; GFX950-NEXT:    v_sub_u32_e32 v3, 0x8d, v3
+; GFX950-NEXT:    v_lshl_or_b32 v3, v3, 23, v4
+; GFX950-NEXT:    v_bfe_u32 v0, v0, 3, 5
+; GFX950-NEXT:    v_lshlrev_b32_e32 v4, 20, v2
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
+; GFX950-NEXT:    v_cmp_eq_u32_e64 s[0:1], 0, v0
+; GFX950-NEXT:    v_lshl_or_b32 v4, v0, 23, v4
+; GFX950-NEXT:    v_add_u32_e32 v4, 0x38000000, v4
+; GFX950-NEXT:    s_and_b64 vcc, s[0:1], vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc
+; GFX950-NEXT:    v_or_b32_e32 v4, v0, v2
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; GFX950-NEXT:    v_cmp_eq_u32_e64 s[0:1], 31, v0
+; GFX950-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, 0, v3, vcc
+; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, 7, v2
+; GFX950-NEXT:    v_mov_b32_e32 v2, 0x7fc00000
+; GFX950-NEXT:    s_and_b64 vcc, s[0:1], vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
+; GFX950-NEXT:    v_and_b32_e32 v3, 7, v1
+; GFX950-NEXT:    v_ffbh_u32_e32 v4, v3
+; GFX950-NEXT:    v_sub_u32_e32 v5, 31, v4
+; GFX950-NEXT:    v_lshlrev_b32_e64 v5, v5, 1
+; GFX950-NEXT:    v_bitop3_b32 v5, v1, v5, 7 bitop3:0x6c
+; GFX950-NEXT:    v_add_u32_e32 v6, -8, v4
+; GFX950-NEXT:    v_lshlrev_b32_e32 v5, v6, v5
+; GFX950-NEXT:    v_sub_u32_e32 v4, 0x8d, v4
+; GFX950-NEXT:    v_lshl_or_b32 v4, v4, 23, v5
+; GFX950-NEXT:    v_bfe_u32 v1, v1, 3, 5
+; GFX950-NEXT:    v_lshlrev_b32_e32 v5, 20, v3
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
+; GFX950-NEXT:    v_cmp_eq_u32_e64 s[0:1], 0, v1
+; GFX950-NEXT:    v_lshl_or_b32 v5, v1, 23, v5
+; GFX950-NEXT:    v_add_u32_e32 v5, 0x38000000, v5
+; GFX950-NEXT:    s_and_b64 vcc, s[0:1], vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
+; GFX950-NEXT:    v_or_b32_e32 v5, v1, v3
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v5
+; GFX950-NEXT:    v_cmp_eq_u32_e64 s[0:1], 31, v1
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, 7, v3
+; GFX950-NEXT:    s_and_b64 vcc, s[0:1], vcc
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v4, v2, vcc
+; GFX950-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1170-LABEL: v2_from_e5m3fnu:
+; GFX1170:       ; %bb.0:
+; GFX1170-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1170-NEXT:    v_cvt_u32_u16_e32 v0, v0.l
+; GFX1170-NEXT:    v_cvt_u32_u16_e32 v1, v1.l
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1170-NEXT:    v_and_b32_e32 v2, 7, v0
+; GFX1170-NEXT:    v_bfe_u32 v0, v0, 3, 5
+; GFX1170-NEXT:    v_clz_i32_u32_e32 v4, v2
+; GFX1170-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v2
+; GFX1170-NEXT:    v_lshlrev_b32_e32 v5, 20, v2
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX1170-NEXT:    v_or_b32_e32 v7, v0, v2
+; GFX1170-NEXT:    v_cmp_eq_u32_e64 s1, 7, v2
+; GFX1170-NEXT:    v_sub_nc_u32_e32 v8, 31, v4
+; GFX1170-NEXT:    v_add_nc_u32_e32 v11, -8, v4
+; GFX1170-NEXT:    v_cmp_eq_u32_e64 s0, 0, v0
+; GFX1170-NEXT:    v_cmp_eq_u32_e64 s2, 31, v0
+; GFX1170-NEXT:    v_sub_nc_u32_e32 v4, 0x8d, v4
+; GFX1170-NEXT:    v_lshlrev_b32_e64 v8, v8, 1
+; GFX1170-NEXT:    v_lshl_or_b32 v0, v0, 23, v5
+; GFX1170-NEXT:    s_and_b32 vcc_lo, s0, vcc_lo
+; GFX1170-NEXT:    v_cmp_ne_u32_e64 s0, 0, v7
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX1170-NEXT:    v_xor_b32_e32 v2, v2, v8
+; GFX1170-NEXT:    v_add_nc_u32_e32 v0, 0x38000000, v0
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1170-NEXT:    v_lshlrev_b32_e32 v2, v11, v2
+; GFX1170-NEXT:    v_lshl_or_b32 v2, v4, 23, v2
+; GFX1170-NEXT:    v_and_b32_e32 v3, 7, v1
+; GFX1170-NEXT:    v_bfe_u32 v1, v1, 3, 5
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX1170-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc_lo
+; GFX1170-NEXT:    v_clz_i32_u32_e32 v6, v3
+; GFX1170-NEXT:    v_lshlrev_b32_e32 v10, 20, v3
+; GFX1170-NEXT:    v_cmp_ne_u32_e64 s3, 0, v3
+; GFX1170-NEXT:    v_cmp_eq_u32_e64 s4, 0, v1
+; GFX1170-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s0
+; GFX1170-NEXT:    v_sub_nc_u32_e32 v9, 31, v6
+; GFX1170-NEXT:    v_add_nc_u32_e32 v8, -8, v6
+; GFX1170-NEXT:    v_sub_nc_u32_e32 v5, 0x8d, v6
+; GFX1170-NEXT:    v_lshl_or_b32 v6, v1, 23, v10
+; GFX1170-NEXT:    s_and_b32 vcc_lo, s4, s3
+; GFX1170-NEXT:    v_lshlrev_b32_e64 v9, v9, 1
+; GFX1170-NEXT:    v_cmp_eq_u32_e64 s5, 7, v3
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX1170-NEXT:    v_add_nc_u32_e32 v4, 0x38000000, v6
+; GFX1170-NEXT:    v_xor_b32_e32 v9, v3, v9
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1170-NEXT:    v_lshlrev_b32_e32 v8, v8, v9
+; GFX1170-NEXT:    v_or_b32_e32 v9, v1, v3
+; GFX1170-NEXT:    v_lshl_or_b32 v5, v5, 23, v8
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1170-NEXT:    v_cmp_ne_u32_e64 s0, 0, v9
+; GFX1170-NEXT:    v_cndmask_b32_e32 v2, v4, v5, vcc_lo
+; GFX1170-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 31, v1
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
+; GFX1170-NEXT:    v_cndmask_b32_e64 v1, 0, v2, s0
+; GFX1170-NEXT:    s_and_b32 s0, s2, s1
+; GFX1170-NEXT:    v_cndmask_b32_e64 v0, v0, 0x7fc00000, s0
+; GFX1170-NEXT:    s_and_b32 s0, vcc_lo, s5
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instid1(SALU_CYCLE_1)
+; GFX1170-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7fc00000, s0
+; GFX1170-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1250-LABEL: v2_from_e5m3fnu:
+; GFX1250:       ; %bb.0:
+; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-NEXT:    v_perm_b32 v1, v0, v1, 0xc0c0004
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1250-NEXT:    v_cvt_f32_fp8_e64 v0, v1 clamp
+; GFX1250-NEXT:    v_cvt_f32_fp8_e64 v1, v1 byte_sel:1 clamp
+; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
+  %r = call <2 x float> @llvm.convert.from.arbitrary.fp.v2f32.v2i8(<2 x i8> %x, metadata !"Float8E5M3FNU")
+  ret <2 x float> %r
+}
+
+define <4 x float> @v4_from_e5m3fnu(<4 x i8> %x) {
+; GFX950-LABEL: v4_from_e5m3fnu:
+; GFX950:       ; %bb.0:
+; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX950-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX950-NEXT:    v_and_b32_e32 v4, 7, v0
+; GFX950-NEXT:    v_ffbh_u32_e32 v5, v4
+; GFX950-NEXT:    v_sub_u32_e32 v6, 31, v5
+; GFX950-NEXT:    v_lshlrev_b32_e64 v6, v6, 1
+; GFX950-NEXT:    v_bitop3_b32 v6, v0, v6, 7 bitop3:0x6c
+; GFX950-NEXT:    v_add_u32_e32 v7, -8, v5
+; GFX950-NEXT:    v_lshlrev_b32_e32 v6, v7, v6
+; GFX950-NEXT:    v_sub_u32_e32 v5, 0x8d, v5
+; GFX950-NEXT:    v_lshl_or_b32 v5, v5, 23, v6
+; GFX950-NEXT:    v_bfe_u32 v0, v0, 3, 5
+; GFX950-NEXT:    v_lshlrev_b32_e32 v6, 20, v4
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; GFX950-NEXT:    v_cmp_eq_u32_e64 s[0:1], 0, v0
+; GFX950-NEXT:    v_lshl_or_b32 v6, v0, 23, v6
+; GFX950-NEXT:    v_add_u32_e32 v6, 0x38000000, v6
+; GFX950-NEXT:    s_and_b64 vcc, s[0:1], vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc
+; GFX950-NEXT:    v_or_b32_e32 v6, v0, v4
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
+; GFX950-NEXT:    v_cmp_eq_u32_e64 s[0:1], 31, v0
+; GFX950-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX950-NEXT:    v_cndmask_b32_e32 v5, 0, v5, vcc
+; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, 7, v4
+; GFX950-NEXT:    v_mov_b32_e32 v4, 0x7fc00000
+; GFX950-NEXT:    s_and_b64 vcc, s[0:1], vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, v5, v4, vcc
+; GFX950-NEXT:    v_and_b32_e32 v5, 7, v1
+; GFX950-NEXT:    v_ffbh_u32_e32 v6, v5
+; GFX950-NEXT:    v_sub_u32_e32 v7, 31, v6
+; GFX950-NEXT:    v_lshlrev_b32_e64 v7, v7, 1
+; GFX950-NEXT:    v_bitop3_b32 v7, v1, v7, 7 bitop3:0x6c
+; GFX950-NEXT:    v_add_u32_e32 v8, -8, v6
+; GFX950-NEXT:    v_lshlrev_b32_e32 v7, v8, v7
+; GFX950-NEXT:    v_sub_u32_e32 v6, 0x8d, v6
+; GFX950-NEXT:    v_lshl_or_b32 v6, v6, 23, v7
+; GFX950-NEXT:    v_bfe_u32 v1, v1, 3, 5
+; GFX950-NEXT:    v_lshlrev_b32_e32 v7, 20, v5
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v5
+; GFX950-NEXT:    v_cmp_eq_u32_e64 s[0:1], 0, v1
+; GFX950-NEXT:    v_lshl_or_b32 v7, v1, 23, v7
+; GFX950-NEXT:    v_add_u32_e32 v7, 0x38000000, v7
+; GFX950-NEXT:    s_and_b64 vcc, s[0:1], vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc
+; GFX950-NEXT:    v_or_b32_e32 v7, v1, v5
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v7
+; GFX950-NEXT:    v_cmp_eq_u32_e64 s[0:1], 31, v1
+; GFX950-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; GFX950-NEXT:    v_cndmask_b32_e32 v6, 0, v6, vcc
+; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, 7, v5
+; GFX950-NEXT:    s_and_b64 vcc, s[0:1], vcc
+; GFX950-NEXT:    v_and_b32_e32 v5, 7, v2
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v6, v4, vcc
+; GFX950-NEXT:    v_ffbh_u32_e32 v6, v5
+; GFX950-NEXT:    v_sub_u32_e32 v7, 31, v6
+; GFX950-NEXT:    v_lshlrev_b32_e64 v7, v7, 1
+; GFX950-NEXT:    v_bitop3_b32 v7, v2, v7, 7 bitop3:0x6c
+; GFX950-NEXT:    v_add_u32_e32 v8, -8, v6
+; GFX950-NEXT:    v_lshlrev_b32_e32 v7, v8, v7
+; GFX950-NEXT:    v_sub_u32_e32 v6, 0x8d, v6
+; GFX950-NEXT:    v_lshl_or_b32 v6, v6, 23, v7
+; GFX950-NEXT:    v_bfe_u32 v2, v2, 3, 5
+; GFX950-NEXT:    v_lshlrev_b32_e32 v7, 20, v5
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v5
+; GFX950-NEXT:    v_cmp_eq_u32_e64 s[0:1], 0, v2
+; GFX950-NEXT:    v_lshl_or_b32 v7, v2, 23, v7
+; GFX950-NEXT:    v_add_u32_e32 v7, 0x38000000, v7
+; GFX950-NEXT:    s_and_b64 vcc, s[0:1], vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc
+; GFX950-NEXT:    v_or_b32_e32 v7, v2, v5
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v7
+; GFX950-NEXT:    v_cmp_eq_u32_e64 s[0:1], 31, v2
+; GFX950-NEXT:    v_and_b32_e32 v3, 0xffff, v3
+; GFX950-NEXT:    v_cndmask_b32_e32 v6, 0, v6, vcc
+; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, 7, v5
+; GFX950-NEXT:    s_and_b64 vcc, s[0:1], vcc
+; GFX950-NEXT:    v_and_b32_e32 v5, 7, v3
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, v6, v4, vcc
+; GFX950-NEXT:    v_ffbh_u32_e32 v6, v5
+; GFX950-NEXT:    v_sub_u32_e32 v7, 31, v6
+; GFX950-NEXT:    v_lshlrev_b32_e64 v7, v7, 1
+; GFX950-NEXT:    v_bitop3_b32 v7, v3, v7, 7 bitop3:0x6c
+; GFX950-NEXT:    v_add_u32_e32 v8, -8, v6
+; GFX950-NEXT:    v_lshlrev_b32_e32 v7, v8, v7
+; GFX950-NEXT:    v_sub_u32_e32 v6, 0x8d, v6
+; GFX950-NEXT:    v_lshl_or_b32 v6, v6, 23, v7
+; GFX950-NEXT:    v_bfe_u32 v3, v3, 3, 5
+; GFX950-NEXT:    v_lshlrev_b32_e32 v7, 20, v5
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v5
+; GFX950-NEXT:    v_cmp_eq_u32_e64 s[0:1], 0, v3
+; GFX950-NEXT:    v_lshl_or_b32 v7, v3, 23, v7
+; GFX950-NEXT:    v_add_u32_e32 v7, 0x38000000, v7
+; GFX950-NEXT:    s_and_b64 vcc, s[0:1], vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc
+; GFX950-NEXT:    v_or_b32_e32 v7, v3, v5
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v7
+; GFX950-NEXT:    v_cmp_eq_u32_e64 s[0:1], 31, v3
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e32 v6, 0, v6, vcc
+; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, 7, v5
+; GFX950-NEXT:    s_and_b64 vcc, s[0:1], vcc
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v6, v4, vcc
+; GFX950-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1170-LABEL: v4_from_e5m3fnu:
+; GFX1170:       ; %bb.0:
+; GFX1170-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1170-NEXT:    v_cvt_u32_u16_e32 v0, v0.l
+; GFX1170-NEXT:    v_cvt_u32_u16_e32 v1, v1.l
+; GFX1170-NEXT:    v_cvt_u32_u16_e32 v2, v2.l
+; GFX1170-NEXT:    v_cvt_u32_u16_e32 v3, v3.l
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX1170-NEXT:    v_and_b32_e32 v4, 7, v0
+; GFX1170-NEXT:    v_bfe_u32 v0, v0, 3, 5
+; GFX1170-NEXT:    v_and_b32_e32 v6, 7, v2
+; GFX1170-NEXT:    v_bfe_u32 v2, v2, 3, 5
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX1170-NEXT:    v_clz_i32_u32_e32 v8, v4
+; GFX1170-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v4
+; GFX1170-NEXT:    v_lshlrev_b32_e32 v9, 20, v4
+; GFX1170-NEXT:    v_or_b32_e32 v10, v0, v4
+; GFX1170-NEXT:    v_cmp_eq_u32_e64 s1, 7, v4
+; GFX1170-NEXT:    v_sub_nc_u32_e32 v11, 31, v8
+; GFX1170-NEXT:    v_add_nc_u32_e32 v17, -8, v8
+; GFX1170-NEXT:    v_cmp_eq_u32_e64 s0, 0, v0
+; GFX1170-NEXT:    v_cmp_eq_u32_e64 s2, 31, v0
+; GFX1170-NEXT:    v_sub_nc_u32_e32 v8, 0x8d, v8
+; GFX1170-NEXT:    v_lshlrev_b32_e64 v11, v11, 1
+; GFX1170-NEXT:    v_lshl_or_b32 v0, v0, 23, v9
+; GFX1170-NEXT:    s_and_b32 vcc_lo, s0, vcc_lo
+; GFX1170-NEXT:    v_clz_i32_u32_e32 v15, v6
+; GFX1170-NEXT:    s_and_b32 s0, s2, s1
+; GFX1170-NEXT:    v_xor_b32_e32 v4, v4, v11
+; GFX1170-NEXT:    v_add_nc_u32_e32 v0, 0x38000000, v0
+; GFX1170-NEXT:    v_cmp_ne_u32_e64 s1, 0, v6
+; GFX1170-NEXT:    v_cmp_eq_u32_e64 s2, 0, v2
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_2) | instid1(VALU_DEP_2)
+; GFX1170-NEXT:    v_lshlrev_b32_e32 v4, v17, v4
+; GFX1170-NEXT:    s_and_b32 s1, s2, s1
+; GFX1170-NEXT:    v_cmp_eq_u32_e64 s2, 31, v2
+; GFX1170-NEXT:    v_lshl_or_b32 v4, v8, 23, v4
+; GFX1170-NEXT:    v_and_b32_e32 v5, 7, v1
+; GFX1170-NEXT:    v_bfe_u32 v1, v1, 3, 5
+; GFX1170-NEXT:    v_sub_nc_u32_e32 v8, 31, v15
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1170-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc_lo
+; GFX1170-NEXT:    v_clz_i32_u32_e32 v12, v5
+; GFX1170-NEXT:    v_lshlrev_b32_e32 v13, 20, v5
+; GFX1170-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v10
+; GFX1170-NEXT:    v_and_b32_e32 v7, 7, v3
+; GFX1170-NEXT:    v_cmp_ne_u32_e64 s3, 0, v5
+; GFX1170-NEXT:    v_sub_nc_u32_e32 v16, 31, v12
+; GFX1170-NEXT:    v_add_nc_u32_e32 v9, -8, v12
+; GFX1170-NEXT:    v_sub_nc_u32_e32 v12, 0x8d, v12
+; GFX1170-NEXT:    v_lshl_or_b32 v13, v1, 23, v13
+; GFX1170-NEXT:    v_cmp_eq_u32_e64 s4, 0, v1
+; GFX1170-NEXT:    v_lshlrev_b32_e64 v16, v16, 1
+; GFX1170-NEXT:    v_or_b32_e32 v14, v1, v5
+; GFX1170-NEXT:    v_lshlrev_b32_e64 v4, v8, 1
+; GFX1170-NEXT:    v_add_nc_u32_e32 v8, 0x38000000, v13
+; GFX1170-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc_lo
+; GFX1170-NEXT:    v_xor_b32_e32 v16, v5, v16
+; GFX1170-NEXT:    v_clz_i32_u32_e32 v11, v7
+; GFX1170-NEXT:    s_and_b32 vcc_lo, s4, s3
+; GFX1170-NEXT:    v_xor_b32_e32 v4, v6, v4
+; GFX1170-NEXT:    v_cndmask_b32_e64 v0, v0, 0x7fc00000, s0
+; GFX1170-NEXT:    v_lshlrev_b32_e32 v9, v9, v16
+; GFX1170-NEXT:    v_sub_nc_u32_e32 v10, 31, v11
+; GFX1170-NEXT:    v_cmp_eq_u32_e64 s0, 31, v1
+; GFX1170-NEXT:    v_bfe_u32 v3, v3, 3, 5
+; GFX1170-NEXT:    v_cmp_ne_u32_e64 s3, 0, v7
+; GFX1170-NEXT:    v_lshl_or_b32 v9, v12, 23, v9
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1170-NEXT:    v_cmp_eq_u32_e64 s4, 0, v3
+; GFX1170-NEXT:    v_dual_cndmask_b32 v8, v8, v9 :: v_dual_add_nc_u32 v9, -8, v15
+; GFX1170-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v14
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX1170-NEXT:    v_lshlrev_b32_e32 v4, v9, v4
+; GFX1170-NEXT:    v_cndmask_b32_e32 v8, 0, v8, vcc_lo
+; GFX1170-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 7, v5
+; GFX1170-NEXT:    v_lshlrev_b32_e64 v5, v10, 1
+; GFX1170-NEXT:    v_sub_nc_u32_e32 v9, 0x8d, v15
+; GFX1170-NEXT:    v_lshlrev_b32_e32 v10, 20, v6
+; GFX1170-NEXT:    s_and_b32 s0, s0, vcc_lo
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_4) | instid1(VALU_DEP_4)
+; GFX1170-NEXT:    v_xor_b32_e32 v1, v7, v5
+; GFX1170-NEXT:    v_add_nc_u32_e32 v5, -8, v11
+; GFX1170-NEXT:    v_lshl_or_b32 v4, v9, 23, v4
+; GFX1170-NEXT:    v_lshl_or_b32 v9, v2, 23, v10
+; GFX1170-NEXT:    v_lshlrev_b32_e32 v10, 20, v7
+; GFX1170-NEXT:    v_lshlrev_b32_e32 v1, v5, v1
+; GFX1170-NEXT:    v_sub_nc_u32_e32 v5, 0x8d, v11
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1170-NEXT:    v_add_nc_u32_e32 v9, 0x38000000, v9
+; GFX1170-NEXT:    v_lshl_or_b32 v10, v3, 23, v10
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX1170-NEXT:    v_lshl_or_b32 v1, v5, 23, v1
+; GFX1170-NEXT:    v_cndmask_b32_e64 v4, v9, v4, s1
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_3) | instid1(VALU_DEP_3)
+; GFX1170-NEXT:    v_add_nc_u32_e32 v5, 0x38000000, v10
+; GFX1170-NEXT:    v_or_b32_e32 v10, v2, v6
+; GFX1170-NEXT:    s_and_b32 s1, s4, s3
+; GFX1170-NEXT:    v_cmp_eq_u32_e64 s4, 31, v3
+; GFX1170-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s1
+; GFX1170-NEXT:    v_or_b32_e32 v5, v3, v7
+; GFX1170-NEXT:    v_cmp_ne_u32_e64 s1, 0, v10
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1170-NEXT:    v_cmp_ne_u32_e64 s3, 0, v5
+; GFX1170-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s1
+; GFX1170-NEXT:    v_cmp_eq_u32_e64 s1, 7, v6
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_3) | instid1(SALU_CYCLE_1)
+; GFX1170-NEXT:    v_cndmask_b32_e64 v5, 0, v1, s3
+; GFX1170-NEXT:    v_cmp_eq_u32_e64 s3, 7, v7
+; GFX1170-NEXT:    v_cndmask_b32_e64 v1, v8, 0x7fc00000, s0
+; GFX1170-NEXT:    s_and_b32 s0, s2, s1
+; GFX1170-NEXT:    v_cndmask_b32_e64 v2, v4, 0x7fc00000, s0
+; GFX1170-NEXT:    s_and_b32 s0, s4, s3
+; GFX1170-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1170-NEXT:    v_cndmask_b32_e64 v3, v5, 0x7fc00000, s0
+; GFX1170-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1250-LABEL: v4_from_e5m3fnu:
+; GFX1250:       ; %bb.0:
+; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-NEXT:    v_perm_b32 v1, v0, v1, 0xc0c0004
+; GFX1250-NEXT:    v_perm_b32 v3, v2, v3, 0xc0c0004
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX1250-NEXT:    v_cvt_f32_fp8_e64 v0, v1 clamp
+; GFX1250-NEXT:    v_cvt_f32_fp8_e64 v1, v1 byte_sel:1 clamp
+; GFX1250-NEXT:    v_cvt_f32_fp8_e64 v2, v3 clamp
+; GFX1250-NEXT:    v_cvt_f32_fp8_e64 v3, v3 byte_sel:1 clamp
+; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
+  %r = call <4 x float> @llvm.convert.from.arbitrary.fp.v4f32.v4i8(<4 x i8> %x, metadata !"Float8E5M3FNU")
+  ret <4 x float> %r
+}

--- a/llvm/test/CodeGen/AMDGPU/float-to-arbitrary-fp-fp8-hw.ll
+++ b/llvm/test/CodeGen/AMDGPU/float-to-arbitrary-fp-fp8-hw.ll
@@ -5,9 +5,9 @@
 ; RUN: llc < %s -mtriple=amdgpu12.50-amd-amdhsa -mattr=-real-true16 | FileCheck -check-prefixes=GFX1250,GFX1250-FAKE16 %s
 ; RUN: llc < %s -mtriple=amdgpu13.10-amd-amdhsa | FileCheck -check-prefix=GFX1310 %s
 
-; llvm.convert.to.arbitrary.fp to OCP FP8 E4M3FN and BF8 E5M2 from f32, lowered
-; to the packed v_cvt_pk_{fp8,bf8}_f32 HW instructions. The FNUZ subtargets are
-; covered by float-to-arbitrary-fp-fp8-fnuz.ll.
+; llvm.convert.to.arbitrary.fp to OCP FP8 E4M3FN and BF8 E5M2 from f32, plus
+; E5M3FNU on GFX1250, lowered to packed HW instructions. The FNUZ subtargets
+; are covered by float-to-arbitrary-fp-fp8-fnuz.ll.
 
 define i8 @to_fp8_f32(float %x) {
 ; GFX950-LABEL: to_fp8_f32:
@@ -1892,5 +1892,1542 @@ define i8 @to_fp8_bf16(bfloat %x) {
 ; GFX1310-NEXT:    v_cndmask_b32_e32 v0, 0x7f, v0, vcc_lo
 ; GFX1310-NEXT:    s_set_pc_i64 s[30:31]
   %r = call i8 @llvm.convert.to.arbitrary.fp.i8.bf16(bfloat %x, metadata !"Float8E4M3FN", metadata !"round.tonearest", i1 false)
+  ret i8 %r
+}
+
+; The clamp modifier selects E5M3 for these instructions. The conversion's
+; native clamping also implements the saturating form of the generic intrinsic.
+define i8 @to_e5m3fnu_f32(float %x) {
+; GFX950-LABEL: to_e5m3fnu_f32:
+; GFX950:       ; %bb.0:
+; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX950-NEXT:    v_frexp_exp_i32_f32_e32 v1, v0
+; GFX950-NEXT:    v_sub_u32_e32 v2, 7, v1
+; GFX950-NEXT:    v_frexp_mant_f32_e32 v3, v0
+; GFX950-NEXT:    v_min_u32_e32 v2, 31, v2
+; GFX950-NEXT:    v_and_b32_e32 v4, 0x7fffff, v3
+; GFX950-NEXT:    v_or_b32_e32 v5, 0x800000, v4
+; GFX950-NEXT:    v_sub_u32_e64 v7, v2, 1 clamp
+; GFX950-NEXT:    v_lshrrev_b32_e32 v8, v7, v5
+; GFX950-NEXT:    v_bfe_u32 v7, v5, 0, v7
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v7
+; GFX950-NEXT:    v_bfe_u32 v6, v5, v2, 1
+; GFX950-NEXT:    v_bfe_u32 v4, v4, 20, 1
+; GFX950-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
+; GFX950-NEXT:    v_bitop3_b32 v6, v8, v7, v6 bitop3:0xe0
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
+; GFX950-NEXT:    v_lshrrev_b32_e32 v2, v2, v5
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e32 v6, 0, v6, vcc
+; GFX950-NEXT:    v_add_u32_e32 v2, v2, v6
+; GFX950-NEXT:    v_cmp_lt_i32_e32 vcc, 7, v2
+; GFX950-NEXT:    v_and_b32_e32 v6, 0x7ffff, v3
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e64 v5, 0, 8, vcc
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
+; GFX950-NEXT:    v_or_b32_e32 v2, v5, v2
+; GFX950-NEXT:    v_lshrrev_b32_e32 v5, 19, v3
+; GFX950-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
+; GFX950-NEXT:    v_bitop3_b32 v4, v5, v6, v4 bitop3:0xe0
+; GFX950-NEXT:    v_bfe_u32 v3, v3, 20, 3
+; GFX950-NEXT:    v_add_u32_e32 v3, v3, v4
+; GFX950-NEXT:    v_cmp_lt_i32_e32 vcc, 7, v3
+; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_cndmask_b32_e64 v3, v3, 0, vcc
+; GFX950-NEXT:    v_addc_co_u32_e32 v1, vcc, 14, v1, vcc
+; GFX950-NEXT:    v_lshl_or_b32 v3, v1, 3, v3
+; GFX950-NEXT:    v_cmp_gt_i32_e32 vcc, 1, v1
+; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v3, v2, vcc
+; GFX950-NEXT:    v_cmp_neq_f32_e32 vcc, 0, v0
+; GFX950-NEXT:    v_mov_b32_e32 v2, 0xff
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc
+; GFX950-NEXT:    v_cmp_o_f32_e32 vcc, v0, v0
+; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
+; GFX950-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1200-LABEL: to_e5m3fnu_f32:
+; GFX1200:       ; %bb.0:
+; GFX1200-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1200-NEXT:    s_wait_expcnt 0x0
+; GFX1200-NEXT:    s_wait_samplecnt 0x0
+; GFX1200-NEXT:    s_wait_bvhcnt 0x0
+; GFX1200-NEXT:    s_wait_kmcnt 0x0
+; GFX1200-NEXT:    v_frexp_exp_i32_f32_e32 v1, v0
+; GFX1200-NEXT:    v_frexp_mant_f32_e32 v3, v0
+; GFX1200-NEXT:    s_mov_b32 s0, 0x7fffff
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_sub_nc_u32_e32 v2, 7, v1
+; GFX1200-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX1200-NEXT:    v_and_or_b32 v4, v3, s0, 0x800000
+; GFX1200-NEXT:    v_and_b32_e32 v8, 0x7ffff, v3
+; GFX1200-NEXT:    v_bfe_u32 v9, v3, 20, 3
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v3, 19, v3
+; GFX1200-NEXT:    v_min_u32_e32 v2, 31, v2
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_sub_nc_u32_e64 v5, v2, 1 clamp
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v7, v2, v4
+; GFX1200-NEXT:    v_bfe_u32 v6, v4, 0, v5
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v4, v5, v4
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_3) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v6
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc_lo
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v8
+; GFX1200-NEXT:    v_and_or_b32 v5, v7, 1, v6
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc_lo
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v2
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX1200-NEXT:    v_and_b32_e32 v4, v4, v5
+; GFX1200-NEXT:    v_and_or_b32 v5, v9, 1, v6
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-NEXT:    v_dual_cndmask_b32 v2, 0, v4 :: v_dual_and_b32 v3, v3, v5
+; GFX1200-NEXT:    v_add_nc_u32_e32 v2, v7, v2
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_add_nc_u32_e32 v3, v9, v3
+; GFX1200-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 7, v2
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_3) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_cmp_lt_i32_e64 s0, 7, v3
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc_lo
+; GFX1200-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v3, v3, 0, s0
+; GFX1200-NEXT:    v_cndmask_b32_e64 v4, 0, 8, vcc_lo
+; GFX1200-NEXT:    v_add_co_ci_u32_e64 v1, null, 14, v1, s0
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_or_b32_e32 v2, v4, v2
+; GFX1200-NEXT:    v_lshl_or_b32 v3, v1, 3, v3
+; GFX1200-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 1, v1
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v1, v3, v2, vcc_lo
+; GFX1200-NEXT:    v_cmp_neq_f32_e32 vcc_lo, 0, v0
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc_lo
+; GFX1200-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v0
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v0, 0xff, v1, vcc_lo
+; GFX1200-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1250-TRUE16-LABEL: to_e5m3fnu_f32:
+; GFX1250-TRUE16:       ; %bb.0:
+; GFX1250-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-TRUE16-NEXT:    v_cvt_pk_fp8_f32 v0.l, v0, v0 clamp
+; GFX1250-TRUE16-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1250-FAKE16-LABEL: to_e5m3fnu_f32:
+; GFX1250-FAKE16:       ; %bb.0:
+; GFX1250-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-FAKE16-NEXT:    v_cvt_pk_fp8_f32 v0, v0, v0 clamp
+; GFX1250-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-LABEL: to_e5m3fnu_f32:
+; GFX1310:       ; %bb.0:
+; GFX1310-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-NEXT:    s_wait_expcnt 0x0
+; GFX1310-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-NEXT:    v_frexp_exp_i32_f32_e32 v1, v0
+; GFX1310-NEXT:    v_frexp_mant_f32_e32 v2, v0
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_4)
+; GFX1310-NEXT:    v_dual_sub_nc_u32 v3, 7, v1 :: v_dual_lshrrev_b32 v10, 19, v2
+; GFX1310-NEXT:    v_and_b32_e32 v4, 0x7fffff, v2
+; GFX1310-NEXT:    v_and_b32_e32 v9, 0x7ffff, v2
+; GFX1310-NEXT:    v_bfe_u32 v2, v2, 20, 3
+; GFX1310-NEXT:    v_min_u32_e32 v3, 31, v3
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX1310-NEXT:    v_or_b32_e32 v5, 0x800000, v4
+; GFX1310-NEXT:    v_bfe_u32 v4, v4, 20, 1
+; GFX1310-NEXT:    v_sub_nc_u32_e64 v6, v3, 1 clamp
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_bfe_u32 v8, v5, v3, 1
+; GFX1310-NEXT:    v_bfe_u32 v7, v5, 0, v6
+; GFX1310-NEXT:    v_dual_lshrrev_b32 v6, v6, v5 :: v_dual_lshrrev_b32 v5, v3, v5
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v7
+; GFX1310-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc_lo
+; GFX1310-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v9
+; GFX1310-NEXT:    v_bitop3_b32 v6, v6, v7, v8 bitop3:0xe0
+; GFX1310-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc_lo
+; GFX1310-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v3
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1310-NEXT:    v_bitop3_b32 v4, v10, v7, v4 bitop3:0xe0
+; GFX1310-NEXT:    v_dual_cndmask_b32 v3, 0, v6 :: v_dual_add_nc_u32 v2, v2, v4
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_add_nc_u32_e32 v3, v5, v3
+; GFX1310-NEXT:    v_cmp_lt_i32_e64 s0, 7, v2
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 7, v3
+; GFX1310-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s0
+; GFX1310-NEXT:    v_cndmask_b32_e64 v3, v3, 0, vcc_lo
+; GFX1310-NEXT:    v_cndmask_b32_e64 v4, 0, 8, vcc_lo
+; GFX1310-NEXT:    v_add_co_ci_u32_e64 v1, null, 14, v1, s0
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_or_b32_e32 v3, v4, v3
+; GFX1310-NEXT:    v_lshl_or_b32 v2, v1, 3, v2
+; GFX1310-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 1, v1
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_cndmask_b32_e32 v1, v2, v3, vcc_lo
+; GFX1310-NEXT:    v_cmp_neq_f32_e32 vcc_lo, 0, v0
+; GFX1310-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc_lo
+; GFX1310-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v0
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX1310-NEXT:    v_cndmask_b32_e32 v0, 0xff, v1, vcc_lo
+; GFX1310-NEXT:    s_set_pc_i64 s[30:31]
+  %r = call i8 @llvm.convert.to.arbitrary.fp.i8.f32(float %x, metadata !"Float8E5M3FNU", metadata !"round.tonearest", i1 false)
+  ret i8 %r
+}
+
+define <2 x i8> @to_e5m3fnu_v2f32(<2 x float> %x) {
+; GFX950-LABEL: to_e5m3fnu_v2f32:
+; GFX950:       ; %bb.0:
+; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX950-NEXT:    v_frexp_exp_i32_f32_e32 v2, v1
+; GFX950-NEXT:    v_sub_u32_e32 v3, 7, v2
+; GFX950-NEXT:    v_frexp_mant_f32_e32 v4, v1
+; GFX950-NEXT:    v_min_u32_e32 v3, 31, v3
+; GFX950-NEXT:    v_and_b32_e32 v5, 0x7fffff, v4
+; GFX950-NEXT:    v_or_b32_e32 v6, 0x800000, v5
+; GFX950-NEXT:    v_sub_u32_e64 v8, v3, 1 clamp
+; GFX950-NEXT:    v_lshrrev_b32_e32 v9, v8, v6
+; GFX950-NEXT:    v_bfe_u32 v8, v6, 0, v8
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
+; GFX950-NEXT:    v_bfe_u32 v7, v6, v3, 1
+; GFX950-NEXT:    v_bfe_u32 v5, v5, 20, 1
+; GFX950-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
+; GFX950-NEXT:    v_bitop3_b32 v7, v9, v8, v7 bitop3:0xe0
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
+; GFX950-NEXT:    v_lshrrev_b32_e32 v3, v3, v6
+; GFX950-NEXT:    s_movk_i32 s0, 0xff
+; GFX950-NEXT:    v_cndmask_b32_e32 v7, 0, v7, vcc
+; GFX950-NEXT:    v_add_u32_e32 v3, v3, v7
+; GFX950-NEXT:    v_cmp_lt_i32_e32 vcc, 7, v3
+; GFX950-NEXT:    v_and_b32_e32 v7, 0x7ffff, v4
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e64 v3, v3, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e64 v6, 0, 8, vcc
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v7
+; GFX950-NEXT:    v_or_b32_e32 v3, v6, v3
+; GFX950-NEXT:    v_lshrrev_b32_e32 v6, 19, v4
+; GFX950-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
+; GFX950-NEXT:    v_bitop3_b32 v5, v6, v7, v5 bitop3:0xe0
+; GFX950-NEXT:    v_bfe_u32 v4, v4, 20, 3
+; GFX950-NEXT:    v_add_u32_e32 v4, v4, v5
+; GFX950-NEXT:    v_cmp_lt_i32_e32 vcc, 7, v4
+; GFX950-NEXT:    v_frexp_mant_f32_e32 v6, v0
+; GFX950-NEXT:    v_and_b32_e32 v7, 0x7fffff, v6
+; GFX950-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
+; GFX950-NEXT:    v_addc_co_u32_e32 v2, vcc, 14, v2, vcc
+; GFX950-NEXT:    v_lshl_or_b32 v4, v2, 3, v4
+; GFX950-NEXT:    v_cmp_gt_i32_e32 vcc, 1, v2
+; GFX950-NEXT:    v_or_b32_e32 v8, 0x800000, v7
+; GFX950-NEXT:    v_bfe_u32 v7, v7, 20, 1
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, v4, v3, vcc
+; GFX950-NEXT:    v_frexp_exp_i32_f32_e32 v4, v0
+; GFX950-NEXT:    v_sub_u32_e32 v5, 7, v4
+; GFX950-NEXT:    v_min_u32_e32 v5, 31, v5
+; GFX950-NEXT:    v_cmp_neq_f32_e32 vcc, 0, v1
+; GFX950-NEXT:    v_sub_u32_e64 v10, v5, 1 clamp
+; GFX950-NEXT:    v_mov_b32_e32 v3, 0xff
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
+; GFX950-NEXT:    v_cmp_o_f32_e32 vcc, v1, v1
+; GFX950-NEXT:    v_lshrrev_b32_e32 v11, v10, v8
+; GFX950-NEXT:    v_bfe_u32 v10, v8, 0, v10
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v3, v2, vcc
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v10
+; GFX950-NEXT:    v_bfe_u32 v9, v8, v5, 1
+; GFX950-NEXT:    v_lshlrev_b16_e32 v2, 8, v1
+; GFX950-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
+; GFX950-NEXT:    v_bitop3_b32 v9, v11, v10, v9 bitop3:0xe0
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v5
+; GFX950-NEXT:    v_lshrrev_b32_e32 v5, v5, v8
+; GFX950-NEXT:    v_and_b32_e32 v1, 0xff, v1
+; GFX950-NEXT:    v_cndmask_b32_e32 v9, 0, v9, vcc
+; GFX950-NEXT:    v_add_u32_e32 v5, v5, v9
+; GFX950-NEXT:    v_cmp_lt_i32_e32 vcc, 7, v5
+; GFX950-NEXT:    v_and_b32_e32 v9, 0x7ffff, v6
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e64 v5, v5, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e64 v8, 0, 8, vcc
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v9
+; GFX950-NEXT:    v_or_b32_e32 v5, v8, v5
+; GFX950-NEXT:    v_lshrrev_b32_e32 v8, 19, v6
+; GFX950-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
+; GFX950-NEXT:    v_bitop3_b32 v7, v8, v9, v7 bitop3:0xe0
+; GFX950-NEXT:    v_bfe_u32 v6, v6, 20, 3
+; GFX950-NEXT:    v_add_u32_e32 v6, v6, v7
+; GFX950-NEXT:    v_cmp_lt_i32_e32 vcc, 7, v6
+; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_cndmask_b32_e64 v6, v6, 0, vcc
+; GFX950-NEXT:    v_addc_co_u32_e32 v4, vcc, 14, v4, vcc
+; GFX950-NEXT:    v_lshl_or_b32 v6, v4, 3, v6
+; GFX950-NEXT:    v_cmp_gt_i32_e32 vcc, 1, v4
+; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_cndmask_b32_e32 v4, v6, v5, vcc
+; GFX950-NEXT:    v_cmp_neq_f32_e32 vcc, 0, v0
+; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GFX950-NEXT:    v_cmp_o_f32_e32 vcc, v0, v0
+; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, v3, v4, vcc
+; GFX950-NEXT:    v_bitop3_b16 v0, v0, v2, s0 bitop3:0xec
+; GFX950-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1200-LABEL: to_e5m3fnu_v2f32:
+; GFX1200:       ; %bb.0:
+; GFX1200-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1200-NEXT:    s_wait_expcnt 0x0
+; GFX1200-NEXT:    s_wait_samplecnt 0x0
+; GFX1200-NEXT:    s_wait_bvhcnt 0x0
+; GFX1200-NEXT:    s_wait_kmcnt 0x0
+; GFX1200-NEXT:    v_frexp_exp_i32_f32_e32 v3, v1
+; GFX1200-NEXT:    v_frexp_mant_f32_e32 v2, v1
+; GFX1200-NEXT:    v_frexp_exp_i32_f32_e32 v5, v0
+; GFX1200-NEXT:    v_frexp_mant_f32_e32 v4, v0
+; GFX1200-NEXT:    s_mov_b32 s0, 0x7fffff
+; GFX1200-NEXT:    v_sub_nc_u32_e32 v7, 7, v3
+; GFX1200-NEXT:    v_and_b32_e32 v8, 0x7ffff, v2
+; GFX1200-NEXT:    v_sub_nc_u32_e32 v10, 7, v5
+; GFX1200-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX1200-NEXT:    v_and_or_b32 v6, v2, s0, 0x800000
+; GFX1200-NEXT:    v_and_b32_e32 v12, 0x7ffff, v4
+; GFX1200-NEXT:    v_min_u32_e32 v7, 31, v7
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v8
+; GFX1200-NEXT:    v_min_u32_e32 v10, 31, v10
+; GFX1200-NEXT:    v_and_or_b32 v11, v4, s0, 0x800000
+; GFX1200-NEXT:    v_bfe_u32 v9, v2, 20, 3
+; GFX1200-NEXT:    v_sub_nc_u32_e64 v14, v7, 1 clamp
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc_lo
+; GFX1200-NEXT:    v_sub_nc_u32_e64 v15, v10, 1 clamp
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v12
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v17, v7, v6
+; GFX1200-NEXT:    v_bfe_u32 v16, v6, 0, v14
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v19, v10, v11
+; GFX1200-NEXT:    v_bfe_u32 v18, v11, 0, v15
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v12, 0, 1, vcc_lo
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v2, 19, v2
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v16
+; GFX1200-NEXT:    v_and_or_b32 v8, v9, 1, v8
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v6, v14, v6
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v11, v15, v11
+; GFX1200-NEXT:    v_bfe_u32 v13, v4, 20, 3
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v16, 0, 1, vcc_lo
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v18
+; GFX1200-NEXT:    v_and_b32_e32 v2, v2, v8
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v4, 19, v4
+; GFX1200-NEXT:    v_and_or_b32 v12, v13, 1, v12
+; GFX1200-NEXT:    v_and_or_b32 v14, v17, 1, v16
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v18, 0, 1, vcc_lo
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v7
+; GFX1200-NEXT:    v_add_nc_u32_e32 v2, v9, v2
+; GFX1200-NEXT:    v_and_b32_e32 v4, v4, v12
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_and_or_b32 v15, v19, 1, v18
+; GFX1200-NEXT:    v_add_nc_u32_e32 v4, v13, v4
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX1200-NEXT:    v_and_b32_e32 v8, v11, v15
+; GFX1200-NEXT:    v_and_b32_e32 v6, v6, v14
+; GFX1200-NEXT:    v_cmp_lt_i32_e64 s0, 7, v4
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v6, 0, v6, vcc_lo
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v10
+; GFX1200-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s0
+; GFX1200-NEXT:    v_add_co_ci_u32_e64 v5, null, 14, v5, s0
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v7, 0, v8, vcc_lo
+; GFX1200-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 7, v2
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX1200-NEXT:    v_lshl_or_b32 v4, v5, 3, v4
+; GFX1200-NEXT:    v_add_nc_u32_e32 v7, v19, v7
+; GFX1200-NEXT:    v_add_nc_u32_e32 v6, v17, v6
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc_lo
+; GFX1200-NEXT:    v_add_co_ci_u32_e64 v3, null, 14, v3, vcc_lo
+; GFX1200-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 7, v7
+; GFX1200-NEXT:    v_cmp_lt_i32_e64 s1, 7, v6
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX1200-NEXT:    v_lshl_or_b32 v2, v3, 3, v2
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v7, v7, 0, vcc_lo
+; GFX1200-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v6, v6, 0, s1
+; GFX1200-NEXT:    v_cndmask_b32_e64 v8, 0, 8, s1
+; GFX1200-NEXT:    v_cndmask_b32_e64 v9, 0, 8, vcc_lo
+; GFX1200-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 1, v3
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX1200-NEXT:    v_or_b32_e32 v6, v8, v6
+; GFX1200-NEXT:    v_or_b32_e32 v7, v9, v7
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v2, v2, v6, vcc_lo
+; GFX1200-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 1, v5
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v3, v4, v7, vcc_lo
+; GFX1200-NEXT:    v_cmp_neq_f32_e32 vcc_lo, 0, v1
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc_lo
+; GFX1200-NEXT:    v_cmp_neq_f32_e32 vcc_lo, 0, v0
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v3, 0, v3, vcc_lo
+; GFX1200-NEXT:    v_cmp_o_f32_e32 vcc_lo, v1, v1
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v1, 0xff, v2, vcc_lo
+; GFX1200-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v0
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_3) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_lshlrev_b16 v0.l, 8, v1.l
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v2, 0xff, v3, vcc_lo
+; GFX1200-NEXT:    v_and_b16 v1.l, 0xff, v1.l
+; GFX1200-NEXT:    v_and_b16 v0.h, 0xff, v2.l
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1200-NEXT:    v_or_b16 v0.l, v0.h, v0.l
+; GFX1200-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1250-TRUE16-LABEL: to_e5m3fnu_v2f32:
+; GFX1250-TRUE16:       ; %bb.0:
+; GFX1250-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-TRUE16-NEXT:    v_cvt_pk_fp8_f32 v0.l, v0, v1 clamp
+; GFX1250-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1250-TRUE16-NEXT:    v_lshrrev_b16 v1.l, 8, v0.l
+; GFX1250-TRUE16-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1250-FAKE16-LABEL: to_e5m3fnu_v2f32:
+; GFX1250-FAKE16:       ; %bb.0:
+; GFX1250-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-FAKE16-NEXT:    v_cvt_pk_fp8_f32 v0, v0, v1 clamp
+; GFX1250-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1250-FAKE16-NEXT:    v_lshrrev_b16 v1, 8, v0
+; GFX1250-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-LABEL: to_e5m3fnu_v2f32:
+; GFX1310:       ; %bb.0:
+; GFX1310-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-NEXT:    s_wait_expcnt 0x0
+; GFX1310-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-NEXT:    v_frexp_exp_i32_f32_e32 v2, v1
+; GFX1310-NEXT:    v_frexp_mant_f32_e32 v3, v1
+; GFX1310-NEXT:    v_frexp_exp_i32_f32_e32 v4, v0
+; GFX1310-NEXT:    v_frexp_mant_f32_e32 v5, v0
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX1310-NEXT:    v_dual_sub_nc_u32 v6, 7, v2 :: v_dual_lshrrev_b32 v8, 19, v3
+; GFX1310-NEXT:    v_and_b32_e32 v7, 0x7fffff, v3
+; GFX1310-NEXT:    v_dual_sub_nc_u32 v10, 7, v4 :: v_dual_lshrrev_b32 v12, 19, v5
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX1310-NEXT:    v_min_u32_e32 v6, 31, v6
+; GFX1310-NEXT:    v_and_b32_e32 v11, 0x7fffff, v5
+; GFX1310-NEXT:    v_or_b32_e32 v14, 0x800000, v7
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX1310-NEXT:    v_min_u32_e32 v10, 31, v10
+; GFX1310-NEXT:    v_and_b32_e32 v9, 0x7ffff, v3
+; GFX1310-NEXT:    v_sub_nc_u32_e64 v15, v6, 1 clamp
+; GFX1310-NEXT:    v_or_b32_e32 v16, 0x800000, v11
+; GFX1310-NEXT:    v_bfe_u32 v18, v14, v6, 1
+; GFX1310-NEXT:    v_sub_nc_u32_e64 v17, v10, 1 clamp
+; GFX1310-NEXT:    v_and_b32_e32 v13, 0x7ffff, v5
+; GFX1310-NEXT:    v_bfe_u32 v19, v14, 0, v15
+; GFX1310-NEXT:    v_lshrrev_b32_e32 v15, v15, v14
+; GFX1310-NEXT:    v_bfe_u32 v7, v7, 20, 1
+; GFX1310-NEXT:    v_bfe_u32 v21, v16, 0, v17
+; GFX1310-NEXT:    v_lshrrev_b32_e32 v17, v17, v16
+; GFX1310-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v19
+; GFX1310-NEXT:    v_bfe_u32 v20, v16, v10, 1
+; GFX1310-NEXT:    v_bfe_u32 v3, v3, 20, 3
+; GFX1310-NEXT:    v_bfe_u32 v11, v11, 20, 1
+; GFX1310-NEXT:    v_bfe_u32 v5, v5, 20, 3
+; GFX1310-NEXT:    v_cndmask_b32_e64 v19, 0, 1, vcc_lo
+; GFX1310-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v21
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_bitop3_b32 v15, v15, v19, v18 bitop3:0xe0
+; GFX1310-NEXT:    v_cndmask_b32_e64 v21, 0, 1, vcc_lo
+; GFX1310-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v9
+; GFX1310-NEXT:    v_bitop3_b32 v17, v17, v21, v20 bitop3:0xe0
+; GFX1310-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc_lo
+; GFX1310-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v6
+; GFX1310-NEXT:    v_lshrrev_b32_e32 v14, v6, v14
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_2) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_bitop3_b32 v7, v8, v9, v7 bitop3:0xe0
+; GFX1310-NEXT:    v_cndmask_b32_e32 v6, 0, v15, vcc_lo
+; GFX1310-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v13
+; GFX1310-NEXT:    v_dual_add_nc_u32 v3, v3, v7 :: v_dual_add_nc_u32 v6, v14, v6
+; GFX1310-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc_lo
+; GFX1310-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v10
+; GFX1310-NEXT:    v_lshrrev_b32_e32 v10, v10, v16
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1310-NEXT:    v_cmp_lt_i32_e64 s0, 7, v3
+; GFX1310-NEXT:    v_bitop3_b32 v9, v12, v13, v11 bitop3:0xe0
+; GFX1310-NEXT:    v_cndmask_b32_e32 v8, 0, v17, vcc_lo
+; GFX1310-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 7, v6
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX1310-NEXT:    v_cndmask_b32_e64 v3, v3, 0, s0
+; GFX1310-NEXT:    v_add_co_ci_u32_e64 v2, null, 14, v2, s0
+; GFX1310-NEXT:    v_dual_add_nc_u32 v5, v5, v9 :: v_dual_add_nc_u32 v7, v10, v8
+; GFX1310-NEXT:    v_cndmask_b32_e64 v6, v6, 0, vcc_lo
+; GFX1310-NEXT:    v_cndmask_b32_e64 v8, 0, 8, vcc_lo
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1310-NEXT:    v_lshl_or_b32 v3, v2, 3, v3
+; GFX1310-NEXT:    v_cmp_lt_i32_e64 s0, 7, v5
+; GFX1310-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 7, v7
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_4) | instid1(VALU_DEP_3)
+; GFX1310-NEXT:    v_cndmask_b32_e64 v5, v5, 0, s0
+; GFX1310-NEXT:    v_cndmask_b32_e64 v7, v7, 0, vcc_lo
+; GFX1310-NEXT:    v_cndmask_b32_e64 v9, 0, 8, vcc_lo
+; GFX1310-NEXT:    v_add_co_ci_u32_e64 v4, null, 14, v4, s0
+; GFX1310-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 1, v2
+; GFX1310-NEXT:    v_or_b32_e32 v7, v9, v7
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1310-NEXT:    v_lshl_or_b32 v5, v4, 3, v5
+; GFX1310-NEXT:    v_or_b32_e32 v6, v8, v6
+; GFX1310-NEXT:    v_cndmask_b32_e32 v2, v3, v6, vcc_lo
+; GFX1310-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 1, v4
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX1310-NEXT:    v_cndmask_b32_e32 v3, v5, v7, vcc_lo
+; GFX1310-NEXT:    v_cmp_neq_f32_e32 vcc_lo, 0, v1
+; GFX1310-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc_lo
+; GFX1310-NEXT:    v_cmp_neq_f32_e32 vcc_lo, 0, v0
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX1310-NEXT:    v_cndmask_b32_e32 v3, 0, v3, vcc_lo
+; GFX1310-NEXT:    v_cmp_o_f32_e32 vcc_lo, v1, v1
+; GFX1310-NEXT:    v_cndmask_b32_e32 v1, 0xff, v2, vcc_lo
+; GFX1310-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v0
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX1310-NEXT:    v_cndmask_b32_e32 v0, 0xff, v3, vcc_lo
+; GFX1310-NEXT:    v_lshlrev_b16 v2, 8, v1
+; GFX1310-NEXT:    v_and_b32_e32 v1, 0xff, v1
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX1310-NEXT:    v_bitop3_b16 v0, v0, v2, 0xff bitop3:0xec
+; GFX1310-NEXT:    s_set_pc_i64 s[30:31]
+  %r = call <2 x i8> @llvm.convert.to.arbitrary.fp.v2i8.v2f32(<2 x float> %x, metadata !"Float8E5M3FNU", metadata !"round.tonearest", i1 false)
+  ret <2 x i8> %r
+}
+
+define <4 x i8> @to_e5m3fnu_v4f32(<4 x float> %x) {
+; GFX950-LABEL: to_e5m3fnu_v4f32:
+; GFX950:       ; %bb.0:
+; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX950-NEXT:    v_frexp_exp_i32_f32_e32 v4, v1
+; GFX950-NEXT:    v_sub_u32_e32 v5, 7, v4
+; GFX950-NEXT:    v_frexp_mant_f32_e32 v6, v1
+; GFX950-NEXT:    v_min_u32_e32 v5, 31, v5
+; GFX950-NEXT:    v_and_b32_e32 v7, 0x7fffff, v6
+; GFX950-NEXT:    v_or_b32_e32 v8, 0x800000, v7
+; GFX950-NEXT:    v_sub_u32_e64 v10, v5, 1 clamp
+; GFX950-NEXT:    v_lshrrev_b32_e32 v11, v10, v8
+; GFX950-NEXT:    v_bfe_u32 v10, v8, 0, v10
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v10
+; GFX950-NEXT:    v_bfe_u32 v9, v8, v5, 1
+; GFX950-NEXT:    v_bfe_u32 v7, v7, 20, 1
+; GFX950-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
+; GFX950-NEXT:    v_bitop3_b32 v9, v11, v10, v9 bitop3:0xe0
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v5
+; GFX950-NEXT:    v_lshrrev_b32_e32 v5, v5, v8
+; GFX950-NEXT:    s_movk_i32 s0, 0xff
+; GFX950-NEXT:    v_cndmask_b32_e32 v9, 0, v9, vcc
+; GFX950-NEXT:    v_add_u32_e32 v5, v5, v9
+; GFX950-NEXT:    v_cmp_lt_i32_e32 vcc, 7, v5
+; GFX950-NEXT:    v_and_b32_e32 v9, 0x7ffff, v6
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e64 v5, v5, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e64 v8, 0, 8, vcc
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v9
+; GFX950-NEXT:    v_or_b32_e32 v5, v8, v5
+; GFX950-NEXT:    v_lshrrev_b32_e32 v8, 19, v6
+; GFX950-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
+; GFX950-NEXT:    v_bitop3_b32 v7, v8, v9, v7 bitop3:0xe0
+; GFX950-NEXT:    v_bfe_u32 v6, v6, 20, 3
+; GFX950-NEXT:    v_add_u32_e32 v6, v6, v7
+; GFX950-NEXT:    v_cmp_lt_i32_e32 vcc, 7, v6
+; GFX950-NEXT:    v_frexp_mant_f32_e32 v7, v0
+; GFX950-NEXT:    v_and_b32_e32 v8, 0x7fffff, v7
+; GFX950-NEXT:    v_cndmask_b32_e64 v6, v6, 0, vcc
+; GFX950-NEXT:    v_addc_co_u32_e32 v4, vcc, 14, v4, vcc
+; GFX950-NEXT:    v_lshl_or_b32 v6, v4, 3, v6
+; GFX950-NEXT:    v_cmp_gt_i32_e32 vcc, 1, v4
+; GFX950-NEXT:    v_or_b32_e32 v9, 0x800000, v8
+; GFX950-NEXT:    v_bfe_u32 v8, v8, 20, 1
+; GFX950-NEXT:    v_cndmask_b32_e32 v4, v6, v5, vcc
+; GFX950-NEXT:    v_cmp_neq_f32_e32 vcc, 0, v1
+; GFX950-NEXT:    v_mov_b32_e32 v5, 0xff
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GFX950-NEXT:    v_cmp_o_f32_e32 vcc, v1, v1
+; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v5, v4, vcc
+; GFX950-NEXT:    v_frexp_exp_i32_f32_e32 v4, v0
+; GFX950-NEXT:    v_sub_u32_e32 v6, 7, v4
+; GFX950-NEXT:    v_min_u32_e32 v6, 31, v6
+; GFX950-NEXT:    v_sub_u32_e64 v11, v6, 1 clamp
+; GFX950-NEXT:    v_lshrrev_b32_e32 v12, v11, v9
+; GFX950-NEXT:    v_bfe_u32 v11, v9, 0, v11
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v11
+; GFX950-NEXT:    v_bfe_u32 v10, v9, v6, 1
+; GFX950-NEXT:    v_lshlrev_b16_e32 v1, 8, v1
+; GFX950-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
+; GFX950-NEXT:    v_bitop3_b32 v10, v12, v11, v10 bitop3:0xe0
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
+; GFX950-NEXT:    v_lshrrev_b32_e32 v6, v6, v9
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e32 v10, 0, v10, vcc
+; GFX950-NEXT:    v_add_u32_e32 v6, v6, v10
+; GFX950-NEXT:    v_cmp_lt_i32_e32 vcc, 7, v6
+; GFX950-NEXT:    v_and_b32_e32 v10, 0x7ffff, v7
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e64 v6, v6, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e64 v9, 0, 8, vcc
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v10
+; GFX950-NEXT:    v_or_b32_e32 v6, v9, v6
+; GFX950-NEXT:    v_lshrrev_b32_e32 v9, 19, v7
+; GFX950-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
+; GFX950-NEXT:    v_bitop3_b32 v8, v9, v10, v8 bitop3:0xe0
+; GFX950-NEXT:    v_bfe_u32 v7, v7, 20, 3
+; GFX950-NEXT:    v_add_u32_e32 v7, v7, v8
+; GFX950-NEXT:    v_cmp_lt_i32_e32 vcc, 7, v7
+; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_cndmask_b32_e64 v7, v7, 0, vcc
+; GFX950-NEXT:    v_addc_co_u32_e32 v4, vcc, 14, v4, vcc
+; GFX950-NEXT:    v_lshl_or_b32 v7, v4, 3, v7
+; GFX950-NEXT:    v_cmp_gt_i32_e32 vcc, 1, v4
+; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_cndmask_b32_e32 v4, v7, v6, vcc
+; GFX950-NEXT:    v_cmp_neq_f32_e32 vcc, 0, v0
+; GFX950-NEXT:    v_frexp_mant_f32_e32 v7, v3
+; GFX950-NEXT:    v_and_b32_e32 v8, 0x7fffff, v7
+; GFX950-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GFX950-NEXT:    v_cmp_o_f32_e32 vcc, v0, v0
+; GFX950-NEXT:    v_or_b32_e32 v9, 0x800000, v8
+; GFX950-NEXT:    v_bfe_u32 v8, v8, 20, 1
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, v5, v4, vcc
+; GFX950-NEXT:    v_frexp_exp_i32_f32_e32 v4, v3
+; GFX950-NEXT:    v_sub_u32_e32 v6, 7, v4
+; GFX950-NEXT:    v_min_u32_e32 v6, 31, v6
+; GFX950-NEXT:    v_sub_u32_e64 v11, v6, 1 clamp
+; GFX950-NEXT:    v_lshrrev_b32_e32 v12, v11, v9
+; GFX950-NEXT:    v_bfe_u32 v11, v9, 0, v11
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v11
+; GFX950-NEXT:    v_bfe_u32 v10, v9, v6, 1
+; GFX950-NEXT:    v_bitop3_b16 v0, v0, v1, s0 bitop3:0xec
+; GFX950-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
+; GFX950-NEXT:    v_bitop3_b32 v10, v12, v11, v10 bitop3:0xe0
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
+; GFX950-NEXT:    v_lshrrev_b32_e32 v6, v6, v9
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e32 v10, 0, v10, vcc
+; GFX950-NEXT:    v_add_u32_e32 v6, v6, v10
+; GFX950-NEXT:    v_cmp_lt_i32_e32 vcc, 7, v6
+; GFX950-NEXT:    v_and_b32_e32 v10, 0x7ffff, v7
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e64 v6, v6, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e64 v9, 0, 8, vcc
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v10
+; GFX950-NEXT:    v_or_b32_e32 v6, v9, v6
+; GFX950-NEXT:    v_lshrrev_b32_e32 v9, 19, v7
+; GFX950-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
+; GFX950-NEXT:    v_bitop3_b32 v8, v9, v10, v8 bitop3:0xe0
+; GFX950-NEXT:    v_bfe_u32 v7, v7, 20, 3
+; GFX950-NEXT:    v_add_u32_e32 v7, v7, v8
+; GFX950-NEXT:    v_cmp_lt_i32_e32 vcc, 7, v7
+; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_cndmask_b32_e64 v7, v7, 0, vcc
+; GFX950-NEXT:    v_addc_co_u32_e32 v4, vcc, 14, v4, vcc
+; GFX950-NEXT:    v_lshl_or_b32 v7, v4, 3, v7
+; GFX950-NEXT:    v_cmp_gt_i32_e32 vcc, 1, v4
+; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_cndmask_b32_e32 v4, v7, v6, vcc
+; GFX950-NEXT:    v_cmp_neq_f32_e32 vcc, 0, v3
+; GFX950-NEXT:    v_frexp_mant_f32_e32 v7, v2
+; GFX950-NEXT:    v_and_b32_e32 v8, 0x7fffff, v7
+; GFX950-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GFX950-NEXT:    v_cmp_o_f32_e32 vcc, v3, v3
+; GFX950-NEXT:    v_or_b32_e32 v9, 0x800000, v8
+; GFX950-NEXT:    v_bfe_u32 v8, v8, 20, 1
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v5, v4, vcc
+; GFX950-NEXT:    v_frexp_exp_i32_f32_e32 v4, v2
+; GFX950-NEXT:    v_sub_u32_e32 v6, 7, v4
+; GFX950-NEXT:    v_min_u32_e32 v6, 31, v6
+; GFX950-NEXT:    v_sub_u32_e64 v11, v6, 1 clamp
+; GFX950-NEXT:    v_lshrrev_b32_e32 v12, v11, v9
+; GFX950-NEXT:    v_bfe_u32 v11, v9, 0, v11
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v11
+; GFX950-NEXT:    v_bfe_u32 v10, v9, v6, 1
+; GFX950-NEXT:    v_lshlrev_b16_e32 v3, 8, v3
+; GFX950-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
+; GFX950-NEXT:    v_bitop3_b32 v10, v12, v11, v10 bitop3:0xe0
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
+; GFX950-NEXT:    v_lshrrev_b32_e32 v6, v6, v9
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e32 v10, 0, v10, vcc
+; GFX950-NEXT:    v_add_u32_e32 v6, v6, v10
+; GFX950-NEXT:    v_cmp_lt_i32_e32 vcc, 7, v6
+; GFX950-NEXT:    v_and_b32_e32 v10, 0x7ffff, v7
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e64 v6, v6, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e64 v9, 0, 8, vcc
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v10
+; GFX950-NEXT:    v_or_b32_e32 v6, v9, v6
+; GFX950-NEXT:    v_lshrrev_b32_e32 v9, 19, v7
+; GFX950-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
+; GFX950-NEXT:    v_bitop3_b32 v8, v9, v10, v8 bitop3:0xe0
+; GFX950-NEXT:    v_bfe_u32 v7, v7, 20, 3
+; GFX950-NEXT:    v_add_u32_e32 v7, v7, v8
+; GFX950-NEXT:    v_cmp_lt_i32_e32 vcc, 7, v7
+; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_cndmask_b32_e64 v7, v7, 0, vcc
+; GFX950-NEXT:    v_addc_co_u32_e32 v4, vcc, 14, v4, vcc
+; GFX950-NEXT:    v_lshl_or_b32 v7, v4, 3, v7
+; GFX950-NEXT:    v_cmp_gt_i32_e32 vcc, 1, v4
+; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_cndmask_b32_e32 v4, v7, v6, vcc
+; GFX950-NEXT:    v_cmp_neq_f32_e32 vcc, 0, v2
+; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GFX950-NEXT:    v_cmp_o_f32_e32 vcc, v2, v2
+; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, v5, v4, vcc
+; GFX950-NEXT:    v_bitop3_b16 v2, v2, v3, s0 bitop3:0xec
+; GFX950-NEXT:    v_lshlrev_b32_e32 v3, 16, v2
+; GFX950-NEXT:    v_lshl_or_b32 v1, v2, 16, v1
+; GFX950-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
+; GFX950-NEXT:    v_lshrrev_b32_e32 v3, 24, v3
+; GFX950-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1200-LABEL: to_e5m3fnu_v4f32:
+; GFX1200:       ; %bb.0:
+; GFX1200-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1200-NEXT:    s_wait_expcnt 0x0
+; GFX1200-NEXT:    s_wait_samplecnt 0x0
+; GFX1200-NEXT:    s_wait_bvhcnt 0x0
+; GFX1200-NEXT:    s_wait_kmcnt 0x0
+; GFX1200-NEXT:    v_frexp_exp_i32_f32_e32 v4, v1
+; GFX1200-NEXT:    v_frexp_mant_f32_e32 v5, v1
+; GFX1200-NEXT:    v_frexp_exp_i32_f32_e32 v6, v0
+; GFX1200-NEXT:    s_mov_b32 s1, 0x7fffff
+; GFX1200-NEXT:    v_frexp_mant_f32_e32 v7, v0
+; GFX1200-NEXT:    v_sub_nc_u32_e32 v8, 7, v4
+; GFX1200-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX1200-NEXT:    v_and_or_b32 v13, v5, s1, 0x800000
+; GFX1200-NEXT:    v_sub_nc_u32_e32 v11, 7, v6
+; GFX1200-NEXT:    v_and_b32_e32 v14, 0x7ffff, v5
+; GFX1200-NEXT:    v_and_or_b32 v17, v7, s1, 0x800000
+; GFX1200-NEXT:    v_min_u32_e32 v8, 31, v8
+; GFX1200-NEXT:    v_bfe_u32 v15, v5, 20, 3
+; GFX1200-NEXT:    v_min_u32_e32 v11, 31, v11
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v14
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v5, 19, v5
+; GFX1200-NEXT:    v_sub_nc_u32_e64 v16, v8, 1 clamp
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v22, v8, v13
+; GFX1200-NEXT:    v_sub_nc_u32_e64 v18, v11, 1 clamp
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc_lo
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v23, v11, v17
+; GFX1200-NEXT:    v_bfe_u32 v20, v13, 0, v16
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v13, v16, v13
+; GFX1200-NEXT:    v_bfe_u32 v21, v17, 0, v18
+; GFX1200-NEXT:    v_and_or_b32 v14, v15, 1, v14
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v17, v18, v17
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v20
+; GFX1200-NEXT:    v_frexp_exp_i32_f32_e32 v10, v3
+; GFX1200-NEXT:    v_frexp_mant_f32_e32 v9, v3
+; GFX1200-NEXT:    v_and_b32_e32 v5, v5, v14
+; GFX1200-NEXT:    v_frexp_exp_i32_f32_e32 v12, v2
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v20, 0, 1, vcc_lo
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v21
+; GFX1200-NEXT:    v_sub_nc_u32_e32 v14, 7, v10
+; GFX1200-NEXT:    v_add_nc_u32_e32 v5, v15, v5
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX1200-NEXT:    v_and_or_b32 v16, v22, 1, v20
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v21, 0, 1, vcc_lo
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v8
+; GFX1200-NEXT:    v_min_u32_e32 v14, 31, v14
+; GFX1200-NEXT:    v_and_or_b32 v20, v9, s1, 0x800000
+; GFX1200-NEXT:    v_and_b32_e32 v13, v13, v16
+; GFX1200-NEXT:    v_and_b32_e32 v19, 0x7ffff, v7
+; GFX1200-NEXT:    v_and_or_b32 v18, v23, 1, v21
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v8, 0, v13, vcc_lo
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v11
+; GFX1200-NEXT:    v_and_b32_e32 v16, v17, v18
+; GFX1200-NEXT:    v_sub_nc_u32_e32 v13, 7, v12
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v18, v14, v20
+; GFX1200-NEXT:    v_add_nc_u32_e32 v8, v22, v8
+; GFX1200-NEXT:    v_bfe_u32 v22, v9, 20, 3
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v11, 0, v16, vcc_lo
+; GFX1200-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 7, v5
+; GFX1200-NEXT:    v_sub_nc_u32_e64 v16, v14, 1 clamp
+; GFX1200-NEXT:    v_cmp_lt_i32_e64 s0, 7, v8
+; GFX1200-NEXT:    v_min_u32_e32 v13, 31, v13
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v5, v5, 0, vcc_lo
+; GFX1200-NEXT:    v_add_co_ci_u32_e64 v4, null, 14, v4, vcc_lo
+; GFX1200-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v8, v8, 0, s0
+; GFX1200-NEXT:    v_cndmask_b32_e64 v15, 0, 8, s0
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_lshl_or_b32 v5, v4, 3, v5
+; GFX1200-NEXT:    v_or_b32_e32 v8, v15, v8
+; GFX1200-NEXT:    v_add_nc_u32_e32 v11, v23, v11
+; GFX1200-NEXT:    v_bfe_u32 v15, v20, 0, v16
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v16, v16, v20
+; GFX1200-NEXT:    v_sub_nc_u32_e64 v20, v13, 1 clamp
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_4) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 7, v11
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v11, v11, 0, vcc_lo
+; GFX1200-NEXT:    v_cndmask_b32_e64 v17, 0, 8, vcc_lo
+; GFX1200-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 1, v4
+; GFX1200-NEXT:    v_or_b32_e32 v11, v17, v11
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v4, v5, v8, vcc_lo
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v15
+; GFX1200-NEXT:    v_frexp_mant_f32_e32 v15, v2
+; GFX1200-NEXT:    v_and_b32_e32 v21, 0x7ffff, v9
+; GFX1200-NEXT:    v_bfe_u32 v17, v7, 20, 3
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v7, 19, v7
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc_lo
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v19
+; GFX1200-NEXT:    v_and_or_b32 v19, v15, s1, 0x800000
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v9, 19, v9
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX1200-NEXT:    v_and_or_b32 v5, v18, 1, v5
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc_lo
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v21
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v23, v13, v19
+; GFX1200-NEXT:    v_and_b32_e32 v5, v16, v5
+; GFX1200-NEXT:    v_bfe_u32 v16, v19, 0, v20
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v21, 0, 1, vcc_lo
+; GFX1200-NEXT:    v_and_or_b32 v8, v17, 1, v8
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v19, v20, v19
+; GFX1200-NEXT:    v_bfe_u32 v20, v15, 20, 3
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v16
+; GFX1200-NEXT:    v_and_or_b32 v21, v22, 1, v21
+; GFX1200-NEXT:    v_and_b32_e32 v7, v7, v8
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v16, 0, 1, vcc_lo
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v14
+; GFX1200-NEXT:    v_and_b32_e32 v14, 0x7ffff, v15
+; GFX1200-NEXT:    v_and_b32_e32 v9, v9, v21
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v15, 19, v15
+; GFX1200-NEXT:    v_and_or_b32 v16, v23, 1, v16
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v5, 0, v5, vcc_lo
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v14
+; GFX1200-NEXT:    v_add_nc_u32_e32 v9, v22, v9
+; GFX1200-NEXT:    v_add_nc_u32_e32 v7, v17, v7
+; GFX1200-NEXT:    v_and_b32_e32 v8, v19, v16
+; GFX1200-NEXT:    v_add_nc_u32_e32 v5, v18, v5
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc_lo
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v13
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_3) | instid1(VALU_DEP_3)
+; GFX1200-NEXT:    v_and_or_b32 v14, v20, 1, v14
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v8, 0, v8, vcc_lo
+; GFX1200-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 7, v5
+; GFX1200-NEXT:    v_and_b32_e32 v13, v15, v14
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX1200-NEXT:    v_add_nc_u32_e32 v8, v23, v8
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v5, v5, 0, vcc_lo
+; GFX1200-NEXT:    v_cndmask_b32_e64 v14, 0, 8, vcc_lo
+; GFX1200-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 7, v9
+; GFX1200-NEXT:    v_add_nc_u32_e32 v13, v20, v13
+; GFX1200-NEXT:    v_cmp_lt_i32_e64 s0, 7, v8
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX1200-NEXT:    v_or_b32_e32 v5, v14, v5
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v9, v9, 0, vcc_lo
+; GFX1200-NEXT:    v_add_co_ci_u32_e64 v10, null, 14, v10, vcc_lo
+; GFX1200-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 7, v13
+; GFX1200-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v8, v8, 0, s0
+; GFX1200-NEXT:    v_cndmask_b32_e64 v15, 0, 8, s0
+; GFX1200-NEXT:    v_lshl_or_b32 v9, v10, 3, v9
+; GFX1200-NEXT:    v_cmp_gt_i32_e64 s0, 1, v10
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v13, v13, 0, vcc_lo
+; GFX1200-NEXT:    v_add_co_ci_u32_e64 v12, null, 14, v12, vcc_lo
+; GFX1200-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 7, v7
+; GFX1200-NEXT:    v_or_b32_e32 v8, v15, v8
+; GFX1200-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v5, v9, v5, s0
+; GFX1200-NEXT:    v_lshl_or_b32 v13, v12, 3, v13
+; GFX1200-NEXT:    v_cmp_gt_i32_e64 s0, 1, v12
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v7, v7, 0, vcc_lo
+; GFX1200-NEXT:    v_add_co_ci_u32_e64 v6, null, 14, v6, vcc_lo
+; GFX1200-NEXT:    v_cmp_neq_f32_e32 vcc_lo, 0, v3
+; GFX1200-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v8, v13, v8, s0
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX1200-NEXT:    v_lshl_or_b32 v7, v6, 3, v7
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v5, 0, v5, vcc_lo
+; GFX1200-NEXT:    v_cmp_neq_f32_e32 vcc_lo, 0, v2
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v8, 0, v8, vcc_lo
+; GFX1200-NEXT:    v_cmp_o_f32_e32 vcc_lo, v3, v3
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v3, 0xff, v5, vcc_lo
+; GFX1200-NEXT:    v_cmp_o_f32_e32 vcc_lo, v2, v2
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_3) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_lshlrev_b16 v2.l, 8, v3.l
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v5, 0xff, v8, vcc_lo
+; GFX1200-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 1, v6
+; GFX1200-NEXT:    v_and_b16 v2.h, 0xff, v5.l
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v6, v7, v11, vcc_lo
+; GFX1200-NEXT:    v_cmp_neq_f32_e32 vcc_lo, 0, v1
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX1200-NEXT:    v_or_b16 v2.h, v2.h, v2.l
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc_lo
+; GFX1200-NEXT:    v_cmp_neq_f32_e32 vcc_lo, 0, v0
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v3, 0, v6, vcc_lo
+; GFX1200-NEXT:    v_cmp_o_f32_e32 vcc_lo, v1, v1
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v1, 0xff, v4, vcc_lo
+; GFX1200-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v0
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_3) | instid1(VALU_DEP_3)
+; GFX1200-NEXT:    v_lshlrev_b16 v2.l, 8, v1.l
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v0, 0xff, v3, vcc_lo
+; GFX1200-NEXT:    v_mov_b16_e32 v3.l, v2.h
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v1, 8, v2
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX1200-NEXT:    v_and_b16 v0.l, 0xff, v0.l
+; GFX1200-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_or_b16 v0.l, v0.l, v2.l
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v3, 24, v3
+; GFX1200-NEXT:    v_mov_b16_e32 v2.l, v2.h
+; GFX1200-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1250-TRUE16-LABEL: to_e5m3fnu_v4f32:
+; GFX1250-TRUE16:       ; %bb.0:
+; GFX1250-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-TRUE16-NEXT:    v_cvt_pk_fp8_f32 v2.l, v2, v3 clamp
+; GFX1250-TRUE16-NEXT:    v_cvt_pk_fp8_f32 v0.l, v0, v1 clamp
+; GFX1250-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1250-TRUE16-NEXT:    v_lshlrev_b32_e32 v1, 16, v2
+; GFX1250-TRUE16-NEXT:    v_bfe_u32 v3, v2, 8, 8
+; GFX1250-TRUE16-NEXT:    v_and_or_b32 v1, 0xff00, v0, v1
+; GFX1250-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1250-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
+; GFX1250-TRUE16-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1250-FAKE16-LABEL: to_e5m3fnu_v4f32:
+; GFX1250-FAKE16:       ; %bb.0:
+; GFX1250-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-FAKE16-NEXT:    v_cvt_pk_fp8_f32 v2, v2, v3 clamp
+; GFX1250-FAKE16-NEXT:    v_cvt_pk_fp8_f32 v0, v0, v1 clamp
+; GFX1250-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1250-FAKE16-NEXT:    v_lshlrev_b32_e32 v1, 16, v2
+; GFX1250-FAKE16-NEXT:    v_bfe_u32 v3, v2, 8, 8
+; GFX1250-FAKE16-NEXT:    v_and_or_b32 v1, 0xff00, v0, v1
+; GFX1250-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1250-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
+; GFX1250-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-LABEL: to_e5m3fnu_v4f32:
+; GFX1310:       ; %bb.0:
+; GFX1310-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-NEXT:    s_wait_expcnt 0x0
+; GFX1310-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-NEXT:    v_frexp_exp_i32_f32_e32 v4, v1
+; GFX1310-NEXT:    v_frexp_mant_f32_e32 v5, v1
+; GFX1310-NEXT:    v_frexp_exp_i32_f32_e32 v6, v0
+; GFX1310-NEXT:    v_frexp_mant_f32_e32 v8, v0
+; GFX1310-NEXT:    v_frexp_exp_i32_f32_e32 v9, v3
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_2) | instid1(VALU_DEP_4)
+; GFX1310-NEXT:    v_dual_sub_nc_u32 v7, 7, v4 :: v_dual_lshrrev_b32 v12, 19, v5
+; GFX1310-NEXT:    v_and_b32_e32 v11, 0x7fffff, v5
+; GFX1310-NEXT:    v_and_b32_e32 v13, 0x7ffff, v5
+; GFX1310-NEXT:    v_dual_sub_nc_u32 v16, 7, v6 :: v_dual_sub_nc_u32 v18, 7, v9
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1310-NEXT:    v_min_u32_e32 v7, 31, v7
+; GFX1310-NEXT:    v_or_b32_e32 v14, 0x800000, v11
+; GFX1310-NEXT:    v_bfe_u32 v11, v11, 20, 1
+; GFX1310-NEXT:    v_bfe_u32 v5, v5, 20, 3
+; GFX1310-NEXT:    v_and_b32_e32 v17, 0x7fffff, v8
+; GFX1310-NEXT:    v_sub_nc_u32_e64 v15, v7, 1 clamp
+; GFX1310-NEXT:    v_min_u32_e32 v16, 31, v16
+; GFX1310-NEXT:    v_bfe_u32 v21, v14, v7, 1
+; GFX1310-NEXT:    v_frexp_mant_f32_e32 v10, v3
+; GFX1310-NEXT:    v_or_b32_e32 v22, 0x800000, v17
+; GFX1310-NEXT:    v_bfe_u32 v20, v14, 0, v15
+; GFX1310-NEXT:    v_min_u32_e32 v18, 31, v18
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX1310-NEXT:    v_and_b32_e32 v19, 0x7fffff, v10
+; GFX1310-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v20
+; GFX1310-NEXT:    v_cndmask_b32_e64 v20, 0, 1, vcc_lo
+; GFX1310-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v13
+; GFX1310-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc_lo
+; GFX1310-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v7
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_3)
+; GFX1310-NEXT:    v_bitop3_b32 v11, v12, v13, v11 bitop3:0xe0
+; GFX1310-NEXT:    v_lshrrev_b32_e32 v15, v15, v14
+; GFX1310-NEXT:    v_bfe_u32 v13, v22, v16, 1
+; GFX1310-NEXT:    v_add_nc_u32_e32 v5, v5, v11
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_bitop3_b32 v15, v15, v20, v21 bitop3:0xe0
+; GFX1310-NEXT:    v_sub_nc_u32_e64 v20, v16, 1 clamp
+; GFX1310-NEXT:    v_dual_cndmask_b32 v7, 0, v15 :: v_dual_lshrrev_b32 v14, v7, v14
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_4)
+; GFX1310-NEXT:    v_bfe_u32 v12, v22, 0, v20
+; GFX1310-NEXT:    v_lshrrev_b32_e32 v11, v20, v22
+; GFX1310-NEXT:    v_sub_nc_u32_e64 v15, v18, 1 clamp
+; GFX1310-NEXT:    v_add_nc_u32_e32 v7, v14, v7
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v12
+; GFX1310-NEXT:    v_cmp_lt_i32_e64 s0, 7, v7
+; GFX1310-NEXT:    v_cndmask_b32_e64 v12, 0, 1, vcc_lo
+; GFX1310-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 7, v5
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX1310-NEXT:    v_cndmask_b32_e64 v7, v7, 0, s0
+; GFX1310-NEXT:    v_bitop3_b32 v11, v11, v12, v13 bitop3:0xe0
+; GFX1310-NEXT:    v_cndmask_b32_e64 v5, v5, 0, vcc_lo
+; GFX1310-NEXT:    v_add_co_ci_u32_e64 v4, null, 14, v4, vcc_lo
+; GFX1310-NEXT:    v_cndmask_b32_e64 v12, 0, 8, s0
+; GFX1310-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v16
+; GFX1310-NEXT:    v_lshrrev_b32_e32 v14, v16, v22
+; GFX1310-NEXT:    v_or_b32_e32 v13, 0x800000, v19
+; GFX1310-NEXT:    v_lshl_or_b32 v5, v4, 3, v5
+; GFX1310-NEXT:    v_or_b32_e32 v7, v12, v7
+; GFX1310-NEXT:    v_cndmask_b32_e32 v11, 0, v11, vcc_lo
+; GFX1310-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 1, v4
+; GFX1310-NEXT:    v_cmp_neq_f32_e64 s0, 0, v1
+; GFX1310-NEXT:    v_bfe_u32 v12, v13, v18, 1
+; GFX1310-NEXT:    v_bfe_u32 v19, v19, 20, 1
+; GFX1310-NEXT:    v_dual_add_nc_u32 v11, v14, v11 :: v_dual_lshrrev_b32 v14, v15, v13
+; GFX1310-NEXT:    v_cndmask_b32_e32 v4, v5, v7, vcc_lo
+; GFX1310-NEXT:    v_bfe_u32 v5, v13, 0, v15
+; GFX1310-NEXT:    v_lshrrev_b32_e32 v13, v18, v13
+; GFX1310-NEXT:    v_frexp_mant_f32_e32 v15, v2
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX1310-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s0
+; GFX1310-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 7, v11
+; GFX1310-NEXT:    v_cndmask_b32_e64 v7, v11, 0, vcc_lo
+; GFX1310-NEXT:    v_cndmask_b32_e64 v11, 0, 8, vcc_lo
+; GFX1310-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v5
+; GFX1310-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc_lo
+; GFX1310-NEXT:    v_cmp_o_f32_e32 vcc_lo, v1, v1
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX1310-NEXT:    v_bitop3_b32 v5, v14, v5, v12 bitop3:0xe0
+; GFX1310-NEXT:    v_and_b32_e32 v12, 0x7ffff, v8
+; GFX1310-NEXT:    v_frexp_exp_i32_f32_e32 v14, v2
+; GFX1310-NEXT:    v_cndmask_b32_e32 v1, 0xff, v4, vcc_lo
+; GFX1310-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v18
+; GFX1310-NEXT:    v_or_b32_e32 v4, v11, v7
+; GFX1310-NEXT:    v_bfe_u32 v11, v17, 20, 1
+; GFX1310-NEXT:    v_and_b32_e32 v17, 0x7ffff, v10
+; GFX1310-NEXT:    v_dual_lshrrev_b32 v7, 19, v8 :: v_dual_cndmask_b32 v5, 0, v5, vcc_lo
+; GFX1310-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v12
+; GFX1310-NEXT:    v_sub_nc_u32_e32 v16, 7, v14
+; GFX1310-NEXT:    v_lshrrev_b32_e32 v18, 19, v10
+; GFX1310-NEXT:    v_bfe_u32 v10, v10, 20, 3
+; GFX1310-NEXT:    v_bfe_u32 v8, v8, 20, 3
+; GFX1310-NEXT:    v_cndmask_b32_e64 v12, 0, 1, vcc_lo
+; GFX1310-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v17
+; GFX1310-NEXT:    v_min_u32_e32 v16, 31, v16
+; GFX1310-NEXT:    v_lshlrev_b16 v1, 8, v1
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX1310-NEXT:    v_bitop3_b32 v7, v7, v12, v11 bitop3:0xe0
+; GFX1310-NEXT:    v_cndmask_b32_e64 v17, 0, 1, vcc_lo
+; GFX1310-NEXT:    v_sub_nc_u32_e64 v21, v16, 1 clamp
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_3)
+; GFX1310-NEXT:    v_bitop3_b32 v12, v18, v17, v19 bitop3:0xe0
+; GFX1310-NEXT:    v_add_nc_u32_e32 v5, v13, v5
+; GFX1310-NEXT:    v_and_b32_e32 v13, 0x7fffff, v15
+; GFX1310-NEXT:    v_add_nc_u32_e32 v10, v10, v12
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX1310-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 7, v5
+; GFX1310-NEXT:    v_or_b32_e32 v20, 0x800000, v13
+; GFX1310-NEXT:    v_lshrrev_b32_e32 v12, 19, v15
+; GFX1310-NEXT:    v_bfe_u32 v13, v13, 20, 1
+; GFX1310-NEXT:    v_cndmask_b32_e64 v5, v5, 0, vcc_lo
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX1310-NEXT:    v_bfe_u32 v11, v20, 0, v21
+; GFX1310-NEXT:    v_lshrrev_b32_e32 v18, v21, v20
+; GFX1310-NEXT:    v_and_b32_e32 v21, 0x7ffff, v15
+; GFX1310-NEXT:    v_bfe_u32 v17, v20, v16, 1
+; GFX1310-NEXT:    v_cndmask_b32_e64 v19, 0, 8, vcc_lo
+; GFX1310-NEXT:    v_cmp_ne_u32_e64 s0, 0, v11
+; GFX1310-NEXT:    v_add_nc_u32_e32 v7, v8, v7
+; GFX1310-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v21
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1310-NEXT:    v_or_b32_e32 v5, v19, v5
+; GFX1310-NEXT:    v_cndmask_b32_e64 v11, 0, 1, s0
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_3)
+; GFX1310-NEXT:    v_bitop3_b32 v11, v18, v11, v17 bitop3:0xe0
+; GFX1310-NEXT:    v_cndmask_b32_e64 v17, 0, 1, vcc_lo
+; GFX1310-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v16
+; GFX1310-NEXT:    v_lshrrev_b32_e32 v16, v16, v20
+; GFX1310-NEXT:    v_bitop3_b32 v12, v12, v17, v13 bitop3:0xe0
+; GFX1310-NEXT:    v_cndmask_b32_e32 v11, 0, v11, vcc_lo
+; GFX1310-NEXT:    v_bfe_u32 v13, v15, 20, 3
+; GFX1310-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 7, v10
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_3)
+; GFX1310-NEXT:    v_dual_add_nc_u32 v11, v16, v11 :: v_dual_add_nc_u32 v12, v13, v12
+; GFX1310-NEXT:    v_cndmask_b32_e64 v10, v10, 0, vcc_lo
+; GFX1310-NEXT:    v_add_co_ci_u32_e64 v9, null, 14, v9, vcc_lo
+; GFX1310-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 7, v11
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX1310-NEXT:    v_cmp_lt_i32_e64 s0, 7, v12
+; GFX1310-NEXT:    v_lshl_or_b32 v8, v9, 3, v10
+; GFX1310-NEXT:    v_cndmask_b32_e64 v10, v11, 0, vcc_lo
+; GFX1310-NEXT:    v_cndmask_b32_e64 v11, 0, 8, vcc_lo
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_3) | instid1(VALU_DEP_3)
+; GFX1310-NEXT:    v_cndmask_b32_e64 v12, v12, 0, s0
+; GFX1310-NEXT:    v_add_co_ci_u32_e64 v13, null, 14, v14, s0
+; GFX1310-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 7, v7
+; GFX1310-NEXT:    v_cmp_gt_i32_e64 s0, 1, v9
+; GFX1310-NEXT:    v_lshl_or_b32 v9, v13, 3, v12
+; GFX1310-NEXT:    v_cndmask_b32_e64 v7, v7, 0, vcc_lo
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_2) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_dual_cndmask_b32 v5, v8, v5, s0 :: v_dual_bitop2_b32 v8, v11, v10 bitop3:0x54
+; GFX1310-NEXT:    v_add_co_ci_u32_e64 v6, null, 14, v6, vcc_lo
+; GFX1310-NEXT:    v_cmp_neq_f32_e32 vcc_lo, 0, v3
+; GFX1310-NEXT:    v_lshl_or_b32 v7, v6, 3, v7
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_3) | instid1(VALU_DEP_4)
+; GFX1310-NEXT:    v_cndmask_b32_e32 v5, 0, v5, vcc_lo
+; GFX1310-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 1, v13
+; GFX1310-NEXT:    v_cndmask_b32_e32 v8, v9, v8, vcc_lo
+; GFX1310-NEXT:    v_cmp_o_f32_e32 vcc_lo, v3, v3
+; GFX1310-NEXT:    v_cndmask_b32_e32 v3, 0xff, v5, vcc_lo
+; GFX1310-NEXT:    v_cmp_neq_f32_e32 vcc_lo, 0, v2
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX1310-NEXT:    v_cndmask_b32_e32 v5, 0, v8, vcc_lo
+; GFX1310-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 1, v6
+; GFX1310-NEXT:    v_cndmask_b32_e32 v4, v7, v4, vcc_lo
+; GFX1310-NEXT:    v_cmp_o_f32_e32 vcc_lo, v2, v2
+; GFX1310-NEXT:    v_lshlrev_b16 v3, 8, v3
+; GFX1310-NEXT:    v_cndmask_b32_e32 v2, 0xff, v5, vcc_lo
+; GFX1310-NEXT:    v_cmp_neq_f32_e32 vcc_lo, 0, v0
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_3) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_bitop3_b16 v2, v2, v3, 0xff bitop3:0xec
+; GFX1310-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc_lo
+; GFX1310-NEXT:    v_and_b32_e32 v3, 0xffff, v1
+; GFX1310-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v0
+; GFX1310-NEXT:    v_lshl_or_b32 v3, v2, 16, v3
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_cndmask_b32_e32 v0, 0xff, v4, vcc_lo
+; GFX1310-NEXT:    v_lshlrev_b32_e32 v4, 16, v2
+; GFX1310-NEXT:    v_bitop3_b16 v0, v0, v1, 0xff bitop3:0xec
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX1310-NEXT:    v_dual_lshrrev_b32 v1, 8, v3 :: v_dual_lshrrev_b32 v3, 24, v4
+; GFX1310-NEXT:    s_set_pc_i64 s[30:31]
+  %r = call <4 x i8> @llvm.convert.to.arbitrary.fp.v4i8.v4f32(<4 x float> %x, metadata !"Float8E5M3FNU", metadata !"round.tonearest", i1 false)
+  ret <4 x i8> %r
+}
+
+define i8 @to_e5m3fnu_f32_sat(float %x) {
+; GFX950-LABEL: to_e5m3fnu_f32_sat:
+; GFX950:       ; %bb.0:
+; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX950-NEXT:    v_frexp_exp_i32_f32_e32 v1, v0
+; GFX950-NEXT:    v_sub_u32_e32 v2, 7, v1
+; GFX950-NEXT:    v_frexp_mant_f32_e32 v3, v0
+; GFX950-NEXT:    v_min_u32_e32 v2, 31, v2
+; GFX950-NEXT:    v_and_b32_e32 v4, 0x7fffff, v3
+; GFX950-NEXT:    v_or_b32_e32 v5, 0x800000, v4
+; GFX950-NEXT:    v_sub_u32_e64 v7, v2, 1 clamp
+; GFX950-NEXT:    v_lshrrev_b32_e32 v8, v7, v5
+; GFX950-NEXT:    v_bfe_u32 v7, v5, 0, v7
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v7
+; GFX950-NEXT:    v_bfe_u32 v6, v5, v2, 1
+; GFX950-NEXT:    v_bfe_u32 v4, v4, 20, 1
+; GFX950-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
+; GFX950-NEXT:    v_bitop3_b32 v6, v8, v7, v6 bitop3:0xe0
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
+; GFX950-NEXT:    v_lshrrev_b32_e32 v2, v2, v5
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e32 v6, 0, v6, vcc
+; GFX950-NEXT:    v_add_u32_e32 v2, v2, v6
+; GFX950-NEXT:    v_cmp_lt_i32_e32 vcc, 7, v2
+; GFX950-NEXT:    v_and_b32_e32 v6, 0x7ffff, v3
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e64 v5, 0, 8, vcc
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
+; GFX950-NEXT:    v_or_b32_e32 v2, v5, v2
+; GFX950-NEXT:    v_lshrrev_b32_e32 v5, 19, v3
+; GFX950-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
+; GFX950-NEXT:    v_bitop3_b32 v4, v5, v6, v4 bitop3:0xe0
+; GFX950-NEXT:    v_bfe_u32 v3, v3, 20, 3
+; GFX950-NEXT:    v_add_u32_e32 v3, v3, v4
+; GFX950-NEXT:    v_cmp_lt_i32_e32 vcc, 7, v3
+; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_cndmask_b32_e64 v3, v3, 0, vcc
+; GFX950-NEXT:    v_addc_co_u32_e32 v1, vcc, 14, v1, vcc
+; GFX950-NEXT:    v_lshl_or_b32 v4, v1, 3, v3
+; GFX950-NEXT:    v_cmp_gt_i32_e32 vcc, 1, v1
+; GFX950-NEXT:    v_cmp_eq_u32_e64 s[0:1], 31, v1
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
+; GFX950-NEXT:    v_cmp_lt_i32_e32 vcc, 6, v3
+; GFX950-NEXT:    s_and_b64 s[0:1], s[0:1], vcc
+; GFX950-NEXT:    v_cmp_lt_i32_e32 vcc, 31, v1
+; GFX950-NEXT:    v_mov_b32_e32 v1, 0xfe
+; GFX950-NEXT:    s_or_b64 vcc, vcc, s[0:1]
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, v2, v1, vcc
+; GFX950-NEXT:    v_cmp_neq_f32_e32 vcc, 0, v0
+; GFX950-NEXT:    s_mov_b32 s0, 0x7f800000
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
+; GFX950-NEXT:    v_cmp_neq_f32_e64 vcc, |v0|, s0
+; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v1, v2, vcc
+; GFX950-NEXT:    v_cmp_ngt_f32_e32 vcc, 0, v0
+; GFX950-NEXT:    v_mov_b32_e32 v2, 0xff
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc
+; GFX950-NEXT:    v_cmp_o_f32_e32 vcc, v0, v0
+; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
+; GFX950-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1200-LABEL: to_e5m3fnu_f32_sat:
+; GFX1200:       ; %bb.0:
+; GFX1200-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1200-NEXT:    s_wait_expcnt 0x0
+; GFX1200-NEXT:    s_wait_samplecnt 0x0
+; GFX1200-NEXT:    s_wait_bvhcnt 0x0
+; GFX1200-NEXT:    s_wait_kmcnt 0x0
+; GFX1200-NEXT:    v_frexp_exp_i32_f32_e32 v1, v0
+; GFX1200-NEXT:    v_frexp_mant_f32_e32 v3, v0
+; GFX1200-NEXT:    s_mov_b32 s0, 0x7fffff
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_sub_nc_u32_e32 v2, 7, v1
+; GFX1200-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX1200-NEXT:    v_and_or_b32 v4, v3, s0, 0x800000
+; GFX1200-NEXT:    v_and_b32_e32 v8, 0x7ffff, v3
+; GFX1200-NEXT:    v_bfe_u32 v9, v3, 20, 3
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v3, 19, v3
+; GFX1200-NEXT:    v_min_u32_e32 v2, 31, v2
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_sub_nc_u32_e64 v5, v2, 1 clamp
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v7, v2, v4
+; GFX1200-NEXT:    v_bfe_u32 v6, v4, 0, v5
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v4, v5, v4
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_3) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v6
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc_lo
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v8
+; GFX1200-NEXT:    v_and_or_b32 v5, v7, 1, v6
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc_lo
+; GFX1200-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v2
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX1200-NEXT:    v_and_b32_e32 v4, v4, v5
+; GFX1200-NEXT:    v_and_or_b32 v5, v9, 1, v6
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-NEXT:    v_dual_cndmask_b32 v2, 0, v4 :: v_dual_and_b32 v3, v3, v5
+; GFX1200-NEXT:    v_add_nc_u32_e32 v2, v7, v2
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_add_nc_u32_e32 v3, v9, v3
+; GFX1200-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 7, v2
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_3) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_cmp_lt_i32_e64 s0, 7, v3
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc_lo
+; GFX1200-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v3, v3, 0, s0
+; GFX1200-NEXT:    v_cndmask_b32_e64 v4, 0, 8, vcc_lo
+; GFX1200-NEXT:    v_add_co_ci_u32_e64 v1, null, 14, v1, s0
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX1200-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 6, v3
+; GFX1200-NEXT:    v_or_b32_e32 v2, v4, v2
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_4) | instid1(VALU_DEP_3)
+; GFX1200-NEXT:    v_lshl_or_b32 v4, v1, 3, v3
+; GFX1200-NEXT:    v_cmp_gt_i32_e64 s2, 1, v1
+; GFX1200-NEXT:    v_cmp_eq_u32_e64 s0, 31, v1
+; GFX1200-NEXT:    v_cmp_lt_i32_e64 s1, 31, v1
+; GFX1200-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v1, v4, v2, s2
+; GFX1200-NEXT:    s_and_b32 s0, s0, vcc_lo
+; GFX1200-NEXT:    v_cmp_neq_f32_e32 vcc_lo, 0, v0
+; GFX1200-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX1200-NEXT:    s_or_b32 s0, s1, s0
+; GFX1200-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v1, v1, 0xfe, s0
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc_lo
+; GFX1200-NEXT:    v_cmp_neq_f32_e64 vcc_lo, 0x7f800000, |v0|
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v1, 0xfe, v1, vcc_lo
+; GFX1200-NEXT:    v_cmp_ngt_f32_e32 vcc_lo, 0, v0
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc_lo
+; GFX1200-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v0
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v0, 0xff, v1, vcc_lo
+; GFX1200-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1250-TRUE16-LABEL: to_e5m3fnu_f32_sat:
+; GFX1250-TRUE16:       ; %bb.0:
+; GFX1250-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-TRUE16-NEXT:    v_cvt_pk_fp8_f32 v0.l, v0, v0 clamp
+; GFX1250-TRUE16-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1250-FAKE16-LABEL: to_e5m3fnu_f32_sat:
+; GFX1250-FAKE16:       ; %bb.0:
+; GFX1250-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-FAKE16-NEXT:    v_cvt_pk_fp8_f32 v0, v0, v0 clamp
+; GFX1250-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-LABEL: to_e5m3fnu_f32_sat:
+; GFX1310:       ; %bb.0:
+; GFX1310-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-NEXT:    s_wait_expcnt 0x0
+; GFX1310-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-NEXT:    v_frexp_exp_i32_f32_e32 v1, v0
+; GFX1310-NEXT:    v_frexp_mant_f32_e32 v2, v0
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_4)
+; GFX1310-NEXT:    v_dual_sub_nc_u32 v3, 7, v1 :: v_dual_lshrrev_b32 v10, 19, v2
+; GFX1310-NEXT:    v_and_b32_e32 v4, 0x7fffff, v2
+; GFX1310-NEXT:    v_and_b32_e32 v9, 0x7ffff, v2
+; GFX1310-NEXT:    v_bfe_u32 v2, v2, 20, 3
+; GFX1310-NEXT:    v_min_u32_e32 v3, 31, v3
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX1310-NEXT:    v_or_b32_e32 v5, 0x800000, v4
+; GFX1310-NEXT:    v_bfe_u32 v4, v4, 20, 1
+; GFX1310-NEXT:    v_sub_nc_u32_e64 v6, v3, 1 clamp
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_bfe_u32 v8, v5, v3, 1
+; GFX1310-NEXT:    v_bfe_u32 v7, v5, 0, v6
+; GFX1310-NEXT:    v_dual_lshrrev_b32 v6, v6, v5 :: v_dual_lshrrev_b32 v5, v3, v5
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v7
+; GFX1310-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc_lo
+; GFX1310-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v9
+; GFX1310-NEXT:    v_bitop3_b32 v6, v6, v7, v8 bitop3:0xe0
+; GFX1310-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc_lo
+; GFX1310-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v3
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1310-NEXT:    v_bitop3_b32 v4, v10, v7, v4 bitop3:0xe0
+; GFX1310-NEXT:    v_dual_cndmask_b32 v3, 0, v6 :: v_dual_add_nc_u32 v2, v2, v4
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_add_nc_u32_e32 v3, v5, v3
+; GFX1310-NEXT:    v_cmp_lt_i32_e64 s0, 7, v2
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 7, v3
+; GFX1310-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s0
+; GFX1310-NEXT:    v_cndmask_b32_e64 v3, v3, 0, vcc_lo
+; GFX1310-NEXT:    v_cndmask_b32_e64 v4, 0, 8, vcc_lo
+; GFX1310-NEXT:    v_add_co_ci_u32_e64 v1, null, 14, v1, s0
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX1310-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 6, v2
+; GFX1310-NEXT:    v_or_b32_e32 v3, v4, v3
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_3) | instid1(VALU_DEP_3)
+; GFX1310-NEXT:    v_lshl_or_b32 v4, v1, 3, v2
+; GFX1310-NEXT:    v_cmp_gt_i32_e64 s2, 1, v1
+; GFX1310-NEXT:    v_cmp_eq_u32_e64 s0, 31, v1
+; GFX1310-NEXT:    v_cmp_lt_i32_e64 s1, 31, v1
+; GFX1310-NEXT:    v_cndmask_b32_e64 v1, v4, v3, s2
+; GFX1310-NEXT:    s_and_b32 s0, s0, vcc_lo
+; GFX1310-NEXT:    v_cmp_neq_f32_e32 vcc_lo, 0, v0
+; GFX1310-NEXT:    s_or_b32 s0, s1, s0
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instid1(SALU_CYCLE_1)
+; GFX1310-NEXT:    v_cndmask_b32_e64 v1, v1, 0xfe, s0
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc_lo
+; GFX1310-NEXT:    v_cmp_neq_f32_e64 vcc_lo, 0x7f800000, |v0|
+; GFX1310-NEXT:    v_cndmask_b32_e32 v1, 0xfe, v1, vcc_lo
+; GFX1310-NEXT:    v_cmp_ngt_f32_e32 vcc_lo, 0, v0
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc_lo
+; GFX1310-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v0
+; GFX1310-NEXT:    v_cndmask_b32_e32 v0, 0xff, v1, vcc_lo
+; GFX1310-NEXT:    s_set_pc_i64 s[30:31]
+  %r = call i8 @llvm.convert.to.arbitrary.fp.i8.f32(float %x, metadata !"Float8E5M3FNU", metadata !"round.tonearest", i1 true)
+  ret i8 %r
+}
+
+define i8 @to_e5m3fnu_f32_rtz(float %x) {
+; GFX950-LABEL: to_e5m3fnu_f32_rtz:
+; GFX950:       ; %bb.0:
+; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX950-NEXT:    v_frexp_mant_f32_e32 v1, v0
+; GFX950-NEXT:    v_frexp_exp_i32_f32_e32 v3, v0
+; GFX950-NEXT:    v_and_b32_e32 v2, 0x7fffff, v1
+; GFX950-NEXT:    v_sub_u32_e32 v4, 7, v3
+; GFX950-NEXT:    v_or_b32_e32 v2, 0x800000, v2
+; GFX950-NEXT:    v_min_u32_e32 v4, 31, v4
+; GFX950-NEXT:    v_lshrrev_b32_e32 v2, v4, v2
+; GFX950-NEXT:    v_cmp_lt_i32_e32 vcc, 7, v2
+; GFX950-NEXT:    v_bfe_u32 v1, v1, 20, 3
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e64 v4, 0, 8, vcc
+; GFX950-NEXT:    v_cmp_lt_i32_e32 vcc, 7, v1
+; GFX950-NEXT:    v_or_b32_e32 v2, v4, v2
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e64 v1, v1, 0, vcc
+; GFX950-NEXT:    v_addc_co_u32_e32 v3, vcc, 14, v3, vcc
+; GFX950-NEXT:    v_lshl_or_b32 v1, v3, 3, v1
+; GFX950-NEXT:    v_cmp_gt_i32_e32 vcc, 1, v3
+; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v1, v2, vcc
+; GFX950-NEXT:    v_cmp_neq_f32_e32 vcc, 0, v0
+; GFX950-NEXT:    v_mov_b32_e32 v2, 0xff
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc
+; GFX950-NEXT:    v_cmp_o_f32_e32 vcc, v0, v0
+; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
+; GFX950-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1200-LABEL: to_e5m3fnu_f32_rtz:
+; GFX1200:       ; %bb.0:
+; GFX1200-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1200-NEXT:    s_wait_expcnt 0x0
+; GFX1200-NEXT:    s_wait_samplecnt 0x0
+; GFX1200-NEXT:    s_wait_bvhcnt 0x0
+; GFX1200-NEXT:    s_wait_kmcnt 0x0
+; GFX1200-NEXT:    v_frexp_exp_i32_f32_e32 v1, v0
+; GFX1200-NEXT:    v_frexp_mant_f32_e32 v2, v0
+; GFX1200-NEXT:    s_mov_b32 s0, 0x7fffff
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_sub_nc_u32_e32 v3, 7, v1
+; GFX1200-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX1200-NEXT:    v_and_or_b32 v4, v2, s0, 0x800000
+; GFX1200-NEXT:    v_bfe_u32 v2, v2, 20, 3
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_min_u32_e32 v3, 31, v3
+; GFX1200-NEXT:    v_cmp_lt_i32_e64 s0, 7, v2
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_lshrrev_b32_e32 v3, v3, v4
+; GFX1200-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s0
+; GFX1200-NEXT:    v_add_co_ci_u32_e64 v1, null, 14, v1, s0
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 7, v3
+; GFX1200-NEXT:    v_lshl_or_b32 v2, v1, 3, v2
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e64 v3, v3, 0, vcc_lo
+; GFX1200-NEXT:    v_cndmask_b32_e64 v4, 0, 8, vcc_lo
+; GFX1200-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 1, v1
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1200-NEXT:    v_or_b32_e32 v3, v4, v3
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v1, v2, v3, vcc_lo
+; GFX1200-NEXT:    v_cmp_neq_f32_e32 vcc_lo, 0, v0
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_2)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc_lo
+; GFX1200-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v0
+; GFX1200-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-NEXT:    v_cndmask_b32_e32 v0, 0xff, v1, vcc_lo
+; GFX1200-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1250-LABEL: to_e5m3fnu_f32_rtz:
+; GFX1250:       ; %bb.0:
+; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-NEXT:    v_frexp_exp_i32_f32_e32 v1, v0
+; GFX1250-NEXT:    v_frexp_mant_f32_e32 v2, v0
+; GFX1250-NEXT:    s_mov_b32 s0, 0x7fffff
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1250-NEXT:    v_sub_nc_u32_e32 v3, 7, v1
+; GFX1250-NEXT:    v_and_or_b32 v4, v2, s0, 0x800000
+; GFX1250-NEXT:    v_bfe_u32 v2, v2, 20, 3
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1250-NEXT:    v_min_u32_e32 v3, 31, v3
+; GFX1250-NEXT:    v_cmp_lt_i32_e64 s0, 7, v2
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1250-NEXT:    v_lshrrev_b32_e32 v3, v3, v4
+; GFX1250-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s0
+; GFX1250-NEXT:    v_add_co_ci_u32_e64 v1, null, 14, v1, s0
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1250-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 7, v3
+; GFX1250-NEXT:    v_lshl_or_b32 v2, v1, 3, v2
+; GFX1250-NEXT:    v_cndmask_b32_e64 v3, v3, 0, vcc_lo
+; GFX1250-NEXT:    v_cndmask_b32_e64 v4, 0, 8, vcc_lo
+; GFX1250-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 1, v1
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1250-NEXT:    v_or_b32_e32 v3, v4, v3
+; GFX1250-NEXT:    v_cndmask_b32_e32 v1, v2, v3, vcc_lo
+; GFX1250-NEXT:    v_cmp_neq_f32_e32 vcc_lo, 0, v0
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1250-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc_lo
+; GFX1250-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v0
+; GFX1250-NEXT:    v_cndmask_b32_e32 v0, 0xff, v1, vcc_lo
+; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-LABEL: to_e5m3fnu_f32_rtz:
+; GFX1310:       ; %bb.0:
+; GFX1310-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-NEXT:    s_wait_expcnt 0x0
+; GFX1310-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-NEXT:    v_frexp_exp_i32_f32_e32 v1, v0
+; GFX1310-NEXT:    v_frexp_mant_f32_e32 v2, v0
+; GFX1310-NEXT:    s_mov_b32 s0, 0x7fffff
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_sub_nc_u32_e32 v3, 7, v1
+; GFX1310-NEXT:    v_and_or_b32 v4, v2, s0, 0x800000
+; GFX1310-NEXT:    v_bfe_u32 v2, v2, 20, 3
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_min_u32_e32 v3, 31, v3
+; GFX1310-NEXT:    v_cmp_lt_i32_e64 s0, 7, v2
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_lshrrev_b32_e32 v3, v3, v4
+; GFX1310-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s0
+; GFX1310-NEXT:    v_add_co_ci_u32_e64 v1, null, 14, v1, s0
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_cmp_lt_i32_e32 vcc_lo, 7, v3
+; GFX1310-NEXT:    v_lshl_or_b32 v2, v1, 3, v2
+; GFX1310-NEXT:    v_cndmask_b32_e64 v3, v3, 0, vcc_lo
+; GFX1310-NEXT:    v_cndmask_b32_e64 v4, 0, 8, vcc_lo
+; GFX1310-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 1, v1
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1310-NEXT:    v_or_b32_e32 v3, v4, v3
+; GFX1310-NEXT:    v_cndmask_b32_e32 v1, v2, v3, vcc_lo
+; GFX1310-NEXT:    v_cmp_neq_f32_e32 vcc_lo, 0, v0
+; GFX1310-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1310-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc_lo
+; GFX1310-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v0
+; GFX1310-NEXT:    v_cndmask_b32_e32 v0, 0xff, v1, vcc_lo
+; GFX1310-NEXT:    s_set_pc_i64 s[30:31]
+  %r = call i8 @llvm.convert.to.arbitrary.fp.i8.f32(float %x, metadata !"Float8E5M3FNU", metadata !"round.towardzero", i1 false)
   ret i8 %r
 }


### PR DESCRIPTION
Some packed convert instructions support producing FP8 floating output in the E5M3 format by control through the CLAMP bit. Currently, we have builtins and intrinsics that support that lowering.

This PR adds lowering through the newly added `convert.{to|from}.arbitrary.fp` intrinsics.