### PR TITLE
[clang-tidy] Fix unique-ptr-array-mismatch crash by safely managing const qualifiers

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/UniquePtrArrayMismatchCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/UniquePtrArrayMismatchCheck.cpp
@@ -20,8 +20,9 @@ UniquePtrArrayMismatchCheck::SmartPtrClassMatcher
 UniquePtrArrayMismatchCheck::getSmartPointerClassMatcher() const {
   const auto DeleterDecl = classTemplateSpecializationDecl(
       hasName("::std::default_delete"), templateArgumentCountIs(1),
-      hasTemplateArgument(0, templateArgument(refersToType(
-                                 qualType(equalsBoundNode(PointerTypeN))))));
+      hasTemplateArgument(
+          0, templateArgument(refersToType(qualType(hasUnqualifiedDesugaredType(
+                 equalsBoundNode(PointerTypeN)))))));
   return classTemplateSpecializationDecl(
       hasName("::std::unique_ptr"), templateArgumentCountIs(2),
       hasTemplateArgument(


### PR DESCRIPTION
Currently clang-tidy crashes when consuming const defined unique pointers, qualifying the check solves this issue.

resolves #217375