### PR TITLE
[CIR] Preserve const pointee information on function params

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
@@ -90,6 +90,7 @@ def CIR_Dialect : Dialect {
     static llvm::StringRef getAMDGPUSramEccAttrName() { return "cir.amdgpu_sramecc"; }
     static llvm::StringRef getOpenCLKernelArgMetadataAttrName() { return "cir.cl.kernel_arg_metadata"; }
     static llvm::StringRef getDefaultTlsModelAttrName() { return "cir.default_tls_model"; }
+    static llvm::StringRef getConstPointeeAttrName() { return "cir.const_pointee"; }
 
     void registerAttributes();
     void registerTypes();

--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -17,7 +17,9 @@
 #include "CIRGenFunctionInfo.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/Attributes.h"
+#include "clang/AST/TypeBase.h"
 #include "clang/CIR/ABIArgInfo.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/MissingFeatures.h"
 #include "llvm/ADT/FloatingPointMode.h"
 #include "llvm/ADT/StringSet.h"
@@ -663,6 +665,16 @@ void CIRGenModule::constructFunctionReturnAttributes(
   }
 }
 
+static bool hasConstQualifiedPointee(QualType type) {
+  if (const auto *ptrTy = type->getAs<PointerType>())
+    return ptrTy->getPointeeType().isConstQualified();
+
+  if (const auto *refTy = type->getAs<ReferenceType>())
+    return refTy->getPointeeType().isConstQualified();
+
+  return false;
+}
+
 void CIRGenModule::constructFunctionArgumentAttributes(
     const CIRGenFunctionInfo &info, const Decl *targetDecl, bool isThunk,
     bool attrOnCallSite, llvm::MutableArrayRef<mlir::NamedAttrList> argAttrs) {
@@ -769,6 +781,11 @@ void CIRGenModule::constructFunctionArgumentAttributes(
     if (!attrOnCallSite && pvd && pvd->getType()->isPointerType() &&
         pvd->getType().isRestrictQualified() && !fd->getBuiltinID())
       argAttrList.set(mlir::LLVM::LLVMDialect::getNoAliasAttrName(),
+                      mlir::UnitAttr::get(&getMLIRContext()));
+
+    // const pointer handling
+    if (pvd && hasConstQualifiedPointee(pvd->getType()))
+      argAttrList.set(cir::CIRDialect::getConstPointeeAttrName(),
                       mlir::UnitAttr::get(&getMLIRContext()));
 
     // __attribute__((nonnull)) on pointer parameters.  Checks both

--- a/clang/test/CIR/CodeGen/builtin-cpu-supports.c
+++ b/clang/test/CIR/CodeGen/builtin-cpu-supports.c
@@ -23,7 +23,7 @@ extern void a(const char *);
 // CIR-NEXT:   cir.if %[[RES]] {
 // CIR-NEXT:     %[[STR:.*]] = cir.get_global 
 // CIR-NEXT:     %[[STR_DECAY:.*]] = cir.cast array_to_ptrdecay %[[STR]] : !cir.ptr<!cir.array<!s8i x 7>> -> !cir.ptr<!s8i>
-// CIR-NEXT:     cir.call @a(%[[STR_DECAY]]) : (!cir.ptr<!s8i> {llvm.noundef}) -> ()
+// CIR-NEXT:     cir.call @a(%[[STR_DECAY]]) : (!cir.ptr<!s8i> {cir.const_pointee, llvm.noundef}) -> ()
 // CIR-NEXT:   }
 // CIR-NEXT: }
 // CIR-NEXT: cir.scope {
@@ -37,7 +37,7 @@ extern void a(const char *);
 // CIR-NEXT:   cir.if %[[RES]] {
 // CIR-NEXT:     %[[STR:.*]] = cir.get_global 
 // CIR-NEXT:     %[[STR_DECAY:.*]] = cir.cast array_to_ptrdecay %[[STR]] : !cir.ptr<!cir.array<!s8i x 5>> -> !cir.ptr<!s8i>
-// CIR-NEXT:     cir.call @a(%[[STR_DECAY]]) : (!cir.ptr<!s8i> {llvm.noundef}) -> ()
+// CIR-NEXT:     cir.call @a(%[[STR_DECAY]]) : (!cir.ptr<!s8i> {cir.const_pointee, llvm.noundef}) -> ()
 // CIR-NEXT:   }
 // CIR-NEXT: }
 

--- a/clang/test/CIR/CodeGen/cxx-rewritten-binary-operator.cpp
+++ b/clang/test/CIR/CodeGen/cxx-rewritten-binary-operator.cpp
@@ -58,7 +58,7 @@ void cxx_rewritten_binary_operator_complex_expr() {
 // CIR: %[[B_ADDR:.*]] = cir.alloca "b" {{.*}} : !cir.ptr<!rec_ComplexItem>
 // CIR: %[[R_ADDR:.*]] = cir.alloca "r" {{.*}} init : !cir.ptr<!cir.complex<!s32i>>
 // CIR: %[[TMP_ADDR:.*]] = cir.alloca "ref.tmp0" {{.*}} : !cir.ptr<!rec_SpaceshipComplexResult>
-// CIR: %[[OP_RESULT:.*]] = cir.call @_ZNK11ComplexItemssERKS_(%[[A_ADDR]], %[[B_ADDR]]) : (!cir.ptr<!rec_ComplexItem> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}, !cir.ptr<!rec_ComplexItem> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}) -> !rec_SpaceshipComplexResult
+// CIR: %[[OP_RESULT:.*]] = cir.call @_ZNK11ComplexItemssERKS_(%[[A_ADDR]], %[[B_ADDR]]) : (!cir.ptr<!rec_ComplexItem> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}, !cir.ptr<!rec_ComplexItem> {cir.const_pointee, llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}) -> !rec_SpaceshipComplexResult
 // CIR: cir.store {{.*}} %[[OP_RESULT]], %[[TMP_ADDR]] : !rec_SpaceshipComplexResult, !cir.ptr<!rec_SpaceshipComplexResult>
 // CIR: %[[CONST_0:.*]] = cir.const #cir.int<0> : !s32i
 // CIR: %[[RESULT:.*]] = cir.call @_ZNK22SpaceshipComplexResultltEi(%[[TMP_ADDR]], %[[CONST_0]]) : (!cir.ptr<!rec_SpaceshipComplexResult> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}, !s32i {llvm.noundef}) -> (!cir.complex<!s32i> {llvm.noundef})
@@ -114,7 +114,7 @@ void cxx_rewritten_binary_operator_aggr_expr() {
 // CIR: %[[B_ADDR:.*]] = cir.alloca "b" {{.*}} : !cir.ptr<!rec_Item>
 // CIR: %[[R_ADDR:.*]] = cir.alloca "r" {{.*}} init : !cir.ptr<!rec_Result>
 // CIR: %[[TMP_ADDR:.*]] = cir.alloca "ref.tmp0" {{.*}} : !cir.ptr<!rec_SpaceshipResult>
-// CIR: %[[OP_RESULT:.*]] = cir.call @_ZNK4ItemssERKS_(%[[A_ADDR]], %[[B_ADDR]]) : (!cir.ptr<!rec_Item> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}, !cir.ptr<!rec_Item> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}) -> !rec_SpaceshipResult
+// CIR: %[[OP_RESULT:.*]] = cir.call @_ZNK4ItemssERKS_(%[[A_ADDR]], %[[B_ADDR]]) : (!cir.ptr<!rec_Item> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}, !cir.ptr<!rec_Item> {cir.const_pointee, llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}) -> !rec_SpaceshipResult
 // CIR: cir.store {{.*}} %[[OP_RESULT]], %[[TMP_ADDR]] : !rec_SpaceshipResult, !cir.ptr<!rec_SpaceshipResult>
 // CIR: %[[CONST_0:.*]] = cir.const #cir.int<0> : !s32i
 // CIR: %[[RESULT:.*]] = cir.call @_ZNK15SpaceshipResultltEi(%[[TMP_ADDR]], %[[CONST_0]]) : (!cir.ptr<!rec_SpaceshipResult> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}, !s32i {llvm.noundef}) -> !rec_Result

--- a/clang/test/CIR/CodeGen/restrict-noalias.c
+++ b/clang/test/CIR/CodeGen/restrict-noalias.c
@@ -28,8 +28,8 @@ void test_builtin(const char *__restrict fmt) {
 }
 
 // Builtins must NOT get noalias from restrict (matching OGCG behavior).
-// CIR: cir.func {{.*}} @test_builtin(%arg0: !cir.ptr<!s8i> {llvm.noalias, llvm.noundef}
-// CIR:   cir.call @printf(%{{.*}}) : (!cir.ptr<!s8i> {llvm.noundef}) -> !s32i
+// CIR: cir.func {{.*}} @test_builtin(%arg0: !cir.ptr<!s8i> {cir.const_pointee, llvm.noalias, llvm.noundef}
+// CIR:   cir.call @printf(%{{.*}}) : (!cir.ptr<!s8i> {cir.const_pointee, llvm.noundef}) -> !s32i
 
 // LLVM: define dso_local void @test_builtin(ptr noalias noundef %{{.*}})
 // LLVM:   call i32 (ptr, ...) @printf(ptr noundef %{{.*}})

--- a/clang/test/CIR/CodeGenBuiltins/builtin-call.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-call.cpp
@@ -85,7 +85,7 @@ void library_builtins() {
 
 // CIR: cir.func{{.*}} @_Z16library_builtinsv()
 // CIR: %[[NULL:.+]] = cir.const #cir.ptr<null> : !cir.ptr<!s8i>
-// CIR: cir.call @printf(%[[NULL]]) nothrow : (!cir.ptr<!s8i> {llvm.noundef}) -> !s32i
+// CIR: cir.call @printf(%[[NULL]]) nothrow : (!cir.ptr<!s8i> {cir.const_pointee, llvm.noundef}) -> !s32i
 // CIR: cir.call @abort() nothrow {noreturn} : () -> ()
 
 // LLVM: define{{.*}} void @_Z16library_builtinsv()

--- a/clang/test/CIR/CodeGenBuiltins/builtin-printf.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-printf.cpp
@@ -24,16 +24,16 @@ void func(char const * const str, int i) {
 // CIR:   cir.store %[[arg0]], %[[str_ptr]] : !cir.ptr<!s8i>, !cir.ptr<!cir.ptr<!s8i>>
 // CIR:   cir.store %[[arg1]], %[[i_ptr]] : !s32i, !cir.ptr<!s32i>
 // CIR:   %[[null_ptr:.+]] = cir.const #cir.ptr<null> : !cir.ptr<!s8i>
-// CIR:   %[[printf_result1:.+]] = cir.call @printf(%[[null_ptr]]) nothrow : (!cir.ptr<!s8i> {llvm.noundef}) -> !s32i
+// CIR:   %[[printf_result1:.+]] = cir.call @printf(%[[null_ptr]]) nothrow : (!cir.ptr<!s8i> {cir.const_pointee, llvm.noundef}) -> !s32i
 // CIR:   %[[str_fmt_global:.+]] = cir.get_global @".str" : !cir.ptr<!cir.array<!s8i x 3>>
 // CIR:   %[[str_fmt_ptr:.+]] = cir.cast array_to_ptrdecay %[[str_fmt_global]] : !cir.ptr<!cir.array<!s8i x 3>> -> !cir.ptr<!s8i>
 // CIR:   %[[str_val:.+]] = cir.load{{.*}} %[[str_ptr]] : !cir.ptr<!cir.ptr<!s8i>>, !cir.ptr<!s8i>
-// CIR:   %[[printf_result2:.+]] = cir.call @printf(%[[str_fmt_ptr]], %[[str_val]]) nothrow : (!cir.ptr<!s8i> {llvm.noundef}, !cir.ptr<!s8i> {llvm.noundef}) -> !s32i
+// CIR:   %[[printf_result2:.+]] = cir.call @printf(%[[str_fmt_ptr]], %[[str_val]]) nothrow : (!cir.ptr<!s8i> {cir.const_pointee, llvm.noundef}, !cir.ptr<!s8i> {llvm.noundef}) -> !s32i
 // CIR:   %[[full_fmt_global:.+]] = cir.get_global @".str.1" : !cir.ptr<!cir.array<!s8i x 7>>
 // CIR:   %[[full_fmt_ptr:.+]] = cir.cast array_to_ptrdecay %[[full_fmt_global]] : !cir.ptr<!cir.array<!s8i x 7>> -> !cir.ptr<!s8i>
 // CIR:   %[[str_val2:.+]] = cir.load{{.*}} %[[str_ptr]] : !cir.ptr<!cir.ptr<!s8i>>, !cir.ptr<!s8i>
 // CIR:   %[[i_val:.+]] = cir.load{{.*}} %[[i_ptr]] : !cir.ptr<!s32i>, !s32i
-// CIR:   %[[printf_result3:.+]] = cir.call @printf(%[[full_fmt_ptr]], %[[str_val2]], %[[i_val]]) nothrow : (!cir.ptr<!s8i> {llvm.noundef}, !cir.ptr<!s8i> {llvm.noundef}, !s32i {llvm.noundef}) -> !s32i
+// CIR:   %[[printf_result3:.+]] = cir.call @printf(%[[full_fmt_ptr]], %[[str_val2]], %[[i_val]]) nothrow : (!cir.ptr<!s8i> {cir.const_pointee, llvm.noundef}, !cir.ptr<!s8i> {llvm.noundef}, !s32i {llvm.noundef}) -> !s32i
 // CIR:   cir.return
 
 // CIR: cir.func{{.*}} @printf(!cir.ptr<!s8i> {{.*}}, ...) -> !s32i

--- a/clang/test/CIR/Transforms/idiom-recognizer.cpp
+++ b/clang/test/CIR/Transforms/idiom-recognizer.cpp
@@ -55,7 +55,7 @@ unsigned long test_strlen(const char *s) { return strlen(s); }
 // FINAL: %[[S_ADDR:.*]] = cir.alloca "s"
 // FINAL: %[[S:.*]] = cir.load{{.*}} %[[S_ADDR]] :
 // FINAL: cir.call @strlen(%[[S]]) nothrow
-// FINAL-SAME: (!cir.ptr<!s8i> {llvm.noundef})
+// FINAL-SAME: (!cir.ptr<!s8i> {cir.const_pointee, llvm.noundef})
 // FINAL-SAME: -> !u64i
 // NO-BUILTIN-MEMCPY: cir.call @strlen
 // NO-BUILTIN-MEMCPY-SAME: nobuiltins = ["memcpy"]


### PR DESCRIPTION
Attached a CIR parameter attribute for function paramerters whose source type has a const-qualier. This preserves source signature info in declarations without changing the lowered pointer type itself.

This keeps the ordinary pointer/lvalue typing unchanged while making the qualifier available on the signature side.

Fixes #217687 

```
!s32i = !cir.int<s, 32>
!s8i = !cir.int<s, 8>
module @"/private/tmp/const-pointee.c" attributes {cir.default_tls_model = #cir.tls_model<tls_dyn>, cir.lang = #cir.lang<c>, cir.module_asm = [], cir.triple = "x86_64-unknown-linux-gnu", dlti.dl_spec = #dlti.dl_spec<!llvm.ptr<270> = dense<32> : vector<4xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, i64 = dense<64> : vector<2xi64>, i128 = dense<128> : vector<2xi64>, f80 = dense<128> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, "dlti.endianness" = "little", "dlti.mangling_mode" = "e", "dlti.legal_int_widths" = array<i32: 8, 16, 32, 64>, "dlti.stack_alignment" = 128 : i64, !cir.ptr<!cir.void> = #cir.ptr_spec<size = 64, abi = 64, preferred = 64, index = 64>>} {
  cir.global external @strcmp_ptr = #cir.global_view<@strcmp> : !cir.ptr<!cir.func<(!cir.ptr<!s8i>, !cir.ptr<!s8i>) -> !s32i>> {alignment = 8 : i64} loc(#loc5)
  cir.func private @strcmp(!cir.ptr<!s8i> {cir.const_pointee, llvm.noundef}, !cir.ptr<!s8i> {cir.const_pointee, llvm.noundef}) -> !s32i attributes {"cir.target-features" = "+cx8,+mmx,+sse,+sse2,+x87", nothrow} loc(#loc6)
} loc(#loc)
#loc = loc("/private/tmp/const-pointee.c":0:0)
#loc1 = loc("/tmp/const-pointee.c":2:1)
#loc2 = loc("/tmp/const-pointee.c":2:49)
#loc3 = loc("/tmp/const-pointee.c":1:1)
#loc4 = loc("/tmp/const-pointee.c":1:38)
#loc5 = loc(fused[#loc1, #loc2])
#loc6 = loc(fused[#loc3, #loc4])
```

This is the output now adding `cir.const_pointee` along with the `llvm.noundef` in the argAttrList. This is also not leaking to the LLVM IR.

```
@strcmp_ptr = global ptr @strcmp, align 8

declare i32 @strcmp(ptr noundef, ptr noundef) #0

attributes #0 = { "target-features"="+cx8,+mmx,+sse,+sse2,+x87" }

!llvm.module.flags = !{!0}

!0 = !{i32 2, !"Debug Info Version", i32 3}
```