### PR TITLE
[InstSimplify] Fold comparisons of unsigned half and complement

### DIFF
--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -3386,6 +3386,20 @@ static bool trySimplifyICmpWithAdds(CmpPredicate Pred, Value *LHS, Value *RHS,
          (C2->sle(*C1) && C1->isNonPositive());
 }
 
+/// Match a quotient Q that is at most half of X and its complement X - Q.
+static bool matchHalfOrLessAndComplement(Value *Q, Value *Complement,
+                                         const SimplifyQuery &SQ) {
+  Value *X;
+  const APInt *C;
+  bool IsHalfOrLess =
+      (match(Q, m_UDiv(m_Value(X), m_APInt(C))) && C->uge(2)) ||
+      (match(Q, m_LShr(m_Value(X), m_APInt(C))) && !C->isZero());
+  // Undef may take different values in the quotient and subtraction.
+  return IsHalfOrLess &&
+         match(Complement, m_Sub(m_Specific(X), m_Specific(Q))) &&
+         isGuaranteedNotToBeUndef(X, SQ.AC, SQ.CxtI, SQ.DT);
+}
+
 /// TODO: A large part of this logic is duplicated in InstCombine's
 /// foldICmpBinOp(). We should be able to share that and avoid the code
 /// duplication.
@@ -3524,6 +3538,14 @@ static Value *simplifyICmpWithBinOp(CmpPredicate Pred, Value *LHS, Value *RHS,
     if (Pred == ICmpInst::ICMP_ULE)
       return ConstantInt::getTrue(getCompareTy(RHS));
   }
+
+  // If Q is at most X / 2, then Q <= X - Q.
+  if ((Pred == ICmpInst::ICMP_ULE || Pred == ICmpInst::ICMP_UGT) &&
+      matchHalfOrLessAndComplement(LHS, RHS, Q))
+    return ConstantInt::get(getCompareTy(LHS), Pred == ICmpInst::ICMP_ULE);
+  if ((Pred == ICmpInst::ICMP_UGE || Pred == ICmpInst::ICMP_ULT) &&
+      matchHalfOrLessAndComplement(RHS, LHS, Q))
+    return ConstantInt::get(getCompareTy(LHS), Pred == ICmpInst::ICMP_UGE);
 
   if (!MaxRecurse || !LBO || !RBO || LBO->getOpcode() != RBO->getOpcode())
     return nullptr;

--- a/llvm/test/Transforms/InstSimplify/compare.ll
+++ b/llvm/test/Transforms/InstSimplify/compare.ll
@@ -1159,6 +1159,103 @@ define i1 @udiv8(i32 %X, i32 %Y) {
   ret i1 %C
 }
 
+; https://github.com/llvm/llvm-project/issues/91527
+
+define i1 @udiv_le_complement(i32 noundef %x) {
+; CHECK-LABEL: @udiv_le_complement(
+; CHECK-NEXT:    ret i1 true
+;
+  %q = udiv i32 %x, 2
+  %complement = sub i32 %x, %q
+  %cmp = icmp ule i32 %q, %complement
+  ret i1 %cmp
+}
+
+define i1 @udiv_gt_complement(i32 noundef %x) {
+; CHECK-LABEL: @udiv_gt_complement(
+; CHECK-NEXT:    ret i1 false
+;
+  %q = udiv i32 %x, 3
+  %complement = sub i32 %x, %q
+  %cmp = icmp ugt i32 %q, %complement
+  ret i1 %cmp
+}
+
+define i1 @udiv_complement_ge(i32 noundef %x) {
+; CHECK-LABEL: @udiv_complement_ge(
+; CHECK-NEXT:    ret i1 true
+;
+  %q = udiv i32 %x, 200
+  %complement = sub i32 %x, %q
+  %cmp = icmp uge i32 %complement, %q
+  ret i1 %cmp
+}
+
+define i1 @udiv_complement_lt(i32 noundef %x) {
+; CHECK-LABEL: @udiv_complement_lt(
+; CHECK-NEXT:    ret i1 false
+;
+  %q = udiv i32 %x, 200
+  %complement = sub i32 %x, %q
+  %cmp = icmp ult i32 %complement, %q
+  ret i1 %cmp
+}
+
+define i1 @lshr_gt_complement(i64 noundef %x) {
+; CHECK-LABEL: @lshr_gt_complement(
+; CHECK-NEXT:    ret i1 false
+;
+  %q = lshr i64 %x, 1
+  %complement = sub i64 %x, %q
+  %cmp = icmp ugt i64 %q, %complement
+  ret i1 %cmp
+}
+
+define <2 x i1> @udiv_le_complement_vec(<2 x i8> noundef %x) {
+; CHECK-LABEL: @udiv_le_complement_vec(
+; CHECK-NEXT:    ret <2 x i1> splat (i1 true)
+;
+  %q = udiv <2 x i8> %x, splat (i8 2)
+  %complement = sub <2 x i8> %x, %q
+  %cmp = icmp ule <2 x i8> %q, %complement
+  ret <2 x i1> %cmp
+}
+
+define i1 @udiv_le_complement_may_be_undef(i32 %x) {
+; CHECK-LABEL: @udiv_le_complement_may_be_undef(
+; CHECK-NEXT:    [[Q:%.*]] = udiv i32 [[X:%.*]], 2
+; CHECK-NEXT:    [[COMPLEMENT:%.*]] = sub i32 [[X]], [[Q]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ule i32 [[Q]], [[COMPLEMENT]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %q = udiv i32 %x, 2
+  %complement = sub i32 %x, %q
+  %cmp = icmp ule i32 %q, %complement
+  ret i1 %cmp
+}
+
+define i1 @udiv_le_complement_divisor_one(i32 noundef %x) {
+; CHECK-LABEL: @udiv_le_complement_divisor_one(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ule i32 [[X:%.*]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %q = udiv i32 %x, 1
+  %complement = sub i32 %x, %q
+  %cmp = icmp ule i32 %q, %complement
+  ret i1 %cmp
+}
+
+define i1 @lshr_le_complement_shift_zero(i32 noundef %x) {
+; CHECK-LABEL: @lshr_le_complement_shift_zero(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ule i32 [[X:%.*]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %q = lshr i32 %x, 0
+  %complement = sub i32 %x, %q
+  %cmp = icmp ule i32 %q, %complement
+  ret i1 %cmp
+}
+
 define i1 @udiv_nonzero_eq(i32 %x) {
 ; CHECK-LABEL: @udiv_nonzero_eq(
 ; CHECK-NEXT:    [[X_NE_0:%.*]] = icmp ne i32 [[X:%.*]], 0


### PR DESCRIPTION
Recognize Q <= X - Q when Q is X / C for C >= 2 or X >> K for K > 0, including inverse and swapped predicates. Require X to be non-undef so its uses remain correlated.

This removes the bounds check from the slice-halving pattern in #91527.

This pr was assisted by a LLM.