### PR TITLE
[lldb] Fix ProcessProperties reading the wrong experimental collection

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -123,6 +123,9 @@ public:
 protected:
   Process *m_process; // Can be nullptr for global ProcessProperties
   std::unique_ptr<ProcessExperimentalProperties> m_experimental_properties_up;
+
+private:
+  OptionValueProperties *GetExperimentalProperties() const;
 };
 
 // ProcessAttachInfo

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -370,11 +370,10 @@ Args ProcessProperties::GetAlwaysRunThreadNames() const {
 }
 
 OptionValueProperties *ProcessProperties::GetExperimentalProperties() const {
-  const Property *exp_property =
-      m_collection_sp->GetProperty(Properties::GetExperimentalSettingsName());
-  if (!exp_property)
+  if (const Property *exp_property =
+      m_collection_sp->GetProperty(Properties::GetExperimentalSettingsName()))
+      return exp_property->GetValue()->GetAsProperties();
     return nullptr;
-  return exp_property->GetValue()->GetAsProperties();
 }
 
 bool ProcessProperties::GetOSPluginReportsAllThreads() const {

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -140,7 +140,6 @@ static constexpr unsigned g_string_read_width = 256;
 enum {
 #define LLDB_PROPERTIES_process
 #include "TargetPropertiesEnum.inc"
-  ePropertyExperimental,
 };
 
 #define LLDB_PROPERTIES_process_experimental
@@ -176,6 +175,14 @@ ProcessProperties::ProcessProperties(lldb_private::Process *process)
     m_collection_sp->AppendProperty(
         "thread", "Settings specific to threads.", true,
         Thread::GetGlobalProperties().GetValueProperties());
+
+    m_experimental_properties_up =
+        std::make_unique<ProcessExperimentalProperties>();
+    m_collection_sp->AppendProperty(
+        Properties::GetExperimentalSettingsName(),
+        "Experimental settings - setting these won't produce "
+        "errors if the setting is not present.",
+        true, m_experimental_properties_up->GetValueProperties());
   } else {
     m_collection_sp =
         OptionValueProperties::CreateLocalCopy(Process::GetGlobalProperties());
@@ -186,14 +193,6 @@ ProcessProperties::ProcessProperties(lldb_private::Process *process)
         ePropertyDisableLangRuntimeUnwindPlans,
         [this] { DisableLanguageRuntimeUnwindPlansCallback(); });
   }
-
-  m_experimental_properties_up =
-      std::make_unique<ProcessExperimentalProperties>();
-  m_collection_sp->AppendProperty(
-      Properties::GetExperimentalSettingsName(),
-      "Experimental settings - setting these won't produce "
-      "errors if the setting is not present.",
-      true, m_experimental_properties_up->GetValueProperties());
 }
 
 ProcessProperties::~ProcessProperties() = default;
@@ -370,26 +369,26 @@ Args ProcessProperties::GetAlwaysRunThreadNames() const {
   return args;
 }
 
