### PR TITLE
[lld][riscv] Remove integer check for R_RISCV_SET32

### DIFF
--- a/lld/ELF/Arch/RISCV.cpp
+++ b/lld/ELF/Arch/RISCV.cpp
@@ -702,6 +702,8 @@ void RISCV::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
     write16le(loc, val);
     return;
   case R_RISCV_SET32:
+    write32le(loc, val);
+    return;
   case R_RISCV_32_PCREL:
   case R_RISCV_PLT32:
   case R_RISCV_GOT32_PCREL:

--- a/lld/test/ELF/riscv-reloc-set32.s
+++ b/lld/test/ELF/riscv-reloc-set32.s
@@ -1,0 +1,25 @@
+# REQUIRES: riscv
+
+# RUN: llvm-mc -filetype=obj -triple=riscv32 %s -o %t32.o
+# RUN: llvm-readobj -r -x .text %t32.o | FileCheck %s --check-prefix=REL
+# RUN: ld.lld %t32.o -Ttext=0x80000000 -o %t32
+# RUN: llvm-readelf -x .text %t32 | FileCheck %s --check-prefix=HEX
+
+# RUN: llvm-mc -filetype=obj -triple=riscv64 %s -o %t64.o
+# RUN: llvm-readobj -r -x .text %t64.o | FileCheck %s --check-prefix=REL
+# RUN: ld.lld %t64.o -Ttext=0x100000000 -o %t64
+# RUN: llvm-readelf -x .text %t64 | FileCheck %s --check-prefix=HEX
+
+# REL:      .rela.text {
+# REL-NEXT:   0x0 R_RISCV_SET32 .Lend 0x0
+# REL-NEXT:   0x0 R_RISCV_SUB32 _start 0x0
+
+# HEX:      section '.text':
+# HEX-NEXT: 0x{{[0-9a-f]+}} 04000000
+
+.globl _start
+_start:
+    .reloc ., R_RISCV_SET32, .Lend
+    .reloc ., R_RISCV_SUB32, _start
+    .word 0
+.Lend:


### PR DESCRIPTION
If linker relaxation is enabled, the assembler might emit a
R_RISCV_SET[n]/R_RISCV_SUB[n] relocation pair for symbolic differences in
case of debug info relaxation (i.e. when relaxing DWARF CFA).

During relocation, the linker checks if the value for the R_RISCV_SET32
relocation fits a 32-bit signed integer (and a range error is issued if
it does not). If the symbol's absolute address is high enough (e.g. the
text section starts from 0x80000000), this results in a linker error.

R_RISCV_SET32 is also an absolute relocation type, so this check should be
removed.
