### PR TITLE
[libc] Add self-define for sigev_notify_thread_id field.

### DIFF
--- a/libc/include/llvm-libc-types/struct_sigevent.h
+++ b/libc/include/llvm-libc-types/struct_sigevent.h
@@ -30,4 +30,7 @@ struct sigevent {
 #endif
 };
 
+// Self-define for compatibility with code assuming a macro.
+#define sigev_notify_thread_id sigev_notify_thread_id
+
 #endif // LLVM_LIBC_TYPES_STRUCT_SIGEVENT_H


### PR DESCRIPTION
Support downstream code that assumes `sigev_notify_thread_id`, even though defined for Linux is a macro that expands to use private `struct sigevent` fields.