### PR TITLE
[llc] Initialize TargetLoweringObjectFile in the NewPM CodeGen path

### DIFF
--- a/llvm/test/CodeGen/NVPTX/stop-after-npm.ll
+++ b/llvm/test/CodeGen/NVPTX/stop-after-npm.ll
@@ -1,0 +1,10 @@
+; A pipeline truncated by -stop-after never runs the AsmPrinter, which is what
+; normally initializes the TargetLoweringObjectFile. ISel still needs it to
+; mangle parameter symbols.
+; RUN: llc -mtriple=nvptx64 -enable-new-pm -stop-after=finalize-isel -o - %s | FileCheck %s
+
+; CHECK: name: test
+; CHECK: LD_i32 {{.*}}&test_param_0
+define i32 @test(i32 %a) {
+  ret i32 %a
+}

--- a/llvm/tools/llc/NewPMDriver.cpp
+++ b/llvm/tools/llc/NewPMDriver.cpp
@@ -43,6 +43,7 @@
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/WithColor.h"
 #include "llvm/Target/CGPassBuilderOption.h"
+#include "llvm/Target/TargetLoweringObjectFile.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Target/TargetOptions.h"
 #include "llvm/Transforms/Scalar/LoopPassManager.h"
@@ -117,6 +118,8 @@ int llvm::compileModuleWithNewPM(
   Opt.RegAlloc = RegAlloc;
 
   MachineModuleInfo MMI(Target.get());
+
+  Target->getObjFileLowering()->Initialize(MMI.getContext(), *Target);
 
   PassInstrumentationCallbacks PIC;
   StandardInstrumentations SI(Context, Opt.DebugPM,


### PR DESCRIPTION
Initialize the `TargetLoweringObjectFile` before building the NewPM codegen pipeline, matching what the legacy path already does in `llc.cpp`.

https://github.com/llvm/llvm-project/blob/207362dd503979f3d74a1ebef0cfbdcf6e7be4c5/llvm/tools/llc/llc.cpp#L861-L862

In the NewPM path the TLOF is only initialized by `AsmPrinter::doInitialization`, reached through the pass added by `addAsmPrinterBegin`. `CodeGenPassBuilder::buildPipeline` only adds that pass when `willCompleteCodeGenPipeline()` is true, so under `-stop-after` or `-stop-before` the TLOF keeps a null `Mangler` and a null `MCContext`. Targets that need a mangled name or a symbol during ISel then crash.