### PR TITLE
[lld][MachO] Order objc stubs by caller priority

### DIFF
--- a/lld/MachO/SyntheticSections.cpp
+++ b/lld/MachO/SyntheticSections.cpp
@@ -26,6 +26,8 @@
 #include "llvm/Support/Parallel.h"
 #include "llvm/Support/xxhash.h"
 
+#include <limits>
+
 #if defined(__APPLE__)
 #include <sys/mman.h>
 
@@ -945,11 +947,18 @@ uint64_t ObjCStubsSection::getSize() const {
 }
 
 void ObjCStubsSection::sortSymbols(
-    llvm::function_ref<bool(const Defined *, const Defined *)> less) {
+    const llvm::DenseMap<const Symbol *, int> &priorities) {
   auto stubSize = config->objcStubsMode == ObjCStubsMode::fast
                       ? target->objcStubsFastSize
                       : target->objcStubsSmallSize;
-  llvm::stable_sort(symbols, less);
+  llvm::stable_sort(symbols, [&](const Defined *a, const Defined *b) {
+    auto priority = [&](const Defined *sym) {
+      auto it = priorities.find(sym);
+      return it == priorities.end() ? std::numeric_limits<int>::max()
+                                    : it->second;
+    };
+    return priority(a) < priority(b);
+  });
   for (auto [idx, sym] : llvm::enumerate(symbols))
     sym->value = idx * stubSize;
 }

--- a/lld/MachO/SyntheticSections.cpp
+++ b/lld/MachO/SyntheticSections.cpp
@@ -944,6 +944,16 @@ uint64_t ObjCStubsSection::getSize() const {
   return stubSize * symbols.size();
 }
 
