### PR TITLE
[GlobalISel] Drop nuw/nsw/disjoint when widening a result with G_ANYEXT

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
@@ -3006,6 +3006,11 @@ LegalizerHelper::widenScalar(MachineInstr &MI, unsigned TypeIdx, LLT WideTy) {
     // don't affect the result) and then truncate the result back to the
     // original type.
     Observer.changingInstr(MI);
+    // The G_ANYEXTs below leave the new high bits unconstrained, so no-wrap and
+    // disjoint claims proved at the narrow width no longer hold. Paths that
+    // widen with value-preserving G_ZEXT/G_SEXT keep their flags.
+    MI.clearFlags(MachineInstr::NoUWrap | MachineInstr::NoSWrap |
+                  MachineInstr::Disjoint);
     widenScalarSrc(MI, WideTy, 1, TargetOpcode::G_ANYEXT);
     widenScalarSrc(MI, WideTy, 2, TargetOpcode::G_ANYEXT);
     widenScalarDst(MI, WideTy);
@@ -3031,6 +3036,10 @@ LegalizerHelper::widenScalar(MachineInstr &MI, unsigned TypeIdx, LLT WideTy) {
     Observer.changingInstr(MI);
 
     if (TypeIdx == 0) {
+      // Widening the result with G_ANYEXT invalidates the no-wrap flags, as in
+      // the G_ADD/G_SUB/G_MUL case above. TypeIdx 1 widens only the shift
+      // amount, which is value-preserving, so it keeps them.
+      MI.clearFlags(MachineInstr::NoUWrap | MachineInstr::NoSWrap);
       widenScalarSrc(MI, WideTy, 1, TargetOpcode::G_ANYEXT);
       widenScalarDst(MI, WideTy);
     } else {

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fshl.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fshl.mir
@@ -28,7 +28,7 @@ body:             |
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[AND2]], [[C3]](i64)
     ; CHECK-NEXT: [[AND3:%[0-9]+]]:_(i32) = G_AND [[LSHR]], [[C2]]
     ; CHECK-NEXT: [[LSHR1:%[0-9]+]]:_(i32) = G_LSHR [[AND3]], [[AND1]](i32)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = disjoint G_OR [[SHL]], [[LSHR1]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[SHL]], [[LSHR1]]
     ; CHECK-NEXT: $w0 = COPY [[OR]](i32)
     ; CHECK-NEXT: RET_ReallyLR implicit $w0
     %3:_(i32) = COPY $w0
@@ -71,7 +71,7 @@ body:             |
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[AND2]], [[C3]](i64)
     ; CHECK-NEXT: [[AND3:%[0-9]+]]:_(i32) = G_AND [[LSHR]], [[C2]]
     ; CHECK-NEXT: [[LSHR1:%[0-9]+]]:_(i32) = G_LSHR [[AND3]], [[AND1]](i32)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = disjoint G_OR [[SHL]], [[LSHR1]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[SHL]], [[LSHR1]]
     ; CHECK-NEXT: $w0 = COPY [[OR]](i32)
     ; CHECK-NEXT: RET_ReallyLR implicit $w0
     %3:_(i32) = COPY $w0
@@ -175,7 +175,7 @@ body:             |
     ; CHECK-NEXT: [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 255
     ; CHECK-NEXT: [[AND:%[0-9]+]]:_(i32) = G_AND [[COPY1]], [[C1]]
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[AND]], [[C]](i64)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = disjoint G_OR [[SHL]], [[LSHR]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[SHL]], [[LSHR]]
     ; CHECK-NEXT: $w0 = COPY [[OR]](i32)
     ; CHECK-NEXT: RET_ReallyLR implicit $w0
     %2:_(i32) = COPY $w0
@@ -209,7 +209,7 @@ body:             |
     ; CHECK-NEXT: [[AND:%[0-9]+]]:_(i32) = G_AND [[COPY1]], [[C1]]
     ; CHECK-NEXT: [[C2:%[0-9]+]]:_(i64) = G_CONSTANT i64 6
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[AND]], [[C2]](i64)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = disjoint G_OR [[SHL]], [[LSHR]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[SHL]], [[LSHR]]
     ; CHECK-NEXT: $w0 = COPY [[OR]](i32)
     ; CHECK-NEXT: RET_ReallyLR implicit $w0
     %2:_(i32) = COPY $w0
@@ -246,7 +246,7 @@ body:             |
     ; CHECK-NEXT: [[AND1:%[0-9]+]]:_(i32) = G_AND [[LSHR]], [[C1]]
     ; CHECK-NEXT: [[C3:%[0-9]+]]:_(i64) = G_CONSTANT i64 7
     ; CHECK-NEXT: [[LSHR1:%[0-9]+]]:_(i32) = G_LSHR [[AND1]], [[C3]](i64)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = disjoint G_OR [[SHL]], [[LSHR1]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[SHL]], [[LSHR1]]
     ; CHECK-NEXT: $w0 = COPY [[OR]](i32)
     ; CHECK-NEXT: RET_ReallyLR implicit $w0
     %2:_(i32) = COPY $w0
@@ -280,7 +280,7 @@ body:             |
     ; CHECK-NEXT: [[AND:%[0-9]+]]:_(i32) = G_AND [[COPY1]], [[C1]]
     ; CHECK-NEXT: [[C2:%[0-9]+]]:_(i64) = G_CONSTANT i64 4
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[AND]], [[C2]](i64)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = disjoint G_OR [[SHL]], [[LSHR]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[SHL]], [[LSHR]]
     ; CHECK-NEXT: $w0 = COPY [[OR]](i32)
     ; CHECK-NEXT: RET_ReallyLR implicit $w0
     %2:_(i32) = COPY $w0
@@ -314,7 +314,7 @@ body:             |
     ; CHECK-NEXT: [[AND:%[0-9]+]]:_(i32) = G_AND [[COPY1]], [[C1]]
     ; CHECK-NEXT: [[C2:%[0-9]+]]:_(i64) = G_CONSTANT i64 12
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[AND]], [[C2]](i64)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = disjoint G_OR [[SHL]], [[LSHR]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[SHL]], [[LSHR]]
     ; CHECK-NEXT: $w0 = COPY [[OR]](i32)
     ; CHECK-NEXT: RET_ReallyLR implicit $w0
     %2:_(i32) = COPY $w0
@@ -351,7 +351,7 @@ body:             |
     ; CHECK-NEXT: [[AND1:%[0-9]+]]:_(i32) = G_AND [[LSHR]], [[C1]]
     ; CHECK-NEXT: [[C3:%[0-9]+]]:_(i64) = G_CONSTANT i64 15
     ; CHECK-NEXT: [[LSHR1:%[0-9]+]]:_(i32) = G_LSHR [[AND1]], [[C3]](i64)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = disjoint G_OR [[SHL]], [[LSHR1]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[SHL]], [[LSHR1]]
     ; CHECK-NEXT: $w0 = COPY [[OR]](i32)
     ; CHECK-NEXT: RET_ReallyLR implicit $w0
     %2:_(i32) = COPY $w0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fshr.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fshr.mir
@@ -27,7 +27,7 @@ body:             |
     ; CHECK-NEXT: [[C3:%[0-9]+]]:_(i32) = G_CONSTANT i32 255
     ; CHECK-NEXT: [[AND2:%[0-9]+]]:_(i32) = G_AND [[COPY1]], [[C3]]
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[AND2]], [[AND]](i32)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = disjoint G_OR [[SHL1]], [[LSHR]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[SHL1]], [[LSHR]]
     ; CHECK-NEXT: $w0 = COPY [[OR]](i32)
     ; CHECK-NEXT: RET_ReallyLR implicit $w0
     %3:_(i32) = COPY $w0
@@ -69,7 +69,7 @@ body:             |
     ; CHECK-NEXT: [[C3:%[0-9]+]]:_(i32) = G_CONSTANT i32 65535
     ; CHECK-NEXT: [[AND2:%[0-9]+]]:_(i32) = G_AND [[COPY1]], [[C3]]
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[AND2]], [[AND]](i32)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = disjoint G_OR [[SHL1]], [[LSHR]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[SHL1]], [[LSHR]]
     ; CHECK-NEXT: $w0 = COPY [[OR]](i32)
     ; CHECK-NEXT: RET_ReallyLR implicit $w0
     %3:_(i32) = COPY $w0
