### PR TITLE
[CIR] Run the CIR lowering pipeline without a live ASTContext and accept serialized .cir as cc1 input

### DIFF
--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -479,6 +479,12 @@ def err_ast_action_on_llvm_ir : Error<
   "cannot apply AST actions to LLVM IR file '%0'">,
   DefaultFatal;
 
+def err_ast_action_on_cir : Error<
+  "cannot apply AST actions to ClangIR file '%0'">,
+  DefaultFatal;
+
+def err_invalid_cir : Error<"invalid ClangIR input: %0">;
+
 def err_invalid_llvm_ir : Error<"invalid LLVM IR input: %0">;
 
 def err_os_unsupport_riscv_fmv : Error<

--- a/clang/include/clang/CIR/CIRToCIRPasses.h
+++ b/clang/include/clang/CIR/CIRToCIRPasses.h
@@ -14,12 +14,17 @@
 #define CLANG_CIR_CIRTOCIRPASSES_H
 
 #include "mlir/Pass/Pass.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
 
 #include <memory>
 
 namespace clang {
 class ASTContext;
 }
+
+namespace llvm::vfs {
+class FileSystem;
+} // namespace llvm::vfs
 
 namespace mlir {
 class MLIRContext;
@@ -28,13 +33,19 @@ class ModuleOp;
 
 namespace cir {
 
-// Run set of cleanup/prepare/etc passes CIR <-> CIR.
+class LowerModule;
+
+// Run set of cleanup/prepare/etc passes CIR <-> CIR. The caller owns
+// `lowerModule`, which provides the target/LangOpts state for AST-free
+// passes (LoweringPrepare and any future helpers). `astCtx` is still
+// required by IdiomRecognizer and the AST-fact materialization pass.
 mlir::LogicalResult
 runCIRToCIRPasses(mlir::ModuleOp theModule, mlir::MLIRContext &mlirCtx,
-                  clang::ASTContext &astCtx, bool enableVerifier,
-                  bool enableIdiomRecognizer, bool enableCIRSimplify,
-                  bool enableLibOpt, llvm::StringRef libOptOptions,
-                  bool enableCallConvLowering);
+                  clang::ASTContext &astCtx, cir::LowerModule &lowerModule,
+                  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs,
+                  bool enableVerifier, bool enableIdiomRecognizer,
+                  bool enableCIRSimplify, bool enableLibOpt,
+                  llvm::StringRef libOptOptions, bool enableCallConvLowering);
 
 } // namespace cir
 

--- a/clang/include/clang/CIR/CIRToCIRPasses.h
+++ b/clang/include/clang/CIR/CIRToCIRPasses.h
@@ -18,10 +18,6 @@
 
 #include <memory>
 
-namespace clang {
-class ASTContext;
-}
-
 namespace llvm::vfs {
 class FileSystem;
 } // namespace llvm::vfs
