### PR TITLE
[offload] Give libLLVMOffloadKernel a working rpath in a shared-library build

### DIFF
--- a/offload/languages/kernel/CMakeLists.txt
+++ b/offload/languages/kernel/CMakeLists.txt
@@ -66,6 +66,7 @@ target_compile_definitions(LLVMOffloadKernel PRIVATE
 
 set_target_properties(LLVMOffloadKernel PROPERTIES
                       RUNTIME_OUTPUT_DIRECTORY "${LLVM_LIBRARY_OUTPUT_INTDIR}/${OFFLOAD_TARGET_SUBDIR}"
+                      LIBRARY_OUTPUT_DIRECTORY "${LLVM_LIBRARY_OUTPUT_INTDIR}/${OFFLOAD_TARGET_SUBDIR}"
                       POSITION_INDEPENDENT_CODE ON
                       INSTALL_RPATH "$ORIGIN"
                       BUILD_RPATH "$ORIGIN:${CMAKE_CURRENT_BINARY_DIR}/..")


### PR DESCRIPTION
libLLVMOffloadKernel links against libLLVMOffload and finds it through an
`$ORIGIN` rpath, which resolves only if the two land in the same directory.
`add_llvm_library` puts the kernel library in LLVM's `lib` while libLLVMOffload
is in `lib/<triple>`, so every test that loads it fails at startup with

    libLLVMOffload.so: cannot open shared object file: No such file or directory

Set `LIBRARY_OUTPUT_DIRECTORY` the way `RUNTIME_OUTPUT_DIRECTORY` already is.

## Testing

Rebased onto `main` at aa332ae6b0c9, which now carries #215557; that gives the
libraries an rpath to LLVM's `lib`, and this leaves the one line that keeps a
second copy of the kernel library out of it. CMake only, no test changes. With
shared libraries and `LLVM_ENABLE_RUNTIMES=...;openmp;offload`, a build without
this patch leaves a stale `lib/libLLVMOffloadKernel.so` that the 26
`offloading/{HIP,CUDA}` tests pick up ahead of the good one in
`lib/<triple>` and fail to load; with it they pass.