### PR TITLE
[mlir][vector] Add missing lit CFG file

### DIFF
--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmNeon/lit.local.cfg
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmNeon/lit.local.cfg
@@ -1,0 +1,9 @@
+import sys
+
+# ArmNeon tests must be enabled via build flag.
+if not config.mlir_run_arm_neon_tests:
+    config.unsupported = True
+
+# No JIT on win32.
+if sys.platform == "win32":
+    config.unsupported = True


### PR DESCRIPTION
This file was meant to be added in #216098 - it makes sure that tests
under mlir/test/Integration/Dialect/Vector/CPU/ArmNeon are only run when
`MLIR_RUN_ARM_NEON_TESTS` is set.
