### PR TITLE
[AArch64] Update the scheduling info for scvtf on Neoverse V3ae.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SchedNeoverseV3AE.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedNeoverseV3AE.td
@@ -1428,32 +1428,24 @@ def : InstRW<[V3AEWrite_3c_1V0], (instregex "^FCVTN(v2|v4)i32",
 // ASIMD FP convert, other, D-form F32 and Q-form F64
 def : InstRW<[V3AEWrite_3c_1V0], (instregex "^FCVT[AMNPZ][SU]v2f(32|64)$",
                                             "^FCVT[AMNPZ][SU]v2i(32|64)_shift$",
-                                            "^FCVT[AMNPZ][SU]v1i64$",
-                                            "^FCVTZ[SU]d$",
+                                            "^FCVT[AMNPZ][SU]v1(f16|i32|i64)$",
+                                            "^FCVTZ[SU][dsh]$",
                                             "^[SU]CVTFv2f(32|64)$",
                                             "^[SU]CVTFv2i(32|64)_shift$",
-                                            "^[SU]CVTFv1i64$",
-                                            "^[SU]CVTFd$")>;
+                                            "^[SU]CVTFv1i(16|32|64)$",
+                                            "^[SU]CVTF[dsh]$")>;
 
 // ASIMD FP convert, other, D-form F16 and Q-form F32
 def : InstRW<[V3AEWrite_4c_2V0], (instregex "^FCVT[AMNPZ][SU]v4f(16|32)$",
                                             "^FCVT[AMNPZ][SU]v4i(16|32)_shift$",
-                                            "^FCVT[AMNPZ][SU]v1i32$",
-                                            "^FCVTZ[SU]s$",
                                             "^[SU]CVTFv4f(16|32)$",
-                                            "^[SU]CVTFv4i(16|32)_shift$",
-                                            "^[SU]CVTFv1i32$",
-                                            "^[SU]CVTFs$")>;
+                                            "^[SU]CVTFv4i(16|32)_shift$")>;
 
 // ASIMD FP convert, other, Q-form F16
 def : InstRW<[V3AEWrite_6c_4V0], (instregex "^FCVT[AMNPZ][SU]v8f16$",
                                             "^FCVT[AMNPZ][SU]v8i16_shift$",
-                                            "^FCVT[AMNPZ][SU]v1f16$",
-                                            "^FCVTZ[SU]h$",
                                             "^[SU]CVTFv8f16$",
-                                            "^[SU]CVTFv8i16_shift$",
-                                            "^[SU]CVTFv1i16$",
-                                            "^[SU]CVTFh$")>;
+                                            "^[SU]CVTFv8i16_shift$")>;
 
 // ASIMD FP divide, D-form, F16
 def : InstRW<[V3AEWrite_9c_1V1_4rc], (instrs FDIVv4f16)>;

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3AE-neon-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3AE-neon-instructions.s
@@ -192,16 +192,16 @@
 # CHECK-NEXT:  1      2     0.50                        fcmlt	v8.4h, v2.4h, #0.0
 # CHECK-NEXT:  1      2     0.50                        fcmlt	v7.2d, v16.2d, #0.0
 # CHECK-NEXT:  1      3     1.00                        fcvtas	d21, d14
-# CHECK-NEXT:  2      4     2.00                        fcvtas	s12, s13
-# CHECK-NEXT:  4      6     4.00                        fcvtas	h12, h13
+# CHECK-NEXT:  1      3     1.00                        fcvtas	s12, s13
+# CHECK-NEXT:  1      3     1.00                        fcvtas	h12, h13
 # CHECK-NEXT:  1      3     1.00                        fcvtas	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     1.00                        fcvtas	v0.2s, v0.2s
 # CHECK-NEXT:  2      4     2.00                        fcvtas	v0.4h, v0.4h
 # CHECK-NEXT:  2      4     2.00                        fcvtas	v0.4s, v0.4s
 # CHECK-NEXT:  4      6     4.00                        fcvtas	v0.8h, v0.8h
 # CHECK-NEXT:  1      3     1.00                        fcvtau	d21, d14
-# CHECK-NEXT:  2      4     2.00                        fcvtau	s12, s13
-# CHECK-NEXT:  4      6     4.00                        fcvtau	h12, h13
+# CHECK-NEXT:  1      3     1.00                        fcvtau	s12, s13
+# CHECK-NEXT:  1      3     1.00                        fcvtau	h12, h13
 # CHECK-NEXT:  1      3     1.00                        fcvtau	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     1.00                        fcvtau	v0.2s, v0.2s
 # CHECK-NEXT:  2      4     2.00                        fcvtau	v0.4h, v0.4h
