### PR TITLE
[LongVec] Add Support for pure HLSL APIs

### DIFF
--- a/clang/include/clang/Basic/HLSLIntrinsics.td
+++ b/clang/include/clang/Basic/HLSLIntrinsics.td
@@ -705,7 +705,6 @@ def hlsl_degrees : HLSLOneArgInlineBuiltin<"degrees"> {
   let Body = "return x * (__detail::elem_type_t<decltype(x)>)(180.L / __detail::Pi);";
   let VaryingTypes = [HalfTy, FloatTy];
   let VaryingLongVector = 1;
-  let VaryingMatDims = [];
 }
 // Returns the cross product of two floating-point, 3D vectors.
 def hlsl_cross : HLSLTwoArgDetail<"cross", "cross_impl"> {
@@ -1407,7 +1406,6 @@ def hlsl_radians : HLSLOneArgInlineBuiltin<"radians"> {
   let Body = "return Val * (__detail::elem_type_t<decltype(Val)>)(__detail::Pi / 180.L);";
   let VaryingTypes = [HalfTy, FloatTy];
   let VaryingLongVector = 1;
-  let VaryingMatDims = [];
 }
 
 // Calculates a fast, approximate, per-component reciprocal ie 1 / x.

--- a/clang/include/clang/Basic/HLSLIntrinsics.td
+++ b/clang/include/clang/Basic/HLSLIntrinsics.td
@@ -343,6 +343,7 @@ function returns its input unchanged.
   let Body = "return V;";
   let IsConstexpr = 1;
   let VaryingTypes = UnsignedIntTypes;
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -703,6 +704,8 @@ def hlsl_degrees : HLSLOneArgInlineBuiltin<"degrees"> {
   let ParamNames = ["x"];
   let Body = "return x * (__detail::elem_type_t<decltype(x)>)(180.L / __detail::Pi);";
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
+  let VaryingMatDims = [];
 }
 // Returns the cross product of two floating-point, 3D vectors.
 def hlsl_cross : HLSLTwoArgDetail<"cross", "cross_impl"> {
@@ -1188,6 +1191,7 @@ can equivalently be written as x + s(y-x).
 }];
   let ParamNames = ["x", "y", "s"];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -1402,6 +1406,8 @@ def hlsl_radians : HLSLOneArgInlineBuiltin<"radians"> {
   let ParamNames = ["Val"];
   let Body = "return Val * (__detail::elem_type_t<decltype(Val)>)(__detail::Pi / 180.L);";
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
+  let VaryingMatDims = [];
 }
 
 // Calculates a fast, approximate, per-component reciprocal ie 1 / x.
@@ -1593,6 +1599,7 @@ between 0 and 1.
 }];
   let ParamNames = ["Min", "Max", "X"];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -1622,6 +1629,7 @@ Step is based on the following formula: (x >= y) ? 1 : 0
 }];
   let ParamNames = ["y", "x"];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 

--- a/clang/test/CodeGenHLSL/builtins/abs.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/abs.hlsl
@@ -155,6 +155,13 @@ uint3 test_abs_uint3(uint3 p0) { return abs(p0); }
 // CHECK-NEXT: ret <4 x i32> [[Val]]
 uint4 test_abs_uint4(uint4 p0) { return abs(p0); }
 
+// CHECK-LABEL: define {{.*}}hlsl3abs{{.*}}(<5 x i32
+// CHECK: [[Alloca:%.*]] = alloca <5 x i32>
+// CHECK-NEXT: store <5 x i32> {{%.*}}, ptr [[Alloca]]
+// CHECK-NEXT: [[Val:%.*]] = load <5 x i32>, ptr [[Alloca]]
+// CHECK-NEXT: ret <5 x i32> [[Val]]
+vector<uint, 5> test_abs_uint5(vector<uint, 5> p0) { return abs(p0); }
+
 // CHECK-LABEL: define {{.*}}hlsl3abs{{.*}}(i64
 // CHECK: [[Alloca:%.*]] = alloca i64
 // CHECK-NEXT: store i64 {{%.*}}, ptr [[Alloca]]

