### PR TITLE
[libc++] Revert extra-attempts to original value

### DIFF
--- a/.github/workflows/libcxx-benchmark-cron.yml
+++ b/.github/workflows/libcxx-benchmark-cron.yml
@@ -167,4 +167,4 @@ jobs:
           fi
 
           libcxx/utils/ci/lnt/dispatch-benchmarks --work-items plan.jsonl --lnt-url "${LNT_URL}"  \
-                                                  --max-in-flight "${MAX_IN_FLIGHT}" "${dry_run[@]}" --extra-attempts 6
+                                                  --max-in-flight "${MAX_IN_FLIGHT}" "${dry_run[@]}"


### PR DESCRIPTION
This reverts ab4cccdf16 now that lnt.llvm.org is stable, the bots have caught up and all machines have data for all the commits.