### PR TITLE
[SPIRV][NewPM] Port SPIRVPreLegalizer

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRV.h
+++ b/llvm/lib/Target/SPIRV/SPIRV.h
@@ -10,6 +10,9 @@
 #define LLVM_LIB_TARGET_SPIRV_SPIRV_H
 
 #include "MCTargetDesc/SPIRVMCTargetDesc.h"
+#include "llvm/CodeGen/MachineFunctionAnalysisManager.h"
+#include "llvm/IR/Analysis.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 #include "llvm/PassRegistry.h"
 #include "llvm/Target/TargetMachine.h"
@@ -115,8 +118,16 @@ public:
 };
 
 FunctionPass *createSPIRVRegularizerPass();
+
+class SPIRVPreLegalizerPass
+    : public RequiredPassInfoMixin<SPIRVPreLegalizerPass> {
+public:
+  PreservedAnalyses run(MachineFunction &MF,
+                        MachineFunctionAnalysisManager &MFAM);
+};
+
+FunctionPass *createSPIRVPreLegalizerLegacyPass();
 FunctionPass *createSPIRVPreLegalizerCombiner();
-FunctionPass *createSPIRVPreLegalizerPass();
 FunctionPass *createSPIRVPostLegalizerPass();
 
 class SPIRVEmitIntrinsicsPass
