### PR TITLE
[NFC][analyzer] Tweak constness of CheckerContext methods

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h
@@ -76,8 +76,7 @@ public:
   /// Returns the previous node in the exploded graph, which includes
   /// the state of the program before the checker ran. Note, checkers should
   /// not retain the node in their state since the nodes might get invalidated.
-  ExplodedNode *getPredecessor() { return Pred; }
-  const ExplodedNode *getPredecessor() const { return Pred; }
+  ExplodedNode *getPredecessor() const { return Pred; }
   const ProgramPoint getLocation() const { return Location; }
   const ProgramStateRef &getState() const { return Pred->getState(); }
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h
@@ -83,7 +83,6 @@ public:
 
   /// Check if the checker changed the state of the execution; ex: added
   /// a new transition or a bug report.
-  bool isDifferent() { return Changed; }
   bool isDifferent() const { return Changed; }
 
   /// Returns the number of times the current block has been visited


### PR DESCRIPTION
The method `CheckerContext::isDifferent` should be a `const` method (it does not modify `*this`), but it was originally declared as non-`const` and later commit f93f6e5259e32a00921c66561f3117356a779a01 introduced the `const` variant as an overload along the non-`const` original variant.

As the non-`const` overload is does not have any advantage, this commit removes it. (In many other cases a separate non-`const` overload is needed because the `const` overload has `const` in its return type, but here both overloads return the same `bool`.)

Additionally `CheckerContext::getPredecessor` had two overloads with signatures
```c++
ExplodedNode *getPredecessor() { return Pred; }            
const ExplodedNode *getPredecessor() const { return Pred; }
```
and this commit corrects it to `ExplodedNode *getPredecessor() const` because we can return a pointer to a non-`const` `ExplodedNode` even if `*this` is `const`. Note that `ExplodedNode`s are rarely `const` because they need to be modified when a successor node is added to them. 
