### PR TITLE
[mlir][Tosa] Use split discardable/inherent attribute APIs

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/Utils/ConversionUtils.h
+++ b/mlir/include/mlir/Dialect/Tosa/Utils/ConversionUtils.h
@@ -101,10 +101,10 @@ TosaOp createOpAndInferShape(ImplicitLocOpBuilder &builder, Type resultTy,
 
   SmallVector<ShapedTypeComponents> returnedShapes;
   if (shapeInterface
-          .inferReturnTypeComponents(op.getContext(), builder.getLoc(),
-                                     op->getOperands(), op->getAttrDictionary(),
-                                     op->getPropertiesStorage(),
-                                     op->getRegions(), returnedShapes)
+          .inferReturnTypeComponents(
+              op.getContext(), builder.getLoc(), op->getOperands(),
+              op->getDiscardableAttrDictionary(), op->getPropertiesStorage(),
+              op->getRegions(), returnedShapes)
           .failed())
     return op;
 

--- a/mlir/lib/Conversion/TosaToLinalg/TosaToLinalg.cpp
+++ b/mlir/lib/Conversion/TosaToLinalg/TosaToLinalg.cpp
@@ -291,7 +291,7 @@ static Value createLinalgBodyCalculationForElementwiseOp(
   // tosa::ArithmeticRightShiftOp
   if (isa<tosa::ArithmeticRightShiftOp>(op) && isa<IntegerType>(elementTy)) {
     auto result = arith::ShRSIOp::create(rewriter, loc, resultTypes, args);
-    auto round = cast<BoolAttr>(op->getAttr("round")).getValue();
+    bool round = cast<tosa::ArithmeticRightShiftOp>(op).getRound();
     if (!round) {
       return result;
     }
@@ -451,8 +451,9 @@ static Value createLinalgBodyCalculationForElementwiseOp(
   // tosa::ClampOp
   if (isa<tosa::ClampOp>(op) && isa<FloatType>(elementTy)) {
     bool losesInfo = false;
-    APFloat minApf = cast<FloatAttr>(op->getAttr("min_val")).getValue();
-    APFloat maxApf = cast<FloatAttr>(op->getAttr("max_val")).getValue();
+    auto clampOp = cast<tosa::ClampOp>(op);
+    APFloat minApf = cast<FloatAttr>(clampOp.getMinValAttr()).getValue();
+    APFloat maxApf = cast<FloatAttr>(clampOp.getMaxValAttr()).getValue();
     minApf.convert(cast<FloatType>(elementTy).getFloatSemantics(),
                    APFloat::rmNearestTiesToEven, &losesInfo);
     maxApf.convert(cast<FloatType>(elementTy).getFloatSemantics(),
@@ -463,7 +464,6 @@ static Value createLinalgBodyCalculationForElementwiseOp(
         rewriter, loc, elementTy, rewriter.getFloatAttr(elementTy, maxApf));
     auto result = clampFloatHelper(loc, args[0], min, max, rewriter);
 
-    auto clampOp = llvm::cast<tosa::ClampOp>(op);
     const auto nanMode = clampOp.getNanMode();
 
     // NaN propagation has no meaning for non floating point types.
@@ -495,10 +495,11 @@ static Value createLinalgBodyCalculationForElementwiseOp(
 
   if (isa<tosa::ClampOp>(op) && isa<IntegerType>(elementTy)) {
     auto intTy = cast<IntegerType>(elementTy);
+    auto clampOp = cast<tosa::ClampOp>(op);
     int64_t min =
-        cast<IntegerAttr>(op->getAttr("min_val")).getValue().getSExtValue();
+        cast<IntegerAttr>(clampOp.getMinValAttr()).getValue().getSExtValue();
     int64_t max =
-        cast<IntegerAttr>(op->getAttr("max_val")).getValue().getSExtValue();
+        cast<IntegerAttr>(clampOp.getMaxValAttr()).getValue().getSExtValue();
 
     int64_t minRepresentable = std::numeric_limits<int64_t>::min();
     int64_t maxRepresentable = std::numeric_limits<int64_t>::max();

--- a/mlir/lib/Conversion/TosaToLinalg/TosaToLinalgNamed.cpp
+++ b/mlir/lib/Conversion/TosaToLinalg/TosaToLinalgNamed.cpp
@@ -445,9 +445,9 @@ public:
     Type inputETy = inputTy.getElementType();
     Type resultETy = resultTy.getElementType();
 
-    auto padAttr = cast<DenseI64ArrayAttr>(op->getAttr("pad"));
-    auto strideTosaAttr = cast<DenseI64ArrayAttr>(op->getAttr("stride"));
-    auto dilationTosaAttr = cast<DenseI64ArrayAttr>(op->getAttr("dilation"));
+    auto padAttr = op.getPadAttr();
+    auto strideTosaAttr = op.getStrideAttr();
+    auto dilationTosaAttr = op.getDilationAttr();
 
     Type accETy = op.getAccType();
 

--- a/mlir/lib/Dialect/Tosa/IR/TargetEnv.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TargetEnv.cpp
@@ -182,7 +182,8 @@ TargetEnvAttr lookupTargetEnv(Operation *op) {
     if (!op)
       break;
 
-    if (auto attr = op->getAttrOfType<TargetEnvAttr>(TargetEnvAttr::name))
+    if (auto attr =
+            op->getDiscardableAttrOfType<TargetEnvAttr>(TargetEnvAttr::name))
       return attr;
 
     op = op->getParentOp();

--- a/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
@@ -400,10 +400,12 @@ void printWithNanPropagationHandling(OpAsmPrinter &parser, Operation *op) {
   parser << " ";
   parser.printOperands(op->getOperands());
 
-  NamedAttrList toPrint(op->getAttrs());
+  NamedAttrList toPrint(op->getDiscardableAttrDictionary().getValue());
+  op->getName().walkInherentAttrs(
+      op, [&](StringRef name, Attribute &attr) { toPrint.append(name, attr); });
   // remove default NanPropagate attribute
   const auto kDefaultNanValue = NanPropagationMode::PROPAGATE;
-  for (auto attr : op->getAttrs()) {
+  for (auto attr : toPrint) {
     if (auto nanAttr = dyn_cast<NanPropagationModeAttr>(attr.getValue())) {
       if (nanAttr.getValue() == kDefaultNanValue) {
         // elide from toPrint
@@ -430,12 +432,14 @@ void printWithEnumHandling(OpAsmPrinter &parser, Operation *op) {
   parser << " ";
   parser.printOperands(op->getOperands());
 
-  if (!op->getAttrs().empty()) {
+  NamedAttrList toPrint(op->getDiscardableAttrDictionary().getValue());
+  op->getName().walkInherentAttrs(
+      op, [&](StringRef name, Attribute &attr) { toPrint.append(name, attr); });
+  if (!toPrint.empty()) {
     parser << " {";
-    llvm::interleaveComma(op->getAttrs(), parser,
-                          [&](const NamedAttribute namedAttr) {
-                            printNamedAttr(parser, namedAttr);
-                          });
+    llvm::interleaveComma(toPrint, parser, [&](NamedAttribute attr) {
+      printNamedAttr(parser, attr);
+    });
     parser << "}";
   }
 
@@ -5762,7 +5766,7 @@ void IfOp::print(OpAsmPrinter &p) {
     p.printRegion(elseRegion);
   }
 
-  p.printOptionalAttrDict((*this)->getAttrs());
+  p.printOptionalAttrDict((*this)->getDiscardableAttrDictionary().getValue());
 }
 
 LogicalResult IfOp::verify() {
@@ -5971,7 +5975,8 @@ void WhileOp::print(OpAsmPrinter &parser) {
   parser.printRegion(getCondGraph(), /*printEntryBlockArgs=*/false);
   parser << " do ";
   parser.printRegion(getBodyGraph());
-  parser.printOptionalAttrDictWithKeyword((*this)->getAttrs());
+  parser.printOptionalAttrDictWithKeyword(
+      (*this)->getDiscardableAttrDictionary().getValue());
 }
 
 // Create a rank-1 const tensor for zero point of the source tensor.

--- a/mlir/lib/Dialect/Tosa/Transforms/TosaAttachTarget.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaAttachTarget.cpp
@@ -67,7 +67,7 @@ public:
     if (failed(TargetEnv::verifyTargetInformation(targetEnvAttr, mod.getLoc())))
       return signalPassFailure();
 
-    mod->setAttr(TargetEnvAttr::name, targetEnvAttr);
+    mod->setDiscardableAttr(TargetEnvAttr::name, targetEnvAttr);
   }
 
 private:

--- a/mlir/lib/Dialect/Tosa/Transforms/TosaConvertIntegerTypeToSignless.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaConvertIntegerTypeToSignless.cpp
@@ -84,7 +84,8 @@ public:
 
     // Create new op with replaced operands and results
     auto *newOp = Operation::create(
-        op->getLoc(), op->getName(), resultTypes, operands, op->getAttrs(),
+        op->getLoc(), op->getName(), resultTypes, operands,
+        op->getDiscardableAttrDictionary().getValue(),
         op->getPropertiesStorage(), op->getSuccessors(), op->getNumRegions());
 
     // Handle regions in e.g. tosa.cond_if and tosa.while_loop

--- a/mlir/lib/Dialect/Tosa/Transforms/TosaNarrowTypes.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaNarrowTypes.cpp
@@ -371,7 +371,11 @@ LogicalResult convertGenericOp(Operation *op, ValueRange operands,
                        newResults, {}, op->getSuccessors());
 
   // Keep attribute payloads consistent with the converted element types.
-  for (const NamedAttribute &namedAttribute : op->getAttrs()) {
+  NamedAttrList sourceAttrs(op->getDiscardableAttrDictionary().getValue());
+  op->getName().walkInherentAttrs(op, [&](StringRef name, Attribute &attr) {
+    sourceAttrs.append(name, attr);
+  });
+  for (const NamedAttribute &namedAttribute : sourceAttrs) {
     const Attribute attribute = namedAttribute.getValue();
 
     if (isa<IntegerAttr>(attribute) || isa<FloatAttr>(attribute)) {
@@ -501,7 +505,7 @@ class ConvertCastOpWithBoundsChecking
 
     rewriter.replaceOpWithNewOp<tosa::CastOp>(
         op, typeConverter->convertType(resultType), adaptor.getInput(),
-        op->getAttrs());
+        op->getDiscardableAttrDictionary().getValue());
     return success();
   }
 };

--- a/mlir/lib/Dialect/Tosa/Transforms/TosaReduceTransposes.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaReduceTransposes.cpp
@@ -385,13 +385,13 @@ std::optional<Value> TosaReduceTransposes::buildMappedToValue(
   // turn "live" until the transpose being hoisted through this chain
   // is replaced with the proper value from the new chain.
 
-  return rewriter
-      .create(op->getLoc(), op->getName().getIdentifier(), operands,
-              RankedTensorType::get(
-                  applyTOSAPermutation(resultType.getShape(), hoistedPerms),
-                  resultType.getElementType()),
-              op->getAttrs())
-      ->getResult(0);
+  Type newResultType = RankedTensorType::get(
+      applyTOSAPermutation(resultType.getShape(), hoistedPerms),
+      resultType.getElementType());
+  OperationState state(op->getLoc(), op->getName(), operands, newResultType,
+                       op->getDiscardableAttrDictionary().getValue());
+  state.propertiesAttr = op->getPropertiesAsAttribute();
+  return rewriter.create(state)->getResult(0);
 }
 
 std::optional<Value> TosaReduceTransposes::buildMappedToValue(

--- a/mlir/lib/Dialect/Tosa/Transforms/TosaValidation.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaValidation.cpp
@@ -29,6 +29,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/FormatVariadic.h"
 
 namespace mlir {
@@ -1022,7 +1023,10 @@ LogicalResult TosaValidation::CheckVariable(Operation *op) {
 LogicalResult TosaValidation::CheckVariableReadOrWrite(Operation *op) {
   if (isa<mlir::tosa::VariableReadOp>(op) ||
       isa<mlir::tosa::VariableWriteOp>(op)) {
-    mlir::StringAttr nameAttr = cast<mlir::StringAttr>(op->getAttr("name"));
+    mlir::StringAttr nameAttr =
+        TypeSwitch<Operation *, mlir::StringAttr>(op)
+            .Case<mlir::tosa::VariableReadOp, mlir::tosa::VariableWriteOp>(
+                [](auto variableOp) { return variableOp.getNameAttr(); });
     if (!variablesMap.count(nameAttr))
       return op->emitOpError() << "name has not been declared";
 

--- a/mlir/lib/Dialect/Tosa/Utils/ConversionUtils.cpp
+++ b/mlir/lib/Dialect/Tosa/Utils/ConversionUtils.cpp
@@ -191,8 +191,7 @@ bool mlir::tosa::getConstShapeValues(Operation *op,
     return false;
   }
   if (auto constOp = mlir::dyn_cast<tosa::ConstShapeOp>(op)) {
-    Attribute constOpAttr = constOp->getAttr("values");
-    DenseElementsAttr elementsAttr = cast<DenseElementsAttr>(constOpAttr);
+    DenseElementsAttr elementsAttr = constOp.getValuesAttr();
     for (int i = 0; i < elementsAttr.size(); i++) {
       int64_t val = elementsAttr.getValues<int64_t>()[i];
       resultShape.push_back(val);


### PR DESCRIPTION
Use typed operation accessors and explicit discardable attribute APIs in the Tosa dialect, conversions, target handling, and validation.

Assisted-by: Codex