### PR TITLE
[clang][bytecode][NFC] Remove unnecessary rvalue reference parameters

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -5330,8 +5330,8 @@ bool Compiler<Emitter>::emitConst(const APSInt &Value, const Expr *E) {
 }
 
 template <class Emitter>
-unsigned Compiler<Emitter>::allocateLocalPrimitive(DeclOrExpr &&Src,
-                                                   PrimType Ty, bool IsConst,
+unsigned Compiler<Emitter>::allocateLocalPrimitive(DeclOrExpr Src, PrimType Ty,
+                                                   bool IsConst,
                                                    bool IsVolatile,
                                                    ScopeKind SC) {
   // FIXME: There are cases where Src.isExpr() is wrong, e.g.
@@ -5348,7 +5348,7 @@ unsigned Compiler<Emitter>::allocateLocalPrimitive(DeclOrExpr &&Src,
 }
 
 template <class Emitter>
-UnsignedOrNone Compiler<Emitter>::allocateLocal(DeclOrExpr &&Src, QualType Ty,
+UnsignedOrNone Compiler<Emitter>::allocateLocal(DeclOrExpr Src, QualType Ty,
                                                 ScopeKind SC) {
   const ValueDecl *Key = nullptr;
   const Expr *Init = nullptr;

--- a/clang/lib/AST/ByteCode/Compiler.h
+++ b/clang/lib/AST/ByteCode/Compiler.h
@@ -346,12 +346,12 @@ protected:
                      bool Activate, bool IsOperatorCall);
 
   /// Creates a local primitive value.
-  unsigned allocateLocalPrimitive(DeclOrExpr &&Decl, PrimType Ty, bool IsConst,
+  unsigned allocateLocalPrimitive(DeclOrExpr Decl, PrimType Ty, bool IsConst,
                                   bool IsVolatile = false,
                                   ScopeKind SC = ScopeKind::Block);
 
   /// Allocates a space storing a local given its type.
-  UnsignedOrNone allocateLocal(DeclOrExpr &&Decl, QualType Ty = QualType(),
+  UnsignedOrNone allocateLocal(DeclOrExpr Decl, QualType Ty = QualType(),
                                ScopeKind = ScopeKind::Block);
   UnsignedOrNone allocateTemporary(const Expr *E);
 


### PR DESCRIPTION
DeclOrExpr is just pointer-sized, so copy them.