### PR TITLE
[libc] Add sysconf(_SC_CLK_TCK) on Linux.

### DIFF
--- a/libc/include/llvm-libc-macros/linux/unistd-macros.h
+++ b/libc/include/llvm-libc-macros/linux/unistd-macros.h
@@ -21,9 +21,10 @@
 #define R_OK 4
 
 #define _SC_ARG_MAX 0
-#define _SC_PAGESIZE 1
-#define _SC_PAGE_SIZE _SC_PAGESIZE
+#define _SC_CLK_TCK	2
 #define _SC_OPEN_MAX 4
+#define _SC_PAGESIZE 30
+#define _SC_PAGE_SIZE _SC_PAGESIZE
 #define _SC_THREADS 67
 #define _SC_NPROCESSORS_CONF 83
 #define _SC_NPROCESSORS_ONLN 84

--- a/libc/include/llvm-libc-macros/linux/unistd-macros.h
+++ b/libc/include/llvm-libc-macros/linux/unistd-macros.h
@@ -21,7 +21,7 @@
 #define R_OK 4
 
 #define _SC_ARG_MAX 0
-#define _SC_CLK_TCK	2
+#define _SC_CLK_TCK 2
 #define _SC_OPEN_MAX 4
 #define _SC_PAGESIZE 30
 #define _SC_PAGE_SIZE _SC_PAGESIZE

--- a/libc/include/unistd.yaml
+++ b/libc/include/unistd.yaml
@@ -16,11 +16,13 @@ macros:
     macro_header: unistd-macros.h
   - macro_name: _SC_ARG_MAX
     macro_header: unistd-macros.h
+  - macro_name: _SC_CLK_TCK
+    macro_header: unistd-macros.h
+  - macro_name: _SC_OPEN_MAX
+    macro_header: unistd-macros.h
   - macro_name: _SC_PAGESIZE
     macro_header: unistd-macros.h
   - macro_name: _SC_PAGE_SIZE
-    macro_header: unistd-macros.h
-  - macro_name: _SC_OPEN_MAX
     macro_header: unistd-macros.h
   - macro_name: _SC_THREADS
     macro_header: unistd-macros.h

--- a/libc/src/unistd/linux/sysconf.cpp
+++ b/libc/src/unistd/linux/sysconf.cpp
@@ -127,6 +127,11 @@ LLVM_LIBC_FUNCTION(long, sysconf, (int name)) {
   switch (name) {
   case _SC_ARG_MAX:
     return get_arg_max();
+  case _SC_CLK_TCK:
+    // On Linux, this is a counterpart of kernel constant USER_HZ, which is
+    // set to 100 on most platforms for user-space compatibility:
+    // https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/param.h#L6
+    return 100;
   case _SC_PAGESIZE:
     return get_page_size();
   case _SC_NPROCESSORS_CONF:

--- a/libc/test/src/unistd/sysconf_test.cpp
+++ b/libc/test/src/unistd/sysconf_test.cpp
@@ -53,3 +53,8 @@ TEST(LlvmLibcSysconfTest, PhysPagesTest) {
   long phys_pages = LIBC_NAMESPACE::sysconf(_SC_PHYS_PAGES);
   ASSERT_GT(phys_pages, 0L);
 }
+
+TEST(LlvmLibcSysconfTest, ClkTckTest) {
+  long clk_tck = LIBC_NAMESPACE::sysconf(_SC_CLK_TCK);
+  ASSERT_EQ(clk_tck, 100L);
+}


### PR DESCRIPTION
_SC_CLK_TCK on Linux is set to 100 for user-space compatibility. In POSIX, there's no matching configuration variable, so we can confidently return a constant.

While here, update the `_SC_PAGESIZE` value, since the rest of the `_SC_` constants defined in LLVM-libc's version of `<unistd.h>` attempt to be match other libc implementations.