### PR TITLE
[MCParser][NFCI] Deduplicate isIdentifierChar

### DIFF
--- a/llvm/include/llvm/MC/MCParser/AsmLexer.h
+++ b/llvm/include/llvm/MC/MCParser/AsmLexer.h
@@ -202,6 +202,9 @@ public:
 
   const MCAsmInfo &getMAI() const { return MAI; }
 
+  static bool isIdentifierChar(char C, bool AllowAt = true,
+                               bool AllowHash = false);
+
 private:
   bool isAtStartOfComment(const char *Ptr);
   bool isAtStatementSeparator(const char *Ptr);

--- a/llvm/lib/MC/MCParser/AsmLexer.cpp
+++ b/llvm/lib/MC/MCParser/AsmLexer.cpp
@@ -229,7 +229,7 @@ AsmToken AsmLexer::LexHexFloatLiteral(bool NoIntDigits) {
 }
 
 /// LexIdentifier: [a-zA-Z_$.@?][a-zA-Z0-9_$.@#?]*
-static bool isIdentifierChar(char C, bool AllowAt, bool AllowHash) {
+bool AsmLexer::isIdentifierChar(char C, bool AllowAt, bool AllowHash) {
   return isAlnum(C) || C == '_' || C == '$' || C == '.' || C == '?' ||
          (AllowAt && C == '@') || (AllowHash && C == '#');
 }

--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -2459,15 +2459,6 @@ void AsmParser::DiagHandler(const SMDiagnostic &Diag, void *Context) {
     Parser->getContext().diagnose(NewDiag);
 }
 
-// FIXME: This is mostly duplicated from the function in AsmLexer.cpp. The
-// difference being that that function accepts '@' as part of identifiers and
-// we can't do that. AsmLexer.cpp should probably be changed to handle
-// '@' as a special case when needed.
-static bool isIdentifierChar(char c) {
-  return isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '$' ||
-         c == '.';
-}
-
 bool AsmParser::expandMacro(raw_svector_ostream &OS, MCAsmMacro &Macro,
                             ArrayRef<MCAsmMacroParameter> Parameters,
                             ArrayRef<MCAsmMacroArgument> A,
@@ -2525,7 +2516,7 @@ bool AsmParser::expandMacro(raw_svector_ostream &OS, MCAsmMacro &Macro,
       }
 
       size_t Pos = ++I;
-      while (I != End && isIdentifierChar(Body[I]))
+      while (I != End && AsmLexer::isIdentifierChar(Body[I], /*AllowAt=*/false))
         ++I;
       StringRef Argument(Body.data() + Pos, I - Pos);
       if (AltMacroMode && I != End && Body[I] == '&')
@@ -2571,13 +2562,13 @@ bool AsmParser::expandMacro(raw_svector_ostream &OS, MCAsmMacro &Macro,
       }
     }
 
-    if (!isIdentifierChar(Body[I]) || IsDarwin) {
+    if (!AsmLexer::isIdentifierChar(Body[I], /*AllowAt=*/false) || IsDarwin) {
       OS << Body[I++];
       continue;
     }
 
     const size_t Start = I;
-    while (++I && isIdentifierChar(Body[I])) {
+    while (++I && AsmLexer::isIdentifierChar(Body[I], /*AllowAt=*/false)) {
     }
     StringRef Token(Body.data() + Start, I - Start);
     if (AltMacroMode) {
@@ -4903,7 +4894,8 @@ void AsmParser::checkForBadMacro(SMLoc DirectiveLoc, StringRef Name,
       Pos += 2;
     } else {
       unsigned I = Pos + 1;
-      while (isIdentifierChar(Body[I]) && I + 1 != End)
+      while (AsmLexer::isIdentifierChar(Body[I], /*AllowAt=*/false) &&
+             I + 1 != End)
         ++I;
 
       const char *Begin = Body.data() + Pos + 1;


### PR DESCRIPTION
Since the function of the same name was moved from the `AsmParser` module to the `AsmLexer` module, I need to expose `isIdentifierChar` in the header file for use by `AsmParser`, thereby resolving the duplicate reference issue.