### PR TITLE
[AsmPrinter] Fix direct callee operand lookup in CallGraphSection

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1999,23 +1999,24 @@ void AsmPrinter::handleCallsiteForCallgraph(
     const MachineFunction::CallSiteInfoMap &CallSitesInfoMap,
     const MachineInstr &MI) {
   assert(MI.isCall() && "This method is meant for call instructions only.");
-  const MachineOperand &CalleeOperand = MI.getOperand(0);
-  if (CalleeOperand.isGlobal() || CalleeOperand.isSymbol()) {
-    // Handle direct calls.
-    MCSymbol *CalleeSymbol = nullptr;
-    switch (CalleeOperand.getType()) {
-    case llvm::MachineOperand::MO_GlobalAddress:
-      CalleeSymbol = getSymbol(CalleeOperand.getGlobal());
-      break;
-    case llvm::MachineOperand::MO_ExternalSymbol:
-      CalleeSymbol = GetExternalSymbolSymbol(CalleeOperand.getSymbolName());
-      break;
-    default:
-      llvm_unreachable(
-          "Expected to only handle direct call instructions here.");
+  for (const MachineOperand &CalleeOperand : MI.operands()) {
+    if (CalleeOperand.isGlobal() || CalleeOperand.isSymbol()) {
+      // Handle direct calls.
+      MCSymbol *CalleeSymbol = nullptr;
+      switch (CalleeOperand.getType()) {
+      case llvm::MachineOperand::MO_GlobalAddress:
+        CalleeSymbol = getSymbol(CalleeOperand.getGlobal());
+        break;
+      case llvm::MachineOperand::MO_ExternalSymbol:
+        CalleeSymbol = GetExternalSymbolSymbol(CalleeOperand.getSymbolName());
+        break;
+      default:
+        llvm_unreachable(
+            "Expected to only handle direct call instructions here.");
+      }
+      FuncCGInfo.DirectCallees.insert(CalleeSymbol);
+      return; // Early exit after handling the direct call instruction.
     }
-    FuncCGInfo.DirectCallees.insert(CalleeSymbol);
-    return; // Early exit after handling the direct call instruction.
   }
   const auto &CallSiteInfo = CallSitesInfoMap.find(&MI);
   if (CallSiteInfo == CallSitesInfoMap.end())

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1999,24 +1999,24 @@ void AsmPrinter::handleCallsiteForCallgraph(
     const MachineFunction::CallSiteInfoMap &CallSitesInfoMap,
     const MachineInstr &MI) {
   assert(MI.isCall() && "This method is meant for call instructions only.");
-  for (const MachineOperand &CalleeOperand : MI.operands()) {
-    if (CalleeOperand.isGlobal() || CalleeOperand.isSymbol()) {
-      // Handle direct calls.
-      MCSymbol *CalleeSymbol = nullptr;
-      switch (CalleeOperand.getType()) {
-      case llvm::MachineOperand::MO_GlobalAddress:
-        CalleeSymbol = getSymbol(CalleeOperand.getGlobal());
-        break;
-      case llvm::MachineOperand::MO_ExternalSymbol:
-        CalleeSymbol = GetExternalSymbolSymbol(CalleeOperand.getSymbolName());
-        break;
-      default:
-        llvm_unreachable(
-            "Expected to only handle direct call instructions here.");
-      }
-      FuncCGInfo.DirectCallees.insert(CalleeSymbol);
-      return; // Early exit after handling the direct call instruction.
+  const TargetInstrInfo *TII = MF->getSubtarget().getInstrInfo();
+  const MachineOperand &CalleeOperand = TII->getCalleeOperand(MI);
+  if (CalleeOperand.isGlobal() || CalleeOperand.isSymbol()) {
+    // Handle direct calls.
+    MCSymbol *CalleeSymbol = nullptr;
+    switch (CalleeOperand.getType()) {
+    case llvm::MachineOperand::MO_GlobalAddress:
+      CalleeSymbol = getSymbol(CalleeOperand.getGlobal());
+      break;
+    case llvm::MachineOperand::MO_ExternalSymbol:
+      CalleeSymbol = GetExternalSymbolSymbol(CalleeOperand.getSymbolName());
+      break;
+    default:
+      llvm_unreachable(
+          "Expected to only handle direct call instructions here.");
     }
+    FuncCGInfo.DirectCallees.insert(CalleeSymbol);
+    return; // Early exit after handling the direct call instruction.
   }
   const auto &CallSiteInfo = CallSitesInfoMap.find(&MI);
   if (CallSiteInfo == CallSitesInfoMap.end())

--- a/llvm/test/CodeGen/ARM/call-graph-section-assembly.ll
+++ b/llvm/test/CodeGen/ARM/call-graph-section-assembly.ll
@@ -5,6 +5,7 @@
 ;; Test if the .llvm.callgraph section contains unique direct callees.
 
 ; RUN: llc -mtriple=arm-unknown-linux --call-graph-section -o - < %s | FileCheck %s
+; RUN: llc -mtriple=thumbv7m-unknown-none-eabi --call-graph-section -o - < %s | FileCheck %s
 
 declare !callgraph !0 void @direct_foo()
 declare !callgraph !1 i32 @direct_bar(i8)

--- a/llvm/test/CodeGen/ARM/call-graph-section-assembly.ll
+++ b/llvm/test/CodeGen/ARM/call-graph-section-assembly.ll
@@ -6,6 +6,7 @@
 
 ; RUN: llc -mtriple=arm-unknown-linux --call-graph-section -o - < %s | FileCheck %s
 ; RUN: llc -mtriple=thumbv7m-unknown-none-eabi --call-graph-section -o - < %s | FileCheck %s
+; RUN: llc -mtriple=thumbv6m-unknown-none-eabi --call-graph-section -o - < %s | FileCheck %s
 
 declare !callgraph !0 void @direct_foo()
 declare !callgraph !1 i32 @direct_bar(i8)


### PR DESCRIPTION
In handleCallsiteForCallgraph, direct callee operand was assumed to
always be at index 0 (MI.getOperand(0)). While true for x86_64, on
ARM Thumb/Thumb-2 (e.g. tBL), operand 0 and 1 represent predicate condition
codes and the target symbol is placed at operand 2.

Iterate over MI.operands() to locate the direct callee symbol operand
across all target instruction formats.

Assisted-by: Gemini
