### PR TITLE
[libc++] Use the FreeBSD CMake cache when testing FreeBSD

### DIFF
--- a/libcxx/utils/ci/buildkite-pipeline.yml
+++ b/libcxx/utils/ci/buildkite-pipeline.yml
@@ -142,7 +142,7 @@ steps:
 - group: ':freebsd: FreeBSD'
   steps:
   - label: FreeBSD 15.1 amd64
-    command: libcxx/utils/ci/run-buildbot generic-cxx26
+    command: libcxx/utils/ci/run-buildbot freebsd
     env:
       CC: clang21
       CXX: clang++21

--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -845,6 +845,12 @@ aix)
     check-abi-list
     check-runtimes
 ;;
+freebsd)
+    clean
+    generate-cmake -C "${MONOREPO_ROOT}/libcxx/cmake/caches/FreeBSD.cmake"
+    check-runtimes
+    check-abi-list
+;;
 android-ndk-*)
     clean
 


### PR DESCRIPTION
While investigating something unrelated, I stumbled upon the fact that the FreeBSD CI job was not currently using the FreeBSD CMake cache. I think it should, since the intent is to have coverage for the configuration used on FreeBSD, not only for building the library on FreeBSD in a generic configuration.