### PR TITLE
[CI][Github] Bump premerge CI containers to LLVM 23

### DIFF
--- a/.github/workflows/containers/github-action-ci-windows/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-windows/Dockerfile
@@ -113,7 +113,7 @@ RUN powershell -Command \
     rm actions-runner-win.zip
 
 # Set the LLVM_VERSION environment variable
-ENV LLVM_VERSION=22.1.4
+ENV LLVM_VERSION=23.1.0
 
 # Download and extract Clang compiler.
 # Create directories, download, extract, and clean up all in one layer

--- a/.github/workflows/containers/github-action-ci/Dockerfile
+++ b/.github/workflows/containers/github-action-ci/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/library/ubuntu:24.04 AS base
 ENV LLVM_SYSROOT=/opt/llvm
 
 FROM base AS stage1-toolchain
-ENV LLVM_VERSION=22.1.4
+ENV LLVM_VERSION=23.1.0
 
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
To ensure we're using the latest release version of clang and friends for things like warnings.