### PR TITLE
[MC] Skip AsmToken::Comment at statement start in AsmParser

### DIFF
--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -1735,9 +1735,15 @@ bool AsmParser::parseBinOpRHS(unsigned Precedence, const MCExpr *&Res,
 bool AsmParser::parseStatement(ParseStatementInfo &Info,
                                MCAsmParserSemaCallback *SI) {
   assert(!hasPendingError() && "parseStatement started with pending error");
-  // Eat initial spaces and comments
-  while (Lexer.is(AsmToken::Space))
+  // Eat initial spaces and comments.  eatToEndOfStatement() lexes raw, so a
+  // block comment can still be the current token here; taken as the start of a
+  // statement it rejects input GNU as accepts.  Lex() drops the ones that
+  // follow, but it cannot see the current token, so preserve that one here.
+  while (Lexer.is(AsmToken::Space) || Lexer.is(AsmToken::Comment)) {
+    if (Lexer.is(AsmToken::Comment) && MAI.preserveAsmComments())
+      Out.addExplicitComment(Twine(Lexer.getTok().getString()));
     Lex();
+  }
   if (Lexer.is(AsmToken::EndOfStatement)) {
     // if this is a line comment we can drop it safely
     if (getTok().getString().empty() || getTok().getString().front() == '\r' ||

--- a/llvm/test/MC/AsmParser/block-comment-after-error.s
+++ b/llvm/test/MC/AsmParser/block-comment-after-error.s
@@ -1,0 +1,17 @@
+# RUN: not llvm-mc -triple x86_64 %s -o /dev/null 2>&1 \
+# RUN:   | FileCheck %s
+
+## The error path into eatToEndOfStatement().  Without the block comment skip
+## in parseStatement() the comment-only line below is taken for the start of a
+## statement and draws a second, spurious error.  See
+## block-comment-at-statement-start.s for the error-free cases.
+##
+## The directives sit above the input on purpose: a # line comment between the
+## two lines lexes as an EndOfStatement and resets the lexer, which hides the
+## very thing this is testing.
+
+# CHECK: [[#@LINE+2]]:{{[0-9]+}}: error: unexpected token
+# CHECK-NOT: error: unexpected token at start of statement
+	.byte 1 2 /* trailing */
+/* a line that is nothing but a comment */
+	nop

--- a/llvm/test/MC/AsmParser/block-comment-at-statement-start.s
+++ b/llvm/test/MC/AsmParser/block-comment-at-statement-start.s
@@ -1,0 +1,30 @@
+# RUN: llvm-mc -triple x86_64 %s -o /dev/null 2>&1 \
+# RUN:   | FileCheck %s --allow-empty --implicit-check-not={{.}}
+
+## eatToEndOfStatement() lexes raw, so it can leave a block comment as the
+## current token.  parseStatement() has to skip it, or each shape below is
+## rejected with "unexpected token at start of statement" -- input GNU as
+## accepts.  .extern reaches eatToEndOfStatement() with no error involved, so
+## none of this depends on error recovery.
+
+	.extern a
+/* comment-only line */
+	nop
+
+	.extern b
+/* spanning
+   several
+   lines */
+	nop
+
+	.extern c
+/* two */ /* on one line */
+	nop
+
+	.extern d
+/* followed by an instruction */ nop
+
+## A block comment as the last thing in the file exercises the Lex()-at-EOF
+## path in the skip loop.
+	.extern e
+/* at end of file */

--- a/llvm/test/MC/AsmParser/block-comment-preserve.s
+++ b/llvm/test/MC/AsmParser/block-comment-preserve.s
@@ -1,0 +1,23 @@
+# RUN: llvm-mc -triple x86_64 -preserve-comments %s \
+# RUN:   | FileCheck %s --strict-whitespace
+
+## parseStatement() skips a block comment left as the current token by
+## eatToEndOfStatement().  It has to hand that comment to the streamer on the
+## way past, or -preserve-comments drops it -- unlike a block comment the
+## ordinary Lex() path sees.  See block-comment-at-statement-start.s for why
+## the comment lands there in the first place.
+##
+## The {{^}} anchors keep these directives from matching their own echo, which
+## -preserve-comments emits as well.
+
+	.extern a
+/* preserved */
+	nop
+# CHECK: {{^}}	# preserved
+
+	.extern b
+/* spanning
+   two lines */
+	nop
+# CHECK: {{^}}	# spanning
+# CHECK: {{^}}	#   two lines


### PR DESCRIPTION
`eatToEndOfStatement()` advances the lexer with `Lexer.Lex()` rather than
`AsmParser::Lex()`, and only the latter filters comment tokens. Its trailing
"eat EOL" step can therefore leave a block comment as the current token, which
`parseStatement()` then takes for the start of a statement and rejects:

```asm
	.extern foo
/* comment */
	nop
```
```
error: unexpected token at start of statement
```

GNU as accepts that input. Nor is this confined to error recovery -- `.extern`
above is an ordinary non-error path. On an error path the same thing adds a
second, spurious diagnostic after the real one.

Skip comment tokens alongside spaces in the start-of-statement loop. Hand each
one to the streamer on the way past, so `-preserve-comments` still emits it, as
it does for a comment the `AsmParser::Lex()` path sees.

`MasmParser::parseStatement()` has the same loop, but `X86MCAsmInfoMicrosoftMASM`
sets `AllowAdditionalComments = false`, so `/* */` never lexes as a `Comment`
there and it needs no change.

Testing: three tests, each confirmed to fail without the fix.
`block-comment-at-statement-start.s` covers five accepted shapes (comment-only
line, multi-line, two on one line, comment then instruction, comment at EOF),
each verified individually to be rejected without it.
`block-comment-preserve.s` covers `-preserve-comments`.
`block-comment-after-error.s` covers the spurious second diagnostic; its check
directives sit above the input because a `#` line comment between the two lines
lexes as an `EndOfStatement` and hides the bug.

Assisted-by: Claude Code