### PR TITLE
[flang] Let -fstack-arrays win over CudaHeapAllocPromotion under mem:unified

### DIFF
--- a/flang/include/flang/Optimizer/Transforms/MemoryUtils.h
+++ b/flang/include/flang/Optimizer/Transforms/MemoryUtils.h
@@ -66,10 +66,13 @@ fir::AllocMemOp createAllocMemFromAlloca(mlir::OpBuilder &builder,
 /// user variables of \p func (automatic arrays and automatic character) to
 /// fir.allocmem/fir.freemem pairs marked for the unified/managed allocator.
 /// Compiler temporaries, fir.must_be_stack allocations, and device code, which
-/// keeps its stack allocations, are left alone. Returns true if the function
-/// was modified. This is what the cuda-heap-alloc-promotion pass runs.
+/// keeps its stack allocations, are left alone. With \p stackArrays,
+/// mem:unified keeps them on the stack too, which mem:managed cannot do.
+/// Returns true if the function was modified. This is what the
+/// cuda-heap-alloc-promotion pass runs.
 bool promoteDynamicVariableAllocasToCudaHeap(mlir::RewriterBase &rewriter,
-                                             mlir::Operation *func);
+                                             mlir::Operation *func,
+                                             bool stackArrays = false);
 
 } // namespace fir
 

--- a/flang/include/flang/Optimizer/Transforms/Passes.td
+++ b/flang/include/flang/Optimizer/Transforms/Passes.td
@@ -301,8 +301,18 @@ def CudaHeapAllocPromotion
     allocation pass the pipeline happens to select. The pairs it creates are
     marked fir.must_be_heap, which keeps those passes from moving them back to
     the stack. Without the module attribute the pass does nothing.
+
+    Under mem:unified every host address is device accessible, including the
+    stack, so there the promotion is a placement choice that -fstack-arrays
+    opts out of. Under mem:managed only what the managed allocator hands out
+    is, so the promotion always happens.
   }];
   let dependentDialects = ["fir::FIROpsDialect"];
+  let options = [
+    Option<"stackArrays", "stack-arrays", "bool", /*default=*/"false",
+           "Keep the automatic arrays of mem:unified on the stack, as "
+           "requested by -fstack-arrays.">
+  ];
 }
 
 def MemoryAllocationOpt : Pass<"memory-allocation-opt", "mlir::func::FuncOp"> {

--- a/flang/lib/Optimizer/Passes/Pipelines.cpp
+++ b/flang/lib/Optimizer/Passes/Pipelines.cpp
@@ -208,7 +208,8 @@ void createDefaultFIROptimizerPassPipeline(mlir::PassManager &pm,
   // -gpu=mem:unified|managed the unified/managed allocators are required for
   // correctness, so this must not depend on which placement pass is selected
   // or on -disable-memory-allocation-opt.
-  pm.addPass(fir::createCudaHeapAllocPromotion());
+  pm.addPass(fir::createCudaHeapAllocPromotion(
+      fir::CudaHeapAllocPromotionOptions{pc.StackArrays}));
 
   if (enableAllocationPlacement)
     fir::addAllocationPlacement(pm, pc.StackArrays);

--- a/flang/lib/Optimizer/Transforms/CudaHeapAllocPromotion.cpp
+++ b/flang/lib/Optimizer/Transforms/CudaHeapAllocPromotion.cpp
@@ -32,7 +32,8 @@ public:
     if (func.empty())
       return;
     mlir::IRRewriter rewriter(&getContext());
-    fir::promoteDynamicVariableAllocasToCudaHeap(rewriter, func.getOperation());
+    fir::promoteDynamicVariableAllocasToCudaHeap(rewriter, func.getOperation(),
+                                                 stackArrays);
   }
 };
 } // namespace

--- a/flang/lib/Optimizer/Transforms/MemoryUtils.cpp
+++ b/flang/lib/Optimizer/Transforms/MemoryUtils.cpp
@@ -350,12 +350,17 @@ static bool isDeviceCode(mlir::Operation *func, mlir::ModuleOp mod) {
 }
 
 bool fir::promoteDynamicVariableAllocasToCudaHeap(mlir::RewriterBase &rewriter,
-                                                  mlir::Operation *func) {
+                                                  mlir::Operation *func,
+                                                  bool stackArrays) {
   auto mod = func->getParentOfType<mlir::ModuleOp>();
   if (!mod)
     return false;
   fir::CudaHeapAllocMode mode = fir::getCudaHeapAllocMode(mod);
   if (mode == fir::CudaHeapAllocMode::None || isDeviceCode(func, mod))
+    return false;
+  // The stack is device accessible under unified memory, so -fstack-arrays can
+  // be honored there. Under managed memory only the allocator can be.
+  if (stackArrays && mode == fir::CudaHeapAllocMode::Unified)
     return false;
 
   bool changed = false;

--- a/flang/test/Fir/CUDA/cuda-heap-alloc-managed.fir
+++ b/flang/test/Fir/CUDA/cuda-heap-alloc-managed.fir
@@ -1,6 +1,10 @@
 // RUN: fir-opt --cuda-heap-alloc-promotion %s | FileCheck %s --check-prefix=HEAP
 // RUN: fir-opt --fir-to-llvm-ir %s | FileCheck %s --check-prefix=LLVM
 
+// Only the managed allocator is device accessible here, so -fstack-arrays
+// cannot keep the automatic arrays on the stack.
+// RUN: fir-opt --cuda-heap-alloc-promotion=stack-arrays=true %s | FileCheck %s --check-prefix=HEAP
+
 // Same routing as cuda-heap-alloc-unified.fir, with the managed entry points.
 
 // Declarations are emitted at the top of the module, before any function.

--- a/flang/test/Fir/CUDA/cuda-heap-alloc-unified.fir
+++ b/flang/test/Fir/CUDA/cuda-heap-alloc-unified.fir
@@ -9,6 +9,12 @@
 // RUN: fir-opt --cuda-heap-alloc-promotion --stack-arrays %s | FileCheck %s --check-prefix=KEEP
 // RUN: fir-opt --cuda-heap-alloc-promotion --allocation-placement %s | FileCheck %s --check-prefix=KEEP
 
+// The stack is device accessible here, so -fstack-arrays can keep the automatic
+// arrays on it.
+// RUN: fir-opt --cuda-heap-alloc-promotion=stack-arrays=true %s | FileCheck %s --check-prefix=STACK
+// STACK-NOT: fir.allocmem !fir.array<?xf32>, %{{.*}} {bindc_name
+// STACK-NOT: fir.allocmem !fir.char
+
 // Under fir.cuda_heap_alloc = "unified", named automatic arrays move to the
 // heap and are marked. Only marked allocations use malloc_unified: memory the
 // Fortran runtime allocated must keep being released by libc free.


### PR DESCRIPTION
Example:
```fortran
subroutine foo(n)
   integer, intent(in) :: n
   real :: tmp(n)
```

Compiled with -gpu=mem:unified -fstack-arrays, tmp still ends up in malloc_unified: CudaHeapAllocPromotion marks the allocation fir.must_be_heap, which StackArrays then skips, so -fstack-arrays is silently dropped. Under mem:unified the stack is device accessible, so the promotion is a placement choice there. Under mem:managed only the managed allocator is, so it stays a correctness requirement.

Fix: add a stack-arrays option to the pass and skip the promotion when it is set and the mode is unified.