### PR TITLE
[lldb/test] Suppress crash reports from LLDB's gtest death tests

### DIFF
--- a/lldb/unittests/Host/ProcessRunLockTest.cpp
+++ b/lldb/unittests/Host/ProcessRunLockTest.cpp
@@ -8,6 +8,8 @@
 
 #include "lldb/Host/ProcessRunLock.h"
 
+#include "llvm/Support/Process.h"
+
 #include "gtest/gtest.h"
 
 #include <condition_variable>
@@ -177,6 +179,11 @@ TEST(ProcessRunLockDeathTest, MoveLockedAcrossThreads) {
   // "ProcessRunLocker" common prefix only.
   EXPECT_DEATH(
       {
+        // The abort below is expected, so keep it away from the system crash
+        // reporter, which would otherwise record it as a real crash. This must
+        // stay inside the death-test statement so only the forked child is
+        // affected.
+        llvm::sys::Process::PreventCoreFiles();
         std::thread t([locker = std::move(a)]() mutable { (void)locker; });
         t.join();
       },

--- a/lldb/unittests/Utility/PolicyTest.cpp
+++ b/lldb/unittests/Utility/PolicyTest.cpp
@@ -8,6 +8,7 @@
 
 #include "lldb/Utility/Policy.h"
 #include "lldb/Utility/StreamString.h"
+#include "llvm/Support/Process.h"
 #include "gtest/gtest.h"
 
 #include <thread>
@@ -202,6 +203,11 @@ TEST(PolicyStackDeathTest, GuardDestroyedOnDifferentThread) {
   // where the violation is detected.
   EXPECT_DEATH(
       {
+        // The abort below is expected, so keep it away from the system crash
+        // reporter, which would otherwise record it as a real crash. This must
+        // stay inside the death-test statement so only the forked child is
+        // affected.
+        llvm::sys::Process::PreventCoreFiles();
         std::thread t([guard = std::move(outer)]() mutable { (void)guard; });
         t.join();
       },


### PR DESCRIPTION
PolicyStackDeathTest.GuardDestroyedOnDifferentThread and ProcessRunLockDeathTest.MoveLockedAcrossThreads deliberately trip thread-affinity checks that call report_fatal_error, so the forked death-test child dies via SIGABRT. On platforms with a system crash reporter that leaves a crash log behind for each run, which CI scrapes and reports as a test failure even though both tests pass.

Call llvm::sys::Process::PreventCoreFiles() as the first statement inside the EXPECT_DEATH block. EXPECT_DEATH forks by default, so this only affects the child process and leaves the runner's own signal handling alone. The assertions still hold: report_fatal_error writes to stderr before aborting, so the regex still matches, and the nonzero exit status satisfies ExitedUnsuccessfully.