### PR TITLE
[NFC][DirectX] Fix GCC 7 build failure caused by a6d7b2f5a931

### DIFF
--- a/llvm/include/llvm/Analysis/DXILResource.h
+++ b/llvm/include/llvm/Analysis/DXILResource.h
@@ -377,6 +377,12 @@ public:
     uint32_t LowerBound;
     uint32_t Size;
 
+    ResourceBinding() : BindingID(0), Space(0), LowerBound(0), Size(0) {}
+    ResourceBinding(uint32_t BindingID, uint32_t Space, uint32_t LowerBound,
+                    uint32_t Size)
+        : BindingID(BindingID), Space(Space), LowerBound(LowerBound),
+          Size(Size) {}
+
     bool operator==(const ResourceBinding &RHS) const {
       return std::tie(BindingID, Space, LowerBound, Size) ==
              std::tie(RHS.BindingID, RHS.Space, RHS.LowerBound, RHS.Size);


### PR DESCRIPTION
GCC 7 cannot determine default-constructibility of ResourceBinding
when it has a default member initializer and is used inside
std::variant. Add explicit default and parameterized constructors.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
