### PR TITLE
[Transforms] Remove unused replaceDbgUsesWithUndef

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/Local.h
+++ b/llvm/include/llvm/Transforms/Utils/Local.h
@@ -144,12 +144,6 @@ LLVM_ABI bool
 SimplifyInstructionsInBlock(BasicBlock *BB,
                             const TargetLibraryInfo *TLI = nullptr);
 
-/// Replace all the uses of an SSA value in @llvm.dbg intrinsics with
-/// undef. This is useful for signaling that a variable, e.g. has been
-/// found dead and hence it's unavailable at a given program point.
-/// Returns true if the dbg values have been changed.
-LLVM_ABI bool replaceDbgUsesWithUndef(Instruction *I);
-
 //===----------------------------------------------------------------------===//
 //  Control Flow Graph Restructuring.
 //

--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -609,14 +609,6 @@ void llvm::RecursivelyDeleteTriviallyDeadInstructions(
   }
 }
 
-bool llvm::replaceDbgUsesWithUndef(Instruction *I) {
-  SmallVector<DbgVariableRecord *, 1> DPUsers;
-  findDbgUsers(I, DPUsers);
-  for (auto *DVR : DPUsers)
-    DVR->setKillLocation();
-  return !DPUsers.empty();
-}
-
 /// areAllUsesEqual - Check whether the uses of a value are all the same.
 /// This is similar to Instruction::hasOneUse() except this will also return
 /// true when there are no uses or multiple uses that all refer to the same


### PR DESCRIPTION
The last use was removed on Mar 5, 2026 in
commit e3b62ffcd8592cf234174057b4581adb1eecbf9c.
