### PR TITLE
Reapply "[clang-repl] Honor -emit-llvm to print incremental IR"

### DIFF
--- a/clang/lib/Interpreter/IncrementalAction.cpp
+++ b/clang/lib/Interpreter/IncrementalAction.cpp
@@ -47,6 +47,7 @@ IncrementalAction::IncrementalAction(CompilerInstance &Instance,
         case frontend::EmitBC:
         case frontend::EmitObj:
         case frontend::PrintPreprocessedInput:
+        case frontend::EmitLLVM:
         case frontend::EmitLLVMOnly:
           Act.reset(new EmitLLVMOnlyAction(&LLVMCtx));
           break;

--- a/clang/lib/Interpreter/Interpreter.cpp
+++ b/clang/lib/Interpreter/Interpreter.cpp
@@ -31,6 +31,7 @@
 #include "clang/Driver/Tool.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendAction.h"
+#include "clang/Frontend/FrontendOptions.h"
 #include "clang/Frontend/MultiplexConsumer.h"
 #include "clang/Frontend/TextDiagnosticBuffer.h"
 #include "clang/FrontendTool/Utils.h"
@@ -580,6 +581,12 @@ Interpreter::Parse(llvm::StringRef Code) {
     return TuOrErr.takeError();
 
   PartialTranslationUnit &LastPTU = IncrParser->RegisterPTU(*TuOrErr);
+
+  // Under -emit-llvm, print the module IR.
+  if (InitPTUSize && LastPTU.TheModule &&
+      getCompilerInstance()->getFrontendOpts().ProgramAction ==
+          frontend::EmitLLVM)
+    LastPTU.TheModule->print(llvm::outs(), /*AAW=*/nullptr);
 
   return LastPTU;
 }

--- a/clang/test/Interpreter/emit-llvm.cpp
+++ b/clang/test/Interpreter/emit-llvm.cpp
@@ -1,0 +1,21 @@
+// REQUIRES: host-supports-jit
+//
+// -emit-llvm prints the IR of each input before running them.
+//
+// RUN: cat %s | clang-repl -Xcc -Xclang -Xcc -emit-llvm | FileCheck %s
+
+extern "C" int add(int a, int b) { return a + b; }
+// CHECK: define {{.*}}i32 @add(
+// CHECK: ret i32
+
+extern "C" int answer = 42;
+// CHECK: @answer = {{.*}}i32 42
+
+extern "C" int neg(int a) { return -a; }
+// CHECK: define {{.*}}i32 @neg(
+
+extern "C" int r = add(19, 23);
+// CHECK: @r = {{.*}}global i32
+// CHECK: call {{.*}}i32 @add(
+r
+// CHECK: (int) 42


### PR DESCRIPTION
Relands #217870 with a fix for the failure in `clang/test/Interpreter/emit-llvm.cpp` seen on ppc64le

cc @vgvassilev