### PR TITLE
[compiler-rt][msan] Ignore addrinfo padding in getaddrinfo interceptor

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc
@@ -2971,8 +2971,30 @@ INTERCEPTOR(int, getaddrinfo, char *node, char *service,
   if (node) COMMON_INTERCEPTOR_READ_RANGE(ctx, node, internal_strlen(node) + 1);
   if (service)
     COMMON_INTERCEPTOR_READ_RANGE(ctx, service, internal_strlen(service) + 1);
-  if (hints)
-    COMMON_INTERCEPTOR_READ_RANGE(ctx, hints, sizeof(__sanitizer_addrinfo));
+  if (hints) {
+    // Check individual members instead of the whole structure to avoid
+    // requiring callers to initialize padding bytes.
+    COMMON_INTERCEPTOR_READ_RANGE(ctx, &hints->ai_flags,
+                                  sizeof(hints->ai_flags));
+    COMMON_INTERCEPTOR_READ_RANGE(ctx, &hints->ai_family,
+                                  sizeof(hints->ai_family));
+    COMMON_INTERCEPTOR_READ_RANGE(ctx, &hints->ai_socktype,
+                                  sizeof(hints->ai_socktype));
+    COMMON_INTERCEPTOR_READ_RANGE(ctx, &hints->ai_protocol,
+                                  sizeof(hints->ai_protocol));
+    COMMON_INTERCEPTOR_READ_RANGE(ctx, &hints->ai_addrlen,
+                                  sizeof(hints->ai_addrlen));
+    COMMON_INTERCEPTOR_READ_RANGE(ctx, &hints->ai_addr,
+                                  sizeof(hints->ai_addr));
+    COMMON_INTERCEPTOR_READ_RANGE(ctx, &hints->ai_canonname,
+                                  sizeof(hints->ai_canonname));
+    COMMON_INTERCEPTOR_READ_RANGE(ctx, &hints->ai_next,
+                                  sizeof(hints->ai_next));
+#if SANITIZER_AIX
+    COMMON_INTERCEPTOR_READ_RANGE(ctx, &hints->ai_eflags,
+                                  sizeof(hints->ai_eflags));
+#endif
+  }
   // FIXME: under ASan the call below may write to freed memory and corrupt
   // its metadata. See
   // https://github.com/google/sanitizers/issues/321.

--- a/compiler-rt/test/msan/getaddrinfo-padding.cpp
+++ b/compiler-rt/test/msan/getaddrinfo-padding.cpp
@@ -1,0 +1,27 @@
+// RUN: %clangxx_msan -O0 %s -o %t && %run %t
+// RUN: %clangxx_msan -O3 %s -o %t && %run %t
+
+#include <assert.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+int main(void) {
+  struct addrinfo hints;
+
+  hints.ai_flags = 0;
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+  hints.ai_protocol = 0;
+  hints.ai_addrlen = 0;
+  hints.ai_addr = nullptr;
+  hints.ai_canonname = nullptr;
+  hints.ai_next = nullptr;
+
+  struct addrinfo *res = nullptr;
+  int ret = getaddrinfo("127.0.0.1", "4567", &hints, &res);
+  assert(ret == 0);
+
+  freeaddrinfo(res);
+  return 0;
+}

--- a/compiler-rt/test/msan/getaddrinfo-positive.cpp
+++ b/compiler-rt/test/msan/getaddrinfo-positive.cpp
@@ -16,7 +16,7 @@ int main(void) {
   int res = getaddrinfo("localhost", NULL, NULL, &ai);
   if (ai) z = 1; // OK
   res = getaddrinfo("localhost", NULL, &hint, &ai);
-  // CHECK: Uninitialized bytes in getaddrinfo at offset 0 inside [0x{{.*}}, 48)
+  // CHECK: Uninitialized bytes in getaddrinfo at offset 0 inside [0x{{.*}}, 4)
   // CHECK: WARNING: MemorySanitizer: use-of-uninitialized-value
   // CHECK: #0 {{.*}} in main {{.*}}getaddrinfo-positive.cpp:[[@LINE-3]]
   return 0;


### PR DESCRIPTION
Avoid checking padding bytes in `struct addrinfo` in the `getaddrinfo` interceptor.

The interceptor used a single `COMMON_INTERCEPTOR_READ_RANGE` for the
whole structure, which caused MSan to report uninitialized padding even when all
named members were initialized.

Check each member separately instead.

Testing
- Added `getaddrinfo-padding.cpp` to cover the padding case
- Verified the new test fails before the fix and passes after the change
- Verified `getaddrinfo-positive.cpp` still reports uninitialized fields
- Ran `ninja -C build/runtimes/runtimes-bins check-msan` on AArch64 Linux

Fixes #162216 