### PR TITLE
[lldb] Fix `shared_ptr<Section>` leak

### DIFF
--- a/lldb/include/lldb/Symbol/Symbol.h
+++ b/lldb/include/lldb/Symbol/Symbol.h
@@ -54,8 +54,7 @@ public:
   Symbol(const Symbol &rhs);
 
   ~Symbol() {
-    if (m_type != lldb::eSymbolTypeReExported &&
-        m_type != lldb::eSymbolTypeInvalid)
+    if (m_type != lldb::eSymbolTypeReExported)
       m_addr_or_reexport.GetAddressRange(*this).Clear();
   }
 

--- a/lldb/include/lldb/Symbol/Symbol.h
+++ b/lldb/include/lldb/Symbol/Symbol.h
@@ -53,10 +53,7 @@ public:
 
   Symbol(const Symbol &rhs);
 
-  ~Symbol() {
-    if (m_type != lldb::eSymbolTypeReExported)
-      m_addr_or_reexport.GetAddressRange(*this).Clear();
-  }
+  ~Symbol() { m_addr_or_reexport.Clear(*this); }
 
   const Symbol &operator=(const Symbol &rhs);
 
@@ -417,6 +414,13 @@ protected:
     // Proper destruction is handled by Symbol's dtor; supply a no-op
     // impl to let the compiler know it's handled.
     ~AddrRangeOrReExport() {}
+
+    void Clear(const Symbol &sym) {
+      if (sym.GetType() == lldb::eSymbolTypeReExported)
+        m_reexport_info.Clear();
+      else
+        m_addr_range.Clear();
+    }
 
   private:
     union {


### PR DESCRIPTION
Introduced by #213356

```
SanitizerError
AddressSanitizer: 2760 byte(s) leaked in 15 allocation(s).
Details

=================================================================
==6162==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 1472 byte(s) in 8 object(s) allocated from:
...
    #8 0x7f4d08980c00 in ObjectFileELF::CreateSections(lldb_private::SectionList&) lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp:2168:28
    #9 0x7f4d085c5651 in lldb_private::Module::GetSectionList() lldb/source/Core/Module.cpp:1226:17
    #10 0x7f4d08af4f6f in lldb_private::plugin::dwarf::SymbolFileDWARF::SymbolFileDWARF(std::__u::shared_ptr<lldb_private::ObjectFile>, lldb_private::SectionList*) lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp:490:44
    #11 0x7f4d08af331e in lldb_private::plugin::dwarf::SymbolFileDWARF::CreateInstance(std::__u::shared_ptr<lldb_private::ObjectFile>) lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp:347:14
    #12 0x7f4d08cc36af in lldb_private::SymbolFile::FindPlugin(std::__u::shared_ptr<lldb_private::ObjectFile>) lldb/source/Symbol/SymbolFile.cpp:64:51
    #13 0x7f4d08cd2dc9 in lldb_private::SymbolVendor::AddSymbolFileRepresentation(std::__u::shared_ptr<lldb_private::ObjectFile> const&) lldb/source/Symbol/SymbolVendor.cpp:65:27
    #14 0x7f4d08cd2ba0 in lldb_private::SymbolVendor::FindPlugin(std::__u::shared_ptr<lldb_private::Module> const&, lldb_private::Stream*) lldb/source/Symbol/SymbolVendor.cpp:51:16
    #15 0x7f4d085c1d9f in lldb_private::Module::GetSymbolFile(bool, lldb_private::Stream*) lldb/source/Core/Module.cpp:991:13
    #16 0x7f50eadaf896 in lldb_private::YAMLModuleTester::YAMLModuleTester(llvm::StringRef, unsigned long) lldb/unittests/TestingSupport/Symbol/YAMLModuleTester.cpp:24:61
    #17 0x7f50eb471eea in DWARFASTParserClangYAMLTester lldb/unittests/SymbolFile/DWARF/DWARFASTParserClangTests.cpp:53:9
    #18 0x7f50eb471eea in DWARFASTParserClangTests_TestRustVariantMember_Test::TestBody() lldb/unittests/SymbolFile/DWARF/DWARFASTParserClangTests.cpp:2128:33
...

Direct leak of 1288 byte(s) in 7 object(s) allocated from:
...
    #8 0x7f4d08980c00 in ObjectFileELF::CreateSections(lldb_private::SectionList&) lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp:2168:28
    #9 0x7f4d085c5651 in lldb_private::Module::GetSectionList() lldb/source/Core/Module.cpp:1226:17
    #10 0x7f4d08af4f6f in lldb_private::plugin::dwarf::SymbolFileDWARF::SymbolFileDWARF(std::__u::shared_ptr<lldb_private::ObjectFile>, lldb_private::SectionList*) lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp:490:44
    #11 0x7f4d08af331e in lldb_private::plugin::dwarf::SymbolFileDWARF::CreateInstance(std::__u::shared_ptr<lldb_private::ObjectFile>) lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp:347:14
    #12 0x7f4d08cc36af in lldb_private::SymbolFile::FindPlugin(std::__u::shared_ptr<lldb_private::ObjectFile>) lldb/source/Symbol/SymbolFile.cpp:64:51
    #13 0x7f4d08cd2dc9 in lldb_private::SymbolVendor::AddSymbolFileRepresentation(std::__u::shared_ptr<lldb_private::ObjectFile> const&) lldb/source/Symbol/SymbolVendor.cpp:65:27
    #14 0x7f4d08cd2ba0 in lldb_private::SymbolVendor::FindPlugin(std::__u::shared_ptr<lldb_private::Module> const&, lldb_private::Stream*) lldb/source/Symbol/SymbolVendor.cpp:51:16
    #15 0x7f4d085c1d9f in lldb_private::Module::GetSymbolFile(bool, lldb_private::Stream*) lldb/source/Core/Module.cpp:991:13
    #16 0x7f50eadaf896 in lldb_private::YAMLModuleTester::YAMLModuleTester(llvm::StringRef, unsigned long) lldb/unittests/TestingSupport/Symbol/YAMLModuleTester.cpp:24:61
    #17 0x7f50eb461ba2 in DWARFASTParserClangYAMLTester lldb/unittests/SymbolFile/DWARF/DWARFASTParserClangTests.cpp:53:9
    #18 0x7f50eb461ba2 in DWARFASTParserClangTests_TestDefaultTemplateParamParsing_Test::TestBody() lldb/unittests/SymbolFile/DWARF/DWARFASTParserClangTests.cpp:587:33
...
```