### PR TITLE
[HLSL] Implement TextureCube resource type

### DIFF
--- a/clang/include/clang/AST/HLSLResource.h
+++ b/clang/include/clang/AST/HLSLResource.h
@@ -109,6 +109,12 @@ inline uint32_t getResourceDimensions(llvm::dxil::ResourceDimension Dim) {
   llvm_unreachable("Unhandled llvm::dxil::ResourceDimension enum.");
 }
 
+// Returns true if sampling operations on a resource of this dimension take a
+// texel-space offset operand.
+inline bool hasResourceOffset(llvm::dxil::ResourceDimension Dim) {
+  return Dim != llvm::dxil::ResourceDimension::Cube;
+}
+
 // Returns true if the second field of the record is a counter resource handle
 inline bool hasCounterHandle(const CXXRecordDecl *RD) {
   if (RD->field_empty())

--- a/clang/lib/CodeGen/CGHLSLBuiltins.cpp
+++ b/clang/lib/CodeGen/CGHLSLBuiltins.cpp
@@ -717,10 +717,9 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
 
     llvm::Type *RetTy = ConvertType(E->getType());
     const unsigned ClampIdx = getHlslClampArgIndex(RT, OffsetIdx);
-    if (E->getNumArgs() <= ClampIdx) {
+    if (E->getNumArgs() <= ClampIdx)
       return EmitIntrinsicCall(CGM.getHLSLRuntime().getSampleIntrinsic(), Args,
                                RetTy);
-    }
 
     Args.push_back(emitHlslClamp(*this, E, ClampIdx));
     return EmitIntrinsicCall(CGM.getHLSLRuntime().getSampleClampIntrinsic(),
@@ -745,10 +744,9 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
 
     llvm::Type *RetTy = ConvertType(E->getType());
     const unsigned ClampIdx = getHlslClampArgIndex(RT, OffsetIdx);
-    if (E->getNumArgs() <= ClampIdx) {
+    if (E->getNumArgs() <= ClampIdx)
       return EmitIntrinsicCall(CGM.getHLSLRuntime().getSampleBiasIntrinsic(),
                                Args, RetTy);
-    }
 
     Args.push_back(emitHlslClamp(*this, E, ClampIdx));
     return EmitIntrinsicCall(CGM.getHLSLRuntime().getSampleBiasClampIntrinsic(),
@@ -774,10 +772,9 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
     llvm::Type *RetTy = ConvertType(E->getType());
 
     const unsigned ClampIdx = getHlslClampArgIndex(RT, OffsetIdx);
-    if (E->getNumArgs() <= ClampIdx) {
+    if (E->getNumArgs() <= ClampIdx)
       return Builder.CreateIntrinsic(
           RetTy, CGM.getHLSLRuntime().getSampleGradIntrinsic(), Args);
-    }
 
     Args.push_back(emitHlslClamp(*this, E, ClampIdx));
     return Builder.CreateIntrinsic(
@@ -871,10 +868,9 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
 
     llvm::Type *RetTy = ConvertType(E->getType());
     const unsigned ClampIdx = getHlslClampArgIndex(RT, OffsetIdx);
-    if (E->getNumArgs() <= ClampIdx) {
+    if (E->getNumArgs() <= ClampIdx)
       return Builder.CreateIntrinsic(
           RetTy, CGM.getHLSLRuntime().getSampleCmpIntrinsic(), Args);
-    }
 
     Args.push_back(emitHlslClamp(*this, E, ClampIdx));
     return Builder.CreateIntrinsic(

--- a/clang/lib/CodeGen/CGHLSLBuiltins.cpp
+++ b/clang/lib/CodeGen/CGHLSLBuiltins.cpp
@@ -524,6 +524,22 @@ static Value *emitHlslOffset(CodeGenFunction &CGF, const CallExpr *E,
   return llvm::Constant::getNullValue(OffsetTy);
 }
 
+static Value *emitHlslSampleOffset(CodeGenFunction &CGF, const CallExpr *E,
+                                   const HLSLAttributedResourceType *RT,
+                                   unsigned OffsetArgIndex) {
+  llvm::Type *OffsetTy = getOffsetType(CGF.CGM, RT);
+  if (!clang::hlsl::hasResourceOffset(RT->getAttrs().ResourceDimension))
+    return llvm::Constant::getNullValue(OffsetTy);
+  return emitHlslOffset(CGF, E, OffsetArgIndex, OffsetTy);
+}
+
+static unsigned getHlslClampArgIndex(const HLSLAttributedResourceType *RT,
+                                     unsigned OffsetArgIndex) {
+  return clang::hlsl::hasResourceOffset(RT->getAttrs().ResourceDimension)
+             ? OffsetArgIndex + 1
+             : OffsetArgIndex;
+}
+
 static Value *emitHlslClamp(CodeGenFunction &CGF, const CallExpr *E,
                             unsigned ClampArgIndex) {
   Value *Clamp = CGF.EmitScalarExpr(E->getArg(ClampArgIndex));
@@ -696,15 +712,17 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
     Args.push_back(HandleOp);
     Args.push_back(SamplerOp);
     Args.push_back(CoordOp);
-    Args.push_back(emitHlslOffset(*this, E, 3, getOffsetType(CGM, RT)));
+    const unsigned OffsetIdx = 3;
+    Args.push_back(emitHlslSampleOffset(*this, E, RT, OffsetIdx));
 
     llvm::Type *RetTy = ConvertType(E->getType());
-    if (E->getNumArgs() <= 4) {
+    const unsigned ClampIdx = getHlslClampArgIndex(RT, OffsetIdx);
+    if (E->getNumArgs() <= ClampIdx) {
       return EmitIntrinsicCall(CGM.getHLSLRuntime().getSampleIntrinsic(), Args,
                                RetTy);
     }
 
-    Args.push_back(emitHlslClamp(*this, E, 4));
+    Args.push_back(emitHlslClamp(*this, E, ClampIdx));
     return EmitIntrinsicCall(CGM.getHLSLRuntime().getSampleClampIntrinsic(),
                              Args, RetTy);
   }
@@ -722,15 +740,17 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
     Args.push_back(SamplerOp);
     Args.push_back(CoordOp);
     Args.push_back(BiasOp);
-    Args.push_back(emitHlslOffset(*this, E, 4, getOffsetType(CGM, RT)));
+    const unsigned OffsetIdx = 4;
+    Args.push_back(emitHlslSampleOffset(*this, E, RT, OffsetIdx));
 
     llvm::Type *RetTy = ConvertType(E->getType());
-    if (E->getNumArgs() <= 5) {
+    const unsigned ClampIdx = getHlslClampArgIndex(RT, OffsetIdx);
+    if (E->getNumArgs() <= ClampIdx) {
       return EmitIntrinsicCall(CGM.getHLSLRuntime().getSampleBiasIntrinsic(),
                                Args, RetTy);
     }
 
-    Args.push_back(emitHlslClamp(*this, E, 5));
+    Args.push_back(emitHlslClamp(*this, E, ClampIdx));
     return EmitIntrinsicCall(CGM.getHLSLRuntime().getSampleBiasClampIntrinsic(),
                              Args, RetTy);
   }
@@ -748,16 +768,18 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
     Args.push_back(CoordOp);
     Args.push_back(DDXOp);
     Args.push_back(DDYOp);
-    Args.push_back(emitHlslOffset(*this, E, 5, getOffsetType(CGM, RT)));
+    const unsigned OffsetIdx = 5;
+    Args.push_back(emitHlslSampleOffset(*this, E, RT, OffsetIdx));
 
     llvm::Type *RetTy = ConvertType(E->getType());
 
-    if (E->getNumArgs() <= 6) {
+    const unsigned ClampIdx = getHlslClampArgIndex(RT, OffsetIdx);
+    if (E->getNumArgs() <= ClampIdx) {
       return Builder.CreateIntrinsic(
           RetTy, CGM.getHLSLRuntime().getSampleGradIntrinsic(), Args);
     }
 
-    Args.push_back(emitHlslClamp(*this, E, 6));
+    Args.push_back(emitHlslClamp(*this, E, ClampIdx));
     return Builder.CreateIntrinsic(
         RetTy, CGM.getHLSLRuntime().getSampleGradClampIntrinsic(), Args);
   }
@@ -775,7 +797,8 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
     Args.push_back(SamplerOp);
     Args.push_back(CoordOp);
     Args.push_back(LODOp);
-    Args.push_back(emitHlslOffset(*this, E, 4, getOffsetType(CGM, RT)));
+    const unsigned OffsetIdx = 4;
+    Args.push_back(emitHlslSampleOffset(*this, E, RT, OffsetIdx));
 
     llvm::Type *RetTy = ConvertType(E->getType());
     return Builder.CreateIntrinsic(
@@ -843,15 +866,17 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
     Args.push_back(SamplerOp);
     Args.push_back(CoordOp);
     Args.push_back(CmpOp);
-    Args.push_back(emitHlslOffset(*this, E, 4, getOffsetType(CGM, RT)));
+    const unsigned OffsetIdx = 4;
+    Args.push_back(emitHlslSampleOffset(*this, E, RT, OffsetIdx));
 
     llvm::Type *RetTy = ConvertType(E->getType());
-    if (E->getNumArgs() <= 5) {
+    const unsigned ClampIdx = getHlslClampArgIndex(RT, OffsetIdx);
+    if (E->getNumArgs() <= ClampIdx) {
       return Builder.CreateIntrinsic(
           RetTy, CGM.getHLSLRuntime().getSampleCmpIntrinsic(), Args);
     }
 
-    Args.push_back(emitHlslClamp(*this, E, 5));
+    Args.push_back(emitHlslClamp(*this, E, ClampIdx));
     return Builder.CreateIntrinsic(
         RetTy, CGM.getHLSLRuntime().getSampleCmpClampIntrinsic(), Args);
   }
@@ -869,7 +894,8 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
     Args.push_back(SamplerOp);
     Args.push_back(CoordOp);
     Args.push_back(CmpOp);
-    Args.push_back(emitHlslOffset(*this, E, 4, getOffsetType(CGM, RT)));
+    const unsigned OffsetIdx = 4;
+    Args.push_back(emitHlslSampleOffset(*this, E, RT, OffsetIdx));
 
     llvm::Type *RetTy = ConvertType(E->getType());
     return Builder.CreateIntrinsic(

--- a/clang/lib/CodeGen/CGHLSLBuiltins.cpp
+++ b/clang/lib/CodeGen/CGHLSLBuiltins.cpp
@@ -712,7 +712,7 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
     Args.push_back(HandleOp);
     Args.push_back(SamplerOp);
     Args.push_back(CoordOp);
-    const unsigned OffsetIdx = 3;
+    constexpr unsigned OffsetIdx = 3;
     Args.push_back(emitHlslSampleOffset(*this, E, RT, OffsetIdx));
 
     llvm::Type *RetTy = ConvertType(E->getType());
@@ -740,7 +740,7 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
     Args.push_back(SamplerOp);
     Args.push_back(CoordOp);
     Args.push_back(BiasOp);
-    const unsigned OffsetIdx = 4;
+    constexpr unsigned OffsetIdx = 4;
     Args.push_back(emitHlslSampleOffset(*this, E, RT, OffsetIdx));
 
     llvm::Type *RetTy = ConvertType(E->getType());
@@ -768,7 +768,7 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
     Args.push_back(CoordOp);
     Args.push_back(DDXOp);
     Args.push_back(DDYOp);
-    const unsigned OffsetIdx = 5;
+    constexpr unsigned OffsetIdx = 5;
     Args.push_back(emitHlslSampleOffset(*this, E, RT, OffsetIdx));
 
     llvm::Type *RetTy = ConvertType(E->getType());
@@ -797,7 +797,7 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
     Args.push_back(SamplerOp);
     Args.push_back(CoordOp);
     Args.push_back(LODOp);
-    const unsigned OffsetIdx = 4;
+    constexpr unsigned OffsetIdx = 4;
     Args.push_back(emitHlslSampleOffset(*this, E, RT, OffsetIdx));
 
     llvm::Type *RetTy = ConvertType(E->getType());
@@ -866,7 +866,7 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
     Args.push_back(SamplerOp);
     Args.push_back(CoordOp);
     Args.push_back(CmpOp);
-    const unsigned OffsetIdx = 4;
+    constexpr unsigned OffsetIdx = 4;
     Args.push_back(emitHlslSampleOffset(*this, E, RT, OffsetIdx));
 
     llvm::Type *RetTy = ConvertType(E->getType());
@@ -894,7 +894,7 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
     Args.push_back(SamplerOp);
     Args.push_back(CoordOp);
     Args.push_back(CmpOp);
-    const unsigned OffsetIdx = 4;
+    constexpr unsigned OffsetIdx = 4;
     Args.push_back(emitHlslSampleOffset(*this, E, RT, OffsetIdx));
 
     llvm::Type *RetTy = ConvertType(E->getType());

--- a/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
+++ b/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
@@ -1802,8 +1802,8 @@ BuiltinTypeDeclBuilder::addSampleMethods(ResourceDimension Dim, bool IsArray) {
       .returnValue(PH::LastStmt)
       .finalize();
 
-  // Cube textures have no offset overloads, but do have a clamp overload.
-  if (Dim == ResourceDimension::Cube) {
+  // Resources without offsets have a clamp overload that takes no offset.
+  if (!hasResourceOffset(Dim)) {
     // T Sample(SamplerState s, float3 location, float clamp)
     BuiltinTypeMethodBuilder(*this, "Sample", ReturnType)
         .addParam("Sampler", SamplerStateType)
@@ -1873,8 +1873,8 @@ BuiltinTypeDeclBuilder::addSampleBiasMethods(ResourceDimension Dim,
       .returnValue(PH::LastStmt)
       .finalize();
 
-  // Cube textures have no offset overloads, but do have a clamp overload.
-  if (Dim == ResourceDimension::Cube) {
+  // Resources without offsets have a clamp overload that takes no offset.
+  if (!hasResourceOffset(Dim)) {
     // T SampleBias(SamplerState s, float3 location, float bias, float clamp)
     BuiltinTypeMethodBuilder(*this, "SampleBias", ReturnType)
         .addParam("Sampler", SamplerStateType)
@@ -1950,8 +1950,8 @@ BuiltinTypeDeclBuilder::addSampleGradMethods(ResourceDimension Dim,
       .returnValue(PH::LastStmt)
       .finalize();
 
-  // Cube textures have no offset overloads, but do have a clamp overload.
-  if (Dim == ResourceDimension::Cube) {
+  // Resources without offsets have a clamp overload that takes no offset.
+  if (!hasResourceOffset(Dim)) {
     // T SampleGrad(SamplerState s, float3 location, float3 ddx, float3 ddy,
     // float clamp)
     BuiltinTypeMethodBuilder(*this, "SampleGrad", ReturnType)
@@ -2028,8 +2028,8 @@ BuiltinTypeDeclBuilder::addSampleLevelMethods(ResourceDimension Dim,
       .returnValue(PH::LastStmt)
       .finalize();
 
-  // Cube textures do not support offsets.
-  if (Dim == ResourceDimension::Cube)
+  // Resources without offsets have no offset overloads.
+  if (!hasResourceOffset(Dim))
     return *this;
 
   // T SampleLevel(SamplerState s, float2 location, float lod, int2 offset)
@@ -2074,8 +2074,8 @@ BuiltinTypeDeclBuilder::addSampleCmpMethods(ResourceDimension Dim,
       .returnValue(PH::LastStmt)
       .finalize();
 
-  // Cube textures have no offset overloads, but do have a clamp overload.
-  if (Dim == ResourceDimension::Cube) {
+  // Resources without offsets have a clamp overload that takes no offset.
+  if (!hasResourceOffset(Dim)) {
     // T SampleCmp(SamplerComparisonState s, float3 location, float
     // compare_value, float clamp)
     BuiltinTypeMethodBuilder(*this, "SampleCmp", ReturnType)
@@ -2152,8 +2152,8 @@ BuiltinTypeDeclBuilder::addSampleCmpLevelZeroMethods(ResourceDimension Dim,
       .returnValue(PH::LastStmt)
       .finalize();
 
-  // Cube textures do not support offsets.
-  if (Dim == ResourceDimension::Cube)
+  // Resources without offsets have no offset overloads.
+  if (!hasResourceOffset(Dim))
     return *this;
 
   // T SampleCmpLevelZero(SamplerComparisonState s, float2 location, float
@@ -2306,8 +2306,8 @@ BuiltinTypeDeclBuilder::addGatherMethods(ResourceDimension Dim, bool IsArray) {
                      getConstantUnsignedIntExpr(V.Component))
         .finalize();
 
-    // Cube textures do not support offsets.
-    if (Dim == ResourceDimension::Cube)
+    // Resources without offsets have no offset overloads.
+    if (!hasResourceOffset(Dim))
       continue;
 
     // ret GatherVariant(SamplerState s, float2 location, int2 offset)
@@ -2367,8 +2367,8 @@ BuiltinTypeDeclBuilder::addGatherCmpMethods(ResourceDimension Dim,
                      getConstantUnsignedIntExpr(V.Component))
         .finalize();
 
-    // Cube textures do not support offsets.
-    if (Dim == ResourceDimension::Cube)
+    // Resources without offsets have no offset overloads.
+    if (!hasResourceOffset(Dim))
       continue;
 
     // ret GatherCmpVariant(SamplerComparisonState s, float2 location, float

--- a/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
+++ b/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
@@ -1451,9 +1451,6 @@ BuiltinTypeDeclBuilder::addArraySubscriptOperators(ResourceDimension Dim,
                                                    bool IsArray) {
   assert(!Record->isCompleteDefinition() && "record is already complete");
 
-  if (Dim == ResourceDimension::Cube)
-    return *this;
-
   ASTContext &AST = Record->getASTContext();
 
   uint32_t VecSize = 1;
@@ -1591,9 +1588,6 @@ BuiltinTypeDeclBuilder &
 BuiltinTypeDeclBuilder::addMipsMember(ResourceDimension Dim) {
   assert(!Record->isCompleteDefinition() && "record is already complete");
 
-  if (Dim == ResourceDimension::Cube)
-    return *this;
-
   ASTContext &AST = Record->getASTContext();
   QualType ReturnType = getHandleElementType();
 
@@ -1610,9 +1604,6 @@ BuiltinTypeDeclBuilder &
 BuiltinTypeDeclBuilder::addTextureLoadMethods(ResourceDimension Dim,
                                               bool IsArray) {
   assert(!Record->isCompleteDefinition() && "record is already complete");
-
-  if (Dim == ResourceDimension::Cube)
-    return *this;
 
   ASTContext &AST = Record->getASTContext();
   uint32_t OffsetSize = getResourceDimensions(Dim);
@@ -1811,31 +1802,45 @@ BuiltinTypeDeclBuilder::addSampleMethods(ResourceDimension Dim, bool IsArray) {
       .returnValue(PH::LastStmt)
       .finalize();
 
-  // Cube textures do not support offsets.
-  if (Dim != ResourceDimension::Cube) {
-    // T Sample(SamplerState s, float2 location, int2 offset)
+  // Cube textures have no offset overloads, but do have a clamp overload.
+  if (Dim == ResourceDimension::Cube) {
+    // T Sample(SamplerState s, float3 location, float clamp)
     BuiltinTypeMethodBuilder(*this, "Sample", ReturnType)
         .addParam("Sampler", SamplerStateType)
         .addParam("Location", CoordTy)
-        .addParam("Offset", OffsetTy)
+        .addParam("Clamp", FloatTy)
         .accessHandleFieldOnResource(PH::_0)
         .callBuiltin("__builtin_hlsl_resource_sample", ReturnType, PH::Handle,
                      PH::LastStmt, PH::_1, PH::_2)
         .returnValue(PH::LastStmt)
         .finalize();
 
-    // T Sample(SamplerState s, float2 location, int2 offset, float clamp)
-    BuiltinTypeMethodBuilder(*this, "Sample", ReturnType)
-        .addParam("Sampler", SamplerStateType)
-        .addParam("Location", CoordTy)
-        .addParam("Offset", OffsetTy)
-        .addParam("Clamp", FloatTy)
-        .accessHandleFieldOnResource(PH::_0)
-        .callBuiltin("__builtin_hlsl_resource_sample", ReturnType, PH::Handle,
-                     PH::LastStmt, PH::_1, PH::_2, PH::_3)
-        .returnValue(PH::LastStmt)
-        .finalize();
+    // Sample uses implicit derivatives to calculate the mip level.
+    return addDerivativeAvailability("Sample");
   }
+
+  // T Sample(SamplerState s, float2 location, int2 offset)
+  BuiltinTypeMethodBuilder(*this, "Sample", ReturnType)
+      .addParam("Sampler", SamplerStateType)
+      .addParam("Location", CoordTy)
+      .addParam("Offset", OffsetTy)
+      .accessHandleFieldOnResource(PH::_0)
+      .callBuiltin("__builtin_hlsl_resource_sample", ReturnType, PH::Handle,
+                   PH::LastStmt, PH::_1, PH::_2)
+      .returnValue(PH::LastStmt)
+      .finalize();
+
+  // T Sample(SamplerState s, float2 location, int2 offset, float clamp)
+  BuiltinTypeMethodBuilder(*this, "Sample", ReturnType)
+      .addParam("Sampler", SamplerStateType)
+      .addParam("Location", CoordTy)
+      .addParam("Offset", OffsetTy)
+      .addParam("Clamp", FloatTy)
+      .accessHandleFieldOnResource(PH::_0)
+      .callBuiltin("__builtin_hlsl_resource_sample", ReturnType, PH::Handle,
+                   PH::LastStmt, PH::_1, PH::_2, PH::_3)
+      .returnValue(PH::LastStmt)
+      .finalize();
 
   // Sample uses implicit derivatives to calculate the mip level.
   return addDerivativeAvailability("Sample");
@@ -1868,34 +1873,49 @@ BuiltinTypeDeclBuilder::addSampleBiasMethods(ResourceDimension Dim,
       .returnValue(PH::LastStmt)
       .finalize();
 
-  // Cube textures do not support offsets.
-  if (Dim != ResourceDimension::Cube) {
-    // T SampleBias(SamplerState s, float2 location, float bias, int2 offset)
+  // Cube textures have no offset overloads, but do have a clamp overload.
+  if (Dim == ResourceDimension::Cube) {
+    // T SampleBias(SamplerState s, float3 location, float bias, float clamp)
     BuiltinTypeMethodBuilder(*this, "SampleBias", ReturnType)
         .addParam("Sampler", SamplerStateType)
         .addParam("Location", CoordTy)
         .addParam("Bias", FloatTy)
-        .addParam("Offset", OffsetTy)
+        .addParam("Clamp", FloatTy)
         .accessHandleFieldOnResource(PH::_0)
         .callBuiltin("__builtin_hlsl_resource_sample_bias", ReturnType,
                      PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3)
         .returnValue(PH::LastStmt)
         .finalize();
 
-    // T SampleBias(SamplerState s, float2 location, float bias, int2 offset,
-    // float clamp)
-    BuiltinTypeMethodBuilder(*this, "SampleBias", ReturnType)
-        .addParam("Sampler", SamplerStateType)
-        .addParam("Location", CoordTy)
-        .addParam("Bias", FloatTy)
-        .addParam("Offset", OffsetTy)
-        .addParam("Clamp", FloatTy)
-        .accessHandleFieldOnResource(PH::_0)
-        .callBuiltin("__builtin_hlsl_resource_sample_bias", ReturnType,
-                     PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3, PH::_4)
-        .returnValue(PH::LastStmt)
-        .finalize();
+    // SampleBias uses implicit derivatives to calculate the mip level.
+    return addDerivativeAvailability("SampleBias");
   }
+
+  // T SampleBias(SamplerState s, float2 location, float bias, int2 offset)
+  BuiltinTypeMethodBuilder(*this, "SampleBias", ReturnType)
+      .addParam("Sampler", SamplerStateType)
+      .addParam("Location", CoordTy)
+      .addParam("Bias", FloatTy)
+      .addParam("Offset", OffsetTy)
+      .accessHandleFieldOnResource(PH::_0)
+      .callBuiltin("__builtin_hlsl_resource_sample_bias", ReturnType,
+                   PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3)
+      .returnValue(PH::LastStmt)
+      .finalize();
+
+  // T SampleBias(SamplerState s, float2 location, float bias, int2 offset,
+  // float clamp)
+  BuiltinTypeMethodBuilder(*this, "SampleBias", ReturnType)
+      .addParam("Sampler", SamplerStateType)
+      .addParam("Location", CoordTy)
+      .addParam("Bias", FloatTy)
+      .addParam("Offset", OffsetTy)
+      .addParam("Clamp", FloatTy)
+      .accessHandleFieldOnResource(PH::_0)
+      .callBuiltin("__builtin_hlsl_resource_sample_bias", ReturnType,
+                   PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3, PH::_4)
+      .returnValue(PH::LastStmt)
+      .finalize();
 
   // SampleBias uses implicit derivatives to calculate the mip level.
   return addDerivativeAvailability("SampleBias");
@@ -1930,38 +1950,53 @@ BuiltinTypeDeclBuilder::addSampleGradMethods(ResourceDimension Dim,
       .returnValue(PH::LastStmt)
       .finalize();
 
-  // Cube textures do not support offsets.
-  if (Dim != ResourceDimension::Cube) {
-    // T SampleGrad(SamplerState s, float2 location, float2 ddx, float2 ddy,
-    // int2 offset)
+  // Cube textures have no offset overloads, but do have a clamp overload.
+  if (Dim == ResourceDimension::Cube) {
+    // T SampleGrad(SamplerState s, float3 location, float3 ddx, float3 ddy,
+    // float clamp)
     BuiltinTypeMethodBuilder(*this, "SampleGrad", ReturnType)
         .addParam("Sampler", SamplerStateType)
         .addParam("Location", CoordTy)
         .addParam("DDX", OffsetFloatTy)
         .addParam("DDY", OffsetFloatTy)
-        .addParam("Offset", OffsetTy)
+        .addParam("Clamp", FloatTy)
         .accessHandleFieldOnResource(PH::_0)
         .callBuiltin("__builtin_hlsl_resource_sample_grad", ReturnType,
                      PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3, PH::_4)
         .returnValue(PH::LastStmt)
         .finalize();
-
-    // T SampleGrad(SamplerState s, float2 location, float2 ddx, float2 ddy,
-    // int2 offset, float clamp)
-    BuiltinTypeMethodBuilder(*this, "SampleGrad", ReturnType)
-        .addParam("Sampler", SamplerStateType)
-        .addParam("Location", CoordTy)
-        .addParam("DDX", OffsetFloatTy)
-        .addParam("DDY", OffsetFloatTy)
-        .addParam("Offset", OffsetTy)
-        .addParam("Clamp", FloatTy)
-        .accessHandleFieldOnResource(PH::_0)
-        .callBuiltin("__builtin_hlsl_resource_sample_grad", ReturnType,
-                     PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3, PH::_4,
-                     PH::_5)
-        .returnValue(PH::LastStmt)
-        .finalize();
+    return *this;
   }
+
+  // T SampleGrad(SamplerState s, float2 location, float2 ddx, float2 ddy,
+  // int2 offset)
+  BuiltinTypeMethodBuilder(*this, "SampleGrad", ReturnType)
+      .addParam("Sampler", SamplerStateType)
+      .addParam("Location", CoordTy)
+      .addParam("DDX", OffsetFloatTy)
+      .addParam("DDY", OffsetFloatTy)
+      .addParam("Offset", OffsetTy)
+      .accessHandleFieldOnResource(PH::_0)
+      .callBuiltin("__builtin_hlsl_resource_sample_grad", ReturnType,
+                   PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3, PH::_4)
+      .returnValue(PH::LastStmt)
+      .finalize();
+
+  // T SampleGrad(SamplerState s, float2 location, float2 ddx, float2 ddy,
+  // int2 offset, float clamp)
+  BuiltinTypeMethodBuilder(*this, "SampleGrad", ReturnType)
+      .addParam("Sampler", SamplerStateType)
+      .addParam("Location", CoordTy)
+      .addParam("DDX", OffsetFloatTy)
+      .addParam("DDY", OffsetFloatTy)
+      .addParam("Offset", OffsetTy)
+      .addParam("Clamp", FloatTy)
+      .accessHandleFieldOnResource(PH::_0)
+      .callBuiltin("__builtin_hlsl_resource_sample_grad", ReturnType,
+                   PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3, PH::_4,
+                   PH::_5)
+      .returnValue(PH::LastStmt)
+      .finalize();
 
   return *this;
 }
@@ -1994,19 +2029,20 @@ BuiltinTypeDeclBuilder::addSampleLevelMethods(ResourceDimension Dim,
       .finalize();
 
   // Cube textures do not support offsets.
-  if (Dim != ResourceDimension::Cube) {
-    // T SampleLevel(SamplerState s, float2 location, float lod, int2 offset)
-    BuiltinTypeMethodBuilder(*this, "SampleLevel", ReturnType)
-        .addParam("Sampler", SamplerStateType)
-        .addParam("Location", CoordTy)
-        .addParam("LOD", FloatTy)
-        .addParam("Offset", OffsetTy)
-        .accessHandleFieldOnResource(PH::_0)
-        .callBuiltin("__builtin_hlsl_resource_sample_level", ReturnType,
-                     PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3)
-        .returnValue(PH::LastStmt)
-        .finalize();
-  }
+  if (Dim == ResourceDimension::Cube)
+    return *this;
+
+  // T SampleLevel(SamplerState s, float2 location, float lod, int2 offset)
+  BuiltinTypeMethodBuilder(*this, "SampleLevel", ReturnType)
+      .addParam("Sampler", SamplerStateType)
+      .addParam("Location", CoordTy)
+      .addParam("LOD", FloatTy)
+      .addParam("Offset", OffsetTy)
+      .accessHandleFieldOnResource(PH::_0)
+      .callBuiltin("__builtin_hlsl_resource_sample_level", ReturnType,
+                   PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3)
+      .returnValue(PH::LastStmt)
+      .finalize();
 
   return *this;
 }
@@ -2038,35 +2074,51 @@ BuiltinTypeDeclBuilder::addSampleCmpMethods(ResourceDimension Dim,
       .returnValue(PH::LastStmt)
       .finalize();
 
-  // Cube textures do not support offsets.
-  if (Dim != ResourceDimension::Cube) {
-    // T SampleCmp(SamplerComparisonState s, float2 location, float
-    // compare_value, int2 offset)
+  // Cube textures have no offset overloads, but do have a clamp overload.
+  if (Dim == ResourceDimension::Cube) {
+    // T SampleCmp(SamplerComparisonState s, float3 location, float
+    // compare_value, float clamp)
     BuiltinTypeMethodBuilder(*this, "SampleCmp", ReturnType)
         .addParam("Sampler", SamplerComparisonStateType)
         .addParam("Location", CoordTy)
         .addParam("CompareValue", FloatTy)
-        .addParam("Offset", OffsetTy)
+        .addParam("Clamp", FloatTy)
         .accessHandleFieldOnResource(PH::_0)
         .callBuiltin("__builtin_hlsl_resource_sample_cmp", ReturnType,
                      PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3)
         .returnValue(PH::LastStmt)
         .finalize();
 
-    // T SampleCmp(SamplerComparisonState s, float2 location, float
-    // compare_value, int2 offset, float clamp)
-    BuiltinTypeMethodBuilder(*this, "SampleCmp", ReturnType)
-        .addParam("Sampler", SamplerComparisonStateType)
-        .addParam("Location", CoordTy)
-        .addParam("CompareValue", FloatTy)
-        .addParam("Offset", OffsetTy)
-        .addParam("Clamp", FloatTy)
-        .accessHandleFieldOnResource(PH::_0)
-        .callBuiltin("__builtin_hlsl_resource_sample_cmp", ReturnType,
-                     PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3, PH::_4)
-        .returnValue(PH::LastStmt)
-        .finalize();
+    // SampleCmp uses implicit derivatives to calculate the mip level.
+    return addDerivativeAvailability("SampleCmp");
   }
+
+  // T SampleCmp(SamplerComparisonState s, float2 location, float
+  // compare_value, int2 offset)
+  BuiltinTypeMethodBuilder(*this, "SampleCmp", ReturnType)
+      .addParam("Sampler", SamplerComparisonStateType)
+      .addParam("Location", CoordTy)
+      .addParam("CompareValue", FloatTy)
+      .addParam("Offset", OffsetTy)
+      .accessHandleFieldOnResource(PH::_0)
+      .callBuiltin("__builtin_hlsl_resource_sample_cmp", ReturnType, PH::Handle,
+                   PH::LastStmt, PH::_1, PH::_2, PH::_3)
+      .returnValue(PH::LastStmt)
+      .finalize();
+
+  // T SampleCmp(SamplerComparisonState s, float2 location, float
+  // compare_value, int2 offset, float clamp)
+  BuiltinTypeMethodBuilder(*this, "SampleCmp", ReturnType)
+      .addParam("Sampler", SamplerComparisonStateType)
+      .addParam("Location", CoordTy)
+      .addParam("CompareValue", FloatTy)
+      .addParam("Offset", OffsetTy)
+      .addParam("Clamp", FloatTy)
+      .accessHandleFieldOnResource(PH::_0)
+      .callBuiltin("__builtin_hlsl_resource_sample_cmp", ReturnType, PH::Handle,
+                   PH::LastStmt, PH::_1, PH::_2, PH::_3, PH::_4)
+      .returnValue(PH::LastStmt)
+      .finalize();
 
   // SampleCmp uses implicit derivatives to calculate the mip level.
   return addDerivativeAvailability("SampleCmp");
@@ -2101,21 +2153,21 @@ BuiltinTypeDeclBuilder::addSampleCmpLevelZeroMethods(ResourceDimension Dim,
       .finalize();
 
   // Cube textures do not support offsets.
-  if (Dim != ResourceDimension::Cube) {
-    // T SampleCmpLevelZero(SamplerComparisonState s, float2 location, float
-    // compare_value, int2 offset)
-    BuiltinTypeMethodBuilder(*this, "SampleCmpLevelZero", ReturnType)
-        .addParam("Sampler", SamplerComparisonStateType)
-        .addParam("Location", CoordTy)
-        .addParam("CompareValue", FloatTy)
-        .addParam("Offset", OffsetTy)
-        .accessHandleFieldOnResource(PH::_0)
-        .callBuiltin("__builtin_hlsl_resource_sample_cmp_level_zero",
-                     ReturnType, PH::Handle, PH::LastStmt, PH::_1, PH::_2,
-                     PH::_3)
-        .returnValue(PH::LastStmt)
-        .finalize();
-  }
+  if (Dim == ResourceDimension::Cube)
+    return *this;
+
+  // T SampleCmpLevelZero(SamplerComparisonState s, float2 location, float
+  // compare_value, int2 offset)
+  BuiltinTypeMethodBuilder(*this, "SampleCmpLevelZero", ReturnType)
+      .addParam("Sampler", SamplerComparisonStateType)
+      .addParam("Location", CoordTy)
+      .addParam("CompareValue", FloatTy)
+      .addParam("Offset", OffsetTy)
+      .accessHandleFieldOnResource(PH::_0)
+      .callBuiltin("__builtin_hlsl_resource_sample_cmp_level_zero", ReturnType,
+                   PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3)
+      .returnValue(PH::LastStmt)
+      .finalize();
 
   return *this;
 }
@@ -2254,18 +2306,20 @@ BuiltinTypeDeclBuilder::addGatherMethods(ResourceDimension Dim, bool IsArray) {
                      getConstantUnsignedIntExpr(V.Component))
         .finalize();
 
-    // ret GatherVariant(SamplerState s, float2 location, int2 offset)
     // Cube textures do not support offsets.
-    if (Dim != ResourceDimension::Cube)
-      BuiltinTypeMethodBuilder(*this, V.Name, ReturnType)
-          .addParam("Sampler", SamplerStateType)
-          .addParam("Location", CoordTy)
-          .addParam("Offset", OffsetTy)
-          .accessHandleFieldOnResource(PH::_0)
-          .callBuiltin("__builtin_hlsl_resource_gather", ReturnType, PH::Handle,
-                       PH::LastStmt, PH::_1,
-                       getConstantUnsignedIntExpr(V.Component), PH::_2)
-          .finalize();
+    if (Dim == ResourceDimension::Cube)
+      continue;
+
+    // ret GatherVariant(SamplerState s, float2 location, int2 offset)
+    BuiltinTypeMethodBuilder(*this, V.Name, ReturnType)
+        .addParam("Sampler", SamplerStateType)
+        .addParam("Location", CoordTy)
+        .addParam("Offset", OffsetTy)
+        .accessHandleFieldOnResource(PH::_0)
+        .callBuiltin("__builtin_hlsl_resource_gather", ReturnType, PH::Handle,
+                     PH::LastStmt, PH::_1,
+                     getConstantUnsignedIntExpr(V.Component), PH::_2)
+        .finalize();
   }
 
   return *this;
@@ -2313,20 +2367,22 @@ BuiltinTypeDeclBuilder::addGatherCmpMethods(ResourceDimension Dim,
                      getConstantUnsignedIntExpr(V.Component))
         .finalize();
 
+    // Cube textures do not support offsets.
+    if (Dim == ResourceDimension::Cube)
+      continue;
+
     // ret GatherCmpVariant(SamplerComparisonState s, float2 location, float
     // compare_value, int2 offset)
-    // Cube textures do not support offsets.
-    if (Dim != ResourceDimension::Cube)
-      BuiltinTypeMethodBuilder(*this, V.Name, ReturnType)
-          .addParam("Sampler", SamplerComparisonStateType)
-          .addParam("Location", CoordTy)
-          .addParam("CompareValue", FloatTy)
-          .addParam("Offset", OffsetTy)
-          .accessHandleFieldOnResource(PH::_0)
-          .callBuiltin("__builtin_hlsl_resource_gather_cmp", ReturnType,
-                       PH::Handle, PH::LastStmt, PH::_1, PH::_2,
-                       getConstantUnsignedIntExpr(V.Component), PH::_3)
-          .finalize();
+    BuiltinTypeMethodBuilder(*this, V.Name, ReturnType)
+        .addParam("Sampler", SamplerComparisonStateType)
+        .addParam("Location", CoordTy)
+        .addParam("CompareValue", FloatTy)
+        .addParam("Offset", OffsetTy)
+        .accessHandleFieldOnResource(PH::_0)
+        .callBuiltin("__builtin_hlsl_resource_gather_cmp", ReturnType,
+                     PH::Handle, PH::LastStmt, PH::_1, PH::_2,
+                     getConstantUnsignedIntExpr(V.Component), PH::_3)
+        .finalize();
   }
 
   return *this;

--- a/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
+++ b/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
@@ -1450,7 +1450,6 @@ BuiltinTypeDeclBuilder &
 BuiltinTypeDeclBuilder::addArraySubscriptOperators(ResourceDimension Dim,
                                                    bool IsArray) {
   assert(!Record->isCompleteDefinition() && "record is already complete");
-
   ASTContext &AST = Record->getASTContext();
 
   uint32_t VecSize = 1;
@@ -1587,7 +1586,6 @@ CXXRecordDecl *BuiltinTypeDeclBuilder::addMipsType(ResourceDimension Dim,
 BuiltinTypeDeclBuilder &
 BuiltinTypeDeclBuilder::addMipsMember(ResourceDimension Dim) {
   assert(!Record->isCompleteDefinition() && "record is already complete");
-
   ASTContext &AST = Record->getASTContext();
   QualType ReturnType = getHandleElementType();
 
@@ -1604,7 +1602,6 @@ BuiltinTypeDeclBuilder &
 BuiltinTypeDeclBuilder::addTextureLoadMethods(ResourceDimension Dim,
                                               bool IsArray) {
   assert(!Record->isCompleteDefinition() && "record is already complete");
-
   ASTContext &AST = Record->getASTContext();
   uint32_t OffsetSize = getResourceDimensions(Dim);
   uint32_t CoordSize = OffsetSize + (IsArray ? 2 : 1);

--- a/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
+++ b/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
@@ -1450,6 +1450,10 @@ BuiltinTypeDeclBuilder &
 BuiltinTypeDeclBuilder::addArraySubscriptOperators(ResourceDimension Dim,
                                                    bool IsArray) {
   assert(!Record->isCompleteDefinition() && "record is already complete");
+
+  if (Dim == ResourceDimension::Cube)
+    return *this;
+
   ASTContext &AST = Record->getASTContext();
 
   uint32_t VecSize = 1;
@@ -1586,6 +1590,10 @@ CXXRecordDecl *BuiltinTypeDeclBuilder::addMipsType(ResourceDimension Dim,
 BuiltinTypeDeclBuilder &
 BuiltinTypeDeclBuilder::addMipsMember(ResourceDimension Dim) {
   assert(!Record->isCompleteDefinition() && "record is already complete");
+
+  if (Dim == ResourceDimension::Cube)
+    return *this;
+
   ASTContext &AST = Record->getASTContext();
   QualType ReturnType = getHandleElementType();
 
@@ -1602,6 +1610,10 @@ BuiltinTypeDeclBuilder &
 BuiltinTypeDeclBuilder::addTextureLoadMethods(ResourceDimension Dim,
                                               bool IsArray) {
   assert(!Record->isCompleteDefinition() && "record is already complete");
+
+  if (Dim == ResourceDimension::Cube)
+    return *this;
+
   ASTContext &AST = Record->getASTContext();
   uint32_t OffsetSize = getResourceDimensions(Dim);
   uint32_t CoordSize = OffsetSize + (IsArray ? 2 : 1);
@@ -1799,28 +1811,31 @@ BuiltinTypeDeclBuilder::addSampleMethods(ResourceDimension Dim, bool IsArray) {
       .returnValue(PH::LastStmt)
       .finalize();
 
-  // T Sample(SamplerState s, float2 location, int2 offset)
-  BuiltinTypeMethodBuilder(*this, "Sample", ReturnType)
-      .addParam("Sampler", SamplerStateType)
-      .addParam("Location", CoordTy)
-      .addParam("Offset", OffsetTy)
-      .accessHandleFieldOnResource(PH::_0)
-      .callBuiltin("__builtin_hlsl_resource_sample", ReturnType, PH::Handle,
-                   PH::LastStmt, PH::_1, PH::_2)
-      .returnValue(PH::LastStmt)
-      .finalize();
+  // Cube textures do not support offsets.
+  if (Dim != ResourceDimension::Cube) {
+    // T Sample(SamplerState s, float2 location, int2 offset)
+    BuiltinTypeMethodBuilder(*this, "Sample", ReturnType)
+        .addParam("Sampler", SamplerStateType)
+        .addParam("Location", CoordTy)
+        .addParam("Offset", OffsetTy)
+        .accessHandleFieldOnResource(PH::_0)
+        .callBuiltin("__builtin_hlsl_resource_sample", ReturnType, PH::Handle,
+                     PH::LastStmt, PH::_1, PH::_2)
+        .returnValue(PH::LastStmt)
+        .finalize();
 
-  // T Sample(SamplerState s, float2 location, int2 offset, float clamp)
-  BuiltinTypeMethodBuilder(*this, "Sample", ReturnType)
-      .addParam("Sampler", SamplerStateType)
-      .addParam("Location", CoordTy)
-      .addParam("Offset", OffsetTy)
-      .addParam("Clamp", FloatTy)
-      .accessHandleFieldOnResource(PH::_0)
-      .callBuiltin("__builtin_hlsl_resource_sample", ReturnType, PH::Handle,
-                   PH::LastStmt, PH::_1, PH::_2, PH::_3)
-      .returnValue(PH::LastStmt)
-      .finalize();
+    // T Sample(SamplerState s, float2 location, int2 offset, float clamp)
+    BuiltinTypeMethodBuilder(*this, "Sample", ReturnType)
+        .addParam("Sampler", SamplerStateType)
+        .addParam("Location", CoordTy)
+        .addParam("Offset", OffsetTy)
+        .addParam("Clamp", FloatTy)
+        .accessHandleFieldOnResource(PH::_0)
+        .callBuiltin("__builtin_hlsl_resource_sample", ReturnType, PH::Handle,
+                     PH::LastStmt, PH::_1, PH::_2, PH::_3)
+        .returnValue(PH::LastStmt)
+        .finalize();
+  }
 
   // Sample uses implicit derivatives to calculate the mip level.
   return addDerivativeAvailability("Sample");
@@ -1853,31 +1868,34 @@ BuiltinTypeDeclBuilder::addSampleBiasMethods(ResourceDimension Dim,
       .returnValue(PH::LastStmt)
       .finalize();
 
-  // T SampleBias(SamplerState s, float2 location, float bias, int2 offset)
-  BuiltinTypeMethodBuilder(*this, "SampleBias", ReturnType)
-      .addParam("Sampler", SamplerStateType)
-      .addParam("Location", CoordTy)
-      .addParam("Bias", FloatTy)
-      .addParam("Offset", OffsetTy)
-      .accessHandleFieldOnResource(PH::_0)
-      .callBuiltin("__builtin_hlsl_resource_sample_bias", ReturnType,
-                   PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3)
-      .returnValue(PH::LastStmt)
-      .finalize();
+  // Cube textures do not support offsets.
+  if (Dim != ResourceDimension::Cube) {
+    // T SampleBias(SamplerState s, float2 location, float bias, int2 offset)
+    BuiltinTypeMethodBuilder(*this, "SampleBias", ReturnType)
+        .addParam("Sampler", SamplerStateType)
+        .addParam("Location", CoordTy)
+        .addParam("Bias", FloatTy)
+        .addParam("Offset", OffsetTy)
+        .accessHandleFieldOnResource(PH::_0)
+        .callBuiltin("__builtin_hlsl_resource_sample_bias", ReturnType,
+                     PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3)
+        .returnValue(PH::LastStmt)
+        .finalize();
 
-  // T SampleBias(SamplerState s, float2 location, float bias, int2 offset,
-  // float clamp)
-  BuiltinTypeMethodBuilder(*this, "SampleBias", ReturnType)
-      .addParam("Sampler", SamplerStateType)
-      .addParam("Location", CoordTy)
-      .addParam("Bias", FloatTy)
-      .addParam("Offset", OffsetTy)
-      .addParam("Clamp", FloatTy)
-      .accessHandleFieldOnResource(PH::_0)
-      .callBuiltin("__builtin_hlsl_resource_sample_bias", ReturnType,
-                   PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3, PH::_4)
-      .returnValue(PH::LastStmt)
-      .finalize();
+    // T SampleBias(SamplerState s, float2 location, float bias, int2 offset,
+    // float clamp)
+    BuiltinTypeMethodBuilder(*this, "SampleBias", ReturnType)
+        .addParam("Sampler", SamplerStateType)
+        .addParam("Location", CoordTy)
+        .addParam("Bias", FloatTy)
+        .addParam("Offset", OffsetTy)
+        .addParam("Clamp", FloatTy)
+        .accessHandleFieldOnResource(PH::_0)
+        .callBuiltin("__builtin_hlsl_resource_sample_bias", ReturnType,
+                     PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3, PH::_4)
+        .returnValue(PH::LastStmt)
+        .finalize();
+  }
 
   // SampleBias uses implicit derivatives to calculate the mip level.
   return addDerivativeAvailability("SampleBias");
@@ -1912,35 +1930,40 @@ BuiltinTypeDeclBuilder::addSampleGradMethods(ResourceDimension Dim,
       .returnValue(PH::LastStmt)
       .finalize();
 
-  // T SampleGrad(SamplerState s, float2 location, float2 ddx, float2 ddy,
-  // int2 offset)
-  BuiltinTypeMethodBuilder(*this, "SampleGrad", ReturnType)
-      .addParam("Sampler", SamplerStateType)
-      .addParam("Location", CoordTy)
-      .addParam("DDX", OffsetFloatTy)
-      .addParam("DDY", OffsetFloatTy)
-      .addParam("Offset", OffsetTy)
-      .accessHandleFieldOnResource(PH::_0)
-      .callBuiltin("__builtin_hlsl_resource_sample_grad", ReturnType,
-                   PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3, PH::_4)
-      .returnValue(PH::LastStmt)
-      .finalize();
+  // Cube textures do not support offsets.
+  if (Dim != ResourceDimension::Cube) {
+    // T SampleGrad(SamplerState s, float2 location, float2 ddx, float2 ddy,
+    // int2 offset)
+    BuiltinTypeMethodBuilder(*this, "SampleGrad", ReturnType)
+        .addParam("Sampler", SamplerStateType)
+        .addParam("Location", CoordTy)
+        .addParam("DDX", OffsetFloatTy)
+        .addParam("DDY", OffsetFloatTy)
+        .addParam("Offset", OffsetTy)
+        .accessHandleFieldOnResource(PH::_0)
+        .callBuiltin("__builtin_hlsl_resource_sample_grad", ReturnType,
+                     PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3, PH::_4)
+        .returnValue(PH::LastStmt)
+        .finalize();
 
-  // T SampleGrad(SamplerState s, float2 location, float2 ddx, float2 ddy,
-  // int2 offset, float clamp)
-  return BuiltinTypeMethodBuilder(*this, "SampleGrad", ReturnType)
-      .addParam("Sampler", SamplerStateType)
-      .addParam("Location", CoordTy)
-      .addParam("DDX", OffsetFloatTy)
-      .addParam("DDY", OffsetFloatTy)
-      .addParam("Offset", OffsetTy)
-      .addParam("Clamp", FloatTy)
-      .accessHandleFieldOnResource(PH::_0)
-      .callBuiltin("__builtin_hlsl_resource_sample_grad", ReturnType,
-                   PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3, PH::_4,
-                   PH::_5)
-      .returnValue(PH::LastStmt)
-      .finalize();
+    // T SampleGrad(SamplerState s, float2 location, float2 ddx, float2 ddy,
+    // int2 offset, float clamp)
+    BuiltinTypeMethodBuilder(*this, "SampleGrad", ReturnType)
+        .addParam("Sampler", SamplerStateType)
+        .addParam("Location", CoordTy)
+        .addParam("DDX", OffsetFloatTy)
+        .addParam("DDY", OffsetFloatTy)
+        .addParam("Offset", OffsetTy)
+        .addParam("Clamp", FloatTy)
+        .accessHandleFieldOnResource(PH::_0)
+        .callBuiltin("__builtin_hlsl_resource_sample_grad", ReturnType,
+                     PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3, PH::_4,
+                     PH::_5)
+        .returnValue(PH::LastStmt)
+        .finalize();
+  }
+
+  return *this;
 }
 
 BuiltinTypeDeclBuilder &
@@ -1970,17 +1993,22 @@ BuiltinTypeDeclBuilder::addSampleLevelMethods(ResourceDimension Dim,
       .returnValue(PH::LastStmt)
       .finalize();
 
-  // T SampleLevel(SamplerState s, float2 location, float lod, int2 offset)
-  return BuiltinTypeMethodBuilder(*this, "SampleLevel", ReturnType)
-      .addParam("Sampler", SamplerStateType)
-      .addParam("Location", CoordTy)
-      .addParam("LOD", FloatTy)
-      .addParam("Offset", OffsetTy)
-      .accessHandleFieldOnResource(PH::_0)
-      .callBuiltin("__builtin_hlsl_resource_sample_level", ReturnType,
-                   PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3)
-      .returnValue(PH::LastStmt)
-      .finalize();
+  // Cube textures do not support offsets.
+  if (Dim != ResourceDimension::Cube) {
+    // T SampleLevel(SamplerState s, float2 location, float lod, int2 offset)
+    BuiltinTypeMethodBuilder(*this, "SampleLevel", ReturnType)
+        .addParam("Sampler", SamplerStateType)
+        .addParam("Location", CoordTy)
+        .addParam("LOD", FloatTy)
+        .addParam("Offset", OffsetTy)
+        .accessHandleFieldOnResource(PH::_0)
+        .callBuiltin("__builtin_hlsl_resource_sample_level", ReturnType,
+                     PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3)
+        .returnValue(PH::LastStmt)
+        .finalize();
+  }
+
+  return *this;
 }
 
 BuiltinTypeDeclBuilder &
@@ -2010,32 +2038,35 @@ BuiltinTypeDeclBuilder::addSampleCmpMethods(ResourceDimension Dim,
       .returnValue(PH::LastStmt)
       .finalize();
 
-  // T SampleCmp(SamplerComparisonState s, float2 location, float compare_value,
-  // int2 offset)
-  BuiltinTypeMethodBuilder(*this, "SampleCmp", ReturnType)
-      .addParam("Sampler", SamplerComparisonStateType)
-      .addParam("Location", CoordTy)
-      .addParam("CompareValue", FloatTy)
-      .addParam("Offset", OffsetTy)
-      .accessHandleFieldOnResource(PH::_0)
-      .callBuiltin("__builtin_hlsl_resource_sample_cmp", ReturnType, PH::Handle,
-                   PH::LastStmt, PH::_1, PH::_2, PH::_3)
-      .returnValue(PH::LastStmt)
-      .finalize();
+  // Cube textures do not support offsets.
+  if (Dim != ResourceDimension::Cube) {
+    // T SampleCmp(SamplerComparisonState s, float2 location, float
+    // compare_value, int2 offset)
+    BuiltinTypeMethodBuilder(*this, "SampleCmp", ReturnType)
+        .addParam("Sampler", SamplerComparisonStateType)
+        .addParam("Location", CoordTy)
+        .addParam("CompareValue", FloatTy)
+        .addParam("Offset", OffsetTy)
+        .accessHandleFieldOnResource(PH::_0)
+        .callBuiltin("__builtin_hlsl_resource_sample_cmp", ReturnType,
+                     PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3)
+        .returnValue(PH::LastStmt)
+        .finalize();
 
-  // T SampleCmp(SamplerComparisonState s, float2 location, float compare_value,
-  // int2 offset, float clamp)
-  BuiltinTypeMethodBuilder(*this, "SampleCmp", ReturnType)
-      .addParam("Sampler", SamplerComparisonStateType)
-      .addParam("Location", CoordTy)
-      .addParam("CompareValue", FloatTy)
-      .addParam("Offset", OffsetTy)
-      .addParam("Clamp", FloatTy)
-      .accessHandleFieldOnResource(PH::_0)
-      .callBuiltin("__builtin_hlsl_resource_sample_cmp", ReturnType, PH::Handle,
-                   PH::LastStmt, PH::_1, PH::_2, PH::_3, PH::_4)
-      .returnValue(PH::LastStmt)
-      .finalize();
+    // T SampleCmp(SamplerComparisonState s, float2 location, float
+    // compare_value, int2 offset, float clamp)
+    BuiltinTypeMethodBuilder(*this, "SampleCmp", ReturnType)
+        .addParam("Sampler", SamplerComparisonStateType)
+        .addParam("Location", CoordTy)
+        .addParam("CompareValue", FloatTy)
+        .addParam("Offset", OffsetTy)
+        .addParam("Clamp", FloatTy)
+        .accessHandleFieldOnResource(PH::_0)
+        .callBuiltin("__builtin_hlsl_resource_sample_cmp", ReturnType,
+                     PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3, PH::_4)
+        .returnValue(PH::LastStmt)
+        .finalize();
+  }
 
   // SampleCmp uses implicit derivatives to calculate the mip level.
   return addDerivativeAvailability("SampleCmp");
@@ -2069,18 +2100,24 @@ BuiltinTypeDeclBuilder::addSampleCmpLevelZeroMethods(ResourceDimension Dim,
       .returnValue(PH::LastStmt)
       .finalize();
 
-  // T SampleCmpLevelZero(SamplerComparisonState s, float2 location, float
-  // compare_value, int2 offset)
-  return BuiltinTypeMethodBuilder(*this, "SampleCmpLevelZero", ReturnType)
-      .addParam("Sampler", SamplerComparisonStateType)
-      .addParam("Location", CoordTy)
-      .addParam("CompareValue", FloatTy)
-      .addParam("Offset", OffsetTy)
-      .accessHandleFieldOnResource(PH::_0)
-      .callBuiltin("__builtin_hlsl_resource_sample_cmp_level_zero", ReturnType,
-                   PH::Handle, PH::LastStmt, PH::_1, PH::_2, PH::_3)
-      .returnValue(PH::LastStmt)
-      .finalize();
+  // Cube textures do not support offsets.
+  if (Dim != ResourceDimension::Cube) {
+    // T SampleCmpLevelZero(SamplerComparisonState s, float2 location, float
+    // compare_value, int2 offset)
+    BuiltinTypeMethodBuilder(*this, "SampleCmpLevelZero", ReturnType)
+        .addParam("Sampler", SamplerComparisonStateType)
+        .addParam("Location", CoordTy)
+        .addParam("CompareValue", FloatTy)
+        .addParam("Offset", OffsetTy)
+        .accessHandleFieldOnResource(PH::_0)
+        .callBuiltin("__builtin_hlsl_resource_sample_cmp_level_zero",
+                     ReturnType, PH::Handle, PH::LastStmt, PH::_1, PH::_2,
+                     PH::_3)
+        .returnValue(PH::LastStmt)
+        .finalize();
+  }
+
+  return *this;
 }
 
 BuiltinTypeDeclBuilder &
@@ -2218,15 +2255,17 @@ BuiltinTypeDeclBuilder::addGatherMethods(ResourceDimension Dim, bool IsArray) {
         .finalize();
 
     // ret GatherVariant(SamplerState s, float2 location, int2 offset)
-    BuiltinTypeMethodBuilder(*this, V.Name, ReturnType)
-        .addParam("Sampler", SamplerStateType)
-        .addParam("Location", CoordTy)
-        .addParam("Offset", OffsetTy)
-        .accessHandleFieldOnResource(PH::_0)
-        .callBuiltin("__builtin_hlsl_resource_gather", ReturnType, PH::Handle,
-                     PH::LastStmt, PH::_1,
-                     getConstantUnsignedIntExpr(V.Component), PH::_2)
-        .finalize();
+    // Cube textures do not support offsets.
+    if (Dim != ResourceDimension::Cube)
+      BuiltinTypeMethodBuilder(*this, V.Name, ReturnType)
+          .addParam("Sampler", SamplerStateType)
+          .addParam("Location", CoordTy)
+          .addParam("Offset", OffsetTy)
+          .accessHandleFieldOnResource(PH::_0)
+          .callBuiltin("__builtin_hlsl_resource_gather", ReturnType, PH::Handle,
+                       PH::LastStmt, PH::_1,
+                       getConstantUnsignedIntExpr(V.Component), PH::_2)
+          .finalize();
   }
 
   return *this;
@@ -2276,16 +2315,18 @@ BuiltinTypeDeclBuilder::addGatherCmpMethods(ResourceDimension Dim,
 
     // ret GatherCmpVariant(SamplerComparisonState s, float2 location, float
     // compare_value, int2 offset)
-    BuiltinTypeMethodBuilder(*this, V.Name, ReturnType)
-        .addParam("Sampler", SamplerComparisonStateType)
-        .addParam("Location", CoordTy)
-        .addParam("CompareValue", FloatTy)
-        .addParam("Offset", OffsetTy)
-        .accessHandleFieldOnResource(PH::_0)
-        .callBuiltin("__builtin_hlsl_resource_gather_cmp", ReturnType,
-                     PH::Handle, PH::LastStmt, PH::_1, PH::_2,
-                     getConstantUnsignedIntExpr(V.Component), PH::_3)
-        .finalize();
+    // Cube textures do not support offsets.
+    if (Dim != ResourceDimension::Cube)
+      BuiltinTypeMethodBuilder(*this, V.Name, ReturnType)
+          .addParam("Sampler", SamplerComparisonStateType)
+          .addParam("Location", CoordTy)
+          .addParam("CompareValue", FloatTy)
+          .addParam("Offset", OffsetTy)
+          .accessHandleFieldOnResource(PH::_0)
+          .callBuiltin("__builtin_hlsl_resource_gather_cmp", ReturnType,
+                       PH::Handle, PH::LastStmt, PH::_1, PH::_2,
+                       getConstantUnsignedIntExpr(V.Component), PH::_3)
+          .finalize();
   }
 
   return *this;

--- a/clang/lib/Sema/HLSLExternalSemaSource.cpp
+++ b/clang/lib/Sema/HLSLExternalSemaSource.cpp
@@ -807,6 +807,27 @@ void HLSLExternalSemaSource::defineHLSLTypesWithForwardDeclarations() {
                        ResourceDimension::Dim2D)
         .completeDefinition();
   });
+
+  // TextureCube — SRV cube texture. Locations are float3 direction vectors.
+  // Cube textures do not support Load, operator[], mips or offsets.
+  Decl = BuiltinTypeDeclBuilder(*SemaPtr, HLSLNamespace, "TextureCube")
+             .addSimpleTemplateParams({"element_type"}, {Float4Ty},
+                                      TypedBufferConcept)
+             .finalizeForwardDeclaration();
+
+  onCompletion(Decl, [this](CXXRecordDecl *Decl) {
+    setupTextureType(Decl, *SemaPtr, ResourceClass::SRV, /*IsROV=*/false,
+                     /*IsArray=*/false, ResourceDimension::Cube)
+        .completeDefinition();
+  });
+
+  auto *PartialSpecCube = addVectorTexturePartialSpecialization(
+      *SemaPtr, HLSLNamespace, Decl->getDescribedClassTemplate());
+  onCompletion(PartialSpecCube, [this](CXXRecordDecl *Decl) {
+    setupTextureType(Decl, *SemaPtr, ResourceClass::SRV, /*IsROV=*/false,
+                     /*IsArray=*/false, ResourceDimension::Cube)
+        .completeDefinition();
+  });
 }
 
 // Build a single overload of an HLSL atomic intrinsic in the hlsl namespace.

--- a/clang/lib/Sema/HLSLExternalSemaSource.cpp
+++ b/clang/lib/Sema/HLSLExternalSemaSource.cpp
@@ -296,6 +296,32 @@ static BuiltinTypeDeclBuilder setupRWTextureType(CXXRecordDecl *Decl, Sema &S,
       .addStaticInitializationFunctions(false);
 }
 
+/// Set up TextureCube type: SRV cube texture. Locations are float3 direction
+/// vectors into the cube rather than texel coordinates, so cube textures have
+/// no Load, no operator[] and no mips member. Their sampling and gather
+/// methods also have no offset overloads.
+static BuiltinTypeDeclBuilder setupTextureCubeType(CXXRecordDecl *Decl,
+                                                   Sema &S) {
+  const ResourceDimension Dim = ResourceDimension::Cube;
+  const bool IsArray = false;
+  return BuiltinTypeDeclBuilder(S, Decl)
+      .addTextureHandle(ResourceClass::SRV, /*IsROV=*/false, IsArray, Dim)
+      .addDefaultHandleConstructor()
+      .addCopyConstructor()
+      .addCopyAssignmentOperator()
+      .addStaticInitializationFunctions(false)
+      .addSampleMethods(Dim, IsArray)
+      .addSampleBiasMethods(Dim, IsArray)
+      .addSampleGradMethods(Dim, IsArray)
+      .addSampleLevelMethods(Dim, IsArray)
+      .addSampleCmpMethods(Dim, IsArray)
+      .addSampleCmpLevelZeroMethods(Dim, IsArray)
+      .addCalculateLodMethods(Dim)
+      .addGetDimensionsMethods(Dim)
+      .addGatherMethods(Dim, IsArray)
+      .addGatherCmpMethods(Dim, IsArray);
+}
+
 /// Set up Texture2DMS (multisampled) type: SRV texture with only operator[]
 /// and sample-indexed Load. It does not support sampling, gather, LOD, or mips.
 static BuiltinTypeDeclBuilder setupMSTextureType(CXXRecordDecl *Decl, Sema &S,
@@ -816,17 +842,13 @@ void HLSLExternalSemaSource::defineHLSLTypesWithForwardDeclarations() {
              .finalizeForwardDeclaration();
 
   onCompletion(Decl, [this](CXXRecordDecl *Decl) {
-    setupTextureType(Decl, *SemaPtr, ResourceClass::SRV, /*IsROV=*/false,
-                     /*IsArray=*/false, ResourceDimension::Cube)
-        .completeDefinition();
+    setupTextureCubeType(Decl, *SemaPtr).completeDefinition();
   });
 
   auto *PartialSpecCube = addVectorTexturePartialSpecialization(
       *SemaPtr, HLSLNamespace, Decl->getDescribedClassTemplate());
   onCompletion(PartialSpecCube, [this](CXXRecordDecl *Decl) {
-    setupTextureType(Decl, *SemaPtr, ResourceClass::SRV, /*IsROV=*/false,
-                     /*IsArray=*/false, ResourceDimension::Cube)
-        .completeDefinition();
+    setupTextureCubeType(Decl, *SemaPtr).completeDefinition();
   });
 }
 

--- a/clang/lib/Sema/HLSLExternalSemaSource.cpp
+++ b/clang/lib/Sema/HLSLExternalSemaSource.cpp
@@ -302,8 +302,8 @@ static BuiltinTypeDeclBuilder setupRWTextureType(CXXRecordDecl *Decl, Sema &S,
 /// methods also have no offset overloads.
 static BuiltinTypeDeclBuilder setupTextureCubeType(CXXRecordDecl *Decl,
                                                    Sema &S) {
-  const ResourceDimension Dim = ResourceDimension::Cube;
-  const bool IsArray = false;
+  constexpr ResourceDimension Dim = ResourceDimension::Cube;
+  constexpr bool IsArray = false;
   return BuiltinTypeDeclBuilder(S, Decl)
       .addTextureHandle(ResourceClass::SRV, /*IsROV=*/false, IsArray, Dim)
       .addDefaultHandleConstructor()

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -4163,8 +4163,9 @@ static bool CheckSamplingBuiltin(Sema &S, CallExpr *TheCall, SampleKind Kind) {
     NextIdx += 2;
   }
 
-  // Check the offset operand.
-  if (TheCall->getNumArgs() > NextIdx) {
+  // Check the offset operand (if applicable).
+  if (hasResourceOffset(ResourceTy->getAttrs().ResourceDimension) &&
+      TheCall->getNumArgs() > NextIdx) {
     if (CheckVectorElementCount(&S, TheCall->getArg(NextIdx)->getType(),
                                 S.Context.IntTy, ExpectedDim,
                                 TheCall->getArg(NextIdx)->getBeginLoc()))

--- a/clang/test/AST/HLSL/Textures-scalar-AST.hlsl
+++ b/clang/test/AST/HLSL/Textures-scalar-AST.hlsl
@@ -1,21 +1,32 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -ast-dump \
-// RUN:   -disable-llvm-passes -finclude-default-header -DTEXTURE=Texture2D \
-// RUN:   -DCOORD_TYPE=float2 -DGRAD_TYPE=float2 -DLOD_LOCATION=loc \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -o - %s \
-// RUN:   | FileCheck %s --check-prefixes=CHECK -DTEXTURE=Texture2D \
-// RUN:   -DDIM_NAME=2D -DDIM=2 -DCOORD_DIM=2 -DLOAD_DIM=3 \
+// RUN:   -disable-llvm-passes -finclude-default-header -DHAS_OFFSET \
+// RUN:   -DHAS_GETDIM_XY -DTEXTURE=Texture2D -DCOORD_TYPE=float2 \
+// RUN:   -DGRAD_TYPE=float2 -DLOD_LOCATION=loc -DOFFSET_ARG="int2(1, 2)" -o - \
+// RUN:   %s \
+// RUN:   | FileCheck %s --check-prefixes=CHECK,TEXEL,OFFSET,GETDIM-XY \
+// RUN:   -DTEXTURE=Texture2D -DDIM_NAME=2D -DDIM=2 -DCOORD_DIM=2 -DLOAD_DIM=3 \
 // RUN:   -DINDEX_TYPE="vector<unsigned int, 2>"
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -ast-dump \
-// RUN:   -disable-llvm-passes -finclude-default-header \
-// RUN:   -DTEXTURE=Texture2DArray -DCOORD_TYPE=float3 -DGRAD_TYPE=float2 \
-// RUN:   -DLOD_LOCATION=loc.xy -DOFFSET_ARG="int2(1, 2)" -o - %s \
-// RUN:   | FileCheck %s --check-prefixes=CHECK,ARRAY -DTEXTURE=Texture2DArray \
-// RUN:   -DDIM_NAME=2D -DDIM=2 -DCOORD_DIM=3 -DLOAD_DIM=4 \
-// RUN:   -DINDEX_TYPE="vector<unsigned int, 3>"
+// RUN:   -disable-llvm-passes -finclude-default-header -DTEXTURE=TextureCube \
+// RUN:   -DCOORD_TYPE=float3 -DGRAD_TYPE=float3 -DLOD_LOCATION=loc -o - %s \
+// RUN:   | FileCheck %s --check-prefixes=CHECK -DTEXTURE=TextureCube \
+// RUN:   -DDIM_NAME=Cube -DDIM=3 -DCOORD_DIM=3
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -ast-dump \
+// RUN:   -disable-llvm-passes -finclude-default-header -DHAS_OFFSET \
+// RUN:   -DHAS_GETDIM_XY -DTEXTURE=Texture2DArray -DCOORD_TYPE=float3 \
+// RUN:   -DGRAD_TYPE=float2 -DLOD_LOCATION=loc.xy -DOFFSET_ARG="int2(1, 2)" \
+// RUN:   -o - %s \
+// RUN:   | FileCheck %s --check-prefixes=CHECK,ARRAY,TEXEL,OFFSET,GETDIM-XY \
+// RUN:   -DTEXTURE=Texture2DArray -DDIM_NAME=2D -DDIM=2 -DCOORD_DIM=3 \
+// RUN:   -DLOAD_DIM=4 -DINDEX_TYPE="vector<unsigned int, 3>"
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
 //
+//   HAS_OFFSET         defined for types whose sampling and gathering methods
+//                      have overloads taking an offset
+//   HAS_GETDIM_XY      defined for types that have the width/height
+//                      GetDimensions overloads
 //   TEXTURE            resource type name
 //   COORD_TYPE         sample location type (DIM components plus the array
 //                      slice)
@@ -31,6 +42,12 @@
 //   INDEX_TYPE         operator[] index type
 //
 // Check prefixes:
+//   TEXEL              the type has integer texel addressing (Load,
+//                      operator[], mips), and therefore a `mips` field in its
+//                      layout
+//   OFFSET             the sampling and gathering methods have offset
+//                      overloads
+//   GETDIM-XY          the width/height GetDimensions overloads exist
 //   ARRAY              the resource has an array slice
 
 // CHECK: CXXRecordDecl {{.*}} SamplerState definition
@@ -53,59 +70,59 @@
 // CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
 // CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
 
-// CHECK: CXXMethodDecl {{.*}} Load 'element_type (vector<int, [[LOAD_DIM]]>)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<int, [[LOAD_DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'element_type' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_load_level' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// TEXEL: CXXMethodDecl {{.*}} Load 'element_type (vector<int, [[LOAD_DIM]]>)'
+// TEXEL-NEXT: ParmVarDecl {{.*}} Location 'vector<int, [[LOAD_DIM]]>'
+// TEXEL-NEXT: CompoundStmt
+// TEXEL-NEXT: ReturnStmt
+// TEXEL-NEXT: CStyleCastExpr {{.*}} 'element_type' <Dependent>
+// TEXEL-NEXT: CallExpr {{.*}} '<dependent type>'
+// TEXEL-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_load_level' 'void (...) noexcept'
+// TEXEL-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// TEXEL-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[LOAD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<int, [[LOAD_DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// TEXEL-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// TEXEL-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// TEXEL-SAME: ' lvalue .__handle
+// TEXEL-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
+// TEXEL-NEXT: DeclRefExpr {{.*}} 'vector<int, [[LOAD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<int, [[LOAD_DIM]]>'
+// TEXEL-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} Load 'element_type (vector<int, [[LOAD_DIM]]>, vector<int, [[DIM]]>)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<int, [[LOAD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'element_type' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_load_level' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// TEXEL: CXXMethodDecl {{.*}} Load 'element_type (vector<int, [[LOAD_DIM]]>, vector<int, [[DIM]]>)'
+// TEXEL-NEXT: ParmVarDecl {{.*}} Location 'vector<int, [[LOAD_DIM]]>'
+// TEXEL-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// TEXEL-NEXT: CompoundStmt
+// TEXEL-NEXT: ReturnStmt
+// TEXEL-NEXT: CStyleCastExpr {{.*}} 'element_type' <Dependent>
+// TEXEL-NEXT: CallExpr {{.*}} '<dependent type>'
+// TEXEL-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_load_level' 'void (...) noexcept'
+// TEXEL-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// TEXEL-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[LOAD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<int, [[LOAD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// TEXEL-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// TEXEL-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// TEXEL-SAME: ' lvalue .__handle
+// TEXEL-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
+// TEXEL-NEXT: DeclRefExpr {{.*}} 'vector<int, [[LOAD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<int, [[LOAD_DIM]]>'
+// TEXEL-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// TEXEL-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} operator[] 'const hlsl_device element_type &([[INDEX_TYPE]]) const' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Index '[[INDEX_TYPE]]'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: UnaryOperator {{.*}} 'hlsl_device element_type' lvalue prefix '*' cannot overflow
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'hlsl_device element_type *' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_getpointer' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// TEXEL: CXXMethodDecl {{.*}} operator[] 'const hlsl_device element_type &([[INDEX_TYPE]]) const' inline
+// TEXEL-NEXT: ParmVarDecl {{.*}} Index '[[INDEX_TYPE]]'
+// TEXEL-NEXT: CompoundStmt
+// TEXEL-NEXT: ReturnStmt
+// TEXEL-NEXT: UnaryOperator {{.*}} 'hlsl_device element_type' lvalue prefix '*' cannot overflow
+// TEXEL-NEXT: CStyleCastExpr {{.*}} 'hlsl_device element_type *' <Dependent>
+// TEXEL-NEXT: CallExpr {{.*}} '<dependent type>'
+// TEXEL-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_getpointer' 'void (...) noexcept'
+// TEXEL-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// TEXEL-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'const hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
-// CHECK-NEXT: DeclRefExpr {{.*}} '[[INDEX_TYPE]]' lvalue ParmVar {{.*}} 'Index' '[[INDEX_TYPE]]'
-// CHECK-NEXT: AlwaysInlineAttr
+// TEXEL-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// TEXEL-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// TEXEL-SAME: ' lvalue .__handle
+// TEXEL-NEXT: CXXThisExpr {{.*}} 'const hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
+// TEXEL-NEXT: DeclRefExpr {{.*}} '[[INDEX_TYPE]]' lvalue ParmVar {{.*}} 'Index' '[[INDEX_TYPE]]'
+// TEXEL-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} Sample 'element_type (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)'
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
@@ -129,55 +146,55 @@
 // CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} Sample 'element_type (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'element_type' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// OFFSET: CXXMethodDecl {{.*}} Sample 'element_type (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'element_type' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} Sample 'element_type (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>, float)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Clamp 'float'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'element_type' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// OFFSET: CXXMethodDecl {{.*}} Sample 'element_type (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>, float)'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Clamp 'float'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'element_type' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Clamp' 'float'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Clamp' 'float'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} SampleBias 'element_type (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, float)'
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
@@ -203,59 +220,59 @@
 // CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Bias' 'float'
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} SampleBias 'element_type (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Bias 'float'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'element_type' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_bias' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// OFFSET: CXXMethodDecl {{.*}} SampleBias 'element_type (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Bias 'float'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'element_type' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_bias' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Bias' 'float'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Bias' 'float'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} SampleBias 'element_type (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>, float)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Bias 'float'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Clamp 'float'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'element_type' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_bias' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// OFFSET: CXXMethodDecl {{.*}} SampleBias 'element_type (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>, float)'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Bias 'float'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Clamp 'float'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'element_type' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_bias' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Bias' 'float'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Clamp' 'float'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Bias' 'float'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Clamp' 'float'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} SampleGrad 'element_type (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<float, [[DIM]]>, vector<float, [[DIM]]>)'
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
@@ -283,63 +300,63 @@
 // CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[DIM]]>' lvalue ParmVar {{.*}} 'DDY' 'vector<float, [[DIM]]>'
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} SampleGrad 'element_type (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<float, [[DIM]]>, vector<float, [[DIM]]>, vector<int, [[DIM]]>)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} DDX 'vector<float, [[DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} DDY 'vector<float, [[DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'element_type' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_grad' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// OFFSET: CXXMethodDecl {{.*}} SampleGrad 'element_type (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<float, [[DIM]]>, vector<float, [[DIM]]>, vector<int, [[DIM]]>)'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} DDX 'vector<float, [[DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} DDY 'vector<float, [[DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'element_type' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_grad' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[DIM]]>' lvalue ParmVar {{.*}} 'DDX' 'vector<float, [[DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[DIM]]>' lvalue ParmVar {{.*}} 'DDY' 'vector<float, [[DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[DIM]]>' lvalue ParmVar {{.*}} 'DDX' 'vector<float, [[DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[DIM]]>' lvalue ParmVar {{.*}} 'DDY' 'vector<float, [[DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} SampleGrad 'element_type (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<float, [[DIM]]>, vector<float, [[DIM]]>, vector<int, [[DIM]]>, float)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} DDX 'vector<float, [[DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} DDY 'vector<float, [[DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Clamp 'float'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'element_type' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_grad' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// OFFSET: CXXMethodDecl {{.*}} SampleGrad 'element_type (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<float, [[DIM]]>, vector<float, [[DIM]]>, vector<int, [[DIM]]>, float)'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} DDX 'vector<float, [[DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} DDY 'vector<float, [[DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Clamp 'float'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'element_type' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_grad' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[DIM]]>' lvalue ParmVar {{.*}} 'DDX' 'vector<float, [[DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[DIM]]>' lvalue ParmVar {{.*}} 'DDY' 'vector<float, [[DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Clamp' 'float'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[DIM]]>' lvalue ParmVar {{.*}} 'DDX' 'vector<float, [[DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[DIM]]>' lvalue ParmVar {{.*}} 'DDY' 'vector<float, [[DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Clamp' 'float'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} SampleLevel 'element_type (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, float)'
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
@@ -365,31 +382,31 @@
 // CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'LOD' 'float'
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} SampleLevel 'element_type (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} LOD 'float'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'element_type' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_level' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// OFFSET: CXXMethodDecl {{.*}} SampleLevel 'element_type (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} LOD 'float'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'element_type' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_level' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'LOD' 'float'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'LOD' 'float'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} SampleCmp 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)'
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
@@ -415,59 +432,59 @@
 // CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} SampleCmp 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// OFFSET: CXXMethodDecl {{.*}} SampleCmp 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} SampleCmp 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>, float)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Clamp 'float'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// OFFSET: CXXMethodDecl {{.*}} SampleCmp 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>, float)'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Clamp 'float'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Clamp' 'float'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Clamp' 'float'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} SampleCmpLevelZero 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)'
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
@@ -493,31 +510,31 @@
 // CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} SampleCmpLevelZero 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp_level_zero' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// OFFSET: CXXMethodDecl {{.*}} SampleCmpLevelZero 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp_level_zero' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} CalculateLevelOfDetail 'float (hlsl::SamplerState, vector<float, [[DIM]]>)'
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
@@ -563,91 +580,91 @@
 // CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[DIM]]>'
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GetDimensions 'void (out unsigned int, out unsigned int)'
-// CHECK-NEXT: ParmVarDecl {{.*}} width 'unsigned int &__restrict'
-// CHECK-NEXT: HLSLParamModifierAttr {{.*}} out
-// CHECK-NEXT: ParmVarDecl {{.*}} height 'unsigned int &__restrict'
-// CHECK-NEXT: HLSLParamModifierAttr {{.*}} out
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_getdimensions_xy' 'void (__hlsl_resource_t, unsigned int &, unsigned int &) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// GETDIM-XY: CXXMethodDecl {{.*}} GetDimensions 'void (out unsigned int, out unsigned int)'
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} width 'unsigned int &__restrict'
+// GETDIM-XY-NEXT: HLSLParamModifierAttr {{.*}} out
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} height 'unsigned int &__restrict'
+// GETDIM-XY-NEXT: HLSLParamModifierAttr {{.*}} out
+// GETDIM-XY-NEXT: CompoundStmt
+// GETDIM-XY-NEXT: CallExpr {{.*}} '<dependent type>'
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_getdimensions_xy' 'void (__hlsl_resource_t, unsigned int &, unsigned int &) noexcept'
+// GETDIM-XY-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// GETDIM-XY-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
-// CHECK-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'width' 'unsigned int &__restrict'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'height' 'unsigned int &__restrict'
-// CHECK-NEXT: AlwaysInlineAttr
+// GETDIM-XY-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// GETDIM-XY-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// GETDIM-XY-SAME: ' lvalue .__handle
+// GETDIM-XY-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'width' 'unsigned int &__restrict'
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'height' 'unsigned int &__restrict'
+// GETDIM-XY-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GetDimensions 'void (unsigned int, out unsigned int, out unsigned int, out unsigned int)'
-// CHECK-NEXT: ParmVarDecl {{.*}} mipLevel 'unsigned int'
-// CHECK-NEXT: ParmVarDecl {{.*}} width 'unsigned int &__restrict'
-// CHECK-NEXT: HLSLParamModifierAttr {{.*}} out
-// CHECK-NEXT: ParmVarDecl {{.*}} height 'unsigned int &__restrict'
-// CHECK-NEXT: HLSLParamModifierAttr {{.*}} out
-// CHECK-NEXT: ParmVarDecl {{.*}} numberOfLevels 'unsigned int &__restrict'
-// CHECK-NEXT: HLSLParamModifierAttr {{.*}} out
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_getdimensions_levels_xy' 'void (__hlsl_resource_t, unsigned int, unsigned int &, unsigned int &, unsigned int &) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// GETDIM-XY: CXXMethodDecl {{.*}} GetDimensions 'void (unsigned int, out unsigned int, out unsigned int, out unsigned int)'
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} mipLevel 'unsigned int'
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} width 'unsigned int &__restrict'
+// GETDIM-XY-NEXT: HLSLParamModifierAttr {{.*}} out
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} height 'unsigned int &__restrict'
+// GETDIM-XY-NEXT: HLSLParamModifierAttr {{.*}} out
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} numberOfLevels 'unsigned int &__restrict'
+// GETDIM-XY-NEXT: HLSLParamModifierAttr {{.*}} out
+// GETDIM-XY-NEXT: CompoundStmt
+// GETDIM-XY-NEXT: CallExpr {{.*}} '<dependent type>'
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_getdimensions_levels_xy' 'void (__hlsl_resource_t, unsigned int, unsigned int &, unsigned int &, unsigned int &) noexcept'
+// GETDIM-XY-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// GETDIM-XY-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
-// CHECK-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'mipLevel' 'unsigned int'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'width' 'unsigned int &__restrict'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'height' 'unsigned int &__restrict'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'numberOfLevels' 'unsigned int &__restrict'
-// CHECK-NEXT: AlwaysInlineAttr
+// GETDIM-XY-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// GETDIM-XY-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// GETDIM-XY-SAME: ' lvalue .__handle
+// GETDIM-XY-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'mipLevel' 'unsigned int'
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'width' 'unsigned int &__restrict'
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'height' 'unsigned int &__restrict'
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'numberOfLevels' 'unsigned int &__restrict'
+// GETDIM-XY-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GetDimensions 'void (out float, out float)'
-// CHECK-NEXT: ParmVarDecl {{.*}} width 'float &__restrict'
-// CHECK-NEXT: HLSLParamModifierAttr {{.*}} out
-// CHECK-NEXT: ParmVarDecl {{.*}} height 'float &__restrict'
-// CHECK-NEXT: HLSLParamModifierAttr {{.*}} out
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_getdimensions_xy_float' 'void (__hlsl_resource_t, float &, float &) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// GETDIM-XY: CXXMethodDecl {{.*}} GetDimensions 'void (out float, out float)'
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} width 'float &__restrict'
+// GETDIM-XY-NEXT: HLSLParamModifierAttr {{.*}} out
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} height 'float &__restrict'
+// GETDIM-XY-NEXT: HLSLParamModifierAttr {{.*}} out
+// GETDIM-XY-NEXT: CompoundStmt
+// GETDIM-XY-NEXT: CallExpr {{.*}} '<dependent type>'
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_getdimensions_xy_float' 'void (__hlsl_resource_t, float &, float &) noexcept'
+// GETDIM-XY-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// GETDIM-XY-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'width' 'float &__restrict'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'height' 'float &__restrict'
-// CHECK-NEXT: AlwaysInlineAttr
+// GETDIM-XY-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// GETDIM-XY-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// GETDIM-XY-SAME: ' lvalue .__handle
+// GETDIM-XY-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'width' 'float &__restrict'
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'height' 'float &__restrict'
+// GETDIM-XY-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GetDimensions 'void (unsigned int, out float, out float, out float)'
-// CHECK-NEXT: ParmVarDecl {{.*}} mipLevel 'unsigned int'
-// CHECK-NEXT: ParmVarDecl {{.*}} width 'float &__restrict'
-// CHECK-NEXT: HLSLParamModifierAttr {{.*}} out
-// CHECK-NEXT: ParmVarDecl {{.*}} height 'float &__restrict'
-// CHECK-NEXT: HLSLParamModifierAttr {{.*}} out
-// CHECK-NEXT: ParmVarDecl {{.*}} numberOfLevels 'float &__restrict'
-// CHECK-NEXT: HLSLParamModifierAttr {{.*}} out
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_getdimensions_levels_xy_float' 'void (__hlsl_resource_t, unsigned int, float &, float &, float &) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// GETDIM-XY: CXXMethodDecl {{.*}} GetDimensions 'void (unsigned int, out float, out float, out float)'
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} mipLevel 'unsigned int'
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} width 'float &__restrict'
+// GETDIM-XY-NEXT: HLSLParamModifierAttr {{.*}} out
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} height 'float &__restrict'
+// GETDIM-XY-NEXT: HLSLParamModifierAttr {{.*}} out
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} numberOfLevels 'float &__restrict'
+// GETDIM-XY-NEXT: HLSLParamModifierAttr {{.*}} out
+// GETDIM-XY-NEXT: CompoundStmt
+// GETDIM-XY-NEXT: CallExpr {{.*}} '<dependent type>'
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_getdimensions_levels_xy_float' 'void (__hlsl_resource_t, unsigned int, float &, float &, float &) noexcept'
+// GETDIM-XY-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// GETDIM-XY-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
-// CHECK-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'mipLevel' 'unsigned int'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'width' 'float &__restrict'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'height' 'float &__restrict'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'numberOfLevels' 'float &__restrict'
-// CHECK-NEXT: AlwaysInlineAttr
+// GETDIM-XY-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// GETDIM-XY-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// GETDIM-XY-SAME: ' lvalue .__handle
+// GETDIM-XY-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'mipLevel' 'unsigned int'
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'width' 'float &__restrict'
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'height' 'float &__restrict'
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'numberOfLevels' 'float &__restrict'
+// GETDIM-XY-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} Gather 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
@@ -665,23 +682,23 @@
 // CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} Gather 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET: CXXMethodDecl {{.*}} Gather 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} GatherRed 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
@@ -699,23 +716,23 @@
 // CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherRed 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET: CXXMethodDecl {{.*}} GatherRed 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} GatherGreen 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
@@ -733,23 +750,23 @@
 // CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 1
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherGreen 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 1
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET: CXXMethodDecl {{.*}} GatherGreen 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 1
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} GatherBlue 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
@@ -767,23 +784,23 @@
 // CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 2
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherBlue 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 2
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET: CXXMethodDecl {{.*}} GatherBlue 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 2
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} GatherAlpha 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
@@ -801,23 +818,23 @@
 // CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 3
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherAlpha 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 3
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET: CXXMethodDecl {{.*}} GatherAlpha 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 3
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} GatherCmp 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)' inline
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
@@ -837,25 +854,25 @@
 // CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherCmp 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET: CXXMethodDecl {{.*}} GatherCmp 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)' inline
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} GatherCmpRed 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)' inline
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
@@ -911,25 +928,25 @@
 // CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 2
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherCmpAlpha 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 3
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET: CXXMethodDecl {{.*}} GatherCmpAlpha 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)' inline
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 3
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 TEXTURE<float> t;
 SamplerState s;
@@ -937,28 +954,34 @@ SamplerComparisonState scs;
 
 void main(COORD_TYPE loc, float cmp) {
   t.Sample(s, loc);
-  t.Sample(s, loc, OFFSET_ARG);
-  t.Sample(s, loc, OFFSET_ARG, 1.0);
   t.SampleBias(s, loc, 0.0);
-  t.SampleBias(s, loc, 0.0, OFFSET_ARG);
-  t.SampleBias(s, loc, 0.0, OFFSET_ARG, 1.0);
   t.SampleGrad(s, loc, (GRAD_TYPE)0, (GRAD_TYPE)0);
-  t.SampleGrad(s, loc, (GRAD_TYPE)0, (GRAD_TYPE)0, OFFSET_ARG);
-  t.SampleGrad(s, loc, (GRAD_TYPE)0, (GRAD_TYPE)0, OFFSET_ARG, 1.0);
   t.SampleLevel(s, loc, 0.0);
-  t.SampleLevel(s, loc, 0.0, OFFSET_ARG);
   t.SampleCmp(scs, loc, cmp);
-  t.SampleCmp(scs, loc, cmp, OFFSET_ARG);
-  t.SampleCmp(scs, loc, cmp, OFFSET_ARG, 1.0f);
   t.SampleCmpLevelZero(scs, loc, cmp);
-  t.SampleCmpLevelZero(scs, loc, cmp, OFFSET_ARG);
   t.CalculateLevelOfDetail(s, LOD_LOCATION);
   t.CalculateLevelOfDetailUnclamped(s, LOD_LOCATION);
   t.Gather(s, loc);
+
+#ifdef HAS_OFFSET
+  t.Sample(s, loc, OFFSET_ARG);
+  t.Sample(s, loc, OFFSET_ARG, 1.0);
+  t.SampleBias(s, loc, 0.0, OFFSET_ARG);
+  t.SampleBias(s, loc, 0.0, OFFSET_ARG, 1.0);
+  t.SampleGrad(s, loc, (GRAD_TYPE)0, (GRAD_TYPE)0, OFFSET_ARG);
+  t.SampleGrad(s, loc, (GRAD_TYPE)0, (GRAD_TYPE)0, OFFSET_ARG, 1.0);
+  t.SampleLevel(s, loc, 0.0, OFFSET_ARG);
+  t.SampleCmp(scs, loc, cmp, OFFSET_ARG);
+  t.SampleCmp(scs, loc, cmp, OFFSET_ARG, 1.0f);
+  t.SampleCmpLevelZero(scs, loc, cmp, OFFSET_ARG);
+#endif
+
+#ifdef HAS_GETDIM_XY
   uint u_w, u_h, u_l;
   float f_w, f_h, f_l;
   t.GetDimensions(u_w, u_h);
   t.GetDimensions(0, u_w, u_h, u_l);
   t.GetDimensions(f_w, f_h);
   t.GetDimensions(0, f_w, f_h, f_l);
+#endif
 }

--- a/clang/test/AST/HLSL/Textures-shorthand-AST.hlsl
+++ b/clang/test/AST/HLSL/Textures-shorthand-AST.hlsl
@@ -3,6 +3,10 @@
 // RUN:   - %s \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2D
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -ast-dump \
+// RUN:   -disable-llvm-passes -finclude-default-header -DTEXTURE=TextureCube \
+// RUN:   -o - %s \
+// RUN:   | FileCheck %s -DTEXTURE=TextureCube
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -ast-dump \
 // RUN:   -disable-llvm-passes -finclude-default-header \
 // RUN:   -DTEXTURE=Texture2DArray -o - %s \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2DArray

--- a/clang/test/AST/HLSL/Textures-vector-AST.hlsl
+++ b/clang/test/AST/HLSL/Textures-vector-AST.hlsl
@@ -1,21 +1,32 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -ast-dump \
-// RUN:   -disable-llvm-passes -finclude-default-header -DTEXTURE=Texture2D \
-// RUN:   -DCOORD_TYPE=float2 -DGRAD_TYPE=float2 -DLOD_LOCATION=loc \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -o - %s \
-// RUN:   | FileCheck %s --check-prefixes=CHECK -DTEXTURE=Texture2D \
-// RUN:   -DDIM_NAME=2D -DDIM=2 -DCOORD_DIM=2 -DLOAD_DIM=3 \
+// RUN:   -disable-llvm-passes -finclude-default-header -DHAS_OFFSET \
+// RUN:   -DHAS_GETDIM_XY -DTEXTURE=Texture2D -DCOORD_TYPE=float2 \
+// RUN:   -DGRAD_TYPE=float2 -DLOD_LOCATION=loc -DOFFSET_ARG="int2(1, 2)" -o - \
+// RUN:   %s \
+// RUN:   | FileCheck %s --check-prefixes=CHECK,TEXEL,OFFSET,GETDIM-XY \
+// RUN:   -DTEXTURE=Texture2D -DDIM_NAME=2D -DDIM=2 -DCOORD_DIM=2 -DLOAD_DIM=3 \
 // RUN:   -DINDEX_TYPE="vector<unsigned int, 2>"
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -ast-dump \
-// RUN:   -disable-llvm-passes -finclude-default-header \
-// RUN:   -DTEXTURE=Texture2DArray -DCOORD_TYPE=float3 -DGRAD_TYPE=float2 \
-// RUN:   -DLOD_LOCATION=loc.xy -DOFFSET_ARG="int2(1, 2)" -o - %s \
-// RUN:   | FileCheck %s --check-prefixes=CHECK,ARRAY -DTEXTURE=Texture2DArray \
-// RUN:   -DDIM_NAME=2D -DDIM=2 -DCOORD_DIM=3 -DLOAD_DIM=4 \
-// RUN:   -DINDEX_TYPE="vector<unsigned int, 3>"
+// RUN:   -disable-llvm-passes -finclude-default-header -DTEXTURE=TextureCube \
+// RUN:   -DCOORD_TYPE=float3 -DGRAD_TYPE=float3 -DLOD_LOCATION=loc -o - %s \
+// RUN:   | FileCheck %s --check-prefixes=CHECK -DTEXTURE=TextureCube \
+// RUN:   -DDIM_NAME=Cube -DDIM=3 -DCOORD_DIM=3
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -ast-dump \
+// RUN:   -disable-llvm-passes -finclude-default-header -DHAS_OFFSET \
+// RUN:   -DHAS_GETDIM_XY -DTEXTURE=Texture2DArray -DCOORD_TYPE=float3 \
+// RUN:   -DGRAD_TYPE=float2 -DLOD_LOCATION=loc.xy -DOFFSET_ARG="int2(1, 2)" \
+// RUN:   -o - %s \
+// RUN:   | FileCheck %s --check-prefixes=CHECK,ARRAY,TEXEL,OFFSET,GETDIM-XY \
+// RUN:   -DTEXTURE=Texture2DArray -DDIM_NAME=2D -DDIM=2 -DCOORD_DIM=3 \
+// RUN:   -DLOAD_DIM=4 -DINDEX_TYPE="vector<unsigned int, 3>"
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
 //
+//   HAS_OFFSET         defined for types whose sampling and gathering methods
+//                      have overloads taking an offset
+//   HAS_GETDIM_XY      defined for types that have the width/height
+//                      GetDimensions overloads
 //   TEXTURE            resource type name
 //   COORD_TYPE         sample location type (DIM components plus the array
 //                      slice)
@@ -31,6 +42,12 @@
 //   INDEX_TYPE         operator[] index type
 //
 // Check prefixes:
+//   TEXEL              the type has integer texel addressing (Load,
+//                      operator[], mips), and therefore a `mips` field in its
+//                      layout
+//   OFFSET             the sampling and gathering methods have offset
+//                      overloads
+//   GETDIM-XY          the width/height GetDimensions overloads exist
 //   ARRAY              the resource has an array slice
 
 // CHECK: CXXRecordDecl {{.*}} SamplerState definition
@@ -57,59 +74,59 @@
 // CHECK-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
 // CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
 
-// CHECK: CXXMethodDecl {{.*}} Load 'vector<element_type, element_count> (vector<int, [[LOAD_DIM]]>)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<int, [[LOAD_DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, element_count>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_load_level' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// TEXEL: CXXMethodDecl {{.*}} Load 'vector<element_type, element_count> (vector<int, [[LOAD_DIM]]>)'
+// TEXEL-NEXT: ParmVarDecl {{.*}} Location 'vector<int, [[LOAD_DIM]]>'
+// TEXEL-NEXT: CompoundStmt
+// TEXEL-NEXT: ReturnStmt
+// TEXEL-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, element_count>' <Dependent>
+// TEXEL-NEXT: CallExpr {{.*}} '<dependent type>'
+// TEXEL-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_load_level' 'void (...) noexcept'
+// TEXEL-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// TEXEL-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[LOAD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<int, [[LOAD_DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// TEXEL-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
+// TEXEL-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// TEXEL-SAME: ' lvalue .__handle
+// TEXEL-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
+// TEXEL-NEXT: DeclRefExpr {{.*}} 'vector<int, [[LOAD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<int, [[LOAD_DIM]]>'
+// TEXEL-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} Load 'vector<element_type, element_count> (vector<int, [[LOAD_DIM]]>, vector<int, [[DIM]]>)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<int, [[LOAD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, element_count>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_load_level' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// TEXEL: CXXMethodDecl {{.*}} Load 'vector<element_type, element_count> (vector<int, [[LOAD_DIM]]>, vector<int, [[DIM]]>)'
+// TEXEL-NEXT: ParmVarDecl {{.*}} Location 'vector<int, [[LOAD_DIM]]>'
+// TEXEL-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// TEXEL-NEXT: CompoundStmt
+// TEXEL-NEXT: ReturnStmt
+// TEXEL-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, element_count>' <Dependent>
+// TEXEL-NEXT: CallExpr {{.*}} '<dependent type>'
+// TEXEL-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_load_level' 'void (...) noexcept'
+// TEXEL-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// TEXEL-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[LOAD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<int, [[LOAD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// TEXEL-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
+// TEXEL-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// TEXEL-SAME: ' lvalue .__handle
+// TEXEL-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
+// TEXEL-NEXT: DeclRefExpr {{.*}} 'vector<int, [[LOAD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<int, [[LOAD_DIM]]>'
+// TEXEL-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// TEXEL-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} operator[] 'vector<element_type, element_count> const hlsl_device &([[INDEX_TYPE]]) const' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Index '[[INDEX_TYPE]]'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: UnaryOperator {{.*}} 'vector<element_type, element_count> hlsl_device' lvalue prefix '*' cannot overflow
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, element_count> hlsl_device *' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_getpointer' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// TEXEL: CXXMethodDecl {{.*}} operator[] 'vector<element_type, element_count> const hlsl_device &([[INDEX_TYPE]]) const' inline
+// TEXEL-NEXT: ParmVarDecl {{.*}} Index '[[INDEX_TYPE]]'
+// TEXEL-NEXT: CompoundStmt
+// TEXEL-NEXT: ReturnStmt
+// TEXEL-NEXT: UnaryOperator {{.*}} 'vector<element_type, element_count> hlsl_device' lvalue prefix '*' cannot overflow
+// TEXEL-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, element_count> hlsl_device *' <Dependent>
+// TEXEL-NEXT: CallExpr {{.*}} '<dependent type>'
+// TEXEL-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_getpointer' 'void (...) noexcept'
+// TEXEL-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// TEXEL-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'const hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
-// CHECK-NEXT: DeclRefExpr {{.*}} '[[INDEX_TYPE]]' lvalue ParmVar {{.*}} 'Index' '[[INDEX_TYPE]]'
-// CHECK-NEXT: AlwaysInlineAttr
+// TEXEL-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
+// TEXEL-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// TEXEL-SAME: ' lvalue .__handle
+// TEXEL-NEXT: CXXThisExpr {{.*}} 'const hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
+// TEXEL-NEXT: DeclRefExpr {{.*}} '[[INDEX_TYPE]]' lvalue ParmVar {{.*}} 'Index' '[[INDEX_TYPE]]'
+// TEXEL-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} Sample 'vector<element_type, element_count> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)'
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
@@ -133,55 +150,55 @@
 // CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} Sample 'vector<element_type, element_count> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, element_count>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// OFFSET: CXXMethodDecl {{.*}} Sample 'vector<element_type, element_count> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, element_count>' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
+// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} Sample 'vector<element_type, element_count> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>, float)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Clamp 'float'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, element_count>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// OFFSET: CXXMethodDecl {{.*}} Sample 'vector<element_type, element_count> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>, float)'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Clamp 'float'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, element_count>' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Clamp' 'float'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
+// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Clamp' 'float'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} SampleBias 'vector<element_type, element_count> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, float)'
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
@@ -207,59 +224,59 @@
 // CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Bias' 'float'
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} SampleBias 'vector<element_type, element_count> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Bias 'float'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, element_count>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_bias' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// OFFSET: CXXMethodDecl {{.*}} SampleBias 'vector<element_type, element_count> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Bias 'float'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, element_count>' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_bias' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Bias' 'float'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
+// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Bias' 'float'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} SampleBias 'vector<element_type, element_count> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>, float)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Bias 'float'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Clamp 'float'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, element_count>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_bias' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// OFFSET: CXXMethodDecl {{.*}} SampleBias 'vector<element_type, element_count> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>, float)'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Bias 'float'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Clamp 'float'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, element_count>' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_bias' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Bias' 'float'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Clamp' 'float'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
+// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Bias' 'float'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Clamp' 'float'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} SampleGrad 'vector<element_type, element_count> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<float, [[DIM]]>, vector<float, [[DIM]]>)'
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
@@ -287,63 +304,63 @@
 // CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[DIM]]>' lvalue ParmVar {{.*}} 'DDY' 'vector<float, [[DIM]]>'
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} SampleGrad 'vector<element_type, element_count> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<float, [[DIM]]>, vector<float, [[DIM]]>, vector<int, [[DIM]]>)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} DDX 'vector<float, [[DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} DDY 'vector<float, [[DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, element_count>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_grad' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// OFFSET: CXXMethodDecl {{.*}} SampleGrad 'vector<element_type, element_count> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<float, [[DIM]]>, vector<float, [[DIM]]>, vector<int, [[DIM]]>)'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} DDX 'vector<float, [[DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} DDY 'vector<float, [[DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, element_count>' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_grad' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[DIM]]>' lvalue ParmVar {{.*}} 'DDX' 'vector<float, [[DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[DIM]]>' lvalue ParmVar {{.*}} 'DDY' 'vector<float, [[DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
+// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[DIM]]>' lvalue ParmVar {{.*}} 'DDX' 'vector<float, [[DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[DIM]]>' lvalue ParmVar {{.*}} 'DDY' 'vector<float, [[DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} SampleGrad 'vector<element_type, element_count> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<float, [[DIM]]>, vector<float, [[DIM]]>, vector<int, [[DIM]]>, float)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} DDX 'vector<float, [[DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} DDY 'vector<float, [[DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Clamp 'float'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, element_count>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_grad' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// OFFSET: CXXMethodDecl {{.*}} SampleGrad 'vector<element_type, element_count> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<float, [[DIM]]>, vector<float, [[DIM]]>, vector<int, [[DIM]]>, float)'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} DDX 'vector<float, [[DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} DDY 'vector<float, [[DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Clamp 'float'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, element_count>' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_grad' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[DIM]]>' lvalue ParmVar {{.*}} 'DDX' 'vector<float, [[DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[DIM]]>' lvalue ParmVar {{.*}} 'DDY' 'vector<float, [[DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Clamp' 'float'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
+// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[DIM]]>' lvalue ParmVar {{.*}} 'DDX' 'vector<float, [[DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[DIM]]>' lvalue ParmVar {{.*}} 'DDY' 'vector<float, [[DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Clamp' 'float'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} SampleLevel 'vector<element_type, element_count> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, float)'
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
@@ -369,31 +386,31 @@
 // CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'LOD' 'float'
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} SampleLevel 'vector<element_type, element_count> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} LOD 'float'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, element_count>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_level' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// OFFSET: CXXMethodDecl {{.*}} SampleLevel 'vector<element_type, element_count> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} LOD 'float'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, element_count>' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_level' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'LOD' 'float'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
+// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'LOD' 'float'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} SampleCmp 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)'
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
@@ -419,59 +436,59 @@
 // CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} SampleCmp 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// OFFSET: CXXMethodDecl {{.*}} SampleCmp 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
+// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} SampleCmp 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>, float)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Clamp 'float'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// OFFSET: CXXMethodDecl {{.*}} SampleCmp 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>, float)'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Clamp 'float'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Clamp' 'float'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
+// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Clamp' 'float'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} SampleCmpLevelZero 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)'
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
@@ -497,31 +514,31 @@
 // CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} SampleCmpLevelZero 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp_level_zero' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// OFFSET: CXXMethodDecl {{.*}} SampleCmpLevelZero 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp_level_zero' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
+// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// OFFSET-SAME: ' lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} CalculateLevelOfDetail 'float (hlsl::SamplerState, vector<float, [[DIM]]>)'
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
@@ -567,87 +584,87 @@
 // CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[DIM]]>'
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GetDimensions 'void (out unsigned int, out unsigned int)'
-// CHECK-NEXT: ParmVarDecl {{.*}} width 'unsigned int &__restrict'
-// CHECK-NEXT: HLSLParamModifierAttr {{.*}} out
-// CHECK-NEXT: ParmVarDecl {{.*}} height 'unsigned int &__restrict'
-// CHECK-NEXT: HLSLParamModifierAttr {{.*}} out
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: CallExpr {{.*}}
-// CHECK-NEXT: DeclRefExpr {{.*}} '__builtin_hlsl_resource_getdimensions_xy' 'void (__hlsl_resource_t, unsigned int &, unsigned int &) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// GETDIM-XY: CXXMethodDecl {{.*}} GetDimensions 'void (out unsigned int, out unsigned int)'
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} width 'unsigned int &__restrict'
+// GETDIM-XY-NEXT: HLSLParamModifierAttr {{.*}} out
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} height 'unsigned int &__restrict'
+// GETDIM-XY-NEXT: HLSLParamModifierAttr {{.*}} out
+// GETDIM-XY-NEXT: CompoundStmt
+// GETDIM-XY-NEXT: CallExpr {{.*}}
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} '__builtin_hlsl_resource_getdimensions_xy' 'void (__hlsl_resource_t, unsigned int &, unsigned int &) noexcept'
+// GETDIM-XY-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// GETDIM-XY-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
-// CHECK-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'width' 'unsigned int &__restrict'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'height' 'unsigned int &__restrict'
+// GETDIM-XY-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
+// GETDIM-XY-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// GETDIM-XY-SAME: ' lvalue .__handle
+// GETDIM-XY-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'width' 'unsigned int &__restrict'
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'height' 'unsigned int &__restrict'
 
-// CHECK: CXXMethodDecl {{.*}} GetDimensions 'void (unsigned int, out unsigned int, out unsigned int, out unsigned int)'
-// CHECK-NEXT: ParmVarDecl {{.*}} mipLevel 'unsigned int'
-// CHECK-NEXT: ParmVarDecl {{.*}} width 'unsigned int &__restrict'
-// CHECK-NEXT: HLSLParamModifierAttr {{.*}} out
-// CHECK-NEXT: ParmVarDecl {{.*}} height 'unsigned int &__restrict'
-// CHECK-NEXT: HLSLParamModifierAttr {{.*}} out
-// CHECK-NEXT: ParmVarDecl {{.*}} numberOfLevels 'unsigned int &__restrict'
-// CHECK-NEXT: HLSLParamModifierAttr {{.*}} out
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: CallExpr {{.*}}
-// CHECK-NEXT: DeclRefExpr {{.*}} '__builtin_hlsl_resource_getdimensions_levels_xy' 'void (__hlsl_resource_t, unsigned int, unsigned int &, unsigned int &, unsigned int &) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// GETDIM-XY: CXXMethodDecl {{.*}} GetDimensions 'void (unsigned int, out unsigned int, out unsigned int, out unsigned int)'
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} mipLevel 'unsigned int'
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} width 'unsigned int &__restrict'
+// GETDIM-XY-NEXT: HLSLParamModifierAttr {{.*}} out
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} height 'unsigned int &__restrict'
+// GETDIM-XY-NEXT: HLSLParamModifierAttr {{.*}} out
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} numberOfLevels 'unsigned int &__restrict'
+// GETDIM-XY-NEXT: HLSLParamModifierAttr {{.*}} out
+// GETDIM-XY-NEXT: CompoundStmt
+// GETDIM-XY-NEXT: CallExpr {{.*}}
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} '__builtin_hlsl_resource_getdimensions_levels_xy' 'void (__hlsl_resource_t, unsigned int, unsigned int &, unsigned int &, unsigned int &) noexcept'
+// GETDIM-XY-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// GETDIM-XY-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
-// CHECK-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'mipLevel' 'unsigned int'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'width' 'unsigned int &__restrict'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'height' 'unsigned int &__restrict'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'numberOfLevels' 'unsigned int &__restrict'
+// GETDIM-XY-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
+// GETDIM-XY-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// GETDIM-XY-SAME: ' lvalue .__handle
+// GETDIM-XY-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'mipLevel' 'unsigned int'
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'width' 'unsigned int &__restrict'
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'height' 'unsigned int &__restrict'
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'numberOfLevels' 'unsigned int &__restrict'
 
-// CHECK: CXXMethodDecl {{.*}} GetDimensions 'void (out float, out float)'
-// CHECK-NEXT: ParmVarDecl {{.*}} width 'float &__restrict'
-// CHECK-NEXT: HLSLParamModifierAttr {{.*}} out
-// CHECK-NEXT: ParmVarDecl {{.*}} height 'float &__restrict'
-// CHECK-NEXT: HLSLParamModifierAttr {{.*}} out
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: CallExpr {{.*}}
-// CHECK-NEXT: DeclRefExpr {{.*}} '__builtin_hlsl_resource_getdimensions_xy_float' 'void (__hlsl_resource_t, float &, float &) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// GETDIM-XY: CXXMethodDecl {{.*}} GetDimensions 'void (out float, out float)'
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} width 'float &__restrict'
+// GETDIM-XY-NEXT: HLSLParamModifierAttr {{.*}} out
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} height 'float &__restrict'
+// GETDIM-XY-NEXT: HLSLParamModifierAttr {{.*}} out
+// GETDIM-XY-NEXT: CompoundStmt
+// GETDIM-XY-NEXT: CallExpr {{.*}}
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} '__builtin_hlsl_resource_getdimensions_xy_float' 'void (__hlsl_resource_t, float &, float &) noexcept'
+// GETDIM-XY-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// GETDIM-XY-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'width' 'float &__restrict'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'height' 'float &__restrict'
+// GETDIM-XY-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
+// GETDIM-XY-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// GETDIM-XY-SAME: ' lvalue .__handle
+// GETDIM-XY-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'width' 'float &__restrict'
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'height' 'float &__restrict'
 
-// CHECK: CXXMethodDecl {{.*}} GetDimensions 'void (unsigned int, out float, out float, out float)'
-// CHECK-NEXT: ParmVarDecl {{.*}} mipLevel 'unsigned int'
-// CHECK-NEXT: ParmVarDecl {{.*}} width 'float &__restrict'
-// CHECK-NEXT: HLSLParamModifierAttr {{.*}} out
-// CHECK-NEXT: ParmVarDecl {{.*}} height 'float &__restrict'
-// CHECK-NEXT: HLSLParamModifierAttr {{.*}} out
-// CHECK-NEXT: ParmVarDecl {{.*}} numberOfLevels 'float &__restrict'
-// CHECK-NEXT: HLSLParamModifierAttr {{.*}} out
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: CallExpr {{.*}}
-// CHECK-NEXT: DeclRefExpr {{.*}} '__builtin_hlsl_resource_getdimensions_levels_xy_float' 'void (__hlsl_resource_t, unsigned int, float &, float &, float &) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// GETDIM-XY: CXXMethodDecl {{.*}} GetDimensions 'void (unsigned int, out float, out float, out float)'
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} mipLevel 'unsigned int'
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} width 'float &__restrict'
+// GETDIM-XY-NEXT: HLSLParamModifierAttr {{.*}} out
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} height 'float &__restrict'
+// GETDIM-XY-NEXT: HLSLParamModifierAttr {{.*}} out
+// GETDIM-XY-NEXT: ParmVarDecl {{.*}} numberOfLevels 'float &__restrict'
+// GETDIM-XY-NEXT: HLSLParamModifierAttr {{.*}} out
+// GETDIM-XY-NEXT: CompoundStmt
+// GETDIM-XY-NEXT: CallExpr {{.*}}
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} '__builtin_hlsl_resource_getdimensions_levels_xy_float' 'void (__hlsl_resource_t, unsigned int, float &, float &, float &) noexcept'
+// GETDIM-XY-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// GETDIM-XY-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// CHECK-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
-// CHECK-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'mipLevel' 'unsigned int'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'width' 'float &__restrict'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'height' 'float &__restrict'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'numberOfLevels' 'float &__restrict'
+// GETDIM-XY-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
+// GETDIM-XY-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// GETDIM-XY-SAME: ' lvalue .__handle
+// GETDIM-XY-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'mipLevel' 'unsigned int'
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'width' 'float &__restrict'
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'height' 'float &__restrict'
+// GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'numberOfLevels' 'float &__restrict'
 
 // CHECK: CXXMethodDecl {{.*}} Gather 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
@@ -665,23 +682,23 @@
 // CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} Gather 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET: CXXMethodDecl {{.*}} Gather 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} GatherRed 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
@@ -699,23 +716,23 @@
 // CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherRed 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET: CXXMethodDecl {{.*}} GatherRed 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} GatherGreen 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
@@ -733,23 +750,23 @@
 // CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 1
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherGreen 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 1
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET: CXXMethodDecl {{.*}} GatherGreen 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 1
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} GatherBlue 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
@@ -767,23 +784,23 @@
 // CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 2
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherBlue 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 2
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET: CXXMethodDecl {{.*}} GatherBlue 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 2
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} GatherAlpha 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
@@ -801,23 +818,23 @@
 // CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 3
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherAlpha 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 3
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET: CXXMethodDecl {{.*}} GatherAlpha 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 3
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} GatherCmp 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)' inline
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
@@ -837,25 +854,25 @@
 // CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherCmp 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET: CXXMethodDecl {{.*}} GatherCmp 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)' inline
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} GatherCmpRed 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)' inline
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
@@ -911,25 +928,25 @@
 // CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 2
 // CHECK-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherCmpAlpha 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// CHECK-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 3
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// CHECK-NEXT: AlwaysInlineAttr
+// OFFSET: CXXMethodDecl {{.*}} GatherCmpAlpha 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)' inline
+// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: CompoundStmt
+// OFFSET-NEXT: ReturnStmt
+// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
+// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 3
+// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// OFFSET-NEXT: AlwaysInlineAttr
 
 TEXTURE<float4> t;
 SamplerState s;
