### PR TITLE
[CIR][AARCH64] Fix neon conversion test

### DIFF
--- a/clang/test/CodeGen/AArch64/neon/intrinsics.c
+++ b/clang/test/CodeGen/AArch64/neon/intrinsics.c
@@ -5623,7 +5623,7 @@ float16x4_t test_vcvt_f16_f32(float32x4_t a) {
 }
 
 // LLVM-LABEL: @test_vcvt_high_f16_f32(
-// CIR-LABEL: @vcvt_f16_f32(
+// CIR-LABEL: @vcvt_high_f16_f32(
 float16x8_t test_vcvt_high_f16_f32(float16x4_t a, float32x4_t b) {
 // CIR:  cir.call @vcvt_f16_f32
 // CIR: cir.call @vcombine_f16


### PR DESCRIPTION
This fixes the neon intrinsics test, which has been failing since a recent change to introduce more conversion handling. The test had an inadvertantly repeated CIR check.