### PR TITLE
[Transforms][Utils] Remove unused hasOnlySimpleTerminator

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/BasicBlockUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/BasicBlockUtils.h
@@ -642,10 +642,6 @@ LLVM_ABI bool SplitIndirectBrCriticalEdges(Function &F,
 // successors
 LLVM_ABI void InvertBranch(CondBrInst *PBI, IRBuilderBase &Builder);
 
-// Check whether the function only has simple terminator:
-// br/brcond/unreachable/ret
-LLVM_ABI bool hasOnlySimpleTerminator(const Function &F);
-
 /// Print BasicBlock \p BB as an operand or print "<nullptr>" if \p BB is a
 /// nullptr.
 LLVM_ABI Printable printBasicBlock(const BasicBlock *BB);

--- a/llvm/lib/Transforms/Utils/BasicBlockUtils.cpp
+++ b/llvm/lib/Transforms/Utils/BasicBlockUtils.cpp
@@ -1890,15 +1890,6 @@ void llvm::InvertBranch(CondBrInst *PBI, IRBuilderBase &Builder) {
   PBI->swapSuccessors();
 }
 
-bool llvm::hasOnlySimpleTerminator(const Function &F) {
-  for (auto &BB : F) {
-    auto *Term = BB.getTerminator();
-    if (!isa<ReturnInst, UnreachableInst, UncondBrInst, CondBrInst>(Term))
-      return false;
-  }
-  return true;
-}
-
 Printable llvm::printBasicBlock(const BasicBlock *BB) {
   return Printable([BB](raw_ostream &OS) {
     if (!BB) {


### PR DESCRIPTION
The last use was removed on Nov 3, 2025 in
commit a8ea7f4580b467183ce2075db6b1b2ec3beb6ebf.
