### PR TITLE
[mlir][Func][Async][EmitC] Use split discardable/inherent attribute APIs

### DIFF
--- a/mlir/include/mlir/Dialect/Async/IR/AsyncOps.td
+++ b/mlir/include/mlir/Dialect/Async/IR/AsyncOps.td
@@ -261,12 +261,12 @@ def Async_CallOp : Async_Op<"call",
 
     /// Return the callee of this operation.
     CallInterfaceCallable getCallableForCallee() {
-      return (*this)->getAttrOfType<SymbolRefAttr>("callee");
+      return getCalleeAttr();
     }
 
     /// Set the callee for this operation.
     void setCalleeFromCallable(CallInterfaceCallable callee) {
-      (*this)->setAttr("callee", cast<SymbolRefAttr>(callee));
+      setCalleeAttr(cast<FlatSymbolRefAttr>(cast<SymbolRefAttr>(callee)));
     }
   }];
 

--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -794,12 +794,12 @@ def EmitC_CallOp : EmitC_Op<"call",
 
     /// Return the callee of this operation.
     CallInterfaceCallable getCallableForCallee() {
-      return (*this)->getAttrOfType<SymbolRefAttr>("callee");
+      return getCalleeAttr();
     }
 
     /// Set the callee for this operation.
     void setCalleeFromCallable(CallInterfaceCallable callee) {
-      (*this)->setAttr("callee", cast<SymbolRefAttr>(callee));
+      setCalleeAttr(cast<FlatSymbolRefAttr>(cast<SymbolRefAttr>(callee)));
     }
 
     bool hasSideEffects() {

--- a/mlir/include/mlir/Dialect/Func/IR/FuncOps.td
+++ b/mlir/include/mlir/Dialect/Func/IR/FuncOps.td
@@ -110,12 +110,12 @@ def CallOp : Func_Op<"call",
 
     /// Return the callee of this operation.
     CallInterfaceCallable getCallableForCallee() {
-      return (*this)->getAttrOfType<SymbolRefAttr>("callee");
+      return getCalleeAttr();
     }
 
     /// Set the callee for this operation.
     void setCalleeFromCallable(CallInterfaceCallable callee) {
-      (*this)->setAttr("callee", cast<SymbolRefAttr>(callee));
+      setCalleeAttr(cast<FlatSymbolRefAttr>(cast<SymbolRefAttr>(callee)));
     }
   }];
 

--- a/mlir/lib/Conversion/FuncToEmitC/FuncToEmitC.cpp
+++ b/mlir/lib/Conversion/FuncToEmitC/FuncToEmitC.cpp
@@ -188,9 +188,12 @@ public:
     }
 
     if (callOp.getNumResults() <= 1) {
-      rewriter.replaceOpWithNewOp<emitc::CallOp>(callOp, convertedResultTypes,
-                                                 adaptor.getOperands(),
-                                                 callOp->getAttrs());
+      auto newCall = rewriter.replaceOpWithNewOp<emitc::CallOp>(
+          callOp, callOp.getCalleeAttr(), convertedResultTypes,
+          adaptor.getOperands());
+      newCall.setArgAttrsAttr(callOp.getArgAttrsAttr());
+      newCall.setResAttrsAttr(callOp.getResAttrsAttr());
+      newCall->setDiscardableAttrs(callOp->getDiscardableAttrDictionary());
       return success();
     }
 
@@ -292,11 +295,19 @@ public:
                           signatureConverter.getConvertedTypes(),
                           resultType ? TypeRange(resultType) : TypeRange()));
 
+    newFuncOp.setArgAttrsAttr(funcOp.getArgAttrsAttr());
+    newFuncOp.setResAttrsAttr(funcOp.getResAttrsAttr());
+    if (StringAttr visibility = funcOp.getSymVisibilityAttr())
+      newFuncOp->setDiscardableAttr(SymbolTable::getVisibilityAttrName(),
+                                    visibility);
+
     // Copy over all attributes other than the function name and type.
