### PR TITLE
[Target] Remove unneeded deps

### DIFF
--- a/llvm/lib/Target/BPF/CMakeLists.txt
+++ b/llvm/lib/Target/BPF/CMakeLists.txt
@@ -54,11 +54,9 @@ add_llvm_target(BPFCodeGen
   CodeGen
   CodeGenTypes
   Core
-  IRPrinter
   GlobalISel
   IPO
   MC
-  ObjCARC
   Passes
   Scalar
   SelectionDAG

--- a/llvm/lib/Target/Lanai/CMakeLists.txt
+++ b/llvm/lib/Target/Lanai/CMakeLists.txt
@@ -38,14 +38,11 @@ add_llvm_target(LanaiCodeGen
   CodeGen
   CodeGenTypes
   Core
-  IRPrinter
   LanaiAsmParser
   LanaiDesc
   LanaiInfo
   MC
-  ObjCARC
   Passes
-  Scalar
   SelectionDAG
   Support
   Target

--- a/llvm/lib/Target/MSP430/CMakeLists.txt
+++ b/llvm/lib/Target/MSP430/CMakeLists.txt
@@ -31,23 +31,18 @@ add_llvm_target(MSP430CodeGen
   MSP430MCInstLower.cpp
 
   LINK_COMPONENTS
-  Analysis
   AsmPrinter
   CodeGen
   CodeGenTypes
   Core
-  IRPrinter
   MC
   MSP430Desc
   MSP430Info
-  ObjCARC
   Passes
-  Scalar
   SelectionDAG
   Support
   Target
   TargetParser
-  TransformUtils
 
   ADD_TO_COMPONENT
   MSP430

--- a/llvm/lib/Target/NVPTX/CMakeLists.txt
+++ b/llvm/lib/Target/NVPTX/CMakeLists.txt
@@ -62,11 +62,9 @@ add_llvm_target(NVPTXCodeGen
   CodeGenTypes
   Core
   IPO
-  IRPrinter
   MC
   NVPTXDesc
   NVPTXInfo
-  ObjCARC
   Passes
   Scalar
   SelectionDAG

--- a/llvm/lib/Target/RISCV/CMakeLists.txt
+++ b/llvm/lib/Target/RISCV/CMakeLists.txt
@@ -96,9 +96,7 @@ add_llvm_target(RISCVCodeGen
   Core
   GlobalISel
   IPO
-  IRPrinter
   MC
-  ObjCARC
   Passes
   RISCVDesc
   RISCVInfo

--- a/llvm/lib/Target/WebAssembly/CMakeLists.txt
+++ b/llvm/lib/Target/WebAssembly/CMakeLists.txt
@@ -88,10 +88,8 @@ add_llvm_target(WebAssemblyCodeGen
   CodeGen
   CodeGenTypes
   Core
-  IRPrinter
   GlobalISel
   MC
-  ObjCARC
   Passes
   Scalar
   SelectionDAG

--- a/llvm/lib/Target/X86/CMakeLists.txt
+++ b/llvm/lib/Target/X86/CMakeLists.txt
@@ -108,13 +108,11 @@ add_llvm_target(X86CodeGen ${sources}
   CodeGenTypes
   Core
   GlobalISel
-  IRPrinter
   Instrumentation
   MC
   ObjCARC
   Passes
   ProfileData
-  Scalar
   SelectionDAG
   Support
   Target


### PR DESCRIPTION
After 050470e75fb67bfb059a88db87ab5b2be96e7515, these dependencies are no longer needed in each target as the need for them is now specific to the Passes library given that's where a big chunk of the CodeGenPassBuilder implementation lives now.