@@ -212,16 +212,16 @@
 # CHECK-NEXT:  1      3     1.00                        fcvtl2	v0.2d, v0.4s
 # CHECK-NEXT:  2      4     2.00                        fcvtl2	v0.4s, v0.8h
 # CHECK-NEXT:  1      3     1.00                        fcvtms	d21, d14
-# CHECK-NEXT:  2      4     2.00                        fcvtms	s22, s13
-# CHECK-NEXT:  4      6     4.00                        fcvtms	h22, h13
+# CHECK-NEXT:  1      3     1.00                        fcvtms	s22, s13
+# CHECK-NEXT:  1      3     1.00                        fcvtms	h22, h13
 # CHECK-NEXT:  1      3     1.00                        fcvtms	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     1.00                        fcvtms	v0.2s, v0.2s
 # CHECK-NEXT:  2      4     2.00                        fcvtms	v0.4h, v0.4h
 # CHECK-NEXT:  2      4     2.00                        fcvtms	v0.4s, v0.4s
 # CHECK-NEXT:  4      6     4.00                        fcvtms	v0.8h, v0.8h
 # CHECK-NEXT:  1      3     1.00                        fcvtmu	d21, d14
-# CHECK-NEXT:  2      4     2.00                        fcvtmu	s12, s13
-# CHECK-NEXT:  4      6     4.00                        fcvtmu	h12, h13
+# CHECK-NEXT:  1      3     1.00                        fcvtmu	s12, s13
+# CHECK-NEXT:  1      3     1.00                        fcvtmu	h12, h13
 # CHECK-NEXT:  1      3     1.00                        fcvtmu	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     1.00                        fcvtmu	v0.2s, v0.2s
 # CHECK-NEXT:  2      4     2.00                        fcvtmu	v0.4h, v0.4h
@@ -232,32 +232,32 @@
 # CHECK-NEXT:  1      3     1.00                        fcvtn2	v0.4s, v0.2d
 # CHECK-NEXT:  2      4     2.00                        fcvtn2	v0.8h, v0.4s
 # CHECK-NEXT:  1      3     1.00                        fcvtns	d21, d14
-# CHECK-NEXT:  2      4     2.00                        fcvtns	s22, s13
-# CHECK-NEXT:  4      6     4.00                        fcvtns	h22, h13
+# CHECK-NEXT:  1      3     1.00                        fcvtns	s22, s13
+# CHECK-NEXT:  1      3     1.00                        fcvtns	h22, h13
 # CHECK-NEXT:  1      3     1.00                        fcvtns	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     1.00                        fcvtns	v0.2s, v0.2s
 # CHECK-NEXT:  2      4     2.00                        fcvtns	v0.4h, v0.4h
 # CHECK-NEXT:  2      4     2.00                        fcvtns	v0.4s, v0.4s
 # CHECK-NEXT:  4      6     4.00                        fcvtns	v0.8h, v0.8h
 # CHECK-NEXT:  1      3     1.00                        fcvtnu	d21, d14
-# CHECK-NEXT:  2      4     2.00                        fcvtnu	s12, s13
-# CHECK-NEXT:  4      6     4.00                        fcvtnu	h12, h13
+# CHECK-NEXT:  1      3     1.00                        fcvtnu	s12, s13
+# CHECK-NEXT:  1      3     1.00                        fcvtnu	h12, h13
 # CHECK-NEXT:  1      3     1.00                        fcvtnu	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     1.00                        fcvtnu	v0.2s, v0.2s
 # CHECK-NEXT:  2      4     2.00                        fcvtnu	v0.4h, v0.4h
 # CHECK-NEXT:  2      4     2.00                        fcvtnu	v0.4s, v0.4s
 # CHECK-NEXT:  4      6     4.00                        fcvtnu	v0.8h, v0.8h
 # CHECK-NEXT:  1      3     1.00                        fcvtps	d21, d14
