### PR TITLE
RISCV: Fix VectorPeephole null dereference on an undef vmerge true operand

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVVectorPeephole.cpp
+++ b/llvm/lib/Target/RISCV/RISCVVectorPeephole.cpp
@@ -664,7 +664,10 @@ bool RISCVVectorPeepholeImpl::foldVMergeToMask(MachineInstr &MI) const {
                                     /*OneUseOnly=*/true, &TrueCopies);
   if (!TrueReg.isVirtual() || !MRI->hasOneUse(TrueReg))
     return false;
-  MachineInstr &True = *MRI->getUniqueVRegDef(TrueReg);
+  MachineInstr *TrueDef = MRI->getVRegDef(TrueReg);
+  if (!TrueDef)
+    return false;
+  MachineInstr &True = *TrueDef;
   if (True.getParent() != MI.getParent())
     return false;
   const MachineOperand &MaskOp = MI.getOperand(4);

--- a/llvm/test/CodeGen/RISCV/rvv/vmerge-peephole.mir
+++ b/llvm/test/CodeGen/RISCV/rvv/vmerge-peephole.mir
@@ -309,3 +309,21 @@ body: |
     %false:vrnov0 = PseudoVMV_V_I_M1 $noreg, 0, %avl, 5 /* e32 */, 0 /* tu, mu */
     %y:vrnov0 = PseudoVMERGE_VVM_M1 $noreg, %false, %x, %mask, %avl, 5 /* e32 */
 ...
+---
+name: vmerge_undef_true
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $x8, $v0, $v8
+    ; CHECK-LABEL: name: vmerge_undef_true
+    ; CHECK: liveins: $x8, $v0, $v8
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: %avl:gprnox0 = COPY $x8
+    ; CHECK-NEXT: %passthru:vrnov0 = COPY $v8
+    ; CHECK-NEXT: %mask:vmv0 = COPY $v0
+    ; CHECK-NEXT: %y:vrnov0 = PseudoVMERGE_VVM_M1 %passthru, %passthru, undef %x:vrnov0, %mask, %avl /* vl */, 5 /* e32 */
+    %avl:gprnox0 = COPY $x8
+    %passthru:vrnov0 = COPY $v8
+    %mask:vmv0 = COPY $v0
+    %y:vrnov0 = PseudoVMERGE_VVM_M1 %passthru, %passthru, undef %x:vrnov0, %mask, %avl, 5 /* e32 */
+...


### PR DESCRIPTION
Also since this is an SSA pass, switch to using getVRegDef instead of
getUniqueVRegDef

Co-Authored-By: Claude <noreply@anthropic.com> (Claude Opus 4.8)