@@ -937,28 +954,34 @@ SamplerComparisonState scs;
 
 void main(COORD_TYPE loc, float cmp) {
   t.Sample(s, loc);
-  t.Sample(s, loc, OFFSET_ARG);
-  t.Sample(s, loc, OFFSET_ARG, 1.0);
   t.SampleBias(s, loc, 0.0);
-  t.SampleBias(s, loc, 0.0, OFFSET_ARG);
-  t.SampleBias(s, loc, 0.0, OFFSET_ARG, 1.0);
   t.SampleGrad(s, loc, (GRAD_TYPE)0, (GRAD_TYPE)0);
-  t.SampleGrad(s, loc, (GRAD_TYPE)0, (GRAD_TYPE)0, OFFSET_ARG);
-  t.SampleGrad(s, loc, (GRAD_TYPE)0, (GRAD_TYPE)0, OFFSET_ARG, 1.0);
   t.SampleLevel(s, loc, 0.0);
-  t.SampleLevel(s, loc, 0.0, OFFSET_ARG);
   t.SampleCmp(scs, loc, cmp);
-  t.SampleCmp(scs, loc, cmp, OFFSET_ARG);
-  t.SampleCmp(scs, loc, cmp, OFFSET_ARG, 1.0f);
   t.SampleCmpLevelZero(scs, loc, cmp);
-  t.SampleCmpLevelZero(scs, loc, cmp, OFFSET_ARG);
   t.CalculateLevelOfDetail(s, LOD_LOCATION);
   t.CalculateLevelOfDetailUnclamped(s, LOD_LOCATION);
   t.Gather(s, loc);
+
+#ifdef HAS_OFFSET
+  t.Sample(s, loc, OFFSET_ARG);
+  t.Sample(s, loc, OFFSET_ARG, 1.0);
+  t.SampleBias(s, loc, 0.0, OFFSET_ARG);
+  t.SampleBias(s, loc, 0.0, OFFSET_ARG, 1.0);
+  t.SampleGrad(s, loc, (GRAD_TYPE)0, (GRAD_TYPE)0, OFFSET_ARG);
+  t.SampleGrad(s, loc, (GRAD_TYPE)0, (GRAD_TYPE)0, OFFSET_ARG, 1.0);
+  t.SampleLevel(s, loc, 0.0, OFFSET_ARG);
+  t.SampleCmp(scs, loc, cmp, OFFSET_ARG);
+  t.SampleCmp(scs, loc, cmp, OFFSET_ARG, 1.0f);
+  t.SampleCmpLevelZero(scs, loc, cmp, OFFSET_ARG);
+#endif
+
+#ifdef HAS_GETDIM_XY
   uint u_w, u_h, u_l;
   float f_w, f_h, f_l;
   t.GetDimensions(u_w, u_h);
   t.GetDimensions(0, u_w, u_h, u_l);
   t.GetDimensions(f_w, f_h);
   t.GetDimensions(0, f_w, f_h, f_l);
+#endif
 }

