### PR TITLE
[llvm][AArch64] Search for a better insertion point for PAUTH_EPILOGUE's AUT

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
+++ b/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
@@ -347,86 +347,79 @@ void AArch64PointerAuthImpl::authenticateLR(
 
   // When ArgumentStackToRestore > 0, this function received more argument
   // space than the tail callee pops. The epilogue contains an SP adjustment
-  // (e.g. "add sp, sp, #N") to discard the leftover argument space. We must
-  // authenticate *before* that adjustment so that AUTI[AB]SP sees the entry
-  // SP discriminator. Move any such SP-adjusting instructions to after the
-  // authentication instruction.
-  //
+  // (e.g. "add sp, sp, #N") to discard the leftover argument space. Look for an
+  // insertion point that minimizes the amount of instructions we have to insert
+  // to materialize the incoming SP.
+  int64_t Offset = -ArgumentStackToRestore;
+  std::pair<int64_t, MachineBasicBlock::iterator> AutI = {Offset, MBBI};
+  for (MachineInstr &MI : make_range(MBBI.getReverse(), MBB.rend())) {
+    if (!MI.getFlag(MachineInstr::FrameDestroy))
+      break;
+
+    if ((MI.getOpcode() == AArch64::ADDXri ||
+        MI.getOpcode() == AArch64::SUBXri) &&
+        MI.getOperand(0).getReg() == AArch64::SP &&
+        MI.getOperand(1).getReg() == AArch64::SP) {
+      int64_t Imm = MI.getOperand(2).getImm()
+                    << AArch64_AM::getShiftValue(MI.getOperand(3).getImm());
+      Offset += MI.getOpcode() == AArch64::ADDXri ? Imm : -Imm;
+    }
+
+    if (std::abs(Offset) < std::abs(AutI.first))
+      AutI = {Offset, MI};
+  }
+
+  // If we found an insertion point with a net zero offset on SP, we can use
+  // an AUT form with a hardcoded SP discriminator.
+  if (AutI.first == 0) {
+    if (MFnI->branchProtectionPAuthLR() && Subtarget->hasPAuthLR()) {
+      assert(PACSym && "No PAC instruction to refer to");
+      BuildMI(MBB, AutI.second, DL,
+              TII->get(UseBKey ? AArch64::AUTIBSPPCi : AArch64::AUTIASPPCi))
+          .addSym(PACSym)
+          .setMIFlag(MachineInstr::FrameDestroy);
+      emitAUTCFI(MBB, AutI.second, EmitAsyncCFI);
+    } else {
+      if (MFnI->branchProtectionPAuthLR()) {
+        emitEpiloguePACSymOffsetIntoReg(*TII, MBB, AutI.second, DL, PACSym,
+                                        AArch64::X16);
+
+        BuildMI(MBB, AutI.second, DL, TII->get(AArch64::PACM))
+            .setMIFlag(MachineInstr::FrameDestroy);
+      }
+      BuildMI(MBB, AutI.second, DL,
+              TII->get(UseBKey ? AArch64::AUTIBSP : AArch64::AUTIASP))
+          .setMIFlag(MachineInstr::FrameDestroy);
+      emitAUTCFI(MBB, AutI.second, EmitAsyncCFI);
+    }
+
+    if (NeedsWinCFI) {
+      assert(UseBKey &&
+            "Windows SEH PAC unwind info only supports B-key signing");
+      BuildMI(MBB, AutI.second, DL, TII->get(AArch64::SEH_PACSignLR))
+          .setMIFlag(MachineInstr::FrameDestroy);
+    }
+
+    return;
+  }
+
   // When ArgumentStackToRestore < 0, the tail callee pops more argument space
   // than this function received, so after the frame teardown, SP is below the
   // entry SP used as the signing modifier.
   //
   // We cannot simply bump SP first and then use AUTI[AB]SP with the bumped
   // value, because the live arguments would fall below SP and potentially
-  // outside the red-zone. Collect those SP adjustments in case we need to move
-  // them after the AUT.
-  int64_t Offset = -ArgumentStackToRestore;
-  SmallVector<MachineInstr *, 2> SPMods;
-  if (ArgumentStackToRestore > 0) {
-    for (MachineInstr &MI : make_range(MBBI.getReverse(), MBB.rend())) {
-      if (!MI.getFlag(MachineInstr::FrameDestroy))
-        break;
-      if ((MI.getOpcode() == AArch64::ADDXri ||
-           MI.getOpcode() == AArch64::SUBXri) &&
-          MI.getOperand(0).getReg() == AArch64::SP &&
-          MI.getOperand(1).getReg() == AArch64::SP) {
-        SPMods.push_back(&MI);
-        int64_t Imm = MI.getOperand(2).getImm()
-                      << AArch64_AM::getShiftValue(MI.getOperand(3).getImm());
-        Offset += MI.getOpcode() == AArch64::ADDXri ? Imm : -Imm;
-      }
-    }
-  }
-
-  for (auto *MI : SPMods)
-    MI->removeFromParent();
-
-  // If there is a net zero offset on SP, we can use an AUT form with a
-  // hardcoded SP discriminator.
-  if (!Offset) {
-    if (MFnI->branchProtectionPAuthLR() && Subtarget->hasPAuthLR()) {
-      assert(PACSym && "No PAC instruction to refer to");
-      BuildMI(MBB, MBBI, DL,
-              TII->get(UseBKey ? AArch64::AUTIBSPPCi : AArch64::AUTIASPPCi))
-          .addSym(PACSym)
-          .setMIFlag(MachineInstr::FrameDestroy);
-      emitAUTCFI(MBB, MBBI, EmitAsyncCFI);
-    } else {
-      if (MFnI->branchProtectionPAuthLR()) {
-        emitEpiloguePACSymOffsetIntoReg(*TII, MBB, MBBI, DL, PACSym,
-                                        AArch64::X16);
-
-        BuildMI(MBB, MBBI, DL, TII->get(AArch64::PACM))
-            .setMIFlag(MachineInstr::FrameDestroy);
-      }
-      BuildMI(MBB, MBBI, DL,
-              TII->get(UseBKey ? AArch64::AUTIBSP : AArch64::AUTIASP))
-          .setMIFlag(MachineInstr::FrameDestroy);
-      emitAUTCFI(MBB, MBBI, EmitAsyncCFI);
-    }
-
-    if (NeedsWinCFI) {
-      assert(UseBKey &&
-             "Windows SEH PAC unwind info only supports B-key signing");
-      BuildMI(MBB, MBBI, DL, TII->get(AArch64::SEH_PACSignLR))
-          .setMIFlag(MachineInstr::FrameDestroy);
-    }
-
-    for (auto *MI : SPMods)
-      MBB.insert(MBBI, MI);
-
-    return;
-  }
-
-  // Otherwise there is an offset to the incoming SP, and we can't use the aut
+  // outside the red-zone.
+  //
+  // At this point there is an offset to the incoming SP, and we can't use the aut
   // variants that hard-code SP. Reconstruct entry SP in x16 and authenticate
   // using AUTI[AB]1716 (x17=LR, x16=entry_SP).
-  emitFrameOffset(MBB, MBBI, DL, AArch64::X16, AArch64::SP,
-                  StackOffset::getFixed(Offset), TII,
+  emitFrameOffset(MBB, AutI.second, DL, AArch64::X16, AArch64::SP,
+                  StackOffset::getFixed(AutI.first), TII,
                   MachineInstr::FrameDestroy);
 
   auto emitMOV = [&](Register Dst, Register Src) {
-    BuildMI(MBB, MBBI, DL, TII->get(AArch64::ORRXrs), Dst)
+    BuildMI(MBB, AutI.second, DL, TII->get(AArch64::ORRXrs), Dst)
         .addReg(AArch64::XZR)
         .addReg(Src)
         .addImm(0)
@@ -437,48 +430,48 @@ void AArch64PointerAuthImpl::authenticateLR(
     emitMOV(AArch64::X17, AArch64::LR);
 
     assert(PACSym && "No PAC instruction to refer to");
-    emitEpiloguePACSymOffsetIntoReg(*TII, MBB, MBBI, DL, PACSym, AArch64::X15);
+    emitEpiloguePACSymOffsetIntoReg(*TII, MBB, AutI.second, DL, PACSym, AArch64::X15);
 
     unsigned AutOpc = UseBKey ? AArch64::AUTIB171615 : AArch64::AUTIA171615;
-    BuildMI(MBB, MBBI, DL, TII->get(AutOpc))
+    BuildMI(MBB, AutI.second, DL, TII->get(AutOpc))
         .setMIFlag(MachineInstr::FrameDestroy);
-    emitAUTCFI(MBB, MBBI, EmitAsyncCFI);
+    emitAUTCFI(MBB, AutI.second, EmitAsyncCFI);
 
     emitMOV(AArch64::LR, AArch64::X17);
   } else if (MFnI->branchProtectionPAuthLR()) {
     emitMOV(AArch64::X17, AArch64::LR);
 
     assert(PACSym && "No PAC instruction to refer to");
-    emitEpiloguePACSymOffsetIntoReg(*TII, MBB, MBBI, DL, PACSym, AArch64::X15);
+    emitEpiloguePACSymOffsetIntoReg(*TII, MBB, AutI.second, DL, PACSym, AArch64::X15);
 
     // The PACM hint-space instruction modifies the following AUTI[AB]1716
     // to optionally take x15 as an extra operand depending on the
     // presence of +pauth-lr at runtime. On machines without +pauth-lr, it
     // behaves as a nop, and the address of the PACI[AB]SP in x15 is
     // ignored.
-    BuildMI(MBB, MBBI, DL, TII->get(AArch64::PACM))
+    BuildMI(MBB, AutI.second, DL, TII->get(AArch64::PACM))
         .setMIFlag(MachineInstr::FrameDestroy);
 
     unsigned AutOpc = UseBKey ? AArch64::AUTIB1716 : AArch64::AUTIA1716;
-    BuildMI(MBB, MBBI, DL, TII->get(AutOpc))
+    BuildMI(MBB, AutI.second, DL, TII->get(AutOpc))
         .setMIFlag(MachineInstr::FrameDestroy);
-    emitAUTCFI(MBB, MBBI, EmitAsyncCFI);
+    emitAUTCFI(MBB, AutI.second, EmitAsyncCFI);
 
     emitMOV(AArch64::LR, AArch64::X17);
   } else if (Subtarget->hasPAuth()) {
-    BuildMI(MBB, MBBI, DL, TII->get(UseBKey ? AArch64::AUTIB : AArch64::AUTIA),
+    BuildMI(MBB, AutI.second, DL, TII->get(UseBKey ? AArch64::AUTIB : AArch64::AUTIA),
             AArch64::LR)
         .addUse(AArch64::LR)
         .addUse(AArch64::X16)
         .setMIFlag(MachineInstr::FrameDestroy);
-    emitAUTCFI(MBB, MBBI, EmitAsyncCFI);
+    emitAUTCFI(MBB, AutI.second, EmitAsyncCFI);
   } else {
     emitMOV(AArch64::X17, AArch64::LR);
 
     unsigned AutOpc = UseBKey ? AArch64::AUTIB1716 : AArch64::AUTIA1716;
-    BuildMI(MBB, MBBI, DL, TII->get(AutOpc))
+    BuildMI(MBB, AutI.second, DL, TII->get(AutOpc))
         .setMIFlag(MachineInstr::FrameDestroy);
-    emitAUTCFI(MBB, MBBI, EmitAsyncCFI);
+    emitAUTCFI(MBB, AutI.second, EmitAsyncCFI);
 
     emitMOV(AArch64::LR, AArch64::X17);
   }
@@ -486,12 +479,9 @@ void AArch64PointerAuthImpl::authenticateLR(
   if (NeedsWinCFI) {
     assert(UseBKey &&
            "Windows SEH PAC unwind info only supports B-key signing");
-    BuildMI(MBB, MBBI, DL, TII->get(AArch64::SEH_PACSignLR))
+    BuildMI(MBB, AutI.second, DL, TII->get(AArch64::SEH_PACSignLR))
         .setMIFlag(MachineInstr::FrameDestroy);
   }
-
-  for (auto *MI : SPMods)
-    MBB.insert(MBBI, MI);
 }
 
 unsigned llvm::AArch64PAuth::getCheckerSizeInBytes(AuthCheckMethod Method) {

--- a/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
+++ b/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
@@ -336,8 +336,7 @@ void AArch64PointerAuthImpl::authenticateLR(
         BuildMI(MBB, MBBI, DL, TII->get(AArch64::PACM))
             .setMIFlag(MachineInstr::FrameDestroy);
       }
-      BuildMI(MBB, TI, DL,
-              TII->get(UseBKey ? AArch64::RETAB : AArch64::RETAA))
+      BuildMI(MBB, TI, DL, TII->get(UseBKey ? AArch64::RETAB : AArch64::RETAA))
           .copyImplicitOps(*MBBI)
           .setMIFlag(MachineInstr::FrameDestroy);
     }
@@ -357,7 +356,7 @@ void AArch64PointerAuthImpl::authenticateLR(
       break;
 
     if ((MI.getOpcode() == AArch64::ADDXri ||
-        MI.getOpcode() == AArch64::SUBXri) &&
+         MI.getOpcode() == AArch64::SUBXri) &&
         MI.getOperand(0).getReg() == AArch64::SP &&
         MI.getOperand(1).getReg() == AArch64::SP) {
       int64_t Imm = MI.getOperand(2).getImm()
@@ -395,7 +394,7 @@ void AArch64PointerAuthImpl::authenticateLR(
 
     if (NeedsWinCFI) {
       assert(UseBKey &&
-            "Windows SEH PAC unwind info only supports B-key signing");
+             "Windows SEH PAC unwind info only supports B-key signing");
       BuildMI(MBB, AutI.second, DL, TII->get(AArch64::SEH_PACSignLR))
           .setMIFlag(MachineInstr::FrameDestroy);
     }
@@ -411,9 +410,9 @@ void AArch64PointerAuthImpl::authenticateLR(
   // value, because the live arguments would fall below SP and potentially
   // outside the red-zone.
   //
-  // At this point there is an offset to the incoming SP, and we can't use the aut
-  // variants that hard-code SP. Reconstruct entry SP in x16 and authenticate
-  // using AUTI[AB]1716 (x17=LR, x16=entry_SP).
+  // At this point there is an offset to the incoming SP, and we can't use the
+  // aut variants that hard-code SP. Reconstruct entry SP in x16 and
+  // authenticate using AUTI[AB]1716 (x17=LR, x16=entry_SP).
   emitFrameOffset(MBB, AutI.second, DL, AArch64::X16, AArch64::SP,
                   StackOffset::getFixed(AutI.first), TII,
                   MachineInstr::FrameDestroy);
@@ -430,7 +429,8 @@ void AArch64PointerAuthImpl::authenticateLR(
     emitMOV(AArch64::X17, AArch64::LR);
 
     assert(PACSym && "No PAC instruction to refer to");
-    emitEpiloguePACSymOffsetIntoReg(*TII, MBB, AutI.second, DL, PACSym, AArch64::X15);
+    emitEpiloguePACSymOffsetIntoReg(*TII, MBB, AutI.second, DL, PACSym,
+                                    AArch64::X15);
 
     unsigned AutOpc = UseBKey ? AArch64::AUTIB171615 : AArch64::AUTIA171615;
     BuildMI(MBB, AutI.second, DL, TII->get(AutOpc))
@@ -442,7 +442,8 @@ void AArch64PointerAuthImpl::authenticateLR(
     emitMOV(AArch64::X17, AArch64::LR);
 
     assert(PACSym && "No PAC instruction to refer to");
-    emitEpiloguePACSymOffsetIntoReg(*TII, MBB, AutI.second, DL, PACSym, AArch64::X15);
+    emitEpiloguePACSymOffsetIntoReg(*TII, MBB, AutI.second, DL, PACSym,
+                                    AArch64::X15);
 
     // The PACM hint-space instruction modifies the following AUTI[AB]1716
     // to optionally take x15 as an extra operand depending on the
@@ -459,8 +460,8 @@ void AArch64PointerAuthImpl::authenticateLR(
 
     emitMOV(AArch64::LR, AArch64::X17);
   } else if (Subtarget->hasPAuth()) {
-    BuildMI(MBB, AutI.second, DL, TII->get(UseBKey ? AArch64::AUTIB : AArch64::AUTIA),
-            AArch64::LR)
+    BuildMI(MBB, AutI.second, DL,
+            TII->get(UseBKey ? AArch64::AUTIB : AArch64::AUTIA), AArch64::LR)
         .addUse(AArch64::LR)
         .addUse(AArch64::X16)
         .setMIFlag(MachineInstr::FrameDestroy);

--- a/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
+++ b/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
@@ -309,6 +309,42 @@ void AArch64PointerAuthImpl::authenticateLR(
       MF.getSubtarget().getFrameLowering());
   int64_t ArgumentStackToRestore = AFL.getArgumentStackToRestore(MF, MBB);
 
+  // The AUTIASP instruction assembles to a hint instruction before v8.3a so
+  // this instruction can safely be used for any v8a architecture.
+  // From v8.3a onwards there are optimised authenticate LR and return
+  // instructions, namely RETA{A,B}, that can be used instead. In this case
+  // the DW_CFA_AARCH64_negate_ra_state can't be emitted. Additionally,
+  // RET{A,B} requires the SP to match its incoming value on entry to the
+  // function.
+  bool TerminatorIsCombinable = TI != MBB.end() &&
+                                TI->getOpcode() == AArch64::RET &&
+                                ArgumentStackToRestore == 0;
+
+  if (Subtarget->hasPAuth() && TerminatorIsCombinable && !NeedsWinCFI &&
+      !MF.getFunction().hasFnAttribute(Attribute::ShadowCallStack)) {
+    if (MFnI->branchProtectionPAuthLR() && Subtarget->hasPAuthLR()) {
+      assert(PACSym && "No PAC instruction to refer to");
+      BuildMI(MBB, TI, DL,
+              TII->get(UseBKey ? AArch64::RETABSPPCi : AArch64::RETAASPPCi))
+          .addSym(PACSym)
+          .copyImplicitOps(*MBBI)
+          .setMIFlag(MachineInstr::FrameDestroy);
+    } else {
+      if (MFnI->branchProtectionPAuthLR()) {
+        emitEpiloguePACSymOffsetIntoReg(*TII, MBB, MBBI, DL, PACSym,
+                                        AArch64::X16);
+        BuildMI(MBB, MBBI, DL, TII->get(AArch64::PACM))
+            .setMIFlag(MachineInstr::FrameDestroy);
+      }
+      BuildMI(MBB, TI, DL,
+              TII->get(UseBKey ? AArch64::RETAB : AArch64::RETAA))
+          .copyImplicitOps(*MBBI)
+          .setMIFlag(MachineInstr::FrameDestroy);
+    }
+    MBB.erase(TI);
+    return;
+  }
+
   // When ArgumentStackToRestore > 0, this function received more argument
   // space than the tail callee pops. The epilogue contains an SP adjustment
   // (e.g. "add sp, sp, #N") to discard the leftover argument space. We must
@@ -342,48 +378,12 @@ void AArch64PointerAuthImpl::authenticateLR(
     }
   }
 
-  // If there will not be an SP bump afterward, we can use an AUT or RET form
-  // with a hardcoded SP discriminator.
+  for (auto *MI : SPMods)
+    MI->removeFromParent();
+
+  // If there is a net zero offset on SP, we can use an AUT form with a
+  // hardcoded SP discriminator.
   if (!Offset) {
-    // The AUTIASP instruction assembles to a hint instruction before v8.3a so
-    // this instruction can safely be used for any v8a architecture.
-    // From v8.3a onwards there are optimised authenticate LR and return
-    // instructions, namely RETA{A,B}, that can be used instead. In this case
-    // the DW_CFA_AARCH64_negate_ra_state can't be emitted. Additionally,
-    // RET{A,B} requires the SP to match its incoming value on entry to the
-    // function.
-    bool TerminatorIsCombinable = TI != MBB.end() &&
-                                  TI->getOpcode() == AArch64::RET &&
-                                  ArgumentStackToRestore == 0;
-
-    if (Subtarget->hasPAuth() && TerminatorIsCombinable && !NeedsWinCFI &&
-        !MF.getFunction().hasFnAttribute(Attribute::ShadowCallStack)) {
-      if (MFnI->branchProtectionPAuthLR() && Subtarget->hasPAuthLR()) {
-        assert(PACSym && "No PAC instruction to refer to");
-        BuildMI(MBB, TI, DL,
-                TII->get(UseBKey ? AArch64::RETABSPPCi : AArch64::RETAASPPCi))
-            .addSym(PACSym)
-            .copyImplicitOps(*MBBI)
-            .setMIFlag(MachineInstr::FrameDestroy);
-      } else {
-        if (MFnI->branchProtectionPAuthLR()) {
-          emitEpiloguePACSymOffsetIntoReg(*TII, MBB, MBBI, DL, PACSym,
-                                          AArch64::X16);
-          BuildMI(MBB, MBBI, DL, TII->get(AArch64::PACM))
-              .setMIFlag(MachineInstr::FrameDestroy);
-        }
-        BuildMI(MBB, TI, DL,
-                TII->get(UseBKey ? AArch64::RETAB : AArch64::RETAA))
-            .copyImplicitOps(*MBBI)
-            .setMIFlag(MachineInstr::FrameDestroy);
-      }
-      MBB.erase(TI);
-      return;
-    }
-
-    for (auto *MI : SPMods)
-      MI->removeFromParent();
-
     if (MFnI->branchProtectionPAuthLR() && Subtarget->hasPAuthLR()) {
       assert(PACSym && "No PAC instruction to refer to");
       BuildMI(MBB, MBBI, DL,
@@ -417,9 +417,6 @@ void AArch64PointerAuthImpl::authenticateLR(
 
     return;
   }
-
-  for (auto *MI : SPMods)
-    MI->removeFromParent();
 
   // Otherwise there is an offset to the incoming SP, and we can't use the aut
   // variants that hard-code SP. Reconstruct entry SP in x16 and authenticate

--- a/llvm/test/CodeGen/AArch64/ptrauth-tail-call-stackadjust.ll
+++ b/llvm/test/CodeGen/AArch64/ptrauth-tail-call-stackadjust.ll
@@ -21,9 +21,9 @@ define swifttailcc void @test_frame_and_args(%large_struct %s) #0 {
 ; CHECK-NEXT:    .cfi_offset w30, -16
 ; CHECK-NEXT:    bl _external_func
 ; CHECK-NEXT:    ldr x30, [sp, #64] ; 8-byte Reload
-; CHECK-NEXT:    add x16, sp, #80
-; CHECK-NEXT:    autib x30, x16
 ; CHECK-NEXT:    add sp, sp, #144
+; CHECK-NEXT:    sub x16, sp, #64
+; CHECK-NEXT:    autib x30, x16
 ; CHECK-NEXT:    ret
 entry:
   %local1 = alloca [32 x i8], align 8
@@ -56,14 +56,53 @@ define swifttailcc void @test_frame_and_large_args(%large_struct2 %s) #0 {
 ; CHECK-NEXT:    ldp x28, x30, [sp, #32] ; 16-byte Folded Reload
 ; CHECK-NEXT:    add x16, sp, #48
 ; CHECK-NEXT:    autib x30, x16
-; CHECK-NEXT:    add sp, sp, #688
 ; CHECK-NEXT:    add sp, sp, #1, lsl #12 ; =4096
+; CHECK-NEXT:    add sp, sp, #688
 ; CHECK-NEXT:    ret
 entry:
   %local1 = alloca [32 x i8], align 8
   call void @llvm.lifetime.start.p0(i64 32, ptr %local1)
   call void @external_func()
   call void @llvm.lifetime.end.p0(i64 32, ptr %local1)
+  ret void
+}
+
+declare swifttailcc void @callee_stack0()
+declare void @use(ptr)
+
+define swifttailcc void @test_frame_and_args_split_by_csr_reload([8 x i64], i64 %x) "sign-return-address"="all" "frame-pointer"="all" uwtable(async) {
+; CHECK-LABEL: test_frame_and_args_split_by_csr_reload:
+; CHECK:       ; %bb.0: ; %entry
+; CHECK-NEXT:    paciasp
+; CHECK-NEXT:    str x28, [sp, #-32]! ; 8-byte Folded Spill
+; CHECK-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-NEXT:    stp x29, x30, [sp, #16] ; 16-byte Folded Spill
+; CHECK-NEXT:    add x29, sp, #16
+; CHECK-NEXT:    .cfi_def_cfa w29, 16
+; CHECK-NEXT:    .cfi_offset w30, -8
+; CHECK-NEXT:    .cfi_offset w29, -16
+; CHECK-NEXT:    .cfi_offset w28, -32
+; CHECK-NEXT:    sub sp, sp, #1, lsl #12 ; =4096
+; CHECK-NEXT:    sub sp, sp, #3904
+; CHECK-NEXT:    mov x0, sp
+; CHECK-NEXT:    bl _use
+; CHECK-NEXT:    add sp, sp, #1, lsl #12 ; =4096
+; CHECK-NEXT:    add sp, sp, #3904
+; CHECK-NEXT:    .cfi_def_cfa wsp, 32
+; CHECK-NEXT:    ldp x29, x30, [sp, #16] ; 16-byte Folded Reload
+; CHECK-NEXT:    ldr x28, [sp], #32 ; 8-byte Folded Reload
+; CHECK-NEXT:    .cfi_def_cfa_offset 0
+; CHECK-NEXT:    autiasp
+; CHECK-NEXT:    add sp, sp, #16
+; CHECK-NEXT:    .cfi_def_cfa_offset -16
+; CHECK-NEXT:    .cfi_restore w30
+; CHECK-NEXT:    .cfi_restore w29
+; CHECK-NEXT:    .cfi_restore w28
+; CHECK-NEXT:    b _callee_stack0
+entry:
+  %buf = alloca [8000 x i8], align 16
+  call void @use(ptr %buf)
+  tail call swifttailcc void @callee_stack0()
   ret void
 }
 

--- a/llvm/test/CodeGen/AArch64/swifttail-ptrauth.ll
+++ b/llvm/test/CodeGen/AArch64/swifttail-ptrauth.ll
@@ -108,9 +108,6 @@ define swifttailcc void @caller_to0_from8([8 x i64], i64) "branch-protection-pau
 ; CHECK-NEXT:    .cfi_def_cfa wsp, 16
 ; CHECK-NEXT:    ldp x29, x30, [sp], #16 // 16-byte Folded Reload
 ; CHECK-NEXT:    .cfi_def_cfa_offset 0
-; CHECK-NEXT:    .cfi_def_cfa_offset -16
-; CHECK-NEXT:    .cfi_restore w30
-; CHECK-NEXT:    .cfi_restore w29
 
 ; COMPAT-NEXT:   adrp x16, .Ltmp1
 ; COMPAT-NEXT:   add x16, x16, :lo12:.Ltmp1
@@ -131,6 +128,9 @@ define swifttailcc void @caller_to0_from8([8 x i64], i64) "branch-protection-pau
 ; PAUTH-NEXT:    .cfi_negate_ra_state
 
 ; CHECK-NEXT:    add sp, sp, #16
+; CHECK-NEXT:    .cfi_def_cfa_offset -16
+; CHECK-NEXT:    .cfi_restore w30
+; CHECK-NEXT:    .cfi_restore w29
 ; CHECK-NEXT:    b callee_stack0
   tail call swifttailcc void @callee_stack0()
   ret void
@@ -245,9 +245,6 @@ define swifttailcc void @crash_tc(i1 %c, [8 x i64] %pad, i64 %x) "branch-protect
 ; CHECK-NEXT:          .cfi_def_cfa wsp, 16
 ; CHECK-NEXT:          ldp     x29, x30, [sp], #16
 ; CHECK-NEXT:          .cfi_def_cfa_offset 0
-; CHECK-NEXT:          .cfi_def_cfa_offset -80
-; CHECK-NEXT:          .cfi_restore w30
-; CHECK-NEXT:          .cfi_restore w29
 
 ; COMPAT-NEXT:         adrp    x16, .Ltmp3
 ; COMPAT-NEXT:         add     x16, x16, :lo12:.Ltmp3
@@ -268,6 +265,9 @@ define swifttailcc void @crash_tc(i1 %c, [8 x i64] %pad, i64 %x) "branch-protect
 ; PAUTH-NEXT:          .cfi_negate_ra_state
 
 ; CHECK-NEXT:          add     sp, sp, #80
+; CHECK-NEXT:          .cfi_def_cfa_offset -80
+; CHECK-NEXT:          .cfi_restore w30
+; CHECK-NEXT:          .cfi_restore w29
 ; CHECK-NEXT:          ret
 ; CHECK-NEXT:  .LBB3_2:
 ; CHECK-NEXT:          .cfi_restore_state
@@ -275,9 +275,6 @@ define swifttailcc void @crash_tc(i1 %c, [8 x i64] %pad, i64 %x) "branch-protect
 ; CHECK-NEXT:          .cfi_def_cfa wsp, 16
 ; CHECK-NEXT:          ldp     x29, x30, [sp], #16
 ; CHECK-NEXT:          .cfi_def_cfa_offset 0
-; CHECK-NEXT:          .cfi_def_cfa_offset -80
-; CHECK-NEXT:          .cfi_restore w30
-; CHECK-NEXT:          .cfi_restore w29
 
 ; COMPAT-NEXT:         adrp    x16, .Ltmp3
 ; COMPAT-NEXT:         add     x16, x16, :lo12:.Ltmp3
@@ -298,6 +295,9 @@ define swifttailcc void @crash_tc(i1 %c, [8 x i64] %pad, i64 %x) "branch-protect
 ; PAUTH-NEXT:          .cfi_negate_ra_state
 
 ; CHECK-NEXT:          add     sp, sp, #80
+; CHECK-NEXT:          .cfi_def_cfa_offset -80
+; CHECK-NEXT:          .cfi_restore w30
+; CHECK-NEXT:          .cfi_restore w29
 ; CHECK-NEXT:          b       callee_stack0
 
 entry:


### PR DESCRIPTION
... rather than moving sp modifying adds/subs around it. This fixes a subtle bug
where those instructions were being moved across loads that rematerialize CSRs.
    
rdar://185540596