### PR TITLE
[Clang][RISCV] Add assumptions for vsetvli and vsetvlimax results

### DIFF
--- a/clang/lib/CodeGen/TargetBuiltins/RISCV.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/RISCV.cpp
@@ -305,7 +305,55 @@ emitRVVVsetvliBuiltin(CodeGenFunction *CGF, const CallExpr *E,
   auto &Builder = CGF->Builder;
   auto &CGM = CGF->CGM;
   llvm::Function *F = CGM.getIntrinsic(ID, {ResultType});
-  return Builder.CreateCall(F, Ops, "");
+  llvm::Value *VSetVL = Builder.CreateCall(F, Ops, "vl");
+
+  bool HasAVL = ID == llvm::Intrinsic::riscv_vsetvli;
+  assert((HasAVL || ID == llvm::Intrinsic::riscv_vsetvlimax) &&
+         "Unexpected vsetvl intrinsic");
+
+  unsigned SEW = llvm::RISCVVType::decodeVSEW(
+      cast<ConstantInt>(Ops[HasAVL])->getZExtValue());
+  auto VLMUL = static_cast<llvm::RISCVVType::VLMUL>(
+      cast<ConstantInt>(Ops[HasAVL + 1])->getZExtValue());
+  unsigned Ratio = llvm::RISCVVType::getSEWLMULRatio(SEW, VLMUL);
+
+  Attribute VScaleRange =
+      CGF->CurFn->getFnAttribute(llvm::Attribute::VScaleRange);
+  if (!VScaleRange.isValid())
+    return VSetVL;
+
+  uint64_t MinVLMAX = uint64_t(VScaleRange.getVScaleRangeMin()) *
+                      llvm::RISCV::RVVBitsPerBlock / Ratio;
+  std::optional<unsigned> MaxVScale = VScaleRange.getVScaleRangeMax();
+
+  if (!HasAVL) {
+    Value *Assumption;
+    if (MaxVScale && *MaxVScale == VScaleRange.getVScaleRangeMin())
+      Assumption = Builder.CreateICmpEQ(
+          VSetVL, llvm::ConstantInt::get(ResultType, MinVLMAX));
+    else
+      Assumption = Builder.CreateICmpUGE(
+          VSetVL, llvm::ConstantInt::get(ResultType, MinVLMAX));
+    Builder.CreateAssumption(Assumption);
+    return VSetVL;
+  }
+
+  Value *AVLAboveMinVLMAX = Builder.CreateICmpUGT(
+      Ops[0], llvm::ConstantInt::get(ResultType, MinVLMAX));
+  Value *VLEqualsAVL = Builder.CreateICmpEQ(VSetVL, Ops[0]);
+  Builder.CreateAssumption(
+      Builder.CreateSelect(AVLAboveMinVLMAX, Builder.getTrue(), VLEqualsAVL));
+
+  if (MaxVScale && *MaxVScale == VScaleRange.getVScaleRangeMin()) {
+    uint64_t FixedVLMAX = MinVLMAX;
+    Value *AVLBelowTwiceVLMAX = Builder.CreateICmpULT(
+        Ops[0], llvm::ConstantInt::get(ResultType, FixedVLMAX * 2));
+    Value *VLEqualsVLMAX = Builder.CreateICmpEQ(
+        VSetVL, llvm::ConstantInt::get(ResultType, FixedVLMAX));
+    Builder.CreateAssumption(Builder.CreateSelect(
+        AVLBelowTwiceVLMAX, Builder.getTrue(), VLEqualsVLMAX));
+  }
+  return VSetVL;
 }
 
 static LLVM_ATTRIBUTE_NOINLINE Value *

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vsetvl.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vsetvl.c
@@ -9,8 +9,12 @@
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e8mf8
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 5)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 5)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 2
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e8mf8(size_t avl) {
   return __riscv_vsetvl_e8mf8(avl);
@@ -19,8 +23,12 @@ size_t test_vsetvl_e8mf8(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e8mf4
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 6)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 6)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 4
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e8mf4(size_t avl) {
   return __riscv_vsetvl_e8mf4(avl);
@@ -29,8 +37,12 @@ size_t test_vsetvl_e8mf4(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e8mf2
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 7)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 7)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 8
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e8mf2(size_t avl) {
   return __riscv_vsetvl_e8mf2(avl);
@@ -39,8 +51,12 @@ size_t test_vsetvl_e8mf2(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e8m1
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 0)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 16
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e8m1(size_t avl) {
   return __riscv_vsetvl_e8m1(avl);
@@ -49,8 +65,12 @@ size_t test_vsetvl_e8m1(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e8m2
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 1)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 32
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e8m2(size_t avl) {
   return __riscv_vsetvl_e8m2(avl);
@@ -59,8 +79,12 @@ size_t test_vsetvl_e8m2(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e8m4
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 2)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 64
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e8m4(size_t avl) {
   return __riscv_vsetvl_e8m4(avl);
@@ -69,8 +93,12 @@ size_t test_vsetvl_e8m4(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e8m8
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 3)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 128
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e8m8(size_t avl) {
   return __riscv_vsetvl_e8m8(avl);
@@ -79,8 +107,12 @@ size_t test_vsetvl_e8m8(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e16mf4
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 6)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 6)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 2
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e16mf4(size_t avl) {
   return __riscv_vsetvl_e16mf4(avl);
@@ -89,8 +121,12 @@ size_t test_vsetvl_e16mf4(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e16mf2
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 7)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 7)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 4
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e16mf2(size_t avl) {
   return __riscv_vsetvl_e16mf2(avl);
@@ -99,8 +135,12 @@ size_t test_vsetvl_e16mf2(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e16m1
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 0)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 8
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e16m1(size_t avl) {
   return __riscv_vsetvl_e16m1(avl);
@@ -109,8 +149,12 @@ size_t test_vsetvl_e16m1(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e16m2
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 1)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 16
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e16m2(size_t avl) {
   return __riscv_vsetvl_e16m2(avl);
@@ -119,8 +163,12 @@ size_t test_vsetvl_e16m2(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e16m4
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 2)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 32
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e16m4(size_t avl) {
   return __riscv_vsetvl_e16m4(avl);
@@ -129,8 +177,12 @@ size_t test_vsetvl_e16m4(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e16m8
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 3)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 64
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e16m8(size_t avl) {
   return __riscv_vsetvl_e16m8(avl);
@@ -139,8 +191,12 @@ size_t test_vsetvl_e16m8(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e32mf2
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 2, i64 7)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 2, i64 7)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 2
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e32mf2(size_t avl) {
   return __riscv_vsetvl_e32mf2(avl);
@@ -149,8 +205,12 @@ size_t test_vsetvl_e32mf2(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e32m1
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 2, i64 0)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 2, i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 4
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e32m1(size_t avl) {
   return __riscv_vsetvl_e32m1(avl);
@@ -159,8 +219,12 @@ size_t test_vsetvl_e32m1(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e32m2
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 2, i64 1)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 2, i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 8
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e32m2(size_t avl) {
   return __riscv_vsetvl_e32m2(avl);
@@ -169,8 +233,12 @@ size_t test_vsetvl_e32m2(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e32m4
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 2, i64 2)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 2, i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 16
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e32m4(size_t avl) {
   return __riscv_vsetvl_e32m4(avl);
@@ -179,8 +247,12 @@ size_t test_vsetvl_e32m4(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e32m8
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 2, i64 3)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 2, i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 32
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e32m8(size_t avl) {
   return __riscv_vsetvl_e32m8(avl);
@@ -189,8 +261,12 @@ size_t test_vsetvl_e32m8(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e64m1
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 3, i64 0)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 3, i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 2
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e64m1(size_t avl) {
   return __riscv_vsetvl_e64m1(avl);
@@ -199,8 +275,12 @@ size_t test_vsetvl_e64m1(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e64m2
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 3, i64 1)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 3, i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 4
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e64m2(size_t avl) {
   return __riscv_vsetvl_e64m2(avl);
@@ -209,8 +289,12 @@ size_t test_vsetvl_e64m2(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e64m4
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 3, i64 2)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 3, i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 8
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e64m4(size_t avl) {
   return __riscv_vsetvl_e64m4(avl);
@@ -219,8 +303,12 @@ size_t test_vsetvl_e64m4(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e64m8
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 3, i64 3)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 3, i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 16
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e64m8(size_t avl) {
   return __riscv_vsetvl_e64m8(avl);

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vsetvlmax.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/non-policy/non-overloaded/vsetvlmax.c
@@ -9,8 +9,10 @@
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e8mf8
 // CHECK-RV64-SAME: () #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 5)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 5)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 2
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e8mf8() {
   return __riscv_vsetvlmax_e8mf8();
@@ -19,8 +21,10 @@ size_t test_vsetvlmax_e8mf8() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e8mf4
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 6)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 6)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 4
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e8mf4() {
   return __riscv_vsetvlmax_e8mf4();
@@ -29,8 +33,10 @@ size_t test_vsetvlmax_e8mf4() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e8mf2
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 7)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 7)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 8
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e8mf2() {
   return __riscv_vsetvlmax_e8mf2();
@@ -39,8 +45,10 @@ size_t test_vsetvlmax_e8mf2() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e8m1
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 0)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 16
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e8m1() {
   return __riscv_vsetvlmax_e8m1();
@@ -49,8 +57,10 @@ size_t test_vsetvlmax_e8m1() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e8m2
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 1)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 32
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e8m2() {
   return __riscv_vsetvlmax_e8m2();
@@ -59,8 +69,10 @@ size_t test_vsetvlmax_e8m2() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e8m4
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 2)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 64
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e8m4() {
   return __riscv_vsetvlmax_e8m4();
@@ -69,8 +81,10 @@ size_t test_vsetvlmax_e8m4() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e8m8
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 3)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 128
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e8m8() {
   return __riscv_vsetvlmax_e8m8();
@@ -79,8 +93,10 @@ size_t test_vsetvlmax_e8m8() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e16mf4
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 6)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 6)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 2
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e16mf4() {
   return __riscv_vsetvlmax_e16mf4();
@@ -89,8 +105,10 @@ size_t test_vsetvlmax_e16mf4() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e16mf2
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 7)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 7)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 4
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e16mf2() {
   return __riscv_vsetvlmax_e16mf2();
@@ -99,8 +117,10 @@ size_t test_vsetvlmax_e16mf2() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e16m1
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 0)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 8
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e16m1() {
   return __riscv_vsetvlmax_e16m1();
@@ -109,8 +129,10 @@ size_t test_vsetvlmax_e16m1() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e16m2
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 1)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 16
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e16m2() {
   return __riscv_vsetvlmax_e16m2();
@@ -119,8 +141,10 @@ size_t test_vsetvlmax_e16m2() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e16m4
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 2)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 32
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e16m4() {
   return __riscv_vsetvlmax_e16m4();
@@ -129,8 +153,10 @@ size_t test_vsetvlmax_e16m4() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e16m8
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 3)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 64
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e16m8() {
   return __riscv_vsetvlmax_e16m8();
@@ -139,8 +165,10 @@ size_t test_vsetvlmax_e16m8() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e32mf2
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 7)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 7)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 2
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e32mf2() {
   return __riscv_vsetvlmax_e32mf2();
@@ -149,8 +177,10 @@ size_t test_vsetvlmax_e32mf2() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e32m1
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 0)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 4
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e32m1() {
   return __riscv_vsetvlmax_e32m1();
@@ -159,8 +189,10 @@ size_t test_vsetvlmax_e32m1() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e32m2
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 1)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 8
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e32m2() {
   return __riscv_vsetvlmax_e32m2();
@@ -169,8 +201,10 @@ size_t test_vsetvlmax_e32m2() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e32m4
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 2)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 16
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e32m4() {
   return __riscv_vsetvlmax_e32m4();
@@ -179,8 +213,10 @@ size_t test_vsetvlmax_e32m4() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e32m8
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 3)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 32
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e32m8() {
   return __riscv_vsetvlmax_e32m8();
@@ -189,8 +225,10 @@ size_t test_vsetvlmax_e32m8() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e64m1
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 3, i64 0)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 3, i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 2
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e64m1() {
   return __riscv_vsetvlmax_e64m1();
@@ -199,8 +237,10 @@ size_t test_vsetvlmax_e64m1() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e64m2
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 3, i64 1)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 3, i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 4
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e64m2() {
   return __riscv_vsetvlmax_e64m2();
@@ -209,8 +249,10 @@ size_t test_vsetvlmax_e64m2() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e64m4
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 3, i64 2)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 3, i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 8
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e64m4() {
   return __riscv_vsetvlmax_e64m4();
@@ -219,8 +261,10 @@ size_t test_vsetvlmax_e64m4() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e64m8
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 3, i64 3)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 3, i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 16
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e64m8() {
   return __riscv_vsetvlmax_e64m8();

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vsetvl.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vsetvl.c
@@ -9,8 +9,12 @@
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e8mf8
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 5)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 5)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 2
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e8mf8(size_t avl) {
   return __riscv_vsetvl_e8mf8(avl);
@@ -19,8 +23,12 @@ size_t test_vsetvl_e8mf8(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e8mf4
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 6)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 6)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 4
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e8mf4(size_t avl) {
   return __riscv_vsetvl_e8mf4(avl);
@@ -29,8 +37,12 @@ size_t test_vsetvl_e8mf4(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e8mf2
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 7)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 7)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 8
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e8mf2(size_t avl) {
   return __riscv_vsetvl_e8mf2(avl);
@@ -39,8 +51,12 @@ size_t test_vsetvl_e8mf2(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e8m1
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 0)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 16
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e8m1(size_t avl) {
   return __riscv_vsetvl_e8m1(avl);
@@ -49,8 +65,12 @@ size_t test_vsetvl_e8m1(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e8m2
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 1)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 32
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e8m2(size_t avl) {
   return __riscv_vsetvl_e8m2(avl);
@@ -59,8 +79,12 @@ size_t test_vsetvl_e8m2(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e8m4
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 2)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 64
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e8m4(size_t avl) {
   return __riscv_vsetvl_e8m4(avl);
@@ -69,8 +93,12 @@ size_t test_vsetvl_e8m4(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e8m8
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 3)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 128
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e8m8(size_t avl) {
   return __riscv_vsetvl_e8m8(avl);
@@ -79,8 +107,12 @@ size_t test_vsetvl_e8m8(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e16mf4
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 6)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 6)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 2
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e16mf4(size_t avl) {
   return __riscv_vsetvl_e16mf4(avl);
@@ -89,8 +121,12 @@ size_t test_vsetvl_e16mf4(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e16mf2
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 7)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 7)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 4
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e16mf2(size_t avl) {
   return __riscv_vsetvl_e16mf2(avl);
@@ -99,8 +135,12 @@ size_t test_vsetvl_e16mf2(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e16m1
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 0)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 8
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e16m1(size_t avl) {
   return __riscv_vsetvl_e16m1(avl);
@@ -109,8 +149,12 @@ size_t test_vsetvl_e16m1(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e16m2
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 1)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 16
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e16m2(size_t avl) {
   return __riscv_vsetvl_e16m2(avl);
@@ -119,8 +163,12 @@ size_t test_vsetvl_e16m2(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e16m4
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 2)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 32
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e16m4(size_t avl) {
   return __riscv_vsetvl_e16m4(avl);
@@ -129,8 +177,12 @@ size_t test_vsetvl_e16m4(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e16m8
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 3)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 1, i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 64
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e16m8(size_t avl) {
   return __riscv_vsetvl_e16m8(avl);
@@ -139,8 +191,12 @@ size_t test_vsetvl_e16m8(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e32mf2
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 2, i64 7)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 2, i64 7)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 2
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e32mf2(size_t avl) {
   return __riscv_vsetvl_e32mf2(avl);
@@ -149,8 +205,12 @@ size_t test_vsetvl_e32mf2(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e32m1
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 2, i64 0)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 2, i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 4
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e32m1(size_t avl) {
   return __riscv_vsetvl_e32m1(avl);
@@ -159,8 +219,12 @@ size_t test_vsetvl_e32m1(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e32m2
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 2, i64 1)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 2, i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 8
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e32m2(size_t avl) {
   return __riscv_vsetvl_e32m2(avl);
@@ -169,8 +233,12 @@ size_t test_vsetvl_e32m2(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e32m4
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 2, i64 2)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 2, i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 16
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e32m4(size_t avl) {
   return __riscv_vsetvl_e32m4(avl);
@@ -179,8 +247,12 @@ size_t test_vsetvl_e32m4(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e32m8
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 2, i64 3)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 2, i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 32
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e32m8(size_t avl) {
   return __riscv_vsetvl_e32m8(avl);
@@ -189,8 +261,12 @@ size_t test_vsetvl_e32m8(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e64m1
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 3, i64 0)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 3, i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 2
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e64m1(size_t avl) {
   return __riscv_vsetvl_e64m1(avl);
@@ -199,8 +275,12 @@ size_t test_vsetvl_e64m1(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e64m2
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 3, i64 1)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 3, i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 4
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e64m2(size_t avl) {
   return __riscv_vsetvl_e64m2(avl);
@@ -209,8 +289,12 @@ size_t test_vsetvl_e64m2(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e64m4
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 3, i64 2)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 3, i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 8
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e64m4(size_t avl) {
   return __riscv_vsetvl_e64m4(avl);
@@ -219,8 +303,12 @@ size_t test_vsetvl_e64m4(size_t avl) {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvl_e64m8
 // CHECK-RV64-SAME: (i64 noundef [[AVL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 3, i64 3)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 3, i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp ugt i64 [[AVL]], 16
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[VL]], [[AVL]]
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = select i1 [[TMP0]], i1 true, i1 [[TMP1]]
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP2]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvl_e64m8(size_t avl) {
   return __riscv_vsetvl_e64m8(avl);

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vsetvlmax.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/policy/non-overloaded/vsetvlmax.c
@@ -9,8 +9,10 @@
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e8mf8
 // CHECK-RV64-SAME: () #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 5)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 5)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 2
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e8mf8() {
   return __riscv_vsetvlmax_e8mf8();
@@ -19,8 +21,10 @@ size_t test_vsetvlmax_e8mf8() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e8mf4
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 6)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 6)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 4
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e8mf4() {
   return __riscv_vsetvlmax_e8mf4();
@@ -29,8 +33,10 @@ size_t test_vsetvlmax_e8mf4() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e8mf2
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 7)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 7)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 8
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e8mf2() {
   return __riscv_vsetvlmax_e8mf2();
@@ -39,8 +45,10 @@ size_t test_vsetvlmax_e8mf2() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e8m1
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 0)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 16
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e8m1() {
   return __riscv_vsetvlmax_e8m1();
@@ -49,8 +57,10 @@ size_t test_vsetvlmax_e8m1() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e8m2
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 1)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 32
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e8m2() {
   return __riscv_vsetvlmax_e8m2();
@@ -59,8 +69,10 @@ size_t test_vsetvlmax_e8m2() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e8m4
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 2)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 64
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e8m4() {
   return __riscv_vsetvlmax_e8m4();
@@ -69,8 +81,10 @@ size_t test_vsetvlmax_e8m4() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e8m8
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 3)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 128
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e8m8() {
   return __riscv_vsetvlmax_e8m8();
@@ -79,8 +93,10 @@ size_t test_vsetvlmax_e8m8() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e16mf4
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 6)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 6)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 2
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e16mf4() {
   return __riscv_vsetvlmax_e16mf4();
@@ -89,8 +105,10 @@ size_t test_vsetvlmax_e16mf4() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e16mf2
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 7)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 7)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 4
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e16mf2() {
   return __riscv_vsetvlmax_e16mf2();
@@ -99,8 +117,10 @@ size_t test_vsetvlmax_e16mf2() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e16m1
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 0)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 8
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e16m1() {
   return __riscv_vsetvlmax_e16m1();
@@ -109,8 +129,10 @@ size_t test_vsetvlmax_e16m1() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e16m2
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 1)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 16
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e16m2() {
   return __riscv_vsetvlmax_e16m2();
@@ -119,8 +141,10 @@ size_t test_vsetvlmax_e16m2() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e16m4
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 2)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 32
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e16m4() {
   return __riscv_vsetvlmax_e16m4();
@@ -129,8 +153,10 @@ size_t test_vsetvlmax_e16m4() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e16m8
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 3)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 1, i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 64
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e16m8() {
   return __riscv_vsetvlmax_e16m8();
@@ -139,8 +165,10 @@ size_t test_vsetvlmax_e16m8() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e32mf2
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 7)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 7)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 2
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e32mf2() {
   return __riscv_vsetvlmax_e32mf2();
@@ -149,8 +177,10 @@ size_t test_vsetvlmax_e32mf2() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e32m1
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 0)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 4
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e32m1() {
   return __riscv_vsetvlmax_e32m1();
@@ -159,8 +189,10 @@ size_t test_vsetvlmax_e32m1() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e32m2
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 1)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 8
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e32m2() {
   return __riscv_vsetvlmax_e32m2();
@@ -169,8 +201,10 @@ size_t test_vsetvlmax_e32m2() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e32m4
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 2)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 16
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e32m4() {
   return __riscv_vsetvlmax_e32m4();
@@ -179,8 +213,10 @@ size_t test_vsetvlmax_e32m4() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e32m8
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 3)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 2, i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 32
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e32m8() {
   return __riscv_vsetvlmax_e32m8();
@@ -189,8 +225,10 @@ size_t test_vsetvlmax_e32m8() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e64m1
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 3, i64 0)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 3, i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 2
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e64m1() {
   return __riscv_vsetvlmax_e64m1();
@@ -199,8 +237,10 @@ size_t test_vsetvlmax_e64m1() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e64m2
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 3, i64 1)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 3, i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 4
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e64m2() {
   return __riscv_vsetvlmax_e64m2();
@@ -209,8 +249,10 @@ size_t test_vsetvlmax_e64m2() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e64m4
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 3, i64 2)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 3, i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 8
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e64m4() {
   return __riscv_vsetvlmax_e64m4();
@@ -219,8 +261,10 @@ size_t test_vsetvlmax_e64m4() {
 // CHECK-RV64-LABEL: define dso_local i64 @test_vsetvlmax_e64m8
 // CHECK-RV64-SAME: () #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 3, i64 3)
-// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+// CHECK-RV64-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvlimax.i64(i64 3, i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = icmp uge i64 [[VL]], 16
+// CHECK-RV64-NEXT:    call void @llvm.assume(i1 [[TMP0]])
+// CHECK-RV64-NEXT:    ret i64 [[VL]]
 //
 size_t test_vsetvlmax_e64m8() {
   return __riscv_vsetvlmax_e64m8();

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-handcrafted/rvv-error.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-handcrafted/rvv-error.c
@@ -6,8 +6,11 @@
 
 // CHECK-RV64V-LABEL: @test(
 // CHECK-RV64V-NEXT:  entry:
-// CHECK-RV64V-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 1, i64 0, i64 0)
-// CHECK-RV64V-NEXT:    [[CONV:%.*]] = trunc i64 [[TMP0]] to i32
+// CHECK-RV64V-NEXT:    [[VL:%.*]] = call i64 @llvm.riscv.vsetvli.i64(i64 1, i64 0, i64 0)
+// CHECK-RV64V-NEXT:    [[TMP0:%.*]] = icmp eq i64 [[VL]], 1
+// CHECK-RV64V-NEXT:    [[TMP1:%.*]] = select i1 false, i1 true, i1 [[TMP0]]
+// CHECK-RV64V-NEXT:    call void @llvm.assume(i1 [[TMP1]])
+// CHECK-RV64V-NEXT:    [[CONV:%.*]] = trunc i64 [[VL]] to i32
 // CHECK-RV64V-NEXT:    ret i32 [[CONV]]
 //
 


### PR DESCRIPTION
There are some assumptions of the return value of vsetvli/vsetvlimax,
we add them via llvm.assume so that middle-end optimizations can
benefit from them.

Fixes #217784.
