### PR TITLE
[CodeGen] Remove dead declarations

### DIFF
--- a/llvm/lib/CodeGen/MLRegAllocEvictAdvisor.h
+++ b/llvm/lib/CodeGen/MLRegAllocEvictAdvisor.h
@@ -33,22 +33,6 @@ struct LRStartEndInfo {
   size_t Pos = 0;
 };
 
-LLVM_ABI_FOR_TEST void extractInstructionFeatures(
-    llvm::SmallVectorImpl<LRStartEndInfo> &LRPosInfo,
-    MLModelRunner *RegallocRunner, function_ref<int(SlotIndex)> GetOpcode,
-    function_ref<float(SlotIndex)> GetMBBFreq,
-    function_ref<MachineBasicBlock *(SlotIndex)> GetMBBReference,
-    const int InstructionsIndex, const int InstructionsMappingIndex,
-    const int MBBFreqIndex, const int MBBMappingIndex,
-    const SlotIndex LastIndex);
-
-LLVM_ABI_FOR_TEST void extractMBBFrequency(
-    const SlotIndex CurrentIndex, const size_t CurrentInstructionIndex,
-    std::map<MachineBasicBlock *, size_t> &VisitedMBBs,
-    function_ref<float(SlotIndex)> GetMBBFreq,
-    MachineBasicBlock *CurrentMBBReference, MLModelRunner *RegallocRunner,
-    const int MBBFreqIndex, const int MBBMappingIndex);
-
 // This is the maximum number of interfererring ranges. That's the number of
 // distinct AllocationOrder values, which comes from MCRegisterClass::RegsSize.
 // For X86, that's 32.


### PR DESCRIPTION
The corresponding function definitions were removed on November 17,
2025 in commit 472e4ab0b02d3dec001f885beb535c9d727d1ea2.
