### PR TITLE
[Remarks] Fix linker warnings from mold

### DIFF
--- a/llvm/tools/remarks-shlib/CMakeLists.txt
+++ b/llvm/tools/remarks-shlib/CMakeLists.txt
@@ -15,11 +15,29 @@ if(LLVM_ENABLE_PIC)
 
   add_llvm_library(Remarks SHARED INSTALL_WITH_TOOLCHAIN ${SOURCES})
 
+  if (NOT BUILD_SHARED_LIBS AND NOT LLVM_LINK_LLVM_DYLIB)
+    # libremarks.cpp only defines LLVMRemarkVersion. Without forcing the
+    # inclusion of all libLLVMRemarks.a members, the linker omits the C API
+    # implementations because nothing references them.
+    if (APPLE)
+      target_link_options(Remarks PRIVATE
+        "LINKER:-force_load,$<TARGET_LINKER_FILE:LLVMRemarks>")
+    elseif(MSVC)
+      target_link_options(Remarks PRIVATE
+        "LINKER:/WHOLEARCHIVE:$<TARGET_LINKER_FILE:LLVMRemarks>")
+    else()
+      target_link_options(Remarks PRIVATE
+        "LINKER:--whole-archive"
+        "LINKER:$<TARGET_LINKER_FILE:LLVMRemarks>"
+        "LINKER:--no-whole-archive")
+    endif()
+  endif()
+
   if (LLVM_INTEGRATED_CRT_ALLOC AND MSVC)
     # Make sure we search LLVMSupport first, before the CRT libs
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -INCLUDE:malloc")
   endif()
-  
+
   install(FILES ${LLVM_MAIN_INCLUDE_DIR}/llvm-c/Remarks.h
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/llvm-c"
     COMPONENT Remarks)


### PR DESCRIPTION
This PR is trying to fix the linker warnings emitted from mold.

```
mold: warning: tools/remarks-shlib/Remarks.exports: cannot assign version `LLVM_24.0` to symbol `LLVMRemarkStringGetData`: symbol not found
```

Fixes #93028.

---

This PR was assisted by AI but I reviewed all code changes.