### PR TITLE
[Clang][Sema] Make _Imag int/float LValue not assignable

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -511,6 +511,7 @@ features cannot lower the translation-unit ABI level;
 - Fixed a bug where repeated #imports of modular headers in non-modular compilation were translated to #pragma clang module import. (#GH216924)
 - Fixed an assertion when `#pragma omp declare simd` or `#pragma omp declare variant` is followed by another OpenMP declarative directive containing a qualified identifier. (#GH217204)
 - Fixed a crash when an `asm` label names the register for a global variable of incomplete type. (#GH219746)
+- Fixed an ICE hat occurred when using `__imag int/float` as lvalue in assignment. (#GH119498)
 
 #### Bug Fixes to Compiler Builtins
 

--- a/clang/lib/AST/ExprClassification.cpp
+++ b/clang/lib/AST/ExprClassification.cpp
@@ -283,7 +283,7 @@ static Cl::Kinds ClassifyInternal(ASTContext &Ctx, const Expr *E) {
     return ClassifyMemberExpr(Ctx, cast<MemberExpr>(E));
 
   case Expr::UnaryOperatorClass:
-    switch (cast<UnaryOperator>(E)->getOpcode()) {
+    switch (auto UnaryOp = cast<UnaryOperator>(E)->getOpcode()) {
       // C++ [expr.unary.op]p1: The unary * operator performs indirection:
       //   [...] the result is an lvalue referring to the object or function
       //   to which the expression points.
@@ -304,6 +304,11 @@ static Cl::Kinds ClassifyInternal(ASTContext &Ctx, const Expr *E) {
 
       if (isa<ObjCPropertyRefExpr>(Op))
         return Cl::CL_SubObjCPropertySetting;
+
+      // _Imag with non-complex operand is not a valid l-value
+      if (UnaryOp == UO_Imag && !Op->getType()->isAnyComplexType())
+        return Cl::CL_PRValue;
+
       return Cl::CL_LValue;
     }
 

--- a/clang/lib/AST/ExprClassification.cpp
+++ b/clang/lib/AST/ExprClassification.cpp
@@ -306,7 +306,7 @@ static Cl::Kinds ClassifyInternal(ASTContext &Ctx, const Expr *E) {
       if (isa<ObjCPropertyRefExpr>(Op))
         return Cl::CL_SubObjCPropertySetting;
 
-      // _Imag with non-complex operand is not a valid l-value
+      // _Imag with non-complex operand is not a valid l-value.
       if (UnaryOp->getOpcode() == UO_Imag && !Op->getType()->isAnyComplexType())
         return Cl::CL_PRValue;
 

--- a/clang/lib/AST/ExprClassification.cpp
+++ b/clang/lib/AST/ExprClassification.cpp
@@ -283,7 +283,7 @@ static Cl::Kinds ClassifyInternal(ASTContext &Ctx, const Expr *E) {
     return ClassifyMemberExpr(Ctx, cast<MemberExpr>(E));
 
   case Expr::UnaryOperatorClass:
-    switch (auto UnaryOp = cast<UnaryOperator>(E)->getOpcode()) {
+    switch (cast<UnaryOperator>(E)->getOpcode()) {
       // C++ [expr.unary.op]p1: The unary * operator performs indirection:
       //   [...] the result is an lvalue referring to the object or function
       //   to which the expression points.
@@ -298,7 +298,8 @@ static Cl::Kinds ClassifyInternal(ASTContext &Ctx, const Expr *E) {
     // expressions:  l-value only if the operand is a true l-value.
     case UO_Real:
     case UO_Imag: {
-      const Expr *Op = cast<UnaryOperator>(E)->getSubExpr()->IgnoreParens();
+      const auto *UnaryOp = cast<UnaryOperator>(E);
+      const Expr *Op = UnaryOp->getSubExpr()->IgnoreParens();
       Cl::Kinds K = ClassifyInternal(Ctx, Op);
       if (K != Cl::CL_LValue) return K;
 
@@ -306,7 +307,7 @@ static Cl::Kinds ClassifyInternal(ASTContext &Ctx, const Expr *E) {
         return Cl::CL_SubObjCPropertySetting;
 
       // _Imag with non-complex operand is not a valid l-value
-      if (UnaryOp == UO_Imag && !Op->getType()->isAnyComplexType())
+      if (UnaryOp->getOpcode() == UO_Imag && !Op->getType()->isAnyComplexType())
         return Cl::CL_PRValue;
 
       return Cl::CL_LValue;

--- a/clang/test/SemaCXX/imag-lvalue-with-non-complex-operand.cpp
+++ b/clang/test/SemaCXX/imag-lvalue-with-non-complex-operand.cpp
@@ -22,7 +22,8 @@ _Complex float baz()
 {
   float f;
   __real__ f = 0;
-  __imag__ }      // expected-error {{expected expression}}
+  __imag__
+} // expected-error {{expected expression}}
 
 
 typedef float C;

--- a/clang/test/SemaCXX/imag-lvalue-with-non-complex-operand.cpp
+++ b/clang/test/SemaCXX/imag-lvalue-with-non-complex-operand.cpp
@@ -10,7 +10,7 @@ void lvalue_with_imag_float() {
   __imag__ i = 0;   // expected-error {{expression is not assignable}}
 }
 
-_Complex float foo() // expected-note {{previous definition is here}}
+_Complex float foo()
 {
   float f;
   __real__ f = 0;
@@ -25,11 +25,11 @@ _Complex float baz()
   __imag__ }      // expected-error {{expected expression}}
 
 
-typedef _Complex float C;
-C foo()          // expected-error {{redefinition of 'foo'}}
+typedef float C;
+C lvalue_with_imag_float_with_typedef()
 {
   C f;
   __real__ f = 0;
-  __imag__ f = 0;
+  __imag__ f = 0;   // expected-error {{expression is not assignable}}
   return f;
 }

--- a/clang/test/SemaCXX/imag-lvalue-with-non-complex-operand.cpp
+++ b/clang/test/SemaCXX/imag-lvalue-with-non-complex-operand.cpp
@@ -1,0 +1,35 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+void lvalue_with_imag_int() {
+  int i;
+  __imag__ i = 0;   // expected-error {{expression is not assignable}}
+}
+
+void lvalue_with_imag_float() {
+  float i;
+  __imag__ i = 0;   // expected-error {{expression is not assignable}}
+}
+
+_Complex float foo() // expected-note {{previous definition is here}}
+{
+  float f;
+  __real__ f = 0;
+  __imag__ f = 0;    // expected-error {{expression is not assignable}}
+  return f;
+}
+
+_Complex float baz()
+{
+  float f;
+  __real__ f = 0;
+  __imag__ }      // expected-error {{expected expression}}
+
+
+typedef _Complex float C;
+C foo()          // expected-error {{redefinition of 'foo'}}
+{
+  C f;
+  __real__ f = 0;
+  __imag__ f = 0;
+  return f;
+}


### PR DESCRIPTION
Clang accepts `__real int/float` as an LValue because it's equal to the scalar value itself, so the assignment will work fine, but it's not the case for `__imag` because, for int and float, there is no imaginary part to assign a value to it, so in the sema we can reject this case, similar to GCC.

Fixes: #119498