### PR TITLE
[MCParser] Share AsmLexer's identifier character predicate with AsmParser. NFC

### DIFF
--- a/llvm/include/llvm/MC/MCParser/AsmLexer.h
+++ b/llvm/include/llvm/MC/MCParser/AsmLexer.h
@@ -15,6 +15,7 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/MC/MCAsmMacro.h"
 #include "llvm/Support/Compiler.h"
@@ -201,6 +202,15 @@ public:
                           bool EndStatementAtEOF = true);
 
   const MCAsmInfo &getMAI() const { return MAI; }
+
+  /// Returns true if `C` can continue an identifier. '@', '#' and '?' are
+  /// syntax dependent; a scan of a macro argument name disables all three.
+  static bool isIdentifierChar(char C, bool AllowAt, bool AllowHash,
+                               bool AllowQuestion = true) {
+    return isAlnum(C) || C == '_' || C == '$' || C == '.' ||
+           (AllowQuestion && C == '?') || (AllowAt && C == '@') ||
+           (AllowHash && C == '#');
+  }
 
 private:
   bool isAtStartOfComment(const char *Ptr);

--- a/llvm/lib/MC/MCParser/AsmLexer.cpp
+++ b/llvm/lib/MC/MCParser/AsmLexer.cpp
@@ -229,11 +229,6 @@ AsmToken AsmLexer::LexHexFloatLiteral(bool NoIntDigits) {
 }
 
 /// LexIdentifier: [a-zA-Z_$.@?][a-zA-Z0-9_$.@#?]*
-static bool isIdentifierChar(char C, bool AllowAt, bool AllowHash) {
-  return isAlnum(C) || C == '_' || C == '$' || C == '.' || C == '?' ||
-         (AllowAt && C == '@') || (AllowHash && C == '#');
-}
-
 AsmToken AsmLexer::LexIdentifier() {
   // Check for floating point literals.
   if (CurPtr[-1] == '.' && isDigit(*CurPtr)) {

--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -2459,13 +2459,11 @@ void AsmParser::DiagHandler(const SMDiagnostic &Diag, void *Context) {
     Parser->getContext().diagnose(NewDiag);
 }
 
-// FIXME: This is mostly duplicated from the function in AsmLexer.cpp. The
-// difference being that that function accepts '@' as part of identifiers and
-// we can't do that. AsmLexer.cpp should probably be changed to handle
-// '@' as a special case when needed.
-static bool isIdentifierChar(char c) {
-  return isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '$' ||
-         c == '.';
+// A macro argument name ends at '@', '#' and '?', which are identifier
+// characters elsewhere.
+static bool isMacroArgumentChar(char C) {
+  return AsmLexer::isIdentifierChar(C, /*AllowAt=*/false, /*AllowHash=*/false,
+                                    /*AllowQuestion=*/false);
 }
 
 bool AsmParser::expandMacro(raw_svector_ostream &OS, MCAsmMacro &Macro,
@@ -2519,13 +2517,13 @@ bool AsmParser::expandMacro(raw_svector_ostream &OS, MCAsmMacro &Macro,
         I += 2;
         continue;
       }
-      if (Body[I + 1] == '(' && Body[I + 2] == ')') {
+      if (Body[I + 1] == '(' && I + 2 != End && Body[I + 2] == ')') {
         I += 3;
         continue;
       }
 
       size_t Pos = ++I;
-      while (I != End && isIdentifierChar(Body[I]))
+      while (I != End && isMacroArgumentChar(Body[I]))
         ++I;
       StringRef Argument(Body.data() + Pos, I - Pos);
       if (AltMacroMode && I != End && Body[I] == '&')
@@ -2571,13 +2569,13 @@ bool AsmParser::expandMacro(raw_svector_ostream &OS, MCAsmMacro &Macro,
       }
     }
 
-    if (!isIdentifierChar(Body[I]) || IsDarwin) {
+    if (!isMacroArgumentChar(Body[I]) || IsDarwin) {
       OS << Body[I++];
       continue;
     }
 
     const size_t Start = I;
-    while (++I && isIdentifierChar(Body[I])) {
+    while (++I != End && isMacroArgumentChar(Body[I])) {
     }
     StringRef Token(Body.data() + Start, I - Start);
     if (AltMacroMode) {
@@ -4902,8 +4900,8 @@ void AsmParser::checkForBadMacro(SMLoc DirectiveLoc, StringRef Name,
       }
       Pos += 2;
     } else {
-      unsigned I = Pos + 1;
-      while (isIdentifierChar(Body[I]) && I + 1 != End)
+      std::size_t I = Pos + 1;
+      while (I != End && isMacroArgumentChar(Body[I]))
         ++I;
 
       const char *Begin = Body.data() + Pos + 1;
@@ -4914,7 +4912,7 @@ void AsmParser::checkForBadMacro(SMLoc DirectiveLoc, StringRef Name,
           break;
 
       if (Index == NParameters) {
-        if (Body[Pos + 1] == '(' && Body[Pos + 2] == ')')
+        if (Body[Pos + 1] == '(' && Pos + 2 != End && Body[Pos + 2] == ')')
           Pos += 3;
         else {
           Pos = I;


### PR DESCRIPTION
AsmParser duplicates AsmLexer::isIdentifierChar with a FIXME asking for the
lexer's version to be parameterized instead. Move the predicate to AsmLexer.h,
with a flag per character that is not universally part of an identifier: a
macro argument name ends at '@', '#' and '?', which AsmLexer accepts.

isalnum() in the removed copy is locale sensitive; llvm::isAlnum() is ASCII only.

Also bound the macro body scans, which index Body[I] with I == End for a body
not ending in a newline.