@@ -175,7 +175,7 @@ body:             |
     ; CHECK-NEXT: [[AND:%[0-9]+]]:_(i32) = G_AND [[COPY1]], [[C1]]
     ; CHECK-NEXT: [[C2:%[0-9]+]]:_(i64) = G_CONSTANT i64 7
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[AND]], [[C2]](i64)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = disjoint G_OR [[SHL]], [[LSHR]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[SHL]], [[LSHR]]
     ; CHECK-NEXT: $w0 = COPY [[OR]](i32)
     ; CHECK-NEXT: RET_ReallyLR implicit $w0
     %2:_(i32) = COPY $w0
@@ -209,7 +209,7 @@ body:             |
     ; CHECK-NEXT: [[AND:%[0-9]+]]:_(i32) = G_AND [[COPY1]], [[C1]]
     ; CHECK-NEXT: [[C2:%[0-9]+]]:_(i64) = G_CONSTANT i64 2
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[AND]], [[C2]](i64)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = disjoint G_OR [[SHL]], [[LSHR]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[SHL]], [[LSHR]]
     ; CHECK-NEXT: $w0 = COPY [[OR]](i32)
     ; CHECK-NEXT: RET_ReallyLR implicit $w0
     %2:_(i32) = COPY $w0
@@ -245,7 +245,7 @@ body:             |
     ; CHECK-NEXT: [[AND:%[0-9]+]]:_(i32) = G_AND [[COPY1]], [[C2]]
     ; CHECK-NEXT: [[C3:%[0-9]+]]:_(i64) = G_CONSTANT i64 0
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[AND]], [[C3]](i64)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = disjoint G_OR [[SHL1]], [[LSHR]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[SHL1]], [[LSHR]]
     ; CHECK-NEXT: $w0 = COPY [[OR]](i32)
     ; CHECK-NEXT: RET_ReallyLR implicit $w0
     %2:_(i32) = COPY $w0
@@ -279,7 +279,7 @@ body:             |
     ; CHECK-NEXT: [[AND:%[0-9]+]]:_(i32) = G_AND [[COPY1]], [[C1]]
     ; CHECK-NEXT: [[C2:%[0-9]+]]:_(i64) = G_CONSTANT i64 5
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[AND]], [[C2]](i64)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = disjoint G_OR [[SHL]], [[LSHR]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[SHL]], [[LSHR]]
     ; CHECK-NEXT: $w0 = COPY [[OR]](i32)
     ; CHECK-NEXT: RET_ReallyLR implicit $w0
     %2:_(i32) = COPY $w0
@@ -313,7 +313,7 @@ body:             |
     ; CHECK-NEXT: [[AND:%[0-9]+]]:_(i32) = G_AND [[COPY1]], [[C1]]
     ; CHECK-NEXT: [[C2:%[0-9]+]]:_(i64) = G_CONSTANT i64 4
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[AND]], [[C2]](i64)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = disjoint G_OR [[SHL]], [[LSHR]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[SHL]], [[LSHR]]
     ; CHECK-NEXT: $w0 = COPY [[OR]](i32)
     ; CHECK-NEXT: RET_ReallyLR implicit $w0
     %2:_(i32) = COPY $w0
