### PR TITLE
RuntimeLibcalls: Add LibraryRef for dispatch-with-exclusion

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.h
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.h
@@ -150,6 +150,10 @@ public:
     AvailableLibcallImpls.set(Impl);
   }
 
+  void setUnavailable(RTLIB::LibcallImpl Impl) {
+    AvailableLibcallImpls.reset(Impl);
+  }
+
   /// Check if a function name is a recognized runtime call of any kind. This
   /// does not consider if this call is available for any current compilation,
   /// just that it is a known call somewhere. This returns the set of all

--- a/llvm/include/llvm/IR/RuntimeLibcallsImpl.td
+++ b/llvm/include/llvm/IR/RuntimeLibcallsImpl.td
@@ -125,6 +125,14 @@ class LibcallLibrary<string name, dag impls,
   RuntimeLibcallAvailability Pred = pred;
 }
 
+// Reference a shared LibcallLibrary from a SystemRuntimeLibrary, dropping the
+// impls in `exclude`. Lets an override target pull a provider library (e.g.
+// compiler-rt) but keep its own versions of a few entries.
+class LibraryRef<LibcallLibrary lib, list<RuntimeLibcallImpl> exclude> {
+  LibcallLibrary Library = lib;
+  list<RuntimeLibcallImpl> Exclude = exclude;
+}
+
 /// Define a complete top level set of runtime libcalls for a target.
 class SystemRuntimeLibrary<RuntimeLibcallAvailability Pred, dag funcList> {
   /// Set the default calling convention assumed for RuntimeLibcallImpl members.

--- a/llvm/test/TableGen/RuntimeLibcallEmitter-library-ref.td
+++ b/llvm/test/TableGen/RuntimeLibcallEmitter-library-ref.td
@@ -1,0 +1,53 @@
+// RUN: llvm-tblgen -gen-runtime-libcalls -I %p/../../include %s | FileCheck %s
+
+// Check that a LibraryRef<Lib, [impls]> member dispatches to the library like a
+// plain reference, with the excluded impls emitted as setUnavailable inside the
+// library function (guarded on the consumer's triple), so the dispatcher stays a
+// plain call.
+
+include "llvm/IR/RuntimeLibcallsImpl.td"
+
+def MEMCPY : RuntimeLibcall;
+def DIV_I32 : RuntimeLibcall;
+def MOD_I32 : RuntimeLibcall;
+def SQRT_F64 : RuntimeLibcall;
+
+def memcpy : RuntimeLibcallImpl<MEMCPY>;
+def __divsi3 : RuntimeLibcallImpl<DIV_I32>;
+def __modsi3 : RuntimeLibcallImpl<MOD_I32>;
+def sqrt : RuntimeLibcallImpl<SQRT_F64, "sqrt">;
+
+def IsX86 : LibcallPredicate<[{TT.isX86()}]>;
+def isX86 : RuntimeLibcallAvailability<(all_of IsX86)>;
+
+def CompilerRt : LibcallLibrary<"compiler-rt", (add memcpy, __divsi3, __modsi3)>;
+def Libm : LibcallLibrary<"libm", (add sqrt)>;
+
+// Dispatch compiler-rt but drop the two div/mod entries this target overrides;
+// dispatch libm plainly.
+def X86System : SystemRuntimeLibrary<isX86,
+    (add LibraryRef<CompilerRt, [__divsi3, __modsi3]>, Libm)>;
+
+// The compiler-rt library function sets its members available, then emits the
+// X86 consumer's opt-out under a triple guard at the end of the same function.
+// CHECK: static void setAvailableLibFuncs_compiler_rt(
+// CHECK: for (const RTLIB::LibcallImpl Impl : LibraryCalls) {
+// CHECK-NEXT: Info.setAvailable(Impl);
+// CHECK: if (TT.isX86()) {
+// CHECK-NEXT: Info.setUnavailable(RTLIB::impl___divsi3); // __divsi3
+// CHECK-NEXT: Info.setUnavailable(RTLIB::impl___modsi3); // __modsi3
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+
+// CHECK: static void setAvailableLibFuncs_libm(
+
+// The dispatcher is a plain call for both libraries; no setUnavailable here.
+// CHECK: void llvm::RTLIB::RuntimeLibcallsInfo::setTargetRuntimeLibcallSets(
+// CHECK:   if (TT.isX86()) {
+// CHECK: AvailableLibcallImpls = SystemAvailableImpls;
+// CHECK-EMPTY:
+// CHECK-NEXT:     if (isLibraryAvailable("compiler-rt"))
+// CHECK-NEXT:       setAvailableLibFuncs_compiler_rt(*this, TT, ExceptionModel, FloatABI, EABIVersion, ABIName, LongDoubleFormat);
+// CHECK-NEXT:     if (isLibraryAvailable("libm"))
+// CHECK-NEXT:       setAvailableLibFuncs_libm(*this, TT, ExceptionModel, FloatABI, EABIVersion, ABIName, LongDoubleFormat);
+// CHECK-NOT:   setUnavailable

--- a/llvm/test/TableGen/RuntimeLibcallEmitter-library-ref.td
+++ b/llvm/test/TableGen/RuntimeLibcallEmitter-library-ref.td
@@ -1,0 +1,53 @@
+// RUN: llvm-tblgen -gen-runtime-libcalls -I %p/../../include %s | FileCheck %s
+
+// Check that a LibraryRef<Lib, [impls]> member dispatches to the library like a
+// plain reference, with the excluded impls emitted as setUnavailable inside the
+// library function (guarded on the consumer's triple), so the dispatcher stays a
+// plain call.
+
+include "llvm/IR/RuntimeLibcallsImpl.td"
+
+def MEMCPY : RuntimeLibcall;
+def DIV_I32 : RuntimeLibcall;
+def MOD_I32 : RuntimeLibcall;
+def SQRT_F64 : RuntimeLibcall;
+
+def memcpy : RuntimeLibcallImpl<MEMCPY>;
+def __divsi3 : RuntimeLibcallImpl<DIV_I32>;
+def __modsi3 : RuntimeLibcallImpl<MOD_I32>;
+def sqrt : RuntimeLibcallImpl<SQRT_F64, "sqrt">;
+
+def IsX86 : LibcallPredicate<[{TT.isX86()}]>;
+def isX86 : RuntimeLibcallAvailability<(all_of IsX86)>;
+
+def CompilerRt : LibcallLibrary<"compiler-rt", (add memcpy, __divsi3, __modsi3)>;
+def Libm : LibcallLibrary<"libm", (add sqrt)>;
+
+// Dispatch compiler-rt but drop the two div/mod entries this target overrides;
+// dispatch libm plainly.
+def X86System : SystemRuntimeLibrary<isX86,
+    (add LibraryRef<CompilerRt, [__divsi3, __modsi3]>, Libm)>;
+
+// The compiler-rt library function sets its members available, then emits the
+// X86 consumer's opt-out under a triple guard at the end of the same function.
+// CHECK: void llvm::RTLIB::RuntimeLibcallsInfo::setAvailableLibFuncs_compiler_rt(
+// CHECK: for (const RTLIB::LibcallImpl Impl : LibraryCalls) {
+// CHECK-NEXT: setAvailable(Impl);
+// CHECK: if (TT.isX86()) {
+// CHECK-NEXT: setUnavailable(RTLIB::impl___divsi3); // __divsi3
+// CHECK-NEXT: setUnavailable(RTLIB::impl___modsi3); // __modsi3
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+
+// CHECK: void llvm::RTLIB::RuntimeLibcallsInfo::setAvailableLibFuncs_libm(
+
+// The dispatcher is a plain call for both libraries; no setUnavailable here.
+// CHECK: void llvm::RTLIB::RuntimeLibcallsInfo::setTargetRuntimeLibcallSets(
+// CHECK:   if (TT.isX86()) {
+// CHECK: AvailableLibcallImpls = SystemAvailableImpls;
+// CHECK-EMPTY:
+// CHECK-NEXT:     if (isLibraryAvailable("compiler-rt"))
+// CHECK-NEXT:       setAvailableLibFuncs_compiler_rt(TT, ExceptionModel, FloatABI, EABIVersion, ABIName, LongDoubleFormat);
+// CHECK-NEXT:     if (isLibraryAvailable("libm"))
+// CHECK-NEXT:       setAvailableLibFuncs_libm(TT, ExceptionModel, FloatABI, EABIVersion, ABIName, LongDoubleFormat);
+// CHECK-NOT:   setUnavailable

--- a/llvm/utils/TableGen/Basic/RuntimeLibcallsEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/RuntimeLibcallsEmitter.cpp
@@ -98,10 +98,19 @@ private:
                       SetVector<PredicateWithCC> &PredicateSorter,
                       unsigned BaseIndent, StringRef Receiver) const;
 
