### PR TITLE
[Clang][Parse] Fix crash on a coroutine keyword in a mem-initializer

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -605,6 +605,8 @@ features cannot lower the translation-unit ABI level;
   available as an identifier (e.g. `struct __make_unsigned`) was seen again
   in a token that was lexed and cached before the first occurrence was parsed.
   (#GH214128)
+- Fixed a crash when a coroutine keyword appeared inside a mem-initializer on a
+  function that is not a constructor. (#GH194298)
 
 #### Bug Fixes to AST Handling
 

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -7738,6 +7738,17 @@ public:
   ///
   Decl *ParseFunctionTryBlock(Decl *Decl, ParseScope &BodyScope);
 
+  /// ParseFunctionBody - Parse the body of a function definition. The
+  /// '= default' and '= delete' forms are handled by the caller.
+  ///
+  /// \verbatim
+  ///       function-body:
+  ///         ctor-initializer[opt] compound-statement
+  ///         function-try-block
+  /// \endverbatim
+  ///
+  Decl *ParseFunctionBody(Decl *D, ParseScope &BodyScope);
+
   /// When in code-completion, skip parsing of the function/method body
   /// unless the body contains the code-completion point.
   ///

--- a/clang/lib/Parse/ParseCXXInlineMethods.cpp
+++ b/clang/lib/Parse/ParseCXXInlineMethods.cpp
@@ -623,23 +623,6 @@ void Parser::ParseLexedMethodDef(LexedMethod &LM) {
         Actions.ActOnFinishInlineFunctionDef(FD);
   });
 
-  if (Tok.is(tok::kw_try)) {
-    ParseFunctionTryBlock(LM.D, FnScope);
-    return;
-  }
-  if (Tok.is(tok::colon)) {
-    ParseConstructorInitializer(LM.D);
-
-    // Error recovery.
-    if (!Tok.is(tok::l_brace)) {
-      FnScope.Exit();
-      LM.D->getAsFunction()->setInvalidDecl();
-      Actions.ActOnFinishFunctionBody(LM.D, nullptr);
-      return;
-    }
-  } else
-    Actions.ActOnDefaultCtorInitializers(LM.D);
-
   assert((Actions.getDiagnostics().hasErrorOccurred() ||
           !isa<FunctionTemplateDecl>(LM.D) ||
           cast<FunctionTemplateDecl>(LM.D)->getTemplateParameters()->getDepth()
@@ -647,7 +630,7 @@ void Parser::ParseLexedMethodDef(LexedMethod &LM) {
          "TemplateParameterDepth should be greater than the depth of "
          "current template being instantiated!");
 
-  ParseFunctionStatementBody(LM.D, FnScope);
+  ParseFunctionBody(LM.D, FnScope);
 }
 
 void Parser::ParseLexedMemberInitializers(ParsingClass &Class) {

--- a/clang/lib/Parse/ParseCXXInlineMethods.cpp
+++ b/clang/lib/Parse/ParseCXXInlineMethods.cpp
@@ -633,6 +633,7 @@ void Parser::ParseLexedMethodDef(LexedMethod &LM) {
     // Error recovery.
     if (!Tok.is(tok::l_brace)) {
       FnScope.Exit();
+      LM.D->getAsFunction()->setInvalidDecl();
       Actions.ActOnFinishFunctionBody(LM.D, nullptr);
       return;
     }

--- a/clang/lib/Parse/ParseObjc.cpp
+++ b/clang/lib/Parse/ParseObjc.cpp
@@ -3306,15 +3306,7 @@ void Parser::ParseLexedObjCMethodDefs(LexedMethod &LM, bool parseMethod) {
     Actions.ObjC().ActOnStartOfObjCMethodDef(getCurScope(), MCDecl);
   else
     Actions.ActOnStartOfFunctionDef(getCurScope(), MCDecl);
-  if (Tok.is(tok::kw_try))
-    ParseFunctionTryBlock(MCDecl, BodyScope);
-  else {
-    if (Tok.is(tok::colon))
-      ParseConstructorInitializer(MCDecl);
-    else
-      Actions.ActOnDefaultCtorInitializers(MCDecl);
-    ParseFunctionStatementBody(MCDecl, BodyScope);
-  }
+  ParseFunctionBody(MCDecl, BodyScope);
 
   if (Tok.getLocation() != OrigLoc) {
     // Due to parsing error, we either went over the cached tokens or

--- a/clang/lib/Parse/ParseTemplate.cpp
+++ b/clang/lib/Parse/ParseTemplate.cpp
@@ -1511,28 +1511,15 @@ void Parser::ParseLateTemplatedFuncDef(LateParsedTemplate &LPT) {
 
   Actions.ActOnStartOfFunctionDef(getCurScope(), FunD);
 
-  if (Tok.is(tok::kw_try)) {
-    ParseFunctionTryBlock(LPT.D, FnScope);
-  } else {
-    if (Tok.is(tok::colon))
-      ParseConstructorInitializer(LPT.D);
-    else
-      Actions.ActOnDefaultCtorInitializers(LPT.D);
+  assert((!isa<FunctionTemplateDecl>(LPT.D) ||
+          cast<FunctionTemplateDecl>(LPT.D)
+                  ->getTemplateParameters()
+                  ->getDepth() == TemplateParameterDepth - 1) &&
+         "TemplateParameterDepth should be greater than the depth of "
+         "current template being instantiated!");
 
-    if (Tok.is(tok::l_brace)) {
-      assert((!isa<FunctionTemplateDecl>(LPT.D) ||
-              cast<FunctionTemplateDecl>(LPT.D)
-                      ->getTemplateParameters()
-                      ->getDepth() == TemplateParameterDepth - 1) &&
-             "TemplateParameterDepth should be greater than the depth of "
-             "current template being instantiated!");
-      ParseFunctionStatementBody(LPT.D, FnScope);
-      Actions.UnmarkAsLateParsedTemplate(FunD);
-    } else {
-      FunD->setInvalidDecl();
-      Actions.ActOnFinishFunctionBody(LPT.D, nullptr);
-    }
-  }
+  ParseFunctionBody(LPT.D, FnScope);
+  Actions.UnmarkAsLateParsedTemplate(FunD);
 }
 
 void Parser::LexTemplateFunctionForLateParsing(CachedTokens &Toks) {

--- a/clang/lib/Parse/ParseTemplate.cpp
+++ b/clang/lib/Parse/ParseTemplate.cpp
@@ -1511,12 +1511,12 @@ void Parser::ParseLateTemplatedFuncDef(LateParsedTemplate &LPT) {
 
   Actions.ActOnStartOfFunctionDef(getCurScope(), FunD);
 
-  assert((!isa<FunctionTemplateDecl>(LPT.D) ||
-          cast<FunctionTemplateDecl>(LPT.D)
-                  ->getTemplateParameters()
-                  ->getDepth() == TemplateParameterDepth - 1) &&
-         "TemplateParameterDepth should be greater than the depth of "
-         "current template being instantiated!");
+  assert(
+      (!isa<FunctionTemplateDecl>(LPT.D) ||
+       cast<FunctionTemplateDecl>(LPT.D)->getTemplateParameters()->getDepth() ==
+           TemplateParameterDepth - 1) &&
+      "TemplateParameterDepth should be greater than the depth of "
+      "current template being instantiated!");
 
   ParseFunctionBody(LPT.D, FnScope);
   Actions.UnmarkAsLateParsedTemplate(FunD);

--- a/clang/lib/Parse/ParseTemplate.cpp
+++ b/clang/lib/Parse/ParseTemplate.cpp
@@ -1528,8 +1528,10 @@ void Parser::ParseLateTemplatedFuncDef(LateParsedTemplate &LPT) {
              "current template being instantiated!");
       ParseFunctionStatementBody(LPT.D, FnScope);
       Actions.UnmarkAsLateParsedTemplate(FunD);
-    } else
+    } else {
+      FunD->setInvalidDecl();
       Actions.ActOnFinishFunctionBody(LPT.D, nullptr);
+    }
   }
 }
 

--- a/clang/lib/Parse/ParseTemplate.cpp
+++ b/clang/lib/Parse/ParseTemplate.cpp
@@ -1517,8 +1517,10 @@ void Parser::ParseLateTemplatedFuncDef(LateParsedTemplate &LPT) {
              "current template being instantiated!");
       ParseFunctionStatementBody(LPT.D, FnScope);
       Actions.UnmarkAsLateParsedTemplate(FunD);
-    } else
+    } else {
+      FunD->setInvalidDecl();
       Actions.ActOnFinishFunctionBody(LPT.D, nullptr);
+    }
   }
 }
 

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -1396,26 +1396,30 @@ Decl *Parser::ParseFunctionDefinition(ParsingDeclarator &D,
     return Actions.ActOnFinishFunctionBody(Res, nullptr, false);
   }
 
