### PR TITLE
[Support] Add DataExtractor::getSLEB128APSInt

### DIFF
--- a/llvm/include/llvm/Support/DataExtractor.h
+++ b/llvm/include/llvm/Support/DataExtractor.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_DATAEXTRACTOR_H
 #define LLVM_SUPPORT_DATAEXTRACTOR_H
 
+#include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
@@ -668,6 +669,39 @@ public:
   /// In case of an extraction error, or if the cursor is already in an error
   /// state, zero is returned.
   uint64_t getULEB128(Cursor &C) const { return getULEB128(&C.Offset, &C.Err); }
+
+  /// Extract an arbitrary-precision signed LEB128 value from \a *OffsetPtr.
+  ///
+  /// Extracts a signed LEB128 number from this object's data starting at the
+  /// offset pointed to by \a OffsetPtr, growing the result to as many bits as
+  /// the encoding requires. This differs from getSLEB128(), which is limited to
+  /// 64 bits. The offset pointed to by \a OffsetPtr will be updated with the
+  /// offset of the byte following the last extracted byte.
+  ///
+  /// @param[in,out] OffsetPtr
+  ///     A pointer to an offset within the data that will be advanced by the
+  ///     appropriate number of bytes if the value is extracted correctly. If
+  ///     the offset is out of bounds or there are not enough bytes to extract
+  ///     this value, the offset will be left unmodified.
+  ///
+  /// @param[in,out] Err
+  ///     A pointer to an Error object. Upon return the Error object is set to
+  ///     indicate the result (success/failure) of the function. If the Error
+  ///     object is already set when calling this function, no extraction is
+  ///     performed.
+  ///
+  /// @return
+  ///     The extracted signed integer value, represented with just enough bits
+  ///     to hold it.
+  LLVM_ABI APSInt getSLEB128APSInt(uint64_t *OffsetPtr,
+                                   Error *Err = nullptr) const;
+
+  /// Extract an arbitrary-precision signed LEB128 value from the location
+  /// given by the cursor. In case of an extraction error, or if the cursor
+  /// is already in an error state, a default-constructed APSInt is returned.
+  APSInt getSLEB128APSInt(Cursor &C) const {
+    return getSLEB128APSInt(&C.Offset, &C.Err);
+  }
 
   /// Advance the Cursor position by the given number of bytes. No-op if the
   /// cursor is in an error state.

--- a/llvm/include/llvm/Support/DataExtractor.h
+++ b/llvm/include/llvm/Support/DataExtractor.h
@@ -678,19 +678,19 @@ public:
   /// 64 bits. The offset pointed to by \a OffsetPtr will be updated with the
   /// offset of the byte following the last extracted byte.
   ///
-  /// @param[in,out] OffsetPtr
+  /// \param[in,out] OffsetPtr
   ///     A pointer to an offset within the data that will be advanced by the
   ///     appropriate number of bytes if the value is extracted correctly. If
   ///     the offset is out of bounds or there are not enough bytes to extract
   ///     this value, the offset will be left unmodified.
   ///
-  /// @param[in,out] Err
+  /// \param[in,out] Err
   ///     A pointer to an Error object. Upon return the Error object is set to
   ///     indicate the result (success/failure) of the function. If the Error
   ///     object is already set when calling this function, no extraction is
   ///     performed.
   ///
-  /// @return
+  /// \return
   ///     The extracted signed integer value, represented with just enough bits
   ///     to hold it.
   LLVM_ABI APSInt getSLEB128APSInt(uint64_t *OffsetPtr,

--- a/llvm/lib/Support/DataExtractor.cpp
+++ b/llvm/lib/Support/DataExtractor.cpp
@@ -245,6 +245,40 @@ int64_t DataExtractor::getSLEB128(uint64_t *offset_ptr, Error *Err) const {
   return getLEB128(Data, offset_ptr, Err, decodeSLEB128);
 }
 
+APSInt DataExtractor::getSLEB128APSInt(uint64_t *OffsetPtr, Error *Err) const {
+  ErrorAsOutParameter ErrAsOut(Err);
+  if (isError(Err))
+    return APSInt();
+
+  uint64_t Offset = *OffsetPtr;
+  APInt Value;
+  unsigned Shift = 0;
+  uint8_t Byte;
+  do {
+    if (!prepareRead(Offset, 1, Err))
+      return APSInt();
+    Byte = Data[Offset++];
+    APInt Slice(7, Byte & 0x7f);
+    if (Shift == 0)
+      Value = Slice;
+    else {
+      Value = Value.zext(Shift + 7);
+      Value.insertBits(Slice, Shift);
+    }
+    Shift += 7;
+  } while (Byte & 0x80);
+
+  // Value is currently an exact, Shift-bit two's complement representation
+  // of the decoded number, with the top bit doubling as its sign. Sign
+  // extend it to a canonical minimum width to match getSLEB128(), growing
+  // it further only if the encoding actually needs more than 64 bits.
+  if (Shift < 64)
+    Value = Value.sext(64);
+
+  *OffsetPtr = Offset;
+  return APSInt(std::move(Value), /*isUnsigned=*/false);
+}
+
 void DataExtractor::skip(Cursor &C, uint64_t Length) const {
   ErrorAsOutParameter ErrAsOut(C.Err);
   if (isError(&C.Err))

--- a/llvm/lib/Support/DataExtractor.cpp
+++ b/llvm/lib/Support/DataExtractor.cpp
@@ -268,10 +268,7 @@ APSInt DataExtractor::getSLEB128APSInt(uint64_t *OffsetPtr, Error *Err) const {
     Shift += 7;
   } while (Byte & 0x80);
 
-  // Value is currently an exact, Shift-bit two's complement representation
-  // of the decoded number, with the top bit doubling as its sign. Sign
-  // extend it to a canonical minimum width to match getSLEB128(), growing
-  // it further only if the encoding actually needs more than 64 bits.
+  // Sign extend Value to at least 64 bits to match getSLEB128.
   if (Shift < 64)
     Value = Value.sext(64);
 

--- a/llvm/unittests/Support/DataExtractorTest.cpp
+++ b/llvm/unittests/Support/DataExtractorTest.cpp
@@ -213,6 +213,72 @@ TEST(DataExtractorTest, LEB128_error) {
                         "malformed uleb128, extends past end"));
 }
 
