### PR TITLE
[mlir][VectorToLLVM] Use the converted index type in vector.type_cast

### DIFF
--- a/mlir/lib/Conversion/VectorToLLVM/ConvertVectorToLLVM.cpp
+++ b/mlir/lib/Conversion/VectorToLLVM/ConvertVectorToLLVM.cpp
@@ -1479,7 +1479,9 @@ public:
     if (llvm::any_of(*targetStrides, ShapedType::isDynamic))
       return failure();
 
-    auto int64Ty = IntegerType::get(rewriter.getContext(), 64);
+    // The offset, size and stride fields of a memref descriptor use the
+    // converted index type.
+    Type indexTy = getTypeConverter()->getIndexType();
 
     // Create descriptor.
     auto desc = MemRefDescriptor::poison(rewriter, loc, llvmTargetDescriptorTy);
@@ -1491,23 +1493,19 @@ public:
     Value ptr = sourceMemRef.alignedPtr(rewriter, loc);
     desc.setAlignedPtr(rewriter, loc, ptr);
     // Fill offset 0.
-    auto attr = rewriter.getIntegerAttr(rewriter.getIndexType(), 0);
-    auto zero = LLVM::ConstantOp::create(rewriter, loc, int64Ty, attr);
-    desc.setOffset(rewriter, loc, zero);
+    desc.setOffset(rewriter, loc,
+                   LLVM::createIndexAttrConstant(rewriter, loc, indexTy, 0));
 
     // Fill size and stride descriptors in memref.
     for (const auto &indexedSize :
          llvm::enumerate(targetMemRefType.getShape())) {
       int64_t index = indexedSize.index();
-      auto sizeAttr =
-          rewriter.getIntegerAttr(rewriter.getIndexType(), indexedSize.value());
-      auto size = LLVM::ConstantOp::create(rewriter, loc, int64Ty, sizeAttr);
-      desc.setSize(rewriter, loc, index, size);
-      auto strideAttr = rewriter.getIntegerAttr(rewriter.getIndexType(),
-                                                (*targetStrides)[index]);
-      auto stride =
-          LLVM::ConstantOp::create(rewriter, loc, int64Ty, strideAttr);
-      desc.setStride(rewriter, loc, index, stride);
+      desc.setSize(rewriter, loc, index,
+                   LLVM::createIndexAttrConstant(rewriter, loc, indexTy,
+                                                 indexedSize.value()));
+      desc.setStride(rewriter, loc, index,
+                     LLVM::createIndexAttrConstant(rewriter, loc, indexTy,
+                                                   (*targetStrides)[index]));
     }
 
     rewriter.replaceOp(castOp, {desc});

--- a/mlir/test/Conversion/VectorToLLVM/vector-to-llvm-32b.mlir
+++ b/mlir/test/Conversion/VectorToLLVM/vector-to-llvm-32b.mlir
@@ -1,0 +1,16 @@
+// The memref descriptor fields use the converted index type, which is not
+// necessarily `i64`.
+
+// RUN: mlir-opt %s --convert-to-llvm | FileCheck %s
+
+module attributes {dlti.dl_spec = #dlti.dl_spec<
+  #dlti.dl_entry<index, 32>,
+>} {
+  // CHECK-LABEL: llvm.func @type_cast
+  //       CHECK:   %[[OFFSET:.*]] = llvm.mlir.constant(0 : index) : i32
+  //       CHECK:   llvm.insertvalue %[[OFFSET]], %{{.*}}[2] : !llvm.struct<(ptr, ptr, i32)>
+  func.func @type_cast(%arg0: memref<8x8x8xf32>) -> memref<vector<8x8x8xf32>> {
+    %0 = vector.type_cast %arg0 : memref<8x8x8xf32> to memref<vector<8x8x8xf32>>
+    return %0 : memref<vector<8x8x8xf32>>
+  }
+}

--- a/mlir/test/Conversion/VectorToLLVM/vector-to-llvm-32b.mlir
+++ b/mlir/test/Conversion/VectorToLLVM/vector-to-llvm-32b.mlir
@@ -1,10 +1,11 @@
 // The memref descriptor fields use the converted index type, which is not
-// necessarily `i64`.
+// necessarily `i64`. Note that dynamic=true is needed to ensure that the data
+// layout is considered.
 
-// RUN: mlir-opt %s --convert-to-llvm | FileCheck %s
+// RUN: mlir-opt %s --convert-to-llvm="dynamic=true" | FileCheck %s
 
 module attributes {dlti.dl_spec = #dlti.dl_spec<
-  #dlti.dl_entry<index, 32>,
+  #dlti.dl_entry<index, 32>
 >} {
   // CHECK-LABEL: llvm.func @type_cast
   //       CHECK:   %[[OFFSET:.*]] = llvm.mlir.constant(0 : index) : i32


### PR DESCRIPTION
`VectorTypeCastOpConversion` hardcoded `i64` for the offset, size and stride constants it inserts into the target memref descriptor, while the descriptor's fields have the converted index type. With a type converter configured for a 32-bit index the pattern therefore emitted invalid IR:

```
'llvm.insertvalue' op Type mismatch: cannot insert 'i64' into
'!llvm.struct<(ptr, ptr, i32)>'
```

Build the constants from the converted index type instead.