### PR TITLE
[AArch64][GlobalISel] Enable constant_fold_cast_op post-legalization

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64Combine.td
+++ b/llvm/lib/Target/AArch64/AArch64Combine.td
@@ -397,7 +397,7 @@ def AArch64PostLegalizerLowering
 // Post-legalization combines which are primarily optimizations.
 def AArch64PostLegalizerCombiner
     : GICombiner<"AArch64PostLegalizerCombinerImpl",
-                       [copy_prop, cast_of_cast_combines, constant_fold_fp_ops, 
+                       [copy_prop, cast_of_cast_combines, constant_fold_fp_ops,
                         buildvector_of_truncate, integer_of_truncate,
                         mutate_anyext_to_zext, combines_for_extload, 
                         combine_indexed_load_store, sext_trunc_sextload,
@@ -411,7 +411,7 @@ def AArch64PostLegalizerCombiner
                         icmp_to_true_false_known_bits, overflow_combines,
                         select_combines, select_zero_true, select_zero_false, select_not,
                         fold_merge_to_zext, merge_combines,
-                        constant_fold_binops, identity_combines,
+                        constant_fold_binops, constant_fold_cast_op, identity_combines,
                         ptr_add_immed_chain, overlapping_and,
                         split_store_zero_128, undef_combines,
                         select_to_minmax, or_to_bsp, trunc_or_to_addhn,

--- a/llvm/test/CodeGen/AArch64/GlobalISel/postlegalizer-combiner-and-trivial-mask.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/postlegalizer-combiner-and-trivial-mask.mir
@@ -161,8 +161,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: %x:_(i32) = COPY $w0
     ; CHECK-NEXT: %y:_(i32) = COPY $w1
-    ; CHECK-NEXT: %z:_(i32) = G_CONSTANT i32 42
-    ; CHECK-NEXT: %ext:_(i64) = G_SEXT %z(i32)
+    ; CHECK-NEXT: %ext:_(i64) = G_CONSTANT i64 42
     ; CHECK-NEXT: $x0 = COPY %ext(i64)
     ; CHECK-NEXT: RET_ReallyLR implicit $x0
     %x:_(i32) = COPY $w0

--- a/llvm/test/CodeGen/AArch64/combine-sdiv.ll
+++ b/llvm/test/CodeGen/AArch64/combine-sdiv.ll
@@ -163,20 +163,17 @@ define <4 x i32> @combine_vec_sdiv_by_pos1(<4 x i32> %x) {
 ;
 ; CHECK-GI-LABEL: combine_vec_sdiv_by_pos1:
 ; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
-; CHECK-GI-NEXT:    movi v2.2d, #0x0000ff000000ff
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    adrp x8, .LCPI11_0
-; CHECK-GI-NEXT:    ldr q3, [x8, :lo12:.LCPI11_0]
-; CHECK-GI-NEXT:    mov v1.s[1], wzr
-; CHECK-GI-NEXT:    and v0.16b, v0.16b, v2.16b
-; CHECK-GI-NEXT:    neg v2.4s, v3.4s
-; CHECK-GI-NEXT:    sshl v2.4s, v0.4s, v2.4s
-; CHECK-GI-NEXT:    mov v1.s[2], wzr
-; CHECK-GI-NEXT:    mov v1.s[3], wzr
-; CHECK-GI-NEXT:    shl v1.4s, v1.4s, #31
-; CHECK-GI-NEXT:    cmlt v1.4s, v1.4s, #0
-; CHECK-GI-NEXT:    bif v0.16b, v2.16b, v1.16b
+; CHECK-GI-NEXT:    movi v1.2d, #0x0000ff000000ff
+; CHECK-GI-NEXT:    adrp x8, .LCPI11_1
+; CHECK-GI-NEXT:    adrp x9, .LCPI11_0
+; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI11_1]
+; CHECK-GI-NEXT:    ldr q3, [x9, :lo12:.LCPI11_0]
+; CHECK-GI-NEXT:    and v0.16b, v0.16b, v1.16b
+; CHECK-GI-NEXT:    neg v1.4s, v2.4s
+; CHECK-GI-NEXT:    shl v2.4s, v3.4s, #31
+; CHECK-GI-NEXT:    sshl v1.4s, v0.4s, v1.4s
+; CHECK-GI-NEXT:    cmlt v2.4s, v2.4s, #0
+; CHECK-GI-NEXT:    bif v0.16b, v1.16b, v2.16b
 ; CHECK-GI-NEXT:    ret
   %1 = and <4 x i32> %x, <i32 255, i32 255, i32 255, i32 255>
   %2 = sdiv <4 x i32> %1, <i32 1, i32 4, i32 8, i32 16>
@@ -418,24 +415,21 @@ define <4 x i32> @combine_vec_sdiv_by_pow2b_v4i32(<4 x i32> %x) {
 ;
 ; CHECK-GI-LABEL: combine_vec_sdiv_by_pow2b_v4i32:
 ; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
-; CHECK-GI-NEXT:    cmlt v3.4s, v0.4s, #0
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    adrp x8, .LCPI18_0
-; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI18_0]
 ; CHECK-GI-NEXT:    adrp x8, .LCPI18_1
-; CHECK-GI-NEXT:    mov v1.s[1], wzr
+; CHECK-GI-NEXT:    cmlt v2.4s, v0.4s, #0
+; CHECK-GI-NEXT:    adrp x9, .LCPI18_0
+; CHECK-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI18_1]
+; CHECK-GI-NEXT:    adrp x8, .LCPI18_2
+; CHECK-GI-NEXT:    ldr q3, [x9, :lo12:.LCPI18_0]
+; CHECK-GI-NEXT:    neg v1.4s, v1.4s
+; CHECK-GI-NEXT:    shl v3.4s, v3.4s, #31
+; CHECK-GI-NEXT:    ushl v1.4s, v2.4s, v1.4s
+; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI18_2]
 ; CHECK-GI-NEXT:    neg v2.4s, v2.4s
-; CHECK-GI-NEXT:    ushl v2.4s, v3.4s, v2.4s
-; CHECK-GI-NEXT:    ldr q3, [x8, :lo12:.LCPI18_1]
-; CHECK-GI-NEXT:    mov v1.s[2], wzr
-; CHECK-GI-NEXT:    neg v3.4s, v3.4s
-; CHECK-GI-NEXT:    add v2.4s, v0.4s, v2.4s
-; CHECK-GI-NEXT:    mov v1.s[3], wzr
-; CHECK-GI-NEXT:    sshl v2.4s, v2.4s, v3.4s
-; CHECK-GI-NEXT:    shl v1.4s, v1.4s, #31
-; CHECK-GI-NEXT:    cmlt v1.4s, v1.4s, #0
-; CHECK-GI-NEXT:    bif v0.16b, v2.16b, v1.16b
+; CHECK-GI-NEXT:    add v1.4s, v0.4s, v1.4s
+; CHECK-GI-NEXT:    sshl v1.4s, v1.4s, v2.4s
+; CHECK-GI-NEXT:    cmlt v2.4s, v3.4s, #0
+; CHECK-GI-NEXT:    bif v0.16b, v1.16b, v2.16b
 ; CHECK-GI-NEXT:    ret
   %1 = sdiv <4 x i32> %x, <i32 1, i32 4, i32 8, i32 16>
   ret <4 x i32> %1
@@ -464,30 +458,27 @@ define <8 x i32> @combine_vec_sdiv_by_pow2b_v8i32(<8 x i32> %x) {
 ;
 ; CHECK-GI-LABEL: combine_vec_sdiv_by_pow2b_v8i32:
 ; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
-; CHECK-GI-NEXT:    cmlt v4.4s, v0.4s, #0
-; CHECK-GI-NEXT:    cmlt v5.4s, v1.4s, #0
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    adrp x8, .LCPI19_0
-; CHECK-GI-NEXT:    ldr q3, [x8, :lo12:.LCPI19_0]
 ; CHECK-GI-NEXT:    adrp x8, .LCPI19_1
-; CHECK-GI-NEXT:    mov v2.h[1], wzr
-; CHECK-GI-NEXT:    neg v3.4s, v3.4s
-; CHECK-GI-NEXT:    ushl v4.4s, v4.4s, v3.4s
-; CHECK-GI-NEXT:    ushl v3.4s, v5.4s, v3.4s
-; CHECK-GI-NEXT:    ldr q5, [x8, :lo12:.LCPI19_1]
-; CHECK-GI-NEXT:    mov v2.h[2], wzr
-; CHECK-GI-NEXT:    neg v5.4s, v5.4s
-; CHECK-GI-NEXT:    add v4.4s, v0.4s, v4.4s
-; CHECK-GI-NEXT:    add v3.4s, v1.4s, v3.4s
-; CHECK-GI-NEXT:    mov v2.h[3], wzr
-; CHECK-GI-NEXT:    sshl v4.4s, v4.4s, v5.4s
-; CHECK-GI-NEXT:    sshl v3.4s, v3.4s, v5.4s
-; CHECK-GI-NEXT:    ushll v2.4s, v2.4h, #0
-; CHECK-GI-NEXT:    shl v2.4s, v2.4s, #31
-; CHECK-GI-NEXT:    cmlt v2.4s, v2.4s, #0
-; CHECK-GI-NEXT:    bif v0.16b, v4.16b, v2.16b
-; CHECK-GI-NEXT:    bif v1.16b, v3.16b, v2.16b
+; CHECK-GI-NEXT:    cmlt v3.4s, v0.4s, #0
+; CHECK-GI-NEXT:    cmlt v4.4s, v1.4s, #0
+; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI19_1]
+; CHECK-GI-NEXT:    adrp x8, .LCPI19_0
+; CHECK-GI-NEXT:    ldr d5, [x8, :lo12:.LCPI19_0]
+; CHECK-GI-NEXT:    adrp x8, .LCPI19_2
+; CHECK-GI-NEXT:    neg v2.4s, v2.4s
+; CHECK-GI-NEXT:    ushll v5.4s, v5.4h, #0
+; CHECK-GI-NEXT:    ushl v3.4s, v3.4s, v2.4s
+; CHECK-GI-NEXT:    ushl v2.4s, v4.4s, v2.4s
+; CHECK-GI-NEXT:    ldr q4, [x8, :lo12:.LCPI19_2]
+; CHECK-GI-NEXT:    shl v5.4s, v5.4s, #31
+; CHECK-GI-NEXT:    neg v4.4s, v4.4s
+; CHECK-GI-NEXT:    add v3.4s, v0.4s, v3.4s
+; CHECK-GI-NEXT:    add v2.4s, v1.4s, v2.4s
+; CHECK-GI-NEXT:    sshl v3.4s, v3.4s, v4.4s
+; CHECK-GI-NEXT:    sshl v2.4s, v2.4s, v4.4s
+; CHECK-GI-NEXT:    cmlt v4.4s, v5.4s, #0
+; CHECK-GI-NEXT:    bif v0.16b, v3.16b, v4.16b
+; CHECK-GI-NEXT:    bif v1.16b, v2.16b, v4.16b
 ; CHECK-GI-NEXT:    ret
   %1 = sdiv <8 x i32> %x, <i32 1, i32 4, i32 8, i32 16, i32 1, i32 4, i32 8, i32 16>
   ret <8 x i32> %1
