### PR TITLE
workflows/release-binaries: Update dispatch options for Windows

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -22,6 +22,8 @@ on:
           - ubuntu-22.04
           - ubuntu-22.04-arm
           - macos-14
+          - windows-2022
+          - windows-11-arm
 
   workflow_call:
     inputs:


### PR DESCRIPTION
This makes it possible to manually build the Windows binaries for releases.