### PR TITLE
[clang][bytecode] Protect evaluateString() from invalid pointers

### DIFF
--- a/clang/lib/AST/ByteCode/Context.cpp
+++ b/clang/lib/AST/ByteCode/Context.cpp
@@ -284,6 +284,9 @@ bool Context::evaluateString(State &Parent, const Expr *E,
     if (!Ptr.isConst())
       return false;
 
+    if (Ptr.isDummy() || Ptr.isUnknownSizeArray() || Ptr.isPastEnd())
+      return false;
+
     unsigned N = Ptr.getNumElems();
 
     if (Ptr.elemSize() == 1 /* bytes */) {

--- a/clang/test/AST/ByteCode/invalid.cpp
+++ b/clang/test/AST/ByteCode/invalid.cpp
@@ -247,3 +247,12 @@ namespace InvalidStaticInvoker {
   constexpr int (*baz)(int) = foo;
   int i = baz(42);
 }
+
+namespace UnknownSizeArrayInEvaluateString {
+  void foo() {
+    constexpr char K[] = {'\0'; // both-error {{expected '}'}} \
+                                // both-note {{to match this}}
+    __builtin_verbose_trap("bar", K); // both-error {{argument to __builtin_verbose_trap must be a pointer to a constant string}}
+  }
+  }
+} // both-error {{extraneous closing brace}}


### PR DESCRIPTION
We can't call `Pointer::getNumElems()` on pointers to unknown size arrays.