### PR TITLE
[clang] fix the empty struct acceptance without a memeber-declaration-list

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -20542,7 +20542,8 @@ void Sema::ActOnFields(Scope *S, SourceLocation RecLoc, Decl *EnclosingDecl,
       // Structs without named members are extension in C (C99 6.7.2.1p7),
       // but are accepted by GCC. In C2y, this became implementation-defined
       // (C2y 6.7.3.2p10).
-      if (NonBitFields == 0 && !getLangOpts().CPlusPlus && !getLangOpts().C2y) {
+      if (NonBitFields == 0 && !getLangOpts().CPlusPlus &&
+          (!getLangOpts().C2y || IsEmpty)) {
         Diag(RecLoc, IsEmpty ? diag::ext_empty_struct_union
                              : diag::ext_no_named_members_in_struct_union)
             << Record->isUnion();

--- a/clang/test/C/C2y/n3341.c
+++ b/clang/test/C/C2y/n3341.c
@@ -4,15 +4,22 @@
 /* WG14 N3341: Yes
  * Slay Some Earthly Demons III
  *
- * Empty structure and union objects are now implementation-defined.
+ * Structure and union objects with a member declaration list but no named
+ * members are now implementation-defined.
  */
 
-// expected-no-diagnostics
-
-struct R {};               // gnu-warning {{empty struct is a GNU extension}}
+struct R {};               // expected-warning {{empty struct is a GNU extension}} \
+                           // gnu-warning {{empty struct is a GNU extension}}
 #if __STDC_VERSION__ >= 201112L
-struct S { struct { }; };  // gnu-warning {{empty struct is a GNU extension}}
+struct S { struct { }; };  // expected-warning {{empty struct is a GNU extension}} \
+                           // gnu-warning {{empty struct is a GNU extension}}
 #endif
 struct T { int : 0; };     // gnu-warning {{struct without named members is a GNU extension}}
-union U {};                // gnu-warning {{empty union is a GNU extension}}
+union U {};                // expected-warning {{empty union is a GNU extension}} \
+                           // gnu-warning {{empty union is a GNU extension}}
 
+void compound_literal_empty_record(void) {
+  (void)(struct {}){};     // expected-warning {{empty struct is a GNU extension}} \
+                           // gnu-warning {{empty struct is a GNU extension}} \
+                           // gnu-warning {{use of an empty initializer is a C23 extension}}
+}


### PR DESCRIPTION
Clang was accepting (struct{}){} which was supposed to be rejected according to the n3341 document.

Updated the regressed test to handle this.

Fixes #218298 