### PR TITLE
[mlir][Bytecode] Use explicit attribute APIs to split inherent/discardable attr access

### DIFF
--- a/mlir/lib/Bytecode/Writer/BytecodeWriter.cpp
+++ b/mlir/lib/Bytecode/Writer/BytecodeWriter.cpp
@@ -1015,14 +1015,19 @@ LogicalResult BytecodeWriter::writeOp(EncodingEmitter &emitter, Operation *op) {
   emitter.emitVarInt(numberingState.getNumber(op->getLoc()), "op location");
 
   // Emit the attributes of this operation.
-  DictionaryAttr attrs = op->getDiscardableAttrDictionary();
+  DictionaryAttr attrs = op->getRawDictionaryAttrs();
   // Allow deployment to version <kNativePropertiesEncoding by merging inherent
   // attribute with the discardable ones. We should fail if there are any
   // conflicts. When properties are not used by the op, also store everything as
   // attributes.
-  if (config.bytecodeVersion < bytecode::kNativePropertiesEncoding ||
-      !op->getPropertiesStorage()) {
-    attrs = op->getAttrDictionary();
+  if (config.bytecodeVersion < bytecode::kNativePropertiesEncoding &&
+      op->getPropertiesStorage()) {
+    NamedAttrList allAttrs;
+    op->getName().walkInherentAttrs(op, [&](StringRef name, Attribute &attr) {
+      allAttrs.append(name, attr);
+    });
+    allAttrs.append(op->getDiscardableAttrDictionary().getValue());
+    attrs = allAttrs.getDictionary(op->getContext());
   }
   if (!attrs.empty()) {
     opEncodingMask |= bytecode::OpEncodingMask::kHasAttrs;

--- a/mlir/lib/Bytecode/Writer/IRNumbering.cpp
+++ b/mlir/lib/Bytecode/Writer/IRNumbering.cpp
@@ -446,10 +446,18 @@ void IRNumberingState::number(Operation &op) {
   // not used, we need to number also the merged dictionary containing both the
   // inherent and discardable attribute.
   DictionaryAttr dictAttr;
-  if (config.getDesiredBytecodeVersion() >= bytecode::kNativePropertiesEncoding)
+  if (config.getDesiredBytecodeVersion() >=
+          bytecode::kNativePropertiesEncoding ||
+      !op.getPropertiesStorage())
     dictAttr = op.getRawDictionaryAttrs();
-  else
-    dictAttr = op.getAttrDictionary();
+  else {
+    NamedAttrList attrs;
+    op.getName().walkInherentAttrs(&op, [&](StringRef name, Attribute &attr) {
+      attrs.append(name, attr);
+    });
+    attrs.append(op.getDiscardableAttrDictionary().getValue());
+    dictAttr = attrs.getDictionary(op.getContext());
+  }
   // Only number the operation's dictionary if it isn't empty.
   if (!dictAttr.empty())
     number(dictAttr);

--- a/mlir/unittests/Bytecode/BytecodeTest.cpp
+++ b/mlir/unittests/Bytecode/BytecodeTest.cpp
@@ -222,7 +222,7 @@ TEST(Bytecode, OpWithoutProperties) {
   ASSERT_TRUE(succeeded(readBytecodeFile(
       llvm::MemoryBufferRef(bytecode, "string-buffer"), block.get(), config)));
   Operation *roundtripped = &block->front();
-  EXPECT_EQ(roundtripped->getAttrs().size(), 2u);
+  EXPECT_EQ(roundtripped->getRawDictionaryAttrs().size(), 2u);
   EXPECT_EQ(roundtripped->getInherentAttr("inherent_attr"), std::nullopt);
   EXPECT_NE(roundtripped->getDiscardableAttr("inherent_attr"), Attribute());
   EXPECT_NE(roundtripped->getDiscardableAttr("other_attr"), Attribute());
@@ -389,7 +389,7 @@ TEST(Bytecode, LocationElisionPreservesAttributes) {
   EXPECT_TRUE(isa<UnknownLoc>(innerOp->getLoc()));
 
   // 2. Verify that the semantic location attribute WAS PRESERVED.
-  Attribute semanticLocAttr = innerOp->getAttr("some_loc_attr");
+  Attribute semanticLocAttr = innerOp->getDiscardableAttr("some_loc_attr");
   ASSERT_TRUE(semanticLocAttr);
   auto locAttr = dyn_cast<LocationAttr>(semanticLocAttr);
   ASSERT_TRUE(locAttr);


### PR DESCRIPTION
Use explicit discardable and inherent attribute access when numbering and writing bytecode, and update the focused unit coverage.

Assisted-by: Codex