### PR TITLE
[flang] Speed up large CHARACTER DATA initializers

### DIFF
--- a/flang/lib/Lower/ConvertConstant.cpp
+++ b/flang/lib/Lower/ConvertConstant.cpp
@@ -627,16 +627,7 @@ genInlinedArrayLit(Fortran::lower::AbstractConverter &converter,
   mlir::Value array = fir::UndefOp::create(builder, loc, arrayTy);
   if (Fortran::evaluate::GetSize(con.shape()) == 0)
     return array;
-  if constexpr (T::category == Fortran::common::TypeCategory::Character) {
-    do {
-      mlir::Value elementVal =
-          genScalarLit<T::kind>(builder, loc, con.At(subscripts), con.LEN(),
-                                /*outlineInReadOnlyMemory=*/false);
-      array =
-          fir::InsertValueOp::create(builder, loc, arrayTy, array, elementVal,
-                                     builder.getArrayAttr(createIdx()));
-    } while (con.IncrementSubscripts(subscripts));
-  } else if constexpr (T::category == Fortran::common::TypeCategory::Derived) {
+  if constexpr (T::category == Fortran::common::TypeCategory::Derived) {
     do {
       mlir::Type eleTy =
           mlir::cast<fir::SequenceType>(arrayTy).getElementType();
@@ -647,15 +638,31 @@ genInlinedArrayLit(Fortran::lower::AbstractConverter &converter,
           fir::InsertValueOp::create(builder, loc, arrayTy, array, elementVal,
                                      builder.getArrayAttr(createIdx()));
     } while (con.IncrementSubscripts(subscripts));
+  } else if constexpr (T::category ==
+                           Fortran::common::TypeCategory::Character &&
+                       T::kind != 1) {
+    do {
+      mlir::Value elementVal =
+          genScalarLit<T::kind>(builder, loc, con.At(subscripts), con.LEN(),
+                                /*outlineInReadOnlyMemory=*/false);
+      array =
+          fir::InsertValueOp::create(builder, loc, arrayTy, array, elementVal,
+                                     builder.getArrayAttr(createIdx()));
+    } while (con.IncrementSubscripts(subscripts));
   } else {
     llvm::SmallVector<mlir::Attribute> rangeStartIdx;
     uint64_t rangeSize = 0;
     mlir::Type eleTy = mlir::cast<fir::SequenceType>(arrayTy).getElementType();
     do {
       auto getElementVal = [&]() {
-        return builder.createConvert(loc, eleTy,
-                                     genScalarLit<T::category, T::kind>(
-                                         builder, loc, con.At(subscripts)));
+        if constexpr (T::category == Fortran::common::TypeCategory::Character)
+          return genScalarLit<T::kind>(builder, loc, con.At(subscripts),
+                                       con.LEN(),
+                                       /*outlineInReadOnlyMemory=*/false);
+        else
+          return builder.createConvert(loc, eleTy,
+                                       genScalarLit<T::category, T::kind>(
+                                           builder, loc, con.At(subscripts)));
       };
       Fortran::evaluate::ConstantSubscripts nextSubscripts = subscripts;
       bool nextIsSame = con.IncrementSubscripts(nextSubscripts) &&

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -2981,10 +2981,15 @@ struct InsertOnRangeOpConversion
 
     auto arrayType = adaptor.getSeq().getType();
 
-    // Iteratively extract the array dimensions from the type.
+    // Iteratively extract the array dimensions from the type. Only the
+    // dimensions represented by InsertOnRangeOp are used to expand a fallback
+    // insert chain. The remaining dimensions, if any, belong to an aggregate
+    // element type (e.g. CHARACTER lowers to an LLVM array).
     llvm::SmallVector<std::int64_t> dims;
     mlir::Type type = arrayType;
-    while (auto t = mlir::dyn_cast<mlir::LLVM::LLVMArrayType>(type)) {
+    auto rank = range.getType().getShape().size();
+    for (std::size_t i = 0; i < rank; ++i) {
+      auto t = mlir::cast<mlir::LLVM::LLVMArrayType>(type);
       dims.push_back(t.getNumElements());
       type = t.getElementType();
     }
@@ -3698,6 +3703,38 @@ struct GlobalOpConversion : public fir::FIROpConversion<fir::GlobalOp> {
       tyAttr = this->lowerTy().convertBoxTypeAsStruct(boxType);
     auto loc = global.getLoc();
     mlir::Attribute initAttr = global.getInitVal().value_or(mlir::Attribute());
+    bool hasFlatCharacterInit = false;
+    if (!global.getRegion().empty()) {
+      auto hasValue =
+          mlir::dyn_cast<fir::HasValueOp>(global.getRegion().front().back());
+      auto sequenceType = mlir::dyn_cast<fir::SequenceType>(global.getType());
+      auto charType =
+          sequenceType
+              ? mlir::dyn_cast<fir::CharacterType>(sequenceType.getEleTy())
+              : fir::CharacterType{};
+      auto insert =
+          hasValue ? hasValue.getResval().getDefiningOp<fir::InsertOnRangeOp>()
+                   : fir::InsertOnRangeOp{};
+      auto stringLit = insert
+                           ? insert.getVal().getDefiningOp<fir::StringLitOp>()
+                           : fir::StringLitOp{};
+      auto stringAttr =
+          stringLit ? mlir::dyn_cast<mlir::StringAttr>(stringLit.getValue())
+                    : mlir::StringAttr{};
+      if (sequenceType && charType && charType.getFKind() == 1 && insert &&
+          insert.isFullRange() && stringAttr) {
+        std::string element{stringAttr.getValue()};
+        element.resize(charType.getLen(), ' ');
+        std::string data;
+        data.reserve(sequenceType.getConstantArraySize() * element.size());
+        for (std::size_t i = 0; i < sequenceType.getConstantArraySize(); ++i)
+          data.append(element);
+        tyAttr =
+            mlir::LLVM::LLVMArrayType::get(rewriter.getI8Type(), data.size());
+        initAttr = rewriter.getStringAttr(data);
+        hasFlatCharacterInit = true;
+      }
+    }
     assert(attributeTypeIsCompatible(global.getContext(), initAttr, tyAttr));
     auto linkage = convertLinkage(global.getLinkName());
     auto isConst = global.getConstant().has_value();
@@ -3749,7 +3786,8 @@ struct GlobalOpConversion : public fir::FIROpConversion<fir::GlobalOp> {
         g->setAttr(attr.getName(), attr.getValue());
 
     auto &gr = g.getInitializerRegion();
-    rewriter.inlineRegionBefore(global.getRegion(), gr, gr.end());
+    if (!hasFlatCharacterInit)
+      rewriter.inlineRegionBefore(global.getRegion(), gr, gr.end());
     if (!gr.empty()) {
       // Replace insert_on_range with a constant dense attribute if the
       // initialization is on the full range.

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -2981,17 +2981,23 @@ struct InsertOnRangeOpConversion
 
     auto arrayType = adaptor.getSeq().getType();
 
-    // Iteratively extract the array dimensions from the type. Only the
-    // dimensions represented by InsertOnRangeOp are used to expand a fallback
-    // insert chain. The remaining dimensions, if any, belong to an aggregate
-    // element type (e.g. CHARACTER lowers to an LLVM array).
+    // Extract the dimensions of the array being initialized. Only those are
+    // used to expand a fallback insert chain. Any remaining LLVM array
+    // dimension belongs to an aggregate element type: a CHARACTER element is
+    // itself an array of characters.
     llvm::SmallVector<std::int64_t> dims;
     mlir::Type type = arrayType;
-    auto rank = range.getType().getShape().size();
-    for (std::size_t i = 0; i < rank; ++i) {
+    for (std::size_t i = 0, rank = range.getType().getShape().size(); i < rank;
+         ++i) {
       auto t = mlir::cast<mlir::LLVM::LLVMArrayType>(type);
       dims.push_back(t.getNumElements());
       type = t.getElementType();
+    }
+    llvm::SmallVector<std::int64_t> elementDims;
+    mlir::Type scalarType = type;
+    while (auto t = mlir::dyn_cast<mlir::LLVM::LLVMArrayType>(scalarType)) {
+      elementDims.push_back(t.getNumElements());
+      scalarType = t.getElementType();
     }
 
     // Avoid generating long insert chain that are very slow to fold back
@@ -3002,16 +3008,45 @@ struct InsertOnRangeOpConversion
       llvm::FailureOr<mlir::Attribute> cst =
           fir::tryFoldingLLVMInsertChain(adaptor.getVal(), rewriter);
       if (llvm::succeeded(cst)) {
-        mlir::Attribute dimVal = *cst;
-        for (auto dim : llvm::reverse(dims)) {
-          // Use std::vector in case the number of elements is big.
-          std::vector<mlir::Attribute> elements(dim, dimVal);
-          dimVal = mlir::ArrayAttr::get(range.getContext(), elements);
+        if (elementDims.empty()) {
+          mlir::Attribute dimVal = *cst;
+          for (auto dim : llvm::reverse(dims)) {
+            // Use std::vector in case the number of elements is big.
+            std::vector<mlir::Attribute> elements(dim, dimVal);
+            dimVal = mlir::ArrayAttr::get(range.getContext(), elements);
+          }
+          // Replace insert chain with constant.
+          rewriter.replaceOpWithNewOp<mlir::LLVM::ConstantOp>(range, arrayType,
+                                                              dimVal);
+          return mlir::success();
         }
-        // Replace insert chain with constant.
-        rewriter.replaceOpWithNewOp<mlir::LLVM::ConstantOp>(range, arrayType,
-                                                            dimVal);
-        return mlir::success();
+        // An array with an aggregate element type cannot be described by a
+        // nested ArrayAttr. A CHARACTER array is a dense array of characters,
+        // so replicate the element data into a dense attribute.
+        if (auto strAttr = mlir::dyn_cast<mlir::StringAttr>(*cst)) {
+          llvm::StringRef element = strAttr.getValue();
+          std::int64_t elementSize = 1;
+          for (std::int64_t dim : elementDims)
+            elementSize *= dim;
+          if (scalarType.isInteger(8) &&
+              element.size() == static_cast<std::size_t>(elementSize)) {
+            std::int64_t count = 1;
+            for (std::int64_t dim : dims)
+              count *= dim;
+            std::string data;
+            data.reserve(count * element.size());
+            for (std::int64_t i = 0; i < count; ++i)
+              data.append(element.data(), element.size());
+            llvm::SmallVector<std::int64_t> shape(dims);
+            shape.append(elementDims);
+            auto denseAttr = mlir::DenseElementsAttr::getFromRawBuffer(
+                mlir::RankedTensorType::get(shape, scalarType),
+                llvm::ArrayRef(data.data(), data.size()));
+            rewriter.replaceOpWithNewOp<mlir::LLVM::ConstantOp>(
+                range, arrayType, denseAttr);
+            return mlir::success();
+          }
+        }
       }
     }
 
@@ -3703,38 +3738,6 @@ struct GlobalOpConversion : public fir::FIROpConversion<fir::GlobalOp> {
       tyAttr = this->lowerTy().convertBoxTypeAsStruct(boxType);
     auto loc = global.getLoc();
     mlir::Attribute initAttr = global.getInitVal().value_or(mlir::Attribute());
-    bool hasFlatCharacterInit = false;
-    if (!global.getRegion().empty()) {
-      auto hasValue =
-          mlir::dyn_cast<fir::HasValueOp>(global.getRegion().front().back());
-      auto sequenceType = mlir::dyn_cast<fir::SequenceType>(global.getType());
-      auto charType =
-          sequenceType
-              ? mlir::dyn_cast<fir::CharacterType>(sequenceType.getEleTy())
-              : fir::CharacterType{};
-      auto insert =
-          hasValue ? hasValue.getResval().getDefiningOp<fir::InsertOnRangeOp>()
-                   : fir::InsertOnRangeOp{};
-      auto stringLit = insert
-                           ? insert.getVal().getDefiningOp<fir::StringLitOp>()
-                           : fir::StringLitOp{};
-      auto stringAttr =
-          stringLit ? mlir::dyn_cast<mlir::StringAttr>(stringLit.getValue())
-                    : mlir::StringAttr{};
-      if (sequenceType && charType && charType.getFKind() == 1 && insert &&
-          insert.isFullRange() && stringAttr) {
-        std::string element{stringAttr.getValue()};
-        element.resize(charType.getLen(), ' ');
-        std::string data;
-        data.reserve(sequenceType.getConstantArraySize() * element.size());
-        for (std::size_t i = 0; i < sequenceType.getConstantArraySize(); ++i)
-          data.append(element);
-        tyAttr =
-            mlir::LLVM::LLVMArrayType::get(rewriter.getI8Type(), data.size());
-        initAttr = rewriter.getStringAttr(data);
-        hasFlatCharacterInit = true;
-      }
-    }
     assert(attributeTypeIsCompatible(global.getContext(), initAttr, tyAttr));
     auto linkage = convertLinkage(global.getLinkName());
     auto isConst = global.getConstant().has_value();
@@ -3786,8 +3789,7 @@ struct GlobalOpConversion : public fir::FIROpConversion<fir::GlobalOp> {
         g->setAttr(attr.getName(), attr.getValue());
 
     auto &gr = g.getInitializerRegion();
-    if (!hasFlatCharacterInit)
-      rewriter.inlineRegionBefore(global.getRegion(), gr, gr.end());
+    rewriter.inlineRegionBefore(global.getRegion(), gr, gr.end());
     if (!gr.empty()) {
       // Replace insert_on_range with a constant dense attribute if the
       // initialization is on the full range.

--- a/flang/test/Lower/character-array-constant.f90
+++ b/flang/test/Lower/character-array-constant.f90
@@ -1,0 +1,24 @@
+! RUN: bbc -emit-hlfir %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-llvm %s -o - | FileCheck %s --check-prefix=LLVM
+
+program character_array_constant
+  character(4) :: values(10000)
+  character(4) :: words(3)
+  data values / 10000 * ' ' /
+  data words / 3 * 'ab' /
+end program
+
+! CHECK-LABEL: fir.global internal @_QFEvalues
+! CHECK: %[[UNDEF:.*]] = fir.undefined !fir.array<10000x!fir.char<1,4>>
+! CHECK-NEXT: %[[SPACE:.*]] = fir.string_lit "    "(4) : !fir.char<1,4>
+! CHECK-NEXT: %[[INIT:.*]] = fir.insert_on_range %[[UNDEF]], %[[SPACE]] from (0) to (9999) : (!fir.array<10000x!fir.char<1,4>>, !fir.char<1,4>) -> !fir.array<10000x!fir.char<1,4>>
+! CHECK: fir.has_value %[[INIT]] : !fir.array<10000x!fir.char<1,4>>
+
+! CHECK-LABEL: fir.global internal @_QFEwords
+! CHECK: %[[UNDEF:.*]] = fir.undefined !fir.array<3x!fir.char<1,4>>
+! CHECK-NEXT: %[[AB:.*]] = fir.string_lit "ab "(4) : !fir.char<1,4>
+! CHECK-NEXT: %[[INIT:.*]] = fir.insert_on_range %[[UNDEF]], %[[AB]] from (0) to (2) : (!fir.array<3x!fir.char<1,4>>, !fir.char<1,4>) -> !fir.array<3x!fir.char<1,4>>
+! CHECK: fir.has_value %[[INIT]] : !fir.array<3x!fir.char<1,4>>
+
+! LLVM: @_QFEvalues = internal global [40000 x i8]
+! LLVM: @_QFEwords = internal global [12 x i8] c"ab  ab  ab  "

--- a/flang/test/Lower/character-array-constant.f90
+++ b/flang/test/Lower/character-array-constant.f90
@@ -20,5 +20,21 @@ end program
 ! CHECK-NEXT: %[[INIT:.*]] = fir.insert_on_range %[[UNDEF]], %[[AB]] from (0) to (2) : (!fir.array<3x!fir.char<1,4>>, !fir.char<1,4>) -> !fir.array<3x!fir.char<1,4>>
 ! CHECK: fir.has_value %[[INIT]] : !fir.array<3x!fir.char<1,4>>
 
-! LLVM: @_QFEvalues = internal global [40000 x i8]
-! LLVM: @_QFEwords = internal global [12 x i8] c"ab  ab  ab  "
+! LLVM: @_QFEvalues = internal global [10000 x [4 x i8]]
+! LLVM: @_QFEwords = internal global [3 x [4 x i8]] [{{.*}}c"ab  ", {{.*}}c"ab  ", {{.*}}c"ab  "]
+
+! A CHARACTER array component is an array of characters nested inside a
+! structure, so its initial value cannot be described by an array attribute.
+subroutine component()
+  type t
+    character(2) :: c(2)
+  end type
+  type(t), save :: x = t(c=["ab", "ab"])
+  call use_x(x)
+end subroutine
+
+! CHECK-LABEL: fir.global internal @_QFcomponentEx
+! CHECK: %[[AB:.*]] = fir.string_lit "ab"(2) : !fir.char<1,2>
+! CHECK-NEXT: fir.insert_on_range %{{.*}}, %[[AB]] from (0) to (1) : (!fir.array<2x!fir.char<1,2>>, !fir.char<1,2>) -> !fir.array<2x!fir.char<1,2>>
+
+! LLVM: @_QFcomponentEx = internal global %_QFcomponentTt { [2 x [2 x i8]] [{{.*}}c"ab", {{.*}}c"ab"] }


### PR DESCRIPTION
[flang] Speed up large CHARACTER DATA initializers

Repeated CHARACTER(KIND=1) array constants were lowered as one
fir.insert_value per element. Converting those chains to LLVM IR is
quadratic and can make compilation take tens of minutes.

Lower consecutive equal KIND=1 character elements with fir.insert_on_range
and emit full-range initializers as a single flattened [N x i8] LLVM global
string, keeping Fortran blank padding.

A 160000-element character DATA statement now compiles in well under a
second and before was more than 10 minutes.