### PR TITLE
Revert "[SSAF] Fix a stage2 test failure with ASan-instrumented clang - continued"

### DIFF
--- a/clang/test/Analysis/Scalable/source-edit-generation/Plugins/TestTransformationPlugin/CMakeLists.txt
+++ b/clang/test/Analysis/Scalable/source-edit-generation/Plugins/TestTransformationPlugin/CMakeLists.txt
@@ -14,13 +14,3 @@ target_include_directories(SSAFTestTransformationPlugin PRIVATE
   $<TARGET_PROPERTY:clangScalableStaticAnalysisCore,INTERFACE_INCLUDE_DIRECTORIES>
   $<TARGET_PROPERTY:clangScalableStaticAnalysisSourceTransformation,INTERFACE_INCLUDE_DIRECTORIES>
   )
-
-# The plugin is loaded into a clang that may be built with sanitizers (e.g. the
-# stage-2 -DLLVM_USE_SANITIZER=Address bots), but does not need instrumenting
-# itself. With ASan, -Wl,-dead_strip drops anonymous constants that ASan's
-# metadata still references, leaving dangling flat-namespace binds that break
-# dlopen ("symbol not found in flat namespace 'l___unnamed_NNNN'"). Opt out.
-if(LLVM_USE_SANITIZER)
-  target_compile_options(SSAFTestTransformationPlugin PRIVATE -fno-sanitize=all)
-  target_link_options(SSAFTestTransformationPlugin PRIVATE -fno-sanitize=all)
-endif()

--- a/clang/test/Analysis/Scalable/source-edit-generation/Plugins/TestTransformationPlugin/TestTransformation.cpp
+++ b/clang/test/Analysis/Scalable/source-edit-generation/Plugins/TestTransformationPlugin/TestTransformation.cpp
@@ -94,7 +94,10 @@ namespace clang::ssaf {
 volatile int SSAFTestTransformationAnchorSource = 0;
 } // namespace clang::ssaf
 
+// This global causes issue in stage2 with ASan-instrumented clang so
+// adding the no-ASan attribute.
 static TransformationRegistry::Add<TestTransformation>
+    __attribute__((no_sanitize("address")))
     RegisterTestTransformation("test-transformation",
                                "Test transformation for the SSAF "
                                "source-edit-generation lit suite");


