### PR TITLE
[Offload] Implement better level zero dispatch

### DIFF
--- a/offload/plugins-nextgen/level_zero/dynamic_l0/L0DynWrapper.cpp
+++ b/offload/plugins-nextgen/level_zero/dynamic_l0/L0DynWrapper.cpp
@@ -96,7 +96,6 @@ DLWRAP(zeCommandListAppendWaitOnEvents, 3)
 DLWRAP(zeEventQueryStatus, 1)
 DLWRAP(zeDriverGetDefaultContext, 1)
 
-
 DLWRAP_FINALIZE()
 
 #ifdef _WIN32

--- a/offload/plugins-nextgen/level_zero/dynamic_l0/L0DynWrapper.cpp
+++ b/offload/plugins-nextgen/level_zero/dynamic_l0/L0DynWrapper.cpp
@@ -94,6 +94,8 @@ DLWRAP(zeCommandListHostSynchronize, 2)
 DLWRAP(zeCommandListAppendSignalEvent, 2)
 DLWRAP(zeCommandListAppendWaitOnEvents, 3)
 DLWRAP(zeEventQueryStatus, 1)
+DLWRAP(zeDriverGetDefaultContext, 1)
+
 
 DLWRAP_FINALIZE()
 
@@ -110,98 +112,11 @@ DLWRAP_FINALIZE()
 #define DEBUG_PREFIX "TARGET " GETNAME(TARGET_NAME) " RTL"
 #endif
 
-// Extension function pointer for getting argument sizes.
-static ze_result_t (*zexKernelGetArgumentSize_ptr)(ze_kernel_handle_t, uint32_t,
-                                                   uint32_t *) = nullptr;
-
-static bool zeCommandListAppendLaunchKernelWithArgumentsFallbackAvailable() {
-  static std::once_flag zexKernelGetArgumentSize_once;
-
-  // Load zexKernelGetArgumentSize extension if available.
-  std::call_once(zexKernelGetArgumentSize_once, []() {
-    uint32_t DriverCount = 0;
-    if (zeDriverGet(&DriverCount, nullptr) == ZE_RESULT_SUCCESS &&
-        DriverCount > 0) {
-      ze_driver_handle_t Driver;
-      DriverCount = 1;
-      if (zeDriverGet(&DriverCount, &Driver) == ZE_RESULT_SUCCESS) {
-        void *ExtFunc = nullptr;
-        if (zeDriverGetExtensionFunctionAddress(
-                Driver, "zexKernelGetArgumentSize", &ExtFunc) ==
-                ZE_RESULT_SUCCESS &&
-            ExtFunc) {
-          zexKernelGetArgumentSize_ptr =
-              reinterpret_cast<decltype(zexKernelGetArgumentSize_ptr)>(ExtFunc);
-          ODBG(OLDT_Init) << "Loaded zexKernelGetArgumentSize extension";
-        }
-      }
-    }
-  });
-  return zexKernelGetArgumentSize_ptr != nullptr;
-}
-
-static ze_result_t zeCommandListAppendLaunchKernelWithArgumentsFallback(
-    ze_command_list_handle_t hCommandList, ze_kernel_handle_t hKernel,
-    const ze_group_count_t groupCounts, const ze_group_size_t groupSizes,
-    void **pArguments, const void *pNext, ze_event_handle_t hSignalEvent,
-    uint32_t numWaitEvents, ze_event_handle_t *phWaitEvents) {
-
-  ze_result_t Res;
-  Res = zeKernelSetGroupSize(hKernel, groupSizes.groupSizeX,
-                             groupSizes.groupSizeY, groupSizes.groupSizeZ);
-  if (Res != ZE_RESULT_SUCCESS)
-    return Res;
-
-  ze_kernel_properties_t KernelProps = {};
-  KernelProps.stype = ZE_STRUCTURE_TYPE_KERNEL_PROPERTIES;
-  Res = zeKernelGetProperties(hKernel, &KernelProps);
-  if (Res != ZE_RESULT_SUCCESS)
-    return Res;
-
-  uint32_t NumKernelArgs = KernelProps.numKernelArgs;
-
-  for (uint32_t KernelArg = 0; KernelArg < NumKernelArgs; KernelArg++) {
-    uint32_t ArgSize = 0;
-
-    Res = zexKernelGetArgumentSize_ptr(hKernel, KernelArg, &ArgSize);
-    if (Res != ZE_RESULT_SUCCESS)
-      return Res;
-
-    Res = zeKernelSetArgumentValue(hKernel, KernelArg, ArgSize,
-                                   pArguments[KernelArg]);
-    if (Res != ZE_RESULT_SUCCESS)
-      return Res;
-  }
-
-  bool IsCooperative = false;
-  if (pNext) {
-    const ze_command_list_append_launch_kernel_param_cooperative_desc_t
-        *CoopDesc = static_cast<
-            const ze_command_list_append_launch_kernel_param_cooperative_desc_t
-                *>(pNext);
-    if (CoopDesc->stype ==
-        ZE_STRUCTURE_TYPE_COMMAND_LIST_APPEND_PARAM_COOPERATIVE_DESC)
-      IsCooperative = CoopDesc->isCooperative;
-  }
-
-  if (IsCooperative)
-    return zeCommandListAppendLaunchCooperativeKernel(
-        hCommandList, hKernel, &groupCounts, hSignalEvent, numWaitEvents,
-        phWaitEvents);
-  return zeCommandListAppendLaunchKernel(hCommandList, hKernel, &groupCounts,
-                                         hSignalEvent, numWaitEvents,
-                                         phWaitEvents);
-}
-
 static struct {
   const char *Name;
   void *FallbackFunc;
   bool (*FallbackAvailable)();
-} ZeFallbacksTbl[] = {
-    {"zeCommandListAppendLaunchKernelWithArguments",
-     reinterpret_cast<void *>(
-         &zeCommandListAppendLaunchKernelWithArgumentsFallback),
-     zeCommandListAppendLaunchKernelWithArgumentsFallbackAvailable}};
+} ZeFallbacksTbl[] = {};
 constexpr size_t ZeFallbacksTblSz =
     sizeof(ZeFallbacksTbl) / sizeof(ZeFallbacksTbl[0]);
 

--- a/offload/plugins-nextgen/level_zero/dynamic_l0/level_zero/ze_api.h
+++ b/offload/plugins-nextgen/level_zero/dynamic_l0/level_zero/ze_api.h
@@ -670,6 +670,8 @@ ZE_APIEXPORT ze_result_t ZE_APICALL zeDriverGetExtensionFunctionAddress(
     ze_driver_handle_t hDriver, const char *name, void **ppFunctionAddress);
 ZE_APIEXPORT ze_result_t ZE_APICALL zeDriverGetExtensionProperties(
     ze_driver_handle_t hDriver, uint32_t *pCount, void *pExtensionProperties);