--- a/clang/test/CodeGenHLSL/builtins/degrees.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/degrees.hlsl
@@ -37,3 +37,10 @@ float3 test_degrees_float3(float3 p0) { return degrees(p0); }
 // CHECK: [[MUL:%.*]] = fmul reassoc nnan ninf nsz arcp afn <4 x float> %{{.*}}, splat (float f0x42652EE1)
 // CHECK-NEXT: ret <4 x float> [[MUL]]
 float4 test_degrees_float4(float4 p0) { return degrees(p0); }
+
+// CHECK-LABEL: test_degrees_float5
+// CHECK: [[MUL:%.*]] = fmul reassoc nnan ninf nsz arcp afn <5 x float> %{{.*}}, splat (float f0x42652EE1)
+// CHECK-NEXT: ret <5 x float> [[MUL]]
+vector<float, 5> test_degrees_float5(vector<float, 5> p0) {
+	return degrees(p0);
+}

--- a/clang/test/CodeGenHLSL/builtins/lerp.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/lerp.hlsl
@@ -57,3 +57,14 @@ float3 test_lerp_float3(float3 p0, float3 p1, float3 p2) { return lerp(p0, p1, p
 // CHECK-NEXT: [[ADD:%.*]] = fadd reassoc nnan ninf nsz arcp afn <4 x float> [[MUL]], %{{.*}}
 // CHECK-NEXT: ret <4 x float> [[ADD]]
 float4 test_lerp_float4(float4 p0, float4 p1, float4 p2) { return lerp(p0, p1, p2); }
+
+// CHECK-LABEL: test_lerp_float5
+// CHECK: [[SUB:%.*]] = fsub reassoc nnan ninf nsz arcp afn <5 x float> %{{.*}}, %{{.*}}
+// CHECK-NEXT: [[MUL:%.*]] = fmul reassoc nnan ninf nsz arcp afn <5 x float> %{{.*}}, [[SUB]]
+// CHECK-NEXT: [[ADD:%.*]] = fadd reassoc nnan ninf nsz arcp afn <5 x float> [[MUL]], %{{.*}}
+// CHECK-NEXT: ret <5 x float> [[ADD]]
+vector<float, 5> test_lerp_float5(vector<float, 5> p0,
+							      vector<float, 5> p1,
+							      vector<float, 5> p2) {
+	return lerp(p0, p1, p2);
+}

--- a/clang/test/CodeGenHLSL/builtins/radians.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/radians.hlsl
@@ -37,3 +37,10 @@ float3 test_radians_float3(float3 p0) { return radians(p0); }
 // CHECK: [[MUL:%.*]] = fmul reassoc nnan ninf nsz arcp afn <4 x float> %{{.*}}, splat (float f0x3C8EFA35)
 // CHECK-NEXT: ret <4 x float> [[MUL]]
 float4 test_radians_float4(float4 p0) { return radians(p0); }
+
+// CHECK-LABEL: test_radians_float5
+// CHECK: [[MUL:%.*]] = fmul reassoc nnan ninf nsz arcp afn <5 x float> %{{.*}}, splat (float f0x3C8EFA35)
+// CHECK-NEXT: ret <5 x float> [[MUL]]
+vector<float, 5> test_radians_float5(vector<float, 5> p0) {
+	return radians(p0);
+}

--- a/clang/test/CodeGenHLSL/builtins/smoothstep.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/smoothstep.hlsl
@@ -174,20 +174,25 @@ float3 test_smoothstep_float3(float3 Min, float3 Max, float3 X) { return smooths
 //
 float4 test_smoothstep_float4(float4 Min, float4 Max, float4 X) { return smoothstep(Min, Max, X); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <5 x float> @{{.*}}test_smoothstep_float5
-// CHECK: [[SUB_I:%.*]] = fsub reassoc nnan ninf nsz arcp afn <5 x float> %{{.*}}, %{{.*}}
-// CHECK-NEXT: [[SUB1_I:%.*]] = fsub reassoc nnan ninf nsz arcp afn <5 x float> %{{.*}}, %{{.*}}
-// CHECK-NEXT: [[DIV_I:%.*]] = fdiv reassoc nnan ninf nsz arcp afn <5 x float> [[SUB_I]], [[SUB1_I]]
-// CHECK-NEXT: [[HLSL_SATURATE_I:%.*]] = tail call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.dx.saturate.v5f32(<5 x float> [[DIV_I]])
-// CHECK-NEXT: [[MUL_I:%.*]] = fmul reassoc nnan ninf nsz arcp afn <5 x float> [[HLSL_SATURATE_I]], splat (float 2.000000e+00)
-// CHECK-NEXT: [[SUB2_I:%.*]] = fsub reassoc nnan ninf nsz arcp afn <5 x float> splat (float 3.000000e+00), [[MUL_I]]
-// CHECK-NEXT: [[TMP0:%.*]] = fmul reassoc nnan ninf nsz arcp afn <5 x float> [[HLSL_SATURATE_I]], [[HLSL_SATURATE_I]]
-// CHECK-NEXT: [[MUL4_I:%.*]] = fmul reassoc nnan ninf nsz arcp afn <5 x float> [[TMP0]], [[SUB2_I]]
-// CHECK-NEXT: ret <5 x float> [[MUL4_I]]
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <5 x float> @_Z22test_smoothstep_float5Dv5_fS_S_(
+// CHECK-SAME: <5 x float> noundef nofpclass(nan inf) [[MIN:%.*]], <5 x float> noundef nofpclass(nan inf) [[MAX:%.*]], <5 x float> noundef nofpclass(nan inf) [[X:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[SUB_I:%.*]] = fsub reassoc nnan ninf nsz arcp afn <5 x float> [[X]], [[MIN]]
+// CHECK-NEXT:    [[SUB1_I:%.*]] = fsub reassoc nnan ninf nsz arcp afn <5 x float> [[MAX]], [[MIN]]
+// CHECK-NEXT:    [[DIV_I:%.*]] = fdiv reassoc nnan ninf nsz arcp afn <5 x float> [[SUB_I]], [[SUB1_I]]
+// CHECK-NEXT:    [[HLSL_SATURATE_I:%.*]] = tail call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.dx.saturate.v5f32(<5 x float> [[DIV_I]])
+// CHECK-NEXT:    [[MUL_I:%.*]] = fmul reassoc nnan ninf nsz arcp afn <5 x float> [[HLSL_SATURATE_I]], splat (float 2.000000e+00)
+// CHECK-NEXT:    [[SUB2_I:%.*]] = fsub reassoc nnan ninf nsz arcp afn <5 x float> splat (float 3.000000e+00), [[MUL_I]]
+// CHECK-NEXT:    [[TMP0:%.*]] = fmul reassoc nnan ninf nsz arcp afn <5 x float> [[HLSL_SATURATE_I]], [[HLSL_SATURATE_I]]
+// CHECK-NEXT:    [[MUL4_I:%.*]] = fmul reassoc nnan ninf nsz arcp afn <5 x float> [[TMP0]], [[SUB2_I]]
+// CHECK-NEXT:    ret <5 x float> [[MUL4_I]]
 //
-// SPVCHECK-LABEL: define hidden spir_func noundef nofpclass(nan inf) <5 x float> @{{.*}}test_smoothstep_float5
-// SPVCHECK: [[SPV_SMOOTHSTEP_I:%.*]] = tail call reassoc nnan ninf nsz arcp afn noundef nofpclass(nan inf) <5 x float> @llvm.spv.smoothstep.v5f32(<5 x float> nofpclass(nan inf) %{{.*}}, <5 x float> nofpclass(nan inf) %{{.*}}, <5 x float> nofpclass(nan inf) %{{.*}})
-// SPVCHECK-NEXT: ret <5 x float> [[SPV_SMOOTHSTEP_I]]
+// SPVCHECK-LABEL: define hidden spir_func noundef nofpclass(nan inf) <5 x float> @_Z22test_smoothstep_float5Dv5_fS_S_(
+// SPVCHECK-SAME: <5 x float> noundef nofpclass(nan inf) [[MIN:%.*]], <5 x float> noundef nofpclass(nan inf) [[MAX:%.*]], <5 x float> noundef nofpclass(nan inf) [[X:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// SPVCHECK-NEXT:  [[ENTRY:.*:]]
+// SPVCHECK-NEXT:    [[SPV_SMOOTHSTEP_I:%.*]] = tail call reassoc nnan ninf nsz arcp afn noundef nofpclass(nan inf) <5 x float> @llvm.spv.smoothstep.v5f32(<5 x float> nofpclass(nan inf) [[MIN]], <5 x float> nofpclass(nan inf) [[MAX]], <5 x float> nofpclass(nan inf) [[X]])
+// SPVCHECK-NEXT:    ret <5 x float> [[SPV_SMOOTHSTEP_I]]
+//
 vector<float, 5> test_smoothstep_float5(vector<float, 5> Min,
 										vector<float, 5> Max,
 										vector<float, 5> X) {

--- a/clang/test/CodeGenHLSL/builtins/smoothstep.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/smoothstep.hlsl
@@ -173,3 +173,23 @@ float3 test_smoothstep_float3(float3 Min, float3 Max, float3 X) { return smooths
 // SPVCHECK-NEXT:    ret <4 x float> [[SPV_SMOOTHSTEP_I]]
 //
 float4 test_smoothstep_float4(float4 Min, float4 Max, float4 X) { return smoothstep(Min, Max, X); }
+
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <5 x float> @{{.*}}test_smoothstep_float5
+// CHECK: [[SUB_I:%.*]] = fsub reassoc nnan ninf nsz arcp afn <5 x float> %{{.*}}, %{{.*}}
+// CHECK-NEXT: [[SUB1_I:%.*]] = fsub reassoc nnan ninf nsz arcp afn <5 x float> %{{.*}}, %{{.*}}
+// CHECK-NEXT: [[DIV_I:%.*]] = fdiv reassoc nnan ninf nsz arcp afn <5 x float> [[SUB_I]], [[SUB1_I]]
+// CHECK-NEXT: [[HLSL_SATURATE_I:%.*]] = tail call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.dx.saturate.v5f32(<5 x float> [[DIV_I]])
+// CHECK-NEXT: [[MUL_I:%.*]] = fmul reassoc nnan ninf nsz arcp afn <5 x float> [[HLSL_SATURATE_I]], splat (float 2.000000e+00)
+// CHECK-NEXT: [[SUB2_I:%.*]] = fsub reassoc nnan ninf nsz arcp afn <5 x float> splat (float 3.000000e+00), [[MUL_I]]
+// CHECK-NEXT: [[TMP0:%.*]] = fmul reassoc nnan ninf nsz arcp afn <5 x float> [[HLSL_SATURATE_I]], [[HLSL_SATURATE_I]]
+// CHECK-NEXT: [[MUL4_I:%.*]] = fmul reassoc nnan ninf nsz arcp afn <5 x float> [[TMP0]], [[SUB2_I]]
+// CHECK-NEXT: ret <5 x float> [[MUL4_I]]
+//
+// SPVCHECK-LABEL: define hidden spir_func noundef nofpclass(nan inf) <5 x float> @{{.*}}test_smoothstep_float5
+// SPVCHECK: [[SPV_SMOOTHSTEP_I:%.*]] = tail call reassoc nnan ninf nsz arcp afn noundef nofpclass(nan inf) <5 x float> @llvm.spv.smoothstep.v5f32(<5 x float> nofpclass(nan inf) %{{.*}}, <5 x float> nofpclass(nan inf) %{{.*}}, <5 x float> nofpclass(nan inf) %{{.*}})
+// SPVCHECK-NEXT: ret <5 x float> [[SPV_SMOOTHSTEP_I]]
+vector<float, 5> test_smoothstep_float5(vector<float, 5> Min,
+										vector<float, 5> Max,
+										vector<float, 5> X) {
+	return smoothstep(Min, Max, X);
+}

--- a/clang/test/CodeGenHLSL/builtins/step.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/step.hlsl
@@ -67,3 +67,13 @@ float4 test_step_float4(float4 p0, float4 p1)
 {
     return step(p0, p1);
 }
+
+// CHECK-LABEL: test_step_float5
+// CHECK: [[CMP:%.*]] = fcmp reassoc nnan ninf nsz arcp afn olt <5 x float> %p1, %p0
+// CHECK-NEXT: [[SPLAT:%.*]] = shufflevector <5 x i1> [[CMP]], <5 x i1> poison, <5 x i32> zeroinitializer
+// CHECK-NEXT: [[SELECT:%.*]] = select reassoc nnan ninf nsz arcp afn <5 x i1> [[SPLAT]], <5 x float> zeroinitializer, <5 x float> splat (float 1.000000e+00)
+// CHECK-NEXT: ret <5 x float> [[SELECT]]
+vector<float, 5> test_step_float5(vector<float, 5> p0,
+                                  vector<float, 5> p1) {
+    return step(p0, p1);
+}

--- a/clang/test/CodeGenHLSL/builtins/step.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/step.hlsl
@@ -70,8 +70,7 @@ float4 test_step_float4(float4 p0, float4 p1)
 
 // CHECK-LABEL: test_step_float5
 // CHECK: [[CMP:%.*]] = fcmp reassoc nnan ninf nsz arcp afn olt <5 x float> %p1, %p0
-// CHECK-NEXT: [[SPLAT:%.*]] = shufflevector <5 x i1> [[CMP]], <5 x i1> poison, <5 x i32> zeroinitializer
-// CHECK-NEXT: [[SELECT:%.*]] = select reassoc nnan ninf nsz arcp afn <5 x i1> [[SPLAT]], <5 x float> zeroinitializer, <5 x float> splat (float 1.000000e+00)
+// CHECK-NEXT: [[SELECT:%.*]] = select reassoc nnan ninf nsz arcp afn <5 x i1> [[CMP]], <5 x float> zeroinitializer, <5 x float> splat (float 1.000000e+00)
 // CHECK-NEXT: ret <5 x float> [[SELECT]]
 vector<float, 5> test_step_float5(vector<float, 5> p0,
                                   vector<float, 5> p1) {

--- a/clang/test/SemaHLSL/BuiltIns/smoothstep-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/smoothstep-errors.hlsl
@@ -4,18 +4,24 @@ float test_no_second_arg(float2 p0) {
   return smoothstep(p0);
   // expected-error@-1 {{no matching function for call to 'smoothstep'}}
   // expected-note@hlsl/hlsl_inline_intrinsics_gen.inc:* 8 {{candidate function not viable: requires 3 arguments, but 1 was provided}}
+  // expected-note@hlsl/hlsl_inline_intrinsics_gen.inc:* 2 {{candidate function template not viable: requires 3 arguments, but 1 was provided}}
+
 }
 
 float test_no_third_arg(float2 p0) {
   return smoothstep(p0, p0);
   // expected-error@-1 {{no matching function for call to 'smoothstep'}}
   // expected-note@hlsl/hlsl_inline_intrinsics_gen.inc:* 8 {{candidate function not viable: requires 3 arguments, but 2 were provided}}
+  // expected-note@hlsl/hlsl_inline_intrinsics_gen.inc:* 2 {{candidate function template not viable: requires 3 arguments, but 2 were provided}}
+
 }
 
 float test_too_many_arg(float2 p0) {
   return smoothstep(p0, p0, p0, p0);
   // expected-error@-1 {{no matching function for call to 'smoothstep'}}
   // expected-note@hlsl/hlsl_inline_intrinsics_gen.inc:* 8 {{candidate function not viable: requires 3 arguments, but 4 were provided}}
+  // expected-note@hlsl/hlsl_inline_intrinsics_gen.inc:* 2 {{candidate function template not viable: requires 3 arguments, but 4 were provided}}
+
 }
 
 float test_double_inputs(double p0, double p1, double p2) {
@@ -33,12 +39,4 @@ float test_int_inputs(int p0, int p1, int p2) {
 float1 test_vec1_inputs(float1 p0, float1 p1, float1 p2) {
   return smoothstep(p0, p1, p2);
   // expected-warning@-1 3 {{implicit conversion turns vector to scalar: 'float1' (aka 'vector<float, 1>') to 'float'}}
-}
-
-typedef float float5 __attribute__((ext_vector_type(5)));
-
-float5 test_vec5_inputs(float5 p0, float5 p1, float5 p2) {
-  return smoothstep(p0, p1, p2);
-  // expected-error@-1  {{call to 'smoothstep' is ambiguous}}
-  // expected-note@hlsl/hlsl_inline_intrinsics_gen.inc:* 4 {{candidate function}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/smoothstep-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/smoothstep-errors.hlsl
@@ -5,7 +5,6 @@ float test_no_second_arg(float2 p0) {
   // expected-error@-1 {{no matching function for call to 'smoothstep'}}
   // expected-note@hlsl/hlsl_inline_intrinsics_gen.inc:* 8 {{candidate function not viable: requires 3 arguments, but 1 was provided}}
   // expected-note@hlsl/hlsl_inline_intrinsics_gen.inc:* 2 {{candidate function template not viable: requires 3 arguments, but 1 was provided}}
-
 }
 
 float test_no_third_arg(float2 p0) {
@@ -13,7 +12,6 @@ float test_no_third_arg(float2 p0) {
   // expected-error@-1 {{no matching function for call to 'smoothstep'}}
   // expected-note@hlsl/hlsl_inline_intrinsics_gen.inc:* 8 {{candidate function not viable: requires 3 arguments, but 2 were provided}}
   // expected-note@hlsl/hlsl_inline_intrinsics_gen.inc:* 2 {{candidate function template not viable: requires 3 arguments, but 2 were provided}}
-
 }
 
 float test_too_many_arg(float2 p0) {
@@ -21,7 +19,6 @@ float test_too_many_arg(float2 p0) {
   // expected-error@-1 {{no matching function for call to 'smoothstep'}}
   // expected-note@hlsl/hlsl_inline_intrinsics_gen.inc:* 8 {{candidate function not viable: requires 3 arguments, but 4 were provided}}
   // expected-note@hlsl/hlsl_inline_intrinsics_gen.inc:* 2 {{candidate function template not viable: requires 3 arguments, but 4 were provided}}
-
 }
 
 float test_double_inputs(double p0, double p1, double p2) {

--- a/clang/test/SemaHLSL/BuiltIns/step-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/step-errors.hlsl
@@ -5,6 +5,7 @@ void test_too_few_arg()
   return step();
   // expected-error@-1 {{no matching function for call to 'step'}}
   // expected-note@hlsl/hlsl_inline_intrinsics_gen.inc:* 8 {{candidate function not viable: requires 2 arguments, but 0 were provided}}
+  // expected-note@hlsl/hlsl_inline_intrinsics_gen.inc:* 2 {{candidate function template not viable: requires 2 arguments, but 0 were provided}}
   // expected-note@hlsl/hlsl_compat_overloads.h:* 20 {{candidate function not viable: requires 2 arguments, but 0 were provided}}
 }
 
@@ -13,6 +14,7 @@ void test_too_many_arg(float2 p0)
   return step(p0, p0, p0);
   // expected-error@-1 {{no matching function for call to 'step'}}
   // expected-note@hlsl/hlsl_inline_intrinsics_gen.inc:* 8 {{candidate function not viable: requires 2 arguments, but 3 were provided}}
+  // expected-note@hlsl/hlsl_inline_intrinsics_gen.inc:* 2 {{candidate function template not viable: requires 2 arguments, but 3 were provided}}
   // expected-note@hlsl/hlsl_compat_overloads.h:* 20 {{candidate function not viable: requires 2 arguments, but 3 were provided}}
 }
 
@@ -27,13 +29,4 @@ float1 test_vec1_inputs(float1 p0, float1 p1)
 {
   return step(p0, p1);
   // expected-warning@-1 2 {{implicit conversion turns vector to scalar: 'float1' (aka 'vector<float, 1>') to 'float'}}
-}
-
-typedef float float5 __attribute__((ext_vector_type(5)));
-
-float5 test_vec5_inputs(float5 p0, float5 p1)
-{
-  return step(p0, p1);
-  // expected-error@-1 {{call to 'step' is ambiguous}}
-  // expected-note@hlsl/hlsl_inline_intrinsics_gen.inc:* 4 {{candidate function}}
 }


### PR DESCRIPTION
resolves https://github.com/llvm/llvm-project/issues/217716

The last pr only added them to clang builtins with the "__builtin_elementwise" prefix. This adds the long vector support to the ones written entirely in hlsl.