+  // A LibraryRef opt-out: the impls a consumer drops from a shared library,
+  // plus the consumer's triple predicate.
+  struct LibraryExclusion {
+    const Record *TriplePred;
+    std::vector<const RuntimeLibcallImpl *> Impls;
+  };
+
   // Emit a file-local `setAvailableLibFuncs_<name>` for all LibcallLibrary defs
-  // sharing \p Name, each gated by its own availability predicate.
+  // sharing \p Name, each gated by its own availability predicate. \p
+  // Exclusions are emitted as guarded setUnavailable calls at the end.
   void emitLibraryFunction(raw_ostream &OS, StringRef Name,
-                           ArrayRef<const Record *> Libs) const;
+                           ArrayRef<const Record *> Libs,
+                           ArrayRef<LibraryExclusion> Exclusions) const;
 
   void emitSystemRuntimeLibrarySetCalls(raw_ostream &OS) const;
 
@@ -488,7 +497,8 @@ static void emitLibFuncSuffix(raw_ostream &OS, StringRef Name) {
 }
 
 void RuntimeLibcallEmitter::emitLibraryFunction(
-    raw_ostream &OS, StringRef Name, ArrayRef<const Record *> Libs) const {
+    raw_ostream &OS, StringRef Name, ArrayRef<const Record *> Libs,
+    ArrayRef<LibraryExclusion> Exclusions) const {
   // File-local; referenced only from the driver in the same fragment.
   OS << "static void setAvailableLibFuncs_";
   emitLibFuncSuffix(OS, Name);
@@ -607,6 +617,21 @@ void RuntimeLibcallEmitter::emitLibraryFunction(
     }
   }
 
