### PR TITLE
Have merge script detect whether to use https or ssh to connect to github.

### DIFF
--- a/llvm/utils/release/merge-release-pr.py
+++ b/llvm/utils/release/merge-release-pr.py
@@ -141,11 +141,19 @@ class PRMerger:
         )
         self.prdata = json.loads(o)
 
+        # Determine if we use https or ssh to connect to github
+        remote = subprocess.run(
+            ["git", "remote", "get-url", self.args.upstream],
+            capture_output=True,
+            text=True,
+        )
+        upstream_remote_type = remote.stdout.strip().replace("llvm/llvm-project.git", "")
+
         # save the baseRefName (target branch) so that we know where to push
         self.target_branch = self.prdata["baseRefName"]
         srepo = self.prdata["headRepository"]["name"]
         sowner = self.prdata["headRepositoryOwner"]["login"]
-        self.source_url = f"https://github.com/{sowner}/{srepo}"
+        self.source_url = f"{upstream_remote_type}{sowner}/{srepo}"
         self.source_branch = self.prdata["headRefName"]
 
         if srepo != "llvm-project":

--- a/llvm/utils/release/merge-release-pr.py
+++ b/llvm/utils/release/merge-release-pr.py
@@ -147,7 +147,9 @@ class PRMerger:
             capture_output=True,
             text=True,
         )
-        upstream_remote_type = remote.stdout.strip().replace("llvm/llvm-project.git", "")
+        upstream_remote_type = remote.stdout.strip().replace(
+            "llvm/llvm-project.git", ""
+        )
 
         # save the baseRefName (target branch) so that we know where to push
         self.target_branch = self.prdata["baseRefName"]


### PR DESCRIPTION
I've been using a version of this script with a private change because I use ssh to access github instead of https, so this change attempts to allow the script to detect whether https or ssh is used to access github and construct the URL accordingly instead of just assuming https.

I've tested this using both https and ssh for the access url and both instances create the correct url for `self.source_url`.

By making this change, I will no longer need to use a locally modified copy when merging changes into the release branch.