### PR TITLE
[libc] Add placeholder for sys/mount.h Linux header.

### DIFF
--- a/libc/config/linux/aarch64/headers.txt
+++ b/libc/config/linux/aarch64/headers.txt
@@ -52,6 +52,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_fcntl
     libc.include.sys_ioctl
     libc.include.sys_mman
+    libc.include.sys_mount
     libc.include.sys_param
     libc.include.sys_personality
     libc.include.sys_poll

--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -54,6 +54,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_ioctl
     libc.include.sys_ipc
     libc.include.sys_mman
+    libc.include.sys_mount
     libc.include.sys_param
     libc.include.sys_personality
     libc.include.sys_poll

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -723,6 +723,15 @@ add_header_macro(
 )
 
 add_header_macro(
+  sys_mount
+  ../libc/include/sys/mount.yaml
+  sys/mount.h
+  DEPENDS
+    .llvm_libc_common_h
+    .llvm-libc-macros.sys_mount_macros
+)
+
+add_header_macro(
   sys_param
   ../libc/include/sys/param.yaml
   sys/param.h

--- a/libc/include/llvm-libc-macros/CMakeLists.txt
+++ b/libc/include/llvm-libc-macros/CMakeLists.txt
@@ -288,6 +288,12 @@ add_macro_header(
 )
 
 add_macro_header(
+  sys_mount_macros
+  HDR
+    sys-mount-macros.h
+)
+
+add_macro_header(
   sys_personality_macros
   HDR
     sys-personality-macros.h

--- a/libc/include/llvm-libc-macros/linux/CMakeLists.txt
+++ b/libc/include/llvm-libc-macros/linux/CMakeLists.txt
@@ -47,6 +47,12 @@ add_header(
 )
 
 add_header(
+  sys_mount_macros
+  HDR
+    sys-mount-macros.h
+)
+
+add_header(
   sys_personality_macros
   HDR
     sys-personality-macros.h

--- a/libc/include/llvm-libc-macros/linux/sys-mount-macros.h
+++ b/libc/include/llvm-libc-macros/linux/sys-mount-macros.h
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Linux specific declarations of macros from sys/mount.h.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_MACROS_LINUX_SYS_MOUNT_MACROS_H
+#define LLVM_LIBC_MACROS_LINUX_SYS_MOUNT_MACROS_H
+
+#define MS_RDONLY (1 << 0)
+#define MS_NOSUID (1 << 1)
+#define MS_NODEV (1 << 2)
+#define MS_NOEXEC (1 << 3)
+#define MS_SYNCHRONOUS (1 << 4)
+#define MS_REMOUNT (1 << 5)
+#define MS_MANDLOCK (1 << 6)
+#define MS_DIRSYNC (1 << 7)
+#define MS_NOSYMFOLLOW (1 << 8)
+#define MS_NOATIME (1 << 10)
+#define MS_NODIRATIME (1 << 11)
+#define MS_BIND (1 << 12)
+#define MS_MOVE (1 << 13)
+#define MS_REC (1 << 14)
+#define MS_SILENT (1 << 15)
+#define MS_UNBINDABLE (1 << 17)
+#define MS_PRIVATE (1 << 18)
+#define MS_SLAVE (1 << 19)
+#define MS_SHARED (1 << 20)
+#define MS_RELATIME (1 << 21)
+#define MS_STRICTATIME (1 << 24)
+#define MS_LAZYTIME (1 << 25)
+
+#endif // LLVM_LIBC_MACROS_LINUX_SYS_MOUNT_MACROS_H

--- a/libc/include/llvm-libc-macros/sys-mount-macros.h
+++ b/libc/include/llvm-libc-macros/sys-mount-macros.h
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Macros defined in sys/mount.h header file.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_MACROS_SYS_MOUNT_MACROS_H
+#define LLVM_LIBC_MACROS_SYS_MOUNT_MACROS_H
+
+#ifdef __linux__
+#include "linux/sys-mount-macros.h"
+#endif
+
+#endif // LLVM_LIBC_MACROS_SYS_MOUNT_MACROS_H

--- a/libc/include/sys/mount.yaml
+++ b/libc/include/sys/mount.yaml
@@ -1,0 +1,15 @@
+# NOTE: Semantics of sys/mount.h is different on Linux and BSD systems.
+header: sys/mount.h
+standards:
+  - linux
+macros:
+  # MS_ macro are defined only on Linux systems. Instead of listing
+  # them all here, do a shortcut (for now), and only reference a single
+  # one to ensure the inclusion of sys-mount-macros.h that would dispatch
+  # to system-specific ones.
+  - macro_name: MS_RDONLY
+    macro_header: sys-mount-macros.h
+types: []
+enums: []
+objects: []
+functions: []


### PR DESCRIPTION
Provide `<sys/mount.h>` header on Linux platforms. This header doesn't yet contain the entrypoints (mount, unmount, unmount2), but has a collection of `MS_`  symbolic constants that should be passed as arguments to `mount` syscall wrapper.

This is an interesting case, since header is a non-POSIX, and contains different information on Linux and on BSD systems (macro are named differently, functions have different prototypes, etc.). We may decide how to approach this at the point when we add function prototypes. For macro, we're in a slightly better shape, as there's existing support for OS-specific macro definitions that we're using here.

Assisted by: automated tooling, human-reviewed