### PR TITLE
[MLIR][Shape] Enable strict property assembly format

### DIFF
--- a/mlir/include/mlir/Dialect/Shape/IR/ShapeBase.td
+++ b/mlir/include/mlir/Dialect/Shape/IR/ShapeBase.td
@@ -22,6 +22,7 @@ include "mlir/IR/OpBase.td"
 
 def ShapeDialect : Dialect {
   let name = "shape";
+  let useStrictPropertiesInAssemblyFormat = 1;
 
   let summary = "Types and operations for shape dialect";
   let description = [{

--- a/mlir/include/mlir/Dialect/Shape/IR/ShapeOps.td
+++ b/mlir/include/mlir/Dialect/Shape/IR/ShapeOps.td
@@ -85,7 +85,8 @@ def Shape_BroadcastOp : Shape_Op<"broadcast", [Commutative, Pure]> {
   let builders = [OpBuilder<(ins "Value":$shape)>];
 
   let assemblyFormat = [{
-    $shapes attr-dict `:` type($shapes) `->` type($result)
+    $shapes (`error` `=` $error^)? attr-dict `:` type($shapes) `->`
+    type($result)
   }];
 
   let builders = [OpBuilder<(ins "::mlir::Type":$result,

--- a/mlir/test/Dialect/Shape/invalid.mlir
+++ b/mlir/test/Dialect/Shape/invalid.mlir
@@ -166,6 +166,16 @@ func.func @broadcast(%arg0 : !shape.shape, %arg1 : tensor<?xindex>) -> tensor<?x
 
 // -----
 
+func.func @broadcast_error_in_attr_dict(%arg0 : !shape.shape,
+                                        %arg1 : !shape.shape) {
+  // expected-error@+1 {{inherent attribute 'error' cannot be parsed from attr-dict when strict properties in assembly format is enabled}}
+  %result = shape.broadcast %arg0, %arg1 {error = "incompatible shapes"}
+      : !shape.shape, !shape.shape -> !shape.shape
+  return
+}
+
+// -----
+
 // Test using an unsupported shape.lib attribute type.
 
 // expected-error@+1 {{only SymbolRefAttr allowed in shape.lib attribute array}}
@@ -300,4 +310,3 @@ func.func @invalid_meet(%arg0 : tensor<2xindex>, %arg1 : tensor<3xindex>) -> ten
   %result = shape.meet %arg0, %arg1 : tensor<2xindex>, tensor<3xindex> -> tensor<?xindex>
   return %result : tensor<?xindex>
 }
-

--- a/mlir/test/Dialect/Shape/ops.mlir
+++ b/mlir/test/Dialect/Shape/ops.mlir
@@ -54,6 +54,16 @@ func.func @test_broadcast_fixed() {
   return
 }
 
+// CHECK-LABEL: @test_broadcast_error
+// CHECK: shape.broadcast %{{.*}}, %{{.*}} error = "incompatible shapes"
+func.func @test_broadcast_error() {
+  %0 = shape.const_shape [10, 1, 57, 92] : !shape.shape
+  %1 = shape.const_shape [4, 57, 92] : !shape.shape
+  %2 = shape.broadcast %0, %1 error = "incompatible shapes"
+      : !shape.shape, !shape.shape -> !shape.shape
+  return
+}
+
 func.func @test_broadcast_extents() -> tensor<4xindex> {
   %0 = shape.const_shape [10, 1, 57, 92] : tensor<4xindex>
   %1 = shape.const_shape [4, 57, 92] : tensor<3xindex>
@@ -347,4 +357,3 @@ func.func @meet_index(%arg0 : index, %arg1 : index) -> index {
   %result = shape.meet %arg0, %arg1 : index, index -> index
   return %result : index
 }
-


### PR DESCRIPTION
Enable the strict properties assembly format mode for the Shape dialect.

Bind the broadcast diagnostic attribute directly. Keep its optional clause unambiguous after variadic operands, and cover the custom and rejected attr-dict spellings.

Assisted-by: Codex