### PR TITLE
[clang] treat [[gnu::flag_enum]] as equivalent to [[clang::flag_enum]]

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -234,6 +234,8 @@ features cannot lower the translation-unit ABI level;
 
 - Clang now properly propagates attributes on class and variable templates to their redeclarations, which will result in redeclarations not interfering with diagnostics. (#GH209812)
 
+- Clang now recognizes the `[[gnu::flag_enum]]` attribute and treats it equivalent to `[[clang::flag_enum]]`
+
 ### Improvements to Clang's diagnostics
 
 - More consistent rendering of Unicode characters in diagnostic messages.

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1994,7 +1994,7 @@ def MinSize : InheritableAttr {
 }
 
 def FlagEnum : InheritableAttr {
-  let Spellings = [Clang<"flag_enum">];
+  let Spellings = [ClangGCC<"flag_enum">];
   let Subjects = SubjectList<[Enum]>;
   let Documentation = [FlagEnumDocs];
   let SimpleHandler = 1;

--- a/clang/test/Sema/attr-c2x.c
+++ b/clang/test/Sema/attr-c2x.c
@@ -11,6 +11,10 @@ enum [[clang::flag_enum]] EnumFlag {
   D0 = 1, D1 = 8
 };
 
+enum [[gnu::flag_enum]] EnumFlag2 {
+  E0 = 1, E1 = 8
+};
+
 [[clang::overloadable]] void foo(void *c);
 [[clang::overloadable]] void foo(char *c);
 


### PR DESCRIPTION
GCC gained a `[[gnu::flag_enum]]` attribute for consistency with clang in GCC 15. With this patch, the `[[gnu::flag_enum]]` is recognized and handled equivalently to `[[clang::flag_enum]]`.

The patch introducing `[[gnu::flag_enum]]` in GCC is https://github.com/gcc-mirror/gcc/commit/1914ca8791ce4e0ba821e818cb6f86c76afdb6f2. GCC treats `[[clang::flag_enum]]` as equivalent to `[[gnu::flag_enum]`.