### PR TITLE
[clang] Add visibility to AST dump

### DIFF
--- a/clang/include/clang/AST/TextNodeDumper.h
+++ b/clang/include/clang/AST/TextNodeDumper.h
@@ -208,7 +208,7 @@ public:
   void dumpType(QualType T);
   void dumpBareDeclRef(const Decl *D);
   void dumpName(const NamedDecl *ND);
-  void dumpLV(const NamedDecl *ND);
+  void dumpLinkageAndVisibility(const NamedDecl *ND);
   void dumpAccessSpecifier(AccessSpecifier AS);
   void dumpCleanupObject(const ExprWithCleanups::CleanupObject &C);
   void dumpTemplateSpecializationKind(TemplateSpecializationKind TSK);

--- a/clang/include/clang/AST/TextNodeDumper.h
+++ b/clang/include/clang/AST/TextNodeDumper.h
@@ -208,7 +208,7 @@ public:
   void dumpType(QualType T);
   void dumpBareDeclRef(const Decl *D);
   void dumpName(const NamedDecl *ND);
-  void dumpFormalLinkage(const NamedDecl *ND);
+  void dumpLV(const NamedDecl *ND);
   void dumpAccessSpecifier(AccessSpecifier AS);
   void dumpCleanupObject(const ExprWithCleanups::CleanupObject &C);
   void dumpTemplateSpecializationKind(TemplateSpecializationKind TSK);

--- a/clang/lib/AST/TextNodeDumper.cpp
+++ b/clang/lib/AST/TextNodeDumper.cpp
@@ -1456,7 +1456,7 @@ static void dumpBasePath(raw_ostream &OS, const CastExpr *Node) {
   OS << ')';
 }
 
