### PR TITLE
[orc-rt] Add SimpleRemoteCA, a SimpleRemote protocol base

### DIFF
--- a/orc-rt/include/CMakeLists.txt
+++ b/orc-rt/include/CMakeLists.txt
@@ -32,6 +32,7 @@ set(ORC_RT_HEADERS
     orc-rt/bedrock/SimpleNativeMemoryMap.h
     orc-rt/bedrock/SimplePackedSerialization.h
     orc-rt/bedrock/SimpleSymbolTable.h
+    orc-rt/bedrock/SimpleRemoteCA.h
     orc-rt/bedrock/StandaloneMachOUnwindInfoRegistrar.h
     orc-rt/bedrock/StringPool.h
     orc-rt/bedrock/TaskGroup.h

--- a/orc-rt/include/orc-rt/bedrock/Session.h
+++ b/orc-rt/include/orc-rt/bedrock/Session.h
@@ -231,16 +231,17 @@ public:
     /// installing a handler via Session::setOnDisconnect:
     ///
     ///   - Success: the disconnection was orderly. Either it was requested
-    ///     locally via disconnect, or the controller announced that it was
-    ///     going away (e.g. by sending an explicit hangup message).
+    ///     locally via disconnect, or the controller cleanly disconnected (e.g.
+    ///     by sending an explicit hangup message with a success value).
     ///
     ///   - Failure: the disconnection was abnormal, and Err describes what was
-    ///     observed: a communication failure, a protocol error, or the
-    ///     controller vanishing without announcing it (e.g. end-of-file on a
-    ///     transport whose protocol requires an explicit hangup). The cause of
-    ///     an abnormal disconnection is generally unknowable -- the controller
-    ///     may have crashed, been killed, or become unreachable -- so Err
-    ///     should describe what was observed rather than assert a cause.
+    ///     observed: a communication failure, a protocol error, a failure the
+    ///     controller reported as it disconnected, or the controller vanishing
+    ///     without announcing it (e.g. end-of-file on a transport whose
+    ///     protocol requires an explicit hangup). The cause of an abnormal
+    ///     disconnection is generally unknowable -- the controller may have
+    ///     crashed, been killed, or become unreachable -- so Err should
+    ///     describe what was observed rather than assert a cause.
     ///
     /// Pass the terminal error here rather than to reportError: if no
     /// on-disconnect handler is installed the Session forwards Err to the error
@@ -349,13 +350,14 @@ public:
   /// The Error it receives describes how the connection ended:
   ///
   ///   - Success: the disconnection was orderly -- it was requested locally,
-  ///     the controller announced that it was going away, or no controller was
-  ///     ever attached (with no connection to lose, the disconnect trivially
+  ///     the controller cleanly disconnected, or no controller was ever
+  ///     attached (with no connection to lose, the disconnect trivially
   ///     succeeds).
   ///
   ///   - Failure: the disconnection was abnormal -- a failure to connect in
-  ///     the first place, a communication failure, or the controller vanishing
-  ///     without announcing it.
+  ///     the first place, a communication failure, a failure the controller
+  ///     reported as it disconnected, or the controller vanishing without
+  ///     announcing it.
   ///
   /// The handler takes ownership of the Error and must consume it. Note that
   /// success covers both an orderly disconnection and never having attached; a

--- a/orc-rt/include/orc-rt/bedrock/SimpleRemoteCA.h
+++ b/orc-rt/include/orc-rt/bedrock/SimpleRemoteCA.h
@@ -1,0 +1,114 @@
+//===-------------------- SimpleRemoteCA.h ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// A ControllerAccess base class implementing the SimpleRemote wire protocol.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ORC_RT_SIMPLEREMOTECA_H
+#define ORC_RT_SIMPLEREMOTECA_H
+
+#include "orc-rt/bedrock/BootstrapInfo.h"
+#include "orc-rt/bedrock/Error.h"
+#include "orc-rt/bedrock/ExecutorAddress.h"
+#include "orc-rt/bedrock/Session.h"
+#include "orc-rt/bedrock/WrapperFunction.h"
+
+#include <mutex>
+#include <unordered_map>
+
+namespace orc_rt {
+
+/// ControllerAccess base for the SimpleRemote protocol.
+///
+/// Implements the protocol semantics -- setup and hang-up message encoding,
+/// message dispatch and validation, pending-call tracking, and completion of
+/// controller calls -- while leaving all wire framing and byte transport,
+/// including sending, to subclasses. Subclasses feed received messages to
+/// handleMessage and build outgoing ones from the Opcode set,
+/// encodeSetupMessage and encodeHangupPayload.
+class SimpleRemoteCA : public Session::ControllerAccess {
+protected:
+  /// SimpleRemote message opcodes.
+  ///
+  /// These values are on-the-wire values, shared with LLVM's
+  /// SimpleRemoteEPCOpcode: do not renumber or reorder them.
+  enum class Opcode { Setup, Hangup, Result, Call, LastOpcode = Call };
+
+  /// Result of handleMessage: whether the session continues, or the controller
+  /// has hung up and the session should end.
+  enum class Action { Continue, End };
+
+  /// Returns a display name for Op, for logging.
+  static const char *getOpcodeName(Opcode Op) noexcept;
+
+  SimpleRemoteCA(Session &S) : ControllerAccess(S) {}
+
+  /// Serializes a setup message from BI and returns its payload. Subclasses
+  /// send this as the first message during connect -- an Opcode::Setup message
+  /// with no sequence number or handler tag.
+  static WrapperFunctionBuffer encodeSetupMessage(const BootstrapInfo &BI);
+
+  /// Serializes Err as the payload of a hang-up message.
+  ///
+  /// A hang-up always carries a serialized Error saying why the session is
+  /// ending: a success value for an orderly disconnect, otherwise the reason.
+  /// handleMessage decodes an incoming hang-up through the matching code, so
+  /// the two directions cannot drift apart.
+  static WrapperFunctionBuffer encodeHangupPayload(Error Err);
+
+  /// Dispatches a received message. Transports call this once per message,
+  /// after de-framing. OpC is the raw wire opcode: this validates it and the
+  /// per-opcode header semantics. Transports are responsible only for verifying
+  /// that the payload deserializes as the message requires.
+  ///
+  /// Every error returned here is terminal for the session: report it via
+  /// notifyDisconnected (as for Action::End, but with the error as the
+  /// disconnection reason) rather than continuing to read.
+  ///
+  /// Calls may come from any thread, but must be serialized with one another
+  /// and must all complete before failAllPendingCalls: the Result path
+  /// completes a pending call, which is only legal while the managed-code group
+  /// is still open. One racing teardown may hit that assertion, or touch a
+  /// *this that notifyDisconnected has already destroyed.
+  Expected<Action> handleMessage(uint64_t OpC, uint64_t SeqNo, ExecutorAddr Tag,
+                                 WrapperFunctionBuffer Payload);
+
+  /// Records OnComplete as awaiting a result and returns the sequence number to
+  /// send the call under. The result is delivered when a matching Result
+  /// message arrives (handleMessage), or the call is failed (see below).
+  ///
+  /// SimpleRemoteCA tracks no connection state, so it cannot reject a call
+  /// registered after failAllPendingCalls has run: such a call is never
+  /// drained, and its handler is silently dropped, leaving the caller awaiting
+  /// a result that can no longer arrive. Subclasses must therefore make their
+  /// disconnecting check and this registration atomic with respect to the drain
+  /// -- e.g. both under the lock that publishes the disconnecting state (see
+  /// Session::ControllerAccess::callController).
+  uint64_t registerPendingCall(OnControllerCallReturn OnComplete);
+
+  /// Fails every pending call with a disconnect error -- the disconnect drain.
+  /// Call before notifyDisconnected, while the managed-code group is still open
+  /// (see Session::ControllerAccess::disconnect). Dispatched under a token.
+  void failAllPendingCalls();
+
+private:
+  Error handleResult(uint64_t SeqNo, WrapperFunctionBuffer ResultBytes);
+
+  std::mutex M;
+
+  // SeqNo zero is reserved for messages with no pending result (Setup, Hangup).
+  uint64_t NextSeqNo = 1;
+
+  using PendingCallsMap = std::unordered_map<uint64_t, OnControllerCallReturn>;
+  PendingCallsMap PendingCalls;
+};
+
+} // namespace orc_rt
+
+#endif // ORC_RT_SIMPLEREMOTECA_H

--- a/orc-rt/lib/bedrock/CMakeLists.txt
+++ b/orc-rt/lib/bedrock/CMakeLists.txt
@@ -12,6 +12,7 @@ set(ORC_RT_SOURCES
   Service.cpp
   Session.cpp
   SimpleNativeMemoryMap.cpp
+  SimpleRemoteCA.cpp
   SimpleSymbolTable.cpp
   StandaloneMachOUnwindInfoRegistrar.cpp
   ThreadPoolRunner.cpp

--- a/orc-rt/lib/bedrock/SimpleRemoteCA.cpp
+++ b/orc-rt/lib/bedrock/SimpleRemoteCA.cpp
@@ -1,0 +1,147 @@
+//===- SimpleRemoteCA.cpp -------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// SimpleRemote-protocol ControllerAccess base class.
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt/bedrock/SimpleRemoteCA.h"
+
+#include "orc-rt/bedrock/Compiler.h"
+#include "orc-rt/bedrock/SimplePackedSerialization.h"
+
+#include <string>
+
+namespace orc_rt {
+
+const char *SimpleRemoteCA::getOpcodeName(Opcode Op) noexcept {
+  switch (Op) {
+  case Opcode::Setup:
+    return "setup";
+  case Opcode::Hangup:
+    return "hang-up";
+  case Opcode::Result:
+    return "result";
+  case Opcode::Call:
+    return "call";
+  }
+  ORC_RT_UNREACHABLE("Unrecognized opcode");
+}
+
+WrapperFunctionBuffer
+SimpleRemoteCA::encodeSetupMessage(const BootstrapInfo &BI) {
+  using SPSSetup = SPSTuple<SPSString, uint64_t,
+                            SPSSequence<SPSTuple<SPSString, SPSSequence<char>>>,
+                            SPSSequence<SPSTuple<SPSString, SPSExecutorAddr>>>;
+
+  // Force uint64_t PageSize.
+  // FIXME: Remove once we allow size_t serialization.
+  uint64_t PageSize = BI.processInfo().pageSize();
+  auto Symbols = iterator_range(BI.symbols());
+  auto BootstrapTuple =
+      std::tie(BI.processInfo().targetTriple(), PageSize, BI.values(), Symbols);
+
+  using SetupSerialize =
+      SPSSerializationTraits<SPSSetup, decltype(BootstrapTuple)>;
+
+  auto Payload =
+      WrapperFunctionBuffer::allocate(SetupSerialize::size(BootstrapTuple));
+  SPSOutputBuffer OB(Payload.data(), Payload.size());
+  if (!SetupSerialize::serialize(OB, BootstrapTuple))
+    ORC_RT_UNREACHABLE("serialization should not fail");
+
+  return Payload;
+}
+
+WrapperFunctionBuffer SimpleRemoteCA::encodeHangupPayload(Error Err) {
+  SPSSerializableError SE(std::move(Err));
+  using SPSSerialize = SPSArgList<SPSError>;
+  auto Payload = WrapperFunctionBuffer::allocate(SPSSerialize::size(SE));
+  SPSOutputBuffer OB(Payload.data(), Payload.size());
+  if (!SPSSerialize::serialize(OB, SE))
+    ORC_RT_UNREACHABLE("serialization should not fail");
+  return Payload;
+}
+
+Expected<SimpleRemoteCA::Action>
+SimpleRemoteCA::handleMessage(uint64_t OpC, uint64_t SeqNo, ExecutorAddr Tag,
+                              WrapperFunctionBuffer Payload) {
+  if (OpC > static_cast<uint64_t>(Opcode::LastOpcode))
+    return make_error<StringError>("Invalid opcode " + std::to_string(OpC));
+
+  switch (static_cast<Opcode>(OpC)) {
+  case Opcode::Setup:
+    return make_error<StringError>("Unexpected Setup message");
+  case Opcode::Hangup: {
+    // A hang-up carries no sequence number or tag, and a payload holding the
+    // reason the controller is going away.
+    if (SeqNo != 0 || Tag)
+      return make_error<StringError>("Malformed hang-up message");
+    SPSSerializableError SE;
+    SPSInputBuffer IB(Payload.data(), Payload.size());
+    if (!SPSArgList<SPSError>::deserialize(IB, SE))
+      return make_error<StringError>(
+          "Malformed hang-up message: could not deserialize reason");
+    // An orderly hang-up ends the session; one carrying a reason ends it with
+    // that reason, which the reactor reports as the disconnection error.
+    if (Error Err = SE.toError())
+      return std::move(Err);
+    return Action::End;
+  }
+  case Opcode::Result:
+    // A result is not associated with a handler tag.
+    if (Tag)
+      return make_error<StringError>(
+          "Result message should not carry a handler tag");
+    if (auto Err = handleResult(SeqNo, std::move(Payload)))
+      return std::move(Err);
+    return Action::Continue;
+  case Opcode::Call:
+    handleWrapperCall(Tag.toPtr<orc_rt_WrapperFunction>(), std::move(Payload),
+                      SeqNo);
+    return Action::Continue;
+  }
+  ORC_RT_UNREACHABLE("Unrecognized opcode");
+}
+
+uint64_t
+SimpleRemoteCA::registerPendingCall(OnControllerCallReturn OnComplete) {
+  std::scoped_lock<std::mutex> Lock(M);
+  PendingCalls.try_emplace(NextSeqNo, std::move(OnComplete));
+  return NextSeqNo++;
+}
+
+void SimpleRemoteCA::failAllPendingCalls() {
+  PendingCallsMap Failed;
+  {
+    std::scoped_lock<std::mutex> Lock(M);
+    std::swap(Failed, PendingCalls);
+  }
+
+  for (auto &[SeqNo, OnComplete] : Failed)
+    failPendingControllerCall(std::move(OnComplete));
+}
+
+Error SimpleRemoteCA::handleResult(uint64_t SeqNo,
+                                   WrapperFunctionBuffer ResultBytes) {
+  OnControllerCallReturn OnComplete;
+  {
+    std::scoped_lock<std::mutex> Lock(M);
+    auto I = PendingCalls.find(SeqNo);
+    if (I == PendingCalls.end())
+      return make_error<StringError>("No pending call for sequence number " +
+                                     std::to_string(SeqNo));
+    OnComplete = std::move(I->second);
+    PendingCalls.erase(I);
+  }
+
+  handleControllerCallResult(std::move(OnComplete), std::move(ResultBytes));
+  return Error::success();
+}
+
+} // namespace orc_rt

--- a/orc-rt/test/unit/CMakeLists.txt
+++ b/orc-rt/test/unit/CMakeLists.txt
@@ -48,6 +48,7 @@ add_orc_rt_unittest(CoreTests
   SimpleNativeMemoryMapSPSCITest.cpp
   SimpleNativeMemoryMapTest.cpp
   SimplePackedSerializationTest.cpp
+  SimpleRemoteCATest.cpp
   SimpleSymbolTableTest.cpp
   StandaloneMachOUnwindInfoRegistrarTest.cpp
   StringExtrasTest.cpp

--- a/orc-rt/test/unit/SimpleRemoteCATest.cpp
+++ b/orc-rt/test/unit/SimpleRemoteCATest.cpp
@@ -1,0 +1,291 @@
+//===- SimpleRemoteCATest.cpp ---------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Tests for orc-rt's SimpleRemoteCA protocol base class.
+//
+// SimpleRemoteCA is transport-independent, so these tests drive its protocol
+// operations directly through a capture-only test double and observe the
+// results via a Session.
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt/bedrock/SimpleRemoteCA.h"
+
+#include "gtest/gtest.h"
+
+#include "CommonTestUtils.h"
+
+#include "orc-rt/bedrock/SimplePackedSerialization.h"
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+using namespace orc_rt;
+
+namespace {
+
+// A SimpleRemoteCA with no real transport. It exposes the protected protocol
+// operations for tests, records outgoing controller calls as pending results,
+// and records the wrapper results the executor produces.
+class TestSimpleRemoteCA : public SimpleRemoteCA {
+public:
+  TestSimpleRemoteCA(Session &S, TestSimpleRemoteCA **Self = nullptr)
+      : SimpleRemoteCA(S) {
+    if (Self)
+      *Self = this;
+  }
+
+  using SimpleRemoteCA::Action;
+  using SimpleRemoteCA::encodeHangupPayload;
+  using SimpleRemoteCA::encodeSetupMessage;
+  using SimpleRemoteCA::handleMessage;
+  using SimpleRemoteCA::Opcode;
+
+  void connect(BootstrapInfo) override {}
+  void disconnect() override {
+    // Mirror a real transport's teardown order: drain, then notify. A locally
+    // requested disconnect is orderly, so the mode is success.
+    failAllPendingCalls();
+    notifyDisconnected(Error::success());
+  }
+  void callController(OnControllerCallReturn OnComplete,
+                      orc_rt_ControllerHandlerTag,
+                      WrapperFunctionBuffer) override {
+    LastCallSeqNo = registerPendingCall(std::move(OnComplete));
+  }
+  void sendWrapperResult(WrapperFunctionBuffer ResultBytes,
+                         uint64_t CallId) override {
+    WrapperResults.emplace_back(CallId, std::move(ResultBytes));
+  }
+
+  uint64_t LastCallSeqNo = 0;
+  std::vector<std::pair<uint64_t, WrapperFunctionBuffer>> WrapperResults;
+};
+
+constexpr uint64_t opc(TestSimpleRemoteCA::Opcode Op) {
+  return static_cast<uint64_t>(Op);
+}
+
+// Wrapper that echoes its arguments back as the result.
+void echoWrapper(orc_rt_SessionRef S, orc_rt_WrapperFunctionBuffer ArgBytes,
+                 orc_rt_WrapperFunctionReturn Return, uint64_t CallId) {
+  Return(S, ArgBytes, CallId);
+}
+
+// Expect an Expected<T> to hold an error whose message equals ExpectedMsg.
+template <typename T> void expectError(Expected<T> R, const char *ExpectedMsg) {
+  if (R)
+    ADD_FAILURE() << "expected error \"" << ExpectedMsg << "\", got a value";
+  else
+    EXPECT_EQ(toString(R.takeError()), ExpectedMsg);
+}
+
+} // namespace
+
+TEST(SimpleRemoteCATest, SetupMessageRoundTrips) {
+  // The setup payload's wire format is shared with the controller (it matches
+  // LLVM's SPSSimpleRemoteEPCExecutorInfo), so pin the field order and types by
+  // decoding a payload the encoder produced.
+  using SPSSetup = SPSTuple<SPSString, uint64_t,
+                            SPSSequence<SPSTuple<SPSString, SPSSequence<char>>>,
+                            SPSSequence<SPSTuple<SPSString, SPSExecutorAddr>>>;
+
+  Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+
+  int SomeSymbol = 0;
+  SimpleSymbolTable Symbols;
+  std::vector<std::pair<std::string, const void *>> SymbolDefs = {
+      {"foo", &SomeSymbol}};
+  cantFail(Symbols.addUnique(SymbolDefs));
+
+  BootstrapInfo BI(S, std::move(Symbols),
+                   BootstrapInfo::ValueMap{{"key", "value"}});
+  auto Payload = TestSimpleRemoteCA::encodeSetupMessage(BI);
+
+  std::string Triple;
+  uint64_t PageSize = 0;
+  std::unordered_map<std::string, std::string> Values;
+  std::unordered_map<std::string, ExecutorAddr> DecodedSymbols;
+  SPSInputBuffer IB(Payload.data(), Payload.size());
+  ASSERT_TRUE(SPSSetup::AsArgList::deserialize(IB, Triple, PageSize, Values,
+                                               DecodedSymbols));
+
+  EXPECT_EQ(Triple, S.processInfo().targetTriple());
+  EXPECT_EQ(PageSize, S.processInfo().pageSize());
+  EXPECT_EQ(Values,
+            (std::unordered_map<std::string, std::string>{{"key", "value"}}));
+  EXPECT_EQ(DecodedSymbols, (std::unordered_map<std::string, ExecutorAddr>{
+                                {"foo", ExecutorAddr::fromPtr(&SomeSymbol)}}));
+
+  // The payload holds exactly the setup fields: no padding, and nothing the
+  // controller would be left to interpret.
+  EXPECT_EQ(static_cast<size_t>(IB.data() - Payload.data()), Payload.size());
+}
+
+TEST(SimpleRemoteCATest, HandleMessageRejectsInvalidOpcode) {
+  Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+  TestSimpleRemoteCA CA(S);
+  expectError(CA.handleMessage(/*OpC=*/99, /*SeqNo=*/0, ExecutorAddr(),
+                               WrapperFunctionBuffer()),
+              "Invalid opcode 99");
+}
+
+TEST(SimpleRemoteCATest, HandleMessageRejectsUnexpectedSetup) {
+  Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+  TestSimpleRemoteCA CA(S);
+  expectError(CA.handleMessage(opc(TestSimpleRemoteCA::Opcode::Setup), 0,
+                               ExecutorAddr(), WrapperFunctionBuffer()),
+              "Unexpected Setup message");
+}
+
+TEST(SimpleRemoteCATest, HandleMessageAcceptsWellFormedHangup) {
+  Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+  TestSimpleRemoteCA CA(S);
+  auto R = CA.handleMessage(
+      opc(TestSimpleRemoteCA::Opcode::Hangup), 0, ExecutorAddr(),
+      TestSimpleRemoteCA::encodeHangupPayload(Error::success()));
+  if (!R)
+    ADD_FAILURE() << "unexpected error: " << toString(R.takeError());
+  else
+    EXPECT_EQ(*R, TestSimpleRemoteCA::Action::End);
+}
+
+TEST(SimpleRemoteCATest, HandleMessageReportsHangupReason) {
+  // A hang-up carrying a reason ends the session with that reason, rather than
+  // reporting a plain End: the reactor turns it into the disconnection error.
+  Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+  TestSimpleRemoteCA CA(S);
+  expectError(CA.handleMessage(
+                  opc(TestSimpleRemoteCA::Opcode::Hangup), 0, ExecutorAddr(),
+                  TestSimpleRemoteCA::encodeHangupPayload(
+                      make_error<StringError>("controller ran out of x"))),
+              "controller ran out of x");
+}
+
+TEST(SimpleRemoteCATest, HandleMessageRejectsMalformedHangup) {
+  Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+  TestSimpleRemoteCA CA(S);
+
+  // A hang-up must carry no sequence number and no tag.
+  expectError(CA.handleMessage(
+                  opc(TestSimpleRemoteCA::Opcode::Hangup), /*SeqNo=*/5,
+                  ExecutorAddr(),
+                  TestSimpleRemoteCA::encodeHangupPayload(Error::success())),
+              "Malformed hang-up message");
+  expectError(CA.handleMessage(
+                  opc(TestSimpleRemoteCA::Opcode::Hangup), 0,
+                  ExecutorAddr(0x1000),
+                  TestSimpleRemoteCA::encodeHangupPayload(Error::success())),
+              "Malformed hang-up message");
+
+  // It must carry a deserializable reason. An empty payload is never valid --
+  // the two ends are rev-locked, so this is a bug in the peer rather than skew.
+  expectError(CA.handleMessage(opc(TestSimpleRemoteCA::Opcode::Hangup), 0,
+                               ExecutorAddr(), WrapperFunctionBuffer()),
+              "Malformed hang-up message: could not deserialize reason");
+}
+
+TEST(SimpleRemoteCATest, HandleMessageRejectsResultWithTag) {
+  Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+  TestSimpleRemoteCA CA(S);
+  expectError(CA.handleMessage(opc(TestSimpleRemoteCA::Opcode::Result),
+                               /*SeqNo=*/1, ExecutorAddr(0x1000),
+                               WrapperFunctionBuffer()),
+              "Result message should not carry a handler tag");
+}
+
+TEST(SimpleRemoteCATest, HandleMessageRejectsResultForUnknownSequenceNumber) {
+  Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+  TestSimpleRemoteCA CA(S);
+  expectError(CA.handleMessage(opc(TestSimpleRemoteCA::Opcode::Result),
+                               /*SeqNo=*/7, ExecutorAddr(),
+                               WrapperFunctionBuffer::copyFrom("r", 1)),
+              "No pending call for sequence number 7");
+}
+
+TEST(SimpleRemoteCATest, ResultCompletesPendingCall) {
+  Session S(mockExecutorProcessInfo(), inlineDispatch, noErrors);
+  TestSimpleRemoteCA *CA = nullptr;
+  S.attach<TestSimpleRemoteCA>(BootstrapInfo(S), &CA);
+  ASSERT_TRUE(CA);
+
+  // Originate a controller call; the test double registers it as pending.
+  std::optional<std::string> Res;
+  S.callController(
+      [&](WrapperFunctionBuffer R) {
+        ASSERT_FALSE(R.getOutOfBandError()) << R.getOutOfBandError();
+        Res = std::string(R.data(), R.size());
+      },
+      nullptr, WrapperFunctionBuffer());
+
+  uint64_t SeqNo = CA->LastCallSeqNo;
+  ASSERT_NE(SeqNo, 0u);
+  ASSERT_FALSE(Res) << "handler fired before the result arrived";
+
+  // Deliver the matching result; handleMessage completes the call inline.
+  auto R = CA->handleMessage(opc(TestSimpleRemoteCA::Opcode::Result), SeqNo,
+                             ExecutorAddr(),
+                             WrapperFunctionBuffer::copyFrom("a", 1));
+  if (!R)
+    ADD_FAILURE() << "unexpected error: " << toString(R.takeError());
+  else
+    EXPECT_EQ(*R, TestSimpleRemoteCA::Action::Continue);
+
+  ASSERT_TRUE(Res);
+  EXPECT_EQ(*Res, "a");
+}
+
+TEST(SimpleRemoteCATest, CallDispatchesWrapperAndReturnsResult) {
+  Session S(mockExecutorProcessInfo(), inlineDispatch, noErrors);
+  TestSimpleRemoteCA *CA = nullptr;
+  S.attach<TestSimpleRemoteCA>(BootstrapInfo(S), &CA);
+  ASSERT_TRUE(CA);
+
+  // A Call names echoWrapper via the tag; SeqNo is the call id.
+  auto R = CA->handleMessage(
+      opc(TestSimpleRemoteCA::Opcode::Call), /*SeqNo=*/42,
+      ExecutorAddr::fromPtr(reinterpret_cast<void *>(echoWrapper)),
+      WrapperFunctionBuffer::copyFrom("world", 5));
+  if (!R)
+    ADD_FAILURE() << "unexpected error: " << toString(R.takeError());
+  else
+    EXPECT_EQ(*R, TestSimpleRemoteCA::Action::Continue);
+
+  ASSERT_EQ(CA->WrapperResults.size(), 1u);
+  EXPECT_EQ(CA->WrapperResults[0].first, 42u);
+  auto &Result = CA->WrapperResults[0].second;
+  EXPECT_EQ(std::string(Result.data(), Result.size()), "world");
+}
+
+TEST(SimpleRemoteCATest, DisconnectDrainsPendingCalls) {
+  Session S(mockExecutorProcessInfo(), inlineDispatch, noErrors);
+  TestSimpleRemoteCA *CA = nullptr;
+  S.attach<TestSimpleRemoteCA>(BootstrapInfo(S), &CA);
+  ASSERT_TRUE(CA);
+
+  // A controller call is in flight (no result will arrive).
+  std::optional<std::string> Err;
+  S.callController(
+      [&](WrapperFunctionBuffer R) {
+        if (const char *M = R.getOutOfBandError())
+          Err = M;
+      },
+      nullptr, WrapperFunctionBuffer());
+  ASSERT_NE(CA->LastCallSeqNo, 0u);
+  ASSERT_FALSE(Err) << "handler fired before disconnect";
+
+  // Detach drives disconnect, which drains the pending call with a
+  // "disconnected" error.
+  S.detach([] {});
+
+  ASSERT_TRUE(Err);
+  EXPECT_EQ(*Err, "disconnected");
+}


### PR DESCRIPTION
SimpleRemoteCA implements the transport-independent parts of the SimpleRemote protocol: opcode and header validation, setup-message encoding, hang-up encoding and decoding, pending-call tracking, and completion of controller calls onto the Session::ControllerAccess contract. Subclasses own wire framing and byte transport entirely -- they de-frame incoming messages and hand the header fields to handleMessage, and build outgoing ones from the Opcode set and the encode helpers.

Header validation rejects fields the protocol requires to be unset: a Result may not carry a handler tag, a hang-up may not carry a sequence number or tag. It does not interpret fields the protocol requires to be present -- in particular a Call's handler tag is passed through as given, since the executor's job is to jump where the controller tells it to.

A hang-up carries a serialized Error giving the reason the session is ending, matching the format SimpleRemoteEPC and SimpleRemoteEPCServer use, so that an orderly disconnect is distinguishable from a peer that vanished. A hang-up whose reason is a failure ends the session with that reason rather than reporting a plain end-of-session.

SimpleRemoteCATest drives the protocol operations directly through a capture-only test double and observes the results via a Session.