### PR TITLE
[clang][bytecode] Avoid copying function call arguments

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -6207,7 +6207,8 @@ bool Compiler<Emitter>::VisitCallExpr(const CallExpr *E) {
     }
   }
 
-  SmallVector<const Expr *, 8> Args(ArrayRef(E->getArgs(), E->getNumArgs()));
+  ArrayRef<const Expr *> Args(E->getArgs(), E->getNumArgs());
+  const Expr *ReversedArgs[2];
 
   bool IsAssignmentOperatorCall = false;
   bool ActivateLHS = false;
@@ -6220,7 +6221,9 @@ bool Compiler<Emitter>::VisitCallExpr(const CallExpr *E) {
     const CXXRecordDecl *LHSRecord = Args[0]->getType()->getAsCXXRecordDecl();
     ActivateLHS = LHSRecord && LHSRecord->hasTrivialDefaultConstructor();
     IsAssignmentOperatorCall = true;
-    std::reverse(Args.begin(), Args.end());
+    ReversedArgs[0] = Args[1];
+    ReversedArgs[1] = Args[0];
+    Args = ReversedArgs;
   }
   // Calling a static operator will still
   // pass the instance, but we don't need it.
@@ -6231,7 +6234,7 @@ bool Compiler<Emitter>::VisitCallExpr(const CallExpr *E) {
       if (!this->discard(E->getArg(0)))
         return false;
       // Drop first arg.
-      Args.erase(Args.begin());
+      Args = Args.drop_front();
     }
   }
 


### PR DESCRIPTION
In most cases, we dony' need the SmallVector (we only use it to reverse the arguments in the assignment operator case).