--- a/clang/test/CodeGenHLSL/resources/Textures-CalculateLevelOfDetail.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-CalculateLevelOfDetail.hlsl
@@ -4,12 +4,24 @@
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2D --check-prefixes=CHECK,DXIL \
 // RUN:   -DDXIL_TY=2 -DRW=0 -DDIM=2
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - -DLOD_TYPE=float3 \
+// RUN:   -DTEXTURE=TextureCube %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=TextureCube --check-prefixes=CHECK,DXIL \
+// RUN:   -DDXIL_TY=5 -DRW=0 -DDIM=3
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - -DLOD_TYPE=float2 \
 // RUN:   -DTEXTURE=Texture2D %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2D --check-prefixes=CHECK,SPIRV \
 // RUN:   -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=1 -DDIM=2
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - -DLOD_TYPE=float3 \
+// RUN:   -DTEXTURE=TextureCube %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=TextureCube --check-prefixes=CHECK,SPIRV \
+// RUN:   -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=3 -DDIM=3
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - -DLOD_TYPE=float2 \
 // RUN:   -DTEXTURE=Texture2DArray %s \

--- a/clang/test/CodeGenHLSL/resources/Textures-Gather.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-Gather.hlsl
@@ -1,38 +1,57 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2D -DCOORD_TYPE=float2 %s \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2D \
+// RUN:   -DCOORD_TYPE=float2 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 \
-// RUN:   --check-prefixes=CHECK,DXIL -DDXIL_TY=2 -DRW=0 -DDIM=2 \
-// RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
-// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
-// RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2D -DCOORD_TYPE=float2 %s \
-// RUN:   | llvm-cxxfilt \
-// RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 \
-// RUN:   --check-prefixes=CHECK,SPIRV -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 \
-// RUN:   -DSPV_DIM=1 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-TEXEL,CHECK-OFFSET,DXIL-OFFSET \
+// RUN:   -DDXIL_TY=2 -DRW=0 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2DArray \
-// RUN:   -DCOORD_TYPE=float3 %s \
+// RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
-// RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DCOORD_DIM=3 \
-// RUN:   --check-prefixes=CHECK,DXIL -DDXIL_TY=7 -DRW=0 -DDIM=2 \
+// RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-NOTEXEL -DDXIL_TY=5 -DRW=0 -DDIM=3
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2D \
+// RUN:   -DCOORD_TYPE=float2 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-TEXEL,CHECK-OFFSET,SPIRV-OFFSET \
+// RUN:   -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=1 -DDIM=2 \
 // RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2DArray \
+// RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-NOTEXEL -DARRAYED=0 -DSAMPLED=1 \
+// RUN:   -DIMG_FMT=0 -DSPV_DIM=3 -DDIM=3
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2DArray \
 // RUN:   -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DCOORD_DIM=3 \
-// RUN:   --check-prefixes=CHECK,SPIRV -DARRAYED=1 -DSAMPLED=1 -DIMG_FMT=0 \
-// RUN:   -DSPV_DIM=1 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-TEXEL,CHECK-OFFSET,DXIL-OFFSET \
+// RUN:   -DDXIL_TY=7 -DRW=0 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2DArray \
+// RUN:   -DCOORD_TYPE=float3 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-TEXEL,CHECK-OFFSET,SPIRV-OFFSET \
+// RUN:   -DARRAYED=1 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=1 -DDIM=2 \
+// RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
 //
 //   OFFSET_ARG         a literal offset argument
+//   HAS_OFFSET         defined for types whose sampling and gathering methods
+//                      have overloads taking an offset
 //   TEXTURE            resource type name
 //   COORD_TYPE         sample location type (DIM components plus the array
 //                      slice)
@@ -46,12 +65,22 @@
 //   SAMPLED            spirv.Image Sampled operand
 //   IMG_FMT            spirv.Image Image Format operand
 //   SPV_DIM            spirv.Image Dim operand
+//
+// Check prefixes:
+//   TEXEL              the type has integer texel addressing (Load,
+//                      operator[], mips), and therefore a `mips` field in its
+//                      layout
+//   OFFSET             the sampling and gathering methods have offset
+//                      overloads
+//   NOTEXEL            the type has no integer texel addressing
 
-// DXIL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// DXIL-TEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// DXIL-NOTEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) }
 // DXIL: %"class.hlsl::SamplerState" = type { target("dx.Sampler", 0) }
 // DXIL: %"class.hlsl::SamplerComparisonState" = type { target("dx.Sampler", 0) }
 
-// SPIRV: %"class.hlsl::[[TEXTURE]]" = type { target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// SPIRV-TEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// SPIRV-NOTEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) }
 // SPIRV: %"class.hlsl::SamplerState" = type { target("spirv.Sampler") }
 // SPIRV: %"class.hlsl::SamplerComparisonState" = type { target("spirv.Sampler") }
 
