### PR TITLE
[AArch64] Correct FDIV/FSQRT throughput for Neoverse V3ae.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SchedNeoverseV3AE.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedNeoverseV3AE.td
@@ -106,10 +106,6 @@ def V3AEWrite_3c_1M    : SchedWriteRes<[V3AEUnitM]>   { let Latency = 3; }
 def V3AEWrite_2c_1M0   : SchedWriteRes<[V3AEUnitM0]>  { let Latency = 2; }
 def V3AEWrite_3c_1M0   : SchedWriteRes<[V3AEUnitM0]>  { let Latency = 3; }
 def V3AEWrite_4c_1M0   : SchedWriteRes<[V3AEUnitM0]>  { let Latency = 4; }
-def V3AEWrite_12c_1M0  : SchedWriteRes<[V3AEUnitM0]>  { let Latency = 12;
-                                                    let ReleaseAtCycles = [12]; }
-def V3AEWrite_20c_1M0  : SchedWriteRes<[V3AEUnitM0]>  { let Latency = 20;
-                                                    let ReleaseAtCycles = [20]; }
 def V3AEWrite_4c_1L    : SchedWriteRes<[V3AEUnitL]>   { let Latency = 4; }
 def V3AEWrite_6c_1L    : SchedWriteRes<[V3AEUnitL]>   { let Latency = 6; }
 def V3AEWrite_2c_1V    : SchedWriteRes<[V3AEUnitV]>   { let Latency = 2; }
@@ -123,16 +119,11 @@ def V3AEWrite_3c_1V0   : SchedWriteRes<[V3AEUnitV0]>  { let Latency = 3; }
 def V3AEWrite_4c_1V0   : SchedWriteRes<[V3AEUnitV0]>  { let Latency = 4; }
 def V3AEWrite_9c_1V0   : SchedWriteRes<[V3AEUnitV0]>  { let Latency = 9; }
 def V3AEWrite_10c_1V0  : SchedWriteRes<[V3AEUnitV0]>  { let Latency = 10; }
-def V3AEWrite_8c_1V1   : SchedWriteRes<[V3AEUnitV1]> { let Latency = 8; }
-def V3AEWrite_12c_1V0  : SchedWriteRes<[V3AEUnitV0]>  { let Latency = 12;
-                                                    let ReleaseAtCycles = [11]; }
+def V3AEWrite_8c_1V1   : SchedWriteRes<[V3AEUnitV1]>  { let Latency = 8; }
 def V3AEWrite_13c_1V0  : SchedWriteRes<[V3AEUnitV0]>  { let Latency = 13; }
 def V3AEWrite_15c_1V0  : SchedWriteRes<[V3AEUnitV0]>  { let Latency = 15; }
-def V3AEWrite_13c_1V1  : SchedWriteRes<[V3AEUnitV1]> { let Latency = 13;
-                                                   let ReleaseAtCycles = [8]; }
+def V3AEWrite_13c_1V1  : SchedWriteRes<[V3AEUnitV1]>  { let Latency = 13; }
 def V3AEWrite_16c_1V0  : SchedWriteRes<[V3AEUnitV0]>  { let Latency = 16; }
-def V3AEWrite_20c_1V0  : SchedWriteRes<[V3AEUnitV0]>  { let Latency = 20;
-                                                    let ReleaseAtCycles = [20]; }
 def V3AEWrite_2c_1V1   : SchedWriteRes<[V3AEUnitV1]>  { let Latency = 2; }
 def V3AEWrite_3c_1V1   : SchedWriteRes<[V3AEUnitV1]>  { let Latency = 3; }
 def V3AEWrite_4c_1V1   : SchedWriteRes<[V3AEUnitV1]>  { let Latency = 4; }
@@ -942,13 +933,17 @@ def V3AERd_ZBFMAL : SchedReadAdvance<3, [V3AEWr_ZBFMAL]>;
 //===----------------------------------------------------------------------===//
 // Define types with long resource cycles (rc)
 
