### PR TITLE
[libc][stdio] Add support for the %m modifier

### DIFF
--- a/libc/config/config.json
+++ b/libc/config/config.json
@@ -77,6 +77,10 @@
     "LIBC_CONF_SCANF_PROVIDE_ISOC99_ALIASES": {
       "value": false,
       "doc": "Add __isoc99_* aliases for scanf's functions."
+    },
+    "LIBC_CONF_SCANF_DISABLE_ALLOCATION": {
+      "value": false,
+      "doc": "Disable %m flag for allocating heap memory for the caller as per POSIX"
     }
   },
   "str_to_float": {

--- a/libc/src/stdio/scanf_core/CMakeLists.txt
+++ b/libc/src/stdio/scanf_core/CMakeLists.txt
@@ -4,6 +4,9 @@ endif()
 if(LIBC_CONF_SCANF_DISABLE_INDEX_MODE)
   libc_add_definition(scanf_config_copts "LIBC_COPT_SCANF_DISABLE_INDEX_MODE")
 endif()
+if(LIBC_CONF_SCANF_DISABLE_ALLOCATION)
+  libc_add_definition(scanf_config_copts "LIBC_COPT_SCANF_DISABLE_ALLOCATION")
+endif()
 if(scanf_config_copts)
   list(PREPEND scanf_config_copts "COMPILE_OPTIONS")
 endif()
@@ -105,6 +108,7 @@ add_header_library(
     libc.src.__support.CPP.limits
     libc.src.__support.char_vector
     libc.src.__support.str_to_float
+    libc.src.__support.CPP.new
     ${use_system_file}
 )
 

--- a/libc/src/stdio/scanf_core/CMakeLists.txt
+++ b/libc/src/stdio/scanf_core/CMakeLists.txt
@@ -108,7 +108,9 @@ add_header_library(
     libc.src.__support.CPP.limits
     libc.src.__support.char_vector
     libc.src.__support.str_to_float
-    libc.src.__support.CPP.new
+    libc.hdr.func.malloc
+    libc.hdr.func.realloc
+    libc.hdr.free
     ${use_system_file}
 )
 

--- a/libc/src/stdio/scanf_core/parser.h
+++ b/libc/src/stdio/scanf_core/parser.h
@@ -81,11 +81,12 @@ public:
         cur_pos = cur_pos + static_cast<size_t>(result.parsed_len);
       }
 
-      // TODO(michaelrj): add posix allocate flag support.
-      // if (str[cur_pos] == 'm') {
-      //   ++cur_pos;
-      //   section.flags = FormatFlags::ALLOCATE;
-      // }
+#ifndef LIBC_COPT_SCANF_DISABLE_ALLOCATION
+      if (str[cur_pos] == 'm') {
+        ++cur_pos;
+        section.flags = static_cast<FormatFlags>(FormatFlags::ALLOCATE);
+      }
+#endif
 
       LengthModifier lm = parse_length_modifier(&cur_pos);
       section.length_modifier = lm;

--- a/libc/src/stdio/scanf_core/string_converter.h
+++ b/libc/src/stdio/scanf_core/string_converter.h
@@ -10,12 +10,18 @@
 #define LLVM_LIBC_SRC_STDIO_SCANF_CORE_STRING_CONVERTER_H
 
 #include "src/__support/CPP/limits.h"
+#include "src/__support/CPP/new.h"
+#include "src/__support/alloc-checker.h"
 #include "src/__support/ctype_utils.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/scanf_core/core_structs.h"
 #include "src/stdio/scanf_core/reader.h"
+#include "src/string/memory_utils/inline_memcpy.h"
 
 #include <stddef.h>
