### PR TITLE
[AMDGPU] Use a disjoint scope domain for noalias kernel arguments

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULowerKernelArguments.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerKernelArguments.cpp
@@ -83,10 +83,13 @@ static void addAliasScopeMetadata(Function &F, const DataLayout &DL,
   if (NoAliasArgs.empty())
     return;
 
-  // Add alias scopes for each noalias argument.
+  // Add alias scopes for each noalias argument. The scopes are disjoint, since
+  // an access based on one noalias argument can't reach memory an access based
+  // on another one reaches.
   MDBuilder MDB(F.getContext());
   DenseMap<const Argument *, MDNode *> NewScopes;
-  MDNode *NewDomain = MDB.createAnonymousAliasScopeDomain(F.getName());
+  MDNode *NewDomain =
+      MDB.createAnonymousAliasScopeDomain(F.getName(), /*DisjointScopes=*/true);
 
   for (unsigned I = 0u; I < NoAliasArgs.size(); ++I) {
     const Argument *Arg = NoAliasArgs[I];
@@ -155,22 +158,26 @@ static void addAliasScopeMetadata(Function &F, const DataLayout &DL,
       if (UsesUnknownObject)
         continue;
 
-      // Collect noalias scopes for instruction.
-      for (const Argument *Arg : NoAliasArgs) {
-        if (ObjSet.contains(Arg))
-          continue;
-
-        if (!RequiresNoCaptureBefore ||
-            !capturesAnything(PointerMayBeCapturedBefore(
-                Arg, false, I, &DT, false, CaptureComponents::Provenance)))
-          NoAliases.push_back(NewScopes[Arg]);
-      }
-
       // Collect scopes for alias.scope metadata.
       if (!UsesAliasingPtr)
         for (const Argument *Arg : NoAliasArgs) {
           if (ObjSet.count(Arg))
             Scopes.push_back(NewScopes[Arg]);
+        }
+
+      // Collect noalias scopes for the instruction, unless the scopes it is
+      // already in imply them. Scopes is only non-empty when no underlying
+      // object is an escape source, so the capture check below would have
+      // admitted every remaining argument anyway.
+      if (Scopes.empty())
+        for (const Argument *Arg : NoAliasArgs) {
+          if (ObjSet.contains(Arg))
+            continue;
+
+          if (!RequiresNoCaptureBefore ||
+              !capturesAnything(PointerMayBeCapturedBefore(
+                  Arg, false, I, &DT, false, CaptureComponents::Provenance)))
+            NoAliases.push_back(NewScopes[Arg]);
         }
     } else {
       // The instruction accesses memory but has no pointer arguments.

--- a/llvm/test/CodeGen/AMDGPU/lower-kernargs.ll
+++ b/llvm/test/CodeGen/AMDGPU/lower-kernargs.ll
@@ -1928,10 +1928,10 @@ attributes #1 = { nounwind "amdgpu-implicitarg-num-bytes"="40" }
 ; HSA: [[META5]] = !{i64 1024}
 ; HSA: [[META6]] = !{[[META7:![0-9]+]]}
 ; HSA: [[META7]] = distinct !{[[META7]], [[META8:![0-9]+]], !"ptr"}
-; HSA: [[META8]] = distinct !{[[META8]], i1 false, !"kern_noalias_global_ptr"}
+; HSA: [[META8]] = distinct !{[[META8]], i1 true, !"kern_noalias_global_ptr"}
 ; HSA: [[META9]] = !{[[META10:![0-9]+]], [[META12:![0-9]+]]}
 ; HSA: [[META10]] = distinct !{[[META10]], [[META11:![0-9]+]], !"ptr0"}
-; HSA: [[META11]] = distinct !{[[META11]], i1 false, !"kern_noalias_global_ptr_x2"}
+; HSA: [[META11]] = distinct !{[[META11]], i1 true, !"kern_noalias_global_ptr_x2"}
 ; HSA: [[META12]] = distinct !{[[META12]], [[META11]], !"ptr1"}
 ;.
 ; MESA: [[META0]] = !{}
@@ -1942,9 +1942,9 @@ attributes #1 = { nounwind "amdgpu-implicitarg-num-bytes"="40" }
 ; MESA: [[META5]] = !{i64 1024}
 ; MESA: [[META6]] = !{[[META7:![0-9]+]]}
 ; MESA: [[META7]] = distinct !{[[META7]], [[META8:![0-9]+]], !"ptr"}
-; MESA: [[META8]] = distinct !{[[META8]], i1 false, !"kern_noalias_global_ptr"}
+; MESA: [[META8]] = distinct !{[[META8]], i1 true, !"kern_noalias_global_ptr"}
 ; MESA: [[META9]] = !{[[META10:![0-9]+]], [[META12:![0-9]+]]}
 ; MESA: [[META10]] = distinct !{[[META10]], [[META11:![0-9]+]], !"ptr0"}
-; MESA: [[META11]] = distinct !{[[META11]], i1 false, !"kern_noalias_global_ptr_x2"}
+; MESA: [[META11]] = distinct !{[[META11]], i1 true, !"kern_noalias_global_ptr_x2"}
 ; MESA: [[META12]] = distinct !{[[META12]], [[META11]], !"ptr1"}
 ;.

--- a/llvm/test/CodeGen/AMDGPU/lower-kernel-arguments-noalias-call-no-ptr-args.ll
+++ b/llvm/test/CodeGen/AMDGPU/lower-kernel-arguments-noalias-call-no-ptr-args.ll
@@ -22,8 +22,8 @@ define amdgpu_kernel void @call_without_ptr_args(ptr addrspace(1) noalias %out, 
 ; CHECK-NEXT:    [[IN_LOAD:%.*]] = load ptr addrspace(1), ptr addrspace(4) [[IN_KERNARG_OFFSET]], align 8, !invariant.load [[META0]]
 ; CHECK-NEXT:    [[VAL:%.*]] = call i32 @memory_read_no_ptr_args(), !noalias [[META1:![0-9]+]]
 ; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i32, ptr addrspace(1) [[IN_LOAD]], i32 [[VAL]]
-; CHECK-NEXT:    [[LOAD:%.*]] = load i32, ptr addrspace(1) [[GEP]], align 4, !alias.scope [[META5:![0-9]+]], !noalias [[META6:![0-9]+]]
-; CHECK-NEXT:    store i32 [[LOAD]], ptr addrspace(1) [[OUT_LOAD]], align 4, !alias.scope [[META6]], !noalias [[META5]]
+; CHECK-NEXT:    [[LOAD:%.*]] = load i32, ptr addrspace(1) [[GEP]], align 4, !alias.scope [[META5:![0-9]+]]
+; CHECK-NEXT:    store i32 [[LOAD]], ptr addrspace(1) [[OUT_LOAD]], align 4, !alias.scope [[META6:![0-9]+]]
 ; CHECK-NEXT:    ret void
 ;
   %val = call i32 @memory_read_no_ptr_args()
@@ -68,8 +68,8 @@ define amdgpu_kernel void @argmemonly_call_without_ptr_args(ptr addrspace(1) noa
 ; CHECK-NEXT:    [[IN_LOAD:%.*]] = load ptr addrspace(1), ptr addrspace(4) [[IN_KERNARG_OFFSET]], align 8, !invariant.load [[META0]]
 ; CHECK-NEXT:    [[VAL:%.*]] = call i32 @argmemonly_read_no_ptr_args(), !noalias [[META10:![0-9]+]]
 ; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i32, ptr addrspace(1) [[IN_LOAD]], i32 [[VAL]]
-; CHECK-NEXT:    [[LOAD:%.*]] = load i32, ptr addrspace(1) [[GEP]], align 4, !alias.scope [[META14:![0-9]+]], !noalias [[META15:![0-9]+]]
-; CHECK-NEXT:    store i32 [[LOAD]], ptr addrspace(1) [[OUT_LOAD]], align 4, !alias.scope [[META15]], !noalias [[META14]]
+; CHECK-NEXT:    [[LOAD:%.*]] = load i32, ptr addrspace(1) [[GEP]], align 4, !alias.scope [[META14:![0-9]+]]
+; CHECK-NEXT:    store i32 [[LOAD]], ptr addrspace(1) [[OUT_LOAD]], align 4, !alias.scope [[META15:![0-9]+]]
 ; CHECK-NEXT:    ret void
 ;
   %val = call i32 @argmemonly_read_no_ptr_args()
@@ -92,9 +92,9 @@ define amdgpu_kernel void @argmemonly_call_with_ptr_arg(ptr addrspace(1) noalias
 ; CHECK-NEXT:    [[OUT_LOAD:%.*]] = load ptr addrspace(1), ptr addrspace(4) [[OUT_KERNARG_OFFSET]], align 16, !invariant.load [[META0]]
 ; CHECK-NEXT:    [[IN_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[ARGMEMONLY_CALL_WITH_PTR_ARG_KERNARG_SEGMENT]], i64 8
 ; CHECK-NEXT:    [[IN_LOAD:%.*]] = load ptr addrspace(1), ptr addrspace(4) [[IN_KERNARG_OFFSET]], align 8, !invariant.load [[META0]]
-; CHECK-NEXT:    [[LOAD:%.*]] = load i32, ptr addrspace(1) [[IN_LOAD]], align 4, !alias.scope [[META16:![0-9]+]], !noalias [[META19:![0-9]+]]
-; CHECK-NEXT:    call void @argmemonly_with_ptr_arg(ptr addrspace(1) [[OUT_LOAD]]), !alias.scope [[META19]], !noalias [[META16]]
-; CHECK-NEXT:    store i32 [[LOAD]], ptr addrspace(1) [[OUT_LOAD]], align 4, !alias.scope [[META19]], !noalias [[META16]]
+; CHECK-NEXT:    [[LOAD:%.*]] = load i32, ptr addrspace(1) [[IN_LOAD]], align 4, !alias.scope [[META16:![0-9]+]]
+; CHECK-NEXT:    call void @argmemonly_with_ptr_arg(ptr addrspace(1) [[OUT_LOAD]]), !alias.scope [[META19:![0-9]+]]
+; CHECK-NEXT:    store i32 [[LOAD]], ptr addrspace(1) [[OUT_LOAD]], align 4, !alias.scope [[META19]]
 ; CHECK-NEXT:    ret void
 ;
   %load = load i32, ptr addrspace(1) %in, align 4
@@ -112,22 +112,22 @@ attributes #4 = { nounwind memory(argmem: readwrite) }
 ; CHECK: [[META0]] = !{}
 ; CHECK: [[META1]] = !{[[META2:![0-9]+]], [[META4:![0-9]+]]}
 ; CHECK: [[META2]] = distinct !{[[META2]], [[META3:![0-9]+]], !"out"}
-; CHECK: [[META3]] = distinct !{[[META3]], i1 false, !"call_without_ptr_args"}
+; CHECK: [[META3]] = distinct !{[[META3]], i1 true, !"call_without_ptr_args"}
 ; CHECK: [[META4]] = distinct !{[[META4]], [[META3]], !"in"}
 ; CHECK: [[META5]] = !{[[META4]]}
 ; CHECK: [[META6]] = !{[[META2]]}
 ; CHECK: [[META7]] = !{[[META8:![0-9]+]]}
 ; CHECK: [[META8]] = distinct !{[[META8]], [[META9:![0-9]+]], !"out"}
-; CHECK: [[META9]] = distinct !{[[META9]], i1 false, !"readnone_call_without_ptr_args"}
+; CHECK: [[META9]] = distinct !{[[META9]], i1 true, !"readnone_call_without_ptr_args"}
 ; CHECK: [[META10]] = !{[[META11:![0-9]+]], [[META13:![0-9]+]]}
 ; CHECK: [[META11]] = distinct !{[[META11]], [[META12:![0-9]+]], !"out"}
-; CHECK: [[META12]] = distinct !{[[META12]], i1 false, !"argmemonly_call_without_ptr_args"}
+; CHECK: [[META12]] = distinct !{[[META12]], i1 true, !"argmemonly_call_without_ptr_args"}
 ; CHECK: [[META13]] = distinct !{[[META13]], [[META12]], !"in"}
 ; CHECK: [[META14]] = !{[[META13]]}
 ; CHECK: [[META15]] = !{[[META11]]}
 ; CHECK: [[META16]] = !{[[META17:![0-9]+]]}
 ; CHECK: [[META17]] = distinct !{[[META17]], [[META18:![0-9]+]], !"in"}
-; CHECK: [[META18]] = distinct !{[[META18]], i1 false, !"argmemonly_call_with_ptr_arg"}
+; CHECK: [[META18]] = distinct !{[[META18]], i1 true, !"argmemonly_call_with_ptr_arg"}
 ; CHECK: [[META19]] = !{[[META20:![0-9]+]]}
 ; CHECK: [[META20]] = distinct !{[[META20]], [[META18]], !"out"}
 ;.

--- a/llvm/test/CodeGen/AMDGPU/lower-noalias-kernargs.ll
+++ b/llvm/test/CodeGen/AMDGPU/lower-noalias-kernargs.ll
@@ -37,9 +37,9 @@ define amdgpu_kernel void @aliasinfo_2i32_NA(ptr addrspace(1) noalias %out, ptr 
 ; CHECK-NEXT:    [[IN_LOAD:%.*]] = load ptr addrspace(1), ptr addrspace(4) [[IN_KERNARG_OFFSET]], align 4, !invariant.load [[META0]]
 ; CHECK-NEXT:    [[TID:%.*]] = call i32 @llvm.amdgcn.workitem.id.x()
 ; CHECK-NEXT:    [[IN_GEP:%.*]] = getelementptr i32, ptr addrspace(1) [[IN_LOAD]], i32 [[TID]]
-; CHECK-NEXT:    [[VAL:%.*]] = load i32, ptr addrspace(1) [[IN_GEP]], align 4, !alias.scope [[META1:![0-9]+]], !noalias [[META4:![0-9]+]]
+; CHECK-NEXT:    [[VAL:%.*]] = load i32, ptr addrspace(1) [[IN_GEP]], align 4, !alias.scope [[META1:![0-9]+]]
 ; CHECK-NEXT:    [[CTLZ:%.*]] = call i32 @llvm.ctlz.i32(i32 [[VAL]], i1 false) #[[ATTR3]]
-; CHECK-NEXT:    store i32 [[CTLZ]], ptr addrspace(1) [[OUT_LOAD]], align 4, !alias.scope [[META4]], !noalias [[META1]]
+; CHECK-NEXT:    store i32 [[CTLZ]], ptr addrspace(1) [[OUT_LOAD]], align 4, !alias.scope [[META4:![0-9]+]]
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -87,9 +87,9 @@ define amdgpu_kernel void @aliasinfo_2i32_NA_AS(ptr addrspace(1) noalias %out, p
 ; CHECK-NEXT:    [[IN_LOAD:%.*]] = load ptr addrspace(1), ptr addrspace(4) [[IN_KERNARG_OFFSET]], align 4, !invariant.load [[META0]]
 ; CHECK-NEXT:    [[TID:%.*]] = call i32 @llvm.amdgcn.workitem.id.x()
 ; CHECK-NEXT:    [[IN_GEP:%.*]] = getelementptr i32, ptr addrspace(1) [[IN_LOAD]], i32 [[TID]]
-; CHECK-NEXT:    [[VAL:%.*]] = load i32, ptr addrspace(1) [[IN_GEP]], align 4, !alias.scope [[META11:![0-9]+]], !noalias [[META14:![0-9]+]]
+; CHECK-NEXT:    [[VAL:%.*]] = load i32, ptr addrspace(1) [[IN_GEP]], align 4, !alias.scope [[META11:![0-9]+]], !noalias [[META9]]
 ; CHECK-NEXT:    [[CTLZ:%.*]] = call i32 @llvm.ctlz.i32(i32 [[VAL]], i1 false) #[[ATTR3]]
-; CHECK-NEXT:    store i32 [[CTLZ]], ptr addrspace(1) [[OUT_LOAD]], align 4, !alias.scope [[META14]], !noalias [[META11]]
+; CHECK-NEXT:    store i32 [[CTLZ]], ptr addrspace(1) [[OUT_LOAD]], align 4, !alias.scope [[META14:![0-9]+]], !noalias [[META6]]
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -154,12 +154,12 @@ define amdgpu_kernel void @aliasinfo_v4f32_3v4i8_NA(ptr addrspace(1) noalias %ou
 ; CHECK-NEXT:    [[TID:%.*]] = call i32 @llvm.amdgcn.workitem.id.x()
 ; CHECK-NEXT:    [[GEP:%.*]] = getelementptr <4 x i8>, ptr addrspace(1) [[IN_LOAD]], i32 [[TID]]
 ; CHECK-NEXT:    [[GEP1:%.*]] = getelementptr <4 x i8>, ptr addrspace(1) [[IN1_LOAD]], i32 [[TID]]
-; CHECK-NEXT:    [[LOAD:%.*]] = load <4 x i8>, ptr addrspace(1) [[GEP]], align 1, !alias.scope [[META16:![0-9]+]], !noalias [[META19:![0-9]+]]
-; CHECK-NEXT:    [[LOAD1:%.*]] = load <4 x i8>, ptr addrspace(1) [[GEP1]], align 1, !alias.scope [[META23:![0-9]+]], !noalias [[META24:![0-9]+]]
+; CHECK-NEXT:    [[LOAD:%.*]] = load <4 x i8>, ptr addrspace(1) [[GEP]], align 1, !alias.scope [[META16:![0-9]+]]
+; CHECK-NEXT:    [[LOAD1:%.*]] = load <4 x i8>, ptr addrspace(1) [[GEP1]], align 1, !alias.scope [[META19:![0-9]+]]
 ; CHECK-NEXT:    [[SHUFFLE0_0:%.*]] = shufflevector <4 x i8> [[LOAD]], <4 x i8> [[LOAD1]], <4 x i32> <i32 3, i32 2, i32 6, i32 2>
 ; CHECK-NEXT:    [[CVT:%.*]] = uitofp <4 x i8> [[SHUFFLE0_0]] to <4 x float>
-; CHECK-NEXT:    store <4 x float> [[CVT]], ptr addrspace(1) [[OUT_LOAD]], align 16, !alias.scope [[META25:![0-9]+]], !noalias [[META26:![0-9]+]]
-; CHECK-NEXT:    store <4 x i8> [[SHUFFLE0_0]], ptr addrspace(1) [[OUT1_LOAD]], align 4, !alias.scope [[META27:![0-9]+]], !noalias [[META28:![0-9]+]]
+; CHECK-NEXT:    store <4 x float> [[CVT]], ptr addrspace(1) [[OUT_LOAD]], align 16, !alias.scope [[META21:![0-9]+]]
+; CHECK-NEXT:    store <4 x i8> [[SHUFFLE0_0]], ptr addrspace(1) [[OUT1_LOAD]], align 4, !alias.scope [[META23:![0-9]+]]
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -228,12 +228,12 @@ define amdgpu_kernel void @aliasinfo_v4f32_3v4i8_NA_AS(ptr addrspace(1) noalias 
 ; CHECK-NEXT:    [[TID:%.*]] = call i32 @llvm.amdgcn.workitem.id.x()
 ; CHECK-NEXT:    [[GEP:%.*]] = getelementptr <4 x i8>, ptr addrspace(1) [[IN_LOAD]], i32 [[TID]]
 ; CHECK-NEXT:    [[GEP1:%.*]] = getelementptr <4 x i8>, ptr addrspace(1) [[IN1_LOAD]], i32 [[TID]]
-; CHECK-NEXT:    [[LOAD:%.*]] = load <4 x i8>, ptr addrspace(1) [[GEP]], align 1, !alias.scope [[META29:![0-9]+]], !noalias [[META32:![0-9]+]]
-; CHECK-NEXT:    [[LOAD1:%.*]] = load <4 x i8>, ptr addrspace(1) [[GEP1]], align 1, !alias.scope [[META36:![0-9]+]], !noalias [[META37:![0-9]+]]
+; CHECK-NEXT:    [[LOAD:%.*]] = load <4 x i8>, ptr addrspace(1) [[GEP]], align 1, !alias.scope [[META25:![0-9]+]], !noalias [[META9]]
+; CHECK-NEXT:    [[LOAD1:%.*]] = load <4 x i8>, ptr addrspace(1) [[GEP1]], align 1, !alias.scope [[META28:![0-9]+]], !noalias [[META9]]
 ; CHECK-NEXT:    [[SHUFFLE0_0:%.*]] = shufflevector <4 x i8> [[LOAD]], <4 x i8> [[LOAD1]], <4 x i32> <i32 3, i32 2, i32 6, i32 2>
 ; CHECK-NEXT:    [[CVT:%.*]] = uitofp <4 x i8> [[SHUFFLE0_0]] to <4 x float>
-; CHECK-NEXT:    store <4 x float> [[CVT]], ptr addrspace(1) [[OUT_LOAD]], align 16, !alias.scope [[META38:![0-9]+]], !noalias [[META39:![0-9]+]]
-; CHECK-NEXT:    store <4 x i8> [[SHUFFLE0_0]], ptr addrspace(1) [[OUT1_LOAD]], align 4, !alias.scope [[META40:![0-9]+]], !noalias [[META41:![0-9]+]]
+; CHECK-NEXT:    store <4 x float> [[CVT]], ptr addrspace(1) [[OUT_LOAD]], align 16, !alias.scope [[META30:![0-9]+]], !noalias [[META6]]
+; CHECK-NEXT:    store <4 x i8> [[SHUFFLE0_0]], ptr addrspace(1) [[OUT1_LOAD]], align 4, !alias.scope [[META32:![0-9]+]], !noalias [[META6]]
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -287,11 +287,11 @@ define amdgpu_kernel void @aliasinfo_mixed_intrinsics_NA(ptr addrspace(1) noalia
 ; CHECK-NEXT:    [[INOUT_LOAD:%.*]] = load ptr addrspace(1), ptr addrspace(4) [[INOUT_KERNARG_OFFSET]], align 4, !invariant.load [[META0]]
 ; CHECK-NEXT:    [[OUT_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[ALIASINFO_MIXED_INTRINSICS_NA_KERNARG_SEGMENT]], i64 52
 ; CHECK-NEXT:    [[OUT_LOAD:%.*]] = load ptr addrspace(1), ptr addrspace(4) [[OUT_KERNARG_OFFSET]], align 4, !invariant.load [[META0]]
-; CHECK-NEXT:    [[VAL1:%.*]] = call <4 x float> @llvm.amdgcn.global.load.tr.b256.v4f32.p1(ptr addrspace(1) [[IN_LOAD]]), !alias.scope [[META42:![0-9]+]], !noalias [[META45:![0-9]+]]
-; CHECK-NEXT:    [[VAL2:%.*]] = call <4 x float> @llvm.amdgcn.global.load.tr.b256.v4f32.p1(ptr addrspace(1) [[INOUT_LOAD]]), !alias.scope [[META48:![0-9]+]], !noalias [[META49:![0-9]+]]
-; CHECK-NEXT:    call void @llvm.memcpy.p1.p1.i64(ptr addrspace(1) [[OUT_LOAD]], ptr addrspace(1) [[INOUT_LOAD]], i64 16, i1 false), !alias.scope [[META45]], !noalias [[META42]]
+; CHECK-NEXT:    [[VAL1:%.*]] = call <4 x float> @llvm.amdgcn.global.load.tr.b256.v4f32.p1(ptr addrspace(1) [[IN_LOAD]]), !alias.scope [[META34:![0-9]+]]
+; CHECK-NEXT:    [[VAL2:%.*]] = call <4 x float> @llvm.amdgcn.global.load.tr.b256.v4f32.p1(ptr addrspace(1) [[INOUT_LOAD]]), !alias.scope [[META37:![0-9]+]]
+; CHECK-NEXT:    call void @llvm.memcpy.p1.p1.i64(ptr addrspace(1) [[OUT_LOAD]], ptr addrspace(1) [[INOUT_LOAD]], i64 16, i1 false), !alias.scope [[META39:![0-9]+]]
 ; CHECK-NEXT:    [[VAL3:%.*]] = fmul <4 x float> [[VAL1]], [[VAL2]]
-; CHECK-NEXT:    store <4 x float> [[VAL3]], ptr addrspace(1) [[INOUT_LOAD]], align 16, !alias.scope [[META48]], !noalias [[META49]]
+; CHECK-NEXT:    store <4 x float> [[VAL3]], ptr addrspace(1) [[INOUT_LOAD]], align 16, !alias.scope [[META37]]
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -341,11 +341,11 @@ define amdgpu_kernel void @aliasinfo_mixed_intrinsics_NA_AS(ptr addrspace(1) noa
 ; CHECK-NEXT:    [[INOUT_LOAD:%.*]] = load ptr addrspace(1), ptr addrspace(4) [[INOUT_KERNARG_OFFSET]], align 4, !invariant.load [[META0]]
 ; CHECK-NEXT:    [[OUT_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[ALIASINFO_MIXED_INTRINSICS_NA_AS_KERNARG_SEGMENT]], i64 52
 ; CHECK-NEXT:    [[OUT_LOAD:%.*]] = load ptr addrspace(1), ptr addrspace(4) [[OUT_KERNARG_OFFSET]], align 4, !invariant.load [[META0]]
-; CHECK-NEXT:    [[VAL1:%.*]] = call <4 x float> @llvm.amdgcn.global.load.tr.b256.v4f32.p1(ptr addrspace(1) [[IN_LOAD]]), !alias.scope [[META50:![0-9]+]], !noalias [[META53:![0-9]+]]
-; CHECK-NEXT:    [[VAL2:%.*]] = call <4 x float> @llvm.amdgcn.global.load.tr.b256.v4f32.p1(ptr addrspace(1) [[INOUT_LOAD]]), !alias.scope [[META56:![0-9]+]], !noalias [[META57:![0-9]+]]
-; CHECK-NEXT:    call void @llvm.memcpy.p1.p1.i64(ptr addrspace(1) [[OUT_LOAD]], ptr addrspace(1) [[INOUT_LOAD]], i64 16, i1 false), !alias.scope [[META53]], !noalias [[META50]]
+; CHECK-NEXT:    [[VAL1:%.*]] = call <4 x float> @llvm.amdgcn.global.load.tr.b256.v4f32.p1(ptr addrspace(1) [[IN_LOAD]]), !alias.scope [[META41:![0-9]+]], !noalias [[META9]]
+; CHECK-NEXT:    [[VAL2:%.*]] = call <4 x float> @llvm.amdgcn.global.load.tr.b256.v4f32.p1(ptr addrspace(1) [[INOUT_LOAD]]), !alias.scope [[META44:![0-9]+]], !noalias [[META9]]
+; CHECK-NEXT:    call void @llvm.memcpy.p1.p1.i64(ptr addrspace(1) [[OUT_LOAD]], ptr addrspace(1) [[INOUT_LOAD]], i64 16, i1 false), !alias.scope [[META46:![0-9]+]], !noalias [[META6]]
 ; CHECK-NEXT:    [[VAL3:%.*]] = fmul <4 x float> [[VAL1]], [[VAL2]]
-; CHECK-NEXT:    store <4 x float> [[VAL3]], ptr addrspace(1) [[INOUT_LOAD]], align 16, !alias.scope [[META58:![0-9]+]], !noalias [[META59:![0-9]+]]
+; CHECK-NEXT:    store <4 x float> [[VAL3]], ptr addrspace(1) [[INOUT_LOAD]], align 16, !alias.scope [[META48:![0-9]+]], !noalias [[META6]]
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -374,7 +374,7 @@ attributes #2 = { nounwind readnone speculatable }
 ; CHECK: [[META0]] = !{}
 ; CHECK: [[META1]] = !{[[META2:![0-9]+]]}
 ; CHECK: [[META2]] = distinct !{[[META2]], [[META3:![0-9]+]], !"in"}
-; CHECK: [[META3]] = distinct !{[[META3]], i1 false, !"aliasinfo_2i32_NA"}
+; CHECK: [[META3]] = distinct !{[[META3]], i1 true, !"aliasinfo_2i32_NA"}
 ; CHECK: [[META4]] = !{[[META5:![0-9]+]]}
 ; CHECK: [[META5]] = distinct !{[[META5]], [[META3]], !"out"}
 ; CHECK: [[META6]] = !{[[META7:![0-9]+]]}
@@ -384,51 +384,40 @@ attributes #2 = { nounwind readnone speculatable }
 ; CHECK: [[META10]] = distinct !{[[META10]], [[META8]], !"alias_scope_1"}
 ; CHECK: [[META11]] = !{[[META7]], [[META12:![0-9]+]]}
 ; CHECK: [[META12]] = distinct !{[[META12]], [[META13:![0-9]+]], !"in"}
-; CHECK: [[META13]] = distinct !{[[META13]], i1 false, !"aliasinfo_2i32_NA_AS"}
+; CHECK: [[META13]] = distinct !{[[META13]], i1 true, !"aliasinfo_2i32_NA_AS"}
 ; CHECK: [[META14]] = !{[[META10]], [[META15:![0-9]+]]}
 ; CHECK: [[META15]] = distinct !{[[META15]], [[META13]], !"out"}
 ; CHECK: [[META16]] = !{[[META17:![0-9]+]]}
 ; CHECK: [[META17]] = distinct !{[[META17]], [[META18:![0-9]+]], !"in"}
-; CHECK: [[META18]] = distinct !{[[META18]], i1 false, !"aliasinfo_v4f32_3v4i8_NA"}
-; CHECK: [[META19]] = !{[[META20:![0-9]+]], [[META21:![0-9]+]], [[META22:![0-9]+]]}
-; CHECK: [[META20]] = distinct !{[[META20]], [[META18]], !"out"}
-; CHECK: [[META21]] = distinct !{[[META21]], [[META18]], !"out1"}
-; CHECK: [[META22]] = distinct !{[[META22]], [[META18]], !"in1"}
-; CHECK: [[META23]] = !{[[META22]]}
-; CHECK: [[META24]] = !{[[META20]], [[META21]], [[META17]]}
-; CHECK: [[META25]] = !{[[META20]]}
-; CHECK: [[META26]] = !{[[META21]], [[META17]], [[META22]]}
-; CHECK: [[META27]] = !{[[META21]]}
-; CHECK: [[META28]] = !{[[META20]], [[META17]], [[META22]]}
-; CHECK: [[META29]] = !{[[META7]], [[META30:![0-9]+]]}
-; CHECK: [[META30]] = distinct !{[[META30]], [[META31:![0-9]+]], !"in"}
-; CHECK: [[META31]] = distinct !{[[META31]], i1 false, !"aliasinfo_v4f32_3v4i8_NA_AS"}
-; CHECK: [[META32]] = !{[[META10]], [[META33:![0-9]+]], [[META34:![0-9]+]], [[META35:![0-9]+]]}
-; CHECK: [[META33]] = distinct !{[[META33]], [[META31]], !"out"}
-; CHECK: [[META34]] = distinct !{[[META34]], [[META31]], !"out1"}
-; CHECK: [[META35]] = distinct !{[[META35]], [[META31]], !"in1"}
-; CHECK: [[META36]] = !{[[META7]], [[META35]]}
-; CHECK: [[META37]] = !{[[META10]], [[META33]], [[META34]], [[META30]]}
-; CHECK: [[META38]] = !{[[META10]], [[META33]]}
-; CHECK: [[META39]] = !{[[META7]], [[META34]], [[META30]], [[META35]]}
-; CHECK: [[META40]] = !{[[META10]], [[META34]]}
-; CHECK: [[META41]] = !{[[META7]], [[META33]], [[META30]], [[META35]]}
-; CHECK: [[META42]] = !{[[META43:![0-9]+]]}
-; CHECK: [[META43]] = distinct !{[[META43]], [[META44:![0-9]+]], !"in"}
-; CHECK: [[META44]] = distinct !{[[META44]], i1 false, !"aliasinfo_mixed_intrinsics_NA"}
-; CHECK: [[META45]] = !{[[META46:![0-9]+]], [[META47:![0-9]+]]}
-; CHECK: [[META46]] = distinct !{[[META46]], [[META44]], !"inout"}
-; CHECK: [[META47]] = distinct !{[[META47]], [[META44]], !"out"}
-; CHECK: [[META48]] = !{[[META46]]}
-; CHECK: [[META49]] = !{[[META43]], [[META47]]}
-; CHECK: [[META50]] = !{[[META7]], [[META51:![0-9]+]]}
-; CHECK: [[META51]] = distinct !{[[META51]], [[META52:![0-9]+]], !"in"}
-; CHECK: [[META52]] = distinct !{[[META52]], i1 false, !"aliasinfo_mixed_intrinsics_NA_AS"}
-; CHECK: [[META53]] = !{[[META10]], [[META54:![0-9]+]], [[META55:![0-9]+]]}
-; CHECK: [[META54]] = distinct !{[[META54]], [[META52]], !"inout"}
-; CHECK: [[META55]] = distinct !{[[META55]], [[META52]], !"out"}
-; CHECK: [[META56]] = !{[[META7]], [[META54]]}
-; CHECK: [[META57]] = !{[[META10]], [[META51]], [[META55]]}
-; CHECK: [[META58]] = !{[[META10]], [[META54]]}
-; CHECK: [[META59]] = !{[[META7]], [[META51]], [[META55]]}
+; CHECK: [[META18]] = distinct !{[[META18]], i1 true, !"aliasinfo_v4f32_3v4i8_NA"}
+; CHECK: [[META19]] = !{[[META20:![0-9]+]]}
+; CHECK: [[META20]] = distinct !{[[META20]], [[META18]], !"in1"}
+; CHECK: [[META21]] = !{[[META22:![0-9]+]]}
+; CHECK: [[META22]] = distinct !{[[META22]], [[META18]], !"out"}
+; CHECK: [[META23]] = !{[[META24:![0-9]+]]}
+; CHECK: [[META24]] = distinct !{[[META24]], [[META18]], !"out1"}
+; CHECK: [[META25]] = !{[[META7]], [[META26:![0-9]+]]}
+; CHECK: [[META26]] = distinct !{[[META26]], [[META27:![0-9]+]], !"in"}
+; CHECK: [[META27]] = distinct !{[[META27]], i1 true, !"aliasinfo_v4f32_3v4i8_NA_AS"}
+; CHECK: [[META28]] = !{[[META7]], [[META29:![0-9]+]]}
+; CHECK: [[META29]] = distinct !{[[META29]], [[META27]], !"in1"}
+; CHECK: [[META30]] = !{[[META10]], [[META31:![0-9]+]]}
+; CHECK: [[META31]] = distinct !{[[META31]], [[META27]], !"out"}
+; CHECK: [[META32]] = !{[[META10]], [[META33:![0-9]+]]}
+; CHECK: [[META33]] = distinct !{[[META33]], [[META27]], !"out1"}
+; CHECK: [[META34]] = !{[[META35:![0-9]+]]}
+; CHECK: [[META35]] = distinct !{[[META35]], [[META36:![0-9]+]], !"in"}
+; CHECK: [[META36]] = distinct !{[[META36]], i1 true, !"aliasinfo_mixed_intrinsics_NA"}
+; CHECK: [[META37]] = !{[[META38:![0-9]+]]}
+; CHECK: [[META38]] = distinct !{[[META38]], [[META36]], !"inout"}
+; CHECK: [[META39]] = !{[[META38]], [[META40:![0-9]+]]}
+; CHECK: [[META40]] = distinct !{[[META40]], [[META36]], !"out"}
+; CHECK: [[META41]] = !{[[META7]], [[META42:![0-9]+]]}
+; CHECK: [[META42]] = distinct !{[[META42]], [[META43:![0-9]+]], !"in"}
+; CHECK: [[META43]] = distinct !{[[META43]], i1 true, !"aliasinfo_mixed_intrinsics_NA_AS"}
+; CHECK: [[META44]] = !{[[META7]], [[META45:![0-9]+]]}
+; CHECK: [[META45]] = distinct !{[[META45]], [[META43]], !"inout"}
+; CHECK: [[META46]] = !{[[META10]], [[META45]], [[META47:![0-9]+]]}
+; CHECK: [[META47]] = distinct !{[[META47]], [[META43]], !"out"}
+; CHECK: [[META48]] = !{[[META10]], [[META45]]}
 ;.

--- a/llvm/test/CodeGen/AMDGPU/si-split-load-store-alias-info.ll
+++ b/llvm/test/CodeGen/AMDGPU/si-split-load-store-alias-info.ll
@@ -3,17 +3,17 @@
 ; This test verifies that instruction selection will propagate alias metadata
 ; to split loads and stores.
 
-; CHECK:      %{{[0-9]+}}:vreg_128 = DS_READ_B128_gfx9 {{.*}} :: (load (s128) from %{{.*}}, align 32, !alias.scope ![[IN:[0-9]+]], !noalias ![[OUT:[0-9]+]], addrspace 3)
-; CHECK-NEXT: %{{[0-9]+}}:vreg_128 = DS_READ_B128_gfx9 {{.*}} :: (load (s128) from %{{.*}}, !alias.scope ![[IN]], !noalias ![[OUT]], addrspace 3)
-; CHECK-NEXT: %{{[0-9]+}}:vreg_128 = DS_READ_B128_gfx9 {{.*}} :: (load (s128) from %{{.*}}, align 32, !alias.scope ![[IN]], !noalias ![[OUT]], addrspace 3)
-; CHECK-NEXT: %{{[0-9]+}}:vreg_128 = DS_READ_B128_gfx9 {{.*}} :: (load (s128) from %{{.*}}, !alias.scope ![[IN]], !noalias ![[OUT]], addrspace 3)
-; CHECK:      DS_WRITE_B128_gfx9 {{.*}} :: (store (s128) into %{{.*}}, !alias.scope ![[OUT]], !noalias ![[IN]], addrspace 3)
+; CHECK:      %{{[0-9]+}}:vreg_128 = DS_READ_B128_gfx9 {{.*}} :: (load (s128) from %{{.*}}, align 32, !alias.scope ![[IN:[0-9]+]], !noalias ![[NOT_IN:[0-9]+]], addrspace 3)
+; CHECK-NEXT: %{{[0-9]+}}:vreg_128 = DS_READ_B128_gfx9 {{.*}} :: (load (s128) from %{{.*}}, !alias.scope ![[IN]], !noalias ![[NOT_IN]], addrspace 3)
+; CHECK-NEXT: %{{[0-9]+}}:vreg_128 = DS_READ_B128_gfx9 {{.*}} :: (load (s128) from %{{.*}}, align 32, !alias.scope ![[IN]], !noalias ![[NOT_IN]], addrspace 3)
+; CHECK-NEXT: %{{[0-9]+}}:vreg_128 = DS_READ_B128_gfx9 {{.*}} :: (load (s128) from %{{.*}}, !alias.scope ![[IN]], !noalias ![[NOT_IN]], addrspace 3)
+; CHECK:      DS_WRITE_B128_gfx9 {{.*}} :: (store (s128) into %{{.*}}, !alias.scope ![[OUT:[0-9]+]], !noalias ![[NOT_OUT:[0-9]+]], addrspace 3)
 ; CHECK-NEXT: %{{[0-9]+}}:vreg_128 = REG_SEQUENCE
-; CHECK-NEXT: DS_WRITE_B128_gfx9 {{.*}} :: (store (s128) into %{{.*}}, !alias.scope ![[OUT]], !noalias ![[IN]], addrspace 3)
+; CHECK-NEXT: DS_WRITE_B128_gfx9 {{.*}} :: (store (s128) into %{{.*}}, !alias.scope ![[OUT]], !noalias ![[NOT_OUT]], addrspace 3)
 ; CHECK-NEXT: %{{[0-9]+}}:vreg_128 = REG_SEQUENCE
-; CHECK-NEXT: DS_WRITE_B128_gfx9 {{.*}} :: (store (s128) into %{{.*}}, !alias.scope ![[OUT]], !noalias ![[IN]], addrspace 3)
+; CHECK-NEXT: DS_WRITE_B128_gfx9 {{.*}} :: (store (s128) into %{{.*}}, !alias.scope ![[OUT]], !noalias ![[NOT_OUT]], addrspace 3)
 ; CHECK-NEXT: %{{[0-9]+}}:vreg_128 = REG_SEQUENCE
-; CHECK-NEXT: DS_WRITE_B128_gfx9 {{.*}} :: (store (s128) into %{{.*}}, !alias.scope ![[OUT]], !noalias ![[IN]], addrspace 3)
+; CHECK-NEXT: DS_WRITE_B128_gfx9 {{.*}} :: (store (s128) into %{{.*}}, !alias.scope ![[OUT]], !noalias ![[NOT_OUT]], addrspace 3)
 
 define amdgpu_kernel void @test(ptr addrspace(3) noalias %in, ptr addrspace(3) noalias %out) {
   %idx = call i32 @llvm.amdgcn.workitem.id.x()


### PR DESCRIPTION
All noalias arguments of a kernel are disjoint with each other, so we
can use a disjoint scope to save on metadata construction.

AI disclosure: Claude wrote this, I looked at it and wrote this
message.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>