### PR TITLE
[CodeView] Require aggregates in getSizeInBytesForTypeRecord

### DIFF
--- a/llvm/lib/DebugInfo/CodeView/TypeRecordHelpers.cpp
+++ b/llvm/lib/DebugInfo/CodeView/TypeRecordHelpers.cpp
@@ -177,6 +177,7 @@ uint64_t llvm::codeview::getSizeInBytesForTypeRecord(CVType CVT) {
   case LF_UNION:
     return getUdtSize<UnionRecord>(std::move(CVT));
   default:
-    return CVT.length();
+    assert(false && "not an aggregate");
+    return 0;
   }
 }


### PR DESCRIPTION
`getSizeInBytesForTypeRecord` returns the size of the CodeView leaf record for non-aggregates. It shouldn't be called with non-aggregates in the first place. This PR adds an assert and returns 0 in that case.
From a search here, it's only used in `LVLogicalVisitor` which already checks for tag records before calling this.