@@ -154,7 +165,7 @@ createSPIRVInstructionSelector(const SPIRVTargetMachine &TM,
 void initializeSPIRVModuleAnalysisPass(PassRegistry &);
 void initializeSPIRVAsmPrinterPass(PassRegistry &);
 void initializeSPIRVConvergenceRegionAnalysisWrapperPassPass(PassRegistry &);
-void initializeSPIRVPreLegalizerPass(PassRegistry &);
+void initializeSPIRVPreLegalizerLegacyPass(PassRegistry &);
 void initializeSPIRVPreLegalizerCombinerPass(PassRegistry &);
 void initializeSPIRVPostLegalizerPass(PassRegistry &);
 void initializeSPIRVStructurizerPass(PassRegistry &);

--- a/llvm/lib/Target/SPIRV/SPIRVCodeGenPassBuilder.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCodeGenPassBuilder.cpp
@@ -153,7 +153,7 @@ Error SPIRVCodeGenPassBuilder::addIRTranslator(PassManagerWrapper &PMW) {
 void SPIRVCodeGenPassBuilder::addPreLegalizeMachineIR(PassManagerWrapper &PMW) {
   // TODO(boomanaiden154): Add SPIRVPreLegalizerCombiner when it has been
   // ported.
-  // TODO(boomanaiden154): Add SPIRVPreLegalizerPass when it has been ported.
+  addMachineFunctionPass(SPIRVPreLegalizerPass(), PMW);
 }
 
 Error SPIRVCodeGenPassBuilder::addLegalizeMachineIR(PassManagerWrapper &PMW) {

--- a/llvm/lib/Target/SPIRV/SPIRVPassRegistry.def
+++ b/llvm/lib/Target/SPIRV/SPIRVPassRegistry.def
@@ -41,3 +41,9 @@ FUNCTION_PASS("spirv-structurizer", SPIRVStructurizerPass())
 #endif
 FUNCTION_ANALYSIS("spirv-convergence-region", SPIRVConvergenceRegionAnalysis())
 #undef FUNCTION_ANALYSIS
+
+#ifndef MACHINE_FUNCTION_PASS
+#define MACHINE_FUNCTION_PASS(NAME, CREATE_PASS)
+#endif
+MACHINE_FUNCTION_PASS("spirv-prelegalizer", SPIRVPreLegalizerPass())
+#undef MACHINE_FUNCTION_PASS

--- a/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
@@ -18,6 +18,9 @@
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/CodeGen/GlobalISel/CSEInfo.h"
 #include "llvm/CodeGen/GlobalISel/GISelValueTracking.h"
+#include "llvm/CodeGen/MachineFunctionAnalysisManager.h"
+#include "llvm/CodeGen/MachinePassManager.h"
+#include "llvm/IR/Analysis.h"
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/InstrTypes.h"
@@ -29,16 +32,16 @@
 using namespace llvm;
 
 namespace {
-class SPIRVPreLegalizer : public MachineFunctionPass {
+class SPIRVPreLegalizerLegacy : public MachineFunctionPass {
 public:
   static char ID;
-  SPIRVPreLegalizer() : MachineFunctionPass(ID) {}
+  SPIRVPreLegalizerLegacy() : MachineFunctionPass(ID) {}
   bool runOnMachineFunction(MachineFunction &MF) override;
   void getAnalysisUsage(AnalysisUsage &AU) const override;
 };
 } // namespace
 
-void SPIRVPreLegalizer::getAnalysisUsage(AnalysisUsage &AU) const {
+void SPIRVPreLegalizerLegacy::getAnalysisUsage(AnalysisUsage &AU) const {
   AU.addPreserved<GISelValueTrackingAnalysisLegacy>();
   MachineFunctionPass::getAnalysisUsage(AU);
 }
@@ -1299,7 +1302,7 @@ static void removeImplicitFallthroughs(MachineFunction &MF,
   }
 }
 
-bool SPIRVPreLegalizer::runOnMachineFunction(MachineFunction &MF) {
+static bool runPreLegalizer(MachineFunction &MF) {
   // Initialize the type registry.
   const SPIRVSubtarget &ST = MF.getSubtarget<SPIRVSubtarget>();
   SPIRVGlobalRegistry *GR = ST.getSPIRVGlobalRegistry();
@@ -1326,11 +1329,26 @@ bool SPIRVPreLegalizer::runOnMachineFunction(MachineFunction &MF) {
   return true;
 }
 
-INITIALIZE_PASS(SPIRVPreLegalizer, DEBUG_TYPE, "SPIRV pre legalizer", false,
-                false)
+INITIALIZE_PASS(SPIRVPreLegalizerLegacy, DEBUG_TYPE, "SPIRV pre legalizer",
+                false, false)
 
-char SPIRVPreLegalizer::ID = 0;
+char SPIRVPreLegalizerLegacy::ID = 0;
 
-FunctionPass *llvm::createSPIRVPreLegalizerPass() {
-  return new SPIRVPreLegalizer();
+FunctionPass *llvm::createSPIRVPreLegalizerLegacyPass() {
+  return new SPIRVPreLegalizerLegacy();
+}
+
+bool SPIRVPreLegalizerLegacy::runOnMachineFunction(MachineFunction &MF) {
+  return runPreLegalizer(MF);
+}
+
+PreservedAnalyses
+SPIRVPreLegalizerPass::run(MachineFunction &MF,
+                           MachineFunctionAnalysisManager &MFAM) {
+  bool Changed = runPreLegalizer(MF);
+  if (!Changed)
+    return PreservedAnalyses::all();
+
+  return getMachineFunctionPassPreservedAnalyses()
+      .preserve<GISelValueTrackingAnalysis>();
 }

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -56,7 +56,7 @@ extern "C" LLVM_ABI LLVM_EXTERNAL_VISIBILITY void LLVMInitializeSPIRVTarget() {
   initializeSPIRVLegalizePointerCastLegacyPass(PR);
   initializeSPIRVLegalizeZeroSizeArraysLegacyPass(PR);
   initializeSPIRVRegularizerLegacyPass(PR);
-  initializeSPIRVPreLegalizerPass(PR);
+  initializeSPIRVPreLegalizerLegacyPass(PR);
   initializeSPIRVPostLegalizerPass(PR);
   initializeSPIRVMergeRegionExitTargetsLegacyPass(PR);
   initializeSPIRVEmitIntrinsicsLegacyPass(PR);
@@ -241,7 +241,7 @@ bool SPIRVPassConfig::addIRTranslator() {
 
 void SPIRVPassConfig::addPreLegalizeMachineIR() {
   addPass(createSPIRVPreLegalizerCombiner());
-  addPass(createSPIRVPreLegalizerPass());
+  addPass(createSPIRVPreLegalizerLegacyPass());
 }
 
 // Use the default legalizer.


### PR DESCRIPTION
Standard NewPM pass porting. The pass does not use any analyses and was
already largely implemented as static functions so this is mostly just
adding the NewPM boilerplate.
