### PR TITLE
[flang][cuda][NFC] Walk fir.call instead of greedy rewrite in CUFFunctionRewrite

### DIFF
--- a/flang/lib/Optimizer/Transforms/CUDA/CUFFunctionRewrite.cpp
+++ b/flang/lib/Optimizer/Transforms/CUDA/CUFFunctionRewrite.cpp
@@ -21,8 +21,6 @@
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LogicalResult.h"
-#include "mlir/Transforms/DialectConversion.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
@@ -41,17 +39,15 @@ using namespace mlir;
 namespace {
 
 using genFunctionType =
-    std::function<mlir::Value(mlir::PatternRewriter &, fir::CallOp op)>;
+    std::function<mlir::Value(mlir::RewriterBase &, fir::CallOp op)>;
 
-class CallConversion : public OpRewritePattern<fir::CallOp> {
+class CallConversion {
 public:
-  CallConversion(MLIRContext *context, bool deferAccRoutines)
-      : OpRewritePattern<fir::CallOp>(context),
-        deferAccRoutines_(deferAccRoutines) {}
+  explicit CallConversion(bool deferAccRoutines)
+      : deferAccRoutines_(deferAccRoutines) {}
 
-  LogicalResult
-  matchAndRewrite(fir::CallOp op,
-                  mlir::PatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(fir::CallOp op,
+                                mlir::RewriterBase &rewriter) const {
     auto callee = op.getCallee();
     if (!callee)
       return failure();
@@ -87,6 +83,7 @@ public:
           return failure();
     }
 
+    rewriter.setInsertionPoint(op);
     mlir::Value result = fct->second(rewriter, op);
     if (!result)
       return failure();
@@ -95,8 +92,7 @@ public:
   }
 
 private:
-  static mlir::Value genOnDevice(mlir::PatternRewriter &rewriter,
-                                 fir::CallOp op) {
+  static mlir::Value genOnDevice(mlir::RewriterBase &rewriter, fir::CallOp op) {
     // Only fold calls that match the intrinsic's shape: no arguments and a
     // single logical result.
     if (!op.getArgs().empty() || op.getNumResults() != 1)
@@ -126,17 +122,11 @@ public:
   using CUFFunctionRewriteBase::CUFFunctionRewriteBase;
 
   void runOnOperation() override {
-    auto *ctx = &getContext();
-    mlir::RewritePatternSet patterns(ctx);
-
-    patterns.insert<CallConversion>(patterns.getContext(), deferAccRoutines);
-
-    if (mlir::failed(
-            mlir::applyPatternsGreedily(getOperation(), std::move(patterns)))) {
-      mlir::emitError(mlir::UnknownLoc::get(ctx),
-                      "error in CUFFunctionRewrite op conversion\n");
-      signalPassFailure();
-    }
+    CallConversion conversion(deferAccRoutines);
+    mlir::IRRewriter rewriter(&getContext());
+    getOperation()->walk([&](fir::CallOp op) {
+      (void)conversion.matchAndRewrite(op, rewriter);
+    });
   }
 };
 

--- a/flang/test/Fir/CUDA/cuda-function-rewrite.mlir
+++ b/flang/test/Fir/CUDA/cuda-function-rewrite.mlir
@@ -23,7 +23,8 @@ gpu.module @cuda_device_mod {
 
 // CHECK-LABEL: gpu.module @cuda_device_mod
 // CHECK: func.func @_QMmtestsPdo2
-// CHECK: fir.if %true
+// CHECK: arith.constant true
+// CHECK-NOT: fir.call @on_device
 
 // -----
 
@@ -46,7 +47,8 @@ func.func @_QMmtestsPdo3(%arg0: !fir.ref<i32> {cuf.data_attr = #cuf.cuda<device>
 }
 
 // CHECK-LABEL: func.func @_QMmtestsPdo3
-// CHECK: fir.if %false
+// CHECK: arith.constant false
+// CHECK-NOT: fir.call @on_device
 
 // -----
 
@@ -70,7 +72,8 @@ gpu.module @acc_device_mod {
 
 // CHECK-LABEL: gpu.module @acc_device_mod
 // CHECK: func.func @_QMmtestPsub_device
-// CHECK: fir.if %true
+// CHECK: arith.constant true
+// CHECK-NOT: fir.call @_QPon_device
 
 // -----
 
@@ -91,7 +94,8 @@ func.func @_QMmtestPsub_host() {
 }
 
 // CHECK-LABEL: func.func @_QMmtestPsub_host
-// CHECK: fir.if %false
+// CHECK: arith.constant false
+// CHECK-NOT: fir.call @_QPon_device
 
 // -----
 
@@ -116,7 +120,8 @@ gpu.module @acc_extname_device_mod {
 
 // CHECK-LABEL: gpu.module @acc_extname_device_mod
 // CHECK: func.func @_QMmtestPsub_extname_device
-// CHECK: fir.if %true
+// CHECK: arith.constant true
+// CHECK-NOT: fir.call @on_device_
 
 // -----
 
@@ -137,12 +142,14 @@ func.func @_QMmtestPsub_extname_host() {
 }
 
 // CHECK-LABEL: func.func @_QMmtestPsub_extname_host
-// CHECK: fir.if %false
+// CHECK: arith.constant false
+// CHECK-NOT: fir.call @on_device_
 
 // A plain host function (not an OpenACC routine) is still folded to .false.
 // even with defer-acc-routines, which only defers OpenACC routine host copies.
 // DEFER-LABEL: func.func @_QMmtestPsub_extname_host
-// DEFER: fir.if %false
+// DEFER: arith.constant false
+// DEFER-NOT: fir.call @on_device_
 
 // -----
 
@@ -166,7 +173,8 @@ func.func @_QMmtestPaccroutine_host() attributes {acc.routine_info = #acc.routin
 }
 
 // CHECK-LABEL: func.func @_QMmtestPaccroutine_host
-// CHECK: fir.if %false
+// CHECK: arith.constant false
+// CHECK-NOT: fir.call @on_device_
 
 // DEFER-LABEL: func.func @_QMmtestPaccroutine_host
 // DEFER: fir.call @on_device_()
@@ -195,11 +203,13 @@ gpu.module @acc_routine_device_mod {
 
 // CHECK-LABEL: gpu.module @acc_routine_device_mod
 // CHECK: func.func @_QMmtestPaccroutine_device
-// CHECK: fir.if %true
+// CHECK: arith.constant true
+// CHECK-NOT: fir.call @on_device_
 
 // DEFER-LABEL: gpu.module @acc_routine_device_mod
 // DEFER: func.func @_QMmtestPaccroutine_device
-// DEFER: fir.if %true
+// DEFER: arith.constant true
+// DEFER-NOT: fir.call @on_device_
 
 // -----
 


### PR DESCRIPTION
The pass only replaces on_device() calls with a constant. The greedy pattern driver was extra work on every fir.call and also folded the surrounding convert chain. Walk with IRRewriter instead, and check for the i1 constant in the tests.

This reduce the footprint of the pass especially if there are many fir.call ops.