### PR TITLE
[OpenMP] Do not GEP 'inbounds' for multi-dimensional OpenMP device maps

### DIFF
--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -35,6 +35,7 @@
 #include "clang/Basic/TargetInfo.h"
 #include "llvm/ADT/APFixedPoint.h"
 #include "llvm/ADT/ScopeExit.h"
+#include "llvm/Analysis/ValueTracking.h"
 #include "llvm/IR/Argument.h"
 #include "llvm/IR/CFG.h"
 #include "llvm/IR/Constants.h"
@@ -6434,6 +6435,23 @@ static GEPOffsetAndOverflow EmitGEPOffsetInBytes(Value *BasePtr, Value *GEPVal,
   return {TotalOffset, OffsetOverflows};
 }
 
+// OpenMP section maps pass `section - host_offset`. A GEP of an array-of-arrays
+// from that pointer is not inbounds of the allocation.
+static llvm::GEPNoWrapFlags
+inBoundsGEPFlags(const CodeGenFunction &CGF, const llvm::Value *Ptr,
+                 llvm::Type *SrcTy, bool SignedIndices, bool IsSubtraction) {
+  llvm::GEPNoWrapFlags NW;
+  auto *AT = dyn_cast<llvm::ArrayType>(SrcTy);
+  bool SectionGEP = CGF.getLangOpts().OpenMPIsTargetDevice && AT &&
+                    AT->getElementType()->isArrayTy() &&
+                    !isa<llvm::AllocaInst>(llvm::getUnderlyingObject(Ptr));
+  if (!SectionGEP)
+    NW = llvm::GEPNoWrapFlags::inBounds();
+  if (!SignedIndices && !IsSubtraction)
+    NW |= llvm::GEPNoWrapFlags::noUnsignedWrap();
+  return NW;
+}
+
 Value *
 CodeGenFunction::EmitCheckedInBoundsGEP(llvm::Type *ElemTy, Value *Ptr,
                                         ArrayRef<Value *> IdxList,
@@ -6441,9 +6459,8 @@ CodeGenFunction::EmitCheckedInBoundsGEP(llvm::Type *ElemTy, Value *Ptr,
                                         SourceLocation Loc, const Twine &Name) {
   llvm::Type *PtrTy = Ptr->getType();
 
-  llvm::GEPNoWrapFlags NWFlags = llvm::GEPNoWrapFlags::inBounds();
-  if (!SignedIndices && !IsSubtraction)
-    NWFlags |= llvm::GEPNoWrapFlags::noUnsignedWrap();
+  llvm::GEPNoWrapFlags NWFlags =
+      inBoundsGEPFlags(*this, Ptr, ElemTy, SignedIndices, IsSubtraction);
 
   Value *GEPVal = Builder.CreateGEP(ElemTy, Ptr, IdxList, Name, NWFlags);
 
@@ -6554,10 +6571,9 @@ Address CodeGenFunction::EmitCheckedInBoundsGEP(
     bool SignedIndices, bool IsSubtraction, SourceLocation Loc, CharUnits Align,
     const Twine &Name) {
   if (!SanOpts.has(SanitizerKind::PointerOverflow)) {
-    llvm::GEPNoWrapFlags NWFlags = llvm::GEPNoWrapFlags::inBounds();
-    if (!SignedIndices && !IsSubtraction)
-      NWFlags |= llvm::GEPNoWrapFlags::noUnsignedWrap();
-
+    llvm::GEPNoWrapFlags NWFlags =
+        inBoundsGEPFlags(*this, Addr.getBasePointer(), Addr.getElementType(),
+                         SignedIndices, IsSubtraction);
     return Builder.CreateGEP(Addr, IdxList, elementType, Align, Name, NWFlags);
   }
 

--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -6441,9 +6441,8 @@ static llvm::GEPNoWrapFlags
 inBoundsGEPFlags(const CodeGenFunction &CGF, const llvm::Value *Ptr,
                  llvm::Type *SrcTy, bool SignedIndices, bool IsSubtraction) {
   llvm::GEPNoWrapFlags NW;
-  auto *AT = dyn_cast<llvm::ArrayType>(SrcTy);
-  bool SectionGEP = CGF.getLangOpts().OpenMPIsTargetDevice && AT &&
-                    AT->getElementType()->isArrayTy() &&
+  bool SectionGEP = CGF.getLangOpts().OpenMPIsTargetDevice &&
+                    isa<llvm::ArrayType>(SrcTy) &&
                     !isa<llvm::AllocaInst>(llvm::getUnderlyingObject(Ptr));
   if (!SectionGEP)
     NW = llvm::GEPNoWrapFlags::inBounds();

--- a/clang/test/OpenMP/target_map_section_inbounds.cpp
+++ b/clang/test/OpenMP/target_map_section_inbounds.cpp
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -verify -fopenmp -x c++ -triple amdgcn-amd-amdhsa \
+// RUN:   -fopenmp-targets=amdgcn-amd-amdhsa -fopenmp-is-target-device \
+// RUN:   -fopenmp-host-ir-file-path %t-host.bc -emit-llvm %s -o - \
+// RUN:   | FileCheck %s
+
+int Data[8][4];
+
+void section_2d(int P, int I) {
+#pragma omp target map(tofrom : Data[P : 1][0 : 4]) firstprivate(P, I)
+  {
+    Data[P][I] = 1;
+  }
+}
+
+// CHECK-LABEL: define {{.*}}@{{__omp_offloading_.+}}section_2d
+// CHECK-NOT: getelementptr inbounds{{.*}}[8 x [4 x i32]]
+// CHECK: getelementptr{{.*}}[8 x [4 x i32]]
+// CHECK: getelementptr inbounds{{.*}}[4 x i32]


### PR DESCRIPTION
The C standard treats array subscripts as inbounds of the object, but
OpenMP section maps intentionally index from a host-relative base that
is not the mapped allocation. Drop inbounds on those GEPs so later
passes do not assume the slice lives inside the object.
