### PR TITLE
Fix wasm test target requirement

### DIFF
--- a/clang/test/CodeGenObjC/gnustep2-wasm32-nil.m
+++ b/clang/test/CodeGenObjC/gnustep2-wasm32-nil.m
@@ -1,3 +1,4 @@
+// REQUIRES: webassembly-registered-target
 // RUN: %clang_cc1 -triple wasm32-unknown-emscripten -emit-llvm -fobjc-runtime=gnustep-2.2 -o - %s | FileCheck %s
 
 

--- a/clang/test/CodeGenObjC/wasm32-eh-arc.m
+++ b/clang/test/CodeGenObjC/wasm32-eh-arc.m
@@ -1,3 +1,4 @@
+// REQUIRES: webassembly-registered-target
 // RUN: %clang_cc1 -triple wasm32-unknown-emscripten -fobjc-runtime=gnustep-2.2 -fobjc-arc -fexceptions -fobjc-exceptions -exception-model=wasm -mllvm -wasm-enable-eh -emit-llvm -o - %s | FileCheck --enable-var-scope %s
 __attribute__((objc_root_class)) @interface Object @end
 extern void mayThrowObjC();

--- a/clang/test/CodeGenObjC/wasm32-eh.m
+++ b/clang/test/CodeGenObjC/wasm32-eh.m
@@ -1,3 +1,4 @@
+// REQUIRES: webassembly-registered-target
 // RUN: %clang_cc1 -triple wasm32-unknown-emscripten -fobjc-exceptions -fexceptions -exception-model=wasm -mllvm -wasm-enable-eh -emit-llvm -fobjc-runtime=gnustep-2.2 -o - %s | FileCheck --enable-var-scope %s
 
 __attribute__((objc_root_class)) @interface Object

--- a/clang/test/CodeGenObjCXX/wasm32-eh-objcxx.mm
+++ b/clang/test/CodeGenObjCXX/wasm32-eh-objcxx.mm
@@ -1,3 +1,4 @@
+// REQUIRES: webassembly-registered-target
 // RUN: %clang_cc1 -target-feature +exception-handling -triple wasm32-unknown-emscripten -fobjc-runtime=gnustep-2.2 -fexceptions -fobjc-exceptions -fcxx-exceptions -exception-model=wasm -mllvm -wasm-enable-eh -emit-llvm -o - %s | FileCheck --enable-var-scope %s
 
 struct ThrowingDestructor {


### PR DESCRIPTION
The new wasm tests need an extra `REQUIRES webassembly-registered-target` guard to prevent build failures:

#215562
