### PR TITLE
[Clang] Implement -fkeep-inline-functions

### DIFF
--- a/clang/docs/UsersManual.md
+++ b/clang/docs/UsersManual.md
@@ -2852,7 +2852,8 @@ or implicitly via constexpr or an in-class member-function definition),
 including template specializations whose definitions are generated in this
 translation unit. Inline functions with the gnu_inline attribute and
 specializations subject to C++ explicit instantiation declarations
-(extern template) are not kept.
+(extern template) are not kept. C++20 immediate functions (e.g., consteval)
+are never emitted.
 
 With C++20 named modules, the option applies to inline functions defined
 in the current module unit, including functions that are not exported.

--- a/clang/docs/UsersManual.md
+++ b/clang/docs/UsersManual.md
@@ -2834,6 +2834,36 @@ $ cd $P && clang foo/name_conflict.o && bar/name_conflict.o
 ```
 :::
 
+:::{option} -f[no-]keep-inline-functions
+
+Force inline functions to be emitted into the object file, even when they
+have been inlined into all callers or are otherwise unused.
+
+Except as noted below, the option keeps definitions of inline functions that
+are available in the current translation unit. LTO observes the kept
+definitions as being marked as used.
+
+In C, functions declared with inline are kept, except where they are
+C99 inline definitions or GNU C89/C90 extern inline functions. This
+includes __attribute__((gnu_inline)) extern inline functions.
+
+In C++, the option applies to functions declared inline (explicitly
+or implicitly via constexpr or an in-class member-function definition),
+including template specializations whose definitions are generated in this
+translation unit. Inline functions with the gnu_inline attribute and
+specializations subject to C++ explicit instantiation declarations
+(extern template) are not kept.
+
+With C++20 named modules, the option applies to inline functions defined
+in the current module unit, including functions that are not exported.
+Imported definitions are affected when their definition is available in the
+current translation unit.
+
+-fno-keep-inline-functions (the default) restores normal inlining
+behaviour.
+
+:::
+
 :::{option} -f[no-]basic-block-address-map:
 Emits a `SHT_LLVM_BB_ADDR_MAP` section which includes address offsets for each
 basic block in the program, relative to the parent function address.

--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -471,6 +471,9 @@ CODEGENOPT(KeepStaticConsts, 1, 0, Benign)
 /// including global, static and thread local variables.
 CODEGENOPT(KeepPersistentStorageVariables, 1, 0, Benign)
 
+/// Whether to emit inline functions into the object file, even if inlined into all callers.
+CODEGENOPT(KeepInlineFunctions, 1, 0, Benign)
+
 /// Whether to follow the AAPCS enforcing at least one read before storing to a volatile bitfield
 CODEGENOPT(ForceAAPCSBitfieldLoad, 1, 0, Benign)
 

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -2561,6 +2561,12 @@ defm keep_persistent_storage_variables : BoolFOption<"keep-persistent-storage-va
   NegFlag<SetFalse, [], [ClangOption], "Disable">,
   BothFlags<[], [],
           " keeping all variables that have a persistent storage duration, including global, static and thread-local variables, to guarantee that they can be directly addressed">>;
+defm keep_inline_functions : BoolFOption<"keep-inline-functions",
+  CodeGenOpts<"KeepInlineFunctions">, DefaultFalse,
+  PosFlag<SetTrue, [], [ClangOption, CC1Option], "Keep">,
+  NegFlag<SetFalse, [], [ClangOption], "Don't keep">,
+  BothFlags<[], [],
+          " inline functions whose definition is owned by this translation unit, even if they are inlined into all callers.">>;
 defm fixed_point : BoolFOption<"fixed-point",
   LangOpts<"FixedPoint">, DefaultFalse,
   PosFlag<SetTrue, [], [ClangOption, CC1Option], "Enable">,
@@ -7607,7 +7613,6 @@ multiclass BooleanFFlag<string name> {
   def fno_#NAME : Flag<["-"], "fno-"#name>;
 }
 
-defm : BooleanFFlag<"keep-inline-functions">, Group<clang_ignored_gcc_optimization_f_Group>;
 
 def fprofile_dir : Joined<["-"], "fprofile-dir=">, Group<f_Group>;
 

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3327,6 +3327,30 @@ void CodeGenModule::addSYCLModuleIdAttr(llvm::Function *Fn) {
   Fn->addFnAttr("sycl-module-id", getModule().getModuleIdentifier());
 }
 
+// Construct a GlobalDecl suitable for linkage queries.
+// GlobalDecl(FunctionDecl *) asserts for constructors and destructors because
+// they require an explicit ctor/dtor variant. Use the complete variant since
+// the variant does not affect linkage.
+static GlobalDecl getGlobalDeclForLinkage(const FunctionDecl *FD) {
+  if (const auto *CD = dyn_cast<CXXConstructorDecl>(FD))
+    return GlobalDecl(CD, Ctor_Complete);
+  if (const auto *DD = dyn_cast<CXXDestructorDecl>(FD))
+    return GlobalDecl(DD, Dtor_Complete);
+  return GlobalDecl(FD);
+}
+
+// Returns true if FD should be kept in the object file when
+// -fkeep-inline-functions is enabled.
+static bool shouldKeepInlineFunction(llvm::GlobalValue::LinkageTypes Linkage,
+                                     const FunctionDecl *FD) {
+  // Keep inline function definitions that are available in the current
+  // translation unit. Exclude available_externally definitions, which are
+  // inlining hints whose authoritative definition is expected to be emitted by
+  // another translation unit.
+  return FD->isInlined() &&
+         Linkage != llvm::GlobalValue::AvailableExternallyLinkage;
+}
+
 void CodeGenModule::SetCommonAttributes(GlobalDecl GD, llvm::GlobalValue *GV) {
   const Decl *D = GD.getDecl();
   if (isa_and_nonnull<NamedDecl>(D))
@@ -3345,6 +3369,11 @@ void CodeGenModule::SetCommonAttributes(GlobalDecl GD, llvm::GlobalValue *GV) {
        (CodeGenOpts.KeepStaticConsts && VD->getStorageDuration() == SD_Static &&
         VD->getType().isConstQualified())))
     addUsedOrCompilerUsedGlobal(GV);
+
+  if (CodeGenOpts.KeepInlineFunctions)
+    if (const auto *FD = dyn_cast_if_present<FunctionDecl>(D))
+      if (shouldKeepInlineFunction(getFunctionLinkage(GD), FD))
+        addUsedOrCompilerUsedGlobal(GV);
 }
 
 /// Get the feature delta from the default feature map for the given target CPU.
@@ -4441,6 +4470,12 @@ bool CodeGenModule::MustBeEmitted(const ValueDecl *Global) {
        (CodeGenOpts.KeepStaticConsts && VD->getStorageDuration() == SD_Static &&
         VD->getType().isConstQualified())))
     return true;
+
+  if (CodeGenOpts.KeepInlineFunctions)
+    if (const auto *FD = dyn_cast<FunctionDecl>(Global))
+      if (shouldKeepInlineFunction(
+              getFunctionLinkage(getGlobalDeclForLinkage(FD)), FD))
+        return true;
 
   return getContext().DeclMustBeEmitted(Global);
 }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8540,6 +8540,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                     options::OPT_fno_keep_static_consts);
   Args.addOptInFlag(CmdArgs, options::OPT_fkeep_persistent_storage_variables,
                     options::OPT_fno_keep_persistent_storage_variables);
+  Args.addOptInFlag(CmdArgs, options::OPT_fkeep_inline_functions,
+                    options::OPT_fno_keep_inline_functions);
   Args.addOptInFlag(CmdArgs, options::OPT_fcomplete_member_pointers,
                     options::OPT_fno_complete_member_pointers);
   if (Arg *A = Args.getLastArg(options::OPT_cxx_static_destructors_EQ))

--- a/clang/test/CodeGen/keep-inline-functions.c
+++ b/clang/test/CodeGen/keep-inline-functions.c
@@ -9,8 +9,8 @@
 // Retained:
 //   f1  static inline
 //   f2  plain inline under -fgnu89-inline
-//   f5  C99 external definition with external linkage
-//       retained under both C99 and -fgnu89-inline
+//   f5  C99 external definition with external linkage;
+//       considered plain inline under -fgnu89-inline
 //
 // Not retained:
 //   f2  C99 inline definition

--- a/clang/test/CodeGen/keep-inline-functions.c
+++ b/clang/test/CodeGen/keep-inline-functions.c
@@ -1,0 +1,42 @@
+// -fkeep-inline-functions has an effect without optimization, although it is
+// primarily useful with optimization enabled.
+
+// RUN: %clang_cc1 -O2 -fkeep-inline-functions -emit-llvm %s -o - -triple x86_64-unknown-linux-gnu | FileCheck %s
+// RUN: %clang_cc1 -O0 -fkeep-inline-functions -emit-llvm %s -o - -triple x86_64-unknown-linux-gnu | FileCheck %s
+// RUN: %clang_cc1 -O2 -fkeep-inline-functions -emit-llvm %s -o - -triple powerpc64-ibm-aix-xcoff | FileCheck %s
+// RUN: %clang_cc1 -O2 -fkeep-inline-functions -fgnu89-inline -emit-llvm %s -o - -triple powerpc64-ibm-aix-xcoff | FileCheck %s --check-prefix=CHECK-GNU89
+
+// Retained:
+//   f1  static inline
+//   f2  plain inline under -fgnu89-inline
+//   f5  C99 external definition with external linkage
+//       retained under both C99 and -fgnu89-inline
+//
+// Not retained:
+//   f2  C99 inline definition
+//   f3  non-inline
+//   f4  GNU C89/C90 extern inline
+
+static inline int f1(int x) { return x + 1; }
+
+inline int f2(int x) { return x + 2; }
+
+int f3(int x) { return x + 3; }
+
+__attribute__((gnu_inline)) extern inline int f4(int x) { return x + 4; }
+
+extern inline int f5(int x);
+inline int f5(int x) { return x + 5; }
+
+// f1 and f5 are unused, so their definitions are emitted due to -fkeep-inline-functions.
+
+// CHECK: @llvm{{(\.compiler)?}}.used = appending global [2 x ptr] [ptr @f1, ptr @f5]
+// CHECK: define internal {{.*}}@f1
+// CHECK: define {{.*}}@f5
+
+int use(void) { return  f2(0) + f3(0) + f4(0); }
+
+// CHECK-GNU89: @llvm{{(\.compiler)?}}.used = appending global [3 x ptr] [ptr @f1, ptr @f2, ptr @f5]
+// CHECK-GNU89: define {{.*}}@f1
+// CHECK-GNU89: define {{.*}}@f2
+// CHECK-GNU89: define {{.*}}@f5

--- a/clang/test/CodeGen/keep-inline-functions.cpp
+++ b/clang/test/CodeGen/keep-inline-functions.cpp
@@ -1,0 +1,78 @@
+// -fkeep-inline-functions has an effect without optimization, although it is
+// primarily useful with optimization enabled.
+
+// RUN: %clang_cc1 -O2 -fkeep-inline-functions -emit-llvm %s -o - -triple x86_64-unknown-linux-gnu | FileCheck %s
+// RUN: %clang_cc1 -O0 -fkeep-inline-functions -emit-llvm %s -o - -triple x86_64-unknown-linux-gnu | FileCheck %s
+// RUN: %clang_cc1 -O2 -fkeep-inline-functions -emit-llvm %s -o - -triple powerpc64-ibm-aix-xcoff | FileCheck %s
+// RUN: %clang_cc1 -O0 -fkeep-inline-functions -emit-llvm %s -o - -triple powerpc64-ibm-aix-xcoff | FileCheck %s
+
+// -fkeep-inline-functions retains inline function definitions available in
+// this translation unit. Definitions emitted with available_externally
+// linkage are excluded.
+
+// Retained:
+//   f1  explicit inline and referenced
+//   f2  static inline
+//   f3  constexpr (implicit inline)
+//   f4  in-class member definition (implicit inline)
+//   f7  explicit inline and unreferenced
+//   f8  explicitly instantiated inline template
+//   TestCtorDtor implicitly inline constructor/destructor variants.
+
+//   Also exercises the GlobalDecl construction path in MustBeEmitted() for
+//   constructors/destructors. Without the special handling, debug builds hit
+//   the GlobalDecl(FunctionDecl*) assertion.
+
+// Not retained:
+//   f5  non-inline
+//   f6  GNU extern inline
+//   f9  extern template specialization
+
+inline int f1(int x) { return x + 1; }
+
+static inline int f2(int x) { return x + 2; }
+
+constexpr int f3(int x) { return x + 3; }
+
+struct S {
+  int f4() { return 4; }
+};
+
+int f5(int x) { return x + 5; }
+
+__attribute__((gnu_inline)) extern inline int f6(int x) { return x + 6; }
+
+inline int f7(int x) { return x + 7; }
+
+template <typename T> inline T f8(T x) { return x + 8; }
+template int f8<int>(int);
+
+template <typename T>
+struct A {
+  static int f9() { return 9; }
+};
+extern template int A<int>::f9();
+
+// Implicitly inline ctor and dtor intentionally unreferenced so
+// MustBeEmitted() is the sole mechanism that forces their emission.
+struct TestCtorDtor {
+  TestCtorDtor() {}
+  ~TestCtorDtor() {}
+};
+
+int use(S s) {
+  return f1(0) + f5(0) + f6(0) + A<int>::f9();
+}
+// CHECK: @llvm{{(\.compiler)?}}.used = appending global [10 x ptr]
+
+// CHECK-DAG: define {{.*}}@_Z2f1i
+// CHECK-DAG: define internal {{.*}}@_ZL2f2i
+// CHECK-DAG: define {{.*}}@_Z2f3i
+// CHECK-DAG: define {{.*}}@_ZN1S2f4Ev
+// CHECK-DAG: define {{.*}}@_Z2f7i
+// CHECK-DAG: define {{.*}}@_Z2f8IiET_S0_
+// CHECK-DAG: define {{.*}}@_ZN12TestCtorDtorC1Ev
+// CHECK-DAG: define {{.*}}@_ZN12TestCtorDtorD1Ev
+// CHECK-DAG: define {{.*}}@_ZN12TestCtorDtorC2Ev
+// CHECK-DAG: define {{.*}}@_ZN12TestCtorDtorD2Ev
+

--- a/clang/test/CodeGen/keep-inline-functions.cpp
+++ b/clang/test/CodeGen/keep-inline-functions.cpp
@@ -2,9 +2,10 @@
 // primarily useful with optimization enabled.
 
 // RUN: %clang_cc1 -O2 -fkeep-inline-functions -emit-llvm %s -o - -triple x86_64-unknown-linux-gnu | FileCheck %s
-// RUN: %clang_cc1 -O0 -fkeep-inline-functions -emit-llvm %s -o - -triple x86_64-unknown-linux-gnu | FileCheck %s
+// RUN: %clang_cc1 -O2 -fkeep-inline-functions -emit-llvm %s -o - -triple x86_64-pc-windows-msvc | FileCheck %s --check-prefix=MSVC
 // RUN: %clang_cc1 -O2 -fkeep-inline-functions -emit-llvm %s -o - -triple powerpc64-ibm-aix-xcoff | FileCheck %s
 // RUN: %clang_cc1 -O0 -fkeep-inline-functions -emit-llvm %s -o - -triple powerpc64-ibm-aix-xcoff | FileCheck %s
+// RUN: %clang_cc1 -O0 -mconstructor-aliases -fkeep-inline-functions -emit-llvm %s -o - -triple powerpc64-ibm-aix-xcoff | FileCheck %s --check-prefix=CONSTRUCTOR-ALIASES
 
 // -fkeep-inline-functions retains inline function definitions available in
 // this translation unit. Definitions emitted with available_externally
@@ -40,7 +41,7 @@ struct S {
 
 int f5(int x) { return x + 5; }
 
-__attribute__((gnu_inline)) extern inline int f6(int x) { return x + 6; }
+__attribute__((gnu_inline)) inline int f6(int x) { return x + 6; }
 
 inline int f7(int x) { return x + 7; }
 
@@ -76,3 +77,29 @@ int use(S s) {
 // CHECK-DAG: define {{.*}}@_ZN12TestCtorDtorC2Ev
 // CHECK-DAG: define {{.*}}@_ZN12TestCtorDtorD2Ev
 
+// FIXME: -mconstructor-aliases is enabled by default by the driver for this
+// target, but is not enabled by default for -cc1. With -mconstructor-aliases,
+// the C1/D1 constructor and destructor variants are not emitted as separate
+// definitions.
+
+// CONSTRUCTOR-ALIASES: @llvm{{(\.compiler)?}}.used = appending global [8 x ptr]
+
+// CONSTRUCTOR-ALIASES-DAG: define {{.*}}@_Z2f1i
+// CONSTRUCTOR-ALIASES-DAG: define internal {{.*}}@_ZL2f2i
+// CONSTRUCTOR-ALIASES-DAG: define {{.*}}@_Z2f3i
+// CONSTRUCTOR-ALIASES-DAG: define {{.*}}@_ZN1S2f4Ev
+// CONSTRUCTOR-ALIASES-DAG: define {{.*}}@_Z2f7i
+// CONSTRUCTOR-ALIASES-DAG: define {{.*}}@_Z2f8IiET_S0_
+// CONSTRUCTOR-ALIASES-DAG: define {{.*}}@_ZN12TestCtorDtorC2Ev
+// CONSTRUCTOR-ALIASES-DAG: define {{.*}}@_ZN12TestCtorDtorD2Ev
+
+// MSVC: @llvm{{(\.compiler)?}}.used = appending global [8 x ptr]
+
+// MSVC-DAG: define {{.*}}@"?f1@@YAHH@Z"
+// MSVC-DAG: define internal {{.*}}@"?f2@@YAHH@Z"
+// MSVC-DAG: define {{.*}}@"?f3@@YAHH@Z"
+// MSVC-DAG: define {{.*}}@"?f4@S@@QEAAHXZ"
+// MSVC-DAG: define {{.*}}@"?f7@@YAHH@Z"
+// MSVC-DAG: define {{.*}}@"??$f8@H@@YAHH@Z"
+// MSVC-DAG: define {{.*}}@"??0TestCtorDtor@@QEAA@XZ"
+// MSVC-DAG: define {{.*}}@"??1TestCtorDtor@@QEAA@XZ"

--- a/clang/test/CodeGen/keep-inline-functions.cppm
+++ b/clang/test/CodeGen/keep-inline-functions.cppm
@@ -1,0 +1,59 @@
+// Tests for -fkeep-inline-functions behaviour with C++20 named modules.
+//
+// Exported inline definitions are owned by the module interface unit and are
+// retained there. Imported inline definitions are only affected if their
+// definition is available in the current TU. If no use requires deserializing
+// the definition, the function is not visible to this option.
+//
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+
+// Compile the module interface unit to verify that the exported inline
+// definition is owned by this TU and retained.
+// RUN: %clang_cc1 -std=c++20 -fkeep-inline-functions -O2 \
+// RUN:   %t/Hello.cppm -emit-llvm -o - \
+// RUN:   | FileCheck %s --check-prefix=CHECK-MODULE
+
+// Build the PCM for the import tests below.
+// RUN: %clang_cc1 -std=c++20 -fkeep-inline-functions -emit-module-interface \
+// RUN:   %t/Hello.cppm -o %t/Hello.pcm
+
+// Compile a TU that imports but does not call hello().
+// The definition is not deserialized, so it is not retained.
+// RUN: %clang_cc1 -std=c++20 -fkeep-inline-functions -O2 \
+// RUN:   -fmodule-file=Hello=%t/Hello.pcm %t/no-use.cpp -emit-llvm -o - \
+// RUN:   | FileCheck %s --check-prefix=CHECK-NO-USE
+
+// Compile a TU that imports and calls hello().
+// Calling hello() deserializes its definition, allowing
+// -fkeep-inline-functions to retain it.
+// RUN: %clang_cc1 -std=c++20 -fkeep-inline-functions -O2 \
+// RUN:   -fmodule-file=Hello=%t/Hello.pcm %t/use.cpp -emit-llvm -o - \
+// RUN:   | FileCheck %s --check-prefix=CHECK-USE
+
+//--- Hello.cppm
+export module Hello;
+
+// CHECK-MODULE: @llvm{{(\.compiler)?}}.used = {{.*}}hello
+// CHECK-MODULE: define {{.*}}@_ZW5Hello5hellov
+export inline int hello() { return 55; }
+
+//--- use.cpp
+import Hello;
+
+// CHECK-USE: @llvm{{(\.compiler)?}}.used = {{.*}}hello
+// CHECK-USE: define {{.*}}@_ZW5Hello5hellov
+int main() {
+  return hello();
+}
+
+//--- no-use.cpp
+import Hello;
+
+// CHECK-NO-USE-NOT: @llvm{{(\.compiler)?}}.used = {{.*}}hello
+// CHECK-NO-USE-NOT: define {{.*}}@_ZW5Hello5hellov
+int main() {
+  return 0;
+}
+

--- a/clang/test/CodeGen/keep-inline-functions.cppm
+++ b/clang/test/CodeGen/keep-inline-functions.cppm
@@ -11,24 +11,24 @@
 
 // Compile the module interface unit to verify that the exported inline
 // definition is owned by this TU and retained.
-// RUN: %clang_cc1 -std=c++20 -fkeep-inline-functions -O2 \
+// RUN: %clang_cc1 -std=c++20 -fkeep-inline-functions -O2 -triple powerpc64-ibm-aix-xcoff \
 // RUN:   %t/Hello.cppm -emit-llvm -o - \
 // RUN:   | FileCheck %s --check-prefix=CHECK-MODULE
 
 // Build the PCM for the import tests below.
-// RUN: %clang_cc1 -std=c++20 -fkeep-inline-functions -emit-module-interface \
+// RUN: %clang_cc1 -std=c++20 -fkeep-inline-functions -triple powerpc64-ibm-aix-xcoff -emit-module-interface \
 // RUN:   %t/Hello.cppm -o %t/Hello.pcm
 
 // Compile a TU that imports but does not call hello().
 // The definition is not deserialized, so it is not retained.
-// RUN: %clang_cc1 -std=c++20 -fkeep-inline-functions -O2 \
+// RUN: %clang_cc1 -std=c++20 -fkeep-inline-functions -O2 -triple powerpc64-ibm-aix-xcoff \
 // RUN:   -fmodule-file=Hello=%t/Hello.pcm %t/no-use.cpp -emit-llvm -o - \
 // RUN:   | FileCheck %s --check-prefix=CHECK-NO-USE
 
 // Compile a TU that imports and calls hello().
 // Calling hello() deserializes its definition, allowing
 // -fkeep-inline-functions to retain it.
-// RUN: %clang_cc1 -std=c++20 -fkeep-inline-functions -O2 \
+// RUN: %clang_cc1 -std=c++20 -fkeep-inline-functions -O2 -triple powerpc64-ibm-aix-xcoff \
 // RUN:   -fmodule-file=Hello=%t/Hello.pcm %t/use.cpp -emit-llvm -o - \
 // RUN:   | FileCheck %s --check-prefix=CHECK-USE
 

--- a/clang/test/Driver/clang_f_opts.c
+++ b/clang/test/Driver/clang_f_opts.c
@@ -325,8 +325,6 @@
 // RUN: -fexpensive-optimizations                                             \
 // RUN: -fno-expensive-optimizations                                          \
 // RUN: -fno-defer-pop                                                        \
-// RUN: -fkeep-inline-functions                                               \
-// RUN: -fno-keep-inline-functions                                            \
 // RUN: -freorder-blocks                                                      \
 // RUN: -ffloat-store                                                         \
 // RUN: -fgcse                                                                \
@@ -385,8 +383,6 @@
 // CHECK-WARNING-DAG: optimization flag '-fexpensive-optimizations' is not supported
 // CHECK-WARNING-DAG: optimization flag '-fno-expensive-optimizations' is not supported
 // CHECK-WARNING-DAG: optimization flag '-fno-defer-pop' is not supported
-// CHECK-WARNING-DAG: optimization flag '-fkeep-inline-functions' is not supported
-// CHECK-WARNING-DAG: optimization flag '-fno-keep-inline-functions' is not supported
 // CHECK-WARNING-DAG: optimization flag '-freorder-blocks' is not supported
 // CHECK-WARNING-DAG: optimization flag '-ffloat-store' is not supported
 // CHECK-WARNING-DAG: optimization flag '-fgcse' is not supported

--- a/clang/test/Driver/fkeep-inline-functions.c
+++ b/clang/test/Driver/fkeep-inline-functions.c
@@ -1,0 +1,5 @@
+// RUN: %clang -fkeep-inline-functions -c %s -### 2>&1 | FileCheck %s
+// RUN: %clang -fkeep-inline-functions -fno-keep-inline-functions -c %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-NOKEEP
+
+// CHECK: "-fkeep-inline-functions"
+// CHECK-NOKEEP-NOT: "-fkeep-inline-functions"


### PR DESCRIPTION
Implement the -fkeep-inline-functions flag, which forces selected inline function definitions to be emitted into the object file even if they have been inlined into all their callers. The function retention behavior follows GCC's semantics.

The front-end has been modified to:
- emit the selected functions even if they are unused; and
- add the selected functions to llvm.compiler.used/llvm.used to ensure they are retained.

The functions selected for emission are inline function definitions that are available in the current translation unit. available_externally definitions are excluded because their authoritative definitions are expected to be emitted by another translation unit.

This is also done for C99 inline function external definitions with external linkage, which would normally be emitted into the object file anyway, to ensure the functions are retained for LTO purposes.

See the proposed Clang documentation update for details on the function selection criteria.