### PR TITLE
[llvm-profgen] Fix dereference of empty function range when --disassemble-functions for symbols with no range

### DIFF
--- a/llvm/test/tools/llvm-profgen/X86/pseudoprobe-decoding.test
+++ b/llvm/test/tools/llvm-profgen/X86/pseudoprobe-decoding.test
@@ -1,5 +1,6 @@
 ; RUN: llvm-profgen --format=text --perfscript=%s  --binary=%S/Inputs/inline-cs-pseudoprobe.perfbin --output=%t --show-pseudo-probe --show-disassembly-only | FileCheck %s
 ; RUN: llvm-profgen --format=text --perfscript=%s  --binary=%S/Inputs/inline-cs-pseudoprobe.perfbin --output=%t --show-pseudo-probe --show-disassembly-only --disassemble-functions=main,foo  | FileCheck %s -check-prefix=SYM
+; RUN: llvm-profgen --format=text --perfscript=%s  --binary=%S/Inputs/inline-cs-pseudoprobe.perfbin --output=%t --show-pseudo-probe --show-disassembly-only --disassemble-functions=_IO_stdin_used  | FileCheck %s -check-prefix=NORANGE
 
 PERF_RECORD_MMAP2 2854748/2854748: [0x400000(0x1000) @ 0 00:1d 123291722 526021]: r-xp /home/inline-cs-pseudoprobe.perfbin
 
@@ -83,6 +84,11 @@ PERF_RECORD_MMAP2 2854748/2854748: [0x400000(0x1000) @ 0 00:1d 123291722 526021]
 ; SYM-NOT: <bar>:
 ; SYM: <foo>:
 ; SYM: <main>:
+
+; _IO_stdin_used is in the symbol table but has no function range. Decoding must
+; not crash and nothing should be disassembled for it.
+; NORANGE: Disassembly of section .text
+; NORANGE-NOT: <
 
 
 

--- a/llvm/tools/llvm-profgen/ProfiledBinary.cpp
+++ b/llvm/tools/llvm-profgen/ProfiledBinary.cpp
@@ -72,7 +72,7 @@ static cl::opt<std::string>
 
 static cl::list<std::string> DisassembleFunctions(
     "disassemble-functions", cl::CommaSeparated,
-    cl::desc("List of functions to print disassembly for. Accept demangled "
+    cl::desc("List of functions to print disassembly for. Accept mangled "
              "names only. Only work with show-disassembly-only"),
     cl::cat(ProfGenCategory));
 
@@ -167,9 +167,8 @@ void BinarySizeContextTracker::trackInlineesOptimizedAway(
     for (auto &ProbeFrame : reverse(ProbeContext)) {
       StringRef CallerName = ProbeFrame.first;
       LineLocation CallsiteLoc(ProbeFrame.second, 0);
-      SizeContext =
-          SizeContext->getOrCreateChildContext(CallsiteLoc,
-                                               FunctionId(CallerName));
+      SizeContext = SizeContext->getOrCreateChildContext(
+          CallsiteLoc, FunctionId(CallerName));
     }
     // Add 0 size to make known.
     SizeContext->addFunctionSize(0);
@@ -501,9 +500,11 @@ void ProfiledBinary::decodePseudoProbe(const ObjectFile *Obj) {
         auto GUID = Function::getGUIDAssumingExternalLinkage(F.first());
         if (auto StartAddr = SymbolStartAddrs.lookup(GUID)) {
           FuncStartAddresses[GUID] = StartAddr;
-          FuncRange &Range = StartAddrToFuncRangeMap[StartAddr];
-          GuidFilter.insert(
-              Function::getGUIDAssumingExternalLinkage(Range.getFuncName()));
+          if (FuncRange *Range = findFuncRangeForStartAddr(StartAddr))
+            GuidFilter.insert(
+                Function::getGUIDAssumingExternalLinkage(Range->getFuncName()));
+          else
+            GuidFilter.insert(GUID);
         }
       }
     }


### PR DESCRIPTION
When `--show-disassembly-only` is combined with `--disassemble-functions`, `decodePseudoProbe()` looks up each requested function's start address. If the start address has no entry in `StartAddrToFuncRangeMap`, `[]` operator returns an empty function range which causes crash when `getFuncName()` dereferences it. Look the range up instead of creating one, and fall back to the symbol's own GUID when there is none, so the requested function is still decoded.

Also fix a typo in `--disassemble-functions` help text. `SymbolStartAddrs` is keyed by the GUID of the raw symbol name, so mangled names are what actually resolve. 