### PR TITLE
[clang][Parse] Fix DeclContext reentry to use the template's lexical TU, not the current fragment's TU

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -532,6 +532,7 @@ features cannot lower the translation-unit ABI level;
   definition of a member of a class template added a default argument to a
   parameter that follows a parameter pack (e.g.
   `template <typename... T> S::S(T..., int = 10) {}`).  (#GH216211)
+- Fixed an assertion failure when instantiating a late-parsed function template defined in an earlier translation unit with -fdelayed-template-parsing. (#GH217073)
 
 #### Bug Fixes to AST Handling
 

--- a/clang/lib/Parse/ParseTemplate.cpp
+++ b/clang/lib/Parse/ParseTemplate.cpp
@@ -1451,17 +1451,25 @@ void Parser::ParseLateTemplatedFuncDef(LateParsedTemplate &LPT) {
   // Track template parameter depth.
   TemplateParameterDepthRAII CurTemplateDepthTracker(TemplateParameterDepth);
 
-  // To restore the context after late parsing.
-  Sema::ContextRAII GlobalSavedContext(
-      Actions, Actions.Context.getTranslationUnitDecl());
-
   MultiParseScope Scopes(*this);
 
   // Get the list of DeclContexts to reenter.
   SmallVector<DeclContext*, 4> DeclContextsToReenter;
-  for (DeclContext *DC = FunD; DC && !DC->isTranslationUnit();
-       DC = DC->getLexicalParent())
+  DeclContext *LexicalTU = nullptr;
+  for (DeclContext *DC = FunD; DC; DC = DC->getLexicalParent()) {
+    if (DC->isTranslationUnit()) {
+      LexicalTU = DC;
+      break;
+    }
     DeclContextsToReenter.push_back(DC);
+  }
+
+  if (!LexicalTU) {
+    LexicalTU = Actions.Context.getTranslationUnitDecl();
+  }
+
+  // To restore the context after late parsing.
+  Sema::ContextRAII GlobalSavedContext(Actions, LexicalTU);
 
   // Reenter scopes from outermost to innermost.
   for (DeclContext *DC : reverse(DeclContextsToReenter)) {

--- a/clang/test/Interpreter/delayed-template-parsing-incremental.cpp
+++ b/clang/test/Interpreter/delayed-template-parsing-incremental.cpp
@@ -1,0 +1,7 @@
+// clang/test/Interpreter/delayed-template-parsing.cpp
+// REQUIRES: host-supports-jit
+// RUN: cat %s | clang-repl -Xcc -fdelayed-template-parsing 2>&1
+// see ISSUE 217073 and PR 218571
+
+namespace GH217073{ template <typename T> int f(T) { return 0; } }
+GH217073::f(1);


### PR DESCRIPTION
Problem:
when  `-fdelayed-template-parsing` is enabled Instantiating a late-parsed function template defined in an earlier TU caused an assertion failure in `clang::Sema::PushDeclContext`:

``DC->getLexicalParent() == CurContext && "The next DeclContext should be lexically contained in the current one."'`

Fix:
- 1 in `Parser::ParseLateTemplatedFuncDef` obtained the enclosing `TranslationUnitDecl` called it `LexicalTU` 
- 2 changed `GlobalSavedContext` with the `LexicalTU` instead of using `Actions.Context.getTranslationUnitDecl()` 
- in the case that no `LexicalTU` was found fellback to `Actions.Context.getTranslationUnitDecl()`
 
Fixes #217073