### PR TITLE
[Support] Add cgroup-aware thread pool strategies

### DIFF
--- a/llvm/include/llvm/Support/Threading.h
+++ b/llvm/include/llvm/Support/Threading.h
@@ -205,6 +205,67 @@ using once_flag = std::once_flag;
     return hardware_concurrency();
   }
 
+  namespace detail {
+
+  struct CgroupFilePaths {
+    StringRef ProcSelfCgroup = "/proc/self/cgroup";
+    StringRef ProcSelfMountInfo = "/proc/self/mountinfo";
+    StringRef V2CpuMax = "/sys/fs/cgroup/cpu.max";
+    StringRef V1CpuQuota = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us";
+    StringRef V1CpuPeriod = "/sys/fs/cgroup/cpu/cpu.cfs_period_us";
+    StringRef V1CpuAcctQuota = "/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us";
+    StringRef V1CpuAcctPeriod = "/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us";
+  };
+
+  /// Return the tightest finite CPU quota visible in the process's cgroup
+  /// hierarchy, rounded up to a whole thread. This is exposed for testing.
+  LLVM_ABI std::optional<unsigned>
+  get_cgroup_cpu_count(const CgroupFilePaths &Paths = CgroupFilePaths());
+
+  } // namespace detail
+
+  /// Returns a thread strategy limited by the number of hardware threads and,
+  /// on Linux, by the process's cgroup CPU quota.
+  inline ThreadPoolStrategy available_concurrency() {
+    ThreadPoolStrategy S = hardware_concurrency();
+    if (std::optional<unsigned> Count = detail::get_cgroup_cpu_count()) {
+      S.ThreadsRequested = *Count;
+      S.Limit = true;
+    }
+    return S;
+  }
+
+  /// Like available_concurrency() above, but builds a strategy based on the
+  /// rules described for get_threadpool_strategy().
+  inline ThreadPoolStrategy available_concurrency(StringRef Num) {
+    std::optional<ThreadPoolStrategy> S =
+        get_threadpool_strategy(Num, available_concurrency());
+    if (S)
+      return *S;
+    return available_concurrency();
+  }
+
+  /// Returns a thread strategy limited by the number of physical cores and,
+  /// on Linux, by the process's cgroup CPU quota.
+  inline ThreadPoolStrategy heavyweight_available_concurrency() {
+    ThreadPoolStrategy S = heavyweight_hardware_concurrency();
+    if (std::optional<unsigned> Count = detail::get_cgroup_cpu_count()) {
+      S.ThreadsRequested = *Count;
+      S.Limit = true;
+    }
+    return S;
+  }
+
+  /// Like heavyweight_available_concurrency() above, but builds a strategy
+  /// based on the rules described for get_threadpool_strategy().
+  inline ThreadPoolStrategy heavyweight_available_concurrency(StringRef Num) {
+    std::optional<ThreadPoolStrategy> S =
+        get_threadpool_strategy(Num, heavyweight_available_concurrency());
+    if (S)
+      return *S;
+    return heavyweight_available_concurrency();
+  }
+
   /// Returns an optimal thread strategy to execute specified amount of tasks.
   /// This strategy should prevent us from creating too many threads if we
   /// occasionaly have an unexpectedly small amount of tasks.

