### PR TITLE
[libc++] Add test for LWG4043 ASCII in text_encoding

### DIFF
--- a/libcxx/docs/Status/Cxx26Issues.csv
+++ b/libcxx/docs/Status/Cxx26Issues.csv
@@ -57,7 +57,7 @@
 "`LWG4036 <https://wg21.link/LWG4036>`__","``__alignof_is_defined`` is only implicitly specified in C++ and not yet deprecated","2024-03 (Tokyo)","","","`#105329 <https://github.com/llvm/llvm-project/issues/105329>`__",""
 "`LWG4037 <https://wg21.link/LWG4037>`__","Static data members of ``ctype_base`` are not yet required to be usable in constant expressions","2024-03 (Tokyo)","","","`#105330 <https://github.com/llvm/llvm-project/issues/105330>`__",""
 "`LWG4038 <https://wg21.link/LWG4038>`__","``std::text_encoding::aliases_view`` should have constexpr iterators","2024-03 (Tokyo)","|Complete|","23","`#105332 <https://github.com/llvm/llvm-project/issues/105332>`__",""
-"`LWG4043 <https://wg21.link/LWG4043>`__","""ASCII"" is not a registered character encoding","2024-03 (Tokyo)","|Nothing To Do|","","`#105335 <https://github.com/llvm/llvm-project/issues/105335>`__",""
+"`LWG4043 <https://wg21.link/LWG4043>`__","""ASCII"" is not a registered character encoding","2024-03 (Tokyo)","|Complete|","23","`#105335 <https://github.com/llvm/llvm-project/issues/105335>`__",""
 "`LWG4045 <https://wg21.link/LWG4045>`__","``tuple`` can create dangling references from ``tuple-like``","2024-03 (Tokyo)","","","`#105337 <https://github.com/llvm/llvm-project/issues/105337>`__",""
 "`LWG4053 <https://wg21.link/LWG4053>`__","Unary call to ``std::views::repeat`` does not decay the argument","2024-03 (Tokyo)","|Complete|","19","`#105338 <https://github.com/llvm/llvm-project/issues/105338>`__",""
 "`LWG4054 <https://wg21.link/LWG4054>`__","Repeating a ``repeat_view`` should repeat the view","2024-03 (Tokyo)","|Complete|","19","`#105340 <https://github.com/llvm/llvm-project/issues/105340>`__",""

--- a/libcxx/test/support/test_text_encoding.h
+++ b/libcxx/test/support/test_text_encoding.h
@@ -293,6 +293,7 @@ constexpr inline enc_data all_encoding_data[] = {
     {3, "ISO_646.irv:1991"},
     {3, "cp367"},
     {3, "csASCII"},
+    {3, "ASCII"},
     {3, "iso-ir-6"},
     {3, "us"},
     {4, "ISO-8859-1"},


### PR DESCRIPTION
It turns out the ASCII entry was not an extension as I had initially thought, and was added as part of the resolution of LWG 4043. Update the test and correct the status page.

Resolves #209899