### PR TITLE
[lld] Respect cgroup CPU quotas when sizing thread pools

### DIFF
--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -1663,6 +1663,7 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
 
   // /threads: takes a positive integer and provides the default value for
   // /opt:lldltojobs=.
+  parallel::strategy = available_concurrency();
   if (auto *arg = args.getLastArg(OPT_threads)) {
     StringRef v(arg->getValue());
     unsigned threads = 0;

--- a/lld/COFF/LTO.cpp
+++ b/lld/COFF/LTO.cpp
@@ -129,14 +129,14 @@ BitcodeCompiler::BitcodeCompiler(COFFLinkerContext &c) : ctx(c) {
   if (ctx.config.thinLTOIndexOnly) {
     auto OnIndexWrite = [&](StringRef S) { thinIndices.erase(S); };
     backend = lto::createWriteIndexesThinBackend(
-        llvm::hardware_concurrency(ctx.config.thinLTOJobs),
+        available_concurrency(ctx.config.thinLTOJobs),
         std::string(ctx.config.thinLTOPrefixReplaceOld),
         std::string(ctx.config.thinLTOPrefixReplaceNew),
         std::string(ctx.config.thinLTOPrefixReplaceNativeObject),
         ctx.config.thinLTOEmitImportsFiles, indexFile.get(), OnIndexWrite);
   } else {
     backend = lto::createInProcessThinBackend(
-        llvm::heavyweight_hardware_concurrency(ctx.config.thinLTOJobs));
+        heavyweight_available_concurrency(ctx.config.thinLTOJobs));
   }
 
   if (ctx.config.dtltoDistributor.empty())

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -1880,6 +1880,7 @@ static void readConfigs(Ctx &ctx, opt::InputArgList &args) {
   // --thinlto-jobs=. If unspecified, cap the number of threads since
   // overhead outweighs optimization for used parallel algorithms for the
   // non-LTO parts.
+  parallel::strategy = available_concurrency();
   if (auto *arg = args.getLastArg(OPT_threads)) {
     StringRef v(arg->getValue());
     unsigned threads = 0;

--- a/lld/ELF/LTO.cpp
+++ b/lld/ELF/LTO.cpp
@@ -186,16 +186,15 @@ BitcodeCompiler::BitcodeCompiler(Ctx &ctx) : ctx(ctx) {
   auto onIndexWrite = [&](StringRef s) { thinIndices.erase(s); };
   if (ctx.arg.thinLTOIndexOnly) {
     backend = lto::createWriteIndexesThinBackend(
-        llvm::hardware_concurrency(ctx.arg.thinLTOJobs),
+        available_concurrency(ctx.arg.thinLTOJobs),
         std::string(ctx.arg.thinLTOPrefixReplaceOld),
         std::string(ctx.arg.thinLTOPrefixReplaceNew),
         std::string(ctx.arg.thinLTOPrefixReplaceNativeObject),
         ctx.arg.thinLTOEmitImportsFiles, indexFile.get(), onIndexWrite);
   } else {
     backend = lto::createInProcessThinBackend(
-        llvm::heavyweight_hardware_concurrency(ctx.arg.thinLTOJobs),
-        onIndexWrite, ctx.arg.thinLTOEmitIndexFiles,
-        ctx.arg.thinLTOEmitImportsFiles);
+        heavyweight_available_concurrency(ctx.arg.thinLTOJobs), onIndexWrite,
+        ctx.arg.thinLTOEmitIndexFiles, ctx.arg.thinLTOEmitImportsFiles);
   }
 
   constexpr llvm::lto::LTO::LTOKind ltoModes[3] = {

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -1925,6 +1925,7 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
          ": option unavailable because lld was not built with thread support");
 #endif
   }
+  parallel::strategy = available_concurrency();
   if (auto *arg = args.getLastArg(OPT_threads_eq)) {
     StringRef v(arg->getValue());
     unsigned threads = 0;

--- a/lld/MachO/LTO.cpp
+++ b/lld/MachO/LTO.cpp
@@ -109,16 +109,15 @@ BitcodeCompiler::BitcodeCompiler() {
   auto onIndexWrite = [&](StringRef S) { thinIndices.erase(S); };
   if (config->thinLTOIndexOnly) {
     backend = lto::createWriteIndexesThinBackend(
-        llvm::hardware_concurrency(config->thinLTOJobs),
+        available_concurrency(config->thinLTOJobs),
         std::string(config->thinLTOPrefixReplaceOld),
         std::string(config->thinLTOPrefixReplaceNew),
         std::string(config->thinLTOPrefixReplaceNativeObject),
         config->thinLTOEmitImportsFiles, indexFile.get(), onIndexWrite);
   } else {
     backend = lto::createInProcessThinBackend(
-        llvm::heavyweight_hardware_concurrency(config->thinLTOJobs),
-        onIndexWrite, config->thinLTOEmitIndexFiles,
-        config->thinLTOEmitImportsFiles);
+        heavyweight_available_concurrency(config->thinLTOJobs), onIndexWrite,
+        config->thinLTOEmitIndexFiles, config->thinLTOEmitImportsFiles);
   }
 
   ltoObj = std::make_unique<lto::LTO>(createConfig(), backend);

--- a/lld/wasm/Driver.cpp
+++ b/lld/wasm/Driver.cpp
@@ -669,6 +669,7 @@ static void readConfigs(opt::InputArgList &args) {
 
   // --threads= takes a positive integer and provides the default value for
   // --thinlto-jobs=.
+  parallel::strategy = available_concurrency();
   if (auto *arg = args.getLastArg(OPT_threads)) {
     StringRef v(arg->getValue());
     unsigned threads = 0;

--- a/lld/wasm/LTO.cpp
+++ b/lld/wasm/LTO.cpp
@@ -103,16 +103,15 @@ BitcodeCompiler::BitcodeCompiler() {
   auto onIndexWrite = [&](StringRef s) { thinIndices.erase(s); };
   if (ctx.arg.thinLTOIndexOnly) {
     backend = lto::createWriteIndexesThinBackend(
-        llvm::hardware_concurrency(ctx.arg.thinLTOJobs),
+        available_concurrency(ctx.arg.thinLTOJobs),
         std::string(ctx.arg.thinLTOPrefixReplaceOld),
         std::string(ctx.arg.thinLTOPrefixReplaceNew),
         std::string(ctx.arg.thinLTOPrefixReplaceNativeObject),
         ctx.arg.thinLTOEmitImportsFiles, indexFile.get(), onIndexWrite);
   } else {
     backend = lto::createInProcessThinBackend(
-        llvm::heavyweight_hardware_concurrency(ctx.arg.thinLTOJobs),
-        onIndexWrite, ctx.arg.thinLTOEmitIndexFiles,
-        ctx.arg.thinLTOEmitImportsFiles);
+        heavyweight_available_concurrency(ctx.arg.thinLTOJobs), onIndexWrite,
+        ctx.arg.thinLTOEmitIndexFiles, ctx.arg.thinLTOEmitImportsFiles);
   }
   ltoObj = std::make_unique<lto::LTO>(createConfig(), backend,
                                       ctx.arg.ltoPartitions);


### PR DESCRIPTION
Use the cgroup-aware LLVM Support strategies for lld's default parallel and
ThinLTO thread pools. This prevents links from sizing themselves from all host
CPUs when running with a smaller cgroup CPU quota.

Explicit --threads and --thinlto-jobs values continue to override the default,
and ELF retains its existing maximum of 16 threads for non-LTO work.

Assisted-by: OpenAI Codex