+  // Emit each consumer's LibraryRef opt-outs.
+  for (const LibraryExclusion &Excl : Exclusions) {
+    OS << '\n' << indent(2);
+    AvailabilityPredicate ExcludePred(Excl.TriplePred);
+    ExcludePred.emitIf(OS);
+    for (const RuntimeLibcallImpl *Impl : Excl.Impls) {
+      OS << indent(4) << "Info.setUnavailable(";
+      Impl->emitEnumEntry(OS);
+      OS << "); // " << Impl->getLibcallFuncName() << '\n';
+    }
+
+    OS << indent(2);
+    ExcludePred.emitEndIf(OS);
+  }
+
   OS << "}\n\n";
 }
 
@@ -619,11 +644,37 @@ void RuntimeLibcallEmitter::emitSystemRuntimeLibrarySetCalls(
   for (const Record *Lib : Records.getAllDerivedDefinitions("LibcallLibrary"))
     LibsByName[Lib->getValueAsString("LibraryName")].push_back(Lib);
 
-  for (const auto &[Name, Libs] : LibsByName)
-    emitLibraryFunction(OS, Name, Libs);
-
   ArrayRef<const Record *> AllLibs =
       Records.getAllDerivedDefinitions("SystemRuntimeLibrary");
+
+  // Collect each shared library's LibraryRef opt-outs, keyed by library name,
+  // so its library function can emit them.
+  MapVector<StringRef, std::vector<LibraryExclusion>> ExclusionsByLibName;
+  for (const Record *R : AllLibs) {
+    const DagInit *MemberDag =
+        R->getValueAsDef("MemberList")->getValueAsDag("MemberList");
+    for (const Init *Arg : MemberDag->getArgs()) {
+      const auto *DI = dyn_cast<DefInit>(Arg);
+      if (!DI || !DI->getDef()->isSubClassOf("LibraryRef"))
+        continue;
+      const Record *Def = DI->getDef();
+      LibraryExclusion Excl{R->getValueAsDef("TriplePred"), {}};
+      for (const Record *ExcludeRec : Def->getValueAsListOfDefs("Exclude")) {
+        if (const RuntimeLibcallImpl *Impl =
+                Libcalls.getRuntimeLibcallImpl(ExcludeRec))
+          Excl.Impls.push_back(Impl);
+      }
+
+      if (!Excl.Impls.empty()) {
+        StringRef LibName =
+            Def->getValueAsDef("Library")->getValueAsString("LibraryName");
+        ExclusionsByLibName[LibName].push_back(std::move(Excl));
+      }
+    }
+  }
+
+  for (const auto &[Name, Libs] : LibsByName)
+    emitLibraryFunction(OS, Name, Libs, ExclusionsByLibName.lookup(Name));
 
   OS << "void llvm::RTLIB::RuntimeLibcallsInfo::setTargetRuntimeLibcallSets("
         "const llvm::Triple &TT, ExceptionHandling ExceptionModel, "
@@ -651,21 +702,41 @@ void RuntimeLibcallEmitter::emitSystemRuntimeLibrarySetCalls(
       }
     }
 
