### PR TITLE
[flang][Semantics] Accept multiple initialization of a COMMON block

### DIFF
--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -391,6 +391,20 @@ print *, is_contiguous(a(::2))                   ! prints T in Flang
   and defined as `ERROR_UNIT` in the intrinsic `ISO_FORTRAN_ENV` module.
 * Objects in blank COMMON may be initialized.
 * Initialization of COMMON blocks outside of BLOCK DATA subprograms.
+* A named COMMON block may be redundantly initialized (via `DATA`
+  statements or declaration initializers) in more than one program
+  unit, with a portability warning, provided that every appearance
+  that initializes the block does so identically: the same members
+  are initialized to the same values everywhere the block appears. A
+  first initialized appearance that leaves some members uninitialized
+  while a later appearance initializes them (or vice versa) is a
+  conflict, not a duplicate, and remains a hard error, as does any
+  appearance that initializes a shared member to a different value.
+  A member that is only indirectly initialized via an object
+  equivalenced with it, rather than directly by a `DATA` statement or
+  declaration initializer, is conservatively treated as a conflict at
+  every appearance, since the equivalenced objects are not compared
+  for agreement.
 * Multiple specifications of the SAVE attribute on the same object
   are allowed, with a warning.
 * Specific intrinsic functions BABS, IIABS, JIABS, KIABS, ZABS, and CDABS.

--- a/flang/include/flang/Semantics/semantics.h
+++ b/flang/include/flang/Semantics/semantics.h
@@ -341,6 +341,15 @@ public:
   // linker).
   void MapCommonBlockAndCheckConflicts(const Symbol &);
 
+  // After DATA statement initializations have been compiled into
+  // symbol initializer values, check any pending conflicts recorded by
+  // MapCommonBlockAndCheckConflicts() that could not be resolved earlier
+  // because the initializer values were not yet known: a duplicate
+  // initialization (identical values) of a COMMON block appearing in more
+  // than one program unit is accepted as an extension, but a conflicting
+  // one is a hard error.
+  void CheckCommonBlockInitializationConflicts();
+
   // Get the list of common blocks appearing in the program. If a common block
   // appears in several subprograms, only one of its appearance is returned in
   // the list alongside the biggest byte size of all its appearances.

--- a/flang/include/flang/Support/Fortran-features.h
+++ b/flang/include/flang/Support/Fortran-features.h
@@ -61,7 +61,8 @@ ENUM_CLASS(LanguageFeature, BackslashEscapes, OldDebugLines,
     MultipleProgramUnitsOnSameLine, AllocatedForAssociated,
     OpenMPThreadprivateEquivalence, RelaxedCLocChecks, CudaPinned,
     OpenAccDefaultNoneScalarsStrict, OpenACCMultipleNamesInRoutine,
-    EnumerationType, CUDAInit, PreferIntrinsicModuleUseAssociation)
+    EnumerationType, CUDAInit, PreferIntrinsicModuleUseAssociation,
+    MultipleCommonBlockInit)
 
 // Portability and suspicious usage warnings
 ENUM_CLASS(UsageWarning, Portability, PointerToUndefinable,

--- a/flang/lib/Semantics/semantics.cpp
+++ b/flang/lib/Semantics/semantics.cpp
@@ -264,6 +264,14 @@ static bool PerformStatementSemantics(
     pass2.CompileDataInitializationsIntoInitializers();
     WarnUnusedOrUndefinedLocal(context, context.globalScope());
   }
+  // Unlike the other checks above, this one is not skipped when an
+  // unrelated fatal error has already occurred elsewhere in the file: it
+  // only reads symbol initializer values (falling back to conservatively
+  // treating an appearance as conflicting, rather than duplicate, if those
+  // are not available because DATA statement compilation above was
+  // skipped), so it can still usefully report on COMMON blocks that are
+  // unaffected by the unrelated error.
+  context.CheckCommonBlockInitializationConflicts();
   return !context.AnyFatalError();
 }
 
