### PR TITLE
[Casting][NFC] Remove soft deprecation on functions with `_or_null` suffix

### DIFF
--- a/llvm/docs/ProgrammersManual.md
+++ b/llvm/docs/ProgrammersManual.md
@@ -147,26 +147,29 @@ rarely have to include this file directly).
   efficient to use the `InstVisitor` class to dispatch over the instruction
   type directly.
 
-`isa_and_present<>`:
+`isa_and_present<>` and `isa_and_nonnull<>`:
   The `isa_and_present<>` operator works just like the `isa<>` operator,
   except that it allows for a null pointer as an argument (which it then
   returns `false`).  This can sometimes be useful, allowing you to combine
   several null checks into one. Similar to `isa<>` operator, you can specify
   more than one class to check.
+  `isa_and_nonnull<>` is currently an alias of `isa_and_present<>`.
 
-`cast_if_present<>`:
+`cast_if_present<>` and `cast_or_null<>`:
   The `cast_if_present<>` operator works just like the `cast<>` operator,
   except that it allows for a null pointer as an argument (which it then
   propagates).  This can sometimes be useful, allowing you to combine several
   null checks into one.
+  `cast_or_null<>` is currently an alias of `cast_if_present<>`.
 
-`dyn_cast_if_present<>`:
+`dyn_cast_if_present<>` and `dyn_cast_or_null<>`:
   The `dyn_cast_if_present<>` operator works just like the `dyn_cast<>`
   operator, except that it allows for a null pointer as an argument (which it
   then propagates).  This can sometimes be useful, allowing you to combine
   several null checks into one.
+  `dyn_cast_or_null<>` is currently an alias of `dyn_cast_if_present<>`.
 
-These five templates can be used with any classes, whether they have a v-table
+These six templates can be used with any classes, whether they have a v-table
 or not.  If you want to add support for these templates, see the document
 {doc}`How to set up LLVM-style RTTI for your class hierarchy <HowToSetUpLLVMStyleRTTI>`
 

--- a/llvm/include/llvm/Support/Casting.h
+++ b/llvm/include/llvm/Support/Casting.h
@@ -708,9 +708,7 @@ template <class X, class Y>
   return UniquePtrCast<X, Y>::doCast(std::move(Val));
 }
 
-// Provide a forwarding from cast_or_null to cast_if_present for current
-// users. This is deprecated and will be removed in a future patch, use
-// cast_if_present instead.
+// Alias of `cast_if_present`.
 template <class X, class Y> auto cast_or_null(const Y &Val) {
   return cast_if_present<X>(Val);
 }
@@ -747,9 +745,7 @@ template <class X, class Y> auto dyn_cast_if_present(Y *Val) {
   return CastInfo<X, Y *>::doCastIfPossible(detail::unwrapValue(Val));
 }
 
-// Forwards to dyn_cast_if_present to avoid breaking current users. This is
-// deprecated and will be removed in a future patch, use
-// dyn_cast_if_present instead.
+// Alias of `dyn_cast_if_present`.
 template <class X, class Y> auto dyn_cast_or_null(const Y &Val) {
   return dyn_cast_if_present<X>(Val);
 }


### PR DESCRIPTION
We still haven't reached a consensus on how to choose between the `_or_null` and `_if_present` suffixes.

See also <https://discourse.llvm.org/t/psa-swapping-out-or-null-with-if-present/65018>.