### PR TITLE
[AMDGPU] Keep wide-store hazard distance path-local

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
@@ -987,24 +987,20 @@ int GCNHazardRecognizer::checkVALUHazardsHelper(
     return 2;
   };
 
-  // For each hazard producer reached, accumulate the wait states still
-  // needed using that producer's own window. The predicate always returns
-  // false so the walk runs to MaxWaitStates.
-  int Distance = 0;
-  auto Counter = [&](const MachineInstr &MI) {
-    int DataIdx = createsVALUHazard(MI);
-    if (DataIdx >= 0 &&
-        TRI->regsOverlap(MI.getOperand(DataIdx).getReg(), Reg)) {
-      int Need = WindowFor(MI) - Distance;
-      WaitStatesNeeded = std::max(WaitStatesNeeded, Need);
-    }
-    // Mirror getWaitStatesSince's accounting, which does not count inline asm
-    // towards the wait-state distance.
-    if (!MI.isInlineAsm())
-      Distance += SIInstrInfo::getNumWaitStates(MI);
-    return false;
-  };
-  getWaitStatesSince(Counter, MaxWaitStates);
+  // Scan each producer class separately so getWaitStatesSince keeps distance
+  // path-local across control-flow joins.
+  for (int RequiredWaitStates = 1; RequiredWaitStates <= MaxWaitStates;
+       ++RequiredWaitStates) {
+    auto IsHazardFn = [&](const MachineInstr &MI) {
+      int DataIdx = createsVALUHazard(MI);
+      return DataIdx >= 0 && WindowFor(MI) == RequiredWaitStates &&
+             TRI->regsOverlap(MI.getOperand(DataIdx).getReg(), Reg);
+    };
+    int WaitStatesSince =
+        getWaitStatesSince(IsHazardFn, RequiredWaitStates);
+    WaitStatesNeeded = std::max(
+        WaitStatesNeeded, RequiredWaitStates - WaitStatesSince);
+  }
 
   return WaitStatesNeeded;
 }

--- a/llvm/test/CodeGen/AMDGPU/buffer-store-dwordx4-vpk-mul-war-hazard-gfx942.mir
+++ b/llvm/test/CodeGen/AMDGPU/buffer-store-dwordx4-vpk-mul-war-hazard-gfx942.mir
@@ -54,6 +54,47 @@ body: |
 ...
 
 ---
+name: global_store_dwordx4_control_flow_join
+tracksRegLiveness: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $vgpr0_vgpr1, $vgpr2_vgpr3_vgpr4_vgpr5, $sgpr0_sgpr1
+    ; GFX950-LABEL: name: global_store_dwordx4_control_flow_join
+    ; GFX950: bb.1:
+    ; GFX950: GLOBAL_STORE_DWORDX4 $vgpr0_vgpr1, $vgpr2_vgpr3_vgpr4_vgpr5, 0, 0, implicit $exec
+    ; GFX950: bb.2:
+    ; GFX950: $sgpr0_sgpr1 = S_OR_B64 $sgpr0_sgpr1, $exec, implicit-def $scc
+    ; GFX950-NEXT: S_NOP 0
+    ; GFX950-NEXT: $vgpr2 = V_MOV_B32_e32 32, implicit $exec
+    ; GFX942-LABEL: name: global_store_dwordx4_control_flow_join
+    ; GFX942: bb.1:
+    ; GFX942: GLOBAL_STORE_DWORDX4 $vgpr0_vgpr1, $vgpr2_vgpr3_vgpr4_vgpr5, 0, 0, implicit $exec
+    ; GFX942: bb.2:
+    ; GFX942: $sgpr0_sgpr1 = S_OR_B64 $sgpr0_sgpr1, $exec, implicit-def $scc
+    ; GFX942-NEXT: S_NOP 0
+    ; GFX942-NEXT: $vgpr2 = V_MOV_B32_e32 32, implicit $exec
+    ; GFX900-LABEL: name: global_store_dwordx4_control_flow_join
+    ; GFX900: bb.1:
+    ; GFX900: GLOBAL_STORE_DWORDX4 $vgpr0_vgpr1, $vgpr2_vgpr3_vgpr4_vgpr5, 0, 0, implicit $exec
+    ; GFX900: bb.2:
+    ; GFX900: $sgpr0_sgpr1 = S_OR_B64 $sgpr0_sgpr1, $exec, implicit-def $scc
+    ; GFX900-NEXT: $vgpr2 = V_MOV_B32_e32 32, implicit $exec
+    S_CBRANCH_EXECZ %bb.2, implicit $exec
+
+  bb.1:
+    successors: %bb.2
+    liveins: $vgpr0_vgpr1, $vgpr2_vgpr3_vgpr4_vgpr5, $sgpr0_sgpr1
+    GLOBAL_STORE_DWORDX4 $vgpr0_vgpr1, $vgpr2_vgpr3_vgpr4_vgpr5, 0, 0, implicit $exec
+
+  bb.2:
+    liveins: $vgpr2_vgpr3_vgpr4_vgpr5, $sgpr0_sgpr1
+    $sgpr0_sgpr1 = S_OR_B64 $sgpr0_sgpr1, $exec, implicit-def $scc
+    $vgpr2 = V_MOV_B32_e32 32, implicit $exec
+    S_ENDPGM 0
+...
+
+---
 name: buffer_store_dwordx4_literal_soffset_then_vpk_mul
 tracksRegLiveness: true
 body: |


### PR DESCRIPTION
## Summary

- Preserve path-local wait-state distance when scanning wide VMEM-store source-VGPR WAR hazards.
- Scan the one- and two-wait producer classes independently.
- Add a control-flow-join MIR regression for gfx950 and gfx942 while preserving gfx900 behavior.

## Root cause

Commit `62b7cf9623fc` introduced support for producer-specific one- and two-wait hazard windows. Its scan tracks the distance in a mutable variable captured by the predicate passed to `getWaitStatesSince`.

`getWaitStatesSince` recursively walks predecessor paths at control-flow joins. Although its own wait-state argument is path-local, the captured distance is shared across the traversal. If a no-store predecessor is visited first, it advances the shared distance; a wide store subsequently found on another predecessor can therefore appear old enough even when it is not.

This occurs in masked output-store diamonds such as:

```text
             /-- global_store_dwordx4 ..., vdata --\
    branch --                                      +-- s_or_b64
             \------------------------------------/    v_or_b32 vdata.sub0, ...
```

On gfx950 the missing delay allows the later VALU result to replace part of the preceding store payload.

The change keeps producer-specific windows but performs one normal `getWaitStatesSince` query per window. This lets its existing recursion retain distance independently for every predecessor path.

## Validation

- Built `llc` and `FileCheck` from this revision with assertions enabled.
- Passed `buffer-store-dwordx4-vpk-mul-war-hazard-gfx942.mir` for gfx950, gfx942, and gfx900.
- The new MIR test fails before this change and passes afterward.
- Compiling the original affected gfx950 LLIR now inserts `S_NOP 0` before all three output-mask VGPR overwrites.
- On gfx950 hardware, inserting the same wait into the affected assembly eliminates the observed numerical corruption.

Detailed end-to-end investigation and generated assembly are recorded in [raikonenfnu/tlx_triton#16](https://github.com/raikonenfnu/tlx_triton/issues/16#issuecomment-5402692919).
