### PR TITLE
[ADT] Remove ComputeNodeHash and Trait::ComputeHash (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/FoldingSet.h
+++ b/llvm/include/llvm/ADT/FoldingSet.h
@@ -128,13 +128,6 @@ template <typename T> struct DefaultFoldingSetTrait {
   // can override this to provide more efficient implementations.
   static inline bool Equals(T &X, const FoldingSetNodeID &ID, unsigned IDHash,
                             FoldingSetNodeID &TempID);
-
-  // ComputeHash - Compute a hash value for X, using TempID to
-  // compute a temporary ID if necessary. The default implementation
-  // just calls Profile and does a regular hash computation.
-  // Implementations can override this to provide more efficient
-  // implementations.
-  static inline unsigned ComputeHash(T &X, FoldingSetNodeID &TempID);
 };
 
 /// This trait class is used to define behavior of how to "profile" (in the
@@ -160,8 +153,6 @@ template <typename T, typename Ctx> struct DefaultContextualFoldingSetTrait {
 
   static inline bool Equals(T &X, const FoldingSetNodeID &ID, unsigned IDHash,
                             FoldingSetNodeID &TempID, Ctx Context);
-  static inline unsigned ComputeHash(T &X, FoldingSetNodeID &TempID,
-                                     Ctx Context);
 };
 
 /// Like FoldingSetTrait, but for ContextualFoldingSets.
@@ -361,11 +352,6 @@ protected:
     bool (*NodeEquals)(const FoldingSetBase *Self, Node *N,
                        const FoldingSetNodeID &ID, unsigned IDHash,
                        FoldingSetNodeID &TempID);
-
-    /// Instantiations of the FoldingSet template implement this function to
-    /// compute a hash value for the given node.
-    unsigned (*ComputeNodeHash)(const FoldingSetBase *Self, Node *N,
-                                FoldingSetNodeID &TempID);
   };
 
 private:
@@ -421,24 +407,12 @@ inline bool DefaultFoldingSetTrait<T>::Equals(T &X, const FoldingSetNodeID &ID,
   FoldingSetTrait<T>::Profile(X, TempID);
   return TempID == ID;
 }
-template <typename T>
-inline unsigned
-DefaultFoldingSetTrait<T>::ComputeHash(T &X, FoldingSetNodeID &TempID) {
-  FoldingSetTrait<T>::Profile(X, TempID);
-  return TempID.ComputeHash();
-}
 template <typename T, typename Ctx>
 inline bool DefaultContextualFoldingSetTrait<T, Ctx>::Equals(
     T &X, const FoldingSetNodeID &ID, unsigned /*IDHash*/,
     FoldingSetNodeID &TempID, Ctx Context) {
   ContextualFoldingSetTrait<T, Ctx>::Profile(X, TempID, Context);
   return TempID == ID;
-}
-template <typename T, typename Ctx>
-inline unsigned DefaultContextualFoldingSetTrait<T, Ctx>::ComputeHash(
-    T &X, FoldingSetNodeID &TempID, Ctx Context) {
-  ContextualFoldingSetTrait<T, Ctx>::Profile(X, TempID, Context);
-  return TempID.ComputeHash();
 }
 
 //===----------------------------------------------------------------------===//
@@ -470,16 +444,6 @@ class FoldingSetImpl : public FoldingSetBase, public Trait::ContextStorage {
           else
             return Trait::Equals(
                 *static_cast<T *>(N), ID, IDHash, TempID,
-                static_cast<const FoldingSetImpl *>(Base)->getContext());
-        },
-        // ComputeNodeHash
-        [](const FoldingSetBase *Base, FoldingSetNode *N,
-           FoldingSetNodeID &TempID) {
-          if constexpr (std::is_empty_v<typename Trait::ContextStorage>)
-            return Trait::ComputeHash(*static_cast<T *>(N), TempID);
-          else
-            return Trait::ComputeHash(
-                *static_cast<T *>(N), TempID,
                 static_cast<const FoldingSetImpl *>(Base)->getContext());
         }};
     return Info;

