### PR TITLE
[CodeGen][DWARF][NFC] Add casts to a few asserts to avoid msvc warning.

### DIFF
--- a/llvm/include/llvm/CodeGen/DIE.h
+++ b/llvm/include/llvm/CodeGen/DIE.h
@@ -547,7 +547,8 @@ struct IntrusiveBackListBase {
 
   void push_back(Node &N) {
     assert(N.Next.getPointer() == &N && "Expected unlinked node");
-    assert(N.Next.getInt() == true && "Expected unlinked node");
+    assert(static_cast<bool>(N.Next.getInt()) == true &&
+           "Expected unlinked node");
 
     if (Last) {
       N.Next = Last->Next;
@@ -558,7 +559,8 @@ struct IntrusiveBackListBase {
 
   void push_front(Node &N) {
     assert(N.Next.getPointer() == &N && "Expected unlinked node");
-    assert(N.Next.getInt() == true && "Expected unlinked node");
+    assert(static_cast<bool>(N.Next.getInt()) == true &&
+           "Expected unlinked node");
 
     if (Last) {
       N.Next.setPointerAndInt(Last->Next.getPointer(), false);


### PR DESCRIPTION
Fix some comparisons to correct the msvc warning: C4805: '==': unsafe mix of type 'IntType' and type 'bool' in operation

Assisted-by: LLM.