@@ -82,31 +111,33 @@ float4 main(COORD_TYPE loc : LOC) : SV_Target {
 // SPIRV: %[[RES:.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.gather.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE]], target("spirv.Sampler") %[[SAMPLER_H]], <[[COORD_DIM]] x float> %[[COORD_VAL]], i32 0, <[[DIM]] x i32> zeroinitializer)
 // CHECK: ret <4 x float> %[[RES]]
 
-// CHECK: define hidden {{.*}} <4 x float> @test_offset(float vector[[[COORD_DIM]]])(<[[COORD_DIM]] x float> noundef nofpclass(nan inf) %[[LOC:.*]])
-// CHECK: %[[CALL:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::Gather(hlsl::SamplerState, float vector[[[COORD_DIM]]], int vector[[[DIM]]])(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x i32> {{.*}} [[OFFSET_CONST]])
-// CHECK: ret <4 x float> %[[CALL]]
+// CHECK-OFFSET: define hidden {{.*}} <4 x float> @test_offset(float vector[[[COORD_DIM]]])(<[[COORD_DIM]] x float> noundef nofpclass(nan inf) %[[LOC:.*]])
+// CHECK-OFFSET: %[[CALL:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::Gather(hlsl::SamplerState, float vector[[[COORD_DIM]]], int vector[[[DIM]]])(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x i32> {{.*}} [[OFFSET_CONST]])
+// CHECK-OFFSET: ret <4 x float> %[[CALL]]
 
+#ifdef HAS_OFFSET
 float4 test_offset(COORD_TYPE loc : LOC) : SV_Target {
   return t.Gather(s, loc, OFFSET_ARG);
 }
+#endif
 
-// CHECK: define linkonce_odr hidden {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::Gather(hlsl::SamplerState, float vector[[[COORD_DIM]]], int vector[[[DIM]]])(ptr {{.*}} %[[THIS:[^,]+]], ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}} %[[SAMPLER:[^,]+]], <[[COORD_DIM]] x float> {{.*}} %[[COORD:[^,]+]], <[[DIM]] x i32> {{.*}} %[[OFFSET:[^)]+]])
-// CHECK: %[[THIS_ADDR:.*]] = alloca ptr
-// CHECK: %[[COORD_ADDR:.*]] = alloca <[[COORD_DIM]] x float>
-// CHECK: %[[OFFSET_ADDR:.*]] = alloca <[[DIM]] x i32>
-// CHECK: store ptr %[[THIS]], ptr %[[THIS_ADDR]]
-// CHECK: store <[[COORD_DIM]] x float> %[[COORD]], ptr %[[COORD_ADDR]]
-// CHECK: store <[[DIM]] x i32> %[[OFFSET]], ptr %[[OFFSET_ADDR]]
-// CHECK: %[[THIS_VAL:.*]] = load ptr, ptr %[[THIS_ADDR]]
-// CHECK: %[[HANDLE_GEP:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL]], i32 0, i32 0
-// CHECK: %[[HANDLE:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP]]
-// CHECK: %[[SAMPLER_GEP:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerState", ptr %[[SAMPLER]], i32 0, i32 0
-// CHECK: %[[SAMPLER_H:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP]]
-// CHECK: %[[COORD_VAL:.*]] = load <[[COORD_DIM]] x float>, ptr %[[COORD_ADDR]]
-// CHECK: %[[OFFSET_VAL:.*]] = load <[[DIM]] x i32>, ptr %[[OFFSET_ADDR]]
-// DXIL: %[[RES:.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.gather.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE]], target("dx.Sampler", 0) %[[SAMPLER_H]], <[[COORD_DIM]] x float> %[[COORD_VAL]], i32 0, <[[DIM]] x i32> %[[OFFSET_VAL]])
-// SPIRV: %[[RES:.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.gather.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE]], target("spirv.Sampler") %[[SAMPLER_H]], <[[COORD_DIM]] x float> %[[COORD_VAL]], i32 0, <[[DIM]] x i32> %[[OFFSET_VAL]])
-// CHECK: ret <4 x float> %[[RES]]
+// CHECK-OFFSET: define linkonce_odr hidden {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::Gather(hlsl::SamplerState, float vector[[[COORD_DIM]]], int vector[[[DIM]]])(ptr {{.*}} %[[THIS:[^,]+]], ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}} %[[SAMPLER:[^,]+]], <[[COORD_DIM]] x float> {{.*}} %[[COORD:[^,]+]], <[[DIM]] x i32> {{.*}} %[[OFFSET:[^)]+]])
+// CHECK-OFFSET: %[[THIS_ADDR:.*]] = alloca ptr
+// CHECK-OFFSET: %[[COORD_ADDR:.*]] = alloca <[[COORD_DIM]] x float>
+// CHECK-OFFSET: %[[OFFSET_ADDR:.*]] = alloca <[[DIM]] x i32>
+// CHECK-OFFSET: store ptr %[[THIS]], ptr %[[THIS_ADDR]]
+// CHECK-OFFSET: store <[[COORD_DIM]] x float> %[[COORD]], ptr %[[COORD_ADDR]]
+// CHECK-OFFSET: store <[[DIM]] x i32> %[[OFFSET]], ptr %[[OFFSET_ADDR]]
+// CHECK-OFFSET: %[[THIS_VAL:.*]] = load ptr, ptr %[[THIS_ADDR]]
+// CHECK-OFFSET: %[[HANDLE_GEP:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL]], i32 0, i32 0
+// CHECK-OFFSET: %[[HANDLE:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP]]
+// CHECK-OFFSET: %[[SAMPLER_GEP:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerState", ptr %[[SAMPLER]], i32 0, i32 0
+// CHECK-OFFSET: %[[SAMPLER_H:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP]]
+// CHECK-OFFSET: %[[COORD_VAL:.*]] = load <[[COORD_DIM]] x float>, ptr %[[COORD_ADDR]]
+// CHECK-OFFSET: %[[OFFSET_VAL:.*]] = load <[[DIM]] x i32>, ptr %[[OFFSET_ADDR]]
+// DXIL-OFFSET: %[[RES:.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.gather.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE]], target("dx.Sampler", 0) %[[SAMPLER_H]], <[[COORD_DIM]] x float> %[[COORD_VAL]], i32 0, <[[DIM]] x i32> %[[OFFSET_VAL]])
+// SPIRV-OFFSET: %[[RES:.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.gather.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE]], target("spirv.Sampler") %[[SAMPLER_H]], <[[COORD_DIM]] x float> %[[COORD_VAL]], i32 0, <[[DIM]] x i32> %[[OFFSET_VAL]])
+// CHECK-OFFSET: ret <4 x float> %[[RES]]
 
 // CHECK: define hidden {{.*}} <4 x float> @test_green(float vector[[[COORD_DIM]]])(<[[COORD_DIM]] x float> noundef nofpclass(nan inf) %[[LOC:.*]])
 // CHECK: %[[CALL:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::GatherGreen(hlsl::SamplerState, float vector[[[COORD_DIM]]])(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}})

--- a/clang/test/CodeGenHLSL/resources/Textures-Sample.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-Sample.hlsl
@@ -1,38 +1,57 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2D -DCOORD_TYPE=float2 %s \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2D \
+// RUN:   -DCOORD_TYPE=float2 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 \
-// RUN:   --check-prefixes=CHECK,DXIL -DDXIL_TY=2 -DRW=0 -DDIM=2 \
-// RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
-// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
-// RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2D -DCOORD_TYPE=float2 %s \
-// RUN:   | llvm-cxxfilt \
-// RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 \
-// RUN:   --check-prefixes=CHECK,SPIRV -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 \
-// RUN:   -DSPV_DIM=1 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-TEXEL,CHECK-OFFSET,DXIL-OFFSET \
+// RUN:   -DDXIL_TY=2 -DRW=0 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2DArray \
-// RUN:   -DCOORD_TYPE=float3 %s \
+// RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
-// RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DCOORD_DIM=3 \
-// RUN:   --check-prefixes=CHECK,DXIL -DDXIL_TY=7 -DRW=0 -DDIM=2 \
+// RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-NOTEXEL -DDXIL_TY=5 -DRW=0 -DDIM=3
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2D \
+// RUN:   -DCOORD_TYPE=float2 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-TEXEL,CHECK-OFFSET,SPIRV-OFFSET \
+// RUN:   -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=1 -DDIM=2 \
 // RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2DArray \
+// RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-NOTEXEL -DARRAYED=0 -DSAMPLED=1 \
+// RUN:   -DIMG_FMT=0 -DSPV_DIM=3 -DDIM=3
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2DArray \
 // RUN:   -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DCOORD_DIM=3 \
-// RUN:   --check-prefixes=CHECK,SPIRV -DARRAYED=1 -DSAMPLED=1 -DIMG_FMT=0 \
-// RUN:   -DSPV_DIM=1 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-TEXEL,CHECK-OFFSET,DXIL-OFFSET \
+// RUN:   -DDXIL_TY=7 -DRW=0 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2DArray \
+// RUN:   -DCOORD_TYPE=float3 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-TEXEL,CHECK-OFFSET,SPIRV-OFFSET \
+// RUN:   -DARRAYED=1 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=1 -DDIM=2 \
+// RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
 //
 //   OFFSET_ARG         a literal offset argument
+//   HAS_OFFSET         defined for types whose sampling and gathering methods
+//                      have overloads taking an offset
 //   TEXTURE            resource type name
 //   COORD_TYPE         sample location type (DIM components plus the array
 //                      slice)
@@ -46,11 +65,21 @@
 //   SAMPLED            spirv.Image Sampled operand
 //   IMG_FMT            spirv.Image Image Format operand
 //   SPV_DIM            spirv.Image Dim operand
+//
+// Check prefixes:
+//   TEXEL              the type has integer texel addressing (Load,
+//                      operator[], mips), and therefore a `mips` field in its
+//                      layout
+//   OFFSET             the sampling and gathering methods have offset
+//                      overloads
+//   NOTEXEL            the type has no integer texel addressing
 
-// DXIL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// DXIL-TEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// DXIL-NOTEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) }
 // DXIL: %"class.hlsl::SamplerState" = type { target("dx.Sampler", 0) }
 
-// SPIRV: %"class.hlsl::[[TEXTURE]]" = type { target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// SPIRV-TEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// SPIRV-NOTEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) }
 // SPIRV: %"class.hlsl::SamplerState" = type { target("spirv.Sampler") }
 
 TEXTURE<float4> t;
@@ -79,58 +108,62 @@ float4 main(COORD_TYPE loc : LOC) : SV_Target {
 // SPIRV: %[[RES:.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.sample.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE]], target("spirv.Sampler") %[[SAMPLER_H]], <[[COORD_DIM]] x float> %[[COORD_VAL]], <[[DIM]] x i32> zeroinitializer) [ "convergencectrl"(token %0) ]
 // CHECK: ret <4 x float> %[[RES]]
 
-// CHECK: define hidden {{.*}} <4 x float> @test_offset(float vector[[[COORD_DIM]]])(<[[COORD_DIM]] x float> noundef nofpclass(nan inf) %[[LOC:.*]])
-// CHECK: %[[CALL:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::Sample(hlsl::SamplerState, float vector[[[COORD_DIM]]], int vector[[[DIM]]])(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x i32> {{.*}} [[OFFSET_CONST]])
-// CHECK: ret <4 x float> %[[CALL]]
+// CHECK-OFFSET: define hidden {{.*}} <4 x float> @test_offset(float vector[[[COORD_DIM]]])(<[[COORD_DIM]] x float> noundef nofpclass(nan inf) %[[LOC:.*]])
+// CHECK-OFFSET: %[[CALL:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::Sample(hlsl::SamplerState, float vector[[[COORD_DIM]]], int vector[[[DIM]]])(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x i32> {{.*}} [[OFFSET_CONST]])
+// CHECK-OFFSET: ret <4 x float> %[[CALL]]
 
+#ifdef HAS_OFFSET
 float4 test_offset(COORD_TYPE loc : LOC) : SV_Target {
   return t.Sample(s, loc, OFFSET_ARG);
 }
+#endif
 
-// CHECK: define linkonce_odr hidden {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::Sample(hlsl::SamplerState, float vector[[[COORD_DIM]]], int vector[[[DIM]]])(ptr {{.*}} %[[THIS:[^,]+]], ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}} %[[SAMPLER:[^,]+]], <[[COORD_DIM]] x float> {{.*}} %[[COORD:[^,]+]], <[[DIM]] x i32> {{.*}} %[[OFFSET:[^)]+]])
-// CHECK: %[[THIS_ADDR:.*]] = alloca ptr
-// CHECK: %[[COORD_ADDR:.*]] = alloca <[[COORD_DIM]] x float>
-// CHECK: %[[OFFSET_ADDR:.*]] = alloca <[[DIM]] x i32>
-// CHECK: store ptr %[[THIS]], ptr %[[THIS_ADDR]]
-// CHECK: store <[[COORD_DIM]] x float> %[[COORD]], ptr %[[COORD_ADDR]]
-// CHECK: store <[[DIM]] x i32> %[[OFFSET]], ptr %[[OFFSET_ADDR]]
-// CHECK: %[[THIS_VAL:.*]] = load ptr, ptr %[[THIS_ADDR]]
-// CHECK: %[[HANDLE_GEP:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL]], i32 0, i32 0
-// CHECK: %[[HANDLE:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP]]
-// CHECK: %[[SAMPLER_GEP:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerState", ptr %[[SAMPLER]], i32 0, i32 0
-// CHECK: %[[SAMPLER_H:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP]]
-// CHECK: %[[COORD_VAL:.*]] = load <[[COORD_DIM]] x float>, ptr %[[COORD_ADDR]]
-// CHECK: %[[OFFSET_VAL:.*]] = load <[[DIM]] x i32>, ptr %[[OFFSET_ADDR]]
-// DXIL: %[[RES:.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.sample.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE]], target("dx.Sampler", 0) %[[SAMPLER_H]], <[[COORD_DIM]] x float> %[[COORD_VAL]], <[[DIM]] x i32> %[[OFFSET_VAL]]) [ "convergencectrl"(token %0) ]
-// SPIRV: %[[RES:.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.sample.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE]], target("spirv.Sampler") %[[SAMPLER_H]], <[[COORD_DIM]] x float> %[[COORD_VAL]], <[[DIM]] x i32> %[[OFFSET_VAL]]) [ "convergencectrl"(token %0) ]
-// CHECK: ret <4 x float> %[[RES]]
+// CHECK-OFFSET: define linkonce_odr hidden {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::Sample(hlsl::SamplerState, float vector[[[COORD_DIM]]], int vector[[[DIM]]])(ptr {{.*}} %[[THIS:[^,]+]], ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}} %[[SAMPLER:[^,]+]], <[[COORD_DIM]] x float> {{.*}} %[[COORD:[^,]+]], <[[DIM]] x i32> {{.*}} %[[OFFSET:[^)]+]])
+// CHECK-OFFSET: %[[THIS_ADDR:.*]] = alloca ptr
+// CHECK-OFFSET: %[[COORD_ADDR:.*]] = alloca <[[COORD_DIM]] x float>
+// CHECK-OFFSET: %[[OFFSET_ADDR:.*]] = alloca <[[DIM]] x i32>
+// CHECK-OFFSET: store ptr %[[THIS]], ptr %[[THIS_ADDR]]
+// CHECK-OFFSET: store <[[COORD_DIM]] x float> %[[COORD]], ptr %[[COORD_ADDR]]
+// CHECK-OFFSET: store <[[DIM]] x i32> %[[OFFSET]], ptr %[[OFFSET_ADDR]]
+// CHECK-OFFSET: %[[THIS_VAL:.*]] = load ptr, ptr %[[THIS_ADDR]]
+// CHECK-OFFSET: %[[HANDLE_GEP:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL]], i32 0, i32 0
+// CHECK-OFFSET: %[[HANDLE:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP]]
+// CHECK-OFFSET: %[[SAMPLER_GEP:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerState", ptr %[[SAMPLER]], i32 0, i32 0
+// CHECK-OFFSET: %[[SAMPLER_H:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP]]
+// CHECK-OFFSET: %[[COORD_VAL:.*]] = load <[[COORD_DIM]] x float>, ptr %[[COORD_ADDR]]
+// CHECK-OFFSET: %[[OFFSET_VAL:.*]] = load <[[DIM]] x i32>, ptr %[[OFFSET_ADDR]]
+// DXIL-OFFSET: %[[RES:.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.sample.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE]], target("dx.Sampler", 0) %[[SAMPLER_H]], <[[COORD_DIM]] x float> %[[COORD_VAL]], <[[DIM]] x i32> %[[OFFSET_VAL]]) [ "convergencectrl"(token %0) ]
+// SPIRV-OFFSET: %[[RES:.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.sample.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE]], target("spirv.Sampler") %[[SAMPLER_H]], <[[COORD_DIM]] x float> %[[COORD_VAL]], <[[DIM]] x i32> %[[OFFSET_VAL]]) [ "convergencectrl"(token %0) ]
+// CHECK-OFFSET: ret <4 x float> %[[RES]]
 
-// CHECK: define hidden {{.*}} <4 x float> @test_clamp(float vector[[[COORD_DIM]]])(<[[COORD_DIM]] x float> noundef nofpclass(nan inf) %[[LOC:.*]])
-// CHECK: %[[CALL:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::Sample(hlsl::SamplerState, float vector[[[COORD_DIM]]], int vector[[[DIM]]], float)(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}}, <[[DIM]] x i32> {{.*}} [[OFFSET_CONST]], float {{.*}} 1.000000e+00)
-// CHECK: ret <4 x float> %[[CALL]]
+// CHECK-OFFSET: define hidden {{.*}} <4 x float> @test_clamp(float vector[[[COORD_DIM]]])(<[[COORD_DIM]] x float> noundef nofpclass(nan inf) %[[LOC:.*]])
+// CHECK-OFFSET: %[[CALL:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::Sample(hlsl::SamplerState, float vector[[[COORD_DIM]]], int vector[[[DIM]]], float)(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}}, <[[DIM]] x i32> {{.*}} [[OFFSET_CONST]], float {{.*}} 1.000000e+00)
+// CHECK-OFFSET: ret <4 x float> %[[CALL]]
 
+#ifdef HAS_OFFSET
 float4 test_clamp(COORD_TYPE loc : LOC) : SV_Target {
   return t.Sample(s, loc, OFFSET_ARG, 1.0f);
 }
+#endif
 
-// CHECK: define linkonce_odr hidden {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::Sample(hlsl::SamplerState, float vector[[[COORD_DIM]]], int vector[[[DIM]]], float)(ptr {{.*}} %[[THIS:[^,]+]], ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}} %[[SAMPLER:[^,]+]], <[[COORD_DIM]] x float> {{.*}} %[[COORD:[^,]+]], <[[DIM]] x i32> {{.*}} %[[OFFSET:[^,]+]], float {{.*}} %[[CLAMP:[^)]+]])
-// CHECK: %[[THIS_ADDR:.*]] = alloca ptr
-// CHECK: %[[COORD_ADDR:.*]] = alloca <[[COORD_DIM]] x float>
-// CHECK: %[[OFFSET_ADDR:.*]] = alloca <[[DIM]] x i32>
-// CHECK: %[[CLAMP_ADDR:.*]] = alloca float
-// CHECK: store ptr %[[THIS]], ptr %[[THIS_ADDR]]
-// CHECK: store <[[COORD_DIM]] x float> %[[COORD]], ptr %[[COORD_ADDR]]
-// CHECK: store <[[DIM]] x i32> %[[OFFSET]], ptr %[[OFFSET_ADDR]]
-// CHECK: store float %[[CLAMP]], ptr %[[CLAMP_ADDR]]
-// CHECK: %[[THIS_VAL:.*]] = load ptr, ptr %[[THIS_ADDR]]
-// CHECK: %[[HANDLE_GEP:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL]], i32 0, i32 0
-// CHECK: %[[HANDLE:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP]]
-// CHECK: %[[SAMPLER_GEP:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerState", ptr %[[SAMPLER]], i32 0, i32 0
-// CHECK: %[[SAMPLER_H:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP]]
-// CHECK: %[[COORD_VAL:.*]] = load <[[COORD_DIM]] x float>, ptr %[[COORD_ADDR]]
-// CHECK: %[[OFFSET_VAL:.*]] = load <[[DIM]] x i32>, ptr %[[OFFSET_ADDR]]
-// CHECK: %[[CLAMP_VAL:.*]] = load float, ptr %[[CLAMP_ADDR]]
-// CHECK: %[[CLAMP_CAST:.*]] = fptrunc {{.*}} double {{.*}} to float
-// DXIL: %[[RES:.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.sample.clamp.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE]], target("dx.Sampler", 0) %[[SAMPLER_H]], <[[COORD_DIM]] x float> %[[COORD_VAL]], <[[DIM]] x i32> %[[OFFSET_VAL]], float %[[CLAMP_CAST]]) [ "convergencectrl"(token %0) ]
-// SPIRV: %[[RES:.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.sample.clamp.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE]], target("spirv.Sampler") %[[SAMPLER_H]], <[[COORD_DIM]] x float> %[[COORD_VAL]], <[[DIM]] x i32> %[[OFFSET_VAL]], float %[[CLAMP_CAST]]) [ "convergencectrl"(token %0) ]
-// CHECK: ret <4 x float> %[[RES]]
+// CHECK-OFFSET: define linkonce_odr hidden {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::Sample(hlsl::SamplerState, float vector[[[COORD_DIM]]], int vector[[[DIM]]], float)(ptr {{.*}} %[[THIS:[^,]+]], ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}} %[[SAMPLER:[^,]+]], <[[COORD_DIM]] x float> {{.*}} %[[COORD:[^,]+]], <[[DIM]] x i32> {{.*}} %[[OFFSET:[^,]+]], float {{.*}} %[[CLAMP:[^)]+]])
+// CHECK-OFFSET: %[[THIS_ADDR:.*]] = alloca ptr
+// CHECK-OFFSET: %[[COORD_ADDR:.*]] = alloca <[[COORD_DIM]] x float>
+// CHECK-OFFSET: %[[OFFSET_ADDR:.*]] = alloca <[[DIM]] x i32>
+// CHECK-OFFSET: %[[CLAMP_ADDR:.*]] = alloca float
+// CHECK-OFFSET: store ptr %[[THIS]], ptr %[[THIS_ADDR]]
+// CHECK-OFFSET: store <[[COORD_DIM]] x float> %[[COORD]], ptr %[[COORD_ADDR]]
+// CHECK-OFFSET: store <[[DIM]] x i32> %[[OFFSET]], ptr %[[OFFSET_ADDR]]
+// CHECK-OFFSET: store float %[[CLAMP]], ptr %[[CLAMP_ADDR]]
+// CHECK-OFFSET: %[[THIS_VAL:.*]] = load ptr, ptr %[[THIS_ADDR]]
+// CHECK-OFFSET: %[[HANDLE_GEP:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL]], i32 0, i32 0
+// CHECK-OFFSET: %[[HANDLE:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP]]
+// CHECK-OFFSET: %[[SAMPLER_GEP:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerState", ptr %[[SAMPLER]], i32 0, i32 0
+// CHECK-OFFSET: %[[SAMPLER_H:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP]]
+// CHECK-OFFSET: %[[COORD_VAL:.*]] = load <[[COORD_DIM]] x float>, ptr %[[COORD_ADDR]]
+// CHECK-OFFSET: %[[OFFSET_VAL:.*]] = load <[[DIM]] x i32>, ptr %[[OFFSET_ADDR]]
+// CHECK-OFFSET: %[[CLAMP_VAL:.*]] = load float, ptr %[[CLAMP_ADDR]]
+// CHECK-OFFSET: %[[CLAMP_CAST:.*]] = fptrunc {{.*}} double {{.*}} to float
+// DXIL-OFFSET: %[[RES:.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.sample.clamp.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE]], target("dx.Sampler", 0) %[[SAMPLER_H]], <[[COORD_DIM]] x float> %[[COORD_VAL]], <[[DIM]] x i32> %[[OFFSET_VAL]], float %[[CLAMP_CAST]]) [ "convergencectrl"(token %0) ]
+// SPIRV-OFFSET: %[[RES:.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.sample.clamp.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE]], target("spirv.Sampler") %[[SAMPLER_H]], <[[COORD_DIM]] x float> %[[COORD_VAL]], <[[DIM]] x i32> %[[OFFSET_VAL]], float %[[CLAMP_CAST]]) [ "convergencectrl"(token %0) ]
+// CHECK-OFFSET: ret <4 x float> %[[RES]]

--- a/clang/test/CodeGenHLSL/resources/Textures-Sample.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-Sample.hlsl
@@ -11,7 +11,7 @@
 // RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
-// RUN:   --check-prefixes=CHECK,DXIL,DXIL-NOTEXEL -DDXIL_TY=5 -DRW=0 -DDIM=3
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-NOTEXEL,CHECK-NOOFFSET,DXIL-NOOFFSET -DDXIL_TY=5 -DRW=0 -DDIM=3
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
 // RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2D \
@@ -26,7 +26,7 @@
 // RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
-// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-NOTEXEL -DARRAYED=0 -DSAMPLED=1 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-NOTEXEL,CHECK-NOOFFSET,SPIRV-NOOFFSET -DARRAYED=0 -DSAMPLED=1 \
 // RUN:   -DIMG_FMT=0 -DSPV_DIM=3 -DDIM=3
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
@@ -73,6 +73,8 @@
 //   OFFSET             the sampling and gathering methods have offset
 //                      overloads
 //   NOTEXEL            the type has no integer texel addressing
+//   NOOFFSET           the sampling methods have no offset overloads, so
+//                      their clamp overload takes the offset's place
 
 // DXIL-TEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
 // DXIL-NOTEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) }
@@ -112,6 +114,7 @@ float4 main(COORD_TYPE loc : LOC) : SV_Target {
 // CHECK-OFFSET: %[[CALL:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::Sample(hlsl::SamplerState, float vector[[[COORD_DIM]]], int vector[[[DIM]]])(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x i32> {{.*}} [[OFFSET_CONST]])
 // CHECK-OFFSET: ret <4 x float> %[[CALL]]
 
+
 #ifdef HAS_OFFSET
 float4 test_offset(COORD_TYPE loc : LOC) : SV_Target {
   return t.Sample(s, loc, OFFSET_ARG);
@@ -140,9 +143,19 @@ float4 test_offset(COORD_TYPE loc : LOC) : SV_Target {
 // CHECK-OFFSET: %[[CALL:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::Sample(hlsl::SamplerState, float vector[[[COORD_DIM]]], int vector[[[DIM]]], float)(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}}, <[[DIM]] x i32> {{.*}} [[OFFSET_CONST]], float {{.*}} 1.000000e+00)
 // CHECK-OFFSET: ret <4 x float> %[[CALL]]
 
+// CHECK-NOOFFSET: @test_clamp(
+// CHECK-NOOFFSET: %[[CALL_NC:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::Sample(hlsl::SamplerState, float vector[[[COORD_DIM]]], float)(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}}, float {{.*}} 1.000000e+00)
+// CHECK-NOOFFSET: ret <4 x float> %[[CALL_NC]]
+
 #ifdef HAS_OFFSET
 float4 test_clamp(COORD_TYPE loc : LOC) : SV_Target {
   return t.Sample(s, loc, OFFSET_ARG, 1.0f);
+}
+#else
+// Cube textures have no offset overload, so the clamp takes the offset's place
+// in the method signature; the intrinsic still receives a zero offset.
+float4 test_clamp(COORD_TYPE loc : LOC) : SV_Target {
+  return t.Sample(s, loc, 1.0f);
 }
 #endif
 
@@ -167,3 +180,13 @@ float4 test_clamp(COORD_TYPE loc : LOC) : SV_Target {
 // DXIL-OFFSET: %[[RES:.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.sample.clamp.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE]], target("dx.Sampler", 0) %[[SAMPLER_H]], <[[COORD_DIM]] x float> %[[COORD_VAL]], <[[DIM]] x i32> %[[OFFSET_VAL]], float %[[CLAMP_CAST]]) [ "convergencectrl"(token %0) ]
 // SPIRV-OFFSET: %[[RES:.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.sample.clamp.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE]], target("spirv.Sampler") %[[SAMPLER_H]], <[[COORD_DIM]] x float> %[[COORD_VAL]], <[[DIM]] x i32> %[[OFFSET_VAL]], float %[[CLAMP_CAST]]) [ "convergencectrl"(token %0) ]
 // CHECK-OFFSET: ret <4 x float> %[[RES]]
+
+// CHECK-NOOFFSET: define linkonce_odr hidden {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::Sample(hlsl::SamplerState, float vector[[[COORD_DIM]]], float)(
+// CHECK-NOOFFSET: %[[THIS_VAL_NC:.*]] = load ptr, ptr %{{.*}}
+// CHECK-NOOFFSET: %[[HANDLE_GEP_NC:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL_NC]], i32 0, i32 0
+// CHECK-NOOFFSET: %[[HANDLE_NC:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP_NC]]
+// CHECK-NOOFFSET: %[[SAMPLER_GEP_NC:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerState", ptr %{{.*}}, i32 0, i32 0
+// CHECK-NOOFFSET: %[[SAMPLER_H_NC:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP_NC]]
+// CHECK-NOOFFSET: %[[CLAMP_CAST_NC:.*]] = fptrunc {{.*}} double {{.*}} to float
+// DXIL-NOOFFSET: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.sample.clamp.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE_NC]], target("dx.Sampler", 0) %[[SAMPLER_H_NC]], <[[COORD_DIM]] x float> %{{.*}}, <[[DIM]] x i32> zeroinitializer, float %[[CLAMP_CAST_NC]])
+// SPIRV-NOOFFSET: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.sample.clamp.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE_NC]], target("spirv.Sampler") %[[SAMPLER_H_NC]], <[[COORD_DIM]] x float> %{{.*}}, <[[DIM]] x i32> zeroinitializer, float %[[CLAMP_CAST_NC]])

--- a/clang/test/CodeGenHLSL/resources/Textures-SampleBias.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-SampleBias.hlsl
@@ -1,38 +1,57 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2D -DCOORD_TYPE=float2 %s \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2D \
+// RUN:   -DCOORD_TYPE=float2 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 \
-// RUN:   --check-prefixes=CHECK,DXIL -DDXIL_TY=2 -DRW=0 -DDIM=2 \
-// RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
-// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
-// RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2D -DCOORD_TYPE=float2 %s \
-// RUN:   | llvm-cxxfilt \
-// RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 \
-// RUN:   --check-prefixes=CHECK,SPIRV -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 \
-// RUN:   -DSPV_DIM=1 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-TEXEL,CHECK-OFFSET,DXIL-OFFSET \
+// RUN:   -DDXIL_TY=2 -DRW=0 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2DArray \
-// RUN:   -DCOORD_TYPE=float3 %s \
+// RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
-// RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DCOORD_DIM=3 \
-// RUN:   --check-prefixes=CHECK,DXIL -DDXIL_TY=7 -DRW=0 -DDIM=2 \
+// RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-NOTEXEL -DDXIL_TY=5 -DRW=0 -DDIM=3
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2D \
+// RUN:   -DCOORD_TYPE=float2 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-TEXEL,CHECK-OFFSET,SPIRV-OFFSET \
+// RUN:   -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=1 -DDIM=2 \
 // RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2DArray \
+// RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-NOTEXEL -DARRAYED=0 -DSAMPLED=1 \
+// RUN:   -DIMG_FMT=0 -DSPV_DIM=3 -DDIM=3
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2DArray \
 // RUN:   -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DCOORD_DIM=3 \
-// RUN:   --check-prefixes=CHECK,SPIRV -DARRAYED=1 -DSAMPLED=1 -DIMG_FMT=0 \
-// RUN:   -DSPV_DIM=1 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-TEXEL,CHECK-OFFSET,DXIL-OFFSET \
+// RUN:   -DDXIL_TY=7 -DRW=0 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2DArray \
+// RUN:   -DCOORD_TYPE=float3 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-TEXEL,CHECK-OFFSET,SPIRV-OFFSET \
+// RUN:   -DARRAYED=1 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=1 -DDIM=2 \
+// RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
 //
 //   OFFSET_ARG         a literal offset argument
+//   HAS_OFFSET         defined for types whose sampling and gathering methods
+//                      have overloads taking an offset
 //   TEXTURE            resource type name
 //   COORD_TYPE         sample location type (DIM components plus the array
 //                      slice)
@@ -46,11 +65,21 @@
 //   SAMPLED            spirv.Image Sampled operand
 //   IMG_FMT            spirv.Image Image Format operand
 //   SPV_DIM            spirv.Image Dim operand
+//
+// Check prefixes:
+//   TEXEL              the type has integer texel addressing (Load,
+//                      operator[], mips), and therefore a `mips` field in its
+//                      layout
+//   OFFSET             the sampling and gathering methods have offset
+//                      overloads
+//   NOTEXEL            the type has no integer texel addressing
 
-// DXIL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// DXIL-TEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// DXIL-NOTEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) }
 // DXIL: %"class.hlsl::SamplerState" = type { target("dx.Sampler", 0) }
 
-// SPIRV: %"class.hlsl::[[TEXTURE]]" = type { target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// SPIRV-TEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// SPIRV-NOTEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) }
 // SPIRV: %"class.hlsl::SamplerState" = type { target("spirv.Sampler") }
 
 TEXTURE<float4> t;
@@ -74,39 +103,43 @@ float4 test_bias(COORD_TYPE loc : LOC) : SV_Target {
 // DXIL: %{{.*}} = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.samplebias.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE1]], target("dx.Sampler", 0) %[[SAMPLER_H1]], <[[COORD_DIM]] x float> %{{.*}}, float %[[BIAS_CAST1]], <[[DIM]] x i32> zeroinitializer) [ "convergencectrl"(token %0) ]
 // SPIRV: %{{.*}} = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.samplebias.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE1]], target("spirv.Sampler") %[[SAMPLER_H1]], <[[COORD_DIM]] x float> %{{.*}}, float %[[BIAS_CAST1]], <[[DIM]] x i32> zeroinitializer) [ "convergencectrl"(token %0) ]
 
-// CHECK: @test_offset(float vector[[[COORD_DIM]]])
-// CHECK: %[[CALL_OFFSET:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleBias(hlsl::SamplerState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]])(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, float {{.*}} 0.000000e+00, <[[DIM]] x i32> noundef [[OFFSET_CONST]])
-// CHECK: ret <4 x float> %[[CALL_OFFSET]]
+// CHECK-OFFSET: @test_offset(float vector[[[COORD_DIM]]])
+// CHECK-OFFSET: %[[CALL_OFFSET:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleBias(hlsl::SamplerState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]])(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, float {{.*}} 0.000000e+00, <[[DIM]] x i32> noundef [[OFFSET_CONST]])
+// CHECK-OFFSET: ret <4 x float> %[[CALL_OFFSET]]
 
+#ifdef HAS_OFFSET
 float4 test_offset(COORD_TYPE loc : LOC) : SV_Target {
   return t.SampleBias(s, loc, 0.0f, OFFSET_ARG);
 }
+#endif
 
-// CHECK: define linkonce_odr hidden {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleBias(hlsl::SamplerState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]])(
-// CHECK: %[[THIS_VAL2:.*]] = load ptr, ptr %{{.*}}
-// CHECK: %[[HANDLE_GEP2:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL2]], i32 0, i32 0
-// CHECK: %[[HANDLE2:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP2]]
-// CHECK: %[[SAMPLER_GEP2:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerState", ptr %{{.*}}, i32 0, i32 0
-// CHECK: %[[SAMPLER_H2:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP2]]
-// CHECK: %[[BIAS_CAST2:.*]] = fptrunc {{.*}} double {{.*}} to float
-// DXIL: %{{.*}} = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.samplebias.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]])
-// SPIRV: %{{.*}} = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.samplebias.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]])
+// CHECK-OFFSET: define linkonce_odr hidden {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleBias(hlsl::SamplerState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]])(
+// CHECK-OFFSET: %[[THIS_VAL2:.*]] = load ptr, ptr %{{.*}}
+// CHECK-OFFSET: %[[HANDLE_GEP2:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL2]], i32 0, i32 0
+// CHECK-OFFSET: %[[HANDLE2:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP2]]
+// CHECK-OFFSET: %[[SAMPLER_GEP2:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerState", ptr %{{.*}}, i32 0, i32 0
+// CHECK-OFFSET: %[[SAMPLER_H2:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP2]]
+// CHECK-OFFSET: %[[BIAS_CAST2:.*]] = fptrunc {{.*}} double {{.*}} to float
+// DXIL-OFFSET: %{{.*}} = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.samplebias.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]])
+// SPIRV-OFFSET: %{{.*}} = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.samplebias.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]])
 
-// CHECK: @test_clamp(float vector[[[COORD_DIM]]])
-// CHECK: %[[CALL_CLAMP:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleBias(hlsl::SamplerState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]], float)(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, float {{.*}} 0.000000e+00, <[[DIM]] x i32> noundef [[OFFSET_CONST]], float {{.*}} 1.000000e+00)
-// CHECK: ret <4 x float> %[[CALL_CLAMP]]
+// CHECK-OFFSET: @test_clamp(float vector[[[COORD_DIM]]])
+// CHECK-OFFSET: %[[CALL_CLAMP:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleBias(hlsl::SamplerState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]], float)(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, float {{.*}} 0.000000e+00, <[[DIM]] x i32> noundef [[OFFSET_CONST]], float {{.*}} 1.000000e+00)
+// CHECK-OFFSET: ret <4 x float> %[[CALL_CLAMP]]
 
+#ifdef HAS_OFFSET
 float4 test_clamp(COORD_TYPE loc : LOC) : SV_Target {
   return t.SampleBias(s, loc, 0.0f, OFFSET_ARG, 1.0f);
 }
+#endif
 
-// CHECK: define linkonce_odr hidden {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleBias(hlsl::SamplerState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]], float)(
-// CHECK: %[[THIS_VAL3:.*]] = load ptr, ptr %{{.*}}
-// CHECK: %[[HANDLE_GEP3:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL3]], i32 0, i32 0
-// CHECK: %[[HANDLE3:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP3]]
-// CHECK: %[[SAMPLER_GEP3:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerState", ptr %{{.*}}, i32 0, i32 0
-// CHECK: %[[SAMPLER_H3:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP3]]
-// CHECK: %[[BIAS_CAST3:.*]] = fptrunc {{.*}} double {{.*}} to float
-// CHECK: %[[CLAMP_CAST3:.*]] = fptrunc {{.*}} double {{.*}} to float
-// DXIL: %{{.*}} = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.samplebias.clamp.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE3]], target("dx.Sampler", 0) %[[SAMPLER_H3]], <[[COORD_DIM]] x float> %{{.*}}, float %[[BIAS_CAST3]], <[[DIM]] x i32> %{{.*}}, float %[[CLAMP_CAST3]]) [ "convergencectrl"(token %0) ]
-// SPIRV: %{{.*}} = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.samplebias.clamp.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE3]], target("spirv.Sampler") %[[SAMPLER_H3]], <[[COORD_DIM]] x float> %{{.*}}, float %[[BIAS_CAST3]], <[[DIM]] x i32> %{{.*}}, float %[[CLAMP_CAST3]]) [ "convergencectrl"(token %0) ]
+// CHECK-OFFSET: define linkonce_odr hidden {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleBias(hlsl::SamplerState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]], float)(
+// CHECK-OFFSET: %[[THIS_VAL3:.*]] = load ptr, ptr %{{.*}}
+// CHECK-OFFSET: %[[HANDLE_GEP3:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL3]], i32 0, i32 0
+// CHECK-OFFSET: %[[HANDLE3:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP3]]
+// CHECK-OFFSET: %[[SAMPLER_GEP3:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerState", ptr %{{.*}}, i32 0, i32 0
+// CHECK-OFFSET: %[[SAMPLER_H3:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP3]]
+// CHECK-OFFSET: %[[BIAS_CAST3:.*]] = fptrunc {{.*}} double {{.*}} to float
+// CHECK-OFFSET: %[[CLAMP_CAST3:.*]] = fptrunc {{.*}} double {{.*}} to float
+// DXIL-OFFSET: %{{.*}} = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.samplebias.clamp.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE3]], target("dx.Sampler", 0) %[[SAMPLER_H3]], <[[COORD_DIM]] x float> %{{.*}}, float %[[BIAS_CAST3]], <[[DIM]] x i32> %{{.*}}, float %[[CLAMP_CAST3]]) [ "convergencectrl"(token %0) ]
+// SPIRV-OFFSET: %{{.*}} = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.samplebias.clamp.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE3]], target("spirv.Sampler") %[[SAMPLER_H3]], <[[COORD_DIM]] x float> %{{.*}}, float %[[BIAS_CAST3]], <[[DIM]] x i32> %{{.*}}, float %[[CLAMP_CAST3]]) [ "convergencectrl"(token %0) ]

--- a/clang/test/CodeGenHLSL/resources/Textures-SampleBias.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-SampleBias.hlsl
@@ -11,7 +11,7 @@
 // RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
-// RUN:   --check-prefixes=CHECK,DXIL,DXIL-NOTEXEL -DDXIL_TY=5 -DRW=0 -DDIM=3
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-NOTEXEL,CHECK-NOOFFSET,DXIL-NOOFFSET -DDXIL_TY=5 -DRW=0 -DDIM=3
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
 // RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2D \
@@ -26,7 +26,7 @@
 // RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
-// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-NOTEXEL -DARRAYED=0 -DSAMPLED=1 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-NOTEXEL,CHECK-NOOFFSET,SPIRV-NOOFFSET -DARRAYED=0 -DSAMPLED=1 \
 // RUN:   -DIMG_FMT=0 -DSPV_DIM=3 -DDIM=3
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
@@ -73,6 +73,8 @@
 //   OFFSET             the sampling and gathering methods have offset
 //                      overloads
 //   NOTEXEL            the type has no integer texel addressing
+//   NOOFFSET           the sampling methods have no offset overloads, so
+//                      their clamp overload takes the offset's place
 
 // DXIL-TEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
 // DXIL-NOTEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) }
@@ -107,6 +109,7 @@ float4 test_bias(COORD_TYPE loc : LOC) : SV_Target {
 // CHECK-OFFSET: %[[CALL_OFFSET:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleBias(hlsl::SamplerState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]])(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, float {{.*}} 0.000000e+00, <[[DIM]] x i32> noundef [[OFFSET_CONST]])
 // CHECK-OFFSET: ret <4 x float> %[[CALL_OFFSET]]
 
+
 #ifdef HAS_OFFSET
 float4 test_offset(COORD_TYPE loc : LOC) : SV_Target {
   return t.SampleBias(s, loc, 0.0f, OFFSET_ARG);
@@ -127,9 +130,19 @@ float4 test_offset(COORD_TYPE loc : LOC) : SV_Target {
 // CHECK-OFFSET: %[[CALL_CLAMP:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleBias(hlsl::SamplerState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]], float)(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, float {{.*}} 0.000000e+00, <[[DIM]] x i32> noundef [[OFFSET_CONST]], float {{.*}} 1.000000e+00)
 // CHECK-OFFSET: ret <4 x float> %[[CALL_CLAMP]]
 
+// CHECK-NOOFFSET: @test_clamp(
+// CHECK-NOOFFSET: %[[CALL_NC:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleBias(hlsl::SamplerState, float vector[[[COORD_DIM]]], float, float)(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, float {{.*}} 0.000000e+00, float {{.*}} 1.000000e+00)
+// CHECK-NOOFFSET: ret <4 x float> %[[CALL_NC]]
+
 #ifdef HAS_OFFSET
 float4 test_clamp(COORD_TYPE loc : LOC) : SV_Target {
   return t.SampleBias(s, loc, 0.0f, OFFSET_ARG, 1.0f);
+}
+#else
+// Cube textures have no offset overload, so the clamp takes the offset's place
+// in the method signature; the intrinsic still receives a zero offset.
+float4 test_clamp(COORD_TYPE loc : LOC) : SV_Target {
+  return t.SampleBias(s, loc, 0.0f, 1.0f);
 }
 #endif
 
@@ -143,3 +156,14 @@ float4 test_clamp(COORD_TYPE loc : LOC) : SV_Target {
 // CHECK-OFFSET: %[[CLAMP_CAST3:.*]] = fptrunc {{.*}} double {{.*}} to float
 // DXIL-OFFSET: %{{.*}} = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.samplebias.clamp.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE3]], target("dx.Sampler", 0) %[[SAMPLER_H3]], <[[COORD_DIM]] x float> %{{.*}}, float %[[BIAS_CAST3]], <[[DIM]] x i32> %{{.*}}, float %[[CLAMP_CAST3]]) [ "convergencectrl"(token %0) ]
 // SPIRV-OFFSET: %{{.*}} = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.samplebias.clamp.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE3]], target("spirv.Sampler") %[[SAMPLER_H3]], <[[COORD_DIM]] x float> %{{.*}}, float %[[BIAS_CAST3]], <[[DIM]] x i32> %{{.*}}, float %[[CLAMP_CAST3]]) [ "convergencectrl"(token %0) ]
+
+// CHECK-NOOFFSET: define linkonce_odr hidden {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleBias(hlsl::SamplerState, float vector[[[COORD_DIM]]], float, float)(
+// CHECK-NOOFFSET: %[[THIS_VAL_NC:.*]] = load ptr, ptr %{{.*}}
+// CHECK-NOOFFSET: %[[HANDLE_GEP_NC:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL_NC]], i32 0, i32 0
+// CHECK-NOOFFSET: %[[HANDLE_NC:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP_NC]]
+// CHECK-NOOFFSET: %[[SAMPLER_GEP_NC:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerState", ptr %{{.*}}, i32 0, i32 0
+// CHECK-NOOFFSET: %[[SAMPLER_H_NC:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP_NC]]
+// CHECK-NOOFFSET: %[[BIAS_CAST_NC:.*]] = fptrunc {{.*}} double {{.*}} to float
+// CHECK-NOOFFSET: %[[CLAMP_CAST_NC:.*]] = fptrunc {{.*}} double {{.*}} to float
+// DXIL-NOOFFSET: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.samplebias.clamp.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE_NC]], target("dx.Sampler", 0) %[[SAMPLER_H_NC]], <[[COORD_DIM]] x float> %{{.*}}, float %[[BIAS_CAST_NC]], <[[DIM]] x i32> zeroinitializer, float %[[CLAMP_CAST_NC]])
+// SPIRV-NOOFFSET: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.samplebias.clamp.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE_NC]], target("spirv.Sampler") %[[SAMPLER_H_NC]], <[[COORD_DIM]] x float> %{{.*}}, float %[[BIAS_CAST_NC]], <[[DIM]] x i32> zeroinitializer, float %[[CLAMP_CAST_NC]])

--- a/clang/test/CodeGenHLSL/resources/Textures-SampleCmp.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-SampleCmp.hlsl
@@ -1,38 +1,57 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2D -DCOORD_TYPE=float2 %s \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2D \
+// RUN:   -DCOORD_TYPE=float2 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 \
-// RUN:   --check-prefixes=CHECK,DXIL -DDXIL_TY=2 -DRW=0 -DDIM=2 \
-// RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
-// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
-// RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2D -DCOORD_TYPE=float2 %s \
-// RUN:   | llvm-cxxfilt \
-// RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 \
-// RUN:   --check-prefixes=CHECK,SPIRV -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 \
-// RUN:   -DSPV_DIM=1 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-TEXEL,CHECK-OFFSET,DXIL-OFFSET \
+// RUN:   -DDXIL_TY=2 -DRW=0 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2DArray \
-// RUN:   -DCOORD_TYPE=float3 %s \
+// RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
-// RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DCOORD_DIM=3 \
-// RUN:   --check-prefixes=CHECK,DXIL -DDXIL_TY=7 -DRW=0 -DDIM=2 \
+// RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-NOTEXEL -DDXIL_TY=5 -DRW=0 -DDIM=3
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2D \
+// RUN:   -DCOORD_TYPE=float2 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-TEXEL,CHECK-OFFSET,SPIRV-OFFSET \
+// RUN:   -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=1 -DDIM=2 \
 // RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2DArray \
+// RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-NOTEXEL -DARRAYED=0 -DSAMPLED=1 \
+// RUN:   -DIMG_FMT=0 -DSPV_DIM=3 -DDIM=3
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2DArray \
 // RUN:   -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DCOORD_DIM=3 \
-// RUN:   --check-prefixes=CHECK,SPIRV -DARRAYED=1 -DSAMPLED=1 -DIMG_FMT=0 \
-// RUN:   -DSPV_DIM=1 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-TEXEL,CHECK-OFFSET,DXIL-OFFSET \
+// RUN:   -DDXIL_TY=7 -DRW=0 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2DArray \
+// RUN:   -DCOORD_TYPE=float3 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-TEXEL,CHECK-OFFSET,SPIRV-OFFSET \
+// RUN:   -DARRAYED=1 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=1 -DDIM=2 \
+// RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
 //
 //   OFFSET_ARG         a literal offset argument
+//   HAS_OFFSET         defined for types whose sampling and gathering methods
+//                      have overloads taking an offset
 //   TEXTURE            resource type name
 //   COORD_TYPE         sample location type (DIM components plus the array
 //                      slice)
@@ -46,11 +65,21 @@
 //   SAMPLED            spirv.Image Sampled operand
 //   IMG_FMT            spirv.Image Image Format operand
 //   SPV_DIM            spirv.Image Dim operand
+//
+// Check prefixes:
+//   TEXEL              the type has integer texel addressing (Load,
+//                      operator[], mips), and therefore a `mips` field in its
+//                      layout
+//   OFFSET             the sampling and gathering methods have offset
+//                      overloads
+//   NOTEXEL            the type has no integer texel addressing
 
-// DXIL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// DXIL-TEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// DXIL-NOTEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) }
 // DXIL: %"class.hlsl::SamplerComparisonState" = type { target("dx.Sampler", 0) }
 
-// SPIRV: %"class.hlsl::[[TEXTURE]]" = type { target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// SPIRV-TEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// SPIRV-NOTEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) }
 // SPIRV: %"class.hlsl::SamplerComparisonState" = type { target("spirv.Sampler") }
 
 TEXTURE<float4> t;
@@ -77,48 +106,52 @@ float test_cmp(COORD_TYPE loc : LOC, float cmp : CMP) : SV_Target {
 // DXIL: call reassoc nnan ninf nsz arcp afn float @llvm.dx.resource.samplecmp.f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE1]], target("dx.Sampler", 0) %[[SAMPLER_H1]], <[[COORD_DIM]] x float> %[[COORD_VAL1]], float %[[CMP_CAST1]], <[[DIM]] x i32> zeroinitializer)
 // SPIRV: call reassoc nnan ninf nsz arcp afn float @llvm.spv.resource.samplecmp.f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE1]], target("spirv.Sampler") %[[SAMPLER_H1]], <[[COORD_DIM]] x float> %[[COORD_VAL1]], float %[[CMP_CAST1]], <[[DIM]] x i32> zeroinitializer)
 
-// CHECK: @test_offset(float vector[[[COORD_DIM]]], float)
-// CHECK: %[[CALL_OFFSET:.*]] = call {{.*}} float @hlsl::[[TEXTURE]]<float vector[4]>::SampleCmp(hlsl::SamplerComparisonState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]])(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerComparisonState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, float {{.*}} 0.000000e+00, <[[DIM]] x i32> noundef [[OFFSET_CONST]])
-// CHECK: ret float %[[CALL_OFFSET]]
+// CHECK-OFFSET: @test_offset(float vector[[[COORD_DIM]]], float)
+// CHECK-OFFSET: %[[CALL_OFFSET:.*]] = call {{.*}} float @hlsl::[[TEXTURE]]<float vector[4]>::SampleCmp(hlsl::SamplerComparisonState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]])(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerComparisonState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, float {{.*}} 0.000000e+00, <[[DIM]] x i32> noundef [[OFFSET_CONST]])
+// CHECK-OFFSET: ret float %[[CALL_OFFSET]]
 
+#ifdef HAS_OFFSET
 float test_offset(COORD_TYPE loc : LOC, float cmp : CMP) : SV_Target {
   return t.SampleCmp(s, loc, 0.0f, OFFSET_ARG);
 }
+#endif
 
-// CHECK: define linkonce_odr hidden {{.*}} float @hlsl::[[TEXTURE]]<float vector[4]>::SampleCmp(hlsl::SamplerComparisonState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]])(
-// CHECK-SAME: ptr noundef nonnull {{.*}} %[[THIS2:[^,]+]], ptr noundef byval(%"class.hlsl::SamplerComparisonState") {{.*}} %[[SAMPLER2:[^,]+]], <[[COORD_DIM]] x float> noundef nofpclass(nan inf) %[[COORD2:[^,]+]], float noundef nofpclass(nan inf) %[[CMP2:[^,]+]], <[[DIM]] x i32> noundef %[[OFFSET2:[^)]+]])
-// CHECK: %[[THIS_VAL2:.*]] = load ptr, ptr %{{.*}}
-// CHECK: %[[HANDLE_GEP2:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL2]], i32 0, i32 0
-// CHECK: %[[HANDLE2:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP2]]
-// CHECK: %[[SAMPLER_GEP2:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerComparisonState", ptr %[[SAMPLER2]], i32 0, i32 0
-// CHECK: %[[SAMPLER_H2:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP2]]
-// CHECK: %[[COORD_VAL2:.*]] = load <[[COORD_DIM]] x float>, ptr %{{.*}}
-// CHECK: %[[CMP_VAL2:.*]] = load float, ptr %{{.*}}
-// CHECK: %[[CMP_CAST2:.*]] = fptrunc {{.*}} double {{.*}} to float
-// CHECK: %[[OFFSET_VAL2:.*]] = load <[[DIM]] x i32>, ptr %{{.*}}
-// DXIL: call reassoc nnan ninf nsz arcp afn float @llvm.dx.resource.samplecmp.f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE2]], target("dx.Sampler", 0) %[[SAMPLER_H2]], <[[COORD_DIM]] x float> %[[COORD_VAL2]], float %[[CMP_CAST2]], <[[DIM]] x i32> %[[OFFSET_VAL2]])
-// SPIRV: call reassoc nnan ninf nsz arcp afn float @llvm.spv.resource.samplecmp.f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE2]], target("spirv.Sampler") %[[SAMPLER_H2]], <[[COORD_DIM]] x float> %[[COORD_VAL2]], float %[[CMP_CAST2]], <[[DIM]] x i32> %[[OFFSET_VAL2]])
+// CHECK-OFFSET: define linkonce_odr hidden {{.*}} float @hlsl::[[TEXTURE]]<float vector[4]>::SampleCmp(hlsl::SamplerComparisonState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]])(
+// CHECK-OFFSET-SAME: ptr noundef nonnull {{.*}} %[[THIS2:[^,]+]], ptr noundef byval(%"class.hlsl::SamplerComparisonState") {{.*}} %[[SAMPLER2:[^,]+]], <[[COORD_DIM]] x float> noundef nofpclass(nan inf) %[[COORD2:[^,]+]], float noundef nofpclass(nan inf) %[[CMP2:[^,]+]], <[[DIM]] x i32> noundef %[[OFFSET2:[^)]+]])
+// CHECK-OFFSET: %[[THIS_VAL2:.*]] = load ptr, ptr %{{.*}}
+// CHECK-OFFSET: %[[HANDLE_GEP2:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL2]], i32 0, i32 0
+// CHECK-OFFSET: %[[HANDLE2:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP2]]
+// CHECK-OFFSET: %[[SAMPLER_GEP2:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerComparisonState", ptr %[[SAMPLER2]], i32 0, i32 0
+// CHECK-OFFSET: %[[SAMPLER_H2:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP2]]
+// CHECK-OFFSET: %[[COORD_VAL2:.*]] = load <[[COORD_DIM]] x float>, ptr %{{.*}}
+// CHECK-OFFSET: %[[CMP_VAL2:.*]] = load float, ptr %{{.*}}
+// CHECK-OFFSET: %[[CMP_CAST2:.*]] = fptrunc {{.*}} double {{.*}} to float
+// CHECK-OFFSET: %[[OFFSET_VAL2:.*]] = load <[[DIM]] x i32>, ptr %{{.*}}
+// DXIL-OFFSET: call reassoc nnan ninf nsz arcp afn float @llvm.dx.resource.samplecmp.f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE2]], target("dx.Sampler", 0) %[[SAMPLER_H2]], <[[COORD_DIM]] x float> %[[COORD_VAL2]], float %[[CMP_CAST2]], <[[DIM]] x i32> %[[OFFSET_VAL2]])
+// SPIRV-OFFSET: call reassoc nnan ninf nsz arcp afn float @llvm.spv.resource.samplecmp.f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE2]], target("spirv.Sampler") %[[SAMPLER_H2]], <[[COORD_DIM]] x float> %[[COORD_VAL2]], float %[[CMP_CAST2]], <[[DIM]] x i32> %[[OFFSET_VAL2]])
 
-// CHECK: @test_clamp(float vector[[[COORD_DIM]]], float)
-// CHECK: %[[CALL_CLAMP:.*]] = call {{.*}} float @hlsl::[[TEXTURE]]<float vector[4]>::SampleCmp(hlsl::SamplerComparisonState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]], float)(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerComparisonState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, float {{.*}} 0.000000e+00, <[[DIM]] x i32> noundef [[OFFSET_CONST]], float {{.*}} 1.000000e+00)
-// CHECK: ret float %[[CALL_CLAMP]]
+// CHECK-OFFSET: @test_clamp(float vector[[[COORD_DIM]]], float)
+// CHECK-OFFSET: %[[CALL_CLAMP:.*]] = call {{.*}} float @hlsl::[[TEXTURE]]<float vector[4]>::SampleCmp(hlsl::SamplerComparisonState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]], float)(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerComparisonState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, float {{.*}} 0.000000e+00, <[[DIM]] x i32> noundef [[OFFSET_CONST]], float {{.*}} 1.000000e+00)
+// CHECK-OFFSET: ret float %[[CALL_CLAMP]]
 
+#ifdef HAS_OFFSET
 float test_clamp(COORD_TYPE loc : LOC, float cmp : CMP) : SV_Target {
   return t.SampleCmp(s, loc, 0.0f, OFFSET_ARG, 1.0f);
 }
+#endif
 
-// CHECK: define linkonce_odr hidden {{.*}} float @hlsl::[[TEXTURE]]<float vector[4]>::SampleCmp(hlsl::SamplerComparisonState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]], float)(
-// CHECK-SAME: ptr noundef nonnull {{.*}} %[[THIS3:[^,]+]], ptr noundef byval(%"class.hlsl::SamplerComparisonState") {{.*}} %[[SAMPLER3:[^,]+]], <[[COORD_DIM]] x float> noundef nofpclass(nan inf) %[[COORD3:[^,]+]], float noundef nofpclass(nan inf) %[[CMP3:[^,]+]], <[[DIM]] x i32> noundef %[[OFFSET3:[^,]+]], float noundef nofpclass(nan inf) %[[CLAMP3:[^)]+]])
-// CHECK: %[[THIS_VAL3:.*]] = load ptr, ptr %{{.*}}
-// CHECK: %[[HANDLE_GEP3:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL3]], i32 0, i32 0
-// CHECK: %[[HANDLE3:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP3]]
-// CHECK: %[[SAMPLER_GEP3:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerComparisonState", ptr %[[SAMPLER3]], i32 0, i32 0
-// CHECK: %[[SAMPLER_H3:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP3]]
-// CHECK: %[[COORD_VAL3:.*]] = load <[[COORD_DIM]] x float>, ptr %{{.*}}
-// CHECK: %[[CMP_VAL3:.*]] = load float, ptr %{{.*}}
-// CHECK: %[[CMP_CAST3:.*]] = fptrunc {{.*}} double {{.*}} to float
-// CHECK: %[[OFFSET_VAL3:.*]] = load <[[DIM]] x i32>, ptr %{{.*}}
-// CHECK: %[[CLAMP_VAL3:.*]] = load float, ptr %{{.*}}
-// CHECK: %[[CLAMP_CAST3:.*]] = fptrunc {{.*}} double {{.*}} to float
-// DXIL: call reassoc nnan ninf nsz arcp afn float @llvm.dx.resource.samplecmp.clamp.f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE3]], target("dx.Sampler", 0) %[[SAMPLER_H3]], <[[COORD_DIM]] x float> %[[COORD_VAL3]], float %[[CMP_CAST3]], <[[DIM]] x i32> %[[OFFSET_VAL3]], float %[[CLAMP_CAST3]])
-// SPIRV: call reassoc nnan ninf nsz arcp afn float @llvm.spv.resource.samplecmp.clamp.f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE3]], target("spirv.Sampler") %[[SAMPLER_H3]], <[[COORD_DIM]] x float> %[[COORD_VAL3]], float %[[CMP_CAST3]], <[[DIM]] x i32> %[[OFFSET_VAL3]], float %[[CLAMP_CAST3]])
+// CHECK-OFFSET: define linkonce_odr hidden {{.*}} float @hlsl::[[TEXTURE]]<float vector[4]>::SampleCmp(hlsl::SamplerComparisonState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]], float)(
+// CHECK-OFFSET-SAME: ptr noundef nonnull {{.*}} %[[THIS3:[^,]+]], ptr noundef byval(%"class.hlsl::SamplerComparisonState") {{.*}} %[[SAMPLER3:[^,]+]], <[[COORD_DIM]] x float> noundef nofpclass(nan inf) %[[COORD3:[^,]+]], float noundef nofpclass(nan inf) %[[CMP3:[^,]+]], <[[DIM]] x i32> noundef %[[OFFSET3:[^,]+]], float noundef nofpclass(nan inf) %[[CLAMP3:[^)]+]])
+// CHECK-OFFSET: %[[THIS_VAL3:.*]] = load ptr, ptr %{{.*}}
+// CHECK-OFFSET: %[[HANDLE_GEP3:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL3]], i32 0, i32 0
+// CHECK-OFFSET: %[[HANDLE3:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP3]]
+// CHECK-OFFSET: %[[SAMPLER_GEP3:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerComparisonState", ptr %[[SAMPLER3]], i32 0, i32 0
+// CHECK-OFFSET: %[[SAMPLER_H3:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP3]]
+// CHECK-OFFSET: %[[COORD_VAL3:.*]] = load <[[COORD_DIM]] x float>, ptr %{{.*}}
+// CHECK-OFFSET: %[[CMP_VAL3:.*]] = load float, ptr %{{.*}}
+// CHECK-OFFSET: %[[CMP_CAST3:.*]] = fptrunc {{.*}} double {{.*}} to float
+// CHECK-OFFSET: %[[OFFSET_VAL3:.*]] = load <[[DIM]] x i32>, ptr %{{.*}}
+// CHECK-OFFSET: %[[CLAMP_VAL3:.*]] = load float, ptr %{{.*}}
+// CHECK-OFFSET: %[[CLAMP_CAST3:.*]] = fptrunc {{.*}} double {{.*}} to float
+// DXIL-OFFSET: call reassoc nnan ninf nsz arcp afn float @llvm.dx.resource.samplecmp.clamp.f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE3]], target("dx.Sampler", 0) %[[SAMPLER_H3]], <[[COORD_DIM]] x float> %[[COORD_VAL3]], float %[[CMP_CAST3]], <[[DIM]] x i32> %[[OFFSET_VAL3]], float %[[CLAMP_CAST3]])
+// SPIRV-OFFSET: call reassoc nnan ninf nsz arcp afn float @llvm.spv.resource.samplecmp.clamp.f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE3]], target("spirv.Sampler") %[[SAMPLER_H3]], <[[COORD_DIM]] x float> %[[COORD_VAL3]], float %[[CMP_CAST3]], <[[DIM]] x i32> %[[OFFSET_VAL3]], float %[[CLAMP_CAST3]])

--- a/clang/test/CodeGenHLSL/resources/Textures-SampleCmp.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-SampleCmp.hlsl
@@ -11,7 +11,7 @@
 // RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
-// RUN:   --check-prefixes=CHECK,DXIL,DXIL-NOTEXEL -DDXIL_TY=5 -DRW=0 -DDIM=3
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-NOTEXEL,CHECK-NOOFFSET,DXIL-NOOFFSET -DDXIL_TY=5 -DRW=0 -DDIM=3
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
 // RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2D \
@@ -26,7 +26,7 @@
 // RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
-// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-NOTEXEL -DARRAYED=0 -DSAMPLED=1 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-NOTEXEL,CHECK-NOOFFSET,SPIRV-NOOFFSET -DARRAYED=0 -DSAMPLED=1 \
 // RUN:   -DIMG_FMT=0 -DSPV_DIM=3 -DDIM=3
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
@@ -73,6 +73,8 @@
 //   OFFSET             the sampling and gathering methods have offset
 //                      overloads
 //   NOTEXEL            the type has no integer texel addressing
+//   NOOFFSET           the sampling methods have no offset overloads, so
+//                      their clamp overload takes the offset's place
 
 // DXIL-TEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
 // DXIL-NOTEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) }
@@ -110,6 +112,7 @@ float test_cmp(COORD_TYPE loc : LOC, float cmp : CMP) : SV_Target {
 // CHECK-OFFSET: %[[CALL_OFFSET:.*]] = call {{.*}} float @hlsl::[[TEXTURE]]<float vector[4]>::SampleCmp(hlsl::SamplerComparisonState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]])(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerComparisonState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, float {{.*}} 0.000000e+00, <[[DIM]] x i32> noundef [[OFFSET_CONST]])
 // CHECK-OFFSET: ret float %[[CALL_OFFSET]]
 
+
 #ifdef HAS_OFFSET
 float test_offset(COORD_TYPE loc : LOC, float cmp : CMP) : SV_Target {
   return t.SampleCmp(s, loc, 0.0f, OFFSET_ARG);
@@ -134,9 +137,19 @@ float test_offset(COORD_TYPE loc : LOC, float cmp : CMP) : SV_Target {
 // CHECK-OFFSET: %[[CALL_CLAMP:.*]] = call {{.*}} float @hlsl::[[TEXTURE]]<float vector[4]>::SampleCmp(hlsl::SamplerComparisonState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]], float)(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerComparisonState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, float {{.*}} 0.000000e+00, <[[DIM]] x i32> noundef [[OFFSET_CONST]], float {{.*}} 1.000000e+00)
 // CHECK-OFFSET: ret float %[[CALL_CLAMP]]
 
+// CHECK-NOOFFSET: @test_clamp(
+// CHECK-NOOFFSET: %[[CALL_NC:.*]] = call {{.*}} float @hlsl::[[TEXTURE]]<float vector[4]>::SampleCmp(hlsl::SamplerComparisonState, float vector[[[COORD_DIM]]], float, float)(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerComparisonState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, float {{.*}} 0.000000e+00, float {{.*}} 1.000000e+00)
+// CHECK-NOOFFSET: ret float %[[CALL_NC]]
+
 #ifdef HAS_OFFSET
 float test_clamp(COORD_TYPE loc : LOC, float cmp : CMP) : SV_Target {
   return t.SampleCmp(s, loc, 0.0f, OFFSET_ARG, 1.0f);
+}
+#else
+// Cube textures have no offset overload, so the clamp takes the offset's place
+// in the method signature; the intrinsic still receives a zero offset.
+float test_clamp(COORD_TYPE loc : LOC, float cmp : CMP) : SV_Target {
+  return t.SampleCmp(s, loc, 0.0f, 1.0f);
 }
 #endif
 
@@ -155,3 +168,14 @@ float test_clamp(COORD_TYPE loc : LOC, float cmp : CMP) : SV_Target {
 // CHECK-OFFSET: %[[CLAMP_CAST3:.*]] = fptrunc {{.*}} double {{.*}} to float
 // DXIL-OFFSET: call reassoc nnan ninf nsz arcp afn float @llvm.dx.resource.samplecmp.clamp.f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE3]], target("dx.Sampler", 0) %[[SAMPLER_H3]], <[[COORD_DIM]] x float> %[[COORD_VAL3]], float %[[CMP_CAST3]], <[[DIM]] x i32> %[[OFFSET_VAL3]], float %[[CLAMP_CAST3]])
 // SPIRV-OFFSET: call reassoc nnan ninf nsz arcp afn float @llvm.spv.resource.samplecmp.clamp.f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE3]], target("spirv.Sampler") %[[SAMPLER_H3]], <[[COORD_DIM]] x float> %[[COORD_VAL3]], float %[[CMP_CAST3]], <[[DIM]] x i32> %[[OFFSET_VAL3]], float %[[CLAMP_CAST3]])
+
+// CHECK-NOOFFSET: define linkonce_odr hidden {{.*}} float @hlsl::[[TEXTURE]]<float vector[4]>::SampleCmp(hlsl::SamplerComparisonState, float vector[[[COORD_DIM]]], float, float)(
+// CHECK-NOOFFSET: %[[THIS_VAL_NC:.*]] = load ptr, ptr %{{.*}}
+// CHECK-NOOFFSET: %[[HANDLE_GEP_NC:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL_NC]], i32 0, i32 0
+// CHECK-NOOFFSET: %[[HANDLE_NC:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP_NC]]
+// CHECK-NOOFFSET: %[[SAMPLER_GEP_NC:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerComparisonState", ptr %{{.*}}, i32 0, i32 0
+// CHECK-NOOFFSET: %[[SAMPLER_H_NC:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP_NC]]
+// CHECK-NOOFFSET: %[[CMP_CAST_NC:.*]] = fptrunc {{.*}} double {{.*}} to float
+// CHECK-NOOFFSET: %[[CLAMP_CAST_NC:.*]] = fptrunc {{.*}} double {{.*}} to float
+// DXIL-NOOFFSET: call reassoc nnan ninf nsz arcp afn float @llvm.dx.resource.samplecmp.clamp.f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE_NC]], target("dx.Sampler", 0) %[[SAMPLER_H_NC]], <[[COORD_DIM]] x float> %{{.*}}, float %[[CMP_CAST_NC]], <[[DIM]] x i32> zeroinitializer, float %[[CLAMP_CAST_NC]])
+// SPIRV-NOOFFSET: call reassoc nnan ninf nsz arcp afn float @llvm.spv.resource.samplecmp.clamp.f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE_NC]], target("spirv.Sampler") %[[SAMPLER_H_NC]], <[[COORD_DIM]] x float> %{{.*}}, float %[[CMP_CAST_NC]], <[[DIM]] x i32> zeroinitializer, float %[[CLAMP_CAST_NC]])

--- a/clang/test/CodeGenHLSL/resources/Textures-SampleCmpLevelZero.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-SampleCmpLevelZero.hlsl
@@ -1,38 +1,57 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2D -DCOORD_TYPE=float2 %s \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2D \
+// RUN:   -DCOORD_TYPE=float2 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 \
-// RUN:   --check-prefixes=CHECK,DXIL -DDXIL_TY=2 -DRW=0 -DDIM=2 \
-// RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
-// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
-// RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2D -DCOORD_TYPE=float2 %s \
-// RUN:   | llvm-cxxfilt \
-// RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 \
-// RUN:   --check-prefixes=CHECK,SPIRV -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 \
-// RUN:   -DSPV_DIM=1 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN:   --check-prefixes=CHECK,DXIL,CHECK-OFFSET,DXIL-OFFSET -DDXIL_TY=2 \
+// RUN:   -DRW=0 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2DArray \
-// RUN:   -DCOORD_TYPE=float3 %s \
+// RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
-// RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DCOORD_DIM=3 \
-// RUN:   --check-prefixes=CHECK,DXIL -DDXIL_TY=7 -DRW=0 -DDIM=2 \
+// RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,DXIL -DDXIL_TY=5 -DRW=0 -DDIM=3
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2D \
+// RUN:   -DCOORD_TYPE=float2 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 \
+// RUN:   --check-prefixes=CHECK,SPIRV,CHECK-OFFSET,SPIRV-OFFSET -DARRAYED=0 \
+// RUN:   -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=1 -DDIM=2 \
 // RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2DArray \
+// RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,SPIRV -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 \
+// RUN:   -DSPV_DIM=3 -DDIM=3
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2DArray \
 // RUN:   -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DCOORD_DIM=3 \
-// RUN:   --check-prefixes=CHECK,SPIRV -DARRAYED=1 -DSAMPLED=1 -DIMG_FMT=0 \
-// RUN:   -DSPV_DIM=1 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN:   --check-prefixes=CHECK,DXIL,CHECK-OFFSET,DXIL-OFFSET -DDXIL_TY=7 \
+// RUN:   -DRW=0 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2DArray \
+// RUN:   -DCOORD_TYPE=float3 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,SPIRV,CHECK-OFFSET,SPIRV-OFFSET -DARRAYED=1 \
+// RUN:   -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=1 -DDIM=2 \
+// RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
 //
 //   OFFSET_ARG         a literal offset argument
+//   HAS_OFFSET         defined for types whose sampling and gathering methods
+//                      have overloads taking an offset
 //   TEXTURE            resource type name
 //   COORD_TYPE         sample location type (DIM components plus the array
 //                      slice)
@@ -46,6 +65,10 @@
 //   SAMPLED            spirv.Image Sampled operand
 //   IMG_FMT            spirv.Image Image Format operand
 //   SPV_DIM            spirv.Image Dim operand
+//
+// Check prefixes:
+//   OFFSET             the sampling and gathering methods have offset
+//                      overloads
 
 TEXTURE<float4> t;
 SamplerComparisonState s;
@@ -71,24 +94,26 @@ float test_cmp_level_zero(COORD_TYPE loc : LOC, float cmp : CMP) : SV_Target {
 // DXIL: call reassoc nnan ninf nsz arcp afn float @llvm.dx.resource.samplecmplevelzero.f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE1]], target("dx.Sampler", 0) %[[SAMPLER_H1]], <[[COORD_DIM]] x float> %[[COORD_VAL1]], float %[[CMP_CAST1]], <[[DIM]] x i32> zeroinitializer)
 // SPIRV: call reassoc nnan ninf nsz arcp afn float @llvm.spv.resource.samplecmplevelzero.f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE1]], target("spirv.Sampler") %[[SAMPLER_H1]], <[[COORD_DIM]] x float> %[[COORD_VAL1]], float %[[CMP_CAST1]], <[[DIM]] x i32> zeroinitializer)
 
-// CHECK: @test_cmp_level_zero_offset(float vector[[[COORD_DIM]]], float)
-// CHECK: %[[CALL_OFFSET:.*]] = call {{.*}} float @hlsl::[[TEXTURE]]<float vector[4]>::SampleCmpLevelZero(hlsl::SamplerComparisonState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]])(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerComparisonState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, float {{.*}} 0.000000e+00, <[[DIM]] x i32> noundef [[OFFSET_CONST]])
-// CHECK: ret float %[[CALL_OFFSET]]
+// CHECK-OFFSET: @test_cmp_level_zero_offset(float vector[[[COORD_DIM]]], float)
+// CHECK-OFFSET: %[[CALL_OFFSET:.*]] = call {{.*}} float @hlsl::[[TEXTURE]]<float vector[4]>::SampleCmpLevelZero(hlsl::SamplerComparisonState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]])(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerComparisonState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, float {{.*}} 0.000000e+00, <[[DIM]] x i32> noundef [[OFFSET_CONST]])
+// CHECK-OFFSET: ret float %[[CALL_OFFSET]]
 
+#ifdef HAS_OFFSET
 float test_cmp_level_zero_offset(COORD_TYPE loc : LOC, float cmp : CMP) : SV_Target {
   return t.SampleCmpLevelZero(s, loc, 0.0f, OFFSET_ARG);
 }
+#endif
 
-// CHECK: define linkonce_odr hidden {{.*}} float @hlsl::[[TEXTURE]]<float vector[4]>::SampleCmpLevelZero(hlsl::SamplerComparisonState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]])(
-// CHECK-SAME: ptr noundef nonnull {{.*}} %[[THIS2:[^,]+]], ptr noundef byval(%"class.hlsl::SamplerComparisonState") {{.*}} %[[SAMPLER2:[^,]+]], <[[COORD_DIM]] x float> noundef nofpclass(nan inf) %[[COORD2:[^,]+]], float noundef nofpclass(nan inf) %[[CMP2:[^,]+]], <[[DIM]] x i32> noundef %[[OFFSET2:[^)]+]])
-// CHECK: %[[THIS_VAL2:.*]] = load ptr, ptr %{{.*}}
-// CHECK: %[[HANDLE_GEP2:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL2]], i32 0, i32 0
-// CHECK: %[[HANDLE2:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP2]]
-// CHECK: %[[SAMPLER_GEP2:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerComparisonState", ptr %[[SAMPLER2]], i32 0, i32 0
-// CHECK: %[[SAMPLER_H2:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP2]]
-// CHECK: %[[COORD_VAL2:.*]] = load <[[COORD_DIM]] x float>, ptr %{{.*}}
-// CHECK: %[[CMP_VAL2:.*]] = load float, ptr %{{.*}}
-// CHECK: %[[CMP_CAST2:.*]] = fptrunc {{.*}} double {{.*}} to float
-// CHECK: %[[OFFSET_VAL2:.*]] = load <[[DIM]] x i32>, ptr %{{.*}}
-// DXIL: call reassoc nnan ninf nsz arcp afn float @llvm.dx.resource.samplecmplevelzero.f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE2]], target("dx.Sampler", 0) %[[SAMPLER_H2]], <[[COORD_DIM]] x float> %[[COORD_VAL2]], float %[[CMP_CAST2]], <[[DIM]] x i32> %[[OFFSET_VAL2]])
-// SPIRV: call reassoc nnan ninf nsz arcp afn float @llvm.spv.resource.samplecmplevelzero.f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE2]], target("spirv.Sampler") %[[SAMPLER_H2]], <[[COORD_DIM]] x float> %[[COORD_VAL2]], float %[[CMP_CAST2]], <[[DIM]] x i32> %[[OFFSET_VAL2]])
+// CHECK-OFFSET: define linkonce_odr hidden {{.*}} float @hlsl::[[TEXTURE]]<float vector[4]>::SampleCmpLevelZero(hlsl::SamplerComparisonState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]])(
+// CHECK-OFFSET-SAME: ptr noundef nonnull {{.*}} %[[THIS2:[^,]+]], ptr noundef byval(%"class.hlsl::SamplerComparisonState") {{.*}} %[[SAMPLER2:[^,]+]], <[[COORD_DIM]] x float> noundef nofpclass(nan inf) %[[COORD2:[^,]+]], float noundef nofpclass(nan inf) %[[CMP2:[^,]+]], <[[DIM]] x i32> noundef %[[OFFSET2:[^)]+]])
+// CHECK-OFFSET: %[[THIS_VAL2:.*]] = load ptr, ptr %{{.*}}
+// CHECK-OFFSET: %[[HANDLE_GEP2:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL2]], i32 0, i32 0
+// CHECK-OFFSET: %[[HANDLE2:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP2]]
+// CHECK-OFFSET: %[[SAMPLER_GEP2:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerComparisonState", ptr %[[SAMPLER2]], i32 0, i32 0
+// CHECK-OFFSET: %[[SAMPLER_H2:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP2]]
+// CHECK-OFFSET: %[[COORD_VAL2:.*]] = load <[[COORD_DIM]] x float>, ptr %{{.*}}
+// CHECK-OFFSET: %[[CMP_VAL2:.*]] = load float, ptr %{{.*}}
+// CHECK-OFFSET: %[[CMP_CAST2:.*]] = fptrunc {{.*}} double {{.*}} to float
+// CHECK-OFFSET: %[[OFFSET_VAL2:.*]] = load <[[DIM]] x i32>, ptr %{{.*}}
+// DXIL-OFFSET: call reassoc nnan ninf nsz arcp afn float @llvm.dx.resource.samplecmplevelzero.f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE2]], target("dx.Sampler", 0) %[[SAMPLER_H2]], <[[COORD_DIM]] x float> %[[COORD_VAL2]], float %[[CMP_CAST2]], <[[DIM]] x i32> %[[OFFSET_VAL2]])
+// SPIRV-OFFSET: call reassoc nnan ninf nsz arcp afn float @llvm.spv.resource.samplecmplevelzero.f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE2]], target("spirv.Sampler") %[[SAMPLER_H2]], <[[COORD_DIM]] x float> %[[COORD_VAL2]], float %[[CMP_CAST2]], <[[DIM]] x i32> %[[OFFSET_VAL2]])

--- a/clang/test/CodeGenHLSL/resources/Textures-SampleGrad.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-SampleGrad.hlsl
@@ -1,35 +1,50 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DGRAD_TYPE=float2 -DTEXTURE=Texture2D \
-// RUN:   -DCOORD_TYPE=float2 %s \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DGRAD_TYPE=float2 -DHAS_OFFSET \
+// RUN:   -DTEXTURE=Texture2D -DCOORD_TYPE=float2 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 \
-// RUN:   --check-prefixes=CHECK,DXIL -DDXIL_TY=2 -DRW=0 -DDIM=2 \
-// RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
-// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
-// RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DGRAD_TYPE=float2 -DTEXTURE=Texture2D \
-// RUN:   -DCOORD_TYPE=float2 %s \
-// RUN:   | llvm-cxxfilt \
-// RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 \
-// RUN:   --check-prefixes=CHECK,SPIRV -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 \
-// RUN:   -DSPV_DIM=1 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-TEXEL,CHECK-OFFSET,DXIL-OFFSET \
+// RUN:   -DDXIL_TY=2 -DRW=0 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DGRAD_TYPE=float2 \
-// RUN:   -DTEXTURE=Texture2DArray -DCOORD_TYPE=float3 %s \
+// RUN:   -DGRAD_TYPE=float3 -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
-// RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DCOORD_DIM=3 \
-// RUN:   --check-prefixes=CHECK,DXIL -DDXIL_TY=7 -DRW=0 -DDIM=2 \
+// RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-NOTEXEL -DDXIL_TY=5 -DRW=0 -DDIM=3
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DGRAD_TYPE=float2 -DHAS_OFFSET \
+// RUN:   -DTEXTURE=Texture2D -DCOORD_TYPE=float2 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-TEXEL,CHECK-OFFSET,SPIRV-OFFSET \
+// RUN:   -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=1 -DDIM=2 \
 // RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DGRAD_TYPE=float2 \
+// RUN:   -DGRAD_TYPE=float3 -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-NOTEXEL -DARRAYED=0 -DSAMPLED=1 \
+// RUN:   -DIMG_FMT=0 -DSPV_DIM=3 -DDIM=3
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DGRAD_TYPE=float2 -DHAS_OFFSET \
 // RUN:   -DTEXTURE=Texture2DArray -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DCOORD_DIM=3 \
-// RUN:   --check-prefixes=CHECK,SPIRV -DARRAYED=1 -DSAMPLED=1 -DIMG_FMT=0 \
-// RUN:   -DSPV_DIM=1 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-TEXEL,CHECK-OFFSET,DXIL-OFFSET \
+// RUN:   -DDXIL_TY=7 -DRW=0 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DGRAD_TYPE=float2 -DHAS_OFFSET \
+// RUN:   -DTEXTURE=Texture2DArray -DCOORD_TYPE=float3 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-TEXEL,CHECK-OFFSET,SPIRV-OFFSET \
+// RUN:   -DARRAYED=1 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=1 -DDIM=2 \
+// RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
@@ -37,6 +52,8 @@
 //   OFFSET_ARG         a literal offset argument
 //   GRAD_TYPE          SampleGrad ddx/ddy type, one component per resource
 //                      dimension
+//   HAS_OFFSET         defined for types whose sampling and gathering methods
+//                      have overloads taking an offset
 //   TEXTURE            resource type name
 //   COORD_TYPE         sample location type (DIM components plus the array
 //                      slice)
@@ -50,11 +67,21 @@
 //   SAMPLED            spirv.Image Sampled operand
 //   IMG_FMT            spirv.Image Image Format operand
 //   SPV_DIM            spirv.Image Dim operand
+//
+// Check prefixes:
+//   TEXEL              the type has integer texel addressing (Load,
+//                      operator[], mips), and therefore a `mips` field in its
+//                      layout
+//   OFFSET             the sampling and gathering methods have offset
+//                      overloads
+//   NOTEXEL            the type has no integer texel addressing
 
-// DXIL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// DXIL-TEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// DXIL-NOTEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) }
 // DXIL: %"class.hlsl::SamplerState" = type { target("dx.Sampler", 0) }
 
-// SPIRV: %"class.hlsl::[[TEXTURE]]" = type { target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// SPIRV-TEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// SPIRV-NOTEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) }
 // SPIRV: %"class.hlsl::SamplerState" = type { target("spirv.Sampler") }
 
 TEXTURE<float4> t;
@@ -89,70 +116,74 @@ float4 test_grad(COORD_TYPE loc : LOC, GRAD_TYPE ddx : DDX, GRAD_TYPE ddy : DDY)
 // DXIL: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.samplegrad.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE1]], target("dx.Sampler", 0) %[[SAMPLER_H1]], <[[COORD_DIM]] x float> %[[COORD_VAL]], <[[DIM]] x float> %[[DDX_VAL]], <[[DIM]] x float> %[[DDY_VAL]], <[[DIM]] x i32> zeroinitializer)
 // SPIRV: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.samplegrad.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE1]], target("spirv.Sampler") %[[SAMPLER_H1]], <[[COORD_DIM]] x float> %[[COORD_VAL]], <[[DIM]] x float> %[[DDX_VAL]], <[[DIM]] x float> %[[DDY_VAL]], <[[DIM]] x i32> zeroinitializer)
 
-// CHECK: @test_offset(float vector[[[COORD_DIM]]], float vector[[[DIM]]], float vector[[[DIM]]])
-// CHECK: %[[CALL_OFFSET:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleGrad(hlsl::SamplerState, float vector[[[COORD_DIM]]], float vector[[[DIM]]], float vector[[[DIM]]], int vector[[[DIM]]])(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x i32> noundef [[OFFSET_CONST]])
-// CHECK: ret <4 x float> %[[CALL_OFFSET]]
+// CHECK-OFFSET: @test_offset(float vector[[[COORD_DIM]]], float vector[[[DIM]]], float vector[[[DIM]]])
+// CHECK-OFFSET: %[[CALL_OFFSET:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleGrad(hlsl::SamplerState, float vector[[[COORD_DIM]]], float vector[[[DIM]]], float vector[[[DIM]]], int vector[[[DIM]]])(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x i32> noundef [[OFFSET_CONST]])
+// CHECK-OFFSET: ret <4 x float> %[[CALL_OFFSET]]
 
+#ifdef HAS_OFFSET
 float4 test_offset(COORD_TYPE loc : LOC, GRAD_TYPE ddx : DDX, GRAD_TYPE ddy : DDY) : SV_Target {
   return t.SampleGrad(s, loc, ddx, ddy, OFFSET_ARG);
 }
+#endif
 
-// CHECK: define linkonce_odr hidden {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleGrad(hlsl::SamplerState, float vector[[[COORD_DIM]]], float vector[[[DIM]]], float vector[[[DIM]]], int vector[[[DIM]]])(
-// CHECK-SAME: ptr {{.*}} %[[THIS:[^,]+]], ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}} %[[SAMPLER:[^,]+]], <[[COORD_DIM]] x float> {{.*}} %[[COORD:[^,]+]], <[[DIM]] x float> {{.*}} %[[DDX:[^,]+]], <[[DIM]] x float> {{.*}} %[[DDY:[^,]+]], <[[DIM]] x i32> {{.*}} %[[OFFSET:[^)]+]])
-// CHECK: %[[THIS_ADDR:.*]] = alloca ptr
-// CHECK: %[[COORD_ADDR:.*]] = alloca <[[COORD_DIM]] x float>
-// CHECK: %[[DDX_ADDR:.*]] = alloca <[[DIM]] x float>
-// CHECK: %[[DDY_ADDR:.*]] = alloca <[[DIM]] x float>
-// CHECK: %[[OFFSET_ADDR:.*]] = alloca <[[DIM]] x i32>
-// CHECK: store ptr %[[THIS]], ptr %[[THIS_ADDR]]
-// CHECK: store <[[COORD_DIM]] x float> %[[COORD]], ptr %[[COORD_ADDR]]
-// CHECK: store <[[DIM]] x float> %[[DDX]], ptr %[[DDX_ADDR]]
-// CHECK: store <[[DIM]] x float> %[[DDY]], ptr %[[DDY_ADDR]]
-// CHECK: store <[[DIM]] x i32> %[[OFFSET]], ptr %[[OFFSET_ADDR]]
-// CHECK: %[[THIS_VAL2:.*]] = load ptr, ptr %[[THIS_ADDR]]
-// CHECK: %[[HANDLE_GEP2:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL2]], i32 0, i32 0
-// CHECK: %[[HANDLE2:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP2]]
-// CHECK: %[[SAMPLER_GEP2:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerState", ptr %[[SAMPLER]], i32 0, i32 0
-// CHECK: %[[SAMPLER_H2:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP2]]
-// CHECK: %[[COORD_VAL:.*]] = load <[[COORD_DIM]] x float>, ptr %[[COORD_ADDR]]
-// CHECK: %[[DDX_VAL:.*]] = load <[[DIM]] x float>, ptr %[[DDX_ADDR]]
-// CHECK: %[[DDY_VAL:.*]] = load <[[DIM]] x float>, ptr %[[DDY_ADDR]]
-// CHECK: %[[OFFSET_VAL:.*]] = load <[[DIM]] x i32>, ptr %[[OFFSET_ADDR]]
-// DXIL: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.samplegrad.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE2]], target("dx.Sampler", 0) %[[SAMPLER_H2]], <[[COORD_DIM]] x float> %[[COORD_VAL]], <[[DIM]] x float> %[[DDX_VAL]], <[[DIM]] x float> %[[DDY_VAL]], <[[DIM]] x i32> %[[OFFSET_VAL]])
-// SPIRV: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.samplegrad.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE2]], target("spirv.Sampler") %[[SAMPLER_H2]], <[[COORD_DIM]] x float> %[[COORD_VAL]], <[[DIM]] x float> %[[DDX_VAL]], <[[DIM]] x float> %[[DDY_VAL]], <[[DIM]] x i32> %[[OFFSET_VAL]])
+// CHECK-OFFSET: define linkonce_odr hidden {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleGrad(hlsl::SamplerState, float vector[[[COORD_DIM]]], float vector[[[DIM]]], float vector[[[DIM]]], int vector[[[DIM]]])(
+// CHECK-OFFSET-SAME: ptr {{.*}} %[[THIS:[^,]+]], ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}} %[[SAMPLER:[^,]+]], <[[COORD_DIM]] x float> {{.*}} %[[COORD:[^,]+]], <[[DIM]] x float> {{.*}} %[[DDX:[^,]+]], <[[DIM]] x float> {{.*}} %[[DDY:[^,]+]], <[[DIM]] x i32> {{.*}} %[[OFFSET:[^)]+]])
+// CHECK-OFFSET: %[[THIS_ADDR:.*]] = alloca ptr
+// CHECK-OFFSET: %[[COORD_ADDR:.*]] = alloca <[[COORD_DIM]] x float>
+// CHECK-OFFSET: %[[DDX_ADDR:.*]] = alloca <[[DIM]] x float>
+// CHECK-OFFSET: %[[DDY_ADDR:.*]] = alloca <[[DIM]] x float>
+// CHECK-OFFSET: %[[OFFSET_ADDR:.*]] = alloca <[[DIM]] x i32>
+// CHECK-OFFSET: store ptr %[[THIS]], ptr %[[THIS_ADDR]]
+// CHECK-OFFSET: store <[[COORD_DIM]] x float> %[[COORD]], ptr %[[COORD_ADDR]]
+// CHECK-OFFSET: store <[[DIM]] x float> %[[DDX]], ptr %[[DDX_ADDR]]
+// CHECK-OFFSET: store <[[DIM]] x float> %[[DDY]], ptr %[[DDY_ADDR]]
+// CHECK-OFFSET: store <[[DIM]] x i32> %[[OFFSET]], ptr %[[OFFSET_ADDR]]
+// CHECK-OFFSET: %[[THIS_VAL2:.*]] = load ptr, ptr %[[THIS_ADDR]]
+// CHECK-OFFSET: %[[HANDLE_GEP2:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL2]], i32 0, i32 0
+// CHECK-OFFSET: %[[HANDLE2:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP2]]
+// CHECK-OFFSET: %[[SAMPLER_GEP2:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerState", ptr %[[SAMPLER]], i32 0, i32 0
+// CHECK-OFFSET: %[[SAMPLER_H2:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP2]]
+// CHECK-OFFSET: %[[COORD_VAL:.*]] = load <[[COORD_DIM]] x float>, ptr %[[COORD_ADDR]]
+// CHECK-OFFSET: %[[DDX_VAL:.*]] = load <[[DIM]] x float>, ptr %[[DDX_ADDR]]
+// CHECK-OFFSET: %[[DDY_VAL:.*]] = load <[[DIM]] x float>, ptr %[[DDY_ADDR]]
+// CHECK-OFFSET: %[[OFFSET_VAL:.*]] = load <[[DIM]] x i32>, ptr %[[OFFSET_ADDR]]
+// DXIL-OFFSET: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.samplegrad.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE2]], target("dx.Sampler", 0) %[[SAMPLER_H2]], <[[COORD_DIM]] x float> %[[COORD_VAL]], <[[DIM]] x float> %[[DDX_VAL]], <[[DIM]] x float> %[[DDY_VAL]], <[[DIM]] x i32> %[[OFFSET_VAL]])
+// SPIRV-OFFSET: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.samplegrad.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE2]], target("spirv.Sampler") %[[SAMPLER_H2]], <[[COORD_DIM]] x float> %[[COORD_VAL]], <[[DIM]] x float> %[[DDX_VAL]], <[[DIM]] x float> %[[DDY_VAL]], <[[DIM]] x i32> %[[OFFSET_VAL]])
 
-// CHECK: @test_clamp(float vector[[[COORD_DIM]]], float vector[[[DIM]]], float vector[[[DIM]]])
-// CHECK: %[[CALL_CLAMP:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleGrad(hlsl::SamplerState, float vector[[[COORD_DIM]]], float vector[[[DIM]]], float vector[[[DIM]]], int vector[[[DIM]]], float)(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x i32> noundef [[OFFSET_CONST]], float {{.*}} 1.000000e+00)
-// CHECK: ret <4 x float> %[[CALL_CLAMP]]
+// CHECK-OFFSET: @test_clamp(float vector[[[COORD_DIM]]], float vector[[[DIM]]], float vector[[[DIM]]])
+// CHECK-OFFSET: %[[CALL_CLAMP:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleGrad(hlsl::SamplerState, float vector[[[COORD_DIM]]], float vector[[[DIM]]], float vector[[[DIM]]], int vector[[[DIM]]], float)(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x i32> noundef [[OFFSET_CONST]], float {{.*}} 1.000000e+00)
+// CHECK-OFFSET: ret <4 x float> %[[CALL_CLAMP]]
 
+#ifdef HAS_OFFSET
 float4 test_clamp(COORD_TYPE loc : LOC, GRAD_TYPE ddx : DDX, GRAD_TYPE ddy : DDY) : SV_Target {
   return t.SampleGrad(s, loc, ddx, ddy, OFFSET_ARG, 1.0f);
 }
+#endif
 
-// CHECK: define linkonce_odr hidden {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleGrad(hlsl::SamplerState, float vector[[[COORD_DIM]]], float vector[[[DIM]]], float vector[[[DIM]]], int vector[[[DIM]]], float)(
-// CHECK-SAME: ptr {{.*}} %[[THIS:[^,]+]], ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}} %[[SAMPLER:[^,]+]], <[[COORD_DIM]] x float> {{.*}} %[[COORD:[^,]+]], <[[DIM]] x float> {{.*}} %[[DDX:[^,]+]], <[[DIM]] x float> {{.*}} %[[DDY:[^,]+]], <[[DIM]] x i32> {{.*}} %[[OFFSET:[^,]+]], float {{.*}} %[[CLAMP:[^)]+]])
-// CHECK: %[[THIS_ADDR:.*]] = alloca ptr
-// CHECK: %[[COORD_ADDR:.*]] = alloca <[[COORD_DIM]] x float>
-// CHECK: %[[DDX_ADDR:.*]] = alloca <[[DIM]] x float>
-// CHECK: %[[DDY_ADDR:.*]] = alloca <[[DIM]] x float>
-// CHECK: %[[OFFSET_ADDR:.*]] = alloca <[[DIM]] x i32>
-// CHECK: %[[CLAMP_ADDR:.*]] = alloca float
-// CHECK: store ptr %[[THIS]], ptr %[[THIS_ADDR]]
-// CHECK: store <[[COORD_DIM]] x float> %[[COORD]], ptr %[[COORD_ADDR]]
-// CHECK: store <[[DIM]] x float> %[[DDX]], ptr %[[DDX_ADDR]]
-// CHECK: store <[[DIM]] x float> %[[DDY]], ptr %[[DDY_ADDR]]
-// CHECK: store <[[DIM]] x i32> %[[OFFSET]], ptr %[[OFFSET_ADDR]]
-// CHECK: store float %[[CLAMP]], ptr %[[CLAMP_ADDR]]
-// CHECK: %[[THIS_VAL3:.*]] = load ptr, ptr %[[THIS_ADDR]]
-// CHECK: %[[HANDLE_GEP3:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL3]], i32 0, i32 0
-// CHECK: %[[HANDLE3:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP3]]
-// CHECK: %[[SAMPLER_GEP3:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerState", ptr %[[SAMPLER]], i32 0, i32 0
-// CHECK: %[[SAMPLER_H3:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP3]]
-// CHECK: %[[COORD_VAL:.*]] = load <[[COORD_DIM]] x float>, ptr %[[COORD_ADDR]]
-// CHECK: %[[DDX_VAL:.*]] = load <[[DIM]] x float>, ptr %[[DDX_ADDR]]
-// CHECK: %[[DDY_VAL:.*]] = load <[[DIM]] x float>, ptr %[[DDY_ADDR]]
-// CHECK: %[[OFFSET_VAL:.*]] = load <[[DIM]] x i32>, ptr %[[OFFSET_ADDR]]
-// CHECK: %[[CLAMP_VAL:.*]] = load float, ptr %[[CLAMP_ADDR]]
-// CHECK: %[[CLAMP_CAST3:.*]] = fptrunc {{.*}} double {{.*}} to float
-// DXIL: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.samplegrad.clamp.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE3]], target("dx.Sampler", 0) %[[SAMPLER_H3]], <[[COORD_DIM]] x float> %[[COORD_VAL]], <[[DIM]] x float> %[[DDX_VAL]], <[[DIM]] x float> %[[DDY_VAL]], <[[DIM]] x i32> %[[OFFSET_VAL]], float %[[CLAMP_CAST3]])
-// SPIRV: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.samplegrad.clamp.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE3]], target("spirv.Sampler") %[[SAMPLER_H3]], <[[COORD_DIM]] x float> %[[COORD_VAL]], <[[DIM]] x float> %[[DDX_VAL]], <[[DIM]] x float> %[[DDY_VAL]], <[[DIM]] x i32> %[[OFFSET_VAL]], float %[[CLAMP_CAST3]])
+// CHECK-OFFSET: define linkonce_odr hidden {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleGrad(hlsl::SamplerState, float vector[[[COORD_DIM]]], float vector[[[DIM]]], float vector[[[DIM]]], int vector[[[DIM]]], float)(
+// CHECK-OFFSET-SAME: ptr {{.*}} %[[THIS:[^,]+]], ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}} %[[SAMPLER:[^,]+]], <[[COORD_DIM]] x float> {{.*}} %[[COORD:[^,]+]], <[[DIM]] x float> {{.*}} %[[DDX:[^,]+]], <[[DIM]] x float> {{.*}} %[[DDY:[^,]+]], <[[DIM]] x i32> {{.*}} %[[OFFSET:[^,]+]], float {{.*}} %[[CLAMP:[^)]+]])
+// CHECK-OFFSET: %[[THIS_ADDR:.*]] = alloca ptr
+// CHECK-OFFSET: %[[COORD_ADDR:.*]] = alloca <[[COORD_DIM]] x float>
+// CHECK-OFFSET: %[[DDX_ADDR:.*]] = alloca <[[DIM]] x float>
+// CHECK-OFFSET: %[[DDY_ADDR:.*]] = alloca <[[DIM]] x float>
+// CHECK-OFFSET: %[[OFFSET_ADDR:.*]] = alloca <[[DIM]] x i32>
+// CHECK-OFFSET: %[[CLAMP_ADDR:.*]] = alloca float
+// CHECK-OFFSET: store ptr %[[THIS]], ptr %[[THIS_ADDR]]
+// CHECK-OFFSET: store <[[COORD_DIM]] x float> %[[COORD]], ptr %[[COORD_ADDR]]
+// CHECK-OFFSET: store <[[DIM]] x float> %[[DDX]], ptr %[[DDX_ADDR]]
+// CHECK-OFFSET: store <[[DIM]] x float> %[[DDY]], ptr %[[DDY_ADDR]]
+// CHECK-OFFSET: store <[[DIM]] x i32> %[[OFFSET]], ptr %[[OFFSET_ADDR]]
+// CHECK-OFFSET: store float %[[CLAMP]], ptr %[[CLAMP_ADDR]]
+// CHECK-OFFSET: %[[THIS_VAL3:.*]] = load ptr, ptr %[[THIS_ADDR]]
+// CHECK-OFFSET: %[[HANDLE_GEP3:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL3]], i32 0, i32 0
+// CHECK-OFFSET: %[[HANDLE3:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP3]]
+// CHECK-OFFSET: %[[SAMPLER_GEP3:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerState", ptr %[[SAMPLER]], i32 0, i32 0
+// CHECK-OFFSET: %[[SAMPLER_H3:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP3]]
+// CHECK-OFFSET: %[[COORD_VAL:.*]] = load <[[COORD_DIM]] x float>, ptr %[[COORD_ADDR]]
+// CHECK-OFFSET: %[[DDX_VAL:.*]] = load <[[DIM]] x float>, ptr %[[DDX_ADDR]]
+// CHECK-OFFSET: %[[DDY_VAL:.*]] = load <[[DIM]] x float>, ptr %[[DDY_ADDR]]
+// CHECK-OFFSET: %[[OFFSET_VAL:.*]] = load <[[DIM]] x i32>, ptr %[[OFFSET_ADDR]]
+// CHECK-OFFSET: %[[CLAMP_VAL:.*]] = load float, ptr %[[CLAMP_ADDR]]
+// CHECK-OFFSET: %[[CLAMP_CAST3:.*]] = fptrunc {{.*}} double {{.*}} to float
+// DXIL-OFFSET: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.samplegrad.clamp.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE3]], target("dx.Sampler", 0) %[[SAMPLER_H3]], <[[COORD_DIM]] x float> %[[COORD_VAL]], <[[DIM]] x float> %[[DDX_VAL]], <[[DIM]] x float> %[[DDY_VAL]], <[[DIM]] x i32> %[[OFFSET_VAL]], float %[[CLAMP_CAST3]])
+// SPIRV-OFFSET: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.samplegrad.clamp.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE3]], target("spirv.Sampler") %[[SAMPLER_H3]], <[[COORD_DIM]] x float> %[[COORD_VAL]], <[[DIM]] x float> %[[DDX_VAL]], <[[DIM]] x float> %[[DDY_VAL]], <[[DIM]] x i32> %[[OFFSET_VAL]], float %[[CLAMP_CAST3]])

--- a/clang/test/CodeGenHLSL/resources/Textures-SampleGrad.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-SampleGrad.hlsl
@@ -11,7 +11,7 @@
 // RUN:   -DGRAD_TYPE=float3 -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
-// RUN:   --check-prefixes=CHECK,DXIL,DXIL-NOTEXEL -DDXIL_TY=5 -DRW=0 -DDIM=3
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-NOTEXEL,CHECK-NOOFFSET,DXIL-NOOFFSET -DDXIL_TY=5 -DRW=0 -DDIM=3
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
 // RUN:   -DOFFSET_ARG="int2(1, 2)" -DGRAD_TYPE=float2 -DHAS_OFFSET \
@@ -26,7 +26,7 @@
 // RUN:   -DGRAD_TYPE=float3 -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
-// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-NOTEXEL -DARRAYED=0 -DSAMPLED=1 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-NOTEXEL,CHECK-NOOFFSET,SPIRV-NOOFFSET -DARRAYED=0 -DSAMPLED=1 \
 // RUN:   -DIMG_FMT=0 -DSPV_DIM=3 -DDIM=3
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
@@ -75,6 +75,8 @@
 //   OFFSET             the sampling and gathering methods have offset
 //                      overloads
 //   NOTEXEL            the type has no integer texel addressing
+//   NOOFFSET           the sampling methods have no offset overloads, so
+//                      their clamp overload takes the offset's place
 
 // DXIL-TEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
 // DXIL-NOTEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) }
@@ -120,6 +122,7 @@ float4 test_grad(COORD_TYPE loc : LOC, GRAD_TYPE ddx : DDX, GRAD_TYPE ddy : DDY)
 // CHECK-OFFSET: %[[CALL_OFFSET:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleGrad(hlsl::SamplerState, float vector[[[COORD_DIM]]], float vector[[[DIM]]], float vector[[[DIM]]], int vector[[[DIM]]])(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x i32> noundef [[OFFSET_CONST]])
 // CHECK-OFFSET: ret <4 x float> %[[CALL_OFFSET]]
 
+
 #ifdef HAS_OFFSET
 float4 test_offset(COORD_TYPE loc : LOC, GRAD_TYPE ddx : DDX, GRAD_TYPE ddy : DDY) : SV_Target {
   return t.SampleGrad(s, loc, ddx, ddy, OFFSET_ARG);
@@ -154,9 +157,19 @@ float4 test_offset(COORD_TYPE loc : LOC, GRAD_TYPE ddx : DDX, GRAD_TYPE ddy : DD
 // CHECK-OFFSET: %[[CALL_CLAMP:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleGrad(hlsl::SamplerState, float vector[[[COORD_DIM]]], float vector[[[DIM]]], float vector[[[DIM]]], int vector[[[DIM]]], float)(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x i32> noundef [[OFFSET_CONST]], float {{.*}} 1.000000e+00)
 // CHECK-OFFSET: ret <4 x float> %[[CALL_CLAMP]]
 
+// CHECK-NOOFFSET: @test_clamp(
+// CHECK-NOOFFSET: %[[CALL_NC:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleGrad(hlsl::SamplerState, float vector[[[COORD_DIM]]], float vector[[[DIM]]], float vector[[[DIM]]], float)(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x float> {{.*}} %{{.*}}, <[[DIM]] x float> {{.*}} %{{.*}}, float {{.*}} 1.000000e+00)
+// CHECK-NOOFFSET: ret <4 x float> %[[CALL_NC]]
+
 #ifdef HAS_OFFSET
 float4 test_clamp(COORD_TYPE loc : LOC, GRAD_TYPE ddx : DDX, GRAD_TYPE ddy : DDY) : SV_Target {
   return t.SampleGrad(s, loc, ddx, ddy, OFFSET_ARG, 1.0f);
+}
+#else
+// Cube textures have no offset overload, so the clamp takes the offset's place
+// in the method signature; the intrinsic still receives a zero offset.
+float4 test_clamp(COORD_TYPE loc : LOC, GRAD_TYPE ddx : DDX, GRAD_TYPE ddy : DDY) : SV_Target {
+  return t.SampleGrad(s, loc, ddx, ddy, 1.0f);
 }
 #endif
 
@@ -187,3 +200,13 @@ float4 test_clamp(COORD_TYPE loc : LOC, GRAD_TYPE ddx : DDX, GRAD_TYPE ddy : DDY
 // CHECK-OFFSET: %[[CLAMP_CAST3:.*]] = fptrunc {{.*}} double {{.*}} to float
 // DXIL-OFFSET: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.samplegrad.clamp.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE3]], target("dx.Sampler", 0) %[[SAMPLER_H3]], <[[COORD_DIM]] x float> %[[COORD_VAL]], <[[DIM]] x float> %[[DDX_VAL]], <[[DIM]] x float> %[[DDY_VAL]], <[[DIM]] x i32> %[[OFFSET_VAL]], float %[[CLAMP_CAST3]])
 // SPIRV-OFFSET: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.samplegrad.clamp.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE3]], target("spirv.Sampler") %[[SAMPLER_H3]], <[[COORD_DIM]] x float> %[[COORD_VAL]], <[[DIM]] x float> %[[DDX_VAL]], <[[DIM]] x float> %[[DDY_VAL]], <[[DIM]] x i32> %[[OFFSET_VAL]], float %[[CLAMP_CAST3]])
+
+// CHECK-NOOFFSET: define linkonce_odr hidden {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleGrad(hlsl::SamplerState, float vector[[[COORD_DIM]]], float vector[[[DIM]]], float vector[[[DIM]]], float)(
+// CHECK-NOOFFSET: %[[THIS_VAL_NC:.*]] = load ptr, ptr %{{.*}}
+// CHECK-NOOFFSET: %[[HANDLE_GEP_NC:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL_NC]], i32 0, i32 0
+// CHECK-NOOFFSET: %[[HANDLE_NC:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP_NC]]
+// CHECK-NOOFFSET: %[[SAMPLER_GEP_NC:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerState", ptr %{{.*}}, i32 0, i32 0
+// CHECK-NOOFFSET: %[[SAMPLER_H_NC:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP_NC]]
+// CHECK-NOOFFSET: %[[CLAMP_CAST_NC:.*]] = fptrunc {{.*}} double {{.*}} to float
+// DXIL-NOOFFSET: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.samplegrad.clamp.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE_NC]], target("dx.Sampler", 0) %[[SAMPLER_H_NC]], <[[COORD_DIM]] x float> %{{.*}}, <[[DIM]] x float> %{{.*}}, <[[DIM]] x float> %{{.*}}, <[[DIM]] x i32> zeroinitializer, float %[[CLAMP_CAST_NC]])
+// SPIRV-NOOFFSET: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.samplegrad.clamp.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE_NC]], target("spirv.Sampler") %[[SAMPLER_H_NC]], <[[COORD_DIM]] x float> %{{.*}}, <[[DIM]] x float> %{{.*}}, <[[DIM]] x float> %{{.*}}, <[[DIM]] x i32> zeroinitializer, float %[[CLAMP_CAST_NC]])

--- a/clang/test/CodeGenHLSL/resources/Textures-SampleLevel.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-SampleLevel.hlsl
@@ -1,38 +1,57 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2D -DCOORD_TYPE=float2 %s \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2D \
+// RUN:   -DCOORD_TYPE=float2 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 \
-// RUN:   --check-prefixes=CHECK,DXIL -DDXIL_TY=2 -DRW=0 -DDIM=2 \
-// RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
-// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
-// RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2D -DCOORD_TYPE=float2 %s \
-// RUN:   | llvm-cxxfilt \
-// RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 \
-// RUN:   --check-prefixes=CHECK,SPIRV -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 \
-// RUN:   -DSPV_DIM=1 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-TEXEL,CHECK-OFFSET,DXIL-OFFSET \
+// RUN:   -DDXIL_TY=2 -DRW=0 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2DArray \
-// RUN:   -DCOORD_TYPE=float3 %s \
+// RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
-// RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DCOORD_DIM=3 \
-// RUN:   --check-prefixes=CHECK,DXIL -DDXIL_TY=7 -DRW=0 -DDIM=2 \
+// RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-NOTEXEL -DDXIL_TY=5 -DRW=0 -DDIM=3
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2D \
+// RUN:   -DCOORD_TYPE=float2 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-TEXEL,CHECK-OFFSET,SPIRV-OFFSET \
+// RUN:   -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=1 -DDIM=2 \
 // RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2DArray \
+// RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-NOTEXEL -DARRAYED=0 -DSAMPLED=1 \
+// RUN:   -DIMG_FMT=0 -DSPV_DIM=3 -DDIM=3
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2DArray \
 // RUN:   -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DCOORD_DIM=3 \
-// RUN:   --check-prefixes=CHECK,SPIRV -DARRAYED=1 -DSAMPLED=1 -DIMG_FMT=0 \
-// RUN:   -DSPV_DIM=1 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-TEXEL,CHECK-OFFSET,DXIL-OFFSET \
+// RUN:   -DDXIL_TY=7 -DRW=0 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -DHAS_OFFSET -DTEXTURE=Texture2DArray \
+// RUN:   -DCOORD_TYPE=float3 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-TEXEL,CHECK-OFFSET,SPIRV-OFFSET \
+// RUN:   -DARRAYED=1 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=1 -DDIM=2 \
+// RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
 //
 //   OFFSET_ARG         a literal offset argument
+//   HAS_OFFSET         defined for types whose sampling and gathering methods
+//                      have overloads taking an offset
 //   TEXTURE            resource type name
 //   COORD_TYPE         sample location type (DIM components plus the array
 //                      slice)
@@ -46,11 +65,21 @@
 //   SAMPLED            spirv.Image Sampled operand
 //   IMG_FMT            spirv.Image Image Format operand
 //   SPV_DIM            spirv.Image Dim operand
+//
+// Check prefixes:
+//   TEXEL              the type has integer texel addressing (Load,
+//                      operator[], mips), and therefore a `mips` field in its
+//                      layout
+//   OFFSET             the sampling and gathering methods have offset
+//                      overloads
+//   NOTEXEL            the type has no integer texel addressing
 
-// DXIL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// DXIL-TEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// DXIL-NOTEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) }
 // DXIL: %"class.hlsl::SamplerState" = type { target("dx.Sampler", 0) }
 
-// SPIRV: %"class.hlsl::[[TEXTURE]]" = type { target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// SPIRV-TEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// SPIRV-NOTEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) }
 // SPIRV: %"class.hlsl::SamplerState" = type { target("spirv.Sampler") }
 
 TEXTURE<float4> t;
@@ -83,32 +112,34 @@ float4 test_level(COORD_TYPE loc : LOC, float lod : LOD) : SV_Target {
 // DXIL: call reassoc nnan ninf nsz arcp afn                         <4 x float> @llvm.dx.resource.samplelevel.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE1]], target("dx.Sampler", 0) %[[SAMPLER_H1]], <[[COORD_DIM]] x float> %[[COORD_VAL1]], float %[[LOD_CAST1]], <[[DIM]] x i32> zeroinitializer)
 // SPIRV: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.samplelevel.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE1]], target("spirv.Sampler") %[[SAMPLER_H1]], <[[COORD_DIM]] x float> %[[COORD_VAL1]], float %[[LOD_CAST1]], <[[DIM]] x i32> zeroinitializer)
 
-// CHECK: @test_offset(float vector[[[COORD_DIM]]], float)
-// CHECK: %[[CALL_OFFSET:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleLevel(hlsl::SamplerState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]])(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, float {{.*}} 0.000000e+00, <[[DIM]] x i32> noundef [[OFFSET_CONST]])
-// CHECK: ret <4 x float> %[[CALL_OFFSET]]
+// CHECK-OFFSET: @test_offset(float vector[[[COORD_DIM]]], float)
+// CHECK-OFFSET: %[[CALL_OFFSET:.*]] = call {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleLevel(hlsl::SamplerState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]])(ptr {{.*}} @t, ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}}, <[[COORD_DIM]] x float> {{.*}} %{{.*}}, float {{.*}} 0.000000e+00, <[[DIM]] x i32> noundef [[OFFSET_CONST]])
+// CHECK-OFFSET: ret <4 x float> %[[CALL_OFFSET]]
 
+#ifdef HAS_OFFSET
 float4 test_offset(COORD_TYPE loc : LOC, float lod : LOD) : SV_Target {
   return t.SampleLevel(s, loc, 0.0f, OFFSET_ARG);
 }
+#endif
 
-// CHECK: define linkonce_odr hidden {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleLevel(hlsl::SamplerState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]])(
-// CHECK-SAME: ptr {{.*}} %[[THIS2:[^,]+]], ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}} %[[SAMPLER2:[^,]+]], <[[COORD_DIM]] x float> noundef nofpclass(nan inf) %[[COORD2:[^,]+]], float noundef nofpclass(nan inf) %[[LOD2:[^,]+]], <[[DIM]] x i32> noundef %[[OFFSET2:[^)]+]])
-// CHECK: %[[THIS_ADDR2:.*]] = alloca ptr
-// CHECK: %[[COORD_ADDR2:.*]] = alloca <[[COORD_DIM]] x float>
-// CHECK: %[[LOD_ADDR2:.*]] = alloca float
-// CHECK: %[[OFFSET_ADDR2:.*]] = alloca <[[DIM]] x i32>
-// CHECK: store ptr %[[THIS2]], ptr %[[THIS_ADDR2]]
-// CHECK: store <[[COORD_DIM]] x float> %[[COORD2]], ptr %[[COORD_ADDR2]]
-// CHECK: store float %[[LOD2]], ptr %[[LOD_ADDR2]]
-// CHECK: store <[[DIM]] x i32> %[[OFFSET2]], ptr %[[OFFSET_ADDR2]]
-// CHECK: %[[THIS_VAL2:.*]] = load ptr, ptr %[[THIS_ADDR2]]
-// CHECK: %[[HANDLE_GEP2:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL2]], i32 0, i32 0
-// CHECK: %[[HANDLE2:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP2]]
-// CHECK: %[[SAMPLER_GEP2:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerState", ptr %[[SAMPLER2]], i32 0, i32 0
-// CHECK: %[[SAMPLER_H2:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP2]]
-// CHECK: %[[COORD_VAL2:.*]] = load <[[COORD_DIM]] x float>, ptr %[[COORD_ADDR2]]
-// CHECK: %[[LOD_VAL2:.*]] = load float, ptr %[[LOD_ADDR2]]
-// CHECK: %[[LOD_CAST2:.*]] = fptrunc {{.*}} double {{.*}} to float
-// CHECK: %[[OFFSET_VAL2:.*]] = load <[[DIM]] x i32>, ptr %[[OFFSET_ADDR2]]
-// DXIL: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.samplelevel.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE2]], target("dx.Sampler", 0) %[[SAMPLER_H2]], <[[COORD_DIM]] x float> %[[COORD_VAL2]], float %[[LOD_CAST2]], <[[DIM]] x i32> %[[OFFSET_VAL2]])
-// SPIRV: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.samplelevel.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE2]], target("spirv.Sampler") %[[SAMPLER_H2]], <[[COORD_DIM]] x float> %[[COORD_VAL2]], float %[[LOD_CAST2]], <[[DIM]] x i32> %[[OFFSET_VAL2]])
+// CHECK-OFFSET: define linkonce_odr hidden {{.*}} <4 x float> @hlsl::[[TEXTURE]]<float vector[4]>::SampleLevel(hlsl::SamplerState, float vector[[[COORD_DIM]]], float, int vector[[[DIM]]])(
+// CHECK-OFFSET-SAME: ptr {{.*}} %[[THIS2:[^,]+]], ptr {{.*}} byval(%"class.hlsl::SamplerState") {{.*}} %[[SAMPLER2:[^,]+]], <[[COORD_DIM]] x float> noundef nofpclass(nan inf) %[[COORD2:[^,]+]], float noundef nofpclass(nan inf) %[[LOD2:[^,]+]], <[[DIM]] x i32> noundef %[[OFFSET2:[^)]+]])
+// CHECK-OFFSET: %[[THIS_ADDR2:.*]] = alloca ptr
+// CHECK-OFFSET: %[[COORD_ADDR2:.*]] = alloca <[[COORD_DIM]] x float>
+// CHECK-OFFSET: %[[LOD_ADDR2:.*]] = alloca float
+// CHECK-OFFSET: %[[OFFSET_ADDR2:.*]] = alloca <[[DIM]] x i32>
+// CHECK-OFFSET: store ptr %[[THIS2]], ptr %[[THIS_ADDR2]]
+// CHECK-OFFSET: store <[[COORD_DIM]] x float> %[[COORD2]], ptr %[[COORD_ADDR2]]
+// CHECK-OFFSET: store float %[[LOD2]], ptr %[[LOD_ADDR2]]
+// CHECK-OFFSET: store <[[DIM]] x i32> %[[OFFSET2]], ptr %[[OFFSET_ADDR2]]
+// CHECK-OFFSET: %[[THIS_VAL2:.*]] = load ptr, ptr %[[THIS_ADDR2]]
+// CHECK-OFFSET: %[[HANDLE_GEP2:.*]] = getelementptr inbounds nuw %"class.hlsl::[[TEXTURE]]", ptr %[[THIS_VAL2]], i32 0, i32 0
+// CHECK-OFFSET: %[[HANDLE2:.*]] = load target{{.*}}, ptr %[[HANDLE_GEP2]]
+// CHECK-OFFSET: %[[SAMPLER_GEP2:.*]] = getelementptr inbounds nuw %"class.hlsl::SamplerState", ptr %[[SAMPLER2]], i32 0, i32 0
+// CHECK-OFFSET: %[[SAMPLER_H2:.*]] = load target{{.*}}, ptr %[[SAMPLER_GEP2]]
+// CHECK-OFFSET: %[[COORD_VAL2:.*]] = load <[[COORD_DIM]] x float>, ptr %[[COORD_ADDR2]]
+// CHECK-OFFSET: %[[LOD_VAL2:.*]] = load float, ptr %[[LOD_ADDR2]]
+// CHECK-OFFSET: %[[LOD_CAST2:.*]] = fptrunc {{.*}} double {{.*}} to float
+// CHECK-OFFSET: %[[OFFSET_VAL2:.*]] = load <[[DIM]] x i32>, ptr %[[OFFSET_ADDR2]]
+// DXIL-OFFSET: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.resource.samplelevel.v4f32.{{.*}}(target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) %[[HANDLE2]], target("dx.Sampler", 0) %[[SAMPLER_H2]], <[[COORD_DIM]] x float> %[[COORD_VAL2]], float %[[LOD_CAST2]], <[[DIM]] x i32> %[[OFFSET_VAL2]])
+// SPIRV-OFFSET: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.spv.resource.samplelevel.v4f32.{{.*}}(target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[IMG_FMT]]) %[[HANDLE2]], target("spirv.Sampler") %[[SAMPLER_H2]], <[[COORD_DIM]] x float> %[[COORD_VAL2]], float %[[LOD_CAST2]], <[[DIM]] x i32> %[[OFFSET_VAL2]])

--- a/clang/test/CodeGenHLSL/resources/Textures-default-explicit-binding.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-default-explicit-binding.hlsl
@@ -4,12 +4,24 @@
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 -DDXIL_TY=2 -DRW=0 \
 // RUN:   --check-prefixes=CHECK
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -DTEXTURE=TextureCube \
+// RUN:   -DCOORD_TYPE=float3 -o - %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 -DDXIL_TY=5 \
+// RUN:   -DRW=0 --check-prefixes=CHECK
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -DTEXTURE=Texture2D \
 // RUN:   -DCOORD_TYPE=float2 -o - %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 -DARRAYED=0 \
 // RUN:   --check-prefixes=SPIRV -DSPV_DIM=1
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -DTEXTURE=TextureCube \
+// RUN:   -DCOORD_TYPE=float3 -o - %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 -DARRAYED=0 \
+// RUN:   --check-prefixes=SPIRV -DSPV_DIM=3
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header \
 // RUN:   -DTEXTURE=Texture2DArray -DCOORD_TYPE=float3 -o - %s \
@@ -38,8 +50,10 @@
 TEXTURE<> default_template : register(t1, space2);
 TEXTURE implicit_template : register(t0, space1);
 
-// CHECK: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
-// SPIRV: %"class.hlsl::[[TEXTURE]]" = type { target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, 1, 0), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// CHECK-TEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// CHECK-NOTEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) }
+// SPIRV-TEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, 1, 0), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// SPIRV-NOTEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("spirv.Image", float, [[SPV_DIM]], 2, [[ARRAYED]], 0, 1, 0) }
 
 // CHECK: @{{.*}}default_template = internal global %"class.hlsl::[[TEXTURE]]" poison, align {{[0-9]+}}
 // CHECK: @{{.*}}implicit_template = internal global %"class.hlsl::[[TEXTURE]]" poison, align {{[0-9]+}}

--- a/clang/test/CodeGenHLSL/resources/Textures-default.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-default.hlsl
@@ -1,11 +1,18 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
 // RUN:   -std=hlsl202x -emit-llvm -disable-llvm-passes \
 // RUN:   -finclude-default-header -DTEXTURE=Texture2D -o - %s \
-// RUN:   | FileCheck %s -DTEXTURE=Texture2D -DDXIL_TY=2 -DRW=0
+// RUN:   | FileCheck %s -DTEXTURE=Texture2D -DDXIL_TY=2 -DRW=0 \
+// RUN:   --check-prefixes=CHECK,CHECK-TEXEL
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
+// RUN:   -std=hlsl202x -emit-llvm -disable-llvm-passes \
+// RUN:   -finclude-default-header -DTEXTURE=TextureCube -o - %s \
+// RUN:   | FileCheck %s -DTEXTURE=TextureCube -DDXIL_TY=5 -DRW=0 \
+// RUN:   --check-prefixes=CHECK,CHECK-NOTEXEL
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
 // RUN:   -std=hlsl202x -emit-llvm -disable-llvm-passes \
 // RUN:   -finclude-default-header -DTEXTURE=Texture2DArray -o - %s \
-// RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DDXIL_TY=7 -DRW=0
+// RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DDXIL_TY=7 -DRW=0 \
+// RUN:   --check-prefixes=CHECK,CHECK-TEXEL
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
@@ -13,9 +20,17 @@
 //   TEXTURE            resource type name
 //   DXIL_TY            dx.Texture resource-kind operand
 //   RW                 dx.Texture UAV operand
+//
+// Check prefixes:
+//   TEXEL              the type has integer texel addressing (Load,
+//                      operator[], mips), and therefore a `mips` field in its
+//                      layout
+//   NOTEXEL            the type has no integer texel addressing
 
-// CHECK: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
-// CHECK: %"class.hlsl::[[TEXTURE]].0" = type { target("dx.Texture", float, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<float>::mips_type" }
+// CHECK-TEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// CHECK-NOTEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) }
+// CHECK-TEXEL: %"class.hlsl::[[TEXTURE]].0" = type { target("dx.Texture", float, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<float>::mips_type" }
+// CHECK-NOTEXEL: %"class.hlsl::[[TEXTURE]].0" = type { target("dx.Texture", float, [[RW]], 0, 0, [[DXIL_TY]]) }
 
 // CHECK: @{{.*}}t1 = internal global %"class.hlsl::[[TEXTURE]]" poison, align 4
 TEXTURE<> t1;

--- a/clang/test/CodeGenHLSL/resources/Textures-shorthand-contexts.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-shorthand-contexts.hlsl
@@ -2,13 +2,20 @@
 // RUN:   -finclude-default-header -emit-llvm -disable-llvm-passes \
 // RUN:   -DTEXTURE=Texture2D -DCOORD_TYPE=float2 -o - %s \
 // RUN:   | llvm-cxxfilt \
-// RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 -DDXIL_TY=2 -DRW=0
+// RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 -DDXIL_TY=2 -DRW=0 \
+// RUN:   --check-prefixes=CHECK,CHECK-TEXEL
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
+// RUN:   -finclude-default-header -emit-llvm -disable-llvm-passes \
+// RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 -o - %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 -DDXIL_TY=5 \
+// RUN:   -DRW=0 --check-prefixes=CHECK,CHECK-NOTEXEL
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
 // RUN:   -finclude-default-header -emit-llvm -disable-llvm-passes \
 // RUN:   -DTEXTURE=Texture2DArray -DCOORD_TYPE=float3 -o - %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2DArray -DCOORD_DIM=3 -DDXIL_TY=7 \
-// RUN:   -DRW=0
+// RUN:   -DRW=0 --check-prefixes=CHECK,CHECK-TEXEL
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
@@ -19,8 +26,15 @@
 //   COORD_DIM          sample location components (DIM plus the array slice)
 //   DXIL_TY            dx.Texture resource-kind operand
 //   RW                 dx.Texture UAV operand
+//
+// Check prefixes:
+//   TEXEL              the type has integer texel addressing (Load,
+//                      operator[], mips), and therefore a `mips` field in its
+//                      layout
+//   NOTEXEL            the type has no integer texel addressing
 
-// CHECK: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// CHECK-TEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]), %"struct.hlsl::[[TEXTURE]]<>::mips_type" }
+// CHECK-NOTEXEL: %"class.hlsl::[[TEXTURE]]" = type { target("dx.Texture", <4 x float>, [[RW]], 0, 0, [[DXIL_TY]]) }
 
 SamplerState g_s : register(s0);
 

--- a/clang/test/SemaHLSL/Resources/Textures-CalculateLevelOfDetail.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-CalculateLevelOfDetail.hlsl
@@ -1,18 +1,23 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library \
 // RUN:   -finclude-default-header -fsyntax-only -verify=expected,dim2 \
-// RUN:   -DLOD_TYPE=float2 -DTEXTURE=Texture2D %s
+// RUN:   -DTEXTURE=Texture2D -DLOD_TYPE=float2 %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library \
 // RUN:   -finclude-default-header -fsyntax-only -verify=expected,dim2 \
-// RUN:   -DLOD_TYPE=float2 -DTEXTURE=Texture2DArray %s
+// RUN:   -DTEXTURE=Texture2DArray -DLOD_TYPE=float2 %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library \
+// RUN:   -finclude-default-header -fsyntax-only -verify=expected,dim3 \
+// RUN:   -DTEXTURE=TextureCube -DLOD_TYPE=float3 %s
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
 //
-//   LOD_TYPE           CalculateLevelOfDetail location type
 //   TEXTURE            resource type name
+//   LOD_TYPE           CalculateLevelOfDetail location type
 //
 // Check prefixes:
 //   dim2               diagnostics naming a 2-component offset or location
+//                      vector
+//   dim3               diagnostics naming a 3-component offset or location
 //                      vector
 
 TEXTURE<float4> tex;
@@ -40,9 +45,11 @@ void main() {
   // expected-note@* {{'CalculateLevelOfDetailUnclamped' declared here}}
   tex.CalculateLevelOfDetailUnclamped(samp, loc, 0);
 
-  // dim2-error@+1 {{cannot initialize a parameter of type 'vector<float, 2>' (vector of 2 'float' values) with an lvalue of type 'const char[8]'}}
+  // dim2-error@+2 {{cannot initialize a parameter of type 'vector<float, 2>' (vector of 2 'float' values) with an lvalue of type 'const char[8]'}}
+  // dim3-error@+1 {{cannot initialize a parameter of type 'vector<float, 3>' (vector of 3 'float' values) with an lvalue of type 'const char[8]'}}
   tex.CalculateLevelOfDetail(samp, "invalid");
 
-  // dim2-error@+1 {{cannot initialize a parameter of type 'vector<float, 2>' (vector of 2 'float' values) with an lvalue of type 'const char[8]'}}
+  // dim2-error@+2 {{cannot initialize a parameter of type 'vector<float, 2>' (vector of 2 'float' values) with an lvalue of type 'const char[8]'}}
+  // dim3-error@+1 {{cannot initialize a parameter of type 'vector<float, 3>' (vector of 3 'float' values) with an lvalue of type 'const char[8]'}}
   tex.CalculateLevelOfDetailUnclamped(samp, "invalid");
 }

--- a/clang/test/SemaHLSL/Resources/Textures-SampleBias.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-SampleBias.hlsl
@@ -1,17 +1,35 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library \
-// RUN:   -finclude-default-header -fsyntax-only -verify -DOFFSET_TYPE=int2 \
-// RUN:   -DTEXTURE=Texture2D -DCOORD_TYPE=float2 %s
+// RUN:   -finclude-default-header -fsyntax-only -verify=expected,offset,dim2 \
+// RUN:   -DHAS_OFFSET -DOFFSET_TYPE=int2 -DTEXTURE=Texture2D \
+// RUN:   -DCOORD_TYPE=float2 %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library \
-// RUN:   -finclude-default-header -fsyntax-only -verify -DOFFSET_TYPE=int2 \
-// RUN:   -DTEXTURE=Texture2DArray -DCOORD_TYPE=float3 %s
+// RUN:   -finclude-default-header -fsyntax-only -verify=expected,offset,dim2 \
+// RUN:   -DHAS_OFFSET -DOFFSET_TYPE=int2 -DTEXTURE=Texture2DArray \
+// RUN:   -DCOORD_TYPE=float3 %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library \
+// RUN:   -finclude-default-header -fsyntax-only \
+// RUN:   -verify=expected,nooffset,dim3 -DOFFSET_TYPE=int3 \
+// RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
 //
+//   HAS_OFFSET         defined for types whose sampling and gathering methods
+//                      have overloads taking an offset
 //   OFFSET_TYPE        offset type, one component per resource dimension
 //   TEXTURE            resource type name
 //   COORD_TYPE         sample location type (DIM components plus the array
 //                      slice)
+//
+// Check prefixes:
+//   offset             diagnostics for types that have offset overloads
+//   dim2               diagnostics naming a 2-component offset or location
+//                      vector
+//   nooffset           diagnostics for types that have no offset overloads
+//   dim3               diagnostics naming a 3-component offset or location
+//                      vector
+//
+// HAS_OFFSET, OFFSET_TYPE and OFFSET_ARG as the matching preprocessor
 
 TEXTURE<float4> tex;
 SamplerState samp;
@@ -23,24 +41,45 @@ void main() {
   float clamp = 0;
 
   tex.SampleBias(samp, loc, bias);
+
+#ifdef HAS_OFFSET
   tex.SampleBias(samp, loc, bias, offset);
   tex.SampleBias(samp, loc, bias, offset, clamp);
+#else
+  // This type has no overload that takes an offset.
+  // nooffset-note@* {{'SampleBias' declared here}}
+  // nooffset-error@+1 {{too many arguments to function call, expected 3, have 4}}
+  tex.SampleBias(samp, loc, bias, offset);
+
+  // nooffset-note@* {{'SampleBias' declared here}}
+  // nooffset-error@+1 {{too many arguments to function call, expected 3, have 5}}
+  tex.SampleBias(samp, loc, bias, offset, clamp);
+#endif
 
   // Too few arguments.
-  tex.SampleBias(samp, loc); // expected-error {{no matching member function for call to 'SampleBias'}}
-  // expected-note@*:* {{candidate function not viable: requires 3 arguments, but 2 were provided}}
-  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 2 were provided}}
-  // expected-note@*:* {{candidate function not viable: requires 5 arguments, but 2 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 3 arguments, but 2 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 2 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 5 arguments, but 2 were provided}}
+  // nooffset-note@* {{'SampleBias' declared here}}
+  // offset-error@+2 {{no matching member function for call to 'SampleBias'}}
+  // nooffset-error@+1 {{too few arguments to function call, expected 3, have 2}}
+  tex.SampleBias(samp, loc);
 
   // Too many arguments.
-  tex.SampleBias(samp, loc, bias, offset, clamp, 0); // expected-error {{no matching member function for call to 'SampleBias'}}
-  // expected-note@*:* {{candidate function not viable: requires 5 arguments, but 6 were provided}}
-  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 6 were provided}}
-  // expected-note@*:* {{candidate function not viable: requires 3 arguments, but 6 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 5 arguments, but 6 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 6 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 3 arguments, but 6 were provided}}
+  // nooffset-note@* {{'SampleBias' declared here}}
+  // offset-error@+2 {{no matching member function for call to 'SampleBias'}}
+  // nooffset-error@+1 {{too many arguments to function call, expected 3, have 6}}
+  tex.SampleBias(samp, loc, bias, offset, clamp, 0);
 
   // Invalid argument types.
-  tex.SampleBias(samp, loc, bias, offset, "invalid"); // expected-error {{no matching member function for call to 'SampleBias'}}
-  // expected-note@*:* {{no known conversion from 'const char[8]' to 'float' for 5th argument}}
-  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 5 were provided}}
-  // expected-note@*:* {{candidate function not viable: requires 3 arguments, but 5 were provided}}
+  // offset-note@*:* {{no known conversion from 'const char[8]' to 'float' for 5th argument}}
+  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 5 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 3 arguments, but 5 were provided}}
+  // nooffset-note@* {{'SampleBias' declared here}}
+  // offset-error@+2 {{no matching member function for call to 'SampleBias'}}
+  // nooffset-error@+1 {{too many arguments to function call, expected 3, have 5}}
+  tex.SampleBias(samp, loc, bias, offset, "invalid");
 }

--- a/clang/test/SemaHLSL/Resources/Textures-SampleBias.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-SampleBias.hlsl
@@ -46,40 +46,33 @@ void main() {
   tex.SampleBias(samp, loc, bias, offset);
   tex.SampleBias(samp, loc, bias, offset, clamp);
 #else
-  // This type has no overload that takes an offset.
-  // nooffset-note@* {{'SampleBias' declared here}}
-  // nooffset-error@+1 {{too many arguments to function call, expected 3, have 4}}
-  tex.SampleBias(samp, loc, bias, offset);
+  // This type has no overload that takes an offset, but it does have one that
+  // takes a clamp, so the 4th parameter is the clamp.
+  tex.SampleBias(samp, loc, bias, clamp);
 
-  // nooffset-note@* {{'SampleBias' declared here}}
-  // nooffset-error@+1 {{too many arguments to function call, expected 3, have 5}}
-  tex.SampleBias(samp, loc, bias, offset, clamp);
+  // Passing an offset therefore selects the clamp overload and truncates.
+  // nooffset-warning@+1 {{implicit conversion turns vector to scalar}}
+  tex.SampleBias(samp, loc, bias, offset);
 #endif
 
   // Too few arguments.
-  // offset-note@*:* {{candidate function not viable: requires 3 arguments, but 2 were provided}}
-  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 2 were provided}}
   // offset-note@*:* {{candidate function not viable: requires 5 arguments, but 2 were provided}}
-  // nooffset-note@* {{'SampleBias' declared here}}
-  // offset-error@+2 {{no matching member function for call to 'SampleBias'}}
-  // nooffset-error@+1 {{too few arguments to function call, expected 3, have 2}}
+  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 2 were provided}}
+  // expected-note@*:* {{candidate function not viable: requires 3 arguments, but 2 were provided}}
+  // expected-error@+1 {{no matching member function for call to 'SampleBias'}}
   tex.SampleBias(samp, loc);
 
   // Too many arguments.
   // offset-note@*:* {{candidate function not viable: requires 5 arguments, but 6 were provided}}
-  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 6 were provided}}
-  // offset-note@*:* {{candidate function not viable: requires 3 arguments, but 6 were provided}}
-  // nooffset-note@* {{'SampleBias' declared here}}
-  // offset-error@+2 {{no matching member function for call to 'SampleBias'}}
-  // nooffset-error@+1 {{too many arguments to function call, expected 3, have 6}}
+  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 6 were provided}}
+  // expected-note@*:* {{candidate function not viable: requires 3 arguments, but 6 were provided}}
+  // expected-error@+1 {{no matching member function for call to 'SampleBias'}}
   tex.SampleBias(samp, loc, bias, offset, clamp, 0);
 
   // Invalid argument types.
   // offset-note@*:* {{no known conversion from 'const char[8]' to 'float' for 5th argument}}
-  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 5 were provided}}
-  // offset-note@*:* {{candidate function not viable: requires 3 arguments, but 5 were provided}}
-  // nooffset-note@* {{'SampleBias' declared here}}
-  // offset-error@+2 {{no matching member function for call to 'SampleBias'}}
-  // nooffset-error@+1 {{too many arguments to function call, expected 3, have 5}}
+  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 5 were provided}}
+  // expected-note@*:* {{candidate function not viable: requires 3 arguments, but 5 were provided}}
+  // expected-error@+1 {{no matching member function for call to 'SampleBias'}}
   tex.SampleBias(samp, loc, bias, offset, "invalid");
 }

--- a/clang/test/SemaHLSL/Resources/Textures-SampleCmp.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-SampleCmp.hlsl
@@ -1,22 +1,36 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
-// RUN:   -fsyntax-only -finclude-default-header -verify=expected,dim2 \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2D -DCOORD_TYPE=float2 %s
+// RUN:   -fsyntax-only -finclude-default-header -verify=expected,offset,dim2 \
+// RUN:   -DHAS_OFFSET -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2D \
+// RUN:   -DCOORD_TYPE=float2 %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
-// RUN:   -fsyntax-only -finclude-default-header -verify=expected,dim2 \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2DArray \
+// RUN:   -fsyntax-only -finclude-default-header -verify=expected,offset,dim2 \
+// RUN:   -DHAS_OFFSET -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2DArray \
 // RUN:   -DCOORD_TYPE=float3 %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
+// RUN:   -fsyntax-only -finclude-default-header \
+// RUN:   -verify=expected,nooffset,dim3 -DOFFSET_ARG="int3(1, 2, 3)" \
+// RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
 //
+//   HAS_OFFSET         defined for types whose sampling and gathering methods
+//                      have overloads taking an offset
 //   OFFSET_ARG         a literal offset argument
 //   TEXTURE            resource type name
 //   COORD_TYPE         sample location type (DIM components plus the array
 //                      slice)
 //
 // Check prefixes:
+//   offset             diagnostics for types that have offset overloads
 //   dim2               diagnostics naming a 2-component offset or location
 //                      vector
+//   nooffset           diagnostics for types that have no offset overloads
+//   dim3               diagnostics naming a 3-component offset or location
+//                      vector
+//
+// HAS_OFFSET, OFFSET_TYPE and OFFSET_ARG as the matching preprocessor
+
 
 TEXTURE<float4> t;
 TEXTURE<int4> t_int;
@@ -25,31 +39,50 @@ SamplerState s2;
 
 void main(COORD_TYPE loc, float cmp) {
   t.SampleCmp(s, loc, cmp);
+
+#ifdef HAS_OFFSET
   t.SampleCmp(s, loc, cmp, OFFSET_ARG);
   t.SampleCmp(s, loc, cmp, OFFSET_ARG, 1.0f);
+#else
+  // This type has no overload that takes an offset.
+  // nooffset-note@* {{'SampleCmp' declared here}}
+  // nooffset-error@+1 {{too many arguments to function call, expected 3, have 4}}
+  t.SampleCmp(s, loc, cmp, OFFSET_ARG);
+
+  // nooffset-note@* {{'SampleCmp' declared here}}
+  // nooffset-error@+1 {{too many arguments to function call, expected 3, have 5}}
+  t.SampleCmp(s, loc, cmp, OFFSET_ARG, 1.0f);
+#endif
 
   // expected-error@* {{'SampleCmp' and 'SampleCmpLevelZero' require resource to contain a floating point type}}
   // expected-note-re@*:* {{in instantiation of member function 'hlsl::Texture{{.+}}::SampleCmp' requested here}}
   t_int.SampleCmp(s, loc, cmp);
 
-  // expected-error@+4 {{no matching member function for call to 'SampleCmp'}}
-  // expected-note@*:* {{candidate function not viable: requires 3 arguments, but 1 was provided}}
-  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 1 was provided}}
-  // expected-note@*:* {{candidate function not viable: requires 5 arguments, but 1 was provided}}
+  // offset-note@*:* {{candidate function not viable: requires 3 arguments, but 1 was provided}}
+  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 1 was provided}}
+  // offset-note@*:* {{candidate function not viable: requires 5 arguments, but 1 was provided}}
+  // nooffset-note@* {{'SampleCmp' declared here}}
+  // offset-error@+2 {{no matching member function for call to 'SampleCmp'}}
+  // nooffset-error@+1 {{too few arguments to function call, expected 3, have 1}}
   t.SampleCmp(loc);
 
