### PR TITLE
[lldb] When re-enabling a watchpoint, save the current bytes

### DIFF
--- a/lldb/source/Breakpoint/Watchpoint.cpp
+++ b/lldb/source/Breakpoint/Watchpoint.cpp
@@ -421,6 +421,11 @@ void Watchpoint::SetEnabled(bool enabled, bool notify) {
   }
   bool changed = enabled != m_enabled;
   m_enabled = enabled;
+  if (enabled && !m_new_value_sp && m_target.GetProcessSP()) {
+    ExecutionContext exe_ctx;
+    m_target.GetProcessSP()->CalculateExecutionContext(exe_ctx);
+    CaptureWatchedValue(exe_ctx);
+  }
   if (notify && !m_is_ephemeral && changed)
     SendWatchpointChangedEvent(enabled ? eWatchpointEventTypeEnabled
                                        : eWatchpointEventTypeDisabled);

--- a/lldb/test/API/functionalities/watchpoint/run-reenable-watchpoint/Makefile
+++ b/lldb/test/API/functionalities/watchpoint/run-reenable-watchpoint/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/watchpoint/run-reenable-watchpoint/TestRunReEnableWatchpoint.py
+++ b/lldb/test/API/functionalities/watchpoint/run-reenable-watchpoint/TestRunReEnableWatchpoint.py
@@ -1,0 +1,51 @@
+"""
+Test that a watchpoint created in one Process can be
+re-enabled in a second Process launch and behave
+correctly.
+"""
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class RunReEnableWatchpointTestCase(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def continue_and_report_stop_reason(self, process, iter_str):
+        process.Continue()
+        self.assertIn(
+            process.GetState(), [lldb.eStateStopped, lldb.eStateExited], iter_str
+        )
+        thread = process.GetSelectedThread()
+        return thread.GetStopReason()
+
+    # We must be able to launch the inferior with ASLR disabled
+    # so the static array lands at the same address after relaunch.
+    @skipUnlessPlatform(["macosx"])
+    def test_rerun_enable_watchpoint(self):
+        """Test set watchpoint, re-run, re-enable wp, hit it."""
+        self.build()
+        self.main_source_file = lldb.SBFileSpec("main.c")
+        li = lldb.SBLaunchInfo(None)
+        li.SetLaunchFlags(lldb.eLaunchFlagDisableASLR)
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "break here", self.main_source_file, launch_info=li
+        )
+
+        frame = thread.GetFrameAtIndex(0)
+        self.runCmd("watch set variable arr")
+
+        reason = self.continue_and_report_stop_reason(process, "continue first-launch")
+        self.assertEqual(reason, lldb.eStopReasonWatchpoint)
+
+        process.Kill()
+        self.runCmd("process launch --disable-aslr true")
+        process = target.GetProcess()
+        self.assertTrue(process.IsValid())
+
+        target.EnableAllWatchpoints()
+
+        reason = self.continue_and_report_stop_reason(process, "continue second-launch")
+        self.assertEqual(reason, lldb.eStopReasonWatchpoint)

--- a/lldb/test/API/functionalities/watchpoint/run-reenable-watchpoint/TestRunReEnableWatchpoint.py
+++ b/lldb/test/API/functionalities/watchpoint/run-reenable-watchpoint/TestRunReEnableWatchpoint.py
@@ -27,12 +27,22 @@ class RunReEnableWatchpointTestCase(TestBase):
     def test_rerun_enable_watchpoint(self):
         """Test set watchpoint, re-run, re-enable wp, hit it."""
         self.build()
-        self.main_source_file = lldb.SBFileSpec("main.c")
-        li = lldb.SBLaunchInfo(None)
-        li.SetLaunchFlags(lldb.eLaunchFlagDisableASLR)
-        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
-            self, "break here", self.main_source_file, launch_info=li
-        )
+        exe = self.getBuildArtifact("a.out")
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+        self.assertGreater(target.GetNumModules(), 0)
+
+        src = lldb.SBFileSpec("main.c")
+        bkpt1 = target.BreakpointCreateBySourceRegex("break here launch1", src)
+        self.assertEqual(bkpt1.GetNumLocations(), 1)
+        self.assertTrue(bkpt1.GetLocationAtIndex(0).IsEnabled())
+
+        self.runCmd("process launch --disable-aslr true")
+        process = target.GetProcess()
+        self.assertTrue(process.IsValid())
+        self.assertEqual(process.GetState(), lldb.eStateStopped)
+        thread = process.GetSelectedThread()
+        self.assertEqual(thread.GetStopReason(), lldb.eStopReasonBreakpoint)
 
         frame = thread.GetFrameAtIndex(0)
         self.runCmd("watch set variable arr")
