### PR TITLE
[Clang] Add TimeTraceScopes to DeduceTemplateArguments

### DIFF
--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -55,6 +55,7 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/SaveAndRestore.h"
+#include "llvm/Support/TimeProfiler.h"
 #include <algorithm>
 #include <cassert>
 #include <optional>
@@ -4489,6 +4490,10 @@ TemplateDeductionResult Sema::DeduceTemplateArguments(
   if (FunctionTemplate->isInvalidDecl())
     return TemplateDeductionResult::Invalid;
 
+  llvm::TimeTraceScope TimeScope("DeduceTemplateArguments", [&] {
+    return FunctionTemplate->getLocation().printToString(SourceMgr);
+  });
+
   FunctionDecl *Function = FunctionTemplate->getTemplatedDecl();
   unsigned NumParams = Function->getNumParams();
   bool HasExplicitObject = false;
@@ -4771,6 +4776,10 @@ TemplateDeductionResult Sema::DeduceTemplateArguments(
     bool IsAddressOfFunction) {
   if (FunctionTemplate->isInvalidDecl())
     return TemplateDeductionResult::Invalid;
+
+  llvm::TimeTraceScope TimeScope("DeduceTemplateArguments", [&] {
+    return FunctionTemplate->getLocation().printToString(SourceMgr);
+  });
 
   FunctionDecl *Function = FunctionTemplate->getTemplatedDecl();
   TemplateParameterList *TemplateParams

--- a/clang/unittests/Support/TimeProfilerTest.cpp
+++ b/clang/unittests/Support/TimeProfilerTest.cpp
@@ -397,6 +397,7 @@ TEST(TimeProfilerTest, TemplateInstantiations) {
   ASSERT_TRUE(compileFromString(Code, "-std=c++20", "test.cc",
                                 /*Headers=*/{{"a.h", A_H}, {"b.h", B_H}}));
   std::string Json = teardownProfiler();
+#ifdef _WIN32
   ASSERT_EQ(R"(
 ExecuteCompiler
 | Frontend (test.cc)
@@ -422,6 +423,33 @@ ExecuteCompiler
 | | | InstantiateFunction (fooMTA<int>, a.h:4)
 )",
             buildTraceGraph(Json));
+#else
+  ASSERT_EQ(R"(
+ExecuteCompiler
+| Frontend (test.cc)
+| | ParseFunctionDefinition (fooC)
+| | ParseFunctionDefinition (fooB)
+| | ParseFunctionDefinition (fooMTA)
+| | ParseFunctionDefinition (fooA)
+| | ParseDeclarationOrFunctionDefinition (test.cc:3:5)
+| | | ParseFunctionDefinition (user)
+| | | | DeduceTemplateArguments (.\\a.h:7:10)
+| | | | DeferInstantiation (fooA<int>)
+| PerformPendingInstantiations
+| | InstantiateFunction (fooA<int>, a.h:7)
+| | | DeduceTemplateArguments (.\\b.h:8:17)
+| | | InstantiateFunction (fooB<int>, b.h:8)
+| | | | DeduceTemplateArguments (.\\b.h:3:7)
+| | | | DeferInstantiation (fooC<int>)
+| | | | BuildCFG
+| | | DeduceTemplateArguments (.\\a.h:4:5 <Spelling=<scratch space>:4:1>)
+| | | DeferInstantiation (fooMTA<int>)
+| | | InstantiateFunction (fooC<int>, b.h:3)
+| | | | BuildCFG
+| | | InstantiateFunction (fooMTA<int>, a.h:4)
+)",
+            buildTraceGraph(Json));
+#endif
 }
 
 static SpecializationCounts

--- a/clang/unittests/Support/TimeProfilerTest.cpp
+++ b/clang/unittests/Support/TimeProfilerTest.cpp
@@ -406,12 +406,16 @@ ExecuteCompiler
 | | ParseFunctionDefinition (fooA)
 | | ParseDeclarationOrFunctionDefinition (test.cc:3:5)
 | | | ParseFunctionDefinition (user)
+| | | | DeduceTemplateArguments (./a.h:7:10)
 | | | | DeferInstantiation (fooA<int>)
 | PerformPendingInstantiations
 | | InstantiateFunction (fooA<int>, a.h:7)
+| | | DeduceTemplateArguments (./b.h:8:17)
 | | | InstantiateFunction (fooB<int>, b.h:8)
+| | | | DeduceTemplateArguments (./b.h:3:7)
 | | | | DeferInstantiation (fooC<int>)
 | | | | BuildCFG
+| | | DeduceTemplateArguments (./a.h:4:5 <Spelling=<scratch space>:4:1>)
 | | | DeferInstantiation (fooMTA<int>)
 | | | InstantiateFunction (fooC<int>, b.h:3)
 | | | | BuildCFG

--- a/clang/unittests/Support/TimeProfilerTest.cpp
+++ b/clang/unittests/Support/TimeProfilerTest.cpp
@@ -397,7 +397,7 @@ TEST(TimeProfilerTest, TemplateInstantiations) {
   ASSERT_TRUE(compileFromString(Code, "-std=c++20", "test.cc",
                                 /*Headers=*/{{"a.h", A_H}, {"b.h", B_H}}));
   std::string Json = teardownProfiler();
-#ifdef _WIN32
+#ifndef _WIN32
   ASSERT_EQ(R"(
 ExecuteCompiler
 | Frontend (test.cc)


### PR DESCRIPTION
`DeduceTemplateArguments` can take a significant amount of time, and is therefore interesting for optimizing compile times.
