### PR TITLE
[lldb][API] Fix SBEnvironment crash when Set is called with a nullptr.

### DIFF
--- a/lldb/source/API/SBEnvironment.cpp
+++ b/lldb/source/API/SBEnvironment.cpp
@@ -76,6 +76,9 @@ bool SBEnvironment::Set(const char *name, const char *value, bool overwrite) {
   LLDB_INSTRUMENT_VA(this, name, value, overwrite);
 
   llvm::StringRef name_ref{name};
+  if (name_ref.trim().empty())
+    return false;
+
   llvm::StringRef value_ref{value};
   if (overwrite) {
     m_opaque_up->insert_or_assign(name_ref, value_ref.str());
@@ -86,6 +89,10 @@ bool SBEnvironment::Set(const char *name, const char *value, bool overwrite) {
 
 bool SBEnvironment::Unset(const char *name) {
   LLDB_INSTRUMENT_VA(this, name);
+
+  llvm::StringRef name_ref{name};
+  if (name_ref.trim().empty())
+    return false;
 
   return m_opaque_up->erase(llvm::StringRef(name));
 }

--- a/lldb/source/API/SBEnvironment.cpp
+++ b/lldb/source/API/SBEnvironment.cpp
@@ -75,17 +75,19 @@ const char *SBEnvironment::GetValueAtIndex(size_t index) {
 bool SBEnvironment::Set(const char *name, const char *value, bool overwrite) {
   LLDB_INSTRUMENT_VA(this, name, value, overwrite);
 
+  llvm::StringRef name_ref{name};
+  llvm::StringRef value_ref{value};
   if (overwrite) {
-    m_opaque_up->insert_or_assign(name, std::string(value));
+    m_opaque_up->insert_or_assign(name_ref, value_ref.str());
     return true;
   }
-  return m_opaque_up->try_emplace(name, std::string(value)).second;
+  return m_opaque_up->try_emplace(name_ref, value_ref.str()).second;
 }
 
 bool SBEnvironment::Unset(const char *name) {
   LLDB_INSTRUMENT_VA(this, name);
 
-  return m_opaque_up->erase(name);
+  return m_opaque_up->erase(llvm::StringRef(name));
 }
 
 SBStringList SBEnvironment::GetEntries() {

--- a/lldb/source/API/SBEnvironment.cpp
+++ b/lldb/source/API/SBEnvironment.cpp
@@ -94,7 +94,7 @@ bool SBEnvironment::Unset(const char *name) {
   if (name_ref.trim().empty())
     return false;
 
-  return m_opaque_up->erase(llvm::StringRef(name));
+  return m_opaque_up->erase(name_ref);
 }
 
 SBStringList SBEnvironment::GetEntries() {

--- a/lldb/unittests/API/CMakeLists.txt
+++ b/lldb/unittests/API/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_lldb_unittest(APITests
   SBCommandInterpreterTest.cpp
+  SBEnvironmentTest.cpp
   SBLineEntryTest.cpp
   SBMutexTest.cpp
   SBBreakpointClearConditionTest.cpp

--- a/lldb/unittests/API/SBEnvironmentTest.cpp
+++ b/lldb/unittests/API/SBEnvironmentTest.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===/
 
+// Use the umbrella header for -Wdocumentation.
+#include "lldb/API/LLDB.h"
+
 #include "lldb/API/SBEnvironment.h"
 #include "gtest/gtest.h"
 

--- a/lldb/unittests/API/SBEnvironmentTest.cpp
+++ b/lldb/unittests/API/SBEnvironmentTest.cpp
@@ -1,0 +1,25 @@
+//===-- SBEnvironment.cpp -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===/
+
+#include "lldb/API/SBEnvironment.h"
+#include "gtest/gtest.h"
+
+TEST(SBEnvironmentTest, SetAndGetEnv) {
+
+  lldb::SBEnvironment env{};
+
+  // Setting an env var without a value does not crash.
+  env.Set("FOO", nullptr, false);
+  const char *foo_val = env.Get("FOO");
+  EXPECT_STREQ(foo_val, "");
+
+  env.Set("BAR", "BAR_VALUE", true);
+  env.Set("BAR", nullptr, true);
+  const char *bar_val = env.Get("BAR");
+  EXPECT_STREQ(bar_val, "") << "'BAR' should return the most recent value";
+}

--- a/lldb/unittests/API/SBEnvironmentTest.cpp
+++ b/lldb/unittests/API/SBEnvironmentTest.cpp
@@ -14,12 +14,20 @@ TEST(SBEnvironmentTest, SetAndGetEnv) {
   lldb::SBEnvironment env{};
 
   // Setting an env var without a value does not crash.
-  env.Set("FOO", nullptr, false);
+  EXPECT_TRUE(env.Set("FOO", nullptr, false));
   const char *foo_val = env.Get("FOO");
   EXPECT_STREQ(foo_val, "");
 
-  env.Set("BAR", "BAR_VALUE", true);
-  env.Set("BAR", nullptr, true);
+  EXPECT_TRUE(env.Set("BAR", "BAR_VALUE", true));
+  EXPECT_TRUE(env.Set("BAR", nullptr, true));
   const char *bar_val = env.Get("BAR");
   EXPECT_STREQ(bar_val, "") << "'BAR' should return the most recent value";
+
+  EXPECT_FALSE(env.Set(nullptr, "VALUE", true));
+  EXPECT_FALSE(env.Set("", "VALUE", true));
+  EXPECT_FALSE(env.Set(" ", "VALUE", true));
+
+  EXPECT_FALSE(env.Get(nullptr));
+  EXPECT_FALSE(env.Get(""));
+  EXPECT_FALSE(env.Get(" "));
 }


### PR DESCRIPTION
Crashed because std::string is constructed with a nullptr. Wrap with `llvm::StringRef`.

Add a unittest