### PR TITLE
[CopyProf] Prefer RequirePassInfoMixin

### DIFF
--- a/llvm/include/llvm/Transforms/Instrumentation/CopyProf.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/CopyProf.h
@@ -20,7 +20,7 @@ namespace llvm {
 
 // Early-stage pass that instruments special member functions to call into the
 // CopyProf runtime.
-class CopyProfPass : public PassInfoMixin<CopyProfPass> {
+class CopyProfPass : public RequiredPassInfoMixin<CopyProfPass> {
 public:
   CopyProfPass() = default;
   LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
@@ -30,7 +30,7 @@ public:
 
 // Module-level pass that inserts the CopyProf runtime initialization
 // constructor and hooks it into @llvm.global_ctors.
-class ModuleCopyProfPass : public PassInfoMixin<ModuleCopyProfPass> {
+class ModuleCopyProfPass : public RequiredPassInfoMixin<ModuleCopyProfPass> {
 public:
   ModuleCopyProfPass() = default;
   LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
@@ -40,7 +40,7 @@ public:
 
 // Late-stage pass that instruments store instructions to detect whether an
 // object copy has been modified before it is destructed.
-class CopyProfStoresPass : public PassInfoMixin<CopyProfStoresPass> {
+class CopyProfStoresPass : public RequiredPassInfoMixin<CopyProfStoresPass> {
 public:
   CopyProfStoresPass() = default;
   LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);


### PR DESCRIPTION
PassInfoMixin will be removed soon. Given these passes are sanitizer
passes, we also probably want them to run regardless of the presence of
optnone.
