### PR TITLE
[flang][NFC] Move DebugTypeGenerator.h to the public include directory

### DIFF
--- a/flang/include/flang/Optimizer/Support/Utils.h
+++ b/flang/include/flang/Optimizer/Support/Utils.h
@@ -24,6 +24,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Location.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "llvm/ADT/StringRef.h"
 #include <string>
@@ -31,6 +32,14 @@
 #include "flang/Optimizer/CodeGen/TypeConverter.h"
 
 namespace fir {
+/// Return the line of a location, or 1 if it does not carry one.
+inline uint32_t getLineFromLoc(mlir::Location loc) {
+  uint32_t line = 1;
+  if (auto fileLoc = mlir::dyn_cast<mlir::FileLineColLoc>(loc))
+    line = fileLoc.getLine();
+  return line;
+}
+
 /// Return the integer value of a arith::ConstantOp.
 inline std::int64_t toInt(mlir::arith::ConstantOp cop) {
   return mlir::cast<mlir::IntegerAttr>(cop.getValue())

--- a/flang/include/flang/Optimizer/Transforms/DebugTypeGenerator.h
+++ b/flang/include/flang/Optimizer/Transforms/DebugTypeGenerator.h
@@ -167,11 +167,4 @@ private:
 
 } // namespace fir
 
-static uint32_t getLineFromLoc(mlir::Location loc) {
-  uint32_t line = 1;
-  if (auto fileLoc = mlir::dyn_cast<mlir::FileLineColLoc>(loc))
-    line = fileLoc.getLine();
-  return line;
-}
-
 #endif // FORTRAN_OPTIMIZER_TRANSFORMS_DEBUGTYPEGENERATOR_H

--- a/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
+++ b/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
@@ -11,7 +11,6 @@
 /// This pass populates some debug information for the module and functions.
 //===----------------------------------------------------------------------===//
 
-#include "DebugTypeGenerator.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Dialect/FIRCG/CGOps.h"
 #include "flang/Optimizer/Dialect/FIRDialect.h"
@@ -21,6 +20,7 @@
 #include "flang/Optimizer/Dialect/Support/FIRContext.h"
 #include "flang/Optimizer/Support/InternalNames.h"
 #include "flang/Optimizer/Support/Utils.h"
+#include "flang/Optimizer/Transforms/DebugTypeGenerator.h"
 #include "flang/Optimizer/Transforms/Passes.h"
 #include "flang/Support/Version.h"
 #include "mlir/Dialect/DLTI/DLTI.h"
@@ -262,14 +262,14 @@ bool AddDebugInfoPass::createCommonBlockGlobal(
     commonName = commonName.drop_back();
 
   // Create the debug attributes.
-  unsigned line = getLineFromLoc(global.getLoc());
+  unsigned line = fir::getLineFromLoc(global.getLoc());
   mlir::LLVM::DICommonBlockAttr commonBlock =
       getOrCreateCommonBlockAttr(commonName, fileAttr, scopeAttr, line);
 
   mlir::LLVM::DITypeAttr diType = typeGen.convertType(
       fir::unwrapRefType(declOp.getType()), fileAttr, scopeAttr, declOp);
 
-  line = getLineFromLoc(declOp.getLoc());
+  line = fir::getLineFromLoc(declOp.getLoc());
   auto gvAttr = mlir::LLVM::DIGlobalVariableAttr::get(
       context, commonBlock, mlir::StringAttr::get(context, name),
       declOp.getUniqName(), fileAttr, line, diType,
@@ -366,7 +366,7 @@ void AddDebugInfoPass::handleLocalVariable(Op declOp, llvm::StringRef name,
 
   auto localVarAttr = mlir::LLVM::DILocalVariableAttr::get(
       context, scopeAttr, mlir::StringAttr::get(context, name), fileAttr,
-      getLineFromLoc(declOp.getLoc()), argNo, /* alignInBits*/ 0, tyAttr,
+      fir::getLineFromLoc(declOp.getLoc()), argNo, /* alignInBits*/ 0, tyAttr,
       mlir::LLVM::DIFlags::Zero);
   declOp->setLoc(builder.getFusedLoc({declOp->getLoc()}, localVarAttr));
 }
@@ -447,7 +447,7 @@ mlir::LLVM::DIModuleAttr AddDebugInfoPass::getOrCreateModuleAttr(
     // caller's guess, which is derived from a member's declaration.
     if (auto iter{moduleDebugImportsByName.find(name)};
         iter != moduleDebugImportsByName.end())
-      line = getLineFromLoc(iter->second.getLoc());
+      line = fir::getLineFromLoc(iter->second.getLoc());
 
     // When decl is true, it means that module is only being used in this
     // compilation unit and it is defined elsewhere. But if the file/line/scope
@@ -487,7 +487,7 @@ AddDebugInfoPass::getModuleAttrFromGlobalOp(fir::GlobalOp globalOp,
   // one). The isInitialized() seems to provide the right information
   // but inverted. It is true where module is actually defined but false where
   // it is used.
-  unsigned line = getLineFromLoc(globalOp.getLoc());
+  unsigned line = fir::getLineFromLoc(globalOp.getLoc());
 
   mlir::LLVM::DISubprogramAttr sp =
       mlir::dyn_cast_if_present<mlir::LLVM::DISubprogramAttr>(scope);
@@ -518,7 +518,7 @@ void AddDebugInfoPass::handleGlobalOp(fir::GlobalOp globalOp,
   if (fir::NameUniquer::isSpecialSymbol(result.second.name))
     return;
 
-  unsigned line = getLineFromLoc(globalOp.getLoc());
+  unsigned line = fir::getLineFromLoc(globalOp.getLoc());
   std::optional<mlir::LLVM::DIModuleAttr> modOpt =
       getModuleAttrFromGlobalOp(globalOp, fileAttr, scope);
   if (modOpt)
@@ -648,7 +648,7 @@ void AddDebugInfoPass::handleFuncOp(mlir::func::FuncOp funcOp,
     subprogramFlags =
         subprogramFlags | mlir::LLVM::DISubprogramFlags::Recursive;
 
-  unsigned line = getLineFromLoc(l);
+  unsigned line = fir::getLineFromLoc(l);
   if (fir::isInternalProcedure(funcOp)) {
     // For contained functions, the scope is the parent subroutine.
     mlir::SymbolRefAttr sym = mlir::cast<mlir::SymbolRefAttr>(
@@ -688,7 +688,7 @@ void AddDebugInfoPass::handleFuncOp(mlir::func::FuncOp funcOp,
     // target op and make sure that all the variables inside the target region
     // get the correct scope in the first place.
     funcOp.walk([&](mlir::omp::TargetOp targetOp) {
-      unsigned line = getLineFromLoc(targetOp.getLoc());
+      unsigned line = fir::getLineFromLoc(targetOp.getLoc());
       mlir::StringAttr name =
           getTargetFunctionName(context, targetOp.getLoc(), funcOp.getName());
       mlir::LLVM::DISubprogramFlags flags =

--- a/flang/lib/Optimizer/Transforms/DebugTypeGenerator.cpp
+++ b/flang/lib/Optimizer/Transforms/DebugTypeGenerator.cpp
@@ -12,7 +12,7 @@
 
 #define DEBUG_TYPE "flang-debug-type-generator"
 
-#include "DebugTypeGenerator.h"
+#include "flang/Optimizer/Transforms/DebugTypeGenerator.h"
 #include "flang/Optimizer/CodeGen/DescriptorModel.h"
 #include "flang/Optimizer/Support/InternalNames.h"
 #include "flang/Optimizer/Support/Utils.h"


### PR DESCRIPTION
DebugTypeGenerator converts FIR/MLIR types to DITypeAttr, but its header lives next to the pass that uses it, so it cannot be reused by passes outside flang/lib/Optimizer/Transforms.

Move it to flang/include/flang/Optimizer/Transforms/ alongside the other public headers, so other consumers can reuse the conversion.

The header's file-static getLineFromLoc is moved to Optimizer/Support/Utils.h as an fir:: helper.