### PR TITLE
[OpenACC] do not report launch args for loops in acc routines

### DIFF
--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCEmitRemarksLoop.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCEmitRemarksLoop.cpp
@@ -36,6 +36,13 @@ using namespace mlir;
 
 namespace {
 
+static bool
+computeRegionInSpecializedAccRoutine(acc::ComputeRegionOp computeRegion) {
+  if (auto func = computeRegion->getParentOfType<FunctionOpInterface>())
+    return acc::isSpecializedAccRoutine(func);
+  return false;
+}
+
 static bool shouldEmitLoopRemarks(acc::ComputeRegionOp computeRegion) {
   StringRef origin = computeRegion.getOrigin();
   if (origin == acc::KernelsOp::getOperationName() ||
@@ -43,9 +50,7 @@ static bool shouldEmitLoopRemarks(acc::ComputeRegionOp computeRegion) {
       origin == acc::SerialOp::getOperationName())
     return true;
 
-  if (auto func = computeRegion->getParentOfType<FunctionOpInterface>())
-    return acc::isSpecializedAccRoutine(func);
-  return false;
+  return computeRegionInSpecializedAccRoutine(computeRegion);
 }
 
 static std::string getACCParLevelName(acc::GPUParallelDimAttr parDim,
@@ -61,7 +66,10 @@ static std::string getACCParLevelName(acc::GPUParallelDimAttr parDim,
   else if (policy.isGang(parDim))
     accName = "gang";
 
-  if (!policy.isSeq(parDim)) {
+  // Don't specify the constant launch args for sequential loops or loops in
+  // specialized acc routines as the launch args are not determined here.
+  if (!policy.isSeq(parDim) &&
+      !computeRegionInSpecializedAccRoutine(computeRegion)) {
     if (std::optional<uint64_t> constant =
             computeRegion.getKnownConstantLaunchArg(parDim))
       accName += "(" + std::to_string(*constant) + ")";

--- a/mlir/test/Dialect/OpenACC/acc-emit-remarks-loop.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-emit-remarks-loop.mlir
@@ -153,3 +153,24 @@ func.func @percent_separator() {
   }
   return
 }
+
+// -----
+
+// CHECK: remark: [Passed] openacc | Category:acc-emit-remarks-loop | Function=acc_routine_gang_vector_loop | Remark="!$acc loop gang, vector ! blockidx.x threadidx.x"
+func.func @acc_routine_gang_vector_loop() attributes {acc.specialized_routine = #acc.specialized_routine<@acc_routine_0, <gang_dim1>, "acc_routine_gang_vector_loop">} {
+  %c1 = arith.constant 1 : index
+  acc.kernel_environment {
+    %0 = acc.par_width %c1 par_dim(#acc.par_dim<block_x>)
+    %1 = acc.par_width %c1 par_dim(#acc.par_dim<thread_x>)
+    acc.compute_region launch(%arg0 = %0, %arg1 = %1) {
+      %c0 = arith.constant 0 : index
+      %c1_1 = arith.constant 1 : index
+      %c128_inner = arith.constant 128 : index
+      scf.parallel (%iv) = (%c0) to (%c128_inner) step (%c1_1) {
+        scf.reduce
+      } {acc.par_dims = #acc<par_dims[block_x, thread_x]>}
+      acc.yield
+    } {origin = "acc.parallel"}
+  }
+  return
+}


### PR DESCRIPTION
ACC routines do not launch kernels, so it should not report the launch args. The par dims should still be reported. E.g.

```
before:

!$acc loop gang(1), vector(1) ! blockidx.x threadidx.x

now:

!$acc loop gang, vector ! blockidx.x threadidx.x
```