### PR TITLE
[lldb] Remove ConstString from Language::MethodName

### DIFF
--- a/lldb/include/lldb/Target/Language.h
+++ b/lldb/include/lldb/Target/Language.h
@@ -221,15 +221,15 @@ public:
   public:
     MethodName() {}
 
-    MethodName(ConstString full)
-        : m_full(full), m_basename(), m_context(), m_arguments(),
+    MethodName(std::string full)
+        : m_full(std::move(full)), m_basename(), m_context(), m_arguments(),
           m_qualifiers(), m_return_type(), m_scope_qualified(), m_parsed(false),
           m_parse_error(false) {}
 
     virtual ~MethodName() {};
 
     void Clear() {
-      m_full.Clear();
+      m_full = {};
       m_basename = llvm::StringRef();
       m_context = llvm::StringRef();
       m_arguments = llvm::StringRef();
@@ -245,10 +245,10 @@ public:
         Parse();
       if (m_parse_error)
         return false;
-      return (bool)m_full;
+      return !m_full.empty();
     }
 
-    ConstString GetFullName() const { return m_full; }
+    const std::string &GetFullName() const { return m_full; }
 
     llvm::StringRef GetBasename() {
       if (!m_parsed)
@@ -292,7 +292,7 @@ public:
       m_parse_error = true;
     }
 
-    ConstString m_full; // Full name:
+    std::string m_full; // Full name:
                         // "size_t lldb::SBTarget::GetBreakpointAtIndex(unsigned
                         // int) const"
     llvm::StringRef m_basename;    // Basename:     "GetBreakpointAtIndex"
@@ -306,9 +306,9 @@ public:
   };
 
   virtual std::unique_ptr<Language::MethodName>
-  GetMethodName(ConstString name) const {
-    return std::make_unique<Language::MethodName>(name);
-  };
+  GetMethodName(llvm::StringRef name) const {
+    return std::make_unique<Language::MethodName>(name.str());
+  }
 
   virtual std::pair<lldb::FunctionNameType, std::optional<ConstString>>
   GetFunctionNameInfo(ConstString name) const {

--- a/lldb/source/Core/RichManglingContext.cpp
+++ b/lldb/source/Core/RichManglingContext.cpp
@@ -150,7 +150,7 @@ llvm::StringRef RichManglingContext::ParseFullName() {
     return processIPDStrResult(buf, n);
   }
   case PluginCxxLanguage:
-    return m_cxx_method_parser->GetFullName().GetStringRef();
+    return llvm::StringRef(m_cxx_method_parser->GetFullName());
   case None:
     return {};
   }

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -67,9 +67,9 @@ void CPlusPlusLanguage::Terminate() {
 }
 
 std::unique_ptr<Language::MethodName>
