### PR TITLE
[flang-rt] Fix out of bounds read in ExternalIOTest.cpp

### DIFF
--- a/flang-rt/unittests/Runtime/ExternalIOTest.cpp
+++ b/flang-rt/unittests/Runtime/ExternalIOTest.cpp
@@ -1063,7 +1063,7 @@ TEST(ExternalIOTests, OpenNewExtant) {
       << "EndIoStatement() for OpenUnit(NEW)";
   // OPEN(10,STATUS='OLD')
   io = IONAME(BeginOpenUnit)(10, __FILE__, __LINE__);
-  ASSERT_TRUE(IONAME(SetFile)(io, "opennewextant", 15))
+  ASSERT_TRUE(IONAME(SetFile)(io, "opennewextant", 13))
       << "SetFile(opennewextant)";
   ASSERT_TRUE(IONAME(SetStatus)(io, "OLD", 3)) << "SetStatus(OLD)";
   ASSERT_EQ(IONAME(EndIoStatement)(io), IostatOk)


### PR DESCRIPTION
The test added by 076da86cd35aa58759c9be7d23ba4cd8693b7414 / #180605 fails when run with ASAN:
```
==339162==ERROR: AddressSanitizer: global-buffer-overflow on address 0xc565e049c86e at pc 0xc565e0ee9268 bp 0xffffd5d7de20 sp 0xffffd5d7de18
READ of size 1 at 0xc565e049c86e thread T0
    #0 0xc565e0ee9264 in Fortran::runtime::TrimTrailingSpaces(char const*, unsigned long) /home/davspi01/llvm-project/flang-rt/lib/runtime/tools.cpp:21:19
    #1 0xc565e0e41d7c in Fortran::runtime::io::OpenStatementState::set_path(char const*, unsigned long) /home/davspi01/llvm-project/flang-rt/lib/runtime/io-stmt.cpp:291:17
    #2 0xc565e0d56a84 in _FortranAioSetFile /home/davspi01/llvm-project/flang-rt/lib/runtime/io-api.cpp:1072:11
<...>
0xc565e049c86e is located 0 bytes after global variable '.str.263' defined in '/home/davspi01/llvm-project/flang-rt/unittests/Runtime/ExternalIOTest.cpp' (0xc565e049c860) of size 14
  '.str.263' is ascii string 'opennewextant'
```
The test calls SetFile with "opennewextant" and a length of 15, but the length of that string is 13 (characters). TrimTrailingSpaces trusts that length and does `s[n - 1]`, which accesses out of bounds.

Fix this by using the correct length of the string.