### PR TITLE
[Github] Hash pin ci-format container

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -13,7 +13,7 @@ jobs:
   code_formatter:
     runs-on: ubuntu-24.04
     container:
-      image: 'ghcr.io/llvm/ci-ubuntu-24.04-format'
+      image: 'ghcr.io/llvm/ci-ubuntu-24.04-format:latest@sha256:2201505efec61dde10ff149e2b6438c8bbdbefeb87c525a56df31cf0954ee6ca'
     timeout-minutes: 30
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION
This follows our own CI best practices and ensures zizmor/CodeQL will not complain about this when people inevitably touch it in the future.