### PR TITLE
[KnownFPClass] Add `KnownFPClass::frem` [NFC]

### DIFF
--- a/llvm/include/llvm/Support/KnownFPClass.h
+++ b/llvm/include/llvm/Support/KnownFPClass.h
@@ -291,6 +291,11 @@ struct KnownFPClass {
 
   /// Report known values for frem
   LLVM_ABI static KnownFPClass
+  frem(const KnownFPClass &LHS, const KnownFPClass &RHS,
+       DenormalMode Mode = DenormalMode::getDynamic());
+
+  /// Report known values for frem x, x
+  LLVM_ABI static KnownFPClass
   frem_self(const KnownFPClass &Src,
             DenormalMode Mode = DenormalMode::getDynamic());
 

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -6022,24 +6022,7 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
       computeKnownFPClass(Op->getOperand(0), DemandedElts, fcAllFlags, KnownLHS,
                           Q, Depth + 1);
 
-    // Inf REM x and x REM 0 produce NaN.
-    if (KnownLHS.isKnownNeverNaN() && KnownRHS.isKnownNeverNaN() &&
-        KnownLHS.isKnownNeverInfinity() &&
-        KnownRHS.isKnownNeverLogicalZero(Mode)) {
-      Known.knownNot(fcNan);
-    }
-
-    // The sign for frem is the same as the first operand.
-    if (KnownLHS.cannotBeOrderedLessThanZero())
-      Known.knownNot(KnownFPClass::OrderedLessThanZeroMask);
-    if (KnownLHS.cannotBeOrderedGreaterThanZero())
-      Known.knownNot(KnownFPClass::OrderedGreaterThanZeroMask);
-
-    // See if we can be more aggressive about the sign of 0.
-    if (KnownLHS.isKnownNever(fcNegative))
-      Known.knownNot(fcNegative);
-    if (KnownLHS.isKnownNever(fcPositive))
-      Known.knownNot(fcPositive);
+    Known = KnownFPClass::frem(KnownLHS, KnownRHS, Mode);
 
     break;
   }

--- a/llvm/lib/CodeGen/GlobalISel/GISelValueTracking.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/GISelValueTracking.cpp
@@ -1904,24 +1904,7 @@ void GISelValueTracking::computeKnownFPClass(Register R,
     if (KnowSomethingUseful || WantPositive)
       computeKnownFPClass(LHS, DemandedElts, fcAllFlags, KnownLHS, Depth + 1);
 
-    // Inf REM x and x REM 0 produce NaN.
-    if (KnownLHS.isKnownNeverNaN() && KnownRHS.isKnownNeverNaN() &&
-        KnownLHS.isKnownNeverInfinity() &&
-        KnownRHS.isKnownNeverLogicalZero(Mode)) {
-      Known.knownNot(fcNan);
-    }
-
-    // The sign for frem is the same as the first operand.
-    if (KnownLHS.cannotBeOrderedLessThanZero())
-      Known.knownNot(KnownFPClass::OrderedLessThanZeroMask);
-    if (KnownLHS.cannotBeOrderedGreaterThanZero())
-      Known.knownNot(KnownFPClass::OrderedGreaterThanZeroMask);
-
-    // See if we can be more aggressive about the sign of 0.
-    if (KnownLHS.isKnownNever(fcNegative))
-      Known.knownNot(fcNegative);
-    if (KnownLHS.isKnownNever(fcPositive))
-      Known.knownNot(fcPositive);
+    Known = KnownFPClass::frem(KnownLHS, KnownRHS, Mode);
 
     break;
   }

--- a/llvm/lib/Support/KnownFPClass.cpp
+++ b/llvm/lib/Support/KnownFPClass.cpp
@@ -502,6 +502,36 @@ KnownFPClass KnownFPClass::fdiv_self(const KnownFPClass &KnownSrc,
 
   return Known;
 }
+
+KnownFPClass KnownFPClass::frem(const KnownFPClass &KnownLHS,
+                                const KnownFPClass &KnownRHS,
+                                DenormalMode Mode) {
+  KnownFPClass Known;
+
+  Known.knownNot(fcInf);
+
+  // Inf REM x and x REM 0 produce NaN.
+  if (KnownLHS.isKnownNeverNaN() && KnownRHS.isKnownNeverNaN() &&
+      KnownLHS.isKnownNeverInfinity() &&
+      KnownRHS.isKnownNeverLogicalZero(Mode)) {
+    Known.knownNot(fcNan);
+  }
+
+  // The sign for frem is the same as the first operand.
+  if (KnownLHS.cannotBeOrderedLessThanZero())
+    Known.knownNot(KnownFPClass::OrderedLessThanZeroMask);
+  if (KnownLHS.cannotBeOrderedGreaterThanZero())
+    Known.knownNot(KnownFPClass::OrderedGreaterThanZeroMask);
+
+  // See if we can be more aggressive about the sign of 0.
+  if (KnownLHS.isKnownNever(fcNegative))
+    Known.knownNot(fcNegative);
+  if (KnownLHS.isKnownNever(fcPositive))
+    Known.knownNot(fcPositive);
+
+  return Known;
+}
+
 KnownFPClass KnownFPClass::frem_self(const KnownFPClass &KnownSrc,
                                      DenormalMode Mode) {
   // X % X is always exactly [+-]0.0 or a NaN.


### PR DESCRIPTION
Follow up to https://github.com/llvm/llvm-project/pull/218726

Moves `frem` deduction logic from `Analysis/ValueTracking.cpp` and `CodeGen/GlobalISel/GISelValueTracking.cpp` to `KnownFPClass::frem`.