### PR TITLE
[Hexagon] Fix sign extension in wide fixed-point multiply-shift idiom

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonVectorCombine.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonVectorCombine.cpp
@@ -3066,8 +3066,12 @@ auto HvxIdioms::processFxpMulChopped(IRBuilderBase &Builder, Instruction &In,
                                            {Hi, Lo, ShiftAmt},
                                            /*FMFSource*/ nullptr, "int");
     } else {
-      // The shift of the most significant word.
-      WordP[Dst] = Builder.CreateAShr(Lo, ShiftAmt, "asr");
+      // The shift of the most significant word. The product is signed only
+      // if one of the operands is, otherwise the top bit is a value bit and
+      // must not be replicated.
+      WordP[Dst] = Op.X.Sgn == Signed || Op.Y.Sgn == Signed
+                       ? Builder.CreateAShr(Lo, ShiftAmt, "asr")
+                       : Builder.CreateLShr(Lo, ShiftAmt, "lsr");
     }
   }
   if (SkipWords != 0)

--- a/llvm/test/CodeGen/Hexagon/autohvx/mulh-shift-signedness.ll
+++ b/llvm/test/CodeGen/Hexagon/autohvx/mulh-shift-signedness.ll
@@ -1,0 +1,39 @@
+; RUN: llc -mtriple=hexagon -mattr=+hvxv68,+hvx-length128b,-packets < %s | FileCheck %s
+
+; The shift of the most significant word must be logical for an unsigned
+; product and arithmetic only when an operand is signed.
+
+; CHECK-LABEL: mulhu_shr:
+; CHECK: vlsr
+; CHECK-NOT: vasr
+define <32 x i32> @mulhu_shr(<32 x i32> %a0) #0 {
+  %v0 = zext <32 x i32> %a0 to <32 x i64>
+  %v1 = mul nuw <32 x i64> %v0, splat (i64 2863311531)
+  %v2 = lshr <32 x i64> %v1, splat (i64 33)
+  %v3 = trunc nuw nsw <32 x i64> %v2 to <32 x i32>
+  ret <32 x i32> %v3
+}
+
+; CHECK-LABEL: mulhs_shr:
+; CHECK: vasr
+define <32 x i32> @mulhs_shr(<32 x i32> %a0, <32 x i32> %a1) #0 {
+  %v0 = sext <32 x i32> %a0 to <32 x i64>
+  %v1 = sext <32 x i32> %a1 to <32 x i64>
+  %v2 = mul nsw <32 x i64> %v0, %v1
+  %v3 = ashr <32 x i64> %v2, splat (i64 33)
+  %v4 = trunc <32 x i64> %v3 to <32 x i32>
+  ret <32 x i32> %v4
+}
+
+; CHECK-LABEL: mulhsu_shr:
+; CHECK: vasr
+define <32 x i32> @mulhsu_shr(<32 x i32> %a0, <32 x i32> %a1) #0 {
+  %v0 = sext <32 x i32> %a0 to <32 x i64>
+  %v1 = zext <32 x i32> %a1 to <32 x i64>
+  %v2 = mul <32 x i64> %v0, %v1
+  %v3 = ashr <32 x i64> %v2, splat (i64 33)
+  %v4 = trunc <32 x i64> %v3 to <32 x i32>
+  ret <32 x i32> %v4
+}
+
+attributes #0 = { nounwind "target-features"="+hvxv68,+hvx-length128b" }


### PR DESCRIPTION
HvxIdioms lowers a widening multiply-then-shift-right idiom with element width >= 32 by splitting the operands into 32-bit words and shifting the multi-word product right. Interior words use a funnel shift, which pulls the incoming high bits from the next word up, but the most significant word has nothing above it and was shifted with an unconditional AShr.

For an unsigned product the top bit of that word is a value bit, not a sign bit, so AShr replicates it downward and corrupts the result. Select AShr/LShr on operand signedness, matching what the Width == 16 path already does.

The bug is only observable when the shift leaves a non-zero remainder mod 32: for a plain 32-bit multiply-high the shift amount is 0 and the AShr is a no-op. Since this is the sequence generated for unsigned division by a non-power-of-two constant, it is reachable from ordinary C, and it miscompiled pr51581-1.c and pr51581-2.c in the test suite.