-def V3AEWrite_6c_1V1_5rc    : SchedWriteRes<[V3AEUnitV1]>  { let Latency =  6; let ReleaseAtCycles = [ 5]; }
-def V3AEWrite_9c_1V1_2rc    : SchedWriteRes<[V3AEUnitV1]>  { let Latency =  9; let ReleaseAtCycles = [ 2]; }
-def V3AEWrite_9c_1V1_4rc    : SchedWriteRes<[V3AEUnitV1]>  { let Latency =  9; let ReleaseAtCycles = [ 4]; }
-def V3AEWrite_10c_1V1_9rc   : SchedWriteRes<[V3AEUnitV1]>  { let Latency = 10; let ReleaseAtCycles = [ 9]; }
-def V3AEWrite_11c_1V1_4rc  : SchedWriteRes<[V3AEUnitV1]> { let Latency = 11; let ReleaseAtCycles = [ 4]; }
-def V3AEWrite_13c_1V1_8rc : SchedWriteRes<[V3AEUnitV1]> { let Latency = 13; let ReleaseAtCycles = [8]; }
-def V3AEWrite_14c_1V1_2rc : SchedWriteRes<[V3AEUnitV1]> { let Latency = 14; let ReleaseAtCycles = [2]; }
+def V3AEWrite_6c_1V1_5rc    : SchedWriteRes<[V3AEUnitV1]>  { let Latency =  6; let ReleaseAtCycles = [5]; }
+def V3AEWrite_9c_1V1_2rc    : SchedWriteRes<[V3AEUnitV1]>  { let Latency =  9; let ReleaseAtCycles = [2]; }
+def V3AEWrite_9c_1V1_4rc    : SchedWriteRes<[V3AEUnitV1]>  { let Latency =  9; let ReleaseAtCycles = [4]; }
+def V3AEWrite_10c_1V1_9rc   : SchedWriteRes<[V3AEUnitV1]>  { let Latency = 10; let ReleaseAtCycles = [9]; }
+def V3AEWrite_11c_1V1_4rc   : SchedWriteRes<[V3AEUnitV1]>  { let Latency = 11; let ReleaseAtCycles = [4]; }
+def V3AEWrite_12c_1M0_12rc  : SchedWriteRes<[V3AEUnitM0]>  { let Latency = 12; let ReleaseAtCycles = [12]; }
+def V3AEWrite_12c_1V0_11rc  : SchedWriteRes<[V3AEUnitV0]>  { let Latency = 12; let ReleaseAtCycles = [11]; }
+def V3AEWrite_13c_1V1_8rc   : SchedWriteRes<[V3AEUnitV1]>  { let Latency = 13; let ReleaseAtCycles = [8]; }
+def V3AEWrite_14c_1V1_2rc   : SchedWriteRes<[V3AEUnitV1]>  { let Latency = 14; let ReleaseAtCycles = [2]; }
+def V3AEWrite_20c_1V0_20rc  : SchedWriteRes<[V3AEUnitV0]>  { let Latency = 20; let ReleaseAtCycles = [20]; }
+def V3AEWrite_20c_1M0_20rc  : SchedWriteRes<[V3AEUnitM0]>  { let Latency = 20; let ReleaseAtCycles = [20]; }
 
 // Miscellaneous
 // -----------------------------------------------------------------------------
@@ -1029,8 +1024,8 @@ def : SchedAlias<WriteImm, V3AEWrite_1c_1I>;
 // -----------------------------------------------------------------------------
 
 // SDIV, UDIV
-def : SchedAlias<WriteID32,  V3AEWrite_12c_1M0>;
-def : SchedAlias<WriteID64,  V3AEWrite_20c_1M0>;
+def : SchedAlias<WriteID32,  V3AEWrite_12c_1M0_12rc>;
+def : SchedAlias<WriteID64,  V3AEWrite_20c_1M0_20rc>;
 
 def : SchedAlias<WriteIM32, V3AEWrite_2c_1M>;
 def : SchedAlias<WriteIM64, V3AEWrite_2c_1M>;
@@ -2103,12 +2098,12 @@ def : InstRW<[V3AEWrite_2c_1V], (instregex "^CPY_ZPm[IV]_[BHSD]",
                                            "^CPY_ZPzI_[BHSD]")>;
 
 // Divides, 32 bit
-def : InstRW<[V3AEWrite_12c_1V0], (instregex "^[SU]DIVR?_ZPmZ_S",
-                                             "^[SU]DIV_ZPZZ_S")>;
+def : InstRW<[V3AEWrite_12c_1V0_11rc], (instregex "^[SU]DIVR?_ZPmZ_S",
+                                                  "^[SU]DIV_ZPZZ_S")>;
 
 // Divides, 64 bit
