### PR TITLE
AMDGPU: Touch up gfx1250-strict definition details

### DIFF
--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -268,7 +268,7 @@ public:
     AMDGPUSubArch1201,
 
     AMDGPUSubArch12_5,
-    AMDGPUSubArch1250_STRICT,
+    AMDGPUSubArch1250S,
     AMDGPUSubArch1250,
     AMDGPUSubArch1251,
 

--- a/llvm/lib/Target/AMDGPU/GCNProcessors.td
+++ b/llvm/lib/Target/AMDGPU/GCNProcessors.td
@@ -371,6 +371,7 @@ def GFX12_GENERIC : AMDGPUProcessorModel<"gfx12-generic", GFX12SpeedModel,
 def GFX1250_STRICT : AMDGPUProcessorModel<"gfx1250-strict", GFX1250SpeedModel,
   FeatureISAVersion12_50_STRICT.Features, [12, 5, 0]> {
   let ArchFeatures = [FEATURE_FAST_FMA_F32, FEATURE_FAST_DENORMAL_F32, FEATURE_WAVE32, FEATURE_XNACK, FEATURE_SRAMECC];
+  let SubArchSpelling = "12.50s";
 }
 
 def GFX1250 : AMDGPUProcessorModel<"gfx1250", GFX1250SpeedModel,
@@ -409,4 +410,3 @@ def GFX13_GENERIC : AMDGPUProcessorModel<"gfx13-generic", GFX12SpeedModel,
 def : AMDGPUFamily<"6", [GFX600, GFX601, GFX602]>;
 def : AMDGPUFamily<"7", [GFX700, GFX701, GFX702, GFX703, GFX704, GFX705]>;
 def : AMDGPUFamily<"8", [GFX801, GFX802, GFX803, GFX805]>;
-def : AMDGPUFamily<"1250_STRICT", [GFX1250_STRICT]>;

