### PR TITLE
workflows/release-binaries: Use the windows-11-vs2026-arm images

### DIFF
--- a/.github/workflows/release-binaries-all.yml
+++ b/.github/workflows/release-binaries-all.yml
@@ -108,10 +108,6 @@ jobs:
         # We use ubuntu-22.04 rather than the latest version to make the built
         # binaries more portable (eg functional aginast older glibc).
         runs-on:
-          - ubuntu-22.04
-          - ubuntu-22.04-arm
-          - macos-14
-          - windows-2022
           - windows-11-arm
 
     uses: ./.github/workflows/release-binaries.yml

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -181,7 +181,7 @@ jobs:
             ;;
           windows-11-arm)
             if [ "$GITHUB_EVENT_NAME" = "pull_request" ] || [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
-              build_runs_on="$INPUTS_RUNS_ON"
+              build_runs_on="windows-11-vs2026-arm"
             else
               build_runs_on="windows-11-arm-16core"
             fi


### PR DESCRIPTION
This will become the default windows-11-arm image very soon, so
switch now to catch any possible issues.
    
https://github.blog/changelog/2026-08-20-windows-11-arm64-vs2026-image-generally-available/