+OptionValueProperties *ProcessProperties::GetExperimentalProperties() const {
+  const Property *exp_property =
+      m_collection_sp->GetProperty(Properties::GetExperimentalSettingsName());
+  if (!exp_property)
+    return nullptr;
+  return exp_property->GetValue()->GetAsProperties();
+}
+
 bool ProcessProperties::GetOSPluginReportsAllThreads() const {
   const bool fail_value = true;
-  const Property *exp_property =
-      m_collection_sp->GetPropertyAtIndex(ePropertyExperimental);
-  OptionValueProperties *exp_values =
-      exp_property->GetValue()->GetAsProperties();
+  OptionValueProperties *exp_values = GetExperimentalProperties();
   if (!exp_values)
     return fail_value;
-
   return exp_values
       ->GetPropertyAtIndexAs<bool>(ePropertyOSPluginReportsAllThreads)
       .value_or(fail_value);
 }
 
 void ProcessProperties::SetOSPluginReportsAllThreads(bool does_report) {
-  const Property *exp_property =
-      m_collection_sp->GetPropertyAtIndex(ePropertyExperimental);
-  OptionValueProperties *exp_values =
-      exp_property->GetValue()->GetAsProperties();
-  if (exp_values)
+  if (OptionValueProperties *exp_values = GetExperimentalProperties())
     exp_values->SetPropertyAtIndex(ePropertyOSPluginReportsAllThreads,
                                    does_report);
 }

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -370,10 +370,10 @@ Args ProcessProperties::GetAlwaysRunThreadNames() const {
 }
 
 OptionValueProperties *ProcessProperties::GetExperimentalProperties() const {
-  if (const Property *exp_property =
-      m_collection_sp->GetProperty(Properties::GetExperimentalSettingsName()))
-      return exp_property->GetValue()->GetAsProperties();
-    return nullptr;
+  if (const Property *exp_property = m_collection_sp->GetProperty(
+          Properties::GetExperimentalSettingsName()))
+    return exp_property->GetValue()->GetAsProperties();
+  return nullptr;
 }
 
 bool ProcessProperties::GetOSPluginReportsAllThreads() const {

--- a/lldb/unittests/Target/CMakeLists.txt
+++ b/lldb/unittests/Target/CMakeLists.txt
@@ -9,6 +9,7 @@ add_lldb_unittest(TargetTests
   MemoryTagMapTest.cpp
   ModuleCacheTest.cpp
   PathMappingListTest.cpp
+  ProcessPropertiesTest.cpp
   RegisterTypeBuilderClangTest.cpp
   RemoteAwarePlatformTest.cpp
   ScratchTypeSystemTest.cpp

--- a/lldb/unittests/Target/ProcessPropertiesTest.cpp
+++ b/lldb/unittests/Target/ProcessPropertiesTest.cpp
@@ -1,4 +1,4 @@
-//===-- ProcessPropertiesTest.cpp -----------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lldb/unittests/Target/ProcessPropertiesTest.cpp
+++ b/lldb/unittests/Target/ProcessPropertiesTest.cpp
@@ -1,0 +1,145 @@
+//===-- ProcessPropertiesTest.cpp -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Plugins/Platform/MacOSX/PlatformMacOSX.h"
+#include "Plugins/Platform/MacOSX/PlatformRemoteMacOSX.h"
+#include "TestingSupport/SubsystemRAII.h"
+#include "TestingSupport/TestUtilities.h"
+#include "lldb/Core/Debugger.h"
+#include "lldb/Host/FileSystem.h"
+#include "lldb/Host/HostInfo.h"
+#include "lldb/Target/Process.h"
+#include "lldb/Target/Target.h"
+#include "lldb/Target/Thread.h"
+#include "lldb/Utility/ArchSpec.h"
+#include "gtest/gtest.h"
+
+#include <mutex>
+
+using namespace lldb_private;
+using namespace lldb;
+
+namespace {
+
+// Paths below target.process, as "settings set" would spell them.
+constexpr const char *k_reports_all_threads =
+    "experimental.os-plugin-reports-all-threads";
+constexpr const char *k_trace_thread = "thread.trace-thread";
+
+class DummyProcess : public Process {
+public:
+  DummyProcess(lldb::TargetSP target_sp, lldb::ListenerSP listener_sp)
+      : Process(target_sp, listener_sp) {}
+  bool CanDebug(lldb::TargetSP, bool) override { return true; }
+  size_t DoReadMemory(const ProcessAddress &, void *, size_t,
+                      Status &) override {
+    return 0;
+  }
+  Status DoDestroy() override { return {}; }
+  void RefreshStateAfterStop() override {}
+  bool DoUpdateThreadList(ThreadList &, ThreadList &) override { return false; }
+  llvm::StringRef GetPluginName() override { return "Dummy"; }
+};
+
+class ProcessPropertiesTest : public ::testing::Test {
+public:
+  SubsystemRAII<FileSystem, HostInfo, PlatformMacOSX> subsystems;
+
+protected:
+  void SetUp() override {
+    std::call_once(TestUtilities::g_debugger_initialize_flag,
+                   [] { Debugger::Initialize(nullptr); });
+    Platform::SetHostPlatform(
+        PlatformRemoteMacOSX::CreateInstance(true, &m_arch));
+    m_debugger_sp = Debugger::CreateInstance();
+  }
+
+  void TearDown() override {
+    // Both settings are global and outlive this test.
+    Process::GetGlobalProperties().SetPropertyValue(
+        nullptr, eVarSetOperationClear, k_reports_all_threads, "");
+    Process::GetGlobalProperties().SetPropertyValue(
+        nullptr, eVarSetOperationClear, k_trace_thread, "");
+    if (m_debugger_sp)
+      Debugger::Destroy(m_debugger_sp);
+  }
+
+  ProcessSP CreateProcess() {
+    PlatformSP platform_sp;
+    TargetSP target_sp;
+    m_debugger_sp->GetTargetList().CreateTarget(
+        *m_debugger_sp, "", m_arch, eLoadDependentsNo, platform_sp, target_sp);
+    if (!target_sp)
+      return nullptr;
+    return std::make_shared<DummyProcess>(target_sp,
+                                          Listener::MakeListener("dummy"));
+  }
+
+  static void SetReportsAllThreads(const char *value) {
+    Process::GetGlobalProperties().SetPropertyValue(
+        nullptr, eVarSetOperationAssign, k_reports_all_threads, value);
+  }
+
+  ArchSpec m_arch = ArchSpec("x86_64-apple-macosx-");
+  DebuggerSP m_debugger_sp;
+};
+
+} // namespace
+
+TEST_F(ProcessPropertiesTest, OSPluginReportsAllThreadsDefaultsToTrue) {
+  ASSERT_TRUE(m_debugger_sp);
+  EXPECT_TRUE(Process::GetGlobalProperties().GetOSPluginReportsAllThreads());
+
+  ProcessSP process_sp = CreateProcess();
+  ASSERT_TRUE(process_sp);
+  EXPECT_TRUE(process_sp->GetOSPluginReportsAllThreads());
+}
+
+// "settings set target.process.experimental.os-plugin-reports-all-threads"
+// must reach what a process reads, not only the global properties.
+TEST_F(ProcessPropertiesTest, OSPluginReportsAllThreadsFollowsGlobalSetting) {
+  ASSERT_TRUE(m_debugger_sp);
+  ProcessSP process_sp = CreateProcess();
+  ASSERT_TRUE(process_sp);
+
+  SetReportsAllThreads("false");
+  EXPECT_FALSE(Process::GetGlobalProperties().GetOSPluginReportsAllThreads());
+  EXPECT_FALSE(process_sp->GetOSPluginReportsAllThreads());
+
+  // The collection is shared, so a process created afterwards sees it too.
+  ProcessSP later_process_sp = CreateProcess();
+  ASSERT_TRUE(later_process_sp);
+  EXPECT_FALSE(later_process_sp->GetOSPluginReportsAllThreads());
+
+  SetReportsAllThreads("true");
+  EXPECT_TRUE(Process::GetGlobalProperties().GetOSPluginReportsAllThreads());
+  EXPECT_TRUE(process_sp->GetOSPluginReportsAllThreads());
+}
+
+// The setter must write the experimental collection and leave the thread
+// collection alone.
+TEST_F(ProcessPropertiesTest, SetOSPluginReportsAllThreadsWritesTheSetting) {
+  ASSERT_TRUE(m_debugger_sp);
+  ProcessSP process_sp = CreateProcess();
+  ASSERT_TRUE(process_sp);
+
+  const bool trace_thread =
+      Thread::GetGlobalProperties().GetTraceEnabledState();
+
+  process_sp->SetOSPluginReportsAllThreads(false);
+  EXPECT_FALSE(process_sp->GetOSPluginReportsAllThreads());
+  EXPECT_EQ(trace_thread, Thread::GetGlobalProperties().GetTraceEnabledState());
+
+  process_sp->SetOSPluginReportsAllThreads(true);
+  EXPECT_TRUE(process_sp->GetOSPluginReportsAllThreads());
+  EXPECT_EQ(trace_thread, Thread::GetGlobalProperties().GetTraceEnabledState());
+
+  // The collection is shared, so writing through a process is visible on the
+  // global properties.
+  EXPECT_TRUE(Process::GetGlobalProperties().GetOSPluginReportsAllThreads());
+}


### PR DESCRIPTION
`ePropertyExperimental` was defined as one past the last generated process
property, on the assumption that "experimental" is appended next.

lldb/source/Target/Process.cpp:
```
 enum {
 #define LLDB_PROPERTIES_process
 #include "TargetPropertiesEnum.inc" // 0..20
   ePropertyExperimental,            // 21
 };
```

However, the global collection appends "thread" first in
`ProcessProperties::ProcessProperties`,

```
175     m_collection_sp->AppendProperty(
176         "thread", "Settings specific to threads.", true,
...
194     m_collection_sp->AppendProperty(
195         Properties::GetExperimentalSettingsName(),
```

so, the index of "thread" is 21, and index of "experimental" is 22.
`GetPropertyAtIndex(ePropertyExperimental)` in `GetOSPluginReportsAllThreads`
gets property of "thread" by mistake.

The fix is to reach the collection by name instead, and drop the enumerator.
It fixes the second problem that "experimental" is registered twice, one
in global properties, and the other is registered when a `Process`
object is created.  It moves the "experimental" part into condition
block `if (process == nullptr)`.

```
(lldb) settings set target.process.experimental.os-plugin-reports-all-threads false
```
is now what the process reads, which the test asserts on a process and not
only on the global properties.
