### PR TITLE
[mlir:tblgen] Qualify access to `getContext` to fix #218872.

### DIFF
--- a/mlir/test/mlir-tblgen/op-format.td
+++ b/mlir/test/mlir-tblgen/op-format.td
@@ -27,6 +27,12 @@ class TestStrictPropertiesFormat_Op<string fmt, list<Trait> traits = []>
 // custom
 //===----------------------------------------------------------------------===//
 
+// CHECK-LABEL: AttrDictContextOperand::print
+// CHECK: _odsPrinter.printOptionalAttrDict(_odsAttrs.getDictionary((*this)->getContext()).getValue(), elidedAttrs);
+def AttrDictContextOperand : TestFormat_Op<[{
+  $context `:` type($context) attr-dict
+}]>, Arguments<(ins AnyType:$context)>;
+
 // CHECK-LABEL: AttrDictDefaultInherentAttr::parse
 // CHECK: verifyInherentAttrs
 def AttrDictDefaultInherentAttr : TestFormat_Op<[{

--- a/mlir/tools/mlir-tblgen/OpFormatGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpFormatGen.cpp
@@ -2549,7 +2549,7 @@ static void genPropDictPrinter(OperationFormat &fmt, Operator &op,
           std::string(tgfmt(attr.getConstBuilderTemplate(), &fctx,
                             tgfmt(attr.getDefaultValue(), &fctx)));
       body << "  {\n";
-      body << "     ::mlir::Builder odsBuilder(getContext());\n";
+      body << "     ::mlir::Builder odsBuilder((*this)->getContext());\n";
       body << "     ::mlir::Attribute attr = " << op.getGetterName(name)
            << "Attr();\n";
       body << "     if(attr && (attr == " << defaultValue << "))\n";
@@ -2572,7 +2572,7 @@ static void genPropDictPrinter(OperationFormat &fmt, Operator &op,
   // The `printProperties` method is responsible for printing out a leading
   // space so that empty `prop-dict`s don't produce stray whitespace.
   if (fmt.useProperties) {
-    body << "  printProperties(this->getContext(), _odsPrinter, "
+    body << "  printProperties((*this)->getContext(), _odsPrinter, "
             "getProperties(), elidedProps);\n";
   }
 }
@@ -2602,7 +2602,7 @@ static void genAttrDictPrinter(OperationFormat &fmt, Operator &op,
           std::string(tgfmt(attr.getConstBuilderTemplate(), &fctx,
                             tgfmt(attr.getDefaultValue(), &fctx)));
       body << "  {\n";
-      body << "     ::mlir::Builder odsBuilder(getContext());\n";
+      body << "     ::mlir::Builder odsBuilder((*this)->getContext());\n";
       body << "     ::mlir::Attribute attr = " << op.getGetterName(name)
            << "Attr();\n";
       body << "     if(attr && (attr == " << defaultValue << "))\n";
@@ -2624,7 +2624,7 @@ static void genAttrDictPrinter(OperationFormat &fmt, Operator &op,
             "  });\n"
             "  _odsPrinter.printOptionalAttrDict"
          << (withKeyword ? "WithKeyword" : "")
-         << "(_odsAttrs.getDictionary(getContext()).getValue(), "
+         << "(_odsAttrs.getDictionary((*this)->getContext()).getValue(), "
             "elidedAttrs);\n";
   }
 }


### PR DESCRIPTION
With #218872, some code generated by `tblgen` containing `getContext()` now uses `OpTyp::getContext()` if that op has a `context` property instead of the intendend `Operation::getContext()`. This PR qualifies the access such that the intended function is always called.