### PR TITLE
[libc] Fix types provided by fcntl.h header.

### DIFF
--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -64,9 +64,9 @@ add_header_macro(
   DEPENDS
     .llvm-libc-macros.fcntl_macros
     .llvm-libc-types.mode_t
+    .llvm-libc-types.struct_f_owner_ex
     .llvm-libc-types.struct_flock
     .llvm-libc-types.struct_flock64
-    .llvm-libc-types.off64_t
     .llvm-libc-types.pid_t
     .llvm-libc-types.off_t
     .llvm_libc_common_h

--- a/libc/include/fcntl.yaml
+++ b/libc/include/fcntl.yaml
@@ -11,8 +11,12 @@ macros:
   - macro_name: AT_EACCESS
     macro_header: fcntl-macros.h
 types:
-  - type_name: off_t
   - type_name: mode_t
+  - type_name: off_t
+  - type_name: pid_t
+  - type_name: struct_f_owner_ex
+  - type_name: struct_flock
+  - type_name: struct_flock64
 enums: []
 objects: []
 functions:


### PR DESCRIPTION
According to POSIX, `<fcntl.h>` header should provide definitions for `f_owner_ex` structure, `flock` structure, as well as `mode_t`, `off_t`, and `pid_t` types. Reflect that in the YAML definition to ensure generated `<fcntl.h>` indeed provide them. The type definitions themselves were already present in the LLVM-libc.

This fixes another problem while building Clang on Linux against LLVM-libc (issue #97191)