### PR TITLE
[lldb][NativePDB] Keep declaration order of struct fields

### DIFF
--- a/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.cpp
@@ -60,6 +60,12 @@ UdtRecordCompleter::UdtRecordCompleter(
   }
 }
 
+llvm::Error
+UdtRecordCompleter::visitMemberEnd(llvm::codeview::CVMemberRecord &Record) {
+  ++m_member_index;
+  return Error::success();
+}
+
 clang::QualType UdtRecordCompleter::AddBaseClassForTypeIndex(
     llvm::codeview::TypeIndex ti, llvm::codeview::MemberAccess access,
     std::optional<uint64_t> vtable_idx) {
@@ -300,8 +306,8 @@ Error UdtRecordCompleter::visitKnownMember(CVMemberRecord &cvr,
       bitfield_width ? bitfield_width : GetSizeOfType(ti, m_index.tpi()) * 8;
   if (field_size == 0)
     return Error::success();
-  m_record.CollectMember(data_member.Name, offset, field_size, member_qt, access,
-                bitfield_width);
+  m_record.CollectMember(data_member.Name, offset, field_size, member_qt,
+                         access, bitfield_width, m_member_index);
   return Error::success();
 }
 
@@ -465,11 +471,22 @@ void UdtRecordCompleter::FinishRecord() {
   }
 }
 
+void UdtRecordCompleter::Member::RestoreOriginalOrder() {
+  llvm::stable_sort(fields, [](const MemberUP &lhs, const MemberUP &rhs) {
+    return std::tie(lhs->original_order, lhs->bit_offset) <
+           std::tie(rhs->original_order, rhs->bit_offset);
+  });
+
+  for (MemberUP &field : fields)
+    field->RestoreOriginalOrder();
+}
+
 void UdtRecordCompleter::Record::CollectMember(
     llvm::StringRef name, uint64_t offset, uint64_t field_size,
-    clang::QualType qt, lldb::AccessType access, uint64_t bitfield_width) {
+    clang::QualType qt, lldb::AccessType access, uint64_t bitfield_width,
+    uint32_t member_index) {
   fields_map[offset].push_back(std::make_unique<Member>(
-      name, offset, field_size, qt, access, bitfield_width));
+      name, offset, field_size, qt, access, bitfield_width, member_index));
   if (start_offset > offset)
     start_offset = offset;
 }
@@ -555,6 +572,7 @@ void UdtRecordCompleter::Record::ConstructRecord() {
       if (parent->kind == Member::Struct) {
         parent->fields.push_back(std::make_unique<Member>(Member::Union));
         parent = parent->fields.back().get();
+        parent->original_order = std::numeric_limits<uint32_t>::max();
         parent->bit_offset = offset;
       } else {
         assert(parent == &record &&
@@ -562,10 +580,15 @@ void UdtRecordCompleter::Record::ConstructRecord() {
       }
       for (auto &field : fields) {
         int64_t bit_size = field->bit_size;
+        // Use the lowest index of the union members.
+        parent->original_order =
+            std::min(parent->original_order, field->original_order);
         parent->fields.push_back(std::move(field));
         end_offset_map[offset + bit_size].push_back(
             parent->fields.back().get());
       }
     }
   }
+
+  record.RestoreOriginalOrder();
 }

