### PR TITLE
[bazel] Link emutls to interpreter

### DIFF
--- a/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
@@ -1957,6 +1957,7 @@ cc_library(
         ":parse",
         ":sema",
         ":serialization",
+        "//compiler-rt:emutls",
         "//llvm:AllTargetsAsmParsers",
         "//llvm:AllTargetsCodeGens",
         "//llvm:Core",

--- a/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
@@ -165,6 +165,15 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "emutls",
+    srcs = [
+        "lib/builtins/emutls.c",
+    ],
+    hdrs = glob(["lib/builtins/*.h"]),
+    linkstatic = True,
+)
+
 filegroup(
     name = "fuzzer_installed_hdrs",
     srcs = glob(["include/fuzzer/*.h"]),


### PR DESCRIPTION
This is needed to fix #209717. https://github.com/llvm/llvm-project/pull/217700 tries to fix it cleanly but it's blocked on review. Get this in while we wait for review.