### PR TITLE
[CIR] Regenerate CHECK lines for seventeen callconv opt-out tests

### DIFF
--- a/clang/test/CIR/CodeGen/cleanup-conditional.cpp
+++ b/clang/test/CIR/CodeGen/cleanup-conditional.cpp
@@ -1,11 +1,9 @@
-// TODO(cir): drop -fno-clangir-call-conv-lowering once CallConvLowering
-// supports _Complex types.
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-call-conv-lowering -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-call-conv-lowering -emit-llvm %s -o %t-cir.ll
-// RUN: FileCheck --input-file=%t-cir.ll %s --check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s --check-prefixes=LLVM,LLVMCIR
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
-// RUN: FileCheck --input-file=%t.ll %s --check-prefix=OGCG
+// RUN: FileCheck --input-file=%t.ll %s --check-prefixes=LLVM,OGCG
 
 struct S {
   S();
@@ -43,42 +41,42 @@ void test_ternary_temporary(bool c, int x) {
 // CIR:     cir.yield
 // CIR:   }
 
-// LLVM-LABEL: define dso_local void @_Z22test_ternary_temporarybi(
-// LLVM:         %[[TMP:.*]] = alloca %struct.S
-// LLVM:         %[[ACTIVE:.*]] = alloca i8
-// LLVM:         %[[RESULT_TMP:.*]] = alloca i32
-// LLVM:         br label %[[INIT:.*]]
-// LLVM:       [[INIT]]:
-// LLVM:         %[[COND_BYTE:.*]] = load i8, ptr %{{.*}}
-// LLVM:         %[[COND_BOOL:.*]] = trunc i8 %[[COND_BYTE]] to i1
-// LLVM:         store i8 0, ptr %[[ACTIVE]]
-// LLVM:         br i1 %[[COND_BOOL]], label %[[TRUE_BR:.*]], label %[[FALSE_BR:.*]]
-// LLVM:       [[TRUE_BR]]:
-// LLVM:         call void @_ZN1SC1Ev(ptr {{.*}} %[[TMP]])
-// LLVM:         store i8 1, ptr %[[ACTIVE]]
-// LLVM:         %[[GET_RESULT:.*]] = call {{.*}} i32 @_ZN1S3getEv(ptr {{.*}} %[[TMP]])
-// LLVM:         br label %[[MERGE:.*]]
-// LLVM:       [[FALSE_BR]]:
-// LLVM:         %[[XVAL:.*]] = load i32, ptr %{{.*}}
-// LLVM:         br label %[[MERGE]]
-// LLVM:       [[MERGE]]:
-// LLVM:         %[[PHI:.*]] = phi i32 [ %[[XVAL]], %[[FALSE_BR]] ], [ %[[GET_RESULT]], %[[TRUE_BR]] ]
-// LLVM:         br label %[[STORE:.*]]
-// LLVM:       [[STORE]]:
-// LLVM:         store i32 %[[PHI]], ptr %[[RESULT_TMP]]
-// LLVM:         br label %[[CLEANUP:.*]]
-// LLVM:       [[CLEANUP]]:
-// LLVM:         %[[ACTIVE_BYTE:.*]] = load i8, ptr %[[ACTIVE]]
-// LLVM:         %[[ACTIVE_BOOL:.*]] = trunc i8 %[[ACTIVE_BYTE]] to i1
-// LLVM:         br i1 %[[ACTIVE_BOOL]], label %[[DTOR:.*]], label %[[SKIP_DTOR:.*]]
-// LLVM:       [[DTOR]]:
-// LLVM:         call void @_ZN1SD1Ev(ptr {{.*}} %[[TMP]])
-// LLVM:         br label %[[SKIP_DTOR]]
-// LLVM:       [[SKIP_DTOR]]:
-// LLVM:         br label %[[EXIT:.*]]
-// LLVM:       [[EXIT]]:
-// LLVM:         %[[RESULT:.*]] = load i32, ptr %[[RESULT_TMP]]
-// LLVM:         store i32 %[[RESULT]], ptr %{{.*}}
+// LLVMCIR-LABEL: define dso_local void @_Z22test_ternary_temporarybi(
+// LLVMCIR:         %[[TMP:.*]] = alloca %struct.S
+// LLVMCIR:         %[[ACTIVE:.*]] = alloca i8
+// LLVMCIR:         %[[RESULT_TMP:.*]] = alloca i32
+// LLVMCIR:         br label %[[INIT:.*]]
+// LLVMCIR:       [[INIT]]:
+// LLVMCIR:         %[[COND_BYTE:.*]] = load i8, ptr %{{.*}}
+// LLVMCIR:         %[[COND_BOOL:.*]] = trunc i8 %[[COND_BYTE]] to i1
+// LLVMCIR:         store i8 0, ptr %[[ACTIVE]]
+// LLVMCIR:         br i1 %[[COND_BOOL]], label %[[TRUE_BR:.*]], label %[[FALSE_BR:.*]]
+// LLVMCIR:       [[TRUE_BR]]:
+// LLVMCIR:         call void @_ZN1SC1Ev(ptr {{.*}} %[[TMP]])
+// LLVMCIR:         store i8 1, ptr %[[ACTIVE]]
+// LLVMCIR:         %[[GET_RESULT:.*]] = call {{.*}} i32 @_ZN1S3getEv(ptr {{.*}} %[[TMP]])
+// LLVMCIR:         br label %[[MERGE:.*]]
+// LLVMCIR:       [[FALSE_BR]]:
+// LLVMCIR:         %[[XVAL:.*]] = load i32, ptr %{{.*}}
+// LLVMCIR:         br label %[[MERGE]]
+// LLVMCIR:       [[MERGE]]:
+// LLVMCIR:         %[[PHI:.*]] = phi i32 [ %[[XVAL]], %[[FALSE_BR]] ], [ %[[GET_RESULT]], %[[TRUE_BR]] ]
+// LLVMCIR:         br label %[[STORE:.*]]
+// LLVMCIR:       [[STORE]]:
+// LLVMCIR:         store i32 %[[PHI]], ptr %[[RESULT_TMP]]
+// LLVMCIR:         br label %[[CLEANUP:.*]]
+// LLVMCIR:       [[CLEANUP]]:
+// LLVMCIR:         %[[ACTIVE_BYTE:.*]] = load i8, ptr %[[ACTIVE]]
+// LLVMCIR:         %[[ACTIVE_BOOL:.*]] = trunc i8 %[[ACTIVE_BYTE]] to i1
+// LLVMCIR:         br i1 %[[ACTIVE_BOOL]], label %[[DTOR:.*]], label %[[SKIP_DTOR:.*]]
+// LLVMCIR:       [[DTOR]]:
+// LLVMCIR:         call void @_ZN1SD1Ev(ptr {{.*}} %[[TMP]])
+// LLVMCIR:         br label %[[SKIP_DTOR]]
+// LLVMCIR:       [[SKIP_DTOR]]:
+// LLVMCIR:         br label %[[EXIT:.*]]
+// LLVMCIR:       [[EXIT]]:
+// LLVMCIR:         %[[RESULT:.*]] = load i32, ptr %[[RESULT_TMP]]
+// LLVMCIR:         store i32 %[[RESULT]], ptr %{{.*}}
 
 // OGCG-LABEL: define dso_local void @_Z22test_ternary_temporarybi(
 // OGCG:       entry:
@@ -155,53 +153,53 @@ void test_ternary_both_branches(bool c) {
 // CIR:     cir.yield
 // CIR:   }
 
-// LLVM-LABEL: define dso_local void @_Z26test_ternary_both_branchesb(
-// LLVM:         %{{.*}} = alloca i8
-// LLVM:         %{{.*}} = alloca i32
-// LLVM:         %[[TMPA:.*]] = alloca %struct.A
-// LLVM:         %[[ACTA:.*]] = alloca i8
-// LLVM:         %[[TMPB:.*]] = alloca %struct.B
-// LLVM:         %[[ACTB:.*]] = alloca i8
-// LLVM:         %[[RESULT_TMP:.*]] = alloca i32
-// LLVM:         br label %[[INIT:.*]]
-// LLVM:       [[INIT]]:
-// LLVM:         %[[COND_BYTE:.*]] = load i8, ptr %{{.*}}
-// LLVM:         %[[COND_BOOL:.*]] = trunc i8 %[[COND_BYTE]] to i1
-// LLVM:         store i8 0, ptr %[[ACTA]]
-// LLVM:         store i8 0, ptr %[[ACTB]]
-// LLVM:         br i1 %[[COND_BOOL]], label %[[CONSTRUCT_A:.*]], label %[[CONSTRUCT_B:.*]]
-// LLVM:       [[CONSTRUCT_A]]:
-// LLVM:         call void @_ZN1AC1Ev({{.*}} %[[TMPA]])
-// LLVM:         store i8 1, ptr %[[ACTA]]
-// LLVM:         %[[CALLA:.*]] = call noundef i32 @_ZN1A3getEv({{.*}} %[[TMPA]])
-// LLVM:         br label %[[MERGE:.*]]
-// LLVM:       [[CONSTRUCT_B]]:
-// LLVM:         call void @_ZN1BC1Ev({{.*}} %[[TMPB]])
-// LLVM:         store i8 1, ptr %[[ACTB]]
-// LLVM:         %[[CALLB:.*]] = call {{.*}} i32 @_ZN1B3getEv({{.*}} %[[TMPB]])
-// LLVM:         br label %[[MERGE]]
-// LLVM:       [[MERGE]]:
-// LLVM:         %[[PHI:.*]] = phi i32 [ %[[CALLB]], %[[CONSTRUCT_B]] ], [ %[[CALLA]], %[[CONSTRUCT_A]] ]
-// LLVM:         br label %[[STORE:.*]]
-// LLVM:       [[STORE]]:
-// LLVM:         store i32 %[[PHI]], ptr %[[RESULT_TMP]]
-// LLVM:         br label %[[CLEANUP_B:.*]]
-// LLVM:       [[CLEANUP_B]]:
-// LLVM:         %[[ACTIVE_BYTE_B:.*]] = load i8, ptr %[[ACTB]]
-// LLVM:         %[[ACTIVE_BOOL_B:.*]] = trunc i8 %[[ACTIVE_BYTE_B]] to i1
-// LLVM:         br i1 %[[ACTIVE_BOOL_B]], label %[[DTOR_B:.*]], label %[[SKIP_DTOR_B:.*]]
-// LLVM:       [[DTOR_B]]:
-// LLVM:         call void @_ZN1BD1Ev({{.*}} %[[TMPB]])
-// LLVM:         br label %[[SKIP_DTOR_B]]
-// LLVM:       [[SKIP_DTOR_B]]:
-// LLVM:         %[[ACTIVE_BYTE_A:.*]] = load i8, ptr %[[ACTA]]
-// LLVM:         %[[ACTIVE_BOOL_A:.*]] = trunc i8 %[[ACTIVE_BYTE_A]] to i1
-// LLVM:         br i1 %[[ACTIVE_BOOL_A]], label %[[DTOR_A:.*]], label %[[SKIP_DTOR_A:.*]]
-// LLVM:       [[DTOR_A]]:
-// LLVM:         call void @_ZN1AD1Ev({{.*}} %[[TMPA]])
-// LLVM:         br label %[[SKIP_DTOR_A]]
-// LLVM:       [[SKIP_DTOR_A]]:
-// LLVM:         br label %{{.*}}
+// LLVMCIR-LABEL: define dso_local void @_Z26test_ternary_both_branchesb(
+// LLVMCIR:         %{{.*}} = alloca i8
+// LLVMCIR:         %{{.*}} = alloca i32
+// LLVMCIR:         %[[TMPA:.*]] = alloca %struct.A
+// LLVMCIR:         %[[ACTA:.*]] = alloca i8
+// LLVMCIR:         %[[TMPB:.*]] = alloca %struct.B
+// LLVMCIR:         %[[ACTB:.*]] = alloca i8
+// LLVMCIR:         %[[RESULT_TMP:.*]] = alloca i32
+// LLVMCIR:         br label %[[INIT:.*]]
+// LLVMCIR:       [[INIT]]:
+// LLVMCIR:         %[[COND_BYTE:.*]] = load i8, ptr %{{.*}}
+// LLVMCIR:         %[[COND_BOOL:.*]] = trunc i8 %[[COND_BYTE]] to i1
+// LLVMCIR:         store i8 0, ptr %[[ACTA]]
+// LLVMCIR:         store i8 0, ptr %[[ACTB]]
+// LLVMCIR:         br i1 %[[COND_BOOL]], label %[[CONSTRUCT_A:.*]], label %[[CONSTRUCT_B:.*]]
+// LLVMCIR:       [[CONSTRUCT_A]]:
+// LLVMCIR:         call void @_ZN1AC1Ev({{.*}} %[[TMPA]])
+// LLVMCIR:         store i8 1, ptr %[[ACTA]]
+// LLVMCIR:         %[[CALLA:.*]] = call noundef i32 @_ZN1A3getEv({{.*}} %[[TMPA]])
+// LLVMCIR:         br label %[[MERGE:.*]]
+// LLVMCIR:       [[CONSTRUCT_B]]:
+// LLVMCIR:         call void @_ZN1BC1Ev({{.*}} %[[TMPB]])
+// LLVMCIR:         store i8 1, ptr %[[ACTB]]
+// LLVMCIR:         %[[CALLB:.*]] = call {{.*}} i32 @_ZN1B3getEv({{.*}} %[[TMPB]])
+// LLVMCIR:         br label %[[MERGE]]
+// LLVMCIR:       [[MERGE]]:
+// LLVMCIR:         %[[PHI:.*]] = phi i32 [ %[[CALLB]], %[[CONSTRUCT_B]] ], [ %[[CALLA]], %[[CONSTRUCT_A]] ]
+// LLVMCIR:         br label %[[STORE:.*]]
+// LLVMCIR:       [[STORE]]:
+// LLVMCIR:         store i32 %[[PHI]], ptr %[[RESULT_TMP]]
+// LLVMCIR:         br label %[[CLEANUP_B:.*]]
+// LLVMCIR:       [[CLEANUP_B]]:
+// LLVMCIR:         %[[ACTIVE_BYTE_B:.*]] = load i8, ptr %[[ACTB]]
+// LLVMCIR:         %[[ACTIVE_BOOL_B:.*]] = trunc i8 %[[ACTIVE_BYTE_B]] to i1
+// LLVMCIR:         br i1 %[[ACTIVE_BOOL_B]], label %[[DTOR_B:.*]], label %[[SKIP_DTOR_B:.*]]
+// LLVMCIR:       [[DTOR_B]]:
+// LLVMCIR:         call void @_ZN1BD1Ev({{.*}} %[[TMPB]])
+// LLVMCIR:         br label %[[SKIP_DTOR_B]]
+// LLVMCIR:       [[SKIP_DTOR_B]]:
+// LLVMCIR:         %[[ACTIVE_BYTE_A:.*]] = load i8, ptr %[[ACTA]]
+// LLVMCIR:         %[[ACTIVE_BOOL_A:.*]] = trunc i8 %[[ACTIVE_BYTE_A]] to i1
+// LLVMCIR:         br i1 %[[ACTIVE_BOOL_A]], label %[[DTOR_A:.*]], label %[[SKIP_DTOR_A:.*]]
+// LLVMCIR:       [[DTOR_A]]:
+// LLVMCIR:         call void @_ZN1AD1Ev({{.*}} %[[TMPA]])
+// LLVMCIR:         br label %[[SKIP_DTOR_A]]
+// LLVMCIR:       [[SKIP_DTOR_A]]:
+// LLVMCIR:         br label %{{.*}}
 
 // OGCG-LABEL: define dso_local void @_Z26test_ternary_both_branchesb(
 // OGCG:       entry:
@@ -277,55 +275,55 @@ int test_return_ternary(bool c) {
 // CIR:   %[[RET:.*]] = cir.load %{{.*}} : !cir.ptr<!s32i>, !s32i
 // CIR:   cir.return %[[RET]] : !s32i
 
-// LLVM-LABEL: define dso_local noundef i32 @_Z19test_return_ternaryb(
-// LLVM:         %{{.*}} = alloca i8
-// LLVM:         %[[RETVAL:.*]] = alloca i32
-// LLVM:         %[[TMPA:.*]] = alloca %struct.A
-// LLVM:         %[[ACTA:.*]] = alloca i8
-// LLVM:         %[[TMPB:.*]] = alloca %struct.B
-// LLVM:         %[[ACTB:.*]] = alloca i8
-// LLVM:         br label %[[INIT:.*]]
-// LLVM:       [[INIT]]:
-// LLVM:         %[[COND_BYTE:.*]] = load i8, ptr %{{.*}}
-// LLVM:         %[[COND_BOOL:.*]] = trunc i8 %[[COND_BYTE]] to i1
-// LLVM:         store i8 0, ptr %[[ACTA]]
-// LLVM:         store i8 0, ptr %[[ACTB]]
-// LLVM:         br i1 %[[COND_BOOL]], label %[[CONSTRUCT_A:.*]], label %[[CONSTRUCT_B:.*]]
-// LLVM:       [[CONSTRUCT_A]]:
-// LLVM:         call void @_ZN1AC1Ev({{.*}} %[[TMPA]])
-// LLVM:         store i8 1, ptr %[[ACTA]]
-// LLVM:         %[[CALLA:.*]] = call noundef i32 @_ZN1A3getEv({{.*}} %[[TMPA]])
-// LLVM:         br label %[[MERGE:.*]]
-// LLVM:       [[CONSTRUCT_B]]:
-// LLVM:         call void @_ZN1BC1Ev({{.*}} %[[TMPB]])
-// LLVM:         store i8 1, ptr %[[ACTB]]
-// LLVM:         %[[CALLB:.*]] = call noundef i32 @_ZN1B3getEv({{.*}} %[[TMPB]])
-// LLVM:         br label %[[MERGE]]
-// LLVM:       [[MERGE]]:
-// LLVM:         %[[PHI:.*]] = phi i32 [ %[[CALLB]], %[[CONSTRUCT_B]] ], [ %[[CALLA]], %[[CONSTRUCT_A]] ]
-// LLVM:         br label %[[STORE_RET:.*]]
-// LLVM:       [[STORE_RET]]:
-// LLVM:         store i32 %[[PHI]], ptr %[[RETVAL]]
-// LLVM:         br label %[[CLEANUP_B:.*]]
-// LLVM:       [[CLEANUP_B]]:
-// LLVM:         %[[ACTIVE_BYTE_B:.*]] = load i8, ptr %[[ACTB]]
-// LLVM:         %[[ACTIVE_BOOL_B:.*]] = trunc i8 %[[ACTIVE_BYTE_B]] to i1
-// LLVM:         br i1 %[[ACTIVE_BOOL_B]], label %[[DTOR_B:.*]], label %[[SKIP_DTOR_B:.*]]
-// LLVM:       [[DTOR_B]]:
-// LLVM:         call void @_ZN1BD1Ev({{.*}} %[[TMPB]])
-// LLVM:         br label %[[SKIP_DTOR_B]]
-// LLVM:       [[SKIP_DTOR_B]]:
-// LLVM:         %[[ACTIVE_BYTE_A:.*]] = load i8, ptr %[[ACTA]]
-// LLVM:         %[[ACTIVE_BOOL_A:.*]] = trunc i8 %[[ACTIVE_BYTE_A]] to i1
-// LLVM:         br i1 %[[ACTIVE_BOOL_A]], label %[[DTOR_A:.*]], label %[[SKIP_DTOR_A:.*]]
-// LLVM:       [[DTOR_A]]:
-// LLVM:         call void @_ZN1AD1Ev({{.*}} %[[TMPA]])
-// LLVM:         br label %[[SKIP_DTOR_A]]
-// LLVM:       [[SKIP_DTOR_A]]:
-// LLVM:         br label %[[EXIT:.*]]
-// LLVM:       [[EXIT]]:
-// LLVM:         %[[RET:.*]] = load i32, ptr %[[RETVAL]]
-// LLVM:         ret i32 %[[RET]]
+// LLVMCIR-LABEL: define dso_local noundef i32 @_Z19test_return_ternaryb(
+// LLVMCIR:         %{{.*}} = alloca i8
+// LLVMCIR:         %[[RETVAL:.*]] = alloca i32
+// LLVMCIR:         %[[TMPA:.*]] = alloca %struct.A
+// LLVMCIR:         %[[ACTA:.*]] = alloca i8
+// LLVMCIR:         %[[TMPB:.*]] = alloca %struct.B
+// LLVMCIR:         %[[ACTB:.*]] = alloca i8
+// LLVMCIR:         br label %[[INIT:.*]]
+// LLVMCIR:       [[INIT]]:
+// LLVMCIR:         %[[COND_BYTE:.*]] = load i8, ptr %{{.*}}
+// LLVMCIR:         %[[COND_BOOL:.*]] = trunc i8 %[[COND_BYTE]] to i1
+// LLVMCIR:         store i8 0, ptr %[[ACTA]]
+// LLVMCIR:         store i8 0, ptr %[[ACTB]]
+// LLVMCIR:         br i1 %[[COND_BOOL]], label %[[CONSTRUCT_A:.*]], label %[[CONSTRUCT_B:.*]]
+// LLVMCIR:       [[CONSTRUCT_A]]:
+// LLVMCIR:         call void @_ZN1AC1Ev({{.*}} %[[TMPA]])
+// LLVMCIR:         store i8 1, ptr %[[ACTA]]
+// LLVMCIR:         %[[CALLA:.*]] = call noundef i32 @_ZN1A3getEv({{.*}} %[[TMPA]])
+// LLVMCIR:         br label %[[MERGE:.*]]
+// LLVMCIR:       [[CONSTRUCT_B]]:
+// LLVMCIR:         call void @_ZN1BC1Ev({{.*}} %[[TMPB]])
+// LLVMCIR:         store i8 1, ptr %[[ACTB]]
+// LLVMCIR:         %[[CALLB:.*]] = call noundef i32 @_ZN1B3getEv({{.*}} %[[TMPB]])
+// LLVMCIR:         br label %[[MERGE]]
+// LLVMCIR:       [[MERGE]]:
+// LLVMCIR:         %[[PHI:.*]] = phi i32 [ %[[CALLB]], %[[CONSTRUCT_B]] ], [ %[[CALLA]], %[[CONSTRUCT_A]] ]
+// LLVMCIR:         br label %[[STORE_RET:.*]]
+// LLVMCIR:       [[STORE_RET]]:
+// LLVMCIR:         store i32 %[[PHI]], ptr %[[RETVAL]]
+// LLVMCIR:         br label %[[CLEANUP_B:.*]]
+// LLVMCIR:       [[CLEANUP_B]]:
+// LLVMCIR:         %[[ACTIVE_BYTE_B:.*]] = load i8, ptr %[[ACTB]]
+// LLVMCIR:         %[[ACTIVE_BOOL_B:.*]] = trunc i8 %[[ACTIVE_BYTE_B]] to i1
+// LLVMCIR:         br i1 %[[ACTIVE_BOOL_B]], label %[[DTOR_B:.*]], label %[[SKIP_DTOR_B:.*]]
+// LLVMCIR:       [[DTOR_B]]:
+// LLVMCIR:         call void @_ZN1BD1Ev({{.*}} %[[TMPB]])
+// LLVMCIR:         br label %[[SKIP_DTOR_B]]
+// LLVMCIR:       [[SKIP_DTOR_B]]:
+// LLVMCIR:         %[[ACTIVE_BYTE_A:.*]] = load i8, ptr %[[ACTA]]
+// LLVMCIR:         %[[ACTIVE_BOOL_A:.*]] = trunc i8 %[[ACTIVE_BYTE_A]] to i1
+// LLVMCIR:         br i1 %[[ACTIVE_BOOL_A]], label %[[DTOR_A:.*]], label %[[SKIP_DTOR_A:.*]]
+// LLVMCIR:       [[DTOR_A]]:
+// LLVMCIR:         call void @_ZN1AD1Ev({{.*}} %[[TMPA]])
+// LLVMCIR:         br label %[[SKIP_DTOR_A]]
+// LLVMCIR:       [[SKIP_DTOR_A]]:
+// LLVMCIR:         br label %[[EXIT:.*]]
+// LLVMCIR:       [[EXIT]]:
+// LLVMCIR:         %[[RET:.*]] = load i32, ptr %[[RETVAL]]
+// LLVMCIR:         ret i32 %[[RET]]
 
 // OGCG-LABEL: define dso_local noundef i32 @_Z19test_return_ternaryb(
 // OGCG:       entry:
@@ -386,23 +384,23 @@ int test_false_positive_conditional(bool c) {
 // CIR:     cir.yield
 // CIR:   }
 
-// LLVM-LABEL: define dso_local noundef i32 @_Z31test_false_positive_conditionalb(
-// LLVM:         %[[RETVAL:.*]] = alloca i32
-// LLVM:         %[[TMP:.*]] = alloca %struct.S
-// LLVM:         call void @_ZN1SC1Ev({{.*}} %[[TMP]])
-// LLVM:         br label %[[BODY:.*]]
-// LLVM:       [[BODY]]:
-// LLVM:         %[[VAL:.*]] = call {{.*}} i32 @_ZN1S3getEv({{.*}} %[[TMP]])
-// LLVM:         %[[CMP:.*]] = icmp ne i32 %[[VAL]], 0
-// LLVM:         %[[SEL:.*]] = select i1 %[[CMP]], i32 1, i32 2
-// LLVM:         store i32 %[[SEL]], ptr %[[RETVAL]]
-// LLVM:         br label %[[DTOR:.*]]
-// LLVM:       [[DTOR]]:
-// LLVM:         call void @_ZN1SD1Ev({{.*}} %[[TMP]])
-// LLVM:         br label %[[EXIT:.*]]
-// LLVM:       [[EXIT]]:
-// LLVM:         %[[RET:.*]] = load i32, ptr %[[RETVAL]]
-// LLVM:         ret i32 %[[RET]]
+// LLVMCIR-LABEL: define dso_local noundef i32 @_Z31test_false_positive_conditionalb(
+// LLVMCIR:         %[[RETVAL:.*]] = alloca i32
+// LLVMCIR:         %[[TMP:.*]] = alloca %struct.S
+// LLVMCIR:         call void @_ZN1SC1Ev({{.*}} %[[TMP]])
+// LLVMCIR:         br label %[[BODY:.*]]
+// LLVMCIR:       [[BODY]]:
+// LLVMCIR:         %[[VAL:.*]] = call {{.*}} i32 @_ZN1S3getEv({{.*}} %[[TMP]])
+// LLVMCIR:         %[[CMP:.*]] = icmp ne i32 %[[VAL]], 0
+// LLVMCIR:         %[[SEL:.*]] = select i1 %[[CMP]], i32 1, i32 2
+// LLVMCIR:         store i32 %[[SEL]], ptr %[[RETVAL]]
+// LLVMCIR:         br label %[[DTOR:.*]]
+// LLVMCIR:       [[DTOR]]:
+// LLVMCIR:         call void @_ZN1SD1Ev({{.*}} %[[TMP]])
+// LLVMCIR:         br label %[[EXIT:.*]]
+// LLVMCIR:       [[EXIT]]:
+// LLVMCIR:         %[[RET:.*]] = load i32, ptr %[[RETVAL]]
+// LLVMCIR:         ret i32 %[[RET]]
 
 // OGCG-LABEL: define dso_local noundef i32 @_Z31test_false_positive_conditionalb(
 // OGCG:         call void @_ZN1SC1Ev({{.*}} %[[TMP:.*]])
@@ -523,40 +521,6 @@ void test_nested_ewc(bool c1, bool c2) {
 // LLVM:         call void @_ZN1TD1Ev({{.*}} %[[REF_TMP]])
 // LLVM:         call void @_ZN1TD1Ev({{.*}} %[[RESULT]])
 
-// OGCG-LABEL: define dso_local void @_Z15test_nested_ewcbb(
-// Inner ternary: c1 ? T(1) : T(2).
-// OGCG:         br i1 %{{.*}}, label %[[T1:.*]], label %[[T2:.*]]
-// OGCG:       [[T1]]:
-// OGCG:         call void @_ZN1TC1Ei({{.*}} %[[S:.*]], i32 {{.*}} 1)
-// OGCG:         br label %[[INNER_MERGE:.*]]
-// OGCG:       [[T2]]:
-// OGCG:         call void @_ZN1TC1Ei({{.*}} %[[S]], i32 {{.*}} 2)
-// OGCG:         br label %[[INNER_MERGE]]
-// Copy construct ref.tmp from s, then destroy s.
-// OGCG:       [[INNER_MERGE]]:
-// OGCG:         call void @_ZN1TC1ERKS_({{.*}} %[[REF_TMP:.*]], {{.*}} %[[S]])
-// OGCG:         call void @_ZN1TD1Ev({{.*}} %[[S]])
-// Outer ternary: operator bool() + conditional construction of result.
-// OGCG:         %[[BOOL:.*]] = call {{.*}} i1 @_ZN1TcvbEv({{.*}} %[[REF_TMP]])
-// OGCG:         br i1 %[[BOOL]], label %[[TRUE:.*]], label %[[FALSE:.*]]
-// OGCG:       [[TRUE]]:
-// OGCG:         br i1 %{{.*}}, label %[[T3:.*]], label %[[T4:.*]]
-// OGCG:       [[T3]]:
-// OGCG:         call void @_ZN1TC1Ei({{.*}} %[[RESULT:.*]], i32 {{.*}} 3)
-// OGCG:         br label %[[OUTER_MERGE1:.*]]
-// OGCG:       [[T4]]:
-// OGCG:         call void @_ZN1TC1Ei({{.*}} %[[RESULT]], i32 {{.*}} 4)
-// OGCG:         br label %[[OUTER_MERGE1]]
-// OGCG:       [[OUTER_MERGE1]]:
-// OGCG:         br label %[[OUTER_MERGE2:.*]]
-// OGCG:       [[FALSE]]:
-// OGCG:         call void @_ZN1TC1Ei({{.*}} %[[RESULT]], i32 {{.*}} 5)
-// OGCG:         br label %[[OUTER_MERGE2]]
-// Cleanup: destroy ref.tmp, then result.
-// OGCG:       [[OUTER_MERGE2]]:
-// OGCG:         call void @_ZN1TD1Ev({{.*}} %[[REF_TMP]])
-// OGCG:         call void @_ZN1TD1Ev({{.*}} %[[RESULT]])
-
 // The result of the ternary is bound to an lvalue (the parameter of
 // operator=), so the enclosing ExprWithCleanups is lowered through the
 // LValue emission path.  The lvalue path must still open a
@@ -620,41 +584,41 @@ void test_lvalue_ternary_cleanup(bool c, V &y) {
 // CIR:     cir.yield
 // CIR:   }
 
-// LLVM-LABEL: define dso_local void @_Z27test_lvalue_ternary_cleanupbR1V(
-// LLVM:         %[[REFTMP:.*]] = alloca %struct.V
-// LLVM:         %[[UTRUE:.*]] = alloca %struct.U
-// LLVM:         %[[ACTTRUE:.*]] = alloca i8
-// LLVM:         %[[UFALSE:.*]] = alloca %struct.U
-// LLVM:         %[[ACTFALSE:.*]] = alloca i8
-// LLVM:         store i8 0, ptr %[[ACTTRUE]]
-// LLVM:         store i8 0, ptr %[[ACTFALSE]]
-// LLVM:         br i1 %{{.*}}, label %[[CONS_TRUE:.*]], label %[[CONS_FALSE:.*]]
-// LLVM:       [[CONS_TRUE]]:
-// LLVM:         call void @_ZN1UC1Ev({{.*}} %[[UTRUE]])
-// LLVM:         store i8 1, ptr %[[ACTTRUE]]
-// LLVM:         call void @_ZN1VC1EiRK1U({{.*}} %[[REFTMP]], i32 {{.*}} 1, {{.*}} %[[UTRUE]])
-// LLVM:         br label %[[MERGE:.*]]
-// LLVM:       [[CONS_FALSE]]:
-// LLVM:         call void @_ZN1UC1Ev({{.*}} %[[UFALSE]])
-// LLVM:         store i8 1, ptr %[[ACTFALSE]]
-// LLVM:         call void @_ZN1VC1EiRK1U({{.*}} %[[REFTMP]], i32 {{.*}} 2, {{.*}} %[[UFALSE]])
-// LLVM:         br label %[[MERGE]]
-// LLVM:       [[MERGE]]:
-// LLVM:         call {{.*}} ptr @_ZN1VaSERKS_({{.*}}, {{.*}} %[[REFTMP]])
-// LLVM:         call void @_ZN1VD1Ev({{.*}} %[[REFTMP]])
-// LLVM:         %[[F2_BYTE:.*]] = load i8, ptr %[[ACTFALSE]]
-// LLVM:         %[[F2:.*]] = trunc i8 %[[F2_BYTE]] to i1
-// LLVM:         br i1 %[[F2]], label %[[DTOR_F:.*]], label %[[SKIP_F:.*]]
-// LLVM:       [[DTOR_F]]:
-// LLVM:         call void @_ZN1UD1Ev({{.*}} %[[UFALSE]])
-// LLVM:         br label %[[SKIP_F]]
-// LLVM:       [[SKIP_F]]:
-// LLVM:         %[[F1_BYTE:.*]] = load i8, ptr %[[ACTTRUE]]
-// LLVM:         %[[F1:.*]] = trunc i8 %[[F1_BYTE]] to i1
-// LLVM:         br i1 %[[F1]], label %[[DTOR_T:.*]], label %[[SKIP_T:.*]]
-// LLVM:       [[DTOR_T]]:
-// LLVM:         call void @_ZN1UD1Ev({{.*}} %[[UTRUE]])
-// LLVM:         br label %[[SKIP_T]]
+// LLVMCIR-LABEL: define dso_local void @_Z27test_lvalue_ternary_cleanupbR1V(
+// LLVMCIR:         %[[REFTMP:.*]] = alloca %struct.V
+// LLVMCIR:         %[[UTRUE:.*]] = alloca %struct.U
+// LLVMCIR:         %[[ACTTRUE:.*]] = alloca i8
+// LLVMCIR:         %[[UFALSE:.*]] = alloca %struct.U
+// LLVMCIR:         %[[ACTFALSE:.*]] = alloca i8
+// LLVMCIR:         store i8 0, ptr %[[ACTTRUE]]
+// LLVMCIR:         store i8 0, ptr %[[ACTFALSE]]
+// LLVMCIR:         br i1 %{{.*}}, label %[[CONS_TRUE:.*]], label %[[CONS_FALSE:.*]]
+// LLVMCIR:       [[CONS_TRUE]]:
+// LLVMCIR:         call void @_ZN1UC1Ev({{.*}} %[[UTRUE]])
+// LLVMCIR:         store i8 1, ptr %[[ACTTRUE]]
+// LLVMCIR:         call void @_ZN1VC1EiRK1U({{.*}} %[[REFTMP]], i32 {{.*}} 1, {{.*}} %[[UTRUE]])
+// LLVMCIR:         br label %[[MERGE:.*]]
+// LLVMCIR:       [[CONS_FALSE]]:
+// LLVMCIR:         call void @_ZN1UC1Ev({{.*}} %[[UFALSE]])
+// LLVMCIR:         store i8 1, ptr %[[ACTFALSE]]
+// LLVMCIR:         call void @_ZN1VC1EiRK1U({{.*}} %[[REFTMP]], i32 {{.*}} 2, {{.*}} %[[UFALSE]])
+// LLVMCIR:         br label %[[MERGE]]
+// LLVMCIR:       [[MERGE]]:
+// LLVMCIR:         call {{.*}} ptr @_ZN1VaSERKS_({{.*}}, {{.*}} %[[REFTMP]])
+// LLVMCIR:         call void @_ZN1VD1Ev({{.*}} %[[REFTMP]])
+// LLVMCIR:         %[[F2_BYTE:.*]] = load i8, ptr %[[ACTFALSE]]
+// LLVMCIR:         %[[F2:.*]] = trunc i8 %[[F2_BYTE]] to i1
+// LLVMCIR:         br i1 %[[F2]], label %[[DTOR_F:.*]], label %[[SKIP_F:.*]]
+// LLVMCIR:       [[DTOR_F]]:
+// LLVMCIR:         call void @_ZN1UD1Ev({{.*}} %[[UFALSE]])
+// LLVMCIR:         br label %[[SKIP_F]]
+// LLVMCIR:       [[SKIP_F]]:
+// LLVMCIR:         %[[F1_BYTE:.*]] = load i8, ptr %[[ACTTRUE]]
+// LLVMCIR:         %[[F1:.*]] = trunc i8 %[[F1_BYTE]] to i1
+// LLVMCIR:         br i1 %[[F1]], label %[[DTOR_T:.*]], label %[[SKIP_T:.*]]
+// LLVMCIR:       [[DTOR_T]]:
+// LLVMCIR:         call void @_ZN1UD1Ev({{.*}} %[[UTRUE]])
+// LLVMCIR:         br label %[[SKIP_T]]
 
 // OGCG-LABEL: define dso_local void @_Z27test_lvalue_ternary_cleanupbR1V(
 // OGCG:         store i1 false, ptr %[[ACTTRUE:.*]]
@@ -745,33 +709,33 @@ void test_lvalue_reload(bool c) {
 // CIR:   %[[RELOAD:.*]] = cir.load {{.*}} %[[SPILL]] : !cir.ptr<!cir.ptr<!s32i>>, !cir.ptr<!s32i>
 // CIR:   cir.store {{.*}} %[[RELOAD]], %[[R_REF]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
 
-// LLVM-LABEL: define dso_local void @_Z18test_lvalue_reloadb(
-// LLVM:         %[[R_REF:.*]] = alloca ptr
-// LLVM:         %[[TMP0:.*]] = alloca %struct.R
-// LLVM:         %[[ACT0:.*]] = alloca i8
-// LLVM:         %[[TMP1:.*]] = alloca %struct.R
-// LLVM:         %[[ACT1:.*]] = alloca i8
-// LLVM:         %[[SPILL:.*]] = alloca ptr
-// LLVM:         br i1 %{{.*}}, label %[[BR_T:.*]], label %[[BR_F:.*]]
-// LLVM:       [[BR_T]]:
-// LLVM:         call void @_ZN1RC1Ei({{.*}} %[[TMP0]], i32 {{.*}} 1)
-// LLVM:         store i8 1, ptr %[[ACT0]]
-// LLVM:         %[[CALL_T:.*]] = call {{.*}} ptr @_Z5pickRRK1R({{.*}} %[[TMP0]])
-// LLVM:         br label %[[MERGE:.*]]
-// LLVM:       [[BR_F]]:
-// LLVM:         call void @_ZN1RC1Ei({{.*}} %[[TMP1]], i32 {{.*}} 2)
-// LLVM:         store i8 1, ptr %[[ACT1]]
-// LLVM:         %[[CALL_F:.*]] = call {{.*}} ptr @_Z5pickRRK1R({{.*}} %[[TMP1]])
-// LLVM:         br label %[[MERGE]]
-// LLVM:       [[MERGE]]:
-// LLVM:         %[[PHI:.*]] = phi ptr [ %[[CALL_F]], %[[BR_F]] ], [ %[[CALL_T]], %[[BR_T]] ]
-// LLVM:         %[[GEP:.*]] = getelementptr {{.*}} %struct.R, ptr %[[PHI]]
-// LLVM:         store ptr %[[GEP]], ptr %[[SPILL]]
+// LLVMCIR-LABEL: define dso_local void @_Z18test_lvalue_reloadb(
+// LLVMCIR:         %[[R_REF:.*]] = alloca ptr
+// LLVMCIR:         %[[TMP0:.*]] = alloca %struct.R
+// LLVMCIR:         %[[ACT0:.*]] = alloca i8
+// LLVMCIR:         %[[TMP1:.*]] = alloca %struct.R
+// LLVMCIR:         %[[ACT1:.*]] = alloca i8
+// LLVMCIR:         %[[SPILL:.*]] = alloca ptr
+// LLVMCIR:         br i1 %{{.*}}, label %[[BR_T:.*]], label %[[BR_F:.*]]
+// LLVMCIR:       [[BR_T]]:
+// LLVMCIR:         call void @_ZN1RC1Ei({{.*}} %[[TMP0]], i32 {{.*}} 1)
+// LLVMCIR:         store i8 1, ptr %[[ACT0]]
+// LLVMCIR:         %[[CALL_T:.*]] = call {{.*}} ptr @_Z5pickRRK1R({{.*}} %[[TMP0]])
+// LLVMCIR:         br label %[[MERGE:.*]]
+// LLVMCIR:       [[BR_F]]:
+// LLVMCIR:         call void @_ZN1RC1Ei({{.*}} %[[TMP1]], i32 {{.*}} 2)
+// LLVMCIR:         store i8 1, ptr %[[ACT1]]
+// LLVMCIR:         %[[CALL_F:.*]] = call {{.*}} ptr @_Z5pickRRK1R({{.*}} %[[TMP1]])
+// LLVMCIR:         br label %[[MERGE]]
+// LLVMCIR:       [[MERGE]]:
+// LLVMCIR:         %[[PHI:.*]] = phi ptr [ %[[CALL_F]], %[[BR_F]] ], [ %[[CALL_T]], %[[BR_T]] ]
+// LLVMCIR:         %[[GEP:.*]] = getelementptr {{.*}} %struct.R, ptr %[[PHI]]
+// LLVMCIR:         store ptr %[[GEP]], ptr %[[SPILL]]
 // Cleanup checks happen between the spill and the reload.
-// LLVM:         load i8, ptr %[[ACT1]]
-// LLVM:         load i8, ptr %[[ACT0]]
-// LLVM:         %[[RELOAD:.*]] = load ptr, ptr %[[SPILL]]
-// LLVM:         store ptr %[[RELOAD]], ptr %[[R_REF]]
+// LLVMCIR:         load i8, ptr %[[ACT1]]
+// LLVMCIR:         load i8, ptr %[[ACT0]]
+// LLVMCIR:         %[[RELOAD:.*]] = load ptr, ptr %[[SPILL]]
+// LLVMCIR:         store ptr %[[RELOAD]], ptr %[[R_REF]]
 
 // OGCG-LABEL: define dso_local void @_Z18test_lvalue_reloadb(
 // OGCG:         %[[R_REF:.*]] = alloca ptr
@@ -822,8 +786,11 @@ _Complex float test_complex_cond_cleanup(bool b, _Complex float x) {
 // CIR:       cir.call @_ZN5CplxDC1Ev(%[[TMP]])
 // CIR:       %[[SET_TRUE:.*]] = cir.const #true
 // CIR:       cir.store %[[SET_TRUE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
-// CIR:       %[[CALL:.*]] = cir.call @_ZN5CplxD3getEv(%[[TMP]])
-// CIR:       cir.yield %[[CALL]] : !cir.complex<!cir.float>
+// CIR:       %[[CALL:.*]] = cir.call @_ZN5CplxD3getEv(%[[TMP]]) : (!cir.ptr<!rec_CplxD> {{.*}}) -> (!cir.vector<2 x !cir.float> {{.*}})
+// CIR:       cir.store %[[CALL]], %[[SLOT:.*]] : !cir.vector<2 x !cir.float>, !cir.ptr<!cir.vector<2 x !cir.float>>
+// CIR:       %[[SLOT_PTR:.*]] = cir.cast bitcast %[[SLOT]] : !cir.ptr<!cir.vector<2 x !cir.float>> -> !cir.ptr<!cir.complex<!cir.float>>
+// CIR:       %[[CPLX:.*]] = cir.load %[[SLOT_PTR]] : !cir.ptr<!cir.complex<!cir.float>>, !cir.complex<!cir.float>
+// CIR:       cir.yield %[[CPLX]] : !cir.complex<!cir.float>
 // CIR:     }, false {
 // CIR:       %[[XV:.*]] = cir.load {{.*}} : !cir.ptr<!cir.complex<!cir.float>>, !cir.complex<!cir.float>
 // CIR:       cir.yield %[[XV]] : !cir.complex<!cir.float>
@@ -837,26 +804,28 @@ _Complex float test_complex_cond_cleanup(bool b, _Complex float x) {
 // CIR:     cir.yield
 // CIR:   }
 
-// LLVM-LABEL: define dso_local {{.*}} { float, float } @_Z25test_complex_cond_cleanupbCf(
-// LLVM:         %[[TMP:.*]] = alloca %struct.CplxD
-// LLVM:         %[[ACTIVE:.*]] = alloca i8
-// LLVM:         br i1 %{{.*}}, label %[[TRUE_BR:.*]], label %[[FALSE_BR:.*]]
-// LLVM:       [[TRUE_BR]]:
-// LLVM:         call void @_ZN5CplxDC1Ev(ptr {{.*}} %[[TMP]])
-// LLVM:         store i8 1, ptr %[[ACTIVE]]
-// LLVM:         %[[CALL:.*]] = call {{.*}} { float, float } @_ZN5CplxD3getEv(ptr {{.*}} %[[TMP]])
-// LLVM:         br label %[[MERGE:.*]]
-// LLVM:       [[FALSE_BR]]:
-// LLVM:         %[[XV:.*]] = load { float, float }, ptr %{{.*}}
-// LLVM:         br label %[[MERGE]]
-// LLVM:       [[MERGE]]:
-// LLVM:         %{{.*}} = phi { float, float } [ %[[XV]], %[[FALSE_BR]] ], [ %[[CALL]], %[[TRUE_BR]] ]
-// LLVM:         %[[ACT:.*]] = load i8, ptr %[[ACTIVE]]
-// LLVM:         %[[ACT_B:.*]] = trunc i8 %[[ACT]] to i1
-// LLVM:         br i1 %[[ACT_B]], label %[[DTOR:.*]], label %[[SKIP:.*]]
-// LLVM:       [[DTOR]]:
-// LLVM:         call void @_ZN5CplxDD1Ev(ptr {{.*}} %[[TMP]])
-// LLVM:         br label %[[SKIP]]
+// LLVMCIR-LABEL: define dso_local {{.*}} <2 x float> @_Z25test_complex_cond_cleanupbCf(i1 noundef zeroext %{{.*}}, <2 x float> noundef %{{.*}})
+// LLVMCIR:         %[[TMP:.*]] = alloca %struct.CplxD
+// LLVMCIR:         %[[ACTIVE:.*]] = alloca i8
+// LLVMCIR:         br i1 %{{.*}}, label %[[TRUE_BR:.*]], label %[[FALSE_BR:.*]]
+// LLVMCIR:       [[TRUE_BR]]:
+// LLVMCIR:         call void @_ZN5CplxDC1Ev(ptr {{.*}} %[[TMP]])
+// LLVMCIR:         store i8 1, ptr %[[ACTIVE]]
+// LLVMCIR:         %[[CALL:.*]] = call {{.*}} <2 x float> @_ZN5CplxD3getEv(ptr {{.*}} %[[TMP]])
+// LLVMCIR:         store <2 x float> %[[CALL]], ptr %[[CSLOT:.*]], align 8
+// LLVMCIR:         %[[CCPLX:.*]] = load { float, float }, ptr %[[CSLOT]], align 4
+// LLVMCIR:         br label %[[MERGE:.*]]
+// LLVMCIR:       [[FALSE_BR]]:
+// LLVMCIR:         %[[XV:.*]] = load { float, float }, ptr %{{.*}}
+// LLVMCIR:         br label %[[MERGE]]
+// LLVMCIR:       [[MERGE]]:
+// LLVMCIR:         %{{.*}} = phi { float, float } [ %[[XV]], %[[FALSE_BR]] ], [ %[[CCPLX]], %[[TRUE_BR]] ]
+// LLVMCIR:         %[[ACT:.*]] = load i8, ptr %[[ACTIVE]]
+// LLVMCIR:         %[[ACT_B:.*]] = trunc i8 %[[ACT]] to i1
+// LLVMCIR:         br i1 %[[ACT_B]], label %[[DTOR:.*]], label %[[SKIP:.*]]
+// LLVMCIR:       [[DTOR]]:
+// LLVMCIR:         call void @_ZN5CplxDD1Ev(ptr {{.*}} %[[TMP]])
+// LLVMCIR:         br label %[[SKIP]]
 
 // OGCG-LABEL: define dso_local {{.*}} <2 x float> @_Z25test_complex_cond_cleanupbCf(
 // OGCG:         %[[TMP:.*]] = alloca %struct.CplxD
@@ -905,20 +874,20 @@ void test_lifetime_ext_cond_ref(bool c) {
 // CIR:   }
 // CIR:   cir.return
 
-// LLVM-LABEL: define dso_local void @_Z26test_lifetime_ext_cond_refb(
-// LLVM:   %[[TMP:.*]] = alloca %struct.LE
-// LLVM:   %[[R:.*]] = alloca ptr
-// LLVM:   %[[SPILL:.*]] = alloca ptr
-// LLVM:   br i1 %{{.*}}, label %[[TRUE:.*]], label %[[FALSE:.*]]
-// LLVM: [[TRUE]]:
-// LLVM:   call void @_ZN2LEC1Ei(ptr {{.*}} %[[TMP]], i32 {{.*}} 1)
-// LLVM: [[FALSE]]:
-// LLVM:   call void @_ZN2LEC1Ei(ptr {{.*}} %[[TMP]], i32 {{.*}} 2)
-// LLVM:   store ptr %[[TMP]], ptr %[[SPILL]]
-// LLVM:   %[[RELOAD:.*]] = load ptr, ptr %[[SPILL]]
-// LLVM:   store ptr %[[RELOAD]], ptr %[[R]]
-// LLVM:   call void @_ZN2LED1Ev(ptr {{.*}} %[[TMP]])
-// LLVM:   ret void
+// LLVMCIR-LABEL: define dso_local void @_Z26test_lifetime_ext_cond_refb(
+// LLVMCIR:   %[[TMP:.*]] = alloca %struct.LE
+// LLVMCIR:   %[[R:.*]] = alloca ptr
+// LLVMCIR:   %[[SPILL:.*]] = alloca ptr
+// LLVMCIR:   br i1 %{{.*}}, label %[[TRUE:.*]], label %[[FALSE:.*]]
+// LLVMCIR: [[TRUE]]:
+// LLVMCIR:   call void @_ZN2LEC1Ei(ptr {{.*}} %[[TMP]], i32 {{.*}} 1)
+// LLVMCIR: [[FALSE]]:
+// LLVMCIR:   call void @_ZN2LEC1Ei(ptr {{.*}} %[[TMP]], i32 {{.*}} 2)
+// LLVMCIR:   store ptr %[[TMP]], ptr %[[SPILL]]
+// LLVMCIR:   %[[RELOAD:.*]] = load ptr, ptr %[[SPILL]]
+// LLVMCIR:   store ptr %[[RELOAD]], ptr %[[R]]
+// LLVMCIR:   call void @_ZN2LED1Ev(ptr {{.*}} %[[TMP]])
+// LLVMCIR:   ret void
 
 // OGCG-LABEL: define dso_local void @_Z26test_lifetime_ext_cond_refb(
 // OGCG:   %[[R:.*]] = alloca ptr
@@ -978,36 +947,36 @@ void test_combined_cleanups(bool c) {
 // CIR:   }
 // CIR:   cir.return
 
-// LLVM-LABEL: define dso_local void @_Z22test_combined_cleanupsb(
-// LLVM:   %[[TMP_LE:.*]] = alloca %struct.LE
-// LLVM:   %[[R:.*]] = alloca ptr
-// LLVM:   %[[TMP_S:.*]] = alloca %struct.S
-// LLVM:   %[[TMP_B:.*]] = alloca %struct.B
-// LLVM:   %[[ACT_B:.*]] = alloca i8
-// LLVM:   %[[SPILL:.*]] = alloca ptr
-// LLVM:   call void @_ZN1SC1Ev(ptr {{.*}} %[[TMP_S]])
-// LLVM:   call {{.*}} i32 @_ZN1S3getEv(ptr {{.*}} %[[TMP_S]])
-// LLVM:   store i8 0, ptr %[[ACT_B]]
-// LLVM:   br i1 %{{.*}}, label %[[T:.*]], label %[[F:.*]]
-// LLVM: [[T]]:
-// LLVM:   call void @_ZN1BC1Ev(ptr {{.*}} %[[TMP_B]])
-// LLVM:   store i8 1, ptr %[[ACT_B]]
-// LLVM:   call {{.*}} i32 @_ZN1B3getEv(ptr {{.*}} %[[TMP_B]])
-// LLVM: [[F]]:
-// LLVM:   phi i32 [ 0, %[[F]] ], [ %{{.*}}, %[[T]] ]
-// LLVM:   call void @_ZN2LEC1Ei(ptr {{.*}} %[[TMP_LE]], i32 {{.*}})
-// LLVM:   store ptr %[[TMP_LE]], ptr %[[SPILL]]
-// LLVM:   call void @_ZN1SD1Ev(ptr {{.*}} %[[TMP_S]])
-// LLVM:   %[[FLAG_BYTE:.*]] = load i8, ptr %[[ACT_B]]
-// LLVM:   %[[FLAG:.*]] = trunc i8 %[[FLAG_BYTE]] to i1
-// LLVM:   br i1 %[[FLAG]], label %[[B_DTOR:.*]], label %[[B_DONE:.*]]
-// LLVM: [[B_DTOR]]:
-// LLVM:   call void @_ZN1BD1Ev(ptr {{.*}} %[[TMP_B]])
-// LLVM: [[B_DONE]]:
-// LLVM:   %[[RELOAD:.*]] = load ptr, ptr %[[SPILL]]
-// LLVM:   store ptr %[[RELOAD]], ptr %[[R]]
-// LLVM:   call void @_ZN2LED1Ev(ptr {{.*}} %[[TMP_LE]])
-// LLVM:   ret void
+// LLVMCIR-LABEL: define dso_local void @_Z22test_combined_cleanupsb(
+// LLVMCIR:   %[[TMP_LE:.*]] = alloca %struct.LE
+// LLVMCIR:   %[[R:.*]] = alloca ptr
+// LLVMCIR:   %[[TMP_S:.*]] = alloca %struct.S
+// LLVMCIR:   %[[TMP_B:.*]] = alloca %struct.B
+// LLVMCIR:   %[[ACT_B:.*]] = alloca i8
+// LLVMCIR:   %[[SPILL:.*]] = alloca ptr
+// LLVMCIR:   call void @_ZN1SC1Ev(ptr {{.*}} %[[TMP_S]])
+// LLVMCIR:   call {{.*}} i32 @_ZN1S3getEv(ptr {{.*}} %[[TMP_S]])
+// LLVMCIR:   store i8 0, ptr %[[ACT_B]]
+// LLVMCIR:   br i1 %{{.*}}, label %[[T:.*]], label %[[F:.*]]
+// LLVMCIR: [[T]]:
+// LLVMCIR:   call void @_ZN1BC1Ev(ptr {{.*}} %[[TMP_B]])
+// LLVMCIR:   store i8 1, ptr %[[ACT_B]]
+// LLVMCIR:   call {{.*}} i32 @_ZN1B3getEv(ptr {{.*}} %[[TMP_B]])
+// LLVMCIR: [[F]]:
+// LLVMCIR:   phi i32 [ 0, %[[F]] ], [ %{{.*}}, %[[T]] ]
+// LLVMCIR:   call void @_ZN2LEC1Ei(ptr {{.*}} %[[TMP_LE]], i32 {{.*}})
+// LLVMCIR:   store ptr %[[TMP_LE]], ptr %[[SPILL]]
+// LLVMCIR:   call void @_ZN1SD1Ev(ptr {{.*}} %[[TMP_S]])
+// LLVMCIR:   %[[FLAG_BYTE:.*]] = load i8, ptr %[[ACT_B]]
+// LLVMCIR:   %[[FLAG:.*]] = trunc i8 %[[FLAG_BYTE]] to i1
+// LLVMCIR:   br i1 %[[FLAG]], label %[[B_DTOR:.*]], label %[[B_DONE:.*]]
+// LLVMCIR: [[B_DTOR]]:
+// LLVMCIR:   call void @_ZN1BD1Ev(ptr {{.*}} %[[TMP_B]])
+// LLVMCIR: [[B_DONE]]:
+// LLVMCIR:   %[[RELOAD:.*]] = load ptr, ptr %[[SPILL]]
+// LLVMCIR:   store ptr %[[RELOAD]], ptr %[[R]]
+// LLVMCIR:   call void @_ZN2LED1Ev(ptr {{.*}} %[[TMP_LE]])
+// LLVMCIR:   ret void
 
 // OGCG-LABEL: define dso_local void @_Z22test_combined_cleanupsb(
 // OGCG:   %[[R:.*]] = alloca ptr

--- a/clang/test/CIR/CodeGen/cleanup-derived-to-base-ref.cpp
+++ b/clang/test/CIR/CodeGen/cleanup-derived-to-base-ref.cpp
@@ -1,8 +1,6 @@
-// TODO(cir): drop -fno-clangir-call-conv-lowering once CallConvLowering
-// supports parameters of an empty or tag class.
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-call-conv-lowering -fcxx-exceptions -fexceptions -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fcxx-exceptions -fexceptions -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-call-conv-lowering -fcxx-exceptions -fexceptions -emit-llvm %s -o %t-cir.ll
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fcxx-exceptions -fexceptions -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --input-file=%t-cir.ll %s --check-prefix=LLVM
 
 struct Base {};
@@ -20,7 +18,7 @@ void bind_base_ref_to_derived_temp() {
 // CIR:   %[[REF_TMP:.*]] = cir.alloca "ref.tmp0" {{.*}} : !cir.ptr<!rec_Derived>
 // CIR:   %[[R:.*]] = cir.alloca "r" {{.*}} init const : !cir.ptr<!cir.ptr<!rec_Base>>
 // CIR:   %[[SPILL:.*]] = cir.alloca "tmp.exprcleanup" {{.*}} : !cir.ptr<!cir.ptr<!rec_Base>>
-// CIR:   cir.call @_Z12make_derivedv()
+// CIR:   cir.call @_Z12make_derivedv(%[[REF_TMP]]) : (!cir.ptr<!rec_Derived> {{.*}}llvm.sret = !rec_Derived{{.*}}) -> ()
 // CIR:   cir.cleanup.scope {
 // CIR:     %[[BASE:.*]] = cir.base_class_addr %[[REF_TMP]] : !cir.ptr<!rec_Derived> nonnull [0] -> !cir.ptr<!rec_Base>
 // CIR:     cir.store {{.*}} %[[BASE]], %[[SPILL]]

--- a/clang/test/CIR/CodeGen/cleanup.cpp
+++ b/clang/test/CIR/CodeGen/cleanup.cpp
@@ -1,6 +1,4 @@
-// TODO(cir): drop -fno-clangir-call-conv-lowering once CallConvLowering
-// supports _Complex types.
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-call-conv-lowering -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
 struct Struk {
@@ -114,7 +112,10 @@ void complex_expr_with_cleanup() {
 // CHECK:   %[[ARG_COMPLEX:.*]] = cir.complex.create %[[CONST_10]], %[[CONST_0]] : !s32i -> !cir.complex<!s32i>
 // CHECK:   cir.store {{.*}} %[[ARG_COMPLEX]], %[[ARG_ADDR]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 // CHECK:   %[[TMP_ARG:.*]] = cir.load {{.*}} %[[ARG_ADDR]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
-// CHECK:   cir.call @_ZN16ComplexContainerC1ECi(%[[CONTAINER_ADDR]], %[[TMP_ARG]]) : (!cir.ptr<!rec_ComplexContainer> {{.*}}, !cir.complex<!s32i> {{.*}}) -> ()
+// CHECK:   cir.store %[[TMP_ARG]], %[[ARG_SLOT:.*]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
+// CHECK:   %[[ARG_PTR:.*]] = cir.cast bitcast %[[ARG_SLOT]] : !cir.ptr<!cir.complex<!s32i>> -> !cir.ptr<!u64i>
+// CHECK:   %[[ARG_COERCED:.*]] = cir.load %[[ARG_PTR]] : !cir.ptr<!u64i>, !u64i
+// CHECK:   cir.call @_ZN16ComplexContainerC1ECi(%[[CONTAINER_ADDR]], %[[ARG_COERCED]]) : (!cir.ptr<!rec_ComplexContainer> {{.*}}, !u64i {{.*}}) -> ()
 // CHECK:   %[[ELEM_0:.*]] = cir.get_member %[[CONTAINER_ADDR]][0] {name = "value"} : !cir.ptr<!rec_ComplexContainer> -> !cir.ptr<!cir.complex<!s32i>>
 // CHECK:   %[[TMP_ELEM_0:.*]] = cir.load {{.*}} %[[ELEM_0]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
 // CHECK:   cir.store {{.*}} %[[TMP_ELEM_0]], %[[RESULT]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
@@ -139,7 +140,10 @@ void complex_expr_with_cleanup_inside_cleanupscope() {
 // CHECK:   %[[ARG_COMPLEX:.*]] = cir.complex.create %[[CONST_10]], %[[CONST_0]] : !s32i -> !cir.complex<!s32i>
 // CHECK:   cir.store {{.*}} %[[ARG_COMPLEX]], %[[ARG_ADDR]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 // CHECK:   %[[TMP_ARG:.*]] = cir.load {{.*}} %[[ARG_ADDR]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
-// CHECK:   cir.call @_ZN24ComplexContainerWithDtorC1ECi(%[[CONTAINER_ADDR]], %[[TMP_ARG]]) : (!cir.ptr<!rec_ComplexContainerWithDtor> {{.*}}, !cir.complex<!s32i> {{.*}}) -> ()
+// CHECK:   cir.store %[[TMP_ARG]], %[[ARG_SLOT:.*]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
+// CHECK:   %[[ARG_PTR:.*]] = cir.cast bitcast %[[ARG_SLOT]] : !cir.ptr<!cir.complex<!s32i>> -> !cir.ptr<!u64i>
+// CHECK:   %[[ARG_COERCED:.*]] = cir.load %[[ARG_PTR]] : !cir.ptr<!u64i>, !u64i
+// CHECK:   cir.call @_ZN24ComplexContainerWithDtorC1ECi(%[[CONTAINER_ADDR]], %[[ARG_COERCED]]) : (!cir.ptr<!rec_ComplexContainerWithDtor> {{.*}}, !u64i {{.*}}) -> ()
 // CHECK:   cir.cleanup.scope {
 // CHECK:     %[[ELEM_0:.*]] = cir.get_member %[[CONTAINER_ADDR]][0] {name = "value"} : !cir.ptr<!rec_ComplexContainerWithDtor> -> !cir.ptr<!cir.complex<!s32i>>
 // CHECK:     %[[TMP_ELEM_0:.*]] = cir.load {{.*}} %[[ELEM_0]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>

--- a/clang/test/CIR/CodeGen/complex-cast.cpp
+++ b/clang/test/CIR/CodeGen/complex-cast.cpp
@@ -1,8 +1,6 @@
-// TODO(cir): drop -fno-clangir-call-conv-lowering once CallConvLowering
-// supports _Complex types.
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-call-conv-lowering -emit-cir -mmlir --mlir-print-ir-before=cir-canonicalize -o %t.cir %s 2>&1 | FileCheck --check-prefix=CIR-BEFORE %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-call-conv-lowering -emit-cir -mmlir --mlir-print-ir-after=cir-lowering-prepare -o %t.cir %s 2>&1 | FileCheck --check-prefixes=CIR-AFTER %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -fno-clangir-call-conv-lowering -emit-llvm %s -o %t-cir.ll
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -mmlir --mlir-print-ir-before=cir-canonicalize -o %t.cir %s 2>&1 | FileCheck --check-prefix=CIR-BEFORE %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -mmlir --mlir-print-ir-after=cir-lowering-prepare -o %t.cir %s 2>&1 | FileCheck --check-prefixes=CIR-AFTER %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -Wno-unused-value -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
@@ -397,8 +395,9 @@ void complex_user_defined_cast() {
 // LLVM: %[[P_ADDR:.*]] = alloca %struct.Point
 // LLVM: %[[C_ADDR:.*]] = alloca { i32, i32 }
 // LLVM: call void @llvm.memcpy.p0.p0.i64(ptr align 4 %[[P_ADDR]], ptr align 4 @__const._Z25complex_user_defined_castv.p, i64 8, i1 false)
-// LLVM: %[[POINT_TO_COMPLEX:.*]] = call noundef { i32, i32 } @_ZZ25complex_user_defined_castvENK5PointcvCiEv(ptr noundef nonnull align 4 dereferenceable(8) %[[P_ADDR]])
-// LLVM: store { i32, i32 } %[[POINT_TO_COMPLEX]], ptr %[[C_ADDR]], align 4
+// LLVM: %[[POINT_TO_COMPLEX:.*]] = call noundef i64 @_ZZ25complex_user_defined_castvENK5PointcvCiEv(ptr noundef nonnull align 4 dereferenceable(8) %[[P_ADDR]])
+// LLVM: store i64 %[[POINT_TO_COMPLEX]], ptr %[[COERCE:.*]], align 8
+// LLVM: load { i32, i32 }, ptr %[[COERCE]], align 4
 
 // OGCG: %[[P_ADDR:.*]] = alloca %struct.Point, align 4
 // OGCG: %[[C_ADDR:.*]] = alloca { i32, i32 }, align 4

--- a/clang/test/CIR/CodeGen/complex.cpp
+++ b/clang/test/CIR/CodeGen/complex.cpp
@@ -1,8 +1,6 @@
-// TODO(cir): drop -fno-clangir-call-conv-lowering once CallConvLowering
-// supports _Complex types.
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -fno-clangir-call-conv-lowering -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -fno-clangir-call-conv-lowering -emit-llvm %s -o %t-cir.ll
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
@@ -404,12 +402,26 @@ bool foo18(int _Complex a, int _Complex b) {
   return a == b;
 }
 
-// CIR: %[[COMPLEX_A:.*]] = cir.load{{.*}} {{.*}} : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
-// CIR: %[[COMPLEX_B:.*]] = cir.load{{.*}} {{.*}} : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
+// CIR: %[[A_ADDR:.*]] = cir.alloca "a" {{.*}} : !cir.ptr<!cir.complex<!s32i>>
+// CIR: %[[B_ADDR:.*]] = cir.alloca "b" {{.*}} : !cir.ptr<!cir.complex<!s32i>>
+// CIR: %[[COMPLEX_A:.*]] = cir.load{{.*}} %[[A_ADDR]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
+// CIR: %[[COMPLEX_B:.*]] = cir.load{{.*}} %[[B_ADDR]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
 // CIR: %[[RESULT:.*]] = cir.cmp eq %[[COMPLEX_A]], %[[COMPLEX_B]] : !cir.complex<!s32i>
 
-// LLVM: %[[COMPLEX_A:.*]] = load { i32, i32 }, ptr {{.*}}, align 4
-// LLVM: %[[COMPLEX_B:.*]] = load { i32, i32 }, ptr {{.*}}, align 4
+// LLVM-LABEL: define dso_local noundef zeroext i1 @_Z5foo18CiS_(i64 noundef %0, i64 noundef %1)
+// LLVM: %[[B_SLOT:.*]] = alloca i64, align 8
+// LLVM-NEXT: store i64 %1, ptr %[[B_SLOT]], align 8
+// LLVM-NEXT: %[[B_RELOAD:.*]] = load { i32, i32 }, ptr %[[B_SLOT]], align 4
+// LLVM-NEXT: %[[A_SLOT:.*]] = alloca i64, align 8
+// LLVM-NEXT: store i64 %0, ptr %[[A_SLOT]], align 8
+// LLVM-NEXT: %[[A_RELOAD:.*]] = load { i32, i32 }, ptr %[[A_SLOT]], align 4
+// LLVM-NEXT: %[[A_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM-NEXT: %[[B_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM-NEXT: alloca i8, align 1
+// LLVM-NEXT: store { i32, i32 } %[[A_RELOAD]], ptr %[[A_ADDR]], align 4
+// LLVM-NEXT: store { i32, i32 } %[[B_RELOAD]], ptr %[[B_ADDR]], align 4
+// LLVM-NEXT: %[[COMPLEX_A:.*]] = load { i32, i32 }, ptr %[[A_ADDR]], align 4
+// LLVM-NEXT: %[[COMPLEX_B:.*]] = load { i32, i32 }, ptr %[[B_ADDR]], align 4
 // LLVM: %[[A_REAL:.*]] = extractvalue { i32, i32 } %[[COMPLEX_A]], 0
 // LLVM: %[[A_IMAG:.*]] = extractvalue { i32, i32 } %[[COMPLEX_A]], 1
 // LLVM: %[[B_REAL:.*]] = extractvalue { i32, i32 } %[[COMPLEX_B]], 0
@@ -436,13 +448,39 @@ bool foo19(double _Complex a, double _Complex b) {
   return a == b;
 }
 
-// CIR: %[[COMPLEX_A:.*]] = cir.load{{.*}} {{.*}} : !cir.ptr<!cir.complex<!cir.double>>, !cir.complex<!cir.double>
-// CIR: %[[COMPLEX_B:.*]] = cir.load{{.*}} {{.*}} : !cir.ptr<!cir.complex<!cir.double>>, !cir.complex<!cir.double>
+// CIR: %[[A_ADDR:.*]] = cir.alloca "a" {{.*}} : !cir.ptr<!cir.complex<!cir.double>>
+// CIR: %[[B_ADDR:.*]] = cir.alloca "b" {{.*}} : !cir.ptr<!cir.complex<!cir.double>>
+// CIR: %[[COMPLEX_A:.*]] = cir.load{{.*}} %[[A_ADDR]] : !cir.ptr<!cir.complex<!cir.double>>, !cir.complex<!cir.double>
+// CIR: %[[COMPLEX_B:.*]] = cir.load{{.*}} %[[B_ADDR]] : !cir.ptr<!cir.complex<!cir.double>>, !cir.complex<!cir.double>
 // CIR: %[[RESULT:.*]] = cir.cmp eq %[[COMPLEX_A]], %[[COMPLEX_B]] : !cir.complex<!cir.double>
 
 
-// LLVM: %[[COMPLEX_A:.*]] = load { double, double }, ptr {{.*}}, align 8
-// LLVM: %[[COMPLEX_B:.*]] = load { double, double }, ptr {{.*}}, align 8
+// LLVM-LABEL: define dso_local noundef zeroext i1 @_Z5foo19CdS_(double %0, double %1, double %2, double %3)
+// LLVM: %[[B_ADDR:.*]] = alloca { double, double }, align 8
+// LLVM-NEXT: %[[B_SLOT:.*]] = alloca { double, double }, align 8
+// LLVM-NEXT: %[[B_SLOT_REALP:.*]] = getelementptr inbounds nuw { double, double }, ptr %[[B_SLOT]], i32 0, i32 0
+// LLVM-NEXT: store double %2, ptr %[[B_SLOT_REALP]], align 8
+// LLVM-NEXT: %[[B_SLOT_IMAGP:.*]] = getelementptr inbounds nuw { double, double }, ptr %[[B_SLOT]], i32 0, i32 1
+// LLVM-NEXT: store double %3, ptr %[[B_SLOT_IMAGP]], align 8
+// LLVM-NEXT: %[[B_RELOAD1:.*]] = load { double, double }, ptr %[[B_SLOT]], align 8
+// LLVM-NEXT: store { double, double } %[[B_RELOAD1]], ptr %[[B_ADDR]], align 8
+// LLVM-NEXT: %[[B_RELOAD2:.*]] = load { double, double }, ptr %[[B_ADDR]], align 8
+// LLVM-NEXT: %[[A_ADDR:.*]] = alloca { double, double }, align 8
+// LLVM-NEXT: %[[A_SLOT:.*]] = alloca { double, double }, align 8
+// LLVM-NEXT: %[[A_SLOT_REALP:.*]] = getelementptr inbounds nuw { double, double }, ptr %[[A_SLOT]], i32 0, i32 0
+// LLVM-NEXT: store double %0, ptr %[[A_SLOT_REALP]], align 8
+// LLVM-NEXT: %[[A_SLOT_IMAGP:.*]] = getelementptr inbounds nuw { double, double }, ptr %[[A_SLOT]], i32 0, i32 1
+// LLVM-NEXT: store double %1, ptr %[[A_SLOT_IMAGP]], align 8
+// LLVM-NEXT: %[[A_RELOAD1:.*]] = load { double, double }, ptr %[[A_SLOT]], align 8
+// LLVM-NEXT: store { double, double } %[[A_RELOAD1]], ptr %[[A_ADDR]], align 8
+// LLVM-NEXT: %[[A_RELOAD2:.*]] = load { double, double }, ptr %[[A_ADDR]], align 8
+// LLVM-NEXT: %[[REAL_A_ADDR:.*]] = alloca { double, double }, align 8
+// LLVM-NEXT: %[[REAL_B_ADDR:.*]] = alloca { double, double }, align 8
+// LLVM-NEXT: alloca i8, align 1
+// LLVM-NEXT: store { double, double } %[[A_RELOAD2]], ptr %[[REAL_A_ADDR]], align 8
+// LLVM-NEXT: store { double, double } %[[B_RELOAD2]], ptr %[[REAL_B_ADDR]], align 8
+// LLVM-NEXT: %[[COMPLEX_A:.*]] = load { double, double }, ptr %[[REAL_A_ADDR]], align 8
+// LLVM-NEXT: %[[COMPLEX_B:.*]] = load { double, double }, ptr %[[REAL_B_ADDR]], align 8
 // LLVM: %[[A_REAL:.*]] = extractvalue { double, double } %[[COMPLEX_A]], 0
 // LLVM: %[[A_IMAG:.*]] = extractvalue { double, double } %[[COMPLEX_A]], 1
 // LLVM: %[[B_REAL:.*]] = extractvalue { double, double } %[[COMPLEX_B]], 0
@@ -478,12 +516,26 @@ bool foo20(int _Complex a, int _Complex b) {
   return a != b;
 }
 
-// CIR: %[[COMPLEX_A:.*]] = cir.load{{.*}} {{.*}} : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
-// CIR: %[[COMPLEX_B:.*]] = cir.load{{.*}} {{.*}} : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
+// CIR: %[[A_ADDR:.*]] = cir.alloca "a" {{.*}} : !cir.ptr<!cir.complex<!s32i>>
+// CIR: %[[B_ADDR:.*]] = cir.alloca "b" {{.*}} : !cir.ptr<!cir.complex<!s32i>>
+// CIR: %[[COMPLEX_A:.*]] = cir.load{{.*}} %[[A_ADDR]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
+// CIR: %[[COMPLEX_B:.*]] = cir.load{{.*}} %[[B_ADDR]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
 // CIR: %[[RESULT:.*]] = cir.cmp ne %[[COMPLEX_A]], %[[COMPLEX_B]] : !cir.complex<!s32i>
 
-// LLVM: %[[COMPLEX_A:.*]] = load { i32, i32 }, ptr {{.*}}, align 4
-// LLVM: %[[COMPLEX_B:.*]] = load { i32, i32 }, ptr {{.*}}, align 4
+// LLVM-LABEL: define dso_local noundef zeroext i1 @_Z5foo20CiS_(i64 noundef %0, i64 noundef %1)
+// LLVM: %[[B_SLOT:.*]] = alloca i64, align 8
+// LLVM-NEXT: store i64 %1, ptr %[[B_SLOT]], align 8
+// LLVM-NEXT: %[[B_RELOAD:.*]] = load { i32, i32 }, ptr %[[B_SLOT]], align 4
+// LLVM-NEXT: %[[A_SLOT:.*]] = alloca i64, align 8
+// LLVM-NEXT: store i64 %0, ptr %[[A_SLOT]], align 8
+// LLVM-NEXT: %[[A_RELOAD:.*]] = load { i32, i32 }, ptr %[[A_SLOT]], align 4
+// LLVM-NEXT: %[[A_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM-NEXT: %[[B_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM-NEXT: alloca i8, align 1
+// LLVM-NEXT: store { i32, i32 } %[[A_RELOAD]], ptr %[[A_ADDR]], align 4
+// LLVM-NEXT: store { i32, i32 } %[[B_RELOAD]], ptr %[[B_ADDR]], align 4
+// LLVM-NEXT: %[[COMPLEX_A:.*]] = load { i32, i32 }, ptr %[[A_ADDR]], align 4
+// LLVM-NEXT: %[[COMPLEX_B:.*]] = load { i32, i32 }, ptr %[[B_ADDR]], align 4
 // LLVM: %[[A_REAL:.*]] = extractvalue { i32, i32 } %[[COMPLEX_A]], 0
 // LLVM: %[[A_IMAG:.*]] = extractvalue { i32, i32 } %[[COMPLEX_A]], 1
 // LLVM: %[[B_REAL:.*]] = extractvalue { i32, i32 } %[[COMPLEX_B]], 0
@@ -510,12 +562,38 @@ bool foo21(double _Complex a, double _Complex b) {
   return a != b;
 }
 
-// CIR: %[[COMPLEX_A:.*]] = cir.load{{.*}} {{.*}} : !cir.ptr<!cir.complex<!cir.double>>, !cir.complex<!cir.double>
-// CIR: %[[COMPLEX_B:.*]] = cir.load{{.*}} {{.*}} : !cir.ptr<!cir.complex<!cir.double>>, !cir.complex<!cir.double>
+// CIR: %[[A_ADDR:.*]] = cir.alloca "a" {{.*}} : !cir.ptr<!cir.complex<!cir.double>>
+// CIR: %[[B_ADDR:.*]] = cir.alloca "b" {{.*}} : !cir.ptr<!cir.complex<!cir.double>>
+// CIR: %[[COMPLEX_A:.*]] = cir.load{{.*}} %[[A_ADDR]] : !cir.ptr<!cir.complex<!cir.double>>, !cir.complex<!cir.double>
+// CIR: %[[COMPLEX_B:.*]] = cir.load{{.*}} %[[B_ADDR]] : !cir.ptr<!cir.complex<!cir.double>>, !cir.complex<!cir.double>
 // CIR: %[[RESULT:.*]] = cir.cmp ne %[[COMPLEX_A]], %[[COMPLEX_B]] : !cir.complex<!cir.double>
 
-// LLVM: %[[COMPLEX_A:.*]] = load { double, double }, ptr {{.*}}, align 8
-// LLVM: %[[COMPLEX_B:.*]] = load { double, double }, ptr {{.*}}, align 8
+// LLVM-LABEL: define dso_local noundef zeroext i1 @_Z5foo21CdS_(double %0, double %1, double %2, double %3)
+// LLVM: %[[B_ADDR:.*]] = alloca { double, double }, align 8
+// LLVM-NEXT: %[[B_SLOT:.*]] = alloca { double, double }, align 8
+// LLVM-NEXT: %[[B_SLOT_REALP:.*]] = getelementptr inbounds nuw { double, double }, ptr %[[B_SLOT]], i32 0, i32 0
+// LLVM-NEXT: store double %2, ptr %[[B_SLOT_REALP]], align 8
+// LLVM-NEXT: %[[B_SLOT_IMAGP:.*]] = getelementptr inbounds nuw { double, double }, ptr %[[B_SLOT]], i32 0, i32 1
+// LLVM-NEXT: store double %3, ptr %[[B_SLOT_IMAGP]], align 8
+// LLVM-NEXT: %[[B_RELOAD1:.*]] = load { double, double }, ptr %[[B_SLOT]], align 8
+// LLVM-NEXT: store { double, double } %[[B_RELOAD1]], ptr %[[B_ADDR]], align 8
+// LLVM-NEXT: %[[B_RELOAD2:.*]] = load { double, double }, ptr %[[B_ADDR]], align 8
+// LLVM-NEXT: %[[A_ADDR:.*]] = alloca { double, double }, align 8
+// LLVM-NEXT: %[[A_SLOT:.*]] = alloca { double, double }, align 8
+// LLVM-NEXT: %[[A_SLOT_REALP:.*]] = getelementptr inbounds nuw { double, double }, ptr %[[A_SLOT]], i32 0, i32 0
+// LLVM-NEXT: store double %0, ptr %[[A_SLOT_REALP]], align 8
+// LLVM-NEXT: %[[A_SLOT_IMAGP:.*]] = getelementptr inbounds nuw { double, double }, ptr %[[A_SLOT]], i32 0, i32 1
+// LLVM-NEXT: store double %1, ptr %[[A_SLOT_IMAGP]], align 8
+// LLVM-NEXT: %[[A_RELOAD1:.*]] = load { double, double }, ptr %[[A_SLOT]], align 8
+// LLVM-NEXT: store { double, double } %[[A_RELOAD1]], ptr %[[A_ADDR]], align 8
+// LLVM-NEXT: %[[A_RELOAD2:.*]] = load { double, double }, ptr %[[A_ADDR]], align 8
+// LLVM-NEXT: %[[REAL_A_ADDR:.*]] = alloca { double, double }, align 8
+// LLVM-NEXT: %[[REAL_B_ADDR:.*]] = alloca { double, double }, align 8
+// LLVM-NEXT: alloca i8, align 1
+// LLVM-NEXT: store { double, double } %[[A_RELOAD2]], ptr %[[REAL_A_ADDR]], align 8
+// LLVM-NEXT: store { double, double } %[[B_RELOAD2]], ptr %[[REAL_B_ADDR]], align 8
+// LLVM-NEXT: %[[COMPLEX_A:.*]] = load { double, double }, ptr %[[REAL_A_ADDR]], align 8
+// LLVM-NEXT: %[[COMPLEX_B:.*]] = load { double, double }, ptr %[[REAL_B_ADDR]], align 8
 // LLVM: %[[A_REAL:.*]] = extractvalue { double, double } %[[COMPLEX_A]], 0
 // LLVM: %[[A_IMAG:.*]] = extractvalue { double, double } %[[COMPLEX_A]], 1
 // LLVM: %[[B_REAL:.*]] = extractvalue { double, double } %[[COMPLEX_B]], 0
@@ -1322,14 +1400,19 @@ void complex_type_argument() {
 // CIR: %[[TMP_A:.*]] = cir.load{{.*}} %[[A_ADDR]] : !cir.ptr<!cir.complex<!cir.float>>, !cir.complex<!cir.float>
 // CIR: cir.store{{.*}} %[[TMP_A]], %[[ARG_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 // CIR: %[[TMP_ARG:.*]] = cir.load{{.*}} %[[ARG_ADDR]] : !cir.ptr<!cir.complex<!cir.float>>, !cir.complex<!cir.float>
-// CIR: cir.call @_Z22complex_type_parameterCf(%[[TMP_ARG]]) : (!cir.complex<!cir.float> {llvm.noundef}) -> ()
+// CIR: cir.store %[[TMP_ARG]], %[[VSLOT:.*]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
+// CIR: %[[VPTR:.*]] = cir.cast bitcast %[[VSLOT]] : !cir.ptr<!cir.complex<!cir.float>> -> !cir.ptr<!cir.vector<2 x !cir.float>>
+// CIR: %[[VARG:.*]] = cir.load %[[VPTR]] : !cir.ptr<!cir.vector<2 x !cir.float>>, !cir.vector<2 x !cir.float>
+// CIR: cir.call @_Z22complex_type_parameterCf(%[[VARG]]) : (!cir.vector<2 x !cir.float> {llvm.noundef}) -> ()
 
 // LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: %[[ARG_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: store { float, float } %[[TMP_A]], ptr %[[ARG_ADDR]], align 4
 // LLVM: %[[TMP_ARG:.*]] = load { float, float }, ptr %[[ARG_ADDR]], align 4
-// LLVM: call void @_Z22complex_type_parameterCf({ float, float } noundef %[[TMP_ARG]])
+// LLVM: store { float, float } %[[TMP_ARG]], ptr %[[VSLOT:.*]], align 4
+// LLVM: %[[VARG:.*]] = load <2 x float>, ptr %[[VSLOT]], align 8
+// LLVM: call void @_Z22complex_type_parameterCf(<2 x float> noundef %[[VARG]])
 
 // OGCG: %[[A_ADDR:.*]] = alloca { float, float }, align 4
 // OGCG: %[[ARG_ADDR:.*]] = alloca { float, float }, align 4
@@ -1352,13 +1435,17 @@ float _Complex complex_type_return_type() {
 // CIR: %[[RET_VAL:.*]] = cir.const #cir.const_complex<#cir.fp<1.000000e+00> : !cir.float, #cir.fp<2.000000e+00> : !cir.float> : !cir.complex<!cir.float>
 // CIR: cir.store{{.*}} %[[RET_VAL]], %[[RET_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 // CIR: %[[TMP_RET:.*]] = cir.load %[[RET_ADDR]] : !cir.ptr<!cir.complex<!cir.float>>, !cir.complex<!cir.float>
-// CIR: cir.return %[[TMP_RET]] : !cir.complex<!cir.float>
+// CIR: cir.store %[[TMP_RET]], %[[RSLOT:.*]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
+// CIR: %[[RPTR:.*]] = cir.cast bitcast %[[RSLOT]] : !cir.ptr<!cir.complex<!cir.float>> -> !cir.ptr<!cir.vector<2 x !cir.float>>
+// CIR: %[[RVEC:.*]] = cir.load %[[RPTR]] : !cir.ptr<!cir.vector<2 x !cir.float>>, !cir.vector<2 x !cir.float>
+// CIR: cir.return %[[RVEC]] : !cir.vector<2 x !cir.float>
 
-// TODO(CIR): the difference between the CIR LLVM and OGCG is because the lack of calling convention lowering,
 // LLVM: %[[RET_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: store { float, float } { float 1.000000e+00, float 2.000000e+00 }, ptr %[[RET_ADDR]], align 4
 // LLVM: %[[TMP_RET:.*]] = load { float, float }, ptr %[[RET_ADDR]], align 4
-// LLVM: ret { float, float } %[[TMP_RET]]
+// LLVM: store { float, float } %[[TMP_RET]], ptr %[[RSLOT:.*]], align 4
+// LLVM: %[[RVEC:.*]] = load <2 x float>, ptr %[[RSLOT]], align 8
+// LLVM: ret <2 x float> %[[RVEC]]
 
 // OGCG: %[[RET_ADDR:.*]] = alloca { float, float }, align 4
 // OGCG: %[[RET_VAL_REAL:.*]] = getelementptr inbounds nuw { float, float }, ptr %[[RET_ADDR]], i32 0, i32 0
@@ -1432,18 +1519,21 @@ void calling_function_with_default_arg() {
   function_with_complex_default_arg();
 }
 
-// CIR: %[[DEFAULT_ARG_ADDR:.*]] = cir.alloca "coerce" {{.*}} : !cir.ptr<!cir.complex<!cir.float>>
+// CIR: %[[DEFAULT_ARG_ADDR:.*]] = cir.alloca "coerce" align(4) : !cir.ptr<!cir.complex<!cir.float>>
 // CIR: %[[DEFAULT_ARG_VAL:.*]] = cir.const #cir.const_complex<#cir.fp<1.000000e+00> : !cir.float, #cir.fp<2.200000e+00> : !cir.float> : !cir.complex<!cir.float>
 // CIR: cir.store{{.*}} %[[DEFAULT_ARG_VAL]], %[[DEFAULT_ARG_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 // CIR: %[[TMP_DEFAULT_ARG:.*]] = cir.load{{.*}} %[[DEFAULT_ARG_ADDR]] : !cir.ptr<!cir.complex<!cir.float>>, !cir.complex<!cir.float>
-// CIR: cir.call @_Z33function_with_complex_default_argCf(%[[TMP_DEFAULT_ARG]]) : (!cir.complex<!cir.float> {{.*}}) -> ()
-
-// TODO(CIR): the difference between the CIR LLVM and OGCG is because the lack of calling convention lowering,
+// CIR: cir.store %[[TMP_DEFAULT_ARG]], %[[VSLOT:.*]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
+// CIR: %[[VPTR:.*]] = cir.cast bitcast %[[VSLOT]] : !cir.ptr<!cir.complex<!cir.float>> -> !cir.ptr<!cir.vector<2 x !cir.float>>
+// CIR: %[[VARG:.*]] = cir.load %[[VPTR]] : !cir.ptr<!cir.vector<2 x !cir.float>>, !cir.vector<2 x !cir.float>
+// CIR: cir.call @_Z33function_with_complex_default_argCf(%[[VARG]]) : (!cir.vector<2 x !cir.float> {{.*}}) -> ()
 
 // LLVM: %[[DEFAULT_ARG_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: store { float, float } { float 1.000000e+00, float 2.200000e+00 }, ptr %[[DEFAULT_ARG_ADDR]], align 4
 // LLVM: %[[TMP_DEFAULT_ARG:.*]] = load { float, float }, ptr %[[DEFAULT_ARG_ADDR]], align 4
-// LLVM: call void @_Z33function_with_complex_default_argCf({ float, float } {{.*}} %[[TMP_DEFAULT_ARG]])
+// LLVM: store { float, float } %[[TMP_DEFAULT_ARG]], ptr %[[VSLOT:.*]], align 4
+// LLVM: %[[VARG:.*]] = load <2 x float>, ptr %[[VSLOT]], align 8
+// LLVM: call void @_Z33function_with_complex_default_argCf(<2 x float> {{.*}} %[[VARG]])
 
 // OGCG: %[[DEFAULT_ARG_ADDR:.*]] = alloca { float, float }, align 4
 // OGCG: %[[DEFAULT_ARG_REAL_PTR:.*]] = getelementptr inbounds nuw { float, float }, ptr %[[DEFAULT_ARG_ADDR]], i32 0, i32 0
@@ -1458,14 +1548,17 @@ void calling_function_that_return_complex() {
 }
 
 // CIR: %[[A_ADDR:.*]] = cir.alloca "a" {{.*}} init : !cir.ptr<!cir.complex<!cir.float>>
-// CIR: %[[RESULT:.*]] = cir.call @_Z24complex_type_return_typev() : () -> (!cir.complex<!cir.float> {llvm.noundef})
-// CIR: cir.store{{.*}} %[[RESULT]], %[[A_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
-
-// TODO(CIR): the difference between the CIR LLVM and OGCG is because the lack of calling convention lowering,
+// CIR: %[[RESULT:.*]] = cir.call @_Z24complex_type_return_typev() : () -> (!cir.vector<2 x !cir.float> {llvm.noundef})
+// CIR: cir.store %[[RESULT]], %[[RSLOT:.*]] : !cir.vector<2 x !cir.float>, !cir.ptr<!cir.vector<2 x !cir.float>>
+// CIR: %[[RPTR:.*]] = cir.cast bitcast %[[RSLOT]] : !cir.ptr<!cir.vector<2 x !cir.float>> -> !cir.ptr<!cir.complex<!cir.float>>
+// CIR: %[[RCPLX:.*]] = cir.load %[[RPTR]] : !cir.ptr<!cir.complex<!cir.float>>, !cir.complex<!cir.float>
+// CIR: cir.store{{.*}} %[[RCPLX]], %[[A_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
 // LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
-// LLVM: %[[RESULT:.*]] = call noundef { float, float } @_Z24complex_type_return_typev()
-// LLVM: store { float, float } %[[RESULT]], ptr %[[A_ADDR]], align 4
+// LLVM: %[[RESULT:.*]] = call noundef <2 x float> @_Z24complex_type_return_typev()
+// LLVM: store <2 x float> %[[RESULT]], ptr %[[RSLOT:.*]], align 8
+// LLVM: %[[RCPLX:.*]] = load { float, float }, ptr %[[RSLOT]], align 4
+// LLVM: store { float, float } %[[RCPLX]], ptr %[[A_ADDR]], align 4
 
 // OGCG: %[[A_ADDR:.*]] = alloca { float, float }, align 4
 // OGCG: %[[RESULT_ADDR:.*]] = alloca { float, float }, align 4
@@ -1944,16 +2037,26 @@ _Complex float complex_invoker() {
 
 // CIR-LABEL: cir.func {{.*}}@_ZZ15complex_invokervEN3$_08__invokeECf
 // CIR: %[[RETVAL:.*]] = cir.alloca "__retval" {{.*}} : !cir.ptr<!cir.complex<!cir.float>>
-// CIR: %[[CALL:.*]] = cir.call @_ZZ15complex_invokervENK3$_0clECf({{.*}}) {{.*}} -> (!cir.complex<!cir.float> {{.*}})
-// CIR: cir.store{{.*}} %[[CALL]], %[[RETVAL]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
+// CIR: %[[CALL:.*]] = cir.call @_ZZ15complex_invokervENK3$_0clECf({{.*}}) {{.*}} -> (!cir.vector<2 x !cir.float> {{.*}})
+// CIR: cir.store %[[CALL]], %[[CSLOT:.*]] : !cir.vector<2 x !cir.float>, !cir.ptr<!cir.vector<2 x !cir.float>>
+// CIR: %[[CPTR:.*]] = cir.cast bitcast %[[CSLOT]] : !cir.ptr<!cir.vector<2 x !cir.float>> -> !cir.ptr<!cir.complex<!cir.float>>
+// CIR: %[[CCPLX:.*]] = cir.load %[[CPTR]] : !cir.ptr<!cir.complex<!cir.float>>, !cir.complex<!cir.float>
+// CIR: cir.store{{.*}} %[[CCPLX]], %[[RETVAL]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 // CIR: %[[RET:.*]] = cir.load %[[RETVAL]] : !cir.ptr<!cir.complex<!cir.float>>, !cir.complex<!cir.float>
-// CIR: cir.return %[[RET]] : !cir.complex<!cir.float>
+// CIR: cir.store %[[RET]], %[[RSLOT:.*]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
+// CIR: %[[RPTR:.*]] = cir.cast bitcast %[[RSLOT]] : !cir.ptr<!cir.complex<!cir.float>> -> !cir.ptr<!cir.vector<2 x !cir.float>>
+// CIR: %[[RVEC:.*]] = cir.load %[[RPTR]] : !cir.ptr<!cir.vector<2 x !cir.float>>, !cir.vector<2 x !cir.float>
+// CIR: cir.return %[[RVEC]] : !cir.vector<2 x !cir.float>
 
-// LLVM-LABEL: define internal {{.*}}{ float, float } @"_ZZ15complex_invokervEN3$_08__invokeECf"
-// LLVM: %[[CALL:.*]] = call {{.*}}{ float, float } @"_ZZ15complex_invokervENK3$_0clECf"
-// LLVM: store { float, float } %[[CALL]], ptr %[[RETVAL:.*]]
-// LLVM: %[[RET:.*]] = load { float, float }, ptr %[[RETVAL]]
-// LLVM: ret { float, float } %[[RET]]
+// LLVM-LABEL: define internal {{.*}}<2 x float> @"_ZZ15complex_invokervEN3$_08__invokeECf"
+// LLVM: %[[CALL:.*]] = call {{.*}}<2 x float> @"_ZZ15complex_invokervENK3$_0clECf"
+// LLVM: store <2 x float> %[[CALL]], ptr %[[CSLOT:.*]], align 8
+// LLVM: %[[CCPLX:.*]] = load { float, float }, ptr %[[CSLOT]], align 4
+// LLVM: store { float, float } %[[CCPLX]], ptr %[[RETVAL:.*]], align 4
+// LLVM: %[[RET:.*]] = load { float, float }, ptr %[[RETVAL]], align 4
+// LLVM: store { float, float } %[[RET]], ptr %[[RSLOT:.*]], align 4
+// LLVM: %[[RVEC:.*]] = load <2 x float>, ptr %[[RSLOT]], align 8
+// LLVM: ret <2 x float> %[[RVEC]]
 
 // OGCG-LABEL: define internal {{.*}} <2 x float> @"_ZZ15complex_invokervEN3$_08__invokeECf"
 // OGCG: %[[CALL:.*]] = call {{.*}}<2 x float> @"_ZZ15complex_invokervENK3$_0clECf"

--- a/clang/test/CIR/CodeGen/cxx-rewritten-binary-operator.cpp
+++ b/clang/test/CIR/CodeGen/cxx-rewritten-binary-operator.cpp
@@ -1,8 +1,6 @@
-// TODO(cir): drop -fno-clangir-call-conv-lowering once CallConvLowering
-// supports _Complex types and parameters of an empty or tag class.
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -fno-clangir-call-conv-lowering -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -fno-clangir-call-conv-lowering -emit-llvm %s -o %t-cir.ll
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
@@ -58,11 +56,15 @@ void cxx_rewritten_binary_operator_complex_expr() {
 // CIR: %[[B_ADDR:.*]] = cir.alloca "b" {{.*}} : !cir.ptr<!rec_ComplexItem>
 // CIR: %[[R_ADDR:.*]] = cir.alloca "r" {{.*}} init : !cir.ptr<!cir.complex<!s32i>>
 // CIR: %[[TMP_ADDR:.*]] = cir.alloca "ref.tmp0" {{.*}} : !cir.ptr<!rec_SpaceshipComplexResult>
-// CIR: %[[OP_RESULT:.*]] = cir.call @_ZNK11ComplexItemssERKS_(%[[A_ADDR]], %[[B_ADDR]]) : (!cir.ptr<!rec_ComplexItem> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}, !cir.ptr<!rec_ComplexItem> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}) -> !rec_SpaceshipComplexResult
-// CIR: cir.store {{.*}} %[[OP_RESULT]], %[[TMP_ADDR]] : !rec_SpaceshipComplexResult, !cir.ptr<!rec_SpaceshipComplexResult>
+// CIR: cir.call @_ZNK11ComplexItemssERKS_(%[[A_ADDR]], %[[B_ADDR]]) : (!cir.ptr<!rec_ComplexItem> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}, !cir.ptr<!rec_ComplexItem> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}) -> ()
+// CIR: %[[POISON:.*]] = cir.const #cir.poison : !rec_SpaceshipComplexResult
+// CIR: cir.store {{.*}} %[[POISON]], %[[TMP_ADDR]] : !rec_SpaceshipComplexResult, !cir.ptr<!rec_SpaceshipComplexResult>
 // CIR: %[[CONST_0:.*]] = cir.const #cir.int<0> : !s32i
-// CIR: %[[RESULT:.*]] = cir.call @_ZNK22SpaceshipComplexResultltEi(%[[TMP_ADDR]], %[[CONST_0]]) : (!cir.ptr<!rec_SpaceshipComplexResult> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}, !s32i {llvm.noundef}) -> (!cir.complex<!s32i> {llvm.noundef})
-// CIR: cir.store {{.*}} %[[RESULT]], %[[R_ADDR]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
+// CIR: %[[RESULT:.*]] = cir.call @_ZNK22SpaceshipComplexResultltEi(%[[TMP_ADDR]], %[[CONST_0]]) : (!cir.ptr<!rec_SpaceshipComplexResult> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}, !s32i {llvm.noundef}) -> (!u64i {llvm.noundef})
+// CIR: cir.store %[[RESULT]], %[[R_SLOT:.*]] : !u64i, !cir.ptr<!u64i>
+// CIR: %[[R_PTR:.*]] = cir.cast bitcast %[[R_SLOT]] : !cir.ptr<!u64i> -> !cir.ptr<!cir.complex<!s32i>>
+// CIR: %[[R_CPLX:.*]] = cir.load %[[R_PTR]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
+// CIR: cir.store {{.*}} %[[R_CPLX]], %[[R_ADDR]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
 // The difference between LLVM and OGCG is due to missing ABI lowering.
 
@@ -70,10 +72,11 @@ void cxx_rewritten_binary_operator_complex_expr() {
 // LLVM: %[[B_ADDR:.*]] = alloca %struct.ComplexItem, align 1
 // LLVM: %[[R_ADDR:.*]] = alloca { i32, i32 }, align 4
 // LLVM: %[[TMP_ADDR:.*]] = alloca %struct.SpaceshipComplexResult, align 1
-// LLVM: %[[OP_RESULT:.*]] = call %struct.SpaceshipComplexResult @_ZNK11ComplexItemssERKS_(ptr noundef nonnull align 1 dereferenceable(1) %[[A_ADDR]], ptr noundef nonnull align 1 dereferenceable(1) %[[B_ADDR]])
-// LLVM: store %struct.SpaceshipComplexResult %[[OP_RESULT]], ptr %[[TMP_ADDR]], align 1
-// LLVM: %[[RESULT:.*]] = call noundef { i32, i32 } @_ZNK22SpaceshipComplexResultltEi(ptr noundef nonnull align 1 dereferenceable(1) %[[TMP_ADDR]], i32 noundef 0)
-// LLVM: store { i32, i32 } %[[RESULT]], ptr %[[R_ADDR]], align 4
+// LLVM: call void @_ZNK11ComplexItemssERKS_(ptr noundef nonnull align 1 dereferenceable(1) %[[A_ADDR]], ptr noundef nonnull align 1 dereferenceable(1) %[[B_ADDR]])
+// LLVM: %[[RESULT:.*]] = call noundef i64 @_ZNK22SpaceshipComplexResultltEi(ptr noundef nonnull align 1 dereferenceable(1) %[[TMP_ADDR]], i32 noundef 0)
+// LLVM: store i64 %[[RESULT]], ptr %[[R_SLOT:.*]], align 8
+// LLVM: %[[R_CPLX:.*]] = load { i32, i32 }, ptr %[[R_SLOT]], align 4
+// LLVM: store { i32, i32 } %[[R_CPLX]], ptr %[[R_ADDR]], align 4
 
 // OGCG: %[[A_ADDR:.*]] = alloca %struct.ComplexItem, align 1
 // OGCG: %[[B_ADDR:.*]] = alloca %struct.ComplexItem, align 1
@@ -114,11 +117,15 @@ void cxx_rewritten_binary_operator_aggr_expr() {
 // CIR: %[[B_ADDR:.*]] = cir.alloca "b" {{.*}} : !cir.ptr<!rec_Item>
 // CIR: %[[R_ADDR:.*]] = cir.alloca "r" {{.*}} init : !cir.ptr<!rec_Result>
 // CIR: %[[TMP_ADDR:.*]] = cir.alloca "ref.tmp0" {{.*}} : !cir.ptr<!rec_SpaceshipResult>
-// CIR: %[[OP_RESULT:.*]] = cir.call @_ZNK4ItemssERKS_(%[[A_ADDR]], %[[B_ADDR]]) : (!cir.ptr<!rec_Item> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}, !cir.ptr<!rec_Item> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}) -> !rec_SpaceshipResult
+// CIR: cir.call @_ZNK4ItemssERKS_(%[[A_ADDR]], %[[B_ADDR]]) : (!cir.ptr<!rec_Item> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}, !cir.ptr<!rec_Item> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}) -> ()
+// CIR: %[[OP_RESULT:.*]] = cir.const #cir.poison : !rec_SpaceshipResult
 // CIR: cir.store {{.*}} %[[OP_RESULT]], %[[TMP_ADDR]] : !rec_SpaceshipResult, !cir.ptr<!rec_SpaceshipResult>
 // CIR: %[[CONST_0:.*]] = cir.const #cir.int<0> : !s32i
-// CIR: %[[RESULT:.*]] = cir.call @_ZNK15SpaceshipResultltEi(%[[TMP_ADDR]], %[[CONST_0]]) : (!cir.ptr<!rec_SpaceshipResult> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}, !s32i {llvm.noundef}) -> !rec_Result
-// CIR: cir.store {{.*}} %[[RESULT]], %[[R_ADDR]] : !rec_Result, !cir.ptr<!rec_Result>
+// CIR: %[[RESULT:.*]] = cir.call @_ZNK15SpaceshipResultltEi(%[[TMP_ADDR]], %[[CONST_0]]) : (!cir.ptr<!rec_SpaceshipResult> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}, !s32i {llvm.noundef}) -> !s32i
+// CIR: cir.store %[[RESULT]], %[[R_SLOT:.*]] : !s32i, !cir.ptr<!s32i>
+// CIR: %[[R_PTR:.*]] = cir.cast bitcast %[[R_SLOT]] : !cir.ptr<!s32i> -> !cir.ptr<!rec_Result>
+// CIR: %[[R_VAL:.*]] = cir.load %[[R_PTR]] : !cir.ptr<!rec_Result>, !rec_Result
+// CIR: cir.store {{.*}} %[[R_VAL]], %[[R_ADDR]] : !rec_Result, !cir.ptr<!rec_Result>
 
 // The difference between LLVM and OGCG is due to missing ABI lowering.
 
@@ -126,10 +133,12 @@ void cxx_rewritten_binary_operator_aggr_expr() {
 // LLVM: %[[B_ADDR:.*]] = alloca %struct.Item, align 1
 // LLVM: %[[R_ADDR:.*]] = alloca %struct.Result, align 4
 // LLVM: %[[TMP_ADDR:.*]] = alloca %struct.SpaceshipResult, align 1
-// LLVM: %[[OP_RESULT:.*]] = call %struct.SpaceshipResult @_ZNK4ItemssERKS_(ptr noundef nonnull align 1 dereferenceable(1) %[[A_ADDR]], ptr noundef nonnull align 1 dereferenceable(1) %[[B_ADDR]])
-// LLVM: store %struct.SpaceshipResult %[[OP_RESULT]], ptr %[[TMP_ADDR]], align 1
-// LLVM: %[[RESULT:.*]] = call %struct.Result @_ZNK15SpaceshipResultltEi(ptr noundef nonnull align 1 dereferenceable(1) %[[TMP_ADDR]], i32 noundef 0)
-// LLVM: store %struct.Result %[[RESULT]], ptr %[[R_ADDR]], align 4
+// LLVM: call void @_ZNK4ItemssERKS_(ptr noundef nonnull align 1 dereferenceable(1) %[[A_ADDR]], ptr noundef nonnull align 1 dereferenceable(1) %[[B_ADDR]])
+// LLVM: store %struct.SpaceshipResult poison, ptr %[[TMP_ADDR]], align 1
+// LLVM: %[[RESULT:.*]] = call i32 @_ZNK15SpaceshipResultltEi(ptr noundef nonnull align 1 dereferenceable(1) %[[TMP_ADDR]], i32 noundef 0)
+// LLVM: store i32 %[[RESULT]], ptr %[[R_SLOT:.*]], align 4
+// LLVM: %[[R_VAL:.*]] = load %struct.Result, ptr %[[R_SLOT]], align 4
+// LLVM: store %struct.Result %[[R_VAL]], ptr %[[R_ADDR]], align 4
 
 // OGCG: %[[A_ADDR:.*]] = alloca %struct.Item, align 1
 // OGCG: %[[B_ADDR:.*]] = alloca %struct.Item, align 1

--- a/clang/test/CIR/CodeGen/delete-destroying.cpp
+++ b/clang/test/CIR/CodeGen/delete-destroying.cpp
@@ -1,8 +1,6 @@
-// TODO(cir): drop -fno-clangir-call-conv-lowering once CallConvLowering
-// supports parameters of an empty or tag class.
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -fno-clangir-call-conv-lowering -mconstructor-aliases -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -mconstructor-aliases -emit-cir %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -fno-clangir-call-conv-lowering -mconstructor-aliases -emit-llvm %s -o %t-cir.ll
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -mconstructor-aliases -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -mconstructor-aliases -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
@@ -43,7 +41,7 @@ void test_destroying_delete(S *s) {
 // CIR:   %[[NOT_NULL:.*]] = cir.cmp ne %[[S]], %[[NULL]] : !cir.ptr<!rec_S>
 // CIR:   cir.if %[[NOT_NULL]] {
 // CIR:     %[[TAG:.*]] = cir.load{{.*}} %[[TAG_ADDR]]
-// CIR:     cir.call @_ZN1SdlEPS_St19destroying_delete_t(%[[S]], %[[TAG]]){{.*}} : (!cir.ptr<!rec_S> {{.*}}, !rec_std3A3Adestroying_delete_t) -> ()
+// CIR:     cir.call @_ZN1SdlEPS_St19destroying_delete_t(%[[S]]){{.*}} : (!cir.ptr<!rec_S> {{.*}}) -> ()
 // CIR-NOT: cir.call @_ZN1SD{{[12]}}Ev
 // CIR:   }
 // CIR:   cir.return
@@ -57,18 +55,15 @@ void test_destroying_delete(S *s) {
 // LLVM:   br i1 %[[NOT_NULL]], label %[[NOTNULL:.*]], label %[[END:.*]]
 // LLVM: [[NOTNULL]]:
 // LLVM:   %[[TAG:.*]] = load %"struct.std::destroying_delete_t", ptr %[[TAG_ADDR]]
-// LLVM:   call void @_ZN1SdlEPS_St19destroying_delete_t(ptr noundef %[[S]], %"struct.std::destroying_delete_t" %[[TAG]])
+// LLVM:   call void @_ZN1SdlEPS_St19destroying_delete_t(ptr noundef %[[S]])
 // LLVM-NOT: call void @_ZN1SD{{[12]}}Ev
 // LLVM: [[END]]:
 // LLVM:   ret void
 
 // S::operator delete(S *, std::destroying_delete_t)
-// CIR: cir.func private @_ZN1SdlEPS_St19destroying_delete_t(!cir.ptr<!rec_S> {llvm.noundef}, !rec_std3A3Adestroying_delete_t)
-// LLVM: declare void @_ZN1SdlEPS_St19destroying_delete_t(ptr noundef, %"struct.std::destroying_delete_t")
+// CIR: cir.func private @_ZN1SdlEPS_St19destroying_delete_t(!cir.ptr<!rec_S> {llvm.noundef})
+// LLVM: declare void @_ZN1SdlEPS_St19destroying_delete_t(ptr noundef)
 
-// Classic codegen elides empty-class parameters at the ABI level, so the
-// destroying_delete_t tag disappears from both the declaration and the call.
-// Either way, no destructor call is emitted from the caller.
 // OGCG: define {{.*}} void @_Z22test_destroying_deleteP1S(ptr {{.*}} %[[ARG:.*]])
 // OGCG:   %[[S_ADDR:.*]] = alloca ptr
 // OGCG:   store ptr %[[ARG]], ptr %[[S_ADDR]]

--- a/clang/test/CIR/CodeGen/dtors.cpp
+++ b/clang/test/CIR/CodeGen/dtors.cpp
@@ -1,8 +1,6 @@
-// TODO(cir): drop -fno-clangir-call-conv-lowering once CallConvLowering
-// supports parameters of an empty or tag class.
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -mconstructor-aliases -fclangir -fno-clangir-call-conv-lowering -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -mconstructor-aliases -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -mconstructor-aliases -fclangir -fno-clangir-call-conv-lowering -emit-llvm %s -o %t-cir.ll
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -mconstructor-aliases -fclangir -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --input-file=%t-cir.ll %s --check-prefix=LLVM
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -mconstructor-aliases -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s --check-prefix=OGCG
@@ -340,8 +338,7 @@ int test_temp_in_condition(G &obj) {
 // CIR:     %[[REF_TMP1:.*]] = cir.alloca "ref.tmp1" {{.*}} : !cir.ptr<!rec_G>
 // CIR:     %[[CLEANUP_TMP:.*]] = cir.alloca "tmp.exprcleanup" {{.*}} : !cir.ptr<!cir.bool>
 // CIR:     %[[LOAD_OBJ:.*]] = cir.load{{.*}} %[[OBJ]] : !cir.ptr<!cir.ptr<!rec_G>>, !cir.ptr<!rec_G>
-// CIR:     %[[COPY:.*]] = cir.call @_ZNK1G4copyEv(%[[LOAD_OBJ]]) : (!cir.ptr<!rec_G> {{.*}}) -> !rec_G
-// CIR:     cir.store{{.*}} %[[COPY]], %[[REF_TMP0]]
+// CIR:     cir.call @_ZNK1G4copyEv(%[[REF_TMP0]], %[[LOAD_OBJ]]) : (!cir.ptr<!rec_G> {{.*}}llvm.sret = !rec_G{{.*}}, !cir.ptr<!rec_G> {{.*}}) -> ()
 // CIR:     cir.cleanup.scope {
 // CIR:       %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
 // CIR:       cir.call @_ZN1GC1Ei(%[[REF_TMP1]], %[[ONE]]) : (!cir.ptr<!rec_G> {{.*}}, !s32i {{.*}}) -> ()
@@ -381,14 +378,13 @@ int test_temp_in_condition(G &obj) {
 // LLVM:   br label %[[SCOPE_BEGIN:.*]]
 // LLVM: [[SCOPE_BEGIN]]:
 // LLVM:   %[[LOAD_OBJ:.*]] = load ptr, ptr %[[OBJ]]
-// LLVM:   %[[COPY:.*]] = call %struct.G @_ZNK1G4copyEv(ptr {{.*}} %[[LOAD_OBJ]])
-// LLVM:   store %struct.G %[[COPY]], ptr %[[REF_TMP0]]
+// LLVM:   call void @_ZNK1G4copyEv(ptr {{.*}} sret(%struct.G) {{.*}} %[[REF_TMP0]], ptr {{.*}} %[[LOAD_OBJ]])
 // LLVM:   br label %[[CLEAN_SCOPE_ONE:.*]]
 // LLVM: [[CLEAN_SCOPE_ONE]]:
 // LLVM:   call void @_ZN1GC1Ei(ptr {{.*}} %[[REF_TMP1]], i32 {{.*}} 1)
 // LLVM:   br label %[[CLEAN_SCOPE_TWO:.*]]
 // LLVM: [[CLEAN_SCOPE_TWO]]:
-// LLVM:   %[[EQUAL:.*]] = call noundef i1 @_ZNK1GeqERKS_(ptr {{.*}} %[[REF_TMP0]], ptr {{.*}} %[[REF_TMP1]])
+// LLVM:   %[[EQUAL:.*]] = call noundef zeroext i1 @_ZNK1GeqERKS_(ptr {{.*}} %[[REF_TMP0]], ptr {{.*}} %[[REF_TMP1]])
 // LLVM:   %[[ZEXT:.*]] = zext i1 %[[EQUAL]] to i8
 // LLVM:   store i8 %[[ZEXT]], ptr %[[TMP_RESULT]]
 // LLVM:   br label %[[CLEAN_SCOPE_TWO_CLEANUP:.*]]

--- a/clang/test/CIR/CodeGen/loop-cond-cleanup.cpp
+++ b/clang/test/CIR/CodeGen/loop-cond-cleanup.cpp
@@ -1,8 +1,6 @@
-// TODO(cir): drop -fno-clangir-call-conv-lowering once CallConvLowering
-// supports parameters of an empty or tag class.
-// RUN: %clang_cc1 -no-enable-noundef-analysis %s -triple=x86_64-linux-gnu -fclangir -fno-clangir-call-conv-lowering -emit-cir -std=c++17 -fcxx-exceptions -fexceptions -o %t.cir
+// RUN: %clang_cc1 -no-enable-noundef-analysis %s -triple=x86_64-linux-gnu -fclangir -emit-cir -std=c++17 -fcxx-exceptions -fexceptions -o %t.cir
 // RUN: FileCheck -check-prefixes=CIR --input-file=%t.cir %s
-// RUN: %clang_cc1 -no-enable-noundef-analysis %s -triple=x86_64-linux-gnu -fclangir -fno-clangir-call-conv-lowering -emit-llvm -std=c++17 -fcxx-exceptions -fexceptions -o %t-cir.ll
+// RUN: %clang_cc1 -no-enable-noundef-analysis %s -triple=x86_64-linux-gnu -fclangir -emit-llvm -std=c++17 -fcxx-exceptions -fexceptions -o %t-cir.ll
 // RUN: FileCheck -check-prefixes=LLVM --input-file=%t-cir.ll %s
 // RUN: %clang_cc1 -no-enable-noundef-analysis %s -triple=x86_64-linux-gnu -emit-llvm -std=c++17 -fcxx-exceptions -fexceptions -o %t.ll
 // RUN: FileCheck -check-prefixes=OGCG --input-file=%t.ll %s
@@ -22,7 +20,7 @@ void while_cond_cleanup(int n) {
 
 // CIR-LABEL: cir.func {{.*}} @_Z18while_cond_cleanupi
 // CIR:   cir.while {
-// CIR:     cir.call @_Z5makeSv()
+// CIR:     cir.call @_Z5makeSv({{.*}}) : (!cir.ptr<!rec_S> {{.*}}llvm.sret = !rec_S{{.*}}) -> ()
 // CIR:     cir.cleanup.scope {
 // CIR:       cir.call @_ZN1ScvbEv(
 // CIR:     } cleanup all {
@@ -33,8 +31,8 @@ void while_cond_cleanup(int n) {
 
 // LLVM-LABEL: define dso_local void @_Z18while_cond_cleanupi(i32 %0) {{.*}} personality ptr @__gxx_personality_v0 {
 // LLVM:   %[[TMP:.*]] = alloca %struct.S
-// LLVM:   call %struct.S @_Z5makeSv()
-// LLVM:   invoke i1 @_ZN1ScvbEv(ptr {{.*}} %[[TMP]])
+// LLVM:   call void @_Z5makeSv(ptr {{.*}} sret(%struct.S) {{.*}} %{{.*}})
+// LLVM:   invoke zeroext i1 @_ZN1ScvbEv(ptr {{.*}} %[[TMP]])
 // LLVM:           to label %[[CONT:.*]] unwind label %[[UNWIND:.*]]
 // LLVM: [[CONT]]:
 // LLVM:   call void @_ZN1SD1Ev(ptr {{.*}} %[[TMP]])
@@ -72,7 +70,7 @@ void do_while_cond_cleanup(int n) {
 // CIR:   cir.do {
 // CIR:     cir.yield
 // CIR:   } while {
-// CIR:     cir.call @_Z5makeSv()
+// CIR:     cir.call @_Z5makeSv({{.*}}) : (!cir.ptr<!rec_S> {{.*}}llvm.sret = !rec_S{{.*}}) -> ()
 // CIR:     cir.cleanup.scope {
 // CIR:       cir.call @_ZN1ScvbEv(
 // CIR:     } cleanup all {
@@ -82,8 +80,8 @@ void do_while_cond_cleanup(int n) {
 
 // LLVM-LABEL: define dso_local void @_Z21do_while_cond_cleanupi(i32 %0) {{.*}} personality ptr @__gxx_personality_v0 {
 // LLVM:   %[[TMP:.*]] = alloca %struct.S
-// LLVM:   call %struct.S @_Z5makeSv()
-// LLVM:   invoke i1 @_ZN1ScvbEv(ptr {{.*}} %[[TMP]])
+// LLVM:   call void @_Z5makeSv(ptr {{.*}} sret(%struct.S) {{.*}} %{{.*}})
+// LLVM:   invoke zeroext i1 @_ZN1ScvbEv(ptr {{.*}} %[[TMP]])
 // LLVM:           to label %[[CONT:.*]] unwind label %[[UNWIND:.*]]
 // LLVM: [[CONT]]:
 // LLVM:   call void @_ZN1SD1Ev(ptr {{.*}} %[[TMP]])
@@ -115,7 +113,7 @@ void for_cond_cleanup(int n) {
 
 // CIR-LABEL: cir.func {{.*}} @_Z16for_cond_cleanupi
 // CIR:   cir.for : cond {
-// CIR:     cir.call @_Z5makeSv()
+// CIR:     cir.call @_Z5makeSv({{.*}}) : (!cir.ptr<!rec_S> {{.*}}llvm.sret = !rec_S{{.*}}) -> ()
 // CIR:     cir.cleanup.scope {
 // CIR:       cir.call @_ZN1ScvbEv(
 // CIR:     } cleanup all {
@@ -126,8 +124,8 @@ void for_cond_cleanup(int n) {
 
 // LLVM-LABEL: define dso_local void @_Z16for_cond_cleanupi(i32 %0) {{.*}} personality ptr @__gxx_personality_v0 {
 // LLVM:   %[[TMP:.*]] = alloca %struct.S
-// LLVM:   call %struct.S @_Z5makeSv()
-// LLVM:   invoke i1 @_ZN1ScvbEv(ptr {{.*}} %[[TMP]])
+// LLVM:   call void @_Z5makeSv(ptr {{.*}} sret(%struct.S) {{.*}} %{{.*}})
+// LLVM:   invoke zeroext i1 @_ZN1ScvbEv(ptr {{.*}} %[[TMP]])
 // LLVM:           to label %[[CONT:.*]] unwind label %[[UNWIND:.*]]
 // LLVM: [[CONT]]:
 // LLVM:   call void @_ZN1SD1Ev(ptr {{.*}} %[[TMP]])
@@ -162,7 +160,7 @@ void for_step_cleanup(int n) {
 // CIR:   cir.for : cond {
 // CIR:   } body {
 // CIR:   } step {
-// CIR:     cir.call @_Z5makeSv()
+// CIR:     cir.call @_Z5makeSv({{.*}}) : (!cir.ptr<!rec_S> {{.*}}llvm.sret = !rec_S{{.*}}) -> ()
 // CIR:     cir.cleanup.scope {
 // CIR:     } cleanup all {
 // CIR:       cir.call @_ZN1SD1Ev({{.*}}) nothrow
@@ -171,7 +169,7 @@ void for_step_cleanup(int n) {
 
 // LLVM-LABEL: define dso_local void @_Z16for_step_cleanupi(i32 %0) {{.*}} {
 // LLVM:   %[[TMP:.*]] = alloca %struct.S
-// LLVM:   call %struct.S @_Z5makeSv()
+// LLVM:   call void @_Z5makeSv(ptr {{.*}} sret(%struct.S) {{.*}} %{{.*}})
 // LLVM:   call void @_ZN1SD1Ev(ptr {{.*}} %[[TMP]])
 // LLVM:   br label
 // LLVM:   ret void
@@ -217,8 +215,8 @@ void range_for_cond_cleanup() {
 
 // LLVM-LABEL: define dso_local void @_Z22range_for_cond_cleanupv() {{.*}} personality ptr @__gxx_personality_v0 {
 // LLVM:   %[[TMP:.*]] = alloca %struct.S
-// LLVM:   call %struct.S @_Zne4Iter11EndSentinel(
-// LLVM:   invoke i1 @_ZN1ScvbEv(ptr {{.*}} %[[TMP]])
+// LLVM:   call void @_Zne4Iter11EndSentinel(ptr {{.*}} sret(%struct.S) {{.*}}
+// LLVM:   invoke zeroext i1 @_ZN1ScvbEv(ptr {{.*}} %[[TMP]])
 // LLVM:           to label %[[CONT:.*]] unwind label %[[UNWIND:.*]]
 // LLVM: [[CONT]]:
 // LLVM:   call void @_ZN1SD1Ev(ptr {{.*}} %[[TMP]])

--- a/clang/test/CIR/CodeGen/loop-cond-var-cleanup.cpp
+++ b/clang/test/CIR/CodeGen/loop-cond-var-cleanup.cpp
@@ -1,8 +1,6 @@
-// TODO(cir): drop -fno-clangir-call-conv-lowering once CallConvLowering
-// supports parameters of an empty or tag class.
-// RUN: %clang_cc1 -no-enable-noundef-analysis %s -triple=x86_64-linux-gnu -fclangir -fno-clangir-call-conv-lowering -emit-cir -std=c++17 -fcxx-exceptions -fexceptions -o %t.cir
+// RUN: %clang_cc1 -no-enable-noundef-analysis %s -triple=x86_64-linux-gnu -fclangir -emit-cir -std=c++17 -fcxx-exceptions -fexceptions -o %t.cir
 // RUN: FileCheck -check-prefixes=CIR --input-file=%t.cir %s
-// RUN: %clang_cc1 -no-enable-noundef-analysis %s -triple=x86_64-linux-gnu -fclangir -fno-clangir-call-conv-lowering -emit-llvm -std=c++17 -fcxx-exceptions -fexceptions -o %t-cir.ll
+// RUN: %clang_cc1 -no-enable-noundef-analysis %s -triple=x86_64-linux-gnu -fclangir -emit-llvm -std=c++17 -fcxx-exceptions -fexceptions -o %t-cir.ll
 // RUN: FileCheck -check-prefixes=LLVM --input-file=%t-cir.ll %s
 // RUN: %clang_cc1 -no-enable-noundef-analysis %s -triple=x86_64-linux-gnu -emit-llvm -std=c++17 -fcxx-exceptions -fexceptions -o %t.ll
 // RUN: FileCheck -check-prefixes=OGCG --input-file=%t.ll %s
@@ -58,7 +56,7 @@ void while_cond_var(int n) {
 // LLVM-NEXT:            to label %[[CTOR_CONT:.*]] unwind label %[[LPAD:.*]]
 // LLVM:       [[CTOR_CONT]]:
 // LLVM:         store i8 1, ptr %[[FLAG]]
-// LLVM:         %[[CALL:.*]] = invoke i1 @_ZN1ScvbEv(ptr {{.*}} %[[S]])
+// LLVM:         %[[CALL:.*]] = invoke zeroext i1 @_ZN1ScvbEv(ptr {{.*}} %[[S]])
 // LLVM-NEXT:            to label %[[CVB_CONT:.*]] unwind label %[[LPAD]]
 // LLVM:       [[CVB_CONT]]:
 // LLVM:         br i1 %[[CALL]], label %[[BODY:.*]], label %[[COND_FALSE:.*]]
@@ -174,7 +172,7 @@ void while_cond_var_break() {
 // LLVM-NEXT:            to label %[[CTOR_CONT:.*]] unwind label %[[LPAD:.*]]
 // LLVM:       [[CTOR_CONT]]:
 // LLVM:         store i8 1, ptr %[[FLAG]]
-// LLVM:         %[[CALL:.*]] = invoke i1 @_ZN1ScvbEv(ptr {{.*}} %[[S]])
+// LLVM:         %[[CALL:.*]] = invoke zeroext i1 @_ZN1ScvbEv(ptr {{.*}} %[[S]])
 // LLVM-NEXT:            to label %[[CVB_CONT:.*]] unwind label %[[LPAD]]
 // LLVM:       [[CVB_CONT]]:
 // LLVM:         br i1 %[[CALL]], label %[[BODY:.*]], label %[[COND_FALSE:.*]]
@@ -275,7 +273,7 @@ void while_cond_var_continue() {
 // LLVM-NEXT:            to label %[[CTOR_CONT:.*]] unwind label %[[LPAD:.*]]
 // LLVM:       [[CTOR_CONT]]:
 // LLVM:         store i8 1, ptr %[[FLAG]]
-// LLVM:         %[[CALL:.*]] = invoke i1 @_ZN1ScvbEv(ptr {{.*}} %[[S]])
+// LLVM:         %[[CALL:.*]] = invoke zeroext i1 @_ZN1ScvbEv(ptr {{.*}} %[[S]])
 // LLVM-NEXT:            to label %[[CVB_CONT:.*]] unwind label %[[LPAD]]
 // LLVM:       [[CVB_CONT]]:
 // LLVM:         br i1 %[[CALL]], label %[[BODY:.*]], label %[[COND_FALSE:.*]]
@@ -382,7 +380,7 @@ void for_cond_var_break() {
 // LLVM-NEXT:            to label %[[CTOR_CONT:.*]] unwind label %[[LPAD:.*]]
 // LLVM:       [[CTOR_CONT]]:
 // LLVM:         store i8 1, ptr %[[FLAG]]
-// LLVM:         %[[CALL:.*]] = invoke i1 @_ZN1ScvbEv(ptr {{.*}} %[[S]])
+// LLVM:         %[[CALL:.*]] = invoke zeroext i1 @_ZN1ScvbEv(ptr {{.*}} %[[S]])
 // LLVM-NEXT:            to label %[[CVB_CONT:.*]] unwind label %[[LPAD]]
 // LLVM:       [[CVB_CONT]]:
 // LLVM:         br i1 %[[CALL]], label %[[BODY:.*]], label %[[COND_FALSE:.*]]
@@ -484,7 +482,7 @@ void for_cond_var_continue() {
 // LLVM-NEXT:            to label %[[CTOR_CONT:.*]] unwind label %[[LPAD:.*]]
 // LLVM:       [[CTOR_CONT]]:
 // LLVM:         store i8 1, ptr %[[FLAG]]
-// LLVM:         %[[CALL:.*]] = invoke i1 @_ZN1ScvbEv(ptr {{.*}} %[[S]])
+// LLVM:         %[[CALL:.*]] = invoke zeroext i1 @_ZN1ScvbEv(ptr {{.*}} %[[S]])
 // LLVM-NEXT:            to label %[[CVB_CONT:.*]] unwind label %[[LPAD]]
 // LLVM:       [[CVB_CONT]]:
 // LLVM:         br i1 %[[CALL]], label %[[BODY:.*]], label %[[COND_FALSE:.*]]
@@ -598,7 +596,7 @@ void for_cond_var(int n) {
 // LLVM-NEXT:            to label %[[CTOR_CONT:.*]] unwind label %[[LPAD:.*]]
 // LLVM:       [[CTOR_CONT]]:
 // LLVM:         store i8 1, ptr %[[FLAG]]
-// LLVM:         %[[CALL:.*]] = invoke i1 @_ZN1ScvbEv(ptr {{.*}} %[[S]])
+// LLVM:         %[[CALL:.*]] = invoke zeroext i1 @_ZN1ScvbEv(ptr {{.*}} %[[S]])
 // LLVM-NEXT:            to label %[[CVB_CONT:.*]] unwind label %[[LPAD]]
 // LLVM:       [[CVB_CONT]]:
 // LLVM:         br i1 %[[CALL]], label %[[BODY:.*]], label %[[COND_FALSE:.*]]
@@ -690,9 +688,9 @@ void while_cond_var_temp(int n) {
 // CIR:     cir.while {
 // CIR:       %[[FALSE:.*]] = cir.const #false
 // CIR:       cir.store %[[FALSE]], %[[FLAG]]
-// CIR:       cir.call @_Z5makeSv() : () -> !rec_S
+// CIR:       cir.call @_Z5makeSv(%[[TMP]]) : (!cir.ptr<!rec_S> {{.*}}llvm.sret = !rec_S{{.*}}) -> ()
 // CIR:       cir.cleanup.scope {
-// CIR:         cir.call @_Z6chainSRK1S(%[[TMP]])
+// CIR:         cir.call @_Z6chainSRK1S(%[[S]], %[[TMP]]) : (!cir.ptr<!rec_S> {{.*}}llvm.sret = !rec_S{{.*}}, !cir.ptr<!rec_S> {{.*}}) -> ()
 // CIR:       } cleanup all {
 // CIR:         cir.call @_ZN1SD1Ev(%[[TMP]]) nothrow
 // CIR:         cir.yield
@@ -720,14 +718,12 @@ void while_cond_var_temp(int n) {
 // LLVM:       [[COND]]:
 // LLVM:         br i1 true, label %{{.*}}, label %[[EXIT:.*]]
 // LLVM:         store i8 0, ptr %[[FLAG]], align 1
-// LLVM:         %[[MK:.*]] = invoke %struct.S @_Z5makeSv()
+// LLVM:         invoke void @_Z5makeSv(ptr {{.*}} sret(%struct.S) {{.*}} %[[TMP]])
 // LLVM-NEXT:            to label %[[MK_CONT:.*]] unwind label %[[LPAD_OUTER:.*]]
 // LLVM:       [[MK_CONT]]:
-// LLVM:         store %struct.S %[[MK]], ptr %[[TMP]], align 1
-// LLVM:         %[[CH:.*]] = invoke %struct.S @_Z6chainSRK1S(ptr {{.*}} %[[TMP]])
+// LLVM:         invoke void @_Z6chainSRK1S(ptr {{.*}} sret(%struct.S) {{.*}} %[[S]], ptr {{.*}} %[[TMP]])
 // LLVM-NEXT:            to label %[[CH_CONT:.*]] unwind label %[[LPAD_TMP:.*]]
 // LLVM:       [[CH_CONT]]:
-// LLVM:         store %struct.S %[[CH]], ptr %[[S]], align 1
 // LLVM:         call void @_ZN1SD1Ev(ptr {{.*}} %[[TMP]])
 // LLVM:       [[LPAD_TMP]]:
 // LLVM:         landingpad { ptr, i32 }
@@ -735,7 +731,7 @@ void while_cond_var_temp(int n) {
 // LLVM:         call void @_ZN1SD1Ev(ptr {{.*}} %[[TMP]])
 // LLVM:         br label %[[EHCOMMON:.*]]
 // LLVM:         store i8 1, ptr %[[FLAG]], align 1
-// LLVM:         %[[CALL:.*]] = invoke i1 @_ZN1ScvbEv(ptr {{.*}} %[[S]])
+// LLVM:         %[[CALL:.*]] = invoke zeroext i1 @_ZN1ScvbEv(ptr {{.*}} %[[S]])
 // LLVM-NEXT:            to label %[[CVB_CONT:.*]] unwind label %[[LPAD_OUTER]]
 // LLVM:       [[CVB_CONT]]:
 // LLVM:         br i1 %[[CALL]], label %[[BODY:.*]], label %[[COND_FALSE:.*]]
@@ -888,7 +884,7 @@ void while_cond_var_nested(int n) {
 // LLVM-NEXT:            to label %[[ICTOR_CONT:.*]] unwind label %[[INNER_LPAD:.*]]
 // LLVM:       [[ICTOR_CONT]]:
 // LLVM:         store i8 1, ptr %[[FLAG_INNER]], align 1
-// LLVM:         %[[TCALL:.*]] = invoke i1 @_ZN1ScvbEv(ptr {{.*}} %[[T]])
+// LLVM:         %[[TCALL:.*]] = invoke zeroext i1 @_ZN1ScvbEv(ptr {{.*}} %[[T]])
 // LLVM-NEXT:            to label %[[TCVB_CONT:.*]] unwind label %[[INNER_LPAD]]
 // LLVM:       [[TCVB_CONT]]:
 // LLVM:         br i1 %[[TCALL]], label %[[IBODY:.*]], label %[[ICOND_FALSE:.*]]
@@ -933,7 +929,7 @@ void while_cond_var_nested(int n) {
 // LLVM-NEXT:            to label %[[OCTOR_CONT:.*]] unwind label %[[OUTER_LPAD:.*]]
 // LLVM:       [[OCTOR_CONT]]:
 // LLVM:         store i8 1, ptr %[[FLAG_OUTER]], align 1
-// LLVM:         %[[SCALL:.*]] = invoke i1 @_ZN1ScvbEv(ptr {{.*}} %[[S]])
+// LLVM:         %[[SCALL:.*]] = invoke zeroext i1 @_ZN1ScvbEv(ptr {{.*}} %[[S]])
 // LLVM-NEXT:            to label %[[SCVB_CONT:.*]] unwind label %[[OUTER_LPAD]]
 // LLVM:       [[SCVB_CONT]]:
 // LLVM:         br i1 %[[SCALL]], label %[[OBODY:.*]], label %[[OCOND_FALSE:.*]]

--- a/clang/test/CIR/CodeGen/new-null.cpp
+++ b/clang/test/CIR/CodeGen/new-null.cpp
@@ -1,8 +1,6 @@
-// TODO(cir): drop -fno-clangir-call-conv-lowering once CallConvLowering
-// supports parameters of an empty or tag class.
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fexceptions -fcxx-exceptions -fclangir -fno-clangir-call-conv-lowering -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fexceptions -fcxx-exceptions -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fexceptions -fcxx-exceptions -fclangir -fno-clangir-call-conv-lowering -emit-llvm %s -o %t-cir.ll
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fexceptions -fcxx-exceptions -fclangir -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fexceptions -fcxx-exceptions -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
@@ -149,8 +147,7 @@ U *test_nothrow_new_temp() {
 // CHECK:     cir.store %[[FALSE]], %[[TMP_ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
 // CHECK:     cir.if %[[IS_NOT_NULL]] {
 // CHECK:       cir.cleanup.scope {
-// CHECK:         %[[MAKE_T:.*]] = cir.call @_Z5makeTv() : () -> !rec_T
-// CHECK:         cir.store{{.*}} %[[MAKE_T]], %[[TMP]] : !rec_T, !cir.ptr<!rec_T>
+// CHECK:         cir.call @_Z5makeTv(%[[TMP]]) : (!cir.ptr<!rec_T> {{.*}}llvm.sret = !rec_T{{.*}}) -> ()
 // CHECK:         %[[TRUE:.*]] = cir.const #true
 // CHECK:         cir.store %[[TRUE]], %[[TMP_ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
 // CHECK:         %[[CONV:.*]] = cir.call @_ZN1TcviEv(%[[TMP]])
@@ -176,10 +173,9 @@ U *test_nothrow_new_temp() {
 // LLVM:   store i8 0, ptr %[[TMP_ACTIVE:.*]]
 // LLVM:   br i1 %[[CMP]], label %[[NOT_NULL:.*]], label %[[CONT:.*]]
 // LLVM: [[NOT_NULL]]:
-// LLVM:   %[[MAKE_T:.*]] = invoke %struct.T @_Z5makeTv()
+// LLVM:   invoke void @_Z5makeTv(ptr {{.*}} sret(%struct.T) {{.*}} %[[TMP]])
 // LLVM:           to label %[[INVOKE_CONT:.*]] unwind label %[[LPAD:.*]]
 // LLVM: [[INVOKE_CONT]]:
-// LLVM:   store {{.*}} %[[MAKE_T]], ptr %[[TMP]]
 // LLVM:   store i8 1, ptr %[[TMP_ACTIVE]]
 // LLVM:   invoke {{.*}} @_ZN1TcviEv(ptr {{.*}} %[[TMP]])
 // LLVM:   invoke void @_ZN1UC1Ei(ptr {{.*}} %[[ALLOC]], i32 {{.*}})
@@ -263,13 +259,11 @@ U *test_nothrow_new_nested_temps() {
 // CHECK:     cir.store %[[FALSE2]], %[[OUTER_ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
 // CHECK:     cir.if %[[IS_NOT_NULL]] {
 // CHECK:       cir.cleanup.scope {
-// CHECK:         %[[MAKE_INNER:.*]] = cir.call @_Z10makeInnerTv() : () -> !rec_InnerT
-// CHECK:         cir.store{{.*}} %[[MAKE_INNER]], %[[INNER_TMP]] : !rec_InnerT, !cir.ptr<!rec_InnerT>
+// CHECK:         cir.call @_Z10makeInnerTv(%[[INNER_TMP]]) : (!cir.ptr<!rec_InnerT> {{.*}}llvm.sret = !rec_InnerT{{.*}}) -> ()
 // CHECK:         %[[TRUE:.*]] = cir.const #true
 // CHECK:         cir.store %[[TRUE]], %[[INNER_ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
 // CHECK:         %[[INNER_CONV:.*]] = cir.call @_ZN6InnerTcviEv(%[[INNER_TMP]])
-// CHECK:         %[[MAKE_OUTER:.*]] = cir.call @_Z10makeOuterTi(%[[INNER_CONV]]) : (!s32i {{.*}}) -> !rec_OuterT
-// CHECK:         cir.store{{.*}} %[[MAKE_OUTER]], %[[OUTER_TMP]] : !rec_OuterT, !cir.ptr<!rec_OuterT>
+// CHECK:         cir.call @_Z10makeOuterTi(%[[OUTER_TMP]], %[[INNER_CONV]]) : (!cir.ptr<!rec_OuterT> {{.*}}llvm.sret = !rec_OuterT{{.*}}, !s32i {{.*}}) -> ()
 // CHECK:         %[[TRUE2:.*]] = cir.const #true
 // CHECK:         cir.store %[[TRUE2]], %[[OUTER_ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
 // CHECK:         %[[OUTER_CONV:.*]] = cir.call @_ZN6OuterTcviEv(%[[OUTER_TMP]])
@@ -301,18 +295,16 @@ U *test_nothrow_new_nested_temps() {
 // LLVM:   store i8 0, ptr %[[OUTER_ACTIVE:.*]]
 // LLVM:   br i1 %[[CMP]], label %[[NOT_NULL:.*]], label %[[CONT:.*]]
 // LLVM: [[NOT_NULL]]:
-// LLVM:   %[[MAKE_INNER:.*]] = invoke %struct.InnerT @_Z10makeInnerTv()
+// LLVM:   invoke void @_Z10makeInnerTv(ptr {{.*}} sret(%struct.InnerT) {{.*}} %[[INNER_TMP]])
 // LLVM:           to label %[[INNER_CONT:.*]] unwind label %[[LPAD:.*]]
 // LLVM: [[INNER_CONT]]:
-// LLVM:   store {{.*}} %[[MAKE_INNER]], ptr %[[INNER_TMP]]
 // LLVM:   store i8 1, ptr %[[INNER_ACTIVE]]
 // LLVM:   %[[INNER_CONV:.*]] = invoke {{.*}} @_ZN6InnerTcviEv(ptr {{.*}} %[[INNER_TMP]])
 // LLVM:           to label %[[INNER_CONV_CONT:.*]] unwind label %[[LPAD]]
 // LLVM: [[INNER_CONV_CONT]]:
-// LLVM:   %[[MAKE_OUTER:.*]] = invoke %struct.OuterT @_Z10makeOuterTi(i32 {{.*}} %[[INNER_CONV]])
+// LLVM:   invoke void @_Z10makeOuterTi(ptr {{.*}} sret(%struct.OuterT) {{.*}} %[[OUTER_TMP]], i32 {{.*}} %[[INNER_CONV]])
 // LLVM:           to label %[[OUTER_CONT:.*]] unwind label %[[LPAD]]
 // LLVM: [[OUTER_CONT]]:
-// LLVM:   store {{.*}} %[[MAKE_OUTER]], ptr %[[OUTER_TMP]]
 // LLVM:   store i8 1, ptr %[[OUTER_ACTIVE]]
 // LLVM:   invoke {{.*}} @_ZN6OuterTcviEv(ptr {{.*}} %[[OUTER_TMP]])
 // LLVM:   invoke void @_ZN1UC1Ei(ptr {{.*}} %[[ALLOC]], i32 {{.*}})

--- a/clang/test/CIR/CodeGen/nofpclass.c
+++ b/clang/test/CIR/CodeGen/nofpclass.c
@@ -1,8 +1,6 @@
-// TODO(cir): drop -fno-clangir-call-conv-lowering once CallConvLowering
-// supports _Complex types.
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -menable-no-infs -menable-no-nans -fclangir -fno-clangir-call-conv-lowering -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -menable-no-infs -menable-no-nans -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -menable-no-infs -menable-no-nans -fclangir -fno-clangir-call-conv-lowering -emit-llvm %s -o %t-cir.ll
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -menable-no-infs -menable-no-nans -fclangir -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -menable-no-infs -menable-no-nans -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
@@ -19,7 +17,7 @@ double add(double a, double b) { return a + b; }
 // LLVM: define {{.*}} nofpclass(nan inf) double @add(double noundef nofpclass(nan inf) %{{.*}}, double noundef nofpclass(nan inf) %{{.*}})
 
 _Complex double ret_complex(void) { return 1.0 + 2.0i; }
-// CIR: cir.func {{.*}} @ret_complex() -> (!cir.complex<!cir.double> {llvm.nofpclass = 519 : i64})
+// CIR: cir.func {{.*}} @ret_complex() -> (!rec_anon_struct {llvm.nofpclass = 519 : i64})
 // LLVM: define {{.*}} nofpclass(nan inf) { double, double } @ret_complex()
 
 int non_fp(int x) { return x; }

--- a/clang/test/CIR/CodeGen/nrvo.cpp
+++ b/clang/test/CIR/CodeGen/nrvo.cpp
@@ -1,10 +1,8 @@
-// TODO(cir): drop -fno-clangir-call-conv-lowering once CallConvLowering
-// supports parameters of an empty or tag class.
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-call-conv-lowering -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fno-elide-constructors -fclangir -fno-clangir-call-conv-lowering -emit-cir %s -o %t-noelide.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fno-elide-constructors -fclangir -emit-cir %s -o %t-noelide.cir
 // RUN: FileCheck --input-file=%t-noelide.cir %s --check-prefix=CIR-NOELIDE
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-call-conv-lowering -emit-llvm %s -o %t-cir.ll
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --input-file=%t-cir.ll %s --check-prefix=LLVM
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s --check-prefix=OGCG
@@ -24,26 +22,37 @@ struct S f1() {
   return s;
 }
 
-// CIR:      cir.func{{.*}} @_Z2f1v() -> !rec_S
+
+// CIR:      cir.func{{.*}} @_Z2f1v() -> !u64i
+// CIR-NEXT:   %[[COERCE:.*]] = cir.alloca "coerce" {{.*}} : !cir.ptr<!rec_S>
 // CIR-NEXT:   %[[RETVAL:.*]] = cir.alloca "__retval" {{.*}} init : !cir.ptr<!rec_S>
 // CIR-NEXT:   cir.call @_ZN1SC1Ev(%[[RETVAL]]) : (!cir.ptr<!rec_S> {{.*}}) -> ()
 // CIR-NEXT:   %[[RET:.*]] = cir.load %[[RETVAL]] : !cir.ptr<!rec_S>, !rec_S
-// CIR-NEXT:   cir.return %[[RET]]
+// CIR-NEXT:   cir.store %[[RET]], %[[COERCE]] : !rec_S, !cir.ptr<!rec_S>
+// CIR-NEXT:   %[[SLOT:.*]] = cir.cast bitcast %[[COERCE]] : !cir.ptr<!rec_S> -> !cir.ptr<!u64i>
+// CIR-NEXT:   %[[COERCED:.*]] = cir.load %[[SLOT]] : !cir.ptr<!u64i>, !u64i
+// CIR-NEXT:   cir.return %[[COERCED]]
 
-// CIR-NOELIDE:      cir.func{{.*}} @_Z2f1v() -> !rec_S
+// CIR-NOELIDE:      cir.func{{.*}} @_Z2f1v() -> !u64i
+// CIR-NOELIDE-NEXT:   %[[COERCE:.*]] = cir.alloca "coerce" {{.*}} : !cir.ptr<!rec_S>
 // CIR-NOELIDE-NEXT:   %[[RETVAL:.*]] = cir.alloca "__retval" {{.*}} : !cir.ptr<!rec_S>
 // CIR-NOELIDE-NEXT:   %[[S:.*]] = cir.alloca "s" {{.*}} init : !cir.ptr<!rec_S>
 // CIR-NOELIDE-NEXT:   cir.call @_ZN1SC1Ev(%[[S]]) : (!cir.ptr<!rec_S> {{.*}}) -> ()
 // CIR-NOELIDE-NEXT:   cir.copy %[[S]] align(4) to %[[RETVAL]] align(4) : !cir.ptr<!rec_S>
 // CIR-NOELIDE-NEXT:   %[[RET:.*]] = cir.load %[[RETVAL]] : !cir.ptr<!rec_S>, !rec_S
-// CIR-NOELIDE-NEXT:   cir.return %[[RET]]
+// CIR-NOELIDE-NEXT:   cir.store %[[RET]], %[[COERCE]] : !rec_S, !cir.ptr<!rec_S>
+// CIR-NOELIDE-NEXT:   %[[SLOT:.*]] = cir.cast bitcast %[[COERCE]] : !cir.ptr<!rec_S> -> !cir.ptr<!u64i>
+// CIR-NOELIDE-NEXT:   %[[COERCED:.*]] = cir.load %[[SLOT]] : !cir.ptr<!u64i>, !u64i
+// CIR-NOELIDE-NEXT:   cir.return %[[COERCED]]
 
-// FIXME: Update this when calling convetnion lowering is implemented.
-// LLVM:      define{{.*}} %struct.S @_Z2f1v()
+// LLVM:      define{{.*}} i64 @_Z2f1v()
+// LLVM-NEXT:   %[[COERCE:.*]] = alloca %struct.S
 // LLVM-NEXT:   %[[RETVAL:.*]] = alloca %struct.S
 // LLVM-NEXT:   call void @_ZN1SC1Ev(ptr {{.*}} %[[RETVAL]])
-// LLVM-NEXT:   %[[RET:.*]] = load %struct.S, ptr %[[RETVAL]]
-// LLVM-NEXT:   ret %struct.S %[[RET]]
+// LLVM-NEXT:   %[[TMP:.*]] = load %struct.S, ptr %[[RETVAL]]
+// LLVM-NEXT:   store %struct.S %[[TMP]], ptr %[[COERCE]]
+// LLVM-NEXT:   %[[RET:.*]] = load i64, ptr %[[COERCE]]
+// LLVM-NEXT:   ret i64 %[[RET]]
 
 // OGCG:      define{{.*}} i64 @_Z2f1v()
 // OGCG-NEXT: entry:
@@ -66,8 +75,8 @@ NonTrivial test_nrvo() {
 
 // TODO(cir): Handle normal cleanup properly.
 
-// CIR: cir.func {{.*}} @_Z9test_nrvov()
-// CIR:   %[[RESULT:.*]] = cir.alloca "__retval" {{.*}} : !cir.ptr<!rec_NonTrivial>
+
+// CIR: cir.func {{.*}} @_Z9test_nrvov(%[[RESULT:.*]]: !cir.ptr<!rec_NonTrivial> {{.*}}llvm.sret = !rec_NonTrivial{{.*}})
 // CIR:   %[[NRVO_FLAG:.*]] = cir.alloca "nrvo" {{.*}} : !cir.ptr<!cir.bool>
 // CIR:   %[[FALSE:.*]] = cir.const #false
 // CIR:   cir.store{{.*}} %[[FALSE]], %[[NRVO_FLAG]]
@@ -75,9 +84,8 @@ NonTrivial test_nrvo() {
 // CIR:     cir.call @_Z10maybeThrowv() : () -> ()
 // CIR:     %[[TRUE:.*]] = cir.const #true
 // CIR:     cir.store{{.*}} %[[TRUE]], %[[NRVO_FLAG]]
-// CIR:     %[[RET:.*]] = cir.load %[[RESULT]]
-// CIR:     cir.return %[[RET]]
-// CIR:   } cleanup  normal {
+// CIR:     cir.return
+// CIR:   } cleanup normal {
 // CIR:     %[[NRVO_FLAG_VAL:.*]] = cir.load{{.*}} %[[NRVO_FLAG]]
 // CIR:     %[[NOT_NRVO_VAL:.*]] = cir.not %[[NRVO_FLAG_VAL]]
 // CIR:     cir.if %[[NOT_NRVO_VAL]] {
@@ -90,8 +98,7 @@ NonTrivial test_nrvo() {
 //            artifact of us falling through to emitImplicitReturn().
 // CIR:   cir.trap
 
-// LLVM: define {{.*}} %struct.NonTrivial @_Z9test_nrvov()
-// LLVM:   %[[RESULT:.*]] = alloca %struct.NonTrivial
+// LLVM: define {{.*}} void @_Z9test_nrvov(ptr dead_on_unwind noalias writable sret(%struct.NonTrivial) align 1 %[[RESULT:.*]])
 // LLVM:   %[[NRVO_FLAG:.*]] = alloca i8
 // LLVM:   store i8 0, ptr %[[NRVO_FLAG]]
 // LLVM:   call void @_Z10maybeThrowv()
@@ -104,8 +111,7 @@ NonTrivial test_nrvo() {
 // LLVM:   call void @_ZN10NonTrivialD1Ev(ptr {{.*}} %[[RESULT]])
 // LLVM:   br label %[[NRVO_USED]]
 // LLVM: [[NRVO_USED]]:
-// LLVM:   %[[RET:.*]] = load %struct.NonTrivial, ptr %[[RESULT]]
-// LLVM:   ret %struct.NonTrivial %[[RET]]
+// LLVM:   ret void
 
 // OGCG: define {{.*}} void @_Z9test_nrvov(ptr {{.*}} sret(%struct.NonTrivial) {{.*}} %[[RESULT:.*]])
 // OGCG:   %[[RESULT_ADDR:.*]] = alloca ptr

--- a/clang/test/CIR/CodeGen/pack-indexing.cpp
+++ b/clang/test/CIR/CodeGen/pack-indexing.cpp
@@ -1,8 +1,6 @@
-// TODO(cir): drop -fno-clangir-call-conv-lowering once CallConvLowering
-// supports _Complex types.
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++2c -fclangir -fno-clangir-call-conv-lowering -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++2c -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++2c -fclangir -fno-clangir-call-conv-lowering -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++2c -fclangir -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++2c -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
@@ -65,12 +63,24 @@ float _Complex pack_indexing_complex() {
 // CIR:   %[[TMP_COMPLEX_0:.*]] = cir.load {{.*}} %[[COMPLEX_0]] : !cir.ptr<!cir.complex<!cir.float>>, !cir.complex<!cir.float>
 // CIR:   cir.store {{.*}} %[[CONST_COMPLEX_1]], %[[COMPLEX_1]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 // CIR:   %[[TMP_COMPLEX_1:.*]] = cir.load {{.*}} %[[COMPLEX_1]] : !cir.ptr<!cir.complex<!cir.float>>, !cir.complex<!cir.float>
-// CIR:   %[[RESULT:.*]] = cir.call @_Z13pack_indexingIJCfS0_EEDaDpT_(%[[TMP_COMPLEX_0]], %[[TMP_COMPLEX_1]]) : (!cir.complex<!cir.float> {llvm.noundef}, !cir.complex<!cir.float> {llvm.noundef}) -> (!cir.complex<!cir.float> {llvm.noundef})
-// CIR:   cir.store {{.*}} %[[RESULT]], %[[RET_VAL]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
+// CIR:   cir.store %[[TMP_COMPLEX_0]], %[[A0:.*]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
+// CIR:   %[[A0_PTR:.*]] = cir.cast bitcast %[[A0]] : !cir.ptr<!cir.complex<!cir.float>> -> !cir.ptr<!cir.vector<2 x !cir.float>>
+// CIR:   %[[A0_VEC:.*]] = cir.load %[[A0_PTR]] : !cir.ptr<!cir.vector<2 x !cir.float>>, !cir.vector<2 x !cir.float>
+// CIR:   cir.store %[[TMP_COMPLEX_1]], %[[A1:.*]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
+// CIR:   %[[A1_PTR:.*]] = cir.cast bitcast %[[A1]] : !cir.ptr<!cir.complex<!cir.float>> -> !cir.ptr<!cir.vector<2 x !cir.float>>
+// CIR:   %[[A1_VEC:.*]] = cir.load %[[A1_PTR]] : !cir.ptr<!cir.vector<2 x !cir.float>>, !cir.vector<2 x !cir.float>
+// CIR:   %[[RESULT:.*]] = cir.call @_Z13pack_indexingIJCfS0_EEDaDpT_(%[[A0_VEC]], %[[A1_VEC]]) : (!cir.vector<2 x !cir.float> {llvm.noundef}, !cir.vector<2 x !cir.float> {llvm.noundef}) -> (!cir.vector<2 x !cir.float> {llvm.noundef})
+// CIR:   cir.store %[[RESULT]], %[[R_SLOT:.*]] : !cir.vector<2 x !cir.float>, !cir.ptr<!cir.vector<2 x !cir.float>>
+// CIR:   %[[R_PTR:.*]] = cir.cast bitcast %[[R_SLOT]] : !cir.ptr<!cir.vector<2 x !cir.float>> -> !cir.ptr<!cir.complex<!cir.float>>
+// CIR:   %[[R_CPLX:.*]] = cir.load %[[R_PTR]] : !cir.ptr<!cir.complex<!cir.float>>, !cir.complex<!cir.float>
+// CIR:   cir.store {{.*}} %[[R_CPLX]], %[[RET_VAL]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 // CIR:   %[[TMP_RET:.*]] = cir.load %[[RET_VAL]] : !cir.ptr<!cir.complex<!cir.float>>, !cir.complex<!cir.float>
-// CIR:   cir.return %[[TMP_RET]] : !cir.complex<!cir.float>
+// CIR:   cir.store %[[TMP_RET]], %[[RET_SLOT:.*]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
+// CIR:   %[[RET_PTR:.*]] = cir.cast bitcast %[[RET_SLOT]] : !cir.ptr<!cir.complex<!cir.float>> -> !cir.ptr<!cir.vector<2 x !cir.float>>
+// CIR:   %[[RET_VEC:.*]] = cir.load %[[RET_PTR]] : !cir.ptr<!cir.vector<2 x !cir.float>>, !cir.vector<2 x !cir.float>
+// CIR:   cir.return %[[RET_VEC]] : !cir.vector<2 x !cir.float>
 
-// LLVM: define {{.*}} { float, float } @_Z21pack_indexing_complexv()
+// LLVM: define {{.*}} <2 x float> @_Z21pack_indexing_complexv()
 // LLVM:   %[[RET_VAL:.*]] = alloca { float, float }, align 4
 // LLVM:   %[[COMPLEX_0:.*]] = alloca { float, float }, align 4
 // LLVM:   %[[COMPLEX_1:.*]] = alloca { float, float }, align 4
@@ -78,13 +88,18 @@ float _Complex pack_indexing_complex() {
 // LLVM:   %[[TMP_COMPLEX_0:.*]] = load { float, float }, ptr %[[COMPLEX_0]], align 4
 // LLVM:   store { float, float } { float 3.000000e+00, float 4.000000e+00 }, ptr %[[COMPLEX_1]], align 4
 // LLVM:   %[[TMP_COMPLEX_1:.*]] = load { float, float }, ptr %[[COMPLEX_1]], align 4
-// LLVM:   %[[RESULT:.*]] = call noundef { float, float } @_Z13pack_indexingIJCfS0_EEDaDpT_({ float, float } {{.*}} %[[TMP_COMPLEX_0]], { float, float } {{.*}} %[[TMP_COMPLEX_1]])
-// LLVM:   store { float, float } %[[RESULT]], ptr %[[RET_VAL]], align 4
+// LLVM:   store { float, float } %[[TMP_COMPLEX_0]], ptr %[[A0:.*]], align 4
+// LLVM:   %[[A0_VEC:.*]] = load <2 x float>, ptr %[[A0]], align 8
+// LLVM:   store { float, float } %[[TMP_COMPLEX_1]], ptr %[[A1:.*]], align 4
+// LLVM:   %[[A1_VEC:.*]] = load <2 x float>, ptr %[[A1]], align 8
+// LLVM:   %[[RESULT:.*]] = call noundef <2 x float> @_Z13pack_indexingIJCfS0_EEDaDpT_(<2 x float> noundef %[[A0_VEC]], <2 x float> noundef %[[A1_VEC]])
+// LLVM:   store <2 x float> %[[RESULT]], ptr %[[R_SLOT:.*]], align 8
+// LLVM:   %[[R_CPLX:.*]] = load { float, float }, ptr %[[R_SLOT]], align 4
+// LLVM:   store { float, float } %[[R_CPLX]], ptr %[[RET_VAL]], align 4
 // LLVM:   %[[TMP_RET:.*]] = load { float, float }, ptr %[[RET_VAL]], align 4
-// LLVM:   ret { float, float } %[[TMP_RET]]
-
-// TODO(CIR): the difference between the CIR LLVM and OGCG is because the lack of calling convention lowering,
-// Test will be updated when that is implemented
+// LLVM:   store { float, float } %[[TMP_RET]], ptr %[[RET_SLOT:.*]], align 4
+// LLVM:   %[[RET_VEC:.*]] = load <2 x float>, ptr %[[RET_SLOT]], align 8
+// LLVM:   ret <2 x float> %[[RET_VEC]]
 
 // OGCG: define {{.*}} <2 x float> @_Z21pack_indexing_complexv()
 // OGCG:   %[[RET_VAL:.*]] = alloca { float, float }, align 4

--- a/clang/test/CIR/CodeGen/three-way-cmp.cpp
+++ b/clang/test/CIR/CodeGen/three-way-cmp.cpp
@@ -1,12 +1,10 @@
-// TODO(cir): drop -fno-clangir-call-conv-lowering once CallConvLowering
-// supports parameters of an empty or tag class.
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -fno-clangir-call-conv-lowering -emit-cir -mmlir --mlir-print-ir-before=cir-lowering-prepare %s -o %t.cir 2> %t-before.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -emit-cir -mmlir --mlir-print-ir-before=cir-lowering-prepare %s -o %t.cir 2> %t-before.cir
 // RUN: FileCheck %s --input-file=%t-before.cir --check-prefix=BEFORE,BOTH
-// RUN: FileCheck %s --input-file=%t.cir --check-prefix=AFTER
+// RUN: FileCheck %s --input-file=%t.cir --check-prefix=FINAL
 
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -fno-clangir-call-conv-lowering -emit-cir -mmlir --mlir-print-ir-after=cir-lowering-prepare %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=AFTER,BOTH
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -emit-cir -mmlir --mlir-print-ir-after=cir-lowering-prepare %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=AFTER,BOTH
 
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -fno-clangir-call-conv-lowering -emit-llvm %s -o %t.ll 2>&1
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -emit-llvm %s -o %t.ll 2>&1
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -emit-llvm %s -o %t-og.ll 2>&1
@@ -40,12 +38,32 @@ auto three_way_strong(int x, int y) {
 // AFTER:   %{{.+}} = cir.load %{{.+}} : !cir.ptr<!rec_std3A3A__13A3Astrong_ordering>, !rec_std3A3A__13A3Astrong_ordering{{.*}}
 // AFTER-NEXT:   cir.return %{{.+}} : !rec_std3A3A__13A3Astrong_ordering{{.*}}
 
-// LLVM:  %[[LHS:.*]] = load i32, ptr %{{.*}}, align 4
-// LLVM-NEXT:  %[[RHS:.*]] = load i32, ptr %{{.*}}, align 4
-// LLVM-NEXT:  %[[CMP_LT:.*]] = icmp slt i32 %[[LHS]], %[[RHS]]
-// LLVM-NEXT:  %[[SEL_LT_GT:.*]] = select i1 %[[CMP_LT]], i8 -1, i8 1
-// LLVM-NEXT:  %[[CMP_EQ:.*]] = icmp eq i32 %[[LHS]], %[[RHS]]
-// LLVM-NEXT:  %[[RES:.*]] = select i1 %[[CMP_EQ]], i8 0, i8 %[[SEL_LT_GT]]
+//      FINAL:   cir.func {{.*}} @_Z16three_way_strongii{{.*}} -> !s8i
+//      FINAL:   %[[RETVAL:.*]] = cir.load %{{.+}} : !cir.ptr<!rec_std3A3A__13A3Astrong_ordering>, !rec_std3A3A__13A3Astrong_ordering
+// FINAL-NEXT:   cir.store %[[RETVAL]], %[[COERCE:.*]] : !rec_std3A3A__13A3Astrong_ordering, !cir.ptr<!rec_std3A3A__13A3Astrong_ordering>
+// FINAL-NEXT:   %[[COERCE_PTR:.*]] = cir.cast bitcast %[[COERCE]] : !cir.ptr<!rec_std3A3A__13A3Astrong_ordering> -> !cir.ptr<!s8i>
+// FINAL-NEXT:   %[[COERCED:.*]] = cir.load %[[COERCE_PTR]] : !cir.ptr<!s8i>, !s8i
+// FINAL-NEXT:   cir.return %[[COERCED]] : !s8i
+
+// LLVM: define dso_local i8 @_Z16three_way_strongii(i32 noundef %[[X:.*]], i32 noundef %[[Y:.*]])
+// LLVM:   %[[COERCE:.*]] = alloca %"class.std::__1::strong_ordering", align 1
+// LLVM:   %[[X_ADDR:.*]] = alloca i32, align 4
+// LLVM:   %[[Y_ADDR:.*]] = alloca i32, align 4
+// LLVM:   %[[RETVAL:.*]] = alloca %"class.std::__1::strong_ordering", align 1
+// LLVM:   store i32 %[[X]], ptr %[[X_ADDR]], align 4
+// LLVM-NEXT:   store i32 %[[Y]], ptr %[[Y_ADDR]], align 4
+// LLVM-NEXT:   %[[LHS:.*]] = load i32, ptr %[[X_ADDR]], align 4
+// LLVM-NEXT:   %[[RHS:.*]] = load i32, ptr %[[Y_ADDR]], align 4
+// LLVM-NEXT:   %[[CMP_LT:.*]] = icmp slt i32 %[[LHS]], %[[RHS]]
+// LLVM-NEXT:   %[[SEL_LT_GT:.*]] = select i1 %[[CMP_LT]], i8 -1, i8 1
+// LLVM-NEXT:   %[[CMP_EQ:.*]] = icmp eq i32 %[[LHS]], %[[RHS]]
+// LLVM-NEXT:   %[[RES:.*]] = select i1 %[[CMP_EQ]], i8 0, i8 %[[SEL_LT_GT]]
+// LLVM-NEXT:   %[[VALUE_GEP:.*]] = getelementptr inbounds nuw %"class.std::__1::strong_ordering", ptr %[[RETVAL]], i32 0, i32 0
+// LLVM-NEXT:   store i8 %[[RES]], ptr %[[VALUE_GEP]], align 1
+// LLVM-NEXT:   %[[RETVAL_LOAD:.*]] = load %"class.std::__1::strong_ordering", ptr %[[RETVAL]], align 1
+// LLVM-NEXT:   store %"class.std::__1::strong_ordering" %[[RETVAL_LOAD]], ptr %[[COERCE]], align 1
+// LLVM-NEXT:   %[[COERCED:.*]] = load i8, ptr %[[COERCE]], align 1
+// LLVM-NEXT:   ret i8 %[[COERCED]]
 
 // OGCG:  %[[LHS:.*]] = load i32, ptr %{{.*}}, align 4
 // OGCG-NEXT:  %[[RHS:.*]] = load i32, ptr %{{.*}}, align 4
@@ -78,14 +96,34 @@ auto three_way_partial(float x, float y) {
 // AFTER:   %{{.+}} = cir.load %{{.+}} : !cir.ptr<!rec_std3A3A__13A3Apartial_ordering>, !rec_std3A3A__13A3Apartial_ordering{{.*}}
 // AFTER-NEXT:   cir.return %{{.+}} : !rec_std3A3A__13A3Apartial_ordering{{.*}}
 
-// LLVM:  %[[LHS:.*]] = load float, ptr %{{.*}}, align 4
-// LLVM:  %[[RHS:.*]] = load float, ptr %{{.*}}, align 4
-// LLVM:  %[[CMP_EQ:.*]] = fcmp oeq float %[[LHS]], %[[RHS]]
-// LLVM:  %[[SEL_EQ_UN:.*]] = select i1 %[[CMP_EQ]], i8 0, i8 -127
-// LLVM:  %[[CMP_GT:.*]] = fcmp ogt float %[[LHS]], %[[RHS]]
-// LLVM:  %[[SEL_GT_EQUN:.*]] = select i1 %[[CMP_GT]], i8 1, i8 %[[SEL_EQ_UN]]
-// LLVM:  %[[CMP_LT:.*]] = fcmp olt float %[[LHS]], %[[RHS]]
-// LLVM:  %[[RES:.*]] = select i1 %[[CMP_LT]], i8 -1, i8 %[[SEL_GT_EQUN]]
+//      FINAL:   cir.func {{.*}} @_Z17three_way_partialff{{.*}} -> !s8i
+//      FINAL:   %[[RETVAL:.*]] = cir.load %{{.+}} : !cir.ptr<!rec_std3A3A__13A3Apartial_ordering>, !rec_std3A3A__13A3Apartial_ordering
+// FINAL-NEXT:   cir.store %[[RETVAL]], %[[COERCE:.*]] : !rec_std3A3A__13A3Apartial_ordering, !cir.ptr<!rec_std3A3A__13A3Apartial_ordering>
+// FINAL-NEXT:   %[[COERCE_PTR:.*]] = cir.cast bitcast %[[COERCE]] : !cir.ptr<!rec_std3A3A__13A3Apartial_ordering> -> !cir.ptr<!s8i>
+// FINAL-NEXT:   %[[COERCED:.*]] = cir.load %[[COERCE_PTR]] : !cir.ptr<!s8i>, !s8i
+// FINAL-NEXT:   cir.return %[[COERCED]] : !s8i
+
+// LLVM: define dso_local i8 @_Z17three_way_partialff(float noundef %[[X:.*]], float noundef %[[Y:.*]])
+// LLVM:   %[[COERCE:.*]] = alloca %"class.std::__1::partial_ordering", align 1
+// LLVM:   %[[X_ADDR:.*]] = alloca float, align 4
+// LLVM:   %[[Y_ADDR:.*]] = alloca float, align 4
+// LLVM:   %[[RETVAL:.*]] = alloca %"class.std::__1::partial_ordering", align 1
+// LLVM:   store float %[[X]], ptr %[[X_ADDR]], align 4
+// LLVM-NEXT:   store float %[[Y]], ptr %[[Y_ADDR]], align 4
+// LLVM-NEXT:   %[[LHS:.*]] = load float, ptr %[[X_ADDR]], align 4
+// LLVM-NEXT:   %[[RHS:.*]] = load float, ptr %[[Y_ADDR]], align 4
+// LLVM-NEXT:   %[[CMP_EQ:.*]] = fcmp oeq float %[[LHS]], %[[RHS]]
+// LLVM-NEXT:   %[[SEL_EQ_UN:.*]] = select i1 %[[CMP_EQ]], i8 0, i8 -127
+// LLVM-NEXT:   %[[CMP_GT:.*]] = fcmp ogt float %[[LHS]], %[[RHS]]
+// LLVM-NEXT:   %[[SEL_GT_EQUN:.*]] = select i1 %[[CMP_GT]], i8 1, i8 %[[SEL_EQ_UN]]
+// LLVM-NEXT:   %[[CMP_LT:.*]] = fcmp olt float %[[LHS]], %[[RHS]]
+// LLVM-NEXT:   %[[RES:.*]] = select i1 %[[CMP_LT]], i8 -1, i8 %[[SEL_GT_EQUN]]
+// LLVM-NEXT:   %[[VALUE_GEP:.*]] = getelementptr inbounds nuw %"class.std::__1::partial_ordering", ptr %[[RETVAL]], i32 0, i32 0
+// LLVM-NEXT:   store i8 %[[RES]], ptr %[[VALUE_GEP]], align 1
+// LLVM-NEXT:   %[[RETVAL_LOAD:.*]] = load %"class.std::__1::partial_ordering", ptr %[[RETVAL]], align 1
+// LLVM-NEXT:   store %"class.std::__1::partial_ordering" %[[RETVAL_LOAD]], ptr %[[COERCE]], align 1
+// LLVM-NEXT:   %[[COERCED:.*]] = load i8, ptr %[[COERCE]], align 1
+// LLVM-NEXT:   ret i8 %[[COERCED]]
 
 // OGCG:  %[[LHS:.*]] = load float, ptr %{{.*}}, align 4
 // OGCG:  %[[RHS:.*]] = load float, ptr %{{.*}}, align 4
@@ -156,32 +194,43 @@ void use_pseudo_ordering(HasMember m1, HasMember m2) {
   // BOTH: %[[RET_LOAD:.*]] = cir.load %[[RET_ALLOCA]] : !cir.ptr<!rec_std3A3A__13A3Astrong_ordering>, !rec_std3A3A__13A3Astrong_ordering
   // BOTH: cir.return %[[RET_LOAD]] : !rec_std3A3A__13A3Astrong_ordering
   std::strong_ordering g = (m1 <=> m2);
-  // LLVM: define {{.*}}void @_Z19use_pseudo_ordering9HasMemberS_(%struct.HasMember %{{.*}}, %struct.HasMember %{{.*}}) #0 {
+
+  // LLVM: define {{.*}}void @_Z19use_pseudo_ordering9HasMemberS_() #0 {
+  // LLVM:   %[[RETVAL:.*]] = alloca i8, align 1
   // LLVM:   %[[M1_ALLOCA:.*]] = alloca %struct.HasMember
   // LLVM:   %[[M2_ALLOCA:.*]] = alloca %struct.HasMember
   // LLVM:   %[[G_ALLOCA:.*]] = alloca %"class.std::__1::strong_ordering"
-  // LLVM:   %[[CALL_RES:.*]] = call %"class.std::__1::strong_ordering" @_ZNK9HasMemberssERKS_(ptr {{.*}}%[[M1_ALLOCA]], ptr {{.*}}%[[M2_ALLOCA]])
-  // LLVM:   store %"class.std::__1::strong_ordering" %[[CALL_RES]], ptr %[[G_ALLOCA]]
+  // LLVM:   store %struct.HasMember poison, ptr %[[M1_ALLOCA]]
+  // LLVM:   store %struct.HasMember poison, ptr %[[M2_ALLOCA]]
+  // LLVM:   %[[CALL_RES:.*]] = call i8 @_ZNK9HasMemberssERKS_(ptr {{.*}}%[[M1_ALLOCA]], ptr {{.*}}%[[M2_ALLOCA]])
+  // LLVM:   store i8 %[[CALL_RES]], ptr %[[RETVAL]]
+  // LLVM:   %[[RETVAL_LOAD:.*]] = load %"class.std::__1::strong_ordering", ptr %[[RETVAL]]
+  // LLVM:   store %"class.std::__1::strong_ordering" %[[RETVAL_LOAD]], ptr %[[G_ALLOCA]]
   // LLVM:   ret void
   // LLVM: }
 
-  // LLVM: define {{.*}} @_ZNK9HasMemberssERKS_(ptr {{.*}}, ptr {{.*}})
-  // LLVM:   %[[TMP_SO:.*]] = alloca %"class.std::__1::strong_ordering"
-  // LLVM:   %[[RET_ALLOCA:.*]] = alloca %"class.std::__1::strong_ordering"
+  // LLVM: define {{.*}} i8 @_ZNK9HasMemberssERKS_(ptr {{.*}}, ptr {{.*}})
+  // LLVM:   %[[CMP_COPY:.*]] = alloca %"class.std::__1::strong_ordering"
+  // LLVM:   %[[CMP_TEMP:.*]] = alloca %"class.std::__1::strong_ordering"
+  // LLVM:   %[[VALUE_SLOT:.*]] = alloca %"class.std::__1::strong_ordering"
+  // LLVM:   %[[RET_SLOT_FALSE:.*]] = alloca %"class.std::__1::strong_ordering"
+  // LLVM:   %[[RET_SLOT_TRUE:.*]] = alloca %"class.std::__1::strong_ordering"
   // LLVM:   %[[LHS_ALLOCA:.*]] = alloca ptr
   // LLVM:   %[[RHS_ALLOCA:.*]] = alloca ptr
-  // LLVM:   %[[TMP_SO2:.*]] = alloca %"class.std::__1::strong_ordering"
+  // LLVM:   %[[RESULT_SLOT:.*]] = alloca %"class.std::__1::strong_ordering"
   // LLVM:   %[[LHS_LOAD:.*]] = load ptr, ptr %[[LHS_ALLOCA]]
+  // LLVM:   br label %[[ENTRY_CONT:.*]]
   //
+  // LLVM: [[ENTRY_CONT]]:
   // LLVM:   %[[RHS_LOAD:.*]] = load ptr, ptr %[[RHS_ALLOCA]]
-  // LLVM:   %[[EQ_RES:.*]] = call noundef i1 @_ZNK6MembereqERKS_(ptr {{.*}}%[[LHS_LOAD]], ptr {{.*}}%[[RHS_LOAD]])
+  // LLVM:   %[[EQ_RES:.*]] = call noundef zeroext i1 @_ZNK6MembereqERKS_(ptr {{.*}}%[[LHS_LOAD]], ptr {{.*}}%[[RHS_LOAD]])
   // LLVM:   br i1 %[[EQ_RES]], label %[[EQ_TRUE:.*]], label %[[EQ_FALSE:.*]]
   //
   // LLVM: [[EQ_TRUE]]:
-  // LLVM:   br label %20
+  // LLVM:   br label %[[AFTER_CMPS:.*]]
   //
   // LLVM: [[EQ_FALSE]]:
-  // LLVM:   %[[LT_RES:.*]] = call noundef i1 @_ZNK6MemberltERKS_(ptr {{.*}}%[[LHS_LOAD]], ptr {{.*}}%[[RHS_LOAD]])
+  // LLVM:   %[[LT_RES:.*]] = call noundef zeroext i1 @_ZNK6MemberltERKS_(ptr {{.*}}%[[LHS_LOAD]], ptr {{.*}}%[[RHS_LOAD]])
   // LLVM:   br i1 %[[LT_RES]], label %[[LT_TRUE:.*]], label %[[LT_FALSE:.*]]
   //
   // LLVM: [[LT_TRUE]]:
@@ -192,34 +241,40 @@ void use_pseudo_ordering(HasMember m1, HasMember m2) {
   //
   // LLVM: [[AFTER_LT]]:
   // LLVM:   %[[LT_RES_PHI:.*]] = phi ptr [ @_ZNSt3__115strong_ordering7greaterE, %[[LT_FALSE]] ], [ @_ZNSt3__115strong_ordering4lessE, %[[LT_TRUE]] ]
-  // LLVM:   br label %[[AFTER_LT_CTD:.*]]
+  // LLVM:   br label %[[LT_CONT:.*]]
   //
-  // LLVM: [[AFTER_LT_CTD]]:
-  // LLVM:   br label %[[AFTER_CMPS:.*]]
+  // LLVM: [[LT_CONT]]:
+  // LLVM:   br label %[[AFTER_CMPS]]
   //
   // LLVM: [[AFTER_CMPS]]:
-  // LLVM:   %[[CMP_RES:.*]] = phi ptr [ %[[LT_RES_PHI]], %[[AFTER_LT_CTD]] ], [ @_ZNSt3__115strong_ordering5equalE, %[[EQ_TRUE]] ]
-  // LLVM:   br label %[[AFTER_CMPS_CTD:.*]]
+  // LLVM:   %[[CMP_RES:.*]] = phi ptr [ %[[LT_RES_PHI]], %[[LT_CONT]] ], [ @_ZNSt3__115strong_ordering5equalE, %[[EQ_TRUE]] ]
+  // LLVM:   br label %[[COPY_BLOCK:.*]]
   //
-  // LLVM: [[AFTER_CMPS_CTD]]:
-  // LLVM:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %[[TMP_SO]], ptr align 1 %[[CMP_RES]], i64 1, i1 false)
-  // LLVM:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %[[RET_ALLOCA]], ptr align 1 %[[TMP_SO]], i64 1, i1 false)
-  // LLVM:   %[[RET_LOAD:.*]] = load %"class.std::__1::strong_ordering", ptr %[[RET_ALLOCA]]
-  // LLVM:   %[[SO_NE_RES:.*]] = call noundef i1 @_ZNSt3__1neENS_15strong_orderingEMNS_19_CmpUnspecifiedTypeEFvvE(%"class.std::__1::strong_ordering" %[[RET_LOAD]],
+  // LLVM: [[COPY_BLOCK]]:
+  // LLVM:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %[[CMP_COPY]], ptr align 1 %[[CMP_RES]], i64 1, i1 false)
+  // LLVM:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %[[CMP_TEMP]], ptr align 1 %[[CMP_COPY]], i64 1, i1 false)
+  // LLVM:   %[[CMP_TEMP_LOAD:.*]] = load %"class.std::__1::strong_ordering", ptr %[[CMP_TEMP]]
+  // LLVM:   store %"class.std::__1::strong_ordering" %[[CMP_TEMP_LOAD]], ptr %[[VALUE_SLOT]]
+  // LLVM:   %[[CMP_I8:.*]] = load i8, ptr %[[VALUE_SLOT]]
+  // LLVM:   %[[SO_NE_RES:.*]] = call noundef zeroext i1 @_ZNSt3__1neENS_15strong_orderingEMNS_19_CmpUnspecifiedTypeEFvvE(i8 %[[CMP_I8]], i64 0, i64 0)
   // LLVM:   br i1 %[[SO_NE_RES]], label %[[SO_NE_RES_TRUE:.*]], label %[[SO_NE_RES_FALSE:.*]]
   //
   // LLVM: [[SO_NE_RES_TRUE]]:
-  // LLVM:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %[[TMP_SO2]], ptr align 1 %[[TMP_SO]], i64 1, i1 false)
-  // LLVM:   %[[TMP_SO2_LOAD:.*]] = load %"class.std::__1::strong_ordering", ptr %[[TMP_SO2]]
-  // LLVM:   ret %"class.std::__1::strong_ordering" %[[TMP_SO2_LOAD]]
+  // LLVM:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %[[RESULT_SLOT]], ptr align 1 %[[CMP_COPY]], i64 1, i1 false)
+  // LLVM:   %[[RESULT_TRUE:.*]] = load %"class.std::__1::strong_ordering", ptr %[[RESULT_SLOT]]
+  // LLVM:   store %"class.std::__1::strong_ordering" %[[RESULT_TRUE]], ptr %[[RET_SLOT_TRUE]]
+  // LLVM:   %[[RES_TRUE:.*]] = load i8, ptr %[[RET_SLOT_TRUE]]
+  // LLVM:   ret i8 %[[RES_TRUE]]
   //
   // LLVM: [[SO_NE_RES_FALSE]]:
   // LLVM:   br label %[[SO_NE_RES_FALSE_CTD:.*]]
   //
   // LLVM: [[SO_NE_RES_FALSE_CTD]]:
-  // LLVM:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %[[TMP_SO2]], ptr align 1 @_ZNSt3__115strong_ordering5equalE, i64 1, i1 false)
-  // LLVM:   %[[TMP_SO2_LOAD:.*]] = load %"class.std::__1::strong_ordering", ptr %[[TMP_SO2]]
-  // LLVM:   ret %"class.std::__1::strong_ordering" %[[TMP_SO2_LOAD]]
+  // LLVM:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %[[RESULT_SLOT]], ptr align 1 @_ZNSt3__115strong_ordering5equalE, i64 1, i1 false)
+  // LLVM:   %[[RESULT_FALSE:.*]] = load %"class.std::__1::strong_ordering", ptr %[[RESULT_SLOT]]
+  // LLVM:   store %"class.std::__1::strong_ordering" %[[RESULT_FALSE]], ptr %[[RET_SLOT_FALSE]]
+  // LLVM:   %[[RES_FALSE:.*]] = load i8, ptr %[[RET_SLOT_FALSE]]
+  // LLVM:   ret i8 %[[RES_FALSE]]
   // LLVM: }
 
   // OGCG: define {{.*}}void @_Z19use_pseudo_ordering9HasMemberS_()

--- a/clang/test/CIR/CodeGen/var-arg-aggregate.c
+++ b/clang/test/CIR/CodeGen/var-arg-aggregate.c
@@ -1,8 +1,6 @@
-// TODO(cir): drop -fno-clangir-call-conv-lowering once CallConvLowering
-// supports padded, packed, and over-aligned record shapes.
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -fno-clangir-call-conv-lowering -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -fno-clangir-call-conv-lowering -emit-llvm %s -o %t-cir.ll
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -Wno-unused-value -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
@@ -21,7 +19,10 @@ struct Bar varargs_aggregate(int count, ...) {
   return res;
 }
 
+
 // CIR-LABEL: cir.func {{.*}} @varargs_aggregate(
+// CIR-SAME: -> !rec_anon_struct
+// CIR:   %[[COERCE:.+]] = cir.alloca "coerce" {{.*}} : !cir.ptr<!rec_anon_struct>
 // CIR:   %[[RET_ADDR:.+]] = cir.alloca "__retval" {{.*}} init : !cir.ptr<!rec_Bar>
 // CIR:   %[[VAAREA:.+]] = cir.alloca "args" {{.*}} : !cir.ptr<!cir.array<!rec___va_list_tag x 1>>
 // CIR:   %[[TMP_ADDR:.+]] = cir.alloca "vaarg.tmp" {{.*}} : !cir.ptr<!rec_Bar>
@@ -34,9 +35,12 @@ struct Bar varargs_aggregate(int count, ...) {
 // CIR:   %[[VA_PTR2:.+]] = cir.cast array_to_ptrdecay %[[VAAREA]] : !cir.ptr<!cir.array<!rec___va_list_tag x 1>> -> !cir.ptr<!rec___va_list_tag>
 // CIR:   cir.va_end %[[VA_PTR2]] : !cir.ptr<!rec___va_list_tag>
 // CIR:   %[[RETVAL:.+]] = cir.load{{.*}} %[[RET_ADDR]] : !cir.ptr<!rec_Bar>, !rec_Bar
-// CIR:   cir.return %[[RETVAL]] : !rec_Bar
+// CIR:   %[[SLOT:.+]] = cir.cast bitcast %[[COERCE]] : !cir.ptr<!rec_anon_struct> -> !cir.ptr<!rec_Bar>
+// CIR:   cir.store %[[RETVAL]], %[[SLOT]] : !rec_Bar, !cir.ptr<!rec_Bar>
+// CIR:   %[[COERCED:.+]] = cir.load %[[COERCE]] : !cir.ptr<!rec_anon_struct>, !rec_anon_struct
+// CIR:   cir.return %[[COERCED]] : !rec_anon_struct
 
-// LLVM-LABEL: define dso_local %struct.Bar @varargs_aggregate(
+// LLVM-LABEL: define dso_local { <2 x float>, i32 } @varargs_aggregate(i32 noundef %{{.*}}, ...)
 // LLVM:   call void @llvm.va_start.p0(ptr %{{.*}})
 // LLVM:   %[[VA_PTR1:.+]] = getelementptr %struct.__va_list_tag, ptr %{{.*}}, i32 0
 // LLVM:   %[[VA_ARG:.+]] = va_arg ptr %[[VA_PTR1]], %struct.Bar

--- a/clang/test/CIR/CodeGenSYCL/kernel-call-stmt.cpp
+++ b/clang/test/CIR/CodeGenSYCL/kernel-call-stmt.cpp
@@ -1,11 +1,9 @@
-// TODO(cir): drop -fno-clangir-call-conv-lowering once CallConvLowering
-// supports parameters of an empty or tag class.
-// RUN: %clang_cc1 -std=c++20 -fsycl-is-host -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-call-conv-lowering -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -std=c++20 -fsycl-is-host -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
-// RUN: %clang_cc1 -std=c++20 -fsycl-is-host -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-call-conv-lowering -emit-llvm %s -o %t-cir.ll
+// RUN: %clang_cc1 -std=c++20 -fsycl-is-host -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
 // RUN: %clang_cc1 -std=c++20 -fsycl-is-host -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
 // Verify that, during host compilation, the body of a function declared with
 // the sycl_kernel_entry_point attribute is lowered to its kernel launch
@@ -41,7 +39,3 @@ void test() { kernel_single_task<KN>(K{}); }
 // LLVM:         call void @_Z18sycl_kernel_launchI2KNJ1KEEvPKcDpT0_
 // LLVM:         ret void
 
-// OGCG-LABEL: define {{.*}}void @_Z18kernel_single_taskI2KN1KEvT0_
-// OGCG-NOT:     call {{.*}}@_ZNK1KclEv
-// OGCG:         call void @_Z18sycl_kernel_launchI2KNJ1KEEvPKcDpT0_
-// OGCG:         ret void


### PR DESCRIPTION
After #214742 (empty class) and #215117 (`_Complex` and other float formats), seventeen tests carried `-fno-clangir-call-conv-lowering` even though the pass refuses nothing in them.  They compile clean with the flag gone.  Their CHECK lines still described the un-lowered signature, so they failed on the coercion rather than on a missing feature.

Update the expectations and drop the opt-out.

Assisted by: Cursor / claude-opus-5
