### PR TITLE
workflows/get-llvm-version: Make this action standalone

### DIFF
--- a/.github/workflows/get-llvm-version/action.yml
+++ b/.github/workflows/get-llvm-version/action.yml
@@ -21,12 +21,21 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
+        path: get-llvm-version
+        sparse-checkout: |
+          llvm/utils/release/get-llvm-version.sh
+          cmake/Modules/LLVMVersion.cmake
+        sparse-checkout-cone-mode: false
+
     - name: Get Version
       shell: bash
       id: version
       run: |
         for v in major minor patch; do
-          echo "$v=`llvm/utils/release/get-llvm-version.sh --$v`" >> $GITHUB_OUTPUT
+          echo "$v=`./get-llvm-version/llvm/utils/release/get-llvm-version.sh --$v`" >> $GITHUB_OUTPUT
         done
 
-        echo "full-no-suffix=$(llvm/utils/release/get-llvm-version.sh)" >> $GITHUB_OUTPUT
+        echo "full-no-suffix=$(./get-llvm-version/llvm/utils/release/get-llvm-version.sh)" >> $GITHUB_OUTPUT

--- a/.github/workflows/libclang-abi-tests.yml
+++ b/.github/workflows/libclang-abi-tests.yml
@@ -37,15 +37,9 @@ jobs:
       LLVM_VERSION_MINOR: ${{ steps.version.outputs.minor }}
       LLVM_VERSION_PATCH: ${{ steps.version.outputs.patch }}
     steps:
-      - name: Checkout source
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-          fetch-depth: 250
-
       - name: Get LLVM version
         id: version
-        uses: ./.github/workflows/get-llvm-version
+        uses: $/.github/workflows/get-llvm-version
 
       - name: Setup Variables
         id: vars

--- a/.github/workflows/llvm-abi-tests.yml
+++ b/.github/workflows/llvm-abi-tests.yml
@@ -37,15 +37,9 @@ jobs:
       LLVM_VERSION_MINOR: ${{ steps.version.outputs.minor }}
       LLVM_VERSION_PATCH: ${{ steps.version.outputs.patch }}
     steps:
-      - name: Checkout source
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-          fetch-depth: 250
-
       - name: Get LLVM version
         id: version
-        uses: ./.github/workflows/get-llvm-version
+        uses: $/.github/workflows/get-llvm-version
 
       - name: Setup Variables
         id: vars

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -69,11 +69,6 @@ jobs:
       attestation-name: ${{ steps.vars.outputs.attestation-name }}
 
     steps:
-    - name: Checkout LLVM
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-          persist-credentials: false
-
     - name: Validate Release Version
       if: inputs.release-version != ''
       uses: $/.github/workflows/validate-release-version
@@ -84,7 +79,7 @@ jobs:
     # to fetch it here.
     - id: version-from-source
       if: runner.os == 'Windows'
-      uses: ./.github/workflows/get-llvm-version
+      uses: $/.github/workflows/get-llvm-version
 
     - name: Collect Variables
       id: vars


### PR DESCRIPTION
You can use this action now without first checking out the llvm-project source code.