--- a/llvm/include/llvm/Analysis/ScalarEvolution.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolution.h
@@ -351,10 +351,6 @@ template <> struct FoldingSetTrait<SCEV> : DefaultFoldingSetTrait<SCEV> {
                      FoldingSetNodeID &TempID) {
     return ID == X.FastID;
   }
-
-  static unsigned ComputeHash(const SCEV &X, FoldingSetNodeID &TempID) {
-    return X.FastID.ComputeHash();
-  }
 };
 
 inline raw_ostream &operator<<(raw_ostream &OS, const SCEV &S) {
@@ -433,11 +429,6 @@ struct FoldingSetTrait<SCEVPredicate> : DefaultFoldingSetTrait<SCEVPredicate> {
   static bool Equals(const SCEVPredicate &X, const FoldingSetNodeID &ID,
                      unsigned IDHash, FoldingSetNodeID &TempID) {
     return ID == X.FastID;
-  }
-
-  static unsigned ComputeHash(const SCEVPredicate &X,
-                              FoldingSetNodeID &TempID) {
-    return X.FastID.ComputeHash();
   }
 };
 

--- a/llvm/include/llvm/CodeGen/SelectionDAG.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAG.h
@@ -110,15 +110,10 @@ class SDVTListNode : public FoldingSetNode {
   FoldingSetNodeIDRef FastID;
   const EVT *VTs;
   unsigned int NumVTs;
-  /// The hash value for SDVTList is fixed, so cache it to avoid
-  /// hash calculation.
-  unsigned HashValue;
 
 public:
-  SDVTListNode(const FoldingSetNodeIDRef ID, const EVT *VT, unsigned int Num) :
-      FastID(ID), VTs(VT), NumVTs(Num) {
-    HashValue = ID.ComputeHash();
-  }
+  SDVTListNode(const FoldingSetNodeIDRef ID, const EVT *VT, unsigned int Num)
+      : FastID(ID), VTs(VT), NumVTs(Num) {}
 
   SDVTList getSDVTList() {
     SDVTList result = {VTs, NumVTs};
@@ -135,8 +130,6 @@ template<> struct FoldingSetTrait<SDVTListNode> : DefaultFoldingSetTrait<SDVTLis
 
   static bool Equals(const SDVTListNode &X, const FoldingSetNodeID &ID,
                      unsigned IDHash, FoldingSetNodeID &TempID) {
-    if (X.HashValue != IDHash)
-      return false;
     return ID == X.FastID;
   }
 };

--- a/llvm/include/llvm/CodeGen/SelectionDAG.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAG.h
@@ -127,7 +127,7 @@ public:
 };
 
 /// Specialize FoldingSetTrait for SDVTListNode
-/// to avoid computing temp FoldingSetNodeID and hash value.
+/// to avoid computing temp FoldingSetNodeID.
 template<> struct FoldingSetTrait<SDVTListNode> : DefaultFoldingSetTrait<SDVTListNode> {
   static void Profile(const SDVTListNode &X, FoldingSetNodeID& ID) {
     ID = X.FastID;
@@ -138,10 +138,6 @@ template<> struct FoldingSetTrait<SDVTListNode> : DefaultFoldingSetTrait<SDVTLis
     if (X.HashValue != IDHash)
       return false;
     return ID == X.FastID;
-  }
-
-  static unsigned ComputeHash(const SDVTListNode &X, FoldingSetNodeID &TempID) {
-    return X.HashValue;
   }
 };
 


### PR DESCRIPTION
With the switch to open addressing (commit b3411b89c3af),
FoldingSetNode stores its hash in the node itself.  Table growth
rehashes nodes by calling getFoldingSetHash(), leaving ComputeNodeHash
and Trait::ComputeHash unused.