-def : InstRW<[V3AEWrite_20c_1V0], (instregex "^[SU]DIVR?_ZPmZ_D",
-                                             "^[SU]DIV_ZPZZ_D")>;
+def : InstRW<[V3AEWrite_20c_1V0_20rc], (instregex "^[SU]DIVR?_ZPmZ_D",
+                                                  "^[SU]DIV_ZPZZ_D")>;
 
 // Dot product, 8 bit
 def : InstRW<[V3AEWr_ZDOTB, V3AERd_ZDOTB], (instregex "^[SU]DOT_ZZZI?_BtoS")>;

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3AE-basic-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3AE-basic-instructions.s
@@ -560,7 +560,7 @@
 # CHECK-NEXT:  1      2     0.50                        fabs	d2, d3
 # CHECK-NEXT:  1      2     0.50                        fneg	d4, d5
 # CHECK-NEXT:  1      6     1.00                        fsqrt	h13, h24
-# CHECK-NEXT:  1      13    8.00                        fsqrt	d6, d7
+# CHECK-NEXT:  1      13    1.00                        fsqrt	d6, d7
 # CHECK-NEXT:  1      3     0.50                        fcvt	s8, d9
 # CHECK-NEXT:  1      3     0.50                        fcvt	h10, d11
 # CHECK-NEXT:  1      3     1.00                        frintn	d12, d13
@@ -588,7 +588,7 @@
 # CHECK-NEXT:  1      3     0.50                        fnmul	h3, h15, h7
 # CHECK-NEXT:  1      3     0.50                        fnmul	s22, s23, s2
 # CHECK-NEXT:  1      3     0.50                        fmul	d20, d19, d17
-# CHECK-NEXT:  1      13    8.00                        fdiv	d1, d2, d3
+# CHECK-NEXT:  1      13    1.00                        fdiv	d1, d2, d3
 # CHECK-NEXT:  1      2     0.50                        fadd	d4, d5, d6
 # CHECK-NEXT:  1      2     0.50                        fsub	d7, d8, d9
 # CHECK-NEXT:  1      2     0.50                        fmax	d10, d11, d12
@@ -1278,7 +1278,7 @@
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [0.2]  [1.0]  [1.1]  [2.0]  [2.1]  [2.2]  [2.3]  [3.0]  [3.1]  [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]
-# CHECK-NEXT: 8.67   8.67   8.67   34.00  34.00  40.75  40.75  40.75  40.75  99.33  99.33  170.33 290.63 163.63 79.96  79.96  79.96  79.96  79.96  79.96  71.00  219.50 96.50
+# CHECK-NEXT: 8.67   8.67   8.67   34.00  34.00  40.75  40.75  40.75  40.75  99.33  99.33  170.33 290.63 163.63 79.96  79.96  79.96  79.96  79.96  79.96  71.00  219.50 82.50
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [0.2]  [1.0]  [1.1]  [2.0]  [2.1]  [2.2]  [2.3]  [3.0]  [3.1]  [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]   Instructions:
@@ -1832,7 +1832,7 @@
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     0.50   0.50   fabs	d2, d3
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     0.50   0.50   fneg	d4, d5
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00   fsqrt	h13, h24
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     8.00   fsqrt	d6, d7
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00   fsqrt	d6, d7
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     0.50   0.50   fcvt	s8, d9
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     0.50   0.50   fcvt	h10, d11
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     frintn	d12, d13
@@ -1860,7 +1860,7 @@
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     0.50   0.50   fnmul	h3, h15, h7
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     0.50   0.50   fnmul	s22, s23, s2
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     0.50   0.50   fmul	d20, d19, d17
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     8.00   fdiv	d1, d2, d3
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00   fdiv	d1, d2, d3
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     0.50   0.50   fadd	d4, d5, d6
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     0.50   0.50   fsub	d7, d8, d9
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     0.50   0.50   fmax	d10, d11, d12


### PR DESCRIPTION
This attempts to improve the throughput of fdiv / fsqrt to the correct throughputs of 1 per cycle. I've moved the SchedWriteRes with multiple ReleaseAtCycles to the correct section / naming whilst here. Which has the result of changing the fdiv and fsqrt throughput to 1.