### PR TITLE
[VPlan] Strip bad FIXME in expand-scev (NFC)

### DIFF
--- a/llvm/test/Transforms/LoopVectorize/VPlan/expand-scev.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/expand-scev.ll
@@ -283,7 +283,6 @@ exit:
   ret void
 }
 
-; FIXME: shl incorrectly carries nsw.
 ; Test for https://github.com/llvm/llvm-project/issues/205252.
 define i32 @mul_by_signed_min_expanded_to_shl(i1 %a) {
 ; CHECK-LABEL: VPlan for loop in 'mul_by_signed_min_expanded_to_shl'


### PR DESCRIPTION
7be188763a ([VPlan] Don't preserve NSW in mul -> shl conversion for bw-1 op) missed stripping it.