### PR TITLE
[Clang] Fix getReturnTypeSourceRange() for trailing return types

### DIFF
--- a/clang-tools-extra/clangd/AST.cpp
+++ b/clang-tools-extra/clangd/AST.cpp
@@ -531,7 +531,8 @@ public:
     if (CurLoc.isInvalid() && isa<CXXConversionDecl>(D))
       CurLoc = D->getTypeSourceInfo()->getTypeLoc().getBeginLoc();
     // Loc of "auto" in function with trailing return type (c++11).
-    if (CurLoc.isInvalid())
+    if (auto *FPT = D->getType()->getAs<FunctionProtoType>();
+        FPT && FPT->hasTrailingReturn())
       CurLoc = D->getSourceRange().getBegin();
     if (CurLoc != SearchedLocation)
       return true;

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -486,9 +486,9 @@ features cannot lower the translation-unit ABI level;
   producing a spurious "no matching function" error with no candidate notes.
   (#GH210822)
 
-- Fixed a crash when module directive export module foo not following a 
+- Fixed a crash when module directive export module foo not following a
   semicolon and there are no rest pp-tokens in current module file. (#GH187771)
-  
+
 - Fixed a crash when a lambda parameter pack was given a default argument that
   is a pack expansion referencing an enclosing function's parameter pack (e.g.
   `[](Types... = args...) {}`). Clang now diagnoses the illegal default
@@ -543,6 +543,9 @@ features cannot lower the translation-unit ABI level;
 - Fixed a non-deterministic ordering of unused local typedefs that made
   serialized PCH/AST files and `-Wunused-local-typedef` diagnostics
   non-reproducible across runs. (#GH209639)
+
+- `FunctionDecl::getReturnTypeSourceRange()` now returns correct source
+  location of a trailing return type. (#GH162649)
 
 #### Miscellaneous Bug Fixes
 

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -4070,12 +4070,9 @@ SourceRange FunctionDecl::getReturnTypeSourceRange() const {
   if (!FTL)
     return SourceRange();
 
-  // Skip self-referential return types.
-  const SourceManager &SM = getASTContext().getSourceManager();
   SourceRange RTRange = FTL.getReturnLoc().getSourceRange();
   SourceLocation Boundary = getNameInfo().getBeginLoc();
-  if (RTRange.isInvalid() || Boundary.isInvalid() ||
-      !SM.isBeforeInTranslationUnit(RTRange.getEnd(), Boundary))
+  if (RTRange.isInvalid() || Boundary.isInvalid())
     return SourceRange();
 
   return RTRange;

--- a/clang/test/Sema/warn-main-return-type.c
+++ b/clang/test/Sema/warn-main-return-type.c
@@ -43,8 +43,9 @@ fptr main(void) {
   return (fptr) 0;
 }
 
-// expected-error@+2 {{conflicting types for 'main}}
-// expected-warning@+1 {{return type of 'main' is not 'int'}}
+// expected-error@+3 {{conflicting types for 'main}}
+// expected-warning@+2 {{return type of 'main' is not 'int'}}
+// expected-note@+1 {{change return type to 'int'}}
 void *(*main(void))(int a) {
   return (fptr) 0;
 }

--- a/clang/test/SemaCXX/trailing-return-0x.cpp
+++ b/clang/test/SemaCXX/trailing-return-0x.cpp
@@ -111,3 +111,15 @@ namespace PR46637 {
   template<typename T> struct Y { T x; };
   Y<auto() -> auto> y; // expected-error {{'auto' not allowed in function return type}}
 }
+
+
+namespace GH162649 {
+
+auto bad() -> const int&;
+void test_bad() {
+  bad() = 10;
+  // expected-error@-1 {{cannot assign}}
+  // expected-note@-4 {{declared here}}
+}
+
+}


### PR DESCRIPTION
I'm not quite sure what that 'self-referential' meant and that logic doesn't seem to make much sense and it doesn't work for trailing return types.

Fixes #162649