### PR TITLE
[SSAF][EntityPointerLevel] Add an intermediate data structure DeclPointerLevel

### DIFF
--- a/clang/include/clang/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevel.h
+++ b/clang/include/clang/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevel.h
@@ -12,9 +12,20 @@
 #include "clang/AST/Expr.h"
 #include "clang/ScalableStaticAnalysis/Core/Model/EntityId.h"
 #include <set>
+#include <vector>
 
 namespace clang::ssaf {
 class TUSummaryExtractor;
+
+// Intermediate data structure that can be converted to a `EntityPointerLevel`,
+// which abstracts away all the additional information carried in the NamedDecl.
+struct DeclPointerLevel {
+  const NamedDecl *Decl;
+  unsigned PointerLevel;
+  bool IsReturn;
+};
+
+using DeclPointerLevels = std::vector<DeclPointerLevel>;
 
 /// An EntityPointerLevel is associated with a level of the declared
 /// pointer/array type of an entity.  In the fully-expanded spelling of the
@@ -90,15 +101,42 @@ using EntityPointerLevelSet =
 ///
 /// \param E the pointer expression to be translated
 /// \param Ctx the AST context of `E`
-/// \param AddEntity the callback provided by the caller to convert EntityNames
-/// to EntityIds.
+/// \param Extractor the TUSummaryExtractor used to convert NamedDecls to
+/// EntityIds.
 llvm::Expected<EntityPointerLevelSet>
 translateEntityPointerLevel(const Expr *E, ASTContext &Ctx,
                             TUSummaryExtractor &Extractor);
 
+/// Same as `translateEntityPointerLevel`, except it returns raw
+/// `(NamedDecl *, pointer level, is-return)` tuples (a.k.a. DeclPointerLevels)
+/// instead of assembling an `EntityPointerLevelSet` directly.
+llvm::Expected<DeclPointerLevels>
+translateDeclPointerLevel(const Expr *E, ASTContext &Ctx,
+                          TUSummaryExtractor &Extractor);
+
+/// Assemble `(NamedDecl *, pointer level, is-return)` tuples (a.k.a.
+/// DeclPointerLevels) to `EntityPointerLevelSet`.
+Expected<EntityPointerLevelSet>
+toEntityPointerLevels(const DeclPointerLevels &DPLs, ASTContext &Ctx,
+                      TUSummaryExtractor &Extractor);
+
+/// Convert a single `(NamedDecl *, pointer level, is-return)` tuple (a.k.a.
+/// DeclPointerLevel) to an `EntityPointerLevel`.
+Expected<EntityPointerLevel>
+toEntityPointerLevel(const DeclPointerLevel &DPL, ASTContext &Ctx,
+                     TUSummaryExtractor &Extractor);
+
 /// Creates a `EntityPointerLevel` from a pair of an EntityId and a pointer
 /// level:
 EntityPointerLevel buildEntityPointerLevel(EntityId, unsigned);
+
+/// Create an DeclPointerLevel (DPL) from a NamedDecl of a pointer/array type.
+///
+/// \param ND the NamedDecl of a pointer/array type.
+/// \param IsFunRet true iff the created DPL is associated with the return type
+/// of a function entity.
+DeclPointerLevel createDeclPointerLevel(const NamedDecl *ND,
+                                        bool IsFunRet = false);
 
 /// Create an EntityPointerLevel (EPL) from a NamedDecl of a pointer/array type.
 ///
@@ -110,6 +148,12 @@ EntityPointerLevel buildEntityPointerLevel(EntityId, unsigned);
 llvm::Expected<EntityPointerLevel>
 createEntityPointerLevel(const NamedDecl *ND, TUSummaryExtractor &Extractor,
                          bool IsFunRet = false);
+
+/// \return an exhaustive vector of DeclPointerLevels, sorted in ascending order
+/// of pointer level, such that every element is identical to \p DPL except with
+/// a no-lower-than pointer level. The pointer level of each element is bounded
+/// by the type of the NamedDecl of \p DPL.
+DeclPointerLevels elaborateHigherDeclPointerLevels(const DeclPointerLevel &DPL);
 
 /// Creates a new EntityPointerLevel (EPL) from `E` by incrementing `E`'s
 /// pointer level.

--- a/clang/include/clang/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevel.h
+++ b/clang/include/clang/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevel.h
@@ -151,7 +151,8 @@ createEntityPointerLevel(const NamedDecl *ND, TUSummaryExtractor &Extractor,
 /// ascending order of pointer levels. All elements are identical to \p DPL
 /// except with a pointer level greater than or equal to that of \p DPL. The
 /// pointer level of each element is bounded by the type of \p DPL's NamedDecl.
-DeclPointerLevelVec elaborateHigherDeclPointerLevels(const DeclPointerLevel &DPL);
+DeclPointerLevelVec
+elaborateHigherDeclPointerLevels(const DeclPointerLevel &DPL);
 
 /// Creates a new EntityPointerLevel (EPL) from `E` by incrementing `E`'s
 /// pointer level.

--- a/clang/include/clang/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevel.h
+++ b/clang/include/clang/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevel.h
@@ -107,7 +107,7 @@ llvm::Expected<EntityPointerLevelSet>
 translateEntityPointerLevel(const Expr *E, ASTContext &Ctx,
                             TUSummaryExtractor &Extractor);
 
-/// Same as `translateEntityPointerLevel`, except it returns raw
+/// Same as \c translateEntityPointerLevel, except it returns raw
 /// `(NamedDecl *, pointer level, is-return)` tuples (a.k.a. DeclPointerLevels)
 /// instead of assembling an `EntityPointerLevelSet` directly.
 llvm::Expected<DeclPointerLevels>

--- a/clang/include/clang/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevel.h
+++ b/clang/include/clang/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevel.h
@@ -11,8 +11,8 @@
 
 #include "clang/AST/Expr.h"
 #include "clang/ScalableStaticAnalysis/Core/Model/EntityId.h"
+#include "llvm/ADT/SmallVector.h"
 #include <set>
-#include <vector>
 
 namespace clang::ssaf {
 class TUSummaryExtractor;
@@ -25,7 +25,7 @@ struct DeclPointerLevel {
   bool IsReturn;
 };
 
-using DeclPointerLevels = std::vector<DeclPointerLevel>;
+using DeclPointerLevelVec = llvm::SmallVector<DeclPointerLevel, 2>;
 
 /// An EntityPointerLevel is associated with a level of the declared
 /// pointer/array type of an entity.  In the fully-expanded spelling of the
@@ -110,18 +110,16 @@ translateEntityPointerLevel(const Expr *E, ASTContext &Ctx,
 /// Same as \c translateEntityPointerLevel, except it returns raw
 /// `(NamedDecl *, pointer level, is-return)` tuples (a.k.a. DeclPointerLevels)
 /// instead of assembling an `EntityPointerLevelSet` directly.
-llvm::Expected<DeclPointerLevels>
+llvm::Expected<DeclPointerLevelVec>
 translateDeclPointerLevel(const Expr *E, ASTContext &Ctx,
                           TUSummaryExtractor &Extractor);
 
-/// Assemble `(NamedDecl *, pointer level, is-return)` tuples (a.k.a.
-/// DeclPointerLevels) to `EntityPointerLevelSet`.
+/// Assemble `DeclPointerLevels` into an `EntityPointerLevelSet`.
 Expected<EntityPointerLevelSet>
-toEntityPointerLevels(const DeclPointerLevels &DPLs, ASTContext &Ctx,
+toEntityPointerLevels(const DeclPointerLevelVec &DPLs, ASTContext &Ctx,
                       TUSummaryExtractor &Extractor);
 
-/// Convert a single `(NamedDecl *, pointer level, is-return)` tuple (a.k.a.
-/// DeclPointerLevel) to an `EntityPointerLevel`.
+/// Convert a single `DeclPointerLevel` to an `EntityPointerLevel`.
 Expected<EntityPointerLevel>
 toEntityPointerLevel(const DeclPointerLevel &DPL, ASTContext &Ctx,
                      TUSummaryExtractor &Extractor);
@@ -149,11 +147,11 @@ llvm::Expected<EntityPointerLevel>
 createEntityPointerLevel(const NamedDecl *ND, TUSummaryExtractor &Extractor,
                          bool IsFunRet = false);
 
-/// \return an exhaustive vector of DeclPointerLevels, sorted in ascending order
-/// of pointer level, such that every element is identical to \p DPL except with
-/// a no-lower-than pointer level. The pointer level of each element is bounded
-/// by the type of the NamedDecl of \p DPL.
-DeclPointerLevels elaborateHigherDeclPointerLevels(const DeclPointerLevel &DPL);
+/// \return an exhaustive vector of unique DeclPointerLevels, sorted in
+/// ascending order of pointer levels. All elements are identical to \p DPL
+/// except with a pointer level greater than or equal to that of \p DPL. The
+/// pointer level of each element is bounded by the type of \p DPL's NamedDecl.
+DeclPointerLevelVec elaborateHigherDeclPointerLevels(const DeclPointerLevel &DPL);
 
 /// Creates a new EntityPointerLevel (EPL) from `E` by incrementing `E`'s
 /// pointer level.

--- a/clang/lib/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevel.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevel.cpp
@@ -14,7 +14,9 @@
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/StmtVisitor.h"
 #include "clang/ScalableStaticAnalysis/Core/TUSummary/TUSummaryExtractor.h"
+#include "llvm/ADT/STLExtras.h"
 #include <optional>
+#include <vector>
 
 using namespace clang;
 using namespace ssaf;
@@ -41,11 +43,11 @@ namespace clang::ssaf {
 //   Translate(&arr[5])            -> {(arr, 1)}
 class EntityPointerLevelTranslator
     : ConstStmtVisitor<EntityPointerLevelTranslator,
-                       Expected<EntityPointerLevelSet>> {
+                       Expected<DeclPointerLevels>> {
   friend class StmtVisitorBase;
 
   // Fallback method for all unsupported expression kind:
-  Expected<EntityPointerLevelSet> fallback(const Stmt *S) {
+  Expected<DeclPointerLevels> fallback(const Stmt *S) {
     // Report an error/warning (at least in debug mode) for any unsupported kind
     // of pointer/array typed expression, because we want to understand every
     // pointer/array expression. But for non-pointer/array typed expressions, we
@@ -55,7 +57,7 @@ class EntityPointerLevelTranslator
       return makeErrAtNode(Ctx, E,
                            "attempt to translate %s to EntityPointerLevels",
                            E->getStmtClassName());
-    return EntityPointerLevelSet{};
+    return DeclPointerLevels{};
   }
 
   Expected<EntityPointerLevel>
@@ -79,15 +81,15 @@ class EntityPointerLevelTranslator
 
   // The common helper function for Translate(*base):
   // Translate(*base) -> Translate(base) with .pointerLevel + 1
-  Expected<EntityPointerLevelSet> translateDereferencePointer(const Expr *Ptr) {
+  Expected<DeclPointerLevels> translateDereferencePointer(const Expr *Ptr) {
     assert(hasPtrOrArrType(Ptr));
 
-    Expected<EntityPointerLevelSet> SubResult = Visit(Ptr);
+    Expected<DeclPointerLevels> SubResult = Visit(Ptr);
     if (!SubResult)
       return SubResult.takeError();
 
-    auto Incremented = llvm::map_range(*SubResult, incrementPointerLevel);
-    return EntityPointerLevelSet{Incremented.begin(), Incremented.end()};
+    llvm::for_each(*SubResult, [](DeclPointerLevel &D) { ++D.PointerLevel; });
+    return SubResult;
   }
 
   TUSummaryExtractor &Extractor;
@@ -97,7 +99,7 @@ public:
   EntityPointerLevelTranslator(TUSummaryExtractor &Extractor, ASTContext &Ctx)
       : Extractor(Extractor), Ctx(Ctx) {}
 
-  Expected<EntityPointerLevelSet> translate(const Expr *E) { return Visit(E); }
+  Expected<DeclPointerLevels> translate(const Expr *E) { return Visit(E); }
   Expected<EntityPointerLevel> translate(const NamedDecl *D, bool IsRet) {
     if (!IsRet)
       return createEntityPointerLevelFor(D);
@@ -109,26 +111,27 @@ public:
                          D->getDeclKindName());
   }
 
+  // Converts a `DeclPointerLevel` to an `EntityPointerLevel`
+  Expected<EntityPointerLevel> toEntityPointerLevel(const DeclPointerLevel &D) {
+    Expected<EntityPointerLevel> Base = translate(D.Decl, D.IsReturn);
+    if (!Base)
+      return Base.takeError();
+    return buildEntityPointerLevel(Base->getEntity(), D.PointerLevel);
+  }
+
   static EntityPointerLevel incrementPointerLevel(const EntityPointerLevel &E) {
     return EntityPointerLevel({E.getEntity(), E.getPointerLevel() + 1});
   }
 
-  static EntityPointerLevel decrementPointerLevel(const EntityPointerLevel &E) {
-    assert(E.getPointerLevel() > 0);
-    return EntityPointerLevel({E.getEntity(), E.getPointerLevel() - 1});
-  }
-
 private:
-  Expected<EntityPointerLevelSet> VisitStmt(const Stmt *E) {
-    return fallback(E);
-  }
+  Expected<DeclPointerLevels> VisitStmt(const Stmt *E) { return fallback(E); }
 
   // Translate(base + x)           -> Translate(base)
   // Translate(x + base)           -> Translate(base)
   // Translate(base - x)           -> Translate(base)
   // Translate(base {+=, -=, =} x) -> Translate(base)
   // Translate(x, base)            -> Translate(base)
-  Expected<EntityPointerLevelSet> VisitBinaryOperator(const BinaryOperator *E) {
+  Expected<DeclPointerLevels> VisitBinaryOperator(const BinaryOperator *E) {
     switch (E->getOpcode()) {
     case clang::BO_Add:
       if (hasPtrOrArrType(E->getLHS()))
@@ -152,7 +155,7 @@ private:
   // Translate(&base)          -> {}, if Translate(base) is {}
   //                           -> Translate(base) with .pointerLevel -= 1
   // Translate(+base)          -> Translate(base)
-  Expected<EntityPointerLevelSet> VisitUnaryOperator(const UnaryOperator *E) {
+  Expected<DeclPointerLevels> VisitUnaryOperator(const UnaryOperator *E) {
     switch (E->getOpcode()) {
     case clang::UO_PostInc:
     case clang::UO_PostDec:
@@ -160,12 +163,15 @@ private:
     case clang::UO_PreDec:
       return Visit(E->getSubExpr());
     case clang::UO_AddrOf: {
-      Expected<EntityPointerLevelSet> SubResult = Visit(E->getSubExpr());
+      Expected<DeclPointerLevels> SubResult = Visit(E->getSubExpr());
       if (!SubResult)
         return SubResult.takeError();
 
-      auto Decremented = llvm::map_range(*SubResult, decrementPointerLevel);
-      return EntityPointerLevelSet{Decremented.begin(), Decremented.end()};
+      llvm::for_each(*SubResult, [](DeclPointerLevel &D) {
+        assert(D.PointerLevel > 0);
+        --D.PointerLevel;
+      });
+      return SubResult;
     }
     case clang::UO_Deref:
       return translateDereferencePointer(E->getSubExpr());
@@ -178,36 +184,35 @@ private:
 
   // Translate((T*)base) -> Translate(base) if base has pointer type
   //                     -> {} otherwise
-  Expected<EntityPointerLevelSet> VisitCastExpr(const CastExpr *E) {
+  Expected<DeclPointerLevels> VisitCastExpr(const CastExpr *E) {
     if (hasPtrOrArrType(E->getSubExpr()))
       return Visit(E->getSubExpr());
-    return EntityPointerLevelSet{};
+    return DeclPointerLevels{};
   }
 
   // Translate(f(...)) -> {} if it is an indirect call
   //                   -> {(f_return, 1)}, otherwise
-  Expected<EntityPointerLevelSet> VisitCallExpr(const CallExpr *E) {
-    if (auto *FD = E->getDirectCallee()) {
-      if (auto ReturnId = Extractor.addEntityForReturn(FD))
-        return EntityPointerLevelSet{buildEntityPointerLevel(*ReturnId, 1)};
-    }
-    return EntityPointerLevelSet{};
+  Expected<DeclPointerLevels> VisitCallExpr(const CallExpr *E) {
+    if (auto *FD = E->getDirectCallee())
+      if (Extractor.addEntityForReturn(FD))
+        return DeclPointerLevels{{FD, /*PointerLevel=*/1, /*IsReturn=*/true}};
+    return DeclPointerLevels{};
   }
 
   // Translate(base[x]) -> Translate(*base)
-  Expected<EntityPointerLevelSet>
+  Expected<DeclPointerLevels>
   VisitArraySubscriptExpr(const ArraySubscriptExpr *E) {
     return translateDereferencePointer(E->getBase());
   }
 
   // Translate(cond ? base1 : base2) := Translate(base1) U Translate(base2)
-  Expected<EntityPointerLevelSet>
+  Expected<DeclPointerLevels>
   VisitAbstractConditionalOperator(const AbstractConditionalOperator *E) {
-    Expected<EntityPointerLevelSet> ReT = Visit(E->getTrueExpr());
-    Expected<EntityPointerLevelSet> ReF = Visit(E->getFalseExpr());
+    Expected<DeclPointerLevels> ReT = Visit(E->getTrueExpr());
+    Expected<DeclPointerLevels> ReF = Visit(E->getFalseExpr());
 
     if (ReT && ReF) {
-      ReT->insert(ReF->begin(), ReF->end());
+      ReT->insert(ReT->end(), ReF->begin(), ReF->end());
       return ReT;
     }
     if (!ReF && !ReT)
@@ -217,100 +222,94 @@ private:
     return ReT.takeError();
   }
 
-  Expected<EntityPointerLevelSet> VisitParenExpr(const ParenExpr *E) {
+  Expected<DeclPointerLevels> VisitParenExpr(const ParenExpr *E) {
     return Visit(E->getSubExpr());
   }
 
   // Translate("string-literal") -> {} // no entity involved
-  Expected<EntityPointerLevelSet> VisitStringLiteral(const StringLiteral *E) {
-    return EntityPointerLevelSet{};
+  Expected<DeclPointerLevels> VisitStringLiteral(const StringLiteral *E) {
+    return DeclPointerLevels{};
   }
 
   // Translate(predefined-expr) -> {} // treated the same as string literals
-  Expected<EntityPointerLevelSet> VisitPredefinedExpr(const PredefinedExpr *E) {
-    return EntityPointerLevelSet{};
+  Expected<DeclPointerLevels> VisitPredefinedExpr(const PredefinedExpr *E) {
+    return DeclPointerLevels{};
   }
 
   // Translate(integer-literal) -> {} // no entity involved
-  Expected<EntityPointerLevelSet> VisitIntegerLiteral(const IntegerLiteral *E) {
-    return EntityPointerLevelSet{};
+  Expected<DeclPointerLevels> VisitIntegerLiteral(const IntegerLiteral *E) {
+    return DeclPointerLevels{};
   }
 
   // Translate(DRE) -> {(Decl, 1)}
-  Expected<EntityPointerLevelSet> VisitDeclRefExpr(const DeclRefExpr *E) {
-    auto Res = createEntityPointerLevelFor(E->getDecl());
-    if (!Res)
-      return Res.takeError();
-    return EntityPointerLevelSet{*Res};
+  Expected<DeclPointerLevels> VisitDeclRefExpr(const DeclRefExpr *E) {
+    return DeclPointerLevels{
+        {E->getDecl(), /*PointerLevel=*/1, /*IsReturn=*/false}};
   }
 
   // Translate({., ->}f) -> {(MemberDecl, 1)}
-  Expected<EntityPointerLevelSet> VisitMemberExpr(const MemberExpr *E) {
-    auto Res = createEntityPointerLevelFor(E->getMemberDecl());
-    if (!Res)
-      return Res.takeError();
-    return EntityPointerLevelSet{*Res};
+  Expected<DeclPointerLevels> VisitMemberExpr(const MemberExpr *E) {
+    return DeclPointerLevels{
+        {E->getMemberDecl(), /*PointerLevel=*/1, /*IsReturn=*/false}};
   }
 
   // Unwrap CXXDefaultArgExpr
-  Expected<EntityPointerLevelSet>
+  Expected<DeclPointerLevels>
   VisitCXXDefaultArgExpr(const CXXDefaultArgExpr *E) {
     return Visit(E->getExpr());
   }
 
   // Unwrap OpaqueValueExpr
-  Expected<EntityPointerLevelSet>
-  VisitOpaqueValueExpr(const OpaqueValueExpr *S) {
+  Expected<DeclPointerLevels> VisitOpaqueValueExpr(const OpaqueValueExpr *S) {
     return Visit(S->getSourceExpr());
   }
 
   // Unwrap ExprWithCleanups
-  Expected<EntityPointerLevelSet>
-  VisitExprWithCleanups(const ExprWithCleanups *S) {
+  Expected<DeclPointerLevels> VisitExprWithCleanups(const ExprWithCleanups *S) {
     return Visit(S->getSubExpr());
   }
 
   // Unwrap MaterializeTemporaryExpr
-  Expected<EntityPointerLevelSet>
+  Expected<DeclPointerLevels>
   VisitMaterializeTemporaryExpr(const MaterializeTemporaryExpr *S) {
     return Visit(S->getSubExpr());
   }
 
   // Unwrap CXXDefaultInitExpr
-  Expected<EntityPointerLevelSet>
+  Expected<DeclPointerLevels>
   VisitCXXDefaultInitExpr(const CXXDefaultInitExpr *E) {
     return Visit(E->getExpr());
   }
 
   // Translate(`nullptr`) -> {}
-  Expected<EntityPointerLevelSet>
+  Expected<DeclPointerLevels>
   VisitCXXNullPtrLiteralExpr(const CXXNullPtrLiteralExpr *S) {
-    return EntityPointerLevelSet{};
+    return DeclPointerLevels{};
   }
 
   // Translate(`this`) -> {}
-  Expected<EntityPointerLevelSet> VisitCXXThisExpr(const CXXThisExpr *S) {
-    return EntityPointerLevelSet{};
+  Expected<DeclPointerLevels> VisitCXXThisExpr(const CXXThisExpr *S) {
+    return DeclPointerLevels{};
   }
 
   // Translate(`new`/`new [*]`) -> {}
-  Expected<EntityPointerLevelSet> VisitCXXNewExpr(const CXXNewExpr *S) {
-    return EntityPointerLevelSet{};
+  Expected<DeclPointerLevels> VisitCXXNewExpr(const CXXNewExpr *S) {
+    return DeclPointerLevels{};
   }
 
   // ImplicitValueInitExpr, for raw pointer type,
   // evaluates to a compile-time constant zero (or null). So no EPL in the
   // result.
-  Expected<EntityPointerLevelSet>
+  Expected<DeclPointerLevels>
   VisitImplicitValueInitExpr(const ImplicitValueInitExpr *S) {
-    return EntityPointerLevelSet{};
+    return DeclPointerLevels{};
   }
 
   // The InitListExpr must be an empty or singleton list that
   // initializes a pointer scalar.  Other cases are unexpected thus an error.
-  Expected<EntityPointerLevelSet> VisitInitListExpr(const InitListExpr *E) {
+  Expected<DeclPointerLevels> VisitInitListExpr(const InitListExpr *E) {
     if (E->getNumInits() < 1)
-      return EntityPointerLevelSet{};
+      return DeclPointerLevels{};
     if (E->getType()->isPointerType())
       return Visit(E->getInit(0));
     return llvm::createStringError(
@@ -323,28 +322,42 @@ private:
   // When a CXXConstructExpr has an array type, clang is initializing an array
   // of class-type objects with default values.  In this case, no entity is
   // associated with the initializer.
-  Expected<EntityPointerLevelSet>
-  VisitCXXConstructExpr(const CXXConstructExpr *E) {
+  Expected<DeclPointerLevels> VisitCXXConstructExpr(const CXXConstructExpr *E) {
     if (E->getType()->isArrayType()) {
-      return EntityPointerLevelSet{};
+      return DeclPointerLevels{};
     }
     return fallback(E);
   }
 
   // No entity is associated with a CXXScalarValueInitExpr:
-  Expected<EntityPointerLevelSet>
+  Expected<DeclPointerLevels>
   VisitCXXScalarValueInitExpr(const CXXScalarValueInitExpr *E) {
-    return EntityPointerLevelSet{};
+    return DeclPointerLevels{};
   }
 };
 } // namespace clang::ssaf
+
+Expected<DeclPointerLevels>
+clang::ssaf::translateDeclPointerLevel(const Expr *E, ASTContext &Ctx,
+                                       TUSummaryExtractor &Extractor) {
+  EntityPointerLevelTranslator Translator(Extractor, Ctx);
+
+  return Translator.translate(E);
+}
 
 Expected<EntityPointerLevelSet>
 clang::ssaf::translateEntityPointerLevel(const Expr *E, ASTContext &Ctx,
                                          TUSummaryExtractor &Extractor) {
   EntityPointerLevelTranslator Translator(Extractor, Ctx);
+  auto DPLs = Translator.translate(E);
+  if (!DPLs)
+    return DPLs.takeError();
+  return toEntityPointerLevels(*DPLs, Ctx, Extractor);
+}
 
-  return Translator.translate(E);
+DeclPointerLevel clang::ssaf::createDeclPointerLevel(const NamedDecl *ND,
+                                                     bool IsFunRet) {
+  return {ND, 1, IsFunRet};
 }
 
 /// Create an EntityPointerLevel from a ValueDecl of a pointer type.
@@ -353,6 +366,59 @@ Expected<EntityPointerLevel> clang::ssaf::createEntityPointerLevel(
   EntityPointerLevelTranslator Translator(Extractor, ND->getASTContext());
 
   return Translator.translate(ND, IsFunRet);
+}
+
+DeclPointerLevels
+clang::ssaf::elaborateHigherDeclPointerLevels(const DeclPointerLevel &DPL) {
+  DeclPointerLevels Result{DPL};
+  QualType T;
+
+  if (DPL.IsReturn) {
+    if (const auto *FD = dyn_cast<FunctionDecl>(DPL.Decl))
+      T = FD->getReturnType().getNonReferenceType();
+  } else if (const auto *VD = dyn_cast<ValueDecl>(DPL.Decl)) {
+    T = VD->getType().getNonReferenceType();
+  }
+  if (T.isNull())
+    return Result;
+
+  // Count the max pointer/array levels of `T`:
+  unsigned MaxLevel = 0;
+  for (T = T.getCanonicalType();; ++MaxLevel) {
+    if (const auto *PT = dyn_cast<PointerType>(T))
+      T = PT->getPointeeType().getCanonicalType();
+    else if (const auto *AT = dyn_cast<ArrayType>(T))
+      T = AT->getElementType().getCanonicalType();
+    else
+      break;
+  }
+
+  for (unsigned Level = DPL.PointerLevel + 1; Level <= MaxLevel; ++Level)
+    Result.push_back({DPL.Decl, Level, DPL.IsReturn});
+  return Result;
+}
+
+Expected<EntityPointerLevelSet>
+clang::ssaf::toEntityPointerLevels(const DeclPointerLevels &DPLs,
+                                   ASTContext &Ctx,
+                                   TUSummaryExtractor &Extractor) {
+  EntityPointerLevelTranslator Translator(Extractor, Ctx);
+  EntityPointerLevelSet Result;
+
+  for (const auto &DPL : DPLs) {
+    Expected<EntityPointerLevel> EPL = Translator.toEntityPointerLevel(DPL);
+    if (!EPL)
+      return EPL.takeError();
+    Result.insert(*EPL);
+  }
+  return Result;
+}
+
+Expected<EntityPointerLevel>
+clang::ssaf::toEntityPointerLevel(const DeclPointerLevel &DPL, ASTContext &Ctx,
+                                  TUSummaryExtractor &Extractor) {
+  EntityPointerLevelTranslator Translator(Extractor, Ctx);
+  return Translator.toEntityPointerLevel(DPL);
 }
 
 EntityPointerLevel

--- a/clang/lib/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevel.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevel.cpp
@@ -16,7 +16,6 @@
 #include "clang/ScalableStaticAnalysis/Core/TUSummary/TUSummaryExtractor.h"
 #include "llvm/ADT/STLExtras.h"
 #include <optional>
-#include <vector>
 
 using namespace clang;
 using namespace ssaf;
@@ -43,11 +42,11 @@ namespace clang::ssaf {
 //   Translate(&arr[5])            -> {(arr, 1)}
 class EntityPointerLevelTranslator
     : ConstStmtVisitor<EntityPointerLevelTranslator,
-                       Expected<DeclPointerLevels>> {
+                       Expected<DeclPointerLevelVec>> {
   friend class StmtVisitorBase;
 
   // Fallback method for all unsupported expression kind:
-  Expected<DeclPointerLevels> fallback(const Stmt *S) {
+  Expected<DeclPointerLevelVec> fallback(const Stmt *S) {
     // Report an error/warning (at least in debug mode) for any unsupported kind
     // of pointer/array typed expression, because we want to understand every
     // pointer/array expression. But for non-pointer/array typed expressions, we
@@ -57,7 +56,7 @@ class EntityPointerLevelTranslator
       return makeErrAtNode(Ctx, E,
                            "attempt to translate %s to EntityPointerLevels",
                            E->getStmtClassName());
-    return DeclPointerLevels{};
+    return DeclPointerLevelVec{};
   }
 
   Expected<EntityPointerLevel>
@@ -81,10 +80,10 @@ class EntityPointerLevelTranslator
 
   // The common helper function for Translate(*base):
   // Translate(*base) -> Translate(base) with .pointerLevel + 1
-  Expected<DeclPointerLevels> translateDereferencePointer(const Expr *Ptr) {
+  Expected<DeclPointerLevelVec> translateDereferencePointer(const Expr *Ptr) {
     assert(hasPtrOrArrType(Ptr));
 
-    Expected<DeclPointerLevels> SubResult = Visit(Ptr);
+    Expected<DeclPointerLevelVec> SubResult = Visit(Ptr);
     if (!SubResult)
       return SubResult.takeError();
 
@@ -99,7 +98,7 @@ public:
   EntityPointerLevelTranslator(TUSummaryExtractor &Extractor, ASTContext &Ctx)
       : Extractor(Extractor), Ctx(Ctx) {}
 
-  Expected<DeclPointerLevels> translate(const Expr *E) { return Visit(E); }
+  Expected<DeclPointerLevelVec> translate(const Expr *E) { return Visit(E); }
   Expected<EntityPointerLevel> translate(const NamedDecl *D, bool IsRet) {
     if (!IsRet)
       return createEntityPointerLevelFor(D);
@@ -124,14 +123,14 @@ public:
   }
 
 private:
-  Expected<DeclPointerLevels> VisitStmt(const Stmt *E) { return fallback(E); }
+  Expected<DeclPointerLevelVec> VisitStmt(const Stmt *E) { return fallback(E); }
 
   // Translate(base + x)           -> Translate(base)
   // Translate(x + base)           -> Translate(base)
   // Translate(base - x)           -> Translate(base)
   // Translate(base {+=, -=, =} x) -> Translate(base)
   // Translate(x, base)            -> Translate(base)
-  Expected<DeclPointerLevels> VisitBinaryOperator(const BinaryOperator *E) {
+  Expected<DeclPointerLevelVec> VisitBinaryOperator(const BinaryOperator *E) {
     switch (E->getOpcode()) {
     case clang::BO_Add:
       if (hasPtrOrArrType(E->getLHS()))
@@ -155,7 +154,7 @@ private:
   // Translate(&base)          -> {}, if Translate(base) is {}
   //                           -> Translate(base) with .pointerLevel -= 1
   // Translate(+base)          -> Translate(base)
-  Expected<DeclPointerLevels> VisitUnaryOperator(const UnaryOperator *E) {
+  Expected<DeclPointerLevelVec> VisitUnaryOperator(const UnaryOperator *E) {
     switch (E->getOpcode()) {
     case clang::UO_PostInc:
     case clang::UO_PostDec:
@@ -163,7 +162,7 @@ private:
     case clang::UO_PreDec:
       return Visit(E->getSubExpr());
     case clang::UO_AddrOf: {
-      Expected<DeclPointerLevels> SubResult = Visit(E->getSubExpr());
+      Expected<DeclPointerLevelVec> SubResult = Visit(E->getSubExpr());
       if (!SubResult)
         return SubResult.takeError();
 
@@ -184,32 +183,31 @@ private:
 
   // Translate((T*)base) -> Translate(base) if base has pointer type
   //                     -> {} otherwise
-  Expected<DeclPointerLevels> VisitCastExpr(const CastExpr *E) {
+  Expected<DeclPointerLevelVec> VisitCastExpr(const CastExpr *E) {
     if (hasPtrOrArrType(E->getSubExpr()))
       return Visit(E->getSubExpr());
-    return DeclPointerLevels{};
+    return DeclPointerLevelVec{};
   }
 
   // Translate(f(...)) -> {} if it is an indirect call
   //                   -> {(f_return, 1)}, otherwise
-  Expected<DeclPointerLevels> VisitCallExpr(const CallExpr *E) {
+  Expected<DeclPointerLevelVec> VisitCallExpr(const CallExpr *E) {
     if (auto *FD = E->getDirectCallee())
-      if (Extractor.addEntityForReturn(FD))
-        return DeclPointerLevels{{FD, /*PointerLevel=*/1, /*IsReturn=*/true}};
-    return DeclPointerLevels{};
+      return DeclPointerLevelVec{{FD, /*PointerLevel=*/1, /*IsReturn=*/true}};
+    return DeclPointerLevelVec{};
   }
 
   // Translate(base[x]) -> Translate(*base)
-  Expected<DeclPointerLevels>
+  Expected<DeclPointerLevelVec>
   VisitArraySubscriptExpr(const ArraySubscriptExpr *E) {
     return translateDereferencePointer(E->getBase());
   }
 
   // Translate(cond ? base1 : base2) := Translate(base1) U Translate(base2)
-  Expected<DeclPointerLevels>
+  Expected<DeclPointerLevelVec>
   VisitAbstractConditionalOperator(const AbstractConditionalOperator *E) {
-    Expected<DeclPointerLevels> ReT = Visit(E->getTrueExpr());
-    Expected<DeclPointerLevels> ReF = Visit(E->getFalseExpr());
+    Expected<DeclPointerLevelVec> ReT = Visit(E->getTrueExpr());
+    Expected<DeclPointerLevelVec> ReF = Visit(E->getFalseExpr());
 
     if (ReT && ReF) {
       ReT->insert(ReT->end(), ReF->begin(), ReF->end());
@@ -222,94 +220,94 @@ private:
     return ReT.takeError();
   }
 
-  Expected<DeclPointerLevels> VisitParenExpr(const ParenExpr *E) {
+  Expected<DeclPointerLevelVec> VisitParenExpr(const ParenExpr *E) {
     return Visit(E->getSubExpr());
   }
 
   // Translate("string-literal") -> {} // no entity involved
-  Expected<DeclPointerLevels> VisitStringLiteral(const StringLiteral *E) {
-    return DeclPointerLevels{};
+  Expected<DeclPointerLevelVec> VisitStringLiteral(const StringLiteral *E) {
+    return DeclPointerLevelVec{};
   }
 
   // Translate(predefined-expr) -> {} // treated the same as string literals
-  Expected<DeclPointerLevels> VisitPredefinedExpr(const PredefinedExpr *E) {
-    return DeclPointerLevels{};
+  Expected<DeclPointerLevelVec> VisitPredefinedExpr(const PredefinedExpr *E) {
+    return DeclPointerLevelVec{};
   }
 
   // Translate(integer-literal) -> {} // no entity involved
-  Expected<DeclPointerLevels> VisitIntegerLiteral(const IntegerLiteral *E) {
-    return DeclPointerLevels{};
+  Expected<DeclPointerLevelVec> VisitIntegerLiteral(const IntegerLiteral *E) {
+    return DeclPointerLevelVec{};
   }
 
   // Translate(DRE) -> {(Decl, 1)}
-  Expected<DeclPointerLevels> VisitDeclRefExpr(const DeclRefExpr *E) {
-    return DeclPointerLevels{
+  Expected<DeclPointerLevelVec> VisitDeclRefExpr(const DeclRefExpr *E) {
+    return DeclPointerLevelVec{
         {E->getDecl(), /*PointerLevel=*/1, /*IsReturn=*/false}};
   }
 
   // Translate({., ->}f) -> {(MemberDecl, 1)}
-  Expected<DeclPointerLevels> VisitMemberExpr(const MemberExpr *E) {
-    return DeclPointerLevels{
+  Expected<DeclPointerLevelVec> VisitMemberExpr(const MemberExpr *E) {
+    return DeclPointerLevelVec{
         {E->getMemberDecl(), /*PointerLevel=*/1, /*IsReturn=*/false}};
   }
 
   // Unwrap CXXDefaultArgExpr
-  Expected<DeclPointerLevels>
+  Expected<DeclPointerLevelVec>
   VisitCXXDefaultArgExpr(const CXXDefaultArgExpr *E) {
     return Visit(E->getExpr());
   }
 
   // Unwrap OpaqueValueExpr
-  Expected<DeclPointerLevels> VisitOpaqueValueExpr(const OpaqueValueExpr *S) {
+  Expected<DeclPointerLevelVec> VisitOpaqueValueExpr(const OpaqueValueExpr *S) {
     return Visit(S->getSourceExpr());
   }
 
   // Unwrap ExprWithCleanups
-  Expected<DeclPointerLevels> VisitExprWithCleanups(const ExprWithCleanups *S) {
+  Expected<DeclPointerLevelVec> VisitExprWithCleanups(const ExprWithCleanups *S) {
     return Visit(S->getSubExpr());
   }
 
   // Unwrap MaterializeTemporaryExpr
-  Expected<DeclPointerLevels>
+  Expected<DeclPointerLevelVec>
   VisitMaterializeTemporaryExpr(const MaterializeTemporaryExpr *S) {
     return Visit(S->getSubExpr());
   }
 
   // Unwrap CXXDefaultInitExpr
-  Expected<DeclPointerLevels>
+  Expected<DeclPointerLevelVec>
   VisitCXXDefaultInitExpr(const CXXDefaultInitExpr *E) {
     return Visit(E->getExpr());
   }
 
   // Translate(`nullptr`) -> {}
-  Expected<DeclPointerLevels>
+  Expected<DeclPointerLevelVec>
   VisitCXXNullPtrLiteralExpr(const CXXNullPtrLiteralExpr *S) {
-    return DeclPointerLevels{};
+    return DeclPointerLevelVec{};
   }
 
   // Translate(`this`) -> {}
-  Expected<DeclPointerLevels> VisitCXXThisExpr(const CXXThisExpr *S) {
-    return DeclPointerLevels{};
+  Expected<DeclPointerLevelVec> VisitCXXThisExpr(const CXXThisExpr *S) {
+    return DeclPointerLevelVec{};
   }
 
   // Translate(`new`/`new [*]`) -> {}
-  Expected<DeclPointerLevels> VisitCXXNewExpr(const CXXNewExpr *S) {
-    return DeclPointerLevels{};
+  Expected<DeclPointerLevelVec> VisitCXXNewExpr(const CXXNewExpr *S) {
+    return DeclPointerLevelVec{};
   }
 
   // ImplicitValueInitExpr, for raw pointer type,
   // evaluates to a compile-time constant zero (or null). So no EPL in the
   // result.
-  Expected<DeclPointerLevels>
+  Expected<DeclPointerLevelVec>
   VisitImplicitValueInitExpr(const ImplicitValueInitExpr *S) {
-    return DeclPointerLevels{};
+    return DeclPointerLevelVec{};
   }
 
   // The InitListExpr must be an empty or singleton list that
   // initializes a pointer scalar.  Other cases are unexpected thus an error.
-  Expected<DeclPointerLevels> VisitInitListExpr(const InitListExpr *E) {
+  Expected<DeclPointerLevelVec> VisitInitListExpr(const InitListExpr *E) {
     if (E->getNumInits() < 1)
-      return DeclPointerLevels{};
+      return DeclPointerLevelVec{};
     if (E->getType()->isPointerType())
       return Visit(E->getInit(0));
     return llvm::createStringError(
@@ -322,22 +320,22 @@ private:
   // When a CXXConstructExpr has an array type, clang is initializing an array
   // of class-type objects with default values.  In this case, no entity is
   // associated with the initializer.
-  Expected<DeclPointerLevels> VisitCXXConstructExpr(const CXXConstructExpr *E) {
+  Expected<DeclPointerLevelVec> VisitCXXConstructExpr(const CXXConstructExpr *E) {
     if (E->getType()->isArrayType()) {
-      return DeclPointerLevels{};
+      return DeclPointerLevelVec{};
     }
     return fallback(E);
   }
 
   // No entity is associated with a CXXScalarValueInitExpr:
-  Expected<DeclPointerLevels>
+  Expected<DeclPointerLevelVec>
   VisitCXXScalarValueInitExpr(const CXXScalarValueInitExpr *E) {
-    return DeclPointerLevels{};
+    return DeclPointerLevelVec{};
   }
 };
 } // namespace clang::ssaf
 
-Expected<DeclPointerLevels>
+Expected<DeclPointerLevelVec>
 clang::ssaf::translateDeclPointerLevel(const Expr *E, ASTContext &Ctx,
                                        TUSummaryExtractor &Extractor) {
   EntityPointerLevelTranslator Translator(Extractor, Ctx);
@@ -368,9 +366,9 @@ Expected<EntityPointerLevel> clang::ssaf::createEntityPointerLevel(
   return Translator.translate(ND, IsFunRet);
 }
 
-DeclPointerLevels
+DeclPointerLevelVec
 clang::ssaf::elaborateHigherDeclPointerLevels(const DeclPointerLevel &DPL) {
-  DeclPointerLevels Result{DPL};
+  DeclPointerLevelVec Result{DPL};
   QualType T;
 
   if (DPL.IsReturn) {
@@ -384,22 +382,24 @@ clang::ssaf::elaborateHigherDeclPointerLevels(const DeclPointerLevel &DPL) {
 
   // Count the max pointer/array levels of `T`:
   unsigned MaxLevel = 0;
-  for (T = T.getCanonicalType();; ++MaxLevel) {
-    if (const auto *PT = dyn_cast<PointerType>(T))
-      T = PT->getPointeeType().getCanonicalType();
-    else if (const auto *AT = dyn_cast<ArrayType>(T))
-      T = AT->getElementType().getCanonicalType();
-    else
-      break;
-  }
 
+  T = T.getCanonicalType();
+  while (!T.isNull() && (T->isPointerType() || T->isArrayType())) {
+    if (const auto *PT = dyn_cast<PointerType>(T))
+      T = PT->getPointeeType();
+    else
+      T = cast<ArrayType>(T)->getElementType();
+    ++MaxLevel;
+  }
+  assert(MaxLevel > 0);
+  Result.reserve(MaxLevel);
   for (unsigned Level = DPL.PointerLevel + 1; Level <= MaxLevel; ++Level)
     Result.push_back({DPL.Decl, Level, DPL.IsReturn});
   return Result;
 }
 
 Expected<EntityPointerLevelSet>
-clang::ssaf::toEntityPointerLevels(const DeclPointerLevels &DPLs,
+clang::ssaf::toEntityPointerLevels(const DeclPointerLevelVec &DPLs,
                                    ASTContext &Ctx,
                                    TUSummaryExtractor &Extractor) {
   EntityPointerLevelTranslator Translator(Extractor, Ctx);

--- a/clang/lib/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevel.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevel.cpp
@@ -263,7 +263,8 @@ private:
   }
 
   // Unwrap ExprWithCleanups
-  Expected<DeclPointerLevelVec> VisitExprWithCleanups(const ExprWithCleanups *S) {
+  Expected<DeclPointerLevelVec>
+  VisitExprWithCleanups(const ExprWithCleanups *S) {
     return Visit(S->getSubExpr());
   }
 
@@ -320,7 +321,8 @@ private:
   // When a CXXConstructExpr has an array type, clang is initializing an array
   // of class-type objects with default values.  In this case, no entity is
   // associated with the initializer.
-  Expected<DeclPointerLevelVec> VisitCXXConstructExpr(const CXXConstructExpr *E) {
+  Expected<DeclPointerLevelVec>
+  VisitCXXConstructExpr(const CXXConstructExpr *E) {
     if (E->getType()->isArrayType()) {
       return DeclPointerLevelVec{};
     }

--- a/clang/unittests/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevelTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevelTest.cpp
@@ -1,0 +1,102 @@
+//===- EntityPointerLevelTest.cpp -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevel.h"
+#include "FindDecl.h"
+#include "clang/AST/Decl.h"
+#include "clang/Frontend/ASTUnit.h"
+#include "clang/Tooling/Tooling.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include <memory>
+#include <vector>
+
+using namespace clang;
+using namespace ssaf;
+using testing::ElementsAre;
+
+namespace {
+
+static std::vector<unsigned> levelsOf(const DeclPointerLevels &DPLs) {
+  std::vector<unsigned> Levels;
+  for (const DeclPointerLevel &DPL : DPLs)
+    Levels.push_back(DPL.PointerLevel);
+  return Levels;
+}
+
+// `elaborateHigherDeclPointerLevels` expands a DeclPointerLevel into an
+// ascending, exhaustive vector of DeclPointerLevels for the same declaration,
+// from the given level up to the maximum pointer level of the declared type.
+TEST(EntityPointerLevelTest, ElaborateHigherDeclPointerLevels) {
+  std::unique_ptr<ASTUnit> AST =
+      tooling::buildASTFromCodeWithArgs(R"cpp(
+    int *p;         // one pointer level
+    int **q;        // two pointer levels
+    int ***r;       // three pointer levels
+    int *arr[10];   // array of pointers: two levels (array + pointer)
+  )cpp",
+                                        {"-Wno-unused"});
+  ASSERT_TRUE(AST);
+  ASTContext &Ctx = AST->getASTContext();
+
+  // Elaborate the decl named `Name` starting at `StartLevel`, checking that
+  // every result shares the input's declaration and is-return flag, and return
+  // the produced pointer levels.
+  auto elaborate = [&](StringRef Name, unsigned StartLevel) {
+    const NamedDecl *ND = findDeclByName(Name, Ctx);
+    EXPECT_NE(ND, nullptr) << "decl not found: " << Name.str();
+    if (!ND)
+      return std::vector<unsigned>{};
+    DeclPointerLevels DPLs = elaborateHigherDeclPointerLevels(
+        DeclPointerLevel{ND, StartLevel, /*IsReturn=*/false});
+    for (const DeclPointerLevel &DPL : DPLs) {
+      EXPECT_TRUE(DPL.Decl == ND);
+      EXPECT_FALSE(DPL.IsReturn);
+    }
+    return levelsOf(DPLs);
+  };
+
+  EXPECT_THAT(elaborate("p", 1), ElementsAre(1U));         // int*
+  EXPECT_THAT(elaborate("q", 1), ElementsAre(1U, 2U));     // int**
+  EXPECT_THAT(elaborate("r", 1), ElementsAre(1U, 2U, 3U)); // int***
+  EXPECT_THAT(elaborate("arr", 1), ElementsAre(1U, 2U));   // int*[10]
+  EXPECT_THAT(elaborate("r", 2), ElementsAre(2U, 3U));
+  EXPECT_THAT(elaborate("r", 3), ElementsAre(3U));
+}
+
+// For a function entity (IsReturn=true), the maximum pointer level is bounded
+// by the return type, whose reference must be stripped first.
+TEST(EntityPointerLevelTest, ElaborateHigherDeclPointerLevelsForReturn) {
+  std::unique_ptr<ASTUnit> AST =
+      tooling::buildASTFromCodeWithArgs(R"cpp(
+    int **&refret();  // reference to int**: two pointer levels
+    int *valret();    // int*: one pointer level
+  )cpp",
+                                        {"-Wno-unused"});
+  ASSERT_TRUE(AST);
+  ASTContext &Ctx = AST->getASTContext();
+
+  auto elaborateReturn = [&](StringRef Name, unsigned StartLevel) {
+    const FunctionDecl *FD = findFnByName(Name, Ctx);
+    EXPECT_NE(FD, nullptr) << "function not found: " << Name.str();
+    if (!FD)
+      return std::vector<unsigned>{};
+    DeclPointerLevels DPLs = elaborateHigherDeclPointerLevels(
+        DeclPointerLevel{FD, StartLevel, /*IsReturn=*/true});
+    for (const DeclPointerLevel &DPL : DPLs) {
+      EXPECT_TRUE(DPL.Decl == FD);
+      EXPECT_TRUE(DPL.IsReturn);
+    }
+    return levelsOf(DPLs);
+  };
+
+  EXPECT_THAT(elaborateReturn("refret", 1), ElementsAre(1U, 2U)); // int**&
+  EXPECT_THAT(elaborateReturn("valret", 1), ElementsAre(1U));     // int*
+}
+
+} // namespace

--- a/clang/unittests/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevelTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevelTest.cpp
@@ -69,7 +69,7 @@ template <typename... Levels> auto hasPointerLevels(Levels... Ls) {
 /// belongs to that declaration.
 template <typename DeclT = NamedDecl>
 DeclPointerLevelVec elaborateFor(ASTContext &Ctx, StringRef Name,
-                               unsigned StartLevel, bool IsReturn = false) {
+                                 unsigned StartLevel, bool IsReturn = false) {
   const DeclT *ND = findDeclByName<DeclT>(Name, Ctx);
   EXPECT_TRUE(ND) << "decl not found: " << Name.str();
   if (!ND)

--- a/clang/unittests/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevelTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevelTest.cpp
@@ -10,68 +10,126 @@
 #include "FindDecl.h"
 #include "clang/AST/Decl.h"
 #include "clang/Frontend/ASTUnit.h"
+#include "clang/Frontend/SSAFOptions.h"
+#include "clang/ScalableStaticAnalysis/Core/Model/BuildNamespace.h"
+#include "clang/ScalableStaticAnalysis/Core/TUSummary/TUSummary.h"
+#include "clang/ScalableStaticAnalysis/Core/TUSummary/TUSummaryBuilder.h"
+#include "clang/ScalableStaticAnalysis/Core/TUSummary/TUSummaryExtractor.h"
 #include "clang/Tooling/Tooling.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Testing/Support/Error.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include <memory>
-#include <vector>
+#include <ostream>
 
 using namespace clang;
 using namespace ssaf;
+using testing::AllOf;
+using testing::Each;
 using testing::ElementsAre;
+using testing::Field;
+using testing::Matcher;
+using testing::Property;
+using testing::UnorderedElementsAre;
+
+namespace clang::ssaf {
+// Let gmock print DeclPointerLevels by declaration name.  Found by ADL, so it
+// must live in the namespace of `DeclPointerLevel`.
+void PrintTo(const DeclPointerLevel &DPL, std::ostream *OS) {
+  *OS << "DeclPointerLevel { Decl: '"
+      << (DPL.Decl ? DPL.Decl->getNameAsString() : "<null>")
+      << "', PointerLevel: " << DPL.PointerLevel
+      << ", IsReturn: " << (DPL.IsReturn ? "true" : "false") << " }";
+}
+} // namespace clang::ssaf
 
 namespace {
 
-static std::vector<unsigned> levelsOf(const DeclPointerLevels &DPLs) {
-  std::vector<unsigned> Levels;
-  for (const DeclPointerLevel &DPL : DPLs)
-    Levels.push_back(DPL.PointerLevel);
-  return Levels;
+/// Matches a DeclPointerLevel at pointer level \p Level.
+Matcher<const DeclPointerLevel &> hasPointerLevel(unsigned Level) {
+  return Field("PointerLevel", &DeclPointerLevel::PointerLevel, Level);
 }
+
+/// Matches a DeclPointerLevel of \p ND, for the entity kind selected by
+/// \p IsReturn.
+Matcher<const DeclPointerLevel &> isLevelOfDecl(const NamedDecl *ND,
+                                                bool IsReturn) {
+  return AllOf(Field("Decl", &DeclPointerLevel::Decl, ND),
+               Field("IsReturn", &DeclPointerLevel::IsReturn, IsReturn));
+}
+
+/// Matches exactly the given pointer levels, in order.
+template <typename... Levels> auto hasPointerLevels(Levels... Ls) {
+  return ElementsAre(hasPointerLevel(Ls)...);
+}
+
+/// Elaborates the DeclPointerLevel of the \p DeclT named \p Name in \p Ctx,
+/// starting at pointer level \p StartLevel, and checks that every result
+/// belongs to that declaration.
+template <typename DeclT = NamedDecl>
+DeclPointerLevelVec elaborateFor(ASTContext &Ctx, StringRef Name,
+                               unsigned StartLevel, bool IsReturn = false) {
+  const DeclT *ND = findDeclByName<DeclT>(Name, Ctx);
+  EXPECT_TRUE(ND) << "decl not found: " << Name.str();
+  if (!ND)
+    return {};
+
+  DeclPointerLevelVec DPLs = elaborateHigherDeclPointerLevels(
+      DeclPointerLevel{ND, StartLevel, IsReturn});
+  EXPECT_THAT(DPLs, Each(isLevelOfDecl(ND, IsReturn)));
+  return DPLs;
+}
+
+/// Matches an EntityPointerLevel with the given entity and pointer level.
+auto isEntityPointerLevel(EntityId Id, unsigned Level) {
+  return AllOf(
+      Property("getEntity", &EntityPointerLevel::getEntity, Id),
+      Property("getPointerLevel", &EntityPointerLevel::getPointerLevel, Level));
+}
+
+struct EntityPointerLevelTest : testing::Test {
+  SSAFOptions Opts;
+  TUSummary Summary{
+      llvm::Triple("fake-unittest-triple"),
+      BuildNamespace(BuildNamespaceKind::CompilationUnit, "Mock.cpp")};
+  TUSummaryBuilder Builder{Summary, Opts};
+  TUSummaryExtractor Extractor{Builder};
+};
 
 // `elaborateHigherDeclPointerLevels` expands a DeclPointerLevel into an
 // ascending, exhaustive vector of DeclPointerLevels for the same declaration,
 // from the given level up to the maximum pointer level of the declared type.
-TEST(EntityPointerLevelTest, ElaborateHigherDeclPointerLevels) {
+TEST_F(EntityPointerLevelTest, ElaborateHigherDeclPointerLevels) {
   std::unique_ptr<ASTUnit> AST =
       tooling::buildASTFromCodeWithArgs(R"cpp(
     int *p;         // one pointer level
     int **q;        // two pointer levels
     int ***r;       // three pointer levels
     int *arr[10];   // array of pointers: two levels (array + pointer)
+    int mat[3][4];  // 2D array: two levels
+    typedef int *IP;
+    IP *pp;         // sugar for `int **`: two levels
   )cpp",
                                         {"-Wno-unused"});
   ASSERT_TRUE(AST);
   ASTContext &Ctx = AST->getASTContext();
 
-  // Elaborate the decl named `Name` starting at `StartLevel`, checking that
-  // every result shares the input's declaration and is-return flag, and return
-  // the produced pointer levels.
-  auto elaborate = [&](StringRef Name, unsigned StartLevel) {
-    const NamedDecl *ND = findDeclByName(Name, Ctx);
-    EXPECT_NE(ND, nullptr) << "decl not found: " << Name.str();
-    if (!ND)
-      return std::vector<unsigned>{};
-    DeclPointerLevels DPLs = elaborateHigherDeclPointerLevels(
-        DeclPointerLevel{ND, StartLevel, /*IsReturn=*/false});
-    for (const DeclPointerLevel &DPL : DPLs) {
-      EXPECT_TRUE(DPL.Decl == ND);
-      EXPECT_FALSE(DPL.IsReturn);
-    }
-    return levelsOf(DPLs);
-  };
-
-  EXPECT_THAT(elaborate("p", 1), ElementsAre(1U));         // int*
-  EXPECT_THAT(elaborate("q", 1), ElementsAre(1U, 2U));     // int**
-  EXPECT_THAT(elaborate("r", 1), ElementsAre(1U, 2U, 3U)); // int***
-  EXPECT_THAT(elaborate("arr", 1), ElementsAre(1U, 2U));   // int*[10]
-  EXPECT_THAT(elaborate("r", 2), ElementsAre(2U, 3U));
-  EXPECT_THAT(elaborate("r", 3), ElementsAre(3U));
+  EXPECT_THAT(elaborateFor(Ctx, "p", 1), hasPointerLevels(1));       // int*
+  EXPECT_THAT(elaborateFor(Ctx, "q", 1), hasPointerLevels(1, 2));    // int**
+  EXPECT_THAT(elaborateFor(Ctx, "r", 1), hasPointerLevels(1, 2, 3)); // int***
+  EXPECT_THAT(elaborateFor(Ctx, "arr", 1), hasPointerLevels(1, 2));  // int*[10]
+  EXPECT_THAT(elaborateFor(Ctx, "mat", 1), hasPointerLevels(1, 2)); // int[3][4]
+  EXPECT_THAT(elaborateFor(Ctx, "pp", 1), hasPointerLevels(1, 2));  // IP*
+  EXPECT_THAT(elaborateFor(Ctx, "r", 2), hasPointerLevels(2, 3));
+  EXPECT_THAT(elaborateFor(Ctx, "r", 3), hasPointerLevels(3));
+  // A level beyond the declared type's level count is preserved as is:
+  EXPECT_THAT(elaborateFor(Ctx, "p", 2), hasPointerLevels(2));
 }
 
 // For a function entity (IsReturn=true), the maximum pointer level is bounded
 // by the return type, whose reference must be stripped first.
-TEST(EntityPointerLevelTest, ElaborateHigherDeclPointerLevelsForReturn) {
+TEST_F(EntityPointerLevelTest, ElaborateHigherDeclPointerLevelsForReturn) {
   std::unique_ptr<ASTUnit> AST =
       tooling::buildASTFromCodeWithArgs(R"cpp(
     int **&refret();  // reference to int**: two pointer levels
@@ -81,22 +139,45 @@ TEST(EntityPointerLevelTest, ElaborateHigherDeclPointerLevelsForReturn) {
   ASSERT_TRUE(AST);
   ASTContext &Ctx = AST->getASTContext();
 
-  auto elaborateReturn = [&](StringRef Name, unsigned StartLevel) {
-    const FunctionDecl *FD = findFnByName(Name, Ctx);
-    EXPECT_NE(FD, nullptr) << "function not found: " << Name.str();
-    if (!FD)
-      return std::vector<unsigned>{};
-    DeclPointerLevels DPLs = elaborateHigherDeclPointerLevels(
-        DeclPointerLevel{FD, StartLevel, /*IsReturn=*/true});
-    for (const DeclPointerLevel &DPL : DPLs) {
-      EXPECT_TRUE(DPL.Decl == FD);
-      EXPECT_TRUE(DPL.IsReturn);
-    }
-    return levelsOf(DPLs);
-  };
+  EXPECT_THAT(elaborateFor<FunctionDecl>(Ctx, "refret", 1, /*IsReturn=*/true),
+              hasPointerLevels(1, 2)); // int**&
+  EXPECT_THAT(elaborateFor<FunctionDecl>(Ctx, "valret", 1, /*IsReturn=*/true),
+              hasPointerLevels(1)); // int*
+}
 
-  EXPECT_THAT(elaborateReturn("refret", 1), ElementsAre(1U, 2U)); // int**&
-  EXPECT_THAT(elaborateReturn("valret", 1), ElementsAre(1U));     // int*
+TEST_F(EntityPointerLevelTest, ToEntityPointerLevel) {
+  std::unique_ptr<ASTUnit> AST =
+      tooling::buildASTFromCodeWithArgs(R"cpp(
+    int ***p;
+    int **&refret();
+  )cpp",
+                                        {"-Wno-unused"});
+  ASSERT_TRUE(AST);
+  ASTContext &Ctx = AST->getASTContext();
+
+  const NamedDecl *ND = findDeclByName("p", Ctx);
+  ASSERT_TRUE(ND);
+  std::optional<EntityId> PId = Extractor.addEntity(ND);
+  ASSERT_TRUE(PId);
+
+  const FunctionDecl *FD = findFnByName("refret", Ctx);
+  ASSERT_TRUE(FD);
+  std::optional<EntityId> RefretId = Extractor.addEntityForReturn(FD);
+  ASSERT_TRUE(RefretId);
+
+  DeclPointerLevelVec DPLs =
+      elaborateHigherDeclPointerLevels({ND, 1, /*IsReturn=*/false});
+  DeclPointerLevelVec ReturnDPLs =
+      elaborateHigherDeclPointerLevels({FD, 1, /*IsReturn=*/true});
+  DPLs.append(ReturnDPLs.begin(), ReturnDPLs.end());
+  DPLs.push_back(DPLs.front()); // duplicate, to exercise de-duplication
+
+  ASSERT_THAT_EXPECTED(
+      toEntityPointerLevels(DPLs, Ctx, Extractor),
+      llvm::HasValue(UnorderedElementsAre(
+          isEntityPointerLevel(*PId, 1), isEntityPointerLevel(*PId, 2),
+          isEntityPointerLevel(*PId, 3), isEntityPointerLevel(*RefretId, 1),
+          isEntityPointerLevel(*RefretId, 2))));
 }
 
 } // namespace

--- a/clang/unittests/ScalableStaticAnalysis/CMakeLists.txt
+++ b/clang/unittests/ScalableStaticAnalysis/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_distinct_clang_unittest(ClangScalableAnalysisTests
+  Analyses/EntityPointerLevel/EntityPointerLevelTest.cpp
   Analyses/PointerFlow/PointerFlowTest.cpp
   Analyses/PointerFlow/PointerFlowWPATest.cpp
   Analyses/CallGraph/CallGraphExtractorTest.cpp


### PR DESCRIPTION
This is the first of three patches aimed at solving a non-termination problem when using DFS in the pointer-flow graph.

Problem & context:
Currently, the pointer-flow graph creates exactly one edge corresponding to an assignment in the source code. For example, a pointer assignment `p = q;` results in an edge `(p, i) -> (q, j)` for some pointer levels `i` and `j`. In unsafe buffer propagation, this edge encodes the meaning that if `p` is bounded, `q` must also be bounded. Additionally, if `*p/p[x]` is bounded, `*q/q[y]` must be bounded, and so on until the maximum pointer level of `p` or `q` is reached.

Because of this, during DFS, a node `(p, i+1)` can reach `(q, j+1)` through the edge `(p, i) -> (q, j)`. This logic is correct only when `p` and `q` have compatible types, which is true for most cases due to standard type checking. However, this assumption breaks down with pointer casts. A cast like `a = (T)b` contributes an edge `(a, x) -> (b, y)` where `a` and `b` do not have compatible types. Consequently, the graph can contain cycles such as `(a, 1) -> (b, 2)` and `(b, 1) -> (a, 2)`. Because type information is abstracted out during DFS, we do not know the exact pointer level upper bounds to limit this growth, causing the DFS to loop indefinitely as pointer levels keep growing.

Solution:
To fix this, the pointer-flow graph must explicitly include the finite set of edges encoded by each assignment. Since type information is available during graph construction, we can use it to compute upper bounds. Consequently, the graph search can go back to being simple and guaranteed to terminate.

As a first step toward that solution, this patch introduces a new data structure: `DeclPointerLevel`. A `DeclPointerLevel` differs from an `EntityPointerLevel` only in that it retains the AST Decl node instead of directly abstracting it to an Entity.  The AST node carries crucial information, such as types, which can be used by extractors before converting `DeclPointerLevels` to `EntityPointerLevels`.

First step for:
rdar://183529483