-void TextNodeDumper::dumpLV(const NamedDecl *ND) {
+void TextNodeDumper::dumpLinkageAndVisibility(const NamedDecl *ND) {
   switch (ND->getFormalLinkage()) {
   case Linkage::None:
     // A lot of declarations have no linkage, so we only dump linkage if there
@@ -2405,7 +2405,7 @@ void TextNodeDumper::VisitTypedefDecl(const TypedefDecl *D) {
 
   const TagDecl *TD = D->getUnderlyingType()->getAsTagDecl();
   if (TD && TD->getTypedefNameForAnonDecl()) {
-    dumpLV(D);
+    dumpLinkageAndVisibility(D);
   }
 }
 
@@ -2427,7 +2427,7 @@ void TextNodeDumper::VisitEnumDecl(const EnumDecl *D) {
     dumpPointer(Instance);
   }
 
-  dumpLV(D);
+  dumpLinkageAndVisibility(D);
 }
 
 void TextNodeDumper::VisitRecordDecl(const RecordDecl *D) {
@@ -2439,7 +2439,7 @@ void TextNodeDumper::VisitRecordDecl(const RecordDecl *D) {
     OS << " definition";
 
   if (!D->isImplicit() && !D->getDescribedTemplate()) {
-    dumpLV(D);
+    dumpLinkageAndVisibility(D);
   }
 }
 
@@ -2540,7 +2540,7 @@ void TextNodeDumper::VisitFunctionDecl(const FunctionDecl *D) {
   }
 
   if (!isa<CXXDeductionGuideDecl>(D) && !D->getDescribedTemplate()) {
-    dumpLV(D);
+    dumpLinkageAndVisibility(D);
   }
 }
 
@@ -2644,7 +2644,7 @@ void TextNodeDumper::VisitVarDecl(const VarDecl *D) {
   }
 
   if (!D->getDescribedVarTemplate()) {
-    dumpLV(D);
+    dumpLinkageAndVisibility(D);
   }
 }
 
@@ -2763,7 +2763,7 @@ void TextNodeDumper::VisitNamespaceDecl(const NamespaceDecl *D) {
   if (!D->isFirstDecl())
     dumpDeclRef(D->getFirstDecl(), "original");
 
-  dumpLV(D);
+  dumpLinkageAndVisibility(D);
 }
 
 void TextNodeDumper::VisitUsingDirectiveDecl(const UsingDirectiveDecl *D) {
@@ -2782,14 +2782,14 @@ void TextNodeDumper::VisitTypeAliasDecl(const TypeAliasDecl *D) {
 
   const TagDecl *TD = D->getUnderlyingType()->getAsTagDecl();
   if (TD && TD->getTypedefNameForAnonDecl()) {
-    dumpLV(D);
+    dumpLinkageAndVisibility(D);
   }
 }
 
 void TextNodeDumper::VisitTypeAliasTemplateDecl(
     const TypeAliasTemplateDecl *D) {
   dumpName(D);
-  dumpLV(D);
+  dumpLinkageAndVisibility(D);
 }
 
 void TextNodeDumper::VisitCXXRecordDecl(const CXXRecordDecl *D) {
@@ -2950,17 +2950,17 @@ void TextNodeDumper::VisitCXXRecordDecl(const CXXRecordDecl *D) {
 
 void TextNodeDumper::VisitFunctionTemplateDecl(const FunctionTemplateDecl *D) {
   dumpName(D);
-  dumpLV(D);
+  dumpLinkageAndVisibility(D);
 }
 
 void TextNodeDumper::VisitClassTemplateDecl(const ClassTemplateDecl *D) {
   dumpName(D);
-  dumpLV(D);
+  dumpLinkageAndVisibility(D);
 }
 
 void TextNodeDumper::VisitVarTemplateDecl(const VarTemplateDecl *D) {
   dumpName(D);
-  dumpLV(D);
+  dumpLinkageAndVisibility(D);
 }
 
 void TextNodeDumper::VisitBuiltinTemplateDecl(const BuiltinTemplateDecl *D) {
@@ -3271,7 +3271,7 @@ void TextNodeDumper::VisitBlockDecl(const BlockDecl *D) {
 
 void TextNodeDumper::VisitConceptDecl(const ConceptDecl *D) {
   dumpName(D);
-  dumpLV(D);
+  dumpLinkageAndVisibility(D);
 }
 
 void TextNodeDumper::VisitCompoundStmt(const CompoundStmt *S) {

--- a/clang/lib/AST/TextNodeDumper.cpp
+++ b/clang/lib/AST/TextNodeDumper.cpp
@@ -1478,16 +1478,6 @@ void TextNodeDumper::dumpLinkageAndVisibility(const NamedDecl *ND) {
     llvm_unreachable("Not a formal linkage!");
   }
 
-  // FIXME: HLSLAttributedResourceType should always have contained type,
-  //        or LinkageComputer::computeTypeLinkageInfo needs to deal with
-  //        the lack of contained type.
-  if (const auto *VD = dyn_cast<VarDecl>(ND)) {
-    if (const auto *Ty = dyn_cast<HLSLAttributedResourceType>(VD->getType());
-        Ty && Ty->getContainedType().isNull()) {
-      return;
-    }
-  }
-
   switch (ND->getVisibility()) {
   case Visibility::DefaultVisibility:
     // A lot of declarations have default visibility, so we only dump other

--- a/clang/lib/AST/TextNodeDumper.cpp
+++ b/clang/lib/AST/TextNodeDumper.cpp
@@ -1482,7 +1482,8 @@ void TextNodeDumper::dumpLV(const NamedDecl *ND) {
   //        or LinkageComputer::computeTypeLinkageInfo needs to deal with
   //        the lack of contained type.
   if (const auto *VD = dyn_cast<VarDecl>(ND)) {
-    if (const auto* Ty = dyn_cast<HLSLAttributedResourceType>(VD->getType()); Ty && Ty->getContainedType().isNull()) {
+    if (const auto *Ty = dyn_cast<HLSLAttributedResourceType>(VD->getType());
+        Ty && Ty->getContainedType().isNull()) {
       return;
     }
   }
@@ -1497,7 +1498,7 @@ void TextNodeDumper::dumpLV(const NamedDecl *ND) {
     break;
   case Visibility::ProtectedVisibility:
     OS << " protected-visibility";
-    break; 
+    break;
   }
 }
 

--- a/clang/lib/AST/TextNodeDumper.cpp
+++ b/clang/lib/AST/TextNodeDumper.cpp
@@ -1456,7 +1456,7 @@ static void dumpBasePath(raw_ostream &OS, const CastExpr *Node) {
   OS << ')';
 }
 
-void TextNodeDumper::dumpFormalLinkage(const NamedDecl *ND) {
+void TextNodeDumper::dumpLV(const NamedDecl *ND) {
   switch (ND->getFormalLinkage()) {
   case Linkage::None:
     // A lot of declarations have no linkage, so we only dump linkage if there
@@ -1476,6 +1476,28 @@ void TextNodeDumper::dumpFormalLinkage(const NamedDecl *ND) {
   case Linkage::UniqueExternal:
   case Linkage::VisibleNone:
     llvm_unreachable("Not a formal linkage!");
+  }
+
+  // FIXME: HLSLAttributedResourceType should always have contained type,
+  //        or LinkageComputer::computeTypeLinkageInfo needs to deal with
+  //        the lack of contained type.
+  if (const auto *VD = dyn_cast<VarDecl>(ND)) {
+    if (const auto* Ty = dyn_cast<HLSLAttributedResourceType>(VD->getType()); Ty && Ty->getContainedType().isNull()) {
+      return;
+    }
+  }
+
+  switch (ND->getVisibility()) {
+  case Visibility::DefaultVisibility:
+    // A lot of declarations have default visibility, so we only dump other
+    // kinds of visibility.
+    break;
+  case Visibility::HiddenVisibility:
+    OS << " hidden-visibility";
+    break;
+  case Visibility::ProtectedVisibility:
+    OS << " protected-visibility";
+    break; 
   }
 }
 
@@ -2382,7 +2404,7 @@ void TextNodeDumper::VisitTypedefDecl(const TypedefDecl *D) {
 
   const TagDecl *TD = D->getUnderlyingType()->getAsTagDecl();
   if (TD && TD->getTypedefNameForAnonDecl()) {
-    dumpFormalLinkage(D);
+    dumpLV(D);
   }
 }
 
@@ -2404,7 +2426,7 @@ void TextNodeDumper::VisitEnumDecl(const EnumDecl *D) {
     dumpPointer(Instance);
   }
 
-  dumpFormalLinkage(D);
+  dumpLV(D);
 }
 
 void TextNodeDumper::VisitRecordDecl(const RecordDecl *D) {
@@ -2416,7 +2438,7 @@ void TextNodeDumper::VisitRecordDecl(const RecordDecl *D) {
     OS << " definition";
 
   if (!D->isImplicit() && !D->getDescribedTemplate()) {
-    dumpFormalLinkage(D);
+    dumpLV(D);
   }
 }
 
@@ -2517,7 +2539,7 @@ void TextNodeDumper::VisitFunctionDecl(const FunctionDecl *D) {
   }
 
   if (!isa<CXXDeductionGuideDecl>(D) && !D->getDescribedTemplate()) {
-    dumpFormalLinkage(D);
+    dumpLV(D);
   }
 }
 
@@ -2621,7 +2643,7 @@ void TextNodeDumper::VisitVarDecl(const VarDecl *D) {
   }
 
   if (!D->getDescribedVarTemplate()) {
-    dumpFormalLinkage(D);
+    dumpLV(D);
   }
 }
 
@@ -2740,7 +2762,7 @@ void TextNodeDumper::VisitNamespaceDecl(const NamespaceDecl *D) {
   if (!D->isFirstDecl())
     dumpDeclRef(D->getFirstDecl(), "original");
 
-  dumpFormalLinkage(D);
+  dumpLV(D);
 }
 
 void TextNodeDumper::VisitUsingDirectiveDecl(const UsingDirectiveDecl *D) {
@@ -2759,14 +2781,14 @@ void TextNodeDumper::VisitTypeAliasDecl(const TypeAliasDecl *D) {
 
   const TagDecl *TD = D->getUnderlyingType()->getAsTagDecl();
   if (TD && TD->getTypedefNameForAnonDecl()) {
-    dumpFormalLinkage(D);
+    dumpLV(D);
   }
 }
 
 void TextNodeDumper::VisitTypeAliasTemplateDecl(
     const TypeAliasTemplateDecl *D) {
   dumpName(D);
-  dumpFormalLinkage(D);
+  dumpLV(D);
 }
 
 void TextNodeDumper::VisitCXXRecordDecl(const CXXRecordDecl *D) {
@@ -2927,17 +2949,17 @@ void TextNodeDumper::VisitCXXRecordDecl(const CXXRecordDecl *D) {
 
 void TextNodeDumper::VisitFunctionTemplateDecl(const FunctionTemplateDecl *D) {
   dumpName(D);
-  dumpFormalLinkage(D);
+  dumpLV(D);
 }
 
 void TextNodeDumper::VisitClassTemplateDecl(const ClassTemplateDecl *D) {
   dumpName(D);
-  dumpFormalLinkage(D);
+  dumpLV(D);
 }
 
 void TextNodeDumper::VisitVarTemplateDecl(const VarTemplateDecl *D) {
   dumpName(D);
-  dumpFormalLinkage(D);
+  dumpLV(D);
 }
 
 void TextNodeDumper::VisitBuiltinTemplateDecl(const BuiltinTemplateDecl *D) {
@@ -3248,7 +3270,7 @@ void TextNodeDumper::VisitBlockDecl(const BlockDecl *D) {
 
 void TextNodeDumper::VisitConceptDecl(const ConceptDecl *D) {
   dumpName(D);
-  dumpFormalLinkage(D);
+  dumpLV(D);
 }
 
 void TextNodeDumper::VisitCompoundStmt(const CompoundStmt *S) {

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -5150,8 +5150,8 @@ LinkageInfo LinkageComputer::computeTypeLinkageInfo(const Type *T) {
     return computeTypeLinkageInfo(
         cast<OverflowBehaviorType>(T)->getUnderlyingType());
   case Type::HLSLAttributedResource:
-    return computeTypeLinkageInfo(cast<HLSLAttributedResourceType>(T)
-                                      ->getWrappedType());
+    return computeTypeLinkageInfo(
+        cast<HLSLAttributedResourceType>(T)->getWrappedType());
   case Type::HLSLInlineSpirv:
     return LinkageInfo::external();
   }

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -5151,8 +5151,7 @@ LinkageInfo LinkageComputer::computeTypeLinkageInfo(const Type *T) {
         cast<OverflowBehaviorType>(T)->getUnderlyingType());
   case Type::HLSLAttributedResource:
     return computeTypeLinkageInfo(cast<HLSLAttributedResourceType>(T)
-                                      ->getContainedType()
-                                      ->getCanonicalTypeInternal());
+                                      ->getWrappedType());
   case Type::HLSLInlineSpirv:
     return LinkageInfo::external();
   }

--- a/clang/test/AST/ast-dump-visibility.cpp
+++ b/clang/test/AST/ast-dump-visibility.cpp
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -ast-dump -std=c++2c -fms-extensions %s | FileCheck --match-full-lines --check-prefix=CHECK %s
+
+int a1;
+// CHECK: |-VarDecl {{.*}} a1 'int' external-linkage
+
+[[gnu::visibility("default")]] int a2;
+// CHECK: |-VarDecl {{.*}} a2 'int' external-linkage
+
+__declspec(dllexport) int a3;
+// CHECK: |-VarDecl {{.*}} a3 'int' external-linkage
+
+[[gnu::visibility("hidden")]] int b;
+// CHECK: |-VarDecl {{.*}} b 'int' external-linkage hidden-visibility
+
+[[gnu::visibility("protected")]] int c;
+// CHECK: `-VarDecl {{.*}} c 'int' external-linkage protected-visibility

--- a/clang/test/AST/ast-dump-visibility.cpp
+++ b/clang/test/AST/ast-dump-visibility.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -ast-dump -std=c++2c -fms-extensions %s | FileCheck --match-full-lines --check-prefix=CHECK %s
+// RUN: %clang_cc1 -ast-dump -std=c++2c -triple x86_64-unknown-linux-gnu -fms-extensions %s | FileCheck --match-full-lines --check-prefix=CHECK %s
 
 int a1;
 // CHECK: |-VarDecl {{.*}} a1 'int' external-linkage


### PR DESCRIPTION
Similarly to https://github.com/llvm/llvm-project/pull/194600, this PR adds visibility information (default/hidden/protected) to AST dump in exactly the same places where linkage is printed. As with no linkage, default visibility is assumed and not printed, as it's so common that I didn't have to update any of the existing tests.