### PR TITLE
[HLSL][NFC] Refactoring in HLSLBuiltinTypeDeclBuilder and SemaHLSL

### DIFF
--- a/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
+++ b/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
@@ -641,16 +641,14 @@ void BuiltinTypeMethodBuilder::createDecl() {
 
 Expr *BuiltinTypeMethodBuilder::getResourceHandleExpr() {
   ensureCompleteDecl();
-  CXXThisExpr *This = createThisExpr();
   FieldDecl *HandleField = DeclBuilder.getResourceHandleField();
-  return createMemberExpr(This, HandleField);
+  return createMemberExpr(createThisExpr(), HandleField);
 }
 
 Expr *BuiltinTypeMethodBuilder::getResourceCounterHandleExpr() {
   ensureCompleteDecl();
-  CXXThisExpr *This = createThisExpr();
   FieldDecl *HandleField = DeclBuilder.getResourceCounterHandleField();
-  return createMemberExpr(This, HandleField);
+  return createMemberExpr(createThisExpr(), HandleField);
 }
 
 template <typename T>
@@ -726,8 +724,7 @@ BuiltinTypeMethodBuilder &BuiltinTypeMethodBuilder::concat(V Vec, S Scalar,
 }
 
 BuiltinTypeMethodBuilder &BuiltinTypeMethodBuilder::returnThis() {
-  CXXThisExpr *ThisExpr = createThisExpr();
-  StmtsList.push_back(ThisExpr);
+  StmtsList.push_back(createThisExpr());
   return *this;
 }
 

--- a/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
+++ b/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
@@ -287,6 +287,9 @@ public:
   Expr *getResourceHandleExpr();
   Expr *getResourceCounterHandleExpr();
 
+  template <typename T> MemberExpr *createMemberExpr(T Base, FieldDecl *Field);
+  CXXThisExpr *createThisExpr();
+
 private:
   void createDecl();
 
@@ -296,6 +299,8 @@ private:
     if (!Method)
       createDecl();
   }
