### PR TITLE
[mlir:arm:tests] Add back `REQUIRED` tag removed by #216098.

### DIFF
--- a/mlir/test/Integration/Dialect/Linalg/CPU/ArmNeon/matmul-i8.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/ArmNeon/matmul-i8.mlir
@@ -1,3 +1,5 @@
+// REQUIRES: mlir_arm_neon_tests
+
 // DEFINE: %{compile} = mlir-opt %s \
 // DEFINE:   -transform-interpreter -test-transform-dialect-erase-schedule \
 // DEFINE:   -cse -canonicalize -convert-vector-to-scf \


### PR DESCRIPTION
The recent #216098 changed which features are used to select with ARM-related tests are run. Among other things, it removed the `REQUIRED` tag of one of the LIT files, `mlir/test/Integration/Dialect/Linalg/CPU/ArmNeon/matmul-i8.mlir`. That test, however, requires the `mcr_aarch64_cmd` substitution, which isn't available always. This PR adds back the tag with the `mlir_arm_neon_tests` feature, which *does* provide the necessary substitution and which seems to be the tag typically used for ARM Neon tests.