-  // expected-error@+4 {{no matching member function for call to 'SampleCmp'}}
-  // expected-note@*:* {{candidate function not viable: requires 5 arguments, but 6 were provided}}
-  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 6 were provided}}
-  // expected-note@*:* {{candidate function not viable: requires 3 arguments, but 6 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 5 arguments, but 6 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 6 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 3 arguments, but 6 were provided}}
+  // nooffset-note@* {{'SampleCmp' declared here}}
+  // offset-error@+2 {{no matching member function for call to 'SampleCmp'}}
+  // nooffset-error@+1 {{too many arguments to function call, expected 3, have 6}}
   t.SampleCmp(s, loc, cmp, OFFSET_ARG, 1.0f, 1.0f);
 
-  // expected-error@+4 {{no matching member function for call to 'SampleCmp'}}
-  // expected-note@*:* {{candidate function not viable: no known conversion from 'SamplerState' to 'hlsl::SamplerComparisonState' for 1st argument}}
-  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 3 were provided}}
-  // expected-note@*:* {{candidate function not viable: requires 5 arguments, but 3 were provided}}
+  // offset-note@*:* {{candidate function not viable: no known conversion from 'SamplerState' to 'hlsl::SamplerComparisonState' for 1st argument}}
+  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 3 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 5 arguments, but 3 were provided}}
+  // nooffset-note@*:* {{candidate constructor not viable: no known conversion from 'SamplerState' to 'const hlsl::SamplerComparisonState &' for 1st argument}}
+  // offset-error@+2 {{no matching member function for call to 'SampleCmp'}}
+  // nooffset-error@+1 {{no viable conversion from 'SamplerState' to 'hlsl::SamplerComparisonState'}}
   t.SampleCmp(s2, loc, cmp);
 