@@ -349,7 +349,7 @@ body:             |
     ; CHECK-NEXT: [[AND:%[0-9]+]]:_(i32) = G_AND [[COPY1]], [[C2]]
     ; CHECK-NEXT: [[C3:%[0-9]+]]:_(i64) = G_CONSTANT i64 0
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[AND]], [[C3]](i64)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = disjoint G_OR [[SHL1]], [[LSHR]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[SHL1]], [[LSHR]]
     ; CHECK-NEXT: $w0 = COPY [[OR]](i32)
     ; CHECK-NEXT: RET_ReallyLR implicit $w0
     %2:_(i32) = COPY $w0

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fshl.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fshl.ll
@@ -765,8 +765,8 @@ define amdgpu_ps i16 @s_fshl_v2i8(i16 inreg %lhs.arg, i16 inreg %rhs.arg, i16 in
 ; GFX6-NEXT:    s_lshr_b32 s1, s1, 1
 ; GFX6-NEXT:    s_lshl_b32 s2, s3, s2
 ; GFX6-NEXT:    s_lshr_b32 s1, s1, s4
-; GFX6-NEXT:    s_or_b32 s2, s2, s1
-; GFX6-NEXT:    s_and_b32 s1, s2, 0xff
+; GFX6-NEXT:    s_or_b32 s1, s2, s1
+; GFX6-NEXT:    s_and_b32 s1, s1, 0xff
 ; GFX6-NEXT:    s_and_b32 s0, s0, 0xff
 ; GFX6-NEXT:    s_lshl_b32 s1, s1, 8
 ; GFX6-NEXT:    s_or_b32 s0, s0, s1
@@ -1087,17 +1087,17 @@ define amdgpu_ps i32 @s_fshl_v4i8(i32 inreg %lhs.arg, i32 inreg %rhs.arg, i32 in
 ; GFX6-NEXT:    s_and_b32 s4, s8, 7
 ; GFX6-NEXT:    s_andn2_b32 s6, 7, s8
 ; GFX6-NEXT:    s_lshr_b32 s1, s1, 25
+; GFX6-NEXT:    s_and_b32 s2, s2, 0xff
 ; GFX6-NEXT:    s_lshl_b32 s4, s5, s4
 ; GFX6-NEXT:    s_lshr_b32 s1, s1, s6
-; GFX6-NEXT:    s_or_b32 s4, s4, s1
-; GFX6-NEXT:    s_and_b32 s1, s2, 0xff
 ; GFX6-NEXT:    s_and_b32 s0, s0, 0xff
-; GFX6-NEXT:    s_lshl_b32 s1, s1, 8
-; GFX6-NEXT:    s_or_b32 s0, s0, s1
-; GFX6-NEXT:    s_and_b32 s1, s3, 0xff
-; GFX6-NEXT:    s_lshl_b32 s1, s1, 16
-; GFX6-NEXT:    s_or_b32 s0, s0, s1
-; GFX6-NEXT:    s_and_b32 s1, s4, 0xff
+; GFX6-NEXT:    s_lshl_b32 s2, s2, 8
+; GFX6-NEXT:    s_or_b32 s1, s4, s1
+; GFX6-NEXT:    s_or_b32 s0, s0, s2
+; GFX6-NEXT:    s_and_b32 s2, s3, 0xff
+; GFX6-NEXT:    s_lshl_b32 s2, s2, 16
+; GFX6-NEXT:    s_and_b32 s1, s1, 0xff
+; GFX6-NEXT:    s_or_b32 s0, s0, s2
 ; GFX6-NEXT:    s_lshl_b32 s1, s1, 24
 ; GFX6-NEXT:    s_or_b32 s0, s0, s1
 ; GFX6-NEXT:    ; return to shader part epilog
@@ -2042,39 +2042,39 @@ define amdgpu_ps i48 @s_fshl_v2i24(i48 inreg %lhs.arg, i48 inreg %rhs.arg, i48 i
 ; GFX6-NEXT:    s_lshr_b32 s1, s1, 1
 ; GFX6-NEXT:    s_lshl_b32 s3, s6, s3
 ; GFX6-NEXT:    s_lshr_b32 s1, s1, s7
-; GFX6-NEXT:    s_or_b32 s3, s3, s1
-; GFX6-NEXT:    v_readfirstlane_b32 s1, v0
-; GFX6-NEXT:    s_mulk_i32 s1, 0xffe8
-; GFX6-NEXT:    s_add_i32 s4, s4, s1
+; GFX6-NEXT:    s_or_b32 s1, s3, s1
+; GFX6-NEXT:    v_readfirstlane_b32 s3, v0
+; GFX6-NEXT:    s_mulk_i32 s3, 0xffe8
+; GFX6-NEXT:    s_add_i32 s4, s4, s3
 ; GFX6-NEXT:    s_cmp_ge_u32 s4, 24
-; GFX6-NEXT:    s_cselect_b32 s1, 1, 0
+; GFX6-NEXT:    s_cselect_b32 s3, 1, 0
 ; GFX6-NEXT:    s_sub_i32 s5, s4, 24
-; GFX6-NEXT:    s_cmp_lg_u32 s1, 0
-; GFX6-NEXT:    s_cselect_b32 s1, s5, s4
-; GFX6-NEXT:    s_cmp_ge_u32 s1, 24
+; GFX6-NEXT:    s_cmp_lg_u32 s3, 0
+; GFX6-NEXT:    s_cselect_b32 s3, s5, s4
+; GFX6-NEXT:    s_cmp_ge_u32 s3, 24
 ; GFX6-NEXT:    s_cselect_b32 s4, 1, 0
-; GFX6-NEXT:    s_sub_i32 s5, s1, 24
+; GFX6-NEXT:    s_sub_i32 s5, s3, 24
 ; GFX6-NEXT:    s_cmp_lg_u32 s4, 0
-; GFX6-NEXT:    s_cselect_b32 s1, s5, s1
-; GFX6-NEXT:    s_sub_i32 s4, 23, s1
-; GFX6-NEXT:    s_lshl_b32 s0, s0, s1
-; GFX6-NEXT:    s_lshr_b32 s1, s2, 1
-; GFX6-NEXT:    s_lshr_b32 s1, s1, s4
-; GFX6-NEXT:    s_bfe_u32 s2, s3, 0x80008
-; GFX6-NEXT:    s_or_b32 s1, s0, s1
-; GFX6-NEXT:    s_and_b32 s0, s3, 0xff
-; GFX6-NEXT:    s_lshl_b32 s2, s2, 8
-; GFX6-NEXT:    s_or_b32 s0, s0, s2
-; GFX6-NEXT:    s_bfe_u32 s2, s3, 0x80010
-; GFX6-NEXT:    s_lshl_b32 s2, s2, 16
-; GFX6-NEXT:    s_or_b32 s0, s0, s2
-; GFX6-NEXT:    s_and_b32 s2, s1, 0xff
-; GFX6-NEXT:    s_lshl_b32 s2, s2, 24
-; GFX6-NEXT:    s_or_b32 s0, s0, s2
-; GFX6-NEXT:    s_bfe_u32 s2, s1, 0x80008
+; GFX6-NEXT:    s_cselect_b32 s3, s5, s3
+; GFX6-NEXT:    s_sub_i32 s4, 23, s3
+; GFX6-NEXT:    s_lshr_b32 s2, s2, 1
+; GFX6-NEXT:    s_lshl_b32 s0, s0, s3
+; GFX6-NEXT:    s_lshr_b32 s2, s2, s4
+; GFX6-NEXT:    s_bfe_u32 s3, s1, 0x80008
+; GFX6-NEXT:    s_or_b32 s2, s0, s2
+; GFX6-NEXT:    s_and_b32 s0, s1, 0xff
+; GFX6-NEXT:    s_lshl_b32 s3, s3, 8
 ; GFX6-NEXT:    s_bfe_u32 s1, s1, 0x80010
-; GFX6-NEXT:    s_lshl_b32 s1, s1, 8
-; GFX6-NEXT:    s_or_b32 s1, s2, s1
+; GFX6-NEXT:    s_or_b32 s0, s0, s3
+; GFX6-NEXT:    s_lshl_b32 s1, s1, 16
+; GFX6-NEXT:    s_or_b32 s0, s0, s1
+; GFX6-NEXT:    s_and_b32 s1, s2, 0xff
+; GFX6-NEXT:    s_lshl_b32 s1, s1, 24
+; GFX6-NEXT:    s_or_b32 s0, s0, s1
+; GFX6-NEXT:    s_bfe_u32 s1, s2, 0x80008
+; GFX6-NEXT:    s_bfe_u32 s2, s2, 0x80010
+; GFX6-NEXT:    s_lshl_b32 s2, s2, 8
+; GFX6-NEXT:    s_or_b32 s1, s1, s2
 ; GFX6-NEXT:    ; return to shader part epilog
 ;
 ; GFX8-LABEL: s_fshl_v2i24:

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fshr.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fshr.ll
@@ -764,8 +764,8 @@ define amdgpu_ps i16 @s_fshr_v2i8(i16 inreg %lhs.arg, i16 inreg %rhs.arg, i16 in
 ; GFX6-NEXT:    s_bfe_u32 s1, s1, 0x80008
 ; GFX6-NEXT:    s_lshl_b32 s3, s3, s4
 ; GFX6-NEXT:    s_lshr_b32 s1, s1, s2
-; GFX6-NEXT:    s_or_b32 s3, s3, s1
-; GFX6-NEXT:    s_and_b32 s1, s3, 0xff
+; GFX6-NEXT:    s_or_b32 s1, s3, s1
+; GFX6-NEXT:    s_and_b32 s1, s1, 0xff
 ; GFX6-NEXT:    s_and_b32 s0, s0, 0xff
 ; GFX6-NEXT:    s_lshl_b32 s1, s1, 8
 ; GFX6-NEXT:    s_or_b32 s0, s0, s1
@@ -1077,28 +1077,28 @@ define amdgpu_ps i32 @s_fshr_v4i8(i32 inreg %lhs.arg, i32 inreg %rhs.arg, i32 in
 ; GFX6-NEXT:    s_bfe_u32 s7, s1, 0x80008
 ; GFX6-NEXT:    s_lshr_b32 s2, s7, s2
 ; GFX6-NEXT:    s_lshr_b32 s6, s1, 24
-; GFX6-NEXT:    s_or_b32 s3, s3, s2
-; GFX6-NEXT:    s_and_b32 s2, s8, 7
+; GFX6-NEXT:    s_or_b32 s2, s3, s2
+; GFX6-NEXT:    s_and_b32 s3, s8, 7
 ; GFX6-NEXT:    s_andn2_b32 s7, 7, s8
 ; GFX6-NEXT:    s_lshl_b32 s4, s4, 1
 ; GFX6-NEXT:    s_bfe_u32 s1, s1, 0x80010
 ; GFX6-NEXT:    s_lshl_b32 s4, s4, s7
-; GFX6-NEXT:    s_lshr_b32 s1, s1, s2
-; GFX6-NEXT:    s_or_b32 s4, s4, s1
-; GFX6-NEXT:    s_and_b32 s1, s9, 7
-; GFX6-NEXT:    s_andn2_b32 s2, 7, s9
+; GFX6-NEXT:    s_lshr_b32 s1, s1, s3
+; GFX6-NEXT:    s_or_b32 s1, s4, s1
+; GFX6-NEXT:    s_and_b32 s3, s9, 7
+; GFX6-NEXT:    s_andn2_b32 s4, 7, s9
 ; GFX6-NEXT:    s_lshl_b32 s5, s5, 1
-; GFX6-NEXT:    s_lshl_b32 s2, s5, s2
-; GFX6-NEXT:    s_lshr_b32 s1, s6, s1
-; GFX6-NEXT:    s_or_b32 s2, s2, s1
-; GFX6-NEXT:    s_and_b32 s1, s3, 0xff
+; GFX6-NEXT:    s_and_b32 s2, s2, 0xff
+; GFX6-NEXT:    s_lshl_b32 s4, s5, s4
+; GFX6-NEXT:    s_lshr_b32 s3, s6, s3
 ; GFX6-NEXT:    s_and_b32 s0, s0, 0xff
-; GFX6-NEXT:    s_lshl_b32 s1, s1, 8
-; GFX6-NEXT:    s_or_b32 s0, s0, s1
-; GFX6-NEXT:    s_and_b32 s1, s4, 0xff
+; GFX6-NEXT:    s_lshl_b32 s2, s2, 8
+; GFX6-NEXT:    s_and_b32 s1, s1, 0xff
+; GFX6-NEXT:    s_or_b32 s3, s4, s3
+; GFX6-NEXT:    s_or_b32 s0, s0, s2
 ; GFX6-NEXT:    s_lshl_b32 s1, s1, 16
 ; GFX6-NEXT:    s_or_b32 s0, s0, s1
-; GFX6-NEXT:    s_and_b32 s1, s2, 0xff
+; GFX6-NEXT:    s_and_b32 s1, s3, 0xff
 ; GFX6-NEXT:    s_lshl_b32 s1, s1, 24
 ; GFX6-NEXT:    s_or_b32 s0, s0, s1
 ; GFX6-NEXT:    ; return to shader part epilog
@@ -2060,32 +2060,32 @@ define amdgpu_ps i48 @s_fshr_v2i24(i48 inreg %lhs.arg, i48 inreg %rhs.arg, i48 i
 ; GFX6-NEXT:    s_or_b32 s6, s6, s8
 ; GFX6-NEXT:    s_lshl_b32 s5, s6, s9
 ; GFX6-NEXT:    s_lshr_b32 s3, s7, s3
-; GFX6-NEXT:    s_or_b32 s5, s5, s3
-; GFX6-NEXT:    v_readfirstlane_b32 s3, v0
-; GFX6-NEXT:    s_mulk_i32 s3, 0xffe8
-; GFX6-NEXT:    s_add_i32 s4, s4, s3
+; GFX6-NEXT:    s_or_b32 s3, s5, s3
+; GFX6-NEXT:    v_readfirstlane_b32 s5, v0
+; GFX6-NEXT:    s_mulk_i32 s5, 0xffe8
+; GFX6-NEXT:    s_add_i32 s4, s4, s5
 ; GFX6-NEXT:    s_cmp_ge_u32 s4, 24
-; GFX6-NEXT:    s_cselect_b32 s3, 1, 0
+; GFX6-NEXT:    s_cselect_b32 s5, 1, 0
 ; GFX6-NEXT:    s_sub_i32 s6, s4, 24
-; GFX6-NEXT:    s_cmp_lg_u32 s3, 0
-; GFX6-NEXT:    s_cselect_b32 s3, s6, s4
-; GFX6-NEXT:    s_cmp_ge_u32 s3, 24
-; GFX6-NEXT:    s_cselect_b32 s4, 1, 0
-; GFX6-NEXT:    s_sub_i32 s6, s3, 24
-; GFX6-NEXT:    s_cmp_lg_u32 s4, 0
-; GFX6-NEXT:    s_cselect_b32 s3, s6, s3
+; GFX6-NEXT:    s_cmp_lg_u32 s5, 0
+; GFX6-NEXT:    s_cselect_b32 s4, s6, s4
+; GFX6-NEXT:    s_cmp_ge_u32 s4, 24
+; GFX6-NEXT:    s_cselect_b32 s5, 1, 0
+; GFX6-NEXT:    s_sub_i32 s6, s4, 24
+; GFX6-NEXT:    s_cmp_lg_u32 s5, 0
+; GFX6-NEXT:    s_cselect_b32 s4, s6, s4
 ; GFX6-NEXT:    s_lshl_b32 s1, s1, 17
 ; GFX6-NEXT:    s_lshl_b32 s0, s0, 1
-; GFX6-NEXT:    s_sub_i32 s4, 23, s3
+; GFX6-NEXT:    s_sub_i32 s5, 23, s4
 ; GFX6-NEXT:    s_or_b32 s0, s1, s0
-; GFX6-NEXT:    s_lshl_b32 s0, s0, s4
-; GFX6-NEXT:    s_lshr_b32 s1, s2, s3
-; GFX6-NEXT:    s_bfe_u32 s2, s5, 0x80008
+; GFX6-NEXT:    s_lshl_b32 s0, s0, s5
+; GFX6-NEXT:    s_lshr_b32 s1, s2, s4
+; GFX6-NEXT:    s_bfe_u32 s2, s3, 0x80008
 ; GFX6-NEXT:    s_or_b32 s1, s0, s1
-; GFX6-NEXT:    s_and_b32 s0, s5, 0xff
+; GFX6-NEXT:    s_and_b32 s0, s3, 0xff
 ; GFX6-NEXT:    s_lshl_b32 s2, s2, 8
 ; GFX6-NEXT:    s_or_b32 s0, s0, s2
-; GFX6-NEXT:    s_bfe_u32 s2, s5, 0x80010
+; GFX6-NEXT:    s_bfe_u32 s2, s3, 0x80010
 ; GFX6-NEXT:    s_lshl_b32 s2, s2, 16
 ; GFX6-NEXT:    s_or_b32 s0, s0, s2
 ; GFX6-NEXT:    s_and_b32 s2, s1, 0xff

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-fshl.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-fshl.mir
@@ -444,7 +444,7 @@ body: |
     ; SI-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[AND2]], [[C2]](s32)
     ; SI-NEXT: [[AND3:%[0-9]+]]:_(s32) = G_AND [[LSHR]], [[C3]]
     ; SI-NEXT: [[LSHR1:%[0-9]+]]:_(s32) = G_LSHR [[AND3]], [[AND1]](s32)
-    ; SI-NEXT: [[OR:%[0-9]+]]:_(s32) = disjoint G_OR [[SHL]], [[LSHR1]]
+    ; SI-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[SHL]], [[LSHR1]]
     ; SI-NEXT: $vgpr0 = COPY [[OR]](s32)
     ;
     ; VI-LABEL: name: test_fshl_s8_s8
@@ -473,7 +473,7 @@ body: |
     ; VI-NEXT: [[LSHR1:%[0-9]+]]:_(s16) = G_LSHR [[AND5]], [[AND4]](s16)
     ; VI-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[SHL]](s16)
     ; VI-NEXT: [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[LSHR1]](s16)
-    ; VI-NEXT: [[OR:%[0-9]+]]:_(s32) = disjoint G_OR [[ANYEXT]], [[ANYEXT1]]
+    ; VI-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[ANYEXT]], [[ANYEXT1]]
     ; VI-NEXT: $vgpr0 = COPY [[OR]](s32)
     ;
     ; GFX9-LABEL: name: test_fshl_s8_s8
@@ -502,7 +502,7 @@ body: |
     ; GFX9-NEXT: [[LSHR1:%[0-9]+]]:_(s16) = G_LSHR [[AND5]], [[AND4]](s16)
     ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[SHL]](s16)
     ; GFX9-NEXT: [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[LSHR1]](s16)
-    ; GFX9-NEXT: [[OR:%[0-9]+]]:_(s32) = disjoint G_OR [[ANYEXT]], [[ANYEXT1]]
+    ; GFX9-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[ANYEXT]], [[ANYEXT1]]
     ; GFX9-NEXT: $vgpr0 = COPY [[OR]](s32)
     %0:_(s32) = COPY $vgpr0
     %1:_(s32) = COPY $vgpr1
