### PR TITLE
[Clang] Rename OffloadArch::TargetArch::SPIRV to AMDGCNSPIRV to avoid confusion

### DIFF
--- a/clang/include/clang/Basic/OffloadArch.h
+++ b/clang/include/clang/Basic/OffloadArch.h
@@ -69,7 +69,9 @@ public:
   }
   static constexpr OffloadArch getUnused() { return {TargetArch::Unused, 0}; }
   static constexpr OffloadArch getUnknown() { return {TargetArch::Unknown, 0}; }
-  static constexpr OffloadArch getAMDGCNSPIRV() { return {TargetArch::AMDGCNSPIRV, 0}; }
+  static constexpr OffloadArch getAMDGCNSPIRV() {
+    return {TargetArch::AMDGCNSPIRV, 0};
+  }
   static constexpr OffloadArch getGeneric() { return {TargetArch::Generic, 0}; }
 
   /// Default architectures used when the user does not specify one.

--- a/clang/include/clang/Basic/OffloadArch.h
+++ b/clang/include/clang/Basic/OffloadArch.h
@@ -32,14 +32,14 @@ namespace clang {
 class OffloadArch {
 public:
   enum class TargetArch : uint8_t {
-    Unused,   // Default-constructed; no architecture bound.
-    Unknown,  // A name that matched no known architecture.
-    NVPTX,    // Kind is an llvm::NVPTX::GPUKind.
-    AMDGPU,   // Kind is an llvm::AMDGPU::GPUKind.
-    SPIRV,    // The 'amdgcnspirv' pseudo target.
-    IntelCPU, // Kind is an IntelArch.
-    IntelGPU, // Kind is an IntelArch.
-    Generic,  // The 'generic' processor model.
+    Unused,      // Default-constructed; no architecture bound.
+    Unknown,     // A name that matched no known architecture.
+    NVPTX,       // Kind is an llvm::NVPTX::GPUKind.
+    AMDGPU,      // Kind is an llvm::AMDGPU::GPUKind.
+    AMDGCNSPIRV, // The 'amdgcnspirv' pseudo target.
+    IntelCPU,    // Kind is an IntelArch.
+    IntelGPU,    // Kind is an IntelArch.
+    Generic,     // The 'generic' processor model.
   };
 
   // Intel architectures, which have no TargetParser list yet.
@@ -69,7 +69,7 @@ public:
   }
   static constexpr OffloadArch getUnused() { return {TargetArch::Unused, 0}; }
   static constexpr OffloadArch getUnknown() { return {TargetArch::Unknown, 0}; }
-  static constexpr OffloadArch getSPIRV() { return {TargetArch::SPIRV, 0}; }
+  static constexpr OffloadArch getAMDGCNSPIRV() { return {TargetArch::AMDGCNSPIRV, 0}; }
   static constexpr OffloadArch getGeneric() { return {TargetArch::Generic, 0}; }
 
   /// Default architectures used when the user does not specify one.
@@ -80,7 +80,7 @@ public:
 
   bool isNVPTX() const { return V == TargetArch::NVPTX; }
   bool isAMDGPU() const { return V == TargetArch::AMDGPU; }
-  bool isSPIRV() const { return V == TargetArch::SPIRV; }
+  bool isAMDGCNSPIRV() const { return V == TargetArch::AMDGCNSPIRV; }
   bool isIntelCPU() const { return V == TargetArch::IntelCPU; }
   bool isIntelGPU() const { return V == TargetArch::IntelGPU; }
   bool isIntel() const { return isIntelCPU() || isIntelGPU(); }

--- a/clang/lib/Basic/Cuda.cpp
+++ b/clang/lib/Basic/Cuda.cpp
@@ -85,7 +85,7 @@ CudaVersion MinVersionForOffloadArch(OffloadArch A) {
     return CudaVersion::UNKNOWN;
 
   // AMD GPUs do not depend on CUDA versions.
-  if (A.isAMDGPU() || A.isSPIRV())
+  if (A.isAMDGPU() || A.isAMDGCNSPIRV())
     return CudaVersion::CUDA_70;
 
   switch (A.nvptxKind()) {
@@ -100,7 +100,7 @@ CudaVersion MinVersionForOffloadArch(OffloadArch A) {
 
 CudaVersion MaxVersionForOffloadArch(OffloadArch A) {
   // AMD GPUs do not depend on CUDA versions.
-  if (A.isAMDGPU() || A.isSPIRV())
+  if (A.isAMDGPU() || A.isAMDGCNSPIRV())
     return CudaVersion::NEW;
 
   if (!A.isNVPTX())

--- a/clang/lib/Basic/OffloadArch.cpp
+++ b/clang/lib/Basic/OffloadArch.cpp
@@ -33,7 +33,7 @@ const char *OffloadArchToString(OffloadArch A) {
     return llvm::NVPTX::getArchName(A.nvptxKind()).data();
   case OffloadArch::TargetArch::AMDGPU:
     return llvm::AMDGPU::getArchNameAMDGCN(A.amdgpuKind()).data();
-  case OffloadArch::TargetArch::SPIRV:
+  case OffloadArch::TargetArch::AMDGCNSPIRV:
     return "amdgcnspirv";
   case OffloadArch::TargetArch::IntelCPU:
     return "graniterapids";
@@ -50,7 +50,7 @@ const char *OffloadArchToVirtualArchString(OffloadArch A) {
   case OffloadArch::TargetArch::NVPTX:
     return llvm::NVPTX::getVirtualArch(A.nvptxKind()).data();
   case OffloadArch::TargetArch::AMDGPU:
-  case OffloadArch::TargetArch::SPIRV:
+  case OffloadArch::TargetArch::AMDGCNSPIRV:
     return "compute_amdgcn";
   case OffloadArch::TargetArch::Unknown:
     return "unknown";
@@ -70,7 +70,7 @@ OffloadArch StringToOffloadArch(llvm::StringRef S) {
 
   // Non-GPU-table pseudo/sentinel architectures.
   if (S == "amdgcnspirv")
-    return OffloadArch::getSPIRV();
+    return OffloadArch::getAMDGCNSPIRV();
   if (S == "generic")
     return OffloadArch::getGeneric();
   if (S == "graniterapids")
@@ -110,7 +110,7 @@ llvm::Triple::SubArchType getOffloadArchSubArch(OffloadArch ID) {
 
 llvm::Triple OffloadArchToTriple(const llvm::Triple &DefaultToolchainTriple,
                                  OffloadArch ID) {
-  if (ID.isSPIRV())
+  if (ID.isAMDGCNSPIRV())
     return llvm::Triple(llvm::Triple::spirv64, llvm::Triple::NoSubArch,
                         llvm::Triple::AMD, llvm::Triple::AMDHSA);
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -999,7 +999,7 @@ static TripleSet inferOffloadToolchains(Compilation &C,
         C.getArgs().hasFlag(options::OPT_foffload_via_llvm,
                             options::OPT_fno_offload_via_llvm, false);
     if (!UsesLLVMOffloading) {
-      if (Kind == Action::OFK_HIP && !ID.isAMDGPU() && !ID.isSPIRV()) {
+      if (Kind == Action::OFK_HIP && !ID.isAMDGPU() && !ID.isAMDGCNSPIRV()) {
         C.getDriver().Diag(clang::diag::err_drv_offload_bad_gpu_arch)
             << "HIP" << Arch;
         return {};
@@ -4918,7 +4918,7 @@ static StringRef getCanonicalArchString(Compilation &C,
         << "CUDA" << ArchStr;
     return StringRef();
   } else if (Triple.isAMDGPU()) {
-    if (Arch.isUnknown() || (!Arch.isAMDGPU() && !Arch.isSPIRV())) {
+    if (Arch.isUnknown() || (!Arch.isAMDGPU() && !Arch.isAMDGCNSPIRV())) {
       C.getDriver().Diag(clang::diag::err_drv_offload_bad_gpu_arch)
           << "HIP" << ArchStr;
       return StringRef();
@@ -4938,7 +4938,7 @@ static StringRef getCanonicalArchString(Compilation &C,
   if (Arch.isNVPTX())
     return Args.MakeArgStringRef(OffloadArchToString(Arch));
 
-  if (Arch.isAMDGPU() || Arch.isSPIRV()) {
+  if (Arch.isAMDGPU() || Arch.isAMDGCNSPIRV()) {
     llvm::StringMap<bool> Features;
     std::optional<StringRef> Arch = parseTargetID(Triple, ArchStr, &Features);
     if (!Arch) {

--- a/clang/unittests/Basic/OffloadArchTest.cpp
+++ b/clang/unittests/Basic/OffloadArchTest.cpp
@@ -25,13 +25,13 @@ TEST(OffloadArchTest, TargetArchClassification) {
   EXPECT_TRUE(parse("gfx12-generic").isAMDGPU());
   EXPECT_FALSE(parse("gfx600").isNVPTX());
 
-  OffloadArch SPIRV = parse("amdgcnspirv");
-  EXPECT_FALSE(SPIRV.isAMDGPU());
-  EXPECT_TRUE(SPIRV.isSPIRV());
+  OffloadArch AMDGCNSPIRV = parse("amdgcnspirv");
+  EXPECT_FALSE(AMDGCNSPIRV.isAMDGPU());
+  EXPECT_TRUE(AMDGCNSPIRV.isAMDGCNSPIRV());
 
   OffloadArch IntelCPU = parse("graniterapids");
   EXPECT_FALSE(IntelCPU.isAMDGPU());
-  EXPECT_FALSE(IntelCPU.isSPIRV());
+  EXPECT_FALSE(IntelCPU.isAMDGCNSPIRV());
   EXPECT_TRUE(IntelCPU.isIntel());
   EXPECT_TRUE(IntelCPU.isIntelCPU());
   EXPECT_FALSE(IntelCPU.isIntelGPU());
@@ -44,7 +44,7 @@ TEST(OffloadArchTest, TargetArchClassification) {
   OffloadArch Generic = parse("generic");
   EXPECT_FALSE(Generic.isNVPTX());
   EXPECT_FALSE(Generic.isAMDGPU());
-  EXPECT_FALSE(Generic.isSPIRV());
+  EXPECT_FALSE(Generic.isAMDGCNSPIRV());
   EXPECT_FALSE(Generic.isIntel());
 }
 
@@ -89,6 +89,6 @@ TEST(OffloadArchTest, AMDGPUSubArchRoundTrip) {
         << "subarch round-trip failed for " << OffloadArchToString(Arch);
   }
 
-  EXPECT_EQ(getOffloadArchSubArch(OffloadArch::getSPIRV()),
+  EXPECT_EQ(getOffloadArchSubArch(OffloadArch::getAMDGCNSPIRV()),
             llvm::Triple::NoSubArch);
 }


### PR DESCRIPTION
Following up to https://github.com/llvm/llvm-project/pull/213362/changes#r3745729994, the `TargetArch::SPIRV` introduced by #213362 actually corresponds to `amdgcnspirv`, which is not the same as standard SPIRV: This could prove rather confusing in the future. Renaming to `TargetArch::AMDGCNSPIRV` also decouples "`TargetArch::SPIRV`" from AMD-specific SPIRV support, as SPIRV is used by other vendors as well.