### PR TITLE
[clang][NFC] Mark clang 23 as released

### DIFF
--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -12245,7 +12245,7 @@
     <td>[<a href="https://wg21.link/expr.prim.lambda.closure">expr.prim.lambda.closure</a>]</td>
     <td>CD4</td>
     <td>Explicit instantiation/specialization of generic lambda <TT>operator()</TT></td>
-    <td class="unreleased" align="center">Clang 23</td>
+    <td class="full" align="center">Clang 23</td>
   </tr>
   <tr id="1781">
     <td><a href="https://cplusplus.github.io/CWG/issues/1781.html">1781</a></td>
@@ -16684,7 +16684,7 @@
     <td>[<a href="https://wg21.link/temp.res">temp.res</a>]</td>
     <td>CD6</td>
     <td><TT>typename</TT> in <I>conversion-function-id</I>s</td>
-    <td class="unreleased" align="center">Clang 23</td>
+    <td class="full" align="center">Clang 23</td>
   </tr>
   <tr id="2414">
     <td><a href="https://cplusplus.github.io/CWG/issues/2414.html">2414</a></td>
@@ -20446,7 +20446,7 @@
     <td>[<a href="https://wg21.link/cpp.module">cpp.module</a>]</td>
     <td>C++26</td>
     <td>Limiting macro expansion in <I>pp-module</I></td>
-    <td class="unreleased" align="center">Clang 23</td>
+    <td class="full" align="center">Clang 23</td>
   </tr>
   <tr class="open" id="2948">
     <td><a href="https://cplusplus.github.io/CWG/issues/2948.html">2948</a></td>
@@ -21762,7 +21762,7 @@
     <td>[<a href="https://wg21.link/dcl.struct.bind">dcl.struct.bind</a>]</td>
     <td>C++26</td>
     <td>constexpr structured bindings with prvalues from tuples</td>
-    <td class="unreleased" align="center">Clang 23</td>
+    <td class="full" align="center">Clang 23</td>
   </tr>
   <tr id="3136">
     <td><a href="https://cplusplus.github.io/CWG/issues/3136.html">3136</a></td>

--- a/clang/www/cxx_status.html
+++ b/clang/www/cxx_status.html
@@ -137,7 +137,7 @@ C++2c, informally referred to as C++2d.</p>
 <tr>
   <td>Adjust identifier following new Unicode recommendations</td>
   <td><a href="https://wg21.link/P3658R1">P3658R1</a> <a href="#dr">(DR)</a></td>
-  <td class="full" align="center">Clang 24</td>
+  <td class="unreleased align="center">Clang 24</td>
 </tr>
 <tr>
   <td><code>return_value</code> &amp; <code>return_void</code> are not mutually exclusive</td>
@@ -294,7 +294,7 @@ C++23, informally referred to as C++26.</p>
  <tr>
   <td>Module Declarations Shouldn’t be Macros</td>
   <td><a href="https://wg21.link/P3034R1">P3034R1</a> (<a href="#dr">DR</a>)</td>
-  <td class="unreleased" align="center">Clang 23</td>
+  <td class="full" align="center">Clang 23</td>
  </tr>
  <tr>
   <td>Trivial infinite loops are not Undefined Behavior</td>
@@ -443,7 +443,7 @@ C++23, informally referred to as C++26.</p>
  <tr>
    <td>constexpr virtual inheritance</td>
    <td><a href="https://wg21.link/P3533">P3533R2</a></td>
-   <td class="full" align="center">Clang 24</td>
+   <td class="unreleased" align="center">Clang 24</td>
  </tr>
  <tr>
    <td>Preprocessing is never undefined</td>
@@ -1078,7 +1078,7 @@ C++23, informally referred to as C++26.</p>
       </tr>
       <tr>
         <td><a href="https://wg21.link/p1703r1">P1703R1</a></td>
-        <td class="unreleased" align="center">Subsumed by P1857</td>
+        <td class="na" align="center">Subsumed by P1857</td>
       </tr>
       <tr> <!-- from Belfast -->
         <td><a href="https://wg21.link/p1874r1">P1874R1</a></td>
@@ -1094,7 +1094,7 @@ C++23, informally referred to as C++26.</p>
       </tr>
       <tr>
         <td><a href="https://wg21.link/p1857r3">P1857R3</a></td>
-        <td class="unreleased" align="center">Clang 23</td>
+        <td class="full" align="center">Clang 23</td>
       </tr>
       <tr>
         <td><a href="https://wg21.link/p2115r0">P2115R0</a></td>

--- a/clang/www/make_cxx_dr_status
+++ b/clang/www/make_cxx_dr_status
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 import sys, os, re, urllib.request
 
-latest_release = 22
+latest_release = 23
 
 clang_www_dir = os.path.dirname(__file__)
 default_issue_list_path = os.path.join(clang_www_dir, 'cwg_index.html')


### PR DESCRIPTION
This PR also updates the `latest_release` constant to 23, and fixes incorrect status as a drive-by.