### PR TITLE
[libc++][NFC] Refactor new.ipp so the _impl functions take a failure mode argument

### DIFF
--- a/libcxx/src/support/new.ipp
+++ b/libcxx/src/support/new.ipp
@@ -23,6 +23,12 @@ void __throw_bad_alloc_shim();
 #  define _LIBCPP_ASSERT_SHIM
 #endif
 
+enum class on_failure {
+  return_null,
+  throw_bad_alloc,
+};
+
+template <on_failure failure_mode>
 static void* operator_new_impl(std::size_t size) {
   if (size == 0)
     size = 1;
@@ -36,14 +42,13 @@ static void* operator_new_impl(std::size_t size) {
     else
       break;
   }
+  if (failure_mode == on_failure::throw_bad_alloc && !p)
+    __throw_bad_alloc_shim();
   return p;
 }
 
 OVERRIDABLE_FUNCTION void* operator new(std::size_t size) _THROW_BAD_ALLOC {
-  void* p = operator_new_impl(size);
-  if (p == nullptr)
-    __throw_bad_alloc_shim();
-  return p;
+  return operator_new_impl<on_failure::throw_bad_alloc>(size);
 }
 
 [[gnu::weak]] void* operator new(size_t size, const std::nothrow_t&) noexcept {
@@ -59,7 +64,7 @@ OVERRIDABLE_FUNCTION void* operator new(std::size_t size) _THROW_BAD_ALLOC {
       "`operator new(size_t, nothrow_t)` as well.");
 #  endif
 
-  return operator_new_impl(size);
+  return operator_new_impl<on_failure::return_null>(size);
 #else
   void* p = nullptr;
   try {
@@ -85,7 +90,7 @@ OVERRIDABLE_FUNCTION void* operator new[](size_t size) _THROW_BAD_ALLOC { return
       "`operator new[](size_t, nothrow_t)` as well.");
 #  endif
 
-  return operator_new_impl(size);
+  return operator_new_impl<on_failure::return_null>(size);
 #else
   void* p = nullptr;
   try {
@@ -110,6 +115,7 @@ OVERRIDABLE_FUNCTION void* operator new[](size_t size) _THROW_BAD_ALLOC { return
 
 #if _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION
 
+template <on_failure failure_mode>
 static void* operator_new_aligned_impl(std::size_t size, std::align_val_t alignment) {
   if (size == 0)
     size = 1;
@@ -127,14 +133,13 @@ static void* operator_new_aligned_impl(std::size_t size, std::align_val_t alignm
     else
       break;
   }
+  if (failure_mode == on_failure::throw_bad_alloc && !p)
+    __throw_bad_alloc_shim();
   return p;
 }
 
 OVERRIDABLE_FUNCTION void* operator new(std::size_t size, std::align_val_t alignment) _THROW_BAD_ALLOC {
-  void* p = operator_new_aligned_impl(size, alignment);
-  if (p == nullptr)
-    __throw_bad_alloc_shim();
-  return p;
+  return operator_new_aligned_impl<on_failure::throw_bad_alloc>(size, alignment);
 }
 
 [[gnu::weak]] void* operator new(size_t size, std::align_val_t alignment, const std::nothrow_t&) noexcept {
@@ -150,7 +155,7 @@ OVERRIDABLE_FUNCTION void* operator new(std::size_t size, std::align_val_t align
       "`operator new(size_t, align_val_t, nothrow_t)` as well.");
 #    endif
 
-  return operator_new_aligned_impl(size, alignment);
+  return operator_new_aligned_impl<on_failure::return_null>(size, alignment);
 #  else
   void* p = nullptr;
   try {
@@ -178,7 +183,7 @@ OVERRIDABLE_FUNCTION void* operator new[](size_t size, std::align_val_t alignmen
       "override `operator new[](size_t, align_val_t, nothrow_t)` as well.");
 #    endif
 
-  return operator_new_aligned_impl(size, alignment);
+  return operator_new_aligned_impl<on_failure::return_null>(size, alignment);
 #  else
   void* p = nullptr;
   try {


### PR DESCRIPTION
This avoids duplicating the failure path everywhere we use these functions. It also makes it more explicit what the intended failure path is.