### PR TITLE
[M68k] Remove unnecessary `EmitCmp()` type promotions and use of `SUB`

### DIFF
--- a/llvm/lib/Target/M68k/M68kISelLowering.cpp
+++ b/llvm/lib/Target/M68k/M68kISelLowering.cpp
@@ -2100,26 +2100,6 @@ SDValue M68kTargetLowering::EmitTest(SDValue Op, unsigned M68kCC,
   return SDValue(New.getNode(), 1);
 }
 
-/// \brief Return true if the condition is an unsigned comparison operation.
-static bool isM68kCCUnsigned(unsigned M68kCC) {
-  switch (M68kCC) {
-  default:
-    llvm_unreachable("Invalid integer condition!");
-  case M68k::COND_EQ:
-  case M68k::COND_NE:
-  case M68k::COND_CS:
-  case M68k::COND_HI:
-  case M68k::COND_LS:
-  case M68k::COND_CC:
-    return true;
-  case M68k::COND_GT:
-  case M68k::COND_GE:
-  case M68k::COND_LT:
-  case M68k::COND_LE:
-    return false;
-  }
-}
-
 SDValue M68kTargetLowering::EmitCmp(SDValue Op0, SDValue Op1, unsigned M68kCC,
                                     const SDLoc &DL, SelectionDAG &DAG) const {
   if (isNullConstant(Op1))
@@ -2128,24 +2108,7 @@ SDValue M68kTargetLowering::EmitCmp(SDValue Op0, SDValue Op1, unsigned M68kCC,
   assert(!(isa<ConstantSDNode>(Op1) && Op0.getValueType() == MVT::i1) &&
          "Unexpected comparison operation for MVT::i1 operands");
 
-  if ((Op0.getValueType() == MVT::i8 || Op0.getValueType() == MVT::i16 ||
-       Op0.getValueType() == MVT::i32 || Op0.getValueType() == MVT::i64)) {
-    // Only promote the compare up to I32 if it is a 16 bit operation
-    // with an immediate.  16 bit immediates are to be avoided.
-    if ((Op0.getValueType() == MVT::i16 &&
-         (isa<ConstantSDNode>(Op0) || isa<ConstantSDNode>(Op1))) &&
-        !DAG.getMachineFunction().getFunction().hasMinSize()) {
-      unsigned ExtendOp =
-          isM68kCCUnsigned(M68kCC) ? ISD::ZERO_EXTEND : ISD::SIGN_EXTEND;
-      Op0 = DAG.getNode(ExtendOp, DL, MVT::i32, Op0);
-      Op1 = DAG.getNode(ExtendOp, DL, MVT::i32, Op1);
-    }
-    // Use SUB instead of CMP to enable CSE between SUB and CMP.
-    SDVTList VTs = DAG.getVTList(Op0.getValueType(), MVT::i8);
-    SDValue Sub = DAG.getNode(M68kISD::SUB, DL, VTs, Op0, Op1);
-    return SDValue(Sub.getNode(), 1);
-  }
-  return DAG.getNode(M68kISD::CMP, DL, MVT::i8, Op0, Op1);
+  return DAG.getNode(M68kISD::CMP, DL, MVT::i8, Op1, Op0);
 }
 
 /// Result of 'and' or 'trunc to i1' is compared against zero.

--- a/llvm/test/CodeGen/M68k/Arith/add.ll
+++ b/llvm/test/CodeGen/M68k/Arith/add.ll
@@ -83,7 +83,7 @@ define fastcc void @test4(ptr inreg %a) nounwind {
 define fastcc i32 @test9(i32 %x, i32 %y) nounwind readnone {
 ; CHECK-LABEL: test9:
 ; CHECK:       ; %bb.0:
-; CHECK-NEXT:    sub.l #10, %d0
+; CHECK-NEXT:    cmpi.l #10, %d0
 ; CHECK-NEXT:    seq %d0
 ; CHECK-NEXT:    ext.w %d0
 ; CHECK-NEXT:    ext.l %d0

--- a/llvm/test/CodeGen/M68k/Atomics/cmpxchg.ll
+++ b/llvm/test/CodeGen/M68k/Atomics/cmpxchg.ll
@@ -20,7 +20,7 @@ define i1 @cmpxchg_i8_monotonic_monotonic(i8 %cmp, i8 %new, ptr %mem) nounwind {
 ; NO-ATOMIC-NEXT:    move.l (32,%sp), %d0
 ; NO-ATOMIC-NEXT:    move.l %d0, (%sp)
 ; NO-ATOMIC-NEXT:    jsr __sync_val_compare_and_swap_1
-; NO-ATOMIC-NEXT:    sub.b %d2, %d0
+; NO-ATOMIC-NEXT:    cmp.b %d2, %d0
 ; NO-ATOMIC-NEXT:    seq %d0
 ; NO-ATOMIC-NEXT:    movem.l (16,%sp), %d2 ; 8-byte Folded Reload
 ; NO-ATOMIC-NEXT:    adda.l #20, %sp
@@ -35,7 +35,7 @@ define i1 @cmpxchg_i8_monotonic_monotonic(i8 %cmp, i8 %new, ptr %mem) nounwind {
 ; ATOMIC-NEXT:    move.b (11,%sp), %d1
 ; ATOMIC-NEXT:    move.b %d1, %d2
 ; ATOMIC-NEXT:    cas.b %d2, %d0, (%a0)
-; ATOMIC-NEXT:    sub.b %d1, %d2
+; ATOMIC-NEXT:    cmp.b %d1, %d2
 ; ATOMIC-NEXT:    seq %d0
 ; ATOMIC-NEXT:    movem.l (0,%sp), %d2 ; 8-byte Folded Reload
 ; ATOMIC-NEXT:    adda.l #4, %sp

--- a/llvm/test/CodeGen/M68k/Atomics/rmw.ll
+++ b/llvm/test/CodeGen/M68k/Atomics/rmw.ll
@@ -49,8 +49,7 @@ define i8 @atomicrmw_add_i8(i8 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    move.b %d2, %d3
 ; ATOMIC-NEXT:    add.b %d1, %d3
 ; ATOMIC-NEXT:    cas.b %d0, %d3, (%a0)
-; ATOMIC-NEXT:    move.b %d0, %d3
-; ATOMIC-NEXT:    sub.b %d2, %d3
+; ATOMIC-NEXT:    cmp.b %d2, %d0
 ; ATOMIC-NEXT:    seq %d2
 ; ATOMIC-NEXT:    and.b #1, %d2
 ; ATOMIC-NEXT:    cmpi.b #0, %d2
@@ -110,8 +109,7 @@ define i16 @atomicrmw_sub_i16(i16 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    move.w %d2, %d3
 ; ATOMIC-NEXT:    sub.w %d1, %d3
 ; ATOMIC-NEXT:    cas.w %d0, %d3, (%a0)
-; ATOMIC-NEXT:    move.w %d0, %d3
-; ATOMIC-NEXT:    sub.w %d2, %d3
+; ATOMIC-NEXT:    cmp.w %d2, %d0
 ; ATOMIC-NEXT:    seq %d2
 ; ATOMIC-NEXT:    and.b #1, %d2
 ; ATOMIC-NEXT:    cmpi.b #0, %d2
@@ -169,8 +167,7 @@ define i32 @atomicrmw_and_i32(i32 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    move.l %d2, %d3
 ; ATOMIC-NEXT:    and.l %d1, %d3
 ; ATOMIC-NEXT:    cas.l %d0, %d3, (%a0)
-; ATOMIC-NEXT:    move.l %d0, %d3
-; ATOMIC-NEXT:    sub.l %d2, %d3
+; ATOMIC-NEXT:    cmp.l %d2, %d0
 ; ATOMIC-NEXT:    seq %d2
 ; ATOMIC-NEXT:    and.b #1, %d2
 ; ATOMIC-NEXT:    cmpi.b #0, %d2
@@ -282,8 +279,7 @@ define i8 @atomicrmw_or_i8(i8 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    move.b %d2, %d3
 ; ATOMIC-NEXT:    or.b %d1, %d3
 ; ATOMIC-NEXT:    cas.b %d0, %d3, (%a0)
-; ATOMIC-NEXT:    move.b %d0, %d3
-; ATOMIC-NEXT:    sub.b %d2, %d3
+; ATOMIC-NEXT:    cmp.b %d2, %d0
 ; ATOMIC-NEXT:    seq %d2
 ; ATOMIC-NEXT:    and.b #1, %d2
 ; ATOMIC-NEXT:    cmpi.b #0, %d2
@@ -352,8 +348,7 @@ define i16 @atmoicrmw_nand_i16(i16 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    and.w %d0, %d3
 ; ATOMIC-NEXT:    not.w %d3
 ; ATOMIC-NEXT:    cas.w %d1, %d3, (%a0)
-; ATOMIC-NEXT:    move.w %d1, %d3
-; ATOMIC-NEXT:    sub.w %d2, %d3
+; ATOMIC-NEXT:    cmp.w %d2, %d1
 ; ATOMIC-NEXT:    seq %d2
 ; ATOMIC-NEXT:    and.b #1, %d2
 ; ATOMIC-NEXT:    cmpi.b #0, %d2
@@ -410,8 +405,7 @@ define i32 @atomicrmw_min_i32(i32 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    ; in Loop: Header=BB6_1 Depth=1
 ; ATOMIC-NEXT:    move.l %d2, %d0
 ; ATOMIC-NEXT:    cas.l %d0, %d3, (%a0)
-; ATOMIC-NEXT:    move.l %d0, %d3
-; ATOMIC-NEXT:    sub.l %d2, %d3
+; ATOMIC-NEXT:    cmp.l %d2, %d0
 ; ATOMIC-NEXT:    seq %d2
 ; ATOMIC-NEXT:    and.b #1, %d2
 ; ATOMIC-NEXT:    cmpi.b #0, %d2
@@ -421,8 +415,7 @@ define i32 @atomicrmw_min_i32(i32 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    bne .LBB6_4
 ; ATOMIC-NEXT:  .LBB6_1: ; %atomicrmw.start
 ; ATOMIC-NEXT:    ; =>This Inner Loop Header: Depth=1
-; ATOMIC-NEXT:    move.l %d2, %d0
-; ATOMIC-NEXT:    sub.l %d1, %d0
+; ATOMIC-NEXT:    cmp.l %d1, %d2
 ; ATOMIC-NEXT:    move.w %ccr, %d0
 ; ATOMIC-NEXT:    move.l %d2, %d3
 ; ATOMIC-NEXT:    move.w %d0, %ccr
@@ -639,8 +632,7 @@ define i8 @atomicrmw_i8_umin(i8 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    ; in Loop: Header=BB8_1 Depth=1
 ; ATOMIC-NEXT:    move.b %d2, %d0
 ; ATOMIC-NEXT:    cas.b %d0, %d3, (%a0)
-; ATOMIC-NEXT:    move.b %d0, %d3
-; ATOMIC-NEXT:    sub.b %d2, %d3
+; ATOMIC-NEXT:    cmp.b %d2, %d0
 ; ATOMIC-NEXT:    seq %d2
 ; ATOMIC-NEXT:    and.b #1, %d2
 ; ATOMIC-NEXT:    cmpi.b #0, %d2
@@ -650,8 +642,7 @@ define i8 @atomicrmw_i8_umin(i8 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    bne .LBB8_4
 ; ATOMIC-NEXT:  .LBB8_1: ; %atomicrmw.start
 ; ATOMIC-NEXT:    ; =>This Inner Loop Header: Depth=1
-; ATOMIC-NEXT:    move.b %d2, %d0
-; ATOMIC-NEXT:    sub.b %d1, %d0
+; ATOMIC-NEXT:    cmp.b %d1, %d2
 ; ATOMIC-NEXT:    move.w %ccr, %d0
 ; ATOMIC-NEXT:    move.b %d2, %d3
 ; ATOMIC-NEXT:    move.w %d0, %ccr
@@ -711,8 +702,7 @@ define i16 @atomicrmw_umax_i16(i16 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    ; in Loop: Header=BB9_1 Depth=1
 ; ATOMIC-NEXT:    move.w %d2, %d0
 ; ATOMIC-NEXT:    cas.w %d0, %d3, (%a0)
-; ATOMIC-NEXT:    move.w %d0, %d3
-; ATOMIC-NEXT:    sub.w %d2, %d3
+; ATOMIC-NEXT:    cmp.w %d2, %d0
 ; ATOMIC-NEXT:    seq %d2
 ; ATOMIC-NEXT:    and.b #1, %d2
 ; ATOMIC-NEXT:    cmpi.b #0, %d2
@@ -722,8 +712,7 @@ define i16 @atomicrmw_umax_i16(i16 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    bne .LBB9_4
 ; ATOMIC-NEXT:  .LBB9_1: ; %atomicrmw.start
 ; ATOMIC-NEXT:    ; =>This Inner Loop Header: Depth=1
-; ATOMIC-NEXT:    move.w %d2, %d0
-; ATOMIC-NEXT:    sub.w %d1, %d0
+; ATOMIC-NEXT:    cmp.w %d1, %d2
 ; ATOMIC-NEXT:    move.w %ccr, %d0
 ; ATOMIC-NEXT:    move.w %d2, %d3
 ; ATOMIC-NEXT:    move.w %d0, %ccr
@@ -772,28 +761,27 @@ define i16 @atomicrmw_xchg_i16(i16 %val, ptr %ptr) {
 ; ATOMIC-LABEL: atomicrmw_xchg_i16:
 ; ATOMIC:         .cfi_startproc
 ; ATOMIC-NEXT:  ; %bb.0: ; %entry
-; ATOMIC-NEXT:    suba.l #8, %sp
-; ATOMIC-NEXT:    .cfi_def_cfa_offset -12
-; ATOMIC-NEXT:    movem.l %d2-%d3, (0,%sp) ; 12-byte Folded Spill
-; ATOMIC-NEXT:    move.w (14,%sp), %d1
-; ATOMIC-NEXT:    move.l (16,%sp), %a0
+; ATOMIC-NEXT:    suba.l #4, %sp
+; ATOMIC-NEXT:    .cfi_def_cfa_offset -8
+; ATOMIC-NEXT:    movem.l %d2, (0,%sp) ; 8-byte Folded Spill
+; ATOMIC-NEXT:    move.w (10,%sp), %d1
+; ATOMIC-NEXT:    move.l (12,%sp), %a0
 ; ATOMIC-NEXT:    move.w (%a0), %d2
 ; ATOMIC-NEXT:    move.w %d2, %d0
 ; ATOMIC-NEXT:  .LBB10_1: ; %atomicrmw.start
 ; ATOMIC-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; ATOMIC-NEXT:    cas.w %d0, %d1, (%a0)
-; ATOMIC-NEXT:    move.w %d0, %d3
-; ATOMIC-NEXT:    sub.w %d2, %d3
+; ATOMIC-NEXT:    cmp.w %d2, %d0
 ; ATOMIC-NEXT:    seq %d2
 ; ATOMIC-NEXT:    and.b #1, %d2
 ; ATOMIC-NEXT:    cmpi.b #0, %d2
-; ATOMIC-NEXT:    move.w %ccr, %d3
+; ATOMIC-NEXT:    move.w %ccr, -(%sp)
 ; ATOMIC-NEXT:    move.w %d0, %d2
-; ATOMIC-NEXT:    move.w %d3, %ccr
+; ATOMIC-NEXT:    move.w (%sp)+, %ccr
 ; ATOMIC-NEXT:    beq .LBB10_1
 ; ATOMIC-NEXT:  ; %bb.2: ; %atomicrmw.end
-; ATOMIC-NEXT:    movem.l (0,%sp), %d2-%d3 ; 12-byte Folded Reload
-; ATOMIC-NEXT:    adda.l #8, %sp
+; ATOMIC-NEXT:    movem.l (0,%sp), %d2 ; 8-byte Folded Reload
+; ATOMIC-NEXT:    adda.l #4, %sp
 ; ATOMIC-NEXT:    rts
 entry:
   %old = atomicrmw xchg ptr %ptr, i16 %val monotonic
@@ -830,28 +818,27 @@ define i32 @atomicrmw_xchg_i32(i32 %val, ptr %ptr) {
 ; ATOMIC-LABEL: atomicrmw_xchg_i32:
 ; ATOMIC:         .cfi_startproc
 ; ATOMIC-NEXT:  ; %bb.0: ; %entry
-; ATOMIC-NEXT:    suba.l #8, %sp
-; ATOMIC-NEXT:    .cfi_def_cfa_offset -12
-; ATOMIC-NEXT:    movem.l %d2-%d3, (0,%sp) ; 12-byte Folded Spill
-; ATOMIC-NEXT:    move.l (12,%sp), %d1
-; ATOMIC-NEXT:    move.l (16,%sp), %a0
+; ATOMIC-NEXT:    suba.l #4, %sp
+; ATOMIC-NEXT:    .cfi_def_cfa_offset -8
+; ATOMIC-NEXT:    movem.l %d2, (0,%sp) ; 8-byte Folded Spill
+; ATOMIC-NEXT:    move.l (8,%sp), %d1
+; ATOMIC-NEXT:    move.l (12,%sp), %a0
 ; ATOMIC-NEXT:    move.l (%a0), %d2
 ; ATOMIC-NEXT:    move.l %d2, %d0
 ; ATOMIC-NEXT:  .LBB11_1: ; %atomicrmw.start
 ; ATOMIC-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; ATOMIC-NEXT:    cas.l %d0, %d1, (%a0)
-; ATOMIC-NEXT:    move.l %d0, %d3
-; ATOMIC-NEXT:    sub.l %d2, %d3
+; ATOMIC-NEXT:    cmp.l %d2, %d0
 ; ATOMIC-NEXT:    seq %d2
 ; ATOMIC-NEXT:    and.b #1, %d2
 ; ATOMIC-NEXT:    cmpi.b #0, %d2
-; ATOMIC-NEXT:    move.w %ccr, %d3
+; ATOMIC-NEXT:    move.w %ccr, -(%sp)
 ; ATOMIC-NEXT:    move.l %d0, %d2
-; ATOMIC-NEXT:    move.w %d3, %ccr
+; ATOMIC-NEXT:    move.w (%sp)+, %ccr
 ; ATOMIC-NEXT:    beq .LBB11_1
 ; ATOMIC-NEXT:  ; %bb.2: ; %atomicrmw.end
-; ATOMIC-NEXT:    movem.l (0,%sp), %d2-%d3 ; 12-byte Folded Reload
-; ATOMIC-NEXT:    adda.l #8, %sp
+; ATOMIC-NEXT:    movem.l (0,%sp), %d2 ; 8-byte Folded Reload
+; ATOMIC-NEXT:    adda.l #4, %sp
 ; ATOMIC-NEXT:    rts
 entry:
   %old = atomicrmw xchg ptr %ptr, i32 %val monotonic
@@ -902,8 +889,7 @@ define i8 @atomicrmw_sub_i8_arid(ptr align 2 %self) {
 ; ATOMIC-NEXT:    move.b %d1, %d2
 ; ATOMIC-NEXT:    add.b #-1, %d2
 ; ATOMIC-NEXT:    cas.b %d0, %d2, (4,%a0)
-; ATOMIC-NEXT:    move.b %d0, %d2
-; ATOMIC-NEXT:    sub.b %d1, %d2
+; ATOMIC-NEXT:    cmp.b %d1, %d0
 ; ATOMIC-NEXT:    seq %d1
 ; ATOMIC-NEXT:    and.b #1, %d1
 ; ATOMIC-NEXT:    cmpi.b #0, %d1
@@ -966,8 +952,7 @@ define i16 @atomicrmw_sub_i16_arid(ptr align 2 %self) {
 ; ATOMIC-NEXT:    move.w %d1, %d2
 ; ATOMIC-NEXT:    add.w #-1, %d2
 ; ATOMIC-NEXT:    cas.w %d0, %d2, (4,%a0)
-; ATOMIC-NEXT:    move.w %d0, %d2
-; ATOMIC-NEXT:    sub.w %d1, %d2
+; ATOMIC-NEXT:    cmp.w %d1, %d0
 ; ATOMIC-NEXT:    seq %d1
 ; ATOMIC-NEXT:    and.b #1, %d1
 ; ATOMIC-NEXT:    cmpi.b #0, %d1
@@ -1030,8 +1015,7 @@ define i32 @atomicrmw_sub_i32_arid(ptr align 2 %self) {
 ; ATOMIC-NEXT:    move.l %d1, %d2
 ; ATOMIC-NEXT:    add.l #-1, %d2
 ; ATOMIC-NEXT:    cas.l %d0, %d2, (4,%a0)
-; ATOMIC-NEXT:    move.l %d0, %d2
-; ATOMIC-NEXT:    sub.l %d1, %d2
+; ATOMIC-NEXT:    cmp.l %d1, %d0
 ; ATOMIC-NEXT:    seq %d1
 ; ATOMIC-NEXT:    and.b #1, %d1
 ; ATOMIC-NEXT:    cmpi.b #0, %d1

--- a/llvm/test/CodeGen/M68k/Bits/btst.ll
+++ b/llvm/test/CodeGen/M68k/Bits/btst.ll
@@ -4,9 +4,7 @@
 define fastcc i16 @switch_to_btst(i16 %a) nounwind {
 ; CHECK-LABEL: switch_to_btst:
 ; CHECK:       ; %bb.0: ; %entry
-; CHECK-NEXT:    move.l %d0, %d1
-; CHECK-NEXT:    and.l #65535, %d1
-; CHECK-NEXT:    sub.l #11, %d1
+; CHECK-NEXT:    cmpi.w #11, %d0
 ; CHECK-NEXT:    bhi .LBB0_3
 ; CHECK-NEXT:  ; %bb.1: ; %entry
 ; CHECK-NEXT:    swap %d0

--- a/llvm/test/CodeGen/M68k/CodeModel/Large/Atomics/cmpxchg.ll
+++ b/llvm/test/CodeGen/M68k/CodeModel/Large/Atomics/cmpxchg.ll
@@ -90,7 +90,7 @@ define i1 @cmpxchg_i8_monotonic_monotonic(i8 %cmp, i8 %new, ptr %mem) nounwind {
 ; NO-ATOMIC-NEXT:    move.l (32,%sp), %d0
 ; NO-ATOMIC-NEXT:    move.l %d0, (%sp)
 ; NO-ATOMIC-NEXT:    jsr __sync_val_compare_and_swap_1
-; NO-ATOMIC-NEXT:    sub.b %d2, %d0
+; NO-ATOMIC-NEXT:    cmp.b %d2, %d0
 ; NO-ATOMIC-NEXT:    seq %d0
 ; NO-ATOMIC-NEXT:    movem.l (16,%sp), %d2 ; 8-byte Folded Reload
 ; NO-ATOMIC-NEXT:    adda.l #20, %sp
@@ -110,7 +110,7 @@ define i1 @cmpxchg_i8_monotonic_monotonic(i8 %cmp, i8 %new, ptr %mem) nounwind {
 ; NO-ATOMIC-PIC-NEXT:    move.l (32,%sp), %d0
 ; NO-ATOMIC-PIC-NEXT:    move.l %d0, (%sp)
 ; NO-ATOMIC-PIC-NEXT:    jsr (__sync_val_compare_and_swap_1@PLT,%pc)
-; NO-ATOMIC-PIC-NEXT:    sub.b %d2, %d0
+; NO-ATOMIC-PIC-NEXT:    cmp.b %d2, %d0
 ; NO-ATOMIC-PIC-NEXT:    seq %d0
 ; NO-ATOMIC-PIC-NEXT:    movem.l (16,%sp), %d2 ; 8-byte Folded Reload
 ; NO-ATOMIC-PIC-NEXT:    adda.l #20, %sp
@@ -125,7 +125,7 @@ define i1 @cmpxchg_i8_monotonic_monotonic(i8 %cmp, i8 %new, ptr %mem) nounwind {
 ; ATOMIC-NEXT:    move.b (11,%sp), %d1
 ; ATOMIC-NEXT:    move.b %d1, %d2
 ; ATOMIC-NEXT:    cas.b %d2, %d0, (%a0)
-; ATOMIC-NEXT:    sub.b %d1, %d2
+; ATOMIC-NEXT:    cmp.b %d1, %d2
 ; ATOMIC-NEXT:    seq %d0
 ; ATOMIC-NEXT:    movem.l (0,%sp), %d2 ; 8-byte Folded Reload
 ; ATOMIC-NEXT:    adda.l #4, %sp
@@ -140,7 +140,7 @@ define i1 @cmpxchg_i8_monotonic_monotonic(i8 %cmp, i8 %new, ptr %mem) nounwind {
 ; ATOMIC-PIC-NEXT:    move.b (11,%sp), %d1
 ; ATOMIC-PIC-NEXT:    move.b %d1, %d2
 ; ATOMIC-PIC-NEXT:    cas.b %d2, %d0, (%a0)
-; ATOMIC-PIC-NEXT:    sub.b %d1, %d2
+; ATOMIC-PIC-NEXT:    cmp.b %d1, %d2
 ; ATOMIC-PIC-NEXT:    seq %d0
 ; ATOMIC-PIC-NEXT:    movem.l (0,%sp), %d2 ; 8-byte Folded Reload
 ; ATOMIC-PIC-NEXT:    adda.l #4, %sp

--- a/llvm/test/CodeGen/M68k/CodeModel/Large/Atomics/rmw.ll
+++ b/llvm/test/CodeGen/M68k/CodeModel/Large/Atomics/rmw.ll
@@ -82,8 +82,7 @@ define i8 @atomicrmw_add_i8(i8 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    move.b %d2, %d3
 ; ATOMIC-NEXT:    add.b %d1, %d3
 ; ATOMIC-NEXT:    cas.b %d0, %d3, (%a0)
-; ATOMIC-NEXT:    move.b %d0, %d3
-; ATOMIC-NEXT:    sub.b %d2, %d3
+; ATOMIC-NEXT:    cmp.b %d2, %d0
 ; ATOMIC-NEXT:    seq %d2
 ; ATOMIC-NEXT:    and.b #1, %d2
 ; ATOMIC-NEXT:    cmpi.b #0, %d2
@@ -111,8 +110,7 @@ define i8 @atomicrmw_add_i8(i8 %val, ptr %ptr) {
 ; ATOMIC-PIC-NEXT:    move.b %d2, %d3
 ; ATOMIC-PIC-NEXT:    add.b %d1, %d3
 ; ATOMIC-PIC-NEXT:    cas.b %d0, %d3, (%a0)
-; ATOMIC-PIC-NEXT:    move.b %d0, %d3
-; ATOMIC-PIC-NEXT:    sub.b %d2, %d3
+; ATOMIC-PIC-NEXT:    cmp.b %d2, %d0
 ; ATOMIC-PIC-NEXT:    seq %d2
 ; ATOMIC-PIC-NEXT:    and.b #1, %d2
 ; ATOMIC-PIC-NEXT:    cmpi.b #0, %d2
@@ -200,8 +198,7 @@ define i16 @atomicrmw_sub_i16(i16 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    move.w %d2, %d3
 ; ATOMIC-NEXT:    sub.w %d1, %d3
 ; ATOMIC-NEXT:    cas.w %d0, %d3, (%a0)
-; ATOMIC-NEXT:    move.w %d0, %d3
-; ATOMIC-NEXT:    sub.w %d2, %d3
+; ATOMIC-NEXT:    cmp.w %d2, %d0
 ; ATOMIC-NEXT:    seq %d2
 ; ATOMIC-NEXT:    and.b #1, %d2
 ; ATOMIC-NEXT:    cmpi.b #0, %d2
@@ -229,8 +226,7 @@ define i16 @atomicrmw_sub_i16(i16 %val, ptr %ptr) {
 ; ATOMIC-PIC-NEXT:    move.w %d2, %d3
 ; ATOMIC-PIC-NEXT:    sub.w %d1, %d3
 ; ATOMIC-PIC-NEXT:    cas.w %d0, %d3, (%a0)
-; ATOMIC-PIC-NEXT:    move.w %d0, %d3
-; ATOMIC-PIC-NEXT:    sub.w %d2, %d3
+; ATOMIC-PIC-NEXT:    cmp.w %d2, %d0
 ; ATOMIC-PIC-NEXT:    seq %d2
 ; ATOMIC-PIC-NEXT:    and.b #1, %d2
 ; ATOMIC-PIC-NEXT:    cmpi.b #0, %d2
@@ -314,8 +310,7 @@ define i32 @atomicrmw_and_i32(i32 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    move.l %d2, %d3
 ; ATOMIC-NEXT:    and.l %d1, %d3
 ; ATOMIC-NEXT:    cas.l %d0, %d3, (%a0)
-; ATOMIC-NEXT:    move.l %d0, %d3
-; ATOMIC-NEXT:    sub.l %d2, %d3
+; ATOMIC-NEXT:    cmp.l %d2, %d0
 ; ATOMIC-NEXT:    seq %d2
 ; ATOMIC-NEXT:    and.b #1, %d2
 ; ATOMIC-NEXT:    cmpi.b #0, %d2
@@ -343,8 +338,7 @@ define i32 @atomicrmw_and_i32(i32 %val, ptr %ptr) {
 ; ATOMIC-PIC-NEXT:    move.l %d2, %d3
 ; ATOMIC-PIC-NEXT:    and.l %d1, %d3
 ; ATOMIC-PIC-NEXT:    cas.l %d0, %d3, (%a0)
-; ATOMIC-PIC-NEXT:    move.l %d0, %d3
-; ATOMIC-PIC-NEXT:    sub.l %d2, %d3
+; ATOMIC-PIC-NEXT:    cmp.l %d2, %d0
 ; ATOMIC-PIC-NEXT:    seq %d2
 ; ATOMIC-PIC-NEXT:    and.b #1, %d2
 ; ATOMIC-PIC-NEXT:    cmpi.b #0, %d2
@@ -532,8 +526,7 @@ define i8 @atomicrmw_or_i8(i8 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    move.b %d2, %d3
 ; ATOMIC-NEXT:    or.b %d1, %d3
 ; ATOMIC-NEXT:    cas.b %d0, %d3, (%a0)
-; ATOMIC-NEXT:    move.b %d0, %d3
-; ATOMIC-NEXT:    sub.b %d2, %d3
+; ATOMIC-NEXT:    cmp.b %d2, %d0
 ; ATOMIC-NEXT:    seq %d2
 ; ATOMIC-NEXT:    and.b #1, %d2
 ; ATOMIC-NEXT:    cmpi.b #0, %d2
@@ -561,8 +554,7 @@ define i8 @atomicrmw_or_i8(i8 %val, ptr %ptr) {
 ; ATOMIC-PIC-NEXT:    move.b %d2, %d3
 ; ATOMIC-PIC-NEXT:    or.b %d1, %d3
 ; ATOMIC-PIC-NEXT:    cas.b %d0, %d3, (%a0)
-; ATOMIC-PIC-NEXT:    move.b %d0, %d3
-; ATOMIC-PIC-NEXT:    sub.b %d2, %d3
+; ATOMIC-PIC-NEXT:    cmp.b %d2, %d0
 ; ATOMIC-PIC-NEXT:    seq %d2
 ; ATOMIC-PIC-NEXT:    and.b #1, %d2
 ; ATOMIC-PIC-NEXT:    cmpi.b #0, %d2
@@ -667,8 +659,7 @@ define i16 @atmoicrmw_nand_i16(i16 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    and.w %d0, %d3
 ; ATOMIC-NEXT:    not.w %d3
 ; ATOMIC-NEXT:    cas.w %d1, %d3, (%a0)
-; ATOMIC-NEXT:    move.w %d1, %d3
-; ATOMIC-NEXT:    sub.w %d2, %d3
+; ATOMIC-NEXT:    cmp.w %d2, %d1
 ; ATOMIC-NEXT:    seq %d2
 ; ATOMIC-NEXT:    and.b #1, %d2
 ; ATOMIC-NEXT:    cmpi.b #0, %d2
@@ -697,8 +688,7 @@ define i16 @atmoicrmw_nand_i16(i16 %val, ptr %ptr) {
 ; ATOMIC-PIC-NEXT:    and.w %d0, %d3
 ; ATOMIC-PIC-NEXT:    not.w %d3
 ; ATOMIC-PIC-NEXT:    cas.w %d1, %d3, (%a0)
-; ATOMIC-PIC-NEXT:    move.w %d1, %d3
-; ATOMIC-PIC-NEXT:    sub.w %d2, %d3
+; ATOMIC-PIC-NEXT:    cmp.w %d2, %d1
 ; ATOMIC-PIC-NEXT:    seq %d2
 ; ATOMIC-PIC-NEXT:    and.b #1, %d2
 ; ATOMIC-PIC-NEXT:    cmpi.b #0, %d2
@@ -781,8 +771,7 @@ define i32 @atomicrmw_min_i32(i32 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    ; in Loop: Header=BB6_1 Depth=1
 ; ATOMIC-NEXT:    move.l %d2, %d0
 ; ATOMIC-NEXT:    cas.l %d0, %d3, (%a0)
-; ATOMIC-NEXT:    move.l %d0, %d3
-; ATOMIC-NEXT:    sub.l %d2, %d3
+; ATOMIC-NEXT:    cmp.l %d2, %d0
 ; ATOMIC-NEXT:    seq %d2
 ; ATOMIC-NEXT:    and.b #1, %d2
 ; ATOMIC-NEXT:    cmpi.b #0, %d2
@@ -792,8 +781,7 @@ define i32 @atomicrmw_min_i32(i32 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    bne .LBB6_4
 ; ATOMIC-NEXT:  .LBB6_1: ; %atomicrmw.start
 ; ATOMIC-NEXT:    ; =>This Inner Loop Header: Depth=1
-; ATOMIC-NEXT:    move.l %d2, %d0
-; ATOMIC-NEXT:    sub.l %d1, %d0
+; ATOMIC-NEXT:    cmp.l %d1, %d2
 ; ATOMIC-NEXT:    move.w %ccr, %d0
 ; ATOMIC-NEXT:    move.l %d2, %d3
 ; ATOMIC-NEXT:    move.w %d0, %ccr
@@ -821,8 +809,7 @@ define i32 @atomicrmw_min_i32(i32 %val, ptr %ptr) {
 ; ATOMIC-PIC-NEXT:    ; in Loop: Header=BB6_1 Depth=1
 ; ATOMIC-PIC-NEXT:    move.l %d2, %d0
 ; ATOMIC-PIC-NEXT:    cas.l %d0, %d3, (%a0)
-; ATOMIC-PIC-NEXT:    move.l %d0, %d3
-; ATOMIC-PIC-NEXT:    sub.l %d2, %d3
+; ATOMIC-PIC-NEXT:    cmp.l %d2, %d0
 ; ATOMIC-PIC-NEXT:    seq %d2
 ; ATOMIC-PIC-NEXT:    and.b #1, %d2
 ; ATOMIC-PIC-NEXT:    cmpi.b #0, %d2
@@ -832,8 +819,7 @@ define i32 @atomicrmw_min_i32(i32 %val, ptr %ptr) {
 ; ATOMIC-PIC-NEXT:    bne .LBB6_4
 ; ATOMIC-PIC-NEXT:  .LBB6_1: ; %atomicrmw.start
 ; ATOMIC-PIC-NEXT:    ; =>This Inner Loop Header: Depth=1
-; ATOMIC-PIC-NEXT:    move.l %d2, %d0
-; ATOMIC-PIC-NEXT:    sub.l %d1, %d0
+; ATOMIC-PIC-NEXT:    cmp.l %d1, %d2
 ; ATOMIC-PIC-NEXT:    move.w %ccr, %d0
 ; ATOMIC-PIC-NEXT:    move.l %d2, %d3
 ; ATOMIC-PIC-NEXT:    move.w %d0, %ccr
@@ -1231,8 +1217,7 @@ define i8 @atomicrmw_i8_umin(i8 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    ; in Loop: Header=BB8_1 Depth=1
 ; ATOMIC-NEXT:    move.b %d2, %d0
 ; ATOMIC-NEXT:    cas.b %d0, %d3, (%a0)
-; ATOMIC-NEXT:    move.b %d0, %d3
-; ATOMIC-NEXT:    sub.b %d2, %d3
+; ATOMIC-NEXT:    cmp.b %d2, %d0
 ; ATOMIC-NEXT:    seq %d2
 ; ATOMIC-NEXT:    and.b #1, %d2
 ; ATOMIC-NEXT:    cmpi.b #0, %d2
@@ -1242,8 +1227,7 @@ define i8 @atomicrmw_i8_umin(i8 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    bne .LBB8_4
 ; ATOMIC-NEXT:  .LBB8_1: ; %atomicrmw.start
 ; ATOMIC-NEXT:    ; =>This Inner Loop Header: Depth=1
-; ATOMIC-NEXT:    move.b %d2, %d0
-; ATOMIC-NEXT:    sub.b %d1, %d0
+; ATOMIC-NEXT:    cmp.b %d1, %d2
 ; ATOMIC-NEXT:    move.w %ccr, %d0
 ; ATOMIC-NEXT:    move.b %d2, %d3
 ; ATOMIC-NEXT:    move.w %d0, %ccr
@@ -1271,8 +1255,7 @@ define i8 @atomicrmw_i8_umin(i8 %val, ptr %ptr) {
 ; ATOMIC-PIC-NEXT:    ; in Loop: Header=BB8_1 Depth=1
 ; ATOMIC-PIC-NEXT:    move.b %d2, %d0
 ; ATOMIC-PIC-NEXT:    cas.b %d0, %d3, (%a0)
-; ATOMIC-PIC-NEXT:    move.b %d0, %d3
-; ATOMIC-PIC-NEXT:    sub.b %d2, %d3
+; ATOMIC-PIC-NEXT:    cmp.b %d2, %d0
 ; ATOMIC-PIC-NEXT:    seq %d2
 ; ATOMIC-PIC-NEXT:    and.b #1, %d2
 ; ATOMIC-PIC-NEXT:    cmpi.b #0, %d2
@@ -1282,8 +1265,7 @@ define i8 @atomicrmw_i8_umin(i8 %val, ptr %ptr) {
 ; ATOMIC-PIC-NEXT:    bne .LBB8_4
 ; ATOMIC-PIC-NEXT:  .LBB8_1: ; %atomicrmw.start
 ; ATOMIC-PIC-NEXT:    ; =>This Inner Loop Header: Depth=1
-; ATOMIC-PIC-NEXT:    move.b %d2, %d0
-; ATOMIC-PIC-NEXT:    sub.b %d1, %d0
+; ATOMIC-PIC-NEXT:    cmp.b %d1, %d2
 ; ATOMIC-PIC-NEXT:    move.w %ccr, %d0
 ; ATOMIC-PIC-NEXT:    move.b %d2, %d3
 ; ATOMIC-PIC-NEXT:    move.w %d0, %ccr
@@ -1371,8 +1353,7 @@ define i16 @atomicrmw_umax_i16(i16 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    ; in Loop: Header=BB9_1 Depth=1
 ; ATOMIC-NEXT:    move.w %d2, %d0
 ; ATOMIC-NEXT:    cas.w %d0, %d3, (%a0)
-; ATOMIC-NEXT:    move.w %d0, %d3
-; ATOMIC-NEXT:    sub.w %d2, %d3
+; ATOMIC-NEXT:    cmp.w %d2, %d0
 ; ATOMIC-NEXT:    seq %d2
 ; ATOMIC-NEXT:    and.b #1, %d2
 ; ATOMIC-NEXT:    cmpi.b #0, %d2
@@ -1382,8 +1363,7 @@ define i16 @atomicrmw_umax_i16(i16 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    bne .LBB9_4
 ; ATOMIC-NEXT:  .LBB9_1: ; %atomicrmw.start
 ; ATOMIC-NEXT:    ; =>This Inner Loop Header: Depth=1
-; ATOMIC-NEXT:    move.w %d2, %d0
-; ATOMIC-NEXT:    sub.w %d1, %d0
+; ATOMIC-NEXT:    cmp.w %d1, %d2
 ; ATOMIC-NEXT:    move.w %ccr, %d0
 ; ATOMIC-NEXT:    move.w %d2, %d3
 ; ATOMIC-NEXT:    move.w %d0, %ccr
@@ -1411,8 +1391,7 @@ define i16 @atomicrmw_umax_i16(i16 %val, ptr %ptr) {
 ; ATOMIC-PIC-NEXT:    ; in Loop: Header=BB9_1 Depth=1
 ; ATOMIC-PIC-NEXT:    move.w %d2, %d0
 ; ATOMIC-PIC-NEXT:    cas.w %d0, %d3, (%a0)
-; ATOMIC-PIC-NEXT:    move.w %d0, %d3
-; ATOMIC-PIC-NEXT:    sub.w %d2, %d3
+; ATOMIC-PIC-NEXT:    cmp.w %d2, %d0
 ; ATOMIC-PIC-NEXT:    seq %d2
 ; ATOMIC-PIC-NEXT:    and.b #1, %d2
 ; ATOMIC-PIC-NEXT:    cmpi.b #0, %d2
@@ -1422,8 +1401,7 @@ define i16 @atomicrmw_umax_i16(i16 %val, ptr %ptr) {
 ; ATOMIC-PIC-NEXT:    bne .LBB9_4
 ; ATOMIC-PIC-NEXT:  .LBB9_1: ; %atomicrmw.start
 ; ATOMIC-PIC-NEXT:    ; =>This Inner Loop Header: Depth=1
-; ATOMIC-PIC-NEXT:    move.w %d2, %d0
-; ATOMIC-PIC-NEXT:    sub.w %d1, %d0
+; ATOMIC-PIC-NEXT:    cmp.w %d1, %d2
 ; ATOMIC-PIC-NEXT:    move.w %ccr, %d0
 ; ATOMIC-PIC-NEXT:    move.w %d2, %d3
 ; ATOMIC-PIC-NEXT:    move.w %d0, %ccr
@@ -1500,55 +1478,53 @@ define i16 @atomicrmw_xchg_i16(i16 %val, ptr %ptr) {
 ; ATOMIC-LABEL: atomicrmw_xchg_i16:
 ; ATOMIC:         .cfi_startproc
 ; ATOMIC-NEXT:  ; %bb.0: ; %entry
-; ATOMIC-NEXT:    suba.l #8, %sp
-; ATOMIC-NEXT:    .cfi_def_cfa_offset -12
-; ATOMIC-NEXT:    movem.l %d2-%d3, (0,%sp) ; 12-byte Folded Spill
-; ATOMIC-NEXT:    move.w (14,%sp), %d1
-; ATOMIC-NEXT:    move.l (16,%sp), %a0
+; ATOMIC-NEXT:    suba.l #4, %sp
+; ATOMIC-NEXT:    .cfi_def_cfa_offset -8
+; ATOMIC-NEXT:    movem.l %d2, (0,%sp) ; 8-byte Folded Spill
+; ATOMIC-NEXT:    move.w (10,%sp), %d1
+; ATOMIC-NEXT:    move.l (12,%sp), %a0
 ; ATOMIC-NEXT:    move.w (%a0), %d2
 ; ATOMIC-NEXT:    move.w %d2, %d0
 ; ATOMIC-NEXT:  .LBB10_1: ; %atomicrmw.start
 ; ATOMIC-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; ATOMIC-NEXT:    cas.w %d0, %d1, (%a0)
-; ATOMIC-NEXT:    move.w %d0, %d3
-; ATOMIC-NEXT:    sub.w %d2, %d3
+; ATOMIC-NEXT:    cmp.w %d2, %d0
 ; ATOMIC-NEXT:    seq %d2
 ; ATOMIC-NEXT:    and.b #1, %d2
 ; ATOMIC-NEXT:    cmpi.b #0, %d2
-; ATOMIC-NEXT:    move.w %ccr, %d3
+; ATOMIC-NEXT:    move.w %ccr, -(%sp)
 ; ATOMIC-NEXT:    move.w %d0, %d2
-; ATOMIC-NEXT:    move.w %d3, %ccr
+; ATOMIC-NEXT:    move.w (%sp)+, %ccr
 ; ATOMIC-NEXT:    beq .LBB10_1
 ; ATOMIC-NEXT:  ; %bb.2: ; %atomicrmw.end
-; ATOMIC-NEXT:    movem.l (0,%sp), %d2-%d3 ; 12-byte Folded Reload
-; ATOMIC-NEXT:    adda.l #8, %sp
+; ATOMIC-NEXT:    movem.l (0,%sp), %d2 ; 8-byte Folded Reload
+; ATOMIC-NEXT:    adda.l #4, %sp
 ; ATOMIC-NEXT:    rts
 ;
 ; ATOMIC-PIC-LABEL: atomicrmw_xchg_i16:
 ; ATOMIC-PIC:         .cfi_startproc
 ; ATOMIC-PIC-NEXT:  ; %bb.0: ; %entry
-; ATOMIC-PIC-NEXT:    suba.l #8, %sp
-; ATOMIC-PIC-NEXT:    .cfi_def_cfa_offset -12
-; ATOMIC-PIC-NEXT:    movem.l %d2-%d3, (0,%sp) ; 12-byte Folded Spill
-; ATOMIC-PIC-NEXT:    move.w (14,%sp), %d1
-; ATOMIC-PIC-NEXT:    move.l (16,%sp), %a0
+; ATOMIC-PIC-NEXT:    suba.l #4, %sp
+; ATOMIC-PIC-NEXT:    .cfi_def_cfa_offset -8
+; ATOMIC-PIC-NEXT:    movem.l %d2, (0,%sp) ; 8-byte Folded Spill
+; ATOMIC-PIC-NEXT:    move.w (10,%sp), %d1
+; ATOMIC-PIC-NEXT:    move.l (12,%sp), %a0
 ; ATOMIC-PIC-NEXT:    move.w (%a0), %d2
 ; ATOMIC-PIC-NEXT:    move.w %d2, %d0
 ; ATOMIC-PIC-NEXT:  .LBB10_1: ; %atomicrmw.start
 ; ATOMIC-PIC-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; ATOMIC-PIC-NEXT:    cas.w %d0, %d1, (%a0)
-; ATOMIC-PIC-NEXT:    move.w %d0, %d3
-; ATOMIC-PIC-NEXT:    sub.w %d2, %d3
+; ATOMIC-PIC-NEXT:    cmp.w %d2, %d0
 ; ATOMIC-PIC-NEXT:    seq %d2
 ; ATOMIC-PIC-NEXT:    and.b #1, %d2
 ; ATOMIC-PIC-NEXT:    cmpi.b #0, %d2
-; ATOMIC-PIC-NEXT:    move.w %ccr, %d3
+; ATOMIC-PIC-NEXT:    move.w %ccr, -(%sp)
 ; ATOMIC-PIC-NEXT:    move.w %d0, %d2
-; ATOMIC-PIC-NEXT:    move.w %d3, %ccr
+; ATOMIC-PIC-NEXT:    move.w (%sp)+, %ccr
 ; ATOMIC-PIC-NEXT:    beq .LBB10_1
 ; ATOMIC-PIC-NEXT:  ; %bb.2: ; %atomicrmw.end
-; ATOMIC-PIC-NEXT:    movem.l (0,%sp), %d2-%d3 ; 12-byte Folded Reload
-; ATOMIC-PIC-NEXT:    adda.l #8, %sp
+; ATOMIC-PIC-NEXT:    movem.l (0,%sp), %d2 ; 8-byte Folded Reload
+; ATOMIC-PIC-NEXT:    adda.l #4, %sp
 ; ATOMIC-PIC-NEXT:    rts
 entry:
   %old = atomicrmw xchg ptr %ptr, i16 %val monotonic
@@ -1611,55 +1587,53 @@ define i32 @atomicrmw_xchg_i32(i32 %val, ptr %ptr) {
 ; ATOMIC-LABEL: atomicrmw_xchg_i32:
 ; ATOMIC:         .cfi_startproc
 ; ATOMIC-NEXT:  ; %bb.0: ; %entry
-; ATOMIC-NEXT:    suba.l #8, %sp
-; ATOMIC-NEXT:    .cfi_def_cfa_offset -12
-; ATOMIC-NEXT:    movem.l %d2-%d3, (0,%sp) ; 12-byte Folded Spill
-; ATOMIC-NEXT:    move.l (12,%sp), %d1
-; ATOMIC-NEXT:    move.l (16,%sp), %a0
+; ATOMIC-NEXT:    suba.l #4, %sp
+; ATOMIC-NEXT:    .cfi_def_cfa_offset -8
+; ATOMIC-NEXT:    movem.l %d2, (0,%sp) ; 8-byte Folded Spill
+; ATOMIC-NEXT:    move.l (8,%sp), %d1
+; ATOMIC-NEXT:    move.l (12,%sp), %a0
 ; ATOMIC-NEXT:    move.l (%a0), %d2
 ; ATOMIC-NEXT:    move.l %d2, %d0
 ; ATOMIC-NEXT:  .LBB11_1: ; %atomicrmw.start
 ; ATOMIC-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; ATOMIC-NEXT:    cas.l %d0, %d1, (%a0)
-; ATOMIC-NEXT:    move.l %d0, %d3
-; ATOMIC-NEXT:    sub.l %d2, %d3
+; ATOMIC-NEXT:    cmp.l %d2, %d0
 ; ATOMIC-NEXT:    seq %d2
 ; ATOMIC-NEXT:    and.b #1, %d2
 ; ATOMIC-NEXT:    cmpi.b #0, %d2
-; ATOMIC-NEXT:    move.w %ccr, %d3
+; ATOMIC-NEXT:    move.w %ccr, -(%sp)
 ; ATOMIC-NEXT:    move.l %d0, %d2
-; ATOMIC-NEXT:    move.w %d3, %ccr
+; ATOMIC-NEXT:    move.w (%sp)+, %ccr
 ; ATOMIC-NEXT:    beq .LBB11_1
 ; ATOMIC-NEXT:  ; %bb.2: ; %atomicrmw.end
-; ATOMIC-NEXT:    movem.l (0,%sp), %d2-%d3 ; 12-byte Folded Reload
-; ATOMIC-NEXT:    adda.l #8, %sp
+; ATOMIC-NEXT:    movem.l (0,%sp), %d2 ; 8-byte Folded Reload
+; ATOMIC-NEXT:    adda.l #4, %sp
 ; ATOMIC-NEXT:    rts
 ;
 ; ATOMIC-PIC-LABEL: atomicrmw_xchg_i32:
 ; ATOMIC-PIC:         .cfi_startproc
 ; ATOMIC-PIC-NEXT:  ; %bb.0: ; %entry
-; ATOMIC-PIC-NEXT:    suba.l #8, %sp
-; ATOMIC-PIC-NEXT:    .cfi_def_cfa_offset -12
-; ATOMIC-PIC-NEXT:    movem.l %d2-%d3, (0,%sp) ; 12-byte Folded Spill
-; ATOMIC-PIC-NEXT:    move.l (12,%sp), %d1
-; ATOMIC-PIC-NEXT:    move.l (16,%sp), %a0
+; ATOMIC-PIC-NEXT:    suba.l #4, %sp
+; ATOMIC-PIC-NEXT:    .cfi_def_cfa_offset -8
+; ATOMIC-PIC-NEXT:    movem.l %d2, (0,%sp) ; 8-byte Folded Spill
+; ATOMIC-PIC-NEXT:    move.l (8,%sp), %d1
+; ATOMIC-PIC-NEXT:    move.l (12,%sp), %a0
 ; ATOMIC-PIC-NEXT:    move.l (%a0), %d2
 ; ATOMIC-PIC-NEXT:    move.l %d2, %d0
 ; ATOMIC-PIC-NEXT:  .LBB11_1: ; %atomicrmw.start
 ; ATOMIC-PIC-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; ATOMIC-PIC-NEXT:    cas.l %d0, %d1, (%a0)
-; ATOMIC-PIC-NEXT:    move.l %d0, %d3
-; ATOMIC-PIC-NEXT:    sub.l %d2, %d3
+; ATOMIC-PIC-NEXT:    cmp.l %d2, %d0
 ; ATOMIC-PIC-NEXT:    seq %d2
 ; ATOMIC-PIC-NEXT:    and.b #1, %d2
 ; ATOMIC-PIC-NEXT:    cmpi.b #0, %d2
-; ATOMIC-PIC-NEXT:    move.w %ccr, %d3
+; ATOMIC-PIC-NEXT:    move.w %ccr, -(%sp)
 ; ATOMIC-PIC-NEXT:    move.l %d0, %d2
-; ATOMIC-PIC-NEXT:    move.w %d3, %ccr
+; ATOMIC-PIC-NEXT:    move.w (%sp)+, %ccr
 ; ATOMIC-PIC-NEXT:    beq .LBB11_1
 ; ATOMIC-PIC-NEXT:  ; %bb.2: ; %atomicrmw.end
-; ATOMIC-PIC-NEXT:    movem.l (0,%sp), %d2-%d3 ; 12-byte Folded Reload
-; ATOMIC-PIC-NEXT:    adda.l #8, %sp
+; ATOMIC-PIC-NEXT:    movem.l (0,%sp), %d2 ; 8-byte Folded Reload
+; ATOMIC-PIC-NEXT:    adda.l #4, %sp
 ; ATOMIC-PIC-NEXT:    rts
 entry:
   %old = atomicrmw xchg ptr %ptr, i32 %val monotonic
@@ -1738,8 +1712,7 @@ define i8 @atomicrmw_sub_i8_arid(ptr align 2 %self) {
 ; ATOMIC-NEXT:    move.b %d1, %d2
 ; ATOMIC-NEXT:    add.b #-1, %d2
 ; ATOMIC-NEXT:    cas.b %d0, %d2, (4,%a0)
-; ATOMIC-NEXT:    move.b %d0, %d2
-; ATOMIC-NEXT:    sub.b %d1, %d2
+; ATOMIC-NEXT:    cmp.b %d1, %d0
 ; ATOMIC-NEXT:    seq %d1
 ; ATOMIC-NEXT:    and.b #1, %d1
 ; ATOMIC-NEXT:    cmpi.b #0, %d1
@@ -1767,8 +1740,7 @@ define i8 @atomicrmw_sub_i8_arid(ptr align 2 %self) {
 ; ATOMIC-PIC-NEXT:    move.b %d1, %d2
 ; ATOMIC-PIC-NEXT:    add.b #-1, %d2
 ; ATOMIC-PIC-NEXT:    cas.b %d0, %d2, (4,%a0)
-; ATOMIC-PIC-NEXT:    move.b %d0, %d2
-; ATOMIC-PIC-NEXT:    sub.b %d1, %d2
+; ATOMIC-PIC-NEXT:    cmp.b %d1, %d0
 ; ATOMIC-PIC-NEXT:    seq %d1
 ; ATOMIC-PIC-NEXT:    and.b #1, %d1
 ; ATOMIC-PIC-NEXT:    cmpi.b #0, %d1
@@ -1859,8 +1831,7 @@ define i16 @atomicrmw_sub_i16_arid(ptr align 2 %self) {
 ; ATOMIC-NEXT:    move.w %d1, %d2
 ; ATOMIC-NEXT:    add.w #-1, %d2
 ; ATOMIC-NEXT:    cas.w %d0, %d2, (4,%a0)
-; ATOMIC-NEXT:    move.w %d0, %d2
-; ATOMIC-NEXT:    sub.w %d1, %d2
+; ATOMIC-NEXT:    cmp.w %d1, %d0
 ; ATOMIC-NEXT:    seq %d1
 ; ATOMIC-NEXT:    and.b #1, %d1
 ; ATOMIC-NEXT:    cmpi.b #0, %d1
@@ -1888,8 +1859,7 @@ define i16 @atomicrmw_sub_i16_arid(ptr align 2 %self) {
 ; ATOMIC-PIC-NEXT:    move.w %d1, %d2
 ; ATOMIC-PIC-NEXT:    add.w #-1, %d2
 ; ATOMIC-PIC-NEXT:    cas.w %d0, %d2, (4,%a0)
-; ATOMIC-PIC-NEXT:    move.w %d0, %d2
-; ATOMIC-PIC-NEXT:    sub.w %d1, %d2
+; ATOMIC-PIC-NEXT:    cmp.w %d1, %d0
 ; ATOMIC-PIC-NEXT:    seq %d1
 ; ATOMIC-PIC-NEXT:    and.b #1, %d1
 ; ATOMIC-PIC-NEXT:    cmpi.b #0, %d1
@@ -1980,8 +1950,7 @@ define i32 @atomicrmw_sub_i32_arid(ptr align 2 %self) {
 ; ATOMIC-NEXT:    move.l %d1, %d2
 ; ATOMIC-NEXT:    add.l #-1, %d2
 ; ATOMIC-NEXT:    cas.l %d0, %d2, (4,%a0)
-; ATOMIC-NEXT:    move.l %d0, %d2
-; ATOMIC-NEXT:    sub.l %d1, %d2
+; ATOMIC-NEXT:    cmp.l %d1, %d0
 ; ATOMIC-NEXT:    seq %d1
 ; ATOMIC-NEXT:    and.b #1, %d1
 ; ATOMIC-NEXT:    cmpi.b #0, %d1
@@ -2009,8 +1978,7 @@ define i32 @atomicrmw_sub_i32_arid(ptr align 2 %self) {
 ; ATOMIC-PIC-NEXT:    move.l %d1, %d2
 ; ATOMIC-PIC-NEXT:    add.l #-1, %d2
 ; ATOMIC-PIC-NEXT:    cas.l %d0, %d2, (4,%a0)
-; ATOMIC-PIC-NEXT:    move.l %d0, %d2
-; ATOMIC-PIC-NEXT:    sub.l %d1, %d2
+; ATOMIC-PIC-NEXT:    cmp.l %d1, %d0
 ; ATOMIC-PIC-NEXT:    seq %d1
 ; ATOMIC-PIC-NEXT:    and.b #1, %d1
 ; ATOMIC-PIC-NEXT:    cmpi.b #0, %d1

--- a/llvm/test/CodeGen/M68k/CodeModel/Large/large-pic.ll
+++ b/llvm/test/CodeGen/M68k/CodeModel/Large/large-pic.ll
@@ -130,8 +130,7 @@ define void @test7(i32 %n.u) nounwind {
 ; CHECK:       ; %bb.0: ; %entry
 ; CHECK-NEXT:    move.l (4,%sp), %d0
 ; CHECK-NEXT:    add.l #-1, %d0
-; CHECK-NEXT:    move.l %d0, %d1
-; CHECK-NEXT:    sub.l #12, %d1
+; CHECK-NEXT:    cmpi.l #12, %d0
 ; CHECK-NEXT:    bhi .LBB6_12
 ; CHECK-NEXT:  ; %bb.1: ; %entry
 ; CHECK-NEXT:    lea (_GLOBAL_OFFSET_TABLE_@GOTPCREL,%pc), %a0

--- a/llvm/test/CodeGen/M68k/CodeModel/Large/large-static.ll
+++ b/llvm/test/CodeGen/M68k/CodeModel/Large/large-static.ll
@@ -109,8 +109,7 @@ define void @test7(i32 %n.u) nounwind {
 ; CHECK:       ; %bb.0: ; %entry
 ; CHECK-NEXT:    move.l (4,%sp), %d0
 ; CHECK-NEXT:    add.l #-1, %d0
-; CHECK-NEXT:    move.l %d0, %d1
-; CHECK-NEXT:    sub.l #12, %d1
+; CHECK-NEXT:    cmpi.l #12, %d0
 ; CHECK-NEXT:    bhi .LBB6_12
 ; CHECK-NEXT:  ; %bb.1: ; %entry
 ; CHECK-NEXT:    lsl.l #2, %d0

--- a/llvm/test/CodeGen/M68k/CodeModel/Medium/medium-pic.ll
+++ b/llvm/test/CodeGen/M68k/CodeModel/Medium/medium-pic.ll
@@ -121,8 +121,7 @@ define void @test7(i32 %n.u) nounwind {
 ; CHECK:       ; %bb.0: ; %entry
 ; CHECK-NEXT:    move.l (4,%sp), %d0
 ; CHECK-NEXT:    add.l #-1, %d0
-; CHECK-NEXT:    move.l %d0, %d1
-; CHECK-NEXT:    sub.l #12, %d1
+; CHECK-NEXT:    cmpi.l #12, %d0
 ; CHECK-NEXT:    bhi .LBB6_12
 ; CHECK-NEXT:  ; %bb.1: ; %entry
 ; CHECK-NEXT:    lea (_GLOBAL_OFFSET_TABLE_@GOTPCREL,%pc), %a0

--- a/llvm/test/CodeGen/M68k/CodeModel/Medium/medium-static.ll
+++ b/llvm/test/CodeGen/M68k/CodeModel/Medium/medium-static.ll
@@ -109,8 +109,7 @@ define void @test7(i32 %n.u) nounwind {
 ; CHECK:       ; %bb.0: ; %entry
 ; CHECK-NEXT:    move.l (4,%sp), %d0
 ; CHECK-NEXT:    add.l #-1, %d0
-; CHECK-NEXT:    move.l %d0, %d1
-; CHECK-NEXT:    sub.l #12, %d1
+; CHECK-NEXT:    cmpi.l #12, %d0
 ; CHECK-NEXT:    bhi .LBB6_12
 ; CHECK-NEXT:  ; %bb.1: ; %entry
 ; CHECK-NEXT:    lsl.l #2, %d0

--- a/llvm/test/CodeGen/M68k/CodeModel/Small/small-pic.ll
+++ b/llvm/test/CodeGen/M68k/CodeModel/Small/small-pic.ll
@@ -117,8 +117,7 @@ define void @test7(i32 %n.u) nounwind {
 ; CHECK:       ; %bb.0: ; %entry
 ; CHECK-NEXT:    move.l (4,%sp), %d0
 ; CHECK-NEXT:    add.l #-1, %d0
-; CHECK-NEXT:    move.l %d0, %d1
-; CHECK-NEXT:    sub.l #12, %d1
+; CHECK-NEXT:    cmpi.l #12, %d0
 ; CHECK-NEXT:    bhi .LBB6_12
 ; CHECK-NEXT:  ; %bb.1: ; %entry
 ; CHECK-NEXT:    lsl.l #2, %d0

--- a/llvm/test/CodeGen/M68k/CodeModel/Small/small-static.ll
+++ b/llvm/test/CodeGen/M68k/CodeModel/Small/small-static.ll
@@ -115,8 +115,7 @@ define void @test7(i32 %n.u) nounwind {
 ; CHECK:       ; %bb.0: ; %entry
 ; CHECK-NEXT:    move.l (4,%sp), %d0
 ; CHECK-NEXT:    add.l #-1, %d0
-; CHECK-NEXT:    move.l %d0, %d1
-; CHECK-NEXT:    sub.l #12, %d1
+; CHECK-NEXT:    cmpi.l #12, %d0
 ; CHECK-NEXT:    bhi .LBB6_12
 ; CHECK-NEXT:  ; %bb.1: ; %entry
 ; CHECK-NEXT:    lsl.l #2, %d0

--- a/llvm/test/CodeGen/M68k/Control/cmp.ll
+++ b/llvm/test/CodeGen/M68k/Control/cmp.ll
@@ -157,8 +157,7 @@ entry:
 define i32 @test8(i64 %res) nounwind {
 ; CHECK-LABEL: test8:
 ; CHECK:       ; %bb.0: ; %entry
-; CHECK-NEXT:    move.l (4,%sp), %d0
-; CHECK-NEXT:    sub.l #3, %d0
+; CHECK-NEXT:    cmpi.l #3, (4,%sp)
 ; CHECK-NEXT:    scs %d0
 ; CHECK-NEXT:    and.l #255, %d0
 ; CHECK-NEXT:    and.l #1, %d0
@@ -174,7 +173,7 @@ define i32 @test11(i64 %l) nounwind {
 ; CHECK:       ; %bb.0: ; %entry
 ; CHECK-NEXT:    move.l (4,%sp), %d0
 ; CHECK-NEXT:    and.l #-32768, %d0
-; CHECK-NEXT:    sub.l #32768, %d0
+; CHECK-NEXT:    cmpi.l #32768, %d0
 ; CHECK-NEXT:    seq %d0
 ; CHECK-NEXT:    and.l #255, %d0
 ; CHECK-NEXT:    and.l #1, %d0
@@ -237,8 +236,7 @@ define zeroext i1 @test15(i32 %bf.load, i32 %n) {
 ; CHECK-NEXT:    moveq #16, %d0
 ; CHECK-NEXT:    move.l (4,%sp), %d1
 ; CHECK-NEXT:    lsr.l %d0, %d1
-; CHECK-NEXT:    move.l %d1, %d0
-; CHECK-NEXT:    sub.l (8,%sp), %d0
+; CHECK-NEXT:    cmp.l (8,%sp), %d1
 ; CHECK-NEXT:    scc %d0
 ; CHECK-NEXT:    cmpi.l #0, %d1
 ; CHECK-NEXT:    seq %d1

--- a/llvm/test/CodeGen/M68k/Control/setcc.ll
+++ b/llvm/test/CodeGen/M68k/Control/setcc.ll
@@ -6,9 +6,7 @@
 define zeroext i16 @t1(i16 zeroext %x) nounwind readnone ssp {
 ; CHECK-LABEL: t1:
 ; CHECK:       ; %bb.0: ; %entry
-; CHECK-NEXT:    moveq #0, %d0
-; CHECK-NEXT:    move.w (6,%sp), %d0
-; CHECK-NEXT:    sub.l #26, %d0
+; CHECK-NEXT:    cmpi.w #26, (6,%sp)
 ; CHECK-NEXT:    shi %d0
 ; CHECK-NEXT:    and.l #255, %d0
 ; CHECK-NEXT:    and.l #1, %d0
@@ -23,9 +21,7 @@ entry:
 define zeroext i16 @t2(i16 zeroext %x) nounwind readnone ssp {
 ; CHECK-LABEL: t2:
 ; CHECK:       ; %bb.0: ; %entry
-; CHECK-NEXT:    moveq #0, %d0
-; CHECK-NEXT:    move.w (6,%sp), %d0
-; CHECK-NEXT:    sub.l #26, %d0
+; CHECK-NEXT:    cmpi.w #26, (6,%sp)
 ; CHECK-NEXT:    scs %d0
 ; CHECK-NEXT:    and.l #255, %d0
 ; CHECK-NEXT:    and.l #1, %d0

--- a/llvm/test/CodeGen/M68k/PR57660.ll
+++ b/llvm/test/CodeGen/M68k/PR57660.ll
@@ -42,7 +42,7 @@ define i32 @foo2(ptr noundef %0) {
 ; CHECK-NEXT:    movem.w %d0, (4,%sp)
 ; CHECK-NEXT:    and.b #1, %d0
 ; CHECK-NEXT:    movem.w %d0, (6,%sp)
-; CHECK-NEXT:    sub.b #1, %d0
+; CHECK-NEXT:    cmpi.b #1, %d0
 ; CHECK-NEXT:    bgt .LBB1_2
 ; CHECK-NEXT:  ; %bb.1: ; %if
 ; CHECK-NEXT:    movem.w (4,%sp), %d1

--- a/llvm/test/CodeGen/M68k/global-address.ll
+++ b/llvm/test/CodeGen/M68k/global-address.ll
@@ -10,7 +10,7 @@ define i1 @folded_offset(i32 %conv29) {
 ; CHECK-NEXT:    move.b (VBRTag+1,%pc), %d0
 ; CHECK-NEXT:    ext.w %d0
 ; CHECK-NEXT:    ext.l %d0
-; CHECK-NEXT:    sub.l (4,%sp), %d0
+; CHECK-NEXT:    cmp.l (4,%sp), %d0
 ; CHECK-NEXT:    seq %d0
 ; CHECK-NEXT:    rts
 entry:
@@ -29,7 +29,7 @@ define i1 @non_folded_offset(i32 %conv29) {
 ; CHECK-NEXT:    move.b (0,%a0,%d0), %d0
 ; CHECK-NEXT:    ext.w %d0
 ; CHECK-NEXT:    ext.l %d0
-; CHECK-NEXT:    sub.l (4,%sp), %d0
+; CHECK-NEXT:    cmp.l (4,%sp), %d0
 ; CHECK-NEXT:    seq %d0
 ; CHECK-NEXT:    rts
 entry:

--- a/llvm/test/CodeGen/M68k/register-spills.ll
+++ b/llvm/test/CodeGen/M68k/register-spills.ll
@@ -10,25 +10,22 @@ define void @test_edge_detection_conditional_branch() {
 ; CHECK-LABEL: test_edge_detection_conditional_branch:
 ; CHECK:         .cfi_startproc
 ; CHECK-NEXT:  ; %bb.0: ; %start
-; CHECK-NEXT:    suba.l #12, %sp
-; CHECK-NEXT:    .cfi_def_cfa_offset -16
-; CHECK-NEXT:    movem.l %d2, (8,%sp) ; 8-byte Folded Spill
+; CHECK-NEXT:    suba.l #4, %sp
+; CHECK-NEXT:    .cfi_def_cfa_offset -8
 ; CHECK-NEXT:    bra .LBB0_1
 ; CHECK-NEXT:  .LBB0_1: ; %condition_check
 ; CHECK-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NEXT:    jsr get1
-; CHECK-NEXT:    move.b (7,%sp), %d2
-; CHECK-NEXT:    and.b #1, %d2
-; CHECK-NEXT:    move.b %d0, %d1
-; CHECK-NEXT:    sub.b %d2, %d1
-; CHECK-NEXT:    movem.w %d0, (4,%sp)
+; CHECK-NEXT:    move.b (3,%sp), %d1
+; CHECK-NEXT:    and.b #1, %d1
+; CHECK-NEXT:    cmp.b %d1, %d0
+; CHECK-NEXT:    movem.w %d0, (0,%sp)
 ; CHECK-NEXT:    bne .LBB0_1
 ; CHECK-NEXT:    bra .LBB0_2
 ; CHECK-NEXT:  .LBB0_2: ; %do_something
-; CHECK-NEXT:    movem.w (4,%sp), %d0
-; CHECK-NEXT:    move.b %d0, (7,%sp)
-; CHECK-NEXT:    movem.l (8,%sp), %d2 ; 8-byte Folded Reload
-; CHECK-NEXT:    adda.l #12, %sp
+; CHECK-NEXT:    movem.w (0,%sp), %d0
+; CHECK-NEXT:    move.b %d0, (3,%sp)
+; CHECK-NEXT:    adda.l #4, %sp
 ; CHECK-NEXT:    rts
 start:
   %prev_state = alloca [1 x i8], align 1

--- a/llvm/test/CodeGen/M68k/setcc-redundant.ll
+++ b/llvm/test/CodeGen/M68k/setcc-redundant.ll
@@ -3,10 +3,11 @@
 
 define i8 @scalar_setcc_lt0(i8 %a, i8 %b, i8 %x, i8 %y) {
 ; CHECK-LABEL: scalar_setcc_lt0:
-; CHECK:       ; %bb.0:
-; CHECK-NEXT:    move.b (11,%sp), %d0
-; CHECK-NEXT:    move.b (7,%sp), %d1
-; CHECK-NEXT:    sub.b %d0, %d1
+; CHECK:         .cfi_startproc
+; CHECK-NEXT:  ; %bb.0:
+; CHECK-NEXT:    move.b (7,%sp), %d0
+; CHECK-NEXT:    move.b (11,%sp), %d1
+; CHECK-NEXT:    cmp.b %d1, %d0
 ; CHECK-NEXT:    blt .LBB0_1
 ; CHECK-NEXT:  ; %bb.2:
 ; CHECK-NEXT:    lea (19,%sp), %a0
@@ -25,10 +26,11 @@ define i8 @scalar_setcc_lt0(i8 %a, i8 %b, i8 %x, i8 %y) {
 
 define i8 @scalar_setcc_ne0(i8 %a, i8 %b, i8 %x, i8 %y) {
 ; CHECK-LABEL: scalar_setcc_ne0:
-; CHECK:       ; %bb.0:
-; CHECK-NEXT:    move.b (11,%sp), %d0
-; CHECK-NEXT:    move.b (7,%sp), %d1
-; CHECK-NEXT:    sub.b %d0, %d1
+; CHECK:         .cfi_startproc
+; CHECK-NEXT:  ; %bb.0:
+; CHECK-NEXT:    move.b (7,%sp), %d0
+; CHECK-NEXT:    move.b (11,%sp), %d1
+; CHECK-NEXT:    cmp.b %d1, %d0
 ; CHECK-NEXT:    blt .LBB1_1
 ; CHECK-NEXT:  ; %bb.2:
 ; CHECK-NEXT:    lea (19,%sp), %a0


### PR DESCRIPTION
The logic for `EmitCmp()` was (from what I can tell) ported over from the X86 target, most of which is not applicable to M68k, and it causes inefficient code to be generated.

- There is no need to promote i16 immediate values, since M68k's compare instruction supports them.
- The logic actually makes it impossible for `CMP` to be emitted, instead always emitting `SUB`. Using `SUB` forces an extra register copy in most situations and doesn't show a provable benefit. 

As shown by the tests, removing this logic results in more efficient and canonical comparisons.