### PR TITLE
[lldb] Fix null object file deref in ModuleList::AppendImpl

### DIFF
--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -240,9 +240,10 @@ void ModuleList::AppendImpl(const ModuleSP &module_sp, bool use_notifier) {
       // 0th element, and only if that's NOT an executable look at the
       // incoming ObjectFile.  That way in the normal case we only look at the
       // element 0 ObjectFile.
+      lldb_private::ObjectFile *elem_zero_obj = m_modules[0]->GetObjectFile();
       const bool elem_zero_is_executable =
-          m_modules[0]->GetObjectFile()->GetType() ==
-          ObjectFile::Type::eTypeExecutable;
+          elem_zero_obj &&
+          elem_zero_obj->GetType() == ObjectFile::Type::eTypeExecutable;
       lldb_private::ObjectFile *obj = module_sp->GetObjectFile();
       if (!elem_zero_is_executable && obj &&
           obj->GetType() == ObjectFile::Type::eTypeExecutable) {

--- a/lldb/test/API/macosx/corefile-unparseable-binary/Makefile
+++ b/lldb/test/API/macosx/corefile-unparseable-binary/Makefile
@@ -1,0 +1,4 @@
+C_SOURCES = main.c
+MAKE_DSYM := NO
+
+include Makefile.rules

--- a/lldb/test/API/macosx/corefile-unparseable-binary/TestCorefileUnparseableBinary.py
+++ b/lldb/test/API/macosx/corefile-unparseable-binary/TestCorefileUnparseableBinary.py
@@ -1,0 +1,107 @@
+"""Test loading a corefile naming a binary that a symbol locator resolves to a
+file which is not an object file."""
+
+import os
+import re
+import subprocess
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestCorefileUnparseableBinary(TestBase):
+    @no_debug_info_test
+    @requireDarwin
+    @skipIfRemote
+    def test(self):
+        self.build()
+        aout_exe = self.getBuildArtifact("a.out")
+        corefile = self.getBuildArtifact("process.core")
+        dsym_for_uuid = self.getBuildArtifact("dsym-for-uuid.sh")
+        not_an_object_file = self.getBuildArtifact("not-an-object-file")
+        hide_dir = self.getBuildArtifact("hide.noindex")
+        lldbutil.mkdir_p(hide_dir)
+        hide_aout_exe = self.getBuildArtifact("hide.noindex/a.out")
+
+        dwarfdump_uuid_regex = re.compile(r"UUID: ([-0-9a-fA-F]+) \(([^\(]+)\) .*")
+        dwarfdump_cmd_output = subprocess.check_output(
+            ('/usr/bin/dwarfdump --uuid "%s"' % aout_exe), shell=True
+        ).decode("utf-8")
+        aout_uuid = None
+        for line in dwarfdump_cmd_output.splitlines():
+            match = dwarfdump_uuid_regex.search(line)
+            if match:
+                aout_uuid = match.group(1)
+        self.assertNotEqual(aout_uuid, None, "Could not get uuid of built a.out")
+
+        with open(not_an_object_file, "w") as writer:
+            writer.write("this is not an object file\n")
+
+        # Create our dsym-for-uuid shell script which returns a file that
+        # exists but cannot be parsed as an object file.
+        shell_cmds = [
+            "#! /bin/sh",
+            "# the last argument is the uuid",
+            "while [ $# -gt 1 ]",
+            "do",
+            "  shift",
+            "done",
+            'echo "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>"',
+            'echo "<!DOCTYPE plist PUBLIC \\"-//Apple//DTD PLIST 1.0//EN\\" \\"http://www.apple.com/DTDs/PropertyList-1.0.dtd\\">"',
+            'echo "<plist version=\\"1.0\\">"',
+            'echo "<dict><key>$1</key><dict>"',
+            "",
+            'if [ "$1" = "%s" ]' % aout_uuid,
+            "then",
+            '  echo "<key>DBGSymbolRichExecutable</key><string>%s</string>"'
+            % not_an_object_file,
+            "else",
+            '  echo "<key>DBGError</key><string>not found</string>"',
+            "fi",
+            "",
+            'echo "</dict></dict></plist>"',
+            "exit 0",
+        ]
+
+        with open(dsym_for_uuid, "w") as writer:
+            for l in shell_cmds:
+                writer.write(l + "\n")
+
+        os.chmod(dsym_for_uuid, 0o755)
+
+        (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.c")
+        )
+
+        self.runCmd("process save-core --style=stack " + corefile)
+        process.Kill()
+        target.Clear()
+        self.dbg.DeleteTarget(target)
+
+        # Move a.out aside so the corefile's image can only be found by uuid,
+        # and hook in the shell script that resolves that uuid.
+        os.rename(aout_exe, hide_aout_exe)
+        os.environ["LLDB_APPLE_DSYMFORUUID_EXECUTABLE"] = dsym_for_uuid
+        self.addTearDownHook(
+            lambda: os.environ.pop("LLDB_APPLE_DSYMFORUUID_EXECUTABLE", None)
+        )
+
+        target = self.dbg.CreateTarget("")
+        process = target.LoadCore(corefile)
+        self.assertTrue(process.IsValid())
+        if self.TraceOn():
+            self.runCmd("image list")
+
+        # The image that could not be parsed has to be followed by another one,
+        # or appending it to the Target is the last thing that happens.
+        num_modules = target.GetNumModules()
+        self.assertGreaterEqual(num_modules, 2)
+
+        modules = [target.GetModuleAtIndex(i) for i in range(num_modules)]
+        unparsed = [m for m in modules if m.GetNumSections() == 0]
+        parsed = [m for m in modules if m.GetNumSections() > 0]
+
+        self.assertEqual(len(unparsed), 1)
+        self.assertGreaterEqual(len(parsed), 1)

--- a/lldb/test/API/macosx/corefile-unparseable-binary/main.c
+++ b/lldb/test/API/macosx/corefile-unparseable-binary/main.c
@@ -1,0 +1,4 @@
+int main() {
+  int stack_int = 5;
+  return stack_int; // break here
+}

--- a/lldb/unittests/Core/ModuleListTest.cpp
+++ b/lldb/unittests/Core/ModuleListTest.cpp
@@ -234,3 +234,15 @@ TEST_F(SymbolLocatorGate, GetSharedModuleCanSkipSymbolLocators) {
   EXPECT_FALSE(module_sp);
   EXPECT_TRUE(error.Fail());
 }
+
+// A Module whose object file could not be parsed is still appended, and does
+// not prevent later modules from being appended after it.
+TEST(ModuleListTest, AppendModuleWithoutObjectFile) {
+  SubsystemRAII<FileSystem> subsystems;
+
+  ModuleList list;
+  list.Append(std::make_shared<Module>(ModuleSpec()));
+  list.Append(std::make_shared<Module>(ModuleSpec()));
+
+  EXPECT_EQ(list.GetSize(), 2U);
+}


### PR DESCRIPTION
`AppendImpl` reads the object file type of the module already at index 0
without checking that it is non-null:

```cpp
const bool elem_zero_is_executable =
    m_modules[0]->GetObjectFile()->GetType() == ObjectFile::Type::eTypeExecutable;
```

A module with no object file can already sit in the list.  `DynamicLoader::LoadBinaryInTarget` appends whatever a symbol locator finds, without checking that it parses.  Appending another module after such a module makes a member call on that null pointer:

```
lldb/source/Core/ModuleList.cpp:244:42: runtime error: member call on null
pointer of type 'lldb_private::ObjectFile'
```

This PR guards it the same way the next line already guards the incoming module.

The same search can also leave a null object file behind in `ObjectFileMachO::LoadCoreFileImages`, fixed in #214634.  This PR adds an `lldb/test/API` regression test that exercises both guards through one corefile.

## Commits

1. Fix the `AppendImpl` null deref, with a `ModuleListTest` unit test.
2. Add `lldb/test/API/macosx/corefile-unparseable-binary`, which loads a corefile naming an image that `LLDB_APPLE_DSYMFORUUID_EXECUTABLE` resolves to a non-object-file, and covers both guards.

## Testing

Reverting the `AppendImpl` guard and running `ModuleListTest.AppendModuleWithoutObjectFile` under ASan and UBSan reproduces the runtime error quoted above.  Restoring the guard passes it.
