### PR TITLE
[Github] Bump containers in pr-code-{format,lint} workflows

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -13,7 +13,7 @@ jobs:
   code_formatter:
     runs-on: ubuntu-24.04
     container:
-      image: 'ghcr.io/llvm/ci-ubuntu-24.04-format:latest@sha256:2201505efec61dde10ff149e2b6438c8bbdbefeb87c525a56df31cf0954ee6ca'
+      image: 'ghcr.io/llvm/ci-ubuntu-24.04-format:latest@sha256:7d17cad6fb4fcf9b23bef3a4c6debe9e516e9a38298d8244bdd486322f2b1cc8'
     timeout-minutes: 30
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-code-lint.yml
+++ b/.github/workflows/pr-code-lint.yml
@@ -21,7 +21,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: 'ghcr.io/llvm/ci-ubuntu-24.04-lint:latest@sha256:416874e477b33c1cb66a30e77e0b9942b7333a7bd304c2f1d51743e7adaedd54'
+      image: 'ghcr.io/llvm/ci-ubuntu-24.04-lint:latest@sha256:1b62569840b08f7c966a20effdba36845b9890dc5661a8ed6f271b0f003e398f'
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This will pick up the LLVM 23 upgrade.