### PR DESCRIPTION
Reverts llvm/llvm-project#217799 because it breaks other ASan buildbots (e.g., https://lab.llvm.org/buildbot/#/builders/169/builds/25867):
```
[1692/5724] Building CXX object tools/clang/test/Analysis/Scalable/source-edit-generation/Plugins/TestTransformationPlugin/CMakeFiles/SSAFTestTransformationPlugin.dir/TestTransformation.cpp.o
FAILED: [code=1] tools/clang/test/Analysis/Scalable/source-edit-generation/Plugins/TestTransformationPlugin/CMakeFiles/SSAFTestTransformationPlugin.dir/TestTransformation.cpp.o 
CCACHE_CPP2=yes CCACHE_HASHDIR=yes CCACHE_SLOPPINESS=pch_defines,time_macros /usr/bin/ccache /home/b/sanitizer-x86_64-linux-fast/build/llvm_build0/bin/clang++ -D_DEBUG -D_GLIBCXX_ASSERTIONS -D_GNU_SOURCE -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/home/b/sanitizer-x86_64-linux-fast/build/llvm_build_asan_ubsan/tools/clang/test/Analysis/Scalable/source-edit-generation/Plugins/TestTransformationPlugin -I/home/b/sanitizer-x86_64-linux-fast/build/llvm-project/clang/test/Analysis/Scalable/source-edit-generation/Plugins/TestTransformationPlugin -I/home/b/sanitizer-x86_64-linux-fast/build/llvm-project/clang/include -I/home/b/sanitizer-x86_64-linux-fast/build/llvm_build_asan_ubsan/tools/clang/include -I/home/b/sanitizer-x86_64-linux-fast/build/llvm_build_asan_ubsan/include -I/home/b/sanitizer-x86_64-linux-fast/build/llvm-project/llvm/include -nostdinc++ -isystem /home/b/sanitizer-x86_64-linux-fast/build/libcxx_install_asan_ubsan/include -isystem /home/b/sanitizer-x86_64-linux-fast/build/libcxx_install_asan_ubsan/include/c++/v1 -fsanitize=address,undefined -fno-sanitize-recover=all -Wl,--rpath=/home/b/sanitizer-x86_64-linux-fast/build/libcxx_install_asan_ubsan/lib -L/home/b/sanitizer-x86_64-linux-fast/build/libcxx_install_asan_ubsan/lib -lc++abi -fuse-ld=lld -w -stdlib=libc++ -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wc++98-compat-extra-semi -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wno-pass-failed -Wmisleading-indentation -Wctad-maybe-unsupported -fno-omit-frame-pointer -gline-tables-only -fsanitize=address -fsanitize=undefined -fno-sanitize=vptr,function -fno-sanitize-recover=all -fsanitize-blacklist=/home/b/sanitizer-x86_64-linux-fast/build/llvm-project/llvm/utils/sanitizers/ubsan_ignorelist.txt -fdiagnostics-color -ffunction-sections -fdata-sections -fno-common -Woverloaded-virtual -Wno-nested-anon-types -O3 -DNDEBUG -std=c++17 -fPIC -UNDEBUG -fno-exceptions -funwind-tables -fno-rtti -fno-sanitize=all -MD -MT tools/clang/test/Analysis/Scalable/source-edit-generation/Plugins/TestTransformationPlugin/CMakeFiles/SSAFTestTransformationPlugin.dir/TestTransformation.cpp.o -MF tools/clang/test/Analysis/Scalable/source-edit-generation/Plugins/TestTransformationPlugin/CMakeFiles/SSAFTestTransformationPlugin.dir/TestTransformation.cpp.o.d -o tools/clang/test/Analysis/Scalable/source-edit-generation/Plugins/TestTransformationPlugin/CMakeFiles/SSAFTestTransformationPlugin.dir/TestTransformation.cpp.o -c /home/b/sanitizer-x86_64-linux-fast/build/llvm-project/clang/test/Analysis/Scalable/source-edit-generation/Plugins/TestTransformationPlugin/TestTransformation.cpp
In file included from /home/b/sanitizer-x86_64-linux-fast/build/llvm-project/clang/test/Analysis/Scalable/source-edit-generation/Plugins/TestTransformationPlugin/TestTransformation.cpp:21:
In file included from /home/b/sanitizer-x86_64-linux-fast/build/llvm-project/clang/include/clang/AST/ASTContext.h:18:
In file included from /home/b/sanitizer-x86_64-linux-fast/build/llvm-project/clang/include/clang/AST/CanonicalType.h:17:
In file included from /home/b/sanitizer-x86_64-linux-fast/build/llvm-project/clang/include/clang/AST/Type.h:20:
In file included from /home/b/sanitizer-x86_64-linux-fast/build/llvm-project/clang/include/clang/AST/Decl.h:16:
In file included from /home/b/sanitizer-x86_64-linux-fast/build/llvm-project/clang/include/clang/AST/APNumericStorage.h:12:
In file included from /home/b/sanitizer-x86_64-linux-fast/build/llvm-project/llvm/include/llvm/ADT/APFloat.h:19:
In file included from /home/b/sanitizer-x86_64-linux-fast/build/llvm-project/llvm/include/llvm/ADT/ArrayRef.h:12:
In file included from /home/b/sanitizer-x86_64-linux-fast/build/llvm-project/llvm/include/llvm/ADT/Hashing.h:58:
In file included from /home/b/sanitizer-x86_64-linux-fast/build/libcxx_install_asan_ubsan/include/c++/v1/string:603:
/home/b/sanitizer-x86_64-linux-fast/build/libcxx_install_asan_ubsan/include/c++/v1/__debug_utils/sanitizers.h:42:4: error: "We can't disable ASAN container checks when libc++ has been built with ASAN container checks enabled"
   42 | #  error "We can't disable ASAN container checks when libc++ has been built with ASAN container checks enabled"
      |    ^
1 error generated.
```
and possibly some MSan buildbots too (e.g., https://lab.llvm.org/buildbot/#/builders/94/builds/20465/steps/11/logs/stdio):
```
  Clang :: Analysis/Scalable/source-edit-generation/coexistence.cpp
  Clang :: Analysis/Scalable/source-edit-generation/happy-path.cpp
  Clang :: Analysis/Scalable/source-edit-generation/write-failure.cpp
```
