### PR TITLE
[flang][test] Link designator-path test with FortranParser

### DIFF
--- a/flang/unittests/Evaluate/CMakeLists.txt
+++ b/flang/unittests/Evaluate/CMakeLists.txt
@@ -25,6 +25,7 @@ add_flang_nongtest_unittest(designator-path
   NonGTestTesting
   FortranEvaluate
   FortranSemantics
+  FortranParser
 )
 
 add_flang_nongtest_unittest(integer


### PR DESCRIPTION
This is the missing build dependency that wasn't added to https://github.com/llvm/llvm-project/pull/211606. 
It should resolve a some of the build bot failures that have been reported there.