-CPlusPlusLanguage::GetMethodName(ConstString full_name) const {
+CPlusPlusLanguage::GetMethodName(llvm::StringRef full_name) const {
   std::unique_ptr<CxxMethodName> cpp_method =
-      std::make_unique<CxxMethodName>(full_name);
+      std::make_unique<CxxMethodName>(full_name.str());
   cpp_method->IsValid();
   return cpp_method;
 }
@@ -80,7 +80,7 @@ CPlusPlusLanguage::GetFunctionNameInfo(ConstString name) const {
     return {eFunctionNameTypeFull, std::nullopt};
 
   FunctionNameType func_name_type = eFunctionNameTypeNone;
-  CxxMethodName method(name);
+  CxxMethodName method(name.GetStringRef().str());
   llvm::StringRef basename = method.GetBasename();
   if (basename.empty()) {
     llvm::StringRef context;
@@ -125,7 +125,7 @@ ConstString CPlusPlusLanguage::GetDemangledFunctionNameWithoutArguments(
                                         // eventually handle eSymbolTypeData,
                                         // we will want this back)
     {
-      CxxMethodName cxx_method(demangled_name);
+      CxxMethodName cxx_method(demangled_name.GetStringRef().str());
       if (!cxx_method.GetBasename().empty()) {
         std::string shortname;
         if (!cxx_method.GetContext().empty())
@@ -227,10 +227,10 @@ static bool IsTrivialContext(llvm::StringRef context) {
 /// but replaces each argument type with the variable name
 /// and the corresponding pretty-printed value
 static bool PrettyPrintFunctionNameWithArgs(Stream &out_stream,
-                                            char const *full_name,
+                                            llvm::StringRef full_name,
                                             ExecutionContextScope *exe_scope,
                                             VariableList const &args) {
-  CPlusPlusLanguage::CxxMethodName cpp_method{ConstString(full_name)};
+  CPlusPlusLanguage::CxxMethodName cpp_method{full_name.str()};
 
   if (!cpp_method.IsValid())
     return false;
@@ -474,7 +474,7 @@ bool CPlusPlusLanguage::CxxMethodName::TrySimplifiedParse() {
   // function don't have return types and templates in the name.
   // A::B::C::fun(std::vector<T> &) const
   size_t arg_start, arg_end;
-  llvm::StringRef full(m_full.GetCString());
+  llvm::StringRef full(m_full);
   llvm::StringRef parens("()", 2);
   if (ReverseFindMatchingChars(full, parens, arg_start, arg_end)) {
     m_arguments = full.substr(arg_start, arg_end - arg_start + 1);
@@ -511,11 +511,11 @@ bool CPlusPlusLanguage::CxxMethodName::TrySimplifiedParse() {
 }
 
 void CPlusPlusLanguage::CxxMethodName::Parse() {
-  if (!m_parsed && m_full) {
+  if (!m_parsed && !m_full.empty()) {
     if (TrySimplifiedParse()) {
       m_parse_error = false;
     } else {
-      CPlusPlusNameParser parser(m_full.GetStringRef());
+      CPlusPlusNameParser parser(m_full);
       if (auto function = parser.ParseAsFunctionDefinition()) {
         m_basename = function->name.basename;
         m_context = function->name.context;
@@ -555,14 +555,14 @@ bool CPlusPlusLanguage::CxxMethodName::ContainsPath(llvm::StringRef path) {
 
   // If we can't parse the incoming name, then just check that it contains path.
   if (m_parse_error)
-    return m_full.GetStringRef().contains(path);
+    return llvm::StringRef(m_full).contains(path);
 
   llvm::StringRef identifier;
   llvm::StringRef context;
   const bool success =
       CPlusPlusLanguage::ExtractContextAndIdentifier(path, context, identifier);
   if (!success)
-    return m_full.GetStringRef().contains(path);
+    return llvm::StringRef(m_full).contains(path);
 
   // Basename may include template arguments.
   // E.g.,
@@ -599,7 +599,7 @@ bool CPlusPlusLanguage::CxxMethodName::ContainsPath(llvm::StringRef path) {
 
 bool CPlusPlusLanguage::DemangledNameContainsPath(llvm::StringRef path,
                                                   ConstString demangled) const {
-  CxxMethodName demangled_name(demangled);
+  CxxMethodName demangled_name(demangled.GetStringRef().str());
   return demangled_name.ContainsPath(path);
 }
 
@@ -699,7 +699,7 @@ ConstString CPlusPlusLanguage::FindBestAlternateFunctionMangledName(
   if (!demangled)
     return ConstString();
 
-  CxxMethodName cpp_name(demangled);
+  CxxMethodName cpp_name(demangled.GetStringRef().str());
   std::string scope_qualified_name = cpp_name.GetScopeQualifiedName();
 
   if (!scope_qualified_name.size())
@@ -722,7 +722,7 @@ ConstString CPlusPlusLanguage::FindBestAlternateFunctionMangledName(
     Mangled mangled(alternate_mangled_name);
     ConstString demangled = mangled.GetDemangledName();
 
-    CxxMethodName alternate_cpp_name(demangled);
+    CxxMethodName alternate_cpp_name(demangled.GetStringRef().str());
     if (!cpp_name.IsValid())
       continue;
 

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.h
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.h
@@ -24,7 +24,7 @@ class CPlusPlusLanguage : public Language {
 public:
   class CxxMethodName : public Language::MethodName {
   public:
-    CxxMethodName(std::string s) : Language::MethodName(s) {}
+    CxxMethodName(std::string s) : Language::MethodName(std::move(s)) {}
 
     bool ContainsPath(llvm::StringRef path);
 

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.h
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.h
@@ -24,7 +24,7 @@ class CPlusPlusLanguage : public Language {
 public:
   class CxxMethodName : public Language::MethodName {
   public:
-    CxxMethodName(ConstString s) : Language::MethodName(s) {}
+    CxxMethodName(std::string s) : Language::MethodName(s) {}
 
     bool ContainsPath(llvm::StringRef path);
 
@@ -53,7 +53,7 @@ public:
   ~CPlusPlusLanguage() override = default;
 
   virtual std::unique_ptr<Language::MethodName>
-  GetMethodName(ConstString name) const override;
+  GetMethodName(llvm::StringRef name) const override;
 
   std::pair<lldb::FunctionNameType, std::optional<ConstString>>
   GetFunctionNameInfo(ConstString name) const override;

--- a/lldb/unittests/Language/CPlusPlus/CPlusPlusLanguageTest.cpp
+++ b/lldb/unittests/Language/CPlusPlus/CPlusPlusLanguageTest.cpp
@@ -244,7 +244,7 @@ TEST(CPlusPlusLanguage, MethodNameParsing) {
        "A::operator<=>[abi:tag]<A::B>"}};
 
   for (const auto &test : test_cases) {
-    CPlusPlusLanguage::CxxMethodName method(ConstString(test.input));
+    CPlusPlusLanguage::CxxMethodName method(test.input);
     EXPECT_TRUE(method.IsValid()) << test.input;
     if (method.IsValid()) {
       EXPECT_EQ(test.return_type, method.GetReturnType().str());
@@ -275,23 +275,22 @@ TEST(CPlusPlusLanguage, InvalidMethodNameParsing) {
   };
 
   for (const auto &name : test_cases) {
-    CPlusPlusLanguage::CxxMethodName method{ConstString(name)};
+    CPlusPlusLanguage::CxxMethodName method{name};
     EXPECT_FALSE(method.IsValid()) << name;
   }
 }
 
 TEST(CPlusPlusLanguage, ContainsPath) {
   CPlusPlusLanguage::CxxMethodName reference_1(
-      ConstString("int foo::bar::func01(int a, double b)"));
+      "int foo::bar::func01(int a, double b)");
   CPlusPlusLanguage::CxxMethodName reference_2(
-      ConstString("int foofoo::bar::func01(std::string a, int b)"));
-  CPlusPlusLanguage::CxxMethodName reference_3(ConstString("int func01()"));
-  CPlusPlusLanguage::CxxMethodName reference_4(
-      ConstString("bar::baz::operator bool()"));
+      "int foofoo::bar::func01(std::string a, int b)");
+  CPlusPlusLanguage::CxxMethodName reference_3("int func01()");
+  CPlusPlusLanguage::CxxMethodName reference_4("bar::baz::operator bool()");
   CPlusPlusLanguage::CxxMethodName reference_5(
-      ConstString("bar::baz::operator bool<int, Type<double>>()"));
-  CPlusPlusLanguage::CxxMethodName reference_6(ConstString(
-      "bar::baz::operator<<<Type<double>, Type<std::vector<double>>>()"));
+      "bar::baz::operator bool<int, Type<double>>()");
+  CPlusPlusLanguage::CxxMethodName reference_6(
+      "bar::baz::operator<<<Type<double>, Type<std::vector<double>>>()");
 
   EXPECT_TRUE(reference_1.ContainsPath(""));
   EXPECT_TRUE(reference_1.ContainsPath("func01"));


### PR DESCRIPTION
This is a precursor to changing Module::LookupInfo (which uses MethodName to extract basenames from inputs).