### PR TITLE
[ModuleSummary] Only compute BFI if function has profile data

### DIFF
--- a/llvm/lib/Analysis/ModuleSummaryAnalysis.cpp
+++ b/llvm/lib/Analysis/ModuleSummaryAnalysis.cpp
@@ -1081,14 +1081,16 @@ ModuleSummaryIndex llvm::buildModuleSummaryIndex(
     DominatorTree DT(const_cast<Function &>(F));
     BlockFrequencyInfo *BFI = nullptr;
     std::unique_ptr<BlockFrequencyInfo> BFIPtr;
-    if (GetBFICallback)
-      BFI = GetBFICallback(F);
-    else if (F.hasProfileData()) {
-      CycleInfo CI;
-      CI.compute(const_cast<Function &>(F));
-      BranchProbabilityInfo BPI{F, CI};
-      BFIPtr = std::make_unique<BlockFrequencyInfo>(F, BPI, CI);
-      BFI = BFIPtr.get();
+    if (F.hasProfileData()) {
+      if (GetBFICallback) {
+        BFI = GetBFICallback(F);
+      } else {
+        CycleInfo CI;
+        CI.compute(const_cast<Function &>(F));
+        BranchProbabilityInfo BPI{F, CI};
+        BFIPtr = std::make_unique<BlockFrequencyInfo>(F, BPI, CI);
+        BFI = BFIPtr.get();
+      }
     }
 
     computeFunctionSummary(Index, M, F, BFI, PSI, DT,


### PR DESCRIPTION
After b30971c4bb3f0654fa4fbb242126376169ae66d0 the module summary should no longer need BFI for functions without profiling data.

Not computing it is a minor compile-time improvement: https://llvm-compile-time-tracker.com/compare.php?from=d8ec70dc8db9b55d3185970be56efdf7066d89fe&to=ded3e100b4af5b70a3bd65307dde5a3da16902f9&stat=instructions:u