### PR TITLE
[SDPatternMatch] Remove MatchContext

### DIFF
--- a/llvm/include/llvm/CodeGen/SDPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/SDPatternMatch.h
@@ -28,67 +28,14 @@
 namespace llvm {
 namespace SDPatternMatch {
 
-/// MatchContext can repurpose existing patterns to behave differently under
-/// a certain context. For instance, `m_SpecificOpc(ISD::ADD)` matches plain ADD
-/// nodes in normal circumstances, but matches VP_ADD nodes under a custom
-/// VPMatchContext. This design is meant to facilitate code / pattern reusing.
-/// TODO: Remove now that we don't need to match over VP nodes.
-
-class BasicMatchContext {
-  const SelectionDAG *DAG;
-  const TargetLowering *TLI;
-
-public:
-  explicit BasicMatchContext(const SelectionDAG *DAG)
-      : DAG(DAG), TLI(DAG ? &DAG->getTargetLoweringInfo() : nullptr) {}
-
-  explicit BasicMatchContext(const TargetLowering *TLI)
-      : DAG(nullptr), TLI(TLI) {}
-
-  // A valid MatchContext has to implement the following functions.
-
-  const SelectionDAG *getDAG() const { return DAG; }
-
-  const TargetLowering *getTLI() const { return TLI; }
-
-  /// Return true if N effectively has opcode Opcode.
-  bool match(SDValue N, unsigned Opcode) const {
-    return N->getOpcode() == Opcode;
-  }
-
-  unsigned getNumOperands(SDValue N) const { return N->getNumOperands(); }
-};
-
-template <typename Pattern, typename MatchContext>
-[[nodiscard]] bool sd_context_match(SDValue N, const MatchContext &Ctx,
-                                    Pattern &&P) {
-  return P.match(Ctx, N);
-}
-
-template <typename Pattern, typename MatchContext>
-[[nodiscard]] bool sd_context_match(SDNode *N, const MatchContext &Ctx,
-                                    Pattern &&P) {
-  return sd_context_match(SDValue(N, 0), Ctx, P);
-}
-
 template <typename Pattern>
-[[nodiscard]] bool sd_match(SDNode *N, const SelectionDAG *DAG, Pattern &&P) {
-  return sd_context_match(N, BasicMatchContext(DAG), P);
-}
-
-template <typename Pattern>
-[[nodiscard]] bool sd_match(SDValue N, const SelectionDAG *DAG, Pattern &&P) {
-  return sd_context_match(N, BasicMatchContext(DAG), P);
+[[nodiscard]] bool sd_match(SDValue N, Pattern &&P) {
+  return P.match(N);
 }
 
 template <typename Pattern>
 [[nodiscard]] bool sd_match(SDNode *N, Pattern &&P) {
-  return sd_match(N, nullptr, P);
-}
-
-template <typename Pattern>
-[[nodiscard]] bool sd_match(SDValue N, Pattern &&P) {
-  return sd_match(N, nullptr, P);
+  return sd_match(SDValue(N, 0), P);
 }
 
 // === Utilities ===
@@ -99,7 +46,7 @@ struct Value_match {
 
   explicit Value_match(SDValue Match) : MatchVal(Match) {}
 
-  template <typename MatchContext> bool match(const MatchContext &, SDValue N) {
+  bool match(SDValue N) {
     if (MatchVal)
       return MatchVal == N;
     return N.getNode();
@@ -119,10 +66,7 @@ template <unsigned ResNo, typename Pattern> struct Result_match {
 
   explicit Result_match(const Pattern &P) : P(P) {}
 
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
-    return N.getResNo() == ResNo && P.match(Ctx, N);
-  }
+  bool match(SDValue N) { return N.getResNo() == ResNo && P.match(N); }
 };
 
 /// Match only if the SDValue is a certain result at ResNo.
@@ -136,9 +80,7 @@ struct DeferredValue_match {
 
   explicit DeferredValue_match(SDValue &Match) : MatchVal(Match) {}
 
-  template <typename MatchContext> bool match(const MatchContext &, SDValue N) {
-    return N == MatchVal;
-  }
+  bool match(SDValue N) { return N == MatchVal; }
 };
 
 /// Similar to m_Specific, but the specific value to match is determined by
@@ -155,17 +97,12 @@ struct Opcode_match {
 
   explicit Opcode_match(unsigned Opc) : Opcode(Opc) {}
 
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
-    return Ctx.match(N, Opcode);
-  }
+  bool match(SDValue N) { return N->getOpcode() == Opcode; }
 };
 
 // === Patterns combinators ===
 template <typename... Preds> struct And {
-  template <typename MatchContext> bool match(const MatchContext &, SDValue N) {
-    return true;
-  }
+  bool match(SDValue N) { return true; }
 };
 
 template <typename Pred, typename... Preds>
@@ -173,16 +110,11 @@ struct And<Pred, Preds...> : And<Preds...> {
   Pred P;
   And(const Pred &p, const Preds &...preds) : And<Preds...>(preds...), P(p) {}
 
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
-    return P.match(Ctx, N) && And<Preds...>::match(Ctx, N);
-  }
+  bool match(SDValue N) { return P.match(N) && And<Preds...>::match(N); }
 };
 
 template <typename... Preds> struct Or {
-  template <typename MatchContext> bool match(const MatchContext &, SDValue N) {
-    return false;
-  }
+  bool match(SDValue N) { return false; }
 };
 
 template <typename Pred, typename... Preds>
@@ -190,10 +122,7 @@ struct Or<Pred, Preds...> : Or<Preds...> {
   Pred P;
   Or(const Pred &p, const Preds &...preds) : Or<Preds...>(preds...), P(p) {}
 
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
-    return P.match(Ctx, N) || Or<Preds...>::match(Ctx, N);
-  }
+  bool match(SDValue N) { return P.match(N) || Or<Preds...>::match(N); }
 };
 
 template <typename Pred> struct Not {
@@ -201,10 +130,7 @@ template <typename Pred> struct Not {
 
   explicit Not(const Pred &P) : P(P) {}
 
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
-    return !P.match(Ctx, N);
-  }
+  bool match(SDValue N) { return !P.match(N); }
 };
 // Explicit deduction guide.
 template <typename Pred> Not(const Pred &P) -> Not<Pred>;
@@ -241,12 +167,11 @@ template <unsigned NumUses, typename Pattern> struct NUses_match {
 
   explicit NUses_match(const Pattern &P) : P(P) {}
 
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
+  bool match(SDValue N) {
     // SDNode::hasNUsesOfValue is pretty expensive when the SDNode produces
     // multiple results, hence we check the subsequent pattern here before
     // checking the number of value users.
-    return P.match(Ctx, N) && N->hasNUsesOfValue(NumUses, N.getResNo());
+    return P.match(N) && N->hasNUsesOfValue(NumUses, N.getResNo());
   }
 };
 
@@ -272,9 +197,8 @@ template <typename PredPattern> struct Value_bind {
 
   Value_bind(SDValue &N, const PredPattern &P) : BindVal(N), Pred(P) {}
 
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
-    if (!Pred.match(Ctx, N))
+  bool match(SDValue N) {
+    if (!Pred.match(N))
       return false;
 
     BindVal = N;
@@ -298,11 +222,7 @@ template <typename Pattern, typename PredFuncT> struct TLI_pred_match {
   TLI_pred_match(const PredFuncT &Pred, const Pattern &P)
       : P(P), PredFunc(Pred) {}
 
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
-    assert(Ctx.getTLI() && "TargetLowering is required for this pattern.");
-    return PredFunc(*Ctx.getTLI(), N) && P.match(Ctx, N);
-  }
+  bool match(SDValue N) { return PredFunc(N) && P.match(N); }
 };
 
 // Explicit deduction guide.
@@ -311,29 +231,13 @@ TLI_pred_match(const PredFuncT &Pred, const Pattern &P)
     -> TLI_pred_match<Pattern, PredFuncT>;
 
 /// Match legal SDNodes based on the information provided by TargetLowering.
-template <typename Pattern> inline auto m_LegalOp(const Pattern &P) {
-  return TLI_pred_match{[](const TargetLowering &TLI, SDValue N) {
-                          return TLI.isOperationLegal(N->getOpcode(),
-                                                      N.getValueType());
+template <typename Pattern>
+inline auto m_LegalOp(const SelectionDAG &DAG, const Pattern &P) {
+  return TLI_pred_match{[&DAG](SDValue N) {
+                          return DAG.getTargetLoweringInfo().isOperationLegal(
+                              N->getOpcode(), N.getValueType());
                         },
                         P};
-}
-
-/// Switch to a different MatchContext for subsequent patterns.
-template <typename NewMatchContext, typename Pattern> struct SwitchContext {
-  const NewMatchContext &Ctx;
-  Pattern P;
-
-  template <typename OrigMatchContext>
-  bool match(const OrigMatchContext &, SDValue N) {
-    return P.match(Ctx, N);
-  }
-};
-
-template <typename MatchContext, typename Pattern>
-inline SwitchContext<MatchContext, Pattern> m_Context(const MatchContext &Ctx,
-                                                      Pattern &&P) {
-  return SwitchContext<MatchContext, Pattern>{Ctx, std::move(P)};
 }
 
 // === Value type ===
@@ -344,10 +248,9 @@ template <typename Pattern> struct ValueType_bind {
 
   explicit ValueType_bind(EVT &Bind, const Pattern &P) : BindVT(Bind), P(P) {}
 
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
+  bool match(SDValue N) {
     BindVT = N.getValueType();
-    return P.match(Ctx, N);
+    return P.match(N);
   }
 };
 
@@ -368,10 +271,7 @@ template <typename Pattern, typename PredFuncT> struct ValueType_match {
   ValueType_match(const PredFuncT &Pred, const Pattern &P)
       : PredFunc(Pred), P(P) {}
 
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
-    return PredFunc(N.getValueType()) && P.match(Ctx, N);
-  }
+  bool match(SDValue N) { return PredFunc(N.getValueType()) && P.match(N); }
 };
 
 // Explicit deduction guide.
@@ -463,20 +363,20 @@ inline auto m_ScalableVectorVT() {
 }
 
 /// Match legal ValueTypes based on the information provided by TargetLowering.
-template <typename Pattern> inline auto m_LegalType(const Pattern &P) {
-  return TLI_pred_match{[](const TargetLowering &TLI, SDValue N) {
-                          return TLI.isTypeLegal(N.getValueType());
+template <typename Pattern>
+inline auto m_LegalType(const SelectionDAG &DAG, const Pattern &P) {
+  return TLI_pred_match{[&DAG](SDValue N) {
+                          return DAG.getTargetLoweringInfo().isTypeLegal(
+                              N.getValueType());
                         },
                         P};
 }
 
 // === Generic node matching ===
 template <unsigned OpIdx, typename... OpndPreds> struct Operands_match {
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
+  bool match(SDValue N) {
     // Returns false if there are more operands than predicates;
-    // Ignores the last two operands if both the Context and the Node are VP
-    return Ctx.getNumOperands(N) == OpIdx;
+    return N->getNumOperands() == OpIdx;
   }
 };
 
@@ -488,11 +388,10 @@ struct Operands_match<OpIdx, OpndPred, OpndPreds...>
   Operands_match(const OpndPred &p, const OpndPreds &...preds)
       : Operands_match<OpIdx + 1, OpndPreds...>(preds...), P(p) {}
 
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
+  bool match(SDValue N) {
     if (OpIdx < N->getNumOperands())
-      return P.match(Ctx, N->getOperand(OpIdx)) &&
-             Operands_match<OpIdx + 1, OpndPreds...>::match(Ctx, N);
+      return P.match(N->getOperand(OpIdx)) &&
+             Operands_match<OpIdx + 1, OpndPreds...>::match(N);
 
     // This is the case where there are more predicates than operands.
     return false;
@@ -511,9 +410,8 @@ template <bool ExcludeChain> struct EffectiveOperands {
   unsigned Size = 0;
   unsigned FirstIndex = 0;
 
-  template <typename MatchContext>
-  explicit EffectiveOperands(SDValue N, const MatchContext &Ctx) {
-    const unsigned TotalNumOps = Ctx.getNumOperands(N);
+  explicit EffectiveOperands(SDValue N) {
+    const unsigned TotalNumOps = N->getNumOperands();
     FirstIndex = TotalNumOps;
     for (unsigned I = 0; I < TotalNumOps; ++I) {
       // Count the number of non-chain and non-glue nodes (we ignore chain
@@ -532,9 +430,7 @@ template <> struct EffectiveOperands<false> {
   unsigned Size = 0;
   unsigned FirstIndex = 0;
 
-  template <typename MatchContext>
-  explicit EffectiveOperands(SDValue N, const MatchContext &Ctx)
-      : Size(Ctx.getNumOperands(N)) {}
+  explicit EffectiveOperands(SDValue N) : Size(N->getNumOperands()) {}
 };
 
 // === Ternary operations ===
@@ -550,16 +446,15 @@ struct TernaryOpc_match {
                    const T2_P &Op2)
       : Opcode(Opc), Op0(Op0), Op1(Op1), Op2(Op2) {}
 
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
-    if (sd_context_match(N, Ctx, m_SpecificOpc(Opcode))) {
-      EffectiveOperands<ExcludeChain> EO(N, Ctx);
+  bool match(SDValue N) {
+    if (sd_match(N, m_SpecificOpc(Opcode))) {
+      EffectiveOperands<ExcludeChain> EO(N);
       assert(EO.Size == 3);
-      return ((Op0.match(Ctx, N->getOperand(EO.FirstIndex)) &&
-               Op1.match(Ctx, N->getOperand(EO.FirstIndex + 1))) ||
-              (Commutable && Op0.match(Ctx, N->getOperand(EO.FirstIndex + 1)) &&
-               Op1.match(Ctx, N->getOperand(EO.FirstIndex)))) &&
-             Op2.match(Ctx, N->getOperand(EO.FirstIndex + 2));
+      return ((Op0.match(N->getOperand(EO.FirstIndex)) &&
+               Op1.match(N->getOperand(EO.FirstIndex + 1))) ||
+              (Commutable && Op0.match(N->getOperand(EO.FirstIndex + 1)) &&
+               Op1.match(N->getOperand(EO.FirstIndex)))) &&
+             Op2.match(N->getOperand(EO.FirstIndex + 2));
     }
 
     return false;
@@ -659,15 +554,14 @@ struct BinaryOpc_match {
                   SDNodeFlags Flgs = SDNodeFlags())
       : Opcode(Opc), LHS(L), RHS(R), Flags(Flgs) {}
 
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
-    if (sd_context_match(N, Ctx, m_SpecificOpc(Opcode))) {
-      EffectiveOperands<ExcludeChain> EO(N, Ctx);
+  bool match(SDValue N) {
+    if (sd_match(N, m_SpecificOpc(Opcode))) {
+      EffectiveOperands<ExcludeChain> EO(N);
       assert(EO.Size == 2);
-      if (!((LHS.match(Ctx, N->getOperand(EO.FirstIndex)) &&
-             RHS.match(Ctx, N->getOperand(EO.FirstIndex + 1))) ||
-            (Commutable && LHS.match(Ctx, N->getOperand(EO.FirstIndex + 1)) &&
-             RHS.match(Ctx, N->getOperand(EO.FirstIndex)))))
+      if (!((LHS.match(N->getOperand(EO.FirstIndex)) &&
+             RHS.match(N->getOperand(EO.FirstIndex + 1))) ||
+            (Commutable && LHS.match(N->getOperand(EO.FirstIndex + 1)) &&
+             RHS.match(N->getOperand(EO.FirstIndex)))))
         return false;
 
       return (Flags & N->getFlags()) == Flags;
@@ -686,11 +580,10 @@ template <typename T0, typename T1, typename T2> struct SDShuffle_match {
   SDShuffle_match(const T0 &Op1, const T1 &Op2, const T2 &Mask)
       : Op1(Op1), Op2(Op2), Mask(Mask) {}
 
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
+  bool match(SDValue N) {
     if (auto *I = dyn_cast<ShuffleVectorSDNode>(N)) {
-      return Op1.match(Ctx, I->getOperand(0)) &&
-             Op2.match(Ctx, I->getOperand(1)) && Mask.match(I->getMask());
+      return Op1.match(I->getOperand(0)) && Op2.match(I->getOperand(1)) &&
+             Mask.match(I->getMask());
     }
     return false;
   }
@@ -719,8 +612,7 @@ struct MaxMin_match {
 
   MaxMin_match(const LHS_P &L, const RHS_P &R) : LHS(L), RHS(R) {}
 
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
+  bool match(SDValue N) {
     auto MatchMinMax = [&](SDValue L, SDValue R, SDValue TrueValue,
                            SDValue FalseValue, ISD::CondCode CC) {
       if ((TrueValue != L || FalseValue != R) &&
@@ -732,20 +624,20 @@ struct MaxMin_match {
       if (!Pred_t::match(Cond))
         return false;
 
-      return (LHS.match(Ctx, L) && RHS.match(Ctx, R)) ||
-             (Commutable && LHS.match(Ctx, R) && RHS.match(Ctx, L));
+      return (LHS.match(L) && RHS.match(R)) ||
+             (Commutable && LHS.match(R) && RHS.match(L));
     };
 
-    if (sd_context_match(N, Ctx, m_SpecificOpc(ISD::SELECT)) ||
-        sd_context_match(N, Ctx, m_SpecificOpc(ISD::VSELECT))) {
-      EffectiveOperands<ExcludeChain> EO_SELECT(N, Ctx);
+    if (sd_match(N, m_SpecificOpc(ISD::SELECT)) ||
+        sd_match(N, m_SpecificOpc(ISD::VSELECT))) {
+      EffectiveOperands<ExcludeChain> EO_SELECT(N);
       assert(EO_SELECT.Size == 3);
       SDValue Cond = N->getOperand(EO_SELECT.FirstIndex);
       SDValue TrueValue = N->getOperand(EO_SELECT.FirstIndex + 1);
       SDValue FalseValue = N->getOperand(EO_SELECT.FirstIndex + 2);
 
-      if (sd_context_match(Cond, Ctx, m_SpecificOpc(ISD::SETCC))) {
-        EffectiveOperands<ExcludeChain> EO_SETCC(Cond, Ctx);
+      if (sd_match(Cond, m_SpecificOpc(ISD::SETCC))) {
+        EffectiveOperands<ExcludeChain> EO_SETCC(Cond);
         assert(EO_SETCC.Size == 3);
         SDValue L = Cond->getOperand(EO_SETCC.FirstIndex);
         SDValue R = Cond->getOperand(EO_SETCC.FirstIndex + 1);
@@ -755,8 +647,8 @@ struct MaxMin_match {
       }
     }
 
-    if (sd_context_match(N, Ctx, m_SpecificOpc(ISD::SELECT_CC))) {
-      EffectiveOperands<ExcludeChain> EO_SELECT(N, Ctx);
+    if (sd_match(N, m_SpecificOpc(ISD::SELECT_CC))) {
+      EffectiveOperands<ExcludeChain> EO_SELECT(N);
       assert(EO_SELECT.Size == 5);
       SDValue L = N->getOperand(EO_SELECT.FirstIndex);
       SDValue R = N->getOperand(EO_SELECT.FirstIndex + 1);
@@ -904,11 +796,12 @@ inline BinaryOpc_match<LHS, RHS, true> m_SMin(const LHS &L, const RHS &R) {
 }
 
 template <typename LHS, typename RHS>
-inline auto m_SMinLike(const LHS &L, const RHS &R) {
-  return m_AnyOf(
-      m_MaxMinLike<ISD::SMIN, smin_pred_ty>(L, R),
-      m_MaxMinLike<ISD::UMIN, umin_pred_ty>(m_NonNegative(L), m_NonNegative(R)),
-      m_MaxMinLike<ISD::UMIN, umin_pred_ty>(m_Negative(L), m_Negative(R)));
+inline auto m_SMinLike(const SelectionDAG &DAG, const LHS &L, const RHS &R) {
+  return m_AnyOf(m_MaxMinLike<ISD::SMIN, smin_pred_ty>(L, R),
+                 m_MaxMinLike<ISD::UMIN, umin_pred_ty>(m_NonNegative(DAG, L),
+                                                       m_NonNegative(DAG, R)),
+                 m_MaxMinLike<ISD::UMIN, umin_pred_ty>(m_Negative(DAG, L),
+                                                       m_Negative(DAG, R)));
 }
 
 template <typename LHS, typename RHS>
@@ -917,11 +810,12 @@ inline BinaryOpc_match<LHS, RHS, true> m_SMax(const LHS &L, const RHS &R) {
 }
 
 template <typename LHS, typename RHS>
-inline auto m_SMaxLike(const LHS &L, const RHS &R) {
-  return m_AnyOf(
-      m_MaxMinLike<ISD::SMAX, smax_pred_ty>(L, R),
-      m_MaxMinLike<ISD::UMAX, umax_pred_ty>(m_NonNegative(L), m_NonNegative(R)),
-      m_MaxMinLike<ISD::UMAX, umax_pred_ty>(m_Negative(L), m_Negative(R)));
+inline auto m_SMaxLike(const SelectionDAG &DAG, const LHS &L, const RHS &R) {
+  return m_AnyOf(m_MaxMinLike<ISD::SMAX, smax_pred_ty>(L, R),
+                 m_MaxMinLike<ISD::UMAX, umax_pred_ty>(m_NonNegative(DAG, L),
+                                                       m_NonNegative(DAG, R)),
+                 m_MaxMinLike<ISD::UMAX, umax_pred_ty>(m_Negative(DAG, L),
+                                                       m_Negative(DAG, R)));
 }
 
 template <typename LHS, typename RHS>
@@ -930,11 +824,12 @@ inline BinaryOpc_match<LHS, RHS, true> m_UMin(const LHS &L, const RHS &R) {
 }
 
 template <typename LHS, typename RHS>
-inline auto m_UMinLike(const LHS &L, const RHS &R) {
-  return m_AnyOf(
-      m_MaxMinLike<ISD::UMIN, umin_pred_ty>(L, R),
-      m_MaxMinLike<ISD::SMIN, smin_pred_ty>(m_NonNegative(L), m_NonNegative(R)),
-      m_MaxMinLike<ISD::SMIN, smin_pred_ty>(m_Negative(L), m_Negative(R)));
+inline auto m_UMinLike(const SelectionDAG &DAG, const LHS &L, const RHS &R) {
+  return m_AnyOf(m_MaxMinLike<ISD::UMIN, umin_pred_ty>(L, R),
+                 m_MaxMinLike<ISD::SMIN, smin_pred_ty>(m_NonNegative(DAG, L),
+                                                       m_NonNegative(DAG, R)),
+                 m_MaxMinLike<ISD::SMIN, smin_pred_ty>(m_Negative(DAG, L),
+                                                       m_Negative(DAG, R)));
 }
 
 template <typename LHS, typename RHS>
@@ -943,11 +838,12 @@ inline BinaryOpc_match<LHS, RHS, true> m_UMax(const LHS &L, const RHS &R) {
 }
 
 template <typename LHS, typename RHS>
-inline auto m_UMaxLike(const LHS &L, const RHS &R) {
-  return m_AnyOf(
-      m_MaxMinLike<ISD::UMAX, umax_pred_ty>(L, R),
-      m_MaxMinLike<ISD::SMAX, smax_pred_ty>(m_NonNegative(L), m_NonNegative(R)),
-      m_MaxMinLike<ISD::SMAX, smax_pred_ty>(m_Negative(L), m_Negative(R)));
+inline auto m_UMaxLike(const SelectionDAG &DAG, const LHS &L, const RHS &R) {
+  return m_AnyOf(m_MaxMinLike<ISD::UMAX, umax_pred_ty>(L, R),
+                 m_MaxMinLike<ISD::SMAX, smax_pred_ty>(m_NonNegative(DAG, L),
+                                                       m_NonNegative(DAG, R)),
+                 m_MaxMinLike<ISD::SMAX, smax_pred_ty>(m_Negative(DAG, L),
+                                                       m_Negative(DAG, R)));
 }
 
 template <typename LHS, typename RHS>
@@ -1030,27 +926,22 @@ struct FunnelShiftLike_match {
            APInt(SumWidth, BitWidth);
   }
 
-  template <typename MatchContext>
-  bool matchOperands(const MatchContext &Ctx, SDValue X, SDValue Y, SDValue Z) {
-    return Op0.match(Ctx, X) && Op1.match(Ctx, Y) && Op2.match(Ctx, Z);
+  bool matchOperands(SDValue X, SDValue Y, SDValue Z) {
+    return Op0.match(X) && Op1.match(Y) && Op2.match(Z);
   }
 
-  template <typename MatchContext>
-  bool matchShiftOr(const MatchContext &Ctx, SDValue N, unsigned BitWidth);
+  bool matchShiftOr(SDValue N, unsigned BitWidth);
 
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
-    if (sd_context_match(N, Ctx,
-                         Left ? m_FShL(Op0, Op1, Op2) : m_FShR(Op0, Op1, Op2)))
+  bool match(SDValue N) {
+    if (sd_match(N, Left ? m_FShL(Op0, Op1, Op2) : m_FShR(Op0, Op1, Op2)))
       return true;
 
     SDValue X, Z;
-    if (sd_context_match(N, Ctx,
-                         Left ? m_Rotl(m_Value(X), m_Value(Z))
-                              : m_Rotr(m_Value(X), m_Value(Z))))
-      return matchOperands(Ctx, X, X, Z);
+    if (sd_match(N, Left ? m_Rotl(m_Value(X), m_Value(Z))
+                         : m_Rotr(m_Value(X), m_Value(Z))))
+      return matchOperands(X, X, Z);
 
-    return matchShiftOr(Ctx, N, N.getValueType().getScalarSizeInBits());
+    return matchShiftOr(N, N.getValueType().getScalarSizeInBits());
   }
 };
 
@@ -1127,12 +1018,11 @@ template <typename Opnd_P, bool ExcludeChain = false> struct UnaryOpc_match {
                  SDNodeFlags Flgs = SDNodeFlags())
       : Opcode(Opc), Opnd(Op), Flags(Flgs) {}
 
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
-    if (sd_context_match(N, Ctx, m_SpecificOpc(Opcode))) {
-      EffectiveOperands<ExcludeChain> EO(N, Ctx);
+  bool match(SDValue N) {
+    if (sd_match(N, m_SpecificOpc(Opcode))) {
+      EffectiveOperands<ExcludeChain> EO(N);
       assert(EO.Size == 1);
-      if (!Opnd.match(Ctx, N->getOperand(EO.FirstIndex)))
+      if (!Opnd.match(N->getOperand(EO.FirstIndex)))
         return false;
 
       return (Flags & N->getFlags()) == Flags;
@@ -1265,7 +1155,7 @@ struct ConstantInt_match {
 
   explicit ConstantInt_match(APInt *V) : BindVal(V) {}
 
-  template <typename MatchContext> bool match(const MatchContext &, SDValue N) {
+  bool match(SDValue N) {
     // The logics here are similar to that in
     // SelectionDAG::isConstantIntBuildVectorOrConstantInt, but the latter also
     // treats GlobalAddressSDNode as a constant, which is difficult to turn into
@@ -1289,10 +1179,9 @@ template <typename T> struct Constant64_match {
 
   explicit Constant64_match(T &V) : BindVal(V) {}
 
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
+  bool match(SDValue N) {
     APInt V;
-    if (!ConstantInt_match(&V).match(Ctx, N))
+    if (!ConstantInt_match(&V).match(N))
       return false;
 
     if constexpr (std::is_signed_v<T>) {
@@ -1332,19 +1221,17 @@ inline Constant64_match<int64_t> m_ConstInt(int64_t &V) {
 }
 
 template <typename T0_P, typename T1_P, typename T2_P, bool Left>
-template <typename MatchContext>
 bool FunnelShiftLike_match<T0_P, T1_P, T2_P, Left>::matchShiftOr(
-    const MatchContext &Ctx, SDValue N, unsigned BitWidth) {
+    SDValue N, unsigned BitWidth) {
   SDValue X, Y, ShlAmt, SrlAmt;
   APInt ShlConst, SrlConst;
-  if (!sd_context_match(
-          N, Ctx,
-          m_Or(m_Shl(m_Value(X), m_Value(ShlAmt, m_ConstInt(ShlConst))),
-               m_Srl(m_Value(Y), m_Value(SrlAmt, m_ConstInt(SrlConst))))) ||
+  if (!sd_match(
+          N, m_Or(m_Shl(m_Value(X), m_Value(ShlAmt, m_ConstInt(ShlConst))),
+                  m_Srl(m_Value(Y), m_Value(SrlAmt, m_ConstInt(SrlConst))))) ||
       !hasComplementaryConstantShifts(ShlConst, SrlConst, BitWidth))
     return false;
 
-  return matchOperands(Ctx, X, Y, Left ? ShlAmt : SrlAmt);
+  return matchOperands(X, Y, Left ? ShlAmt : SrlAmt);
 }
 
 struct SpecificInt_match {
@@ -1352,10 +1239,9 @@ struct SpecificInt_match {
 
   explicit SpecificInt_match(APInt APV) : IntVal(std::move(APV)) {}
 
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
+  bool match(SDValue N) {
     APInt ConstInt;
-    if (sd_context_match(N, Ctx, m_ConstInt(ConstInt)))
+    if (sd_match(N, m_ConstInt(ConstInt)))
       return APInt::isSameValue(IntVal, ConstInt);
     return false;
   }
@@ -1374,8 +1260,7 @@ struct SpecificFP_match {
 
   explicit SpecificFP_match(APFloat V) : Val(V) {}
 
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue V) {
+  bool match(SDValue V) {
     if (const auto *CFP = dyn_cast<ConstantFPSDNode>(V.getNode()))
       return CFP->isExactlyValue(Val);
     if (ConstantFPSDNode *C = isConstOrConstSplatFP(V, /*AllowUndefs=*/true))
@@ -1392,7 +1277,7 @@ inline SpecificFP_match m_SpecificFP(double V) {
 }
 
 struct AnyZeroFP_match {
-  template <typename MatchContext> bool match(const MatchContext &, SDValue N) {
+  bool match(SDValue N) {
     if (ConstantFPSDNode *C = isConstOrConstSplatFP(N))
       return C->isZero();
     return false;
@@ -1403,43 +1288,28 @@ struct AnyZeroFP_match {
 inline AnyZeroFP_match m_AnyZeroFP() { return AnyZeroFP_match(); }
 
 struct Negative_match {
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
-    const SelectionDAG *DAG = Ctx.getDAG();
-    return DAG && DAG->computeKnownBits(N).isNegative();
-  }
+  const SelectionDAG &DAG;
+  bool match(SDValue N) { return DAG.computeKnownBits(N).isNegative(); }
 };
 
 struct NonNegative_match {
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
-    const SelectionDAG *DAG = Ctx.getDAG();
-    return DAG && DAG->computeKnownBits(N).isNonNegative();
-  }
+  const SelectionDAG &DAG;
+  bool match(SDValue N) { return DAG.computeKnownBits(N).isNonNegative(); }
 };
 
 struct StrictlyPositive_match {
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
-    const SelectionDAG *DAG = Ctx.getDAG();
-    return DAG && DAG->computeKnownBits(N).isStrictlyPositive();
-  }
+  const SelectionDAG &DAG;
+  bool match(SDValue N) { return DAG.computeKnownBits(N).isStrictlyPositive(); }
 };
 
 struct NonPositive_match {
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
-    const SelectionDAG *DAG = Ctx.getDAG();
-    return DAG && DAG->computeKnownBits(N).isNonPositive();
-  }
+  const SelectionDAG &DAG;
+  bool match(SDValue N) { return DAG.computeKnownBits(N).isNonPositive(); }
 };
 
 struct NonZero_match {
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
-    const SelectionDAG *DAG = Ctx.getDAG();
-    return DAG && DAG->computeKnownBits(N).isNonZero();
-  }
+  const SelectionDAG &DAG;
+  bool match(SDValue N) { return DAG.computeKnownBits(N).isNonZero(); }
 };
 
 struct Zero_match {
@@ -1447,10 +1317,7 @@ struct Zero_match {
 
   explicit Zero_match(bool AllowUndefs) : AllowUndefs(AllowUndefs) {}
 
-  template <typename MatchContext>
-  bool match(const MatchContext &, SDValue N) const {
-    return isZeroOrZeroSplat(N, AllowUndefs);
-  }
+  bool match(SDValue N) const { return isZeroOrZeroSplat(N, AllowUndefs); }
 };
 
 struct Ones_match {
@@ -1458,9 +1325,7 @@ struct Ones_match {
 
   Ones_match(bool AllowUndefs) : AllowUndefs(AllowUndefs) {}
 
-  template <typename MatchContext> bool match(const MatchContext &, SDValue N) {
-    return isOnesOrOnesSplat(N, AllowUndefs);
-  }
+  bool match(SDValue N) { return isOnesOrOnesSplat(N, AllowUndefs); }
 };
 
 struct AllOnes_match {
@@ -1468,32 +1333,39 @@ struct AllOnes_match {
 
   AllOnes_match(bool AllowUndefs) : AllowUndefs(AllowUndefs) {}
 
-  template <typename MatchContext> bool match(const MatchContext &, SDValue N) {
-    return isAllOnesOrAllOnesSplat(N, AllowUndefs);
-  }
+  bool match(SDValue N) { return isAllOnesOrAllOnesSplat(N, AllowUndefs); }
 };
 
-inline Negative_match m_Negative() { return Negative_match(); }
-template <typename Pattern> inline auto m_Negative(const Pattern &P) {
-  return m_AllOf(m_Negative(), P);
+inline Negative_match m_Negative(const SelectionDAG &DAG) { return {DAG}; }
+template <typename Pattern>
+inline auto m_Negative(const SelectionDAG &DAG, const Pattern &P) {
+  return m_AllOf(m_Negative(DAG), P);
 }
-inline NonNegative_match m_NonNegative() { return NonNegative_match(); }
-template <typename Pattern> inline auto m_NonNegative(const Pattern &P) {
-  return m_AllOf(m_NonNegative(), P);
+inline NonNegative_match m_NonNegative(const SelectionDAG &DAG) {
+  return {DAG};
 }
-inline StrictlyPositive_match m_StrictlyPositive() {
-  return StrictlyPositive_match();
+template <typename Pattern>
+inline auto m_NonNegative(const SelectionDAG &DAG, const Pattern &P) {
+  return m_AllOf(m_NonNegative(DAG), P);
 }
-template <typename Pattern> inline auto m_StrictlyPositive(const Pattern &P) {
-  return m_AllOf(m_StrictlyPositive(), P);
+inline StrictlyPositive_match m_StrictlyPositive(const SelectionDAG &DAG) {
+  return {DAG};
 }
-inline NonPositive_match m_NonPositive() { return NonPositive_match(); }
-template <typename Pattern> inline auto m_NonPositive(const Pattern &P) {
-  return m_AllOf(m_NonPositive(), P);
+template <typename Pattern>
+inline auto m_StrictlyPositive(const SelectionDAG &DAG, const Pattern &P) {
+  return m_AllOf(m_StrictlyPositive(DAG), P);
 }
-inline NonZero_match m_NonZero() { return NonZero_match(); }
-template <typename Pattern> inline auto m_NonZero(const Pattern &P) {
-  return m_AllOf(m_NonZero(), P);
+inline NonPositive_match m_NonPositive(const SelectionDAG &DAG) {
+  return {DAG};
+}
+template <typename Pattern>
+inline auto m_NonPositive(const SelectionDAG &DAG, const Pattern &P) {
+  return m_AllOf(m_NonPositive(DAG), P);
+}
+inline NonZero_match m_NonZero(const SelectionDAG &DAG) { return {DAG}; }
+template <typename Pattern>
+inline auto m_NonZero(const SelectionDAG &DAG, const Pattern &P) {
+  return m_AllOf(m_NonZero(DAG), P);
 }
 inline Ones_match m_One(bool AllowUndefs = false) {
   return Ones_match(AllowUndefs);
@@ -1507,12 +1379,13 @@ inline AllOnes_match m_AllOnes(bool AllowUndefs = false) {
 
 /// Match true boolean value based on the information provided by
 /// TargetLowering.
-inline auto m_True() {
+inline auto m_True(const SelectionDAG &DAG) {
   return TLI_pred_match{
-      [](const TargetLowering &TLI, SDValue N) {
+      [&DAG](SDValue N) {
         APInt ConstVal;
         if (sd_match(N, m_ConstInt(ConstVal)))
-          switch (TLI.getBooleanContents(N.getValueType())) {
+          switch (DAG.getTargetLoweringInfo().getBooleanContents(
+              N.getValueType())) {
           case TargetLowering::ZeroOrOneBooleanContent:
             return ConstVal.isOne();
           case TargetLowering::ZeroOrNegativeOneBooleanContent:
@@ -1527,12 +1400,13 @@ inline auto m_True() {
 }
 /// Match false boolean value based on the information provided by
 /// TargetLowering.
-inline auto m_False() {
+inline auto m_False(const SelectionDAG &DAG) {
   return TLI_pred_match{
-      [](const TargetLowering &TLI, SDValue N) {
+      [&DAG](SDValue N) {
         APInt ConstVal;
         if (sd_match(N, m_ConstInt(ConstVal)))
-          switch (TLI.getBooleanContents(N.getValueType())) {
+          switch (DAG.getTargetLoweringInfo().getBooleanContents(
+              N.getValueType())) {
           case TargetLowering::ZeroOrOneBooleanContent:
           case TargetLowering::ZeroOrNegativeOneBooleanContent:
             return ConstVal.isZero();
@@ -1553,7 +1427,7 @@ struct CondCode_match {
 
   explicit CondCode_match(ISD::CondCode *CC) : BindCC(CC) {}
 
-  template <typename MatchContext> bool match(const MatchContext &, SDValue N) {
+  bool match(SDValue N) {
     if (auto *CC = dyn_cast<CondCodeSDNode>(N.getNode())) {
       if (CCToMatch && *CCToMatch != CC->get())
         return false;
@@ -1600,9 +1474,8 @@ struct SpecificNeg_match {
 
   explicit SpecificNeg_match(SDValue V) : V(V) {}
 
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
-    if (sd_context_match(N, Ctx, m_Neg(m_Specific(V))))
+  bool match(SDValue N) {
+    if (sd_match(N, m_Neg(m_Specific(V))))
       return true;
 
     return ISD::matchBinaryPredicate(
@@ -1633,8 +1506,7 @@ template <typename... PatternTs> struct ReassociatableOpc_match {
                           const PatternTs &...Patterns)
       : Opcode(Opcode), Patterns(Patterns...), Flags(Flags) {}
 
-  template <typename MatchContext>
-  bool match(const MatchContext &Ctx, SDValue N) {
+  bool match(SDValue N) {
     std::array<SDValue, NumPatterns> Leaves;
     size_t LeavesIdx = 0;
     if (!(collectLeaves(N, Leaves, LeavesIdx) && (LeavesIdx == NumPatterns)))
@@ -1643,7 +1515,7 @@ template <typename... PatternTs> struct ReassociatableOpc_match {
     Bitset<NumPatterns> Used;
     return std::apply(
         [&](auto &...P) -> bool {
-          return reassociatableMatchHelper(Ctx, Leaves, Used, P...);
+          return reassociatableMatchHelper(Leaves, Used, P...);
         },
         Patterns);
   }
@@ -1663,25 +1535,24 @@ template <typename... PatternTs> struct ReassociatableOpc_match {
   }
 
   // Searchs for a matching leaf for every sub-pattern.
-  template <typename MatchContext, typename PatternHd, typename... PatternTl>
+  template <typename PatternHd, typename... PatternTl>
   [[nodiscard]] inline bool
-  reassociatableMatchHelper(const MatchContext &Ctx, ArrayRef<SDValue> Leaves,
-                            Bitset<NumPatterns> &Used, PatternHd &HeadPattern,
+  reassociatableMatchHelper(ArrayRef<SDValue> Leaves, Bitset<NumPatterns> &Used,
+                            PatternHd &HeadPattern,
                             PatternTl &...TailPatterns) {
     for (size_t Match = 0, N = Used.size(); Match < N; Match++) {
-      if (Used[Match] || !(sd_context_match(Leaves[Match], Ctx, HeadPattern)))
+      if (Used[Match] || !(sd_match(Leaves[Match], HeadPattern)))
         continue;
       Used.set(Match);
-      if (reassociatableMatchHelper(Ctx, Leaves, Used, TailPatterns...))
+      if (reassociatableMatchHelper(Leaves, Used, TailPatterns...))
         return true;
       Used.reset(Match);
     }
     return false;
   }
 
-  template <typename MatchContext>
   [[nodiscard]] inline bool
-  reassociatableMatchHelper(const MatchContext &Ctx, ArrayRef<SDValue> Leaves,
+  reassociatableMatchHelper(ArrayRef<SDValue> Leaves,
                             Bitset<NumPatterns> &Used) {
     return true;
   }

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -4646,26 +4646,26 @@ SDValue DAGCombiner::visitSUB(SDNode *N) {
 
   // smax(a,b) - smin(a,b) --> abds(a,b)
   if ((!LegalOperations || hasOperation(ISD::ABDS, VT)) &&
-      sd_match(N0, &DAG, m_SMaxLike(m_Value(A), m_Value(B))) &&
-      sd_match(N1, &DAG, m_SMinLike(m_Specific(A), m_Specific(B))))
+      sd_match(N0, m_SMaxLike(DAG, m_Value(A), m_Value(B))) &&
+      sd_match(N1, m_SMinLike(DAG, m_Specific(A), m_Specific(B))))
     return DAG.getNode(ISD::ABDS, DL, VT, A, B);
 
   // smin(a,b) - smax(a,b) --> neg(abds(a,b))
   if (hasOperation(ISD::ABDS, VT) &&
-      sd_match(N0, &DAG, m_SMinLike(m_Value(A), m_Value(B))) &&
-      sd_match(N1, &DAG, m_SMaxLike(m_Specific(A), m_Specific(B))))
+      sd_match(N0, m_SMinLike(DAG, m_Value(A), m_Value(B))) &&
+      sd_match(N1, m_SMaxLike(DAG, m_Specific(A), m_Specific(B))))
     return DAG.getNegative(DAG.getNode(ISD::ABDS, DL, VT, A, B), DL, VT);
 
   // umax(a,b) - umin(a,b) --> abdu(a,b)
   if ((!LegalOperations || hasOperation(ISD::ABDU, VT)) &&
-      sd_match(N0, &DAG, m_UMaxLike(m_Value(A), m_Value(B))) &&
-      sd_match(N1, &DAG, m_UMinLike(m_Specific(A), m_Specific(B))))
+      sd_match(N0, m_UMaxLike(DAG, m_Value(A), m_Value(B))) &&
+      sd_match(N1, m_UMinLike(DAG, m_Specific(A), m_Specific(B))))
     return DAG.getNode(ISD::ABDU, DL, VT, A, B);
 
   // umin(a,b) - umax(a,b) --> neg(abdu(a,b))
   if (hasOperation(ISD::ABDU, VT) &&
-      sd_match(N0, &DAG, m_UMinLike(m_Value(A), m_Value(B))) &&
-      sd_match(N1, &DAG, m_UMaxLike(m_Specific(A), m_Specific(B))))
+      sd_match(N0, m_UMinLike(DAG, m_Value(A), m_Value(B))) &&
+      sd_match(N1, m_UMaxLike(DAG, m_Specific(A), m_Specific(B))))
     return DAG.getNegative(DAG.getNode(ISD::ABDU, DL, VT, A, B), DL, VT);
 
   return SDValue();

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -56286,7 +56286,7 @@ static SDValue combineVTRUNCSAT(SDNode *N, SelectionDAG &DAG,
   if (EltSizeInBits <= 16 &&
       (sd_match(N, m_UnaryOp(X86ISD::VTRUNCS, m_Value(Src))) ||
        sd_match(N, m_UnaryOp(X86ISD::VTRUNCUS,
-                             m_SMaxLike(m_Value(Src), m_Zero())))) &&
+                             m_SMaxLike(DAG, m_Value(Src), m_Zero())))) &&
       (EltSizeInBits * 2) == Src.getScalarValueSizeInBits() &&
       isFreeToSplitVector(Src, DAG)) {
     SDLoc DL(N);
@@ -61056,8 +61056,8 @@ static SDValue combineConcatVectorOps(const SDLoc &DL, MVT VT,
           using namespace SDPatternMatch;
           SDValue N0 = Ops[0].getOperand(0), N1 = Ops[1].getOperand(0);
           if (Opcode == X86ISD::VTRUNCS ||
-              (sd_match(N0, m_SMaxLike(m_Value(N0), m_Zero())) &&
-               sd_match(N1, m_SMaxLike(m_Value(N1), m_Zero())))) {
+              (sd_match(N0, m_SMaxLike(DAG, m_Value(N0), m_Zero())) &&
+               sd_match(N1, m_SMaxLike(DAG, m_Value(N1), m_Zero())))) {
             N0 = DAG.getBitcast(MVT::v8i64, N0);
             N1 = DAG.getBitcast(MVT::v8i64, N1);
             SDValue LHS = DAG.getVectorShuffle(MVT::v8i64, DL, N0, N1,

--- a/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
+++ b/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
@@ -379,111 +379,111 @@ TEST_F(SelectionDAGPatternMatchTest, matchBinaryOp) {
 
   EXPECT_TRUE(sd_match(SMax, m_c_BinOp(ISD::SMAX, m_Value(), m_Value())));
   EXPECT_TRUE(sd_match(SMax, m_SMax(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(SMax, m_SMaxLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(SMaxLikeGT, m_SMaxLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(SMaxLikeGE, m_SMaxLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(CCSMaxLikeGT, m_SMaxLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(CCSMaxLikeGE, m_SMaxLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(CCSMaxLikeLT, m_SMaxLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(CCSMaxLikeLE, m_SMaxLike(m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(SMax, m_SMaxLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(SMaxLikeGT, m_SMaxLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(SMaxLikeGE, m_SMaxLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(CCSMaxLikeGT, m_SMaxLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(CCSMaxLikeGE, m_SMaxLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(CCSMaxLikeLT, m_SMaxLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(CCSMaxLikeLE, m_SMaxLike(*DAG, m_Value(), m_Value())));
   EXPECT_TRUE(sd_match(SMin, m_c_BinOp(ISD::SMIN, m_Value(), m_Value())));
   EXPECT_TRUE(sd_match(SMin, m_SMin(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(SMin, m_SMinLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(SMinLikeLT, m_SMinLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(SMinLikeLE, m_SMinLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(CCSMinLikeGT, m_SMinLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(CCSMinLikeGE, m_SMinLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(CCSMinLikeLT, m_SMinLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(CCSMinLikeLE, m_SMinLike(m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(SMin, m_SMinLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(SMinLikeLT, m_SMinLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(SMinLikeLE, m_SMinLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(CCSMinLikeGT, m_SMinLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(CCSMinLikeGE, m_SMinLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(CCSMinLikeLT, m_SMinLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(CCSMinLikeLE, m_SMinLike(*DAG, m_Value(), m_Value())));
   EXPECT_TRUE(sd_match(UMax, m_c_BinOp(ISD::UMAX, m_Value(), m_Value())));
   EXPECT_TRUE(sd_match(UMax, m_UMax(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(UMax, m_UMaxLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(UMaxLikeUGT, m_UMaxLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(UMaxLikeUGE, m_UMaxLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(CCUMaxLikeUGT, m_UMaxLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(CCUMaxLikeUGE, m_UMaxLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(CCUMaxLikeULT, m_UMaxLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(CCUMaxLikeULE, m_UMaxLike(m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(UMax, m_UMaxLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(UMaxLikeUGT, m_UMaxLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(UMaxLikeUGE, m_UMaxLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(CCUMaxLikeUGT, m_UMaxLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(CCUMaxLikeUGE, m_UMaxLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(CCUMaxLikeULT, m_UMaxLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(CCUMaxLikeULE, m_UMaxLike(*DAG, m_Value(), m_Value())));
   EXPECT_TRUE(sd_match(UMin, m_c_BinOp(ISD::UMIN, m_Value(), m_Value())));
   EXPECT_TRUE(sd_match(UMin, m_UMin(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(UMin, m_UMinLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(UMinLikeULT, m_UMinLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(UMinLikeULE, m_UMinLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(CCUMinLikeUGT, m_UMinLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(CCUMinLikeUGE, m_UMinLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(CCUMinLikeULT, m_UMinLike(m_Value(), m_Value())));
-  EXPECT_TRUE(sd_match(CCUMinLikeULE, m_UMinLike(m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(UMin, m_UMinLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(UMinLikeULT, m_UMinLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(UMinLikeULE, m_UMinLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(CCUMinLikeUGT, m_UMinLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(CCUMinLikeUGE, m_UMinLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(CCUMinLikeULT, m_UMinLike(*DAG, m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(CCUMinLikeULE, m_UMinLike(*DAG, m_Value(), m_Value())));
 
-  EXPECT_TRUE(sd_match(UMaxNonNeg, DAG.get(),
-                       m_UMaxLike(m_Specific(NonNeg0), m_Specific(NonNeg1))));
-  EXPECT_TRUE(sd_match(UMaxNonNeg, DAG.get(),
-                       m_SMaxLike(m_Specific(NonNeg0), m_Specific(NonNeg1))));
-  EXPECT_TRUE(sd_match(UMinNonNeg, DAG.get(),
-                       m_UMinLike(m_Specific(NonNeg0), m_Specific(NonNeg1))));
-  EXPECT_TRUE(sd_match(UMinNonNeg, DAG.get(),
-                       m_SMinLike(m_Specific(NonNeg0), m_Specific(NonNeg1))));
+  EXPECT_TRUE(sd_match(
+      UMaxNonNeg, m_UMaxLike(*DAG, m_Specific(NonNeg0), m_Specific(NonNeg1))));
+  EXPECT_TRUE(sd_match(
+      UMaxNonNeg, m_SMaxLike(*DAG, m_Specific(NonNeg0), m_Specific(NonNeg1))));
+  EXPECT_TRUE(sd_match(
+      UMinNonNeg, m_UMinLike(*DAG, m_Specific(NonNeg0), m_Specific(NonNeg1))));
+  EXPECT_TRUE(sd_match(
+      UMinNonNeg, m_SMinLike(*DAG, m_Specific(NonNeg0), m_Specific(NonNeg1))));
 
-  EXPECT_TRUE(sd_match(SMaxNonNeg, DAG.get(),
-                       m_SMaxLike(m_Specific(NonNeg0), m_Specific(NonNeg1))));
-  EXPECT_TRUE(sd_match(SMaxNonNeg, DAG.get(),
-                       m_UMaxLike(m_Specific(NonNeg0), m_Specific(NonNeg1))));
-  EXPECT_TRUE(sd_match(SMinNonNeg, DAG.get(),
-                       m_SMinLike(m_Specific(NonNeg0), m_Specific(NonNeg1))));
-  EXPECT_TRUE(sd_match(SMinNonNeg, DAG.get(),
-                       m_UMinLike(m_Specific(NonNeg0), m_Specific(NonNeg1))));
+  EXPECT_TRUE(sd_match(
+      SMaxNonNeg, m_SMaxLike(*DAG, m_Specific(NonNeg0), m_Specific(NonNeg1))));
+  EXPECT_TRUE(sd_match(
+      SMaxNonNeg, m_UMaxLike(*DAG, m_Specific(NonNeg0), m_Specific(NonNeg1))));
+  EXPECT_TRUE(sd_match(
+      SMinNonNeg, m_SMinLike(*DAG, m_Specific(NonNeg0), m_Specific(NonNeg1))));
+  EXPECT_TRUE(sd_match(
+      SMinNonNeg, m_UMinLike(*DAG, m_Specific(NonNeg0), m_Specific(NonNeg1))));
 
-  EXPECT_TRUE(sd_match(UMaxNeg, DAG.get(),
-                       m_UMaxLike(m_Specific(Neg0), m_Specific(Neg1))));
-  EXPECT_TRUE(sd_match(UMaxNeg, DAG.get(),
-                       m_SMaxLike(m_Specific(Neg0), m_Specific(Neg1))));
-  EXPECT_TRUE(sd_match(UMinNeg, DAG.get(),
-                       m_UMinLike(m_Specific(Neg0), m_Specific(Neg1))));
-  EXPECT_TRUE(sd_match(UMinNeg, DAG.get(),
-                       m_SMinLike(m_Specific(Neg0), m_Specific(Neg1))));
+  EXPECT_TRUE(
+      sd_match(UMaxNeg, m_UMaxLike(*DAG, m_Specific(Neg0), m_Specific(Neg1))));
+  EXPECT_TRUE(
+      sd_match(UMaxNeg, m_SMaxLike(*DAG, m_Specific(Neg0), m_Specific(Neg1))));
+  EXPECT_TRUE(
+      sd_match(UMinNeg, m_UMinLike(*DAG, m_Specific(Neg0), m_Specific(Neg1))));
+  EXPECT_TRUE(
+      sd_match(UMinNeg, m_SMinLike(*DAG, m_Specific(Neg0), m_Specific(Neg1))));
 
-  EXPECT_TRUE(sd_match(SMaxNeg, DAG.get(),
-                       m_SMaxLike(m_Specific(Neg0), m_Specific(Neg1))));
-  EXPECT_TRUE(sd_match(SMaxNeg, DAG.get(),
-                       m_UMaxLike(m_Specific(Neg0), m_Specific(Neg1))));
-  EXPECT_TRUE(sd_match(SMinNeg, DAG.get(),
-                       m_SMinLike(m_Specific(Neg0), m_Specific(Neg1))));
-  EXPECT_TRUE(sd_match(SMinNeg, DAG.get(),
-                       m_UMinLike(m_Specific(Neg0), m_Specific(Neg1))));
+  EXPECT_TRUE(
+      sd_match(SMaxNeg, m_SMaxLike(*DAG, m_Specific(Neg0), m_Specific(Neg1))));
+  EXPECT_TRUE(
+      sd_match(SMaxNeg, m_UMaxLike(*DAG, m_Specific(Neg0), m_Specific(Neg1))));
+  EXPECT_TRUE(
+      sd_match(SMinNeg, m_SMinLike(*DAG, m_Specific(Neg0), m_Specific(Neg1))));
+  EXPECT_TRUE(
+      sd_match(SMinNeg, m_UMinLike(*DAG, m_Specific(Neg0), m_Specific(Neg1))));
 
-  EXPECT_TRUE(sd_match(UMaxLikeNN_UGT, DAG.get(),
-                       m_SMaxLike(m_Specific(NonNeg0), m_Specific(NonNeg1))));
-  EXPECT_TRUE(sd_match(UMinLikeNN_ULT, DAG.get(),
-                       m_SMinLike(m_Specific(NonNeg0), m_Specific(NonNeg1))));
-  EXPECT_TRUE(sd_match(SMaxLikeNN_GT, DAG.get(),
-                       m_UMaxLike(m_Specific(NonNeg0), m_Specific(NonNeg1))));
-  EXPECT_TRUE(sd_match(SMinLikeNN_LT, DAG.get(),
-                       m_UMinLike(m_Specific(NonNeg0), m_Specific(NonNeg1))));
-  EXPECT_TRUE(sd_match(UMaxLikeN_UGT, DAG.get(),
-                       m_SMaxLike(m_Specific(Neg0), m_Specific(Neg1))));
-  EXPECT_TRUE(sd_match(UMinLikeN_ULT, DAG.get(),
-                       m_SMinLike(m_Specific(Neg0), m_Specific(Neg1))));
-  EXPECT_TRUE(sd_match(SMaxLikeN_GT, DAG.get(),
-                       m_UMaxLike(m_Specific(Neg0), m_Specific(Neg1))));
-  EXPECT_TRUE(sd_match(SMinLikeN_LT, DAG.get(),
-                       m_UMinLike(m_Specific(Neg0), m_Specific(Neg1))));
+  EXPECT_TRUE(sd_match(UMaxLikeNN_UGT, m_SMaxLike(*DAG, m_Specific(NonNeg0),
+                                                  m_Specific(NonNeg1))));
+  EXPECT_TRUE(sd_match(UMinLikeNN_ULT, m_SMinLike(*DAG, m_Specific(NonNeg0),
+                                                  m_Specific(NonNeg1))));
+  EXPECT_TRUE(sd_match(SMaxLikeNN_GT, m_UMaxLike(*DAG, m_Specific(NonNeg0),
+                                                 m_Specific(NonNeg1))));
+  EXPECT_TRUE(sd_match(SMinLikeNN_LT, m_UMinLike(*DAG, m_Specific(NonNeg0),
+                                                 m_Specific(NonNeg1))));
+  EXPECT_TRUE(sd_match(UMaxLikeN_UGT,
+                       m_SMaxLike(*DAG, m_Specific(Neg0), m_Specific(Neg1))));
+  EXPECT_TRUE(sd_match(UMinLikeN_ULT,
+                       m_SMinLike(*DAG, m_Specific(Neg0), m_Specific(Neg1))));
+  EXPECT_TRUE(sd_match(SMaxLikeN_GT,
+                       m_UMaxLike(*DAG, m_Specific(Neg0), m_Specific(Neg1))));
+  EXPECT_TRUE(sd_match(SMinLikeN_LT,
+                       m_UMinLike(*DAG, m_Specific(Neg0), m_Specific(Neg1))));
 
   EXPECT_FALSE(
-      sd_match(UMax, DAG.get(), m_SMaxLike(m_Specific(Op0), m_Specific(Op1))));
+      sd_match(UMax, m_SMaxLike(*DAG, m_Specific(Op0), m_Specific(Op1))));
   EXPECT_FALSE(
-      sd_match(UMin, DAG.get(), m_SMinLike(m_Specific(Op0), m_Specific(Op1))));
+      sd_match(UMin, m_SMinLike(*DAG, m_Specific(Op0), m_Specific(Op1))));
   EXPECT_FALSE(
-      sd_match(SMax, DAG.get(), m_UMaxLike(m_Specific(Op0), m_Specific(Op1))));
+      sd_match(SMax, m_UMaxLike(*DAG, m_Specific(Op0), m_Specific(Op1))));
   EXPECT_FALSE(
-      sd_match(SMin, DAG.get(), m_UMinLike(m_Specific(Op0), m_Specific(Op1))));
+      sd_match(SMin, m_UMinLike(*DAG, m_Specific(Op0), m_Specific(Op1))));
 
-  EXPECT_FALSE(sd_match(UMaxDiffSign, DAG.get(),
-                        m_SMaxLike(m_Specific(Neg0), m_Specific(NonNeg1))));
-  EXPECT_FALSE(sd_match(UMinDiffSign, DAG.get(),
-                        m_SMinLike(m_Specific(Neg0), m_Specific(NonNeg1))));
-  EXPECT_FALSE(sd_match(SMaxDiffSign, DAG.get(),
-                        m_UMaxLike(m_Specific(Neg0), m_Specific(NonNeg1))));
-  EXPECT_FALSE(sd_match(SMinDiffSign, DAG.get(),
-                        m_UMinLike(m_Specific(Neg0), m_Specific(NonNeg1))));
+  EXPECT_FALSE(sd_match(
+      UMaxDiffSign, m_SMaxLike(*DAG, m_Specific(Neg0), m_Specific(NonNeg1))));
+  EXPECT_FALSE(sd_match(
+      UMinDiffSign, m_SMinLike(*DAG, m_Specific(Neg0), m_Specific(NonNeg1))));
+  EXPECT_FALSE(sd_match(
+      SMaxDiffSign, m_UMaxLike(*DAG, m_Specific(Neg0), m_Specific(NonNeg1))));
+  EXPECT_FALSE(sd_match(
+      SMinDiffSign, m_UMinLike(*DAG, m_Specific(Neg0), m_Specific(NonNeg1))));
 
   SDValue BindVal;
   // By default, it matches any of the results.
@@ -828,62 +828,48 @@ TEST_F(SelectionDAGPatternMatchTest, matchUnaryOp) {
 
   SDValue BindVal;
 
-  EXPECT_FALSE(sd_match(Abs, DAG.get(), m_Negative()));
+  EXPECT_FALSE(sd_match(Abs, m_Negative(*DAG)));
 
-  EXPECT_FALSE(
-      sd_match(NonNegativeValue, DAG.get(), m_Negative(m_Value(BindVal))));
+  EXPECT_FALSE(sd_match(NonNegativeValue, m_Negative(*DAG, m_Value(BindVal))));
+  EXPECT_NE(BindVal, NonNegativeValue);
+  EXPECT_FALSE(sd_match(NonNegativeValue, m_NonZero(*DAG, m_Value(BindVal))));
   EXPECT_NE(BindVal, NonNegativeValue);
   EXPECT_FALSE(
-      sd_match(NonNegativeValue, DAG.get(), m_NonZero(m_Value(BindVal))));
-  EXPECT_NE(BindVal, NonNegativeValue);
-  EXPECT_FALSE(sd_match(NonNegativeValue, DAG.get(),
-                        m_StrictlyPositive(m_Value(BindVal))));
+      sd_match(NonNegativeValue, m_StrictlyPositive(*DAG, m_Value(BindVal))));
   EXPECT_NE(BindVal, NonNegativeValue);
   EXPECT_FALSE(
-      sd_match(NonNegativeValue, DAG.get(), m_NonPositive(m_Value(BindVal))));
+      sd_match(NonNegativeValue, m_NonPositive(*DAG, m_Value(BindVal))));
   EXPECT_NE(BindVal, NonNegativeValue);
 
   EXPECT_TRUE(
-      sd_match(NonNegativeValue, DAG.get(), m_NonNegative(m_Value(BindVal))));
+      sd_match(NonNegativeValue, m_NonNegative(*DAG, m_Value(BindVal))));
   EXPECT_EQ(BindVal, NonNegativeValue);
 
-  EXPECT_FALSE(
-      sd_match(NegativeValue, DAG.get(), m_NonNegative(m_Value(BindVal))));
+  EXPECT_FALSE(sd_match(NegativeValue, m_NonNegative(*DAG, m_Value(BindVal))));
   EXPECT_NE(BindVal, NegativeValue);
   EXPECT_FALSE(
-      sd_match(NegativeValue, DAG.get(), m_StrictlyPositive(m_Value(BindVal))));
+      sd_match(NegativeValue, m_StrictlyPositive(*DAG, m_Value(BindVal))));
   EXPECT_NE(BindVal, NegativeValue);
 
-  EXPECT_TRUE(sd_match(NegativeValue, DAG.get(), m_Negative(m_Value(BindVal))));
+  EXPECT_TRUE(sd_match(NegativeValue, m_Negative(*DAG, m_Value(BindVal))));
   EXPECT_EQ(BindVal, NegativeValue);
-  EXPECT_TRUE(sd_match(NegativeValue, DAG.get(), m_NonZero(m_Value(BindVal))));
+  EXPECT_TRUE(sd_match(NegativeValue, m_NonZero(*DAG, m_Value(BindVal))));
   EXPECT_EQ(BindVal, NegativeValue);
-  EXPECT_TRUE(
-      sd_match(NegativeValue, DAG.get(), m_NonPositive(m_Value(BindVal))));
+  EXPECT_TRUE(sd_match(NegativeValue, m_NonPositive(*DAG, m_Value(BindVal))));
   EXPECT_EQ(BindVal, NegativeValue);
 
-  EXPECT_FALSE(
-      sd_match(PositiveValue, DAG.get(), m_Negative(m_Value(BindVal))));
+  EXPECT_FALSE(sd_match(PositiveValue, m_Negative(*DAG, m_Value(BindVal))));
   EXPECT_NE(BindVal, PositiveValue);
-  EXPECT_FALSE(
-      sd_match(PositiveValue, DAG.get(), m_NonPositive(m_Value(BindVal))));
+  EXPECT_FALSE(sd_match(PositiveValue, m_NonPositive(*DAG, m_Value(BindVal))));
   EXPECT_NE(BindVal, PositiveValue);
 
-  EXPECT_TRUE(sd_match(PositiveValue, DAG.get(), m_NonZero(m_Value(BindVal))));
+  EXPECT_TRUE(sd_match(PositiveValue, m_NonZero(*DAG, m_Value(BindVal))));
+  EXPECT_EQ(BindVal, PositiveValue);
+  EXPECT_TRUE(sd_match(PositiveValue, m_NonNegative(*DAG, m_Value(BindVal))));
   EXPECT_EQ(BindVal, PositiveValue);
   EXPECT_TRUE(
-      sd_match(PositiveValue, DAG.get(), m_NonNegative(m_Value(BindVal))));
+      sd_match(PositiveValue, m_StrictlyPositive(*DAG, m_Value(BindVal))));
   EXPECT_EQ(BindVal, PositiveValue);
-  EXPECT_TRUE(
-      sd_match(PositiveValue, DAG.get(), m_StrictlyPositive(m_Value(BindVal))));
-  EXPECT_EQ(BindVal, PositiveValue);
-
-  // If DAG is not provided all matches fail regardless of the value
-  EXPECT_FALSE(sd_match(NegativeValue, m_Negative(m_Value(BindVal))));
-  EXPECT_FALSE(sd_match(NonNegativeValue, m_NonNegative(m_Value(BindVal))));
-  EXPECT_FALSE(sd_match(NegativeValue, m_NonZero(m_Value(BindVal))));
-  EXPECT_FALSE(sd_match(NegativeValue, m_NonPositive(m_Value(BindVal))));
-  EXPECT_FALSE(sd_match(PositiveValue, m_StrictlyPositive(m_Value(BindVal))));
 
   EXPECT_TRUE(sd_match(VScale, m_VScale(m_Value())));
 
@@ -947,34 +933,27 @@ TEST_F(SelectionDAGPatternMatchTest, matchConstants) {
   EXPECT_TRUE(sd_match(Const3, m_SpecificInt(ConstVal)));
   EXPECT_TRUE(sd_match(AllOnes, m_AllOnes()));
 
-  EXPECT_TRUE(sd_match(Zero, DAG.get(), m_False()));
-  EXPECT_TRUE(sd_match(One, DAG.get(), m_True()));
-  EXPECT_FALSE(sd_match(AllOnes, DAG.get(), m_True()));
+  EXPECT_TRUE(sd_match(Zero, m_False(*DAG)));
+  EXPECT_TRUE(sd_match(One, m_True(*DAG)));
+  EXPECT_FALSE(sd_match(AllOnes, m_True(*DAG)));
 
-  EXPECT_TRUE(sd_match(MinusOne, DAG.get(), m_Negative()));
-  EXPECT_FALSE(sd_match(MinusOne, DAG.get(), m_NonNegative()));
-  EXPECT_TRUE(sd_match(MinusOne, DAG.get(), m_NonZero()));
-  EXPECT_TRUE(sd_match(MinusOne, DAG.get(), m_NonPositive()));
-  EXPECT_FALSE(sd_match(MinusOne, DAG.get(), m_StrictlyPositive()));
+  EXPECT_TRUE(sd_match(MinusOne, m_Negative(*DAG)));
+  EXPECT_FALSE(sd_match(MinusOne, m_NonNegative(*DAG)));
+  EXPECT_TRUE(sd_match(MinusOne, m_NonZero(*DAG)));
+  EXPECT_TRUE(sd_match(MinusOne, m_NonPositive(*DAG)));
+  EXPECT_FALSE(sd_match(MinusOne, m_StrictlyPositive(*DAG)));
 
-  EXPECT_FALSE(sd_match(Zero, DAG.get(), m_Negative()));
-  EXPECT_TRUE(sd_match(Zero, DAG.get(), m_NonNegative()));
-  EXPECT_FALSE(sd_match(Zero, DAG.get(), m_NonZero()));
-  EXPECT_TRUE(sd_match(Zero, DAG.get(), m_NonPositive()));
-  EXPECT_FALSE(sd_match(Zero, DAG.get(), m_StrictlyPositive()));
+  EXPECT_FALSE(sd_match(Zero, m_Negative(*DAG)));
+  EXPECT_TRUE(sd_match(Zero, m_NonNegative(*DAG)));
+  EXPECT_FALSE(sd_match(Zero, m_NonZero(*DAG)));
+  EXPECT_TRUE(sd_match(Zero, m_NonPositive(*DAG)));
+  EXPECT_FALSE(sd_match(Zero, m_StrictlyPositive(*DAG)));
 
-  EXPECT_FALSE(sd_match(One, DAG.get(), m_Negative()));
-  EXPECT_TRUE(sd_match(One, DAG.get(), m_NonNegative()));
-  EXPECT_TRUE(sd_match(One, DAG.get(), m_NonZero()));
-  EXPECT_FALSE(sd_match(One, DAG.get(), m_NonPositive()));
-  EXPECT_TRUE(sd_match(One, DAG.get(), m_StrictlyPositive()));
-
-  // If DAG is not provided all matches would fail
-  EXPECT_FALSE(sd_match(MinusOne, m_Negative()));
-  EXPECT_FALSE(sd_match(Zero, m_NonNegative()));
-  EXPECT_FALSE(sd_match(One, m_NonZero()));
-  EXPECT_FALSE(sd_match(Zero, m_NonPositive()));
-  EXPECT_FALSE(sd_match(One, m_StrictlyPositive()));
+  EXPECT_FALSE(sd_match(One, m_Negative(*DAG)));
+  EXPECT_TRUE(sd_match(One, m_NonNegative(*DAG)));
+  EXPECT_TRUE(sd_match(One, m_NonZero(*DAG)));
+  EXPECT_FALSE(sd_match(One, m_NonPositive(*DAG)));
+  EXPECT_TRUE(sd_match(One, m_StrictlyPositive(*DAG)));
 
   ISD::CondCode CC;
   EXPECT_TRUE(sd_match(
@@ -1050,7 +1029,7 @@ TEST_F(SelectionDAGPatternMatchTest, optionalResizing) {
   EXPECT_TRUE(sd_match(Trunc, m_TruncOrSelf(m_Value(A))));
   EXPECT_TRUE(A == Op64);
 
-  EXPECT_TRUE(sd_match(ZExt, DAG.get(), m_NonNegative(m_Value())));
+  EXPECT_TRUE(sd_match(ZExt, m_NonNegative(*DAG, m_Value())));
 }
 
 TEST_F(SelectionDAGPatternMatchTest, matchNode) {
@@ -1164,10 +1143,10 @@ TEST_F(SelectionDAGPatternMatchTest, matchAdvancedProperties) {
   SDValue Add = DAG->getNode(ISD::ADD, DL, Int64VT, Op0, Op0);
 
   using namespace SDPatternMatch;
-  EXPECT_TRUE(sd_match(Op0, DAG.get(), m_LegalType(m_Value())));
-  EXPECT_FALSE(sd_match(Op1, DAG.get(), m_LegalType(m_Value())));
-  EXPECT_TRUE(sd_match(Add, DAG.get(),
-                       m_LegalOp(m_IntegerVT(m_Add(m_Value(), m_Value())))));
+  EXPECT_TRUE(sd_match(Op0, m_LegalType(*DAG, m_Value())));
+  EXPECT_FALSE(sd_match(Op1, m_LegalType(*DAG, m_Value())));
+  EXPECT_TRUE(
+      sd_match(Add, m_LegalOp(*DAG, m_IntegerVT(m_Add(m_Value(), m_Value())))));
 }
 
 TEST_F(SelectionDAGPatternMatchTest, matchReassociatableOp) {
@@ -1341,22 +1320,22 @@ TEST_F(SelectionDAGPatternMatchTest, MatchZeroOneAllOnes) {
 
   // Scalar constant 0
   SDValue Zero = DAG->getConstant(0, DL, VT);
-  EXPECT_TRUE(sd_match(Zero, DAG.get(), m_Zero()));
-  EXPECT_FALSE(sd_match(Zero, DAG.get(), m_One()));
-  EXPECT_FALSE(sd_match(Zero, DAG.get(), m_AllOnes()));
+  EXPECT_TRUE(sd_match(Zero, m_Zero()));
+  EXPECT_FALSE(sd_match(Zero, m_One()));
+  EXPECT_FALSE(sd_match(Zero, m_AllOnes()));
 
   // Scalar constant 1
   SDValue One = DAG->getConstant(1, DL, VT);
-  EXPECT_FALSE(sd_match(One, DAG.get(), m_Zero()));
-  EXPECT_TRUE(sd_match(One, DAG.get(), m_One()));
-  EXPECT_FALSE(sd_match(One, DAG.get(), m_AllOnes()));
+  EXPECT_FALSE(sd_match(One, m_Zero()));
+  EXPECT_TRUE(sd_match(One, m_One()));
+  EXPECT_FALSE(sd_match(One, m_AllOnes()));
 
   // Scalar constant -1
   SDValue AllOnes =
       DAG->getConstant(APInt::getAllOnes(VT.getSizeInBits()), DL, VT);
-  EXPECT_FALSE(sd_match(AllOnes, DAG.get(), m_Zero()));
-  EXPECT_FALSE(sd_match(AllOnes, DAG.get(), m_One()));
-  EXPECT_TRUE(sd_match(AllOnes, DAG.get(), m_AllOnes()));
+  EXPECT_FALSE(sd_match(AllOnes, m_Zero()));
+  EXPECT_FALSE(sd_match(AllOnes, m_One()));
+  EXPECT_TRUE(sd_match(AllOnes, m_AllOnes()));
 
   EVT VecF32 = EVT::getVectorVT(Context, MVT::f32, 4);
   EVT VecVT = EVT::getVectorVT(Context, MVT::i32, 4);
@@ -1366,13 +1345,13 @@ TEST_F(SelectionDAGPatternMatchTest, MatchZeroOneAllOnes) {
     SDValue SplatVal = DAG->getConstant(0, DL, MVT::i32);
     SDValue VecSplat = DAG->getSplatBuildVector(VecVT, DL, SplatVal);
     SDValue Bitcasted = DAG->getNode(ISD::BITCAST, DL, VecF32, VecSplat);
-    EXPECT_TRUE(sd_match(Bitcasted, DAG.get(), m_Zero()));
+    EXPECT_TRUE(sd_match(Bitcasted, m_Zero()));
 
-    EXPECT_FALSE(sd_match(Bitcasted, DAG.get(), m_Negative()));
-    EXPECT_TRUE(sd_match(Bitcasted, DAG.get(), m_NonNegative()));
-    EXPECT_FALSE(sd_match(Bitcasted, DAG.get(), m_NonZero()));
-    EXPECT_FALSE(sd_match(Bitcasted, DAG.get(), m_StrictlyPositive()));
-    EXPECT_TRUE(sd_match(Bitcasted, DAG.get(), m_NonPositive()));
+    EXPECT_FALSE(sd_match(Bitcasted, m_Negative(*DAG)));
+    EXPECT_TRUE(sd_match(Bitcasted, m_NonNegative(*DAG)));
+    EXPECT_FALSE(sd_match(Bitcasted, m_NonZero(*DAG)));
+    EXPECT_FALSE(sd_match(Bitcasted, m_StrictlyPositive(*DAG)));
+    EXPECT_TRUE(sd_match(Bitcasted, m_NonPositive(*DAG)));
   }
 
   // m_One: splat vector of 1 → bitcast
@@ -1380,13 +1359,13 @@ TEST_F(SelectionDAGPatternMatchTest, MatchZeroOneAllOnes) {
     SDValue SplatVal = DAG->getConstant(1, DL, MVT::i32);
     SDValue VecSplat = DAG->getSplatBuildVector(VecVT, DL, SplatVal);
     SDValue Bitcasted = DAG->getNode(ISD::BITCAST, DL, VecF32, VecSplat);
-    EXPECT_FALSE(sd_match(Bitcasted, DAG.get(), m_One()));
+    EXPECT_FALSE(sd_match(Bitcasted, m_One()));
 
-    EXPECT_FALSE(sd_match(Bitcasted, DAG.get(), m_Negative()));
-    EXPECT_TRUE(sd_match(Bitcasted, DAG.get(), m_NonNegative()));
-    EXPECT_TRUE(sd_match(Bitcasted, DAG.get(), m_NonZero()));
-    EXPECT_FALSE(sd_match(Bitcasted, DAG.get(), m_NonPositive()));
-    EXPECT_TRUE(sd_match(Bitcasted, DAG.get(), m_StrictlyPositive()));
+    EXPECT_FALSE(sd_match(Bitcasted, m_Negative(*DAG)));
+    EXPECT_TRUE(sd_match(Bitcasted, m_NonNegative(*DAG)));
+    EXPECT_TRUE(sd_match(Bitcasted, m_NonZero(*DAG)));
+    EXPECT_FALSE(sd_match(Bitcasted, m_NonPositive(*DAG)));
+    EXPECT_TRUE(sd_match(Bitcasted, m_StrictlyPositive(*DAG)));
   }
 
   // m_AllOnes: splat vector of -1 → bitcast
@@ -1394,13 +1373,13 @@ TEST_F(SelectionDAGPatternMatchTest, MatchZeroOneAllOnes) {
     SDValue SplatVal = DAG->getConstant(APInt::getAllOnes(32), DL, MVT::i32);
     SDValue VecSplat = DAG->getSplatBuildVector(VecVT, DL, SplatVal);
     SDValue Bitcasted = DAG->getNode(ISD::BITCAST, DL, VecF32, VecSplat);
-    EXPECT_TRUE(sd_match(Bitcasted, DAG.get(), m_AllOnes()));
+    EXPECT_TRUE(sd_match(Bitcasted, m_AllOnes()));
 
-    EXPECT_TRUE(sd_match(Bitcasted, DAG.get(), m_Negative()));
-    EXPECT_FALSE(sd_match(Bitcasted, DAG.get(), m_NonNegative()));
-    EXPECT_TRUE(sd_match(Bitcasted, DAG.get(), m_NonZero()));
-    EXPECT_TRUE(sd_match(Bitcasted, DAG.get(), m_NonPositive()));
-    EXPECT_FALSE(sd_match(Bitcasted, DAG.get(), m_StrictlyPositive()));
+    EXPECT_TRUE(sd_match(Bitcasted, m_Negative(*DAG)));
+    EXPECT_FALSE(sd_match(Bitcasted, m_NonNegative(*DAG)));
+    EXPECT_TRUE(sd_match(Bitcasted, m_NonZero(*DAG)));
+    EXPECT_TRUE(sd_match(Bitcasted, m_NonPositive(*DAG)));
+    EXPECT_FALSE(sd_match(Bitcasted, m_StrictlyPositive(*DAG)));
   }
 
   // splat vector with one undef → default should NOT match
@@ -1412,8 +1391,8 @@ TEST_F(SelectionDAGPatternMatchTest, MatchZeroOneAllOnes) {
     SmallVector<SDValue, 4> Ops(4, Zero);
     Ops[2] = Undef;
     SDValue Vec = DAG->getBuildVector(VecVT, DL, Ops);
-    EXPECT_FALSE(sd_match(Vec, DAG.get(), m_Zero()));
-    EXPECT_TRUE(sd_match(Vec, DAG.get(), m_Zero(true)));
+    EXPECT_FALSE(sd_match(Vec, m_Zero()));
+    EXPECT_TRUE(sd_match(Vec, m_Zero(true)));
   }
 
   {
@@ -1422,8 +1401,8 @@ TEST_F(SelectionDAGPatternMatchTest, MatchZeroOneAllOnes) {
     SmallVector<SDValue, 4> Ops(4, One);
     Ops[1] = Undef;
     SDValue Vec = DAG->getBuildVector(VecVT, DL, Ops);
-    EXPECT_FALSE(sd_match(Vec, DAG.get(), m_One()));
-    EXPECT_TRUE(sd_match(Vec, DAG.get(), m_One(true)));
+    EXPECT_FALSE(sd_match(Vec, m_One()));
+    EXPECT_TRUE(sd_match(Vec, m_One(true)));
   }
 
   {
@@ -1432,8 +1411,8 @@ TEST_F(SelectionDAGPatternMatchTest, MatchZeroOneAllOnes) {
     SmallVector<SDValue, 4> Ops(4, AllOnes);
     Ops[0] = Undef;
     SDValue Vec = DAG->getBuildVector(VecVT, DL, Ops);
-    EXPECT_FALSE(sd_match(Vec, DAG.get(), m_AllOnes()));
-    EXPECT_TRUE(sd_match(Vec, DAG.get(), m_AllOnes(true)));
+    EXPECT_FALSE(sd_match(Vec, m_AllOnes()));
+    EXPECT_TRUE(sd_match(Vec, m_AllOnes(true)));
   }
 }
 


### PR DESCRIPTION
This removes the match context templating now that trivial VP nodes are gone.

For the KnownBits and TLI based matchers which previously looked up the DAG in the match context, they've been changed to have the DAG explicitly passed through. This should prevent users from forgetting to pass in the DAG, and some places in X86ISelLowering.cpp were updated to now take in the DAG. So this patch isn't strictly NFC, but I couldn't find a way to exercise any codegen change in practice.
