### PR TITLE
[WebAssembly] Expand v8f16 SELECT_CC

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
@@ -390,9 +390,8 @@ WebAssemblyTargetLowering::WebAssemblyTargetLowering(
         setOperationAction(Op, T, Expand);
 
   // There is no vector conditional select instruction
-  for (auto T :
-       {MVT::v16i8, MVT::v8i16, MVT::v4i32, MVT::v4f32, MVT::v2i64,
-        MVT::v2f64, MVT::v8f16})
+  for (auto T : {MVT::v16i8, MVT::v8i16, MVT::v4i32, MVT::v4f32, MVT::v2i64,
+                 MVT::v2f64, MVT::v8f16})
     setOperationAction(ISD::SELECT_CC, T, Expand);
 
   // We have custom switch handling.

--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
@@ -391,7 +391,8 @@ WebAssemblyTargetLowering::WebAssemblyTargetLowering(
 
   // There is no vector conditional select instruction
   for (auto T :
-       {MVT::v16i8, MVT::v8i16, MVT::v4i32, MVT::v4f32, MVT::v2i64, MVT::v2f64})
+       {MVT::v16i8, MVT::v8i16, MVT::v4i32, MVT::v4f32, MVT::v2i64,
+        MVT::v2f64, MVT::v8f16})
     setOperationAction(ISD::SELECT_CC, T, Expand);
 
   // We have custom switch handling.

--- a/llvm/test/CodeGen/WebAssembly/f16-intrinsics.ll
+++ b/llvm/test/CodeGen/WebAssembly/f16-intrinsics.ll
@@ -134,6 +134,38 @@ define <8 x half> @vselect_cmp_v8f16(<8 x half> %a, <8 x half> %b,
   ret <8 x half> %result
 }
 
+; CHECK-LABEL: select_cmp_v8f16:
+; CHECK:       i32.const $push0=, 0
+; CHECK-NEXT:  i32.lt_s $push1=, $0, $pop0
+; CHECK-NEXT:  v128.select $push2=, $1, $2, $pop1
+; CHECK-NEXT:  return $pop2
+define <8 x half> @select_cmp_v8f16(i32 %i, <8 x half> %x,
+                                     <8 x half> %y) {
+  %cond = icmp slt i32 %i, 0
+  %result = select i1 %cond, <8 x half> %x, <8 x half> %y
+  ret <8 x half> %result
+}
+
+; CHECK-LABEL: select_ne_v8f16:
+; CHECK:       v128.select $push0=, $1, $2, $0
+; CHECK-NEXT:  return $pop0
+define <8 x half> @select_ne_v8f16(i32 %i, <8 x half> %x,
+                                    <8 x half> %y) {
+  %cond = icmp ne i32 %i, 0
+  %result = select i1 %cond, <8 x half> %x, <8 x half> %y
+  ret <8 x half> %result
+}
+
+; CHECK-LABEL: select_eq_v8f16:
+; CHECK:       v128.select $push0=, $2, $1, $0
+; CHECK-NEXT:  return $pop0
+define <8 x half> @select_eq_v8f16(i32 %i, <8 x half> %x,
+                                    <8 x half> %y) {
+  %cond = icmp eq i32 %i, 0
+  %result = select i1 %cond, <8 x half> %x, <8 x half> %y
+  ret <8 x half> %result
+}
+
 ; CHECK-LABEL: add_v8f16:
 ; CHECK:       f16x8.add $push0=, $0, $1
 ; CHECK-NEXT:  return $pop0


### PR DESCRIPTION
Follow up for #213280 (read https://github.com/llvm/llvm-project/pull/213280#discussion_r3797603654)

Mark `v8f16 SELECT_CC` for expansion so scalar comparison-based selects lower through the existing comparison and `v128.select` patterns