### PR TITLE
[Clang] Fix C++26 fold expression normalization of PackIndexingExpr

### DIFF
--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -269,6 +269,12 @@ public:
     return Result;
   }
 
+  QualType TransformPackIndexingType(TypeLocBuilder &TLB,
+                                     PackIndexingTypeLoc TL) {
+    llvm::SaveAndRestore _1(RemoveNonPackExpansionPacks, false);
+    return inherited::TransformPackIndexingType(TLB, TL);
+  }
+
   bool AlreadyTransformed(QualType T) {
     if (T.isNull())
       return true;

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -7124,10 +7124,6 @@ TreeTransform<Derived>::TransformPackIndexingType(TypeLocBuilder &TLB,
 
   for (QualType T : Types) {
     if (!T->containsUnexpandedParameterPack()) {
-      // A pack indexing type can appear in a larger pack expansion,
-      // e.g. `Pack...[pack_of_indexes]...`
-      // so we need to temporarily disable substitution of pack elements
-      Sema::ArgPackSubstIndexRAII SubstIndex(getSema(), std::nullopt);
       QualType Transformed = getDerived().TransformType(T);
       if (Transformed.isNull())
         return QualType();

--- a/clang/test/SemaCXX/cxx2c-fold-exprs.cpp
+++ b/clang/test/SemaCXX/cxx2c-fold-exprs.cpp
@@ -641,3 +641,21 @@ void f()
 void g() { f<long long, float>(); }
 
 }
+
+namespace GH218548 {
+
+template <class T>
+concept same_as_impl = sizeof(T) == 2;
+template <typename... P>
+void f() requires(same_as_impl<P...[sizeof(P)]> && ...) // #GH218548_f
+{}
+void g() {
+  f<char, short, short>();
+
+  f<char, int, short>();
+  // expected-error@-1 {{no matching function}}
+  // expected-note@#GH218548_f {{constraints not satisfied}}
+  // expected-note@#GH218548_f {{invalid index}}
+}
+
+}


### PR DESCRIPTION
It turns out that PackIndexingExpr doesn't create any PackExpansionTypes for unexpanded packs and thus we don't have to remove the packs during the normalization.

This also reverts the previous attempt f3fd5b2dd9 that doesn't completely solve the problem.

Fixes #218548
