### PR TITLE
[MC] Increase asm-macro-max-nesting-depth default to 100

### DIFF
--- a/llvm/lib/MC/MCParser/MCAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/MCAsmParser.cpp
@@ -23,8 +23,9 @@
 using namespace llvm;
 
 namespace llvm {
+// 100 matches the GNU assembler's default macro nesting limit.
 cl::opt<unsigned> AsmMacroMaxNestingDepth(
-    "asm-macro-max-nesting-depth", cl::init(20), cl::Hidden,
+    "asm-macro-max-nesting-depth", cl::init(100), cl::Hidden,
     cl::desc("The maximum nesting depth allowed for assembly macros."));
 }
 

--- a/llvm/test/MC/AsmParser/macro-max-depth.s
+++ b/llvm/test/MC/AsmParser/macro-max-depth.s
@@ -1,20 +1,27 @@
-// RUN: llvm-mc -triple x86_64-unknown-unknown -asm-macro-max-nesting-depth=42 %s | FileCheck %s -check-prefix=CHECK_PASS
-// RUN: not llvm-mc -triple x86_64-unknown-unknown %s 2> %t
-// RUN: FileCheck -check-prefix=CHECK_FAIL < %t %s
+// RUN: llvm-mc -triple x86_64 -defsym DEPTH=30 %s \
+// RUN:   | FileCheck %s --check-prefix=PASS
+// RUN: llvm-mc -triple x86_64 -defsym DEPTH=99 %s \
+// RUN:   | FileCheck %s --check-prefix=PASS
+// RUN: not llvm-mc -triple x86_64 -defsym DEPTH=100 %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=TOODEEP-DEFAULT
 
-.macro rec head, tail:vararg
- .ifnb \tail
- rec \tail
+/// -asm-macro-max-nesting-depth overrides the default.
+// RUN: llvm-mc -triple x86_64 -asm-macro-max-nesting-depth=42 \
+// RUN:   -defsym DEPTH=41 %s | FileCheck %s --check-prefix=PASS
+// RUN: not llvm-mc -triple x86_64 -asm-macro-max-nesting-depth=42 \
+// RUN:   -defsym DEPTH=42 %s 2>&1 | FileCheck %s --check-prefix=TOODEEP-FLAG
+
+.macro rec n
+ .if \n > 0
+ rec "(\n - 1)"
  .else
  .long 42
  .endif
 .endm
 
-.macro amplify macro, args:vararg
- \macro  \args \args \args \args
-.endm
+rec DEPTH
 
-amplify rec 0 0 0 0 0 0 0 0 0 0
-
-// CHECK_PASS: .long 42
-// CHECK_FAIL: error: macros cannot be nested more than {{[0-9]+}} levels deep. Use -asm-macro-max-nesting-depth to increase this limit.
+/// DEPTH=n nests n+1 deep, counting the outermost invocation.
+// PASS: .long 42
+// TOODEEP-DEFAULT: error: macros cannot be nested more than 100 levels deep. Use -asm-macro-max-nesting-depth to increase this limit.
+// TOODEEP-FLAG: error: macros cannot be nested more than 42 levels deep. Use -asm-macro-max-nesting-depth to increase this limit.


### PR DESCRIPTION
GNU as accepts assembly we reject at the current default of 20, e.g. glibc's
`sysdeps/unix/sysv/linux/alpha/rt_sigaction.S`, which nests 31 deep. Raise the
default to 100, matching GNU as.

Assisted-by: Claude Code