### PR TITLE
[analyzer] Use makeNode instead of ExplodedGraph::getNode

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -2379,6 +2379,9 @@ bool ExprEngine::replayWithoutInlining(ExplodedNode *N,
   ExplodedNode *NewNode = G.getNode(NewNodeLoc, NewNodeState, false, &IsNew);
   // We cached out at this point. Caching out is common due to us backtracking
   // from the inlined function, which might spawn several paths.
+  // NOTE: We must return before the `addPredecessor()` call, otherwise the
+  // node vectors `NewNode->Preds` and `BeforeProcessingCall->Succs` would
+  // end up containing multiple copies of `BeforeProcessingCall` / `NewNode`.
   if (!IsNew)
     return true;
 

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
@@ -541,12 +541,8 @@ void ExprEngine::inlineCall(WorkList *WList, const CallEvent &Call,
   // formal arguments.
   State = State->enterStackFrame(Call, CalleeSF);
 
-  bool isNew;
-  if (ExplodedNode *N = G.getNode(Loc, State, false, &isNew)) {
-    N->addPredecessor(Pred, G);
-    if (isNew)
-      WList->enqueue(N);
-  }
+  if (ExplodedNode *N = Engine.makeNode(Loc, State, Pred))
+    WList->enqueue(N);
 
   NumInlinedCalls++;
   Engine.FunctionSummaries->bumpNumTimesInlined(D);

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
@@ -53,14 +53,10 @@ void ExprEngine::processCallEnter(CallEnter CE, ExplodedNode *Pred) {
   // Construct an edge representing the starting location in the callee.
   BlockEdge Loc(Entry, Succ, CE.getCalleeStackFrame());
 
-  ProgramStateRef state = Pred->getState();
-
   // Construct a new node, notify checkers that analysis of the function has
   // begun, and add the resultant nodes to the worklist.
-  bool isNew;
-  ExplodedNode *Node = G.getNode(Loc, state, false, &isNew);
-  Node->addPredecessor(Pred, G);
-  if (isNew) {
+  ExplodedNode *Node = Engine.makeNode(Loc, Pred->getState(), Pred);
+  if (Node) {
     // FIXME: In the `processBeginOfFunction` callback
     // `ExprEngine::getCurrStackFrame()` can be different from the
     // `StackFrame` queried from e.g. the `ExplodedNode`s. I'm not


### PR DESCRIPTION
The method `CoreEngine::makeNode` is the canonical way of creating a new node in the exploded graph and connecting it to its predecessor. Apply it in two locations that previously duplicated its logic.

Note that `ExplodedGraph::getNode` always returns a non-null `ExplodedNode *` (that points to either an old node or the freshly created node); `inlineCall` had no reason to check whether it returns a nullpointer.

This change is very close to being NFC, but could technically change the behavior if the state is `PosteriorlyOverconstrained` (which is vanishingly rare).