### PR TITLE
[alpha.webkit.NoDeleteChecker] Allow a temporary Ref/RefPtr when the result is kept alive

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -987,7 +987,7 @@ public:
 
   bool VisitCXXConstructExpr(const CXXConstructExpr *CE) {
     if (CE->getNumArgs() == 1) {
-      auto* InnerArg = CE->getArg(0);
+      auto *InnerArg = CE->getArg(0);
       if (auto *MTE = dyn_cast<MaterializeTemporaryExpr>(InnerArg)) {
         auto *InnerExpr = MTE->getSubExpr();
         if (auto *BTE = dyn_cast<CXXBindTemporaryExpr>(InnerExpr))

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -971,8 +971,6 @@ public:
       if (Init->getNumInits() == 1)
         Arg = Init->getInit(0);
     }
-    if (auto *ExprWithClean = dyn_cast<ExprWithCleanups>(Arg))
-      Arg = ExprWithClean->getSubExpr()->IgnoreParenCasts();
     if (auto *BTE = dyn_cast<CXXBindTemporaryExpr>(Arg)) {
       // Only elide when the temporary *is* the returned object, i.e. it has the
       // same smart-pointer type as the return value. Compare canonical,
@@ -993,13 +991,11 @@ public:
         if (auto *BTE = dyn_cast<CXXBindTemporaryExpr>(InnerExpr))
           InnerExpr = BTE->getSubExpr();
         auto InnerQT = InnerExpr->getType();
-        if (!InnerQT.isNull()) {
-          if (auto *InnerDecl = InnerQT->getAsCXXRecordDecl()) {
-            auto *OuterCls = CE->getConstructor()->getParent();
-            if (isRefType(safeGetName(OuterCls)) &&
-                isRefType(safeGetName(InnerDecl)))
-              return Visit(InnerExpr);
-          }
+        if (auto *InnerDecl = InnerQT->getAsCXXRecordDecl()) {
+          auto *OuterCls = CE->getConstructor()->getParent();
+          if (isRefType(safeGetName(OuterCls)) &&
+              isRefType(safeGetName(InnerDecl)))
+            return Visit(InnerExpr);
         }
       }
     }

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -967,6 +967,10 @@ public:
     Arg = Arg->IgnoreParenCasts();
     if (!Arg->isPRValue())
       return Visit(Arg);
+    if (auto *Init = dyn_cast<InitListExpr>(Arg)) {
+      if (Init->getNumInits() == 1)
+        Arg = Init->getInit(0);
+    }
     if (auto *ExprWithClean = dyn_cast<ExprWithCleanups>(Arg))
       Arg = ExprWithClean->getSubExpr()->IgnoreParenCasts();
     if (auto *BTE = dyn_cast<CXXBindTemporaryExpr>(Arg)) {
@@ -982,6 +986,24 @@ public:
   }
 
   bool VisitCXXConstructExpr(const CXXConstructExpr *CE) {
+    if (CE->getNumArgs() == 1) {
+      auto* InnerArg = CE->getArg(0);
+      if (auto *MTE = dyn_cast<MaterializeTemporaryExpr>(InnerArg)) {
+        auto *InnerExpr = MTE->getSubExpr();
+        if (auto *BTE = dyn_cast<CXXBindTemporaryExpr>(InnerExpr))
+          InnerExpr = BTE->getSubExpr();
+        auto InnerQT = InnerExpr->getType();
+        if (!InnerQT.isNull()) {
+          if (auto *InnerDecl = InnerQT->getAsCXXRecordDecl()) {
+            auto *OuterCls = CE->getConstructor()->getParent();
+            if (isRefType(safeGetName(OuterCls)) &&
+                isRefType(safeGetName(InnerDecl)))
+              return Visit(InnerExpr);
+          }
+        }
+      }
+    }
+
     for (const Expr *Arg : CE->arguments()) {
       if (Arg && !Visit(Arg))
         return false;

--- a/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
@@ -623,6 +623,42 @@ Ref<RefCountable> [[clang::annotate_type("webkit.nodelete")]] returnClassStatic(
 
 } // namespace copy_elision_edge_cases
 
+namespace return_temp_ref_ptr {
+
+struct RefObj {
+  mutable unsigned m_refCount { 0 };
+  void ref() const { m_refCount++; }
+  void deref() const {
+    m_refCount--;
+    if (!m_refCount)
+      delete const_cast<RefObj*>(this);
+  }
+
+  static Ref<RefObj> create(int) {
+    return adoptRef(*new RefObj);
+  }
+};
+
+Ref<RefObj> [[clang::annotate_type("webkit.nodelete")]] returnRef() {
+  return RefObj::create(0);
+}
+
+Ref<RefObj> [[clang::annotate_type("webkit.nodelete")]] returnRefWithInit() {
+  return { RefObj::create(0) };
+}
+
+RefPtr<RefObj> [[clang::annotate_type("webkit.nodelete")]] returnRefPtrSafe() {
+  return { RefObj::create(0) };
+}
+
+int val();
+RefPtr<RefObj> [[clang::annotate_type("webkit.nodelete")]] returnRefPtrUnsafe() {
+  return { RefObj::create(val()) };
+  // expected-warning@-1{{A function 'returnRefPtrUnsafe' has [[clang::annotate_type("webkit.nodelete")]] but it contains code that could destruct an object}}
+}
+
+} // namespace return_temp_ref_ptr
+
 namespace temp_object_typecheck {
 
 struct Tracked {


### PR DESCRIPTION
Creating a temporary Ref/RefPtr is ordinarily treated as a potentially destructive operation because the destructor could call deref for the last time and destruct the object.

However, when such a temporary Ref/RefPtr is immediately converted to another Ref/RefPtr, such a destruction will never take place and therefore safe.

This PR adds the logic to detect this case when handling CXXConstructExpr and allow it in alpha.webkit.NoDeleteChecker and in other WebKit checkers which check "triviality" of given code.