### PR TITLE
[TableGen] Disable HwMode expansion in CodeGenDAGPatterns for InstrInfoEmitter.

### DIFF
--- a/llvm/utils/TableGen/InstrInfoEmitter.cpp
+++ b/llvm/utils/TableGen/InstrInfoEmitter.cpp
@@ -59,7 +59,8 @@ class InstrInfoEmitter {
 
 public:
   InstrInfoEmitter(const RecordKeeper &R)
-      : Records(R), CDP(R), SchedModels(CDP.getTargetInfo().getSchedModels()) {}
+      : Records(R), CDP(R, /*ExpandHwMode=*/false),
+        SchedModels(CDP.getTargetInfo().getSchedModels()) {}
 
   // run - Output the instruction set description.
   void run(raw_ostream &OS);


### PR DESCRIPTION
InstrInfoEmitter doesn't use the types and patterns so they don't need to be expanded.