### PR TITLE
[DebugInfo] Ignore undefined constexpr constructors in constructor homing.

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -3239,11 +3239,17 @@ static bool canUseCtorHoming(const CXXRecordDecl *RD) {
   if (isClassOrMethodDLLImport(RD))
     return false;
 
-  if (RD->isLambda() || RD->isAggregate() ||
-      RD->hasTrivialDefaultConstructor() ||
-      RD->hasConstexprNonCopyMoveConstructor())
+  if (RD->isLambda() || RD->isAggregate() || RD->hasTrivialDefaultConstructor())
     return false;
 
+  // Skip this optimization if the class has an implicit constexpr default
+  // constructor, since those constructors can be invoked without emitting type
+  // information for the constructor.
+  if (RD->needsImplicitDefaultConstructor() &&
+      RD->defaultedDefaultConstructorIsConstexpr())
+    return false;
+
+  bool HasNonDeletedCtor = false;
   for (const CXXConstructorDecl *Ctor : RD->ctors()) {
     if (Ctor->isCopyOrMoveConstructor())
       continue;
@@ -3254,11 +3260,15 @@ static bool canUseCtorHoming(const CXXRecordDecl *RD) {
       // copy/move constructor, which does not enable homing.
       if (CtorDef->isDelegatingConstructor())
         continue;
+      // Skip this optimization if we see a defined constexpr constructor, which
+      // can be invoked without emitting type info.
+      if (Ctor->isConstexpr() && !Ctor->isDeleted())
+        return false;
     }
     if (!Ctor->isDeleted())
-      return true;
+      HasNonDeletedCtor = true;
   }
-  return false;
+  return HasNonDeletedCtor;
 }
 
 static bool shouldOmitDefinition(llvm::codegenoptions::DebugInfoKind DebugKind,

--- a/clang/test/DebugInfo/CXX/limited-ctor.cpp
+++ b/clang/test/DebugInfo/CXX/limited-ctor.cpp
@@ -27,6 +27,19 @@ struct E {
   constexpr E(){};
 } TestE;
 
+// Declared but not defined constexpr constructor should not emit full debug info..
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "DeclaredConstexpr"{{.*}}flags: DIFlagFwdDecl
+struct DeclaredConstexpr {
+  constexpr DeclaredConstexpr();
+} TestDeclaredConstexpr;
+
+// Defined out-of-line constexpr constructor should emit full debug info.
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "OutOfLineConstexpr"{{.*}}DIFlagTypePassByValue
+struct OutOfLineConstexpr {
+  constexpr OutOfLineConstexpr();
+} TestOutOfLineConstexpr;
+constexpr OutOfLineConstexpr::OutOfLineConstexpr() {}
+
 // Defined delegating constructor where delegated constructor is not defined
 // should not emit full debug info.
 // CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "Delegating"{{.*}}flags: DIFlagFwdDecl
@@ -102,6 +115,25 @@ struct DelegatingToMoveCtor {
 };
 void TestDelegatingToMoveCtor(DelegatingToMoveCtor) {}
 
+// Defined delegating constexpr constructor where delegated constructor is also
+// defined should emit full debug info.
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "DelegatingConstexpr"{{.*}}DIFlagTypePassByValue
+struct DelegatingConstexpr {
+  constexpr DelegatingConstexpr() : DelegatingConstexpr(42) {}
+  constexpr DelegatingConstexpr(int) {}
+} TestDelegatingConstexpr;
+
+// Defined out-of-line delegating constexpr constructor where delegated
+// constructor is also defined out-of-line should emit full debug info.
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "DelegatingConstexprOutOfLine"{{.*}}DIFlagTypePassByValue
+struct DelegatingConstexprOutOfLine {
+  constexpr DelegatingConstexprOutOfLine();
+  constexpr DelegatingConstexprOutOfLine(int);
+} TestDelegatingConstexprOutOfLine;
+constexpr DelegatingConstexprOutOfLine::DelegatingConstexprOutOfLine()
+    : DelegatingConstexprOutOfLine(42) {}
+constexpr DelegatingConstexprOutOfLine::DelegatingConstexprOutOfLine(int) {}
+
 // Test for trivial constructor.
 // CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "F"{{.*}}DIFlagTypePassByValue
 struct F {
@@ -149,6 +181,7 @@ struct NonTrivial {
 };
 struct DeletedCtors {
   DeletedCtors() = delete;
+  constexpr DeletedCtors(int) = delete;
   DeletedCtors(const DeletedCtors &) = default;
   void f1();
   NonTrivial t;


### PR DESCRIPTION
The constructor homing optimization limits the amount of redundant debug info generated for classes by only emitting forward declarations to debug info in translation units that can't instantiate the class on their own (i.e. they don't see the definitions of any constructors).

Currently, classes that have _any_ constexpr constructors are excluded from the optimization. This is being changed to only exclude _defined_ constexpr constructors, as declared constexpr constructors are not callable in a TU that doesn't see their definition.