### PR TITLE
[mlir][SparseTensor] Use explicit attribute APIs

### DIFF
--- a/mlir/lib/Dialect/SparseTensor/IR/SparseTensorDialect.cpp
+++ b/mlir/lib/Dialect/SparseTensor/IR/SparseTensorDialect.cpp
@@ -1799,7 +1799,7 @@ static LogicalResult verifyNumBlockArgs(T *op, Region &region,
 }
 
 LogicalResult BinaryOp::verify() {
-  NamedAttrList attrs = (*this)->getAttrs();
+  NamedAttrList attrs = (*this)->getDiscardableAttrDictionary().getValue();
   Type leftType = getX().getType();
   Type rightType = getY().getType();
   Type outputType = getOutput().getType();

--- a/mlir/lib/Dialect/SparseTensor/Transforms/SparseAssembler.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/SparseAssembler.cpp
@@ -233,12 +233,13 @@ struct SparseFuncAssembler : public OpRewritePattern<func::FuncOp> {
     func::ReturnOp::create(rewriter, loc, outputs);
 
     // Finally, migrate a potential c-interface property.
-    if (funcOp->getAttrOfType<UnitAttr>(
+    if (funcOp->getDiscardableAttrOfType<UnitAttr>(
             LLVM::LLVMDialect::getEmitCWrapperAttrName())) {
-      func->setAttr(LLVM::LLVMDialect::getEmitCWrapperAttrName(),
-                    UnitAttr::get(context));
+      func->setDiscardableAttr(LLVM::LLVMDialect::getEmitCWrapperAttrName(),
+                               UnitAttr::get(context));
       rewriter.modifyOpInPlace(funcOp, [&]() {
-        funcOp->removeAttr(LLVM::LLVMDialect::getEmitCWrapperAttrName());
+        funcOp->removeDiscardableAttr(
+            LLVM::LLVMDialect::getEmitCWrapperAttrName());
       });
     }
     return success();

--- a/mlir/lib/Dialect/SparseTensor/Transforms/SparseGPUCodegen.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/SparseGPUCodegen.cpp
@@ -50,8 +50,8 @@ enum class CuSparseFormat {
 
 /// Marks the given top module as a GPU container module.
 static void markAsGPUContainer(ModuleOp topModule) {
-  topModule->setAttr(gpu::GPUDialect::getContainerModuleAttrName(),
-                     UnitAttr::get(topModule->getContext()));
+  topModule->setDiscardableAttr(gpu::GPUDialect::getContainerModuleAttrName(),
+                                UnitAttr::get(topModule->getContext()));
 }
 
 /// Constructs a new GPU module (for GPU kernels) inside the given top module,
@@ -1189,7 +1189,8 @@ struct ForallRewriter : public OpRewritePattern<scf::ParallelOp> {
     // of the form
     //   forall (i = 0; i < N; i++)
     // so that cyclic scheduling over the threads is easy.
-    if (!forallOp->hasAttr(LoopEmitter::getLoopEmitterLoopAttrName()) ||
+    if (!forallOp->hasDiscardableAttr(
+            LoopEmitter::getLoopEmitterLoopAttrName()) ||
         forallOp.getNumReductions() != 0 || forallOp.getNumLoops() != 1 ||
         !matchPattern(forallOp.getLowerBound()[0], m_Zero()) ||
         !matchPattern(forallOp.getStep()[0], m_One()))

--- a/mlir/lib/Dialect/SparseTensor/Transforms/SparseReinterpretMap.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/SparseReinterpretMap.cpp
@@ -426,7 +426,7 @@ struct GenericOpScheduler : public OpRewritePattern<linalg::GenericOp> {
     }
 
     const StringRef sorted = "sorted";
-    if (linalgOp->hasAttr(sorted))
+    if (linalgOp->hasDiscardableAttr(sorted))
       return failure();
 
     // Pass strategy to IterationGraphSorter.
@@ -468,7 +468,7 @@ struct GenericOpScheduler : public OpRewritePattern<linalg::GenericOp> {
 
     // Marks the GenericOp to avoid recursive matching.
     rewriter.modifyOpInPlace(linalgOp, [&]() {
-      linalgOp->setAttr(sorted, rewriter.getBoolAttr(true));
+      linalgOp->setDiscardableAttr(sorted, rewriter.getBoolAttr(true));
     });
 
     // Already sorted.

--- a/mlir/lib/Dialect/SparseTensor/Transforms/SparseVectorization.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/SparseVectorization.cpp
@@ -585,9 +585,9 @@ static bool vectorizeStmt(PatternRewriter &rewriter, scf::ForOp forOp, VL vl,
           scf::ForOp::create(rewriter, loc, forOp.getLowerBound(),
                              forOp.getUpperBound(), step, vinit,
                              /*bodyBuilder=*/nullptr, forOp.getUnsignedCmp());
-      forOpNew->setAttr(
+      forOpNew->setDiscardableAttr(
           LoopEmitter::getLoopEmitterLoopAttrName(),
-          forOp->getAttr(LoopEmitter::getLoopEmitterLoopAttrName()));
+          forOp->getDiscardableAttr(LoopEmitter::getLoopEmitterLoopAttrName()));
       rewriter.setInsertionPointToStart(forOpNew.getBody());
     } else {
       rewriter.modifyOpInPlace(forOp, [&]() { forOp.setStep(step); });
@@ -666,7 +666,7 @@ public:
     // sparsifier, which means no data dependence analysis is required,
     // and its loop-body is very restricted in form.
     if (!op.getRegion().hasOneBlock() || !isOneInteger(op.getStep()) ||
-        !op->hasAttr(LoopEmitter::getLoopEmitterLoopAttrName()))
+        !op->hasDiscardableAttr(LoopEmitter::getLoopEmitterLoopAttrName()))
       return failure();
     // Analyze (!codegen) and rewrite (codegen) loop-body.
     if (vectorizeStmt(rewriter, op, vl, /*codegen=*/false) &&
@@ -683,7 +683,8 @@ static LogicalResult cleanReducChain(PatternRewriter &rewriter, Operation *op,
                                      Value inp) {
   if (auto redOp = inp.getDefiningOp<vector::ReductionOp>()) {
     if (auto forOp = redOp.getVector().getDefiningOp<scf::ForOp>()) {
-      if (forOp->hasAttr(LoopEmitter::getLoopEmitterLoopAttrName())) {
+      if (forOp->hasDiscardableAttr(
+              LoopEmitter::getLoopEmitterLoopAttrName())) {
         rewriter.replaceOp(op, redOp.getVector());
         return success();
       }

--- a/mlir/lib/Dialect/SparseTensor/Transforms/Sparsification.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/Sparsification.cpp
@@ -876,7 +876,7 @@ static void finalizeWhileOp(CodegenEnv &env, OpBuilder &builder,
     while (auto ifOp = dyn_cast_or_null<scf::IfOp>(
                builder.getInsertionBlock()->getParentOp())) {
       // Break on IfOp for slicing filtering.
-      if (ifOp->getAttr(LoopEmitter::getLoopEmitterLoopAttrName()) ==
+      if (ifOp->getDiscardableAttr(LoopEmitter::getLoopEmitterLoopAttrName()) ==
           StringAttr::get(ifOp->getContext(), "slice"))
         break;
 
@@ -1411,7 +1411,7 @@ public:
       return failure();
 
     // Only accept scheduled loops.
-    if (!op->hasAttr("sorted")) {
+    if (!op->hasDiscardableAttr("sorted")) {
       return rewriter.notifyMatchFailure(
           op, "Loops not yet scheduled, try run --sparse-reinterpret-map "
               "before sparsification.");

--- a/mlir/lib/Dialect/SparseTensor/Transforms/Utils/CodegenUtils.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/Utils/CodegenUtils.cpp
@@ -332,8 +332,8 @@ FlatSymbolRefAttr mlir::sparse_tensor::getFunc(ModuleOp module, StringRef name,
         FunctionType::get(context, operands.getTypes(), resultType));
     func.setPrivate();
     if (static_cast<bool>(emitCInterface))
-      func->setAttr(LLVM::LLVMDialect::getEmitCWrapperAttrName(),
-                    UnitAttr::get(context));
+      func->setDiscardableAttr(LLVM::LLVMDialect::getEmitCWrapperAttrName(),
+                               UnitAttr::get(context));
   }
   return result;
 }

--- a/mlir/lib/Dialect/SparseTensor/Transforms/Utils/LoopEmitter.h
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/Utils/LoopEmitter.h
@@ -257,7 +257,8 @@ private:
         : tidLvls(tidLvls), loop(loop), userCodeBlock(userBlock), iv(iv) {
       // Attached a special tag to loop emitter generated loop.
       if (loopTag)
-        loop->setAttr(LoopEmitter::getLoopEmitterLoopAttrName(), loopTag);
+        loop->setDiscardableAttr(LoopEmitter::getLoopEmitterLoopAttrName(),
+                                 loopTag);
     }
     // The set of <tensor, lvl>, with *only* trivial index expressions, that are
     // used as the condition for the generated loop. Extra information is


### PR DESCRIPTION
Migrate SparseTensor IR, lowering, code generation, and loop emission to explicit discardable or operation-specific attribute access.

Assisted-by: Codex