+
+  ASTContext &getASTContext() { return DeclBuilder.SemaRef.getASTContext(); }
 };
 
 TemplateParameterListBuilder::~TemplateParameterListBuilder() {
@@ -474,12 +479,8 @@ Expr *BuiltinTypeMethodBuilder::convertPlaceholder(PlaceHolder PH) {
     return getResourceHandleExpr();
   if (PH == PlaceHolder::CounterHandle)
     return getResourceCounterHandleExpr();
-  if (PH == PlaceHolder::This) {
-    ASTContext &AST = DeclBuilder.SemaRef.getASTContext();
-    return CXXThisExpr::Create(AST, SourceLocation(),
-                               Method->getFunctionObjectParameterType(),
-                               /*IsImplicit=*/true);
-  }
+  if (PH == PlaceHolder::This)
+    return createThisExpr();
 
   if (PH == PlaceHolder::LastStmt) {
     assert(!StmtsList.empty() && "no statements in the list");
@@ -492,11 +493,10 @@ Expr *BuiltinTypeMethodBuilder::convertPlaceholder(PlaceHolder PH) {
   // LValue. It needs to be an LValue if the result expression will be used as
   // the actual parameter for an out parameter. The dimension builtins are an
   // example where this happens.
-  ASTContext &AST = DeclBuilder.SemaRef.getASTContext();
   ParmVarDecl *ParamDecl = Method->getParamDecl(static_cast<unsigned>(PH));
   return DeclRefExpr::Create(
-      AST, NestedNameSpecifierLoc(), SourceLocation(), ParamDecl, false,
-      DeclarationNameInfo(ParamDecl->getDeclName(), SourceLocation()),
+      getASTContext(), NestedNameSpecifierLoc(), SourceLocation(), ParamDecl,
+      false, DeclarationNameInfo(ParamDecl->getDeclName(), SourceLocation()),
       ParamDecl->getType().getNonReferenceType(), VK_LValue);
 }
 
@@ -510,7 +510,7 @@ Expr *BuiltinTypeMethodBuilder::convertPlaceholder(LocalVar &Var) {
 }
 
 Expr *BuiltinTypeMethodBuilder::convertPlaceholder(QualType Ty) {
-  ASTContext &AST = DeclBuilder.SemaRef.getASTContext();
+  ASTContext &AST = getASTContext();
   QualType PtrTy = AST.getPointerType(Ty);
   // Creates a value-initialized null pointer of type Ty*.
   return new (AST) CXXScalarValueInitExpr(
@@ -529,7 +529,7 @@ BuiltinTypeMethodBuilder::BuiltinTypeMethodBuilder(BuiltinTypeDeclBuilder &DB,
   assert((!NameStr.empty() || IsCtor) && "method needs a name");
   assert(((IsCtor && !IsConst) || !IsCtor) && "constructor cannot be const");
 
-  ASTContext &AST = DB.SemaRef.getASTContext();
+  ASTContext &AST = getASTContext();
   if (IsCtor) {
     Name = AST.DeclarationNames.getCXXConstructorName(
         AST.getCanonicalTagType(DB.Record));
@@ -544,15 +544,15 @@ BuiltinTypeMethodBuilder &
 BuiltinTypeMethodBuilder::addParam(StringRef Name, QualType Ty,
                                    HLSLParamModifierAttr::Spelling Modifier) {
   assert(Method == nullptr && "Cannot add param, method already created");
-  const IdentifierInfo &II = DeclBuilder.SemaRef.getASTContext().Idents.get(
-      Name, tok::TokenKind::identifier);
+  const IdentifierInfo &II =
+      getASTContext().Idents.get(Name, tok::TokenKind::identifier);
   Params.emplace_back(II, Ty, Modifier);
   return *this;
 }
 QualType BuiltinTypeMethodBuilder::addTemplateTypeParam(StringRef Name) {
   assert(Method == nullptr &&
          "Cannot add template param, method already created");
-  ASTContext &AST = DeclBuilder.SemaRef.getASTContext();
+  ASTContext &AST = getASTContext();
   unsigned Position = static_cast<unsigned>(TemplateParamDecls.size());
   auto *Decl = TemplateTypeParmDecl::Create(
       AST, DeclBuilder.Record, SourceLocation(), SourceLocation(),
@@ -570,7 +570,7 @@ void BuiltinTypeMethodBuilder::createDecl() {
   assert(Method == nullptr && "Method or constructor is already created");
 
   // create function prototype
-  ASTContext &AST = DeclBuilder.SemaRef.getASTContext();
+  ASTContext &AST = getASTContext();
   SmallVector<QualType> ParamTypes;
   SmallVector<FunctionType::ExtParameterInfo> ParamExtInfos(Params.size());
   uint32_t ArgIndex = 0;
@@ -641,26 +641,32 @@ void BuiltinTypeMethodBuilder::createDecl() {
 
 Expr *BuiltinTypeMethodBuilder::getResourceHandleExpr() {
   ensureCompleteDecl();
-
-  ASTContext &AST = DeclBuilder.SemaRef.getASTContext();
-  CXXThisExpr *This = CXXThisExpr::Create(
-      AST, SourceLocation(), Method->getFunctionObjectParameterType(), true);
+  CXXThisExpr *This = createThisExpr();
   FieldDecl *HandleField = DeclBuilder.getResourceHandleField();
-  return MemberExpr::CreateImplicit(AST, This, false, HandleField,
-                                    HandleField->getType(), VK_LValue,
-                                    OK_Ordinary);
+  return createMemberExpr(This, HandleField);
 }
 
 Expr *BuiltinTypeMethodBuilder::getResourceCounterHandleExpr() {
   ensureCompleteDecl();
-
-  ASTContext &AST = DeclBuilder.SemaRef.getASTContext();
-  CXXThisExpr *This = CXXThisExpr::Create(
-      AST, SourceLocation(), Method->getFunctionObjectParameterType(), true);
+  CXXThisExpr *This = createThisExpr();
   FieldDecl *HandleField = DeclBuilder.getResourceCounterHandleField();
-  return MemberExpr::CreateImplicit(AST, This, false, HandleField,
-                                    HandleField->getType(), VK_LValue,
-                                    OK_Ordinary);
+  return createMemberExpr(This, HandleField);
+}
+
+template <typename T>
+MemberExpr *BuiltinTypeMethodBuilder::createMemberExpr(T Base,
+                                                       FieldDecl *Member) {
+  ensureCompleteDecl();
+  Expr *BaseExpr = convertPlaceholder(Base);
+  return MemberExpr::CreateImplicit(getASTContext(), BaseExpr, false, Member,
+                                    Member->getType(), VK_LValue, OK_Ordinary);
+}
+
+CXXThisExpr *BuiltinTypeMethodBuilder::createThisExpr() {
+  CXXThisExpr *This =
+      CXXThisExpr::Create(getASTContext(), SourceLocation(),
+                          Method->getFunctionObjectParameterType(), true);
+  return This;
 }
 
 BuiltinTypeMethodBuilder &
@@ -669,7 +675,7 @@ BuiltinTypeMethodBuilder::declareLocalVar(LocalVar &Var) {
 
   assert(Var.Decl == nullptr && "local variable is already declared");
 
-  ASTContext &AST = DeclBuilder.SemaRef.getASTContext();
+  ASTContext &AST = getASTContext();
   Var.Decl = VarDecl::Create(
       AST, Method, SourceLocation(), SourceLocation(),
       &AST.Idents.get(Var.Name, tok::TokenKind::identifier), Var.Ty,
@@ -684,7 +690,6 @@ template <typename V, typename S>
 BuiltinTypeMethodBuilder &BuiltinTypeMethodBuilder::concat(V Vec, S Scalar,
                                                            QualType ResultTy) {
   assert(ResultTy->isVectorType() && "The result type must be a vector type.");
-  ASTContext &AST = DeclBuilder.SemaRef.getASTContext();
   Expr *VecExpr = convertPlaceholder(Vec);
   auto *VecTy = VecExpr->getType()->castAs<VectorType>();
   Expr *ScalarExpr = convertPlaceholder(Scalar);
@@ -698,6 +703,7 @@ BuiltinTypeMethodBuilder &BuiltinTypeMethodBuilder::concat(V Vec, S Scalar,
   QualType EltTy = VecTy->getElementType();
   unsigned NumElts = VecTy->getNumElements();
 
+  ASTContext &AST = getASTContext();
   SmallVector<Expr *, 4> Elts;
   for (unsigned I = 0; I < NumElts; ++I) {
     Elts.push_back(new (AST) ArraySubscriptExpr(
@@ -720,10 +726,7 @@ BuiltinTypeMethodBuilder &BuiltinTypeMethodBuilder::concat(V Vec, S Scalar,
 }
 
 BuiltinTypeMethodBuilder &BuiltinTypeMethodBuilder::returnThis() {
-  ASTContext &AST = DeclBuilder.SemaRef.getASTContext();
-  CXXThisExpr *ThisExpr = CXXThisExpr::Create(
-      AST, SourceLocation(), Method->getFunctionObjectParameterType(),
-      /*IsImplicit=*/true);
+  CXXThisExpr *ThisExpr = createThisExpr();
   StmtsList.push_back(ThisExpr);
   return *this;
 }
@@ -737,7 +740,7 @@ BuiltinTypeMethodBuilder::callBuiltin(StringRef BuiltinName,
   std::array<Expr *, sizeof...(ArgSpecs)> Args{
       convertPlaceholder(std::forward<Ts>(ArgSpecs))...};
 
-  ASTContext &AST = DeclBuilder.SemaRef.getASTContext();
+  ASTContext &AST = getASTContext();
   FunctionDecl *FD = lookupBuiltinFunction(DeclBuilder.SemaRef, BuiltinName);
   DeclRefExpr *DRE = DeclRefExpr::Create(
       AST, NestedNameSpecifierLoc(), SourceLocation(), FD, false,
@@ -767,9 +770,9 @@ BuiltinTypeMethodBuilder &BuiltinTypeMethodBuilder::assign(TLHS LHS, TRHS RHS) {
   Expr *LHSExpr = convertPlaceholder(LHS);
   Expr *RHSExpr = convertPlaceholder(RHS);
   Stmt *AssignStmt = BinaryOperator::Create(
-      DeclBuilder.SemaRef.getASTContext(), LHSExpr, RHSExpr, BO_Assign,
-      LHSExpr->getType(), ExprValueKind::VK_PRValue,
-      ExprObjectKind::OK_Ordinary, SourceLocation(), FPOptionsOverride());
+      getASTContext(), LHSExpr, RHSExpr, BO_Assign, LHSExpr->getType(),
+      ExprValueKind::VK_PRValue, ExprObjectKind::OK_Ordinary, SourceLocation(),
+      FPOptionsOverride());
   StmtsList.push_back(AssignStmt);
   return *this;
 }
@@ -777,11 +780,10 @@ BuiltinTypeMethodBuilder &BuiltinTypeMethodBuilder::assign(TLHS LHS, TRHS RHS) {
 template <typename T>
 BuiltinTypeMethodBuilder &BuiltinTypeMethodBuilder::dereference(T Ptr) {
   Expr *PtrExpr = convertPlaceholder(Ptr);
-  Expr *Deref =
-      UnaryOperator::Create(DeclBuilder.SemaRef.getASTContext(), PtrExpr,
-                            UO_Deref, PtrExpr->getType()->getPointeeType(),
-                            VK_LValue, OK_Ordinary, SourceLocation(),
-                            /*CanOverflow=*/false, FPOptionsOverride());
+  Expr *Deref = UnaryOperator::Create(
+      getASTContext(), PtrExpr, UO_Deref, PtrExpr->getType()->getPointeeType(),
+      VK_LValue, OK_Ordinary, SourceLocation(),
+      /*CanOverflow=*/false, FPOptionsOverride());
   StmtsList.push_back(Deref);
   return *this;
 }
@@ -794,7 +796,7 @@ BuiltinTypeMethodBuilder::accessHandleFieldOnResource(T ResourceRecord) {
   Expr *ResourceExpr = convertPlaceholder(ResourceRecord);
   auto *ResourceTypeDecl = ResourceExpr->getType()->getAsCXXRecordDecl();
 
-  ASTContext &AST = DeclBuilder.SemaRef.getASTContext();
+  ASTContext &AST = getASTContext();
   FieldDecl *HandleField = nullptr;
 
   if (ResourceTypeDecl == DeclBuilder.Record)
@@ -820,12 +822,7 @@ BuiltinTypeMethodBuilder &
 BuiltinTypeMethodBuilder::accessFieldOnResource(T ResourceRecord,
                                                 FieldDecl *Field) {
   ensureCompleteDecl();
-  Expr *Base = convertPlaceholder(ResourceRecord);
-
-  ASTContext &AST = DeclBuilder.SemaRef.getASTContext();
-  auto *Member =
-      MemberExpr::CreateImplicit(AST, Base, /*IsArrow=*/false, Field,
-                                 Field->getType(), VK_LValue, OK_Ordinary);
+  auto *Member = createMemberExpr(ResourceRecord, Field);
   StmtsList.push_back(Member);
   return *this;
 }
@@ -835,7 +832,6 @@ void BuiltinTypeMethodBuilder::setMipsHandleField(LocalVar &ResourceRecord) {
   if (!MipsField)
     return;
 
-  ASTContext &AST = DeclBuilder.SemaRef.getASTContext();
   QualType MipsTy = MipsField->getType();
   const auto *RT = MipsTy->castAs<RecordType>();
   CXXRecordDecl *MipsRecord = cast<CXXRecordDecl>(RT->getDecl());
@@ -849,19 +845,14 @@ void BuiltinTypeMethodBuilder::setMipsHandleField(LocalVar &ResourceRecord) {
 
   FieldDecl *HandleField = DeclBuilder.getResourceHandleField();
   Expr *ResExpr = convertPlaceholder(ResourceRecord);
-  MemberExpr *HandleMemberExpr = MemberExpr::CreateImplicit(
-      AST, ResExpr, false, HandleField, HandleField->getType(), VK_LValue,
-      OK_Ordinary);
+  MemberExpr *HandleMemberExpr = createMemberExpr(ResExpr, HandleField);
 
-  MemberExpr *MipsMemberExpr =
-      MemberExpr::CreateImplicit(AST, ResExpr, false, MipsField,
-                                 MipsField->getType(), VK_LValue, OK_Ordinary);
-  MemberExpr *MipsHandleMemberExpr = MemberExpr::CreateImplicit(
-      AST, MipsMemberExpr, false, MipsHandleField, MipsHandleField->getType(),
-      VK_LValue, OK_Ordinary);
+  MemberExpr *MipsMemberExpr = createMemberExpr(ResExpr, MipsField);
+  MemberExpr *MipsHandleMemberExpr =
+      createMemberExpr(MipsMemberExpr, MipsHandleField);
 
   Stmt *AssignStmt = BinaryOperator::Create(
-      AST, MipsHandleMemberExpr, HandleMemberExpr, BO_Assign,
+      getASTContext(), MipsHandleMemberExpr, HandleMemberExpr, BO_Assign,
       MipsHandleMemberExpr->getType(), ExprValueKind::VK_LValue,
       ExprObjectKind::OK_Ordinary, SourceLocation(), FPOptionsOverride());
 
@@ -898,13 +889,10 @@ BuiltinTypeMethodBuilder &BuiltinTypeMethodBuilder::setFieldOnResource(
 
   Expr *HandleValueExpr = convertPlaceholder(HandleValue);
 
-  ASTContext &AST = DeclBuilder.SemaRef.getASTContext();
-  MemberExpr *HandleMemberExpr = MemberExpr::CreateImplicit(
-      AST, ResourceExpr, false, HandleField, HandleField->getType(), VK_LValue,
-      OK_Ordinary);
+  MemberExpr *HandleMemberExpr = createMemberExpr(ResourceExpr, HandleField);
   Stmt *AssignStmt = BinaryOperator::Create(
-      DeclBuilder.SemaRef.getASTContext(), HandleMemberExpr, HandleValueExpr,
-      BO_Assign, HandleMemberExpr->getType(), ExprValueKind::VK_PRValue,
+      getASTContext(), HandleMemberExpr, HandleValueExpr, BO_Assign,
+      HandleMemberExpr->getType(), ExprValueKind::VK_PRValue,
       ExprObjectKind::OK_Ordinary, SourceLocation(), FPOptionsOverride());
   StmtsList.push_back(AssignStmt);
   return *this;
@@ -919,11 +907,8 @@ BuiltinTypeMethodBuilder::accessCounterHandleFieldOnResource(T ResourceRecord) {
   assert(ResourceExpr->getType()->getAsCXXRecordDecl() == DeclBuilder.Record &&
          "Getting the field from the wrong resource type.");
 
-  ASTContext &AST = DeclBuilder.SemaRef.getASTContext();
   FieldDecl *HandleField = DeclBuilder.getResourceCounterHandleField();
-  MemberExpr *HandleExpr = MemberExpr::CreateImplicit(
-      AST, ResourceExpr, false, HandleField, HandleField->getType(), VK_LValue,
-      OK_Ordinary);
+  MemberExpr *HandleExpr = createMemberExpr(ResourceExpr, HandleField);
   StmtsList.push_back(HandleExpr);
   return *this;
 }
@@ -933,7 +918,7 @@ BuiltinTypeMethodBuilder &BuiltinTypeMethodBuilder::returnValue(T ReturnValue) {
   ensureCompleteDecl();
 
   Expr *ReturnValueExpr = convertPlaceholder(ReturnValue);
-  ASTContext &AST = DeclBuilder.SemaRef.getASTContext();
+  ASTContext &AST = getASTContext();
 
   QualType Ty = ReturnValueExpr->getType();
   if (Ty->isRecordType() && !Method->getReturnType()->isReferenceType()) {
@@ -964,7 +949,7 @@ BuiltinTypeMethodBuilder::finalize(AccessSpecifier Access) {
   ensureCompleteDecl();
 
   if (!Method->hasBody()) {
-    ASTContext &AST = DeclBuilder.SemaRef.getASTContext();
+    ASTContext &AST = getASTContext();
     assert((ReturnTy == AST.VoidTy || !StmtsList.empty()) &&
            "nothing to return from non-void method");
     if (ReturnTy != AST.VoidTy) {
@@ -1185,33 +1170,33 @@ BuiltinTypeDeclBuilder &BuiltinTypeDeclBuilder::addResourceMember(
     Expr *SampleCountExpr, AccessSpecifier Access) {
   assert(!Record->isCompleteDefinition() && "record is already complete");
 
-  ASTContext &Ctx = SemaRef.getASTContext();
+  ASTContext &AST = SemaRef.getASTContext();
 
   assert(!ElementTy.isNull() &&
          "The caller should always pass in the type for the handle.");
   TypeSourceInfo *ElementTypeInfo =
-      Ctx.getTrivialTypeSourceInfo(ElementTy, SourceLocation());
+      AST.getTrivialTypeSourceInfo(ElementTy, SourceLocation());
 
   // add handle member with resource type attributes
   QualType AttributedResTy = QualType();
   SmallVector<const Attr *> Attrs = {
-      HLSLResourceClassAttr::CreateImplicit(Ctx, RC),
-      IsROV ? HLSLIsROVAttr::CreateImplicit(Ctx) : nullptr,
-      RawBuffer ? HLSLRawBufferAttr::CreateImplicit(Ctx) : nullptr,
+      HLSLResourceClassAttr::CreateImplicit(AST, RC),
+      IsROV ? HLSLIsROVAttr::CreateImplicit(AST) : nullptr,
+      RawBuffer ? HLSLRawBufferAttr::CreateImplicit(AST) : nullptr,
       RD != ResourceDimension::Unknown
-          ? HLSLResourceDimensionAttr::CreateImplicit(Ctx, RD)
+          ? HLSLResourceDimensionAttr::CreateImplicit(AST, RD)
           : nullptr,
       ElementTypeInfo && RC != ResourceClass::Sampler
-          ? HLSLContainedTypeAttr::CreateImplicit(Ctx, ElementTypeInfo)
+          ? HLSLContainedTypeAttr::CreateImplicit(AST, ElementTypeInfo)
           : nullptr};
   if (IsCounter)
-    Attrs.push_back(HLSLIsCounterAttr::CreateImplicit(Ctx));
+    Attrs.push_back(HLSLIsCounterAttr::CreateImplicit(AST));
   if (IsArray)
-    Attrs.push_back(HLSLIsArrayAttr::CreateImplicit(Ctx));
+    Attrs.push_back(HLSLIsArrayAttr::CreateImplicit(AST));
   if (SampleCountExpr)
-    Attrs.push_back(HLSLIsMultiSampledAttr::CreateImplicit(Ctx));
+    Attrs.push_back(HLSLIsMultiSampledAttr::CreateImplicit(AST));
 
-  if (CreateHLSLAttributedResourceType(SemaRef, Ctx.HLSLResourceTy, Attrs,
+  if (CreateHLSLAttributedResourceType(SemaRef, AST.HLSLResourceTy, Attrs,
                                        AttributedResTy, /*LocInfo=*/nullptr,
                                        SampleCountExpr))
     addMemberVariable(MemberName, AttributedResTy, {}, Access);

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -3756,6 +3756,19 @@ static bool CheckResourceHandle(
   return false;
 }
 
+static QualType createCounterHandleType(ASTContext &AST,
+                                        QualType MainHandleTy) {
+  assert(MainHandleTy->isHLSLAttributedResourceType() &&
+         "expected resource handle type");
+  auto *MainResType = MainHandleTy->getAs<HLSLAttributedResourceType>();
+  auto MainAttrs = MainResType->getAttrs();
+  assert(!MainAttrs.IsCounter && "cannot create a counter from a counter");
+  MainAttrs.IsCounter = true;
+  return AST.getHLSLAttributedResourceType(MainResType->getWrappedType(),
+                                           MainResType->getContainedType(),
+                                           MainAttrs);
+}
+
 static bool CheckVectorElementCount(Sema *S, QualType PassedType,
                                     QualType BaseType, unsigned ExpectedCount,
                                     SourceLocation Loc) {
@@ -4364,15 +4377,10 @@ bool SemaHLSL::CheckBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
     assert(TheCall->getNumArgs() == 3 && "expected 3 args");
     ASTContext &AST = SemaRef.getASTContext();
     QualType MainHandleTy = TheCall->getArg(0)->getType();
-    auto *MainResType = MainHandleTy->getAs<HLSLAttributedResourceType>();
-    auto MainAttrs = MainResType->getAttrs();
-    assert(!MainAttrs.IsCounter && "cannot create a counter from a counter");
-    MainAttrs.IsCounter = true;
-    QualType CounterHandleTy = AST.getHLSLAttributedResourceType(
-        MainResType->getWrappedType(), MainResType->getContainedType(),
-        MainAttrs);
     // Update return type to be the attributed resource type from arg0
     // with added IsCounter flag.
+    QualType CounterHandleTy =
+        createCounterHandleType(SemaRef.getASTContext(), MainHandleTy);
     TheCall->setType(CounterHandleTy);
     break;
   }

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -4375,7 +4375,6 @@ bool SemaHLSL::CheckBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
   }
   case Builtin::BI__builtin_hlsl_resource_counterhandlefromimplicitbinding: {
     assert(TheCall->getNumArgs() == 3 && "expected 3 args");
-    ASTContext &AST = SemaRef.getASTContext();
     QualType MainHandleTy = TheCall->getArg(0)->getType();
     // Update return type to be the attributed resource type from arg0
     // with added IsCounter flag.


### PR DESCRIPTION
Creates helper functions for frequently used constructs in `HLSLBuiltinTypeDeclBuilder` and adds helper function for creating counter handle from a main resource handle in `SemaHLSL`.