### PR TITLE
[SPARC][IAS] Adjust bounds check in %rX name parsing

### DIFF
--- a/llvm/lib/Target/Sparc/AsmParser/SparcAsmParser.cpp
+++ b/llvm/lib/Target/Sparc/AsmParser/SparcAsmParser.cpp
@@ -1615,7 +1615,7 @@ MCRegister SparcAsmParser::matchRegisterName(const AsmToken &Tok,
   // %r0 - %r31
   int64_t RegNo = 0;
   if (Name.starts_with_insensitive("r") &&
-      !Name.substr(1, 2).getAsInteger(10, RegNo) && RegNo < 31) {
+      !Name.substr(1, 2).getAsInteger(10, RegNo) && RegNo <= 31) {
     RegKind = SparcOperand::rk_IntReg;
     return IntRegs[RegNo];
   }

--- a/llvm/test/MC/Sparc/sparc-alu-instructions.s
+++ b/llvm/test/MC/Sparc/sparc-alu-instructions.s
@@ -9,9 +9,12 @@
         add %r8, %r9, %l0
         ! CHECK: add %o0, 10,  %l0    ! encoding: [0xa0,0x02,0x20,0x0a]
         add %o0, 10, %l0
+        ! CHECK: add %g0, %o7, %i7    ! encoding: [0xbe,0x00,0x00,0x0f]
+        add %r0, %r15, %r31
 
         ! CHECK: addcc %g1, %g2, %g3  ! encoding: [0x86,0x80,0x40,0x02]
         addcc %g1, %g2, %g3
+
 
         ! CHECK: addxcc %g1, %g2, %g3 ! encoding: [0x86,0xc0,0x40,0x02]
         addxcc %g1, %g2, %g3

--- a/llvm/test/MC/Sparc/sparc-alu-instructions.s
+++ b/llvm/test/MC/Sparc/sparc-alu-instructions.s
@@ -15,7 +15,6 @@
         ! CHECK: addcc %g1, %g2, %g3  ! encoding: [0x86,0x80,0x40,0x02]
         addcc %g1, %g2, %g3
 
-
         ! CHECK: addxcc %g1, %g2, %g3 ! encoding: [0x86,0xc0,0x40,0x02]
         addxcc %g1, %g2, %g3
 


### PR DESCRIPTION
Fix an off-by-one error that results in %r31 being incorrectly rejected.

This was reported by the folks at OpenBSD.