@@ -559,7 +559,7 @@ body: |
     ; SI-NEXT: [[AND3:%[0-9]+]]:_(s32) = G_AND [[SUB4]], [[C2]]
     ; SI-NEXT: [[AND4:%[0-9]+]]:_(s32) = G_AND [[LSHR]], [[C2]]
     ; SI-NEXT: [[LSHR1:%[0-9]+]]:_(s32) = G_LSHR [[AND4]], [[AND3]](s32)
-    ; SI-NEXT: [[OR:%[0-9]+]]:_(s32) = disjoint G_OR [[SHL]], [[LSHR1]]
+    ; SI-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[SHL]], [[LSHR1]]
     ; SI-NEXT: $vgpr0 = COPY [[OR]](s32)
     ;
     ; VI-LABEL: name: test_fshl_s24_s24
@@ -600,7 +600,7 @@ body: |
     ; VI-NEXT: [[AND3:%[0-9]+]]:_(s32) = G_AND [[SUB4]], [[C2]]
     ; VI-NEXT: [[AND4:%[0-9]+]]:_(s32) = G_AND [[LSHR]], [[C2]]
     ; VI-NEXT: [[LSHR1:%[0-9]+]]:_(s32) = G_LSHR [[AND4]], [[AND3]](s32)
-    ; VI-NEXT: [[OR:%[0-9]+]]:_(s32) = disjoint G_OR [[SHL]], [[LSHR1]]
+    ; VI-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[SHL]], [[LSHR1]]
     ; VI-NEXT: $vgpr0 = COPY [[OR]](s32)
     ;
     ; GFX9-LABEL: name: test_fshl_s24_s24
@@ -641,7 +641,7 @@ body: |
     ; GFX9-NEXT: [[AND3:%[0-9]+]]:_(s32) = G_AND [[SUB4]], [[C2]]
     ; GFX9-NEXT: [[AND4:%[0-9]+]]:_(s32) = G_AND [[LSHR]], [[C2]]
     ; GFX9-NEXT: [[LSHR1:%[0-9]+]]:_(s32) = G_LSHR [[AND4]], [[AND3]](s32)
-    ; GFX9-NEXT: [[OR:%[0-9]+]]:_(s32) = disjoint G_OR [[SHL]], [[LSHR1]]
+    ; GFX9-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[SHL]], [[LSHR1]]
     ; GFX9-NEXT: $vgpr0 = COPY [[OR]](s32)
     %0:_(s32) = COPY $vgpr0
     %1:_(s32) = COPY $vgpr1

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-fshr.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-fshr.mir
@@ -405,7 +405,7 @@ body: |
     ; SI-NEXT: [[C3:%[0-9]+]]:_(s32) = G_CONSTANT i32 255
     ; SI-NEXT: [[AND2:%[0-9]+]]:_(s32) = G_AND [[COPY1]], [[C3]]
     ; SI-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[AND2]], [[AND]](s32)
