### PR TITLE
[NVPTX] Fix lowering of fabs and fneg

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
@@ -954,16 +954,19 @@ NVPTXTargetLowering::NVPTXTargetLowering(const NVPTXTargetMachine &TM,
     }
   }
 
+  // Lower fneg x to xor x, 0x80... to preserve NaN payloads
+  setOperationAction(ISD::FNEG, {MVT::f32, MVT::f64}, Custom);
+
   // f16/f16x2 neg was introduced in PTX 60, SM_53.
   const bool IsFP16FP16x2NegAvailable = STI.hasFeature(NVPTX::SM53) &&
                                         STI.hasFeature(NVPTX::PTX60) &&
                                         STI.allowFP16Math();
   for (const auto &VT : {MVT::f16, MVT::v2f16})
     setOperationAction(ISD::FNEG, VT,
-                       IsFP16FP16x2NegAvailable ? Legal : Expand);
+                       IsFP16FP16x2NegAvailable ? Custom : Expand);
 
-  setBF16OperationAction(ISD::FNEG, MVT::bf16, Legal, Expand);
-  setBF16OperationAction(ISD::FNEG, MVT::v2bf16, Legal, Expand);
+  setBF16OperationAction(ISD::FNEG, MVT::bf16, Custom, Expand);
+  setBF16OperationAction(ISD::FNEG, MVT::v2bf16, Custom, Expand);
   setOperationAction(ISD::FNEG, MVT::v2f32, Expand);
   // (would be) Library functions.
 
