### PR TITLE
[AMDGPU] Extend select/setcc swap to multi-use conditions

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -5079,6 +5079,18 @@ AMDGPUTargetLowering::foldFreeOpFromSelect(TargetLowering::DAGCombinerInfo &DCI,
   return SDValue();
 }
 
+static bool isSelectSwapCandidate(SDNode *User, const SDNode *Cond,
+                                  SelectionDAG &DAG) {
+  if (User->getOpcode() != ISD::SELECT)
+    return false;
+  if (User->getOperand(0).getNode() != Cond)
+    return false;
+  SDValue True = User->getOperand(1);
+  SDValue False = User->getOperand(2);
+  return DAG.isConstantValueOfAnyType(True) &&
+         !DAG.isConstantValueOfAnyType(False);
+}
+
 SDValue AMDGPUTargetLowering::performSelectCombine(SDNode *N,
                                                    DAGCombinerInfo &DCI) const {
   if (SDValue Folded = foldFreeOpFromSelect(DCI, SDValue(N, 0)))
@@ -5096,22 +5108,48 @@ SDValue AMDGPUTargetLowering::performSelectCombine(SDNode *N,
   SDValue True = N->getOperand(1);
   SDValue False = N->getOperand(2);
 
-  if (Cond.hasOneUse()) { // TODO: Look for multiple select uses.
-    SelectionDAG &DAG = DCI.DAG;
-    if (DAG.isConstantValueOfAnyType(True) &&
-        !DAG.isConstantValueOfAnyType(False)) {
-      // Swap cmp + select pair to move constant to false input.
-      // This will allow using VOPC cndmasks more often.
-      // select (setcc x, y), k, x -> select (setccinv x, y), x, k
+  SelectionDAG &DAG = DCI.DAG;
+  if (DAG.isConstantValueOfAnyType(True) &&
+      !DAG.isConstantValueOfAnyType(False)) {
+    // Swap cmp + select pair to move constant to false input.
+    // This will allow using VOPC cndmasks more often.
+    // select (setcc x, y), k, x -> select (setccinv x, y), x, k
 
+    bool CanSwap = true;
+    if (!Cond.hasOneUse()) {
+      for (SDNode *User : Cond->users()) {
+        if (User == N)
+          continue;
+        if (!isSelectSwapCandidate(User, Cond.getNode(), DAG)) {
+          CanSwap = false;
+          break;
+        }
+      }
+    }
+
+    if (CanSwap) {
       SDLoc SL(N);
       ISD::CondCode NewCC =
           getSetCCInverse(cast<CondCodeSDNode>(CC)->get(), LHS.getValueType());
 
       SDValue NewCond = DAG.getSetCC(SL, Cond.getValueType(), LHS, RHS, NewCC);
+
+      for (SDNode *User : llvm::make_early_inc_range(Cond->users())) {
+        if (User == N)
+          continue;
+        EVT UserVT = User->getValueType(0);
+        SDValue UserTrue = User->getOperand(1);
+        SDValue UserFalse = User->getOperand(2);
+        SDValue NewUserSelect = DAG.getNode(ISD::SELECT, SDLoc(User), UserVT,
+                                            NewCond, UserFalse, UserTrue);
+        DCI.CombineTo(User, NewUserSelect);
+      }
+
       return DAG.getNode(ISD::SELECT, SL, VT, NewCond, False, True);
     }
+  }
 
+  if (Cond.hasOneUse()) {
     if (VT == MVT::f32 && Subtarget->hasFminFmaxLegacy()) {
       SDValue MinMax
         = combineFMinMaxLegacy(SDLoc(N), VT, LHS, RHS, True, False, CC, DCI);

--- a/llvm/test/CodeGen/AMDGPU/a-v-flat-atomicrmw.ll
+++ b/llvm/test/CodeGen/AMDGPU/a-v-flat-atomicrmw.ll
@@ -10815,9 +10815,9 @@ define void @flat_atomic_fmaximum_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    v_max_f64 v[0:1], v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v1, v8, vcc
-; GFX90A-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX90A-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[6:7], v[0:3] glc
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
@@ -10842,11 +10842,11 @@ define void @flat_atomic_fmaximum_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
-; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
 ; GFX90A-NEXT:    buffer_store_dword v2, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v3, v6, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB135_6: ; %atomicrmw.phi
@@ -10882,10 +10882,10 @@ define void @flat_atomic_fmaximum_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_max_f64 v[0:1], v[2:3], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v1, v8, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX950-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[6:7], v[0:3] sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
@@ -10910,11 +10910,11 @@ define void @flat_atomic_fmaximum_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    scratch_load_dwordx2 v[0:1], v6, off
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
 ; GFX950-NEXT:    scratch_store_dwordx2 v6, v[2:3], off
 ; GFX950-NEXT:  .LBB135_6: ; %atomicrmw.phi
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[0:1]
@@ -10953,9 +10953,9 @@ define void @flat_atomic_fmaximum_f64_ret_av_av(ptr %ptr) #0 {
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    v_max_f64 v[0:1], v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v1, v8, vcc
-; GFX90A-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX90A-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[6:7], v[0:3] glc
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
@@ -10978,9 +10978,9 @@ define void @flat_atomic_fmaximum_f64_ret_av_av(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
-; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
-; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
 ; GFX90A-NEXT:    buffer_store_dword v2, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v3, v6, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB136_6: ; %atomicrmw.phi
@@ -11014,10 +11014,10 @@ define void @flat_atomic_fmaximum_f64_ret_av_av(ptr %ptr) #0 {
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_max_f64 v[0:1], v[2:3], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v1, v8, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX950-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[6:7], v[0:3] sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
@@ -11040,10 +11040,10 @@ define void @flat_atomic_fmaximum_f64_ret_av_av(ptr %ptr) #0 {
 ; GFX950-NEXT:    scratch_load_dwordx2 v[0:1], v6, off
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
 ; GFX950-NEXT:    scratch_store_dwordx2 v6, v[2:3], off
 ; GFX950-NEXT:  .LBB136_6: ; %atomicrmw.phi
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[0:1]
@@ -11084,9 +11084,9 @@ define void @flat_atomic_fminimum_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    v_min_f64 v[0:1], v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v1, v8, vcc
-; GFX90A-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX90A-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[6:7], v[0:3] glc
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
@@ -11111,11 +11111,11 @@ define void @flat_atomic_fminimum_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
-; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
 ; GFX90A-NEXT:    buffer_store_dword v2, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v3, v6, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB137_6: ; %atomicrmw.phi
@@ -11151,10 +11151,10 @@ define void @flat_atomic_fminimum_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_min_f64 v[0:1], v[2:3], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v1, v8, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX950-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[6:7], v[0:3] sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
@@ -11179,11 +11179,11 @@ define void @flat_atomic_fminimum_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    scratch_load_dwordx2 v[0:1], v6, off
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
 ; GFX950-NEXT:    scratch_store_dwordx2 v6, v[2:3], off
 ; GFX950-NEXT:  .LBB137_6: ; %atomicrmw.phi
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[0:1]
@@ -11222,9 +11222,9 @@ define void @flat_atomic_fminimum_f64_ret_av_av(ptr %ptr) #0 {
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    v_min_f64 v[0:1], v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v1, v8, vcc
-; GFX90A-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX90A-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[6:7], v[0:3] glc
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
@@ -11247,9 +11247,9 @@ define void @flat_atomic_fminimum_f64_ret_av_av(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
-; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
-; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
 ; GFX90A-NEXT:    buffer_store_dword v2, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v3, v6, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB138_6: ; %atomicrmw.phi
@@ -11283,10 +11283,10 @@ define void @flat_atomic_fminimum_f64_ret_av_av(ptr %ptr) #0 {
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_min_f64 v[0:1], v[2:3], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v1, v8, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX950-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[6:7], v[0:3] sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
@@ -11309,10 +11309,10 @@ define void @flat_atomic_fminimum_f64_ret_av_av(ptr %ptr) #0 {
 ; GFX950-NEXT:    scratch_load_dwordx2 v[0:1], v6, off
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
 ; GFX950-NEXT:    scratch_store_dwordx2 v6, v[2:3], off
 ; GFX950-NEXT:  .LBB138_6: ; %atomicrmw.phi
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[0:1]
@@ -19552,9 +19552,9 @@ define void @flat_atomic_fmaximum_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    v_max_f64 v[0:1], v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v1, v8, vcc
-; GFX90A-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX90A-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[6:7], v[0:3] glc
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
@@ -19579,11 +19579,11 @@ define void @flat_atomic_fmaximum_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
-; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
 ; GFX90A-NEXT:    buffer_store_dword v2, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v3, v6, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB243_6: ; %atomicrmw.phi
@@ -19618,10 +19618,10 @@ define void @flat_atomic_fmaximum_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_max_f64 v[0:1], v[2:3], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v1, v8, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX950-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[6:7], v[0:3] sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
@@ -19644,11 +19644,11 @@ define void @flat_atomic_fmaximum_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v3, v6, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v6, v3, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
 ; GFX950-NEXT:    scratch_store_dwordx2 off, v[2:3], s0
 ; GFX950-NEXT:  .LBB243_6: ; %atomicrmw.phi
 ; GFX950-NEXT:    ;;#ASMSTART
@@ -19686,9 +19686,9 @@ define void @flat_atomic_fmaximum_f64_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    v_max_f64 v[0:1], v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v1, v8, vcc
-; GFX90A-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX90A-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[6:7], v[0:3] glc
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
@@ -19711,9 +19711,9 @@ define void @flat_atomic_fmaximum_f64_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
-; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
-; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
 ; GFX90A-NEXT:    buffer_store_dword v2, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v3, v6, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB244_6: ; %atomicrmw.phi
@@ -19746,10 +19746,10 @@ define void @flat_atomic_fmaximum_f64_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_max_f64 v[0:1], v[2:3], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v1, v8, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX950-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[6:7], v[0:3] sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
@@ -19770,10 +19770,10 @@ define void @flat_atomic_fmaximum_f64_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v3, v6, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v6, v3, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
 ; GFX950-NEXT:    scratch_store_dwordx2 off, v[2:3], s0
 ; GFX950-NEXT:  .LBB244_6: ; %atomicrmw.phi
 ; GFX950-NEXT:    ;;#ASMSTART
@@ -19813,9 +19813,9 @@ define void @flat_atomic_fminimum_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    v_min_f64 v[0:1], v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v1, v8, vcc
-; GFX90A-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX90A-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[6:7], v[0:3] glc
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
@@ -19840,11 +19840,11 @@ define void @flat_atomic_fminimum_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
-; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
 ; GFX90A-NEXT:    buffer_store_dword v2, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v3, v6, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB245_6: ; %atomicrmw.phi
@@ -19879,10 +19879,10 @@ define void @flat_atomic_fminimum_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_min_f64 v[0:1], v[2:3], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v1, v8, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX950-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[6:7], v[0:3] sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
@@ -19905,11 +19905,11 @@ define void @flat_atomic_fminimum_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v3, v6, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v6, v3, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
 ; GFX950-NEXT:    scratch_store_dwordx2 off, v[2:3], s0
 ; GFX950-NEXT:  .LBB245_6: ; %atomicrmw.phi
 ; GFX950-NEXT:    ;;#ASMSTART
@@ -19947,9 +19947,9 @@ define void @flat_atomic_fminimum_f64_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    v_min_f64 v[0:1], v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v1, v8, vcc
-; GFX90A-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX90A-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[6:7], v[0:3] glc
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
@@ -19972,9 +19972,9 @@ define void @flat_atomic_fminimum_f64_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
-; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
-; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
 ; GFX90A-NEXT:    buffer_store_dword v2, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v3, v6, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB246_6: ; %atomicrmw.phi
@@ -20007,10 +20007,10 @@ define void @flat_atomic_fminimum_f64_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_min_f64 v[0:1], v[2:3], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v1, v8, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX950-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[6:7], v[0:3] sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
@@ -20031,10 +20031,10 @@ define void @flat_atomic_fminimum_f64_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v3, v6, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v6, v3, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
 ; GFX950-NEXT:    scratch_store_dwordx2 off, v[2:3], s0
 ; GFX950-NEXT:  .LBB246_6: ; %atomicrmw.phi
 ; GFX950-NEXT:    ;;#ASMSTART

--- a/llvm/test/CodeGen/AMDGPU/a-v-global-atomicrmw.ll
+++ b/llvm/test/CodeGen/AMDGPU/a-v-global-atomicrmw.ll
@@ -7132,9 +7132,9 @@ define void @global_atomic_fmaximum_f64_ret_a_a(ptr addrspace(1) %ptr) #0 {
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_max_f64 v[2:3], v[4:5], v[6:7]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[6:7]
-; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v3, v8, vcc
-; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[6:7]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v8, v3, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
 ; GFX90A-NEXT:    global_atomic_cmpswap_x2 v[2:3], v[0:1], v[2:5], off offset:80 glc
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[2:3], v[4:5]
@@ -7167,10 +7167,10 @@ define void @global_atomic_fmaximum_f64_ret_a_a(ptr addrspace(1) %ptr) #0 {
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_max_f64 v[2:3], v[4:5], v[6:7]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[6:7]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[6:7]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v3, v8, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v8, v3, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
 ; GFX950-NEXT:    global_atomic_cmpswap_x2 v[2:3], v[0:1], v[2:5], off offset:80 sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[2:3], v[4:5]
@@ -7207,9 +7207,9 @@ define void @global_atomic_fmaximum_f64_ret_av_av(ptr addrspace(1) %ptr) #0 {
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_max_f64 v[2:3], v[4:5], v[6:7]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[6:7]
-; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v3, v8, vcc
-; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[6:7]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v8, v3, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
 ; GFX90A-NEXT:    global_atomic_cmpswap_x2 v[2:3], v[0:1], v[2:5], off offset:80 glc
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[2:3], v[4:5]
@@ -7238,10 +7238,10 @@ define void @global_atomic_fmaximum_f64_ret_av_av(ptr addrspace(1) %ptr) #0 {
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_max_f64 v[2:3], v[4:5], v[6:7]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[6:7]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[6:7]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v3, v8, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v8, v3, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
 ; GFX950-NEXT:    global_atomic_cmpswap_x2 v[2:3], v[0:1], v[2:5], off offset:80 sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[2:3], v[4:5]
@@ -7278,9 +7278,9 @@ define void @global_atomic_fminimum_f64_ret_a_a(ptr addrspace(1) %ptr) #0 {
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_min_f64 v[2:3], v[4:5], v[6:7]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[6:7]
-; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v3, v8, vcc
-; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[6:7]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v8, v3, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
 ; GFX90A-NEXT:    global_atomic_cmpswap_x2 v[2:3], v[0:1], v[2:5], off offset:80 glc
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[2:3], v[4:5]
@@ -7313,10 +7313,10 @@ define void @global_atomic_fminimum_f64_ret_a_a(ptr addrspace(1) %ptr) #0 {
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_min_f64 v[2:3], v[4:5], v[6:7]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[6:7]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[6:7]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v3, v8, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v8, v3, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
 ; GFX950-NEXT:    global_atomic_cmpswap_x2 v[2:3], v[0:1], v[2:5], off offset:80 sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[2:3], v[4:5]
@@ -7353,9 +7353,9 @@ define void @global_atomic_fminimum_f64_ret_av_av(ptr addrspace(1) %ptr) #0 {
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_min_f64 v[2:3], v[4:5], v[6:7]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[6:7]
-; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v3, v8, vcc
-; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[6:7]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v8, v3, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
 ; GFX90A-NEXT:    global_atomic_cmpswap_x2 v[2:3], v[0:1], v[2:5], off offset:80 glc
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[2:3], v[4:5]
@@ -7384,10 +7384,10 @@ define void @global_atomic_fminimum_f64_ret_av_av(ptr addrspace(1) %ptr) #0 {
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_min_f64 v[2:3], v[4:5], v[6:7]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[6:7]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[6:7]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v3, v8, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v8, v3, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
 ; GFX950-NEXT:    global_atomic_cmpswap_x2 v[2:3], v[0:1], v[2:5], off offset:80 sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[2:3], v[4:5]
@@ -12987,9 +12987,9 @@ define void @global_atomic_fmaximum_f64_saddr_ret_a_a(ptr addrspace(1) inreg %pt
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_max_f64 v[0:1], v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v1, v7, vcc
-; GFX90A-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v7, v1, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX90A-NEXT:    global_atomic_cmpswap_x2 v[0:1], v6, v[0:3], s[16:17] offset:80 glc
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
@@ -13023,10 +13023,10 @@ define void @global_atomic_fmaximum_f64_saddr_ret_a_a(ptr addrspace(1) inreg %pt
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_max_f64 v[0:1], v[2:3], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v1, v7, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v7, v1, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX950-NEXT:    global_atomic_cmpswap_x2 v[0:1], v6, v[0:3], s[0:1] offset:80 sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
@@ -13064,9 +13064,9 @@ define void @global_atomic_fmaximum_f64_saddr_ret_av_av(ptr addrspace(1) inreg %
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_max_f64 v[0:1], v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v1, v7, vcc
-; GFX90A-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v7, v1, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX90A-NEXT:    global_atomic_cmpswap_x2 v[0:1], v6, v[0:3], s[16:17] offset:80 glc
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
@@ -13096,10 +13096,10 @@ define void @global_atomic_fmaximum_f64_saddr_ret_av_av(ptr addrspace(1) inreg %
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_max_f64 v[0:1], v[2:3], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v1, v7, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v7, v1, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX950-NEXT:    global_atomic_cmpswap_x2 v[0:1], v6, v[0:3], s[0:1] offset:80 sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
@@ -13137,9 +13137,9 @@ define void @global_atomic_fminimum_f64_saddr_ret_a_a(ptr addrspace(1) inreg %pt
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_min_f64 v[0:1], v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v1, v7, vcc
-; GFX90A-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v7, v1, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX90A-NEXT:    global_atomic_cmpswap_x2 v[0:1], v6, v[0:3], s[16:17] offset:80 glc
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
@@ -13173,10 +13173,10 @@ define void @global_atomic_fminimum_f64_saddr_ret_a_a(ptr addrspace(1) inreg %pt
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_min_f64 v[0:1], v[2:3], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v1, v7, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v7, v1, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX950-NEXT:    global_atomic_cmpswap_x2 v[0:1], v6, v[0:3], s[0:1] offset:80 sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
@@ -13214,9 +13214,9 @@ define void @global_atomic_fminimum_f64_saddr_ret_av_av(ptr addrspace(1) inreg %
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_min_f64 v[0:1], v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
-; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v1, v7, vcc
-; GFX90A-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX90A-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
+; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v7, v1, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX90A-NEXT:    global_atomic_cmpswap_x2 v[0:1], v6, v[0:3], s[16:17] offset:80 glc
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
@@ -13246,10 +13246,10 @@ define void @global_atomic_fminimum_f64_saddr_ret_av_av(ptr addrspace(1) inreg %
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_min_f64 v[0:1], v[2:3], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v1, v7, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v7, v1, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX950-NEXT:    global_atomic_cmpswap_x2 v[0:1], v6, v[0:3], s[0:1] offset:80 sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]

--- a/llvm/test/CodeGen/AMDGPU/clmul.ll
+++ b/llvm/test/CodeGen/AMDGPU/clmul.ll
@@ -532,269 +532,179 @@ define amdgpu_kernel void @test_clmul_i32(ptr addrspace(1) %out, ptr addrspace(1
 define amdgpu_kernel void @test_clmulr_i32(ptr addrspace(1) %out, ptr addrspace(1) %in) {
 ; SI-LABEL: test_clmulr_i32:
 ; SI:       ; %bb.0:
-; SI-NEXT:    s_load_dwordx4 s[4:7], s[4:5], 0x9
+; SI-NEXT:    s_load_dwordx4 s[8:11], s[4:5], 0x9
 ; SI-NEXT:    s_mov_b32 s3, 0xf000
 ; SI-NEXT:    s_mov_b32 s2, -1
-; SI-NEXT:    s_mov_b32 s10, s2
-; SI-NEXT:    s_mov_b32 s11, s3
+; SI-NEXT:    s_mov_b32 s6, s2
+; SI-NEXT:    s_mov_b32 s7, s3
 ; SI-NEXT:    s_waitcnt lgkmcnt(0)
-; SI-NEXT:    s_mov_b32 s8, s6
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    buffer_load_dwordx2 v[0:1], off, s[8:11], 0
-; SI-NEXT:    s_mov_b32 s7, 0
-; SI-NEXT:    s_mov_b32 s21, s7
-; SI-NEXT:    s_mov_b32 s0, s4
-; SI-NEXT:    s_mov_b32 s1, s5
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    s_mov_b32 s15, s7
-; SI-NEXT:    s_mov_b32 s11, s7
-; SI-NEXT:    s_mov_b32 s13, s7
-; SI-NEXT:    s_mov_b32 s17, s7
-; SI-NEXT:    s_mov_b32 s19, s7
-; SI-NEXT:    s_mov_b32 s23, s7
-; SI-NEXT:    s_mov_b32 s25, s7
-; SI-NEXT:    s_mov_b32 s27, s7
-; SI-NEXT:    s_mov_b32 s29, s7
-; SI-NEXT:    s_mov_b32 s31, s7
-; SI-NEXT:    s_mov_b32 s35, s7
-; SI-NEXT:    s_mov_b32 s37, s7
-; SI-NEXT:    s_mov_b32 s39, s7
-; SI-NEXT:    s_mov_b32 s41, s7
-; SI-NEXT:    s_mov_b32 s43, s7
+; SI-NEXT:    s_mov_b32 s4, s10
+; SI-NEXT:    s_mov_b32 s5, s11
+; SI-NEXT:    buffer_load_dwordx2 v[0:1], off, s[4:7], 0
+; SI-NEXT:    s_mov_b32 s5, 0
+; SI-NEXT:    s_mov_b32 s0, s8
+; SI-NEXT:    s_mov_b32 s1, s9
 ; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    v_readfirstlane_b32 s33, v1
-; SI-NEXT:    s_and_b32 s20, s33, 2
-; SI-NEXT:    v_readfirstlane_b32 s6, v0
-; SI-NEXT:    s_bfe_i32 s8, s33, 0x10000
-; SI-NEXT:    v_cmp_eq_u64_e64 s[20:21], s[20:21], 0
-; SI-NEXT:    s_lshl_b64 s[4:5], s[6:7], 1
-; SI-NEXT:    s_and_b32 s8, s8, s6
-; SI-NEXT:    s_and_b64 s[20:21], s[20:21], exec
-; SI-NEXT:    s_cselect_b32 s21, 0, s5
-; SI-NEXT:    s_cselect_b32 s20, 0, s4
-; SI-NEXT:    s_and_b32 s14, s33, 4
-; SI-NEXT:    s_xor_b64 s[20:21], s[8:9], s[20:21]
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[14:15], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 2
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s15, 0, s15
-; SI-NEXT:    s_cselect_b32 s14, 0, s14
-; SI-NEXT:    s_and_b32 s10, s33, 8
-; SI-NEXT:    v_cmp_eq_u64_e64 s[10:11], s[10:11], 0
-; SI-NEXT:    s_xor_b64 s[14:15], s[20:21], s[14:15]
-; SI-NEXT:    s_lshl_b64 s[20:21], s[6:7], 3
-; SI-NEXT:    s_and_b64 s[10:11], s[10:11], exec
-; SI-NEXT:    s_cselect_b32 s11, 0, s21
-; SI-NEXT:    s_cselect_b32 s10, 0, s20
-; SI-NEXT:    s_and_b32 s12, s33, 16
-; SI-NEXT:    v_cmp_eq_u64_e64 s[12:13], s[12:13], 0
-; SI-NEXT:    s_lshl_b64 s[20:21], s[6:7], 4
-; SI-NEXT:    s_xor_b64 s[10:11], s[14:15], s[10:11]
-; SI-NEXT:    s_and_b64 s[12:13], s[12:13], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s21
-; SI-NEXT:    s_cselect_b32 s12, 0, s20
-; SI-NEXT:    s_and_b32 s16, s33, 32
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[16:17], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 5
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s18, s33, 64
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[18:19], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 6
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s22, s33, 0x80
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[22:23], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 7
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s24, s33, 0x100
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[24:25], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 8
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s26, s33, 0x200
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[26:27], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 9
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s28, s33, 0x400
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[28:29], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 10
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s30, s33, 0x800
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[30:31], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 11
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s34, s33, 0x1000
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[34:35], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 12
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s36, s33, 0x2000
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[36:37], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 13
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s38, s33, 0x4000
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[38:39], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 14
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s40, s33, 0x8000
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[40:41], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 15
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s42, s33, 0x10000
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[42:43], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 16
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_mov_b32 s5, s7
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s4, s33, 0x20000
-; SI-NEXT:    v_cmp_eq_u64_e64 s[4:5], s[4:5], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 17
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[4:5], s[4:5], exec
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    s_cselect_b32 s5, 0, s15
-; SI-NEXT:    s_cselect_b32 s4, 0, s14
-; SI-NEXT:    s_and_b32 s8, s33, 0x40000
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 18
-; SI-NEXT:    s_xor_b64 s[4:5], s[10:11], s[4:5]
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s13
-; SI-NEXT:    s_cselect_b32 s8, 0, s12
-; SI-NEXT:    s_and_b32 s10, s33, 0x80000
-; SI-NEXT:    s_mov_b32 s11, s7
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[10:11], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 19
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_and_b32 s8, s33, 0x100000
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 20
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_and_b32 s8, s33, 0x200000
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 21
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_and_b32 s8, s33, 0x400000
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 22
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_and_b32 s8, s33, 0x800000
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 23
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_and_b32 s8, s33, 0x1000000
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 24
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_and_b32 s8, s33, 0x2000000
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 25
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_and_b32 s8, s33, 0x4000000
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 26
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_and_b32 s8, s33, 0x8000000
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 27
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_and_b32 s8, s33, 0x10000000
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 28
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_and_b32 s8, s33, 0x20000000
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 29
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_and_b32 s8, s33, 2.0
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 30
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_lshl_b64 s[6:7], s[6:7], 31
-; SI-NEXT:    s_cmp_gt_i32 s33, -1
-; SI-NEXT:    s_cselect_b32 s7, 0, s7
-; SI-NEXT:    s_cselect_b32 s6, 0, s6
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[6:7]
+; SI-NEXT:    v_readfirstlane_b32 s6, v1
+; SI-NEXT:    v_readfirstlane_b32 s4, v0
+; SI-NEXT:    s_bitcmp1_b32 s6, 0
+; SI-NEXT:    s_cselect_b32 s9, 0, 0
+; SI-NEXT:    s_cselect_b32 s8, s4, 0
+; SI-NEXT:    s_lshl_b64 s[10:11], s[4:5], 1
+; SI-NEXT:    s_bitcmp1_b32 s6, 1
+; SI-NEXT:    s_cselect_b32 s11, s11, 0
+; SI-NEXT:    s_cselect_b32 s10, s10, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 2
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 2
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 3
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 3
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 4
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 4
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 5
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 5
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 6
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 6
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 7
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 7
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 8
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 8
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 9
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 9
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 10
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 10
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 11
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 11
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 12
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 12
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 13
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 13
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 14
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 14
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 15
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 15
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 16
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 16
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 17
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 17
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 18
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 18
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 19
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 19
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 20
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 20
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 21
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 21
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 22
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 22
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 23
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 23
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 24
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 24
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 25
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 25
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 26
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 26
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 27
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 27
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 28
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 28
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 29
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 29
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 30
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 30
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[4:5], s[4:5], 31
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 31
+; SI-NEXT:    s_cselect_b32 s5, s5, 0
+; SI-NEXT:    s_cselect_b32 s4, s4, 0
+; SI-NEXT:    s_xor_b64 s[4:5], s[8:9], s[4:5]
 ; SI-NEXT:    s_lshr_b64 s[4:5], s[4:5], 31
 ; SI-NEXT:    v_mov_b32_e32 v0, s4
 ; SI-NEXT:    buffer_store_dword v0, off, s[0:3], 0
@@ -802,228 +712,178 @@ define amdgpu_kernel void @test_clmulr_i32(ptr addrspace(1) %out, ptr addrspace(
 ;
 ; VI-LABEL: test_clmulr_i32:
 ; VI:       ; %bb.0:
-; VI-NEXT:    s_load_dwordx4 s[4:7], s[4:5], 0x24
+; VI-NEXT:    s_load_dwordx4 s[8:11], s[4:5], 0x24
 ; VI-NEXT:    s_mov_b32 s3, 0xf000
 ; VI-NEXT:    s_mov_b32 s2, -1
-; VI-NEXT:    s_mov_b32 s10, s2
-; VI-NEXT:    s_mov_b32 s11, s3
+; VI-NEXT:    s_mov_b32 s6, s2
+; VI-NEXT:    s_mov_b32 s7, s3
 ; VI-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-NEXT:    s_mov_b32 s8, s6
-; VI-NEXT:    s_mov_b32 s9, s7
-; VI-NEXT:    buffer_load_dwordx2 v[0:1], off, s[8:11], 0
-; VI-NEXT:    s_mov_b32 s0, s4
-; VI-NEXT:    s_mov_b32 s7, 0
-; VI-NEXT:    s_mov_b32 s1, s5
-; VI-NEXT:    s_mov_b32 s11, s7
-; VI-NEXT:    s_mov_b32 s9, s7
-; VI-NEXT:    s_mov_b32 s13, s7
-; VI-NEXT:    s_mov_b32 s15, s7
-; VI-NEXT:    s_mov_b32 s17, s7
-; VI-NEXT:    s_mov_b32 s19, s7
-; VI-NEXT:    s_mov_b32 s21, s7
-; VI-NEXT:    s_mov_b32 s23, s7
-; VI-NEXT:    s_mov_b32 s25, s7
-; VI-NEXT:    s_mov_b32 s27, s7
-; VI-NEXT:    s_mov_b32 s29, s7
-; VI-NEXT:    s_mov_b32 s31, s7
-; VI-NEXT:    s_mov_b32 s35, s7
-; VI-NEXT:    s_mov_b32 s37, s7
-; VI-NEXT:    s_mov_b32 s39, s7
-; VI-NEXT:    s_mov_b32 s41, s7
-; VI-NEXT:    s_mov_b32 s43, s7
-; VI-NEXT:    s_mov_b32 s45, s7
-; VI-NEXT:    s_mov_b32 s47, s7
+; VI-NEXT:    s_mov_b32 s4, s10
+; VI-NEXT:    s_mov_b32 s5, s11
+; VI-NEXT:    buffer_load_dwordx2 v[0:1], off, s[4:7], 0
+; VI-NEXT:    s_mov_b32 s5, 0
+; VI-NEXT:    s_mov_b32 s0, s8
+; VI-NEXT:    s_mov_b32 s1, s9
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    v_readfirstlane_b32 s4, v1
-; VI-NEXT:    v_readfirstlane_b32 s6, v0
-; VI-NEXT:    s_bfe_i32 s5, s4, 0x10000
-; VI-NEXT:    s_lshl_b64 s[48:49], s[6:7], 1
-; VI-NEXT:    s_and_b32 s10, s4, 2
-; VI-NEXT:    s_and_b32 s8, s5, s6
-; VI-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s49
-; VI-NEXT:    s_cselect_b32 s10, 0, s48
-; VI-NEXT:    s_lshl_b64 s[48:49], s[6:7], 2
-; VI-NEXT:    s_and_b32 s12, s4, 4
+; VI-NEXT:    v_readfirstlane_b32 s6, v1
+; VI-NEXT:    v_readfirstlane_b32 s4, v0
+; VI-NEXT:    s_bitcmp1_b32 s6, 0
+; VI-NEXT:    s_cselect_b32 s9, 0, 0
+; VI-NEXT:    s_cselect_b32 s8, s4, 0
+; VI-NEXT:    s_lshl_b64 s[10:11], s[4:5], 1
+; VI-NEXT:    s_bitcmp1_b32 s6, 1
+; VI-NEXT:    s_cselect_b32 s11, s11, 0
+; VI-NEXT:    s_cselect_b32 s10, s10, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 2
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s49
-; VI-NEXT:    s_cselect_b32 s10, 0, s48
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 3
-; VI-NEXT:    s_and_b32 s14, s4, 8
+; VI-NEXT:    s_bitcmp1_b32 s6, 2
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 3
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[14:15], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 4
-; VI-NEXT:    s_and_b32 s16, s4, 16
+; VI-NEXT:    s_bitcmp1_b32 s6, 3
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 4
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[16:17], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 5
-; VI-NEXT:    s_and_b32 s18, s4, 32
+; VI-NEXT:    s_bitcmp1_b32 s6, 4
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 5
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[18:19], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 6
-; VI-NEXT:    s_and_b32 s20, s4, 64
+; VI-NEXT:    s_bitcmp1_b32 s6, 5
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 6
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[20:21], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 7
-; VI-NEXT:    s_and_b32 s22, s4, 0x80
+; VI-NEXT:    s_bitcmp1_b32 s6, 6
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 7
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[22:23], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 8
-; VI-NEXT:    s_and_b32 s24, s4, 0x100
+; VI-NEXT:    s_bitcmp1_b32 s6, 7
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 8
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[24:25], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 9
-; VI-NEXT:    s_and_b32 s26, s4, 0x200
+; VI-NEXT:    s_bitcmp1_b32 s6, 8
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 9
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[26:27], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 10
-; VI-NEXT:    s_and_b32 s28, s4, 0x400
+; VI-NEXT:    s_bitcmp1_b32 s6, 9
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 10
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[28:29], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 11
-; VI-NEXT:    s_and_b32 s30, s4, 0x800
+; VI-NEXT:    s_bitcmp1_b32 s6, 10
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 11
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[30:31], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 12
-; VI-NEXT:    s_and_b32 s34, s4, 0x1000
+; VI-NEXT:    s_bitcmp1_b32 s6, 11
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 12
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[34:35], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 13
-; VI-NEXT:    s_and_b32 s36, s4, 0x2000
+; VI-NEXT:    s_bitcmp1_b32 s6, 12
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 13
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[36:37], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 14
-; VI-NEXT:    s_and_b32 s38, s4, 0x4000
+; VI-NEXT:    s_bitcmp1_b32 s6, 13
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 14
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[38:39], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 15
-; VI-NEXT:    s_and_b32 s40, s4, 0x8000
+; VI-NEXT:    s_bitcmp1_b32 s6, 14
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 15
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[40:41], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 16
-; VI-NEXT:    s_and_b32 s42, s4, 0x10000
+; VI-NEXT:    s_bitcmp1_b32 s6, 15
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 16
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[42:43], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 17
-; VI-NEXT:    s_and_b32 s44, s4, 0x20000
+; VI-NEXT:    s_bitcmp1_b32 s6, 16
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 17
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[44:45], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 18
-; VI-NEXT:    s_and_b32 s46, s4, 0x40000
+; VI-NEXT:    s_bitcmp1_b32 s6, 17
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 18
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[46:47], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 19
+; VI-NEXT:    s_bitcmp1_b32 s6, 18
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 19
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_and_b32 s10, s4, 0x80000
-; VI-NEXT:    s_mov_b32 s11, s7
-; VI-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
+; VI-NEXT:    s_bitcmp1_b32 s6, 19
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 20
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 20
-; VI-NEXT:    s_and_b32 s12, s4, 0x100000
-; VI-NEXT:    s_mov_b32 s13, s7
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s11
-; VI-NEXT:    s_cselect_b32 s10, 0, s10
+; VI-NEXT:    s_bitcmp1_b32 s6, 20
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 21
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 21
-; VI-NEXT:    s_and_b32 s12, s4, 0x200000
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s11
-; VI-NEXT:    s_cselect_b32 s10, 0, s10
+; VI-NEXT:    s_bitcmp1_b32 s6, 21
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 22
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 22
-; VI-NEXT:    s_and_b32 s12, s4, 0x400000
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s11
-; VI-NEXT:    s_cselect_b32 s10, 0, s10
+; VI-NEXT:    s_bitcmp1_b32 s6, 22
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 23
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 23
-; VI-NEXT:    s_and_b32 s12, s4, 0x800000
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s11
-; VI-NEXT:    s_cselect_b32 s10, 0, s10
+; VI-NEXT:    s_bitcmp1_b32 s6, 23
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 24
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 24
-; VI-NEXT:    s_and_b32 s12, s4, 0x1000000
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s11
-; VI-NEXT:    s_cselect_b32 s10, 0, s10
+; VI-NEXT:    s_bitcmp1_b32 s6, 24
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 25
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 25
-; VI-NEXT:    s_and_b32 s12, s4, 0x2000000
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s11
-; VI-NEXT:    s_cselect_b32 s10, 0, s10
+; VI-NEXT:    s_bitcmp1_b32 s6, 25
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 26
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 26
-; VI-NEXT:    s_and_b32 s12, s4, 0x4000000
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s11
-; VI-NEXT:    s_cselect_b32 s10, 0, s10
+; VI-NEXT:    s_bitcmp1_b32 s6, 26
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 27
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 27
-; VI-NEXT:    s_and_b32 s12, s4, 0x8000000
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s11
-; VI-NEXT:    s_cselect_b32 s10, 0, s10
+; VI-NEXT:    s_bitcmp1_b32 s6, 27
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 28
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 28
-; VI-NEXT:    s_and_b32 s12, s4, 0x10000000
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s11
-; VI-NEXT:    s_cselect_b32 s10, 0, s10
+; VI-NEXT:    s_bitcmp1_b32 s6, 28
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 29
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 29
-; VI-NEXT:    s_and_b32 s12, s4, 0x20000000
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s11
-; VI-NEXT:    s_cselect_b32 s10, 0, s10
+; VI-NEXT:    s_bitcmp1_b32 s6, 29
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 30
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 30
-; VI-NEXT:    s_and_b32 s12, s4, 2.0
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s11
-; VI-NEXT:    s_cselect_b32 s10, 0, s10
+; VI-NEXT:    s_bitcmp1_b32 s6, 30
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[4:5], s[4:5], 31
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[6:7], s[6:7], 31
-; VI-NEXT:    s_cmp_gt_i32 s4, -1
-; VI-NEXT:    s_cselect_b32 s5, 0, s7
-; VI-NEXT:    s_cselect_b32 s4, 0, s6
+; VI-NEXT:    s_bitcmp1_b32 s6, 31
+; VI-NEXT:    s_cselect_b32 s5, s5, 0
+; VI-NEXT:    s_cselect_b32 s4, s4, 0
 ; VI-NEXT:    s_xor_b64 s[4:5], s[8:9], s[4:5]
 ; VI-NEXT:    s_lshr_b64 s[4:5], s[4:5], 31
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
@@ -1041,220 +901,170 @@ define amdgpu_kernel void @test_clmulr_i32(ptr addrspace(1) %out, ptr addrspace(
 ; GFX9-NEXT:    s_mov_b32 s4, s10
 ; GFX9-NEXT:    s_mov_b32 s5, s11
 ; GFX9-NEXT:    buffer_load_dwordx2 v[0:1], off, s[4:7], 0
-; GFX9-NEXT:    s_mov_b32 s0, s8
 ; GFX9-NEXT:    s_mov_b32 s5, 0
-; GFX9-NEXT:    s_mov_b32 s11, s5
-; GFX9-NEXT:    s_mov_b32 s7, s5
-; GFX9-NEXT:    s_mov_b32 s13, s5
-; GFX9-NEXT:    s_mov_b32 s15, s5
-; GFX9-NEXT:    s_mov_b32 s17, s5
-; GFX9-NEXT:    s_mov_b32 s19, s5
-; GFX9-NEXT:    s_mov_b32 s21, s5
-; GFX9-NEXT:    s_mov_b32 s23, s5
-; GFX9-NEXT:    s_mov_b32 s25, s5
-; GFX9-NEXT:    s_mov_b32 s27, s5
-; GFX9-NEXT:    s_mov_b32 s29, s5
-; GFX9-NEXT:    s_mov_b32 s31, s5
-; GFX9-NEXT:    s_mov_b32 s35, s5
-; GFX9-NEXT:    s_mov_b32 s37, s5
-; GFX9-NEXT:    s_mov_b32 s39, s5
-; GFX9-NEXT:    s_mov_b32 s41, s5
-; GFX9-NEXT:    s_mov_b32 s43, s5
-; GFX9-NEXT:    s_mov_b32 s45, s5
-; GFX9-NEXT:    s_mov_b32 s47, s5
+; GFX9-NEXT:    s_mov_b32 s0, s8
 ; GFX9-NEXT:    s_mov_b32 s1, s9
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v1
 ; GFX9-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX9-NEXT:    s_bfe_i32 s6, s8, 0x10000
-; GFX9-NEXT:    s_lshl_b64 s[48:49], s[4:5], 1
-; GFX9-NEXT:    s_and_b32 s10, s8, 2
-; GFX9-NEXT:    s_and_b32 s6, s6, s4
-; GFX9-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s49
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s48
-; GFX9-NEXT:    s_lshl_b64 s[48:49], s[4:5], 2
-; GFX9-NEXT:    s_and_b32 s12, s8, 4
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s49
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s48
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 0
+; GFX9-NEXT:    s_cselect_b32 s9, 0, 0
+; GFX9-NEXT:    s_cselect_b32 s8, s4, 0
+; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 1
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 1
+; GFX9-NEXT:    s_cselect_b32 s11, s11, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s10, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 2
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 2
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 3
-; GFX9-NEXT:    s_and_b32 s14, s8, 8
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[14:15], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 3
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 4
-; GFX9-NEXT:    s_and_b32 s16, s8, 16
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[16:17], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 4
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 5
-; GFX9-NEXT:    s_and_b32 s18, s8, 32
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[18:19], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 5
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 6
-; GFX9-NEXT:    s_and_b32 s20, s8, 64
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[20:21], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 6
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 7
-; GFX9-NEXT:    s_and_b32 s22, s8, 0x80
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[22:23], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 7
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 8
-; GFX9-NEXT:    s_and_b32 s24, s8, 0x100
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[24:25], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 8
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 9
-; GFX9-NEXT:    s_and_b32 s26, s8, 0x200
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[26:27], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 9
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 10
-; GFX9-NEXT:    s_and_b32 s28, s8, 0x400
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[28:29], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 10
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 11
-; GFX9-NEXT:    s_and_b32 s30, s8, 0x800
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[30:31], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 11
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 12
-; GFX9-NEXT:    s_and_b32 s34, s8, 0x1000
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[34:35], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 12
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 13
-; GFX9-NEXT:    s_and_b32 s36, s8, 0x2000
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[36:37], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 13
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 14
-; GFX9-NEXT:    s_and_b32 s38, s8, 0x4000
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[38:39], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 14
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 15
-; GFX9-NEXT:    s_and_b32 s40, s8, 0x8000
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[40:41], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 15
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 16
-; GFX9-NEXT:    s_and_b32 s42, s8, 0x10000
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[42:43], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 16
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 17
-; GFX9-NEXT:    s_and_b32 s44, s8, 0x20000
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[44:45], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 17
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 18
-; GFX9-NEXT:    s_and_b32 s46, s8, 0x40000
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[46:47], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 18
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 19
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_and_b32 s10, s8, 0x80000
-; GFX9-NEXT:    s_mov_b32 s11, s5
-; GFX9-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 20
-; GFX9-NEXT:    s_and_b32 s12, s8, 0x100000
-; GFX9-NEXT:    s_mov_b32 s13, s5
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 21
-; GFX9-NEXT:    s_and_b32 s12, s8, 0x200000
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 22
-; GFX9-NEXT:    s_and_b32 s12, s8, 0x400000
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 23
-; GFX9-NEXT:    s_and_b32 s12, s8, 0x800000
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 24
-; GFX9-NEXT:    s_and_b32 s12, s8, 0x1000000
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 25
-; GFX9-NEXT:    s_and_b32 s12, s8, 0x2000000
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 26
-; GFX9-NEXT:    s_and_b32 s12, s8, 0x4000000
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 27
-; GFX9-NEXT:    s_and_b32 s12, s8, 0x8000000
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 28
-; GFX9-NEXT:    s_and_b32 s12, s8, 0x10000000
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 29
-; GFX9-NEXT:    s_and_b32 s12, s8, 0x20000000
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 30
-; GFX9-NEXT:    s_and_b32 s12, s8, 2.0
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 19
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 20
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 20
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 21
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 21
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 22
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 22
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 23
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 23
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 24
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 24
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 25
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 25
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 26
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 26
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 27
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 27
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 28
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 28
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 29
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 29
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 30
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 30
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[4:5], s[4:5], 31
-; GFX9-NEXT:    s_cmp_gt_i32 s8, -1
-; GFX9-NEXT:    s_cselect_b32 s5, 0, s5
-; GFX9-NEXT:    s_cselect_b32 s4, 0, s4
-; GFX9-NEXT:    s_xor_b64 s[4:5], s[6:7], s[4:5]
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 31
+; GFX9-NEXT:    s_cselect_b32 s5, s5, 0
+; GFX9-NEXT:    s_cselect_b32 s4, s4, 0
+; GFX9-NEXT:    s_xor_b64 s[4:5], s[8:9], s[4:5]
 ; GFX9-NEXT:    s_lshr_b64 s[4:5], s[4:5], 31
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    buffer_store_dword v0, off, s[0:3], 0
@@ -1272,200 +1082,168 @@ define amdgpu_kernel void @test_clmulr_i32(ptr addrspace(1) %out, ptr addrspace(
 ; GFX10-NEXT:    s_mov_b32 s9, s3
 ; GFX10-NEXT:    s_mov_b32 s3, 0
 ; GFX10-NEXT:    buffer_load_dwordx2 v[0:1], off, s[8:11], 0
-; GFX10-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
-; GFX10-NEXT:    s_mov_b32 s11, s3
-; GFX10-NEXT:    s_mov_b32 s9, s3
+; GFX10-NEXT:    s_mov_b32 s5, s1
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-NEXT:    v_readfirstlane_b32 s4, v1
 ; GFX10-NEXT:    v_readfirstlane_b32 s2, v0
-; GFX10-NEXT:    s_bfe_i32 s5, s4, 0x10000
-; GFX10-NEXT:    s_and_b32 s10, s4, 2
-; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 1
-; GFX10-NEXT:    s_and_b32 s8, s5, s2
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_mov_b32 s5, s1
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s13
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s12
-; GFX10-NEXT:    s_and_b32 s10, s4, 4
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 2
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 8
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 3
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 16
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 4
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 32
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 5
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 64
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 6
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x80
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 7
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x100
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 8
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x200
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 9
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x400
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 10
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x800
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 11
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x1000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 12
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x2000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 13
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x4000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 14
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x8000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 15
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x10000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 16
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x20000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 17
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x40000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 18
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x80000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 19
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x100000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 20
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x200000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 21
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x400000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 22
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x800000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 23
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x1000000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 24
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x2000000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 25
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x4000000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 26
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x8000000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 27
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x10000000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 28
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x20000000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 29
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 2.0
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 30
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s11, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s10, 0, s14
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 0
+; GFX10-NEXT:    s_cselect_b32 s9, 0, 0
+; GFX10-NEXT:    s_cselect_b32 s8, s2, 0
+; GFX10-NEXT:    s_lshl_b64 s[10:11], s[2:3], 1
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 1
+; GFX10-NEXT:    s_cselect_b32 s11, s11, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s10, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 2
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 2
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 3
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 3
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 4
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 4
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 5
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 5
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 6
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 6
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 7
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 7
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 8
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 8
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 9
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 9
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 10
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 10
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 11
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 11
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 12
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 12
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 13
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 13
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 14
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 14
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 15
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 15
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 16
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 16
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 17
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 17
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 18
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 18
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 19
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 19
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 20
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 20
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 21
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 21
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 22
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 22
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 23
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 23
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 24
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 24
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 25
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 25
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 26
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 26
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 27
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 27
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 28
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 28
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 29
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 29
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 30
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 30
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX10-NEXT:    s_lshl_b64 s[2:3], s[2:3], 31
 ; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; GFX10-NEXT:    s_cmp_gt_i32 s4, -1
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 31
 ; GFX10-NEXT:    s_mov_b32 s4, s0
-; GFX10-NEXT:    s_cselect_b32 s3, 0, s3
-; GFX10-NEXT:    s_cselect_b32 s2, 0, s2
+; GFX10-NEXT:    s_cselect_b32 s3, s3, 0
+; GFX10-NEXT:    s_cselect_b32 s2, s2, 0
 ; GFX10-NEXT:    s_xor_b64 s[2:3], s[8:9], s[2:3]
 ; GFX10-NEXT:    s_lshr_b64 s[2:3], s[2:3], 31
 ; GFX10-NEXT:    v_mov_b32_e32 v0, s2
@@ -1484,199 +1262,168 @@ define amdgpu_kernel void @test_clmulr_i32(ptr addrspace(1) %out, ptr addrspace(
 ; GFX11-NEXT:    s_mov_b32 s9, s3
 ; GFX11-NEXT:    s_mov_b32 s3, 0
 ; GFX11-NEXT:    buffer_load_b64 v[0:1], off, s[8:11], 0
-; GFX11-NEXT:    s_mov_b32 s11, s3
-; GFX11-NEXT:    s_mov_b32 s9, s3
+; GFX11-NEXT:    s_mov_b32 s5, s1
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    v_readfirstlane_b32 s4, v1
 ; GFX11-NEXT:    v_readfirstlane_b32 s2, v0
-; GFX11-NEXT:    s_bfe_i32 s5, s4, 0x10000
-; GFX11-NEXT:    s_and_b32 s10, s4, 2
-; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 1
-; GFX11-NEXT:    s_and_b32 s8, s5, s2
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_mov_b32 s5, s1
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s13
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s12
-; GFX11-NEXT:    s_and_b32 s10, s4, 4
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 2
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 8
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 3
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 16
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 4
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 32
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 5
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 64
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 6
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x80
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 7
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x100
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 8
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x200
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 9
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x400
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 10
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x800
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 11
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x1000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 12
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x2000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 13
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x4000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 14
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x8000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 15
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x10000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 16
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x20000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 17
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x40000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 18
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x80000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 19
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x100000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 20
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x200000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 21
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x400000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 22
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x800000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 23
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x1000000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 24
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x2000000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 25
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x4000000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 26
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x8000000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 27
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x10000000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 28
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x20000000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 29
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 2.0
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 30
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s11, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s10, 0, s14
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 0
+; GFX11-NEXT:    s_cselect_b32 s9, 0, 0
+; GFX11-NEXT:    s_cselect_b32 s8, s2, 0
+; GFX11-NEXT:    s_lshl_b64 s[10:11], s[2:3], 1
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 1
+; GFX11-NEXT:    s_cselect_b32 s11, s11, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s10, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 2
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 2
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 3
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 3
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 4
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 4
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 5
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 5
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 6
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 6
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 7
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 7
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 8
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 8
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 9
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 9
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 10
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 10
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 11
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 11
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 12
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 12
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 13
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 13
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 14
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 14
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 15
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 15
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 16
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 16
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 17
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 17
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 18
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 18
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 19
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 19
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 20
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 20
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 21
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 21
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 22
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 22
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 23
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 23
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 24
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 24
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 25
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 25
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 26
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 26
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 27
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 27
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 28
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 28
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 29
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 29
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 30
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 30
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX11-NEXT:    s_lshl_b64 s[2:3], s[2:3], 31
 ; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; GFX11-NEXT:    s_cmp_gt_i32 s4, -1
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 31
 ; GFX11-NEXT:    s_mov_b32 s4, s0
-; GFX11-NEXT:    s_cselect_b32 s3, 0, s3
-; GFX11-NEXT:    s_cselect_b32 s2, 0, s2
+; GFX11-NEXT:    s_cselect_b32 s3, s3, 0
+; GFX11-NEXT:    s_cselect_b32 s2, s2, 0
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX11-NEXT:    s_xor_b64 s[2:3], s[8:9], s[2:3]
 ; GFX11-NEXT:    s_lshr_b64 s[2:3], s[2:3], 31
@@ -2014,497 +1761,357 @@ define amdgpu_kernel void @test_clmulr_i32(ptr addrspace(1) %out, ptr addrspace(
 define amdgpu_kernel void @test_clmulh_i32(ptr addrspace(1) %out, ptr addrspace(1) %in) {
 ; SI-LABEL: test_clmulh_i32:
 ; SI:       ; %bb.0:
-; SI-NEXT:    s_load_dwordx4 s[4:7], s[4:5], 0x9
+; SI-NEXT:    s_load_dwordx4 s[8:11], s[4:5], 0x9
 ; SI-NEXT:    s_mov_b32 s3, 0xf000
 ; SI-NEXT:    s_mov_b32 s2, -1
-; SI-NEXT:    s_mov_b32 s10, s2
-; SI-NEXT:    s_mov_b32 s11, s3
+; SI-NEXT:    s_mov_b32 s6, s2
+; SI-NEXT:    s_mov_b32 s7, s3
 ; SI-NEXT:    s_waitcnt lgkmcnt(0)
-; SI-NEXT:    s_mov_b32 s8, s6
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    buffer_load_dwordx2 v[0:1], off, s[8:11], 0
-; SI-NEXT:    s_mov_b32 s7, 0
-; SI-NEXT:    s_mov_b32 s21, s7
-; SI-NEXT:    s_mov_b32 s0, s4
-; SI-NEXT:    s_mov_b32 s1, s5
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    s_mov_b32 s15, s7
-; SI-NEXT:    s_mov_b32 s11, s7
-; SI-NEXT:    s_mov_b32 s13, s7
-; SI-NEXT:    s_mov_b32 s17, s7
-; SI-NEXT:    s_mov_b32 s19, s7
-; SI-NEXT:    s_mov_b32 s23, s7
-; SI-NEXT:    s_mov_b32 s25, s7
-; SI-NEXT:    s_mov_b32 s27, s7
-; SI-NEXT:    s_mov_b32 s29, s7
-; SI-NEXT:    s_mov_b32 s31, s7
-; SI-NEXT:    s_mov_b32 s35, s7
-; SI-NEXT:    s_mov_b32 s37, s7
-; SI-NEXT:    s_mov_b32 s39, s7
-; SI-NEXT:    s_mov_b32 s41, s7
-; SI-NEXT:    s_mov_b32 s43, s7
+; SI-NEXT:    s_mov_b32 s4, s10
+; SI-NEXT:    s_mov_b32 s5, s11
+; SI-NEXT:    buffer_load_dwordx2 v[0:1], off, s[4:7], 0
+; SI-NEXT:    s_mov_b32 s5, 0
+; SI-NEXT:    s_mov_b32 s0, s8
+; SI-NEXT:    s_mov_b32 s1, s9
 ; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    v_readfirstlane_b32 s33, v1
-; SI-NEXT:    s_and_b32 s20, s33, 2
-; SI-NEXT:    v_readfirstlane_b32 s6, v0
-; SI-NEXT:    s_bfe_i32 s8, s33, 0x10000
-; SI-NEXT:    v_cmp_eq_u64_e64 s[20:21], s[20:21], 0
-; SI-NEXT:    s_lshl_b64 s[4:5], s[6:7], 1
-; SI-NEXT:    s_and_b32 s8, s8, s6
-; SI-NEXT:    s_and_b64 s[20:21], s[20:21], exec
-; SI-NEXT:    s_cselect_b32 s21, 0, s5
-; SI-NEXT:    s_cselect_b32 s20, 0, s4
-; SI-NEXT:    s_and_b32 s14, s33, 4
-; SI-NEXT:    s_xor_b64 s[20:21], s[8:9], s[20:21]
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[14:15], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 2
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s15, 0, s15
-; SI-NEXT:    s_cselect_b32 s14, 0, s14
-; SI-NEXT:    s_and_b32 s10, s33, 8
-; SI-NEXT:    v_cmp_eq_u64_e64 s[10:11], s[10:11], 0
-; SI-NEXT:    s_xor_b64 s[14:15], s[20:21], s[14:15]
-; SI-NEXT:    s_lshl_b64 s[20:21], s[6:7], 3
-; SI-NEXT:    s_and_b64 s[10:11], s[10:11], exec
-; SI-NEXT:    s_cselect_b32 s11, 0, s21
-; SI-NEXT:    s_cselect_b32 s10, 0, s20
-; SI-NEXT:    s_and_b32 s12, s33, 16
-; SI-NEXT:    v_cmp_eq_u64_e64 s[12:13], s[12:13], 0
-; SI-NEXT:    s_lshl_b64 s[20:21], s[6:7], 4
-; SI-NEXT:    s_xor_b64 s[10:11], s[14:15], s[10:11]
-; SI-NEXT:    s_and_b64 s[12:13], s[12:13], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s21
-; SI-NEXT:    s_cselect_b32 s12, 0, s20
-; SI-NEXT:    s_and_b32 s16, s33, 32
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[16:17], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 5
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s18, s33, 64
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[18:19], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 6
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s22, s33, 0x80
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[22:23], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 7
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s24, s33, 0x100
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[24:25], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 8
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s26, s33, 0x200
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[26:27], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 9
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s28, s33, 0x400
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[28:29], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 10
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s30, s33, 0x800
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[30:31], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 11
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s34, s33, 0x1000
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[34:35], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 12
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s36, s33, 0x2000
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[36:37], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 13
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s38, s33, 0x4000
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[38:39], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 14
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s40, s33, 0x8000
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[40:41], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 15
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s42, s33, 0x10000
-; SI-NEXT:    v_cmp_eq_u64_e64 s[16:17], s[42:43], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 16
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[12:13], s[16:17], exec
-; SI-NEXT:    s_mov_b32 s5, s7
-; SI-NEXT:    s_cselect_b32 s13, 0, s15
-; SI-NEXT:    s_cselect_b32 s12, 0, s14
-; SI-NEXT:    s_and_b32 s4, s33, 0x20000
-; SI-NEXT:    v_cmp_eq_u64_e64 s[4:5], s[4:5], 0
-; SI-NEXT:    s_lshl_b64 s[14:15], s[6:7], 17
-; SI-NEXT:    s_xor_b64 s[10:11], s[10:11], s[12:13]
-; SI-NEXT:    s_and_b64 s[4:5], s[4:5], exec
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    s_cselect_b32 s5, 0, s15
-; SI-NEXT:    s_cselect_b32 s4, 0, s14
-; SI-NEXT:    s_and_b32 s8, s33, 0x40000
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 18
-; SI-NEXT:    s_xor_b64 s[4:5], s[10:11], s[4:5]
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s13
-; SI-NEXT:    s_cselect_b32 s8, 0, s12
-; SI-NEXT:    s_and_b32 s10, s33, 0x80000
-; SI-NEXT:    s_mov_b32 s11, s7
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[10:11], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 19
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_and_b32 s8, s33, 0x100000
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 20
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_and_b32 s8, s33, 0x200000
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 21
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_and_b32 s8, s33, 0x400000
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 22
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_and_b32 s8, s33, 0x800000
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 23
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_and_b32 s8, s33, 0x1000000
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 24
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_and_b32 s8, s33, 0x2000000
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 25
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_and_b32 s8, s33, 0x4000000
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 26
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_and_b32 s8, s33, 0x8000000
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 27
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_and_b32 s8, s33, 0x10000000
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 28
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_and_b32 s8, s33, 0x20000000
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 29
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_and_b32 s8, s33, 2.0
-; SI-NEXT:    s_mov_b32 s9, s7
-; SI-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[8:9], 0
-; SI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 30
-; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; SI-NEXT:    s_cselect_b32 s9, 0, s11
-; SI-NEXT:    s_cselect_b32 s8, 0, s10
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[8:9]
-; SI-NEXT:    s_lshl_b64 s[6:7], s[6:7], 31
-; SI-NEXT:    s_cmp_gt_i32 s33, -1
-; SI-NEXT:    s_cselect_b32 s7, 0, s7
-; SI-NEXT:    s_cselect_b32 s6, 0, s6
-; SI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[6:7]
+; SI-NEXT:    v_readfirstlane_b32 s6, v1
+; SI-NEXT:    v_readfirstlane_b32 s4, v0
+; SI-NEXT:    s_bitcmp1_b32 s6, 0
+; SI-NEXT:    s_cselect_b32 s9, 0, 0
+; SI-NEXT:    s_cselect_b32 s8, s4, 0
+; SI-NEXT:    s_lshl_b64 s[10:11], s[4:5], 1
+; SI-NEXT:    s_bitcmp1_b32 s6, 1
+; SI-NEXT:    s_cselect_b32 s11, s11, 0
+; SI-NEXT:    s_cselect_b32 s10, s10, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 2
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 2
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 3
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 3
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 4
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 4
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 5
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 5
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 6
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 6
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 7
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 7
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 8
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 8
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 9
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 9
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 10
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 10
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 11
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 11
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 12
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 12
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 13
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 13
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 14
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 14
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 15
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 15
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 16
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 16
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 17
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 17
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 18
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 18
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 19
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 19
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 20
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 20
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 21
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 21
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 22
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 22
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 23
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 23
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 24
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 24
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 25
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 25
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 26
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 26
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 27
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 27
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 28
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 28
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 29
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 29
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 30
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 30
+; SI-NEXT:    s_cselect_b32 s11, s13, 0
+; SI-NEXT:    s_cselect_b32 s10, s12, 0
+; SI-NEXT:    s_lshl_b64 s[4:5], s[4:5], 31
+; SI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_bitcmp1_b32 s6, 31
+; SI-NEXT:    s_cselect_b32 s5, s5, 0
+; SI-NEXT:    s_cselect_b32 s4, s4, 0
+; SI-NEXT:    s_xor_b64 s[4:5], s[8:9], s[4:5]
 ; SI-NEXT:    v_mov_b32_e32 v0, s5
 ; SI-NEXT:    buffer_store_dword v0, off, s[0:3], 0
 ; SI-NEXT:    s_endpgm
 ;
 ; VI-LABEL: test_clmulh_i32:
 ; VI:       ; %bb.0:
-; VI-NEXT:    s_load_dwordx4 s[4:7], s[4:5], 0x24
+; VI-NEXT:    s_load_dwordx4 s[8:11], s[4:5], 0x24
 ; VI-NEXT:    s_mov_b32 s3, 0xf000
 ; VI-NEXT:    s_mov_b32 s2, -1
-; VI-NEXT:    s_mov_b32 s10, s2
-; VI-NEXT:    s_mov_b32 s11, s3
+; VI-NEXT:    s_mov_b32 s6, s2
+; VI-NEXT:    s_mov_b32 s7, s3
 ; VI-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-NEXT:    s_mov_b32 s8, s6
-; VI-NEXT:    s_mov_b32 s9, s7
-; VI-NEXT:    buffer_load_dwordx2 v[0:1], off, s[8:11], 0
-; VI-NEXT:    s_mov_b32 s0, s4
-; VI-NEXT:    s_mov_b32 s7, 0
-; VI-NEXT:    s_mov_b32 s1, s5
-; VI-NEXT:    s_mov_b32 s11, s7
-; VI-NEXT:    s_mov_b32 s9, s7
-; VI-NEXT:    s_mov_b32 s13, s7
-; VI-NEXT:    s_mov_b32 s15, s7
-; VI-NEXT:    s_mov_b32 s17, s7
-; VI-NEXT:    s_mov_b32 s19, s7
-; VI-NEXT:    s_mov_b32 s21, s7
-; VI-NEXT:    s_mov_b32 s23, s7
-; VI-NEXT:    s_mov_b32 s25, s7
-; VI-NEXT:    s_mov_b32 s27, s7
-; VI-NEXT:    s_mov_b32 s29, s7
-; VI-NEXT:    s_mov_b32 s31, s7
-; VI-NEXT:    s_mov_b32 s35, s7
-; VI-NEXT:    s_mov_b32 s37, s7
-; VI-NEXT:    s_mov_b32 s39, s7
-; VI-NEXT:    s_mov_b32 s41, s7
-; VI-NEXT:    s_mov_b32 s43, s7
-; VI-NEXT:    s_mov_b32 s45, s7
-; VI-NEXT:    s_mov_b32 s47, s7
+; VI-NEXT:    s_mov_b32 s4, s10
+; VI-NEXT:    s_mov_b32 s5, s11
+; VI-NEXT:    buffer_load_dwordx2 v[0:1], off, s[4:7], 0
+; VI-NEXT:    s_mov_b32 s5, 0
+; VI-NEXT:    s_mov_b32 s0, s8
+; VI-NEXT:    s_mov_b32 s1, s9
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    v_readfirstlane_b32 s4, v1
-; VI-NEXT:    v_readfirstlane_b32 s6, v0
-; VI-NEXT:    s_bfe_i32 s5, s4, 0x10000
-; VI-NEXT:    s_lshl_b64 s[48:49], s[6:7], 1
-; VI-NEXT:    s_and_b32 s10, s4, 2
-; VI-NEXT:    s_and_b32 s8, s5, s6
-; VI-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s49
-; VI-NEXT:    s_cselect_b32 s10, 0, s48
-; VI-NEXT:    s_lshl_b64 s[48:49], s[6:7], 2
-; VI-NEXT:    s_and_b32 s12, s4, 4
+; VI-NEXT:    v_readfirstlane_b32 s6, v1
+; VI-NEXT:    v_readfirstlane_b32 s4, v0
+; VI-NEXT:    s_bitcmp1_b32 s6, 0
+; VI-NEXT:    s_cselect_b32 s9, 0, 0
+; VI-NEXT:    s_cselect_b32 s8, s4, 0
+; VI-NEXT:    s_lshl_b64 s[10:11], s[4:5], 1
+; VI-NEXT:    s_bitcmp1_b32 s6, 1
+; VI-NEXT:    s_cselect_b32 s11, s11, 0
+; VI-NEXT:    s_cselect_b32 s10, s10, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 2
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s49
-; VI-NEXT:    s_cselect_b32 s10, 0, s48
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 3
-; VI-NEXT:    s_and_b32 s14, s4, 8
+; VI-NEXT:    s_bitcmp1_b32 s6, 2
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 3
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[14:15], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 4
-; VI-NEXT:    s_and_b32 s16, s4, 16
+; VI-NEXT:    s_bitcmp1_b32 s6, 3
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 4
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[16:17], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 5
-; VI-NEXT:    s_and_b32 s18, s4, 32
+; VI-NEXT:    s_bitcmp1_b32 s6, 4
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 5
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[18:19], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 6
-; VI-NEXT:    s_and_b32 s20, s4, 64
+; VI-NEXT:    s_bitcmp1_b32 s6, 5
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 6
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[20:21], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 7
-; VI-NEXT:    s_and_b32 s22, s4, 0x80
+; VI-NEXT:    s_bitcmp1_b32 s6, 6
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 7
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[22:23], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 8
-; VI-NEXT:    s_and_b32 s24, s4, 0x100
+; VI-NEXT:    s_bitcmp1_b32 s6, 7
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 8
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[24:25], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 9
-; VI-NEXT:    s_and_b32 s26, s4, 0x200
+; VI-NEXT:    s_bitcmp1_b32 s6, 8
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 9
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[26:27], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 10
-; VI-NEXT:    s_and_b32 s28, s4, 0x400
+; VI-NEXT:    s_bitcmp1_b32 s6, 9
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 10
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[28:29], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 11
-; VI-NEXT:    s_and_b32 s30, s4, 0x800
+; VI-NEXT:    s_bitcmp1_b32 s6, 10
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 11
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[30:31], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 12
-; VI-NEXT:    s_and_b32 s34, s4, 0x1000
+; VI-NEXT:    s_bitcmp1_b32 s6, 11
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 12
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[34:35], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 13
-; VI-NEXT:    s_and_b32 s36, s4, 0x2000
+; VI-NEXT:    s_bitcmp1_b32 s6, 12
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 13
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[36:37], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 14
-; VI-NEXT:    s_and_b32 s38, s4, 0x4000
+; VI-NEXT:    s_bitcmp1_b32 s6, 13
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 14
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[38:39], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 15
-; VI-NEXT:    s_and_b32 s40, s4, 0x8000
+; VI-NEXT:    s_bitcmp1_b32 s6, 14
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 15
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[40:41], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 16
-; VI-NEXT:    s_and_b32 s42, s4, 0x10000
+; VI-NEXT:    s_bitcmp1_b32 s6, 15
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 16
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[42:43], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 17
-; VI-NEXT:    s_and_b32 s44, s4, 0x20000
+; VI-NEXT:    s_bitcmp1_b32 s6, 16
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 17
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[44:45], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 18
-; VI-NEXT:    s_and_b32 s46, s4, 0x40000
+; VI-NEXT:    s_bitcmp1_b32 s6, 17
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 18
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_cmp_eq_u64 s[46:47], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
-; VI-NEXT:    s_lshl_b64 s[12:13], s[6:7], 19
+; VI-NEXT:    s_bitcmp1_b32 s6, 18
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 19
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_and_b32 s10, s4, 0x80000
-; VI-NEXT:    s_mov_b32 s11, s7
-; VI-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s13
-; VI-NEXT:    s_cselect_b32 s10, 0, s12
+; VI-NEXT:    s_bitcmp1_b32 s6, 19
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 20
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 20
-; VI-NEXT:    s_and_b32 s12, s4, 0x100000
-; VI-NEXT:    s_mov_b32 s13, s7
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s11
-; VI-NEXT:    s_cselect_b32 s10, 0, s10
+; VI-NEXT:    s_bitcmp1_b32 s6, 20
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 21
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 21
-; VI-NEXT:    s_and_b32 s12, s4, 0x200000
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s11
-; VI-NEXT:    s_cselect_b32 s10, 0, s10
+; VI-NEXT:    s_bitcmp1_b32 s6, 21
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 22
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 22
-; VI-NEXT:    s_and_b32 s12, s4, 0x400000
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s11
-; VI-NEXT:    s_cselect_b32 s10, 0, s10
+; VI-NEXT:    s_bitcmp1_b32 s6, 22
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 23
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 23
-; VI-NEXT:    s_and_b32 s12, s4, 0x800000
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s11
-; VI-NEXT:    s_cselect_b32 s10, 0, s10
+; VI-NEXT:    s_bitcmp1_b32 s6, 23
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 24
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 24
-; VI-NEXT:    s_and_b32 s12, s4, 0x1000000
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s11
-; VI-NEXT:    s_cselect_b32 s10, 0, s10
+; VI-NEXT:    s_bitcmp1_b32 s6, 24
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 25
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 25
-; VI-NEXT:    s_and_b32 s12, s4, 0x2000000
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s11
-; VI-NEXT:    s_cselect_b32 s10, 0, s10
+; VI-NEXT:    s_bitcmp1_b32 s6, 25
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 26
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 26
-; VI-NEXT:    s_and_b32 s12, s4, 0x4000000
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s11
-; VI-NEXT:    s_cselect_b32 s10, 0, s10
+; VI-NEXT:    s_bitcmp1_b32 s6, 26
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 27
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 27
-; VI-NEXT:    s_and_b32 s12, s4, 0x8000000
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s11
-; VI-NEXT:    s_cselect_b32 s10, 0, s10
+; VI-NEXT:    s_bitcmp1_b32 s6, 27
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 28
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 28
-; VI-NEXT:    s_and_b32 s12, s4, 0x10000000
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s11
-; VI-NEXT:    s_cselect_b32 s10, 0, s10
+; VI-NEXT:    s_bitcmp1_b32 s6, 28
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 29
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 29
-; VI-NEXT:    s_and_b32 s12, s4, 0x20000000
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s11
-; VI-NEXT:    s_cselect_b32 s10, 0, s10
+; VI-NEXT:    s_bitcmp1_b32 s6, 29
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[12:13], s[4:5], 30
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[10:11], s[6:7], 30
-; VI-NEXT:    s_and_b32 s12, s4, 2.0
-; VI-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; VI-NEXT:    s_cselect_b32 s11, 0, s11
-; VI-NEXT:    s_cselect_b32 s10, 0, s10
+; VI-NEXT:    s_bitcmp1_b32 s6, 30
+; VI-NEXT:    s_cselect_b32 s11, s13, 0
+; VI-NEXT:    s_cselect_b32 s10, s12, 0
+; VI-NEXT:    s_lshl_b64 s[4:5], s[4:5], 31
 ; VI-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; VI-NEXT:    s_lshl_b64 s[6:7], s[6:7], 31
-; VI-NEXT:    s_cmp_gt_i32 s4, -1
-; VI-NEXT:    s_cselect_b32 s5, 0, s7
-; VI-NEXT:    s_cselect_b32 s4, 0, s6
+; VI-NEXT:    s_bitcmp1_b32 s6, 31
+; VI-NEXT:    s_cselect_b32 s5, s5, 0
+; VI-NEXT:    s_cselect_b32 s4, s4, 0
 ; VI-NEXT:    s_xor_b64 s[4:5], s[8:9], s[4:5]
 ; VI-NEXT:    v_mov_b32_e32 v0, s5
 ; VI-NEXT:    buffer_store_dword v0, off, s[0:3], 0
@@ -2521,220 +2128,170 @@ define amdgpu_kernel void @test_clmulh_i32(ptr addrspace(1) %out, ptr addrspace(
 ; GFX9-NEXT:    s_mov_b32 s4, s10
 ; GFX9-NEXT:    s_mov_b32 s5, s11
 ; GFX9-NEXT:    buffer_load_dwordx2 v[0:1], off, s[4:7], 0
-; GFX9-NEXT:    s_mov_b32 s0, s8
 ; GFX9-NEXT:    s_mov_b32 s5, 0
-; GFX9-NEXT:    s_mov_b32 s11, s5
-; GFX9-NEXT:    s_mov_b32 s7, s5
-; GFX9-NEXT:    s_mov_b32 s13, s5
-; GFX9-NEXT:    s_mov_b32 s15, s5
-; GFX9-NEXT:    s_mov_b32 s17, s5
-; GFX9-NEXT:    s_mov_b32 s19, s5
-; GFX9-NEXT:    s_mov_b32 s21, s5
-; GFX9-NEXT:    s_mov_b32 s23, s5
-; GFX9-NEXT:    s_mov_b32 s25, s5
-; GFX9-NEXT:    s_mov_b32 s27, s5
-; GFX9-NEXT:    s_mov_b32 s29, s5
-; GFX9-NEXT:    s_mov_b32 s31, s5
-; GFX9-NEXT:    s_mov_b32 s35, s5
-; GFX9-NEXT:    s_mov_b32 s37, s5
-; GFX9-NEXT:    s_mov_b32 s39, s5
-; GFX9-NEXT:    s_mov_b32 s41, s5
-; GFX9-NEXT:    s_mov_b32 s43, s5
-; GFX9-NEXT:    s_mov_b32 s45, s5
-; GFX9-NEXT:    s_mov_b32 s47, s5
+; GFX9-NEXT:    s_mov_b32 s0, s8
 ; GFX9-NEXT:    s_mov_b32 s1, s9
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v1
 ; GFX9-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX9-NEXT:    s_bfe_i32 s6, s8, 0x10000
-; GFX9-NEXT:    s_lshl_b64 s[48:49], s[4:5], 1
-; GFX9-NEXT:    s_and_b32 s10, s8, 2
-; GFX9-NEXT:    s_and_b32 s6, s6, s4
-; GFX9-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s49
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s48
-; GFX9-NEXT:    s_lshl_b64 s[48:49], s[4:5], 2
-; GFX9-NEXT:    s_and_b32 s12, s8, 4
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s49
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s48
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 0
+; GFX9-NEXT:    s_cselect_b32 s9, 0, 0
+; GFX9-NEXT:    s_cselect_b32 s8, s4, 0
+; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 1
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 1
+; GFX9-NEXT:    s_cselect_b32 s11, s11, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s10, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 2
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 2
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 3
-; GFX9-NEXT:    s_and_b32 s14, s8, 8
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[14:15], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 3
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 4
-; GFX9-NEXT:    s_and_b32 s16, s8, 16
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[16:17], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 4
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 5
-; GFX9-NEXT:    s_and_b32 s18, s8, 32
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[18:19], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 5
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 6
-; GFX9-NEXT:    s_and_b32 s20, s8, 64
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[20:21], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 6
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 7
-; GFX9-NEXT:    s_and_b32 s22, s8, 0x80
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[22:23], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 7
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 8
-; GFX9-NEXT:    s_and_b32 s24, s8, 0x100
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[24:25], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 8
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 9
-; GFX9-NEXT:    s_and_b32 s26, s8, 0x200
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[26:27], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 9
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 10
-; GFX9-NEXT:    s_and_b32 s28, s8, 0x400
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[28:29], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 10
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 11
-; GFX9-NEXT:    s_and_b32 s30, s8, 0x800
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[30:31], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 11
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 12
-; GFX9-NEXT:    s_and_b32 s34, s8, 0x1000
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[34:35], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 12
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 13
-; GFX9-NEXT:    s_and_b32 s36, s8, 0x2000
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[36:37], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 13
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 14
-; GFX9-NEXT:    s_and_b32 s38, s8, 0x4000
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[38:39], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 14
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 15
-; GFX9-NEXT:    s_and_b32 s40, s8, 0x8000
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[40:41], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 15
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 16
-; GFX9-NEXT:    s_and_b32 s42, s8, 0x10000
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[42:43], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 16
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 17
-; GFX9-NEXT:    s_and_b32 s44, s8, 0x20000
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[44:45], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 17
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 18
-; GFX9-NEXT:    s_and_b32 s46, s8, 0x40000
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_cmp_eq_u64 s[46:47], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 18
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 19
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_and_b32 s10, s8, 0x80000
-; GFX9-NEXT:    s_mov_b32 s11, s5
-; GFX9-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s13
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s12
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 20
-; GFX9-NEXT:    s_and_b32 s12, s8, 0x100000
-; GFX9-NEXT:    s_mov_b32 s13, s5
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 21
-; GFX9-NEXT:    s_and_b32 s12, s8, 0x200000
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 22
-; GFX9-NEXT:    s_and_b32 s12, s8, 0x400000
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 23
-; GFX9-NEXT:    s_and_b32 s12, s8, 0x800000
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 24
-; GFX9-NEXT:    s_and_b32 s12, s8, 0x1000000
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 25
-; GFX9-NEXT:    s_and_b32 s12, s8, 0x2000000
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 26
-; GFX9-NEXT:    s_and_b32 s12, s8, 0x4000000
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 27
-; GFX9-NEXT:    s_and_b32 s12, s8, 0x8000000
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 28
-; GFX9-NEXT:    s_and_b32 s12, s8, 0x10000000
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 29
-; GFX9-NEXT:    s_and_b32 s12, s8, 0x20000000
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], 30
-; GFX9-NEXT:    s_and_b32 s12, s8, 2.0
-; GFX9-NEXT:    s_cmp_eq_u64 s[12:13], 0
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    s_xor_b64 s[6:7], s[6:7], s[10:11]
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 19
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 20
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 20
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 21
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 21
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 22
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 22
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 23
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 23
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 24
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 24
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 25
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 25
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 26
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 26
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 27
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 27
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 28
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 28
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 29
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 29
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX9-NEXT:    s_lshl_b64 s[12:13], s[4:5], 30
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 30
+; GFX9-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX9-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX9-NEXT:    s_lshl_b64 s[4:5], s[4:5], 31
-; GFX9-NEXT:    s_cmp_gt_i32 s8, -1
-; GFX9-NEXT:    s_cselect_b32 s5, 0, s5
-; GFX9-NEXT:    s_cselect_b32 s4, 0, s4
-; GFX9-NEXT:    s_xor_b64 s[4:5], s[6:7], s[4:5]
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_bitcmp1_b32 s6, 31
+; GFX9-NEXT:    s_cselect_b32 s5, s5, 0
+; GFX9-NEXT:    s_cselect_b32 s4, s4, 0
+; GFX9-NEXT:    s_xor_b64 s[4:5], s[8:9], s[4:5]
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s5
 ; GFX9-NEXT:    buffer_store_dword v0, off, s[0:3], 0
 ; GFX9-NEXT:    s_endpgm
@@ -2751,200 +2308,168 @@ define amdgpu_kernel void @test_clmulh_i32(ptr addrspace(1) %out, ptr addrspace(
 ; GFX10-NEXT:    s_mov_b32 s9, s3
 ; GFX10-NEXT:    s_mov_b32 s3, 0
 ; GFX10-NEXT:    buffer_load_dwordx2 v[0:1], off, s[8:11], 0
-; GFX10-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
-; GFX10-NEXT:    s_mov_b32 s11, s3
-; GFX10-NEXT:    s_mov_b32 s9, s3
+; GFX10-NEXT:    s_mov_b32 s5, s1
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-NEXT:    v_readfirstlane_b32 s4, v1
 ; GFX10-NEXT:    v_readfirstlane_b32 s2, v0
-; GFX10-NEXT:    s_bfe_i32 s5, s4, 0x10000
-; GFX10-NEXT:    s_and_b32 s10, s4, 2
-; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 1
-; GFX10-NEXT:    s_and_b32 s8, s5, s2
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_mov_b32 s5, s1
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s13
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s12
-; GFX10-NEXT:    s_and_b32 s10, s4, 4
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 2
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 8
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 3
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 16
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 4
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 32
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 5
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 64
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 6
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x80
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 7
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x100
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 8
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x200
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 9
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x400
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 10
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x800
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 11
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x1000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 12
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x2000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 13
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x4000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 14
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x8000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 15
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x10000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 16
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x20000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 17
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x40000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 18
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x80000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 19
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x100000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 20
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x200000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 21
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x400000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 22
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x800000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 23
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x1000000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 24
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x2000000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 25
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x4000000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 26
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x8000000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 27
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x10000000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 28
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 0x20000000
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 29
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX10-NEXT:    s_and_b32 s10, s4, 2.0
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], 30
-; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX10-NEXT:    s_cselect_b32 s11, 0, s15
-; GFX10-NEXT:    s_cselect_b32 s10, 0, s14
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 0
+; GFX10-NEXT:    s_cselect_b32 s9, 0, 0
+; GFX10-NEXT:    s_cselect_b32 s8, s2, 0
+; GFX10-NEXT:    s_lshl_b64 s[10:11], s[2:3], 1
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 1
+; GFX10-NEXT:    s_cselect_b32 s11, s11, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s10, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 2
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 2
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 3
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 3
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 4
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 4
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 5
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 5
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 6
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 6
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 7
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 7
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 8
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 8
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 9
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 9
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 10
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 10
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 11
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 11
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 12
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 12
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 13
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 13
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 14
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 14
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 15
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 15
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 16
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 16
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 17
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 17
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 18
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 18
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 19
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 19
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 20
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 20
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 21
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 21
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 22
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 22
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 23
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 23
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 24
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 24
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 25
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 25
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 26
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 26
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 27
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 27
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 28
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 28
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 29
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 29
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX10-NEXT:    s_lshl_b64 s[12:13], s[2:3], 30
+; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 30
+; GFX10-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX10-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX10-NEXT:    s_lshl_b64 s[2:3], s[2:3], 31
 ; GFX10-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; GFX10-NEXT:    s_cmp_gt_i32 s4, -1
+; GFX10-NEXT:    s_bitcmp1_b32 s4, 31
 ; GFX10-NEXT:    s_mov_b32 s4, s0
-; GFX10-NEXT:    s_cselect_b32 s3, 0, s3
-; GFX10-NEXT:    s_cselect_b32 s2, 0, s2
+; GFX10-NEXT:    s_cselect_b32 s3, s3, 0
+; GFX10-NEXT:    s_cselect_b32 s2, s2, 0
 ; GFX10-NEXT:    s_xor_b64 s[2:3], s[8:9], s[2:3]
 ; GFX10-NEXT:    v_mov_b32_e32 v0, s3
 ; GFX10-NEXT:    buffer_store_dword v0, off, s[4:7], 0
@@ -2962,199 +2487,168 @@ define amdgpu_kernel void @test_clmulh_i32(ptr addrspace(1) %out, ptr addrspace(
 ; GFX11-NEXT:    s_mov_b32 s9, s3
 ; GFX11-NEXT:    s_mov_b32 s3, 0
 ; GFX11-NEXT:    buffer_load_b64 v[0:1], off, s[8:11], 0
-; GFX11-NEXT:    s_mov_b32 s11, s3
-; GFX11-NEXT:    s_mov_b32 s9, s3
+; GFX11-NEXT:    s_mov_b32 s5, s1
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    v_readfirstlane_b32 s4, v1
 ; GFX11-NEXT:    v_readfirstlane_b32 s2, v0
-; GFX11-NEXT:    s_bfe_i32 s5, s4, 0x10000
-; GFX11-NEXT:    s_and_b32 s10, s4, 2
-; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 1
-; GFX11-NEXT:    s_and_b32 s8, s5, s2
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_mov_b32 s5, s1
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s13
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s12
-; GFX11-NEXT:    s_and_b32 s10, s4, 4
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 2
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 8
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 3
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 16
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 4
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 32
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 5
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 64
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 6
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x80
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 7
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x100
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 8
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x200
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 9
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x400
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 10
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x800
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 11
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x1000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 12
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x2000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 13
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x4000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 14
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x8000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 15
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x10000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 16
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x20000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 17
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x40000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 18
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x80000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 19
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x100000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 20
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x200000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 21
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x400000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 22
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x800000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 23
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x1000000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 24
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x2000000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 25
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x4000000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 26
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x8000000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 27
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x10000000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 28
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 0x20000000
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 29
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s13, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s12, 0, s14
-; GFX11-NEXT:    s_and_b32 s10, s4, 2.0
-; GFX11-NEXT:    s_lshl_b64 s[14:15], s[2:3], 30
-; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[12:13]
-; GFX11-NEXT:    s_cmp_eq_u64 s[10:11], 0
-; GFX11-NEXT:    s_cselect_b32 s11, 0, s15
-; GFX11-NEXT:    s_cselect_b32 s10, 0, s14
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 0
+; GFX11-NEXT:    s_cselect_b32 s9, 0, 0
+; GFX11-NEXT:    s_cselect_b32 s8, s2, 0
+; GFX11-NEXT:    s_lshl_b64 s[10:11], s[2:3], 1
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 1
+; GFX11-NEXT:    s_cselect_b32 s11, s11, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s10, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 2
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 2
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 3
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 3
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 4
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 4
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 5
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 5
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 6
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 6
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 7
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 7
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 8
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 8
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 9
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 9
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 10
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 10
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 11
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 11
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 12
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 12
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 13
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 13
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 14
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 14
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 15
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 15
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 16
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 16
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 17
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 17
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 18
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 18
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 19
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 19
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 20
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 20
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 21
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 21
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 22
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 22
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 23
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 23
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 24
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 24
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 25
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 25
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 26
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 26
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 27
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 27
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 28
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 28
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 29
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 29
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
+; GFX11-NEXT:    s_lshl_b64 s[12:13], s[2:3], 30
+; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 30
+; GFX11-NEXT:    s_cselect_b32 s11, s13, 0
+; GFX11-NEXT:    s_cselect_b32 s10, s12, 0
 ; GFX11-NEXT:    s_lshl_b64 s[2:3], s[2:3], 31
 ; GFX11-NEXT:    s_xor_b64 s[8:9], s[8:9], s[10:11]
-; GFX11-NEXT:    s_cmp_gt_i32 s4, -1
+; GFX11-NEXT:    s_bitcmp1_b32 s4, 31
 ; GFX11-NEXT:    s_mov_b32 s4, s0
-; GFX11-NEXT:    s_cselect_b32 s3, 0, s3
-; GFX11-NEXT:    s_cselect_b32 s2, 0, s2
+; GFX11-NEXT:    s_cselect_b32 s3, s3, 0
+; GFX11-NEXT:    s_cselect_b32 s2, s2, 0
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX11-NEXT:    s_xor_b64 s[2:3], s[8:9], s[2:3]
 ; GFX11-NEXT:    v_mov_b32_e32 v0, s3

--- a/llvm/test/CodeGen/AMDGPU/eliminate-frame-index-select.ll
+++ b/llvm/test/CodeGen/AMDGPU/eliminate-frame-index-select.ll
@@ -57,7 +57,7 @@ define void @wobble() #0 {
 ; CHECK-NEXT:  .LBB0_1: ; %bb1
 ; CHECK-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NEXT:    v_lshrrev_b32_e64 v0, 5, s33
-; CHECK-NEXT:    s_cmp_eq_u32 s4, 0
+; CHECK-NEXT:    s_cmp_lg_u32 s4, 0
 ; CHECK-NEXT:    flat_store_dword v[41:42], v41
 ; CHECK-NEXT:    v_mov_b32_e32 v31, v40
 ; CHECK-NEXT:    v_mov_b32_e32 v2, 0
@@ -70,8 +70,8 @@ define void @wobble() #0 {
 ; CHECK-NEXT:    s_mov_b32 s13, s52
 ; CHECK-NEXT:    s_mov_b32 s14, s51
 ; CHECK-NEXT:    s_mov_b32 s15, s50
-; CHECK-NEXT:    s_cselect_b32 s4, 0, s5
-; CHECK-NEXT:    s_cselect_b32 s5, 4, s54
+; CHECK-NEXT:    s_cselect_b32 s4, s5, 0
+; CHECK-NEXT:    s_cselect_b32 s5, s54, 4
 ; CHECK-NEXT:    v_mov_b32_e32 v0, s4
 ; CHECK-NEXT:    v_mov_b32_e32 v1, s5
 ; CHECK-NEXT:    s_getpc_b64 s[16:17]

--- a/llvm/test/CodeGen/AMDGPU/extract_vector_dynelt.ll
+++ b/llvm/test/CodeGen/AMDGPU/extract_vector_dynelt.ll
@@ -117,12 +117,12 @@ define amdgpu_kernel void @double4_extelt(ptr addrspace(1) %out, i32 %sel) {
 ; GCN-NEXT:    s_cmp_eq_u32 s2, 1
 ; GCN-NEXT:    s_cselect_b32 s3, s3, 0x3f847ae1
 ; GCN-NEXT:    s_cselect_b32 s4, s4, 0x47ae147b
-; GCN-NEXT:    s_cmp_eq_u32 s2, 2
-; GCN-NEXT:    s_cselect_b32 s4, 0xe147ae14, s4
-; GCN-NEXT:    s_cselect_b32 s3, 0x4000147a, s3
-; GCN-NEXT:    s_cmp_eq_u32 s2, 3
-; GCN-NEXT:    s_cselect_b32 s2, 0x40100a3d, s3
-; GCN-NEXT:    s_cselect_b32 s3, 0x70a3d70a, s4
+; GCN-NEXT:    s_cmp_lg_u32 s2, 2
+; GCN-NEXT:    s_cselect_b32 s4, s4, 0xe147ae14
+; GCN-NEXT:    s_cselect_b32 s3, s3, 0x4000147a
+; GCN-NEXT:    s_cmp_lg_u32 s2, 3
+; GCN-NEXT:    s_cselect_b32 s2, s3, 0x40100a3d
+; GCN-NEXT:    s_cselect_b32 s3, s4, 0x70a3d70a
 ; GCN-NEXT:    v_mov_b32_e32 v0, s3
 ; GCN-NEXT:    v_mov_b32_e32 v1, s2
 ; GCN-NEXT:    v_mov_b32_e32 v3, s1
@@ -218,20 +218,20 @@ define amdgpu_kernel void @double5_extelt(ptr addrspace(1) %out, i32 %sel) {
 ; GCN-NEXT:    s_cmp_eq_u32 s6, 1
 ; GCN-NEXT:    s_cselect_b32 s2, s2, 0x3f847ae1
 ; GCN-NEXT:    s_cselect_b32 s3, s3, 0x47ae147b
-; GCN-NEXT:    s_cmp_eq_u32 s6, 2
-; GCN-NEXT:    s_cselect_b32 s8, 0xe147ae14, s3
-; GCN-NEXT:    s_cselect_b32 s7, 0x4000147a, s2
-; GCN-NEXT:    s_cmp_eq_u32 s6, 3
+; GCN-NEXT:    s_cmp_lg_u32 s6, 2
+; GCN-NEXT:    s_cselect_b32 s8, s3, 0xe147ae14
+; GCN-NEXT:    s_cselect_b32 s7, s2, 0x4000147a
+; GCN-NEXT:    s_cmp_lg_u32 s6, 3
 ; GCN-NEXT:    s_cselect_b64 s[2:3], -1, 0
 ; GCN-NEXT:    s_and_b64 s[4:5], s[2:3], exec
-; GCN-NEXT:    s_cselect_b32 s9, 0x40100a3d, s7
-; GCN-NEXT:    s_cmp_eq_u32 s6, 4
+; GCN-NEXT:    s_cselect_b32 s9, s7, 0x40100a3d
+; GCN-NEXT:    s_cmp_lg_u32 s6, 4
 ; GCN-NEXT:    s_cselect_b64 s[4:5], -1, 0
 ; GCN-NEXT:    s_and_b64 s[6:7], s[4:5], exec
-; GCN-NEXT:    s_cselect_b32 s6, 0x40140a3d, s9
-; GCN-NEXT:    s_or_b64 s[2:3], s[4:5], s[2:3]
+; GCN-NEXT:    s_cselect_b32 s6, s9, 0x40140a3d
+; GCN-NEXT:    s_and_b64 s[2:3], s[4:5], s[2:3]
 ; GCN-NEXT:    s_and_b64 s[2:3], s[2:3], exec
-; GCN-NEXT:    s_cselect_b32 s2, 0x70a3d70a, s8
+; GCN-NEXT:    s_cselect_b32 s2, s8, 0x70a3d70a
 ; GCN-NEXT:    v_mov_b32_e32 v0, s2
 ; GCN-NEXT:    v_mov_b32_e32 v1, s6
 ; GCN-NEXT:    v_mov_b32_e32 v3, s1
@@ -3056,71 +3056,71 @@ define double @double16_extelt_vec(i32 %sel) {
 ; GCN-LABEL: double16_extelt_vec:
 ; GCN:       ; %bb.0: ; %entry
 ; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GCN-NEXT:    v_mov_b32_e32 v3, 0x3ff19999
-; GCN-NEXT:    v_mov_b32_e32 v4, 0x4000cccc
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 1, v0
-; GCN-NEXT:    v_cmp_eq_u32_e64 s[4:5], 2, v0
 ; GCN-NEXT:    v_mov_b32_e32 v1, 0x9999999a
 ; GCN-NEXT:    v_mov_b32_e32 v2, 0xcccccccd
+; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 1, v0
+; GCN-NEXT:    v_cndmask_b32_e32 v3, v1, v2, vcc
+; GCN-NEXT:    v_cmp_ne_u32_e64 s[4:5], 2, v0
+; GCN-NEXT:    v_cndmask_b32_e64 v2, v2, v3, s[4:5]
+; GCN-NEXT:    v_mov_b32_e32 v3, 0x3ff19999
+; GCN-NEXT:    v_mov_b32_e32 v4, 0x4000cccc
 ; GCN-NEXT:    v_cndmask_b32_e32 v3, v3, v4, vcc
 ; GCN-NEXT:    v_mov_b32_e32 v4, 0x4008cccc
-; GCN-NEXT:    s_or_b64 vcc, s[4:5], vcc
-; GCN-NEXT:    v_cndmask_b32_e64 v3, v3, v4, s[4:5]
-; GCN-NEXT:    v_cndmask_b32_e32 v2, v1, v2, vcc
+; GCN-NEXT:    v_cndmask_b32_e64 v3, v4, v3, s[4:5]
 ; GCN-NEXT:    v_mov_b32_e32 v4, 0x40106666
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 3, v0
-; GCN-NEXT:    v_cndmask_b32_e32 v3, v3, v4, vcc
+; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 3, v0
+; GCN-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc
 ; GCN-NEXT:    v_mov_b32_e32 v4, 0x40146666
-; GCN-NEXT:    v_cmp_eq_u32_e64 s[4:5], 4, v0
-; GCN-NEXT:    v_cndmask_b32_e64 v3, v3, v4, s[4:5]
-; GCN-NEXT:    s_or_b64 s[4:5], s[4:5], vcc
+; GCN-NEXT:    v_cmp_ne_u32_e64 s[4:5], 4, v0
+; GCN-NEXT:    v_cndmask_b32_e64 v3, v4, v3, s[4:5]
+; GCN-NEXT:    s_and_b64 s[4:5], s[4:5], vcc
 ; GCN-NEXT:    v_mov_b32_e32 v4, 0x40186666
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 5, v0
-; GCN-NEXT:    v_cndmask_b32_e32 v3, v3, v4, vcc
-; GCN-NEXT:    s_or_b64 s[4:5], vcc, s[4:5]
+; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 5, v0
+; GCN-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc
+; GCN-NEXT:    s_and_b64 s[4:5], vcc, s[4:5]
 ; GCN-NEXT:    v_mov_b32_e32 v5, 0x401c6666
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 6, v0
+; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 6, v0
 ; GCN-NEXT:    v_mov_b32_e32 v4, 0x66666666
-; GCN-NEXT:    v_cndmask_b32_e32 v3, v3, v5, vcc
-; GCN-NEXT:    s_or_b64 vcc, vcc, s[4:5]
-; GCN-NEXT:    v_cndmask_b32_e32 v2, v2, v4, vcc
+; GCN-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
+; GCN-NEXT:    s_and_b64 vcc, vcc, s[4:5]
+; GCN-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
 ; GCN-NEXT:    v_mov_b32_e32 v4, 0x40203333
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 7, v0
-; GCN-NEXT:    v_cndmask_b32_e32 v3, v3, v4, vcc
+; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 7, v0
+; GCN-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc
 ; GCN-NEXT:    v_mov_b32_e32 v4, 0x40223333
-; GCN-NEXT:    v_cmp_eq_u32_e64 s[4:5], 8, v0
-; GCN-NEXT:    v_cndmask_b32_e64 v3, v3, v4, s[4:5]
-; GCN-NEXT:    s_or_b64 s[4:5], s[4:5], vcc
+; GCN-NEXT:    v_cmp_ne_u32_e64 s[4:5], 8, v0
+; GCN-NEXT:    v_cndmask_b32_e64 v3, v4, v3, s[4:5]
+; GCN-NEXT:    s_and_b64 s[4:5], s[4:5], vcc
 ; GCN-NEXT:    v_mov_b32_e32 v4, 0x40243333
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 9, v0
-; GCN-NEXT:    v_cndmask_b32_e32 v3, v3, v4, vcc
-; GCN-NEXT:    s_or_b64 s[4:5], vcc, s[4:5]
+; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 9, v0
+; GCN-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc
+; GCN-NEXT:    s_and_b64 s[4:5], vcc, s[4:5]
 ; GCN-NEXT:    v_mov_b32_e32 v4, 0x40263333
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 10, v0
-; GCN-NEXT:    v_cndmask_b32_e32 v3, v3, v4, vcc
-; GCN-NEXT:    s_or_b64 s[4:5], vcc, s[4:5]
+; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 10, v0
+; GCN-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc
+; GCN-NEXT:    s_and_b64 s[4:5], vcc, s[4:5]
 ; GCN-NEXT:    v_mov_b32_e32 v4, 0x40283333
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 11, v0
-; GCN-NEXT:    v_cndmask_b32_e32 v3, v3, v4, vcc
-; GCN-NEXT:    s_or_b64 s[4:5], vcc, s[4:5]
+; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 11, v0
+; GCN-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc
+; GCN-NEXT:    s_and_b64 s[4:5], vcc, s[4:5]
 ; GCN-NEXT:    v_mov_b32_e32 v4, 0x402a3333
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 12, v0
-; GCN-NEXT:    v_cndmask_b32_e32 v3, v3, v4, vcc
-; GCN-NEXT:    s_or_b64 s[4:5], vcc, s[4:5]
+; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 12, v0
+; GCN-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc
+; GCN-NEXT:    s_and_b64 s[4:5], vcc, s[4:5]
 ; GCN-NEXT:    v_mov_b32_e32 v4, 0x402c3333
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 13, v0
-; GCN-NEXT:    v_cndmask_b32_e32 v3, v3, v4, vcc
-; GCN-NEXT:    s_or_b64 s[4:5], vcc, s[4:5]
+; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 13, v0
+; GCN-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc
+; GCN-NEXT:    s_and_b64 s[4:5], vcc, s[4:5]
 ; GCN-NEXT:    v_mov_b32_e32 v5, 0x402e3333
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 14, v0
+; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 14, v0
 ; GCN-NEXT:    v_mov_b32_e32 v4, 0x33333333
-; GCN-NEXT:    v_cndmask_b32_e32 v3, v3, v5, vcc
-; GCN-NEXT:    s_or_b64 vcc, vcc, s[4:5]
-; GCN-NEXT:    v_cndmask_b32_e32 v2, v2, v4, vcc
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 15, v0
-; GCN-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
+; GCN-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
+; GCN-NEXT:    s_and_b64 vcc, vcc, s[4:5]
+; GCN-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
+; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 15, v0
+; GCN-NEXT:    v_cndmask_b32_e32 v0, v1, v2, vcc
 ; GCN-NEXT:    v_mov_b32_e32 v1, 0x40301999
-; GCN-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
+; GCN-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; GCN-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GCN-O0-LABEL: double16_extelt_vec:

--- a/llvm/test/CodeGen/AMDGPU/fmaximum.ll
+++ b/llvm/test/CodeGen/AMDGPU/fmaximum.ll
@@ -901,23 +901,14 @@ define amdgpu_ps <4 x half> @test_fmaximum_v4f16_ss(<4 x half> inreg %a, <4 x ha
 }
 
 define amdgpu_ps <2 x float> @test_fmaximum_f64_vv(double %a, double %b) {
-; GFX9-SDAG-LABEL: test_fmaximum_f64_vv:
-; GFX9-SDAG:       ; %bb.0:
-; GFX9-SDAG-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX9-SDAG-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX9-SDAG-NEXT:    ; return to shader part epilog
-;
-; GFX9-GISEL-LABEL: test_fmaximum_f64_vv:
-; GFX9-GISEL:       ; %bb.0:
-; GFX9-GISEL-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX9-GISEL-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
-; GFX9-GISEL-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX9-GISEL-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
-; GFX9-GISEL-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
-; GFX9-GISEL-NEXT:    ; return to shader part epilog
+; GFX9-LABEL: test_fmaximum_f64_vv:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
+; GFX9-NEXT:    ; return to shader part epilog
 ;
 ; GFX1170-LABEL: test_fmaximum_f64_vv:
 ; GFX1170:       ; %bb.0:
@@ -939,10 +930,10 @@ define amdgpu_ps <2 x float> @test_fmaximum_f64_ss(double inreg %a, double inreg
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v0, s2
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v1, s3
 ; GFX9-SDAG-NEXT:    v_max_f64 v[2:3], s[0:1], v[0:1]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e32 vcc, s[0:1], v[0:1]
+; GFX9-SDAG-NEXT:    v_cmp_o_f64_e32 vcc, s[0:1], v[0:1]
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; GFX9-SDAG-NEXT:    ; return to shader part epilog
 ;
 ; GFX9-GISEL-LABEL: test_fmaximum_f64_ss:
@@ -1002,16 +993,16 @@ define amdgpu_ps <4 x float> @test_fmaximum_v2f64_ss(<2 x double> inreg %a, <2 x
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v1, s5
 ; GFX9-SDAG-NEXT:    v_max_f64 v[2:3], s[0:1], v[0:1]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e32 vcc, s[0:1], v[0:1]
+; GFX9-SDAG-NEXT:    v_cmp_o_f64_e32 vcc, s[0:1], v[0:1]
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v1, s7
 ; GFX9-SDAG-NEXT:    v_max_f64 v[4:5], s[2:3], v[0:1]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e64 s[0:1], s[2:3], v[0:1]
+; GFX9-SDAG-NEXT:    v_cmp_o_f64_e64 s[0:1], s[2:3], v[0:1]
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v6, vcc
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s[0:1]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v3, v5, v6, s[0:1]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v1, v6, v3, vcc
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s[0:1]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v3, v6, v5, s[0:1]
 ; GFX9-SDAG-NEXT:    ; return to shader part epilog
 ;
 ; GFX9-GISEL-LABEL: test_fmaximum_v2f64_ss:
@@ -1091,22 +1082,22 @@ define amdgpu_ps <8 x float> @test_fmaximum_v4f64(<4 x double> %a, <4 x double> 
 ; GFX9-SDAG-LABEL: test_fmaximum_v4f64:
 ; GFX9-SDAG:       ; %bb.0:
 ; GFX9-SDAG-NEXT:    v_max_f64 v[16:17], v[0:1], v[8:9]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[8:9]
+; GFX9-SDAG-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[8:9]
 ; GFX9-SDAG-NEXT:    v_max_f64 v[8:9], v[2:3], v[10:11]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e64 s[0:1], v[2:3], v[10:11]
+; GFX9-SDAG-NEXT:    v_cmp_o_f64_e64 s[0:1], v[2:3], v[10:11]
 ; GFX9-SDAG-NEXT:    v_max_f64 v[10:11], v[4:5], v[12:13]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e64 s[2:3], v[4:5], v[12:13]
+; GFX9-SDAG-NEXT:    v_cmp_o_f64_e64 s[2:3], v[4:5], v[12:13]
 ; GFX9-SDAG-NEXT:    v_max_f64 v[12:13], v[6:7], v[14:15]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e64 s[4:5], v[6:7], v[14:15]
+; GFX9-SDAG-NEXT:    v_cmp_o_f64_e64 s[4:5], v[6:7], v[14:15]
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v1, v17, v7, vcc
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v2, v8, 0, s[0:1]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v3, v9, v7, s[0:1]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[2:3]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v5, v11, v7, s[2:3]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s[4:5]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v7, v13, v7, s[4:5]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v1, v7, v17, vcc
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v2, 0, v8, s[0:1]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v3, v7, v9, s[0:1]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s[2:3]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v5, v7, v11, s[2:3]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s[4:5]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v7, v7, v13, s[4:5]
 ; GFX9-SDAG-NEXT:    ; return to shader part epilog
 ;
 ; GFX9-GISEL-LABEL: test_fmaximum_v4f64:
@@ -1156,28 +1147,28 @@ define amdgpu_ps <8 x float> @test_fmaximum_v4f64_ss(<4 x double> inreg %a, <4 x
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v0, s8
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v1, s9
 ; GFX9-SDAG-NEXT:    v_max_f64 v[2:3], s[0:1], v[0:1]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e32 vcc, s[0:1], v[0:1]
+; GFX9-SDAG-NEXT:    v_cmp_o_f64_e32 vcc, s[0:1], v[0:1]
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v1, s10
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v10, 0x7ff80000
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v2, s11
 ; GFX9-SDAG-NEXT:    v_max_f64 v[4:5], s[2:3], v[1:2]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e64 s[0:1], s[2:3], v[1:2]
+; GFX9-SDAG-NEXT:    v_cmp_o_f64_e64 s[0:1], s[2:3], v[1:2]
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v1, s12
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v2, s13
 ; GFX9-SDAG-NEXT:    v_max_f64 v[6:7], s[4:5], v[1:2]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e64 s[2:3], s[4:5], v[1:2]
+; GFX9-SDAG-NEXT:    v_cmp_o_f64_e64 s[2:3], s[4:5], v[1:2]
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v1, s14
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v2, s15
 ; GFX9-SDAG-NEXT:    v_max_f64 v[8:9], s[6:7], v[1:2]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e64 s[4:5], s[6:7], v[1:2]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v10, vcc
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s[0:1]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v3, v5, v10, s[0:1]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v4, v6, 0, s[2:3]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v5, v7, v10, s[2:3]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v6, v8, 0, s[4:5]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v7, v9, v10, s[4:5]
+; GFX9-SDAG-NEXT:    v_cmp_o_f64_e64 s[4:5], s[6:7], v[1:2]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v1, v10, v3, vcc
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s[0:1]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v3, v10, v5, s[0:1]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, v6, s[2:3]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v5, v10, v7, s[2:3]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v6, 0, v8, s[4:5]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v7, v10, v9, s[4:5]
 ; GFX9-SDAG-NEXT:    ; return to shader part epilog
 ;
 ; GFX9-GISEL-LABEL: test_fmaximum_v4f64_ss:

--- a/llvm/test/CodeGen/AMDGPU/fmaximum3.ll
+++ b/llvm/test/CodeGen/AMDGPU/fmaximum3.ll
@@ -3774,15 +3774,15 @@ define double @v_fmaximum3_f64(double %a, double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_max_f64 v[6:7], v[0:1], v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %max0 = call double @llvm.maximum.f64(double %a, double %b)
   %max1 = call double @llvm.maximum.f64(double %max0, double %c)
@@ -3815,15 +3815,15 @@ define double @v_fmaximum3_f64_commute(double %a, double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_max_f64 v[6:7], v[0:1], v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_max_f64 v[2:3], v[4:5], v[0:1]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[0:1]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[0:1]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %max0 = call double @llvm.maximum.f64(double %a, double %b)
   %max1 = call double @llvm.maximum.f64(double %c, double %max0)
@@ -3857,15 +3857,15 @@ define amdgpu_ps <2 x i32> @s_fmaximum3_f64(double inreg %a, double inreg %b, do
 ; GFX9-NEXT:    v_mov_b64_e32 v[0:1], s[2:3]
 ; GFX9-NEXT:    v_max_f64 v[2:3], s[0:1], v[0:1]
 ; GFX9-NEXT:    v_mov_b32_e32 v4, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, s[0:1], v[0:1]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, s[0:1], v[0:1]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v4, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v4, v3, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
 ; GFX9-NEXT:    v_max_f64 v[2:3], v[0:1], s[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, s[4:5], v[0:1]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, s[4:5], v[0:1]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v4, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v2, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v4, v3, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, 0, v2, vcc
 ; GFX9-NEXT:    v_readfirstlane_b32 s1, v0
 ; GFX9-NEXT:    v_readfirstlane_b32 s0, v1
 ; GFX9-NEXT:    ; return to shader part epilog
@@ -3907,15 +3907,15 @@ define double @v_fmaximum3_f64_fabs0(double %a, double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_max_f64 v[6:7], |v[0:1]|, v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, |v[0:1]|, v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, |v[0:1]|, v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %a.fabs = call double @llvm.fabs.f64(double %a)
   %max0 = call double @llvm.maximum.f64(double %a.fabs, double %b)
@@ -3949,15 +3949,15 @@ define double @v_fmaximum3_f64_fabs1(double %a, double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_max_f64 v[6:7], v[0:1], |v[2:3]|
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, v[0:1], |v[2:3]|
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, v[0:1], |v[2:3]|
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %b.fabs = call double @llvm.fabs.f64(double %b)
   %max0 = call double @llvm.maximum.f64(double %a, double %b.fabs)
@@ -3991,15 +3991,15 @@ define double @v_fmaximum3_f64_fabs2(double %a, double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_max_f64 v[6:7], v[0:1], v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_max_f64 v[2:3], v[0:1], |v[4:5]|
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, v[0:1], |v[4:5]|
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, v[0:1], |v[4:5]|
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %c.fabs = call double @llvm.fabs.f64(double %c)
   %max0 = call double @llvm.maximum.f64(double %a, double %b)
@@ -4033,15 +4033,15 @@ define double @v_fmaximum3_f64_fabs_all(double %a, double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_max_f64 v[6:7], |v[0:1]|, |v[2:3]|
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, |v[0:1]|, |v[2:3]|
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, |v[0:1]|, |v[2:3]|
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_max_f64 v[2:3], v[0:1], |v[4:5]|
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, v[0:1], |v[4:5]|
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, v[0:1], |v[4:5]|
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %a.fabs = call double @llvm.fabs.f64(double %a)
   %b.fabs = call double @llvm.fabs.f64(double %b)
@@ -4077,15 +4077,15 @@ define double @v_fmaximum3_f64_fneg_all(double %a, double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_max_f64 v[6:7], -v[0:1], -v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, -v[0:1], -v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, -v[0:1], -v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_max_f64 v[2:3], v[0:1], -v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, v[0:1], -v[4:5]
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, v[0:1], -v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %a.fneg = fneg double %a
   %b.fneg = fneg double %b
@@ -4121,15 +4121,15 @@ define double @v_fmaximum3_f64_fneg_fabs_all(double %a, double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_max_f64 v[6:7], -|v[0:1]|, -|v[2:3]|
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, -|v[0:1]|, -|v[2:3]|
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, -|v[0:1]|, -|v[2:3]|
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_max_f64 v[2:3], v[0:1], -|v[4:5]|
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, v[0:1], -|v[4:5]|
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, v[0:1], -|v[4:5]|
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %a.fabs = call double @llvm.fabs.f64(double %a)
   %b.fabs = call double @llvm.fabs.f64(double %b)
@@ -4168,15 +4168,15 @@ define double @v_fmaximum3_f64_fneg0(double %a, double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_max_f64 v[6:7], -v[0:1], v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, -v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, -v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %a.fneg = fneg double %a
   %max0 = call double @llvm.maximum.f64(double %a.fneg, double %b)
@@ -4210,15 +4210,15 @@ define double @v_fmaximum3_f64_fneg1(double %a, double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_max_f64 v[6:7], v[0:1], -v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, v[0:1], -v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, v[0:1], -v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %b.fneg = fneg double %b
   %max0 = call double @llvm.maximum.f64(double %a, double %b.fneg)
@@ -4252,15 +4252,15 @@ define double @v_fmaximum3_f64_fneg2(double %a, double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_max_f64 v[6:7], v[0:1], v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_max_f64 v[2:3], v[0:1], -v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, v[0:1], -v[4:5]
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, v[0:1], -v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %c.fneg = fneg double %c
   %max0 = call double @llvm.maximum.f64(double %a, double %b)
@@ -4296,15 +4296,15 @@ define double @v_fmaximum3_f64_const0(double %b, double %c) {
 ; GFX9-NEXT:    s_mov_b32 s1, 0x40200000
 ; GFX9-NEXT:    v_max_f64 v[4:5], v[0:1], s[0:1]
 ; GFX9-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[0:1]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[0:1]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v6, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v5, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
 ; GFX9-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v6, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v5, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %max0 = call double @llvm.maximum.f64(double 8.0, double %b)
   %max1 = call double @llvm.maximum.f64(double %max0, double %c)
@@ -4337,16 +4337,16 @@ define double @v_fmaximum3_f64__const2(double %a, double %b) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_mov_b32 s0, 0
 ; GFX9-NEXT:    s_mov_b32 s1, 0x40200000
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v6, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v5, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
 ; GFX9-NEXT:    v_max_f64 v[2:3], v[0:1], s[0:1]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[0:1]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[0:1]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v6, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %max0 = call double @llvm.maximum.f64(double %a, double %b)
   %max1 = call double @llvm.maximum.f64(double %max0, double 8.0)
@@ -4379,15 +4379,15 @@ define double @v_fmaximum3_f64_inlineimm0(double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_max_f64 v[4:5], v[0:1], 4.0
 ; GFX9-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[0:1]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[0:1]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v6, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v5, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
 ; GFX9-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v6, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v5, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %max0 = call double @llvm.maximum.f64(double 4.0, double %b)
   %max1 = call double @llvm.maximum.f64(double %max0, double %c)
@@ -4420,15 +4420,15 @@ define double @v_fmaximum3_f64__inlineimm(double %a, double %b) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v6, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v5, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
 ; GFX9-NEXT:    v_max_f64 v[2:3], v[0:1], 4.0
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[0:1]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[0:1]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v6, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %max0 = call double @llvm.maximum.f64(double %a, double %b)
   %max1 = call double @llvm.maximum.f64(double %max0, double 4.0)
@@ -4463,16 +4463,16 @@ define double @v_fmaximum3_f64_const1_const2(double %a) {
 ; GFX9-NEXT:    s_mov_b32 s1, 0x40200000
 ; GFX9-NEXT:    v_max_f64 v[2:3], v[0:1], s[0:1]
 ; GFX9-NEXT:    v_mov_b32_e32 v4, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[0:1]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[0:1]
 ; GFX9-NEXT:    s_mov_b32 s0, 0
 ; GFX9-NEXT:    s_mov_b32 s1, 0x40300000
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v4, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v4, v3, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
 ; GFX9-NEXT:    v_max_f64 v[2:3], v[0:1], s[0:1]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[0:1]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[0:1]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v4, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v4, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %max0 = call double @llvm.maximum.f64(double %a, double 8.0)
   %max1 = call double @llvm.maximum.f64(double %max0, double 16.0)
@@ -4813,15 +4813,15 @@ define <2 x double> @v_no_fmaximum3_f64__multi_use(double %a, double %b, double 
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_max_f64 v[6:7], v[0:1], v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %max0 = call double @llvm.maximum.f64(double %a, double %b)
   %max1 = call double @llvm.maximum.f64(double %max0, double %c)

--- a/llvm/test/CodeGen/AMDGPU/fminimum.ll
+++ b/llvm/test/CodeGen/AMDGPU/fminimum.ll
@@ -901,23 +901,14 @@ define amdgpu_ps <4 x half> @test_fminimum_v4f16_ss(<4 x half> inreg %a, <4 x ha
 }
 
 define amdgpu_ps <2 x float> @test_fminimum_f64_vv(double %a, double %b) {
-; GFX9-SDAG-LABEL: test_fminimum_f64_vv:
-; GFX9-SDAG:       ; %bb.0:
-; GFX9-SDAG-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX9-SDAG-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX9-SDAG-NEXT:    ; return to shader part epilog
-;
-; GFX9-GISEL-LABEL: test_fminimum_f64_vv:
-; GFX9-GISEL:       ; %bb.0:
-; GFX9-GISEL-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX9-GISEL-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
-; GFX9-GISEL-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX9-GISEL-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
-; GFX9-GISEL-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
-; GFX9-GISEL-NEXT:    ; return to shader part epilog
+; GFX9-LABEL: test_fminimum_f64_vv:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
+; GFX9-NEXT:    ; return to shader part epilog
 ;
 ; GFX1170-LABEL: test_fminimum_f64_vv:
 ; GFX1170:       ; %bb.0:
@@ -939,10 +930,10 @@ define amdgpu_ps <2 x float> @test_fminimum_f64_ss(double inreg %a, double inreg
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v0, s2
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v1, s3
 ; GFX9-SDAG-NEXT:    v_min_f64 v[2:3], s[0:1], v[0:1]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e32 vcc, s[0:1], v[0:1]
+; GFX9-SDAG-NEXT:    v_cmp_o_f64_e32 vcc, s[0:1], v[0:1]
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; GFX9-SDAG-NEXT:    ; return to shader part epilog
 ;
 ; GFX9-GISEL-LABEL: test_fminimum_f64_ss:
@@ -1002,16 +993,16 @@ define amdgpu_ps <4 x float> @test_fminimum_v2f64_ss(<2 x double> inreg %a, <2 x
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v1, s5
 ; GFX9-SDAG-NEXT:    v_min_f64 v[2:3], s[0:1], v[0:1]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e32 vcc, s[0:1], v[0:1]
+; GFX9-SDAG-NEXT:    v_cmp_o_f64_e32 vcc, s[0:1], v[0:1]
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v1, s7
 ; GFX9-SDAG-NEXT:    v_min_f64 v[4:5], s[2:3], v[0:1]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e64 s[0:1], s[2:3], v[0:1]
+; GFX9-SDAG-NEXT:    v_cmp_o_f64_e64 s[0:1], s[2:3], v[0:1]
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v6, vcc
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s[0:1]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v3, v5, v6, s[0:1]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v1, v6, v3, vcc
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s[0:1]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v3, v6, v5, s[0:1]
 ; GFX9-SDAG-NEXT:    ; return to shader part epilog
 ;
 ; GFX9-GISEL-LABEL: test_fminimum_v2f64_ss:
@@ -1091,22 +1082,22 @@ define amdgpu_ps <8 x float> @test_fminimum_v4f64(<4 x double> %a, <4 x double> 
 ; GFX9-SDAG-LABEL: test_fminimum_v4f64:
 ; GFX9-SDAG:       ; %bb.0:
 ; GFX9-SDAG-NEXT:    v_min_f64 v[16:17], v[0:1], v[8:9]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[8:9]
+; GFX9-SDAG-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[8:9]
 ; GFX9-SDAG-NEXT:    v_min_f64 v[8:9], v[2:3], v[10:11]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e64 s[0:1], v[2:3], v[10:11]
+; GFX9-SDAG-NEXT:    v_cmp_o_f64_e64 s[0:1], v[2:3], v[10:11]
 ; GFX9-SDAG-NEXT:    v_min_f64 v[10:11], v[4:5], v[12:13]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e64 s[2:3], v[4:5], v[12:13]
+; GFX9-SDAG-NEXT:    v_cmp_o_f64_e64 s[2:3], v[4:5], v[12:13]
 ; GFX9-SDAG-NEXT:    v_min_f64 v[12:13], v[6:7], v[14:15]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e64 s[4:5], v[6:7], v[14:15]
+; GFX9-SDAG-NEXT:    v_cmp_o_f64_e64 s[4:5], v[6:7], v[14:15]
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v1, v17, v7, vcc
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v2, v8, 0, s[0:1]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v3, v9, v7, s[0:1]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[2:3]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v5, v11, v7, s[2:3]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s[4:5]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v7, v13, v7, s[4:5]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v1, v7, v17, vcc
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v2, 0, v8, s[0:1]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v3, v7, v9, s[0:1]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s[2:3]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v5, v7, v11, s[2:3]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s[4:5]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v7, v7, v13, s[4:5]
 ; GFX9-SDAG-NEXT:    ; return to shader part epilog
 ;
 ; GFX9-GISEL-LABEL: test_fminimum_v4f64:
@@ -1156,28 +1147,28 @@ define amdgpu_ps <8 x float> @test_fminimum_v4f64_ss(<4 x double> inreg %a, <4 x
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v0, s8
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v1, s9
 ; GFX9-SDAG-NEXT:    v_min_f64 v[2:3], s[0:1], v[0:1]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e32 vcc, s[0:1], v[0:1]
+; GFX9-SDAG-NEXT:    v_cmp_o_f64_e32 vcc, s[0:1], v[0:1]
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v1, s10
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v10, 0x7ff80000
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v2, s11
 ; GFX9-SDAG-NEXT:    v_min_f64 v[4:5], s[2:3], v[1:2]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e64 s[0:1], s[2:3], v[1:2]
+; GFX9-SDAG-NEXT:    v_cmp_o_f64_e64 s[0:1], s[2:3], v[1:2]
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v1, s12
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v2, s13
 ; GFX9-SDAG-NEXT:    v_min_f64 v[6:7], s[4:5], v[1:2]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e64 s[2:3], s[4:5], v[1:2]
+; GFX9-SDAG-NEXT:    v_cmp_o_f64_e64 s[2:3], s[4:5], v[1:2]
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v1, s14
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v2, s15
 ; GFX9-SDAG-NEXT:    v_min_f64 v[8:9], s[6:7], v[1:2]
-; GFX9-SDAG-NEXT:    v_cmp_u_f64_e64 s[4:5], s[6:7], v[1:2]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v10, vcc
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s[0:1]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v3, v5, v10, s[0:1]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v4, v6, 0, s[2:3]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v5, v7, v10, s[2:3]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v6, v8, 0, s[4:5]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v7, v9, v10, s[4:5]
+; GFX9-SDAG-NEXT:    v_cmp_o_f64_e64 s[4:5], s[6:7], v[1:2]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v1, v10, v3, vcc
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s[0:1]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v3, v10, v5, s[0:1]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, v6, s[2:3]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v5, v10, v7, s[2:3]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v6, 0, v8, s[4:5]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v7, v10, v9, s[4:5]
 ; GFX9-SDAG-NEXT:    ; return to shader part epilog
 ;
 ; GFX9-GISEL-LABEL: test_fminimum_v4f64_ss:

--- a/llvm/test/CodeGen/AMDGPU/fminimum3.ll
+++ b/llvm/test/CodeGen/AMDGPU/fminimum3.ll
@@ -3774,15 +3774,15 @@ define double @v_fminimum3_f64(double %a, double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_min_f64 v[6:7], v[0:1], v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %max0 = call double @llvm.minimum.f64(double %a, double %b)
   %max1 = call double @llvm.minimum.f64(double %max0, double %c)
@@ -3815,15 +3815,15 @@ define double @v_fminimum3_f64_commute(double %a, double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_min_f64 v[6:7], v[0:1], v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_min_f64 v[2:3], v[4:5], v[0:1]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[0:1]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[0:1]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %max0 = call double @llvm.minimum.f64(double %a, double %b)
   %max1 = call double @llvm.minimum.f64(double %c, double %max0)
@@ -3857,15 +3857,15 @@ define amdgpu_ps <2 x i32> @s_fminimum3_f64(double inreg %a, double inreg %b, do
 ; GFX9-NEXT:    v_mov_b64_e32 v[0:1], s[2:3]
 ; GFX9-NEXT:    v_min_f64 v[2:3], s[0:1], v[0:1]
 ; GFX9-NEXT:    v_mov_b32_e32 v4, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, s[0:1], v[0:1]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, s[0:1], v[0:1]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v4, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v4, v3, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
 ; GFX9-NEXT:    v_min_f64 v[2:3], v[0:1], s[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, s[4:5], v[0:1]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, s[4:5], v[0:1]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v4, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v2, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v4, v3, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, 0, v2, vcc
 ; GFX9-NEXT:    v_readfirstlane_b32 s1, v0
 ; GFX9-NEXT:    v_readfirstlane_b32 s0, v1
 ; GFX9-NEXT:    ; return to shader part epilog
@@ -3907,15 +3907,15 @@ define double @v_fminimum3_f64_fabs0(double %a, double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_min_f64 v[6:7], |v[0:1]|, v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, |v[0:1]|, v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, |v[0:1]|, v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %a.fabs = call double @llvm.fabs.f64(double %a)
   %max0 = call double @llvm.minimum.f64(double %a.fabs, double %b)
@@ -3949,15 +3949,15 @@ define double @v_fminimum3_f64_fabs1(double %a, double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_min_f64 v[6:7], v[0:1], |v[2:3]|
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, v[0:1], |v[2:3]|
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, v[0:1], |v[2:3]|
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %b.fabs = call double @llvm.fabs.f64(double %b)
   %max0 = call double @llvm.minimum.f64(double %a, double %b.fabs)
@@ -3991,15 +3991,15 @@ define double @v_fminimum3_f64_fabs2(double %a, double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_min_f64 v[6:7], v[0:1], v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_min_f64 v[2:3], v[0:1], |v[4:5]|
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, v[0:1], |v[4:5]|
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, v[0:1], |v[4:5]|
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %c.fabs = call double @llvm.fabs.f64(double %c)
   %max0 = call double @llvm.minimum.f64(double %a, double %b)
@@ -4033,15 +4033,15 @@ define double @v_fminimum3_f64_fabs_all(double %a, double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_min_f64 v[6:7], |v[0:1]|, |v[2:3]|
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, |v[0:1]|, |v[2:3]|
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, |v[0:1]|, |v[2:3]|
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_min_f64 v[2:3], v[0:1], |v[4:5]|
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, v[0:1], |v[4:5]|
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, v[0:1], |v[4:5]|
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %a.fabs = call double @llvm.fabs.f64(double %a)
   %b.fabs = call double @llvm.fabs.f64(double %b)
@@ -4077,15 +4077,15 @@ define double @v_fminimum3_f64_fneg_all(double %a, double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_min_f64 v[6:7], -v[0:1], -v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, -v[0:1], -v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, -v[0:1], -v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_min_f64 v[2:3], v[0:1], -v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, v[0:1], -v[4:5]
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, v[0:1], -v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %a.fneg = fneg double %a
   %b.fneg = fneg double %b
@@ -4121,15 +4121,15 @@ define double @v_fminimum3_f64_fneg_fabs_all(double %a, double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_min_f64 v[6:7], -|v[0:1]|, -|v[2:3]|
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, -|v[0:1]|, -|v[2:3]|
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, -|v[0:1]|, -|v[2:3]|
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_min_f64 v[2:3], v[0:1], -|v[4:5]|
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, v[0:1], -|v[4:5]|
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, v[0:1], -|v[4:5]|
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %a.fabs = call double @llvm.fabs.f64(double %a)
   %b.fabs = call double @llvm.fabs.f64(double %b)
@@ -4168,15 +4168,15 @@ define double @v_fminimum3_f64_fneg0(double %a, double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_min_f64 v[6:7], -v[0:1], v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, -v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, -v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %a.fneg = fneg double %a
   %max0 = call double @llvm.minimum.f64(double %a.fneg, double %b)
@@ -4210,15 +4210,15 @@ define double @v_fminimum3_f64_fneg1(double %a, double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_min_f64 v[6:7], v[0:1], -v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, v[0:1], -v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, v[0:1], -v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %b.fneg = fneg double %b
   %max0 = call double @llvm.minimum.f64(double %a, double %b.fneg)
@@ -4252,15 +4252,15 @@ define double @v_fminimum3_f64_fneg2(double %a, double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_min_f64 v[6:7], v[0:1], v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_min_f64 v[2:3], v[0:1], -v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e64 vcc, v[0:1], -v[4:5]
+; GFX9-NEXT:    v_cmp_o_f64_e64 vcc, v[0:1], -v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %c.fneg = fneg double %c
   %max0 = call double @llvm.minimum.f64(double %a, double %b)
@@ -4296,15 +4296,15 @@ define double @v_fminimum3_f64_const0(double %b, double %c) {
 ; GFX9-NEXT:    s_mov_b32 s1, 0x40200000
 ; GFX9-NEXT:    v_min_f64 v[4:5], v[0:1], s[0:1]
 ; GFX9-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[0:1]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[0:1]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v6, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v5, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
 ; GFX9-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v6, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v5, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %max0 = call double @llvm.minimum.f64(double 8.0, double %b)
   %max1 = call double @llvm.minimum.f64(double %max0, double %c)
@@ -4337,16 +4337,16 @@ define double @v_fminimum3_f64__const2(double %a, double %b) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_mov_b32 s0, 0
 ; GFX9-NEXT:    s_mov_b32 s1, 0x40200000
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v6, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v5, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
 ; GFX9-NEXT:    v_min_f64 v[2:3], v[0:1], s[0:1]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[0:1]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[0:1]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v6, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %max0 = call double @llvm.minimum.f64(double %a, double %b)
   %max1 = call double @llvm.minimum.f64(double %max0, double 8.0)
@@ -4379,15 +4379,15 @@ define double @v_fminimum3_f64_inlineimm0(double %b, double %c) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_min_f64 v[4:5], v[0:1], 4.0
 ; GFX9-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[0:1]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[0:1]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v6, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v5, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
 ; GFX9-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v6, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v5, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %max0 = call double @llvm.minimum.f64(double 4.0, double %b)
   %max1 = call double @llvm.minimum.f64(double %max0, double %c)
@@ -4420,15 +4420,15 @@ define double @v_fminimum3_f64__inlineimm(double %a, double %b) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v6, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v5, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
 ; GFX9-NEXT:    v_min_f64 v[2:3], v[0:1], 4.0
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[0:1]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[0:1]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v6, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %max0 = call double @llvm.minimum.f64(double %a, double %b)
   %max1 = call double @llvm.minimum.f64(double %max0, double 4.0)
@@ -4463,16 +4463,16 @@ define double @v_fminimum3_f64_const1_const2(double %a) {
 ; GFX9-NEXT:    s_mov_b32 s1, 0x40200000
 ; GFX9-NEXT:    v_min_f64 v[2:3], v[0:1], s[0:1]
 ; GFX9-NEXT:    v_mov_b32_e32 v4, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[0:1]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[0:1]
 ; GFX9-NEXT:    s_mov_b32 s0, 0
 ; GFX9-NEXT:    s_mov_b32 s1, 0x40300000
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v4, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v4, v3, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
 ; GFX9-NEXT:    v_min_f64 v[2:3], v[0:1], s[0:1]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[0:1]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[0:1]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v4, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v4, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %max0 = call double @llvm.minimum.f64(double %a, double 8.0)
   %max1 = call double @llvm.minimum.f64(double %max0, double 16.0)
@@ -4813,15 +4813,15 @@ define <2 x double> @v_no_fminimum3_f64__multi_use(double %a, double %b, double 
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_min_f64 v[6:7], v[0:1], v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
   %max0 = call double @llvm.minimum.f64(double %a, double %b)
   %max1 = call double @llvm.minimum.f64(double %max0, double %c)

--- a/llvm/test/CodeGen/AMDGPU/fneg-combines.new.ll
+++ b/llvm/test/CodeGen/AMDGPU/fneg-combines.new.ll
@@ -1651,20 +1651,20 @@ define double @v_fneg_inv2pi_minimum_f64(double %a) #0 {
 ; SI-NEXT:    s_mov_b32 s4, 0x6dc9c882
 ; SI-NEXT:    s_mov_b32 s5, 0xbfc45f30
 ; SI-NEXT:    v_max_f64 v[2:3], -v[0:1], s[4:5]
-; SI-NEXT:    v_cmp_u_f64_e64 vcc, -v[0:1], -v[0:1]
+; SI-NEXT:    v_cmp_o_f64_e64 vcc, -v[0:1], -v[0:1]
 ; SI-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; SI-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; SI-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
+; SI-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; SI-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; VI-LABEL: v_fneg_inv2pi_minimum_f64:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    v_min_f64 v[2:3], v[0:1], 0.15915494309189532
-; VI-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[0:1]
+; VI-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[0:1]
 ; VI-NEXT:    v_mov_b32_e32 v1, 0xfff80000
-; VI-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; VI-NEXT:    v_cndmask_b32_e64 v1, -v3, v1, vcc
+; VI-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; VI-NEXT:    v_cndmask_b32_e64 v1, v1, -v3, vcc
 ; VI-NEXT:    s_setpc_b64 s[30:31]
   %min = call double @llvm.minimum.f64(double 0x3fc45f306dc9c882, double %a)
   %fneg = fneg double %min
@@ -1678,20 +1678,20 @@ define double @v_fneg_neg_inv2pi_minimum_f64(double %a) #0 {
 ; SI-NEXT:    s_mov_b32 s4, 0x6dc9c882
 ; SI-NEXT:    s_mov_b32 s5, 0x3fc45f30
 ; SI-NEXT:    v_max_f64 v[2:3], -v[0:1], s[4:5]
-; SI-NEXT:    v_cmp_u_f64_e64 vcc, -v[0:1], -v[0:1]
+; SI-NEXT:    v_cmp_o_f64_e64 vcc, -v[0:1], -v[0:1]
 ; SI-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; SI-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; SI-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
+; SI-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; SI-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; VI-LABEL: v_fneg_neg_inv2pi_minimum_f64:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    v_max_f64 v[2:3], -v[0:1], 0.15915494309189532
-; VI-NEXT:    v_cmp_u_f64_e64 vcc, -v[0:1], -v[0:1]
+; VI-NEXT:    v_cmp_o_f64_e64 vcc, -v[0:1], -v[0:1]
 ; VI-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; VI-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; VI-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
+; VI-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; VI-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; VI-NEXT:    s_setpc_b64 s[30:31]
   %min = call double @llvm.minimum.f64(double 0xbfc45f306dc9c882, double %a)
   %fneg = fneg double %min

--- a/llvm/test/CodeGen/AMDGPU/fptosi-sat-scalar.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptosi-sat-scalar.ll
@@ -225,18 +225,18 @@ define i64 @test_signed_i64_f32(float %f) nounwind {
 ; GFX7-ISEL-NEXT:    v_xor_b32_e32 v2, v2, v1
 ; GFX7-ISEL-NEXT:    v_sub_i32_e32 v2, vcc, v2, v1
 ; GFX7-ISEL-NEXT:    v_subb_u32_e32 v1, vcc, v3, v1, vcc
-; GFX7-ISEL-NEXT:    v_cmp_nle_f32_e32 vcc, s4, v0
+; GFX7-ISEL-NEXT:    v_cmp_le_f32_e32 vcc, s4, v0
 ; GFX7-ISEL-NEXT:    s_mov_b32 s4, 0x5effffff
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
-; GFX7-ISEL-NEXT:    v_cmp_lt_f32_e64 s[4:5], s4, v0
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v2, -1, s[4:5]
-; GFX7-ISEL-NEXT:    v_cmp_u_f32_e64 s[6:7], v0, v0
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v2, 0, s[6:7]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
+; GFX7-ISEL-NEXT:    v_cmp_nlt_f32_e64 s[4:5], s4, v0
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, -1, v2, s[4:5]
+; GFX7-ISEL-NEXT:    v_cmp_o_f32_e64 s[6:7], v0, v0
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, 0, v2, s[6:7]
 ; GFX7-ISEL-NEXT:    v_bfrev_b32_e32 v2, 1
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v1, v1, v2, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
 ; GFX7-ISEL-NEXT:    v_bfrev_b32_e32 v2, -2
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, v1, v2, s[4:5]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[6:7]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, v2, v1, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, 0, v1, s[6:7]
 ; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX7-GI-LABEL: test_signed_i64_f32:
@@ -287,18 +287,18 @@ define i64 @test_signed_i64_f32(float %f) nounwind {
 ; GFX9-NEXT:    v_xor_b32_e32 v2, v2, v1
 ; GFX9-NEXT:    v_sub_co_u32_e32 v2, vcc, v2, v1
 ; GFX9-NEXT:    v_subb_co_u32_e32 v1, vcc, v3, v1, vcc
-; GFX9-NEXT:    v_cmp_nle_f32_e32 vcc, s4, v0
+; GFX9-NEXT:    v_cmp_le_f32_e32 vcc, s4, v0
 ; GFX9-NEXT:    s_mov_b32 s4, 0x5effffff
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
-; GFX9-NEXT:    v_cmp_lt_f32_e64 s[4:5], s4, v0
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v2, -1, s[4:5]
-; GFX9-NEXT:    v_cmp_u_f32_e64 s[6:7], v0, v0
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, s[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
+; GFX9-NEXT:    v_cmp_nlt_f32_e64 s[4:5], s4, v0
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, -1, v2, s[4:5]
+; GFX9-NEXT:    v_cmp_o_f32_e64 s[6:7], v0, v0
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, 0, v2, s[6:7]
 ; GFX9-NEXT:    v_bfrev_b32_e32 v2, 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
 ; GFX9-NEXT:    v_bfrev_b32_e32 v2, -2
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, v2, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, v2, v1, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, v1, s[6:7]
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: test_signed_i64_f32:
@@ -315,15 +315,12 @@ define i64 @test_signed_i64_f32(float %f) nounwind {
 ; GFX11-NEXT:    v_xor_b32_e32 v3, v3, v1
 ; GFX11-NEXT:    v_sub_co_u32 v3, vcc_lo, v3, v1
 ; GFX11-NEXT:    v_sub_co_ci_u32_e64 v1, null, v2, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_nle_f32_e32 vcc_lo, 0xdf000000, v0
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v3, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0x80000000, vcc_lo
-; GFX11-NEXT:    v_cmp_lt_f32_e32 vcc_lo, 0x5effffff, v0
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v2, -1, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7fffffff, vcc_lo
-; GFX11-NEXT:    v_cmp_u_f32_e32 vcc_lo, v0, v0
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0, vcc_lo
+; GFX11-NEXT:    v_cmp_le_f32_e32 vcc_lo, 0xdf000000, v0
+; GFX11-NEXT:    v_dual_cndmask_b32 v2, 0, v3 :: v_dual_cndmask_b32 v1, 0x80000000, v1
+; GFX11-NEXT:    v_cmp_nlt_f32_e32 vcc_lo, 0x5effffff, v0
+; GFX11-NEXT:    v_dual_cndmask_b32 v2, -1, v2 :: v_dual_cndmask_b32 v1, 0x7fffffff, v1
+; GFX11-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v0
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v2 :: v_dual_cndmask_b32 v1, 0, v1
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-ISEL-LABEL: test_signed_i64_f32:
@@ -345,18 +342,15 @@ define i64 @test_signed_i64_f32(float %f) nounwind {
 ; GFX12-ISEL-NEXT:    v_sub_co_u32 v3, vcc_lo, v3, v1
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_vcc(0)
 ; GFX12-ISEL-NEXT:    v_sub_co_ci_u32_e64 v1, null, v2, v1, vcc_lo
-; GFX12-ISEL-NEXT:    v_cmp_nle_f32_e32 vcc_lo, 0xdf000000, v0
+; GFX12-ISEL-NEXT:    v_cmp_le_f32_e32 vcc_lo, 0xdf000000, v0
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, v3, 0, vcc_lo
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v1, 0x80000000, vcc_lo
-; GFX12-ISEL-NEXT:    v_cmp_lt_f32_e32 vcc_lo, 0x5effffff, v0
+; GFX12-ISEL-NEXT:    v_dual_cndmask_b32 v2, 0, v3 :: v_dual_cndmask_b32 v1, 0x80000000, v1
+; GFX12-ISEL-NEXT:    v_cmp_nlt_f32_e32 vcc_lo, 0x5effffff, v0
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, v2, -1, vcc_lo
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7fffffff, vcc_lo
-; GFX12-ISEL-NEXT:    v_cmp_u_f32_e32 vcc_lo, v0, v0
+; GFX12-ISEL-NEXT:    v_dual_cndmask_b32 v2, -1, v2 :: v_dual_cndmask_b32 v1, 0x7fffffff, v1
+; GFX12-ISEL-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v0
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc_lo
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v1, 0, vcc_lo
+; GFX12-ISEL-NEXT:    v_dual_cndmask_b32 v0, 0, v2 :: v_dual_cndmask_b32 v1, 0, v1
 ; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GI-LABEL: test_signed_i64_f32:
@@ -635,22 +629,22 @@ define i64 @test_s_signed_i64_f32(float inreg %f) nounwind {
 ; GFX7-ISEL-NEXT:    s_sub_u32 s7, s4, s6
 ; GFX7-ISEL-NEXT:    v_mov_b32_e32 v0, 0xdf000000
 ; GFX7-ISEL-NEXT:    s_subb_u32 s10, s5, s6
-; GFX7-ISEL-NEXT:    v_cmp_nge_f32_e32 vcc, s16, v0
+; GFX7-ISEL-NEXT:    v_cmp_ge_f32_e32 vcc, s16, v0
 ; GFX7-ISEL-NEXT:    s_and_b64 s[4:5], vcc, exec
 ; GFX7-ISEL-NEXT:    v_mov_b32_e32 v0, 0x5effffff
-; GFX7-ISEL-NEXT:    v_cmp_gt_f32_e64 s[4:5], s16, v0
-; GFX7-ISEL-NEXT:    s_cselect_b32 s8, 0, s7
+; GFX7-ISEL-NEXT:    v_cmp_ngt_f32_e64 s[4:5], s16, v0
+; GFX7-ISEL-NEXT:    s_cselect_b32 s8, s7, 0
 ; GFX7-ISEL-NEXT:    s_and_b64 s[6:7], s[4:5], exec
-; GFX7-ISEL-NEXT:    v_cmp_u_f32_e64 s[6:7], s16, s16
-; GFX7-ISEL-NEXT:    s_cselect_b32 s11, -1, s8
+; GFX7-ISEL-NEXT:    v_cmp_o_f32_e64 s[6:7], s16, s16
+; GFX7-ISEL-NEXT:    s_cselect_b32 s11, s8, -1
 ; GFX7-ISEL-NEXT:    s_and_b64 s[8:9], s[6:7], exec
-; GFX7-ISEL-NEXT:    s_cselect_b32 s11, 0, s11
+; GFX7-ISEL-NEXT:    s_cselect_b32 s11, s11, 0
 ; GFX7-ISEL-NEXT:    s_and_b64 s[8:9], vcc, exec
-; GFX7-ISEL-NEXT:    s_cselect_b32 s8, 0x80000000, s10
+; GFX7-ISEL-NEXT:    s_cselect_b32 s8, s10, 0x80000000
 ; GFX7-ISEL-NEXT:    s_and_b64 s[4:5], s[4:5], exec
-; GFX7-ISEL-NEXT:    s_cselect_b32 s8, 0x7fffffff, s8
+; GFX7-ISEL-NEXT:    s_cselect_b32 s8, s8, 0x7fffffff
 ; GFX7-ISEL-NEXT:    s_and_b64 s[4:5], s[6:7], exec
-; GFX7-ISEL-NEXT:    s_cselect_b32 s4, 0, s8
+; GFX7-ISEL-NEXT:    s_cselect_b32 s4, s8, 0
 ; GFX7-ISEL-NEXT:    v_mov_b32_e32 v0, s11
 ; GFX7-ISEL-NEXT:    v_mov_b32_e32 v1, s4
 ; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -712,22 +706,22 @@ define i64 @test_s_signed_i64_f32(float inreg %f) nounwind {
 ; GFX9-NEXT:    s_sub_u32 s7, s4, s6
 ; GFX9-NEXT:    v_mov_b32_e32 v0, 0xdf000000
 ; GFX9-NEXT:    s_subb_u32 s10, s5, s6
-; GFX9-NEXT:    v_cmp_nge_f32_e32 vcc, s16, v0
+; GFX9-NEXT:    v_cmp_ge_f32_e32 vcc, s16, v0
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
 ; GFX9-NEXT:    v_mov_b32_e32 v0, 0x5effffff
-; GFX9-NEXT:    v_cmp_gt_f32_e64 s[4:5], s16, v0
-; GFX9-NEXT:    s_cselect_b32 s8, 0, s7
+; GFX9-NEXT:    v_cmp_ngt_f32_e64 s[4:5], s16, v0
+; GFX9-NEXT:    s_cselect_b32 s8, s7, 0
 ; GFX9-NEXT:    s_and_b64 s[6:7], s[4:5], exec
-; GFX9-NEXT:    v_cmp_u_f32_e64 s[6:7], s16, s16
-; GFX9-NEXT:    s_cselect_b32 s11, -1, s8
+; GFX9-NEXT:    v_cmp_o_f32_e64 s[6:7], s16, s16
+; GFX9-NEXT:    s_cselect_b32 s11, s8, -1
 ; GFX9-NEXT:    s_and_b64 s[8:9], s[6:7], exec
-; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
+; GFX9-NEXT:    s_cselect_b32 s11, s11, 0
 ; GFX9-NEXT:    s_and_b64 s[8:9], vcc, exec
-; GFX9-NEXT:    s_cselect_b32 s8, 0x80000000, s10
+; GFX9-NEXT:    s_cselect_b32 s8, s10, 0x80000000
 ; GFX9-NEXT:    s_and_b64 s[4:5], s[4:5], exec
-; GFX9-NEXT:    s_cselect_b32 s8, 0x7fffffff, s8
+; GFX9-NEXT:    s_cselect_b32 s8, s8, 0x7fffffff
 ; GFX9-NEXT:    s_and_b64 s[4:5], s[6:7], exec
-; GFX9-NEXT:    s_cselect_b32 s4, 0, s8
+; GFX9-NEXT:    s_cselect_b32 s4, s8, 0
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s11
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s4
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
@@ -736,14 +730,14 @@ define i64 @test_s_signed_i64_f32(float inreg %f) nounwind {
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_trunc_f32_e32 v0, s0
-; GFX11-NEXT:    v_cmp_lt_f32_e64 s6, 0x5effffff, s0
+; GFX11-NEXT:    v_cmp_nlt_f32_e64 s6, 0x5effffff, s0
 ; GFX11-NEXT:    v_mul_f32_e64 v1, 0x2f800000, |v0|
 ; GFX11-NEXT:    v_readfirstlane_b32 s1, v0
 ; GFX11-NEXT:    v_floor_f32_e32 v1, v1
 ; GFX11-NEXT:    s_ashr_i32 s4, s1, 31
-; GFX11-NEXT:    v_cmp_nle_f32_e64 s1, 0xdf000000, s0
+; GFX11-NEXT:    v_cmp_le_f32_e64 s1, 0xdf000000, s0
 ; GFX11-NEXT:    s_mov_b32 s5, s4
-; GFX11-NEXT:    v_cmp_u_f32_e64 s0, s0, s0
+; GFX11-NEXT:    v_cmp_o_f32_e64 s0, s0, s0
 ; GFX11-NEXT:    v_fma_f32 v2, 0xcf800000, v1, |v0|
 ; GFX11-NEXT:    v_cvt_u32_f32_e32 v1, v1
 ; GFX11-NEXT:    v_cvt_u32_f32_e32 v2, v2
@@ -753,17 +747,17 @@ define i64 @test_s_signed_i64_f32(float inreg %f) nounwind {
 ; GFX11-NEXT:    s_sub_u32 s2, s2, s4
 ; GFX11-NEXT:    s_subb_u32 s3, s3, s4
 ; GFX11-NEXT:    s_and_b32 s4, s1, exec_lo
-; GFX11-NEXT:    s_cselect_b32 s2, 0, s2
+; GFX11-NEXT:    s_cselect_b32 s2, s2, 0
 ; GFX11-NEXT:    s_and_b32 s4, s6, exec_lo
-; GFX11-NEXT:    s_cselect_b32 s2, -1, s2
+; GFX11-NEXT:    s_cselect_b32 s2, s2, -1
 ; GFX11-NEXT:    s_and_b32 s4, s0, exec_lo
-; GFX11-NEXT:    s_cselect_b32 s2, 0, s2
+; GFX11-NEXT:    s_cselect_b32 s2, s2, 0
 ; GFX11-NEXT:    s_and_b32 s1, s1, exec_lo
-; GFX11-NEXT:    s_cselect_b32 s1, 0x80000000, s3
+; GFX11-NEXT:    s_cselect_b32 s1, s3, 0x80000000
 ; GFX11-NEXT:    s_and_b32 s3, s6, exec_lo
-; GFX11-NEXT:    s_cselect_b32 s1, 0x7fffffff, s1
+; GFX11-NEXT:    s_cselect_b32 s1, s1, 0x7fffffff
 ; GFX11-NEXT:    s_and_b32 s0, s0, exec_lo
-; GFX11-NEXT:    s_cselect_b32 s0, 0, s1
+; GFX11-NEXT:    s_cselect_b32 s0, s1, 0
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s2 :: v_dual_mov_b32 v1, s0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -790,20 +784,20 @@ define i64 @test_s_signed_i64_f32(float inreg %f) nounwind {
 ; GFX12-ISEL-NEXT:    s_mov_b32 s3, s2
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-ISEL-NEXT:    s_xor_b64 s[4:5], s[4:5], s[2:3]
-; GFX12-ISEL-NEXT:    s_cmp_nge_f32 s0, 0xdf000000
+; GFX12-ISEL-NEXT:    s_cmp_ge_f32 s0, 0xdf000000
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-ISEL-NEXT:    s_sub_nc_u64 s[2:3], s[4:5], s[2:3]
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-ISEL-NEXT:    s_cselect_b32 s1, 0, s2
-; GFX12-ISEL-NEXT:    s_cselect_b32 s2, 0x80000000, s3
-; GFX12-ISEL-NEXT:    s_cmp_gt_f32 s0, 0x5effffff
+; GFX12-ISEL-NEXT:    s_cselect_b32 s1, s2, 0
+; GFX12-ISEL-NEXT:    s_cselect_b32 s2, s3, 0x80000000
+; GFX12-ISEL-NEXT:    s_cmp_ngt_f32 s0, 0x5effffff
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-ISEL-NEXT:    s_cselect_b32 s2, 0x7fffffff, s2
-; GFX12-ISEL-NEXT:    s_cselect_b32 s1, -1, s1
-; GFX12-ISEL-NEXT:    s_cmp_u_f32 s0, s0
+; GFX12-ISEL-NEXT:    s_cselect_b32 s2, s2, 0x7fffffff
+; GFX12-ISEL-NEXT:    s_cselect_b32 s1, s1, -1
+; GFX12-ISEL-NEXT:    s_cmp_o_f32 s0, s0
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-ISEL-NEXT:    s_cselect_b32 s0, 0, s1
-; GFX12-ISEL-NEXT:    s_cselect_b32 s1, 0, s2
+; GFX12-ISEL-NEXT:    s_cselect_b32 s0, s1, 0
+; GFX12-ISEL-NEXT:    s_cselect_b32 s1, s2, 0
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -1073,20 +1067,20 @@ define i64 @test_signed_i64_f64(double %f) nounwind {
 ; GFX7-ISEL-NEXT:    v_bfrev_b32_e32 v6, 1
 ; GFX7-ISEL-NEXT:    v_ldexp_f64 v[4:5], v[2:3], s4
 ; GFX7-ISEL-NEXT:    s_mov_b32 s4, 0
-; GFX7-ISEL-NEXT:    v_cmp_nle_f64_e32 vcc, s[4:5], v[0:1]
-; GFX7-ISEL-NEXT:    v_cmp_lt_f64_e64 s[4:5], s[6:7], v[0:1]
-; GFX7-ISEL-NEXT:    v_cmp_u_f64_e64 s[6:7], v[0:1], v[0:1]
+; GFX7-ISEL-NEXT:    v_cmp_le_f64_e32 vcc, s[4:5], v[0:1]
+; GFX7-ISEL-NEXT:    v_cmp_nlt_f64_e64 s[4:5], s[6:7], v[0:1]
+; GFX7-ISEL-NEXT:    v_cmp_o_f64_e64 s[6:7], v[0:1], v[0:1]
 ; GFX7-ISEL-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
 ; GFX7-ISEL-NEXT:    v_fma_f64 v[2:3], v[4:5], s[8:9], v[2:3]
 ; GFX7-ISEL-NEXT:    v_cvt_i32_f64_e32 v7, v[4:5]
 ; GFX7-ISEL-NEXT:    v_bfrev_b32_e32 v4, -2
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v5, v7, v6, vcc
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v4, v5, v4, s[4:5]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, v4, 0, s[6:7]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v5, v6, v7, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v4, v4, v5, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, 0, v4, s[6:7]
 ; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v0, v[2:3]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s[4:5]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[6:7]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[6:7]
 ; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX7-GI-LABEL: test_signed_i64_f64:
@@ -1132,42 +1126,41 @@ define i64 @test_signed_i64_f64(double %f) nounwind {
 ; GFX9-NEXT:    v_bfrev_b32_e32 v6, 1
 ; GFX9-NEXT:    v_ldexp_f64 v[4:5], v[2:3], s4
 ; GFX9-NEXT:    s_mov_b32 s4, 0
-; GFX9-NEXT:    v_cmp_nle_f64_e32 vcc, s[4:5], v[0:1]
-; GFX9-NEXT:    v_cmp_lt_f64_e64 s[4:5], s[6:7], v[0:1]
-; GFX9-NEXT:    v_cmp_u_f64_e64 s[6:7], v[0:1], v[0:1]
+; GFX9-NEXT:    v_cmp_le_f64_e32 vcc, s[4:5], v[0:1]
+; GFX9-NEXT:    v_cmp_nlt_f64_e64 s[4:5], s[6:7], v[0:1]
+; GFX9-NEXT:    v_cmp_o_f64_e64 s[6:7], v[0:1], v[0:1]
 ; GFX9-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
 ; GFX9-NEXT:    v_fma_f64 v[2:3], v[4:5], s[8:9], v[2:3]
 ; GFX9-NEXT:    v_cvt_i32_f64_e32 v7, v[4:5]
 ; GFX9-NEXT:    v_bfrev_b32_e32 v4, -2
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v7, v6, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, v5, v4, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v4, 0, s[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e32 v5, v6, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v4, v4, v5, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, v4, s[6:7]
 ; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, v[2:3]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[6:7]
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: test_signed_i64_f64:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_trunc_f64_e32 v[2:3], v[0:1]
-; GFX11-NEXT:    v_cmp_nle_f64_e32 vcc_lo, 0xc3e00000, v[0:1]
+; GFX11-NEXT:    v_cmp_le_f64_e32 vcc_lo, 0xc3e00000, v[0:1]
 ; GFX11-NEXT:    s_mov_b32 s0, -1
 ; GFX11-NEXT:    s_mov_b32 s1, 0x43dfffff
-; GFX11-NEXT:    v_cmp_lt_f64_e64 s0, s[0:1], v[0:1]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s1, v[0:1], v[0:1]
+; GFX11-NEXT:    v_cmp_nlt_f64_e64 s0, s[0:1], v[0:1]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s1, v[0:1], v[0:1]
 ; GFX11-NEXT:    v_ldexp_f64 v[4:5], v[2:3], 0xffffffe0
 ; GFX11-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
 ; GFX11-NEXT:    v_fma_f64 v[2:3], 0xc1f00000, v[4:5], v[2:3]
 ; GFX11-NEXT:    v_cvt_i32_f64_e32 v4, v[4:5]
 ; GFX11-NEXT:    v_cvt_u32_f64_e32 v2, v[2:3]
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v4, 0x80000000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v3, 0x7fffffff, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v3, 0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s1
+; GFX11-NEXT:    v_dual_cndmask_b32 v3, 0x80000000, v4 :: v_dual_cndmask_b32 v0, 0, v2
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7fffffff, v3, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, 0, v3, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s1
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-ISEL-LABEL: test_signed_i64_f64:
@@ -1178,25 +1171,24 @@ define i64 @test_signed_i64_f64(double %f) nounwind {
 ; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-ISEL-NEXT:    v_trunc_f64_e32 v[2:3], v[0:1]
-; GFX12-ISEL-NEXT:    v_cmp_nle_f64_e32 vcc_lo, 0xc3e00000, v[0:1]
+; GFX12-ISEL-NEXT:    v_cmp_le_f64_e32 vcc_lo, 0xc3e00000, v[0:1]
 ; GFX12-ISEL-NEXT:    s_mov_b32 s0, -1
 ; GFX12-ISEL-NEXT:    s_mov_b32 s1, 0x43dfffff
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-ISEL-NEXT:    v_cmp_lt_f64_e64 s0, s[0:1], v[0:1]
-; GFX12-ISEL-NEXT:    v_cmp_u_f64_e64 s1, v[0:1], v[0:1]
+; GFX12-ISEL-NEXT:    v_cmp_nlt_f64_e64 s0, s[0:1], v[0:1]
+; GFX12-ISEL-NEXT:    v_cmp_o_f64_e64 s1, v[0:1], v[0:1]
 ; GFX12-ISEL-NEXT:    v_ldexp_f64 v[4:5], v[2:3], 0xffffffe0
 ; GFX12-ISEL-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
 ; GFX12-ISEL-NEXT:    v_fma_f64 v[2:3], 0xc1f00000, v[4:5], v[2:3]
 ; GFX12-ISEL-NEXT:    v_cvt_i32_f64_e32 v4, v[4:5]
 ; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v2, v[2:3]
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, v4, 0x80000000, vcc_lo
+; GFX12-ISEL-NEXT:    v_dual_cndmask_b32 v3, 0x80000000, v4 :: v_dual_cndmask_b32 v0, 0, v2
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, v3, 0x7fffffff, s0
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v3, 0, s1
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc_lo
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s0
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s1
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, 0x7fffffff, v3, s0
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s0
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, 0, v3, s1
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s1
 ; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GI-LABEL: test_signed_i64_f64:
@@ -1472,23 +1464,23 @@ define i64 @test_s_signed_i64_f64(double inreg %f) nounwind {
 ; GFX7-ISEL-NEXT:    v_mov_b32_e32 v5, 0xc3e00000
 ; GFX7-ISEL-NEXT:    v_mov_b32_e32 v6, -1
 ; GFX7-ISEL-NEXT:    v_mov_b32_e32 v7, 0x43dfffff
-; GFX7-ISEL-NEXT:    v_cmp_nge_f64_e32 vcc, s[16:17], v[4:5]
+; GFX7-ISEL-NEXT:    v_cmp_ge_f64_e32 vcc, s[16:17], v[4:5]
 ; GFX7-ISEL-NEXT:    v_ldexp_f64 v[2:3], v[0:1], s4
 ; GFX7-ISEL-NEXT:    s_mov_b32 s4, 0
-; GFX7-ISEL-NEXT:    v_cmp_u_f64_e64 s[6:7], s[16:17], s[16:17]
+; GFX7-ISEL-NEXT:    v_cmp_o_f64_e64 s[6:7], s[16:17], s[16:17]
 ; GFX7-ISEL-NEXT:    v_bfrev_b32_e32 v8, 1
 ; GFX7-ISEL-NEXT:    v_floor_f64_e32 v[2:3], v[2:3]
 ; GFX7-ISEL-NEXT:    v_fma_f64 v[0:1], v[2:3], s[4:5], v[0:1]
-; GFX7-ISEL-NEXT:    v_cmp_gt_f64_e64 s[4:5], s[16:17], v[6:7]
+; GFX7-ISEL-NEXT:    v_cmp_ngt_f64_e64 s[4:5], s[16:17], v[6:7]
 ; GFX7-ISEL-NEXT:    v_cvt_i32_f64_e32 v9, v[2:3]
 ; GFX7-ISEL-NEXT:    v_bfrev_b32_e32 v2, -2
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v3, v9, v8, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v3, v8, v9, vcc
 ; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v3, v2, s[4:5]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, v2, 0, s[6:7]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s[4:5]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[6:7]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v2, v3, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, 0, v2, s[6:7]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[6:7]
 ; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX7-GI-LABEL: test_s_signed_i64_f64:
@@ -1537,45 +1529,44 @@ define i64 @test_s_signed_i64_f64(double inreg %f) nounwind {
 ; GFX9-NEXT:    v_mov_b32_e32 v5, 0xc3e00000
 ; GFX9-NEXT:    v_mov_b32_e32 v6, -1
 ; GFX9-NEXT:    v_mov_b32_e32 v7, 0x43dfffff
-; GFX9-NEXT:    v_cmp_nge_f64_e32 vcc, s[16:17], v[4:5]
+; GFX9-NEXT:    v_cmp_ge_f64_e32 vcc, s[16:17], v[4:5]
 ; GFX9-NEXT:    v_ldexp_f64 v[2:3], v[0:1], s4
 ; GFX9-NEXT:    s_mov_b32 s4, 0
-; GFX9-NEXT:    v_cmp_u_f64_e64 s[6:7], s[16:17], s[16:17]
+; GFX9-NEXT:    v_cmp_o_f64_e64 s[6:7], s[16:17], s[16:17]
 ; GFX9-NEXT:    v_bfrev_b32_e32 v8, 1
 ; GFX9-NEXT:    v_floor_f64_e32 v[2:3], v[2:3]
 ; GFX9-NEXT:    v_fma_f64 v[0:1], v[2:3], s[4:5], v[0:1]
-; GFX9-NEXT:    v_cmp_gt_f64_e64 s[4:5], s[16:17], v[6:7]
+; GFX9-NEXT:    v_cmp_ngt_f64_e64 s[4:5], s[16:17], v[6:7]
 ; GFX9-NEXT:    v_cvt_i32_f64_e32 v9, v[2:3]
 ; GFX9-NEXT:    v_bfrev_b32_e32 v2, -2
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v9, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v8, v9, vcc
 ; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v3, v2, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v2, 0, s[6:7]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, v2, v3, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, v2, s[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[6:7]
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: test_s_signed_i64_f64:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_trunc_f64_e32 v[0:1], s[0:1]
-; GFX11-NEXT:    v_cmp_nle_f64_e64 s4, 0xc3e00000, s[0:1]
+; GFX11-NEXT:    v_cmp_le_f64_e64 vcc_lo, 0xc3e00000, s[0:1]
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    s_mov_b32 s3, 0x43dfffff
-; GFX11-NEXT:    v_cmp_gt_f64_e64 s2, s[0:1], s[2:3]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, s[0:1], s[0:1]
+; GFX11-NEXT:    v_cmp_ngt_f64_e64 s2, s[0:1], s[2:3]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, s[0:1], s[0:1]
 ; GFX11-NEXT:    v_ldexp_f64 v[2:3], v[0:1], 0xffffffe0
 ; GFX11-NEXT:    v_floor_f64_e32 v[2:3], v[2:3]
 ; GFX11-NEXT:    v_fma_f64 v[0:1], 0xc1f00000, v[2:3], v[0:1]
 ; GFX11-NEXT:    v_cvt_i32_f64_e32 v2, v[2:3]
 ; GFX11-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v2, 0x80000000, s4
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7fffffff, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s4
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s0
+; GFX11-NEXT:    v_dual_cndmask_b32 v1, 0x80000000, v2 :: v_dual_cndmask_b32 v0, 0, v0
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, 0x7fffffff, v1, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, 0, v1, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-ISEL-LABEL: test_s_signed_i64_f64:
@@ -1586,24 +1577,24 @@ define i64 @test_s_signed_i64_f64(double inreg %f) nounwind {
 ; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-ISEL-NEXT:    v_trunc_f64_e32 v[0:1], s[0:1]
-; GFX12-ISEL-NEXT:    v_cmp_nle_f64_e64 s4, 0xc3e00000, s[0:1]
+; GFX12-ISEL-NEXT:    v_cmp_le_f64_e64 vcc_lo, 0xc3e00000, s[0:1]
 ; GFX12-ISEL-NEXT:    s_mov_b32 s2, -1
 ; GFX12-ISEL-NEXT:    s_mov_b32 s3, 0x43dfffff
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-ISEL-NEXT:    v_cmp_gt_f64_e64 s2, s[0:1], s[2:3]
-; GFX12-ISEL-NEXT:    v_cmp_u_f64_e64 s0, s[0:1], s[0:1]
+; GFX12-ISEL-NEXT:    v_cmp_ngt_f64_e64 s2, s[0:1], s[2:3]
+; GFX12-ISEL-NEXT:    v_cmp_o_f64_e64 s0, s[0:1], s[0:1]
 ; GFX12-ISEL-NEXT:    v_ldexp_f64 v[2:3], v[0:1], 0xffffffe0
 ; GFX12-ISEL-NEXT:    v_floor_f64_e32 v[2:3], v[2:3]
 ; GFX12-ISEL-NEXT:    v_fma_f64 v[0:1], 0xc1f00000, v[2:3], v[0:1]
 ; GFX12-ISEL-NEXT:    v_cvt_i32_f64_e32 v2, v[2:3]
 ; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX12-ISEL-NEXT:    v_dual_cndmask_b32 v1, 0x80000000, v2 :: v_dual_cndmask_b32 v0, 0, v0
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v2, 0x80000000, s4
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7fffffff, s2
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s0
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s4
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s2
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s0
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, 0x7fffffff, v1, s2
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s2
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, 0, v1, s0
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s0
 ; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GI-LABEL: test_s_signed_i64_f64:

--- a/llvm/test/CodeGen/AMDGPU/fptosi-sat-vector.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptosi-sat-vector.ll
@@ -1643,34 +1643,34 @@ define <2 x i64> @test_signed_v2f64_v2i64(<2 x double> %f) {
 ; GFX7-ISEL-NEXT:    v_ldexp_f64 v[8:9], v[4:5], s4
 ; GFX7-ISEL-NEXT:    v_ldexp_f64 v[10:11], v[6:7], s4
 ; GFX7-ISEL-NEXT:    s_mov_b32 s4, 0
-; GFX7-ISEL-NEXT:    v_cmp_nle_f64_e32 vcc, s[4:5], v[0:1]
-; GFX7-ISEL-NEXT:    v_cmp_nle_f64_e64 s[4:5], s[4:5], v[2:3]
-; GFX7-ISEL-NEXT:    v_cmp_u_f64_e64 s[10:11], v[0:1], v[0:1]
-; GFX7-ISEL-NEXT:    v_cmp_u_f64_e64 s[12:13], v[2:3], v[2:3]
+; GFX7-ISEL-NEXT:    v_cmp_le_f64_e32 vcc, s[4:5], v[0:1]
+; GFX7-ISEL-NEXT:    v_cmp_le_f64_e64 s[4:5], s[4:5], v[2:3]
+; GFX7-ISEL-NEXT:    v_cmp_o_f64_e64 s[10:11], v[0:1], v[0:1]
+; GFX7-ISEL-NEXT:    v_cmp_o_f64_e64 s[12:13], v[2:3], v[2:3]
 ; GFX7-ISEL-NEXT:    v_bfrev_b32_e32 v12, 1
 ; GFX7-ISEL-NEXT:    v_floor_f64_e32 v[8:9], v[8:9]
 ; GFX7-ISEL-NEXT:    v_floor_f64_e32 v[10:11], v[10:11]
 ; GFX7-ISEL-NEXT:    v_bfrev_b32_e32 v13, -2
 ; GFX7-ISEL-NEXT:    v_fma_f64 v[4:5], v[8:9], s[6:7], v[4:5]
 ; GFX7-ISEL-NEXT:    v_fma_f64 v[6:7], v[10:11], s[6:7], v[6:7]
-; GFX7-ISEL-NEXT:    v_cmp_lt_f64_e64 s[6:7], s[8:9], v[0:1]
-; GFX7-ISEL-NEXT:    v_cmp_lt_f64_e64 s[8:9], s[8:9], v[2:3]
+; GFX7-ISEL-NEXT:    v_cmp_nlt_f64_e64 s[6:7], s[8:9], v[0:1]
+; GFX7-ISEL-NEXT:    v_cmp_nlt_f64_e64 s[8:9], s[8:9], v[2:3]
 ; GFX7-ISEL-NEXT:    v_cvt_i32_f64_e32 v14, v[8:9]
 ; GFX7-ISEL-NEXT:    v_cvt_i32_f64_e32 v15, v[10:11]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v8, v14, v12, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v8, v12, v14, vcc
 ; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v0, v[4:5]
 ; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v2, v[6:7]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v9, v15, v12, s[4:5]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v8, v8, v13, s[6:7]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[4:5]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v9, v9, v13, s[8:9]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s[6:7]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v2, -1, s[8:9]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, v8, 0, s[10:11]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v3, v9, 0, s[12:13]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[10:11]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[12:13]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v9, v12, v15, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v8, v13, v8, s[6:7]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v9, v13, v9, s[8:9]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s[6:7]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, -1, v2, s[8:9]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, 0, v8, s[10:11]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v3, 0, v9, s[12:13]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[10:11]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[12:13]
 ; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX7-GI-LABEL: test_signed_v2f64_v2i64:
@@ -1732,34 +1732,34 @@ define <2 x i64> @test_signed_v2f64_v2i64(<2 x double> %f) {
 ; GFX9-NEXT:    v_ldexp_f64 v[8:9], v[4:5], s4
 ; GFX9-NEXT:    v_ldexp_f64 v[10:11], v[6:7], s4
 ; GFX9-NEXT:    s_mov_b32 s4, 0
-; GFX9-NEXT:    v_cmp_nle_f64_e32 vcc, s[4:5], v[0:1]
-; GFX9-NEXT:    v_cmp_nle_f64_e64 s[4:5], s[4:5], v[2:3]
-; GFX9-NEXT:    v_cmp_u_f64_e64 s[10:11], v[0:1], v[0:1]
-; GFX9-NEXT:    v_cmp_u_f64_e64 s[12:13], v[2:3], v[2:3]
+; GFX9-NEXT:    v_cmp_le_f64_e32 vcc, s[4:5], v[0:1]
+; GFX9-NEXT:    v_cmp_le_f64_e64 s[4:5], s[4:5], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e64 s[10:11], v[0:1], v[0:1]
+; GFX9-NEXT:    v_cmp_o_f64_e64 s[12:13], v[2:3], v[2:3]
 ; GFX9-NEXT:    v_bfrev_b32_e32 v12, 1
 ; GFX9-NEXT:    v_floor_f64_e32 v[8:9], v[8:9]
 ; GFX9-NEXT:    v_floor_f64_e32 v[10:11], v[10:11]
 ; GFX9-NEXT:    v_bfrev_b32_e32 v13, -2
 ; GFX9-NEXT:    v_fma_f64 v[4:5], v[8:9], s[6:7], v[4:5]
 ; GFX9-NEXT:    v_fma_f64 v[6:7], v[10:11], s[6:7], v[6:7]
-; GFX9-NEXT:    v_cmp_lt_f64_e64 s[6:7], s[8:9], v[0:1]
-; GFX9-NEXT:    v_cmp_lt_f64_e64 s[8:9], s[8:9], v[2:3]
+; GFX9-NEXT:    v_cmp_nlt_f64_e64 s[6:7], s[8:9], v[0:1]
+; GFX9-NEXT:    v_cmp_nlt_f64_e64 s[8:9], s[8:9], v[2:3]
 ; GFX9-NEXT:    v_cvt_i32_f64_e32 v14, v[8:9]
 ; GFX9-NEXT:    v_cvt_i32_f64_e32 v15, v[10:11]
-; GFX9-NEXT:    v_cndmask_b32_e32 v8, v14, v12, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v8, v12, v14, vcc
 ; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, v[4:5]
 ; GFX9-NEXT:    v_cvt_u32_f64_e32 v2, v[6:7]
-; GFX9-NEXT:    v_cndmask_b32_e64 v9, v15, v12, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v8, v8, v13, s[6:7]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v9, v9, v13, s[8:9]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s[6:7]
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v2, -1, s[8:9]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v8, 0, s[10:11]
-; GFX9-NEXT:    v_cndmask_b32_e64 v3, v9, 0, s[12:13]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[10:11]
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[12:13]
+; GFX9-NEXT:    v_cndmask_b32_e64 v9, v12, v15, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v8, v13, v8, s[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v9, v13, v9, s[8:9]
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, -1, v2, s[8:9]
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, v8, s[10:11]
+; GFX9-NEXT:    v_cndmask_b32_e64 v3, 0, v9, s[12:13]
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[10:11]
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[12:13]
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: test_signed_v2f64_v2i64:
@@ -1767,14 +1767,14 @@ define <2 x i64> @test_signed_v2f64_v2i64(<2 x double> %f) {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_trunc_f64_e32 v[4:5], v[0:1]
 ; GFX11-NEXT:    v_trunc_f64_e32 v[6:7], v[2:3]
-; GFX11-NEXT:    v_cmp_nle_f64_e32 vcc_lo, 0xc3e00000, v[0:1]
-; GFX11-NEXT:    v_cmp_nle_f64_e64 s0, 0xc3e00000, v[2:3]
+; GFX11-NEXT:    v_cmp_le_f64_e32 vcc_lo, 0xc3e00000, v[0:1]
+; GFX11-NEXT:    v_cmp_le_f64_e64 s0, 0xc3e00000, v[2:3]
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    s_mov_b32 s3, 0x43dfffff
-; GFX11-NEXT:    v_cmp_u_f64_e64 s4, v[2:3], v[2:3]
-; GFX11-NEXT:    v_cmp_lt_f64_e64 s1, s[2:3], v[0:1]
-; GFX11-NEXT:    v_cmp_lt_f64_e64 s2, s[2:3], v[2:3]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s3, v[0:1], v[0:1]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s4, v[2:3], v[2:3]
+; GFX11-NEXT:    v_cmp_nlt_f64_e64 s1, s[2:3], v[0:1]
+; GFX11-NEXT:    v_cmp_nlt_f64_e64 s2, s[2:3], v[2:3]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s3, v[0:1], v[0:1]
 ; GFX11-NEXT:    v_ldexp_f64 v[8:9], v[4:5], 0xffffffe0
 ; GFX11-NEXT:    v_ldexp_f64 v[10:11], v[6:7], 0xffffffe0
 ; GFX11-NEXT:    v_floor_f64_e32 v[8:9], v[8:9]
@@ -1785,18 +1785,18 @@ define <2 x i64> @test_signed_v2f64_v2i64(<2 x double> %f) {
 ; GFX11-NEXT:    v_cvt_i32_f64_e32 v9, v[10:11]
 ; GFX11-NEXT:    v_cvt_u32_f64_e32 v4, v[4:5]
 ; GFX11-NEXT:    v_cvt_u32_f64_e32 v5, v[6:7]
-; GFX11-NEXT:    v_cndmask_b32_e64 v6, v8, 0x80000000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v7, v9, 0x80000000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v6, v6, 0x7fffffff, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v7, 0x7fffffff, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v0, 0, s4
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v4, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v5, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v1, -1, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v2, -1, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v6, 0, s3
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, s3
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s4
+; GFX11-NEXT:    v_cndmask_b32_e32 v6, 0x80000000, v8, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e64 v7, 0x80000000, v9, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v6, 0x7fffffff, v6, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, 0x7fffffff, v7, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0, v0, s4
+; GFX11-NEXT:    v_cndmask_b32_e32 v1, 0, v4, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v5, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v4, -1, v1, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, -1, v2, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, 0, v6, s3
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, 0, v4, s3
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s4
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-ISEL-LABEL: test_signed_v2f64_v2i64:
@@ -1808,15 +1808,15 @@ define <2 x i64> @test_signed_v2f64_v2i64(<2 x double> %f) {
 ; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-ISEL-NEXT:    v_trunc_f64_e32 v[4:5], v[0:1]
 ; GFX12-ISEL-NEXT:    v_trunc_f64_e32 v[6:7], v[2:3]
-; GFX12-ISEL-NEXT:    v_cmp_nle_f64_e32 vcc_lo, 0xc3e00000, v[0:1]
-; GFX12-ISEL-NEXT:    v_cmp_nle_f64_e64 s0, 0xc3e00000, v[2:3]
+; GFX12-ISEL-NEXT:    v_cmp_le_f64_e32 vcc_lo, 0xc3e00000, v[0:1]
+; GFX12-ISEL-NEXT:    v_cmp_le_f64_e64 s0, 0xc3e00000, v[2:3]
 ; GFX12-ISEL-NEXT:    s_mov_b32 s2, -1
 ; GFX12-ISEL-NEXT:    s_mov_b32 s3, 0x43dfffff
-; GFX12-ISEL-NEXT:    v_cmp_u_f64_e64 s4, v[2:3], v[2:3]
+; GFX12-ISEL-NEXT:    v_cmp_o_f64_e64 s4, v[2:3], v[2:3]
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-ISEL-NEXT:    v_cmp_lt_f64_e64 s1, s[2:3], v[0:1]
-; GFX12-ISEL-NEXT:    v_cmp_lt_f64_e64 s2, s[2:3], v[2:3]
-; GFX12-ISEL-NEXT:    v_cmp_u_f64_e64 s3, v[0:1], v[0:1]
+; GFX12-ISEL-NEXT:    v_cmp_nlt_f64_e64 s1, s[2:3], v[0:1]
+; GFX12-ISEL-NEXT:    v_cmp_nlt_f64_e64 s2, s[2:3], v[2:3]
+; GFX12-ISEL-NEXT:    v_cmp_o_f64_e64 s3, v[0:1], v[0:1]
 ; GFX12-ISEL-NEXT:    v_ldexp_f64 v[8:9], v[4:5], 0xffffffe0
 ; GFX12-ISEL-NEXT:    v_ldexp_f64 v[10:11], v[6:7], 0xffffffe0
 ; GFX12-ISEL-NEXT:    v_floor_f64_e32 v[8:9], v[8:9]
@@ -1828,19 +1828,19 @@ define <2 x i64> @test_signed_v2f64_v2i64(<2 x double> %f) {
 ; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v4, v[4:5]
 ; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v5, v[6:7]
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v6, v8, 0x80000000, vcc_lo
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e32 v6, 0x80000000, v8, vcc_lo
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v7, v9, 0x80000000, s0
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v6, v6, 0x7fffffff, s1
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v7, 0x7fffffff, s2
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, v0, 0, s4
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v4, 0, vcc_lo
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, v5, 0, s0
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v4, v1, -1, s1
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, v2, -1, s2
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v6, 0, s3
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v4, 0, s3
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s4
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v7, 0x80000000, v9, s0
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v6, 0x7fffffff, v6, s1
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, 0x7fffffff, v7, s2
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, 0, v0, s4
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e32 v1, 0, v4, vcc_lo
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, 0, v5, s0
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v4, -1, v1, s1
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, -1, v2, s2
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, 0, v6, s3
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, 0, v4, s3
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s4
 ; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GI-LABEL: test_signed_v2f64_v2i64:
@@ -2212,34 +2212,34 @@ define <2 x i64> @test_s_signed_v2f64_v2i64(<2 x double> inreg %f) {
 ; GFX7-ISEL-NEXT:    s_mov_b32 s4, -1
 ; GFX7-ISEL-NEXT:    v_mov_b32_e32 v11, s5
 ; GFX7-ISEL-NEXT:    v_mov_b32_e32 v10, s4
-; GFX7-ISEL-NEXT:    v_cmp_nge_f64_e32 vcc, s[16:17], v[8:9]
-; GFX7-ISEL-NEXT:    v_cmp_nge_f64_e64 s[4:5], s[18:19], v[8:9]
-; GFX7-ISEL-NEXT:    v_cmp_gt_f64_e64 s[8:9], s[18:19], v[10:11]
+; GFX7-ISEL-NEXT:    v_cmp_ge_f64_e32 vcc, s[16:17], v[8:9]
+; GFX7-ISEL-NEXT:    v_cmp_ge_f64_e64 s[4:5], s[18:19], v[8:9]
+; GFX7-ISEL-NEXT:    v_cmp_ngt_f64_e64 s[8:9], s[18:19], v[10:11]
 ; GFX7-ISEL-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
 ; GFX7-ISEL-NEXT:    v_floor_f64_e32 v[6:7], v[6:7]
-; GFX7-ISEL-NEXT:    v_cmp_u_f64_e64 s[10:11], s[16:17], s[16:17]
-; GFX7-ISEL-NEXT:    v_cmp_u_f64_e64 s[12:13], s[18:19], s[18:19]
+; GFX7-ISEL-NEXT:    v_cmp_o_f64_e64 s[10:11], s[16:17], s[16:17]
+; GFX7-ISEL-NEXT:    v_cmp_o_f64_e64 s[12:13], s[18:19], s[18:19]
 ; GFX7-ISEL-NEXT:    v_bfrev_b32_e32 v12, 1
 ; GFX7-ISEL-NEXT:    v_bfrev_b32_e32 v13, -2
 ; GFX7-ISEL-NEXT:    v_cvt_i32_f64_e32 v14, v[4:5]
 ; GFX7-ISEL-NEXT:    v_cvt_i32_f64_e32 v15, v[6:7]
 ; GFX7-ISEL-NEXT:    v_fma_f64 v[4:5], v[4:5], s[6:7], v[0:1]
 ; GFX7-ISEL-NEXT:    v_fma_f64 v[6:7], v[6:7], s[6:7], v[2:3]
-; GFX7-ISEL-NEXT:    v_cmp_gt_f64_e64 s[6:7], s[16:17], v[10:11]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v0, v14, v12, vcc
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, v15, v12, s[4:5]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v1, v13, s[8:9]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v3, v2, 0, s[12:13]
+; GFX7-ISEL-NEXT:    v_cmp_ngt_f64_e64 s[6:7], s[16:17], v[10:11]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v0, v12, v14, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, v12, v15, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v13, v1, s[8:9]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v3, 0, v2, s[12:13]
 ; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v2, v[6:7]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, v13, s[6:7]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, v0, 0, s[10:11]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v13, v0, s[6:7]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, 0, v0, s[10:11]
 ; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v0, v[4:5]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[4:5]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v2, -1, s[8:9]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[12:13]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s[6:7]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[10:11]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, -1, v2, s[8:9]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[12:13]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s[6:7]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[10:11]
 ; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX7-GI-LABEL: test_s_signed_v2f64_v2i64:
@@ -2313,34 +2313,34 @@ define <2 x i64> @test_s_signed_v2f64_v2i64(<2 x double> inreg %f) {
 ; GFX9-NEXT:    s_mov_b32 s4, -1
 ; GFX9-NEXT:    v_mov_b32_e32 v11, s5
 ; GFX9-NEXT:    v_mov_b32_e32 v10, s4
-; GFX9-NEXT:    v_cmp_nge_f64_e32 vcc, s[16:17], v[8:9]
-; GFX9-NEXT:    v_cmp_nge_f64_e64 s[4:5], s[18:19], v[8:9]
-; GFX9-NEXT:    v_cmp_gt_f64_e64 s[8:9], s[18:19], v[10:11]
+; GFX9-NEXT:    v_cmp_ge_f64_e32 vcc, s[16:17], v[8:9]
+; GFX9-NEXT:    v_cmp_ge_f64_e64 s[4:5], s[18:19], v[8:9]
+; GFX9-NEXT:    v_cmp_ngt_f64_e64 s[8:9], s[18:19], v[10:11]
 ; GFX9-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
 ; GFX9-NEXT:    v_floor_f64_e32 v[6:7], v[6:7]
-; GFX9-NEXT:    v_cmp_u_f64_e64 s[10:11], s[16:17], s[16:17]
-; GFX9-NEXT:    v_cmp_u_f64_e64 s[12:13], s[18:19], s[18:19]
+; GFX9-NEXT:    v_cmp_o_f64_e64 s[10:11], s[16:17], s[16:17]
+; GFX9-NEXT:    v_cmp_o_f64_e64 s[12:13], s[18:19], s[18:19]
 ; GFX9-NEXT:    v_bfrev_b32_e32 v12, 1
 ; GFX9-NEXT:    v_bfrev_b32_e32 v13, -2
 ; GFX9-NEXT:    v_cvt_i32_f64_e32 v14, v[4:5]
 ; GFX9-NEXT:    v_cvt_i32_f64_e32 v15, v[6:7]
 ; GFX9-NEXT:    v_fma_f64 v[4:5], v[4:5], s[6:7], v[0:1]
 ; GFX9-NEXT:    v_fma_f64 v[6:7], v[6:7], s[6:7], v[2:3]
-; GFX9-NEXT:    v_cmp_gt_f64_e64 s[6:7], s[16:17], v[10:11]
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v14, v12, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v15, v12, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v1, v13, s[8:9]
-; GFX9-NEXT:    v_cndmask_b32_e64 v3, v2, 0, s[12:13]
+; GFX9-NEXT:    v_cmp_ngt_f64_e64 s[6:7], s[16:17], v[10:11]
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v12, v14, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, v12, v15, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, v13, v1, s[8:9]
+; GFX9-NEXT:    v_cndmask_b32_e64 v3, 0, v2, s[12:13]
 ; GFX9-NEXT:    v_cvt_u32_f64_e32 v2, v[6:7]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, v13, s[6:7]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v0, 0, s[10:11]
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, v13, v0, s[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, v0, s[10:11]
 ; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, v[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v2, -1, s[8:9]
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[12:13]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s[6:7]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[10:11]
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, -1, v2, s[8:9]
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[12:13]
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[10:11]
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: test_s_signed_v2f64_v2i64:
@@ -2348,14 +2348,14 @@ define <2 x i64> @test_s_signed_v2f64_v2i64(<2 x double> inreg %f) {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_trunc_f64_e32 v[0:1], s[0:1]
 ; GFX11-NEXT:    v_trunc_f64_e32 v[2:3], s[2:3]
-; GFX11-NEXT:    v_cmp_nle_f64_e64 s6, 0xc3e00000, s[0:1]
-; GFX11-NEXT:    v_cmp_nle_f64_e64 s7, 0xc3e00000, s[2:3]
-; GFX11-NEXT:    s_mov_b32 s4, -1
-; GFX11-NEXT:    s_mov_b32 s5, 0x43dfffff
-; GFX11-NEXT:    v_cmp_gt_f64_e64 s8, s[0:1], s[4:5]
-; GFX11-NEXT:    v_cmp_gt_f64_e64 s4, s[2:3], s[4:5]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, s[0:1], s[0:1]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s1, s[2:3], s[2:3]
+; GFX11-NEXT:    v_cmp_le_f64_e64 vcc_lo, 0xc3e00000, s[0:1]
+; GFX11-NEXT:    v_cmp_le_f64_e64 s4, 0xc3e00000, s[2:3]
+; GFX11-NEXT:    s_mov_b32 s6, -1
+; GFX11-NEXT:    s_mov_b32 s7, 0x43dfffff
+; GFX11-NEXT:    v_cmp_ngt_f64_e64 s5, s[0:1], s[6:7]
+; GFX11-NEXT:    v_cmp_ngt_f64_e64 s6, s[2:3], s[6:7]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, s[0:1], s[0:1]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s1, s[2:3], s[2:3]
 ; GFX11-NEXT:    v_ldexp_f64 v[4:5], v[0:1], 0xffffffe0
 ; GFX11-NEXT:    v_ldexp_f64 v[6:7], v[2:3], 0xffffffe0
 ; GFX11-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
@@ -2366,18 +2366,18 @@ define <2 x i64> @test_s_signed_v2f64_v2i64(<2 x double> inreg %f) {
 ; GFX11-NEXT:    v_cvt_i32_f64_e32 v5, v[6:7]
 ; GFX11-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
 ; GFX11-NEXT:    v_cvt_u32_f64_e32 v1, v[2:3]
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v4, 0x80000000, s6
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v5, 0x80000000, s7
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v2, 0x7fffffff, s8
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v3, 0x7fffffff, s4
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v3, 0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s6
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s7
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s8
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v1, -1, s4
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v2, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s1
+; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0x80000000, v4, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x80000000, v5, s4
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0x7fffffff, v2, s5
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7fffffff, v3, s6
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0, v3, s1
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, 0, v1, s4
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s5
+; GFX11-NEXT:    v_cndmask_b32_e64 v4, -1, v1, s6
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, 0, v2, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s1
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-ISEL-LABEL: test_s_signed_v2f64_v2i64:
@@ -2389,15 +2389,15 @@ define <2 x i64> @test_s_signed_v2f64_v2i64(<2 x double> inreg %f) {
 ; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-ISEL-NEXT:    v_trunc_f64_e32 v[0:1], s[0:1]
 ; GFX12-ISEL-NEXT:    v_trunc_f64_e32 v[2:3], s[2:3]
-; GFX12-ISEL-NEXT:    v_cmp_nle_f64_e64 s6, 0xc3e00000, s[0:1]
-; GFX12-ISEL-NEXT:    v_cmp_nle_f64_e64 s7, 0xc3e00000, s[2:3]
-; GFX12-ISEL-NEXT:    s_mov_b32 s4, -1
-; GFX12-ISEL-NEXT:    s_mov_b32 s5, 0x43dfffff
+; GFX12-ISEL-NEXT:    v_cmp_le_f64_e64 vcc_lo, 0xc3e00000, s[0:1]
+; GFX12-ISEL-NEXT:    v_cmp_le_f64_e64 s4, 0xc3e00000, s[2:3]
+; GFX12-ISEL-NEXT:    s_mov_b32 s6, -1
+; GFX12-ISEL-NEXT:    s_mov_b32 s7, 0x43dfffff
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-ISEL-NEXT:    v_cmp_gt_f64_e64 s8, s[0:1], s[4:5]
-; GFX12-ISEL-NEXT:    v_cmp_gt_f64_e64 s4, s[2:3], s[4:5]
-; GFX12-ISEL-NEXT:    v_cmp_u_f64_e64 s0, s[0:1], s[0:1]
-; GFX12-ISEL-NEXT:    v_cmp_u_f64_e64 s1, s[2:3], s[2:3]
+; GFX12-ISEL-NEXT:    v_cmp_ngt_f64_e64 s5, s[0:1], s[6:7]
+; GFX12-ISEL-NEXT:    v_cmp_ngt_f64_e64 s6, s[2:3], s[6:7]
+; GFX12-ISEL-NEXT:    v_cmp_o_f64_e64 s0, s[0:1], s[0:1]
+; GFX12-ISEL-NEXT:    v_cmp_o_f64_e64 s1, s[2:3], s[2:3]
 ; GFX12-ISEL-NEXT:    v_ldexp_f64 v[4:5], v[0:1], 0xffffffe0
 ; GFX12-ISEL-NEXT:    v_ldexp_f64 v[6:7], v[2:3], 0xffffffe0
 ; GFX12-ISEL-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
@@ -2408,19 +2408,20 @@ define <2 x i64> @test_s_signed_v2f64_v2i64(<2 x double> inreg %f) {
 ; GFX12-ISEL-NEXT:    v_cvt_i32_f64_e32 v5, v[6:7]
 ; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
 ; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v1, v[2:3]
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e32 v2, 0x80000000, v4, vcc_lo
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, v4, 0x80000000, s6
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, v5, 0x80000000, s7
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, v2, 0x7fffffff, s8
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, v3, 0x7fffffff, s4
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, v3, 0, s1
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s6
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s7
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s8
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v4, v1, -1, s4
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v2, 0, s0
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s0
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s1
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, 0x80000000, v5, s4
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, 0x7fffffff, v2, s5
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, 0x7fffffff, v3, s6
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, 0, v3, s1
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc_lo
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, 0, v1, s4
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s5
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v4, -1, v1, s6
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, 0, v2, s0
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s0
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s1
 ; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GI-LABEL: test_s_signed_v2f64_v2i64:

--- a/llvm/test/CodeGen/AMDGPU/fptoui-sat-scalar.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptoui-sat-scalar.ll
@@ -176,14 +176,14 @@ define i64 @test_unsigned_i64_f32(float %f) nounwind {
 ; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v3, v2
 ; GFX7-ISEL-NEXT:    s_mov_b32 s4, 0xcf800000
 ; GFX7-ISEL-NEXT:    v_fma_f32 v1, v2, s4, v1
-; GFX7-ISEL-NEXT:    v_cmp_nle_f32_e32 vcc, 0, v0
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v3, 0, vcc
+; GFX7-ISEL-NEXT:    v_cmp_le_f32_e32 vcc, 0, v0
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v2, 0, v3, vcc
 ; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v3, v1
 ; GFX7-ISEL-NEXT:    s_mov_b32 s4, 0x5f7fffff
-; GFX7-ISEL-NEXT:    v_cmp_lt_f32_e64 s[4:5], s4, v0
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, v2, -1, s[4:5]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v3, 0, vcc
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s[4:5]
+; GFX7-ISEL-NEXT:    v_cmp_nlt_f32_e64 s[4:5], s4, v0
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, -1, v2, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v0, 0, v3, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s[4:5]
 ; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX7-GI-LABEL: test_unsigned_i64_f32:
@@ -214,31 +214,30 @@ define i64 @test_unsigned_i64_f32(float %f) nounwind {
 ; GFX9-NEXT:    v_cvt_u32_f32_e32 v3, v2
 ; GFX9-NEXT:    s_mov_b32 s4, 0xcf800000
 ; GFX9-NEXT:    v_fma_f32 v1, v2, s4, v1
-; GFX9-NEXT:    v_cmp_nle_f32_e32 vcc, 0, v0
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v3, 0, vcc
+; GFX9-NEXT:    v_cmp_le_f32_e32 vcc, 0, v0
+; GFX9-NEXT:    v_cndmask_b32_e32 v2, 0, v3, vcc
 ; GFX9-NEXT:    v_cvt_u32_f32_e32 v3, v1
 ; GFX9-NEXT:    s_mov_b32 s4, 0x5f7fffff
-; GFX9-NEXT:    v_cmp_lt_f32_e64 s[4:5], s4, v0
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v2, -1, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v3, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s[4:5]
+; GFX9-NEXT:    v_cmp_nlt_f32_e64 s[4:5], s4, v0
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, -1, v2, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v3, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s[4:5]
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: test_unsigned_i64_f32:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_trunc_f32_e32 v1, v0
-; GFX11-NEXT:    v_cmp_nle_f32_e32 vcc_lo, 0, v0
+; GFX11-NEXT:    v_cmp_le_f32_e32 vcc_lo, 0, v0
 ; GFX11-NEXT:    v_mul_f32_e32 v2, 0x2f800000, v1
 ; GFX11-NEXT:    v_floor_f32_e32 v2, v2
 ; GFX11-NEXT:    v_fmamk_f32 v1, v2, 0xcf800000, v1
 ; GFX11-NEXT:    v_cvt_u32_f32_e32 v2, v2
+; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc_lo
 ; GFX11-NEXT:    v_cvt_u32_f32_e32 v1, v1
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v1, 0, vcc_lo
-; GFX11-NEXT:    v_cmp_lt_f32_e32 vcc_lo, 0x5f7fffff, v0
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v2, -1, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v3, -1, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e32 v3, 0, v1, vcc_lo
+; GFX11-NEXT:    v_cmp_nlt_f32_e32 vcc_lo, 0x5f7fffff, v0
+; GFX11-NEXT:    v_dual_cndmask_b32 v1, -1, v2 :: v_dual_cndmask_b32 v0, -1, v3
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-ISEL-LABEL: test_unsigned_i64_f32:
@@ -249,19 +248,18 @@ define i64 @test_unsigned_i64_f32(float %f) nounwind {
 ; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-ISEL-NEXT:    v_trunc_f32_e32 v1, v0
-; GFX12-ISEL-NEXT:    v_cmp_nle_f32_e32 vcc_lo, 0, v0
+; GFX12-ISEL-NEXT:    v_cmp_le_f32_e32 vcc_lo, 0, v0
 ; GFX12-ISEL-NEXT:    v_mul_f32_e32 v2, 0x2f800000, v1
 ; GFX12-ISEL-NEXT:    v_floor_f32_e32 v2, v2
 ; GFX12-ISEL-NEXT:    v_fmamk_f32 v1, v2, 0xcf800000, v1
 ; GFX12-ISEL-NEXT:    v_cvt_u32_f32_e32 v2, v2
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc_lo
 ; GFX12-ISEL-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e32 v3, 0, v1, vcc_lo
+; GFX12-ISEL-NEXT:    v_cmp_nlt_f32_e32 vcc_lo, 0x5f7fffff, v0
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc_lo
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, v1, 0, vcc_lo
-; GFX12-ISEL-NEXT:    v_cmp_lt_f32_e32 vcc_lo, 0x5f7fffff, v0
-; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v2, -1, vcc_lo
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v3, -1, vcc_lo
+; GFX12-ISEL-NEXT:    v_dual_cndmask_b32 v1, -1, v2 :: v_dual_cndmask_b32 v0, -1, v3
 ; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GI-LABEL: test_unsigned_i64_f32:
@@ -469,13 +467,13 @@ define i64 @test_s_unsigned_i64_f32(float inreg %f) nounwind {
 ; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v2, v1
 ; GFX7-ISEL-NEXT:    v_fma_f32 v0, v1, s4, v0
 ; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX7-ISEL-NEXT:    v_cmp_nge_f32_e64 s[4:5], s16, 0
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, v2, 0, s[4:5]
+; GFX7-ISEL-NEXT:    v_cmp_ge_f32_e64 vcc, s16, 0
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v1, 0, v2, vcc
 ; GFX7-ISEL-NEXT:    v_mov_b32_e32 v2, 0x5f7fffff
-; GFX7-ISEL-NEXT:    v_cmp_gt_f32_e32 vcc, s16, v2
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[4:5]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, v1, -1, vcc
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, vcc
+; GFX7-ISEL-NEXT:    v_cmp_ngt_f32_e64 s[4:5], s16, v2
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, -1, v1, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s[4:5]
 ; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX7-GI-LABEL: test_s_unsigned_i64_f32:
@@ -511,30 +509,29 @@ define i64 @test_s_unsigned_i64_f32(float inreg %f) nounwind {
 ; GFX9-NEXT:    v_cvt_u32_f32_e32 v2, v1
 ; GFX9-NEXT:    v_fma_f32 v0, v1, s4, v0
 ; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX9-NEXT:    v_cmp_nge_f32_e64 s[4:5], s16, 0
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v2, 0, s[4:5]
+; GFX9-NEXT:    v_cmp_ge_f32_e64 vcc, s16, 0
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, 0, v2, vcc
 ; GFX9-NEXT:    v_mov_b32_e32 v2, 0x5f7fffff
-; GFX9-NEXT:    v_cmp_gt_f32_e32 vcc, s16, v2
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, -1, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, -1, vcc
+; GFX9-NEXT:    v_cmp_ngt_f32_e64 s[4:5], s16, v2
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, -1, v1, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s[4:5]
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: test_s_unsigned_i64_f32:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_trunc_f32_e32 v0, s0
-; GFX11-NEXT:    v_cmp_nge_f32_e64 s1, s0, 0
-; GFX11-NEXT:    v_cmp_lt_f32_e64 s0, 0x5f7fffff, s0
+; GFX11-NEXT:    v_cmp_ge_f32_e64 vcc_lo, s0, 0
 ; GFX11-NEXT:    v_mul_f32_e32 v1, 0x2f800000, v0
 ; GFX11-NEXT:    v_floor_f32_e32 v1, v1
 ; GFX11-NEXT:    v_fmamk_f32 v0, v1, 0xcf800000, v0
 ; GFX11-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX11-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc_lo
 ; GFX11-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, -1, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s0
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc_lo
+; GFX11-NEXT:    v_cmp_nlt_f32_e64 vcc_lo, 0x5f7fffff, s0
+; GFX11-NEXT:    v_dual_cndmask_b32 v1, -1, v1 :: v_dual_cndmask_b32 v0, -1, v0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-ISEL-LABEL: test_s_unsigned_i64_f32:
@@ -545,7 +542,7 @@ define i64 @test_s_unsigned_i64_f32(float inreg %f) nounwind {
 ; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-ISEL-NEXT:    s_trunc_f32 s1, s0
-; GFX12-ISEL-NEXT:    s_cmp_nge_f32 s0, 0
+; GFX12-ISEL-NEXT:    s_cmp_ge_f32 s0, 0
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-ISEL-NEXT:    s_mul_f32 s2, s1, 0x2f800000
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -555,13 +552,13 @@ define i64 @test_s_unsigned_i64_f32(float inreg %f) nounwind {
 ; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s2, s2
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s1, s1
-; GFX12-ISEL-NEXT:    s_cselect_b32 s2, 0, s2
+; GFX12-ISEL-NEXT:    s_cselect_b32 s2, s2, 0
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-ISEL-NEXT:    s_cselect_b32 s1, 0, s1
-; GFX12-ISEL-NEXT:    s_cmp_gt_f32 s0, 0x5f7fffff
+; GFX12-ISEL-NEXT:    s_cselect_b32 s1, s1, 0
+; GFX12-ISEL-NEXT:    s_cmp_ngt_f32 s0, 0x5f7fffff
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-ISEL-NEXT:    s_cselect_b32 s0, -1, s1
-; GFX12-ISEL-NEXT:    s_cselect_b32 s1, -1, s2
+; GFX12-ISEL-NEXT:    s_cselect_b32 s0, s1, -1
+; GFX12-ISEL-NEXT:    s_cselect_b32 s1, s2, -1
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -753,20 +750,20 @@ define i64 @test_unsigned_i64_f64(double %f) nounwind {
 ; GFX7-ISEL-NEXT:    v_trunc_f64_e32 v[2:3], v[0:1]
 ; GFX7-ISEL-NEXT:    s_movk_i32 s4, 0xffe0
 ; GFX7-ISEL-NEXT:    s_mov_b32 s5, 0xc1f00000
-; GFX7-ISEL-NEXT:    v_cmp_nle_f64_e32 vcc, 0, v[0:1]
+; GFX7-ISEL-NEXT:    v_cmp_le_f64_e32 vcc, 0, v[0:1]
 ; GFX7-ISEL-NEXT:    v_ldexp_f64 v[4:5], v[2:3], s4
 ; GFX7-ISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX7-ISEL-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
 ; GFX7-ISEL-NEXT:    v_fma_f64 v[2:3], v[4:5], s[4:5], v[2:3]
 ; GFX7-ISEL-NEXT:    s_mov_b32 s4, -1
 ; GFX7-ISEL-NEXT:    s_mov_b32 s5, 0x43efffff
-; GFX7-ISEL-NEXT:    v_cmp_lt_f64_e64 s[4:5], s[4:5], v[0:1]
+; GFX7-ISEL-NEXT:    v_cmp_nlt_f64_e64 s[4:5], s[4:5], v[0:1]
 ; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v6, v[4:5]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v4, v6, 0, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v4, 0, v6, vcc
 ; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v0, v[2:3]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, v4, -1, s[4:5]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, -1, v4, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s[4:5]
 ; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX7-GI-LABEL: test_unsigned_i64_f64:
@@ -798,39 +795,38 @@ define i64 @test_unsigned_i64_f64(double %f) nounwind {
 ; GFX9-NEXT:    v_trunc_f64_e32 v[2:3], v[0:1]
 ; GFX9-NEXT:    s_movk_i32 s4, 0xffe0
 ; GFX9-NEXT:    s_mov_b32 s5, 0xc1f00000
-; GFX9-NEXT:    v_cmp_nle_f64_e32 vcc, 0, v[0:1]
+; GFX9-NEXT:    v_cmp_le_f64_e32 vcc, 0, v[0:1]
 ; GFX9-NEXT:    v_ldexp_f64 v[4:5], v[2:3], s4
 ; GFX9-NEXT:    s_mov_b32 s4, 0
 ; GFX9-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
 ; GFX9-NEXT:    v_fma_f64 v[2:3], v[4:5], s[4:5], v[2:3]
 ; GFX9-NEXT:    s_mov_b32 s4, -1
 ; GFX9-NEXT:    s_mov_b32 s5, 0x43efffff
-; GFX9-NEXT:    v_cmp_lt_f64_e64 s[4:5], s[4:5], v[0:1]
+; GFX9-NEXT:    v_cmp_nlt_f64_e64 s[4:5], s[4:5], v[0:1]
 ; GFX9-NEXT:    v_cvt_u32_f64_e32 v6, v[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v4, 0, v6, vcc
 ; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, v[2:3]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v4, -1, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, -1, v4, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s[4:5]
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: test_unsigned_i64_f64:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_trunc_f64_e32 v[2:3], v[0:1]
-; GFX11-NEXT:    v_cmp_nle_f64_e32 vcc_lo, 0, v[0:1]
+; GFX11-NEXT:    v_cmp_le_f64_e32 vcc_lo, 0, v[0:1]
 ; GFX11-NEXT:    s_mov_b32 s0, -1
 ; GFX11-NEXT:    s_mov_b32 s1, 0x43efffff
-; GFX11-NEXT:    v_cmp_lt_f64_e64 s0, s[0:1], v[0:1]
+; GFX11-NEXT:    v_cmp_nlt_f64_e64 s0, s[0:1], v[0:1]
 ; GFX11-NEXT:    v_ldexp_f64 v[4:5], v[2:3], 0xffffffe0
 ; GFX11-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
 ; GFX11-NEXT:    v_fma_f64 v[2:3], 0xc1f00000, v[4:5], v[2:3]
 ; GFX11-NEXT:    v_cvt_u32_f64_e32 v4, v[4:5]
 ; GFX11-NEXT:    v_cvt_u32_f64_e32 v2, v[2:3]
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v4, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v3, -1, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s0
+; GFX11-NEXT:    v_dual_cndmask_b32 v3, 0, v4 :: v_dual_cndmask_b32 v0, 0, v2
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, -1, v3, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-ISEL-LABEL: test_unsigned_i64_f64:
@@ -841,22 +837,21 @@ define i64 @test_unsigned_i64_f64(double %f) nounwind {
 ; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-ISEL-NEXT:    v_trunc_f64_e32 v[2:3], v[0:1]
-; GFX12-ISEL-NEXT:    v_cmp_nle_f64_e32 vcc_lo, 0, v[0:1]
+; GFX12-ISEL-NEXT:    v_cmp_le_f64_e32 vcc_lo, 0, v[0:1]
 ; GFX12-ISEL-NEXT:    s_mov_b32 s0, -1
 ; GFX12-ISEL-NEXT:    s_mov_b32 s1, 0x43efffff
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-ISEL-NEXT:    v_cmp_lt_f64_e64 s0, s[0:1], v[0:1]
+; GFX12-ISEL-NEXT:    v_cmp_nlt_f64_e64 s0, s[0:1], v[0:1]
 ; GFX12-ISEL-NEXT:    v_ldexp_f64 v[4:5], v[2:3], 0xffffffe0
 ; GFX12-ISEL-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
 ; GFX12-ISEL-NEXT:    v_fma_f64 v[2:3], 0xc1f00000, v[4:5], v[2:3]
 ; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v4, v[4:5]
 ; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v2, v[2:3]
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, v4, 0, vcc_lo
+; GFX12-ISEL-NEXT:    v_dual_cndmask_b32 v3, 0, v4 :: v_dual_cndmask_b32 v0, 0, v2
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v3, -1, s0
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc_lo
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s0
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, -1, v3, s0
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s0
 ; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GI-LABEL: test_unsigned_i64_f64:
@@ -1102,6 +1097,7 @@ define i64 @test_s_unsigned_i64_f64(double inreg %f) nounwind {
 ; GFX7-ISEL-NEXT:    v_trunc_f64_e32 v[0:1], s[16:17]
 ; GFX7-ISEL-NEXT:    s_movk_i32 s4, 0xffe0
 ; GFX7-ISEL-NEXT:    s_mov_b32 s5, 0xc1f00000
+; GFX7-ISEL-NEXT:    v_cmp_ge_f64_e64 vcc, s[16:17], 0
 ; GFX7-ISEL-NEXT:    v_ldexp_f64 v[2:3], v[0:1], s4
 ; GFX7-ISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX7-ISEL-NEXT:    v_floor_f64_e32 v[2:3], v[2:3]
@@ -1109,13 +1105,12 @@ define i64 @test_s_unsigned_i64_f64(double inreg %f) nounwind {
 ; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v4, v[2:3]
 ; GFX7-ISEL-NEXT:    v_mov_b32_e32 v2, -1
 ; GFX7-ISEL-NEXT:    v_mov_b32_e32 v3, 0x43efffff
-; GFX7-ISEL-NEXT:    v_cmp_nge_f64_e64 s[4:5], s[16:17], 0
-; GFX7-ISEL-NEXT:    v_cmp_gt_f64_e32 vcc, s[16:17], v[2:3]
+; GFX7-ISEL-NEXT:    v_cmp_ngt_f64_e64 s[4:5], s[16:17], v[2:3]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
 ; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[4:5]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[4:5]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, v4, -1, vcc
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, -1, v4, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s[4:5]
 ; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX7-GI-LABEL: test_s_unsigned_i64_f64:
@@ -1151,6 +1146,7 @@ define i64 @test_s_unsigned_i64_f64(double inreg %f) nounwind {
 ; GFX9-NEXT:    v_trunc_f64_e32 v[0:1], s[16:17]
 ; GFX9-NEXT:    s_movk_i32 s4, 0xffe0
 ; GFX9-NEXT:    s_mov_b32 s5, 0xc1f00000
+; GFX9-NEXT:    v_cmp_ge_f64_e64 vcc, s[16:17], 0
 ; GFX9-NEXT:    v_ldexp_f64 v[2:3], v[0:1], s4
 ; GFX9-NEXT:    s_mov_b32 s4, 0
 ; GFX9-NEXT:    v_floor_f64_e32 v[2:3], v[2:3]
@@ -1158,32 +1154,30 @@ define i64 @test_s_unsigned_i64_f64(double inreg %f) nounwind {
 ; GFX9-NEXT:    v_cvt_u32_f64_e32 v4, v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v2, -1
 ; GFX9-NEXT:    v_mov_b32_e32 v3, 0x43efffff
-; GFX9-NEXT:    v_cmp_nge_f64_e64 s[4:5], s[16:17], 0
-; GFX9-NEXT:    v_cmp_gt_f64_e32 vcc, s[16:17], v[2:3]
+; GFX9-NEXT:    v_cmp_ngt_f64_e64 s[4:5], s[16:17], v[2:3]
+; GFX9-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
 ; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v4, -1, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, -1, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, -1, v4, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s[4:5]
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: test_s_unsigned_i64_f64:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_trunc_f64_e32 v[0:1], s[0:1]
-; GFX11-NEXT:    v_cmp_nge_f64_e64 s4, s[0:1], 0
+; GFX11-NEXT:    v_cmp_ge_f64_e64 vcc_lo, s[0:1], 0
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    s_mov_b32 s3, 0x43efffff
-; GFX11-NEXT:    v_cmp_gt_f64_e64 s0, s[0:1], s[2:3]
+; GFX11-NEXT:    v_cmp_ngt_f64_e64 s0, s[0:1], s[2:3]
 ; GFX11-NEXT:    v_ldexp_f64 v[2:3], v[0:1], 0xffffffe0
 ; GFX11-NEXT:    v_floor_f64_e32 v[2:3], v[2:3]
 ; GFX11-NEXT:    v_fma_f64 v[0:1], 0xc1f00000, v[2:3], v[0:1]
 ; GFX11-NEXT:    v_cvt_u32_f64_e32 v2, v[2:3]
 ; GFX11-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v2, 0, s4
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, -1, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s4
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s0
+; GFX11-NEXT:    v_dual_cndmask_b32 v1, 0, v2 :: v_dual_cndmask_b32 v0, 0, v0
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, -1, v1, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-ISEL-LABEL: test_s_unsigned_i64_f64:
@@ -1194,21 +1188,21 @@ define i64 @test_s_unsigned_i64_f64(double inreg %f) nounwind {
 ; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-ISEL-NEXT:    v_trunc_f64_e32 v[0:1], s[0:1]
-; GFX12-ISEL-NEXT:    v_cmp_nge_f64_e64 s4, s[0:1], 0
+; GFX12-ISEL-NEXT:    v_cmp_ge_f64_e64 vcc_lo, s[0:1], 0
 ; GFX12-ISEL-NEXT:    s_mov_b32 s2, -1
 ; GFX12-ISEL-NEXT:    s_mov_b32 s3, 0x43efffff
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-ISEL-NEXT:    v_cmp_gt_f64_e64 s0, s[0:1], s[2:3]
+; GFX12-ISEL-NEXT:    v_cmp_ngt_f64_e64 s0, s[0:1], s[2:3]
 ; GFX12-ISEL-NEXT:    v_ldexp_f64 v[2:3], v[0:1], 0xffffffe0
 ; GFX12-ISEL-NEXT:    v_floor_f64_e32 v[2:3], v[2:3]
 ; GFX12-ISEL-NEXT:    v_fma_f64 v[0:1], 0xc1f00000, v[2:3], v[0:1]
 ; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v2, v[2:3]
 ; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX12-ISEL-NEXT:    v_dual_cndmask_b32 v1, 0, v2 :: v_dual_cndmask_b32 v0, 0, v0
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v2, 0, s4
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v1, -1, s0
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s4
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s0
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, -1, v1, s0
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s0
 ; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GI-LABEL: test_s_unsigned_i64_f64:

--- a/llvm/test/CodeGen/AMDGPU/fptoui-sat-vector.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptoui-sat-vector.ll
@@ -1587,8 +1587,8 @@ define <2 x i64> @test_unsigned_v2f64_v2i64(<2 x double> %f) {
 ; GFX7-ISEL-NEXT:    s_mov_b32 s5, 0xc1f00000
 ; GFX7-ISEL-NEXT:    s_mov_b32 s8, -1
 ; GFX7-ISEL-NEXT:    s_mov_b32 s9, 0x43efffff
-; GFX7-ISEL-NEXT:    v_cmp_nle_f64_e64 s[6:7], 0, v[2:3]
-; GFX7-ISEL-NEXT:    v_cmp_nle_f64_e32 vcc, 0, v[0:1]
+; GFX7-ISEL-NEXT:    v_cmp_le_f64_e64 s[6:7], 0, v[2:3]
+; GFX7-ISEL-NEXT:    v_cmp_le_f64_e32 vcc, 0, v[0:1]
 ; GFX7-ISEL-NEXT:    v_ldexp_f64 v[8:9], v[4:5], s4
 ; GFX7-ISEL-NEXT:    v_ldexp_f64 v[10:11], v[6:7], s4
 ; GFX7-ISEL-NEXT:    s_mov_b32 s4, 0
@@ -1596,20 +1596,20 @@ define <2 x i64> @test_unsigned_v2f64_v2i64(<2 x double> %f) {
 ; GFX7-ISEL-NEXT:    v_floor_f64_e32 v[10:11], v[10:11]
 ; GFX7-ISEL-NEXT:    v_fma_f64 v[4:5], v[8:9], s[4:5], v[4:5]
 ; GFX7-ISEL-NEXT:    v_fma_f64 v[6:7], v[10:11], s[4:5], v[6:7]
-; GFX7-ISEL-NEXT:    v_cmp_lt_f64_e64 s[4:5], s[8:9], v[0:1]
-; GFX7-ISEL-NEXT:    v_cmp_lt_f64_e64 s[8:9], s[8:9], v[2:3]
+; GFX7-ISEL-NEXT:    v_cmp_nlt_f64_e64 s[4:5], s[8:9], v[0:1]
+; GFX7-ISEL-NEXT:    v_cmp_nlt_f64_e64 s[8:9], s[8:9], v[2:3]
 ; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v13, v[10:11]
 ; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v12, v[8:9]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v13, 0, s[6:7]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, 0, v13, s[6:7]
 ; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v2, v[4:5]
 ; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v4, v[6:7]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v8, v12, 0, vcc
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v3, v0, -1, s[8:9]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s[6:7]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, v8, -1, s[4:5]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s[4:5]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v2, -1, s[8:9]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v8, 0, v12, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v3, -1, v0, s[8:9]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s[6:7]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, -1, v8, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, -1, v2, s[8:9]
 ; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX7-GI-LABEL: test_unsigned_v2f64_v2i64:
@@ -1656,8 +1656,8 @@ define <2 x i64> @test_unsigned_v2f64_v2i64(<2 x double> %f) {
 ; GFX9-NEXT:    s_mov_b32 s5, 0xc1f00000
 ; GFX9-NEXT:    s_mov_b32 s8, -1
 ; GFX9-NEXT:    s_mov_b32 s9, 0x43efffff
-; GFX9-NEXT:    v_cmp_nle_f64_e64 s[6:7], 0, v[2:3]
-; GFX9-NEXT:    v_cmp_nle_f64_e32 vcc, 0, v[0:1]
+; GFX9-NEXT:    v_cmp_le_f64_e64 s[6:7], 0, v[2:3]
+; GFX9-NEXT:    v_cmp_le_f64_e32 vcc, 0, v[0:1]
 ; GFX9-NEXT:    v_ldexp_f64 v[8:9], v[4:5], s4
 ; GFX9-NEXT:    v_ldexp_f64 v[10:11], v[6:7], s4
 ; GFX9-NEXT:    s_mov_b32 s4, 0
@@ -1665,20 +1665,20 @@ define <2 x i64> @test_unsigned_v2f64_v2i64(<2 x double> %f) {
 ; GFX9-NEXT:    v_floor_f64_e32 v[10:11], v[10:11]
 ; GFX9-NEXT:    v_fma_f64 v[4:5], v[8:9], s[4:5], v[4:5]
 ; GFX9-NEXT:    v_fma_f64 v[6:7], v[10:11], s[4:5], v[6:7]
-; GFX9-NEXT:    v_cmp_lt_f64_e64 s[4:5], s[8:9], v[0:1]
-; GFX9-NEXT:    v_cmp_lt_f64_e64 s[8:9], s[8:9], v[2:3]
+; GFX9-NEXT:    v_cmp_nlt_f64_e64 s[4:5], s[8:9], v[0:1]
+; GFX9-NEXT:    v_cmp_nlt_f64_e64 s[8:9], s[8:9], v[2:3]
 ; GFX9-NEXT:    v_cvt_u32_f64_e32 v13, v[10:11]
 ; GFX9-NEXT:    v_cvt_u32_f64_e32 v12, v[8:9]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v13, 0, s[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, 0, v13, s[6:7]
 ; GFX9-NEXT:    v_cvt_u32_f64_e32 v2, v[4:5]
 ; GFX9-NEXT:    v_cvt_u32_f64_e32 v4, v[6:7]
-; GFX9-NEXT:    v_cndmask_b32_e64 v8, v12, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v3, v0, -1, s[8:9]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s[6:7]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v8, -1, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v2, -1, s[8:9]
+; GFX9-NEXT:    v_cndmask_b32_e32 v8, 0, v12, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v3, -1, v0, s[8:9]
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, -1, v8, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, -1, v2, s[8:9]
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: test_unsigned_v2f64_v2i64:
@@ -1686,12 +1686,12 @@ define <2 x i64> @test_unsigned_v2f64_v2i64(<2 x double> %f) {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_trunc_f64_e32 v[4:5], v[0:1]
 ; GFX11-NEXT:    v_trunc_f64_e32 v[6:7], v[2:3]
-; GFX11-NEXT:    v_cmp_nle_f64_e32 vcc_lo, 0, v[0:1]
-; GFX11-NEXT:    v_cmp_nle_f64_e64 s0, 0, v[2:3]
+; GFX11-NEXT:    v_cmp_le_f64_e32 vcc_lo, 0, v[0:1]
+; GFX11-NEXT:    v_cmp_le_f64_e64 s0, 0, v[2:3]
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    s_mov_b32 s3, 0x43efffff
-; GFX11-NEXT:    v_cmp_lt_f64_e64 s1, s[2:3], v[0:1]
-; GFX11-NEXT:    v_cmp_lt_f64_e64 s2, s[2:3], v[2:3]
+; GFX11-NEXT:    v_cmp_nlt_f64_e64 s1, s[2:3], v[0:1]
+; GFX11-NEXT:    v_cmp_nlt_f64_e64 s2, s[2:3], v[2:3]
 ; GFX11-NEXT:    v_ldexp_f64 v[8:9], v[4:5], 0xffffffe0
 ; GFX11-NEXT:    v_ldexp_f64 v[10:11], v[6:7], 0xffffffe0
 ; GFX11-NEXT:    v_floor_f64_e32 v[8:9], v[8:9]
@@ -1702,14 +1702,14 @@ define <2 x i64> @test_unsigned_v2f64_v2i64(<2 x double> %f) {
 ; GFX11-NEXT:    v_cvt_u32_f64_e32 v9, v[10:11]
 ; GFX11-NEXT:    v_cvt_u32_f64_e32 v4, v[4:5]
 ; GFX11-NEXT:    v_cvt_u32_f64_e32 v5, v[6:7]
-; GFX11-NEXT:    v_cndmask_b32_e64 v6, v8, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v9, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v6, -1, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v0, -1, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v4, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v5, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v2, -1, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v4, -1, s2
+; GFX11-NEXT:    v_cndmask_b32_e32 v6, 0, v8, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, 0, v9, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, -1, v6, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, -1, v0, s2
+; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0, v4, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e64 v4, 0, v5, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, -1, v2, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, -1, v4, s2
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-ISEL-LABEL: test_unsigned_v2f64_v2i64:
@@ -1721,13 +1721,13 @@ define <2 x i64> @test_unsigned_v2f64_v2i64(<2 x double> %f) {
 ; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-ISEL-NEXT:    v_trunc_f64_e32 v[4:5], v[0:1]
 ; GFX12-ISEL-NEXT:    v_trunc_f64_e32 v[6:7], v[2:3]
-; GFX12-ISEL-NEXT:    v_cmp_nle_f64_e32 vcc_lo, 0, v[0:1]
-; GFX12-ISEL-NEXT:    v_cmp_nle_f64_e64 s0, 0, v[2:3]
+; GFX12-ISEL-NEXT:    v_cmp_le_f64_e32 vcc_lo, 0, v[0:1]
+; GFX12-ISEL-NEXT:    v_cmp_le_f64_e64 s0, 0, v[2:3]
 ; GFX12-ISEL-NEXT:    s_mov_b32 s2, -1
 ; GFX12-ISEL-NEXT:    s_mov_b32 s3, 0x43efffff
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-ISEL-NEXT:    v_cmp_lt_f64_e64 s1, s[2:3], v[0:1]
-; GFX12-ISEL-NEXT:    v_cmp_lt_f64_e64 s2, s[2:3], v[2:3]
+; GFX12-ISEL-NEXT:    v_cmp_nlt_f64_e64 s1, s[2:3], v[0:1]
+; GFX12-ISEL-NEXT:    v_cmp_nlt_f64_e64 s2, s[2:3], v[2:3]
 ; GFX12-ISEL-NEXT:    v_ldexp_f64 v[8:9], v[4:5], 0xffffffe0
 ; GFX12-ISEL-NEXT:    v_ldexp_f64 v[10:11], v[6:7], 0xffffffe0
 ; GFX12-ISEL-NEXT:    v_floor_f64_e32 v[8:9], v[8:9]
@@ -1739,15 +1739,15 @@ define <2 x i64> @test_unsigned_v2f64_v2i64(<2 x double> %f) {
 ; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v4, v[4:5]
 ; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v5, v[6:7]
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v6, v8, 0, vcc_lo
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e32 v6, 0, v8, vcc_lo
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v9, 0, s0
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v6, -1, s1
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, v0, -1, s2
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, v4, 0, vcc_lo
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v4, v5, 0, s0
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v2, -1, s1
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, v4, -1, s2
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, 0, v9, s0
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, -1, v6, s1
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, -1, v0, s2
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e32 v2, 0, v4, vcc_lo
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v4, 0, v5, s0
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, -1, v2, s1
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, -1, v4, s2
 ; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GI-LABEL: test_unsigned_v2f64_v2i64:
@@ -2064,31 +2064,31 @@ define <2 x i64> @test_s_unsigned_v2f64_v2i64(<2 x double> inreg %f) {
 ; GFX7-ISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX7-ISEL-NEXT:    s_mov_b32 s7, 0xc1f00000
 ; GFX7-ISEL-NEXT:    s_mov_b32 s5, 0x43efffff
-; GFX7-ISEL-NEXT:    v_cmp_nge_f64_e64 s[8:9], s[18:19], 0
+; GFX7-ISEL-NEXT:    v_cmp_ge_f64_e64 vcc, s[16:17], 0
 ; GFX7-ISEL-NEXT:    v_ldexp_f64 v[4:5], v[0:1], s4
 ; GFX7-ISEL-NEXT:    v_ldexp_f64 v[6:7], v[2:3], s4
 ; GFX7-ISEL-NEXT:    s_mov_b32 s4, -1
 ; GFX7-ISEL-NEXT:    v_mov_b32_e32 v9, s5
 ; GFX7-ISEL-NEXT:    v_mov_b32_e32 v8, s4
-; GFX7-ISEL-NEXT:    v_cmp_gt_f64_e32 vcc, s[16:17], v[8:9]
-; GFX7-ISEL-NEXT:    v_cmp_gt_f64_e64 s[4:5], s[18:19], v[8:9]
+; GFX7-ISEL-NEXT:    v_cmp_ngt_f64_e64 s[4:5], s[16:17], v[8:9]
+; GFX7-ISEL-NEXT:    v_cmp_ngt_f64_e64 s[8:9], s[18:19], v[8:9]
 ; GFX7-ISEL-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
 ; GFX7-ISEL-NEXT:    v_floor_f64_e32 v[6:7], v[6:7]
 ; GFX7-ISEL-NEXT:    v_fma_f64 v[0:1], v[4:5], s[6:7], v[0:1]
 ; GFX7-ISEL-NEXT:    v_fma_f64 v[2:3], v[6:7], s[6:7], v[2:3]
-; GFX7-ISEL-NEXT:    v_cmp_nge_f64_e64 s[6:7], s[16:17], 0
+; GFX7-ISEL-NEXT:    v_cmp_ge_f64_e64 s[6:7], s[18:19], 0
 ; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v10, v[4:5]
 ; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v11, v[6:7]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v5, v11, 0, s[8:9]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v4, 0, v10, vcc
 ; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
 ; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v2, v[2:3]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[6:7]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, v4, -1, vcc
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[6:7]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[8:9]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v3, v5, -1, s[4:5]
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, vcc
-; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v2, -1, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v5, 0, v11, s[6:7]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, -1, v4, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[6:7]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v3, -1, v5, s[8:9]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, -1, v2, s[8:9]
 ; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX7-GI-LABEL: test_s_unsigned_v2f64_v2i64:
@@ -2143,31 +2143,31 @@ define <2 x i64> @test_s_unsigned_v2f64_v2i64(<2 x double> inreg %f) {
 ; GFX9-NEXT:    s_mov_b32 s6, 0
 ; GFX9-NEXT:    s_mov_b32 s7, 0xc1f00000
 ; GFX9-NEXT:    s_mov_b32 s5, 0x43efffff
-; GFX9-NEXT:    v_cmp_nge_f64_e64 s[8:9], s[18:19], 0
+; GFX9-NEXT:    v_cmp_ge_f64_e64 vcc, s[16:17], 0
 ; GFX9-NEXT:    v_ldexp_f64 v[4:5], v[0:1], s4
 ; GFX9-NEXT:    v_ldexp_f64 v[6:7], v[2:3], s4
 ; GFX9-NEXT:    s_mov_b32 s4, -1
 ; GFX9-NEXT:    v_mov_b32_e32 v9, s5
 ; GFX9-NEXT:    v_mov_b32_e32 v8, s4
-; GFX9-NEXT:    v_cmp_gt_f64_e32 vcc, s[16:17], v[8:9]
-; GFX9-NEXT:    v_cmp_gt_f64_e64 s[4:5], s[18:19], v[8:9]
+; GFX9-NEXT:    v_cmp_ngt_f64_e64 s[4:5], s[16:17], v[8:9]
+; GFX9-NEXT:    v_cmp_ngt_f64_e64 s[8:9], s[18:19], v[8:9]
 ; GFX9-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
 ; GFX9-NEXT:    v_floor_f64_e32 v[6:7], v[6:7]
 ; GFX9-NEXT:    v_fma_f64 v[0:1], v[4:5], s[6:7], v[0:1]
 ; GFX9-NEXT:    v_fma_f64 v[2:3], v[6:7], s[6:7], v[2:3]
-; GFX9-NEXT:    v_cmp_nge_f64_e64 s[6:7], s[16:17], 0
+; GFX9-NEXT:    v_cmp_ge_f64_e64 s[6:7], s[18:19], 0
 ; GFX9-NEXT:    v_cvt_u32_f64_e32 v10, v[4:5]
 ; GFX9-NEXT:    v_cvt_u32_f64_e32 v11, v[6:7]
-; GFX9-NEXT:    v_cndmask_b32_e64 v5, v11, 0, s[8:9]
+; GFX9-NEXT:    v_cndmask_b32_e32 v4, 0, v10, vcc
 ; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
 ; GFX9-NEXT:    v_cvt_u32_f64_e32 v2, v[2:3]
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[6:7]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v4, -1, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[6:7]
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[8:9]
-; GFX9-NEXT:    v_cndmask_b32_e64 v3, v5, -1, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, -1, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v2, -1, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v5, 0, v11, s[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, -1, v4, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e64 v3, -1, v5, s[8:9]
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, -1, v2, s[8:9]
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: test_s_unsigned_v2f64_v2i64:
@@ -2175,12 +2175,12 @@ define <2 x i64> @test_s_unsigned_v2f64_v2i64(<2 x double> inreg %f) {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_trunc_f64_e32 v[0:1], s[0:1]
 ; GFX11-NEXT:    v_trunc_f64_e32 v[2:3], s[2:3]
-; GFX11-NEXT:    v_cmp_nge_f64_e64 s6, s[0:1], 0
-; GFX11-NEXT:    v_cmp_nge_f64_e64 s7, s[2:3], 0
-; GFX11-NEXT:    s_mov_b32 s4, -1
-; GFX11-NEXT:    s_mov_b32 s5, 0x43efffff
-; GFX11-NEXT:    v_cmp_gt_f64_e64 s0, s[0:1], s[4:5]
-; GFX11-NEXT:    v_cmp_gt_f64_e64 s1, s[2:3], s[4:5]
+; GFX11-NEXT:    v_cmp_ge_f64_e64 vcc_lo, s[0:1], 0
+; GFX11-NEXT:    v_cmp_ge_f64_e64 s4, s[2:3], 0
+; GFX11-NEXT:    s_mov_b32 s6, -1
+; GFX11-NEXT:    s_mov_b32 s7, 0x43efffff
+; GFX11-NEXT:    v_cmp_ngt_f64_e64 s0, s[0:1], s[6:7]
+; GFX11-NEXT:    v_cmp_ngt_f64_e64 s1, s[2:3], s[6:7]
 ; GFX11-NEXT:    v_ldexp_f64 v[4:5], v[0:1], 0xffffffe0
 ; GFX11-NEXT:    v_ldexp_f64 v[6:7], v[2:3], 0xffffffe0
 ; GFX11-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
@@ -2191,14 +2191,14 @@ define <2 x i64> @test_s_unsigned_v2f64_v2i64(<2 x double> inreg %f) {
 ; GFX11-NEXT:    v_cvt_u32_f64_e32 v5, v[6:7]
 ; GFX11-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
 ; GFX11-NEXT:    v_cvt_u32_f64_e32 v1, v[2:3]
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s6
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v5, 0, s7
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v3, -1, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s6
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v1, 0, s7
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v2, -1, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v4, -1, s1
+; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0, v4, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0, v5, s4
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, -1, v3, s1
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e64 v4, 0, v1, s4
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, -1, v2, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, -1, v4, s1
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-ISEL-LABEL: test_s_unsigned_v2f64_v2i64:
@@ -2210,13 +2210,13 @@ define <2 x i64> @test_s_unsigned_v2f64_v2i64(<2 x double> inreg %f) {
 ; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-ISEL-NEXT:    v_trunc_f64_e32 v[0:1], s[0:1]
 ; GFX12-ISEL-NEXT:    v_trunc_f64_e32 v[2:3], s[2:3]
-; GFX12-ISEL-NEXT:    v_cmp_nge_f64_e64 s6, s[0:1], 0
-; GFX12-ISEL-NEXT:    v_cmp_nge_f64_e64 s7, s[2:3], 0
-; GFX12-ISEL-NEXT:    s_mov_b32 s4, -1
-; GFX12-ISEL-NEXT:    s_mov_b32 s5, 0x43efffff
+; GFX12-ISEL-NEXT:    v_cmp_ge_f64_e64 vcc_lo, s[0:1], 0
+; GFX12-ISEL-NEXT:    v_cmp_ge_f64_e64 s4, s[2:3], 0
+; GFX12-ISEL-NEXT:    s_mov_b32 s6, -1
+; GFX12-ISEL-NEXT:    s_mov_b32 s7, 0x43efffff
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-ISEL-NEXT:    v_cmp_gt_f64_e64 s0, s[0:1], s[4:5]
-; GFX12-ISEL-NEXT:    v_cmp_gt_f64_e64 s1, s[2:3], s[4:5]
+; GFX12-ISEL-NEXT:    v_cmp_ngt_f64_e64 s0, s[0:1], s[6:7]
+; GFX12-ISEL-NEXT:    v_cmp_ngt_f64_e64 s1, s[2:3], s[6:7]
 ; GFX12-ISEL-NEXT:    v_ldexp_f64 v[4:5], v[0:1], 0xffffffe0
 ; GFX12-ISEL-NEXT:    v_ldexp_f64 v[6:7], v[2:3], 0xffffffe0
 ; GFX12-ISEL-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
@@ -2227,15 +2227,16 @@ define <2 x i64> @test_s_unsigned_v2f64_v2i64(<2 x double> inreg %f) {
 ; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v5, v[6:7]
 ; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
 ; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v1, v[2:3]
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e32 v2, 0, v4, vcc_lo
 ; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s6
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, v5, 0, s7
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, v3, -1, s1
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s6
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v4, v1, 0, s7
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v2, -1, s0
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s0
-; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, v4, -1, s1
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, 0, v5, s4
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, -1, v3, s1
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc_lo
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v4, 0, v1, s4
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, -1, v2, s0
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, -1, v0, s0
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, -1, v4, s1
 ; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GI-LABEL: test_s_unsigned_v2f64_v2i64:

--- a/llvm/test/CodeGen/AMDGPU/fptoui_uitofp.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptoui_uitofp.ll
@@ -250,9 +250,9 @@ define amdgpu_kernel void @fptoui_f64_to_i64_to_f64(ptr addrspace(1) %out, doubl
 ; GFX6-NEXT:    s_mov_b32 s0, s6
 ; GFX6-NEXT:    s_lshr_b64 s[0:1], s[0:1], s8
 ; GFX6-NEXT:    s_andn2_b64 s[0:1], s[2:3], s[0:1]
-; GFX6-NEXT:    s_cmp_lt_i32 s8, 0
-; GFX6-NEXT:    s_cselect_b32 s0, 0, s0
-; GFX6-NEXT:    s_cselect_b32 s1, 0, s1
+; GFX6-NEXT:    s_cmp_gt_i32 s8, -1
+; GFX6-NEXT:    s_cselect_b32 s0, s0, 0
+; GFX6-NEXT:    s_cselect_b32 s1, s1, 0
 ; GFX6-NEXT:    s_cmp_gt_i32 s8, 51
 ; GFX6-NEXT:    s_cselect_b32 s1, s3, s1
 ; GFX6-NEXT:    s_cselect_b32 s0, s2, s0

--- a/llvm/test/CodeGen/AMDGPU/frexp-inf-nan-combine.ll
+++ b/llvm/test/CodeGen/AMDGPU/frexp-inf-nan-combine.ll
@@ -853,9 +853,9 @@ define { float, i32 } @frexp_nan_clamp_both_f32(float %x) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_frexp_exp_i32_f32_e32 v1, v0
 ; GFX9-NEXT:    v_frexp_mant_f32_e32 v2, v0
-; GFX9-NEXT:    v_cmp_u_f32_e32 vcc, v0, v0
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, 0, vcc
+; GFX9-NEXT:    v_cmp_o_f32_e32 vcc, v0, v0
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: frexp_nan_clamp_both_f32:
@@ -863,9 +863,9 @@ define { float, i32 } @frexp_nan_clamp_both_f32(float %x) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_frexp_exp_i32_f32_e32 v1, v0
 ; GFX10-NEXT:    v_frexp_mant_f32_e32 v2, v0
-; GFX10-NEXT:    v_cmp_u_f32_e32 vcc_lo, v0, v0
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, 0, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v0
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: frexp_nan_clamp_both_f32:
@@ -873,10 +873,9 @@ define { float, i32 } @frexp_nan_clamp_both_f32(float %x) {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_frexp_exp_i32_f32_e32 v1, v0
 ; GFX11-NEXT:    v_frexp_mant_f32_e32 v2, v0
-; GFX11-NEXT:    v_cmp_u_f32_e32 vcc_lo, v0, v0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v2 :: v_dual_cndmask_b32 v1, 0, v1
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: frexp_nan_clamp_both_f32:
@@ -884,24 +883,24 @@ define { float, i32 } @frexp_nan_clamp_both_f32(float %x) {
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_frexp_exp_i32_f32_e32 v1, v0
 ; GFX950-NEXT:    v_frexp_mant_f32_e32 v2, v0
-; GFX950-NEXT:    v_cmp_u_f32_e32 vcc, v0, v0
+; GFX950-NEXT:    v_cmp_o_f32_e32 vcc, v0, v0
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v1, v1, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX6-LABEL: frexp_nan_clamp_both_f32:
 ; GFX6:       ; %bb.0:
 ; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX6-NEXT:    s_mov_b32 s4, 0x7f800000
-; GFX6-NEXT:    v_frexp_exp_i32_f32_e32 v1, v0
+; GFX6-NEXT:    v_frexp_mant_f32_e32 v1, v0
 ; GFX6-NEXT:    v_cmp_lt_f32_e64 vcc, |v0|, s4
-; GFX6-NEXT:    v_frexp_mant_f32_e32 v2, v0
-; GFX6-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v2, v0, v2, vcc
-; GFX6-NEXT:    v_cmp_u_f32_e32 vcc, v0, v0
-; GFX6-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX6-NEXT:    v_cndmask_b32_e64 v1, v1, 0, vcc
+; GFX6-NEXT:    v_cmp_o_f32_e64 s[4:5], v0, v0
+; GFX6-NEXT:    v_cndmask_b32_e32 v1, v0, v1, vcc
+; GFX6-NEXT:    v_frexp_exp_i32_f32_e32 v2, v0
+; GFX6-NEXT:    s_and_b64 vcc, s[4:5], vcc
+; GFX6-NEXT:    v_cndmask_b32_e64 v0, 0, v1, s[4:5]
+; GFX6-NEXT:    v_cndmask_b32_e32 v1, 0, v2, vcc
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
   %frexp = call { float, i32 } @llvm.frexp.f32.i32(float %x)
   %mant = extractvalue { float, i32 } %frexp, 0

--- a/llvm/test/CodeGen/AMDGPU/insert_vector_dynelt.ll
+++ b/llvm/test/CodeGen/AMDGPU/insert_vector_dynelt.ll
@@ -2064,12 +2064,12 @@ define amdgpu_kernel void @double2_inselt(ptr addrspace(1) %out, <2 x double> %v
 ; GCN-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x34
 ; GCN-NEXT:    s_load_dwordx2 s[4:5], s[4:5], 0x24
 ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-NEXT:    s_cmp_eq_u32 s6, 1
-; GCN-NEXT:    s_cselect_b32 s3, 0x3ff00000, s3
-; GCN-NEXT:    s_cselect_b32 s2, 0, s2
-; GCN-NEXT:    s_cmp_eq_u32 s6, 0
-; GCN-NEXT:    s_cselect_b32 s1, 0x3ff00000, s1
-; GCN-NEXT:    s_cselect_b32 s0, 0, s0
+; GCN-NEXT:    s_cmp_lg_u32 s6, 1
+; GCN-NEXT:    s_cselect_b32 s3, s3, 0x3ff00000
+; GCN-NEXT:    s_cselect_b32 s2, s2, 0
+; GCN-NEXT:    s_cmp_lg_u32 s6, 0
+; GCN-NEXT:    s_cselect_b32 s1, s1, 0x3ff00000
+; GCN-NEXT:    s_cselect_b32 s0, s0, 0
 ; GCN-NEXT:    v_mov_b32_e32 v0, s0
 ; GCN-NEXT:    v_mov_b32_e32 v1, s1
 ; GCN-NEXT:    v_mov_b32_e32 v2, s2
@@ -2126,21 +2126,21 @@ define amdgpu_kernel void @double5_inselt(ptr addrspace(1) %out, <5 x double> %v
 ; GCN-NEXT:    s_load_dwordx2 s[10:11], s[4:5], 0x24
 ; GCN-NEXT:    s_load_dwordx8 s[0:7], s[4:5], 0x64
 ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-NEXT:    s_cmp_eq_u32 s12, 4
-; GCN-NEXT:    s_cselect_b32 s9, 0x3ff00000, s9
-; GCN-NEXT:    s_cselect_b32 s8, 0, s8
-; GCN-NEXT:    s_cmp_eq_u32 s12, 1
-; GCN-NEXT:    s_cselect_b32 s3, 0x3ff00000, s3
-; GCN-NEXT:    s_cselect_b32 s2, 0, s2
-; GCN-NEXT:    s_cmp_eq_u32 s12, 0
-; GCN-NEXT:    s_cselect_b32 s13, 0x3ff00000, s1
-; GCN-NEXT:    s_cselect_b32 s14, 0, s0
-; GCN-NEXT:    s_cmp_eq_u32 s12, 3
-; GCN-NEXT:    s_cselect_b32 s0, 0x3ff00000, s7
-; GCN-NEXT:    s_cselect_b32 s1, 0, s6
-; GCN-NEXT:    s_cmp_eq_u32 s12, 2
-; GCN-NEXT:    s_cselect_b32 s5, 0x3ff00000, s5
-; GCN-NEXT:    s_cselect_b32 s4, 0, s4
+; GCN-NEXT:    s_cmp_lg_u32 s12, 4
+; GCN-NEXT:    s_cselect_b32 s9, s9, 0x3ff00000
+; GCN-NEXT:    s_cselect_b32 s8, s8, 0
+; GCN-NEXT:    s_cmp_lg_u32 s12, 1
+; GCN-NEXT:    s_cselect_b32 s3, s3, 0x3ff00000
+; GCN-NEXT:    s_cselect_b32 s2, s2, 0
+; GCN-NEXT:    s_cmp_lg_u32 s12, 0
+; GCN-NEXT:    s_cselect_b32 s13, s1, 0x3ff00000
+; GCN-NEXT:    s_cselect_b32 s14, s0, 0
+; GCN-NEXT:    s_cmp_lg_u32 s12, 3
+; GCN-NEXT:    s_cselect_b32 s0, s7, 0x3ff00000
+; GCN-NEXT:    s_cselect_b32 s1, s6, 0
+; GCN-NEXT:    s_cmp_lg_u32 s12, 2
+; GCN-NEXT:    s_cselect_b32 s5, s5, 0x3ff00000
+; GCN-NEXT:    s_cselect_b32 s4, s4, 0
 ; GCN-NEXT:    v_mov_b32_e32 v3, s0
 ; GCN-NEXT:    s_add_u32 s0, s10, 16
 ; GCN-NEXT:    v_mov_b32_e32 v2, s1
@@ -8435,31 +8435,31 @@ define <8 x double> @double8_inselt_vec(<8 x double> %vec, i32 %sel) {
 ; GCN-LABEL: double8_inselt_vec:
 ; GCN:       ; %bb.0: ; %entry
 ; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v16
+; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v16
 ; GCN-NEXT:    v_mov_b32_e32 v17, 0x3ff00000
-; GCN-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
-; GCN-NEXT:    v_cndmask_b32_e32 v1, v1, v17, vcc
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 1, v16
-; GCN-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
-; GCN-NEXT:    v_cndmask_b32_e32 v3, v3, v17, vcc
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 2, v16
-; GCN-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GCN-NEXT:    v_cndmask_b32_e32 v5, v5, v17, vcc
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 3, v16
-; GCN-NEXT:    v_cndmask_b32_e64 v6, v6, 0, vcc
-; GCN-NEXT:    v_cndmask_b32_e32 v7, v7, v17, vcc
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 4, v16
-; GCN-NEXT:    v_cndmask_b32_e64 v8, v8, 0, vcc
-; GCN-NEXT:    v_cndmask_b32_e32 v9, v9, v17, vcc
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 5, v16
-; GCN-NEXT:    v_cndmask_b32_e64 v10, v10, 0, vcc
-; GCN-NEXT:    v_cndmask_b32_e32 v11, v11, v17, vcc
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 6, v16
-; GCN-NEXT:    v_cndmask_b32_e64 v12, v12, 0, vcc
-; GCN-NEXT:    v_cndmask_b32_e32 v13, v13, v17, vcc
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 7, v16
-; GCN-NEXT:    v_cndmask_b32_e64 v14, v14, 0, vcc
-; GCN-NEXT:    v_cndmask_b32_e32 v15, v15, v17, vcc
+; GCN-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GCN-NEXT:    v_cndmask_b32_e32 v1, v17, v1, vcc
+; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v16
+; GCN-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
+; GCN-NEXT:    v_cndmask_b32_e32 v3, v17, v3, vcc
+; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 2, v16
+; GCN-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GCN-NEXT:    v_cndmask_b32_e32 v5, v17, v5, vcc
+; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 3, v16
+; GCN-NEXT:    v_cndmask_b32_e32 v6, 0, v6, vcc
+; GCN-NEXT:    v_cndmask_b32_e32 v7, v17, v7, vcc
+; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 4, v16
+; GCN-NEXT:    v_cndmask_b32_e32 v8, 0, v8, vcc
+; GCN-NEXT:    v_cndmask_b32_e32 v9, v17, v9, vcc
+; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 5, v16
+; GCN-NEXT:    v_cndmask_b32_e32 v10, 0, v10, vcc
+; GCN-NEXT:    v_cndmask_b32_e32 v11, v17, v11, vcc
+; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 6, v16
+; GCN-NEXT:    v_cndmask_b32_e32 v12, 0, v12, vcc
+; GCN-NEXT:    v_cndmask_b32_e32 v13, v17, v13, vcc
+; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 7, v16
+; GCN-NEXT:    v_cndmask_b32_e32 v14, 0, v14, vcc
+; GCN-NEXT:    v_cndmask_b32_e32 v15, v17, v15, vcc
 ; GCN-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GCN-O0-LABEL: double8_inselt_vec:

--- a/llvm/test/CodeGen/AMDGPU/insert_vector_elt.ll
+++ b/llvm/test/CodeGen/AMDGPU/insert_vector_elt.ll
@@ -2052,12 +2052,12 @@ define amdgpu_kernel void @dynamic_insertelement_v2f64(ptr addrspace(1) %out, [8
 ; SI-NEXT:    s_mov_b32 s7, 0x100f000
 ; SI-NEXT:    s_mov_b32 s6, -1
 ; SI-NEXT:    s_waitcnt lgkmcnt(0)
-; SI-NEXT:    s_cmp_eq_u32 s10, 1
-; SI-NEXT:    s_cselect_b32 s3, 0x40200000, s3
-; SI-NEXT:    s_cselect_b32 s2, 0, s2
-; SI-NEXT:    s_cmp_eq_u32 s10, 0
-; SI-NEXT:    s_cselect_b32 s1, 0x40200000, s1
-; SI-NEXT:    s_cselect_b32 s0, 0, s0
+; SI-NEXT:    s_cmp_lg_u32 s10, 1
+; SI-NEXT:    s_cselect_b32 s3, s3, 0x40200000
+; SI-NEXT:    s_cselect_b32 s2, s2, 0
+; SI-NEXT:    s_cmp_lg_u32 s10, 0
+; SI-NEXT:    s_cselect_b32 s1, s1, 0x40200000
+; SI-NEXT:    s_cselect_b32 s0, s0, 0
 ; SI-NEXT:    v_mov_b32_e32 v0, s0
 ; SI-NEXT:    v_mov_b32_e32 v1, s1
 ; SI-NEXT:    v_mov_b32_e32 v2, s2
@@ -2073,12 +2073,12 @@ define amdgpu_kernel void @dynamic_insertelement_v2f64(ptr addrspace(1) %out, [8
 ; VI-NEXT:    s_mov_b32 s7, 0x1100f000
 ; VI-NEXT:    s_mov_b32 s6, -1
 ; VI-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-NEXT:    s_cmp_eq_u32 s10, 1
-; VI-NEXT:    s_cselect_b32 s3, 0x40200000, s3
-; VI-NEXT:    s_cselect_b32 s2, 0, s2
-; VI-NEXT:    s_cmp_eq_u32 s10, 0
-; VI-NEXT:    s_cselect_b32 s1, 0x40200000, s1
-; VI-NEXT:    s_cselect_b32 s0, 0, s0
+; VI-NEXT:    s_cmp_lg_u32 s10, 1
+; VI-NEXT:    s_cselect_b32 s3, s3, 0x40200000
+; VI-NEXT:    s_cselect_b32 s2, s2, 0
+; VI-NEXT:    s_cmp_lg_u32 s10, 0
+; VI-NEXT:    s_cselect_b32 s1, s1, 0x40200000
+; VI-NEXT:    s_cselect_b32 s0, s0, 0
 ; VI-NEXT:    v_mov_b32_e32 v0, s0
 ; VI-NEXT:    v_mov_b32_e32 v1, s1
 ; VI-NEXT:    v_mov_b32_e32 v2, s2
@@ -2099,12 +2099,12 @@ define amdgpu_kernel void @dynamic_insertelement_v2i64(ptr addrspace(1) %out, <2
 ; SI-NEXT:    s_mov_b32 s7, 0x100f000
 ; SI-NEXT:    s_mov_b32 s6, -1
 ; SI-NEXT:    s_waitcnt lgkmcnt(0)
-; SI-NEXT:    s_cmp_eq_u32 s10, 1
-; SI-NEXT:    s_cselect_b32 s3, 0, s3
-; SI-NEXT:    s_cselect_b32 s2, 5, s2
-; SI-NEXT:    s_cmp_eq_u32 s10, 0
-; SI-NEXT:    s_cselect_b32 s1, 0, s1
-; SI-NEXT:    s_cselect_b32 s0, 5, s0
+; SI-NEXT:    s_cmp_lg_u32 s10, 1
+; SI-NEXT:    s_cselect_b32 s3, s3, 0
+; SI-NEXT:    s_cselect_b32 s2, s2, 5
+; SI-NEXT:    s_cmp_lg_u32 s10, 0
+; SI-NEXT:    s_cselect_b32 s1, s1, 0
+; SI-NEXT:    s_cselect_b32 s0, s0, 5
 ; SI-NEXT:    v_mov_b32_e32 v0, s0
 ; SI-NEXT:    v_mov_b32_e32 v1, s1
 ; SI-NEXT:    v_mov_b32_e32 v2, s2
@@ -2120,12 +2120,12 @@ define amdgpu_kernel void @dynamic_insertelement_v2i64(ptr addrspace(1) %out, <2
 ; VI-NEXT:    s_mov_b32 s7, 0x1100f000
 ; VI-NEXT:    s_mov_b32 s6, -1
 ; VI-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-NEXT:    s_cmp_eq_u32 s10, 1
-; VI-NEXT:    s_cselect_b32 s3, 0, s3
-; VI-NEXT:    s_cselect_b32 s2, 5, s2
-; VI-NEXT:    s_cmp_eq_u32 s10, 0
-; VI-NEXT:    s_cselect_b32 s1, 0, s1
-; VI-NEXT:    s_cselect_b32 s0, 5, s0
+; VI-NEXT:    s_cmp_lg_u32 s10, 1
+; VI-NEXT:    s_cselect_b32 s3, s3, 0
+; VI-NEXT:    s_cselect_b32 s2, s2, 5
+; VI-NEXT:    s_cmp_lg_u32 s10, 0
+; VI-NEXT:    s_cselect_b32 s1, s1, 0
+; VI-NEXT:    s_cselect_b32 s0, s0, 5
 ; VI-NEXT:    v_mov_b32_e32 v0, s0
 ; VI-NEXT:    v_mov_b32_e32 v1, s1
 ; VI-NEXT:    v_mov_b32_e32 v2, s2
@@ -2146,16 +2146,16 @@ define amdgpu_kernel void @dynamic_insertelement_v3i64(ptr addrspace(1) %out, <3
 ; SI-NEXT:    s_load_dwordx2 s[8:9], s[8:9], 0xc
 ; SI-NEXT:    s_mov_b32 s3, 0x100f000
 ; SI-NEXT:    s_waitcnt lgkmcnt(0)
-; SI-NEXT:    s_cmp_eq_u32 s10, 1
+; SI-NEXT:    s_cmp_lg_u32 s10, 1
 ; SI-NEXT:    s_mov_b32 s2, -1
-; SI-NEXT:    s_cselect_b32 s7, 0, s7
-; SI-NEXT:    s_cselect_b32 s6, 5, s6
-; SI-NEXT:    s_cmp_eq_u32 s10, 0
-; SI-NEXT:    s_cselect_b32 s5, 0, s5
-; SI-NEXT:    s_cselect_b32 s4, 5, s4
-; SI-NEXT:    s_cmp_eq_u32 s10, 2
-; SI-NEXT:    s_cselect_b32 s9, 0, s9
-; SI-NEXT:    s_cselect_b32 s8, 5, s8
+; SI-NEXT:    s_cselect_b32 s7, s7, 0
+; SI-NEXT:    s_cselect_b32 s6, s6, 5
+; SI-NEXT:    s_cmp_lg_u32 s10, 0
+; SI-NEXT:    s_cselect_b32 s5, s5, 0
+; SI-NEXT:    s_cselect_b32 s4, s4, 5
+; SI-NEXT:    s_cmp_lg_u32 s10, 2
+; SI-NEXT:    s_cselect_b32 s9, s9, 0
+; SI-NEXT:    s_cselect_b32 s8, s8, 5
 ; SI-NEXT:    v_mov_b32_e32 v0, s8
 ; SI-NEXT:    v_mov_b32_e32 v1, s9
 ; SI-NEXT:    buffer_store_dwordx2 v[0:1], off, s[0:3], 0 offset:16
@@ -2174,16 +2174,16 @@ define amdgpu_kernel void @dynamic_insertelement_v3i64(ptr addrspace(1) %out, <3
 ; VI-NEXT:    s_load_dwordx2 s[8:9], s[8:9], 0x30
 ; VI-NEXT:    s_mov_b32 s3, 0x1100f000
 ; VI-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-NEXT:    s_cmp_eq_u32 s10, 1
+; VI-NEXT:    s_cmp_lg_u32 s10, 1
 ; VI-NEXT:    s_mov_b32 s2, -1
-; VI-NEXT:    s_cselect_b32 s7, 0, s7
-; VI-NEXT:    s_cselect_b32 s6, 5, s6
-; VI-NEXT:    s_cmp_eq_u32 s10, 0
-; VI-NEXT:    s_cselect_b32 s5, 0, s5
-; VI-NEXT:    s_cselect_b32 s4, 5, s4
-; VI-NEXT:    s_cmp_eq_u32 s10, 2
-; VI-NEXT:    s_cselect_b32 s9, 0, s9
-; VI-NEXT:    s_cselect_b32 s8, 5, s8
+; VI-NEXT:    s_cselect_b32 s7, s7, 0
+; VI-NEXT:    s_cselect_b32 s6, s6, 5
+; VI-NEXT:    s_cmp_lg_u32 s10, 0
+; VI-NEXT:    s_cselect_b32 s5, s5, 0
+; VI-NEXT:    s_cselect_b32 s4, s4, 5
+; VI-NEXT:    s_cmp_lg_u32 s10, 2
+; VI-NEXT:    s_cselect_b32 s9, s9, 0
+; VI-NEXT:    s_cselect_b32 s8, s8, 5
 ; VI-NEXT:    v_mov_b32_e32 v0, s8
 ; VI-NEXT:    v_mov_b32_e32 v1, s9
 ; VI-NEXT:    buffer_store_dwordx2 v[0:1], off, s[0:3], 0 offset:16
@@ -2207,18 +2207,18 @@ define amdgpu_kernel void @dynamic_insertelement_v4f64(ptr addrspace(1) %out, <4
 ; SI-NEXT:    s_mov_b32 s11, 0x100f000
 ; SI-NEXT:    s_mov_b32 s10, -1
 ; SI-NEXT:    s_waitcnt lgkmcnt(0)
-; SI-NEXT:    s_cmp_eq_u32 s12, 1
-; SI-NEXT:    s_cselect_b32 s3, 0x40200000, s3
-; SI-NEXT:    s_cselect_b32 s2, 0, s2
-; SI-NEXT:    s_cmp_eq_u32 s12, 0
-; SI-NEXT:    s_cselect_b32 s1, 0x40200000, s1
-; SI-NEXT:    s_cselect_b32 s0, 0, s0
-; SI-NEXT:    s_cmp_eq_u32 s12, 3
-; SI-NEXT:    s_cselect_b32 s7, 0x40200000, s7
-; SI-NEXT:    s_cselect_b32 s6, 0, s6
-; SI-NEXT:    s_cmp_eq_u32 s12, 2
-; SI-NEXT:    s_cselect_b32 s5, 0x40200000, s5
-; SI-NEXT:    s_cselect_b32 s4, 0, s4
+; SI-NEXT:    s_cmp_lg_u32 s12, 1
+; SI-NEXT:    s_cselect_b32 s3, s3, 0x40200000
+; SI-NEXT:    s_cselect_b32 s2, s2, 0
+; SI-NEXT:    s_cmp_lg_u32 s12, 0
+; SI-NEXT:    s_cselect_b32 s1, s1, 0x40200000
+; SI-NEXT:    s_cselect_b32 s0, s0, 0
+; SI-NEXT:    s_cmp_lg_u32 s12, 3
+; SI-NEXT:    s_cselect_b32 s7, s7, 0x40200000
+; SI-NEXT:    s_cselect_b32 s6, s6, 0
+; SI-NEXT:    s_cmp_lg_u32 s12, 2
+; SI-NEXT:    s_cselect_b32 s5, s5, 0x40200000
+; SI-NEXT:    s_cselect_b32 s4, s4, 0
 ; SI-NEXT:    v_mov_b32_e32 v0, s4
 ; SI-NEXT:    v_mov_b32_e32 v1, s5
 ; SI-NEXT:    v_mov_b32_e32 v2, s6
@@ -2240,18 +2240,18 @@ define amdgpu_kernel void @dynamic_insertelement_v4f64(ptr addrspace(1) %out, <4
 ; VI-NEXT:    s_mov_b32 s11, 0x1100f000
 ; VI-NEXT:    s_mov_b32 s10, -1
 ; VI-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-NEXT:    s_cmp_eq_u32 s12, 1
-; VI-NEXT:    s_cselect_b32 s3, 0x40200000, s3
-; VI-NEXT:    s_cselect_b32 s2, 0, s2
-; VI-NEXT:    s_cmp_eq_u32 s12, 0
-; VI-NEXT:    s_cselect_b32 s1, 0x40200000, s1
-; VI-NEXT:    s_cselect_b32 s0, 0, s0
-; VI-NEXT:    s_cmp_eq_u32 s12, 3
-; VI-NEXT:    s_cselect_b32 s7, 0x40200000, s7
-; VI-NEXT:    s_cselect_b32 s6, 0, s6
-; VI-NEXT:    s_cmp_eq_u32 s12, 2
-; VI-NEXT:    s_cselect_b32 s5, 0x40200000, s5
-; VI-NEXT:    s_cselect_b32 s4, 0, s4
+; VI-NEXT:    s_cmp_lg_u32 s12, 1
+; VI-NEXT:    s_cselect_b32 s3, s3, 0x40200000
+; VI-NEXT:    s_cselect_b32 s2, s2, 0
+; VI-NEXT:    s_cmp_lg_u32 s12, 0
+; VI-NEXT:    s_cselect_b32 s1, s1, 0x40200000
+; VI-NEXT:    s_cselect_b32 s0, s0, 0
+; VI-NEXT:    s_cmp_lg_u32 s12, 3
+; VI-NEXT:    s_cselect_b32 s7, s7, 0x40200000
+; VI-NEXT:    s_cselect_b32 s6, s6, 0
+; VI-NEXT:    s_cmp_lg_u32 s12, 2
+; VI-NEXT:    s_cselect_b32 s5, s5, 0x40200000
+; VI-NEXT:    s_cselect_b32 s4, s4, 0
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
 ; VI-NEXT:    v_mov_b32_e32 v2, s6

--- a/llvm/test/CodeGen/AMDGPU/llvm.maximum.f64.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.maximum.f64.ll
@@ -13,60 +13,59 @@ define double @v_maximum_f64(double %src0, double %src1) #0 {
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX7-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_f64:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX8-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_maximum_f64:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX900-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_maximum_f64:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX950-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_f64:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v5, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_f64:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v4 :: v_dual_cndmask_b32 v1, 0x7ff80000, v5
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_maximum_f64:
@@ -143,60 +142,59 @@ define double @v_maximum_f64__nsz(double %src0, double %src1) #0 {
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX7-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_f64__nsz:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX8-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_maximum_f64__nsz:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX900-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_maximum_f64__nsz:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX950-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_f64__nsz:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v5, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_f64__nsz:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v4 :: v_dual_cndmask_b32 v1, 0x7ff80000, v5
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_maximum_f64__nsz:
@@ -274,10 +272,10 @@ define double @v_maximum_f64__nnan_src0(double %arg0, double %src1) #0 {
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
 ; GFX7-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX7-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_f64__nnan_src0:
@@ -285,10 +283,10 @@ define double @v_maximum_f64__nnan_src0(double %arg0, double %src1) #0 {
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
 ; GFX8-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX8-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_maximum_f64__nnan_src0:
@@ -296,10 +294,10 @@ define double @v_maximum_f64__nnan_src0(double %arg0, double %src1) #0 {
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
 ; GFX900-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX900-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_maximum_f64__nnan_src0:
@@ -307,11 +305,11 @@ define double @v_maximum_f64__nnan_src0(double %arg0, double %src1) #0 {
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
 ; GFX950-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX950-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_f64__nnan_src0:
@@ -319,9 +317,9 @@ define double @v_maximum_f64__nnan_src0(double %arg0, double %src1) #0 {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
 ; GFX10-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v5, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_f64__nnan_src0:
@@ -330,10 +328,8 @@ define double @v_maximum_f64__nnan_src0(double %arg0, double %src1) #0 {
 ; GFX11-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v4 :: v_dual_cndmask_b32 v1, 0x7ff80000, v5
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_maximum_f64__nnan_src0:
@@ -366,10 +362,10 @@ define double @v_maximum_f64__nnan_src1(double %src0, double %arg1) #0 {
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX7-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX7-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_f64__nnan_src1:
@@ -377,10 +373,10 @@ define double @v_maximum_f64__nnan_src1(double %src0, double %arg1) #0 {
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX8-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX8-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_maximum_f64__nnan_src1:
@@ -388,10 +384,10 @@ define double @v_maximum_f64__nnan_src1(double %src0, double %arg1) #0 {
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX900-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX900-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_maximum_f64__nnan_src1:
@@ -399,11 +395,11 @@ define double @v_maximum_f64__nnan_src1(double %src0, double %arg1) #0 {
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX950-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX950-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_f64__nnan_src1:
@@ -411,9 +407,9 @@ define double @v_maximum_f64__nnan_src1(double %src0, double %arg1) #0 {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX10-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v5, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_f64__nnan_src1:
@@ -422,10 +418,8 @@ define double @v_maximum_f64__nnan_src1(double %src0, double %arg1) #0 {
 ; GFX11-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v4 :: v_dual_cndmask_b32 v1, 0x7ff80000, v5
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_maximum_f64__nnan_src1:
@@ -459,10 +453,10 @@ define void @s_maximum_f64(double inreg %src0, double inreg %src1) #0 {
 ; GFX7-NEXT:    v_mov_b32_e32 v0, s18
 ; GFX7-NEXT:    v_mov_b32_e32 v1, s19
 ; GFX7-NEXT:    v_max_f64 v[2:3], s[16:17], v[0:1]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, s[16:17], v[0:1]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, s[16:17], v[0:1]
 ; GFX7-NEXT:    v_mov_b32_e32 v4, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v3, v4, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v4, v3, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
 ; GFX7-NEXT:    ;;#ASMSTART
 ; GFX7-NEXT:    ; use v[0:1]
 ; GFX7-NEXT:    ;;#ASMEND
@@ -474,10 +468,10 @@ define void @s_maximum_f64(double inreg %src0, double inreg %src1) #0 {
 ; GFX8-NEXT:    v_mov_b32_e32 v0, s18
 ; GFX8-NEXT:    v_mov_b32_e32 v1, s19
 ; GFX8-NEXT:    v_max_f64 v[2:3], s[16:17], v[0:1]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, s[16:17], v[0:1]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, s[16:17], v[0:1]
 ; GFX8-NEXT:    v_mov_b32_e32 v4, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v3, v4, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v4, v3, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
 ; GFX8-NEXT:    ;;#ASMSTART
 ; GFX8-NEXT:    ; use v[0:1]
 ; GFX8-NEXT:    ;;#ASMEND
@@ -489,10 +483,10 @@ define void @s_maximum_f64(double inreg %src0, double inreg %src1) #0 {
 ; GFX900-NEXT:    v_mov_b32_e32 v0, s18
 ; GFX900-NEXT:    v_mov_b32_e32 v1, s19
 ; GFX900-NEXT:    v_max_f64 v[2:3], s[16:17], v[0:1]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, s[16:17], v[0:1]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, s[16:17], v[0:1]
 ; GFX900-NEXT:    v_mov_b32_e32 v4, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v3, v4, vcc
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v4, v3, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
 ; GFX900-NEXT:    ;;#ASMSTART
 ; GFX900-NEXT:    ; use v[0:1]
 ; GFX900-NEXT:    ;;#ASMEND
@@ -504,10 +498,10 @@ define void @s_maximum_f64(double inreg %src0, double inreg %src1) #0 {
 ; GFX950-NEXT:    v_mov_b64_e32 v[0:1], s[2:3]
 ; GFX950-NEXT:    v_max_f64 v[2:3], s[0:1], v[0:1]
 ; GFX950-NEXT:    v_mov_b32_e32 v4, 0x7ff80000
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, s[0:1], v[0:1]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, s[0:1], v[0:1]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v3, v4, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v4, v3, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; use v[0:1]
 ; GFX950-NEXT:    ;;#ASMEND
@@ -517,9 +511,9 @@ define void @s_maximum_f64(double inreg %src0, double inreg %src1) #0 {
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_max_f64 v[0:1], s[16:17], s[18:19]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, s[16:17], s[18:19]
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s4
+; GFX10-NEXT:    v_cmp_o_f64_e64 vcc_lo, s[16:17], s[18:19]
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v1, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc_lo
 ; GFX10-NEXT:    ;;#ASMSTART
 ; GFX10-NEXT:    ; use v[0:1]
 ; GFX10-NEXT:    ;;#ASMEND
@@ -529,10 +523,9 @@ define void @s_maximum_f64(double inreg %src0, double inreg %src1) #0 {
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_max_f64 v[0:1], s[0:1], s[2:3]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, s[0:1], s[2:3]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s0
+; GFX11-NEXT:    v_cmp_o_f64_e64 vcc_lo, s[0:1], s[2:3]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v1, 0x7ff80000, v1 :: v_dual_cndmask_b32 v0, 0, v0
 ; GFX11-NEXT:    ;;#ASMSTART
 ; GFX11-NEXT:    ; use v[0:1]
 ; GFX11-NEXT:    ;;#ASMEND
@@ -569,85 +562,85 @@ define <2 x double> @v_maximum_v2f64(<2 x double> %src0, <2 x double> %src1) #0 
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_max_f64 v[8:9], v[0:1], v[4:5]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX7-NEXT:    v_max_f64 v[4:5], v[2:3], v[6:7]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[6:7]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[6:7]
 ; GFX7-NEXT:    v_mov_b32_e32 v3, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v9, v3, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v3, v5, v3, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v3, v9, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v3, v3, v5, s[4:5]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_v2f64:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_max_f64 v[8:9], v[0:1], v[4:5]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX8-NEXT:    v_max_f64 v[4:5], v[2:3], v[6:7]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[6:7]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[6:7]
 ; GFX8-NEXT:    v_mov_b32_e32 v3, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v9, v3, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, v5, v3, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v3, v9, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, v3, v5, s[4:5]
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_maximum_v2f64:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-NEXT:    v_max_f64 v[8:9], v[0:1], v[4:5]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX900-NEXT:    v_max_f64 v[4:5], v[2:3], v[6:7]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[6:7]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[6:7]
 ; GFX900-NEXT:    v_mov_b32_e32 v3, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v9, v3, vcc
-; GFX900-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v3, v5, v3, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v3, v9, vcc
+; GFX900-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v3, v3, v5, s[4:5]
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_maximum_v2f64:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_max_f64 v[8:9], v[0:1], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX950-NEXT:    v_max_f64 v[4:5], v[2:3], v[6:7]
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
 ; GFX950-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v9, v8, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[6:7]
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v8, v9, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[6:7]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v4, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v5, v8, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v4, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v8, v5, vcc
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_v2f64:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_max_f64 v[8:9], v[0:1], v[4:5]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[4:5]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[4:5]
 ; GFX10-NEXT:    v_max_f64 v[4:5], v[2:3], v[6:7]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[2:3], v[6:7]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v9, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v5, 0x7ff80000, s4
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[2:3], v[6:7]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v9, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v5, s4
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_v2f64:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_max_f64 v[8:9], v[0:1], v[4:5]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[4:5]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[4:5]
 ; GFX11-NEXT:    v_max_f64 v[4:5], v[2:3], v[6:7]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[2:3], v[6:7]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v9, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v5, 0x7ff80000, s0
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[2:3], v[6:7]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v8 :: v_dual_cndmask_b32 v1, 0x7ff80000, v9
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v5, s0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_maximum_v2f64:
@@ -733,85 +726,85 @@ define <2 x double> @v_maximum_v2f64__nsz(<2 x double> %src0, <2 x double> %src1
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_max_f64 v[8:9], v[0:1], v[4:5]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX7-NEXT:    v_max_f64 v[4:5], v[2:3], v[6:7]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[6:7]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[6:7]
 ; GFX7-NEXT:    v_mov_b32_e32 v3, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v9, v3, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v3, v5, v3, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v3, v9, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v3, v3, v5, s[4:5]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_v2f64__nsz:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_max_f64 v[8:9], v[0:1], v[4:5]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX8-NEXT:    v_max_f64 v[4:5], v[2:3], v[6:7]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[6:7]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[6:7]
 ; GFX8-NEXT:    v_mov_b32_e32 v3, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v9, v3, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, v5, v3, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v3, v9, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, v3, v5, s[4:5]
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_maximum_v2f64__nsz:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-NEXT:    v_max_f64 v[8:9], v[0:1], v[4:5]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX900-NEXT:    v_max_f64 v[4:5], v[2:3], v[6:7]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[6:7]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[6:7]
 ; GFX900-NEXT:    v_mov_b32_e32 v3, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v9, v3, vcc
-; GFX900-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v3, v5, v3, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v3, v9, vcc
+; GFX900-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v3, v3, v5, s[4:5]
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_maximum_v2f64__nsz:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_max_f64 v[8:9], v[0:1], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX950-NEXT:    v_max_f64 v[4:5], v[2:3], v[6:7]
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
 ; GFX950-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v9, v8, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[6:7]
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v8, v9, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[6:7]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v4, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v5, v8, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v4, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v8, v5, vcc
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_v2f64__nsz:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_max_f64 v[8:9], v[0:1], v[4:5]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[4:5]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[4:5]
 ; GFX10-NEXT:    v_max_f64 v[4:5], v[2:3], v[6:7]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[2:3], v[6:7]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v9, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v5, 0x7ff80000, s4
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[2:3], v[6:7]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v9, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v5, s4
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_v2f64__nsz:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_max_f64 v[8:9], v[0:1], v[4:5]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[4:5]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[4:5]
 ; GFX11-NEXT:    v_max_f64 v[4:5], v[2:3], v[6:7]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[2:3], v[6:7]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v9, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v5, 0x7ff80000, s0
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[2:3], v[6:7]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v8 :: v_dual_cndmask_b32 v1, 0x7ff80000, v9
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v5, s0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_maximum_v2f64__nsz:
@@ -899,16 +892,16 @@ define void @s_maximum_v2f64(<2 x double> inreg %src0, <2 x double> inreg %src1)
 ; GFX7-NEXT:    v_mov_b32_e32 v0, s22
 ; GFX7-NEXT:    v_mov_b32_e32 v1, s23
 ; GFX7-NEXT:    v_max_f64 v[2:3], s[18:19], v[0:1]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, s[18:19], v[0:1]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, s[18:19], v[0:1]
 ; GFX7-NEXT:    v_mov_b32_e32 v0, s20
 ; GFX7-NEXT:    v_mov_b32_e32 v1, s21
 ; GFX7-NEXT:    v_max_f64 v[4:5], s[16:17], v[0:1]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], s[16:17], v[0:1]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], s[16:17], v[0:1]
 ; GFX7-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v3, v6, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v5, v6, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e32 v3, v6, v3, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v1, v6, v5, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v0, 0, v4, s[4:5]
 ; GFX7-NEXT:    ;;#ASMSTART
 ; GFX7-NEXT:    ; use v[0:3]
 ; GFX7-NEXT:    ;;#ASMEND
@@ -920,16 +913,16 @@ define void @s_maximum_v2f64(<2 x double> inreg %src0, <2 x double> inreg %src1)
 ; GFX8-NEXT:    v_mov_b32_e32 v0, s22
 ; GFX8-NEXT:    v_mov_b32_e32 v1, s23
 ; GFX8-NEXT:    v_max_f64 v[2:3], s[18:19], v[0:1]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, s[18:19], v[0:1]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, s[18:19], v[0:1]
 ; GFX8-NEXT:    v_mov_b32_e32 v0, s20
 ; GFX8-NEXT:    v_mov_b32_e32 v1, s21
 ; GFX8-NEXT:    v_max_f64 v[4:5], s[16:17], v[0:1]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], s[16:17], v[0:1]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], s[16:17], v[0:1]
 ; GFX8-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v3, v6, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v5, v6, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v6, v3, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v1, v6, v5, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v0, 0, v4, s[4:5]
 ; GFX8-NEXT:    ;;#ASMSTART
 ; GFX8-NEXT:    ; use v[0:3]
 ; GFX8-NEXT:    ;;#ASMEND
@@ -941,16 +934,16 @@ define void @s_maximum_v2f64(<2 x double> inreg %src0, <2 x double> inreg %src1)
 ; GFX900-NEXT:    v_mov_b32_e32 v0, s22
 ; GFX900-NEXT:    v_mov_b32_e32 v1, s23
 ; GFX900-NEXT:    v_max_f64 v[2:3], s[18:19], v[0:1]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, s[18:19], v[0:1]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, s[18:19], v[0:1]
 ; GFX900-NEXT:    v_mov_b32_e32 v0, s20
 ; GFX900-NEXT:    v_mov_b32_e32 v1, s21
 ; GFX900-NEXT:    v_max_f64 v[4:5], s[16:17], v[0:1]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[4:5], s[16:17], v[0:1]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[4:5], s[16:17], v[0:1]
 ; GFX900-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e32 v3, v3, v6, vcc
-; GFX900-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e64 v1, v5, v6, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v4, 0, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e32 v3, v6, v3, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
+; GFX900-NEXT:    v_cndmask_b32_e64 v1, v6, v5, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v0, 0, v4, s[4:5]
 ; GFX900-NEXT:    ;;#ASMSTART
 ; GFX900-NEXT:    ; use v[0:3]
 ; GFX900-NEXT:    ;;#ASMEND
@@ -962,15 +955,15 @@ define void @s_maximum_v2f64(<2 x double> inreg %src0, <2 x double> inreg %src1)
 ; GFX950-NEXT:    v_mov_b64_e32 v[0:1], s[18:19]
 ; GFX950-NEXT:    v_max_f64 v[2:3], s[2:3], v[0:1]
 ; GFX950-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, s[2:3], v[0:1]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, s[2:3], v[0:1]
 ; GFX950-NEXT:    v_mov_b64_e32 v[0:1], s[16:17]
 ; GFX950-NEXT:    v_max_f64 v[4:5], s[0:1], v[0:1]
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v3, v6, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, s[0:1], v[0:1]
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v6, v3, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, s[0:1], v[0:1]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v5, v6, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v6, v5, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; use v[0:3]
 ; GFX950-NEXT:    ;;#ASMEND
@@ -980,13 +973,13 @@ define void @s_maximum_v2f64(<2 x double> inreg %src0, <2 x double> inreg %src1)
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_max_f64 v[0:1], s[18:19], s[22:23]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, s[18:19], s[22:23]
+; GFX10-NEXT:    v_cmp_o_f64_e64 vcc_lo, s[18:19], s[22:23]
 ; GFX10-NEXT:    v_max_f64 v[4:5], s[16:17], s[20:21]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s5, s[16:17], s[20:21]
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v1, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v0, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, s5
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, s[16:17], s[20:21]
+; GFX10-NEXT:    v_cndmask_b32_e32 v3, 0x7ff80000, v1, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v2, 0, v0, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, 0x7ff80000, v5, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, 0, v4, s4
 ; GFX10-NEXT:    ;;#ASMSTART
 ; GFX10-NEXT:    ; use v[0:3]
 ; GFX10-NEXT:    ;;#ASMEND
@@ -996,14 +989,14 @@ define void @s_maximum_v2f64(<2 x double> inreg %src0, <2 x double> inreg %src1)
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_max_f64 v[0:1], s[2:3], s[18:19]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s2, s[2:3], s[18:19]
+; GFX11-NEXT:    v_cmp_o_f64_e64 vcc_lo, s[2:3], s[18:19]
 ; GFX11-NEXT:    v_max_f64 v[4:5], s[0:1], s[16:17]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, s[0:1], s[16:17]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v1, 0x7ff80000, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v0, 0, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, s0
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, s[0:1], s[16:17]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v3, 0x7ff80000, v1 :: v_dual_cndmask_b32 v2, 0, v0
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, 0x7ff80000, v5, s0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, 0, v4, s0
 ; GFX11-NEXT:    ;;#ASMSTART
 ; GFX11-NEXT:    ; use v[0:3]
 ; GFX11-NEXT:    ;;#ASMEND
@@ -1042,109 +1035,109 @@ define <3 x double> @v_maximum_v3f64(<3 x double> %src0, <3 x double> %src1) #0 
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_max_f64 v[12:13], v[0:1], v[6:7]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[6:7]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[6:7]
 ; GFX7-NEXT:    v_max_f64 v[6:7], v[2:3], v[8:9]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[8:9]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[8:9]
 ; GFX7-NEXT:    v_max_f64 v[8:9], v[4:5], v[10:11]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[10:11]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[10:11]
 ; GFX7-NEXT:    v_mov_b32_e32 v5, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v13, v5, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v6, 0, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v3, v7, v5, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v8, 0, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v5, v9, v5, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v12, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v13, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, 0, v6, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v3, v5, v7, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v4, 0, v8, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v5, v5, v9, s[6:7]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_v3f64:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_max_f64 v[12:13], v[0:1], v[6:7]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[6:7]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[6:7]
 ; GFX8-NEXT:    v_max_f64 v[6:7], v[2:3], v[8:9]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[8:9]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[8:9]
 ; GFX8-NEXT:    v_max_f64 v[8:9], v[4:5], v[10:11]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[10:11]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[10:11]
 ; GFX8-NEXT:    v_mov_b32_e32 v5, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v13, v5, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v6, 0, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, v7, v5, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v8, 0, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v5, v9, v5, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v12, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v13, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, v6, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, v5, v7, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, v8, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, v5, v9, s[6:7]
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_maximum_v3f64:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-NEXT:    v_max_f64 v[12:13], v[0:1], v[6:7]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[6:7]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[6:7]
 ; GFX900-NEXT:    v_max_f64 v[6:7], v[2:3], v[8:9]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[8:9]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[8:9]
 ; GFX900-NEXT:    v_max_f64 v[8:9], v[4:5], v[10:11]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[10:11]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[10:11]
 ; GFX900-NEXT:    v_mov_b32_e32 v5, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v13, v5, vcc
-; GFX900-NEXT:    v_cndmask_b32_e64 v2, v6, 0, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v3, v7, v5, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v4, v8, 0, s[6:7]
-; GFX900-NEXT:    v_cndmask_b32_e64 v5, v9, v5, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v12, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v5, v13, vcc
+; GFX900-NEXT:    v_cndmask_b32_e64 v2, 0, v6, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v3, v5, v7, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v4, 0, v8, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e64 v5, v5, v9, s[6:7]
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_maximum_v3f64:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_max_f64 v[12:13], v[0:1], v[6:7]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[6:7]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[6:7]
 ; GFX950-NEXT:    v_max_f64 v[6:7], v[2:3], v[8:9]
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v12, vcc
 ; GFX950-NEXT:    v_mov_b32_e32 v12, 0x7ff80000
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v13, v12, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[8:9]
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v12, v13, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[8:9]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v6, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v7, v12, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v6, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v12, v7, vcc
 ; GFX950-NEXT:    v_max_f64 v[6:7], v[4:5], v[10:11]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[10:11]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[10:11]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v4, v6, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v5, v7, v12, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v4, 0, v6, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v5, v12, v7, vcc
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_v3f64:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_max_f64 v[12:13], v[0:1], v[6:7]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[6:7]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[6:7]
 ; GFX10-NEXT:    v_max_f64 v[6:7], v[2:3], v[8:9]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[2:3], v[8:9]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[2:3], v[8:9]
 ; GFX10-NEXT:    v_max_f64 v[8:9], v[4:5], v[10:11]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s5, v[4:5], v[10:11]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v13, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v6, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v7, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v8, 0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v9, 0x7ff80000, s5
+; GFX10-NEXT:    v_cmp_o_f64_e64 s5, v[4:5], v[10:11]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v12, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v13, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v6, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v7, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, v8, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v9, s5
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_v3f64:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_max_f64 v[12:13], v[0:1], v[6:7]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[6:7]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[6:7]
 ; GFX11-NEXT:    v_max_f64 v[6:7], v[2:3], v[8:9]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[2:3], v[8:9]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[2:3], v[8:9]
 ; GFX11-NEXT:    v_max_f64 v[8:9], v[4:5], v[10:11]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s1, v[4:5], v[10:11]
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v13, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v6, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v7, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v8, 0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v9, 0x7ff80000, s1
+; GFX11-NEXT:    v_cmp_o_f64_e64 s1, v[4:5], v[10:11]
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v12 :: v_dual_cndmask_b32 v1, 0x7ff80000, v13
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v6, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v7, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v4, 0, v8, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v9, s1
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_maximum_v3f64:
@@ -1239,109 +1232,109 @@ define <3 x double> @v_maximum_v3f64__nsz(<3 x double> %src0, <3 x double> %src1
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_max_f64 v[12:13], v[0:1], v[6:7]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[6:7]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[6:7]
 ; GFX7-NEXT:    v_max_f64 v[6:7], v[2:3], v[8:9]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[8:9]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[8:9]
 ; GFX7-NEXT:    v_max_f64 v[8:9], v[4:5], v[10:11]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[10:11]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[10:11]
 ; GFX7-NEXT:    v_mov_b32_e32 v5, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v13, v5, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v6, 0, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v3, v7, v5, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v8, 0, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v5, v9, v5, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v12, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v13, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, 0, v6, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v3, v5, v7, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v4, 0, v8, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v5, v5, v9, s[6:7]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_v3f64__nsz:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_max_f64 v[12:13], v[0:1], v[6:7]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[6:7]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[6:7]
 ; GFX8-NEXT:    v_max_f64 v[6:7], v[2:3], v[8:9]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[8:9]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[8:9]
 ; GFX8-NEXT:    v_max_f64 v[8:9], v[4:5], v[10:11]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[10:11]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[10:11]
 ; GFX8-NEXT:    v_mov_b32_e32 v5, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v13, v5, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v6, 0, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, v7, v5, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v8, 0, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v5, v9, v5, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v12, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v13, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, v6, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, v5, v7, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, v8, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, v5, v9, s[6:7]
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_maximum_v3f64__nsz:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-NEXT:    v_max_f64 v[12:13], v[0:1], v[6:7]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[6:7]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[6:7]
 ; GFX900-NEXT:    v_max_f64 v[6:7], v[2:3], v[8:9]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[8:9]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[8:9]
 ; GFX900-NEXT:    v_max_f64 v[8:9], v[4:5], v[10:11]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[10:11]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[10:11]
 ; GFX900-NEXT:    v_mov_b32_e32 v5, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v13, v5, vcc
-; GFX900-NEXT:    v_cndmask_b32_e64 v2, v6, 0, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v3, v7, v5, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v4, v8, 0, s[6:7]
-; GFX900-NEXT:    v_cndmask_b32_e64 v5, v9, v5, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v12, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v5, v13, vcc
+; GFX900-NEXT:    v_cndmask_b32_e64 v2, 0, v6, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v3, v5, v7, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v4, 0, v8, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e64 v5, v5, v9, s[6:7]
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_maximum_v3f64__nsz:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_max_f64 v[12:13], v[0:1], v[6:7]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[6:7]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[6:7]
 ; GFX950-NEXT:    v_max_f64 v[6:7], v[2:3], v[8:9]
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v12, vcc
 ; GFX950-NEXT:    v_mov_b32_e32 v12, 0x7ff80000
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v13, v12, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[8:9]
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v12, v13, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[8:9]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v6, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v7, v12, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v6, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v12, v7, vcc
 ; GFX950-NEXT:    v_max_f64 v[6:7], v[4:5], v[10:11]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[10:11]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[10:11]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v4, v6, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v5, v7, v12, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v4, 0, v6, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v5, v12, v7, vcc
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_v3f64__nsz:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_max_f64 v[12:13], v[0:1], v[6:7]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[6:7]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[6:7]
 ; GFX10-NEXT:    v_max_f64 v[6:7], v[2:3], v[8:9]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[2:3], v[8:9]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[2:3], v[8:9]
 ; GFX10-NEXT:    v_max_f64 v[8:9], v[4:5], v[10:11]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s5, v[4:5], v[10:11]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v13, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v6, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v7, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v8, 0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v9, 0x7ff80000, s5
+; GFX10-NEXT:    v_cmp_o_f64_e64 s5, v[4:5], v[10:11]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v12, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v13, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v6, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v7, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, v8, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v9, s5
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_v3f64__nsz:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_max_f64 v[12:13], v[0:1], v[6:7]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[6:7]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[6:7]
 ; GFX11-NEXT:    v_max_f64 v[6:7], v[2:3], v[8:9]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[2:3], v[8:9]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[2:3], v[8:9]
 ; GFX11-NEXT:    v_max_f64 v[8:9], v[4:5], v[10:11]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s1, v[4:5], v[10:11]
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v13, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v6, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v7, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v8, 0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v9, 0x7ff80000, s1
+; GFX11-NEXT:    v_cmp_o_f64_e64 s1, v[4:5], v[10:11]
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v12 :: v_dual_cndmask_b32 v1, 0x7ff80000, v13
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v6, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v7, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v4, 0, v8, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v9, s1
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_maximum_v3f64__nsz:
@@ -1436,134 +1429,133 @@ define <4 x double> @v_maximum_v4f64(<4 x double> %src0, <4 x double> %src1) #0 
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_max_f64 v[16:17], v[0:1], v[8:9]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[8:9]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[8:9]
 ; GFX7-NEXT:    v_max_f64 v[8:9], v[2:3], v[10:11]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[10:11]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[10:11]
 ; GFX7-NEXT:    v_max_f64 v[10:11], v[4:5], v[12:13]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[12:13]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[12:13]
 ; GFX7-NEXT:    v_max_f64 v[12:13], v[6:7], v[14:15]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[14:15]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[14:15]
 ; GFX7-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v17, v7, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v8, 0, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v3, v9, v7, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v5, v11, v7, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s[8:9]
-; GFX7-NEXT:    v_cndmask_b32_e64 v7, v13, v7, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v7, v17, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, 0, v8, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v3, v7, v9, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v5, v7, v11, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e64 v7, v7, v13, s[8:9]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_v4f64:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_max_f64 v[16:17], v[0:1], v[8:9]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[8:9]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[8:9]
 ; GFX8-NEXT:    v_max_f64 v[8:9], v[2:3], v[10:11]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[10:11]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[10:11]
 ; GFX8-NEXT:    v_max_f64 v[10:11], v[4:5], v[12:13]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[12:13]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[12:13]
 ; GFX8-NEXT:    v_max_f64 v[12:13], v[6:7], v[14:15]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[14:15]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[14:15]
 ; GFX8-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v17, v7, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v8, 0, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, v9, v7, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v5, v11, v7, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s[8:9]
-; GFX8-NEXT:    v_cndmask_b32_e64 v7, v13, v7, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v7, v17, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, v8, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, v7, v9, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, v7, v11, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e64 v7, v7, v13, s[8:9]
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_maximum_v4f64:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-NEXT:    v_max_f64 v[16:17], v[0:1], v[8:9]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[8:9]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[8:9]
 ; GFX900-NEXT:    v_max_f64 v[8:9], v[2:3], v[10:11]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[10:11]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[10:11]
 ; GFX900-NEXT:    v_max_f64 v[10:11], v[4:5], v[12:13]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[12:13]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[12:13]
 ; GFX900-NEXT:    v_max_f64 v[12:13], v[6:7], v[14:15]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[14:15]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[14:15]
 ; GFX900-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v17, v7, vcc
-; GFX900-NEXT:    v_cndmask_b32_e64 v2, v8, 0, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v3, v9, v7, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[6:7]
-; GFX900-NEXT:    v_cndmask_b32_e64 v5, v11, v7, s[6:7]
-; GFX900-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s[8:9]
-; GFX900-NEXT:    v_cndmask_b32_e64 v7, v13, v7, s[8:9]
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v7, v17, vcc
+; GFX900-NEXT:    v_cndmask_b32_e64 v2, 0, v8, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v3, v7, v9, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e64 v5, v7, v11, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s[8:9]
+; GFX900-NEXT:    v_cndmask_b32_e64 v7, v7, v13, s[8:9]
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_maximum_v4f64:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_max_f64 v[16:17], v[0:1], v[8:9]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[8:9]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[8:9]
 ; GFX950-NEXT:    v_max_f64 v[8:9], v[2:3], v[10:11]
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc
 ; GFX950-NEXT:    v_mov_b32_e32 v16, 0x7ff80000
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v17, v16, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[10:11]
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v16, v17, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[10:11]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v8, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v9, v16, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v8, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v16, v9, vcc
 ; GFX950-NEXT:    v_max_f64 v[8:9], v[4:5], v[12:13]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[12:13]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[12:13]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v4, v8, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v5, v9, v16, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v4, 0, v8, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v5, v16, v9, vcc
 ; GFX950-NEXT:    v_max_f64 v[8:9], v[6:7], v[14:15]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[6:7], v[14:15]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[6:7], v[14:15]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v6, v8, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v7, v9, v16, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v6, 0, v8, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v7, v16, v9, vcc
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_v4f64:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_max_f64 v[16:17], v[0:1], v[8:9]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[8:9]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[8:9]
 ; GFX10-NEXT:    v_max_f64 v[8:9], v[2:3], v[10:11]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[2:3], v[10:11]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[2:3], v[10:11]
 ; GFX10-NEXT:    v_max_f64 v[10:11], v[4:5], v[12:13]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s5, v[4:5], v[12:13]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s5, v[4:5], v[12:13]
 ; GFX10-NEXT:    v_max_f64 v[12:13], v[6:7], v[14:15]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s6, v[6:7], v[14:15]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v17, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v8, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v9, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v11, 0x7ff80000, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v7, v13, 0x7ff80000, s6
+; GFX10-NEXT:    v_cmp_o_f64_e64 s6, v[6:7], v[14:15]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v17, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v8, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v9, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v11, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s6
+; GFX10-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v13, s6
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_v4f64:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_max_f64 v[16:17], v[0:1], v[8:9]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[8:9]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[8:9]
 ; GFX11-NEXT:    v_max_f64 v[8:9], v[2:3], v[10:11]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[2:3], v[10:11]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[2:3], v[10:11]
 ; GFX11-NEXT:    v_max_f64 v[10:11], v[4:5], v[12:13]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s1, v[4:5], v[12:13]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s1, v[4:5], v[12:13]
 ; GFX11-NEXT:    v_max_f64 v[12:13], v[6:7], v[14:15]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s2, v[6:7], v[14:15]
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v17, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v8, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v9, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v11, 0x7ff80000, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v7, v13, 0x7ff80000, s2
+; GFX11-NEXT:    v_cmp_o_f64_e64 s2, v[6:7], v[14:15]
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v16 :: v_dual_cndmask_b32 v1, 0x7ff80000, v17
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v8, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v9, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v11, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v13, s2
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_maximum_v4f64:
@@ -1667,134 +1659,133 @@ define <4 x double> @v_maximum_v4f64__nsz(<4 x double> %src0, <4 x double> %src1
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_max_f64 v[16:17], v[0:1], v[8:9]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[8:9]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[8:9]
 ; GFX7-NEXT:    v_max_f64 v[8:9], v[2:3], v[10:11]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[10:11]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[10:11]
 ; GFX7-NEXT:    v_max_f64 v[10:11], v[4:5], v[12:13]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[12:13]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[12:13]
 ; GFX7-NEXT:    v_max_f64 v[12:13], v[6:7], v[14:15]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[14:15]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[14:15]
 ; GFX7-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v17, v7, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v8, 0, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v3, v9, v7, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v5, v11, v7, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s[8:9]
-; GFX7-NEXT:    v_cndmask_b32_e64 v7, v13, v7, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v7, v17, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, 0, v8, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v3, v7, v9, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v5, v7, v11, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e64 v7, v7, v13, s[8:9]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_v4f64__nsz:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_max_f64 v[16:17], v[0:1], v[8:9]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[8:9]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[8:9]
 ; GFX8-NEXT:    v_max_f64 v[8:9], v[2:3], v[10:11]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[10:11]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[10:11]
 ; GFX8-NEXT:    v_max_f64 v[10:11], v[4:5], v[12:13]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[12:13]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[12:13]
 ; GFX8-NEXT:    v_max_f64 v[12:13], v[6:7], v[14:15]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[14:15]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[14:15]
 ; GFX8-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v17, v7, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v8, 0, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, v9, v7, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v5, v11, v7, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s[8:9]
-; GFX8-NEXT:    v_cndmask_b32_e64 v7, v13, v7, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v7, v17, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, v8, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, v7, v9, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, v7, v11, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e64 v7, v7, v13, s[8:9]
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_maximum_v4f64__nsz:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-NEXT:    v_max_f64 v[16:17], v[0:1], v[8:9]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[8:9]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[8:9]
 ; GFX900-NEXT:    v_max_f64 v[8:9], v[2:3], v[10:11]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[10:11]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[10:11]
 ; GFX900-NEXT:    v_max_f64 v[10:11], v[4:5], v[12:13]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[12:13]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[12:13]
 ; GFX900-NEXT:    v_max_f64 v[12:13], v[6:7], v[14:15]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[14:15]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[14:15]
 ; GFX900-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v17, v7, vcc
-; GFX900-NEXT:    v_cndmask_b32_e64 v2, v8, 0, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v3, v9, v7, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[6:7]
-; GFX900-NEXT:    v_cndmask_b32_e64 v5, v11, v7, s[6:7]
-; GFX900-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s[8:9]
-; GFX900-NEXT:    v_cndmask_b32_e64 v7, v13, v7, s[8:9]
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v7, v17, vcc
+; GFX900-NEXT:    v_cndmask_b32_e64 v2, 0, v8, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v3, v7, v9, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e64 v5, v7, v11, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s[8:9]
+; GFX900-NEXT:    v_cndmask_b32_e64 v7, v7, v13, s[8:9]
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_maximum_v4f64__nsz:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_max_f64 v[16:17], v[0:1], v[8:9]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[8:9]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[8:9]
 ; GFX950-NEXT:    v_max_f64 v[8:9], v[2:3], v[10:11]
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc
 ; GFX950-NEXT:    v_mov_b32_e32 v16, 0x7ff80000
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v17, v16, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[10:11]
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v16, v17, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[10:11]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v8, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v9, v16, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v8, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v16, v9, vcc
 ; GFX950-NEXT:    v_max_f64 v[8:9], v[4:5], v[12:13]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[12:13]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[12:13]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v4, v8, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v5, v9, v16, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v4, 0, v8, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v5, v16, v9, vcc
 ; GFX950-NEXT:    v_max_f64 v[8:9], v[6:7], v[14:15]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[6:7], v[14:15]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[6:7], v[14:15]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v6, v8, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v7, v9, v16, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v6, 0, v8, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v7, v16, v9, vcc
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_v4f64__nsz:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_max_f64 v[16:17], v[0:1], v[8:9]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[8:9]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[8:9]
 ; GFX10-NEXT:    v_max_f64 v[8:9], v[2:3], v[10:11]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[2:3], v[10:11]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[2:3], v[10:11]
 ; GFX10-NEXT:    v_max_f64 v[10:11], v[4:5], v[12:13]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s5, v[4:5], v[12:13]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s5, v[4:5], v[12:13]
 ; GFX10-NEXT:    v_max_f64 v[12:13], v[6:7], v[14:15]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s6, v[6:7], v[14:15]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v17, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v8, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v9, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v11, 0x7ff80000, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v7, v13, 0x7ff80000, s6
+; GFX10-NEXT:    v_cmp_o_f64_e64 s6, v[6:7], v[14:15]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v17, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v8, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v9, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v11, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s6
+; GFX10-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v13, s6
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_v4f64__nsz:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_max_f64 v[16:17], v[0:1], v[8:9]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[8:9]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[8:9]
 ; GFX11-NEXT:    v_max_f64 v[8:9], v[2:3], v[10:11]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[2:3], v[10:11]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[2:3], v[10:11]
 ; GFX11-NEXT:    v_max_f64 v[10:11], v[4:5], v[12:13]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s1, v[4:5], v[12:13]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s1, v[4:5], v[12:13]
 ; GFX11-NEXT:    v_max_f64 v[12:13], v[6:7], v[14:15]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s2, v[6:7], v[14:15]
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v17, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v8, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v9, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v11, 0x7ff80000, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v7, v13, 0x7ff80000, s2
+; GFX11-NEXT:    v_cmp_o_f64_e64 s2, v[6:7], v[14:15]
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v16 :: v_dual_cndmask_b32 v1, 0x7ff80000, v17
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v8, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v9, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v11, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v13, s2
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_maximum_v4f64__nsz:
@@ -1899,39 +1890,39 @@ define <8 x double> @v_maximum_v8f64(<8 x double> %src0, <8 x double> %src1) #0 
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32
 ; GFX7-NEXT:    v_max_f64 v[32:33], v[0:1], v[16:17]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[16:17]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[16:17]
 ; GFX7-NEXT:    v_max_f64 v[16:17], v[2:3], v[18:19]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[18:19]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[18:19]
 ; GFX7-NEXT:    v_mov_b32_e32 v34, 0x7ff80000
 ; GFX7-NEXT:    v_max_f64 v[18:19], v[4:5], v[20:21]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[20:21]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[20:21]
 ; GFX7-NEXT:    v_max_f64 v[20:21], v[6:7], v[22:23]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[22:23]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[22:23]
 ; GFX7-NEXT:    v_max_f64 v[22:23], v[8:9], v[24:25]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[10:11], v[8:9], v[24:25]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[10:11], v[8:9], v[24:25]
 ; GFX7-NEXT:    v_max_f64 v[24:25], v[10:11], v[26:27]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[12:13], v[10:11], v[26:27]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[12:13], v[10:11], v[26:27]
 ; GFX7-NEXT:    v_max_f64 v[26:27], v[12:13], v[28:29]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[14:15], v[12:13], v[28:29]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v32, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v33, v34, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v16, 0, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v3, v17, v34, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v18, 0, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v5, v19, v34, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v6, v20, 0, s[8:9]
-; GFX7-NEXT:    v_cndmask_b32_e64 v7, v21, v34, s[8:9]
-; GFX7-NEXT:    v_cndmask_b32_e64 v8, v22, 0, s[10:11]
-; GFX7-NEXT:    v_cndmask_b32_e64 v9, v23, v34, s[10:11]
-; GFX7-NEXT:    v_cndmask_b32_e64 v10, v24, 0, s[12:13]
-; GFX7-NEXT:    v_cndmask_b32_e64 v11, v25, v34, s[12:13]
-; GFX7-NEXT:    v_cndmask_b32_e64 v12, v26, 0, s[14:15]
-; GFX7-NEXT:    v_cndmask_b32_e64 v13, v27, v34, s[14:15]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[14:15], v[12:13], v[28:29]
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v32, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v34, v33, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, 0, v16, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v3, v34, v17, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v4, 0, v18, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v5, v34, v19, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v6, 0, v20, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e64 v7, v34, v21, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e64 v8, 0, v22, s[10:11]
+; GFX7-NEXT:    v_cndmask_b32_e64 v9, v34, v23, s[10:11]
+; GFX7-NEXT:    v_cndmask_b32_e64 v10, 0, v24, s[12:13]
+; GFX7-NEXT:    v_cndmask_b32_e64 v11, v34, v25, s[12:13]
+; GFX7-NEXT:    v_cndmask_b32_e64 v12, 0, v26, s[14:15]
+; GFX7-NEXT:    v_cndmask_b32_e64 v13, v34, v27, s[14:15]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
 ; GFX7-NEXT:    v_max_f64 v[16:17], v[14:15], v[30:31]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[14:15], v[30:31]
-; GFX7-NEXT:    v_cndmask_b32_e64 v14, v16, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v15, v17, v34, vcc
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[14:15], v[30:31]
+; GFX7-NEXT:    v_cndmask_b32_e32 v14, 0, v16, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v15, v34, v17, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_v8f64:
@@ -1939,39 +1930,39 @@ define <8 x double> @v_maximum_v8f64(<8 x double> %src0, <8 x double> %src1) #0 
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32
 ; GFX8-NEXT:    v_max_f64 v[32:33], v[0:1], v[16:17]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[16:17]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[16:17]
 ; GFX8-NEXT:    v_max_f64 v[16:17], v[2:3], v[18:19]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[18:19]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[18:19]
 ; GFX8-NEXT:    v_mov_b32_e32 v34, 0x7ff80000
 ; GFX8-NEXT:    v_max_f64 v[18:19], v[4:5], v[20:21]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[20:21]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[20:21]
 ; GFX8-NEXT:    v_max_f64 v[20:21], v[6:7], v[22:23]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[22:23]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[22:23]
 ; GFX8-NEXT:    v_max_f64 v[22:23], v[8:9], v[24:25]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[10:11], v[8:9], v[24:25]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[10:11], v[8:9], v[24:25]
 ; GFX8-NEXT:    v_max_f64 v[24:25], v[10:11], v[26:27]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[12:13], v[10:11], v[26:27]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[12:13], v[10:11], v[26:27]
 ; GFX8-NEXT:    v_max_f64 v[26:27], v[12:13], v[28:29]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[14:15], v[12:13], v[28:29]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v32, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v33, v34, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v16, 0, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, v17, v34, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v18, 0, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v5, v19, v34, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v6, v20, 0, s[8:9]
-; GFX8-NEXT:    v_cndmask_b32_e64 v7, v21, v34, s[8:9]
-; GFX8-NEXT:    v_cndmask_b32_e64 v8, v22, 0, s[10:11]
-; GFX8-NEXT:    v_cndmask_b32_e64 v9, v23, v34, s[10:11]
-; GFX8-NEXT:    v_cndmask_b32_e64 v10, v24, 0, s[12:13]
-; GFX8-NEXT:    v_cndmask_b32_e64 v11, v25, v34, s[12:13]
-; GFX8-NEXT:    v_cndmask_b32_e64 v12, v26, 0, s[14:15]
-; GFX8-NEXT:    v_cndmask_b32_e64 v13, v27, v34, s[14:15]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[14:15], v[12:13], v[28:29]
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v32, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v34, v33, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, v16, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, v34, v17, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, v18, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, v34, v19, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, v20, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e64 v7, v34, v21, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e64 v8, 0, v22, s[10:11]
+; GFX8-NEXT:    v_cndmask_b32_e64 v9, v34, v23, s[10:11]
+; GFX8-NEXT:    v_cndmask_b32_e64 v10, 0, v24, s[12:13]
+; GFX8-NEXT:    v_cndmask_b32_e64 v11, v34, v25, s[12:13]
+; GFX8-NEXT:    v_cndmask_b32_e64 v12, 0, v26, s[14:15]
+; GFX8-NEXT:    v_cndmask_b32_e64 v13, v34, v27, s[14:15]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
 ; GFX8-NEXT:    v_max_f64 v[16:17], v[14:15], v[30:31]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[14:15], v[30:31]
-; GFX8-NEXT:    v_cndmask_b32_e64 v14, v16, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v15, v17, v34, vcc
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[14:15], v[30:31]
+; GFX8-NEXT:    v_cndmask_b32_e32 v14, 0, v16, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v15, v34, v17, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_maximum_v8f64:
@@ -1979,39 +1970,39 @@ define <8 x double> @v_maximum_v8f64(<8 x double> %src0, <8 x double> %src1) #0 
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32
 ; GFX900-NEXT:    v_max_f64 v[32:33], v[0:1], v[16:17]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[16:17]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[16:17]
 ; GFX900-NEXT:    v_max_f64 v[16:17], v[2:3], v[18:19]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[18:19]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[18:19]
 ; GFX900-NEXT:    v_mov_b32_e32 v34, 0x7ff80000
 ; GFX900-NEXT:    v_max_f64 v[18:19], v[4:5], v[20:21]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[20:21]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[20:21]
 ; GFX900-NEXT:    v_max_f64 v[20:21], v[6:7], v[22:23]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[22:23]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[22:23]
 ; GFX900-NEXT:    v_max_f64 v[22:23], v[8:9], v[24:25]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[10:11], v[8:9], v[24:25]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[10:11], v[8:9], v[24:25]
 ; GFX900-NEXT:    v_max_f64 v[24:25], v[10:11], v[26:27]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[12:13], v[10:11], v[26:27]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[12:13], v[10:11], v[26:27]
 ; GFX900-NEXT:    v_max_f64 v[26:27], v[12:13], v[28:29]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[14:15], v[12:13], v[28:29]
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v32, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v33, v34, vcc
-; GFX900-NEXT:    v_cndmask_b32_e64 v2, v16, 0, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v3, v17, v34, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v4, v18, 0, s[6:7]
-; GFX900-NEXT:    v_cndmask_b32_e64 v5, v19, v34, s[6:7]
-; GFX900-NEXT:    v_cndmask_b32_e64 v6, v20, 0, s[8:9]
-; GFX900-NEXT:    v_cndmask_b32_e64 v7, v21, v34, s[8:9]
-; GFX900-NEXT:    v_cndmask_b32_e64 v8, v22, 0, s[10:11]
-; GFX900-NEXT:    v_cndmask_b32_e64 v9, v23, v34, s[10:11]
-; GFX900-NEXT:    v_cndmask_b32_e64 v10, v24, 0, s[12:13]
-; GFX900-NEXT:    v_cndmask_b32_e64 v11, v25, v34, s[12:13]
-; GFX900-NEXT:    v_cndmask_b32_e64 v12, v26, 0, s[14:15]
-; GFX900-NEXT:    v_cndmask_b32_e64 v13, v27, v34, s[14:15]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[14:15], v[12:13], v[28:29]
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v32, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v34, v33, vcc
+; GFX900-NEXT:    v_cndmask_b32_e64 v2, 0, v16, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v3, v34, v17, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v4, 0, v18, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e64 v5, v34, v19, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e64 v6, 0, v20, s[8:9]
+; GFX900-NEXT:    v_cndmask_b32_e64 v7, v34, v21, s[8:9]
+; GFX900-NEXT:    v_cndmask_b32_e64 v8, 0, v22, s[10:11]
+; GFX900-NEXT:    v_cndmask_b32_e64 v9, v34, v23, s[10:11]
+; GFX900-NEXT:    v_cndmask_b32_e64 v10, 0, v24, s[12:13]
+; GFX900-NEXT:    v_cndmask_b32_e64 v11, v34, v25, s[12:13]
+; GFX900-NEXT:    v_cndmask_b32_e64 v12, 0, v26, s[14:15]
+; GFX900-NEXT:    v_cndmask_b32_e64 v13, v34, v27, s[14:15]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
 ; GFX900-NEXT:    v_max_f64 v[16:17], v[14:15], v[30:31]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[14:15], v[30:31]
-; GFX900-NEXT:    v_cndmask_b32_e64 v14, v16, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v15, v17, v34, vcc
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[14:15], v[30:31]
+; GFX900-NEXT:    v_cndmask_b32_e32 v14, 0, v16, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v15, v34, v17, vcc
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_maximum_v8f64:
@@ -2020,42 +2011,42 @@ define <8 x double> @v_maximum_v8f64(<8 x double> %src0, <8 x double> %src1) #0 
 ; GFX950-NEXT:    scratch_load_dword v31, off, s32
 ; GFX950-NEXT:    v_mov_b32_e32 v54, 0x7ff80000
 ; GFX950-NEXT:    v_max_f64 v[32:33], v[0:1], v[16:17]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[16:17]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[16:17]
 ; GFX950-NEXT:    v_max_f64 v[34:35], v[2:3], v[18:19]
 ; GFX950-NEXT:    v_max_f64 v[36:37], v[4:5], v[20:21]
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v32, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v33, v54, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[18:19]
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v32, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v54, v33, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[18:19]
 ; GFX950-NEXT:    v_max_f64 v[38:39], v[6:7], v[22:23]
 ; GFX950-NEXT:    v_max_f64 v[48:49], v[8:9], v[24:25]
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v34, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v35, v54, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[20:21]
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v34, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v54, v35, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[20:21]
 ; GFX950-NEXT:    v_max_f64 v[50:51], v[10:11], v[26:27]
 ; GFX950-NEXT:    v_max_f64 v[52:53], v[12:13], v[28:29]
-; GFX950-NEXT:    v_cndmask_b32_e64 v4, v36, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v5, v37, v54, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[6:7], v[22:23]
+; GFX950-NEXT:    v_cndmask_b32_e32 v4, 0, v36, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v5, v54, v37, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[6:7], v[22:23]
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_max_f64 v[16:17], v[14:15], v[30:31]
-; GFX950-NEXT:    v_cndmask_b32_e64 v6, v38, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v7, v39, v54, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[8:9], v[24:25]
+; GFX950-NEXT:    v_cndmask_b32_e32 v6, 0, v38, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v7, v54, v39, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[8:9], v[24:25]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v8, v48, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v9, v49, v54, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[10:11], v[26:27]
+; GFX950-NEXT:    v_cndmask_b32_e32 v8, 0, v48, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v9, v54, v49, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[10:11], v[26:27]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v10, v50, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v11, v51, v54, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[12:13], v[28:29]
+; GFX950-NEXT:    v_cndmask_b32_e32 v10, 0, v50, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v11, v54, v51, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[12:13], v[28:29]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v12, v52, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v13, v53, v54, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[14:15], v[30:31]
+; GFX950-NEXT:    v_cndmask_b32_e32 v12, 0, v52, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v13, v54, v53, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[14:15], v[30:31]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v14, v16, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v15, v17, v54, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v14, 0, v16, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v15, v54, v17, vcc
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_v8f64:
@@ -2063,38 +2054,38 @@ define <8 x double> @v_maximum_v8f64(<8 x double> %src0, <8 x double> %src1) #0 
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    buffer_load_dword v31, off, s[0:3], s32
 ; GFX10-NEXT:    v_max_f64 v[32:33], v[0:1], v[16:17]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[16:17]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[16:17]
 ; GFX10-NEXT:    v_max_f64 v[16:17], v[2:3], v[18:19]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[2:3], v[18:19]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[2:3], v[18:19]
 ; GFX10-NEXT:    v_max_f64 v[18:19], v[4:5], v[20:21]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s5, v[4:5], v[20:21]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s5, v[4:5], v[20:21]
 ; GFX10-NEXT:    v_max_f64 v[20:21], v[6:7], v[22:23]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s6, v[6:7], v[22:23]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s6, v[6:7], v[22:23]
 ; GFX10-NEXT:    v_max_f64 v[22:23], v[8:9], v[24:25]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s7, v[8:9], v[24:25]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s7, v[8:9], v[24:25]
 ; GFX10-NEXT:    v_max_f64 v[24:25], v[10:11], v[26:27]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s8, v[10:11], v[26:27]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s8, v[10:11], v[26:27]
 ; GFX10-NEXT:    v_max_f64 v[26:27], v[12:13], v[28:29]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s9, v[12:13], v[28:29]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v32, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v33, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v16, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v17, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v18, 0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v19, 0x7ff80000, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, v20, 0, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v7, v21, 0x7ff80000, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v8, v22, 0, s7
-; GFX10-NEXT:    v_cndmask_b32_e64 v9, v23, 0x7ff80000, s7
-; GFX10-NEXT:    v_cndmask_b32_e64 v10, v24, 0, s8
-; GFX10-NEXT:    v_cndmask_b32_e64 v11, v25, 0x7ff80000, s8
-; GFX10-NEXT:    v_cndmask_b32_e64 v12, v26, 0, s9
-; GFX10-NEXT:    v_cndmask_b32_e64 v13, v27, 0x7ff80000, s9
+; GFX10-NEXT:    v_cmp_o_f64_e64 s9, v[12:13], v[28:29]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v32, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v33, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v16, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v17, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, v18, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v19, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, 0, v20, s6
+; GFX10-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v21, s6
+; GFX10-NEXT:    v_cndmask_b32_e64 v8, 0, v22, s7
+; GFX10-NEXT:    v_cndmask_b32_e64 v9, 0x7ff80000, v23, s7
+; GFX10-NEXT:    v_cndmask_b32_e64 v10, 0, v24, s8
+; GFX10-NEXT:    v_cndmask_b32_e64 v11, 0x7ff80000, v25, s8
+; GFX10-NEXT:    v_cndmask_b32_e64 v12, 0, v26, s9
+; GFX10-NEXT:    v_cndmask_b32_e64 v13, 0x7ff80000, v27, s9
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-NEXT:    v_max_f64 v[28:29], v[14:15], v[30:31]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s10, v[14:15], v[30:31]
-; GFX10-NEXT:    v_cndmask_b32_e64 v14, v28, 0, s10
-; GFX10-NEXT:    v_cndmask_b32_e64 v15, v29, 0x7ff80000, s10
+; GFX10-NEXT:    v_cmp_o_f64_e64 s10, v[14:15], v[30:31]
+; GFX10-NEXT:    v_cndmask_b32_e64 v14, 0, v28, s10
+; GFX10-NEXT:    v_cndmask_b32_e64 v15, 0x7ff80000, v29, s10
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_v8f64:
@@ -2102,39 +2093,38 @@ define <8 x double> @v_maximum_v8f64(<8 x double> %src0, <8 x double> %src1) #0 
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    scratch_load_b32 v31, off, s32
 ; GFX11-NEXT:    v_max_f64 v[32:33], v[0:1], v[16:17]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[16:17]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[16:17]
 ; GFX11-NEXT:    v_max_f64 v[16:17], v[2:3], v[18:19]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[2:3], v[18:19]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[2:3], v[18:19]
 ; GFX11-NEXT:    v_max_f64 v[18:19], v[4:5], v[20:21]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s1, v[4:5], v[20:21]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s1, v[4:5], v[20:21]
 ; GFX11-NEXT:    v_max_f64 v[20:21], v[6:7], v[22:23]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s2, v[6:7], v[22:23]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s2, v[6:7], v[22:23]
 ; GFX11-NEXT:    v_max_f64 v[22:23], v[8:9], v[24:25]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s3, v[8:9], v[24:25]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s3, v[8:9], v[24:25]
 ; GFX11-NEXT:    v_max_f64 v[24:25], v[10:11], v[26:27]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s4, v[10:11], v[26:27]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s4, v[10:11], v[26:27]
 ; GFX11-NEXT:    v_max_f64 v[26:27], v[12:13], v[28:29]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s5, v[12:13], v[28:29]
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v32, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v33, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v16, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v17, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v18, 0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v19, 0x7ff80000, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v6, v20, 0, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v7, v21, 0x7ff80000, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v8, v22, 0, s3
-; GFX11-NEXT:    v_cndmask_b32_e64 v9, v23, 0x7ff80000, s3
-; GFX11-NEXT:    v_cndmask_b32_e64 v10, v24, 0, s4
-; GFX11-NEXT:    v_cndmask_b32_e64 v11, v25, 0x7ff80000, s4
-; GFX11-NEXT:    v_cndmask_b32_e64 v12, v26, 0, s5
-; GFX11-NEXT:    v_cndmask_b32_e64 v13, v27, 0x7ff80000, s5
+; GFX11-NEXT:    v_cmp_o_f64_e64 s5, v[12:13], v[28:29]
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v32 :: v_dual_cndmask_b32 v1, 0x7ff80000, v33
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v16, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v17, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v4, 0, v18, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v19, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v6, 0, v20, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v21, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v8, 0, v22, s3
+; GFX11-NEXT:    v_cndmask_b32_e64 v9, 0x7ff80000, v23, s3
+; GFX11-NEXT:    v_cndmask_b32_e64 v10, 0, v24, s4
+; GFX11-NEXT:    v_cndmask_b32_e64 v11, 0x7ff80000, v25, s4
+; GFX11-NEXT:    v_cndmask_b32_e64 v12, 0, v26, s5
+; GFX11-NEXT:    v_cndmask_b32_e64 v13, 0x7ff80000, v27, s5
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    v_max_f64 v[28:29], v[14:15], v[30:31]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s6, v[14:15], v[30:31]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s6, v[14:15], v[30:31]
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v14, v28, 0, s6
-; GFX11-NEXT:    v_cndmask_b32_e64 v15, v29, 0x7ff80000, s6
+; GFX11-NEXT:    v_cndmask_b32_e64 v14, 0, v28, s6
+; GFX11-NEXT:    v_cndmask_b32_e64 v15, 0x7ff80000, v29, s6
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_maximum_v8f64:
@@ -2181,117 +2171,117 @@ define <16 x double> @v_maximum_v16f64(<16 x double> %src0, <16 x double> %src1)
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:8
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:4
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[31:32]
 ; GFX7-NEXT:    v_max_f64 v[0:1], v[0:1], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:16
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:12
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[31:32]
 ; GFX7-NEXT:    v_max_f64 v[2:3], v[2:3], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:24
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:20
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[4:5]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[31:32]
 ; GFX7-NEXT:    v_max_f64 v[4:5], v[4:5], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:32
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:28
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s[6:7]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[31:32]
 ; GFX7-NEXT:    v_max_f64 v[6:7], v[6:7], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:36
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:40
-; GFX7-NEXT:    v_cndmask_b32_e64 v6, v6, 0, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s[8:9]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[10:11], v[8:9], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[10:11], v[8:9], v[31:32]
 ; GFX7-NEXT:    v_max_f64 v[8:9], v[8:9], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:48
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:44
-; GFX7-NEXT:    v_cndmask_b32_e64 v8, v8, 0, s[10:11]
+; GFX7-NEXT:    v_cndmask_b32_e64 v8, 0, v8, s[10:11]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[12:13], v[10:11], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[12:13], v[10:11], v[31:32]
 ; GFX7-NEXT:    v_max_f64 v[10:11], v[10:11], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:56
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:52
-; GFX7-NEXT:    v_cndmask_b32_e64 v10, v10, 0, s[12:13]
+; GFX7-NEXT:    v_cndmask_b32_e64 v10, 0, v10, s[12:13]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[14:15], v[12:13], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[14:15], v[12:13], v[31:32]
 ; GFX7-NEXT:    v_max_f64 v[12:13], v[12:13], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:64
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:60
-; GFX7-NEXT:    v_cndmask_b32_e64 v12, v12, 0, s[14:15]
+; GFX7-NEXT:    v_cndmask_b32_e64 v12, 0, v12, s[14:15]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[16:17], v[14:15], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[16:17], v[14:15], v[31:32]
 ; GFX7-NEXT:    v_max_f64 v[14:15], v[14:15], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:68
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:72
-; GFX7-NEXT:    v_cndmask_b32_e64 v14, v14, 0, s[16:17]
+; GFX7-NEXT:    v_cndmask_b32_e64 v14, 0, v14, s[16:17]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[18:19], v[16:17], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[18:19], v[16:17], v[31:32]
 ; GFX7-NEXT:    v_max_f64 v[16:17], v[16:17], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:80
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:76
-; GFX7-NEXT:    v_cndmask_b32_e64 v16, v16, 0, s[18:19]
+; GFX7-NEXT:    v_cndmask_b32_e64 v16, 0, v16, s[18:19]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[20:21], v[18:19], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[20:21], v[18:19], v[31:32]
 ; GFX7-NEXT:    v_max_f64 v[18:19], v[18:19], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:88
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:84
-; GFX7-NEXT:    v_cndmask_b32_e64 v18, v18, 0, s[20:21]
+; GFX7-NEXT:    v_cndmask_b32_e64 v18, 0, v18, s[20:21]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[22:23], v[20:21], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[22:23], v[20:21], v[31:32]
 ; GFX7-NEXT:    v_max_f64 v[20:21], v[20:21], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:96
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:92
-; GFX7-NEXT:    v_cndmask_b32_e64 v20, v20, 0, s[22:23]
+; GFX7-NEXT:    v_cndmask_b32_e64 v20, 0, v20, s[22:23]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[24:25], v[22:23], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[24:25], v[22:23], v[31:32]
 ; GFX7-NEXT:    v_max_f64 v[22:23], v[22:23], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:100
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:104
-; GFX7-NEXT:    v_cndmask_b32_e64 v22, v22, 0, s[24:25]
+; GFX7-NEXT:    v_cndmask_b32_e64 v22, 0, v22, s[24:25]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[26:27], v[24:25], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[26:27], v[24:25], v[31:32]
 ; GFX7-NEXT:    v_max_f64 v[24:25], v[24:25], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:112
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:108
-; GFX7-NEXT:    v_cndmask_b32_e64 v24, v24, 0, s[26:27]
+; GFX7-NEXT:    v_cndmask_b32_e64 v24, 0, v24, s[26:27]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[28:29], v[26:27], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[28:29], v[26:27], v[31:32]
 ; GFX7-NEXT:    v_max_f64 v[26:27], v[26:27], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:120
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:116
-; GFX7-NEXT:    v_cndmask_b32_e64 v26, v26, 0, s[28:29]
+; GFX7-NEXT:    v_cndmask_b32_e64 v26, 0, v26, s[28:29]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[40:41], v[28:29], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[40:41], v[28:29], v[31:32]
 ; GFX7-NEXT:    v_max_f64 v[28:29], v[28:29], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32
 ; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:128
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:124
-; GFX7-NEXT:    v_cndmask_b32_e64 v28, v28, 0, s[40:41]
+; GFX7-NEXT:    v_cndmask_b32_e64 v28, 0, v28, s[40:41]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[42:43], v[30:31], v[32:33]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[42:43], v[30:31], v[32:33]
 ; GFX7-NEXT:    v_max_f64 v[30:31], v[30:31], v[32:33]
 ; GFX7-NEXT:    v_mov_b32_e32 v32, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v32, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v3, v3, v32, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v5, v5, v32, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v7, v7, v32, s[8:9]
-; GFX7-NEXT:    v_cndmask_b32_e64 v9, v9, v32, s[10:11]
-; GFX7-NEXT:    v_cndmask_b32_e64 v11, v11, v32, s[12:13]
-; GFX7-NEXT:    v_cndmask_b32_e64 v13, v13, v32, s[14:15]
-; GFX7-NEXT:    v_cndmask_b32_e64 v15, v15, v32, s[16:17]
-; GFX7-NEXT:    v_cndmask_b32_e64 v17, v17, v32, s[18:19]
-; GFX7-NEXT:    v_cndmask_b32_e64 v19, v19, v32, s[20:21]
-; GFX7-NEXT:    v_cndmask_b32_e64 v21, v21, v32, s[22:23]
-; GFX7-NEXT:    v_cndmask_b32_e64 v23, v23, v32, s[24:25]
-; GFX7-NEXT:    v_cndmask_b32_e64 v25, v25, v32, s[26:27]
-; GFX7-NEXT:    v_cndmask_b32_e64 v27, v27, v32, s[28:29]
-; GFX7-NEXT:    v_cndmask_b32_e64 v29, v29, v32, s[40:41]
-; GFX7-NEXT:    v_cndmask_b32_e64 v31, v31, v32, s[42:43]
-; GFX7-NEXT:    v_cndmask_b32_e64 v30, v30, 0, s[42:43]
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v32, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v3, v32, v3, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v5, v32, v5, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v7, v32, v7, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e64 v9, v32, v9, s[10:11]
+; GFX7-NEXT:    v_cndmask_b32_e64 v11, v32, v11, s[12:13]
+; GFX7-NEXT:    v_cndmask_b32_e64 v13, v32, v13, s[14:15]
+; GFX7-NEXT:    v_cndmask_b32_e64 v15, v32, v15, s[16:17]
+; GFX7-NEXT:    v_cndmask_b32_e64 v17, v32, v17, s[18:19]
+; GFX7-NEXT:    v_cndmask_b32_e64 v19, v32, v19, s[20:21]
+; GFX7-NEXT:    v_cndmask_b32_e64 v21, v32, v21, s[22:23]
+; GFX7-NEXT:    v_cndmask_b32_e64 v23, v32, v23, s[24:25]
+; GFX7-NEXT:    v_cndmask_b32_e64 v25, v32, v25, s[26:27]
+; GFX7-NEXT:    v_cndmask_b32_e64 v27, v32, v27, s[28:29]
+; GFX7-NEXT:    v_cndmask_b32_e64 v29, v32, v29, s[40:41]
+; GFX7-NEXT:    v_cndmask_b32_e64 v31, v32, v31, s[42:43]
+; GFX7-NEXT:    v_cndmask_b32_e64 v30, 0, v30, s[42:43]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_v16f64:
@@ -2300,117 +2290,117 @@ define <16 x double> @v_maximum_v16f64(<16 x double> %src0, <16 x double> %src1)
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:8
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:4
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[31:32]
 ; GFX8-NEXT:    v_max_f64 v[0:1], v[0:1], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:16
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:12
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[31:32]
 ; GFX8-NEXT:    v_max_f64 v[2:3], v[2:3], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:24
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:20
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[4:5]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[31:32]
 ; GFX8-NEXT:    v_max_f64 v[4:5], v[4:5], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:32
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:28
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s[6:7]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[31:32]
 ; GFX8-NEXT:    v_max_f64 v[6:7], v[6:7], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:36
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:40
-; GFX8-NEXT:    v_cndmask_b32_e64 v6, v6, 0, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s[8:9]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[10:11], v[8:9], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[10:11], v[8:9], v[31:32]
 ; GFX8-NEXT:    v_max_f64 v[8:9], v[8:9], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:48
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:44
-; GFX8-NEXT:    v_cndmask_b32_e64 v8, v8, 0, s[10:11]
+; GFX8-NEXT:    v_cndmask_b32_e64 v8, 0, v8, s[10:11]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[12:13], v[10:11], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[12:13], v[10:11], v[31:32]
 ; GFX8-NEXT:    v_max_f64 v[10:11], v[10:11], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:56
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:52
-; GFX8-NEXT:    v_cndmask_b32_e64 v10, v10, 0, s[12:13]
+; GFX8-NEXT:    v_cndmask_b32_e64 v10, 0, v10, s[12:13]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[14:15], v[12:13], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[14:15], v[12:13], v[31:32]
 ; GFX8-NEXT:    v_max_f64 v[12:13], v[12:13], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:64
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:60
-; GFX8-NEXT:    v_cndmask_b32_e64 v12, v12, 0, s[14:15]
+; GFX8-NEXT:    v_cndmask_b32_e64 v12, 0, v12, s[14:15]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[16:17], v[14:15], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[16:17], v[14:15], v[31:32]
 ; GFX8-NEXT:    v_max_f64 v[14:15], v[14:15], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:68
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:72
-; GFX8-NEXT:    v_cndmask_b32_e64 v14, v14, 0, s[16:17]
+; GFX8-NEXT:    v_cndmask_b32_e64 v14, 0, v14, s[16:17]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[18:19], v[16:17], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[18:19], v[16:17], v[31:32]
 ; GFX8-NEXT:    v_max_f64 v[16:17], v[16:17], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:80
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:76
-; GFX8-NEXT:    v_cndmask_b32_e64 v16, v16, 0, s[18:19]
+; GFX8-NEXT:    v_cndmask_b32_e64 v16, 0, v16, s[18:19]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[20:21], v[18:19], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[20:21], v[18:19], v[31:32]
 ; GFX8-NEXT:    v_max_f64 v[18:19], v[18:19], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:88
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:84
-; GFX8-NEXT:    v_cndmask_b32_e64 v18, v18, 0, s[20:21]
+; GFX8-NEXT:    v_cndmask_b32_e64 v18, 0, v18, s[20:21]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[22:23], v[20:21], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[22:23], v[20:21], v[31:32]
 ; GFX8-NEXT:    v_max_f64 v[20:21], v[20:21], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:96
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:92
-; GFX8-NEXT:    v_cndmask_b32_e64 v20, v20, 0, s[22:23]
+; GFX8-NEXT:    v_cndmask_b32_e64 v20, 0, v20, s[22:23]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[24:25], v[22:23], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[24:25], v[22:23], v[31:32]
 ; GFX8-NEXT:    v_max_f64 v[22:23], v[22:23], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:100
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:104
-; GFX8-NEXT:    v_cndmask_b32_e64 v22, v22, 0, s[24:25]
+; GFX8-NEXT:    v_cndmask_b32_e64 v22, 0, v22, s[24:25]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[26:27], v[24:25], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[26:27], v[24:25], v[31:32]
 ; GFX8-NEXT:    v_max_f64 v[24:25], v[24:25], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:112
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:108
-; GFX8-NEXT:    v_cndmask_b32_e64 v24, v24, 0, s[26:27]
+; GFX8-NEXT:    v_cndmask_b32_e64 v24, 0, v24, s[26:27]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[28:29], v[26:27], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[28:29], v[26:27], v[31:32]
 ; GFX8-NEXT:    v_max_f64 v[26:27], v[26:27], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:120
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:116
-; GFX8-NEXT:    v_cndmask_b32_e64 v26, v26, 0, s[28:29]
+; GFX8-NEXT:    v_cndmask_b32_e64 v26, 0, v26, s[28:29]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[40:41], v[28:29], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[40:41], v[28:29], v[31:32]
 ; GFX8-NEXT:    v_max_f64 v[28:29], v[28:29], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32
 ; GFX8-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:128
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:124
-; GFX8-NEXT:    v_cndmask_b32_e64 v28, v28, 0, s[40:41]
+; GFX8-NEXT:    v_cndmask_b32_e64 v28, 0, v28, s[40:41]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[42:43], v[30:31], v[32:33]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[42:43], v[30:31], v[32:33]
 ; GFX8-NEXT:    v_max_f64 v[30:31], v[30:31], v[32:33]
 ; GFX8-NEXT:    v_mov_b32_e32 v32, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v32, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, v3, v32, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v5, v5, v32, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v7, v7, v32, s[8:9]
-; GFX8-NEXT:    v_cndmask_b32_e64 v9, v9, v32, s[10:11]
-; GFX8-NEXT:    v_cndmask_b32_e64 v11, v11, v32, s[12:13]
-; GFX8-NEXT:    v_cndmask_b32_e64 v13, v13, v32, s[14:15]
-; GFX8-NEXT:    v_cndmask_b32_e64 v15, v15, v32, s[16:17]
-; GFX8-NEXT:    v_cndmask_b32_e64 v17, v17, v32, s[18:19]
-; GFX8-NEXT:    v_cndmask_b32_e64 v19, v19, v32, s[20:21]
-; GFX8-NEXT:    v_cndmask_b32_e64 v21, v21, v32, s[22:23]
-; GFX8-NEXT:    v_cndmask_b32_e64 v23, v23, v32, s[24:25]
-; GFX8-NEXT:    v_cndmask_b32_e64 v25, v25, v32, s[26:27]
-; GFX8-NEXT:    v_cndmask_b32_e64 v27, v27, v32, s[28:29]
-; GFX8-NEXT:    v_cndmask_b32_e64 v29, v29, v32, s[40:41]
-; GFX8-NEXT:    v_cndmask_b32_e64 v31, v31, v32, s[42:43]
-; GFX8-NEXT:    v_cndmask_b32_e64 v30, v30, 0, s[42:43]
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v32, v1, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, v32, v3, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, v32, v5, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v7, v32, v7, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e64 v9, v32, v9, s[10:11]
+; GFX8-NEXT:    v_cndmask_b32_e64 v11, v32, v11, s[12:13]
+; GFX8-NEXT:    v_cndmask_b32_e64 v13, v32, v13, s[14:15]
+; GFX8-NEXT:    v_cndmask_b32_e64 v15, v32, v15, s[16:17]
+; GFX8-NEXT:    v_cndmask_b32_e64 v17, v32, v17, s[18:19]
+; GFX8-NEXT:    v_cndmask_b32_e64 v19, v32, v19, s[20:21]
+; GFX8-NEXT:    v_cndmask_b32_e64 v21, v32, v21, s[22:23]
+; GFX8-NEXT:    v_cndmask_b32_e64 v23, v32, v23, s[24:25]
+; GFX8-NEXT:    v_cndmask_b32_e64 v25, v32, v25, s[26:27]
+; GFX8-NEXT:    v_cndmask_b32_e64 v27, v32, v27, s[28:29]
+; GFX8-NEXT:    v_cndmask_b32_e64 v29, v32, v29, s[40:41]
+; GFX8-NEXT:    v_cndmask_b32_e64 v31, v32, v31, s[42:43]
+; GFX8-NEXT:    v_cndmask_b32_e64 v30, 0, v30, s[42:43]
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_maximum_v16f64:
@@ -2419,117 +2409,117 @@ define <16 x double> @v_maximum_v16f64(<16 x double> %src0, <16 x double> %src1)
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:8
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:4
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[31:32]
 ; GFX900-NEXT:    v_max_f64 v[0:1], v[0:1], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:16
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:12
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[31:32]
 ; GFX900-NEXT:    v_max_f64 v[2:3], v[2:3], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:24
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:20
-; GFX900-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[4:5]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[31:32]
 ; GFX900-NEXT:    v_max_f64 v[4:5], v[4:5], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:32
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:28
-; GFX900-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s[6:7]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[31:32]
 ; GFX900-NEXT:    v_max_f64 v[6:7], v[6:7], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:36
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:40
-; GFX900-NEXT:    v_cndmask_b32_e64 v6, v6, 0, s[8:9]
+; GFX900-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s[8:9]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[10:11], v[8:9], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[10:11], v[8:9], v[31:32]
 ; GFX900-NEXT:    v_max_f64 v[8:9], v[8:9], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:48
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:44
-; GFX900-NEXT:    v_cndmask_b32_e64 v8, v8, 0, s[10:11]
+; GFX900-NEXT:    v_cndmask_b32_e64 v8, 0, v8, s[10:11]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[12:13], v[10:11], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[12:13], v[10:11], v[31:32]
 ; GFX900-NEXT:    v_max_f64 v[10:11], v[10:11], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:56
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:52
-; GFX900-NEXT:    v_cndmask_b32_e64 v10, v10, 0, s[12:13]
+; GFX900-NEXT:    v_cndmask_b32_e64 v10, 0, v10, s[12:13]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[14:15], v[12:13], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[14:15], v[12:13], v[31:32]
 ; GFX900-NEXT:    v_max_f64 v[12:13], v[12:13], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:64
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:60
-; GFX900-NEXT:    v_cndmask_b32_e64 v12, v12, 0, s[14:15]
+; GFX900-NEXT:    v_cndmask_b32_e64 v12, 0, v12, s[14:15]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[16:17], v[14:15], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[16:17], v[14:15], v[31:32]
 ; GFX900-NEXT:    v_max_f64 v[14:15], v[14:15], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:68
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:72
-; GFX900-NEXT:    v_cndmask_b32_e64 v14, v14, 0, s[16:17]
+; GFX900-NEXT:    v_cndmask_b32_e64 v14, 0, v14, s[16:17]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[18:19], v[16:17], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[18:19], v[16:17], v[31:32]
 ; GFX900-NEXT:    v_max_f64 v[16:17], v[16:17], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:80
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:76
-; GFX900-NEXT:    v_cndmask_b32_e64 v16, v16, 0, s[18:19]
+; GFX900-NEXT:    v_cndmask_b32_e64 v16, 0, v16, s[18:19]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[20:21], v[18:19], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[20:21], v[18:19], v[31:32]
 ; GFX900-NEXT:    v_max_f64 v[18:19], v[18:19], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:88
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:84
-; GFX900-NEXT:    v_cndmask_b32_e64 v18, v18, 0, s[20:21]
+; GFX900-NEXT:    v_cndmask_b32_e64 v18, 0, v18, s[20:21]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[22:23], v[20:21], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[22:23], v[20:21], v[31:32]
 ; GFX900-NEXT:    v_max_f64 v[20:21], v[20:21], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:96
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:92
-; GFX900-NEXT:    v_cndmask_b32_e64 v20, v20, 0, s[22:23]
+; GFX900-NEXT:    v_cndmask_b32_e64 v20, 0, v20, s[22:23]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[24:25], v[22:23], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[24:25], v[22:23], v[31:32]
 ; GFX900-NEXT:    v_max_f64 v[22:23], v[22:23], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:100
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:104
-; GFX900-NEXT:    v_cndmask_b32_e64 v22, v22, 0, s[24:25]
+; GFX900-NEXT:    v_cndmask_b32_e64 v22, 0, v22, s[24:25]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[26:27], v[24:25], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[26:27], v[24:25], v[31:32]
 ; GFX900-NEXT:    v_max_f64 v[24:25], v[24:25], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:112
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:108
-; GFX900-NEXT:    v_cndmask_b32_e64 v24, v24, 0, s[26:27]
+; GFX900-NEXT:    v_cndmask_b32_e64 v24, 0, v24, s[26:27]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[28:29], v[26:27], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[28:29], v[26:27], v[31:32]
 ; GFX900-NEXT:    v_max_f64 v[26:27], v[26:27], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:120
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:116
-; GFX900-NEXT:    v_cndmask_b32_e64 v26, v26, 0, s[28:29]
+; GFX900-NEXT:    v_cndmask_b32_e64 v26, 0, v26, s[28:29]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[40:41], v[28:29], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[40:41], v[28:29], v[31:32]
 ; GFX900-NEXT:    v_max_f64 v[28:29], v[28:29], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32
 ; GFX900-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:128
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:124
-; GFX900-NEXT:    v_cndmask_b32_e64 v28, v28, 0, s[40:41]
+; GFX900-NEXT:    v_cndmask_b32_e64 v28, 0, v28, s[40:41]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[42:43], v[30:31], v[32:33]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[42:43], v[30:31], v[32:33]
 ; GFX900-NEXT:    v_max_f64 v[30:31], v[30:31], v[32:33]
 ; GFX900-NEXT:    v_mov_b32_e32 v32, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v1, v32, vcc
-; GFX900-NEXT:    v_cndmask_b32_e64 v3, v3, v32, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v5, v5, v32, s[6:7]
-; GFX900-NEXT:    v_cndmask_b32_e64 v7, v7, v32, s[8:9]
-; GFX900-NEXT:    v_cndmask_b32_e64 v9, v9, v32, s[10:11]
-; GFX900-NEXT:    v_cndmask_b32_e64 v11, v11, v32, s[12:13]
-; GFX900-NEXT:    v_cndmask_b32_e64 v13, v13, v32, s[14:15]
-; GFX900-NEXT:    v_cndmask_b32_e64 v15, v15, v32, s[16:17]
-; GFX900-NEXT:    v_cndmask_b32_e64 v17, v17, v32, s[18:19]
-; GFX900-NEXT:    v_cndmask_b32_e64 v19, v19, v32, s[20:21]
-; GFX900-NEXT:    v_cndmask_b32_e64 v21, v21, v32, s[22:23]
-; GFX900-NEXT:    v_cndmask_b32_e64 v23, v23, v32, s[24:25]
-; GFX900-NEXT:    v_cndmask_b32_e64 v25, v25, v32, s[26:27]
-; GFX900-NEXT:    v_cndmask_b32_e64 v27, v27, v32, s[28:29]
-; GFX900-NEXT:    v_cndmask_b32_e64 v29, v29, v32, s[40:41]
-; GFX900-NEXT:    v_cndmask_b32_e64 v31, v31, v32, s[42:43]
-; GFX900-NEXT:    v_cndmask_b32_e64 v30, v30, 0, s[42:43]
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v32, v1, vcc
+; GFX900-NEXT:    v_cndmask_b32_e64 v3, v32, v3, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v5, v32, v5, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e64 v7, v32, v7, s[8:9]
+; GFX900-NEXT:    v_cndmask_b32_e64 v9, v32, v9, s[10:11]
+; GFX900-NEXT:    v_cndmask_b32_e64 v11, v32, v11, s[12:13]
+; GFX900-NEXT:    v_cndmask_b32_e64 v13, v32, v13, s[14:15]
+; GFX900-NEXT:    v_cndmask_b32_e64 v15, v32, v15, s[16:17]
+; GFX900-NEXT:    v_cndmask_b32_e64 v17, v32, v17, s[18:19]
+; GFX900-NEXT:    v_cndmask_b32_e64 v19, v32, v19, s[20:21]
+; GFX900-NEXT:    v_cndmask_b32_e64 v21, v32, v21, s[22:23]
+; GFX900-NEXT:    v_cndmask_b32_e64 v23, v32, v23, s[24:25]
+; GFX900-NEXT:    v_cndmask_b32_e64 v25, v32, v25, s[26:27]
+; GFX900-NEXT:    v_cndmask_b32_e64 v27, v32, v27, s[28:29]
+; GFX900-NEXT:    v_cndmask_b32_e64 v29, v32, v29, s[40:41]
+; GFX900-NEXT:    v_cndmask_b32_e64 v31, v32, v31, s[42:43]
+; GFX900-NEXT:    v_cndmask_b32_e64 v30, 0, v30, s[42:43]
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_maximum_v16f64:
@@ -2580,107 +2570,107 @@ define <16 x double> @v_maximum_v16f64(<16 x double> %src0, <16 x double> %src1)
 ; GFX950-NEXT:    scratch_load_dword v32, off, s32 offset:100
 ; GFX950-NEXT:    s_waitcnt vmcnt(25)
 ; GFX950-NEXT:    v_max_f64 v[58:59], v[0:1], v[34:35]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[34:35]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[34:35]
 ; GFX950-NEXT:    scratch_load_dword v35, off, s32 offset:112
 ; GFX950-NEXT:    scratch_load_dword v34, off, s32 offset:108
 ; GFX950-NEXT:    s_waitcnt vmcnt(25)
 ; GFX950-NEXT:    v_max_f64 v[60:61], v[2:3], v[36:37]
-; GFX950-NEXT:    v_cmp_u_f64_e64 s[0:1], v[2:3], v[36:37]
+; GFX950-NEXT:    v_cmp_o_f64_e64 s[0:1], v[2:3], v[36:37]
 ; GFX950-NEXT:    scratch_load_dword v37, off, s32 offset:120
 ; GFX950-NEXT:    scratch_load_dword v36, off, s32 offset:116
 ; GFX950-NEXT:    s_waitcnt vmcnt(25)
 ; GFX950-NEXT:    v_max_f64 v[62:63], v[4:5], v[38:39]
-; GFX950-NEXT:    v_cmp_u_f64_e64 s[2:3], v[4:5], v[38:39]
+; GFX950-NEXT:    v_cmp_o_f64_e64 s[2:3], v[4:5], v[38:39]
 ; GFX950-NEXT:    scratch_load_dword v39, off, s32 offset:128
 ; GFX950-NEXT:    scratch_load_dword v38, off, s32 offset:124
 ; GFX950-NEXT:    v_mov_b32_e32 v2, 0x7ff80000
 ; GFX950-NEXT:    s_waitcnt vmcnt(25)
 ; GFX950-NEXT:    v_max_f64 v[0:1], v[6:7], v[56:57]
-; GFX950-NEXT:    v_cmp_u_f64_e64 s[4:5], v[6:7], v[56:57]
+; GFX950-NEXT:    v_cmp_o_f64_e64 s[4:5], v[6:7], v[56:57]
 ; GFX950-NEXT:    s_waitcnt vmcnt(23)
 ; GFX950-NEXT:    v_max_f64 v[56:57], v[8:9], v[46:47]
-; GFX950-NEXT:    v_cndmask_b32_e64 v58, v58, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v59, v59, v2, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[8:9], v[46:47]
-; GFX950-NEXT:    v_cndmask_b32_e64 v6, v0, 0, s[4:5]
-; GFX950-NEXT:    v_cndmask_b32_e64 v7, v1, v2, s[4:5]
-; GFX950-NEXT:    v_cndmask_b32_e64 v8, v56, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v9, v57, v2, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v58, 0, v58, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v59, v2, v59, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[8:9], v[46:47]
+; GFX950-NEXT:    v_cndmask_b32_e64 v6, 0, v0, s[4:5]
+; GFX950-NEXT:    v_cndmask_b32_e64 v7, v2, v1, s[4:5]
+; GFX950-NEXT:    v_cndmask_b32_e32 v8, 0, v56, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v9, v2, v57, vcc
 ; GFX950-NEXT:    s_waitcnt vmcnt(21)
 ; GFX950-NEXT:    v_max_f64 v[0:1], v[10:11], v[44:45]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[10:11], v[44:45]
-; GFX950-NEXT:    v_cndmask_b32_e64 v60, v60, 0, s[0:1]
-; GFX950-NEXT:    v_cndmask_b32_e64 v3, v61, v2, s[0:1]
-; GFX950-NEXT:    v_cndmask_b32_e64 v10, v0, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v11, v1, v2, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[10:11], v[44:45]
+; GFX950-NEXT:    v_cndmask_b32_e64 v60, 0, v60, s[0:1]
+; GFX950-NEXT:    v_cndmask_b32_e64 v3, v2, v61, s[0:1]
+; GFX950-NEXT:    v_cndmask_b32_e32 v10, 0, v0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v11, v2, v1, vcc
 ; GFX950-NEXT:    s_waitcnt vmcnt(19)
 ; GFX950-NEXT:    v_max_f64 v[0:1], v[12:13], v[42:43]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[12:13], v[42:43]
-; GFX950-NEXT:    v_cndmask_b32_e64 v4, v62, 0, s[2:3]
-; GFX950-NEXT:    v_cndmask_b32_e64 v5, v63, v2, s[2:3]
-; GFX950-NEXT:    v_cndmask_b32_e64 v12, v0, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v13, v1, v2, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[12:13], v[42:43]
+; GFX950-NEXT:    v_cndmask_b32_e64 v4, 0, v62, s[2:3]
+; GFX950-NEXT:    v_cndmask_b32_e64 v5, v2, v63, s[2:3]
+; GFX950-NEXT:    v_cndmask_b32_e32 v12, 0, v0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v13, v2, v1, vcc
 ; GFX950-NEXT:    s_waitcnt vmcnt(17)
 ; GFX950-NEXT:    v_max_f64 v[0:1], v[14:15], v[40:41]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[14:15], v[40:41]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[14:15], v[40:41]
 ; GFX950-NEXT:    v_accvgpr_read_b32 v63, a15 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_read_b32 v62, a14 ; Reload Reuse
-; GFX950-NEXT:    v_cndmask_b32_e64 v14, v0, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v15, v1, v2, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v14, 0, v0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v15, v2, v1, vcc
 ; GFX950-NEXT:    s_waitcnt vmcnt(15)
 ; GFX950-NEXT:    v_max_f64 v[0:1], v[16:17], v[54:55]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[16:17], v[54:55]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[16:17], v[54:55]
 ; GFX950-NEXT:    v_accvgpr_read_b32 v61, a13 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_read_b32 v57, a9 ; Reload Reuse
-; GFX950-NEXT:    v_cndmask_b32_e64 v16, v0, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v17, v1, v2, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v16, 0, v0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v17, v2, v1, vcc
 ; GFX950-NEXT:    s_waitcnt vmcnt(13)
 ; GFX950-NEXT:    v_max_f64 v[0:1], v[18:19], v[52:53]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[18:19], v[52:53]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[18:19], v[52:53]
 ; GFX950-NEXT:    v_accvgpr_read_b32 v56, a8 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_read_b32 v47, a7 ; Reload Reuse
-; GFX950-NEXT:    v_cndmask_b32_e64 v18, v0, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v19, v1, v2, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v18, 0, v0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v19, v2, v1, vcc
 ; GFX950-NEXT:    s_waitcnt vmcnt(11)
 ; GFX950-NEXT:    v_max_f64 v[0:1], v[20:21], v[50:51]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[20:21], v[50:51]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[20:21], v[50:51]
 ; GFX950-NEXT:    v_accvgpr_read_b32 v46, a6 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_read_b32 v45, a5 ; Reload Reuse
-; GFX950-NEXT:    v_cndmask_b32_e64 v20, v0, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v21, v1, v2, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v20, 0, v0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v21, v2, v1, vcc
 ; GFX950-NEXT:    s_waitcnt vmcnt(9)
 ; GFX950-NEXT:    v_max_f64 v[0:1], v[22:23], v[48:49]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[22:23], v[48:49]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[22:23], v[48:49]
 ; GFX950-NEXT:    v_accvgpr_read_b32 v44, a4 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_read_b32 v43, a3 ; Reload Reuse
-; GFX950-NEXT:    v_cndmask_b32_e64 v22, v0, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v23, v1, v2, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v22, 0, v0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v23, v2, v1, vcc
 ; GFX950-NEXT:    s_waitcnt vmcnt(6)
 ; GFX950-NEXT:    v_max_f64 v[0:1], v[24:25], v[32:33]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[24:25], v[32:33]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[24:25], v[32:33]
 ; GFX950-NEXT:    v_accvgpr_read_b32 v42, a2 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_read_b32 v41, a1 ; Reload Reuse
-; GFX950-NEXT:    v_cndmask_b32_e64 v24, v0, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v25, v1, v2, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v24, 0, v0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v25, v2, v1, vcc
 ; GFX950-NEXT:    v_accvgpr_read_b32 v40, a0 ; Reload Reuse
 ; GFX950-NEXT:    s_waitcnt vmcnt(4)
 ; GFX950-NEXT:    v_max_f64 v[0:1], v[26:27], v[34:35]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[26:27], v[34:35]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[26:27], v[34:35]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v26, v0, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v27, v1, v2, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v26, 0, v0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v27, v2, v1, vcc
 ; GFX950-NEXT:    s_waitcnt vmcnt(2)
 ; GFX950-NEXT:    v_max_f64 v[0:1], v[28:29], v[36:37]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[28:29], v[36:37]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[28:29], v[36:37]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v28, v0, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v29, v1, v2, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v28, 0, v0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v29, v2, v1, vcc
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_max_f64 v[0:1], v[30:31], v[38:39]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[30:31], v[38:39]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[30:31], v[38:39]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v30, v0, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v31, v1, v2, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v30, 0, v0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v31, v2, v1, vcc
 ; GFX950-NEXT:    v_mov_b32_e32 v0, v58
 ; GFX950-NEXT:    v_mov_b32_e32 v1, v59
 ; GFX950-NEXT:    v_mov_b32_e32 v2, v60
@@ -2720,13 +2710,13 @@ define <16 x double> @v_maximum_v16f64(<16 x double> %src0, <16 x double> %src1)
 ; GFX10-NEXT:    buffer_load_dword v51, off, s[0:3], s32 offset:72
 ; GFX10-NEXT:    s_waitcnt vmcnt(23)
 ; GFX10-NEXT:    v_max_f64 v[82:83], v[0:1], v[31:32]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[31:32]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[31:32]
 ; GFX10-NEXT:    s_waitcnt vmcnt(21)
 ; GFX10-NEXT:    v_max_f64 v[84:85], v[2:3], v[33:34]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[2:3], v[33:34]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[2:3], v[33:34]
 ; GFX10-NEXT:    s_waitcnt vmcnt(19)
 ; GFX10-NEXT:    v_max_f64 v[32:33], v[4:5], v[35:36]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s5, v[4:5], v[35:36]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s5, v[4:5], v[35:36]
 ; GFX10-NEXT:    s_clause 0x7
 ; GFX10-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:112
 ; GFX10-NEXT:    buffer_load_dword v67, off, s[0:3], s32 offset:104
@@ -2738,74 +2728,74 @@ define <16 x double> @v_maximum_v16f64(<16 x double> %src0, <16 x double> %src1)
 ; GFX10-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:124
 ; GFX10-NEXT:    s_waitcnt vmcnt(24)
 ; GFX10-NEXT:    v_max_f64 v[34:35], v[6:7], v[48:49]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s6, v[6:7], v[48:49]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s6, v[6:7], v[48:49]
 ; GFX10-NEXT:    s_waitcnt vmcnt(21)
-; GFX10-NEXT:    v_cmp_u_f64_e64 s10, v[14:15], v[52:53]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s10, v[14:15], v[52:53]
 ; GFX10-NEXT:    s_waitcnt vmcnt(19)
-; GFX10-NEXT:    v_cmp_u_f64_e64 s9, v[12:13], v[54:55]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s9, v[12:13], v[54:55]
 ; GFX10-NEXT:    s_waitcnt vmcnt(17)
-; GFX10-NEXT:    v_cmp_u_f64_e64 s8, v[10:11], v[64:65]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s8, v[10:11], v[64:65]
 ; GFX10-NEXT:    s_waitcnt vmcnt(16)
 ; GFX10-NEXT:    v_max_f64 v[48:49], v[8:9], v[37:38]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s7, v[8:9], v[37:38]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s7, v[8:9], v[37:38]
 ; GFX10-NEXT:    v_max_f64 v[36:37], v[10:11], v[64:65]
 ; GFX10-NEXT:    v_max_f64 v[38:39], v[12:13], v[54:55]
 ; GFX10-NEXT:    v_max_f64 v[54:55], v[14:15], v[52:53]
 ; GFX10-NEXT:    s_waitcnt vmcnt(11)
 ; GFX10-NEXT:    v_max_f64 v[64:65], v[20:21], v[70:71]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s13, v[20:21], v[70:71]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s13, v[20:21], v[70:71]
 ; GFX10-NEXT:    s_waitcnt vmcnt(9)
-; GFX10-NEXT:    v_cmp_u_f64_e64 s12, v[18:19], v[80:81]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s12, v[18:19], v[80:81]
 ; GFX10-NEXT:    s_waitcnt vmcnt(8)
 ; GFX10-NEXT:    v_max_f64 v[52:53], v[16:17], v[50:51]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s11, v[16:17], v[50:51]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s11, v[16:17], v[50:51]
 ; GFX10-NEXT:    v_max_f64 v[50:51], v[18:19], v[80:81]
 ; GFX10-NEXT:    v_max_f64 v[70:71], v[22:23], v[68:69]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s14, v[22:23], v[68:69]
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, v34, 0, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v7, v35, 0x7ff80000, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v8, v48, 0, s7
-; GFX10-NEXT:    v_cndmask_b32_e64 v9, v49, 0x7ff80000, s7
-; GFX10-NEXT:    v_cndmask_b32_e64 v10, v36, 0, s8
-; GFX10-NEXT:    v_cndmask_b32_e64 v11, v37, 0x7ff80000, s8
-; GFX10-NEXT:    v_cndmask_b32_e64 v12, v38, 0, s9
-; GFX10-NEXT:    v_cndmask_b32_e64 v13, v39, 0x7ff80000, s9
-; GFX10-NEXT:    v_cndmask_b32_e64 v14, v54, 0, s10
-; GFX10-NEXT:    v_cndmask_b32_e64 v15, v55, 0x7ff80000, s10
-; GFX10-NEXT:    v_cndmask_b32_e64 v16, v52, 0, s11
-; GFX10-NEXT:    v_cndmask_b32_e64 v17, v53, 0x7ff80000, s11
-; GFX10-NEXT:    v_cndmask_b32_e64 v18, v50, 0, s12
-; GFX10-NEXT:    v_cndmask_b32_e64 v19, v51, 0x7ff80000, s12
-; GFX10-NEXT:    v_cndmask_b32_e64 v20, v64, 0, s13
-; GFX10-NEXT:    v_cndmask_b32_e64 v21, v65, 0x7ff80000, s13
-; GFX10-NEXT:    v_cndmask_b32_e64 v22, v70, 0, s14
-; GFX10-NEXT:    v_cndmask_b32_e64 v23, v71, 0x7ff80000, s14
+; GFX10-NEXT:    v_cmp_o_f64_e64 s14, v[22:23], v[68:69]
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, 0, v34, s6
+; GFX10-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v35, s6
+; GFX10-NEXT:    v_cndmask_b32_e64 v8, 0, v48, s7
+; GFX10-NEXT:    v_cndmask_b32_e64 v9, 0x7ff80000, v49, s7
+; GFX10-NEXT:    v_cndmask_b32_e64 v10, 0, v36, s8
+; GFX10-NEXT:    v_cndmask_b32_e64 v11, 0x7ff80000, v37, s8
+; GFX10-NEXT:    v_cndmask_b32_e64 v12, 0, v38, s9
+; GFX10-NEXT:    v_cndmask_b32_e64 v13, 0x7ff80000, v39, s9
+; GFX10-NEXT:    v_cndmask_b32_e64 v14, 0, v54, s10
+; GFX10-NEXT:    v_cndmask_b32_e64 v15, 0x7ff80000, v55, s10
+; GFX10-NEXT:    v_cndmask_b32_e64 v16, 0, v52, s11
+; GFX10-NEXT:    v_cndmask_b32_e64 v17, 0x7ff80000, v53, s11
+; GFX10-NEXT:    v_cndmask_b32_e64 v18, 0, v50, s12
+; GFX10-NEXT:    v_cndmask_b32_e64 v19, 0x7ff80000, v51, s12
+; GFX10-NEXT:    v_cndmask_b32_e64 v20, 0, v64, s13
+; GFX10-NEXT:    v_cndmask_b32_e64 v21, 0x7ff80000, v65, s13
+; GFX10-NEXT:    v_cndmask_b32_e64 v22, 0, v70, s14
+; GFX10-NEXT:    v_cndmask_b32_e64 v23, 0x7ff80000, v71, s14
 ; GFX10-NEXT:    s_waitcnt vmcnt(6)
 ; GFX10-NEXT:    v_max_f64 v[68:69], v[24:25], v[66:67]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s15, v[24:25], v[66:67]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s15, v[24:25], v[66:67]
 ; GFX10-NEXT:    s_waitcnt vmcnt(5)
 ; GFX10-NEXT:    v_max_f64 v[66:67], v[26:27], v[0:1]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s16, v[26:27], v[0:1]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s16, v[26:27], v[0:1]
 ; GFX10-NEXT:    s_waitcnt vmcnt(3)
 ; GFX10-NEXT:    v_max_f64 v[80:81], v[28:29], v[2:3]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s17, v[28:29], v[2:3]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s17, v[28:29], v[2:3]
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-NEXT:    v_max_f64 v[86:87], v[30:31], v[4:5]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s18, v[30:31], v[4:5]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v82, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v83, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v84, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v85, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v32, 0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v33, 0x7ff80000, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v24, v68, 0, s15
-; GFX10-NEXT:    v_cndmask_b32_e64 v25, v69, 0x7ff80000, s15
-; GFX10-NEXT:    v_cndmask_b32_e64 v26, v66, 0, s16
-; GFX10-NEXT:    v_cndmask_b32_e64 v27, v67, 0x7ff80000, s16
-; GFX10-NEXT:    v_cndmask_b32_e64 v28, v80, 0, s17
-; GFX10-NEXT:    v_cndmask_b32_e64 v29, v81, 0x7ff80000, s17
-; GFX10-NEXT:    v_cndmask_b32_e64 v30, v86, 0, s18
-; GFX10-NEXT:    v_cndmask_b32_e64 v31, v87, 0x7ff80000, s18
+; GFX10-NEXT:    v_cmp_o_f64_e64 s18, v[30:31], v[4:5]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v82, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v83, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v84, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v85, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, v32, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v33, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v24, 0, v68, s15
+; GFX10-NEXT:    v_cndmask_b32_e64 v25, 0x7ff80000, v69, s15
+; GFX10-NEXT:    v_cndmask_b32_e64 v26, 0, v66, s16
+; GFX10-NEXT:    v_cndmask_b32_e64 v27, 0x7ff80000, v67, s16
+; GFX10-NEXT:    v_cndmask_b32_e64 v28, 0, v80, s17
+; GFX10-NEXT:    v_cndmask_b32_e64 v29, 0x7ff80000, v81, s17
+; GFX10-NEXT:    v_cndmask_b32_e64 v30, 0, v86, s18
+; GFX10-NEXT:    v_cndmask_b32_e64 v31, 0x7ff80000, v87, s18
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_v16f64:
@@ -2847,84 +2837,83 @@ define <16 x double> @v_maximum_v16f64(<16 x double> %src0, <16 x double> %src1)
 ; GFX11-NEXT:    scratch_load_b32 v86, off, s32 offset:124
 ; GFX11-NEXT:    s_waitcnt vmcnt(30)
 ; GFX11-NEXT:    v_max_f64 v[96:97], v[0:1], v[32:33]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[32:33]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[32:33]
 ; GFX11-NEXT:    s_waitcnt vmcnt(28)
 ; GFX11-NEXT:    v_max_f64 v[32:33], v[2:3], v[34:35]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[2:3], v[34:35]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[2:3], v[34:35]
 ; GFX11-NEXT:    s_waitcnt vmcnt(26)
 ; GFX11-NEXT:    v_max_f64 v[34:35], v[4:5], v[36:37]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s1, v[4:5], v[36:37]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s1, v[4:5], v[36:37]
 ; GFX11-NEXT:    s_waitcnt vmcnt(24)
 ; GFX11-NEXT:    v_max_f64 v[36:37], v[6:7], v[38:39]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s2, v[6:7], v[38:39]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s2, v[6:7], v[38:39]
 ; GFX11-NEXT:    s_waitcnt vmcnt(22)
 ; GFX11-NEXT:    v_max_f64 v[38:39], v[8:9], v[48:49]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s3, v[8:9], v[48:49]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s3, v[8:9], v[48:49]
 ; GFX11-NEXT:    s_waitcnt vmcnt(20)
 ; GFX11-NEXT:    v_max_f64 v[48:49], v[10:11], v[50:51]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s4, v[10:11], v[50:51]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s4, v[10:11], v[50:51]
 ; GFX11-NEXT:    s_waitcnt vmcnt(18)
 ; GFX11-NEXT:    v_max_f64 v[50:51], v[12:13], v[52:53]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s5, v[12:13], v[52:53]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s5, v[12:13], v[52:53]
 ; GFX11-NEXT:    s_waitcnt vmcnt(16)
 ; GFX11-NEXT:    v_max_f64 v[52:53], v[14:15], v[54:55]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s6, v[14:15], v[54:55]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s6, v[14:15], v[54:55]
 ; GFX11-NEXT:    s_waitcnt vmcnt(14)
 ; GFX11-NEXT:    v_max_f64 v[54:55], v[16:17], v[64:65]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s7, v[16:17], v[64:65]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s7, v[16:17], v[64:65]
 ; GFX11-NEXT:    s_waitcnt vmcnt(12)
 ; GFX11-NEXT:    v_max_f64 v[64:65], v[18:19], v[66:67]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s8, v[18:19], v[66:67]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s8, v[18:19], v[66:67]
 ; GFX11-NEXT:    s_waitcnt vmcnt(10)
 ; GFX11-NEXT:    v_max_f64 v[66:67], v[20:21], v[68:69]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s9, v[20:21], v[68:69]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s9, v[20:21], v[68:69]
 ; GFX11-NEXT:    s_waitcnt vmcnt(8)
 ; GFX11-NEXT:    v_max_f64 v[68:69], v[22:23], v[70:71]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s10, v[22:23], v[70:71]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s10, v[22:23], v[70:71]
 ; GFX11-NEXT:    s_waitcnt vmcnt(6)
 ; GFX11-NEXT:    v_max_f64 v[70:71], v[24:25], v[80:81]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s11, v[24:25], v[80:81]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s11, v[24:25], v[80:81]
 ; GFX11-NEXT:    s_waitcnt vmcnt(4)
 ; GFX11-NEXT:    v_max_f64 v[80:81], v[26:27], v[82:83]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s12, v[26:27], v[82:83]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s12, v[26:27], v[82:83]
 ; GFX11-NEXT:    s_waitcnt vmcnt(2)
 ; GFX11-NEXT:    v_max_f64 v[82:83], v[28:29], v[84:85]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s13, v[28:29], v[84:85]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s13, v[28:29], v[84:85]
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    v_max_f64 v[84:85], v[30:31], v[86:87]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s14, v[30:31], v[86:87]
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v96, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v97, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v32, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v33, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v34, 0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v35, 0x7ff80000, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v6, v36, 0, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v7, v37, 0x7ff80000, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v8, v38, 0, s3
-; GFX11-NEXT:    v_cndmask_b32_e64 v9, v39, 0x7ff80000, s3
-; GFX11-NEXT:    v_cndmask_b32_e64 v10, v48, 0, s4
-; GFX11-NEXT:    v_cndmask_b32_e64 v11, v49, 0x7ff80000, s4
-; GFX11-NEXT:    v_cndmask_b32_e64 v12, v50, 0, s5
-; GFX11-NEXT:    v_cndmask_b32_e64 v13, v51, 0x7ff80000, s5
-; GFX11-NEXT:    v_cndmask_b32_e64 v14, v52, 0, s6
-; GFX11-NEXT:    v_cndmask_b32_e64 v15, v53, 0x7ff80000, s6
-; GFX11-NEXT:    v_cndmask_b32_e64 v16, v54, 0, s7
-; GFX11-NEXT:    v_cndmask_b32_e64 v17, v55, 0x7ff80000, s7
-; GFX11-NEXT:    v_cndmask_b32_e64 v18, v64, 0, s8
-; GFX11-NEXT:    v_cndmask_b32_e64 v19, v65, 0x7ff80000, s8
-; GFX11-NEXT:    v_cndmask_b32_e64 v20, v66, 0, s9
-; GFX11-NEXT:    v_cndmask_b32_e64 v21, v67, 0x7ff80000, s9
-; GFX11-NEXT:    v_cndmask_b32_e64 v22, v68, 0, s10
-; GFX11-NEXT:    v_cndmask_b32_e64 v23, v69, 0x7ff80000, s10
-; GFX11-NEXT:    v_cndmask_b32_e64 v24, v70, 0, s11
-; GFX11-NEXT:    v_cndmask_b32_e64 v25, v71, 0x7ff80000, s11
-; GFX11-NEXT:    v_cndmask_b32_e64 v26, v80, 0, s12
-; GFX11-NEXT:    v_cndmask_b32_e64 v27, v81, 0x7ff80000, s12
-; GFX11-NEXT:    v_cndmask_b32_e64 v28, v82, 0, s13
-; GFX11-NEXT:    v_cndmask_b32_e64 v29, v83, 0x7ff80000, s13
-; GFX11-NEXT:    v_cndmask_b32_e64 v30, v84, 0, s14
-; GFX11-NEXT:    v_cndmask_b32_e64 v31, v85, 0x7ff80000, s14
+; GFX11-NEXT:    v_cmp_o_f64_e64 s14, v[30:31], v[86:87]
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v96 :: v_dual_cndmask_b32 v1, 0x7ff80000, v97
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v32, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v33, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v4, 0, v34, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v35, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v6, 0, v36, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v37, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v8, 0, v38, s3
+; GFX11-NEXT:    v_cndmask_b32_e64 v9, 0x7ff80000, v39, s3
+; GFX11-NEXT:    v_cndmask_b32_e64 v10, 0, v48, s4
+; GFX11-NEXT:    v_cndmask_b32_e64 v11, 0x7ff80000, v49, s4
+; GFX11-NEXT:    v_cndmask_b32_e64 v12, 0, v50, s5
+; GFX11-NEXT:    v_cndmask_b32_e64 v13, 0x7ff80000, v51, s5
+; GFX11-NEXT:    v_cndmask_b32_e64 v14, 0, v52, s6
+; GFX11-NEXT:    v_cndmask_b32_e64 v15, 0x7ff80000, v53, s6
+; GFX11-NEXT:    v_cndmask_b32_e64 v16, 0, v54, s7
+; GFX11-NEXT:    v_cndmask_b32_e64 v17, 0x7ff80000, v55, s7
+; GFX11-NEXT:    v_cndmask_b32_e64 v18, 0, v64, s8
+; GFX11-NEXT:    v_cndmask_b32_e64 v19, 0x7ff80000, v65, s8
+; GFX11-NEXT:    v_cndmask_b32_e64 v20, 0, v66, s9
+; GFX11-NEXT:    v_cndmask_b32_e64 v21, 0x7ff80000, v67, s9
+; GFX11-NEXT:    v_cndmask_b32_e64 v22, 0, v68, s10
+; GFX11-NEXT:    v_cndmask_b32_e64 v23, 0x7ff80000, v69, s10
+; GFX11-NEXT:    v_cndmask_b32_e64 v24, 0, v70, s11
+; GFX11-NEXT:    v_cndmask_b32_e64 v25, 0x7ff80000, v71, s11
+; GFX11-NEXT:    v_cndmask_b32_e64 v26, 0, v80, s12
+; GFX11-NEXT:    v_cndmask_b32_e64 v27, 0x7ff80000, v81, s12
+; GFX11-NEXT:    v_cndmask_b32_e64 v28, 0, v82, s13
+; GFX11-NEXT:    v_cndmask_b32_e64 v29, 0x7ff80000, v83, s13
+; GFX11-NEXT:    v_cndmask_b32_e64 v30, 0, v84, s14
+; GFX11-NEXT:    v_cndmask_b32_e64 v31, 0x7ff80000, v85, s14
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_maximum_v16f64:

--- a/llvm/test/CodeGen/AMDGPU/llvm.minimum.f64.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.minimum.f64.ll
@@ -13,60 +13,59 @@ define double @v_minimum_f64(double %src0, double %src1) #0 {
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX7-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_minimum_f64:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX8-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_minimum_f64:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX900-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_minimum_f64:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX950-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_f64:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v5, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_f64:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v4 :: v_dual_cndmask_b32 v1, 0x7ff80000, v5
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_minimum_f64:
@@ -143,60 +142,59 @@ define double @v_minimum_f64__nsz(double %src0, double %src1) #0 {
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX7-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_minimum_f64__nsz:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX8-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_minimum_f64__nsz:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX900-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_minimum_f64__nsz:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX950-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_f64__nsz:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v5, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_f64__nsz:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v4 :: v_dual_cndmask_b32 v1, 0x7ff80000, v5
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_minimum_f64__nsz:
@@ -274,10 +272,10 @@ define double @v_minimum_f64__nnan_src0(double %arg0, double %src1) #0 {
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
 ; GFX7-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX7-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_minimum_f64__nnan_src0:
@@ -285,10 +283,10 @@ define double @v_minimum_f64__nnan_src0(double %arg0, double %src1) #0 {
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
 ; GFX8-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX8-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_minimum_f64__nnan_src0:
@@ -296,10 +294,10 @@ define double @v_minimum_f64__nnan_src0(double %arg0, double %src1) #0 {
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
 ; GFX900-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX900-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_minimum_f64__nnan_src0:
@@ -307,11 +305,11 @@ define double @v_minimum_f64__nnan_src0(double %arg0, double %src1) #0 {
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
 ; GFX950-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX950-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_f64__nnan_src0:
@@ -319,9 +317,9 @@ define double @v_minimum_f64__nnan_src0(double %arg0, double %src1) #0 {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
 ; GFX10-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v5, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_f64__nnan_src0:
@@ -330,10 +328,8 @@ define double @v_minimum_f64__nnan_src0(double %arg0, double %src1) #0 {
 ; GFX11-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v4 :: v_dual_cndmask_b32 v1, 0x7ff80000, v5
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_minimum_f64__nnan_src0:
@@ -366,10 +362,10 @@ define double @v_minimum_f64__nnan_src1(double %src0, double %arg1) #0 {
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX7-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX7-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_minimum_f64__nnan_src1:
@@ -377,10 +373,10 @@ define double @v_minimum_f64__nnan_src1(double %src0, double %arg1) #0 {
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX8-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX8-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_minimum_f64__nnan_src1:
@@ -388,10 +384,10 @@ define double @v_minimum_f64__nnan_src1(double %src0, double %arg1) #0 {
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX900-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX900-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_minimum_f64__nnan_src1:
@@ -399,11 +395,11 @@ define double @v_minimum_f64__nnan_src1(double %src0, double %arg1) #0 {
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX950-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX950-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_f64__nnan_src1:
@@ -411,9 +407,9 @@ define double @v_minimum_f64__nnan_src1(double %src0, double %arg1) #0 {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX10-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v5, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_f64__nnan_src1:
@@ -422,10 +418,8 @@ define double @v_minimum_f64__nnan_src1(double %src0, double %arg1) #0 {
 ; GFX11-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v4 :: v_dual_cndmask_b32 v1, 0x7ff80000, v5
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_minimum_f64__nnan_src1:
@@ -459,10 +453,10 @@ define void @s_minimum_f64(double inreg %src0, double inreg %src1) #0 {
 ; GFX7-NEXT:    v_mov_b32_e32 v0, s18
 ; GFX7-NEXT:    v_mov_b32_e32 v1, s19
 ; GFX7-NEXT:    v_min_f64 v[2:3], s[16:17], v[0:1]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, s[16:17], v[0:1]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, s[16:17], v[0:1]
 ; GFX7-NEXT:    v_mov_b32_e32 v4, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v3, v4, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v4, v3, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
 ; GFX7-NEXT:    ;;#ASMSTART
 ; GFX7-NEXT:    ; use v[0:1]
 ; GFX7-NEXT:    ;;#ASMEND
@@ -474,10 +468,10 @@ define void @s_minimum_f64(double inreg %src0, double inreg %src1) #0 {
 ; GFX8-NEXT:    v_mov_b32_e32 v0, s18
 ; GFX8-NEXT:    v_mov_b32_e32 v1, s19
 ; GFX8-NEXT:    v_min_f64 v[2:3], s[16:17], v[0:1]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, s[16:17], v[0:1]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, s[16:17], v[0:1]
 ; GFX8-NEXT:    v_mov_b32_e32 v4, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v3, v4, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v4, v3, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
 ; GFX8-NEXT:    ;;#ASMSTART
 ; GFX8-NEXT:    ; use v[0:1]
 ; GFX8-NEXT:    ;;#ASMEND
@@ -489,10 +483,10 @@ define void @s_minimum_f64(double inreg %src0, double inreg %src1) #0 {
 ; GFX900-NEXT:    v_mov_b32_e32 v0, s18
 ; GFX900-NEXT:    v_mov_b32_e32 v1, s19
 ; GFX900-NEXT:    v_min_f64 v[2:3], s[16:17], v[0:1]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, s[16:17], v[0:1]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, s[16:17], v[0:1]
 ; GFX900-NEXT:    v_mov_b32_e32 v4, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v3, v4, vcc
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v4, v3, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
 ; GFX900-NEXT:    ;;#ASMSTART
 ; GFX900-NEXT:    ; use v[0:1]
 ; GFX900-NEXT:    ;;#ASMEND
@@ -504,10 +498,10 @@ define void @s_minimum_f64(double inreg %src0, double inreg %src1) #0 {
 ; GFX950-NEXT:    v_mov_b64_e32 v[0:1], s[2:3]
 ; GFX950-NEXT:    v_min_f64 v[2:3], s[0:1], v[0:1]
 ; GFX950-NEXT:    v_mov_b32_e32 v4, 0x7ff80000
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, s[0:1], v[0:1]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, s[0:1], v[0:1]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v3, v4, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v4, v3, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; use v[0:1]
 ; GFX950-NEXT:    ;;#ASMEND
@@ -517,9 +511,9 @@ define void @s_minimum_f64(double inreg %src0, double inreg %src1) #0 {
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_min_f64 v[0:1], s[16:17], s[18:19]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, s[16:17], s[18:19]
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s4
+; GFX10-NEXT:    v_cmp_o_f64_e64 vcc_lo, s[16:17], s[18:19]
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v1, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc_lo
 ; GFX10-NEXT:    ;;#ASMSTART
 ; GFX10-NEXT:    ; use v[0:1]
 ; GFX10-NEXT:    ;;#ASMEND
@@ -529,10 +523,9 @@ define void @s_minimum_f64(double inreg %src0, double inreg %src1) #0 {
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_min_f64 v[0:1], s[0:1], s[2:3]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, s[0:1], s[2:3]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s0
+; GFX11-NEXT:    v_cmp_o_f64_e64 vcc_lo, s[0:1], s[2:3]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v1, 0x7ff80000, v1 :: v_dual_cndmask_b32 v0, 0, v0
 ; GFX11-NEXT:    ;;#ASMSTART
 ; GFX11-NEXT:    ; use v[0:1]
 ; GFX11-NEXT:    ;;#ASMEND
@@ -569,85 +562,85 @@ define <2 x double> @v_minimum_v2f64(<2 x double> %src0, <2 x double> %src1) #0 
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_min_f64 v[8:9], v[0:1], v[4:5]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX7-NEXT:    v_min_f64 v[4:5], v[2:3], v[6:7]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[6:7]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[6:7]
 ; GFX7-NEXT:    v_mov_b32_e32 v3, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v9, v3, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v3, v5, v3, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v3, v9, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v3, v3, v5, s[4:5]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_minimum_v2f64:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_min_f64 v[8:9], v[0:1], v[4:5]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX8-NEXT:    v_min_f64 v[4:5], v[2:3], v[6:7]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[6:7]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[6:7]
 ; GFX8-NEXT:    v_mov_b32_e32 v3, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v9, v3, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, v5, v3, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v3, v9, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, v3, v5, s[4:5]
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_minimum_v2f64:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-NEXT:    v_min_f64 v[8:9], v[0:1], v[4:5]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX900-NEXT:    v_min_f64 v[4:5], v[2:3], v[6:7]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[6:7]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[6:7]
 ; GFX900-NEXT:    v_mov_b32_e32 v3, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v9, v3, vcc
-; GFX900-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v3, v5, v3, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v3, v9, vcc
+; GFX900-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v3, v3, v5, s[4:5]
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_minimum_v2f64:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_min_f64 v[8:9], v[0:1], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX950-NEXT:    v_min_f64 v[4:5], v[2:3], v[6:7]
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
 ; GFX950-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v9, v8, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[6:7]
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v8, v9, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[6:7]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v4, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v5, v8, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v4, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v8, v5, vcc
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_v2f64:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_min_f64 v[8:9], v[0:1], v[4:5]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[4:5]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[4:5]
 ; GFX10-NEXT:    v_min_f64 v[4:5], v[2:3], v[6:7]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[2:3], v[6:7]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v9, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v5, 0x7ff80000, s4
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[2:3], v[6:7]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v9, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v5, s4
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_v2f64:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_min_f64 v[8:9], v[0:1], v[4:5]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[4:5]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[4:5]
 ; GFX11-NEXT:    v_min_f64 v[4:5], v[2:3], v[6:7]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[2:3], v[6:7]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v9, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v5, 0x7ff80000, s0
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[2:3], v[6:7]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v8 :: v_dual_cndmask_b32 v1, 0x7ff80000, v9
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v5, s0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_minimum_v2f64:
@@ -733,85 +726,85 @@ define <2 x double> @v_minimum_v2f64__nsz(<2 x double> %src0, <2 x double> %src1
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_min_f64 v[8:9], v[0:1], v[4:5]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX7-NEXT:    v_min_f64 v[4:5], v[2:3], v[6:7]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[6:7]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[6:7]
 ; GFX7-NEXT:    v_mov_b32_e32 v3, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v9, v3, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v3, v5, v3, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v3, v9, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v3, v3, v5, s[4:5]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_minimum_v2f64__nsz:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_min_f64 v[8:9], v[0:1], v[4:5]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX8-NEXT:    v_min_f64 v[4:5], v[2:3], v[6:7]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[6:7]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[6:7]
 ; GFX8-NEXT:    v_mov_b32_e32 v3, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v9, v3, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, v5, v3, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v3, v9, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, v3, v5, s[4:5]
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_minimum_v2f64__nsz:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-NEXT:    v_min_f64 v[8:9], v[0:1], v[4:5]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX900-NEXT:    v_min_f64 v[4:5], v[2:3], v[6:7]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[6:7]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[6:7]
 ; GFX900-NEXT:    v_mov_b32_e32 v3, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v9, v3, vcc
-; GFX900-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v3, v5, v3, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v3, v9, vcc
+; GFX900-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v3, v3, v5, s[4:5]
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_minimum_v2f64__nsz:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_min_f64 v[8:9], v[0:1], v[4:5]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX950-NEXT:    v_min_f64 v[4:5], v[2:3], v[6:7]
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
 ; GFX950-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v9, v8, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[6:7]
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v8, v9, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[6:7]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v4, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v5, v8, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v4, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v8, v5, vcc
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_v2f64__nsz:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_min_f64 v[8:9], v[0:1], v[4:5]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[4:5]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[4:5]
 ; GFX10-NEXT:    v_min_f64 v[4:5], v[2:3], v[6:7]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[2:3], v[6:7]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v9, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v5, 0x7ff80000, s4
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[2:3], v[6:7]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v9, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v5, s4
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_v2f64__nsz:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_min_f64 v[8:9], v[0:1], v[4:5]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[4:5]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[4:5]
 ; GFX11-NEXT:    v_min_f64 v[4:5], v[2:3], v[6:7]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[2:3], v[6:7]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v9, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v5, 0x7ff80000, s0
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[2:3], v[6:7]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v8 :: v_dual_cndmask_b32 v1, 0x7ff80000, v9
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v5, s0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_minimum_v2f64__nsz:
@@ -899,16 +892,16 @@ define void @s_minimum_v2f64(<2 x double> inreg %src0, <2 x double> inreg %src1)
 ; GFX7-NEXT:    v_mov_b32_e32 v0, s22
 ; GFX7-NEXT:    v_mov_b32_e32 v1, s23
 ; GFX7-NEXT:    v_min_f64 v[2:3], s[18:19], v[0:1]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, s[18:19], v[0:1]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, s[18:19], v[0:1]
 ; GFX7-NEXT:    v_mov_b32_e32 v0, s20
 ; GFX7-NEXT:    v_mov_b32_e32 v1, s21
 ; GFX7-NEXT:    v_min_f64 v[4:5], s[16:17], v[0:1]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], s[16:17], v[0:1]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], s[16:17], v[0:1]
 ; GFX7-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v3, v6, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v5, v6, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e32 v3, v6, v3, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v1, v6, v5, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v0, 0, v4, s[4:5]
 ; GFX7-NEXT:    ;;#ASMSTART
 ; GFX7-NEXT:    ; use v[0:3]
 ; GFX7-NEXT:    ;;#ASMEND
@@ -920,16 +913,16 @@ define void @s_minimum_v2f64(<2 x double> inreg %src0, <2 x double> inreg %src1)
 ; GFX8-NEXT:    v_mov_b32_e32 v0, s22
 ; GFX8-NEXT:    v_mov_b32_e32 v1, s23
 ; GFX8-NEXT:    v_min_f64 v[2:3], s[18:19], v[0:1]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, s[18:19], v[0:1]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, s[18:19], v[0:1]
 ; GFX8-NEXT:    v_mov_b32_e32 v0, s20
 ; GFX8-NEXT:    v_mov_b32_e32 v1, s21
 ; GFX8-NEXT:    v_min_f64 v[4:5], s[16:17], v[0:1]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], s[16:17], v[0:1]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], s[16:17], v[0:1]
 ; GFX8-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v3, v6, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v5, v6, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v6, v3, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v1, v6, v5, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v0, 0, v4, s[4:5]
 ; GFX8-NEXT:    ;;#ASMSTART
 ; GFX8-NEXT:    ; use v[0:3]
 ; GFX8-NEXT:    ;;#ASMEND
@@ -941,16 +934,16 @@ define void @s_minimum_v2f64(<2 x double> inreg %src0, <2 x double> inreg %src1)
 ; GFX900-NEXT:    v_mov_b32_e32 v0, s22
 ; GFX900-NEXT:    v_mov_b32_e32 v1, s23
 ; GFX900-NEXT:    v_min_f64 v[2:3], s[18:19], v[0:1]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, s[18:19], v[0:1]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, s[18:19], v[0:1]
 ; GFX900-NEXT:    v_mov_b32_e32 v0, s20
 ; GFX900-NEXT:    v_mov_b32_e32 v1, s21
 ; GFX900-NEXT:    v_min_f64 v[4:5], s[16:17], v[0:1]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[4:5], s[16:17], v[0:1]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[4:5], s[16:17], v[0:1]
 ; GFX900-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e32 v3, v3, v6, vcc
-; GFX900-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e64 v1, v5, v6, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v4, 0, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e32 v3, v6, v3, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
+; GFX900-NEXT:    v_cndmask_b32_e64 v1, v6, v5, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v0, 0, v4, s[4:5]
 ; GFX900-NEXT:    ;;#ASMSTART
 ; GFX900-NEXT:    ; use v[0:3]
 ; GFX900-NEXT:    ;;#ASMEND
@@ -962,15 +955,15 @@ define void @s_minimum_v2f64(<2 x double> inreg %src0, <2 x double> inreg %src1)
 ; GFX950-NEXT:    v_mov_b64_e32 v[0:1], s[18:19]
 ; GFX950-NEXT:    v_min_f64 v[2:3], s[2:3], v[0:1]
 ; GFX950-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, s[2:3], v[0:1]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, s[2:3], v[0:1]
 ; GFX950-NEXT:    v_mov_b64_e32 v[0:1], s[16:17]
 ; GFX950-NEXT:    v_min_f64 v[4:5], s[0:1], v[0:1]
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v3, v6, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, s[0:1], v[0:1]
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v6, v3, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v2, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, s[0:1], v[0:1]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v5, v6, vcc
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v6, v5, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; use v[0:3]
 ; GFX950-NEXT:    ;;#ASMEND
@@ -980,13 +973,13 @@ define void @s_minimum_v2f64(<2 x double> inreg %src0, <2 x double> inreg %src1)
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_min_f64 v[0:1], s[18:19], s[22:23]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, s[18:19], s[22:23]
+; GFX10-NEXT:    v_cmp_o_f64_e64 vcc_lo, s[18:19], s[22:23]
 ; GFX10-NEXT:    v_min_f64 v[4:5], s[16:17], s[20:21]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s5, s[16:17], s[20:21]
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v1, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v0, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, s5
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, s[16:17], s[20:21]
+; GFX10-NEXT:    v_cndmask_b32_e32 v3, 0x7ff80000, v1, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v2, 0, v0, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, 0x7ff80000, v5, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, 0, v4, s4
 ; GFX10-NEXT:    ;;#ASMSTART
 ; GFX10-NEXT:    ; use v[0:3]
 ; GFX10-NEXT:    ;;#ASMEND
@@ -996,14 +989,14 @@ define void @s_minimum_v2f64(<2 x double> inreg %src0, <2 x double> inreg %src1)
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_min_f64 v[0:1], s[2:3], s[18:19]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s2, s[2:3], s[18:19]
+; GFX11-NEXT:    v_cmp_o_f64_e64 vcc_lo, s[2:3], s[18:19]
 ; GFX11-NEXT:    v_min_f64 v[4:5], s[0:1], s[16:17]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, s[0:1], s[16:17]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v1, 0x7ff80000, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v0, 0, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, s0
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, s[0:1], s[16:17]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v3, 0x7ff80000, v1 :: v_dual_cndmask_b32 v2, 0, v0
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, 0x7ff80000, v5, s0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, 0, v4, s0
 ; GFX11-NEXT:    ;;#ASMSTART
 ; GFX11-NEXT:    ; use v[0:3]
 ; GFX11-NEXT:    ;;#ASMEND
@@ -1042,109 +1035,109 @@ define <3 x double> @v_minimum_v3f64(<3 x double> %src0, <3 x double> %src1) #0 
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_min_f64 v[12:13], v[0:1], v[6:7]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[6:7]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[6:7]
 ; GFX7-NEXT:    v_min_f64 v[6:7], v[2:3], v[8:9]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[8:9]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[8:9]
 ; GFX7-NEXT:    v_min_f64 v[8:9], v[4:5], v[10:11]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[10:11]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[10:11]
 ; GFX7-NEXT:    v_mov_b32_e32 v5, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v13, v5, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v6, 0, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v3, v7, v5, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v8, 0, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v5, v9, v5, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v12, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v13, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, 0, v6, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v3, v5, v7, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v4, 0, v8, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v5, v5, v9, s[6:7]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_minimum_v3f64:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_min_f64 v[12:13], v[0:1], v[6:7]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[6:7]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[6:7]
 ; GFX8-NEXT:    v_min_f64 v[6:7], v[2:3], v[8:9]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[8:9]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[8:9]
 ; GFX8-NEXT:    v_min_f64 v[8:9], v[4:5], v[10:11]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[10:11]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[10:11]
 ; GFX8-NEXT:    v_mov_b32_e32 v5, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v13, v5, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v6, 0, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, v7, v5, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v8, 0, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v5, v9, v5, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v12, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v13, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, v6, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, v5, v7, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, v8, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, v5, v9, s[6:7]
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_minimum_v3f64:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-NEXT:    v_min_f64 v[12:13], v[0:1], v[6:7]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[6:7]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[6:7]
 ; GFX900-NEXT:    v_min_f64 v[6:7], v[2:3], v[8:9]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[8:9]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[8:9]
 ; GFX900-NEXT:    v_min_f64 v[8:9], v[4:5], v[10:11]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[10:11]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[10:11]
 ; GFX900-NEXT:    v_mov_b32_e32 v5, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v13, v5, vcc
-; GFX900-NEXT:    v_cndmask_b32_e64 v2, v6, 0, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v3, v7, v5, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v4, v8, 0, s[6:7]
-; GFX900-NEXT:    v_cndmask_b32_e64 v5, v9, v5, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v12, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v5, v13, vcc
+; GFX900-NEXT:    v_cndmask_b32_e64 v2, 0, v6, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v3, v5, v7, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v4, 0, v8, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e64 v5, v5, v9, s[6:7]
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_minimum_v3f64:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_min_f64 v[12:13], v[0:1], v[6:7]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[6:7]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[6:7]
 ; GFX950-NEXT:    v_min_f64 v[6:7], v[2:3], v[8:9]
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v12, vcc
 ; GFX950-NEXT:    v_mov_b32_e32 v12, 0x7ff80000
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v13, v12, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[8:9]
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v12, v13, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[8:9]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v6, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v7, v12, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v6, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v12, v7, vcc
 ; GFX950-NEXT:    v_min_f64 v[6:7], v[4:5], v[10:11]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[10:11]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[10:11]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v4, v6, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v5, v7, v12, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v4, 0, v6, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v5, v12, v7, vcc
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_v3f64:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_min_f64 v[12:13], v[0:1], v[6:7]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[6:7]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[6:7]
 ; GFX10-NEXT:    v_min_f64 v[6:7], v[2:3], v[8:9]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[2:3], v[8:9]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[2:3], v[8:9]
 ; GFX10-NEXT:    v_min_f64 v[8:9], v[4:5], v[10:11]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s5, v[4:5], v[10:11]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v13, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v6, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v7, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v8, 0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v9, 0x7ff80000, s5
+; GFX10-NEXT:    v_cmp_o_f64_e64 s5, v[4:5], v[10:11]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v12, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v13, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v6, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v7, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, v8, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v9, s5
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_v3f64:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_min_f64 v[12:13], v[0:1], v[6:7]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[6:7]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[6:7]
 ; GFX11-NEXT:    v_min_f64 v[6:7], v[2:3], v[8:9]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[2:3], v[8:9]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[2:3], v[8:9]
 ; GFX11-NEXT:    v_min_f64 v[8:9], v[4:5], v[10:11]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s1, v[4:5], v[10:11]
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v13, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v6, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v7, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v8, 0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v9, 0x7ff80000, s1
+; GFX11-NEXT:    v_cmp_o_f64_e64 s1, v[4:5], v[10:11]
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v12 :: v_dual_cndmask_b32 v1, 0x7ff80000, v13
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v6, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v7, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v4, 0, v8, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v9, s1
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_minimum_v3f64:
@@ -1239,109 +1232,109 @@ define <3 x double> @v_minimum_v3f64__nsz(<3 x double> %src0, <3 x double> %src1
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_min_f64 v[12:13], v[0:1], v[6:7]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[6:7]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[6:7]
 ; GFX7-NEXT:    v_min_f64 v[6:7], v[2:3], v[8:9]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[8:9]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[8:9]
 ; GFX7-NEXT:    v_min_f64 v[8:9], v[4:5], v[10:11]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[10:11]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[10:11]
 ; GFX7-NEXT:    v_mov_b32_e32 v5, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v13, v5, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v6, 0, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v3, v7, v5, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v8, 0, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v5, v9, v5, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v12, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v13, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, 0, v6, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v3, v5, v7, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v4, 0, v8, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v5, v5, v9, s[6:7]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_minimum_v3f64__nsz:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_min_f64 v[12:13], v[0:1], v[6:7]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[6:7]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[6:7]
 ; GFX8-NEXT:    v_min_f64 v[6:7], v[2:3], v[8:9]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[8:9]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[8:9]
 ; GFX8-NEXT:    v_min_f64 v[8:9], v[4:5], v[10:11]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[10:11]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[10:11]
 ; GFX8-NEXT:    v_mov_b32_e32 v5, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v13, v5, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v6, 0, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, v7, v5, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v8, 0, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v5, v9, v5, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v12, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v13, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, v6, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, v5, v7, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, v8, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, v5, v9, s[6:7]
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_minimum_v3f64__nsz:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-NEXT:    v_min_f64 v[12:13], v[0:1], v[6:7]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[6:7]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[6:7]
 ; GFX900-NEXT:    v_min_f64 v[6:7], v[2:3], v[8:9]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[8:9]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[8:9]
 ; GFX900-NEXT:    v_min_f64 v[8:9], v[4:5], v[10:11]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[10:11]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[10:11]
 ; GFX900-NEXT:    v_mov_b32_e32 v5, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v13, v5, vcc
-; GFX900-NEXT:    v_cndmask_b32_e64 v2, v6, 0, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v3, v7, v5, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v4, v8, 0, s[6:7]
-; GFX900-NEXT:    v_cndmask_b32_e64 v5, v9, v5, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v12, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v5, v13, vcc
+; GFX900-NEXT:    v_cndmask_b32_e64 v2, 0, v6, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v3, v5, v7, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v4, 0, v8, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e64 v5, v5, v9, s[6:7]
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_minimum_v3f64__nsz:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_min_f64 v[12:13], v[0:1], v[6:7]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[6:7]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[6:7]
 ; GFX950-NEXT:    v_min_f64 v[6:7], v[2:3], v[8:9]
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v12, vcc
 ; GFX950-NEXT:    v_mov_b32_e32 v12, 0x7ff80000
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v13, v12, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[8:9]
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v12, v13, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[8:9]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v6, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v7, v12, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v6, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v12, v7, vcc
 ; GFX950-NEXT:    v_min_f64 v[6:7], v[4:5], v[10:11]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[10:11]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[10:11]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v4, v6, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v5, v7, v12, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v4, 0, v6, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v5, v12, v7, vcc
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_v3f64__nsz:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_min_f64 v[12:13], v[0:1], v[6:7]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[6:7]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[6:7]
 ; GFX10-NEXT:    v_min_f64 v[6:7], v[2:3], v[8:9]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[2:3], v[8:9]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[2:3], v[8:9]
 ; GFX10-NEXT:    v_min_f64 v[8:9], v[4:5], v[10:11]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s5, v[4:5], v[10:11]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v13, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v6, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v7, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v8, 0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v9, 0x7ff80000, s5
+; GFX10-NEXT:    v_cmp_o_f64_e64 s5, v[4:5], v[10:11]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v12, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v13, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v6, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v7, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, v8, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v9, s5
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_v3f64__nsz:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_min_f64 v[12:13], v[0:1], v[6:7]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[6:7]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[6:7]
 ; GFX11-NEXT:    v_min_f64 v[6:7], v[2:3], v[8:9]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[2:3], v[8:9]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[2:3], v[8:9]
 ; GFX11-NEXT:    v_min_f64 v[8:9], v[4:5], v[10:11]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s1, v[4:5], v[10:11]
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v13, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v6, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v7, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v8, 0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v9, 0x7ff80000, s1
+; GFX11-NEXT:    v_cmp_o_f64_e64 s1, v[4:5], v[10:11]
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v12 :: v_dual_cndmask_b32 v1, 0x7ff80000, v13
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v6, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v7, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v4, 0, v8, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v9, s1
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_minimum_v3f64__nsz:
@@ -1436,134 +1429,133 @@ define <4 x double> @v_minimum_v4f64(<4 x double> %src0, <4 x double> %src1) #0 
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_min_f64 v[16:17], v[0:1], v[8:9]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[8:9]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[8:9]
 ; GFX7-NEXT:    v_min_f64 v[8:9], v[2:3], v[10:11]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[10:11]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[10:11]
 ; GFX7-NEXT:    v_min_f64 v[10:11], v[4:5], v[12:13]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[12:13]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[12:13]
 ; GFX7-NEXT:    v_min_f64 v[12:13], v[6:7], v[14:15]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[14:15]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[14:15]
 ; GFX7-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v17, v7, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v8, 0, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v3, v9, v7, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v5, v11, v7, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s[8:9]
-; GFX7-NEXT:    v_cndmask_b32_e64 v7, v13, v7, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v7, v17, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, 0, v8, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v3, v7, v9, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v5, v7, v11, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e64 v7, v7, v13, s[8:9]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_minimum_v4f64:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_min_f64 v[16:17], v[0:1], v[8:9]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[8:9]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[8:9]
 ; GFX8-NEXT:    v_min_f64 v[8:9], v[2:3], v[10:11]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[10:11]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[10:11]
 ; GFX8-NEXT:    v_min_f64 v[10:11], v[4:5], v[12:13]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[12:13]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[12:13]
 ; GFX8-NEXT:    v_min_f64 v[12:13], v[6:7], v[14:15]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[14:15]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[14:15]
 ; GFX8-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v17, v7, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v8, 0, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, v9, v7, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v5, v11, v7, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s[8:9]
-; GFX8-NEXT:    v_cndmask_b32_e64 v7, v13, v7, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v7, v17, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, v8, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, v7, v9, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, v7, v11, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e64 v7, v7, v13, s[8:9]
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_minimum_v4f64:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-NEXT:    v_min_f64 v[16:17], v[0:1], v[8:9]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[8:9]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[8:9]
 ; GFX900-NEXT:    v_min_f64 v[8:9], v[2:3], v[10:11]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[10:11]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[10:11]
 ; GFX900-NEXT:    v_min_f64 v[10:11], v[4:5], v[12:13]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[12:13]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[12:13]
 ; GFX900-NEXT:    v_min_f64 v[12:13], v[6:7], v[14:15]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[14:15]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[14:15]
 ; GFX900-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v17, v7, vcc
-; GFX900-NEXT:    v_cndmask_b32_e64 v2, v8, 0, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v3, v9, v7, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[6:7]
-; GFX900-NEXT:    v_cndmask_b32_e64 v5, v11, v7, s[6:7]
-; GFX900-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s[8:9]
-; GFX900-NEXT:    v_cndmask_b32_e64 v7, v13, v7, s[8:9]
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v7, v17, vcc
+; GFX900-NEXT:    v_cndmask_b32_e64 v2, 0, v8, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v3, v7, v9, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e64 v5, v7, v11, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s[8:9]
+; GFX900-NEXT:    v_cndmask_b32_e64 v7, v7, v13, s[8:9]
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_minimum_v4f64:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_min_f64 v[16:17], v[0:1], v[8:9]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[8:9]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[8:9]
 ; GFX950-NEXT:    v_min_f64 v[8:9], v[2:3], v[10:11]
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc
 ; GFX950-NEXT:    v_mov_b32_e32 v16, 0x7ff80000
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v17, v16, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[10:11]
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v16, v17, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[10:11]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v8, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v9, v16, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v8, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v16, v9, vcc
 ; GFX950-NEXT:    v_min_f64 v[8:9], v[4:5], v[12:13]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[12:13]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[12:13]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v4, v8, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v5, v9, v16, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v4, 0, v8, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v5, v16, v9, vcc
 ; GFX950-NEXT:    v_min_f64 v[8:9], v[6:7], v[14:15]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[6:7], v[14:15]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[6:7], v[14:15]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v6, v8, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v7, v9, v16, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v6, 0, v8, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v7, v16, v9, vcc
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_v4f64:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_min_f64 v[16:17], v[0:1], v[8:9]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[8:9]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[8:9]
 ; GFX10-NEXT:    v_min_f64 v[8:9], v[2:3], v[10:11]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[2:3], v[10:11]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[2:3], v[10:11]
 ; GFX10-NEXT:    v_min_f64 v[10:11], v[4:5], v[12:13]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s5, v[4:5], v[12:13]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s5, v[4:5], v[12:13]
 ; GFX10-NEXT:    v_min_f64 v[12:13], v[6:7], v[14:15]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s6, v[6:7], v[14:15]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v17, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v8, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v9, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v11, 0x7ff80000, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v7, v13, 0x7ff80000, s6
+; GFX10-NEXT:    v_cmp_o_f64_e64 s6, v[6:7], v[14:15]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v17, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v8, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v9, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v11, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s6
+; GFX10-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v13, s6
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_v4f64:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_min_f64 v[16:17], v[0:1], v[8:9]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[8:9]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[8:9]
 ; GFX11-NEXT:    v_min_f64 v[8:9], v[2:3], v[10:11]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[2:3], v[10:11]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[2:3], v[10:11]
 ; GFX11-NEXT:    v_min_f64 v[10:11], v[4:5], v[12:13]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s1, v[4:5], v[12:13]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s1, v[4:5], v[12:13]
 ; GFX11-NEXT:    v_min_f64 v[12:13], v[6:7], v[14:15]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s2, v[6:7], v[14:15]
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v17, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v8, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v9, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v11, 0x7ff80000, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v7, v13, 0x7ff80000, s2
+; GFX11-NEXT:    v_cmp_o_f64_e64 s2, v[6:7], v[14:15]
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v16 :: v_dual_cndmask_b32 v1, 0x7ff80000, v17
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v8, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v9, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v11, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v13, s2
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_minimum_v4f64:
@@ -1667,134 +1659,133 @@ define <4 x double> @v_minimum_v4f64__nsz(<4 x double> %src0, <4 x double> %src1
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_min_f64 v[16:17], v[0:1], v[8:9]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[8:9]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[8:9]
 ; GFX7-NEXT:    v_min_f64 v[8:9], v[2:3], v[10:11]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[10:11]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[10:11]
 ; GFX7-NEXT:    v_min_f64 v[10:11], v[4:5], v[12:13]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[12:13]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[12:13]
 ; GFX7-NEXT:    v_min_f64 v[12:13], v[6:7], v[14:15]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[14:15]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[14:15]
 ; GFX7-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v17, v7, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v8, 0, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v3, v9, v7, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v5, v11, v7, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s[8:9]
-; GFX7-NEXT:    v_cndmask_b32_e64 v7, v13, v7, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v7, v17, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, 0, v8, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v3, v7, v9, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v5, v7, v11, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e64 v7, v7, v13, s[8:9]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_minimum_v4f64__nsz:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_min_f64 v[16:17], v[0:1], v[8:9]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[8:9]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[8:9]
 ; GFX8-NEXT:    v_min_f64 v[8:9], v[2:3], v[10:11]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[10:11]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[10:11]
 ; GFX8-NEXT:    v_min_f64 v[10:11], v[4:5], v[12:13]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[12:13]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[12:13]
 ; GFX8-NEXT:    v_min_f64 v[12:13], v[6:7], v[14:15]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[14:15]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[14:15]
 ; GFX8-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v17, v7, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v8, 0, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, v9, v7, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v5, v11, v7, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s[8:9]
-; GFX8-NEXT:    v_cndmask_b32_e64 v7, v13, v7, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v7, v17, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, v8, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, v7, v9, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, v7, v11, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e64 v7, v7, v13, s[8:9]
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_minimum_v4f64__nsz:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-NEXT:    v_min_f64 v[16:17], v[0:1], v[8:9]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[8:9]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[8:9]
 ; GFX900-NEXT:    v_min_f64 v[8:9], v[2:3], v[10:11]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[10:11]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[10:11]
 ; GFX900-NEXT:    v_min_f64 v[10:11], v[4:5], v[12:13]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[12:13]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[12:13]
 ; GFX900-NEXT:    v_min_f64 v[12:13], v[6:7], v[14:15]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[14:15]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[14:15]
 ; GFX900-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v17, v7, vcc
-; GFX900-NEXT:    v_cndmask_b32_e64 v2, v8, 0, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v3, v9, v7, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[6:7]
-; GFX900-NEXT:    v_cndmask_b32_e64 v5, v11, v7, s[6:7]
-; GFX900-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s[8:9]
-; GFX900-NEXT:    v_cndmask_b32_e64 v7, v13, v7, s[8:9]
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v7, v17, vcc
+; GFX900-NEXT:    v_cndmask_b32_e64 v2, 0, v8, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v3, v7, v9, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e64 v5, v7, v11, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s[8:9]
+; GFX900-NEXT:    v_cndmask_b32_e64 v7, v7, v13, s[8:9]
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_minimum_v4f64__nsz:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_min_f64 v[16:17], v[0:1], v[8:9]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[8:9]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[8:9]
 ; GFX950-NEXT:    v_min_f64 v[8:9], v[2:3], v[10:11]
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc
 ; GFX950-NEXT:    v_mov_b32_e32 v16, 0x7ff80000
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v17, v16, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[10:11]
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v16, v17, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[10:11]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v8, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v9, v16, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v8, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v16, v9, vcc
 ; GFX950-NEXT:    v_min_f64 v[8:9], v[4:5], v[12:13]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[12:13]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[12:13]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v4, v8, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v5, v9, v16, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v4, 0, v8, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v5, v16, v9, vcc
 ; GFX950-NEXT:    v_min_f64 v[8:9], v[6:7], v[14:15]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[6:7], v[14:15]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[6:7], v[14:15]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v6, v8, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v7, v9, v16, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v6, 0, v8, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v7, v16, v9, vcc
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_v4f64__nsz:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_min_f64 v[16:17], v[0:1], v[8:9]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[8:9]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[8:9]
 ; GFX10-NEXT:    v_min_f64 v[8:9], v[2:3], v[10:11]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[2:3], v[10:11]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[2:3], v[10:11]
 ; GFX10-NEXT:    v_min_f64 v[10:11], v[4:5], v[12:13]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s5, v[4:5], v[12:13]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s5, v[4:5], v[12:13]
 ; GFX10-NEXT:    v_min_f64 v[12:13], v[6:7], v[14:15]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s6, v[6:7], v[14:15]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v17, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v8, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v9, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v11, 0x7ff80000, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v7, v13, 0x7ff80000, s6
+; GFX10-NEXT:    v_cmp_o_f64_e64 s6, v[6:7], v[14:15]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v17, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v8, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v9, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v11, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s6
+; GFX10-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v13, s6
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_v4f64__nsz:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_min_f64 v[16:17], v[0:1], v[8:9]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[8:9]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[8:9]
 ; GFX11-NEXT:    v_min_f64 v[8:9], v[2:3], v[10:11]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[2:3], v[10:11]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[2:3], v[10:11]
 ; GFX11-NEXT:    v_min_f64 v[10:11], v[4:5], v[12:13]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s1, v[4:5], v[12:13]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s1, v[4:5], v[12:13]
 ; GFX11-NEXT:    v_min_f64 v[12:13], v[6:7], v[14:15]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s2, v[6:7], v[14:15]
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v17, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v8, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v9, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v11, 0x7ff80000, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v7, v13, 0x7ff80000, s2
+; GFX11-NEXT:    v_cmp_o_f64_e64 s2, v[6:7], v[14:15]
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v16 :: v_dual_cndmask_b32 v1, 0x7ff80000, v17
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v8, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v9, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v11, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v13, s2
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_minimum_v4f64__nsz:
@@ -1899,39 +1890,39 @@ define <8 x double> @v_minimum_v8f64(<8 x double> %src0, <8 x double> %src1) #0 
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32
 ; GFX7-NEXT:    v_min_f64 v[32:33], v[0:1], v[16:17]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[16:17]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[16:17]
 ; GFX7-NEXT:    v_min_f64 v[16:17], v[2:3], v[18:19]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[18:19]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[18:19]
 ; GFX7-NEXT:    v_mov_b32_e32 v34, 0x7ff80000
 ; GFX7-NEXT:    v_min_f64 v[18:19], v[4:5], v[20:21]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[20:21]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[20:21]
 ; GFX7-NEXT:    v_min_f64 v[20:21], v[6:7], v[22:23]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[22:23]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[22:23]
 ; GFX7-NEXT:    v_min_f64 v[22:23], v[8:9], v[24:25]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[10:11], v[8:9], v[24:25]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[10:11], v[8:9], v[24:25]
 ; GFX7-NEXT:    v_min_f64 v[24:25], v[10:11], v[26:27]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[12:13], v[10:11], v[26:27]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[12:13], v[10:11], v[26:27]
 ; GFX7-NEXT:    v_min_f64 v[26:27], v[12:13], v[28:29]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[14:15], v[12:13], v[28:29]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v32, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v33, v34, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v16, 0, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v3, v17, v34, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v18, 0, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v5, v19, v34, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v6, v20, 0, s[8:9]
-; GFX7-NEXT:    v_cndmask_b32_e64 v7, v21, v34, s[8:9]
-; GFX7-NEXT:    v_cndmask_b32_e64 v8, v22, 0, s[10:11]
-; GFX7-NEXT:    v_cndmask_b32_e64 v9, v23, v34, s[10:11]
-; GFX7-NEXT:    v_cndmask_b32_e64 v10, v24, 0, s[12:13]
-; GFX7-NEXT:    v_cndmask_b32_e64 v11, v25, v34, s[12:13]
-; GFX7-NEXT:    v_cndmask_b32_e64 v12, v26, 0, s[14:15]
-; GFX7-NEXT:    v_cndmask_b32_e64 v13, v27, v34, s[14:15]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[14:15], v[12:13], v[28:29]
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v32, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v34, v33, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, 0, v16, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v3, v34, v17, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v4, 0, v18, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v5, v34, v19, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v6, 0, v20, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e64 v7, v34, v21, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e64 v8, 0, v22, s[10:11]
+; GFX7-NEXT:    v_cndmask_b32_e64 v9, v34, v23, s[10:11]
+; GFX7-NEXT:    v_cndmask_b32_e64 v10, 0, v24, s[12:13]
+; GFX7-NEXT:    v_cndmask_b32_e64 v11, v34, v25, s[12:13]
+; GFX7-NEXT:    v_cndmask_b32_e64 v12, 0, v26, s[14:15]
+; GFX7-NEXT:    v_cndmask_b32_e64 v13, v34, v27, s[14:15]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
 ; GFX7-NEXT:    v_min_f64 v[16:17], v[14:15], v[30:31]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[14:15], v[30:31]
-; GFX7-NEXT:    v_cndmask_b32_e64 v14, v16, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v15, v17, v34, vcc
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[14:15], v[30:31]
+; GFX7-NEXT:    v_cndmask_b32_e32 v14, 0, v16, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v15, v34, v17, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_minimum_v8f64:
@@ -1939,39 +1930,39 @@ define <8 x double> @v_minimum_v8f64(<8 x double> %src0, <8 x double> %src1) #0 
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32
 ; GFX8-NEXT:    v_min_f64 v[32:33], v[0:1], v[16:17]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[16:17]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[16:17]
 ; GFX8-NEXT:    v_min_f64 v[16:17], v[2:3], v[18:19]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[18:19]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[18:19]
 ; GFX8-NEXT:    v_mov_b32_e32 v34, 0x7ff80000
 ; GFX8-NEXT:    v_min_f64 v[18:19], v[4:5], v[20:21]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[20:21]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[20:21]
 ; GFX8-NEXT:    v_min_f64 v[20:21], v[6:7], v[22:23]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[22:23]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[22:23]
 ; GFX8-NEXT:    v_min_f64 v[22:23], v[8:9], v[24:25]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[10:11], v[8:9], v[24:25]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[10:11], v[8:9], v[24:25]
 ; GFX8-NEXT:    v_min_f64 v[24:25], v[10:11], v[26:27]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[12:13], v[10:11], v[26:27]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[12:13], v[10:11], v[26:27]
 ; GFX8-NEXT:    v_min_f64 v[26:27], v[12:13], v[28:29]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[14:15], v[12:13], v[28:29]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v32, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v33, v34, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v16, 0, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, v17, v34, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v18, 0, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v5, v19, v34, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v6, v20, 0, s[8:9]
-; GFX8-NEXT:    v_cndmask_b32_e64 v7, v21, v34, s[8:9]
-; GFX8-NEXT:    v_cndmask_b32_e64 v8, v22, 0, s[10:11]
-; GFX8-NEXT:    v_cndmask_b32_e64 v9, v23, v34, s[10:11]
-; GFX8-NEXT:    v_cndmask_b32_e64 v10, v24, 0, s[12:13]
-; GFX8-NEXT:    v_cndmask_b32_e64 v11, v25, v34, s[12:13]
-; GFX8-NEXT:    v_cndmask_b32_e64 v12, v26, 0, s[14:15]
-; GFX8-NEXT:    v_cndmask_b32_e64 v13, v27, v34, s[14:15]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[14:15], v[12:13], v[28:29]
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v32, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v34, v33, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, v16, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, v34, v17, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, v18, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, v34, v19, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, v20, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e64 v7, v34, v21, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e64 v8, 0, v22, s[10:11]
+; GFX8-NEXT:    v_cndmask_b32_e64 v9, v34, v23, s[10:11]
+; GFX8-NEXT:    v_cndmask_b32_e64 v10, 0, v24, s[12:13]
+; GFX8-NEXT:    v_cndmask_b32_e64 v11, v34, v25, s[12:13]
+; GFX8-NEXT:    v_cndmask_b32_e64 v12, 0, v26, s[14:15]
+; GFX8-NEXT:    v_cndmask_b32_e64 v13, v34, v27, s[14:15]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
 ; GFX8-NEXT:    v_min_f64 v[16:17], v[14:15], v[30:31]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[14:15], v[30:31]
-; GFX8-NEXT:    v_cndmask_b32_e64 v14, v16, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v15, v17, v34, vcc
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[14:15], v[30:31]
+; GFX8-NEXT:    v_cndmask_b32_e32 v14, 0, v16, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v15, v34, v17, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_minimum_v8f64:
@@ -1979,39 +1970,39 @@ define <8 x double> @v_minimum_v8f64(<8 x double> %src0, <8 x double> %src1) #0 
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32
 ; GFX900-NEXT:    v_min_f64 v[32:33], v[0:1], v[16:17]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[16:17]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[16:17]
 ; GFX900-NEXT:    v_min_f64 v[16:17], v[2:3], v[18:19]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[18:19]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[18:19]
 ; GFX900-NEXT:    v_mov_b32_e32 v34, 0x7ff80000
 ; GFX900-NEXT:    v_min_f64 v[18:19], v[4:5], v[20:21]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[20:21]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[20:21]
 ; GFX900-NEXT:    v_min_f64 v[20:21], v[6:7], v[22:23]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[22:23]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[22:23]
 ; GFX900-NEXT:    v_min_f64 v[22:23], v[8:9], v[24:25]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[10:11], v[8:9], v[24:25]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[10:11], v[8:9], v[24:25]
 ; GFX900-NEXT:    v_min_f64 v[24:25], v[10:11], v[26:27]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[12:13], v[10:11], v[26:27]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[12:13], v[10:11], v[26:27]
 ; GFX900-NEXT:    v_min_f64 v[26:27], v[12:13], v[28:29]
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[14:15], v[12:13], v[28:29]
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v32, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v33, v34, vcc
-; GFX900-NEXT:    v_cndmask_b32_e64 v2, v16, 0, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v3, v17, v34, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v4, v18, 0, s[6:7]
-; GFX900-NEXT:    v_cndmask_b32_e64 v5, v19, v34, s[6:7]
-; GFX900-NEXT:    v_cndmask_b32_e64 v6, v20, 0, s[8:9]
-; GFX900-NEXT:    v_cndmask_b32_e64 v7, v21, v34, s[8:9]
-; GFX900-NEXT:    v_cndmask_b32_e64 v8, v22, 0, s[10:11]
-; GFX900-NEXT:    v_cndmask_b32_e64 v9, v23, v34, s[10:11]
-; GFX900-NEXT:    v_cndmask_b32_e64 v10, v24, 0, s[12:13]
-; GFX900-NEXT:    v_cndmask_b32_e64 v11, v25, v34, s[12:13]
-; GFX900-NEXT:    v_cndmask_b32_e64 v12, v26, 0, s[14:15]
-; GFX900-NEXT:    v_cndmask_b32_e64 v13, v27, v34, s[14:15]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[14:15], v[12:13], v[28:29]
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v32, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v34, v33, vcc
+; GFX900-NEXT:    v_cndmask_b32_e64 v2, 0, v16, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v3, v34, v17, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v4, 0, v18, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e64 v5, v34, v19, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e64 v6, 0, v20, s[8:9]
+; GFX900-NEXT:    v_cndmask_b32_e64 v7, v34, v21, s[8:9]
+; GFX900-NEXT:    v_cndmask_b32_e64 v8, 0, v22, s[10:11]
+; GFX900-NEXT:    v_cndmask_b32_e64 v9, v34, v23, s[10:11]
+; GFX900-NEXT:    v_cndmask_b32_e64 v10, 0, v24, s[12:13]
+; GFX900-NEXT:    v_cndmask_b32_e64 v11, v34, v25, s[12:13]
+; GFX900-NEXT:    v_cndmask_b32_e64 v12, 0, v26, s[14:15]
+; GFX900-NEXT:    v_cndmask_b32_e64 v13, v34, v27, s[14:15]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
 ; GFX900-NEXT:    v_min_f64 v[16:17], v[14:15], v[30:31]
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[14:15], v[30:31]
-; GFX900-NEXT:    v_cndmask_b32_e64 v14, v16, 0, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v15, v17, v34, vcc
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[14:15], v[30:31]
+; GFX900-NEXT:    v_cndmask_b32_e32 v14, 0, v16, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v15, v34, v17, vcc
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_minimum_v8f64:
@@ -2020,42 +2011,42 @@ define <8 x double> @v_minimum_v8f64(<8 x double> %src0, <8 x double> %src1) #0 
 ; GFX950-NEXT:    scratch_load_dword v31, off, s32
 ; GFX950-NEXT:    v_mov_b32_e32 v54, 0x7ff80000
 ; GFX950-NEXT:    v_min_f64 v[32:33], v[0:1], v[16:17]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[16:17]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[16:17]
 ; GFX950-NEXT:    v_min_f64 v[34:35], v[2:3], v[18:19]
 ; GFX950-NEXT:    v_min_f64 v[36:37], v[4:5], v[20:21]
-; GFX950-NEXT:    v_cndmask_b32_e64 v0, v32, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v1, v33, v54, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[18:19]
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, 0, v32, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v1, v54, v33, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[18:19]
 ; GFX950-NEXT:    v_min_f64 v[38:39], v[6:7], v[22:23]
 ; GFX950-NEXT:    v_min_f64 v[48:49], v[8:9], v[24:25]
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, v34, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v3, v35, v54, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[20:21]
+; GFX950-NEXT:    v_cndmask_b32_e32 v2, 0, v34, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v3, v54, v35, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[20:21]
 ; GFX950-NEXT:    v_min_f64 v[50:51], v[10:11], v[26:27]
 ; GFX950-NEXT:    v_min_f64 v[52:53], v[12:13], v[28:29]
-; GFX950-NEXT:    v_cndmask_b32_e64 v4, v36, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v5, v37, v54, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[6:7], v[22:23]
+; GFX950-NEXT:    v_cndmask_b32_e32 v4, 0, v36, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v5, v54, v37, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[6:7], v[22:23]
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_min_f64 v[16:17], v[14:15], v[30:31]
-; GFX950-NEXT:    v_cndmask_b32_e64 v6, v38, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v7, v39, v54, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[8:9], v[24:25]
+; GFX950-NEXT:    v_cndmask_b32_e32 v6, 0, v38, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v7, v54, v39, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[8:9], v[24:25]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v8, v48, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v9, v49, v54, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[10:11], v[26:27]
+; GFX950-NEXT:    v_cndmask_b32_e32 v8, 0, v48, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v9, v54, v49, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[10:11], v[26:27]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v10, v50, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v11, v51, v54, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[12:13], v[28:29]
+; GFX950-NEXT:    v_cndmask_b32_e32 v10, 0, v50, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v11, v54, v51, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[12:13], v[28:29]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v12, v52, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v13, v53, v54, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[14:15], v[30:31]
+; GFX950-NEXT:    v_cndmask_b32_e32 v12, 0, v52, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v13, v54, v53, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[14:15], v[30:31]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v14, v16, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v15, v17, v54, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v14, 0, v16, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v15, v54, v17, vcc
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_v8f64:
@@ -2063,38 +2054,38 @@ define <8 x double> @v_minimum_v8f64(<8 x double> %src0, <8 x double> %src1) #0 
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    buffer_load_dword v31, off, s[0:3], s32
 ; GFX10-NEXT:    v_min_f64 v[32:33], v[0:1], v[16:17]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[16:17]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[16:17]
 ; GFX10-NEXT:    v_min_f64 v[16:17], v[2:3], v[18:19]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[2:3], v[18:19]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[2:3], v[18:19]
 ; GFX10-NEXT:    v_min_f64 v[18:19], v[4:5], v[20:21]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s5, v[4:5], v[20:21]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s5, v[4:5], v[20:21]
 ; GFX10-NEXT:    v_min_f64 v[20:21], v[6:7], v[22:23]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s6, v[6:7], v[22:23]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s6, v[6:7], v[22:23]
 ; GFX10-NEXT:    v_min_f64 v[22:23], v[8:9], v[24:25]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s7, v[8:9], v[24:25]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s7, v[8:9], v[24:25]
 ; GFX10-NEXT:    v_min_f64 v[24:25], v[10:11], v[26:27]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s8, v[10:11], v[26:27]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s8, v[10:11], v[26:27]
 ; GFX10-NEXT:    v_min_f64 v[26:27], v[12:13], v[28:29]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s9, v[12:13], v[28:29]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v32, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v33, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v16, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v17, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v18, 0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v19, 0x7ff80000, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, v20, 0, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v7, v21, 0x7ff80000, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v8, v22, 0, s7
-; GFX10-NEXT:    v_cndmask_b32_e64 v9, v23, 0x7ff80000, s7
-; GFX10-NEXT:    v_cndmask_b32_e64 v10, v24, 0, s8
-; GFX10-NEXT:    v_cndmask_b32_e64 v11, v25, 0x7ff80000, s8
-; GFX10-NEXT:    v_cndmask_b32_e64 v12, v26, 0, s9
-; GFX10-NEXT:    v_cndmask_b32_e64 v13, v27, 0x7ff80000, s9
+; GFX10-NEXT:    v_cmp_o_f64_e64 s9, v[12:13], v[28:29]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v32, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v33, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v16, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v17, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, v18, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v19, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, 0, v20, s6
+; GFX10-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v21, s6
+; GFX10-NEXT:    v_cndmask_b32_e64 v8, 0, v22, s7
+; GFX10-NEXT:    v_cndmask_b32_e64 v9, 0x7ff80000, v23, s7
+; GFX10-NEXT:    v_cndmask_b32_e64 v10, 0, v24, s8
+; GFX10-NEXT:    v_cndmask_b32_e64 v11, 0x7ff80000, v25, s8
+; GFX10-NEXT:    v_cndmask_b32_e64 v12, 0, v26, s9
+; GFX10-NEXT:    v_cndmask_b32_e64 v13, 0x7ff80000, v27, s9
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-NEXT:    v_min_f64 v[28:29], v[14:15], v[30:31]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s10, v[14:15], v[30:31]
-; GFX10-NEXT:    v_cndmask_b32_e64 v14, v28, 0, s10
-; GFX10-NEXT:    v_cndmask_b32_e64 v15, v29, 0x7ff80000, s10
+; GFX10-NEXT:    v_cmp_o_f64_e64 s10, v[14:15], v[30:31]
+; GFX10-NEXT:    v_cndmask_b32_e64 v14, 0, v28, s10
+; GFX10-NEXT:    v_cndmask_b32_e64 v15, 0x7ff80000, v29, s10
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_v8f64:
@@ -2102,39 +2093,38 @@ define <8 x double> @v_minimum_v8f64(<8 x double> %src0, <8 x double> %src1) #0 
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    scratch_load_b32 v31, off, s32
 ; GFX11-NEXT:    v_min_f64 v[32:33], v[0:1], v[16:17]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[16:17]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[16:17]
 ; GFX11-NEXT:    v_min_f64 v[16:17], v[2:3], v[18:19]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[2:3], v[18:19]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[2:3], v[18:19]
 ; GFX11-NEXT:    v_min_f64 v[18:19], v[4:5], v[20:21]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s1, v[4:5], v[20:21]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s1, v[4:5], v[20:21]
 ; GFX11-NEXT:    v_min_f64 v[20:21], v[6:7], v[22:23]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s2, v[6:7], v[22:23]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s2, v[6:7], v[22:23]
 ; GFX11-NEXT:    v_min_f64 v[22:23], v[8:9], v[24:25]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s3, v[8:9], v[24:25]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s3, v[8:9], v[24:25]
 ; GFX11-NEXT:    v_min_f64 v[24:25], v[10:11], v[26:27]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s4, v[10:11], v[26:27]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s4, v[10:11], v[26:27]
 ; GFX11-NEXT:    v_min_f64 v[26:27], v[12:13], v[28:29]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s5, v[12:13], v[28:29]
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v32, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v33, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v16, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v17, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v18, 0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v19, 0x7ff80000, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v6, v20, 0, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v7, v21, 0x7ff80000, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v8, v22, 0, s3
-; GFX11-NEXT:    v_cndmask_b32_e64 v9, v23, 0x7ff80000, s3
-; GFX11-NEXT:    v_cndmask_b32_e64 v10, v24, 0, s4
-; GFX11-NEXT:    v_cndmask_b32_e64 v11, v25, 0x7ff80000, s4
-; GFX11-NEXT:    v_cndmask_b32_e64 v12, v26, 0, s5
-; GFX11-NEXT:    v_cndmask_b32_e64 v13, v27, 0x7ff80000, s5
+; GFX11-NEXT:    v_cmp_o_f64_e64 s5, v[12:13], v[28:29]
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v32 :: v_dual_cndmask_b32 v1, 0x7ff80000, v33
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v16, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v17, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v4, 0, v18, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v19, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v6, 0, v20, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v21, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v8, 0, v22, s3
+; GFX11-NEXT:    v_cndmask_b32_e64 v9, 0x7ff80000, v23, s3
+; GFX11-NEXT:    v_cndmask_b32_e64 v10, 0, v24, s4
+; GFX11-NEXT:    v_cndmask_b32_e64 v11, 0x7ff80000, v25, s4
+; GFX11-NEXT:    v_cndmask_b32_e64 v12, 0, v26, s5
+; GFX11-NEXT:    v_cndmask_b32_e64 v13, 0x7ff80000, v27, s5
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    v_min_f64 v[28:29], v[14:15], v[30:31]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s6, v[14:15], v[30:31]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s6, v[14:15], v[30:31]
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v14, v28, 0, s6
-; GFX11-NEXT:    v_cndmask_b32_e64 v15, v29, 0x7ff80000, s6
+; GFX11-NEXT:    v_cndmask_b32_e64 v14, 0, v28, s6
+; GFX11-NEXT:    v_cndmask_b32_e64 v15, 0x7ff80000, v29, s6
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_minimum_v8f64:
@@ -2181,117 +2171,117 @@ define <16 x double> @v_minimum_v16f64(<16 x double> %src0, <16 x double> %src1)
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:8
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:4
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[31:32]
 ; GFX7-NEXT:    v_min_f64 v[0:1], v[0:1], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:16
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:12
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[31:32]
 ; GFX7-NEXT:    v_min_f64 v[2:3], v[2:3], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:24
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:20
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[4:5]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[31:32]
 ; GFX7-NEXT:    v_min_f64 v[4:5], v[4:5], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:32
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:28
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s[6:7]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[31:32]
 ; GFX7-NEXT:    v_min_f64 v[6:7], v[6:7], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:36
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:40
-; GFX7-NEXT:    v_cndmask_b32_e64 v6, v6, 0, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s[8:9]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[10:11], v[8:9], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[10:11], v[8:9], v[31:32]
 ; GFX7-NEXT:    v_min_f64 v[8:9], v[8:9], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:48
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:44
-; GFX7-NEXT:    v_cndmask_b32_e64 v8, v8, 0, s[10:11]
+; GFX7-NEXT:    v_cndmask_b32_e64 v8, 0, v8, s[10:11]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[12:13], v[10:11], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[12:13], v[10:11], v[31:32]
 ; GFX7-NEXT:    v_min_f64 v[10:11], v[10:11], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:56
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:52
-; GFX7-NEXT:    v_cndmask_b32_e64 v10, v10, 0, s[12:13]
+; GFX7-NEXT:    v_cndmask_b32_e64 v10, 0, v10, s[12:13]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[14:15], v[12:13], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[14:15], v[12:13], v[31:32]
 ; GFX7-NEXT:    v_min_f64 v[12:13], v[12:13], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:64
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:60
-; GFX7-NEXT:    v_cndmask_b32_e64 v12, v12, 0, s[14:15]
+; GFX7-NEXT:    v_cndmask_b32_e64 v12, 0, v12, s[14:15]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[16:17], v[14:15], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[16:17], v[14:15], v[31:32]
 ; GFX7-NEXT:    v_min_f64 v[14:15], v[14:15], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:68
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:72
-; GFX7-NEXT:    v_cndmask_b32_e64 v14, v14, 0, s[16:17]
+; GFX7-NEXT:    v_cndmask_b32_e64 v14, 0, v14, s[16:17]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[18:19], v[16:17], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[18:19], v[16:17], v[31:32]
 ; GFX7-NEXT:    v_min_f64 v[16:17], v[16:17], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:80
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:76
-; GFX7-NEXT:    v_cndmask_b32_e64 v16, v16, 0, s[18:19]
+; GFX7-NEXT:    v_cndmask_b32_e64 v16, 0, v16, s[18:19]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[20:21], v[18:19], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[20:21], v[18:19], v[31:32]
 ; GFX7-NEXT:    v_min_f64 v[18:19], v[18:19], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:88
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:84
-; GFX7-NEXT:    v_cndmask_b32_e64 v18, v18, 0, s[20:21]
+; GFX7-NEXT:    v_cndmask_b32_e64 v18, 0, v18, s[20:21]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[22:23], v[20:21], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[22:23], v[20:21], v[31:32]
 ; GFX7-NEXT:    v_min_f64 v[20:21], v[20:21], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:96
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:92
-; GFX7-NEXT:    v_cndmask_b32_e64 v20, v20, 0, s[22:23]
+; GFX7-NEXT:    v_cndmask_b32_e64 v20, 0, v20, s[22:23]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[24:25], v[22:23], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[24:25], v[22:23], v[31:32]
 ; GFX7-NEXT:    v_min_f64 v[22:23], v[22:23], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:100
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:104
-; GFX7-NEXT:    v_cndmask_b32_e64 v22, v22, 0, s[24:25]
+; GFX7-NEXT:    v_cndmask_b32_e64 v22, 0, v22, s[24:25]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[26:27], v[24:25], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[26:27], v[24:25], v[31:32]
 ; GFX7-NEXT:    v_min_f64 v[24:25], v[24:25], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:112
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:108
-; GFX7-NEXT:    v_cndmask_b32_e64 v24, v24, 0, s[26:27]
+; GFX7-NEXT:    v_cndmask_b32_e64 v24, 0, v24, s[26:27]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[28:29], v[26:27], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[28:29], v[26:27], v[31:32]
 ; GFX7-NEXT:    v_min_f64 v[26:27], v[26:27], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:120
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:116
-; GFX7-NEXT:    v_cndmask_b32_e64 v26, v26, 0, s[28:29]
+; GFX7-NEXT:    v_cndmask_b32_e64 v26, 0, v26, s[28:29]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[40:41], v[28:29], v[31:32]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[40:41], v[28:29], v[31:32]
 ; GFX7-NEXT:    v_min_f64 v[28:29], v[28:29], v[31:32]
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32
 ; GFX7-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:128
 ; GFX7-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:124
-; GFX7-NEXT:    v_cndmask_b32_e64 v28, v28, 0, s[40:41]
+; GFX7-NEXT:    v_cndmask_b32_e64 v28, 0, v28, s[40:41]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[42:43], v[30:31], v[32:33]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[42:43], v[30:31], v[32:33]
 ; GFX7-NEXT:    v_min_f64 v[30:31], v[30:31], v[32:33]
 ; GFX7-NEXT:    v_mov_b32_e32 v32, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v32, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v3, v3, v32, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v5, v5, v32, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v7, v7, v32, s[8:9]
-; GFX7-NEXT:    v_cndmask_b32_e64 v9, v9, v32, s[10:11]
-; GFX7-NEXT:    v_cndmask_b32_e64 v11, v11, v32, s[12:13]
-; GFX7-NEXT:    v_cndmask_b32_e64 v13, v13, v32, s[14:15]
-; GFX7-NEXT:    v_cndmask_b32_e64 v15, v15, v32, s[16:17]
-; GFX7-NEXT:    v_cndmask_b32_e64 v17, v17, v32, s[18:19]
-; GFX7-NEXT:    v_cndmask_b32_e64 v19, v19, v32, s[20:21]
-; GFX7-NEXT:    v_cndmask_b32_e64 v21, v21, v32, s[22:23]
-; GFX7-NEXT:    v_cndmask_b32_e64 v23, v23, v32, s[24:25]
-; GFX7-NEXT:    v_cndmask_b32_e64 v25, v25, v32, s[26:27]
-; GFX7-NEXT:    v_cndmask_b32_e64 v27, v27, v32, s[28:29]
-; GFX7-NEXT:    v_cndmask_b32_e64 v29, v29, v32, s[40:41]
-; GFX7-NEXT:    v_cndmask_b32_e64 v31, v31, v32, s[42:43]
-; GFX7-NEXT:    v_cndmask_b32_e64 v30, v30, 0, s[42:43]
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v32, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v3, v32, v3, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v5, v32, v5, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v7, v32, v7, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e64 v9, v32, v9, s[10:11]
+; GFX7-NEXT:    v_cndmask_b32_e64 v11, v32, v11, s[12:13]
+; GFX7-NEXT:    v_cndmask_b32_e64 v13, v32, v13, s[14:15]
+; GFX7-NEXT:    v_cndmask_b32_e64 v15, v32, v15, s[16:17]
+; GFX7-NEXT:    v_cndmask_b32_e64 v17, v32, v17, s[18:19]
+; GFX7-NEXT:    v_cndmask_b32_e64 v19, v32, v19, s[20:21]
+; GFX7-NEXT:    v_cndmask_b32_e64 v21, v32, v21, s[22:23]
+; GFX7-NEXT:    v_cndmask_b32_e64 v23, v32, v23, s[24:25]
+; GFX7-NEXT:    v_cndmask_b32_e64 v25, v32, v25, s[26:27]
+; GFX7-NEXT:    v_cndmask_b32_e64 v27, v32, v27, s[28:29]
+; GFX7-NEXT:    v_cndmask_b32_e64 v29, v32, v29, s[40:41]
+; GFX7-NEXT:    v_cndmask_b32_e64 v31, v32, v31, s[42:43]
+; GFX7-NEXT:    v_cndmask_b32_e64 v30, 0, v30, s[42:43]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_minimum_v16f64:
@@ -2300,117 +2290,117 @@ define <16 x double> @v_minimum_v16f64(<16 x double> %src0, <16 x double> %src1)
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:8
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:4
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[31:32]
 ; GFX8-NEXT:    v_min_f64 v[0:1], v[0:1], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:16
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:12
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[31:32]
 ; GFX8-NEXT:    v_min_f64 v[2:3], v[2:3], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:24
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:20
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[4:5]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[31:32]
 ; GFX8-NEXT:    v_min_f64 v[4:5], v[4:5], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:32
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:28
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s[6:7]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[31:32]
 ; GFX8-NEXT:    v_min_f64 v[6:7], v[6:7], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:36
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:40
-; GFX8-NEXT:    v_cndmask_b32_e64 v6, v6, 0, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s[8:9]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[10:11], v[8:9], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[10:11], v[8:9], v[31:32]
 ; GFX8-NEXT:    v_min_f64 v[8:9], v[8:9], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:48
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:44
-; GFX8-NEXT:    v_cndmask_b32_e64 v8, v8, 0, s[10:11]
+; GFX8-NEXT:    v_cndmask_b32_e64 v8, 0, v8, s[10:11]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[12:13], v[10:11], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[12:13], v[10:11], v[31:32]
 ; GFX8-NEXT:    v_min_f64 v[10:11], v[10:11], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:56
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:52
-; GFX8-NEXT:    v_cndmask_b32_e64 v10, v10, 0, s[12:13]
+; GFX8-NEXT:    v_cndmask_b32_e64 v10, 0, v10, s[12:13]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[14:15], v[12:13], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[14:15], v[12:13], v[31:32]
 ; GFX8-NEXT:    v_min_f64 v[12:13], v[12:13], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:64
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:60
-; GFX8-NEXT:    v_cndmask_b32_e64 v12, v12, 0, s[14:15]
+; GFX8-NEXT:    v_cndmask_b32_e64 v12, 0, v12, s[14:15]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[16:17], v[14:15], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[16:17], v[14:15], v[31:32]
 ; GFX8-NEXT:    v_min_f64 v[14:15], v[14:15], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:68
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:72
-; GFX8-NEXT:    v_cndmask_b32_e64 v14, v14, 0, s[16:17]
+; GFX8-NEXT:    v_cndmask_b32_e64 v14, 0, v14, s[16:17]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[18:19], v[16:17], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[18:19], v[16:17], v[31:32]
 ; GFX8-NEXT:    v_min_f64 v[16:17], v[16:17], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:80
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:76
-; GFX8-NEXT:    v_cndmask_b32_e64 v16, v16, 0, s[18:19]
+; GFX8-NEXT:    v_cndmask_b32_e64 v16, 0, v16, s[18:19]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[20:21], v[18:19], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[20:21], v[18:19], v[31:32]
 ; GFX8-NEXT:    v_min_f64 v[18:19], v[18:19], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:88
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:84
-; GFX8-NEXT:    v_cndmask_b32_e64 v18, v18, 0, s[20:21]
+; GFX8-NEXT:    v_cndmask_b32_e64 v18, 0, v18, s[20:21]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[22:23], v[20:21], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[22:23], v[20:21], v[31:32]
 ; GFX8-NEXT:    v_min_f64 v[20:21], v[20:21], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:96
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:92
-; GFX8-NEXT:    v_cndmask_b32_e64 v20, v20, 0, s[22:23]
+; GFX8-NEXT:    v_cndmask_b32_e64 v20, 0, v20, s[22:23]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[24:25], v[22:23], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[24:25], v[22:23], v[31:32]
 ; GFX8-NEXT:    v_min_f64 v[22:23], v[22:23], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:100
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:104
-; GFX8-NEXT:    v_cndmask_b32_e64 v22, v22, 0, s[24:25]
+; GFX8-NEXT:    v_cndmask_b32_e64 v22, 0, v22, s[24:25]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[26:27], v[24:25], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[26:27], v[24:25], v[31:32]
 ; GFX8-NEXT:    v_min_f64 v[24:25], v[24:25], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:112
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:108
-; GFX8-NEXT:    v_cndmask_b32_e64 v24, v24, 0, s[26:27]
+; GFX8-NEXT:    v_cndmask_b32_e64 v24, 0, v24, s[26:27]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[28:29], v[26:27], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[28:29], v[26:27], v[31:32]
 ; GFX8-NEXT:    v_min_f64 v[26:27], v[26:27], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:120
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:116
-; GFX8-NEXT:    v_cndmask_b32_e64 v26, v26, 0, s[28:29]
+; GFX8-NEXT:    v_cndmask_b32_e64 v26, 0, v26, s[28:29]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[40:41], v[28:29], v[31:32]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[40:41], v[28:29], v[31:32]
 ; GFX8-NEXT:    v_min_f64 v[28:29], v[28:29], v[31:32]
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32
 ; GFX8-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:128
 ; GFX8-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:124
-; GFX8-NEXT:    v_cndmask_b32_e64 v28, v28, 0, s[40:41]
+; GFX8-NEXT:    v_cndmask_b32_e64 v28, 0, v28, s[40:41]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[42:43], v[30:31], v[32:33]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[42:43], v[30:31], v[32:33]
 ; GFX8-NEXT:    v_min_f64 v[30:31], v[30:31], v[32:33]
 ; GFX8-NEXT:    v_mov_b32_e32 v32, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v32, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, v3, v32, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v5, v5, v32, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v7, v7, v32, s[8:9]
-; GFX8-NEXT:    v_cndmask_b32_e64 v9, v9, v32, s[10:11]
-; GFX8-NEXT:    v_cndmask_b32_e64 v11, v11, v32, s[12:13]
-; GFX8-NEXT:    v_cndmask_b32_e64 v13, v13, v32, s[14:15]
-; GFX8-NEXT:    v_cndmask_b32_e64 v15, v15, v32, s[16:17]
-; GFX8-NEXT:    v_cndmask_b32_e64 v17, v17, v32, s[18:19]
-; GFX8-NEXT:    v_cndmask_b32_e64 v19, v19, v32, s[20:21]
-; GFX8-NEXT:    v_cndmask_b32_e64 v21, v21, v32, s[22:23]
-; GFX8-NEXT:    v_cndmask_b32_e64 v23, v23, v32, s[24:25]
-; GFX8-NEXT:    v_cndmask_b32_e64 v25, v25, v32, s[26:27]
-; GFX8-NEXT:    v_cndmask_b32_e64 v27, v27, v32, s[28:29]
-; GFX8-NEXT:    v_cndmask_b32_e64 v29, v29, v32, s[40:41]
-; GFX8-NEXT:    v_cndmask_b32_e64 v31, v31, v32, s[42:43]
-; GFX8-NEXT:    v_cndmask_b32_e64 v30, v30, 0, s[42:43]
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v32, v1, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, v32, v3, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, v32, v5, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v7, v32, v7, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e64 v9, v32, v9, s[10:11]
+; GFX8-NEXT:    v_cndmask_b32_e64 v11, v32, v11, s[12:13]
+; GFX8-NEXT:    v_cndmask_b32_e64 v13, v32, v13, s[14:15]
+; GFX8-NEXT:    v_cndmask_b32_e64 v15, v32, v15, s[16:17]
+; GFX8-NEXT:    v_cndmask_b32_e64 v17, v32, v17, s[18:19]
+; GFX8-NEXT:    v_cndmask_b32_e64 v19, v32, v19, s[20:21]
+; GFX8-NEXT:    v_cndmask_b32_e64 v21, v32, v21, s[22:23]
+; GFX8-NEXT:    v_cndmask_b32_e64 v23, v32, v23, s[24:25]
+; GFX8-NEXT:    v_cndmask_b32_e64 v25, v32, v25, s[26:27]
+; GFX8-NEXT:    v_cndmask_b32_e64 v27, v32, v27, s[28:29]
+; GFX8-NEXT:    v_cndmask_b32_e64 v29, v32, v29, s[40:41]
+; GFX8-NEXT:    v_cndmask_b32_e64 v31, v32, v31, s[42:43]
+; GFX8-NEXT:    v_cndmask_b32_e64 v30, 0, v30, s[42:43]
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_minimum_v16f64:
@@ -2419,117 +2409,117 @@ define <16 x double> @v_minimum_v16f64(<16 x double> %src0, <16 x double> %src1)
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:8
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:4
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[31:32]
 ; GFX900-NEXT:    v_min_f64 v[0:1], v[0:1], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:16
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:12
-; GFX900-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX900-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[4:5], v[2:3], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[4:5], v[2:3], v[31:32]
 ; GFX900-NEXT:    v_min_f64 v[2:3], v[2:3], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:24
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:20
-; GFX900-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[4:5]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[6:7], v[4:5], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[6:7], v[4:5], v[31:32]
 ; GFX900-NEXT:    v_min_f64 v[4:5], v[4:5], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:32
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:28
-; GFX900-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s[6:7]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[8:9], v[6:7], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[8:9], v[6:7], v[31:32]
 ; GFX900-NEXT:    v_min_f64 v[6:7], v[6:7], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:36
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:40
-; GFX900-NEXT:    v_cndmask_b32_e64 v6, v6, 0, s[8:9]
+; GFX900-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s[8:9]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[10:11], v[8:9], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[10:11], v[8:9], v[31:32]
 ; GFX900-NEXT:    v_min_f64 v[8:9], v[8:9], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:48
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:44
-; GFX900-NEXT:    v_cndmask_b32_e64 v8, v8, 0, s[10:11]
+; GFX900-NEXT:    v_cndmask_b32_e64 v8, 0, v8, s[10:11]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[12:13], v[10:11], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[12:13], v[10:11], v[31:32]
 ; GFX900-NEXT:    v_min_f64 v[10:11], v[10:11], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:56
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:52
-; GFX900-NEXT:    v_cndmask_b32_e64 v10, v10, 0, s[12:13]
+; GFX900-NEXT:    v_cndmask_b32_e64 v10, 0, v10, s[12:13]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[14:15], v[12:13], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[14:15], v[12:13], v[31:32]
 ; GFX900-NEXT:    v_min_f64 v[12:13], v[12:13], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:64
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:60
-; GFX900-NEXT:    v_cndmask_b32_e64 v12, v12, 0, s[14:15]
+; GFX900-NEXT:    v_cndmask_b32_e64 v12, 0, v12, s[14:15]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[16:17], v[14:15], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[16:17], v[14:15], v[31:32]
 ; GFX900-NEXT:    v_min_f64 v[14:15], v[14:15], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:68
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:72
-; GFX900-NEXT:    v_cndmask_b32_e64 v14, v14, 0, s[16:17]
+; GFX900-NEXT:    v_cndmask_b32_e64 v14, 0, v14, s[16:17]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[18:19], v[16:17], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[18:19], v[16:17], v[31:32]
 ; GFX900-NEXT:    v_min_f64 v[16:17], v[16:17], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:80
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:76
-; GFX900-NEXT:    v_cndmask_b32_e64 v16, v16, 0, s[18:19]
+; GFX900-NEXT:    v_cndmask_b32_e64 v16, 0, v16, s[18:19]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[20:21], v[18:19], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[20:21], v[18:19], v[31:32]
 ; GFX900-NEXT:    v_min_f64 v[18:19], v[18:19], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:88
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:84
-; GFX900-NEXT:    v_cndmask_b32_e64 v18, v18, 0, s[20:21]
+; GFX900-NEXT:    v_cndmask_b32_e64 v18, 0, v18, s[20:21]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[22:23], v[20:21], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[22:23], v[20:21], v[31:32]
 ; GFX900-NEXT:    v_min_f64 v[20:21], v[20:21], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:96
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:92
-; GFX900-NEXT:    v_cndmask_b32_e64 v20, v20, 0, s[22:23]
+; GFX900-NEXT:    v_cndmask_b32_e64 v20, 0, v20, s[22:23]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[24:25], v[22:23], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[24:25], v[22:23], v[31:32]
 ; GFX900-NEXT:    v_min_f64 v[22:23], v[22:23], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:100
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:104
-; GFX900-NEXT:    v_cndmask_b32_e64 v22, v22, 0, s[24:25]
+; GFX900-NEXT:    v_cndmask_b32_e64 v22, 0, v22, s[24:25]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[26:27], v[24:25], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[26:27], v[24:25], v[31:32]
 ; GFX900-NEXT:    v_min_f64 v[24:25], v[24:25], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:112
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:108
-; GFX900-NEXT:    v_cndmask_b32_e64 v24, v24, 0, s[26:27]
+; GFX900-NEXT:    v_cndmask_b32_e64 v24, 0, v24, s[26:27]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[28:29], v[26:27], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[28:29], v[26:27], v[31:32]
 ; GFX900-NEXT:    v_min_f64 v[26:27], v[26:27], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:120
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:116
-; GFX900-NEXT:    v_cndmask_b32_e64 v26, v26, 0, s[28:29]
+; GFX900-NEXT:    v_cndmask_b32_e64 v26, 0, v26, s[28:29]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[40:41], v[28:29], v[31:32]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[40:41], v[28:29], v[31:32]
 ; GFX900-NEXT:    v_min_f64 v[28:29], v[28:29], v[31:32]
 ; GFX900-NEXT:    buffer_load_dword v31, off, s[0:3], s32
 ; GFX900-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:128
 ; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:124
-; GFX900-NEXT:    v_cndmask_b32_e64 v28, v28, 0, s[40:41]
+; GFX900-NEXT:    v_cndmask_b32_e64 v28, 0, v28, s[40:41]
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_cmp_u_f64_e64 s[42:43], v[30:31], v[32:33]
+; GFX900-NEXT:    v_cmp_o_f64_e64 s[42:43], v[30:31], v[32:33]
 ; GFX900-NEXT:    v_min_f64 v[30:31], v[30:31], v[32:33]
 ; GFX900-NEXT:    v_mov_b32_e32 v32, 0x7ff80000
-; GFX900-NEXT:    v_cndmask_b32_e32 v1, v1, v32, vcc
-; GFX900-NEXT:    v_cndmask_b32_e64 v3, v3, v32, s[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v5, v5, v32, s[6:7]
-; GFX900-NEXT:    v_cndmask_b32_e64 v7, v7, v32, s[8:9]
-; GFX900-NEXT:    v_cndmask_b32_e64 v9, v9, v32, s[10:11]
-; GFX900-NEXT:    v_cndmask_b32_e64 v11, v11, v32, s[12:13]
-; GFX900-NEXT:    v_cndmask_b32_e64 v13, v13, v32, s[14:15]
-; GFX900-NEXT:    v_cndmask_b32_e64 v15, v15, v32, s[16:17]
-; GFX900-NEXT:    v_cndmask_b32_e64 v17, v17, v32, s[18:19]
-; GFX900-NEXT:    v_cndmask_b32_e64 v19, v19, v32, s[20:21]
-; GFX900-NEXT:    v_cndmask_b32_e64 v21, v21, v32, s[22:23]
-; GFX900-NEXT:    v_cndmask_b32_e64 v23, v23, v32, s[24:25]
-; GFX900-NEXT:    v_cndmask_b32_e64 v25, v25, v32, s[26:27]
-; GFX900-NEXT:    v_cndmask_b32_e64 v27, v27, v32, s[28:29]
-; GFX900-NEXT:    v_cndmask_b32_e64 v29, v29, v32, s[40:41]
-; GFX900-NEXT:    v_cndmask_b32_e64 v31, v31, v32, s[42:43]
-; GFX900-NEXT:    v_cndmask_b32_e64 v30, v30, 0, s[42:43]
+; GFX900-NEXT:    v_cndmask_b32_e32 v1, v32, v1, vcc
+; GFX900-NEXT:    v_cndmask_b32_e64 v3, v32, v3, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v5, v32, v5, s[6:7]
+; GFX900-NEXT:    v_cndmask_b32_e64 v7, v32, v7, s[8:9]
+; GFX900-NEXT:    v_cndmask_b32_e64 v9, v32, v9, s[10:11]
+; GFX900-NEXT:    v_cndmask_b32_e64 v11, v32, v11, s[12:13]
+; GFX900-NEXT:    v_cndmask_b32_e64 v13, v32, v13, s[14:15]
+; GFX900-NEXT:    v_cndmask_b32_e64 v15, v32, v15, s[16:17]
+; GFX900-NEXT:    v_cndmask_b32_e64 v17, v32, v17, s[18:19]
+; GFX900-NEXT:    v_cndmask_b32_e64 v19, v32, v19, s[20:21]
+; GFX900-NEXT:    v_cndmask_b32_e64 v21, v32, v21, s[22:23]
+; GFX900-NEXT:    v_cndmask_b32_e64 v23, v32, v23, s[24:25]
+; GFX900-NEXT:    v_cndmask_b32_e64 v25, v32, v25, s[26:27]
+; GFX900-NEXT:    v_cndmask_b32_e64 v27, v32, v27, s[28:29]
+; GFX900-NEXT:    v_cndmask_b32_e64 v29, v32, v29, s[40:41]
+; GFX900-NEXT:    v_cndmask_b32_e64 v31, v32, v31, s[42:43]
+; GFX900-NEXT:    v_cndmask_b32_e64 v30, 0, v30, s[42:43]
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_minimum_v16f64:
@@ -2580,107 +2570,107 @@ define <16 x double> @v_minimum_v16f64(<16 x double> %src0, <16 x double> %src1)
 ; GFX950-NEXT:    scratch_load_dword v32, off, s32 offset:100
 ; GFX950-NEXT:    s_waitcnt vmcnt(25)
 ; GFX950-NEXT:    v_min_f64 v[58:59], v[0:1], v[34:35]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[34:35]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[34:35]
 ; GFX950-NEXT:    scratch_load_dword v35, off, s32 offset:112
 ; GFX950-NEXT:    scratch_load_dword v34, off, s32 offset:108
 ; GFX950-NEXT:    s_waitcnt vmcnt(25)
 ; GFX950-NEXT:    v_min_f64 v[60:61], v[2:3], v[36:37]
-; GFX950-NEXT:    v_cmp_u_f64_e64 s[0:1], v[2:3], v[36:37]
+; GFX950-NEXT:    v_cmp_o_f64_e64 s[0:1], v[2:3], v[36:37]
 ; GFX950-NEXT:    scratch_load_dword v37, off, s32 offset:120
 ; GFX950-NEXT:    scratch_load_dword v36, off, s32 offset:116
 ; GFX950-NEXT:    s_waitcnt vmcnt(25)
 ; GFX950-NEXT:    v_min_f64 v[62:63], v[4:5], v[38:39]
-; GFX950-NEXT:    v_cmp_u_f64_e64 s[2:3], v[4:5], v[38:39]
+; GFX950-NEXT:    v_cmp_o_f64_e64 s[2:3], v[4:5], v[38:39]
 ; GFX950-NEXT:    scratch_load_dword v39, off, s32 offset:128
 ; GFX950-NEXT:    scratch_load_dword v38, off, s32 offset:124
 ; GFX950-NEXT:    v_mov_b32_e32 v2, 0x7ff80000
 ; GFX950-NEXT:    s_waitcnt vmcnt(25)
 ; GFX950-NEXT:    v_min_f64 v[0:1], v[6:7], v[56:57]
-; GFX950-NEXT:    v_cmp_u_f64_e64 s[4:5], v[6:7], v[56:57]
+; GFX950-NEXT:    v_cmp_o_f64_e64 s[4:5], v[6:7], v[56:57]
 ; GFX950-NEXT:    s_waitcnt vmcnt(23)
 ; GFX950-NEXT:    v_min_f64 v[56:57], v[8:9], v[46:47]
-; GFX950-NEXT:    v_cndmask_b32_e64 v58, v58, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v59, v59, v2, vcc
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[8:9], v[46:47]
-; GFX950-NEXT:    v_cndmask_b32_e64 v6, v0, 0, s[4:5]
-; GFX950-NEXT:    v_cndmask_b32_e64 v7, v1, v2, s[4:5]
-; GFX950-NEXT:    v_cndmask_b32_e64 v8, v56, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v9, v57, v2, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v58, 0, v58, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v59, v2, v59, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[8:9], v[46:47]
+; GFX950-NEXT:    v_cndmask_b32_e64 v6, 0, v0, s[4:5]
+; GFX950-NEXT:    v_cndmask_b32_e64 v7, v2, v1, s[4:5]
+; GFX950-NEXT:    v_cndmask_b32_e32 v8, 0, v56, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v9, v2, v57, vcc
 ; GFX950-NEXT:    s_waitcnt vmcnt(21)
 ; GFX950-NEXT:    v_min_f64 v[0:1], v[10:11], v[44:45]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[10:11], v[44:45]
-; GFX950-NEXT:    v_cndmask_b32_e64 v60, v60, 0, s[0:1]
-; GFX950-NEXT:    v_cndmask_b32_e64 v3, v61, v2, s[0:1]
-; GFX950-NEXT:    v_cndmask_b32_e64 v10, v0, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v11, v1, v2, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[10:11], v[44:45]
+; GFX950-NEXT:    v_cndmask_b32_e64 v60, 0, v60, s[0:1]
+; GFX950-NEXT:    v_cndmask_b32_e64 v3, v2, v61, s[0:1]
+; GFX950-NEXT:    v_cndmask_b32_e32 v10, 0, v0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v11, v2, v1, vcc
 ; GFX950-NEXT:    s_waitcnt vmcnt(19)
 ; GFX950-NEXT:    v_min_f64 v[0:1], v[12:13], v[42:43]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[12:13], v[42:43]
-; GFX950-NEXT:    v_cndmask_b32_e64 v4, v62, 0, s[2:3]
-; GFX950-NEXT:    v_cndmask_b32_e64 v5, v63, v2, s[2:3]
-; GFX950-NEXT:    v_cndmask_b32_e64 v12, v0, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v13, v1, v2, vcc
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[12:13], v[42:43]
+; GFX950-NEXT:    v_cndmask_b32_e64 v4, 0, v62, s[2:3]
+; GFX950-NEXT:    v_cndmask_b32_e64 v5, v2, v63, s[2:3]
+; GFX950-NEXT:    v_cndmask_b32_e32 v12, 0, v0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v13, v2, v1, vcc
 ; GFX950-NEXT:    s_waitcnt vmcnt(17)
 ; GFX950-NEXT:    v_min_f64 v[0:1], v[14:15], v[40:41]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[14:15], v[40:41]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[14:15], v[40:41]
 ; GFX950-NEXT:    v_accvgpr_read_b32 v63, a15 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_read_b32 v62, a14 ; Reload Reuse
-; GFX950-NEXT:    v_cndmask_b32_e64 v14, v0, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v15, v1, v2, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v14, 0, v0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v15, v2, v1, vcc
 ; GFX950-NEXT:    s_waitcnt vmcnt(15)
 ; GFX950-NEXT:    v_min_f64 v[0:1], v[16:17], v[54:55]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[16:17], v[54:55]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[16:17], v[54:55]
 ; GFX950-NEXT:    v_accvgpr_read_b32 v61, a13 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_read_b32 v57, a9 ; Reload Reuse
-; GFX950-NEXT:    v_cndmask_b32_e64 v16, v0, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v17, v1, v2, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v16, 0, v0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v17, v2, v1, vcc
 ; GFX950-NEXT:    s_waitcnt vmcnt(13)
 ; GFX950-NEXT:    v_min_f64 v[0:1], v[18:19], v[52:53]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[18:19], v[52:53]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[18:19], v[52:53]
 ; GFX950-NEXT:    v_accvgpr_read_b32 v56, a8 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_read_b32 v47, a7 ; Reload Reuse
-; GFX950-NEXT:    v_cndmask_b32_e64 v18, v0, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v19, v1, v2, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v18, 0, v0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v19, v2, v1, vcc
 ; GFX950-NEXT:    s_waitcnt vmcnt(11)
 ; GFX950-NEXT:    v_min_f64 v[0:1], v[20:21], v[50:51]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[20:21], v[50:51]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[20:21], v[50:51]
 ; GFX950-NEXT:    v_accvgpr_read_b32 v46, a6 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_read_b32 v45, a5 ; Reload Reuse
-; GFX950-NEXT:    v_cndmask_b32_e64 v20, v0, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v21, v1, v2, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v20, 0, v0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v21, v2, v1, vcc
 ; GFX950-NEXT:    s_waitcnt vmcnt(9)
 ; GFX950-NEXT:    v_min_f64 v[0:1], v[22:23], v[48:49]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[22:23], v[48:49]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[22:23], v[48:49]
 ; GFX950-NEXT:    v_accvgpr_read_b32 v44, a4 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_read_b32 v43, a3 ; Reload Reuse
-; GFX950-NEXT:    v_cndmask_b32_e64 v22, v0, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v23, v1, v2, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v22, 0, v0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v23, v2, v1, vcc
 ; GFX950-NEXT:    s_waitcnt vmcnt(6)
 ; GFX950-NEXT:    v_min_f64 v[0:1], v[24:25], v[32:33]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[24:25], v[32:33]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[24:25], v[32:33]
 ; GFX950-NEXT:    v_accvgpr_read_b32 v42, a2 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_read_b32 v41, a1 ; Reload Reuse
-; GFX950-NEXT:    v_cndmask_b32_e64 v24, v0, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v25, v1, v2, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v24, 0, v0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v25, v2, v1, vcc
 ; GFX950-NEXT:    v_accvgpr_read_b32 v40, a0 ; Reload Reuse
 ; GFX950-NEXT:    s_waitcnt vmcnt(4)
 ; GFX950-NEXT:    v_min_f64 v[0:1], v[26:27], v[34:35]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[26:27], v[34:35]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[26:27], v[34:35]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v26, v0, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v27, v1, v2, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v26, 0, v0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v27, v2, v1, vcc
 ; GFX950-NEXT:    s_waitcnt vmcnt(2)
 ; GFX950-NEXT:    v_min_f64 v[0:1], v[28:29], v[36:37]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[28:29], v[36:37]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[28:29], v[36:37]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v28, v0, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v29, v1, v2, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v28, 0, v0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v29, v2, v1, vcc
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_min_f64 v[0:1], v[30:31], v[38:39]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[30:31], v[38:39]
+; GFX950-NEXT:    v_cmp_o_f64_e32 vcc, v[30:31], v[38:39]
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v30, v0, 0, vcc
-; GFX950-NEXT:    v_cndmask_b32_e32 v31, v1, v2, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v30, 0, v0, vcc
+; GFX950-NEXT:    v_cndmask_b32_e32 v31, v2, v1, vcc
 ; GFX950-NEXT:    v_mov_b32_e32 v0, v58
 ; GFX950-NEXT:    v_mov_b32_e32 v1, v59
 ; GFX950-NEXT:    v_mov_b32_e32 v2, v60
@@ -2720,13 +2710,13 @@ define <16 x double> @v_minimum_v16f64(<16 x double> %src0, <16 x double> %src1)
 ; GFX10-NEXT:    buffer_load_dword v51, off, s[0:3], s32 offset:72
 ; GFX10-NEXT:    s_waitcnt vmcnt(23)
 ; GFX10-NEXT:    v_min_f64 v[82:83], v[0:1], v[31:32]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[31:32]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[31:32]
 ; GFX10-NEXT:    s_waitcnt vmcnt(21)
 ; GFX10-NEXT:    v_min_f64 v[84:85], v[2:3], v[33:34]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[2:3], v[33:34]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[2:3], v[33:34]
 ; GFX10-NEXT:    s_waitcnt vmcnt(19)
 ; GFX10-NEXT:    v_min_f64 v[32:33], v[4:5], v[35:36]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s5, v[4:5], v[35:36]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s5, v[4:5], v[35:36]
 ; GFX10-NEXT:    s_clause 0x7
 ; GFX10-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:112
 ; GFX10-NEXT:    buffer_load_dword v67, off, s[0:3], s32 offset:104
@@ -2738,74 +2728,74 @@ define <16 x double> @v_minimum_v16f64(<16 x double> %src0, <16 x double> %src1)
 ; GFX10-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:124
 ; GFX10-NEXT:    s_waitcnt vmcnt(24)
 ; GFX10-NEXT:    v_min_f64 v[34:35], v[6:7], v[48:49]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s6, v[6:7], v[48:49]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s6, v[6:7], v[48:49]
 ; GFX10-NEXT:    s_waitcnt vmcnt(21)
-; GFX10-NEXT:    v_cmp_u_f64_e64 s10, v[14:15], v[52:53]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s10, v[14:15], v[52:53]
 ; GFX10-NEXT:    s_waitcnt vmcnt(19)
-; GFX10-NEXT:    v_cmp_u_f64_e64 s9, v[12:13], v[54:55]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s9, v[12:13], v[54:55]
 ; GFX10-NEXT:    s_waitcnt vmcnt(17)
-; GFX10-NEXT:    v_cmp_u_f64_e64 s8, v[10:11], v[64:65]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s8, v[10:11], v[64:65]
 ; GFX10-NEXT:    s_waitcnt vmcnt(16)
 ; GFX10-NEXT:    v_min_f64 v[48:49], v[8:9], v[37:38]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s7, v[8:9], v[37:38]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s7, v[8:9], v[37:38]
 ; GFX10-NEXT:    v_min_f64 v[36:37], v[10:11], v[64:65]
 ; GFX10-NEXT:    v_min_f64 v[38:39], v[12:13], v[54:55]
 ; GFX10-NEXT:    v_min_f64 v[54:55], v[14:15], v[52:53]
 ; GFX10-NEXT:    s_waitcnt vmcnt(11)
 ; GFX10-NEXT:    v_min_f64 v[64:65], v[20:21], v[70:71]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s13, v[20:21], v[70:71]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s13, v[20:21], v[70:71]
 ; GFX10-NEXT:    s_waitcnt vmcnt(9)
-; GFX10-NEXT:    v_cmp_u_f64_e64 s12, v[18:19], v[80:81]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s12, v[18:19], v[80:81]
 ; GFX10-NEXT:    s_waitcnt vmcnt(8)
 ; GFX10-NEXT:    v_min_f64 v[52:53], v[16:17], v[50:51]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s11, v[16:17], v[50:51]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s11, v[16:17], v[50:51]
 ; GFX10-NEXT:    v_min_f64 v[50:51], v[18:19], v[80:81]
 ; GFX10-NEXT:    v_min_f64 v[70:71], v[22:23], v[68:69]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s14, v[22:23], v[68:69]
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, v34, 0, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v7, v35, 0x7ff80000, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v8, v48, 0, s7
-; GFX10-NEXT:    v_cndmask_b32_e64 v9, v49, 0x7ff80000, s7
-; GFX10-NEXT:    v_cndmask_b32_e64 v10, v36, 0, s8
-; GFX10-NEXT:    v_cndmask_b32_e64 v11, v37, 0x7ff80000, s8
-; GFX10-NEXT:    v_cndmask_b32_e64 v12, v38, 0, s9
-; GFX10-NEXT:    v_cndmask_b32_e64 v13, v39, 0x7ff80000, s9
-; GFX10-NEXT:    v_cndmask_b32_e64 v14, v54, 0, s10
-; GFX10-NEXT:    v_cndmask_b32_e64 v15, v55, 0x7ff80000, s10
-; GFX10-NEXT:    v_cndmask_b32_e64 v16, v52, 0, s11
-; GFX10-NEXT:    v_cndmask_b32_e64 v17, v53, 0x7ff80000, s11
-; GFX10-NEXT:    v_cndmask_b32_e64 v18, v50, 0, s12
-; GFX10-NEXT:    v_cndmask_b32_e64 v19, v51, 0x7ff80000, s12
-; GFX10-NEXT:    v_cndmask_b32_e64 v20, v64, 0, s13
-; GFX10-NEXT:    v_cndmask_b32_e64 v21, v65, 0x7ff80000, s13
-; GFX10-NEXT:    v_cndmask_b32_e64 v22, v70, 0, s14
-; GFX10-NEXT:    v_cndmask_b32_e64 v23, v71, 0x7ff80000, s14
+; GFX10-NEXT:    v_cmp_o_f64_e64 s14, v[22:23], v[68:69]
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, 0, v34, s6
+; GFX10-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v35, s6
+; GFX10-NEXT:    v_cndmask_b32_e64 v8, 0, v48, s7
+; GFX10-NEXT:    v_cndmask_b32_e64 v9, 0x7ff80000, v49, s7
+; GFX10-NEXT:    v_cndmask_b32_e64 v10, 0, v36, s8
+; GFX10-NEXT:    v_cndmask_b32_e64 v11, 0x7ff80000, v37, s8
+; GFX10-NEXT:    v_cndmask_b32_e64 v12, 0, v38, s9
+; GFX10-NEXT:    v_cndmask_b32_e64 v13, 0x7ff80000, v39, s9
+; GFX10-NEXT:    v_cndmask_b32_e64 v14, 0, v54, s10
+; GFX10-NEXT:    v_cndmask_b32_e64 v15, 0x7ff80000, v55, s10
+; GFX10-NEXT:    v_cndmask_b32_e64 v16, 0, v52, s11
+; GFX10-NEXT:    v_cndmask_b32_e64 v17, 0x7ff80000, v53, s11
+; GFX10-NEXT:    v_cndmask_b32_e64 v18, 0, v50, s12
+; GFX10-NEXT:    v_cndmask_b32_e64 v19, 0x7ff80000, v51, s12
+; GFX10-NEXT:    v_cndmask_b32_e64 v20, 0, v64, s13
+; GFX10-NEXT:    v_cndmask_b32_e64 v21, 0x7ff80000, v65, s13
+; GFX10-NEXT:    v_cndmask_b32_e64 v22, 0, v70, s14
+; GFX10-NEXT:    v_cndmask_b32_e64 v23, 0x7ff80000, v71, s14
 ; GFX10-NEXT:    s_waitcnt vmcnt(6)
 ; GFX10-NEXT:    v_min_f64 v[68:69], v[24:25], v[66:67]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s15, v[24:25], v[66:67]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s15, v[24:25], v[66:67]
 ; GFX10-NEXT:    s_waitcnt vmcnt(5)
 ; GFX10-NEXT:    v_min_f64 v[66:67], v[26:27], v[0:1]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s16, v[26:27], v[0:1]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s16, v[26:27], v[0:1]
 ; GFX10-NEXT:    s_waitcnt vmcnt(3)
 ; GFX10-NEXT:    v_min_f64 v[80:81], v[28:29], v[2:3]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s17, v[28:29], v[2:3]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s17, v[28:29], v[2:3]
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-NEXT:    v_min_f64 v[86:87], v[30:31], v[4:5]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s18, v[30:31], v[4:5]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v82, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v83, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v84, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v85, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v32, 0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v33, 0x7ff80000, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v24, v68, 0, s15
-; GFX10-NEXT:    v_cndmask_b32_e64 v25, v69, 0x7ff80000, s15
-; GFX10-NEXT:    v_cndmask_b32_e64 v26, v66, 0, s16
-; GFX10-NEXT:    v_cndmask_b32_e64 v27, v67, 0x7ff80000, s16
-; GFX10-NEXT:    v_cndmask_b32_e64 v28, v80, 0, s17
-; GFX10-NEXT:    v_cndmask_b32_e64 v29, v81, 0x7ff80000, s17
-; GFX10-NEXT:    v_cndmask_b32_e64 v30, v86, 0, s18
-; GFX10-NEXT:    v_cndmask_b32_e64 v31, v87, 0x7ff80000, s18
+; GFX10-NEXT:    v_cmp_o_f64_e64 s18, v[30:31], v[4:5]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v82, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v83, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v84, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v85, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, v32, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v33, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v24, 0, v68, s15
+; GFX10-NEXT:    v_cndmask_b32_e64 v25, 0x7ff80000, v69, s15
+; GFX10-NEXT:    v_cndmask_b32_e64 v26, 0, v66, s16
+; GFX10-NEXT:    v_cndmask_b32_e64 v27, 0x7ff80000, v67, s16
+; GFX10-NEXT:    v_cndmask_b32_e64 v28, 0, v80, s17
+; GFX10-NEXT:    v_cndmask_b32_e64 v29, 0x7ff80000, v81, s17
+; GFX10-NEXT:    v_cndmask_b32_e64 v30, 0, v86, s18
+; GFX10-NEXT:    v_cndmask_b32_e64 v31, 0x7ff80000, v87, s18
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_v16f64:
@@ -2847,84 +2837,83 @@ define <16 x double> @v_minimum_v16f64(<16 x double> %src0, <16 x double> %src1)
 ; GFX11-NEXT:    scratch_load_b32 v86, off, s32 offset:124
 ; GFX11-NEXT:    s_waitcnt vmcnt(30)
 ; GFX11-NEXT:    v_min_f64 v[96:97], v[0:1], v[32:33]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[32:33]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[32:33]
 ; GFX11-NEXT:    s_waitcnt vmcnt(28)
 ; GFX11-NEXT:    v_min_f64 v[32:33], v[2:3], v[34:35]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[2:3], v[34:35]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[2:3], v[34:35]
 ; GFX11-NEXT:    s_waitcnt vmcnt(26)
 ; GFX11-NEXT:    v_min_f64 v[34:35], v[4:5], v[36:37]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s1, v[4:5], v[36:37]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s1, v[4:5], v[36:37]
 ; GFX11-NEXT:    s_waitcnt vmcnt(24)
 ; GFX11-NEXT:    v_min_f64 v[36:37], v[6:7], v[38:39]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s2, v[6:7], v[38:39]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s2, v[6:7], v[38:39]
 ; GFX11-NEXT:    s_waitcnt vmcnt(22)
 ; GFX11-NEXT:    v_min_f64 v[38:39], v[8:9], v[48:49]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s3, v[8:9], v[48:49]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s3, v[8:9], v[48:49]
 ; GFX11-NEXT:    s_waitcnt vmcnt(20)
 ; GFX11-NEXT:    v_min_f64 v[48:49], v[10:11], v[50:51]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s4, v[10:11], v[50:51]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s4, v[10:11], v[50:51]
 ; GFX11-NEXT:    s_waitcnt vmcnt(18)
 ; GFX11-NEXT:    v_min_f64 v[50:51], v[12:13], v[52:53]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s5, v[12:13], v[52:53]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s5, v[12:13], v[52:53]
 ; GFX11-NEXT:    s_waitcnt vmcnt(16)
 ; GFX11-NEXT:    v_min_f64 v[52:53], v[14:15], v[54:55]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s6, v[14:15], v[54:55]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s6, v[14:15], v[54:55]
 ; GFX11-NEXT:    s_waitcnt vmcnt(14)
 ; GFX11-NEXT:    v_min_f64 v[54:55], v[16:17], v[64:65]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s7, v[16:17], v[64:65]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s7, v[16:17], v[64:65]
 ; GFX11-NEXT:    s_waitcnt vmcnt(12)
 ; GFX11-NEXT:    v_min_f64 v[64:65], v[18:19], v[66:67]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s8, v[18:19], v[66:67]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s8, v[18:19], v[66:67]
 ; GFX11-NEXT:    s_waitcnt vmcnt(10)
 ; GFX11-NEXT:    v_min_f64 v[66:67], v[20:21], v[68:69]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s9, v[20:21], v[68:69]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s9, v[20:21], v[68:69]
 ; GFX11-NEXT:    s_waitcnt vmcnt(8)
 ; GFX11-NEXT:    v_min_f64 v[68:69], v[22:23], v[70:71]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s10, v[22:23], v[70:71]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s10, v[22:23], v[70:71]
 ; GFX11-NEXT:    s_waitcnt vmcnt(6)
 ; GFX11-NEXT:    v_min_f64 v[70:71], v[24:25], v[80:81]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s11, v[24:25], v[80:81]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s11, v[24:25], v[80:81]
 ; GFX11-NEXT:    s_waitcnt vmcnt(4)
 ; GFX11-NEXT:    v_min_f64 v[80:81], v[26:27], v[82:83]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s12, v[26:27], v[82:83]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s12, v[26:27], v[82:83]
 ; GFX11-NEXT:    s_waitcnt vmcnt(2)
 ; GFX11-NEXT:    v_min_f64 v[82:83], v[28:29], v[84:85]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s13, v[28:29], v[84:85]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s13, v[28:29], v[84:85]
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    v_min_f64 v[84:85], v[30:31], v[86:87]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s14, v[30:31], v[86:87]
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v96, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v97, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v32, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v33, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v34, 0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v35, 0x7ff80000, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v6, v36, 0, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v7, v37, 0x7ff80000, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v8, v38, 0, s3
-; GFX11-NEXT:    v_cndmask_b32_e64 v9, v39, 0x7ff80000, s3
-; GFX11-NEXT:    v_cndmask_b32_e64 v10, v48, 0, s4
-; GFX11-NEXT:    v_cndmask_b32_e64 v11, v49, 0x7ff80000, s4
-; GFX11-NEXT:    v_cndmask_b32_e64 v12, v50, 0, s5
-; GFX11-NEXT:    v_cndmask_b32_e64 v13, v51, 0x7ff80000, s5
-; GFX11-NEXT:    v_cndmask_b32_e64 v14, v52, 0, s6
-; GFX11-NEXT:    v_cndmask_b32_e64 v15, v53, 0x7ff80000, s6
-; GFX11-NEXT:    v_cndmask_b32_e64 v16, v54, 0, s7
-; GFX11-NEXT:    v_cndmask_b32_e64 v17, v55, 0x7ff80000, s7
-; GFX11-NEXT:    v_cndmask_b32_e64 v18, v64, 0, s8
-; GFX11-NEXT:    v_cndmask_b32_e64 v19, v65, 0x7ff80000, s8
-; GFX11-NEXT:    v_cndmask_b32_e64 v20, v66, 0, s9
-; GFX11-NEXT:    v_cndmask_b32_e64 v21, v67, 0x7ff80000, s9
-; GFX11-NEXT:    v_cndmask_b32_e64 v22, v68, 0, s10
-; GFX11-NEXT:    v_cndmask_b32_e64 v23, v69, 0x7ff80000, s10
-; GFX11-NEXT:    v_cndmask_b32_e64 v24, v70, 0, s11
-; GFX11-NEXT:    v_cndmask_b32_e64 v25, v71, 0x7ff80000, s11
-; GFX11-NEXT:    v_cndmask_b32_e64 v26, v80, 0, s12
-; GFX11-NEXT:    v_cndmask_b32_e64 v27, v81, 0x7ff80000, s12
-; GFX11-NEXT:    v_cndmask_b32_e64 v28, v82, 0, s13
-; GFX11-NEXT:    v_cndmask_b32_e64 v29, v83, 0x7ff80000, s13
-; GFX11-NEXT:    v_cndmask_b32_e64 v30, v84, 0, s14
-; GFX11-NEXT:    v_cndmask_b32_e64 v31, v85, 0x7ff80000, s14
+; GFX11-NEXT:    v_cmp_o_f64_e64 s14, v[30:31], v[86:87]
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v96 :: v_dual_cndmask_b32 v1, 0x7ff80000, v97
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v32, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v33, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v4, 0, v34, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v35, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v6, 0, v36, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v37, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v8, 0, v38, s3
+; GFX11-NEXT:    v_cndmask_b32_e64 v9, 0x7ff80000, v39, s3
+; GFX11-NEXT:    v_cndmask_b32_e64 v10, 0, v48, s4
+; GFX11-NEXT:    v_cndmask_b32_e64 v11, 0x7ff80000, v49, s4
+; GFX11-NEXT:    v_cndmask_b32_e64 v12, 0, v50, s5
+; GFX11-NEXT:    v_cndmask_b32_e64 v13, 0x7ff80000, v51, s5
+; GFX11-NEXT:    v_cndmask_b32_e64 v14, 0, v52, s6
+; GFX11-NEXT:    v_cndmask_b32_e64 v15, 0x7ff80000, v53, s6
+; GFX11-NEXT:    v_cndmask_b32_e64 v16, 0, v54, s7
+; GFX11-NEXT:    v_cndmask_b32_e64 v17, 0x7ff80000, v55, s7
+; GFX11-NEXT:    v_cndmask_b32_e64 v18, 0, v64, s8
+; GFX11-NEXT:    v_cndmask_b32_e64 v19, 0x7ff80000, v65, s8
+; GFX11-NEXT:    v_cndmask_b32_e64 v20, 0, v66, s9
+; GFX11-NEXT:    v_cndmask_b32_e64 v21, 0x7ff80000, v67, s9
+; GFX11-NEXT:    v_cndmask_b32_e64 v22, 0, v68, s10
+; GFX11-NEXT:    v_cndmask_b32_e64 v23, 0x7ff80000, v69, s10
+; GFX11-NEXT:    v_cndmask_b32_e64 v24, 0, v70, s11
+; GFX11-NEXT:    v_cndmask_b32_e64 v25, 0x7ff80000, v71, s11
+; GFX11-NEXT:    v_cndmask_b32_e64 v26, 0, v80, s12
+; GFX11-NEXT:    v_cndmask_b32_e64 v27, 0x7ff80000, v81, s12
+; GFX11-NEXT:    v_cndmask_b32_e64 v28, 0, v82, s13
+; GFX11-NEXT:    v_cndmask_b32_e64 v29, 0x7ff80000, v83, s13
+; GFX11-NEXT:    v_cndmask_b32_e64 v30, 0, v84, s14
+; GFX11-NEXT:    v_cndmask_b32_e64 v31, 0x7ff80000, v85, s14
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: v_minimum_v16f64:

--- a/llvm/test/CodeGen/AMDGPU/llvm.modf.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.modf.ll
@@ -363,13 +363,14 @@ define { double, double } @test_modf_f64(double %x) {
 ; GFX9-SDAG:       ; %bb.0:
 ; GFX9-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-SDAG-NEXT:    v_trunc_f64_e32 v[2:3], v[0:1]
-; GFX9-SDAG-NEXT:    s_movk_i32 s4, 0x204
-; GFX9-SDAG-NEXT:    v_cmp_class_f64_e64 s[4:5], v[0:1], s4
-; GFX9-SDAG-NEXT:    s_brev_b32 s6, -2
+; GFX9-SDAG-NEXT:    s_mov_b32 s4, 0
+; GFX9-SDAG-NEXT:    s_mov_b32 s5, 0x7ff00000
+; GFX9-SDAG-NEXT:    v_cmp_neq_f64_e64 vcc, |v[0:1]|, s[4:5]
+; GFX9-SDAG-NEXT:    s_brev_b32 s4, -2
 ; GFX9-SDAG-NEXT:    v_add_f64 v[4:5], v[0:1], -v[2:3]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v0, v4, 0, s[4:5]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v4, v5, 0, s[4:5]
-; GFX9-SDAG-NEXT:    v_bfi_b32 v1, s6, v4, v1
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v5, vcc
+; GFX9-SDAG-NEXT:    v_bfi_b32 v1, s4, v4, v1
 ; GFX9-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-GISEL-LABEL: test_modf_f64:
@@ -395,13 +396,14 @@ define double @test_modf_f64_only_use_fract(double %x) {
 ; GFX9-SDAG:       ; %bb.0:
 ; GFX9-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-SDAG-NEXT:    v_trunc_f64_e32 v[2:3], v[0:1]
-; GFX9-SDAG-NEXT:    s_movk_i32 s4, 0x204
-; GFX9-SDAG-NEXT:    v_cmp_class_f64_e64 s[4:5], v[0:1], s4
-; GFX9-SDAG-NEXT:    s_brev_b32 s6, -2
+; GFX9-SDAG-NEXT:    s_mov_b32 s4, 0
+; GFX9-SDAG-NEXT:    s_mov_b32 s5, 0x7ff00000
+; GFX9-SDAG-NEXT:    v_cmp_neq_f64_e64 vcc, |v[0:1]|, s[4:5]
+; GFX9-SDAG-NEXT:    s_brev_b32 s4, -2
 ; GFX9-SDAG-NEXT:    v_add_f64 v[2:3], v[0:1], -v[2:3]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v0, v2, 0, s[4:5]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v2, v3, 0, s[4:5]
-; GFX9-SDAG-NEXT:    v_bfi_b32 v1, s6, v2, v1
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v2, 0, v3, vcc
+; GFX9-SDAG-NEXT:    v_bfi_b32 v1, s4, v2, v1
 ; GFX9-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-GISEL-LABEL: test_modf_f64_only_use_fract:
@@ -440,18 +442,19 @@ define { <2 x double>, <2 x double> } @test_modf_v2f64(<2 x double> %x) {
 ; GFX9-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-SDAG-NEXT:    v_trunc_f64_e32 v[4:5], v[0:1]
 ; GFX9-SDAG-NEXT:    v_trunc_f64_e32 v[6:7], v[2:3]
-; GFX9-SDAG-NEXT:    s_movk_i32 s6, 0x204
-; GFX9-SDAG-NEXT:    v_cmp_class_f64_e64 s[4:5], v[0:1], s6
-; GFX9-SDAG-NEXT:    v_cmp_class_f64_e64 s[6:7], v[2:3], s6
-; GFX9-SDAG-NEXT:    s_brev_b32 s8, -2
+; GFX9-SDAG-NEXT:    s_mov_b32 s4, 0
+; GFX9-SDAG-NEXT:    s_mov_b32 s5, 0x7ff00000
+; GFX9-SDAG-NEXT:    v_cmp_neq_f64_e64 vcc, |v[0:1]|, s[4:5]
+; GFX9-SDAG-NEXT:    v_cmp_neq_f64_e64 s[4:5], |v[2:3]|, s[4:5]
+; GFX9-SDAG-NEXT:    s_brev_b32 s6, -2
 ; GFX9-SDAG-NEXT:    v_add_f64 v[8:9], v[0:1], -v[4:5]
 ; GFX9-SDAG-NEXT:    v_add_f64 v[10:11], v[2:3], -v[6:7]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v0, v8, 0, s[4:5]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v8, v9, 0, s[4:5]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v9, v11, 0, s[6:7]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v2, v10, 0, s[6:7]
-; GFX9-SDAG-NEXT:    v_bfi_b32 v1, s8, v8, v1
-; GFX9-SDAG-NEXT:    v_bfi_b32 v3, s8, v9, v3
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v8, 0, v9, vcc
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v9, 0, v11, s[4:5]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v2, 0, v10, s[4:5]
+; GFX9-SDAG-NEXT:    v_bfi_b32 v1, s6, v8, v1
+; GFX9-SDAG-NEXT:    v_bfi_b32 v3, s6, v9, v3
 ; GFX9-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-GISEL-LABEL: test_modf_v2f64:
@@ -485,18 +488,19 @@ define <2 x double> @test_modf_v2f64_only_use_fract(<2 x double> %x) {
 ; GFX9-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-SDAG-NEXT:    v_trunc_f64_e32 v[4:5], v[0:1]
 ; GFX9-SDAG-NEXT:    v_trunc_f64_e32 v[6:7], v[2:3]
-; GFX9-SDAG-NEXT:    s_movk_i32 s6, 0x204
-; GFX9-SDAG-NEXT:    v_cmp_class_f64_e64 s[4:5], v[0:1], s6
-; GFX9-SDAG-NEXT:    v_cmp_class_f64_e64 s[6:7], v[2:3], s6
-; GFX9-SDAG-NEXT:    s_brev_b32 s8, -2
+; GFX9-SDAG-NEXT:    s_mov_b32 s4, 0
+; GFX9-SDAG-NEXT:    s_mov_b32 s5, 0x7ff00000
+; GFX9-SDAG-NEXT:    v_cmp_neq_f64_e64 vcc, |v[0:1]|, s[4:5]
+; GFX9-SDAG-NEXT:    v_cmp_neq_f64_e64 s[4:5], |v[2:3]|, s[4:5]
+; GFX9-SDAG-NEXT:    s_brev_b32 s6, -2
 ; GFX9-SDAG-NEXT:    v_add_f64 v[4:5], v[0:1], -v[4:5]
 ; GFX9-SDAG-NEXT:    v_add_f64 v[6:7], v[2:3], -v[6:7]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v0, v4, 0, s[4:5]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v4, v5, 0, s[4:5]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v5, v7, 0, s[6:7]
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v2, v6, 0, s[6:7]
-; GFX9-SDAG-NEXT:    v_bfi_b32 v1, s8, v4, v1
-; GFX9-SDAG-NEXT:    v_bfi_b32 v3, s8, v5, v3
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v5, vcc
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v5, 0, v7, s[4:5]
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v2, 0, v6, s[4:5]
+; GFX9-SDAG-NEXT:    v_bfi_b32 v1, s6, v4, v1
+; GFX9-SDAG-NEXT:    v_bfi_b32 v3, s6, v5, v3
 ; GFX9-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-GISEL-LABEL: test_modf_v2f64_only_use_fract:

--- a/llvm/test/CodeGen/AMDGPU/llvm.mulo.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.mulo.ll
@@ -352,11 +352,11 @@ define amdgpu_kernel void @umulo_i64_s(i64 %x, i64 %y) {
 ; SI-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
 ; SI-NEXT:    v_add_i32_e32 v2, vcc, s5, v2
 ; SI-NEXT:    v_add_i32_e32 v2, vcc, s4, v2
-; SI-NEXT:    v_cmp_ne_u64_e32 vcc, 0, v[0:1]
+; SI-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[0:1]
 ; SI-NEXT:    s_mul_i32 s2, s0, s2
 ; SI-NEXT:    s_and_b64 s[0:1], vcc, exec
-; SI-NEXT:    s_cselect_b32 s0, 0, s2
-; SI-NEXT:    v_cndmask_b32_e64 v1, v2, 0, vcc
+; SI-NEXT:    s_cselect_b32 s0, s2, 0
+; SI-NEXT:    v_cndmask_b32_e32 v1, 0, v2, vcc
 ; SI-NEXT:    v_mov_b32_e32 v0, s0
 ; SI-NEXT:    s_mov_b32 s3, 0xf000
 ; SI-NEXT:    s_mov_b32 s2, -1
@@ -384,9 +384,9 @@ define amdgpu_kernel void @umulo_i64_s(i64 %x, i64 %y) {
 ; GFX9-NEXT:    s_add_i32 s1, s8, s7
 ; GFX9-NEXT:    s_add_i32 s1, s1, s6
 ; GFX9-NEXT:    s_mul_i32 s0, s0, s2
-; GFX9-NEXT:    s_cmp_lg_u64 s[4:5], 0
-; GFX9-NEXT:    s_cselect_b32 s1, 0, s1
-; GFX9-NEXT:    s_cselect_b32 s0, 0, s0
+; GFX9-NEXT:    s_cmp_eq_u64 s[4:5], 0
+; GFX9-NEXT:    s_cselect_b32 s1, s1, 0
+; GFX9-NEXT:    s_cselect_b32 s0, s0, 0
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s1
 ; GFX9-NEXT:    global_store_dwordx2 v[0:1], v[0:1], off
@@ -413,9 +413,9 @@ define amdgpu_kernel void @umulo_i64_s(i64 %x, i64 %y) {
 ; GFX10-NEXT:    s_add_i32 s1, s8, s7
 ; GFX10-NEXT:    s_mul_i32 s0, s0, s2
 ; GFX10-NEXT:    s_add_i32 s1, s1, s6
-; GFX10-NEXT:    s_cmp_lg_u64 s[4:5], 0
-; GFX10-NEXT:    s_cselect_b32 s0, 0, s0
-; GFX10-NEXT:    s_cselect_b32 s1, 0, s1
+; GFX10-NEXT:    s_cmp_eq_u64 s[4:5], 0
+; GFX10-NEXT:    s_cselect_b32 s0, s0, 0
+; GFX10-NEXT:    s_cselect_b32 s1, s1, 0
 ; GFX10-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX10-NEXT:    v_mov_b32_e32 v1, s1
 ; GFX10-NEXT:    global_store_dwordx2 v[0:1], v[0:1], off
@@ -442,9 +442,9 @@ define amdgpu_kernel void @umulo_i64_s(i64 %x, i64 %y) {
 ; GFX11-NEXT:    s_add_i32 s1, s8, s7
 ; GFX11-NEXT:    s_mul_i32 s0, s0, s2
 ; GFX11-NEXT:    s_add_i32 s1, s1, s6
-; GFX11-NEXT:    s_cmp_lg_u64 s[4:5], 0
-; GFX11-NEXT:    s_cselect_b32 s0, 0, s0
-; GFX11-NEXT:    s_cselect_b32 s1, 0, s1
+; GFX11-NEXT:    s_cmp_eq_u64 s[4:5], 0
+; GFX11-NEXT:    s_cselect_b32 s0, s0, 0
+; GFX11-NEXT:    s_cselect_b32 s1, s1, 0
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    global_store_b64 v[0:1], v[0:1], off
@@ -469,9 +469,9 @@ define amdgpu_kernel void @umulo_i64_s(i64 %x, i64 %y) {
 ; GFX12-NEXT:    s_mul_u64 s[0:1], s[0:1], s[2:3]
 ; GFX12-NEXT:    s_add_nc_u64 s[4:5], s[4:5], s[8:9]
 ; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_2) | instid1(SALU_CYCLE_1)
-; GFX12-NEXT:    s_cmp_lg_u64 s[4:5], 0
-; GFX12-NEXT:    s_cselect_b32 s0, 0, s0
-; GFX12-NEXT:    s_cselect_b32 s1, 0, s1
+; GFX12-NEXT:    s_cmp_eq_u64 s[4:5], 0
+; GFX12-NEXT:    s_cselect_b32 s0, s0, 0
+; GFX12-NEXT:    s_cselect_b32 s1, s1, 0
 ; GFX12-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX12-NEXT:    global_store_b64 v[0:1], v[0:1], off
 ; GFX12-NEXT:    s_endpgm
@@ -523,11 +523,11 @@ define amdgpu_kernel void @smulo_i64_s(i64 %x, i64 %y) {
 ; SI-NEXT:    s_cselect_b32 s5, s5, s1
 ; SI-NEXT:    s_cselect_b32 s4, s8, s4
 ; SI-NEXT:    v_mov_b32_e32 v1, v0
-; SI-NEXT:    v_cmp_ne_u64_e32 vcc, s[4:5], v[0:1]
+; SI-NEXT:    v_cmp_eq_u64_e32 vcc, s[4:5], v[0:1]
 ; SI-NEXT:    s_mul_i32 s2, s0, s2
 ; SI-NEXT:    s_and_b64 s[0:1], vcc, exec
-; SI-NEXT:    s_cselect_b32 s0, 0, s2
-; SI-NEXT:    v_cndmask_b32_e64 v1, v2, 0, vcc
+; SI-NEXT:    s_cselect_b32 s0, s2, 0
+; SI-NEXT:    v_cndmask_b32_e32 v1, 0, v2, vcc
 ; SI-NEXT:    v_mov_b32_e32 v0, s0
 ; SI-NEXT:    s_mov_b32 s3, 0xf000
 ; SI-NEXT:    s_mov_b32 s2, -1
@@ -567,9 +567,9 @@ define amdgpu_kernel void @smulo_i64_s(i64 %x, i64 %y) {
 ; GFX9-NEXT:    s_ashr_i32 s6, s1, 31
 ; GFX9-NEXT:    s_mov_b32 s7, s6
 ; GFX9-NEXT:    s_mul_i32 s0, s0, s2
-; GFX9-NEXT:    s_cmp_lg_u64 s[4:5], s[6:7]
-; GFX9-NEXT:    s_cselect_b32 s1, 0, s1
-; GFX9-NEXT:    s_cselect_b32 s0, 0, s0
+; GFX9-NEXT:    s_cmp_eq_u64 s[4:5], s[6:7]
+; GFX9-NEXT:    s_cselect_b32 s1, s1, 0
+; GFX9-NEXT:    s_cselect_b32 s0, s0, 0
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s1
 ; GFX9-NEXT:    global_store_dwordx2 v[0:1], v[0:1], off
@@ -608,9 +608,9 @@ define amdgpu_kernel void @smulo_i64_s(i64 %x, i64 %y) {
 ; GFX10-NEXT:    s_add_i32 s1, s1, s6
 ; GFX10-NEXT:    s_ashr_i32 s6, s1, 31
 ; GFX10-NEXT:    s_mov_b32 s7, s6
-; GFX10-NEXT:    s_cmp_lg_u64 s[4:5], s[6:7]
-; GFX10-NEXT:    s_cselect_b32 s0, 0, s0
-; GFX10-NEXT:    s_cselect_b32 s1, 0, s1
+; GFX10-NEXT:    s_cmp_eq_u64 s[4:5], s[6:7]
+; GFX10-NEXT:    s_cselect_b32 s0, s0, 0
+; GFX10-NEXT:    s_cselect_b32 s1, s1, 0
 ; GFX10-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX10-NEXT:    v_mov_b32_e32 v1, s1
 ; GFX10-NEXT:    global_store_dwordx2 v[0:1], v[0:1], off
@@ -651,9 +651,9 @@ define amdgpu_kernel void @smulo_i64_s(i64 %x, i64 %y) {
 ; GFX11-NEXT:    s_ashr_i32 s6, s1, 31
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX11-NEXT:    s_mov_b32 s7, s6
-; GFX11-NEXT:    s_cmp_lg_u64 s[4:5], s[6:7]
-; GFX11-NEXT:    s_cselect_b32 s0, 0, s0
-; GFX11-NEXT:    s_cselect_b32 s1, 0, s1
+; GFX11-NEXT:    s_cmp_eq_u64 s[4:5], s[6:7]
+; GFX11-NEXT:    s_cselect_b32 s0, s0, 0
+; GFX11-NEXT:    s_cselect_b32 s1, s1, 0
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    global_store_b64 v[0:1], v[0:1], off
@@ -691,9 +691,9 @@ define amdgpu_kernel void @smulo_i64_s(i64 %x, i64 %y) {
 ; GFX12-NEXT:    s_ashr_i32 s4, s1, 31
 ; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX12-NEXT:    s_mov_b32 s5, s4
-; GFX12-NEXT:    s_cmp_lg_u64 s[2:3], s[4:5]
-; GFX12-NEXT:    s_cselect_b32 s0, 0, s0
-; GFX12-NEXT:    s_cselect_b32 s1, 0, s1
+; GFX12-NEXT:    s_cmp_eq_u64 s[2:3], s[4:5]
+; GFX12-NEXT:    s_cselect_b32 s0, s0, 0
+; GFX12-NEXT:    s_cselect_b32 s1, s1, 0
 ; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
 ; GFX12-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX12-NEXT:    global_store_b64 v[0:1], v[0:1], off

--- a/llvm/test/CodeGen/AMDGPU/uniform-vgpr-to-sgpr-return.ll
+++ b/llvm/test/CodeGen/AMDGPU/uniform-vgpr-to-sgpr-return.ll
@@ -20,12 +20,11 @@ define amdgpu_ps i64 @uniform_v_to_s_i64(double inreg %a, double inreg %b) {
 ; GFX11-LABEL: uniform_v_to_s_i64:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    v_max_f64 v[0:1], s[0:1], s[2:3]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, s[0:1], s[2:3]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_cmp_o_f64_e64 vcc_lo, s[0:1], s[2:3]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-NEXT:    v_dual_cndmask_b32 v1, 0x7ff80000, v1 :: v_dual_cndmask_b32 v0, 0, v0
 ; GFX11-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX11-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX11-NEXT:    ; return to shader part epilog
   %max0 = call double @llvm.maximum.f64(double %a, double %b)
@@ -78,12 +77,11 @@ define amdgpu_ps double @uniform_v_to_s_double(double inreg %a, double inreg %b)
 ; GFX11-LABEL: uniform_v_to_s_double:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    v_max_f64 v[0:1], s[0:1], s[2:3]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, s[0:1], s[2:3]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_cmp_o_f64_e64 vcc_lo, s[0:1], s[2:3]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-NEXT:    v_dual_cndmask_b32 v1, 0x7ff80000, v1 :: v_dual_cndmask_b32 v0, 0, v0
 ; GFX11-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX11-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX11-NEXT:    ; return to shader part epilog
   %max0 = call double @llvm.maximum.f64(double %a, double %b)

--- a/llvm/test/CodeGen/AMDGPU/v_cndmask.ll
+++ b/llvm/test/CodeGen/AMDGPU/v_cndmask.ll
@@ -2044,9 +2044,9 @@ define amdgpu_kernel void @fcmp_k0_vgprX_select_k1_vgprZ_f32_cond_use_x2(ptr add
 ; SI-NEXT:    buffer_load_dword v3, v[0:1], s[8:11], 0 addr64 glc
 ; SI-NEXT:    s_waitcnt vmcnt(0)
 ; SI-NEXT:    s_mov_b64 s[2:3], s[6:7]
-; SI-NEXT:    v_cmp_nle_f32_e32 vcc, 4.0, v2
-; SI-NEXT:    v_cndmask_b32_e64 v2, v3, -1.0, vcc
-; SI-NEXT:    v_cndmask_b32_e64 v3, v3, -2.0, vcc
+; SI-NEXT:    v_cmp_le_f32_e32 vcc, 4.0, v2
+; SI-NEXT:    v_cndmask_b32_e32 v2, -1.0, v3, vcc
+; SI-NEXT:    v_cndmask_b32_e32 v3, -2.0, v3, vcc
 ; SI-NEXT:    buffer_store_dword v2, v[0:1], s[0:3], 0 addr64
 ; SI-NEXT:    s_waitcnt vmcnt(0)
 ; SI-NEXT:    buffer_store_dword v3, v[0:1], s[0:3], 0 addr64
@@ -2072,9 +2072,9 @@ define amdgpu_kernel void @fcmp_k0_vgprX_select_k1_vgprZ_f32_cond_use_x2(ptr add
 ; VI-NEXT:    v_mov_b32_e32 v1, s1
 ; VI-NEXT:    v_add_u32_e32 v0, vcc, s0, v4
 ; VI-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
-; VI-NEXT:    v_cmp_nle_f32_e32 vcc, 4.0, v5
-; VI-NEXT:    v_cndmask_b32_e64 v3, v2, -1.0, vcc
-; VI-NEXT:    v_cndmask_b32_e64 v2, v2, -2.0, vcc
+; VI-NEXT:    v_cmp_le_f32_e32 vcc, 4.0, v5
+; VI-NEXT:    v_cndmask_b32_e32 v3, -1.0, v2, vcc
+; VI-NEXT:    v_cndmask_b32_e32 v2, -2.0, v2, vcc
 ; VI-NEXT:    flat_store_dword v[0:1], v3
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    flat_store_dword v[0:1], v2
@@ -2092,9 +2092,9 @@ define amdgpu_kernel void @fcmp_k0_vgprX_select_k1_vgprZ_f32_cond_use_x2(ptr add
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-NEXT:    global_load_dword v2, v0, s[6:7] glc dlc
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-NEXT:    v_cmp_nle_f32_e32 vcc, 4.0, v1
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v2, -1.0, vcc
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v2, -2.0, vcc
+; GFX10-NEXT:    v_cmp_le_f32_e32 vcc, 4.0, v1
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, -1.0, v2, vcc
+; GFX10-NEXT:    v_cndmask_b32_e32 v2, -2.0, v2, vcc
 ; GFX10-NEXT:    global_store_dword v0, v1, s[0:1]
 ; GFX10-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX10-NEXT:    global_store_dword v0, v2, s[0:1]
@@ -2114,9 +2114,9 @@ define amdgpu_kernel void @fcmp_k0_vgprX_select_k1_vgprZ_f32_cond_use_x2(ptr add
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    global_load_b32 v2, v0, s[4:5] glc dlc
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_cmp_nle_f32_e32 vcc, 4.0, v1
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v2, -1.0, vcc
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v2, -2.0, vcc
+; GFX11-NEXT:    v_cmp_le_f32_e32 vcc, 4.0, v1
+; GFX11-NEXT:    v_cndmask_b32_e32 v1, -1.0, v2, vcc
+; GFX11-NEXT:    v_cndmask_b32_e32 v2, -2.0, v2, vcc
 ; GFX11-NEXT:    global_store_b32 v0, v1, s[0:1] dlc
 ; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-NEXT:    global_store_b32 v0, v2, s[0:1] dlc
@@ -2136,9 +2136,9 @@ define amdgpu_kernel void @fcmp_k0_vgprX_select_k1_vgprZ_f32_cond_use_x2(ptr add
 ; GFX12-NEXT:    s_wait_loadcnt 0x0
 ; GFX12-NEXT:    global_load_b32 v2, v0, s[4:5] scope:SCOPE_SYS
 ; GFX12-NEXT:    s_wait_loadcnt 0x0
-; GFX12-NEXT:    v_cmp_nle_f32_e32 vcc, 4.0, v1
-; GFX12-NEXT:    v_cndmask_b32_e64 v1, v2, -1.0, vcc
-; GFX12-NEXT:    v_cndmask_b32_e64 v2, v2, -2.0, vcc
+; GFX12-NEXT:    v_cmp_le_f32_e32 vcc, 4.0, v1
+; GFX12-NEXT:    v_cndmask_b32_e32 v1, -1.0, v2, vcc
+; GFX12-NEXT:    v_cndmask_b32_e32 v2, -2.0, v2, vcc
 ; GFX12-NEXT:    global_store_b32 v0, v1, s[0:1] scope:SCOPE_SYS
 ; GFX12-NEXT:    s_wait_storecnt 0x0
 ; GFX12-NEXT:    global_store_b32 v0, v2, s[0:1] scope:SCOPE_SYS

--- a/llvm/test/CodeGen/AMDGPU/vector-reduce-fmaximum.ll
+++ b/llvm/test/CodeGen/AMDGPU/vector-reduce-fmaximum.ll
@@ -1943,50 +1943,49 @@ define double @test_vector_reduce_fmaximum_v2double(<2 x double> %v) {
 ; GFX7:       ; %bb.0: ; %entry
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX7-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: test_vector_reduce_fmaximum_v2double:
 ; GFX8:       ; %bb.0: ; %entry
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX8-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: test_vector_reduce_fmaximum_v2double:
 ; GFX9:       ; %bb.0: ; %entry
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
 ; GFX9-NEXT:    s_nop 0
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: test_vector_reduce_fmaximum_v2double:
 ; GFX10:       ; %bb.0: ; %entry
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v5, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: test_vector_reduce_fmaximum_v2double:
 ; GFX11:       ; %bb.0: ; %entry
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v4 :: v_dual_cndmask_b32 v1, 0x7ff80000, v5
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: test_vector_reduce_fmaximum_v2double:
@@ -2014,28 +2013,28 @@ define double @test_vector_reduce_fmaximum_v3double(<3 x double> %v) {
 ; GFX7:       ; %bb.0: ; %entry
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_max_f64 v[6:7], v[0:1], v[2:3]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX7-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX7-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: test_vector_reduce_fmaximum_v3double:
 ; GFX8:       ; %bb.0: ; %entry
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_max_f64 v[6:7], v[0:1], v[2:3]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX8-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX8-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: test_vector_reduce_fmaximum_v3double:
@@ -2043,44 +2042,41 @@ define double @test_vector_reduce_fmaximum_v3double(<3 x double> %v) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_max_f64 v[6:7], v[0:1], v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: test_vector_reduce_fmaximum_v3double:
 ; GFX10:       ; %bb.0: ; %entry
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_max_f64 v[6:7], v[0:1], v[2:3]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v7, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v7, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc_lo
 ; GFX10-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[4:5]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v3, 0x7ff80000, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[4:5]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v3, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: test_vector_reduce_fmaximum_v3double:
 ; GFX11:       ; %bb.0: ; %entry
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_max_f64 v[6:7], v[0:1], v[2:3]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v7, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-NEXT:    v_dual_cndmask_b32 v1, 0x7ff80000, v7 :: v_dual_cndmask_b32 v0, 0, v6
 ; GFX11-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[4:5]
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v3, 0x7ff80000, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[4:5]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v2 :: v_dual_cndmask_b32 v1, 0x7ff80000, v3
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: test_vector_reduce_fmaximum_v3double:
@@ -2112,36 +2108,36 @@ define double @test_vector_reduce_fmaximum_v4double(<4 x double> %v) {
 ; GFX7:       ; %bb.0: ; %entry
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_max_f64 v[8:9], v[2:3], v[6:7]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[6:7]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[6:7]
 ; GFX7-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[0:1], v[4:5]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[0:1], v[4:5]
 ; GFX7-NEXT:    v_mov_b32_e32 v10, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v9, v10, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v3, v3, v10, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v10, v9, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v3, v10, v3, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[4:5]
 ; GFX7-NEXT:    v_max_f64 v[4:5], v[2:3], v[0:1]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[0:1]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v10, vcc
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[0:1]
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v10, v5, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: test_vector_reduce_fmaximum_v4double:
 ; GFX8:       ; %bb.0: ; %entry
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_max_f64 v[8:9], v[2:3], v[6:7]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[6:7]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[6:7]
 ; GFX8-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[0:1], v[4:5]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[0:1], v[4:5]
 ; GFX8-NEXT:    v_mov_b32_e32 v10, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v9, v10, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, v3, v10, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v10, v9, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, v10, v3, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[4:5]
 ; GFX8-NEXT:    v_max_f64 v[4:5], v[2:3], v[0:1]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[0:1]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v10, vcc
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[0:1]
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v10, v5, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: test_vector_reduce_fmaximum_v4double:
@@ -2149,57 +2145,55 @@ define double @test_vector_reduce_fmaximum_v4double(<4 x double> %v) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_max_f64 v[8:9], v[2:3], v[6:7]
 ; GFX9-NEXT:    v_mov_b32_e32 v10, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[6:7]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[6:7]
 ; GFX9-NEXT:    v_max_f64 v[6:7], v[0:1], v[4:5]
 ; GFX9-NEXT:    s_nop 0
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v9, v10, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v8, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v10, v9, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v2, 0, v8, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v10, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v10, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v10, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v10, v5, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: test_vector_reduce_fmaximum_v4double:
 ; GFX10:       ; %bb.0: ; %entry
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_max_f64 v[8:9], v[2:3], v[6:7]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[2:3], v[6:7]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[2:3], v[6:7]
 ; GFX10-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[0:1], v[4:5]
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v9, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v3, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s4
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[0:1], v[4:5]
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v9, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v3, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s4
 ; GFX10-NEXT:    v_max_f64 v[4:5], v[2:3], v[0:1]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[2:3], v[0:1]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[2:3], v[0:1]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v5, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: test_vector_reduce_fmaximum_v4double:
 ; GFX11:       ; %bb.0: ; %entry
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_max_f64 v[8:9], v[2:3], v[6:7]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[2:3], v[6:7]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[2:3], v[6:7]
 ; GFX11-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[0:1], v[4:5]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v9, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v3, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[0:1], v[4:5]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v1, 0x7ff80000, v9 :: v_dual_cndmask_b32 v0, 0, v8
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v3, s0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s0
 ; GFX11-NEXT:    v_max_f64 v[4:5], v[2:3], v[0:1]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[2:3], v[0:1]
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[2:3], v[0:1]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v4 :: v_dual_cndmask_b32 v1, 0x7ff80000, v5
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: test_vector_reduce_fmaximum_v4double:
@@ -2233,68 +2227,68 @@ define double @test_vector_reduce_fmaximum_v8double(<8 x double> %v) {
 ; GFX7:       ; %bb.0: ; %entry
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_max_f64 v[16:17], v[4:5], v[12:13]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[12:13]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[12:13]
 ; GFX7-NEXT:    v_max_f64 v[4:5], v[0:1], v[8:9]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[0:1], v[8:9]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[0:1], v[8:9]
 ; GFX7-NEXT:    v_max_f64 v[0:1], v[6:7], v[14:15]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[6:7], v[6:7], v[14:15]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[6:7], v[6:7], v[14:15]
 ; GFX7-NEXT:    v_max_f64 v[6:7], v[2:3], v[10:11]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[8:9], v[2:3], v[10:11]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[8:9], v[2:3], v[10:11]
 ; GFX7-NEXT:    v_mov_b32_e32 v18, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v17, v18, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v16, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v5, v5, v18, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v1, v18, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v7, v7, v18, s[8:9]
-; GFX7-NEXT:    v_cndmask_b32_e64 v6, v6, 0, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e32 v3, v18, v17, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v2, 0, v16, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v5, v18, v5, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v1, v18, v1, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v7, v18, v7, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s[8:9]
 ; GFX7-NEXT:    v_max_f64 v[8:9], v[6:7], v[0:1]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[6:7], v[0:1]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[6:7], v[0:1]
 ; GFX7-NEXT:    v_max_f64 v[0:1], v[4:5], v[2:3]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[4:5], v[2:3]
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v9, v18, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v8, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v1, v18, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[4:5]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[4:5], v[2:3]
+; GFX7-NEXT:    v_cndmask_b32_e32 v3, v18, v9, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v2, 0, v8, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v1, v18, v1, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[4:5]
 ; GFX7-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v18, vcc
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v18, v5, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: test_vector_reduce_fmaximum_v8double:
 ; GFX8:       ; %bb.0: ; %entry
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_max_f64 v[16:17], v[4:5], v[12:13]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[12:13]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[12:13]
 ; GFX8-NEXT:    v_max_f64 v[4:5], v[0:1], v[8:9]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[0:1], v[8:9]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[0:1], v[8:9]
 ; GFX8-NEXT:    v_max_f64 v[0:1], v[6:7], v[14:15]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[6:7], v[6:7], v[14:15]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[6:7], v[6:7], v[14:15]
 ; GFX8-NEXT:    v_max_f64 v[6:7], v[2:3], v[10:11]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[8:9], v[2:3], v[10:11]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[8:9], v[2:3], v[10:11]
 ; GFX8-NEXT:    v_mov_b32_e32 v18, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v17, v18, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v16, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v5, v5, v18, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, v18, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v7, v7, v18, s[8:9]
-; GFX8-NEXT:    v_cndmask_b32_e64 v6, v6, 0, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v18, v17, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v2, 0, v16, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, v18, v5, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v1, v18, v1, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v7, v18, v7, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s[8:9]
 ; GFX8-NEXT:    v_max_f64 v[8:9], v[6:7], v[0:1]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[6:7], v[0:1]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[6:7], v[0:1]
 ; GFX8-NEXT:    v_max_f64 v[0:1], v[4:5], v[2:3]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[4:5], v[2:3]
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v9, v18, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v8, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, v18, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[4:5]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[4:5], v[2:3]
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v18, v9, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v2, 0, v8, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v1, v18, v1, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[4:5]
 ; GFX8-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v18, vcc
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v18, v5, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: test_vector_reduce_fmaximum_v8double:
@@ -2302,110 +2296,107 @@ define double @test_vector_reduce_fmaximum_v8double(<8 x double> %v) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_max_f64 v[16:17], v[4:5], v[12:13]
 ; GFX9-NEXT:    v_mov_b32_e32 v18, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[12:13]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[12:13]
 ; GFX9-NEXT:    v_max_f64 v[12:13], v[0:1], v[8:9]
 ; GFX9-NEXT:    s_nop 0
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v17, v18, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, v16, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[8:9]
+; GFX9-NEXT:    v_cndmask_b32_e32 v5, v18, v17, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v4, 0, v16, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[8:9]
 ; GFX9-NEXT:    v_max_f64 v[8:9], v[6:7], v[14:15]
 ; GFX9-NEXT:    s_nop 0
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v13, v18, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[6:7], v[14:15]
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v18, v13, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v12, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[6:7], v[14:15]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v9, v18, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v6, v8, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v7, v18, v9, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v6, 0, v8, vcc
 ; GFX9-NEXT:    v_max_f64 v[8:9], v[2:3], v[10:11]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[10:11]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[10:11]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v9, v18, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v8, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v18, v9, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v2, 0, v8, vcc
 ; GFX9-NEXT:    v_max_f64 v[8:9], v[2:3], v[6:7]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[6:7]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[6:7]
 ; GFX9-NEXT:    v_max_f64 v[6:7], v[0:1], v[4:5]
 ; GFX9-NEXT:    s_nop 0
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v9, v18, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v8, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v18, v9, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v2, 0, v8, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v18, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v18, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v18, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v18, v5, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: test_vector_reduce_fmaximum_v8double:
 ; GFX10:       ; %bb.0: ; %entry
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_max_f64 v[16:17], v[4:5], v[12:13]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[4:5], v[12:13]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[4:5], v[12:13]
 ; GFX10-NEXT:    v_max_f64 v[4:5], v[6:7], v[14:15]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[6:7], v[14:15]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[6:7], v[14:15]
 ; GFX10-NEXT:    v_max_f64 v[6:7], v[2:3], v[10:11]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s5, v[2:3], v[10:11]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s5, v[2:3], v[10:11]
 ; GFX10-NEXT:    v_max_f64 v[2:3], v[0:1], v[8:9]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s6, v[0:1], v[8:9]
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v17, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v5, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v7, v7, 0x7ff80000, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, v6, 0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v3, 0x7ff80000, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s6
+; GFX10-NEXT:    v_cmp_o_f64_e64 s6, v[0:1], v[8:9]
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v17, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v5, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v7, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v3, s6
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s6
 ; GFX10-NEXT:    v_max_f64 v[8:9], v[6:7], v[4:5]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[6:7], v[4:5]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[6:7], v[4:5]
 ; GFX10-NEXT:    v_max_f64 v[4:5], v[2:3], v[0:1]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[2:3], v[0:1]
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v9, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v5, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s4
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[2:3], v[0:1]
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v9, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v5, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s4
 ; GFX10-NEXT:    v_max_f64 v[4:5], v[2:3], v[0:1]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[2:3], v[0:1]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[2:3], v[0:1]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v5, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: test_vector_reduce_fmaximum_v8double:
 ; GFX11:       ; %bb.0: ; %entry
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_max_f64 v[16:17], v[4:5], v[12:13]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[4:5], v[12:13]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[4:5], v[12:13]
 ; GFX11-NEXT:    v_max_f64 v[4:5], v[6:7], v[14:15]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[6:7], v[14:15]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[6:7], v[14:15]
 ; GFX11-NEXT:    v_max_f64 v[6:7], v[2:3], v[10:11]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s1, v[2:3], v[10:11]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s1, v[2:3], v[10:11]
 ; GFX11-NEXT:    v_max_f64 v[2:3], v[0:1], v[8:9]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s2, v[0:1], v[8:9]
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v17, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v5, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v7, v7, 0x7ff80000, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v6, v6, 0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v3, 0x7ff80000, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s2
+; GFX11-NEXT:    v_cmp_o_f64_e64 s2, v[0:1], v[8:9]
+; GFX11-NEXT:    v_dual_cndmask_b32 v1, 0x7ff80000, v17 :: v_dual_cndmask_b32 v0, 0, v16
+; GFX11-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v5, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v7, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v3, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s2
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
 ; GFX11-NEXT:    v_max_f64 v[8:9], v[6:7], v[4:5]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[6:7], v[4:5]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[6:7], v[4:5]
 ; GFX11-NEXT:    v_max_f64 v[4:5], v[2:3], v[0:1]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[2:3], v[0:1]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v9, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v5, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[2:3], v[0:1]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v1, 0x7ff80000, v9 :: v_dual_cndmask_b32 v0, 0, v8
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v5, s0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s0
 ; GFX11-NEXT:    v_max_f64 v[4:5], v[2:3], v[0:1]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[2:3], v[0:1]
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[2:3], v[0:1]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v4 :: v_dual_cndmask_b32 v1, 0x7ff80000, v5
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: test_vector_reduce_fmaximum_v8double:
@@ -2450,67 +2441,67 @@ define double @test_vector_reduce_fmaximum_v16double(<16 x double> %v) {
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32
 ; GFX7-NEXT:    v_max_f64 v[32:33], v[8:9], v[24:25]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[8:9], v[24:25]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[8:9], v[24:25]
 ; GFX7-NEXT:    v_max_f64 v[8:9], v[0:1], v[16:17]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[0:1], v[16:17]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[0:1], v[16:17]
 ; GFX7-NEXT:    v_max_f64 v[0:1], v[12:13], v[28:29]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[6:7], v[12:13], v[28:29]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[6:7], v[12:13], v[28:29]
 ; GFX7-NEXT:    v_max_f64 v[12:13], v[10:11], v[26:27]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[8:9], v[10:11], v[26:27]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[8:9], v[10:11], v[26:27]
 ; GFX7-NEXT:    v_max_f64 v[10:11], v[2:3], v[18:19]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[10:11], v[2:3], v[18:19]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[10:11], v[2:3], v[18:19]
 ; GFX7-NEXT:    v_mov_b32_e32 v34, 0x7ff80000
 ; GFX7-NEXT:    v_max_f64 v[2:3], v[4:5], v[20:21]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[12:13], v[4:5], v[20:21]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[12:13], v[4:5], v[20:21]
 ; GFX7-NEXT:    v_max_f64 v[4:5], v[6:7], v[22:23]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[14:15], v[6:7], v[22:23]
-; GFX7-NEXT:    v_cndmask_b32_e64 v7, v13, v34, s[8:9]
-; GFX7-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s[8:9]
-; GFX7-NEXT:    v_cndmask_b32_e64 v11, v11, v34, s[10:11]
-; GFX7-NEXT:    v_cndmask_b32_e64 v10, v10, 0, s[10:11]
-; GFX7-NEXT:    v_cndmask_b32_e32 v13, v33, v34, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v12, v32, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v9, v9, v34, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v8, v8, 0, s[4:5]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[14:15], v[6:7], v[22:23]
+; GFX7-NEXT:    v_cndmask_b32_e64 v7, v34, v13, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e64 v11, v34, v11, s[10:11]
+; GFX7-NEXT:    v_cndmask_b32_e64 v10, 0, v10, s[10:11]
+; GFX7-NEXT:    v_cndmask_b32_e32 v13, v34, v33, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v12, 0, v32, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v9, v34, v9, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v8, 0, v8, s[4:5]
 ; GFX7-NEXT:    v_max_f64 v[16:17], v[10:11], v[6:7]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[10:11], v[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v1, v34, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v3, v3, v34, s[12:13]
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[12:13]
-; GFX7-NEXT:    v_cndmask_b32_e64 v5, v5, v34, s[14:15]
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[14:15]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[10:11], v[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v1, v34, v1, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v3, v34, v3, s[12:13]
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[12:13]
+; GFX7-NEXT:    v_cndmask_b32_e64 v5, v34, v5, s[14:15]
+; GFX7-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s[14:15]
 ; GFX7-NEXT:    v_max_f64 v[10:11], v[2:3], v[0:1]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[6:7], v[2:3], v[0:1]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[6:7], v[2:3], v[0:1]
 ; GFX7-NEXT:    v_max_f64 v[0:1], v[8:9], v[12:13]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[8:9], v[8:9], v[12:13]
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v17, v34, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v16, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v1, v34, s[8:9]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[8:9]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[8:9], v[8:9], v[12:13]
+; GFX7-NEXT:    v_cndmask_b32_e32 v3, v34, v17, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v2, 0, v16, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v1, v34, v1, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[8:9]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
 ; GFX7-NEXT:    v_max_f64 v[6:7], v[14:15], v[30:31]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[14:15], v[30:31]
-; GFX7-NEXT:    v_cndmask_b32_e64 v7, v7, v34, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v6, v6, 0, s[4:5]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[14:15], v[30:31]
+; GFX7-NEXT:    v_cndmask_b32_e64 v7, v34, v7, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s[4:5]
 ; GFX7-NEXT:    v_max_f64 v[8:9], v[4:5], v[6:7]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v5, v11, v34, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[6:7]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v5, v34, v11, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s[6:7]
 ; GFX7-NEXT:    v_max_f64 v[6:7], v[0:1], v[4:5]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[0:1], v[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v9, v34, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[0:1], v[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v34, v9, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
 ; GFX7-NEXT:    v_max_f64 v[4:5], v[2:3], v[0:1]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[0:1]
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v7, v34, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v6, 0, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v5, v34, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v4, 0, vcc
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[0:1]
+; GFX7-NEXT:    v_cndmask_b32_e64 v1, v34, v7, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v0, 0, v6, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e32 v3, v34, v5, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v2, 0, v4, vcc
 ; GFX7-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v34, vcc
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v34, v5, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: test_vector_reduce_fmaximum_v16double:
@@ -2518,67 +2509,67 @@ define double @test_vector_reduce_fmaximum_v16double(<16 x double> %v) {
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32
 ; GFX8-NEXT:    v_max_f64 v[32:33], v[8:9], v[24:25]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[8:9], v[24:25]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[8:9], v[24:25]
 ; GFX8-NEXT:    v_max_f64 v[8:9], v[0:1], v[16:17]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[0:1], v[16:17]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[0:1], v[16:17]
 ; GFX8-NEXT:    v_max_f64 v[0:1], v[12:13], v[28:29]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[6:7], v[12:13], v[28:29]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[6:7], v[12:13], v[28:29]
 ; GFX8-NEXT:    v_max_f64 v[12:13], v[10:11], v[26:27]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[8:9], v[10:11], v[26:27]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[8:9], v[10:11], v[26:27]
 ; GFX8-NEXT:    v_max_f64 v[10:11], v[2:3], v[18:19]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[10:11], v[2:3], v[18:19]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[10:11], v[2:3], v[18:19]
 ; GFX8-NEXT:    v_mov_b32_e32 v34, 0x7ff80000
 ; GFX8-NEXT:    v_max_f64 v[2:3], v[4:5], v[20:21]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[12:13], v[4:5], v[20:21]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[12:13], v[4:5], v[20:21]
 ; GFX8-NEXT:    v_max_f64 v[4:5], v[6:7], v[22:23]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[14:15], v[6:7], v[22:23]
-; GFX8-NEXT:    v_cndmask_b32_e64 v7, v13, v34, s[8:9]
-; GFX8-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s[8:9]
-; GFX8-NEXT:    v_cndmask_b32_e64 v11, v11, v34, s[10:11]
-; GFX8-NEXT:    v_cndmask_b32_e64 v10, v10, 0, s[10:11]
-; GFX8-NEXT:    v_cndmask_b32_e32 v13, v33, v34, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v12, v32, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v9, v9, v34, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v8, v8, 0, s[4:5]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[14:15], v[6:7], v[22:23]
+; GFX8-NEXT:    v_cndmask_b32_e64 v7, v34, v13, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e64 v11, v34, v11, s[10:11]
+; GFX8-NEXT:    v_cndmask_b32_e64 v10, 0, v10, s[10:11]
+; GFX8-NEXT:    v_cndmask_b32_e32 v13, v34, v33, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v12, 0, v32, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v9, v34, v9, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v8, 0, v8, s[4:5]
 ; GFX8-NEXT:    v_max_f64 v[16:17], v[10:11], v[6:7]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[10:11], v[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, v34, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, v3, v34, s[12:13]
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[12:13]
-; GFX8-NEXT:    v_cndmask_b32_e64 v5, v5, v34, s[14:15]
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[14:15]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[10:11], v[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v1, v34, v1, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, v34, v3, s[12:13]
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[12:13]
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, v34, v5, s[14:15]
+; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s[14:15]
 ; GFX8-NEXT:    v_max_f64 v[10:11], v[2:3], v[0:1]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[6:7], v[2:3], v[0:1]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[6:7], v[2:3], v[0:1]
 ; GFX8-NEXT:    v_max_f64 v[0:1], v[8:9], v[12:13]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[8:9], v[8:9], v[12:13]
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v17, v34, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v16, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, v34, s[8:9]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[8:9]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[8:9], v[8:9], v[12:13]
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v34, v17, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v2, 0, v16, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v1, v34, v1, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[8:9]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
 ; GFX8-NEXT:    v_max_f64 v[6:7], v[14:15], v[30:31]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[14:15], v[30:31]
-; GFX8-NEXT:    v_cndmask_b32_e64 v7, v7, v34, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v6, v6, 0, s[4:5]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[14:15], v[30:31]
+; GFX8-NEXT:    v_cndmask_b32_e64 v7, v34, v7, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s[4:5]
 ; GFX8-NEXT:    v_max_f64 v[8:9], v[4:5], v[6:7]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v5, v11, v34, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[6:7]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, v34, v11, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s[6:7]
 ; GFX8-NEXT:    v_max_f64 v[6:7], v[0:1], v[4:5]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[0:1], v[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v9, v34, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[0:1], v[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v34, v9, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
 ; GFX8-NEXT:    v_max_f64 v[4:5], v[2:3], v[0:1]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[0:1]
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v7, v34, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v6, 0, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v5, v34, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v4, 0, vcc
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[0:1]
+; GFX8-NEXT:    v_cndmask_b32_e64 v1, v34, v7, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v0, 0, v6, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v34, v5, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v2, 0, v4, vcc
 ; GFX8-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v34, vcc
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v34, v5, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: test_vector_reduce_fmaximum_v16double:
@@ -2587,74 +2578,74 @@ define double @test_vector_reduce_fmaximum_v16double(<16 x double> %v) {
 ; GFX9-NEXT:    scratch_load_dword v31, off, s32
 ; GFX9-NEXT:    v_mov_b32_e32 v36, 0x7ff80000
 ; GFX9-NEXT:    v_max_f64 v[32:33], v[8:9], v[24:25]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[8:9], v[24:25]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[8:9], v[24:25]
 ; GFX9-NEXT:    v_max_f64 v[34:35], v[0:1], v[16:17]
 ; GFX9-NEXT:    v_max_f64 v[38:39], v[12:13], v[28:29]
-; GFX9-NEXT:    v_cndmask_b32_e32 v9, v33, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v8, v32, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[16:17]
+; GFX9-NEXT:    v_cndmask_b32_e32 v9, v36, v33, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v8, 0, v32, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[16:17]
 ; GFX9-NEXT:    v_max_f64 v[48:49], v[4:5], v[20:21]
 ; GFX9-NEXT:    v_max_f64 v[50:51], v[6:7], v[22:23]
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v35, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v34, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[12:13], v[28:29]
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v36, v35, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v34, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[12:13], v[28:29]
 ; GFX9-NEXT:    v_max_f64 v[52:53], v[10:11], v[26:27]
 ; GFX9-NEXT:    v_max_f64 v[54:55], v[2:3], v[18:19]
-; GFX9-NEXT:    v_cndmask_b32_e32 v13, v39, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v12, v38, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[20:21]
+; GFX9-NEXT:    v_cndmask_b32_e32 v13, v36, v39, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v12, 0, v38, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[20:21]
 ; GFX9-NEXT:    v_max_f64 v[20:21], v[0:1], v[8:9]
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    v_cmp_u_f64_e64 s[0:1], v[14:15], v[30:31]
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v49, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, v48, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[6:7], v[22:23]
+; GFX9-NEXT:    v_cmp_o_f64_e64 s[0:1], v[14:15], v[30:31]
+; GFX9-NEXT:    v_cndmask_b32_e32 v5, v36, v49, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v4, 0, v48, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[6:7], v[22:23]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v51, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v6, v50, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[10:11], v[26:27]
+; GFX9-NEXT:    v_cndmask_b32_e32 v7, v36, v51, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v6, 0, v50, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[10:11], v[26:27]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, v53, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v10, v52, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[18:19]
+; GFX9-NEXT:    v_cndmask_b32_e32 v11, v36, v53, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v10, 0, v52, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[18:19]
 ; GFX9-NEXT:    v_max_f64 v[18:19], v[4:5], v[12:13]
 ; GFX9-NEXT:    s_nop 0
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v55, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v54, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v36, v55, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v2, 0, v54, vcc
 ; GFX9-NEXT:    v_max_f64 v[16:17], v[2:3], v[10:11]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[10:11]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[10:11]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v17, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v16, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[12:13]
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v36, v17, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v2, 0, v16, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[12:13]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v19, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, v18, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[8:9]
+; GFX9-NEXT:    v_cndmask_b32_e32 v5, v36, v19, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v4, 0, v18, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[8:9]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v21, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v20, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v36, v21, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v20, vcc
 ; GFX9-NEXT:    v_max_f64 v[8:9], v[0:1], v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX9-NEXT:    v_max_f64 v[4:5], v[14:15], v[30:31]
-; GFX9-NEXT:    v_cndmask_b32_e64 v5, v5, v36, s[0:1]
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[0:1]
+; GFX9-NEXT:    v_cndmask_b32_e64 v5, v36, v5, s[0:1]
+; GFX9-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s[0:1]
 ; GFX9-NEXT:    v_max_f64 v[10:11], v[6:7], v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e64 s[0:1], v[6:7], v[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v9, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v5, v11, v36, s[0:1]
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[0:1]
+; GFX9-NEXT:    v_cmp_o_f64_e64 s[0:1], v[6:7], v[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v36, v9, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v5, v36, v11, s[0:1]
+; GFX9-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s[0:1]
 ; GFX9-NEXT:    v_max_f64 v[6:7], v[2:3], v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v7, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v36, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v2, 0, v6, vcc
 ; GFX9-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v36, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v36, v5, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: test_vector_reduce_fmaximum_v16double:
@@ -2662,66 +2653,66 @@ define double @test_vector_reduce_fmaximum_v16double(<16 x double> %v) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    buffer_load_dword v31, off, s[0:3], s32
 ; GFX10-NEXT:    v_max_f64 v[32:33], v[8:9], v[24:25]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[8:9], v[24:25]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[8:9], v[24:25]
 ; GFX10-NEXT:    v_max_f64 v[8:9], v[0:1], v[16:17]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[0:1], v[16:17]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[0:1], v[16:17]
 ; GFX10-NEXT:    v_max_f64 v[0:1], v[12:13], v[28:29]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s5, v[12:13], v[28:29]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s5, v[12:13], v[28:29]
 ; GFX10-NEXT:    v_max_f64 v[12:13], v[10:11], v[26:27]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s6, v[10:11], v[26:27]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s6, v[10:11], v[26:27]
 ; GFX10-NEXT:    v_max_f64 v[10:11], v[2:3], v[18:19]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s7, v[2:3], v[18:19]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s7, v[2:3], v[18:19]
 ; GFX10-NEXT:    v_max_f64 v[2:3], v[4:5], v[20:21]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s8, v[4:5], v[20:21]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s8, v[4:5], v[20:21]
 ; GFX10-NEXT:    v_max_f64 v[4:5], v[6:7], v[22:23]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s9, v[6:7], v[22:23]
-; GFX10-NEXT:    v_cndmask_b32_e64 v9, v9, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v8, v8, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7ff80000, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v13, v13, 0x7ff80000, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v12, v12, 0, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v11, v11, 0x7ff80000, s7
-; GFX10-NEXT:    v_cndmask_b32_e64 v10, v10, 0, s7
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v3, 0x7ff80000, s8
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s8
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v5, 0x7ff80000, s9
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s9
+; GFX10-NEXT:    v_cmp_o_f64_e64 s9, v[6:7], v[22:23]
+; GFX10-NEXT:    v_cndmask_b32_e64 v9, 0x7ff80000, v9, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v8, 0, v8, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, 0x7ff80000, v1, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v13, 0x7ff80000, v13, s6
+; GFX10-NEXT:    v_cndmask_b32_e64 v12, 0, v12, s6
+; GFX10-NEXT:    v_cndmask_b32_e64 v11, 0x7ff80000, v11, s7
+; GFX10-NEXT:    v_cndmask_b32_e64 v10, 0, v10, s7
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v3, s8
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s8
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v5, s9
+; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s9
 ; GFX10-NEXT:    v_max_f64 v[16:17], v[10:11], v[12:13]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[2:3], v[0:1]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[2:3], v[0:1]
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-NEXT:    v_max_f64 v[6:7], v[14:15], v[30:31]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s10, v[14:15], v[30:31]
-; GFX10-NEXT:    v_cndmask_b32_e64 v15, v33, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v14, v32, 0, vcc_lo
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[10:11], v[12:13]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s10, v[14:15], v[30:31]
+; GFX10-NEXT:    v_cndmask_b32_e32 v15, 0x7ff80000, v33, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v14, 0, v32, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[10:11], v[12:13]
 ; GFX10-NEXT:    v_max_f64 v[10:11], v[2:3], v[0:1]
 ; GFX10-NEXT:    v_max_f64 v[0:1], v[8:9], v[14:15]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s5, v[8:9], v[14:15]
-; GFX10-NEXT:    v_cndmask_b32_e64 v7, v7, 0x7ff80000, s10
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, v6, 0, s10
+; GFX10-NEXT:    v_cmp_o_f64_e64 s5, v[8:9], v[14:15]
+; GFX10-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v7, s10
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s10
 ; GFX10-NEXT:    v_max_f64 v[2:3], v[4:5], v[6:7]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s6, v[4:5], v[6:7]
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v17, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v16, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v7, v11, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, v10, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7ff80000, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s5
+; GFX10-NEXT:    v_cmp_o_f64_e64 s6, v[4:5], v[6:7]
+; GFX10-NEXT:    v_cndmask_b32_e32 v5, 0x7ff80000, v17, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v4, 0, v16, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v11, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, 0, v10, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, 0x7ff80000, v1, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s5
 ; GFX10-NEXT:    v_max_f64 v[8:9], v[0:1], v[6:7]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[6:7]
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v3, 0x7ff80000, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s6
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[6:7]
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v3, s6
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s6
 ; GFX10-NEXT:    v_max_f64 v[0:1], v[4:5], v[2:3]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[4:5], v[2:3]
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v9, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v8, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s4
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[4:5], v[2:3]
+; GFX10-NEXT:    v_cndmask_b32_e32 v3, 0x7ff80000, v9, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v2, 0, v8, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, 0x7ff80000, v1, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s4
 ; GFX10-NEXT:    v_max_f64 v[4:5], v[2:3], v[0:1]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[2:3], v[0:1]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[2:3], v[0:1]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v5, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: test_vector_reduce_fmaximum_v16double:
@@ -2729,71 +2720,67 @@ define double @test_vector_reduce_fmaximum_v16double(<16 x double> %v) {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    scratch_load_b32 v31, off, s32
 ; GFX11-NEXT:    v_max_f64 v[32:33], v[8:9], v[24:25]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[8:9], v[24:25]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[8:9], v[24:25]
 ; GFX11-NEXT:    v_max_f64 v[8:9], v[0:1], v[16:17]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[0:1], v[16:17]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[0:1], v[16:17]
 ; GFX11-NEXT:    v_max_f64 v[0:1], v[12:13], v[28:29]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s1, v[12:13], v[28:29]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s1, v[12:13], v[28:29]
 ; GFX11-NEXT:    v_max_f64 v[12:13], v[10:11], v[26:27]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s2, v[10:11], v[26:27]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s2, v[10:11], v[26:27]
 ; GFX11-NEXT:    v_max_f64 v[10:11], v[2:3], v[18:19]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s3, v[2:3], v[18:19]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s3, v[2:3], v[18:19]
 ; GFX11-NEXT:    v_max_f64 v[2:3], v[4:5], v[20:21]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s4, v[4:5], v[20:21]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s4, v[4:5], v[20:21]
 ; GFX11-NEXT:    v_max_f64 v[4:5], v[6:7], v[22:23]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s5, v[6:7], v[22:23]
-; GFX11-NEXT:    v_cndmask_b32_e64 v9, v9, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v8, v8, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7ff80000, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v13, v13, 0x7ff80000, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v12, v12, 0, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v11, v11, 0x7ff80000, s3
-; GFX11-NEXT:    v_cndmask_b32_e64 v10, v10, 0, s3
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v3, 0x7ff80000, s4
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s4
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v5, 0x7ff80000, s5
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s5
+; GFX11-NEXT:    v_cmp_o_f64_e64 s5, v[6:7], v[22:23]
+; GFX11-NEXT:    v_cndmask_b32_e64 v9, 0x7ff80000, v9, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v8, 0, v8, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, 0x7ff80000, v1, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v13, 0x7ff80000, v13, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v12, 0, v12, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v11, 0x7ff80000, v11, s3
+; GFX11-NEXT:    v_cndmask_b32_e64 v10, 0, v10, s3
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v3, s4
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s4
+; GFX11-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v5, s5
+; GFX11-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s5
 ; GFX11-NEXT:    v_max_f64 v[16:17], v[10:11], v[12:13]
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[2:3], v[0:1]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[2:3], v[0:1]
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    v_max_f64 v[6:7], v[14:15], v[30:31]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s6, v[14:15], v[30:31]
-; GFX11-NEXT:    v_cndmask_b32_e64 v15, v33, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v14, v32, 0, vcc_lo
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[10:11], v[12:13]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s6, v[14:15], v[30:31]
+; GFX11-NEXT:    v_dual_cndmask_b32 v15, 0x7ff80000, v33 :: v_dual_cndmask_b32 v14, 0, v32
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[10:11], v[12:13]
 ; GFX11-NEXT:    v_max_f64 v[10:11], v[2:3], v[0:1]
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_3) | instid1(VALU_DEP_1)
 ; GFX11-NEXT:    v_max_f64 v[0:1], v[8:9], v[14:15]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s1, v[8:9], v[14:15]
-; GFX11-NEXT:    v_cndmask_b32_e64 v7, v7, 0x7ff80000, s6
-; GFX11-NEXT:    v_cndmask_b32_e64 v6, v6, 0, s6
+; GFX11-NEXT:    v_cmp_o_f64_e64 s1, v[8:9], v[14:15]
+; GFX11-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v7, s6
+; GFX11-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s6
 ; GFX11-NEXT:    v_max_f64 v[2:3], v[4:5], v[6:7]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s2, v[4:5], v[6:7]
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v17, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v16, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v7, v11, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v6, v10, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7ff80000, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s1
+; GFX11-NEXT:    v_cmp_o_f64_e64 s2, v[4:5], v[6:7]
+; GFX11-NEXT:    v_dual_cndmask_b32 v5, 0x7ff80000, v17 :: v_dual_cndmask_b32 v4, 0, v16
+; GFX11-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v11, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v6, 0, v10, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, 0x7ff80000, v1, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s1
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_1)
 ; GFX11-NEXT:    v_max_f64 v[8:9], v[0:1], v[6:7]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[6:7]
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v3, 0x7ff80000, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s2
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[6:7]
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v3, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s2
 ; GFX11-NEXT:    v_max_f64 v[0:1], v[4:5], v[2:3]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[4:5], v[2:3]
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v9, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v8, 0, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s0
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[4:5], v[2:3]
+; GFX11-NEXT:    v_dual_cndmask_b32 v3, 0x7ff80000, v9 :: v_dual_cndmask_b32 v2, 0, v8
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, 0x7ff80000, v1, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_max_f64 v[4:5], v[2:3], v[0:1]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[2:3], v[0:1]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[2:3], v[0:1]
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v4 :: v_dual_cndmask_b32 v1, 0x7ff80000, v5
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: test_vector_reduce_fmaximum_v16double:

--- a/llvm/test/CodeGen/AMDGPU/vector-reduce-fminimum.ll
+++ b/llvm/test/CodeGen/AMDGPU/vector-reduce-fminimum.ll
@@ -2287,50 +2287,49 @@ define double @test_vector_reduce_fminimum_v2double(<2 x double> %v) {
 ; GFX7:       ; %bb.0: ; %entry
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX7-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: test_vector_reduce_fminimum_v2double:
 ; GFX8:       ; %bb.0: ; %entry
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX8-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: test_vector_reduce_fminimum_v2double:
 ; GFX9:       ; %bb.0: ; %entry
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
 ; GFX9-NEXT:    s_nop 0
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: test_vector_reduce_fminimum_v2double:
 ; GFX10:       ; %bb.0: ; %entry
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v5, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: test_vector_reduce_fminimum_v2double:
 ; GFX11:       ; %bb.0: ; %entry
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v4 :: v_dual_cndmask_b32 v1, 0x7ff80000, v5
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: test_vector_reduce_fminimum_v2double:
@@ -2358,28 +2357,28 @@ define double @test_vector_reduce_fminimum_v3double(<3 x double> %v) {
 ; GFX7:       ; %bb.0: ; %entry
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_min_f64 v[6:7], v[0:1], v[2:3]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX7-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX7-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: test_vector_reduce_fminimum_v3double:
 ; GFX8:       ; %bb.0: ; %entry
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_min_f64 v[6:7], v[0:1], v[2:3]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX8-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX8-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: test_vector_reduce_fminimum_v3double:
@@ -2387,44 +2386,41 @@ define double @test_vector_reduce_fminimum_v3double(<3 x double> %v) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_min_f64 v[6:7], v[0:1], v[2:3]
 ; GFX9-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: test_vector_reduce_fminimum_v3double:
 ; GFX10:       ; %bb.0: ; %entry
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_min_f64 v[6:7], v[0:1], v[2:3]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v7, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v7, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc_lo
 ; GFX10-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[4:5]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v3, 0x7ff80000, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[4:5]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v3, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: test_vector_reduce_fminimum_v3double:
 ; GFX11:       ; %bb.0: ; %entry
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_min_f64 v[6:7], v[0:1], v[2:3]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v7, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[2:3]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-NEXT:    v_dual_cndmask_b32 v1, 0x7ff80000, v7 :: v_dual_cndmask_b32 v0, 0, v6
 ; GFX11-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[4:5]
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v3, 0x7ff80000, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[4:5]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v2 :: v_dual_cndmask_b32 v1, 0x7ff80000, v3
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-LABEL: test_vector_reduce_fminimum_v3double:
@@ -2456,36 +2452,36 @@ define double @test_vector_reduce_fminimum_v4double(<4 x double> %v) {
 ; GFX7:       ; %bb.0: ; %entry
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_min_f64 v[8:9], v[2:3], v[6:7]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[6:7]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[6:7]
 ; GFX7-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[0:1], v[4:5]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[0:1], v[4:5]
 ; GFX7-NEXT:    v_mov_b32_e32 v10, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v9, v10, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v3, v3, v10, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v10, v9, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v3, v10, v3, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[4:5]
 ; GFX7-NEXT:    v_min_f64 v[4:5], v[2:3], v[0:1]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[0:1]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v10, vcc
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[0:1]
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v10, v5, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: test_vector_reduce_fminimum_v4double:
 ; GFX8:       ; %bb.0: ; %entry
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_min_f64 v[8:9], v[2:3], v[6:7]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[6:7]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[6:7]
 ; GFX8-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[0:1], v[4:5]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[0:1], v[4:5]
 ; GFX8-NEXT:    v_mov_b32_e32 v10, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v9, v10, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, v3, v10, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v10, v9, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, v10, v3, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[4:5]
 ; GFX8-NEXT:    v_min_f64 v[4:5], v[2:3], v[0:1]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[0:1]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v10, vcc
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[0:1]
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v10, v5, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: test_vector_reduce_fminimum_v4double:
@@ -2493,57 +2489,55 @@ define double @test_vector_reduce_fminimum_v4double(<4 x double> %v) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_min_f64 v[8:9], v[2:3], v[6:7]
 ; GFX9-NEXT:    v_mov_b32_e32 v10, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[6:7]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[6:7]
 ; GFX9-NEXT:    v_min_f64 v[6:7], v[0:1], v[4:5]
 ; GFX9-NEXT:    s_nop 0
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v9, v10, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v8, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v10, v9, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v2, 0, v8, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v10, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v10, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v10, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v10, v5, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: test_vector_reduce_fminimum_v4double:
 ; GFX10:       ; %bb.0: ; %entry
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_min_f64 v[8:9], v[2:3], v[6:7]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[2:3], v[6:7]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[2:3], v[6:7]
 ; GFX10-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[0:1], v[4:5]
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v9, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v3, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s4
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[0:1], v[4:5]
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v9, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v3, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s4
 ; GFX10-NEXT:    v_min_f64 v[4:5], v[2:3], v[0:1]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[2:3], v[0:1]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[2:3], v[0:1]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v5, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: test_vector_reduce_fminimum_v4double:
 ; GFX11:       ; %bb.0: ; %entry
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_min_f64 v[8:9], v[2:3], v[6:7]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[2:3], v[6:7]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[2:3], v[6:7]
 ; GFX11-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[0:1], v[4:5]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v9, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v3, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[0:1], v[4:5]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v1, 0x7ff80000, v9 :: v_dual_cndmask_b32 v0, 0, v8
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v3, s0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s0
 ; GFX11-NEXT:    v_min_f64 v[4:5], v[2:3], v[0:1]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[2:3], v[0:1]
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[2:3], v[0:1]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v4 :: v_dual_cndmask_b32 v1, 0x7ff80000, v5
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-SDAG-LABEL: test_vector_reduce_fminimum_v4double:
@@ -2599,68 +2593,68 @@ define double @test_vector_reduce_fminimum_v8double(<8 x double> %v) {
 ; GFX7:       ; %bb.0: ; %entry
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_min_f64 v[16:17], v[4:5], v[12:13]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[12:13]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[12:13]
 ; GFX7-NEXT:    v_min_f64 v[4:5], v[0:1], v[8:9]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[0:1], v[8:9]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[0:1], v[8:9]
 ; GFX7-NEXT:    v_min_f64 v[0:1], v[6:7], v[14:15]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[6:7], v[6:7], v[14:15]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[6:7], v[6:7], v[14:15]
 ; GFX7-NEXT:    v_min_f64 v[6:7], v[2:3], v[10:11]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[8:9], v[2:3], v[10:11]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[8:9], v[2:3], v[10:11]
 ; GFX7-NEXT:    v_mov_b32_e32 v18, 0x7ff80000
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v17, v18, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v16, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v5, v5, v18, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v1, v18, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v7, v7, v18, s[8:9]
-; GFX7-NEXT:    v_cndmask_b32_e64 v6, v6, 0, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e32 v3, v18, v17, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v2, 0, v16, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v5, v18, v5, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v1, v18, v1, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v7, v18, v7, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s[8:9]
 ; GFX7-NEXT:    v_min_f64 v[8:9], v[6:7], v[0:1]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[6:7], v[0:1]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[6:7], v[0:1]
 ; GFX7-NEXT:    v_min_f64 v[0:1], v[4:5], v[2:3]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[4:5], v[2:3]
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v9, v18, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v8, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v1, v18, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[4:5]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[4:5], v[2:3]
+; GFX7-NEXT:    v_cndmask_b32_e32 v3, v18, v9, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v2, 0, v8, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v1, v18, v1, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[4:5]
 ; GFX7-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v18, vcc
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v18, v5, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: test_vector_reduce_fminimum_v8double:
 ; GFX8:       ; %bb.0: ; %entry
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_min_f64 v[16:17], v[4:5], v[12:13]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[12:13]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[12:13]
 ; GFX8-NEXT:    v_min_f64 v[4:5], v[0:1], v[8:9]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[0:1], v[8:9]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[0:1], v[8:9]
 ; GFX8-NEXT:    v_min_f64 v[0:1], v[6:7], v[14:15]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[6:7], v[6:7], v[14:15]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[6:7], v[6:7], v[14:15]
 ; GFX8-NEXT:    v_min_f64 v[6:7], v[2:3], v[10:11]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[8:9], v[2:3], v[10:11]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[8:9], v[2:3], v[10:11]
 ; GFX8-NEXT:    v_mov_b32_e32 v18, 0x7ff80000
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v17, v18, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v16, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v5, v5, v18, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, v18, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v7, v7, v18, s[8:9]
-; GFX8-NEXT:    v_cndmask_b32_e64 v6, v6, 0, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v18, v17, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v2, 0, v16, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, v18, v5, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v1, v18, v1, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v7, v18, v7, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s[8:9]
 ; GFX8-NEXT:    v_min_f64 v[8:9], v[6:7], v[0:1]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[6:7], v[0:1]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[6:7], v[0:1]
 ; GFX8-NEXT:    v_min_f64 v[0:1], v[4:5], v[2:3]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[4:5], v[2:3]
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v9, v18, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v8, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, v18, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[4:5]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[4:5], v[2:3]
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v18, v9, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v2, 0, v8, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v1, v18, v1, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[4:5]
 ; GFX8-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v18, vcc
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v18, v5, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: test_vector_reduce_fminimum_v8double:
@@ -2668,110 +2662,107 @@ define double @test_vector_reduce_fminimum_v8double(<8 x double> %v) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_min_f64 v[16:17], v[4:5], v[12:13]
 ; GFX9-NEXT:    v_mov_b32_e32 v18, 0x7ff80000
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[12:13]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[12:13]
 ; GFX9-NEXT:    v_min_f64 v[12:13], v[0:1], v[8:9]
 ; GFX9-NEXT:    s_nop 0
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v17, v18, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, v16, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[8:9]
+; GFX9-NEXT:    v_cndmask_b32_e32 v5, v18, v17, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v4, 0, v16, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[8:9]
 ; GFX9-NEXT:    v_min_f64 v[8:9], v[6:7], v[14:15]
 ; GFX9-NEXT:    s_nop 0
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v13, v18, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v12, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[6:7], v[14:15]
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v18, v13, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v12, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[6:7], v[14:15]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v9, v18, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v6, v8, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v7, v18, v9, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v6, 0, v8, vcc
 ; GFX9-NEXT:    v_min_f64 v[8:9], v[2:3], v[10:11]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[10:11]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[10:11]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v9, v18, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v8, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v18, v9, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v2, 0, v8, vcc
 ; GFX9-NEXT:    v_min_f64 v[8:9], v[2:3], v[6:7]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[6:7]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[6:7]
 ; GFX9-NEXT:    v_min_f64 v[6:7], v[0:1], v[4:5]
 ; GFX9-NEXT:    s_nop 0
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v9, v18, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v8, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v18, v9, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v2, 0, v8, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v7, v18, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v18, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v6, vcc
 ; GFX9-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v18, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v18, v5, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: test_vector_reduce_fminimum_v8double:
 ; GFX10:       ; %bb.0: ; %entry
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_min_f64 v[16:17], v[4:5], v[12:13]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[4:5], v[12:13]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[4:5], v[12:13]
 ; GFX10-NEXT:    v_min_f64 v[4:5], v[6:7], v[14:15]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[6:7], v[14:15]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[6:7], v[14:15]
 ; GFX10-NEXT:    v_min_f64 v[6:7], v[2:3], v[10:11]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s5, v[2:3], v[10:11]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s5, v[2:3], v[10:11]
 ; GFX10-NEXT:    v_min_f64 v[2:3], v[0:1], v[8:9]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s6, v[0:1], v[8:9]
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v17, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v5, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v7, v7, 0x7ff80000, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, v6, 0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v3, 0x7ff80000, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s6
+; GFX10-NEXT:    v_cmp_o_f64_e64 s6, v[0:1], v[8:9]
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v17, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v16, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v5, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v7, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v3, s6
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s6
 ; GFX10-NEXT:    v_min_f64 v[8:9], v[6:7], v[4:5]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[6:7], v[4:5]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[6:7], v[4:5]
 ; GFX10-NEXT:    v_min_f64 v[4:5], v[2:3], v[0:1]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[2:3], v[0:1]
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v9, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v5, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s4
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[2:3], v[0:1]
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v9, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v5, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s4
 ; GFX10-NEXT:    v_min_f64 v[4:5], v[2:3], v[0:1]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[2:3], v[0:1]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[2:3], v[0:1]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v5, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: test_vector_reduce_fminimum_v8double:
 ; GFX11:       ; %bb.0: ; %entry
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_min_f64 v[16:17], v[4:5], v[12:13]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[4:5], v[12:13]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[4:5], v[12:13]
 ; GFX11-NEXT:    v_min_f64 v[4:5], v[6:7], v[14:15]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[6:7], v[14:15]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[6:7], v[14:15]
 ; GFX11-NEXT:    v_min_f64 v[6:7], v[2:3], v[10:11]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s1, v[2:3], v[10:11]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s1, v[2:3], v[10:11]
 ; GFX11-NEXT:    v_min_f64 v[2:3], v[0:1], v[8:9]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s2, v[0:1], v[8:9]
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v17, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v16, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v5, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v7, v7, 0x7ff80000, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v6, v6, 0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v3, 0x7ff80000, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s2
+; GFX11-NEXT:    v_cmp_o_f64_e64 s2, v[0:1], v[8:9]
+; GFX11-NEXT:    v_dual_cndmask_b32 v1, 0x7ff80000, v17 :: v_dual_cndmask_b32 v0, 0, v16
+; GFX11-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v5, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v7, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v3, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s2
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
 ; GFX11-NEXT:    v_min_f64 v[8:9], v[6:7], v[4:5]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[6:7], v[4:5]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[6:7], v[4:5]
 ; GFX11-NEXT:    v_min_f64 v[4:5], v[2:3], v[0:1]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[2:3], v[0:1]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v9, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v5, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[2:3], v[0:1]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v1, 0x7ff80000, v9 :: v_dual_cndmask_b32 v0, 0, v8
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v5, s0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v4, s0
 ; GFX11-NEXT:    v_min_f64 v[4:5], v[2:3], v[0:1]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[2:3], v[0:1]
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[2:3], v[0:1]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v4 :: v_dual_cndmask_b32 v1, 0x7ff80000, v5
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-SDAG-LABEL: test_vector_reduce_fminimum_v8double:
@@ -2848,67 +2839,67 @@ define double @test_vector_reduce_fminimum_v16double(<16 x double> %v) {
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    buffer_load_dword v31, off, s[0:3], s32
 ; GFX7-NEXT:    v_min_f64 v[32:33], v[8:9], v[24:25]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[8:9], v[24:25]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[8:9], v[24:25]
 ; GFX7-NEXT:    v_min_f64 v[8:9], v[0:1], v[16:17]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[0:1], v[16:17]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[0:1], v[16:17]
 ; GFX7-NEXT:    v_min_f64 v[0:1], v[12:13], v[28:29]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[6:7], v[12:13], v[28:29]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[6:7], v[12:13], v[28:29]
 ; GFX7-NEXT:    v_min_f64 v[12:13], v[10:11], v[26:27]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[8:9], v[10:11], v[26:27]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[8:9], v[10:11], v[26:27]
 ; GFX7-NEXT:    v_min_f64 v[10:11], v[2:3], v[18:19]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[10:11], v[2:3], v[18:19]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[10:11], v[2:3], v[18:19]
 ; GFX7-NEXT:    v_mov_b32_e32 v34, 0x7ff80000
 ; GFX7-NEXT:    v_min_f64 v[2:3], v[4:5], v[20:21]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[12:13], v[4:5], v[20:21]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[12:13], v[4:5], v[20:21]
 ; GFX7-NEXT:    v_min_f64 v[4:5], v[6:7], v[22:23]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[14:15], v[6:7], v[22:23]
-; GFX7-NEXT:    v_cndmask_b32_e64 v7, v13, v34, s[8:9]
-; GFX7-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s[8:9]
-; GFX7-NEXT:    v_cndmask_b32_e64 v11, v11, v34, s[10:11]
-; GFX7-NEXT:    v_cndmask_b32_e64 v10, v10, 0, s[10:11]
-; GFX7-NEXT:    v_cndmask_b32_e32 v13, v33, v34, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v12, v32, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v9, v9, v34, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v8, v8, 0, s[4:5]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[14:15], v[6:7], v[22:23]
+; GFX7-NEXT:    v_cndmask_b32_e64 v7, v34, v13, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e64 v11, v34, v11, s[10:11]
+; GFX7-NEXT:    v_cndmask_b32_e64 v10, 0, v10, s[10:11]
+; GFX7-NEXT:    v_cndmask_b32_e32 v13, v34, v33, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v12, 0, v32, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v9, v34, v9, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v8, 0, v8, s[4:5]
 ; GFX7-NEXT:    v_min_f64 v[16:17], v[10:11], v[6:7]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[10:11], v[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v1, v34, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v3, v3, v34, s[12:13]
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[12:13]
-; GFX7-NEXT:    v_cndmask_b32_e64 v5, v5, v34, s[14:15]
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[14:15]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[10:11], v[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v1, v34, v1, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v3, v34, v3, s[12:13]
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[12:13]
+; GFX7-NEXT:    v_cndmask_b32_e64 v5, v34, v5, s[14:15]
+; GFX7-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s[14:15]
 ; GFX7-NEXT:    v_min_f64 v[10:11], v[2:3], v[0:1]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[6:7], v[2:3], v[0:1]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[6:7], v[2:3], v[0:1]
 ; GFX7-NEXT:    v_min_f64 v[0:1], v[8:9], v[12:13]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[8:9], v[8:9], v[12:13]
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v17, v34, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v16, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v1, v34, s[8:9]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[8:9]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[8:9], v[8:9], v[12:13]
+; GFX7-NEXT:    v_cndmask_b32_e32 v3, v34, v17, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v2, 0, v16, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v1, v34, v1, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[8:9]
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
 ; GFX7-NEXT:    v_min_f64 v[6:7], v[14:15], v[30:31]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[14:15], v[30:31]
-; GFX7-NEXT:    v_cndmask_b32_e64 v7, v7, v34, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v6, v6, 0, s[4:5]
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[14:15], v[30:31]
+; GFX7-NEXT:    v_cndmask_b32_e64 v7, v34, v7, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s[4:5]
 ; GFX7-NEXT:    v_min_f64 v[8:9], v[4:5], v[6:7]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v5, v11, v34, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[6:7]
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v5, v34, v11, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s[6:7]
 ; GFX7-NEXT:    v_min_f64 v[6:7], v[0:1], v[4:5]
-; GFX7-NEXT:    v_cmp_u_f64_e64 s[4:5], v[0:1], v[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v9, v34, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
+; GFX7-NEXT:    v_cmp_o_f64_e64 s[4:5], v[0:1], v[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v34, v9, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
 ; GFX7-NEXT:    v_min_f64 v[4:5], v[2:3], v[0:1]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[0:1]
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v7, v34, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v6, 0, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v5, v34, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v4, 0, vcc
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[0:1]
+; GFX7-NEXT:    v_cndmask_b32_e64 v1, v34, v7, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v0, 0, v6, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e32 v3, v34, v5, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v2, 0, v4, vcc
 ; GFX7-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v34, vcc
+; GFX7-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v34, v5, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: test_vector_reduce_fminimum_v16double:
@@ -2916,67 +2907,67 @@ define double @test_vector_reduce_fminimum_v16double(<16 x double> %v) {
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    buffer_load_dword v31, off, s[0:3], s32
 ; GFX8-NEXT:    v_min_f64 v[32:33], v[8:9], v[24:25]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[8:9], v[24:25]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[8:9], v[24:25]
 ; GFX8-NEXT:    v_min_f64 v[8:9], v[0:1], v[16:17]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[0:1], v[16:17]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[0:1], v[16:17]
 ; GFX8-NEXT:    v_min_f64 v[0:1], v[12:13], v[28:29]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[6:7], v[12:13], v[28:29]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[6:7], v[12:13], v[28:29]
 ; GFX8-NEXT:    v_min_f64 v[12:13], v[10:11], v[26:27]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[8:9], v[10:11], v[26:27]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[8:9], v[10:11], v[26:27]
 ; GFX8-NEXT:    v_min_f64 v[10:11], v[2:3], v[18:19]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[10:11], v[2:3], v[18:19]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[10:11], v[2:3], v[18:19]
 ; GFX8-NEXT:    v_mov_b32_e32 v34, 0x7ff80000
 ; GFX8-NEXT:    v_min_f64 v[2:3], v[4:5], v[20:21]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[12:13], v[4:5], v[20:21]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[12:13], v[4:5], v[20:21]
 ; GFX8-NEXT:    v_min_f64 v[4:5], v[6:7], v[22:23]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[14:15], v[6:7], v[22:23]
-; GFX8-NEXT:    v_cndmask_b32_e64 v7, v13, v34, s[8:9]
-; GFX8-NEXT:    v_cndmask_b32_e64 v6, v12, 0, s[8:9]
-; GFX8-NEXT:    v_cndmask_b32_e64 v11, v11, v34, s[10:11]
-; GFX8-NEXT:    v_cndmask_b32_e64 v10, v10, 0, s[10:11]
-; GFX8-NEXT:    v_cndmask_b32_e32 v13, v33, v34, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v12, v32, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v9, v9, v34, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v8, v8, 0, s[4:5]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[14:15], v[6:7], v[22:23]
+; GFX8-NEXT:    v_cndmask_b32_e64 v7, v34, v13, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, v12, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e64 v11, v34, v11, s[10:11]
+; GFX8-NEXT:    v_cndmask_b32_e64 v10, 0, v10, s[10:11]
+; GFX8-NEXT:    v_cndmask_b32_e32 v13, v34, v33, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v12, 0, v32, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v9, v34, v9, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v8, 0, v8, s[4:5]
 ; GFX8-NEXT:    v_min_f64 v[16:17], v[10:11], v[6:7]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[10:11], v[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, v34, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, v3, v34, s[12:13]
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[12:13]
-; GFX8-NEXT:    v_cndmask_b32_e64 v5, v5, v34, s[14:15]
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[14:15]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[10:11], v[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v1, v34, v1, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, v34, v3, s[12:13]
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[12:13]
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, v34, v5, s[14:15]
+; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s[14:15]
 ; GFX8-NEXT:    v_min_f64 v[10:11], v[2:3], v[0:1]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[6:7], v[2:3], v[0:1]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[6:7], v[2:3], v[0:1]
 ; GFX8-NEXT:    v_min_f64 v[0:1], v[8:9], v[12:13]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[8:9], v[8:9], v[12:13]
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v17, v34, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v16, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, v34, s[8:9]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[8:9]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[8:9], v[8:9], v[12:13]
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v34, v17, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v2, 0, v16, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v1, v34, v1, s[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s[8:9]
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
 ; GFX8-NEXT:    v_min_f64 v[6:7], v[14:15], v[30:31]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[14:15], v[30:31]
-; GFX8-NEXT:    v_cndmask_b32_e64 v7, v7, v34, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v6, v6, 0, s[4:5]
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[14:15], v[30:31]
+; GFX8-NEXT:    v_cndmask_b32_e64 v7, v34, v7, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s[4:5]
 ; GFX8-NEXT:    v_min_f64 v[8:9], v[4:5], v[6:7]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v5, v11, v34, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[6:7]
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, v34, v11, s[6:7]
+; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s[6:7]
 ; GFX8-NEXT:    v_min_f64 v[6:7], v[0:1], v[4:5]
-; GFX8-NEXT:    v_cmp_u_f64_e64 s[4:5], v[0:1], v[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v9, v34, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
+; GFX8-NEXT:    v_cmp_o_f64_e64 s[4:5], v[0:1], v[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v34, v9, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
 ; GFX8-NEXT:    v_min_f64 v[4:5], v[2:3], v[0:1]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[0:1]
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v7, v34, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v6, 0, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v5, v34, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v4, 0, vcc
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[0:1]
+; GFX8-NEXT:    v_cndmask_b32_e64 v1, v34, v7, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v0, 0, v6, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v34, v5, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v2, 0, v4, vcc
 ; GFX8-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v34, vcc
+; GFX8-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v34, v5, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: test_vector_reduce_fminimum_v16double:
@@ -2985,74 +2976,74 @@ define double @test_vector_reduce_fminimum_v16double(<16 x double> %v) {
 ; GFX9-NEXT:    scratch_load_dword v31, off, s32
 ; GFX9-NEXT:    v_mov_b32_e32 v36, 0x7ff80000
 ; GFX9-NEXT:    v_min_f64 v[32:33], v[8:9], v[24:25]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[8:9], v[24:25]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[8:9], v[24:25]
 ; GFX9-NEXT:    v_min_f64 v[34:35], v[0:1], v[16:17]
 ; GFX9-NEXT:    v_min_f64 v[38:39], v[12:13], v[28:29]
-; GFX9-NEXT:    v_cndmask_b32_e32 v9, v33, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v8, v32, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[16:17]
+; GFX9-NEXT:    v_cndmask_b32_e32 v9, v36, v33, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v8, 0, v32, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[16:17]
 ; GFX9-NEXT:    v_min_f64 v[48:49], v[4:5], v[20:21]
 ; GFX9-NEXT:    v_min_f64 v[50:51], v[6:7], v[22:23]
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v35, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v34, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[12:13], v[28:29]
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v36, v35, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v34, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[12:13], v[28:29]
 ; GFX9-NEXT:    v_min_f64 v[52:53], v[10:11], v[26:27]
 ; GFX9-NEXT:    v_min_f64 v[54:55], v[2:3], v[18:19]
-; GFX9-NEXT:    v_cndmask_b32_e32 v13, v39, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v12, v38, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[20:21]
+; GFX9-NEXT:    v_cndmask_b32_e32 v13, v36, v39, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v12, 0, v38, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[20:21]
 ; GFX9-NEXT:    v_min_f64 v[20:21], v[0:1], v[8:9]
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    v_cmp_u_f64_e64 s[0:1], v[14:15], v[30:31]
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v49, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, v48, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[6:7], v[22:23]
+; GFX9-NEXT:    v_cmp_o_f64_e64 s[0:1], v[14:15], v[30:31]
+; GFX9-NEXT:    v_cndmask_b32_e32 v5, v36, v49, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v4, 0, v48, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[6:7], v[22:23]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v51, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v6, v50, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[10:11], v[26:27]
+; GFX9-NEXT:    v_cndmask_b32_e32 v7, v36, v51, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v6, 0, v50, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[10:11], v[26:27]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, v53, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v10, v52, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[18:19]
+; GFX9-NEXT:    v_cndmask_b32_e32 v11, v36, v53, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v10, 0, v52, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[18:19]
 ; GFX9-NEXT:    v_min_f64 v[18:19], v[4:5], v[12:13]
 ; GFX9-NEXT:    s_nop 0
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v55, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v54, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v36, v55, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v2, 0, v54, vcc
 ; GFX9-NEXT:    v_min_f64 v[16:17], v[2:3], v[10:11]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[10:11]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[10:11]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v17, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v16, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[4:5], v[12:13]
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v36, v17, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v2, 0, v16, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[4:5], v[12:13]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v19, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, v18, 0, vcc
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[8:9]
+; GFX9-NEXT:    v_cndmask_b32_e32 v5, v36, v19, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v4, 0, v18, vcc
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[8:9]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v21, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v20, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v36, v21, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v20, vcc
 ; GFX9-NEXT:    v_min_f64 v[8:9], v[0:1], v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX9-NEXT:    v_min_f64 v[4:5], v[14:15], v[30:31]
-; GFX9-NEXT:    v_cndmask_b32_e64 v5, v5, v36, s[0:1]
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[0:1]
+; GFX9-NEXT:    v_cndmask_b32_e64 v5, v36, v5, s[0:1]
+; GFX9-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s[0:1]
 ; GFX9-NEXT:    v_min_f64 v[10:11], v[6:7], v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e64 s[0:1], v[6:7], v[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v9, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v5, v11, v36, s[0:1]
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[0:1]
+; GFX9-NEXT:    v_cmp_o_f64_e64 s[0:1], v[6:7], v[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v36, v9, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v5, v36, v11, s[0:1]
+; GFX9-NEXT:    v_cndmask_b32_e64 v4, 0, v10, s[0:1]
 ; GFX9-NEXT:    v_min_f64 v[6:7], v[2:3], v[4:5]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[2:3], v[4:5]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[2:3], v[4:5]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v7, v36, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v6, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v36, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v2, 0, v6, vcc
 ; GFX9-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
+; GFX9-NEXT:    v_cmp_o_f64_e32 vcc, v[0:1], v[2:3]
 ; GFX9-NEXT:    s_nop 1
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v36, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v36, v5, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: test_vector_reduce_fminimum_v16double:
@@ -3060,66 +3051,66 @@ define double @test_vector_reduce_fminimum_v16double(<16 x double> %v) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    buffer_load_dword v31, off, s[0:3], s32
 ; GFX10-NEXT:    v_min_f64 v[32:33], v[8:9], v[24:25]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[8:9], v[24:25]
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[8:9], v[24:25]
 ; GFX10-NEXT:    v_min_f64 v[8:9], v[0:1], v[16:17]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[0:1], v[16:17]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[0:1], v[16:17]
 ; GFX10-NEXT:    v_min_f64 v[0:1], v[12:13], v[28:29]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s5, v[12:13], v[28:29]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s5, v[12:13], v[28:29]
 ; GFX10-NEXT:    v_min_f64 v[12:13], v[10:11], v[26:27]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s6, v[10:11], v[26:27]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s6, v[10:11], v[26:27]
 ; GFX10-NEXT:    v_min_f64 v[10:11], v[2:3], v[18:19]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s7, v[2:3], v[18:19]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s7, v[2:3], v[18:19]
 ; GFX10-NEXT:    v_min_f64 v[2:3], v[4:5], v[20:21]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s8, v[4:5], v[20:21]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s8, v[4:5], v[20:21]
 ; GFX10-NEXT:    v_min_f64 v[4:5], v[6:7], v[22:23]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s9, v[6:7], v[22:23]
-; GFX10-NEXT:    v_cndmask_b32_e64 v9, v9, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v8, v8, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7ff80000, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v13, v13, 0x7ff80000, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v12, v12, 0, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v11, v11, 0x7ff80000, s7
-; GFX10-NEXT:    v_cndmask_b32_e64 v10, v10, 0, s7
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v3, 0x7ff80000, s8
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s8
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v5, 0x7ff80000, s9
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s9
+; GFX10-NEXT:    v_cmp_o_f64_e64 s9, v[6:7], v[22:23]
+; GFX10-NEXT:    v_cndmask_b32_e64 v9, 0x7ff80000, v9, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v8, 0, v8, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, 0x7ff80000, v1, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v13, 0x7ff80000, v13, s6
+; GFX10-NEXT:    v_cndmask_b32_e64 v12, 0, v12, s6
+; GFX10-NEXT:    v_cndmask_b32_e64 v11, 0x7ff80000, v11, s7
+; GFX10-NEXT:    v_cndmask_b32_e64 v10, 0, v10, s7
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v3, s8
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s8
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v5, s9
+; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s9
 ; GFX10-NEXT:    v_min_f64 v[16:17], v[10:11], v[12:13]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[2:3], v[0:1]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[2:3], v[0:1]
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-NEXT:    v_min_f64 v[6:7], v[14:15], v[30:31]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s10, v[14:15], v[30:31]
-; GFX10-NEXT:    v_cndmask_b32_e64 v15, v33, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v14, v32, 0, vcc_lo
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[10:11], v[12:13]
+; GFX10-NEXT:    v_cmp_o_f64_e64 s10, v[14:15], v[30:31]
+; GFX10-NEXT:    v_cndmask_b32_e32 v15, 0x7ff80000, v33, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v14, 0, v32, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[10:11], v[12:13]
 ; GFX10-NEXT:    v_min_f64 v[10:11], v[2:3], v[0:1]
 ; GFX10-NEXT:    v_min_f64 v[0:1], v[8:9], v[14:15]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s5, v[8:9], v[14:15]
-; GFX10-NEXT:    v_cndmask_b32_e64 v7, v7, 0x7ff80000, s10
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, v6, 0, s10
+; GFX10-NEXT:    v_cmp_o_f64_e64 s5, v[8:9], v[14:15]
+; GFX10-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v7, s10
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s10
 ; GFX10-NEXT:    v_min_f64 v[2:3], v[4:5], v[6:7]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s6, v[4:5], v[6:7]
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v17, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v16, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v7, v11, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, v10, 0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7ff80000, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s5
+; GFX10-NEXT:    v_cmp_o_f64_e64 s6, v[4:5], v[6:7]
+; GFX10-NEXT:    v_cndmask_b32_e32 v5, 0x7ff80000, v17, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v4, 0, v16, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v11, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, 0, v10, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, 0x7ff80000, v1, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s5
 ; GFX10-NEXT:    v_min_f64 v[8:9], v[0:1], v[6:7]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[6:7]
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v3, 0x7ff80000, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s6
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[6:7]
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v3, s6
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s6
 ; GFX10-NEXT:    v_min_f64 v[0:1], v[4:5], v[2:3]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s4, v[4:5], v[2:3]
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v9, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v8, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7ff80000, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s4
+; GFX10-NEXT:    v_cmp_o_f64_e64 s4, v[4:5], v[2:3]
+; GFX10-NEXT:    v_cndmask_b32_e32 v3, 0x7ff80000, v9, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v2, 0, v8, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, 0x7ff80000, v1, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s4
 ; GFX10-NEXT:    v_min_f64 v[4:5], v[2:3], v[0:1]
-; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[2:3], v[0:1]
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[2:3], v[0:1]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0, v4, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7ff80000, v5, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: test_vector_reduce_fminimum_v16double:
@@ -3127,71 +3118,67 @@ define double @test_vector_reduce_fminimum_v16double(<16 x double> %v) {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    scratch_load_b32 v31, off, s32
 ; GFX11-NEXT:    v_min_f64 v[32:33], v[8:9], v[24:25]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[8:9], v[24:25]
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[8:9], v[24:25]
 ; GFX11-NEXT:    v_min_f64 v[8:9], v[0:1], v[16:17]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[0:1], v[16:17]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[0:1], v[16:17]
 ; GFX11-NEXT:    v_min_f64 v[0:1], v[12:13], v[28:29]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s1, v[12:13], v[28:29]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s1, v[12:13], v[28:29]
 ; GFX11-NEXT:    v_min_f64 v[12:13], v[10:11], v[26:27]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s2, v[10:11], v[26:27]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s2, v[10:11], v[26:27]
 ; GFX11-NEXT:    v_min_f64 v[10:11], v[2:3], v[18:19]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s3, v[2:3], v[18:19]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s3, v[2:3], v[18:19]
 ; GFX11-NEXT:    v_min_f64 v[2:3], v[4:5], v[20:21]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s4, v[4:5], v[20:21]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s4, v[4:5], v[20:21]
 ; GFX11-NEXT:    v_min_f64 v[4:5], v[6:7], v[22:23]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s5, v[6:7], v[22:23]
-; GFX11-NEXT:    v_cndmask_b32_e64 v9, v9, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v8, v8, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7ff80000, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v13, v13, 0x7ff80000, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v12, v12, 0, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v11, v11, 0x7ff80000, s3
-; GFX11-NEXT:    v_cndmask_b32_e64 v10, v10, 0, s3
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v3, 0x7ff80000, s4
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s4
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v5, 0x7ff80000, s5
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s5
+; GFX11-NEXT:    v_cmp_o_f64_e64 s5, v[6:7], v[22:23]
+; GFX11-NEXT:    v_cndmask_b32_e64 v9, 0x7ff80000, v9, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v8, 0, v8, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, 0x7ff80000, v1, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v13, 0x7ff80000, v13, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v12, 0, v12, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v11, 0x7ff80000, v11, s3
+; GFX11-NEXT:    v_cndmask_b32_e64 v10, 0, v10, s3
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v3, s4
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s4
+; GFX11-NEXT:    v_cndmask_b32_e64 v5, 0x7ff80000, v5, s5
+; GFX11-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s5
 ; GFX11-NEXT:    v_min_f64 v[16:17], v[10:11], v[12:13]
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[2:3], v[0:1]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[2:3], v[0:1]
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    v_min_f64 v[6:7], v[14:15], v[30:31]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s6, v[14:15], v[30:31]
-; GFX11-NEXT:    v_cndmask_b32_e64 v15, v33, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v14, v32, 0, vcc_lo
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[10:11], v[12:13]
+; GFX11-NEXT:    v_cmp_o_f64_e64 s6, v[14:15], v[30:31]
+; GFX11-NEXT:    v_dual_cndmask_b32 v15, 0x7ff80000, v33 :: v_dual_cndmask_b32 v14, 0, v32
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[10:11], v[12:13]
 ; GFX11-NEXT:    v_min_f64 v[10:11], v[2:3], v[0:1]
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_3) | instid1(VALU_DEP_1)
 ; GFX11-NEXT:    v_min_f64 v[0:1], v[8:9], v[14:15]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s1, v[8:9], v[14:15]
-; GFX11-NEXT:    v_cndmask_b32_e64 v7, v7, 0x7ff80000, s6
-; GFX11-NEXT:    v_cndmask_b32_e64 v6, v6, 0, s6
+; GFX11-NEXT:    v_cmp_o_f64_e64 s1, v[8:9], v[14:15]
+; GFX11-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v7, s6
+; GFX11-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s6
 ; GFX11-NEXT:    v_min_f64 v[2:3], v[4:5], v[6:7]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s2, v[4:5], v[6:7]
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v17, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v16, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v7, v11, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v6, v10, 0, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7ff80000, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s1
+; GFX11-NEXT:    v_cmp_o_f64_e64 s2, v[4:5], v[6:7]
+; GFX11-NEXT:    v_dual_cndmask_b32 v5, 0x7ff80000, v17 :: v_dual_cndmask_b32 v4, 0, v16
+; GFX11-NEXT:    v_cndmask_b32_e64 v7, 0x7ff80000, v11, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v6, 0, v10, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, 0x7ff80000, v1, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s1
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_1)
 ; GFX11-NEXT:    v_min_f64 v[8:9], v[0:1], v[6:7]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[6:7]
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v3, 0x7ff80000, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s2
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[0:1], v[6:7]
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0x7ff80000, v3, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s2
 ; GFX11-NEXT:    v_min_f64 v[0:1], v[4:5], v[2:3]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s0, v[4:5], v[2:3]
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v9, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v8, 0, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7ff80000, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s0
+; GFX11-NEXT:    v_cmp_o_f64_e64 s0, v[4:5], v[2:3]
+; GFX11-NEXT:    v_dual_cndmask_b32 v3, 0x7ff80000, v9 :: v_dual_cndmask_b32 v2, 0, v8
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, 0x7ff80000, v1, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, 0, v0, s0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_min_f64 v[4:5], v[2:3], v[0:1]
-; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[2:3], v[0:1]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f64_e32 vcc_lo, v[2:3], v[0:1]
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, 0, v4 :: v_dual_cndmask_b32 v1, 0x7ff80000, v5
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-SDAG-LABEL: test_vector_reduce_fminimum_v16double:


### PR DESCRIPTION
Extend `performSelectCombine` to handle the cases with setcc condition having multiple select users. This enable cheap `v_cndmask_b32_e32` encoding in more cases.