--- a/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.cpp
@@ -473,8 +473,8 @@ void UdtRecordCompleter::FinishRecord() {
 
 void UdtRecordCompleter::Member::RestoreOriginalOrder() {
   llvm::stable_sort(fields, [](const MemberUP &lhs, const MemberUP &rhs) {
-    return std::tie(lhs->original_order, lhs->bit_offset) <
-           std::tie(rhs->original_order, rhs->bit_offset);
+    return std::tie(lhs->original_index, lhs->bit_offset) <
+           std::tie(rhs->original_index, rhs->bit_offset);
   });
 
   for (MemberUP &field : fields)
@@ -572,7 +572,7 @@ void UdtRecordCompleter::Record::ConstructRecord() {
       if (parent->kind == Member::Struct) {
         parent->fields.push_back(std::make_unique<Member>(Member::Union));
         parent = parent->fields.back().get();
-        parent->original_order = std::numeric_limits<uint32_t>::max();
+        parent->original_index = std::numeric_limits<uint32_t>::max();
         parent->bit_offset = offset;
       } else {
         assert(parent == &record &&
@@ -581,8 +581,8 @@ void UdtRecordCompleter::Record::ConstructRecord() {
       for (auto &field : fields) {
         int64_t bit_size = field->bit_size;
         // Use the lowest index of the union members.
-        parent->original_order =
-            std::min(parent->original_order, field->original_order);
+        parent->original_index =
+            std::min(parent->original_index, field->original_index);
         parent->fields.push_back(std::move(field));
         end_offset_map[offset + bit_size].push_back(
             parent->fields.back().get());

--- a/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.h
@@ -53,6 +53,8 @@ class UdtRecordCompleter : public llvm::codeview::TypeVisitorCallbacks {
   llvm::DenseMap<lldb::opaque_compiler_type_t,
                  llvm::SmallSet<std::pair<llvm::StringRef, CompilerType>, 8>>
       &m_cxx_record_map;
+  /// Index of the current member.
+  uint32_t m_member_index = 0;
 
 public:
   UdtRecordCompleter(
@@ -62,6 +64,8 @@ public:
       llvm::DenseMap<lldb::opaque_compiler_type_t,
                      llvm::SmallSet<std::pair<llvm::StringRef, CompilerType>,
                                     8>> &cxx_record_map);
+
+  llvm::Error visitMemberEnd(llvm::codeview::CVMemberRecord &Record) override;
 
 #define MEMBER_RECORD(EnumName, EnumVal, Name)                                 \
   llvm::Error visitKnownMember(llvm::codeview::CVMemberRecord &CVR,            \
@@ -81,6 +85,7 @@ public:
     clang::QualType qt;
     lldb::AccessType access;
     uint32_t bitfield_width;
+    uint32_t original_order = 0;
     // Following are Only used for struct or union.
     uint64_t base_offset;
     llvm::SmallVector<MemberUP, 1> fields;
@@ -90,20 +95,25 @@ public:
         : kind(kind), name(), bit_offset(0), bit_size(0), qt(),
           access(lldb::eAccessPublic), bitfield_width(0), base_offset(0) {}
     Member(llvm::StringRef name, uint64_t bit_offset, uint64_t bit_size,
-           clang::QualType qt, lldb::AccessType access, uint32_t bitfield_width)
+           clang::QualType qt, lldb::AccessType access, uint32_t bitfield_width,
+           uint32_t original_order)
         : kind(Field), name(name), bit_offset(bit_offset), bit_size(bit_size),
           qt(qt), access(access), bitfield_width(bitfield_width),
-          base_offset(0) {}
+          original_order(original_order), base_offset(0) {}
     void ConvertToStruct() {
       kind = Struct;
       base_offset = bit_offset;
       fields.push_back(std::make_unique<Member>(name, bit_offset, bit_size, qt,
-                                                access, bitfield_width));
+                                                access, bitfield_width,
+                                                original_order));
       name = llvm::StringRef();
       qt = clang::QualType();
       access = lldb::eAccessPublic;
       bit_offset = bit_size = bitfield_width = 0;
+      // Keep original_order.
     }
+
+    void RestoreOriginalOrder();
   };
 
   struct Record {
@@ -113,7 +123,8 @@ public:
     std::map<uint64_t, llvm::SmallVector<MemberUP, 1>> fields_map;
     void CollectMember(llvm::StringRef name, uint64_t offset,
                        uint64_t field_size, clang::QualType qt,
-                       lldb::AccessType access, uint64_t bitfield_width);
+                       lldb::AccessType access, uint64_t bitfield_width,
+                       uint32_t member_index);
     void ConstructRecord();
   };
   void complete();

--- a/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.h
@@ -85,7 +85,8 @@ public:
     clang::QualType qt;
     lldb::AccessType access;
     uint32_t bitfield_width;
-    uint32_t original_order = 0;
+    /// Index of the member inside the LF_FIELDLIST.
+    uint32_t original_index = 0;
     // Following are Only used for struct or union.
     uint64_t base_offset;
     llvm::SmallVector<MemberUP, 1> fields;
@@ -96,21 +97,21 @@ public:
           access(lldb::eAccessPublic), bitfield_width(0), base_offset(0) {}
     Member(llvm::StringRef name, uint64_t bit_offset, uint64_t bit_size,
            clang::QualType qt, lldb::AccessType access, uint32_t bitfield_width,
-           uint32_t original_order)
+           uint32_t original_index)
         : kind(Field), name(name), bit_offset(bit_offset), bit_size(bit_size),
           qt(qt), access(access), bitfield_width(bitfield_width),
-          original_order(original_order), base_offset(0) {}
+          original_index(original_index), base_offset(0) {}
     void ConvertToStruct() {
       kind = Struct;
       base_offset = bit_offset;
       fields.push_back(std::make_unique<Member>(name, bit_offset, bit_size, qt,
                                                 access, bitfield_width,
-                                                original_order));
+                                                original_index));
       name = llvm::StringRef();
       qt = clang::QualType();
       access = lldb::eAccessPublic;
       bit_offset = bit_size = bitfield_width = 0;
-      // Keep original_order.
+      // Keep original_index.
     }
 
     void RestoreOriginalOrder();

--- a/lldb/unittests/SymbolFile/NativePDB/UdtRecordCompleterTests.cpp
+++ b/lldb/unittests/SymbolFile/NativePDB/UdtRecordCompleterTests.cpp
@@ -41,10 +41,11 @@ private:
 
   friend llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                                        const WrappedMember &w) {
-    os << llvm::formatv("Member{.kind={0}, .name=\"{1}\", .bit_offset={2}, "
-                        ".bit_size={3}, .base_offset={4}, .fields=[",
-                        w.m_obj.kind, w.m_obj.name, w.m_obj.bit_offset,
-                        w.m_obj.bit_size, w.m_obj.base_offset);
+    os << llvm::formatv(
+        "Member{.kind={0}, .name=\"{1}\", .bit_offset={2}, "
+        ".bit_size={3}, .base_offset={4}, .original_order={5}, .fields=[",
+        w.m_obj.kind, w.m_obj.name, w.m_obj.bit_offset, w.m_obj.bit_size,
+        w.m_obj.base_offset, w.m_obj.original_order);
     llvm::ListSeparator sep;
     for (auto &f : w.m_obj.fields)
       os << sep << WrappedMember(*f);
@@ -83,21 +84,27 @@ private:
 class UdtRecordCompleterRecordTests : public testing::Test {
 protected:
   Record record;
+  uint32_t field_index = 0;
 
 public:
   void SetKind(Member::Kind kind) { record.record.kind = kind; }
   void CollectMember(StringRef name, uint64_t byte_offset, uint64_t byte_size) {
     record.CollectMember(name, byte_offset * 8, byte_size * 8,
-                         clang::QualType(), lldb::eAccessPublic, 0);
+                         clang::QualType(), lldb::eAccessPublic, 0,
+                         ++field_index);
   }
-  void ConstructRecord() { record.ConstructRecord(); }
+  void ConstructRecord() {
+    record.ConstructRecord();
+    field_index = 0;
+  }
 };
