### PR TITLE
[BOLT][RISCV] Keep the link register when rewriting a call

### DIFF
--- a/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
+++ b/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
@@ -109,6 +109,7 @@ public:
     default:
       return MCPlusBuilder::isPseudo(Inst);
     case RISCV::PseudoCALL:
+    case RISCV::PseudoCALLReg:
     case RISCV::PseudoTAIL:
       return false;
     }
@@ -259,16 +260,36 @@ public:
   }
 
   void createCall(unsigned Opcode, MCInst &Inst, const MCSymbol *Target,
-                  MCContext *Ctx) {
+                  MCContext *Ctx,
+                  const MCOperand &LinkReg = MCOperand()) const {
     Inst.setOpcode(Opcode);
     Inst.clear();
+    if (LinkReg.isValid())
+      Inst.addOperand(LinkReg);
     Inst.addOperand(MCOperand::createExpr(MCSpecifierExpr::create(
         MCSymbolRefExpr::create(Target, *Ctx), RISCV::S_CALL_PLT, *Ctx)));
   }
 
+  MCPhysReg getCallLinkRegister(const MCInst &Inst) const {
+    switch (Inst.getOpcode()) {
+    default:
+      return RISCV::X1;
+    case RISCV::JAL:
+    case RISCV::JALR:
+    case RISCV::PseudoCALLReg:
+      return Inst.getOperand(0).getReg();
+    }
+  }
+
   void createCall(MCInst &Inst, const MCSymbol *Target,
                   MCContext *Ctx) override {
-    return createCall(RISCV::PseudoCALL, Inst, Target, Ctx);
+    MCPhysReg LinkReg = getCallLinkRegister(Inst);
+    unsigned Opcode;
+    if (LinkReg == RISCV::X1)
+      createCall(RISCV::PseudoCALL, Inst, Target, Ctx);
+    else
+      createCall(RISCV::PseudoCALLReg, Inst, Target, Ctx,
+                 MCOperand::createReg(LinkReg));
   }
 
   void createLongTailCall(InstructionListType &Seq, const MCSymbol *Target,
@@ -341,6 +362,9 @@ public:
     case RISCV::PseudoCALL:
     case RISCV::PseudoTAIL:
       OpNum = 0;
+      return true;
+    case RISCV::PseudoCALLReg:
+      OpNum = 1;
       return true;
     case RISCV::AUIPC:
     case RISCV::JAL:

--- a/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
+++ b/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
@@ -260,12 +260,11 @@ public:
   }
 
   void createCall(unsigned Opcode, MCInst &Inst, const MCSymbol *Target,
-                  MCContext *Ctx,
-                  const MCOperand &LinkReg = MCOperand()) const {
+                  MCContext *Ctx, MCRegister LinkReg = MCRegister()) const {
     Inst.setOpcode(Opcode);
     Inst.clear();
     if (LinkReg.isValid())
-      Inst.addOperand(LinkReg);
+      Inst.addOperand(MCOperand::createReg(LinkReg));
     Inst.addOperand(MCOperand::createExpr(MCSpecifierExpr::create(
         MCSymbolRefExpr::create(Target, *Ctx), RISCV::S_CALL_PLT, *Ctx)));
   }
@@ -287,8 +286,7 @@ public:
     if (LinkReg == RISCV::X1)
       createCall(RISCV::PseudoCALL, Inst, Target, Ctx);
     else
-      createCall(RISCV::PseudoCALLReg, Inst, Target, Ctx,
-                 MCOperand::createReg(LinkReg));
+      createCall(RISCV::PseudoCALLReg, Inst, Target, Ctx, LinkReg);
   }
 
   void createLongTailCall(InstructionListType &Seq, const MCSymbol *Target,

--- a/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
+++ b/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
@@ -284,7 +284,6 @@ public:
   void createCall(MCInst &Inst, const MCSymbol *Target,
                   MCContext *Ctx) override {
     MCPhysReg LinkReg = getCallLinkRegister(Inst);
-    unsigned Opcode;
     if (LinkReg == RISCV::X1)
       createCall(RISCV::PseudoCALL, Inst, Target, Ctx);
     else

--- a/bolt/test/RISCV/call-link-register.s
+++ b/bolt/test/RISCV/call-link-register.s
@@ -10,13 +10,10 @@ _start:
 // CHECK-LABEL: <_start>:
 /// The auipc of the pair, replaced by a nop once the call is rewritten.
 // CHECK-NEXT: nop
-/// FIXME: the link register is dropped here: the call is rewritten to link
-/// through ra, so f returns to whatever t0 happens to hold.
-// CHECK-NEXT: jal 0x{{.*}} <f>
+// CHECK-NEXT: jal t0, 0x{{.*}} <f>
   call t0, f
 /// A jal in direct range is rewritten on its own, with no auipc to nop out.
-/// FIXME: the link register is dropped here too.
-// CHECK-NEXT: jal 0x{{.*}} <f>
+// CHECK-NEXT: jal t0, 0x{{.*}} <f>
   jal t0, f
 /// A call that already links through ra keeps ra.
 // CHECK-NEXT: nop


### PR DESCRIPTION
FixRISCVCallsPass rewrites an auipc/jalr call pair into a PseudoCALL, which always links through ra. That is wrong for the machine outliner: it calls an outlined function with "call t0, func" and the callee returns with "jr t0", so after the rewrite the callee returns to whatever t0 happens to hold.

Read the link register off the instruction being replaced and emit a PseudoCALLReg with it whenever it is not ra.

Assisted-by: Opus.