-    ; SI-NEXT: [[OR:%[0-9]+]]:_(s32) = disjoint G_OR [[SHL1]], [[LSHR]]
+    ; SI-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[SHL1]], [[LSHR]]
     ; SI-NEXT: $vgpr0 = COPY [[OR]](s32)
     ;
     ; VI-LABEL: name: test_fshr_s8_s8
@@ -433,7 +433,7 @@ body: |
     ; VI-NEXT: [[LSHR:%[0-9]+]]:_(s16) = G_LSHR [[AND4]], [[AND3]](s16)
     ; VI-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[SHL1]](s16)
     ; VI-NEXT: [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[LSHR]](s16)
-    ; VI-NEXT: [[OR:%[0-9]+]]:_(s32) = disjoint G_OR [[ANYEXT]], [[ANYEXT1]]
+    ; VI-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[ANYEXT]], [[ANYEXT1]]
     ; VI-NEXT: $vgpr0 = COPY [[OR]](s32)
     ;
     ; GFX9-LABEL: name: test_fshr_s8_s8
@@ -461,7 +461,7 @@ body: |
     ; GFX9-NEXT: [[LSHR:%[0-9]+]]:_(s16) = G_LSHR [[AND4]], [[AND3]](s16)
     ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[SHL1]](s16)
     ; GFX9-NEXT: [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[LSHR]](s16)
-    ; GFX9-NEXT: [[OR:%[0-9]+]]:_(s32) = disjoint G_OR [[ANYEXT]], [[ANYEXT1]]
+    ; GFX9-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[ANYEXT]], [[ANYEXT1]]
     ; GFX9-NEXT: $vgpr0 = COPY [[OR]](s32)
     %0:_(s32) = COPY $vgpr0
     %1:_(s32) = COPY $vgpr1
@@ -517,7 +517,7 @@ body: |
     ; SI-NEXT: [[AND2:%[0-9]+]]:_(s32) = G_AND [[SELECT1]], [[C2]]
     ; SI-NEXT: [[AND3:%[0-9]+]]:_(s32) = G_AND [[COPY1]], [[C2]]
     ; SI-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[AND3]], [[AND2]](s32)
-    ; SI-NEXT: [[OR:%[0-9]+]]:_(s32) = disjoint G_OR [[SHL1]], [[LSHR]]
+    ; SI-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[SHL1]], [[LSHR]]
     ; SI-NEXT: $vgpr0 = COPY [[OR]](s32)
     ;
     ; VI-LABEL: name: test_fshr_s24_s24
@@ -557,7 +557,7 @@ body: |
     ; VI-NEXT: [[AND2:%[0-9]+]]:_(s32) = G_AND [[SELECT1]], [[C2]]
     ; VI-NEXT: [[AND3:%[0-9]+]]:_(s32) = G_AND [[COPY1]], [[C2]]
     ; VI-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[AND3]], [[AND2]](s32)
-    ; VI-NEXT: [[OR:%[0-9]+]]:_(s32) = disjoint G_OR [[SHL1]], [[LSHR]]
+    ; VI-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[SHL1]], [[LSHR]]
     ; VI-NEXT: $vgpr0 = COPY [[OR]](s32)
     ;
     ; GFX9-LABEL: name: test_fshr_s24_s24
@@ -597,7 +597,7 @@ body: |
     ; GFX9-NEXT: [[AND2:%[0-9]+]]:_(s32) = G_AND [[SELECT1]], [[C2]]
     ; GFX9-NEXT: [[AND3:%[0-9]+]]:_(s32) = G_AND [[COPY1]], [[C2]]
     ; GFX9-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[AND3]], [[AND2]](s32)
-    ; GFX9-NEXT: [[OR:%[0-9]+]]:_(s32) = disjoint G_OR [[SHL1]], [[LSHR]]
+    ; GFX9-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[SHL1]], [[LSHR]]
     ; GFX9-NEXT: $vgpr0 = COPY [[OR]](s32)
     %0:_(s32) = COPY $vgpr0
     %1:_(s32) = COPY $vgpr1

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-rotl-rotr.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-rotl-rotr.mir
@@ -48,7 +48,7 @@ body:             |
     ; GFX6-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[AND2]], [[C5]](s32)
     ; GFX6-NEXT: [[AND3:%[0-9]+]]:_(s32) = G_AND [[SUB4]], [[C2]]
     ; GFX6-NEXT: [[LSHR1:%[0-9]+]]:_(s32) = G_LSHR [[LSHR]], [[AND3]](s32)
-    ; GFX6-NEXT: [[OR:%[0-9]+]]:_(s32) = disjoint G_OR [[SHL]], [[LSHR1]]
+    ; GFX6-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[SHL]], [[LSHR1]]
     ; GFX6-NEXT: $sgpr0 = COPY [[OR]](s32)
     ;
     ; GFX8-LABEL: name: rotl_i15
@@ -93,7 +93,7 @@ body:             |
     ; GFX8-NEXT: [[LSHR1:%[0-9]+]]:_(s16) = G_LSHR [[LSHR]], [[AND3]](s16)
     ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[SHL]](s16)
     ; GFX8-NEXT: [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[LSHR1]](s16)
-    ; GFX8-NEXT: [[OR:%[0-9]+]]:_(s32) = disjoint G_OR [[ANYEXT]], [[ANYEXT1]]
+    ; GFX8-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[ANYEXT]], [[ANYEXT1]]
     ; GFX8-NEXT: $sgpr0 = COPY [[OR]](s32)
     %2:_(s32) = COPY $sgpr0
     %0:_(s15) = G_TRUNC %2(s32)
@@ -235,7 +235,7 @@ body:             |
     ; GFX-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[AND2]], [[C5]](s32)
     ; GFX-NEXT: [[AND3:%[0-9]+]]:_(s32) = G_AND [[SUB4]], [[C2]]
     ; GFX-NEXT: [[LSHR1:%[0-9]+]]:_(s32) = G_LSHR [[LSHR]], [[AND3]](s32)
-    ; GFX-NEXT: [[OR:%[0-9]+]]:_(s32) = disjoint G_OR [[SHL]], [[LSHR1]]
+    ; GFX-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[SHL]], [[LSHR1]]
     ; GFX-NEXT: $sgpr0 = COPY [[OR]](s32)
     %0:_(s32) = COPY $sgpr0
     %1:_(s32) = COPY $sgpr1

--- a/llvm/test/CodeGen/RISCV/GlobalISel/legalizer/legalize-fshl-fshr-rv32.mir
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/legalizer/legalize-fshl-fshr-rv32.mir
@@ -25,7 +25,7 @@ body:             |
     ; CHECK-NEXT: [[AND2:%[0-9]+]]:_(s32) = G_AND [[COPY1]], [[C3]]
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[AND2]], [[C2]](s32)
     ; CHECK-NEXT: [[LSHR1:%[0-9]+]]:_(s32) = G_LSHR [[LSHR]], [[AND1]](s32)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = disjoint G_OR [[SHL]], [[LSHR1]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[SHL]], [[LSHR1]]
     ; CHECK-NEXT: $x10 = COPY [[OR]](s32)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %3:_(s32) = COPY $x10
@@ -63,7 +63,7 @@ body:             |
     ; CHECK-NEXT: [[AND2:%[0-9]+]]:_(s32) = G_AND [[COPY1]], [[C3]]
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[AND2]], [[C2]](s32)
     ; CHECK-NEXT: [[LSHR1:%[0-9]+]]:_(s32) = G_LSHR [[LSHR]], [[AND1]](s32)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = disjoint G_OR [[SHL]], [[LSHR1]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[SHL]], [[LSHR1]]
     ; CHECK-NEXT: $x10 = COPY [[OR]](s32)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %3:_(s32) = COPY $x10
@@ -205,7 +205,7 @@ body:             |
     ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s32) = G_CONSTANT i32 255
     ; CHECK-NEXT: [[AND2:%[0-9]+]]:_(s32) = G_AND [[COPY1]], [[C3]]
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[AND2]], [[AND]](s32)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = disjoint G_OR [[SHL1]], [[LSHR]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[SHL1]], [[LSHR]]
     ; CHECK-NEXT: $x10 = COPY [[OR]](s32)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %3:_(s32) = COPY $x10
@@ -243,7 +243,7 @@ body:             |
     ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s32) = G_CONSTANT i32 65535
     ; CHECK-NEXT: [[AND2:%[0-9]+]]:_(s32) = G_AND [[COPY1]], [[C3]]
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[AND2]], [[AND]](s32)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = disjoint G_OR [[SHL1]], [[LSHR]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[SHL1]], [[LSHR]]
     ; CHECK-NEXT: $x10 = COPY [[OR]](s32)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %3:_(s32) = COPY $x10

