### PR TITLE
Connect the HIP device parser into the interpreter

### DIFF
--- a/clang/include/clang/Interpreter/Interpreter.h
+++ b/clang/include/clang/Interpreter/Interpreter.h
@@ -45,6 +45,7 @@ class CXXRecordDecl;
 class Decl;
 class IncrementalParser;
 class IncrementalCUDADeviceParser;
+class IncrementalHIPDeviceParser;
 
 /// Create a pre-configured \c CompilerInstance for incremental processing.
 class IncrementalCompilerBuilder {
@@ -114,6 +115,9 @@ class Interpreter {
 
   // An optional parser for CUDA offloading
   std::unique_ptr<IncrementalCUDADeviceParser> CUDADeviceParser;
+
+  // An optional parser for HIP offloading
+  std::unique_ptr<IncrementalHIPDeviceParser> HIPDeviceParser;
 
   // An optional action for Device offloading
   std::unique_ptr<IncrementalAction> DeviceAct;

--- a/clang/include/clang/Interpreter/Interpreter.h
+++ b/clang/include/clang/Interpreter/Interpreter.h
@@ -65,27 +65,34 @@ public:
   // Offload options
   void SetOffloadArch(llvm::StringRef Arch) { OffloadArch = Arch; };
 
-  // CUDA specific
-  void SetCudaSDK(llvm::StringRef path) { CudaSDKPath = path; };
+  void SetDeviceSDK(llvm::StringRef Path, bool HipEnabled) {
+    if (HipEnabled)
+      RocmSDKPath = Path;
+    else
+      CudaSDKPath = Path;
+  }
 
   // Hand over the compilation.
   void SetDriverCompilationCallback(std::function<DriverCompilationFn> C) {
     CompilationCB = C;
   }
 
-  llvm::Expected<std::unique_ptr<CompilerInstance>> CreateCudaHost();
-  llvm::Expected<std::unique_ptr<CompilerInstance>> CreateCudaDevice();
+  llvm::Expected<std::unique_ptr<CompilerInstance>> CreateHost(bool HipEnabled);
+  llvm::Expected<std::unique_ptr<CompilerInstance>>
+  CreateDevice(bool HipEnabled);
 
 private:
   llvm::Expected<std::unique_ptr<CompilerInstance>>
   create(std::string TT, std::vector<const char *> &ClangArgv);
 
-  llvm::Expected<std::unique_ptr<CompilerInstance>> createCuda(bool device);
+  llvm::Expected<std::unique_ptr<CompilerInstance>>
+  createOffload(bool HipEnabled, bool device);
 
   std::vector<const char *> UserArgs;
   std::optional<std::string> TargetTriple;
 
   llvm::StringRef OffloadArch;
+  llvm::StringRef RocmSDKPath;
   llvm::StringRef CudaSDKPath;
 
   std::optional<std::function<DriverCompilationFn>> CompilationCB;
@@ -106,9 +113,9 @@ class Interpreter {
   std::unique_ptr<IncrementalExecutor> IncrExecutor;
 
   // An optional parser for CUDA offloading
-  std::unique_ptr<IncrementalCUDADeviceParser> DeviceParser;
+  std::unique_ptr<IncrementalCUDADeviceParser> CUDADeviceParser;
 
-  // An optional action for CUDA offloading
+  // An optional action for Device offloading
   std::unique_ptr<IncrementalAction> DeviceAct;
 
   /// List containing information about each incrementally parsed piece of code.
@@ -147,8 +154,8 @@ public:
   create(std::unique_ptr<CompilerInstance> CI,
          std::unique_ptr<IncrementalExecutorBuilder> IEB = nullptr);
   static llvm::Expected<std::unique_ptr<Interpreter>>
-  createWithCUDA(std::unique_ptr<CompilerInstance> CI,
-                 std::unique_ptr<CompilerInstance> DCI);
+  createWithDevice(bool HipEnabled, std::unique_ptr<CompilerInstance> CI,
+                   std::unique_ptr<CompilerInstance> DCI);
 
   const ASTContext &getASTContext() const;
   ASTContext &getASTContext();

--- a/clang/include/clang/Interpreter/Interpreter.h
+++ b/clang/include/clang/Interpreter/Interpreter.h
@@ -46,6 +46,8 @@ class Decl;
 class IncrementalParser;
 class IncrementalCUDADeviceParser;
 
+enum class OffloadType { CUDA, HIP };
+
 /// Create a pre-configured \c CompilerInstance for incremental processing.
 class IncrementalCompilerBuilder {
   using DriverCompilationFn = llvm::Error(const driver::Compilation &);
@@ -65,28 +67,51 @@ public:
   // Offload options
   void SetOffloadArch(llvm::StringRef Arch) { OffloadArch = Arch; };
 
-  // CUDA specific
-  void SetCudaSDK(llvm::StringRef path) { CudaSDKPath = path; };
+  void SetDeviceSDK(OffloadType Type, llvm::StringRef Path) {
+    if (Type == OffloadType::HIP)
+      RocmSDKPath = Path;
+    else
+      CudaSDKPath = Path;
+  }
+
+  // Retained for compatibility with existing CUDA callers.
+  void SetCudaSDK(llvm::StringRef Path) {
+    SetDeviceSDK(OffloadType::CUDA, Path);
+  }
 
   // Hand over the compilation.
   void SetDriverCompilationCallback(std::function<DriverCompilationFn> C) {
     CompilationCB = C;
   }
 
-  llvm::Expected<std::unique_ptr<CompilerInstance>> CreateCudaHost();
-  llvm::Expected<std::unique_ptr<CompilerInstance>> CreateCudaDevice();
+  llvm::Expected<std::unique_ptr<CompilerInstance>>
+  CreateHost(OffloadType Type);
+  llvm::Expected<std::unique_ptr<CompilerInstance>>
+  CreateDevice(OffloadType Type);
+
+  // Retained for compatibility with existing CUDA callers.
+  llvm::Expected<std::unique_ptr<CompilerInstance>> CreateCudaHost() {
+    return CreateHost(OffloadType::CUDA);
+  }
+  llvm::Expected<std::unique_ptr<CompilerInstance>> CreateCudaDevice() {
+    return CreateDevice(OffloadType::CUDA);
+  }
 
 private:
   llvm::Expected<std::unique_ptr<CompilerInstance>>
   create(std::string TT, std::vector<const char *> &ClangArgv);
 
-  llvm::Expected<std::unique_ptr<CompilerInstance>> createCuda(bool device);
+  llvm::Expected<std::unique_ptr<CompilerInstance>>
+  createOffload(OffloadType Type, bool device);
 
   std::vector<const char *> UserArgs;
   std::optional<std::string> TargetTriple;
 
   llvm::StringRef OffloadArch;
+  llvm::StringRef RocmSDKPath;
   llvm::StringRef CudaSDKPath;
+
+  std::string OffloadCUID;
 
   std::optional<std::function<DriverCompilationFn>> CompilationCB;
 };
@@ -147,8 +172,8 @@ public:
   create(std::unique_ptr<CompilerInstance> CI,
          std::unique_ptr<IncrementalExecutorBuilder> IEB = nullptr);
   static llvm::Expected<std::unique_ptr<Interpreter>>
-  createWithCUDA(std::unique_ptr<CompilerInstance> CI,
-                 std::unique_ptr<CompilerInstance> DCI);
+  createWithDevice(OffloadType Type, std::unique_ptr<CompilerInstance> CI,
+                   std::unique_ptr<CompilerInstance> DCI);
 
   const ASTContext &getASTContext() const;
   ASTContext &getASTContext();

--- a/clang/include/clang/Interpreter/Interpreter.h
+++ b/clang/include/clang/Interpreter/Interpreter.h
@@ -45,6 +45,7 @@ class CXXRecordDecl;
 class Decl;
 class IncrementalParser;
 class IncrementalCUDADeviceParser;
+class IncrementalHIPDeviceParser;
 
 enum class OffloadType { CUDA, HIP };
 
@@ -133,7 +134,10 @@ class Interpreter {
   // An optional parser for CUDA offloading
   std::unique_ptr<IncrementalCUDADeviceParser> DeviceParser;
 
-  // An optional action for CUDA offloading
+  // An optional parser for HIP offloading
+  std::unique_ptr<IncrementalHIPDeviceParser> HIPDeviceParser;
+
+  // An optional action for device offloading
   std::unique_ptr<IncrementalAction> DeviceAct;
 
   /// List containing information about each incrementally parsed piece of code.

--- a/clang/lib/Interpreter/Interpreter.cpp
+++ b/clang/lib/Interpreter/Interpreter.cpp
@@ -406,6 +406,8 @@ Interpreter::~Interpreter() {
   Act->FinalizeAction();
   if (CUDADeviceParser)
     CUDADeviceParser.reset();
+  if (HIPDeviceParser)
+    HIPDeviceParser.reset();
   if (DeviceAct)
     DeviceAct->FinalizeAction();
   if (IncrExecutor) {
@@ -510,8 +512,14 @@ Interpreter::createWithDevice(bool HipEnabled,
   Interp->DeviceCI = std::move(DCI);
 
   if (HipEnabled) {
-    // FIXME: HIP device parsing is not supported yet; it should use an
-    // IncrementalHIPDeviceParser once one exists.
+    auto HIPDeviceParser = std::make_unique<IncrementalHIPDeviceParser>(
+        *Interp->DeviceCI, *Interp->getCompilerInstance(),
+        Interp->DeviceAct.get(), IMVFS, Err, Interp->PTUs);
+
+    if (Err)
+      return std::move(Err);
+
+    Interp->HIPDeviceParser = std::move(HIPDeviceParser);
   } else {
     auto CUDADeviceParser = std::make_unique<IncrementalCUDADeviceParser>(
         *Interp->DeviceCI, *Interp->getCompilerInstance(),
@@ -576,6 +584,33 @@ Interpreter::Parse(llvm::StringRef Code) {
 
     llvm::Error Err = CUDADeviceParser->GenerateFatbinary();
     if (Err)
+      return std::move(Err);
+  }
+
+  // HIP device code is compiled into its own code object per chunk. Each PTU is
+  // linked against the device libraries, optimized, and lowered to a
+  // relocatable code object (.hsaco) that is wrapped in a fat binary and
+  // embedded into the host module.
+  if (HIPDeviceParser) {
+    llvm::Expected<TranslationUnitDecl *> DeviceTU =
+        HIPDeviceParser->Parse(Code);
+    if (auto E = DeviceTU.takeError())
+      return std::move(E);
+
+    HIPDeviceParser->RegisterPTU(*DeviceTU);
+
+    if (llvm::Error Err = HIPDeviceParser->LinkDeviceLibs())
+      return std::move(Err);
+
+    if (llvm::Error Err = HIPDeviceParser->optimize())
+      return std::move(Err);
+
+    if (llvm::Expected<llvm::StringRef> HSACO =
+            HIPDeviceParser->GenerateHSACO();
+        !HSACO)
+      return HSACO.takeError();
+
+    if (llvm::Error Err = HIPDeviceParser->GenerateOffloadBundle())
       return std::move(Err);
   }
 

--- a/clang/lib/Interpreter/Interpreter.cpp
+++ b/clang/lib/Interpreter/Interpreter.cpp
@@ -302,19 +302,16 @@ IncrementalCompilerBuilder::CreateCpp() {
 }
 
 llvm::Expected<std::unique_ptr<CompilerInstance>>
-IncrementalCompilerBuilder::createCuda(bool device) {
+IncrementalCompilerBuilder::createOffload(bool HipEnabled, bool device) {
   std::vector<const char *> Argv;
   Argv.reserve(5 + 4 + UserArgs.size());
+  Argv.push_back(HipEnabled ? "-xhip" : "-xcuda");
+  Argv.push_back(device ? "--cuda-device-only" : "--cuda-host-only");
 
-  Argv.push_back("-xcuda");
-  if (device)
-    Argv.push_back("--cuda-device-only");
-  else
-    Argv.push_back("--cuda-host-only");
-
-  std::string SDKPathArg = "--cuda-path=";
-  if (!CudaSDKPath.empty()) {
-    SDKPathArg += CudaSDKPath;
+  llvm::StringRef SDKPath = HipEnabled ? RocmSDKPath : CudaSDKPath;
+  std::string SDKPathArg = HipEnabled ? "--rocm-path=" : "--cuda-path=";
+  if (!SDKPath.empty()) {
+    SDKPathArg += SDKPath;
     Argv.push_back(SDKPathArg.c_str());
   }
 
@@ -324,6 +321,9 @@ IncrementalCompilerBuilder::createCuda(bool device) {
     Argv.push_back(ArchArg.c_str());
   }
 
+  if (device && HipEnabled)
+    Argv.push_back("-O3");
+
   llvm::append_range(Argv, UserArgs);
 
   std::string TT = TargetTriple ? *TargetTriple : llvm::sys::getProcessTriple();
@@ -331,13 +331,14 @@ IncrementalCompilerBuilder::createCuda(bool device) {
 }
 
 llvm::Expected<std::unique_ptr<CompilerInstance>>
-IncrementalCompilerBuilder::CreateCudaDevice() {
-  return IncrementalCompilerBuilder::createCuda(true);
+IncrementalCompilerBuilder::CreateDevice(bool HipEnabled) {
+  return IncrementalCompilerBuilder::createOffload(HipEnabled, /*device=*/true);
 }
 
 llvm::Expected<std::unique_ptr<CompilerInstance>>
-IncrementalCompilerBuilder::CreateCudaHost() {
-  return IncrementalCompilerBuilder::createCuda(false);
+IncrementalCompilerBuilder::CreateHost(bool HipEnabled) {
+  return IncrementalCompilerBuilder::createOffload(HipEnabled,
+                                                   /*device=*/false);
 }
 
 Interpreter::Interpreter(std::unique_ptr<CompilerInstance> Instance,
@@ -403,8 +404,8 @@ Interpreter::Interpreter(std::unique_ptr<CompilerInstance> Instance,
 Interpreter::~Interpreter() {
   IncrParser.reset();
   Act->FinalizeAction();
-  if (DeviceParser)
-    DeviceParser.reset();
+  if (CUDADeviceParser)
+    CUDADeviceParser.reset();
   if (DeviceAct)
     DeviceAct->FinalizeAction();
   if (IncrExecutor) {
@@ -472,8 +473,9 @@ llvm::Expected<std::unique_ptr<Interpreter>> Interpreter::create(
 }
 
 llvm::Expected<std::unique_ptr<Interpreter>>
-Interpreter::createWithCUDA(std::unique_ptr<CompilerInstance> CI,
-                            std::unique_ptr<CompilerInstance> DCI) {
+Interpreter::createWithDevice(bool HipEnabled,
+                              std::unique_ptr<CompilerInstance> CI,
+                              std::unique_ptr<CompilerInstance> DCI) {
   // avoid writing fat binary to disk using an in-memory virtual file system
   llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> IMVFS =
       std::make_unique<llvm::vfs::InMemoryFileSystem>();
@@ -507,14 +509,20 @@ Interpreter::createWithCUDA(std::unique_ptr<CompilerInstance> CI,
 
   Interp->DeviceCI = std::move(DCI);
 
-  auto DeviceParser = std::make_unique<IncrementalCUDADeviceParser>(
-      *Interp->DeviceCI, *Interp->getCompilerInstance(),
-      Interp->DeviceAct.get(), IMVFS, Err, Interp->PTUs);
+  if (HipEnabled) {
+    // FIXME: HIP device parsing is not supported yet; it should use an
+    // IncrementalHIPDeviceParser once one exists.
+  } else {
+    auto CUDADeviceParser = std::make_unique<IncrementalCUDADeviceParser>(
+        *Interp->DeviceCI, *Interp->getCompilerInstance(),
+        Interp->DeviceAct.get(), IMVFS, Err, Interp->PTUs);
 
-  if (Err)
-    return std::move(Err);
+    if (Err)
+      return std::move(Err);
 
-  Interp->DeviceParser = std::move(DeviceParser);
+    Interp->CUDADeviceParser = std::move(CUDADeviceParser);
+  }
+
   return std::move(Interp);
 }
 
@@ -554,18 +562,19 @@ llvm::Expected<PartialTranslationUnit &>
 Interpreter::Parse(llvm::StringRef Code) {
   // If we have a device parser, parse it first. The generated code will be
   // included in the host compilation
-  if (DeviceParser) {
-    llvm::Expected<TranslationUnitDecl *> DeviceTU = DeviceParser->Parse(Code);
+  if (CUDADeviceParser) {
+    llvm::Expected<TranslationUnitDecl *> DeviceTU =
+        CUDADeviceParser->Parse(Code);
     if (auto E = DeviceTU.takeError())
       return std::move(E);
 
-    DeviceParser->RegisterPTU(*DeviceTU);
+    CUDADeviceParser->RegisterPTU(*DeviceTU);
 
-    llvm::Expected<llvm::StringRef> PTX = DeviceParser->GeneratePTX();
+    llvm::Expected<llvm::StringRef> PTX = CUDADeviceParser->GeneratePTX();
     if (!PTX)
       return PTX.takeError();
 
-    llvm::Error Err = DeviceParser->GenerateFatbinary();
+    llvm::Error Err = CUDADeviceParser->GenerateFatbinary();
     if (Err)
       return std::move(Err);
   }

--- a/clang/lib/Interpreter/Interpreter.cpp
+++ b/clang/lib/Interpreter/Interpreter.cpp
@@ -45,12 +45,14 @@
 #include "clang/Serialization/ASTReader.h"
 #include "clang/Serialization/ModuleCache.h"
 #include "clang/Serialization/ObjectFilePCHContainerReader.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/ExecutionEngine/Orc/EPCDynamicLibrarySearchGenerator.h"
 #include "llvm/ExecutionEngine/Orc/LLJIT.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/Process.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Host.h"
@@ -303,19 +305,17 @@ IncrementalCompilerBuilder::CreateCpp() {
 }
 
 llvm::Expected<std::unique_ptr<CompilerInstance>>
-IncrementalCompilerBuilder::createCuda(bool device) {
+IncrementalCompilerBuilder::createOffload(OffloadType Type, bool device) {
+  const bool HipEnabled = Type == OffloadType::HIP;
   std::vector<const char *> Argv;
   Argv.reserve(5 + 4 + UserArgs.size());
+  Argv.push_back(HipEnabled ? "-xhip" : "-xcuda");
+  Argv.push_back(device ? "--cuda-device-only" : "--cuda-host-only");
 
-  Argv.push_back("-xcuda");
-  if (device)
-    Argv.push_back("--cuda-device-only");
-  else
-    Argv.push_back("--cuda-host-only");
-
-  std::string SDKPathArg = "--cuda-path=";
-  if (!CudaSDKPath.empty()) {
-    SDKPathArg += CudaSDKPath;
+  llvm::StringRef SDKPath = HipEnabled ? RocmSDKPath : CudaSDKPath;
+  std::string SDKPathArg = HipEnabled ? "--rocm-path=" : "--cuda-path=";
+  if (!SDKPath.empty()) {
+    SDKPathArg += SDKPath;
     Argv.push_back(SDKPathArg.c_str());
   }
 
@@ -325,6 +325,12 @@ IncrementalCompilerBuilder::createCuda(bool device) {
     Argv.push_back(ArchArg.c_str());
   }
 
+  if (OffloadCUID.empty())
+    OffloadCUID = llvm::utohexstr(llvm::sys::Process::GetRandomNumber(),
+                                  /*LowerCase=*/true);
+  std::string CUIDArg = "-cuid=" + OffloadCUID;
+  Argv.push_back(CUIDArg.c_str());
+
   llvm::append_range(Argv, UserArgs);
 
   std::string TT = TargetTriple ? *TargetTriple : llvm::sys::getProcessTriple();
@@ -332,13 +338,13 @@ IncrementalCompilerBuilder::createCuda(bool device) {
 }
 
 llvm::Expected<std::unique_ptr<CompilerInstance>>
-IncrementalCompilerBuilder::CreateCudaDevice() {
-  return IncrementalCompilerBuilder::createCuda(true);
+IncrementalCompilerBuilder::CreateDevice(OffloadType Type) {
+  return IncrementalCompilerBuilder::createOffload(Type, /*device=*/true);
 }
 
 llvm::Expected<std::unique_ptr<CompilerInstance>>
-IncrementalCompilerBuilder::CreateCudaHost() {
-  return IncrementalCompilerBuilder::createCuda(false);
+IncrementalCompilerBuilder::CreateHost(OffloadType Type) {
+  return IncrementalCompilerBuilder::createOffload(Type, /*device=*/false);
 }
 
 Interpreter::Interpreter(std::unique_ptr<CompilerInstance> Instance,
@@ -473,8 +479,9 @@ llvm::Expected<std::unique_ptr<Interpreter>> Interpreter::create(
 }
 
 llvm::Expected<std::unique_ptr<Interpreter>>
-Interpreter::createWithCUDA(std::unique_ptr<CompilerInstance> CI,
-                            std::unique_ptr<CompilerInstance> DCI) {
+Interpreter::createWithDevice(OffloadType Type,
+                              std::unique_ptr<CompilerInstance> CI,
+                              std::unique_ptr<CompilerInstance> DCI) {
   // avoid writing fat binary to disk using an in-memory virtual file system
   llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> IMVFS =
       std::make_unique<llvm::vfs::InMemoryFileSystem>();
@@ -508,14 +515,20 @@ Interpreter::createWithCUDA(std::unique_ptr<CompilerInstance> CI,
 
   Interp->DeviceCI = std::move(DCI);
 
-  auto DeviceParser = std::make_unique<IncrementalCUDADeviceParser>(
-      *Interp->DeviceCI, *Interp->getCompilerInstance(),
-      Interp->DeviceAct.get(), IMVFS, Err, Interp->PTUs);
+  if (Type == OffloadType::HIP) {
+    // FIXME: HIP device parsing is not supported yet; it should use an
+    // IncrementalHIPDeviceParser once one exists.
+  } else {
+    auto DeviceParser = std::make_unique<IncrementalCUDADeviceParser>(
+        *Interp->DeviceCI, *Interp->getCompilerInstance(),
+        Interp->DeviceAct.get(), IMVFS, Err, Interp->PTUs);
 
-  if (Err)
-    return std::move(Err);
+    if (Err)
+      return std::move(Err);
 
-  Interp->DeviceParser = std::move(DeviceParser);
+    Interp->DeviceParser = std::move(DeviceParser);
+  }
+
   return std::move(Interp);
 }
 

--- a/clang/lib/Interpreter/Interpreter.cpp
+++ b/clang/lib/Interpreter/Interpreter.cpp
@@ -412,6 +412,8 @@ Interpreter::~Interpreter() {
   Act->FinalizeAction();
   if (DeviceParser)
     DeviceParser.reset();
+  if (HIPDeviceParser)
+    HIPDeviceParser.reset();
   if (DeviceAct)
     DeviceAct->FinalizeAction();
   if (IncrExecutor) {
@@ -516,8 +518,14 @@ Interpreter::createWithDevice(OffloadType Type,
   Interp->DeviceCI = std::move(DCI);
 
   if (Type == OffloadType::HIP) {
-    // FIXME: HIP device parsing is not supported yet; it should use an
-    // IncrementalHIPDeviceParser once one exists.
+    auto HIPDeviceParser = std::make_unique<IncrementalHIPDeviceParser>(
+        *Interp->DeviceCI, *Interp->getCompilerInstance(),
+        Interp->DeviceAct.get(), IMVFS, Err, Interp->PTUs);
+
+    if (Err)
+      return std::move(Err);
+
+    Interp->HIPDeviceParser = std::move(HIPDeviceParser);
   } else {
     auto DeviceParser = std::make_unique<IncrementalCUDADeviceParser>(
         *Interp->DeviceCI, *Interp->getCompilerInstance(),
@@ -581,6 +589,26 @@ Interpreter::Parse(llvm::StringRef Code) {
 
     llvm::Error Err = DeviceParser->GenerateFatbinary();
     if (Err)
+      return std::move(Err);
+  }
+
+  // If we have a HIP device parser, parse and lower the device code first so
+  // that the generated offload bundle is available to the host compilation.
+  if (HIPDeviceParser) {
+    llvm::Expected<TranslationUnitDecl *> DeviceTU = HIPDeviceParser->Parse(Code);
+    if (auto E = DeviceTU.takeError())
+      return std::move(E);
+
+    HIPDeviceParser->RegisterPTU(*DeviceTU);
+
+    if (llvm::Error Err = HIPDeviceParser->optimize())
+      return std::move(Err);
+
+    llvm::Expected<llvm::StringRef> HSACO = HIPDeviceParser->GenerateHSACO();
+    if (!HSACO)
+      return HSACO.takeError();
+
+    if (llvm::Error Err = HIPDeviceParser->GenerateOffloadBundle())
       return std::move(Err);
   }
 

--- a/clang/test/Interpreter/HIP/device-function-template.hip
+++ b/clang/test/Interpreter/HIP/device-function-template.hip
@@ -1,0 +1,26 @@
+// Tests device function templates
+// RUN: cat %s | clang-repl --hip | FileCheck %s
+
+#include <hip/hip_runtime.h>
+
+extern "C" int printf(const char*, ...);
+
+template <typename T> __device__ inline T sum(T a, T b) { return a + b; }
+__global__ void test_kernel(int* value) { *value = sum(40, 2); }
+
+int var;
+int* devptr = nullptr;
+printf("hipMalloc: %d\n", hipMalloc((void **) &devptr, sizeof(int)));
+// CHECK: hipMalloc: 0
+
+test_kernel<<<1,1>>>(devptr);
+printf("HIP Error: %d\n", hipGetLastError());
+// CHECK-NEXT: HIP Error: 0
+
+printf("hipMemcpy: %d\n", hipMemcpy(&var, devptr, sizeof(int), hipMemcpyDeviceToHost));
+// CHECK-NEXT: hipMemcpy: 0
+
+printf("Value: %d\n", var);
+// CHECK-NEXT: Value: 42
+
+%quit

--- a/clang/test/Interpreter/HIP/device-function.hip
+++ b/clang/test/Interpreter/HIP/device-function.hip
@@ -1,0 +1,26 @@
+// Tests __device__ function calls
+// RUN: cat %s | clang-repl --hip | FileCheck %s
+
+#include <hip/hip_runtime.h>
+
+extern "C" int printf(const char*, ...);
+
+__device__ inline void test_device(int* value) { *value = 42; }
+__global__ void test_kernel(int* value) { test_device(value); }
+
+int var;
+int* devptr = nullptr;
+printf("hipMalloc: %d\n", hipMalloc((void **) &devptr, sizeof(int)));
+// CHECK: hipMalloc: 0
+
+test_kernel<<<1,1>>>(devptr);
+printf("HIP Error: %d\n", hipGetLastError());
+// CHECK-NEXT: HIP Error: 0
+
+printf("hipMemcpy: %d\n", hipMemcpy(&var, devptr, sizeof(int), hipMemcpyDeviceToHost));
+// CHECK-NEXT: hipMemcpy: 0
+
+printf("Value: %d\n", var);
+// CHECK-NEXT: Value: 42
+
+%quit

--- a/clang/test/Interpreter/HIP/hip-environment.hip
+++ b/clang/test/Interpreter/HIP/hip-environment.hip
@@ -1,8 +1,0 @@
-// Check that clang-repl initializes the HIP environment. HIP execution is not
-// supported yet, so this only verifies that the environment is set up and that
-// clang-repl reports it as unsupported. When both -cuda and -hip are passed,
-// -hip wins (it appears later), so the HIP path is taken.
-
-// RUN: not clang-repl -cuda -hip 2>&1 | FileCheck %s
-
-// CHECK: HIP environment is initialized but not supported as of now.

--- a/clang/test/Interpreter/HIP/hip-environment.hip
+++ b/clang/test/Interpreter/HIP/hip-environment.hip
@@ -1,0 +1,8 @@
+// Check that clang-repl initializes the HIP environment. HIP execution is not
+// supported yet, so this only verifies that the environment is set up and that
+// clang-repl reports it as unsupported. When both -cuda and -hip are passed,
+// -hip wins (it appears later), so the HIP path is taken.
+
+// RUN: not clang-repl -cuda -hip 2>&1 | FileCheck %s
+
+// CHECK: HIP environment is initialized but not supported as of now.

--- a/clang/test/Interpreter/HIP/hip-environment.hip
+++ b/clang/test/Interpreter/HIP/hip-environment.hip
@@ -1,0 +1,11 @@
+// Check that clang-repl initializes the HIP environment but reports it as
+// unsupported, since HIP execution is not implemented yet. When both -cuda and
+// -hip are passed, -hip wins because it appears later, so the HIP path is taken.
+// An explicit --offload-arch is passed so the test does not rely on GPU
+// auto-detection (--offload-arch=native), which fails on systems that have ROCm
+// installed but no GPU. The test never runs device code, so the arch is
+// arbitrary.
+
+// RUN: not clang-repl -cuda -hip --offload-arch=gfx1100 2>&1 | FileCheck %s
+
+// CHECK: HIP environment is initialized but not supported as of now.

--- a/clang/test/Interpreter/HIP/host-and-device.hip
+++ b/clang/test/Interpreter/HIP/host-and-device.hip
@@ -1,0 +1,29 @@
+// Checks that a function is available in both __host__ and __device__
+// RUN: cat %s | clang-repl --hip | FileCheck %s
+
+#include <hip/hip_runtime.h>
+
+extern "C" int printf(const char*, ...);
+
+__host__ __device__ inline int sum(int a, int b){ return a + b; }
+__global__ void kernel(int * output){ *output = sum(40,2); }
+
+printf("Host sum: %d\n", sum(41,1));
+// CHECK: Host sum: 42
+
+int var = 0;
+int * deviceVar;
+printf("hipMalloc: %d\n", hipMalloc((void **) &deviceVar, sizeof(int)));
+// CHECK-NEXT: hipMalloc: 0
+
+kernel<<<1,1>>>(deviceVar);
+printf("HIP Error: %d\n", hipGetLastError());
+// CHECK-NEXT: HIP Error: 0
+
+printf("hipMemcpy: %d\n", hipMemcpy(&var, deviceVar, sizeof(int), hipMemcpyDeviceToHost));
+// CHECK-NEXT: hipMemcpy: 0
+
+printf("var: %d\n", var);
+// CHECK-NEXT: var: 42
+
+%quit

--- a/clang/test/Interpreter/HIP/lit.local.cfg
+++ b/clang/test/Interpreter/HIP/lit.local.cfg
@@ -1,0 +1,2 @@
+if 'host-supports-hip' not in config.available_features:
+    config.unsupported = True

--- a/clang/test/Interpreter/HIP/memory.hip
+++ b/clang/test/Interpreter/HIP/memory.hip
@@ -1,0 +1,25 @@
+// Tests hipMemcpy and writes from kernel
+// RUN: cat %s | clang-repl --hip | FileCheck %s
+
+#include <hip/hip_runtime.h>
+
+extern "C" int printf(const char*, ...);
+
+__global__ void test_func(int* value) { *value = 42; }
+
+int var;
+int* devptr = nullptr;
+printf("hipMalloc: %d\n", hipMalloc((void **) &devptr, sizeof(int)));
+// CHECK: hipMalloc: 0
+
+test_func<<<1,1>>>(devptr);
+printf("HIP Error: %d\n", hipGetLastError());
+// CHECK-NEXT: HIP Error: 0
+
+printf("hipMemcpy: %d\n", hipMemcpy(&var, devptr, sizeof(int), hipMemcpyDeviceToHost));
+// CHECK-NEXT: hipMemcpy: 0
+
+printf("Value: %d\n", var);
+// CHECK-NEXT: Value: 42
+
+%quit

--- a/clang/test/Interpreter/HIP/sanity.hip
+++ b/clang/test/Interpreter/HIP/sanity.hip
@@ -1,0 +1,13 @@
+// RUN: cat %s | clang-repl --hip | FileCheck %s
+
+#include <hip/hip_runtime.h>
+
+extern "C" int printf(const char*, ...);
+
+__global__ void test_func() {}
+
+test_func<<<1,1>>>();
+printf("HIP Error: %d", hipGetLastError());
+// CHECK: HIP Error: 0
+
+%quit

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -221,6 +221,34 @@ def have_host_clang_repl_cuda():
 
     return False
 
+def have_host_clang_repl_hip():
+    clang_repl_exe = lit.util.which('clang-repl', config.clang_tools_dir)
+
+    if not clang_repl_exe:
+        return False
+
+    testcode = b'\n'.join([
+        b"#include <hip/hip_runtime.h>",
+        b"__global__ void test_func() {}",
+        b"test_func<<<1,1>>>();",
+        b"extern \"C\" int puts(const char *s);",
+        b"puts(hipGetLastError() ? \"failure\" : \"success\");",
+        b"%quit"
+    ])
+    try:
+        clang_repl_cmd = subprocess.run([clang_repl_exe, '--hip'],
+                                        stdout=subprocess.PIPE,
+                                        stderr=subprocess.PIPE,
+                                        input=testcode)
+    except OSError:
+        return False
+
+    if clang_repl_cmd.returncode == 0:
+        if clang_repl_cmd.stdout.find(b"success") != -1:
+            return True
+
+    return False
+
 
 skip_clang_repl_checks = lit.util.pythonize_bool(
     lit_config.params.get(
@@ -234,6 +262,9 @@ if not skip_clang_repl_checks and have_host_jit_feature_support("jit"):
 
     if have_host_clang_repl_cuda():
         config.available_features.add('host-supports-cuda')
+
+    if have_host_clang_repl_hip():
+        config.available_features.add('host-supports-hip')
     hosttriple = run_clang_repl("--host-jit-triple")
     config.substitutions.append(("%host-jit-triple", hosttriple.strip()))
 

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -1,5 +1,6 @@
 # -*- Python -*-
 
+import glob
 import os
 import platform
 import re
@@ -222,6 +223,54 @@ def have_host_clang_repl_cuda():
     return False
 
 
+def _hip_lib_directory():
+    explicit = lit_config.params.get("hip_lib_path")
+    if explicit:
+        candidates = [explicit]
+    else:
+        candidates = []
+        for var in ("ROCM_PATH", "HIP_PATH"):
+            if os.environ.get(var):
+                candidates.append(os.path.join(os.environ[var], "lib"))
+        candidates.append("/opt/rocm/lib")
+    for directory in candidates:
+        if directory and glob.glob(os.path.join(directory, "libamdhip64.so*")):
+            return directory
+    return None
+
+
+def _clang_can_compile_hip(clang, rocm_lib_dir):
+    rocm_root = os.path.dirname(rocm_lib_dir)
+    offload_arch = lit_config.params.get("amdgpu_arch", "gfx906")
+    test_src = b"#include <hip/hip_runtime.h>\n__global__ void k() {}\n"
+    try:
+        proc = subprocess.run(
+            [
+                clang,
+                "-x",
+                "hip",
+                "-fsyntax-only",
+                "-nogpulib",
+                "--offload-arch=" + offload_arch,
+                "--rocm-path=" + rocm_root,
+                "-",
+            ],
+            input=test_src,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except OSError:
+        return False
+    return proc.returncode == 0
+
+
+def have_host_hip_environment():
+    hip_lib_dir = _hip_lib_directory()
+    if not hip_lib_dir or not config.clang:
+        return False
+    return _clang_can_compile_hip(config.clang, hip_lib_dir)
+
+
 skip_clang_repl_checks = lit.util.pythonize_bool(
     lit_config.params.get(
         "clang_skip_clang_repl_checks",
@@ -234,6 +283,9 @@ if not skip_clang_repl_checks and have_host_jit_feature_support("jit"):
 
     if have_host_clang_repl_cuda():
         config.available_features.add('host-supports-cuda')
+
+    if have_host_hip_environment():
+        config.available_features.add("host-supports-hip")
     hosttriple = run_clang_repl("--host-jit-triple")
     config.substitutions.append(("%host-jit-triple", hosttriple.strip()))
 

--- a/clang/tools/clang-repl/ClangRepl.cpp
+++ b/clang/tools/clang-repl/ClangRepl.cpp
@@ -52,6 +52,8 @@ LLVM_ATTRIBUTE_USED int __lsan_is_turned_off() { return 1; }
 
 #define DEBUG_TYPE "clang-repl"
 
+static llvm::cl::opt<bool> HipEnabled("hip", llvm::cl::Hidden);
+static llvm::cl::opt<std::string> RocmPath("rocm-path", llvm::cl::Hidden);
 static llvm::cl::opt<bool> CudaEnabled("cuda", llvm::cl::Hidden);
 static llvm::cl::opt<std::string> CudaPath("cuda-path", llvm::cl::Hidden);
 static llvm::cl::opt<std::string> OffloadArch("offload-arch", llvm::cl::Hidden);
@@ -310,24 +312,31 @@ int main(int argc, const char **argv) {
   IEB->SlabAllocateSize = *SizeOrErr;
   IEB->UseSharedMemory = UseSharedMemory;
 
+  if (HipEnabled && CudaEnabled) {
+    if (HipEnabled.getPosition() > CudaEnabled.getPosition())
+      CudaEnabled = false;
+    else
+      HipEnabled = false;
+  }
+
+  bool DeviceEnabled = HipEnabled || CudaEnabled;
+  llvm::StringRef DevicePath = HipEnabled ? RocmPath : CudaPath;
+  llvm::StringRef DeviceOffloadArch = !OffloadArch.empty()
+                                          ? llvm::StringRef(OffloadArch)
+                                          : (HipEnabled ? "gfx906" : "sm_35");
   std::unique_ptr<clang::CompilerInstance> DeviceCI;
-  if (CudaEnabled) {
-    if (!CudaPath.empty())
-      CB.SetCudaSDK(CudaPath);
 
-    if (OffloadArch.empty()) {
-      OffloadArch = "sm_35";
-    }
-    CB.SetOffloadArch(OffloadArch);
-
-    DeviceCI = ExitOnErr(CB.CreateCudaDevice());
+  if (DeviceEnabled) {
+    CB.SetDeviceSDK(DevicePath, HipEnabled);
+    CB.SetOffloadArch(DeviceOffloadArch);
+    DeviceCI = ExitOnErr(CB.CreateDevice(HipEnabled));
   }
 
   // FIXME: Investigate if we could use runToolOnCodeWithArgs from tooling. It
   // can replace the boilerplate code for creation of the compiler instance.
   std::unique_ptr<clang::CompilerInstance> CI;
-  if (CudaEnabled) {
-    CI = ExitOnErr(CB.CreateCudaHost());
+  if (DeviceEnabled) {
+    CI = ExitOnErr(CB.CreateHost(HipEnabled));
   } else {
     CI = ExitOnErr(CB.CreateCpp());
   }
@@ -339,20 +348,36 @@ int main(int argc, const char **argv) {
 
   // Load any requested plugins.
   CI->LoadRequestedPlugins();
-  if (CudaEnabled)
+  if (DeviceEnabled)
     DeviceCI->LoadRequestedPlugins();
 
   std::unique_ptr<clang::Interpreter> Interp;
 
-  if (CudaEnabled) {
-    Interp = ExitOnErr(
-        clang::Interpreter::createWithCUDA(std::move(CI), std::move(DeviceCI)));
+  if (DeviceEnabled) {
+    Interp = ExitOnErr(clang::Interpreter::createWithDevice(
+        HipEnabled, std::move(CI), std::move(DeviceCI)));
 
-    if (CudaPath.empty()) {
-      ExitOnErr(Interp->LoadDynamicLibrary("libcudart.so"));
-    } else {
-      auto CudaRuntimeLibPath = CudaPath + "/lib/libcudart.so";
-      ExitOnErr(Interp->LoadDynamicLibrary(CudaRuntimeLibPath.c_str()));
+    if (HipEnabled) {
+      if (RocmPath.empty()) {
+        ExitOnErr(Interp->LoadDynamicLibrary("libamdhip64.so"));
+      } else {
+        auto RocmRuntimeLibPath = RocmPath + "/lib/libamdhip64.so";
+        ExitOnErr(Interp->LoadDynamicLibrary(RocmRuntimeLibPath.c_str()));
+      }
+
+      llvm::errs().changeColor(llvm::raw_ostream::RED, /*Bold=*/true);
+      llvm::errs()
+          << "HIP environment is initialized but not supported as of now.\n";
+      llvm::errs().resetColor();
+      return EXIT_FAILURE;
+    }
+    if (CudaEnabled) {
+      if (CudaPath.empty()) {
+        ExitOnErr(Interp->LoadDynamicLibrary("libcudart.so"));
+      } else {
+        auto CudaRuntimeLibPath = CudaPath + "/lib/libcudart.so";
+        ExitOnErr(Interp->LoadDynamicLibrary(CudaRuntimeLibPath.c_str()));
+      }
     }
   } else {
     Interp =

--- a/clang/tools/clang-repl/ClangRepl.cpp
+++ b/clang/tools/clang-repl/ClangRepl.cpp
@@ -52,6 +52,8 @@ LLVM_ATTRIBUTE_USED int __lsan_is_turned_off() { return 1; }
 
 #define DEBUG_TYPE "clang-repl"
 
+static llvm::cl::opt<bool> HipEnabled("hip", llvm::cl::Hidden);
+static llvm::cl::opt<std::string> RocmPath("rocm-path", llvm::cl::Hidden);
 static llvm::cl::opt<bool> CudaEnabled("cuda", llvm::cl::Hidden);
 static llvm::cl::opt<std::string> CudaPath("cuda-path", llvm::cl::Hidden);
 static llvm::cl::opt<std::string> OffloadArch("offload-arch", llvm::cl::Hidden);
@@ -310,24 +312,34 @@ int main(int argc, const char **argv) {
   IEB->SlabAllocateSize = *SizeOrErr;
   IEB->UseSharedMemory = UseSharedMemory;
 
+  if (HipEnabled && CudaEnabled) {
+    if (HipEnabled.getPosition() > CudaEnabled.getPosition())
+      CudaEnabled = false;
+    else
+      HipEnabled = false;
+  }
+
+  bool DeviceEnabled = HipEnabled || CudaEnabled;
+  clang::OffloadType OffloadKind =
+      HipEnabled ? clang::OffloadType::HIP : clang::OffloadType::CUDA;
+  llvm::StringRef DevicePath = HipEnabled ? RocmPath : CudaPath;
+  // For HIP, let the driver auto-detect the GPU via --offload-arch=native.
+  llvm::StringRef DeviceOffloadArch = !OffloadArch.empty()
+                                          ? llvm::StringRef(OffloadArch)
+                                          : (HipEnabled ? "native" : "sm_35");
   std::unique_ptr<clang::CompilerInstance> DeviceCI;
-  if (CudaEnabled) {
-    if (!CudaPath.empty())
-      CB.SetCudaSDK(CudaPath);
 
-    if (OffloadArch.empty()) {
-      OffloadArch = "sm_35";
-    }
-    CB.SetOffloadArch(OffloadArch);
-
-    DeviceCI = ExitOnErr(CB.CreateCudaDevice());
+  if (DeviceEnabled) {
+    CB.SetDeviceSDK(OffloadKind, DevicePath);
+    CB.SetOffloadArch(DeviceOffloadArch);
+    DeviceCI = ExitOnErr(CB.CreateDevice(OffloadKind));
   }
 
   // FIXME: Investigate if we could use runToolOnCodeWithArgs from tooling. It
   // can replace the boilerplate code for creation of the compiler instance.
   std::unique_ptr<clang::CompilerInstance> CI;
-  if (CudaEnabled) {
-    CI = ExitOnErr(CB.CreateCudaHost());
+  if (DeviceEnabled) {
+    CI = ExitOnErr(CB.CreateHost(OffloadKind));
   } else {
     CI = ExitOnErr(CB.CreateCpp());
   }
@@ -339,20 +351,33 @@ int main(int argc, const char **argv) {
 
   // Load any requested plugins.
   CI->LoadRequestedPlugins();
-  if (CudaEnabled)
+  if (DeviceEnabled)
     DeviceCI->LoadRequestedPlugins();
 
   std::unique_ptr<clang::Interpreter> Interp;
 
-  if (CudaEnabled) {
-    Interp = ExitOnErr(
-        clang::Interpreter::createWithCUDA(std::move(CI), std::move(DeviceCI)));
+  if (DeviceEnabled) {
+    Interp = ExitOnErr(clang::Interpreter::createWithDevice(
+        OffloadKind, std::move(CI), std::move(DeviceCI)));
 
-    if (CudaPath.empty()) {
-      ExitOnErr(Interp->LoadDynamicLibrary("libcudart.so"));
-    } else {
-      auto CudaRuntimeLibPath = CudaPath + "/lib/libcudart.so";
-      ExitOnErr(Interp->LoadDynamicLibrary(CudaRuntimeLibPath.c_str()));
+    if (HipEnabled) {
+      if (RocmPath.empty()) {
+        ExitOnErr(Interp->LoadDynamicLibrary("libamdhip64.so"));
+      } else {
+        auto RocmRuntimeLibPath = RocmPath + "/lib/libamdhip64.so";
+        ExitOnErr(Interp->LoadDynamicLibrary(RocmRuntimeLibPath.c_str()));
+      }
+      llvm::errs()
+          << "HIP environment is initialized but not supported as of now.\n";
+      return EXIT_FAILURE;
+    }
+    if (CudaEnabled) {
+      if (CudaPath.empty()) {
+        ExitOnErr(Interp->LoadDynamicLibrary("libcudart.so"));
+      } else {
+        auto CudaRuntimeLibPath = CudaPath + "/lib/libcudart.so";
+        ExitOnErr(Interp->LoadDynamicLibrary(CudaRuntimeLibPath.c_str()));
+      }
     }
   } else {
     Interp =


### PR DESCRIPTION
This PR wires the HIP device parser into clang-repl so HIP device code is compiled and embedded into the host module, letting HIP kernels run in the interpreter.

This PR adds a HIP interpreter test suite under clang/test/Interpreter/HIP/, mirroring the existing CUDA tests, all gated on the host-supports-hip feature via lit.local.cfg. It also removes the temporary hip-environment.hip placeholder that was added when the HIP environment was first initialized, since it is now superseded by this real end-to-end test suite.

Prerequisite PRs : #217582 , #218337 , #218784 , #218659 

Assisted by Claude Opus 4.8