### PR TITLE
[KnownFPClass] Refactor direct access to `KnownFPClass::SignBit` [NFC]

### DIFF
--- a/llvm/include/llvm/Support/KnownFPClass.h
+++ b/llvm/include/llvm/Support/KnownFPClass.h
@@ -28,16 +28,21 @@ struct KnownFPClass {
   /// Floating-point classes the value could be one of.
   FPClassTest KnownFPClasses = fcAllFlags;
 
+  std::optional<bool> SignBitValue;
+
   /// std::nullopt if the sign bit is unknown, true if the sign bit is
   /// definitely set or false if the sign bit is definitely unset.
-  std::optional<bool> SignBit;
+  std::optional<bool> getSignBit() const { return SignBitValue; }
+
+  void setSignBit(std::optional<bool> Sign) { SignBitValue = Sign; }
 
   KnownFPClass(FPClassTest Known = fcAllFlags, std::optional<bool> Sign = {})
-      : KnownFPClasses(Known), SignBit(Sign) {}
+      : KnownFPClasses(Known), SignBitValue(Sign) {}
   LLVM_ABI KnownFPClass(const APFloat &C);
 
   bool operator==(KnownFPClass Other) const {
-    return KnownFPClasses == Other.KnownFPClasses && SignBit == Other.SignBit;
+    return KnownFPClasses == Other.KnownFPClasses &&
+           getSignBit() == Other.getSignBit();
   }
 
   /// Return true if it's known this can never be one of the mask entries.
@@ -47,7 +52,9 @@ struct KnownFPClass {
 
   bool isKnownAlways(FPClassTest Mask) const { return isKnownNever(~Mask); }
 
-  bool isUnknown() const { return KnownFPClasses == fcAllFlags && !SignBit; }
+  bool isUnknown() const {
+    return KnownFPClasses == fcAllFlags && !getSignBit();
+  }
 
   /// Return true if it's known this can never be a nan.
   bool isKnownNeverNaN() const { return isKnownNever(fcNan); }
@@ -152,15 +159,16 @@ struct KnownFPClass {
 
   KnownFPClass intersectWith(const KnownFPClass &RHS) const {
     return KnownFPClass(KnownFPClasses | RHS.KnownFPClasses,
-                        SignBit == RHS.SignBit ? SignBit : std::nullopt);
+                        getSignBit() == RHS.getSignBit() ? getSignBit()
+                                                         : std::nullopt);
   }
 
   KnownFPClass unionWith(const KnownFPClass &RHS) const {
     std::optional<bool> MergedSignBit;
-    if (SignBit && !RHS.SignBit)
-      MergedSignBit = SignBit;
-    else if (!SignBit && RHS.SignBit)
-      MergedSignBit = RHS.SignBit;
+    if (getSignBit() && !RHS.getSignBit())
+      MergedSignBit = getSignBit();
+    else if (!getSignBit() && RHS.getSignBit())
+      MergedSignBit = RHS.getSignBit();
 
     return KnownFPClass(KnownFPClasses & RHS.KnownFPClasses, MergedSignBit);
   }
@@ -168,25 +176,25 @@ struct KnownFPClass {
   KnownFPClass &operator|=(const KnownFPClass &RHS) {
     KnownFPClasses = KnownFPClasses | RHS.KnownFPClasses;
 
-    if (SignBit != RHS.SignBit)
-      SignBit = std::nullopt;
+    if (getSignBit() != RHS.getSignBit())
+      setSignBit(std::nullopt);
     return *this;
   }
 
   void knownNot(FPClassTest RuleOut) {
     KnownFPClasses = KnownFPClasses & ~RuleOut;
-    if (isKnownNever(fcNan) && !SignBit) {
+    if (isKnownNever(fcNan) && !getSignBit()) {
       if (isKnownNever(fcNegative))
-        SignBit = false;
+        setSignBit(false);
       else if (isKnownNever(fcPositive))
-        SignBit = true;
+        setSignBit(true);
     }
   }
 
   void fneg() {
     KnownFPClasses = llvm::fneg(KnownFPClasses);
-    if (SignBit)
-      SignBit = !*SignBit;
+    if (std::optional<bool> Sign = getSignBit())
+      setSignBit(!*Sign);
   }
 
   static KnownFPClass fneg(const KnownFPClass &Src) {
@@ -354,13 +362,13 @@ struct KnownFPClass {
   /// Assume the sign bit is zero.
   void signBitMustBeZero() {
     KnownFPClasses &= (fcPositive | fcNan);
-    SignBit = false;
+    setSignBit(false);
   }
 
   /// Assume the sign bit is one.
   void signBitMustBeOne() {
     KnownFPClasses &= (fcNegative | fcNan);
-    SignBit = true;
+    setSignBit(true);
   }
 
   void copysign(const KnownFPClass &Sign) {
@@ -376,12 +384,14 @@ struct KnownFPClass {
       KnownFPClasses |= fcInf;
 
     // Sign bit is exactly preserved even for nans.
-    SignBit = Sign.SignBit;
+    setSignBit(Sign.getSignBit());
 
     // Clear sign bits based on the input sign mask.
-    if (Sign.isKnownNever(fcPositive | fcNan) || (SignBit && *SignBit))
+    if (Sign.isKnownNever(fcPositive | fcNan) ||
+        (getSignBit() && *getSignBit()))
       KnownFPClasses &= (fcNegative | fcNan);
-    if (Sign.isKnownNever(fcNegative | fcNan) || (SignBit && !*SignBit))
+    if (Sign.isKnownNever(fcNegative | fcNan) ||
+        (getSignBit() && !*getSignBit()))
       KnownFPClasses &= (fcPositive | fcNan);
   }
 
@@ -412,7 +422,7 @@ struct KnownFPClass {
     if (Src.isKnownNever(fcNan)) {
       knownNot(fcNan);
       if (PreserveSign)
-        SignBit = Src.SignBit;
+        setSignBit(Src.getSignBit());
     }
   }
 

--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -6151,10 +6151,10 @@ static Value *simplifyFMAFMul(Value *Op0, Value *Op1, FastMathFlags FMF,
       if (FMF.noSignedZeros())
         return ConstantFP::getZero(Op0->getType());
       // +normal number * (-)0.0 --> (-)0.0
-      if (Known.SignBit == false)
+      if (Known.getSignBit() == false)
         return Op1;
       // -normal number * (-)0.0 --> -(-)0.0
-      if (Known.SignBit == true)
+      if (Known.getSignBit() == true)
         return foldConstant(Instruction::FNeg, Op1, Q);
     }
   }
@@ -6609,7 +6609,7 @@ static Value *simplifyUnaryIntrinsic(Intrinsic::ID IID, Value *Op0,
   switch (IID) {
   case Intrinsic::fabs: {
     KnownFPClass KnownClass = computeKnownFPClass(Op0, fcAllFlags, Q);
-    if (KnownClass.SignBit == false)
+    if (KnownClass.getSignBit() == false)
       return Op0;
 
     if (KnownClass.cannotBeOrderedLessThanZero() &&

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -5114,13 +5114,13 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
 
   if (isa<ConstantAggregateZero>(V)) {
     Known.KnownFPClasses = fcPosZero;
-    Known.SignBit = false;
+    Known.setSignBit(false);
     return;
   }
 
   if (isa<PoisonValue>(V)) {
     Known.KnownFPClasses = fcNone;
-    Known.SignBit = false;
+    Known.setSignBit(false);
     return;
   }
 
@@ -5159,7 +5159,7 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
         SignBitAllOne = false;
     }
     if (SignBitAllOne != SignBitAllZero)
-      Known.SignBit = SignBitAllOne;
+      Known.setSignBit(SignBitAllOne);
     return;
   }
 
@@ -5209,8 +5209,8 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
 
   llvm::scope_exit ClearClassesFromFlags([=, &Known] {
     Known.knownNot(KnownNotFromFlags);
-    if (!Known.SignBit && AssumedClasses.SignBit) {
-      if (*AssumedClasses.SignBit)
+    if (!Known.getSignBit() && AssumedClasses.getSignBit()) {
+      if (*AssumedClasses.getSignBit())
         Known.signBitMustBeOne();
       else
         Known.signBitMustBeZero();
@@ -5496,7 +5496,7 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
                                   InterestedClasses, Q, Depth + 1);
       // Can only propagate sign if output is never NaN.
       if (!Known.isKnownNeverNaN())
-        Known.SignBit.reset();
+        Known.setSignBit(std::nullopt);
       break;
     }
       // reverse preserves all characteristics of the input vec's element.
@@ -6457,7 +6457,7 @@ std::optional<bool> llvm::computeKnownFPSignBit(const Value *V,
                                                 const SimplifyQuery &SQ,
                                                 unsigned Depth) {
   KnownFPClass Known = computeKnownFPClass(V, fcAllFlags, SQ, Depth);
-  return Known.SignBit;
+  return Known.getSignBit();
 }
 
 bool llvm::canIgnoreSignBitOfZero(const Use &U) {

--- a/llvm/lib/CodeGen/GlobalISel/GISelValueTracking.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/GISelValueTracking.cpp
@@ -1205,7 +1205,7 @@ void GISelValueTracking::computeKnownFPClass(Register R,
     case GFConstant::GFConstantKind::Scalar: {
       auto APF = Cst->getScalarValue();
       Known.KnownFPClasses = APF.classify();
-      Known.SignBit = APF.isNegative();
+      Known.setSignBit(APF.isNegative());
       break;
     }
     case GFConstant::GFConstantKind::FixedVector: {
@@ -1222,7 +1222,7 @@ void GISelValueTracking::computeKnownFPClass(Register R,
       }
 
       if (SignBitAllOne != SignBitAllZero)
-        Known.SignBit = SignBitAllOne;
+        Known.setSignBit(SignBitAllOne);
 
       break;
     }
@@ -1579,7 +1579,7 @@ void GISelValueTracking::computeKnownFPClass(Register R,
         computeKnownFPClass(Val, MI.getFlags(), InterestedClasses, Depth + 1);
     // Can only propagate sign if output is never NaN.
     if (!Known.isKnownNeverNaN())
-      Known.SignBit.reset();
+      Known.setSignBit(std::nullopt);
     break;
   }
   case TargetOpcode::G_FFLOOR:

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -6152,7 +6152,7 @@ KnownFPClass SelectionDAG::computeKnownFPClass(SDValue Op,
   switch (Opcode) {
   case ISD::POISON: {
     Known.KnownFPClasses = fcNone;
-    Known.SignBit = false;
+    Known.setSignBit(false);
     break;
   }
   case ISD::FNEG: {

--- a/llvm/lib/Support/KnownFPClass.cpp
+++ b/llvm/lib/Support/KnownFPClass.cpp
@@ -18,8 +18,9 @@
 
 using namespace llvm;
 
-KnownFPClass::KnownFPClass(const APFloat &C)
-    : KnownFPClasses(C.classify()), SignBit(C.isNegative()) {}
+KnownFPClass::KnownFPClass(const APFloat &C) : KnownFPClasses(C.classify()) {
+  setSignBit(C.isNegative());
+}
 
 /// Return true if it's possible to assume IEEE treatment of input denormals in
 /// \p F for \p Val.
@@ -140,9 +141,9 @@ KnownFPClass KnownFPClass::minMaxLike(const KnownFPClass &LHS_,
   }
 
   if (Known.isKnownNeverNaN()) {
-    if (KnownLHS.SignBit && KnownRHS.SignBit &&
-        *KnownLHS.SignBit == *KnownRHS.SignBit) {
-      if (*KnownLHS.SignBit)
+    if (KnownLHS.getSignBit() && KnownRHS.getSignBit() &&
+        *KnownLHS.getSignBit() == *KnownRHS.getSignBit()) {
+      if (*KnownLHS.getSignBit())
         Known.signBitMustBeOne();
       else
         Known.signBitMustBeZero();
@@ -156,16 +157,16 @@ KnownFPClass KnownFPClass::minMaxLike(const KnownFPClass &LHS_,
                  KnownRHS.isKnownNeverNegZero()))) {
       // Don't take sign bit from NaN operands.
       if (!KnownLHS.isKnownNeverNaN())
-        KnownLHS.SignBit = std::nullopt;
+        KnownLHS.setSignBit(std::nullopt);
       if (!KnownRHS.isKnownNeverNaN())
-        KnownRHS.SignBit = std::nullopt;
+        KnownRHS.setSignBit(std::nullopt);
       if ((Kind == MinMaxKind::maximum || Kind == MinMaxKind::maximumnum ||
            Kind == MinMaxKind::maxnum) &&
-          (KnownLHS.SignBit == false || KnownRHS.SignBit == false))
+          (KnownLHS.getSignBit() == false || KnownRHS.getSignBit() == false))
         Known.signBitMustBeZero();
       else if ((Kind == MinMaxKind::minimum || Kind == MinMaxKind::minimumnum ||
                 Kind == MinMaxKind::minnum) &&
-               (KnownLHS.SignBit == true || KnownRHS.SignBit == true))
+               (KnownLHS.getSignBit() == true || KnownRHS.getSignBit() == true))
         Known.signBitMustBeOne();
     }
   }
@@ -305,8 +306,8 @@ KnownBits KnownFPClass::toKnownBits(const fltSemantics &FltSemantics) const {
     Known.One.clearSignBit();
   }
 
-  if (SignBit) {
-    if (*SignBit)
+  if (std::optional<bool> Sign = getSignBit()) {
+    if (*Sign)
       Known.makeNegative();
     else
       Known.makeNonNegative();
@@ -779,7 +780,7 @@ KnownFPClass KnownFPClass::fpext(const KnownFPClass &KnownSrc,
 
   // Sign bit of a nan isn't guaranteed.
   if (!Known.isKnownNeverNaN())
-    Known.SignBit = std::nullopt;
+    Known.setSignBit(std::nullopt);
 
   return Known;
 }

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -2130,7 +2130,7 @@ static Value *simplifyDemandedFPClassFabs(KnownFPClass &Known, Value *Src,
   if ((DemandedMask & fcInf) == fcNone)
     KnownSrc.knownNot(fcInf);
 
-  if (KnownSrc.SignBit == false ||
+  if (KnownSrc.getSignBit() == false ||
       ((DemandedMask & fcNan) == fcNone && KnownSrc.isKnownNever(fcNegative)))
     return Src;
 
@@ -2213,7 +2213,7 @@ static Value *simplifyDemandedFPClassFnegFabs(KnownFPClass &Known, Value *Src,
     KnownSrc.knownNot(fcInf);
 
   // If the source value is known negative, we can directly fold to it.
-  if (KnownSrc.SignBit == true)
+  if (KnownSrc.getSignBit() == true)
     return Src;
 
   // If the only sign bit difference is for 0, ignore it with nsz.
@@ -2242,10 +2242,11 @@ static Value *simplifyDemandedFPClassCopysignMag(Value *MagSrc,
         KnownSrc.isKnownAlways(PosOrZero))
       return MagSrc;
   } else {
-    if ((DemandedMask & ~fcNegative) == fcNone && KnownSrc.SignBit == true)
+    if ((DemandedMask & ~fcNegative) == fcNone && KnownSrc.getSignBit() == true)
       return MagSrc;
 
-    if ((DemandedMask & ~fcPositive) == fcNone && KnownSrc.SignBit == false)
+    if ((DemandedMask & ~fcPositive) == fcNone &&
+        KnownSrc.getSignBit() == false)
       return MagSrc;
   }
 
@@ -2425,7 +2426,7 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
         KnownSrc.knownNot(fcInf);
 
       // fneg(fabs(x)) => fneg(x)
-      if (KnownSrc.SignBit == false)
+      if (KnownSrc.getSignBit() == false)
         return replaceOperand(*I, 0, FNegFAbsSrc);
 
       // fneg(fabs(x)) => fneg(x), ignoring -0 if nsz.
@@ -2933,8 +2934,8 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
 
       KnownFPClass KnownSign =
           computeKnownFPClass(CI->getArgOperand(1), fcAllFlags, SQ, Depth + 1);
-      if (KnownMag.SignBit && KnownSign.SignBit &&
-          *KnownMag.SignBit == *KnownSign.SignBit)
+      if (KnownMag.getSignBit() && KnownSign.getSignBit() &&
+          *KnownMag.getSignBit() == *KnownSign.getSignBit())
         return CI->getOperand(0);
 
       // TODO: Call argument attribute not considered
@@ -2942,13 +2943,13 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
       if (FMF.noNaNs())
         KnownSign.knownNot(fcNan);
 
-      if (KnownSign.SignBit == false) {
+      if (KnownSign.getSignBit() == false) {
         CI->dropUBImplyingAttrsAndMetadata();
         CI->setOperand(1, ConstantFP::getZero(VTy));
         return I;
       }
 
-      if (KnownSign.SignBit == true) {
+      if (KnownSign.getSignBit() == true) {
         CI->dropUBImplyingAttrsAndMetadata();
         CI->setOperand(1, ConstantFP::get(VTy, -1.0));
         return I;
@@ -3707,8 +3708,8 @@ Value *InstCombinerImpl::SimplifyMultipleUseDemandedFPClass(
       if (FMF.noNaNs())
         KnownSign.knownNot(fcNan);
 
-      if (KnownSign.SignBit && KnownMag.SignBit &&
-          *KnownSign.SignBit == *KnownMag.SignBit)
+      if (KnownSign.getSignBit() && KnownMag.getSignBit() &&
+          *KnownSign.getSignBit() == *KnownMag.getSignBit())
         return Mag;
 
       Known = KnownFPClass::copysign(KnownMag, KnownSign);

--- a/llvm/unittests/Analysis/ValueTrackingTest.cpp
+++ b/llvm/unittests/Analysis/ValueTrackingTest.cpp
@@ -127,7 +127,7 @@ protected:
 
     KnownFPClass Known = computeKnownFPClass(TestVal, M->getDataLayout());
     EXPECT_EQ(KnownTrue, Known.KnownFPClasses);
-    EXPECT_EQ(SignBitKnown, Known.SignBit);
+    EXPECT_EQ(SignBitKnown, Known.getSignBit());
   }
 };
 }
@@ -2357,13 +2357,13 @@ TEST_F(ComputeKnownFPClassTest, SqrtNszSignBit) {
         computeKnownFPClass(A, M->getDataLayout(), fcAllFlags, nullptr, nullptr,
                             nullptr, nullptr, /*UseInstrInfo=*/true);
     EXPECT_EQ(SqrtMask, UseInstrInfo.KnownFPClasses);
-    EXPECT_EQ(std::nullopt, UseInstrInfo.SignBit);
+    EXPECT_EQ(std::nullopt, UseInstrInfo.getSignBit());
 
     KnownFPClass NoUseInstrInfo =
         computeKnownFPClass(A, M->getDataLayout(), fcAllFlags, nullptr, nullptr,
                             nullptr, nullptr, /*UseInstrInfo=*/false);
     EXPECT_EQ(SqrtMask, NoUseInstrInfo.KnownFPClasses);
-    EXPECT_EQ(std::nullopt, NoUseInstrInfo.SignBit);
+    EXPECT_EQ(std::nullopt, NoUseInstrInfo.getSignBit());
   }
 
   {
@@ -2371,13 +2371,13 @@ TEST_F(ComputeKnownFPClassTest, SqrtNszSignBit) {
         computeKnownFPClass(A2, M->getDataLayout(), fcAllFlags, nullptr,
                             nullptr, nullptr, nullptr, /*UseInstrInfo=*/true);
     EXPECT_EQ(NszSqrtMask, UseInstrInfoNSZ.KnownFPClasses);
-    EXPECT_EQ(std::nullopt, UseInstrInfoNSZ.SignBit);
+    EXPECT_EQ(std::nullopt, UseInstrInfoNSZ.getSignBit());
 
     KnownFPClass NoUseInstrInfoNSZ =
         computeKnownFPClass(A2, M->getDataLayout(), fcAllFlags, nullptr,
                             nullptr, nullptr, nullptr, /*UseInstrInfo=*/false);
     EXPECT_EQ(SqrtMask, NoUseInstrInfoNSZ.KnownFPClasses);
-    EXPECT_EQ(std::nullopt, NoUseInstrInfoNSZ.SignBit);
+    EXPECT_EQ(std::nullopt, NoUseInstrInfoNSZ.getSignBit());
   }
 
   {
@@ -2386,14 +2386,14 @@ TEST_F(ComputeKnownFPClassTest, SqrtNszSignBit) {
                             nullptr, nullptr, nullptr, /*UseInstrInfo=*/true);
     EXPECT_EQ(fcPosInf | fcPosNormal | fcZero | fcQNan,
               UseInstrInfoNoNan.KnownFPClasses);
-    EXPECT_EQ(std::nullopt, UseInstrInfoNoNan.SignBit);
+    EXPECT_EQ(std::nullopt, UseInstrInfoNoNan.getSignBit());
 
     KnownFPClass NoUseInstrInfoNoNan =
         computeKnownFPClass(A3, M->getDataLayout(), fcAllFlags, nullptr,
                             nullptr, nullptr, nullptr, /*UseInstrInfo=*/false);
     EXPECT_EQ(fcPosNormal | fcPosInf | fcZero | fcQNan,
               NoUseInstrInfoNoNan.KnownFPClasses);
-    EXPECT_EQ(std::nullopt, NoUseInstrInfoNoNan.SignBit);
+    EXPECT_EQ(std::nullopt, NoUseInstrInfoNoNan.getSignBit());
   }
 
   {
@@ -2402,14 +2402,14 @@ TEST_F(ComputeKnownFPClassTest, SqrtNszSignBit) {
                             nullptr, nullptr, nullptr, /*UseInstrInfo=*/true);
     EXPECT_EQ(fcPosInf | fcPosNormal | fcPosZero | fcQNan,
               UseInstrInfoNSZNoNan.KnownFPClasses);
-    EXPECT_EQ(std::nullopt, UseInstrInfoNSZNoNan.SignBit);
+    EXPECT_EQ(std::nullopt, UseInstrInfoNSZNoNan.getSignBit());
 
     KnownFPClass NoUseInstrInfoNSZNoNan =
         computeKnownFPClass(A4, M->getDataLayout(), fcAllFlags, nullptr,
                             nullptr, nullptr, nullptr, /*UseInstrInfo=*/false);
     EXPECT_EQ(fcPosInf | fcPosNormal | fcZero | fcQNan,
               NoUseInstrInfoNSZNoNan.KnownFPClasses);
-    EXPECT_EQ(std::nullopt, NoUseInstrInfoNSZNoNan.SignBit);
+    EXPECT_EQ(std::nullopt, NoUseInstrInfoNSZNoNan.getSignBit());
   }
 }
 
@@ -2428,23 +2428,23 @@ TEST_F(ComputeKnownFPClassTest, Constants) {
         ConstantAggregateZero::get(V4F32), M->getDataLayout(), fcAllFlags);
 
     EXPECT_EQ(fcPosZero, ConstAggZero.KnownFPClasses);
-    ASSERT_TRUE(ConstAggZero.SignBit);
-    EXPECT_FALSE(*ConstAggZero.SignBit);
+    ASSERT_TRUE(ConstAggZero.getSignBit());
+    EXPECT_FALSE(*ConstAggZero.getSignBit());
   }
 
   {
     KnownFPClass Undef = computeKnownFPClass(UndefValue::get(F32),
                                              M->getDataLayout(), fcAllFlags);
     EXPECT_EQ(fcAllFlags, Undef.KnownFPClasses);
-    EXPECT_FALSE(Undef.SignBit);
+    EXPECT_FALSE(Undef.getSignBit());
   }
 
   {
     KnownFPClass Poison = computeKnownFPClass(PoisonValue::get(F32),
                                               M->getDataLayout(), fcAllFlags);
     EXPECT_EQ(fcNone, Poison.KnownFPClasses);
-    ASSERT_TRUE(Poison.SignBit);
-    EXPECT_FALSE(*Poison.SignBit);
+    ASSERT_TRUE(Poison.getSignBit());
+    EXPECT_FALSE(*Poison.getSignBit());
   }
 
   {
@@ -2456,8 +2456,8 @@ TEST_F(ComputeKnownFPClassTest, Constants) {
         computeKnownFPClass(ConstantVector::get({ZeroF32, PoisonF32}),
                             M->getDataLayout(), fcAllFlags);
     EXPECT_EQ(fcPosZero, PartiallyPoison.KnownFPClasses);
-    ASSERT_TRUE(PartiallyPoison.SignBit);
-    EXPECT_FALSE(*PartiallyPoison.SignBit);
+    ASSERT_TRUE(PartiallyPoison.getSignBit());
+    EXPECT_FALSE(*PartiallyPoison.getSignBit());
   }
 
   {
@@ -2469,8 +2469,8 @@ TEST_F(ComputeKnownFPClassTest, Constants) {
         computeKnownFPClass(ConstantVector::get({NegZeroF32, PoisonF32}),
                             M->getDataLayout(), fcAllFlags);
     EXPECT_EQ(fcNegZero, PartiallyPoison.KnownFPClasses);
-    ASSERT_TRUE(PartiallyPoison.SignBit);
-    EXPECT_TRUE(*PartiallyPoison.SignBit);
+    ASSERT_TRUE(PartiallyPoison.getSignBit());
+    EXPECT_TRUE(*PartiallyPoison.getSignBit());
   }
 
   {
@@ -2482,7 +2482,7 @@ TEST_F(ComputeKnownFPClassTest, Constants) {
         computeKnownFPClass(ConstantVector::get({PoisonF32, NegZeroF32}),
                             M->getDataLayout(), fcAllFlags);
     EXPECT_EQ(fcNegZero, PartiallyPoison.KnownFPClasses);
-    EXPECT_TRUE(PartiallyPoison.SignBit);
+    EXPECT_TRUE(PartiallyPoison.getSignBit());
   }
 }
 

--- a/llvm/unittests/CodeGen/GlobalISel/KnownFPClassTest.cpp
+++ b/llvm/unittests/CodeGen/GlobalISel/KnownFPClassTest.cpp
@@ -28,7 +28,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCstPosZero) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPosZero, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassCstNegZero) {
@@ -46,7 +46,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCstNegZero) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcNegZero, Known.KnownFPClasses);
-  EXPECT_EQ(true, Known.SignBit);
+  EXPECT_EQ(true, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassUndef) {
@@ -68,7 +68,7 @@ TEST_F(AArch64GISelMITest, TestFPClassUndef) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcAllFlags, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassCstVecNegZero) {
@@ -93,7 +93,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCstVecNegZero) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcNegZero, Known.KnownFPClasses);
-  EXPECT_EQ(true, Known.SignBit);
+  EXPECT_EQ(true, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassCstZeroFPExt) {
@@ -116,7 +116,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCstZeroFPExt) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPosZero, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassCstVecZeroFPExt) {
@@ -142,7 +142,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCstVecZeroFPExt) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPosZero, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassCstZeroFPTrunc) {
@@ -165,7 +165,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCstZeroFPTrunc) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPosFinite | fcNegZero, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassCstVecZeroFPTrunc) {
@@ -191,7 +191,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCstVecZeroFPTrunc) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPosFinite | fcNegZero, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassSelectPos0) {
@@ -217,7 +217,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSelectPos0) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPosZero, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassSelectNeg0) {
@@ -243,7 +243,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSelectNeg0) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcNegZero, Known.KnownFPClasses);
-  EXPECT_EQ(true, Known.SignBit);
+  EXPECT_EQ(true, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassSelectPosOrNeg0) {
@@ -269,7 +269,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSelectPosOrNeg0) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcZero, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassSelectPosInf) {
@@ -295,7 +295,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSelectPosInf) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPosInf, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassSelectNegInf) {
@@ -321,7 +321,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSelectNegInf) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcNegInf, Known.KnownFPClasses);
-  EXPECT_EQ(true, Known.SignBit);
+  EXPECT_EQ(true, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassSelectPosOrNegInf) {
@@ -347,7 +347,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSelectPosOrNegInf) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcInf, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassSelectNNaN) {
@@ -373,7 +373,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSelectNNaN) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(~fcNan, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassSelectNInf) {
@@ -399,7 +399,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSelectNInf) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(~fcInf, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassSelectNNaNNInf) {
@@ -425,7 +425,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSelectNNaNNInf) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(~(fcNan | fcInf), Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFNegNInf) {
@@ -449,7 +449,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFNegNInf) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(~fcInf, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFabsUnknown) {
@@ -473,7 +473,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFabsUnknown) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPositive | fcNan, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassVecFabsUnknown) {
@@ -497,7 +497,7 @@ TEST_F(AArch64GISelMITest, TestFPClassVecFabsUnknown) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPositive | fcNan, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFnegFabs) {
@@ -522,7 +522,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFnegFabs) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcNegative | fcNan, Known.KnownFPClasses);
-  EXPECT_EQ(true, Known.SignBit);
+  EXPECT_EQ(true, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFnegFabsNInf) {
@@ -547,7 +547,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFnegFabsNInf) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcNegFinite | fcNan, Known.KnownFPClasses);
-  EXPECT_EQ(true, Known.SignBit);
+  EXPECT_EQ(true, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFnegFabsNNan) {
@@ -572,7 +572,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFnegFabsNNan) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcNegative, Known.KnownFPClasses);
-  EXPECT_EQ(true, Known.SignBit);
+  EXPECT_EQ(true, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassCopySignNNanSrc0) {
@@ -598,7 +598,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCopySignNNanSrc0) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(~fcNan, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassCopySignNInfSrc0_NegSign) {
@@ -624,7 +624,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCopySignNInfSrc0_NegSign) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcNan | fcNegZero | fcNegNormal, Known.KnownFPClasses);
-  EXPECT_EQ(true, Known.SignBit);
+  EXPECT_EQ(true, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassCopySignNInfSrc0_PosSign) {
@@ -650,7 +650,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCopySignNInfSrc0_PosSign) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcNan | fcPosZero | fcPosNormal, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassUIToFP) {
@@ -674,7 +674,7 @@ TEST_F(AArch64GISelMITest, TestFPClassUIToFP) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPosZero | fcPosNormal, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassSIToFP) {
@@ -698,7 +698,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSIToFP) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPosNormal | fcNegNormal | fcPosZero, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFAdd) {
@@ -723,7 +723,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFAdd) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcAllFlags, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFAdd_Zero) {
@@ -748,7 +748,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFAdd_Zero) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcAllFlags & ~fcNegZero, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFAdd_NegZero) {
@@ -773,7 +773,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFAdd_NegZero) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcAllFlags, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFstrictAdd_Zero) {
@@ -798,7 +798,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFstrictAdd_Zero) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcAllFlags & ~fcNegZero, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFMul) {
@@ -823,7 +823,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFMul) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPositive | fcNan, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFMulZero) {
@@ -849,7 +849,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFMulZero) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPosZero, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFLogNeg) {
@@ -875,7 +875,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFLogNeg) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcNan | fcNegInf | fcPosZero | fcNormal, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFLogPosZero) {
@@ -898,7 +898,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFLogPosZero) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcNegInf | fcPosZero | fcNormal, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFLogNegZero) {
@@ -921,7 +921,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFLogNegZero) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcNegInf | fcPosZero | fcNormal, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassCopy) {
@@ -946,7 +946,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCopy) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(~fcNegative, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassSelectIsFPClass) {
@@ -972,7 +972,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSelectIsFPClass) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcZero, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFLDExp) {
@@ -998,7 +998,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFLDExp) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPositive | fcNan, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFPowPos) {
@@ -1023,7 +1023,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFPowPos) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPositive | fcNan, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
   EXPECT_TRUE(Info.isKnownNeverNaN(SrcReg, true));
 }
 