@@ -526,40 +517,37 @@ define <16 x i32> @combine_vec_sdiv_by_pow2b_v16i32(<16 x i32> %x) {
 ;
 ; CHECK-GI-LABEL: combine_vec_sdiv_by_pow2b_v16i32:
 ; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
-; CHECK-GI-NEXT:    cmlt v6.4s, v0.4s, #0
-; CHECK-GI-NEXT:    cmlt v7.4s, v1.4s, #0
-; CHECK-GI-NEXT:    fmov s4, w8
-; CHECK-GI-NEXT:    adrp x8, .LCPI20_0
-; CHECK-GI-NEXT:    cmlt v16.4s, v2.4s, #0
-; CHECK-GI-NEXT:    ldr q5, [x8, :lo12:.LCPI20_0]
-; CHECK-GI-NEXT:    cmlt v17.4s, v3.4s, #0
 ; CHECK-GI-NEXT:    adrp x8, .LCPI20_1
-; CHECK-GI-NEXT:    mov v4.h[1], wzr
-; CHECK-GI-NEXT:    neg v5.4s, v5.4s
-; CHECK-GI-NEXT:    ushl v6.4s, v6.4s, v5.4s
-; CHECK-GI-NEXT:    ushl v7.4s, v7.4s, v5.4s
-; CHECK-GI-NEXT:    ushl v16.4s, v16.4s, v5.4s
-; CHECK-GI-NEXT:    mov v4.h[2], wzr
-; CHECK-GI-NEXT:    ushl v5.4s, v17.4s, v5.4s
-; CHECK-GI-NEXT:    ldr q17, [x8, :lo12:.LCPI20_1]
-; CHECK-GI-NEXT:    neg v17.4s, v17.4s
-; CHECK-GI-NEXT:    add v6.4s, v0.4s, v6.4s
-; CHECK-GI-NEXT:    add v7.4s, v1.4s, v7.4s
-; CHECK-GI-NEXT:    add v16.4s, v2.4s, v16.4s
-; CHECK-GI-NEXT:    add v5.4s, v3.4s, v5.4s
-; CHECK-GI-NEXT:    mov v4.h[3], wzr
-; CHECK-GI-NEXT:    sshl v6.4s, v6.4s, v17.4s
-; CHECK-GI-NEXT:    sshl v7.4s, v7.4s, v17.4s
-; CHECK-GI-NEXT:    sshl v16.4s, v16.4s, v17.4s
-; CHECK-GI-NEXT:    sshl v5.4s, v5.4s, v17.4s
-; CHECK-GI-NEXT:    ushll v4.4s, v4.4h, #0
-; CHECK-GI-NEXT:    shl v4.4s, v4.4s, #31
-; CHECK-GI-NEXT:    cmlt v4.4s, v4.4s, #0
-; CHECK-GI-NEXT:    bif v0.16b, v6.16b, v4.16b
-; CHECK-GI-NEXT:    bif v1.16b, v7.16b, v4.16b
-; CHECK-GI-NEXT:    bif v2.16b, v16.16b, v4.16b
-; CHECK-GI-NEXT:    bif v3.16b, v5.16b, v4.16b
+; CHECK-GI-NEXT:    cmlt v5.4s, v0.4s, #0
+; CHECK-GI-NEXT:    cmlt v6.4s, v1.4s, #0
+; CHECK-GI-NEXT:    ldr q4, [x8, :lo12:.LCPI20_1]
+; CHECK-GI-NEXT:    adrp x8, .LCPI20_0
+; CHECK-GI-NEXT:    cmlt v7.4s, v2.4s, #0
+; CHECK-GI-NEXT:    cmlt v16.4s, v3.4s, #0
+; CHECK-GI-NEXT:    ldr d17, [x8, :lo12:.LCPI20_0]
+; CHECK-GI-NEXT:    adrp x8, .LCPI20_2
+; CHECK-GI-NEXT:    neg v4.4s, v4.4s
+; CHECK-GI-NEXT:    ushll v17.4s, v17.4h, #0
+; CHECK-GI-NEXT:    ushl v5.4s, v5.4s, v4.4s
+; CHECK-GI-NEXT:    ushl v6.4s, v6.4s, v4.4s
+; CHECK-GI-NEXT:    ushl v7.4s, v7.4s, v4.4s
+; CHECK-GI-NEXT:    ushl v4.4s, v16.4s, v4.4s
+; CHECK-GI-NEXT:    ldr q16, [x8, :lo12:.LCPI20_2]
+; CHECK-GI-NEXT:    shl v17.4s, v17.4s, #31
+; CHECK-GI-NEXT:    neg v16.4s, v16.4s
+; CHECK-GI-NEXT:    add v5.4s, v0.4s, v5.4s
+; CHECK-GI-NEXT:    add v6.4s, v1.4s, v6.4s
+; CHECK-GI-NEXT:    add v7.4s, v2.4s, v7.4s
+; CHECK-GI-NEXT:    add v4.4s, v3.4s, v4.4s
+; CHECK-GI-NEXT:    cmlt v17.4s, v17.4s, #0
+; CHECK-GI-NEXT:    sshl v5.4s, v5.4s, v16.4s
+; CHECK-GI-NEXT:    sshl v6.4s, v6.4s, v16.4s
+; CHECK-GI-NEXT:    sshl v7.4s, v7.4s, v16.4s
+; CHECK-GI-NEXT:    sshl v4.4s, v4.4s, v16.4s
+; CHECK-GI-NEXT:    bif v0.16b, v5.16b, v17.16b
+; CHECK-GI-NEXT:    bif v1.16b, v6.16b, v17.16b
+; CHECK-GI-NEXT:    bif v2.16b, v7.16b, v17.16b
+; CHECK-GI-NEXT:    bif v3.16b, v4.16b, v17.16b
 ; CHECK-GI-NEXT:    ret
   %1 = sdiv <16 x i32> %x, <i32 1, i32 4, i32 8, i32 16, i32 1, i32 4, i32 8, i32 16, i32 1, i32 4, i32 8, i32 16, i32 1, i32 4, i32 8, i32 16>
   ret <16 x i32> %1
@@ -694,53 +682,50 @@ define <8 x i64> @combine_vec_sdiv_by_pow2b_v8i64(<8 x i64> %x) {
 ;
 ; CHECK-GI-LABEL: combine_vec_sdiv_by_pow2b_v8i64:
 ; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
+; CHECK-GI-NEXT:    adrp x8, .LCPI23_2
 ; CHECK-GI-NEXT:    adrp x9, .LCPI23_0
 ; CHECK-GI-NEXT:    cmlt v7.2d, v0.2d, #0
-; CHECK-GI-NEXT:    fmov s4, w8
+; CHECK-GI-NEXT:    ldr q4, [x8, :lo12:.LCPI23_2]
 ; CHECK-GI-NEXT:    adrp x8, .LCPI23_1
-; CHECK-GI-NEXT:    ldr q6, [x9, :lo12:.LCPI23_0]
-; CHECK-GI-NEXT:    ldr q5, [x8, :lo12:.LCPI23_1]
+; CHECK-GI-NEXT:    ldr d5, [x9, :lo12:.LCPI23_0]
+; CHECK-GI-NEXT:    ldr q6, [x8, :lo12:.LCPI23_1]
 ; CHECK-GI-NEXT:    cmlt v16.2d, v1.2d, #0
 ; CHECK-GI-NEXT:    cmlt v17.2d, v2.2d, #0
+; CHECK-GI-NEXT:    neg v4.2d, v4.2d
+; CHECK-GI-NEXT:    ushll v5.4s, v5.4h, #0
+; CHECK-GI-NEXT:    cmlt v19.2d, v3.2d, #0
 ; CHECK-GI-NEXT:    neg v6.2d, v6.2d
-; CHECK-GI-NEXT:    cmlt v18.2d, v3.2d, #0
+; CHECK-GI-NEXT:    adrp x8, .LCPI23_4
+; CHECK-GI-NEXT:    ldr q18, [x8, :lo12:.LCPI23_4]
 ; CHECK-GI-NEXT:    adrp x8, .LCPI23_3
-; CHECK-GI-NEXT:    mov v4.h[1], wzr
-; CHECK-GI-NEXT:    neg v5.2d, v5.2d
-; CHECK-GI-NEXT:    adrp x9, .LCPI23_2
-; CHECK-GI-NEXT:    ldr q19, [x8, :lo12:.LCPI23_3]
-; CHECK-GI-NEXT:    ldr q20, [x9, :lo12:.LCPI23_2]
+; CHECK-GI-NEXT:    ushl v7.2d, v7.2d, v4.2d
+; CHECK-GI-NEXT:    ushll v20.2d, v5.2s, #0
+; CHECK-GI-NEXT:    ushl v4.2d, v17.2d, v4.2d
 ; CHECK-GI-NEXT:    ushl v16.2d, v16.2d, v6.2d
-; CHECK-GI-NEXT:    ushl v6.2d, v18.2d, v6.2d
-; CHECK-GI-NEXT:    ushl v7.2d, v7.2d, v5.2d
-; CHECK-GI-NEXT:    ushl v5.2d, v17.2d, v5.2d
-; CHECK-GI-NEXT:    neg v19.2d, v19.2d
-; CHECK-GI-NEXT:    mov v4.h[2], wzr
-; CHECK-GI-NEXT:    neg v20.2d, v20.2d
-; CHECK-GI-NEXT:    add v16.2d, v1.2d, v16.2d
-; CHECK-GI-NEXT:    add v6.2d, v3.2d, v6.2d
+; CHECK-GI-NEXT:    ushll v17.2d, v5.2s, #0
+; CHECK-GI-NEXT:    ushl v6.2d, v19.2d, v6.2d
+; CHECK-GI-NEXT:    ushll2 v5.2d, v5.4s, #0
+; CHECK-GI-NEXT:    ldr q19, [x8, :lo12:.LCPI23_3]
+; CHECK-GI-NEXT:    neg v18.2d, v18.2d
 ; CHECK-GI-NEXT:    add v7.2d, v0.2d, v7.2d
-; CHECK-GI-NEXT:    add v5.2d, v2.2d, v5.2d
-; CHECK-GI-NEXT:    mov v4.h[3], wzr
-; CHECK-GI-NEXT:    sshl v16.2d, v16.2d, v20.2d
-; CHECK-GI-NEXT:    sshl v6.2d, v6.2d, v20.2d
-; CHECK-GI-NEXT:    sshl v7.2d, v7.2d, v19.2d
-; CHECK-GI-NEXT:    sshl v5.2d, v5.2d, v19.2d
-; CHECK-GI-NEXT:    ushll v4.4s, v4.4h, #0
-; CHECK-GI-NEXT:    ushll v17.2d, v4.2s, #0
-; CHECK-GI-NEXT:    ushll2 v18.2d, v4.4s, #0
-; CHECK-GI-NEXT:    ushll v4.2d, v4.2s, #0
-; CHECK-GI-NEXT:    shl v17.2d, v17.2d, #63
-; CHECK-GI-NEXT:    shl v18.2d, v18.2d, #63
-; CHECK-GI-NEXT:    shl v4.2d, v4.2d, #63
-; CHECK-GI-NEXT:    cmlt v17.2d, v17.2d, #0
-; CHECK-GI-NEXT:    cmlt v18.2d, v18.2d, #0
-; CHECK-GI-NEXT:    cmlt v4.2d, v4.2d, #0
-; CHECK-GI-NEXT:    bif v0.16b, v7.16b, v17.16b
-; CHECK-GI-NEXT:    bif v1.16b, v16.16b, v18.16b
-; CHECK-GI-NEXT:    bif v2.16b, v5.16b, v4.16b
-; CHECK-GI-NEXT:    bif v3.16b, v6.16b, v18.16b
+; CHECK-GI-NEXT:    shl v20.2d, v20.2d, #63
+; CHECK-GI-NEXT:    add v4.2d, v2.2d, v4.2d
+; CHECK-GI-NEXT:    add v1.2d, v1.2d, v16.2d
+; CHECK-GI-NEXT:    shl v16.2d, v17.2d, #63
+; CHECK-GI-NEXT:    neg v17.2d, v19.2d
+; CHECK-GI-NEXT:    add v3.2d, v3.2d, v6.2d
+; CHECK-GI-NEXT:    shl v5.2d, v5.2d, #63
+; CHECK-GI-NEXT:    sshl v6.2d, v7.2d, v18.2d
+; CHECK-GI-NEXT:    cmlt v7.2d, v20.2d, #0
+; CHECK-GI-NEXT:    sshl v4.2d, v4.2d, v18.2d
+; CHECK-GI-NEXT:    cmlt v16.2d, v16.2d, #0
+; CHECK-GI-NEXT:    sshl v1.2d, v1.2d, v17.2d
+; CHECK-GI-NEXT:    sshl v3.2d, v3.2d, v17.2d
+; CHECK-GI-NEXT:    cmlt v5.2d, v5.2d, #0
+; CHECK-GI-NEXT:    bif v0.16b, v6.16b, v7.16b
+; CHECK-GI-NEXT:    bif v2.16b, v4.16b, v16.16b
+; CHECK-GI-NEXT:    bic v1.16b, v1.16b, v5.16b
+; CHECK-GI-NEXT:    bic v3.16b, v3.16b, v5.16b
 ; CHECK-GI-NEXT:    ret
   %1 = sdiv <8 x i64> %x, <i64 1, i64 4, i64 8, i64 16, i64 1, i64 4, i64 8, i64 16>
   ret <8 x i64> %1
@@ -767,29 +752,25 @@ define <4 x i32> @combine_vec_sdiv_by_pow2b_PosAndNeg(<4 x i32> %x) {
 ;
 ; CHECK-GI-LABEL: combine_vec_sdiv_by_pow2b_PosAndNeg:
 ; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
-; CHECK-GI-NEXT:    adrp x9, .LCPI24_0
-; CHECK-GI-NEXT:    cmlt v4.4s, v0.4s, #0
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    ldr q3, [x9, :lo12:.LCPI24_0]
-; CHECK-GI-NEXT:    movi d1, #0000000000000000
+; CHECK-GI-NEXT:    adrp x8, .LCPI24_2
+; CHECK-GI-NEXT:    cmlt v2.4s, v0.4s, #0
 ; CHECK-GI-NEXT:    adrp x9, .LCPI24_1
-; CHECK-GI-NEXT:    neg v3.4s, v3.4s
-; CHECK-GI-NEXT:    mov v2.s[1], wzr
-; CHECK-GI-NEXT:    mov v1.s[1], w8
-; CHECK-GI-NEXT:    ushl v3.4s, v4.4s, v3.4s
-; CHECK-GI-NEXT:    ldr q4, [x9, :lo12:.LCPI24_1]
-; CHECK-GI-NEXT:    mov v2.s[2], wzr
-; CHECK-GI-NEXT:    neg v4.4s, v4.4s
-; CHECK-GI-NEXT:    add v3.4s, v0.4s, v3.4s
-; CHECK-GI-NEXT:    mov v1.d[1], v1.d[0]
-; CHECK-GI-NEXT:    mov v2.s[3], wzr
-; CHECK-GI-NEXT:    sshl v3.4s, v3.4s, v4.4s
-; CHECK-GI-NEXT:    shl v1.4s, v1.4s, #31
-; CHECK-GI-NEXT:    shl v2.4s, v2.4s, #31
+; CHECK-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI24_2]
+; CHECK-GI-NEXT:    adrp x8, .LCPI24_3
+; CHECK-GI-NEXT:    ldr q3, [x9, :lo12:.LCPI24_1]
+; CHECK-GI-NEXT:    neg v1.4s, v1.4s
+; CHECK-GI-NEXT:    shl v3.4s, v3.4s, #31
+; CHECK-GI-NEXT:    ushl v1.4s, v2.4s, v1.4s
+; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI24_3]
+; CHECK-GI-NEXT:    adrp x8, .LCPI24_0
+; CHECK-GI-NEXT:    neg v2.4s, v2.4s
+; CHECK-GI-NEXT:    add v1.4s, v0.4s, v1.4s
+; CHECK-GI-NEXT:    sshl v1.4s, v1.4s, v2.4s
+; CHECK-GI-NEXT:    cmlt v2.4s, v3.4s, #0
+; CHECK-GI-NEXT:    ldr q3, [x8, :lo12:.LCPI24_0]
+; CHECK-GI-NEXT:    bif v0.16b, v1.16b, v2.16b
+; CHECK-GI-NEXT:    shl v1.4s, v3.4s, #31
 ; CHECK-GI-NEXT:    cmlt v1.4s, v1.4s, #0
-; CHECK-GI-NEXT:    cmlt v2.4s, v2.4s, #0
-; CHECK-GI-NEXT:    bif v0.16b, v3.16b, v2.16b
 ; CHECK-GI-NEXT:    neg v2.4s, v0.4s
 ; CHECK-GI-NEXT:    bit v0.16b, v2.16b, v1.16b
 ; CHECK-GI-NEXT:    ret
@@ -926,29 +907,24 @@ define <4 x i32> @non_splat_minus_one_divisor_2(<4 x i32> %A) {
 ;
 ; CHECK-GI-LABEL: non_splat_minus_one_divisor_2:
 ; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
-; CHECK-GI-NEXT:    adrp x9, .LCPI27_0
-; CHECK-GI-NEXT:    cmlt v3.4s, v0.4s, #0
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    ldr q2, [x9, :lo12:.LCPI27_0]
-; CHECK-GI-NEXT:    fmov s4, w8
+; CHECK-GI-NEXT:    adrp x8, .LCPI27_2
+; CHECK-GI-NEXT:    cmlt v2.4s, v0.4s, #0
 ; CHECK-GI-NEXT:    adrp x9, .LCPI27_1
-; CHECK-GI-NEXT:    neg v2.4s, v2.4s
-; CHECK-GI-NEXT:    mov v1.s[1], w8
-; CHECK-GI-NEXT:    mov v4.s[1], wzr
-; CHECK-GI-NEXT:    ushl v2.4s, v3.4s, v2.4s
+; CHECK-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI27_2]
+; CHECK-GI-NEXT:    adrp x8, .LCPI27_3
 ; CHECK-GI-NEXT:    ldr q3, [x9, :lo12:.LCPI27_1]
-; CHECK-GI-NEXT:    mov v1.s[2], wzr
-; CHECK-GI-NEXT:    mov v4.s[2], wzr
-; CHECK-GI-NEXT:    neg v3.4s, v3.4s
-; CHECK-GI-NEXT:    add v2.4s, v0.4s, v2.4s
-; CHECK-GI-NEXT:    mov v1.s[3], wzr
-; CHECK-GI-NEXT:    sshl v2.4s, v2.4s, v3.4s
-; CHECK-GI-NEXT:    mov v4.s[3], w8
-; CHECK-GI-NEXT:    shl v1.4s, v1.4s, #31
-; CHECK-GI-NEXT:    cmlt v1.4s, v1.4s, #0
-; CHECK-GI-NEXT:    bif v0.16b, v2.16b, v1.16b
-; CHECK-GI-NEXT:    shl v1.4s, v4.4s, #31
+; CHECK-GI-NEXT:    neg v1.4s, v1.4s
+; CHECK-GI-NEXT:    shl v3.4s, v3.4s, #31
+; CHECK-GI-NEXT:    ushl v1.4s, v2.4s, v1.4s
+; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI27_3]
+; CHECK-GI-NEXT:    adrp x8, .LCPI27_0
+; CHECK-GI-NEXT:    neg v2.4s, v2.4s
+; CHECK-GI-NEXT:    add v1.4s, v0.4s, v1.4s
+; CHECK-GI-NEXT:    sshl v1.4s, v1.4s, v2.4s
+; CHECK-GI-NEXT:    cmlt v2.4s, v3.4s, #0
+; CHECK-GI-NEXT:    ldr q3, [x8, :lo12:.LCPI27_0]
+; CHECK-GI-NEXT:    bif v0.16b, v1.16b, v2.16b
+; CHECK-GI-NEXT:    shl v1.4s, v3.4s, #31
 ; CHECK-GI-NEXT:    cmlt v1.4s, v1.4s, #0
 ; CHECK-GI-NEXT:    neg v2.4s, v0.4s
 ; CHECK-GI-NEXT:    bit v0.16b, v2.16b, v1.16b

