### PR TITLE
[clang][Sema] Fix iterator invalidation in isLayoutCompatibleUnion

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -16592,19 +16592,13 @@ static bool isLayoutCompatibleUnion(const ASTContext &C, const RecordDecl *RD1,
                                                           RD2->fields());
 
   for (auto *Field1 : RD1->fields()) {
-    auto I = UnmatchedFields.begin();
-    auto E = UnmatchedFields.end();
-
-    for ( ; I != E; ++I) {
-      if (isLayoutCompatible(C, Field1, *I, /*IsUnionMember=*/true)) {
-        bool Result = UnmatchedFields.erase(*I);
-        (void) Result;
-        assert(Result);
-        break;
-      }
-    }
-    if (I == E)
+    auto It = llvm::find_if(UnmatchedFields, [&](const FieldDecl *Field2) {
+      return isLayoutCompatible(C, Field1, Field2, /*IsUnionMember=*/true);
+    });
+    if (It == UnmatchedFields.end())
       return false;
+    [[maybe_unused]] bool Result = UnmatchedFields.erase(*It);
+    assert(Result);
   }
 
   return UnmatchedFields.empty();


### PR DESCRIPTION
This patch fixes an iterator invalidation bug in isLayoutCompatibleUnion.

Without this patch, if we delete a matching field, we end up
evaluating I == E even though the iterators are invalidated.  Deleting
a match after the loop fixes the problem.

This bug was discovered with tightened epoch checks in
SmallPtrSetIterator.

Assisted-by: Antigravity
