### PR TITLE
[cmake] Pass arguments to ccache on Windows

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -332,51 +332,56 @@ if(LLVM_CCACHE_BUILD)
   if(CCACHE_PROGRAM)
     set(LLVM_CCACHE_MAXSIZE "" CACHE STRING "Size of ccache")
     set(LLVM_CCACHE_DIR "" CACHE STRING "Directory to keep ccached data")
-    set(LLVM_CCACHE_PARAMS "CCACHE_CPP2=yes CCACHE_HASHDIR=yes CCACHE_SLOPPINESS=pch_defines,time_macros"
-        CACHE STRING "Parameters to pass through to ccache")
 
-    if(NOT CMAKE_HOST_WIN32)
-      set(CCACHE_PROGRAM "${LLVM_CCACHE_PARAMS} ${CCACHE_PROGRAM}")
-      if (LLVM_CCACHE_MAXSIZE)
-        set(CCACHE_PROGRAM "CCACHE_MAXSIZE=${LLVM_CCACHE_MAXSIZE} ${CCACHE_PROGRAM}")
-      endif()
-      if (LLVM_CCACHE_DIR)
-        set(CCACHE_PROGRAM "CCACHE_DIR=${LLVM_CCACHE_DIR} ${CCACHE_PROGRAM}")
-      endif()
-      set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_PROGRAM})
-
-      if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        # ccache with PCH can lead to false-positives when only a macro
-        # definition changes with non-Clang compilers, because macro definitions
-        # are not compared in preprocessed mode.
-        # See: https://github.com/ccache/ccache/issues/1668
-        if(NOT DEFINED CMAKE_DISABLE_PRECOMPILE_HEADERS)
-          message(NOTICE "Using ccache with precompiled headers with non-Clang "
+    if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+      # ccache with PCH can lead to false-positives when only a macro
+      # definition changes with non-Clang compilers, because macro definitions
+      # are not compared in preprocessed mode.
+      # See: https://github.com/ccache/ccache/issues/1668
+      if(NOT DEFINED CMAKE_DISABLE_PRECOMPILE_HEADERS)
+        message(NOTICE "Using ccache with precompiled headers with non-Clang "
             "compilers is not supported. CMAKE_DISABLE_PRECOMPILE_HEADERS will be set to ON. "
             "Pass -DCMAKE_DISABLE_PRECOMPILE_HEADERS=OFF to override this.")
-          set(CMAKE_DISABLE_PRECOMPILE_HEADERS "ON")
-        elseif(NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
-          message(WARNING "Using ccache with precompiled headers with non-Clang "
-            "compilers is not supported.")
-        endif()
-      endif()
-    else()
-      # Until a way to reliably configure ccache on Windows is found,
-      # disable precompiled headers for Windows + ccache builds
-      if(NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
-        message(WARNING "Using ccache with precompiled headers on Windows is currently not supported.
-          CMAKE_DISABLE_PRECOMPILE_HEADERS will be set to ON.")
         set(CMAKE_DISABLE_PRECOMPILE_HEADERS "ON")
+      elseif(NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
+        message(WARNING "Using ccache with precompiled headers with non-Clang "
+            "compilers is not supported.")
       endif()
-      if(LLVM_CCACHE_MAXSIZE OR LLVM_CCACHE_DIR OR
-         NOT LLVM_CCACHE_PARAMS MATCHES "CCACHE_CPP2=yes CCACHE_HASHDIR=yes CCACHE_SLOPPINESS=pch_defines,time_macros")
-        message(FATAL_ERROR "Ccache configuration through CMake is not supported on Windows. Please use environment variables.")
+    endif()
+
+    if (NOT CMAKE_HOST_WIN32)
+      set(LLVM_CCACHE_PARAMS "CCACHE_CPP2=yes CCACHE_HASHDIR=yes CCACHE_SLOPPINESS=pch_defines,time_macros"
+        CACHE STRING "Parameters to pass through to ccache")
+
+      if (LLVM_CCACHE_MAXSIZE)
+        set(LLVM_CCACHE_PARAMS "CCACHE_MAXSIZE=${LLVM_CCACHE_MAXSIZE} ${LLVM_CCACHE_PARAMS}")
       endif()
+      if (LLVM_CCACHE_DIR)
+        set(LLVM_CCACHE_PARAMS "CCACHE_DIR=${LLVM_CCACHE_DIR} ${LLVM_CCACHE_PARAMS}")
+      endif()
+
+      # On platforms other than Windows pass the arguments as an env var to support older ccache versions
+      set(CCACHE_PROGRAM "${LLVM_CCACHE_PARAMS} ${CCACHE_PROGRAM}")
+      set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_PROGRAM})
+    else()
+      set(LLVM_CCACHE_PARAMS "run_second_cpp=true;hash_dir=true;sloppiness=pch_defines,time_macros"
+        CACHE STRING "Parameters to pass through to ccache")
+
+      if (LLVM_CCACHE_MAXSIZE)
+        list(APPEND LLVM_CCACHE_PARAMS "cache_maxsize=${LLVM_CCACHE_MAXSIZE}")
+      endif()
+      if (LLVM_CCACHE_DIR)
+        list(APPEND LLVM_CCACHE_PARAMS "cache_dir=${LLVM_CCACHE_DIR}")
+      endif()
+
+      # Since ccache 4.8 it is possible to pass options as arguments
+      set(CCACHE_PROGRAM ${CCACHE_PROGRAM} ${LLVM_CCACHE_PARAMS})
       # RULE_LAUNCH_COMPILE should work with Ninja but currently has issues
       # with cmd.exe and some MSVC tools other than cl.exe
       set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
       set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
     endif()
+
   else()
     message(FATAL_ERROR "Unable to find the program ccache. Set LLVM_CCACHE_BUILD to OFF")
   endif()


### PR DESCRIPTION
Since ccache 4.8 it is possible to pass options as arguments. As such now PCH files can be enabled along with ccache on windows when using clang as the compiler. The original behavior was left on other systems to preserve compatibility with older ccache versions.