### PR TITLE
[mlir][Bufferization] Separate AllocTensorOp properties from discardable attribute in assembly

### DIFF
--- a/mlir/lib/Dialect/Bufferization/IR/BufferizationOps.cpp
+++ b/mlir/lib/Dialect/Bufferization/IR/BufferizationOps.cpp
@@ -297,7 +297,26 @@ ParseResult AllocTensorOp::parse(OpAsmParser &parser, OperationState &result) {
   if (sizeHintKeyword.succeeded())
     if (parser.parseEqual() || parser.parseOperand(sizeHintOperand))
       return failure();
-  if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon())
+
+  Attribute parsedProperties;
+  if (AllocTensorOp::genericParseProperties(parser, parsedProperties))
+    return failure();
+  auto propertyDictionary = dyn_cast_or_null<DictionaryAttr>(parsedProperties);
+  if (parsedProperties && !propertyDictionary)
+    return parser.emitError(parser.getNameLoc(),
+                            "expected properties dictionary");
+
+  auto attrsLoc = parser.getCurrentLocation();
+  if (parser.parseOptionalAttrDict(result.attributes))
+    return failure();
+  for (StringRef attrName : AllocTensorOp::getAttributeNames()) {
+    if (result.attributes.get(attrName))
+      return parser.emitError(attrsLoc)
+             << "inherent attribute '" << attrName
+             << "' cannot be parsed from attr-dict when strict properties in "
+                "assembly format is enabled";
+  }
+  if (parser.parseColon())
     return failure();
 
   TensorType type;
@@ -314,11 +333,24 @@ ParseResult AllocTensorOp::parse(OpAsmParser &parser, OperationState &result) {
   if (sizeHintKeyword.succeeded())
     if (parser.resolveOperand(sizeHintOperand, indexType, result.operands))
       return failure();
-  result.addAttribute(AllocTensorOp::getOperandSegmentSizeAttr(),
-                      parser.getBuilder().getDenseI32ArrayAttr(
-                          {static_cast<int32_t>(dynamicSizesOperands.size()),
-                           static_cast<int32_t>(copyKeyword.succeeded()),
-                           static_cast<int32_t>(sizeHintKeyword.succeeded())}));
+  Builder &builder = parser.getBuilder();
+  NamedAttrList properties(propertyDictionary ? propertyDictionary
+                                              : builder.getDictionaryAttr({}));
+  properties.set(AllocTensorOp::getOperandSegmentSizeAttr(),
+                 builder.getDenseI32ArrayAttr(
+                     {static_cast<int32_t>(dynamicSizesOperands.size()),
+                      static_cast<int32_t>(copyKeyword.succeeded()),
+                      static_cast<int32_t>(sizeHintKeyword.succeeded())}));
+  propertyDictionary = properties.getDictionary(builder.getContext());
+  auto emitError = [&]() {
+    return mlir::emitError(result.location, "invalid properties ")
+           << propertyDictionary << " for op " << result.name.getStringRef()
+           << ": ";
+  };
+  if (failed(AllocTensorOp::setPropertiesFromParsedAttr(
+          result.getOrAddProperties<Properties>(), propertyDictionary,
+          emitError)))
+    return failure();
   return success();
 }
 
