### PR TITLE
[clang] Fixed while condition empty init statement with attributes dereferencing nullptr

### DIFF
--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -1936,7 +1936,7 @@ Sema::ConditionResult Parser::ParseCondition(StmtResult *InitStmt,
 
     // Handle '(; expr)', '([[...]]; expr)' and '(__attribute__((...)); expr)'
     // when GNU-style attributes are finalized.
-    if (Tok.is(tok::semi)) {
+    if (InitStmt && Tok.is(tok::semi)) {
       StmtResult Null = Actions.ActOnNullStmt(ConsumeToken());
       if (ParsedAttrs) {
         WarnOnInit();

--- a/clang/test/Parser/c2x-attributes.c
+++ b/clang/test/Parser/c2x-attributes.c
@@ -120,6 +120,12 @@ void f11(void) {
 
   [[]] for (;;);
   [[]] while (1);
+
+  while ([[]];) {} // expected-error {{an attribute list cannot appear here}} \
+                   // expected-error {{expected expression}}
+  while (;[[]];;) {} // expected-error {{expected expression}} \
+                     // expected-error {{expected expression}}
+
   [[]] do [[]] { } while(1);
 
   [[]] (void)1;


### PR DESCRIPTION
In conditions with an empty init statement with attributes such as '([[]];)', the InitStmt pointer argument in the ParseCondition method will be dereferenced. However, InitStmt is set to nullptr when parsing a 'while' statement condition, causing a crash.

This change fixes the issue by added a check that InitStmt is not nullptr before entering the associated logic, which is consistent with how other parts of this function handle a nullptr InitStmt. This makes sense because a nullptr InitStmt is associated with conditions that cannot have an init statement (the only case being 'while') and this block operates exclusively on init statements.

Fix #218879