-    // Split the top-level member list into named LibcallLibrary references,
-    // which are dispatched to their own setAvailableLibFuncs_<name> function
-    // under an isLibraryAvailable guard, and the remaining (bare impl /
-    // LibcallImpls) members, which are emitted inline via the flat path below.
+    // Split the top-level member list into named LibcallLibrary references
+    // (dispatched to their own setAvailableLibFuncs_<name> under an
+    // isLibraryAvailable guard) and the remaining bare impl / LibcallImpls
+    // members. A LibraryRef also records impls to drop.
+    struct DispatchLib {
+      StringRef Name;
+      std::vector<const RuntimeLibcallImpl *> Exclude;
+    };
     const DagInit *MemberDag =
         R->getValueAsDef("MemberList")->getValueAsDag("MemberList");
-    SmallVector<StringRef, 4> DispatchLibs;
+    SmallVector<DispatchLib, 4> DispatchLibs;
     SmallVector<const Init *, 16> InlineArgs;
     SmallVector<const StringInit *, 16> InlineArgNames;
     for (auto [Arg, ArgName] :
          zip_equal(MemberDag->getArgs(), MemberDag->getArgNames())) {
-      if (const auto *DI = dyn_cast<DefInit>(Arg);
-          DI && DI->getDef()->isSubClassOf("LibcallLibrary")) {
-        DispatchLibs.push_back(DI->getDef()->getValueAsString("LibraryName"));
-        continue;
+      if (const auto *DI = dyn_cast<DefInit>(Arg)) {
+        const Record *Def = DI->getDef();
+        if (Def->isSubClassOf("LibcallLibrary")) {
+          DispatchLibs.push_back({Def->getValueAsString("LibraryName"), {}});
+          continue;
+        }
+
+        if (Def->isSubClassOf("LibraryRef")) {
+          const Record *Lib = Def->getValueAsDef("Library");
+          DispatchLib DL{Lib->getValueAsString("LibraryName"), {}};
+          for (const Record *ExcludeRec :
+               Def->getValueAsListOfDefs("Exclude")) {
+            if (const RuntimeLibcallImpl *Impl =
+                    Libcalls.getRuntimeLibcallImpl(ExcludeRec))
+              DL.Exclude.push_back(Impl);
+          }
+
+          DispatchLibs.push_back(std::move(DL));
+          continue;
+        }
       }
       InlineArgs.push_back(Arg);
       InlineArgNames.push_back(ArgName);
@@ -750,10 +821,10 @@ void RuntimeLibcallEmitter::emitSystemRuntimeLibrarySetCalls(
     // Dispatch to each named library's setup function. This must come after the
     // SystemAvailableImpls assignment above (which overwrites the bitset); the
     // library functions union their members in on top via setAvailable.
-    for (StringRef LibName : DispatchLibs) {
-      OS << indent(4) << "if (isLibraryAvailable(\"" << LibName << "\"))\n"
+    for (const DispatchLib &DL : DispatchLibs) {
+      OS << indent(4) << "if (isLibraryAvailable(\"" << DL.Name << "\"))\n"
          << indent(6) << "setAvailableLibFuncs_";
-      emitLibFuncSuffix(OS, LibName);
+      emitLibFuncSuffix(OS, DL.Name);
       OS << "(*this, TT, ExceptionModel, FloatABI, EABIVersion, ABIName, "
             "LongDoubleFormat);\n";
     }

--- a/llvm/utils/TableGen/Basic/RuntimeLibcallsEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/RuntimeLibcallsEmitter.cpp
@@ -98,10 +98,19 @@ private:
                       SetVector<PredicateWithCC> &PredicateSorter,
                       unsigned BaseIndent) const;
 
+  // A LibraryRef opt-out: the impls a consumer drops from a shared library,
+  // plus the consumer's triple predicate.
+  struct LibraryExclusion {
+    const Record *TriplePred;
+    std::vector<const RuntimeLibcallImpl *> Impls;
+  };
+
   // Emit a `setAvailableLibFuncs_<name>` member function for all LibcallLibrary
-  // defs sharing \p Name, each gated by its own availability predicate.
+  // defs sharing \p Name, each gated by its own availability predicate. \p
+  // Exclusions are emitted as guarded setUnavailable calls at the end.
   void emitLibraryFunction(raw_ostream &OS, StringRef Name,
-                           ArrayRef<const Record *> Libs) const;
+                           ArrayRef<const Record *> Libs,
+                           ArrayRef<LibraryExclusion> Exclusions) const;
 
   // Group all LibcallLibrary defs by their shared LibraryName, preserving
   // definition order. Both the member-declaration fragment and the definitions
@@ -494,7 +503,8 @@ static void emitLibFuncSuffix(raw_ostream &OS, StringRef Name) {
 }
 
 void RuntimeLibcallEmitter::emitLibraryFunction(
-    raw_ostream &OS, StringRef Name, ArrayRef<const Record *> Libs) const {
+    raw_ostream &OS, StringRef Name, ArrayRef<const Record *> Libs,
+    ArrayRef<LibraryExclusion> Exclusions) const {
   OS << "void llvm::RTLIB::RuntimeLibcallsInfo::setAvailableLibFuncs_";
   emitLibFuncSuffix(OS, Name);
   OS << "(const llvm::Triple &TT, "
@@ -612,6 +622,21 @@ void RuntimeLibcallEmitter::emitLibraryFunction(
     }
   }
 
+  // Emit each consumer's LibraryRef opt-outs.
+  for (const LibraryExclusion &Excl : Exclusions) {
+    OS << '\n' << indent(2);
+    AvailabilityPredicate ExcludePred(Excl.TriplePred);
+    ExcludePred.emitIf(OS);
+    for (const RuntimeLibcallImpl *Impl : Excl.Impls) {
+      OS << indent(4) << "setUnavailable(";
+      Impl->emitEnumEntry(OS);
+      OS << "); // " << Impl->getLibcallFuncName() << '\n';
+    }
+
+    OS << indent(2);
+    ExcludePred.emitEndIf(OS);
+  }
+
   OS << "}\n\n";
 }
 
@@ -637,12 +662,37 @@ void RuntimeLibcallEmitter::emitRuntimeLibcallsInfoMemberDecls(
 
 void RuntimeLibcallEmitter::emitSystemRuntimeLibrarySetCalls(
     raw_ostream &OS) const {
-  // Emit one function per distinct library name; same-named defs merge.
-  for (const auto &[Name, Libs] : collectLibrariesByName())
-    emitLibraryFunction(OS, Name, Libs);
-
   ArrayRef<const Record *> AllLibs =
       Records.getAllDerivedDefinitions("SystemRuntimeLibrary");
+
+  // Collect each shared library's LibraryRef opt-outs, keyed by library name,
+  // so its library function can emit them.
+  MapVector<StringRef, std::vector<LibraryExclusion>> ExclusionsByLibName;
+  for (const Record *R : AllLibs) {
+    const DagInit *MemberDag =
+        R->getValueAsDef("MemberList")->getValueAsDag("MemberList");
+    for (const Init *Arg : MemberDag->getArgs()) {
+      const auto *DI = dyn_cast<DefInit>(Arg);
+      if (!DI || !DI->getDef()->isSubClassOf("LibraryRef"))
+        continue;
+      const Record *Def = DI->getDef();
+      LibraryExclusion Excl{R->getValueAsDef("TriplePred"), {}};
+      for (const Record *ExcludeRec : Def->getValueAsListOfDefs("Exclude")) {
+        if (const RuntimeLibcallImpl *Impl =
+                Libcalls.getRuntimeLibcallImpl(ExcludeRec))
+          Excl.Impls.push_back(Impl);
+      }
+
+      if (!Excl.Impls.empty()) {
+        StringRef LibName =
+            Def->getValueAsDef("Library")->getValueAsString("LibraryName");
+        ExclusionsByLibName[LibName].push_back(std::move(Excl));
+      }
+    }
+  }
+
+  for (const auto &[Name, Libs] : collectLibrariesByName())
+    emitLibraryFunction(OS, Name, Libs, ExclusionsByLibName.lookup(Name));
 
   OS << "void llvm::RTLIB::RuntimeLibcallsInfo::setTargetRuntimeLibcallSets("
         "const llvm::Triple &TT, ExceptionHandling ExceptionModel, "
@@ -670,21 +720,41 @@ void RuntimeLibcallEmitter::emitSystemRuntimeLibrarySetCalls(
       }
     }
 
-    // Split the top-level member list into named LibcallLibrary references,
-    // which are dispatched to their own setAvailableLibFuncs_<name> function
-    // under an isLibraryAvailable guard, and the remaining (bare impl /
-    // LibcallImpls) members, which are emitted inline via the flat path below.
+    // Split the top-level member list into named LibcallLibrary references
+    // (dispatched to their own setAvailableLibFuncs_<name> under an
+    // isLibraryAvailable guard) and the remaining bare impl / LibcallImpls
+    // members. A LibraryRef also records impls to drop.
+    struct DispatchLib {
+      StringRef Name;
+      std::vector<const RuntimeLibcallImpl *> Exclude;
+    };
     const DagInit *MemberDag =
         R->getValueAsDef("MemberList")->getValueAsDag("MemberList");
-    SmallVector<StringRef, 4> DispatchLibs;
+    SmallVector<DispatchLib, 4> DispatchLibs;
     SmallVector<const Init *, 16> InlineArgs;
     SmallVector<const StringInit *, 16> InlineArgNames;
     for (auto [Arg, ArgName] :
          zip_equal(MemberDag->getArgs(), MemberDag->getArgNames())) {
-      if (const auto *DI = dyn_cast<DefInit>(Arg);
-          DI && DI->getDef()->isSubClassOf("LibcallLibrary")) {
-        DispatchLibs.push_back(DI->getDef()->getValueAsString("LibraryName"));
-        continue;
+      if (const auto *DI = dyn_cast<DefInit>(Arg)) {
+        const Record *Def = DI->getDef();
+        if (Def->isSubClassOf("LibcallLibrary")) {
+          DispatchLibs.push_back({Def->getValueAsString("LibraryName"), {}});
+          continue;
+        }
+
+        if (Def->isSubClassOf("LibraryRef")) {
+          const Record *Lib = Def->getValueAsDef("Library");
+          DispatchLib DL{Lib->getValueAsString("LibraryName"), {}};
+          for (const Record *ExcludeRec :
+               Def->getValueAsListOfDefs("Exclude")) {
+            if (const RuntimeLibcallImpl *Impl =
+                    Libcalls.getRuntimeLibcallImpl(ExcludeRec))
+              DL.Exclude.push_back(Impl);
+          }
+
+          DispatchLibs.push_back(std::move(DL));
+          continue;
+        }
       }
       InlineArgs.push_back(Arg);
       InlineArgNames.push_back(ArgName);
@@ -769,10 +839,10 @@ void RuntimeLibcallEmitter::emitSystemRuntimeLibrarySetCalls(
     // Dispatch to each named library's setup function. This must come after the
     // SystemAvailableImpls assignment above (which overwrites the bitset); the
     // library functions union their members in on top via setAvailable.
-    for (StringRef LibName : DispatchLibs) {
-      OS << indent(4) << "if (isLibraryAvailable(\"" << LibName << "\"))\n"
+    for (const DispatchLib &DL : DispatchLibs) {
+      OS << indent(4) << "if (isLibraryAvailable(\"" << DL.Name << "\"))\n"
          << indent(6) << "setAvailableLibFuncs_";
-      emitLibFuncSuffix(OS, LibName);
+      emitLibFuncSuffix(OS, DL.Name);
       OS << "(TT, ExceptionModel, FloatABI, EABIVersion, ABIName, "
             "LongDoubleFormat);\n";
     }


### PR DESCRIPTION
Let a SystemRuntimeLibrary dispatch a shared provider library while dropping the
impls the target replaces, since a library reference cannot nest inside (sub ...).
This is a compromise from the ideal of explicitly listing all calls, but getting
to that point is prooving to be difficult.

The opt-out is emitted inside setAvailableLibFuncs_<lib>, so the single library's
logic is self contained.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>