### PR TITLE
[AArch64] Use unscaled load for weak external GOT references on COFF

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
@@ -1488,10 +1488,83 @@ bool AArch64ExpandPseudoImpl::expandMI(MachineBasicBlock &MBB,
       // Small codemodel expand into ADRP + LDR.
       MachineFunction &MF = *MI.getParent()->getParent();
       DebugLoc DL = MI.getDebugLoc();
+
+      // A weak external reference may be resolved by the linker to a
+      // definition from another object file whose alignment cannot be
+      // relied upon (e.g. a COFF weak external default fallback), so do
+      // not fold the page offset into a scaled LDR. Expand into
+      // ADRP + ADD + LDR instead, which uses relocations that are valid
+      // regardless of the alignment of the resolved symbol.
+      //
+      // References that go through a pointer slot (.refptr. or __imp_)
+      // instead of the symbol itself keep the scaled form, as the slot is
+      // sufficiently aligned.
+      const bool IsWeakExternalCOFF =
+          MO1.isGlobal() && MO1.getGlobal()->hasExternalWeakLinkage() &&
+          MF.getTarget().getTargetTriple().isOSBinFormatCOFF() &&
+          !(Flags & (AArch64II::MO_COFFSTUB | AArch64II::MO_DLLIMPORT));
+
       MachineInstrBuilder MIB1 =
           BuildMI(MBB, MBBI, MI.getDebugLoc(), TII->get(AArch64::ADRP), DstReg);
 
       MachineInstrBuilder MIB2;
+      if (IsWeakExternalCOFF) {
+        MachineInstrBuilder MIBAdd =
+            BuildMI(MBB, MBBI, DL, TII->get(AArch64::ADDXri), DstReg)
+                .addReg(DstReg);
+        if (MO1.isGlobal())
+          MIBAdd.addGlobalAddress(MO1.getGlobal(), MO1.getOffset(),
+                                  Flags | AArch64II::MO_PAGEOFF |
+                                      AArch64II::MO_NC);
+        else if (MO1.isSymbol())
+          MIBAdd.addExternalSymbol(MO1.getSymbolName(),
+                                   Flags | AArch64II::MO_PAGEOFF |
+                                       AArch64II::MO_NC);
+        else {
+          assert(MO1.isCPI() &&
+                 "Only expect globals, externalsymbols, or constant pools");
+          MIBAdd.addConstantPoolIndex(MO1.getIndex(), MO1.getOffset(),
+                                      Flags | AArch64II::MO_PAGEOFF |
+                                          AArch64II::MO_NC);
+        }
+        MIBAdd.addImm(0);
+        if (MF.getSubtarget<AArch64Subtarget>().isTargetILP32()) {
+          auto TRI = MBB.getParent()->getSubtarget().getRegisterInfo();
+          unsigned Reg32 = TRI->getSubReg(DstReg, AArch64::sub_32);
+          MIB2 = BuildMI(MBB, MBBI, DL, TII->get(AArch64::LDRWui))
+                     .addDef(Reg32)
+                     .addReg(DstReg, RegState::Kill)
+                     .addReg(DstReg, RegState::Implicit);
+        } else {
+          Register DstReg = MI.getOperand(0).getReg();
+          MIB2 = BuildMI(MBB, MBBI, DL, TII->get(AArch64::LDRXui), DstReg)
+                     .addUse(DstReg, RegState::Kill);
+        }
+        // The offset operand of the LDR is a plain immediate now; the page
+        // offset is folded into the ADD above.
+        MIB2.addImm(0);
+        if (MO1.isGlobal())
+          MIB1.addGlobalAddress(MO1.getGlobal(), 0, Flags | AArch64II::MO_PAGE);
+        else if (MO1.isSymbol())
+          MIB1.addExternalSymbol(MO1.getSymbolName(),
+                                 Flags | AArch64II::MO_PAGE);
+        else {
+          assert(MO1.isCPI() &&
+                 "Only expect globals, externalsymbols, or constant pools");
+          MIB1.addConstantPoolIndex(MO1.getIndex(), MO1.getOffset(),
+                                    Flags | AArch64II::MO_PAGE);
+        }
+
+        // If the LOADgot instruction has a debug-instr-number, annotate the
+        // LDRWui instruction that it is expanded to with the same
+        // debug-instr-number to preserve debug information.
+        if (MI.peekDebugInstrNum() != 0)
+          MIB2->setDebugInstrNum(MI.peekDebugInstrNum());
+        transferImpOps(MI, MIB1, MIB2);
+        MI.eraseFromParent();
+        return true;
+      }
+
       if (MF.getSubtarget<AArch64Subtarget>().isTargetILP32()) {
         auto TRI = MBB.getParent()->getSubtarget().getRegisterInfo();
         unsigned Reg32 = TRI->getSubReg(DstReg, AArch64::sub_32);

--- a/llvm/test/CodeGen/AArch64/coff-loadgot-weak-extern.ll
+++ b/llvm/test/CodeGen/AArch64/coff-loadgot-weak-extern.ll
@@ -1,0 +1,30 @@
+; RUN: llc -mtriple=aarch64-windows-gnu < %s | FileCheck %s
+; RUN: llc -mtriple=aarch64-windows-msvc < %s | FileCheck %s
+; RUN: llc -mtriple=aarch64-linux-gnu < %s | FileCheck -check-prefix=ELF %s
+
+; A weak external may be resolved by the linker to a definition from another
+; object file whose alignment cannot be relied upon (e.g. a COFF weak external
+; default fallback). The GOT-style reference must therefore not use a scaled
+; LDR with the page offset folded into the instruction, because that requires
+; the resolved symbol to be sufficiently aligned. Use an unscaled LDR through
+; an ADD-computed address instead, which has no alignment requirement.
+
+declare extern_weak dso_local ptr @foo()
+
+define dso_local ptr @call_weak() {
+entry:
+  %r = call ptr @foo()
+  ret ptr %r
+}
+
+; CHECK-LABEL: call_weak:
+; CHECK-NOT: ldr {{x[0-9]+}}, [{{x[0-9]+}}, :lo12:foo
+; CHECK: adrp [[REG:x[0-9]+]], foo
+; CHECK-NEXT: add [[REG]], [[REG]], :lo12:foo
+; CHECK-NEXT: ldr [[REG]], [[[REG]]]
+; CHECK-NEXT: blr [[REG]]
+
+; On ELF an undefined weak callee can be resolved by the linker directly, so
+; a plain call is emitted.
+; ELF-LABEL: call_weak:
+; ELF: bl foo


### PR DESCRIPTION
A weak external that is explicitly marked dso_local in IR bypasses shouldAssumeDSOLocal()'s extern_weak exclusion (GV->isDSOLocal() is checked first), so ClassifyGlobalReference() returns bare MO_GOT without MO_COFFSTUB or MO_DLLIMPORT. The LOADgot pseudo then expands into ADRP + scaled LDRXui, emitting an IMAGE_REL_ARM64_PAGEOFFSET_12L relocation directly against the weak external symbol.

PAGEOFFSET_12L applies to scaled loads and requires the resolved symbol to be aligned to the access size. A COFF weak external can be resolved by the linker to a definition from any object file, including a weak-external .default fallback synthesized by the assembler into an arbitrary, possibly under-aligned section, so the alignment assumption does not hold. lld correctly rejects such links with "misaligned ldr/str offset", making otherwise valid code unlinkable. ThinLTO hits this in practice because LTO's symbol resolution marks prevailing weak symbols as dso_local.

References that go through a pointer slot (.refptr. via MO_COFFSTUB or __imp_ via MO_DLLIMPORT) keep the scaled form: those cells are locally emitted or import-table entries with guaranteed 8-byte alignment.

Fix by expanding LOADgot for such references into ADRP + ADD (:lo12:) + unscaled LDR, whose relocations carry no alignment requirement. ELF is unaffected: undefined weak callees lower to direct BL there, and GOT slots guarantee alignment where they are used.