### PR TITLE
[mlir][MPIToLLVM] Take the descriptor index type from the descriptor

### DIFF
--- a/mlir/include/mlir/Conversion/LLVMCommon/Pattern.h
+++ b/mlir/include/mlir/Conversion/LLVMCommon/Pattern.h
@@ -88,6 +88,11 @@ LogicalResult decomposeValue(OpBuilder &builder, Location loc, Value src,
 Value composeValue(OpBuilder &builder, Location loc, ValueRange src,
                    Type dstType);
 
+/// Creates a constant Op producing a value of `resultType` from an index-typed
+/// integer attribute.
+Value createIndexAttrConstant(OpBuilder &builder, Location loc, Type resultType,
+                              int64_t value);
+
 /// Performs the index computation to get to the element at `indices` of the
 /// memory pointed to by `memRefDesc`, using the layout map of `type`.
 /// The indices are linearized as:

--- a/mlir/lib/Conversion/LLVMCommon/MemRefBuilder.cpp
+++ b/mlir/lib/Conversion/LLVMCommon/MemRefBuilder.cpp
@@ -8,6 +8,7 @@
 
 #include "mlir/Conversion/LLVMCommon/MemRefBuilder.h"
 #include "MemRefDescriptor.h"
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
@@ -95,14 +96,6 @@ void MemRefDescriptor::setAlignedPtr(OpBuilder &builder, Location loc,
   setPtr(builder, loc, kAlignedPtrPosInMemRefDescriptor, ptr);
 }
 
-// Creates a constant Op producing a value of `resultType` from an index-typed
-// integer attribute.
-static Value createIndexAttrConstant(OpBuilder &builder, Location loc,
-                                     Type resultType, int64_t value) {
-  return LLVM::ConstantOp::create(builder, loc, resultType,
-                                  builder.getIndexAttr(value));
-}
-
 /// Builds IR extracting the offset from the descriptor.
 Value MemRefDescriptor::offset(OpBuilder &builder, Location loc) {
   return LLVM::ExtractValueOp::create(builder, loc, value,
@@ -120,7 +113,7 @@ void MemRefDescriptor::setOffset(OpBuilder &builder, Location loc,
 void MemRefDescriptor::setConstantOffset(OpBuilder &builder, Location loc,
                                          uint64_t offset) {
   setOffset(builder, loc,
-            createIndexAttrConstant(builder, loc, indexType, offset));
+            LLVM::createIndexAttrConstant(builder, loc, indexType, offset));
 }
 
 /// Builds IR extracting the pos-th size from the descriptor.
@@ -137,7 +130,7 @@ Value MemRefDescriptor::size(OpBuilder &builder, Location loc, Value pos,
   auto ptrTy = LLVM::LLVMPointerType::get(builder.getContext());
 
   // Copy size values to stack-allocated memory.
-  auto one = createIndexAttrConstant(builder, loc, indexType, 1);
+  auto one = LLVM::createIndexAttrConstant(builder, loc, indexType, 1);
   auto sizes = LLVM::ExtractValueOp::create(
       builder, loc, value,
       llvm::ArrayRef<int64_t>({kSizePosInMemRefDescriptor}));
@@ -162,7 +155,7 @@ void MemRefDescriptor::setSize(OpBuilder &builder, Location loc, unsigned pos,
 void MemRefDescriptor::setConstantSize(OpBuilder &builder, Location loc,
                                        unsigned pos, uint64_t size) {
   setSize(builder, loc, pos,
-          createIndexAttrConstant(builder, loc, indexType, size));
+          LLVM::createIndexAttrConstant(builder, loc, indexType, size));
 }
 
 /// Builds IR extracting the pos-th stride from the descriptor.
@@ -183,7 +176,7 @@ void MemRefDescriptor::setStride(OpBuilder &builder, Location loc, unsigned pos,
 void MemRefDescriptor::setConstantStride(OpBuilder &builder, Location loc,
                                          unsigned pos, uint64_t stride) {
   setStride(builder, loc, pos,
-            createIndexAttrConstant(builder, loc, indexType, stride));
+            LLVM::createIndexAttrConstant(builder, loc, indexType, stride));
 }
 
 LLVM::LLVMPointerType MemRefDescriptor::getElementPtrType() {
@@ -209,7 +202,7 @@ Value MemRefDescriptor::bufferPtr(OpBuilder &builder, Location loc,
   Value offsetVal =
       ShapedType::isDynamic(offsetCst)
           ? offset(builder, loc)
-          : createIndexAttrConstant(builder, loc, indexType, offsetCst);
+          : LLVM::createIndexAttrConstant(builder, loc, indexType, offsetCst);
   Type elementType = converter.convertType(type.getElementType());
   ptr = LLVM::GEPOp::create(builder, loc, ptr.getType(), elementType, ptr,
                             offsetVal);
@@ -360,9 +353,9 @@ Value UnrankedMemRefDescriptor::computeSize(
   Type indexType = typeConverter.getIndexType();
 
   // Initialize shared constants.
-  Value one = createIndexAttrConstant(builder, loc, indexType, 1);
-  Value two = createIndexAttrConstant(builder, loc, indexType, 2);
-  Value indexSize = createIndexAttrConstant(
+  Value one = LLVM::createIndexAttrConstant(builder, loc, indexType, 1);
+  Value two = LLVM::createIndexAttrConstant(builder, loc, indexType, 2);
+  Value indexSize = LLVM::createIndexAttrConstant(
       builder, loc, indexType,
       llvm::divideCeil(typeConverter.getIndexTypeBitwidth(), 8));
 
@@ -373,7 +366,7 @@ Value UnrankedMemRefDescriptor::computeSize(
   //   2 * sizeof(pointer) + (1 + 2 * rank) * sizeof(index).
   // TODO: consider including the actual size (including eventual padding due
   // to data layout) into the unranked descriptor.
-  Value pointerSize = createIndexAttrConstant(
+  Value pointerSize = LLVM::createIndexAttrConstant(
       builder, loc, indexType,
       llvm::divideCeil(typeConverter.getPointerBitwidth(addressSpace), 8));
   Value doublePointerSize =

--- a/mlir/lib/Conversion/LLVMCommon/Pattern.cpp
+++ b/mlir/lib/Conversion/LLVMCommon/Pattern.cpp
@@ -55,12 +55,17 @@ Type ConvertToLLVMPattern::getPtrType(unsigned addressSpace) const {
 
 Type ConvertToLLVMPattern::getVoidPtrType() const { return getPtrType(); }
 
+Value mlir::LLVM::createIndexAttrConstant(OpBuilder &builder, Location loc,
+                                          Type resultType, int64_t value) {
+  return LLVM::ConstantOp::create(builder, loc, resultType,
+                                  builder.getIndexAttr(value));
+}
+
 Value ConvertToLLVMPattern::createIndexAttrConstant(OpBuilder &builder,
                                                     Location loc,
                                                     Type resultType,
                                                     int64_t value) {
-  return LLVM::ConstantOp::create(builder, loc, resultType,
-                                  builder.getIndexAttr(value));
+  return LLVM::createIndexAttrConstant(builder, loc, resultType, value);
 }
 
 Value ConvertToLLVMPattern::getStridedElementPtr(
@@ -628,11 +633,10 @@ Value mlir::LLVM::getStridedElementPtr(OpBuilder &builder, Location loc,
   for (int i = 0, e = indices.size(); i < e; ++i) {
     Value increment = indices[i];
     if (strides[i] != 1) { // Skip if stride is 1.
-      Value stride =
-          ShapedType::isDynamic(strides[i])
-              ? memRefDescriptor.stride(builder, loc, i)
-              : LLVM::ConstantOp::create(builder, loc, indexType,
-                                         builder.getIndexAttr(strides[i]));
+      Value stride = ShapedType::isDynamic(strides[i])
+                         ? memRefDescriptor.stride(builder, loc, i)
+                         : LLVM::createIndexAttrConstant(builder, loc,
+                                                         indexType, strides[i]);
       increment = LLVM::MulOp::create(builder, loc, increment, stride,
                                       intOverflowFlags);
     }

--- a/mlir/lib/Conversion/MPIToLLVM/MPIToLLVM.cpp
+++ b/mlir/lib/Conversion/MPIToLLVM/MPIToLLVM.cpp
@@ -15,7 +15,6 @@
 #include "mlir/Conversion/MPIToLLVM/MPIToLLVM.h"
 #include "mlir/Conversion/ConvertToLLVM/ToLLVMInterface.h"
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
-#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/DLTI/DLTI.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -56,24 +55,33 @@ std::pair<Value, Value> getRawPtrAndSize(const Location loc,
                                          Value memRef, int64_t rank,
                                          Type elType) {
   Type ptrType = LLVM::LLVMPointerType::get(rewriter.getContext());
+  Type i32Type = rewriter.getI32Type();
+  auto descriptorType = cast<LLVM::LLVMStructType>(memRef.getType());
+  // The offset and the sizes of a memref descriptor have the converted index
+  // type, which is not necessarily `i64`. Take it from the descriptor itself.
+  auto indexType = cast<IntegerType>(descriptorType.getBody()[2]);
+
   Value dataPtr =
       LLVM::ExtractValueOp::create(rewriter, loc, ptrType, memRef, 1);
-  Value offset = LLVM::ExtractValueOp::create(rewriter, loc,
-                                              rewriter.getI64Type(), memRef, 2);
+  Value offset =
+      LLVM::ExtractValueOp::create(rewriter, loc, indexType, memRef, 2);
   Value resPtr =
       LLVM::GEPOp::create(rewriter, loc, ptrType, elType, dataPtr, offset);
-  Value size = LLVM::ConstantOp::create(rewriter, loc, rewriter.getI32Type(),
+  Value size = LLVM::ConstantOp::create(rewriter, loc, i32Type,
                                         rewriter.getIndexAttr(1));
-  if (cast<LLVM::LLVMStructType>(memRef.getType()).getBody().size() > 3) {
+  if (descriptorType.getBody().size() > 3) {
     for (int64_t i = 0; i < rank; ++i) {
       Value dim = LLVM::ExtractValueOp::create(rewriter, loc, memRef,
                                                ArrayRef<int64_t>{3, i});
-      dim = LLVM::TruncOp::create(rewriter, loc, rewriter.getI32Type(), dim);
-      size =
-          LLVM::MulOp::create(rewriter, loc, rewriter.getI32Type(), dim, size);
+      // The MPI interface counts elements in an `i32`, so adjust the
+      // index-typed extent to that width. Extents are non-negative, hence the
+      // zero extension.
+      if (indexType.getWidth() > 32)
+        dim = LLVM::TruncOp::create(rewriter, loc, i32Type, dim);
+      else if (indexType.getWidth() < 32)
+        dim = LLVM::ZExtOp::create(rewriter, loc, i32Type, dim);
+      size = LLVM::MulOp::create(rewriter, loc, i32Type, dim, size);
     }
-  } else {
-    size = arith::ConstantIntOp::create(rewriter, loc, 1, 32);
   }
   return {resPtr, size};
 }

--- a/mlir/test/Conversion/MPIToLLVM/mpitollvm.mlir
+++ b/mlir/test/Conversion/MPIToLLVM/mpitollvm.mlir
@@ -1,4 +1,6 @@
-// RUN: mlir-opt -split-input-file -convert-to-llvm %s | FileCheck %s
+// `dynamic=true` makes the conversion respect the module's data layout,
+// which is needed to test index types other than the default `i64`.
+// RUN: mlir-opt -split-input-file -convert-to-llvm="dynamic=true" %s | FileCheck %s
 
 // COM: Test MPICH ABI
 // CHECK-LABEL: module attributes {dlti.map = #dlti.map<"MPI:Implementation" = "MPICH">} {
@@ -322,6 +324,74 @@ module attributes {mpi.dlti = #dlti.map<"MPI:Implementation" = "MPICH", "MPI:com
     // CHECK-NOT: llvm.call @MPI_Comm_size
     // CHECK: llvm.call @MPI_Allgather({{.*}}) : (!llvm.ptr, i32, i32, !llvm.ptr, i32, i32, i32) -> i32
     %err3 = mpi.allgather(%arg0, %arg0, %comm) : memref<100xf32>, memref<100xf32> -> !mpi.retval
+    return
+  }
+}
+
+// -----
+
+// COM: Test that an index type that already matches the MPI element count width
+// COM: is used as is, both for the offset and for the extents.
+module attributes {dlti.map = #dlti.map<"MPI:Implementation" = "MPICH">,
+                   dlti.dl_spec = #dlti.dl_spec<index = 32 : i32>} {
+  // CHECK-LABEL: llvm.func @test_send_index32
+  func.func @test_send_index32(%arg0: memref<100xf32>, %rank: i32) {
+    // CHECK: [[v0:%.*]] = llvm.insertvalue {{.*}}[4, 0] : !llvm.struct<(ptr, ptr, i32, array<1 x i32>, array<1 x i32>)>
+    %comm = mpi.comm_world : !mpi.comm
+    // CHECK: [[v1:%.*]] = llvm.extractvalue [[v0]][1] : !llvm.struct<(ptr, ptr, i32, array<1 x i32>, array<1 x i32>)>
+    // CHECK: [[v2:%.*]] = llvm.extractvalue [[v0]][2] : !llvm.struct<(ptr, ptr, i32, array<1 x i32>, array<1 x i32>)>
+    // CHECK: [[v3:%.*]] = llvm.getelementptr [[v1]][[[v2]]] : (!llvm.ptr, i32) -> !llvm.ptr, f32
+    // CHECK: [[v4:%.*]] = llvm.mlir.constant(1 : index) : i32
+    // CHECK: [[v5:%.*]] = llvm.extractvalue [[v0]][3, 0] : !llvm.struct<(ptr, ptr, i32, array<1 x i32>, array<1 x i32>)>
+    // COM: No width adjustment, the extent is already an `i32`.
+    // CHECK-NOT: llvm.trunc
+    // CHECK-NOT: llvm.zext
+    // CHECK: [[v6:%.*]] = llvm.mul [[v5]], [[v4]] : i32
+    // CHECK: llvm.call @MPI_Send([[v3]], [[v6]], {{.*}}) : (!llvm.ptr, i32, i32, i32, i32, i32) -> i32
+    mpi.send(%arg0, %rank, %rank, %comm) : memref<100xf32>, i32, i32
+    return
+  }
+}
+
+// -----
+
+// COM: Test that an index type narrower than the MPI element count is zero
+// COM: extended.
+module attributes {dlti.map = #dlti.map<"MPI:Implementation" = "MPICH">,
+                   dlti.dl_spec = #dlti.dl_spec<index = 16 : i32>} {
+  // CHECK-LABEL: llvm.func @test_send_index16
+  func.func @test_send_index16(%arg0: memref<100xf32>, %rank: i32) {
+    // CHECK: [[v0:%.*]] = llvm.insertvalue {{.*}}[4, 0] : !llvm.struct<(ptr, ptr, i16, array<1 x i16>, array<1 x i16>)>
+    %comm = mpi.comm_world : !mpi.comm
+    // CHECK: [[v1:%.*]] = llvm.extractvalue [[v0]][1] : !llvm.struct<(ptr, ptr, i16, array<1 x i16>, array<1 x i16>)>
+    // CHECK: [[v2:%.*]] = llvm.extractvalue [[v0]][2] : !llvm.struct<(ptr, ptr, i16, array<1 x i16>, array<1 x i16>)>
+    // CHECK: [[v3:%.*]] = llvm.getelementptr [[v1]][[[v2]]] : (!llvm.ptr, i16) -> !llvm.ptr, f32
+    // CHECK: [[v4:%.*]] = llvm.mlir.constant(1 : index) : i32
+    // CHECK: [[v5:%.*]] = llvm.extractvalue [[v0]][3, 0] : !llvm.struct<(ptr, ptr, i16, array<1 x i16>, array<1 x i16>)>
+    // CHECK: [[v6:%.*]] = llvm.zext [[v5]] : i16 to i32
+    // CHECK: [[v7:%.*]] = llvm.mul [[v6]], [[v4]] : i32
+    // CHECK: llvm.call @MPI_Send([[v3]], [[v7]], {{.*}}) : (!llvm.ptr, i32, i32, i32, i32, i32) -> i32
+    mpi.send(%arg0, %rank, %rank, %comm) : memref<100xf32>, i32, i32
+    return
+  }
+}
+
+// -----
+
+// COM: Test that a rank-zero memref, whose descriptor carries no extents, uses
+// COM: the element count of one directly.
+module attributes {dlti.map = #dlti.map<"MPI:Implementation" = "MPICH">} {
+  // CHECK-LABEL: llvm.func @test_send_rank_zero
+  func.func @test_send_rank_zero(%arg0: memref<f32>, %rank: i32) {
+    // CHECK: [[v0:%.*]] = llvm.insertvalue {{.*}}[2] : !llvm.struct<(ptr, ptr, i64)>
+    %comm = mpi.comm_world : !mpi.comm
+    // CHECK: [[v1:%.*]] = llvm.extractvalue [[v0]][1] : !llvm.struct<(ptr, ptr, i64)>
+    // CHECK: [[v2:%.*]] = llvm.extractvalue [[v0]][2] : !llvm.struct<(ptr, ptr, i64)>
+    // CHECK: [[v3:%.*]] = llvm.getelementptr [[v1]][[[v2]]] : (!llvm.ptr, i64) -> !llvm.ptr, f32
+    // CHECK: [[v4:%.*]] = llvm.mlir.constant(1 : index) : i32
+    // CHECK-NOT: llvm.mul
+    // CHECK: llvm.call @MPI_Send([[v3]], [[v4]], {{.*}}) : (!llvm.ptr, i32, i32, i32, i32, i32) -> i32
+    mpi.send(%arg0, %rank, %rank, %comm) : memref<f32>, i32, i32
     return
   }
 }


### PR DESCRIPTION
`getRawPtrAndSize` extracted the memref descriptor's offset as `i64` and unconditionally truncated the extents to `i32`. Both assume a 64-bit index: with a 32-bit one the extract disagrees with the descriptor's field type and the truncation becomes an invalid `llvm.trunc` from `i32` to `i32`.

Read the index type off the descriptor and only adjust the extent width when it actually differs. While here, drop the rank-0 branch that rebuilt the already available element count as an `arith.constant` in the middle of an LLVM lowering.