### PR TITLE
[flang][OpenMP] Implement verification of modifier sets

### DIFF
--- a/flang/include/flang/Parser/openmp-utils.h
+++ b/flang/include/flang/Parser/openmp-utils.h
@@ -235,6 +235,7 @@ static constexpr bool HasModifier = detail::HasModifierImpl<ClauseTy>::value;
 
 struct AppliedModifier {
   llvm::omp::Modifier modifierId;
+  std::optional<llvm::omp::ModifierSet> setId;
   parser::CharBlock source;
 };
 
@@ -250,7 +251,15 @@ AppliedModifierInfo GetAppliedModifiers(
     for (auto &m : *modifiers) {
       common::visit(
           [&](auto &&s) {
-            info.modifiers.emplace_back(AppliedModifier{s.Id, m.source});
+            using TypeId = llvm::remove_cvref_t<decltype(s.Id)>;
+            if constexpr (std::is_same_v<TypeId, llvm::omp::ModifierSet>) {
+              info.modifiers.emplace_back(AppliedModifier{
+                  common::visit([](auto &&p) { return p.Id; }, s.u), s.Id,
+                  m.source});
+            } else if constexpr (std::is_same_v<TypeId, llvm::omp::Modifier>) {
+              info.modifiers.emplace_back(
+                  AppliedModifier{s.Id, std::nullopt, m.source});
+            }
           },
           m.u);
     }

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -1191,6 +1191,32 @@ bool OmpStructureChecker::VerifyModifierRequired(
       }
     }
   }
+  for (llvm::omp::ModifierSet s : cdesc.getModifierSets(version)) {
+    auto &sdesc{llvm::omp::getDescriptor(s)};
+    // Is group is required, at least one modifier from that group must be
+    // present.
+    if (sdesc.getProperties(version).test(llvm::omp::Property::Required)) {
+      bool present{false};
+      for (llvm::omp::Modifier m : sdesc.getModifiers(version)) {
+        if (isPresent(m)) {
+          present = true;
+          break;
+        }
+      }
+      if (!present) {
+        if (llvm::omp::isModifierGroup(s)) {
+          context_.Say(clause.source,
+              "modifier from '%s' modifier group is required"_err_en_US,
+              sdesc.getName().str());
+        } else {
+          context_.Say(clause.source,
+              "modifier from the modifier set on %s clause is required"_err_en_US,
+              GetUpperName(clause.value, version));
+        }
+        valid = false;
+      }
+    }
+  }
 
   return valid;
 }
@@ -1208,6 +1234,12 @@ bool OmpStructureChecker::VerifyModifierUnique(
     // Exclusive modifiers should have the "unique" property present as well.
     if (mdesc.getProperties(version).test(llvm::omp::Property::Unique)) {
       unique.set(m);
+    }
+  }
+  for (llvm::omp::ModifierSet s : cdesc.getModifierSets(version)) {
+    auto &sdesc{llvm::omp::getDescriptor(s)};
+    if (sdesc.getProperties(version).test(llvm::omp::Property::Unique)) {
+      unique |= sdesc.getModifiers(version);
     }
   }
 
@@ -1283,6 +1315,32 @@ bool OmpStructureChecker::VerifyModifierExclusive(
     }
   }
 
+  // Check modifier sets.
+  llvm::DenseMap<llvm::omp::ModifierSet, const AppliedModifier *> exclusive;
+  for (const AppliedModifier &am : info.modifiers) {
+    if (!am.setId) {
+      continue;
+    }
+    auto &sdesc{llvm::omp::getDescriptor(*am.setId)};
+    if (!sdesc.getProperties(version).test(llvm::omp::Property::Exclusive)) {
+      continue;
+    }
+    auto [where, inserted]{exclusive.insert({*am.setId, &am})};
+    if (!inserted) {
+      const AppliedModifier *prev{where->second};
+      if (prev->modifierId != am.modifierId) {
+        auto &prevDesc{llvm::omp::getDescriptor(prev->modifierId)};
+        auto &thisDesc{llvm::omp::getDescriptor(am.modifierId)};
+        context_
+            .Say(prev->source,
+                "The '%s' and '%s' modifiers are mutually exclusive"_err_en_US,
+                prevDesc.getName().str(), thisDesc.getName().str())
+            .Attach(am.source, "'%s' modifier specified here"_en_US,
+                thisDesc.getName().str());
+        valid = false;
+      }
+    }
+  }
   return valid;
 }
 

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -1193,8 +1193,8 @@ bool OmpStructureChecker::VerifyModifierRequired(
   }
   for (llvm::omp::ModifierSet s : cdesc.getModifierSets(version)) {
     auto &sdesc{llvm::omp::getDescriptor(s)};
-    // Is group is required, at least one modifier from that group must be
-    // present.
+    // If the group is required, at least one modifier from that group must
+    // be present.
     if (sdesc.getProperties(version).test(llvm::omp::Property::Required)) {
       bool present{false};
       for (llvm::omp::Modifier m : sdesc.getModifiers(version)) {

--- a/flang/test/Semantics/OpenMP/declare-variant-v61.f90
+++ b/flang/test/Semantics/OpenMP/declare-variant-v61.f90
@@ -1,0 +1,30 @@
+!RUN: %python %S/../test_errors.py %s %flang -fopenmp -fopenmp-version=61
+
+! OpenMP 6.1 introduced modifier groups, and the ADJUST_ARGS clause now accepts
+! the 'adjust-op' modifier group. The group is required, meaning that at least
+! one modifier from the group must appear on the clause.
+subroutine f00
+!ERROR: ADJUST_ARGS clause on the DECLARE VARIANT directive is not yet implemented
+!ERROR: modifier from 'adjust-op' modifier group is required
+  !$omp declare variant (sub:vsub) match (construct={dispatch}) adjust_args(obj)
+contains
+  subroutine sub(x)
+    integer :: x
+  end
+  subroutine vsub(x, obj)
+    integer :: x, obj
+  end
+end
+
+subroutine f01
+!ERROR: ADJUST_ARGS clause on the DECLARE VARIANT directive is not yet implemented
+!ERROR: modifier from 'adjust-op' modifier group is required
+  !$omp declare variant (sub:vsub) match (construct={dispatch}) adjust_args(nothing, need_device_ptr: obj)
+contains
+  subroutine sub(x)
+    integer :: x
+  end
+  subroutine vsub(x, obj)
+    integer :: x, obj
+  end
+end

--- a/flang/test/Semantics/OpenMP/task-depend.f90
+++ b/flang/test/Semantics/OpenMP/task-depend.f90
@@ -1,6 +1,7 @@
 ! RUN: %python %S/../test_errors.py %s %flang -fopenmp
 
 program test
+! ERROR: modifier from the modifier set on DEPEND clause is required
 ! ERROR: A DEPEND clause on a TASK construct must have a valid task dependence type
 !$omp task depend(ii)
 !$omp end task

--- a/llvm/include/llvm/Frontend/OpenMP/OMPDescriptors.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPDescriptors.h
@@ -38,8 +38,39 @@ static constexpr size_t Modifier_enumSize =
     llvm::to_underlying(Modifier::Last_) -
     llvm::to_underlying(Modifier::First_) + 1;
 
+enum class ModifierSet {
+#define GEN_OMP_MODIFIER_GROUP_ENUMS
+#define First_ FirstGroup_
+#define Last_ LastGroup_
+#include "llvm/Frontend/OpenMP/OMPDescriptors.h.inc"
+#undef Last_
+#undef First_
+#undef GEN_OMP_MODIFIER_GROUP_ENUMS
+
+#define GEN_OMP_MODIFIER_SET_ENUMS
+#define First_ FirstSet_
+#define Last_ LastSet_
+#include "llvm/Frontend/OpenMP/OMPDescriptors.h.inc"
+#undef Last_
+#undef First_
+#undef GEN_OMP_MODIFIER_SET_ENUMS
+  First_ = FirstGroup_,
+  Last_ = LastSet_,
+};
+
+static constexpr size_t ModifierSet_enumSize =
+    llvm::to_underlying(ModifierSet::Last_) -
+    llvm::to_underlying(ModifierSet::First_) + 1;
+
+constexpr inline bool isModifierGroup(ModifierSet S) {
+  return //
+      llvm::to_underlying(ModifierSet::FirstGroup_) <= llvm::to_underlying(S) &&
+      llvm::to_underlying(S) <= llvm::to_underlying(ModifierSet::LastGroup_);
+}
+
 using Properties = EnumSet<Property, Property_enumSize>;
 using Modifiers = EnumSet<Modifier, Modifier_enumSize>;
+using ModifierSets = EnumSet<ModifierSet, ModifierSet_enumSize>;
 
 using Clauses = llvm::omp::ClauseSet;
 using Directives = llvm::omp::DirectiveSet;
@@ -55,9 +86,15 @@ struct Clause : public Base {
   Directives Dirs;
   SourceLanguage Langs;
   Modifiers Mods;
+  ModifierSets ModSets;
 };
 
 struct Modifier : public Base {
+  Clauses Cls;
+};
+
+struct ModifierSet : public Base {
+  Modifiers Mods;
   Clauses Cls;
 };
 } // namespace details
@@ -95,12 +132,21 @@ struct Clause : public Descriptor<details::Clause> {
   LLVM_ABI Properties getProperties(unsigned V) const;
   LLVM_ABI Directives getDirectives(unsigned V) const;
   LLVM_ABI Modifiers getModifiers(unsigned V) const;
+  LLVM_ABI ModifierSets getModifierSets(unsigned V) const;
 };
 
 struct Modifier : public Descriptor<details::Modifier> {
   using Base = Descriptor<details::Modifier>;
   using Base::Base;
   LLVM_ABI Properties getProperties(unsigned V) const;
+  LLVM_ABI Clauses getClauses(unsigned V) const;
+};
+
+struct ModifierSet : public Descriptor<details::ModifierSet> {
+  using Base = Descriptor<details::ModifierSet>;
+  using Base::Base;
+  LLVM_ABI Properties getProperties(unsigned V) const;
+  LLVM_ABI Modifiers getModifiers(unsigned V) const;
   LLVM_ABI Clauses getClauses(unsigned V) const;
 };
 } // namespace descriptor
@@ -110,6 +156,7 @@ using DescriptorMap = DenseMap<Enum, DescriptorTy>;
 
 LLVM_ABI const descriptor::Clause &getDescriptor(llvm::omp::Clause C);
 LLVM_ABI const descriptor::Modifier &getDescriptor(llvm::omp::Modifier M);
+LLVM_ABI const descriptor::ModifierSet &getDescriptor(llvm::omp::ModifierSet G);
 
 LLVM_ABI Properties getProperties(Clause C, unsigned Version);
 } // namespace llvm::omp

