### PR TITLE
[tsan] Add symbol for `__atomic_is_lock_free`

### DIFF
--- a/compiler-rt/lib/tsan/rtl/tsan.syms.extra
+++ b/compiler-rt/lib/tsan/rtl/tsan.syms.extra
@@ -1,3 +1,4 @@
+__atomic_is_lock_free
 __cxa_guard_acquire
 __cxa_guard_abort
 __cxa_guard_release

--- a/compiler-rt/lib/tsan/rtl/tsan_interface_atomic.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interface_atomic.cpp
@@ -890,6 +890,38 @@ void __tsan_atomic_thread_fence(int mo) {
 
 SANITIZER_INTERFACE_ATTRIBUTE
 void __tsan_atomic_signal_fence(int mo) {}
+
+// __atomic_is_lock_free is a compiler builtin so defining it with that name is
+// an error. That's the reason for all the hackery redefining it.
+#  if defined(__PRAGMA_REDEFINE_EXTNAME)
+#    pragma redefine_extname __atomic_is_lock_free_c __atomic_is_lock_free
+#  elif defined(__GNUC__)
+SANITIZER_INTERFACE_ATTRIBUTE
+bool __atomic_is_lock_free_c(uptr size, const volatile void* ptr) __asm__(
+    "__atomic_is_lock_free");
+#  endif
+
+SANITIZER_INTERFACE_ATTRIBUTE
+bool __atomic_is_lock_free_c(uptr size, const volatile void* ptr) {
+  switch (size) {
+    case 1:
+      return true;
+    case 2:
+      return IsAligned((uptr)ptr, 2);
+    case 4:
+      return IsAligned((uptr)ptr, 4);
+    case 8:
+      return IsAligned((uptr)ptr, 8);
+#  if __TSAN_HAS_INT128
+    case 16:
+      // 128-bit atomics require hardware support and are otherwise emulated via
+      // spinlocks.
+      return __atomic_always_lock_free(16, 0) && IsAligned((uptr)ptr, 16);
+#  endif
+    default:
+      return false;
+  }
+}
 }  // extern "C"
 
 #else  // #if !SANITIZER_GO

--- a/compiler-rt/test/tsan/atomic_is_lock_free.cpp
+++ b/compiler-rt/test/tsan/atomic_is_lock_free.cpp
@@ -1,0 +1,83 @@
+// RUN: %clangxx_tsan -O1 %s -o %t && %run %t 2>&1 | FileCheck %s
+#include <atomic>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+
+struct alignas(16) Large {
+  char data[16];
+};
+
+struct Huge {
+  char data[32];
+};
+
+extern "C" bool __atomic_is_lock_free(size_t size, const volatile void *ptr);
+
+int main() {
+#if defined(__SIZEOF_INT128__)
+  if (__atomic_always_lock_free(sizeof(Large), 0)) {
+    std::atomic<Large> a;
+    assert(a.is_lock_free());
+  }
+#endif
+
+  std::atomic<Huge> b;
+  assert(!b.is_lock_free());
+
+  // Use volatile to ensure runtime function invocation (avoid compiler constant folding).
+  volatile size_t s0 = 0;
+  volatile size_t s1 = 1;
+  volatile size_t s2 = 2;
+  volatile size_t s3 = 3;
+  volatile size_t s4 = 4;
+  volatile size_t s8 = 8;
+  volatile size_t s16 = 16;
+  volatile size_t s32 = 32;
+
+  assert(!__atomic_is_lock_free(s0, nullptr));
+  assert(__atomic_is_lock_free(s1, nullptr));
+  assert(__atomic_is_lock_free(s2, nullptr));
+  assert(!__atomic_is_lock_free(s3, nullptr));
+  assert(__atomic_is_lock_free(s4, nullptr));
+  assert(__atomic_is_lock_free(s8, nullptr));
+  assert(!__atomic_is_lock_free(s32, nullptr));
+
+#if defined(__SIZEOF_INT128__)
+  if (__atomic_always_lock_free(16, 0)) {
+    assert(__atomic_is_lock_free(s16, nullptr));
+  } else {
+    assert(!__atomic_is_lock_free(s16, nullptr));
+  }
+#endif
+
+  alignas(16) char buffer[32];
+  // Size 1 is always lock-free regardless of alignment.
+  assert(__atomic_is_lock_free(s1, buffer));
+  assert(__atomic_is_lock_free(s1, buffer + 1));
+
+  // Size 2
+  assert(__atomic_is_lock_free(s2, buffer));
+  assert(!__atomic_is_lock_free(s2, buffer + 1));
+
+  // Size 4
+  assert(__atomic_is_lock_free(s4, buffer));
+  assert(!__atomic_is_lock_free(s4, buffer + 1));
+
+  // Size 8
+  assert(__atomic_is_lock_free(s8, buffer));
+  assert(!__atomic_is_lock_free(s8, buffer + 1));
+
+#if defined(__SIZEOF_INT128__)
+  if (__atomic_always_lock_free(16, 0)) {
+    assert(__atomic_is_lock_free(s16, buffer));
+    assert(!__atomic_is_lock_free(s16, buffer + 1));
+  }
+#endif
+
+  fprintf(stderr, "PASS\n");
+  return 0;
+}
+
+// CHECK: PASS

