### PR TITLE
[libc++] Disable SSP in `clear_padding.pass.cpp`

### DIFF
--- a/libcxx/test/libcxx/atomics/clear_padding.pass.cpp
+++ b/libcxx/test/libcxx/atomics/clear_padding.pass.cpp
@@ -22,7 +22,9 @@
 // XFAIL: clang-23 && asan
 // UNSUPPORTED: clang-24 && asan
 
-// ADDITIONAL_COMPILE_FLAGS: -Wno-deprecated-volatile -Wno-dynamic-class-memaccess
+// This test crashes with -fstack-protector-strong
+// (see https://github.com/llvm/llvm-project/issues/212002)
+// ADDITIONAL_COMPILE_FLAGS: -Wno-deprecated-volatile -Wno-dynamic-class-memaccess -fno-stack-protector
 
 #include <atomic>
 #include <cassert>

--- a/libcxx/test/libcxx/atomics/clear_padding.pass.cpp
+++ b/libcxx/test/libcxx/atomics/clear_padding.pass.cpp
@@ -25,7 +25,7 @@
 // ADDITIONAL_COMPILE_FLAGS: -Wno-deprecated-volatile -Wno-dynamic-class-memaccess
 
 // This test crashes with -fstack-protector-strong
-// (see https://github.com/llvm/llvm-project/issues/212002)
+// (see https://llvm.org/PR212002)
 // ADDITIONAL_COMPILE_FLAGS: -fno-stack-protector
 
 #include <atomic>

--- a/libcxx/test/libcxx/atomics/clear_padding.pass.cpp
+++ b/libcxx/test/libcxx/atomics/clear_padding.pass.cpp
@@ -24,6 +24,10 @@
 
 // ADDITIONAL_COMPILE_FLAGS: -Wno-deprecated-volatile -Wno-dynamic-class-memaccess
 
+// This test crashes with -fstack-protector-strong
+// (see https://github.com/llvm/llvm-project/issues/212002)
+// ADDITIONAL_COMPILE_FLAGS: -fno-stack-protector
+
 #include <atomic>
 #include <cassert>
 #include <cstring>


### PR DESCRIPTION
Compile `clear_padding.pass.cpp` test `-fno-stack-protector` to fix crash due to the generated code overflowing the buffer.  This is most likely a bug in clang.

Bug #212002
Fixes a test regression introduced in #76180

CC @huixie90 