--- a/llvm/test/CodeGen/RISCV/GlobalISel/legalizer/legalize-fshl-fshr-rv64.mir
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/legalizer/legalize-fshl-fshr-rv64.mir
@@ -25,7 +25,7 @@ body:             |
     ; CHECK-NEXT: [[AND2:%[0-9]+]]:_(s64) = G_AND [[COPY1]], [[C3]]
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s64) = G_LSHR [[AND2]], [[C2]](s64)
     ; CHECK-NEXT: [[LSHR1:%[0-9]+]]:_(s64) = G_LSHR [[LSHR]], [[AND1]](s64)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s64) = disjoint G_OR [[SHL]], [[LSHR1]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s64) = G_OR [[SHL]], [[LSHR1]]
     ; CHECK-NEXT: $x10 = COPY [[OR]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %3:_(s64) = COPY $x10
@@ -63,7 +63,7 @@ body:             |
     ; CHECK-NEXT: [[AND2:%[0-9]+]]:_(s64) = G_AND [[COPY1]], [[C3]]
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s64) = G_LSHR [[AND2]], [[C2]](s64)
     ; CHECK-NEXT: [[LSHR1:%[0-9]+]]:_(s64) = G_LSHR [[LSHR]], [[AND1]](s64)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s64) = disjoint G_OR [[SHL]], [[LSHR1]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s64) = G_OR [[SHL]], [[LSHR1]]
     ; CHECK-NEXT: $x10 = COPY [[OR]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %3:_(s64) = COPY $x10
@@ -101,7 +101,7 @@ body:             |
     ; CHECK-NEXT: [[AND2:%[0-9]+]]:_(s64) = G_AND [[COPY1]], [[C3]]
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s64) = G_LSHR [[AND2]], [[C2]](s64)
     ; CHECK-NEXT: [[SRLW:%[0-9]+]]:_(s64) = G_SRLW [[LSHR]], [[AND1]]
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s64) = disjoint G_OR [[SLLW]], [[SRLW]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s64) = G_OR [[SLLW]], [[SRLW]]
     ; CHECK-NEXT: $x10 = COPY [[OR]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %3:_(s64) = COPY $x10
@@ -171,7 +171,7 @@ body:             |
     ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s64) = G_CONSTANT i64 255
     ; CHECK-NEXT: [[AND2:%[0-9]+]]:_(s64) = G_AND [[COPY1]], [[C3]]
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s64) = G_LSHR [[AND2]], [[AND]](s64)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s64) = disjoint G_OR [[SHL1]], [[LSHR]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s64) = G_OR [[SHL1]], [[LSHR]]
     ; CHECK-NEXT: $x10 = COPY [[OR]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %3:_(s64) = COPY $x10
@@ -209,7 +209,7 @@ body:             |
     ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s64) = G_CONSTANT i64 65535
     ; CHECK-NEXT: [[AND2:%[0-9]+]]:_(s64) = G_AND [[COPY1]], [[C3]]
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s64) = G_LSHR [[AND2]], [[AND]](s64)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s64) = disjoint G_OR [[SHL1]], [[LSHR]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s64) = G_OR [[SHL1]], [[LSHR]]
     ; CHECK-NEXT: $x10 = COPY [[OR]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %3:_(s64) = COPY $x10
@@ -245,7 +245,7 @@ body:             |
     ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(s64) = G_SHL [[COPY]], [[C2]](s64)
     ; CHECK-NEXT: [[SLLW:%[0-9]+]]:_(s64) = G_SLLW [[SHL]], [[AND1]]
     ; CHECK-NEXT: [[SRLW:%[0-9]+]]:_(s64) = G_SRLW [[COPY1]], [[AND]]
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s64) = disjoint G_OR [[SLLW]], [[SRLW]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s64) = G_OR [[SLLW]], [[SRLW]]
     ; CHECK-NEXT: $x10 = COPY [[OR]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %3:_(s64) = COPY $x10

--- a/llvm/test/CodeGen/RISCV/GlobalISel/legalizer/legalize-rotate-rv32.mir
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/legalizer/legalize-rotate-rv32.mir
@@ -27,7 +27,7 @@ body:             |
     ; CHECK-NEXT: [[AND2:%[0-9]+]]:_(s32) = G_AND [[SUB]], [[C1]]
     ; CHECK-NEXT: [[AND3:%[0-9]+]]:_(s32) = G_AND [[COPY]], [[C2]]
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[AND3]], [[AND2]](s32)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = disjoint G_OR [[SHL]], [[LSHR]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[SHL]], [[LSHR]]
     ; CHECK-NEXT: $x10 = COPY [[OR]](s32)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %2:_(s32) = COPY $x10
@@ -61,7 +61,7 @@ body:             |
     ; CHECK-NEXT: [[AND2:%[0-9]+]]:_(s32) = G_AND [[SUB]], [[C1]]
     ; CHECK-NEXT: [[AND3:%[0-9]+]]:_(s32) = G_AND [[COPY]], [[C2]]
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[AND3]], [[AND2]](s32)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = disjoint G_OR [[SHL]], [[LSHR]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[SHL]], [[LSHR]]
     ; CHECK-NEXT: $x10 = COPY [[OR]](s32)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %2:_(s32) = COPY $x10
@@ -192,7 +192,7 @@ body:             |
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[AND2]], [[AND1]](s32)
     ; CHECK-NEXT: [[AND3:%[0-9]+]]:_(s32) = G_AND [[SUB]], [[C1]]
     ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(s32) = G_SHL [[COPY]], [[AND3]](s32)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = disjoint G_OR [[LSHR]], [[SHL]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[LSHR]], [[SHL]]
     ; CHECK-NEXT: $x10 = COPY [[OR]](s32)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %2:_(s32) = COPY $x10
@@ -226,7 +226,7 @@ body:             |
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[AND2]], [[AND1]](s32)
     ; CHECK-NEXT: [[AND3:%[0-9]+]]:_(s32) = G_AND [[SUB]], [[C1]]
     ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(s32) = G_SHL [[COPY]], [[AND3]](s32)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = disjoint G_OR [[LSHR]], [[SHL]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[LSHR]], [[SHL]]
     ; CHECK-NEXT: $x10 = COPY [[OR]](s32)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %2:_(s32) = COPY $x10

--- a/llvm/test/CodeGen/RISCV/GlobalISel/legalizer/legalize-rotate-rv64.mir
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/legalizer/legalize-rotate-rv64.mir
@@ -27,7 +27,7 @@ body:             |
     ; CHECK-NEXT: [[AND2:%[0-9]+]]:_(s64) = G_AND [[SUB]], [[C1]]
     ; CHECK-NEXT: [[AND3:%[0-9]+]]:_(s64) = G_AND [[COPY]], [[C2]]
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s64) = G_LSHR [[AND3]], [[AND2]](s64)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s64) = disjoint G_OR [[SHL]], [[LSHR]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s64) = G_OR [[SHL]], [[LSHR]]
     ; CHECK-NEXT: $x10 = COPY [[OR]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %2:_(s64) = COPY $x10
@@ -61,7 +61,7 @@ body:             |
     ; CHECK-NEXT: [[AND2:%[0-9]+]]:_(s64) = G_AND [[SUB]], [[C1]]
     ; CHECK-NEXT: [[AND3:%[0-9]+]]:_(s64) = G_AND [[COPY]], [[C2]]
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s64) = G_LSHR [[AND3]], [[AND2]](s64)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s64) = disjoint G_OR [[SHL]], [[LSHR]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s64) = G_OR [[SHL]], [[LSHR]]
     ; CHECK-NEXT: $x10 = COPY [[OR]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %2:_(s64) = COPY $x10
@@ -93,7 +93,7 @@ body:             |
     ; RV64I-NEXT: [[SLLW:%[0-9]+]]:_(s64) = G_SLLW [[COPY]], [[AND]]
     ; RV64I-NEXT: [[AND1:%[0-9]+]]:_(s64) = G_AND [[SEXT_INREG]], [[C1]]
     ; RV64I-NEXT: [[SRLW:%[0-9]+]]:_(s64) = G_SRLW [[COPY]], [[AND1]]
-    ; RV64I-NEXT: [[OR:%[0-9]+]]:_(s64) = disjoint G_OR [[SLLW]], [[SRLW]]
+    ; RV64I-NEXT: [[OR:%[0-9]+]]:_(s64) = G_OR [[SLLW]], [[SRLW]]
     ; RV64I-NEXT: $x10 = COPY [[OR]](s64)
     ; RV64I-NEXT: PseudoRET implicit $x10
     ;
@@ -173,7 +173,7 @@ body:             |
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s64) = G_LSHR [[AND2]], [[AND1]](s64)
     ; CHECK-NEXT: [[AND3:%[0-9]+]]:_(s64) = G_AND [[SUB]], [[C1]]
     ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(s64) = G_SHL [[COPY]], [[AND3]](s64)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s64) = disjoint G_OR [[LSHR]], [[SHL]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s64) = G_OR [[LSHR]], [[SHL]]
     ; CHECK-NEXT: $x10 = COPY [[OR]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %2:_(s64) = COPY $x10
@@ -207,7 +207,7 @@ body:             |
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s64) = G_LSHR [[AND2]], [[AND1]](s64)
     ; CHECK-NEXT: [[AND3:%[0-9]+]]:_(s64) = G_AND [[SUB]], [[C1]]
     ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(s64) = G_SHL [[COPY]], [[AND3]](s64)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s64) = disjoint G_OR [[LSHR]], [[SHL]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s64) = G_OR [[LSHR]], [[SHL]]
     ; CHECK-NEXT: $x10 = COPY [[OR]](s64)
     ; CHECK-NEXT: PseudoRET implicit $x10
     %2:_(s64) = COPY $x10
