### PR TITLE
[Driver] Normalize SPIRV offload triple to canonical form

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1119,7 +1119,14 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
     std::vector<std::string> ArgValues =
         C.getInputArgs().getAllArgValues(options::OPT_offload_targets_EQ);
     for (llvm::StringRef Target : ArgValues) {
-      Triples.insert(ToolChain::normalizeOffloadTriple(Target));
+      llvm::Triple T(ToolChain::normalizeOffloadTriple(Target));
+      if (T.isSPIRV() && Kinds.contains(Action::OFK_SYCL)) {
+        if (T.getVendor() == llvm::Triple::UnknownVendor)
+          T.setVendor(llvm::Triple::UnknownVendor);
+        if (T.getOS() == llvm::Triple::UnknownOS)
+          T.setOS(llvm::Triple::UnknownOS);
+      }
+      Triples.insert(T);
     }
 
     if (ArgValues.empty())

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9749,13 +9749,11 @@ void OffloadPackager::ConstructJob(Compilation &C, const JobAction &JA,
     llvm::copy_if(Features, std::back_inserter(FeatureArgs),
                   [](StringRef Arg) { return !Arg.starts_with("-target"); });
 
-    // TODO: We need to pass in the full target-id and handle it properly in the
-    // linker wrapper.
-    llvm::Triple EffectiveTriple(TC->ComputeEffectiveClangTriple(TCArgs, Arch));
     // Ensure SPIRV SYCL device images are tagged with the canonical
     // three-component triple (e.g. "spirv64-unknown-unknown") so that the SYCL
     // runtime's exact-string image compatibility check succeeds.  An arch-only
     // spelling like "spirv64" is accepted by the driver but does not match.
+    llvm::Triple EffectiveTriple(TC->ComputeEffectiveClangTriple(TCArgs, Arch));
     if (EffectiveTriple.isSPIRV() &&
         OffloadAction->getOffloadingDeviceKind() == Action::OFK_SYCL) {
       if (EffectiveTriple.getVendor() == llvm::Triple::UnknownVendor)
@@ -9763,6 +9761,8 @@ void OffloadPackager::ConstructJob(Compilation &C, const JobAction &JA,
       if (EffectiveTriple.getOS() == llvm::Triple::UnknownOS)
         EffectiveTriple.setOS(llvm::Triple::UnknownOS);
     }
+    // TODO: We need to pass in the full target-id and handle it properly in the
+    // linker wrapper.
     SmallVector<std::string> Parts{
         "file=" + File.str(),
         "triple=" + EffectiveTriple.getTriple(),

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9751,9 +9751,21 @@ void OffloadPackager::ConstructJob(Compilation &C, const JobAction &JA,
 
     // TODO: We need to pass in the full target-id and handle it properly in the
     // linker wrapper.
+    llvm::Triple EffectiveTriple(TC->ComputeEffectiveClangTriple(TCArgs, Arch));
+    // Ensure SPIRV SYCL device images are tagged with the canonical
+    // three-component triple (e.g. "spirv64-unknown-unknown") so that the SYCL
+    // runtime's exact-string image compatibility check succeeds.  An arch-only
+    // spelling like "spirv64" is accepted by the driver but does not match.
+    if (EffectiveTriple.isSPIRV() &&
+        OffloadAction->getOffloadingDeviceKind() == Action::OFK_SYCL) {
+      if (EffectiveTriple.getVendor() == llvm::Triple::UnknownVendor)
+        EffectiveTriple.setVendor(llvm::Triple::UnknownVendor);
+      if (EffectiveTriple.getOS() == llvm::Triple::UnknownOS)
+        EffectiveTriple.setOS(llvm::Triple::UnknownOS);
+    }
     SmallVector<std::string> Parts{
         "file=" + File.str(),
-        "triple=" + TC->ComputeEffectiveClangTriple(TCArgs, Arch),
+        "triple=" + EffectiveTriple.getTriple(),
         "arch=" + (Arch.empty() ? "generic" : Arch.ArchName.str()),
         "kind=" + Kind.str(),
     };

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9749,23 +9749,11 @@ void OffloadPackager::ConstructJob(Compilation &C, const JobAction &JA,
     llvm::copy_if(Features, std::back_inserter(FeatureArgs),
                   [](StringRef Arg) { return !Arg.starts_with("-target"); });
 
-    // Ensure SPIRV SYCL device images are tagged with the canonical
-    // three-component triple (e.g. "spirv64-unknown-unknown") so that the SYCL
-    // runtime's exact-string image compatibility check succeeds.  An arch-only
-    // spelling like "spirv64" is accepted by the driver but does not match.
-    llvm::Triple EffectiveTriple(TC->ComputeEffectiveClangTriple(TCArgs, Arch));
-    if (EffectiveTriple.isSPIRV() &&
-        OffloadAction->getOffloadingDeviceKind() == Action::OFK_SYCL) {
-      if (EffectiveTriple.getVendor() == llvm::Triple::UnknownVendor)
-        EffectiveTriple.setVendor(llvm::Triple::UnknownVendor);
-      if (EffectiveTriple.getOS() == llvm::Triple::UnknownOS)
-        EffectiveTriple.setOS(llvm::Triple::UnknownOS);
-    }
     // TODO: We need to pass in the full target-id and handle it properly in the
     // linker wrapper.
     SmallVector<std::string> Parts{
         "file=" + File.str(),
-        "triple=" + EffectiveTriple.getTriple(),
+        "triple=" + TC->ComputeEffectiveClangTriple(TCArgs, Arch),
         "arch=" + (Arch.empty() ? "generic" : Arch.ArchName.str()),
         "kind=" + Kind.str(),
     };

--- a/clang/test/Driver/offload-target.c
+++ b/clang/test/Driver/offload-target.c
@@ -1,6 +1,6 @@
 // RUN: %clang -### -fsycl --offload-targets=spirv64 -nogpuinc -x c++ %s -ccc-print-bindings 2>&1 \
 // RUN: | FileCheck %s -check-prefix=SYCL
-// SYCL: "spirv64" - "clang", inputs: ["[[INPUT:.+]]"], output: "[[SYCL_BC:.+]]"
+// SYCL: "spirv64-unknown-unknown" - "clang", inputs: ["[[INPUT:.+]]"], output: "[[SYCL_BC:.+]]"
 
 // RUN: %clang -### --offload-targets=amdgcn-amd-amdhsa -nogpulib -nogpuinc -x hip %s -ccc-print-bindings 2>&1 \
 // RUN: | FileCheck %s -check-prefix=HIP

--- a/clang/test/Driver/sycl-spirv64-triple-normalization.cpp
+++ b/clang/test/Driver/sycl-spirv64-triple-normalization.cpp
@@ -1,0 +1,11 @@
+// Verify that --offload-targets=spirv64 (arch-only spelling) is normalized to
+// the canonical spirv64-unknown-unknown triple in the offload image metadata.
+// The SYCL runtime does an exact string match against "spirv64-unknown-unknown"
+// so using the arch-only form causes "No compatible image found" at runtime.
+//
+// RUN: %clang -### -fsycl --offload-targets=spirv64 \
+// RUN:   --no-offloadlib -c %s 2>&1 | FileCheck %s
+// RUN: %clang_cl -### -fsycl --offload-targets=spirv64 \
+// RUN:   --no-offloadlib -c -- %s 2>&1 | FileCheck %s
+//
+// CHECK: "--image=file={{.*}},triple=spirv64-unknown-unknown,arch=generic,kind=sycl"


### PR DESCRIPTION
`ToolChain::normalizeOffloadTriple()` expands shortened NVPTX and AMDGCN triples but left SPIR-V alone, so `'--offload-targets=spirv64'` reached the offload image metadata as `'spirv64'`. 

The SYCL runtime compares that string exactly against `"spirv64-unknown-unknown"`, so the image was rejected at runtime with "No compatible image found".

Expand `'spirv64'` and `'spirv64-unknown'` to `'spirv64-unknown-unknown'`. A triple naming a vendor `('spirv64-intel')` or an OS `('spirv64-unknown-chipstar')` is used as given.