@@ -1064,17 +1067,18 @@ NVPTXTargetLowering::NVPTXTargetLowering(const NVPTXTargetMachine &TM,
   setFP16OperationAction(ISD::FTANH, MVT::v2f16, Legal, Expand);
   setBF16OperationAction(ISD::FTANH, MVT::v2bf16, Legal, Expand);
 
-  setOperationAction(ISD::FABS, {MVT::f32, MVT::f64}, Legal);
+  // Lower fabs x to and x, 0x7f... to preserve NaN payloads
+  setOperationAction(ISD::FABS, {MVT::f32, MVT::f64}, Custom);
   setOperationAction(ISD::FABS, MVT::v2f32, Expand);
   if (STI.hasFeature(NVPTX::PTX65)) {
-    setFP16OperationAction(ISD::FABS, MVT::f16, Legal, Promote);
-    setFP16OperationAction(ISD::FABS, MVT::v2f16, Legal, Expand);
+    setFP16OperationAction(ISD::FABS, MVT::f16, Custom, Promote);
+    setFP16OperationAction(ISD::FABS, MVT::v2f16, Custom, Expand);
   } else {
     setOperationAction(ISD::FABS, MVT::f16, Promote);
     setOperationAction(ISD::FABS, MVT::v2f16, Expand);
   }
-  setBF16OperationAction(ISD::FABS, MVT::v2bf16, Legal, Expand);
-  setBF16OperationAction(ISD::FABS, MVT::bf16, Legal, Promote);
+  setBF16OperationAction(ISD::FABS, MVT::v2bf16, Custom, Expand);
+  setBF16OperationAction(ISD::FABS, MVT::bf16, Custom, Promote);
   if (getOperationAction(ISD::FABS, MVT::bf16) == Promote)
     AddPromotedToType(ISD::FABS, MVT::bf16, MVT::f32);
 
@@ -2242,6 +2246,73 @@ SDValue NVPTXTargetLowering::LowerFCOPYSIGN(SDValue Op,
     return SDValue();
 
   return DAG.getNode(NVPTXISD::FCOPYSIGN, DL, VT, In1, In2);
+}
+
+static bool isCanonicalizingFPOp(unsigned Opc) {
+  switch (Opc) {
+  case ISD::FADD:
+  case ISD::FSUB:
+  case ISD::FMUL:
+  case ISD::FDIV:
+  case ISD::FREM:
+  case ISD::FMA:
+  case ISD::FSQRT:
+  case ISD::FMINNUM:
+  case ISD::FMAXNUM:
+  case ISD::FMINIMUM:
+  case ISD::FMAXIMUM:
+  case ISD::FMINIMUMNUM:
+  case ISD::FMAXIMUMNUM:
+  case ISD::FCEIL:
+  case ISD::FFLOOR:
+  case ISD::FTRUNC:
+  case ISD::FRINT:
+  case ISD::FNEARBYINT:
+  case ISD::FROUNDEVEN:
+  case ISD::FROUND:
+  case ISD::FP_TO_SINT:
+  case ISD::FP_TO_UINT:
+  case ISD::FP_TO_SINT_SAT:
+  case ISD::FP_TO_UINT_SAT:
+  case ISD::FSIN:
+  case ISD::FCOS:
+  case ISD::FTANH:
+  // SETCC is not strictly canonicalizing, just eats the nan
+  case ISD::SETCC:
+    return true;
+  default:
+    return false;
+  }
+}
+
+static bool canUseNativeSignOp(SDValue Op, SelectionDAG &DAG) {
+  // A canonicalizing input is not enough: abs/neg still return an unspecified
+  // NaN for it. Only a non-NaN input makes the native op exact.
+  if (DAG.isKnownNeverNaN(Op.getOperand(0)))
+    return true;
+  return llvm::all_of(Op->users(), [](const SDNode *U) {
+    return isCanonicalizingFPOp(U->getOpcode());
+  });
+}
+
+static SDValue lowerFABSOrFNEG(SDValue Op, SelectionDAG &DAG) {
+  const bool IsNeg = Op.getOpcode() == ISD::FNEG;
+  SDLoc DL(Op);
+  EVT VT = Op.getValueType();
+  SDValue In = Op.getOperand(0);
+
+  if (canUseNativeSignOp(Op, DAG))
+    return DAG.getNode(IsNeg ? NVPTXISD::FNEG : NVPTXISD::FABS, DL, VT, In);
+
+  const unsigned Bits = VT.getSizeInBits();
+  const unsigned EltBits = VT.getScalarSizeInBits();
+  EVT IntVT = EVT::getIntegerVT(*DAG.getContext(), Bits);
+  APInt Mask = APInt::getSplat(Bits, IsNeg ? APInt::getSignMask(EltBits)
+                                           : APInt::getSignedMaxValue(EltBits));
+  SDValue AsInt = DAG.getNode(ISD::BITCAST, DL, IntVT, In);
+  SDValue Masked = DAG.getNode(IsNeg ? ISD::XOR : ISD::AND, DL, IntVT, AsInt,
+                               DAG.getConstant(Mask, DL, IntVT));
+  return DAG.getNode(ISD::BITCAST, DL, VT, Masked);
 }
 
 SDValue NVPTXTargetLowering::LowerFROUND(SDValue Op, SelectionDAG &DAG) const {
@@ -3479,6 +3550,9 @@ NVPTXTargetLowering::LowerOperation(SDValue Op, SelectionDAG &DAG) const {
     return LowerShiftRightParts(Op, DAG);
   case ISD::SELECT:
     return lowerSELECT(Op, DAG);
+  case ISD::FABS:
+  case ISD::FNEG:
+    return lowerFABSOrFNEG(Op, DAG);
   case ISD::FROUND:
     return LowerFROUND(Op, DAG);
   case ISD::FCOPYSIGN:

--- a/llvm/lib/Target/NVPTX/NVPTXInstrInfo.td
+++ b/llvm/lib/Target/NVPTX/NVPTXInstrInfo.td
@@ -259,6 +259,17 @@ def fpimm_1 : FPImmLeaf<fAny, [{ return Imm.isOne(); }]>;
 def fpimm_neg_1 : FPImmLeaf<fAny, [{ return Imm.isMinusOne(); }]>;
 
 
+// For lowering to ptx native abs/neg
+def nvptx_fabs : SDNode<"NVPTXISD::FABS", SDTFPUnaryOp>;
+def nvptx_fneg : SDNode<"NVPTXISD::FNEG", SDTFPUnaryOp>;
+
+// LowerFNEG emits either of these, so folds of a negated operand match both.
+class fneg_xor<ValueType vt, ValueType ivt, int signmask> :
+  PatFrag<(ops node:$a), (vt (bitconvert (xor node:$a, (ivt signmask))))>;
+def fneg_xor_f32 : fneg_xor<f32, i32, -2147483648>;
+def fneg_xor_f64 : fneg_xor<f64, i64, -9223372036854775808>;
+
+
 // Operands which can hold a Register or an Immediate.
 //
 // Unfortunately, since most register classes can hold multiple types, we must
@@ -1011,7 +1022,7 @@ def : Pat<(vt (select i1:$p, vt:$a, vt:$b)),
 // Test Instructions
 //-----------------------------------
 
-def fabs_oneuse : OneUse1<fabs>;
+def fabs_oneuse : OneUse1<nvptx_fabs>;
 
 def TESTINF_f32r : BasicNVPTXInst<(outs B1:$p), (ins B32:$a),
                              "testp.infinite.f32",
@@ -1197,10 +1208,10 @@ defm FMAX3 : FMINIMUMMAXIMUM3<"max", /* NaN */ false, nvptx_fmaxnum3>;
 defm FMINNAN3 : FMINIMUMMAXIMUM3<"min", /* NaN */ true, nvptx_fminimum3>;
 defm FMAXNAN3 : FMINIMUMMAXIMUM3<"max", /* NaN */ true, nvptx_fmaximum3>;
 
-defm FABS  : F2<"abs", fabs>;
-defm FNEG  : F2<"neg", fneg>;
-defm FABS_H: F2_Support_Half<"abs", fabs>;
-defm FNEG_H: F2_Support_Half<"neg", fneg>;
+defm FABS  : F2<"abs", nvptx_fabs>;
+defm FNEG  : F2<"neg", nvptx_fneg>;
+defm FABS_H: F2_Support_Half<"abs", nvptx_fabs>;
+defm FNEG_H: F2_Support_Half<"neg", nvptx_fneg>;
 
 defm FSQRT : F2<"sqrt.rn", fsqrt>;
 
@@ -1210,8 +1221,10 @@ defm FSQRT : F2<"sqrt.rn", fsqrt>;
 class FNEG16<RegTyInfo t> :
       BasicFlagsNVPTXInst<(outs t.RC:$dst), (ins t.RC:$src), (ins FTZFlag:$ftz),
                 "neg$ftz." # t.PtxType,
-                [(set t.Ty:$dst, (fneg t.Ty:$src))]>;
+                [(set t.Ty:$dst, (nvptx_fneg t.Ty:$src))]>;
 
+// These (PTX60) cover the full f16/f16x2 FNEG custom range, unlike FNEG_Hf16
+// and FNEG_Hf16x2 which require PTX65.
 let Predicates = [allowFP16Math, PTX60, SM53] in {
   def NEG_F16    : FNEG16<F16RT>;
   def NEG_F16x2  : FNEG16<F16X2RT>;

--- a/llvm/lib/Target/NVPTX/NVPTXIntrinsics.td
+++ b/llvm/lib/Target/NVPTX/NVPTXIntrinsics.td
@@ -2332,7 +2332,10 @@ foreach rnd = ["_rn", "_rz", "_rm", "_rp"] in {
       def INT_NVVM_SUB # rnd # ftz # sat # _F : 
         BasicNVPTXInst<(outs B32:$dst), (ins B32:$a, B32:$b),
           !subst("_", ".", "sub" # rnd # sat # ftz # "_f32"),
-          [(set f32:$dst, (add_intrin f32:$a, (f32 (fneg f32:$b))))]>;
+          [(set f32:$dst, (add_intrin f32:$a, (f32 (nvptx_fneg f32:$b))))]>;
+      def : Pat<(add_intrin f32:$a, (fneg_xor_f32 B32:$b)),
+                (!cast<NVPTXInst>("INT_NVVM_SUB" # rnd # ftz # sat # "_F")
+                  $a, $b)>;
     }
   }
   
@@ -2340,7 +2343,9 @@ foreach rnd = ["_rn", "_rz", "_rm", "_rp"] in {
   def INT_NVVM_SUB # rnd # _D : 
     BasicNVPTXInst<(outs B64:$dst), (ins B64:$a, B64:$b),
       !subst("_", ".", "sub" # rnd # "_f64"),
-      [(set f64:$dst, (add_intrin f64:$a, (f64 (fneg f64:$b))))]>;
+      [(set f64:$dst, (add_intrin f64:$a, (f64 (nvptx_fneg f64:$b))))]>;
+  def : Pat<(add_intrin f64:$a, (fneg_xor_f64 B64:$b)),
+            (!cast<NVPTXInst>("INT_NVVM_SUB" # rnd # "_D") $a, $b)>;
 }
 
 foreach rnd = ["_rn", "_rz", "_rm", "_rp"] in {
@@ -2352,7 +2357,12 @@ foreach rnd = ["_rn", "_rz", "_rm", "_rp"] in {
           [(set f32:$dst, 
            (!cast<Intrinsic>("int_nvvm_add" # rnd # sat # "_f") 
              (f32 (fpextend type:$a)),
-             (f32 (fneg f32:$b))))]>,
+             (f32 (nvptx_fneg f32:$b))))]>,
+        Requires<[SM100]>;
+      def : Pat<(!cast<Intrinsic>("int_nvvm_add" # rnd # sat # "_f")
+                  (f32 (fpextend type:$a)), (fneg_xor_f32 B32:$b)),
+                (!cast<NVPTXInst>("INT_NVVM_MIXED_SUB" # rnd # sat #
+                                  "_f32_" # type) $a, $b)>,
         Requires<[SM100]>;
     }
   }

--- a/llvm/test/CodeGen/NVPTX/bf16-neg-noftz.ll
+++ b/llvm/test/CodeGen/NVPTX/bf16-neg-noftz.ll
@@ -1,24 +1,42 @@
 ; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_80 -mattr=+ptx70 -denormal-fp-math-f32=preserve-sign | FileCheck %s
 ; RUN: %if ptxas-sm_80 && ptxas-isa-7.0 %{ llc < %s -mtriple=nvptx64 -mcpu=sm_80 -mattr=+ptx70 -denormal-fp-math-f32=preserve-sign | %ptxas-verify -arch=sm_80 %}
 
-; Check for working ftz on f16 to be sure
+; fneg whose result is observed as raw bits (returned) expands to a sign-bit
+; XOR to preserve NaN payloads rather than using native neg.
 define half @neg_f16_ftz(half %a) {
 ; CHECK-LABEL: neg_f16_ftz
-; CHECK: neg.ftz.f16
+; CHECK: xor.b16 {{.*}}, -32768
   %r = fneg half %a
   ret half %r
 }
 
 define bfloat @neg_bf16_no_ftz(bfloat %a) {
 ; CHECK-LABEL: neg_bf16_no_ftz
-; CHECK: neg.bf16
+; CHECK: xor.b16 {{.*}}, -32768
   %r = fneg bfloat %a
   ret bfloat %r
 }
 
 define <2 x bfloat> @neg_bf16x2_no_ftz(<2 x bfloat> %a) {
 ; CHECK-LABEL: neg_bf16x2_no_ftz
-; CHECK: neg.bf16x2
+; CHECK: xor.b32 {{.*}}, -2147450880
   %r = fneg <2 x bfloat> %a
   ret <2 x bfloat> %r
+}
+
+; Check for working ftz on f16 to be sure
+define half @neg_fma_f16_ftz(half %a, half %b, half %c) {
+; CHECK-LABEL: neg_fma_f16_ftz
+; CHECK: neg.ftz.f16
+  %n = fneg half %a
+  %r = call half @llvm.fma.f16(half %n, half %b, half %c)
+  ret half %r
+}
+
+define bfloat @neg_fma_bf16_no_ftz(bfloat %a, bfloat %b, bfloat %c) {
+; CHECK-LABEL: neg_fma_bf16_no_ftz
+; CHECK: neg.bf16
+  %n = fneg bfloat %a
+  %r = call bfloat @llvm.fma.bf16(bfloat %n, bfloat %b, bfloat %c)
+  ret bfloat %r
 }

--- a/llvm/test/CodeGen/NVPTX/bf16x2-instructions.ll
+++ b/llvm/test/CodeGen/NVPTX/bf16x2-instructions.ll
@@ -153,7 +153,7 @@ define <2 x bfloat> @test_fneg(<2 x bfloat> %a) #0 {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    ld.param.b32 %r1, [test_fneg_param_0];
-; CHECK-NEXT:    neg.bf16x2 %r2, %r1;
+; CHECK-NEXT:    xor.b32 %r2, %r1, -2147450880;
 ; CHECK-NEXT:    st.param.b32 [func_retval0], %r2;
 ; CHECK-NEXT:    ret;
   %r = fneg <2 x bfloat> %a
@@ -478,7 +478,7 @@ define <2 x bfloat> @test_fabs(<2 x bfloat> %a) #0 {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    ld.param.b32 %r1, [test_fabs_param_0];
-; CHECK-NEXT:    abs.bf16x2 %r2, %r1;
+; CHECK-NEXT:    and.b32 %r2, %r1, 2147450879;
 ; CHECK-NEXT:    st.param.b32 [func_retval0], %r2;
 ; CHECK-NEXT:    ret;
   %r = call <2 x bfloat> @llvm.fabs.f16(<2 x bfloat> %a)

--- a/llvm/test/CodeGen/NVPTX/copysign.ll
+++ b/llvm/test/CodeGen/NVPTX/copysign.ll
@@ -44,8 +44,8 @@ define float @fcopysign_f_d(float %a, double %b) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    ld.param.b32 %r1, [fcopysign_f_d_param_0];
-; CHECK-NEXT:    abs.f32 %r2, %r1;
-; CHECK-NEXT:    neg.f32 %r3, %r2;
+; CHECK-NEXT:    and.b32 %r2, %r1, 2147483647;
+; CHECK-NEXT:    or.b32 %r3, %r1, -2147483648;
 ; CHECK-NEXT:    ld.param.b64 %rd1, [fcopysign_f_d_param_1];
 ; CHECK-NEXT:    shr.u64 %rd2, %rd1, 63;
 ; CHECK-NEXT:    and.b64 %rd3, %rd2, 1;
@@ -67,8 +67,8 @@ define float @fcopysign_f_h(float %a, half %b) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    ld.param.b32 %r1, [fcopysign_f_h_param_0];
-; CHECK-NEXT:    abs.f32 %r2, %r1;
-; CHECK-NEXT:    neg.f32 %r3, %r2;
+; CHECK-NEXT:    and.b32 %r2, %r1, 2147483647;
+; CHECK-NEXT:    or.b32 %r3, %r1, -2147483648;
 ; CHECK-NEXT:    ld.param.b16 %rs1, [fcopysign_f_h_param_1];
 ; CHECK-NEXT:    shr.u16 %rs2, %rs1, 15;
 ; CHECK-NEXT:    and.b16 %rs3, %rs2, 1;
@@ -90,8 +90,8 @@ define double @fcopysign_d_f(double %a, float %b) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    ld.param.b64 %rd1, [fcopysign_d_f_param_0];
-; CHECK-NEXT:    abs.f64 %rd2, %rd1;
-; CHECK-NEXT:    neg.f64 %rd3, %rd2;
+; CHECK-NEXT:    and.b64 %rd2, %rd1, 9223372036854775807;
+; CHECK-NEXT:    or.b64 %rd3, %rd1, -9223372036854775808;
 ; CHECK-NEXT:    ld.param.b32 %r1, [fcopysign_d_f_param_1];
 ; CHECK-NEXT:    shr.u32 %r2, %r1, 31;
 ; CHECK-NEXT:    and.b32 %r3, %r2, 1;
@@ -113,8 +113,8 @@ define double @fcopysign_d_h(double %a, half %b) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    ld.param.b64 %rd1, [fcopysign_d_h_param_0];
-; CHECK-NEXT:    abs.f64 %rd2, %rd1;
-; CHECK-NEXT:    neg.f64 %rd3, %rd2;
+; CHECK-NEXT:    and.b64 %rd2, %rd1, 9223372036854775807;
+; CHECK-NEXT:    or.b64 %rd3, %rd1, -9223372036854775808;
 ; CHECK-NEXT:    ld.param.b16 %rs1, [fcopysign_d_h_param_1];
 ; CHECK-NEXT:    shr.u16 %rs2, %rs1, 15;
 ; CHECK-NEXT:    and.b16 %rs3, %rs2, 1;

--- a/llvm/test/CodeGen/NVPTX/f16-abs.ll
+++ b/llvm/test/CodeGen/NVPTX/f16-abs.ll
@@ -54,7 +54,7 @@ define half @test_fabs(half %a) {
 ; CHECK-NOF16-NEXT:  // %bb.0:
 ; CHECK-NOF16-NEXT:    ld.param.b16 %rs1, [test_fabs_param_0];
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %r1, %rs1;
-; CHECK-NOF16-NEXT:    abs.f32 %r2, %r1;
+; CHECK-NOF16-NEXT:    and.b32 %r2, %r1, 2147483647;
 ; CHECK-NOF16-NEXT:    cvt.rn.f16.f32 %rs2, %r2;
 ; CHECK-NOF16-NEXT:    st.param.b16 [func_retval0], %rs2;
 ; CHECK-NOF16-NEXT:    ret;
@@ -65,7 +65,7 @@ define half @test_fabs(half %a) {
 ; CHECK-F16-ABS-EMPTY:
 ; CHECK-F16-ABS-NEXT:  // %bb.0:
 ; CHECK-F16-ABS-NEXT:    ld.param.b16 %rs1, [test_fabs_param_0];
-; CHECK-F16-ABS-NEXT:    abs.f16 %rs2, %rs1;
+; CHECK-F16-ABS-NEXT:    and.b16 %rs2, %rs1, 32767;
 ; CHECK-F16-ABS-NEXT:    st.param.b16 [func_retval0], %rs2;
 ; CHECK-F16-ABS-NEXT:    ret;
   %r = call half @llvm.fabs.f16(half %a)
@@ -83,13 +83,23 @@ define <2 x half> @test_fabs_2(<2 x half> %a) #0 {
 ; CHECK-F16-NEXT:    st.param.b32 [func_retval0], %r3;
 ; CHECK-F16-NEXT:    ret;
 ;
+; CHECK-NOF16-LABEL: test_fabs_2(
+; CHECK-NOF16:       {
+; CHECK-NOF16-NEXT:    .reg .b32 %r<3>;
+; CHECK-NOF16-EMPTY:
+; CHECK-NOF16-NEXT:  // %bb.0:
+; CHECK-NOF16-NEXT:    ld.param.b32 %r1, [test_fabs_2_param_0];
+; CHECK-NOF16-NEXT:    and.b32 %r2, %r1, 2147450879;
+; CHECK-NOF16-NEXT:    st.param.b32 [func_retval0], %r2;
+; CHECK-NOF16-NEXT:    ret;
+;
 ; CHECK-F16-ABS-LABEL: test_fabs_2(
 ; CHECK-F16-ABS:       {
 ; CHECK-F16-ABS-NEXT:    .reg .b32 %r<3>;
 ; CHECK-F16-ABS-EMPTY:
 ; CHECK-F16-ABS-NEXT:  // %bb.0:
 ; CHECK-F16-ABS-NEXT:    ld.param.b32 %r1, [test_fabs_2_param_0];
-; CHECK-F16-ABS-NEXT:    abs.f16x2 %r2, %r1;
+; CHECK-F16-ABS-NEXT:    and.b32 %r2, %r1, 2147450879;
 ; CHECK-F16-ABS-NEXT:    st.param.b32 [func_retval0], %r2;
 ; CHECK-F16-ABS-NEXT:    ret;
   %r = call <2 x half> @llvm.fabs.v2f16(<2 x half> %a)

--- a/llvm/test/CodeGen/NVPTX/f16-instructions.ll
+++ b/llvm/test/CodeGen/NVPTX/f16-instructions.ll
@@ -150,9 +150,7 @@ define half @test_old_fneg(half %a) #0 {
 
 ; CHECK-LABEL: test_fneg(
 ; CHECK:  ld.param.b16    [[A:%rs[0-9]+]], [test_fneg_param_0];
-; CHECK-F16-NOFTZ-NEXT:   neg.f16     [[R:%rs[0-9]+]], [[A]];
-; CHECK-F16-FTZ-NEXT:   neg.ftz.f16     [[R:%rs[0-9]+]], [[A]];
-; CHECK-NOF16-NEXT:  xor.b16    [[R:%rs[0-9]+]], [[A]], -32768;
+; CHECK-NEXT:  xor.b16    [[R:%rs[0-9]+]], [[A]], -32768;
 ; CHECK-NEXT: st.param.b16    [func_retval0], [[R]];
 ; CHECK-NEXT: ret;
 define half @test_fneg(half %a) #0 {
@@ -969,9 +967,8 @@ define half @test_fma(half %a, half %b, half %c) #0 {
 ; CHECK-LABEL: test_fabs(
 ; CHECK:      ld.param.b16    [[A:%rs[0-9]+]], [test_fabs_param_0];
 ; CHECK-NOFTZ:      cvt.f32.f16     [[AF:%r[0-9]+]], [[A]];
-; CHECK-NOFTZ:      abs.f32         [[RF:%r[0-9]+]], [[AF]];
 ; CHECK-F16-FTZ:      cvt.ftz.f32.f16     [[AF:%r[0-9]+]], [[A]];
-; CHECK-F16-FTZ:      abs.ftz.f32         [[RF:%r[0-9]+]], [[AF]];
+; CHECK:      and.b32         [[RF:%r[0-9]+]], [[AF]], 2147483647;
 ; CHECK:      cvt.rn.f16.f32  [[R:%rs[0-9]+]], [[RF]];
 ; CHECK:      st.param.b16    [func_retval0], [[R]];
 ; CHECK:      ret;
@@ -1165,18 +1162,14 @@ define half @test_fmuladd(half %a, half %b, half %c) #0 {
 }
 
 ; CHECK-LABEL: test_neg_f16(
-; CHECK-F16-NOFTZ: neg.f16
-; CHECK-F16-FTZ: neg.ftz.f16
-; CHECK-NOF16: xor.b16  	%rs{{.*}}, %rs{{.*}}, -32768
+; CHECK: xor.b16  	%rs{{.*}}, %rs{{.*}}, -32768
 define half @test_neg_f16(half noundef %arg) #0 {
   %res = fneg half %arg
   ret half %res
 }
 
 ; CHECK-LABEL: test_neg_f16x2(
-; CHECK-F16-NOFTZ: neg.f16x2
-; CHECK-F16-FTZ: neg.ftz.f16x2
-; CHECK-NOF16: xor.b32 %r{{.*}}, %r{{.*}}, -2147450880
+; CHECK: xor.b32 %r{{.*}}, %r{{.*}}, -2147450880
 define <2 x half> @test_neg_f16x2(<2 x half> noundef %arg) #0 {
   %res = fneg <2 x half> %arg
   ret <2 x half> %res

--- a/llvm/test/CodeGen/NVPTX/f32x2-instructions.ll
+++ b/llvm/test/CodeGen/NVPTX/f32x2-instructions.ll
@@ -341,8 +341,8 @@ define <2 x float> @test_fneg(<2 x float> %a) #0 {
 ; CHECK-NOF32X2-EMPTY:
 ; CHECK-NOF32X2-NEXT:  // %bb.0:
 ; CHECK-NOF32X2-NEXT:    ld.param.v2.b32 {%r1, %r2}, [test_fneg_param_0];
-; CHECK-NOF32X2-NEXT:    neg.f32 %r3, %r2;
-; CHECK-NOF32X2-NEXT:    neg.f32 %r4, %r1;
+; CHECK-NOF32X2-NEXT:    xor.b32 %r3, %r2, -2147483648;
+; CHECK-NOF32X2-NEXT:    xor.b32 %r4, %r1, -2147483648;
 ; CHECK-NOF32X2-NEXT:    st.param.v2.b32 [func_retval0], {%r4, %r3};
 ; CHECK-NOF32X2-NEXT:    ret;
 ;
@@ -354,8 +354,8 @@ define <2 x float> @test_fneg(<2 x float> %a) #0 {
 ; CHECK-F32X2-NEXT:  // %bb.0:
 ; CHECK-F32X2-NEXT:    ld.param::func.b64 %rd1, [test_fneg_param_0];
 ; CHECK-F32X2-NEXT:    mov.b64 {%r1, %r2}, %rd1;
-; CHECK-F32X2-NEXT:    neg.f32 %r3, %r2;
-; CHECK-F32X2-NEXT:    neg.f32 %r4, %r1;
+; CHECK-F32X2-NEXT:    xor.b32 %r3, %r2, -2147483648;
+; CHECK-F32X2-NEXT:    xor.b32 %r4, %r1, -2147483648;
 ; CHECK-F32X2-NEXT:    st.param::func.v2.b32 [func_retval0], {%r4, %r3};
 ; CHECK-F32X2-NEXT:    ret;
   %r = fneg <2 x float> %a
@@ -692,8 +692,8 @@ define <2 x float> @test_fneg_ftz(<2 x float> %a) #2 {
 ; CHECK-NOF32X2-EMPTY:
 ; CHECK-NOF32X2-NEXT:  // %bb.0:
 ; CHECK-NOF32X2-NEXT:    ld.param.v2.b32 {%r1, %r2}, [test_fneg_ftz_param_0];
-; CHECK-NOF32X2-NEXT:    neg.ftz.f32 %r3, %r2;
-; CHECK-NOF32X2-NEXT:    neg.ftz.f32 %r4, %r1;
+; CHECK-NOF32X2-NEXT:    xor.b32 %r3, %r2, -2147483648;
+; CHECK-NOF32X2-NEXT:    xor.b32 %r4, %r1, -2147483648;
 ; CHECK-NOF32X2-NEXT:    st.param.v2.b32 [func_retval0], {%r4, %r3};
 ; CHECK-NOF32X2-NEXT:    ret;
 ;
@@ -705,8 +705,8 @@ define <2 x float> @test_fneg_ftz(<2 x float> %a) #2 {
 ; CHECK-F32X2-NEXT:  // %bb.0:
 ; CHECK-F32X2-NEXT:    ld.param::func.b64 %rd1, [test_fneg_ftz_param_0];
 ; CHECK-F32X2-NEXT:    mov.b64 {%r1, %r2}, %rd1;
-; CHECK-F32X2-NEXT:    neg.ftz.f32 %r3, %r2;
-; CHECK-F32X2-NEXT:    neg.ftz.f32 %r4, %r1;
+; CHECK-F32X2-NEXT:    xor.b32 %r3, %r2, -2147483648;
+; CHECK-F32X2-NEXT:    xor.b32 %r4, %r1, -2147483648;
 ; CHECK-F32X2-NEXT:    st.param::func.v2.b32 [func_retval0], {%r4, %r3};
 ; CHECK-F32X2-NEXT:    ret;
   %r = fneg <2 x float> %a
@@ -2420,8 +2420,8 @@ define <2 x float> @test_fabs(<2 x float> %a) #0 {
 ; CHECK-NOF32X2-EMPTY:
 ; CHECK-NOF32X2-NEXT:  // %bb.0:
 ; CHECK-NOF32X2-NEXT:    ld.param.v2.b32 {%r1, %r2}, [test_fabs_param_0];
-; CHECK-NOF32X2-NEXT:    abs.f32 %r3, %r2;
-; CHECK-NOF32X2-NEXT:    abs.f32 %r4, %r1;
+; CHECK-NOF32X2-NEXT:    and.b32 %r3, %r2, 2147483647;
+; CHECK-NOF32X2-NEXT:    and.b32 %r4, %r1, 2147483647;
 ; CHECK-NOF32X2-NEXT:    st.param.v2.b32 [func_retval0], {%r4, %r3};
 ; CHECK-NOF32X2-NEXT:    ret;
 ;
@@ -2433,8 +2433,8 @@ define <2 x float> @test_fabs(<2 x float> %a) #0 {
 ; CHECK-F32X2-NEXT:  // %bb.0:
 ; CHECK-F32X2-NEXT:    ld.param::func.b64 %rd1, [test_fabs_param_0];
 ; CHECK-F32X2-NEXT:    mov.b64 {%r1, %r2}, %rd1;
-; CHECK-F32X2-NEXT:    abs.f32 %r3, %r2;
-; CHECK-F32X2-NEXT:    abs.f32 %r4, %r1;
+; CHECK-F32X2-NEXT:    and.b32 %r3, %r2, 2147483647;
+; CHECK-F32X2-NEXT:    and.b32 %r4, %r1, 2147483647;
 ; CHECK-F32X2-NEXT:    st.param::func.v2.b32 [func_retval0], {%r4, %r3};
 ; CHECK-F32X2-NEXT:    ret;
   %r = call <2 x float> @llvm.fabs(<2 x float> %a)
@@ -2544,14 +2544,14 @@ define <2 x float> @test_copysign_f64(<2 x float> %a, <2 x double> %b) #0 {
 ; CHECK-NOF32X2-NEXT:  // %bb.0:
 ; CHECK-NOF32X2-NEXT:    ld.param.v2.b64 {%rd1, %rd2}, [test_copysign_f64_param_1];
 ; CHECK-NOF32X2-NEXT:    ld.param.v2.b32 {%r1, %r2}, [test_copysign_f64_param_0];
-; CHECK-NOF32X2-NEXT:    abs.f32 %r3, %r2;
-; CHECK-NOF32X2-NEXT:    neg.f32 %r4, %r3;
+; CHECK-NOF32X2-NEXT:    and.b32 %r3, %r2, 2147483647;
+; CHECK-NOF32X2-NEXT:    or.b32 %r4, %r2, -2147483648;
 ; CHECK-NOF32X2-NEXT:    shr.u64 %rd3, %rd2, 63;
 ; CHECK-NOF32X2-NEXT:    and.b64 %rd4, %rd3, 1;
 ; CHECK-NOF32X2-NEXT:    setp.ne.b64 %p1, %rd4, 0;
 ; CHECK-NOF32X2-NEXT:    selp.f32 %r5, %r4, %r3, %p1;
-; CHECK-NOF32X2-NEXT:    abs.f32 %r6, %r1;
-; CHECK-NOF32X2-NEXT:    neg.f32 %r7, %r6;
+; CHECK-NOF32X2-NEXT:    and.b32 %r6, %r1, 2147483647;
+; CHECK-NOF32X2-NEXT:    or.b32 %r7, %r1, -2147483648;
 ; CHECK-NOF32X2-NEXT:    shr.u64 %rd5, %rd1, 63;
 ; CHECK-NOF32X2-NEXT:    and.b64 %rd6, %rd5, 1;
 ; CHECK-NOF32X2-NEXT:    setp.ne.b64 %p2, %rd6, 0;
@@ -2568,18 +2568,18 @@ define <2 x float> @test_copysign_f64(<2 x float> %a, <2 x double> %b) #0 {
 ; CHECK-F32X2-NEXT:  // %bb.0:
 ; CHECK-F32X2-NEXT:    ld.param::func.v2.b64 {%rd2, %rd3}, [test_copysign_f64_param_1];
 ; CHECK-F32X2-NEXT:    ld.param::func.b64 %rd1, [test_copysign_f64_param_0];
+; CHECK-F32X2-NEXT:    mov.b64 {%r1, %r2}, %rd1;
+; CHECK-F32X2-NEXT:    and.b32 %r3, %r2, 2147483647;
+; CHECK-F32X2-NEXT:    or.b32 %r4, %r2, -2147483648;
 ; CHECK-F32X2-NEXT:    shr.u64 %rd4, %rd3, 63;
 ; CHECK-F32X2-NEXT:    and.b64 %rd5, %rd4, 1;
 ; CHECK-F32X2-NEXT:    setp.ne.b64 %p1, %rd5, 0;
-; CHECK-F32X2-NEXT:    mov.b64 {%r1, %r2}, %rd1;
-; CHECK-F32X2-NEXT:    abs.f32 %r3, %r2;
-; CHECK-F32X2-NEXT:    neg.f32 %r4, %r3;
 ; CHECK-F32X2-NEXT:    selp.f32 %r5, %r4, %r3, %p1;
+; CHECK-F32X2-NEXT:    and.b32 %r6, %r1, 2147483647;
+; CHECK-F32X2-NEXT:    or.b32 %r7, %r1, -2147483648;
 ; CHECK-F32X2-NEXT:    shr.u64 %rd6, %rd2, 63;
 ; CHECK-F32X2-NEXT:    and.b64 %rd7, %rd6, 1;
 ; CHECK-F32X2-NEXT:    setp.ne.b64 %p2, %rd7, 0;
-; CHECK-F32X2-NEXT:    abs.f32 %r6, %r1;
-; CHECK-F32X2-NEXT:    neg.f32 %r7, %r6;
 ; CHECK-F32X2-NEXT:    selp.f32 %r8, %r7, %r6, %p2;
 ; CHECK-F32X2-NEXT:    st.param::func.v2.b32 [func_retval0], {%r8, %r5};
 ; CHECK-F32X2-NEXT:    ret;

--- a/llvm/test/CodeGen/NVPTX/fabs-fneg-nan-payload.ll
+++ b/llvm/test/CodeGen/NVPTX/fabs-fneg-nan-payload.ll
@@ -1,0 +1,246 @@
+; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_60 | FileCheck %s
+; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_53 -mattr=+ptx65 | FileCheck %s --check-prefix=CHECK-F16
+; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_80 -mattr=+ptx70 | FileCheck %s --check-prefix=CHECK-BF16
+
+; fneg with bitcast (non-canonicalizing) user -> xor (expanded)
+; CHECK-LABEL: test_fneg_bitcast(
+define i32 @test_fneg_bitcast(float %a) {
+; CHECK: xor.b32
+  %neg = fneg float %a
+  %b = bitcast float %neg to i32
+  ret i32 %b
+}
+
+; fneg with canonicalizing user (fadd) -> folds into the sub
+; CHECK-LABEL: test_fneg_canon(
+define float @test_fneg_canon(float %a, float %b) {
+; CHECK: sub.rn.f32
+; CHECK-NOT: xor.b32
+  %neg = fneg float %a
+  %r = fadd float %neg, %b
+  ret float %r
+}
+
+; fneg with canonicalized input (may still be a NaN) -> xor (expanded)
+; CHECK-LABEL: test_fneg_canon_input(
+define float @test_fneg_canon_input(float %a, float %b) {
+; CHECK: xor.b32
+; CHECK-NOT: neg.f32
+  %add = fadd float %a, %b
+  %neg = fneg float %add
+  ret float %neg
+}
+
+; fneg f64 with canonicalizing user -> folds into the sub
+; CHECK-LABEL: test_fneg_f64_canon(
+define double @test_fneg_f64_canon(double %a, double %b) {
+; CHECK: sub.rn.f64
+; CHECK-NOT: xor.b64
+  %neg = fneg double %a
+  %r = fadd double %neg, %b
+  ret double %r
+}
+
+; fneg f64 with bitcast (non-canonicalizing) user -> xor (expanded)
+; CHECK-LABEL: test_fneg_f64_bitcast(
+define i64 @test_fneg_f64_bitcast(double %a) {
+; CHECK: xor.b64
+  %neg = fneg double %a
+  %b = bitcast double %neg to i64
+  ret i64 %b
+}
+
+; fneg with mixed users (fadd + bitcast) -> xor (conservative)
+; CHECK-LABEL: test_fneg_mixed(
+define {i32, float} @test_fneg_mixed(float %a, float %b) {
+; CHECK: xor.b32
+; CHECK-NOT: neg.f32
+  %neg = fneg float %a
+  %cast = bitcast float %neg to i32
+  %add = fadd float %neg, %b
+  %r0 = insertvalue {i32, float} poison, i32 %cast, 0
+  %r1 = insertvalue {i32, float} %r0, float %add, 1
+  ret {i32, float} %r1
+}
+
+; fabs with bitcast (non-canonicalizing) user -> and (expanded)
+; CHECK-LABEL: test_fabs_bitcast(
+define i32 @test_fabs_bitcast(float %a) {
+; CHECK: and.b32
+; CHECK-NOT: abs.f32
+  %abs = call float @llvm.fabs.f32(float %a)
+  %b = bitcast float %abs to i32
+  ret i32 %b
+}
+
+; fabs with canonicalizing user (fadd) -> native abs
+; CHECK-LABEL: test_fabs_canon(
+define float @test_fabs_canon(float %a, float %b) {
+; CHECK: abs.f32
+; CHECK-NOT: and.b32
+  %abs = call float @llvm.fabs.f32(float %a)
+  %r = fadd float %abs, %b
+  ret float %r
+}
+
+; fabs with canonicalized input (may still be a NaN) -> and (expanded)
+; CHECK-LABEL: test_fabs_canon_input(
+define float @test_fabs_canon_input(float %a, float %b) {
+; CHECK: and.b32
+; CHECK-NOT: abs.f32
+  %add = fadd float %a, %b
+  %abs = call float @llvm.fabs.f32(float %add)
+  ret float %abs
+}
+
+; fabs with setcc (canonicalizing) user -> native abs
+; CHECK-LABEL: test_fabs_cmp(
+define i1 @test_fabs_cmp(float %a) {
+; CHECK: abs.f32
+; CHECK-NOT: and.b32
+  %abs = call float @llvm.fabs.f32(float %a)
+  %r = fcmp olt float %abs, 1.0
+  ret i1 %r
+}
+
+; fabs with mixed users (fadd + bitcast) -> and (conservative)
+; CHECK-LABEL: test_fabs_mixed(
+define {i32, float} @test_fabs_mixed(float %a, float %b) {
+; CHECK: and.b32
+; CHECK-NOT: abs.f32
+  %abs = call float @llvm.fabs.f32(float %a)
+  %cast = bitcast float %abs to i32
+  %add = fadd float %abs, %b
+  %r0 = insertvalue {i32, float} poison, i32 %cast, 0
+  %r1 = insertvalue {i32, float} %r0, float %add, 1
+  ret {i32, float} %r1
+}
+
+; fabs f64 with canonicalizing user -> native abs
+; CHECK-LABEL: test_fabs_f64_canon(
+define double @test_fabs_f64_canon(double %a, double %b) {
+; CHECK: abs.f64
+; CHECK-NOT: and.b64
+  %abs = call double @llvm.fabs.f64(double %a)
+  %r = fadd double %abs, %b
+  ret double %r
+}
+
+; fabs f64 with non-canonicalizing user -> and (expanded)
+; CHECK-LABEL: test_fabs_f64_bitcast(
+define i64 @test_fabs_f64_bitcast(double %a) {
+; CHECK: and.b64
+; CHECK-NOT: abs.f64
+  %abs = call double @llvm.fabs.f64(double %a)
+  %b = bitcast double %abs to i64
+  ret i64 %b
+}
+
+; f16 fabs with canonicalizing user -> native abs
+; CHECK-F16-LABEL: test_fabs_f16_canon(
+define half @test_fabs_f16_canon(half %a, half %b) {
+; CHECK-F16: abs.f16
+; CHECK-F16-NOT: and.b16
+  %abs = call half @llvm.fabs.f16(half %a)
+  %r = fadd half %abs, %b
+  ret half %r
+}
+
+; f16 fabs with bitcast user -> expanded (and.b16, not native abs)
+; CHECK-F16-LABEL: test_fabs_f16_bitcast(
+define i16 @test_fabs_f16_bitcast(half %a) {
+; CHECK-F16-NOT: abs.f16
+; CHECK-F16: and.b16
+  %abs = call half @llvm.fabs.f16(half %a)
+  %b = bitcast half %abs to i16
+  ret i16 %b
+}
+
+; fneg feeding fma -> native neg, not xor
+; CHECK-LABEL: test_fneg_fma(
+define float @test_fneg_fma(float %a, float %b, float %c) {
+; CHECK: neg.f32
+; CHECK: fma.rn.f32
+  %neg = fneg float %a
+  %r = call float @llvm.fma.f32(float %neg, float %b, float %c)
+  ret float %r
+}
+
+; bf16 fabs with canonicalizing user -> native abs
+; CHECK-BF16-LABEL: test_fabs_bf16_canon(
+define bfloat @test_fabs_bf16_canon(bfloat %a, bfloat %b) {
+; CHECK-BF16: abs.bf16
+; CHECK-BF16-NOT: and.b16
+  %abs = call bfloat @llvm.fabs.bf16(bfloat %a)
+  %r = fadd bfloat %abs, %b
+  ret bfloat %r
+}
+
+; bf16 fneg with canonicalized input -> xor (expanded)
+; CHECK-BF16-LABEL: test_fneg_bf16_canon_input(
+define bfloat @test_fneg_bf16_canon_input(bfloat %a, bfloat %b) {
+; CHECK-BF16: xor.b16
+; CHECK-BF16-NOT: neg.bf16
+  %add = fadd bfloat %a, %b
+  %neg = fneg bfloat %add
+  ret bfloat %neg
+}
+
+; f16 fneg with canonicalized input -> xor (expanded)
+; CHECK-F16-LABEL: test_fneg_f16_canon_input(
+define half @test_fneg_f16_canon_input(half %a, half %b) {
+; CHECK-F16: xor.b16
+; CHECK-F16-NOT: neg.f16
+  %add = fadd half %a, %b
+  %neg = fneg half %add
+  ret half %neg
+}
+
+; the packed types are handled the same way, elementwise
+; CHECK-F16-LABEL: test_fabs_v2f16_canon(
+define <2 x half> @test_fabs_v2f16_canon(<2 x half> %a, <2 x half> %b) {
+; CHECK-F16: abs.f16x2
+; CHECK-F16-NOT: and.b32
+  %abs = call <2 x half> @llvm.fabs.v2f16(<2 x half> %a)
+  %r = fadd <2 x half> %abs, %b
+  ret <2 x half> %r
+}
+
+; CHECK-BF16-LABEL: test_fneg_v2bf16_canon_input(
+define <2 x bfloat> @test_fneg_v2bf16_canon_input(<2 x bfloat> %a, <2 x bfloat> %b) {
+; CHECK-BF16: xor.b32
+; CHECK-BF16-NOT: neg.bf16x2
+  %add = fadd <2 x bfloat> %a, %b
+  %neg = fneg <2 x bfloat> %add
+  ret <2 x bfloat> %neg
+}
+
+; fabs whose input is int-to-fp (never NaN) -> native abs
+; CHECK-LABEL: test_fabs_sitofp_input(
+define float @test_fabs_sitofp_input(i32 %i) {
+; CHECK: abs.f32
+; CHECK-NOT: and.b32
+  %f = sitofp i32 %i to float
+  %a = call float @llvm.fabs.f32(float %f)
+  ret float %a
+}
+
+; fabs whose only user is a saturating fp-to-int (payload unobservable) -> native abs
+; CHECK-LABEL: test_fabs_fptosi_sat(
+define i32 @test_fabs_fptosi_sat(float %x) {
+; CHECK: abs.f32
+; CHECK-NOT: and.b32
+  %a = call float @llvm.fabs.f32(float %x)
+  %i = call i32 @llvm.fptosi.sat.i32.f32(float %a)
+  ret i32 %i
+}
+
+; fabs whose only user is fp-to-uint (payload unobservable) -> native abs
+; CHECK-LABEL: test_fabs_fptoui(
+define i32 @test_fabs_fptoui(float %x) {
+; CHECK: abs.f32
+; CHECK-NOT: and.b32
+  %a = call float @llvm.fabs.f32(float %x)
+  %i = fptoui float %a to i32
+  ret i32 %i
+}

--- a/llvm/test/CodeGen/NVPTX/float-to-arbitrary-fp.ll
+++ b/llvm/test/CodeGen/NVPTX/float-to-arbitrary-fp.ll
@@ -1828,7 +1828,7 @@ define i8 @to_f8e5m2_from_f16(half %x) {
 ; CHECK-NEXT:    setp.eq.f16 %p12, %rs1, %rs58;
 ; CHECK-NEXT:    selp.b16 %rs59, %rs35, %rs57, %p12;
 ; CHECK-NEXT:    cvt.f32.f16 %r8, %rs1;
-; CHECK-NEXT:    abs.f32 %r9, %r8;
+; CHECK-NEXT:    and.b32 %r9, %r8, 2147483647;
 ; CHECK-NEXT:    cvt.rn.f16.f32 %rs60, %r9;
 ; CHECK-NEXT:    mov.b16 %rs61, 0x7C00;
 ; CHECK-NEXT:    setp.eq.f16 %p13, %rs60, %rs61;
@@ -1936,12 +1936,12 @@ define i8 @to_f8e5m2_from_bf16(bfloat %x) {
 ; CHECK-NEXT:    selp.b16 %rs56, %rs53, %rs55, %p12;
 ; CHECK-NEXT:    setp.eq.f32 %p13, %r2, 0f00000000;
 ; CHECK-NEXT:    selp.b16 %rs57, %rs34, %rs56, %p13;
-; CHECK-NEXT:    abs.f32 %r16, %r2;
-; CHECK-NEXT:    bfe.u32 %r17, %r16, 16, 1;
-; CHECK-NEXT:    or.b32 %r18, %r17, %r16;
+; CHECK-NEXT:    and.b32 %r16, %r1, 1;
+; CHECK-NEXT:    and.b32 %r17, %r2, 2147418112;
+; CHECK-NEXT:    or.b32 %r18, %r16, %r17;
 ; CHECK-NEXT:    add.s32 %r19, %r18, 32767;
-; CHECK-NEXT:    setp.nan.f32 %p14, %r16, %r16;
-; CHECK-NEXT:    or.b32 %r20, %r16, 4194304;
+; CHECK-NEXT:    or.b32 %r20, %r2, 4194304;
+; CHECK-NEXT:    setp.nan.f32 %p14, %r17, %r17;
 ; CHECK-NEXT:    selp.b32 %r21, %r20, %r19, %p14;
 ; CHECK-NEXT:    and.b32 %r22, %r21, 2147418112;
 ; CHECK-NEXT:    setp.eq.f32 %p15, %r22, 0f7F800000;

--- a/llvm/test/CodeGen/NVPTX/fp-fold-sub.ll
+++ b/llvm/test/CodeGen/NVPTX/fp-fold-sub.ll
@@ -68,3 +68,42 @@ define double @sub_f64(double %a, double %b) {
 
   ret double %r4
 }
+
+; A negated operand that is known to never be a NaN reaches isel as the native
+; neg rather than a sign-bit xor. The fold has to apply to that form too.
+define float @sub_f32_never_nan(float %a, i32 %i) {
+; CHECK-LABEL: sub_f32_never_nan(
+; CHECK:       {
+; CHECK-NEXT:    .reg .b32 %r<5>;
+; CHECK-EMPTY:
+; CHECK-NEXT:  // %bb.0:
+; CHECK-NEXT:    ld.param.b32 %r1, [sub_f32_never_nan_param_0];
+; CHECK-NEXT:    ld.param.b32 %r2, [sub_f32_never_nan_param_1];
+; CHECK-NEXT:    cvt.rn.f32.s32 %r3, %r2;
+; CHECK-NEXT:    sub.rn.f32 %r4, %r1, %r3;
+; CHECK-NEXT:    st.param.b32 [func_retval0], %r4;
+; CHECK-NEXT:    ret;
+  %b = sitofp i32 %i to float
+  %f = fneg float %b
+  %r = call float @llvm.nvvm.add.rn.f(float %a, float %f)
+  ret float %r
+}
+
+define double @sub_f64_never_nan(double %a, i32 %i) {
+; CHECK-LABEL: sub_f64_never_nan(
+; CHECK:       {
+; CHECK-NEXT:    .reg .b32 %r<2>;
+; CHECK-NEXT:    .reg .b64 %rd<4>;
+; CHECK-EMPTY:
+; CHECK-NEXT:  // %bb.0:
+; CHECK-NEXT:    ld.param.b64 %rd1, [sub_f64_never_nan_param_0];
+; CHECK-NEXT:    ld.param.b32 %r1, [sub_f64_never_nan_param_1];
+; CHECK-NEXT:    cvt.rn.f64.s32 %rd2, %r1;
+; CHECK-NEXT:    sub.rn.f64 %rd3, %rd1, %rd2;
+; CHECK-NEXT:    st.param.b64 [func_retval0], %rd3;
+; CHECK-NEXT:    ret;
+  %b = sitofp i32 %i to double
+  %f = fneg double %b
+  %r = call double @llvm.nvvm.add.rn.d(double %a, double %f)
+  ret double %r
+}

--- a/llvm/test/CodeGen/NVPTX/intrinsics.ll
+++ b/llvm/test/CodeGen/NVPTX/intrinsics.ll
@@ -11,7 +11,7 @@ define float @test_fabsf(float %f) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    ld.param.b32 %r1, [test_fabsf_param_0];
-; CHECK-NEXT:    abs.f32 %r2, %r1;
+; CHECK-NEXT:    and.b32 %r2, %r1, 2147483647;
 ; CHECK-NEXT:    st.param.b32 [func_retval0], %r2;
 ; CHECK-NEXT:    ret;
   %x = call float @llvm.fabs.f32(float %f)
@@ -25,7 +25,7 @@ define double @test_fabs(double %d) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    ld.param.b64 %rd1, [test_fabs_param_0];
-; CHECK-NEXT:    abs.f64 %rd2, %rd1;
+; CHECK-NEXT:    and.b64 %rd2, %rd1, 9223372036854775807;
 ; CHECK-NEXT:    st.param.b64 [func_retval0], %rd2;
 ; CHECK-NEXT:    ret;
   %x = call double @llvm.fabs.f64(double %d)

--- a/llvm/test/CodeGen/NVPTX/math-intrins.ll
+++ b/llvm/test/CodeGen/NVPTX/math-intrins.ll
@@ -552,7 +552,7 @@ define float @abs_float(float %a) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    ld.param.b32 %r1, [abs_float_param_0];
-; CHECK-NEXT:    abs.f32 %r2, %r1;
+; CHECK-NEXT:    and.b32 %r2, %r1, 2147483647;
 ; CHECK-NEXT:    st.param.b32 [func_retval0], %r2;
 ; CHECK-NEXT:    ret;
   %b = call float @llvm.fabs.f32(float %a)
@@ -566,11 +566,28 @@ define float @abs_float_ftz(float %a) #1 {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    ld.param.b32 %r1, [abs_float_ftz_param_0];
-; CHECK-NEXT:    abs.ftz.f32 %r2, %r1;
+; CHECK-NEXT:    and.b32 %r2, %r1, 2147483647;
 ; CHECK-NEXT:    st.param.b32 [func_retval0], %r2;
 ; CHECK-NEXT:    ret;
   %b = call float @llvm.fabs.f32(float %a)
   ret float %b
+}
+
+define float @abs_float_ftz_add(float %a, float %b) #1 {
+; CHECK-LABEL: abs_float_ftz_add(
+; CHECK:       {
+; CHECK-NEXT:    .reg .b32 %r<5>;
+; CHECK-EMPTY:
+; CHECK-NEXT:  // %bb.0:
+; CHECK-NEXT:    ld.param.b32 %r1, [abs_float_ftz_add_param_0];
+; CHECK-NEXT:    abs.ftz.f32 %r2, %r1;
+; CHECK-NEXT:    ld.param.b32 %r3, [abs_float_ftz_add_param_1];
+; CHECK-NEXT:    add.rn.ftz.f32 %r4, %r2, %r3;
+; CHECK-NEXT:    st.param.b32 [func_retval0], %r4;
+; CHECK-NEXT:    ret;
+  %c = call float @llvm.fabs.f32(float %a)
+  %d = fadd float %c, %b
+  ret float %d
 }
 
 define double @abs_double(double %a) {
@@ -580,7 +597,7 @@ define double @abs_double(double %a) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    ld.param.b64 %rd1, [abs_double_param_0];
-; CHECK-NEXT:    abs.f64 %rd2, %rd1;
+; CHECK-NEXT:    and.b64 %rd2, %rd1, 9223372036854775807;
 ; CHECK-NEXT:    st.param.b64 [func_retval0], %rd2;
 ; CHECK-NEXT:    ret;
   %b = call double @llvm.fabs.f64(double %a)


### PR DESCRIPTION
LLVM fabs/fneg can only touch the sign bit and must preserve the rest of the value, including NaN payloads. PTX abs/neg do not have this guarantee, making a direct lowering unsound in general.

Lower fabs to AND with 0x7fff... and fneg to XOR with 0x8000... instead. Keep lowering to the native instructions when the input is known never-NaN, or every user is an operator that canonicalizes it anyway. Those cases now go through the newly added NVPTXISD::FABS/FNEG.