### PR TITLE
[M68k] Fix build after InstructionSelect rename

### DIFF
--- a/llvm/lib/Target/M68k/M68kTargetMachine.cpp
+++ b/llvm/lib/Target/M68k/M68kTargetMachine.cpp
@@ -159,7 +159,7 @@ bool M68kPassConfig::addRegBankSelect() {
 }
 
 bool M68kPassConfig::addGlobalInstructionSelect() {
-  addPass(new InstructionSelect(getOptLevel()));
+  addPass(new InstructionSelectLegacy(getOptLevel()));
   return false;
 }
 


### PR DESCRIPTION
Done in 8f543c25c44eb175b583bceaa9230dd981cdd463.

Fixes https://lab.llvm.org/buildbot/#/builders/27/builds/3952.