### PR TITLE
[InstCombine] Narrow signed min/max DAGs before truncation

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -667,16 +667,25 @@ bool TypeEvaluationHelper::canEvaluateTruncatedPred(Value *V, Type *Ty,
     Value *Op1 = MM->getRHS();
     uint32_t BitWidth = Ty->getScalarSizeInBits();
     if (MM->isSigned()) {
-      if (IC.ComputeMaxSignificantBits(Op0, CxtI) > BitWidth ||
-          IC.ComputeMaxSignificantBits(Op1, CxtI) > BitWidth)
-        break;
-    } else {
-      APInt Mask =
-          APInt::getBitsSetFrom(OrigTy->getScalarSizeInBits(), BitWidth);
-      if (!IC.MaskedValueIsZero(Op0, Mask, CxtI) ||
-          !IC.MaskedValueIsZero(Op1, Mask, CxtI))
-        break;
+      auto CanEvaluateOperand = [&](Value *Op) {
+        if (IC.ComputeMaxSignificantBits(Op, CxtI) <= BitWidth)
+          return canEvaluateTruncatedImpl(Op, Ty, IC, CxtI);
+
+        // A signed min/max result is one of its operands, so recursively prove
+        // the range for nested fixed-vector signed min/max operations.
+        auto *NestedMM = dyn_cast<MinMaxIntrinsic>(Op);
+        return isa<FixedVectorType>(Ty) && NestedMM && NestedMM->isSigned() &&
+               canEvaluateTruncatedImpl(Op, Ty, IC, CxtI);
+      };
+
+      return CanEvaluateOperand(Op0) && CanEvaluateOperand(Op1);
     }
+
+    APInt Mask = APInt::getBitsSetFrom(OrigTy->getScalarSizeInBits(), BitWidth);
+    if (!IC.MaskedValueIsZero(Op0, Mask, CxtI) ||
+        !IC.MaskedValueIsZero(Op1, Mask, CxtI))
+      break;
+
     return canEvaluateTruncatedImpl(Op0, Ty, IC, CxtI) &&
            canEvaluateTruncatedImpl(Op1, Ty, IC, CxtI);
   }

--- a/llvm/test/Transforms/InstCombine/trunc-minmax-intrinsics.ll
+++ b/llvm/test/Transforms/InstCombine/trunc-minmax-intrinsics.ll
@@ -2,6 +2,7 @@
 ; RUN: opt -passes=instcombine %s -S | FileCheck %s
 
 declare void @use_i32(i32)
