### PR TITLE
Use explicit `operator==` call for `DenseMapInfo<mlir::TypeRange>` to avoid `C++20 says that these are ambiguous, even though the second is reversed` warning

### DIFF
--- a/mlir/include/mlir/IR/TypeRange.h
+++ b/mlir/include/mlir/IR/TypeRange.h
@@ -208,7 +208,7 @@ struct DenseMapInfo<mlir::TypeRange> {
   static unsigned getHashValue(mlir::TypeRange val) { return hash_value(val); }
 
   static bool isEqual(mlir::TypeRange lhs, mlir::TypeRange rhs) {
-    return lhs == rhs;
+    return operator==(lhs, rhs);
   }
 };
 


### PR DESCRIPTION
Fix https://github.com/llvm/llvm-project/issues/81769