### PR TITLE
[ConstraintElim] Avoid overflow when negating offsets

### DIFF
--- a/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
@@ -776,7 +776,8 @@ ConstraintInfo::getConstraint(CmpInst::Predicate Pred, Value *Op0, Value *Op1,
                         IsSigned, DL);
   int64_t Offset1 = ADec.Offset;
   int64_t Offset2 = BDec.Offset;
-  Offset1 *= -1;
+  if (MulOverflow(Offset1, int64_t(-1), Offset1))
+    return {};
 
   auto &VariablesA = ADec.Vars;
   auto &VariablesB = BDec.Vars;

--- a/llvm/test/Transforms/ConstraintElimination/constraint-overflow.ll
+++ b/llvm/test/Transforms/ConstraintElimination/constraint-overflow.ll
@@ -193,3 +193,25 @@ then:
 else:
   ret i1 false
 }
+
+; The offset of %a is INT64_MIN. Negating it overflows, so no constraint can
+; be built for the assume. Make sure %r is not folded to true.
+define i1 @constraint_offset_negation_overflow(i64 %x) {
+; CHECK-LABEL: define i1 @constraint_offset_negation_overflow(
+; CHECK-SAME: i64 [[X:%.*]]) {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[A0:%.*]] = add nsw i64 [[X]], -9223372036854775807
+; CHECK-NEXT:    [[A:%.*]] = add nsw i64 [[A0]], -1
+; CHECK-NEXT:    [[A_NONPOS:%.*]] = icmp sle i64 [[A]], 0
+; CHECK-NEXT:    call void @llvm.assume(i1 [[A_NONPOS]])
+; CHECK-NEXT:    [[R:%.*]] = icmp slt i64 [[X]], 0
+; CHECK-NEXT:    ret i1 [[R]]
+;
+entry:
+  %a0 = add nsw i64 %x, -9223372036854775807
+  %a = add nsw i64 %a0, -1
+  %a.nonpos = icmp sle i64 %a, 0
+  call void @llvm.assume(i1 %a.nonpos)
+  %r = icmp slt i64 %x, 0
+  ret i1 %r
+}


### PR DESCRIPTION
This patch fixes a miscompilation in ConstraintElimination caused by negating an INT64_MIN offset while constructing a constraint.

Use MulOverflow when negating the decomposed offset and skip constraint construction if the negation overflows. Add a regression test for the reported reproducer in Issue #218569.

Before this change, the reproducer was incorrectly folded to `ret i1 true`. After this change, the comparison is preserved.

Tests:
- build-cir/bin/llvm-lit llvm/test/Transforms/ConstraintElimination/constraint-overflow.ll