### PR TITLE
[KnownFPClass] Move float-to-integer bitcast handling into KnownFPClass [NFC]

### DIFF
--- a/llvm/include/llvm/Support/KnownFPClass.h
+++ b/llvm/include/llvm/Support/KnownFPClass.h
@@ -241,6 +241,9 @@ struct KnownFPClass {
   LLVM_ABI static KnownFPClass bitcast(const fltSemantics &FltSemantics,
                                        const KnownBits &Bits);
 
+  /// Report known bits for a float with provided semantics.
+  LLVM_ABI KnownBits toKnownBits(const fltSemantics &FltSemantics) const;
+
   /// Report known values for fadd
   LLVM_ABI static KnownFPClass
   fadd(const KnownFPClass &LHS, const KnownFPClass &RHS,

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -12,7 +12,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Analysis/ValueTracking.h"
-#include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FloatingPointMode.h"
@@ -1529,33 +1528,8 @@ static void computeKnownBitsFromOperator(const Operator *I,
       Type *FPType = V->getType()->getScalarType();
       KnownFPClass Result =
           computeKnownFPClass(V, DemandedElts, fcAllFlags, Q, Depth + 1);
-      FPClassTest FPClasses = Result.KnownFPClasses;
 
-      // TODO: Treat it as zero/poison if the use of I is unreachable.
-      if (FPClasses == fcNone)
-        break;
-
-      if (Result.isKnownNever(fcNormal | fcSubnormal | fcNan)) {
-        Known.setAllConflict();
-
-        if (FPClasses & fcInf)
-          Known = Known.intersectWith(KnownBits::makeConstant(
-              APFloat::getInf(FPType->getFltSemantics()).bitcastToAPInt()));
-
-        if (FPClasses & fcZero)
-          Known = Known.intersectWith(KnownBits::makeConstant(
-              APInt::getZero(FPType->getScalarSizeInBits())));
-
-        Known.Zero.clearSignBit();
-        Known.One.clearSignBit();
-      }
-
-      if (Result.SignBit) {
-        if (*Result.SignBit)
-          Known.makeNegative();
-        else
-          Known.makeNonNegative();
-      }
+      Known = Result.toKnownBits(FPType->getFltSemantics());
 
       break;
     }

--- a/llvm/lib/Support/KnownFPClass.cpp
+++ b/llvm/lib/Support/KnownFPClass.cpp
@@ -282,6 +282,39 @@ KnownFPClass KnownFPClass::bitcast(const fltSemantics &FltSemantics,
   return Known;
 }
 
+KnownBits KnownFPClass::toKnownBits(const fltSemantics &FltSemantics) const {
+  KnownBits Known(FltSemantics.sizeInBits);
+  const FPClassTest FPClasses = KnownFPClasses;
+
+  // Return unknown if poison.
+  if (FPClasses == fcNone)
+    return Known;
+
+  if (isKnownNever(fcNormal | fcSubnormal | fcNan)) {
+    Known.setAllConflict();
+
+    if (FPClasses & fcInf)
+      Known = Known.intersectWith(KnownBits::makeConstant(
+          APFloat::getInf(FltSemantics).bitcastToAPInt()));
+
+    if (FPClasses & fcZero)
+      Known = Known.intersectWith(
+          KnownBits::makeConstant(APInt::getZero(FltSemantics.sizeInBits)));
+
+    Known.Zero.clearSignBit();
+    Known.One.clearSignBit();
+  }
+
+  if (SignBit) {
+    if (*SignBit)
+      Known.makeNegative();
+    else
+      Known.makeNonNegative();
+  }
+
+  return Known;
+}
+
 // Handle known sign bit and nan cases for fadd.
 static KnownFPClass fadd_impl(const KnownFPClass &KnownLHS,
                               const KnownFPClass &KnownRHS, DenormalMode Mode) {


### PR DESCRIPTION
I moved the float-to-integer bitcast code into a new `KnownBits bitcastToKnownBits(const fltSemantics &FltSemantics) const;` function. This allows the code to be unit testable, and allows the code to be reused elsewhere.

I also have future plans to work on the `KnownBits` deductions for the float-to-integer bitcast.

AI Disclosure:
I used ChatGPT Codex (sol-5.6) to help move the code which I reviewed.
