### PR TITLE
[ConstFold] Avoid overflows in folding fixed ALM

### DIFF
--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -4367,12 +4367,14 @@ static Constant *ConstantFoldFixedVectorCall(
     auto *Op1 = dyn_cast<ConstantInt>(Operands[1]);
     if (Op0 && Op1) {
       unsigned Lanes = FVTy->getNumElements();
-      uint64_t Base = Op0->getZExtValue();
-      uint64_t Limit = Op1->getZExtValue();
+      APInt Base = Op0->getValue();
+      APInt Limit = Op1->getValue();
 
       SmallVector<Constant *, 16> NCs;
-      for (unsigned i = 0; i < Lanes; i++) {
-        if (Base + i < Limit)
+      for (unsigned I = 0; I < Lanes; I++) {
+        bool Overflow;
+        if (Base.uadd_ov(APInt(Base.getBitWidth(), I), Overflow).ult(Limit) &&
+            !Overflow)
           NCs.push_back(ConstantInt::getTrue(Ty));
         else
           NCs.push_back(ConstantInt::getFalse(Ty));

--- a/llvm/test/Transforms/InstSimplify/ConstProp/active-lane-mask.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/active-lane-mask.ll
@@ -370,6 +370,21 @@ entry:
   ret <vscale x 16 x i1> %mask
 }
 
+define <16 x i1> @base_overflow() {
+; CHECK-LABEL: @base_overflow(
+; CHECK-NEXT:    ret <16 x i1> <i1 true, i1 true, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false>
+;
+  %mask = call <16 x i1> @llvm.get.active.lane.mask.v16i1.i64(i64 -3, i64 -1)
+  ret <16 x i1> %mask
+}
+
+define <16 x i1> @int_overflow() {
+; CHECK-LABEL: @int_overflow(
+; CHECK-NEXT:    ret <16 x i1> <i1 true, i1 true, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false>
+;
+  %mask = call <16 x i1> @llvm.get.active.lane.mask.v16i1.i128(i128 -3, i128 -1)
+  ret <16 x i1> %mask
+}
 
 declare <4 x i1> @llvm.get.active.lane.mask.v4i1.i32(i32, i32)
 declare <8 x i1> @llvm.get.active.lane.mask.v8i1.i32(i32, i32)


### PR DESCRIPTION
Avoid overflows in folding fixed-vector get.active.lane.mask using APInts and APInt::uadd_ov.