+TEST(DataExtractorTest, SLEB128APSInt) {
+  {
+    // Values that fit within 64 bits should match getSLEB128() exactly.
+    DataExtractor DE(StringRef(leb128data), false);
+    uint64_t Offset = 0;
+    APSInt Result = DE.getSLEB128APSInt(&Offset);
+    EXPECT_EQ(2U, Offset);
+    EXPECT_EQ(64U, Result.getBitWidth());
+    EXPECT_EQ(APSInt::get(-7002ULL), Result);
+  }
+
+  {
+    DataExtractor DE(StringRef(bigleb128data), false);
+    uint64_t Offset = 0;
+    APSInt Result = DE.getSLEB128APSInt(&Offset);
+    EXPECT_EQ(8U, Offset);
+    EXPECT_EQ(64U, Result.getBitWidth());
+    EXPECT_EQ(APSInt::get(-29839268287359830LL), Result);
+  }
+
+  {
+    // Same idea, at the INT64_MAX/UINT64_MAX boundary: 2^63 is representable
+    // as an unsigned 64-bit value but overflows int64_t.
+    const char twoPow63Data[] = "\x80\x80\x80\x80\x80\x80\x80\x80\x80\x01";
+    DataExtractor DE(StringRef(twoPow63Data), false);
+    uint64_t Offset = 0;
+    APSInt Result = DE.getSLEB128APSInt(&Offset);
+    EXPECT_EQ(strlen(twoPow63Data), Offset);
+    EXPECT_FALSE(Result.isNegative());
+    EXPECT_EQ(1ULL << 63, Result.getZExtValue());
+  }
+
+  {
+    // INT64_MAX + 1 (aka 2^63 + 1): one past the previous boundary.
+    const char twoPow63Plus1Data[] =
+        "\x81\x80\x80\x80\x80\x80\x80\x80\x80\x01";
+    DataExtractor DE(StringRef(twoPow63Plus1Data), false);
+    uint64_t Offset = 0;
+    APSInt Result = DE.getSLEB128APSInt(&Offset);
+    EXPECT_EQ(strlen(twoPow63Plus1Data), Offset);
+    EXPECT_FALSE(Result.isNegative());
+    EXPECT_EQ((1ULL << 63) + 1, Result.getZExtValue());
+  }
+
+  {
+    // A value greater than INT64_MAX (but no greater than UINT64_MAX) does not
+    // fit in the 64-bit accumulator that getSLEB128() uses, so it requires 65
+    // significant bits (64 magnitude bits, plus a 0 sign bit) to encode as a
+    // positive number. getSLEB128() rejects such an encoding outright, while
+    // getSLEB128APSInt() should grow to accommodate it.
+    const char uint64MaxData[] = "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01";
+    DataExtractor DE(StringRef(uint64MaxData), false);
+    uint64_t Offset = 0;
+    {
+      llvm::Error Err = llvm::Error::success();
+      EXPECT_EQ(0, DE.getSLEB128(&Offset, &Err));
+      EXPECT_THAT_ERROR(std::move(Err), Failed());
+    }
+    Offset = 0;
+    APSInt Result = DE.getSLEB128APSInt(&Offset);
+    EXPECT_EQ(strlen(uint64MaxData), Offset);
+    EXPECT_FALSE(Result.isNegative());
+    EXPECT_EQ(UINT64_MAX, Result.getZExtValue());
+  }
+}
+
 TEST(DataExtractorTest, Cursor_tell) {
   DataExtractor DE(StringRef("AB"), false);
   DataExtractor::Cursor C(0);

--- a/llvm/unittests/Support/DataExtractorTest.cpp
+++ b/llvm/unittests/Support/DataExtractorTest.cpp
@@ -234,36 +234,9 @@ TEST(DataExtractorTest, SLEB128APSInt) {
   }
 
   {
-    // Same idea, at the INT64_MAX/UINT64_MAX boundary: 2^63 is representable
-    // as an unsigned 64-bit value but overflows int64_t.
-    const char twoPow63Data[] = "\x80\x80\x80\x80\x80\x80\x80\x80\x80\x01";
-    DataExtractor DE(StringRef(twoPow63Data), false);
-    uint64_t Offset = 0;
-    APSInt Result = DE.getSLEB128APSInt(&Offset);
-    EXPECT_EQ(strlen(twoPow63Data), Offset);
-    EXPECT_FALSE(Result.isNegative());
-    EXPECT_EQ(1ULL << 63, Result.getZExtValue());
-  }
-
-  {
-    // INT64_MAX + 1 (aka 2^63 + 1): one past the previous boundary.
-    const char twoPow63Plus1Data[] = "\x81\x80\x80\x80\x80\x80\x80\x80\x80\x01";
-    DataExtractor DE(StringRef(twoPow63Plus1Data), false);
-    uint64_t Offset = 0;
-    APSInt Result = DE.getSLEB128APSInt(&Offset);
-    EXPECT_EQ(strlen(twoPow63Plus1Data), Offset);
-    EXPECT_FALSE(Result.isNegative());
-    EXPECT_EQ((1ULL << 63) + 1, Result.getZExtValue());
-  }
-
-  {
-    // A value greater than INT64_MAX (but no greater than UINT64_MAX) does not
-    // fit in the 64-bit accumulator that getSLEB128() uses, so it requires 65
-    // significant bits (64 magnitude bits, plus a 0 sign bit) to encode as a
-    // positive number. getSLEB128() rejects such an encoding outright, while
-    // getSLEB128APSInt() should grow to accommodate it.
-    const char uint64MaxData[] = "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01";
-    DataExtractor DE(StringRef(uint64MaxData), false);
+    // 2^63 is representable as a uint64_t, but overflows int64_t.
+    const char TwoPow63Data[] = "\x80\x80\x80\x80\x80\x80\x80\x80\x80\x01";
+    DataExtractor DE(StringRef(TwoPow63Data), false);
     uint64_t Offset = 0;
     {
       llvm::Error Err = llvm::Error::success();
@@ -272,7 +245,30 @@ TEST(DataExtractorTest, SLEB128APSInt) {
     }
     Offset = 0;
     APSInt Result = DE.getSLEB128APSInt(&Offset);
-    EXPECT_EQ(strlen(uint64MaxData), Offset);
+    EXPECT_EQ(strlen(TwoPow63Data), Offset);
+    EXPECT_FALSE(Result.isNegative());
+    EXPECT_EQ(1ULL << 63, Result.getZExtValue());
+  }
+
+  {
+    // A value in the [INT64_MAX+1, UINT64_MAX] range does not fit the 64-bit
+    // accumulator used by getSLEB128 -- it requires 65 significant bits (64
+    // magnitude bits, plus a 0 sign bit). These encoded values are rejected by
+    // getSLEB128, while getSLEB128APSInt uses APSInt to accommodate it.
+    //
+    // Test an all-ones pattern to verify a bit pattern surviving the growth
+    // past 64 bits (unlike the all-zero data pattern of TwoPow63Data above).
+    const char UInt64MaxData[] = "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x01";
+    DataExtractor DE(StringRef(UInt64MaxData), false);
+    uint64_t Offset = 0;
+    {
+      llvm::Error Err = llvm::Error::success();
+      EXPECT_EQ(0, DE.getSLEB128(&Offset, &Err));
+      EXPECT_THAT_ERROR(std::move(Err), Failed());
+    }
+    Offset = 0;
+    APSInt Result = DE.getSLEB128APSInt(&Offset);
+    EXPECT_EQ(strlen(UInt64MaxData), Offset);
     EXPECT_FALSE(Result.isNegative());
     EXPECT_EQ(UINT64_MAX, Result.getZExtValue());
   }

--- a/llvm/unittests/Support/DataExtractorTest.cpp
+++ b/llvm/unittests/Support/DataExtractorTest.cpp
@@ -247,8 +247,7 @@ TEST(DataExtractorTest, SLEB128APSInt) {
 
   {
     // INT64_MAX + 1 (aka 2^63 + 1): one past the previous boundary.
-    const char twoPow63Plus1Data[] =
-        "\x81\x80\x80\x80\x80\x80\x80\x80\x80\x01";
+    const char twoPow63Plus1Data[] = "\x81\x80\x80\x80\x80\x80\x80\x80\x80\x01";
     DataExtractor DE(StringRef(twoPow63Plus1Data), false);
     uint64_t Offset = 0;
     APSInt Result = DE.getSLEB128APSInt(&Offset);


### PR DESCRIPTION
Add a APSInt variant of `getSLEB128`, supporting values greater than int64_t.

The new `getSLEB128APSInt` can support values greater than `INT64_MAX`. This functionality will be used by LLDB formatter bytecode.

Assisted-by: claude