### PR TITLE
[X86] Fix ISel crash for @llvm.prefetch with instruction cache and invalid hints

### DIFF
--- a/llvm/lib/Target/X86/X86InstrMisc.td
+++ b/llvm/lib/Target/X86/X86InstrMisc.td
@@ -1690,9 +1690,16 @@ let Predicates = [HasUINTR, In64BitMode], SchedRW = [WriteSystem] in {
 // prefetch ADDR, RW, Locality, Data
 let Predicates = [HasPREFETCHI, In64BitMode], SchedRW = [WriteLoad] in {
   def PREFETCHIT0 : I<0x18, MRM7m, (outs), (ins i8mem:$src),
-    "prefetchit0\t$src", [(prefetch addr:$src, (i32 0), (i32 3), (i32 0))]>, TB;
+    "prefetchit0\t$src", [(prefetch addr:$src, timm, (i32 3), (i32 0))]>, TB;
   def PREFETCHIT1 : I<0x18, MRM6m, (outs), (ins i8mem:$src),
-    "prefetchit1\t$src", [(prefetch addr:$src, (i32 0), (i32 2), (i32 0))]>, TB;
+    "prefetchit1\t$src", [(prefetch addr:$src, timm, (i32 2), (i32 0))]>, TB;
+}
+
+let Predicates = [HasPREFETCHI, In64BitMode] in {
+  def : Pat<(prefetch addr:$src, timm, (i32 1), (i32 0)),
+            (PREFETCHIT1 addr:$src)>;
+  def : Pat<(prefetch addr:$src, timm, (i32 0), (i32 0)),
+            (PREFETCHIT1 addr:$src)>;
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/test/CodeGen/X86/prefetchi.ll
+++ b/llvm/test/CodeGen/X86/prefetchi.ll
@@ -9,6 +9,10 @@ define dso_local void @t(ptr %ptr) nounwind  {
 ; CHECK-NEXT:    prefetchit0 (%rdi)
 ; CHECK-NEXT:    prefetchit1 t(%rip)
 ; CHECK-NEXT:    prefetchit0 ext(%rip)
+; CHECK-NEXT:    prefetchit1 (%rdi)
+; CHECK-NEXT:    prefetchit1 (%rdi)
+; CHECK-NEXT:    prefetchit0 (%rdi)
+; CHECK-NEXT:    prefetchit1 (%rdi)
 ; CHECK-NEXT:    retq
 ;
 ; NOPREFETCHI-LABEL: t:
@@ -19,6 +23,14 @@ entry:
   tail call void @llvm.prefetch(ptr %ptr, i32 0, i32 3, i32 0)
   tail call void @llvm.prefetch(ptr @t,   i32 0, i32 2, i32 0)
   tail call void @llvm.prefetch(ptr @ext, i32 0, i32 3, i32 0)
+
+  ; Test for locality 0 and 1 (fallback to PREFETCHIT1)
+  tail call void @llvm.prefetch(ptr %ptr, i32 0, i32 0, i32 0)
+  tail call void @llvm.prefetch(ptr %ptr, i32 0, i32 1, i32 0)
+
+  ; Test for rw=1 (fallback to PREFETCHIT1/PREFETCHIT0 depending on locality)
+  tail call void @llvm.prefetch(ptr %ptr, i32 1, i32 3, i32 0)
+  tail call void @llvm.prefetch(ptr %ptr, i32 1, i32 2, i32 0)
   ret void
 }
 


### PR DESCRIPTION
This PR fixes an ICE that occurs during Instruction Selection when the `@llvm.prefetch` intrinsic is used for instruction cache prefetching (`cache type = 0`) with lower locality values (`0` or `1`), or with a write hint (`rw = 1`).

Resolves https://github.com/llvm/llvm-project/issues/218236