+#ifdef HAS_OFFSET
   // expected-error@+4 {{no matching member function for call to 'SampleCmp'}}
   // dim2-note@*:* {{candidate function not viable: no known conversion from 'SamplerComparisonState' to 'vector<int, 2>' (vector of 2 'int' values) for 4th argument}}
   // expected-note@*:* {{candidate function not viable: requires 3 arguments, but 4 were provided}}
@@ -61,4 +94,5 @@ void main(COORD_TYPE loc, float cmp) {
   // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 5 were provided}}
   // expected-note@*:* {{candidate function not viable: requires 3 arguments, but 5 were provided}}
   t.SampleCmp(s, loc, cmp, OFFSET_ARG, s);
+#endif
 }

--- a/clang/test/SemaHLSL/Resources/Textures-SampleCmp.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-SampleCmp.hlsl
@@ -44,42 +44,35 @@ void main(COORD_TYPE loc, float cmp) {
   t.SampleCmp(s, loc, cmp, OFFSET_ARG);
   t.SampleCmp(s, loc, cmp, OFFSET_ARG, 1.0f);
 #else
-  // This type has no overload that takes an offset.
-  // nooffset-note@* {{'SampleCmp' declared here}}
-  // nooffset-error@+1 {{too many arguments to function call, expected 3, have 4}}
-  t.SampleCmp(s, loc, cmp, OFFSET_ARG);
+  // This type has no overload that takes an offset, but it does have one that
+  // takes a clamp, so the 4th parameter is the clamp.
+  t.SampleCmp(s, loc, cmp, 1.0f);
 
-  // nooffset-note@* {{'SampleCmp' declared here}}
-  // nooffset-error@+1 {{too many arguments to function call, expected 3, have 5}}
-  t.SampleCmp(s, loc, cmp, OFFSET_ARG, 1.0f);
+  // Passing an offset therefore selects the clamp overload and truncates.
+  // nooffset-warning@+1 {{implicit conversion turns vector to scalar}}
+  t.SampleCmp(s, loc, cmp, OFFSET_ARG);
 #endif
 
   // expected-error@* {{'SampleCmp' and 'SampleCmpLevelZero' require resource to contain a floating point type}}
   // expected-note-re@*:* {{in instantiation of member function 'hlsl::Texture{{.+}}::SampleCmp' requested here}}
   t_int.SampleCmp(s, loc, cmp);
 
-  // offset-note@*:* {{candidate function not viable: requires 3 arguments, but 1 was provided}}
-  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 1 was provided}}
+  // expected-note@*:* {{candidate function not viable: requires 3 arguments, but 1 was provided}}
+  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 1 was provided}}
   // offset-note@*:* {{candidate function not viable: requires 5 arguments, but 1 was provided}}