+
+constexpr int ALLOCATION_SCALE = 2;
+constexpr int ALLOCATION_BASE = 32;
 
 namespace LIBC_NAMESPACE_DECL {
 namespace scanf_core {
@@ -40,8 +46,26 @@ int convert_string(Reader<T> *reader, const FormatSection &to_conv) {
     }
   }
 
-  char *output = reinterpret_cast<char *>(to_conv.output_ptr);
-
+  char *output;
+ AllocChecker ac;
+#ifndef LIBC_COPT_SCANF_DISABLE_ALLOCATION
+  size_t alloc_size;
+  if ((to_conv.flags & NO_WRITE) == 0 && (to_conv.flags & ALLOCATE) != 0) {
+    if (to_conv.conv_name == 'c')
+      alloc_size = max_width + 1;
+    else
+      alloc_size =
+          (max_width < ALLOCATION_BASE) ? max_width + 1 : ALLOCATION_BASE;
+    output = new (ac) char[alloc_size];
+    if (!ac) {
+      return ALLOCATION_FAILURE;
+    }
+  } else {
+    output = reinterpret_cast<char *>(to_conv.output_ptr);
+  }
+#else
+  output = reinterpret_cast<char *>(to_conv.output_ptr);
+#endif
   char cur_char = reader->getc();
   size_t i = 0;
   for (; i < max_width && cur_char != '\0'; ++i) {
@@ -52,8 +76,26 @@ int convert_string(Reader<T> *reader, const FormatSection &to_conv) {
       break;
     }
     // if the NO_WRITE flag is not set, write to the output.
-    if ((to_conv.flags & NO_WRITE) == 0)
+    if ((to_conv.flags & NO_WRITE) == 0) {
       output[i] = cur_char;
+#ifndef LIBC_COPT_SCANF_DISABLE_ALLOCATION
+      if (((to_conv.flags & ALLOCATE) != 0) && (i + 1) == alloc_size &&
+          alloc_size < max_width) {
+        alloc_size *= ALLOCATION_SCALE;
+        if (alloc_size > max_width + 1)
+          alloc_size = max_width + 1;
+        char *tmp = new (ac) char[alloc_size];
+        if (!ac) {
+          delete[] output;
+          reader->ungetc(cur_char);
+          return ALLOCATION_FAILURE;
+        }
+        inline_memcpy(tmp, output, i + 1);
+        delete[] output;
+        output = tmp;
+      }
+#endif
+    }
     cur_char = reader->getc();
   }
 
@@ -61,8 +103,11 @@ int convert_string(Reader<T> *reader, const FormatSection &to_conv) {
   // last one back.
   reader->ungetc(cur_char);
 
+  bool null_terminate =
+      (to_conv.conv_name != 'c') || ((to_conv.flags & ALLOCATE) != 0);
+
   // If this is %s or %[]
-  if (to_conv.conv_name != 'c' && (to_conv.flags & NO_WRITE) == 0) {
+  if (null_terminate && (to_conv.flags & NO_WRITE) == 0) {
     // Always null terminate the string. This may cause a write to the
     // (max_width + 1) byte, which is correct. The max width describes the max
     // number of characters read from the input string, and doesn't necessarily
@@ -70,8 +115,20 @@ int convert_string(Reader<T> *reader, const FormatSection &to_conv) {
     output[i] = '\0';
   }
 
-  if (i == 0)
+  if (i == 0) {
+#ifndef LIBC_COPT_SCANF_DISABLE_ALLOCATION
+    if ((to_conv.flags & ALLOCATE) != 0 && output)
+      delete[] output;
+#endif
     return MATCHING_FAILURE;
+  }
+
+#ifndef LIBC_COPT_SCANF_DISABLE_ALLOCATION
+  if ((to_conv.flags & ALLOCATE) != 0) {
+    *reinterpret_cast<char **>(to_conv.output_ptr) = output;
+  }
+#endif
+
   return READ_OK;
 }
 

--- a/libc/src/stdio/scanf_core/string_converter.h
+++ b/libc/src/stdio/scanf_core/string_converter.h
@@ -9,14 +9,14 @@
 #ifndef LLVM_LIBC_SRC_STDIO_SCANF_CORE_STRING_CONVERTER_H
 #define LLVM_LIBC_SRC_STDIO_SCANF_CORE_STRING_CONVERTER_H
 
+#include "hdr/func/free.h"
+#include "hdr/func/malloc.h"
+#include "hdr/func/realloc.h"
 #include "src/__support/CPP/limits.h"
-#include "src/__support/CPP/new.h"
-#include "src/__support/alloc-checker.h"
 #include "src/__support/ctype_utils.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/scanf_core/core_structs.h"
 #include "src/stdio/scanf_core/reader.h"
-#include "src/string/memory_utils/inline_memcpy.h"
 
 #include <stddef.h>
 
@@ -47,7 +47,6 @@ int convert_string(Reader<T> *reader, const FormatSection &to_conv) {
   }
 
   char *output;
- AllocChecker ac;
 #ifndef LIBC_COPT_SCANF_DISABLE_ALLOCATION
   size_t alloc_size;
   if ((to_conv.flags & NO_WRITE) == 0 && (to_conv.flags & ALLOCATE) != 0) {
@@ -56,10 +55,9 @@ int convert_string(Reader<T> *reader, const FormatSection &to_conv) {
     else
       alloc_size =
           (max_width < ALLOCATION_BASE) ? max_width + 1 : ALLOCATION_BASE;
-    output = new (ac) char[alloc_size];
-    if (!ac) {
+    output = reinterpret_cast<char *>(malloc(alloc_size));
+    if (!output)
       return ALLOCATION_FAILURE;
-    }
   } else {
     output = reinterpret_cast<char *>(to_conv.output_ptr);
   }
@@ -84,14 +82,12 @@ int convert_string(Reader<T> *reader, const FormatSection &to_conv) {
         alloc_size *= ALLOCATION_SCALE;
         if (alloc_size > max_width + 1)
           alloc_size = max_width + 1;
-        char *tmp = new (ac) char[alloc_size];
-        if (!ac) {
-          delete[] output;
+        char *tmp = reinterpret_cast<char *>(realloc(output, alloc_size));
+        if (!tmp) {
+          free(output);
           reader->ungetc(cur_char);
           return ALLOCATION_FAILURE;
         }
-        inline_memcpy(tmp, output, i + 1);
-        delete[] output;
         output = tmp;
       }
 #endif
@@ -118,7 +114,7 @@ int convert_string(Reader<T> *reader, const FormatSection &to_conv) {
   if (i == 0) {
 #ifndef LIBC_COPT_SCANF_DISABLE_ALLOCATION
     if ((to_conv.flags & ALLOCATE) != 0 && output)
-      delete[] output;
+      free(output);
 #endif
     return MATCHING_FAILURE;
   }

--- a/libc/test/src/stdio/scanf_core/CMakeLists.txt
+++ b/libc/test/src/stdio/scanf_core/CMakeLists.txt
@@ -47,6 +47,7 @@ add_libc_test(
     libc.src.stdio.scanf_core.converter
     libc.src.stdio.scanf_core.string_reader
     libc.src.__support.CPP.string_view
+    libc.src.__support.CPP.new
   COMPILE_OPTIONS
     ${use_system_file}
 )


### PR DESCRIPTION
Add support for the %m modifier and it's derivatives as per
POSIX 2008.1 by leveraging the preexisting FormatFlags::Allocate
and allocating 32 bytes at a time that scale by 2x on each iteration
till it reaches the desired outcome.