### PR TITLE
[clang-tidy] Fix modernize-use-noexcept crash on unparsed exception specs

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseNoexceptCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseNoexceptCheck.cpp
@@ -76,7 +76,8 @@ void UseNoexceptCheck::check(const MatchFinder::MatchResult &Result) {
   }
 
   assert(FnTy && "FunctionProtoType is null.");
-  if (isUnresolvedExceptionSpec(FnTy->getExceptionSpecType()))
+  if (FnTy->getExceptionSpecType() == EST_Unparsed ||
+      isUnresolvedExceptionSpec(FnTy->getExceptionSpecType()))
     return;
 
   assert(Range.isValid() && "Exception Source Range is invalid.");

--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -168,6 +168,10 @@ infrastructure are described first, followed by tool-specific sections.
   `std::initializer_list` constructor, as the braced form could select a
   different constructor.
 
+- Fixed a crash in {doc}`modernize-use-noexcept
+  <clang-tidy/checks/modernize/use-noexcept>` when analyzing malformed template
+  code with an unparsed exception specification.
+
 - Improved {doc}`performance-inefficient-algorithm
   <clang-tidy/checks/performance/inefficient-algorithm>` check to no longer
   produce a fix with the container or the searched-for value missing, such as

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-noexcept-unparsed-exception-spec.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-noexcept-unparsed-exception-spec.cpp
@@ -1,0 +1,12 @@
+// RUN: %check_clang_tidy -std=c++11,c++14 -check-suffix=COMMON -expect-clang-tidy-error %s modernize-use-noexcept %t
+// RUN: %check_clang_tidy -std=c++17-or-later -check-suffixes=COMMON,CXX17 -expect-clang-tidy-error %s modernize-use-noexcept %t
+
+struct S {
+  template <typename T>
+  static void f() throw(typename T::X);
+  // CHECK-MESSAGES-CXX17: :[[@LINE-1]]:19: error: ISO C++17 does not allow dynamic exception specifications [clang-diagnostic-dynamic-exception-spec]
+  // CHECK-MESSAGES-COMMON: :[[@LINE-2]]:19: warning: dynamic exception specification 'throw(typename T::X)' is deprecated; consider using 'noexcept(false)' instead [modernize-use-noexcept]
+
+  typedef decltype(f<S>()) X;
+  // CHECK-MESSAGES-COMMON: :[[@LINE-1]]:20: error: exception specification is not available until end of class definition [clang-diagnostic-error]
+};


### PR DESCRIPTION
A failed template instantiation can leave a function type with an `EST_Unparsed` exception specification. 
`modernize-use-noexcept` currently calls `FunctionProtoType::isNothrow()` for that type, which reaches an unreachable path in `FunctionProtoType::canThrow()`.

This fixes the crash by skipping unparsed exception specifications before querying whether the function is non-throwing.

Fixes #214291