### PR TITLE
[VectorCombine] Check call targets when folding deinterleave/interleave pairs

### DIFF
--- a/llvm/include/llvm/IR/Instruction.h
+++ b/llvm/include/llvm/IR/Instruction.h
@@ -951,6 +951,8 @@ public:
     CompareUsingScalarTypes = 1 << 1,
     /// Check for equivalence with intersected callbase attrs.
     CompareUsingIntersectedAttrs = 1 << 2,
+    /// Check for equivalence by comparing call targets.
+    CompareCallTargets = 1 << 3,
   };
 
   /// This function determines if the specified instruction executes the same

--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -1019,6 +1019,7 @@ bool Instruction::isSameOperationAs(const Instruction *I,
   bool IgnoreAlignment = flags & CompareIgnoringAlignment;
   bool UseScalarTypes = flags & CompareUsingScalarTypes;
   bool IntersectAttrs = flags & CompareUsingIntersectedAttrs;
+  bool CheckCallTargets = flags & CompareCallTargets;
 
   if (getOpcode() != I->getOpcode() ||
       getNumOperands() != I->getNumOperands() ||
@@ -1035,6 +1036,11 @@ bool Instruction::isSameOperationAs(const Instruction *I,
           I->getOperand(i)->getType()->getScalarType() :
         getOperand(i)->getType() != I->getOperand(i)->getType())
       return false;
+
+  if (CheckCallTargets)
+    if (const auto *CB = dyn_cast<CallBase>(this))
+      if (CB->getCalledOperand() != cast<CallBase>(I)->getCalledOperand())
+        return false;
 
   return this->hasSameSpecialState(I, IgnoreAlignment, IntersectAttrs);
 }

--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -6153,11 +6153,13 @@ bool VectorCombine::foldDeinterleaveInterleavePair(Instruction &I) {
       return false;
 
     unsigned ChainOperand = CurrentUses.front()->getOperandNo();
-    if (any_of(CurrentUses, [&](Use *U) {
-          auto *Inst = cast<Instruction>(U->getUser());
-          return Inst != FirstInst && (U->getOperandNo() != ChainOperand ||
-                                       !FirstInst->isSameOperationAs(Inst));
-        }))
+    bool MismatchedUse = any_of(CurrentUses, [&](Use *U) {
+      auto *Inst = cast<Instruction>(U->getUser());
+      return Inst != FirstInst && (U->getOperandNo() != ChainOperand ||
+                                   !FirstInst->isSameOperationAs(
+                                       Inst, Instruction::CompareCallTargets));
+    });
+    if (MismatchedUse)
       return false;
 
     auto GetSplatOrScalar = [](Value *V) {

--- a/llvm/test/Transforms/VectorCombine/deinterleave-interleave-pairs.ll
+++ b/llvm/test/Transforms/VectorCombine/deinterleave-interleave-pairs.ll
@@ -712,6 +712,41 @@ else:
   ret <vscale x 16 x i16> zeroinitializer
 }
 
+define <4 x i16> @deinterleave2_same_intrinsic_interleave2(<4 x i16> %v) {
+; CHECK-LABEL: define <4 x i16> @deinterleave2_same_intrinsic_interleave2(
+; CHECK-SAME: <4 x i16> [[V:%.*]]) {
+; CHECK-NEXT:    [[R:%.*]] = call <4 x i16> @llvm.smax.v4i16(<4 x i16> [[V]], <4 x i16> splat (i16 3))
+; CHECK-NEXT:    ret <4 x i16> [[R]]
+;
+  %d = call { <2 x i16>, <2 x i16> } @llvm.vector.deinterleave2.v4i16(<4 x i16> %v)
+  %f0 = extractvalue { <2 x i16>, <2 x i16> } %d, 0
+  %f1 = extractvalue { <2 x i16>, <2 x i16> } %d, 1
+  %u0 = call <2 x i16> @llvm.smax.v2i16(<2 x i16> %f0, <2 x i16> splat (i16 3))
+  %u1 = call <2 x i16> @llvm.smax.v2i16(<2 x i16> %f1, <2 x i16> splat (i16 3))
+  %r = call <4 x i16> @llvm.vector.interleave2.v4i16(<2 x i16> %u0, <2 x i16> %u1)
+  ret <4 x i16> %r
+}
+
+define <4 x i16> @negative_deinterleave2_different_intrinsics_interleave2(<4 x i16> %v) {
+; CHECK-LABEL: define <4 x i16> @negative_deinterleave2_different_intrinsics_interleave2(
+; CHECK-SAME: <4 x i16> [[V:%.*]]) {
+; CHECK-NEXT:    [[D:%.*]] = call { <2 x i16>, <2 x i16> } @llvm.vector.deinterleave2.v4i16(<4 x i16> [[V]])
+; CHECK-NEXT:    [[F0:%.*]] = extractvalue { <2 x i16>, <2 x i16> } [[D]], 0
+; CHECK-NEXT:    [[F1:%.*]] = extractvalue { <2 x i16>, <2 x i16> } [[D]], 1
+; CHECK-NEXT:    [[U0:%.*]] = call <2 x i16> @llvm.smax.v2i16(<2 x i16> [[F0]], <2 x i16> splat (i16 3))
+; CHECK-NEXT:    [[U1:%.*]] = call <2 x i16> @llvm.smin.v2i16(<2 x i16> [[F1]], <2 x i16> splat (i16 3))
+; CHECK-NEXT:    [[R:%.*]] = call <4 x i16> @llvm.vector.interleave2.v4i16(<2 x i16> [[U0]], <2 x i16> [[U1]])
+; CHECK-NEXT:    ret <4 x i16> [[R]]
+;
+  %d = call { <2 x i16>, <2 x i16> } @llvm.vector.deinterleave2.v4i16(<4 x i16> %v)
+  %f0 = extractvalue { <2 x i16>, <2 x i16> } %d, 0
+  %f1 = extractvalue { <2 x i16>, <2 x i16> } %d, 1
+  %u0 = call <2 x i16> @llvm.smax.v2i16(<2 x i16> %f0, <2 x i16> splat (i16 3))
+  %u1 = call <2 x i16> @llvm.smin.v2i16(<2 x i16> %f1, <2 x i16> splat (i16 3))
+  %r = call <4 x i16> @llvm.vector.interleave2.v4i16(<2 x i16> %u0, <2 x i16> %u1)
+  ret <4 x i16> %r
+}
+
 !0 = !{!"function_entry_count", i64 1000}
 !1 = !{!"branch_weights", i32 2, i32 3}
 

--- a/llvm/unittests/IR/InstructionsTest.cpp
+++ b/llvm/unittests/IR/InstructionsTest.cpp
@@ -743,6 +743,80 @@ TEST(InstructionsTest, CloneCall) {
   }
 }
 
+TEST(InstructionsTest, IsSameOperationAsCompareCallTargets) {
+  LLVMContext C;
+  std::unique_ptr<Module> M = parseIR(C, R"(
+declare i32 @foo(i32)
+declare i32 @bar(i32)
+
+define void @test_calls(ptr %fp1, ptr %fp2, i32 %x) {
+entry:
+  %same_direct0 = call i32 @foo(i32 %x)
+  %same_direct1 = call i32 @foo(i32 %x)
+  %diff_direct = call i32 @bar(i32 %x)
+  %same_indirect0 = call i32 %fp1(i32 %x)
+  %same_indirect1 = call i32 %fp1(i32 %x)
+  %diff_indirect = call i32 %fp2(i32 %x)
+  %attr_same0 = call i32 @foo(i32 %x) #0
+  %attr_same1 = call i32 @foo(i32 %x) #1
+  %attr_diff = call i32 @bar(i32 %x) #1
+  ret void
+}
+
+attributes #0 = { nounwind }
+attributes #1 = { willreturn }
+)");
+  ASSERT_TRUE(M);
+
+  auto GetNamedInst = [](Function *F, StringRef Name) -> Instruction * {
+    for (BasicBlock &BB : *F)
+      for (Instruction &I : BB)
+        if (I.getName() == Name)
+          return &I;
+    ADD_FAILURE() << "Could not find instruction " << Name;
+    return nullptr;
+  };
+
+  Function *TestCalls = M->getFunction("test_calls");
+  ASSERT_NE(TestCalls, nullptr);
+  Instruction *SameDirect0 = GetNamedInst(TestCalls, "same_direct0");
+  Instruction *SameDirect1 = GetNamedInst(TestCalls, "same_direct1");
+  Instruction *DiffDirect = GetNamedInst(TestCalls, "diff_direct");
+  Instruction *SameIndirect0 = GetNamedInst(TestCalls, "same_indirect0");
+  Instruction *SameIndirect1 = GetNamedInst(TestCalls, "same_indirect1");
+  Instruction *DiffIndirect = GetNamedInst(TestCalls, "diff_indirect");
+  Instruction *AttrSame0 = GetNamedInst(TestCalls, "attr_same0");
+  Instruction *AttrSame1 = GetNamedInst(TestCalls, "attr_same1");
+  Instruction *AttrDiff = GetNamedInst(TestCalls, "attr_diff");
+  ASSERT_TRUE(SameDirect0 && SameDirect1 && DiffDirect && SameIndirect0 &&
+              SameIndirect1 && DiffIndirect && AttrSame0 && AttrSame1 &&
+              AttrDiff);
+
+  EXPECT_TRUE(SameDirect0->isSameOperationAs(SameDirect1));
+  EXPECT_TRUE(SameDirect0->isSameOperationAs(DiffDirect));
+  EXPECT_TRUE(SameDirect0->isSameOperationAs(SameDirect1,
+                                             Instruction::CompareCallTargets));
+  EXPECT_FALSE(SameDirect0->isSameOperationAs(DiffDirect,
+                                              Instruction::CompareCallTargets));
+
+  EXPECT_TRUE(SameIndirect0->isSameOperationAs(DiffIndirect));
+  EXPECT_TRUE(SameIndirect0->isSameOperationAs(
+      SameIndirect1, Instruction::CompareCallTargets));
+  EXPECT_FALSE(SameIndirect0->isSameOperationAs(
+      DiffIndirect, Instruction::CompareCallTargets));
+
+  EXPECT_FALSE(
+      AttrSame0->isSameOperationAs(AttrSame1, Instruction::CompareCallTargets));
+  EXPECT_TRUE(AttrSame0->isSameOperationAs(
+      AttrSame1, Instruction::CompareCallTargets |
+                     Instruction::CompareUsingIntersectedAttrs));
+  EXPECT_TRUE(AttrSame0->isSameOperationAs(
+      AttrDiff, Instruction::CompareUsingIntersectedAttrs));
+  EXPECT_FALSE(AttrSame0->isSameOperationAs(
+      AttrDiff, Instruction::CompareCallTargets |
+                    Instruction::CompareUsingIntersectedAttrs));
+}
+
 TEST(InstructionsTest, AlterCallBundles) {
   LLVMContext C;
   Type *Int32Ty = Type::getInt32Ty(C);


### PR DESCRIPTION
Instruction::isSameOperationAs() intentionally compares operation shape and
special state without requiring operand identity. For CallBase instructions,
this means calls to different targets with otherwise compatible signatures can
compare as equivalent.

This caused VectorCombine::foldDeinterleaveInterleavePair() to treat
same-signature intrinsics such as llvm.smax and llvm.smin as the same operation
and incorrectly fold them into a single widened call.

Add an opt-in Instruction::CompareCallTargets operation-equivalence flag. When
requested, isSameOperationAs() additionally requires
CallBase::getCalledOperand() to match. Existing callers retain the current
behavior unless they explicitly request call-target comparison.

Update VectorCombine to use the new flag when comparing operations on
deinterleaved chains.

Add direct unit coverage for the new flag and preserve the existing
VectorCombine regression coverage.

Fixes #218162.