### PR TITLE
workflows/release-binaries-all: Use self-repository reference for actions

### DIFF
--- a/.github/workflows/release-binaries-all.yml
+++ b/.github/workflows/release-binaries-all.yml
@@ -68,16 +68,9 @@ jobs:
       release-version: ${{ steps.vars.outputs.release-version }}
       upload: ${{ steps.vars.outputs.upload }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          sparse-checkout: |
-            .github/workflows/validate-release-version
-          sparse-checkout-cone-mode: false
-
       - name: Validate Input
         if: inputs.release-version != ''
-        uses: ./.github/workflows/validate-release-version
+        uses: $/.github/workflows/validate-release-version
         with:
           release-version: ${{ inputs.release-version }}
       - shell: bash


### PR DESCRIPTION
This allows us to skip a checkout step.

https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/