### PR TITLE
[CIR] Update CHECK lines for the nofreeobj rename

### DIFF
--- a/clang/test/CIR/CodeGen/attr-noundef.cpp
+++ b/clang/test/CIR/CodeGen/attr-noundef.cpp
@@ -43,7 +43,7 @@ void pass_nocopy(NoCopy e) {}
 // LLVM-LABEL: define {{.*}} void @_ZN13check_structs11pass_nocopyENS_6NoCopyE(
 
 // OGCG: define{{.*}} void @_ZN13check_structs10ret_nocopyEv{{.*}}(ptr dead_on_unwind noalias writable sret({{[^)]+}}) align 4 %
-// OGCG: define{{.*}} void @_ZN13check_structs11pass_nocopyENS_6NoCopyE{{.*}}(ptr nofree noundef align 4 dead_on_return dereferenceable(4) %
+// OGCG: define{{.*}} void @_ZN13check_structs11pass_nocopyENS_6NoCopyE{{.*}}(ptr nofreeobj noundef align 4 dead_on_return dereferenceable(4) %
 
 struct Huge {
   int a[1024];
@@ -93,7 +93,7 @@ void pass_nocopy(NoCopy e) {}
 // LLVM-LABEL: define {{.*}} void @_ZN12check_unions11pass_nocopyENS_6NoCopyE(
 
 // OGCG: define{{.*}} void @_ZN12check_unions10ret_nocopyEv{{.*}}(ptr dead_on_unwind noalias writable sret({{[^)]+}}) align 4 %
-// OGCG: define{{.*}} void @_ZN12check_unions11pass_nocopyENS_6NoCopyE{{.*}}(ptr nofree noundef align 4 dead_on_return dereferenceable(4) %
+// OGCG: define{{.*}} void @_ZN12check_unions11pass_nocopyENS_6NoCopyE{{.*}}(ptr nofreeobj noundef align 4 dead_on_return dereferenceable(4) %
 } // namespace check_unions
 
 //************ Passing `this` pointers

--- a/clang/test/CIR/CodeGen/call-conv-lowering-x86_64-byref.cpp
+++ b/clang/test/CIR/CodeGen/call-conv-lowering-x86_64-byref.cpp
@@ -47,7 +47,7 @@ void callByref() {
 // LLVM-CIR:     call void @_Z9takeByref8WithDtor(ptr byref(%struct.WithDtor) align 4 %[[TMP]])
 // LLVM-CIR:     call void @_ZN8WithDtorD1Ev(ptr noundef nonnull align 4 dereferenceable(4) %[[TMP]])
 // LLVM-CIR:     call void @_ZN8WithDtorD1Ev(ptr noundef nonnull align 4 dereferenceable(4) %[[T]])
-// OGCG:         call void @_Z9takeByref8WithDtor(ptr nofree noundef align 4 dereferenceable(4) %[[TMP]])
+// OGCG:         call void @_Z9takeByref8WithDtor(ptr nofreeobj noundef align 4 dereferenceable(4) %[[TMP]])
 // OGCG:         call void @_ZN8WithDtorD1Ev(ptr noundef nonnull align 4 dead_on_return(4) dereferenceable(4) %[[TMP]])
 // OGCG:         call void @_ZN8WithDtorD1Ev(ptr noundef nonnull align 4 dead_on_return(4) dereferenceable(4) %[[T]])
 
@@ -71,7 +71,7 @@ void callTwoByref() {
 // LLVM-CIR:     call void @_Z12takeTwoByref8WithDtorS_(ptr byref(%struct.WithDtor) align 4 %[[TMP_A]], ptr byref(%struct.WithDtor) align 4 %[[TMP_B]])
 // LLVM-CIR:     call void @_ZN8WithDtorD1Ev(ptr noundef nonnull align 4 dereferenceable(4) %[[TMP_B]])
 // LLVM-CIR:     call void @_ZN8WithDtorD1Ev(ptr noundef nonnull align 4 dereferenceable(4) %[[TMP_A]])
-// OGCG:         call void @_Z12takeTwoByref8WithDtorS_(ptr nofree noundef align 4 dereferenceable(4) %[[TMP_A]], ptr nofree noundef align 4 dereferenceable(4) %[[TMP_B]])
+// OGCG:         call void @_Z12takeTwoByref8WithDtorS_(ptr nofreeobj noundef align 4 dereferenceable(4) %[[TMP_A]], ptr nofreeobj noundef align 4 dereferenceable(4) %[[TMP_B]])
 // OGCG:         call void @_ZN8WithDtorD1Ev(ptr noundef nonnull align 4 dead_on_return(4) dereferenceable(4) %[[TMP_B]])
 // OGCG:         call void @_ZN8WithDtorD1Ev(ptr noundef nonnull align 4 dead_on_return(4) dereferenceable(4) %[[TMP_A]])
 
@@ -94,7 +94,7 @@ void callCopyCtorByref() {
 // LLVM:         call void @_ZN12WithCopyCtorC1Ev(ptr noundef nonnull align 4 dereferenceable(4) %[[C:[^)]+]])
 // LLVM:         call void @_ZN12WithCopyCtorC1ERKS_(ptr noundef nonnull align 4 dereferenceable(4) %[[TMP:[^,]+]], ptr noundef nonnull align 4 dereferenceable(4) %[[C]])
 // LLVM-CIR:     call void @_Z17takeCopyCtorByref12WithCopyCtor(ptr byref(%struct.WithCopyCtor) align 4 %[[TMP]])
-// OGCG:         call void @_Z17takeCopyCtorByref12WithCopyCtor(ptr nofree noundef align 4 dead_on_return dereferenceable(4) %[[TMP]])
+// OGCG:         call void @_Z17takeCopyCtorByref12WithCopyCtor(ptr nofreeobj noundef align 4 dead_on_return dereferenceable(4) %[[TMP]])
 
 // byval keeps the fresh copy the callee owns.
 void callByval() {


### PR DESCRIPTION
#218404 renamed classic's indirect-argument attribute from nofree to nofreeobj.  Five OGCG lines across two tests still pinned the old spelling.

Assisted-by: Cursor / claude-opus-5
