### PR TITLE
Revert "Revert "workflows/release-binaries: Disable flang on Darwin (#164667)""

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -153,13 +153,6 @@ jobs:
           target_cmake_flags="$target_cmake_flags -DBOOTSTRAP_BOOTSTRAP_COMPILER_RT_ENABLE_IOS=OFF"
           if [ "$RUNNER_ARCH" = "ARM64" ]; then
             arches=arm64
-          else
-            arches=x86_64
-            # Disable Flang builds on macOS x86_64.  The FortranLower library takes
-            # 2-3 hours to build on macOS, much slower than on Linux.
-            # The long build time causes the release build to time out on x86_64,
-            # so we need to disable flang there.
-            target_cmake_flags="$target_cmake_flags -DLLVM_RELEASE_ENABLE_PROJECTS='clang;lld;lldb;clang-tools-extra;polly;mlir'"
           fi
           target_cmake_flags="$target_cmake_flags -DBOOTSTRAP_BOOTSTRAP_DARWIN_osx_ARCHS=$arches -DBOOTSTRAP_BOOTSTRAP_DARWIN_osx_BUILTIN_ARCHS=$arches"
         fi

--- a/clang/cmake/caches/Release.cmake
+++ b/clang/cmake/caches/Release.cmake
@@ -30,13 +30,19 @@ endfunction()
 #
 # cmake -D LLVM_RELEASE_ENABLE_PGO=ON -C Release.cmake
 
-set (DEFAULT_PROJECTS "clang;lld;lldb;clang-tools-extra;polly;mlir;flang")
+set (DEFAULT_PROJECTS "clang;lld;lldb;clang-tools-extra;polly;mlir")
 # bolt only supports ELF, so only enable it for Linux.
 if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Linux")
   list(APPEND DEFAULT_PROJECTS "bolt")
 endif()
 
-set (DEFAULT_RUNTIMES "compiler-rt;libcxx;openmp;flang-rt")
+set (DEFAULT_RUNTIMES "compiler-rt;libcxx;openmp")
+# Don't build flang on Darwin due to:
+# https://github.com/llvm/llvm-project/issues/160546
+if (NOT ${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")
+  list(APPEND DEFAULT_PROJECTS "flang")
+  list(APPEND DEFAULT_RUNTIMES "flang-rt")
+endif()
 
 if (NOT WIN32)
   list(APPEND DEFAULT_RUNTIMES "libcxxabi" "libunwind")


### PR DESCRIPTION
Reverts llvm/llvm-project#216667

This change was ported to the `release/23.x` branch in #217059, and when we created the first release that included this change (3.1.0), the job for the MacOS ARM binaries was killed when the job hit the 6 hour mark. Previous 3.1.0-rc release did not include this change and all completed well within the 6 hour time out.

To enable the job that builds the release binaries to complete within the allotted time, I am reverting this change  which will essentially disable flang from building on Darwin.

In the future if we get faster builders, we can explore re-enabling building flang.