### PR TITLE
workflows/release-binaries.yml: Only dump the wix logs on failure

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -316,7 +316,7 @@ jobs:
         echo "windows-installer-filename=$(Split-Path -Path $installer -Leaf)" >> $env:GITHUB_OUTPUT
     
     - name: Dump Wix logs
-      if: runner.os == 'Windows' && always()
+      if: runner.os == 'Windows' && failure()
       env:
         LLVM_VERSION: ${{ needs.prepare.outputs.release-version }}
         BUILD_DIR_SUFFIX: ${{ case(runner.arch == 'ARM64', 'arm64', 'amd64') }}


### PR DESCRIPTION
There is currently a bug in the path on ARM64 Windows, so this step always fails.  Running it after a successful build doesn't make much sense anyway since since we don't need to see the logs for a good build. Also, we risk having it fail the whole job even after a successful build (like what is currently happening on ARM64 Windows), so that's another reason only to run this when the bulid fails.