### PR TITLE
[libc] Add stub for confstr

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -392,6 +392,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.access
     libc.src.unistd.chdir
     libc.src.unistd.chown
+    libc.src.unistd.confstr
     libc.src.unistd.close
     libc.src.unistd.dup
     libc.src.unistd.dup2
@@ -1373,11 +1374,6 @@ if(LLVM_LIBC_FULL_BUILD)
 endif()
 
 if(LLVM_LIBC_ENABLE_EXPERIMENTAL_ENTRYPOINTS)
-  list(APPEND TARGET_LIBC_ENTRYPOINTS
-    # unistd.h entrypoints
-    libc.src.unistd.confstr
-  )
-
   if(LLVM_LIBC_FULL_BUILD)
     list(APPEND TARGET_LIBC_ENTRYPOINTS
       # net/if.h entrypoints

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -1373,6 +1373,11 @@ if(LLVM_LIBC_FULL_BUILD)
 endif()
 
 if(LLVM_LIBC_ENABLE_EXPERIMENTAL_ENTRYPOINTS)
+  list(APPEND TARGET_LIBC_ENTRYPOINTS
+    # unistd.h entrypoints
+    libc.src.unistd.confstr
+  )
+
   if(LLVM_LIBC_FULL_BUILD)
     list(APPEND TARGET_LIBC_ENTRYPOINTS
       # net/if.h entrypoints

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -661,6 +661,11 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
 )
 
 if(LLVM_LIBC_ENABLE_EXPERIMENTAL_ENTRYPOINTS)
+  list(APPEND TARGET_LIBC_ENTRYPOINTS
+    # unistd.h entrypoints
+    libc.src.unistd.confstr
+  )
+
   if(LLVM_LIBC_FULL_BUILD)
     list(APPEND TARGET_LIBC_ENTRYPOINTS
       # regex.h entrypoints

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -228,6 +228,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.access
     libc.src.unistd.chdir
     libc.src.unistd.chown
+    libc.src.unistd.confstr
     libc.src.unistd.close
     libc.src.unistd.dup
     libc.src.unistd.dup2
@@ -661,11 +662,6 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
 )
 
 if(LLVM_LIBC_ENABLE_EXPERIMENTAL_ENTRYPOINTS)
-  list(APPEND TARGET_LIBC_ENTRYPOINTS
-    # unistd.h entrypoints
-    libc.src.unistd.confstr
-  )
-
   if(LLVM_LIBC_FULL_BUILD)
     list(APPEND TARGET_LIBC_ENTRYPOINTS
       # regex.h entrypoints

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -422,6 +422,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.access
     libc.src.unistd.chdir
     libc.src.unistd.chown
+    libc.src.unistd.confstr
     libc.src.unistd.close
     libc.src.unistd.dup
     libc.src.unistd.dup2
@@ -1591,11 +1592,6 @@ if(LLVM_LIBC_FULL_BUILD)
 endif()
 
 if(LLVM_LIBC_ENABLE_EXPERIMENTAL_ENTRYPOINTS)
-  list(APPEND TARGET_LIBC_ENTRYPOINTS
-    # unistd.h entrypoints
-    libc.src.unistd.confstr
-  )
-
   if(LLVM_LIBC_FULL_BUILD)
     list(APPEND TARGET_LIBC_ENTRYPOINTS
       # net/if.h entrypoints

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -1591,6 +1591,11 @@ if(LLVM_LIBC_FULL_BUILD)
 endif()
 
 if(LLVM_LIBC_ENABLE_EXPERIMENTAL_ENTRYPOINTS)
+  list(APPEND TARGET_LIBC_ENTRYPOINTS
+    # unistd.h entrypoints
+    libc.src.unistd.confstr
+  )
+
   if(LLVM_LIBC_FULL_BUILD)
     list(APPEND TARGET_LIBC_ENTRYPOINTS
       # net/if.h entrypoints

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1604,6 +1604,11 @@ if(LLVM_LIBC_FULL_BUILD)
 endif()
 
 if(LLVM_LIBC_ENABLE_EXPERIMENTAL_ENTRYPOINTS)
+  list(APPEND TARGET_LIBC_ENTRYPOINTS
+    # unistd.h entrypoints
+    libc.src.unistd.confstr
+  )
+
   if(LLVM_LIBC_FULL_BUILD)
     list(APPEND TARGET_LIBC_ENTRYPOINTS
       # net/if.h entrypoints

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -431,6 +431,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.access
     libc.src.unistd.chdir
     libc.src.unistd.chown
+    libc.src.unistd.confstr
     libc.src.unistd.close
     libc.src.unistd.dup
     libc.src.unistd.dup2
@@ -1604,11 +1605,6 @@ if(LLVM_LIBC_FULL_BUILD)
 endif()
 
 if(LLVM_LIBC_ENABLE_EXPERIMENTAL_ENTRYPOINTS)
-  list(APPEND TARGET_LIBC_ENTRYPOINTS
-    # unistd.h entrypoints
-    libc.src.unistd.confstr
-  )
-
   if(LLVM_LIBC_FULL_BUILD)
     list(APPEND TARGET_LIBC_ENTRYPOINTS
       # net/if.h entrypoints

--- a/libc/include/unistd.yaml
+++ b/libc/include/unistd.yaml
@@ -103,6 +103,14 @@ functions:
       - type: const char *
       - type: uid_t
       - type: gid_t
+  - name: confstr
+    standards:
+      - posix
+    return_type: size_t
+    arguments:
+      - type: int
+      - type: char *
+      - type: size_t
   - name: close
     standards:
       - posix

--- a/libc/src/unistd/CMakeLists.txt
+++ b/libc/src/unistd/CMakeLists.txt
@@ -48,6 +48,19 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  confstr
+  SRCS
+    confstr.cpp
+  HDRS
+    confstr.h
+  DEPENDS
+    libc.hdr.types.size_t
+    libc.hdr.unistd_macros
+    libc.src.__support.common
+    libc.src.__support.macros.config
+)
+
+add_entrypoint_object(
   close
   ALIAS
   DEPENDS

--- a/libc/src/unistd/CMakeLists.txt
+++ b/libc/src/unistd/CMakeLists.txt
@@ -54,9 +54,11 @@ add_entrypoint_object(
   HDRS
     confstr.h
   DEPENDS
+    libc.hdr.errno_macros
     libc.hdr.types.size_t
     libc.hdr.unistd_macros
     libc.src.__support.common
+    libc.src.__support.libc_errno
     libc.src.__support.macros.config
 )
 

--- a/libc/src/unistd/CMakeLists.txt
+++ b/libc/src/unistd/CMakeLists.txt
@@ -60,6 +60,7 @@ add_entrypoint_object(
     libc.src.__support.common
     libc.src.__support.libc_errno
     libc.src.__support.macros.config
+    libc.src.errno.errno
 )
 
 add_entrypoint_object(

--- a/libc/src/unistd/confstr.cpp
+++ b/libc/src/unistd/confstr.cpp
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation of confstr
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/unistd/confstr.h"
+
+#include "hdr/types/size_t.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(size_t, confstr, (int, char *, size_t)) { return 0; }
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/unistd/confstr.cpp
+++ b/libc/src/unistd/confstr.cpp
@@ -15,6 +15,7 @@
 
 #include "hdr/errno_macros.h"
 #include "hdr/types/size_t.h"
+#include "hdr/unistd_macros.h"
 #include "src/__support/common.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"

--- a/libc/src/unistd/confstr.cpp
+++ b/libc/src/unistd/confstr.cpp
@@ -13,12 +13,17 @@
 
 #include "src/unistd/confstr.h"
 
+#include "hdr/errno_macros.h"
 #include "hdr/types/size_t.h"
 #include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(size_t, confstr, (int, char *, size_t)) { return 0; }
+LLVM_LIBC_FUNCTION(size_t, confstr, (int, char *, size_t)) {
+  libc_errno = EINVAL;
+  return 0;
+}
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/unistd/confstr.h
+++ b/libc/src/unistd/confstr.h
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for confstr
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_UNISTD_CONFSTR_H
+#define LLVM_LIBC_SRC_UNISTD_CONFSTR_H
+
+#include "hdr/types/size_t.h"
+#include "hdr/unistd_macros.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+size_t confstr(int name, char *buf, size_t len);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_UNISTD_CONFSTR_H

--- a/libc/src/unistd/confstr.h
+++ b/libc/src/unistd/confstr.h
@@ -15,7 +15,6 @@
 #define LLVM_LIBC_SRC_UNISTD_CONFSTR_H
 
 #include "hdr/types/size_t.h"
-#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/test/src/unistd/CMakeLists.txt
+++ b/libc/test/src/unistd/CMakeLists.txt
@@ -648,8 +648,10 @@ add_libc_test(
   SRCS
     confstr_test.cpp
   DEPENDS
+    libc.hdr.errno_macros
     libc.hdr.types.size_t
     libc.src.unistd.confstr
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_test(

--- a/libc/test/src/unistd/CMakeLists.txt
+++ b/libc/test/src/unistd/CMakeLists.txt
@@ -642,6 +642,17 @@ add_libc_test(
 
 
 add_libc_test(
+  confstr_test
+  SUITE
+    libc_unistd_unittests
+  SRCS
+    confstr_test.cpp
+  DEPENDS
+    libc.hdr.types.size_t
+    libc.src.unistd.confstr
+)
+
+add_libc_test(
   sysconf_test
   SUITE
     libc_unistd_unittests

--- a/libc/test/src/unistd/CMakeLists.txt
+++ b/libc/test/src/unistd/CMakeLists.txt
@@ -651,6 +651,7 @@ add_libc_test(
     libc.hdr.errno_macros
     libc.hdr.types.size_t
     libc.src.unistd.confstr
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 

--- a/libc/test/src/unistd/confstr_test.cpp
+++ b/libc/test/src/unistd/confstr_test.cpp
@@ -13,22 +13,18 @@
 
 #include "src/unistd/confstr.h"
 
+#include "hdr/errno_macros.h"
 #include "hdr/types/size_t.h"
+#include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
-TEST(LlvmLibcConfStrTest, Basic) {
+using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
+
+TEST(LlvmLibcConfStrTest, InvalidName) {
   char buf[64] = "initial";
-  size_t ret = LIBC_NAMESPACE::confstr(0, buf, sizeof(buf));
-  EXPECT_EQ(ret, size_t(0));
-}
-
-TEST(LlvmLibcConfStrTest, NullBufZeroLen) {
-  size_t ret = LIBC_NAMESPACE::confstr(0, nullptr, 0);
-  EXPECT_EQ(ret, size_t(0));
-}
-
-TEST(LlvmLibcConfStrTest, NonExistentConfig) {
-  char buf[64];
-  size_t ret = LIBC_NAMESPACE::confstr(-1, buf, sizeof(buf));
-  EXPECT_EQ(ret, size_t(0));
+  EXPECT_THAT(LIBC_NAMESPACE::confstr(0, buf, sizeof(buf)),
+              Fails(EINVAL, size_t(0)));
+  EXPECT_THAT(LIBC_NAMESPACE::confstr(0, nullptr, 0), Fails(EINVAL, size_t(0)));
+  EXPECT_THAT(LIBC_NAMESPACE::confstr(-1, buf, sizeof(buf)),
+              Fails(EINVAL, size_t(0)));
 }

--- a/libc/test/src/unistd/confstr_test.cpp
+++ b/libc/test/src/unistd/confstr_test.cpp
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for confstr
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/unistd/confstr.h"
+
+#include "hdr/types/size_t.h"
+#include "test/UnitTest/Test.h"
+
+TEST(LlvmLibcConfStrTest, Basic) {
+  char buf[64] = "initial";
+  size_t ret = LIBC_NAMESPACE::confstr(0, buf, sizeof(buf));
+  EXPECT_EQ(ret, size_t(0));
+}
+
+TEST(LlvmLibcConfStrTest, NullBufZeroLen) {
+  size_t ret = LIBC_NAMESPACE::confstr(0, nullptr, 0);
+  EXPECT_EQ(ret, size_t(0));
+}
+
+TEST(LlvmLibcConfStrTest, NonExistentConfig) {
+  char buf[64];
+  size_t ret = LIBC_NAMESPACE::confstr(-1, buf, sizeof(buf));
+  EXPECT_EQ(ret, size_t(0));
+}

--- a/libc/test/src/unistd/confstr_test.cpp
+++ b/libc/test/src/unistd/confstr_test.cpp
@@ -15,12 +15,13 @@
 
 #include "hdr/errno_macros.h"
 #include "hdr/types/size_t.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
-#include "test/UnitTest/Test.h"
 
+using LlvmLibcConfStrTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
 
-TEST(LlvmLibcConfStrTest, InvalidName) {
+TEST_F(LlvmLibcConfStrTest, InvalidName) {
   char buf[64] = "initial";
   EXPECT_THAT(LIBC_NAMESPACE::confstr(0, buf, sizeof(buf)),
               Fails(EINVAL, size_t(0)));


### PR DESCRIPTION
POSIX defines confstr as returning strings for various macros (see:
https://pubs.opengroup.org/onlinepubs/9799919799/functions/confstr.html)
This PR adds an implementation as experimental that always returns that
there's no valid string.

Assisted-by: Automated tooling, human reviewed.
