### PR TITLE
[ADT] Simplify FoldingSetIterator (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/FoldingSet.h
+++ b/llvm/include/llvm/ADT/FoldingSet.h
@@ -638,8 +638,7 @@ public:
 };
 
 //===----------------------------------------------------------------------===//
-/// FoldingSetIterator - Forward iterator for FoldingSet and
-/// ContextualFoldingSet.
+/// Forward iterator for FoldingSet and ContextualFoldingSet.
 template <class T> class FoldingSetIterator : DebugEpochBase::HandleBase {
   void **Bucket = nullptr;
   void **End = nullptr;

--- a/llvm/include/llvm/ADT/FoldingSet.h
+++ b/llvm/include/llvm/ADT/FoldingSet.h
@@ -378,8 +378,6 @@ private:
   static bool nodeEquals(const FoldingSetInfo &Info, const FoldingSetBase *Self,
                          Node *N, const FoldingSetNodeID &ID, unsigned IDHash);
 
-  friend class FoldingSetIteratorImpl;
-
   /// Rehash into at least \p MinNumBuckets buckets, rounded up to a power of
   /// two and floored at the constructor's minimum.
   void grow(unsigned MinNumBuckets);
@@ -502,13 +500,19 @@ public:
 public:
   using iterator = FoldingSetIterator<T>;
 
-  iterator begin() { return iterator(this, 0); }
-  iterator end() { return iterator(this, NumBuckets); }
+  iterator begin() { return iterator(Buckets, Buckets + NumBuckets, this); }
+  iterator end() {
+    return iterator(Buckets + NumBuckets, Buckets + NumBuckets, this);
+  }
 
   using const_iterator = FoldingSetIterator<const T>;
 
-  const_iterator begin() const { return const_iterator(this, 0); }
-  const_iterator end() const { return const_iterator(this, NumBuckets); }
+  const_iterator begin() const {
+    return const_iterator(Buckets, Buckets + NumBuckets, this);
+  }
+  const_iterator end() const {
+    return const_iterator(Buckets + NumBuckets, Buckets + NumBuckets, this);
+  }
 
   /// Remove a node from the folding set, returning true if one
   /// was removed or false if the node was not in the folding set.
@@ -634,40 +638,32 @@ public:
 };
 
 //===----------------------------------------------------------------------===//
-/// This is the common iterator support shared by all folding sets, which knows
-/// how to walk the folding set hash table.
-class FoldingSetIteratorImpl : DebugEpochBase::HandleBase {
-protected:
-  const FoldingSetBase *Set = nullptr;
-  unsigned Index = 0;
+/// FoldingSetIterator - Forward iterator for FoldingSet and
+/// ContextualFoldingSet.
+template <class T> class FoldingSetIterator : DebugEpochBase::HandleBase {
+  void **Bucket = nullptr;
+  void **End = nullptr;
 
-  LLVM_ABI FoldingSetIteratorImpl(const FoldingSetBase *Set, unsigned Index);
-
-  LLVM_ABI void advance();
-
-  FoldingSetNode *getNode() const {
+  void advance() {
     assert(isHandleInSync() && "invalid iterator access!");
-    return static_cast<FoldingSetNode *>(Set->Buckets[Index]);
+    do
+      ++Bucket;
+    while (Bucket != End && *Bucket == nullptr);
   }
 
 public:
-  bool operator==(const FoldingSetIteratorImpl &RHS) const {
-    assert(isHandleInSync() && RHS.isHandleInSync() && "handle not in sync!");
-    return Set == RHS.Set && Index == RHS.Index;
+  FoldingSetIterator(void **Bucket, void **End, const DebugEpochBase *Epoch)
+      : DebugEpochBase::HandleBase(Epoch), Bucket(Bucket), End(End) {
+    while (this->Bucket != this->End && *this->Bucket == nullptr)
+      ++this->Bucket;
   }
-  bool operator!=(const FoldingSetIteratorImpl &RHS) const {
-    return !(*this == RHS);
+
+  T &operator*() const {
+    assert(isHandleInSync() && "invalid iterator access!");
+    return *static_cast<T *>(*Bucket);
   }
-};
 
-template <class T> class FoldingSetIterator : public FoldingSetIteratorImpl {
-public:
-  explicit FoldingSetIterator(const FoldingSetBase *Set, unsigned Index)
-      : FoldingSetIteratorImpl(Set, Index) {}
-
-  T &operator*() const { return *static_cast<T *>(getNode()); }
-
-  T *operator->() const { return static_cast<T *>(getNode()); }
+  T *operator->() const { return &operator*(); }
 
   inline FoldingSetIterator &operator++() { // Preincrement
     advance();
@@ -677,6 +673,14 @@ public:
     FoldingSetIterator tmp = *this;
     ++*this;
     return tmp;
+  }
+
+  bool operator==(const FoldingSetIterator &RHS) const {
+    assert(isHandleInSync() && RHS.isHandleInSync() && "handle not in sync!");
+    return Bucket == RHS.Bucket;
+  }
+  bool operator!=(const FoldingSetIterator &RHS) const {
+    return !(*this == RHS);
   }
 };
 

--- a/llvm/lib/Support/FoldingSet.cpp
+++ b/llvm/lib/Support/FoldingSet.cpp
@@ -287,20 +287,3 @@ FoldingSetBase::GetOrInsertNode(Node *N, const FoldingSetInfo &Info) {
   InsertNode(N, IP);
   return N;
 }
-
-//===----------------------------------------------------------------------===//
-// FoldingSetIteratorImpl Implementation
-
-FoldingSetIteratorImpl::FoldingSetIteratorImpl(const FoldingSetBase *Set,
-                                               unsigned Index)
-    : DebugEpochBase::HandleBase(Set), Set(Set), Index(Index) {
-  while (this->Index < Set->NumBuckets && !Set->Buckets[this->Index])
-    ++this->Index;
-}
-
-void FoldingSetIteratorImpl::advance() {
-  assert(isHandleInSync() && "invalid iterator access!");
-  do
-    ++Index;
-  while (Index < Set->NumBuckets && !Set->Buckets[Index]);
-}


### PR DESCRIPTION
This patch simplifies FoldingSetIterator by defining it entirely in the
header without the type-erased FoldingSetIteratorImpl.

Now that FoldingSet uses an open-addressing hash table, we just have to
march through the entire bucket array while skipping empty slots.  It
does not make sense to call out-of-line advance().

This also reduces the .text section size of a release build of bin/clang
by 647 bytes (from 185,968,635 to 185,967,988 bytes).

Assisted-by: Antigravity
