### PR TITLE
[BOLT] Preserve branches past function boundaries

### DIFF
--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1452,16 +1452,13 @@ Error BinaryFunction::disassemble() {
                 TargetAddress < getAddress() + getMaxSize() &&
                 !(BC.isAArch64() &&
                   BC.handleAArch64Veneer(TargetAddress, /*MatchOnly*/ true))) {
-              // Result of __builtin_unreachable().
+              // This may be an effect of source-level undefined behavior, such
+              // as __builtin_unreachable(). It may also be valid code at a
+              // temporary label omitted from the symbol table by the assembler.
+              // Since BOLT cannot distinguish these cases, preserve the branch.
               errs() << "BOLT-WARNING: jump past end detected at 0x"
                      << Twine::utohexstr(AbsoluteInstrAddr) << " in function "
-                     << *this << " : replacing with nop.\n";
-              BC.MIB->createNoop(Instruction);
-              if (IsCondBranch) {
-                // Register branch offset for profile validation.
-                IgnoredBranches.emplace_back(Offset, Offset + Size);
-              }
-              goto add_instruction;
+                     << *this << ".\n";
             }
             // May update Instruction and IsCall
             TargetSymbol = handleExternalReference(Instruction, Size, Offset,
@@ -1539,7 +1536,6 @@ Error BinaryFunction::disassemble() {
       }
     }
 
-add_instruction:
     if (!getDWARFUnits().empty()) {
       SmallVector<DebugLineTableRowRef, 1> Rows;
       for (const auto &[_, Unit] : getDWARFUnits()) {

--- a/bolt/test/AArch64/invalid-code-padding.s
+++ b/bolt/test/AArch64/invalid-code-padding.s
@@ -9,12 +9,12 @@
   .type foo, %function
 foo:
   cmp x0, x1
-  b.eq .Ltmp1
+  b.eq .Ltmp2
   adrp x1, jmptbl
   add x1, x1, :lo12:jmptbl
   ldrsw x2, [x1, x2, lsl #2]
   br x2
-  b .Ltmp1
+  b .Ltmp2
 .Ltmp2:
   add x0, x0, x1
   ret

--- a/bolt/test/AArch64/jump-past-end.s
+++ b/bolt/test/AArch64/jump-past-end.s
@@ -1,0 +1,43 @@
+## Check that BOLT preserves a branch to code immediately past the size of a
+## function. Such code can result from a temporary assembler symbol that is
+## not retained in the linked binary.
+
+# REQUIRES: system-linux, target=aarch64{{.*}}
+
+# RUN: llvm-mc -filetype=obj -triple aarch64-unknown-linux %s -o %t.o
+# RUN: %clang %cflags %t.o -o %t.exe -nostdlib -Wl,-q,-e,_start
+# RUN: llvm-bolt %t.exe -o %t.bolt --relocs=1 --lite=0 2>&1 \
+# RUN:   | FileCheck %s --check-prefix=WARNING
+# RUN: llvm-objdump -d --no-show-raw-insn -j .text %t.bolt \
+# RUN:   | FileCheck %s --check-prefix=DISASM
+
+# WARNING: BOLT-WARNING: jump past end detected
+
+# DISASM: <f>:
+# DISASM-NEXT: {{.*}}cbnz x0,
+# DISASM-NEXT: {{.*}}ret
+
+  .text
+  .global _start
+  .type _start, %function
+_start:
+  b f
+  .size _start, .-_start
+
+  .global f
+  .type f, %function
+f:
+  cbnz x0, .Lf_helper
+  ret
+  .size f, .-f
+
+  .type .Lf_helper, %function
+.Lf_helper:
+  mov x1, #42
+  ret
+  .size .Lf_helper, .-.Lf_helper
+
+  .type next, %function
+next:
+  ret
+  .size next, .-next


### PR DESCRIPTION
BOLT currently replaces a branch immediately past a function boundary with a NOP, assuming it results from undefined behavior. However, the target may be valid code marked by a temporary label that the assembler omitted from the symbol table.

This change keeps the warning but preserves the branch as an external reference. This should not occur in binaries produced by Clang from C/C++ sources, but handling it conservatively is just safer.