### PR TITLE
[FunctionAttrs] Handle nofreeobj

### DIFF
--- a/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
@@ -952,7 +952,8 @@ determinePointerAccessAttrs(Argument *A,
       if (isModSet(ArgMR) && !CB->onlyReadsMemory(UseIndex)) {
         Props.IsWrite = true;
         if (CB->isArgOperand(U) && !CB->hasFnAttr(Attribute::NoFree) &&
-            !CB->paramHasAttr(UseIndex, Attribute::NoFree))
+            !CB->paramHasAttr(UseIndex, Attribute::NoFree) &&
+            !CB->paramHasAttr(UseIndex, Attribute::NoFreeObj))
           Props.IsFree = true;
       }
     } else {
@@ -1075,7 +1076,8 @@ static bool addAccessAttrs(Argument *A, ArgAccessProperties Props) {
   assert(A && "Argument must not be null.");
 
   bool Changed = false;
-  if (!Props.IsFree && !A->hasAttribute(Attribute::NoFree)) {
+  if (!Props.IsFree && !A->hasAttribute(Attribute::NoFree) &&
+      !A->hasAttribute(Attribute::NoFreeObj)) {
     ++NumNoFreeArg;
     A->addAttr(Attribute::NoFree);
     Changed = true;

--- a/llvm/test/Transforms/FunctionAttrs/nofree.ll
+++ b/llvm/test/Transforms/FunctionAttrs/nofree.ll
@@ -103,7 +103,7 @@ define void @_Z4foo7Pi(ptr %a) local_unnamed_addr #1 {
 ; CHECK-NEXT:    [[ISNULL:%.*]] = icmp eq ptr [[A]], null
 ; CHECK-NEXT:    br i1 [[ISNULL]], label %[[DELETE_END:.*]], label %[[DELETE_NOTNULL:.*]]
 ; CHECK:       [[DELETE_NOTNULL]]:
-; CHECK-NEXT:    tail call void @_ZdlPv(ptr [[A]]) #[[ATTR8:[0-9]+]]
+; CHECK-NEXT:    tail call void @_ZdlPv(ptr [[A]]) #[[ATTR9:[0-9]+]]
 ; CHECK-NEXT:    br label %[[DELETE_END]]
 ; CHECK:       [[DELETE_END]]:
 ; CHECK-NEXT:    ret void
@@ -130,7 +130,7 @@ define void @_Z4foo8Pi(ptr %a) local_unnamed_addr #1 {
 ; CHECK-NEXT:    [[ISNULL:%.*]] = icmp eq ptr [[A]], null
 ; CHECK-NEXT:    br i1 [[ISNULL]], label %[[DELETE_END:.*]], label %[[DELETE_NOTNULL:.*]]
 ; CHECK:       [[DELETE_NOTNULL]]:
-; CHECK-NEXT:    tail call void @_ZdaPv(ptr [[A]]) #[[ATTR8]]
+; CHECK-NEXT:    tail call void @_ZdaPv(ptr [[A]]) #[[ATTR9]]
 ; CHECK-NEXT:    br label %[[DELETE_END]]
 ; CHECK:       [[DELETE_END]]:
 ; CHECK-NEXT:    ret void
@@ -252,7 +252,7 @@ define void @passed_to_nofree_fn_maybe_capture_arg(ptr %p) {
 define void @passed_to_readonly_fn_nocapture_arg(ptr %p) {
 ; CHECK-LABEL: define void @passed_to_readonly_fn_nocapture_arg(
 ; CHECK-SAME: ptr nofree readonly captures(address) [[P:%.*]]) {
-; CHECK-NEXT:    call void @takes_ptr(ptr captures(address, read_provenance) [[P]]) #[[ATTR9:[0-9]+]]
+; CHECK-NEXT:    call void @takes_ptr(ptr captures(address, read_provenance) [[P]]) #[[ATTR10:[0-9]+]]
 ; CHECK-NEXT:    call void @may_free()
 ; CHECK-NEXT:    ret void
 ;
@@ -295,6 +295,25 @@ define void @passed_to_unknown_bundle(ptr %p) {
 ;
   call void @may_free() ["unknown"(ptr %p)]
   call void @may_free()
+  ret void
+}
+
+define void @already_nofreeobj(ptr nofreeobj %p) {
+; CHECK: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+; CHECK-LABEL: define void @already_nofreeobj(
+; CHECK-SAME: ptr nofree nofreeobj readnone captures(none) [[P:%.*]]) #[[ATTR7:[0-9]+]] {
+; CHECK-NEXT:    ret void
+;
+  ret void
+}
+
+define void @call_with_nofreeobj(ptr %p) {
+; CHECK-LABEL: define void @call_with_nofreeobj(
+; CHECK-SAME: ptr captures(none) [[P:%.*]]) {
+; CHECK-NEXT:    call void @takes_ptr(ptr nofreeobj captures(none) [[P]])
+; CHECK-NEXT:    ret void
+;
+  call void @takes_ptr(ptr nofreeobj captures(none) %p)
   ret void
 }
 

--- a/llvm/test/Transforms/FunctionAttrs/nofree.ll
+++ b/llvm/test/Transforms/FunctionAttrs/nofree.ll
@@ -301,7 +301,7 @@ define void @passed_to_unknown_bundle(ptr %p) {
 define void @already_nofreeobj(ptr nofreeobj %p) {
 ; CHECK: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 ; CHECK-LABEL: define void @already_nofreeobj(
-; CHECK-SAME: ptr nofree nofreeobj readnone captures(none) [[P:%.*]]) #[[ATTR7:[0-9]+]] {
+; CHECK-SAME: ptr nofreeobj readnone captures(none) [[P:%.*]]) #[[ATTR7:[0-9]+]] {
 ; CHECK-NEXT:    ret void
 ;
   ret void
@@ -309,7 +309,7 @@ define void @already_nofreeobj(ptr nofreeobj %p) {
 
 define void @call_with_nofreeobj(ptr %p) {
 ; CHECK-LABEL: define void @call_with_nofreeobj(
-; CHECK-SAME: ptr captures(none) [[P:%.*]]) {
+; CHECK-SAME: ptr nofree captures(none) [[P:%.*]]) {
 ; CHECK-NEXT:    call void @takes_ptr(ptr nofreeobj captures(none) [[P]])
 ; CHECK-NEXT:    ret void
 ;


### PR DESCRIPTION
This adds handling for nofreeobj (introduced in https://github.com/llvm/llvm-project/pull/206445) in two places:

 * Don't infer `nofree` if we already have `nofreeobj`. `nofreeobj` is a stronger property, it's pointless to have both.
 * Use `nofreeobj` on call arguments when inferring `nofree`.