### PR TITLE
[libc] Only use the x86_64 sqrt inline asm on x86_64

### DIFF
--- a/libc/src/__support/FPUtil/sqrt.h
+++ b/libc/src/__support/FPUtil/sqrt.h
@@ -48,7 +48,7 @@ template <> LIBC_INLINE long double sqrt<long double>(long double x) {
 
 #else // __builtin_elementwise_sqrt
 // Use inline assembly when __builtin_elementwise_sqrt is not available.
-#if defined(LIBC_TARGET_CPU_HAS_SSE2)
+#if defined(LIBC_TARGET_CPU_HAS_SSE2) && defined(LIBC_TARGET_ARCH_IS_X86_64)
 #include "x86_64/sqrt.h"
 #elif defined(LIBC_TARGET_ARCH_IS_AARCH64) && defined(__ARM_FP)
 #include "aarch64/sqrt.h"


### PR DESCRIPTION
x86_64/sqrt.h is included whenever SSE2 is available, but it #errors out unless the target is x86_64. This breaks 32-bit x86 builds which enable SSE2 (e.g. -march=pentium4 -mfpmath=sse), so also require x86_64 here and let 32-bit x86 use the unconditionally-included generic/sqrt.h instead.