### PR TITLE
[lldb] Harden register type XML serialization [1/5]

### DIFF
--- a/lldb/include/lldb/Utility/RegisterType.h
+++ b/lldb/include/lldb/Utility/RegisterType.h
@@ -9,6 +9,8 @@
 #ifndef LLDB_UTILITY_REGISTERTYPE_H
 #define LLDB_UTILITY_REGISTERTYPE_H
 
+#include "llvm/ADT/StringRef.h"
+
 #include <cstdint>
 #include <string>
 #include <unordered_set>
@@ -36,10 +38,12 @@ public:
 
   /// Output XML that describes this type, to be inserted into a target XML
   /// file. Reserved characters like "<" are replaced with their XML safe
-  /// equivalents like "&gt;".
-  void ToXML(Stream &strm,
-             std::unordered_set<const RegisterType *> &previously_emitted,
+  /// equivalents like "&lt;".
+  void ToXML(Stream &strm, std::unordered_set<std::string> &previously_emitted,
              const RegisterType *user = nullptr) const;
+
+  /// Print a string escaped for use as an XML attribute value.
+  static void PrintXMLAttributeValue(Stream &strm, llvm::StringRef value);
 
   virtual ~RegisterType() = default;
 

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -3334,7 +3334,7 @@ GDBRemoteCommunicationServerLLGS::BuildTargetXml() {
   if (registers_count)
     response.IndentMore();
 
-  std::unordered_set<const RegisterType *> register_types_emitted;
+  std::unordered_set<std::string> register_types_emitted;
   for (int reg_index = 0; reg_index < registers_count; reg_index++) {
     const RegisterInfo *reg_info =
         reg_context.GetRegisterInfoAtIndex(reg_index);
@@ -3369,7 +3369,9 @@ GDBRemoteCommunicationServerLLGS::BuildTargetXml() {
       response << "format=\"" << format << "\" ";
 
     if (reg_info->register_type)
-      response << "type=\"" << reg_info->register_type->GetID() << "\" ";
+      response << "type=\""
+               << XMLEncodeAttributeValue(reg_info->register_type->GetID())
+               << "\" ";
 
     const char *const register_set_name =
         reg_context.GetRegisterSetNameForRegisterAtIndex(reg_index);
@@ -4455,6 +4457,9 @@ std::string GDBRemoteCommunicationServerLLGS::XMLEncodeAttributeValue(
   std::string result;
   for (const char &c : value) {
     switch (c) {
+    case '&':
+      result += "&amp;";
+      break;
     case '\'':
       result += "&apos;";
       break;

--- a/lldb/source/Utility/RegisterType.cpp
+++ b/lldb/source/Utility/RegisterType.cpp
@@ -8,6 +8,10 @@
 
 #include "lldb/Utility/RegisterType.h"
 
+#include "lldb/Utility/Stream.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/raw_ostream.h"
+
 #include <atomic>
 
 using namespace lldb_private;
@@ -18,11 +22,11 @@ RegisterType::RegisterType(RegisterTypeKind kind, std::string id)
     : m_kind(kind), m_id(std::move(id)),
       m_uid(g_next_register_type_uid.fetch_add(1, std::memory_order_relaxed)) {}
 
-void RegisterType::ToXML(
-    Stream &strm, std::unordered_set<const RegisterType *> &previously_emitted,
-    const RegisterType *user) const {
-  // If we already emitted this, don't emit it again.
-  if (!previously_emitted.insert(this).second)
+void RegisterType::ToXML(Stream &strm,
+                         std::unordered_set<std::string> &previously_emitted,
+                         const RegisterType *user) const {
+  // XML type references use IDs, so definitions must also be unique by ID.
+  if (!previously_emitted.insert(GetID()).second)
     return;
 
   // Emit this type's dependencies first.
@@ -31,4 +35,11 @@ void RegisterType::ToXML(
 
   // Finally emit this type.
   ToXMLElement(strm, user);
+}
+
+void RegisterType::PrintXMLAttributeValue(Stream &strm, llvm::StringRef value) {
+  std::string escaped;
+  llvm::raw_string_ostream escape_strm(escaped);
+  llvm::printHTMLEscaped(value, escape_strm);
+  strm << escaped;
 }

--- a/lldb/source/Utility/RegisterTypeFlags.cpp
+++ b/lldb/source/Utility/RegisterTypeFlags.cpp
@@ -335,7 +335,9 @@ void RegisterTypeEnum::ToXMLElement(Stream &strm,
   // it.
 
   strm.Indent();
-  strm << "<enum id=\"" << GetID() << "\"";
+  strm << "<enum id=\"";
+  PrintXMLAttributeValue(strm, GetID());
+  strm << "\"";
 
   // We don't expect the user of an enum type to be anything but a register,
   // but we cannot crash if that isn't true.
@@ -389,7 +391,9 @@ void RegisterTypeFlags::ToXMLElement(Stream &strm,
   //   <field name="incorrect" start="0" end="0"/>
   // </flags>
   strm.Indent();
-  strm << "<flags id=\"" << GetID() << "\" ";
+  strm << "<flags id=\"";
+  PrintXMLAttributeValue(strm, GetID());
+  strm << "\" ";
   strm.Printf("size=\"%d\"", GetSize());
   strm << ">";
   for (const Field &field : m_fields) {
@@ -421,8 +425,11 @@ void RegisterTypeFlags::Field::ToXMLElement(Stream &strm) const {
 
   strm.Printf("start=\"%d\" end=\"%d\"", GetStart(), GetEnd());
 
-  if (const RegisterTypeEnum *enum_type = GetEnum())
-    strm << " type=\"" << enum_type->GetID() << "\"";
+  if (const RegisterTypeEnum *enum_type = GetEnum()) {
+    strm << " type=\"";
+    RegisterType::PrintXMLAttributeValue(strm, enum_type->GetID());
+    strm << "\"";
+  }
 
   strm << "/>";
 }

--- a/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationServerLLGSTest.cpp
+++ b/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationServerLLGSTest.cpp
@@ -12,6 +12,18 @@
 
 using namespace lldb_private::process_gdb_remote;
 
+class TestGDBRemoteCommunicationServerLLGS
+    : public GDBRemoteCommunicationServerLLGS {
+public:
+  using GDBRemoteCommunicationServerLLGS::XMLEncodeAttributeValue;
+};
+
+TEST(GDBRemoteCommunicationServerLLGSTest, XMLEncodeAttributeValue) {
+  EXPECT_EQ(TestGDBRemoteCommunicationServerLLGS::XMLEncodeAttributeValue(
+                "type<>&\"'"),
+            "type&lt;&gt;&amp;&quot;&apos;");
+}
+
 TEST(GDBRemoteCommunicationServerLLGSTest, LLGSArgToURL) {
   // LLGS new-style URLs should be passed through (indepenently of
   // --reverse-connect)

--- a/lldb/unittests/Utility/RegisterTypeTest.cpp
+++ b/lldb/unittests/Utility/RegisterTypeTest.cpp
@@ -499,9 +499,6 @@ TEST(RegisterTypeTest, RegisterTypeFlagsToXML) {
   // then the flags set itself. There should only be one definition of each
   // enum, even if it is used by multiple fields.
 
-  // In the server we assume that each type has a unqiue address and use
-  // that to deduplicate them. So here we heap allocate them to simulate that.
-
   StreamString strm;
   auto enum_a = std::make_shared<RegisterTypeEnum>(
       "enum_a",
@@ -513,9 +510,9 @@ TEST(RegisterTypeTest, RegisterTypeFlagsToXML) {
       "enum_c",
       RegisterTypeEnum::Enumerators{RegisterTypeEnum::Enumerator(2, "two")});
 
-  std::unordered_set<const RegisterType *> previously_emitted;
+  std::unordered_set<std::string> previously_emitted;
   // Pretend that enum_c was already emitted for a different flag set.
-  previously_emitted.insert(enum_c.get());
+  previously_emitted.insert(enum_c->GetID());
 
   std::vector<RegisterTypeFlags::Field> fields{
       RegisterTypeFlags::Field("f1", 31, 31, enum_a.get()),
@@ -546,7 +543,7 @@ TEST(RegisterTypeTest, RegisterTypeFlagsToXML) {
       "enum_d",
       RegisterTypeEnum::Enumerators{RegisterTypeEnum::Enumerator(3, "three")});
   fields.push_back(RegisterTypeFlags::Field("f5", 25, 26, enum_d.get()));
-  auto TestFlags2 = std::make_shared<RegisterTypeFlags>("Test", 4, fields);
+  auto TestFlags2 = std::make_shared<RegisterTypeFlags>("Test2", 4, fields);
 
   strm.Clear();
   TestFlags2->ToXML(strm, previously_emitted);
@@ -554,7 +551,7 @@ TEST(RegisterTypeTest, RegisterTypeFlagsToXML) {
             "<enum id=\"enum_d\" size=\"4\">\n"
             "  <evalue name=\"three\" value=\"3\"/>\n"
             "</enum>\n"
-            "<flags id=\"Test\" size=\"4\">\n"
+            "<flags id=\"Test2\" size=\"4\">\n"
             "  <field name=\"f1\" start=\"31\" end=\"31\" type=\"enum_a\"/>\n"
             "  <field name=\"f2\" start=\"30\" end=\"30\" type=\"enum_a\"/>\n"
             "  <field name=\"f3\" start=\"29\" end=\"29\" type=\"enum_b\"/>\n"
@@ -566,4 +563,37 @@ TEST(RegisterTypeTest, RegisterTypeFlagsToXML) {
   strm.Clear();
   TestFlags2->ToXML(strm, previously_emitted);
   ASSERT_EQ(strm.GetString(), "");
+}
+
+TEST(RegisterTypeTest, XMLAttributeEscaping) {
+  RegisterTypeEnum enum_type("enum<>&\"'",
+                             {RegisterTypeEnum::Enumerator(0, "zero")});
+  RegisterTypeFlags flags_type(
+      "flags<>&\"'", 1, {RegisterTypeFlags::Field("field", 0, 0, &enum_type)});
+
+  StreamString strm;
+  std::unordered_set<std::string> previously_emitted;
+  flags_type.ToXML(strm, previously_emitted);
+  EXPECT_EQ(strm.GetString(),
+            "<enum id=\"enum&lt;&gt;&amp;&quot;&apos;\" size=\"1\">\n"
+            "  <evalue name=\"zero\" value=\"0\"/>\n"
+            "</enum>\n"
+            "<flags id=\"flags&lt;&gt;&amp;&quot;&apos;\" size=\"1\">\n"
+            "  <field name=\"field\" start=\"0\" end=\"0\" "
+            "type=\"enum&lt;&gt;&amp;&quot;&apos;\"/>\n"
+            "</flags>\n");
+}
+
+TEST(RegisterTypeTest, XMLDefinitionsAreDeduplicatedByID) {
+  RegisterTypeEnum first("same_id", {RegisterTypeEnum::Enumerator(0, "first")});
+  RegisterTypeEnum second("same_id",
+                          {RegisterTypeEnum::Enumerator(1, "second")});
+
+  StreamString strm;
+  std::unordered_set<std::string> previously_emitted;
+  first.ToXML(strm, previously_emitted);
+  second.ToXML(strm, previously_emitted);
+  EXPECT_EQ(strm.GetString(), "<enum id=\"same_id\">\n"
+                              "  <evalue name=\"first\" value=\"0\"/>\n"
+                              "</enum>\n");
 }


### PR DESCRIPTION
This is patch 1/5 preparing LLDB's register-type infrastructure for GDB XML vector types.

- Deduplicate emitted type definitions by XML ID instead of object address.
- Centralize XML attribute escaping in `RegisterType`.
- Escape enum, flags, field-reference, and register type IDs.
- Add missing `&` escaping to LLGS XML attributes.

XML references identify types by their textual ID, so separate objects with the same ID must not produce duplicate definitions.