@@ -303,18 +311,33 @@ public:
       if (isInitialized) {
         if (info.initialization.has_value() &&
             &**info.initialization != &common) {
-          // Use the location of the initialization in the error message because
-          // common block symbols may have no location if they are blank
-          // commons.
-          const Symbol &previousInit{
-              DEREF(CommonBlockIsInitialized(**info.initialization))};
-          context
-              .Say(isInitialized->name(),
-                  "Multiple initialization of COMMON block /%s/"_err_en_US,
-                  common.name())
-              .Attach(previousInit.name(),
-                  "Previous initialization of COMMON block /%s/"_en_US,
-                  common.name());
+          if (!context.IsEnabled(
+                  common::LanguageFeature::MultipleCommonBlockInit)) {
+            // Use the location of the initialization in the error message
+            // because common block symbols may have no location if they are
+            // blank commons.
+            const Symbol &previousInit{
+                DEREF(CommonBlockIsInitialized(**info.initialization))};
+            context
+                .Say(isInitialized->name(),
+                    "Multiple initialization of COMMON block /%s/"_err_en_US,
+                    common.name())
+                .Attach(previousInit.name(),
+                    "Previous initialization of COMMON block /%s/"_en_US,
+                    (*info.initialization)->name());
+          } else {
+            // Some compilers accept initialization (via DATA statements or
+            // declaration initializers) of the same named COMMON block
+            // appearing in more than one program unit as a nonstandard
+            // extension, so long as the values agree everywhere the block
+            // is initialized -- a duplicate, redundant initialization is
+            // accepted, but a genuine conflict is still a hard error. DATA
+            // statement values are not yet known at this point in
+            // compilation, so the decision is deferred; see
+            // CheckDeferredConflicts(), which runs after DATA statement
+            // compilation.
+            pendingInitConflicts_.emplace_back(common, **info.initialization);
+          }
         } else {
           info.initialization = common;
         }
@@ -346,7 +369,116 @@ public:
     return result;
   }
 
+  // Resolves the multiple-initialization conflicts that were deferred by
+  // MapCommonBlockAndCheckConflicts() because the DATA statement values
+  // were not yet known. Must be called after DATA statement initializations
+  // have been compiled into symbol initializer values.
+  void CheckDeferredConflicts(SemanticsContext &context) const {
+    for (const auto &[common, previous] : pendingInitConflicts_) {
+      // Use the location of the initialization in the error message because
+      // common block symbols may have no location if they are blank
+      // commons.
+      const Symbol &isInitialized{DEREF(CommonBlockIsInitialized(common))};
+      const Symbol &previousInit{DEREF(CommonBlockIsInitialized(previous))};
+      if (AreCommonBlockInitializationsDuplicate(common, previous)) {
+        if (auto *msg{context.Warn(
+                common::LanguageFeature::MultipleCommonBlockInit,
+                isInitialized.name(),
+                "Multiple initialization of COMMON block /%s/ is not standard; this appearance duplicates the previous initialization"_port_en_US,
+                common->name())}) {
+          msg->Attach(previousInit.name(),
+              "Previous initialization of COMMON block /%s/"_en_US,
+              previous->name());
+        }
+      } else {
+        context
+            .Say(isInitialized.name(),
+                "Multiple initialization of COMMON block /%s/"_err_en_US,
+                common->name())
+            .Attach(previousInit.name(),
+                "Previous initialization of COMMON block /%s/"_en_US,
+                previous->name());
+      }
+    }
+  }
+
 private:
