### PR TITLE
[gn][NFC] Remove obsolete macro definition

### DIFF
--- a/llvm/utils/gn/secondary/libcxx/src/BUILD.gn
+++ b/llvm/utils/gn/secondary/libcxx/src/BUILD.gn
@@ -87,9 +87,6 @@ config("cxx_config") {
       "_CRT_STDIO_ISO_WIDE_SPECIFIERS",
     ]
   }
-  if (!libcxx_enable_new_delete_definitions) {
-    defines += [ "_LIBCPP_DISABLE_NEW_DELETE_DEFINITIONS" ]
-  }
   if (libcxx_enable_exceptions) {
     if (current_os == "win") {
       cflags_cc += [ "/EHsc" ]


### PR DESCRIPTION
The _LIBCPP_DISABLE_NEW_DELETE_DEFINITIONS macro is not honoured anymore since afc5cca0d401, 3 years ago. This has been dead code since then.