### PR TITLE
[clang][bytecode] Use a SmallPtrSet in collectBlocks()

### DIFF
--- a/clang/lib/AST/ByteCode/EvaluationResult.cpp
+++ b/clang/lib/AST/ByteCode/EvaluationResult.cpp
@@ -11,7 +11,7 @@
 #include "Pointer.h"
 #include "Record.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include <iterator>
 
 namespace clang {
@@ -171,7 +171,8 @@ static bool isOrHasPtr(const Descriptor *D) {
   return false;
 }
 
-static void collectBlocks(PtrView Ptr, llvm::SetVector<const Block *> &Blocks,
+static void collectBlocks(PtrView Ptr,
+                          llvm::SmallPtrSet<const Block *, 4> &Blocks,
                           bool IsCompleteClass = true) {
   auto isUsefulPtr = [](const Pointer &P) -> bool {
     return P.isLive() && P.isBlockPointer() && !P.isZero() && !P.isDummy() &&
@@ -250,7 +251,7 @@ bool EvaluationResult::checkDynamicAllocations(InterpState &S,
     return true;
   // Collect all blocks that this pointer (transitively) points to and
   // return false if any of them is a dynamic block.
-  llvm::SetVector<const Block *> Blocks;
+  llvm::SmallPtrSet<const Block *, 4> Blocks;
 
   collectBlocks(Ptr.view(), Blocks);
 


### PR DESCRIPTION
Not sure why I used a SetVector here, but switch it to a SmallPtrSet (this also gets rid of an additional include when #186045 gets merged).