@@ -239,7 +239,7 @@ body:             |
     ; RV64I-NEXT: [[SRLW:%[0-9]+]]:_(s64) = G_SRLW [[COPY]], [[AND]]
     ; RV64I-NEXT: [[AND1:%[0-9]+]]:_(s64) = G_AND [[SEXT_INREG]], [[C1]]
     ; RV64I-NEXT: [[SLLW:%[0-9]+]]:_(s64) = G_SLLW [[COPY]], [[AND1]]
-    ; RV64I-NEXT: [[OR:%[0-9]+]]:_(s64) = disjoint G_OR [[SRLW]], [[SLLW]]
+    ; RV64I-NEXT: [[OR:%[0-9]+]]:_(s64) = G_OR [[SRLW]], [[SLLW]]
     ; RV64I-NEXT: $x10 = COPY [[OR]](s64)
     ; RV64I-NEXT: PseudoRET implicit $x10
     ;

--- a/llvm/test/CodeGen/WebAssembly/GlobalISel/instructions/rotl.mir
+++ b/llvm/test/CodeGen/WebAssembly/GlobalISel/instructions/rotl.mir
@@ -19,7 +19,7 @@ body: |
     ; CHECK-NEXT: [[CONST_I32_2:%[0-9]+]]:i32 = CONST_I32 255, implicit-def dead $arguments
     ; CHECK-NEXT: [[AND_I32_:%[0-9]+]]:i32 = AND_I32 [[ARGUMENT_i32_]], [[CONST_I32_2]], implicit-def dead $arguments
     ; CHECK-NEXT: [[SHR_U_I32_:%[0-9]+]]:i32 = SHR_U_I32 [[AND_I32_]], [[CONST_I32_1]], implicit-def dead $arguments
-    ; CHECK-NEXT: [[OR_I32_:%[0-9]+]]:i32 = disjoint OR_I32 [[SHL_I32_]], [[SHR_U_I32_]], implicit-def dead $arguments
+    ; CHECK-NEXT: [[OR_I32_:%[0-9]+]]:i32 = OR_I32 [[SHL_I32_]], [[SHR_U_I32_]], implicit-def dead $arguments
     ; CHECK-NEXT: RETURN [[OR_I32_]], implicit-def $arguments
     %2:i32(i32) = ARGUMENT_i32 0, implicit $arguments
     %0:_(i8) = G_TRUNC %2(i32)
@@ -50,7 +50,7 @@ body: |
     ; CHECK-NEXT: [[CONST_I32_2:%[0-9]+]]:i32 = CONST_I32 255, implicit-def dead $arguments
     ; CHECK-NEXT: [[AND_I32_2:%[0-9]+]]:i32 = AND_I32 [[ARGUMENT_i32_]], [[CONST_I32_2]], implicit-def dead $arguments
     ; CHECK-NEXT: [[SHR_U_I32_:%[0-9]+]]:i32 = SHR_U_I32 [[AND_I32_2]], [[AND_I32_1]], implicit-def dead $arguments
-    ; CHECK-NEXT: [[OR_I32_:%[0-9]+]]:i32 = disjoint OR_I32 [[SHL_I32_]], [[SHR_U_I32_]], implicit-def dead $arguments
+    ; CHECK-NEXT: [[OR_I32_:%[0-9]+]]:i32 = OR_I32 [[SHL_I32_]], [[SHR_U_I32_]], implicit-def dead $arguments
     ; CHECK-NEXT: RETURN [[OR_I32_]], implicit-def $arguments
     %2:i32(i32) = ARGUMENT_i32 0, implicit $arguments
     %0:_(i8) = G_TRUNC %2(i32)
@@ -78,7 +78,7 @@ body: |
     ; CHECK-NEXT: [[CONST_I32_2:%[0-9]+]]:i32 = CONST_I32 65535, implicit-def dead $arguments
     ; CHECK-NEXT: [[AND_I32_:%[0-9]+]]:i32 = AND_I32 [[ARGUMENT_i32_]], [[CONST_I32_2]], implicit-def dead $arguments
     ; CHECK-NEXT: [[SHR_U_I32_:%[0-9]+]]:i32 = SHR_U_I32 [[AND_I32_]], [[CONST_I32_1]], implicit-def dead $arguments
-    ; CHECK-NEXT: [[OR_I32_:%[0-9]+]]:i32 = disjoint OR_I32 [[SHL_I32_]], [[SHR_U_I32_]], implicit-def dead $arguments
+    ; CHECK-NEXT: [[OR_I32_:%[0-9]+]]:i32 = OR_I32 [[SHL_I32_]], [[SHR_U_I32_]], implicit-def dead $arguments
     ; CHECK-NEXT: RETURN [[OR_I32_]], implicit-def $arguments
     %2:i32(i32) = ARGUMENT_i32 0, implicit $arguments
     %0:_(i16) = G_TRUNC %2(i32)
@@ -109,7 +109,7 @@ body: |
     ; CHECK-NEXT: [[CONST_I32_2:%[0-9]+]]:i32 = CONST_I32 65535, implicit-def dead $arguments
     ; CHECK-NEXT: [[AND_I32_2:%[0-9]+]]:i32 = AND_I32 [[ARGUMENT_i32_]], [[CONST_I32_2]], implicit-def dead $arguments
     ; CHECK-NEXT: [[SHR_U_I32_:%[0-9]+]]:i32 = SHR_U_I32 [[AND_I32_2]], [[AND_I32_1]], implicit-def dead $arguments
-    ; CHECK-NEXT: [[OR_I32_:%[0-9]+]]:i32 = disjoint OR_I32 [[SHL_I32_]], [[SHR_U_I32_]], implicit-def dead $arguments
+    ; CHECK-NEXT: [[OR_I32_:%[0-9]+]]:i32 = OR_I32 [[SHL_I32_]], [[SHR_U_I32_]], implicit-def dead $arguments
     ; CHECK-NEXT: RETURN [[OR_I32_]], implicit-def $arguments
     %2:i32(i32) = ARGUMENT_i32 0, implicit $arguments
     %0:_(i16) = G_TRUNC %2(i32)

--- a/llvm/test/CodeGen/WebAssembly/GlobalISel/instructions/rotr.mir
+++ b/llvm/test/CodeGen/WebAssembly/GlobalISel/instructions/rotr.mir
@@ -19,7 +19,7 @@ body: |
     ; CHECK-NEXT: [[SHR_U_I32_:%[0-9]+]]:i32 = SHR_U_I32 [[AND_I32_]], [[CONST_I32_]], implicit-def dead $arguments
     ; CHECK-NEXT: [[CONST_I32_2:%[0-9]+]]:i32 = CONST_I32 3, implicit-def dead $arguments
     ; CHECK-NEXT: [[SHL_I32_:%[0-9]+]]:i32 = SHL_I32 [[ARGUMENT_i32_]], [[CONST_I32_2]], implicit-def dead $arguments
-    ; CHECK-NEXT: [[OR_I32_:%[0-9]+]]:i32 = disjoint OR_I32 [[SHR_U_I32_]], [[SHL_I32_]], implicit-def dead $arguments
+    ; CHECK-NEXT: [[OR_I32_:%[0-9]+]]:i32 = OR_I32 [[SHR_U_I32_]], [[SHL_I32_]], implicit-def dead $arguments
     ; CHECK-NEXT: RETURN [[OR_I32_]], implicit-def $arguments
     %2:i32(i32) = ARGUMENT_i32 0, implicit $arguments
     %0:_(i8) = G_TRUNC %2(i32)