-# CHECK-NEXT:  2      4     2.00                        fcvtps	s22, s13
-# CHECK-NEXT:  4      6     4.00                        fcvtps	h22, h13
+# CHECK-NEXT:  1      3     1.00                        fcvtps	s22, s13
+# CHECK-NEXT:  1      3     1.00                        fcvtps	h22, h13
 # CHECK-NEXT:  1      3     1.00                        fcvtps	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     1.00                        fcvtps	v0.2s, v0.2s
 # CHECK-NEXT:  2      4     2.00                        fcvtps	v0.4h, v0.4h
 # CHECK-NEXT:  2      4     2.00                        fcvtps	v0.4s, v0.4s
 # CHECK-NEXT:  4      6     4.00                        fcvtps	v0.8h, v0.8h
 # CHECK-NEXT:  1      3     1.00                        fcvtpu	d21, d14
-# CHECK-NEXT:  2      4     2.00                        fcvtpu	s12, s13
-# CHECK-NEXT:  4      6     4.00                        fcvtpu	h12, h13
+# CHECK-NEXT:  1      3     1.00                        fcvtpu	s12, s13
+# CHECK-NEXT:  1      3     1.00                        fcvtpu	h12, h13
 # CHECK-NEXT:  1      3     1.00                        fcvtpu	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     1.00                        fcvtpu	v0.2s, v0.2s
 # CHECK-NEXT:  2      4     2.00                        fcvtpu	v0.4h, v0.4h
@@ -268,10 +268,10 @@
 # CHECK-NEXT:  1      3     1.00                        fcvtxn2	v0.4s, v0.2d
 # CHECK-NEXT:  1      3     1.00                        fcvtzs	d21, d12, #1
 # CHECK-NEXT:  1      3     1.00                        fcvtzs	d21, d14
-# CHECK-NEXT:  2      4     2.00                        fcvtzs	s12, s13
-# CHECK-NEXT:  2      4     2.00                        fcvtzs	s21, s12, #1
-# CHECK-NEXT:  4      6     4.00                        fcvtzs	h21, h14
-# CHECK-NEXT:  4      6     4.00                        fcvtzs	h21, h12, #1
+# CHECK-NEXT:  1      3     1.00                        fcvtzs	s12, s13
+# CHECK-NEXT:  1      3     1.00                        fcvtzs	s21, s12, #1
+# CHECK-NEXT:  1      3     1.00                        fcvtzs	h21, h14
+# CHECK-NEXT:  1      3     1.00                        fcvtzs	h21, h12, #1
 # CHECK-NEXT:  1      3     1.00                        fcvtzs	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     1.00                        fcvtzs	v0.2d, v0.2d, #3
 # CHECK-NEXT:  1      3     1.00                        fcvtzs	v0.2s, v0.2s
@@ -284,10 +284,10 @@
 # CHECK-NEXT:  4      6     4.00                        fcvtzs	v18.8h, v10.8h, #7
 # CHECK-NEXT:  1      3     1.00                        fcvtzu	d21, d12, #1
 # CHECK-NEXT:  1      3     1.00                        fcvtzu	d21, d14
-# CHECK-NEXT:  2      4     2.00                        fcvtzu	s12, s13
-# CHECK-NEXT:  2      4     2.00                        fcvtzu	s21, s12, #1
-# CHECK-NEXT:  4      6     4.00                        fcvtzu	h12, h13
-# CHECK-NEXT:  4      6     4.00                        fcvtzu	h21, h12, #1
+# CHECK-NEXT:  1      3     1.00                        fcvtzu	s12, s13
+# CHECK-NEXT:  1      3     1.00                        fcvtzu	s21, s12, #1
+# CHECK-NEXT:  1      3     1.00                        fcvtzu	h12, h13
+# CHECK-NEXT:  1      3     1.00                        fcvtzu	h21, h12, #1
 # CHECK-NEXT:  1      3     1.00                        fcvtzu	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     1.00                        fcvtzu	v0.2d, v0.2d, #3
 # CHECK-NEXT:  1      3     1.00                        fcvtzu	v0.2s, v0.2s
@@ -751,12 +751,12 @@
 # CHECK-NEXT:  1      2     0.50                        saddw2	v0.2d, v0.2d, v0.4s
 # CHECK-NEXT:  1      2     0.50                        saddw2	v0.4s, v0.4s, v0.8h
 # CHECK-NEXT:  1      2     0.50                        saddw2	v0.8h, v0.8h, v0.16b
-# CHECK-NEXT:  4      6     4.00                        scvtf	h4, h8, #9
-# CHECK-NEXT:  4      6     4.00                        scvtf	h5, h14
+# CHECK-NEXT:  1      3     1.00                        scvtf	h4, h8, #9
+# CHECK-NEXT:  1      3     1.00                        scvtf	h5, h14
 # CHECK-NEXT:  1      3     1.00                        scvtf	d21, d12
 # CHECK-NEXT:  1      3     1.00                        scvtf	d21, d12, #64
