### PR TITLE
[lldb] Remove ConstString from CommandObjectType interfaces

### DIFF
--- a/lldb/source/Commands/CommandObjectType.cpp
+++ b/lldb/source/Commands/CommandObjectType.cpp
@@ -144,7 +144,7 @@ private:
     TypeSummaryImpl::Flags m_flags;
     FormatterMatchType m_match_type = eFormatterMatchExact;
     std::string m_format_string;
-    ConstString m_name;
+    std::string m_name;
     std::string m_python_script;
     std::string m_python_function;
     bool m_is_add_script = false;
@@ -224,9 +224,8 @@ public:
                 Status error;
 
                 for (const std::string &type_name : options->m_target_types) {
-                  AddSummary(ConstString(type_name), script_format,
-                             options->m_match_type, options->m_category,
-                             &error);
+                  AddSummary(type_name, script_format, options->m_match_type,
+                             options->m_category, &error);
                   if (error.Fail()) {
                     LockedStreamFile locked_stream = error_sp->Lock();
                     locked_stream.Printf("error: %s", error.AsCString());
@@ -235,10 +234,12 @@ public:
 
                 if (options->m_name) {
                   CommandObjectTypeSummaryAdd::AddNamedSummary(
-                      options->m_name, script_format, &error);
+                      options->m_name.GetStringRef().str(), script_format,
+                      &error);
                   if (error.Fail()) {
                     CommandObjectTypeSummaryAdd::AddNamedSummary(
-                        options->m_name, script_format, &error);
+                        options->m_name.GetStringRef().str(), script_format,
+                        &error);
                     if (error.Fail()) {
                       LockedStreamFile locked_stream = error_sp->Lock();
                       locked_stream.Printf("error: %s", error.AsCString());
@@ -282,11 +283,11 @@ public:
     io_handler.SetIsDone(true);
   }
 
-  bool AddSummary(ConstString type_name, lldb::TypeSummaryImplSP entry,
+  bool AddSummary(std::string type_name, lldb::TypeSummaryImplSP entry,
                   FormatterMatchType match_type, std::string category,
                   Status *error = nullptr);
 
-  bool AddNamedSummary(ConstString summary_name, lldb::TypeSummaryImplSP entry,
+  bool AddNamedSummary(std::string summary_name, lldb::TypeSummaryImplSP entry,
                        Status *error = nullptr);
 
 protected:
@@ -482,7 +483,7 @@ protected:
 
                 for (const std::string &type_name : options->m_target_types) {
                   if (!type_name.empty()) {
-                    if (AddSynth(ConstString(type_name), synth_provider,
+                    if (AddSynth(type_name, synth_provider,
                                  options->m_match_type, options->m_category,
                                  &error)) {
                       LockedStreamFile locked_stream = error_sp->Lock();
@@ -529,7 +530,7 @@ public:
 
   ~CommandObjectTypeSynthAdd() override = default;
 
-  bool AddSynth(ConstString type_name, lldb::SyntheticChildrenSP entry,
+  bool AddSynth(std::string type_name, lldb::SyntheticChildrenSP entry,
                 FormatterMatchType match_type, std::string category_name,
                 Status *error);
 };
@@ -877,7 +878,7 @@ protected:
     } else {
       lldb::TypeCategoryImplSP category;
       DataVisualization::Categories::GetCategory(
-          ConstString(m_options.m_category.c_str()), category);
+          ConstString(m_options.m_category), category);
       if (category)
         delete_category = category->Delete(typeCS, m_formatter_kind);
       extra_deletion = FormatterSpecificDeletion(typeCS);
@@ -1222,7 +1223,7 @@ Status CommandObjectTypeSummaryAdd::CommandOptions::SetOptionValue(
       m_match_type = eFormatterMatchCallback;
     break;
   case 'n':
-    m_name.SetString(option_arg);
+    m_name = std::string(option_arg);
     break;
   case 'o':
     m_python_script = std::string(option_arg);
@@ -1257,7 +1258,7 @@ void CommandObjectTypeSummaryAdd::CommandOptions::OptionParsingStarting(
       .SetHideItemNames(false);
 
   m_match_type = eFormatterMatchExact;
-  m_name.Clear();
+  m_name.clear();
   m_python_script = "";
   m_python_function = "";
   m_format_string = "";
@@ -1271,7 +1272,7 @@ bool CommandObjectTypeSummaryAdd::Execute_ScriptSummary(
     Args &command, CommandReturnObject &result) {
   const size_t argc = command.GetArgumentCount();
 
-  if (argc < 1 && !m_options.m_name) {
+  if (argc < 1 && m_options.m_name.empty()) {
     result.AppendErrorWithFormat("%s takes one or more args",
                                  m_cmd_name.c_str());
     return false;
@@ -1332,8 +1333,9 @@ bool CommandObjectTypeSummaryAdd::Execute_ScriptSummary(
   } else {
     // Use an IOHandler to grab Python code from the user
     auto options = std::make_unique<ScriptAddOptions>(
-        m_options.m_flags, m_options.m_match_type, m_options.m_name,
-        m_options.m_category, m_options.m_ptr_match_depth);
+        m_options.m_flags, m_options.m_match_type,
+        ConstString(m_options.m_name), m_options.m_category,
+        m_options.m_ptr_match_depth);
 
     for (auto &entry : command.entries()) {
       if (entry.ref().empty()) {
@@ -1360,7 +1362,7 @@ bool CommandObjectTypeSummaryAdd::Execute_ScriptSummary(
   Status error;
 
   for (auto &entry : command.entries()) {
-    AddSummary(ConstString(entry.ref()), script_format, m_options.m_match_type,
+    AddSummary(entry.ref().str(), script_format, m_options.m_match_type,
                m_options.m_category, &error);
     if (error.Fail()) {
       result.AppendError(error.AsCString());
@@ -1368,7 +1370,7 @@ bool CommandObjectTypeSummaryAdd::Execute_ScriptSummary(
     }
   }
 
-  if (m_options.m_name) {
+  if (!m_options.m_name.empty()) {
     AddNamedSummary(m_options.m_name, script_format, &error);
     if (error.Fail()) {
       result.AppendError(error.AsCString());
@@ -1384,7 +1386,7 @@ bool CommandObjectTypeSummaryAdd::Execute_PythonClassSummary(
     Args &command, CommandReturnObject &result) {
   const size_t argc = command.GetArgumentCount();
 
-  if (argc < 1 && !m_options.m_name) {
+  if (argc < 1 && m_options.m_name.empty()) {
     result.AppendErrorWithFormat("%s takes one or more args",
                                  m_cmd_name.c_str());
     return false;
@@ -1402,7 +1404,7 @@ bool CommandObjectTypeSummaryAdd::Execute_PythonClassSummary(
   Status error;
 
   for (auto &entry : command.entries()) {
-    AddSummary(ConstString(entry.ref()), script_format, m_options.m_match_type,
+    AddSummary(entry.ref().str(), script_format, m_options.m_match_type,
                m_options.m_category, &error);
     if (error.Fail()) {
       result.AppendError(error.AsCString());
@@ -1410,7 +1412,7 @@ bool CommandObjectTypeSummaryAdd::Execute_PythonClassSummary(
     }
   }
 
-  if (m_options.m_name) {
+  if (!m_options.m_name.empty()) {
     AddNamedSummary(m_options.m_name, script_format, &error);
     if (error.Fail()) {
       result.AppendError(error.AsCString());
@@ -1428,7 +1430,7 @@ bool CommandObjectTypeSummaryAdd::Execute_StringSummary(
     Args &command, CommandReturnObject &result) {
   const size_t argc = command.GetArgumentCount();
 
-  if (argc < 1 && !m_options.m_name) {
+  if (argc < 1 && m_options.m_name.empty()) {
     result.AppendErrorWithFormat("%s takes one or more args",
                                  m_cmd_name.c_str());
     return false;
@@ -1470,10 +1472,9 @@ bool CommandObjectTypeSummaryAdd::Execute_StringSummary(
       result.AppendError("empty typenames not allowed");
       return false;
     }
-    ConstString typeCS(arg_entry.ref());
 
-    AddSummary(typeCS, entry, m_options.m_match_type, m_options.m_category,
-               &error);
+    AddSummary(arg_entry.ref().str(), entry, m_options.m_match_type,
+               m_options.m_category, &error);
 
     if (error.Fail()) {
       result.AppendError(error.AsCString());
@@ -1481,7 +1482,7 @@ bool CommandObjectTypeSummaryAdd::Execute_StringSummary(
     }
   }
 
-  if (m_options.m_name) {
+  if (!m_options.m_name.empty()) {
     AddNamedSummary(m_options.m_name, entry, &error);
     if (error.Fail()) {
       result.AppendError(error.AsCString());
@@ -1628,31 +1629,29 @@ void CommandObjectTypeSummaryAdd::DoExecute(Args &command,
     result.SetStatus(eReturnStatusSuccessFinishResult);
 }
 
-static bool FixArrayTypeNameWithRegex(ConstString &type_name) {
-  llvm::StringRef type_name_ref(type_name.GetStringRef());
+static bool FixArrayTypeNameWithRegex(std::string &type_name) {
+  llvm::StringRef type_name_ref(type_name);
 
   if (type_name_ref.ends_with("[]")) {
-    std::string type_name_str(type_name.GetCString());
-    type_name_str.resize(type_name_str.length() - 2);
-    if (type_name_str.back() != ' ')
-      type_name_str.append(" ?\\[[0-9]+\\]");
+    type_name.resize(type_name.length() - 2);
+    if (type_name.back() != ' ')
+      type_name.append(" ?\\[[0-9]+\\]");
     else
-      type_name_str.append("\\[[0-9]+\\]");
-    type_name.SetCString(type_name_str.c_str());
+      type_name.append("\\[[0-9]+\\]");
     return true;
   }
   return false;
 }
 
-bool CommandObjectTypeSummaryAdd::AddNamedSummary(ConstString summary_name,
+bool CommandObjectTypeSummaryAdd::AddNamedSummary(std::string summary_name,
                                                   TypeSummaryImplSP entry,
                                                   Status *error) {
   // system named summaries do not exist (yet?)
-  DataVisualization::NamedSummaryFormats::Add(summary_name, entry);
+  DataVisualization::NamedSummaryFormats::Add(ConstString(summary_name), entry);
   return true;
 }
 
-bool CommandObjectTypeSummaryAdd::AddSummary(ConstString type_name,
+bool CommandObjectTypeSummaryAdd::AddSummary(std::string type_name,
                                              TypeSummaryImplSP entry,
                                              FormatterMatchType match_type,
                                              std::string category_name,
@@ -1668,7 +1667,7 @@ bool CommandObjectTypeSummaryAdd::AddSummary(ConstString type_name,
 
   if (match_type == eFormatterMatchRegex) {
     match_type = eFormatterMatchRegex;
-    RegularExpression typeRX(type_name.GetStringRef());
+    RegularExpression typeRX(type_name);
     if (!typeRX.IsValid()) {
       if (error)
         *error = Status::FromErrorString(
@@ -1678,17 +1677,16 @@ bool CommandObjectTypeSummaryAdd::AddSummary(ConstString type_name,
   }
 
   if (match_type == eFormatterMatchCallback) {
-    const char *function_name = type_name.AsCString(nullptr);
     ScriptInterpreter *interpreter = GetDebugger().GetScriptInterpreter();
-    if (interpreter && !interpreter->CheckObjectExists(function_name)) {
+    if (interpreter && !interpreter->CheckObjectExists(type_name.c_str())) {
       *error = Status::FromErrorStringWithFormat(
           "The provided recognizer function \"%s\" does not exist - "
           "please define it before attempting to use this summary.\n",
-          function_name);
+          type_name.c_str());
       return false;
     }
   }
-  category->AddTypeSummary(type_name.GetStringRef(), match_type, entry);
+  category->AddTypeSummary(llvm::StringRef(type_name), match_type, entry);
   return true;
 }
 
@@ -2277,9 +2275,8 @@ bool CommandObjectTypeSynthAdd::Execute_PythonClass(
       return false;
     }
 
-    ConstString typeCS(arg_entry.ref());
-    if (!AddSynth(typeCS, entry, m_options.m_match_type, m_options.m_category,
-                  &error)) {
+    if (!AddSynth(arg_entry.ref().str(), entry, m_options.m_match_type,
+                  m_options.m_category, &error)) {
       result.AppendError(error.AsCString());
       return false;
     }
@@ -2297,7 +2294,7 @@ CommandObjectTypeSynthAdd::CommandObjectTypeSynthAdd(
   AddSimpleArgumentList(eArgTypeName, eArgRepeatPlus);
 }
 
-bool CommandObjectTypeSynthAdd::AddSynth(ConstString type_name,
+bool CommandObjectTypeSynthAdd::AddSynth(std::string type_name,
                                          SyntheticChildrenSP entry,
                                          FormatterMatchType match_type,
                                          std::string category_name,
@@ -2318,7 +2315,8 @@ bool CommandObjectTypeSynthAdd::AddSynth(ConstString type_name,
     // It's not generally possible to get a type object here. For example, this
     // command can be run before loading any binaries. Do just a best-effort
     // name-based lookup here to try to prevent conflicts.
-    FormattersMatchCandidate candidate_type(type_name, nullptr, TypeImpl(),
+    FormattersMatchCandidate candidate_type(ConstString(type_name), nullptr,
+                                            TypeImpl(),
                                             FormattersMatchCandidate::Flags());
     if (category->AnyMatches(candidate_type, eFormatCategoryItemFilter)) {
       if (error)
@@ -2331,7 +2329,7 @@ bool CommandObjectTypeSynthAdd::AddSynth(ConstString type_name,
   }
 
   if (match_type == eFormatterMatchRegex) {
-    RegularExpression typeRX(type_name.GetStringRef());
+    RegularExpression typeRX(type_name);
     if (!typeRX.IsValid()) {
       if (error)
         *error = Status::FromErrorString(
@@ -2341,18 +2339,17 @@ bool CommandObjectTypeSynthAdd::AddSynth(ConstString type_name,
   }
 
   if (match_type == eFormatterMatchCallback) {
-    const char *function_name = type_name.AsCString(nullptr);
     ScriptInterpreter *interpreter = GetDebugger().GetScriptInterpreter();
-    if (interpreter && !interpreter->CheckObjectExists(function_name)) {
+    if (interpreter && !interpreter->CheckObjectExists(type_name.c_str())) {
       *error = Status::FromErrorStringWithFormat(
           "The provided recognizer function \"%s\" does not exist - "
           "please define it before attempting to use this summary.\n",
-          function_name);
+          type_name.c_str());
       return false;
     }
   }
 
-  category->AddTypeSynthetic(type_name.GetStringRef(), match_type, entry);
+  category->AddTypeSynthetic(type_name, match_type, entry);
   return true;
 }
 
@@ -2439,7 +2436,7 @@ private:
 
   enum FilterFormatType { eRegularFilter, eRegexFilter };
 
-  bool AddFilter(ConstString type_name, TypeFilterImplSP entry,
+  bool AddFilter(std::string type_name, TypeFilterImplSP entry,
                  FilterFormatType type, std::string category_name,
                  Status *error) {
     lldb::TypeCategoryImplSP category;
@@ -2459,7 +2456,8 @@ private:
       // this command can be run before loading any binaries. Do just a
       // best-effort name-based lookup here to try to prevent conflicts.
       FormattersMatchCandidate candidate_type(
-          type_name, nullptr, TypeImpl(), FormattersMatchCandidate::Flags());
+          ConstString(type_name), nullptr, TypeImpl(),
+          FormattersMatchCandidate::Flags());
       lldb::SyntheticChildrenSP entry;
       if (category->AnyMatches(candidate_type, eFormatCategoryItemSynth)) {
         if (error)
@@ -2475,7 +2473,7 @@ private:
     FormatterMatchType match_type = eFormatterMatchExact;
     if (type == eRegexFilter) {
       match_type = eFormatterMatchRegex;
-      RegularExpression typeRX(type_name.GetStringRef());
+      RegularExpression typeRX(type_name);
       if (!typeRX.IsValid()) {
         if (error)
           *error = Status::FromErrorString(
@@ -2483,7 +2481,7 @@ private:
         return false;
       }
     }
-    category->AddTypeFilter(type_name.GetStringRef(), match_type, entry);
+    category->AddTypeFilter(llvm::StringRef(type_name), match_type, entry);
     return true;
   }
 
@@ -2577,8 +2575,7 @@ protected:
         return;
       }
 
-      ConstString typeCS(arg_entry.ref());
-      if (!AddFilter(typeCS, entry,
+      if (!AddFilter(arg_entry.ref().str(), entry,
                      m_options.m_regex ? eRegexFilter : eRegularFilter,
                      m_options.m_category, &error)) {
         result.AppendError(error.AsCString());


### PR DESCRIPTION
CommandObjectType was creating ConstStrings type names, function names, etc. before they needed to be. I'd like to remove ConstString from the DataFormatter code entirely, so pushing the creation down as far as possible first is a good first step.

The only remaining use (outside of function arguments) is ScriptAddOptions. I need to understand it more before I can really remove it.