### PR TITLE
[clang][AST] Dump function typedef parameter names as JSON

### DIFF
--- a/clang/include/clang/AST/JSONNodeDumper.h
+++ b/clang/include/clang/AST/JSONNodeDumper.h
@@ -383,7 +383,23 @@ public:
 };
 
 class JSONDumper : public ASTNodeTraverser<JSONDumper, JSONNodeDumper> {
+  using Base = ASTNodeTraverser<JSONDumper, JSONNodeDumper>;
+
   JSONNodeDumper NodeDumper;
+
+  void dumpFunctionTypeParameters(const TypeSourceInfo *TSI) {
+    if (!TSI)
+      return;
+
+    for (TypeLoc TL = TSI->getTypeLoc(); !TL.isNull();
+         TL = TL.getNextTypeLoc()) {
+      if (auto FTL = TL.getAs<FunctionProtoTypeLoc>()) {
+        for (const auto *Param : FTL.getParams())
+          Visit(Param);
+        return;
+      }
+    }
+  }
 
   template <typename SpecializationDecl>
   void writeTemplateDeclSpecialization(const SpecializationDecl *SD,
@@ -461,6 +477,14 @@ public:
   }
   void VisitVarTemplateDecl(const VarTemplateDecl *VTD) {
     writeTemplateDecl(VTD, false);
+  }
+  void VisitTypedefDecl(const TypedefDecl *TD) {
+    Base::VisitTypedefDecl(TD);
+    dumpFunctionTypeParameters(TD->getTypeSourceInfo());
+  }
+  void VisitTypeAliasDecl(const TypeAliasDecl *TAD) {
+    Base::VisitTypeAliasDecl(TAD);
+    dumpFunctionTypeParameters(TAD->getTypeSourceInfo());
   }
 };
 

--- a/clang/test/AST/ast-dump-function-typedef-json.cpp
+++ b/clang/test/AST/ast-dump-function-typedef-json.cpp
@@ -1,0 +1,26 @@
+// RUN: %clang_cc1 -std=c++11 -ast-dump=json -ast-dump-filter Test %s | FileCheck %s
+
+typedef double (*TestFunctionPointer)(int first, const char *second);
+using TestFunctionAlias = void(long third, bool fourth);
+
+// CHECK:      "kind": "TypedefDecl"
+// CHECK:      "name": "TestFunctionPointer"
+// CHECK:      "kind": "ParmVarDecl"
+// CHECK:      "name": "first"
+// CHECK:      "type": {
+// CHECK-NEXT:   "qualType": "int"
+// CHECK:      "kind": "ParmVarDecl"
+// CHECK:      "name": "second"
+// CHECK:      "type": {
+// CHECK-NEXT:   "qualType": "const char *"
+
+// CHECK:      "kind": "TypeAliasDecl"
+// CHECK:      "name": "TestFunctionAlias"
+// CHECK:      "kind": "ParmVarDecl"
+// CHECK:      "name": "third"
+// CHECK:      "type": {
+// CHECK-NEXT:   "qualType": "long"
+// CHECK:      "kind": "ParmVarDecl"
+// CHECK:      "name": "fourth"
+// CHECK:      "type": {
+// CHECK-NEXT:   "qualType": "bool"

--- a/clang/test/AST/ast-dump-types-json.cpp
+++ b/clang/test/AST/ast-dump-types-json.cpp
@@ -402,6 +402,31 @@ using ::TestUsingShadowDeclType;
 // CHECK-NEXT:      ]
 // CHECK-NEXT:     }
 // CHECK-NEXT:    ]
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:    "id": "0x{{.*}}",
+// CHECK-NEXT:    "kind": "ParmVarDecl",
+// CHECK-NEXT:    "loc": {
+// CHECK-NEXT:     "offset": 489,
+// CHECK-NEXT:     "col": 46,
+// CHECK-NEXT:     "tokLen": 1
+// CHECK-NEXT:    },
+// CHECK-NEXT:    "range": {
+// CHECK-NEXT:     "begin": {
+// CHECK-NEXT:      "offset": 477,
+// CHECK-NEXT:      "col": 34,
+// CHECK-NEXT:      "tokLen": 5
+// CHECK-NEXT:     },
+// CHECK-NEXT:     "end": {
+// CHECK-NEXT:      "offset": 489,
+// CHECK-NEXT:      "col": 46,
+// CHECK-NEXT:      "tokLen": 1
+// CHECK-NEXT:     }
+// CHECK-NEXT:    },
+// CHECK-NEXT:    "name": "c",
+// CHECK-NEXT:    "type": {
+// CHECK-NEXT:     "qualType": "const char *"
+// CHECK-NEXT:    }
 // CHECK-NEXT:   }
 // CHECK-NEXT:  ]
 // CHECK-NEXT: }


### PR DESCRIPTION
This makes JSON AST dumps include ParmVarDecl nodes for function typedefs and type aliases. The paramater names were already in TypeLoc, they just werent dumped.

This handles the parameter-name part of #97131.