@@ -36,12 +32,15 @@ namespace cir {
 class LowerModule;
 
 // Run set of cleanup/prepare/etc passes CIR <-> CIR. The caller owns
-// `lowerModule`, which provides the target/LangOpts state for AST-free
-// passes (LoweringPrepare and any future helpers). `astCtx` is still
-// required by IdiomRecognizer and the AST-fact materialization pass.
+// `lowerModule`, which provides the target/LangOpts state that drives the
+// pipeline (LoweringPrepare, CallConvLowering, and any future helpers). The
+// pipeline needs no live ASTContext, so it can run on serialized .cir input
+// as well as in-process CIRGen. IdiomRecognizer documents an AST dependency
+// and is opt-in; callers without an AST should pass enableIdiomRecognizer
+// = false.
 mlir::LogicalResult
 runCIRToCIRPasses(mlir::ModuleOp theModule, mlir::MLIRContext &mlirCtx,
-                  clang::ASTContext &astCtx, cir::LowerModule &lowerModule,
+                  cir::LowerModule &lowerModule,
                   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs,
                   bool enableVerifier, bool enableIdiomRecognizer,
                   bool enableCIRSimplify, bool enableLibOpt,

--- a/clang/include/clang/CIR/Dialect/Passes.h
+++ b/clang/include/clang/CIR/Dialect/Passes.h
@@ -15,6 +15,7 @@
 
 #include "mlir/Pass/Pass.h"
 #include "llvm/ABI/TargetInfo.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
 
 namespace cir {
 /// The ABI target whose calling-convention rules drive CallConvLowering.
@@ -26,6 +27,14 @@ enum class CallConvTarget { None, Test, X86_64 };
 namespace clang {
 class ASTContext;
 }
+
+namespace llvm::vfs {
+class FileSystem;
+} // namespace llvm::vfs
+
+namespace cir {
+class LowerModule;
+} // namespace cir
 
 namespace mlir {
 
@@ -41,7 +50,9 @@ std::unique_ptr<Pass> createCallConvLoweringPass(
     bool allowsX86TargetAttrAvx, const llvm::abi::ABICompatInfo &x86AbiCompat);
 std::unique_ptr<Pass> createHoistAllocasPass();
 std::unique_ptr<Pass> createLoweringPreparePass();
-std::unique_ptr<Pass> createLoweringPreparePass(clang::ASTContext *astCtx);
+std::unique_ptr<Pass> createLoweringPreparePass(
+    cir::LowerModule *lowerModule,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs = nullptr);
 std::unique_ptr<Pass> createGotoSolverPass();
 std::unique_ptr<Pass> createIdiomRecognizerPass();
 std::unique_ptr<Pass> createLibOptPass();

--- a/clang/include/clang/CIR/FrontendAction/CIRGenAction.h
+++ b/clang/include/clang/CIR/FrontendAction/CIRGenAction.h
@@ -57,8 +57,12 @@ protected:
   CreateASTConsumer(clang::CompilerInstance &CI,
                     llvm::StringRef InFile) override;
 
+  void ExecuteAction() override;
+
 public:
   ~CIRGenAction() override;
+
+  bool hasCIRSupport() const override { return true; }
 
   OutputType Action;
 };

--- a/clang/include/clang/Frontend/FrontendAction.h
+++ b/clang/include/clang/Frontend/FrontendAction.h
@@ -193,6 +193,9 @@ public:
   /// Does this action support use with IR files?
   virtual bool hasIRSupport() const { return false; }
 
+  /// Does this action support use with serialized CIR (.cir) files?
+  virtual bool hasCIRSupport() const { return false; }
+
   /// Does this action support use with code completion?
   virtual bool hasCodeCompletionSupport() const { return false; }
 
@@ -323,6 +326,7 @@ public:
   bool hasPCHSupport() const override;
   bool hasASTFileSupport() const override;
   bool hasIRSupport() const override;
+  bool hasCIRSupport() const override;
   bool hasCodeCompletionSupport() const override;
 };
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2105,6 +2105,15 @@ mlir::LogicalResult cir::GlobalOp::verify() {
         "Cannot have a static-local global-op with a constructor or "
         "destructor, they require in-function initialization via LocalInitOp");
 
+  // A guarded static-local carries the facts LoweringPrepare needs to outline
+  // its initializer in 'static_local_info'. CIRGen always emits the two
+  // together, and lowering reads the info when it sees the guard, so require
+  // that a guard implies the info attribute. This rejects hand-written or
+  // serialized .cir that would otherwise crash lowering with a missing info.
+  if (getStaticLocalGuard().has_value() && !getStaticLocalInfo().has_value())
+    return emitOpError(
+        "'static_local_guard' requires 'static_local_info' to be present");
+
   if (getTlsRefs()) {
     if (getStaticLocalGuard().has_value())
       return emitOpError("cannot have both static local and tls references");

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -1366,7 +1366,15 @@ void LoweringPreparePass::handleStaticLocal(cir::GlobalOp globalOp,
   // CIRGen, so this pass does not need a live ASTContext to read them.
   std::optional<cir::StaticLocalInfoAttr> infoOption =
       globalOp.getStaticLocalInfo();
-  assert(infoOption.has_value());
+  // The GlobalOp verifier pairs 'static_local_guard' with 'static_local_info',
+  // so this should hold for verified IR. Fail gracefully instead of asserting
+  // so a malformed .cir input reports an error rather than crashing a release
+  // build.
+  if (!infoOption.has_value()) {
+    globalOp->emitError(
+        "static-local global with a guard is missing 'static_local_info'");
+    return;
+  }
   cir::StaticLocalInfoAttr info = infoOption.value();
 
   builder.setInsertionPointAfter(localInitOp);

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -7,16 +7,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "PassDetail.h"
+#include "TargetLowering/LowerModule.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributeInterfaces.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/Location.h"
 #include "mlir/IR/Value.h"
-#include "clang/AST/ASTContext.h"
-#include "clang/AST/Mangle.h"
 #include "clang/Basic/Cuda.h"
-#include "clang/Basic/Module.h"
-#include "clang/Basic/SourceManager.h"
 #include "clang/Basic/Specifiers.h"
 #include "clang/Basic/TargetCXXABI.h"
 #include "clang/Basic/TargetInfo.h"
@@ -247,8 +244,8 @@ struct LoweringPreparePass
       guardAlignment = clang::CharUnits::One();
     } else if (useARMGuardVarABI()) {
       // Guard variables are size width on ARM (32-bit AArch32, 64-bit AArch64).
-      const unsigned sizeTypeSize =
-          astCtx->getTypeSize(astCtx->getSignedSizeType());
+      const unsigned sizeTypeSize = lowerModule->getTarget().getTypeWidth(
+          lowerModule->getTarget().getSignedSizeType());
       guardTy =
           cir::IntType::get(&getContext(), sizeTypeSize, /*isSigned=*/true);
       guardAlignment =
@@ -276,7 +273,7 @@ struct LoweringPreparePass
       // for non-ELF and non-Wasm object formats, so only do it for ELF and
       // Wasm.
       bool hasComdat = globalOp.getComdat();
-      const llvm::Triple &triple = astCtx->getTargetInfo().getTriple();
+      const llvm::Triple &triple = lowerModule->getTarget().getTriple();
       // TODO(cir): for now, we're just setting comdat to true, but it should
       // contain a comdat reference name here instead.
       if (!isLocalVarDecl && hasComdat &&
@@ -293,10 +290,19 @@ struct LoweringPreparePass
   }
 
   ///
-  /// AST related
-  /// -----------
+  /// Target / language fact source
+  /// -----------------------------
 
-  clang::ASTContext *astCtx;
+  /// Target/LangOpts/CXXABI bundle the pass reads instead of going to a live
+  /// ASTContext.  Set from the surrounding cc1 invocation by
+  /// runCIRToCIRPasses (or by the .cir input path in CIRGenAction).  Always
+  /// non-null while the pass runs.
+  cir::LowerModule *lowerModule = nullptr;
+
+  /// Filesystem used to read CUDA/HIP fatbin payloads referenced by the
+  /// module.  Defaults to the real filesystem; CIRGen can plumb the cc1
+  /// invocation's VFS instead so virtualized inputs keep working.
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs;
 
   /// Tracks current module.
   mlir::ModuleOp mlirModule;
@@ -347,7 +353,7 @@ struct LoweringPreparePass
   /// Returns true if the target uses ARM-style guard variables for static
   /// local initialization (32-bit guard, check bit 0 only).
   bool useARMGuardVarABI() const {
-    switch (astCtx->getCXXABIKind()) {
+    switch (lowerModule->getCXXABIKind()) {
     case clang::TargetCXXABI::GenericARM:
     case clang::TargetCXXABI::iOS:
     case clang::TargetCXXABI::WatchOS:
@@ -388,7 +394,7 @@ struct LoweringPreparePass
 
     llvm::StringLiteral nameAtExit = "__cxa_atexit";
     if (tls)
-      nameAtExit = astCtx->getTargetInfo().getTriple().isOSDarwin()
+      nameAtExit = lowerModule->getTarget().getTriple().isOSDarwin()
                        ? llvm::StringLiteral("_tlv_atexit")
                        : llvm::StringLiteral("__cxa_thread_atexit");
 
@@ -497,7 +503,7 @@ struct LoweringPreparePass
       // structural, so it is only worth building when there can be one.
       // OG: CGF.EHStack.pushCleanup<CallGuardAbort>(EHCleanup, guard);
       //     ... CGF.PopCleanupBlock();
-      if (astCtx->getLangOpts().Exceptions) {
+      if (lowerModule->getLangOpts().Exceptions) {
         cir::CleanupScopeOp::create(
             builder, loc, cir::CleanupKind::EH,
             [&](mlir::OpBuilder &, mlir::Location bodyLoc) {
@@ -545,7 +551,10 @@ struct LoweringPreparePass
     builder.createYield(loc); // Outermost IfOp
   }
 
-  void setASTContext(clang::ASTContext *c) { astCtx = c; }
+  void setLowerModule(cir::LowerModule *lm) { lowerModule = lm; }
+  void setVFS(llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> v) {
+    vfs = std::move(v);
+  }
 };
 
 } // namespace
@@ -837,7 +846,7 @@ buildRangeReductionComplexDiv(CIRBaseBuilderTy &builder, mlir::Location loc,
 }
 
 static mlir::Type higherPrecisionElementTypeForComplexArithmetic(
-    mlir::MLIRContext &context, clang::ASTContext &cc,
+    mlir::MLIRContext &context, const cir::LowerModule &lm,
     CIRBaseBuilderTy &builder, mlir::Type elementType) {
 
   auto getHigherPrecisionFPType = [&context](mlir::Type type) -> mlir::Type {
@@ -854,8 +863,9 @@ static mlir::Type higherPrecisionElementTypeForComplexArithmetic(
   };
 
   auto getFloatTypeSemantics =
-      [&cc](mlir::Type type) -> const llvm::fltSemantics & {
-    const clang::TargetInfo &info = cc.getTargetInfo();
+      [&lm](mlir::Type type) -> const llvm::fltSemantics & {
+    const clang::TargetInfo &info = lm.getTarget();
+    const clang::LangOptions &langOpts = lm.getLangOpts();
     if (mlir::isa<cir::FP16Type>(type))
       return info.getHalfFormat();
 
@@ -869,13 +879,13 @@ static mlir::Type higherPrecisionElementTypeForComplexArithmetic(
       return info.getDoubleFormat();
 
     if (mlir::isa<cir::LongDoubleType>(type)) {
-      if (cc.getLangOpts().OpenMP && cc.getLangOpts().OpenMPIsTargetDevice)
+      if (langOpts.OpenMP && langOpts.OpenMPIsTargetDevice)
         llvm_unreachable("NYI Float type semantics with OpenMP");
       return info.getLongDoubleFormat();
     }
 
     if (mlir::isa<cir::FP128Type>(type)) {
-      if (cc.getLangOpts().OpenMP && cc.getLangOpts().OpenMPIsTargetDevice)
+      if (langOpts.OpenMP && langOpts.OpenMPIsTargetDevice)
         llvm_unreachable("NYI Float type semantics with OpenMP");
       return info.getFloat128Format();
     }
@@ -910,7 +920,7 @@ static mlir::Value
 lowerComplexDiv(LoweringPreparePass &pass, CIRBaseBuilderTy &builder,
                 mlir::Location loc, cir::ComplexDivOp op, mlir::Value lhsReal,
                 mlir::Value lhsImag, mlir::Value rhsReal, mlir::Value rhsImag,
-                mlir::MLIRContext &mlirCx, clang::ASTContext &cc) {
+                mlir::MLIRContext &mlirCx, const cir::LowerModule &lm) {
   cir::ComplexType complexTy = op.getType();
   if (mlir::isa<cir::FPTypeInterface>(complexTy.getElementType())) {
     cir::ComplexRangeKind range = op.getRange();
@@ -926,7 +936,7 @@ lowerComplexDiv(LoweringPreparePass &pass, CIRBaseBuilderTy &builder,
     if (range == cir::ComplexRangeKind::Promoted) {
       mlir::Type originalElementType = complexTy.getElementType();
       mlir::Type higherPrecisionElementType =
-          higherPrecisionElementTypeForComplexArithmetic(mlirCx, cc, builder,
+          higherPrecisionElementTypeForComplexArithmetic(mlirCx, lm, builder,
                                                          originalElementType);
 
       if (!higherPrecisionElementType)
@@ -974,7 +984,7 @@ void LoweringPreparePass::lowerComplexDivOp(cir::ComplexDivOp op) {
 
   mlir::Value loweredResult =
       lowerComplexDiv(*this, builder, loc, op, lhsReal, lhsImag, rhsReal,
-                      rhsImag, getContext(), *astCtx);
+                      rhsImag, getContext(), *lowerModule);
   op.replaceAllUsesWith(loweredResult);
   op.erase();
 }
@@ -1390,7 +1400,7 @@ void LoweringPreparePass::handleStaticLocal(cir::GlobalOp globalOp,
   // We only need to use thread-safe statics for local non-TLS variables and
   // inline variables; other global initialization is always single-threaded
   // or (through lazy dynamic loading in multiple threads) unsequenced.
-  bool threadsafe = astCtx->getLangOpts().ThreadsafeStatics &&
+  bool threadsafe = lowerModule->getLangOpts().ThreadsafeStatics &&
                     (info.getLocal() || nonTemplateInline) &&
                     info.getTls() == cir::TLSKind::None;
 
@@ -1431,7 +1441,7 @@ void LoweringPreparePass::handleStaticLocal(cir::GlobalOp globalOp,
   // call __cxa_guard_acquire unconditionally. The "inline" check isn't
   // actually inline, and the user might not expect calls to __atomic libcalls.
   unsigned maxInlineWidthInBits =
-      astCtx->getTargetInfo().getMaxAtomicInlineWidth();
+      lowerModule->getTarget().getMaxAtomicInlineWidth();
 
   if (!threadsafe || maxInlineWidthInBits) {
     // Load the first byte of the guard variable.
@@ -1521,20 +1531,20 @@ void LoweringPreparePass::lowerLocalInitOp(cir::LocalInitOp initOp) {
   // Remove the init local op, now that we've done everything we need with it.
   initOp.erase();
 }
-static bool isThreadWrapperReplaceable(clang::ASTContext &astCtx) {
+static bool isThreadWrapperReplaceable(const cir::LowerModule &lm) {
   // Note: Classic codegen needs to check that the VarDecl.getTLSKind() ==
   // TLS_Dynamic, but we don't attempt to emit the thread wrapper unless that is
   // already the case.  So the only thing that matters here is whether it is
   // darwin.
-  return astCtx.getTargetInfo().getTriple().isOSDarwin();
+  return lm.getTarget().getTriple().isOSDarwin();
 }
 
 static cir::GlobalLinkageKind
-getThreadLocalWrapperLinkage(GlobalOp op, clang::ASTContext &astCtx) {
+getThreadLocalWrapperLinkage(GlobalOp op, const cir::LowerModule &lm) {
   if (isLocalLinkage(op.getLinkage()))
     return op.getLinkage();
 
-  if (isThreadWrapperReplaceable(astCtx))
+  if (isThreadWrapperReplaceable(lm))
     if (!isLinkOnceLinkage(op.getLinkage()) &&
         !isWeakODRLinkage(op.getLinkage()))
       return op.getLinkage();
@@ -1564,13 +1574,13 @@ LoweringPreparePass::getOrCreateThreadLocalWrapper(CIRBaseBuilderTy &builder,
       cir::FuncOp::create(builder, op.getLoc(), wrapperName, funcType);
 
   cir::GlobalLinkageKind linkageKind =
-      getThreadLocalWrapperLinkage(op, *astCtx);
+      getThreadLocalWrapperLinkage(op, *lowerModule);
   func.setLinkageAttr(
       cir::GlobalLinkageKindAttr::get(&getContext(), linkageKind));
 
   // TODO(cir): This is supposed to refer to the comdat of the global symbol,
   // but that isn't in CIR yet.
-  if (astCtx->getTargetInfo().getTriple().supportsCOMDAT() &&
+  if (lowerModule->getTarget().getTriple().supportsCOMDAT() &&
       func.isWeakForLinker())
     func.setComdat(true);
 
@@ -1578,12 +1588,12 @@ LoweringPreparePass::getOrCreateThreadLocalWrapper(CIRBaseBuilderTy &builder,
       func, mlir::SymbolTable::Visibility::Private);
 
   if (!isLocalLinkage(linkageKind)) {
-    if (!isThreadWrapperReplaceable(*astCtx) ||
+    if (!isThreadWrapperReplaceable(*lowerModule) ||
         isLinkOnceLinkage(linkageKind) || isWeakODRLinkage(linkageKind) ||
         op.getGlobalVisibility() == cir::VisibilityKind::Hidden)
       func.setGlobalVisibility(cir::VisibilityKind::Hidden);
   }
-  if (isThreadWrapperReplaceable(*astCtx))
+  if (isThreadWrapperReplaceable(*lowerModule))
     op->emitError("Unhandled thread wrapper attributes for CC and Nounwind");
 
   threadLocalWrappers.insert({wrapperName.getValue(), func});
@@ -1975,19 +1985,11 @@ void LoweringPreparePass::buildCXXGlobalInitFunc() {
   // way as a non-modular TU with imports.
   // The C++20 named-module init function name is precomputed by CIRGen and
   // stored as a module-level attribute, so this pass does not need a live
-  // ASTContext in split-compilation flows. Fall back to the AST-based path
-  // only when the attribute is absent (e.g. tests that bypass CIRGen).
+  // ASTContext.  Modules built directly from textual CIR can opt in to the
+  // module-init form by setting the same attribute.
   if (auto fnNameAttr = mlirModule->getAttrOfType<mlir::StringAttr>(
           cir::CIRDialect::getCXXModuleInitFnNameAttrName())) {
     fnName += fnNameAttr.getValue();
-    linkage = cir::GlobalLinkageKind::ExternalLinkage;
-  } else if (astCtx && astCtx->getCurrentNamedModule() &&
-             !astCtx->getCurrentNamedModule()->isModuleImplementation()) {
-    llvm::raw_svector_ostream out(fnName);
-    std::unique_ptr<clang::MangleContext> mangleCtx(
-        astCtx->createMangleContext());
-    cast<clang::ItaniumMangleContext>(*mangleCtx)
-        .mangleModuleInitializer(astCtx->getCurrentNamedModule(), out);
     linkage = cir::GlobalLinkageKind::ExternalLinkage;
   } else {
     fnName += "_GLOBAL__sub_I_";
@@ -2004,7 +2006,7 @@ void LoweringPreparePass::buildCXXGlobalInitFunc() {
 /// region is non-empty, the ctor loop is wrapped in a cir.cleanup.scope whose
 /// EH cleanup performs a reverse destruction loop using the partial dtor body.
 static void lowerArrayDtorCtorIntoLoop(cir::CIRBaseBuilderTy &builder,
-                                       clang::ASTContext *astCtx,
+                                       const cir::LowerModule *lm,
                                        mlir::Operation *op, mlir::Type eltTy,
                                        mlir::Value addr,
                                        mlir::Value numElements,
@@ -2012,10 +2014,10 @@ static void lowerArrayDtorCtorIntoLoop(cir::CIRBaseBuilderTy &builder,
   mlir::Location loc = op->getLoc();
   bool isDynamic = numElements != nullptr;
 
-  // TODO: instead of getting the size from the AST context, create alias for
+  // TODO: instead of getting the size from the lower module, create alias for
   // PtrDiffTy and unify with CIRGen stuff.
   const unsigned sizeTypeSize =
-      astCtx->getTypeSize(astCtx->getSignedSizeType());
+      lm->getTarget().getTypeWidth(lm->getTarget().getSignedSizeType());
 
   // Both constructors and destructors use end = begin + numElements.
   // Constructors iterate forward [begin, end).  Destructors iterate backward
@@ -2182,7 +2184,7 @@ void LoweringPreparePass::lowerArrayDtor(cir::ArrayDtor op) {
   mlir::Type eltTy = op->getRegion(0).getArgument(0).getType();
 
   if (op.getNumElements()) {
-    lowerArrayDtorCtorIntoLoop(builder, astCtx, op, eltTy, op.getAddr(),
+    lowerArrayDtorCtorIntoLoop(builder, lowerModule, op, eltTy, op.getAddr(),
                                op.getNumElements(), /*arrayLen=*/0,
                                /*isCtor=*/false);
     return;
@@ -2190,7 +2192,7 @@ void LoweringPreparePass::lowerArrayDtor(cir::ArrayDtor op) {
 
   auto arrayLen =
       mlir::cast<cir::ArrayType>(op.getAddr().getType().getPointee()).getSize();
-  lowerArrayDtorCtorIntoLoop(builder, astCtx, op, eltTy, op.getAddr(),
+  lowerArrayDtorCtorIntoLoop(builder, lowerModule, op, eltTy, op.getAddr(),
                              /*numElements=*/nullptr, arrayLen,
                              /*isCtor=*/false);
 }
@@ -2202,7 +2204,7 @@ void LoweringPreparePass::lowerArrayCtor(cir::ArrayCtor op) {
   mlir::Type eltTy = op->getRegion(0).getArgument(0).getType();
 
   if (op.getNumElements()) {
-    lowerArrayDtorCtorIntoLoop(builder, astCtx, op, eltTy, op.getAddr(),
+    lowerArrayDtorCtorIntoLoop(builder, lowerModule, op, eltTy, op.getAddr(),
                                op.getNumElements(), /*arrayLen=*/0,
                                /*isCtor=*/true);
     return;
@@ -2210,7 +2212,7 @@ void LoweringPreparePass::lowerArrayCtor(cir::ArrayCtor op) {
 
   auto arrayLen =
       mlir::cast<cir::ArrayType>(op.getAddr().getType().getPointee()).getSize();
-  lowerArrayDtorCtorIntoLoop(builder, astCtx, op, eltTy, op.getAddr(),
+  lowerArrayDtorCtorIntoLoop(builder, lowerModule, op, eltTy, op.getAddr(),
                              /*numElements=*/nullptr, arrayLen,
                              /*isCtor=*/true);
 }
@@ -2429,8 +2431,8 @@ void LoweringPreparePass::runOnOp(mlir::Operation *op) {
   }
 }
 
-static llvm::StringRef getCUDAPrefix(clang::ASTContext *astCtx) {
-  if (astCtx->getLangOpts().HIP)
+static llvm::StringRef getCUDAPrefix(const cir::LowerModule *lm) {
+  if (lm->getLangOpts().HIP)
     return "hip";
   return "cuda";
 }
@@ -2460,9 +2462,9 @@ static std::string addUnderscoredPrefix(llvm::StringRef prefix,
 /// }
 /// \endcode
 void LoweringPreparePass::buildCUDAModuleCtor() {
-  bool isHIP = astCtx->getLangOpts().HIP;
+  bool isHIP = lowerModule->getLangOpts().HIP;
 
-  if (astCtx->getLangOpts().GPURelocatableDeviceCode)
+  if (lowerModule->getLangOpts().GPURelocatableDeviceCode)
     llvm_unreachable("GPU RDC NYI");
 
   // For CUDA without -fgpu-rdc, it's safe to stop generating ctor
@@ -2485,10 +2487,10 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
           .getName()
           .getValue();
 
-  llvm::vfs::FileSystem &vfs =
-      astCtx->getSourceManager().getFileManager().getVirtualFileSystem();
+  llvm::vfs::FileSystem &gpuBinaryVFS =
+      vfs ? *vfs : *llvm::vfs::getRealFileSystem();
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> gpuBinaryOrErr =
-      vfs.getBufferForFile(cudaGPUBinaryName);
+      gpuBinaryVFS.getBufferForFile(cudaGPUBinaryName);
   if (std::error_code ec = gpuBinaryOrErr.getError()) {
     mlirModule->emitError("cannot open GPU binary file: " + cudaGPUBinaryName +
                           ": " + ec.message());
@@ -2498,7 +2500,7 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
       std::move(gpuBinaryOrErr.get());
 
   // Set up common types and builder.
-  llvm::StringRef cudaPrefix = getCUDAPrefix(astCtx);
+  llvm::StringRef cudaPrefix = getCUDAPrefix(lowerModule);
   mlir::Location loc = mlirModule->getLoc();
   CIRBaseBuilderTy builder(getContext());
   builder.setInsertionPointToStart(mlirModule.getBody());
@@ -2507,17 +2509,18 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
   PointerType voidPtrTy = builder.getVoidPtrTy();
   PointerType voidPtrPtrTy = builder.getPointerTo(voidPtrTy);
   IntType intTy = builder.getSIntNTy(32);
-  IntType charTy = cir::IntType::get(&getContext(), astCtx->getCharWidth(),
-                                     /*isSigned=*/false);
+  IntType charTy =
+      cir::IntType::get(&getContext(), lowerModule->getTarget().getCharWidth(),
+                        /*isSigned=*/false);
 
   // --- Create fatbin globals ---
 
   // The section names are different for MAC OS X.
   llvm::StringRef fatbinConstName =
-      astCtx->getLangOpts().HIP ? ".hip_fatbin" : ".nv_fatbin";
+      lowerModule->getLangOpts().HIP ? ".hip_fatbin" : ".nv_fatbin";
 
   llvm::StringRef fatbinSectionName =
-      astCtx->getLangOpts().HIP ? ".hipFatBinSegment" : ".nvFatBinSegment";
+      lowerModule->getLangOpts().HIP ? ".hipFatBinSegment" : ".nvFatBinSegment";
 
   // Create the fatbin string constant with GPU binary contents.
   auto fatbinType =
@@ -2655,7 +2658,7 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
     }
     return;
   }
-  if (!astCtx->getLangOpts().GPURelocatableDeviceCode) {
+  if (!lowerModule->getLangOpts().GPURelocatableDeviceCode) {
 
     // --- Create CUDA CTOR-DTOR ---
     // Register binary with CUDA runtime. This is substantially different in
@@ -2680,7 +2683,7 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
     //      void __cudaRegisterFatBinaryEnd(void **fatbinHandle);
     // This is CUDA-specific, so no need to use `addUnderscoredPrefix`.
     if (clang::CudaFeatureEnabled(
-            astCtx->getTargetInfo().getSDKVersion(),
+            lowerModule->getTarget().getSDKVersion(),
             clang::CudaFeature::CUDA_USES_FATBIN_REGISTER_END)) {
       cir::CIRBaseBuilderTy globalBuilder(getContext());
       globalBuilder.setInsertionPointToStart(mlirModule.getBody());
@@ -2715,7 +2718,7 @@ std::optional<FuncOp> LoweringPreparePass::buildCUDAModuleDtor() {
   if (!mlirModule->getAttr(CIRDialect::getCUDABinaryHandleAttrName()))
     return {};
 
-  llvm::StringRef prefix = getCUDAPrefix(astCtx);
+  llvm::StringRef prefix = getCUDAPrefix(lowerModule);
 
   VoidType voidTy = VoidType::get(&getContext());
   PointerType voidPtrPtrTy = PointerType::get(PointerType::get(voidTy));
@@ -2772,7 +2775,7 @@ std::optional<FuncOp> LoweringPreparePass::buildHIPModuleDtor() {
   if (!mlirModule->getAttr(CIRDialect::getCUDABinaryHandleAttrName()))
     return {};
 
-  llvm::StringRef prefix = getCUDAPrefix(astCtx);
+  llvm::StringRef prefix = getCUDAPrefix(lowerModule);
 
   VoidType voidTy = VoidType::get(&getContext());
   PointerType voidPtrPtrTy = PointerType::get(PointerType::get(voidTy));
@@ -2835,7 +2838,7 @@ std::optional<FuncOp> LoweringPreparePass::buildCUDARegisterGlobals() {
   builder.setInsertionPointToStart(mlirModule.getBody());
 
   mlir::Location loc = mlirModule.getLoc();
-  llvm::StringRef cudaPrefix = getCUDAPrefix(astCtx);
+  llvm::StringRef cudaPrefix = getCUDAPrefix(lowerModule);
 
   auto voidTy = VoidType::get(&getContext());
   auto voidPtrTy = PointerType::get(voidTy);
@@ -2861,15 +2864,16 @@ std::optional<FuncOp> LoweringPreparePass::buildCUDARegisterGlobals() {
 void LoweringPreparePass::buildCUDARegisterGlobalFunctions(
     cir::CIRBaseBuilderTy &builder, FuncOp regGlobalFunc) {
   mlir::Location loc = mlirModule.getLoc();
-  llvm::StringRef cudaPrefix = getCUDAPrefix(astCtx);
+  llvm::StringRef cudaPrefix = getCUDAPrefix(lowerModule);
   cir::CIRDataLayout dataLayout(mlirModule);
 
   auto voidTy = VoidType::get(&getContext());
   auto voidPtrTy = PointerType::get(voidTy);
   auto voidPtrPtrTy = PointerType::get(voidPtrTy);
   IntType intTy = builder.getSIntNTy(32);
-  IntType charTy = cir::IntType::get(&getContext(), astCtx->getCharWidth(),
-                                     /*isSigned=*/false);
+  IntType charTy =
+      cir::IntType::get(&getContext(), lowerModule->getTarget().getCharWidth(),
+                        /*isSigned=*/false);
 
   // Extract the GPU binary handle argument.
   mlir::Value fatbinHandle = *regGlobalFunc.args_begin();
@@ -2910,7 +2914,7 @@ void LoweringPreparePass::buildCUDARegisterGlobalFunctions(
   };
 
   cir::ConstantOp cirNullPtr = builder.getNullPtr(voidPtrTy, loc);
-  bool isHIP = astCtx->getLangOpts().HIP;
+  bool isHIP = lowerModule->getLangOpts().HIP;
   for (auto kernelName : cudaKernelMap.keys()) {
     FuncOp deviceStub = cudaKernelMap[kernelName];
     GlobalOp deviceFuncStr = makeConstantString(kernelName);
@@ -2948,16 +2952,17 @@ void LoweringPreparePass::buildCUDARegisterGlobalFunctions(
 void LoweringPreparePass::buildCUDARegisterVars(cir::CIRBaseBuilderTy &builder,
                                                 FuncOp regGlobalFunc) {
   mlir::Location loc = mlirModule.getLoc();
-  llvm::StringRef cudaPrefix = getCUDAPrefix(astCtx);
+  llvm::StringRef cudaPrefix = getCUDAPrefix(lowerModule);
   cir::CIRDataLayout dataLayout(mlirModule);
 
   PointerType voidPtrTy = builder.getVoidPtrTy();
   PointerType voidPtrPtrTy = builder.getPointerTo(voidPtrTy);
   IntType intTy = builder.getSIntNTy(32);
   IntType sizeTy =
-      builder.getUIntNTy(astCtx->getTargetInfo().getMaxPointerWidth());
-  IntType charTy = cir::IntType::get(&getContext(), astCtx->getCharWidth(),
-                                     /*isSigned=*/false);
+      builder.getUIntNTy(lowerModule->getTarget().getMaxPointerWidth());
+  IntType charTy =
+      cir::IntType::get(&getContext(), lowerModule->getTarget().getCharWidth(),
+                        /*isSigned=*/false);
 
   if (cudaDeviceVars.empty())
     return;
@@ -3046,7 +3051,8 @@ void LoweringPreparePass::runOnOperation() {
 
   buildCXXGlobalInitFunc();
   buildCXXGlobalTlsFunc();
-  if (astCtx->getLangOpts().CUDA && !astCtx->getLangOpts().CUDAIsDevice)
+  if (lowerModule->getLangOpts().CUDA &&
+      !lowerModule->getLangOpts().CUDAIsDevice)
     buildCUDAModuleCtor();
 
   buildGlobalCtorDtorList();
@@ -3056,9 +3062,11 @@ std::unique_ptr<Pass> mlir::createLoweringPreparePass() {
   return std::make_unique<LoweringPreparePass>();
 }
 
-std::unique_ptr<Pass>
-mlir::createLoweringPreparePass(clang::ASTContext *astCtx) {
+std::unique_ptr<Pass> mlir::createLoweringPreparePass(
+    cir::LowerModule *lowerModule,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs) {
   auto pass = std::make_unique<LoweringPreparePass>();
-  pass->setASTContext(astCtx);
-  return std::move(pass);
+  pass->setLowerModule(lowerModule);
+  pass->setVFS(std::move(vfs));
+  return pass;
 }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
@@ -67,7 +67,9 @@ LowerModule::LowerModule(clang::LangOptions langOpts,
                          clang::CodeGenOptions codeGenOpts,
                          mlir::ModuleOp &module,
                          std::unique_ptr<clang::TargetInfo> target)
-    : module(module), target(std::move(target)), abi(createCXXABI(*this)) {}
+    : module(module), langOpts(std::move(langOpts)),
+      codeGenOpts(std::move(codeGenOpts)), target(std::move(target)),
+      abi(createCXXABI(*this)) {}
 
 const TargetLoweringInfo &LowerModule::getTargetLoweringInfo() {
   if (!targetLoweringInfo)
@@ -111,6 +113,14 @@ std::unique_ptr<LowerModule> createLowerModule(mlir::ModuleOp module) {
   return std::make_unique<LowerModule>(std::move(langOpts),
                                        std::move(codeGenOpts), module,
                                        std::move(targetInfo));
+}
+
+std::unique_ptr<LowerModule>
+createLowerModule(mlir::ModuleOp module, const clang::LangOptions &langOpts,
+                  const clang::CodeGenOptions &codeGenOpts,
+                  std::unique_ptr<clang::TargetInfo> target) {
+  return std::make_unique<LowerModule>(langOpts, codeGenOpts, module,
+                                       std::move(target));
 }
 
 } // namespace cir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.h
@@ -28,6 +28,8 @@ namespace cir {
 
 class LowerModule {
   mlir::ModuleOp module;
+  clang::LangOptions langOpts;
+  clang::CodeGenOptions codeGenOpts;
   const std::unique_ptr<clang::TargetInfo> target;
   std::unique_ptr<TargetLoweringInfo> targetLoweringInfo;
   std::unique_ptr<CIRCXXABI> abi;
@@ -39,18 +41,33 @@ public:
   ~LowerModule() = default;
 
   clang::TargetCXXABI::Kind getCXXABIKind() const {
-    assert(!cir::MissingFeatures::lowerModuleLangOpts());
     return target->getCXXABI().getKind();
   }
 
   CIRCXXABI &getCXXABI() const { return *abi; }
   const clang::TargetInfo &getTarget() const { return *target; }
+  const clang::LangOptions &getLangOpts() const { return langOpts; }
+  const clang::CodeGenOptions &getCodeGenOpts() const { return codeGenOpts; }
   mlir::MLIRContext *getMLIRContext() { return module.getContext(); }
 
   const TargetLoweringInfo &getTargetLoweringInfo();
 };
 
+/// Build a LowerModule from a parsed CIR module alone, deriving the target
+/// from the `cir.triple` attribute. LangOptions and CodeGenOptions are
+/// default-constructed; only the optimization level is recovered from the
+/// `cir.opt_info` attribute when present.
 std::unique_ptr<LowerModule> createLowerModule(mlir::ModuleOp module);
+
+/// Build a LowerModule using the LangOptions, CodeGenOptions, and TargetInfo
+/// from the surrounding compiler invocation. Preferred over the
+/// module-only factory whenever a live invocation is available, since it
+/// captures cc1 flags that influence lowering decisions (HIP/CUDA, OpenMP,
+/// thread-safe statics, target features, etc.).
+std::unique_ptr<LowerModule>
+createLowerModule(mlir::ModuleOp module, const clang::LangOptions &langOpts,
+                  const clang::CodeGenOptions &codeGenOpts,
+                  std::unique_ptr<clang::TargetInfo> target);
 
 } // namespace cir
 

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -85,15 +85,15 @@ lowerFromCIRToLLVMIR(mlir::ModuleOp MLIRModule, llvm::LLVMContext &LLVMCtx,
 // in-process CIRGen (where the same TargetInfo also drives the AST) and for
 // the .cir input path, where there is no AST at all.
 static std::unique_ptr<cir::LowerModule>
-makeLowerModuleFromInvocation(CompilerInstance &CI, mlir::ModuleOp module) {
+makeLowerModuleFromInvocation(CompilerInstance &CI, mlir::ModuleOp Module) {
   // Clone TargetInfo: LowerModule takes ownership and CI keeps its copy.
-  auto target =
+  auto Target =
       std::unique_ptr<clang::TargetInfo>(clang::TargetInfo::CreateTargetInfo(
           CI.getDiagnostics(), CI.getInvocation().getTargetOpts()));
-  if (!target)
+  if (!Target)
     return nullptr;
-  return cir::createLowerModule(module, CI.getLangOpts(), CI.getCodeGenOpts(),
-                                std::move(target));
+  return cir::createLowerModule(Module, CI.getLangOpts(), CI.getCodeGenOpts(),
+                                std::move(Target));
 }
 
 class CIRGenConsumer : public clang::ASTConsumer {
@@ -183,14 +183,14 @@ public:
       // Setup and run CIR pipeline.
       const bool EnableLibOpt =
           FEOptions.ClangIRLibOptEnabled && (CGO.OptimizationLevel > 0);
-      std::unique_ptr<cir::LowerModule> lowerModule =
+      std::unique_ptr<cir::LowerModule> LowerMod =
           makeLowerModuleFromInvocation(CI, MlirModule);
-      if (!lowerModule) {
+      if (!LowerMod) {
         CI.getDiagnostics().Report(diag::err_cir_to_cir_transform_failed);
         return;
       }
       if (runCIRToCIRPasses(
-              MlirModule, MlirCtx, *lowerModule, &CI.getVirtualFileSystem(),
+              MlirModule, MlirCtx, *LowerMod, &CI.getVirtualFileSystem(),
               !FEOptions.ClangIRDisableCIRVerifier,
               FEOptions.ClangIREnableIdiomRecognizer, CGO.OptimizationLevel > 0,
               EnableLibOpt, LibOptOptions, FEOptions.ClangIRCallConvLowering)
@@ -316,14 +316,14 @@ bool CIRGenAction::BeginSourceFileAction(CompilerInstance &CI) {
   return ASTFrontendAction::BeginSourceFileAction(CI);
 }
 
-static void registerCIRInputDialects(mlir::MLIRContext &ctx) {
-  mlir::DialectRegistry registry;
-  registry.insert<mlir::DLTIDialect, mlir::LLVM::LLVMDialect,
+static void registerCIRInputDialects(mlir::MLIRContext &Ctx) {
+  mlir::DialectRegistry Registry;
+  Registry.insert<mlir::DLTIDialect, mlir::LLVM::LLVMDialect,
                   mlir::omp::OpenMPDialect, cir::CIRDialect>();
-  cir::acc::registerOpenACCExtensions(registry);
-  cir::omp::registerOpenMPExtensions(registry);
-  ctx.appendDialectRegistry(registry);
-  ctx.loadDialect<mlir::DLTIDialect, mlir::LLVM::LLVMDialect,
+  cir::acc::registerOpenACCExtensions(Registry);
+  cir::omp::registerOpenMPExtensions(Registry);
+  Ctx.appendDialectRegistry(Registry);
+  Ctx.loadDialect<mlir::DLTIDialect, mlir::LLVM::LLVMDialect,
                   mlir::omp::OpenMPDialect, cir::CIRDialect>();
 }
 
@@ -394,24 +394,24 @@ void CIRGenAction::ExecuteAction() {
 
   // Honor the cc1 -triple flag: rewrite cir.triple if it disagrees so the
   // downstream lowering sees the invocation's target.
-  llvm::StringRef invocationTriple = CI.getTargetOpts().Triple;
-  if (auto modTriple = Mod->getAttrOfType<mlir::StringAttr>(
+  llvm::StringRef InvocationTriple = CI.getTargetOpts().Triple;
+  if (auto ModTriple = Mod->getAttrOfType<mlir::StringAttr>(
           cir::CIRDialect::getTripleAttrName())) {
-    if (modTriple.getValue() != invocationTriple) {
+    if (ModTriple.getValue() != InvocationTriple) {
       CI.getDiagnostics().Report(diag::warn_fe_override_module)
-          << invocationTriple;
+          << InvocationTriple;
       Mod->setAttr(cir::CIRDialect::getTripleAttrName(),
-                   mlir::StringAttr::get(MLIRCtx, invocationTriple));
+                   mlir::StringAttr::get(MLIRCtx, InvocationTriple));
     }
   } else {
     Mod->setAttr(cir::CIRDialect::getTripleAttrName(),
-                 mlir::StringAttr::get(MLIRCtx, invocationTriple));
+                 mlir::StringAttr::get(MLIRCtx, InvocationTriple));
   }
 
   if (Action == OutputType::EmitCIR) {
-    mlir::OpPrintingFlags flags;
-    flags.enableDebugInfo(/*enable=*/true, /*prettyForm=*/false);
-    Mod.print(*OS, flags);
+    mlir::OpPrintingFlags Flags;
+    Flags.enableDebugInfo(/*enable=*/true, /*prettyForm=*/false);
+    Mod.print(*OS, Flags);
     return;
   }
 
@@ -420,9 +420,9 @@ void CIRGenAction::ExecuteAction() {
   // cc1 invocation, so it needs no live ASTContext. IdiomRecognizer is
   // skipped here -- it documents an AST dependency and is opt-in even on the
   // source path.
-  std::unique_ptr<cir::LowerModule> lowerModule =
+  std::unique_ptr<cir::LowerModule> LowerMod =
       makeLowerModuleFromInvocation(CI, Mod);
-  if (!lowerModule) {
+  if (!LowerMod) {
     CI.getDiagnostics().Report(diag::err_cir_to_cir_transform_failed);
     return;
   }
@@ -430,7 +430,7 @@ void CIRGenAction::ExecuteAction() {
   const CodeGenOptions &CGO = CI.getCodeGenOpts();
   const bool EnableLibOpt =
       FEOptions.ClangIRLibOptEnabled && (CGO.OptimizationLevel > 0);
-  if (runCIRToCIRPasses(Mod, *MLIRCtx, *lowerModule, &CI.getVirtualFileSystem(),
+  if (runCIRToCIRPasses(Mod, *MLIRCtx, *LowerMod, &CI.getVirtualFileSystem(),
                         !FEOptions.ClangIRDisableCIRVerifier,
                         /*enableIdiomRecognizer=*/false,
                         CGO.OptimizationLevel > 0, EnableLibOpt,
@@ -453,6 +453,14 @@ void CIRGenAction::ExecuteAction() {
       CI.getDiagnostics().Report(diag::err_cir_to_cir_transform_failed);
     return;
   }
+
+  // TODO(cir): this emission tail (CIR-to-LLVM lowering + backend output)
+  // duplicates CIRGenConsumer::HandleTranslationUnit. Extract it into a shared
+  // helper both paths call.
+  // TODO(cir): the .cir path does not link the modules loaded from
+  // -mlink-builtin-bitcode (LinkModules is populated in BeginSourceFileAction
+  // but ignored here). Sharing the tail above reaches parity with the source
+  // path's linkInModules.
 
   // emitBackendOutput compares the module's data layout against the target's
   // expected description. The .cir input path bypasses BeginSourceFile, which

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -8,12 +8,22 @@
 
 #include "clang/CIR/FrontendAction/CIRGenAction.h"
 #include "CIRDiagnosticHandler.h"
+#include "mlir/Dialect/DLTI/DLTI.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/DialectRegistry.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OwningOpRef.h"
+#include "mlir/Parser/Parser.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/Basic/DiagnosticCodeGen.h"
+#include "clang/Basic/DiagnosticFrontend.h"
 #include "clang/CIR/CIRGenerator.h"
 #include "clang/CIR/CIRToCIRPasses.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Dialect/OpenACC/RegisterOpenACCExtensions.h"
+#include "clang/CIR/Dialect/OpenMP/RegisterOpenMPExtensions.h"
 #include "clang/CIR/LowerToLLVM.h"
 #include "clang/CodeGen/BackendUtil.h"
 #include "clang/CodeGen/ModuleLinker.h"
@@ -27,7 +37,9 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Linker/Linker.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/IPO/Internalize.h"
 
@@ -279,6 +291,17 @@ bool CIRGenAction::BeginSourceFileAction(CompilerInstance &CI) {
   return ASTFrontendAction::BeginSourceFileAction(CI);
 }
 
+static void registerCIRInputDialects(mlir::MLIRContext &ctx) {
+  mlir::DialectRegistry registry;
+  registry.insert<mlir::DLTIDialect, mlir::LLVM::LLVMDialect,
+                  mlir::omp::OpenMPDialect, cir::CIRDialect>();
+  cir::acc::registerOpenACCExtensions(registry);
+  cir::omp::registerOpenMPExtensions(registry);
+  ctx.appendDialectRegistry(registry);
+  ctx.loadDialect<mlir::DLTIDialect, mlir::LLVM::LLVMDialect,
+                  mlir::omp::OpenMPDialect, cir::CIRDialect>();
+}
+
 static std::unique_ptr<raw_pwrite_stream>
 getOutputStream(CompilerInstance &CI, StringRef InFile,
                 CIRGenAction::OutputType Action) {
@@ -295,6 +318,101 @@ getOutputStream(CompilerInstance &CI, StringRef InFile,
     return CI.createDefaultOutputFile(true, InFile, "o");
   }
   llvm_unreachable("Invalid CIRGenAction::OutputType");
+}
+
+void CIRGenAction::ExecuteAction() {
+  // Source-based inputs run through the AST pipeline as before.
+  if (getCurrentFileKind().getLanguage() != Language::CIR) {
+    this->ASTFrontendAction::ExecuteAction();
+    return;
+  }
+
+  // .cir input: parse the serialized module, skip CIRGen, and continue with
+  // the existing CIR-to-LLVM lowering and backend codegen path.
+  CompilerInstance &CI = getCompilerInstance();
+
+  std::unique_ptr<raw_pwrite_stream> OS = CI.takeOutputStream();
+  if (!OS)
+    OS = getOutputStream(CI, getCurrentFileOrBufferName(), Action);
+  if (!OS)
+    return;
+
+  SourceManager &SM = CI.getSourceManager();
+  std::optional<llvm::MemoryBufferRef> MainFile =
+      SM.getBufferOrNone(SM.getMainFileID());
+  if (!MainFile)
+    return;
+
+  registerCIRInputDialects(*MLIRCtx);
+
+  llvm::SourceMgr SrcMgr;
+  SrcMgr.AddNewSourceBuffer(
+      llvm::MemoryBuffer::getMemBufferCopy(MainFile->getBuffer(),
+                                           MainFile->getBufferIdentifier()),
+      llvm::SMLoc());
+
+  MLIRMod = mlir::parseSourceFile<mlir::ModuleOp>(SrcMgr, MLIRCtx);
+  if (!MLIRMod) {
+    CI.getDiagnostics().Report(diag::err_invalid_cir)
+        << MainFile->getBufferIdentifier();
+    return;
+  }
+
+  mlir::ModuleOp Mod = MLIRMod.get();
+
+  // Honor the cc1 -triple flag: rewrite cir.triple if it disagrees so the
+  // downstream lowering sees the invocation's target.
+  llvm::StringRef invocationTriple = CI.getTargetOpts().Triple;
+  if (auto modTriple = Mod->getAttrOfType<mlir::StringAttr>(
+          cir::CIRDialect::getTripleAttrName())) {
+    if (modTriple.getValue() != invocationTriple) {
+      CI.getDiagnostics().Report(diag::warn_fe_override_module)
+          << invocationTriple;
+      Mod->setAttr(cir::CIRDialect::getTripleAttrName(),
+                   mlir::StringAttr::get(MLIRCtx, invocationTriple));
+    }
+  } else {
+    Mod->setAttr(cir::CIRDialect::getTripleAttrName(),
+                 mlir::StringAttr::get(MLIRCtx, invocationTriple));
+  }
+
+  // For now, the CIR-to-CIR pipeline (target-lowering, cxxabi-lowering,
+  // lowering-prepare) still requires a live ASTContext. On .cir input that
+  // ASTContext is unavailable, so this path only supports formats whose
+  // emission does not rely on those passes:
+  //   * EmitCIR: round-trip the parsed module.
+  //   * EmitLLVM/EmitBC/EmitObj/EmitAssembly: lower directly via the existing
+  //     CIR-to-LLVM dialect translation, which itself does not require an
+  //     ASTContext, and hand the result to the LLVM backend.
+  // Lifting the remaining ASTContext dependency from LoweringPrepare is
+  // tracked separately and will let this entry point run the full pipeline.
+
+  if (Action == OutputType::EmitCIR) {
+    mlir::OpPrintingFlags flags;
+    flags.enableDebugInfo(/*enable=*/true, /*prettyForm=*/false);
+    Mod.print(*OS, flags);
+    return;
+  }
+
+  llvm::LLVMContext LLVMCtx;
+  std::unique_ptr<llvm::Module> LLVMModule =
+      lowerFromCIRToLLVMIR(Mod, LLVMCtx, /*mlirSaveTempsOutFile=*/{},
+                           &CI.getVirtualFileSystem());
+  if (!LLVMModule) {
+    CI.getDiagnostics().Report(diag::err_cir_to_cir_transform_failed);
+    return;
+  }
+
+  // emitBackendOutput compares the module's data layout against the target's
+  // expected description. The .cir input path bypasses BeginSourceFile, which
+  // is normally where the target gets created, so set it up here.
+  if (!CI.hasTarget() && !CI.createTarget())
+    return;
+
+  BackendAction BEAction = getBackendActionFromOutputType(Action);
+  emitBackendOutput(CI, CI.getCodeGenOpts(),
+                    CI.getTarget().getDataLayoutString(), LLVMModule.get(),
+                    BEAction, &CI.getVirtualFileSystem(), std::move(OS));
 }
 
 std::unique_ptr<ASTConsumer>

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -17,7 +17,6 @@
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OwningOpRef.h"
 #include "mlir/Parser/Parser.h"
-#include "mlir/Pass/PassManager.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/Basic/DiagnosticCodeGen.h"
 #include "clang/Basic/DiagnosticFrontend.h"
@@ -27,7 +26,6 @@
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/OpenACC/RegisterOpenACCExtensions.h"
 #include "clang/CIR/Dialect/OpenMP/RegisterOpenMPExtensions.h"
-#include "clang/CIR/Dialect/Passes.h"
 #include "clang/CIR/LowerToLLVM.h"
 #include "clang/CodeGen/BackendUtil.h"
 #include "clang/CodeGen/ModuleLinker.h"
@@ -192,7 +190,7 @@ public:
         return;
       }
       if (runCIRToCIRPasses(
-              MlirModule, MlirCtx, C, *lowerModule, &CI.getVirtualFileSystem(),
+              MlirModule, MlirCtx, *lowerModule, &CI.getVirtualFileSystem(),
               !FEOptions.ClangIRDisableCIRVerifier,
               FEOptions.ClangIREnableIdiomRecognizer, CGO.OptimizationLevel > 0,
               EnableLibOpt, LibOptOptions, FEOptions.ClangIRCallConvLowering)
@@ -417,32 +415,33 @@ void CIRGenAction::ExecuteAction() {
     return;
   }
 
-  // Run the post-CIRGen pipeline (target-lowering, cxxabi-lowering,
-  // lowering-prepare). LoweringPrepare reads target/LangOpts facts via the
-  // LowerModule we build from the surrounding cc1 invocation, so it does not
-  // need a live ASTContext. IdiomRecognizer is intentionally skipped on this
-  // path -- it documents an AST dependency and is opt-in even on the source
-  // path.
+  // Run the same CIR-to-CIR pipeline the source path uses. It reads
+  // target/LangOpts facts via the LowerModule we build from the surrounding
+  // cc1 invocation, so it needs no live ASTContext. IdiomRecognizer is
+  // skipped here -- it documents an AST dependency and is opt-in even on the
+  // source path.
   std::unique_ptr<cir::LowerModule> lowerModule =
       makeLowerModuleFromInvocation(CI, Mod);
   if (!lowerModule) {
     CI.getDiagnostics().Report(diag::err_cir_to_cir_transform_failed);
     return;
   }
-  {
-    mlir::PassManager pm(MLIRCtx);
-    pm.addPass(mlir::createCIRCanonicalizePass());
-    pm.addPass(mlir::createTargetLoweringPass());
-    pm.addPass(mlir::createCXXABILoweringPass());
-    pm.addPass(mlir::createLoweringPreparePass(lowerModule.get(),
-                                               &CI.getVirtualFileSystem()));
-    if (mlir::failed(pm.run(Mod))) {
-      // Pass-side errors are routed through DiagHandler above; only emit the
-      // generic catch-all if nothing more specific was reported.
-      if (!CI.getDiagnostics().hasErrorOccurred())
-        CI.getDiagnostics().Report(diag::err_cir_to_cir_transform_failed);
-      return;
-    }
+  const FrontendOptions &FEOptions = CI.getFrontendOpts();
+  const CodeGenOptions &CGO = CI.getCodeGenOpts();
+  const bool EnableLibOpt =
+      FEOptions.ClangIRLibOptEnabled && (CGO.OptimizationLevel > 0);
+  if (runCIRToCIRPasses(Mod, *MLIRCtx, *lowerModule, &CI.getVirtualFileSystem(),
+                        !FEOptions.ClangIRDisableCIRVerifier,
+                        /*enableIdiomRecognizer=*/false,
+                        CGO.OptimizationLevel > 0, EnableLibOpt,
+                        FEOptions.ClangIRLibOptOptions,
+                        FEOptions.ClangIRCallConvLowering)
+          .failed()) {
+    // Pass-side errors are routed through DiagHandler above; only emit the
+    // generic catch-all if nothing more specific was reported.
+    if (!CI.getDiagnostics().hasErrorOccurred())
+      CI.getDiagnostics().Report(diag::err_cir_to_cir_transform_failed);
+    return;
   }
 
   llvm::LLVMContext LLVMCtx;

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -8,6 +8,7 @@
 
 #include "clang/CIR/FrontendAction/CIRGenAction.h"
 #include "CIRDiagnosticHandler.h"
+#include "TargetLowering/LowerModule.h"
 #include "mlir/Dialect/DLTI/DLTI.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
@@ -16,14 +17,17 @@
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OwningOpRef.h"
 #include "mlir/Parser/Parser.h"
+#include "mlir/Pass/PassManager.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/Basic/DiagnosticCodeGen.h"
 #include "clang/Basic/DiagnosticFrontend.h"
+#include "clang/Basic/TargetInfo.h"
 #include "clang/CIR/CIRGenerator.h"
 #include "clang/CIR/CIRToCIRPasses.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/OpenACC/RegisterOpenACCExtensions.h"
 #include "clang/CIR/Dialect/OpenMP/RegisterOpenMPExtensions.h"
+#include "clang/CIR/Dialect/Passes.h"
 #include "clang/CIR/LowerToLLVM.h"
 #include "clang/CodeGen/BackendUtil.h"
 #include "clang/CodeGen/ModuleLinker.h"
@@ -40,6 +44,7 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/IPO/Internalize.h"
 
@@ -76,6 +81,21 @@ lowerFromCIRToLLVMIR(mlir::ModuleOp MLIRModule, llvm::LLVMContext &LLVMCtx,
                      llvm::vfs::FileSystem *fs = nullptr) {
   return direct::lowerDirectlyFromCIRToLLVMIR(MLIRModule, LLVMCtx, EnableOpenMP,
                                               mlirSaveTempsOutFile, fs);
+}
+
+// Build a LowerModule from the surrounding cc1 invocation. Used both for
+// in-process CIRGen (where the same TargetInfo also drives the AST) and for
+// the .cir input path, where there is no AST at all.
+static std::unique_ptr<cir::LowerModule>
+makeLowerModuleFromInvocation(CompilerInstance &CI, mlir::ModuleOp module) {
+  // Clone TargetInfo: LowerModule takes ownership and CI keeps its copy.
+  auto target =
+      std::unique_ptr<clang::TargetInfo>(clang::TargetInfo::CreateTargetInfo(
+          CI.getDiagnostics(), CI.getInvocation().getTargetOpts()));
+  if (!target)
+    return nullptr;
+  return cir::createLowerModule(module, CI.getLangOpts(), CI.getCodeGenOpts(),
+                                std::move(target));
 }
 
 class CIRGenConsumer : public clang::ASTConsumer {
@@ -165,8 +185,15 @@ public:
       // Setup and run CIR pipeline.
       const bool EnableLibOpt =
           FEOptions.ClangIRLibOptEnabled && (CGO.OptimizationLevel > 0);
+      std::unique_ptr<cir::LowerModule> lowerModule =
+          makeLowerModuleFromInvocation(CI, MlirModule);
+      if (!lowerModule) {
+        CI.getDiagnostics().Report(diag::err_cir_to_cir_transform_failed);
+        return;
+      }
       if (runCIRToCIRPasses(
-              MlirModule, MlirCtx, C, !FEOptions.ClangIRDisableCIRVerifier,
+              MlirModule, MlirCtx, C, *lowerModule, &CI.getVirtualFileSystem(),
+              !FEOptions.ClangIRDisableCIRVerifier,
               FEOptions.ClangIREnableIdiomRecognizer, CGO.OptimizationLevel > 0,
               EnableLibOpt, LibOptOptions, FEOptions.ClangIRCallConvLowering)
               .failed()) {
@@ -345,6 +372,13 @@ void CIRGenAction::ExecuteAction() {
 
   registerCIRInputDialects(*MLIRCtx);
 
+  // Route MLIR diagnostics (parse errors and pass-side errors) through
+  // clang's DiagnosticsEngine, so this path reports real MLIR error text like
+  // the source path does. Without a live ASTContext the SourceManager still
+  // holds the .cir buffer, which is enough to translate cir.loc locations.
+  CIRDiagnosticHandler DiagHandler(MLIRCtx, CI.getDiagnostics(),
+                                   CI.getSourceManager(), CI.getFileManager());
+
   llvm::SourceMgr SrcMgr;
   SrcMgr.AddNewSourceBuffer(
       llvm::MemoryBuffer::getMemBufferCopy(MainFile->getBuffer(),
@@ -376,17 +410,6 @@ void CIRGenAction::ExecuteAction() {
                  mlir::StringAttr::get(MLIRCtx, invocationTriple));
   }
 
-  // For now, the CIR-to-CIR pipeline (target-lowering, cxxabi-lowering,
-  // lowering-prepare) still requires a live ASTContext. On .cir input that
-  // ASTContext is unavailable, so this path only supports formats whose
-  // emission does not rely on those passes:
-  //   * EmitCIR: round-trip the parsed module.
-  //   * EmitLLVM/EmitBC/EmitObj/EmitAssembly: lower directly via the existing
-  //     CIR-to-LLVM dialect translation, which itself does not require an
-  //     ASTContext, and hand the result to the LLVM backend.
-  // Lifting the remaining ASTContext dependency from LoweringPrepare is
-  // tracked separately and will let this entry point run the full pipeline.
-
   if (Action == OutputType::EmitCIR) {
     mlir::OpPrintingFlags flags;
     flags.enableDebugInfo(/*enable=*/true, /*prettyForm=*/false);
@@ -394,12 +417,41 @@ void CIRGenAction::ExecuteAction() {
     return;
   }
 
-  llvm::LLVMContext LLVMCtx;
-  std::unique_ptr<llvm::Module> LLVMModule =
-      lowerFromCIRToLLVMIR(Mod, LLVMCtx, /*mlirSaveTempsOutFile=*/{},
-                           &CI.getVirtualFileSystem());
-  if (!LLVMModule) {
+  // Run the post-CIRGen pipeline (target-lowering, cxxabi-lowering,
+  // lowering-prepare). LoweringPrepare reads target/LangOpts facts via the
+  // LowerModule we build from the surrounding cc1 invocation, so it does not
+  // need a live ASTContext. IdiomRecognizer is intentionally skipped on this
+  // path -- it documents an AST dependency and is opt-in even on the source
+  // path.
+  std::unique_ptr<cir::LowerModule> lowerModule =
+      makeLowerModuleFromInvocation(CI, Mod);
+  if (!lowerModule) {
     CI.getDiagnostics().Report(diag::err_cir_to_cir_transform_failed);
+    return;
+  }
+  {
+    mlir::PassManager pm(MLIRCtx);
+    pm.addPass(mlir::createCIRCanonicalizePass());
+    pm.addPass(mlir::createTargetLoweringPass());
+    pm.addPass(mlir::createCXXABILoweringPass());
+    pm.addPass(mlir::createLoweringPreparePass(lowerModule.get(),
+                                               &CI.getVirtualFileSystem()));
+    if (mlir::failed(pm.run(Mod))) {
+      // Pass-side errors are routed through DiagHandler above; only emit the
+      // generic catch-all if nothing more specific was reported.
+      if (!CI.getDiagnostics().hasErrorOccurred())
+        CI.getDiagnostics().Report(diag::err_cir_to_cir_transform_failed);
+      return;
+    }
+  }
+
+  llvm::LLVMContext LLVMCtx;
+  std::unique_ptr<llvm::Module> LLVMModule = lowerFromCIRToLLVMIR(
+      Mod, LLVMCtx, CI.getLangOpts().OpenMP,
+      /*mlirSaveTempsOutFile=*/{}, &CI.getVirtualFileSystem());
+  if (!LLVMModule) {
+    if (!CI.getDiagnostics().hasErrorOccurred())
+      CI.getDiagnostics().Report(diag::err_cir_to_cir_transform_failed);
     return;
   }
 

--- a/clang/lib/CIR/FrontendAction/CMakeLists.txt
+++ b/clang/lib/CIR/FrontendAction/CMakeLists.txt
@@ -24,6 +24,12 @@ add_clang_library(clangCIRFrontendAction
   clangCIRLoweringCommon
   clangCIRLoweringDirectToLLVM
   clangCodeGen
+  CIROpenACCSupport
+  CIROpenMPSupport
   MLIRCIR
+  MLIRDLTIDialect
   MLIRIR
+  MLIRLLVMDialect
+  MLIROpenMPDialect
+  MLIRParser
   )

--- a/clang/lib/CIR/FrontendAction/CMakeLists.txt
+++ b/clang/lib/CIR/FrontendAction/CMakeLists.txt
@@ -7,6 +7,10 @@ set(LLVM_LINK_COMPONENTS
 
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
+# CIRGenAction reaches into the Transforms-private LowerModule helper to
+# stand up the AST-free LoweringPrepare pipeline.
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../Dialect/Transforms)
+
 add_clang_library(clangCIRFrontendAction
   CIRGenAction.cpp
   CIRDiagnosticHandler.cpp
@@ -27,6 +31,8 @@ add_clang_library(clangCIRFrontendAction
   CIROpenACCSupport
   CIROpenMPSupport
   MLIRCIR
+  MLIRCIRTargetLowering
+  MLIRCIRTransforms
   MLIRDLTIDialect
   MLIRIR
   MLIRLLVMDialect

--- a/clang/lib/CIR/Lowering/CIRPasses.cpp
+++ b/clang/lib/CIR/Lowering/CIRPasses.cpp
@@ -17,6 +17,7 @@
 #include "clang/Basic/TargetInfo.h"
 #include "clang/CIR/Dialect/Passes.h"
 #include "llvm/Support/TimeProfiler.h"
+#include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/TargetParser/Triple.h"
 
 namespace cir {
@@ -75,10 +76,11 @@ getX86ABICompatInfo(const clang::ASTContext &astContext) {
 
 mlir::LogicalResult
 runCIRToCIRPasses(mlir::ModuleOp theModule, mlir::MLIRContext &mlirContext,
-                  clang::ASTContext &astContext, bool enableVerifier,
-                  bool enableIdiomRecognizer, bool enableCIRSimplify,
-                  bool enableLibOpt, llvm::StringRef libOptOptions,
-                  bool enableCallConvLowering) {
+                  clang::ASTContext &astContext, cir::LowerModule &lowerModule,
+                  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs,
+                  bool enableVerifier, bool enableIdiomRecognizer,
+                  bool enableCIRSimplify, bool enableLibOpt,
+                  llvm::StringRef libOptOptions, bool enableCallConvLowering) {
 
   llvm::TimeTraceScope scope("CIR To CIR Passes");
 
@@ -110,7 +112,7 @@ runCIRToCIRPasses(mlir::ModuleOp theModule, mlir::MLIRContext &mlirContext,
   // outlines dynamic global initializers into functions.  It must run before
   // CallConvLowering so the classifier sees them, otherwise their signatures
   // go unclassified and caller and callee disagree on the ABI.
-  pm.addPass(mlir::createLoweringPreparePass(&astContext));
+  pm.addPass(mlir::createLoweringPreparePass(&lowerModule, std::move(vfs)));
 
   if (enableCallConvLowering) {
     // CallConvLowering rewrites signatures and call sites using the classifier,

--- a/clang/lib/CIR/Lowering/CIRPasses.cpp
+++ b/clang/lib/CIR/Lowering/CIRPasses.cpp
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "TargetLowering/LowerModule.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/PassManager.h"
-#include "clang/AST/ASTContext.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/CIR/Dialect/Passes.h"
@@ -43,10 +43,10 @@ static llvm::abi::X86AVXABILevel getX86AVXABILevel(llvm::StringRef abi) {
 /// Whether `__attribute__((target(...)))` on a function may raise its AVX ABI
 /// level above the command line's.  A target that opts out, and any ABI older
 /// than the rule, stay at the module level.
-static bool allowsX86TargetAttrAvx(const clang::ASTContext &astContext) {
-  return !astContext.getTargetInfo().getTriple().isPS() &&
-         astContext.getLangOpts().getClangABICompat() >
-             clang::LangOptions::ClangABI::Ver23;
+static bool allowsX86TargetAttrAvx(const clang::TargetInfo &targetInfo,
+                                   const clang::LangOptions &langOpts) {
+  return !targetInfo.getTriple().isPS() &&
+         langOpts.getClangABICompat() > clang::LangOptions::ClangABI::Ver23;
 }
 
 /// The x86_64 ABI-compatibility flags, derived from the target and the
@@ -55,9 +55,9 @@ static bool allowsX86TargetAttrAvx(const clang::ASTContext &astContext) {
 /// modern Linux target, so leaving it at the default classifies a union larger
 /// than an eightbyte as though every member spanned its size.
 static llvm::abi::ABICompatInfo
-getX86ABICompatInfo(const clang::ASTContext &astContext) {
-  const llvm::Triple &triple = astContext.getTargetInfo().getTriple();
-  const clang::LangOptions &langOpts = astContext.getLangOpts();
+getX86ABICompatInfo(const clang::TargetInfo &targetInfo,
+                    const clang::LangOptions &langOpts) {
+  const llvm::Triple &triple = targetInfo.getTriple();
   clang::LangOptions::ClangABI compat = langOpts.getClangABICompat();
   llvm::abi::ABICompatInfo abiCompat;
   abiCompat.HonorsRevision98 = !triple.isOSDarwin();
@@ -76,7 +76,7 @@ getX86ABICompatInfo(const clang::ASTContext &astContext) {
 
 mlir::LogicalResult
 runCIRToCIRPasses(mlir::ModuleOp theModule, mlir::MLIRContext &mlirContext,
-                  clang::ASTContext &astContext, cir::LowerModule &lowerModule,
+                  cir::LowerModule &lowerModule,
                   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs,
                   bool enableVerifier, bool enableIdiomRecognizer,
                   bool enableCIRSimplify, bool enableLibOpt,
@@ -119,12 +119,14 @@ runCIRToCIRPasses(mlir::ModuleOp theModule, mlir::MLIRContext &mlirContext,
     // so it must run after CXXABILowering has lowered C++ ABI types to plain
     // records the classifier can handle.  Only the x86_64 System V classifier
     // is implemented; other targets are left unchanged.
-    const clang::TargetInfo &targetInfo = astContext.getTargetInfo();
+    const clang::TargetInfo &targetInfo = lowerModule.getTarget();
+    const clang::LangOptions &langOpts = lowerModule.getLangOpts();
     CallConvTarget target = getCallConvTarget(targetInfo.getTriple());
     if (target != CallConvTarget::None)
       pm.addPass(mlir::createCallConvLoweringPass(
           target, getX86AVXABILevel(targetInfo.getABI()),
-          allowsX86TargetAttrAvx(astContext), getX86ABICompatInfo(astContext)));
+          allowsX86TargetAttrAvx(targetInfo, langOpts),
+          getX86ABICompatInfo(targetInfo, langOpts)));
   }
 
   pm.enableVerifier(enableVerifier);

--- a/clang/lib/CIR/Lowering/CMakeLists.txt
+++ b/clang/lib/CIR/Lowering/CMakeLists.txt
@@ -5,6 +5,11 @@ set(LLVM_LINK_COMPONENTS
 
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
+# runCIRToCIRPasses reaches into the Transforms-private LowerModule helper to
+# read the target/LangOpts state that drives CallConvLowering, so the pipeline
+# needs no live ASTContext.
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../Dialect/Transforms)
+
 add_clang_library(clangCIRLoweringCommon
   CIRPasses.cpp
   LoweringHelpers.cpp

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -1051,6 +1051,28 @@ bool FrontendAction::BeginSourceFile(CompilerInstance &CI,
     return true;
   }
 
+  // Serialized ClangIR (.cir) input bypasses AST/preprocessor initialization
+  // the same way LLVM IR does.
+  if (Input.getKind().getLanguage() == Language::CIR) {
+    if (!hasCIRSupport()) {
+      CI.getDiagnostics().Report(diag::err_ast_action_on_cir)
+          << Input.getFile();
+      return false;
+    }
+
+    CI.getDiagnosticClient().BeginSourceFile(CI.getLangOpts(), nullptr);
+    HasBegunSourceFile = true;
+
+    if (!BeginSourceFileAction(CI))
+      return false;
+
+    if (!CI.InitializeSourceManager(CurrentInput))
+      return false;
+
+    FailureCleanup.release();
+    return true;
+  }
+
   if (!CI.getPreprocessorOpts().ImplicitPCHInclude.empty()) {
     FileManager &FileMgr = CI.getFileManager();
     PreprocessorOptions &PPOpts = CI.getPreprocessorOpts();
@@ -1542,6 +1564,9 @@ bool WrapperFrontendAction::hasASTFileSupport() const {
 }
 bool WrapperFrontendAction::hasIRSupport() const {
   return WrappedAction->hasIRSupport();
+}
+bool WrapperFrontendAction::hasCIRSupport() const {
+  return WrappedAction->hasCIRSupport();
 }
 bool WrapperFrontendAction::hasCodeCompletionSupport() const {
   return WrappedAction->hasCodeCompletionSupport();

--- a/clang/test/CIR/IR/invalid-static-local-info.cir
+++ b/clang/test/CIR/IR/invalid-static-local-info.cir
@@ -1,0 +1,13 @@
+// RUN: cir-opt %s -verify-diagnostics -split-input-file
+
+// A guarded static-local relies on 'static_local_info' during LoweringPrepare,
+// so the GlobalOp verifier rejects a 'static_local_guard' without it. This
+// guards the static-local lowering path against hand-written or serialized
+// .cir that would otherwise crash lowering with a missing info attribute.
+
+!s32i = !cir.int<s, 32>
+
+module {
+  // expected-error@+1 {{'static_local_guard' requires 'static_local_info' to be present}}
+  cir.global "private" internal static_local_guard<"_ZGVZ1fvE1x"> @_ZZ1fvE1x : !s32i
+}

--- a/clang/test/CIR/IR/invalid-static-local.cir
+++ b/clang/test/CIR/IR/invalid-static-local.cir
@@ -23,6 +23,7 @@ module {
 
 // Global is marked static_local_guard, but get_global is not static_local
 cir.global "private" internal static_local_guard<"_ZGVZ1fvE1y"> @_ZZ1fvE1y : !s32i
+  {static_local_info = #cir.static_local_info<local = true, tls = none, is_inline = false, tsk = undeclared>}
 
 cir.func @test_static_local_mismatch_reverse() {
   // expected-error @below {{static_local attribute mismatch}}
@@ -40,6 +41,7 @@ module {
 
 // local_init is both static_local and thread_local
 cir.global "private" internal static_local_guard<"_ZGVZ1fvE1y"> @_ZZ1fvE1y : !s32i
+  {static_local_info = #cir.static_local_info<local = true, tls = none, is_inline = false, tsk = undeclared>}
 
 cir.func @test_static_local_and_tls() {
   %0 = cir.get_global static_local @_ZZ1fvE1y : !cir.ptr<!s32i>
@@ -63,6 +65,7 @@ module {
 
 // local_init not at function scope.
 cir.global "private" internal static_local_guard<"_ZGVZ1fvE1y"> @_ZZ1fvE1y : !s32i
+  {static_local_info = #cir.static_local_info<local = true, tls = none, is_inline = false, tsk = undeclared>}
 
 cir.global "private" internal @_AnotherGlobal = ctor : !s32i {
   // expected-error @below {{'cir.local_init' op expects ancestor op 'cir.func'}}

--- a/clang/test/CIR/IR/invalid-tls.cir
+++ b/clang/test/CIR/IR/invalid-tls.cir
@@ -18,6 +18,7 @@ module {
 module {
   // expected-error@+1{{op cannot have both static local and tls references}}
 cir.global "private" internal tls_model = <tls_dyn> tls_refs = <"asdf", "asdf", "asdf"> static_local_guard<"asdf"> @_ZZ1fvE1y : !s32i
+  {static_local_info = #cir.static_local_info<local = true, tls = dynamic, is_inline = false, tsk = undeclared>}
 }
 
 // -----

--- a/clang/test/CIR/IR/static-local.cir
+++ b/clang/test/CIR/IR/static-local.cir
@@ -4,17 +4,25 @@
 
 module {
 
-// Test static_local_guard attribute on global and static_local on get_global
+// Test static_local_guard attribute on global and static_local on get_global.
+// The GlobalOp verifier requires static_local_guard and static_local_info to
+// be paired, matching what CIRGen emits, so each guarded global also carries
+// the info attribute here.
 cir.global "private" internal static_local_guard<"_ZGVZ1fvE1x"> @_ZZ1fvE1x : !s32i
+  {static_local_info = #cir.static_local_info<local = true, tls = none, is_inline = false, tsk = undeclared>}
 // CHECK: cir.global "private" internal static_local_guard<"_ZGVZ1fvE1x"> @_ZZ1fvE1x : !s32i
 
 cir.global "private" internal static_local_guard<"_HasInitGuard"> @_HasInit : !s32i
+  {static_local_info = #cir.static_local_info<local = true, tls = none, is_inline = false, tsk = undeclared>}
 // CHECK: cir.global "private" internal static_local_guard<"_HasInitGuard"> @_HasInit : !s32i
 cir.global "private" internal static_local_guard<"_HasInitGuard2"> @_HasInit2 : !s32i
+  {static_local_info = #cir.static_local_info<local = true, tls = none, is_inline = false, tsk = undeclared>}
 // CHECK: cir.global "private" internal static_local_guard<"_HasInitGuard2"> @_HasInit2 : !s32i
 cir.global "private" internal static_local_guard<"_HasInitGuard3"> @_HasInit3 : !s32i
+  {static_local_info = #cir.static_local_info<local = true, tls = none, is_inline = false, tsk = undeclared>}
 // CHECK: cir.global "private" internal static_local_guard<"_HasInitGuard3"> @_HasInit3 : !s32i
 cir.global "private" internal static_local_guard<"_HasInitGuard4"> @_HasInit4 : !s32i
+  {static_local_info = #cir.static_local_info<local = true, tls = none, is_inline = false, tsk = undeclared>}
 // CHECK: cir.global "private" internal static_local_guard<"_HasInitGuard4"> @_HasInit4 : !s32i
 
 cir.func @test_static_local() {

--- a/clang/test/CIR/cc1-cir-input-callconv.c
+++ b/clang/test/CIR/cc1-cir-input-callconv.c
@@ -1,0 +1,30 @@
+// Verify the .cir cc1 input path runs the full CIR-to-CIR pipeline, including
+// CallConvLowering. We first emit *un-lowered* CIR (-clangir-disable-passes)
+// so the serialized module still returns the struct by value; feeding it back
+// through the .cir path must apply the x86_64 System V ABI, coercing the
+// 8-byte struct return to i64. Before the .cir path shared runCIRToCIRPasses
+// it skipped CallConvLowering and this coercion would not happen.
+//
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir \
+// RUN:   -clangir-disable-passes -emit-cir %s -o %t.cir
+// RUN: FileCheck %s --check-prefix=CIR --input-file=%t.cir
+//
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -x cir %t.cir \
+// RUN:   -emit-llvm -o - | FileCheck %s --check-prefix=LLVM
+
+struct S {
+  int a, b;
+};
+
+struct S make(int x) {
+  struct S s = {x, x};
+  return s;
+}
+
+// The serialized module is still high-level: the struct is returned by value,
+// not yet coerced to an ABI type.
+// CIR: cir.func {{.*}}@make(%arg0: !s32i {{.*}}) -> !rec_S
+
+// After the .cir path runs CallConvLowering, the 8-byte struct return is
+// coerced to i64 per the x86_64 System V ABI.
+// LLVM: define {{.*}} i64 @make(i32 {{.*}}%{{.+}})

--- a/clang/test/CIR/cc1-cir-input.c
+++ b/clang/test/CIR/cc1-cir-input.c
@@ -1,0 +1,24 @@
+// Verify clang -cc1 accepts a serialized .cir file as input and re-emits it,
+// proving the new -x cir entry point round-trips through the frontend.
+//
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s \
+// RUN:   -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -x cir %t.cir \
+// RUN:   -emit-cir -o - | FileCheck %s --check-prefix=ROUNDTRIP
+
+// Lower a parsed .cir file all the way to LLVM IR. The CIR-to-LLVM dialect
+// translation does not require a live ASTContext, so this path is supported
+// even before LoweringPrepare is made AST-free.
+//
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s \
+// RUN:   -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -x cir %t.cir \
+// RUN:   -emit-llvm -o - | FileCheck %s --check-prefix=LLVM
+
+int add(int a, int b) { return a + b; }
+
+// ROUNDTRIP: cir.func {{.*}}@add
+// ROUNDTRIP: cir.return
+
+// LLVM: define {{.*}} i32 @add(i32 {{.*}}%[[A:.+]], i32 {{.*}}%[[B:.+]])
+// LLVM: ret i32

--- a/clang/test/CIR/cc1-cir-input.c
+++ b/clang/test/CIR/cc1-cir-input.c
@@ -1,19 +1,19 @@
-// Verify clang -cc1 accepts a serialized .cir file as input and re-emits it,
-// proving the new -x cir entry point round-trips through the frontend.
+// Verify clang -cc1 accepts a serialized .cir file as input across all of
+// the formats CIRGenAction can emit. With LoweringPrepare AST-free the
+// .cir path runs the full CIR-to-CIR pipeline, so emit-obj is now valid as
+// well.
 //
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s \
 // RUN:   -o %t.cir
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -x cir %t.cir \
 // RUN:   -emit-cir -o - | FileCheck %s --check-prefix=ROUNDTRIP
-
-// Lower a parsed .cir file all the way to LLVM IR. The CIR-to-LLVM dialect
-// translation does not require a live ASTContext, so this path is supported
-// even before LoweringPrepare is made AST-free.
 //
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s \
-// RUN:   -o %t.cir
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -x cir %t.cir \
 // RUN:   -emit-llvm -o - | FileCheck %s --check-prefix=LLVM
+//
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -x cir %t.cir \
+// RUN:   -emit-obj -o %t.o
+// RUN: llvm-nm %t.o | FileCheck %s --check-prefix=OBJ
 
 int add(int a, int b) { return a + b; }
 
@@ -22,3 +22,5 @@ int add(int a, int b) { return a + b; }
 
 // LLVM: define {{.*}} i32 @add(i32 {{.*}}%[[A:.+]], i32 {{.*}}%[[B:.+]])
 // LLVM: ret i32
+
+// OBJ: T add


### PR DESCRIPTION
Makes the post-CIRGen CIR-to-CIR pipeline runnable without a live `clang::ASTContext`, and adds a `clang -cc1 -x cir` path that lowers a serialized .cir module straight to LLVM IR / object code. 

The pipeline no longer reaches into the AST for `target/LangOpts` facts: those now come from `LowerModule`, which is built from the surrounding `cc1` invocation. 

The one AST fact LoweringPrepare needs  (static-local init) is materialized at CIRGen into a serializable `#cir.static_local_info` attribute (#215921 ) and read from the IR, not the AST.

Some known limitations marked already as todos:

* The .cir path does not yet link -mlink-builtin-bitcode modules.
* The module-only `createLowerModule(module)` used by TargetLowering/CXXABILowering still default-constructs LangOptions/CodeGenOptions (
    - This PR does not change this,  I just note it for completeness.
* The .cir path duplicates most of the lowering + backend-emit tail of HandleTranslationUnit. So, tt doesn't yet handle `-mlink-builtin-bitcode` modules. Both are resolved by extracting a shared tail (follow-up, TODO(cir) in-code).