--- a/llvm/include/llvm/Frontend/OpenMP/OMPDescriptors.h.inc
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPDescriptors.h.inc
@@ -124,4 +124,21 @@
   VariableCategory,
   Last_ = VariableCategory,
 #endif // GEN_OMP_MODIFIER_ENUMS
+#ifdef GEN_OMP_MODIFIER_SET_ENUMS
+  DependModifierSet1,
+  First_ = DependModifierSet1,
+  NumTeamsModifierSet1,
+  ReductionModifierSet1,
+  Last_ = ReductionModifierSet1,
+#endif // GEN_OMP_MODIFIER_SET_ENUMS
+#ifdef GEN_OMP_MODIFIER_GROUP_ENUMS
+  AdjustOp,
+  First_ = AdjustOp,
+  DependListType,
+  InteropType,
+  MapTypeModifying,
+  ReductionType,
+  VariableSelector,
+  Last_ = VariableSelector,
+#endif // GEN_OMP_MODIFIER_GROUP_ENUMS
    // clang-format on

--- a/llvm/lib/Frontend/OpenMP/OMPDescriptors.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPDescriptors.cpp
@@ -34,6 +34,19 @@ const DescriptorMap<Modifier, descriptor::Modifier> &getModifierMap() {
   return Map;
 }
 
+const DescriptorMap<ModifierSet, descriptor::ModifierSet> &getModifierSetMap() {
+  static const DescriptorMap<ModifierSet, descriptor::ModifierSet> Map{
+#define GEN_OMP_MODIFIER_GROUP_DESCRIPTORS
+#include "OMPDescriptors.inc"
+#undef GEN_OMP_MODIFIER_GROUP_DESCRIPTORS
+
+#define GEN_OMP_MODIFIER_SET_DESCRIPTORS
+#include "OMPDescriptors.inc"
+#undef GEN_OMP_MODIFIER_SET_DESCRIPTORS
+  };
+  return Map;
+}
+
 #define GET_THING_OR_EMPTY(Thing, Member)                                      \
   template <typename DetailsTy>                                                \
   static Thing get##Thing##OrEmpty(const DetailsTy &D, unsigned V) {           \
