### PR TITLE
[Clang] Cast UBSan globals to appropriate generic address space

### DIFF
--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -4307,8 +4307,8 @@ void CodeGenFunction::EmitCheck(
         CGM.getDataLayout().getDefaultGlobalsAddressSpace());
     InfoPtr->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
     CGM.getSanitizerMetadata()->disableSanitizerForGlobal(InfoPtr);
-    Args.push_back(InfoPtr);
-    ArgTypes.push_back(Args.back()->getType());
+    Args.push_back(Builder.CreateAddrSpaceCast(InfoPtr, CGM.VoidPtrTy));
+    ArgTypes.push_back(CGM.VoidPtrTy);
   }
 
   for (llvm::Value *DynamicArg : DynamicArgs) {

--- a/clang/test/CodeGenHIP/sanitize-undefined-null.hip
+++ b/clang/test/CodeGenHIP/sanitize-undefined-null.hip
@@ -22,7 +22,7 @@
 // CHECK-NEXT:    br i1 [[TMP1]], label [[CONT:%.*]], label [[HANDLER_TYPE_MISMATCH:%.*]], !prof [[PROF3:![0-9]+]], !nosanitize !3
 // CHECK:       handler.type_mismatch:
 // CHECK-NEXT:    [[TMP2:%.*]] = ptrtoint ptr [[TMP0]] to i64, !nosanitize !3
-// CHECK-NEXT:    call void @__ubsan_handle_type_mismatch_v1_abort(ptr addrspace(1) @[[GLOB1:[0-9]+]], i64 [[TMP2]]) #[[ATTR2:[0-9]+]], !nosanitize !3
+// CHECK-NEXT:    call void @__ubsan_handle_type_mismatch_v1_abort(ptr addrspacecast (ptr addrspace(1) @[[GLOB1:[0-9]+]] to ptr), i64 [[TMP2]]) #[[ATTR2:[0-9]+]], !nosanitize !3
 // CHECK-NEXT:    unreachable, !nosanitize !3
 // CHECK:       cont:
 // CHECK-NEXT:    store i8 0, ptr [[TMP0]], align 1


### PR DESCRIPTION
Summary:
For GPU targets trying to use these checks, it would cause some issues.
the RTL function takes a flat pointer, but the global would be generated
as AS(1) with no cast. This seemed to work fine, mostly because for
AMDGPU the flat and global address spaces are byte identical, but it's
broken heavior. It lead to the backend not being able to fully identify
the call graph because it was not calling the 'right' function. Just add
an address space cast, these are no-ops in the vast majority of cases.