--- a/llvm/test/CodeGen/AArch64/cttz.ll
+++ b/llvm/test/CodeGen/AArch64/cttz.ll
@@ -103,16 +103,12 @@ define void @v4i8(ptr %p1) {
 ;
 ; CHECK-GI-LABEL: v4i8:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #255 // =0xff
 ; CHECK-GI-NEXT:    ldr s1, [x0]
-; CHECK-GI-NEXT:    fmov s0, w8
+; CHECK-GI-NEXT:    movi d0, #0xff00ff00ff00ff
 ; CHECK-GI-NEXT:    zip1 v2.8b, v1.8b, v1.8b
-; CHECK-GI-NEXT:    mov v0.h[1], w8
-; CHECK-GI-NEXT:    mov v0.h[2], w8
-; CHECK-GI-NEXT:    mov v0.h[3], w8
-; CHECK-GI-NEXT:    eor v2.8b, v2.8b, v0.8b
-; CHECK-GI-NEXT:    uaddw v0.8h, v0.8h, v1.8b
-; CHECK-GI-NEXT:    and v0.8b, v2.8b, v0.8b
+; CHECK-GI-NEXT:    uaddw v1.8h, v0.8h, v1.8b
+; CHECK-GI-NEXT:    eor v0.8b, v2.8b, v0.8b
+; CHECK-GI-NEXT:    and v0.8b, v0.8b, v1.8b
 ; CHECK-GI-NEXT:    uzp1 v0.8b, v0.8b, v0.8b
 ; CHECK-GI-NEXT:    cnt v0.8b, v0.8b
 ; CHECK-GI-NEXT:    str s0, [x0]
@@ -202,16 +198,14 @@ define void @v2i16(ptr %p1) {
 ;
 ; CHECK-GI-LABEL: v2i16:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #65535 // =0xffff
-; CHECK-GI-NEXT:    ld1 { v0.h }[0], [x0]
-; CHECK-GI-NEXT:    ldr h1, [x0, #2]
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    mov v0.s[1], v1.s[0]
-; CHECK-GI-NEXT:    mov v2.s[1], w8
+; CHECK-GI-NEXT:    ld1 { v1.h }[0], [x0]
+; CHECK-GI-NEXT:    ldr h2, [x0, #2]
+; CHECK-GI-NEXT:    movi d0, #0x00ffff0000ffff
 ; CHECK-GI-NEXT:    add x8, x0, #2
-; CHECK-GI-NEXT:    eor v1.8b, v0.8b, v2.8b
-; CHECK-GI-NEXT:    add v0.2s, v0.2s, v2.2s
-; CHECK-GI-NEXT:    and v0.8b, v1.8b, v0.8b
+; CHECK-GI-NEXT:    mov v1.s[1], v2.s[0]
+; CHECK-GI-NEXT:    eor v2.8b, v1.8b, v0.8b
+; CHECK-GI-NEXT:    add v0.2s, v1.2s, v0.2s
+; CHECK-GI-NEXT:    and v0.8b, v2.8b, v0.8b
 ; CHECK-GI-NEXT:    uzp1 v0.4h, v0.4h, v0.4h
 ; CHECK-GI-NEXT:    cnt v0.8b, v0.8b
 ; CHECK-GI-NEXT:    uaddlp v0.4h, v0.8b

--- a/llvm/test/CodeGen/AArch64/fcvt-i256.ll
+++ b/llvm/test/CodeGen/AArch64/fcvt-i256.ll
@@ -672,9 +672,7 @@ define i256 @f32_to_s256(float %val) {
 ; CHECK-GI-NEXT:  // %bb.2: // %fp-to-i-if-exp.small
 ; CHECK-GI-NEXT:    mov w12, #150 // =0x96
 ; CHECK-GI-NEXT:    umulh x15, x9, xzr
-; CHECK-GI-NEXT:    and x17, xzr, #0x1
 ; CHECK-GI-NEXT:    sub w11, w12, w11
-; CHECK-GI-NEXT:    and x18, xzr, #0x1
 ; CHECK-GI-NEXT:    lsr w10, w10, w11
 ; CHECK-GI-NEXT:    umulh x12, x8, xzr
 ; CHECK-GI-NEXT:    umulh x11, x10, x8
@@ -683,22 +681,16 @@ define i256 @f32_to_s256(float %val) {
 ; CHECK-GI-NEXT:    smull x16, w10, w9
 ; CHECK-GI-NEXT:    smull x0, w10, w8
 ; CHECK-GI-NEXT:    adds x1, x11, x14
-; CHECK-GI-NEXT:    add x11, x17, x18
-; CHECK-GI-NEXT:    add x14, x12, x13
-; CHECK-GI-NEXT:    cset w17, hs
-; CHECK-GI-NEXT:    adds x14, x14, x16
-; CHECK-GI-NEXT:    and x16, xzr, #0x1
-; CHECK-GI-NEXT:    and x17, x17, #0x1
-; CHECK-GI-NEXT:    add x12, x12, x15
-; CHECK-GI-NEXT:    cset w15, hs
-; CHECK-GI-NEXT:    add x16, x17, x16
-; CHECK-GI-NEXT:    and x17, xzr, #0x1
+; CHECK-GI-NEXT:    add x14, x12, x15
 ; CHECK-GI-NEXT:    add x12, x12, x13
-; CHECK-GI-NEXT:    smaddl x9, w10, w9, x12
-; CHECK-GI-NEXT:    and x12, x15, #0x1
-; CHECK-GI-NEXT:    add x11, x11, x17
-; CHECK-GI-NEXT:    adds x2, x14, x16
-; CHECK-GI-NEXT:    add x8, x11, x12
+; CHECK-GI-NEXT:    cset w11, hs
+; CHECK-GI-NEXT:    adds x12, x12, x16
+; CHECK-GI-NEXT:    add x13, x14, x13
+; CHECK-GI-NEXT:    and x11, x11, #0x1
+; CHECK-GI-NEXT:    smaddl x9, w10, w9, x13
+; CHECK-GI-NEXT:    cset w13, hs
+; CHECK-GI-NEXT:    adds x2, x12, x11
+; CHECK-GI-NEXT:    and x8, x13, #0x1
 ; CHECK-GI-NEXT:    cset w10, hs
 ; CHECK-GI-NEXT:    and x10, x10, #0x1
 ; CHECK-GI-NEXT:    add x8, x9, x8
@@ -1042,36 +1034,28 @@ define i256 @f64_to_s256(double %val) {
 ; CHECK-GI-NEXT:  // %bb.2: // %fp-to-i-if-exp.small
 ; CHECK-GI-NEXT:    mov w12, #1075 // =0x433
 ; CHECK-GI-NEXT:    umulh x13, x8, xzr
-; CHECK-GI-NEXT:    and x16, xzr, #0x1
 ; CHECK-GI-NEXT:    sub x11, x12, x11
-; CHECK-GI-NEXT:    and x17, xzr, #0x1
 ; CHECK-GI-NEXT:    lsr x10, x10, x11
 ; CHECK-GI-NEXT:    umulh x14, x9, xzr
 ; CHECK-GI-NEXT:    umulh x11, x10, x8
 ; CHECK-GI-NEXT:    mul x12, x10, x9
-; CHECK-GI-NEXT:    add x14, x13, x14
 ; CHECK-GI-NEXT:    umulh x15, x10, x9
 ; CHECK-GI-NEXT:    mul x0, x10, x8
 ; CHECK-GI-NEXT:    adds x1, x11, x12
-; CHECK-GI-NEXT:    add x11, x13, x15
-; CHECK-GI-NEXT:    add x13, x14, x15
+; CHECK-GI-NEXT:    add x11, x13, x14
 ; CHECK-GI-NEXT:    cset w14, hs
-; CHECK-GI-NEXT:    madd x9, x10, x9, x13
-; CHECK-GI-NEXT:    adds x11, x11, x12
-; CHECK-GI-NEXT:    and x12, x14, #0x1
-; CHECK-GI-NEXT:    and x13, xzr, #0x1
-; CHECK-GI-NEXT:    cset w14, hs
-; CHECK-GI-NEXT:    add x12, x12, x16
-; CHECK-GI-NEXT:    add x13, x17, x13
-; CHECK-GI-NEXT:    and x15, xzr, #0x1
-; CHECK-GI-NEXT:    and x8, x14, #0x1
-; CHECK-GI-NEXT:    add x10, x13, x15
-; CHECK-GI-NEXT:    adds x2, x11, x12
+; CHECK-GI-NEXT:    add x13, x13, x15
+; CHECK-GI-NEXT:    add x11, x11, x15
+; CHECK-GI-NEXT:    madd x9, x10, x9, x11
+; CHECK-GI-NEXT:    and x11, x14, #0x1
+; CHECK-GI-NEXT:    adds x12, x13, x12
+; CHECK-GI-NEXT:    cset w13, hs
+; CHECK-GI-NEXT:    adds x2, x12, x11
+; CHECK-GI-NEXT:    cset w8, hs
+; CHECK-GI-NEXT:    and x10, x13, #0x1
+; CHECK-GI-NEXT:    and x8, x8, #0x1
 ; CHECK-GI-NEXT:    add x8, x10, x8
-; CHECK-GI-NEXT:    cset w10, hs
-; CHECK-GI-NEXT:    and x10, x10, #0x1
-; CHECK-GI-NEXT:    add x8, x9, x8
-; CHECK-GI-NEXT:    add x3, x8, x10
+; CHECK-GI-NEXT:    add x3, x9, x8
 ; CHECK-GI-NEXT:    ret
 ; CHECK-GI-NEXT:  .LBB6_3: // %fp-to-i-if-exp.large
 ; CHECK-GI-NEXT:    sub x11, x11, #1075
@@ -1432,9 +1416,7 @@ define i256 @f32_to_s256_sat(float %val) {
 ; CHECK-GI-NEXT:  // %bb.4: // %fp-to-i-if-exp.small
 ; CHECK-GI-NEXT:    mov w12, #150 // =0x96
 ; CHECK-GI-NEXT:    umulh x15, x9, xzr
-; CHECK-GI-NEXT:    and x17, xzr, #0x1
 ; CHECK-GI-NEXT:    sub w11, w12, w11
-; CHECK-GI-NEXT:    and x18, xzr, #0x1
 ; CHECK-GI-NEXT:    lsr w10, w10, w11
 ; CHECK-GI-NEXT:    umulh x12, x8, xzr
 ; CHECK-GI-NEXT:    umulh x11, x10, x8
@@ -1443,22 +1425,16 @@ define i256 @f32_to_s256_sat(float %val) {
 ; CHECK-GI-NEXT:    smull x16, w10, w9
 ; CHECK-GI-NEXT:    smull x0, w10, w8
 ; CHECK-GI-NEXT:    adds x1, x11, x14
-; CHECK-GI-NEXT:    add x11, x17, x18
-; CHECK-GI-NEXT:    add x14, x12, x13
-; CHECK-GI-NEXT:    cset w17, hs
-; CHECK-GI-NEXT:    adds x14, x14, x16
-; CHECK-GI-NEXT:    and x16, xzr, #0x1
-; CHECK-GI-NEXT:    and x17, x17, #0x1
-; CHECK-GI-NEXT:    add x12, x12, x15
-; CHECK-GI-NEXT:    cset w15, hs
-; CHECK-GI-NEXT:    add x16, x17, x16
-; CHECK-GI-NEXT:    and x17, xzr, #0x1
+; CHECK-GI-NEXT:    add x14, x12, x15
 ; CHECK-GI-NEXT:    add x12, x12, x13
-; CHECK-GI-NEXT:    smaddl x9, w10, w9, x12
-; CHECK-GI-NEXT:    and x12, x15, #0x1
-; CHECK-GI-NEXT:    add x11, x11, x17
-; CHECK-GI-NEXT:    adds x2, x14, x16
-; CHECK-GI-NEXT:    add x8, x11, x12
+; CHECK-GI-NEXT:    cset w11, hs
+; CHECK-GI-NEXT:    adds x12, x12, x16
+; CHECK-GI-NEXT:    add x13, x14, x13
+; CHECK-GI-NEXT:    and x11, x11, #0x1
+; CHECK-GI-NEXT:    smaddl x9, w10, w9, x13
+; CHECK-GI-NEXT:    cset w13, hs
+; CHECK-GI-NEXT:    adds x2, x12, x11
+; CHECK-GI-NEXT:    and x8, x13, #0x1
 ; CHECK-GI-NEXT:    cset w10, hs
 ; CHECK-GI-NEXT:    and x10, x10, #0x1
 ; CHECK-GI-NEXT:    add x8, x9, x8
@@ -1868,36 +1844,28 @@ define i256 @f64_to_s256_sat(double %val) {
 ; CHECK-GI-NEXT:  // %bb.4: // %fp-to-i-if-exp.small
 ; CHECK-GI-NEXT:    mov w12, #1075 // =0x433
 ; CHECK-GI-NEXT:    umulh x13, x8, xzr
-; CHECK-GI-NEXT:    and x16, xzr, #0x1
 ; CHECK-GI-NEXT:    sub x11, x12, x11
-; CHECK-GI-NEXT:    and x17, xzr, #0x1
 ; CHECK-GI-NEXT:    lsr x10, x10, x11
 ; CHECK-GI-NEXT:    umulh x14, x9, xzr
 ; CHECK-GI-NEXT:    umulh x11, x10, x8
 ; CHECK-GI-NEXT:    mul x12, x10, x9
-; CHECK-GI-NEXT:    add x14, x13, x14
 ; CHECK-GI-NEXT:    umulh x15, x10, x9
 ; CHECK-GI-NEXT:    mul x0, x10, x8
 ; CHECK-GI-NEXT:    adds x1, x11, x12
-; CHECK-GI-NEXT:    add x11, x13, x15
-; CHECK-GI-NEXT:    add x13, x14, x15
+; CHECK-GI-NEXT:    add x11, x13, x14
 ; CHECK-GI-NEXT:    cset w14, hs
-; CHECK-GI-NEXT:    madd x9, x10, x9, x13
-; CHECK-GI-NEXT:    adds x11, x11, x12
-; CHECK-GI-NEXT:    and x12, x14, #0x1
-; CHECK-GI-NEXT:    and x13, xzr, #0x1
-; CHECK-GI-NEXT:    cset w14, hs
-; CHECK-GI-NEXT:    add x12, x12, x16
-; CHECK-GI-NEXT:    add x13, x17, x13
-; CHECK-GI-NEXT:    and x15, xzr, #0x1
-; CHECK-GI-NEXT:    and x8, x14, #0x1
-; CHECK-GI-NEXT:    add x10, x13, x15
-; CHECK-GI-NEXT:    adds x2, x11, x12
+; CHECK-GI-NEXT:    add x13, x13, x15
+; CHECK-GI-NEXT:    add x11, x11, x15
+; CHECK-GI-NEXT:    madd x9, x10, x9, x11
+; CHECK-GI-NEXT:    and x11, x14, #0x1
+; CHECK-GI-NEXT:    adds x12, x13, x12
+; CHECK-GI-NEXT:    cset w13, hs
+; CHECK-GI-NEXT:    adds x2, x12, x11
+; CHECK-GI-NEXT:    cset w8, hs
+; CHECK-GI-NEXT:    and x10, x13, #0x1
+; CHECK-GI-NEXT:    and x8, x8, #0x1
 ; CHECK-GI-NEXT:    add x8, x10, x8
-; CHECK-GI-NEXT:    cset w10, hs
-; CHECK-GI-NEXT:    and x10, x10, #0x1
-; CHECK-GI-NEXT:    add x8, x9, x8
-; CHECK-GI-NEXT:    add x3, x8, x10
+; CHECK-GI-NEXT:    add x3, x9, x8
 ; CHECK-GI-NEXT:    ret
 ; CHECK-GI-NEXT:  .LBB10_5:
 ; CHECK-GI-NEXT:    mov x0, xzr

--- a/llvm/test/CodeGen/AArch64/is_fpclass.ll
+++ b/llvm/test/CodeGen/AArch64/is_fpclass.ll
@@ -395,15 +395,10 @@ define <4 x i1> @isfinite_v4h(<4 x half> %x) {
 ;
 ; CHECK-GI-LABEL: isfinite_v4h:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    movi d1, #0000000000000000
-; CHECK-GI-NEXT:    mvni v2.4h, #128, lsl #8
-; CHECK-GI-NEXT:    movi v3.4h, #124, lsl #8
-; CHECK-GI-NEXT:    and v0.8b, v0.8b, v2.8b
-; CHECK-GI-NEXT:    mov v1.h[1], wzr
-; CHECK-GI-NEXT:    cmhi v0.4h, v3.4h, v0.4h
-; CHECK-GI-NEXT:    mov v1.h[2], wzr
-; CHECK-GI-NEXT:    mov v1.h[3], wzr
-; CHECK-GI-NEXT:    orr v0.8b, v1.8b, v0.8b
+; CHECK-GI-NEXT:    mvni v1.4h, #128, lsl #8
+; CHECK-GI-NEXT:    movi v2.4h, #124, lsl #8
+; CHECK-GI-NEXT:    and v0.8b, v0.8b, v1.8b
+; CHECK-GI-NEXT:    cmhi v0.4h, v2.4h, v0.4h
 ; CHECK-GI-NEXT:    ret
 ;
 ; CHECK-NOFP-LABEL: isfinite_v4h:
@@ -436,16 +431,11 @@ define <4 x i1> @not_isfinite_v4h(<4 x half> %x) {
 ;
 ; CHECK-GI-LABEL: not_isfinite_v4h:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    movi d1, #0000000000000000
-; CHECK-GI-NEXT:    mvni v2.4h, #128, lsl #8
-; CHECK-GI-NEXT:    movi v3.4h, #124, lsl #8
-; CHECK-GI-NEXT:    and v0.8b, v0.8b, v2.8b
-; CHECK-GI-NEXT:    mov v1.h[1], wzr
-; CHECK-GI-NEXT:    cmeq v2.4h, v0.4h, v3.4h
-; CHECK-GI-NEXT:    cmhi v0.4h, v0.4h, v3.4h
-; CHECK-GI-NEXT:    mov v1.h[2], wzr
-; CHECK-GI-NEXT:    orr v0.8b, v2.8b, v0.8b
-; CHECK-GI-NEXT:    mov v1.h[3], wzr
+; CHECK-GI-NEXT:    mvni v1.4h, #128, lsl #8
+; CHECK-GI-NEXT:    movi v2.4h, #124, lsl #8
+; CHECK-GI-NEXT:    and v0.8b, v0.8b, v1.8b
+; CHECK-GI-NEXT:    cmeq v1.4h, v0.4h, v2.4h
+; CHECK-GI-NEXT:    cmhi v0.4h, v0.4h, v2.4h
 ; CHECK-GI-NEXT:    orr v0.8b, v1.8b, v0.8b
 ; CHECK-GI-NEXT:    ret
 ;
@@ -482,17 +472,12 @@ define <4 x i1> @isfinite_v4f(<4 x float> %x) {
 ;
 ; CHECK-GI-LABEL: isfinite_v4f:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    movi d1, #0000000000000000
-; CHECK-GI-NEXT:    mvni v2.4s, #127, msl #16
-; CHECK-GI-NEXT:    mvni v3.4s, #128, lsl #24
-; CHECK-GI-NEXT:    fneg v2.4s, v2.4s
-; CHECK-GI-NEXT:    and v0.16b, v0.16b, v3.16b
-; CHECK-GI-NEXT:    mov v1.h[1], wzr
-; CHECK-GI-NEXT:    cmhi v0.4s, v2.4s, v0.4s
-; CHECK-GI-NEXT:    mov v1.h[2], wzr
+; CHECK-GI-NEXT:    mvni v1.4s, #127, msl #16
+; CHECK-GI-NEXT:    mvni v2.4s, #128, lsl #24
+; CHECK-GI-NEXT:    fneg v1.4s, v1.4s
+; CHECK-GI-NEXT:    and v0.16b, v0.16b, v2.16b
+; CHECK-GI-NEXT:    cmhi v0.4s, v1.4s, v0.4s
 ; CHECK-GI-NEXT:    xtn v0.4h, v0.4s
-; CHECK-GI-NEXT:    mov v1.h[3], wzr
-; CHECK-GI-NEXT:    orr v0.8b, v1.8b, v0.8b
 ; CHECK-GI-NEXT:    ret
 ;
 ; CHECK-NOFP-LABEL: isfinite_v4f:
@@ -526,20 +511,13 @@ define <4 x i1> @not_isfinite_v4f(<4 x float> %x) {
 ;
 ; CHECK-GI-LABEL: not_isfinite_v4f:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    movi d1, #0000000000000000
-; CHECK-GI-NEXT:    mvni v2.4s, #127, msl #16
-; CHECK-GI-NEXT:    mvni v3.4s, #128, lsl #24
-; CHECK-GI-NEXT:    fneg v2.4s, v2.4s
-; CHECK-GI-NEXT:    and v0.16b, v0.16b, v3.16b
-; CHECK-GI-NEXT:    mov v1.h[1], wzr
-; CHECK-GI-NEXT:    cmeq v3.4s, v0.4s, v2.4s
-; CHECK-GI-NEXT:    cmhi v0.4s, v0.4s, v2.4s
-; CHECK-GI-NEXT:    mov v1.h[2], wzr
-; CHECK-GI-NEXT:    xtn v3.4h, v3.4s
-; CHECK-GI-NEXT:    xtn v0.4h, v0.4s
-; CHECK-GI-NEXT:    mov v1.h[3], wzr
-; CHECK-GI-NEXT:    orr v1.8b, v1.8b, v3.8b
-; CHECK-GI-NEXT:    orr v0.8b, v1.8b, v0.8b
+; CHECK-GI-NEXT:    mvni v1.4s, #127, msl #16
+; CHECK-GI-NEXT:    mvni v2.4s, #128, lsl #24
+; CHECK-GI-NEXT:    fneg v1.4s, v1.4s
+; CHECK-GI-NEXT:    and v0.16b, v0.16b, v2.16b
+; CHECK-GI-NEXT:    cmeq v2.4s, v0.4s, v1.4s
+; CHECK-GI-NEXT:    cmhi v0.4s, v0.4s, v1.4s
+; CHECK-GI-NEXT:    addhn v0.4h, v2.4s, v0.4s
 ; CHECK-GI-NEXT:    ret
 ;
 ; CHECK-NOFP-LABEL: not_isfinite_v4f:

--- a/llvm/test/CodeGen/AArch64/neon-anyof-splat.ll
+++ b/llvm/test/CodeGen/AArch64/neon-anyof-splat.ll
@@ -69,6 +69,7 @@ define <4 x i8> @any_of_select_v4i8(<4 x i32> %mask, <4 x i8> %a, <4 x i8> %b) {
 ; CHECK-GI-NEXT:    sub sp, sp, #16
 ; CHECK-GI-NEXT:    .cfi_def_cfa_offset 16
 ; CHECK-GI-NEXT:    cmlt v0.4s, v0.4s, #0
+; CHECK-GI-NEXT:    movi d3, #0xff00ff00ff00ff
 ; CHECK-GI-NEXT:    mov w8, v0.s[1]
 ; CHECK-GI-NEXT:    mov w9, v0.s[2]
 ; CHECK-GI-NEXT:    fmov w11, s0
@@ -79,18 +80,13 @@ define <4 x i8> @any_of_select_v4i8(<4 x i32> %mask, <4 x i8> %a, <4 x i8> %b) {
 ; CHECK-GI-NEXT:    and w9, w10, #0x1
 ; CHECK-GI-NEXT:    orr w8, w11, w8, lsl #2
 ; CHECK-GI-NEXT:    orr w8, w8, w9, lsl #3
-; CHECK-GI-NEXT:    mov w9, #255 // =0xff
-; CHECK-GI-NEXT:    fmov s3, w9
 ; CHECK-GI-NEXT:    strb w8, [sp, #15]
 ; CHECK-GI-NEXT:    and w8, w8, #0xff
 ; CHECK-GI-NEXT:    tst w8, #0xf
 ; CHECK-GI-NEXT:    cset w8, eq
-; CHECK-GI-NEXT:    mov v3.h[1], w9
 ; CHECK-GI-NEXT:    sbfx w8, w8, #0, #1
 ; CHECK-GI-NEXT:    fmov s0, w8
-; CHECK-GI-NEXT:    mov v3.h[2], w9
 ; CHECK-GI-NEXT:    uzp1 v0.8b, v0.8b, v0.8b
-; CHECK-GI-NEXT:    mov v3.h[3], w9
 ; CHECK-GI-NEXT:    dup v0.8b, v0.b[0]
 ; CHECK-GI-NEXT:    zip1 v0.8b, v0.8b, v0.8b
 ; CHECK-GI-NEXT:    eor v3.8b, v0.8b, v3.8b

--- a/llvm/test/CodeGen/AArch64/neon-bitwise-instructions.ll
+++ b/llvm/test/CodeGen/AArch64/neon-bitwise-instructions.ll
@@ -1126,11 +1126,8 @@ define <4 x i16> @vselect_constant_cond_zero_v4i16(<4 x i16> %a) {
 ;
 ; CHECK-GI-LABEL: vselect_constant_cond_zero_v4i16:
 ; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    mov v1.h[1], wzr
-; CHECK-GI-NEXT:    mov v1.h[2], wzr
-; CHECK-GI-NEXT:    mov v1.h[3], w8
+; CHECK-GI-NEXT:    adrp x8, .LCPI84_0
+; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI84_0]
 ; CHECK-GI-NEXT:    shl v1.4h, v1.4h, #15
 ; CHECK-GI-NEXT:    cmlt v1.4h, v1.4h, #0
 ; CHECK-GI-NEXT:    and v0.8b, v0.8b, v1.8b
@@ -1149,11 +1146,8 @@ define <4 x i32> @vselect_constant_cond_zero_v4i32(<4 x i32> %a) {
 ;
 ; CHECK-GI-LABEL: vselect_constant_cond_zero_v4i32:
 ; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    mov v1.s[1], wzr
-; CHECK-GI-NEXT:    mov v1.s[2], wzr
-; CHECK-GI-NEXT:    mov v1.s[3], w8
+; CHECK-GI-NEXT:    adrp x8, .LCPI85_0
+; CHECK-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI85_0]
 ; CHECK-GI-NEXT:    shl v1.4s, v1.4s, #31
 ; CHECK-GI-NEXT:    cmlt v1.4s, v1.4s, #0
 ; CHECK-GI-NEXT:    and v0.16b, v0.16b, v1.16b
@@ -1190,11 +1184,8 @@ define <4 x i16> @vselect_constant_cond_v4i16(<4 x i16> %a, <4 x i16> %b) {
 ;
 ; CHECK-GI-LABEL: vselect_constant_cond_v4i16:
 ; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    mov v2.h[1], wzr
-; CHECK-GI-NEXT:    mov v2.h[2], wzr
-; CHECK-GI-NEXT:    mov v2.h[3], w8
+; CHECK-GI-NEXT:    adrp x8, .LCPI87_0
+; CHECK-GI-NEXT:    ldr d2, [x8, :lo12:.LCPI87_0]
 ; CHECK-GI-NEXT:    shl v2.4h, v2.4h, #15
 ; CHECK-GI-NEXT:    cmlt v2.4h, v2.4h, #0
 ; CHECK-GI-NEXT:    bif v0.8b, v1.8b, v2.8b
@@ -1213,11 +1204,8 @@ define <4 x i32> @vselect_constant_cond_v4i32(<4 x i32> %a, <4 x i32> %b) {
 ;
 ; CHECK-GI-LABEL: vselect_constant_cond_v4i32:
 ; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    mov v2.s[1], wzr
-; CHECK-GI-NEXT:    mov v2.s[2], wzr
-; CHECK-GI-NEXT:    mov v2.s[3], w8
+; CHECK-GI-NEXT:    adrp x8, .LCPI88_0
+; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI88_0]
 ; CHECK-GI-NEXT:    shl v2.4s, v2.4s, #31
 ; CHECK-GI-NEXT:    cmlt v2.4s, v2.4s, #0
 ; CHECK-GI-NEXT:    bif v0.16b, v1.16b, v2.16b

--- a/llvm/test/CodeGen/AArch64/neon-compare-instructions.ll
+++ b/llvm/test/CodeGen/AArch64/neon-compare-instructions.ll
@@ -2545,8 +2545,7 @@ define <4 x i32> @fcmal4xfloat(<4 x float> %A, <4 x float> %B) {
 ;
 ; CHECK-GI-LABEL: fcmal4xfloat:
 ; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    movi v0.2s, #1
-; CHECK-GI-NEXT:    mov v0.d[1], v0.d[0]
+; CHECK-GI-NEXT:    movi v0.4s, #1
 ; CHECK-GI-NEXT:    shl v0.4s, v0.4s, #31
 ; CHECK-GI-NEXT:    cmlt v0.4s, v0.4s, #0
 ; CHECK-GI-NEXT:    ret
@@ -2583,19 +2582,10 @@ define <2 x i32> @fcmnv2xfloat(<2 x float> %A, <2 x float> %B) {
 }
 
 define <4 x i32> @fcmnv4xfloat(<4 x float> %A, <4 x float> %B) {
-; CHECK-SD-LABEL: fcmnv4xfloat:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    movi v0.2d, #0000000000000000
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: fcmnv4xfloat:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    movi d0, #0000000000000000
-; CHECK-GI-NEXT:    mov v0.s[1], wzr
-; CHECK-GI-NEXT:    mov v0.d[1], v0.d[0]
-; CHECK-GI-NEXT:    shl v0.4s, v0.4s, #31
-; CHECK-GI-NEXT:    cmlt v0.4s, v0.4s, #0
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: fcmnv4xfloat:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    movi v0.2d, #0000000000000000
+; CHECK-NEXT:    ret
   %tmp3 = fcmp false <4 x float> %A, %B
   %tmp4 = sext <4 x i1> %tmp3 to <4 x i32>
   ret <4 x i32> %tmp4

--- a/llvm/test/CodeGen/AArch64/rem-by-const.ll
+++ b/llvm/test/CodeGen/AArch64/rem-by-const.ll
@@ -521,7 +521,6 @@ define i128 @ui128_7(i128 %a, i128 %b) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    mov x8, #18725 // =0x4925
 ; CHECK-GI-NEXT:    mov x10, #9362 // =0x2492
-; CHECK-GI-NEXT:    umulh x16, x0, xzr
 ; CHECK-GI-NEXT:    movk x8, #9362, lsl #16
 ; CHECK-GI-NEXT:    movk x10, #37449, lsl #16
 ; CHECK-GI-NEXT:    movk x8, #37449, lsl #32
@@ -536,35 +535,30 @@ define i128 @ui128_7(i128 %a, i128 %b) {
 ; CHECK-GI-NEXT:    umulh x14, x0, x10
 ; CHECK-GI-NEXT:    cset w11, hs
 ; CHECK-GI-NEXT:    cmn x9, x12
-; CHECK-GI-NEXT:    and x11, x11, #0x1
 ; CHECK-GI-NEXT:    mul x15, x1, x10
-; CHECK-GI-NEXT:    cset w9, hs
-; CHECK-GI-NEXT:    and x9, x9, #0x1
 ; CHECK-GI-NEXT:    umulh x8, xzr, x8
-; CHECK-GI-NEXT:    add x9, x11, x9
 ; CHECK-GI-NEXT:    add x12, x13, x14
-; CHECK-GI-NEXT:    and x13, xzr, #0x1
-; CHECK-GI-NEXT:    and x14, xzr, #0x1
-; CHECK-GI-NEXT:    umulh x10, x1, x10
-; CHECK-GI-NEXT:    add x11, x13, x14
-; CHECK-GI-NEXT:    adds x12, x12, x15
-; CHECK-GI-NEXT:    cset w13, hs
-; CHECK-GI-NEXT:    adds x9, x12, x9
-; CHECK-GI-NEXT:    and x12, xzr, #0x1
-; CHECK-GI-NEXT:    and x13, x13, #0x1
-; CHECK-GI-NEXT:    add x11, x11, x12
+; CHECK-GI-NEXT:    umulh x9, x1, x10
+; CHECK-GI-NEXT:    and x10, x11, #0x1
+; CHECK-GI-NEXT:    cset w11, hs
+; CHECK-GI-NEXT:    and x11, x11, #0x1
+; CHECK-GI-NEXT:    umulh x13, x0, xzr
+; CHECK-GI-NEXT:    add x10, x10, x11
+; CHECK-GI-NEXT:    adds x11, x12, x15
 ; CHECK-GI-NEXT:    cset w12, hs
-; CHECK-GI-NEXT:    add x11, x11, x13
+; CHECK-GI-NEXT:    adds x10, x11, x10
+; CHECK-GI-NEXT:    cset w11, hs
 ; CHECK-GI-NEXT:    and x12, x12, #0x1
-; CHECK-GI-NEXT:    add x8, x8, x10
-; CHECK-GI-NEXT:    add x10, x11, x12
-; CHECK-GI-NEXT:    add x8, x8, x16
-; CHECK-GI-NEXT:    add x8, x8, x10
-; CHECK-GI-NEXT:    subs x10, x0, x9
+; CHECK-GI-NEXT:    and x11, x11, #0x1
+; CHECK-GI-NEXT:    add x8, x8, x9
+; CHECK-GI-NEXT:    add x9, x12, x11
+; CHECK-GI-NEXT:    add x8, x8, x13
+; CHECK-GI-NEXT:    add x8, x8, x9
+; CHECK-GI-NEXT:    subs x9, x0, x10
 ; CHECK-GI-NEXT:    sbc x11, x1, x8
-; CHECK-GI-NEXT:    extr x10, x11, x10, #1
+; CHECK-GI-NEXT:    extr x9, x11, x9, #1
 ; CHECK-GI-NEXT:    lsr x11, x11, #1
-; CHECK-GI-NEXT:    adds x9, x10, x9
+; CHECK-GI-NEXT:    adds x9, x9, x10
 ; CHECK-GI-NEXT:    mov x10, #-7 // =0xfffffffffffffff9
 ; CHECK-GI-NEXT:    adc x8, x11, x8
 ; CHECK-GI-NEXT:    extr x9, x8, x9, #2
@@ -621,34 +615,30 @@ define i128 @ui128_100(i128 %a, i128 %b) {
 ; CHECK-GI-NEXT:    umulh x14, x0, x10
 ; CHECK-GI-NEXT:    cset w11, hs
 ; CHECK-GI-NEXT:    cmn x9, x12
-; CHECK-GI-NEXT:    and x11, x11, #0x1
 ; CHECK-GI-NEXT:    mul x15, x1, x10
-; CHECK-GI-NEXT:    cset w9, hs
-; CHECK-GI-NEXT:    and x9, x9, #0x1
 ; CHECK-GI-NEXT:    umulh x8, xzr, x8
-; CHECK-GI-NEXT:    add x9, x11, x9
-; CHECK-GI-NEXT:    adds x11, x13, x14
-; CHECK-GI-NEXT:    and x14, xzr, #0x1
-; CHECK-GI-NEXT:    umulh x10, x1, x10
-; CHECK-GI-NEXT:    cset w12, hs
-; CHECK-GI-NEXT:    adds x11, x11, x15
-; CHECK-GI-NEXT:    and x12, x12, #0x1
+; CHECK-GI-NEXT:    umulh x9, x1, x10
+; CHECK-GI-NEXT:    and x10, x11, #0x1
+; CHECK-GI-NEXT:    cset w11, hs
+; CHECK-GI-NEXT:    and x11, x11, #0x1
+; CHECK-GI-NEXT:    adds x12, x13, x14
 ; CHECK-GI-NEXT:    umulh x13, x0, xzr
-; CHECK-GI-NEXT:    cset w15, hs
-; CHECK-GI-NEXT:    add x12, x12, x14
-; CHECK-GI-NEXT:    and x14, x15, #0x1
-; CHECK-GI-NEXT:    adds x9, x11, x9
-; CHECK-GI-NEXT:    add x11, x12, x14
-; CHECK-GI-NEXT:    and x12, xzr, #0x1
+; CHECK-GI-NEXT:    add x10, x10, x11
+; CHECK-GI-NEXT:    cset w11, hs
+; CHECK-GI-NEXT:    adds x12, x12, x15
+; CHECK-GI-NEXT:    and x11, x11, #0x1
 ; CHECK-GI-NEXT:    cset w14, hs
+; CHECK-GI-NEXT:    adds x10, x12, x10
+; CHECK-GI-NEXT:    and x12, x14, #0x1
+; CHECK-GI-NEXT:    cset w14, hs
+; CHECK-GI-NEXT:    add x8, x8, x9
 ; CHECK-GI-NEXT:    add x11, x11, x12
 ; CHECK-GI-NEXT:    and x12, x14, #0x1
-; CHECK-GI-NEXT:    add x8, x8, x10
-; CHECK-GI-NEXT:    add x10, x11, x12
+; CHECK-GI-NEXT:    add x9, x11, x12
 ; CHECK-GI-NEXT:    add x8, x8, x13
-; CHECK-GI-NEXT:    add x8, x8, x10
+; CHECK-GI-NEXT:    add x8, x8, x9
+; CHECK-GI-NEXT:    extr x9, x8, x10, #4
 ; CHECK-GI-NEXT:    mov x10, #-100 // =0xffffffffffffff9c
-; CHECK-GI-NEXT:    extr x9, x8, x9, #4
 ; CHECK-GI-NEXT:    lsr x8, x8, #4
 ; CHECK-GI-NEXT:    umulh x11, x9, x10
 ; CHECK-GI-NEXT:    mul x12, x9, x10
@@ -2845,110 +2835,98 @@ define <2 x i128> @uv2i128_7(<2 x i128> %d, <2 x i128> %e) {
 ;
 ; CHECK-GI-LABEL: uv2i128_7:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov x11, #18725 // =0x4925
+; CHECK-GI-NEXT:    mov x10, #18725 // =0x4925
 ; CHECK-GI-NEXT:    mov x8, #9362 // =0x2492
 ; CHECK-GI-NEXT:    umulh x18, x0, xzr
-; CHECK-GI-NEXT:    movk x11, #9362, lsl #16
+; CHECK-GI-NEXT:    movk x10, #9362, lsl #16
 ; CHECK-GI-NEXT:    movk x8, #37449, lsl #16
-; CHECK-GI-NEXT:    movk x11, #37449, lsl #32
+; CHECK-GI-NEXT:    movk x10, #37449, lsl #32
 ; CHECK-GI-NEXT:    movk x8, #18724, lsl #32
-; CHECK-GI-NEXT:    movk x11, #18724, lsl #48
+; CHECK-GI-NEXT:    movk x10, #18724, lsl #48
 ; CHECK-GI-NEXT:    movk x8, #9362, lsl #48
-; CHECK-GI-NEXT:    umulh x10, x0, x11
+; CHECK-GI-NEXT:    umulh x11, x0, x10
 ; CHECK-GI-NEXT:    mul x12, x0, x8
-; CHECK-GI-NEXT:    mul x13, x1, x11
-; CHECK-GI-NEXT:    umulh x14, x1, x11
-; CHECK-GI-NEXT:    adds x10, x10, x12
+; CHECK-GI-NEXT:    mul x13, x1, x10
+; CHECK-GI-NEXT:    umulh x14, x1, x10
+; CHECK-GI-NEXT:    adds x11, x11, x12
 ; CHECK-GI-NEXT:    umulh x15, x0, x8
-; CHECK-GI-NEXT:    cset w12, hs
-; CHECK-GI-NEXT:    cmn x10, x13
-; CHECK-GI-NEXT:    and x10, x12, #0x1
+; CHECK-GI-NEXT:    cset w6, hs
+; CHECK-GI-NEXT:    cmn x11, x13
+; CHECK-GI-NEXT:    and x13, x6, #0x1
 ; CHECK-GI-NEXT:    mul x16, x1, x8
-; CHECK-GI-NEXT:    cset w12, hs
-; CHECK-GI-NEXT:    and x12, x12, #0x1
-; CHECK-GI-NEXT:    umulh x4, x2, x11
-; CHECK-GI-NEXT:    add x10, x10, x12
+; CHECK-GI-NEXT:    cset w11, hs
+; CHECK-GI-NEXT:    and x11, x11, #0x1
+; CHECK-GI-NEXT:    umulh x4, x2, x10
+; CHECK-GI-NEXT:    add x11, x13, x11
 ; CHECK-GI-NEXT:    add x14, x14, x15
-; CHECK-GI-NEXT:    mul x13, x2, x8
-; CHECK-GI-NEXT:    adds x12, x14, x16
-; CHECK-GI-NEXT:    mul x15, x3, x11
-; CHECK-GI-NEXT:    cset w14, hs
-; CHECK-GI-NEXT:    adds x10, x12, x10
-; CHECK-GI-NEXT:    and x12, xzr, #0x1
-; CHECK-GI-NEXT:    cset w16, hs
-; CHECK-GI-NEXT:    and x14, x14, #0x1
-; CHECK-GI-NEXT:    umulh x9, xzr, x11
-; CHECK-GI-NEXT:    adds x13, x4, x13
-; CHECK-GI-NEXT:    and x4, xzr, #0x1
-; CHECK-GI-NEXT:    umulh x17, x1, x8
+; CHECK-GI-NEXT:    mul x5, x2, x8
+; CHECK-GI-NEXT:    adds x13, x14, x16
+; CHECK-GI-NEXT:    mul x12, x3, x10
+; CHECK-GI-NEXT:    cset w15, hs
+; CHECK-GI-NEXT:    adds x11, x13, x11
+; CHECK-GI-NEXT:    cset w13, hs
+; CHECK-GI-NEXT:    umulh x9, xzr, x10
+; CHECK-GI-NEXT:    and x13, x13, #0x1
+; CHECK-GI-NEXT:    adds x16, x4, x5
+; CHECK-GI-NEXT:    umulh x10, x3, x10
 ; CHECK-GI-NEXT:    cset w5, hs
-; CHECK-GI-NEXT:    add x12, x12, x4
-; CHECK-GI-NEXT:    cmn x13, x15
-; CHECK-GI-NEXT:    and x13, xzr, #0x1
-; CHECK-GI-NEXT:    umulh x11, x3, x11
+; CHECK-GI-NEXT:    cmn x16, x12
+; CHECK-GI-NEXT:    and x12, x15, #0x1
+; CHECK-GI-NEXT:    umulh x14, x2, x8
+; CHECK-GI-NEXT:    cset w15, hs
 ; CHECK-GI-NEXT:    add x12, x12, x13
-; CHECK-GI-NEXT:    add x12, x12, x14
-; CHECK-GI-NEXT:    and x14, x16, #0x1
-; CHECK-GI-NEXT:    and x16, x5, #0x1
-; CHECK-GI-NEXT:    umulh x6, x2, x8
-; CHECK-GI-NEXT:    add x12, x12, x14
-; CHECK-GI-NEXT:    add x15, x9, x17
-; CHECK-GI-NEXT:    and x17, xzr, #0x1
-; CHECK-GI-NEXT:    mul x13, x3, x8
-; CHECK-GI-NEXT:    add x14, x15, x18
-; CHECK-GI-NEXT:    cset w15, hs
+; CHECK-GI-NEXT:    and x13, x5, #0x1
 ; CHECK-GI-NEXT:    and x15, x15, #0x1
-; CHECK-GI-NEXT:    and x18, xzr, #0x1
-; CHECK-GI-NEXT:    add x12, x14, x12
+; CHECK-GI-NEXT:    umulh x17, x1, x8
+; CHECK-GI-NEXT:    add x13, x13, x15
+; CHECK-GI-NEXT:    mul x4, x3, x8
+; CHECK-GI-NEXT:    add x10, x10, x14
 ; CHECK-GI-NEXT:    umulh x8, x3, x8
-; CHECK-GI-NEXT:    add x15, x16, x15
-; CHECK-GI-NEXT:    and x16, xzr, #0x1
-; CHECK-GI-NEXT:    add x11, x11, x6
-; CHECK-GI-NEXT:    add x16, x16, x17
-; CHECK-GI-NEXT:    add x16, x16, x18
-; CHECK-GI-NEXT:    adds x11, x11, x13
-; CHECK-GI-NEXT:    umulh x13, x2, xzr
-; CHECK-GI-NEXT:    cset w17, hs
-; CHECK-GI-NEXT:    adds x11, x11, x15
-; CHECK-GI-NEXT:    and x17, x17, #0x1
+; CHECK-GI-NEXT:    add x15, x9, x17
+; CHECK-GI-NEXT:    umulh x14, x2, xzr
+; CHECK-GI-NEXT:    add x15, x15, x18
+; CHECK-GI-NEXT:    adds x10, x10, x4
+; CHECK-GI-NEXT:    add x12, x15, x12
+; CHECK-GI-NEXT:    cset w16, hs
+; CHECK-GI-NEXT:    adds x10, x10, x13
 ; CHECK-GI-NEXT:    cset w15, hs
+; CHECK-GI-NEXT:    and x13, x16, #0x1
 ; CHECK-GI-NEXT:    add x8, x9, x8
-; CHECK-GI-NEXT:    add x14, x16, x17
 ; CHECK-GI-NEXT:    and x15, x15, #0x1
-; CHECK-GI-NEXT:    subs x9, x0, x10
-; CHECK-GI-NEXT:    add x14, x14, x15
-; CHECK-GI-NEXT:    add x8, x8, x13
-; CHECK-GI-NEXT:    sbc x13, x1, x12
+; CHECK-GI-NEXT:    subs x9, x0, x11
+; CHECK-GI-NEXT:    add x13, x13, x15
 ; CHECK-GI-NEXT:    add x8, x8, x14
-; CHECK-GI-NEXT:    subs x14, x2, x11
-; CHECK-GI-NEXT:    extr x9, x13, x9, #1
+; CHECK-GI-NEXT:    sbc x14, x1, x12
+; CHECK-GI-NEXT:    add x8, x8, x13
+; CHECK-GI-NEXT:    subs x13, x2, x10
+; CHECK-GI-NEXT:    extr x9, x14, x9, #1
 ; CHECK-GI-NEXT:    sbc x15, x3, x8
-; CHECK-GI-NEXT:    lsr x13, x13, #1
-; CHECK-GI-NEXT:    extr x14, x15, x14, #1
-; CHECK-GI-NEXT:    adds x9, x9, x10
-; CHECK-GI-NEXT:    lsr x10, x15, #1
-; CHECK-GI-NEXT:    adc x12, x13, x12
-; CHECK-GI-NEXT:    mov w13, #7 // =0x7
-; CHECK-GI-NEXT:    adds x11, x14, x11
+; CHECK-GI-NEXT:    lsr x14, x14, #1
+; CHECK-GI-NEXT:    extr x13, x15, x13, #1
+; CHECK-GI-NEXT:    adds x9, x9, x11
+; CHECK-GI-NEXT:    lsr x11, x15, #1
+; CHECK-GI-NEXT:    adc x12, x14, x12
+; CHECK-GI-NEXT:    adds x10, x13, x10
 ; CHECK-GI-NEXT:    extr x9, x12, x9, #2
-; CHECK-GI-NEXT:    adc x8, x10, x8
-; CHECK-GI-NEXT:    lsr x10, x12, #2
-; CHECK-GI-NEXT:    extr x11, x8, x11, #2
+; CHECK-GI-NEXT:    mov w13, #7 // =0x7
+; CHECK-GI-NEXT:    adc x8, x11, x8
+; CHECK-GI-NEXT:    lsr x11, x12, #2
+; CHECK-GI-NEXT:    extr x10, x8, x10, #2
 ; CHECK-GI-NEXT:    umulh x12, x9, x13
 ; CHECK-GI-NEXT:    lsr x8, x8, #2
-; CHECK-GI-NEXT:    lsl x14, x10, #3
-; CHECK-GI-NEXT:    lsl x15, x9, #3
-; CHECK-GI-NEXT:    umulh x13, x11, x13
-; CHECK-GI-NEXT:    lsl x16, x8, #3
-; CHECK-GI-NEXT:    sub x10, x14, x10
 ; CHECK-GI-NEXT:    lsl x14, x11, #3
+; CHECK-GI-NEXT:    lsl x15, x9, #3
+; CHECK-GI-NEXT:    umulh x13, x10, x13
+; CHECK-GI-NEXT:    lsl x16, x8, #3
+; CHECK-GI-NEXT:    sub x11, x14, x11
+; CHECK-GI-NEXT:    lsl x14, x10, #3
 ; CHECK-GI-NEXT:    sub x9, x15, x9
 ; CHECK-GI-NEXT:    sub x8, x16, x8
 ; CHECK-GI-NEXT:    subs x0, x0, x9
-; CHECK-GI-NEXT:    add x10, x12, x10
-; CHECK-GI-NEXT:    sub x11, x14, x11
-; CHECK-GI-NEXT:    sbc x1, x1, x10
-; CHECK-GI-NEXT:    subs x2, x2, x11
+; CHECK-GI-NEXT:    add x11, x12, x11
+; CHECK-GI-NEXT:    sub x10, x14, x10
+; CHECK-GI-NEXT:    sbc x1, x1, x11
+; CHECK-GI-NEXT:    subs x2, x2, x10
 ; CHECK-GI-NEXT:    add x8, x13, x8
 ; CHECK-GI-NEXT:    sbc x3, x3, x8
 ; CHECK-GI-NEXT:    ret
@@ -3010,73 +2988,65 @@ define <2 x i128> @uv2i128_100(<2 x i128> %d, <2 x i128> %e) {
 ; CHECK-GI-NEXT:    mul x16, x1, x8
 ; CHECK-GI-NEXT:    cset w13, hs
 ; CHECK-GI-NEXT:    and x13, x13, #0x1
-; CHECK-GI-NEXT:    umulh x9, xzr, x10
+; CHECK-GI-NEXT:    umulh x4, x2, x10
 ; CHECK-GI-NEXT:    add x12, x12, x13
 ; CHECK-GI-NEXT:    adds x13, x14, x15
-; CHECK-GI-NEXT:    umulh x17, x1, x8
+; CHECK-GI-NEXT:    mul x11, x2, x8
 ; CHECK-GI-NEXT:    cset w14, hs
 ; CHECK-GI-NEXT:    adds x13, x13, x16
 ; CHECK-GI-NEXT:    and x14, x14, #0x1
-; CHECK-GI-NEXT:    and x16, xzr, #0x1
-; CHECK-GI-NEXT:    umulh x11, x2, x10
-; CHECK-GI-NEXT:    cset w5, hs
-; CHECK-GI-NEXT:    add x14, x14, x16
-; CHECK-GI-NEXT:    and x16, x5, #0x1
+; CHECK-GI-NEXT:    umulh x9, xzr, x10
+; CHECK-GI-NEXT:    cset w15, hs
 ; CHECK-GI-NEXT:    adds x12, x13, x12
-; CHECK-GI-NEXT:    and x13, xzr, #0x1
-; CHECK-GI-NEXT:    mul x4, x2, x8
-; CHECK-GI-NEXT:    add x14, x14, x16
-; CHECK-GI-NEXT:    cset w16, hs
+; CHECK-GI-NEXT:    and x13, x15, #0x1
+; CHECK-GI-NEXT:    cset w15, hs
+; CHECK-GI-NEXT:    umulh x17, x1, x8
 ; CHECK-GI-NEXT:    add x13, x14, x13
-; CHECK-GI-NEXT:    and x14, x16, #0x1
-; CHECK-GI-NEXT:    add x16, x9, x17
-; CHECK-GI-NEXT:    mul x15, x3, x10
+; CHECK-GI-NEXT:    and x14, x15, #0x1
+; CHECK-GI-NEXT:    adds x11, x4, x11
+; CHECK-GI-NEXT:    mul x5, x3, x10
 ; CHECK-GI-NEXT:    umulh x10, x3, x10
-; CHECK-GI-NEXT:    adds x11, x11, x4
-; CHECK-GI-NEXT:    umulh x5, x2, x8
+; CHECK-GI-NEXT:    add x15, x9, x17
 ; CHECK-GI-NEXT:    cset w17, hs
-; CHECK-GI-NEXT:    cmn x11, x15
+; CHECK-GI-NEXT:    umulh x16, x2, x8
+; CHECK-GI-NEXT:    cmn x11, x5
 ; CHECK-GI-NEXT:    add x11, x13, x14
-; CHECK-GI-NEXT:    add x13, x16, x18
+; CHECK-GI-NEXT:    add x13, x15, x18
 ; CHECK-GI-NEXT:    mul x4, x3, x8
 ; CHECK-GI-NEXT:    add x11, x13, x11
 ; CHECK-GI-NEXT:    cset w13, hs
-; CHECK-GI-NEXT:    and x15, x17, #0x1
+; CHECK-GI-NEXT:    and x14, x17, #0x1
 ; CHECK-GI-NEXT:    and x13, x13, #0x1
-; CHECK-GI-NEXT:    and x16, xzr, #0x1
-; CHECK-GI-NEXT:    add x13, x15, x13
-; CHECK-GI-NEXT:    umulh x8, x3, x8
 ; CHECK-GI-NEXT:    extr x12, x11, x12, #4
-; CHECK-GI-NEXT:    adds x10, x10, x5
-; CHECK-GI-NEXT:    mov w14, #100 // =0x64
-; CHECK-GI-NEXT:    cset w15, hs
-; CHECK-GI-NEXT:    umulh x17, x2, xzr
-; CHECK-GI-NEXT:    and x15, x15, #0x1
+; CHECK-GI-NEXT:    umulh x8, x3, x8
+; CHECK-GI-NEXT:    add x13, x14, x13
+; CHECK-GI-NEXT:    mov w15, #100 // =0x64
+; CHECK-GI-NEXT:    adds x10, x10, x16
+; CHECK-GI-NEXT:    umulh x16, x2, xzr
+; CHECK-GI-NEXT:    cset w14, hs
 ; CHECK-GI-NEXT:    adds x10, x10, x4
-; CHECK-GI-NEXT:    add x15, x15, x16
-; CHECK-GI-NEXT:    cset w16, hs
+; CHECK-GI-NEXT:    cset w17, hs
 ; CHECK-GI-NEXT:    adds x10, x10, x13
-; CHECK-GI-NEXT:    and x16, x16, #0x1
+; CHECK-GI-NEXT:    and x13, x14, #0x1
+; CHECK-GI-NEXT:    and x14, x17, #0x1
+; CHECK-GI-NEXT:    cset w17, hs
 ; CHECK-GI-NEXT:    add x8, x9, x8
+; CHECK-GI-NEXT:    add x13, x13, x14
+; CHECK-GI-NEXT:    and x14, x17, #0x1
+; CHECK-GI-NEXT:    umulh x17, x12, x15
+; CHECK-GI-NEXT:    add x13, x13, x14
+; CHECK-GI-NEXT:    add x8, x8, x16
 ; CHECK-GI-NEXT:    lsr x9, x11, #4
-; CHECK-GI-NEXT:    add x13, x15, x16
-; CHECK-GI-NEXT:    and x15, xzr, #0x1
-; CHECK-GI-NEXT:    cset w16, hs
-; CHECK-GI-NEXT:    add x13, x13, x15
-; CHECK-GI-NEXT:    and x15, x16, #0x1
-; CHECK-GI-NEXT:    add x8, x8, x17
-; CHECK-GI-NEXT:    add x13, x13, x15
-; CHECK-GI-NEXT:    umulh x16, x12, x14
 ; CHECK-GI-NEXT:    add x8, x8, x13
+; CHECK-GI-NEXT:    mul x11, x12, x15
 ; CHECK-GI-NEXT:    extr x10, x8, x10, #4
-; CHECK-GI-NEXT:    mul x11, x12, x14
 ; CHECK-GI-NEXT:    lsr x8, x8, #4
-; CHECK-GI-NEXT:    umulh x12, x10, x14
-; CHECK-GI-NEXT:    madd x9, x9, x14, x16
+; CHECK-GI-NEXT:    madd x9, x9, x15, x17
+; CHECK-GI-NEXT:    umulh x12, x10, x15
 ; CHECK-GI-NEXT:    subs x0, x0, x11
-; CHECK-GI-NEXT:    mul x10, x10, x14
-; CHECK-GI-NEXT:    madd x8, x8, x14, x12
+; CHECK-GI-NEXT:    mul x10, x10, x15
 ; CHECK-GI-NEXT:    sbc x1, x1, x9
+; CHECK-GI-NEXT:    madd x8, x8, x15, x12
 ; CHECK-GI-NEXT:    subs x2, x2, x10
 ; CHECK-GI-NEXT:    sbc x3, x3, x8
 ; CHECK-GI-NEXT:    ret

--- a/llvm/test/CodeGen/AArch64/vec-combine-compare-to-bitmask.ll
+++ b/llvm/test/CodeGen/AArch64/vec-combine-compare-to-bitmask.ll
@@ -404,48 +404,31 @@ define i4 @convert_to_bitmask_with_unknown_type_in_long_chain(<4 x i32> %vec1, <
 ; CHECK-GI:       ; %bb.0:
 ; CHECK-GI-NEXT:    sub sp, sp, #16
 ; CHECK-GI-NEXT:    .cfi_def_cfa_offset 16
-; CHECK-GI-NEXT:    mov w8, #1 ; =0x1
-; CHECK-GI-NEXT:    movi d2, #0000000000000000
 ; CHECK-GI-NEXT:    cmeq.4s v0, v0, #0
-; CHECK-GI-NEXT:    fmov s3, w8
 ; CHECK-GI-NEXT:    cmeq.4s v1, v1, #0
-; CHECK-GI-NEXT:    mov.16b v4, v3
-; CHECK-GI-NEXT:    mov.16b v5, v2
-; CHECK-GI-NEXT:    mov.h v2[1], w8
+; CHECK-GI-NEXT:    adrp x8, lCPI8_4@PAGE
+; CHECK-GI-NEXT:    adrp x9, lCPI8_0@PAGE
+; CHECK-GI-NEXT:    ldr d2, [x9, lCPI8_0@PAGEOFF]
+; CHECK-GI-NEXT:    adrp x9, lCPI8_1@PAGE
 ; CHECK-GI-NEXT:    bic.16b v0, v1, v0
-; CHECK-GI-NEXT:    mov.16b v1, v3
-; CHECK-GI-NEXT:    mov.h v3[1], w8
-; CHECK-GI-NEXT:    mov.h v4[1], w8
-; CHECK-GI-NEXT:    mov.h v5[1], w8
-; CHECK-GI-NEXT:    mov.h v1[1], w8
-; CHECK-GI-NEXT:    mov.h v2[2], w8
+; CHECK-GI-NEXT:    ldr d1, [x8, lCPI8_4@PAGEOFF]
+; CHECK-GI-NEXT:    adrp x8, lCPI8_3@PAGE
+; CHECK-GI-NEXT:    ldr d3, [x9, lCPI8_1@PAGEOFF]
 ; CHECK-GI-NEXT:    xtn.4h v0, v0
-; CHECK-GI-NEXT:    mov.h v3[2], w8
-; CHECK-GI-NEXT:    mov.h v4[2], wzr
-; CHECK-GI-NEXT:    mov.h v5[2], wzr
-; CHECK-GI-NEXT:    mov.h v1[2], wzr
-; CHECK-GI-NEXT:    mov.h v2[3], wzr
-; CHECK-GI-NEXT:    mov.h v3[3], wzr
-; CHECK-GI-NEXT:    mov.h v4[3], wzr
-; CHECK-GI-NEXT:    mov.h v5[3], w8
-; CHECK-GI-NEXT:    mov.h v1[3], w8
-; CHECK-GI-NEXT:    orr.8b v0, v0, v4
-; CHECK-GI-NEXT:    eor.8b v4, v0, v5
+; CHECK-GI-NEXT:    orr.8b v0, v0, v1
+; CHECK-GI-NEXT:    ldr d1, [x8, lCPI8_3@PAGEOFF]
+; CHECK-GI-NEXT:    adrp x8, lCPI8_2@PAGE
+; CHECK-GI-NEXT:    eor.8b v1, v0, v1
 ; CHECK-GI-NEXT:    eor.8b v0, v2, v0
-; CHECK-GI-NEXT:    and.8b v1, v4, v1
+; CHECK-GI-NEXT:    ldr d2, [x8, lCPI8_2@PAGEOFF]
+; CHECK-GI-NEXT:    and.8b v1, v1, v2
 ; CHECK-GI-NEXT:    orr.8b v0, v3, v0
 ; CHECK-GI-NEXT:    orr.8b v0, v1, v0
 ; CHECK-GI-NEXT:    ushll.4s v0, v0, #0
-; CHECK-GI-NEXT:    mov.s w8, v0[1]
-; CHECK-GI-NEXT:    mov.s w9, v0[2]
-; CHECK-GI-NEXT:    fmov w11, s0
-; CHECK-GI-NEXT:    mov.s w10, v0[3]
+; CHECK-GI-NEXT:    mov.s w8, v0[3]
 ; CHECK-GI-NEXT:    and w8, w8, #0x1
-; CHECK-GI-NEXT:    bfi w11, w8, #1, #31
-; CHECK-GI-NEXT:    and w8, w9, #0x1
-; CHECK-GI-NEXT:    and w9, w10, #0x1
-; CHECK-GI-NEXT:    orr w8, w11, w8, lsl #2
-; CHECK-GI-NEXT:    orr w8, w8, w9, lsl #3
+; CHECK-GI-NEXT:    lsl w8, w8, #3
+; CHECK-GI-NEXT:    orr w8, w8, #0x7
 ; CHECK-GI-NEXT:    strb w8, [sp, #15]
 ; CHECK-GI-NEXT:    and w0, w8, #0xff
 ; CHECK-GI-NEXT:    add sp, sp, #16


### PR DESCRIPTION
We were not enabling constant_fold_cast_op post-legalization. Doing so allows us to clear up some s/z/anyext(constant)'s.