### PR TITLE
[flang][debug] Don't ask for a name table with -gline-directives-only

### DIFF
--- a/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
+++ b/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
@@ -1037,11 +1037,19 @@ void AddDebugInfoPass::runOnOperation() {
   if (!dwarfDebugFlags.empty())
     producerString += " " + dwarfDebugFlags;
   mlir::StringAttr producer = mlir::StringAttr::get(context, producerString);
+  // A unit that only emits line directives has no .debug_info, so the header
+  // of its compile unit, and with it the label the DWARF 5 accelerator table
+  // points at, is never written. Asking for a name table would have that table
+  // reference a label that does not exist. Clang leaves the name table off for
+  // the same reason.
+  mlir::LLVM::DINameTableKind nameTableKind =
+      debugLevel == mlir::LLVM::DIEmissionKind::DebugDirectivesOnly
+          ? mlir::LLVM::DINameTableKind::None
+          : mlir::LLVM::DINameTableKind::Default;
   mlir::LLVM::DICompileUnitAttr cuAttr = mlir::LLVM::DICompileUnitAttr::get(
       mlir::DistinctAttr::create(mlir::UnitAttr::get(context)),
       llvm::dwarf::getLanguage("DW_LANG_Fortran95"), fileAttr, producer,
-      isOptimized, debugLevel, debugInfoForProfiling,
-      /*nameTableKind=*/mlir::LLVM::DINameTableKind::Default,
+      isOptimized, debugLevel, debugInfoForProfiling, nameTableKind,
       splitDwarfFile.empty() ? mlir::StringAttr()
                              : mlir::StringAttr::get(context, splitDwarfFile));
 

--- a/flang/test/Integration/debug-line-directives-only.f90
+++ b/flang/test/Integration/debug-line-directives-only.f90
@@ -1,0 +1,10 @@
+! Test that -gline-directives-only leaves the name table off.
+
+! RUN: %flang_fc1 -debug-info-kind=line-directives-only -emit-llvm -o - %s \
+! RUN:   | FileCheck %s
+
+! CHECK: !DICompileUnit({{.*}}emissionKind: DebugDirectivesOnly
+! CHECK-SAME: nameTableKind: None
+
+program test
+end program test

--- a/flang/test/Transforms/debug-line-table.fir
+++ b/flang/test/Transforms/debug-line-table.fir
@@ -28,7 +28,7 @@ module {
 // FULL: #di_compile_unit = #llvm.di_compile_unit<id = distinct[{{.*}}]<>, sourceLanguage = DW_LANG_Fortran95, file = #di_file, producer = "{{.*}}flang{{.*}}", emissionKind = Full>
 // OPT: #di_compile_unit = #llvm.di_compile_unit<id = distinct[{{.*}}]<>, sourceLanguage = DW_LANG_Fortran95, file = #di_file, producer = "{{.*}}flang{{.*}}", isOptimized = true, emissionKind = Full>
 // LINETABLE: #di_compile_unit = #llvm.di_compile_unit<id = distinct[{{.*}}]<>, sourceLanguage = DW_LANG_Fortran95, file = #di_file, producer = "{{.*}}flang{{.*}}", emissionKind = LineTablesOnly>
-// DIRECTIVES: #di_compile_unit = #llvm.di_compile_unit<id = distinct[{{.*}}]<>, sourceLanguage = DW_LANG_Fortran95, file = #di_file, producer = "{{.*}}flang{{.*}}", emissionKind = DebugDirectivesOnly>
+// DIRECTIVES: #di_compile_unit = #llvm.di_compile_unit<id = distinct[{{.*}}]<>, sourceLanguage = DW_LANG_Fortran95, file = #di_file, producer = "{{.*}}flang{{.*}}", emissionKind = DebugDirectivesOnly, nameTableKind = None>
 // CHECK: #di_subroutine_type = #llvm.di_subroutine_type<callingConvention = DW_CC_normal, types = #di_basic_type, #di_basic_type>
 // CHECK: #[[SB_SUBPROGRAM:.*]] = #llvm.di_subprogram<id = distinct[{{.*}}]<>, compileUnit = #di_compile_unit, scope = #di_file, name = "[[SB_NAME]]", linkageName = "[[SB_NAME]]", file = #di_file, line = 1, scopeLine = 1, subprogramFlags = "Definition|Optimized", type = #di_subroutine_type>
 // CHECK: #[[DECL_SUBPROGRAM:.*]] = #llvm.di_subprogram<scope = #di_file, name = "[[DECL_NAME]]", linkageName = "[[DECL_NAME]]", file = #di_file, line = 1, scopeLine = 1, subprogramFlags = Optimized, type = #di_subroutine_type>


### PR DESCRIPTION
On current main (since #217132), a unit built with `-gline-directives-only` crashes the backend when DWARF 5 is requested:

```console
$ echo 'end program' > test.f90
$ flang -gdwarf-5 -gline-directives-only -S -o /dev/null test.f90
flang: llvm/lib/CodeGen/AsmPrinter/DwarfUnit.h:107:
llvm::MCSymbol *llvm::DwarfUnit::getLabelBegin() const:
Assertion `LabelBegin && "LabelBegin is not initialized"' failed.
```

The version has to be spelled out because flang does not yet default to DWARF 5. Everything else about the command line is ordinary.

Such a unit emits line directives and no `.debug_info`, so the header of its compile unit is never written and neither is the label that header defines. Under DWARF 5 the accelerator table indexes every compile unit whose `nameTableKind` is `Default` and refers to that label, which is what trips the assertion.

This patch leaves the name table off for that emission kind, as clang does. Nothing is lost, as the unit has no `.debug_info` for a name table to point into.

flang gained `-gline-directives-only` in #217132; before that the driver rejected the option with a warning, so `DebugDirectivesOnly` never reached this pass and the combination was unreachable.