### PR TITLE
[CodeGen] Relax an overly strict assert in EmitAggregateCopy

### DIFF
--- a/clang/lib/CodeGen/CGExprAgg.cpp
+++ b/clang/lib/CodeGen/CGExprAgg.cpp
@@ -2343,11 +2343,10 @@ void CodeGenFunction::EmitAggregateCopy(LValue Dest, LValue Src, QualType Ty,
 
   if (getLangOpts().CPlusPlus) {
     if (const auto *Record = Ty->getAsCXXRecordDecl()) {
-      assert((Record->hasTrivialCopyConstructor() ||
+      assert((Record->hasTrivialCopyConstructorForCall() ||
               Record->hasTrivialCopyAssignment() ||
-              Record->hasTrivialMoveConstructor() ||
-              Record->hasTrivialMoveAssignment() ||
-              Record->hasAttr<TrivialABIAttr>() || Record->isUnion() ||
+              Record->hasTrivialMoveConstructorForCall() ||
+              Record->hasTrivialMoveAssignment() || Record->isUnion() ||
               // HLSL uses aggregate-copy for user-defined record types.
               (getLangOpts().HLSL && !Record->isHLSLBuiltinRecord())) &&
              "Trying to aggregate-copy a type without a trivial copy/move "

--- a/clang/test/CodeGenObjCXX/arc-forwarded-lambda-call.mm
+++ b/clang/test/CodeGenObjCXX/arc-forwarded-lambda-call.mm
@@ -41,3 +41,17 @@ void testWeak() {
   extern void testWeak_helper(void (^)(Weak));
   testWeak_helper([](Weak){});
 }
+
+// The code below used to cause an assertion to fail.
+struct Strong {
+  int x;
+  __strong id obj;
+};
+
+using FP = Strong (*)();
+FP test2_fp = []() -> Strong { return Strong{}; };
+// CHECK-LABEL: define internal { i32, ptr } @"_ZN3$_38__invokeEv"(
+// CHECK: %call = call { i32, ptr } @"_ZNK3$_3clEv"
+// CHECK: call void @llvm.memcpy.p0.p0.i64(ptr align 8 %retval, ptr align 8 %coerce, i64 16, i1 false)
+// CHECK-NEXT: [[RET:%.*]] = load { i32, ptr }, ptr %retval
+// CHECK-NEXT: ret { i32, ptr } [[RET]]


### PR DESCRIPTION
EmitAggregateCopy contains a sanity check verifying that a record being bitwise copied has a genuinely trivial copy/move constructor or assignment operator. The check did not account for records that are non-trivial only because they contain an ARC __strong field. Such records are still trivial for the purposes of calls, so clang can legitimately use memcpy to copy them when passing or returning the type by value.

Relax the assertion by using hasTrivialCopyConstructorForCall() and hasTrivialMoveConstructorForCall() instead of the plain hasTrivialCopyConstructor()/hasTrivialMoveConstructor() checks, since these are exactly the predicates that capture that notion of triviality for calls. This also makes the separate hasAttr<TrivialABIAttr>() check redundant, since the trivial_abi attribute unconditionally sets the for-call bits for the copy constructor, move constructor, and destructor.

rdar://182749806