### PR TITLE
Followup for #218572 broken build bots

### DIFF
--- a/clang/test/Analysis/Scalable/source-edit-generation/coexistence.cpp
+++ b/clang/test/Analysis/Scalable/source-edit-generation/coexistence.cpp
@@ -6,7 +6,7 @@
 
 // REQUIRES: plugins
 
-// XFAIL: *
+// UNSUPPORTED: *
 
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %clang_cc1 -load %llvmshlibdir/SSAFTestTransformationPlugin%pluginext \

--- a/clang/test/Analysis/Scalable/source-edit-generation/happy-path.cpp
+++ b/clang/test/Analysis/Scalable/source-edit-generation/happy-path.cpp
@@ -7,7 +7,7 @@
 
 // REQUIRES: plugins
 
-// XFAIL: *
+// UNSUPPORTED: *
 
 
 // RUN: rm -rf %t && mkdir -p %t

--- a/clang/test/Analysis/Scalable/source-edit-generation/write-failure.cpp
+++ b/clang/test/Analysis/Scalable/source-edit-generation/write-failure.cpp
@@ -5,7 +5,7 @@
 
 // REQUIRES: plugins
 
-// XFAIL: *
+// UNSUPPORTED: *
 
 // RUN: rm -rf %t && mkdir -p %t
 


### PR DESCRIPTION
The PR intended to workaround some failing internal build bots tracked as rdar://185749574

However, this (7c9ba667766060d112e5851879c305a45d035034) itself caused upstream build bots to fail:
https://lab.llvm.org/buildbot/#/builders/225/builds/16454
https://lab.llvm.org/buildbot/#/builders/144/builds/63036
https://lab.llvm.org/buildbot/#/builders/27/builds/4103
https://lab.llvm.org/buildbot/#/builders/65/builds/39394
https://lab.llvm.org/buildbot/#/builders/190/builds/48503
https://lab.llvm.org/buildbot/#/builders/154/builds/35610
https://lab.llvm.org/buildbot/#/builders/174/builds/40232

For example:
```
XPASS: Clang :: Analysis/Scalable/source-edit-generation/happy-path.cpp (2274 of 111631)
******************** TEST 'Clang :: Analysis/Scalable/source-edit-generation/happy-path.cpp' FAILED ********************
```
and
```
XPASS: Clang :: Analysis/Scalable/source-edit-generation/write-failure.cpp (8964 of 98502)
******************** TEST 'Clang :: Analysis/Scalable/source-edit-generation/write-failure.cpp' FAILED ********************
```

Let's opt for using `UNSUPPORTED` for these tests until the breakage is fixed.