### PR TITLE
[libunwind] Make Apple OS version XFAILs robust to patch-level versions

### DIFF
--- a/libunwind/test/aarch64_za_unwind.pass.cpp
+++ b/libunwind/test/aarch64_za_unwind.pass.cpp
@@ -11,7 +11,7 @@
 
 // Fails on targets that support SME but where the system libunwind is too old
 // to disable ZA before resuming from unwinding.
-// UNSUPPORTED: stdlib=system && target={{.+}}-apple-{{.*}}{{(11|12|13|14|15|26)(\.\d+)?}}
+// UNSUPPORTED: stdlib=system && target={{.+}}-apple-{{.*}}{{(11|12|13|14|15|26)(\.\d+)*}}
 
 #include <alloca.h>
 #include <libunwind.h>

--- a/libunwind/test/ra_sign_state.pass.cpp
+++ b/libunwind/test/ra_sign_state.pass.cpp
@@ -14,8 +14,8 @@
 
 // The libSystem unwinder does not correctly read UNW_AARCH64_RA_SIGN_STATE, at
 // least through OS version 27.0
-// XFAIL: stdlib=apple-libc++ && target={{.*}}-apple-{{.*}}{{(11|12|13|14|15|26)(\.\d+)?}}
-// XFAIL: stdlib=apple-libc++ && target={{.*}}-apple-{{.*}}27.0
+// XFAIL: stdlib=apple-libc++ && target={{.*}}-apple-{{.*}}{{(11|12|13|14|15|26)(\.\d+)*}}
+// XFAIL: stdlib=apple-libc++ && target={{.*}}-apple-{{.*}}27.0{{(\.\d+)*}}
 
 // clang-format on
 


### PR DESCRIPTION
We are seeing some failures since some of the Apple CI runners have been updated to 26.5.2. That was caused by the regular expressions not matching patch level version bumps.