### PR TITLE
[AMDGPU] Add `getLDSBankCount` query to TargetParser

### DIFF
--- a/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
+++ b/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
@@ -209,6 +209,10 @@ LLVM_ABI unsigned getMaxHWAddressableLocalMemorySize(GPUKind AK);
 LLVM_ABI unsigned
 getMaxHWAddressableLocalMemorySize(Triple::SubArchType SubArch);
 
+/// \returns Number of LDS banks per compute unit.
+LLVM_ABI unsigned getLDSBankCount(GPUKind AK);
+LLVM_ABI unsigned getLDSBankCount(Triple::SubArchType SubArch);
+
 /// \returns Number of SIMDs a work-group's waves run on. All four SIMDs of the
 /// functional block in full-SIMD mode, half of them otherwise.
 constexpr unsigned getNumWorkGroupSIMDs(bool FullSIMDMode) {

--- a/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
+++ b/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
@@ -202,6 +202,10 @@ LLVM_ABI unsigned getAddressableNumSGPRs(Triple::SubArchType SubArch);
 LLVM_ABI unsigned getSGPRAllocGranule(GPUKind AK);
 LLVM_ABI unsigned getSGPRAllocGranule(Triple::SubArchType SubArch);
 
+/// \returns Number of LDS banks per compute unit.
+LLVM_ABI unsigned getLDSBankCount(GPUKind AK);
+LLVM_ABI unsigned getLDSBankCount(Triple::SubArchType SubArch);
+
 /// \returns Number of SIMDs a work-group's waves run on. All four SIMDs of the
 /// functional block in full-SIMD mode, half of them otherwise.
 constexpr unsigned getNumWorkGroupSIMDs(bool FullSIMDMode) {

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -43,6 +43,7 @@ struct GPUInfo {
   StringTable::Offset BaseName; // The canonical device name for a variant.
   uint8_t MaxWavesPerEU;
   uint32_t MaxHWAddressableLocalMemorySize;
+  uint8_t LDSBankCount;
 };
 
 // Per-GPU data for the R600 GPUKinds.
@@ -438,6 +439,15 @@ unsigned AMDGPU::getMaxHWAddressableLocalMemorySize(GPUKind AK) {
 unsigned
 AMDGPU::getMaxHWAddressableLocalMemorySize(Triple::SubArchType SubArch) {
   return getMaxHWAddressableLocalMemorySize(getGPUKindFromSubArch(SubArch));
+}
+
+unsigned AMDGPU::getLDSBankCount(GPUKind AK) {
+  const GPUInfo *Info = getAMDGPUInfo(AK);
+  return Info ? Info->LDSBankCount : 32;
+}
+
+unsigned AMDGPU::getLDSBankCount(Triple::SubArchType SubArch) {
+  return getLDSBankCount(getGPUKindFromSubArch(SubArch));
 }
 
 unsigned AMDGPU::getMaxWavesPerEU(GPUKind AK) {

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -43,6 +43,7 @@ struct GPUInfo {
   StringTable::Offset FamilyName;
   StringTable::Offset BaseName; // The canonical device name for a variant.
   uint8_t MaxWavesPerEU;
+  uint8_t LDSBankCount;
 };
 
 // Per-GPU data for the R600 GPUKinds.
@@ -428,6 +429,15 @@ unsigned AMDGPU::getSGPRAllocGranule(Triple::SubArchType SubArch) {
   if (Version.Major >= 8)
     return 16;
   return 8;
+}
+
+unsigned AMDGPU::getLDSBankCount(GPUKind AK) {
+  const GPUInfo *Info = getAMDGPUInfo(AK);
+  return Info ? Info->LDSBankCount : 32;
+}
+
+unsigned AMDGPU::getLDSBankCount(Triple::SubArchType SubArch) {
+  return getLDSBankCount(getGPUKindFromSubArch(SubArch));
 }
 
 unsigned AMDGPU::getMaxWavesPerEU(GPUKind AK) {

--- a/llvm/test/TableGen/AMDGPUTargetDefSubArchSpelling.td
+++ b/llvm/test/TableGen/AMDGPUTargetDefSubArchSpelling.td
@@ -46,9 +46,9 @@ def GFX88F : ProcessorModel<"gfx88f", NoSchedModel, []>,
 
 // The GPU table: the base GPU has no base name (offset 0); the variant uses
 // AMDGPUSubArch888A and records "gfx888" as its base name.
-// CHECK: {[[#]], Triple::AMDGPUSubArch888, {{.*}}, {8, 8, 8}, [[FAM:[0-9]+]], 0, [[#]], [[#]]},
-// CHECK: {[[#]], Triple::AMDGPUSubArch888A, {{.*}}, {8, 8, 8}, [[FAM]], [[#]], [[#]], [[#]]},
-// CHECK: {[[#]], Triple::AMDGPUSubArch88F, {{.*}}, {8, 8, 15}, [[#]], 0, [[#]], [[#]]},
+// CHECK: {[[#]], Triple::AMDGPUSubArch888, {{.*}}, {8, 8, 8}, [[FAM:[0-9]+]], 0, [[#]], [[#]], [[#]]},
+// CHECK: {[[#]], Triple::AMDGPUSubArch888A, {{.*}}, {8, 8, 8}, [[FAM]], [[#]], [[#]], [[#]], [[#]]},
+// CHECK: {[[#]], Triple::AMDGPUSubArch88F, {{.*}}, {8, 8, 15}, [[#]], 0, [[#]], [[#]], [[#]]},
 
 // The subarch-name table maps the variant's own subarch to its triple name.
 // CHECK: {Triple::AMDGPUSubArch888A, [[#]], [[#]]},

--- a/llvm/test/TableGen/AMDGPUTargetDefSubArchSpelling.td
+++ b/llvm/test/TableGen/AMDGPUTargetDefSubArchSpelling.td
@@ -37,7 +37,7 @@ def GFX888_AMAZING : ProcessorModel<"gfx888-amazing", NoSchedModel, []>,
 
 // The GPU table: the base GPU has no base name (offset 0); the variant uses
 // AMDGPUSubArch8_88A and records "gfx888" as its base name.
-// CHECK: {[[#]], Triple::AMDGPUSubArch888, {{.*}}, {8, 8, 8}, [[FAM:[0-9]+]], 0, [[#]]},
+// CHECK: {[[#]], Triple::AMDGPUSubArch888, {{.*}}, {8, 8, 8}, [[FAM:[0-9]+]], 0, [[#]], [[#]]},
 
 // The subarch-name table maps the variant's own subarch to its triple name.
 // CHECK: {Triple::AMDGPUSubArch888A, [[#]], [[#]]},

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -3107,6 +3107,20 @@ TEST(TargetParserTest, testAMDGPUgetNumWorkGroupSIMDs) {
   EXPECT_EQ(AMDGPU::getNumWorkGroupSIMDs(false), 2u);
 }
 
+TEST(TargetParserTest, testAMDGPUgetLDSBankCount) {
+  EXPECT_EQ(AMDGPU::getLDSBankCount(Triple::AMDGPUSubArch702), 16u);
+  EXPECT_EQ(AMDGPU::getLDSBankCount(Triple::AMDGPUSubArch900), 32u);
+  EXPECT_EQ(AMDGPU::getLDSBankCount(Triple::AMDGPUSubArch1030), 32u);
+  EXPECT_EQ(AMDGPU::getLDSBankCount(Triple::AMDGPUSubArch1200), 32u);
+  // gfx12.5 doubled the bank count.
+  EXPECT_EQ(AMDGPU::getLDSBankCount(Triple::AMDGPUSubArch1250), 64u);
+
+  // The GPUKind overload resolves to the same values.
+  EXPECT_EQ(AMDGPU::getLDSBankCount(AMDGPU::GK_GFX900), 32u);
+  EXPECT_EQ(AMDGPU::getLDSBankCount(AMDGPU::GK_GFX1250), 64u);
+  EXPECT_EQ(AMDGPU::getLDSBankCount(AMDGPU::GK_GFX1251), 64u);
+}
+
 TEST(TargetParserTest, testAMDGPUgetMaxWavesPerEU) {
   EXPECT_EQ(AMDGPU::getMinWavesPerEU(), 1u);
 

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -3075,6 +3075,20 @@ TEST(TargetParserTest, testAMDGPUgetNumWorkGroupSIMDs) {
   EXPECT_EQ(AMDGPU::getNumWorkGroupSIMDs(false), 2u);
 }
 
+TEST(TargetParserTest, testAMDGPUgetLDSBankCount) {
+  EXPECT_EQ(AMDGPU::getLDSBankCount(Triple::AMDGPUSubArch702), 16u);
+  EXPECT_EQ(AMDGPU::getLDSBankCount(Triple::AMDGPUSubArch900), 32u);
+  EXPECT_EQ(AMDGPU::getLDSBankCount(Triple::AMDGPUSubArch1030), 32u);
+  EXPECT_EQ(AMDGPU::getLDSBankCount(Triple::AMDGPUSubArch1200), 32u);
+  // gfx12.5 doubled the bank count.
+  EXPECT_EQ(AMDGPU::getLDSBankCount(Triple::AMDGPUSubArch1250), 64u);
+
+  // The GPUKind overload resolves to the same values.
+  EXPECT_EQ(AMDGPU::getLDSBankCount(AMDGPU::GK_GFX900), 32u);
+  EXPECT_EQ(AMDGPU::getLDSBankCount(AMDGPU::GK_GFX1250), 64u);
+  EXPECT_EQ(AMDGPU::getLDSBankCount(AMDGPU::GK_GFX1251), 64u);
+}
+
 TEST(TargetParserTest, testAMDGPUgetMaxWavesPerEU) {
   EXPECT_EQ(AMDGPU::getMinWavesPerEU(), 1u);
 

--- a/llvm/utils/TableGen/Basic/AMDGPUTargetDefEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/AMDGPUTargetDefEmitter.cpp
@@ -613,7 +613,8 @@ emitAMDGPUTable(raw_ostream &OS, const RecordKeeper &RK,
     emitBaseName(BaseNameOS, R);
     OS << Names.GetOrAddStringOffset(BaseName) << ", "
        << getFeatureValue(R, "MaxWavesPerEU", 10) << ", "
-       << getFeatureValue(R, "AddressableLocalMemorySize", 32768) << "},\n";
+       << getFeatureValue(R, "AddressableLocalMemorySize", 32768) << ", "
+       << getFeatureValue(R, "LDSBankCount", 32) << "},\n";
   }
   OS << "};\n"
         "#endif // GET_AMDGPU_GPU_TABLE\n\n";

--- a/llvm/utils/TableGen/Basic/AMDGPUTargetDefEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/AMDGPUTargetDefEmitter.cpp
@@ -599,7 +599,8 @@ emitAMDGPUTable(raw_ostream &OS, const RecordKeeper &RK,
     raw_svector_ostream BaseNameOS(BaseName);
     emitBaseName(BaseNameOS, R);
     OS << Names.GetOrAddStringOffset(BaseName) << ", "
-       << getFeatureValue(R, "MaxWavesPerEU", 10) << "},\n";
+       << getFeatureValue(R, "MaxWavesPerEU", 10) << ", "
+       << getFeatureValue(R, "LDSBankCount", 32) << "},\n";
   }
   OS << "};\n"
         "#endif // GET_AMDGPU_GPU_TABLE\n\n";


### PR DESCRIPTION
Emit LDSBankCount as a column of the generated AMDGPU GPU table and expose `getLDSBankCount()` from TargetParser, so consumers that only have a GPUKind or subarch can read it without an `MCSubtargetInfo`.

Aids in resolving : https://github.com/ROCm/llvm-project/issues/3298 : "Comgr should use target information from upstream TargetParser rather than maintaining its own"