### PR TITLE
CodeGen: Add UsesBlockArgs MachineFunction property

### DIFF
--- a/llvm/include/llvm/CodeGen/MIRYamlMapping.h
+++ b/llvm/include/llvm/CodeGen/MIRYamlMapping.h
@@ -845,6 +845,7 @@ struct MachineFunction {
   bool FailsVerification = false;
   bool TracksDebugUserValues = false;
   bool UseDebugInstrRef = false;
+  bool UsesBlockArgs = false;
   std::vector<VirtualRegisterDefinition> VirtualRegisters;
   std::vector<MachineFunctionLiveIn> LiveIns;
   std::optional<std::vector<FlowStringValue>> CalleeSavedRegisters;
@@ -895,6 +896,7 @@ template <> struct MappingTraits<MachineFunction> {
     YamlIO.mapOptional("failsVerification", MF.FailsVerification, false);
     YamlIO.mapOptional("tracksDebugUserValues", MF.TracksDebugUserValues,
                        false);
+    YamlIO.mapOptional("usesBlockArgs", MF.UsesBlockArgs, false);
     YamlIO.mapOptional("registers", MF.VirtualRegisters,
                        std::vector<VirtualRegisterDefinition>());
     YamlIO.mapOptional("liveins", MF.LiveIns,

--- a/llvm/include/llvm/CodeGen/MachineFunction.h
+++ b/llvm/include/llvm/CodeGen/MachineFunction.h
@@ -198,7 +198,8 @@ public:
     FailsVerification,
     FailedRegAlloc,
     TracksDebugUserValues,
-    LastProperty = TracksDebugUserValues,
+    UsesBlockArgs,
+    LastProperty = UsesBlockArgs,
   };
 
   bool hasProperty(Property P) const {
@@ -233,6 +234,7 @@ public:
   PPACCESSORS(FailsVerification)
   PPACCESSORS(FailedRegAlloc)
   PPACCESSORS(TracksDebugUserValues)
+  PPACCESSORS(UsesBlockArgs)
 
   /// Reset all the properties.
   MachineFunctionProperties &reset() {

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -596,6 +596,8 @@ MIRParserImpl::initializeMachineFunction(const yaml::MachineFunction &YamlMF,
     Props.setFailsVerification();
   if (YamlMF.TracksDebugUserValues)
     Props.setTracksDebugUserValues();
+  if (YamlMF.UsesBlockArgs)
+    Props.setUsesBlockArgs();
 
   PerFunctionMIParsingState PFS(MF, SM, IRSlots, *Target);
   if (parseRegisterInfo(PFS, YamlMF))

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -599,6 +599,8 @@ MIRParserImpl::initializeMachineFunction(const yaml::MachineFunction &YamlMF,
     Props.setFailsVerification();
   if (YamlMF.TracksDebugUserValues)
     Props.setTracksDebugUserValues();
+  if (YamlMF.UsesBlockArgs)
+    Props.setUsesBlockArgs();
 
   PerFunctionMIParsingState PFS(MF, SM, IRSlots, *Target);
   if (parseRegisterInfo(PFS, YamlMF))

--- a/llvm/lib/CodeGen/MIRPrinter.cpp
+++ b/llvm/lib/CodeGen/MIRPrinter.cpp
@@ -206,6 +206,7 @@ static void printMF(raw_ostream &OS, MFGetterFnT Fn, const MachineFunction &MF,
   YamlMF.NoPHIs = Props.hasNoPHIs();
   YamlMF.IsSSA = Props.hasIsSSA();
   YamlMF.NoVRegs = Props.hasNoVRegs();
+  YamlMF.UsesBlockArgs = Props.hasUsesBlockArgs();
 
   convertMRI(YamlMF, MF, MF.getRegInfo(), MF.getSubtarget().getRegisterInfo(),
              VRM);

--- a/llvm/lib/CodeGen/MachineFunction.cpp
+++ b/llvm/lib/CodeGen/MachineFunction.cpp
@@ -105,6 +105,7 @@ static const char *getPropertyName(MachineFunctionProperties::Property Prop) {
   case P::FailsVerification: return "FailsVerification";
   case P::FailedRegAlloc: return "FailedRegAlloc";
   case P::TracksDebugUserValues: return "TracksDebugUserValues";
+  case P::UsesBlockArgs: return "UsesBlockArgs";
   }
   // clang-format on
   llvm_unreachable("Invalid machine function property");

--- a/llvm/test/CodeGen/MIR/X86/uses-block-args-property.mir
+++ b/llvm/test/CodeGen/MIR/X86/uses-block-args-property.mir
@@ -1,0 +1,20 @@
+# RUN: llc -mtriple=x86_64-- -run-pass=none -o - %s | FileCheck %s
+# Round-trip test for the usesBlockArgs machine function property.
+
+---
+# CHECK-LABEL: name: with_block_args
+# CHECK: usesBlockArgs: true
+name: with_block_args
+usesBlockArgs: true
+body: |
+  bb.0:
+    RET64
+...
+---
+# CHECK-LABEL: name: without_block_args
+# CHECK: usesBlockArgs: false
+name: without_block_args
+body: |
+  bb.0:
+    RET64
+...


### PR DESCRIPTION
Bringup guard for block argument support.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>