+
 Member *AddField(Member *member, StringRef name, uint64_t byte_offset,
                  uint64_t byte_size, Member::Kind kind,
                  uint64_t base_offset = 0) {
-  auto field =
-      std::make_unique<Member>(name, byte_offset * 8, byte_size * 8,
-                               clang::QualType(), lldb::eAccessPublic, 0);
+  auto field = std::make_unique<Member>(
+      name, byte_offset * 8, byte_size * 8, clang::QualType(),
+      lldb::eAccessPublic, /*bitfield_width=*/0, /*original_order=*/0);
   field->kind = kind;
   field->base_offset = base_offset * 8;
   member->fields.push_back(std::move(field));
@@ -291,5 +298,32 @@ TEST_F(UdtRecordCompleterRecordTests, TestNestedStructInUnionInStructInUnion) {
   AddField(u, "m5", 6, 2, Member::Field);
   AddField(u, "m6", 6, 2, Member::Field);
   AddField(s, "m7", 8, 2, Member::Field);
+  EXPECT_EQ(WrappedRecord(this->record), WrappedRecord(record));
+}
+
+TEST_F(UdtRecordCompleterRecordTests, TestReorderedStuctFields) {
+  SetKind(Member::Kind::Struct);
+  CollectMember("__0", 12, 2);
+  CollectMember("__1", 14, 2);
+  CollectMember("__2", 8, 4);
+  CollectMember("__3", 0, 8);
+  ConstructRecord();
+
+  // From Rust.
+  // struct Foo(i16, u16, i32, u64)
+  // Is reordered by Rust to:
+  // struct Foo {
+  //   u64 __3;
+  //   i32 __2;
+  //   i16 __0;
+  //   u16 __1:
+  // };
+
+  Record record;
+  record.start_offset = 0;
+  AddField(&record.record, "__0", 12, 2, Member::Field);
+  AddField(&record.record, "__1", 14, 2, Member::Field);
+  AddField(&record.record, "__2", 8, 4, Member::Field);
+  AddField(&record.record, "__3", 0, 8, Member::Field);
   EXPECT_EQ(WrappedRecord(this->record), WrappedRecord(record));
 }

--- a/lldb/unittests/SymbolFile/NativePDB/UdtRecordCompleterTests.cpp
+++ b/lldb/unittests/SymbolFile/NativePDB/UdtRecordCompleterTests.cpp
@@ -43,9 +43,9 @@ private:
                                        const WrappedMember &w) {
     os << llvm::formatv(
         "Member{.kind={0}, .name=\"{1}\", .bit_offset={2}, "
-        ".bit_size={3}, .base_offset={4}, .original_order={5}, .fields=[",
+        ".bit_size={3}, .base_offset={4}, .original_index={5}, .fields=[",
         w.m_obj.kind, w.m_obj.name, w.m_obj.bit_offset, w.m_obj.bit_size,
-        w.m_obj.base_offset, w.m_obj.original_order);
+        w.m_obj.base_offset, w.m_obj.original_index);
     llvm::ListSeparator sep;
     for (auto &f : w.m_obj.fields)
       os << sep << WrappedMember(*f);
@@ -104,7 +104,7 @@ Member *AddField(Member *member, StringRef name, uint64_t byte_offset,
                  uint64_t base_offset = 0) {
   auto field = std::make_unique<Member>(
       name, byte_offset * 8, byte_size * 8, clang::QualType(),
-      lldb::eAccessPublic, /*bitfield_width=*/0, /*original_order=*/0);
+      lldb::eAccessPublic, /*bitfield_width=*/0, /*original_index=*/0);
   field->kind = kind;
   field->base_offset = base_offset * 8;
   member->fields.push_back(std::move(field));


### PR DESCRIPTION
Unlike in C/C++, struct fields in Rust may be reordered by the compiler to reduce padding. When completing records, we only tracked the offset of fields inside the struct. For Rust this could result in an order that didn't match the declaration (#218613).

This PR tracks the declaration order and sorts fields after the record is constructed. It's assumed that the members inside the `LF_FIELDLIST` are present in declaration order.

Fixes #218613.