+void ObjCStubsSection::sortSymbols(
+    llvm::function_ref<bool(const Defined *, const Defined *)> less) {
+  auto stubSize = config->objcStubsMode == ObjCStubsMode::fast
+                      ? target->objcStubsFastSize
+                      : target->objcStubsSmallSize;
+  llvm::stable_sort(symbols, less);
+  for (auto [idx, sym] : llvm::enumerate(symbols))
+    sym->value = idx * stubSize;
+}
+
 void ObjCStubsSection::writeTo(uint8_t *buf) const {
   uint64_t stubOffset = 0;
   for (Defined *sym : symbols) {

--- a/lld/MachO/SyntheticSections.cpp
+++ b/lld/MachO/SyntheticSections.cpp
@@ -899,15 +899,19 @@ StringRef ObjCStubsSection::getMethname(Symbol *sym) {
   return methname;
 }
 
+size_t ObjCStubsSection::getStubSize() const {
+  return config->objcStubsMode == ObjCStubsMode::fast
+             ? target->objcStubsFastSize
+             : target->objcStubsSmallSize;
+}
+
 void ObjCStubsSection::addEntry(Symbol *sym) {
   StringRef methname = getMethname(sym);
   // We create a selref entry for each unique methname.
   if (!ObjCSelRefsHelper::getSelRef(methname))
     ObjCSelRefsHelper::makeSelRef(methname);
 
-  auto stubSize = config->objcStubsMode == ObjCStubsMode::fast
-                      ? target->objcStubsFastSize
-                      : target->objcStubsSmallSize;
+  size_t stubSize = getStubSize();
   Defined *newSym = replaceSymbol<Defined>(
       sym, sym->getName(), nullptr, isec,
       /*value=*/symbols.size() * stubSize,
@@ -940,17 +944,11 @@ void ObjCStubsSection::setUp() {
 }
 
 uint64_t ObjCStubsSection::getSize() const {
-  auto stubSize = config->objcStubsMode == ObjCStubsMode::fast
-                      ? target->objcStubsFastSize
-                      : target->objcStubsSmallSize;
-  return stubSize * symbols.size();
+  return getStubSize() * symbols.size();
 }
 
 void ObjCStubsSection::sortSymbols(
     const llvm::DenseMap<const Symbol *, int> &priorities) {
-  auto stubSize = config->objcStubsMode == ObjCStubsMode::fast
-                      ? target->objcStubsFastSize
-                      : target->objcStubsSmallSize;
   llvm::stable_sort(symbols, [&](const Defined *a, const Defined *b) {
     auto priority = [&](const Defined *sym) {
       auto it = priorities.find(sym);
@@ -959,6 +957,7 @@ void ObjCStubsSection::sortSymbols(
     };
     return priority(a) < priority(b);
   });
+  size_t stubSize = getStubSize();
   for (auto [idx, sym] : llvm::enumerate(symbols))
     sym->value = idx * stubSize;
 }

--- a/lld/MachO/SyntheticSections.h
+++ b/lld/MachO/SyntheticSections.h
@@ -346,6 +346,11 @@ public:
   static bool isObjCStubSymbol(Symbol *sym);
   static StringRef getMethname(Symbol *sym);
 
+  /// Stably sort the stubs by \p less and reassign their offsets. Must run
+  /// before addresses are assigned.
+  void
+  sortSymbols(llvm::function_ref<bool(const Defined *, const Defined *)> less);
+
 private:
   std::vector<Defined *> symbols;
   Symbol *objcMsgSend = nullptr;

--- a/lld/MachO/SyntheticSections.h
+++ b/lld/MachO/SyntheticSections.h
@@ -346,10 +346,9 @@ public:
   static bool isObjCStubSymbol(Symbol *sym);
   static StringRef getMethname(Symbol *sym);
 
-  /// Stably sort the stubs by \p less and reassign their offsets. Must run
-  /// before addresses are assigned.
-  void
-  sortSymbols(llvm::function_ref<bool(const Defined *, const Defined *)> less);
+  /// Stably sort the stubs by \p priorities and reassign their offsets. Must
+  /// run before addresses are assigned.
+  void sortSymbols(const llvm::DenseMap<const Symbol *, int> &priorities);
 
 private:
   std::vector<Defined *> symbols;

--- a/lld/MachO/SyntheticSections.h
+++ b/lld/MachO/SyntheticSections.h
@@ -351,6 +351,8 @@ public:
   void sortSymbols(const llvm::DenseMap<const Symbol *, int> &priorities);
 
 private:
+  size_t getStubSize() const;
+
   std::vector<Defined *> symbols;
   Symbol *objcMsgSend = nullptr;
 };

--- a/lld/MachO/Writer.cpp
+++ b/lld/MachO/Writer.cpp
@@ -33,6 +33,7 @@
 #include "llvm/Support/xxhash.h"
 
 #include <algorithm>
+
 using namespace llvm;
 using namespace llvm::MachO;
 using namespace llvm::sys;

--- a/lld/MachO/Writer.cpp
+++ b/lld/MachO/Writer.cpp
@@ -33,6 +33,7 @@
 #include "llvm/Support/xxhash.h"
 
 #include <algorithm>
+#include <limits>
 
 using namespace llvm;
 using namespace llvm::MachO;
@@ -971,6 +972,53 @@ template <class LP> void Writer::createLoadCommands() {
                               : 0));
 }
 
+// __objc_stubs is synthetic, so the input section sorting in
+// sortSegmentsAndSections() does not reach its entries. Order each stub by the
+// priority of the earliest-laid-out section that calls it, which keeps the
+// stubs reached during startup together.
+static void orderObjCStubsByCallerPriority(
+    const DenseMap<const InputSection *, int> &priorities) {
+  if (priorities.empty() || !in.objcStubs->isNeeded())
+    return;
+
+  // ICF may make the prioritized section differ from the section whose
+  // relocations describe the original calls. Use the canonical section for
+  // priority lookup, but scan the original section's relocations.
+  DenseMap<const Symbol *, int> stubPriority;
+  for (const ConcatInputSection *isec : inputSections) {
+    if (!isCodeSection(isec))
+      continue;
+    const auto *priorityIsec = cast<ConcatInputSection>(isec->canonical());
+    if (priorityIsec->shouldOmitFromOutput())
+      continue;
+    auto prio = priorities.find(priorityIsec);
+    if (prio == priorities.end())
+      continue;
+    for (const Relocation &r : isec->relocs) {
+      if (!target->hasAttr(r.type, RelocAttrBits::BRANCH))
+        continue;
+      auto *stub = dyn_cast_if_present<Symbol *>(r.referent);
+      if (!stub || !ObjCStubsSection::isObjCStubSymbol(stub))
+        continue;
+      auto [it, inserted] = stubPriority.try_emplace(stub, prio->second);
+      if (!inserted)
+        it->second = std::min(it->second, prio->second);
+    }
+  }
+  if (stubPriority.empty())
+    return;
+
+  auto priorityOf = [&](const Defined *sym) {
+    auto it = stubPriority.find(sym);
+    // Stubs with no prioritized caller sort last, keeping their original order.
+    return it == stubPriority.end() ? std::numeric_limits<int>::max()
+                                    : it->second;
+  };
+  in.objcStubs->sortSymbols([&](const Defined *a, const Defined *b) {
+    return priorityOf(a) < priorityOf(b);
+  });
+}
+
 // Sorting only can happen once all outputs have been collected. Here we sort
 // segments, output sections within each segment, and input sections within each
 // output segment.
@@ -980,6 +1028,8 @@ static void sortSegmentsAndSections() {
 
   DenseMap<const InputSection *, int> isecPriorities =
       priorityBuilder.buildInputSectionPriorities();
+
+  orderObjCStubsByCallerPriority(isecPriorities);
 
   uint32_t sectionIndex = 0;
   for (OutputSegment *seg : outputSegments) {

--- a/lld/MachO/Writer.cpp
+++ b/lld/MachO/Writer.cpp
@@ -33,8 +33,6 @@
 #include "llvm/Support/xxhash.h"
 
 #include <algorithm>
-#include <limits>
-
 using namespace llvm;
 using namespace llvm::MachO;
 using namespace llvm::sys;
@@ -1008,15 +1006,7 @@ static void orderObjCStubsByCallerPriority(
   if (stubPriority.empty())
     return;
 
-  auto priorityOf = [&](const Defined *sym) {
-    auto it = stubPriority.find(sym);
-    // Stubs with no prioritized caller sort last, keeping their original order.
-    return it == stubPriority.end() ? std::numeric_limits<int>::max()
-                                    : it->second;
-  };
-  in.objcStubs->sortSymbols([&](const Defined *a, const Defined *b) {
-    return priorityOf(a) < priorityOf(b);
-  });
+  in.objcStubs->sortSymbols(stubPriority);
 }
 
 // Sorting only can happen once all outputs have been collected. Here we sort

--- a/lld/docs/ReleaseNotes.md
+++ b/lld/docs/ReleaseNotes.md
@@ -37,6 +37,10 @@ from the [LLVM releases web site](https://llvm.org/releases/).
 
 ### MachO Improvements
 
+* `__objc_stubs` entries are now ordered by the priority of the sections that
+  call them, so that stubs reached from prioritized code are laid out together.
+  This applies whenever section priorities exist, such as with `-order_file`.
+
 ### WebAssembly Improvements
 
 * Added support for resolving and merging common data symbols (allocating them

--- a/lld/test/MachO/objc-stubs-order-file-icf-safe-thunks.s
+++ b/lld/test/MachO/objc-stubs-order-file-icf-safe-thunks.s
@@ -1,0 +1,63 @@
+# REQUIRES: aarch64
+
+## An order-file symbol folded to a safe thunk should still order the ObjC stub
+## called by the original folded body.
+
+# RUN: rm -rf %t && split-file %s %t
+# RUN: llvm-mc -filetype=obj -triple=arm64-apple-darwin %t/input.s -o %t/input.o
+# RUN: %lld -arch arm64 -e _entry -U _objc_msgSend -o %t/out %t/input.o \
+# RUN:   -objc_stubs_small --icf=safe_thunks -order_file %t/order
+# RUN: llvm-objdump --no-show-raw-insn -d %t/out | \
+# RUN:   FileCheck %s --check-prefix=THUNK
+# RUN: llvm-objdump --no-show-raw-insn --section=__TEXT,__objc_stubs --macho \
+# RUN:   %t/out | FileCheck %s --check-prefix=ORDERED
+
+# THUNK-LABEL: <_dup>:
+# THUNK-NEXT:  b 0x{{[0-9a-f]+}} <_hot>
+
+# ORDERED:      Contents of (__TEXT,__objc_stubs) section
+# ORDERED-NEXT: _objc_msgSend$hot:
+# ORDERED:      Objc selector ref: hot
+# ORDERED:      _objc_msgSend$cold:
+# ORDERED:      Objc selector ref: cold
+# ORDERED:      _objc_msgSend$mild:
+# ORDERED:      Objc selector ref: mild
+
+#--- input.s
+.text
+.globl _cold
+_cold:
+  bl _objc_msgSend$cold
+  ret
+
+.globl _mild
+_mild:
+  bl _objc_msgSend$mild
+  ret
+
+.globl _hot
+_hot:
+  bl _objc_msgSend$hot
+  ret
+
+.globl _dup
+_dup:
+  bl _objc_msgSend$hot
+  ret
+
+.globl _entry
+_entry:
+  bl _cold
+  bl _mild
+  bl _hot
+  bl _dup
+  ret
+
+.addrsig
+.addrsig_sym _hot
+.addrsig_sym _dup
+
+.subsections_via_symbols
+
+#--- order
+_dup

--- a/lld/test/MachO/objc-stubs-order-file-icf-safe-thunks.s
+++ b/lld/test/MachO/objc-stubs-order-file-icf-safe-thunks.s
@@ -17,11 +17,8 @@
 
 # ORDERED:      Contents of (__TEXT,__objc_stubs) section
 # ORDERED-NEXT: _objc_msgSend$hot:
-# ORDERED:      Objc selector ref: hot
 # ORDERED:      _objc_msgSend$cold:
-# ORDERED:      Objc selector ref: cold
 # ORDERED:      _objc_msgSend$mild:
-# ORDERED:      Objc selector ref: mild
 
 #--- input.s
 .text

--- a/lld/test/MachO/objc-stubs-order-file.s
+++ b/lld/test/MachO/objc-stubs-order-file.s
@@ -1,0 +1,90 @@
+# REQUIRES: aarch64
+
+## __objc_stubs is synthetic, so the input section sorting does not reach its
+## entries. Check that they are instead ordered by the priority of the sections
+## that call them.
+
+# RUN: rm -rf %t && split-file %s %t
+# RUN: llvm-mc -filetype=obj -triple=arm64-apple-darwin %t/a.s -o %t/a.o
+
+## Without an order file the stubs keep the order they were interned in.
+# RUN: %lld -arch arm64 -e _main -U _objc_msgSend -o %t/base.out %t/a.o \
+# RUN:   -objc_stubs_small
+# RUN: llvm-objdump --no-show-raw-insn --section=__TEXT,__objc_stubs --macho \
+# RUN:   %t/base.out | FileCheck %s --check-prefix=BASE
+
+## _hot is ordered first, so the stub it calls moves ahead of the others, which
+## keep their relative order. Each stub must still load its own selector.
+# RUN: %lld -arch arm64 -e _main -U _objc_msgSend -o %t/ordered.out %t/a.o \
+# RUN:   -objc_stubs_small -order_file %t/order
+# RUN: llvm-objdump --no-show-raw-insn --section=__TEXT,__objc_stubs --macho \
+# RUN:   %t/ordered.out | FileCheck %s --check-prefix=ORDERED
+
+# RUN: %lld -arch arm64 -e _main -U _objc_msgSend -o %t/fast.out %t/a.o \
+# RUN:   -objc_stubs_fast -order_file %t/order
+# RUN: llvm-objdump --no-show-raw-insn --section=__TEXT,__objc_stubs --macho \
+# RUN:   %t/fast.out | FileCheck %s --check-prefix=ORDERED
+
+## Callers are recorded after ICF. _dup is identical to _hot and folds with it,
+## so the priority has to reach the stub through the surviving section.
+# RUN: %lld -arch arm64 -e _main -U _objc_msgSend -o %t/icf.out %t/a.o \
+# RUN:   -objc_stubs_small -order_file %t/order --icf=all
+# RUN: llvm-nm --numeric-sort %t/icf.out | FileCheck %s --check-prefix=FOLDED
+# RUN: llvm-objdump --no-show-raw-insn --section=__TEXT,__objc_stubs --macho \
+# RUN:   %t/icf.out | FileCheck %s --check-prefix=ORDERED
+
+## Check that _dup folded into _hot.
+# FOLDED:      [[ADDR:[0-9a-f]+]] T _dup
+# FOLDED-NEXT: [[ADDR]] T _hot
+
+# BASE:      Contents of (__TEXT,__objc_stubs) section
+# BASE-NEXT: _objc_msgSend$cold:
+# BASE:      _objc_msgSend$hot:
+# BASE:      _objc_msgSend$mild:
+
+# ORDERED:      Contents of (__TEXT,__objc_stubs) section
+# ORDERED-NEXT: _objc_msgSend$hot:
+# ORDERED:      Objc selector ref: hot
+# ORDERED:      _objc_msgSend$cold:
+# ORDERED:      Objc selector ref: cold
+# ORDERED:      _objc_msgSend$mild:
+# ORDERED:      Objc selector ref: mild
+
+#--- a.s
+.text
+.globl _cold
+.p2align 2
+_cold:
+  bl _objc_msgSend$cold
+  ret
+
+.globl _mild
+.p2align 2
+_mild:
+  bl _objc_msgSend$mild
+  ret
+
+.globl _hot
+.p2align 2
+_hot:
+  bl _objc_msgSend$hot
+  ret
+
+.globl _dup
+.p2align 2
+_dup:
+  bl _objc_msgSend$hot
+  ret
+
+.globl _main
+.p2align 2
+_main:
+  bl _cold
+  bl _mild
+  bl _hot
+  ret
+
+.subsections_via_symbols
+
+#--- order
+_hot

--- a/lld/test/MachO/objc-stubs-order-file.s
+++ b/lld/test/MachO/objc-stubs-order-file.s
@@ -14,7 +14,7 @@
 # RUN:   %t/base.out | FileCheck %s --check-prefix=BASE
 
 ## _hot is ordered first, so the stub it calls moves ahead of the others, which
-## keep their relative order. Each stub must still load its own selector.
+## keep their relative order.
 # RUN: %lld -arch arm64 -e _main -U _objc_msgSend -o %t/ordered.out %t/a.o \
 # RUN:   -objc_stubs_small -order_file %t/order
 # RUN: llvm-objdump --no-show-raw-insn --section=__TEXT,__objc_stubs --macho \
@@ -44,11 +44,8 @@
 
 # ORDERED:      Contents of (__TEXT,__objc_stubs) section
 # ORDERED-NEXT: _objc_msgSend$hot:
-# ORDERED:      Objc selector ref: hot
 # ORDERED:      _objc_msgSend$cold:
-# ORDERED:      Objc selector ref: cold
 # ORDERED:      _objc_msgSend$mild:
-# ORDERED:      Objc selector ref: mild
 
 #--- a.s
 .text


### PR DESCRIPTION
__objc_stubs is synthetic, so the input section sorting never reaches its entries. A stub is faulted in when its caller runs, so stubs called from hot code end up scattered across pages that startup otherwise never touches.

Record the sections that branch to each stub, give each stub the lowest priority among its callers, and stable-sort the stubs before addresses are assigned. Stubs with no prioritized caller keep their relative order at the end.

This reduces page faults in __objc_stubs by 40% for a large app.