### PR TITLE
[MCParser,test] Improve macro argument charset test

### DIFF
--- a/llvm/test/MC/AsmParser/altmacro-arg.s
+++ b/llvm/test/MC/AsmParser/altmacro-arg.s
@@ -10,6 +10,7 @@
 # CHECK:      .data
 # CHECK-NEXT: .ascii "b cc rbx"
 # CHECK-NEXT: .ascii "bcc ccx rbx raxx"
+# CHECK-NEXT: .ascii "b?x b@x b#x b!x a_"
 .macro gen a, ra, rax
   ja 1f
   xorq %rax, %rax
@@ -17,6 +18,7 @@
 .data
   .ascii "\a \ra \rax"
   .ascii "a\()ra ra\()x rax raxx"
+  .ascii "a?x a@x a#x a!x a_"
 .endm
 gen b, cc, rbx
 

--- a/llvm/test/MC/AsmParser/macro-arg.s
+++ b/llvm/test/MC/AsmParser/macro-arg.s
@@ -100,3 +100,12 @@ ascii3 x - y z 1
 ascii3 1, (2 3)
 # CHECK: .ascii "1|(2 3)|"
 ascii3 1 (2 3)
+
+## '@', '#' and '?' are identifier characters, but they terminate a macro argument name.
+.macro charset a
+.ascii "\a?x|\a?|\a@x|\a#x|\a!x"
+\a?y:
+.endm
+# CHECK:      .ascii "fo?x|fo?|fo@x|fo#x|fo!x"
+# CHECK-NEXT: "fo?y":
+charset fo


### PR DESCRIPTION
'@', '#', and '?' are assembly identifier characters, but they terminate
a macro argument name.