### PR TITLE
[TableGen] Remove unnecessary sorts from writeToStream in InfoByHwMode subclasses. NFC

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
@@ -188,21 +188,14 @@ bool TypeSetByHwMode::assign_if(const TypeSetByHwMode &VTS, Predicate P) {
 }
 
 void TypeSetByHwMode::writeToStream(raw_ostream &OS) const {
-  SmallVector<unsigned, 4> Modes;
-  Modes.reserve(Map.size());
-
-  for (const auto &I : *this)
-    Modes.push_back(I.first);
-  if (Modes.empty()) {
+  if (Map.empty()) {
     OS << "{}";
     return;
   }
-  array_pod_sort(Modes.begin(), Modes.end());
-
   OS << '{';
-  for (unsigned M : Modes) {
-    OS << ' ' << getModeName(M) << ':';
-    get(M).writeToStream(OS);
+  for (const auto &P : Map) {
+    OS << ' ' << getModeName(P.first) << ':';
+    P.second.writeToStream(OS);
   }
   OS << " }";
 }

--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
@@ -193,9 +193,9 @@ void TypeSetByHwMode::writeToStream(raw_ostream &OS) const {
     return;
   }
   OS << '{';
-  for (const auto &P : Map) {
-    OS << ' ' << getModeName(P.first) << ':';
-    P.second.writeToStream(OS);
+  for (const auto &[Mode, Types] : Map) {
+    OS << ' ' << getModeName(Mode) << ':';
+    Types.writeToStream(OS);
   }
   OS << " }";
 }

--- a/llvm/utils/TableGen/Common/InfoByHwMode.cpp
+++ b/llvm/utils/TableGen/Common/InfoByHwMode.cpp
@@ -82,8 +82,7 @@ void ValueTypeByHwMode::writeToStream(raw_ostream &OS) const {
   OS << '{';
   ListSeparator LS(",");
   for (const auto &[Mode, VT] : Map)
-    OS << LS << '(' << getModeName(Mode) << ':' << getMVTName(VT).str()
-       << ')';
+    OS << LS << '(' << getModeName(Mode) << ':' << getMVTName(VT).str() << ')';
   OS << '}';
 }
 

--- a/llvm/utils/TableGen/Common/InfoByHwMode.cpp
+++ b/llvm/utils/TableGen/Common/InfoByHwMode.cpp
@@ -79,16 +79,11 @@ void ValueTypeByHwMode::writeToStream(raw_ostream &OS) const {
     return;
   }
 
-  std::vector<const PairType *> Pairs;
-  for (const auto &P : Map)
-    Pairs.push_back(&P);
-  llvm::sort(Pairs, deref<std::less<PairType>>());
-
   OS << '{';
   ListSeparator LS(",");
-  for (const PairType *P : Pairs)
-    OS << LS << '(' << getModeName(P->first) << ':'
-       << getMVTName(P->second).str() << ')';
+  for (const auto &P : Map)
+    OS << LS << '(' << getModeName(P.first) << ':' << getMVTName(P.second).str()
+       << ')';
   OS << '}';
 }
 
@@ -167,16 +162,10 @@ bool RegSizeInfoByHwMode::hasStricterSpillThan(
 }
 
 void RegSizeInfoByHwMode::writeToStream(raw_ostream &OS) const {
-  using PairType = decltype(Map)::value_type;
-  std::vector<const PairType *> Pairs;
-  for (const auto &P : Map)
-    Pairs.push_back(&P);
-  llvm::sort(Pairs, deref<std::less<PairType>>());
-
   OS << '{';
   ListSeparator LS(",");
-  for (const PairType *P : Pairs)
-    OS << LS << '(' << getModeName(P->first) << ':' << P->second << ')';
+  for (const auto &P : Map)
+    OS << LS << '(' << getModeName(P.first) << ':' << P.second << ')';
   OS << '}';
 }
 

--- a/llvm/utils/TableGen/Common/InfoByHwMode.cpp
+++ b/llvm/utils/TableGen/Common/InfoByHwMode.cpp
@@ -81,8 +81,8 @@ void ValueTypeByHwMode::writeToStream(raw_ostream &OS) const {
 
   OS << '{';
   ListSeparator LS(",");
-  for (const auto &P : Map)
-    OS << LS << '(' << getModeName(P.first) << ':' << getMVTName(P.second).str()
+  for (const auto &[Mode, VT] : Map)
+    OS << LS << '(' << getModeName(Mode) << ':' << getMVTName(VT).str()
        << ')';
   OS << '}';
 }
@@ -164,8 +164,8 @@ bool RegSizeInfoByHwMode::hasStricterSpillThan(
 void RegSizeInfoByHwMode::writeToStream(raw_ostream &OS) const {
   OS << '{';
   ListSeparator LS(",");
-  for (const auto &P : Map)
-    OS << LS << '(' << getModeName(P.first) << ':' << P.second << ')';
+  for (const auto &[Mode, Info] : Map)
+    OS << LS << '(' << getModeName(Mode) << ':' << Info << ')';
   OS << '}';
 }
 

--- a/llvm/utils/TableGen/Common/InfoByHwMode.cpp
+++ b/llvm/utils/TableGen/Common/InfoByHwMode.cpp
@@ -82,7 +82,7 @@ void ValueTypeByHwMode::writeToStream(raw_ostream &OS) const {
   OS << '{';
   ListSeparator LS(",");
   for (const auto &[Mode, VT] : Map)
-    OS << LS << '(' << getModeName(Mode) << ':' << getMVTName(VT).str() << ')';
+    OS << LS << '(' << getModeName(Mode) << ':' << getMVTName(VT) << ')';
   OS << '}';
 }
 


### PR DESCRIPTION
The underlying map is already sorted by mode, so we can iterate over it.