### PR TITLE
[NFC] Skip a test on target={{.*}}-apple-darwin for TLS using

### DIFF
--- a/clang/test/CodeGenCXX/module-initializer-elision.cpp
+++ b/clang/test/CodeGenCXX/module-initializer-elision.cpp
@@ -1,3 +1,5 @@
+// UNSUPPORTED: target={{.*}}-apple-darwin
+
 // RUN: rm -rf %t
 // RUN: split-file %s %t
 // RUN: cd %t


### PR DESCRIPTION
Close https://github.com/llvm/llvm-project/pull/218346