### PR TITLE
[lsan][llvm-profdata] Suppress leak check on abnormal exit

### DIFF
--- a/llvm/tools/llvm-profdata/llvm-profdata.cpp
+++ b/llvm/tools/llvm-profdata/llvm-profdata.cpp
@@ -54,9 +54,7 @@
 #include <sanitizer/lsan_interface.h>
 static int SkipLeakCheck;
 LLVM_ATTRIBUTE_USED int __lsan_is_turned_off() { return SkipLeakCheck; }
-static void skipLeakCheck() {
-  SkipLeakCheck = 1;
-}
+static void skipLeakCheck() { SkipLeakCheck = 1; }
 #else
 static void skipLeakCheck() {}
 #endif

--- a/llvm/tools/llvm-profdata/llvm-profdata.cpp
+++ b/llvm/tools/llvm-profdata/llvm-profdata.cpp
@@ -50,6 +50,17 @@
 #include <cmath>
 #include <optional>
 
+#if LLVM_ADDRESS_SANITIZER_BUILD || LLVM_HWADDRESS_SANITIZER_BUILD
+#include <sanitizer/lsan_interface.h>
+static int SkipLeakCheck;
+LLVM_ATTRIBUTE_USED int __lsan_is_turned_off() { return SkipLeakCheck; }
+static void skipLeakCheck() {
+  SkipLeakCheck = 1;
+}
+#else
+static void skipLeakCheck() {}
+#endif
+
 using namespace llvm;
 using ProfCorrelatorKind = InstrProfCorrelator::ProfCorrelatorKind;
 
@@ -533,6 +544,10 @@ static void exitWithError(Twine Message, StringRef Whence = "",
   errs() << Message << "\n";
   if (!Hint.empty())
     WithColor::note() << Hint << "\n";
+  // exit() terminates without unwinding the stack or running destructors, and
+  // there is no guaranty that pointers to allocations will be preserved, so
+  // LSan reports in-flight heap allocations as leaks at atexit.
+  skipLeakCheck();
   ::exit(1);
 }
 


### PR DESCRIPTION
This is common issue with lsan after exit().
`exit()` is no return, we can't expect that compiler
will preserve pointers to allocations done by callers.

Fixes new build bot report after upgrading base compiler to clang 23.1.0 https://lab.llvm.org/buildbot/#/builders/169/builds/26007
It probably has improved stack or registers re-use.