+  return ParseFunctionBody(Res, BodyScope);
+}
+
+Decl *Parser::ParseFunctionBody(Decl *D, ParseScope &BodyScope) {
   if (Tok.is(tok::kw_try))
-    return ParseFunctionTryBlock(Res, BodyScope);
+    return ParseFunctionTryBlock(D, BodyScope);
 
   // If we have a colon, then we're probably parsing a C++
   // ctor-initializer.
   if (Tok.is(tok::colon)) {
-    ParseConstructorInitializer(Res);
+    ParseConstructorInitializer(D);
 
     // Recover from error.
     if (!Tok.is(tok::l_brace)) {
       BodyScope.Exit();
-      if (Res)
-        Res->getAsFunction()->setInvalidDecl();
-      Actions.ActOnFinishFunctionBody(Res, nullptr);
-      return Res;
+      if (D)
+        D->getAsFunction()->setInvalidDecl();
+      Actions.ActOnFinishFunctionBody(D, nullptr);
+      return D;
     }
   } else
-    Actions.ActOnDefaultCtorInitializers(Res);
+    Actions.ActOnDefaultCtorInitializers(D);
 
-  return ParseFunctionStatementBody(Res, BodyScope);
+  return ParseFunctionStatementBody(D, BodyScope);
 }
 
 void Parser::SkipFunctionBody() {

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -1407,6 +1407,8 @@ Decl *Parser::ParseFunctionDefinition(ParsingDeclarator &D,
     // Recover from error.
     if (!Tok.is(tok::l_brace)) {
       BodyScope.Exit();
+      if (Res)
+        Res->getAsFunction()->setInvalidDecl();
       Actions.ActOnFinishFunctionBody(Res, nullptr);
       return Res;
     }

--- a/clang/test/SemaCXX/coroutines.cpp
+++ b/clang/test/SemaCXX/coroutines.cpp
@@ -1568,7 +1568,6 @@ void g() {
 }
 
 namespace GH194298 {
-// https://github.com/llvm/llvm-project/issues/194298
 coro<promise_void> f1() : bar { co_await suspend_always{} }; // expected-error {{only constructors take base initializers}}
 coro<promise> f2() : bar { co_yield 0 }; // expected-error {{only constructors take base initializers}}
 coro<promise_void> f3() : bar { co_return }; // expected-error {{expected expression}} \

--- a/clang/test/SemaCXX/coroutines.cpp
+++ b/clang/test/SemaCXX/coroutines.cpp
@@ -1566,3 +1566,11 @@ void g() {
 }
 
 }
+
+namespace GH194298 {
+// https://github.com/llvm/llvm-project/issues/194298
+coro<promise_void> f1() : bar { co_await suspend_always{} }; // expected-error {{only constructors take base initializers}}
+coro<promise> f2() : bar { co_yield 0 }; // expected-error {{only constructors take base initializers}}
+coro<promise_void> f3() : bar { co_return }; // expected-error {{expected expression}} \
+                                             // expected-error {{only constructors take base initializers}}
+}

--- a/clang/test/SemaCXX/coroutines.cpp
+++ b/clang/test/SemaCXX/coroutines.cpp
@@ -1572,4 +1572,9 @@ coro<promise_void> f1() : bar { co_await suspend_always{} }; // expected-error {
 coro<promise> f2() : bar { co_yield 0 }; // expected-error {{only constructors take base initializers}}
 coro<promise_void> f3() : bar { co_return }; // expected-error {{expected expression}} \
                                              // expected-error {{only constructors take base initializers}}
+coro<good_promise_13> f4() try : bar { co_await suspend_always{} } { } catch (...) {} // expected-error {{only constructors take base initializers}}
+struct S {
+  coro<good_promise_13> m1() : bar { co_await suspend_always{} } { } // expected-error {{only constructors take base initializers}}
+  coro<good_promise_13> m2() try : bar { co_await suspend_always{} } { } catch (...) {} // expected-error {{only constructors take base initializers}}
+};
 }


### PR DESCRIPTION
Hi, this is my first contribution to the LLVM project, so please let me know if there is anything I should follow when contributing.

Simply fixes https://github.com/llvm/llvm-project/issues/194298
- If a function has a ":" symbol in its declaration, the following "{" symbol is interpreted as an initializer, not as the function body.
- Hence, the function is interpreted as a function declaration without a body.
- Meanwhile, "co_await" marks the function as a coroutine, so it tries to find the function body and crashes while accessing it.
- This diff marks the function as invalid if there is an initializer but no actual function body.

I utilized AI while trying to understand why this change makes sense as much as possible.

Assisted-by: Claude Opus 5 (Claude Code)