--- a/llvm/lib/Support/CMakeLists.txt
+++ b/llvm/lib/Support/CMakeLists.txt
@@ -179,6 +179,7 @@ add_llvm_component_library(LLVMSupport
   ConvertUTF.cpp
   ConvertEBCDIC.cpp
   ConvertUTFWrapper.cpp
+  Cgroup.cpp
   CrashRecoveryContext.cpp
   CSKYAttributes.cpp
   CSKYAttributeParser.cpp

--- a/llvm/lib/Support/Cgroup.cpp
+++ b/llvm/lib/Support/Cgroup.cpp
@@ -1,0 +1,249 @@
+//===- Cgroup.cpp - Cgroup support ---------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/Threading.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Path.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+using namespace llvm;
+
+namespace {
+
+#ifdef __linux__
+
+enum class CgroupVersion { V1, V2 };
+
+struct CgroupMembership {
+  CgroupVersion Version;
+  std::string Path;
+};
+
+struct CgroupMount {
+  std::string Root;
+  std::string MountPoint;
+};
+
+static std::unique_ptr<MemoryBuffer> readFile(StringRef Path) {
+  if (Path.empty())
+    return nullptr;
+  // procfs and cgroupfs files commonly report a size of zero and cannot be
+  // read through the mmap-based path used by MemoryBuffer::getFile().
+  auto Buffer = MemoryBuffer::getFileAsStream(Path);
+  if (!Buffer)
+    return nullptr;
+  return std::move(*Buffer);
+}
+
+static bool hasController(StringRef Controllers, StringRef Expected) {
+  SmallVector<StringRef, 4> Values;
+  Controllers.split(Values, ',', /*MaxSplit=*/-1, /*KeepEmpty=*/false);
+  return llvm::is_contained(Values, Expected);
+}
+
+static std::string unescapeMountInfoPath(StringRef Value) {
+  std::string Result;
+  Result.reserve(Value.size());
+  for (size_t I = 0; I < Value.size(); ++I) {
+    if (Value[I] != '\\' || I + 3 >= Value.size()) {
+      Result.push_back(Value[I]);
+      continue;
+    }
+    StringRef Escape = Value.substr(I + 1, 3);
+    unsigned C;
+    if (Escape.getAsInteger(8, C) || C > 255) {
+      Result.push_back(Value[I]);
+      continue;
+    }
+    Result.push_back(static_cast<char>(C));
+    I += 3;
+  }
+  return Result;
+}
+
+static std::optional<CgroupMembership>
+findCgroupMembership(StringRef Contents, CgroupVersion Version) {
+  SmallVector<StringRef, 16> Lines;
+  Contents.split(Lines, '\n', /*MaxSplit=*/-1, /*KeepEmpty=*/false);
+  for (StringRef Line : Lines) {
+    auto [Hierarchy, Rest] = Line.split(':');
+    auto [Controllers, Path] = Rest.split(':');
+    if (Rest.empty() || Path.empty())
+      continue;
+    if (Version == CgroupVersion::V2 && Hierarchy == "0" && Controllers.empty())
+      return CgroupMembership{Version, Path.str()};
+    if (Version == CgroupVersion::V1 && hasController(Controllers, "cpu"))
+      return CgroupMembership{Version, Path.str()};
+  }
+  return std::nullopt;
+}
+
+static SmallVector<CgroupMount, 2> findCgroupMounts(StringRef Contents,
+                                                    CgroupVersion Version) {
+  SmallVector<CgroupMount, 2> Mounts;
+  SmallVector<StringRef, 16> Lines;
+  Contents.split(Lines, '\n', /*MaxSplit=*/-1, /*KeepEmpty=*/false);
+  for (StringRef Line : Lines) {
+    SmallVector<StringRef, 16> Fields;
+    Line.split(Fields, ' ', /*MaxSplit=*/-1, /*KeepEmpty=*/false);
+    auto Separator = llvm::find(Fields, "-");
+    if (Separator == Fields.end())
+      continue;
+    size_t SeparatorIndex = std::distance(Fields.begin(), Separator);
+    if (SeparatorIndex < 5 || SeparatorIndex + 3 >= Fields.size())
+      continue;
+
+    StringRef FileSystemType = Fields[SeparatorIndex + 1];
+    StringRef SuperOptions = Fields[SeparatorIndex + 3];
+    bool Matches =
+        Version == CgroupVersion::V2
+            ? FileSystemType == "cgroup2"
+            : FileSystemType == "cgroup" && hasController(SuperOptions, "cpu");
+    if (!Matches)
+      continue;
+    Mounts.push_back(CgroupMount{unescapeMountInfoPath(Fields[3]),
+                                 unescapeMountInfoPath(Fields[4])});
+  }
+  return Mounts;
+}
+
+static std::optional<StringRef> relativeTo(StringRef Child, StringRef Parent) {
+  while (Parent.size() > 1 && Parent.ends_with('/'))
+    Parent = Parent.drop_back();
+  while (Child.size() > 1 && Child.ends_with('/'))
+    Child = Child.drop_back();
+  if (Parent == "/")
+    return Child.consume_front("/") ? std::optional<StringRef>(Child)
+                                    : std::nullopt;
+  if (Child == Parent)
+    return StringRef();
+  if (!Child.consume_front(Parent) || !Child.consume_front("/"))
+    return std::nullopt;
+  return Child;
+}
+
+static std::optional<unsigned> cpuCountFromQuota(uint64_t Quota,
+                                                 uint64_t Period) {
+  if (Quota == 0 || Period == 0)
+    return std::nullopt;
+  uint64_t Count = Quota / Period + (Quota % Period != 0);
+  return static_cast<unsigned>(
+      std::min<uint64_t>(Count, std::numeric_limits<unsigned>::max()));
+}
+
+static std::optional<unsigned> readCgroupV2Limit(StringRef Path) {
+  auto Buffer = readFile(Path);
+  if (!Buffer)
+    return std::nullopt;
+  SmallVector<StringRef, 3> Fields;
+  Buffer->getBuffer().trim().split(Fields, ' ', /*MaxSplit=*/-1,
+                                   /*KeepEmpty=*/false);
+  if (Fields.size() != 2 || Fields[0] == "max")
+    return std::nullopt;
+  uint64_t Quota, Period;
+  if (Fields[0].getAsInteger(10, Quota) || Fields[1].getAsInteger(10, Period))
+    return std::nullopt;
+  return cpuCountFromQuota(Quota, Period);
+}
+
+static std::optional<unsigned> readCgroupV1Limit(StringRef QuotaPath,
+                                                 StringRef PeriodPath) {
+  auto QuotaBuffer = readFile(QuotaPath);
+  auto PeriodBuffer = readFile(PeriodPath);
+  if (!QuotaBuffer || !PeriodBuffer)
+    return std::nullopt;
+  int64_t Quota;
+  uint64_t Period;
+  if (QuotaBuffer->getBuffer().trim().getAsInteger(10, Quota) || Quota <= 0 ||
+      PeriodBuffer->getBuffer().trim().getAsInteger(10, Period))
+    return std::nullopt;
+  return cpuCountFromQuota(static_cast<uint64_t>(Quota), Period);
+}
+
+static std::optional<unsigned>
+readHierarchyLimit(const CgroupMembership &Membership,
+                   const CgroupMount &Mount) {
+  std::optional<StringRef> Relative = relativeTo(Membership.Path, Mount.Root);
+  if (!Relative)
+    return std::nullopt;
+
+  SmallString<256> MountPoint(Mount.MountPoint);
+  sys::path::remove_dots(MountPoint, /*remove_dot_dot=*/true);
+  SmallString<256> Current(MountPoint);
+  if (!Relative->empty())
+    sys::path::append(Current, *Relative);
+  sys::path::remove_dots(Current, /*remove_dot_dot=*/true);
+
+  std::optional<unsigned> Result;
+  for (;;) {
+    std::optional<unsigned> Limit;
+    if (Membership.Version == CgroupVersion::V2) {
+      SmallString<256> CpuMax(Current);
+      sys::path::append(CpuMax, "cpu.max");
+      Limit = readCgroupV2Limit(CpuMax);
+    } else {
+      SmallString<256> Quota(Current), Period(Current);
+      sys::path::append(Quota, "cpu.cfs_quota_us");
+      sys::path::append(Period, "cpu.cfs_period_us");
+      Limit = readCgroupV1Limit(Quota, Period);
+    }
+    if (Limit)
+      Result = Result ? std::min(*Result, *Limit) : Limit;
+
+    if (Current == MountPoint)
+      break;
+    sys::path::remove_filename(Current);
+    while (Current.size() > 1 && sys::path::is_separator(Current.back()))
+      Current.pop_back();
+    if (Current.empty() || !relativeTo(Current, MountPoint))
+      break;
+  }
+  return Result;
+}
+
+#endif
+
+} // namespace
+
+std::optional<unsigned>
+llvm::detail::get_cgroup_cpu_count(const CgroupFilePaths &Paths) {
+#ifdef __linux__
+  auto Cgroup = readFile(Paths.ProcSelfCgroup);
+  auto MountInfo = readFile(Paths.ProcSelfMountInfo);
+  if (Cgroup && MountInfo) {
+    for (CgroupVersion Version : {CgroupVersion::V2, CgroupVersion::V1}) {
+      auto Membership = findCgroupMembership(Cgroup->getBuffer(), Version);
+      if (!Membership)
+        continue;
+      for (const CgroupMount &Mount :
+           findCgroupMounts(MountInfo->getBuffer(), Version))
+        if (auto Limit = readHierarchyLimit(*Membership, Mount))
+          return Limit;
+    }
+  }
+
+  if (auto Limit = readCgroupV2Limit(Paths.V2CpuMax))
+    return Limit;
+  if (auto Limit = readCgroupV1Limit(Paths.V1CpuQuota, Paths.V1CpuPeriod))
+    return Limit;
+  return readCgroupV1Limit(Paths.V1CpuAcctQuota, Paths.V1CpuAcctPeriod);
+#else
+  return std::nullopt;
+#endif
+}

--- a/llvm/unittests/Support/Threading.cpp
+++ b/llvm/unittests/Support/Threading.cpp
@@ -7,10 +7,15 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Support/Threading.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/Config/llvm-config.h" // for LLVM_ENABLE_THREADS
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/thread.h"
 #include "llvm/TargetParser/Host.h"
 #include "llvm/TargetParser/Triple.h"
+#include "llvm/Testing/Support/SupportHelpers.h"
 #include "gtest/gtest.h"
 
 #include <atomic>
@@ -57,6 +62,138 @@ TEST(Threading, NumPhysicalCoresUnsupported) {
   int Num = get_physical_cores();
   ASSERT_EQ(Num, -1);
 }
+
+#ifdef __linux__
+
+class CgroupCpuCountTest : public testing::Test {
+protected:
+  CgroupCpuCountTest()
+      : ProcSelfCgroup(Root.path("proc-self-cgroup")),
+        ProcSelfMountInfo(Root.path("proc-self-mountinfo")),
+        CgroupMount(Root.path("cgroup")) {
+    EXPECT_FALSE(sys::fs::create_directories(CgroupMount));
+  }
+
+  void write(StringRef Path, StringRef Contents) {
+    std::error_code EC;
+    raw_fd_ostream OS(Path, EC);
+    ASSERT_FALSE(EC) << EC.message();
+    OS << Contents;
+  }
+
+  void configureV2(StringRef Membership, StringRef MountRoot = "/") {
+    write(ProcSelfCgroup, (Twine("0::") + Membership + "\n").str());
+    write(ProcSelfMountInfo,
+          (Twine("29 23 0:26 ") + MountRoot + " " + CgroupMount +
+           " rw,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw\n")
+              .str());
+  }
+
+  void configureV1(StringRef Membership) {
+    write(ProcSelfCgroup, (Twine("2:cpu,cpuacct:") + Membership + "\n").str());
+    write(ProcSelfMountInfo,
+          (Twine("30 23 0:27 / ") + CgroupMount +
+           " rw,nosuid,nodev,noexec,relatime - cgroup cgroup "
+           "rw,cpu,cpuacct\n")
+              .str());
+  }
+
+  SmallString<128> path(StringRef Relative) {
+    SmallString<128> Result(CgroupMount);
+    sys::path::append(Result, Relative);
+    return Result;
+  }
+
+  detail::CgroupFilePaths paths() const {
+    detail::CgroupFilePaths Paths;
+    Paths.ProcSelfCgroup = ProcSelfCgroup;
+    Paths.ProcSelfMountInfo = ProcSelfMountInfo;
+    Paths.V2CpuMax = "";
+    Paths.V1CpuQuota = "";
+    Paths.V1CpuPeriod = "";
+    Paths.V1CpuAcctQuota = "";
+    Paths.V1CpuAcctPeriod = "";
+    return Paths;
+  }
+
+  unittest::TempDir Root{"llvm-cgroup-test", /*Unique=*/true};
+  SmallString<128> ProcSelfCgroup;
+  SmallString<128> ProcSelfMountInfo;
+  SmallString<128> CgroupMount;
+};
+
+TEST_F(CgroupCpuCountTest, V2LeafQuota) {
+  configureV2("/parent/child");
+  ASSERT_FALSE(sys::fs::create_directories(path("parent/child")));
+  write(path("parent/child/cpu.max"), "800000 100000\n");
+
+  std::optional<unsigned> Count = detail::get_cgroup_cpu_count(paths());
+  ASSERT_TRUE(Count);
+  EXPECT_EQ(*Count, 8u);
+}
+
+TEST_F(CgroupCpuCountTest, V2TightestAncestorQuota) {
+  configureV2("/parent/child");
+  ASSERT_FALSE(sys::fs::create_directories(path("parent/child")));
+  write(path("parent/child/cpu.max"), "max 100000\n");
+  write(path("parent/cpu.max"), "750000 100000\n");
+  write(path("cpu.max"), "1200000 100000\n");
+
+  std::optional<unsigned> Count = detail::get_cgroup_cpu_count(paths());
+  ASSERT_TRUE(Count);
+  EXPECT_EQ(*Count, 8u);
+}
+
+TEST_F(CgroupCpuCountTest, V2MountRootMapsMembership) {
+  configureV2("/tenant/action", "/tenant");
+  ASSERT_FALSE(sys::fs::create_directories(path("action")));
+  write(path("action/cpu.max"), "max 100000\n");
+  write(path("cpu.max"), "600000 100000\n");
+
+  std::optional<unsigned> Count = detail::get_cgroup_cpu_count(paths());
+  ASSERT_TRUE(Count);
+  EXPECT_EQ(*Count, 6u);
+}
+
+TEST_F(CgroupCpuCountTest, V2SkipsUnrelatedMount) {
+  configureV2("/tenant/action", "/tenant");
+  SmallString<128> UnrelatedMount(Root.path("unrelated-cgroup"));
+  ASSERT_FALSE(sys::fs::create_directories(UnrelatedMount));
+  write(ProcSelfMountInfo,
+        (Twine("28 23 0:25 /other ") + UnrelatedMount +
+         " rw,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw\n" +
+         "29 23 0:26 /tenant " + CgroupMount +
+         " rw,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw\n")
+            .str());
+  ASSERT_FALSE(sys::fs::create_directories(path("action")));
+  write(path("action/cpu.max"), "400000 100000\n");
+
+  std::optional<unsigned> Count = detail::get_cgroup_cpu_count(paths());
+  ASSERT_TRUE(Count);
+  EXPECT_EQ(*Count, 4u);
+}
+
+TEST_F(CgroupCpuCountTest, V1ParentQuota) {
+  configureV1("/parent/child");
+  ASSERT_FALSE(sys::fs::create_directories(path("parent/child")));
+  write(path("parent/child/cpu.cfs_quota_us"), "-1\n");
+  write(path("parent/child/cpu.cfs_period_us"), "100000\n");
+  write(path("parent/cpu.cfs_quota_us"), "250000\n");
+  write(path("parent/cpu.cfs_period_us"), "100000\n");
+
+  std::optional<unsigned> Count = detail::get_cgroup_cpu_count(paths());
+  ASSERT_TRUE(Count);
+  EXPECT_EQ(*Count, 3u);
+}
+
+TEST_F(CgroupCpuCountTest, UnlimitedHierarchy) {
+  configureV2("/");
+  write(path("cpu.max"), "max 100000\n");
+
+  EXPECT_FALSE(detail::get_cgroup_cpu_count(paths()));
+}
+
+#endif
 
 #if LLVM_ENABLE_THREADS
 

--- a/llvm/utils/gn/secondary/llvm/lib/Support/BUILD.gn
+++ b/llvm/utils/gn/secondary/llvm/lib/Support/BUILD.gn
@@ -72,6 +72,7 @@ static_library("Support") {
     "ConvertEBCDIC.cpp",
     "ConvertUTF.cpp",
     "ConvertUTFWrapper.cpp",
+    "Cgroup.cpp",
     "CrashRecoveryContext.cpp",
     "DAGDeltaAlgorithm.cpp",
     "DJB.cpp",


### PR DESCRIPTION
## Motivation

This came out of a discussion with @jtbraun at Meta where we noticed the default multi-threaded support for `lld` was defaulted to 1 thread per core but our remote-execution machines leverage cgroups, so this was causing a lot of thrashing.

The quick solution was to hard-cap `-Wl,--threads` but a "proper fix" seemed to be a new thread strategy that respects cgroups. 

Some numbers that show the motivation:
  - On a 176-core host, link time remained roughly 19–22 seconds from 8 through 64 threads (best observed: 18.6 seconds at 32 threads), while 4 threads took 44 seconds.
  - On a 96-core host, the uncapped default took 40.0 seconds for a warm link, compared with 33.2 seconds at 8–16 threads. Over 60% of profiler samples were in native_queued_spin_lock_slowpath, primarily from Btrfs extent-state locking, and the run incurred 109,000 involuntary context switches.

These results suggest that host CPU count is a poor default inside a resource-constrained environment: excess threads can add substantial contention without improving throughput.

## Change

Linux cgroup CPU quotas can expose less sustained CPU capacity than the host CPU count or process affinity mask. Add available_concurrency strategies that constrain the existing hardware-based strategies by the tightest visible cgroup v1 or v2 CPU quota.

Keep hardware_concurrency behavior unchanged and make the new behavior opt-in. Explicit thread counts parsed by get_threadpool_strategy continue to override the default strategy.

Assisted-by: OpenAI Codex

## Additional Context

@MatzeB asked what is the difference with `sched_getaffinity` thinking it was already restrictions?

sched_getaffinity handles affinity and cgroup cpuset restrictions, but it does not reflect CPU bandwidth limits from cpu.max (cgroup v2) or cpu.cfs_quota_us (cgroup v1). 

A quota can limit a process to, for example, eight CPUs’ worth of execution while its affinity mask still contains all 96 host CPUs. 

This change preserves the existing affinity-aware calculation and additionally caps it by the effective CPU quota, including tighter ancestor quotas. If the environment only uses cpusets instead of CPU quotas, the existing implementation would already be sufficient.