### PR TITLE
[libc] Add redirecting headers sys/vfs.h and sys/syslog.h on Linux.

### DIFF
--- a/libc/config/linux/aarch64/headers.txt
+++ b/libc/config/linux/aarch64/headers.txt
@@ -69,12 +69,14 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_sysinfo
     libc.include.sys_syscall
     libc.include.sys_sysmacros
+    libc.include.sys_syslog
     libc.include.sys_time
     libc.include.sys_types
     libc.include.sys_uio
     libc.include.sys_un
     libc.include.sys_unistd
     libc.include.sys_utsname
+    libc.include.sys_vfs
     libc.include.sys_wait
     libc.include.syscall
     libc.include.sysexits

--- a/libc/config/linux/riscv/headers.txt
+++ b/libc/config/linux/riscv/headers.txt
@@ -69,12 +69,14 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_statvfs
     libc.include.sys_sysinfo
     libc.include.sys_syscall
+    libc.include.sys_syslog
     libc.include.sys_time
     libc.include.sys_types
     libc.include.sys_uio
     libc.include.sys_un
     libc.include.sys_unistd
     libc.include.sys_utsname
+    libc.include.sys_vfs
     libc.include.sys_wait
     libc.include.syscall
     libc.include.sysexits

--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -72,6 +72,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_sysinfo
     libc.include.sys_syscall
     libc.include.sys_sysmacros
+    libc.include.sys_syslog
     libc.include.sys_time
     libc.include.sys_types
     libc.include.sys_ucontext
@@ -79,6 +80,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_un
     libc.include.sys_unistd
     libc.include.sys_utsname
+    libc.include.sys_vfs
     libc.include.sys_wait
     libc.include.syscall
     libc.include.sysexits

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -248,6 +248,14 @@ add_header_macro(
 )
 
 add_header_macro(
+  sys_syslog
+  ../libc/include/sys/syslog.yaml
+  sys/syslog.h
+  DEPENDS
+    .syslog
+)
+
+add_header_macro(
   alloca
   ../libc/include/alloca.yaml
   alloca.h
@@ -1007,6 +1015,14 @@ add_header_macro(
   DEPENDS
     .llvm_libc_common_h
     .llvm-libc-types.struct_sockaddr_un
+)
+
+add_header_macro(
+  sys_vfs
+  ../libc/include/sys/vfs.yaml
+  sys/vfs.h
+  DEPENDS
+    .sys_statfs
 )
 
 add_header_macro(

--- a/libc/include/sys/syslog.yaml
+++ b/libc/include/sys/syslog.yaml
@@ -1,0 +1,5 @@
+header: sys/syslog.h
+public_includes:
+  - syslog.h
+standards:
+  - posix

--- a/libc/include/sys/vfs.yaml
+++ b/libc/include/sys/vfs.yaml
@@ -1,0 +1,5 @@
+header: sys/vfs.h
+public_includes:
+  - sys/statfs.h
+standards:
+  - linux


### PR DESCRIPTION
* `<sys/vfs.h>` is a Linux header for providing `statfs` function, and can be used interchangeably with `<sys/statfs.h>` (https://man7.org/linux/man-pages/man2/statfs.2.html). Simply redirect the former to the latter, as `statfs` is already implemented.
* `<sys/syslog.h>` is frequently used instead of POSIX-specified `<syslog.h>` header, so create the redirecting alias for it as well.

This would fix one of the problems in issue #97191 (building Clang against LLVM-libc), since `<sys/vfs.h>` is actually used by LLVM Support.