-  // nooffset-note@* {{'SampleCmp' declared here}}
-  // offset-error@+2 {{no matching member function for call to 'SampleCmp'}}
-  // nooffset-error@+1 {{too few arguments to function call, expected 3, have 1}}
+  // expected-error@+1 {{no matching member function for call to 'SampleCmp'}}
   t.SampleCmp(loc);
 
   // offset-note@*:* {{candidate function not viable: requires 5 arguments, but 6 were provided}}
-  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 6 were provided}}
-  // offset-note@*:* {{candidate function not viable: requires 3 arguments, but 6 were provided}}
-  // nooffset-note@* {{'SampleCmp' declared here}}
-  // offset-error@+2 {{no matching member function for call to 'SampleCmp'}}
-  // nooffset-error@+1 {{too many arguments to function call, expected 3, have 6}}
+  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 6 were provided}}
+  // expected-note@*:* {{candidate function not viable: requires 3 arguments, but 6 were provided}}
+  // expected-error@+1 {{no matching member function for call to 'SampleCmp'}}
   t.SampleCmp(s, loc, cmp, OFFSET_ARG, 1.0f, 1.0f);
 
-  // offset-note@*:* {{candidate function not viable: no known conversion from 'SamplerState' to 'hlsl::SamplerComparisonState' for 1st argument}}
-  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 3 were provided}}
+  // expected-note@*:* {{candidate function not viable: no known conversion from 'SamplerState' to 'hlsl::SamplerComparisonState' for 1st argument}}
+  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 3 were provided}}
   // offset-note@*:* {{candidate function not viable: requires 5 arguments, but 3 were provided}}
-  // nooffset-note@*:* {{candidate constructor not viable: no known conversion from 'SamplerState' to 'const hlsl::SamplerComparisonState &' for 1st argument}}
-  // offset-error@+2 {{no matching member function for call to 'SampleCmp'}}
-  // nooffset-error@+1 {{no viable conversion from 'SamplerState' to 'hlsl::SamplerComparisonState'}}
+  // expected-error@+1 {{no matching member function for call to 'SampleCmp'}}
   t.SampleCmp(s2, loc, cmp);
 
 #ifdef HAS_OFFSET

--- a/clang/test/SemaHLSL/Resources/Textures-SampleCmpLevelZero.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-SampleCmpLevelZero.hlsl
@@ -1,23 +1,36 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
-// RUN:   -fsyntax-only -finclude-default-header -verify=expected,dim2 \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2D -DCOORD_TYPE=float2 %s
+// RUN:   -fsyntax-only -finclude-default-header -verify=expected,offset,dim2 \
+// RUN:   -DHAS_OFFSET -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2D \
+// RUN:   -DCOORD_TYPE=float2 %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
-// RUN:   -fsyntax-only -finclude-default-header -verify=expected,dim2 \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2DArray \
+// RUN:   -fsyntax-only -finclude-default-header -verify=expected,offset,dim2 \
+// RUN:   -DHAS_OFFSET -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2DArray \
 // RUN:   -DCOORD_TYPE=float3 %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
+// RUN:   -fsyntax-only -finclude-default-header \
+// RUN:   -verify=expected,nooffset,dim3 -DOFFSET_ARG="int3(1, 2, 3)" \
+// RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
 //
+//   HAS_OFFSET         defined for types whose sampling and gathering methods
+//                      have overloads taking an offset
 //   OFFSET_ARG         a literal offset argument
 //   TEXTURE            resource type name
 //   COORD_TYPE         sample location type (DIM components plus the array
 //                      slice)
 //
 // Check prefixes:
+//   offset             diagnostics for types that have offset overloads
 //   dim2               diagnostics naming a 2-component offset or location
 //                      vector
+//   nooffset           diagnostics for types that have no offset overloads
+//   dim3               diagnostics naming a 3-component offset or location
+//                      vector
 //
+// HAS_OFFSET, OFFSET_TYPE and OFFSET_ARG as the matching preprocessor
+
 // expected-error@* {{'SampleCmp' and 'SampleCmpLevelZero' require resource to contain a floating point type}}
 
 TEXTURE<float4> t;
@@ -27,28 +40,44 @@ SamplerState s2;
 
 void main(COORD_TYPE loc, float cmp) {
   t.SampleCmpLevelZero(s, loc, cmp);
+
+#ifdef HAS_OFFSET
   t.SampleCmpLevelZero(s, loc, cmp, OFFSET_ARG);
+#else
+  // This type has no overload that takes an offset.
+  // nooffset-note@* {{'SampleCmpLevelZero' declared here}}
+  // nooffset-error@+1 {{too many arguments to function call, expected 3, have 4}}
+  t.SampleCmpLevelZero(s, loc, cmp, OFFSET_ARG);
+#endif
 
   // expected-note-re@*:* {{in instantiation of member function 'hlsl::Texture{{.+}}::SampleCmpLevelZero' requested here}}
   t_int.SampleCmpLevelZero(s, loc, cmp);
 
-  // expected-error@+3 {{no matching member function for call to 'SampleCmpLevelZero'}}
-  // expected-note@*:* {{candidate function not viable: requires 3 arguments, but 1 was provided}}
-  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 1 was provided}}
+  // offset-note@*:* {{candidate function not viable: requires 3 arguments, but 1 was provided}}
+  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 1 was provided}}
+  // nooffset-note@* {{'SampleCmpLevelZero' declared here}}
+  // offset-error@+2 {{no matching member function for call to 'SampleCmpLevelZero'}}
+  // nooffset-error@+1 {{too few arguments to function call, expected 3, have 1}}
   t.SampleCmpLevelZero(loc);
 
-  // expected-error@+3 {{no matching member function for call to 'SampleCmpLevelZero'}}
-  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 5 were provided}}
-  // expected-note@*:* {{candidate function not viable: requires 3 arguments, but 5 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 5 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 3 arguments, but 5 were provided}}
+  // nooffset-note@* {{'SampleCmpLevelZero' declared here}}
+  // offset-error@+2 {{no matching member function for call to 'SampleCmpLevelZero'}}
+  // nooffset-error@+1 {{too many arguments to function call, expected 3, have 5}}
   t.SampleCmpLevelZero(s, loc, cmp, OFFSET_ARG, 1.0f);
 
-  // expected-error@+3 {{no matching member function for call to 'SampleCmpLevelZero'}}
-  // expected-note@*:* {{candidate function not viable: no known conversion from 'SamplerState' to 'hlsl::SamplerComparisonState' for 1st argument}}
-  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 3 were provided}}
+  // offset-note@*:* {{candidate function not viable: no known conversion from 'SamplerState' to 'hlsl::SamplerComparisonState' for 1st argument}}
+  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 3 were provided}}
+  // nooffset-note@*:* {{candidate constructor not viable: no known conversion from 'SamplerState' to 'const hlsl::SamplerComparisonState &' for 1st argument}}
+  // offset-error@+2 {{no matching member function for call to 'SampleCmpLevelZero'}}
+  // nooffset-error@+1 {{no viable conversion from 'SamplerState' to 'hlsl::SamplerComparisonState'}}
   t.SampleCmpLevelZero(s2, loc, cmp);
 
+#ifdef HAS_OFFSET
   // expected-error@+3 {{no matching member function for call to 'SampleCmpLevelZero'}}
   // dim2-note@*:* {{candidate function not viable: no known conversion from 'SamplerComparisonState' to 'vector<int, 2>' (vector of 2 'int' values) for 4th argument}}
   // expected-note@*:* {{candidate function not viable: requires 3 arguments, but 4 were provided}}
   t.SampleCmpLevelZero(s, loc, cmp, s);
+#endif
 }

--- a/clang/test/SemaHLSL/Resources/Textures-SampleGrad.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-SampleGrad.hlsl
@@ -1,19 +1,37 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library \
-// RUN:   -finclude-default-header -fsyntax-only -verify -DOFFSET_TYPE=int2 \
-// RUN:   -DGRAD_TYPE=float2 -DTEXTURE=Texture2D -DCOORD_TYPE=float2 %s
+// RUN:   -finclude-default-header -fsyntax-only -verify=expected,offset,dim2 \
+// RUN:   -DHAS_OFFSET -DOFFSET_TYPE=int2 -DTEXTURE=Texture2D \
+// RUN:   -DCOORD_TYPE=float2 -DGRAD_TYPE=float2 %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library \
-// RUN:   -finclude-default-header -fsyntax-only -verify -DOFFSET_TYPE=int2 \
-// RUN:   -DGRAD_TYPE=float2 -DTEXTURE=Texture2DArray -DCOORD_TYPE=float3 %s
+// RUN:   -finclude-default-header -fsyntax-only -verify=expected,offset,dim2 \
+// RUN:   -DHAS_OFFSET -DOFFSET_TYPE=int2 -DTEXTURE=Texture2DArray \
+// RUN:   -DCOORD_TYPE=float3 -DGRAD_TYPE=float2 %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library \
+// RUN:   -finclude-default-header -fsyntax-only \
+// RUN:   -verify=expected,nooffset,dim3 -DOFFSET_TYPE=int3 \
+// RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 -DGRAD_TYPE=float3 %s
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
 //
+//   HAS_OFFSET         defined for types whose sampling and gathering methods
+//                      have overloads taking an offset
 //   OFFSET_TYPE        offset type, one component per resource dimension
-//   GRAD_TYPE          SampleGrad ddx/ddy type, one component per resource
-//                      dimension
 //   TEXTURE            resource type name
 //   COORD_TYPE         sample location type (DIM components plus the array
 //                      slice)
+//   GRAD_TYPE          SampleGrad ddx/ddy type, one component per resource
+//                      dimension
+//
+// Check prefixes:
+//   offset             diagnostics for types that have offset overloads
+//   dim2               diagnostics naming a 2-component offset or location
+//                      vector
+//   nooffset           diagnostics for types that have no offset overloads
+//   dim3               diagnostics naming a 3-component offset or location
+//                      vector
+//
+// HAS_OFFSET, OFFSET_TYPE and OFFSET_ARG as the matching preprocessor
 
 TEXTURE<float4> tex;
 SamplerState samp;
@@ -26,24 +44,45 @@ void main() {
   float clamp = 0;
 
   tex.SampleGrad(samp, loc, ddx, ddy);
+
+#ifdef HAS_OFFSET
   tex.SampleGrad(samp, loc, ddx, ddy, offset);
   tex.SampleGrad(samp, loc, ddx, ddy, offset, clamp);
+#else
+  // This type has no overload that takes an offset.
+  // nooffset-note@* {{'SampleGrad' declared here}}
+  // nooffset-error@+1 {{too many arguments to function call, expected 4, have 5}}
+  tex.SampleGrad(samp, loc, ddx, ddy, offset);
+
+  // nooffset-note@* {{'SampleGrad' declared here}}
+  // nooffset-error@+1 {{too many arguments to function call, expected 4, have 6}}
+  tex.SampleGrad(samp, loc, ddx, ddy, offset, clamp);
+#endif
 
   // Too few arguments.
-  tex.SampleGrad(samp, loc, ddx); // expected-error {{no matching member function for call to 'SampleGrad'}}
-  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 3 were provided}}
-  // expected-note@*:* {{candidate function not viable: requires 5 arguments, but 3 were provided}}
-  // expected-note@*:* {{candidate function not viable: requires 6 arguments, but 3 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 3 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 5 arguments, but 3 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 6 arguments, but 3 were provided}}
+  // nooffset-note@* {{'SampleGrad' declared here}}
+  // offset-error@+2 {{no matching member function for call to 'SampleGrad'}}
+  // nooffset-error@+1 {{too few arguments to function call, expected 4, have 3}}
+  tex.SampleGrad(samp, loc, ddx);
 
   // Too many arguments.
-  tex.SampleGrad(samp, loc, ddx, ddy, offset, clamp, 0); // expected-error {{no matching member function for call to 'SampleGrad'}}
-  // expected-note@*:* {{candidate function not viable: requires 6 arguments, but 7 were provided}}
-  // expected-note@*:* {{candidate function not viable: requires 5 arguments, but 7 were provided}}
-  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 7 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 6 arguments, but 7 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 5 arguments, but 7 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 7 were provided}}
+  // nooffset-note@* {{'SampleGrad' declared here}}
+  // offset-error@+2 {{no matching member function for call to 'SampleGrad'}}
+  // nooffset-error@+1 {{too many arguments to function call, expected 4, have 7}}
+  tex.SampleGrad(samp, loc, ddx, ddy, offset, clamp, 0);
 
   // Invalid argument types.
-  tex.SampleGrad(samp, loc, ddx, ddy, offset, "invalid"); // expected-error {{no matching member function for call to 'SampleGrad'}}
-  // expected-note@*:* {{no known conversion from 'const char[8]' to 'float' for 6th argument}}
-  // expected-note@*:* {{candidate function not viable: requires 5 arguments, but 6 were provided}}
-  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 6 were provided}}
+  // offset-note@*:* {{no known conversion from 'const char[8]' to 'float' for 6th argument}}
+  // offset-note@*:* {{candidate function not viable: requires 5 arguments, but 6 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 6 were provided}}
+  // nooffset-note@* {{'SampleGrad' declared here}}
+  // offset-error@+2 {{no matching member function for call to 'SampleGrad'}}
+  // nooffset-error@+1 {{too many arguments to function call, expected 4, have 6}}
+  tex.SampleGrad(samp, loc, ddx, ddy, offset, "invalid");
 }

--- a/clang/test/SemaHLSL/Resources/Textures-SampleGrad.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-SampleGrad.hlsl
@@ -49,40 +49,33 @@ void main() {
   tex.SampleGrad(samp, loc, ddx, ddy, offset);
   tex.SampleGrad(samp, loc, ddx, ddy, offset, clamp);
 #else
-  // This type has no overload that takes an offset.
-  // nooffset-note@* {{'SampleGrad' declared here}}
-  // nooffset-error@+1 {{too many arguments to function call, expected 4, have 5}}
-  tex.SampleGrad(samp, loc, ddx, ddy, offset);
+  // This type has no overload that takes an offset, but it does have one that
+  // takes a clamp, so the 5th parameter is the clamp.
+  tex.SampleGrad(samp, loc, ddx, ddy, clamp);
 
-  // nooffset-note@* {{'SampleGrad' declared here}}
-  // nooffset-error@+1 {{too many arguments to function call, expected 4, have 6}}
-  tex.SampleGrad(samp, loc, ddx, ddy, offset, clamp);
+  // Passing an offset therefore selects the clamp overload and truncates.
+  // nooffset-warning@+1 {{implicit conversion turns vector to scalar}}
+  tex.SampleGrad(samp, loc, ddx, ddy, offset);
 #endif
 
   // Too few arguments.
-  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 3 were provided}}
-  // offset-note@*:* {{candidate function not viable: requires 5 arguments, but 3 were provided}}
+  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 3 were provided}}
+  // expected-note@*:* {{candidate function not viable: requires 5 arguments, but 3 were provided}}
   // offset-note@*:* {{candidate function not viable: requires 6 arguments, but 3 were provided}}
-  // nooffset-note@* {{'SampleGrad' declared here}}
-  // offset-error@+2 {{no matching member function for call to 'SampleGrad'}}
-  // nooffset-error@+1 {{too few arguments to function call, expected 4, have 3}}
+  // expected-error@+1 {{no matching member function for call to 'SampleGrad'}}
   tex.SampleGrad(samp, loc, ddx);
 
   // Too many arguments.
   // offset-note@*:* {{candidate function not viable: requires 6 arguments, but 7 were provided}}
-  // offset-note@*:* {{candidate function not viable: requires 5 arguments, but 7 were provided}}
-  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 7 were provided}}
-  // nooffset-note@* {{'SampleGrad' declared here}}
-  // offset-error@+2 {{no matching member function for call to 'SampleGrad'}}
-  // nooffset-error@+1 {{too many arguments to function call, expected 4, have 7}}
+  // expected-note@*:* {{candidate function not viable: requires 5 arguments, but 7 were provided}}
+  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 7 were provided}}
+  // expected-error@+1 {{no matching member function for call to 'SampleGrad'}}
   tex.SampleGrad(samp, loc, ddx, ddy, offset, clamp, 0);
 
   // Invalid argument types.
   // offset-note@*:* {{no known conversion from 'const char[8]' to 'float' for 6th argument}}
-  // offset-note@*:* {{candidate function not viable: requires 5 arguments, but 6 were provided}}
-  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 6 were provided}}
-  // nooffset-note@* {{'SampleGrad' declared here}}
-  // offset-error@+2 {{no matching member function for call to 'SampleGrad'}}
-  // nooffset-error@+1 {{too many arguments to function call, expected 4, have 6}}
+  // expected-note@*:* {{candidate function not viable: requires 5 arguments, but 6 were provided}}
+  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 6 were provided}}
+  // expected-error@+1 {{no matching member function for call to 'SampleGrad'}}
   tex.SampleGrad(samp, loc, ddx, ddy, offset, "invalid");
 }

--- a/clang/test/SemaHLSL/Resources/Textures-SampleLevel.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-SampleLevel.hlsl
@@ -1,17 +1,35 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library \
-// RUN:   -finclude-default-header -fsyntax-only -verify -DOFFSET_TYPE=int2 \
-// RUN:   -DTEXTURE=Texture2D -DCOORD_TYPE=float2 %s
+// RUN:   -finclude-default-header -fsyntax-only -verify=expected,offset,dim2 \
+// RUN:   -DHAS_OFFSET -DOFFSET_TYPE=int2 -DTEXTURE=Texture2D \
+// RUN:   -DCOORD_TYPE=float2 %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library \
-// RUN:   -finclude-default-header -fsyntax-only -verify -DOFFSET_TYPE=int2 \
-// RUN:   -DTEXTURE=Texture2DArray -DCOORD_TYPE=float3 %s
+// RUN:   -finclude-default-header -fsyntax-only -verify=expected,offset,dim2 \
+// RUN:   -DHAS_OFFSET -DOFFSET_TYPE=int2 -DTEXTURE=Texture2DArray \
+// RUN:   -DCOORD_TYPE=float3 %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library \
+// RUN:   -finclude-default-header -fsyntax-only \
+// RUN:   -verify=expected,nooffset,dim3 -DOFFSET_TYPE=int3 \
+// RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
 //
+//   HAS_OFFSET         defined for types whose sampling and gathering methods
+//                      have overloads taking an offset
 //   OFFSET_TYPE        offset type, one component per resource dimension
 //   TEXTURE            resource type name
 //   COORD_TYPE         sample location type (DIM components plus the array
 //                      slice)
+//
+// Check prefixes:
+//   offset             diagnostics for types that have offset overloads
+//   dim2               diagnostics naming a 2-component offset or location
+//                      vector
+//   nooffset           diagnostics for types that have no offset overloads
+//   dim3               diagnostics naming a 3-component offset or location
+//                      vector
+//
+// HAS_OFFSET, OFFSET_TYPE and OFFSET_ARG as the matching preprocessor
 
 TEXTURE<float4> tex;
 SamplerState samp;
@@ -22,20 +40,36 @@ void main() {
   OFFSET_TYPE offset = (OFFSET_TYPE)0;
 
   tex.SampleLevel(samp, loc, lod);
+
+#ifdef HAS_OFFSET
   tex.SampleLevel(samp, loc, lod, offset);
+#else
+  // This type has no overload that takes an offset.
+  // nooffset-note@* {{'SampleLevel' declared here}}
+  // nooffset-error@+1 {{too many arguments to function call, expected 3, have 4}}
+  tex.SampleLevel(samp, loc, lod, offset);
+#endif
 
   // Too few arguments.
-  tex.SampleLevel(samp, loc); // expected-error {{no matching member function for call to 'SampleLevel'}}
-  // expected-note@*:* {{candidate function not viable: requires 3 arguments, but 2 were provided}}
-  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 2 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 3 arguments, but 2 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 2 were provided}}
+  // nooffset-note@* {{'SampleLevel' declared here}}
+  // offset-error@+2 {{no matching member function for call to 'SampleLevel'}}
+  // nooffset-error@+1 {{too few arguments to function call, expected 3, have 2}}
+  tex.SampleLevel(samp, loc);
 
   // Too many arguments.
-  tex.SampleLevel(samp, loc, lod, offset, 0); // expected-error {{no matching member function for call to 'SampleLevel'}}
-  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 5 were provided}}
-  // expected-note@*:* {{candidate function not viable: requires 3 arguments, but 5 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 5 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 3 arguments, but 5 were provided}}
+  // nooffset-note@* {{'SampleLevel' declared here}}
+  // offset-error@+2 {{no matching member function for call to 'SampleLevel'}}
+  // nooffset-error@+1 {{too many arguments to function call, expected 3, have 5}}
+  tex.SampleLevel(samp, loc, lod, offset, 0);
 
   // Invalid argument types.
-  tex.SampleLevel(samp, loc, "invalid"); // expected-error {{no matching member function for call to 'SampleLevel'}}
-  // expected-note@*:* {{no known conversion from 'const char[8]' to 'float' for 3rd argument}}
-  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 3 were provided}}
+  // offset-note@*:* {{no known conversion from 'const char[8]' to 'float' for 3rd argument}}
+  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 3 were provided}}
+  // offset-error@+2 {{no matching member function for call to 'SampleLevel'}}
+  // nooffset-error@+1 {{cannot initialize a parameter of type 'float' with an lvalue of type 'const char[8]'}}
+  tex.SampleLevel(samp, loc, "invalid");
 }

--- a/clang/test/SemaHLSL/Resources/Textures-Sema.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-Sema.hlsl
@@ -1,43 +1,70 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
-// RUN:   -fsyntax-only -finclude-default-header -verify=expected,dim2 \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2D -DCOORD_TYPE=float2 %s
+// RUN:   -fsyntax-only -finclude-default-header -verify=expected,offset,dim2 \
+// RUN:   -DHAS_OFFSET -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2D \
+// RUN:   -DCOORD_TYPE=float2 %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
-// RUN:   -fsyntax-only -finclude-default-header -verify=expected,dim2 \
-// RUN:   -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2DArray \
+// RUN:   -fsyntax-only -finclude-default-header -verify=expected,offset,dim2 \
+// RUN:   -DHAS_OFFSET -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2DArray \
 // RUN:   -DCOORD_TYPE=float3 %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
+// RUN:   -fsyntax-only -finclude-default-header \
+// RUN:   -verify=expected,nooffset,dim3 -DOFFSET_ARG="int3(1, 2, 3)" \
+// RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
 //
+//   HAS_OFFSET         defined for types whose sampling and gathering methods
+//                      have overloads taking an offset
 //   OFFSET_ARG         a literal offset argument
 //   TEXTURE            resource type name
 //   COORD_TYPE         sample location type (DIM components plus the array
 //                      slice)
 //
 // Check prefixes:
+//   offset             diagnostics for types that have offset overloads
 //   dim2               diagnostics naming a 2-component offset or location
 //                      vector
+//   nooffset           diagnostics for types that have no offset overloads
+//   dim3               diagnostics naming a 3-component offset or location
+//                      vector
+//
+// HAS_OFFSET, OFFSET_TYPE and OFFSET_ARG as the matching preprocessor
+
+// TextureCube only has the Sample(SamplerState, float3) overload, so calls with
+// a wrong argument count are reported as a plain arity mismatch there, while the
+// 2D textures report a failed overload resolution.
 
 TEXTURE<float4> t;
 SamplerState s;
 
 void main(COORD_TYPE loc) {
   t.Sample(s, loc);
-  t.Sample(s, loc, OFFSET_ARG);
 
-  // expected-error@+4 {{no matching member function for call to 'Sample'}}
-  // expected-note@*:* {{candidate function not viable: requires 2 arguments, but 1 was provided}}
-  // expected-note@*:* {{candidate function not viable: requires 3 arguments, but 1 was provided}}
-  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 1 was provided}}
+  // offset-note@*:* {{candidate function not viable: requires 2 arguments, but 1 was provided}}
+  // offset-note@*:* {{candidate function not viable: requires 3 arguments, but 1 was provided}}
+  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 1 was provided}}
+  // nooffset-note@* {{'Sample' declared here}}
+  // offset-error@+2 {{no matching member function for call to 'Sample'}}
+  // nooffset-error@+1 {{too few arguments to function call, expected 2, have 1}}
   t.Sample(loc);
 
-  t.Sample(s, loc, OFFSET_ARG, 1.0);
-
-  // expected-error@+4 {{no matching member function for call to 'Sample'}}
-  // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 5 were provided}}
-  // expected-note@*:* {{candidate function not viable: requires 3 arguments, but 5 were provided}}
-  // expected-note@*:* {{candidate function not viable: requires 2 arguments, but 5 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 5 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 3 arguments, but 5 were provided}}
+  // offset-note@*:* {{candidate function not viable: requires 2 arguments, but 5 were provided}}
+  // nooffset-note@* {{'Sample' declared here}}
+  // offset-error@+2 {{no matching member function for call to 'Sample'}}
+  // nooffset-error@+1 {{too many arguments to function call, expected 2, have 5}}
   t.Sample(s, loc, OFFSET_ARG, 1.0, 1.0);
+
+  // Test with wrong coordinate dimension.
+  // Note: float implicitly converts to float2/float3 (splat), so no error here.
+  t.Sample(s, loc.x);
+
+#ifdef HAS_OFFSET
+  t.Sample(s, loc, OFFSET_ARG);
+
+  t.Sample(s, loc, OFFSET_ARG, 1.0);
 
   // expected-error@+4 {{no matching member function for call to 'Sample'}}
   // dim2-note@*:* {{candidate function not viable: no known conversion from 'SamplerState' to 'vector<int, 2>' (vector of 2 'int' values) for 3rd argument}}
@@ -51,11 +78,17 @@ void main(COORD_TYPE loc) {
   // expected-note@*:* {{candidate function not viable: requires 2 arguments, but 4 were provided}}
   t.Sample(s, loc, OFFSET_ARG, s);
 
-  // Test with wrong coordinate dimension.
-  // Note: float implicitly converts to float2/float3 (splat), so no error here.
-  t.Sample(s, loc.x);
-
   // Test with wrong offset dimension.
   // Note: int implicitly converts to int2 (splat), so no error here.
   t.Sample(s, loc, 1);
+#else
+  // This type has no overload that takes an offset.
+  // nooffset-error@+2 {{too many arguments to function call, expected 2, have 3}}
+  // nooffset-note@* {{'Sample' declared here}}
+  t.Sample(s, loc, OFFSET_ARG);
+
+  // nooffset-error@+2 {{too many arguments to function call, expected 2, have 4}}
+  // nooffset-note@* {{'Sample' declared here}}
+  t.Sample(s, loc, OFFSET_ARG, 1.0);
+#endif
 }

--- a/clang/test/SemaHLSL/Resources/Textures-Sema.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-Sema.hlsl
@@ -41,20 +41,16 @@ SamplerState s;
 void main(COORD_TYPE loc) {
   t.Sample(s, loc);
 
-  // offset-note@*:* {{candidate function not viable: requires 2 arguments, but 1 was provided}}
-  // offset-note@*:* {{candidate function not viable: requires 3 arguments, but 1 was provided}}
+  // expected-note@*:* {{candidate function not viable: requires 2 arguments, but 1 was provided}}
+  // expected-note@*:* {{candidate function not viable: requires 3 arguments, but 1 was provided}}
   // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 1 was provided}}
-  // nooffset-note@* {{'Sample' declared here}}
-  // offset-error@+2 {{no matching member function for call to 'Sample'}}
-  // nooffset-error@+1 {{too few arguments to function call, expected 2, have 1}}
+  // expected-error@+1 {{no matching member function for call to 'Sample'}}
   t.Sample(loc);
 
   // offset-note@*:* {{candidate function not viable: requires 4 arguments, but 5 were provided}}
-  // offset-note@*:* {{candidate function not viable: requires 3 arguments, but 5 were provided}}
-  // offset-note@*:* {{candidate function not viable: requires 2 arguments, but 5 were provided}}
-  // nooffset-note@* {{'Sample' declared here}}
-  // offset-error@+2 {{no matching member function for call to 'Sample'}}
-  // nooffset-error@+1 {{too many arguments to function call, expected 2, have 5}}
+  // expected-note@*:* {{candidate function not viable: requires 3 arguments, but 5 were provided}}
+  // expected-note@*:* {{candidate function not viable: requires 2 arguments, but 5 were provided}}
+  // expected-error@+1 {{no matching member function for call to 'Sample'}}
   t.Sample(s, loc, OFFSET_ARG, 1.0, 1.0);
 
   // Test with wrong coordinate dimension.
@@ -82,13 +78,17 @@ void main(COORD_TYPE loc) {
   // Note: int implicitly converts to int2 (splat), so no error here.
   t.Sample(s, loc, 1);
 #else
-  // This type has no overload that takes an offset.
-  // nooffset-error@+2 {{too many arguments to function call, expected 2, have 3}}
-  // nooffset-note@* {{'Sample' declared here}}
+  // This type has no overload that takes an offset, but it does have one that
+  // takes a clamp, so the 3rd parameter is the clamp.
+  t.Sample(s, loc, 1.0);
+
+  // Passing an offset therefore selects the clamp overload and truncates.
+  // nooffset-warning@+1 {{implicit conversion turns vector to scalar}}
   t.Sample(s, loc, OFFSET_ARG);
 
-  // nooffset-error@+2 {{too many arguments to function call, expected 2, have 4}}
-  // nooffset-note@* {{'Sample' declared here}}
+  // nooffset-note@*:* {{candidate function not viable: requires 3 arguments, but 4 were provided}}
+  // nooffset-note@*:* {{candidate function not viable: requires 2 arguments, but 4 were provided}}
+  // nooffset-error@+1 {{no matching member function for call to 'Sample'}}
   t.Sample(s, loc, OFFSET_ARG, 1.0);
 #endif
 }

--- a/clang/test/SemaHLSL/Resources/Textures-declaration-order.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-declaration-order.hlsl
@@ -20,6 +20,8 @@ Texture2DArray<float> Tex2DArray;
 Texture2DArray<float2> Tex2DArrayVec;
 RWTexture2DArray<float> RWTex2DArray;
 RWTexture2DArray<float2> RWTex2DArrayVec;
+TextureCube<float> TexCube;
+TextureCube<float2> TexCubeVec;
 #else
 Texture2D<float2> Tex2DVec;
 Texture2D<float> Tex2D;
@@ -29,6 +31,8 @@ Texture2DArray<float2> Tex2DArrayVec;
 Texture2DArray<float> Tex2DArray;
 RWTexture2DArray<float2> RWTex2DArrayVec;
 RWTexture2DArray<float> RWTex2DArray;
+TextureCube<float2> TexCubeVec;
+TextureCube<float> TexCube;
 #endif
 
 SamplerState Samp;
@@ -45,4 +49,7 @@ export void useTextures(float2 UV, float3 UVW) {
   float2 AV = Tex2DArrayVec.Sample(Samp, UVW);
   RWTex2DArray[uint3(0, 0, 0)] = AS;
   RWTex2DArrayVec[uint3(0, 0, 0)] = AV;
+
+  float CS = TexCube.Sample(Samp, UVW);
+  float2 CV = TexCubeVec.Sample(Samp, UVW);
 }

--- a/clang/test/SemaHLSL/Resources/Textures-mips-errors.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-mips-errors.hlsl
@@ -10,18 +10,18 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
 // RUN:   -emit-llvm-only -disable-llvm-passes -finclude-default-header \
 // RUN:   -DTEXTURE=RWTexture2DArray -verify %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
+// RUN:   -emit-llvm-only -disable-llvm-passes -finclude-default-header \
+// RUN:   -DTEXTURE=TextureCube -verify %s
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
 //
 //   TEXTURE            resource type name
 //   INDEX_TYPE         operator[] index type
-//   HAS_MIPS           defined for the texture types that have a `mips` view
+//   HAS_MIPS           defined for types that have a `mips` view
 //
 // A texture with a mips view exposes mips_type / mips_slice_type as private
-// members with protected constructors, so naming them is an access error; a
-// texture without one has no such member or type. The diagnostics use `-re`
-// directives so that the type name does not have to be spelled out per type.
 
 TEXTURE<float4> t;
 

--- a/clang/test/SemaHLSL/Resources/Textures-unsupported-methods-errors.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-unsupported-methods-errors.hlsl
@@ -1,22 +1,32 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
-// RUN:   -finclude-default-header -DTEXTURE=RWTexture2D -DCOORD_TYPE=float2 \
-// RUN:   -DGRAD_TYPE=float2 -DOFFSET_TYPE=int2 -verify %s
+// RUN:   -finclude-default-header -DHAS_TEXEL -DTEXTURE=RWTexture2D \
+// RUN:   -DCOORD_TYPE=float2 -DGRAD_TYPE=float2 -DOFFSET_TYPE=int2 -verify %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
-// RUN:   -finclude-default-header -DTEXTURE=RWTexture2DArray \
+// RUN:   -finclude-default-header -DHAS_TEXEL -DTEXTURE=RWTexture2DArray \
 // RUN:   -DCOORD_TYPE=float3 -DGRAD_TYPE=float2 -DOFFSET_TYPE=int2 -verify %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
+// RUN:   -finclude-default-header -DHAS_SAMPLE -DHAS_GATHER -DHAS_LOD \
+// RUN:   -DLOAD_ARG="int4(0, 0, 0, 0)" -DINDEX_ARG="uint3(0, 0, 0)" \
+// RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 -DOFFSET_TYPE=int3 -verify \
+// RUN:   %s
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
 //
+//   HAS_TEXEL          defined for types that have Load and operator[]
+//   LOAD_ARG           a literal Load location
+//   INDEX_ARG          a literal operator[] index
 //   TEXTURE            resource type name
 //   COORD_TYPE         sample location type (DIM components plus the array
 //                      slice)
 //   GRAD_TYPE          SampleGrad ddx/ddy type, one component per resource
 //                      dimension
 //   OFFSET_TYPE        offset type, one component per resource dimension
+//   HAS_SAMPLE         defined for types that have the Sample* methods
+//   HAS_GATHER         defined for types that have the Gather* methods
+//   HAS_LOD            defined for types that have CalculateLevelOfDetail*
 //
-// Writable (UAV) textures have none of them. The diagnostics use `-re`
-// directives so that the type name does not have to be spelled out per type.
+// Writable (UAV) textures have no sampling, gathering or LOD methods; cube
 
 TEXTURE<float4> Tex;
 SamplerState Samp;
@@ -57,5 +67,12 @@ void main(COORD_TYPE uv) {
   (void)Tex.CalculateLevelOfDetail(Samp, uv);
   // expected-error-re@+1 {{no member named 'CalculateLevelOfDetailUnclamped' in 'hlsl::{{.*}}Texture}}
   (void)Tex.CalculateLevelOfDetailUnclamped(Samp, uv);
+#endif
+
+#ifndef HAS_TEXEL
+  // expected-error-re@+1 {{no member named 'Load' in 'hlsl::{{.*}}Texture}}
+  Tex.Load(LOAD_ARG);
+  // expected-error@+1 {{does not provide a subscript operator}}
+  (void)Tex[INDEX_ARG];
 #endif
 }

--- a/clang/test/SemaHLSL/Resources/Textures-unsupported-methods-errors.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-unsupported-methods-errors.hlsl
@@ -26,7 +26,7 @@
 //   HAS_GATHER         defined for types that have the Gather* methods
 //   HAS_LOD            defined for types that have CalculateLevelOfDetail*
 //
-// Writable (UAV) textures have no sampling, gathering or LOD methods; cube
+// Writable (UAV) textures have no sampling, gathering or LOD methods.
 
 TEXTURE<float4> Tex;
 SamplerState Samp;


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/194740 

This PR implements the TextureCube type in HLSL. 
It registers a new TextureCube type much like the existing Texture2D, but excludes methods that do not apply to cube textures. Codegen has been modified to also support sampling methods that lack an offset parameter but still have a clamp parameter.

Texture tests have also been modified to add support for TextureCube. Some tests simply add a new RUN line for TextureCube, while others needed new check prefixes and macros to accomodate the texels, offsets, etc.

Assisted by: Claude Opus 5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>