### PR TITLE
[AArch64] Restore always-inline behaviour for incompatible SME attributes.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
@@ -301,7 +301,12 @@ bool AArch64TTIImpl::areInlineCompatible(const Function *Caller,
   if (CallAttrs.requiresLazySave() || CallAttrs.requiresSMChange() ||
       CallAttrs.requiresPreservingZT0() ||
       CallAttrs.requiresPreservingAllZAState()) {
-    if (hasPossibleIncompatibleOps(Callee, *getTLI()))
+    // For always-inline functions we can ignore the SME attributes as we should
+    // be able to assume that the user knows what they're doing and that the
+    // front-end has given sufficient warning or error diagnostics to guard the
+    // user.
+    if (!Callee->hasFnAttribute(Attribute::AlwaysInline) &&
+        hasPossibleIncompatibleOps(Callee, *getTLI()))
       return false;
   }
 

--- a/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
@@ -301,10 +301,15 @@ bool AArch64TTIImpl::areInlineCompatible(const Function *Caller,
   if (CallAttrs.requiresLazySave() || CallAttrs.requiresSMChange() ||
       CallAttrs.requiresPreservingZT0() ||
       CallAttrs.requiresPreservingAllZAState()) {
-    // For always-inline functions we can ignore the SME attributes as we should
-    // be able to assume that the user knows what they're doing and that the
-    // front-end has given sufficient warning or error diagnostics to guard the
-    // user.
+    // For always-inline functions we don't check the SME attributes as
+    // otherwise it would block simple 'alwaysinline' utility functions in
+    // existing libraries from being inlined in streaming functions (e.g.
+    // std::max). Clang issues a warning diagnostic for this case to warn the
+    // user that always-inlining the function may not be safe. Unfortunately, it
+    // is difficult to comprehensively guard against this in Clang, as it would
+    // require analyzing the function bodies for all always-inline functions
+    // for each of their call-sites. The approach taken here is therefore a
+    // compromise between safety and usability.
     if (!Callee->hasFnAttribute(Attribute::AlwaysInline) &&
         hasPossibleIncompatibleOps(Callee, *getTLI()))
       return false;

--- a/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
@@ -310,6 +310,8 @@ bool AArch64TTIImpl::areInlineCompatible(const Function *Caller,
     // require analyzing the function bodies for all always-inline functions
     // for each of their call-sites. The approach taken here is therefore a
     // compromise between safety and usability.
+    // FIXME: Make `hasPossibleIncompatibleOps` consider intrinsics more
+    // accurately so that we can remove this stopgap.
     if (!Callee->hasFnAttribute(Attribute::AlwaysInline) &&
         hasPossibleIncompatibleOps(Callee, *getTLI()))
       return false;

--- a/llvm/test/Transforms/Inline/AArch64/sme-always-inline.ll
+++ b/llvm/test/Transforms/Inline/AArch64/sme-always-inline.ll
@@ -1,0 +1,27 @@
+; REQUIRES: aarch64-registered-target
+; RUN: opt -passes=always-inline -S < %s | FileCheck %s
+
+target triple = "aarch64"
+
+define internal float @callee(float %v) #0 {
+; CHECK-LABEL: define internal float @callee(
+; CHECK-SAME: float [[V:%.*]]) #[[ATTR0:[0-9]+]] {
+; CHECK-NEXT:    [[RES:%.*]] = tail call float @llvm.sin.f32(float [[V]])
+; CHECK-NEXT:    ret float [[RES]]
+;
+  %res = tail call float @llvm.sin.f32(float %v)
+  ret float %res
+}
+
+define float @caller(float %v) #1 {
+; CHECK-LABEL: define float @caller(
+; CHECK-SAME: float [[V:%.*]]) #[[ATTR1:[0-9]+]] {
+; CHECK-NEXT:    [[RES:%.*]] = call float @callee(float [[V]])
+; CHECK-NEXT:    ret float [[RES]]
+;
+  %res = call float @callee(float %v)
+  ret float %res
+}
+
+attributes #0 = { "target-features"="+sme2" nounwind alwaysinline }
+attributes #1 = { "target-features"="+sme2" nounwind "aarch64_pstate_sm_enabled" }

--- a/llvm/test/Transforms/Inline/AArch64/sme-always-inline.ll
+++ b/llvm/test/Transforms/Inline/AArch64/sme-always-inline.ll
@@ -4,19 +4,15 @@
 target triple = "aarch64"
 
 define internal float @callee(float %v) #0 {
-; CHECK-LABEL: define internal float @callee(
-; CHECK-SAME: float [[V:%.*]]) #[[ATTR0:[0-9]+]] {
-; CHECK-NEXT:    [[RES:%.*]] = tail call float @llvm.sin.f32(float [[V]])
-; CHECK-NEXT:    ret float [[RES]]
-;
+; CHECK-NOT: define internal float @callee
   %res = tail call float @llvm.sin.f32(float %v)
   ret float %res
 }
 
 define float @caller(float %v) #1 {
 ; CHECK-LABEL: define float @caller(
-; CHECK-SAME: float [[V:%.*]]) #[[ATTR1:[0-9]+]] {
-; CHECK-NEXT:    [[RES:%.*]] = call float @callee(float [[V]])
+; CHECK-SAME: float [[V:%.*]]) #[[ATTR0:[0-9]+]] {
+; CHECK-NEXT:    [[RES:%.*]] = call float @llvm.sin.f32(float [[V]])
 ; CHECK-NEXT:    ret float [[RES]]
 ;
   %res = call float @callee(float %v)

--- a/llvm/test/Transforms/Inline/AArch64/sme-always-inline.ll
+++ b/llvm/test/Transforms/Inline/AArch64/sme-always-inline.ll
@@ -1,15 +1,16 @@
-; REQUIRES: aarch64-registered-target
 ; RUN: opt -passes=always-inline -S < %s | FileCheck %s
 
 target triple = "aarch64"
 
-define internal float @callee(float %v) #0 {
+define internal float @callee(float %v) "target-features"="+sme2" alwaysinline {
 ; CHECK-NOT: define internal float @callee
   %res = tail call float @llvm.sin.f32(float %v)
   ret float %res
 }
 
-define float @caller(float %v) #1 {
+; Test that the body of @callee is inlined due to it's `alwaysinline` attribute,
+; despite having mismatching streaming attributes.
+define float @caller(float %v) "target-features"="+sme2" "aarch64_pstate_sm_enabled" {
 ; CHECK-LABEL: define float @caller(
 ; CHECK-SAME: float [[V:%.*]]) #[[ATTR0:[0-9]+]] {
 ; CHECK-NEXT:    [[RES:%.*]] = call float @llvm.sin.f32(float [[V]])
@@ -18,6 +19,3 @@ define float @caller(float %v) #1 {
   %res = call float @callee(float %v)
   ret float %res
 }
-
-attributes #0 = { "target-features"="+sme2" nounwind alwaysinline }
-attributes #1 = { "target-features"="+sme2" nounwind "aarch64_pstate_sm_enabled" }


### PR DESCRIPTION
PR #209345 changed inlining behaviour for 'alwaysinline' functions
when the callee's SME attributes were incompatible with the caller's
SME attributes. This is not desirable, as it would stop small utility
routines being inlined into streaming functions (such as std::max).

This PR restores the original behaviour from before #209345.

Fixes https://github.com/llvm/llvm-project/issues/217639