### PR TITLE
[mlir][vector] Fix multi-reduction unroll test after #217288

### DIFF
--- a/mlir/test/Dialect/Vector/vector-unroll-options.mlir
+++ b/mlir/test/Dialect/Vector/vector-unroll-options.mlir
@@ -875,16 +875,16 @@ func.func @vector_multi_reduction_rank_mismatch(%v : vector<2x2x4xf32>, %acc: ve
 }
 // CHECK-LABEL: func @vector_multi_reduction_rank_mismatch
 //       CHECK:   %[[V0:.*]] = arith.constant dense<0.000000e+00> : vector<2x2xf32>
-//       CHECK:   %[[E0:.*]] = vector.extract_strided_slice %{{.*}} {offsets = [0, 0, 0], sizes = [1, 2, 2], strides = [1, 1, 1]} : vector<2x2x4xf32> to vector<1x2x2xf32>
-//       CHECK:   %[[ACC0:.*]] = vector.extract_strided_slice %{{.*}} {offsets = [0, 0], sizes = [1, 2], strides = [1, 1]} : vector<2x2xf32> to vector<1x2xf32>
+//       CHECK:   %[[E0:.*]] = vector.extract_strided_slice %{{.*}} offsets = [0, 0, 0], sizes = [1, 2, 2], strides = [1, 1, 1] : vector<2x2x4xf32> to vector<1x2x2xf32>
+//       CHECK:   %[[ACC0:.*]] = vector.extract_strided_slice %{{.*}} offsets = [0, 0], sizes = [1, 2], strides = [1, 1] : vector<2x2xf32> to vector<1x2xf32>
 //       CHECK:   %[[R0:.*]] = vector.multi_reduction <add>, %[[E0]], %[[ACC0]] [2] : vector<1x2x2xf32> to vector<1x2xf32>
-//       CHECK:   %[[E1:.*]] = vector.extract_strided_slice %{{.*}} {offsets = [0, 0, 2], sizes = [1, 2, 2], strides = [1, 1, 1]} : vector<2x2x4xf32> to vector<1x2x2xf32>
+//       CHECK:   %[[E1:.*]] = vector.extract_strided_slice %{{.*}} offsets = [0, 0, 2], sizes = [1, 2, 2], strides = [1, 1, 1] : vector<2x2x4xf32> to vector<1x2x2xf32>
 //       CHECK:   %[[R1:.*]] = vector.multi_reduction <add>, %[[E1]], %[[R0]] [2] : vector<1x2x2xf32> to vector<1x2xf32>
-//       CHECK:   %[[E2:.*]] = vector.extract_strided_slice %{{.*}} {offsets = [1, 0, 0], sizes = [1, 2, 2], strides = [1, 1, 1]} : vector<2x2x4xf32> to vector<1x2x2xf32>
-//       CHECK:   %[[ACC1:.*]] = vector.extract_strided_slice %{{.*}} {offsets = [1, 0], sizes = [1, 2], strides = [1, 1]} : vector<2x2xf32> to vector<1x2xf32>
+//       CHECK:   %[[E2:.*]] = vector.extract_strided_slice %{{.*}} offsets = [1, 0, 0], sizes = [1, 2, 2], strides = [1, 1, 1] : vector<2x2x4xf32> to vector<1x2x2xf32>
+//       CHECK:   %[[ACC1:.*]] = vector.extract_strided_slice %{{.*}} offsets = [1, 0], sizes = [1, 2], strides = [1, 1] : vector<2x2xf32> to vector<1x2xf32>
 //       CHECK:   %[[R2:.*]] = vector.multi_reduction <add>, %[[E2]], %[[ACC1]] [2] : vector<1x2x2xf32> to vector<1x2xf32>
-//       CHECK:   %[[E3:.*]] = vector.extract_strided_slice %{{.*}} {offsets = [1, 0, 2], sizes = [1, 2, 2], strides = [1, 1, 1]} : vector<2x2x4xf32> to vector<1x2x2xf32>
+//       CHECK:   %[[E3:.*]] = vector.extract_strided_slice %{{.*}} offsets = [1, 0, 2], sizes = [1, 2, 2], strides = [1, 1, 1] : vector<2x2x4xf32> to vector<1x2x2xf32>
 //       CHECK:   %[[R3:.*]] = vector.multi_reduction <add>, %[[E3]], %[[R2]] [2] : vector<1x2x2xf32> to vector<1x2xf32>
-//       CHECK:   %[[V1:.*]] = vector.insert_strided_slice %[[R1]], %[[V0]] {offsets = [0, 0], strides = [1, 1]} : vector<1x2xf32> into vector<2x2xf32>
-//       CHECK:   %[[V2:.*]] = vector.insert_strided_slice %[[R3]], %[[V1]] {offsets = [1, 0], strides = [1, 1]} : vector<1x2xf32> into vector<2x2xf32>
+//       CHECK:   %[[V1:.*]] = vector.insert_strided_slice %[[R1]], %[[V0]] offsets = [0, 0], strides = [1, 1] : vector<1x2xf32> into vector<2x2xf32>
+//       CHECK:   %[[V2:.*]] = vector.insert_strided_slice %[[R3]], %[[V1]] offsets = [1, 0], strides = [1, 1] : vector<1x2xf32> into vector<2x2xf32>
 //       CHECK:   return %[[V2]] : vector<2x2xf32>


### PR DESCRIPTION
This fixes a buildbot break. Test-only change.

`mlir/test/Dialect/Vector/vector-unroll-options.mlir` is failing on main:

```
check:878'1  error: no match found in search range
check:878'2  pattern attempts to capture variables: "E0"
```

#217288 switched `vector.extract_strided_slice` and
`vector.insert_strided_slice` to the strict property assembly format, which
prints `offsets`/`sizes`/`strides` without enclosing braces:

```
- vector.extract_strided_slice %v {offsets = [0, 0, 0], sizes = [1, 2, 2], strides = [1, 1, 1]} : ...
+ vector.extract_strided_slice %v offsets = [0, 0, 0], sizes = [1, 2, 2], strides = [1, 1, 1] : ...
```

The test added by #216799 was branched before that change and merged after it,
so its CHECK lines still expect the old spelling. CI on the PR ran against the
older base and passed.

This drops the braces from the 8 affected CHECK lines in
`@vector_multi_reduction_rank_mismatch`, which is the same rewrite #217288
already applied to the other tests in this file.

Verified locally: the test passes with this change and fails without it, with
the same error the bot reported.

Sorry for the breakage.