@@ -40,12 +50,33 @@ class RunReEnableWatchpointTestCase(TestBase):
         reason = self.continue_and_report_stop_reason(process, "continue first-launch")
         self.assertEqual(reason, lldb.eStopReasonWatchpoint)
 
+        var_list = target.FindGlobalVariables("arr", 1)
+        self.assertEqual(var_list.GetSize(), 1)
+        arr = var_list.GetValueAtIndex(0)
+        self.assertEqual(arr.GetNumChildren(), 6)
+        self.assertEqual(arr.GetChildAtIndex(0).GetValueAsUnsigned(), 2)
+
+        target.DeleteAllBreakpoints()
         process.Kill()
+
+        bkpt2 = target.BreakpointCreateBySourceRegex("break here launch2", src)
+        self.assertEqual(bkpt2.GetNumLocations(), 1)
+        self.assertTrue(bkpt2.GetLocationAtIndex(0).IsEnabled())
+
         self.runCmd("process launch --disable-aslr true")
         process = target.GetProcess()
         self.assertTrue(process.IsValid())
+        self.assertEqual(process.GetState(), lldb.eStateStopped)
+        thread = process.GetSelectedThread()
+        self.assertEqual(thread.GetStopReason(), lldb.eStopReasonBreakpoint)
 
         target.EnableAllWatchpoints()
 
         reason = self.continue_and_report_stop_reason(process, "continue second-launch")
         self.assertEqual(reason, lldb.eStopReasonWatchpoint)
+
+        var_list = target.FindGlobalVariables("arr", 1)
+        self.assertEqual(var_list.GetSize(), 1)
+        arr = var_list.GetValueAtIndex(0)
+        self.assertEqual(arr.GetNumChildren(), 6)
+        self.assertEqual(arr.GetChildAtIndex(0).GetValueAsUnsigned(), 4)

--- a/lldb/test/API/functionalities/watchpoint/run-reenable-watchpoint/main.c
+++ b/lldb/test/API/functionalities/watchpoint/run-reenable-watchpoint/main.c
@@ -1,0 +1,7 @@
+static int arr[] = {1, 2, 0, 3, 4, 0x55555555};
+int main()
+{
+    arr[0]++; // break here
+    arr[0]++;
+    return arr[4];
+}

--- a/lldb/test/API/functionalities/watchpoint/run-reenable-watchpoint/main.c
+++ b/lldb/test/API/functionalities/watchpoint/run-reenable-watchpoint/main.c
@@ -1,7 +1,6 @@
 static int arr[] = {1, 2, 0, 3, 4, 0x55555555};
-int main()
-{
-    arr[0]++; // break here
-    arr[0]++;
-    return arr[4];
+int main() {
+  arr[0]++; // break here
+  arr[0]++;
+  return arr[4];
 }

--- a/lldb/test/API/functionalities/watchpoint/run-reenable-watchpoint/main.c
+++ b/lldb/test/API/functionalities/watchpoint/run-reenable-watchpoint/main.c
@@ -1,6 +1,8 @@
 static int arr[] = {1, 2, 0, 3, 4, 0x55555555};
 int main() {
-  arr[0]++; // break here
+  arr[0]++; // break here launch1
+  arr[0]++;
+  arr[0]++; // break here launch2
   arr[0]++;
   return arr[4];
 }


### PR DESCRIPTION
A watchpoint holds the current byte values of the memory region it is watching.  When we have a watchpoint in place and re-run, the saved values are flushed.  If the user then re-enables that watchpoint in the next Process launch, we need to collect the current values again for the Watchpoint at that point.

The test depends on watching a byte range that does not change across process launch.  On Darwin systems, macOS is the only one that can disable ASLR.  I don't know if this test can be enabled on Linux with the disable-ASLR process launch option.

rdar://184927603