### PR TITLE
[BOLT] Ensure runtime is built with uncompressed debug symbols

### DIFF
--- a/bolt/runtime/CMakeLists.txt
+++ b/bolt/runtime/CMakeLists.txt
@@ -40,6 +40,9 @@ set(BOLT_RT_FLAGS
   # Protect against distros adding -fno-omit-frame-pointer and compiling with GCC.
   # Refs: llvm/llvm-project#148595 https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77882
   -fomit-frame-pointer
+  # JITLink currently does not support SHF_COMPRESSED sections with relocations, ensure
+  # debug sections are uncompressed to avoid out-of-bounds read and segfault.
+  -gz=none
 )
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
   set(BOLT_RT_FLAGS ${BOLT_RT_FLAGS} 


### PR DESCRIPTION
Currently, if the runtime is built with compressed debug symbols it causes an out-of-bounds read and segfault when instrumenting a binary.

This is due to JITLink currently not supporting SHF_COMPRESSED symbols as it would need to decompress the symbols first to update the reloc symbols

As some distributions are starting to enable compressed debug sections in their toolchains by default, ensure the runtime is built without them until JITLink supports updating  SHF_COMPRESSED relocs.