### PR TITLE
[Transforms] Remove dead declarations

### DIFF
--- a/llvm/include/llvm/Transforms/Coroutines/CoroShape.h
+++ b/llvm/include/llvm/Transforms/Coroutines/CoroShape.h
@@ -95,8 +95,6 @@ struct Shape {
   LLVM_ABI void
   invalidateCoroutine(Function &F,
                       SmallVectorImpl<CoroFrameInst *> &CoroFrames);
-  // Perform ABI related initial transformation
-  LLVM_ABI void initABI();
   // Remove orphaned and unnecessary intrinsics
   LLVM_ABI void
   cleanCoroutine(SmallVectorImpl<CoroFrameInst *> &CoroFrames,

--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -763,15 +763,6 @@ template <> struct DenseMapInfo<AA::RangeTy> {
   }
 };
 
-/// Helper for AA::PointerInfo::Access DenseMap/Set usage ignoring everythign
-/// but the instruction
-struct AccessAsInstructionInfo : DenseMapInfo<Instruction *> {
-  using Base = DenseMapInfo<Instruction *>;
-  using Access = AAPointerInfo::Access;
-  static unsigned getHashValue(const Access &A);
-  static bool isEqual(const Access &LHS, const Access &RHS);
-};
-
 } // namespace llvm
 
 /// A type to track pointer/struct usage and accesses for AAPointerInfo.


### PR DESCRIPTION
initABI: The corresponding function definition was removed on October 3,
2024 in commit 66227bf7ee2cd674e0306d9a1e9f1d86bc75123f.

AccessAsInstructionInfo: The last use was removed on March 8, 2022 in
commit e8fadafe774c7e601129be50cedce1dd20843cea.
