### PR TITLE
[clang][CodeGen] Decide the array-bounds comparison from the enclosin…

### DIFF
--- a/clang/lib/CodeGen/CGDeclCXX.cpp
+++ b/clang/lib/CodeGen/CGDeclCXX.cpp
@@ -180,6 +180,11 @@ void CodeGenFunction::EmitCXXGlobalVarDeclInit(const VarDecl &D,
   const Expr *Init = D.getInit();
   QualType T = D.getType();
 
+  // Emitted in a function synthesized for the variable, which has no declaration
+  // for StartFunction to walk, so this initializer is its own root.
+  if (Init)
+    computeBoundsCheckRequirements(Init, Init->isGLValue());
+
   // The address space of a static local variable (DeclPtr) may be different
   // from the address space of the "this" argument of the constructor. In that
   // case, we need an addrspacecast before calling the constructor.

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -29,6 +29,7 @@
 #include "clang/AST/ASTLambda.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/DeclObjC.h"
+#include "clang/AST/EvaluatedExprVisitor.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/InferAlloc.h"
 #include "clang/AST/MatrixUtils.h"
@@ -53,6 +54,8 @@
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/SaveAndRestore.h"
 #include "llvm/Support/xxhash.h"
 #include "llvm/Transforms/Utils/SanitizerStats.h"
 
@@ -1282,10 +1285,361 @@ llvm::Value *CodeGenFunction::EmitLoadOfCountedByField(
   return nullptr;
 }
 
+//===----------------------------------------------------------------------===//
+// One-past-the-end validity for -fsanitize=array-bounds
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// Records, for each expression -fsanitize=array-bounds may check, whether the
+/// context requires the object it designates -- or, for pointer type, the object
+/// it points to -- to exist. An index equal to the bound is valid exactly when it
+/// does not: `a + N` is a valid pointer value and `&a[N]` a legal way to spell it
+/// (C99 6.5.6p8, 6.5.3.2p3), so requiring `index < bound` everywhere would reject
+/// conforming code.
+///
+///   x = a[i];       reads it       -> icmp ult
+///   a[i] = 0;       writes it      -> icmp ult
+///   p = &a[i];      address only   -> icmp ule
+///
+/// The same subtree, three answers, so the answer belongs to the context. It is
+/// computed as an inherited attribute: one bit handed down, with each edge either
+/// asserting the requirement (a load, an assignment's target, the base of a
+/// member access), clearing it (a subscript's index, a comma's left operand, a
+/// value-changing conversion) or propagating it (`&`, `*`, parentheses, and casts
+/// that change only the type; C99 6.5.3.2p3 makes `&*p` mean `p`).
+///
+/// A node kind with no handler falls through to VisitStmt, which clears. That
+/// direction is deliberate: an unmodelled construct loses a check rather than
+/// reporting one the language permits.
+class DesignatedObjectRequirement
+    : public ConstEvaluatedExprVisitor<DesignatedObjectRequirement> {
+  using Base = ConstEvaluatedExprVisitor<DesignatedObjectRequirement>;
+
+  /// Where the answers are recorded.
+  CodeGenFunction::BoundsCheckRequirementMap &Answers;
+  /// Does the context of the node currently being visited require the object it
+  /// designates to exist?
+  bool ObjectMustExist = false;
+
+  /// Records the answer for \p E by union: a node can be reached twice, since a
+  /// default argument's expression is shared by every call that uses it and
+  /// `x ?: y` reaches its common expression as both condition and result. One
+  /// evaluation serves every use, so any context that requires the object wins.
+  void record(const Expr *E) { Answers[E] |= ObjectMustExist; }
+
+  void visitWith(const Stmt *S, bool MustExist) {
+    if (!S)
+      return;
+    llvm::SaveAndRestore<bool> SavedRequirement(ObjectMustExist, MustExist);
+    Base::Visit(S);
+  }
+
+public:
+  DesignatedObjectRequirement(const ASTContext &Ctx,
+                              CodeGenFunction::BoundsCheckRequirementMap &A)
+      : Base(Ctx), Answers(A) {}
+
+  /// Walk \p Root and record an answer for every expression in it that a bounds
+  /// check can be emitted for. \p MustExist is what the context asks of \p Root
+  /// itself; a statement is asked nothing, an initializer may be asked for the
+  /// object by what it initializes.
+  void computeIn(const Stmt *Root, bool MustExist) {
+    visitWith(Root, MustExist);
+  }
+
+  void VisitArraySubscriptExpr(const ArraySubscriptExpr *E) {
+    record(E);
+    visitWith(E->getBase(), ObjectMustExist);
+    visitWith(E->getIdx(), /*MustExist=*/false);
+  }
+
+  void VisitParenExpr(const ParenExpr *E) {
+    visitWith(E->getSubExpr(), ObjectMustExist);
+  }
+
+  /// Keyed on the cast kind, so an explicit cast is exactly as transparent as
+  /// the implicit conversion it spells; this covers all of CastExpr's
+  /// subclasses, including the C++ named casts.
+  void VisitCastExpr(const CastExpr *E) {
+    switch (E->getCastKind()) {
+    case CK_LValueToRValue:
+      // This conversion is the read.
+      visitWith(E->getSubExpr(), /*MustExist=*/true);
+      return;
+    case CK_DerivedToBase:
+    case CK_UncheckedDerivedToBase:
+    case CK_BaseToDerived:
+      // As a glvalue conversion this designates a base (or derived) class
+      // subobject of the operand's object ([expr.static.cast]p2), so that
+      // object has to exist. The pointer form is address arithmetic on a value
+      // that may be one past the end, so it inherits instead.
+      visitWith(E->getSubExpr(), E->isGLValue() ? true : ObjectMustExist);
+      return;
+    case CK_NoOp:
+    case CK_BitCast:
+    case CK_LValueBitCast:
+    case CK_LValueToRValueBitCast:
+    case CK_AddressSpaceConversion:
+    case CK_ArrayToPointerDecay:
+      // A change of type, not of what is designated. Decay included: `p = a2[i]`
+      // only forms an address.
+      visitWith(E->getSubExpr(), ObjectMustExist);
+      return;
+    default:
+      // A value-changing conversion; its operand was already loaded by a
+      // CK_LValueToRValue below, so nothing here designates storage.
+      visitWith(E->getSubExpr(), /*MustExist=*/false);
+      return;
+    }
+  }
+
+  void VisitUnaryOperator(const UnaryOperator *E) {
+    switch (E->getOpcode()) {
+    case UO_AddrOf:
+    case UO_Deref:
+    case UO_Extension:
+      visitWith(E->getSubExpr(), ObjectMustExist);
+      return;
+    case UO_Real:
+    case UO_Imag:
+      // Names storage inside the object, so that object must exist
+      // (6.3.2.1p1); 6.5.3.2p3 exempts `*` and `[]` only.
+      visitWith(E->getSubExpr(), /*MustExist=*/true);
+      return;
+    case UO_PreInc:
+    case UO_PreDec:
+    case UO_PostInc:
+    case UO_PostDec:
+      visitWith(E->getSubExpr(), /*MustExist=*/true);
+      return;
+    default:
+      visitWith(E->getSubExpr(), /*MustExist=*/false);
+      return;
+    }
+  }
+
+  /// Covers CompoundAssignOperator too.
+  void VisitBinaryOperator(const BinaryOperator *E) {
+    if (E->isAssignmentOp()) {
+      visitWith(E->getLHS(), /*MustExist=*/true);
+      visitWith(E->getRHS(), /*MustExist=*/false);
+      return;
+    }
+    if (E->getOpcode() == BO_Comma) {
+      visitWith(E->getLHS(), /*MustExist=*/false);
+      visitWith(E->getRHS(), ObjectMustExist);
+      return;
+    }
+    if (E->isAdditiveOp() && E->getType()->isPointerType()) {
+      // `a[i]` is `*(a + i)` (C99 6.5.2.1p2), and a check is emitted here too.
+      record(E);
+      bool LHSIsPointer = E->getLHS()->getType()->isPointerType();
+      visitWith(LHSIsPointer ? E->getLHS() : E->getRHS(), ObjectMustExist);
+      visitWith(LHSIsPointer ? E->getRHS() : E->getLHS(), /*MustExist=*/false);
+      return;
+    }
+    if (E->isPtrMemOp()) {
+      // `E1.*E2` designates a member of the object E1 designates
+      // ([expr.mptr.oper]p4), the same rule as MemberExpr's base.
+      visitWith(E->getLHS(), /*MustExist=*/true);
+      visitWith(E->getRHS(), /*MustExist=*/false);
+      return;
+    }
+    visitWith(E->getLHS(), /*MustExist=*/false);
+    visitWith(E->getRHS(), /*MustExist=*/false);
+  }
+
+  void VisitMemberExpr(const MemberExpr *E) {
+    // Naming a data member designates storage inside the object (C99 6.5.2.3p3,
+    // [expr.ref]p6); 6.5.3.2p3 exempts `*` and `[]`, never `.`. A static member
+    // or a member function names no subobject; VisitCXXMemberCallExpr covers a
+    // call's object.
+    const ValueDecl *MD = E->getMemberDecl();
+    visitWith(E->getBase(), isa<FieldDecl>(MD) || isa<IndirectFieldDecl>(MD));
+  }
+
+  void VisitExtVectorElementExpr(const ExtVectorElementExpr *E) {
+    visitWith(E->getBase(), /*MustExist=*/true);
+  }
+
+  void VisitAbstractConditionalOperator(const AbstractConditionalOperator *E) {
+    // For the GNU `x ?: y` form the common expression is evaluated once and is
+    // both the condition and the result, so it inherits; getCond() and
+    // getTrueExpr() only reach it through an OpaqueValueExpr.
+    if (const auto *BCO = dyn_cast<BinaryConditionalOperator>(E))
+      visitWith(BCO->getCommon(), ObjectMustExist);
+    visitWith(E->getCond(), /*MustExist=*/false);
+    visitWith(E->getTrueExpr(), ObjectMustExist);
+    visitWith(E->getFalseExpr(), ObjectMustExist);
+  }
+
+  void VisitChooseExpr(const ChooseExpr *E) {
+    // Only the selected arm is evaluated, and it is what the expression yields.
+    if (!E->isConditionDependent())
+      visitWith(E->getChosenSubExpr(), ObjectMustExist);
+  }
+
+  void VisitGenericSelectionExpr(const GenericSelectionExpr *E) {
+    if (!E->isResultDependent())
+      visitWith(E->getResultExpr(), ObjectMustExist);
+  }
+
+  void VisitCallExpr(const CallExpr *E) {
+    // __builtin_addressof(x) is `&x`: a reference parameter, but only an address
+    // is formed. EmitPointerWithAlignment excepts the same three.
+    switch (E->getBuiltinCallee()) {
+    default:
+      break;
+    case Builtin::BIaddressof:
+    case Builtin::BI__addressof:
+    case Builtin::BI__builtin_addressof:
+      visitWith(E->getArg(0), ObjectMustExist);
+      return;
+    }
+
+    // An argument still a glvalue here is bound to a reference parameter, which
+    // requires the object ([dcl.ref]p5); EmitCallArg asserts that equivalence.
+    // One passed by value carries its own conversion.
+    //
+    // Overriding this also drops EvaluatedExprVisitor's skip for unevaluated
+    // builtin calls, deliberately: CodeGen still emits checks inside them.
+    visitWith(E->getCallee(), /*MustExist=*/false);
+    for (unsigned I = 0, N = E->getNumArgs(); I != N; ++I)
+      visitWith(E->getArg(I), E->getArg(I)->isGLValue());
+  }
+
+  void VisitCXXMemberCallExpr(const CXXMemberCallExpr *E) {
+    // Calling a non-static member function requires an object
+    // ([class.mfct.non-static]p2).
+    visitWith(E->getImplicitObjectArgument(), /*MustExist=*/true);
+    // The callee still has to be walked: for `(x->*pm)()` it is a `->*` whose
+    // right operand is an expression of its own that
+    // getImplicitObjectArgument() does not cover.
+    visitWith(E->getCallee(), /*MustExist=*/false);
+    for (unsigned I = 0, N = E->getNumArgs(); I != N; ++I)
+      visitWith(E->getArg(I), E->getArg(I)->isGLValue());
+  }
+
+  void VisitCXXOperatorCallExpr(const CXXOperatorCallExpr *E) {
+    const auto *MD = dyn_cast_if_present<CXXMethodDecl>(E->getDirectCallee());
+    if (!MD || !MD->isInstance()) {
+      // A non-member operator; every argument binds to a parameter of its own.
+      visitWith(E->getCallee(), /*MustExist=*/false);
+      for (unsigned I = 0, N = E->getNumArgs(); I != N; ++I)
+        visitWith(E->getArg(I), E->getArg(I)->isGLValue());
+      return;
+    }
+
+    // A trivial copy or move assignment copies the right operand, so it is
+    // read; this mirrors the TCK_Load in
+    // CodeGenFunction::EmitCXXMemberOrOperatorMemberCallExpr for the same case.
+    bool TrivialForCodegen =
+        MD->isTrivial() || (MD->isDefaulted() && MD->getParent()->isUnion());
+    bool TrivialAssignment =
+        TrivialForCodegen &&
+        (MD->isCopyAssignmentOperator() || MD->isMoveAssignmentOperator()) &&
+        !MD->getParent()->mayInsertExtraPadding();
+
+    visitWith(E->getCallee(), /*MustExist=*/false);
+    for (unsigned I = 0, N = E->getNumArgs(); I != N; ++I)
+      visitWith(E->getArg(I),
+                /*MustExist=*/I == 0 || (TrivialAssignment && I == 1) ||
+                    E->getArg(I)->isGLValue());
+  }
+
+  void VisitCXXConstructExpr(const CXXConstructExpr *E) {
+    // Copy- or move-constructing from an element binds the constructor's
+    // reference parameter to it, so the element has to exist ([dcl.ref]p5).
+    // This is the shape both a by-value argument and a copy-initialization
+    // take, including when the copy is trivial and CodeGen emits no call.
+    for (unsigned I = 0, N = E->getNumArgs(); I != N; ++I)
+      visitWith(E->getArg(I), E->getArg(I)->isGLValue());
+  }
+
+  void VisitCXXDefaultArgExpr(const CXXDefaultArgExpr *E) {
+    // The expression belongs to the callee's parameter rather than to this
+    // node's children, so reaching it takes an explicit edge. The demand is
+    // the one that parameter placed on the argument.
+    visitWith(E->getExpr(), ObjectMustExist);
+  }
+
+  void VisitCXXDefaultInitExpr(const CXXDefaultInitExpr *E) {
+    // As for a default argument: the expression belongs to the field, not to
+    // this node's children, and the demand is the one the member's declared
+    // type placed on its initializer.
+    visitWith(E->getExpr(), ObjectMustExist);
+  }
+
+  void VisitReturnStmt(const ReturnStmt *S) {
+    // Judged as an argument and an initializer are: a returned glvalue is bound
+    // to a reference return type and so requires the object ([dcl.ref]p5),
+    // where a returned value carries a conversion of its own.
+    if (const Expr *RV = S->getRetValue())
+      visitWith(RV, RV->isGLValue());
+  }
+
+  void VisitDeclStmt(const DeclStmt *S) {
+    // Walk everything the statement holds with no demand of its own -- a
+    // variable-length array bound, or an initializer that reads through a
+    // conversion of its own -- then judge each initializer as an argument and a
+    // member initializer are judged: one left as a glvalue is bound to a
+    // reference variable and requires the object ([dcl.ref]p5).
+    VisitStmt(S);
+    for (const Decl *D : S->decls())
+      if (const auto *VD = dyn_cast<VarDecl>(D))
+        if (VD->hasInit() && VD->getInit()->isGLValue())
+          visitWith(VD->getInit(), /*MustExist=*/true);
+  }
+
+  void VisitExprWithCleanups(const ExprWithCleanups *E) {
+    // Transparent: the cleanups are for temporaries the subexpression built,
+    // and the value is the subexpression's.
+    visitWith(E->getSubExpr(), ObjectMustExist);
+  }
+
+  void VisitStmt(const Stmt *S) {
+    for (const Stmt *Child : S->children())
+      visitWith(Child, /*MustExist=*/false);
+  }
+};
+} // namespace
+
+bool CodeGenFunction::mustElementExist(const Expr *E) {
+  // A vector element cannot have its address taken, so a vector subscript is
+  // always an access. This cannot be answered from the context: subscripting a
+  // vector rvalue is itself a prvalue, with no conversion above it to ask.
+  if (const auto *ASE = dyn_cast<ArraySubscriptExpr>(E)) {
+    QualType BaseTy = ASE->getBase()->getType();
+    if (BaseTy->isVectorType() || BaseTy->isSveVLSBuiltinType())
+      return true;
+  }
+
+  // No entry means the walk never reached E, so the answer is unknown and the
+  // check is left permissive. -debug-only=array-bounds reports those.
+  auto It = BoundsCheckRequirements.find(E);
+  DEBUG_WITH_TYPE("array-bounds", {
+    if (It == BoundsCheckRequirements.end())
+      llvm::dbgs() << "array-bounds: no requirement computed for "
+                   << E->getStmtClassName() << " at "
+                   << E->getExprLoc().printToString(
+                          getContext().getSourceManager())
+                   << "\n";
+  });
+  return It != BoundsCheckRequirements.end() && It->second;
+}
+
+void CodeGenFunction::computeBoundsCheckRequirements(const Stmt *Root,
+                                                     bool RootRequires) {
+  if (!Root || !SanOpts.has(SanitizerKind::ArrayBounds))
+    return;
+  DesignatedObjectRequirement(getContext(), BoundsCheckRequirements)
+      .computeIn(Root, RootRequires);
+}
+
 void CodeGenFunction::EmitBoundsCheck(const Expr *ArrayExpr,
                                       const Expr *ArrayExprBase,
                                       llvm::Value *IndexVal, QualType IndexType,
-                                      bool Accessed) {
+                                      bool MustExist) {
   assert(SanOpts.has(SanitizerKind::ArrayBounds) &&
          "should not be called unless adding bounds checks");
   const LangOptions::StrictFlexArraysLevelKind StrictFlexArraysLevel =
@@ -1295,7 +1649,7 @@ void CodeGenFunction::EmitBoundsCheck(const Expr *ArrayExpr,
       *this, ArrayExprBase, ArrayExprBaseType, StrictFlexArraysLevel);
 
   EmitBoundsCheckImpl(ArrayExpr, ArrayExprBaseType, IndexVal, IndexType,
-                      BoundsVal, getContext().getSizeType(), Accessed);
+                      BoundsVal, getContext().getSizeType(), MustExist);
 }
 
 void CodeGenFunction::EmitBoundsCheckImpl(const Expr *ArrayExpr,
@@ -1303,7 +1657,7 @@ void CodeGenFunction::EmitBoundsCheckImpl(const Expr *ArrayExpr,
                                           llvm::Value *IndexVal,
                                           QualType IndexType,
                                           llvm::Value *BoundsVal,
-                                          QualType BoundsType, bool Accessed) {
+                                          QualType BoundsType, bool MustExist) {
   if (!BoundsVal)
     return;
 
@@ -1329,8 +1683,8 @@ void CodeGenFunction::EmitBoundsCheckImpl(const Expr *ArrayExpr,
       EmitCheckTypeDescriptor(IndexType),
   };
 
-  llvm::Value *Check = Accessed ? Builder.CreateICmpULT(IndexInst, BoundsInst)
-                                : Builder.CreateICmpULE(IndexInst, BoundsInst);
+  llvm::Value *Check = MustExist ? Builder.CreateICmpULT(IndexInst, BoundsInst)
+                                 : Builder.CreateICmpULE(IndexInst, BoundsInst);
 
   if (BoundsSigned) {
     // Don't allow a negative bounds.
@@ -1700,11 +2054,10 @@ bool CodeGenFunction::IsWrappedCXXThis(const Expr *Obj) {
 }
 
 LValue CodeGenFunction::EmitCheckedLValue(const Expr *E, TypeCheckKind TCK) {
-  LValue LV;
-  if (SanOpts.has(SanitizerKind::ArrayBounds) && isa<ArraySubscriptExpr>(E))
-    LV = EmitArraySubscriptExpr(cast<ArraySubscriptExpr>(E), /*Accessed*/true);
-  else
-    LV = EmitLValue(E);
+  // Whether an index one past the last element is valid is a property of the
+  // enclosing context, answered by mustElementExist(); there is nothing to
+  // reconstruct from the expression handed to us here.
+  LValue LV = EmitLValue(E);
   if (!isa<DeclRefExpr>(E) && !LV.isBitField() && LV.isSimple()) {
     SanitizerSet SkippedChecks;
     if (const auto *ME = dyn_cast<MemberExpr>(E)) {
@@ -4957,7 +5310,7 @@ static std::optional<int64_t> getOffsetDifferenceInBits(CodeGenFunction &CGF,
 /// similar to emit the correct GEP.
 void CodeGenFunction::EmitCountedByBoundsChecking(
     const Expr *ArrayExpr, QualType ArrayType, Address ArrayInst,
-    QualType IndexType, llvm::Value *IndexVal, bool Accessed,
+    QualType IndexType, llvm::Value *IndexVal, bool MustExist,
     bool FlexibleArray) {
   const auto *ME = dyn_cast<MemberExpr>(ArrayExpr->IgnoreImpCasts());
   if (!ME || !ME->getMemberDecl()->getType()->isCountAttributedType())
@@ -5001,12 +5354,11 @@ void CodeGenFunction::EmitCountedByBoundsChecking(
 
     // Now emit the bounds checking.
     EmitBoundsCheckImpl(ArrayExpr, ArrayType, IndexVal, IndexType, BoundsVal,
-                        CountFD->getType(), Accessed);
+                        CountFD->getType(), MustExist);
   }
 }
 
-LValue CodeGenFunction::EmitArraySubscriptExpr(const ArraySubscriptExpr *E,
-                                               bool Accessed) {
+LValue CodeGenFunction::EmitArraySubscriptExpr(const ArraySubscriptExpr *E) {
   // The index must always be an integer, which is not an aggregate.  Emit it
   // in lexical order (this complexity is, sadly, required by C++17).
   llvm::Value *IdxPre =
@@ -5024,7 +5376,7 @@ LValue CodeGenFunction::EmitArraySubscriptExpr(const ArraySubscriptExpr *E,
     SignedIndices |= IdxSigned;
 
     if (SanOpts.has(SanitizerKind::ArrayBounds))
-      EmitBoundsCheck(E, E->getBase(), Idx, IdxTy, Accessed);
+      EmitBoundsCheck(E, E->getBase(), Idx, IdxTy, mustElementExist(E));
 
     // Extend or truncate the index type to 32 or 64-bits.
     if (Promote && Idx->getType() != IntPtrTy)
@@ -5137,18 +5489,16 @@ LValue CodeGenFunction::EmitArraySubscriptExpr(const ArraySubscriptExpr *E,
     // "gep x, i" here.  Emit one "gep A, 0, i".
     assert(Array->getType()->isArrayType() &&
            "Array to pointer decay must have array source type!");
-    LValue ArrayLV;
-    // For simple multidimensional array indexing, set the 'accessed' flag for
-    // better bounds-checking of the base expression.
-    if (const auto *ASE = dyn_cast<ArraySubscriptExpr>(Array))
-      ArrayLV = EmitArraySubscriptExpr(ASE, /*Accessed*/ true);
-    else
-      ArrayLV = EmitLValue(Array);
+    // The 'accessed' flag this used to force is now answered by
+    // mustElementExist(), which asserts the demand for a decayed subscript
+    // base.
+    LValue ArrayLV = EmitLValue(Array);
     auto *Idx = EmitIdxAfterBase(/*Promote*/true);
 
     if (SanOpts.has(SanitizerKind::ArrayBounds))
       EmitCountedByBoundsChecking(Array, Array->getType(), ArrayLV.getAddress(),
-                                  E->getIdx()->getType(), Idx, Accessed,
+                                  E->getIdx()->getType(), Idx,
+                                  mustElementExist(E),
                                   /*FlexibleArray=*/true);
 
     // Propagate the alignment from the array itself to the result.
@@ -5202,7 +5552,8 @@ LValue CodeGenFunction::EmitArraySubscriptExpr(const ArraySubscriptExpr *E,
       if (const auto *CE = dyn_cast_if_present<CastExpr>(Base);
           CE && CE->getCastKind() == CK_LValueToRValue)
         EmitCountedByBoundsChecking(CE, ptrType, Address::invalid(),
-                                    E->getIdx()->getType(), Idx, Accessed,
+                                    E->getIdx()->getType(), Idx,
+                                    mustElementExist(E),
                                     /*FlexibleArray=*/false);
     }
   }
@@ -5438,13 +5789,10 @@ LValue CodeGenFunction::EmitArraySectionExpr(const ArraySectionExpr *E,
     // "gep x, i" here.  Emit one "gep A, 0, i".
     assert(Array->getType()->isArrayType() &&
            "Array to pointer decay must have array source type!");
-    LValue ArrayLV;
-    // For simple multidimensional array indexing, set the 'accessed' flag for
-    // better bounds-checking of the base expression.
-    if (const auto *ASE = dyn_cast<ArraySubscriptExpr>(Array))
-      ArrayLV = EmitArraySubscriptExpr(ASE, /*Accessed*/ true);
-    else
-      ArrayLV = EmitLValue(Array);
+    // The 'accessed' flag this used to force is now answered by
+    // mustElementExist(), which asserts the demand for a decayed subscript
+    // base.
+    LValue ArrayLV = EmitLValue(Array);
 
     // Propagate the alignment from the array itself to the result.
     EltPtr = emitArraySubscriptGEP(

--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -2193,7 +2193,7 @@ Value *ScalarExprEmitter::VisitArraySubscriptExpr(ArraySubscriptExpr *E) {
   QualType IdxTy = E->getIdx()->getType();
 
   if (CGF.SanOpts.has(SanitizerKind::ArrayBounds))
-    CGF.EmitBoundsCheck(E, E->getBase(), Idx, IdxTy, /*Accessed*/true);
+    CGF.EmitBoundsCheck(E, E->getBase(), Idx, IdxTy, CGF.mustElementExist(E));
 
   Value *Ret = Builder.CreateExtractElement(Base, Idx, "vecext");
 
@@ -4580,8 +4580,10 @@ llvm::Value *CodeGenFunction::EmitPointerArithmetic(
     index = Builder.CreateNeg(index, "idx.neg");
 
   if (SanOpts.has(SanitizerKind::ArrayBounds))
+    // `a[i]` is `*(a + i)` (C99 6.5.2.1p2), so ask the context as a subscript
+    // does; `p = a + i` only computes an address.
     EmitBoundsCheck(BO, pointerOperand, index, indexOperand->getType(),
-                    /*Accessed*/ false);
+                    mustElementExist(BO));
 
   const PointerType *pointerType =
       pointerOperand->getType()->getAs<PointerType>();

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -772,6 +772,17 @@ void CodeGenFunction::StartFunction(GlobalDecl GD, QualType RetTy,
   if (FD && FD->usesSEHTry())
     CurSEHParent = GD;
   CurFuncDecl = (D ? D->getNonClosureContext() : nullptr);
+
+  // For -fsanitize=array-bounds: the body, plus a constructor's initializers,
+  // which are emitted before it and are each their own root.
+  if (D) {
+    computeBoundsCheckRequirements(D->getBody());
+    if (const auto *Ctor = dyn_cast<CXXConstructorDecl>(D))
+      for (const CXXCtorInitializer *Init : Ctor->inits())
+        if (const Expr *E = Init->getInit())
+          computeBoundsCheckRequirements(E, E->isGLValue());
+  }
+
   FnRetTy = RetTy;
   CurFn = Fn;
   CurFnInfo = &FnInfo;

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -346,6 +346,18 @@ public:
   void InsertHelper(llvm::Instruction *I, const llvm::Twine &Name,
                     llvm::BasicBlock::iterator InsertPt) const;
 
+  /// For -fsanitize=array-bounds: whether the context of each expression a check
+  /// may be emitted for requires the object it designates to exist. An
+  /// expression with no entry was never walked; see mustElementExist().
+  using BoundsCheckRequirementMap = llvm::DenseMap<const Expr *, bool>;
+  BoundsCheckRequirementMap BoundsCheckRequirements;
+
+  /// Records those requirements for every expression in \p Root.
+  /// \p RootRequires is what the context asks of \p Root itself: nothing for a
+  /// body, but a reference member's initializer is asked for the object.
+  void computeBoundsCheckRequirements(const Stmt *Root,
+                                      bool RootRequires = false);
+
   /// CurFuncDecl - Holds the Decl for the current outermost
   /// non-closure context.
   const Decl *CurFuncDecl = nullptr;
@@ -3397,15 +3409,23 @@ public:
                      SanitizerSet SkippedChecks = SanitizerSet(),
                      llvm::Value *ArraySize = nullptr);
 
-  /// Emit a check that \p Base points into an array object, which
-  /// we can access at index \p Index. \p Accessed should be \c false if we
-  /// this expression is used as an lvalue, for instance in "&Arr[Idx]".
+  /// Emit a check that \p Base points into an array object, which we can access
+  /// at index \p Index. \p MustExist selects the comparison: when the context
+  /// requires the designated element to exist the index must be strictly less
+  /// than the bound, otherwise an index equal to the bound is accepted, because
+  /// C11 6.5.6p8 makes a one-past-the-end pointer a valid value and 6.5.3.2p3
+  /// makes "&Arr[Idx]" legal for Idx equal to the bound.
   void EmitBoundsCheck(const Expr *ArrayExpr, const Expr *ArrayExprBase,
-                       llvm::Value *Index, QualType IndexType, bool Accessed);
+                       llvm::Value *Index, QualType IndexType, bool MustExist);
+
+  /// Does the context \p E appears in require the element it designates to
+  /// exist? Read from BoundsCheckRequirements; see the comment
+  /// on mustElementExist in CGExpr.cpp for the model.
+  bool mustElementExist(const Expr *E);
   void EmitBoundsCheckImpl(const Expr *ArrayExpr, QualType ArrayBaseType,
                            llvm::Value *IndexVal, QualType IndexType,
                            llvm::Value *BoundsVal, QualType BoundsType,
-                           bool Accessed);
+                           bool MustExist);
 
   /// Returns debug info, with additional annotation if
   /// CGM.getCodeGenOpts().SanitizeAnnotateDebugInfo[Ordinal] is enabled for
@@ -3436,7 +3456,7 @@ public:
   // counted_by attribute.
   void EmitCountedByBoundsChecking(const Expr *ArrayExpr, QualType ArrayType,
                                    Address ArrayInst, QualType IndexType,
-                                   llvm::Value *IndexVal, bool Accessed,
+                                   llvm::Value *IndexVal, bool MustExist,
                                    bool FlexibleArray);
 
   llvm::Value *EmitScalarPrePostIncDec(const UnaryOperator *E, LValue LV,
@@ -4496,8 +4516,7 @@ public:
   LValue EmitObjCEncodeExprLValue(const ObjCEncodeExpr *E);
   LValue EmitPredefinedLValue(const PredefinedExpr *E);
   LValue EmitUnaryOpLValue(const UnaryOperator *E);
-  LValue EmitArraySubscriptExpr(const ArraySubscriptExpr *E,
-                                bool Accessed = false);
+  LValue EmitArraySubscriptExpr(const ArraySubscriptExpr *E);
   llvm::Value *EmitMatrixIndexExpr(const Expr *E);
   LValue EmitMatrixSingleSubscriptExpr(const MatrixSingleSubscriptExpr *E);
   LValue EmitMatrixSubscriptExpr(const MatrixSubscriptExpr *E);

--- a/clang/test/CodeGen/attr-counted-by-for-pointers.c
+++ b/clang/test/CodeGen/attr-counted-by-for-pointers.c
@@ -140,7 +140,7 @@ void test_store_subscript_through_cast(struct annotated_ptr *p, int index, struc
 // SANITIZE-WITH-ATTR-NEXT:  [[ENTRY:.*:]]
 // SANITIZE-WITH-ATTR-NEXT:    [[DOTCOUNTED_BY_GEP:%.*]] = getelementptr inbounds nuw i8, ptr [[P]], i64 16
 // SANITIZE-WITH-ATTR-NEXT:    [[DOTCOUNTED_BY_LOAD:%.*]] = load i32, ptr [[DOTCOUNTED_BY_GEP]], align 8
-// SANITIZE-WITH-ATTR-NEXT:    [[TMP0:%.*]] = icmp ule i32 [[INDEX]], [[DOTCOUNTED_BY_LOAD]], !nosanitize [[META6]]
+// SANITIZE-WITH-ATTR-NEXT:    [[TMP0:%.*]] = icmp ult i32 [[INDEX]], [[DOTCOUNTED_BY_LOAD]], !nosanitize [[META6]]
 // SANITIZE-WITH-ATTR-NEXT:    [[TMP1:%.*]] = icmp sgt i32 [[DOTCOUNTED_BY_LOAD]], 0, !nosanitize [[META6]]
 // SANITIZE-WITH-ATTR-NEXT:    [[TMP2:%.*]] = and i1 [[TMP1]], [[TMP0]], !nosanitize [[META6]]
 // SANITIZE-WITH-ATTR-NEXT:    br i1 [[TMP2]], label %[[CONT10:.*]], label %[[HANDLER_OUT_OF_BOUNDS:.*]], !prof [[PROF7]], !nosanitize [[META6]]

--- a/clang/test/CodeGen/attr-counted-by-with-sanitizers.c
+++ b/clang/test/CodeGen/attr-counted-by-with-sanitizers.c
@@ -529,12 +529,12 @@ size_t test_return_bdos_of_anon_struct(struct union_of_fams *p) {
 // SANITIZE-WITH-ATTR-NEXT:    [[COUNTED_BY_LOAD:%.*]] = load i8, ptr [[TMP0]], align 4
 // SANITIZE-WITH-ATTR-NEXT:    [[TMP1:%.*]] = zext i8 [[COUNTED_BY_LOAD]] to i32, !nosanitize [[META6]]
 // SANITIZE-WITH-ATTR-NEXT:    [[TMP2:%.*]] = icmp ult i32 [[INDEX]], [[TMP1]], !nosanitize [[META6]]
-// SANITIZE-WITH-ATTR-NEXT:    br i1 [[TMP2]], label %[[CONT14:.*]], label %[[HANDLER_OUT_OF_BOUNDS:.*]], !prof [[PROF7]], !nosanitize [[META6]]
+// SANITIZE-WITH-ATTR-NEXT:    br i1 [[TMP2]], label %[[CONT16:.*]], label %[[HANDLER_OUT_OF_BOUNDS:.*]], !prof [[PROF7]], !nosanitize [[META6]]
 // SANITIZE-WITH-ATTR:       [[HANDLER_OUT_OF_BOUNDS]]:
 // SANITIZE-WITH-ATTR-NEXT:    [[TMP3:%.*]] = zext i32 [[INDEX]] to i64, !nosanitize [[META6]]
 // SANITIZE-WITH-ATTR-NEXT:    tail call void @__ubsan_handle_out_of_bounds_abort(ptr nonnull @[[GLOB16:[0-9]+]], i64 [[TMP3]]) #[[ATTR7]], !nosanitize [[META6]]
 // SANITIZE-WITH-ATTR-NEXT:    unreachable, !nosanitize [[META6]]
-// SANITIZE-WITH-ATTR:       [[CONT14]]:
+// SANITIZE-WITH-ATTR:       [[CONT16]]:
 // SANITIZE-WITH-ATTR-NEXT:    [[INTS:%.*]] = getelementptr inbounds nuw i8, ptr [[P]], i64 9
 // SANITIZE-WITH-ATTR-NEXT:    [[IDXPROM:%.*]] = zext nneg i32 [[INDEX]] to i64
 // SANITIZE-WITH-ATTR-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds nuw i8, ptr [[INTS]], i64 [[IDXPROM]]
@@ -612,12 +612,12 @@ void test_assign_bdos_of_struct_to_union_fam(struct union_of_fams *p, int index)
 // SANITIZE-WITH-ATTR-NEXT:    [[TMP1:%.*]] = icmp ult i32 [[INDEX]], [[COUNTED_BY_LOAD]], !nosanitize [[META6]]
 // SANITIZE-WITH-ATTR-NEXT:    [[TMP2:%.*]] = icmp sgt i32 [[COUNTED_BY_LOAD]], 0, !nosanitize [[META6]]
 // SANITIZE-WITH-ATTR-NEXT:    [[TMP3:%.*]] = and i1 [[TMP2]], [[TMP1]], !nosanitize [[META6]]
-// SANITIZE-WITH-ATTR-NEXT:    br i1 [[TMP3]], label %[[CONT14:.*]], label %[[HANDLER_OUT_OF_BOUNDS:.*]], !prof [[PROF7]], !nosanitize [[META6]]
+// SANITIZE-WITH-ATTR-NEXT:    br i1 [[TMP3]], label %[[CONT16:.*]], label %[[HANDLER_OUT_OF_BOUNDS:.*]], !prof [[PROF7]], !nosanitize [[META6]]
 // SANITIZE-WITH-ATTR:       [[HANDLER_OUT_OF_BOUNDS]]:
 // SANITIZE-WITH-ATTR-NEXT:    [[TMP4:%.*]] = zext i32 [[INDEX]] to i64, !nosanitize [[META6]]
 // SANITIZE-WITH-ATTR-NEXT:    tail call void @__ubsan_handle_out_of_bounds_abort(ptr nonnull @[[GLOB19:[0-9]+]], i64 [[TMP4]]) #[[ATTR7]], !nosanitize [[META6]]
 // SANITIZE-WITH-ATTR-NEXT:    unreachable, !nosanitize [[META6]]
-// SANITIZE-WITH-ATTR:       [[CONT14]]:
+// SANITIZE-WITH-ATTR:       [[CONT16]]:
 // SANITIZE-WITH-ATTR-NEXT:    [[BYTES:%.*]] = getelementptr inbounds nuw i8, ptr [[P]], i64 12
 // SANITIZE-WITH-ATTR-NEXT:    [[IDXPROM:%.*]] = sext i32 [[INDEX]] to i64
 // SANITIZE-WITH-ATTR-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds i8, ptr [[BYTES]], i64 [[IDXPROM]]
@@ -1464,7 +1464,7 @@ struct multi_subscripts {
 // SANITIZE-WITH-ATTR-LABEL: define dso_local i64 @test_return_bdos_of_multiple_indices(
 // SANITIZE-WITH-ATTR-SAME: ptr noundef [[PTR:%.*]], i32 noundef [[IDX1:%.*]], i32 noundef [[IDX2:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // SANITIZE-WITH-ATTR-NEXT:  [[ENTRY:.*:]]
-// SANITIZE-WITH-ATTR-NEXT:    [[TMP0:%.*]] = icmp ult i32 [[IDX1]], 42
+// SANITIZE-WITH-ATTR-NEXT:    [[TMP0:%.*]] = icmp ult i32 [[IDX1]], 43
 // SANITIZE-WITH-ATTR-NEXT:    br i1 [[TMP0]], label %[[CONT1:.*]], label %[[HANDLER_OUT_OF_BOUNDS:.*]], !prof [[PROF7]], !nosanitize [[META6]]
 // SANITIZE-WITH-ATTR:       [[HANDLER_OUT_OF_BOUNDS]]:
 // SANITIZE-WITH-ATTR-NEXT:    [[TMP1:%.*]] = sext i32 [[IDX1]] to i64, !nosanitize [[META6]]
@@ -1483,7 +1483,7 @@ struct multi_subscripts {
 // SANITIZE-WITHOUT-ATTR-LABEL: define dso_local i64 @test_return_bdos_of_multiple_indices(
 // SANITIZE-WITHOUT-ATTR-SAME: ptr noundef [[PTR:%.*]], i32 noundef [[IDX1:%.*]], i32 noundef [[IDX2:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // SANITIZE-WITHOUT-ATTR-NEXT:  [[ENTRY:.*:]]
-// SANITIZE-WITHOUT-ATTR-NEXT:    [[TMP0:%.*]] = icmp ult i32 [[IDX1]], 42
+// SANITIZE-WITHOUT-ATTR-NEXT:    [[TMP0:%.*]] = icmp ult i32 [[IDX1]], 43
 // SANITIZE-WITHOUT-ATTR-NEXT:    br i1 [[TMP0]], label %[[CONT1:.*]], label %[[HANDLER_OUT_OF_BOUNDS:.*]], !prof [[PROF10]], !nosanitize [[META9]]
 // SANITIZE-WITHOUT-ATTR:       [[HANDLER_OUT_OF_BOUNDS]]:
 // SANITIZE-WITHOUT-ATTR-NEXT:    [[TMP1:%.*]] = sext i32 [[IDX1]] to i64, !nosanitize [[META9]]

--- a/clang/test/CodeGen/ubsan-aggregate-null-align-bounds.c
+++ b/clang/test/CodeGen/ubsan-aggregate-null-align-bounds.c
@@ -89,12 +89,14 @@ void test_init_from_subscript(AGG arr[4]) {
 }
 
 // Array bounds - out-of-bounds access (RHS)
-// Note: GCC also does not detect the out-of-bounds access here when compiled as
-// C++.
+// In C++ this is a call to the implicit copy assignment operator, whose right
+// operand is copied and so must exist. It used to be missed there, because the
+// right operand of an aggregate assignment carries no lvalue-to-rvalue
+// conversion for the check to key on.
 
 // CHECK-LABEL: define {{.*}}@test_oob_rhs(
 // C: br i1 false, label %cont, label %handler.out_of_bounds
-// CXX: br i1 true, label %cont, label %handler.out_of_bounds
+// CXX: br i1 false, label %cont, label %handler.out_of_bounds
 // CHECK: handler.out_of_bounds:
 // CHECK-NEXT: call void @__ubsan_handle_out_of_bounds_abort
 // CHECK: handler.type_mismatch:

--- a/clang/test/CodeGen/ubsan-array-bounds-baseline-arc.m
+++ b/clang/test/CodeGen/ubsan-array-bounds-baseline-arc.m
@@ -1,0 +1,51 @@
+// Baseline for the Objective-C ARC contexts a subscript can appear in. Split
+// from ubsan-array-bounds-baseline.c because ARC's __weak needs a Darwin
+// triple, not because the contexts are unrelated.
+// RUN: %clang_cc1 -triple arm64-apple-macosx11.0.0 -emit-llvm \
+// RUN:     -fsanitize=array-bounds \
+// RUN:     -Wno-array-bounds -fobjc-arc -fobjc-runtime-has-weak -fblocks \
+// RUN:     %s -o - | FileCheck %s
+
+__weak id wa[4];
+id st[4];
+__unsafe_unretained id ua[4];
+__strong id *p;
+
+//===----------------------------------------------------------------------===//
+// Contexts that require the element to exist.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: define {{.*}}@arc_weak_store(
+// CHECK: icmp ult i64 {{.*}}, 4
+void arc_weak_store(int i, id v) { wa[i] = v; }
+
+// CHECK-LABEL: define {{.*}}@arc_strong_store(
+// CHECK: icmp ult i64 {{.*}}, 4
+void arc_strong_store(int i, id v) { st[i] = v; }
+
+// CHECK-LABEL: define {{.*}}@arc_weak_load(
+// CHECK: icmp ult i64 {{.*}}, 4
+void arc_weak_load(int i, id *o) { *o = wa[i]; }
+
+// The remaining lifetimes take their own emitters, so each is covered rather
+// than assumed to follow from the two above.
+
+// CHECK-LABEL: define {{.*}}@arc_strong_load(
+// CHECK: icmp ult i64 {{.*}}, 4
+void arc_strong_load(int i, id *o) { *o = st[i]; }
+
+// CHECK-LABEL: define {{.*}}@arc_unsafe_store(
+// CHECK: icmp ult i64 {{.*}}, 4
+void arc_unsafe_store(int i, id v) { ua[i] = v; }
+
+// CHECK-LABEL: define {{.*}}@arc_unsafe_load(
+// CHECK: icmp ult i64 {{.*}}, 4
+void arc_unsafe_load(int i, id *o) { *o = ua[i]; }
+
+//===----------------------------------------------------------------------===//
+// Address-only: `ule` is required.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: define {{.*}}@arc_ctl_addr(
+// CHECK: icmp ule i64 {{.*}}, 4
+void arc_ctl_addr(int i) { p = &st[i]; }

--- a/clang/test/CodeGen/ubsan-array-bounds-baseline-ptrauth.c
+++ b/clang/test/CodeGen/ubsan-array-bounds-baseline-ptrauth.c
@@ -1,0 +1,24 @@
+// A __ptrauth-qualified pointer is loaded through its own path in
+// CGPointerAuth.cpp, which needs a triple with pointer authentication, hence a
+// file of its own. See ubsan-array-bounds-baseline.c for the rest.
+//
+// REQUIRES: aarch64-registered-target
+// RUN: %clang_cc1 -triple arm64e-apple-macosx11.0.0 -fptrauth-calls \
+// RUN:     -fptrauth-intrinsics -fptrauth-returns -emit-llvm \
+// RUN:     -fsanitize=array-bounds -Wno-array-bounds %s -o - | FileCheck %s
+
+#define AQ __ptrauth(2, 1, 42)
+
+int *AQ pa[4];
+
+// CHECK-LABEL: define {{.*}}@p_load(
+// CHECK: icmp ult i64 {{.*}}, 4
+int *p_load(int i) { return pa[i]; }
+
+// CHECK-LABEL: define {{.*}}@p_load_paren(
+// CHECK: icmp ult i64 {{.*}}, 4
+int *p_load_paren(int i) { return (pa[i]); }
+
+// CHECK-LABEL: define {{.*}}@p_load_deref_addr(
+// CHECK: icmp ult i64 {{.*}}, 4
+int *p_load_deref_addr(int i) { return *&pa[i]; }

--- a/clang/test/CodeGen/ubsan-array-bounds-baseline.c
+++ b/clang/test/CodeGen/ubsan-array-bounds-baseline.c
@@ -1,0 +1,270 @@
+// Baseline record of the comparison -fsanitize=array-bounds emits for each
+// context a subscript can appear in. `ult` requires the element to exist; `ule`
+// also accepts an index equal to the bound, which is right only where the
+// expression forms an address without reaching the object (C99 6.5.6p8,
+// C99 6.5.3.2p3).
+//
+// A case named `..._arrow` spells the same access as its non-arrow counterpart,
+// through a pointer instead; C99 6.5.2.3p4 makes them one expression, so the two
+// must agree.
+//
+// Later commits in this series change individual CHECK lines, so each shows in
+// its diff exactly which contexts it affects.
+//
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -emit-llvm -fsanitize=array-bounds \
+// RUN:     -Wno-array-bounds -std=c11 %s -o - | FileCheck %s
+//
+// The __block section needs -fblocks, so it is checked under its own prefix.
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -emit-llvm -fsanitize=array-bounds \
+// RUN:     -Wno-array-bounds -std=c11 -fblocks -DBLOCKS %s -o - \
+// RUN:     | FileCheck %s --check-prefixes=CHECK,BLOCKS
+
+struct S {
+  int x;
+};
+typedef int v4 __attribute__((ext_vector_type(4)));
+struct CB {
+  int n;
+  int fam[] __attribute__((counted_by(n)));
+};
+
+int a[4];
+int a2[4][4];
+struct S sa[4];
+_Complex double ca[4];
+v4 va[4];
+int *p;
+struct S *q;
+int v;
+struct S aggl;
+_Complex double cv;
+void sink(struct S);
+
+//===----------------------------------------------------------------------===//
+// Contexts that require the element to exist.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: define {{.*}}@c_store(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_store(int i) { a[i] = 1; }
+
+// CHECK-LABEL: define {{.*}}@c_load(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_load(int i) { v = a[i]; }
+
+// CHECK-LABEL: define {{.*}}@c_load_deref_addr(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_load_deref_addr(int i) { v = *&a[i]; }
+
+// CHECK-LABEL: define {{.*}}@c_load_cast(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_load_cast(int i) { v = *(int *)&a[i]; }
+
+// CHECK-LABEL: define {{.*}}@c_compound(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_compound(int i) { a[i] += 1; }
+
+// CHECK-LABEL: define {{.*}}@c_compound_paren(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_compound_paren(int i) { (a[i]) += 1; }
+
+// CHECK-LABEL: define {{.*}}@c_compound_deref_addr(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_compound_deref_addr(int i) { *&a[i] += 1; }
+
+// CHECK-LABEL: define {{.*}}@c_postinc(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_postinc(int i) { a[i]++; }
+
+// CHECK-LABEL: define {{.*}}@c_postdec(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_postdec(int i) { a[i]--; }
+
+// CHECK-LABEL: define {{.*}}@c_preinc(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_preinc(int i) { ++a[i]; }
+
+// CHECK-LABEL: define {{.*}}@c_predec(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_predec(int i) { --a[i]; }
+
+// CHECK-LABEL: define {{.*}}@c_agg_store(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_agg_store(int i) { sa[i] = aggl; }
+
+// CHECK-LABEL: define {{.*}}@c_agg_store_paren(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_agg_store_paren(int i) { (sa[i]) = aggl; }
+
+// CHECK-LABEL: define {{.*}}@c_agg_store_deref_addr(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_agg_store_deref_addr(int i) { *&sa[i] = aggl; }
+
+// CHECK-LABEL: define {{.*}}@c_agg_load(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_agg_load(int i) { aggl = sa[i]; }
+
+// CHECK-LABEL: define {{.*}}@c_agg_load_deref_addr(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_agg_load_deref_addr(int i) { aggl = *&sa[i]; }
+
+// CHECK-LABEL: define {{.*}}@c_member_dot(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_member_dot(int i) { sa[i].x = 1; }
+
+// CHECK-LABEL: define {{.*}}@c_member_dot_deref_addr(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_member_dot_deref_addr(int i) { (*&sa[i]).x = 1; }
+
+// CHECK-LABEL: define {{.*}}@c_member_dot_deref_addr_load(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_member_dot_deref_addr_load(int i) { v = (*&sa[i]).x; }
+
+// CHECK-LABEL: define {{.*}}@c_member_arrow(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_member_arrow(int i) { (&sa[i])->x = 1; }
+
+// Taking the address of a member is not one of the rewrites in C99 6.5.3.2p3,
+// so unlike ctl_struct_addr these require the element to exist.
+// CHECK-LABEL: define {{.*}}@c_member_dot_addr(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_member_dot_addr(int i) { p = &sa[i].x; }
+
+// CHECK-LABEL: define {{.*}}@c_member_arrow_addr(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_member_arrow_addr(int i) { p = &(&sa[i])->x; }
+
+// CHECK-LABEL: define {{.*}}@c_complex_real(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_complex_real(int i) { __real__ ca[i] = 1; }
+
+// CHECK-LABEL: define {{.*}}@c_complex_imag(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_complex_imag(int i) { __imag__ ca[i] = 1; }
+
+// CHECK-LABEL: define {{.*}}@c_complex_load(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_complex_load(int i) { cv = ca[i]; }
+
+// CHECK-LABEL: define {{.*}}@c_complex_store(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_complex_store(int i) { ca[i] = cv; }
+
+// CHECK-LABEL: define {{.*}}@c_complex_compound(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_complex_compound(int i) { ca[i] += cv; }
+
+// CHECK-LABEL: define {{.*}}@c_complex_incdec(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_complex_incdec(int i) { ca[i]++; }
+
+// CHECK-LABEL: define {{.*}}@c_vec_elem(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_vec_elem(int i) { va[i].x = 1; }
+
+// CHECK-LABEL: define {{.*}}@c_vec_elem_arrow(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_vec_elem_arrow(int i) { (&va[i])->x = 1; }
+
+// The component belongs to a temporary, not to an element; the
+// element is read in order to build it.
+// CHECK-LABEL: define {{.*}}@c_vec_rvalue(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_vec_rvalue(int i) {
+  v = (va[i] + va[0]).x;
+}
+
+// CHECK-LABEL: define {{.*}}@c_byval(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_byval(int i) { sink(sa[i]); }
+
+// Same expression as c_store: C99 6.5.3.2p3 makes `&*E` into `E`.
+// CHECK-LABEL: define {{.*}}@c_deref_addr(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_deref_addr(int i) { *&a[i] = 1; }
+
+// CHECK-LABEL: define {{.*}}@c_paren(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_paren(int i) { (a[i]) = 1; }
+
+// CHECK-LABEL: define {{.*}}@c_extension(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_extension(int i) { __extension__(a[i]) = 1; }
+
+// CHECK-LABEL: define {{.*}}@c_cast_store(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_cast_store(int i) { *(int *)&a[i] = 1; }
+
+// C99 6.5.2.1p2 makes `a[i]` mean `*(a + i)`, so these must agree with c_store
+// and c_load.
+// CHECK-LABEL: define {{.*}}@c_deref_plus_store(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_deref_plus_store(int i) { *(a + i) = 1; }
+
+// CHECK-LABEL: define {{.*}}@c_deref_plus_load(
+// CHECK: icmp ult i64 {{.*}}, 4
+void c_deref_plus_load(int i) { v = *(a + i); }
+
+// CHECK-LABEL: define {{.*}}@c_counted(
+// CHECK: icmp ult i32 {{.*}}
+void c_counted(struct CB *s, int i) { s->fam[i] = 1; }
+
+//===----------------------------------------------------------------------===//
+// __block storage. AggExprEmitter::VisitBinAssign has a separate path for a
+// __block LHS whose RHS has side effects -- the comment there calls it
+// "pretty semantically fragile" -- so both shapes are covered: only the first
+// reaches that path.
+//===----------------------------------------------------------------------===//
+
+#ifdef BLOCKS
+struct S mk(void);
+
+// A side-effecting right operand takes a different path from
+// blk_plain below.
+// BLOCKS-LABEL: define {{.*}}@blk_side_effect(
+// BLOCKS: icmp ult i64 {{.*}}, 4
+void blk_side_effect(int i) {
+  __block struct S barr[4];
+  barr[i] = mk();
+  (void)barr;
+}
+
+// BLOCKS-LABEL: define {{.*}}@blk_plain(
+// BLOCKS: icmp ult i64 {{.*}}, 4
+void blk_plain(int i, struct S v) {
+  __block struct S barr[4];
+  barr[i] = v;
+  (void)barr;
+}
+#endif
+
+//===----------------------------------------------------------------------===//
+// Address-only contexts. `ule` is required here: these expressions form an
+// address without reaching the object, so a strict comparison would reject
+// correct code.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: define {{.*}}@ctl_addr(
+// CHECK: icmp ule i64 {{.*}}, 4
+void ctl_addr(int i) { p = &a[i]; }
+
+// CHECK-LABEL: define {{.*}}@ctl_decay(
+// CHECK: icmp ule i64 {{.*}}, 4
+void ctl_decay(int i) { p = a + i; }
+
+// CHECK-LABEL: define {{.*}}@ctl_row(
+// CHECK: icmp ule i64 {{.*}}, 4
+void ctl_row(int i) { p = a2[i]; }
+
+// Same expression as ctl_row: C99 6.5.3.2p3.
+// CHECK-LABEL: define {{.*}}@ctl_row_elem0(
+// CHECK: icmp ule i64 {{.*}}, 4
+void ctl_row_elem0(int i) { p = &a2[i][0]; }
+
+// CHECK-LABEL: define {{.*}}@ctl_struct_addr(
+// CHECK: icmp ule i64 {{.*}}, 4
+void ctl_struct_addr(int i) { q = &sa[i]; }
+
+// CHECK-LABEL: define {{.*}}@ctl_addr_deref(
+// CHECK: icmp ule i64 {{.*}}, 4
+void ctl_addr_deref(int i) { p = &*&a[i]; }

--- a/clang/test/CodeGenCXX/ubsan-array-bounds-baseline.cpp
+++ b/clang/test/CodeGenCXX/ubsan-array-bounds-baseline.cpp
@@ -1,0 +1,273 @@
+// C++ counterpart of ubsan-array-bounds-baseline.c: reference binding, member
+// calls, base conversions, pointers to members and default arguments. As there,
+// a case named `..._arrow` is the same access as its non-arrow counterpart and
+// the two must agree.
+//
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -emit-llvm -fsanitize=array-bounds \
+// RUN:     -Wno-array-bounds -std=c++17 %s -o - | FileCheck %s
+//
+// Constructors are emitted after the free functions, so the cases whose check
+// lands in one are checked under their own prefix.
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -emit-llvm -fsanitize=array-bounds \
+// RUN:     -Wno-array-bounds -std=c++17 %s -o - | FileCheck %s \
+// RUN:     --check-prefix=CTOR
+
+struct T {
+  T();
+  ~T();
+};
+struct M {
+  int f;
+  void m();
+};
+struct Base {
+  int b;
+};
+struct Derived : Base {
+  int d;
+};
+struct Agg {
+  int x;
+};
+
+int a[4];
+int a2[4][4];
+M ma[4];
+Derived da[4];
+Agg agga[4];
+Agg agglocal;
+int gidx;
+int *p;
+M *q;
+int M::*pmf = &M::f;
+
+// Separate from M so that adding a vptr does not perturb the cases above.
+struct MS {
+  int f;
+  static void stat();
+  virtual void virt();
+};
+MS msa[4];
+
+//===----------------------------------------------------------------------===//
+// Contexts that require the element to exist.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: define {{.*}}@_Z10x_ref_bindi(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_ref_bind(int i) {
+  int &r = a[i];
+  (void)r;
+}
+
+// CHECK-LABEL: define {{.*}}@_Z11x_ref_consti(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_ref_const(int i) {
+  const int &r = a[i];
+  (void)r;
+}
+
+// CHECK-LABEL: define {{.*}}@_Z14x_ref_cleanupsi(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_ref_cleanups(int i) {
+  int &r = (T(), a[i]);
+  (void)r;
+}
+
+// CHECK-LABEL: define {{.*}}@_Z12x_ref_returni(
+// CHECK: icmp ult i64 {{.*}}, 4
+int &x_ref_return(int i) { return a[i]; }
+
+void takes_ref(int &);
+// CHECK-LABEL: define {{.*}}@_Z11x_ref_parami(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_ref_param(int i) { takes_ref(a[i]); }
+
+// CHECK-LABEL: define {{.*}}@_Z16x_ref_structuredi(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_ref_structured(int i) {
+  auto &[e] = agga[i];
+  (void)e;
+}
+
+// A default argument bound to a reference.
+int &pick(int &r = a[gidx]);
+// CHECK-LABEL: define {{.*}}@_Z13x_default_argv(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_default_arg() { pick(); }
+
+// A default member initializer bound to a reference. The check lands in the
+// constructor.
+struct R {
+  int &r = a[gidx];
+};
+// CTOR-LABEL: define {{.*}}@_ZN1RC2Ev(
+// CTOR: icmp ult i64 {{.*}}, 4
+void x_default_init() {
+  R x;
+  (void)x;
+}
+
+struct S {
+  int &r;
+  S(int i) : r(a[i]) {}
+};
+// CTOR-LABEL: define {{.*}}@_ZN1SC2Ei(
+// CTOR: icmp ult i64 {{.*}}, 4
+void x_ref_meminit(int i) {
+  S x(i);
+  (void)x;
+}
+
+// CHECK-LABEL: define {{.*}}@_Z13x_member_calli(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_member_call(int i) { ma[i].m(); }
+
+// CHECK-LABEL: define {{.*}}@_Z19x_member_call_arrowi(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_member_call_arrow(int i) { (&ma[i])->m(); }
+
+// CHECK-LABEL: define {{.*}}@_Z21x_member_call_virtuali(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_member_call_virtual(int i) { msa[i].virt(); }
+
+// TODO: confirm with reviewers. C++ [class.static]p2 says the object expression
+// is evaluated, but the call does not use the object, and whether evaluating a
+// glvalue that designates no object is undefined when nothing reads it is not
+// settled (see CWG 232). Permissive is the conservative answer; CHECK-NOT guards
+// against the member-call rule over-applying to it.
+// CHECK-LABEL: define {{.*}}@_Z20x_member_call_statici(
+// CHECK: icmp ule i64 {{.*}}, 4
+// CHECK-NOT: icmp ult
+void x_member_call_static(int i) { msa[i].stat(); }
+
+// CHECK-LABEL: define {{.*}}@_Z12x_member_doti(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_member_dot(int i) { ma[i].f = 1; }
+
+// CHECK-LABEL: define {{.*}}@_Z14x_member_arrowi(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_member_arrow(int i) { (&ma[i])->f = 1; }
+
+// CHECK-LABEL: define {{.*}}@_Z20x_trivial_assign_lhsi(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_trivial_assign_lhs(int i) { agga[i] = agglocal; }
+
+// CHECK-LABEL: define {{.*}}@_Z20x_trivial_assign_rhsi(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_trivial_assign_rhs(int i) { agglocal = agga[i]; }
+
+// The same assignment spelled as an explicit operator= call.
+// CHECK-LABEL: define {{.*}}@_Z17x_explicit_assigni(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_explicit_assign(int i) { agglocal.operator=(agga[i]); }
+
+// CHECK-LABEL: define {{.*}}@_Z17x_derived_to_basei(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_derived_to_base(int i) {
+  Base &r = da[i];
+  (void)r;
+}
+
+// CHECK-LABEL: define {{.*}}@_Z18x_static_cast_basei(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_static_cast_base(int i) {
+  Base &r = static_cast<Base &>(da[i]);
+  (void)r;
+}
+
+// The other direction.
+Base ba[4];
+// CHECK-LABEL: define {{.*}}@_Z17x_base_to_derivedi(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_base_to_derived(int i) {
+  Derived &r = static_cast<Derived &>(ba[i]);
+  (void)r;
+}
+
+// CHECK-LABEL: define {{.*}}@_Z15x_ptr_to_memberi(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_ptr_to_member(int i) { ma[i].*pmf = 1; }
+
+// CHECK-LABEL: define {{.*}}@_Z21x_ptr_to_member_arrowi(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_ptr_to_member_arrow(int i) { (&ma[i])->*pmf = 1; }
+
+// CHECK-LABEL: define {{.*}}@_Z10x_cond_armib(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_cond_arm(int i, bool c) { (c ? a[i] : a[0]) = 1; }
+
+// An assignment is a prvalue in C and an lvalue in C++, so the four cases below
+// reach a different emitter than their equivalents in the C file.
+// CHECK-LABEL: define {{.*}}@_Z7x_storei(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_store(int i) { a[i] = 1; }
+
+// CHECK-LABEL: define {{.*}}@_Z7x_pareni(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_paren(int i) { (a[i]) = 1; }
+
+// CHECK-LABEL: define {{.*}}@_Z12x_deref_addri(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_deref_addr(int i) { *&a[i] = 1; }
+
+// C has no glvalue comma, so the C file can only test the pointer
+// form, c_comma_addr.
+// CHECK-LABEL: define {{.*}}@_Z7x_commai(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_comma(int i) { (1, a[i]) = 1; }
+
+// CHECK-LABEL: define {{.*}}@_Z11x_copy_initi(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_copy_init(int i) {
+  Agg b = agga[i];
+  (void)b;
+}
+
+// The element passed by value, through the same constructor.
+void xsink(Agg);
+// CHECK-LABEL: define {{.*}}@_Z7x_byvali(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_byval(int i) { xsink(agga[i]); }
+
+// With a non-trivial copy constructor there is a real call and the argument binds
+// to `const T &`, so this is reference binding instead.
+struct NT {
+  NT();
+  NT(const NT &);
+  int x;
+};
+NT nta[4];
+void ntsink(NT);
+// A non-trivial copy constructor makes a real call, so the
+// argument binds to a reference instead.
+// CHECK-LABEL: define {{.*}}@_Z18x_byval_nontriviali(
+// CHECK: icmp ult i64 {{.*}}, 4
+void x_byval_nontrivial(int i) { ntsink(nta[i]); }
+
+//===----------------------------------------------------------------------===//
+// Address-only contexts: `ule` is required.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: define {{.*}}@_Z9xctl_addri(
+// CHECK: icmp ule i64 {{.*}}, 4
+void xctl_addr(int i) { p = &a[i]; }
+
+// CHECK-LABEL: define {{.*}}@_Z8xctl_rowi(
+// CHECK: icmp ule i64 {{.*}}, 4
+void xctl_row(int i) { p = a2[i]; }
+
+// Same expression as xctl_row.
+// CHECK-LABEL: define {{.*}}@_Z14xctl_row_elem0i(
+// CHECK: icmp ule i64 {{.*}}, 4
+void xctl_row_elem0(int i) { p = &a2[i][0]; }
+
+// CHECK-LABEL: define {{.*}}@_Z16xctl_struct_addri(
+// CHECK: icmp ule i64 {{.*}}, 4
+void xctl_struct_addr(int i) { q = &ma[i]; }
+
+// The pointer form of the conversion in x_derived_to_base, which
+// is arithmetic rather than a subobject designation.
+// CHECK-LABEL: define {{.*}}@_Z13xctl_base_ptri(
+// CHECK: icmp ule i64 {{.*}}, 4
+Base *xctl_base_ptr(int i) { return &da[i]; }


### PR DESCRIPTION
…g statement

-fsanitize=array-bounds has two comparisons available to it. Where a program uses the subscripted element, the index has to be below the bound; where it only computes an address, an index equal to the bound is fine, because one past the end is a legal address to form (C99 6.5.6p8, and 6.5.3.2p3 which makes `&a[i]` mean `a + i`). Which of the two applies is a property of the context the subscript appears in rather than of the subscript itself: `x = a[i]` and `p = &a[i]` contain the same subexpression and need different answers.

Until now the answer was inferred from the expression the check was being emitted for, by testing whether that expression happened to be a subscript. That works while the subscript is written directly where it is used and quietly gives the permissive answer otherwise, so a pair of parentheses, a cast or a `*&` was enough to lose a check -- and emitters that never consulted the helper at all, among them increments, complex and aggregate lvalues, ARC stores, member calls and reference binding, never had the information in the first place.

Work it out from the enclosing statement instead. Each function is walked once, where CodeGen starts emitting it; every step either establishes that the element must exist, clears that demand, or passes along whatever it was handed, and an answer is recorded for each expression a check can be emitted for, which the check then reads. The rules
the walk applies, each with the wording behind it, are set out in the comment on DesignatedObjectRequirement in CGExpr.cpp.

Because the answer is about the context rather than the syntax, spellings of the same access agree where they did not before: `a[i]` and `*(a + i)` are one expression by C99 6.5.2.1p2, as are `s[i].f` and `(&s[i])->f` by 6.5.2.3p4, and each pair is now checked the same way.

Two observations do most of the work. `&` and `*` are the identity for this property rather than a plus or minus one, because they change how storage is named and never whether it must exist. And an operand left as a glvalue where it is consumed is bound to a reference, where one converted to a value carries its own conversion -- which is how arguments, initializers, members and reference returns are all answered by a single rule instead of by inspecting declarations.

Over ninety contexts across C, C++, Objective-C ARC and __ptrauth are recorded in new baseline tests, which is where the behaviour change is visible: 20 of them were checked strictly before this change and 81 are now. One case moves the other way. At -O0 a nested subscript is emitted as a single address computation, and that shortcut used to force the strict comparison on the base, rejecting `&a2[i][0]` although the language permits it; with the answer coming from the context there is nothing left for the shortcut to force.

Not covered: `s->fam[i]` through counted_by keeps its own predicate, and a subscript reached only through a construct the walk does not model gets the permissive answer, which loses a check rather than reporting one the language allows.

This is the single-commit form, for review of the approach as a whole. The same change split into one commit per rule, each with its own test flips, is available separately.