### PR TITLE
workflows/release-binaries: Fix setting Wix PATH for ARM64 Windows

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -292,7 +292,7 @@ jobs:
       run: |
         choco install wixtoolset --version 3.14.1.20250415
         # Add wix install directory to PATH.
-        Split-Path (Get-ChildItem -Path "C:\" -Filter candle.exe -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1).FullName
+        Split-Path (Get-ChildItem -Path "C:\" -Filter candle.exe -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1).FullName >> $env:GITHUB_PATH
 
     - name: Build Windows
       id: build-windows


### PR DESCRIPTION
This accidentally omitted from f75f48e3ce41227c5a0ae5d2c6d6ea90100b9bc4.