@@ -50,7 +50,7 @@ body: |
     ; CHECK-NEXT: [[SHR_U_I32_:%[0-9]+]]:i32 = SHR_U_I32 [[AND_I32_1]], [[AND_I32_]], implicit-def dead $arguments
     ; CHECK-NEXT: [[AND_I32_2:%[0-9]+]]:i32 = AND_I32 [[SUB_I32_]], [[CONST_I32_1]], implicit-def dead $arguments
     ; CHECK-NEXT: [[SHL_I32_:%[0-9]+]]:i32 = SHL_I32 [[ARGUMENT_i32_]], [[AND_I32_2]], implicit-def dead $arguments
-    ; CHECK-NEXT: [[OR_I32_:%[0-9]+]]:i32 = disjoint OR_I32 [[SHR_U_I32_]], [[SHL_I32_]], implicit-def dead $arguments
+    ; CHECK-NEXT: [[OR_I32_:%[0-9]+]]:i32 = OR_I32 [[SHR_U_I32_]], [[SHL_I32_]], implicit-def dead $arguments
     ; CHECK-NEXT: RETURN [[OR_I32_]], implicit-def $arguments
     %2:i32(i32) = ARGUMENT_i32 0, implicit $arguments
     %0:_(i8) = G_TRUNC %2(i32)
@@ -78,7 +78,7 @@ body: |
     ; CHECK-NEXT: [[SHR_U_I32_:%[0-9]+]]:i32 = SHR_U_I32 [[AND_I32_]], [[CONST_I32_]], implicit-def dead $arguments
     ; CHECK-NEXT: [[CONST_I32_2:%[0-9]+]]:i32 = CONST_I32 3, implicit-def dead $arguments
     ; CHECK-NEXT: [[SHL_I32_:%[0-9]+]]:i32 = SHL_I32 [[ARGUMENT_i32_]], [[CONST_I32_2]], implicit-def dead $arguments
-    ; CHECK-NEXT: [[OR_I32_:%[0-9]+]]:i32 = disjoint OR_I32 [[SHR_U_I32_]], [[SHL_I32_]], implicit-def dead $arguments
+    ; CHECK-NEXT: [[OR_I32_:%[0-9]+]]:i32 = OR_I32 [[SHR_U_I32_]], [[SHL_I32_]], implicit-def dead $arguments
     ; CHECK-NEXT: RETURN [[OR_I32_]], implicit-def $arguments
     %2:i32(i32) = ARGUMENT_i32 0, implicit $arguments
     %0:_(i16) = G_TRUNC %2(i32)
@@ -109,7 +109,7 @@ body: |
     ; CHECK-NEXT: [[SHR_U_I32_:%[0-9]+]]:i32 = SHR_U_I32 [[AND_I32_1]], [[AND_I32_]], implicit-def dead $arguments
     ; CHECK-NEXT: [[AND_I32_2:%[0-9]+]]:i32 = AND_I32 [[SUB_I32_]], [[CONST_I32_1]], implicit-def dead $arguments
     ; CHECK-NEXT: [[SHL_I32_:%[0-9]+]]:i32 = SHL_I32 [[ARGUMENT_i32_]], [[AND_I32_2]], implicit-def dead $arguments
-    ; CHECK-NEXT: [[OR_I32_:%[0-9]+]]:i32 = disjoint OR_I32 [[SHR_U_I32_]], [[SHL_I32_]], implicit-def dead $arguments
+    ; CHECK-NEXT: [[OR_I32_:%[0-9]+]]:i32 = OR_I32 [[SHR_U_I32_]], [[SHL_I32_]], implicit-def dead $arguments
     ; CHECK-NEXT: RETURN [[OR_I32_]], implicit-def $arguments
     %2:i32(i32) = ARGUMENT_i32 0, implicit $arguments
     %0:_(i16) = G_TRUNC %2(i32)

--- a/llvm/unittests/CodeGen/GlobalISel/LegalizerHelperTest.cpp
+++ b/llvm/unittests/CodeGen/GlobalISel/LegalizerHelperTest.cpp
@@ -1898,6 +1898,57 @@ TEST_F(AArch64GISelMITest, WidenScalarMergeValuesPointer) {
   EXPECT_TRUE(CheckMachineFunction(*MF, CheckStr)) << *MF;
 }
 
+TEST_F(AArch64GISelMITest, WidenScalarFlags) {
+  setUp();
+  if (!TM)
+    GTEST_SKIP();
+
+  DefineLegalizerInfo(A, {});
+
+  const LLT S8 = LLT::scalar(8);
+  const LLT S16 = LLT::scalar(16);
+  const unsigned NoWrapFlags = MachineInstr::NoUWrap | MachineInstr::NoSWrap;
+
+  auto One8 = B.buildConstant(S8, 1);
+  auto Two8 = B.buildConstant(S8, 2);
+  auto One16 = B.buildConstant(S16, 1);
+
+  SmallVector<MachineInstr *, 3> NoWrapOps;
+  for (unsigned Opcode :
+       {TargetOpcode::G_ADD, TargetOpcode::G_SUB, TargetOpcode::G_MUL})
+    NoWrapOps.push_back(
+        B.buildInstr(Opcode, {S8}, {One8, Two8}, NoWrapFlags).getInstr());
+  auto Or = B.buildOr(S8, One8, Two8, MachineInstr::Disjoint);
+  auto ShlValue = B.buildShl(S8, One8, One8, NoWrapFlags);
+  auto ShlAmount = B.buildShl(S16, One16, One8, NoWrapFlags);
+
+  AInfo Info(MF->getSubtarget());
+  DummyGISelObserver Observer;
+  LegalizerHelper Helper(*MF, Info, Observer, B);
+
+  for (MachineInstr *MI : NoWrapOps) {
+    B.setInstr(*MI);
+    EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
+              Helper.widenScalar(*MI, 0, S16));
+    EXPECT_EQ(0u, MI->getFlags() & NoWrapFlags);
+  }
+
+  B.setInstr(*Or);
+  EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
+            Helper.widenScalar(*Or, 0, S16));
+  EXPECT_FALSE(Or->getFlag(MachineInstr::Disjoint));
+
+  B.setInstr(*ShlValue);
+  EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
+            Helper.widenScalar(*ShlValue, 0, S16));
+  EXPECT_EQ(0u, ShlValue->getFlags() & NoWrapFlags);
+
+  B.setInstr(*ShlAmount);
+  EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
+            Helper.widenScalar(*ShlAmount, 1, S16));
+  EXPECT_EQ(NoWrapFlags, ShlAmount->getFlags() & NoWrapFlags);
+}
+
 TEST_F(AArch64GISelMITest, WidenSEXTINREG) {
   setUp();
   if (!TM)

--- a/llvm/unittests/CodeGen/GlobalISel/LegalizerHelperTest.cpp
+++ b/llvm/unittests/CodeGen/GlobalISel/LegalizerHelperTest.cpp
@@ -1913,11 +1913,11 @@ TEST_F(AArch64GISelMITest, WidenScalarFlags) {
   auto Two8 = B.buildConstant(S8, 2);
   auto One16 = B.buildConstant(S16, 1);
 
-  SmallVector<MachineInstr *, 3> NoWrapOps;
-  for (unsigned Opcode :
-       {TargetOpcode::G_ADD, TargetOpcode::G_SUB, TargetOpcode::G_MUL})
-    NoWrapOps.push_back(
-        B.buildInstr(Opcode, {S8}, {One8, Two8}, NoWrapFlags).getInstr());
+  MachineInstr *NoWrapOps[] = {
+      B.buildAdd(S8, One8, Two8, NoWrapFlags).getInstr(),
+      B.buildSub(S8, Two8, One8, NoWrapFlags).getInstr(),
+      B.buildMul(S8, One8, Two8, NoWrapFlags).getInstr(),
+  };
   auto Or = B.buildOr(S8, One8, Two8, MachineInstr::Disjoint);
   auto ShlValue = B.buildShl(S8, One8, One8, NoWrapFlags);
   auto ShlAmount = B.buildShl(S16, One16, One8, NoWrapFlags);


### PR DESCRIPTION
nuw/nsw/disjoint flags are only true at the original width. G_ANYEXT leaves the new high bits unconstrained, so they must be dropped.