### PR TITLE
workflows/release-binaries: Use self-repository reference for validate-release-version

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -76,7 +76,7 @@ jobs:
 
     - name: Validate Release Version
       if: inputs.release-version != ''
-      uses: ./.github/workflows/validate-release-version
+      uses: $/.github/workflows/validate-release-version
       with:
         release-version: ${{ inputs.release-version }}
 


### PR DESCRIPTION
https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/