### PR TITLE
[SPIR-V] Fix swapped type sets in G_LROUND/G_LLROUND legalization

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -494,8 +494,8 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
   MulFix.lower();
 
   getActionDefinitionsBuilder({G_LROUND, G_LLROUND})
-      .legalForCartesianProduct(allFloatScalarsAndVectors,
-                                allIntScalarsAndVectors);
+      .legalForCartesianProduct(allIntScalarsAndVectors,
+                                allFloatScalarsAndVectors);
 
   // FP conversions.
   getActionDefinitionsBuilder({G_FPTRUNC, G_FPEXT})

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/llround.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/llround.ll
@@ -6,11 +6,14 @@
 ; CHECK-DAG:      [[i32:%[0-9]+]] = OpTypeInt 32 0
 ; CHECK-DAG:      [[f64:%[0-9]+]] = OpTypeFloat 64
 ; CHECK-DAG:      [[i64:%[0-9]+]] = OpTypeInt 64 0
+; CHECK-DAG:      [[i8:%[0-9]+]] = OpTypeInt 8 0
 ; CHECK-DAG:      [[vecf32:%[0-9]+]] = OpTypeVector [[f32]]
 ; CHECK-DAG:      [[veci32:%[0-9]+]] = OpTypeVector [[i32]]
 ; CHECK-DAG:      [[vecf64:%[0-9]+]] = OpTypeVector [[f64]]
 ; CHECK-DAG:      [[veci64:%[0-9]+]] = OpTypeVector [[i64]]
 
+; CHECK:      [[rounded_i8_f32:%[0-9]+]] = OpExtInst [[f32]] [[opencl]] round %[[#]]
+; CHECK-NEXT:      %[[#]] = OpConvertFToS [[i8]] [[rounded_i8_f32]]
 ; CHECK:      [[rounded_i32_f32:%[0-9]+]] = OpExtInst [[f32]] [[opencl]] round %[[#]]
 ; CHECK-NEXT:      %[[#]] = OpConvertFToS [[i32]] [[rounded_i32_f32]]
 ; CHECK:      [[rounded_i32_f64:%[0-9]+]] = OpExtInst [[f64]] [[opencl]] round %[[#]]
@@ -27,6 +30,12 @@
 ; CHECK-NEXT:      %[[#]] = OpConvertFToS [[veci64]] [[rounded_v4i64_f32]]
 ; CHECK:      [[rounded_v4i64_f64:%[0-9]+]] = OpExtInst [[vecf64]] [[opencl]] round %[[#]]
 ; CHECK-NEXT:      %[[#]] = OpConvertFToS [[veci64]] [[rounded_v4i64_f64]]
+
+define spir_func i8 @test_llround_i8_f32(float %arg0) {
+entry:
+  %0 = call i8 @llvm.llround.i8.f32(float %arg0)
+  ret i8 %0
+}
 
 define spir_func i32 @test_llround_i32_f32(float %arg0) {
 entry:
@@ -76,6 +85,7 @@ entry:
   ret <4 x i64> %0
 }
  
+declare i8 @llvm.llround.i8.f32(float)
 declare i32 @llvm.llround.i32.f32(float)
 declare i32 @llvm.llround.i32.f64(double)
 declare i64 @llvm.llround.i64.f32(float)

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/lround.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/lround.ll
@@ -6,11 +6,14 @@
 ; CHECK-DAG:      [[i32:%[0-9]+]] = OpTypeInt 32 0
 ; CHECK-DAG:      [[f64:%[0-9]+]] = OpTypeFloat 64
 ; CHECK-DAG:      [[i64:%[0-9]+]] = OpTypeInt 64 0
+; CHECK-DAG:      [[i8:%[0-9]+]] = OpTypeInt 8 0
 ; CHECK-DAG:      [[vecf32:%[0-9]+]] = OpTypeVector [[f32]]
 ; CHECK-DAG:      [[veci32:%[0-9]+]] = OpTypeVector [[i32]]
 ; CHECK-DAG:      [[vecf64:%[0-9]+]] = OpTypeVector [[f64]]
 ; CHECK-DAG:      [[veci64:%[0-9]+]] = OpTypeVector [[i64]]
 
+; CHECK:      [[rounded_i8_f32:%[0-9]+]] = OpExtInst [[f32]] [[opencl]] round %[[#]]
+; CHECK-NEXT:      %[[#]] = OpConvertFToS [[i8]] [[rounded_i8_f32]]
 ; CHECK:      [[rounded_i32_f32:%[0-9]+]] = OpExtInst [[f32]] [[opencl]] round %[[#]]
 ; CHECK-NEXT:      %[[#]] = OpConvertFToS [[i32]] [[rounded_i32_f32]]
 ; CHECK:      [[rounded_i32_f64:%[0-9]+]] = OpExtInst [[f64]] [[opencl]] round %[[#]]
@@ -27,6 +30,12 @@
 ; CHECK-NEXT:      %[[#]] = OpConvertFToS [[veci64]] [[rounded_v4i64_f32]]
 ; CHECK:      [[rounded_v4i64_f64:%[0-9]+]] = OpExtInst [[vecf64]] [[opencl]] round %[[#]]
 ; CHECK-NEXT:      %[[#]] = OpConvertFToS [[veci64]] [[rounded_v4i64_f64]]
+
+define spir_func i8 @test_lround_i8_f32(float %arg0) {
+entry:
+  %0 = call i8 @llvm.lround.i8.f32(float %arg0)
+  ret i8 %0
+}
 
 define spir_func i32 @test_lround_i32_f32(float %arg0) {
 entry:
@@ -76,6 +85,7 @@ entry:
   ret <4 x i64> %0
 }
  
+declare i8 @llvm.lround.i8.f32(float)
 declare i32 @llvm.lround.i32.f32(float)
 declare i32 @llvm.lround.i32.f64(double)
 declare i64 @llvm.lround.i64.f32(float)


### PR DESCRIPTION
Result and source types were reversed, only working by luck at widths where LLT cannot tell int from float, fixes i8 results