### PR TITLE
[AMDGPU] Add FeatureLDSBankCount64 for gfx12.5

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPU.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.td
@@ -413,6 +413,7 @@ class SubtargetFeatureLDSBankCount <int Value> : SubtargetFeature <
 
 def FeatureLDSBankCount16 : SubtargetFeatureLDSBankCount<16>;
 def FeatureLDSBankCount32 : SubtargetFeatureLDSBankCount<32>;
+def FeatureLDSBankCount64 : SubtargetFeatureLDSBankCount<64>;
 
 class SubtargetFeatureMaxWavesPerEU <int Value> : SubtargetFeature <
   "max-waves-per-eu-"#Value,
@@ -2343,7 +2344,7 @@ def FeatureISAVersion12_50_Common : FeatureSet<
    FeatureCuMode,
    Feature1024AddressableVGPRs,
    Feature64BitLiterals,
-   FeatureLDSBankCount32,
+   FeatureLDSBankCount64,
    FeatureDLInsts,
    FeatureFmacF64Inst,
    FeaturePackedFP32SingleSGPROps,


### PR DESCRIPTION
gfx1250, gfx1251 and gfx1250-strict have 64 LDS banks rather than 32. Set the count on FeatureISAVersion12_50_Common so all three, and the gfx12-5-generic target covering them, inherit it.