### PR TITLE
[offload] add handling of memory alignment to MemoryManagerTy

### DIFF
--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -339,7 +339,7 @@ struct AMDGPUMemoryPoolTy {
     // compared with the alignment of the memory allocated using the given pool.
     // If the default alignment is greater than or equal to the alignment
     // requested by the user, it would still meet the user's requirements.
-    if (Alignment > 0 && Alignment > PoolAllocationAlignment) {
+    if (Alignment > PoolAllocationAlignment) {
       return Plugin::error(ErrorCode::UNSUPPORTED,
                            "requested alignment (%lu) larger than maximum "
                            "supported pool alignment (%lu)",
@@ -348,18 +348,6 @@ struct AMDGPUMemoryPoolTy {
 
     hsa_status_t Status =
         hsa_amd_memory_pool_allocate(MemoryPool, Size, 0, PtrStorage);
-
-    if (Alignment > 0 && !isAddrAligned(Align(Alignment), *PtrStorage)) {
-      if (auto FreeErr = deallocate(*PtrStorage)) {
-        return Plugin::error(ErrorCode::UNKNOWN,
-                             "Failure in deallcation of the incorrectly "
-                             "aligned pointer; requested alignemnt: %lu",
-                             Alignment);
-      }
-
-      return Plugin::error(ErrorCode::UNSUPPORTED,
-                           "unsupported alignment size");
-    }
 
     return Plugin::check(Status, "error in hsa_amd_memory_pool_allocate: %s");
   }

--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -349,6 +349,18 @@ struct AMDGPUMemoryPoolTy {
     hsa_status_t Status =
         hsa_amd_memory_pool_allocate(MemoryPool, Size, 0, PtrStorage);
 
+    if (Alignment > 0 && !isAddrAligned(Align(Alignment), *PtrStorage)) {
+      if (auto FreeErr = deallocate(*PtrStorage)) {
+        return Plugin::error(ErrorCode::UNKNOWN,
+                             "Failure in deallcation of the incorrectly "
+                             "aligned pointer; requested alignemnt: %lu",
+                             Alignment);
+      }
+
+      return Plugin::error(ErrorCode::UNSUPPORTED,
+                           "unsupported alignment size");
+    }
+
     return Plugin::check(Status, "error in hsa_amd_memory_pool_allocate: %s");
   }
 

--- a/offload/plugins-nextgen/common/include/MemoryManager.h
+++ b/offload/plugins-nextgen/common/include/MemoryManager.h
@@ -106,13 +106,17 @@ class MemoryManagerTy {
 
   /// A structure stores the meta data of a target pointer
   struct NodeTy {
-    /// Memory size
+    /// Final memory size, including the alignment
     const size_t Size;
-    /// Target pointer
+    /// Target pointer, returned to the caller after adjustments related to the
+    /// memory alignment (moving the pointer)
     void *Ptr;
+    /// Pointer to the originally allocated memory
+    void *BasePtr;
 
     /// Constructor
-    NodeTy(size_t Size, void *Ptr) : Size(Size), Ptr(Ptr) {}
+    NodeTy(size_t FinalSize, void *Ptr, void *BasePtr)
+        : Size(FinalSize), Ptr(Ptr), BasePtr(BasePtr) {}
   };
 
   /// To make \p NodePtrTy ordered when they're put into \p std::multiset.
@@ -171,7 +175,7 @@ class MemoryManagerTy {
       if (List.empty())
         continue;
       for (const NodeTy &N : List) {
-        if (auto Err = deleteOnDevice(N.Ptr))
+        if (auto Err = deleteOnDevice(N.BasePtr))
           return Err;
         RemoveList.push_back(N.Ptr);
       }
@@ -218,6 +222,19 @@ class MemoryManagerTy {
     return TgtPtr;
   }
 
+  void changeKeyPtr(void *FinalPtr, NodeTy *NodePtr) {
+    std::lock_guard<std::mutex> LG(MapTableLock);
+    auto NodeHandle = PtrToNodeTable.extract(NodePtr->Ptr);
+    NodeHandle.mapped().Ptr = FinalPtr;
+    NodeHandle.key() = FinalPtr;
+    PtrToNodeTable.insert(std::move(NodeHandle));
+  }
+
+  void *alignPointer(void *PtrToBeAligned, size_t Alignment) {
+    uintptr_t AlignedPointer = (uintptr_t)PtrToBeAligned;
+    return (void *)((AlignedPointer + Alignment - 1) & ~(Alignment - 1));
+  }
+
 public:
   static constexpr size_t DefaultSizeThreshold = 1U << 13;
 
@@ -234,8 +251,8 @@ public:
   /// Destructor
   ~MemoryManagerTy() {
     for (auto &PtrToNode : PtrToNodeTable) {
-      assert(PtrToNode.second.Ptr && "nullptr in map table");
-      if (auto Err = deleteOnDevice(PtrToNode.second.Ptr))
+      assert(PtrToNode.second.BasePtr && "nullptr in map table");
+      if (auto Err = deleteOnDevice(PtrToNode.second.BasePtr))
         REPORT() << "Failure to delete memory: " << toString(std::move(Err));
     }
   }
@@ -264,9 +281,22 @@ public:
       ODBG(OLDT_Alloc) << "Got target pointer " << *TgtPtrOrErr
                        << ". Return directly.";
 
+      if (Alignment > 0 && !isAddrAligned(Align(Alignment), *TgtPtrOrErr)) {
+        auto AlignErr = make_error<StringError>(
+            "Allocated address is misaligned", inconvertibleErrorCode());
+        if (auto FreeErr = deleteOnDevice(*TgtPtrOrErr)) {
+          return joinErrors(std::move(FreeErr), std::move(AlignErr));
+        }
+
+        return AlignErr;
+      }
+
       return *TgtPtrOrErr;
     }
 
+    if (Alignment > 0) {
+      Size += Alignment - 1;
+    }
     NodeTy *NodePtr = nullptr;
 
     // Try to get a node from FreeList
@@ -274,21 +304,31 @@ public:
       const int B = findBucket(Size);
       FreeListTy &List = FreeLists[B];
 
-      NodeTy TempNode(Size, nullptr);
+      NodeTy TempNode(Size, nullptr, nullptr);
       std::lock_guard<std::mutex> LG(FreeListLocks[B]);
-      auto [First, Last] = List.equal_range(TempNode);
+      auto Itr = List.find(TempNode);
 
-      auto Itr = std::find_if(First, Last, [Alignment](const NodeTy &N) {
-        return Alignment == 0 || isAddrAligned(Align(Alignment), N.Ptr);
-      });
-      if (Itr != Last) {
+      if (Itr != List.end()) {
         NodePtr = &Itr->get();
         List.erase(Itr);
       }
     }
 
-    if (NodePtr != nullptr)
+    if (NodePtr != nullptr) {
       ODBG(OLDT_Alloc) << "Find one node " << NodePtr << " in the bucket.";
+
+      if (Alignment > 0) {
+        void *AlignedPointer = alignPointer(NodePtr->BasePtr, Alignment);
+
+        if (AlignedPointer != NodePtr->Ptr) {
+          changeKeyPtr(AlignedPointer, NodePtr);
+        }
+      } else {
+        if (NodePtr->Ptr != NodePtr->BasePtr) {
+          changeKeyPtr(NodePtr->BasePtr, NodePtr);
+        }
+      }
+    }
 
     // We cannot find a valid node in FreeLists. Let's allocate on device and
     // create a node for it.
@@ -305,10 +345,16 @@ public:
       if (TgtPtr == nullptr)
         return nullptr;
 
+      void *BasePtr = TgtPtr;
+      if (Alignment > 0) {
+        TgtPtr = alignPointer(TgtPtr, Alignment);
+      }
+
       // Create a new node and add it into the map table
       {
         std::lock_guard<std::mutex> Guard(MapTableLock);
-        auto Itr = PtrToNodeTable.emplace(TgtPtr, NodeTy(Size, TgtPtr));
+        auto Itr =
+            PtrToNodeTable.emplace(TgtPtr, NodeTy(Size, TgtPtr, BasePtr));
         NodePtr = &Itr.first->second;
       }
 

--- a/offload/plugins-nextgen/common/include/MemoryManager.h
+++ b/offload/plugins-nextgen/common/include/MemoryManager.h
@@ -106,7 +106,7 @@ class MemoryManagerTy {
 
   /// A structure stores the meta data of a target pointer
   struct NodeTy {
-    /// Final memory size, including the alignment
+    /// Final allocation size, including the alignment padding
     const size_t Size;
     /// Target pointer, returned to the caller after adjustments related to the
     /// memory alignment (moving the pointer)
@@ -115,8 +115,8 @@ class MemoryManagerTy {
     void *BasePtr;
 
     /// Constructor
-    NodeTy(size_t FinalSize, void *Ptr, void *BasePtr)
-        : Size(FinalSize), Ptr(Ptr), BasePtr(BasePtr) {}
+    NodeTy(size_t Size, void *Ptr, void *BasePtr)
+        : Size(Size), Ptr(Ptr), BasePtr(BasePtr) {}
   };
 
   /// To make \p NodePtrTy ordered when they're put into \p std::multiset.
@@ -230,11 +230,6 @@ class MemoryManagerTy {
     PtrToNodeTable.insert(std::move(NodeHandle));
   }
 
-  void *alignPointer(void *PtrToBeAligned, size_t Alignment) {
-    uintptr_t AlignedPointer = (uintptr_t)PtrToBeAligned;
-    return (void *)((AlignedPointer + Alignment - 1) & ~(Alignment - 1));
-  }
-
 public:
   static constexpr size_t DefaultSizeThreshold = 1U << 13;
 
@@ -265,16 +260,19 @@ public:
     if (Size == 0)
       return nullptr;
 
-    ODBG(OLDT_Alloc) << "MemoryManagerTy::allocate: size " << Size
+    size_t AllocationSize = Alignment > 0 ? (Size + Alignment - 1) : Size;
+
+    ODBG(OLDT_Alloc) << "MemoryManagerTy::allocate: requested memory " << Size
+                     << ", allocated:  " << AllocationSize
                      << " with host pointer " << HstPtr << ".";
 
     // If the size is greater than the threshold, allocate it directly from
     // device.
-    if (Size > SizeThreshold) {
-      ODBG(OLDT_Alloc) << Size << " is greater than the threshold "
+    if (AllocationSize > SizeThreshold) {
+      ODBG(OLDT_Alloc) << AllocationSize << " is greater than the threshold "
                        << SizeThreshold << ". Allocate it directly from device";
       auto TgtPtrOrErr =
-          allocateOrFreeAndAllocateOnDevice(Size, HstPtr, Alignment);
+          allocateOrFreeAndAllocateOnDevice(AllocationSize, HstPtr, Alignment);
       if (!TgtPtrOrErr)
         return TgtPtrOrErr.takeError();
 
@@ -294,17 +292,14 @@ public:
       return *TgtPtrOrErr;
     }
 
-    if (Alignment > 0) {
-      Size += Alignment - 1;
-    }
     NodeTy *NodePtr = nullptr;
 
     // Try to get a node from FreeList
     {
-      const int B = findBucket(Size);
+      const int B = findBucket(AllocationSize);
       FreeListTy &List = FreeLists[B];
 
-      NodeTy TempNode(Size, nullptr, nullptr);
+      NodeTy TempNode(AllocationSize, nullptr, nullptr);
       std::lock_guard<std::mutex> LG(FreeListLocks[B]);
       auto Itr = List.find(TempNode);
 
@@ -318,7 +313,8 @@ public:
       ODBG(OLDT_Alloc) << "Find one node " << NodePtr << " in the bucket.";
 
       if (Alignment > 0) {
-        void *AlignedPointer = alignPointer(NodePtr->BasePtr, Alignment);
+        void *AlignedPointer =
+            (void *)alignAddr(NodePtr->BasePtr, Align(Alignment));
 
         if (AlignedPointer != NodePtr->Ptr) {
           changeKeyPtr(AlignedPointer, NodePtr);
@@ -337,7 +333,7 @@ public:
                        << "Allocate on device.";
       // Allocate one on device
       auto TgtPtrOrErr =
-          allocateOrFreeAndAllocateOnDevice(Size, HstPtr, Alignment);
+          allocateOrFreeAndAllocateOnDevice(AllocationSize, HstPtr, Alignment);
       if (!TgtPtrOrErr)
         return TgtPtrOrErr.takeError();
 
@@ -347,19 +343,19 @@ public:
 
       void *BasePtr = TgtPtr;
       if (Alignment > 0) {
-        TgtPtr = alignPointer(TgtPtr, Alignment);
+        TgtPtr = (void *)alignAddr(TgtPtr, Align(Alignment));
       }
 
       // Create a new node and add it into the map table
       {
         std::lock_guard<std::mutex> Guard(MapTableLock);
-        auto Itr =
-            PtrToNodeTable.emplace(TgtPtr, NodeTy(Size, TgtPtr, BasePtr));
+        auto Itr = PtrToNodeTable.emplace(
+            TgtPtr, NodeTy(AllocationSize, TgtPtr, BasePtr));
         NodePtr = &Itr.first->second;
       }
 
       ODBG(OLDT_Alloc) << "Node address " << NodePtr << ", target pointer "
-                       << TgtPtr << ", size " << Size;
+                       << TgtPtr << ", size " << AllocationSize;
     }
 
     assert(NodePtr && "NodePtr should not be nullptr at this point");

--- a/offload/plugins-nextgen/cuda/src/rtl.cpp
+++ b/offload/plugins-nextgen/cuda/src/rtl.cpp
@@ -590,7 +590,7 @@ struct CUDADeviceTy : public GenericDeviceTy {
     CUdeviceptr DevicePtr;
     CUresult Res;
 
-    if (Alignment > 0 && Alignment > Granularity) {
+    if (Alignment > Granularity) {
       return Plugin::error(ErrorCode::UNSUPPORTED,
                            "requested alignment (%lu) larger than maximum "
                            "supported alignment (%lu)",
@@ -614,18 +614,6 @@ struct CUDADeviceTy : public GenericDeviceTy {
 
     if (auto Err = Plugin::check(Res, "error in cuMemAlloc[Host|Managed]: %s"))
       return std::move(Err);
-
-    if (Alignment > 0 && !isAddrAligned(Align(Alignment), MemAlloc)) {
-      if (auto FreeErr = free(MemAlloc, Kind)) {
-        return Plugin::error(ErrorCode::UNKNOWN,
-                             "Failure in deallcation of the incorrectly "
-                             "aligned pointer; requested alignemnt: %lu",
-                             Alignment);
-      }
-
-      return Plugin::error(ErrorCode::UNSUPPORTED,
-                           "unsupported alignment size");
-    }
 
     return MemAlloc;
   }

--- a/offload/plugins-nextgen/cuda/src/rtl.cpp
+++ b/offload/plugins-nextgen/cuda/src/rtl.cpp
@@ -615,6 +615,18 @@ struct CUDADeviceTy : public GenericDeviceTy {
     if (auto Err = Plugin::check(Res, "error in cuMemAlloc[Host|Managed]: %s"))
       return std::move(Err);
 
+    if (Alignment > 0 && !isAddrAligned(Align(Alignment), MemAlloc)) {
+      if (auto FreeErr = free(MemAlloc, Kind)) {
+        return Plugin::error(ErrorCode::UNKNOWN,
+                             "Failure in deallcation of the incorrectly "
+                             "aligned pointer; requested alignemnt: %lu",
+                             Alignment);
+      }
+
+      return Plugin::error(ErrorCode::UNSUPPORTED,
+                           "unsupported alignment size");
+    }
+
     return MemAlloc;
   }
 


### PR DESCRIPTION
Previously, memory alignment was handled internally by the device. The `MemoryManagerTy` either redirected large allocation requests directly to the device or stored pointers to the smaller memory chunks in pools. The information about the alignment expected by the user was just passed by the `MemoryManagerTy` to the device allocators. However, most vendors do not provide an API for specifying the alignment of the memory allocation (except for the Level Zero plugin), allowing only for verification of whether the returned pointer is correctly aligned. In this patch, `MemoryManagerTy` allocates excess memory and performs pointer arithmetic on the pointer returned by the device allocator, so that the final pointer is aligned accordingly regardless of the plugin.

NodeTy has two new fields:
- `BasePtr`: the pointer to the originally allocated memory
- `Ptr`: the pointer returned to the caller, possibly after pointer arithmetic operations on `BasePtr` for ensuring the requested alignment.

Pointer arithmetic is performed when a specific alignment is requested or when the chosen pointer from the memory pool is being reused after an aligned allocation, since `Ptr`s are not reset to `BasePtr`s during deallocation.

The Alignment parameter is preserved in the plugin-side implementations of `allocate()` for validation purposes, since the device allocations might have granularity which is not compatible with the requested alignment.

The presented changes are part of the series of patches introducing memory alignment. The next patch will remove the doubling of the memory alignment management in the `MemoryManagerTy` and the Level Zero plugin, leaving the implementation in `MemoryManagerTy`.