### PR TITLE
[libc] Add <grp.h> POSIX header.

### DIFF
--- a/libc/config/linux/aarch64/headers.txt
+++ b/libc/config/linux/aarch64/headers.txt
@@ -16,6 +16,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.features
     libc.include.fenv
     libc.include.float
+    libc.include.grp
     libc.include.inttypes
     libc.include.langinfo
     libc.include.libgen

--- a/libc/config/linux/riscv/headers.txt
+++ b/libc/config/linux/riscv/headers.txt
@@ -16,6 +16,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.features
     libc.include.fenv
     libc.include.float
+    libc.include.grp
     libc.include.inttypes
     libc.include.langinfo
     libc.include.libgen

--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -16,6 +16,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.features
     libc.include.fenv
     libc.include.float
+    libc.include.grp
     libc.include.inttypes
     libc.include.langinfo
     libc.include.libgen

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -155,6 +155,17 @@ add_header_macro(
 )
 
 add_header_macro(
+  grp
+  ../libc/include/grp.yaml
+  grp.h
+  DEPENDS
+    .llvm-libc-types.struct_group
+    .llvm-libc-types.gid_t
+    .llvm-libc-types.size_t
+    .llvm_libc_common_h
+)
+
+add_header_macro(
   libgen
   ../libc/include/libgen.yaml
   libgen.h

--- a/libc/include/grp.yaml
+++ b/libc/include/grp.yaml
@@ -1,0 +1,10 @@
+header: grp.h
+standards:
+  - posix
+types:
+  - type_name: struct_group
+  - type_name: gid_t
+  - type_name: size_t
+enums: []
+objects: []
+functions: []

--- a/libc/include/llvm-libc-types/CMakeLists.txt
+++ b/libc/include/llvm-libc-types/CMakeLists.txt
@@ -216,6 +216,7 @@ add_header(
 )
 add_header(struct_tm HDR struct_tm.h)
 add_header(struct_passwd HDR struct_passwd.h DEPENDS .uid_t .gid_t)
+add_header(struct_group HDR struct_group.h DEPENDS .gid_t)
 if(TARGET libc.include.llvm-libc-types.${LIBC_TARGET_OS}.struct_sysinfo)
   add_header(struct_sysinfo HDR struct_sysinfo.h DEPENDS .${LIBC_TARGET_OS}.struct_sysinfo)
 else()

--- a/libc/include/llvm-libc-types/struct_group.h
+++ b/libc/include/llvm-libc-types/struct_group.h
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of struct group.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_STRUCT_GROUP_H
+#define LLVM_LIBC_TYPES_STRUCT_GROUP_H
+
+#include "gid_t.h"
+
+// Structure representing group information in the group database.
+struct group {
+  char *gr_name;   // The name of the group.
+  char *gr_passwd; // Group password.
+  gid_t gr_gid;    // Numerical group ID.
+  char **gr_mem;   // Pointer to a null-terminated array of member names.
+};
+
+#endif // LLVM_LIBC_TYPES_STRUCT_GROUP_H


### PR DESCRIPTION
This PR adds a POSIX header `<grp.h>` and a definition for `struct group` type (plus standard-mandated references to `gid_t` and `size_t`).

It doesn't yet declare / implement functions for iterating over group database, those would be added in later PRs, basing off the WIP work for passwd entries.

Assisted by: Gemini