-# CHECK-NEXT:  2      4     2.00                        scvtf	s22, s13
-# CHECK-NEXT:  2      4     2.00                        scvtf	s22, s13, #32
+# CHECK-NEXT:  1      3     1.00                        scvtf	s22, s13
+# CHECK-NEXT:  1      3     1.00                        scvtf	s22, s13, #32
 # CHECK-NEXT:  1      3     1.00                        scvtf	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     1.00                        scvtf	v0.2d, v0.2d, #3
 # CHECK-NEXT:  1      3     1.00                        scvtf	v0.2s, v0.2s
@@ -1302,13 +1302,13 @@
 # CHECK-NEXT:  1      2     0.50                        uaddw2	v0.4s, v0.4s, v0.8h
 # CHECK-NEXT:  1      2     0.50                        uaddw2	v0.8h, v0.8h, v0.16b
 # CHECK-NEXT:  1      3     1.00                        ucvtf	h17, x12
-# CHECK-NEXT:  4      6     4.00                        ucvtf	h22, h16, #11
-# CHECK-NEXT:  4      6     4.00                        ucvtf	h7, h21
+# CHECK-NEXT:  1      3     1.00                        ucvtf	h22, h16, #11
+# CHECK-NEXT:  1      3     1.00                        ucvtf	h7, h21
 # CHECK-NEXT:  1      3     1.00                        ucvtf	d21, d14
 # CHECK-NEXT:  1      3     1.00                        ucvtf	d21, d14, #64
 # CHECK-NEXT:  1      3     1.00                        ucvtf	s8, x0
-# CHECK-NEXT:  2      4     2.00                        ucvtf	s22, s13
-# CHECK-NEXT:  2      4     2.00                        ucvtf	s22, s13, #32
+# CHECK-NEXT:  1      3     1.00                        ucvtf	s22, s13
+# CHECK-NEXT:  1      3     1.00                        ucvtf	s22, s13, #32
 # CHECK-NEXT:  1      3     1.00                        ucvtf	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     1.00                        ucvtf	v0.2d, v0.2d, #3
 # CHECK-NEXT:  1      3     1.00                        ucvtf	v0.2s, v0.2s
