### PR TITLE
[Clang][CodeGen] Fix crash in EmitParmDecl for bodyless destructors with -fextend-variable-liveness

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -550,6 +550,7 @@ features cannot lower the translation-unit ABI level;
 - Fixed a crash when instantiating an invalid dependent friend destructor declaration in a class template. (#GH210234)
 - Fixed an assertion failure in `-extract-api` when a documentation comment
   contains invalid UTF-8. (#GH212393)
+- Fixed a crash when generating fake uses for parameters of bodyless destructors with `-fextend-variable-liveness`.
 
 ### OpenACC Specific Changes
 

--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -2856,7 +2856,7 @@ void CodeGenFunction::EmitParmDecl(const VarDecl &D, ParamValue Arg,
        &D == CXXABIThisDecl)) {
     // We don't emit fake uses for coroutine parameters, other than `this`.
     if (auto *FnDecl = dyn_cast_or_null<FunctionDecl>(CurCodeDecl);
-        &D == CXXABIThisDecl || !FnDecl ||
+        &D == CXXABIThisDecl || !FnDecl || !FnDecl->getBody() ||
         FnDecl->getBody()->getStmtClass() != Stmt::CoroutineBodyStmtClass) {
       if (shouldExtendLifetime(getContext(), CurCodeDecl, D, CXXABIThisDecl))
         EHStack.pushCleanup<FakeUse>(NormalFakeUse, DeclPtr);

--- a/clang/test/CodeGen/fake-use-msvc-dtor.cpp
+++ b/clang/test/CodeGen/fake-use-msvc-dtor.cpp
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 %s -triple x86_64-pc-windows-msvc -emit-llvm -fextend-variable-liveness=all -O1 -mconstructor-aliases -o /dev/null
+// Verify that we do not crash when generating fake uses for parameters
+// of destructor declarations that have no body (the should_call_delete
+// implicit parameter in MSVC deleting destructors).
+
+struct A {
+  virtual ~A(void);
+};
+struct B {
+  virtual ~B(void);
+};
+
+struct C : A, B {};
+
+void foo() {
+  C c;
+}


### PR DESCRIPTION
The fake-use coroutine check in EmitParmDecl calls FnDecl->getBody()->getStmtClass() without guarding against a null getBody(). This crashes when processing implicit parameters (e.g. should_call_delete) of MSVC deleting destructors whose base destructor is only declared, not defined.