### PR TITLE
[clang-tidy][NFC] Disable new checks in .clang-tidy

### DIFF
--- a/clang-tools-extra/clang-tidy/.clang-tidy
+++ b/clang-tools-extra/clang-tidy/.clang-tidy
@@ -4,22 +4,27 @@ ExcludeHeaderFilterRegex: 'include-cleaner|clang-query'
 Checks: >
   bugprone-*,
   -bugprone-assignment-in-if-condition,
+  -bugprone-assignment-in-selection-statement,
   -bugprone-branch-clone,
-  -bugprone-easily-swappable-parameters,
-  -bugprone-narrowing-conversions,
-  -bugprone-unused-return-value,
   -bugprone-derived-method-shadowing-base-method,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-missing-end-comparison,
+  -bugprone-narrowing-conversions,
+  -bugprone-signed-bitwise,
+  -bugprone-unused-return-value,
   cppcoreguidelines-init-variables,
   cppcoreguidelines-missing-std-forward,
   cppcoreguidelines-rvalue-reference-param-not-moved,
   cppcoreguidelines-virtual-class-destructor,
   google-readability-casting,
   misc-const-correctness,
+  -misc-explicit-constructor,
   misc-include-cleaner,
   modernize-*,
   -modernize-avoid-c-arrays,
   -modernize-pass-by-value,
   -modernize-use-nodiscard,
+  -modernize-use-string-view,
   -modernize-use-trailing-return-type,
   performance-*,
   -performance-enum-size,
@@ -36,14 +41,16 @@ Checks: >
   -readability-magic-numbers,
   -readability-named-parameter,
   -readability-qualified-auto,
+  -readability-redundant-lambda-parameter-list,
   -readability-simplify-boolean-expr,
   -readability-static-definition-in-anonymous-namespace,
-  -readability-suspicious-call-argument
+  -readability-suspicious-call-argument,
+  -readability-trailing-comma
 
 CheckOptions:
-  - key:             performance-move-const-arg.CheckTriviallyCopyableMove
-    value:           false
   - key:             misc-include-cleaner.MissingIncludes
     value:           false
   - key:             misc-override-with-different-visibility.DisallowedVisibilityChange
     value:           widening
+  - key:             performance-move-const-arg.CheckTriviallyCopyableMove
+    value:           false


### PR DESCRIPTION
Disabled new checks form 23 release that I found not comply with current style (yet).