--- a/compiler-rt/test/tsan/atomic_is_lock_free.cpp
+++ b/compiler-rt/test/tsan/atomic_is_lock_free.cpp
@@ -16,6 +16,13 @@ struct Huge {
 extern "C" bool __atomic_is_lock_free(size_t size, const volatile void *ptr);
 
 int main() {
+#if defined(__SIZEOF_INT128__)
+  if (__atomic_always_lock_free(sizeof(Large), 0)) {
+    std::atomic<Large> a;
+    assert(a.is_lock_free());
+  }
+#endif
+
   std::atomic<Huge> b;
   assert(!b.is_lock_free());
 
@@ -55,16 +62,20 @@ int main() {
   assert(!__atomic_is_lock_free(s8, buffer + 1));
 
 #if defined(__SIZEOF_INT128__)
-  std::atomic<Large> a;
-  bool is_16_lock_free = a.is_lock_free();
-  assert(__atomic_is_lock_free(s16, nullptr) == is_16_lock_free);
-
-  if (is_16_lock_free) {
+#  if defined(__APPLE__)
+  // On Apple platforms, dynamic calls to __atomic_is_lock_free resolve to
+  // libSystem, which returns false for 128-bit atomics.
+  assert(!__atomic_is_lock_free(s16, nullptr));
+  assert(!__atomic_is_lock_free(s16, buffer));
+#  else
+  // On Linux/ELF, dynamic calls resolve to compiler-rt's __atomic_is_lock_free.
+  if (__atomic_always_lock_free(16, 0)) {
     assert(__atomic_is_lock_free(s16, buffer));
     assert(!__atomic_is_lock_free(s16, buffer + 1));
   } else {
     assert(!__atomic_is_lock_free(s16, buffer));
   }
+#  endif
 #endif
 
   fprintf(stderr, "PASS\n");

--- a/compiler-rt/test/tsan/atomic_is_lock_free.cpp
+++ b/compiler-rt/test/tsan/atomic_is_lock_free.cpp
@@ -16,13 +16,6 @@ struct Huge {
 extern "C" bool __atomic_is_lock_free(size_t size, const volatile void *ptr);
 
 int main() {
-#if defined(__SIZEOF_INT128__)
-  if (__atomic_always_lock_free(sizeof(Large), 0)) {
-    std::atomic<Large> a;
-    assert(a.is_lock_free());
-  }
-#endif
-
   std::atomic<Huge> b;
   assert(!b.is_lock_free());
 
@@ -44,14 +37,6 @@ int main() {
   assert(__atomic_is_lock_free(s8, nullptr));
   assert(!__atomic_is_lock_free(s32, nullptr));
 
-#if defined(__SIZEOF_INT128__)
-  if (__atomic_always_lock_free(16, 0)) {
-    assert(__atomic_is_lock_free(s16, nullptr));
-  } else {
-    assert(!__atomic_is_lock_free(s16, nullptr));
-  }
-#endif
-
   alignas(16) char buffer[32];
   // Size 1 is always lock-free regardless of alignment.
   assert(__atomic_is_lock_free(s1, buffer));
@@ -70,9 +55,15 @@ int main() {
   assert(!__atomic_is_lock_free(s8, buffer + 1));
 
 #if defined(__SIZEOF_INT128__)
-  if (__atomic_always_lock_free(16, 0)) {
+  std::atomic<Large> a;
+  bool is_16_lock_free = a.is_lock_free();
+  assert(__atomic_is_lock_free(s16, nullptr) == is_16_lock_free);
+
+  if (is_16_lock_free) {
     assert(__atomic_is_lock_free(s16, buffer));
     assert(!__atomic_is_lock_free(s16, buffer + 1));
+  } else {
+    assert(!__atomic_is_lock_free(s16, buffer));
   }
 #endif
 


### PR DESCRIPTION
When attempting to remove `-latomic` from libcxx's test configuration
(#208049) I ran into an issue caused by tsan not defining
`__atomic_is_lock_free`. It's usually a compiler builtin but for some
larger sizes it gets turned into a libcall. It occurred to me that the
simplest solution was to just add it to tsan. This PR adds that
function, as well as appropriate testing.

Assisted-by: LLM based tooling, human reviewed.