@@ -328,8 +360,9 @@ void AllocTensorOp::print(OpAsmPrinter &p) {
     p << " copy(" << getCopy() << ")";
   if (getSizeHint())
     p << " size_hint=" << getSizeHint();
-  p.printOptionalAttrDict((*this)->getAttrs(), /*elidedAttrs=*/{
-                              AllocTensorOp::getOperandSegmentSizeAttr()});
+  AllocTensorOp::printProperties(getContext(), p, getProperties(),
+                                 /*elidedProps=*/getOperandSegmentSizeAttr());
+  p.printOptionalAttrDict((*this)->getDiscardableAttrDictionary().getValue());
   p << " : ";
   auto type = getResult().getType();
   if (auto validType = llvm::dyn_cast<::mlir::TensorType>(type))

--- a/mlir/test/Dialect/Arith/one-shot-bufferize-memory-space-invalid.mlir
+++ b/mlir/test/Dialect/Arith/one-shot-bufferize-memory-space-invalid.mlir
@@ -3,8 +3,8 @@
 func.func @inconsistent_memory_space_arith_select(%c: i1) -> tensor<10xf32> {
   // Selecting tensors with different memory spaces. Such IR cannot be
   // bufferized.
-  %0 = bufferization.alloc_tensor() {memory_space = 0 : ui64} : tensor<10xf32>
-  %1 = bufferization.alloc_tensor() {memory_space = 1 : ui64} : tensor<10xf32>
+  %0 = bufferization.alloc_tensor() <{memory_space = 0 : ui64}> : tensor<10xf32>
+  %1 = bufferization.alloc_tensor() <{memory_space = 1 : ui64}> : tensor<10xf32>
   // expected-error @+2 {{incompatible buffer types on true/false operands}}
   // expected-error @+1 {{failed to bufferize op}}
   %r = arith.select %c, %0, %1 : tensor<10xf32>

--- a/mlir/test/Dialect/Bufferization/Transforms/one-shot-bufferize-encodings.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/one-shot-bufferize-encodings.mlir
@@ -1,7 +1,7 @@
 // RUN: mlir-opt %s -one-shot-bufferize="use-encoding-for-memory-space" -split-input-file | FileCheck %s
 
 func.func @alloc_tesor_with_space_no_encoding() -> tensor<128xf32> {
-  %0 = bufferization.alloc_tensor() {memory_space = 1 : i64} : tensor<128xf32>
+  %0 = bufferization.alloc_tensor() <{memory_space = 1 : i64}> : tensor<128xf32>
   return %0 : tensor<128xf32>
 }
 
@@ -14,7 +14,7 @@ func.func @alloc_tesor_with_space_no_encoding() -> tensor<128xf32> {
 // -----
 
 func.func @alloc_tesor_with_space_and_cast() -> tensor<128xf32, 1> {
-  %0 = bufferization.alloc_tensor() {memory_space = 1 : i64} : tensor<128xf32>
+  %0 = bufferization.alloc_tensor() <{memory_space = 1 : i64}> : tensor<128xf32>
   %1 = tensor.cast %0 : tensor<128xf32> to tensor<128xf32, 1>
   return %1 : tensor<128xf32, 1>
 }
@@ -28,7 +28,7 @@ func.func @alloc_tesor_with_space_and_cast() -> tensor<128xf32, 1> {
 // -----
 
 func.func @alloc_tesor_with_space_with_encoding() -> tensor<128xf32, 1 : i64> {
-  %0 = bufferization.alloc_tensor() {memory_space = 1 : i64} : tensor<128xf32, 1 : i64>
+  %0 = bufferization.alloc_tensor() <{memory_space = 1 : i64}> : tensor<128xf32, 1 : i64>
   return %0 : tensor<128xf32, 1 : i64>
 }
 
@@ -41,7 +41,7 @@ func.func @alloc_tesor_with_space_with_encoding() -> tensor<128xf32, 1 : i64> {
 // -----
 
 func.func @alloc_tesor_copy_from_default_space(%arg0: tensor<128xf32>) -> tensor<128xf32> {
-  %0 = bufferization.alloc_tensor() copy(%arg0) {memory_space = 1 : i64} : tensor<128xf32>
+  %0 = bufferization.alloc_tensor() copy(%arg0) <{memory_space = 1 : i64}> : tensor<128xf32>
   return %0 : tensor<128xf32>
 }
 
@@ -56,7 +56,7 @@ func.func @alloc_tesor_copy_from_default_space(%arg0: tensor<128xf32>) -> tensor
 // -----
 
 func.func @alloc_tesor_copy_from_non_default_space(%arg0: tensor<128xf32, 1>) -> tensor<128xf32, 2> {
-  %0 = bufferization.alloc_tensor() copy(%arg0) {memory_space = 2 : i64} : tensor<128xf32, 1>
+  %0 = bufferization.alloc_tensor() copy(%arg0) <{memory_space = 2 : i64}> : tensor<128xf32, 1>
   %1 = tensor.cast %0 : tensor<128xf32, 1> to tensor<128xf32, 2>
   return %1 : tensor<128xf32, 2>
 }
@@ -75,7 +75,7 @@ func.func @alloc_tesor_copy_from_non_default_space(%arg0: tensor<128xf32, 1>) ->
 // bufferize function boundaries.
 func.func @alloc_tesor_copy_from_non_default_space_no_cast(%arg0: tensor<128xf32, 1>,
                                                            %arg1: tensor<4xf32, 1>) -> tensor<128xf32, 1> {
-  %0 = bufferization.alloc_tensor() copy(%arg0) {memory_space = 2 : i64} : tensor<128xf32, 1>
+  %0 = bufferization.alloc_tensor() copy(%arg0) <{memory_space = 2 : i64}> : tensor<128xf32, 1>
   %1 = tensor.insert_slice %arg1 into %arg0 [0][4][1] : tensor<4xf32, 1> into tensor<128xf32, 1>
   return %0 : tensor<128xf32, 1>
 }
@@ -97,7 +97,7 @@ func.func @alloc_tesor_copy_from_non_default_space_no_cast(%arg0: tensor<128xf32
 // -----
 
 func.func @materialize_in_destination(%arg0: tensor<128xf32, 1>) -> tensor<128xf32, 2> {
-  %0 = bufferization.alloc_tensor () {memory_space = 2 : i64} : tensor<128xf32, 2>
+  %0 = bufferization.alloc_tensor () <{memory_space = 2 : i64}> : tensor<128xf32, 2>
   %1 = bufferization.materialize_in_destination %arg0 in %0 : (tensor<128xf32, 1>, tensor<128xf32, 2>) -> tensor<128xf32, 2>
   return %1 : tensor<128xf32, 2>
 }

--- a/mlir/test/Dialect/Bufferization/Transforms/one-shot-bufferize.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/one-shot-bufferize.mlir
@@ -183,7 +183,7 @@ func.func @alloc_tensor_with_copy_and_size_hint(%t: tensor<5xf32>) -> tensor<5xf
 // CHECK-LABEL: func @alloc_tensor_with_memory_space()
 func.func @alloc_tensor_with_memory_space() -> tensor<5xf32> {
   // CHECK: %[[alloc:.*]] = memref.alloc() {{.*}} : memref<5xf32, 1>
-  %0 = bufferization.alloc_tensor() {memory_space = 1 : i64} : tensor<5xf32>
+  %0 = bufferization.alloc_tensor() <{memory_space = 1 : i64}> : tensor<5xf32>
   // CHECK: %[[r:.*]] = bufferization.to_tensor %[[alloc]]
   // CHECK: return %[[r]]
   return %0 : tensor<5xf32>

--- a/mlir/test/Dialect/Bufferization/Transforms/tensor-copy-insertion-memory-space.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/tensor-copy-insertion-memory-space.mlir
@@ -17,9 +17,9 @@ func.func @unknown_op_copy() -> (tensor<10xf32>, tensor<10xf32>) {
 func.func @alloc_tensor_copy() -> (tensor<10xf32>, tensor<10xf32>) {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.0 : f32
-  // CHECK: bufferization.alloc_tensor() {memory_space = 1 : ui64} : tensor<10xf32>
-  %t = bufferization.alloc_tensor() {memory_space = 1 : ui64} : tensor<10xf32>
-  // CHECK: bufferization.alloc_tensor() {memory_space = 1 : ui64} : tensor<10xf32>
+  // CHECK: bufferization.alloc_tensor() <{memory_space = 1 : ui64}> : tensor<10xf32>
+  %t = bufferization.alloc_tensor() <{memory_space = 1 : ui64}> : tensor<10xf32>
+  // CHECK: bufferization.alloc_tensor() <{memory_space = 1 : ui64}> : tensor<10xf32>
   %s = tensor.insert %cst into %t[%c0] : tensor<10xf32>
   return %s, %t : tensor<10xf32>, tensor<10xf32>
 }

--- a/mlir/test/Dialect/Bufferization/bufferize.mlir
+++ b/mlir/test/Dialect/Bufferization/bufferize.mlir
@@ -30,7 +30,7 @@ func.func @alloc_tensor_dynamic(%d0: index) -> tensor<?x16xf32> {
 // CHECK-LABEL: @alloc_tensor_memory_space
 func.func @alloc_tensor_memory_space(%i: index) -> f32 {
   // CHECK: memref.alloc() alignment = 64 : memref<8x16xf32, 1>
-  %0 = bufferization.alloc_tensor() {memory_space = 1 : i64} : tensor<8x16xf32>
+  %0 = bufferization.alloc_tensor() <{memory_space = 1 : i64}> : tensor<8x16xf32>
   %1 = tensor.extract %0[%i, %i] : tensor<8x16xf32>
   return %1 : f32
 }

--- a/mlir/test/Dialect/Bufferization/invalid.mlir
+++ b/mlir/test/Dialect/Bufferization/invalid.mlir
@@ -26,6 +26,14 @@ func.func @alloc_tensor_copy_and_dims(%t: tensor<?xf32>, %sz: index) {
 
 // -----
 
+func.func @alloc_tensor_memory_space_in_attr_dict() {
+  // expected-error@+1 {{inherent attribute 'memory_space' cannot be parsed from attr-dict when strict properties in assembly format is enabled}}
+  %0 = bufferization.alloc_tensor() {memory_space = "foo"} : tensor<4xf32>
+  return
+}
+
+// -----
+
 // expected-error @+1{{invalid value for 'bufferization.access'}}
 func.func private @invalid_buffer_access_type(tensor<*xf32> {bufferization.access = "foo"})
 

--- a/mlir/test/Dialect/Bufferization/ops.mlir
+++ b/mlir/test/Dialect/Bufferization/ops.mlir
@@ -46,8 +46,8 @@ func.func @test_alloc_tensor_op(%t: tensor<?x5xf32>, %sz: index)
   %c100 = arith.constant 100 : index
   // CHECK: bufferization.alloc_tensor() size_hint=
   %6 = bufferization.alloc_tensor() size_hint=%c100 : tensor<100x100xf64, #CSR>
-  // CHECK: bufferization.alloc_tensor(%{{.+}}) {memory_space = "foo"} : tensor<?xf32>
-  %7 = bufferization.alloc_tensor(%sz) {memory_space = "foo"} : tensor<?xf32>
+  // CHECK: bufferization.alloc_tensor(%{{.+}}) <{memory_space = "foo"}> {escape = true} : tensor<?xf32>
+  %7 = bufferization.alloc_tensor(%sz) <{memory_space = "foo"}> {escape = true} : tensor<?xf32>
   return %1 : tensor<?x5xf32>
 }
 

--- a/mlir/test/Dialect/ControlFlow/one-shot-bufferize-invalid.mlir
+++ b/mlir/test/Dialect/ControlFlow/one-shot-bufferize-invalid.mlir
@@ -3,12 +3,12 @@
 // expected-error @below{{failed to bufferize op}}
 // expected-error @below{{incoming operands of block argument have incompatible buffer types}}
 func.func @inconsistent_memory_space() -> tensor<5xf32> {
-  %0 = bufferization.alloc_tensor() {memory_space = 0 : ui64} : tensor<5xf32>
+  %0 = bufferization.alloc_tensor() <{memory_space = 0 : ui64}> : tensor<5xf32>
   cf.br ^bb1(%0: tensor<5xf32>)
 ^bb1(%arg1: tensor<5xf32>):
   func.return %arg1 : tensor<5xf32>
 ^bb2():
-  %1 = bufferization.alloc_tensor() {memory_space = 1 : ui64} : tensor<5xf32>
+  %1 = bufferization.alloc_tensor() <{memory_space = 1 : ui64}> : tensor<5xf32>
   cf.br ^bb1(%1: tensor<5xf32>)
 }
 

--- a/mlir/test/Dialect/SCF/one-shot-bufferize-invalid.mlir
+++ b/mlir/test/Dialect/SCF/one-shot-bufferize-invalid.mlir
@@ -3,8 +3,8 @@
 func.func @inconsistent_memory_space_scf_if(%c: i1) -> tensor<10xf32> {
   // Yielding tensors with different memory spaces. Such IR cannot be
   // bufferized.
-  %0 = bufferization.alloc_tensor() {memory_space = 0 : ui64} : tensor<10xf32>
-  %1 = bufferization.alloc_tensor() {memory_space = 1 : ui64} : tensor<10xf32>
+  %0 = bufferization.alloc_tensor() <{memory_space = 0 : ui64}> : tensor<10xf32>
+  %1 = bufferization.alloc_tensor() <{memory_space = 1 : ui64}> : tensor<10xf32>
   // expected-error @+1 {{incompatible buffer types on then/else branches}}
   %r = scf.if %c -> tensor<10xf32> {
     // expected-error @+1 {{failed to bufferize op}}
@@ -44,8 +44,8 @@ func.func @execute_region_no_yield(%t: tensor<5xf32>) -> tensor<5xf32> {
 // -----
 
 func.func @inconsistent_memory_space_scf_for(%lb: index, %ub: index, %step: index) -> tensor<10xf32> {
-  %0 = bufferization.alloc_tensor() {memory_space = 0 : ui64} : tensor<10xf32>
-  %1 = bufferization.alloc_tensor() {memory_space = 1 : ui64} : tensor<10xf32>
+  %0 = bufferization.alloc_tensor() <{memory_space = 0 : ui64}> : tensor<10xf32>
+  %1 = bufferization.alloc_tensor() <{memory_space = 1 : ui64}> : tensor<10xf32>
   // expected-error @below{{init_arg and yielded value bufferize to incompatible buffer types}}
   %2 = scf.for %iv = %lb to %ub step %step iter_args(%arg = %0) -> tensor<10xf32> {
     // expected-error @below {{failed to bufferize op}}

--- a/mlir/test/Dialect/SCF/one-shot-bufferize.mlir
+++ b/mlir/test/Dialect/SCF/one-shot-bufferize.mlir
@@ -656,7 +656,7 @@ func.func @scf_if_memory_space(%c: i1, %f: f32, %cst: f32) -> (f32, f32)
 {
   %c0 = arith.constant 0 : index
   // CHECK: %[[alloc:.*]] = memref.alloc() {{.*}} : memref<5xf32, 1>
-  %alloc = bufferization.alloc_tensor() {memory_space = 1 : i64} : tensor<5xf32>
+  %alloc = bufferization.alloc_tensor() <{memory_space = 1 : i64}> : tensor<5xf32>
   // CHECK: linalg.fill {{.*}} outs(%[[alloc]] : memref<5xf32, 1>)
   %filled = linalg.fill ins(%cst : f32) outs(%alloc : tensor<5xf32>) -> tensor<5xf32>
   // CHECK: scf.if %{{.*}} -> (memref<5xf32, 1>) {
@@ -684,7 +684,7 @@ func.func @scf_if_memory_space(%c: i1, %f: f32, %cst: f32) -> (f32, f32)
 func.func @scf_execute_region_memory_space(%f: f32) -> f32 {
   %c0 = arith.constant 0 : index
   %0 = scf.execute_region -> tensor<5xf32> {
-    %1 = bufferization.alloc_tensor() {memory_space = 1 : i64} : tensor<5xf32>
+    %1 = bufferization.alloc_tensor() <{memory_space = 1 : i64}> : tensor<5xf32>
     %2 = tensor.insert %f into %1[%c0] : tensor<5xf32>
     scf.yield %2 : tensor<5xf32>
   }
@@ -704,8 +704,8 @@ func.func @scf_for_swapping_yields_memory_space(
 {
   // CHECK: memref.alloc(%{{.*}}) {{.*}} : memref<?xf32, 1>
   // CHECK: memref.alloc(%{{.*}}) {{.*}} : memref<?xf32, 1>
-  %A = bufferization.alloc_tensor(%sz) {memory_space = 1 : i64} : tensor<?xf32>
-  %B = bufferization.alloc_tensor(%sz) {memory_space = 1 : i64} : tensor<?xf32>
+  %A = bufferization.alloc_tensor(%sz) <{memory_space = 1 : i64}> : tensor<?xf32>
+  %B = bufferization.alloc_tensor(%sz) <{memory_space = 1 : i64}> : tensor<?xf32>
 
   // CHECK: scf.for {{.*}} {
   %r0:2 = scf.for %i = %lb to %ub step %step iter_args(%tA = %A, %tB = %B)

--- a/mlir/test/Dialect/Tensor/one-shot-bufferize.mlir
+++ b/mlir/test/Dialect/Tensor/one-shot-bufferize.mlir
@@ -251,7 +251,7 @@ func.func @pad_memory_space(%t: tensor<?xf32>, %h1: index, %f: f32, %pos: index)
   // CHECK: %[[alloc_tensor:.*]] = memref.alloc{{.*}} : memref<?xf32, 3>
   // CHECK: memref.copy %[[t]], %[[alloc_tensor]]
   %0 = bufferization.alloc_tensor() copy(%t)
-      {memory_space = 3 : i64} : tensor<?xf32>
+      <{memory_space = 3 : i64}> : tensor<?xf32>
   // CHECK: %[[padded_alloc:.*]] = memref.alloc() {{.*}} : memref<15xf32, 3>
   // CHECK: linalg.map
   // CHECK:     outs(%[[padded_alloc]] : memref<15xf32, 3>)

--- a/mlir/test/Dialect/Transform/test-promote-tensors.mlir
+++ b/mlir/test/Dialect/Transform/test-promote-tensors.mlir
@@ -4,7 +4,7 @@
 // CHECK-SAME:  (%[[ARG0:.+]]: tensor<?x42xf32>, %{{.*}}, %{{.*}})
 // CHECK:  %[[C0:.+]] = arith.constant 0
 // CHECK:  %[[DIM:.+]] = tensor.dim %[[ARG0]], %[[C0]]
-// CHECK:  %[[ALLOC:.+]] = bufferization.alloc_tensor(%[[DIM]]) {memory_space = 1 : i64}
+// CHECK:  %[[ALLOC:.+]] = bufferization.alloc_tensor(%[[DIM]]) <{memory_space = 1 : i64}>
 // CHECK:  %[[MAT:.+]] = bufferization.materialize_in_destination %[[ARG0]] in %[[ALLOC]]
 // CHECK:  linalg.matmul ins(%[[MAT]], %{{.*}}
 func.func @promote_in0(%arg0: tensor<?x42xf32>, %arg1: tensor<42x?xf32>, %arg2: tensor<?x?xf32>) -> tensor<?x?xf32> {
@@ -33,7 +33,7 @@ func.func @promote_out(%arg0: tensor<?x42xf32>, %arg1: tensor<?x42xf32>, %arg2: 
     // CHECK:  %[[DIM0:.+]] = tensor.dim %[[ARG2]], %[[C0]]
     // CHECK:  %[[C1:.+]] = arith.constant 1
     // CHECK:  %[[DIM1:.+]] = tensor.dim %[[ARG2]], %[[C1]]
-    // CHECK:  %[[ALLOC:.+]] = bufferization.alloc_tensor(%[[DIM0]], %[[DIM1]]) {memory_space = 1 : i64}
+    // CHECK:  %[[ALLOC:.+]] = bufferization.alloc_tensor(%[[DIM0]], %[[DIM1]]) <{memory_space = 1 : i64}>
     // CHECK-NOT: materialize_in_destination
     // CHECK:  linalg.add {{.*}} outs(%[[ALLOC]]
     %0 = linalg.add ins(%arg0, %arg1 : tensor<?x42xf32>, tensor<?x42xf32>)


### PR DESCRIPTION
Print and parse inherent properties separately from discardable attributes in the AllocTensorOp custom assembly format.

Keep operand segment sizes inferred from the operand syntax and move memory space spellings to the property dictionary.

Assisted-by: Codex