+declare void @use_v8i32(<8 x i32>)
 
 define i8 @umin_mul3_clamp(i8 %x) {
 ; CHECK-LABEL: define i8 @umin_mul3_clamp(
@@ -620,4 +621,133 @@ define <vscale x 4 x i8> @smax_sext_scalable_vec(<vscale x 4 x i8> %x, <vscale x
   %u = call <vscale x 4 x i32> @llvm.smax.nxv4i32(<vscale x 4 x i32> %sx, <vscale x 4 x i32> %sy)
   %t = trunc <vscale x 4 x i32> %u to <vscale x 4 x i8>
   ret <vscale x 4 x i8> %t
+}
+
+define <8 x i16> @smin_smax_dag_shared_sext_vec(
+; CHECK-LABEL: define <8 x i16> @smin_smax_dag_shared_sext_vec(
+; CHECK-SAME: <8 x i16> [[A:%.*]], <8 x i16> [[B:%.*]], <8 x i16> [[C:%.*]]) {
+; CHECK-NEXT:    [[AW:%.*]] = sext <8 x i16> [[A]] to <8 x i32>
+; CHECK-NEXT:    [[BW:%.*]] = sext <8 x i16> [[B]] to <8 x i32>
+; CHECK-NEXT:    [[CW:%.*]] = sext <8 x i16> [[C]] to <8 x i32>
+; CHECK-NEXT:    [[LO:%.*]] = call <8 x i32> @llvm.smin.v8i32(<8 x i32> [[AW]], <8 x i32> [[BW]])
+; CHECK-NEXT:    [[HI:%.*]] = call <8 x i32> @llvm.smax.v8i32(<8 x i32> [[AW]], <8 x i32> [[BW]])
+; CHECK-NEXT:    [[MID:%.*]] = call <8 x i32> @llvm.smin.v8i32(<8 x i32> [[CW]], <8 x i32> [[HI]])
+; CHECK-NEXT:    [[WIDE:%.*]] = call <8 x i32> @llvm.smax.v8i32(<8 x i32> [[MID]], <8 x i32> [[LO]])
+; CHECK-NEXT:    [[RESULT:%.*]] = trunc nsw <8 x i32> [[WIDE]] to <8 x i16>
+; CHECK-NEXT:    ret <8 x i16> [[RESULT]]
+;
+  <8 x i16> %a, <8 x i16> %b, <8 x i16> %c) {
+  %aw = sext <8 x i16> %a to <8 x i32>
+  %bw = sext <8 x i16> %b to <8 x i32>
+  %cw = sext <8 x i16> %c to <8 x i32>
+  %lo = call <8 x i32> @llvm.smin.v8i32(<8 x i32> %aw, <8 x i32> %bw)
+  %hi = call <8 x i32> @llvm.smax.v8i32(<8 x i32> %aw, <8 x i32> %bw)
+  %mid = call <8 x i32> @llvm.smin.v8i32(<8 x i32> %cw, <8 x i32> %hi)
+  %wide = call <8 x i32> @llvm.smax.v8i32(<8 x i32> %mid, <8 x i32> %lo)
+  %result = trunc nsw <8 x i32> %wide to <8 x i16>
+  ret <8 x i16> %result
+}
+
+; Check that the fold is independent of the element widths and also handles a
+; non-adjacent narrowing from i64 to i8.
+define <4 x i8> @smin_smax_dag_sext_i8_i64_vec(
+; CHECK-LABEL: define <4 x i8> @smin_smax_dag_sext_i8_i64_vec(
+; CHECK-SAME: <4 x i8> [[A:%.*]], <4 x i8> [[B:%.*]], <4 x i8> [[C:%.*]]) {
+; CHECK-NEXT:    [[AW:%.*]] = sext <4 x i8> [[A]] to <4 x i64>
+; CHECK-NEXT:    [[BW:%.*]] = sext <4 x i8> [[B]] to <4 x i64>
+; CHECK-NEXT:    [[CW:%.*]] = sext <4 x i8> [[C]] to <4 x i64>
+; CHECK-NEXT:    [[LO:%.*]] = call <4 x i64> @llvm.smin.v4i64(<4 x i64> [[AW]], <4 x i64> [[BW]])
+; CHECK-NEXT:    [[HI:%.*]] = call <4 x i64> @llvm.smax.v4i64(<4 x i64> [[AW]], <4 x i64> [[BW]])
+; CHECK-NEXT:    [[MID:%.*]] = call <4 x i64> @llvm.smin.v4i64(<4 x i64> [[CW]], <4 x i64> [[HI]])
+; CHECK-NEXT:    [[WIDE:%.*]] = call <4 x i64> @llvm.smax.v4i64(<4 x i64> [[MID]], <4 x i64> [[LO]])
+; CHECK-NEXT:    [[RESULT:%.*]] = trunc nsw <4 x i64> [[WIDE]] to <4 x i8>
+; CHECK-NEXT:    ret <4 x i8> [[RESULT]]
+;
+    <4 x i8> %a, <4 x i8> %b, <4 x i8> %c) {
+  %aw = sext <4 x i8> %a to <4 x i64>
+  %bw = sext <4 x i8> %b to <4 x i64>
+  %cw = sext <4 x i8> %c to <4 x i64>
+  %lo = call <4 x i64> @llvm.smin.v4i64(<4 x i64> %aw, <4 x i64> %bw)
+  %hi = call <4 x i64> @llvm.smax.v4i64(<4 x i64> %aw, <4 x i64> %bw)
+  %mid = call <4 x i64> @llvm.smin.v4i64(<4 x i64> %cw, <4 x i64> %hi)
+  %wide = call <4 x i64> @llvm.smax.v4i64(<4 x i64> %mid, <4 x i64> %lo)
+  %result = trunc nsw <4 x i64> %wide to <4 x i8>
+  ret <4 x i8> %result
+}
+
+; Do not build a narrow DAG when that would leave an externally-used copy of
+; the wide DAG alive.
+define <8 x i16> @smin_smax_dag_external_wide_use_vec(
+; CHECK-LABEL: define <8 x i16> @smin_smax_dag_external_wide_use_vec(
+; CHECK-SAME: <8 x i16> [[A:%.*]], <8 x i16> [[B:%.*]], <8 x i16> [[C:%.*]]) {
+; CHECK-NEXT:    [[AW:%.*]] = sext <8 x i16> [[A]] to <8 x i32>
+; CHECK-NEXT:    [[BW:%.*]] = sext <8 x i16> [[B]] to <8 x i32>
+; CHECK-NEXT:    [[CW:%.*]] = sext <8 x i16> [[C]] to <8 x i32>
+; CHECK-NEXT:    [[LO:%.*]] = call <8 x i32> @llvm.smin.v8i32(<8 x i32> [[AW]], <8 x i32> [[BW]])
+; CHECK-NEXT:    call void @use_v8i32(<8 x i32> [[LO]])
+; CHECK-NEXT:    [[HI:%.*]] = call <8 x i32> @llvm.smax.v8i32(<8 x i32> [[AW]], <8 x i32> [[BW]])
+; CHECK-NEXT:    [[MID:%.*]] = call <8 x i32> @llvm.smin.v8i32(<8 x i32> [[CW]], <8 x i32> [[HI]])
+; CHECK-NEXT:    [[WIDE:%.*]] = call <8 x i32> @llvm.smax.v8i32(<8 x i32> [[MID]], <8 x i32> [[LO]])
+; CHECK-NEXT:    [[RESULT:%.*]] = trunc nsw <8 x i32> [[WIDE]] to <8 x i16>
+; CHECK-NEXT:    ret <8 x i16> [[RESULT]]
+;
+    <8 x i16> %a, <8 x i16> %b, <8 x i16> %c) {
+  %aw = sext <8 x i16> %a to <8 x i32>
+  %bw = sext <8 x i16> %b to <8 x i32>
+  %cw = sext <8 x i16> %c to <8 x i32>
+  %lo = call <8 x i32> @llvm.smin.v8i32(<8 x i32> %aw, <8 x i32> %bw)
+  call void @use_v8i32(<8 x i32> %lo)
+  %hi = call <8 x i32> @llvm.smax.v8i32(<8 x i32> %aw, <8 x i32> %bw)
+  %mid = call <8 x i32> @llvm.smin.v8i32(<8 x i32> %cw, <8 x i32> %hi)
+  %wide = call <8 x i32> @llvm.smax.v8i32(<8 x i32> %mid, <8 x i32> %lo)
+  %result = trunc nsw <8 x i32> %wide to <8 x i16>
+  ret <8 x i16> %result
+}
+
+; Do not narrow a DAG with a leaf that is not a sign extension from the
+; destination type.
+define <8 x i16> @smin_smax_dag_non_sext_leaf_vec(
+; CHECK-LABEL: define <8 x i16> @smin_smax_dag_non_sext_leaf_vec(
+; CHECK-SAME: <8 x i16> [[A:%.*]], <8 x i16> [[B:%.*]], <8 x i32> [[X:%.*]]) {
+; CHECK-NEXT:    [[AW:%.*]] = sext <8 x i16> [[A]] to <8 x i32>
+; CHECK-NEXT:    [[BW:%.*]] = sext <8 x i16> [[B]] to <8 x i32>
+; CHECK-NEXT:    [[LO:%.*]] = call <8 x i32> @llvm.smin.v8i32(<8 x i32> [[AW]], <8 x i32> [[X]])
+; CHECK-NEXT:    [[WIDE:%.*]] = call <8 x i32> @llvm.smax.v8i32(<8 x i32> [[LO]], <8 x i32> [[BW]])
+; CHECK-NEXT:    [[RESULT:%.*]] = trunc nsw <8 x i32> [[WIDE]] to <8 x i16>
+; CHECK-NEXT:    ret <8 x i16> [[RESULT]]
+;
+    <8 x i16> %a, <8 x i16> %b, <8 x i32> %x) {
+  %aw = sext <8 x i16> %a to <8 x i32>
+  %bw = sext <8 x i16> %b to <8 x i32>
+  %lo = call <8 x i32> @llvm.smin.v8i32(<8 x i32> %aw, <8 x i32> %x)
+  %wide = call <8 x i32> @llvm.smax.v8i32(<8 x i32> %lo, <8 x i32> %bw)
+  %result = trunc nsw <8 x i32> %wide to <8 x i16>
+  ret <8 x i16> %result
+}
+
+; The min/max DAG itself proves that the wide result fits in the narrow type,
+; so the final trunc does not need an nsw flag.
+define <4 x i16> @smin_smax_dag_plain_trunc_vec(
+; CHECK-LABEL: define <4 x i16> @smin_smax_dag_plain_trunc_vec(
+; CHECK-SAME: <4 x i16> [[A:%.*]], <4 x i16> [[B:%.*]], <4 x i16> [[C:%.*]]) {
+; CHECK-NEXT:    [[AW:%.*]] = sext <4 x i16> [[A]] to <4 x i32>
+; CHECK-NEXT:    [[BW:%.*]] = sext <4 x i16> [[B]] to <4 x i32>
+; CHECK-NEXT:    [[CW:%.*]] = sext <4 x i16> [[C]] to <4 x i32>
+; CHECK-NEXT:    [[LO:%.*]] = call <4 x i32> @llvm.smin.v4i32(<4 x i32> [[AW]], <4 x i32> [[BW]])
+; CHECK-NEXT:    [[HI:%.*]] = call <4 x i32> @llvm.smax.v4i32(<4 x i32> [[AW]], <4 x i32> [[BW]])
+; CHECK-NEXT:    [[MID:%.*]] = call <4 x i32> @llvm.smin.v4i32(<4 x i32> [[CW]], <4 x i32> [[HI]])
+; CHECK-NEXT:    [[WIDE:%.*]] = call <4 x i32> @llvm.smax.v4i32(<4 x i32> [[MID]], <4 x i32> [[LO]])
+; CHECK-NEXT:    [[RESULT:%.*]] = trunc <4 x i32> [[WIDE]] to <4 x i16>
+; CHECK-NEXT:    ret <4 x i16> [[RESULT]]
+;
+    <4 x i16> %a, <4 x i16> %b, <4 x i16> %c) {
+  %aw = sext <4 x i16> %a to <4 x i32>
+  %bw = sext <4 x i16> %b to <4 x i32>
+  %cw = sext <4 x i16> %c to <4 x i32>
+  %lo = call <4 x i32> @llvm.smin.v4i32(<4 x i32> %aw, <4 x i32> %bw)
+  %hi = call <4 x i32> @llvm.smax.v4i32(<4 x i32> %aw, <4 x i32> %bw)
+  %mid = call <4 x i32> @llvm.smin.v4i32(<4 x i32> %cw, <4 x i32> %hi)
+  %wide = call <4 x i32> @llvm.smax.v4i32(<4 x i32> %mid, <4 x i32> %lo)
+  %result = trunc <4 x i32> %wide to <4 x i16>
+  ret <4 x i16> %result
 }

--- a/llvm/test/Transforms/InstCombine/trunc-minmax-intrinsics.ll
+++ b/llvm/test/Transforms/InstCombine/trunc-minmax-intrinsics.ll
@@ -626,15 +626,11 @@ define <vscale x 4 x i8> @smax_sext_scalable_vec(<vscale x 4 x i8> %x, <vscale x
 define <8 x i16> @smin_smax_dag_shared_sext_vec(
 ; CHECK-LABEL: define <8 x i16> @smin_smax_dag_shared_sext_vec(
 ; CHECK-SAME: <8 x i16> [[A:%.*]], <8 x i16> [[B:%.*]], <8 x i16> [[C:%.*]]) {
-; CHECK-NEXT:    [[AW:%.*]] = sext <8 x i16> [[A]] to <8 x i32>
-; CHECK-NEXT:    [[BW:%.*]] = sext <8 x i16> [[B]] to <8 x i32>
-; CHECK-NEXT:    [[CW:%.*]] = sext <8 x i16> [[C]] to <8 x i32>
-; CHECK-NEXT:    [[LO:%.*]] = call <8 x i32> @llvm.smin.v8i32(<8 x i32> [[AW]], <8 x i32> [[BW]])
-; CHECK-NEXT:    [[HI:%.*]] = call <8 x i32> @llvm.smax.v8i32(<8 x i32> [[AW]], <8 x i32> [[BW]])
-; CHECK-NEXT:    [[MID:%.*]] = call <8 x i32> @llvm.smin.v8i32(<8 x i32> [[CW]], <8 x i32> [[HI]])
-; CHECK-NEXT:    [[WIDE:%.*]] = call <8 x i32> @llvm.smax.v8i32(<8 x i32> [[MID]], <8 x i32> [[LO]])
-; CHECK-NEXT:    [[RESULT:%.*]] = trunc nsw <8 x i32> [[WIDE]] to <8 x i16>
-; CHECK-NEXT:    ret <8 x i16> [[RESULT]]
+; CHECK-NEXT:    [[LO:%.*]] = call <8 x i16> @llvm.smin.v8i16(<8 x i16> [[A]], <8 x i16> [[B]])
+; CHECK-NEXT:    [[HI:%.*]] = call <8 x i16> @llvm.smax.v8i16(<8 x i16> [[A]], <8 x i16> [[B]])
+; CHECK-NEXT:    [[MID:%.*]] = call <8 x i16> @llvm.smin.v8i16(<8 x i16> [[C]], <8 x i16> [[HI]])
+; CHECK-NEXT:    [[WIDE:%.*]] = call <8 x i16> @llvm.smax.v8i16(<8 x i16> [[MID]], <8 x i16> [[LO]])
+; CHECK-NEXT:    ret <8 x i16> [[WIDE]]
 ;
   <8 x i16> %a, <8 x i16> %b, <8 x i16> %c) {
   %aw = sext <8 x i16> %a to <8 x i32>
@@ -653,15 +649,11 @@ define <8 x i16> @smin_smax_dag_shared_sext_vec(
 define <4 x i8> @smin_smax_dag_sext_i8_i64_vec(
 ; CHECK-LABEL: define <4 x i8> @smin_smax_dag_sext_i8_i64_vec(
 ; CHECK-SAME: <4 x i8> [[A:%.*]], <4 x i8> [[B:%.*]], <4 x i8> [[C:%.*]]) {
-; CHECK-NEXT:    [[AW:%.*]] = sext <4 x i8> [[A]] to <4 x i64>
-; CHECK-NEXT:    [[BW:%.*]] = sext <4 x i8> [[B]] to <4 x i64>
-; CHECK-NEXT:    [[CW:%.*]] = sext <4 x i8> [[C]] to <4 x i64>
-; CHECK-NEXT:    [[LO:%.*]] = call <4 x i64> @llvm.smin.v4i64(<4 x i64> [[AW]], <4 x i64> [[BW]])
-; CHECK-NEXT:    [[HI:%.*]] = call <4 x i64> @llvm.smax.v4i64(<4 x i64> [[AW]], <4 x i64> [[BW]])
-; CHECK-NEXT:    [[MID:%.*]] = call <4 x i64> @llvm.smin.v4i64(<4 x i64> [[CW]], <4 x i64> [[HI]])
-; CHECK-NEXT:    [[WIDE:%.*]] = call <4 x i64> @llvm.smax.v4i64(<4 x i64> [[MID]], <4 x i64> [[LO]])
-; CHECK-NEXT:    [[RESULT:%.*]] = trunc nsw <4 x i64> [[WIDE]] to <4 x i8>
-; CHECK-NEXT:    ret <4 x i8> [[RESULT]]
+; CHECK-NEXT:    [[LO:%.*]] = call <4 x i8> @llvm.smin.v4i8(<4 x i8> [[A]], <4 x i8> [[B]])
+; CHECK-NEXT:    [[HI:%.*]] = call <4 x i8> @llvm.smax.v4i8(<4 x i8> [[A]], <4 x i8> [[B]])
+; CHECK-NEXT:    [[MID:%.*]] = call <4 x i8> @llvm.smin.v4i8(<4 x i8> [[C]], <4 x i8> [[HI]])
+; CHECK-NEXT:    [[WIDE:%.*]] = call <4 x i8> @llvm.smax.v4i8(<4 x i8> [[MID]], <4 x i8> [[LO]])
+; CHECK-NEXT:    ret <4 x i8> [[WIDE]]
 ;
     <4 x i8> %a, <4 x i8> %b, <4 x i8> %c) {
   %aw = sext <4 x i8> %a to <4 x i64>
@@ -730,15 +722,11 @@ define <8 x i16> @smin_smax_dag_non_sext_leaf_vec(
 define <4 x i16> @smin_smax_dag_plain_trunc_vec(
 ; CHECK-LABEL: define <4 x i16> @smin_smax_dag_plain_trunc_vec(
 ; CHECK-SAME: <4 x i16> [[A:%.*]], <4 x i16> [[B:%.*]], <4 x i16> [[C:%.*]]) {
-; CHECK-NEXT:    [[AW:%.*]] = sext <4 x i16> [[A]] to <4 x i32>
-; CHECK-NEXT:    [[BW:%.*]] = sext <4 x i16> [[B]] to <4 x i32>
-; CHECK-NEXT:    [[CW:%.*]] = sext <4 x i16> [[C]] to <4 x i32>
-; CHECK-NEXT:    [[LO:%.*]] = call <4 x i32> @llvm.smin.v4i32(<4 x i32> [[AW]], <4 x i32> [[BW]])
-; CHECK-NEXT:    [[HI:%.*]] = call <4 x i32> @llvm.smax.v4i32(<4 x i32> [[AW]], <4 x i32> [[BW]])
-; CHECK-NEXT:    [[MID:%.*]] = call <4 x i32> @llvm.smin.v4i32(<4 x i32> [[CW]], <4 x i32> [[HI]])
-; CHECK-NEXT:    [[WIDE:%.*]] = call <4 x i32> @llvm.smax.v4i32(<4 x i32> [[MID]], <4 x i32> [[LO]])
-; CHECK-NEXT:    [[RESULT:%.*]] = trunc <4 x i32> [[WIDE]] to <4 x i16>
-; CHECK-NEXT:    ret <4 x i16> [[RESULT]]
+; CHECK-NEXT:    [[LO:%.*]] = call <4 x i16> @llvm.smin.v4i16(<4 x i16> [[A]], <4 x i16> [[B]])
+; CHECK-NEXT:    [[HI:%.*]] = call <4 x i16> @llvm.smax.v4i16(<4 x i16> [[A]], <4 x i16> [[B]])
+; CHECK-NEXT:    [[MID:%.*]] = call <4 x i16> @llvm.smin.v4i16(<4 x i16> [[C]], <4 x i16> [[HI]])
+; CHECK-NEXT:    [[WIDE:%.*]] = call <4 x i16> @llvm.smax.v4i16(<4 x i16> [[MID]], <4 x i16> [[LO]])
+; CHECK-NEXT:    ret <4 x i16> [[WIDE]]
 ;
     <4 x i16> %a, <4 x i16> %b, <4 x i16> %c) {
   %aw = sext <4 x i16> %a to <4 x i32>


### PR DESCRIPTION
Extend the existing `canEvaluateTruncated()` handling for fixed-vector signed
`llvm.smin`/`llvm.smax` expressions so that nested min/max operands can be
evaluated recursively in the truncation destination type when their range
cannot be proven directly by `ComputeMaxSignificantBits()`.

For example, this changes the following expression shape:

```
trunc(smax(smin(sext(C), smax(sext(A), sext(B))),
           smin(sext(A), sext(B))))
```

into:

```
smax(smin(C, smax(A, B)), smin(A, B))
```

Sign extension preserves signed ordering, so signed minimum and maximum
commute with sign extension. Since each signed min/max result lane is
selected from one of the corresponding operand lanes, if the operands can
be evaluated in the narrow signed type, the intermediate min/max result
also remains within that range. The fold therefore applies whether or not
the final `trunc` carries `nsw`.

The existing significant-bit check is still used for ordinary operands.
When it cannot directly prove the range of a nested signed min/max operand,
the new fallback recursively checks whether that expression can be
evaluated in the truncation destination type.

The transformation reuses the existing `TypeEvaluationHelper` machinery
for shared values and external users, so narrowing is rejected when
rebuilding the expression would leave an externally-used wide computation
alive.

The new recursive fallback is intentionally restricted to fixed vectors.
Allowing it for scalar types also changes existing scalar saturation/clamp
canonicalizations, including `sadd_sat4`. Those transformations are not
obviously incorrect, but evaluating their interaction with
`llvm.sadd.sat` recognition and backend profitability is outside the scope
of this change.

For the motivating pattern, this removes three sign extensions and the
final truncation, and performs all four min/max operations in the narrow
vector type.

Tests cover:

* A shared `<8 x i16>` to `<8 x i32>` signed min/max DAG
* Non-adjacent narrowing from `<4 x i64>` to `<4 x i8>`
* Final truncation both with and without `nsw`
* A wide DAG node with an external user
* A DAG containing an operand that cannot be evaluated in the destination type

Testing:

* `llvm-lit -v llvm/test/Transforms/InstCombine/trunc-minmax-intrinsics.ll`
* `llvm-lit -sv -j2 llvm/test/Transforms/InstCombine`
* `opt -passes=instcombine -verify-each -disable-output llvm/test/Transforms/InstCombine/trunc-minmax-intrinsics.ll`

Proof:

* Full fixed-vector form (with `--disable-undef-input`):
  https://alive2.llvm.org/ce/z/ngfMYZ
* Scalar per-lane relation (without that option):
  https://alive2.llvm.org/ce/z/7VtWe8

Fixes #214224