### PR TITLE
[OpenMP] Make map-type-modifier repeatable in 4.5

### DIFF
--- a/llvm/lib/Frontend/OpenMP/OMPDescriptors.inc
+++ b/llvm/lib/Frontend/OpenMP/OMPDescriptors.inc
@@ -2024,7 +2024,7 @@
     descriptor::Modifier(
       "map-type-modifier",
       {
-        {45, {{{Property::MapTypeModifying, Property::Unique}}, {Clause::OMPC_map}}},
+        {45, {{{Property::MapTypeModifying, Property::Repeatable}}, {Clause::OMPC_map}}},
         {50, {{{Property::MapTypeModifying, Property::Repeatable}}, {Clause::OMPC_map}}},
         {51, {{{Property::MapTypeModifying, Property::Repeatable}}, {Clause::OMPC_map}}},
         {52, {{{Property::MapTypeModifying, Property::Repeatable}}, {Clause::OMPC_map}}},


### PR DESCRIPTION
This is either a temporary hack to allow gfortran tests to pass, or a change to make the behavior of the mep-type-modifier consistent across OpenMP versions.

The map-type-modifier in OpenMP 4.5 can only take one value: the keyword ALWAYS. It doesn't make sense for it to be repeated. At the same time later versions introduced additional keywords: CLOSE and then PRESENT. Any specific keyword can only appear once, but the modifier itself is repeatable. In version 5.2 the modifier was (unintentionally) unique although the actual intent remained the same.

With that in mind the map-type-modifier in 4.5 can be treated either as a repeatable modifier with the per-keyword uniqueness restriction (as it is in later versions), or a a unique modifier.

The former interpretation has the benefit of uniformity across versions, plus it works around an issue in the gfortran test suite: Flang's default OpenMP version is 3.1, but the semantics analysis assumes 4.5 as the minimum, making it the de facto default version. The gfortran test suite has tests using OpenMP features introduced in later OpenMP specs, and compiles them without setting the OpenMP version. With stricter version conformance checking, these tests fail simply due to the wrong OpenMP version for the features being tested. Making the map-type-modifier repeatable in 4.5 avoids a couple of regressions caused by that mismatch.