### PR TITLE
[Clang] Clear outer SubstIndex when normalizing PackIndexingType

### DIFF
--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -7124,6 +7124,10 @@ TreeTransform<Derived>::TransformPackIndexingType(TypeLocBuilder &TLB,
 
   for (QualType T : Types) {
     if (!T->containsUnexpandedParameterPack()) {
+      // A pack indexing type can appear in a larger pack expansion,
+      // e.g. `Pack...[pack_of_indexes]...`
+      // so we need to temporarily disable substitution of pack elements
+      Sema::ArgPackSubstIndexRAII SubstIndex(getSema(), std::nullopt);
       QualType Transformed = getDerived().TransformType(T);
       if (Transformed.isNull())
         return QualType();

--- a/clang/test/SemaCXX/cxx2c-fold-exprs.cpp
+++ b/clang/test/SemaCXX/cxx2c-fold-exprs.cpp
@@ -629,3 +629,15 @@ static_assert(MutabilityAlias<Constant::alias>);
 static_assert(MutabilityAlias<Mutable::alias>);
 
 }
+
+namespace GH218035 {
+
+template <class T, class UnusedParam>
+concept same_as_impl = sizeof(T) == 8;
+template <typename... P>
+void f()
+  requires(same_as_impl<P...[0], P> && ...)
+{}
+void g() { f<long long, float>(); }
+
+}


### PR DESCRIPTION
When we instantiate a fold-expression concept we expand the template arguments outside of the TreeTransform. However a PackIndexingType should gain its own index from the index expression, not the outer SubstIndex.

The bug occurs because we don't support rewrite of PackIndexingType, which the default transform unexpectedly expands the pattern in the normalization so that the instantiation picks up the outer SubstIndex that is set up for a fold expression.

This is identical to the [fix to the pattern transform](https://github.com/llvm/llvm-project/pull/90195), and in fact we're unnecessarily transforming the pattern of PackIndexingType repeatedly.

This is a regression since #161671, so no release note for backporting.

Fixes #218035