+ZE_APIEXPORT ze_context_handle_t ZE_APICALL
+zeDriverGetDefaultContext(ze_driver_handle_t hDriver);
 
 /* Device functions */
 ZE_APIEXPORT ze_result_t ZE_APICALL zeDeviceGet(ze_driver_handle_t hDriver,

--- a/offload/plugins-nextgen/level_zero/include/L0CmdListManager.h
+++ b/offload/plugins-nextgen/level_zero/include/L0CmdListManager.h
@@ -18,6 +18,8 @@
 #include "L0Defs.h"
 #include "L0Trace.h"
 #include "PluginInterface.h"
+#include "level_zero/ze_api.h"
+#include <atomic>
 #include <mutex>
 
 namespace llvm::omp::target::plugin {
@@ -129,7 +131,7 @@ public:
       ze_event_handle_t SignalEvent = nullptr, uint32_t NumWaitEvents = 0,
       ze_event_handle_t *WaitEvents = nullptr, bool IsCooperative = false) {
 
-    if (!api_helper::canCall<zeCommandListAppendLaunchKernelWithArguments>())
+    if (Context.LaunchKernelWithArguments.available() == false)
       return Plugin::error(
           ErrorCode::UNSUPPORTED,
           "zeCommandListAppendLaunchKernelWithArguments is not "
@@ -140,10 +142,26 @@ public:
         static_cast<ze_bool_t>(IsCooperative)};
     std::lock_guard<std::mutex> Lock(Mtx);
 
-    CALL_ZE_RET_ERROR(zeCommandListAppendLaunchKernelWithArguments, CmdList,
-                      Kernel, *GroupCounts, *GroupSizes, ArgPtrs,
-                      IsCooperative ? &CoopDesc : nullptr, SignalEvent,
-                      NumWaitEvents, WaitEvents);
+    auto Result = Context.LaunchKernelWithArguments(
+        CmdList, Kernel, *GroupCounts, *GroupSizes, ArgPtrs,
+        IsCooperative ? &CoopDesc : nullptr, SignalEvent, NumWaitEvents,
+        WaitEvents);
+
+    if (Result == ze_result_t::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
+      Context.AppendLaunchKernelSupported.store(false, std::memory_order_release);
+      return Plugin::error(
+          ErrorCode::UNSUPPORTED,
+          "zeCommandListAppendLaunchKernelWithArguments is not "
+          "supported on this driver");
+    }
+
+    if (Result != ze_result_t::ZE_RESULT_SUCCESS) {
+      return Plugin::error(getOffloadErrorCode(Result),
+                           "zeCommandListAppendLaunchKernelWithArguments "
+                           "failed with error %d, %s",
+                           Result, getZeErrorName(Result));
+    }
+
     return Plugin::success();
   }
 
@@ -177,13 +195,12 @@ public:
                            ze_event_handle_t SignalEvent = nullptr,
                            uint32_t NumWaitEvents = 0,
                            ze_event_handle_t *WaitEvents = nullptr) {
-    auto zeCommandListAppendHost = Context.zeCommandListAppendHostFunction;
-    if (!zeCommandListAppendHost)
+    if (!Context.CommandListAppendHostFunction.available())
       return Plugin::error(ErrorCode::UNSUPPORTED,
                            "zeCommandListAppendHostFunction extension is not "
                            "available on this driver");
     std::lock_guard<std::mutex> Lock(Mtx);
-    CALL_ZE_RET_ERROR(zeCommandListAppendHost, CmdList,
+    CALL_ZE_RET_ERROR(Context.CommandListAppendHostFunction, CmdList,
                       reinterpret_cast<void *>(Callback), UserData,
                       /*pReserved*/ nullptr, SignalEvent, NumWaitEvents,
                       WaitEvents);

--- a/offload/plugins-nextgen/level_zero/include/L0CmdListManager.h
+++ b/offload/plugins-nextgen/level_zero/include/L0CmdListManager.h
@@ -148,7 +148,8 @@ public:
         WaitEvents);
 
     if (Result == ze_result_t::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
-      Context.AppendLaunchKernelSupported.store(false, std::memory_order_release);
+      Context.AppendLaunchKernelSupported.store(false,
+                                                std::memory_order_release);
       return Plugin::error(
           ErrorCode::UNSUPPORTED,
           "zeCommandListAppendLaunchKernelWithArguments is not "

--- a/offload/plugins-nextgen/level_zero/include/L0CmdListManager.h
+++ b/offload/plugins-nextgen/level_zero/include/L0CmdListManager.h
@@ -202,7 +202,8 @@ public:
     std::lock_guard<std::mutex> Lock(Mtx);
 
     // Alias for better error reporting
-    auto zeCommandListAppendHostFunction = Context.CommandListAppendHostFunction;
+    auto zeCommandListAppendHostFunction =
+        Context.CommandListAppendHostFunction;
     CALL_ZE_RET_ERROR(zeCommandListAppendHostFunction, CmdList,
                       reinterpret_cast<void *>(Callback), UserData,
                       /*pReserved*/ nullptr, SignalEvent, NumWaitEvents,

--- a/offload/plugins-nextgen/level_zero/include/L0CmdListManager.h
+++ b/offload/plugins-nextgen/level_zero/include/L0CmdListManager.h
@@ -148,7 +148,7 @@ public:
         WaitEvents);
 
     if (Result == ze_result_t::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
-      Context.AppendLaunchKernelSupported.store(false,
+      Context.AppendLaunchKernelWithArgsSupported.store(false,
                                                 std::memory_order_release);
       return Plugin::error(
           ErrorCode::UNSUPPORTED,

--- a/offload/plugins-nextgen/level_zero/include/L0CmdListManager.h
+++ b/offload/plugins-nextgen/level_zero/include/L0CmdListManager.h
@@ -148,8 +148,8 @@ public:
         WaitEvents);
 
     if (Result == ze_result_t::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
-      Context.AppendLaunchKernelWithArgsSupported.store(false,
-                                                std::memory_order_release);
+      Context.AppendLaunchKernelWithArgsSupported.store(
+          false, std::memory_order_release);
       return Plugin::error(
           ErrorCode::UNSUPPORTED,
           "zeCommandListAppendLaunchKernelWithArguments is not "

--- a/offload/plugins-nextgen/level_zero/include/L0CmdListManager.h
+++ b/offload/plugins-nextgen/level_zero/include/L0CmdListManager.h
@@ -200,7 +200,10 @@ public:
                            "zeCommandListAppendHostFunction extension is not "
                            "available on this driver");
     std::lock_guard<std::mutex> Lock(Mtx);
-    CALL_ZE_RET_ERROR(Context.CommandListAppendHostFunction, CmdList,
+
+    // Alias for better error reporting
+    auto zeCommandListAppendHostFunction = Context.CommandListAppendHostFunction;
+    CALL_ZE_RET_ERROR(zeCommandListAppendHostFunction, CmdList,
                       reinterpret_cast<void *>(Callback), UserData,
                       /*pReserved*/ nullptr, SignalEvent, NumWaitEvents,
                       WaitEvents);

--- a/offload/plugins-nextgen/level_zero/include/L0CmdListManager.h
+++ b/offload/plugins-nextgen/level_zero/include/L0CmdListManager.h
@@ -156,12 +156,11 @@ public:
           "supported on this driver");
     }
 
-    if (Result != ze_result_t::ZE_RESULT_SUCCESS) {
+    if (Result != ze_result_t::ZE_RESULT_SUCCESS)
       return Plugin::error(getOffloadErrorCode(Result),
                            "zeCommandListAppendLaunchKernelWithArguments "
                            "failed with error %d, %s",
                            Result, getZeErrorName(Result));
-    }
 
     return Plugin::success();
   }

--- a/offload/plugins-nextgen/level_zero/include/L0Compat.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Compat.h
@@ -25,4 +25,17 @@ API_HELPER_OPTIONAL(ze_result_t, zeCommandListAppendLaunchKernelWithArguments,
                     const void *pNext, ze_event_handle_t hSignalEvent,
                     uint32_t numWaitEvents, ze_event_handle_t *phWaitEvents)
 
+API_HELPER_OPTIONAL(ze_result_t, zexKernelGetArgumentSize,
+                    ze_kernel_handle_t hKernel, uint32_t argIndex,
+                    uint32_t *pArgSize)
+
+API_HELPER_OPTIONAL(ze_result_t, zeCommandListAppendHostFunction,
+                    ze_command_list_handle_t hCommandList,
+                    void *pfnHostFunction, void *pUserData, void *pReserved,
+                    ze_event_handle_t hSignalEvent, uint32_t numWaitEvents,
+                    ze_event_handle_t *phWaitEvents)
+
+API_HELPER_OPTIONAL(ze_context_handle_t, zeDriverGetDefaultContext,
+                    ze_driver_handle_t hDriver)
+
 #endif // OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_LEVEL_ZERO_L0COMPAT_H

--- a/offload/plugins-nextgen/level_zero/include/L0Context.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Context.h
@@ -13,9 +13,12 @@
 #ifndef OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_LEVEL_ZERO_L0CONTEXT_H
 #define OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_LEVEL_ZERO_L0CONTEXT_H
 
+#include "APIHelpers.h"
+#include "L0Compat.h"
 #include "L0Event.h"
 #include "L0Memory.h"
 #include "PerThreadTable.h"
+#include "level_zero/ze_api.h"
 
 namespace llvm::omp::target::plugin {
 
@@ -30,6 +33,76 @@ public:
   const StagingBufferTy &getStagingBuffer() const { return StagingBuffer; }
 
   Error deinit() { return StagingBuffer.clear(); }
+};
+
+// Helper for managing Level Zero APIs.
+// It provides two interfaces - by default it tries to call the function
+// directly - either through dlopen or directly linked (see L0DynWrapper.cpp).
+// It is also possible to call through an internal function pointer, which
+// can be populated using `tryLoadingExperimental` using
+// `zeDriverGetExtensionFunctionAddress` or simple set method
+// `addFallbackFunction`. It was implemented in order to support different
+// versions of level zero software stack and different kinds of drivers.
+template <auto Fn, auto UnsupportedValue> class ZeDispatcher {
+public:
+  constexpr ZeDispatcher() = default;
+
+  [[nodiscard]]
+  bool available() const {
+    if (UsesFuncPtr)
+      return FuncPtr != nullptr;
+
+    return api_helper::canCall<Fn>();
+  }
+
+  explicit operator bool() const { return available(); }
+
+  template <typename... Args>
+  decltype(auto) operator()(Args &&...ArgsList) const {
+    // Need to cast the type to avoid mismatch of return type deduction
+    using ReturnTy = std::invoke_result_t<decltype(Fn), Args...>;
+    if (UsesFuncPtr) {
+      if (FuncPtr == nullptr) {
+        return static_cast<ReturnTy>(UnsupportedValue);
+      }
+      auto Result = FuncPtr(std::forward<Args>(ArgsList)...);
+      return Result;
+    }
+
+    if (!api_helper::canCall<Fn>()) {
+      return static_cast<ReturnTy>(UnsupportedValue);
+    }
+    auto Result = Fn(std::forward<Args>(ArgsList)...);
+
+    return Result;
+  }
+
+  bool tryLoadingExperimental(ze_driver_handle_t zeDriver,
+                              const char *FuncName) {
+    if (api_helper::canCall<Fn>()) {
+      return true; // Function is already available, no need to load it using
+                   // experimental API.
+    }
+
+    auto Result = zeDriverGetExtensionFunctionAddress(
+        zeDriver, FuncName, reinterpret_cast<void **>(&FuncPtr));
+
+    if (Result != ZE_RESULT_SUCCESS || FuncPtr == nullptr) {
+      return false;
+    }
+
+    UsesFuncPtr = true;
+    return true;
+  }
+
+  void addFallbackFunction(decltype(Fn) FallbackFunc) {
+    UsesFuncPtr = true;
+    FuncPtr = FallbackFunc;
+  }
+
+private:
+  bool UsesFuncPtr = false;
+  decltype(Fn) FuncPtr = nullptr;
 };
 
 struct L0ContextTLSTableTy
@@ -145,21 +218,17 @@ public:
   const MemAllocatorTy &getHostMemAllocator() const { return HostMemAllocator; }
   MemAllocatorTy &getHostMemAllocator() { return HostMemAllocator; }
 
-  /// Level Zero extension function pointer for kernel argument size query.
-  ze_result_t(ZE_APICALL *zexKernelGetArgumentSize)(
-      ze_kernel_handle_t hKernel, uint32_t argIndex,
-      uint32_t *pArgSize) = nullptr;
+  std::atomic<bool> AppendLaunchKernelSupported = true;
 
-  /// Level Zero extension function pointer for host function callbacks.
-  ze_result_t(ZE_APICALL *zeCommandListAppendHostFunction)(
-      ze_command_list_handle_t hCommandList, void *pfnHostFunction,
-      void *pUserData, void *pReserved, ze_event_handle_t hSignalEvent,
-      uint32_t numWaitEvents, ze_event_handle_t *phWaitEvents) = nullptr;
-
-  /// Level Zero extension function pointer for querying the driver's default
-  /// ze_context, when the extension is supported.
-  ze_context_handle_t(ZE_APICALL *zeDriverGetDefaultContext)(
-      ze_driver_handle_t hDriver) = nullptr;
+  ZeDispatcher<zeCommandListAppendLaunchKernelWithArguments,
+               ZE_RESULT_ERROR_UNSUPPORTED_FEATURE>
+      LaunchKernelWithArguments;
+  ZeDispatcher<zexKernelGetArgumentSize, ZE_RESULT_ERROR_UNSUPPORTED_FEATURE>
+      KernelGetArgumentSize;
+  ZeDispatcher<zeCommandListAppendHostFunction,
+               ZE_RESULT_ERROR_UNSUPPORTED_FEATURE>
+      CommandListAppendHostFunction;
+  ZeDispatcher<zeDriverGetDefaultContext, nullptr> DriverGetDefaultContext;
 };
 
 } // namespace llvm::omp::target::plugin

--- a/offload/plugins-nextgen/level_zero/include/L0Context.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Context.h
@@ -95,7 +95,7 @@ public:
     return true;
   }
 
-  void addFallbackFunction(decltype(Fn) FallbackFunc) {
+  void setFallbackFunction(decltype(Fn) FallbackFunc) {
     UsesFuncPtr = true;
     FuncPtr = FallbackFunc;
   }

--- a/offload/plugins-nextgen/level_zero/include/L0Context.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Context.h
@@ -39,7 +39,7 @@ public:
 // It provides two interfaces - by default it tries to call the function
 // directly - either through dlopen or directly linked (see L0DynWrapper.cpp).
 // It is also possible to call through an internal function pointer, which
-// can be populated using `tryLoadingExperimental` using
+// can be populated using `loadExperimental` using
 // `zeDriverGetExtensionFunctionAddress`.
 // `addFallbackFunction`. It was implemented in order to support different
 // versions of level zero software stack and different kinds of drivers.
@@ -70,14 +70,15 @@ public:
     return Fn(std::forward<Args>(ArgsList)...);
   }
 
-  bool tryLoadingExperimental(ze_driver_handle_t zeDriver,
+  bool loadExperimental(ze_driver_handle_t zeDriver,
                               const char *FuncName) {
-    if (api_helper::canCall<Fn>())
-      return true; // Function is already available, no need to load it using
-                   // experimental API.
+    assert(!api_helper::canCall<Fn>() &&
+           "ZeDispatcher::loadExperimental called without "
+           "ZeDispatcher::available check!");
 
-    auto Result = zeDriverGetExtensionFunctionAddress(
-        zeDriver, FuncName, reinterpret_cast<void **>(&FuncPtr));
+    ze_result_t Result = ZE_RESULT_SUCCESS;
+    CALL_ZE_RET(Result, zeDriverGetExtensionFunctionAddress, zeDriver, FuncName,
+                reinterpret_cast<void **>(&FuncPtr));
 
     if (Result != ZE_RESULT_SUCCESS || FuncPtr == nullptr)
       return false;

--- a/offload/plugins-nextgen/level_zero/include/L0Context.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Context.h
@@ -49,8 +49,8 @@ public:
 
   [[nodiscard]]
   bool available() const {
-    if (UsesFuncPtr)
-      return FuncPtr != nullptr;
+    if (FuncPtr != nullptr)
+      return true;
 
     return api_helper::canCall<Fn>();
   }
@@ -61,13 +61,8 @@ public:
   decltype(auto) operator()(Args &&...ArgsList) const {
     // Need to cast the type to avoid mismatch of return type deduction
     using ReturnTy = std::invoke_result_t<decltype(Fn), Args...>;
-    if (UsesFuncPtr) {
-      if (FuncPtr == nullptr)
-        return static_cast<ReturnTy>(UnsupportedValue);
-
-      auto Result = FuncPtr(std::forward<Args>(ArgsList)...);
-      return Result;
-    }
+    if (FuncPtr != nullptr)
+      return FuncPtr(std::forward<Args>(ArgsList)...);
 
     if (!api_helper::canCall<Fn>())
       return static_cast<ReturnTy>(UnsupportedValue);
@@ -89,12 +84,10 @@ public:
     if (Result != ZE_RESULT_SUCCESS || FuncPtr == nullptr)
       return false;
 
-    UsesFuncPtr = true;
     return true;
   }
 
 private:
-  bool UsesFuncPtr = false;
   decltype(Fn) FuncPtr = nullptr;
 };
 

--- a/offload/plugins-nextgen/level_zero/include/L0Context.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Context.h
@@ -203,7 +203,7 @@ public:
   const MemAllocatorTy &getHostMemAllocator() const { return HostMemAllocator; }
   MemAllocatorTy &getHostMemAllocator() { return HostMemAllocator; }
 
-  std::atomic<bool> AppendLaunchKernelSupported = true;
+  std::atomic<bool> AppendLaunchKernelWithArgsSupported = true;
 
   ZeDispatcher<zeCommandListAppendLaunchKernelWithArguments>
       LaunchKernelWithArguments;

--- a/offload/plugins-nextgen/level_zero/include/L0Context.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Context.h
@@ -67,9 +67,7 @@ public:
     if (!api_helper::canCall<Fn>())
       return static_cast<ReturnTy>(UnsupportedValue);
 
-    auto Result = Fn(std::forward<Args>(ArgsList)...);
-
-    return Result;
+    return Fn(std::forward<Args>(ArgsList)...);
   }
 
   bool tryLoadingExperimental(ze_driver_handle_t zeDriver,

--- a/offload/plugins-nextgen/level_zero/include/L0Context.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Context.h
@@ -69,9 +69,9 @@ public:
       return Result;
     }
 
-    if (!api_helper::canCall<Fn>()) {
+    if (!api_helper::canCall<Fn>())
       return static_cast<ReturnTy>(UnsupportedValue);
-    }
+
     auto Result = Fn(std::forward<Args>(ArgsList)...);
 
     return Result;

--- a/offload/plugins-nextgen/level_zero/include/L0Context.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Context.h
@@ -19,6 +19,8 @@
 #include "L0Memory.h"
 #include "PerThreadTable.h"
 #include "level_zero/ze_api.h"
+#include <cassert>
+#include <cstdint>
 
 namespace llvm::omp::target::plugin {
 
@@ -93,11 +95,6 @@ public:
 
     UsesFuncPtr = true;
     return true;
-  }
-
-  void setFallbackFunction(decltype(Fn) FallbackFunc) {
-    UsesFuncPtr = true;
-    FuncPtr = FallbackFunc;
   }
 
 private:

--- a/offload/plugins-nextgen/level_zero/include/L0Context.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Context.h
@@ -19,8 +19,6 @@
 #include "L0Memory.h"
 #include "PerThreadTable.h"
 #include "level_zero/ze_api.h"
-#include <cassert>
-#include <cstdint>
 
 namespace llvm::omp::target::plugin {
 

--- a/offload/plugins-nextgen/level_zero/include/L0Context.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Context.h
@@ -40,10 +40,10 @@ public:
 // directly - either through dlopen or directly linked (see L0DynWrapper.cpp).
 // It is also possible to call through an internal function pointer, which
 // can be populated using `tryLoadingExperimental` using
-// `zeDriverGetExtensionFunctionAddress` or simple set method
+// `zeDriverGetExtensionFunctionAddress`.
 // `addFallbackFunction`. It was implemented in order to support different
 // versions of level zero software stack and different kinds of drivers.
-template <auto Fn, auto UnsupportedValue> class ZeDispatcher {
+template <auto Fn, auto UnsupportedValue = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE> class ZeDispatcher {
 public:
   constexpr ZeDispatcher() = default;
 
@@ -206,13 +206,11 @@ public:
 
   std::atomic<bool> AppendLaunchKernelSupported = true;
 
-  ZeDispatcher<zeCommandListAppendLaunchKernelWithArguments,
-               ZE_RESULT_ERROR_UNSUPPORTED_FEATURE>
+  ZeDispatcher<zeCommandListAppendLaunchKernelWithArguments>
       LaunchKernelWithArguments;
-  ZeDispatcher<zexKernelGetArgumentSize, ZE_RESULT_ERROR_UNSUPPORTED_FEATURE>
+  ZeDispatcher<zexKernelGetArgumentSize>
       KernelGetArgumentSize;
-  ZeDispatcher<zeCommandListAppendHostFunction,
-               ZE_RESULT_ERROR_UNSUPPORTED_FEATURE>
+  ZeDispatcher<zeCommandListAppendHostFunction>
       CommandListAppendHostFunction;
   ZeDispatcher<zeDriverGetDefaultContext, nullptr> DriverGetDefaultContext;
 };

--- a/offload/plugins-nextgen/level_zero/include/L0Context.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Context.h
@@ -43,7 +43,8 @@ public:
 // `zeDriverGetExtensionFunctionAddress`.
 // `addFallbackFunction`. It was implemented in order to support different
 // versions of level zero software stack and different kinds of drivers.
-template <auto Fn, auto UnsupportedValue = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE> class ZeDispatcher {
+template <auto Fn, auto UnsupportedValue = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE>
+class ZeDispatcher {
 public:
   constexpr ZeDispatcher() = default;
 
@@ -70,8 +71,7 @@ public:
     return Fn(std::forward<Args>(ArgsList)...);
   }
 
-  bool loadExperimental(ze_driver_handle_t zeDriver,
-                              const char *FuncName) {
+  bool loadExperimental(ze_driver_handle_t zeDriver, const char *FuncName) {
     assert(!api_helper::canCall<Fn>() &&
            "ZeDispatcher::loadExperimental called without "
            "ZeDispatcher::available check!");
@@ -207,10 +207,8 @@ public:
 
   ZeDispatcher<zeCommandListAppendLaunchKernelWithArguments>
       LaunchKernelWithArguments;
-  ZeDispatcher<zexKernelGetArgumentSize>
-      KernelGetArgumentSize;
-  ZeDispatcher<zeCommandListAppendHostFunction>
-      CommandListAppendHostFunction;
+  ZeDispatcher<zexKernelGetArgumentSize> KernelGetArgumentSize;
+  ZeDispatcher<zeCommandListAppendHostFunction> CommandListAppendHostFunction;
   ZeDispatcher<zeDriverGetDefaultContext, nullptr> DriverGetDefaultContext;
 };
 

--- a/offload/plugins-nextgen/level_zero/include/L0Context.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Context.h
@@ -62,9 +62,9 @@ public:
     // Need to cast the type to avoid mismatch of return type deduction
     using ReturnTy = std::invoke_result_t<decltype(Fn), Args...>;
     if (UsesFuncPtr) {
-      if (FuncPtr == nullptr) {
+      if (FuncPtr == nullptr)
         return static_cast<ReturnTy>(UnsupportedValue);
-      }
+
       auto Result = FuncPtr(std::forward<Args>(ArgsList)...);
       return Result;
     }
@@ -79,17 +79,15 @@ public:
 
   bool tryLoadingExperimental(ze_driver_handle_t zeDriver,
                               const char *FuncName) {
-    if (api_helper::canCall<Fn>()) {
+    if (api_helper::canCall<Fn>())
       return true; // Function is already available, no need to load it using
                    // experimental API.
-    }
 
     auto Result = zeDriverGetExtensionFunctionAddress(
         zeDriver, FuncName, reinterpret_cast<void **>(&FuncPtr));
 
-    if (Result != ZE_RESULT_SUCCESS || FuncPtr == nullptr) {
+    if (Result != ZE_RESULT_SUCCESS || FuncPtr == nullptr)
       return false;
-    }
 
     UsesFuncPtr = true;
     return true;

--- a/offload/plugins-nextgen/level_zero/include/L0Kernel.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Kernel.h
@@ -42,13 +42,14 @@ struct L0LaunchEnvTy {
   KernelPropertiesTy &KernelPR;
   bool IsCooperative = false;
   void **ArgPtrs = nullptr;
-  int64_t *ArgSizes = nullptr; 
+  int64_t *ArgSizes = nullptr;
   std::unique_lock<std::mutex> Lock;
 
   L0LaunchEnvTy(KernelPropertiesTy &KernelPR,
                 const KernelLaunchArgsTy &LaunchArgs)
       : KernelPR(KernelPR), IsCooperative(LaunchArgs.Flags.Cooperative),
-        ArgPtrs(LaunchArgs.Args), ArgSizes(LaunchArgs.ArgSizes), Lock(KernelPR.Mtx, std::defer_lock) {}
+        ArgPtrs(LaunchArgs.Args), ArgSizes(LaunchArgs.ArgSizes),
+        Lock(KernelPR.Mtx, std::defer_lock) {}
 };
 
 class L0KernelTy : public GenericKernelTy {

--- a/offload/plugins-nextgen/level_zero/include/L0Kernel.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Kernel.h
@@ -31,7 +31,6 @@ struct KernelPropertiesTy {
   uint32_t SIMDWidth = 0;
   uint32_t MaxThreadGroupSize = 0;
   uint32_t NumKernelArgs = 0;
-  std::unique_ptr<uint32_t[]> ArgSizes;
   ze_kernel_indirect_access_flags_t IndirectAccessFlags =
       std::numeric_limits<decltype(IndirectAccessFlags)>::max();
   std::mutex Mtx;
@@ -43,12 +42,13 @@ struct L0LaunchEnvTy {
   KernelPropertiesTy &KernelPR;
   bool IsCooperative = false;
   void **ArgPtrs = nullptr;
+  int64_t *ArgSizes = nullptr; 
   std::unique_lock<std::mutex> Lock;
 
   L0LaunchEnvTy(KernelPropertiesTy &KernelPR,
                 const KernelLaunchArgsTy &LaunchArgs)
       : KernelPR(KernelPR), IsCooperative(LaunchArgs.Flags.Cooperative),
-        ArgPtrs(LaunchArgs.Args), Lock(KernelPR.Mtx, std::defer_lock) {}
+        ArgPtrs(LaunchArgs.Args), ArgSizes(LaunchArgs.ArgSizes), Lock(KernelPR.Mtx, std::defer_lock) {}
 };
 
 class L0KernelTy : public GenericKernelTy {

--- a/offload/plugins-nextgen/level_zero/src/L0Context.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Context.cpp
@@ -57,22 +57,47 @@ Error L0ContextTy::init() {
     return Err;
   }
 
-  ze_result_t RC;
-  CALL_ZE(RC, zeDriverGetExtensionFunctionAddress, zeDriver,
-          "zexKernelGetArgumentSize", (void **)&zexKernelGetArgumentSize);
-  if (RC != ZE_RESULT_SUCCESS)
-    zexKernelGetArgumentSize = nullptr;
+  ODBG(OLDT_Init) << "APIs supported by the context with dlopen: ";
+  ODBG(OLDT_Init) << "  zeCommandListAppendLaunchKernelWithArguments: "
+                  << (LaunchKernelWithArguments.available() ? "yes" : "no");
+  ODBG(OLDT_Init) << "  zexKernelGetArgumentSize: "
+                  << (KernelGetArgumentSize.available() ? "yes" : "no");
+  ODBG(OLDT_Init) << "  zeCommandListAppendHostFunction: "
+                  << (CommandListAppendHostFunction.available() ? "yes" : "no");
+  ODBG(OLDT_Init) << "  zeDriverGetDefaultContext: "
+                  << (DriverGetDefaultContext.available() ? "yes" : "no");
 
-  CALL_ZE(RC, zeDriverGetExtensionFunctionAddress, zeDriver,
-          "zeCommandListAppendHostFunction",
-          (void **)&zeCommandListAppendHostFunction);
-  if (RC != ZE_RESULT_SUCCESS)
-    zeCommandListAppendHostFunction = nullptr;
+  LaunchKernelWithArguments.tryLoadingExperimental(
+      zeDriver, "zeCommandListAppendLaunchKernelWithArguments");
+  KernelGetArgumentSize.tryLoadingExperimental(zeDriver,
+                                               "zexKernelGetArgumentSize");
+  CommandListAppendHostFunction.tryLoadingExperimental(
+      zeDriver, "zeCommandListAppendHostFunction");
+  DriverGetDefaultContext.tryLoadingExperimental(zeDriver,
+                                                 "zeDriverGetDefaultContext");
 
-  CALL_ZE(RC, zeDriverGetExtensionFunctionAddress, zeDriver,
-          "zeDriverGetDefaultContext", (void **)&zeDriverGetDefaultContext);
-  if (RC != ZE_RESULT_SUCCESS)
-    zeDriverGetDefaultContext = nullptr;
+  ODBG(OLDT_Init) << "APIs supported by the context with added extensions: ";
+  ODBG(OLDT_Init) << "  zeCommandListAppendLaunchKernelWithArguments: "
+                  << (LaunchKernelWithArguments.available() ? "yes" : "no");
+  ODBG(OLDT_Init) << "  zexKernelGetArgumentSize: "
+                  << (KernelGetArgumentSize.available() ? "yes" : "no");
+  ODBG(OLDT_Init) << "  zeCommandListAppendHostFunction: "
+                  << (CommandListAppendHostFunction.available() ? "yes" : "no");
+  ODBG(OLDT_Init) << "  zeDriverGetDefaultContext: "
+                  << (DriverGetDefaultContext.available() ? "yes" : "no");
+
+  if (!LaunchKernelWithArguments.available() &&
+      KernelGetArgumentSize.available()) {
+    // Launch kernel was not available, both through dlopen and experimental API
+    // use fallback with KernelGetArgumentSize
+    // LaunchKernelWithArguments.addFallbackFunction(zeCommandListAppendLaunchKernelWithArgumentsFallback);
+  }
+
+  if (!CommandListAppendHostFunction.available()) {
+    // Try again with a name used in compute runtime 25.35 to 25.48
+    CommandListAppendHostFunction.tryLoadingExperimental(
+        zeDriver, "zexCommandListAppendHostFunction");
+  }
 
   DefaultUserCtx = std::make_unique<LevelZeroPluginContextTy>(
       Plugin, /*Devices=*/llvm::ArrayRef<GenericDeviceTy *>{}, zeDriver,

--- a/offload/plugins-nextgen/level_zero/src/L0Context.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Context.cpp
@@ -86,11 +86,10 @@ Error L0ContextTy::init() {
   ODBG(OLDT_Init) << "  zeDriverGetDefaultContext: "
                   << (DriverGetDefaultContext.available() ? "yes" : "no");
 
-  if (!CommandListAppendHostFunction.available()) {
+  if (!CommandListAppendHostFunction.available())
     // Try again with a name used in compute runtime 25.35 to 25.48
     CommandListAppendHostFunction.tryLoadingExperimental(
         zeDriver, "zexCommandListAppendHostFunction");
-  }
 
   DefaultUserCtx = std::make_unique<LevelZeroPluginContextTy>(
       Plugin, /*Devices=*/llvm::ArrayRef<GenericDeviceTy *>{}, zeDriver,

--- a/offload/plugins-nextgen/level_zero/src/L0Context.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Context.cpp
@@ -67,14 +67,25 @@ Error L0ContextTy::init() {
   ODBG(OLDT_Init) << "  zeDriverGetDefaultContext: "
                   << (DriverGetDefaultContext.available() ? "yes" : "no");
 
-  LaunchKernelWithArguments.tryLoadingExperimental(
-      zeDriver, "zeCommandListAppendLaunchKernelWithArguments");
-  KernelGetArgumentSize.tryLoadingExperimental(zeDriver,
-                                               "zexKernelGetArgumentSize");
-  CommandListAppendHostFunction.tryLoadingExperimental(
-      zeDriver, "zeCommandListAppendHostFunction");
-  DriverGetDefaultContext.tryLoadingExperimental(zeDriver,
-                                                 "zeDriverGetDefaultContext");
+  if (!LaunchKernelWithArguments)
+    LaunchKernelWithArguments.loadExperimental(
+        zeDriver, "zeCommandListAppendLaunchKernelWithArguments");
+
+  if (!KernelGetArgumentSize)
+    KernelGetArgumentSize.loadExperimental(zeDriver,
+                                           "zexKernelGetArgumentSize");
+
+  if (!CommandListAppendHostFunction)
+    CommandListAppendHostFunction.loadExperimental(
+        zeDriver, "zeCommandListAppendHostFunction");
+  if (!CommandListAppendHostFunction)
+    // Try again with a name used in compute runtime 25.35 to 25.48
+    CommandListAppendHostFunction.loadExperimental(
+        zeDriver, "zexCommandListAppendHostFunction");
+
+  if (!DriverGetDefaultContext)
+    DriverGetDefaultContext.loadExperimental(zeDriver,
+                                             "zeDriverGetDefaultContext");
 
   ODBG(OLDT_Init) << "APIs supported by the context with added extensions: ";
   ODBG(OLDT_Init) << "  zeCommandListAppendLaunchKernelWithArguments: "
@@ -85,11 +96,6 @@ Error L0ContextTy::init() {
                   << (CommandListAppendHostFunction.available() ? "yes" : "no");
   ODBG(OLDT_Init) << "  zeDriverGetDefaultContext: "
                   << (DriverGetDefaultContext.available() ? "yes" : "no");
-
-  if (!CommandListAppendHostFunction.available())
-    // Try again with a name used in compute runtime 25.35 to 25.48
-    CommandListAppendHostFunction.tryLoadingExperimental(
-        zeDriver, "zexCommandListAppendHostFunction");
 
   DefaultUserCtx = std::make_unique<LevelZeroPluginContextTy>(
       Plugin, /*Devices=*/llvm::ArrayRef<GenericDeviceTy *>{}, zeDriver,

--- a/offload/plugins-nextgen/level_zero/src/L0Context.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Context.cpp
@@ -86,13 +86,6 @@ Error L0ContextTy::init() {
   ODBG(OLDT_Init) << "  zeDriverGetDefaultContext: "
                   << (DriverGetDefaultContext.available() ? "yes" : "no");
 
-  if (!LaunchKernelWithArguments.available() &&
-      KernelGetArgumentSize.available()) {
-    // Launch kernel was not available, both through dlopen and experimental API
-    // use fallback with KernelGetArgumentSize
-    // LaunchKernelWithArguments.addFallbackFunction(zeCommandListAppendLaunchKernelWithArgumentsFallback);
-  }
-
   if (!CommandListAppendHostFunction.available()) {
     // Try again with a name used in compute runtime 25.35 to 25.48
     CommandListAppendHostFunction.tryLoadingExperimental(

--- a/offload/plugins-nextgen/level_zero/src/L0Kernel.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Kernel.cpp
@@ -43,10 +43,10 @@ Error L0KernelTy::readKernelProperties(L0ProgramTy &Program) {
 
   // Query and cache argument sizes if extension is available.
   auto &Context = L0Device.getL0Context();
-  if (KernelPR.NumKernelArgs > 0 && Context.zexKernelGetArgumentSize) {
+  if (KernelPR.NumKernelArgs > 0 && Context.KernelGetArgumentSize.available()) {
     KernelPR.ArgSizes = std::make_unique<uint32_t[]>(KernelPR.NumKernelArgs);
     for (uint32_t I = 0; I < KernelPR.NumKernelArgs; I++) {
-      CALL_ZE_RET_ERROR(Context.zexKernelGetArgumentSize, zeKernel, I,
+      CALL_ZE_RET_ERROR(Context.KernelGetArgumentSize, zeKernel, I,
                         &KernelPR.ArgSizes[I]);
     }
   }

--- a/offload/plugins-nextgen/level_zero/src/L0Kernel.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Kernel.cpp
@@ -41,16 +41,6 @@ Error L0KernelTy::readKernelProperties(L0ProgramTy &Program) {
   }
   KernelPR.MaxThreadGroupSize = KP.maxSubgroupSize * KP.maxNumSubgroups;
 
-  // Query and cache argument sizes if extension is available.
-  auto &Context = L0Device.getL0Context();
-  if (KernelPR.NumKernelArgs > 0 && Context.KernelGetArgumentSize.available()) {
-    KernelPR.ArgSizes = std::make_unique<uint32_t[]>(KernelPR.NumKernelArgs);
-    for (uint32_t I = 0; I < KernelPR.NumKernelArgs; I++) {
-      CALL_ZE_RET_ERROR(Context.KernelGetArgumentSize, zeKernel, I,
-                        &KernelPR.ArgSizes[I]);
-    }
-  }
-
   return Plugin::success();
 }
 

--- a/offload/plugins-nextgen/level_zero/src/L0Plugin.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Plugin.cpp
@@ -305,8 +305,8 @@ LevelZeroPluginTy::createPluginContext(
 
   ze_context_handle_t ZeContext = nullptr;
   bool OwnsZeContext = false;
-  if (IsFullDriver && DriverCtx.zeDriverGetDefaultContext)
-    ZeContext = DriverCtx.zeDriverGetDefaultContext(Driver);
+  if (IsFullDriver && DriverCtx.DriverGetDefaultContext.available())
+    ZeContext = DriverCtx.DriverGetDefaultContext(Driver);
   if (!ZeContext) {
     ze_context_desc_t Desc{ZE_STRUCTURE_TYPE_CONTEXT_DESC, nullptr, 0};
     CALL_ZE_RET_ERROR(zeContextCreate, Driver, &Desc, &ZeContext);

--- a/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
@@ -57,14 +57,17 @@ Error L0QueueTy::dispatchLaunchKernel(ze_kernel_handle_t Kernel,
 
   bool AppendLaunchKernelWithArgsAvailable =
       Device.getL0Context().LaunchKernelWithArguments.available();
-  
-  if (AppendLaunchKernelWithArgsAvailable && Device.getL0Context().AppendLaunchKernelSupported.load(std::memory_order_acquire)) {
+
+  if (AppendLaunchKernelWithArgsAvailable &&
+      Device.getL0Context().AppendLaunchKernelSupported.load(
+          std::memory_order_acquire)) {
     auto Result = CmdList->appendLaunchKernelWithArgs(
         Kernel, &KEnv.GroupCounts, &KEnv.GroupSizes, KEnv.ArgPtrs, SignalEvent,
         NumWaitEvents, WaitEvents, KEnv.IsCooperative);
 
     // Can a context have multiple users?
-    if (!Device.getL0Context().AppendLaunchKernelSupported.load(std::memory_order_acquire)) {
+    if (!Device.getL0Context().AppendLaunchKernelSupported.load(
+            std::memory_order_acquire)) {
       // Commandlist failed to launch kernel with arguments, fallback to older
       // API.
       consumeError(std::move(Result));

--- a/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
@@ -14,7 +14,9 @@
 #include "L0Device.h"
 #include "L0Kernel.h"
 #include "L0Plugin.h"
+#include "PluginInterface.h"
 #include "llvm/ADT/ScopeExit.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/MathExtras.h"
 
 #include <algorithm>
@@ -52,9 +54,49 @@ Error L0QueueTy::dispatchLaunchKernel(ze_kernel_handle_t Kernel,
                                       ze_event_handle_t *WaitEvents) {
   // Unlock KEnv lock after launching the kernel.
   llvm::scope_exit UnlockGuard([&KEnv]() { KEnv.Lock.unlock(); });
-  return CmdList->appendLaunchKernelWithArgs(
-      Kernel, &KEnv.GroupCounts, &KEnv.GroupSizes, KEnv.ArgPtrs, SignalEvent,
-      NumWaitEvents, WaitEvents, KEnv.IsCooperative);
+
+  bool AppendLaunchKernelWithArgsAvailable =
+      Device.getL0Context().LaunchKernelWithArguments.available();
+  
+  if (AppendLaunchKernelWithArgsAvailable && Device.getL0Context().AppendLaunchKernelSupported.load(std::memory_order_acquire)) {
+    auto Result = CmdList->appendLaunchKernelWithArgs(
+        Kernel, &KEnv.GroupCounts, &KEnv.GroupSizes, KEnv.ArgPtrs, SignalEvent,
+        NumWaitEvents, WaitEvents, KEnv.IsCooperative);
+
+    // Can a context have multiple users?
+    if (!Device.getL0Context().AppendLaunchKernelSupported.load(std::memory_order_acquire)) {
+      // Commandlist failed to launch kernel with arguments, fallback to older
+      // API.
+      consumeError(std::move(Result));
+    } else {
+      return Result;
+    }
+  }
+
+  // Submit kernel using older set of APIs - zeKernelSetArgumentValue
+  auto &GroupSizes = KEnv.GroupSizes;
+  auto Res = zeKernelSetGroupSize(Kernel, GroupSizes.groupSizeX,
+                                  GroupSizes.groupSizeY, GroupSizes.groupSizeZ);
+  if (Res != ZE_RESULT_SUCCESS)
+    return error::createOffloadError(ErrorCode::UNKNOWN,
+                                     "Could not set group size!");
+
+  auto &KernelProperties = KEnv.KernelPR;
+
+  for (uint32_t KernelArg = 0; KernelArg < KernelProperties.NumKernelArgs;
+       KernelArg++) {
+    uint32_t ArgSize = KernelProperties.ArgSizes[KernelArg];
+
+    Res = zeKernelSetArgumentValue(Kernel, KernelArg, ArgSize,
+                                   KEnv.ArgPtrs[KernelArg]);
+    if (Res != ZE_RESULT_SUCCESS)
+      return error::createOffloadError(ErrorCode::UNKNOWN,
+                                       "Could not set argument to a kernel!");
+  }
+
+  return CmdList->appendLaunchKernel(Kernel, &KEnv.GroupCounts, SignalEvent,
+                                     NumWaitEvents, WaitEvents,
+                                     KEnv.IsCooperative);
 }
 
 Error L0QueueTy::memoryFill(void *Ptr, const void *Pattern, size_t PatternSize,

--- a/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
@@ -60,7 +60,7 @@ Error L0QueueTy::dispatchLaunchKernel(ze_kernel_handle_t Kernel,
       Device.getL0Context().LaunchKernelWithArguments.available();
 
   if (AppendLaunchKernelWithArgsAvailable &&
-      Device.getL0Context().AppendLaunchKernelSupported.load(
+      Device.getL0Context().AppendLaunchKernelWithArgsSupported.load(
           std::memory_order_acquire)) {
     auto Err = CmdList->appendLaunchKernelWithArgs(
         Kernel, &KEnv.GroupCounts, &KEnv.GroupSizes, KEnv.ArgPtrs, SignalEvent,

--- a/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
@@ -61,19 +61,29 @@ Error L0QueueTy::dispatchLaunchKernel(ze_kernel_handle_t Kernel,
   if (AppendLaunchKernelWithArgsAvailable &&
       Device.getL0Context().AppendLaunchKernelSupported.load(
           std::memory_order_acquire)) {
-    auto Result = CmdList->appendLaunchKernelWithArgs(
+    auto Err = CmdList->appendLaunchKernelWithArgs(
         Kernel, &KEnv.GroupCounts, &KEnv.GroupSizes, KEnv.ArgPtrs, SignalEvent,
         NumWaitEvents, WaitEvents, KEnv.IsCooperative);
 
-    // Can a context have multiple users?
-    if (!Device.getL0Context().AppendLaunchKernelSupported.load(
-            std::memory_order_acquire)) {
-      // Commandlist failed to launch kernel with arguments, fallback to older
-      // API.
-      consumeError(std::move(Result));
-    } else {
-      return Result;
+    if (!Err)
+      return Plugin::success();
+
+    // Check if Err is ErrorCode::UNSUPPORTED, if so consume it
+    Err = llvm::handleErrors(
+        std::move(Err),
+        [&](std::unique_ptr<error::OffloadError> E) -> llvm::Error {
+          if (E->convertToErrorCode() ==
+              error::make_error_code(error::ErrorCode::UNSUPPORTED))
+            return llvm::Error::success(); // Swallow error
+          return llvm::Error(std::move(E));
+        });
+
+    if (Err) {
+      // Err is still here, so it was not ErrorCode::UNSUPPORTED
+      return Err;
     }
+
+    // No Err - it was ErrorCode::UNSUPPORTED, continue into fallback
   }
 
   // Submit kernel using older set of APIs - zeKernelSetArgumentValue

--- a/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
@@ -14,6 +14,7 @@
 #include "L0Device.h"
 #include "L0Kernel.h"
 #include "L0Plugin.h"
+#include "L0Trace.h"
 #include "PluginInterface.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/Support/Error.h"
@@ -93,11 +94,8 @@ Error L0QueueTy::dispatchLaunchKernel(ze_kernel_handle_t Kernel,
 
   // Submit kernel using older set of APIs - zeKernelSetArgumentValue
   auto &GroupSizes = KEnv.GroupSizes;
-  auto Res = zeKernelSetGroupSize(Kernel, GroupSizes.groupSizeX,
-                                  GroupSizes.groupSizeY, GroupSizes.groupSizeZ);
-  if (Res != ZE_RESULT_SUCCESS)
-    return error::createOffloadError(ErrorCode::UNSUPPORTED,
-                                     "Could not set group size!");
+  CALL_ZE_RET_ERROR(zeKernelSetGroupSize, Kernel, GroupSizes.groupSizeX,
+                    GroupSizes.groupSizeY, GroupSizes.groupSizeZ);
 
   auto &KernelProperties = KEnv.KernelPR;
 
@@ -105,11 +103,8 @@ Error L0QueueTy::dispatchLaunchKernel(ze_kernel_handle_t Kernel,
        KernelArg++) {
     uint32_t ArgSize = KEnv.ArgSizes[KernelArg];
 
-    Res = zeKernelSetArgumentValue(Kernel, KernelArg, ArgSize,
-                                   KEnv.ArgPtrs[KernelArg]);
-    if (Res != ZE_RESULT_SUCCESS)
-      return error::createOffloadError(ErrorCode::UNKNOWN,
-                                       "Could not set argument to a kernel!");
+    CALL_ZE_RET_ERROR(zeKernelSetArgumentValue, Kernel, KernelArg, ArgSize,
+                      KEnv.ArgPtrs[KernelArg]);
   }
 
   return CmdList->appendLaunchKernel(Kernel, &KEnv.GroupCounts, SignalEvent,

--- a/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
@@ -85,6 +85,12 @@ Error L0QueueTy::dispatchLaunchKernel(ze_kernel_handle_t Kernel,
     // No Err - it was ErrorCode::UNSUPPORTED, continue into fallback
   }
 
+  if (KEnv.ArgPtrs == nullptr)
+    return error::createOffloadError(
+        ErrorCode::UNSUPPORTED,
+        "zeCommandListAppendLaunchKernelWithArguments is not supported on this "
+        "platform and fallback is not possible!");
+
   // Submit kernel using older set of APIs - zeKernelSetArgumentValue
   auto &GroupSizes = KEnv.GroupSizes;
   auto Res = zeKernelSetGroupSize(Kernel, GroupSizes.groupSizeX,

--- a/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
@@ -78,10 +78,9 @@ Error L0QueueTy::dispatchLaunchKernel(ze_kernel_handle_t Kernel,
           return llvm::Error(std::move(E));
         });
 
-    if (Err) {
+    if (Err)
       // Err is still here, so it was not ErrorCode::UNSUPPORTED
       return Err;
-    }
 
     // No Err - it was ErrorCode::UNSUPPORTED, continue into fallback
   }
@@ -91,14 +90,14 @@ Error L0QueueTy::dispatchLaunchKernel(ze_kernel_handle_t Kernel,
   auto Res = zeKernelSetGroupSize(Kernel, GroupSizes.groupSizeX,
                                   GroupSizes.groupSizeY, GroupSizes.groupSizeZ);
   if (Res != ZE_RESULT_SUCCESS)
-    return error::createOffloadError(ErrorCode::UNKNOWN,
+    return error::createOffloadError(ErrorCode::UNSUPPORTED,
                                      "Could not set group size!");
 
   auto &KernelProperties = KEnv.KernelPR;
 
   for (uint32_t KernelArg = 0; KernelArg < KernelProperties.NumKernelArgs;
        KernelArg++) {
-    uint32_t ArgSize = KernelProperties.ArgSizes[KernelArg];
+    uint32_t ArgSize = KEnv.ArgSizes[KernelArg];
 
     Res = zeKernelSetArgumentValue(Kernel, KernelArg, ArgSize,
                                    KEnv.ArgPtrs[KernelArg]);

--- a/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
@@ -86,18 +86,20 @@ Error L0QueueTy::dispatchLaunchKernel(ze_kernel_handle_t Kernel,
     // No Err - it was ErrorCode::UNSUPPORTED, continue into fallback
   }
 
-  if (KEnv.ArgPtrs == nullptr)
+  auto &KernelProperties = KEnv.KernelPR;
+  if (KernelProperties.NumKernelArgs > 0 &&
+      (KEnv.ArgPtrs == nullptr || KEnv.ArgSizes == nullptr))
     return error::createOffloadError(
-        ErrorCode::UNSUPPORTED,
+        ErrorCode::INVALID_ARGUMENT,
         "zeCommandListAppendLaunchKernelWithArguments is not supported on this "
-        "platform and fallback is not possible!");
+        "platform and fallback is not possible, becaue ArgPtrs(%p) or "
+        "ArgSizes(%p) were not provided!",
+        KEnv.ArgPtrs, KEnv.ArgSizes);
 
   // Submit kernel using older set of APIs - zeKernelSetArgumentValue
   auto &GroupSizes = KEnv.GroupSizes;
   CALL_ZE_RET_ERROR(zeKernelSetGroupSize, Kernel, GroupSizes.groupSizeX,
                     GroupSizes.groupSizeY, GroupSizes.groupSizeZ);
-
-  auto &KernelProperties = KEnv.KernelPR;
 
   for (uint32_t KernelArg = 0; KernelArg < KernelProperties.NumKernelArgs;
        KernelArg++) {


### PR DESCRIPTION
This PR implements better handling of level zero APIs which might act differently depending on level zero version:

Here's a small table that I based the PR on, you can see that some APIs are available in the loader level through direct linking or dlopen (D) or require call to `zeDriverGetExtensionFunctionAddress` (X)

```
                                              25.18  25.22  25.35  25.44  25.48  26.22
zeDriverGetDefaultContext                       D      X      X      X      X      D
zeCommandListAppendLaunchKernelWithArguments    D      X      X      X      X      D
zeCommandListAppendLaunchKernelWithParameters   D      D      X      X      X      D
zeCommandListAppendHostFunction                 .      .      .      .      X      X
zexCommandListAppendHostFunction                .      .      .      X      .      .
```

Please note that all the possibly unavailable APIs are stored inside a context, because one platform might have multiple drivers with different features supported.