### PR TITLE
[Analysis] Fix the build

### DIFF
--- a/llvm/lib/Analysis/AliasSetTracker.cpp
+++ b/llvm/lib/Analysis/AliasSetTracker.cpp
@@ -333,7 +333,7 @@ void AliasSetTracker::addWithoutAATags(StoreInst *SI) {
   assert(!isStrongerThanMonotonic(SI->getOrdering()) &&
          "Can't handle release stores here");
   addMemoryLocation(MemoryLocation::get(SI).getWithoutAATags(),
-                    AliasSet::ModAccess);
+                    ModRefInfo::Mod);
 }
 
 void AliasSetTracker::add(VAArgInst *VAAI) {


### PR DESCRIPTION
This patch fixes:

  llvm/lib/Analysis/AliasSetTracker.cpp:336:31: error: no member named
  'ModAccess' in 'llvm::AliasSet'
