### PR TITLE
Add conduct email contact for the CODE_OF_CONDUCT page

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,5 @@
 # Code of Conduct
 
 The LLVM Community Code of Conduct can be found at https://llvm.org/docs/CodeOfConduct.html.
+For inquiries about moderation, bans, or other Code of Conduct issues, please
+contact the LLVM Code of Conduct Committee at conduct@llvm.org

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 # Code of Conduct
 
 The LLVM Community Code of Conduct can be found at https://llvm.org/docs/CodeOfConduct.html.
-For inquiries about moderation, bans, or other Code of Conduct issues, please
+For inquiries about moderation, bans, or related issues, please
 contact the LLVM Code of Conduct Committee at conduct@llvm.org


### PR DESCRIPTION
This turns out to be the landing page users get linked to when
(temporarily or permanently) banned. And since there is no way to
privately message through GitHub, this is basically where they end up
and having an immediate way to reach the CoC Committee to discuss those
moderation actions is important.
