### PR TITLE
[alpha.webkit.UncheckedLambdaCapturesChecker] Allow protectedThis of RefPtr

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLambdaCapturesChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLambdaCapturesChecker.cpp
@@ -441,8 +441,8 @@ public:
             auto *Ctor = CE->getConstructor();
             if (!Ctor)
               return false;
-            auto clsName = safeGetName(Ctor->getParent());
-            if (Checker->isPtrType(clsName) && CE->getNumArgs()) {
+            auto ArgClsTy = dyn_cast_or_null<CXXRecordDecl>(Ctor->getParent());
+            if (Checker->Model->isSafePtr(ArgClsTy) && CE->getNumArgs()) {
               Arg = CE->getArg(0)->IgnoreParenCasts();
               continue;
             }

--- a/clang/test/Analysis/Checkers/WebKit/unchecked-lambda-captures.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/unchecked-lambda-captures.cpp
@@ -127,6 +127,8 @@ void lambda_capture_param(CheckedObj* obj) {
 struct CheckedObjWithLambdaCapturingThis {
   void incrementCheckedPtrCount() const;
   void decrementCheckedPtrCount() const;
+  void ref() const;
+  void deref() const;
   void nonTrivial();
 
   void method_captures_this_safe() {
@@ -263,6 +265,12 @@ struct CheckedObjWithLambdaCapturingThis {
       callAsync([this, protectedThis = WTF::move(*protectedThis)] {
         nonTrivial();
       });
+    });
+  }
+
+  void method_captures_this_with_protected_refptr() {
+    call([this, protectedThis = RefPtr { this }]() {
+      nonTrivial();
     });
   }
 };


### PR DESCRIPTION
Fix a bug that lambda capture checkers were checking for the exact match for "protectedThis" as opposed to any protective smart pointer.