--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.cpp
@@ -83,7 +83,7 @@ static AMDGPUSubtarget::Generation computeDefaultGeneration(const Triple &TT) {
     return AMDGPUSubtarget::GFX11;
   case Triple::AMDGPUSubArch12:
   case Triple::AMDGPUSubArch12_5:
-  case Triple::AMDGPUSubArch1250_STRICT:
+  case Triple::AMDGPUSubArch1250S:
     return AMDGPUSubtarget::GFX12;
   case Triple::AMDGPUSubArch13:
     return AMDGPUSubtarget::GFX13;

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -840,7 +840,7 @@ Triple::SubArchType Triple::parseSubArch(StringRef SubArchName) {
         .Case("12.01", Triple::AMDGPUSubArch1201)
         .Case("12.5", Triple::AMDGPUSubArch12_5)
         .Case("12.50", Triple::AMDGPUSubArch1250)
-        .Case("12.50s", Triple::AMDGPUSubArch1250_STRICT)
+        .Case("12.50s", Triple::AMDGPUSubArch1250S)
         .Case("12.51", Triple::AMDGPUSubArch1251)
         .Case("13", Triple::AMDGPUSubArch13)
         .Case("13.10", Triple::AMDGPUSubArch1310)

--- a/llvm/test/CodeGen/AMDGPU/validate-subtarget-subarch.ll
+++ b/llvm/test/CodeGen/AMDGPU/validate-subtarget-subarch.ll
@@ -7,6 +7,11 @@
 ; RUN: llc -mtriple=amdgpu11 -mcpu=gfx1100 -filetype=null %s
 ; RUN: llc -mtriple=amdgpu11.7 -mcpu=gfx1170 -filetype=null %s
 
+; RUN: llc -mtriple=amdgpu12.5 -mcpu=gfx1250 -filetype=null %s
+; RUN: llc -mtriple=amdgpu12.5 -mcpu=gfx1251 -filetype=null %s
+; RUN: llc -mtriple=amdgpu12.50 -mcpu=gfx1250 -filetype=null %s
+; RUN: llc -mtriple=amdgpu12.50s -mcpu=gfx1250-strict -filetype=null %s
+
 ; Test legacy missing subarch
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx950 -filetype=null %s
 ; RUN: llc -mtriple=amdgpu -mcpu=gfx950 -filetype=null %s
@@ -31,6 +36,13 @@
 ; RUN: sed 's/TARGET_CPU/gfx908/g' < %s | not llc -mtriple=amdgpu9 -filetype=null 2>&1 | FileCheck -check-prefix=ERR %s
 ; RUN: sed 's/TARGET_CPU/gfx1170/g' < %s | not llc -mtriple=amdgpu11 -filetype=null 2>&1 | FileCheck -check-prefix=ERR %s
 ; RUN: sed 's/TARGET_CPU/gfx1100/g' < %s | not llc -mtriple=amdgpu11.7 -filetype=null 2>&1 | FileCheck -check-prefix=ERR %s
+
+; RUN: sed 's/TARGET_CPU/gfx1250-strict/g' < %s | not llc -mtriple=amdgpu12.5 -filetype=null 2>&1 | FileCheck -check-prefix=ERR %s
+; RUN: sed 's/TARGET_CPU/gfx1250-strict/g' < %s | not llc -mtriple=amdgpu12.50 -filetype=null 2>&1 | FileCheck -check-prefix=ERR %s
+; RUN: sed 's/TARGET_CPU/gfx1250-strict/g' < %s | not llc -mtriple=amdgpu12.51 -filetype=null 2>&1 | FileCheck -check-prefix=ERR %s
+; RUN: sed 's/TARGET_CPU/gfx1250-strict/g' < %s | not llc -mtriple=amdgpu12 -filetype=null 2>&1 | FileCheck -check-prefix=ERR %s
+; RUN: sed 's/TARGET_CPU/gfx1250/g' < %s | not llc -mtriple=amdgpu12.50s -filetype=null 2>&1 | FileCheck -check-prefix=ERR %s
+; RUN: sed 's/TARGET_CPU/gfx1251/g' < %s | not llc -mtriple=amdgpu12.50s -filetype=null 2>&1 | FileCheck -check-prefix=ERR %s
 
 ; Check that subtargets not covered by the subarch are rejected. This
 ; tests the error on subtarget construction, which is different from

--- a/llvm/test/TableGen/AMDGPUTargetDefSubArchSpelling.td
+++ b/llvm/test/TableGen/AMDGPUTargetDefSubArchSpelling.td
@@ -36,9 +36,9 @@ def GFX888_AMAZING : ProcessorModel<"gfx888-amazing", NoSchedModel, []>,
 // CHECK: "amdgpu8.88a\0"
 
 // The GPU table: the base GPU has no base name (offset 0); the variant uses
-// AMDGPUSubArch8_88A and records "gfx888" as its base name.
+// AMDGPUSubArch888A and records "gfx888" as its base name.
 // CHECK: {[[#]], Triple::AMDGPUSubArch888, {{.*}}, {8, 8, 8}, [[FAM:[0-9]+]], 0},
-// CHECK: {[[#]], Triple::AMDGPUSubArch8_88A, {{.*}}, {8, 8, 8}, [[FAM]], [[#]]},
+// CHECK: {[[#]], Triple::AMDGPUSubArch888A, {{.*}}, {8, 8, 8}, [[FAM]], [[#]]},
 
 // The subarch-name table maps the variant's own subarch to its triple name.
-// CHECK: {Triple::AMDGPUSubArch8_88A, [[#]], [[#]]},
+// CHECK: {Triple::AMDGPUSubArch888A, [[#]], [[#]]},

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -2515,9 +2515,9 @@ TEST(TargetParserTest, testAMDGPUArch) {
     EXPECT_EQ(Triple("amdgpu12.00--").getSubArch(), Triple::AMDGPUSubArch1200);
     EXPECT_EQ(Triple("amdgpu12.01--").getSubArch(), Triple::AMDGPUSubArch1201);
     EXPECT_EQ(Triple("amdgpu12.5--").getSubArch(), Triple::AMDGPUSubArch12_5);
-    EXPECT_EQ(Triple("amdgpu12.50--").getSubArch(), Triple::AMDGPUSubArch1250);
     EXPECT_EQ(Triple("amdgpu12.50s--").getSubArch(),
-              Triple::AMDGPUSubArch1250_STRICT);
+              Triple::AMDGPUSubArch1250S);
+    EXPECT_EQ(Triple("amdgpu12.50--").getSubArch(), Triple::AMDGPUSubArch1250);
     EXPECT_EQ(Triple("amdgpu12.51--").getSubArch(), Triple::AMDGPUSubArch1251);
     EXPECT_EQ(Triple("amdgpu122--").getSubArch(), Triple::NoSubArch); // Unknown
     EXPECT_EQ(Triple("amdgpu12.59--").getSubArch(),
@@ -2638,6 +2638,40 @@ TEST(TargetParserTest, testAMDGPUisSubArchCompatible) {
   // An unrecognized subarch is incompatible with any recognized subarch.
   EXPECT_FALSE(AMDGPU::isSubArchCompatible(Triple("amdgpu9.99-amd-amdhsa"),
                                            Triple("amdgpu9.00-amd-amdhsa")));
+
+  // subarch 12.50s is its own major, so it is compatible only with itself; the
+  // 12.5 family, gfx1250, and sibling gfx1251 all reject it, both directions.
+  EXPECT_TRUE(AMDGPU::isSubArchCompatible(Triple::AMDGPUSubArch1250S,
+                                          Triple::AMDGPUSubArch1250S));
+  EXPECT_FALSE(AMDGPU::isSubArchCompatible(Triple::AMDGPUSubArch12_5,
+                                           Triple::AMDGPUSubArch1250S));
+  EXPECT_FALSE(AMDGPU::isSubArchCompatible(Triple::AMDGPUSubArch1250S,
+                                           Triple::AMDGPUSubArch12_5));
+  EXPECT_FALSE(AMDGPU::isSubArchCompatible(Triple::AMDGPUSubArch1250S,
+                                           Triple::AMDGPUSubArch1250));
+  EXPECT_FALSE(AMDGPU::isSubArchCompatible(Triple::AMDGPUSubArch1250,
+                                           Triple::AMDGPUSubArch1250S));
+  EXPECT_FALSE(AMDGPU::isSubArchCompatible(Triple::AMDGPUSubArch1250S,
+                                           Triple::AMDGPUSubArch1251));
+
+  // gfx1250 remains a normal member of the gfx12.5 family.
+  EXPECT_TRUE(AMDGPU::isSubArchCompatible(Triple::AMDGPUSubArch12_5,
+                                          Triple::AMDGPUSubArch1250));
+  EXPECT_TRUE(AMDGPU::isSubArchCompatible(Triple::AMDGPUSubArch1250,
+                                          Triple::AMDGPUSubArch12_5));
+
+  // Same, via triple spellings: only amdgpu12.50s accepts it; amdgpu12.5 and
+  // amdgpu12.50 both reject it.
+  EXPECT_TRUE(AMDGPU::isSubArchCompatible(Triple("amdgpu12.50s-amd-amdhsa"),
+                                          Triple("amdgpu12.50s-amd-amdhsa")));
+  EXPECT_FALSE(AMDGPU::isSubArchCompatible(Triple("amdgpu12.5-amd-amdhsa"),
+                                           Triple("amdgpu12.50s-amd-amdhsa")));
+  EXPECT_FALSE(AMDGPU::isSubArchCompatible(Triple("amdgpu12.50s-amd-amdhsa"),
+                                           Triple("amdgpu12.5-amd-amdhsa")));
+  EXPECT_FALSE(AMDGPU::isSubArchCompatible(Triple("amdgpu12.50-amd-amdhsa"),
+                                           Triple("amdgpu12.50s-amd-amdhsa")));
+  EXPECT_FALSE(AMDGPU::isSubArchCompatible(Triple("amdgpu12.50s-amd-amdhsa"),
+                                           Triple("amdgpu12.50-amd-amdhsa")));
 }
 
 TEST(TargetParserTest, testAMDGPUisCPUValidForSubArch) {
@@ -2948,7 +2982,7 @@ TEST(TargetParserTest, testAMDGPUgetGPUKindFromSubArch) {
       {Triple::AMDGPUSubArch1200, AMDGPU::GK_GFX1200},
       {Triple::AMDGPUSubArch1201, AMDGPU::GK_GFX1201},
       {Triple::AMDGPUSubArch12_5, AMDGPU::GK_GFX12_5_GENERIC},
-      {Triple::AMDGPUSubArch1250_STRICT, AMDGPU::GK_GFX1250_STRICT},
+      {Triple::AMDGPUSubArch1250S, AMDGPU::GK_GFX1250_STRICT},
       {Triple::AMDGPUSubArch1250, AMDGPU::GK_GFX1250},
       {Triple::AMDGPUSubArch1251, AMDGPU::GK_GFX1251},
 
@@ -2969,7 +3003,7 @@ TEST(TargetParserTest, testAMDGPUgetIsaVersionFromSubArch) {
             (AMDGPU::IsaVersion{9, 0, 0}));
   EXPECT_EQ(AMDGPU::getIsaVersion(Triple::AMDGPUSubArch1250),
             (AMDGPU::IsaVersion{12, 5, 0}));
-  EXPECT_EQ(AMDGPU::getIsaVersion(Triple::AMDGPUSubArch1250_STRICT),
+  EXPECT_EQ(AMDGPU::getIsaVersion(Triple::AMDGPUSubArch1250S),
             (AMDGPU::IsaVersion{12, 5, 0}));
   EXPECT_EQ(AMDGPU::getIsaVersion(Triple::AMDGPUSubArch1251),
             (AMDGPU::IsaVersion{12, 5, 1}));

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -3861,6 +3861,13 @@ TEST(TripleTest, isCompatibleWith) {
       {"amdgpu12.5-amd-amdhsa", "amdgpu12.50-amd-amdhsa", true},
       {"amdgpu12.5-amd-amdhsa", "amdgpu12.51-amd-amdhsa", true},
 
+      // amdgpu12.50s is its own major subarch: compatible only with itself.
+      {"amdgpu12.50s-amd-amdhsa", "amdgpu12.50s-amd-amdhsa", true},
+      {"amdgpu12.5-amd-amdhsa", "amdgpu12.50s-amd-amdhsa", false},
+      {"amdgpu12.50-amd-amdhsa", "amdgpu12.50s-amd-amdhsa", false},
+      {"amdgpu12.51-amd-amdhsa", "amdgpu12.50s-amd-amdhsa", false},
+      {"amdgpu12-amd-amdhsa", "amdgpu12.50s-amd-amdhsa", false},
+
       {"amdgpu13-amd-amdhsa", "amdgpu13.10-amd-amdhsa", true},
 
       // A vendor mismatch is incompatible even when the subarch is otherwise

--- a/llvm/utils/TableGen/Basic/AMDGPUTargetDefEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/AMDGPUTargetDefEmitter.cpp
@@ -70,11 +70,12 @@ static std::optional<StringRef> getSubArchSpelling(const Record *Rec) {
   return Rec->getValueAsOptionalString("SubArchSpelling");
 }
 
-// Emit a subarch enumerator suffix for a spelling, converting '.' to '_' and
-// upcasing, e.g. "4.67q" -> "4_67Q".
+// Emit a subarch enumerator suffix for a spelling, dropping '.' and upcasing,
+// e.g. "12.50s" -> "1250S", matching the sibling name-derived enumerators.
 static void emitSpellingSuffix(raw_ostream &OS, StringRef Spelling) {
   for (char C : Spelling)
-    OS << static_cast<char>((C == '.') ? '_' : toUpper(C));
+    if (C != '.')
+      OS << static_cast<char>(toUpper(C));
 }
 
 // Derive the Triple::SubArchType for a canonical GPU record. A pseudo target


### PR DESCRIPTION
Rename the subarch triple enum for consistency, and place
it next to 1250. Add expanded test coverage.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>