### PR TITLE
[AArch64] Add Neoverse V3AE scheduling info for v264 frecpe

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SchedNeoverseV3AE.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedNeoverseV3AE.td
@@ -1576,6 +1576,7 @@ def : InstRW<[V3AEWrite_4c_2V0], (instrs URECPEv4i32, URSQRTEv4i32)>;
 // ASIMD reciprocal and square root estimate, D-form F32 and scalar forms
 def : InstRW<[V3AEWrite_3c_1V0], (instrs FRECPEv1f16, FRECPEv1i32,
                                          FRECPEv1i64, FRECPEv2f32,
+                                         FRECPEv2f64, FRSQRTEv2f64,
                                          FRSQRTEv1f16, FRSQRTEv1i32,
                                          FRSQRTEv1i64, FRSQRTEv2f32)>;
 

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3AE-neon-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3AE-neon-instructions.s
@@ -398,7 +398,7 @@
 # CHECK-NEXT:  1      3     1.00                        frecpe	h20, h8
 # CHECK-NEXT:  1      3     1.00                        frecpe	d13, d13
 # CHECK-NEXT:  1      3     1.00                        frecpe	s19, s14
-# CHECK-NEXT:  1      2     0.50                        frecpe	v0.2d, v0.2d
+# CHECK-NEXT:  1      3     1.00                        frecpe	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     1.00                        frecpe	v0.2s, v0.2s
 # CHECK-NEXT:  2      4     2.00                        frecpe	v0.4h, v0.4h
 # CHECK-NEXT:  2      4     2.00                        frecpe	v0.4s, v0.4s
@@ -450,7 +450,7 @@
 # CHECK-NEXT:  1      3     1.00                        frsqrte	h23, h26
 # CHECK-NEXT:  1      3     1.00                        frsqrte	d21, d12
 # CHECK-NEXT:  1      3     1.00                        frsqrte	s22, s13
-# CHECK-NEXT:  1      2     0.50                        frsqrte	v0.2d, v0.2d
+# CHECK-NEXT:  1      3     1.00                        frsqrte	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     1.00                        frsqrte	v0.2s, v0.2s
 # CHECK-NEXT:  2      4     2.00                        frsqrte	v0.4h, v0.4h
 # CHECK-NEXT:  2      4     2.00                        frsqrte	v0.4s, v0.4s
@@ -1599,7 +1599,7 @@
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [0.2]  [1.0]  [1.1]  [2.0]  [2.1]  [2.2]  [2.3]  [3.0]  [3.1]  [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     106.00 106.00 189.00 19.13  6.13   6.13   6.13   6.13   6.13   6.13   6.13   83.00  1341.50 859.50
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     106.00 106.00 189.00 19.13  6.13   6.13   6.13   6.13   6.13   6.13   6.13   83.00  1342.50 858.50
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [0.2]  [1.0]  [1.1]  [2.0]  [2.1]  [2.2]  [2.3]  [3.0]  [3.1]  [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]   Instructions:
@@ -1991,7 +1991,7 @@
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     frecpe	h20, h8
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     frecpe	d13, d13
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     frecpe	s19, s14
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     0.50   0.50   frecpe	v0.2d, v0.2d
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     frecpe	v0.2d, v0.2d
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     frecpe	v0.2s, v0.2s
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     frecpe	v0.4h, v0.4h
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     frecpe	v0.4s, v0.4s
@@ -2043,7 +2043,7 @@
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     frsqrte	h23, h26
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     frsqrte	d21, d12
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     frsqrte	s22, s13
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     0.50   0.50   frsqrte	v0.2d, v0.2d
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     frsqrte	v0.2d, v0.2d
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     frsqrte	v0.2s, v0.2s
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     frsqrte	v0.4h, v0.4h
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     frsqrte	v0.4s, v0.4s


### PR DESCRIPTION
This was missing, falling back to the default information. It should be like the others.