### PR TITLE
[lldb][test] Disable TestDAP_attach.py on AArch64 Linux

### DIFF
--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -16,9 +16,11 @@ from lldbsuite.test.tools.lldb_dap.types import (
 )
 
 
-# Often fails on Arm Linux, but not specifically because it's Arm, something in
-# process scheduling can cause a massive (minutes) delay during this test.
-@skipIf(oslist=["linux"], archs=["arm$"])
+# Often fails on Arm/AArch64 Linux, but not specifically because of the,
+# architecture, something in process scheduling can cause a massive (minutes)
+# delay during this test.
+# https://github.com/llvm/llvm-project/issues/137660
+@skipIf(oslist=["linux"], archs=["arm$", "aarch64"])
 @requireNotWasm("no attach support")
 class TestDAP_attach(DAPTestCaseBase):
     SHARED_BUILD_TESTCASE = False

--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -16,7 +16,7 @@ from lldbsuite.test.tools.lldb_dap.types import (
 )
 
 
-# Often fails on Arm/AArch64 Linux, but not specifically because of the,
+# Often fails on Arm/AArch64 Linux, but not specifically because of the
 # architecture, something in process scheduling can cause a massive (minutes)
 # delay during this test.
 # https://github.com/llvm/llvm-project/issues/137660


### PR DESCRIPTION
We've had many reports of timeouts in pre and post-commit.

https://github.com/llvm/llvm-project/issues/137660