### PR TITLE
[mlir] Remove dead forward declarations

### DIFF
--- a/mlir/include/mlir/Dialect/Affine/Analysis/AffineStructures.h
+++ b/mlir/include/mlir/Dialect/Affine/Analysis/AffineStructures.h
@@ -33,7 +33,6 @@ class MultiAffineFunction;
 } // namespace presburger
 
 namespace affine {
-class AffineCondition;
 class AffineForOp;
 class AffineIfOp;
 class AffineParallelOp;

--- a/mlir/include/mlir/Dialect/GPU/TransformOps/Utils.h
+++ b/mlir/include/mlir/Dialect/GPU/TransformOps/Utils.h
@@ -17,7 +17,6 @@
 
 namespace mlir {
 namespace gpu {
-class GPUOp;
 class LaunchOp;
 enum class MappingId : uint64_t;
 } // namespace gpu

--- a/mlir/include/mlir/Dialect/IRDL/IR/IRDL.h
+++ b/mlir/include/mlir/Dialect/IRDL/IR/IRDL.h
@@ -22,14 +22,6 @@
 
 #include <memory>
 
-// Forward declaration.
-namespace mlir {
-namespace irdl {
-class OpDef;
-class OpDefAttr;
-} // namespace irdl
-} // namespace mlir
-
 //===----------------------------------------------------------------------===//
 // IRDL Dialect
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMDialect.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMDialect.h
@@ -45,11 +45,6 @@ class SmartMutex;
 namespace mlir {
 namespace LLVM {
 class LLVMDialect;
-
-namespace detail {
-struct LLVMTypeStorage;
-struct LLVMDialectImpl;
-} // namespace detail
 } // namespace LLVM
 } // namespace mlir
 

--- a/mlir/include/mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.h
+++ b/mlir/include/mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.h
@@ -26,7 +26,6 @@ class RewriterBase;
 
 namespace linalg {
 class CopyOp;
-struct ForallTilingResult;
 class GenericOp;
 class LinalgOp;
 } // namespace linalg


### PR DESCRIPTION
This patch removes forward declarations of classes and structs that
are no longer referenced anywhere in MLIR.
