### PR TITLE
[SCEV] Fix dead CHECK lines in ptrtoint.ll (NFC)

### DIFF
--- a/llvm/test/Analysis/ScalarEvolution/ptrtoint.ll
+++ b/llvm/test/Analysis/ScalarEvolution/ptrtoint.ll
@@ -680,13 +680,21 @@ bb14:                                             ; preds = %bb
 }
 
 define i64 @ptrtoint_signbits(i1 %c) {
-; CHECK-LABEL: 'ptrtoint_signbits'
-; CHECK-NEXT:  Classifying expressions for: @ptrtoint_signbits
-; CHECK-NEXT:    %p = select i1 %c, ptr null, ptr inttoptr (i64 -1 to ptr)
-; CHECK-NEXT:    --> %p U: [-1,1) S: [-1,1)
-; CHECK-NEXT:    %a = ptrtoint ptr %p to i64
-; CHECK-NEXT:    --> %a U: full-set S: full-set
-; CHECK-NEXT:  Determining loop execution counts for: @ptrtoint_signbits
+; X64-LABEL: 'ptrtoint_signbits'
+; X64-NEXT:  Classifying expressions for: @ptrtoint_signbits
+; X64-NEXT:    %p = select i1 %c, ptr null, ptr inttoptr (i64 -1 to ptr)
+; X64-NEXT:    --> %p U: [-1,1) S: [-1,1)
+; X64-NEXT:    %a = ptrtoint ptr %p to i64
+; X64-NEXT:    --> %a U: full-set S: full-set
+; X64-NEXT:  Determining loop execution counts for: @ptrtoint_signbits
+;
+; X32-LABEL: 'ptrtoint_signbits'
+; X32-NEXT:  Classifying expressions for: @ptrtoint_signbits
+; X32-NEXT:    %p = select i1 %c, ptr null, ptr inttoptr (i64 -1 to ptr)
+; X32-NEXT:    --> %p U: [-1,1) S: [-1,1)
+; X32-NEXT:    %a = ptrtoint ptr %p to i64
+; X32-NEXT:    --> %a U: [0,4294967296) S: [0,4294967296)
+; X32-NEXT:  Determining loop execution counts for: @ptrtoint_signbits
 ;
   %p = select i1 %c, ptr null, ptr inttoptr (i64 -1 to ptr)
   %a = ptrtoint ptr %p to i64
@@ -694,26 +702,47 @@ define i64 @ptrtoint_signbits(i1 %c) {
 }
 
 define void @ptrtoint_iv_start(ptr %arg, ptr %dst) {
-; CHECK-LABEL: 'ptrtoint_iv_start_no_cancel'
-; CHECK-NEXT:  Classifying expressions for: @ptrtoint_iv_start_no_cancel
-; CHECK-NEXT:    %start = ptrtoint ptr %arg to i64
-; CHECK-NEXT:    --> %start U: full-set S: full-set
-; CHECK-NEXT:    %p = phi ptr [ %arg, %entry ], [ %p.next, %loop ]
-; CHECK-NEXT:    --> {%arg,+,8}<%loop> U: full-set S: full-set Exits: <<Unknown>> LoopDispositions: { %loop: Computable }
-; CHECK-NEXT:    %pi = phi i64 [ %start, %entry ], [ %pi.next, %loop ]
-; CHECK-NEXT:    --> {%start,+,8}<%loop> U: full-set S: full-set Exits: <<Unknown>> LoopDispositions: { %loop: Computable }
-; CHECK-NEXT:    %cur = ptrtoint ptr %p to i64
-; CHECK-NEXT:    --> {(ptrtoaddr ptr %arg to i64),+,8}<%loop> U: full-set S: full-set Exits: <<Unknown>> LoopDispositions: { %loop: Computable }
-; CHECK-NEXT:    %off = sub i64 %cur, %pi
-; CHECK-NEXT:    --> ((-1 * %start) + (ptrtoaddr ptr %arg to i64)) U: full-set S: full-set Exits: ((-1 * %start) + (ptrtoaddr ptr %arg to i64)) LoopDispositions: { %loop: Invariant }
-; CHECK-NEXT:    %p.next = getelementptr i8, ptr %p, i64 8
-; CHECK-NEXT:    --> {(8 + %arg),+,8}<%loop> U: full-set S: full-set Exits: <<Unknown>> LoopDispositions: { %loop: Computable }
-; CHECK-NEXT:    %pi.next = add i64 %pi, 8
-; CHECK-NEXT:    --> {(8 + %start),+,8}<%loop> U: full-set S: full-set Exits: <<Unknown>> LoopDispositions: { %loop: Computable }
-; CHECK-NEXT:  Determining loop execution counts for: @ptrtoint_iv_start_no_cancel
-; CHECK-NEXT:  Loop %loop: Unpredictable backedge-taken count.
-; CHECK-NEXT:  Loop %loop: Unpredictable constant max backedge-taken count.
-; CHECK-NEXT:  Loop %loop: Unpredictable symbolic max backedge-taken count.
+; X64-LABEL: 'ptrtoint_iv_start'
+; X64-NEXT:  Classifying expressions for: @ptrtoint_iv_start
+; X64-NEXT:    %start = ptrtoint ptr %arg to i64
+; X64-NEXT:    --> %start U: full-set S: full-set
+; X64-NEXT:    %p = phi ptr [ %arg, %entry ], [ %p.next, %loop ]
+; X64-NEXT:    --> {%arg,+,8}<%loop> U: full-set S: full-set Exits: <<Unknown>> LoopDispositions: { %loop: Computable }
+; X64-NEXT:    %pi = phi i64 [ %start, %entry ], [ %pi.next, %loop ]
+; X64-NEXT:    --> {%start,+,8}<%loop> U: full-set S: full-set Exits: <<Unknown>> LoopDispositions: { %loop: Computable }
+; X64-NEXT:    %cur = ptrtoint ptr %p to i64
+; X64-NEXT:    --> {(ptrtoaddr ptr %arg to i64),+,8}<%loop> U: full-set S: full-set Exits: <<Unknown>> LoopDispositions: { %loop: Computable }
+; X64-NEXT:    %off = sub i64 %cur, %pi
+; X64-NEXT:    --> ((-1 * %start) + (ptrtoaddr ptr %arg to i64)) U: full-set S: full-set Exits: ((-1 * %start) + (ptrtoaddr ptr %arg to i64)) LoopDispositions: { %loop: Invariant }
+; X64-NEXT:    %p.next = getelementptr i8, ptr %p, i64 8
+; X64-NEXT:    --> {(8 + %arg),+,8}<%loop> U: full-set S: full-set Exits: <<Unknown>> LoopDispositions: { %loop: Computable }
+; X64-NEXT:    %pi.next = add i64 %pi, 8
+; X64-NEXT:    --> {(8 + %start),+,8}<%loop> U: full-set S: full-set Exits: <<Unknown>> LoopDispositions: { %loop: Computable }
+; X64-NEXT:  Determining loop execution counts for: @ptrtoint_iv_start
+; X64-NEXT:  Loop %loop: Unpredictable backedge-taken count.
+; X64-NEXT:  Loop %loop: Unpredictable constant max backedge-taken count.
+; X64-NEXT:  Loop %loop: Unpredictable symbolic max backedge-taken count.
+;
+; X32-LABEL: 'ptrtoint_iv_start'
+; X32-NEXT:  Classifying expressions for: @ptrtoint_iv_start
+; X32-NEXT:    %start = ptrtoint ptr %arg to i64
+; X32-NEXT:    --> %start U: [0,4294967296) S: [0,4294967296)
+; X32-NEXT:    %p = phi ptr [ %arg, %entry ], [ %p.next, %loop ]
+; X32-NEXT:    --> {%arg,+,8}<%loop> U: full-set S: full-set Exits: <<Unknown>> LoopDispositions: { %loop: Computable }
+; X32-NEXT:    %pi = phi i64 [ %start, %entry ], [ %pi.next, %loop ]
+; X32-NEXT:    --> {%start,+,8}<%loop> U: full-set S: full-set Exits: <<Unknown>> LoopDispositions: { %loop: Computable }
+; X32-NEXT:    %cur = ptrtoint ptr %p to i64
+; X32-NEXT:    --> %cur U: [0,4294967296) S: [0,4294967296) Exits: <<Unknown>> LoopDispositions: { %loop: Variant }
+; X32-NEXT:    %off = sub i64 %cur, %pi
+; X32-NEXT:    --> ({(-1 * %start)<nsw>,+,-8}<%loop> + %cur) U: full-set S: full-set Exits: <<Unknown>> LoopDispositions: { %loop: Variant }
+; X32-NEXT:    %p.next = getelementptr i8, ptr %p, i64 8
+; X32-NEXT:    --> {(8 + %arg),+,8}<%loop> U: full-set S: full-set Exits: <<Unknown>> LoopDispositions: { %loop: Computable }
+; X32-NEXT:    %pi.next = add i64 %pi, 8
+; X32-NEXT:    --> {(8 + %start)<nuw><nsw>,+,8}<%loop> U: full-set S: full-set Exits: <<Unknown>> LoopDispositions: { %loop: Computable }
+; X32-NEXT:  Determining loop execution counts for: @ptrtoint_iv_start
+; X32-NEXT:  Loop %loop: Unpredictable backedge-taken count.
+; X32-NEXT:  Loop %loop: Unpredictable constant max backedge-taken count.
+; X32-NEXT:  Loop %loop: Unpredictable symbolic max backedge-taken count.
 ;
 entry:
   %start = ptrtoint ptr %arg to i64


### PR DESCRIPTION
There is no CHECK prefix; remove and regenerate with X32/X86 check lines.

As suggested in https://github.com/llvm/llvm-project/pull/217378.