### PR TITLE
[mlir][NFC] Share createIndexAttrConstant as a free function

### DIFF
--- a/mlir/include/mlir/Conversion/LLVMCommon/Pattern.h
+++ b/mlir/include/mlir/Conversion/LLVMCommon/Pattern.h
@@ -88,6 +88,11 @@ LogicalResult decomposeValue(OpBuilder &builder, Location loc, Value src,
 Value composeValue(OpBuilder &builder, Location loc, ValueRange src,
                    Type dstType);
 
+/// Creates a constant Op producing a value of `resultType` from an index-typed
+/// integer attribute.
+Value createIndexAttrConstant(OpBuilder &builder, Location loc, Type resultType,
+                              int64_t value);
+
 /// Performs the index computation to get to the element at `indices` of the
 /// memory pointed to by `memRefDesc`, using the layout map of `type`.
 /// The indices are linearized as:

--- a/mlir/lib/Conversion/LLVMCommon/MemRefBuilder.cpp
+++ b/mlir/lib/Conversion/LLVMCommon/MemRefBuilder.cpp
@@ -8,6 +8,7 @@
 
 #include "mlir/Conversion/LLVMCommon/MemRefBuilder.h"
 #include "MemRefDescriptor.h"
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
@@ -95,14 +96,6 @@ void MemRefDescriptor::setAlignedPtr(OpBuilder &builder, Location loc,
   setPtr(builder, loc, kAlignedPtrPosInMemRefDescriptor, ptr);
 }
 
-// Creates a constant Op producing a value of `resultType` from an index-typed
-// integer attribute.
-static Value createIndexAttrConstant(OpBuilder &builder, Location loc,
-                                     Type resultType, int64_t value) {
-  return LLVM::ConstantOp::create(builder, loc, resultType,
-                                  builder.getIndexAttr(value));
-}
-
 /// Builds IR extracting the offset from the descriptor.
 Value MemRefDescriptor::offset(OpBuilder &builder, Location loc) {
   return LLVM::ExtractValueOp::create(builder, loc, value,
@@ -120,7 +113,7 @@ void MemRefDescriptor::setOffset(OpBuilder &builder, Location loc,
 void MemRefDescriptor::setConstantOffset(OpBuilder &builder, Location loc,
                                          uint64_t offset) {
   setOffset(builder, loc,
-            createIndexAttrConstant(builder, loc, indexType, offset));
+            LLVM::createIndexAttrConstant(builder, loc, indexType, offset));
 }
 
 /// Builds IR extracting the pos-th size from the descriptor.
@@ -137,7 +130,7 @@ Value MemRefDescriptor::size(OpBuilder &builder, Location loc, Value pos,
   auto ptrTy = LLVM::LLVMPointerType::get(builder.getContext());
 
   // Copy size values to stack-allocated memory.
-  auto one = createIndexAttrConstant(builder, loc, indexType, 1);
+  auto one = LLVM::createIndexAttrConstant(builder, loc, indexType, 1);
   auto sizes = LLVM::ExtractValueOp::create(
       builder, loc, value,
       llvm::ArrayRef<int64_t>({kSizePosInMemRefDescriptor}));
@@ -162,7 +155,7 @@ void MemRefDescriptor::setSize(OpBuilder &builder, Location loc, unsigned pos,
 void MemRefDescriptor::setConstantSize(OpBuilder &builder, Location loc,
                                        unsigned pos, uint64_t size) {
   setSize(builder, loc, pos,
-          createIndexAttrConstant(builder, loc, indexType, size));
+          LLVM::createIndexAttrConstant(builder, loc, indexType, size));
 }
 
 /// Builds IR extracting the pos-th stride from the descriptor.
@@ -183,7 +176,7 @@ void MemRefDescriptor::setStride(OpBuilder &builder, Location loc, unsigned pos,
 void MemRefDescriptor::setConstantStride(OpBuilder &builder, Location loc,
                                          unsigned pos, uint64_t stride) {
   setStride(builder, loc, pos,
-            createIndexAttrConstant(builder, loc, indexType, stride));
+            LLVM::createIndexAttrConstant(builder, loc, indexType, stride));
 }
 
 LLVM::LLVMPointerType MemRefDescriptor::getElementPtrType() {
@@ -209,7 +202,7 @@ Value MemRefDescriptor::bufferPtr(OpBuilder &builder, Location loc,
   Value offsetVal =
       ShapedType::isDynamic(offsetCst)
           ? offset(builder, loc)
-          : createIndexAttrConstant(builder, loc, indexType, offsetCst);
+          : LLVM::createIndexAttrConstant(builder, loc, indexType, offsetCst);
   Type elementType = converter.convertType(type.getElementType());
   ptr = LLVM::GEPOp::create(builder, loc, ptr.getType(), elementType, ptr,
                             offsetVal);
@@ -360,9 +353,9 @@ Value UnrankedMemRefDescriptor::computeSize(
   Type indexType = typeConverter.getIndexType();
 
   // Initialize shared constants.
-  Value one = createIndexAttrConstant(builder, loc, indexType, 1);
-  Value two = createIndexAttrConstant(builder, loc, indexType, 2);
-  Value indexSize = createIndexAttrConstant(
+  Value one = LLVM::createIndexAttrConstant(builder, loc, indexType, 1);
+  Value two = LLVM::createIndexAttrConstant(builder, loc, indexType, 2);
+  Value indexSize = LLVM::createIndexAttrConstant(
       builder, loc, indexType,
       llvm::divideCeil(typeConverter.getIndexTypeBitwidth(), 8));
 
@@ -373,7 +366,7 @@ Value UnrankedMemRefDescriptor::computeSize(
   //   2 * sizeof(pointer) + (1 + 2 * rank) * sizeof(index).
   // TODO: consider including the actual size (including eventual padding due
   // to data layout) into the unranked descriptor.
-  Value pointerSize = createIndexAttrConstant(
+  Value pointerSize = LLVM::createIndexAttrConstant(
       builder, loc, indexType,
       llvm::divideCeil(typeConverter.getPointerBitwidth(addressSpace), 8));
   Value doublePointerSize =

--- a/mlir/lib/Conversion/LLVMCommon/Pattern.cpp
+++ b/mlir/lib/Conversion/LLVMCommon/Pattern.cpp
@@ -55,12 +55,17 @@ Type ConvertToLLVMPattern::getPtrType(unsigned addressSpace) const {
 
 Type ConvertToLLVMPattern::getVoidPtrType() const { return getPtrType(); }
 
+Value mlir::LLVM::createIndexAttrConstant(OpBuilder &builder, Location loc,
+                                          Type resultType, int64_t value) {
+  return LLVM::ConstantOp::create(builder, loc, resultType,
+                                  builder.getIndexAttr(value));
+}
+
 Value ConvertToLLVMPattern::createIndexAttrConstant(OpBuilder &builder,
                                                     Location loc,
                                                     Type resultType,
                                                     int64_t value) {
-  return LLVM::ConstantOp::create(builder, loc, resultType,
-                                  builder.getIndexAttr(value));
+  return LLVM::createIndexAttrConstant(builder, loc, resultType, value);
 }
 
 Value ConvertToLLVMPattern::getStridedElementPtr(
@@ -628,11 +633,10 @@ Value mlir::LLVM::getStridedElementPtr(OpBuilder &builder, Location loc,
   for (int i = 0, e = indices.size(); i < e; ++i) {
     Value increment = indices[i];
     if (strides[i] != 1) { // Skip if stride is 1.
-      Value stride =
-          ShapedType::isDynamic(strides[i])
-              ? memRefDescriptor.stride(builder, loc, i)
-              : LLVM::ConstantOp::create(builder, loc, indexType,
-                                         builder.getIndexAttr(strides[i]));
+      Value stride = ShapedType::isDynamic(strides[i])
+                         ? memRefDescriptor.stride(builder, loc, i)
+                         : LLVM::createIndexAttrConstant(builder, loc,
+                                                         indexType, strides[i]);
       increment = LLVM::MulOp::create(builder, loc, increment, stride,
                                       intOverflowFlags);
     }


### PR DESCRIPTION
The `LLVM::ConstantOp` with an index-typed attribute idiom existed in three byte-identical copies: the protected `ConvertToLLVMPattern` member, a file-static helper in `MemRefBuilder.cpp`, and open-coded in the free function `mlir::LLVM::getStridedElementPtr`, which cannot reach the protected member.

Promote a single free `mlir::LLVM::createIndexAttrConstant` and route all three through it, so that a change to how these constants are built has one place to happen.