### PR TITLE
[DebugInfo] Support global addresses in variable locations 

### DIFF
--- a/llvm/include/llvm/CodeGen/Analysis.h
+++ b/llvm/include/llvm/CodeGen/Analysis.h
@@ -116,6 +116,12 @@ LLVM_ABI ISD::CondCode getICmpCondCode(ICmpInst::Predicate Pred);
 /// corresponding to the given ISD integer condition code.
 LLVM_ABI ICmpInst::Predicate getICmpCondCode(ISD::CondCode Pred);
 
+/// Test if the address of \p GV can be described in debug info as a plain
+/// reference to its symbol, so that a variable holding that address can be
+/// described for the whole of its scope rather than only from wherever the
+/// address happens to be materialized.
+LLVM_ABI bool canDescribeGlobalAddressInDebugInfo(const GlobalValue *GV);
+
 /// Test if the given instruction is in a position to be optimized
 /// with a tail-call. This roughly means that it's in a block with
 /// a return and there's nothing that needs to be scheduled

--- a/llvm/include/llvm/CodeGen/Analysis.h
+++ b/llvm/include/llvm/CodeGen/Analysis.h
@@ -20,6 +20,8 @@
 
 namespace llvm {
 template <typename T> class SmallVectorImpl;
+class Constant;
+class DataLayout;
 class GlobalValue;
 class LLT;
 class MachineBasicBlock;
@@ -121,6 +123,15 @@ LLVM_ABI ICmpInst::Predicate getICmpCondCode(ISD::CondCode Pred);
 /// described for the whole of its scope rather than only from wherever the
 /// address happens to be materialized.
 LLVM_ABI bool canDescribeGlobalAddressInDebugInfo(const GlobalValue *GV);
+
+/// If \p C is the address of a global, possibly displaced by a constant,
+/// return that global and set \p Offset to the displacement in bytes. Returns
+/// nullptr if \p C is not such an address, or if the global's address cannot
+/// be described per canDescribeGlobalAddressInDebugInfo(); \p Offset is then
+/// meaningless.
+LLVM_ABI const GlobalValue *getDescribableGlobalAddress(const Constant *C,
+                                                        int64_t &Offset,
+                                                        const DataLayout &DL);
 
 /// Test if the given instruction is in a position to be optimized
 /// with a tail-call. This roughly means that it's in a block with

--- a/llvm/include/llvm/CodeGen/Analysis.h
+++ b/llvm/include/llvm/CodeGen/Analysis.h
@@ -21,7 +21,6 @@
 namespace llvm {
 template <typename T> class SmallVectorImpl;
 class Constant;
-class DataLayout;
 class GlobalValue;
 class LLT;
 class MachineBasicBlock;
@@ -122,16 +121,22 @@ LLVM_ABI ICmpInst::Predicate getICmpCondCode(ISD::CondCode Pred);
 /// reference to its symbol, so that a variable holding that address can be
 /// described for the whole of its scope rather than only from wherever the
 /// address happens to be materialized.
-LLVM_ABI bool canDescribeGlobalAddressInDebugInfo(const GlobalValue *GV);
+///
+/// Whether the symbol alone denotes the runtime address depends on \p MF: the
+/// relocation model decides whether a base has to be added to it, and the
+/// debug format and DWARF version decide whether the result can be spelled as
+/// a value rather than as a place to load from.
+LLVM_ABI bool canDescribeGlobalAddressInDebugInfo(const GlobalValue *GV,
+                                                  const MachineFunction &MF);
 
 /// If \p C is the address of a global, possibly displaced by a constant,
 /// return that global and set \p Offset to the displacement in bytes. Returns
-/// nullptr if \p C is not such an address, or if the global's address cannot
-/// be described per canDescribeGlobalAddressInDebugInfo(); \p Offset is then
-/// meaningless.
-LLVM_ABI const GlobalValue *getDescribableGlobalAddress(const Constant *C,
-                                                        int64_t &Offset,
-                                                        const DataLayout &DL);
+/// nullptr if \p C is not such an address, or if the global's address cannot be
+/// described per canDescribeGlobalAddressInDebugInfo(). \p Offset is set to
+/// zero in those cases, so it only carries a displacement alongside a global.
+LLVM_ABI const GlobalValue *
+getDescribableGlobalAddress(const Constant *C, int64_t &Offset,
+                            const MachineFunction &MF);
 
 /// Test if the given instruction is in a position to be optimized
 /// with a tail-call. This roughly means that it's in a block with

--- a/llvm/lib/CodeGen/Analysis.cpp
+++ b/llvm/lib/CodeGen/Analysis.cpp
@@ -529,6 +529,21 @@ static bool nextRealType(SmallVectorImpl<Type *> &SubTypes,
   return true;
 }
 
+bool llvm::canDescribeGlobalAddressInDebugInfo(const GlobalValue *GV) {
+  // A thread-local's address is not known until it is resolved against a
+  // thread's storage, which a plain symbol reference cannot express.
+  if (GV->isThreadLocal())
+    return false;
+  // Computing the address of a dllimport'd entity requires a load from the
+  // import address table, which a static symbol reference cannot express.
+  if (GV->hasDLLImportStorageClass())
+    return false;
+  // An ifunc resolves to whatever its resolver returns at load time, so the
+  // symbol's own address is not the value of the pointer.
+  if (isa<GlobalIFunc>(GV))
+    return false;
+  return true;
+}
 
 /// Test if the given instruction is in a position to be optimized
 /// with a tail-call. This roughly means that it's in a block with

--- a/llvm/lib/CodeGen/Analysis.cpp
+++ b/llvm/lib/CodeGen/Analysis.cpp
@@ -530,6 +530,9 @@ static bool nextRealType(SmallVectorImpl<Type *> &SubTypes,
 }
 
 bool llvm::canDescribeGlobalAddressInDebugInfo(const GlobalValue *GV) {
+  // Only a definitions have an address a symbol reference can name.
+  if (GV->isDeclarationForLinker())
+    return false;
   // A thread-local's address is not known until it is resolved against a
   // thread's storage, which a plain symbol reference cannot express.
   if (GV->isThreadLocal())

--- a/llvm/lib/CodeGen/Analysis.cpp
+++ b/llvm/lib/CodeGen/Analysis.cpp
@@ -12,6 +12,7 @@
 
 #include "llvm/CodeGen/Analysis.h"
 #include "llvm/Analysis/ValueTracking.h"
+#include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/TargetInstrInfo.h"
 #include "llvm/CodeGen/TargetLowering.h"
@@ -23,6 +24,7 @@
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Target/TargetLoweringObjectFile.h"
 #include "llvm/Target/TargetMachine.h"
 
 using namespace llvm;
@@ -529,8 +531,9 @@ static bool nextRealType(SmallVectorImpl<Type *> &SubTypes,
   return true;
 }
 
-bool llvm::canDescribeGlobalAddressInDebugInfo(const GlobalValue *GV) {
-  // Only a definitions have an address a symbol reference can name.
+bool llvm::canDescribeGlobalAddressInDebugInfo(const GlobalValue *GV,
+                                               const MachineFunction &MF) {
+  // Only definitions have an address a symbol reference can name.
   if (GV->isDeclarationForLinker())
     return false;
   // A thread-local's address is not known until it is resolved against a
@@ -545,23 +548,67 @@ bool llvm::canDescribeGlobalAddressInDebugInfo(const GlobalValue *GV) {
   // symbol's own address is not the value of the pointer.
   if (isa<GlobalIFunc>(GV))
     return false;
+
+  const Module &M = *MF.getFunction().getParent();
+  const TargetMachine &TM = MF.getTarget();
+
+  // CodeView has no way to name a symbol in a local variable's location, so
+  // choosing one here would leave the variable with no location at all.
+  if (M.getCodeViewFlag())
+    return false;
+
+  // Saying that the variable holds this address, rather than that it lives at
+  // it, needs DW_OP_stack_value, which DWARF 4 introduced. Nothing older can
+  // express the difference, so leave those versions to describe the variable by
+  // wherever the address is materialized instead. DwarfExpression refuses the
+  // same versions; deciding here only picks the better of the two fallbacks,
+  // while a materialized location is still available to fall back on.
+  // FIXME: Share this resolution with DwarfDebug's, which has to match.
+  unsigned DwarfVersion = TM.Options.MCOptions.DwarfVersion;
+  if (!DwarfVersion)
+    DwarfVersion = M.getDwarfVersion();
+  if (!DwarfVersion)
+    DwarfVersion = dwarf::DWARF_VERSION;
+  if (DwarfVersion < 4)
+    return false;
+
+  // On some targets a global does not live at its symbol's address; a base
+  // known only at run time has to be added to it. DwarfCompileUnit builds
+  // those addends for global variables, but they need a relocation, which a
+  // location list cannot carry, so a local pointing at such a global has to
+  // keep being described by whatever register holds the computed address.
+  if (TM.getTargetTriple().isWasm() && TM.getRelocationModel() == Reloc::PIC_)
+    return false;
+  if (TM.getRelocationModel() == Reloc::RWPI ||
+      TM.getRelocationModel() == Reloc::ROPI_RWPI) {
+    // Only writable globals are addressed relative to the static base;
+    // read-only ones keep an absolute address. An alias may name either, so
+    // give up rather than chase it.
+    const auto *GO = dyn_cast<GlobalObject>(GV);
+    if (!GO || !TM.getObjFileLowering()->getKindForGlobal(GO, TM).isReadOnly())
+      return false;
+  }
+
   return true;
 }
 
-const GlobalValue *llvm::getDescribableGlobalAddress(const Constant *C,
-                                                     int64_t &Offset,
-                                                     const DataLayout &DL) {
+const GlobalValue *
+llvm::getDescribableGlobalAddress(const Constant *C, int64_t &Offset,
+                                  const MachineFunction &MF) {
+  Offset = 0;
   if (!C->getType()->isPointerTy())
     return nullptr;
 
   // Non-inbounds offsets are stripped as well, which is the default. The
   // inbounds flag constrains what the program may do with the pointer, not
   // what its value is, and describing an address needs only the value.
-  const auto *GV =
-      dyn_cast<GlobalValue>(GetPointerBaseWithConstantOffset(C, Offset, DL));
-  if (!GV || !canDescribeGlobalAddressInDebugInfo(GV))
+  int64_t GVOffset;
+  const auto *GV = dyn_cast<GlobalValue>(
+      GetPointerBaseWithConstantOffset(C, GVOffset, MF.getDataLayout()));
+  if (!GV || !canDescribeGlobalAddressInDebugInfo(GV, MF))
     return nullptr;
 
+  Offset = GVOffset;
   return GV;
 }
 

--- a/llvm/lib/CodeGen/Analysis.cpp
+++ b/llvm/lib/CodeGen/Analysis.cpp
@@ -548,6 +548,23 @@ bool llvm::canDescribeGlobalAddressInDebugInfo(const GlobalValue *GV) {
   return true;
 }
 
+const GlobalValue *llvm::getDescribableGlobalAddress(const Constant *C,
+                                                     int64_t &Offset,
+                                                     const DataLayout &DL) {
+  if (!C->getType()->isPointerTy())
+    return nullptr;
+
+  // Non-inbounds offsets are stripped as well, which is the default. The
+  // inbounds flag constrains what the program may do with the pointer, not
+  // what its value is, and describing an address needs only the value.
+  const auto *GV =
+      dyn_cast<GlobalValue>(GetPointerBaseWithConstantOffset(C, Offset, DL));
+  if (!GV || !canDescribeGlobalAddressInDebugInfo(GV))
+    return nullptr;
+
+  return GV;
+}
+
 /// Test if the given instruction is in a position to be optimized
 /// with a tail-call. This roughly means that it's in a block with
 /// a return and there's nothing that needs to be scheduled

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1343,6 +1343,12 @@ static bool emitDebugValueComment(const MachineInstr *MI, AsmPrinter &AP) {
       OS << "!target-index(" << Op.getIndex() << "," << Op.getOffset() << ")";
       break;
     }
+    case MachineOperand::MO_GlobalAddress: {
+      Op.getGlobal()->printAsOperand(OS, /*PrintType=*/false);
+      if (Op.getOffset())
+        OS << '+' << Op.getOffset();
+      break;
+    }
     case MachineOperand::MO_Register:
     case MachineOperand::MO_FrameIndex: {
       Register Reg;

--- a/llvm/lib/CodeGen/AsmPrinter/DebugLocEntry.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DebugLocEntry.h
@@ -19,6 +19,7 @@
 
 namespace llvm {
 class AsmPrinter;
+class GlobalValue;
 
 /// This struct describes target specific location.
 struct TargetIndexLocation {
@@ -45,7 +46,8 @@ class DbgValueLocEntry {
     E_Integer,
     E_ConstantFP,
     E_ConstantInt,
-    E_TargetIndexLocation
+    E_TargetIndexLocation,
+    E_GlobalAddress
   };
   enum EntryType EntryKind;
 
@@ -54,6 +56,7 @@ class DbgValueLocEntry {
     int64_t Int;
     const ConstantFP *CFP;
     const ConstantInt *CIP;
+    const GlobalValue *GV;
   } Constant;
 
   union {
@@ -74,6 +77,9 @@ public:
   DbgValueLocEntry(MachineLocation Loc) : EntryKind(E_Location), Loc(Loc) {}
   DbgValueLocEntry(TargetIndexLocation Loc)
       : EntryKind(E_TargetIndexLocation), TIL(Loc) {}
+  DbgValueLocEntry(const GlobalValue *GV) : EntryKind(E_GlobalAddress) {
+    Constant.GV = GV;
+  }
 
   bool isLocation() const { return EntryKind == E_Location; }
   bool isIndirectLocation() const {
@@ -85,9 +91,11 @@ public:
   bool isInt() const { return EntryKind == E_Integer; }
   bool isConstantFP() const { return EntryKind == E_ConstantFP; }
   bool isConstantInt() const { return EntryKind == E_ConstantInt; }
+  bool isGlobalAddress() const { return EntryKind == E_GlobalAddress; }
   int64_t getInt() const { return Constant.Int; }
   const ConstantFP *getConstantFP() const { return Constant.CFP; }
   const ConstantInt *getConstantInt() const { return Constant.CIP; }
+  const GlobalValue *getGlobalAddress() const { return Constant.GV; }
   MachineLocation getLoc() const { return Loc; }
   TargetIndexLocation getTargetIndexLocation() const { return TIL; }
   friend bool operator==(const DbgValueLocEntry &, const DbgValueLocEntry &);
@@ -266,6 +274,8 @@ inline bool operator==(const DbgValueLocEntry &A, const DbgValueLocEntry &B) {
     return A.Constant.CFP == B.Constant.CFP;
   case DbgValueLocEntry::E_ConstantInt:
     return A.Constant.CIP == B.Constant.CIP;
+  case DbgValueLocEntry::E_GlobalAddress:
+    return A.Constant.GV == B.Constant.GV;
   }
   llvm_unreachable("unhandled EntryKind");
 }

--- a/llvm/lib/CodeGen/AsmPrinter/DebugLocEntry.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DebugLocEntry.h
@@ -35,6 +35,20 @@ struct TargetIndexLocation {
   }
 };
 
+/// This struct describes the address of a global, displaced by a constant.
+struct GlobalAddressLocation {
+  const GlobalValue *GV;
+  int64_t Offset;
+
+  GlobalAddressLocation() = default;
+  GlobalAddressLocation(const GlobalValue *GV, int64_t Offset)
+      : GV(GV), Offset(Offset) {}
+
+  bool operator==(const GlobalAddressLocation &Other) const {
+    return GV == Other.GV && Offset == Other.Offset;
+  }
+};
+
 /// A single location or constant within a variable location description, with
 /// either a single entry (with an optional DIExpression) used for a DBG_VALUE,
 /// or a list of entries used for a DBG_VALUE_LIST.
@@ -56,7 +70,6 @@ class DbgValueLocEntry {
     int64_t Int;
     const ConstantFP *CFP;
     const ConstantInt *CIP;
-    const GlobalValue *GV;
   } Constant;
 
   union {
@@ -64,6 +77,8 @@ class DbgValueLocEntry {
     MachineLocation Loc;
     /// Or a location from target specific location.
     TargetIndexLocation TIL;
+    /// Or the address of a global.
+    GlobalAddressLocation GAL;
   };
 
 public:
@@ -77,9 +92,8 @@ public:
   DbgValueLocEntry(MachineLocation Loc) : EntryKind(E_Location), Loc(Loc) {}
   DbgValueLocEntry(TargetIndexLocation Loc)
       : EntryKind(E_TargetIndexLocation), TIL(Loc) {}
-  DbgValueLocEntry(const GlobalValue *GV) : EntryKind(E_GlobalAddress) {
-    Constant.GV = GV;
-  }
+  DbgValueLocEntry(GlobalAddressLocation GAL)
+      : EntryKind(E_GlobalAddress), GAL(GAL) {}
 
   bool isLocation() const { return EntryKind == E_Location; }
   bool isIndirectLocation() const {
@@ -95,7 +109,8 @@ public:
   int64_t getInt() const { return Constant.Int; }
   const ConstantFP *getConstantFP() const { return Constant.CFP; }
   const ConstantInt *getConstantInt() const { return Constant.CIP; }
-  const GlobalValue *getGlobalAddress() const { return Constant.GV; }
+  const GlobalValue *getGlobalAddress() const { return GAL.GV; }
+  int64_t getGlobalOffset() const { return GAL.Offset; }
   MachineLocation getLoc() const { return Loc; }
   TargetIndexLocation getTargetIndexLocation() const { return TIL; }
   friend bool operator==(const DbgValueLocEntry &, const DbgValueLocEntry &);
@@ -275,7 +290,7 @@ inline bool operator==(const DbgValueLocEntry &A, const DbgValueLocEntry &B) {
   case DbgValueLocEntry::E_ConstantInt:
     return A.Constant.CIP == B.Constant.CIP;
   case DbgValueLocEntry::E_GlobalAddress:
-    return A.Constant.GV == B.Constant.GV;
+    return A.GAL == B.GAL;
   }
   llvm_unreachable("unhandled EntryKind");
 }

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
@@ -923,6 +923,15 @@ void DwarfCompileUnit::applyConcreteDbgVariableAttributes(
       addConstantFPValue(VariableDie, Entry->getConstantFP());
     } else if (Entry->isConstantInt()) {
       addConstantValue(VariableDie, Entry->getConstantInt(), DV.getType());
+    } else if (Entry->isGlobalAddress()) {
+      auto *Expr = Single.getExpr();
+      DIELoc *Loc = new (DIEValueAllocator) DIELoc;
+      DIEDwarfExpression DwarfExpr(*Asm, *this, *Loc);
+      DwarfExpr.addFragmentOffset(Expr);
+      if (!DwarfExpr.addGlobalAddress(Entry->getGlobalAddress()))
+        return;
+      DwarfExpr.addExpression(Expr);
+      addBlock(VariableDie, dwarf::DW_AT_location, DwarfExpr.finalize());
     } else if (Entry->isTargetIndexLocation()) {
       DIELoc *Loc = new (DIEValueAllocator) DIELoc;
       DIEDwarfExpression DwarfExpr(*Asm, *this, *Loc);
@@ -976,6 +985,9 @@ void DwarfCompileUnit::applyConcreteDbgVariableAttributes(
       // only the WebAssembly-specific encoding is supported.
       assert(Asm->TM.getTargetTriple().isWasm());
       DwarfExpr.addWasmLocation(Loc.Index, static_cast<uint64_t>(Loc.Offset));
+    } else if (Entry.isGlobalAddress()) {
+      if (!DwarfExpr.addGlobalAddress(Entry.getGlobalAddress()))
+        return false;
     } else {
       llvm_unreachable("Unsupported Entry type.");
     }

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
@@ -928,7 +928,8 @@ void DwarfCompileUnit::applyConcreteDbgVariableAttributes(
       DIELoc *Loc = new (DIEValueAllocator) DIELoc;
       DIEDwarfExpression DwarfExpr(*Asm, *this, *Loc);
       DwarfExpr.addFragmentOffset(Expr);
-      if (!DwarfExpr.addGlobalAddress(Entry->getGlobalAddress()))
+      if (!DwarfExpr.addGlobalAddress(Entry->getGlobalAddress(),
+                                      Entry->getGlobalOffset()))
         return;
       DwarfExpr.addExpression(Expr);
       addBlock(VariableDie, dwarf::DW_AT_location, DwarfExpr.finalize());
@@ -986,7 +987,8 @@ void DwarfCompileUnit::applyConcreteDbgVariableAttributes(
       assert(Asm->TM.getTargetTriple().isWasm());
       DwarfExpr.addWasmLocation(Loc.Index, static_cast<uint64_t>(Loc.Offset));
     } else if (Entry.isGlobalAddress()) {
-      if (!DwarfExpr.addGlobalAddress(Entry.getGlobalAddress()))
+      if (!DwarfExpr.addGlobalAddress(Entry.getGlobalAddress(),
+                                      Entry.getGlobalOffset()))
         return false;
     } else {
       llvm_unreachable("Unsupported Entry type.");

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
@@ -933,6 +933,9 @@ void DwarfCompileUnit::applyConcreteDbgVariableAttributes(
         return;
       DwarfExpr.addExpression(Expr);
       addBlock(VariableDie, dwarf::DW_AT_location, DwarfExpr.finalize());
+      if (DwarfExpr.TagOffset)
+        addUInt(VariableDie, dwarf::DW_AT_LLVM_tag_offset, dwarf::DW_FORM_data1,
+                *DwarfExpr.TagOffset);
     } else if (Entry->isTargetIndexLocation()) {
       DIELoc *Loc = new (DIEValueAllocator) DIELoc;
       DIEDwarfExpression DwarfExpr(*Asm, *this, *Loc);

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -258,6 +258,8 @@ static DbgValueLoc getDebugLocValue(const MachineInstr *MI) {
     } else if (Op.isTargetIndex()) {
       DbgValueLocEntries.push_back(
           DbgValueLocEntry(TargetIndexLocation(Op.getIndex(), Op.getOffset())));
+    } else if (Op.isGlobal()) {
+      DbgValueLocEntries.push_back(DbgValueLocEntry(Op.getGlobal()));
     } else if (Op.isImm())
       DbgValueLocEntries.push_back(DbgValueLocEntry(Op.getImm()));
     else if (Op.isFPImm())
@@ -1784,9 +1786,12 @@ static bool validThroughout(LexicalScopes &LScopes,
   // throughout the function. This is a hack, presumably for DWARF v2 and not
   // necessarily correct. It would be much better to use a dbg.declare instead
   // if we know the constant is live throughout the scope.
+  // The address of a global is a link-time constant, so for those this is not
+  // a hack: the location genuinely does describe the variable throughout.
   if (MBB->pred_empty() &&
-      all_of(DbgValue->debug_operands(),
-             [](const MachineOperand &Op) { return Op.isImm(); }))
+      all_of(DbgValue->debug_operands(), [](const MachineOperand &Op) {
+        return Op.isImm() || Op.isGlobal();
+      }))
     return true;
 
   // Test if the location terminates before the end of the scope.
@@ -3341,6 +3346,9 @@ void DwarfDebug::emitDebugLocValue(const AsmPrinter &AP, const DIBasicType *BT,
       // WebAssembly-specific encoding is supported.
       assert(AP.TM.getTargetTriple().isWasm());
       DwarfExpr.addWasmLocation(Loc.Index, static_cast<uint64_t>(Loc.Offset));
+    } else if (Entry.isGlobalAddress()) {
+      if (!DwarfExpr.addGlobalAddress(Entry.getGlobalAddress()))
+        return false;
     } else if (Entry.isConstantFP()) {
       if (AP.getDwarfVersion() >= 4 && !AP.getDwarfDebug()->tuneForSCE() &&
           !Cursor) {

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -259,7 +259,8 @@ static DbgValueLoc getDebugLocValue(const MachineInstr *MI) {
       DbgValueLocEntries.push_back(
           DbgValueLocEntry(TargetIndexLocation(Op.getIndex(), Op.getOffset())));
     } else if (Op.isGlobal()) {
-      DbgValueLocEntries.push_back(DbgValueLocEntry(Op.getGlobal()));
+      DbgValueLocEntries.push_back(DbgValueLocEntry(
+          GlobalAddressLocation(Op.getGlobal(), Op.getOffset())));
     } else if (Op.isImm())
       DbgValueLocEntries.push_back(DbgValueLocEntry(Op.getImm()));
     else if (Op.isFPImm())
@@ -3347,7 +3348,8 @@ void DwarfDebug::emitDebugLocValue(const AsmPrinter &AP, const DIBasicType *BT,
       assert(AP.TM.getTargetTriple().isWasm());
       DwarfExpr.addWasmLocation(Loc.Index, static_cast<uint64_t>(Loc.Offset));
     } else if (Entry.isGlobalAddress()) {
-      if (!DwarfExpr.addGlobalAddress(Entry.getGlobalAddress()))
+      if (!DwarfExpr.addGlobalAddress(Entry.getGlobalAddress(),
+                                      Entry.getGlobalOffset()))
         return false;
     } else if (Entry.isConstantFP()) {
       if (AP.getDwarfVersion() >= 4 && !AP.getDwarfDebug()->tuneForSCE() &&

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
@@ -862,6 +862,32 @@ void DwarfExpression::emitLegacyZExt(unsigned FromBits) {
   emitOp(dwarf::DW_OP_and);
 }
 
+bool DwarfExpression::addGlobalAddress(const GlobalValue *GV) {
+  DwarfDebug &DD = CU.getDwarfDebug();
+
+  // Prefer the address pool, whose index is plain data and so can be emitted
+  // into either output form. Before DWARF 5 the pool is only available under
+  // split DWARF, leaving a relocated DW_OP_addr as the only spelling -- which
+  // only a DIE can carry.
+  bool UsePool = DwarfVersion >= 5 || DD.useSplitDwarf();
+  if (!UsePool && !supportsRelocatedAddress())
+    return false;
+
+  assert(isImplicitLocation() || isUnknownLocation());
+  LocationKind = Implicit;
+
+  const MCSymbol *Sym = CU.getAsmPrinter()->getSymbol(GV);
+  if (UsePool) {
+    emitOp(DwarfVersion >= 5 ? dwarf::DW_OP_addrx
+                             : dwarf::DW_OP_GNU_addr_index);
+    emitUnsigned(DD.getAddressPool().getIndex(Sym));
+  } else {
+    emitOp(dwarf::DW_OP_addr);
+    emitRelocatedAddress(Sym);
+  }
+  return true;
+}
+
 void DwarfExpression::addWasmLocation(unsigned Index, uint64_t Offset) {
   emitOp(dwarf::DW_OP_WASM_location);
   emitUnsigned(Index == 4/*TI_LOCAL_INDIRECT*/ ? 0/*TI_LOCAL*/ : Index);

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
@@ -865,6 +865,13 @@ void DwarfExpression::emitLegacyZExt(unsigned FromBits) {
 bool DwarfExpression::addGlobalAddress(const GlobalValue *GV, int64_t Offset) {
   DwarfDebug &DD = CU.getDwarfDebug();
 
+  // This is an implicit location, and finalize() spells that with
+  // DW_OP_stack_value, which DWARF 4 introduced. Before it, the expression
+  // would read as the address the variable lives at rather than as its value,
+  // and there is no older spelling to fall back on.
+  if (DwarfVersion < 4)
+    return false;
+
   // Prefer the address pool, whose index is plain data and so can be emitted
   // into either output form. Before DWARF 5 the pool is only available under
   // split DWARF, leaving a relocated DW_OP_addr as the only spelling -- which

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
@@ -862,7 +862,7 @@ void DwarfExpression::emitLegacyZExt(unsigned FromBits) {
   emitOp(dwarf::DW_OP_and);
 }
 
-bool DwarfExpression::addGlobalAddress(const GlobalValue *GV) {
+bool DwarfExpression::addGlobalAddress(const GlobalValue *GV, int64_t Offset) {
   DwarfDebug &DD = CU.getDwarfDebug();
 
   // Prefer the address pool, whose index is plain data and so can be emitted
@@ -884,6 +884,17 @@ bool DwarfExpression::addGlobalAddress(const GlobalValue *GV) {
   } else {
     emitOp(dwarf::DW_OP_addr);
     emitRelocatedAddress(Sym);
+  }
+
+  // The displacement cannot be folded into the address itself: a pool entry is
+  // keyed on the symbol alone, and a DW_FORM_addr label carries no addend. Let
+  // the expression apply it instead.
+  if (Offset > 0) {
+    emitOp(dwarf::DW_OP_plus_uconst);
+    emitUnsigned(Offset);
+  } else if (Offset < 0) {
+    addSignedConstant(Offset);
+    emitOp(dwarf::DW_OP_plus);
   }
   return true;
 }

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.h
@@ -27,6 +27,7 @@ class AsmPrinter;
 class APInt;
 class DwarfCompileUnit;
 class DIELoc;
+class GlobalValue;
 class TargetRegisterInfo;
 class MachineLocation;
 
@@ -135,6 +136,17 @@ protected:
   virtual void emitData1(uint8_t Value) = 0;
 
   virtual void emitBaseTypeRef(uint64_t Idx) = 0;
+
+  /// Whether a relocated address operand, as needed by DW_OP_addr, can be
+  /// emitted into this output form. A location list is backed by a plain byte
+  /// buffer, which cannot carry a relocation.
+  virtual bool supportsRelocatedAddress() const { return false; }
+
+  /// Emit a relocated address operand. Only called when
+  /// supportsRelocatedAddress() returns true.
+  virtual void emitRelocatedAddress(const MCSymbol *Sym) {
+    llvm_unreachable("relocated address unsupported by this output form");
+  }
 
   /// Start emitting data to the temporary buffer. The data stored in the
   /// temporary buffer can be committed to the main output using
@@ -307,6 +319,11 @@ public:
   /// Emit location information expressed via WebAssembly location + offset
   /// The Index is an identifier for locals, globals or operand stack.
   void addWasmLocation(unsigned Index, uint64_t Offset);
+
+  /// Emit the address of \p GV as an implicit location description, i.e. as the
+  /// value of the described entity rather than as the address of its storage.
+  /// Returns false if the address cannot be spelled in this unit's DWARF.
+  bool addGlobalAddress(const GlobalValue *GV);
 };
 
 /// DwarfExpression implementation for .debug_loc entries.
@@ -362,6 +379,9 @@ class DIEDwarfExpression final : public DwarfExpression {
   void emitUnsigned(uint64_t Value) override;
   void emitData1(uint8_t Value) override;
   void emitBaseTypeRef(uint64_t Idx) override;
+
+  bool supportsRelocatedAddress() const override { return true; }
+  void emitRelocatedAddress(const MCSymbol *Sym) override;
 
   void enableTemporaryBuffer() override;
   void disableTemporaryBuffer() override;

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.h
@@ -320,10 +320,11 @@ public:
   /// The Index is an identifier for locals, globals or operand stack.
   void addWasmLocation(unsigned Index, uint64_t Offset);
 
-  /// Emit the address of \p GV as an implicit location description, i.e. as the
-  /// value of the described entity rather than as the address of its storage.
-  /// Returns false if the address cannot be spelled in this unit's DWARF.
-  bool addGlobalAddress(const GlobalValue *GV);
+  /// Emit the address of \p GV displaced by \p Offset as an implicit location
+  /// description, i.e. as the value of the described entity rather than as the
+  /// address of its storage. Returns false if the address cannot be spelled in
+  /// this unit's DWARF.
+  bool addGlobalAddress(const GlobalValue *GV, int64_t Offset);
 };
 
 /// DwarfExpression implementation for .debug_loc entries.

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
@@ -61,6 +61,10 @@ void DIEDwarfExpression::emitBaseTypeRef(uint64_t Idx) {
   CU.addBaseTypeRef(getActiveDIE(), Idx);
 }
 
+void DIEDwarfExpression::emitRelocatedAddress(const MCSymbol *Sym) {
+  CU.addLabel(getActiveDIE(), dwarf::DW_FORM_addr, Sym);
+}
+
 void DIEDwarfExpression::enableTemporaryBuffer() {
   assert(!IsBuffering && "Already buffering?");
   IsBuffering = true;

--- a/llvm/lib/CodeGen/GlobalISel/MachineIRBuilder.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/MachineIRBuilder.cpp
@@ -9,6 +9,7 @@
 /// This file implements the MachineIRBuidler class.
 //===----------------------------------------------------------------------===//
 #include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
+#include "llvm/CodeGen/Analysis.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineInstr.h"
 #include "llvm/CodeGen/MachineInstrBuilder.h"
@@ -108,6 +109,7 @@ MachineInstrBuilder MachineIRBuilder::buildConstDbgValue(const Constant &C,
     return &C;
   }();
 
+  bool IsIndirect = true;
   if (auto *CI = dyn_cast<ConstantInt>(NumericConstant)) {
     if (CI->getBitWidth() > 64)
       MIB.addCImm(CI);
@@ -119,12 +121,25 @@ MachineInstrBuilder MachineIRBuilder::buildConstDbgValue(const Constant &C,
     MIB.addFPImm(CFP);
   } else if (isa<ConstantPointerNull>(NumericConstant)) {
     MIB.addImm(0);
+  } else if (auto *GV = dyn_cast<GlobalValue>(NumericConstant);
+             GV && canDescribeGlobalAddressInDebugInfo(GV)) {
+    // The address of a global is a direct link-time constant.
+    MIB.addGlobalAddress(GV);
+    IsIndirect = false;
   } else {
     // Insert $noreg if we didn't find a usable constant and had to drop it.
     MIB.addReg(Register());
   }
 
-  MIB.addImm(0).addMetadata(Variable).addMetadata(Expr);
+  // DBG_VALUE spells an indirect location with a zero immediate offset operand
+  // and a direct one with $noreg. isIndirectDebugValue() ignores the offset for
+  // a non-register location operand, but isDebugOffsetImm() does not, and
+  // several consumers ask that instead.
+  if (IsIndirect)
+    MIB.addImm(0);
+  else
+    MIB.addReg(Register());
+  MIB.addMetadata(Variable).addMetadata(Expr);
   return insertInstr(MIB);
 }
 

--- a/llvm/lib/CodeGen/GlobalISel/MachineIRBuilder.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/MachineIRBuilder.cpp
@@ -110,6 +110,7 @@ MachineInstrBuilder MachineIRBuilder::buildConstDbgValue(const Constant &C,
   }();
 
   bool IsIndirect = true;
+  int64_t GlobalOffset = 0;
   if (auto *CI = dyn_cast<ConstantInt>(NumericConstant)) {
     if (CI->getBitWidth() > 64)
       MIB.addCImm(CI);
@@ -121,10 +122,17 @@ MachineInstrBuilder MachineIRBuilder::buildConstDbgValue(const Constant &C,
     MIB.addFPImm(CFP);
   } else if (isa<ConstantPointerNull>(NumericConstant)) {
     MIB.addImm(0);
-  } else if (auto *GV = dyn_cast<GlobalValue>(NumericConstant);
-             GV && canDescribeGlobalAddressInDebugInfo(GV)) {
-    // The address of a global is a direct link-time constant.
+  } else if (const GlobalValue *GV = getDescribableGlobalAddress(
+                 NumericConstant, GlobalOffset, getMF().getDataLayout())) {
+    // The address of a global is a direct link-time constant. A displacement
+    // from it rides along in the expression rather than in the operand.
     MIB.addGlobalAddress(GV);
+    if (GlobalOffset) {
+      SmallVector<uint64_t, 3> Ops;
+      DIExpression::appendOffset(Ops, GlobalOffset);
+      Expr = DIExpression::appendOpsToArg(cast<DIExpression>(Expr), Ops, 0,
+                                          /*StackValue=*/false);
+    }
     IsIndirect = false;
   } else {
     // Insert $noreg if we didn't find a usable constant and had to drop it.

--- a/llvm/lib/CodeGen/GlobalISel/MachineIRBuilder.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/MachineIRBuilder.cpp
@@ -110,7 +110,7 @@ MachineInstrBuilder MachineIRBuilder::buildConstDbgValue(const Constant &C,
   }();
 
   bool IsIndirect = true;
-  int64_t GlobalOffset = 0;
+  int64_t GlobalOffset;
   if (auto *CI = dyn_cast<ConstantInt>(NumericConstant)) {
     if (CI->getBitWidth() > 64)
       MIB.addCImm(CI);
@@ -123,7 +123,7 @@ MachineInstrBuilder MachineIRBuilder::buildConstDbgValue(const Constant &C,
   } else if (isa<ConstantPointerNull>(NumericConstant)) {
     MIB.addImm(0);
   } else if (const GlobalValue *GV = getDescribableGlobalAddress(
-                 NumericConstant, GlobalOffset, getMF().getDataLayout())) {
+                 NumericConstant, GlobalOffset, getMF())) {
     // The address of a global is a direct link-time constant. A displacement
     // from it rides along in the expression rather than in the operand.
     MIB.addGlobalAddress(GV);

--- a/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.cpp
+++ b/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.cpp
@@ -1466,7 +1466,7 @@ bool InstrRefBasedLDV::transferDebugValue(const MachineInstr &MI) {
         // debug values.
         if (MO.isReg()) {
           DebugOps.push_back(DbgOpStore.insert(MTracker->readReg(MO.getReg())));
-        } else if (MO.isImm() || MO.isFPImm() || MO.isCImm()) {
+        } else if (MO.isImm() || MO.isFPImm() || MO.isCImm() || MO.isGlobal()) {
           DebugOps.push_back(DbgOpStore.insert(MO));
         } else {
           llvm_unreachable("Unexpected debug operand type.");

--- a/llvm/lib/CodeGen/LiveDebugValues/VarLocBasedImpl.cpp
+++ b/llvm/lib/CodeGen/LiveDebugValues/VarLocBasedImpl.cpp
@@ -341,7 +341,8 @@ private:
       RegisterKind,
       SpillLocKind,
       ImmediateKind,
-      WasmLocKind
+      WasmLocKind,
+      GlobalAddrKind
     };
 
     enum class EntryValueLocKind {
@@ -361,6 +362,7 @@ private:
       const ConstantFP *FPImm;
       const ConstantInt *CImm;
       WasmLoc WasmLocation;
+      const GlobalValue *GV;
       MachineLocValue() : Hash(0) {}
     };
 
@@ -381,6 +383,7 @@ private:
           return Value.WasmLocation == Other.Value.WasmLocation;
         case MachineLocKind::RegisterKind:
         case MachineLocKind::ImmediateKind:
+        case MachineLocKind::GlobalAddrKind:
           return Value.Hash == Other.Value.Hash;
         default:
           llvm_unreachable("Invalid kind");
@@ -404,6 +407,7 @@ private:
                                  Other.Value.WasmLocation.Offset);
         case MachineLocKind::RegisterKind:
         case MachineLocKind::ImmediateKind:
+        case MachineLocKind::GlobalAddrKind:
           return std::tie(Kind, Value.Hash) <
                  std::tie(Other.Kind, Other.Value.Hash);
         default:
@@ -468,6 +472,9 @@ private:
       } else if (Op.isTargetIndex()) {
         Kind = MachineLocKind::WasmLocKind;
         Loc.WasmLocation = {Op.getIndex(), Op.getOffset()};
+      } else if (Op.isGlobal()) {
+        Kind = MachineLocKind::GlobalAddrKind;
+        Loc.GV = Op.getGlobal();
       } else
         llvm_unreachable("Invalid Op kind for MachineLoc.");
       return {Kind, Loc};
@@ -601,7 +608,8 @@ private:
           MOs.push_back(Orig);
           break;
         }
-        case MachineLocKind::WasmLocKind: {
+        case MachineLocKind::WasmLocKind:
+        case MachineLocKind::GlobalAddrKind: {
           MOs.push_back(Orig);
           break;
         }
@@ -614,7 +622,8 @@ private:
 
     /// Is the Loc field a constant or constant object?
     bool isConstant(MachineLocKind Kind) const {
-      return Kind == MachineLocKind::ImmediateKind;
+      return Kind == MachineLocKind::ImmediateKind ||
+             Kind == MachineLocKind::GlobalAddrKind;
     }
 
     /// Check if the Loc field is an entry backup location.
@@ -732,6 +741,9 @@ private:
           break;
         case MachineLocKind::ImmediateKind:
           Out << MLoc.Value.Immediate;
+          break;
+        case MachineLocKind::GlobalAddrKind:
+          Out << MLoc.Value.GV->getName();
           break;
         case MachineLocKind::WasmLocKind: {
           if (TII) {
@@ -1432,7 +1444,7 @@ void VarLocBasedLDV::transferDebugValue(const MachineInstr &MI,
 
   if (all_of(MI.debug_operands(), [](const MachineOperand &MO) {
         return (MO.isReg() && MO.getReg()) || MO.isImm() || MO.isFPImm() ||
-               MO.isCImm() || MO.isTargetIndex();
+               MO.isCImm() || MO.isTargetIndex() || MO.isGlobal();
       })) {
     // Use normal VarLoc constructor for registers and immediates.
     VarLoc VL(MI);

--- a/llvm/lib/CodeGen/LiveDebugValues/VarLocBasedImpl.cpp
+++ b/llvm/lib/CodeGen/LiveDebugValues/VarLocBasedImpl.cpp
@@ -326,6 +326,14 @@ private:
       bool operator!=(const WasmLoc &Other) const { return !(*this == Other); }
     };
 
+    struct GlobalAddr {
+      const GlobalValue *GV;
+      int64_t Offset;
+      bool operator==(const GlobalAddr &Other) const {
+        return GV == Other.GV && Offset == Other.Offset;
+      }
+    };
+
     /// Identity of the variable at this location.
     const DebugVariable Var;
 
@@ -362,7 +370,7 @@ private:
       const ConstantFP *FPImm;
       const ConstantInt *CImm;
       WasmLoc WasmLocation;
-      const GlobalValue *GV;
+      GlobalAddr GlobalAddress;
       MachineLocValue() : Hash(0) {}
     };
 
@@ -381,9 +389,10 @@ private:
           return Value.SpillLocation == Other.Value.SpillLocation;
         case MachineLocKind::WasmLocKind:
           return Value.WasmLocation == Other.Value.WasmLocation;
+        case MachineLocKind::GlobalAddrKind:
+          return Value.GlobalAddress == Other.Value.GlobalAddress;
         case MachineLocKind::RegisterKind:
         case MachineLocKind::ImmediateKind:
-        case MachineLocKind::GlobalAddrKind:
           return Value.Hash == Other.Value.Hash;
         default:
           llvm_unreachable("Invalid kind");
@@ -405,9 +414,13 @@ private:
                                  Value.WasmLocation.Offset) <
                  std::make_tuple(Other.Kind, Other.Value.WasmLocation.Index,
                                  Other.Value.WasmLocation.Offset);
+        case MachineLocKind::GlobalAddrKind:
+          return std::make_tuple(Kind, Value.GlobalAddress.GV,
+                                 Value.GlobalAddress.Offset) <
+                 std::make_tuple(Other.Kind, Other.Value.GlobalAddress.GV,
+                                 Other.Value.GlobalAddress.Offset);
         case MachineLocKind::RegisterKind:
         case MachineLocKind::ImmediateKind:
-        case MachineLocKind::GlobalAddrKind:
           return std::tie(Kind, Value.Hash) <
                  std::tie(Other.Kind, Other.Value.Hash);
         default:
@@ -474,7 +487,7 @@ private:
         Loc.WasmLocation = {Op.getIndex(), Op.getOffset()};
       } else if (Op.isGlobal()) {
         Kind = MachineLocKind::GlobalAddrKind;
-        Loc.GV = Op.getGlobal();
+        Loc.GlobalAddress = {Op.getGlobal(), Op.getOffset()};
       } else
         llvm_unreachable("Invalid Op kind for MachineLoc.");
       return {Kind, Loc};
@@ -743,7 +756,9 @@ private:
           Out << MLoc.Value.Immediate;
           break;
         case MachineLocKind::GlobalAddrKind:
-          Out << MLoc.Value.GV->getName();
+          Out << MLoc.Value.GlobalAddress.GV->getName();
+          if (MLoc.Value.GlobalAddress.Offset)
+            Out << '+' << MLoc.Value.GlobalAddress.Offset;
           break;
         case MachineLocKind::WasmLocKind: {
           if (TII) {

--- a/llvm/lib/CodeGen/LiveDebugValues/VarLocBasedImpl.cpp
+++ b/llvm/lib/CodeGen/LiveDebugValues/VarLocBasedImpl.cpp
@@ -374,8 +374,8 @@ private:
       MachineLocValue() : Hash(0) {}
     };
 
-    /// A single machine location; its Kind is either a register, spill
-    /// location, or immediate value.
+    /// A single machine location; its Kind is a register, a spill location, an
+    /// immediate value, a WebAssembly local, or the address of a global.
     /// If the VarLoc is not a NonEntryValueKind, then it will use only a
     /// single MachineLoc of RegisterKind.
     struct MachineLoc {
@@ -399,30 +399,32 @@ private:
         }
       }
       bool operator<(const MachineLoc &Other) const {
+        // Order by kind first, and only then by the payload. Which union member
+        // is the active one depends on the kind, so reading either side's
+        // payload is only well defined once both kinds are known to agree.
+        if (Kind != Other.Kind)
+          return Kind < Other.Kind;
         switch (Kind) {
         case MachineLocKind::SpillLocKind:
           return std::make_tuple(
-                     Kind, Value.SpillLocation.SpillBase,
+                     Value.SpillLocation.SpillBase,
                      Value.SpillLocation.SpillOffset.getFixed(),
                      Value.SpillLocation.SpillOffset.getScalable()) <
                  std::make_tuple(
-                     Other.Kind, Other.Value.SpillLocation.SpillBase,
+                     Other.Value.SpillLocation.SpillBase,
                      Other.Value.SpillLocation.SpillOffset.getFixed(),
                      Other.Value.SpillLocation.SpillOffset.getScalable());
         case MachineLocKind::WasmLocKind:
-          return std::make_tuple(Kind, Value.WasmLocation.Index,
-                                 Value.WasmLocation.Offset) <
-                 std::make_tuple(Other.Kind, Other.Value.WasmLocation.Index,
-                                 Other.Value.WasmLocation.Offset);
+          return std::tie(Value.WasmLocation.Index, Value.WasmLocation.Offset) <
+                 std::tie(Other.Value.WasmLocation.Index,
+                          Other.Value.WasmLocation.Offset);
         case MachineLocKind::GlobalAddrKind:
-          return std::make_tuple(Kind, Value.GlobalAddress.GV,
-                                 Value.GlobalAddress.Offset) <
-                 std::make_tuple(Other.Kind, Other.Value.GlobalAddress.GV,
-                                 Other.Value.GlobalAddress.Offset);
+          return std::tie(Value.GlobalAddress.GV, Value.GlobalAddress.Offset) <
+                 std::tie(Other.Value.GlobalAddress.GV,
+                          Other.Value.GlobalAddress.Offset);
         case MachineLocKind::RegisterKind:
         case MachineLocKind::ImmediateKind:
-          return std::tie(Kind, Value.Hash) <
-                 std::tie(Other.Kind, Other.Value.Hash);
+          return Value.Hash < Other.Value.Hash;
         default:
           llvm_unreachable("Invalid kind");
         }
@@ -1461,7 +1463,8 @@ void VarLocBasedLDV::transferDebugValue(const MachineInstr &MI,
         return (MO.isReg() && MO.getReg()) || MO.isImm() || MO.isFPImm() ||
                MO.isCImm() || MO.isTargetIndex() || MO.isGlobal();
       })) {
-    // Use normal VarLoc constructor for registers and immediates.
+    // Use the normal VarLoc constructor for every operand kind MachineLoc can
+    // hold directly: registers, immediates, WebAssembly locals and globals.
     VarLoc VL(MI);
     // End all previous ranges of VL.Var.
     OpenRanges.erase(VL);

--- a/llvm/lib/CodeGen/SelectionDAG/InstrEmitter.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/InstrEmitter.cpp
@@ -785,6 +785,9 @@ void InstrEmitter::AddDbgValueLocationOps(
     case SDDbgOperand::CONST:
       MIB.add(GetMOForConstDbgOp(Op));
       break;
+    case SDDbgOperand::GLOBALADDR:
+      MIB.addGlobalAddress(Op.getGlobal());
+      break;
     }
   }
 }
@@ -805,7 +808,8 @@ InstrEmitter::EmitDbgInstrRef(SDDbgValue *SD,
   // Returns true if the given operand is not itself an instruction reference
   // but is a legal debug operand for a DBG_INSTR_REF.
   auto IsNonInstrRefOp = [](SDDbgOperand DbgOp) {
-    return DbgOp.getKind() == SDDbgOperand::CONST;
+    return DbgOp.getKind() == SDDbgOperand::CONST ||
+           DbgOp.getKind() == SDDbgOperand::GLOBALADDR;
   };
 
   // If this variable location does not depend on any instructions or contains
@@ -883,6 +887,10 @@ InstrEmitter::EmitDbgInstrRef(SDDbgValue *SD,
       }
 
       DefMI = &*MRI->def_instr_begin(VReg);
+    } else if (DbgOperand.getKind() == SDDbgOperand::GLOBALADDR) {
+      MOs.push_back(MachineOperand::CreateGA(DbgOperand.getGlobal(),
+                                             /*Offset=*/0));
+      continue;
     } else {
       assert(DbgOperand.getKind() == SDDbgOperand::CONST);
       MOs.push_back(GetMOForConstDbgOp(DbgOperand));

--- a/llvm/lib/CodeGen/SelectionDAG/SDNodeDbgValue.h
+++ b/llvm/lib/CodeGen/SelectionDAG/SDNodeDbgValue.h
@@ -23,19 +23,22 @@ namespace llvm {
 
 class DIVariable;
 class DIExpression;
+class GlobalValue;
 class SDNode;
 class Value;
 class raw_ostream;
 
 /// Holds the information for a single machine location through SDISel; either
-/// an SDNode, a constant, a stack location, or a virtual register.
+/// an SDNode, a constant, a stack location, a virtual register, or the address
+/// of a global.
 class SDDbgOperand {
 public:
   enum Kind {
-    SDNODE = 0,  ///< Value is the result of an expression.
-    CONST = 1,   ///< Value is a constant.
-    FRAMEIX = 2, ///< Value is contents of a stack location.
-    VREG = 3     ///< Value is a virtual register.
+    SDNODE = 0,    ///< Value is the result of an expression.
+    CONST = 1,     ///< Value is a constant.
+    FRAMEIX = 2,   ///< Value is contents of a stack location.
+    VREG = 3,      ///< Value is a virtual register.
+    GLOBALADDR = 4 ///< Value is the address of a global.
   };
   Kind getKind() const { return kind; }
 
@@ -69,6 +72,12 @@ public:
     return u.VReg;
   }
 
+  /// Returns the GlobalValue whose address describes the variable.
+  const GlobalValue *getGlobal() const {
+    assert(kind == GLOBALADDR);
+    return u.GA;
+  }
+
   static SDDbgOperand fromNode(SDNode *Node, unsigned ResNo) {
     return SDDbgOperand(Node, ResNo);
   }
@@ -80,6 +89,9 @@ public:
   }
   static SDDbgOperand fromConst(const Value *Const) {
     return SDDbgOperand(Const);
+  }
+  static SDDbgOperand fromGlobalAddr(const GlobalValue *GV) {
+    return SDDbgOperand(GV, GLOBALADDR);
   }
 
   bool operator!=(const SDDbgOperand &Other) const { return !(*this == Other); }
@@ -95,6 +107,8 @@ public:
       return getVReg() == Other.getVReg();
     case FRAMEIX:
       return getFrameIx() == Other.getFrameIx();
+    case GLOBALADDR:
+      return getGlobal() == Other.getGlobal();
     }
     return false;
   }
@@ -106,9 +120,10 @@ private:
       SDNode *Node;   ///< Valid for expressions.
       unsigned ResNo; ///< Valid for expressions.
     } s;
-    const Value *Const; ///< Valid for constants.
-    unsigned FrameIx;   ///< Valid for stack objects.
-    unsigned VReg;      ///< Valid for registers.
+    const Value *Const;    ///< Valid for constants.
+    unsigned FrameIx;      ///< Valid for stack objects.
+    unsigned VReg;         ///< Valid for registers.
+    const GlobalValue *GA; ///< Valid for global addresses.
   } u;
 
   /// Constructor for non-constants.
@@ -118,6 +133,12 @@ private:
   }
   /// Constructor for constants.
   SDDbgOperand(const Value *C) : kind(CONST) { u.Const = C; }
+  /// Constructor for global addresses. Takes an explicit Kind because a
+  /// GlobalValue would otherwise be ambiguous with the Value constructor.
+  SDDbgOperand(const GlobalValue *GV, Kind Kind) : kind(Kind) {
+    assert(Kind == GLOBALADDR && "Invalid SDDbgValue constructor");
+    u.GA = GV;
+  }
   /// Constructor for virtual registers and frame indices.
   SDDbgOperand(unsigned VRegOrFrameIdx, Kind Kind) : kind(Kind) {
     assert((Kind == VREG || Kind == FRAMEIX) &&

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -1656,6 +1656,13 @@ bool SelectionDAGBuilder::handleDebugValue(ArrayRef<const Value *> Values,
         continue;
       }
 
+    // The address of a global is a link-time constant.
+    if (const auto *GV = dyn_cast<GlobalValue>(V))
+      if (canDescribeGlobalAddressInDebugInfo(GV)) {
+        LocationOps.emplace_back(SDDbgOperand::fromGlobalAddr(GV));
+        continue;
+      }
+
     // If the Value is a frame index, we can create a FrameIndex debug value
     // without relying on the DAG at all.
     if (const AllocaInst *AI = dyn_cast<AllocaInst>(V)) {

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -1659,10 +1659,12 @@ bool SelectionDAGBuilder::handleDebugValue(ArrayRef<const Value *> Values,
     // The address of a global is a link-time constant, and so is a constant
     // displacement from one. The displacement rides along in the expression
     // rather than in the operand, so that it survives into a DBG_INSTR_REF.
+    // A global whose address cannot be described this way falls through to be
+    // described by whatever materializes it instead.
     if (const auto *C = dyn_cast<Constant>(V)) {
-      int64_t Offset = 0;
-      if (const GlobalValue *GV =
-              getDescribableGlobalAddress(C, Offset, DAG.getDataLayout())) {
+      int64_t Offset;
+      if (const GlobalValue *GV = getDescribableGlobalAddress(
+              C, Offset, DAG.getMachineFunction())) {
         if (Offset) {
           SmallVector<uint64_t, 3> Ops;
           DIExpression::appendOffset(Ops, Offset);

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -1641,7 +1641,7 @@ bool SelectionDAGBuilder::handleDebugValue(ArrayRef<const Value *> Values,
 
   SmallVector<SDDbgOperand> LocationOps;
   SmallVector<SDNode *> Dependencies;
-  for (const Value *V : Values) {
+  for (const auto &[OpIdx, V] : enumerate(Values)) {
     // Constant value.
     if (isa<ConstantInt>(V) || isa<ConstantFP>(V) || isa<UndefValue>(V) ||
         isa<ConstantPointerNull>(V)) {
@@ -1656,12 +1656,23 @@ bool SelectionDAGBuilder::handleDebugValue(ArrayRef<const Value *> Values,
         continue;
       }
 
-    // The address of a global is a link-time constant.
-    if (const auto *GV = dyn_cast<GlobalValue>(V))
-      if (canDescribeGlobalAddressInDebugInfo(GV)) {
+    // The address of a global is a link-time constant, and so is a constant
+    // displacement from one. The displacement rides along in the expression
+    // rather than in the operand, so that it survives into a DBG_INSTR_REF.
+    if (const auto *C = dyn_cast<Constant>(V)) {
+      int64_t Offset = 0;
+      if (const GlobalValue *GV =
+              getDescribableGlobalAddress(C, Offset, DAG.getDataLayout())) {
+        if (Offset) {
+          SmallVector<uint64_t, 3> Ops;
+          DIExpression::appendOffset(Ops, Offset);
+          Expr = DIExpression::appendOpsToArg(Expr, Ops, OpIdx,
+                                              /*StackValue=*/false);
+        }
         LocationOps.emplace_back(SDDbgOperand::fromGlobalAddr(GV));
         continue;
       }
+    }
 
     // If the Value is a frame index, we can create a FrameIndex debug value
     // without relying on the DAG at all.

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGDumper.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGDumper.cpp
@@ -1063,6 +1063,9 @@ LLVM_DUMP_METHOD void SDDbgValue::print(raw_ostream &OS) const {
     case SDDbgOperand::VREG:
       OS << "VREG=" << printReg(Op.getVReg());
       break;
+    case SDDbgOperand::GLOBALADDR:
+      OS << "GLOBALADDR=" << Op.getGlobal()->getName();
+      break;
     }
     Comma = true;
   }

--- a/llvm/test/CodeGen/AArch64/GlobalISel/debug-insts.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/debug-insts.ll
@@ -46,7 +46,7 @@ define void @debug_value(i32 %in) #0 !dbg !16 {
   call void @llvm.dbg.value(metadata float 1.000000e+00, i64 0, metadata !17, metadata !DIExpression()), !dbg !18
 ; CHECK: DBG_VALUE 0, 0, !17, !DIExpression(), debug-location !18
   call void @llvm.dbg.value(metadata ptr null, i64 0, metadata !17, metadata !DIExpression()), !dbg !18
-; CHECK: DBG_VALUE $noreg, 0, !17, !DIExpression(), debug-location !18
+; CHECK: DBG_VALUE @gv, $noreg, !17, !DIExpression(), debug-location !18
   call void @llvm.dbg.value(metadata ptr @gv, i64 0, metadata !17, metadata !DIExpression()), !dbg !18
 ; CHECK: DBG_VALUE 42, 0, !17, !DIExpression(), debug-location !18
   call void @llvm.dbg.value(metadata ptr inttoptr (i64 42 to ptr), i64 0, metadata !17, metadata !DIExpression()), !dbg !18

--- a/llvm/test/DebugInfo/AArch64/dbg-value-globaladdr-gisel.ll
+++ b/llvm/test/DebugInfo/AArch64/dbg-value-globaladdr-gisel.ll
@@ -1,0 +1,89 @@
+;; Check that GlobalISel describes a variable holding the address of a global by
+;; naming the symbol, matching the SelectionDAG path in
+;; DebugInfo/X86/dbg-value-globaladdr.ll. The IRTranslator builds the same
+;; DBG_VALUE, and LiveDebugValues and the DWARF emitter are shared, so the
+;; emitted DWARF is identical between the two pipelines.
+
+; RUN: llc -O2 -mtriple=aarch64-apple-macosx -global-isel -stop-after=irtranslator \
+; RUN:   < %s | FileCheck %s --check-prefix=MIR
+; RUN: llc -O2 -mtriple=aarch64-apple-macosx -global-isel -filetype=obj < %s \
+; RUN:   | llvm-dwarfdump - | FileCheck %s --check-prefix=DWARF
+
+@g = external global i64, align 8
+@tls = external thread_local global i64, align 8
+
+;; Nothing in the function materializes the address. GlobalISel has no dangling
+;; debug info recovery at all, so before this the variable was dropped outright.
+; MIR-LABEL: name: global_only
+; MIR: DBG_VALUE @g, $noreg, ![[#]], !DIExpression()
+;
+; DWARF-LABEL: DW_AT_name ("global_only")
+; DWARF: DW_TAG_variable
+; DWARF-NEXT: DW_AT_location (DW_OP_addrx 0x1, DW_OP_stack_value)
+; DWARF-NEXT: DW_AT_name ("x")
+define void @global_only() !dbg !6 {
+entry:
+    #dbg_value(ptr @g, !10, !DIExpression(), !11)
+  tail call void @sink(ptr null), !dbg !11
+  ret void, !dbg !11
+}
+
+;; Here the address is materialized into a vreg, but describing the variable by
+;; that register would leave the start of the scope uncovered.
+; MIR-LABEL: name: global_stored
+; MIR: DBG_VALUE @g, $noreg, ![[#]], !DIExpression()
+; MIR-NOT: DBG_VALUE
+;
+; DWARF-LABEL: DW_AT_name ("global_stored")
+; DWARF: DW_TAG_variable
+; DWARF-NEXT: DW_AT_location (DW_OP_addrx 0x1, DW_OP_stack_value)
+; DWARF-NEXT: DW_AT_name ("y")
+define void @global_stored() !dbg !12 {
+entry:
+    #dbg_value(ptr @g, !13, !DIExpression(), !14)
+  %box = tail call ptr @alloc(), !dbg !14
+  store ptr @g, ptr %box, align 8, !dbg !14
+  tail call void @sink(ptr %box), !dbg !14
+  ret void, !dbg !14
+}
+
+;; A thread-local's address is not a link-time constant: describing it needs
+;; DW_OP_form_tls_address, so it must not be named as a symbol here. GlobalISel
+;; then drops it, which is what it did for every global before this -- naming the
+;; symbol does not regress that case, but does not fix it either.
+; MIR-LABEL: name: thread_local_global
+; MIR-NOT: DBG_VALUE @tls
+; MIR: DBG_VALUE $noreg, 0, ![[#]], !DIExpression()
+define void @thread_local_global() !dbg !15 {
+entry:
+    #dbg_value(ptr @tls, !16, !DIExpression(), !17)
+  tail call void @sink(ptr @tls), !dbg !17
+  ret void, !dbg !17
+}
+
+declare void @sink(ptr)
+declare ptr @alloc()
+
+!llvm.module.flags = !{!0, !1}
+!llvm.dbg.cu = !{!2}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = !{i32 7, !"Dwarf Version", i32 5}
+!2 = distinct !DICompileUnit(language: DW_LANG_C11, file: !3, producer: "clang", isOptimized: true, emissionKind: FullDebug)
+!3 = !DIFile(filename: "t.c", directory: "/")
+!4 = !DISubroutineType(types: !5)
+!5 = !{null}
+!6 = distinct !DISubprogram(name: "global_only", scope: !3, file: !3, line: 1, type: !4, scopeLine: 1, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2)
+!7 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !8, size: 64)
+!8 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+!9 = distinct !DILexicalBlock(scope: !6, file: !3, line: 2, column: 1)
+!10 = !DILocalVariable(name: "x", scope: !9, file: !3, line: 2, type: !7)
+!11 = !DILocation(line: 2, column: 1, scope: !9)
+!12 = distinct !DISubprogram(name: "global_stored", scope: !3, file: !3, line: 5, type: !4, scopeLine: 5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2)
+!13 = !DILocalVariable(name: "y", scope: !18, file: !3, line: 6, type: !7)
+!14 = !DILocation(line: 6, column: 1, scope: !18)
+!15 = distinct !DISubprogram(name: "thread_local_global", scope: !3, file: !3, line: 10, type: !4, scopeLine: 10, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2)
+!16 = !DILocalVariable(name: "z", scope: !19, file: !3, line: 11, type: !7)
+!17 = !DILocation(line: 11, column: 1, scope: !19)
+!18 = distinct !DILexicalBlock(scope: !12, file: !3, line: 6, column: 1)
+!19 = distinct !DILexicalBlock(scope: !15, file: !3, line: 11, column: 1)

--- a/llvm/test/DebugInfo/AArch64/dbg-value-globaladdr-gisel.ll
+++ b/llvm/test/DebugInfo/AArch64/dbg-value-globaladdr-gisel.ll
@@ -9,8 +9,8 @@
 ; RUN: llc -O2 -mtriple=aarch64-apple-macosx -global-isel -filetype=obj < %s \
 ; RUN:   | llvm-dwarfdump - | FileCheck %s --check-prefix=DWARF
 
-@g = external global i64, align 8
-@tls = external thread_local global i64, align 8
+@g = global i64 0, align 8
+@tls = thread_local global i64 0, align 8
 
 ;; Nothing in the function materializes the address. GlobalISel has no dangling
 ;; debug info recovery at all, so before this the variable was dropped outright.

--- a/llvm/test/DebugInfo/AArch64/dbg-value-globaladdr-gisel.ll
+++ b/llvm/test/DebugInfo/AArch64/dbg-value-globaladdr-gisel.ll
@@ -61,6 +61,23 @@ entry:
   ret void, !dbg !17
 }
 
+;; A constant displacement from the global rides along in the expression, the
+;; same way the SelectionDAG path spells it in
+;; DebugInfo/X86/globaladdr-offset.ll.
+; MIR-LABEL: name: globaladdr_offset
+; MIR: DBG_VALUE @g, $noreg, ![[#]], !DIExpression(DW_OP_plus_uconst, 8)
+;
+; DWARF-LABEL: DW_AT_name ("globaladdr_offset")
+; DWARF: DW_TAG_variable
+; DWARF-NEXT: DW_AT_location (DW_OP_addrx 0x1, DW_OP_plus_uconst 0x8, DW_OP_stack_value)
+; DWARF-NEXT: DW_AT_name ("w")
+define void @globaladdr_offset() !dbg !20 {
+entry:
+    #dbg_value(ptr getelementptr (i8, ptr @g, i64 8), !21, !DIExpression(), !22)
+  tail call void @sink(ptr null), !dbg !22
+  ret void, !dbg !22
+}
+
 declare void @sink(ptr)
 declare ptr @alloc()
 
@@ -87,3 +104,7 @@ declare ptr @alloc()
 !17 = !DILocation(line: 11, column: 1, scope: !19)
 !18 = distinct !DILexicalBlock(scope: !12, file: !3, line: 6, column: 1)
 !19 = distinct !DILexicalBlock(scope: !15, file: !3, line: 11, column: 1)
+!20 = distinct !DISubprogram(name: "globaladdr_offset", scope: !3, file: !3, line: 14, type: !4, scopeLine: 14, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2)
+!21 = !DILocalVariable(name: "w", scope: !23, file: !3, line: 15, type: !7)
+!22 = !DILocation(line: 15, column: 1, scope: !23)
+!23 = distinct !DILexicalBlock(scope: !20, file: !3, line: 15, column: 1)

--- a/llvm/test/DebugInfo/ARM/dbg-value-globaladdr-rwpi.ll
+++ b/llvm/test/DebugInfo/ARM/dbg-value-globaladdr-rwpi.ll
@@ -1,0 +1,79 @@
+;; Under RWPI a writable global is addressed relative to the static base
+;; register, so naming its symbol alone would describe a link-time offset where
+;; the source variable holds a runtime address. Check that a variable holding
+;; that address keeps the location it is materialized into, while a read-only
+;; global, which does keep an absolute address, is still named directly.
+
+; RUN: llc -O2 -mtriple=armv7-none-eabi -relocation-model=rwpi \
+; RUN:   -stop-after=finalize-isel < %s | FileCheck %s --check-prefix=MIR \
+; RUN:       --implicit-check-not='DBG_VALUE @g'
+; RUN: llc -O2 -mtriple=armv7-none-eabi -relocation-model=rwpi -filetype=obj \
+; RUN:   < %s | llvm-dwarfdump - | FileCheck %s --check-prefix=DWARF
+
+target datalayout = "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
+
+@g = global i32 0, align 4, !dbg !0
+@ro = constant i32 7, align 4, !dbg !14
+
+;; The static base register the debugger would have to add is not part of the
+;; symbol, and DwarfCompileUnit's construction for it needs an R_ARM_SBREL32
+;; relocation, which a location list cannot carry.
+; MIR-LABEL: name: writable
+; MIR: DBG_VALUE %{{[0-9]+}}, $noreg, ![[#]], !DIExpression()
+;
+; DWARF-LABEL: DW_AT_name ("writable")
+; DWARF: DW_TAG_variable
+; DWARF-NEXT: DW_AT_location (indexed (0x0) loclist = 0x{{[0-9a-f]+}}:
+; DWARF-NEXT: DW_OP_reg{{[0-9]+}} R{{[0-9]+}})
+; DWARF-NEXT: DW_AT_name ("p")
+define void @writable() !dbg !9 {
+entry:
+    #dbg_value(ptr @g, !12, !DIExpression(), !13)
+  %box = tail call ptr @alloc(), !dbg !13
+  store ptr @g, ptr %box, align 4, !dbg !13
+  tail call void @sink(ptr %box), !dbg !13
+  ret void, !dbg !13
+}
+
+; MIR-LABEL: name: readonly
+; MIR: DBG_VALUE @ro, $noreg, ![[#]], !DIExpression()
+;
+; DWARF-LABEL: DW_AT_name ("readonly")
+; DWARF: DW_TAG_variable
+; DWARF-NEXT: DW_AT_location (DW_OP_addrx 0x{{[0-9a-f]+}}, DW_OP_stack_value)
+; DWARF-NEXT: DW_AT_name ("q")
+define void @readonly() !dbg !16 {
+entry:
+    #dbg_value(ptr @ro, !17, !DIExpression(), !18)
+  %box = tail call ptr @alloc(), !dbg !18
+  store ptr @ro, ptr %box, align 4, !dbg !18
+  tail call void @sink(ptr %box), !dbg !18
+  ret void, !dbg !18
+}
+
+declare void @sink(ptr)
+declare ptr @alloc()
+
+!llvm.module.flags = !{!5, !6}
+!llvm.dbg.cu = !{!2}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "g", scope: !2, file: !3, line: 1, type: !8, isLocal: false, isDefinition: true)
+!2 = distinct !DICompileUnit(language: DW_LANG_C11, file: !3, producer: "clang", isOptimized: true, emissionKind: FullDebug, globals: !4)
+!3 = !DIFile(filename: "t.c", directory: "/")
+!4 = !{!0, !14}
+!5 = !{i32 2, !"Debug Info Version", i32 3}
+!6 = !{i32 7, !"Dwarf Version", i32 5}
+!7 = !DISubroutineType(types: !{null})
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = distinct !DISubprogram(name: "writable", scope: !3, file: !3, line: 5, type: !7, scopeLine: 5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2)
+!10 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !8, size: 32)
+!11 = distinct !DILexicalBlock(scope: !9, file: !3, line: 6, column: 1)
+!12 = !DILocalVariable(name: "p", scope: !11, file: !3, line: 6, type: !10)
+!13 = !DILocation(line: 6, column: 1, scope: !11)
+!14 = !DIGlobalVariableExpression(var: !15, expr: !DIExpression())
+!15 = distinct !DIGlobalVariable(name: "ro", scope: !2, file: !3, line: 2, type: !8, isLocal: false, isDefinition: true)
+!16 = distinct !DISubprogram(name: "readonly", scope: !3, file: !3, line: 12, type: !7, scopeLine: 12, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2)
+!17 = !DILocalVariable(name: "q", scope: !19, file: !3, line: 13, type: !10)
+!18 = !DILocation(line: 13, column: 1, scope: !19)
+!19 = distinct !DILexicalBlock(scope: !16, file: !3, line: 13, column: 1)

--- a/llvm/test/DebugInfo/COFF/globaladdr-codeview.ll
+++ b/llvm/test/DebugInfo/COFF/globaladdr-codeview.ll
@@ -1,0 +1,47 @@
+;; CodeView has no way to name a symbol in a local variable's location: a
+;; definition range holds a single register, and the fallback for anything else
+;; only covers immediates. Check that a variable holding the address of a
+;; global keeps the register location CodeView can consume rather than being
+;; described by a symbol and so marked optimized out.
+
+; RUN: llc -O2 -mtriple=x86_64-pc-windows-msvc -stop-after=finalize-isel < %s \
+; RUN:   | FileCheck %s --check-prefix=MIR --implicit-check-not='DBG_VALUE @g'
+; RUN: llc -O2 -mtriple=x86_64-pc-windows-msvc -filetype=obj < %s \
+; RUN:   | llvm-readobj --codeview - | FileCheck %s --check-prefix=CODEVIEW \
+; RUN:       --implicit-check-not=IsOptimizedOut
+
+@g = global i64 0, align 8
+
+; MIR-LABEL: name: codeview_global
+; MIR: DBG_INSTR_REF ![[#]], !DIExpression(DW_OP_LLVM_arg, 0)
+;
+; CODEVIEW:      VarName: p
+; CODEVIEW-NEXT: }
+; CODEVIEW-NEXT: DefRangeRegisterSym {
+; CODEVIEW:        Register: R{{[A-Z0-9]+}}
+define void @codeview_global() !dbg !6 {
+entry:
+    #dbg_value(ptr @g, !9, !DIExpression(), !10)
+  %box = tail call ptr @alloc(), !dbg !10
+  store ptr @g, ptr %box, align 8, !dbg !10
+  tail call void @sink(ptr %box), !dbg !10
+  ret void, !dbg !10
+}
+
+declare void @sink(ptr)
+declare ptr @alloc()
+
+!llvm.module.flags = !{!0, !1}
+!llvm.dbg.cu = !{!2}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = !{i32 2, !"CodeView", i32 1}
+!2 = distinct !DICompileUnit(language: DW_LANG_C11, file: !3, producer: "clang", isOptimized: true, emissionKind: FullDebug)
+!3 = !DIFile(filename: "t.c", directory: "/")
+!4 = !DISubroutineType(types: !{null})
+!5 = !DIBasicType(name: "long long", size: 64, encoding: DW_ATE_signed)
+!6 = distinct !DISubprogram(name: "codeview_global", scope: !3, file: !3, line: 1, type: !4, scopeLine: 1, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2)
+!7 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !5, size: 64)
+!8 = distinct !DILexicalBlock(scope: !6, file: !3, line: 2, column: 1)
+!9 = !DILocalVariable(name: "p", scope: !8, file: !3, line: 2, type: !7)
+!10 = !DILocation(line: 2, column: 1, scope: !8)

--- a/llvm/test/DebugInfo/MIR/X86/globaladdr-mixed-locations.mir
+++ b/llvm/test/DebugInfo/MIR/X86/globaladdr-mixed-locations.mir
@@ -1,0 +1,83 @@
+# RUN: llc %s -run-pass=livedebugvalues -o - \
+# RUN:   -experimental-debug-variable-locations=false | FileCheck %s
+
+## VarLoc-based LiveDebugValues keys its location map on a tagged union, so a
+## variable that has both a global-address range and a register range makes it
+## order the two kinds against each other. Check that both directions are
+## handled and that a global-address location is propagated across the CFG the
+## same way a register one is.
+##
+## Variables p and r hold the same two locations in opposite orders, so the map
+## sees a global-address key compared against a register key both ways round.
+
+# CHECK-LABEL: name: mixed_locations
+
+## Entering bb.1 from bb.0, both locations are live and get reinstated before
+## the local DBG_VALUEs redefine them.
+# CHECK-LABEL: bb.1:
+# CHECK-DAG: DBG_VALUE @g, $noreg, ![[P:[0-9]+]], !DIExpression()
+# CHECK-DAG: DBG_VALUE $rsi, $noreg, ![[R:[0-9]+]], !DIExpression()
+# CHECK: DBG_VALUE $rsi, $noreg, ![[P]], !DIExpression()
+# CHECK-NEXT: DBG_VALUE @g, $noreg, ![[R]], !DIExpression()
+
+## bb.2 is reached with p and r in different locations depending on the path,
+## so neither is live-in there and nothing is reinstated.
+# CHECK-LABEL: bb.2:
+# CHECK-NOT: DBG_VALUE
+# CHECK: RET64
+
+--- |
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-unknown-linux-gnu"
+
+  @g = dso_local global i64 0, align 8
+
+  define dso_local void @mixed_locations(i32 %c, ptr %q) !dbg !6 {
+    ret void
+  }
+
+  !llvm.dbg.cu = !{!2}
+  !llvm.module.flags = !{!0, !1}
+
+  !0 = !{i32 2, !"Debug Info Version", i32 3}
+  !1 = !{i32 7, !"Dwarf Version", i32 5}
+  !2 = distinct !DICompileUnit(language: DW_LANG_C11, file: !3, producer: "clang", isOptimized: true, emissionKind: FullDebug)
+  !3 = !DIFile(filename: "t.c", directory: "/")
+  !4 = !DISubroutineType(types: !{null})
+  !5 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+  !6 = distinct !DISubprogram(name: "mixed_locations", scope: !3, file: !3, line: 1, type: !4, scopeLine: 1, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !12)
+  !7 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !5, size: 64)
+  !8 = distinct !DILexicalBlock(scope: !6, file: !3, line: 2, column: 1)
+  !9 = !DILocalVariable(name: "p", scope: !8, file: !3, line: 2, type: !7)
+  !10 = !DILocalVariable(name: "r", scope: !8, file: !3, line: 3, type: !7)
+  !11 = !DILocation(line: 2, column: 1, scope: !8)
+  !12 = !{!9, !10}
+
+...
+---
+name:            mixed_locations
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $edi, $rsi
+
+    DBG_VALUE @g, $noreg, !9, !DIExpression(), debug-location !11
+    DBG_VALUE $rsi, $noreg, !10, !DIExpression(), debug-location !11
+    TEST32rr killed renamable $edi, renamable $edi, implicit-def $eflags, debug-location !11
+    JCC_1 %bb.2, 4, implicit $eflags, debug-location !11
+
+  bb.1:
+    successors: %bb.2
+    liveins: $rsi
+
+    DBG_VALUE $rsi, $noreg, !9, !DIExpression(), debug-location !11
+    DBG_VALUE @g, $noreg, !10, !DIExpression(), debug-location !11
+    JMP_1 %bb.2, debug-location !11
+
+  bb.2:
+    liveins: $rsi
+
+    RET64 debug-location !11
+
+...

--- a/llvm/test/DebugInfo/MIR/X86/globaladdr-offset.mir
+++ b/llvm/test/DebugInfo/MIR/X86/globaladdr-offset.mir
@@ -1,0 +1,115 @@
+# RUN: llc -mtriple=x86_64-unknown-linux-gnu -dwarf-version=5 \
+# RUN:   -filetype=obj -start-after=livedebugvalues -o - %s \
+# RUN:   | llvm-dwarfdump - | FileCheck %s
+
+# A displacement cannot be folded into an address pool entry, which is keyed on
+# the symbol alone, so it has to be applied by the expression.
+
+# CHECK-LABEL: DW_AT_name ("globaladdr_offset")
+# CHECK:       DW_TAG_variable
+# CHECK:       DW_AT_location (DW_OP_addrx {{0x[0-9a-f]+}}, DW_OP_plus_uconst 0x8, DW_OP_stack_value)
+# CHECK:       DW_AT_name ("x")
+
+# CHECK-LABEL: DW_AT_name ("globaladdr_negative_offset")
+# CHECK:       DW_TAG_variable
+# CHECK:       DW_AT_location (DW_OP_addrx {{0x[0-9a-f]+}}, DW_OP_consts -8, DW_OP_plus, DW_OP_stack_value)
+# CHECK:       DW_AT_name ("y")
+
+# Two locations that differ only in their displacement must not be merged into
+# a single range.
+
+# CHECK-LABEL: DW_AT_name ("globaladdr_offset_loclist")
+# CHECK:       DW_TAG_variable
+# CHECK:       DW_AT_location ({{.*}}loclist
+# CHECK-NEXT:  DW_OP_addrx [[POOL:0x[0-9a-f]+]], DW_OP_stack_value
+# CHECK-NEXT:  DW_OP_addrx [[POOL]], DW_OP_plus_uconst 0x8, DW_OP_stack_value
+# CHECK:       DW_AT_name ("z")
+--- |
+  ; ModuleID = 'globaladdr-offset.c'
+  source_filename = "globaladdr-offset.c"
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-unknown-linux-gnu"
+
+  @g = global i64 0, align 8
+
+  define void @globaladdr_offset() !dbg !5 {
+  entry:
+    ret void, !dbg !10
+  }
+
+  define void @globaladdr_negative_offset() !dbg !12 {
+  entry:
+    ret void, !dbg !14
+  }
+
+  define void @globaladdr_offset_loclist(i1 %c) !dbg !15 {
+  entry:
+    br i1 %c, label %taken, label %exit
+  taken:
+    br label %exit
+  exit:
+    ret void, !dbg !17
+  }
+
+  !llvm.module.flags = !{!0, !1}
+  !llvm.dbg.cu = !{!2}
+
+  !0 = !{i32 2, !"Debug Info Version", i32 3}
+  !1 = !{i32 7, !"Dwarf Version", i32 5}
+  !2 = distinct !DICompileUnit(language: DW_LANG_C11, file: !3, producer: "oracle", isOptimized: true, emissionKind: FullDebug)
+  !3 = !DIFile(filename: "globaladdr-offset.c", directory: "/")
+  !4 = !DISubroutineType(types: !11)
+  !5 = distinct !DISubprogram(name: "globaladdr_offset", scope: !3, file: !3, line: 1, type: !4, scopeLine: 1, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !6)
+  !6 = !{!7}
+  !7 = !DILocalVariable(name: "x", scope: !5, file: !3, line: 2, type: !8)
+  !8 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !9, size: 64)
+  !9 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+  !10 = !DILocation(line: 2, column: 1, scope: !5)
+  !11 = !{null}
+  !12 = distinct !DISubprogram(name: "globaladdr_negative_offset", scope: !3, file: !3, line: 4, type: !4, scopeLine: 4, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !18)
+  !13 = !DILocalVariable(name: "y", scope: !12, file: !3, line: 5, type: !8)
+  !14 = !DILocation(line: 5, column: 1, scope: !12)
+  !15 = distinct !DISubprogram(name: "globaladdr_offset_loclist", scope: !3, file: !3, line: 7, type: !4, scopeLine: 7, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !19)
+  !16 = !DILocalVariable(name: "z", scope: !15, file: !3, line: 8, type: !8)
+  !17 = !DILocation(line: 8, column: 1, scope: !15)
+  !18 = !{!13}
+  !19 = !{!16}
+...
+---
+name:            globaladdr_offset
+alignment:       16
+body:             |
+  bb.0.entry:
+    DBG_VALUE @g + 8, $noreg, !7, !DIExpression(), debug-location !10
+    RET64 debug-location !10
+...
+---
+name:            globaladdr_negative_offset
+alignment:       16
+body:             |
+  bb.0.entry:
+    DBG_VALUE @g + -8, $noreg, !13, !DIExpression(), debug-location !14
+    RET64 debug-location !14
+...
+---
+name:            globaladdr_offset_loclist
+alignment:       16
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    successors: %bb.1, %bb.2
+    liveins: $edi
+
+    DBG_VALUE @g + 0, $noreg, !16, !DIExpression(), debug-location !17
+    TEST8ri killed renamable $dil, 1, implicit-def $eflags
+    JCC_1 %bb.2, 4, implicit $eflags
+
+  bb.1.taken:
+    successors: %bb.2
+
+    DBG_VALUE @g + 8, $noreg, !16, !DIExpression(), debug-location !17
+    $eax = MOV32ri 0, debug-location !17
+
+  bb.2.exit:
+    RET64 debug-location !17
+...

--- a/llvm/test/DebugInfo/WebAssembly/dbg-value-globaladdr-pic.ll
+++ b/llvm/test/DebugInfo/WebAssembly/dbg-value-globaladdr-pic.ll
@@ -1,0 +1,71 @@
+;; Under PIC a WebAssembly global lives at __memory_base plus its symbol's
+;; address, so naming the symbol alone would describe a link-time offset where
+;; the source variable holds a runtime address. Check that a variable holding
+;; that address is left to the location the address is materialized into, and
+;; that non-PIC, where the symbol does name the address, still uses it.
+
+; RUN: llc -O2 -mtriple=wasm32-unknown-unknown -relocation-model=pic \
+; RUN:   -stop-after=finalize-isel < %s | FileCheck %s --check-prefix=PIC-MIR \
+; RUN:       --implicit-check-not='DBG_VALUE @g'
+; RUN: llc -O2 -mtriple=wasm32-unknown-unknown -relocation-model=pic \
+; RUN:   -filetype=obj < %s | llvm-dwarfdump - | FileCheck %s --check-prefix=PIC
+; RUN: llc -O2 -mtriple=wasm32-unknown-unknown -stop-after=finalize-isel < %s \
+; RUN:   | FileCheck %s --check-prefix=STATIC-MIR
+; RUN: llc -O2 -mtriple=wasm32-unknown-unknown -filetype=obj < %s \
+; RUN:   | llvm-dwarfdump - | FileCheck %s --check-prefix=STATIC
+
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-i128:128-n32:64-S128-ni:1:10:20"
+
+@g = global i32 0, align 4, !dbg !0
+
+; PIC-MIR-LABEL: name: global_stored
+; PIC-MIR: DBG_VALUE %{{[0-9]+}}, $noreg, ![[#]], !DIExpression()
+;
+;; The variable keeps the location the address is computed into. The global
+;; variable's own location shows what a description of that address takes: the
+;; symbol is only half of it, and DW_OP_WASM_location needs a relocation that a
+;; location list cannot carry.
+; PIC-LABEL: DW_AT_name ("global_stored")
+; PIC: DW_TAG_variable
+; PIC-NEXT: DW_AT_location (indexed (0x0) loclist = 0x{{[0-9a-f]+}}:
+; PIC-NEXT: DW_OP_WASM_location 0x0 0x0, DW_OP_stack_value)
+; PIC-NEXT: DW_AT_name ("p")
+; PIC: DW_AT_name ("g")
+; PIC: DW_AT_location (DW_OP_WASM_location 0x3 0x1, DW_OP_addrx 0x1, DW_OP_plus)
+;
+; STATIC-MIR-LABEL: name: global_stored
+; STATIC-MIR: DBG_VALUE @g, $noreg, ![[#]], !DIExpression()
+;
+; STATIC-LABEL: DW_AT_name ("global_stored")
+; STATIC: DW_TAG_variable
+; STATIC-NEXT: DW_AT_location (DW_OP_addrx 0x1, DW_OP_stack_value)
+; STATIC-NEXT: DW_AT_name ("p")
+define void @global_stored() !dbg !9 {
+entry:
+    #dbg_value(ptr @g, !12, !DIExpression(), !13)
+  %box = tail call ptr @alloc(), !dbg !13
+  store ptr @g, ptr %box, align 4, !dbg !13
+  tail call void @sink(ptr %box), !dbg !13
+  ret void, !dbg !13
+}
+
+declare void @sink(ptr)
+declare ptr @alloc()
+
+!llvm.module.flags = !{!5, !6}
+!llvm.dbg.cu = !{!2}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "g", scope: !2, file: !3, line: 1, type: !8, isLocal: false, isDefinition: true)
+!2 = distinct !DICompileUnit(language: DW_LANG_C11, file: !3, producer: "clang", isOptimized: true, emissionKind: FullDebug, globals: !4)
+!3 = !DIFile(filename: "t.c", directory: "/")
+!4 = !{!0}
+!5 = !{i32 2, !"Debug Info Version", i32 3}
+!6 = !{i32 7, !"Dwarf Version", i32 5}
+!7 = !DISubroutineType(types: !{null})
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = distinct !DISubprogram(name: "global_stored", scope: !3, file: !3, line: 5, type: !7, scopeLine: 5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2)
+!10 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !8, size: 32)
+!11 = distinct !DILexicalBlock(scope: !9, file: !3, line: 6, column: 1)
+!12 = !DILocalVariable(name: "p", scope: !11, file: !3, line: 6, type: !10)
+!13 = !DILocation(line: 6, column: 1, scope: !11)

--- a/llvm/test/DebugInfo/X86/dbg-val-list-dangling.ll
+++ b/llvm/test/DebugInfo/X86/dbg-val-list-dangling.ll
@@ -1,9 +1,5 @@
-;; At the moment we emit an undef as soon as we encounter "dangling" variadic
-;; dbg_value nodes. This does not reduce correctness but does reduce coverage.
-;; We should make variadic dbg_values work in the same way as their
-;; non-variadic counterparts here.
-;; FIXME: When dangling nodes for a variadic dbg_value are found, we should be
-;; able to recover the value in some cases.
+;; The address of a global is emitted as a location in its own right, so it never
+;; dangles and a variadic dbg_value recovers it just like a non-variadic one.
 
 ; RUN: llc %s -start-after=codegenprepare -stop-before=finalize-isel -o - -experimental-debug-variable-locations=false | FileCheck %s
 
@@ -22,8 +18,8 @@
 ; CHECK: ![[C:[0-9]+]] = !DILocalVariable(name: "c",
 ; CHECK: ![[D:[0-9]+]] = !DILocalVariable(name: "d",
 
-; CHECK-DAG: DBG_VALUE %[[VREG:[0-9]]], $noreg, ![[C]], !DIExpression(), debug-location
-; CHECK-DAG: DBG_VALUE_LIST ![[D]], !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_stack_value), $noreg, debug-location
+; CHECK-DAG: DBG_VALUE @.str, $noreg, ![[C]], !DIExpression(), debug-location
+; CHECK-DAG: DBG_VALUE_LIST ![[D]], !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_stack_value), @.str, debug-location
 
 target triple = "x86_64-unknown-linux-gnu"
 

--- a/llvm/test/DebugInfo/X86/dbg-value-globaladdr-rejected.ll
+++ b/llvm/test/DebugInfo/X86/dbg-value-globaladdr-rejected.ll
@@ -1,0 +1,82 @@
+;; Check the cases where the address of a global is not what its symbol names,
+;; and so must not be used as a variable location. Each keeps describing the
+;; variable by wherever the address is materialized instead.
+
+;; Nothing anywhere in the output may name a global as a debug value.
+; RUN: llc -O2 -mtriple=x86_64-unknown-linux-gnu -stop-after=finalize-isel \
+; RUN:   < %s | FileCheck %s --check-prefixes=CHECK,ELF \
+; RUN:       --implicit-check-not='DBG_VALUE @'
+; RUN: llc -O2 -mtriple=x86_64-pc-windows-gnu -stop-after=finalize-isel \
+; RUN:   < %s | FileCheck %s --check-prefixes=CHECK,COFF \
+; RUN:       --implicit-check-not='DBG_VALUE @'
+
+@declared = external global i64
+@imported = external dllimport global i64
+@chosen = ifunc void (), ptr @resolve_chosen
+
+;; A declaration has no definition here for a symbol reference to name.
+; CHECK-LABEL: name: external_declaration
+; CHECK: DBG_INSTR_REF ![[#]], !DIExpression(DW_OP_LLVM_arg, 0)
+define void @external_declaration() !dbg !6 {
+entry:
+    #dbg_value(ptr @declared, !9, !DIExpression(), !10)
+  tail call void @sink(ptr @declared), !dbg !10
+  ret void, !dbg !10
+}
+
+;; The address of a dllimport'd entity comes out of the import address table,
+;; so it is only known once that load has happened. IR can only spell dllimport
+;; on something that is a declaration for the linker anyway, so this is the
+;; behaviour rather than a distinct branch of the predicate.
+; COFF-LABEL: name: dllimport_address
+; COFF: DBG_INSTR_REF ![[#]], !DIExpression(DW_OP_LLVM_arg, 0)
+define void @dllimport_address() !dbg !11 {
+entry:
+    #dbg_value(ptr @imported, !12, !DIExpression(), !13)
+  tail call void @sink(ptr @imported), !dbg !13
+  ret void, !dbg !13
+}
+
+;; An ifunc's symbol resolves to whatever its resolver returns at load time,
+;; which is not the address of the symbol itself.
+; ELF-LABEL: name: ifunc_address
+; ELF: DBG_INSTR_REF ![[#]], !DIExpression(DW_OP_LLVM_arg, 0)
+define void @ifunc_address() !dbg !14 {
+entry:
+    #dbg_value(ptr @chosen, !15, !DIExpression(), !16)
+  tail call void @sink(ptr @chosen), !dbg !16
+  ret void, !dbg !16
+}
+
+define internal void @implementation() {
+  ret void
+}
+
+define internal ptr @resolve_chosen() {
+  ret ptr @implementation
+}
+
+declare void @sink(ptr)
+
+!llvm.module.flags = !{!0, !1}
+!llvm.dbg.cu = !{!2}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = !{i32 7, !"Dwarf Version", i32 5}
+!2 = distinct !DICompileUnit(language: DW_LANG_C11, file: !3, producer: "clang", isOptimized: true, emissionKind: FullDebug)
+!3 = !DIFile(filename: "t.c", directory: "/")
+!4 = !DISubroutineType(types: !{null})
+!5 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+!6 = distinct !DISubprogram(name: "external_declaration", scope: !3, file: !3, line: 1, type: !4, scopeLine: 1, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2)
+!7 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !5, size: 64)
+!8 = distinct !DILexicalBlock(scope: !6, file: !3, line: 2, column: 1)
+!9 = !DILocalVariable(name: "p", scope: !8, file: !3, line: 2, type: !7)
+!10 = !DILocation(line: 2, column: 1, scope: !8)
+!11 = distinct !DISubprogram(name: "dllimport_address", scope: !3, file: !3, line: 5, type: !4, scopeLine: 5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2)
+!12 = !DILocalVariable(name: "q", scope: !17, file: !3, line: 6, type: !7)
+!13 = !DILocation(line: 6, column: 1, scope: !17)
+!14 = distinct !DISubprogram(name: "ifunc_address", scope: !3, file: !3, line: 9, type: !4, scopeLine: 9, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2)
+!15 = !DILocalVariable(name: "r", scope: !18, file: !3, line: 10, type: !7)
+!16 = !DILocation(line: 10, column: 1, scope: !18)
+!17 = distinct !DILexicalBlock(scope: !11, file: !3, line: 6, column: 1)
+!18 = distinct !DILexicalBlock(scope: !14, file: !3, line: 10, column: 1)

--- a/llvm/test/DebugInfo/X86/dbg-value-globaladdr.ll
+++ b/llvm/test/DebugInfo/X86/dbg-value-globaladdr.ll
@@ -1,0 +1,97 @@
+;; Check that a dbg_value naming the address of a global describes the variable
+;; directly, for the whole of its scope, rather than waiting for the address to
+;; be materialized into a register.
+
+; RUN: llc -O2 -mtriple=x86_64-unknown-linux-gnu -stop-after=finalize-isel < %s \
+; RUN:   | FileCheck %s --check-prefix=MIR
+;; The GlobalISel equivalent is DebugInfo/AArch64/dbg-value-globaladdr-gisel.ll.
+; RUN: llc -O2 -mtriple=x86_64-unknown-linux-gnu -filetype=obj < %s \
+; RUN:   | llvm-dwarfdump - | FileCheck %s --check-prefix=DWARF5
+; RUN: llc -O2 -mtriple=x86_64-unknown-linux-gnu -dwarf-version=4 -filetype=obj < %s \
+; RUN:   | llvm-dwarfdump - | FileCheck %s --check-prefix=DWARF4
+
+@g = external global i64, align 8
+@tls = external thread_local global i64, align 8
+
+;; Nothing in the function materializes the address, so before this was
+;; described the variable was dropped entirely.
+; MIR-LABEL: name: global_only
+; MIR: DBG_VALUE @g, $noreg, ![[#]], !DIExpression()
+;
+;; DW_OP_addrx indexes .debug_addr, which is relocated to @g.
+; DWARF5-LABEL: DW_AT_name ("global_only")
+; DWARF5: DW_TAG_variable
+; DWARF5-NEXT: DW_AT_location (DW_OP_addrx 0x1, DW_OP_stack_value)
+; DWARF5-NEXT: DW_AT_name ("x")
+;
+;; Before DWARF 5 there is no .debug_addr to index outside of split DWARF, so
+;; the address is spelled as a relocated DW_OP_addr instead.
+; DWARF4-LABEL: DW_AT_name ("global_only")
+; DWARF4: DW_TAG_variable
+; DWARF4-NEXT: DW_AT_location (DW_OP_addr 0x0, DW_OP_stack_value)
+; DWARF4-NEXT: DW_AT_name ("x")
+define void @global_only() !dbg !6 {
+entry:
+    #dbg_value(ptr @g, !10, !DIExpression(), !11)
+  tail call void @sink(ptr null), !dbg !11
+  ret void, !dbg !11
+}
+
+;; Here the address is materialized, but describing the variable by the
+;; resulting register would leave the start of the scope uncovered.
+; MIR-LABEL: name: global_stored
+; MIR: DBG_VALUE @g, $noreg, ![[#]], !DIExpression()
+; MIR-NOT: DBG_VALUE
+;
+; DWARF5-LABEL: DW_AT_name ("global_stored")
+; DWARF5: DW_TAG_variable
+; DWARF5-NEXT: DW_AT_location (DW_OP_addrx 0x1, DW_OP_stack_value)
+; DWARF5-NEXT: DW_AT_name ("y")
+define void @global_stored() !dbg !12 {
+entry:
+    #dbg_value(ptr @g, !13, !DIExpression(), !14)
+  %box = tail call ptr @alloc(), !dbg !14
+  store ptr @g, ptr %box, align 8, !dbg !14
+  tail call void @sink(ptr %box), !dbg !14
+  ret void, !dbg !14
+}
+
+;; A thread-local's address is not a link-time constant: describing it needs
+;; DW_OP_form_tls_address, so it must not be named as a symbol here.
+; MIR-LABEL: name: thread_local_global
+; MIR-NOT: DBG_VALUE @tls
+;; It still gets a register location recovered from the dangling debug info.
+; MIR: DBG_INSTR_REF ![[#]], !DIExpression(DW_OP_LLVM_arg, 0)
+define void @thread_local_global() !dbg !15 {
+entry:
+    #dbg_value(ptr @tls, !16, !DIExpression(), !17)
+  tail call void @sink(ptr @tls), !dbg !17
+  ret void, !dbg !17
+}
+
+declare void @sink(ptr)
+declare ptr @alloc()
+
+!llvm.module.flags = !{!0, !1}
+!llvm.dbg.cu = !{!2}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = !{i32 7, !"Dwarf Version", i32 5}
+!2 = distinct !DICompileUnit(language: DW_LANG_C11, file: !3, producer: "clang", isOptimized: true, emissionKind: FullDebug)
+!3 = !DIFile(filename: "t.c", directory: "/")
+!4 = !DISubroutineType(types: !5)
+!5 = !{null}
+!6 = distinct !DISubprogram(name: "global_only", scope: !3, file: !3, line: 1, type: !4, scopeLine: 1, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2)
+!7 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !8, size: 64)
+!8 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+!10 = !DILocalVariable(name: "x", scope: !9, file: !3, line: 2, type: !7)
+!9 = distinct !DILexicalBlock(scope: !6, file: !3, line: 2, column: 1)
+!11 = !DILocation(line: 2, column: 1, scope: !9)
+!12 = distinct !DISubprogram(name: "global_stored", scope: !3, file: !3, line: 5, type: !4, scopeLine: 5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2)
+!13 = !DILocalVariable(name: "y", scope: !18, file: !3, line: 6, type: !7)
+!18 = distinct !DILexicalBlock(scope: !12, file: !3, line: 6, column: 1)
+!14 = !DILocation(line: 6, column: 1, scope: !18)
+!15 = distinct !DISubprogram(name: "thread_local_global", scope: !3, file: !3, line: 10, type: !4, scopeLine: 10, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2)
+!16 = !DILocalVariable(name: "z", scope: !19, file: !3, line: 11, type: !7)
+!19 = distinct !DILexicalBlock(scope: !15, file: !3, line: 11, column: 1)
+!17 = !DILocation(line: 11, column: 1, scope: !19)

--- a/llvm/test/DebugInfo/X86/dbg-value-globaladdr.ll
+++ b/llvm/test/DebugInfo/X86/dbg-value-globaladdr.ll
@@ -10,8 +10,8 @@
 ; RUN: llc -O2 -mtriple=x86_64-unknown-linux-gnu -dwarf-version=4 -filetype=obj < %s \
 ; RUN:   | llvm-dwarfdump - | FileCheck %s --check-prefix=DWARF4
 
-@g = external global i64, align 8
-@tls = external thread_local global i64, align 8
+@g = global i64 0, align 8
+@tls = thread_local global i64 0, align 8
 
 ;; Nothing in the function materializes the address, so before this was
 ;; described the variable was dropped entirely.

--- a/llvm/test/DebugInfo/X86/dbg-value-globaladdr.ll
+++ b/llvm/test/DebugInfo/X86/dbg-value-globaladdr.ll
@@ -9,6 +9,22 @@
 ; RUN:   | llvm-dwarfdump - | FileCheck %s --check-prefix=DWARF5
 ; RUN: llc -O2 -mtriple=x86_64-unknown-linux-gnu -dwarf-version=4 -filetype=obj < %s \
 ; RUN:   | llvm-dwarfdump - | FileCheck %s --check-prefix=DWARF4
+;; Describing the address as the variable's value needs DW_OP_stack_value, so
+;; neither the module flag nor the -dwarf-version override may pick this
+;; representation below DWARF 4. A bare DW_OP_addr would read as the address the
+;; variable lives at, so the implicit-check-nots below exclude it -- spelled
+;; with its operand, since a bare DW_OP_addr is also a prefix of DW_OP_addrx.
+; RUN: sed -e 's/!"Dwarf Version", i32 5/!"Dwarf Version", i32 3/' %s \
+; RUN:   | llc -O2 -mtriple=x86_64-unknown-linux-gnu -stop-after=finalize-isel \
+; RUN:   | FileCheck %s --check-prefix=DWARF3-MIR \
+; RUN:       --implicit-check-not='DBG_VALUE @'
+; RUN: sed -e 's/!"Dwarf Version", i32 5/!"Dwarf Version", i32 3/' %s \
+; RUN:   | llc -O2 -mtriple=x86_64-unknown-linux-gnu -filetype=obj \
+; RUN:   | llvm-dwarfdump - | FileCheck %s --check-prefix=DWARF3 \
+; RUN:       --implicit-check-not='DW_OP_addr 0x'
+; RUN: llc -O2 -mtriple=x86_64-unknown-linux-gnu -dwarf-version=2 -filetype=obj \
+; RUN:   < %s | llvm-dwarfdump - | FileCheck %s --check-prefix=DWARF2 \
+; RUN:       --implicit-check-not='DW_OP_addr 0x'
 
 @g = global i64 0, align 8
 @tls = thread_local global i64 0, align 8
@@ -47,6 +63,24 @@ entry:
 ; DWARF5: DW_TAG_variable
 ; DWARF5-NEXT: DW_AT_location (DW_OP_addrx 0x1, DW_OP_stack_value)
 ; DWARF5-NEXT: DW_AT_name ("y")
+;
+;; Below DWARF 4 the register the address is materialized into is still a valid
+;; location, and rejecting the symbol early is what keeps it available. Both the
+;; module flag and the -dwarf-version override reject, so both end up here.
+; DWARF3-MIR-LABEL: name: global_stored
+; DWARF3-MIR: DBG_INSTR_REF ![[#]], !DIExpression(DW_OP_LLVM_arg, 0)
+;
+; DWARF3-LABEL: DW_AT_name ("global_stored")
+; DWARF3: DW_TAG_variable
+; DWARF3-NEXT: DW_AT_location (0x{{[0-9a-f]+}}:
+; DWARF3-NEXT: DW_OP_reg[[#]] R{{[A-Z0-9]+}})
+; DWARF3-NEXT: DW_AT_name ("y")
+;
+; DWARF2-LABEL: DW_AT_name ("global_stored")
+; DWARF2: DW_TAG_variable
+; DWARF2-NEXT: DW_AT_location (0x{{[0-9a-f]+}}:
+; DWARF2-NEXT: DW_OP_reg[[#]] R{{[A-Z0-9]+}})
+; DWARF2-NEXT: DW_AT_name ("y")
 define void @global_stored() !dbg !12 {
 entry:
     #dbg_value(ptr @g, !13, !DIExpression(), !14)

--- a/llvm/test/DebugInfo/X86/globaladdr-offset.ll
+++ b/llvm/test/DebugInfo/X86/globaladdr-offset.ll
@@ -1,0 +1,87 @@
+;; A constant displacement from a global's address is a link-time constant too.
+;; The displacement is folded into the DIExpression rather than carried as an
+;; operand offset, so that it survives into a DBG_INSTR_REF, whose operands
+;; cannot hold one. DebugInfo/MIR/X86/globaladdr-offset.mir covers the
+;; operand-offset spelling that hand-written MIR and LiveDebugValues produce;
+;; both reach the same DWARF.
+
+; RUN: llc -O2 -mtriple=x86_64-unknown-linux-gnu -dwarf-version=5 \
+; RUN:   -stop-after=livedebugvalues < %s | FileCheck %s --check-prefix=MIR
+; RUN: llc -O2 -mtriple=x86_64-unknown-linux-gnu -dwarf-version=5 \
+; RUN:   -filetype=obj < %s | llvm-dwarfdump - | FileCheck %s --check-prefix=DWARF
+
+@g = global i64 0, align 8
+
+;; Nothing in the function materializes the address, so without this the
+;; variable is dropped outright.
+; MIR-LABEL: name: globaladdr_offset{{$}}
+; MIR: DBG_VALUE @g, $noreg, ![[#]], !DIExpression(DW_OP_plus_uconst, 8)
+;
+; DWARF-LABEL: DW_AT_name ("globaladdr_offset")
+; DWARF: DW_TAG_variable
+; DWARF-NEXT: DW_AT_location (DW_OP_addrx {{0x[0-9a-f]+}}, DW_OP_plus_uconst 0x8, DW_OP_stack_value)
+; DWARF-NEXT: DW_AT_name ("x")
+define void @globaladdr_offset() !dbg !5 {
+entry:
+    #dbg_value(ptr getelementptr (i8, ptr @g, i64 8), !7, !DIExpression(), !10)
+  call void @sink(ptr null), !dbg !10
+  ret void, !dbg !10
+}
+
+; MIR-LABEL: name: globaladdr_negative_offset{{$}}
+; MIR: DBG_VALUE @g, $noreg, ![[#]], !DIExpression(DW_OP_constu, 8, DW_OP_minus)
+;
+; DWARF-LABEL: DW_AT_name ("globaladdr_negative_offset")
+; DWARF: DW_TAG_variable
+; DWARF-NEXT: DW_AT_location (DW_OP_addrx {{0x[0-9a-f]+}}, DW_OP_lit8, DW_OP_minus, DW_OP_stack_value)
+; DWARF-NEXT: DW_AT_name ("y")
+define void @globaladdr_negative_offset() !dbg !12 {
+entry:
+    #dbg_value(ptr getelementptr (i8, ptr @g, i64 -8), !13, !DIExpression(), !14)
+  call void @sink(ptr null), !dbg !14
+  ret void, !dbg !14
+}
+
+;; In a DBG_VALUE_LIST the displacement has to be applied to its own operand,
+;; not to whatever happens to be on the stack. Which register the other operand
+;; lands in is beside the point, so only the tail of the expression is matched.
+; MIR-LABEL: name: globaladdr_offset_variadic{{$}}
+; MIR: DBG_VALUE_LIST ![[#]], !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_LLVM_arg, 1, DW_OP_plus_uconst, 8, DW_OP_plus, DW_OP_stack_value), $rdi, @g
+;
+; DWARF-LABEL: DW_AT_name ("globaladdr_offset_variadic")
+; DWARF: DW_TAG_variable
+; DWARF: DW_OP_addrx {{0x[0-9a-f]+}}, DW_OP_plus_uconst 0x8, DW_OP_plus, DW_OP_stack_value
+; DWARF: DW_AT_name ("z")
+define void @globaladdr_offset_variadic(i64 %n) !dbg !15 {
+entry:
+    #dbg_value(!DIArgList(i64 %n, ptr getelementptr (i8, ptr @g, i64 8)), !16, !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_LLVM_arg, 1, DW_OP_plus, DW_OP_stack_value), !17)
+  call void @sink_i64(i64 %n), !dbg !17
+  ret void, !dbg !17
+}
+
+declare void @sink(ptr)
+declare void @sink_i64(i64)
+
+!llvm.module.flags = !{!0, !1}
+!llvm.dbg.cu = !{!2}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = !{i32 7, !"Dwarf Version", i32 5}
+!2 = distinct !DICompileUnit(language: DW_LANG_C11, file: !3, producer: "clang", isOptimized: true, emissionKind: FullDebug)
+!3 = !DIFile(filename: "globaladdr-offset.c", directory: "/")
+!4 = !DISubroutineType(types: !11)
+!5 = distinct !DISubprogram(name: "globaladdr_offset", scope: !3, file: !3, line: 1, type: !4, scopeLine: 1, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !6)
+!6 = !{!7}
+!7 = !DILocalVariable(name: "x", scope: !5, file: !3, line: 2, type: !8)
+!8 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !9, size: 64)
+!9 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+!10 = !DILocation(line: 2, column: 1, scope: !5)
+!11 = !{null}
+!12 = distinct !DISubprogram(name: "globaladdr_negative_offset", scope: !3, file: !3, line: 4, type: !4, scopeLine: 4, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !18)
+!13 = !DILocalVariable(name: "y", scope: !12, file: !3, line: 5, type: !8)
+!14 = !DILocation(line: 5, column: 1, scope: !12)
+!15 = distinct !DISubprogram(name: "globaladdr_offset_variadic", scope: !3, file: !3, line: 7, type: !4, scopeLine: 7, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !19)
+!16 = !DILocalVariable(name: "z", scope: !15, file: !3, line: 8, type: !8)
+!17 = !DILocation(line: 8, column: 1, scope: !15)
+!18 = !{!13}
+!19 = !{!16}

--- a/llvm/test/DebugInfo/X86/globaladdr-tag-offset.ll
+++ b/llvm/test/DebugInfo/X86/globaladdr-tag-offset.ll
@@ -1,0 +1,36 @@
+; RUN: llc -O2 -mtriple=x86_64-unknown-linux-gnu -filetype=obj < %s \
+; RUN:   | llvm-dwarfdump - | FileCheck %s
+
+@g = global i64 0, align 8
+
+; CHECK-LABEL: DW_AT_name ("globaladdr_tag_offset")
+; CHECK:       DW_TAG_variable
+; CHECK:       DW_AT_location (DW_OP_addrx {{0x[0-9a-f]+}}, DW_OP_stack_value)
+; CHECK:       DW_AT_LLVM_tag_offset (0x07)
+; CHECK:       DW_AT_name ("x")
+define void @globaladdr_tag_offset() !dbg !6 {
+entry:
+  call void @llvm.dbg.value(metadata ptr @g, metadata !10, metadata !DIExpression(DW_OP_LLVM_tag_offset, 7)), !dbg !11
+  tail call void @sink(ptr null), !dbg !11
+  ret void, !dbg !11
+}
+
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+declare void @sink(ptr)
+
+!llvm.module.flags = !{!0, !1}
+!llvm.dbg.cu = !{!2}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = !{i32 7, !"Dwarf Version", i32 5}
+!2 = distinct !DICompileUnit(language: DW_LANG_C11, file: !3, producer: "clang", isOptimized: true, emissionKind: FullDebug)
+!3 = !DIFile(filename: "globaladdr-tag-offset.c", directory: "/")
+!4 = !DISubroutineType(types: !5)
+!5 = !{null}
+!6 = distinct !DISubprogram(name: "globaladdr_tag_offset", scope: !3, file: !3, line: 1, type: !4, scopeLine: 1, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !12)
+!7 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !8, size: 64)
+!8 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+!10 = !DILocalVariable(name: "x", scope: !9, file: !3, line: 2, type: !7)
+!9 = distinct !DILexicalBlock(scope: !6, file: !3, line: 2, column: 1)
+!11 = !DILocation(line: 2, column: 1, scope: !9)
+!12 = !{!10}

--- a/llvm/test/DebugInfo/X86/sdag-dangling-dbgvalue.ll
+++ b/llvm/test/DebugInfo/X86/sdag-dangling-dbgvalue.ll
@@ -1,9 +1,10 @@
 ; RUN: llc %s -stop-before finalize-isel -o - \
-; RUN:    -experimental-debug-variable-locations=false \
-; RUN: | FileCheck %s --check-prefixes=CHECK,DBGVALUE
+; RUN:    -experimental-debug-variable-locations=false | FileCheck %s
 ; RUN: llc %s -stop-before finalize-isel -o - \
-; RUN:    -experimental-debug-variable-locations=true \
-; RUN: | FileCheck %s --check-prefixes=CHECK,INSTRREF
+; RUN:    -experimental-debug-variable-locations=true | FileCheck %s
+
+;; The address of a global is emitted as a location in its own right, so none of
+;; these locations depend on an instruction and both modes agree.
 
 ;--------------------------------------------------------------------
 ; This test case is basically generated from the following C code.
@@ -67,59 +68,51 @@ target triple = "x86_64-apple-macosx10.4.0"
 
 @S = global %struct.SS { i32 23, i32 -17 }, align 4, !dbg !0
 
-; Verify that the def comes before the for foo1.
+; Verify that foo1 is described by the address of S rather than by the register
+; that address is later materialized into.
 define i32 @test1() local_unnamed_addr #0 !dbg !17 {
 ; CHECK-LABEL: bb.0.entry1
+; CHECK-NEXT:    DBG_VALUE @S, $noreg, ![[FOO1]], !DIExpression()
 ; CHECK-NEXT:    DBG_VALUE 0, $noreg, ![[BAR1]], !DIExpression()
-; CHECK-NEXT:    [[REG1:%[0-9]+]]:gr64 = LEA64r
-; INSTRREF-SAME:    debug-instr-number 1
-; INSTRREF-NEXT:  DBG_INSTR_REF ![[FOO1]], !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(1, 0)
-; DBGVALUE-NEXT:  DBG_VALUE [[REG1]], $noreg, ![[FOO1]], !DIExpression()
+; CHECK-NEXT:    %{{[0-9]+}}:gr64 = LEA64r
 entry1:
   call void @llvm.dbg.value(metadata ptr @S, metadata !20, metadata !DIExpression()), !dbg !23
   call void @llvm.dbg.value(metadata ptr null, metadata !22, metadata !DIExpression()), !dbg !24
   ret i32 ptrtoint (ptr @S to i32), !dbg !25
 }
 
-; Verify that the def comes before the for foo2 and bar2.
+; Verify that two variables sharing the address describe it independently.
 define i32 @test2() local_unnamed_addr #0 !dbg !26 {
 ; CHECK-LABEL: bb.0.entry2
-; CHECK-NEXT:    [[REG2:%[0-9]+]]:gr64 = LEA64r
-; INSTRREF-SAME:    debug-instr-number 1
-; INSTRREF-NEXT: DBG_INSTR_REF ![[FOO2]], !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(1, 0)
-; INSTRREF-NEXT: DBG_INSTR_REF ![[BAR2]], !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(1, 0)
-; DBGVALUE-NEXT: DBG_VALUE [[REG2]], $noreg, ![[FOO2]], !DIExpression
-; DBGVALUE-NEXT: DBG_VALUE [[REG2]], $noreg, ![[BAR2]], !DIExpression
+; CHECK-NEXT:    DBG_VALUE @S, $noreg, ![[FOO2]], !DIExpression()
+; CHECK-NEXT:    DBG_VALUE @S, $noreg, ![[BAR2]], !DIExpression()
+; CHECK-NEXT:    %{{[0-9]+}}:gr64 = LEA64r
 entry2:
   call void @llvm.dbg.value(metadata ptr @S, metadata !28, metadata !DIExpression()), !dbg !30
   call void @llvm.dbg.value(metadata ptr @S, metadata !29, metadata !DIExpression()), !dbg !31
   ret i32 add (i32 ptrtoint (ptr @S to i32), i32 ptrtoint (ptr @S to i32)), !dbg !32
 }
 
-; Verify that the def comes before the for foo3 and bar3.
+; Verify the same in the opposite declaration order.
 define i32 @test3() local_unnamed_addr #0 !dbg !33 {
 ; CHECK-LABEL: bb.0.entry3
-; CHECK-NEXT:    [[REG3:%[0-9]+]]:gr64 = LEA64r
-; INSTRREF-SAME:    debug-instr-number 1
-; INSTRREF-NEXT: DBG_INSTR_REF ![[BAR3]], !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(1, 0)
-; INSTRREF-NEXT: DBG_INSTR_REF ![[FOO3]], !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(1, 0)
-; DBGVALUE-NEXT: DBG_VALUE [[REG3]], $noreg, ![[BAR3]], !DIExpression()
-; DBGVALUE-NEXT: DBG_VALUE [[REG3]], $noreg, ![[FOO3]], !DIExpression()
+; CHECK-NEXT:    DBG_VALUE @S, $noreg, ![[BAR3]], !DIExpression()
+; CHECK-NEXT:    DBG_VALUE @S, $noreg, ![[FOO3]], !DIExpression()
+; CHECK-NEXT:    %{{[0-9]+}}:gr64 = LEA64r
 entry3:
   call void @llvm.dbg.value(metadata ptr @S, metadata !36, metadata !DIExpression()), !dbg !38
   call void @llvm.dbg.value(metadata ptr @S, metadata !35, metadata !DIExpression()), !dbg !37
   ret i32 add (i32 ptrtoint (ptr @S to i32), i32 ptrtoint (ptr @S to i32)), !dbg !39
 }
 
-; Verify that the def comes before the for bar4.
+; Verify that a variable reassigned after taking the address is described in
+; program order, so that the later assignment wins.
 define i32 @test4() local_unnamed_addr #0 !dbg !40 {
 ; CHECK-LABEL: bb.0.entry4
-; CHECK-NEXT:    DBG_VALUE $noreg, $noreg, ![[FOO4]], !DIExpression()
+; CHECK-NEXT:    DBG_VALUE @S, $noreg, ![[FOO4]], !DIExpression()
+; CHECK-NEXT:    DBG_VALUE @S, $noreg, ![[BAR4]], !DIExpression()
 ; CHECK-NEXT:    DBG_VALUE 0, $noreg, ![[FOO4]], !DIExpression()
-; CHECK-NEXT:    [[REG4:%[0-9]+]]:gr64 = LEA64r
-; INSTRREF-SAME:    debug-instr-number 1
-; INSTRREF-NEXT: DBG_INSTR_REF ![[BAR4]], !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(1, 0)
-; DBGVALUE-NEXT: DBG_VALUE [[REG4]], $noreg, ![[BAR4]], !DIExpression()
+; CHECK-NEXT:    %{{[0-9]+}}:gr64 = LEA64r
 entry4:
   call void @llvm.dbg.value(metadata ptr @S, metadata !42, metadata !DIExpression()), !dbg !44
   call void @llvm.dbg.value(metadata ptr @S, metadata !43, metadata !DIExpression()), !dbg !45
@@ -127,15 +120,13 @@ entry4:
   ret i32 ptrtoint (ptr @S to i32), !dbg !46
 }
 
-; Verify that we do not get a DBG_VALUE that maps foo5 to @S here.
+; Verify that foo5 is not mapped back to @S after being reassigned.
 define i32 @test5() local_unnamed_addr #0 !dbg !47 {
 ; CHECK-LABEL: bb.0.entry5:
-; CHECK-NEXT:    DBG_VALUE $noreg, $noreg, ![[FOO5]], !DIExpression()
+; CHECK-NEXT:    DBG_VALUE @S, $noreg, ![[BAR5]], !DIExpression()
+; CHECK-NEXT:    DBG_VALUE @S, $noreg, ![[FOO5]], !DIExpression()
 ; CHECK-NEXT:    DBG_VALUE 0, $noreg, ![[FOO5]], !DIExpression()
-; CHECK-NEXT:    [[REG5:%[0-9]+]]:gr64 = LEA64r
-; INSTRREF-SAME:    debug-instr-number 1
-; INSTRREF-NEXT: DBG_INSTR_REF ![[BAR5]], !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(1, 0)
-; DBGVALUE-NEXT: DBG_VALUE [[REG5]], $noreg, ![[BAR5]], !DIExpression()
+; CHECK-NEXT:    %{{[0-9]+}}:gr64 = LEA64r
 ; CHECK-NOT:     DBG_{{.*}} ![[FOO5]], !DIExpression()
 ; CHECK:         RET
 entry5:

--- a/llvm/test/DebugInfo/X86/sdag-dangling-dbgvalue.ll
+++ b/llvm/test/DebugInfo/X86/sdag-dangling-dbgvalue.ll
@@ -4,7 +4,9 @@
 ; RUN:    -experimental-debug-variable-locations=true | FileCheck %s
 
 ;; The address of a global is emitted as a location in its own right, so none of
-;; these locations depend on an instruction and both modes agree.
+;; these locations depend on an instruction and both modes agree. That needs
+;; DW_OP_stack_value to describe, hence the DWARF 5 module flag below; the
+;; original DWARF 2 flag is covered by DebugInfo/X86/dbg-value-globaladdr.ll.
 
 ;--------------------------------------------------------------------
 ; This test case is basically generated from the following C code.
@@ -158,7 +160,7 @@ attributes #1 = { nounwind readnone speculatable }
 !9 = !{!10, !11}
 !10 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !8, file: !3, line: 2, baseType: !6, size: 32)
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !8, file: !3, line: 3, baseType: !6, size: 32, offset: 32)
-!12 = !{i32 2, !"Dwarf Version", i32 2}
+!12 = !{i32 2, !"Dwarf Version", i32 5}
 !13 = !{i32 2, !"Debug Info Version", i32 3}
 !14 = !{i32 1, !"wchar_size", i32 4}
 !15 = !{i32 7, !"PIC Level", i32 2}

--- a/llvm/test/DebugInfo/assignment-tracking/X86/sdag-dangling-dbgassign.ll
+++ b/llvm/test/DebugInfo/assignment-tracking/X86/sdag-dangling-dbgassign.ll
@@ -1,10 +1,11 @@
 ; RUN: llc %s -stop-before finalize-isel -o - \
-; RUN:    -experimental-debug-variable-locations=false \
-; RUN: | FileCheck %s --check-prefixes=CHECK,DBGVALUE
+; RUN:    -experimental-debug-variable-locations=false | FileCheck %s
 
 ; RUN: llc %s -stop-before finalize-isel -o - \
-; RUN:    -experimental-debug-variable-locations=true \
-; RUN: | FileCheck %s --check-prefixes=CHECK,INSTRREF
+; RUN:    -experimental-debug-variable-locations=true | FileCheck %s
+
+;; The address of a global is emitted as a location in its own right, so none of
+;; these locations depend on an instruction and both modes agree.
 
 ;--------------------------------------------------------------------
 ; Adapted from sdag-dangling-dbgvalue.ll to test dbg.assign intrinsics. This
@@ -72,60 +73,51 @@ target triple = "x86_64-apple-macosx10.4.0"
 
 @S = global %struct.SS { i32 23, i32 -17 }, align 4, !dbg !0
 
-; Verify that the def comes before the for foo1.
+; Verify that foo1 is described by the address of S rather than by the register
+; that address is later materialized into.
 define i32 @test1() local_unnamed_addr #0 !dbg !17 {
 ; CHECK-LABEL: bb.0.entry1
+; CHECK-NEXT:    DBG_VALUE @S, $noreg, ![[FOO1]], !DIExpression()
 ; CHECK-NEXT:    DBG_VALUE 0, $noreg, ![[BAR1]], !DIExpression()
-; CHECK-NEXT:    [[REG1:%[0-9]+]]:gr64 = LEA64r
-; INSTRREF-SAME:    debug-instr-number 1
-; INSTRREF-NEXT:  DBG_INSTR_REF ![[FOO1]], !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(1, 0)
-; DBGVALUE-NEXT:  DBG_VALUE [[REG1]], $noreg, ![[FOO1]], !DIExpression()
+; CHECK-NEXT:    %{{[0-9]+}}:gr64 = LEA64r
 entry1:
   call void @llvm.dbg.assign(metadata ptr @S, metadata !20, metadata !DIExpression(), metadata !54, metadata ptr undef, metadata !DIExpression()), !dbg !23
   call void @llvm.dbg.assign(metadata ptr null, metadata !22, metadata !DIExpression(), metadata !54, metadata ptr undef, metadata !DIExpression()), !dbg !24
   ret i32 ptrtoint (ptr @S to i32), !dbg !25
 }
 
-; Verify that the def comes before the for foo2 and bar2.
+; Verify that two variables sharing the address describe it independently.
 define i32 @test2() local_unnamed_addr #0 !dbg !26 {
 ; CHECK-LABEL: bb.0.entry2
-; CHECK-NEXT:    [[REG2:%[0-9]+]]:gr64 = LEA64r
-; INSTRREF-SAME:    debug-instr-number 1
-; INSTRREF-NEXT: DBG_INSTR_REF ![[FOO2]], !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(1, 0)
-; INSTRREF-NEXT: DBG_INSTR_REF ![[BAR2]], !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(1, 0)
-; DBGVALUE-NEXT: DBG_VALUE [[REG2]], $noreg, ![[FOO2]], !DIExpression
-; DBGVALUE-NEXT: DBG_VALUE [[REG2]], $noreg, ![[BAR2]], !DIExpression
+; CHECK-NEXT:    DBG_VALUE @S, $noreg, ![[FOO2]], !DIExpression()
+; CHECK-NEXT:    DBG_VALUE @S, $noreg, ![[BAR2]], !DIExpression()
+; CHECK-NEXT:    %{{[0-9]+}}:gr64 = LEA64r
 entry2:
   call void @llvm.dbg.assign(metadata ptr @S, metadata !28, metadata !DIExpression(), metadata !54, metadata ptr undef, metadata !DIExpression()), !dbg !30
   call void @llvm.dbg.assign(metadata ptr @S, metadata !29, metadata !DIExpression(), metadata !54, metadata ptr undef, metadata !DIExpression()), !dbg !31
   ret i32 add (i32 ptrtoint (ptr @S to i32), i32 ptrtoint (ptr @S to i32)), !dbg !32
 }
 
-; Verify that the def comes before the for foo3 and bar3.
+; Verify the same in the opposite declaration order.
 define i32 @test3() local_unnamed_addr #0 !dbg !33 {
 ; CHECK-LABEL: bb.0.entry3
-; CHECK-NEXT:    [[REG3:%[0-9]+]]:gr64 = LEA64r
-; INSTRREF-SAME:    debug-instr-number 1
-; INSTRREF-NEXT: DBG_INSTR_REF ![[BAR3]], !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(1, 0)
-; INSTRREF-NEXT: DBG_INSTR_REF ![[FOO3]], !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(1, 0)
-; DBGVALUE-NEXT: DBG_VALUE [[REG3]], $noreg, ![[BAR3]], !DIExpression()
-; DBGVALUE-NEXT: DBG_VALUE [[REG3]], $noreg, ![[FOO3]], !DIExpression()
+; CHECK-NEXT:    DBG_VALUE @S, $noreg, ![[BAR3]], !DIExpression()
+; CHECK-NEXT:    DBG_VALUE @S, $noreg, ![[FOO3]], !DIExpression()
+; CHECK-NEXT:    %{{[0-9]+}}:gr64 = LEA64r
 entry3:
   call void @llvm.dbg.assign(metadata ptr @S, metadata !36, metadata !DIExpression(), metadata !54, metadata ptr undef, metadata !DIExpression()), !dbg !38
   call void @llvm.dbg.assign(metadata ptr @S, metadata !35, metadata !DIExpression(), metadata !54, metadata ptr undef, metadata !DIExpression()), !dbg !37
   ret i32 add (i32 ptrtoint (ptr @S to i32), i32 ptrtoint (ptr @S to i32)), !dbg !39
 }
 
-; Verify that the def comes before the for bar4.
+; Verify that a variable reassigned after taking the address is described in
+; program order, so that the later assignment wins. Assignment tracking has
+; already dropped foo4's redundant @S location.
 define i32 @test4() local_unnamed_addr #0 !dbg !40 {
 ; CHECK-LABEL: bb.0.entry4
-;; NOTE: The check for `DBG_VALUE $noreg, $noreg, ![[FOO4]], !DIExpression()`
-;; has been removed because AT lowering removes redundant debug intrinsics.
+; CHECK-NEXT:    DBG_VALUE @S, $noreg, ![[BAR4]], !DIExpression()
 ; CHECK-NEXT:    DBG_VALUE 0, $noreg, ![[FOO4]], !DIExpression()
-; CHECK-NEXT:    [[REG4:%[0-9]+]]:gr64 = LEA64r
-; INSTRREF-SAME:    debug-instr-number 1
-; INSTRREF-NEXT: DBG_INSTR_REF ![[BAR4]], !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(1, 0)
-; DBGVALUE-NEXT: DBG_VALUE [[REG4]], $noreg, ![[BAR4]], !DIExpression()
+; CHECK-NEXT:    %{{[0-9]+}}:gr64 = LEA64r
 entry4:
   call void @llvm.dbg.assign(metadata ptr @S, metadata !42, metadata !DIExpression(), metadata !54, metadata ptr undef, metadata !DIExpression()), !dbg !44
   call void @llvm.dbg.assign(metadata ptr @S, metadata !43, metadata !DIExpression(), metadata !54, metadata ptr undef, metadata !DIExpression()), !dbg !45
@@ -133,15 +125,12 @@ entry4:
   ret i32 ptrtoint (ptr @S to i32), !dbg !46
 }
 
-; Verify that we do not get a DBG_VALUE that maps foo5 to @S here.
+; Verify that foo5 is not mapped back to @S after being reassigned.
 define i32 @test5() local_unnamed_addr #0 !dbg !47 {
 ; CHECK-LABEL: bb.0.entry5:
-; cHECK-NEXT:    DBG_VALUE $noreg, $noreg, ![[FOO5]], !DIExpression()
+; CHECK-NEXT:    DBG_VALUE @S, $noreg, ![[BAR5]], !DIExpression()
 ; CHECK-NEXT:    DBG_VALUE 0, $noreg, ![[FOO5]], !DIExpression()
-; CHECK-NEXT:    [[REG5:%[0-9]+]]:gr64 = LEA64r
-; INSTRREF-SAME:    debug-instr-number 1
-; INSTRREF-NEXT: DBG_INSTR_REF ![[BAR5]], !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(1, 0)
-; DBGVALUE-NEXT: DBG_VALUE [[REG5]], $noreg, ![[BAR5]], !DIExpression()
+; CHECK-NEXT:    %{{[0-9]+}}:gr64 = LEA64r
 ; CHECK-NOT:     DBG_{{.*}} ![[FOO5]], !DIExpression()
 ; CHECK:         RET
 entry5:

--- a/llvm/test/DebugInfo/assignment-tracking/X86/sdag-dangling-dbgassign.ll
+++ b/llvm/test/DebugInfo/assignment-tracking/X86/sdag-dangling-dbgassign.ll
@@ -5,7 +5,8 @@
 ; RUN:    -experimental-debug-variable-locations=true | FileCheck %s
 
 ;; The address of a global is emitted as a location in its own right, so none of
-;; these locations depend on an instruction and both modes agree.
+;; these locations depend on an instruction and both modes agree. That needs
+;; DW_OP_stack_value to describe, hence the DWARF 5 module flag below.
 
 ;--------------------------------------------------------------------
 ; Adapted from sdag-dangling-dbgvalue.ll to test dbg.assign intrinsics. This
@@ -161,7 +162,7 @@ attributes #1 = { nounwind readnone speculatable }
 !9 = !{!10, !11}
 !10 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !8, file: !3, line: 2, baseType: !6, size: 32)
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !8, file: !3, line: 3, baseType: !6, size: 32, offset: 32)
-!12 = !{i32 2, !"Dwarf Version", i32 2}
+!12 = !{i32 2, !"Dwarf Version", i32 5}
 !13 = !{i32 2, !"Debug Info Version", i32 3}
 !14 = !{i32 1, !"wchar_size", i32 4}
 !15 = !{i32 7, !"PIC Level", i32 2}


### PR DESCRIPTION
This patch adds support for global address locations to SelectionDAG, GlobalISel and AsmPrinter. The actual implementation is very similar to how constants are being handled so most code changes are very mechanical.

The motivation for adding global address support is the Swift compiler and it is needed even in unoptimized code. For example, the standard libary implements the empty array with a global "empty array storage" singleton object, so it can show up as the location of array values. Another very common use-case are references to type metadata, which is also accessed via global symbols.

It is even possible to motivate this with a C exmple:

  extern int g; int *p = &g;

also produces the dbg_value with a global value.

This patch adds an SDDbgOperand kind for a global address which gets lowered to a MO_GlobalAddress DBG_VALUE operand, a DbgValueLocEntry, and finally DW_OP_addrx/DW_OP_stack_value, similar to how global DITemplateValueParameter are handled.

In AsmPrinter the address pool is preferred, its index is plain data that both a DIE and the byte stream backing a location list can hold. Before DWARF 5 the pool is only available under split DWARF, so fall back to a relocated DW_OP_addr, which only a DIE can carry. Emit no location at all when neither is possible.

Not handled are thread locals, which need DW_OP_form_tls_address, dllimport, whose address requires a load from the import address table, and ifuncs, whose symbol address is not the value of the pointer.

rdar://156549577
Assisted-by: Claude