### PR TITLE
[IndVarSimplify] Invalidate only dispositions after invariant sink

### DIFF
--- a/llvm/lib/Transforms/Scalar/IndVarSimplify.cpp
+++ b/llvm/lib/Transforms/Scalar/IndVarSimplify.cpp
@@ -1268,9 +1268,11 @@ bool IndVarSimplify::sinkUnusedInvariants(Loop *L) {
 
     // Otherwise, sink it to the exit block.
     I.moveBefore(ExitBlock->getFirstInsertionPt());
-    SE->forgetValue(&I);
     MadeAnyChanges = true;
   }
+
+  if (MadeAnyChanges)
+    SE->forgetBlockAndLoopDispositions();
 
   return MadeAnyChanges;
 }


### PR DESCRIPTION
So I am not too experienced with LLVM code.

but It looks like every `forgetValue` was causing it to clear the cache of the entire SCEV, and it does this for every instruction in `visitAndClearUsers` which walks the def-use children via `PushDefUseChildren`

```cpp
void ScalarEvolution::forgetValue(Value *V) {
  SmallPtrSet<Instruction *, 8> Visited;
  visitAndClearUsers(Worklist, Visited, ToForget);
  ...
}

// visitAndClearUsers
while (!Worklist.empty()) {
  Instruction *I = Worklist.pop_back_val();
  ...
  ValueExprMap ... erase ...
  PushDefUseChildren(I, Worklist, Visited);
}

// PushDefUseChildren
for (User *U : I->users()) {
  auto *UserInsn = cast<Instruction>(U);
  if (Visited.insert(UserInsn).second)
    Worklist.push_back(UserInsn);
}
```

so that caused it to be $O(n^2)$.
Only doing dispositions seems to fix the issue.

If it is better, I could also instead make a new forgetValue function that forgets them all at once.