-    for (const auto &namedAttr : funcOp->getAttrs()) {
+    for (const auto &namedAttr :
+         funcOp->getDiscardableAttrDictionary().getValue()) {
       if (namedAttr.getName() != funcOp.getFunctionTypeAttrName() &&
           namedAttr.getName() != SymbolTable::getSymbolAttrName())
-        newFuncOp->setAttr(namedAttr.getName(), namedAttr.getValue());
+        newFuncOp->setDiscardableAttr(namedAttr.getName(),
+                                      namedAttr.getValue());
     }
 
     // Add `extern` to specifiers if `func.func` is declaration only.

--- a/mlir/lib/Conversion/FuncToLLVM/FuncToLLVM.cpp
+++ b/mlir/lib/Conversion/FuncToLLVM/FuncToLLVM.cpp
@@ -58,7 +58,7 @@ static constexpr StringRef barePtrAttrName = "llvm.bareptr";
 /// Return `true` if the `op` should use bare pointer calling convention.
 static bool shouldUseBarePtrCallConv(Operation *op,
                                      const LLVMTypeConverter *typeConverter) {
-  return (op && op->hasAttr(barePtrAttrName)) ||
+  return (op && op->hasDiscardableAttr(barePtrAttrName)) ||
          typeConverter->getOptions().useBarePtrCallConv;
 }
 
@@ -71,7 +71,8 @@ static bool isDiscardableAttr(StringRef name) {
 /// `LLVMFuncOp::build`.
 static void filterFuncAttributes(FunctionOpInterface func,
                                  SmallVectorImpl<NamedAttribute> &result) {
-  for (const NamedAttribute &attr : func->getDiscardableAttrs()) {
+  for (const NamedAttribute &attr :
+       func->getDiscardableAttrDictionary().getValue()) {
     if (isDiscardableAttr(attr.getName().strref()))
       continue;
     result.push_back(attr);
@@ -298,7 +299,8 @@ static FailureOr<LLVM::LLVMFunctionType> convertFuncSignature(
     FunctionOpInterface funcOp, const LLVMTypeConverter &converter,
     bool useBarePtrCallConv, TypeConverter::SignatureConversion &result,
     SmallVectorImpl<std::optional<NamedAttribute>> &byValRefNonPtrAttrs) {
-  auto varargsAttr = funcOp->getAttrOfType<BoolAttr>(varargsAttrName);
+  auto varargsAttr =
+      funcOp->getDiscardableAttrOfType<BoolAttr>(varargsAttrName);
   auto llvmType = dyn_cast_or_null<LLVM::LLVMFunctionType>(
       converter.convertFunctionSignature(
           funcOp, varargsAttr && varargsAttr.getValue(), useBarePtrCallConv,
@@ -334,7 +336,7 @@ static LLVM::LLVMFuncOp createLLVMFuncOp(FunctionOpInterface funcOp,
       .setVisibility(funcOp.getVisibility());
 
   // Set readnone memory effects
-  if (funcOp->hasAttr(LLVM::LLVMDialect::getReadnoneAttrName())) {
+  if (funcOp->hasDiscardableAttr(LLVM::LLVMDialect::getReadnoneAttrName())) {
     auto memoryAttr = LLVM::MemoryEffectsAttr::get(
         rewriter.getContext(), {/*other=*/LLVM::ModRefInfo::NoModRef,
                                 /*argMem=*/LLVM::ModRefInfo::NoModRef,
@@ -466,7 +468,7 @@ FailureOr<LLVM::LLVMFuncOp> mlir::convertFuncOpToLLVMFuncOp(
     return rewriter.notifyMatchFailure(funcOp, "signature conversion failed");
 
   // Validate C wrapper varargs constraint
-  bool emitCWrapper = funcOp->hasAttrOfType<UnitAttr>(
+  bool emitCWrapper = funcOp->hasDiscardableAttrOfType<UnitAttr>(
       LLVM::LLVMDialect::getEmitCWrapperAttrName());
   if (!useBarePtrCallConv && emitCWrapper && llvmType->isVarArg())
     return funcOp.emitError("C interface for variadic functions is not "
@@ -549,10 +551,11 @@ struct ConstantOpLowering : public ConvertOpToLLVMPattern<func::ConstantOp> {
 
     auto newOp =
         LLVM::AddressOfOp::create(rewriter, op.getLoc(), type, op.getValue());
-    for (const NamedAttribute &attr : op->getAttrs()) {
+    for (const NamedAttribute &attr :
+         op->getDiscardableAttrDictionary().getValue()) {
       if (attr.getName().strref() == "value")
         continue;
-      newOp->setAttr(attr.getName(), attr.getValue());
+      newOp->setDiscardableAttr(attr.getName(), attr.getValue());
     }
     rewriter.replaceOp(op, newOp->getResults());
     return success();
@@ -597,10 +600,12 @@ struct CallOpInterfaceLowering : public ConvertOpToLLVMPattern<CallOpType> {
     auto promoted = this->getTypeConverter()->promoteOperands(
         callOp.getLoc(), /*opOperands=*/callOp->getOperands(),
         adaptor.getOperands(), rewriter, useBarePtrCallConv);
-    auto newOp = LLVM::CallOp::create(rewriter, callOp.getLoc(),
-                                      packedResult ? TypeRange(packedResult)
-                                                   : TypeRange(),
-                                      promoted, callOp->getAttrs());
+    auto newOp = LLVM::CallOp::create(
+        rewriter, callOp.getLoc(),
+        packedResult ? TypeRange(packedResult) : TypeRange(), promoted,
+        callOp->getDiscardableAttrDictionary().getValue());
+    if constexpr (std::is_same_v<CallOpType, func::CallOp>)
+      newOp.setCalleeAttr(callOp.getCalleeAttr());
 
     newOp.getProperties().operandSegmentSizes = {
         static_cast<int32_t>(promoted.size()), 0};
@@ -687,13 +692,13 @@ public:
       Operation *callee =
           symbolTables->lookupNearestSymbolFrom(callOp, callOp.getCalleeAttr());
       useBarePtrCallConv =
-          callee != nullptr && callee->hasAttr(barePtrAttrName);
+          callee != nullptr && callee->hasDiscardableAttr(barePtrAttrName);
     } else {
       // Warning: This is a linear lookup.
       Operation *callee =
           SymbolTable::lookupNearestSymbolFrom(callOp, callOp.getCalleeAttr());
       useBarePtrCallConv =
-          callee != nullptr && callee->hasAttr(barePtrAttrName);
+          callee != nullptr && callee->hasDiscardableAttr(barePtrAttrName);
     }
     return matchAndRewriteImpl(callOp, adaptor, rewriter, useBarePtrCallConv);
   }
@@ -795,7 +800,8 @@ struct ReturnOpLowering : public ConvertOpToLLVMPattern<func::ReturnOp> {
     // If ReturnOp has 0 or 1 operand, create it and return immediately.
     if (updatedOperands.size() <= 1) {
       rewriter.replaceOpWithNewOp<LLVM::ReturnOp>(
-          op, TypeRange(), updatedOperands, op->getAttrs());
+          op, TypeRange(), updatedOperands,
+          op->getDiscardableAttrDictionary().getValue());
       return success();
     }
 
@@ -811,8 +817,8 @@ struct ReturnOpLowering : public ConvertOpToLLVMPattern<func::ReturnOp> {
     for (auto [idx, operand] : llvm::enumerate(updatedOperands)) {
       packed = LLVM::InsertValueOp::create(rewriter, loc, packed, operand, idx);
     }
-    rewriter.replaceOpWithNewOp<LLVM::ReturnOp>(op, TypeRange(), packed,
-                                                op->getAttrs());
+    rewriter.replaceOpWithNewOp<LLVM::ReturnOp>(
+        op, TypeRange(), packed, op->getDiscardableAttrDictionary().getValue());
     return success();
   }
 };
@@ -845,7 +851,7 @@ struct ConvertFuncToLLVMPass
     ModuleOp m = getOperation();
     StringRef dataLayout;
     auto dataLayoutAttr = dyn_cast_or_null<StringAttr>(
-        m->getAttr(LLVM::LLVMDialect::getDataLayoutAttrName()));
+        m->getDiscardableAttr(LLVM::LLVMDialect::getDataLayoutAttrName()));
     if (dataLayoutAttr)
       dataLayout = dataLayoutAttr.getValue();
 
@@ -896,8 +902,8 @@ struct SetLLVMModuleDataLayoutPass
       return;
     }
     ModuleOp m = getOperation();
-    m->setAttr(LLVM::LLVMDialect::getDataLayoutAttrName(),
-               StringAttr::get(m.getContext(), this->dataLayout));
+    m->setDiscardableAttr(LLVM::LLVMDialect::getDataLayoutAttrName(),
+                          StringAttr::get(m.getContext(), this->dataLayout));
   }
 };
 } // namespace

--- a/mlir/lib/Conversion/MathToFuncs/MathToFuncs.cpp
+++ b/mlir/lib/Conversion/MathToFuncs/MathToFuncs.cpp
@@ -197,7 +197,7 @@ static func::FuncOp createElementIPowIFunc(ModuleOp *module, Type elementType) {
   LLVM::linkage::Linkage inlineLinkage = LLVM::linkage::Linkage::LinkonceODR;
   Attribute linkage =
       LLVM::LinkageAttr::get(builder.getContext(), inlineLinkage);
-  funcOp->setAttr("llvm.linkage", linkage);
+  funcOp->setDiscardableAttr("llvm.linkage", linkage);
   funcOp.setPrivate();
 
   Block *entryBlock = funcOp.addEntryBlock();
@@ -424,7 +424,7 @@ static func::FuncOp createElementFPowIFunc(ModuleOp *module,
   LLVM::linkage::Linkage inlineLinkage = LLVM::linkage::Linkage::LinkonceODR;
   Attribute linkage =
       LLVM::LinkageAttr::get(builder.getContext(), inlineLinkage);
-  funcOp->setAttr("llvm.linkage", linkage);
+  funcOp->setDiscardableAttr("llvm.linkage", linkage);
   funcOp.setPrivate();
 
   Block *entryBlock = funcOp.addEntryBlock();
@@ -674,7 +674,7 @@ static func::FuncOp createCtlzFunc(ModuleOp *module, Type elementType) {
   LLVM::linkage::Linkage inlineLinkage = LLVM::linkage::Linkage::LinkonceODR;
   Attribute linkage =
       LLVM::LinkageAttr::get(builder.getContext(), inlineLinkage);
-  funcOp->setAttr("llvm.linkage", linkage);
+  funcOp->setDiscardableAttr("llvm.linkage", linkage);
   funcOp.setPrivate();
 
   // set the insertion point to the start of the function

--- a/mlir/lib/Conversion/MathToLibm/MathToLibm.cpp
+++ b/mlir/lib/Conversion/MathToLibm/MathToLibm.cpp
@@ -150,8 +150,8 @@ ScalarOpToLibmCall<Op>::matchAndRewrite(Op op,
     // optimization opportunities (e.g. LICM) for backends targeting LLVM IR.
     // This will have to be changed, when strict FP behavior is supported
     // by Math dialect.
-    opFunc->setAttr(LLVM::LLVMDialect::getReadnoneAttrName(),
-                    UnitAttr::get(rewriter.getContext()));
+    opFunc->setDiscardableAttr(LLVM::LLVMDialect::getReadnoneAttrName(),
+                               UnitAttr::get(rewriter.getContext()));
   }
   assert(isa<FunctionOpInterface>(SymbolTable::lookupSymbolIn(module, name)));
 

--- a/mlir/lib/Dialect/Async/IR/Async.cpp
+++ b/mlir/lib/Dialect/Async/IR/Async.cpp
@@ -127,8 +127,9 @@ void ExecuteOp::print(OpAsmPrinter &p) {
 
   // -> (!async.value<!return.type>, ...)
   p.printOptionalArrowTypeList(llvm::drop_begin(getResultTypes()));
-  p.printOptionalAttrDictWithKeyword((*this)->getAttrs(),
-                                     {kOperandSegmentSizesAttr});
+  p.printOptionalAttrDictWithKeyword(
+      (*this)->getDiscardableAttrDictionary().getValue(),
+      {kOperandSegmentSizesAttr});
   p << ' ';
   p.printRegion(getBodyRegion(), /*printEntryBlockArgs=*/false);
 }
@@ -367,7 +368,7 @@ LogicalResult FuncOp::verify() {
 
 LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   // Check that the callee attribute was specified.
-  auto fnAttr = (*this)->getAttrOfType<FlatSymbolRefAttr>("callee");
+  auto fnAttr = getCalleeAttr();
   if (!fnAttr)
     return emitOpError("requires a 'callee' symbol reference attribute");
   FuncOp fn = symbolTable.lookupNearestSymbolFrom<FuncOp>(*this, fnAttr);

--- a/mlir/lib/Dialect/Async/Transforms/AsyncToAsyncRuntime.cpp
+++ b/mlir/lib/Dialect/Async/Transforms/AsyncToAsyncRuntime.cpp
@@ -244,8 +244,9 @@ static CoroMachinery setupCoroMachinery(func::FuncOp func) {
 
   // The switch-resumed API based coroutine should be marked with
   // presplitcoroutine attribute to mark the function as a coroutine.
-  func->setAttr("llvm.passthrough", builder.getArrayAttr(StringAttr::get(
-                                        ctx, "presplitcoroutine")));
+  func->setDiscardableAttr(
+      "llvm.passthrough",
+      builder.getArrayAttr(StringAttr::get(ctx, "presplitcoroutine")));
 
   CoroMachinery machinery;
   machinery.func = func;
@@ -475,9 +476,11 @@ public:
     SymbolTable::setSymbolVisibility(newFuncOp,
                                      SymbolTable::getSymbolVisibility(op));
     // Copy over all attributes other than the name.
-    for (const auto &namedAttr : op->getAttrs()) {
+    for (const auto &namedAttr :
+         op->getDiscardableAttrDictionary().getValue()) {
       if (namedAttr.getName() != SymbolTable::getSymbolAttrName())
-        newFuncOp->setAttr(namedAttr.getName(), namedAttr.getValue());
+        newFuncOp->setDiscardableAttr(namedAttr.getName(),
+                                      namedAttr.getValue());
     }
 
     rewriter.inlineRegionBefore(op.getBody(), newFuncOp.getBody(),

--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -717,7 +717,7 @@ void ForOp::print(OpAsmPrinter &p) {
   p.printRegion(getRegion(),
                 /*printEntryBlockArgs=*/false,
                 /*printBlockTerminators=*/false);
-  p.printOptionalAttrDict((*this)->getAttrs());
+  p.printOptionalAttrDict((*this)->getDiscardableAttrDictionary().getValue());
 }
 
 LogicalResult ForOp::verifyRegions() {
@@ -740,7 +740,7 @@ LogicalResult ForOp::verifyRegions() {
 
 LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   // Check that the callee attribute was specified.
-  auto fnAttr = (*this)->getAttrOfType<FlatSymbolRefAttr>("callee");
+  auto fnAttr = getCalleeAttr();
   if (!fnAttr)
     return emitOpError("requires a 'callee' symbol reference attribute");
   FuncOp fn = symbolTable.lookupNearestSymbolFrom<FuncOp>(*this, fnAttr);
@@ -955,7 +955,7 @@ void IfOp::print(OpAsmPrinter &p) {
                   /*printBlockTerminators=*/printBlockTerminators);
   }
 
-  p.printOptionalAttrDict((*this)->getAttrs());
+  p.printOptionalAttrDict((*this)->getDiscardableAttrDictionary().getValue());
 }
 
 /// Given the region at `index`, or the parent operation if `index` is None,
@@ -1747,7 +1747,8 @@ void DoOp::print(OpAsmPrinter &p) {
   p.printRegion(getBodyRegion(), /*printEntryBlockArgs=*/false);
   p << " while ";
   p.printRegion(getConditionRegion());
-  p.printOptionalAttrDictWithKeyword(getOperation()->getAttrs());
+  p.printOptionalAttrDictWithKeyword(
+      getOperation()->getDiscardableAttrDictionary().getValue());
 }
 
 LogicalResult emitc::DoOp::verify() {

--- a/mlir/lib/Dialect/EmitC/Transforms/MLGOAddReflectionMap.cpp
+++ b/mlir/lib/Dialect/EmitC/Transforms/MLGOAddReflectionMap.cpp
@@ -147,7 +147,8 @@ public:
     std::vector<std::pair<StringRef, StringRef>> fieldNames;
     classOp.walk([&](FieldOp fieldOp) {
       for (const auto &attr : includedFieldAttrs) {
-        auto arrayAttr = dyn_cast_if_present<ArrayAttr>(fieldOp->getAttr(attr));
+        auto arrayAttr =
+            dyn_cast_if_present<ArrayAttr>(fieldOp->getDiscardableAttr(attr));
 
         if (!arrayAttr)
           continue;

--- a/mlir/lib/Dialect/Func/IR/FuncOps.cpp
+++ b/mlir/lib/Dialect/Func/IR/FuncOps.cpp
@@ -62,7 +62,7 @@ Operation *FuncDialect::materializeConstant(OpBuilder &builder, Attribute value,
 
 LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   // Check that the callee attribute was specified.
-  auto fnAttr = (*this)->getAttrOfType<FlatSymbolRefAttr>("callee");
+  auto fnAttr = getCalleeAttr();
   if (!fnAttr)
     return emitOpError("requires a 'callee' symbol reference attribute");
   FuncOp fn = symbolTable.lookupNearestSymbolFrom<FuncOp>(*this, fnAttr);
@@ -196,16 +196,16 @@ void FuncOp::print(OpAsmPrinter &p) {
 void FuncOp::cloneInto(FuncOp dest, IRMapping &mapper) {
   // Add the attributes of this function to dest.
   llvm::MapVector<StringAttr, Attribute> newAttrMap;
-  for (const auto &attr : dest->getAttrs())
+  for (const auto &attr : dest->getDiscardableAttrDictionary().getValue())
     newAttrMap.insert({attr.getName(), attr.getValue()});
-  for (const auto &attr : (*this)->getAttrs())
+  for (const auto &attr : (*this)->getDiscardableAttrDictionary().getValue())
     newAttrMap.insert({attr.getName(), attr.getValue()});
 
   auto newAttrs = llvm::map_to_vector(
       newAttrMap, [](std::pair<StringAttr, Attribute> attrPair) {
         return NamedAttribute(attrPair.first, attrPair.second);
       });
-  dest->setAttrs(DictionaryAttr::get(getContext(), newAttrs));
+  dest->setDiscardableAttrs(DictionaryAttr::get(getContext(), newAttrs));
 
   // Clone the body.
   getBody().cloneInto(&dest.getBody(), mapper);

--- a/mlir/lib/Dialect/Func/Transforms/DuplicateFunctionElimination.cpp
+++ b/mlir/lib/Dialect/Func/Transforms/DuplicateFunctionElimination.cpp
@@ -31,7 +31,8 @@ struct DuplicateFuncOpEquivalenceInfo
     llvm::hash_code hash = {};
     func::FuncOp func = const_cast<func::FuncOp &>(cFunc);
     StringAttr symNameAttrName = func.getSymNameAttrName();
-    for (NamedAttribute namedAttr : cFunc->getAttrs()) {
+    for (NamedAttribute namedAttr :
+         cFunc->getDiscardableAttrDictionary().getValue()) {
       StringAttr attrName = namedAttr.getName();
       if (attrName == symNameAttrName)
         continue;


### PR DESCRIPTION
Use operation-specific accessors and explicit discardable attribute APIs in the Func, Async, and EmitC dialects and their associated conversions.

Assisted-by: Codex