@@ -46,10 +59,12 @@ const DescriptorMap<Modifier, descriptor::Modifier> &getModifierMap() {
 GET_THING_OR_EMPTY(Clauses, Cls)
 GET_THING_OR_EMPTY(Directives, Dirs)
 GET_THING_OR_EMPTY(Modifiers, Mods)
+GET_THING_OR_EMPTY(ModifierSets, ModSets)
 GET_THING_OR_EMPTY(Properties, Props)
 
 #undef GET_THING_OR_EMPTY
 
+// Clause
 Properties descriptor::Clause::getProperties(unsigned V) const {
   return getPropertiesOrEmpty(Details, V);
 }
@@ -59,19 +74,35 @@ Directives descriptor::Clause::getDirectives(unsigned V) const {
 Modifiers descriptor::Clause::getModifiers(unsigned V) const {
   return getModifiersOrEmpty(Details, V);
 }
+ModifierSets descriptor::Clause::getModifierSets(unsigned V) const {
+  return getModifierSetsOrEmpty(Details, V);
+}
+// Modifier
 Properties descriptor::Modifier::getProperties(unsigned V) const {
   return getPropertiesOrEmpty(Details, V);
 }
 Clauses descriptor::Modifier::getClauses(unsigned V) const {
   return getClausesOrEmpty(Details, V);
 }
+// ModifierSet
+Properties descriptor::ModifierSet::getProperties(unsigned V) const {
+  return getPropertiesOrEmpty(Details, V);
+}
+Modifiers descriptor::ModifierSet::getModifiers(unsigned V) const {
+  return getModifiersOrEmpty(Details, V);
+}
+Clauses descriptor::ModifierSet::getClauses(unsigned V) const {
+  return getClausesOrEmpty(Details, V);
+}
 
 const descriptor::Clause &getDescriptor(llvm::omp::Clause C) {
   return getClauseMap().at(C);
 }
-
 const descriptor::Modifier &getDescriptor(llvm::omp::Modifier M) {
   return getModifierMap().at(M);
+}
+const descriptor::ModifierSet &getDescriptor(llvm::omp::ModifierSet S) {
+  return getModifierSetMap().at(S);
 }
 
 Properties getProperties(Clause C, unsigned Version) {

--- a/llvm/lib/Frontend/OpenMP/OMPDescriptors.inc
+++ b/llvm/lib/Frontend/OpenMP/OMPDescriptors.inc
@@ -13,10 +13,10 @@
     descriptor::Clause(
       "absent",
       {
-        {51, {{{Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {51, {{{Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -25,11 +25,11 @@
     descriptor::Clause(
       "acq_rel",
       {
-        {50, {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {50, {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -38,11 +38,11 @@
     descriptor::Clause(
       "acquire",
       {
-        {50, {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {50, {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -51,10 +51,10 @@
     descriptor::Clause(
       "adjust_args",
       {
-        {51, {{{Property::DispatchCompliant}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AdjustOp}}},
-        {52, {{{Property::DispatchCompliant}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AdjustOp}}},
-        {60, {{{Property::DispatchCompliant}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AdjustOp, Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DispatchCompliant}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {51, {{{Property::DispatchCompliant}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AdjustOp}, {}}},
+        {52, {{{Property::DispatchCompliant}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AdjustOp}, {}}},
+        {60, {{{Property::DispatchCompliant}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AdjustOp, Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::DispatchCompliant}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {ModifierSet::AdjustOp}}},
       }
     ),
   },
@@ -63,11 +63,11 @@
     descriptor::Clause(
       "affinity",
       {
-        {50, {{{}}, "affinity", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator}}},
-        {51, {{{}}, "affinity", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator}}},
-        {52, {{{Property::Unique}}, "affinity", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator}}},
-        {60, {{{Property::TaskInherited}}, "affinity", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator}}},
-        {61, {{{Property::TaskInherited}}, "affinity", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator}}},
+        {50, {{{}}, "affinity", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator}, {}}},
+        {51, {{{}}, "affinity", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator}, {}}},
+        {52, {{{Property::Unique}}, "affinity", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator}, {}}},
+        {60, {{{Property::TaskInherited}}, "affinity", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator}, {}}},
+        {61, {{{Property::TaskInherited}}, "affinity", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator}, {}}},
       }
     ),
   },
@@ -76,10 +76,10 @@
     descriptor::Clause(
       "align",
       {
-        {51, {{{Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {51, {{{Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -88,12 +88,12 @@
     descriptor::Clause(
       "aligned",
       {
-        {45, {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}}},
-        {50, {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment, Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment, Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}, {}}},
+        {50, {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}, {}}},
+        {51, {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}, {}}},
+        {52, {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}, {}}},
+        {60, {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment, Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment, Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -102,11 +102,11 @@
     descriptor::Clause(
       "allocate",
       {
-        {50, {{{Property::AllPrivatizing}}, "allocate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AllocatorSimpleModifier}}},
-        {51, {{{Property::AllPrivatizing}}, "allocate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorSimpleModifier}}},
-        {52, {{{Property::AllPrivatizing}}, "allocate", {Directive::OMPD_allocators, Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorComplexModifier, Modifier::AllocatorSimpleModifier}}},
-        {60, {{{Property::AllPrivatizing}}, "allocate", {Directive::OMPD_allocators, Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorComplexModifier, Modifier::AllocatorSimpleModifier, Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::AllPrivatizing, Property::TargetConsistent}}, "allocate", {Directive::OMPD_allocators, Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorComplexModifier, Modifier::AllocatorSimpleModifier, Modifier::DirectiveNameModifier}}},
+        {50, {{{Property::AllPrivatizing}}, "allocate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AllocatorSimpleModifier}, {}}},
+        {51, {{{Property::AllPrivatizing}}, "allocate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorSimpleModifier}, {}}},
+        {52, {{{Property::AllPrivatizing}}, "allocate", {Directive::OMPD_allocators, Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorComplexModifier, Modifier::AllocatorSimpleModifier}, {}}},
+        {60, {{{Property::AllPrivatizing}}, "allocate", {Directive::OMPD_allocators, Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorComplexModifier, Modifier::AllocatorSimpleModifier, Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::AllPrivatizing, Property::TargetConsistent}}, "allocate", {Directive::OMPD_allocators, Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorComplexModifier, Modifier::AllocatorSimpleModifier, Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -115,11 +115,11 @@
     descriptor::Clause(
       "allocator",
       {
-        {50, {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {50, {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -128,10 +128,10 @@
     descriptor::Clause(
       "append_args",
       {
-        {51, {{{Property::DispatchCompliant, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DispatchCompliant, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DispatchCompliant, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DispatchCompliant, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {51, {{{Property::DispatchCompliant, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::DispatchCompliant, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::DispatchCompliant, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::DispatchCompliant, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -140,8 +140,8 @@
     descriptor::Clause(
       "apply",
       {
-        {60, {{{}}, "apply", {Directive::OMPD_fuse, Directive::OMPD_interchange, Directive::OMPD_nothing, Directive::OMPD_reverse, Directive::OMPD_split, Directive::OMPD_stripe, Directive::OMPD_tile, Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LoopModifier}}},
-        {61, {{{}}, "apply", {Directive::OMPD_flatten, Directive::OMPD_fuse, Directive::OMPD_interchange, Directive::OMPD_nothing, Directive::OMPD_reverse, Directive::OMPD_split, Directive::OMPD_stripe, Directive::OMPD_tile, Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LoopModifier}}},
+        {60, {{{}}, "apply", {Directive::OMPD_fuse, Directive::OMPD_interchange, Directive::OMPD_nothing, Directive::OMPD_reverse, Directive::OMPD_split, Directive::OMPD_stripe, Directive::OMPD_tile, Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LoopModifier}, {}}},
+        {61, {{{}}, "apply", {Directive::OMPD_flatten, Directive::OMPD_fuse, Directive::OMPD_interchange, Directive::OMPD_nothing, Directive::OMPD_reverse, Directive::OMPD_split, Directive::OMPD_stripe, Directive::OMPD_tile, Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LoopModifier}, {}}},
       }
     ),
   },
@@ -150,10 +150,10 @@
     descriptor::Clause(
       "at",
       {
-        {51, {{{Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {51, {{{Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -162,11 +162,11 @@
     descriptor::Clause(
       "atomic_default_mem_order",
       {
-        {50, {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {50, {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -175,11 +175,11 @@
     descriptor::Clause(
       "bind",
       {
-        {50, {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {50, {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -188,12 +188,12 @@
     descriptor::Clause(
       "capture",
       {
-        {45, {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -202,12 +202,12 @@
     descriptor::Clause(
       "collapse",
       {
-        {45, {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -216,8 +216,8 @@
     descriptor::Clause(
       "collector",
       {
-        {60, {{{Property::Required, Property::Unique}}, "collector", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Required, Property::Unique}}, "collector", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {60, {{{Property::Required, Property::Unique}}, "collector", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Required, Property::Unique}}, "collector", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -226,8 +226,8 @@
     descriptor::Clause(
       "combiner",
       {
-        {60, {{{Property::Required, Property::Unique}}, "combiner", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Required, Property::Unique}}, "combiner", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {60, {{{Property::Required, Property::Unique}}, "combiner", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Required, Property::Unique}}, "combiner", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -236,10 +236,10 @@
     descriptor::Clause(
       "compare",
       {
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {51, {{{Property::InnermostLeaf, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::InnermostLeaf, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::InnermostLeaf, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::InnermostLeaf, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -248,10 +248,10 @@
     descriptor::Clause(
       "contains",
       {
-        {51, {{{Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {51, {{{Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -260,12 +260,12 @@
     descriptor::Clause(
       "copyin",
       {
-        {45, {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -274,12 +274,12 @@
     descriptor::Clause(
       "copyprivate",
       {
-        {45, {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -288,8 +288,8 @@
     descriptor::Clause(
       "counts",
       {
-        {60, {{{Property::Required, Property::Unique}}, "counts", {Directive::OMPD_split}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Required, Property::Unique}}, "counts", {Directive::OMPD_split}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {60, {{{Property::Required, Property::Unique}}, "counts", {Directive::OMPD_split}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Required, Property::Unique}}, "counts", {Directive::OMPD_split}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -298,12 +298,12 @@
     descriptor::Clause(
       "default",
       {
-        {45, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}}},
-        {51, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}}},
-        {52, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}}},
-        {60, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::VariableCategory}}},
-        {61, {{{Property::DefaultAttribute, Property::PostModified}}, "default", {Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}, {}}},
+        {51, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}, {}}},
+        {52, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}, {}}},
+        {60, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::VariableCategory}, {}}},
+        {61, {{{Property::DefaultAttribute, Property::PostModified}}, "default", {Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {ModifierSet::VariableSelector}}},
       }
     ),
   },
@@ -312,8 +312,8 @@
     descriptor::Clause(
       "default-variant",
       {
-        {50, {{{Property::Ultimate, Property::Unique}}, "default-variant", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Ultimate, Property::Unique}}, "default-variant", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {50, {{{Property::Ultimate, Property::Unique}}, "default-variant", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Ultimate, Property::Unique}}, "default-variant", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
       }
     ),
   },
@@ -322,12 +322,12 @@
     descriptor::Clause(
       "defaultmap",
       {
-        {45, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}}},
-        {50, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}}},
-        {51, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}}},
-        {52, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}}},
-        {60, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::VariableCategory}}},
-        {61, {{{Property::DefaultAttribute, Property::PostModified}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}, {}}},
+        {50, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}, {}}},
+        {51, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}, {}}},
+        {52, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}, {}}},
+        {60, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::VariableCategory}, {}}},
+        {61, {{{Property::DefaultAttribute, Property::PostModified}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {ModifierSet::VariableSelector}}},
       }
     ),
   },
@@ -336,12 +336,12 @@
     descriptor::Clause(
       "depend",
       {
-        {45, {{{}}, "depend", {Directive::OMPD_ordered_standalone, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::TaskDependenceType}}},
-        {50, {{{}}, "depend", {Directive::OMPD_depobj, Directive::OMPD_ordered_standalone, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::Iterator, Modifier::TaskDependenceType}}},
-        {51, {{{Property::DispatchRequirement}}, "depend", {Directive::OMPD_depobj, Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_ordered_standalone, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::Iterator, Modifier::TaskDependenceType}}},
-        {52, {{{Property::DispatchRequirement}}, "depend", {Directive::OMPD_depobj, Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::TaskDependenceType}}},
-        {60, {{{Property::DispatchRequirement, Property::TaskInherited, Property::TaskgraphAltering}}, "depend", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::TaskDependenceType}}},
-        {61, {{{Property::DispatchRequirement, Property::TaskInherited, Property::TaskSynchronizing, Property::TaskgraphAltering}}, "depend", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::TaskDependenceType}}},
+        {45, {{{}}, "depend", {Directive::OMPD_ordered_standalone, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::TaskDependenceType}, {ModifierSet::DependModifierSet1}}},
+        {50, {{{}}, "depend", {Directive::OMPD_depobj, Directive::OMPD_ordered_standalone, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::Iterator, Modifier::TaskDependenceType}, {ModifierSet::DependModifierSet1}}},
+        {51, {{{Property::DispatchRequirement}}, "depend", {Directive::OMPD_depobj, Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_ordered_standalone, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::Iterator, Modifier::TaskDependenceType}, {ModifierSet::DependModifierSet1}}},
+        {52, {{{Property::DispatchRequirement}}, "depend", {Directive::OMPD_depobj, Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::TaskDependenceType}, {}}},
+        {60, {{{Property::DispatchRequirement, Property::TaskInherited, Property::TaskgraphAltering}}, "depend", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::TaskDependenceType}, {}}},
+        {61, {{{Property::DispatchRequirement, Property::TaskInherited, Property::TaskSynchronizing, Property::TaskgraphAltering}}, "depend", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::TaskDependenceType}, {ModifierSet::DependListType}}},
       }
     ),
   },
@@ -350,7 +350,7 @@
     descriptor::Clause(
       "depth",
       {
-        {61, {{{Property::Unique}}, "depth", {Directive::OMPD_flatten, Directive::OMPD_fuse}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {61, {{{Property::Unique}}, "depth", {Directive::OMPD_flatten, Directive::OMPD_fuse}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -359,11 +359,11 @@
     descriptor::Clause(
       "destroy",
       {
-        {50, {{{}}, "destroy", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {50, {{{}}, "destroy", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -372,11 +372,11 @@
     descriptor::Clause(
       "detach",
       {
-        {50, {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {50, {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -385,12 +385,12 @@
     descriptor::Clause(
       "device",
       {
-        {45, {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier}}},
-        {51, {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier}}},
-        {52, {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier}}},
-        {60, {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier, Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier, Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier}, {}}},
+        {51, {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier}, {}}},
+        {52, {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier}, {}}},
+        {60, {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier, Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier, Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -399,8 +399,8 @@
     descriptor::Clause(
       "device_safesync",
       {
-        {60, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "device_safesync", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "device_safesync", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {60, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "device_safesync", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "device_safesync", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -409,11 +409,11 @@
     descriptor::Clause(
       "device_type",
       {
-        {50, {{{Property::Unique}}, "device_type", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target, Directive::OMPD_groupprivate, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target, Directive::OMPD_groupprivate, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {50, {{{Property::Unique}}, "device_type", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target, Directive::OMPD_groupprivate, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target, Directive::OMPD_groupprivate, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -422,12 +422,12 @@
     descriptor::Clause(
       "dist_schedule",
       {
-        {45, {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -436,9 +436,9 @@
     descriptor::Clause(
       "doacross",
       {
-        {52, {{{Property::Required}}, "doacross", {Directive::OMPD_ordered_standalone}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType}}},
-        {60, {{{Property::Required}}, "doacross", {Directive::OMPD_ordered_standalone}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Required}}, "doacross", {Directive::OMPD_ordered_standalone}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::DirectiveNameModifier}}},
+        {52, {{{Property::Required}}, "doacross", {Directive::OMPD_ordered_standalone}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType}, {}}},
+        {60, {{{Property::Required}}, "doacross", {Directive::OMPD_ordered_standalone}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Required}}, "doacross", {Directive::OMPD_ordered_standalone}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -447,7 +447,7 @@
     descriptor::Clause(
       "dyn_groupprivate",
       {
-        {61, {{{Property::TargetConsistent}}, "dyn_groupprivate", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AccessGroup, Modifier::DirectiveNameModifier, Modifier::FallbackModifier}}},
+        {61, {{{Property::TargetConsistent}}, "dyn_groupprivate", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AccessGroup, Modifier::DirectiveNameModifier, Modifier::FallbackModifier}, {}}},
       }
     ),
   },
@@ -456,11 +456,11 @@
     descriptor::Clause(
       "dynamic_allocators",
       {
-        {50, {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {50, {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -469,9 +469,9 @@
     descriptor::Clause(
       "enter",
       {
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "enter", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "enter", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AutomapModifier, Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "enter", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AutomapModifier, Modifier::DirectiveNameModifier}}},
+        {52, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "enter", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "enter", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AutomapModifier, Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "enter", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AutomapModifier, Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -480,11 +480,11 @@
     descriptor::Clause(
       "exclusive",
       {
-        {50, {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {50, {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -493,10 +493,10 @@
     descriptor::Clause(
       "fail",
       {
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {51, {{{Property::InnermostLeaf, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::InnermostLeaf, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::InnermostLeaf, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::InnermostLeaf, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -505,10 +505,10 @@
     descriptor::Clause(
       "filter",
       {
-        {51, {{{Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {51, {{{Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -517,12 +517,12 @@
     descriptor::Clause(
       "final",
       {
-        {45, {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -531,12 +531,12 @@
     descriptor::Clause(
       "firstprivate",
       {
-        {45, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Saved}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Saved}}},
+        {45, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Saved}, {}}},
+        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Saved}, {}}},
       }
     ),
   },
@@ -545,12 +545,12 @@
     descriptor::Clause(
       "from",
       {
-        {45, {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Mapper}}},
-        {51, {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::Mapper, Modifier::MotionModifier}}},
-        {52, {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Expectation, Modifier::Iterator, Modifier::Mapper}}},
-        {60, {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}}},
-        {61, {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}}},
+        {45, {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Mapper}, {}}},
+        {51, {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::Mapper, Modifier::MotionModifier}, {}}},
+        {52, {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Expectation, Modifier::Iterator, Modifier::Mapper}, {}}},
+        {60, {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}, {}}},
+        {61, {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}, {}}},
       }
     ),
   },
@@ -559,10 +559,10 @@
     descriptor::Clause(
       "full",
       {
-        {51, {{{Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {51, {{{Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -571,12 +571,12 @@
     descriptor::Clause(
       "grainsize",
       {
-        {45, {{{Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}}},
-        {52, {{{Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}}},
-        {60, {{{Property::TaskgraphAltering, Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}}},
-        {61, {{{Property::TaskgraphAltering, Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}}},
+        {45, {{{Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}, {}}},
+        {52, {{{Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}, {}}},
+        {60, {{{Property::TaskgraphAltering, Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}, {}}},
+        {61, {{{Property::TaskgraphAltering, Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}, {}}},
       }
     ),
   },
@@ -585,8 +585,8 @@
     descriptor::Clause(
       "graph_id",
       {
-        {60, {{{Property::Unique}}, "graph_id", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "graph_id", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {60, {{{Property::Unique}}, "graph_id", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "graph_id", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -595,8 +595,8 @@
     descriptor::Clause(
       "graph_reset",
       {
-        {60, {{{Property::Unique}}, "graph_reset", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "graph_reset", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {60, {{{Property::Unique}}, "graph_reset", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "graph_reset", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -605,10 +605,10 @@
     descriptor::Clause(
       "has_device_addr",
       {
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::OutermostLeaf}}, "has_device_addr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::OutermostLeaf}}, "has_device_addr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::OutermostLeaf}}, "has_device_addr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::OutermostLeaf}}, "has_device_addr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::OutermostLeaf}}, "has_device_addr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::OutermostLeaf}}, "has_device_addr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::OutermostLeaf}}, "has_device_addr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::OutermostLeaf}}, "has_device_addr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -617,12 +617,12 @@
     descriptor::Clause(
       "hint",
       {
-        {45, {{{Property::Unique}}, "hint", {Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::Unique}}, "hint", {Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -631,10 +631,10 @@
     descriptor::Clause(
       "holds",
       {
-        {51, {{{Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {51, {{{Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -643,12 +643,12 @@
     descriptor::Clause(
       "if",
       {
-        {45, {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {50, {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {51, {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {52, {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {60, {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {50, {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {51, {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {52, {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {60, {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -657,11 +657,11 @@
     descriptor::Clause(
       "in_reduction",
       {
-        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}}},
+        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}, {}}},
+        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}, {}}},
+        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}, {}}},
+        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}, {}}},
+        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}, {}}},
       }
     ),
   },
@@ -670,12 +670,12 @@
     descriptor::Clause(
       "inbranch",
       {
-        {45, {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -684,11 +684,11 @@
     descriptor::Clause(
       "inclusive",
       {
-        {50, {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {50, {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -697,10 +697,10 @@
     descriptor::Clause(
       "indirect",
       {
-        {51, {{{Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {51, {{{Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -709,8 +709,8 @@
     descriptor::Clause(
       "induction",
       {
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "induction", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::InductionIdentifier, Modifier::InductionModifier, Modifier::StepModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "induction", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::InductionIdentifier, Modifier::InductionModifier, Modifier::StepModifier}}},
+        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "induction", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::InductionIdentifier, Modifier::InductionModifier, Modifier::StepModifier}, {}}},
+        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "induction", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::InductionIdentifier, Modifier::InductionModifier, Modifier::StepModifier}, {}}},
       }
     ),
   },
@@ -719,8 +719,8 @@
     descriptor::Clause(
       "inductor",
       {
-        {60, {{{Property::Required, Property::Unique}}, "inductor", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Required, Property::Unique}}, "inductor", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {60, {{{Property::Required, Property::Unique}}, "inductor", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Required, Property::Unique}}, "inductor", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -729,10 +729,10 @@
     descriptor::Clause(
       "init",
       {
-        {51, {{{Property::InnermostLeaf}}, "init", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::InteropType}}},
-        {52, {{{Property::InnermostLeaf}}, "init", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::InteropType}}},
-        {60, {{{Property::InnermostLeaf}}, "init", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DepinfoModifier, Modifier::DirectiveNameModifier, Modifier::InteropType, Modifier::PreferType}}},
-        {61, {{{Property::InnermostLeaf}}, "init", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DepinfoModifier, Modifier::DirectiveNameModifier, Modifier::PreferType}}},
+        {51, {{{Property::InnermostLeaf}}, "init", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::InteropType}, {}}},
+        {52, {{{Property::InnermostLeaf}}, "init", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::InteropType}, {}}},
+        {60, {{{Property::InnermostLeaf}}, "init", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DepinfoModifier, Modifier::DirectiveNameModifier, Modifier::InteropType, Modifier::PreferType}, {}}},
+        {61, {{{Property::InnermostLeaf}}, "init", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DepinfoModifier, Modifier::DirectiveNameModifier, Modifier::PreferType}, {ModifierSet::InteropType}}},
       }
     ),
   },
@@ -741,8 +741,8 @@
     descriptor::Clause(
       "init_complete",
       {
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "init_complete", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "init_complete", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {60, {{{Property::InnermostLeaf, Property::Unique}}, "init_complete", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::InnermostLeaf, Property::Unique}}, "init_complete", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -751,11 +751,11 @@
     descriptor::Clause(
       "initializer",
       {
-        {50, {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {50, {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -764,8 +764,8 @@
     descriptor::Clause(
       "interop",
       {
-        {60, {{{Property::DispatchRequirement, Property::Unique}}, "interop", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DispatchRequirement, Property::Unique}}, "interop", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {60, {{{Property::DispatchRequirement, Property::Unique}}, "interop", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::DispatchRequirement, Property::Unique}}, "interop", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -774,12 +774,12 @@
     descriptor::Clause(
       "is_device_ptr",
       {
-        {45, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -788,12 +788,12 @@
     descriptor::Clause(
       "lastprivate",
       {
-        {45, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LastprivateModifier}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LastprivateModifier}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LastprivateModifier}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LastprivateModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LastprivateModifier}}},
+        {45, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LastprivateModifier}, {}}},
+        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LastprivateModifier}, {}}},
+        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LastprivateModifier}, {}}},
+        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LastprivateModifier}, {}}},
+        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LastprivateModifier}, {}}},
       }
     ),
   },
@@ -802,12 +802,12 @@
     descriptor::Clause(
       "linear",
       {
-        {45, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::LinearStep}}},
-        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::LinearStep}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::LinearStep}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::StepComplexModifier, Modifier::StepSimpleModifier}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LinearModifier, Modifier::StepComplexModifier, Modifier::StepSimpleModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LinearModifier, Modifier::StepComplexModifier, Modifier::StepSimpleModifier}}},
+        {45, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::LinearStep}, {}}},
+        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::LinearStep}, {}}},
+        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::LinearStep}, {}}},
+        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::StepComplexModifier, Modifier::StepSimpleModifier}, {}}},
+        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LinearModifier, Modifier::StepComplexModifier, Modifier::StepSimpleModifier}, {}}},
+        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LinearModifier, Modifier::StepComplexModifier, Modifier::StepSimpleModifier}, {}}},
       }
     ),
   },
@@ -816,12 +816,12 @@
     descriptor::Clause(
       "link",
       {
-        {45, {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -830,8 +830,8 @@
     descriptor::Clause(
       "local",
       {
-        {60, {{{Property::DataEnvironmentAttribute}}, "local", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute}}, "local", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {60, {{{Property::DataEnvironmentAttribute}}, "local", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::DataEnvironmentAttribute}}, "local", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -840,8 +840,8 @@
     descriptor::Clause(
       "looprange",
       {
-        {60, {{{Property::Unique}}, "looprange", {Directive::OMPD_fuse}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "looprange", {Directive::OMPD_fuse}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {60, {{{Property::Unique}}, "looprange", {Directive::OMPD_fuse}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "looprange", {Directive::OMPD_fuse}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -850,12 +850,12 @@
     descriptor::Clause(
       "map",
       {
-        {45, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::MapType, Modifier::MapTypeModifier, Modifier::OmpxHoldModifier}}},
-        {50, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::MapType, Modifier::MapTypeModifier, Modifier::Mapper, Modifier::OmpxHoldModifier}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::MapType, Modifier::MapTypeModifier, Modifier::Mapper, Modifier::OmpxHoldModifier}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::MapType, Modifier::MapTypeModifier, Modifier::Mapper, Modifier::OmpxHoldModifier}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlwaysModifier, Modifier::CloseModifier, Modifier::DeleteModifier, Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::MapType, Modifier::Mapper, Modifier::OmpxHoldModifier, Modifier::PresentModifier, Modifier::RefModifier, Modifier::SelfModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AttachModifier, Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::MapType, Modifier::Mapper, Modifier::OmpxHoldModifier, Modifier::RefModifier}}},
+        {45, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::MapType, Modifier::MapTypeModifier, Modifier::OmpxHoldModifier}, {}}},
+        {50, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::MapType, Modifier::MapTypeModifier, Modifier::Mapper, Modifier::OmpxHoldModifier}, {}}},
+        {51, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::MapType, Modifier::MapTypeModifier, Modifier::Mapper, Modifier::OmpxHoldModifier}, {}}},
+        {52, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::MapType, Modifier::MapTypeModifier, Modifier::Mapper, Modifier::OmpxHoldModifier}, {}}},
+        {60, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlwaysModifier, Modifier::CloseModifier, Modifier::DeleteModifier, Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::MapType, Modifier::Mapper, Modifier::OmpxHoldModifier, Modifier::PresentModifier, Modifier::RefModifier, Modifier::SelfModifier}, {}}},
+        {61, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AttachModifier, Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::MapType, Modifier::Mapper, Modifier::OmpxHoldModifier, Modifier::RefModifier}, {ModifierSet::MapTypeModifying}}},
       }
     ),
   },
@@ -864,11 +864,11 @@
     descriptor::Clause(
       "match",
       {
-        {50, {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {50, {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -877,8 +877,8 @@
     descriptor::Clause(
       "memscope",
       {
-        {60, {{{Property::Unique}}, "memscope", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "memscope", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {60, {{{Property::Unique}}, "memscope", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "memscope", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -887,12 +887,12 @@
     descriptor::Clause(
       "mergeable",
       {
-        {45, {{{Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "mergeable", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "mergeable", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "mergeable", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "mergeable", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -901,10 +901,10 @@
     descriptor::Clause(
       "message",
       {
-        {51, {{{Property::Unique}}, "message", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "message", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "message", {Directive::OMPD_error, Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "message", {Directive::OMPD_error, Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {51, {{{Property::Unique}}, "message", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "message", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "message", {Directive::OMPD_error, Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "message", {Directive::OMPD_error, Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -913,10 +913,10 @@
     descriptor::Clause(
       "no_openmp",
       {
-        {51, {{{Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {51, {{{Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -925,8 +925,8 @@
     descriptor::Clause(
       "no_openmp_constructs",
       {
-        {60, {{{Property::Unique}}, "no_openmp_constructs", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "no_openmp_constructs", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {60, {{{Property::Unique}}, "no_openmp_constructs", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "no_openmp_constructs", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -935,10 +935,10 @@
     descriptor::Clause(
       "no_openmp_routines",
       {
-        {51, {{{Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {51, {{{Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -947,10 +947,10 @@
     descriptor::Clause(
       "no_parallelism",
       {
-        {51, {{{Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {51, {{{Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -959,10 +959,10 @@
     descriptor::Clause(
       "nocontext",
       {
-        {51, {{{Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {51, {{{Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -971,12 +971,12 @@
     descriptor::Clause(
       "nogroup",
       {
-        {45, {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_target_data, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::OutermostLeaf, Property::TaskSynchronizing, Property::Unique}}, "nogroup", {Directive::OMPD_target_data, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_target_data, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::OutermostLeaf, Property::TaskSynchronizing, Property::Unique}}, "nogroup", {Directive::OMPD_target_data, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -985,11 +985,11 @@
     descriptor::Clause(
       "nontemporal",
       {
-        {50, {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {50, {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -998,12 +998,12 @@
     descriptor::Clause(
       "notinbranch",
       {
-        {45, {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1012,10 +1012,10 @@
     descriptor::Clause(
       "novariants",
       {
-        {51, {{{Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {51, {{{Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1024,12 +1024,12 @@
     descriptor::Clause(
       "nowait",
       {
-        {45, {{{Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DispatchRequirement, Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DispatchRequirement, Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DispatchRequirement, Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DispatchRequirement, Property::EndClause, Property::OutermostLeaf, Property::TaskSynchronizing, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::DispatchRequirement, Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::DispatchRequirement, Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::DispatchRequirement, Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::DispatchRequirement, Property::EndClause, Property::OutermostLeaf, Property::TaskSynchronizing, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1038,12 +1038,12 @@
     descriptor::Clause(
       "num_tasks",
       {
-        {45, {{{Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}}},
-        {52, {{{Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}}},
-        {60, {{{Property::TaskgraphAltering, Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}}},
-        {61, {{{Property::TaskgraphAltering, Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}}},
+        {45, {{{Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}, {}}},
+        {52, {{{Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}, {}}},
+        {60, {{{Property::TaskgraphAltering, Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}, {}}},
+        {61, {{{Property::TaskgraphAltering, Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}, {}}},
       }
     ),
   },
@@ -1052,12 +1052,12 @@
     descriptor::Clause(
       "num_teams",
       {
-        {45, {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LowerBound}}},
-        {51, {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LowerBound}}},
-        {52, {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LowerBound}}},
-        {60, {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LowerBound}}},
-        {61, {{{Property::SpaceConfiguring, Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DimsModifier, Modifier::DirectiveNameModifier, Modifier::LowerBound}}},
+        {45, {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LowerBound}, {}}},
+        {51, {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LowerBound}, {}}},
+        {52, {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LowerBound}, {}}},
+        {60, {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LowerBound}, {}}},
+        {61, {{{Property::SpaceConfiguring, Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DimsModifier, Modifier::DirectiveNameModifier, Modifier::LowerBound}, {ModifierSet::NumTeamsModifierSet1}}},
       }
     ),
   },
@@ -1066,12 +1066,12 @@
     descriptor::Clause(
       "num_threads",
       {
-        {45, {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}}},
-        {61, {{{Property::SpaceConfiguring, Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DimsModifier, Modifier::DirectiveNameModifier, Modifier::PrescriptivenessModifier}}},
+        {45, {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}, {}}},
+        {61, {{{Property::SpaceConfiguring, Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DimsModifier, Modifier::DirectiveNameModifier, Modifier::PrescriptivenessModifier}, {}}},
       }
     ),
   },
@@ -1080,11 +1080,11 @@
     descriptor::Clause(
       "order",
       {
-        {50, {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::OrderModifier}}},
-        {52, {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::OrderModifier}}},
-        {60, {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OrderModifier}}},
-        {61, {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OrderModifier}}},
+        {50, {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::OrderModifier}, {}}},
+        {52, {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::OrderModifier}, {}}},
+        {60, {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OrderModifier}, {}}},
+        {61, {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OrderModifier}, {}}},
       }
     ),
   },
@@ -1093,12 +1093,12 @@
     descriptor::Clause(
       "ordered",
       {
-        {45, {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1107,9 +1107,9 @@
     descriptor::Clause(
       "otherwise",
       {
-        {52, {{{Property::Ultimate, Property::Unique}}, "otherwise", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Ultimate, Property::Unique}}, "otherwise", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Ultimate, Property::Unique}}, "otherwise", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {52, {{{Property::Ultimate, Property::Unique}}, "otherwise", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Ultimate, Property::Unique}}, "otherwise", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Ultimate, Property::Unique}}, "otherwise", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1118,10 +1118,10 @@
     descriptor::Clause(
       "partial",
       {
-        {51, {{{Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {51, {{{Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1130,8 +1130,8 @@
     descriptor::Clause(
       "permutation",
       {
-        {60, {{{Property::Unique}}, "permutation", {Directive::OMPD_interchange}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "permutation", {Directive::OMPD_interchange}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {60, {{{Property::Unique}}, "permutation", {Directive::OMPD_interchange}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "permutation", {Directive::OMPD_interchange}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1140,12 +1140,12 @@
     descriptor::Clause(
       "priority",
       {
-        {45, {{{Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "priority", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "priority", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "priority", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "priority", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1154,12 +1154,12 @@
     descriptor::Clause(
       "private",
       {
-        {45, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1168,12 +1168,12 @@
     descriptor::Clause(
       "proc_bind",
       {
-        {45, {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1182,12 +1182,12 @@
     descriptor::Clause(
       "read",
       {
-        {45, {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1196,12 +1196,12 @@
     descriptor::Clause(
       "reduction",
       {
-        {45, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}}},
-        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier, Modifier::ReductionModifier}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier, Modifier::ReductionModifier}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier, Modifier::ReductionModifier}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OriginalSharingModifier, Modifier::ReductionIdentifier, Modifier::ReductionModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OriginalSharingModifier, Modifier::PerThreadModifier, Modifier::ReductionIdentifier}}},
+        {45, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}, {}}},
+        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier, Modifier::ReductionModifier}, {}}},
+        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier, Modifier::ReductionModifier}, {}}},
+        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier, Modifier::ReductionModifier}, {}}},
+        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OriginalSharingModifier, Modifier::ReductionIdentifier, Modifier::ReductionModifier}, {}}},
+        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OriginalSharingModifier, Modifier::PerThreadModifier, Modifier::ReductionIdentifier}, {ModifierSet::ReductionModifierSet1, ModifierSet::ReductionType}}},
       }
     ),
   },
@@ -1210,11 +1210,11 @@
     descriptor::Clause(
       "relaxed",
       {
-        {50, {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {50, {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1223,11 +1223,11 @@
     descriptor::Clause(
       "release",
       {
-        {50, {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {50, {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1236,8 +1236,8 @@
     descriptor::Clause(
       "replayable",
       {
-        {60, {{{Property::Unique}}, "replayable", {Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "replayable", {Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {60, {{{Property::Unique}}, "replayable", {Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "replayable", {Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1246,11 +1246,11 @@
     descriptor::Clause(
       "reverse_offload",
       {
-        {50, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {50, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1259,12 +1259,12 @@
     descriptor::Clause(
       "safelen",
       {
-        {45, {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1273,8 +1273,8 @@
     descriptor::Clause(
       "safesync",
       {
-        {60, {{{Property::Unique}}, "safesync", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "safesync", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {60, {{{Property::Unique}}, "safesync", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "safesync", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1283,12 +1283,12 @@
     descriptor::Clause(
       "schedule",
       {
-        {45, {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}}},
-        {50, {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}}},
-        {51, {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}}},
-        {52, {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}}},
-        {60, {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::DirectiveNameModifier, Modifier::OrderingModifier}}},
-        {61, {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::DirectiveNameModifier, Modifier::OrderingModifier}}},
+        {45, {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}, {}}},
+        {50, {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}, {}}},
+        {51, {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}, {}}},
+        {52, {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}, {}}},
+        {60, {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::DirectiveNameModifier, Modifier::OrderingModifier}, {}}},
+        {61, {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::DirectiveNameModifier, Modifier::OrderingModifier}, {}}},
       }
     ),
   },
@@ -1297,8 +1297,8 @@
     descriptor::Clause(
       "self_maps",
       {
-        {60, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "self_maps", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "self_maps", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {60, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "self_maps", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "self_maps", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1307,12 +1307,12 @@
     descriptor::Clause(
       "seq_cst",
       {
-        {45, {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1321,10 +1321,10 @@
     descriptor::Clause(
       "severity",
       {
-        {51, {{{Property::Unique}}, "severity", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "severity", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "severity", {Directive::OMPD_error, Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "severity", {Directive::OMPD_error, Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {51, {{{Property::Unique}}, "severity", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "severity", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "severity", {Directive::OMPD_error, Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "severity", {Directive::OMPD_error, Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1333,12 +1333,12 @@
     descriptor::Clause(
       "shared",
       {
-        {45, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1347,12 +1347,12 @@
     descriptor::Clause(
       "simd",
       {
-        {45, {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1361,12 +1361,12 @@
     descriptor::Clause(
       "simdlen",
       {
-        {45, {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ScaledModifier}}},
+        {45, {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ScaledModifier}, {}}},
       }
     ),
   },
@@ -1375,10 +1375,10 @@
     descriptor::Clause(
       "sizes",
       {
-        {51, {{{Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_stripe, Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_stripe, Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::SizesSelector}}},
+        {51, {{{Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_stripe, Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_stripe, Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::SizesSelector}, {}}},
       }
     ),
   },
@@ -1387,11 +1387,11 @@
     descriptor::Clause(
       "task_reduction",
       {
-        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}}},
+        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}, {}}},
+        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}, {}}},
+        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}, {}}},
+        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}, {}}},
+        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}, {}}},
       }
     ),
   },
@@ -1400,12 +1400,12 @@
     descriptor::Clause(
       "thread_limit",
       {
-        {45, {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::IcvModifying, Property::SpaceConfiguring, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DimsModifier, Modifier::DirectiveNameModifier, Modifier::PrescriptivenessModifier}}},
+        {45, {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::IcvModifying, Property::SpaceConfiguring, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DimsModifier, Modifier::DirectiveNameModifier, Modifier::PrescriptivenessModifier}, {}}},
       }
     ),
   },
@@ -1414,12 +1414,12 @@
     descriptor::Clause(
       "threads",
       {
-        {45, {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1428,8 +1428,8 @@
     descriptor::Clause(
       "threadset",
       {
-        {60, {{{Property::Unique}}, "threadset", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "threadset", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {60, {{{Property::Unique}}, "threadset", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "threadset", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1438,12 +1438,12 @@
     descriptor::Clause(
       "to",
       {
-        {45, {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_declare_target, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_declare_target, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Mapper}}},
-        {51, {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_declare_target, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::Mapper, Modifier::MotionModifier}}},
-        {52, {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Expectation, Modifier::Iterator, Modifier::Mapper}}},
-        {60, {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}}},
-        {61, {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}}},
+        {45, {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_declare_target, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_declare_target, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Mapper}, {}}},
+        {51, {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_declare_target, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::Mapper, Modifier::MotionModifier}, {}}},
+        {52, {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Expectation, Modifier::Iterator, Modifier::Mapper}, {}}},
+        {60, {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}, {}}},
+        {61, {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}, {}}},
       }
     ),
   },
@@ -1452,8 +1452,8 @@
     descriptor::Clause(
       "transparent",
       {
-        {60, {{{Property::Unique}}, "transparent", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "transparent", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {60, {{{Property::Unique}}, "transparent", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "transparent", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1462,11 +1462,11 @@
     descriptor::Clause(
       "unified_address",
       {
-        {50, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {50, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1475,11 +1475,11 @@
     descriptor::Clause(
       "unified_shared_memory",
       {
-        {50, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {50, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1488,12 +1488,12 @@
     descriptor::Clause(
       "uniform",
       {
-        {45, {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1502,12 +1502,12 @@
     descriptor::Clause(
       "untied",
       {
-        {45, {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1516,12 +1516,12 @@
     descriptor::Clause(
       "update",
       {
-        {45, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1530,11 +1530,11 @@
     descriptor::Clause(
       "update-depend_objects",
       {
-        {50, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::TaskDependenceType}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::TaskDependenceType}}},
+        {50, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::TaskDependenceType}, {}}},
+        {61, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::TaskDependenceType}, {}}},
       }
     ),
   },
@@ -1543,10 +1543,10 @@
     descriptor::Clause(
       "use",
       {
-        {51, {{{}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {51, {{{}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1555,11 +1555,11 @@
     descriptor::Clause(
       "use_device_addr",
       {
-        {50, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {50, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1568,12 +1568,12 @@
     descriptor::Clause(
       "use_device_ptr",
       {
-        {45, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Fallback}}},
+        {45, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Fallback}, {}}},
       }
     ),
   },
@@ -1582,11 +1582,11 @@
     descriptor::Clause(
       "uses_allocators",
       {
-        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::MemSpace, Modifier::TraitsArray}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::MemSpace, Modifier::TraitsArray}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::MemSpace, Modifier::TraitsArray}}},
+        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::MemSpace, Modifier::TraitsArray}, {}}},
+        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::MemSpace, Modifier::TraitsArray}, {}}},
+        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::MemSpace, Modifier::TraitsArray}, {}}},
       }
     ),
   },
@@ -1595,10 +1595,10 @@
     descriptor::Clause(
       "weak",
       {
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {51, {{{Property::InnermostLeaf, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::InnermostLeaf, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::InnermostLeaf, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::InnermostLeaf, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1607,11 +1607,11 @@
     descriptor::Clause(
       "when",
       {
-        {50, {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector}}},
-        {51, {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector}}},
-        {52, {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector}}},
-        {60, {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector, Modifier::DirectiveNameModifier}}},
-        {61, {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector, Modifier::DirectiveNameModifier}}},
+        {50, {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector}, {}}},
+        {51, {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector}, {}}},
+        {52, {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector}, {}}},
+        {60, {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector, Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector, Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1620,12 +1620,12 @@
     descriptor::Clause(
       "write",
       {
-        {45, {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {45, {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {50, {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {51, {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {52, {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {60, {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {61, {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -2299,7 +2299,6 @@
     descriptor::Modifier(
       "step-modifier",
       {
-        {52, {{{Property::Required, Property::Unique}}, {}}},
         {60, {{{Property::Required, Property::Unique}}, {Clause::OMPC_induction}}},
         {61, {{{Property::Required, Property::Unique}}, {Clause::OMPC_induction}}},
       }
@@ -2383,4 +2382,91 @@
     ),
   },
 #endif // GEN_OMP_MODIFIER_DESCRIPTORS
+#ifdef GEN_OMP_MODIFIER_SET_DESCRIPTORS
+  {
+    ModifierSet::DependModifierSet1,
+    descriptor::ModifierSet(
+      "depend_modifier_set_1",
+      {
+        {45, {{{Property::Exclusive, Property::Required}}, {Modifier::DependenceType, Modifier::TaskDependenceType}, {Clause::OMPC_depend}}},
+        {50, {{{Property::Exclusive, Property::Required}}, {Modifier::DependenceType, Modifier::TaskDependenceType}, {Clause::OMPC_depend}}},
+        {51, {{{Property::Exclusive, Property::Required}}, {Modifier::DependenceType, Modifier::TaskDependenceType}, {Clause::OMPC_depend}}},
+      }
+    ),
+  },
+  {
+    ModifierSet::NumTeamsModifierSet1,
+    descriptor::ModifierSet(
+      "num_teams_modifier_set_1",
+      {
+        {61, {{{Property::Exclusive}}, {Modifier::DimsModifier, Modifier::LowerBound}, {Clause::OMPC_num_teams}}},
+      }
+    ),
+  },
+  {
+    ModifierSet::ReductionModifierSet1,
+    descriptor::ModifierSet(
+      "reduction_modifier_set_1",
+      {
+        {61, {{{Property::Exclusive}}, {Modifier::InscanModifier, Modifier::NoncommutativeModifier, Modifier::PerThreadModifier}, {Clause::OMPC_reduction}}},
+      }
+    ),
+  },
+#endif // GEN_OMP_MODIFIER_SET_DESCRIPTORS
+#ifdef GEN_OMP_MODIFIER_GROUP_DESCRIPTORS
+  {
+    ModifierSet::AdjustOp,
+    descriptor::ModifierSet(
+      "adjust-op",
+      {
+        {61, {{{Property::Exclusive, Property::Required}}, {Modifier::NeedDeviceAddr, Modifier::NeedDevicePtr, Modifier::Nothing}, {Clause::OMPC_adjust_args}}},
+      }
+    ),
+  },
+  {
+    ModifierSet::DependListType,
+    descriptor::ModifierSet(
+      "depend-list-type",
+      {
+        {61, {{{Property::Exclusive}}, {Modifier::DepobjModifier, Modifier::LocModifier}, {Clause::OMPC_depend}}},
+      }
+    ),
+  },
+  {
+    ModifierSet::InteropType,
+    descriptor::ModifierSet(
+      "interop-type",
+      {
+        {61, {{{Property::Unique}}, {Modifier::TargetType, Modifier::TargetsyncType}, {Clause::OMPC_init}}},
+      }
+    ),
+  },
+  {
+    ModifierSet::MapTypeModifying,
+    descriptor::ModifierSet(
+      "map-type-modifying",
+      {
+        {61, {{{Property::Unique}}, {Modifier::AlwaysModifier, Modifier::CloseModifier, Modifier::DeleteModifier, Modifier::PresentModifier, Modifier::SelfModifier}, {Clause::OMPC_map}}},
+      }
+    ),
+  },
+  {
+    ModifierSet::ReductionType,
+    descriptor::ModifierSet(
+      "reduction-type",
+      {
+        {61, {{{Property::Exclusive}}, {Modifier::DefaultModifier, Modifier::InscanModifier, Modifier::NoncommutativeModifier, Modifier::TaskModifier}, {Clause::OMPC_reduction}}},
+      }
+    ),
+  },
+  {
+    ModifierSet::VariableSelector,
+    descriptor::ModifierSet(
+      "variable-selector",
+      {
+        {61, {{{Property::Required}}, {Modifier::OptionalModifier, Modifier::VariableCategory}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
+      }
+    ),
+  },
+#endif // GEN_OMP_MODIFIER_GROUP_DESCRIPTORS
     // clang-format on


### PR DESCRIPTION
Modifier sets and modifier groups are the modifier analogues of clause
sets and clause groups. In the OpenMP specification, modifier groups
have properties that are independent of the clause on which a member of
the group is specified, whereas modifier sets are local to clauses.

The implementation of modifier groups is identical to that of groups,
the only exception is that modifier sets don't have names that are
usable in diagnostic messages.