### PR TITLE
[FlattenCFG] Merge parallel conditions with logical and/or

### DIFF
--- a/llvm/lib/Transforms/Utils/FlattenCFG.cpp
+++ b/llvm/lib/Transforms/Utils/FlattenCFG.cpp
@@ -12,18 +12,19 @@
 
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Analysis/AliasAnalysis.h"
-#include "llvm/Transforms/Utils/Local.h"
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Instruction.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/ProfDataUtils.h"
 #include "llvm/IR/Value.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
+#include "llvm/Transforms/Utils/Local.h"
 #include <cassert>
 
 using namespace llvm;
@@ -283,10 +284,13 @@ bool FlattenCFGOpt::FlattenParallelAndOr(BasicBlock *BB, IRBuilder<> &Builder) {
     Value *NC;
     if (Idx == 0)
       // Case 2, use parallel or.
-      NC = Builder.CreateOr(PC, CC);
+      NC = Builder.CreateLogicalOr(PC, CC);
     else
       // Case 1, use parallel and.
-      NC = Builder.CreateAnd(PC, CC);
+      NC = Builder.CreateLogicalAnd(PC, CC);
+
+    if (SelectInst *SI = dyn_cast<SelectInst>(NC))
+      setExplicitlyUnknownBranchWeightsIfProfiled(*SI, DEBUG_TYPE);
 
     PBI->replaceUsesOfWith(CC, NC);
     PC = NC;

--- a/llvm/test/CodeGen/AMDGPU/scalar-branch-missing-and-exec.ll
+++ b/llvm/test/CodeGen/AMDGPU/scalar-branch-missing-and-exec.ll
@@ -27,22 +27,16 @@ define amdgpu_cs void @main(i32 inreg %arg) {
   %tmp22 = load volatile float, ptr addrspace(1) poison
   %tmp25 = load volatile float, ptr addrspace(1) poison
   %tmp31 = fcmp olt float %tmp16, 0x3FA99999A0000000
-  br i1 %tmp31, label %bb, label %.exit.thread
-
-bb:                                               ; preds = %.entry
   %tmp42 = fcmp olt float %tmp25, 0x3FA99999A0000000
-  br i1 %tmp42, label %bb43, label %.exit.thread
-
-bb43:
+  %tmp43 = and i1 %tmp31, %tmp42
   %tmp46 = fcmp olt <2 x float> %tmp44, <float 0x3FA99999A0000000, float 0x3FA99999A0000000>
   %tmp47 = extractelement <2 x i1> %tmp46, i32 0
   %tmp48 = extractelement <2 x i1> %tmp46, i32 1
   %tmp49 = and i1 %tmp47, %tmp48
-  br i1 %tmp49, label %bb50, label %.exit.thread
-
-bb50:
+  %tmp50 = and i1 %tmp43, %tmp49
   %tmp53 = fcmp olt float %tmp22, 0x3FA99999A0000000
-  br i1 %tmp53, label %.exit3.i, label %.exit.thread
+  %tmp54 = and i1 %tmp50, %tmp53
+  br i1 %tmp54, label %.exit3.i, label %.exit.thread
 
 .exit3.i:
   store volatile i32 0, ptr addrspace(1) poison

--- a/llvm/test/Transforms/Util/flatten-cfg.ll
+++ b/llvm/test/Transforms/Util/flatten-cfg.ll
@@ -448,4 +448,70 @@ if.end2:
   ret i32 0
 }
 
+; %add is poison at %y == INT_MAX and the source only branches on %cmp.y when
+; %cmp.x has not decided the branch, so a bitwise merge would branch on poison.
+define void @test_parallel_or(i32 %x, i32 %y, i32 %z) {
+; CHECK-LABEL: define void @test_parallel_or
+; CHECK-SAME: (i32 [[X:%.*]], i32 [[Y:%.*]], i32 [[Z:%.*]]) {
+; CHECK-NEXT:  entry.x:
+; CHECK-NEXT:    [[CMP_X:%.*]] = icmp sgt i32 [[X]], 0
+; CHECK-NEXT:    [[ADD:%.*]] = add nsw i32 [[Y]], 1
+; CHECK-NEXT:    [[CMP_Y:%.*]] = icmp sgt i32 [[ADD]], 0
+; CHECK-NEXT:    [[TMP0:%.*]] = select i1 [[CMP_X]], i1 true, i1 [[CMP_Y]]
+; CHECK-NEXT:    br i1 [[TMP0]], label [[IF_THEN:%.*]], label [[EXIT:%.*]]
+; CHECK:       if.then:
+; CHECK-NEXT:    store i32 [[Z]], ptr @g, align 4
+; CHECK-NEXT:    br label [[EXIT]]
+; CHECK:       exit:
+; CHECK-NEXT:    ret void
+;
+entry.x:
+  %cmp.x = icmp sgt i32 %x, 0
+  br i1 %cmp.x, label %if.then, label %entry.y
+
+entry.y:
+  %add = add nsw i32 %y, 1
+  %cmp.y = icmp sgt i32 %add, 0
+  br i1 %cmp.y, label %if.then, label %exit
+
+if.then:
+  store i32 %z, ptr @g, align 4
+  br label %exit
+
+exit:
+  ret void
+}
+
+define void @test_parallel_and(i32 %x, i32 %y, i32 %z) {
+; CHECK-LABEL: define void @test_parallel_and
+; CHECK-SAME: (i32 [[X:%.*]], i32 [[Y:%.*]], i32 [[Z:%.*]]) {
+; CHECK-NEXT:  entry.x:
+; CHECK-NEXT:    [[CMP_X:%.*]] = icmp sgt i32 [[X]], 0
+; CHECK-NEXT:    [[ADD:%.*]] = add nsw i32 [[Y]], 1
+; CHECK-NEXT:    [[CMP_Y:%.*]] = icmp sgt i32 [[ADD]], 0
+; CHECK-NEXT:    [[TMP0:%.*]] = select i1 [[CMP_X]], i1 [[CMP_Y]], i1 false
+; CHECK-NEXT:    br i1 [[TMP0]], label [[IF_THEN:%.*]], label [[EXIT:%.*]]
+; CHECK:       if.then:
+; CHECK-NEXT:    store i32 [[Z]], ptr @g, align 4
+; CHECK-NEXT:    br label [[EXIT]]
+; CHECK:       exit:
+; CHECK-NEXT:    ret void
+;
+entry.x:
+  %cmp.x = icmp sgt i32 %x, 0
+  br i1 %cmp.x, label %entry.y, label %exit
+
+entry.y:
+  %add = add nsw i32 %y, 1
+  %cmp.y = icmp sgt i32 %add, 0
+  br i1 %cmp.y, label %if.then, label %exit
+
+if.then:
+  store i32 %z, ptr @g, align 4
+  br label %exit
+
+exit:
+  ret void
+}
+
 attributes #1 = { readnone willreturn nounwind }


### PR DESCRIPTION
`FlattenParallelAndOr` merges a short-circuit branch pair into one branch using a bitwise `or`/`and`. Those propagate poison from either operand, so a condition the source only evaluated behind a guard ends up feeding an unconditional branch. Emit a logical or/and instead.

`MergeIfRegion` is left alone: `GetIfCondition` only matches when the second condition already executes on every path, so a poison operand there is UB before the transform too.

The merged weights compose, but the branch's !prof has the same staleness problem and longer chains need the product carried through, so the select is marked explicitly unknown here and the derivation is a follow-up.

AMDGPU is the only in-tree user. `scalar-branch-missing-and-exec.ll` was relying on flatten-cfg to build its and-chain, and the select chain lowers to `s_and_b64 s[0:1], s[0:1], exec` rather than the `s_xor_b64` it checks for. Nothing is miscompiled, but the test would stop covering what it was written for, so it now hands the backend the merged conditions directly. Its CHECK lines are unchanged and it passes on main.

Fixes https://github.com/llvm/llvm-project/issues/217313