@@ -1599,7 +1599,7 @@
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [0.2]  [1.0]  [1.1]  [2.0]  [2.1]  [2.2]  [2.3]  [3.0]  [3.1]  [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     106.00 106.00 189.00 19.13  6.13   6.13   6.13   6.13   6.13   6.13   6.13   83.00  1342.50 858.50
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     106.00 106.00 189.00 19.13  6.13   6.13   6.13   6.13   6.13   6.13   6.13   83.00  1278.50 858.50
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [0.2]  [1.0]  [1.1]  [2.0]  [2.1]  [2.2]  [2.3]  [3.0]  [3.1]  [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]   Instructions:
@@ -1785,16 +1785,16 @@
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     0.50   0.50   fcmlt	v8.4h, v2.4h, #0.0
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     0.50   0.50   fcmlt	v7.2d, v16.2d, #0.0
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtas	d21, d14
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtas	s12, s13
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     fcvtas	h12, h13
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtas	s12, s13
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtas	h12, h13
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtas	v0.2d, v0.2d
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtas	v0.2s, v0.2s
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtas	v0.4h, v0.4h
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtas	v0.4s, v0.4s
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     fcvtas	v0.8h, v0.8h
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtau	d21, d14
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtau	s12, s13
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     fcvtau	h12, h13
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtau	s12, s13
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtau	h12, h13
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtau	v0.2d, v0.2d
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtau	v0.2s, v0.2s
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtau	v0.4h, v0.4h
@@ -1805,16 +1805,16 @@
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtl2	v0.2d, v0.4s
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtl2	v0.4s, v0.8h
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtms	d21, d14
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtms	s22, s13
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     fcvtms	h22, h13
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtms	s22, s13
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtms	h22, h13
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtms	v0.2d, v0.2d
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtms	v0.2s, v0.2s
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtms	v0.4h, v0.4h
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtms	v0.4s, v0.4s
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     fcvtms	v0.8h, v0.8h
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtmu	d21, d14
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtmu	s12, s13
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     fcvtmu	h12, h13
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtmu	s12, s13
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtmu	h12, h13
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtmu	v0.2d, v0.2d
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtmu	v0.2s, v0.2s
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtmu	v0.4h, v0.4h
@@ -1825,32 +1825,32 @@
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtn2	v0.4s, v0.2d
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtn2	v0.8h, v0.4s
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtns	d21, d14
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtns	s22, s13
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     fcvtns	h22, h13
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtns	s22, s13
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtns	h22, h13
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtns	v0.2d, v0.2d
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtns	v0.2s, v0.2s
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtns	v0.4h, v0.4h
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtns	v0.4s, v0.4s
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     fcvtns	v0.8h, v0.8h
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtnu	d21, d14
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtnu	s12, s13
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     fcvtnu	h12, h13
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtnu	s12, s13
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtnu	h12, h13
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtnu	v0.2d, v0.2d
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtnu	v0.2s, v0.2s
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtnu	v0.4h, v0.4h
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtnu	v0.4s, v0.4s
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     fcvtnu	v0.8h, v0.8h
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtps	d21, d14
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtps	s22, s13
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     fcvtps	h22, h13
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtps	s22, s13
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtps	h22, h13
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtps	v0.2d, v0.2d
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtps	v0.2s, v0.2s
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtps	v0.4h, v0.4h
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtps	v0.4s, v0.4s
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     fcvtps	v0.8h, v0.8h
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtpu	d21, d14
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtpu	s12, s13
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     fcvtpu	h12, h13
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtpu	s12, s13
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtpu	h12, h13
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtpu	v0.2d, v0.2d
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtpu	v0.2s, v0.2s
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtpu	v0.4h, v0.4h
@@ -1861,10 +1861,10 @@
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtxn2	v0.4s, v0.2d
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtzs	d21, d12, #1
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtzs	d21, d14
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtzs	s12, s13
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtzs	s21, s12, #1
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     fcvtzs	h21, h14
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     fcvtzs	h21, h12, #1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtzs	s12, s13
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtzs	s21, s12, #1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtzs	h21, h14
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtzs	h21, h12, #1
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtzs	v0.2d, v0.2d
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtzs	v0.2d, v0.2d, #3
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtzs	v0.2s, v0.2s
@@ -1877,10 +1877,10 @@
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     fcvtzs	v18.8h, v10.8h, #7
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtzu	d21, d12, #1
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtzu	d21, d14
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtzu	s12, s13
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     fcvtzu	s21, s12, #1
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     fcvtzu	h12, h13
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     fcvtzu	h21, h12, #1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtzu	s12, s13
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtzu	s21, s12, #1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtzu	h12, h13
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtzu	h21, h12, #1
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtzu	v0.2d, v0.2d
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtzu	v0.2d, v0.2d, #3
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     fcvtzu	v0.2s, v0.2s
@@ -2344,12 +2344,12 @@
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     0.50   0.50   saddw2	v0.2d, v0.2d, v0.4s
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     0.50   0.50   saddw2	v0.4s, v0.4s, v0.8h
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     0.50   0.50   saddw2	v0.8h, v0.8h, v0.16b
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     scvtf	h4, h8, #9
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     scvtf	h5, h14
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     scvtf	h4, h8, #9
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     scvtf	h5, h14
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     scvtf	d21, d12
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     scvtf	d21, d12, #64
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     scvtf	s22, s13
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     scvtf	s22, s13, #32
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     scvtf	s22, s13
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     scvtf	s22, s13, #32
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     scvtf	v0.2d, v0.2d
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     scvtf	v0.2d, v0.2d, #3
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     scvtf	v0.2s, v0.2s
@@ -2895,13 +2895,13 @@
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     0.50   0.50   uaddw2	v0.4s, v0.4s, v0.8h
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     0.50   0.50   uaddw2	v0.8h, v0.8h, v0.16b
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -     ucvtf	h17, x12
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     ucvtf	h22, h16, #11
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     ucvtf	h7, h21
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     ucvtf	h22, h16, #11
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     ucvtf	h7, h21
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     ucvtf	d21, d14
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     ucvtf	d21, d14, #64
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -     ucvtf	s8, x0
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     ucvtf	s22, s13
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     ucvtf	s22, s13, #32
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     ucvtf	s22, s13
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     ucvtf	s22, s13, #32
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     ucvtf	v0.2d, v0.2d
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     ucvtf	v0.2d, v0.2d, #3
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     ucvtf	v0.2s, v0.2s


### PR DESCRIPTION
These scalar instructions were being treated like vector operations, but only require a single microop.