@@ -1050,7 +1050,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFPowPosNNaN) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPositive, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFPowIEvenExp) {
@@ -1075,7 +1075,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFPowIEvenExp) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPositive | fcNan, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFPowIPos) {
@@ -1101,7 +1101,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFPowIPos) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPositive, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFPowIInf) {
@@ -1141,7 +1141,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFPowIInf) {
   KnownFPClass Known0 = Info.computeKnownFPClass(SrcReg0, fcAllFlags);
   KnownFPClass KnownInf0 = Info.computeKnownFPClass(SrcReg0, fcInf);
   EXPECT_EQ(~fcInf, Known0.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known0.SignBit);
+  EXPECT_EQ(std::nullopt, Known0.getSignBit());
   EXPECT_TRUE(KnownInf0.isKnownNeverInfinity());
 
   // powi(finite, 2)  -->  fcPositive | fcNan
@@ -1151,7 +1151,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFPowIInf) {
   KnownFPClass Known1 = Info.computeKnownFPClass(SrcReg1, fcAllFlags);
   KnownFPClass KnownInf1 = Info.computeKnownFPClass(SrcReg1, fcInf);
   EXPECT_EQ(fcPositive | fcNan, Known1.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known1.SignBit);
+  EXPECT_EQ(std::nullopt, Known1.getSignBit());
   EXPECT_FALSE(KnownInf1.isKnownNeverInfinity());
 
   // powi(normal, -1)  -->  fcPosFinite
@@ -1161,7 +1161,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFPowIInf) {
   KnownFPClass Known2 = Info.computeKnownFPClass(SrcReg2, fcAllFlags);
   KnownFPClass KnownInf2 = Info.computeKnownFPClass(SrcReg2, fcInf);
   EXPECT_EQ(fcPosFinite, Known2.KnownFPClasses);
-  EXPECT_EQ(false, Known2.SignBit);
+  EXPECT_EQ(false, Known2.getSignBit());
   EXPECT_TRUE(KnownInf2.isKnownNeverInfinity());
 
   // powi(zero_or_nan, nonneg)  -->  ~fcInf
@@ -1196,7 +1196,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFDiv) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPosNormal | fcNan, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFDiv_Inf) {
@@ -1220,7 +1220,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFDiv_Inf) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPosInf, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFDivSqrt) {
@@ -1247,7 +1247,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFDivSqrt) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcAllFlags & ~(fcNegNormal | fcNegSubnormal), Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFDivNegSqrtNeg) {
@@ -1275,7 +1275,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFDivNegSqrtNeg) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg, fcPositive);
 
   EXPECT_EQ(fcAllFlags & ~(fcPosNormal | fcPosSubnormal), Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassSqrtFDiv) {
@@ -1302,7 +1302,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSqrtFDiv) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcNan | fcZero | fcPosNormal | fcPosInf, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFRem) {
@@ -1327,7 +1327,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFRem) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcZero | fcNan, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFRemSelf_KnownFiniteNonZero) {
@@ -1379,7 +1379,7 @@ TEST_F(AArch64GISelMITest, TestFPClassShuffleVec) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPosFinite, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassBuildVec) {
@@ -1405,7 +1405,7 @@ TEST_F(AArch64GISelMITest, TestFPClassBuildVec) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPosFinite, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassConcatVec) {
@@ -1434,7 +1434,7 @@ TEST_F(AArch64GISelMITest, TestFPClassConcatVec) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPosFinite, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassVecExtractElem) {
@@ -1460,7 +1460,7 @@ TEST_F(AArch64GISelMITest, TestFPClassVecExtractElem) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPosFinite, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassVecInsertElem) {
@@ -1488,7 +1488,7 @@ TEST_F(AArch64GISelMITest, TestFPClassVecInsertElem) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPosFinite, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFSinh) {
@@ -1507,7 +1507,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFSinh) {
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
   EXPECT_EQ(fcAllFlags, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFSinhPos) {
@@ -1528,7 +1528,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFSinhPos) {
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
   EXPECT_EQ(fcPositive, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFCosh) {
@@ -1548,7 +1548,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFCosh) {
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
   EXPECT_EQ(fcPosNormal | fcPosInf | fcNan, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFCoshNNaN) {
@@ -1569,7 +1569,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFCoshNNaN) {
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
   EXPECT_EQ(fcPosNormal | fcPosInf, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFTanh) {
@@ -1589,7 +1589,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFTanh) {
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
   EXPECT_EQ(fcAllFlags & ~fcInf, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFTanhPos) {
@@ -1610,7 +1610,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFTanhPos) {
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
   EXPECT_EQ(fcPosFinite, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFAsin) {
@@ -1630,7 +1630,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFAsin) {
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
   EXPECT_EQ(fcAllFlags & ~fcInf, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFAsinPos) {
@@ -1652,7 +1652,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFAsinPos) {
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
   EXPECT_EQ(fcPosFinite | fcQNan, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFAcos) {
@@ -1672,7 +1672,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFAcos) {
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
   EXPECT_EQ(fcPosZero | fcPosNormal | fcNan, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFAcosPos) {
@@ -1694,7 +1694,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFAcosPos) {
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
   EXPECT_EQ(fcPosZero | fcPosNormal | fcQNan, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFAtan) {
@@ -1714,7 +1714,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFAtan) {
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
   EXPECT_EQ(fcAllFlags & ~fcInf, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFAtanPos) {
@@ -1735,7 +1735,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFAtanPos) {
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
   EXPECT_EQ(fcPosFinite, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.SignBit);
+  EXPECT_EQ(false, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFTan) {
@@ -1755,7 +1755,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFTan) {
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
   EXPECT_EQ(fcAllFlags & ~fcInf, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFTanNNaN) {
@@ -1776,7 +1776,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFTanNNaN) {
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
   EXPECT_EQ(fcFinite, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFAtan2) {
@@ -1797,7 +1797,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFAtan2) {
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
   EXPECT_EQ(fcAllFlags & ~fcInf, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFAtan2NNaN) {
@@ -1820,7 +1820,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFAtan2NNaN) {
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
   EXPECT_EQ(fcFinite, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 // isAbsoluteValueULEOne: x - floor(x) is in [0, 1), so multiplying a known-
@@ -1845,7 +1845,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFMulAbsULEOne) {
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
   EXPECT_EQ(~fcInf, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 // G_FMA with A == B (and A guaranteed not-undef): the multiply part is a
@@ -1868,5 +1868,5 @@ TEST_F(AArch64GISelMITest, TestFPClassFMASelfSquare) {
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
   EXPECT_EQ(fcNan | fcPosInf | fcPosNormal, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }

--- a/llvm/unittests/Target/AArch64/AArch64SelectionDAGTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64SelectionDAGTest.cpp
@@ -1685,22 +1685,22 @@ TEST_F(AArch64SelectionDAGTest, ComputeKnownFPClass_ConstantScalar) {
                                        Loc, MVT::f32);
   KnownFPClass Known = DAG->computeKnownFPClass(PosZero, fcAllFlags);
   EXPECT_EQ(Known.KnownFPClasses, fcPosZero);
-  EXPECT_TRUE(Known.SignBit.has_value());
-  EXPECT_FALSE(*Known.SignBit);
+  EXPECT_TRUE(Known.getSignBit().has_value());
+  EXPECT_FALSE(*Known.getSignBit());
 
   SDValue NegZero = DAG->getConstantFP(
       APFloat::getZero(APFloat::IEEEsingle(), true), Loc, MVT::f32);
   Known = DAG->computeKnownFPClass(NegZero, fcAllFlags);
   EXPECT_EQ(Known.KnownFPClasses, fcNegZero);
-  EXPECT_TRUE(Known.SignBit.has_value());
-  EXPECT_TRUE(*Known.SignBit);
+  EXPECT_TRUE(Known.getSignBit().has_value());
+  EXPECT_TRUE(*Known.getSignBit());
 
   SDValue PosInf =
       DAG->getConstantFP(APFloat::getInf(APFloat::IEEEsingle()), Loc, MVT::f32);
   Known = DAG->computeKnownFPClass(PosInf, fcAllFlags);
   EXPECT_EQ(Known.KnownFPClasses, fcPosInf);
-  EXPECT_TRUE(Known.SignBit.has_value());
-  EXPECT_FALSE(*Known.SignBit);
+  EXPECT_TRUE(Known.getSignBit().has_value());
+  EXPECT_FALSE(*Known.getSignBit());
 
   SDValue QNaN = DAG->getConstantFP(APFloat::getQNaN(APFloat::IEEEsingle()),
                                     Loc, MVT::f32);
@@ -1710,8 +1710,8 @@ TEST_F(AArch64SelectionDAGTest, ComputeKnownFPClass_ConstantScalar) {
   SDValue One = DAG->getConstantFP(1.0, Loc, MVT::f32);
   Known = DAG->computeKnownFPClass(One, fcAllFlags);
   EXPECT_EQ(Known.KnownFPClasses, fcPosNormal);
-  EXPECT_TRUE(Known.SignBit.has_value());
-  EXPECT_FALSE(*Known.SignBit);
+  EXPECT_TRUE(Known.getSignBit().has_value());
+  EXPECT_FALSE(*Known.getSignBit());
 }
 
 TEST_F(AArch64SelectionDAGTest, ComputeKnownFPClass_BuildVector) {
@@ -1726,13 +1726,13 @@ TEST_F(AArch64SelectionDAGTest, ComputeKnownFPClass_BuildVector) {
   SDValue VecPosPos = DAG->getBuildVector(VecVT, Loc, {PosOne, PosTwo});
   KnownFPClass Known = DAG->computeKnownFPClass(VecPosPos, fcAllFlags);
   EXPECT_EQ(Known.KnownFPClasses, fcPosNormal);
-  EXPECT_TRUE(Known.SignBit.has_value());
-  EXPECT_FALSE(*Known.SignBit);
+  EXPECT_TRUE(Known.getSignBit().has_value());
+  EXPECT_FALSE(*Known.getSignBit());
 
   SDValue VecPosNeg = DAG->getBuildVector(VecVT, Loc, {PosOne, NegOne});
   Known = DAG->computeKnownFPClass(VecPosNeg, fcAllFlags);
   EXPECT_EQ(Known.KnownFPClasses, fcPosNormal | fcNegNormal);
-  EXPECT_FALSE(Known.SignBit.has_value());
+  EXPECT_FALSE(Known.getSignBit().has_value());
 }
 
 TEST_F(AArch64SelectionDAGTest, ComputeKnownFPClass_DemandedElts) {
@@ -1746,24 +1746,24 @@ TEST_F(AArch64SelectionDAGTest, ComputeKnownFPClass_DemandedElts) {
   APInt DemandLo(2, 1);
   KnownFPClass Known = DAG->computeKnownFPClass(Vec, DemandLo, fcAllFlags);
   EXPECT_EQ(Known.KnownFPClasses, fcPosNormal);
-  EXPECT_TRUE(Known.SignBit.has_value());
-  EXPECT_FALSE(*Known.SignBit);
+  EXPECT_TRUE(Known.getSignBit().has_value());
+  EXPECT_FALSE(*Known.getSignBit());
 
   APInt DemandHi(2, 2);
   Known = DAG->computeKnownFPClass(Vec, DemandHi, fcAllFlags);
   EXPECT_EQ(Known.KnownFPClasses, fcNegNormal);
-  EXPECT_TRUE(Known.SignBit.has_value());
-  EXPECT_TRUE(*Known.SignBit);
+  EXPECT_TRUE(Known.getSignBit().has_value());
+  EXPECT_TRUE(*Known.getSignBit());
 
   APInt DemandAll(2, 3);
   Known = DAG->computeKnownFPClass(Vec, DemandAll, fcAllFlags);
   EXPECT_EQ(Known.KnownFPClasses, fcPosNormal | fcNegNormal);
-  EXPECT_FALSE(Known.SignBit.has_value());
+  EXPECT_FALSE(Known.getSignBit().has_value());
 
   APInt DemandNone(2, 0);
   Known = DAG->computeKnownFPClass(Vec, DemandNone, fcAllFlags);
   EXPECT_EQ(Known.KnownFPClasses, fcAllFlags);
-  EXPECT_FALSE(Known.SignBit.has_value());
+  EXPECT_FALSE(Known.getSignBit().has_value());
 }
 
 TEST_F(AArch64SelectionDAGTest, ComputeKnownFPClass_MaxDepth) {
@@ -1782,7 +1782,7 @@ TEST_F(AArch64SelectionDAGTest, ComputeKnownFPClass_MaxDepth) {
   Known = DAG->computeKnownFPClass(Vec, fcAllFlags,
                                    SelectionDAG::MaxRecursionDepth);
   EXPECT_EQ(Known.KnownFPClasses, fcAllFlags);
-  EXPECT_FALSE(Known.SignBit.has_value());
+  EXPECT_FALSE(Known.getSignBit().has_value());
 }
 
 TEST_F(AArch64SelectionDAGTest, ComputeKnownFPClass_UndefAndPoison) {
@@ -1792,14 +1792,14 @@ TEST_F(AArch64SelectionDAGTest, ComputeKnownFPClass_UndefAndPoison) {
   SDValue Undef = DAG->getUNDEF(MVT::f32);
   KnownFPClass Known = DAG->computeKnownFPClass(Undef, fcAllFlags);
   EXPECT_EQ(Known.KnownFPClasses, fcAllFlags);
-  EXPECT_FALSE(Known.SignBit.has_value());
+  EXPECT_FALSE(Known.getSignBit().has_value());
 
   // POISON is fcNone — can be assumed to never be observed.
   SDValue Poison = DAG->getPOISON(MVT::f32);
   Known = DAG->computeKnownFPClass(Poison, fcAllFlags);
   EXPECT_EQ(Known.KnownFPClasses, fcNone);
-  EXPECT_TRUE(Known.SignBit.has_value());
-  EXPECT_FALSE(*Known.SignBit);
+  EXPECT_TRUE(Known.getSignBit().has_value());
+  EXPECT_FALSE(*Known.getSignBit());
 }
 
 } // end namespace llvm


### PR DESCRIPTION
Part of https://github.com/llvm/llvm-project/issues/217072

This PR is the first step in refactoring `KnownFPClass`. It replaces direct access to the `SignBit` field with getters and setters.

The long-term goal is to eliminate the `SignBit` field so that `KnownFPClass` can be represented by a single bitmask, rather than an `FPClassTest` together with a `std::optional<bool>`.
```c++
struct KnownFPClass {
  FPClassTest KnownFPClasses = fcAllFlags;
  std::optional<bool> SignBit;
};

struct KnownFPClass {
  // Also distinguishes positive/negative qNaN and sNaN.
  KnownFPMask KnownFPClasses = kfcAllFlags;
};
```
In particular, the future `KnownFPMask` (name tentative) would directly encode `kfcPosQNaN`, `kfcNegQNaN`, `kfcPosSNaN`, and `kfcNegSNaN`, allowing the separate `SignBit` state to be removed.

***

Overall, the plan is to do these commits:
1. Replace direct uses of the `SignBit` field with getters/setters. (This PR)
2. Replace direct uses of the `KnownFPClasses` field with getters/setters.
3. Replace `KnownFPClasses` and `SignBit` with a single `KnownFPMask`.
