### PR TITLE
[WebAssembly] Add v8f16 bitselect pattern

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrSIMD.td
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrSIMD.td
@@ -903,7 +903,7 @@ defm BITSELECT :
   SIMD_I<(outs V128:$dst), (ins V128:$v1, V128:$v2, V128:$c), (outs), (ins), [],
          "v128.bitselect\t$dst, $v1, $v2, $c", "v128.bitselect", 82>;
 
-foreach vec = StdVecs in
+foreach vec = AllVecs in
 def : Pat<(vec.vt (int_wasm_bitselect
             (vec.vt V128:$v1), (vec.vt V128:$v2), (vec.vt V128:$c))),
           (BITSELECT $v1, $v2, $c)>;

--- a/llvm/test/CodeGen/WebAssembly/f16-intrinsics.ll
+++ b/llvm/test/CodeGen/WebAssembly/f16-intrinsics.ll
@@ -89,6 +89,18 @@ define <8 x half> @insert_lane_v8f16(<8 x half> %v, half %x) {
   ret <8 x half> %r
 }
 
+; CHECK-LABEL: bitselect_v8f16:
+; CHECK:       v128.bitselect $push0=, $0, $1, $2
+; CHECK-NEXT:  return $pop0
+declare <8 x half> @llvm.wasm.bitselect.v8f16(<8 x half>, <8 x half>,
+                                              <8 x half>)
+define <8 x half> @bitselect_v8f16(<8 x half> %a, <8 x half> %b,
+                                    <8 x half> %mask) {
+  %result = call <8 x half> @llvm.wasm.bitselect.v8f16(
+      <8 x half> %a, <8 x half> %b, <8 x half> %mask)
+  ret <8 x half> %result
+}
+
 ; CHECK-LABEL: select_v8f16:
 ; CHECK:       v128.select $push0=, $1, $2, $0
 ; CHECK-NEXT:  return $pop0


### PR DESCRIPTION
Building upon top of https://github.com/llvm/llvm-project/pull/213280 we should move to `AllVecs` instead of `StdVecs` now.

cc @brendandahl 