+  // True if some other object in an equivalence set containing "member" is
+  // initialized. This covers the case of a COMMON block member that is
+  // itself never directly initialized (no DATA statement, no declaration
+  // initializer) but is nonetheless indirectly initialized because it is
+  // equivalenced with an object that is.
+  static bool IsIndirectlyInitializedViaEquivalence(const Symbol &member) {
+    if (const Symbol *common{FindCommonBlockContaining(member)}) {
+      for (const Fortran::semantics::EquivalenceSet &set :
+          common->owner().equivalenceSets()) {
+        bool containsMember{false};
+        for (const Fortran::semantics::EquivalenceObject &obj : set) {
+          if (&obj.symbol == &member) {
+            containsMember = true;
+            break;
+          }
+        }
+        if (containsMember) {
+          for (const Fortran::semantics::EquivalenceObject &obj : set) {
+            if (&obj.symbol != &member && IsInitialized(obj.symbol)) {
+              return true;
+            }
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  // True if every member position that is initialized in either common
+  // block appearance is also initialized, with an identical value, in the
+  // other appearance -- i.e., the two appearances are a duplicate,
+  // redundant initialization of the block rather than a genuine conflict.
+  // Positions initialized in neither appearance are not compared. Members
+  // whose initial value cannot be directly compared (e.g., procedure
+  // pointers, indirect initialization via an equivalenced object, or
+  // default component initialization of a derived type without an
+  // explicit initializer) are conservatively treated as non-duplicate.
+  static bool AreCommonBlockInitializationsDuplicate(
+      const Symbol &common1, const Symbol &common2) {
+    const auto &objects1{
+        common1.get<Fortran::semantics::CommonBlockDetails>().objects()};
+    const auto &objects2{
+        common2.get<Fortran::semantics::CommonBlockDetails>().objects()};
+    if (objects1.size() != objects2.size()) {
+      return false;
+    }
+    auto iter2{objects2.begin()};
+    for (auto iter1{objects1.begin()}; iter1 != objects1.end();
+        ++iter1, ++iter2) {
+      const Symbol &member1{**iter1};
+      const Symbol &member2{**iter2};
+      bool initialized1{IsInitialized(member1) ||
+          IsIndirectlyInitializedViaEquivalence(member1)};
+      bool initialized2{IsInitialized(member2) ||
+          IsIndirectlyInitializedViaEquivalence(member2)};
+      if (initialized1 != initialized2) {
+        return false;
+      }
+      if (initialized1) {
+        if (IsIndirectlyInitializedViaEquivalence(member1) ||
+            IsIndirectlyInitializedViaEquivalence(member2)) {
+          return false;
+        }
+        const auto *object1{member1.detailsIf<ObjectEntityDetails>()};
+        const auto *object2{member2.detailsIf<ObjectEntityDetails>()};
+        if (!object1 || !object2 || !object1->init() || !object2->init()) {
+          return false;
+        }
+        if (!(*object1->init() == *object2->init())) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
   /// Return the symbol of an initialized member if a COMMON block
   /// is initalized. Otherwise, return nullptr.
   static Symbol *CommonBlockIsInitialized(const Symbol &common) {
@@ -375,6 +507,7 @@ private:
   }
 
   std::map<std::string, CommonBlockInfo> commonBlocks_;
+  std::vector<std::pair<SymbolRef, SymbolRef>> pendingInitConflicts_;
 };
 
 SemanticsContext::SemanticsContext(
@@ -834,6 +967,12 @@ CommonBlockList SemanticsContext::GetCommonBlocks() const {
     return commonBlockMap_->GetCommonBlocks();
   }
   return {};
+}
+
+void SemanticsContext::CheckCommonBlockInitializationConflicts() {
+  if (commonBlockMap_) {
+    commonBlockMap_->CheckDeferredConflicts(*this);
+  }
 }
 
 void SemanticsContext::NoteDefinedSymbol(const Symbol &symbol) {

--- a/flang/lib/Support/Fortran-features.cpp
+++ b/flang/lib/Support/Fortran-features.cpp
@@ -227,6 +227,7 @@ LanguageFeatureControl::LanguageFeatureControl() {
   warnLanguage_.set(LanguageFeature::OpenMPThreadprivateEquivalence);
   warnLanguage_.set(LanguageFeature::OpenAccDefaultNoneScalarsStrict);
   warnLanguage_.set(LanguageFeature::OpenACCMultipleNamesInRoutine);
+  warnLanguage_.set(LanguageFeature::MultipleCommonBlockInit);
 }
 
 std::optional<LanguageControlFlag> LanguageFeatureControl::FindWarning(

--- a/flang/test/Lower/common-block-multiple-init.f90
+++ b/flang/test/Lower/common-block-multiple-init.f90
@@ -1,0 +1,28 @@
+! RUN: bbc %s -o - | FileCheck %s
+
+! Test that a duplicate (identical-valued) initialization of a named
+! COMMON block across program units still lowers correctly, embedding the
+! (shared) value once. Only duplicate initializations reach lowering: a
+! disjoint or otherwise conflicting initialization across appearances is
+! rejected earlier, in semantics -- see
+! flang/test/Semantics/common-block-multiple-init.f90 and
+! flang/docs/Extensions.md.
+
+! CHECK-LABEL: fir.global @blk_ {alignment = 4 : i64} : tuple<i32, !fir.array<4xi8>> {
+! CHECK:  %[[val:.*]] = arith.constant 111 : i32
+! CHECK:  %[[undef:.*]] = fir.zero_bits tuple<i32, !fir.array<4xi8>>
+! CHECK:  %[[init:.*]] = fir.insert_value %[[undef]], %[[val]], [0 : index] : (tuple<i32, !fir.array<4xi8>>, i32) -> tuple<i32, !fir.array<4xi8>>
+! CHECK-NOT: fir.insert_value
+! CHECK:  fir.has_value %[[init]] : tuple<i32, !fir.array<4xi8>>
+
+subroutine first
+  integer :: i, j
+  common /blk/ i, j
+  data i /111/
+end subroutine
+
+subroutine second
+  integer :: i, j
+  common /blk/ i, j
+  data i /111/
+end subroutine

--- a/flang/test/Semantics/common-block-multiple-init-bindc.f90
+++ b/flang/test/Semantics/common-block-multiple-init-bindc.f90
@@ -1,0 +1,29 @@
+! RUN: not %flang -fsyntax-only 2>&1 %s | FileCheck %s
+
+! Test that when two differently-named Fortran COMMON blocks are merged by
+! a shared BIND(C) name, the "Previous initialization" attachment names the
+! block where the previous initialization actually appeared, not the
+! current appearance's own (different) Fortran name.
+!
+! This file also has an unrelated BIND(C) name-clash error (the two
+! merged blocks having a shared BIND(C) name is itself illegal), which
+! prevents DATA statement compilation from running, so the
+! multiple-initialization check below conservatively reports a hard error
+! here rather than the usual portability warning for a duplicate -- see
+! common-block-multiple-init.f90 for that.
+
+subroutine s1
+  integer :: xa
+  common /a/ xa
+  bind(c, name="cblk") :: /a/
+  data xa /1/
+end subroutine
+
+subroutine s2
+  integer :: xb
+  common /b/ xb
+  bind(c, name="cblk") :: /b/
+  ! CHECK: error: Multiple initialization of COMMON block /b/
+  ! CHECK: Previous initialization of COMMON block /a/
+  data xb /1/
+end subroutine

--- a/flang/test/Semantics/common-block-multiple-init-flags.f90
+++ b/flang/test/Semantics/common-block-multiple-init-flags.f90
@@ -1,0 +1,26 @@
+! RUN: %flang_fc1 -fsyntax-only %s 2>&1 | FileCheck --check-prefix=DEFAULT %s
+! RUN: %flang_fc1 -fsyntax-only -Wno-multiple-common-block-init %s 2>&1 | FileCheck --check-prefix=SILENT --allow-empty %s
+! RUN: %flang_fc1 -fsyntax-only -w %s 2>&1 | FileCheck --check-prefix=SILENT --allow-empty %s
+! RUN: not %flang_fc1 -fsyntax-only -Werror %s 2>&1 | FileCheck --check-prefix=WERROR %s
+
+! Test the -Wmultiple-common-block-init spelling: silencing via
+! -Wno-multiple-common-block-init and via blanket -w, and promotion to a
+! hard error via blanket -Werror (flang does not support the per-feature
+! -Werror=<name> spelling, so blanket -Werror is the strictness mechanism
+! for this diagnostic).
+
+subroutine s1
+  integer :: i
+  common /cw/ i
+  data i /1/
+end subroutine
+subroutine s2
+  integer :: i
+  common /cw/ i
+  data i /1/
+end subroutine
+
+! DEFAULT: portability: Multiple initialization of COMMON block /cw/ is not standard; this appearance duplicates the previous initialization [-Wmultiple-common-block-init]
+! SILENT-NOT: Multiple initialization
+! WERROR: error: Semantic errors in {{.*}}common-block-multiple-init-flags.f90
+! WERROR: portability: Multiple initialization of COMMON block /cw/ is not standard; this appearance duplicates the previous initialization [-Wmultiple-common-block-init]

--- a/flang/test/Semantics/common-block-multiple-init.f90
+++ b/flang/test/Semantics/common-block-multiple-init.f90
@@ -1,0 +1,217 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1 -Werror
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror
+
+! A *duplicate* (identical-valued) initialization of a named COMMON block
+! across program units is accepted as a nonstandard extension with a
+! portability warning; a genuinely *conflicting* one is still a hard
+! error. This covers the various shapes both checks apply to, and pins
+! that -pedantic does not change the accepted case's severity (unlike
+! most other checks gated by -pedantic, this one is not tied to strict
+! standard conformance).
+
+! Control: two DATA statements in the same program unit, each initializing
+! a distinct member of the same COMMON block, is a single (first)
+! appearance -- not "multiple initialization".
+subroutine same_unit_control
+  integer :: p, q
+  common /cs/ p, q
+  data p /1/
+  data q /2/
+end subroutine
+
+!-------------------------------------------------------------------------
+! Accepted: duplicate (identical-valued) initialization.
+!-------------------------------------------------------------------------
+
+! Baseline: DATA-statement initialization of the same block, with the same
+! value, in two program units.
+subroutine data_dup_first
+  integer :: i
+  common /cd/ i
+  data i /111/
+end subroutine
+subroutine data_dup_second
+  !PORTABILITY: Multiple initialization of COMMON block /cd/ is not standard; this appearance duplicates the previous initialization [-Wmultiple-common-block-init]
+  integer :: i
+  common /cd/ i
+  data i /111/
+end subroutine
+
+! The check also applies to declaration initializers, not just DATA
+! statements.
+subroutine decl_dup_first
+  integer :: i = 111
+  common /ce/ i
+end subroutine
+subroutine decl_dup_second
+  !PORTABILITY: Multiple initialization of COMMON block /ce/ is not standard; this appearance duplicates the previous initialization [-Wmultiple-common-block-init]
+  integer :: i = 111
+  common /ce/ i
+end subroutine
+
+! Mixed: one appearance uses a declaration initializer, the other a DATA
+! statement, both with the same value.
+subroutine mixed_dup_decl
+  integer :: i = 111
+  common /cf/ i
+end subroutine
+subroutine mixed_dup_data
+  !PORTABILITY: Multiple initialization of COMMON block /cf/ is not standard; this appearance duplicates the previous initialization [-Wmultiple-common-block-init]
+  integer :: i
+  common /cf/ i
+  data i /111/
+end subroutine
+
+! Three duplicate appearances: the second and third each warn, both
+! against the first.
+subroutine dup_three_a
+  integer :: i
+  common /cg/ i
+  data i /1/
+end subroutine
+subroutine dup_three_b
+  !PORTABILITY: Multiple initialization of COMMON block /cg/ is not standard; this appearance duplicates the previous initialization [-Wmultiple-common-block-init]
+  integer :: i
+  common /cg/ i
+  data i /1/
+end subroutine
+subroutine dup_three_c
+  !PORTABILITY: Multiple initialization of COMMON block /cg/ is not standard; this appearance duplicates the previous initialization [-Wmultiple-common-block-init]
+  integer :: i
+  common /cg/ i
+  data i /1/
+end subroutine
+
+! An uninitialized first appearance is not "the first appearance" for this
+! check -- only the first *initialized* appearance matters, and later
+! initialized appearances are compared against it, not against the
+! uninitialized one.
+subroutine dup_uninit_first
+  integer :: i
+  common /ch/ i
+end subroutine
+subroutine dup_uninit_second
+  integer :: i
+  common /ch/ i
+  data i /1/
+end subroutine
+subroutine dup_uninit_third
+  !PORTABILITY: Multiple initialization of COMMON block /ch/ is not standard; this appearance duplicates the previous initialization [-Wmultiple-common-block-init]
+  integer :: i
+  common /ch/ i
+  data i /1/
+end subroutine
+
+! An array member initialized to the same constant in both appearances.
+subroutine array_dup_first
+  integer :: a(3)
+  common /ci/ a
+  data a /1, 2, 3/
+end subroutine
+subroutine array_dup_second
+  !PORTABILITY: Multiple initialization of COMMON block /ci/ is not standard; this appearance duplicates the previous initialization [-Wmultiple-common-block-init]
+  integer :: a(3)
+  common /ci/ a
+  data a /1, 2, 3/
+end subroutine
+
+!-------------------------------------------------------------------------
+! Rejected: genuinely conflicting initialization.
+!-------------------------------------------------------------------------
+
+! DATA-statement initialization of the same member with different values.
+subroutine data_conflict_first
+  integer :: i
+  common /da/ i
+  data i /111/
+end subroutine
+subroutine data_conflict_second
+  !ERROR: Multiple initialization of COMMON block /da/
+  integer :: i
+  common /da/ i
+  data i /222/
+end subroutine
+
+! Declaration initializers with different values.
+subroutine decl_conflict_first
+  integer :: i = 111
+  common /db/ i
+end subroutine
+subroutine decl_conflict_second
+  !ERROR: Multiple initialization of COMMON block /db/
+  integer :: i = 222
+  common /db/ i
+end subroutine
+
+! Disjoint members: each appearance initializes a *different* member of the
+! same block. This is not a duplicate initialization (neither appearance
+! repeats the other's value), so it is rejected rather than accepted, even
+! though the two appearances do not directly disagree on any one member's
+! value.
+subroutine disjoint_first
+  integer :: i, j
+  common /dc/ i, j
+  data i /111/
+end subroutine
+subroutine disjoint_second
+  !ERROR: Multiple initialization of COMMON block /dc/
+  integer :: i, j
+  common /dc/ i, j
+  data j /222/
+end subroutine
+
+! Three appearances where only one conflicts: the third disagrees with the
+! (duplicate) first and second, and is rejected; the second still matches
+! the first and is accepted.
+subroutine three_mixed_a
+  integer :: i
+  common /dd/ i
+  data i /1/
+end subroutine
+subroutine three_mixed_b
+  !PORTABILITY: Multiple initialization of COMMON block /dd/ is not standard; this appearance duplicates the previous initialization [-Wmultiple-common-block-init]
+  integer :: i
+  common /dd/ i
+  data i /1/
+end subroutine
+subroutine three_mixed_c
+  !ERROR: Multiple initialization of COMMON block /dd/
+  integer :: i
+  common /dd/ i
+  data i /2/
+end subroutine
+
+! A COMMON block member that is never itself directly initialized (no DATA
+! statement, no declaration initializer) but is indirectly initialized via
+! an equivalenced object is conservatively rejected as a conflict, rather
+! than being compared for a duplicate value: the equivalenced objects may
+! differ in name, offset, or type across appearances, so no attempt is
+! made to determine whether they truly agree.
+subroutine equiv_first
+  integer :: i, e
+  common /de/ i
+  equivalence (i, e)
+  data e /111/
+end subroutine
+subroutine equiv_second
+  !ERROR: Multiple initialization of COMMON block /de/
+  integer :: i, e
+  common /de/ i
+  equivalence (i, e)
+  data e /111/
+end subroutine
+
+! +0.0 and -0.0 compare equal under Fortran's == operator, but they are not
+! the same value (they have different representations), so this is a
+! conflict, not a duplicate.
+subroutine zero_first
+  real :: x
+  common /df/ x
+  data x /0.0/
+end subroutine
+subroutine zero_second
+  !ERROR: Multiple initialization of COMMON block /df/
+  real :: x
+  common /df/ x
+  data x /-0.0/
+end subroutine


### PR DESCRIPTION
…as a GNU extension

Some compilers accept a named COMMON block variable being redundantly initialized (via DATA statements or declaration initializers) in more than one program unit, as a nonstandard extension, so long as every appearance that initializes the block does so identically: the same members are initialized to the same values everywhere the block appears. flang currently rejects this unconditionally as a hard error, whether or not the appearances agree.

Downgrade this to a portability warning enabled by default (matching the behavior of the other compilers) when the initializations are duplicates. A conflicting initialization -- a different value for a shared member, or a member initialized in one appearance but not another -- remains a hard error, as it has no defined, portable behavior (compilers that accept it disagree on which appearance wins). A member that is only indirectly initialized via an equivalenced object (rather than directly, by a DATA statement or declaration initializer) is conservatively treated as a conflict rather than compared for a duplicate value, since the equivalenced objects may differ in name, offset, or type across appearances.

Since DATA statement values are not yet known at the point where COMMON block conflicts are otherwise detected (during offset computation, before DATA statements are compiled into initializer values), the duplicate-vs-conflict decision for such conflicts is deferred until after DATA statement compilation; this deferred check runs even when an unrelated fatal error has occurred elsewhere in the file, since it can still usefully diagnose COMMON blocks unaffected by that error.

Update the existing common-blocks.f90 test for the new diagnostic, add semantics tests covering the shapes both the accepted (duplicate) and rejected (conflicting) cases apply to -- DATA statements, declaration initializers, three or more appearances, an uninitialized first appearance, disjoint members, indirect initialization via equivalence -- and the -Wmultiple-common-block-init spelling (silencing and -Werror promotion), a test pinning that a shared BIND(C) name correctly attributes the previous initialization to the right block, a Lower test pinning that a duplicate initialization still lowers correctly, and a flang/docs/Extensions.md entry documenting the behavior.

Assisted-by: AI