### PR TITLE
[libc++] Make lazy three way comparator optimization apply in older standard modes

### DIFF
--- a/libcxx/include/map
+++ b/libcxx/include/map
@@ -680,7 +680,6 @@ struct __make_transparent<_Key, __map_value_compare<_Key, _MapValueT, _Compare> 
   using type _LIBCPP_NODEBUG = __map_value_compare<_Key, _MapValueT, __make_transparent_t<_Key, _Compare> >;
 };
 
-#  if _LIBCPP_STD_VER >= 14
 template <class _MapValueT, class _Key, class _Compare>
 struct __lazy_synth_three_way_comparator<__map_value_compare<_Key, _MapValueT, _Compare>, _MapValueT, _MapValueT> {
   __lazy_synth_three_way_comparator<_Compare, _Key, _Key> __comp_;
@@ -690,7 +689,8 @@ struct __lazy_synth_three_way_comparator<__map_value_compare<_Key, _MapValueT, _
       : __comp_(__comp.key_comp()) {}
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 auto
-  operator()(_LIBCPP_LIFETIMEBOUND const _MapValueT& __lhs, _LIBCPP_LIFETIMEBOUND const _MapValueT& __rhs) const {
+  operator()(_LIBCPP_LIFETIMEBOUND const _MapValueT& __lhs, _LIBCPP_LIFETIMEBOUND const _MapValueT& __rhs) const
+      -> decltype(__comp_(__lhs.first, __rhs.first)) {
     return __comp_(__lhs.first, __rhs.first);
   }
 };
@@ -704,7 +704,8 @@ struct __lazy_synth_three_way_comparator<__map_value_compare<_Key, _MapValueT, _
       : __comp_(__comp.key_comp()) {}
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 auto
-  operator()(_LIBCPP_LIFETIMEBOUND const _TransparentKey& __lhs, _LIBCPP_LIFETIMEBOUND const _MapValueT& __rhs) const {
+  operator()(_LIBCPP_LIFETIMEBOUND const _TransparentKey& __lhs, _LIBCPP_LIFETIMEBOUND const _MapValueT& __rhs) const
+      -> decltype(__comp_(__lhs, __rhs.first)) {
     return __comp_(__lhs, __rhs.first);
   }
 };
@@ -713,16 +714,16 @@ template <class _MapValueT, class _Key, class _TransparentKey, class _Compare>
 struct __lazy_synth_three_way_comparator<__map_value_compare<_Key, _MapValueT, _Compare>, _MapValueT, _TransparentKey> {
   __lazy_synth_three_way_comparator<_Compare, _Key, _TransparentKey> __comp_;
 
-  __lazy_synth_three_way_comparator(
+  _LIBCPP_CONSTEXPR_SINCE_CXX26 __lazy_synth_three_way_comparator(
       _LIBCPP_CTOR_LIFETIMEBOUND const __map_value_compare<_Key, _MapValueT, _Compare>& __comp)
       : __comp_(__comp.key_comp()) {}
 
-  _LIBCPP_HIDE_FROM_ABI auto
-  operator()(_LIBCPP_LIFETIMEBOUND const _MapValueT& __lhs, _LIBCPP_LIFETIMEBOUND const _TransparentKey& __rhs) const {
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 auto
+  operator()(_LIBCPP_LIFETIMEBOUND const _MapValueT& __lhs, _LIBCPP_LIFETIMEBOUND const _TransparentKey& __rhs) const
+      -> decltype(__comp_(__lhs.first, __rhs)) {
     return __comp_(__lhs.first, __rhs);
   }
 };
-#  endif // _LIBCPP_STD_VER >= 14
 
 template <class _Key, class _CP, class _Compare>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void


### PR DESCRIPTION
Drop the #if C++14 by using C++11 style trailing decltype. This also resolves an ABI incompatibility between C++11 and C++14, see #218524.