### PR TITLE
[offload][sycl] add context parameter to olCreateProgram

### DIFF
--- a/libsycl/src/detail/device_image_wrapper.cpp
+++ b/libsycl/src/detail/device_image_wrapper.cpp
@@ -13,12 +13,15 @@
 _LIBSYCL_BEGIN_NAMESPACE_SYCL
 namespace detail {
 
-ProgramWrapper::ProgramWrapper(ol_device_handle_t Device,
+ProgramWrapper::ProgramWrapper(ol_context_handle_t Context,
+                               ol_device_handle_t Device,
                                DeviceImageManager &DevImage) {
+  assert(Context);
   assert(Device);
 
   llvm::StringRef Image = DevImage.getOffloadBinary().getImage();
-  callAndThrow(olCreateProgram, Device, Image.data(), Image.size(), &MProgram);
+  callAndThrow(olCreateProgram, Context, Device, Image.data(), Image.size(),
+               &MProgram);
 }
 
 ProgramWrapper::~ProgramWrapper() {
@@ -28,10 +31,11 @@ ProgramWrapper::~ProgramWrapper() {
 }
 
 ol_program_handle_t
-DeviceImageManager::getOrCreateProgram(ol_device_handle_t DeviceHandle) {
+DeviceImageManager::getOrCreateProgram(ol_context_handle_t ContextHandle,
+                                       ol_device_handle_t DeviceHandle) {
   const auto &[Iterator, Flag] = MPrograms.emplace(
       std::piecewise_construct, std::forward_as_tuple(DeviceHandle),
-      std::forward_as_tuple(DeviceHandle, *this));
+      std::forward_as_tuple(ContextHandle, DeviceHandle, *this));
   return Iterator->second.getOLHandle();
 }
 

--- a/libsycl/src/detail/device_image_wrapper.hpp
+++ b/libsycl/src/detail/device_image_wrapper.hpp
@@ -35,11 +35,13 @@ public:
   /// Constructs ProgramWrapper by creating a liboffload program with the
   /// provided arguments.
   ///
+  /// \param Context is the context to use for program creation.
   /// \param Device is the device to use for program creation.
   /// \param DevImage is the device image to use for program creation.
   /// \throw sycl::exception with sycl::errc::runtime when failed to create the
   /// program.
-  ProgramWrapper(ol_device_handle_t Device, DeviceImageManager &DevImage);
+  ProgramWrapper(ol_context_handle_t Context, ol_device_handle_t Device,
+                 DeviceImageManager &DevImage);
 
   /// Releases the corresponding liboffload program handle by calling
   /// olDestroyProgram.
@@ -78,11 +80,14 @@ public:
   /// Returns a liboffload program which is compatible with the specified
   /// device. Searches among existing programs and creates a new one if no
   /// compatible image is found.
+  /// \param ContextHandle the liboffload handle of the context to create the
+  /// program in.
   /// \param DeviceHandle the liboffload handle of the device the program must
   /// be compatible with.
   /// \return the liboffload handle of the program compatible with the specified
   /// device.
-  ol_program_handle_t getOrCreateProgram(ol_device_handle_t DeviceHandle);
+  ol_program_handle_t getOrCreateProgram(ol_context_handle_t ContextHandle,
+                                         ol_device_handle_t DeviceHandle);
 
 protected:
   std::unordered_map<ol_device_handle_t, ProgramWrapper> MPrograms;

--- a/libsycl/src/detail/program_manager.cpp
+++ b/libsycl/src/detail/program_manager.cpp
@@ -11,6 +11,7 @@
 #include <sycl/__impl/detail/get_device_kernel_info.hpp>
 #include <sycl/__impl/exception.hpp>
 
+#include <detail/context_impl.hpp>
 #include <detail/device_impl.hpp>
 #include <detail/offload/offload_utils.hpp>
 
@@ -127,10 +128,8 @@ static bool isImageCompatible(const DeviceImageManager &Image,
   return IsValid;
 }
 
-ol_symbol_handle_t
-ProgramAndKernelManager::getOrCreateKernel(DeviceKernelInfo &KernelInfo,
-                                           ol_context_handle_t Context,
-                                           DeviceImpl &Device) {
+ol_symbol_handle_t ProgramAndKernelManager::getOrCreateKernel(
+    DeviceKernelInfo &KernelInfo, ContextImpl &Context, DeviceImpl &Device) {
 
   std::lock_guard<std::mutex> KernelGuard(MDataCollectionMutex);
 
@@ -145,7 +144,8 @@ ProgramAndKernelManager::getOrCreateKernel(DeviceKernelInfo &KernelInfo,
                         KernelInfo.getName().data() + " was found");
 
   auto DeviceHandle = Device.getOLHandle();
-  auto Program = DeviceImage.getOrCreateProgram(Context, DeviceHandle);
+  auto Program =
+      DeviceImage.getOrCreateProgram(Context.getOLHandleRef(), DeviceHandle);
 
   ol_symbol_handle_t Kernel{};
   callAndThrow(olGetSymbol, Program, KernelInfo.getName().data(),

--- a/libsycl/src/detail/program_manager.cpp
+++ b/libsycl/src/detail/program_manager.cpp
@@ -129,6 +129,7 @@ static bool isImageCompatible(const DeviceImageManager &Image,
 
 ol_symbol_handle_t
 ProgramAndKernelManager::getOrCreateKernel(DeviceKernelInfo &KernelInfo,
+                                           ol_context_handle_t Context,
                                            DeviceImpl &Device) {
 
   std::lock_guard<std::mutex> KernelGuard(MDataCollectionMutex);
@@ -144,7 +145,7 @@ ProgramAndKernelManager::getOrCreateKernel(DeviceKernelInfo &KernelInfo,
                         KernelInfo.getName().data() + " was found");
 
   auto DeviceHandle = Device.getOLHandle();
-  auto Program = DeviceImage.getOrCreateProgram(DeviceHandle);
+  auto Program = DeviceImage.getOrCreateProgram(Context, DeviceHandle);
 
   ol_symbol_handle_t Kernel{};
   callAndThrow(olGetSymbol, Program, KernelInfo.getName().data(),

--- a/libsycl/src/detail/program_manager.hpp
+++ b/libsycl/src/detail/program_manager.hpp
@@ -80,10 +80,12 @@ public:
   /// This method is thread-safe.
   /// \param KernelInfo a set of kernel specific data: name, corresponding
   /// device image, etc.
+  /// \param Context the context in which the underlying program is created.
   /// \param Device the device for which this kernel must be compiled.
   /// \return a liboffload kernel handle that is ready to be passed to kernel
   /// execution methods.
   ol_symbol_handle_t getOrCreateKernel(DeviceKernelInfo &KernelInfo,
+                                       ol_context_handle_t Context,
                                        DeviceImpl &Device);
 
   /// \return kernel info for the kernel with the specified name.

--- a/libsycl/src/detail/program_manager.hpp
+++ b/libsycl/src/detail/program_manager.hpp
@@ -54,6 +54,7 @@ _LIBSYCL_BEGIN_NAMESPACE_SYCL
 
 namespace detail {
 
+class ContextImpl;
 class DeviceImpl;
 
 /// A class to manage programs and kernels.
@@ -80,12 +81,13 @@ public:
   /// This method is thread-safe.
   /// \param KernelInfo a set of kernel specific data: name, corresponding
   /// device image, etc.
-  /// \param Context the context in which the underlying program is created.
+  /// \param Context the context in which the underlying program must be
+  /// created.
   /// \param Device the device for which this kernel must be compiled.
   /// \return a liboffload kernel handle that is ready to be passed to kernel
   /// execution methods.
   ol_symbol_handle_t getOrCreateKernel(DeviceKernelInfo &KernelInfo,
-                                       ol_context_handle_t Context,
+                                       ContextImpl &Context,
                                        DeviceImpl &Device);
 
   /// \return kernel info for the kernel with the specified name.

--- a/libsycl/src/detail/queue_impl.cpp
+++ b/libsycl/src/detail/queue_impl.cpp
@@ -130,7 +130,7 @@ void QueueImpl::submitKernelImpl(DeviceKernelInfo &KernelInfo, void *ArgData,
                                  size_t ArgSize) {
   ol_symbol_handle_t Kernel =
       detail::ProgramAndKernelManager::getInstance().getOrCreateKernel(
-          KernelInfo, MContext.getOLHandleRef(), MDevice);
+          KernelInfo, MContext, MDevice);
   assert(Kernel);
 
   handleEventDependencies(MCurrentSubmitInfo.DepEvents);

--- a/libsycl/src/detail/queue_impl.cpp
+++ b/libsycl/src/detail/queue_impl.cpp
@@ -130,7 +130,7 @@ void QueueImpl::submitKernelImpl(DeviceKernelInfo &KernelInfo, void *ArgData,
                                  size_t ArgSize) {
   ol_symbol_handle_t Kernel =
       detail::ProgramAndKernelManager::getInstance().getOrCreateKernel(
-          KernelInfo, MDevice);
+          KernelInfo, MContext.getOLHandleRef(), MDevice);
   assert(Kernel);
 
   handleEventDependencies(MCurrentSubmitInfo.DepEvents);

--- a/libsycl/unittests/mock/helpers.cpp
+++ b/libsycl/unittests/mock/helpers.cpp
@@ -182,9 +182,10 @@ void mock::MockLiboffload::initDefault() {
       });
 
   ON_CALL(*this, olCreateProgram)
-      .WillByDefault([](ol_device_handle_t Device, const void *ProgData,
-                        size_t ProgDataSize,
+      .WillByDefault([](ol_context_handle_t Context, ol_device_handle_t Device,
+                        const void *ProgData, size_t ProgDataSize,
                         ol_program_handle_t *Program) -> ol_result_t {
+        std::ignore = Context;
         EXPECT_NE(Device, nullptr);
         EXPECT_NE(ProgData, nullptr);
         EXPECT_GT(ProgDataSize, 0);

--- a/libsycl/unittests/mock/helpers.cpp
+++ b/libsycl/unittests/mock/helpers.cpp
@@ -185,7 +185,7 @@ void mock::MockLiboffload::initDefault() {
       .WillByDefault([](ol_context_handle_t Context, ol_device_handle_t Device,
                         const void *ProgData, size_t ProgDataSize,
                         ol_program_handle_t *Program) -> ol_result_t {
-        std::ignore = Context;
+        EXPECT_NE(Context, nullptr);
         EXPECT_NE(Device, nullptr);
         EXPECT_NE(ProgData, nullptr);
         EXPECT_GT(ProgDataSize, 0);

--- a/libsycl/unittests/mock/helpers.hpp
+++ b/libsycl/unittests/mock/helpers.hpp
@@ -100,8 +100,9 @@ public:
   MOCK_METHOD(ol_result_t, olSyncQueue, (ol_queue_handle_t Queue));
   MOCK_METHOD(ol_result_t, olDestroyEvent, (ol_event_handle_t Event));
   MOCK_METHOD(ol_result_t, olCreateProgram,
-              (ol_device_handle_t Device, const void *ProgData,
-               size_t ProgDataSize, ol_program_handle_t *Program));
+              (ol_context_handle_t Context, ol_device_handle_t Device,
+               const void *ProgData, size_t ProgDataSize,
+               ol_program_handle_t *Program));
 
   MOCK_METHOD(ol_result_t, olGetSymbol,
               (ol_program_handle_t Program, const char *Name,

--- a/libsycl/unittests/mock/mock.cpp
+++ b/libsycl/unittests/mock/mock.cpp
@@ -73,9 +73,10 @@ ol_result_t olSyncQueue(ol_queue_handle_t Queue) {
   return mock::getMockLiboffload().olSyncQueue(Queue);
 }
 
-ol_result_t olCreateProgram(ol_device_handle_t Device, const void *ProgData,
+ol_result_t olCreateProgram(ol_context_handle_t Context,
+                            ol_device_handle_t Device, const void *ProgData,
                             size_t ProgDataSize, ol_program_handle_t *Program) {
-  return mock::getMockLiboffload().olCreateProgram(Device, ProgData,
+  return mock::getMockLiboffload().olCreateProgram(Context, Device, ProgData,
                                                    ProgDataSize, Program);
 }
 

--- a/llvm/tools/llvm-gpu-loader/llvm-gpu-loader.cpp
+++ b/llvm/tools/llvm-gpu-loader/llvm-gpu-loader.cpp
@@ -256,7 +256,7 @@ int main(int argc, const char **argv, const char **envp) {
   OFFLOAD_ERR(olCreateContext(1, &Device, &Context));
 
   ol_program_handle_t Program;
-  OFFLOAD_ERR(olCreateProgram(Device, Image.getBufferStart(),
+  OFFLOAD_ERR(olCreateProgram(Context, Device, Image.getBufferStart(),
                               Image.getBufferSize(), &Program));
 
   ol_queue_handle_t Queue;

--- a/llvm/tools/llvm-gpu-loader/llvm-gpu-loader.h
+++ b/llvm/tools/llvm-gpu-loader/llvm-gpu-loader.h
@@ -123,7 +123,8 @@ ol_result_t (*olIterateDevices)(ol_device_iterate_cb_t Callback,
 ol_result_t (*olIsValidBinary)(ol_device_handle_t Device, const void *ProgData,
                                size_t ProgDataSize, bool *Valid);
 
-ol_result_t (*olCreateProgram)(ol_device_handle_t Device, const void *ProgData,
+ol_result_t (*olCreateProgram)(ol_context_handle_t Context,
+                               ol_device_handle_t Device, const void *ProgData,
                                size_t ProgDataSize,
                                ol_program_handle_t *Program);
 

--- a/offload/languages/kernel/src/LanguageRegistration.cpp
+++ b/offload/languages/kernel/src/LanguageRegistration.cpp
@@ -80,6 +80,7 @@ void __tgt_register_lib(__tgt_bin_desc *Desc) {
   RuntimeState &State = RuntimeState::get();
   ThreadState &Thread = ThreadState::get();
   ol_device_handle_t Device = Thread.getDefaultDevice();
+  ol_context_handle_t Context = State.getContext();
 
   for (int32_t I = 0, E = Desc->NumDeviceImages; I < E; ++I) {
     ol_program_handle_t Program = nullptr;
@@ -89,7 +90,7 @@ void __tgt_register_lib(__tgt_bin_desc *Desc) {
     size_t ProgramSize =
         (char *)DeviceImage.ImageEnd - (char *)DeviceImage.ImageStart;
     ol_result_t Result =
-        olCreateProgram(Device, ProgramData, ProgramSize, &Program);
+        olCreateProgram(Context, Device, ProgramData, ProgramSize, &Program);
 
     if (Result && Result->Code) {
       fprintf(stderr, "Failed to register device code (%i): %s\n", Result->Code,

--- a/offload/liboffload/API/Program.td
+++ b/offload/liboffload/API/Program.td
@@ -11,11 +11,14 @@
 //===----------------------------------------------------------------------===//
 
 def olCreateProgram : Function {
-    let desc = "Create a program for the device from the binary image pointed to by `ProgData`.";
+    let desc = "Create a program for the device from the binary image pointed to by `ProgData` within the given context.";
     let details = [
         "The provided `ProgData` will be copied and need not outlive the returned handle",
+        "The program is scoped to `Context` and `Device` must belong to it.",
+        "The program can only be used with queues that were created in the same context."
     ];
     let params = [
+        Param<"ol_context_handle_t", "Context", "handle of the context", PARAM_IN>,
         Param<"ol_device_handle_t", "Device", "handle of the device", PARAM_IN>,
         Param<"const void*", "ProgData", "pointer to the program binary data", PARAM_IN>,
         Param<"size_t", "ProgDataSize", "size of the program binary in bytes", PARAM_IN>,
@@ -24,6 +27,9 @@ def olCreateProgram : Function {
     let returns = [
         Return<"OL_ERRC_INVALID_BINARY", [
             "If the buffer described by `ProgData` and `ProgDataSize` is not a valid binary image for the platform."
+        ]>,
+        Return<"OL_ERRC_INVALID_DEVICE", [
+            "Device does not belong to `Context`"
         ]>,
     ];
 }

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -133,9 +133,10 @@ struct ol_event_impl_t {
 };
 
 struct ol_program_impl_t {
-  ol_program_impl_t(plugin::DeviceImageTy *Image,
+  ol_program_impl_t(ol_context_handle_t Context, plugin::DeviceImageTy *Image,
                     llvm::MemoryBufferRef DeviceImage)
-      : Image(Image), DeviceImage(DeviceImage) {}
+      : Context(Context), Image(Image), DeviceImage(DeviceImage) {}
+  ol_context_handle_t Context;
   plugin::DeviceImageTy *Image;
   std::mutex SymbolListMutex;
   llvm::MemoryBufferRef DeviceImage;
@@ -1166,16 +1167,21 @@ Error olMemPrefetch_impl(ol_queue_handle_t Queue, size_t Count,
                                              Queue->AsyncInfo);
 }
 
-Error olCreateProgram_impl(ol_device_handle_t Device, const void *ProgData,
+Error olCreateProgram_impl(ol_context_handle_t Context,
+                           ol_device_handle_t Device, const void *ProgData,
                            size_t ProgDataSize, ol_program_handle_t *Program) {
+  if (!Context->contains(Device))
+    return createOffloadError(ErrorCode::INVALID_DEVICE,
+                              "device does not belong to the given context");
+
   StringRef Buffer(reinterpret_cast<const char *>(ProgData), ProgDataSize);
-  Expected<plugin::DeviceImageTy *> Res =
-      Device->Device->loadBinary(Device->Device->Plugin, Buffer);
+  Expected<plugin::DeviceImageTy *> Res = Device->Device->loadBinary(
+      Device->Device->Plugin, Buffer, Context->PluginCtx.get());
   if (!Res)
     return Res.takeError();
   assert(*Res && "loadBinary returned nullptr");
 
-  *Program = new ol_program_impl_t(*Res, (*Res)->getMemoryBuffer());
+  *Program = new ol_program_impl_t(Context, *Res, (*Res)->getMemoryBuffer());
   return Error::success();
 }
 

--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -2686,8 +2686,8 @@ struct AMDGPUDeviceTy : public GenericDeviceTy, AMDGenericDeviceTy {
 
   /// Load the binary image into the device and allocate an image object.
   Expected<DeviceImageTy *>
-  loadBinaryImpl(std::unique_ptr<MemoryBuffer> &&TgtImage,
-                 int32_t ImageId) override {
+  loadBinaryImpl(std::unique_ptr<MemoryBuffer> &&TgtImage, int32_t ImageId,
+                 PluginContextTy * /*Context*/) override {
     // Allocate and initialize the image object.
     AMDGPUDeviceImageTy *AMDImage = Plugin.allocate<AMDGPUDeviceImageTy>();
     new (AMDImage) AMDGPUDeviceImageTy(ImageId, *this, std::move(TgtImage));

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -983,11 +983,14 @@ struct GenericDeviceTy : public DeviceAllocatorTy {
   Error deinit(GenericPluginTy &Plugin);
   virtual Error deinitImpl() = 0;
 
-  /// Load the binary image into the device and return the target table.
+  /// Load the binary image into the device and return the target table. When
+  /// \p Context is null the plugin's driver-scoped default context is used.
   Expected<DeviceImageTy *> loadBinary(GenericPluginTy &Plugin,
-                                       StringRef TgtImage);
+                                       StringRef TgtImage,
+                                       PluginContextTy *Context);
   virtual Expected<DeviceImageTy *>
-  loadBinaryImpl(std::unique_ptr<MemoryBuffer> &&TgtImage, int32_t ImageId) = 0;
+  loadBinaryImpl(std::unique_ptr<MemoryBuffer> &&TgtImage, int32_t ImageId,
+                 PluginContextTy *Context) = 0;
 
   /// Unload a previously loaded Image from the device
   Error unloadBinary(DeviceImageTy *Image);

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -645,8 +645,9 @@ Error GenericDeviceTy::deinit(GenericPluginTy &Plugin) {
 
   return deinitImpl();
 }
-Expected<DeviceImageTy *> GenericDeviceTy::loadBinary(GenericPluginTy &Plugin,
-                                                      StringRef InputTgtImage) {
+Expected<DeviceImageTy *>
+GenericDeviceTy::loadBinary(GenericPluginTy &Plugin, StringRef InputTgtImage,
+                            PluginContextTy *Context) {
   ODBG(OLDT_Init) << "Load data from image "
                   << static_cast<const void *>(InputTgtImage.bytes_begin());
 
@@ -674,7 +675,8 @@ Expected<DeviceImageTy *> GenericDeviceTy::loadBinary(GenericPluginTy &Plugin,
 
   // Load the binary and allocate the image object. Use the next available id
   // for the image id, which is the number of previously loaded images.
-  auto ImageOrErr = loadBinaryImpl(std::move(Buffer), LoadedImages.size());
+  auto ImageOrErr =
+      loadBinaryImpl(std::move(Buffer), LoadedImages.size(), Context);
   if (!ImageOrErr)
     return ImageOrErr.takeError();
   DeviceImageTy *Image = *ImageOrErr;
@@ -1542,7 +1544,7 @@ int32_t GenericPluginTy::load_binary(int32_t DeviceId,
 
   StringRef Buffer(reinterpret_cast<const char *>(TgtImage->ImageStart),
                    utils::getPtrDiff(TgtImage->ImageEnd, TgtImage->ImageStart));
-  auto ImageOrErr = Device.loadBinary(*this, Buffer);
+  auto ImageOrErr = Device.loadBinary(*this, Buffer, /*Context=*/nullptr);
   if (!ImageOrErr) {
     auto Err = ImageOrErr.takeError();
     REPORT() << "Failure to load binary image " << TgtImage << " on device "

--- a/offload/plugins-nextgen/cuda/src/rtl.cpp
+++ b/offload/plugins-nextgen/cuda/src/rtl.cpp
@@ -561,8 +561,8 @@ struct CUDADeviceTy : public GenericDeviceTy {
 
   /// Load the binary image into the device and allocate an image object.
   Expected<DeviceImageTy *>
-  loadBinaryImpl(std::unique_ptr<MemoryBuffer> &&TgtImage,
-                 int32_t ImageId) override {
+  loadBinaryImpl(std::unique_ptr<MemoryBuffer> &&TgtImage, int32_t ImageId,
+                 PluginContextTy * /*Context*/) override {
     if (auto Err = setContext())
       return std::move(Err);
 

--- a/offload/plugins-nextgen/host/src/rtl.cpp
+++ b/offload/plugins-nextgen/host/src/rtl.cpp
@@ -182,8 +182,8 @@ struct GenELF64DeviceTy : public GenericDeviceTy {
 
   /// Load the binary image into the device and allocate an image object.
   Expected<DeviceImageTy *>
-  loadBinaryImpl(std::unique_ptr<MemoryBuffer> &&TgtImage,
-                 int32_t ImageId) override {
+  loadBinaryImpl(std::unique_ptr<MemoryBuffer> &&TgtImage, int32_t ImageId,
+                 PluginContextTy * /*Context*/) override {
     // Allocate and initialize the image object.
     GenELF64DeviceImageTy *Image = Plugin.allocate<GenELF64DeviceImageTy>();
     new (Image) GenELF64DeviceImageTy(ImageId, *this, std::move(TgtImage));

--- a/offload/plugins-nextgen/level_zero/include/L0Device.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Device.h
@@ -213,9 +213,10 @@ public:
   }
   ze_module_handle_t *getGlobalModulesArray() { return GlobalModules.data(); }
 
-  L0ProgramTy *getProgramFromImage(MemoryBufferRef Image) {
+  L0ProgramTy *getProgramFromImage(MemoryBufferRef Image,
+                                   ze_context_handle_t ZeContext) {
     for (auto &PGM : Programs)
-      if (PGM.getMemoryBuffer() == Image)
+      if (PGM.getMemoryBuffer() == Image && PGM.getZeContext() == ZeContext)
         return &PGM;
     return nullptr;
   }
@@ -234,9 +235,9 @@ public:
     auto ImageOrErr = Builder.getELF();
     if (!ImageOrErr)
       return ImageOrErr.takeError();
-    Programs.emplace_back(ImageId, *this, std::move(*ImageOrErr),
-                          Builder.getGlobalModule(),
-                          std::move(Builder.getModules()));
+    Programs.emplace_back(
+        ImageId, *this, std::move(*ImageOrErr), Builder.getGlobalModule(),
+        std::move(Builder.getModules()), Builder.getZeContext());
     return Programs.back();
   }
 

--- a/offload/plugins-nextgen/level_zero/include/L0Device.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Device.h
@@ -510,8 +510,8 @@ public:
 
   // Generic device interface implementation.
   Expected<DeviceImageTy *>
-  loadBinaryImpl(std::unique_ptr<MemoryBuffer> &&TgtImage,
-                 int32_t ImageId) override;
+  loadBinaryImpl(std::unique_ptr<MemoryBuffer> &&TgtImage, int32_t ImageId,
+                 PluginContextTy *UserCtx) override;
   Error unloadBinaryImpl(DeviceImageTy *Image) override;
   Expected<void *> allocate(size_t Size, void *HstPtr, TargetAllocTy Kind,
                             size_t Alignment) override;

--- a/offload/plugins-nextgen/level_zero/include/L0Program.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Program.h
@@ -74,6 +74,10 @@ class L0ProgramTy : public DeviceImageTy {
   /// Module that contains global data including device RTL.
   ze_module_handle_t GlobalModule = nullptr;
 
+  /// L0 context the modules were built against. Cached programs are only
+  /// reusable for lookups that share this context.
+  ze_context_handle_t ZeContext = nullptr;
+
   L0DeviceTy &getL0Device() const;
 
 public:
@@ -82,9 +86,11 @@ public:
   L0ProgramTy(int32_t ImageId, GenericDeviceTy &Device,
               std::unique_ptr<MemoryBuffer> Image,
               ze_module_handle_t GlobalModule,
-              llvm::SmallVector<ze_module_handle_t> &&Modules)
+              llvm::SmallVector<ze_module_handle_t> &&Modules,
+              ze_context_handle_t ZeContext)
       : DeviceImageTy(ImageId, Device, std::move(Image)),
-        Modules(std::move(Modules)), GlobalModule(GlobalModule) {}
+        Modules(std::move(Modules)), GlobalModule(GlobalModule),
+        ZeContext(ZeContext) {}
   ~L0ProgramTy() = default;
 
   L0ProgramTy(const L0ProgramTy &Other) = delete;
@@ -93,6 +99,8 @@ public:
   L0ProgramTy &operator=(const L0ProgramTy &&) = delete;
 
   Error deinit();
+
+  ze_context_handle_t getZeContext() const { return ZeContext; }
 
   static L0ProgramTy &makeL0Program(DeviceImageTy &Device) {
     return static_cast<L0ProgramTy &>(Device);

--- a/offload/plugins-nextgen/level_zero/include/L0Program.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Program.h
@@ -21,6 +21,8 @@ class L0DeviceTy;
 
 class L0ProgramBuilderTy {
   L0DeviceTy &Device;
+  /// L0 context that owns the built modules.
+  ze_context_handle_t ZeContext;
   std::unique_ptr<MemoryBuffer> Image;
   /// Handle multiple modules within a single target image.
   llvm::SmallVector<ze_module_handle_t> Modules;
@@ -39,11 +41,13 @@ class L0ProgramBuilderTy {
   Error linkModules();
 
 public:
-  L0ProgramBuilderTy(L0DeviceTy &Device, std::unique_ptr<MemoryBuffer> &&Image)
-      : Device(Device), Image(std::move(Image)) {}
+  L0ProgramBuilderTy(L0DeviceTy &Device, ze_context_handle_t ZeContext,
+                     std::unique_ptr<MemoryBuffer> &&Image)
+      : Device(Device), ZeContext(ZeContext), Image(std::move(Image)) {}
   ~L0ProgramBuilderTy() = default;
 
   L0DeviceTy &getL0Device() const { return Device; }
+  ze_context_handle_t getZeContext() const { return ZeContext; }
   ze_module_handle_t getGlobalModule() const { return GlobalModule; }
   llvm::SmallVector<ze_module_handle_t> &getModules() { return Modules; }
 

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -213,7 +213,7 @@ Error L0DeviceTy::deinitImpl() {
 
 Expected<DeviceImageTy *>
 L0DeviceTy::loadBinaryImpl(std::unique_ptr<MemoryBuffer> &&TgtImage,
-                           int32_t ImageId) {
+                           int32_t ImageId, PluginContextTy *UserCtx) {
   auto *PGM = getProgramFromImage(TgtImage->getMemBufferRef());
   if (PGM) {
     // Program already exists.
@@ -234,7 +234,9 @@ L0DeviceTy::loadBinaryImpl(std::unique_ptr<MemoryBuffer> &&TgtImage,
   CompilationOptions += " ";
   CompilationOptions += Options.InternalCompilationOptions;
 
-  L0ProgramBuilderTy Builder(*this, std::move(TgtImage));
+  auto &Ctx = UserCtx ? static_cast<LevelZeroPluginContextTy &>(*UserCtx)
+                      : L0Context.getDefaultUserCtx();
+  L0ProgramBuilderTy Builder(*this, Ctx.getZeContext(), std::move(TgtImage));
   if (auto Err = Builder.buildModules(CompilationOptions))
     return std::move(Err);
 

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -214,7 +214,11 @@ Error L0DeviceTy::deinitImpl() {
 Expected<DeviceImageTy *>
 L0DeviceTy::loadBinaryImpl(std::unique_ptr<MemoryBuffer> &&TgtImage,
                            int32_t ImageId, PluginContextTy *UserCtx) {
-  auto *PGM = getProgramFromImage(TgtImage->getMemBufferRef());
+  auto &Ctx = UserCtx ? static_cast<LevelZeroPluginContextTy &>(*UserCtx)
+                      : L0Context.getDefaultUserCtx();
+  auto ZeContext = Ctx.getZeContext();
+
+  auto *PGM = getProgramFromImage(TgtImage->getMemBufferRef(), ZeContext);
   if (PGM) {
     // Program already exists.
     return PGM;
@@ -234,9 +238,7 @@ L0DeviceTy::loadBinaryImpl(std::unique_ptr<MemoryBuffer> &&TgtImage,
   CompilationOptions += " ";
   CompilationOptions += Options.InternalCompilationOptions;
 
-  auto &Ctx = UserCtx ? static_cast<LevelZeroPluginContextTy &>(*UserCtx)
-                      : L0Context.getDefaultUserCtx();
-  L0ProgramBuilderTy Builder(*this, Ctx.getZeContext(), std::move(TgtImage));
+  L0ProgramBuilderTy Builder(*this, ZeContext, std::move(TgtImage));
   if (auto Err = Builder.buildModules(CompilationOptions))
     return std::move(Err);
 

--- a/offload/plugins-nextgen/level_zero/src/L0Program.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Program.cpp
@@ -94,7 +94,7 @@ Error L0ProgramBuilderTy::addModule(size_t Size, const uint8_t *Image,
   ModuleDesc.pBuildFlags = BuildOptions.c_str();
   ModuleDesc.pConstants = &SpecConstants;
   ze_result_t RC;
-  CALL_ZE(RC, zeModuleCreate, L0Device.getZeContext(), L0Device.getZeDevice(),
+  CALL_ZE(RC, zeModuleCreate, getZeContext(), L0Device.getZeDevice(),
           &ModuleDesc, &Module, &BuildLog);
   if (BuildLog)
     zeModuleBuildLogDestroy(BuildLog);

--- a/offload/unittests/Conformance/lib/DeviceContext.cpp
+++ b/offload/unittests/Conformance/lib/DeviceContext.cpp
@@ -252,7 +252,7 @@ DeviceContext::loadBinary(llvm::StringRef Directory,
 
   ol_program_handle_t ProgramHandle = nullptr;
   const ol_result_t OlResult =
-      olCreateProgram(DeviceHandle, BinaryData->getBufferStart(),
+      olCreateProgram(Context, DeviceHandle, BinaryData->getBufferStart(),
                       BinaryData->getBufferSize(), &ProgramHandle);
 
   if (OlResult != OL_SUCCESS) {

--- a/offload/unittests/OffloadAPI/common/Fixtures.hpp
+++ b/offload/unittests/OffloadAPI/common/Fixtures.hpp
@@ -261,7 +261,8 @@ struct OffloadProgramTestWithParam : OffloadDeviceTestWithParam<T> {
     ASSERT_TRUE(TestEnvironment::loadDeviceBinary(ProgramName, this->Device,
                                                   DeviceBin));
     ASSERT_GE(DeviceBin->getBufferSize(), 0lu);
-    ASSERT_SUCCESS(olCreateProgram(this->Device, DeviceBin->getBufferStart(),
+    ASSERT_SUCCESS(olCreateProgram(this->Context, this->Device,
+                                   DeviceBin->getBufferStart(),
                                    DeviceBin->getBufferSize(), &Program));
   }
 
@@ -346,7 +347,7 @@ struct LaunchKernelTestBase : OffloadQueueTest {
     RETURN_ON_FATAL_FAILURE(OffloadQueueTest::SetUp());
     ASSERT_TRUE(TestEnvironment::loadDeviceBinary(program, Device, DeviceBin));
     ASSERT_GE(DeviceBin->getBufferSize(), 0lu);
-    ASSERT_SUCCESS(olCreateProgram(Device, DeviceBin->getBufferStart(),
+    ASSERT_SUCCESS(olCreateProgram(Context, Device, DeviceBin->getBufferStart(),
                                    DeviceBin->getBufferSize(), &Program));
 
     LaunchArgs.Dimensions = 1;

--- a/offload/unittests/OffloadAPI/event/olGetEventElapsedTime.cpp
+++ b/offload/unittests/OffloadAPI/event/olGetEventElapsedTime.cpp
@@ -19,7 +19,7 @@ struct olGetEventElapsedTimeTest : OffloadQueueTest {
     SKIP_KNOWN_FAILURE(LevelZero{"unsupported feature"});
 
     ASSERT_TRUE(TestEnvironment::loadDeviceBinary("foo", Device, DeviceBin));
-    ASSERT_SUCCESS(olCreateProgram(Device, DeviceBin->getBufferStart(),
+    ASSERT_SUCCESS(olCreateProgram(Context, Device, DeviceBin->getBufferStart(),
                                    DeviceBin->getBufferSize(), &Program));
     ASSERT_SUCCESS(olGetSymbol(Program, "foo", OL_SYMBOL_KIND_KERNEL, &Kernel));
 

--- a/offload/unittests/OffloadAPI/program/olCreateProgram.cpp
+++ b/offload/unittests/OffloadAPI/program/olCreateProgram.cpp
@@ -20,7 +20,7 @@ TEST_P(olCreateProgramTest, Success) {
   ASSERT_GE(DeviceBin->getBufferSize(), 0lu);
 
   ol_program_handle_t Program;
-  ASSERT_SUCCESS(olCreateProgram(Device, DeviceBin->getBufferStart(),
+  ASSERT_SUCCESS(olCreateProgram(Context, Device, DeviceBin->getBufferStart(),
                                  DeviceBin->getBufferSize(), &Program));
   ASSERT_NE(Program, nullptr);
 
@@ -34,7 +34,7 @@ TEST_P(olCreateProgramTest, JITSuccess) {
   ASSERT_GE(DeviceBin->getBufferSize(), 0lu);
 
   ol_program_handle_t Program;
-  ASSERT_SUCCESS(olCreateProgram(Device, DeviceBin->getBufferStart(),
+  ASSERT_SUCCESS(olCreateProgram(Context, Device, DeviceBin->getBufferStart(),
                                  DeviceBin->getBufferSize(), &Program));
   ASSERT_NE(Program, nullptr);
 
@@ -46,6 +46,18 @@ TEST_P(olCreateProgramTest, JITSuccess) {
   ASSERT_SUCCESS(olDestroyProgram(Program));
 }
 
+TEST_P(olCreateProgramTest, NullContextHandle) {
+
+  std::unique_ptr<llvm::MemoryBuffer> DeviceBin;
+  ASSERT_TRUE(TestEnvironment::loadDeviceBinary("foo", Device, DeviceBin));
+  ASSERT_GE(DeviceBin->getBufferSize(), 0lu);
+
+  ol_program_handle_t Program;
+  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
+               olCreateProgram(nullptr, Device, DeviceBin->getBufferStart(),
+                               DeviceBin->getBufferSize(), &Program));
+}
+
 TEST_P(olCreateProgramTest, NullDeviceHandle) {
 
   std::unique_ptr<llvm::MemoryBuffer> DeviceBin;
@@ -54,7 +66,7 @@ TEST_P(olCreateProgramTest, NullDeviceHandle) {
 
   ol_program_handle_t Program;
   ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
-               olCreateProgram(nullptr, DeviceBin->getBufferStart(),
+               olCreateProgram(Context, nullptr, DeviceBin->getBufferStart(),
                                DeviceBin->getBufferSize(), &Program));
 }
 
@@ -65,9 +77,9 @@ TEST_P(olCreateProgramTest, NullProgData) {
   ASSERT_GE(DeviceBin->getBufferSize(), 0lu);
 
   ol_program_handle_t Program;
-  ASSERT_ERROR(
-      OL_ERRC_INVALID_NULL_POINTER,
-      olCreateProgram(Device, nullptr, DeviceBin->getBufferSize(), &Program));
+  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
+               olCreateProgram(Context, Device, nullptr,
+                               DeviceBin->getBufferSize(), &Program));
 }
 
 TEST_P(olCreateProgramTest, NullOutputProgram) {
@@ -77,7 +89,7 @@ TEST_P(olCreateProgramTest, NullOutputProgram) {
   ASSERT_GE(DeviceBin->getBufferSize(), 0lu);
 
   ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
-               olCreateProgram(Device, DeviceBin->getBufferStart(),
+               olCreateProgram(Context, Device, DeviceBin->getBufferStart(),
                                DeviceBin->getBufferSize(), nullptr));
 }
 
@@ -88,9 +100,9 @@ TEST_P(olCreateProgramTest, ZeroSizeBinary) {
 
   ol_program_handle_t Program = nullptr;
 
-  ASSERT_ERROR(
-      OL_ERRC_INVALID_BINARY,
-      olCreateProgram(Device, DeviceBin->getBufferStart(), 0, &Program));
+  ASSERT_ERROR(OL_ERRC_INVALID_BINARY,
+               olCreateProgram(Context, Device, DeviceBin->getBufferStart(), 0,
+                               &Program));
   ASSERT_EQ(Program, nullptr);
 }
 
@@ -99,8 +111,8 @@ TEST_P(olCreateProgramTest, InvalidBinary) {
 
   ol_program_handle_t Program = nullptr;
   ASSERT_ERROR(OL_ERRC_INVALID_BINARY,
-               olCreateProgram(Device, InvalidBinary, sizeof(InvalidBinary) - 1,
-                               &Program));
+               olCreateProgram(Context, Device, InvalidBinary,
+                               sizeof(InvalidBinary) - 1, &Program));
   ASSERT_EQ(Program, nullptr);
 }
 
@@ -120,7 +132,19 @@ TEST_P(olCreateProgramTest, WrongArchitecture) {
 
   ol_program_handle_t Program = nullptr;
   ASSERT_ERROR(OL_ERRC_INVALID_BINARY,
-               olCreateProgram(Device, ForeignBin->getBufferStart(),
+               olCreateProgram(Context, Device, ForeignBin->getBufferStart(),
                                ForeignBin->getBufferSize(), &Program));
+  ASSERT_EQ(Program, nullptr);
+}
+
+TEST_P(olCreateProgramTest, InvalidDeviceNotInContext) {
+  std::unique_ptr<llvm::MemoryBuffer> DeviceBin;
+  ASSERT_TRUE(TestEnvironment::loadDeviceBinary("foo", Device, DeviceBin));
+  ASSERT_GE(DeviceBin->getBufferSize(), 0lu);
+
+  ol_program_handle_t Program = nullptr;
+  ASSERT_ERROR(OL_ERRC_INVALID_DEVICE,
+               olCreateProgram(Context, Host, DeviceBin->getBufferStart(),
+                               DeviceBin->getBufferSize(), &Program));
   ASSERT_EQ(Program, nullptr);
 }

--- a/offload/unittests/OffloadAPI/symbol/olGetSymbol.cpp
+++ b/offload/unittests/OffloadAPI/symbol/olGetSymbol.cpp
@@ -18,7 +18,7 @@ struct olGetSymbolGlobalTest : OffloadQueueTest {
     RETURN_ON_FATAL_FAILURE(OffloadQueueTest::SetUp());
     ASSERT_TRUE(TestEnvironment::loadDeviceBinary("global", Device, DeviceBin));
     ASSERT_GE(DeviceBin->getBufferSize(), 0lu);
-    ASSERT_SUCCESS(olCreateProgram(Device, DeviceBin->getBufferStart(),
+    ASSERT_SUCCESS(olCreateProgram(Context, Device, DeviceBin->getBufferStart(),
                                    DeviceBin->getBufferSize(), &Program));
   }
 


### PR DESCRIPTION
This patch is the 3rd patch in the context patch series. This change is relatively simple compared to the others: we just introduce context to the create program API and pass it down through the plugin interface to the plugins.