### PR TITLE
[openmp] - Remove hwloc INSTALL_INTERFACE on omp target

### DIFF
--- a/openmp/runtime/src/CMakeLists.txt
+++ b/openmp/runtime/src/CMakeLists.txt
@@ -200,12 +200,10 @@ if(LIBOMP_USE_HWLOC)
   # the options to other libraries that depend on it, e.g. libompd.
   target_include_directories(obj.omp
     PRIVATE
-    "$<BUILD_INTERFACE:${LIBOMP_HWLOC_INCLUDE_DIR}>"
-    "$<INSTALL_INTERFACE:${LIBOMP_HWLOC_INCLUDE_DIR}>")
+    "$<BUILD_INTERFACE:${LIBOMP_HWLOC_INCLUDE_DIR}>")
   target_include_directories(omp
     INTERFACE
-    "$<BUILD_INTERFACE:${LIBOMP_HWLOC_INCLUDE_DIR}>"
-    "$<INSTALL_INTERFACE:${LIBOMP_HWLOC_INCLUDE_DIR}>")
+    "$<BUILD_INTERFACE:${LIBOMP_HWLOC_INCLUDE_DIR}>")
 endif()
 
 if(OPENMP_MSVC_NAME_SCHEME)


### PR DESCRIPTION
Reasons for removal:
1. hwloc is not present in installed headers, therefore a consumer of openmp does not need hwloc
2. There is no omp target exported currently, which means INSTALL_INTERFACE is ignored.
3. If there is a future omp target exported then there is a possible relocation issue if LIBOMP_HWLOC_INCLUDE_DIR differs in build environment vs end user's environment.

We need to keep BUILD_INTERFACE for unit testing and ompd build.

Originally introduced in https://reviews.llvm.org/D123888