### PR TITLE
[AMDGPU] Add MaxHWAddressableLocalMemorySize to TargetParser

### DIFF
--- a/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
+++ b/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
@@ -202,6 +202,13 @@ LLVM_ABI unsigned getAddressableNumSGPRs(Triple::SubArchType SubArch);
 LLVM_ABI unsigned getSGPRAllocGranule(GPUKind AK);
 LLVM_ABI unsigned getSGPRAllocGranule(Triple::SubArchType SubArch);
 
+/// \returns Maximum LDS in bytes a single work-group can address. This is a
+/// fixed hardware cap and does not depend on how many SIMDs a work-group runs
+/// on.
+LLVM_ABI unsigned getMaxHWAddressableLocalMemorySize(GPUKind AK);
+LLVM_ABI unsigned
+getMaxHWAddressableLocalMemorySize(Triple::SubArchType SubArch);
+
 /// \returns Number of SIMDs a work-group's waves run on. All four SIMDs of the
 /// functional block in full-SIMD mode, half of them otherwise.
 constexpr unsigned getNumWorkGroupSIMDs(bool FullSIMDMode) {

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -1179,8 +1179,17 @@ unsigned getWavefrontSize(const MCSubtargetInfo &STI) {
 // Maximum LDS a single work-group can address. This is a fixed HW cap. It does
 // not depend on how many SIMDs a work-group runs on.
 static unsigned getMaxHWAddressableLocalMemorySize(const MCSubtargetInfo &STI) {
-  return AMDGPU::getMaxHWAddressableLocalMemorySize(
-      parseArchAMDGCN(STI.getCPU()));
+  if (STI.getFeatureBits().test(FeatureAddressableLocalMemorySize32768))
+    return 32768;
+  if (STI.getFeatureBits().test(FeatureAddressableLocalMemorySize65536))
+    return 65536;
+  if (STI.getFeatureBits().test(FeatureAddressableLocalMemorySize163840))
+    return 163840;
+  if (STI.getFeatureBits().test(FeatureAddressableLocalMemorySize196608))
+    return 196608;
+  if (STI.getFeatureBits().test(FeatureAddressableLocalMemorySize327680))
+    return 327680;
+  return 32768;
 }
 
 // Total physical size of LDS on the block, in bytes. On targets with

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -1179,17 +1179,8 @@ unsigned getWavefrontSize(const MCSubtargetInfo &STI) {
 // Maximum LDS a single work-group can address. This is a fixed HW cap. It does
 // not depend on how many SIMDs a work-group runs on.
 static unsigned getMaxHWAddressableLocalMemorySize(const MCSubtargetInfo &STI) {
-  if (STI.getFeatureBits().test(FeatureAddressableLocalMemorySize32768))
-    return 32768;
-  if (STI.getFeatureBits().test(FeatureAddressableLocalMemorySize65536))
-    return 65536;
-  if (STI.getFeatureBits().test(FeatureAddressableLocalMemorySize163840))
-    return 163840;
-  if (STI.getFeatureBits().test(FeatureAddressableLocalMemorySize196608))
-    return 196608;
-  if (STI.getFeatureBits().test(FeatureAddressableLocalMemorySize327680))
-    return 327680;
-  return 32768;
+  return AMDGPU::getMaxHWAddressableLocalMemorySize(
+      parseArchAMDGCN(STI.getCPU()));
 }
 
 // Total physical size of LDS on the block, in bytes. On targets with

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -43,6 +43,7 @@ struct GPUInfo {
   StringTable::Offset FamilyName;
   StringTable::Offset BaseName; // The canonical device name for a variant.
   uint8_t MaxWavesPerEU;
+  uint32_t MaxHWAddressableLocalMemorySize;
 };
 
 // Per-GPU data for the R600 GPUKinds.
@@ -428,6 +429,16 @@ unsigned AMDGPU::getSGPRAllocGranule(Triple::SubArchType SubArch) {
   if (Version.Major >= 8)
     return 16;
   return 8;
+}
+
+unsigned AMDGPU::getMaxHWAddressableLocalMemorySize(GPUKind AK) {
+  const GPUInfo *Info = getAMDGPUInfo(AK);
+  return Info ? Info->MaxHWAddressableLocalMemorySize : 32768;
+}
+
+unsigned
+AMDGPU::getMaxHWAddressableLocalMemorySize(Triple::SubArchType SubArch) {
+  return getMaxHWAddressableLocalMemorySize(getGPUKindFromSubArch(SubArch));
 }
 
 unsigned AMDGPU::getMaxWavesPerEU(GPUKind AK) {

--- a/llvm/test/TableGen/AMDGPUTargetDefSubArchSpelling.td
+++ b/llvm/test/TableGen/AMDGPUTargetDefSubArchSpelling.td
@@ -37,7 +37,7 @@ def GFX888_AMAZING : ProcessorModel<"gfx888-amazing", NoSchedModel, []>,
 
 // The GPU table: the base GPU has no base name (offset 0); the variant uses
 // AMDGPUSubArch8_88A and records "gfx888" as its base name.
-// CHECK: {[[#]], Triple::AMDGPUSubArch888, {{.*}}, {8, 8, 8}, [[FAM:[0-9]+]], 0, [[#]]},
+// CHECK: {[[#]], Triple::AMDGPUSubArch888, {{.*}}, {8, 8, 8}, [[FAM:[0-9]+]], 0, [[#]], [[#]]},
 
 // The subarch-name table maps the variant's own subarch to its triple name.
 // CHECK: {Triple::AMDGPUSubArch888A, [[#]], [[#]]},

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -3070,6 +3070,38 @@ TEST(TargetParserTest, testAMDGPUgetSGPRAllocGranule) {
   EXPECT_EQ(AMDGPU::getSGPRAllocGranule(AMDGPU::GK_GFX1030), 106u);
 }
 
+TEST(TargetParserTest, testAMDGPUgetMaxHWAddressableLocalMemorySize) {
+  // The addressable cap is a fixed hardware property, independent of how many
+  // SIMDs a work-group runs on.
+  EXPECT_EQ(
+      AMDGPU::getMaxHWAddressableLocalMemorySize(Triple::AMDGPUSubArch600),
+      32768u);
+  EXPECT_EQ(
+      AMDGPU::getMaxHWAddressableLocalMemorySize(Triple::AMDGPUSubArch700),
+      65536u);
+  EXPECT_EQ(
+      AMDGPU::getMaxHWAddressableLocalMemorySize(Triple::AMDGPUSubArch900),
+      65536u);
+  EXPECT_EQ(
+      AMDGPU::getMaxHWAddressableLocalMemorySize(Triple::AMDGPUSubArch950),
+      163840u);
+  // gfx10+ addresses 64 KiB even though the physical block is 128 KiB.
+  EXPECT_EQ(
+      AMDGPU::getMaxHWAddressableLocalMemorySize(Triple::AMDGPUSubArch1030),
+      65536u);
+  EXPECT_EQ(
+      AMDGPU::getMaxHWAddressableLocalMemorySize(Triple::AMDGPUSubArch1250),
+      327680u);
+
+  // The GPUKind overload resolves to the same values.
+  EXPECT_EQ(AMDGPU::getMaxHWAddressableLocalMemorySize(AMDGPU::GK_GFX900),
+            65536u);
+  EXPECT_EQ(AMDGPU::getMaxHWAddressableLocalMemorySize(AMDGPU::GK_GFX950),
+            163840u);
+  EXPECT_EQ(AMDGPU::getMaxHWAddressableLocalMemorySize(AMDGPU::GK_GFX1250),
+            327680u);
+}
+
 TEST(TargetParserTest, testAMDGPUgetNumWorkGroupSIMDs) {
   EXPECT_EQ(AMDGPU::getNumWorkGroupSIMDs(true), 4u);
   EXPECT_EQ(AMDGPU::getNumWorkGroupSIMDs(false), 2u);

--- a/llvm/utils/TableGen/Basic/AMDGPUTargetDefEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/AMDGPUTargetDefEmitter.cpp
@@ -599,7 +599,8 @@ emitAMDGPUTable(raw_ostream &OS, const RecordKeeper &RK,
     raw_svector_ostream BaseNameOS(BaseName);
     emitBaseName(BaseNameOS, R);
     OS << Names.GetOrAddStringOffset(BaseName) << ", "
-       << getFeatureValue(R, "MaxWavesPerEU", 10) << "},\n";
+       << getFeatureValue(R, "MaxWavesPerEU", 10) << ", "
+       << getFeatureValue(R, "AddressableLocalMemorySize", 32768) << "},\n";
   }
   OS << "};\n"
         "#endif // GET_AMDGPU_GPU_TABLE\n\n";


### PR DESCRIPTION
This is to aid in resolving https://github.com/ROCm/llvm-project/issues/3298 : "Comgr should use target information from upstream TargetParser rather than maintaining its own"