### PR TITLE
[lldb-dap][NFC] Create a type alias for sourceReference.

### DIFF
--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -521,17 +521,18 @@ void DAP::SendProgressEvent(uint64_t progress_id, const char *message,
   progress_event_reporter.Push(progress_id, message, completed, total);
 }
 
-int32_t DAP::CreateSourceReference(lldb::addr_t address) {
+src_ref_t DAP::CreateSourceReference(lldb::addr_t address) {
   std::lock_guard<std::mutex> guard(m_source_references_mutex);
   auto iter = llvm::find(m_source_references, address);
   if (iter != m_source_references.end())
     return std::distance(m_source_references.begin(), iter) + 1;
 
   m_source_references.emplace_back(address);
-  return static_cast<int32_t>(m_source_references.size());
+  return static_cast<src_ref_t>(m_source_references.size());
 }
 
-std::optional<lldb::addr_t> DAP::GetSourceReferenceAddress(int32_t reference) {
+std::optional<lldb::addr_t>
+DAP::GetSourceReferenceAddress(src_ref_t reference) {
   std::lock_guard<std::mutex> guard(m_source_references_mutex);
   if (reference <= LLDB_DAP_INVALID_SRC_REF)
     return std::nullopt;

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -238,9 +238,9 @@ struct DAP final : public DAPTransport::MessageHandler {
   void SendProgressEvent(uint64_t progress_id, const char *message,
                          uint64_t completed, uint64_t total);
 
-  int32_t CreateSourceReference(lldb::addr_t address);
+  src_ref_t CreateSourceReference(lldb::addr_t address);
 
-  std::optional<lldb::addr_t> GetSourceReferenceAddress(int32_t reference);
+  std::optional<lldb::addr_t> GetSourceReferenceAddress(src_ref_t reference);
 
   ExceptionBreakpoint *GetExceptionBPFromStopReason(lldb::SBThread &thread);
 
@@ -512,7 +512,7 @@ private:
   const protocol::Request *m_active_request;
 
   llvm::StringMap<SourceBreakpointMap> m_source_breakpoints;
-  llvm::DenseMap<int64_t, SourceBreakpointMap> m_source_assembly_breakpoints;
+  llvm::DenseMap<src_ref_t, SourceBreakpointMap> m_source_assembly_breakpoints;
 };
 
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/Handler/BreakpointLocationsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/BreakpointLocationsRequestHandler.cpp
@@ -104,7 +104,7 @@ BreakpointLocationsRequestHandler::GetSourceBreakpointLocations(
 
 std::vector<std::pair<uint32_t, uint32_t>>
 BreakpointLocationsRequestHandler::GetAssemblyBreakpointLocations(
-    int64_t source_reference, uint32_t start_line, uint32_t end_line) const {
+    src_ref_t source_reference, uint32_t start_line, uint32_t end_line) const {
   std::vector<std::pair<uint32_t, uint32_t>> locations;
   lldb::SBAddress address(source_reference, dap.target);
   if (!address.IsValid())

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.h
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.h
@@ -234,8 +234,8 @@ public:
                                uint32_t start_column, uint32_t end_line,
                                uint32_t end_column) const;
   std::vector<std::pair<uint32_t, uint32_t>>
-  GetAssemblyBreakpointLocations(int64_t source_reference, uint32_t start_line,
-                                 uint32_t end_line) const;
+  GetAssemblyBreakpointLocations(src_ref_t source_reference,
+                                 uint32_t start_line, uint32_t end_line) const;
 };
 
 class CompletionsRequestHandler

--- a/lldb/tools/lldb-dap/Handler/SourceRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/SourceRequestHandler.cpp
@@ -30,7 +30,7 @@ namespace lldb_dap {
 llvm::Expected<protocol::SourceResponseBody>
 SourceRequestHandler::Run(const protocol::SourceArguments &args) const {
 
-  uint32_t source_ref =
+  src_ref_t source_ref =
       args.source ? args.source->sourceReference.value_or(args.sourceReference)
                   : args.sourceReference;
   const std::optional<lldb::addr_t> source_addr_opt =

--- a/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
@@ -520,7 +520,7 @@ struct SourceArguments {
   /// The reference to the source. This is the same as `source.sourceReference`.
   /// This is provided for backward compatibility since old clients do not
   /// understand the `source` attribute.
-  int64_t sourceReference = LLDB_DAP_INVALID_SRC_REF;
+  src_ref_t sourceReference = LLDB_DAP_INVALID_SRC_REF;
 };
 bool fromJSON(const llvm::json::Value &, SourceArguments &, llvm::json::Path);
 

--- a/lldb/tools/lldb-dap/Protocol/ProtocolTypes.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolTypes.h
@@ -29,11 +29,15 @@
 #include <cstdint>
 #include <optional>
 
-#define LLDB_DAP_INVALID_SRC_REF 0
+#define LLDB_DAP_INVALID_SRC_REF int32_t(0U)
 #define LLDB_DAP_INVALID_VALUE_LOC 0
 #define LLDB_DAP_INVALID_STACK_FRAME_ID UINT64_MAX
 
 namespace lldb_dap::protocol {
+
+/// The DAP `sourceReference`.
+/// The spec defines it as int32 with a minimum value of 0.
+using src_ref_t = int32_t;
 
 /// An `ExceptionBreakpointsFilter` is shown in the UI as an filter option for
 /// configuring how exceptions are dealt with.
@@ -413,7 +417,7 @@ struct Source {
   /// `source` request (even if a path is specified). Since a `sourceReference`
   /// is only valid for a session, it can not be used to persist a source. The
   /// value should be less than or equal to 2147483647 (2^31-1).
-  std::optional<int32_t> sourceReference;
+  std::optional<src_ref_t> sourceReference;
 
   /// A hint for how to present the source in the UI. A value of `deemphasize`
   /// can be used to indicate that the source is not available or that it is
@@ -1133,5 +1137,9 @@ llvm::json::Value toJSON(const StackFrame::PresentationHint &);
 llvm::json::Value toJSON(const StackFrame &);
 
 } // namespace lldb_dap::protocol
+
+namespace lldb_dap {
+using src_ref_t = protocol::src_ref_t;
+} // namespace lldb_dap
 
 #endif

--- a/lldb/tools/lldb-dap/Protocol/ProtocolTypes.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolTypes.h
@@ -29,7 +29,7 @@
 #include <cstdint>
 #include <optional>
 
-#define LLDB_DAP_INVALID_SRC_REF int32_t(0U)
+#define LLDB_DAP_INVALID_SRC_REF int32_t(0)
 #define LLDB_DAP_INVALID_VALUE_LOC 0
 #define LLDB_DAP_INVALID_STACK_FRAME_ID UINT64_MAX
 

--- a/lldb/tools/lldb-dap/SourceBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.cpp
@@ -86,7 +86,7 @@ void SourceBreakpoint::CreatePathBreakpoint(const protocol::Source &source) {
 }
 
 llvm::Error SourceBreakpoint::CreateAssemblyBreakpointWithSourceReference(
-    int64_t source_reference) {
+    src_ref_t source_reference) {
   std::optional<lldb::addr_t> raw_addr =
       m_dap.GetSourceReferenceAddress(source_reference);
   if (!raw_addr)

--- a/lldb/tools/lldb-dap/SourceBreakpoint.h
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.h
@@ -53,7 +53,7 @@ public:
 protected:
   void CreatePathBreakpoint(const protocol::Source &source);
   llvm::Error
-  CreateAssemblyBreakpointWithSourceReference(int64_t source_reference);
+  CreateAssemblyBreakpointWithSourceReference(src_ref_t source_reference);
   llvm::Error CreateAssemblyBreakpointWithPersistenceData(
       const protocol::PersistenceData &persistence_data);
 


### PR DESCRIPTION
The spec requires sourceReference to be of type int32 and a minimum value of 0. src_ref_t is an alias to int32_t.

Replace narrowed values in function helpers and struct declarations.