### PR TITLE
[flang-rt][OpenMP] fix buildbot failures after commit 01079d2605aabd0beccecb270f51d40119422f04

### DIFF
--- a/flang-rt/lib/runtime/CMakeLists.txt
+++ b/flang-rt/lib/runtime/CMakeLists.txt
@@ -325,7 +325,8 @@ endif ()
 # Include the Fortran OpenMP module implementation (omp_lib.o) in
 # libflang_rt.runtime when the OpenMP runtime is also being built.
 # Skip for GPU-default targets: omp_lib is a host-side Fortran module.
-if (TARGET libomp-mod AND NOT "${LLVM_DEFAULT_TARGET_TRIPLE}" MATCHES "^amdgcn|^nvptx")
+if (TARGET libomp-mod AND NOT "${LLVM_DEFAULT_TARGET_TRIPLE}" MATCHES "^amdgcn|^nvptx"
+    AND NOT FLANG_RT_EXPERIMENTAL_OFFLOAD_SUPPORT STREQUAL "CUDA")
   list(APPEND sources "$<TARGET_OBJECTS:libomp-mod>")
 endif ()
 


### PR DESCRIPTION

The commit that introduced integer kind wrappers in libomp-mod caused a regression in CUDA Flang runtime builds. This change resolves the issue by skipping the build of libomp-mod for experimental CUDA offload configurations, ensuring that host-side Fortran objects are not included in the CUDA/PTX compilation path.

Fixes: https://lab.llvm.org/buildbot/#/builders/152