### PR TITLE
[mlir][OpenACC][OpenMP] Use explicit attribute APIs

### DIFF
--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-acc.mlir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-acc.mlir
@@ -79,7 +79,7 @@ func.func @testComputeRegionCopyinDistinctHostsInsideConvert() {
     %va = fir.convert %arg0 {test.ptr = "cr_dist_a"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %arg1 {test.ptr = "cr_dist_b"} : (!fir.ref<f32>) -> !fir.ref<f32>
     acc.yield
-  } {origin = "acc.kernels"}
+  } <{origin = "acc.kernels"}>
   return
 }
 
@@ -99,7 +99,7 @@ func.func @testComputeRegionCreateDistinctHostsInsideConvert() {
     %va = fir.convert %arg0 {test.ptr = "cr_crt_a"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %arg1 {test.ptr = "cr_crt_b"} : (!fir.ref<f32>) -> !fir.ref<f32>
     acc.yield
-  } {origin = "acc.kernels"}
+  } <{origin = "acc.kernels"}>
   return
 }
 
@@ -120,7 +120,7 @@ func.func @testComputeRegionCopyinTargetDummiesMayAliasInsideConvert(%arg0: !fir
     %va = fir.convert %cr0 {test.ptr = "cr_tgt_a"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %cr1 {test.ptr = "cr_tgt_b"} : (!fir.ref<f32>) -> !fir.ref<f32>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -139,7 +139,7 @@ func.func @testComputeRegionCopyinSameHostMustAliasInsideConvert() {
     %va = fir.convert %arg0 {test.ptr = "cr_must_a"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %arg1 {test.ptr = "cr_must_b"} : (!fir.ref<f32>) -> !fir.ref<f32>
     acc.yield
-  } {origin = "acc.kernels"}
+  } <{origin = "acc.kernels"}>
   return
 }
 
@@ -241,7 +241,7 @@ func.func @testComputeRegionPrivateInsideConvert() {
     %va = fir.convert %arg0 {test.ptr = "cr_priv_a"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %arg1 {test.ptr = "cr_priv_b"} : (!fir.ref<f32>) -> !fir.ref<f32>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -261,7 +261,7 @@ func.func @testComputeRegionCopyinVsPrivateSameHostNoAlias() {
     %va = fir.convert %arg0 {test.ptr = "cr_mix_cp"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %arg1 {test.ptr = "cr_mix_pr"} : (!fir.ref<f32>) -> !fir.ref<f32>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -279,7 +279,7 @@ func.func @testComputeRegionCreateVsPrivateSameHostNoAlias() {
     %va = fir.convert %arg0 {test.ptr = "cr_mix_cr"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %arg1 {test.ptr = "cr_mix_pr2"} : (!fir.ref<f32>) -> !fir.ref<f32>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -298,7 +298,7 @@ func.func @testComputeRegionCopyinVsFirstprivateSameHostNoAlias() {
     %va = fir.convert %arg0 {test.ptr = "cr_fp_cp"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %arg1 {test.ptr = "cr_fp_pr"} : (!fir.ref<f32>) -> !fir.ref<f32>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -317,7 +317,7 @@ func.func @testComputeRegionCopyinVsFirstprivateMapSameHostNoAlias() {
     %va = fir.convert %arg0 {test.ptr = "cr_fpm_cp"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %arg1 {test.ptr = "cr_fpm_fm"} : (!fir.ref<f32>) -> !fir.ref<f32>
     acc.yield
-  } {origin = "acc.kernels"}
+  } <{origin = "acc.kernels"}>
   return
 }
 
@@ -411,7 +411,7 @@ func.func @testComputeRegionPrivateOpInsideVsInsCreateNoAlias() {
     %vb = fir.convert %pv {test.ptr = "cr_body_pr"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vc = fir.convert %arg0 {test.ptr = "cr_body_cr"} : (!fir.ref<f32>) -> !fir.ref<f32>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -477,7 +477,7 @@ func.func @testComputeRegionReductionDistinctHostsInsideConvert() {
     %va = fir.convert %arg0 {test.ptr = "cr_red_a"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %arg1 {test.ptr = "cr_red_b"} : (!fir.ref<f32>) -> !fir.ref<f32>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -511,7 +511,7 @@ func.func @testComputeRegionReductionVsPrivateSameHostNoAlias() {
     %va = fir.convert %arg0 {test.ptr = "cr_mix_rd"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %arg1 {test.ptr = "cr_mix_pr3"} : (!fir.ref<f32>) -> !fir.ref<f32>
     acc.yield
-  } {origin = "acc.kernels"}
+  } <{origin = "acc.kernels"}>
   return
 }
 
@@ -560,7 +560,7 @@ func.func @test_acc_routine__0(%arg0: !fir.ref<f32> {fir.bindc_name = "a"}, %arg
     %4 = fir.load %3 : !fir.ref<f32>
     fir.store %4 to %2 : !fir.ref<f32>
     acc.yield
-  } {origin = "acc.routine"}
+  } <{origin = "acc.routine"}>
   return
 }
 
@@ -585,7 +585,7 @@ func.func @test_acc_compute_region_box_load(%arg0: !fir.ref<!fir.box<!fir.heap<!
       %lx = fir.load %arg2 {test.ptr = "load_x"} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
       %ly = fir.load %arg3 {test.ptr = "load_y"} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
       acc.yield
-    } {origin = "acc.kernels"}
+    } <{origin = "acc.kernels"}>
   }
   return
 }

--- a/flang/test/Transforms/licm-acc-compute-region.fir
+++ b/flang/test/Transforms/licm-acc-compute-region.fir
@@ -21,7 +21,7 @@
 // CHECK:                 memref.store %{{.*}}, %[[REINTERPRET_CAST_0]]{{\[}}%[[VAL_2]]] : memref<?xf32, strided<[?]>>
 // CHECK:               }
 // CHECK:               acc.yield
-// CHECK:             } {origin = "acc.kernels"}
+// CHECK:             } <{origin = "acc.kernels"}>
 // CHECK:           }
 // CHECK:           acc.copyout accVar(%[[COPYIN_0]] : !fir.box<!fir.array<?xf32>>) to var(%[[REBOX_0]] : !fir.box<!fir.array<?xf32>>) dataClause(acc_copy) implicit(true) name("x")
 // CHECK:           return
@@ -46,7 +46,7 @@ func.func @test_(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x"}, %arg
         memref.store %cst, %reinterpret_cast[%arg4] : memref<?xf32, strided<[?]>>
       }
       acc.yield
-    } {origin = "acc.kernels"}
+    } <{origin = "acc.kernels"}>
   }
   acc.copyout accVar(%7 : !fir.box<!fir.array<?xf32>>) to var(%5 : !fir.box<!fir.array<?xf32>>) dataClause(acc_copy) implicit(true) name("x")
   return

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACC.h
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACC.h
@@ -193,13 +193,14 @@ static constexpr StringLiteral getSpecializedRoutineAttrName() {
 /// Used to check whether the current operation is marked with
 /// `acc routine`. The operation passed in should be a function.
 inline bool isAccRoutine(mlir::Operation *op) {
-  return op && op->hasAttr(mlir::acc::getRoutineInfoAttrName());
+  return op && op->hasDiscardableAttr(mlir::acc::getRoutineInfoAttrName());
 }
 
 /// Used to check whether this is a specialized accelerator version of
 /// `acc routine` function.
 inline bool isSpecializedAccRoutine(mlir::Operation *op) {
-  return op && op->hasAttr(mlir::acc::getSpecializedRoutineAttrName());
+  return op &&
+         op->hasDiscardableAttr(mlir::acc::getSpecializedRoutineAttrName());
 }
 
 static constexpr StringLiteral getFromDefaultClauseAttrName() {

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
@@ -609,7 +609,7 @@ def OpenACC_ComputeRegionOp
         scf.reduce
       } {acc.par_dims = #acc<par_dims[thread_x]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
     ```
   }];
 
@@ -738,7 +738,7 @@ def OpenACC_PredicateRegionOp
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
     ```
   }];
   let regions = (region AnyRegion:$region);

--- a/mlir/include/mlir/Dialect/OpenACCMPCommon/Interfaces/AtomicInterfaces.td
+++ b/mlir/include/mlir/Dialect/OpenACCMPCommon/Interfaces/AtomicInterfaces.td
@@ -445,7 +445,8 @@ def AtomicCompareOpInterface : OpInterface<"AtomicCompareOpInterface"> {
           llvm::StringRef opName = op.getName().getStringRef();
           if (opName == "arith.cmpi" || opName == "llvm.icmp") {
             foundComparison = true;
-            auto predAttr = op.getAttrOfType<mlir::IntegerAttr>("predicate");
+            auto predAttr = llvm::dyn_cast_or_null<mlir::IntegerAttr>(
+                op.getInherentAttr("predicate").value_or(mlir::Attribute{}));
             if (predAttr) {
 	      auto predName = mlir::arith::stringifyCmpIPredicate(
                   static_cast<mlir::arith::CmpIPredicate>(predAttr.getInt()));
@@ -460,7 +461,8 @@ def AtomicCompareOpInterface : OpInterface<"AtomicCompareOpInterface"> {
             break;
           } else if (opName == "arith.cmpf" || opName == "llvm.fcmp") {
             foundComparison = true;
-            auto predAttr = op.getAttrOfType<mlir::IntegerAttr>("predicate");
+            auto predAttr = llvm::dyn_cast_or_null<mlir::IntegerAttr>(
+                op.getInherentAttr("predicate").value_or(mlir::Attribute{}));
             if (predAttr) {
               auto predName = mlir::arith::stringifyCmpFPredicate(
                   static_cast<mlir::arith::CmpFPredicate>(predAttr.getInt()));
@@ -475,7 +477,8 @@ def AtomicCompareOpInterface : OpInterface<"AtomicCompareOpInterface"> {
             break;
           } else if (opName == "fir.cmpc") {
             foundComparison = true;
-            auto predAttr = op.getAttrOfType<mlir::IntegerAttr>("predicate");
+            auto predAttr = llvm::dyn_cast_or_null<mlir::IntegerAttr>(
+                op.getInherentAttr("predicate").value_or(mlir::Attribute{}));
             if (predAttr) {
               auto predName = mlir::arith::stringifyCmpFPredicate(
                   static_cast<mlir::arith::CmpFPredicate>(predAttr.getInt()));

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOpsInterfaces.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOpsInterfaces.td
@@ -42,6 +42,25 @@ class BlockArgOpenMPClause<string clauseNameSnake, string clauseNameCamel,
     }]
   >;
 
+  // Default-implemented method, overridden by the corresponding clause. It
+  // returns the symbols associated with the clause.
+  //
+  // For the override to work, the clause tablegen definition must contain an
+  // `OptionalAttr<SymbolRefArrayAttr> $clause_name_syms` argument.
+  //
+  // Usage example:
+  //
+  // ```c++
+  // std::optional<ArrayAttr> reductionSyms = op.getReductionSyms();
+  // ```
+  InterfaceMethod symsMethod = InterfaceMethod<
+    "Get symbols associated to `" # clauseNameSnake # "`, if present.",
+    "::std::optional<::mlir::ArrayAttr>",
+    "get" # clauseNameCamel # "Syms", (ins), [{}], [{
+      return nullptr;
+    }]
+  >;
+
   // It returns the number of entry block arguments introduced by the given
   // clause.
   //
@@ -132,6 +151,7 @@ def BlockArgOpenMPOpInterface : OpInterface<"BlockArgOpenMPOpInterface"> {
 
   let methods = !listconcat(
     !foreach(clause, clauses, clause.varsMethod),
+    !foreach(clause, clauses, clause.symsMethod),
     !foreach(clause, clauses, clause.numArgsMethod),
     !foreach(clause, clauses, clause.startMethod),
     !foreach(clause, clauses, clause.blockArgsMethod),
@@ -297,7 +317,7 @@ def ComposableOpInterface : OpInterface<"ComposableOpInterface"> {
       /*retTy=*/"bool",
       /*methodName=*/"isComposite",
       (ins ), [{}], [{
-        return $_op->hasAttr("omp.composite");
+        return $_op->hasDiscardableAttr("omp.composite");
       }]
     >,
     InterfaceMethod<
@@ -322,7 +342,7 @@ def ComposableOpInterface : OpInterface<"ComposableOpInterface"> {
       /*retTy=*/"bool",
       /*methodName=*/"isCombined",
       (ins ), [{}], [{
-        return $_op->hasAttr("omp.combined");
+        return $_op->hasDiscardableAttr("omp.combined");
       }]
     >,
     InterfaceMethod<
@@ -377,7 +397,7 @@ def DeclareTargetInterface : OpInterface<"DeclareTargetInterface"> {
       (ins "mlir::omp::DeclareTargetDeviceType":$deviceType,
            "mlir::omp::DeclareTargetCaptureClause":$captureClause,
            "bool":$automap, "bool":$implicit), [{}], [{
-        $_op->setAttr("omp.declare_target",
+        $_op->setDiscardableAttr("omp.declare_target",
                   mlir::omp::DeclareTargetAttr::get(
                       $_op->getContext(),
                       mlir::omp::DeclareTargetDeviceTypeAttr::get(
@@ -395,7 +415,7 @@ def DeclareTargetInterface : OpInterface<"DeclareTargetInterface"> {
       /*retTy=*/"bool",
       /*methodName=*/"isDeclareTarget",
       (ins), [{}], [{
-        return $_op->hasAttr("omp.declare_target");
+        return $_op->hasDiscardableAttr("omp.declare_target");
       }]>,
       InterfaceMethod<
       /*description=*/[{
@@ -405,7 +425,7 @@ def DeclareTargetInterface : OpInterface<"DeclareTargetInterface"> {
       /*retTy=*/"mlir::omp::DeclareTargetDeviceType",
       /*methodName=*/"getDeclareTargetDeviceType",
       (ins), [{}], [{
-        if (mlir::Attribute dTar = $_op->getAttr("omp.declare_target"))
+        if (mlir::Attribute dTar = $_op->getDiscardableAttr("omp.declare_target"))
           if (auto dAttr = llvm::dyn_cast_or_null<mlir::omp::DeclareTargetAttr>(dTar))
             return dAttr.getDeviceType().getValue();
         return {};
@@ -418,7 +438,7 @@ def DeclareTargetInterface : OpInterface<"DeclareTargetInterface"> {
       /*retTy=*/"mlir::omp::DeclareTargetCaptureClause",
       /*methodName=*/"getDeclareTargetCaptureClause",
       (ins), [{}], [{
-        if (mlir::Attribute dTar = $_op->getAttr("omp.declare_target"))
+        if (mlir::Attribute dTar = $_op->getDiscardableAttr("omp.declare_target"))
           if (auto dAttr = llvm::dyn_cast_or_null<mlir::omp::DeclareTargetAttr>(dTar))
             return dAttr.getCaptureClause().getValue();
         return {};
@@ -430,7 +450,7 @@ def DeclareTargetInterface : OpInterface<"DeclareTargetInterface"> {
       /*retTy=*/"bool",
       /*methodName=*/"getDeclareTargetAutomap",
       (ins), [{}], [{
-        if (mlir::Attribute dTar = $_op->getAttr("omp.declare_target"))
+        if (mlir::Attribute dTar = $_op->getDiscardableAttr("omp.declare_target"))
           if (auto dAttr = llvm::dyn_cast_or_null<mlir::omp::DeclareTargetAttr>(dTar))
             return dAttr.getAutomap();
          return false;
@@ -442,7 +462,8 @@ def DeclareTargetInterface : OpInterface<"DeclareTargetInterface"> {
       /*retTy=*/"bool",
       /*methodName=*/"isImplicitDeclareTarget",
       (ins), [{}], [{
-        if (mlir::Attribute dTar = $_op->getAttr("omp.declare_target"))
+        if (mlir::Attribute dTar =
+                $_op->getDiscardableAttr("omp.declare_target"))
           if (auto dAttr = llvm::dyn_cast_or_null<mlir::omp::DeclareTargetAttr>(dTar))
             return dAttr.getImplicit();
          return false;
@@ -467,7 +488,7 @@ def OffloadModuleInterface : OpInterface<"OffloadModuleInterface"> {
       /*retTy=*/"void",
       /*methodName=*/"setIsTargetDevice",
       (ins "bool":$isTargetDevice), [{}], [{
-        $_op->setAttr(
+        $_op->setDiscardableAttr(
           mlir::StringAttr::get($_op->getContext(), llvm::Twine{"omp.is_target_device"}),
             mlir::BoolAttr::get($_op->getContext(), isTargetDevice));
       }]>,
@@ -479,7 +500,7 @@ def OffloadModuleInterface : OpInterface<"OffloadModuleInterface"> {
       /*retTy=*/"bool",
       /*methodName=*/"getIsTargetDevice",
       (ins), [{}], [{
-        if (Attribute isTargetDevice = $_op->getAttr("omp.is_target_device"))
+        if (Attribute isTargetDevice = $_op->getDiscardableAttr("omp.is_target_device"))
           if (::llvm::isa<mlir::BoolAttr>(isTargetDevice))
            return ::llvm::dyn_cast<BoolAttr>(isTargetDevice).getValue();
         return false;
@@ -492,7 +513,7 @@ def OffloadModuleInterface : OpInterface<"OffloadModuleInterface"> {
       /*retTy=*/"void",
       /*methodName=*/"setIsGPU",
       (ins "bool":$isGPU), [{}], [{
-        $_op->setAttr(
+        $_op->setDiscardableAttr(
           mlir::StringAttr::get($_op->getContext(), "omp.is_gpu"),
             mlir::BoolAttr::get($_op->getContext(), isGPU));
       }]>,
@@ -504,7 +525,7 @@ def OffloadModuleInterface : OpInterface<"OffloadModuleInterface"> {
       /*retTy=*/"bool",
       /*methodName=*/"getIsGPU",
       (ins), [{}], [{
-        if (Attribute isTargetCGAttr = $_op->getAttr("omp.is_gpu"))
+        if (Attribute isTargetCGAttr = $_op->getDiscardableAttr("omp.is_gpu"))
           if (auto isTargetCGVal = ::llvm::dyn_cast<BoolAttr>(isTargetCGAttr))
            return isTargetCGVal.getValue();
         return false;
@@ -517,7 +538,7 @@ def OffloadModuleInterface : OpInterface<"OffloadModuleInterface"> {
       /*retTy=*/"mlir::omp::FlagsAttr",
       /*methodName=*/"getFlags",
       (ins), [{}], [{
-        if (Attribute flags = $_op->getAttr("omp.flags"))
+        if (Attribute flags = $_op->getDiscardableAttr("omp.flags"))
           return ::llvm::dyn_cast_or_null<mlir::omp::FlagsAttr>(flags);
         return nullptr;
       }]>,
@@ -535,7 +556,7 @@ def OffloadModuleInterface : OpInterface<"OffloadModuleInterface"> {
             "bool":$assumeNoNestedParallelism,
             "uint32_t":$openmpDeviceVersion,
             "bool":$noGPULib), [{}], [{
-        $_op->setAttr(("omp." + mlir::omp::FlagsAttr::getMnemonic()).str(),
+        $_op->setDiscardableAttr(("omp." + mlir::omp::FlagsAttr::getMnemonic()).str(),
                   mlir::omp::FlagsAttr::get($_op->getContext(), debugKind,
                       assumeTeamsOversubscription, assumeThreadsOversubscription,
                       assumeNoThreadState, assumeNoNestedParallelism, noGPULib, openmpDeviceVersion));
@@ -549,7 +570,7 @@ def OffloadModuleInterface : OpInterface<"OffloadModuleInterface"> {
       /*retTy=*/"void",
       /*methodName=*/"setHostIRFilePath",
       (ins "std::string":$hostIRFilePath), [{}], [{
-        $_op->setAttr(
+        $_op->setDiscardableAttr(
           mlir::StringAttr::get($_op->getContext(), llvm::Twine{"omp.host_ir_filepath"}),
             mlir::StringAttr::get($_op->getContext(), hostIRFilePath));
        }]>,
@@ -563,7 +584,7 @@ def OffloadModuleInterface : OpInterface<"OffloadModuleInterface"> {
       /*retTy=*/"llvm::StringRef",
       /*methodName=*/"getHostIRFilePath",
       (ins), [{}], [{
-        if (Attribute filepath = $_op->getAttr("omp.host_ir_filepath"))
+        if (Attribute filepath = $_op->getDiscardableAttr("omp.host_ir_filepath"))
           if (::llvm::isa<mlir::StringAttr>(filepath))
             return ::llvm::dyn_cast<mlir::StringAttr>(filepath).getValue();
         return {};
@@ -577,7 +598,7 @@ def OffloadModuleInterface : OpInterface<"OffloadModuleInterface"> {
       /*retTy=*/"::mlir::omp::ClauseRequires",
       /*methodName=*/"getRequires",
       (ins), [{}], [{
-        if (Attribute requiresAttr = $_op->getAttr("omp.requires"))
+        if (Attribute requiresAttr = $_op->getDiscardableAttr("omp.requires"))
           if (auto requiresVal = ::llvm::dyn_cast<mlir::omp::ClauseRequiresAttr>(requiresAttr))
             return requiresVal.getValue();
         return mlir::omp::ClauseRequires::none;
@@ -589,7 +610,7 @@ def OffloadModuleInterface : OpInterface<"OffloadModuleInterface"> {
       /*retTy=*/"void",
       /*methodName=*/"setRequires",
       (ins "::mlir::omp::ClauseRequires":$clauses), [{}], [{
-        $_op->setAttr(mlir::StringAttr::get($_op->getContext(), "omp.requires"),
+        $_op->setDiscardableAttr(mlir::StringAttr::get($_op->getContext(), "omp.requires"),
           mlir::omp::ClauseRequiresAttr::get($_op->getContext(), clauses));
       }]>,
     InterfaceMethod<
@@ -600,7 +621,7 @@ def OffloadModuleInterface : OpInterface<"OffloadModuleInterface"> {
       /*retTy=*/"::llvm::ArrayRef<::mlir::Attribute>",
       /*methodName=*/"getTargetTriples",
       (ins), [{}], [{
-        if (Attribute triplesAttr = $_op->getAttr("omp.target_triples"))
+        if (Attribute triplesAttr = $_op->getDiscardableAttr("omp.target_triples"))
           if (auto triples = ::llvm::dyn_cast<::mlir::ArrayAttr>(triplesAttr))
             return triples.getValue();
         return {};
@@ -616,7 +637,7 @@ def OffloadModuleInterface : OpInterface<"OffloadModuleInterface"> {
             targetTriples, [&](::std::string str) -> ::mlir::Attribute {
               return mlir::StringAttr::get($_op->getContext(), str);
             }));
-        $_op->setAttr(
+        $_op->setDiscardableAttr(
             ::mlir::StringAttr::get($_op->getContext(), "omp.target_triples"),
             ::mlir::ArrayAttr::get($_op->getContext(), names));
       }]>

--- a/mlir/lib/Conversion/OpenMPToLLVM/OpenMPToLLVM.cpp
+++ b/mlir/lib/Conversion/OpenMPToLLVM/OpenMPToLLVM.cpp
@@ -28,6 +28,32 @@ using namespace mlir;
 
 namespace {
 
+static LogicalResult convertTypeAttr(Attribute &attr,
+                                     const TypeConverter &typeConverter) {
+  auto typeAttr = dyn_cast<TypeAttr>(attr);
+  if (!typeAttr)
+    return success();
+  Type convertedType = typeConverter.convertType(typeAttr.getValue());
+  if (!convertedType)
+    return failure();
+  attr = TypeAttr::get(convertedType);
+  return success();
+}
+
+static bool areTypeAttrsLegal(Operation *op,
+                              const TypeConverter &typeConverter) {
+  bool inherentAttrsLegal = true;
+  op->getName().walkInherentAttrs(op, [&](StringRef, Attribute &attr) {
+    if (auto typeAttr = dyn_cast<TypeAttr>(attr))
+      inherentAttrsLegal &= typeConverter.isLegal(typeAttr.getValue());
+  });
+  return inherentAttrsLegal &&
+         llvm::all_of(op->getDiscardableAttrs(), [&](NamedAttribute attr) {
+           auto typeAttr = dyn_cast<TypeAttr>(attr.getValue());
+           return !typeAttr || typeConverter.isLegal(typeAttr.getValue());
+         });
+}
+
 /// A pattern that converts the result and operand types, attributes, and region
 /// arguments of an OpenMP operation to the LLVM dialect.
 ///
@@ -60,20 +86,26 @@ struct OpenMPOpConversion : public ConvertOpToLLVMPattern<T> {
     if (failed(converter->convertTypes(op->getResultTypes(), resTypes)))
       return failure();
 
-    // Translate type attributes.
+    // Translate type attributes in the properties and discardable attributes.
     // They are kept unmodified except if they are type attributes.
-    SmallVector<NamedAttribute> convertedAttrs;
-    for (NamedAttribute attr : op->getAttrs()) {
-      if (auto typeAttr = dyn_cast<TypeAttr>(attr.getValue())) {
-        Type convertedType = converter->convertType(typeAttr.getValue());
-        if (!convertedType)
-          return rewriter.notifyMatchFailure(
-              op, "failed to convert type in attribute");
-        convertedAttrs.emplace_back(attr.getName(),
-                                    TypeAttr::get(convertedType));
-      } else {
-        convertedAttrs.push_back(attr);
-      }
+    typename T::Properties convertedProperties = op.getProperties();
+    LogicalResult attrConversionResult = success();
+    T::walkInherentAttrs(
+        op.getContext(), convertedProperties, [&](StringRef, Attribute &attr) {
+          if (succeeded(attrConversionResult))
+            attrConversionResult = convertTypeAttr(attr, *converter);
+        });
+    if (failed(attrConversionResult))
+      return rewriter.notifyMatchFailure(op,
+                                         "failed to convert type in attribute");
+
+    SmallVector<NamedAttribute> convertedDiscardableAttrs;
+    for (NamedAttribute attr : op->getDiscardableAttrs()) {
+      Attribute convertedAttr = attr.getValue();
+      if (failed(convertTypeAttr(convertedAttr, *converter)))
+        return rewriter.notifyMatchFailure(
+            op, "failed to convert type in attribute");
+      convertedDiscardableAttrs.emplace_back(attr.getName(), convertedAttr);
     }
 
     // Translate operands.
@@ -99,7 +131,7 @@ struct OpenMPOpConversion : public ConvertOpToLLVMPattern<T> {
 
     // Create new operation.
     auto newOp = T::create(rewriter, op.getLoc(), resTypes, convertedOperands,
-                           convertedAttrs);
+                           convertedProperties, convertedDiscardableAttrs);
 
     // Translate regions.
     for (auto [originalRegion, convertedRegion] :
@@ -131,10 +163,7 @@ void mlir::configureOpenMPToLLVMConversionLegality(
                         [&](Region &region) {
                           return typeConverter.isLegal(&region);
                         }) &&
-           llvm::all_of(op->getAttrs(), [&](NamedAttribute attr) {
-             auto typeAttr = dyn_cast<TypeAttr>(attr.getValue());
-             return !typeAttr || typeConverter.isLegal(typeAttr.getValue());
-           });
+           areTypeAttrsLegal(op, typeConverter);
   });
 }
 

--- a/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
@@ -49,7 +49,7 @@ static void attachVarNameAttr(Operation *op, OpBuilder &builder,
                               StringRef varName) {
   if (!varName.empty()) {
     auto varNameAttr = acc::VarNameAttr::get(builder.getContext(), varName);
-    op->setAttr(acc::getVarNameAttrName(), varNameAttr);
+    op->setDiscardableAttr(acc::getVarNameAttrName(), varNameAttr);
   }
 }
 

--- a/mlir/lib/Dialect/OpenACC/IR/OpenACCCG.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACCCG.cpp
@@ -82,10 +82,11 @@ static void updateComputeRegionInputOperandSegments(ComputeRegionOp op,
                                                     PatternRewriter &rewriter,
                                                     size_t numInput) {
   const size_t numLaunch = op.getLaunchArgs().size();
-  op->setAttr(ComputeRegionOp::getOperandSegmentSizeAttr(),
-              rewriter.getDenseI32ArrayAttr({static_cast<int32_t>(numLaunch),
-                                             static_cast<int32_t>(numInput),
-                                             op.getStream() ? 1 : 0}));
+  op->setInherentAttr(
+      rewriter.getStringAttr(ComputeRegionOp::getOperandSegmentSizeAttr()),
+      rewriter.getDenseI32ArrayAttr({static_cast<int32_t>(numLaunch),
+                                     static_cast<int32_t>(numInput),
+                                     op.getStream() ? 1 : 0}));
 }
 
 struct ComputeRegionRemoveDuplicateArgs
@@ -734,8 +735,9 @@ void ComputeRegionOp::print(OpAsmPrinter &p) {
   p.printOptionalArrowTypeList(getResultTypes());
   p << " ";
   p.printRegion(getRegion(), /*printEntryBlockArgs=*/false);
-  p.printOptionalAttrDict((*this)->getAttrs(),
-                          /*elidedAttrs=*/getOperandSegmentSizeAttr());
+  ComputeRegionOp::printProperties(getContext(), p, getProperties(),
+                                   /*elidedProps=*/getOperandSegmentSizeAttr());
+  p.printOptionalAttrDict((*this)->getDiscardableAttrDictionary().getValue());
 }
 
 ParseResult ComputeRegionOp::parse(OpAsmParser &parser,
@@ -790,11 +792,9 @@ ParseResult ComputeRegionOp::parse(OpAsmParser &parser,
   assert(numLaunchOperands + numInputOperands == regionArgs.size() &&
          "compute region args mismatch");
 
-  result.addAttribute(
-      ComputeRegionOp::getOperandSegmentSizeAttr(),
-      builder.getDenseI32ArrayAttr({static_cast<int32_t>(numLaunchOperands),
-                                    static_cast<int32_t>(numInputOperands),
-                                    hasStream ? 1 : 0}));
+  DenseI32ArrayAttr operandSegmentSizes = builder.getDenseI32ArrayAttr(
+      {static_cast<int32_t>(numLaunchOperands),
+       static_cast<int32_t>(numInputOperands), hasStream ? 1 : 0});
 
   for (size_t i = 0; i < numLaunchOperands; ++i) {
     if (parser.resolveOperand(launchOperands[i], types[i], result.operands))
@@ -812,8 +812,39 @@ ParseResult ComputeRegionOp::parse(OpAsmParser &parser,
       return failure();
   }
 
+  Attribute parsedProperties;
+  if (ComputeRegionOp::genericParseProperties(parser, parsedProperties))
+    return failure();
+  auto propertyDictionary = dyn_cast_or_null<DictionaryAttr>(parsedProperties);
+  if (parsedProperties && !propertyDictionary)
+    return parser.emitError(parser.getNameLoc(),
+                            "expected properties dictionary");
+
+  NamedAttrList properties(propertyDictionary ? propertyDictionary
+                                              : builder.getDictionaryAttr({}));
+  properties.set(ComputeRegionOp::getOperandSegmentSizeAttr(),
+                 operandSegmentSizes);
+  propertyDictionary = properties.getDictionary(builder.getContext());
+  auto emitError = [&]() {
+    return mlir::emitError(result.location, "invalid properties ")
+           << propertyDictionary << " for op " << result.name.getStringRef()
+           << ": ";
+  };
+  if (failed(ComputeRegionOp::setPropertiesFromParsedAttr(
+          result.getOrAddProperties<Properties>(), propertyDictionary,
+          emitError)))
+    return failure();
+
+  auto attrsLoc = parser.getCurrentLocation();
   if (parser.parseOptionalAttrDict(result.attributes))
     return failure();
+  for (StringRef attrName : ComputeRegionOp::getAttributeNames()) {
+    if (result.attributes.get(attrName))
+      return parser.emitError(attrsLoc)
+             << "inherent attribute '" << attrName
+             << "' cannot be parsed from attr-dict when strict properties in "
+                "assembly format is enabled";
+  }
 
   return success();
 }

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCBindRoutine.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCBindRoutine.cpp
@@ -55,12 +55,12 @@ namespace {
 static RoutineOp getFirstAccRoutineOp(FunctionOpInterface funcOp,
                                       const SymbolTable &symTab) {
   if (isSpecializedAccRoutine(funcOp)) {
-    auto attr = funcOp->getAttrOfType<SpecializedRoutineAttr>(
+    auto attr = funcOp->getDiscardableAttrOfType<SpecializedRoutineAttr>(
         getSpecializedRoutineAttrName());
     return symTab.lookup<RoutineOp>(attr.getRoutine().getLeafReference());
   }
-  auto routineInfo =
-      funcOp->getAttrOfType<RoutineInfoAttr>(getRoutineInfoAttrName());
+  auto routineInfo = funcOp->getDiscardableAttrOfType<RoutineInfoAttr>(
+      getRoutineInfoAttrName());
   assert(routineInfo && "expected acc.routine_info for acc routine function");
   auto accRoutines = routineInfo.getAccRoutines();
   assert(!accRoutines.empty() && "expected at least one acc routine");
@@ -111,7 +111,7 @@ public:
       if (!(isAccRoutine(callee) || isSpecializedAccRoutine(callee)))
         return;
 
-      if (auto routineInfo = callee->getAttrOfType<RoutineInfoAttr>(
+      if (auto routineInfo = callee->getDiscardableAttrOfType<RoutineInfoAttr>(
               getRoutineInfoAttrName())) {
         if (routineInfo.getAccRoutines().size() > 1) {
           (void)accSupport.emitNYI(callOp.getLoc(), "multiple `acc routine`s");

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -62,7 +62,7 @@
 //       scf.reduce
 //     } {acc.par_dims = #acc<par_dims[thread_x]>}
 //     acc.yield
-//   } {origin = "acc.parallel"}
+//   } <{origin = "acc.parallel"}>
 //
 // After:
 //   gpu.launch blocks(%bidx, %bidy, %bidz) in (%gdimx = %c1, ...)
@@ -193,12 +193,14 @@ getAccRoutineParDim(RoutineOp routineOp, MLIRContext *ctx,
 static RoutineOp getRoutineOpForAccRoutineFunction(FunctionOpInterface funcOp,
                                                    const SymbolTable &symTab) {
   if (isSpecializedAccRoutine(funcOp)) {
-    SpecializedRoutineAttr attr = funcOp->getAttrOfType<SpecializedRoutineAttr>(
-        getSpecializedRoutineAttrName());
+    SpecializedRoutineAttr attr =
+        funcOp->getDiscardableAttrOfType<SpecializedRoutineAttr>(
+            getSpecializedRoutineAttrName());
     return symTab.lookup<RoutineOp>(attr.getRoutine().getLeafReference());
   }
   RoutineInfoAttr routineInfo =
-      funcOp->getAttrOfType<RoutineInfoAttr>(getRoutineInfoAttrName());
+      funcOp->getDiscardableAttrOfType<RoutineInfoAttr>(
+          getRoutineInfoAttrName());
   if (!routineInfo || routineInfo.getAccRoutines().empty())
     return nullptr;
   return symTab.lookup<RoutineOp>(
@@ -210,7 +212,7 @@ static GPUParallelDimAttr
 getSpecializedRoutineDim(FunctionOpInterface funcOp,
                          const ACCToGPUMappingPolicy &policy) {
   SpecializedRoutineAttr specAttr =
-      funcOp->getAttrOfType<SpecializedRoutineAttr>(
+      funcOp->getDiscardableAttrOfType<SpecializedRoutineAttr>(
           getSpecializedRoutineAttrName());
   assert(specAttr && "expected specialized routine attribute");
   return policy.map(funcOp->getContext(), specAttr.getLevel().getValue());

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCComputeLowering.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCComputeLowering.cpp
@@ -94,7 +94,7 @@ static bool isOpInSerialRegion(Operation *op) {
     return computeRegion.isEffectivelySerial();
   if (auto funcOp = op->getParentOfType<FunctionOpInterface>()) {
     if (isSpecializedAccRoutine(funcOp)) {
-      auto attr = funcOp->getAttrOfType<SpecializedRoutineAttr>(
+      auto attr = funcOp->getDiscardableAttrOfType<SpecializedRoutineAttr>(
           getSpecializedRoutineAttrName());
       if (attr && attr.getLevel().getValue() == ParLevel::seq)
         return true;

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCDeclareGPUModuleInsertion.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCDeclareGPUModuleInsertion.cpp
@@ -72,14 +72,16 @@ namespace {
 
 static bool hasAccDeclareGlobals(ModuleOp mod) {
   for (Operation &op : mod.getBody()->getOperations())
-    if (op.getAttr(acc::getDeclareAttrName()))
+    if (op.getDiscardableAttr(acc::getDeclareAttrName()))
       return true;
   return false;
 }
 
 static void makeDeviceGlobalDeclaration(Operation &globalOp) {
-  globalOp.removeAttr("initVal");
-  globalOp.removeAttr("linkName");
+  globalOp.setInherentAttr(StringAttr::get(globalOp.getContext(), "initVal"),
+                           {});
+  globalOp.setInherentAttr(StringAttr::get(globalOp.getContext(), "linkName"),
+                           {});
   for (Region &region : globalOp.getRegions()) {
     region.dropAllReferences();
     region.getBlocks().clear();
@@ -98,7 +100,7 @@ public:
     SymbolTable gpuSymTable(gpuMod);
 
     for (Operation &globalOp : mod.getBody()->getOperations()) {
-      if (!globalOp.getAttr(acc::getDeclareAttrName()))
+      if (!globalOp.getDiscardableAttr(acc::getDeclareAttrName()))
         continue;
 
       auto symOp = dyn_cast<SymbolOpInterface>(&globalOp);
@@ -107,8 +109,8 @@ public:
 
       StringAttr name = symOp.getNameAttr();
       Operation *deviceGlobal = globalOp.clone();
-      auto declareAttr =
-          globalOp.getAttrOfType<acc::DeclareAttr>(acc::getDeclareAttrName());
+      auto declareAttr = globalOp.getDiscardableAttrOfType<acc::DeclareAttr>(
+          acc::getDeclareAttrName());
       auto globalVar = dyn_cast<acc::GlobalVariableOpInterface>(&globalOp);
       bool makeUnifiedDeclaration =
           cudaUnified &&
@@ -152,10 +154,11 @@ public:
         }
         // Propagate acc.declare onto the GPU copy if it was cloned before the
         // host global was marked.
-        if (!existing->getAttr(acc::getDeclareAttrName()))
+        if (!existing->getDiscardableAttr(acc::getDeclareAttrName()))
           if (Attribute declareAttr =
-                  globalOp.getAttr(acc::getDeclareAttrName()))
-            existing->setAttr(acc::getDeclareAttrName(), declareAttr);
+                  globalOp.getDiscardableAttr(acc::getDeclareAttrName()))
+            existing->setDiscardableAttr(acc::getDeclareAttrName(),
+                                         declareAttr);
         deviceGlobal->destroy();
         continue;
       }

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCEmitRemarksData.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCEmitRemarksData.cpp
@@ -200,7 +200,7 @@ static void emitDataMappingRemarks(ValueRange mappingOperands,
         [&]() {
           std::string message = "Generating ";
           message += directivePrefix.str();
-          if (op->getAttr(acc::getFromDefaultClauseAttrName()))
+          if (op->getDiscardableAttr(acc::getFromDefaultClauseAttrName()))
             message += "default ";
           else if (acc::getImplicitFlag(op))
             message += "implicit ";

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCEmitRemarksLoop.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCEmitRemarksLoop.cpp
@@ -104,7 +104,7 @@ static void emitLoopMappingRemark(acc::ComputeRegionOp computeRegion,
                                   const acc::ACCToGPUMappingPolicy &policy,
                                   llvm::StringRef gpuDimSeparator) {
   acc::GPUParallelDimsAttr parDimsAttr =
-      loopOp->getAttrOfType<acc::GPUParallelDimsAttr>(
+      loopOp->getDiscardableAttrOfType<acc::GPUParallelDimsAttr>(
           acc::GPUParallelDimsAttr::name);
 
   SmallVector<acc::GPUParallelDimAttr, 1> seqParDims;

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCImplicitData.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCImplicitData.cpp
@@ -530,8 +530,8 @@ Operation *ACCImplicitData::generateDataClauseOpForCandidate(
       newDataOp = acc::PresentOp::create(builder, loc, var,
                                          /*structured=*/true, /*implicit=*/true,
                                          accSupport.getVariableName(var));
-      newDataOp->setAttr(acc::getFromDefaultClauseAttrName(),
-                         builder.getUnitAttr());
+      newDataOp->setDiscardableAttr(acc::getFromDefaultClauseAttrName(),
+                                    builder.getUnitAttr());
     } else {
       auto copyinOp =
           acc::CopyinOp::create(builder, loc, var,

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCImplicitDeclare.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCImplicitDeclare.cpp
@@ -331,9 +331,10 @@ static void collectGlobalsFromDeviceRegion(Region &region,
 // Adds the declare attribute to the operation `op`.
 static void addDeclareAttr(MLIRContext *context, Operation *op,
                            acc::DataClause clause) {
-  op->setAttr(acc::getDeclareAttrName(),
-              acc::DeclareAttr::get(context,
-                                    acc::DataClauseAttr::get(context, clause)));
+  op->setDiscardableAttr(
+      acc::getDeclareAttrName(),
+      acc::DeclareAttr::get(context,
+                            acc::DataClauseAttr::get(context, clause)));
 }
 
 // This pass applies implicit declare actions for globals referenced in
@@ -381,7 +382,7 @@ public:
                                              symTab);
           })
           .Case([&](acc::GlobalVariableOpInterface globalVarOp) {
-            if (globalVarOp->getAttr(acc::getDeclareAttrName()))
+            if (globalVarOp->getDiscardableAttr(acc::getDeclareAttrName()))
               if (Region *initRegion = globalVarOp.getInitRegion())
                 collectGlobalsFromDeviceRegion(*initRegion, globalsToAccDeclare,
                                                accSupport, symTab);

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCImplicitRoutine.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCImplicitRoutine.cpp
@@ -119,10 +119,10 @@ private:
         /* gangDimDeviceType=*/nullptr);
 
     // Assert that the callee does not already have routine info attribute
-    assert(!callee->hasAttr(acc::getRoutineInfoAttrName()) &&
+    assert(!callee->hasDiscardableAttr(acc::getRoutineInfoAttrName()) &&
            "function is already associated with a routine");
 
-    callee->setAttr(
+    callee->setDiscardableAttr(
         acc::getRoutineInfoAttrName(),
         mlir::acc::RoutineInfoAttr::get(
             builder.getContext(),

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCRecipeMaterialization.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCRecipeMaterialization.cpp
@@ -88,12 +88,13 @@ static void saveVarName(StringRef name, Value dst) {
   if (name.empty())
     return;
   if (Operation *dstOp = dst.getDefiningOp()) {
-    if (dstOp->getAttrOfType<acc::VarNameAttr>(acc::getVarNameAttrName()))
+    if (dstOp->getDiscardableAttrOfType<acc::VarNameAttr>(
+            acc::getVarNameAttrName()))
       return;
     if (isa<ACC_DATA_ENTRY_OPS>(dstOp))
       return;
-    dstOp->setAttr(acc::getVarNameAttrName(),
-                   acc::VarNameAttr::get(dstOp->getContext(), name));
+    dstOp->setDiscardableAttr(acc::getVarNameAttrName(),
+                              acc::VarNameAttr::get(dstOp->getContext(), name));
     return;
   }
   auto blockArg = dyn_cast<BlockArgument>(dst);
@@ -126,13 +127,14 @@ static void resolveVarNamePlaceholders(Block *block, Block::iterator ip,
                                        StringRef name) {
   StringRef placeholder = acc::getVarNamePlaceholder();
   for (auto it = block->begin(); it != std::next(ip); ++it) {
-    auto attr = it->getAttrOfType<acc::VarNameAttr>(acc::getVarNameAttrName());
+    auto attr = it->getDiscardableAttrOfType<acc::VarNameAttr>(
+        acc::getVarNameAttrName());
     if (attr && attr.getName() == placeholder) {
       if (name.empty())
-        it->removeAttr(acc::getVarNameAttrName());
+        it->removeDiscardableAttr(acc::getVarNameAttrName());
       else
-        it->setAttr(acc::getVarNameAttrName(),
-                    acc::VarNameAttr::get(it->getContext(), name));
+        it->setDiscardableAttr(acc::getVarNameAttrName(),
+                               acc::VarNameAttr::get(it->getContext(), name));
     }
   }
 }

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCRoutineLowering.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCRoutineLowering.cpp
@@ -107,13 +107,15 @@ static func::FuncOp createFunctionForDeviceStaging(func::FuncOp hostFunc,
   FunctionType funcType = hostFunc.getFunctionType();
   func::FuncOp deviceFunc =
       func::FuncOp::create(rewriter, loc, hostFunc.getName(), funcType);
-  deviceFunc->setAttrs(hostFunc->getAttrs());
-  deviceFunc->removeAttr(getRoutineInfoAttrName());
-  deviceFunc->setAttr(getSpecializedRoutineAttrName(),
-                      SpecializedRoutineAttr::get(
-                          ctx, SymbolRefAttr::get(ctx, routineOp.getSymName()),
-                          ParLevelAttr::get(ctx, parLevel),
-                          StringAttr::get(ctx, hostFunc.getName())));
+  deviceFunc->setDiscardableAttrs(
+      hostFunc->getDiscardableAttrDictionary().getValue());
+  deviceFunc->removeDiscardableAttr(getRoutineInfoAttrName());
+  deviceFunc->setDiscardableAttr(
+      getSpecializedRoutineAttrName(),
+      SpecializedRoutineAttr::get(
+          ctx, SymbolRefAttr::get(ctx, routineOp.getSymName()),
+          ParLevelAttr::get(ctx, parLevel),
+          StringAttr::get(ctx, hostFunc.getName())));
 
   Block *sourceBlock = &hostFunc.getBody().front();
   Block *newBlock = rewriter.createBlock(&deviceFunc.getRegion());

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCRoutineToGPUFunc.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCRoutineToGPUFunc.cpp
@@ -244,8 +244,9 @@ static LogicalResult cloneFuncsToGPUModule(
 
     gpu::GPUFuncOp deviceFuncOp = createGPUFuncFromFunc(builder, srcFunc);
 
-    if (auto specRoutineAttr = srcFunc->getAttrOfType<SpecializedRoutineAttr>(
-            getSpecializedRoutineAttrName())) {
+    if (auto specRoutineAttr =
+            srcFunc->getDiscardableAttrOfType<SpecializedRoutineAttr>(
+                getSpecializedRoutineAttrName())) {
       StringAttr funcName = specRoutineAttr.getFuncName();
       if (failed(SymbolTable::replaceAllSymbolUses(
               StringAttr::get(ctx, deviceFuncOp.getName()), funcName, mod))) {
@@ -253,11 +254,14 @@ static LogicalResult cloneFuncsToGPUModule(
                            "cannot replace symbol for acc routine");
         return failure();
       }
-      deviceFuncOp->setAttr(SymbolTable::getSymbolAttrName(), funcName);
+      deviceFuncOp->setDiscardableAttr(SymbolTable::getSymbolAttrName(),
+                                       funcName);
     }
-    if (auto specAttr = srcFunc->getAttrOfType<SpecializedRoutineAttr>(
-            getSpecializedRoutineAttrName()))
-      deviceFuncOp->setAttr(getSpecializedRoutineAttrName(), specAttr);
+    if (auto specAttr =
+            srcFunc->getDiscardableAttrOfType<SpecializedRoutineAttr>(
+                getSpecializedRoutineAttrName()))
+      deviceFuncOp->setDiscardableAttr(getSpecializedRoutineAttrName(),
+                                       specAttr);
 
     gpuSymTab.insert(deviceFuncOp);
   }

--- a/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtils.cpp
+++ b/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtils.cpp
@@ -120,8 +120,8 @@ std::string mlir::acc::getVariableName(mlir::Value v) {
       return std::to_string(*constVal);
 
     // Check for `acc.var_name` attribute
-    if (auto varNameAttr =
-            definingOp->getAttrOfType<VarNameAttr>(getVarNameAttrName()))
+    if (auto varNameAttr = definingOp->getDiscardableAttrOfType<VarNameAttr>(
+            getVarNameAttrName()))
       return varNameAttr.getName().str();
 
     // If it is a data entry operation, get name via getVarName
@@ -222,8 +222,8 @@ bool mlir::acc::isValidSymbolUse(mlir::Operation *user,
           mlir::dyn_cast_if_present<mlir::FunctionOpInterface>(definingOp)) {
     // If this symbol is actually an acc routine or a specialized acc routine -
     // then it is expected for it to be offloaded - therefore it is valid.
-    if (func->hasAttr(mlir::acc::getRoutineInfoAttrName()) ||
-        func->hasAttr(mlir::acc::getSpecializedRoutineAttrName()))
+    if (func->hasDiscardableAttr(mlir::acc::getRoutineInfoAttrName()) ||
+        func->hasDiscardableAttr(mlir::acc::getSpecializedRoutineAttrName()))
       return true;
 
     // If this symbol is a call to an LLVM intrinsic, then it is likely valid.
@@ -240,7 +240,8 @@ bool mlir::acc::isValidSymbolUse(mlir::Operation *user,
   }
 
   // A declare attribute is needed for symbol references.
-  bool hasDeclare = definingOp->hasAttr(mlir::acc::getDeclareAttrName());
+  bool hasDeclare =
+      definingOp->hasDiscardableAttr(mlir::acc::getDeclareAttrName());
   return hasDeclare;
 }
 
@@ -261,8 +262,9 @@ bool mlir::acc::isDeviceValue(mlir::Value val) {
 
   // `acc.declare` with deviceptr marks data that is already associated with
   // the device.
-  if (auto declareAttr = defOp->getAttrOfType<mlir::acc::DeclareAttr>(
-          mlir::acc::getDeclareAttrName()))
+  if (auto declareAttr =
+          defOp->getDiscardableAttrOfType<mlir::acc::DeclareAttr>(
+              mlir::acc::getDeclareAttrName()))
     if (declareAttr.getDataClause().getValue() ==
         mlir::acc::DataClause::acc_deviceptr)
       return true;

--- a/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsCG.cpp
+++ b/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsCG.cpp
@@ -172,7 +172,8 @@ GPUParallelDimsAttr getParDimsAttr(Operation *op) {
       .Case<ACC_OP_WITH_PAR_DIMS_LIST>(
           [](auto parOp) { return parOp.getParDimsAttr(); })
       .Default([](Operation *op) -> GPUParallelDimsAttr {
-        if (Attribute attr = op->getAttr(GPUParallelDimsAttr::name)) {
+        if (Attribute attr =
+                op->getDiscardableAttr(GPUParallelDimsAttr::name)) {
           GPUParallelDimsAttr parDimsAttr = dyn_cast<GPUParallelDimsAttr>(attr);
           assert(parDimsAttr && "acc.par_dims must be a GPUParallelDimsAttr");
           return parDimsAttr;
@@ -194,8 +195,9 @@ void setParDimsAttr(Operation *op, GPUParallelDimsAttr attr) {
   llvm::TypeSwitch<Operation *>(op)
       .Case<ACC_OP_WITH_PAR_DIMS_LIST>(
           [&](auto parOp) { parOp.setParDimsAttr(attr); })
-      .Default(
-          [&](Operation *op) { op->setAttr(GPUParallelDimsAttr::name, attr); });
+      .Default([&](Operation *op) {
+        op->setDiscardableAttr(GPUParallelDimsAttr::name, attr);
+      });
 }
 
 void updateParDimsAttr(Operation *op, GPUParallelDimsAttr attr) {
@@ -204,19 +206,21 @@ void updateParDimsAttr(Operation *op, GPUParallelDimsAttr attr) {
   llvm::TypeSwitch<Operation *>(op)
       .Case<ACC_OP_WITH_PAR_DIMS_LIST>(
           [&](auto parOp) { parOp.setParDimsAttr(attr); })
-      .Default(
-          [&](Operation *op) { op->setAttr(GPUParallelDimsAttr::name, attr); });
+      .Default([&](Operation *op) {
+        op->setDiscardableAttr(GPUParallelDimsAttr::name, attr);
+      });
 }
 
 #undef ACC_OP_WITH_PAR_DIMS_LIST
 
 bool hasGPUBlockRedundantAttr(Operation *op) {
-  return op->hasAttrOfType<GPUBlockRedundantAttr>(GPUBlockRedundantAttr::name);
+  return op->hasDiscardableAttrOfType<GPUBlockRedundantAttr>(
+      GPUBlockRedundantAttr::name);
 }
 
 void setGPUBlockRedundantAttr(Operation *op) {
-  op->setAttr(GPUBlockRedundantAttr::name,
-              GPUBlockRedundantAttr::get(op->getContext()));
+  op->setDiscardableAttr(GPUBlockRedundantAttr::name,
+                         GPUBlockRedundantAttr::get(op->getContext()));
 }
 
 void copyParDimsAttr(Operation *from, Operation *to) {
@@ -226,7 +230,8 @@ void copyParDimsAttr(Operation *from, Operation *to) {
 }
 
 ActiveParDimsAttr getActiveParDimsAttr(Operation *op) {
-  return op->getAttrOfType<ActiveParDimsAttr>(ActiveParDimsAttr::name);
+  return op->getDiscardableAttrOfType<ActiveParDimsAttr>(
+      ActiveParDimsAttr::name);
 }
 
 bool hasActiveParDimsAttr(Operation *op) {
@@ -234,7 +239,7 @@ bool hasActiveParDimsAttr(Operation *op) {
 }
 
 void setActiveParDimsAttr(Operation *op, ActiveParDimsAttr attr) {
-  op->setAttr(ActiveParDimsAttr::name, attr);
+  op->setDiscardableAttr(ActiveParDimsAttr::name, attr);
 }
 
 void setActiveParDimsAttr(Operation *op, ArrayRef<GPUParallelDimAttr> dims) {

--- a/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsGPU.cpp
@@ -33,8 +33,8 @@ std::optional<gpu::GPUModuleOp> getOrCreateGPUModule(ModuleOp mod, bool create,
 
   // Create a new GPU module
   auto *ctx = mod.getContext();
-  mod->setAttr(gpu::GPUDialect::getContainerModuleAttrName(),
-               UnitAttr::get(ctx));
+  mod->setDiscardableAttr(gpu::GPUDialect::getContainerModuleAttrName(),
+                          UnitAttr::get(ctx));
 
   OpBuilder builder(ctx);
   auto gpuMod = gpu::GPUModuleOp::create(builder, mod.getLoc(), moduleName);

--- a/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsLoop.cpp
+++ b/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsLoop.cpp
@@ -351,12 +351,14 @@ convertUnstructuredACCLoopToSCFExecuteRegion(LoopOp loopOp,
 }
 
 void setCollapseCountAttr(Operation *op, uint64_t count) {
-  op->setAttr(getCollapseCountAttrName(),
-              IntegerAttr::get(IntegerType::get(op->getContext(), 64), count));
+  op->setDiscardableAttr(
+      getCollapseCountAttrName(),
+      IntegerAttr::get(IntegerType::get(op->getContext(), 64), count));
 }
 
 uint64_t getCollapseCount(Operation *op) {
-  if (auto attr = op->getAttrOfType<IntegerAttr>(getCollapseCountAttrName()))
+  if (auto attr =
+          op->getDiscardableAttrOfType<IntegerAttr>(getCollapseCountAttrName()))
     return attr.getValue().getZExtValue();
   return 1;
 }

--- a/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
+++ b/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
@@ -4406,7 +4406,7 @@ void CanonicalLoopOp::print(OpAsmPrinter &p) {
   p.printRegion(getRegion(), /*printEntryBlockArgs=*/false,
                 /*printBlockTerminators=*/true);
 
-  p.printOptionalAttrDict((*this)->getAttrs());
+  p.printOptionalAttrDict((*this)->getDiscardableAttrDictionary().getValue());
 }
 
 mlir::ParseResult CanonicalLoopOp::parse(::mlir::OpAsmParser &parser,
@@ -4494,7 +4494,7 @@ void UnrollHeuristicOp::build(::mlir::OpBuilder &odsBuilder,
 void UnrollHeuristicOp::print(OpAsmPrinter &p) {
   p << '(' << getApplyee() << ')';
 
-  p.printOptionalAttrDict((*this)->getAttrs());
+  p.printOptionalAttrDict((*this)->getDiscardableAttrDictionary().getValue());
 }
 
 mlir::ParseResult UnrollHeuristicOp::parse(::mlir::OpAsmParser &parser,
@@ -4547,7 +4547,7 @@ void UnrollFullOp::build(::mlir::OpBuilder &odsBuilder,
 void UnrollFullOp::print(OpAsmPrinter &p) {
   p << '(' << getApplyee() << ')';
 
-  p.printOptionalAttrDict((*this)->getAttrs());
+  p.printOptionalAttrDict((*this)->getDiscardableAttrDictionary().getValue());
 }
 
 mlir::ParseResult UnrollFullOp::parse(::mlir::OpAsmParser &parser,
@@ -4618,7 +4618,10 @@ void UnrollPartialOp::build(::mlir::OpBuilder &odsBuilder,
 void UnrollPartialOp::print(OpAsmPrinter &p) {
   p << '(' << getApplyee() << ')';
 
-  p.printOptionalAttrDict((*this)->getAttrs());
+  SmallVector<NamedAttribute> attrs((*this)->getDiscardableAttrs());
+  attrs.emplace_back(getUnrollFactorAttrName(), getUnrollFactorAttr());
+  llvm::sort(attrs);
+  p.printOptionalAttrDict(attrs);
 }
 
 mlir::ParseResult UnrollPartialOp::parse(::mlir::OpAsmParser &parser,
@@ -5011,7 +5014,7 @@ LogicalResult AtomicReadOp::verify() {
 
   int64_t version = 50;
   if (auto moduleOp = getOperation()->getParentOfType<ModuleOp>())
-    if (Attribute verAttr = moduleOp->getAttr("omp.version"))
+    if (Attribute verAttr = moduleOp->getDiscardableAttr("omp.version"))
       version = llvm::cast<VersionAttr>(verAttr).getVersion();
 
   if (auto mo = getMemoryOrder()) {
@@ -5037,7 +5040,7 @@ LogicalResult AtomicWriteOp::verify() {
 
   int64_t version = 50;
   if (auto moduleOp = getOperation()->getParentOfType<ModuleOp>())
-    if (Attribute verAttr = moduleOp->getAttr("omp.version"))
+    if (Attribute verAttr = moduleOp->getDiscardableAttr("omp.version"))
       version = llvm::cast<VersionAttr>(verAttr).getVersion();
 
   if (auto mo = getMemoryOrder()) {
@@ -5077,7 +5080,7 @@ LogicalResult AtomicUpdateOp::verify() {
 
   int64_t version = 50;
   if (auto moduleOp = getOperation()->getParentOfType<ModuleOp>())
-    if (Attribute verAttr = moduleOp->getAttr("omp.version"))
+    if (Attribute verAttr = moduleOp->getDiscardableAttr("omp.version"))
       version = llvm::cast<VersionAttr>(verAttr).getVersion();
 
   if (auto mo = getMemoryOrder()) {
@@ -5131,12 +5134,13 @@ LogicalResult AtomicCaptureOp::verifyRegions() {
   if (verifyRegionsCommon().failed())
     return mlir::failure();
 
-  if (getFirstOp()->getAttr("hint") || getSecondOp()->getAttr("hint"))
+  if (getFirstOp()->getInherentAttr("hint").value_or(Attribute{}) ||
+      getSecondOp()->getInherentAttr("hint").value_or(Attribute{}))
     return emitOpError(
         "operations inside capture region must not have hint clause");
 
-  if (getFirstOp()->getAttr("memory_order") ||
-      getSecondOp()->getAttr("memory_order"))
+  if (getFirstOp()->getInherentAttr("memory_order").value_or(Attribute{}) ||
+      getSecondOp()->getInherentAttr("memory_order").value_or(Attribute{}))
     return emitOpError(
         "operations inside capture region must not have memory_order clause");
   return success();

--- a/mlir/lib/Dialect/OpenMP/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/OpenMP/Utils/Utils.cpp
@@ -42,20 +42,20 @@ void mlir::omp::setOffloadModuleInterfaceAttributes(
 }
 
 void mlir::omp::setOpenMPVersionAttribute(ModuleOp module, int64_t version) {
-  module->setAttr(
+  module->setDiscardableAttr(
       StringAttr::get(module.getContext(), llvm::Twine{"omp.version"}),
       VersionAttr::get(module.getContext(), version));
 }
 
 int64_t mlir::omp::getOpenMPVersionAttribute(ModuleOp module,
                                              int64_t fallback) {
-  if (Attribute verAttr = module->getAttr("omp.version"))
+  if (Attribute verAttr = module->getDiscardableAttr("omp.version"))
     return llvm::cast<VersionAttr>(verAttr).getVersion();
   return fallback;
 }
 
 bool mlir::omp::isOpenMPModule(ModuleOp module) {
-  return module->hasAttr("omp.version");
+  return module->hasDiscardableAttr("omp.version");
 }
 
 static bool allocaUseRequiresSharedMem(const OpOperand &use) {
@@ -75,7 +75,7 @@ static bool allocaUseRequiresSharedMem(const OpOperand &use) {
       OperandRange privateVars = argIface.getPrivateVars();
       auto it = llvm::find(privateVars, use.get());
       if (it != privateVars.end()) {
-        auto privateSyms = owner->getAttrOfType<ArrayAttr>("private_syms");
+        ArrayAttr privateSyms = *argIface.getPrivateSyms();
         size_t idx = std::distance(privateVars.begin(), it);
         auto privateOp =
             SymbolTable::lookupNearestSymbolFrom<omp::PrivateClauseOp>(

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -5715,8 +5715,7 @@ static void extractAtomicControlFlags(omp::AtomicUpdateOp atomicUpdateOp,
   isIgnoreDenormalMode = false;
   isFineGrainedMemory = false;
   isRemoteMemory = false;
-  if (atomicUpdateOp &&
-      atomicUpdateOp->hasAttr(atomicUpdateOp.getAtomicControlAttrName())) {
+  if (atomicUpdateOp && atomicUpdateOp.getAtomicControlAttr()) {
     mlir::omp::AtomicControlAttr atomicControlAttr =
         atomicUpdateOp.getAtomicControlAttr();
     isIgnoreDenormalMode = atomicControlAttr.getIgnoreDenormalMode();
@@ -9827,7 +9826,7 @@ convertDeclareTargetAttr(Operation *op, mlir::omp::DeclareTargetAttr attribute,
 
       std::vector<llvm::Triple> targetTriple;
       auto targetTripleAttr = dyn_cast_or_null<mlir::StringAttr>(
-          op->getParentOfType<mlir::ModuleOp>()->getAttr(
+          op->getParentOfType<mlir::ModuleOp>()->getDiscardableAttr(
               LLVM::LLVMDialect::getTargetTripleAttrName()));
       if (targetTripleAttr)
         targetTriple.emplace_back(targetTripleAttr.data());

--- a/mlir/test/Conversion/OpenMPToLLVM/convert-to-llvmir.mlir
+++ b/mlir/test/Conversion/OpenMPToLLVM/convert-to-llvmir.mlir
@@ -5,6 +5,16 @@
 // CHECK-LABEL: llvm.func @foo(i64, i64)
 func.func private @foo(index, index)
 
+// CHECK-LABEL: llvm.func @discardable_attribute
+func.func @discardable_attribute() {
+  // CHECK: omp.critical
+  omp.critical {
+    // CHECK: } {test.discardable}
+    omp.terminator
+  } {test.discardable}
+  return
+}
+
 // CHECK-LABEL: llvm.func @critical_block_arg
 func.func @critical_block_arg() {
   // CHECK: omp.critical

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-barrier-gang-private-init.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-barrier-gang-private-init.mlir
@@ -48,7 +48,7 @@ func.func @test_gang_private_init_barrier(%arg0: memref<100x100xf32>) {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }
@@ -101,7 +101,7 @@ func.func @test_thread_private_init_no_barrier(%arg0: memref<100x100xf32>) {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-block-redundant-seq-gang-private.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-block-redundant-seq-gang-private.mlir
@@ -51,7 +51,7 @@ func.func @block_redundant_seq_gang_private(%arg0: memref<32xi32>) {
       } {acc.par_dims = #acc<par_dims[sequential]>,
          acc.gpu_block_redundant = #acc.gpu_block_redundant}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-block-redundant.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-block-redundant.mlir
@@ -32,7 +32,7 @@ func.func @block_redundant_vector_no_predicate(%arg0: memref<32xi32>) {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[thread_x]>, acc.gpu_block_redundant = #acc.gpu_block_redundant}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-bound-routine-call.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-bound-routine-call.mlir
@@ -17,7 +17,7 @@ func.func @bound_vector_call(%arg0: memref<4xf32>) {
       func.call @wrapped_vector(%arg10) : (memref<4xf32>) -> ()
     }
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-launch-mapping.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-launch-mapping.mlir
@@ -15,7 +15,7 @@ func.func @par0_loop() {
       scf.reduce
     } {acc.par_dims = #acc<par_dims[sequential]>}
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -37,7 +37,7 @@ func.func @par1_loop() {
       scf.reduce
     } {acc.par_dims = #acc<par_dims[thread_x]>}
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -64,7 +64,7 @@ func.func @par1_0_loop() {
       scf.reduce
     } {acc.par_dims = #acc<par_dims[thread_x]>}
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -91,7 +91,7 @@ func.func @par0_1_loop() {
       scf.reduce
     } {acc.par_dims = #acc<par_dims[sequential]>}
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -118,7 +118,7 @@ func.func @par2_1_loop() {
       scf.reduce
     } {acc.par_dims = #acc<par_dims[thread_y]>}
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -150,7 +150,7 @@ func.func @par2_0_1_loop() {
       scf.reduce
     } {acc.par_dims = #acc<par_dims[thread_y]>}
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -170,7 +170,7 @@ func.func @empty() {
   acc.compute_region {
   ^bb1:
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -191,7 +191,7 @@ func.func @empty_some_known_launch_arg() {
   %par_dim1 = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.compute_region launch(%arg0 = %par_dim1) {
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -231,7 +231,7 @@ func.func @empty_all_known_launch_arg() {
   %par_dim6 = acc.par_width %c128 par_dim(#acc.par_dim<block_z>)
   acc.compute_region launch(%tx = %par_dim1, %ty = %par_dim2, %tz = %par_dim3, %bx = %par_dim4, %by = %par_dim5, %bz = %par_dim6) {
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -272,6 +272,6 @@ func.func @using_block_args(%arr : memref<?xf32>) {
       }
     }
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-predicate-region-reuse-barrier.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-predicate-region-reuse-barrier.mlir
@@ -42,7 +42,7 @@ func.func @reuse_barrier_in_block_seq_loop() {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }
@@ -77,7 +77,7 @@ func.func @no_reuse_barrier_outside_seq_loop() {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-predicate-region.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-predicate-region.mlir
@@ -21,7 +21,7 @@ func.func @predicate_region_reduction(%arg0: memref<i32>) {
         acc.yield %alloca : memref<i32>
       }
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-private-local-gang-redundant.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-private-local-gang-redundant.mlir
@@ -30,7 +30,7 @@ func.func @gang_redundant_worker_private() {
         memref.store %c42, %loc[%c0] : memref<1xi32>
       }
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-privatize-local.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-privatize-local.mlir
@@ -16,7 +16,7 @@ module attributes {gpu.container_module} {
       acc.compute_region launch(%arg3 = %1, %arg4 = %2) ins(%arg10 = %4) : (!acc.private_type<memref<4xi8>>) {
         %8 = acc.private_local %arg10 : (!acc.private_type<memref<4xi8>>) -> memref<f32>
         acc.yield
-      } {origin = "acc.routine"}
+      } <{origin = "acc.routine"}>
       gpu.return
     }
   }

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-privatize-routine-seq.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-privatize-routine-seq.mlir
@@ -29,7 +29,7 @@ module attributes {gpu.container_module} {
       acc.compute_region launch(%arg0 = %0) ins(%arg10 = %1) : (!acc.private_type<memref<10xi32>>) {
         %2 = acc.private_local %arg10 : (!acc.private_type<memref<10xi32>>) -> memref<10xi32>
         acc.yield
-      } {origin = "acc.routine"}
+      } <{origin = "acc.routine"}>
       gpu.return
     }
 

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-privatize-threadprivate.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-privatize-threadprivate.mlir
@@ -20,7 +20,7 @@ func.func @threadprivate(%host: memref<i32>) {
     %next = arith.addi %v, %v : i32
     memref.store %next, %local[] : memref<i32>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -51,6 +51,6 @@ func.func @dynamic_threadprivate(%n: index) {
         : (!acc.private_type<memref<?xi32>>) -> memref<?xi32>
     memref.store %one, %local[%c0] : memref<?xi32>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-array-shared.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-array-shared.mlir
@@ -56,7 +56,7 @@ func.func @array_reduction_shared(%arg0: memref<8192xi32>) {
         }
       }
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   acc.copyout accPtr(%0 : memref<8192xi32>) to varPtr(%arg0 : memref<8192xi32>) dataClause(acc_reduction) implicit(true) name("r")
   return
@@ -112,7 +112,7 @@ func.func @array_reduction_shared_partitioned(%arg0: memref<8192xi32>) {
         }
       }
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   acc.copyout accPtr(%0 : memref<8192xi32>) to varPtr(%arg0 : memref<8192xi32>) dataClause(acc_reduction) implicit(true) name("r")
   return
@@ -161,7 +161,7 @@ func.func @array_reduction_gang_storage_thread_accum(%arg0: memref<4xi32>) {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   acc.copyout accPtr(%0 : memref<4xi32>) to varPtr(%arg0 : memref<4xi32>) dataClause(acc_reduction) implicit(true) name("r")
   return

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-array.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-array.mlir
@@ -57,7 +57,7 @@ func.func @array_reduction(%arg0: memref<2xi32>) {
         }
       }
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   acc.copyout accPtr(%0 : memref<2xi32>) to varPtr(%arg0 : memref<2xi32>) dataClause(acc_reduction) implicit(true) name("r")
   return
@@ -80,7 +80,7 @@ func.func @array_reduction_small_shared() {
         par_dims(#acc<par_dims[block_x, thread_x]>) : memref<2xi32>
     memref.dealloc %shared : memref<2xi32>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -107,7 +107,7 @@ func.func @array_reduction_strided_extent() {
     acc.reduction_accumulate_array %local bounds(%bounds) <add>
         par_dims(#acc<par_dims[block_x, thread_x]>) : memref<8xi32>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -130,7 +130,7 @@ func.func @array_reduction_dynamic_par_dims(%buf: memref<?xi32>, %n: index) {
     acc.reduction_accumulate_array %view bounds(%bounds) <add>
         par_dims(#acc<par_dims[block_x, thread_x]>) : memref<?xi32, strided<[1]>>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -159,7 +159,7 @@ func.func @rank_two_array_reduction() {
     %bounds = acc.bounds extent(%c6 : index)
     acc.reduction_accumulate_array %local bounds(%bounds) <add> par_dims(#acc<par_dims[block_x, thread_x]>) : memref<2x3xi32>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -191,7 +191,7 @@ func.func @rank_three_array_reduction() {
     %bounds = acc.bounds extent(%c8 : index)
     acc.reduction_accumulate_array %local bounds(%bounds) <add> par_dims(#acc<par_dims[block_x, thread_x]>) : memref<2x2x2xi32>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -219,7 +219,7 @@ func.func @dynamic_rank_two_array_reduction(
     %bounds = acc.bounds extent(%extent : index)
     acc.reduction_accumulate_array %arg0 bounds(%bounds) <add> par_dims(#acc<par_dims[block_x, thread_x]>) : memref<2x?xi32>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -250,7 +250,7 @@ func.func @rank_two_partial_bounds_strided_layout() {
     acc.reduction_accumulate_array %local bounds(%bounds) <add>
         par_dims(#acc<par_dims[block_x, thread_x]>) : memref<3x4xi32, strided<[8, 2]>>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -272,7 +272,7 @@ func.func @partial_thread_x_reduction() {
     acc.reduction_accumulate_array %local bounds(%bounds) <add>
         par_dims(#acc<par_dims[block_x, thread_x]>) : memref<2xi32>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -296,7 +296,7 @@ func.func @thread_y_reduction_single_thread_rows() {
     acc.reduction_accumulate %c0_i32 to %local <add>
         par_dims(#acc<par_dims[block_x, thread_y]>) : i32 -> memref<i32>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -321,7 +321,7 @@ func.func @thread_y_reduction_narrow_rows() {
     acc.reduction_accumulate %c0_i32 to %local <add>
         par_dims(#acc<par_dims[block_x, thread_y]>) : i32 -> memref<i32>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -349,7 +349,7 @@ func.func @thread_y_reduction_with_thread_x_reduction() {
     acc.reduction_accumulate %c0_i32 to %vector <add>
         par_dims(#acc<par_dims[block_x, thread_x]>) : i32 -> memref<i32>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -372,7 +372,7 @@ func.func @thread_y_reduction_more_workers_than_subgroup() {
     acc.reduction_accumulate %c0_i32 to %local <add>
         par_dims(#acc<par_dims[block_x, thread_y]>) : i32 -> memref<i32>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -396,7 +396,7 @@ func.func @thread_x_reduction_with_thread_y_width() {
     acc.reduction_accumulate %c0_i32 to %local <add>
         par_dims(#acc<par_dims[block_x, thread_x]>) : i32 -> memref<i32>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -420,7 +420,7 @@ func.func @thread_x_reduction_with_thread_z_width() {
     acc.reduction_accumulate %c0_i32 to %local <add>
         par_dims(#acc<par_dims[block_x, thread_x]>) : i32 -> memref<i32>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -450,6 +450,6 @@ func.func @thread_only_array_reduction_single_block() {
     acc.reduction_accumulate_array %local bounds(%bounds) <add>
         par_dims(#acc<par_dims[thread_x]>) : memref<8xi32>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-block-combine-no-reload.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-block-combine-no-reload.mlir
@@ -56,7 +56,7 @@ module attributes {gpu.container_module} {
         acc.reduction_combine %a_slot into %a_res <add> par_dims(#acc<par_dims[block_x, thread_x]>) : memref<i32>
       }
       acc.yield
-    } {kernel_func_name = @test_block_combine_no_reload_kernel, kernel_module_name = @cuda_device_mod, origin = "acc.parallel"}
+    } <{kernel_func_name = @test_block_combine_no_reload_kernel, kernel_module_name = @cuda_device_mod, origin = "acc.parallel"}>
     return
   }
 }

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-combine-region-private-dest.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-combine-region-private-dest.mlir
@@ -77,6 +77,6 @@ func.func @combine_region_private_dest(%arg: memref<i32>) {
       } {acc.par_dims = #acc<par_dims[block_x, thread_x]>}
     }
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reuse-barrier-sibling-region-privatize.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reuse-barrier-sibling-region-privatize.mlir
@@ -41,7 +41,7 @@ func.func @sibling_regions_share_seq_loop() {
           scf.reduce
         } {acc.par_dims = #acc<par_dims[block_x]>}
         acc.yield
-      } {origin = "acc.parallel"}
+      } <{origin = "acc.parallel"}>
       // Region with a gang-private store inside a block-level predicate region.
       acc.compute_region launch(%gridA = %par_bx, %blockA = %par_tx) ins(%argA = %priv0) : (!acc.private_type<memref<i64>>) {
         %ca0 = arith.constant 0 : index
@@ -60,7 +60,7 @@ func.func @sibling_regions_share_seq_loop() {
           scf.reduce
         } {acc.par_dims = #acc<par_dims[block_x]>}
         acc.yield
-      } {origin = "acc.parallel"}
+      } <{origin = "acc.parallel"}>
     }
   }
   return

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-routine-call-nested-if.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-routine-call-nested-if.mlir
@@ -27,7 +27,7 @@ func.func @routine_call_in_nested_if(%arg0: memref<4xf32>, %arg1: memref<4xf32>)
       scf.reduce
     } {acc.par_dims = #acc<par_dims[block_x]>}
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-routine-worker-call-with-thread-y-reduction.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-routine-worker-call-with-thread-y-reduction.mlir
@@ -68,7 +68,7 @@ module attributes {gpu.container_module} {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       acc.yield
-    } {kernel_func_name = @test_worker_routine_kernel, kernel_module_name = @cuda_device_mod, origin = "acc.parallel"}
+    } <{kernel_func_name = @test_worker_routine_kernel, kernel_module_name = @cuda_device_mod, origin = "acc.parallel"}>
     return
   }
 }

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-private-dynamic-nw.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-private-dynamic-nw.mlir
@@ -23,7 +23,7 @@ func.func @test_worker_private_dynamic_nw(%nw: index) {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[thread_y]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-private-foldable-nw.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-private-foldable-nw.mlir
@@ -24,7 +24,7 @@ func.func @test_worker_private_foldable_nw() {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[thread_y]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine-mixed-scope.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine-mixed-scope.mlir
@@ -35,7 +35,7 @@ func.func @mixed_scope_worker_reduction_combine(
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_y]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }
@@ -74,7 +74,7 @@ func.func @worker_combine_with_single_store(%result: memref<i32>) {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_y]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }
@@ -111,7 +111,7 @@ func.func @worker_combine_with_atomic_update(%result: memref<i32>) {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_y]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine.mlir
@@ -41,7 +41,7 @@ func.func @worker_reduction_combine(%result: memref<i32>) {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_y]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }
@@ -89,7 +89,7 @@ func.func @worker_reduction_combine_region(%result: memref<i32>) {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_y]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }
@@ -139,7 +139,7 @@ func.func @nested_worker_reduction_combines(
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_y]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }
@@ -177,7 +177,7 @@ func.func @worker_combine_in_scf_if(%result: memref<i32>) {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_y]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-private.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-private.mlir
@@ -35,7 +35,7 @@ func.func @worker_reduction_private() {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-vector-reuse-barrier.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-vector-reuse-barrier.mlir
@@ -58,7 +58,7 @@ func.func @worker_seq_vector_reuse() {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-vector-subgroup-align.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-vector-subgroup-align.mlir
@@ -49,7 +49,7 @@ func.func @worker_divergent_subgroup_barrier() {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-emit-remarks-data.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-emit-remarks-data.mlir
@@ -121,7 +121,7 @@ func.func @kernel_environment(
       memref<f32>) {
     acc.compute_region {
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-emit-remarks-loop.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-emit-remarks-loop.mlir
@@ -14,7 +14,7 @@ func.func @vector_loop() {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[thread_x]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }
@@ -34,7 +34,7 @@ func.func @gang_loop() {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }
@@ -54,7 +54,7 @@ func.func @worker_loop() {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[thread_y]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }
@@ -72,7 +72,7 @@ func.func @sequential_loop() {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[sequential]>}
       acc.yield
-    } {origin = "acc.kernels"}
+    } <{origin = "acc.kernels"}>
   }
   return
 }
@@ -95,7 +95,7 @@ func.func @block_and_vector() {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x, thread_x]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }
@@ -112,7 +112,7 @@ func.func @scf_for_sequential() {
       scf.for %iv = %c0 to %c4 step %c1 {
       }
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }
@@ -129,7 +129,7 @@ func.func @collapse_loop() {
       scf.for %iv = %c0 to %c4 step %c1 {
       } {acc.par_dims = #acc<par_dims[sequential]>, acc.collapse_count = 2 : i64}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }
@@ -149,7 +149,7 @@ func.func @percent_separator() {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[thread_x]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }
@@ -170,7 +170,7 @@ func.func @acc_routine_gang_vector_loop() attributes {acc.specialized_routine = 
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x, thread_x]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-implicit-declare.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-implicit-declare.mlir
@@ -206,7 +206,7 @@ func.func @test_scalar_in_compute_region() {
     %addr = memref.get_global @global_in_compute_region : memref<f32>
     %load = memref.load %addr[] : memref<f32>
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 

--- a/mlir/test/Dialect/OpenACC/acc-routine-lowering.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-routine-lowering.mlir
@@ -86,7 +86,7 @@ acc.routine @routine_cf func(@host_cf) seq
 // CHECK: %[[EXE:[0-9]+]] = scf.execute_region
 // CHECK: scf.yield %{{.*}} : i32
 // CHECK: acc.yield %[[EXE]] : i32
-// CHECK: } {origin = "acc.routine"}
+// CHECK: } <{origin = "acc.routine"}>
 // CHECK: return %[[CR]] : i32
 func.func @host_cf(%cond: i1) -> i32 {
   cf.cond_br %cond, ^then, ^else

--- a/mlir/test/Dialect/OpenACC/compute-region-canonicalize.mlir
+++ b/mlir/test/Dialect/OpenACC/compute-region-canonicalize.mlir
@@ -15,7 +15,7 @@ func.func @merge_duplicate_ins() -> i32 {
     %x = arith.addi %v, %c1 : i32
     memref.store %x, %a[] : memref<i32>
     acc.yield
-  } {origin = "acc.serial"}
+  } <{origin = "acc.serial"}>
   %r = memref.load %m[] : memref<i32>
   return %r : i32
 }
@@ -50,7 +50,7 @@ func.func @merge_duplicate_ins_complex_pattern() -> i32 {
     %out = arith.addi %sum6, %one : i32
     memref.store %out, %a0[] : memref<i32>
     acc.yield
-  } {origin = "acc.serial"}
+  } <{origin = "acc.serial"}>
   %r = memref.load %ma[] : memref<i32>
   return %r : i32
 }
@@ -73,7 +73,7 @@ func.func @drop_unused_ins() -> i32 {
     %x = arith.addi %v, %c1 : i32
     memref.store %x, %a[] : memref<i32>
     acc.yield
-  } {origin = "acc.serial"}
+  } <{origin = "acc.serial"}>
   %r = memref.load %ma[] : memref<i32>
   return %r : i32
 }

--- a/mlir/test/Dialect/OpenACC/invalid-cg.mlir
+++ b/mlir/test/Dialect/OpenACC/invalid-cg.mlir
@@ -26,7 +26,15 @@ scf.parallel (%iv) = (%c0_2) to (%c4_2) step (%c1_2) {
 // expected-error@+1 {{'acc.compute_region' op launch arguments must be results of acc.par_width operations}}
 acc.compute_region launch(%arg0 = %c32) {
   acc.yield
-} {origin = "acc.parallel"}
+} <{origin = "acc.parallel"}>
+
+// -----
+
+func.func @compute_region_inherent_attr_in_attr_dict() {
+  // expected-error@+1 {{inherent attribute 'origin' cannot be parsed from attr-dict when strict properties in assembly format is enabled}}
+  acc.compute_region {} <{origin = "acc.parallel"}> {origin = "acc.parallel"}
+  return
+}
 
 // -----
 
@@ -100,7 +108,7 @@ func.func @predicate_region_empty() {
     acc.predicate_region {
     }
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 
@@ -114,7 +122,7 @@ func.func @predicate_region_with_args() {
       %c0 = arith.constant 0 : index
     }
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 

--- a/mlir/test/Dialect/OpenACC/ops-cg-privatization.mlir
+++ b/mlir/test/Dialect/OpenACC/ops-cg-privatization.mlir
@@ -105,7 +105,7 @@ func.func @privatize_inside_compute_region(%data : memref<64xf32>) {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[thread_x]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   acc.delete accPtr(%copy : memref<64xf32>)
   return
@@ -115,7 +115,7 @@ func.func @privatize_inside_compute_region(%data : memref<64xf32>) {
 // CHECK: acc.privatize par_dims(#acc<par_dims[thread_x]>) : () -> !acc.private_type<memref<f32>>
 // CHECK: acc.private_local
 // CHECK: memref.load %{{.*}}[%{{.*}}] : memref<64xf32>
-// CHECK: } {origin = "acc.parallel"}
+// CHECK: } <{origin = "acc.parallel"}>
 
 // -----
 

--- a/mlir/test/Dialect/OpenACC/ops-cg.mlir
+++ b/mlir/test/Dialect/OpenACC/ops-cg.mlir
@@ -116,7 +116,7 @@ func.func @compute_region_single_dim(%data: memref<1024xf32>,
         scf.reduce
       } {acc.par_dims = #acc<par_dims[thread_x]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   acc.copyout accPtr(%copy : memref<f32>) to varPtr(%result : memref<f32>) dataClause(acc_copy)
   acc.delete accPtr(%copyin : memref<1024xf32>)
@@ -125,7 +125,7 @@ func.func @compute_region_single_dim(%data: memref<1024xf32>,
 // CHECK: %[[W:.*]] = acc.par_width %{{.*}} par_dim(#acc.par_dim<thread_x>)
 // CHECK: acc.compute_region launch(%{{.*}} = %[[W]]) ins({{.*}}) : (memref<1024xf32>, memref<f32>) {
 // CHECK:   acc.yield
-// CHECK: } {origin = "acc.parallel"}
+// CHECK: } <{origin = "acc.parallel"}>
 
 // -----
 
@@ -159,7 +159,7 @@ func.func @compute_region_two_dims(%data: memref<8xi32>,
       } {acc.par_dims = #acc<par_dims[block_x, thread_x]>}
       acc.reduction_combine %init into %arg3 <add> : memref<i32>
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   acc.copyout accPtr(%copyin_red : memref<i32>) to varPtr(%reduction_var : memref<i32>) dataClause(acc_reduction)
   acc.delete accPtr(%copyin_data : memref<8xi32>)
@@ -169,7 +169,7 @@ func.func @compute_region_two_dims(%data: memref<8xi32>,
 // CHECK: %[[W1:.*]] = acc.par_width %{{.*}} par_dim(#acc.par_dim<thread_x>)
 // CHECK: acc.compute_region launch(%{{.*}} = %[[W0]], %{{.*}} = %[[W1]]) ins({{.*}}) : (memref<8xi32>, memref<i32>) {
 // CHECK:   acc.yield
-// CHECK: } {origin = "acc.parallel"}
+// CHECK: } <{origin = "acc.parallel"}>
 
 // -----
 
@@ -201,7 +201,7 @@ func.func @compute_region_unknown_width(%data: memref<100xf32>) {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[thread_x]>}
       acc.yield
-    } {origin = "acc.kernels"}
+    } <{origin = "acc.kernels"}>
   }
   acc.delete accPtr(%copyin : memref<100xf32>)
   return
@@ -209,7 +209,7 @@ func.func @compute_region_unknown_width(%data: memref<100xf32>) {
 // CHECK: %[[W:.*]] = acc.par_width par_dim(#acc.par_dim<thread_x>)
 // CHECK: acc.compute_region launch(%{{.*}} = %[[W]]) ins({{.*}}) : (memref<100xf32>) {
 // CHECK:   acc.yield
-// CHECK: } {origin = "acc.kernels"}
+// CHECK: } <{origin = "acc.kernels"}>
 
 // -----
 
@@ -224,7 +224,7 @@ func.func @compute_region_no_launch(%a: memref<i32>, %b: memref<i32>) {
       memref.store %c1, %arg0[] : memref<i32>
       memref.store %c1, %arg1[] : memref<i32>
       acc.yield
-    } {origin = "acc.serial"}
+    } <{origin = "acc.serial"}>
   }
   acc.copyout accPtr(%copy_a : memref<i32>) to varPtr(%a : memref<i32>) dataClause(acc_copy)
   acc.copyout accPtr(%copy_b : memref<i32>) to varPtr(%b : memref<i32>) dataClause(acc_copy)
@@ -232,7 +232,7 @@ func.func @compute_region_no_launch(%a: memref<i32>, %b: memref<i32>) {
 }
 // CHECK: acc.compute_region ins({{.*}}) : (memref<i32>, memref<i32>) {
 // CHECK:   acc.yield
-// CHECK: } {origin = "acc.serial"}
+// CHECK: } <{origin = "acc.serial"}>
 
 // -----
 
@@ -242,25 +242,25 @@ func.func @compute_region_launch_only() {
   %w0 = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.compute_region launch(%arg0 = %w0) {
     acc.yield
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 // CHECK: %[[W:.*]] = acc.par_width %{{.*}} par_dim(#acc.par_dim<thread_x>)
 // CHECK: acc.compute_region launch(%{{.*}} = %[[W]]) {
 // CHECK:   acc.yield
-// CHECK: } {origin = "acc.parallel"}
+// CHECK: } <{origin = "acc.parallel"}>
 
 // -----
 
 // CHECK-LABEL: func @compute_region_empty
 func.func @compute_region_empty() {
   acc.compute_region {
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return
 }
 // CHECK: acc.compute_region {
 // CHECK:   acc.yield
-// CHECK: } {origin = "acc.parallel"}
+// CHECK: } <{origin = "acc.parallel"}>
 
 // -----
 
@@ -284,7 +284,7 @@ func.func @compute_region_all_fields(%data: memref<1024xf32>,
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x, thread_x]>}
       acc.yield
-    } {kernel_func_name = @compute_kernel, kernel_module_name = @device_module, origin = "acc.parallel"}
+    } <{kernel_func_name = @compute_kernel, kernel_module_name = @device_module, origin = "acc.parallel"}> {test.discardable}
   }
   acc.delete accPtr(%copyin : memref<1024xf32>)
   return
@@ -293,7 +293,7 @@ func.func @compute_region_all_fields(%data: memref<1024xf32>,
 // CHECK: %[[W1:.*]] = acc.par_width %{{.*}} par_dim(#acc.par_dim<thread_x>)
 // CHECK: acc.compute_region stream(%[[STREAM]] : !gpu.async.token) launch(%{{.*}} = %[[W0]], %{{.*}} = %[[W1]]) ins({{.*}}) : (memref<1024xf32>) {
 // CHECK:   acc.yield
-// CHECK: } {kernel_func_name = @compute_kernel, kernel_module_name = @device_module, origin = "acc.parallel"}
+// CHECK: } <{kernel_func_name = @compute_kernel, kernel_module_name = @device_module, origin = "acc.parallel"}> {test.discardable}
 
 // -----
 
@@ -361,13 +361,13 @@ func.func @compute_region_with_results() -> i32 {
   %0 = acc.compute_region launch(%arg0 = %w0) -> i32 {
     %c0_i32 = arith.constant 0 : i32
     acc.yield %c0_i32 : i32
-  } {origin = "acc.parallel"}
+  } <{origin = "acc.parallel"}>
   return %0 : i32
 }
 // CHECK: %[[W:.*]] = acc.par_width par_dim(#acc.par_dim<thread_x>)
 // CHECK: {{.*}} = acc.compute_region launch(%{{.*}} = %[[W]]) -> i32 {
 // CHECK:   acc.yield
-// CHECK: } {origin = "acc.parallel"}
+// CHECK: } <{origin = "acc.parallel"}>
 
 // -----
 
@@ -405,7 +405,7 @@ func.func @predicate_region_gang_vector_atomics(%c1: memref<i32>, %c2: memref<i3
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   acc.copyout accPtr(%copy_c1 : memref<i32>) to varPtr(%c1 : memref<i32>) dataClause(acc_copy)
   acc.copyout accPtr(%copy_c2 : memref<i32>) to varPtr(%c2 : memref<i32>) dataClause(acc_copy)
@@ -445,7 +445,7 @@ func.func @predicate_region_gang_redundant_setup(%idx: memref<i32>, %table: memr
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       acc.yield
-    } {origin = "acc.kernels"}
+    } <{origin = "acc.kernels"}>
   }
   acc.copyout accPtr(%copy_idx : memref<i32>) to varPtr(%idx : memref<i32>) dataClause(acc_copy)
   acc.delete accPtr(%copy_table : memref<10xi32>)

--- a/mlir/test/Transforms/sccp.mlir
+++ b/mlir/test/Transforms/sccp.mlir
@@ -282,7 +282,7 @@ func.func @no_crash_acc_kernel_environment(%data: memref<8xi32>) {
   acc.kernel_environment {
     acc.compute_region {
       acc.yield
-    } {origin = "acc.parallel"}
+    } <{origin = "acc.parallel"}>
   }
   return
 }

--- a/mlir/test/lib/Dialect/OpenACC/TestOpenACCSupport.cpp
+++ b/mlir/test/lib/Dialect/OpenACC/TestOpenACCSupport.cpp
@@ -49,7 +49,7 @@ void TestOpenACCSupportPass::runOnOperation() {
   func.walk([&](Operation *op) {
     // Check for test.var_name attribute. This is the marker used to identify
     // the operations that need to be tested for getVariableName.
-    if (op->hasAttr("test.var_name")) {
+    if (op->hasDiscardableAttr("test.var_name")) {
       // For each result of this operation, try to get the variable name
       for (auto result : op->getResults()) {
         std::string foundName = support.getVariableName(result);
@@ -61,7 +61,7 @@ void TestOpenACCSupportPass::runOnOperation() {
     // Check for test.recipe_name attribute. This is the marker used to identify
     // the operations that need to be tested for getRecipeName.
     if (auto recipeAttr =
-            op->getAttrOfType<RecipeKindAttr>("test.recipe_name")) {
+            op->getDiscardableAttrOfType<RecipeKindAttr>("test.recipe_name")) {
       RecipeKind kind = recipeAttr.getValue();
       // Get the type from the first result if available
       if (op->getNumResults() > 0) {
@@ -76,7 +76,8 @@ void TestOpenACCSupportPass::runOnOperation() {
 
     // Check for test.emit_nyi attribute. This is the marker used to
     // test whether the not yet implemented case is reported correctly.
-    if (auto messageAttr = op->getAttrOfType<StringAttr>("test.emit_nyi")) {
+    if (auto messageAttr =
+            op->getDiscardableAttrOfType<StringAttr>("test.emit_nyi")) {
       support.emitNYI(op->getLoc(), messageAttr.getValue());
     }
   });

--- a/mlir/test/lib/Dialect/OpenACC/TestPointerLikeTypeInterface.cpp
+++ b/mlir/test/lib/Dialect/OpenACC/TestPointerLikeTypeInterface.cpp
@@ -101,9 +101,10 @@ void TestPointerLikeTypeInterfacePass::runOnOperation() {
 
   if (testMode == "cast") {
     func.walk([&](Operation *op) {
-      if (!op->hasAttr("test.cast"))
+      if (!op->hasDiscardableAttr("test.cast"))
         return;
-      auto destAttr = dyn_cast_or_null<TypeAttr>(op->getAttr("cast_dest"));
+      auto destAttr =
+          dyn_cast_or_null<TypeAttr>(op->getDiscardableAttr("cast_dest"));
       if (!destAttr || op->getNumResults() == 0)
         return;
       testGenCast(op, op->getResult(0), destAttr.getValue(), builder);
@@ -118,7 +119,7 @@ void TestPointerLikeTypeInterfacePass::runOnOperation() {
     // For store mode, also look for a test value to use
     Value testValue;
     func.walk([&](Operation *op) {
-      if (op->hasAttr("test.ptr")) {
+      if (op->hasDiscardableAttr("test.ptr")) {
         for (auto result : op->getResults()) {
           if (isa<PointerLikeType>(result.getType())) {
             candidates.push_back(
@@ -128,7 +129,7 @@ void TestPointerLikeTypeInterfacePass::runOnOperation() {
         }
       }
       // Collect value marked with test.value for store tests
-      if (testMode == "store" && op->hasAttr("test.value")) {
+      if (testMode == "store" && op->hasDiscardableAttr("test.value")) {
         if (op->getNumResults() > 0)
           testValue = op->getResult(0);
       }
@@ -154,7 +155,7 @@ void TestPointerLikeTypeInterfacePass::runOnOperation() {
     SmallVector<PointerCandidate> sources, destinations;
 
     func.walk([&](Operation *op) {
-      if (op->hasAttr("test.src_ptr")) {
+      if (op->hasDiscardableAttr("test.src_ptr")) {
         for (auto result : op->getResults()) {
           if (isa<PointerLikeType>(result.getType())) {
             sources.push_back(
@@ -163,7 +164,7 @@ void TestPointerLikeTypeInterfacePass::runOnOperation() {
           }
         }
       }
-      if (op->hasAttr("test.dest_ptr")) {
+      if (op->hasDiscardableAttr("test.dest_ptr")) {
         for (auto result : op->getResults()) {
           if (isa<PointerLikeType>(result.getType())) {
             destinations.push_back(
@@ -188,8 +189,9 @@ void TestPointerLikeTypeInterfacePass::walkAndPrint() {
   func.walk([&](Operation *op) {
     // Look for operations marked with "test.ptr", "test.src_ptr", or
     // "test.dest_ptr"
-    if (op->hasAttr("test.ptr") || op->hasAttr("test.src_ptr") ||
-        op->hasAttr("test.dest_ptr")) {
+    if (op->hasDiscardableAttr("test.ptr") ||
+        op->hasDiscardableAttr("test.src_ptr") ||
+        op->hasDiscardableAttr("test.dest_ptr")) {
       llvm::errs() << "Operation: ";
       op->print(llvm::errs());
       llvm::errs() << "\n";

--- a/mlir/test/lib/Dialect/OpenACC/TestRecipePopulate.cpp
+++ b/mlir/test/lib/Dialect/OpenACC/TestRecipePopulate.cpp
@@ -62,7 +62,7 @@ void TestRecipePopulatePass::runOnOperation() {
   SmallVector<std::tuple<Operation *, Value, std::string>> testVars;
 
   module.walk([&](Operation *op) {
-    if (auto varName = op->getAttrOfType<StringAttr>("test.var")) {
+    if (auto varName = op->getDiscardableAttrOfType<StringAttr>("test.var")) {
       for (auto result : op->getResults()) {
         testVars.push_back({op, result, varName.str()});
       }

--- a/mlir/unittests/Dialect/OpenACC/OpenACCUtilsCGTest.cpp
+++ b/mlir/unittests/Dialect/OpenACC/OpenACCUtilsCGTest.cpp
@@ -161,7 +161,7 @@ TEST_F(OpenACCUtilsCGTest, getDataLayoutWithSpec) {
   auto indexEntry = DataLayoutEntryAttr::get(IndexType::get(&context),
                                              b.getI32IntegerAttr(32));
   auto spec = DataLayoutSpecAttr::get(&context, {indexEntry});
-  (*module)->setAttr(DLTIDialect::kDataLayoutAttrName, spec);
+  (*module)->setDiscardableAttr(DLTIDialect::kDataLayoutAttrName, spec);
 
   // With explicit spec, should return DataLayout regardless of allowDefault
   auto dl1 = getDataLayout(module->getOperation(), /*allowDefault=*/false);

--- a/mlir/unittests/Dialect/OpenACC/OpenACCUtilsGPUTest.cpp
+++ b/mlir/unittests/Dialect/OpenACC/OpenACCUtilsGPUTest.cpp
@@ -51,8 +51,8 @@ TEST_F(OpenACCUtilsGPUTest, getOrCreateGPUModuleCreatesWhenMissing) {
   EXPECT_EQ(gpuMod->getName(), kDefaultGPUModuleName);
 
   // Module should now have the container module attribute
-  EXPECT_TRUE(
-      (*module)->hasAttr(gpu::GPUDialect::getContainerModuleAttrName()));
+  EXPECT_TRUE((*module)->hasDiscardableAttr(
+      gpu::GPUDialect::getContainerModuleAttrName()));
 }
 
 TEST_F(OpenACCUtilsGPUTest, getOrCreateGPUModuleReturnsExisting) {

--- a/mlir/unittests/Dialect/OpenACC/OpenACCUtilsLoopTest.cpp
+++ b/mlir/unittests/Dialect/OpenACC/OpenACCUtilsLoopTest.cpp
@@ -274,7 +274,7 @@ TEST_F(OpenACCUtilsLoopTest, ConvertLoopToSCFForWithCollapse) {
   // Ensure the collapsed loop has an attribute indicating the number
   // of collapsed loops
   auto collapseAttr =
-      forOp->getAttrOfType<IntegerAttr>(getCollapseCountAttrName());
+      forOp->getDiscardableAttrOfType<IntegerAttr>(getCollapseCountAttrName());
   ASSERT_TRUE(collapseAttr);
   EXPECT_EQ(collapseAttr.getInt(), 2);
 
@@ -311,7 +311,7 @@ TEST_F(OpenACCUtilsLoopTest, ConvertLoopToSCFForNoCollapse) {
   EXPECT_TRUE(hasNestedFor);
 
   // No collapse happened, so no collapse_count attribute is expected
-  EXPECT_FALSE(forOp->hasAttr(getCollapseCountAttrName()));
+  EXPECT_FALSE(forOp->hasDiscardableAttr(getCollapseCountAttrName()));
 }
 
 TEST_F(OpenACCUtilsLoopTest, ConvertLoopToSCFForWithCollapseAndDynamicBounds) {

--- a/mlir/unittests/Dialect/OpenACC/OpenACCUtilsTest.cpp
+++ b/mlir/unittests/Dialect/OpenACC/OpenACCUtilsTest.cpp
@@ -425,7 +425,7 @@ TEST_F(OpenACCUtilsTest, getVariableNameDirect) {
 
   // Set the acc.var_name attribute
   auto varNameAttr = VarNameAttr::get(&context, "my_variable");
-  allocOp.get()->setAttr(getVarNameAttrName(), varNameAttr);
+  allocOp.get()->setDiscardableAttr(getVarNameAttrName(), varNameAttr);
 
   Value varPtr = allocOp->getResult();
 
@@ -442,7 +442,7 @@ TEST_F(OpenACCUtilsTest, getVariableNameThroughCast) {
 
   // Set the acc.var_name attribute on the alloca
   auto varNameAttr = VarNameAttr::get(&context, "casted_variable");
-  allocOp.get()->setAttr(getVarNameAttrName(), varNameAttr);
+  allocOp.get()->setDiscardableAttr(getVarNameAttrName(), varNameAttr);
 
   Value allocResult = allocOp->getResult();
 
@@ -774,8 +774,8 @@ TEST_F(OpenACCUtilsTest, isValidSymbolUseFunctionWithRoutineInfo) {
   // Add routine_info attribute with a reference to a routine
   SmallVector<SymbolRefAttr> routineRefs = {
       SymbolRefAttr::get(&context, "acc_routine")};
-  funcOp.get()->setAttr(getRoutineInfoAttrName(),
-                        RoutineInfoAttr::get(&context, routineRefs));
+  funcOp.get()->setDiscardableAttr(getRoutineInfoAttrName(),
+                                   RoutineInfoAttr::get(&context, routineRefs));
 
   // Create a call operation that uses the function symbol
   SymbolRefAttr funcSymbol = SymbolRefAttr::get(&context, funcName);
@@ -862,7 +862,7 @@ TEST_F(OpenACCUtilsTest, isValidSymbolUseWithDeclareAttr) {
       func::FuncOp::create(b, loc, funcName, funcType);
 
   // Add declare attribute
-  funcOp.get()->setAttr(
+  funcOp.get()->setDiscardableAttr(
       getDeclareAttrName(),
       DeclareAttr::get(&context,
                        DataClauseAttr::get(&context, DataClause::acc_copy)));
@@ -1418,8 +1418,9 @@ static Value memrefViewFromBlockArgWithDeclare(OpBuilder &builder, Location loc,
   Value c0 = arith::ConstantIndexOp::create(builder, loc, 0);
   memref::ViewOp viewOp =
       memref::ViewOp::create(builder, loc, viewTy, buf, c0, ValueRange{});
-  viewOp->setAttr(getDeclareAttrName(),
-                  DeclareAttr::get(ctx, DataClauseAttr::get(ctx, clause)));
+  viewOp->setDiscardableAttr(
+      getDeclareAttrName(),
+      DeclareAttr::get(ctx, DataClauseAttr::get(ctx, clause)));
   func::ReturnOp::create(builder, loc);
   return viewOp.getResult();
 }


### PR DESCRIPTION
Use discardable attribute APIs and typed operation accessors throughout the OpenACC and OpenMP dialects, conversions, translation, utilities, and tests.

Keep ComputeRegionOp inherent properties in the property dictionary and discardable attributes in the attribute dictionary.

Assisted-by: Codex