### PR TITLE
[clang] prevent double package search if LLVM already found in parent directory

### DIFF
--- a/clang/CMakeLists.txt
+++ b/clang/CMakeLists.txt
@@ -45,7 +45,9 @@ if(CLANG_BUILT_STANDALONE)
     mark_as_advanced(LLVM_ENABLE_ASSERTIONS)
   endif()
 
-  find_package(LLVM REQUIRED HINTS "${LLVM_CMAKE_DIR}")
+  if(NOT LLVM_FOUND)
+    find_package(LLVM REQUIRED HINTS "${LLVM_CMAKE_DIR}")
+  endif()
   list(APPEND CMAKE_MODULE_PATH "${LLVM_DIR}")
 
   # Turn into CACHE PATHs for overwritting


### PR DESCRIPTION
Alternative to https://github.com/llvm/llvm-project/pull/135570

See also https://github.com/root-project/root/issues/23155 and https://github.com/conda-forge/llvmdev-feedstock/issues/357

fyi @Ericson2314 @tstellar @petrhosek @nga888 @mgorny @pawosm-arm