### PR TITLE
[WebAssembly] Fold offsets into extending SIMD loads

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrSIMD.td
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrSIMD.td
@@ -1667,13 +1667,15 @@ defm "" : HalfPrecisionConvert<F32x4, I16x8, promote_low, "promote_low_f16x8",
 def extloadv2f32 : PatFrag<(ops node:$ptr), (extload node:$ptr)> {
   let MemoryVT = v2f32;
 }
-// Adapted from the body of LoadPatNoOffset
-// TODO: other addressing patterns
-def : Pat<(v2f64 (extloadv2f32 (i32 I32:$addr))),
-          (promote_low_F64x2 (LOAD_ZERO_64_A32 0, 0, I32:$addr))>,
+def : Pat<(v2f64 (extloadv2f32
+                   (AddrOps32 offset32_op:$offset, I32:$addr))),
+          (promote_low_F64x2
+            (LOAD_ZERO_64_A32 0, offset32_op:$offset, I32:$addr))>,
       Requires<[HasAddr32]>;
-def : Pat<(v2f64 (extloadv2f32 (i64 I64:$addr))),
-          (promote_low_F64x2 (LOAD_ZERO_64_A64 0, 0, I64:$addr))>,
+def : Pat<(v2f64 (extloadv2f32
+                   (AddrOps64 offset64_op:$offset, I64:$addr))),
+          (promote_low_F64x2
+            (LOAD_ZERO_64_A64 0, offset64_op:$offset, I64:$addr))>,
       Requires<[HasAddr64]>;
 
 //===----------------------------------------------------------------------===//

--- a/llvm/test/CodeGen/WebAssembly/simd-load-promote-wide.ll
+++ b/llvm/test/CodeGen/WebAssembly/simd-load-promote-wide.ll
@@ -12,9 +12,7 @@ define <4 x double> @load_promote_v2f64(ptr %p) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    i32.const 8
-; CHECK-NEXT:    i32.add
-; CHECK-NEXT:    v128.load64_zero 0
+; CHECK-NEXT:    v128.load64_zero 8
 ; CHECK-NEXT:    f64x2.promote_low_f32x4
 ; CHECK-NEXT:    v128.store 16
 ; CHECK-NEXT:    local.get 0
@@ -34,16 +32,12 @@ define <4 x double> @load_promote_v2f64_with_folded_offset(ptr %p) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    i32.const 24
-; CHECK-NEXT:    i32.add
-; CHECK-NEXT:    v128.load64_zero 0
+; CHECK-NEXT:    v128.load64_zero 24
 ; CHECK-NEXT:    f64x2.promote_low_f32x4
 ; CHECK-NEXT:    v128.store 16
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    i32.const 16
-; CHECK-NEXT:    i32.add
-; CHECK-NEXT:    v128.load64_zero 0
+; CHECK-NEXT:    v128.load64_zero 16
 ; CHECK-NEXT:    f64x2.promote_low_f32x4
 ; CHECK-NEXT:    v128.store 0
 ; CHECK-NEXT:    # fallthrough-return
@@ -61,16 +55,12 @@ define <4 x double> @load_promote_v2f64_with_folded_gep_offset(ptr %p) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    i32.const 24
-; CHECK-NEXT:    i32.add
-; CHECK-NEXT:    v128.load64_zero 0
+; CHECK-NEXT:    v128.load64_zero 24
 ; CHECK-NEXT:    f64x2.promote_low_f32x4
 ; CHECK-NEXT:    v128.store 16
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    i32.const 16
-; CHECK-NEXT:    i32.add
-; CHECK-NEXT:    v128.load64_zero 0
+; CHECK-NEXT:    v128.load64_zero 16
 ; CHECK-NEXT:    f64x2.promote_low_f32x4
 ; CHECK-NEXT:    v128.store 0
 ; CHECK-NEXT:    # fallthrough-return
@@ -89,16 +79,14 @@ define <4 x double> @load_promote_v2f64_with_unfolded_gep_negative_offset(ptr %p
 ; CHECK-NEXT:    i32.const -16
 ; CHECK-NEXT:    i32.add
 ; CHECK-NEXT:    local.tee 1
+; CHECK-NEXT:    v128.load64_zero 8
+; CHECK-NEXT:    f64x2.promote_low_f32x4
+; CHECK-NEXT:    v128.store 16
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
 ; CHECK-NEXT:    v128.load64_zero 0
 ; CHECK-NEXT:    f64x2.promote_low_f32x4
 ; CHECK-NEXT:    v128.store 0
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    i32.const 8
-; CHECK-NEXT:    i32.add
-; CHECK-NEXT:    v128.load64_zero 0
-; CHECK-NEXT:    f64x2.promote_low_f32x4
-; CHECK-NEXT:    v128.store 16
 ; CHECK-NEXT:    # fallthrough-return
   %s = getelementptr inbounds <4 x float>, ptr %p, i32 -1
   %e = load <4 x float>, ptr %s
@@ -163,13 +151,13 @@ define <4 x double> @load_promote_v2f64_from_numeric_address() {
 ; CHECK:         .functype load_promote_v2f64_from_numeric_address (i32) -> ()
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    i32.const 40
-; CHECK-NEXT:    v128.load64_zero 0
+; CHECK-NEXT:    i32.const 0
+; CHECK-NEXT:    v128.load64_zero 40
 ; CHECK-NEXT:    f64x2.promote_low_f32x4
 ; CHECK-NEXT:    v128.store 16
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    i32.const 32
-; CHECK-NEXT:    v128.load64_zero 0
+; CHECK-NEXT:    i32.const 0
+; CHECK-NEXT:    v128.load64_zero 32
 ; CHECK-NEXT:    f64x2.promote_low_f32x4
 ; CHECK-NEXT:    v128.store 0
 ; CHECK-NEXT:    # fallthrough-return
@@ -185,15 +173,13 @@ define <4 x double> @load_promote_v2f64_from_global_address() {
 ; CHECK:         .functype load_promote_v2f64_from_global_address (i32) -> ()
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    i32.const gv_v4f32
 ; CHECK-NEXT:    i32.const 8
-; CHECK-NEXT:    i32.add
-; CHECK-NEXT:    v128.load64_zero 0
+; CHECK-NEXT:    v128.load64_zero gv_v4f32
 ; CHECK-NEXT:    f64x2.promote_low_f32x4
 ; CHECK-NEXT:    v128.store 16
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    i32.const gv_v4f32
-; CHECK-NEXT:    v128.load64_zero 0
+; CHECK-NEXT:    i32.const 0
+; CHECK-NEXT:    v128.load64_zero gv_v4f32
 ; CHECK-NEXT:    f64x2.promote_low_f32x4
 ; CHECK-NEXT:    v128.store 0
 ; CHECK-NEXT:    # fallthrough-return

--- a/llvm/test/CodeGen/WebAssembly/simd-offset.ll
+++ b/llvm/test/CodeGen/WebAssembly/simd-offset.ll
@@ -3254,9 +3254,7 @@ define <2 x double> @load_promote_v2f64_with_folded_offset(ptr %p) {
 ; CHECK:         .functype load_promote_v2f64_with_folded_offset (i32) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    i32.const 16
-; CHECK-NEXT:    i32.add
-; CHECK-NEXT:    v128.load64_zero 0
+; CHECK-NEXT:    v128.load64_zero 16
 ; CHECK-NEXT:    f64x2.promote_low_f32x4
 ; CHECK-NEXT:    # fallthrough-return
   %q = ptrtoint ptr %p to i32
@@ -3298,9 +3296,7 @@ define <2 x double> @load_promote_v2f64_with_folded_gep_offset(ptr %p) {
 ; CHECK:         .functype load_promote_v2f64_with_folded_gep_offset (i32) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    i32.const 8
-; CHECK-NEXT:    i32.add
-; CHECK-NEXT:    v128.load64_zero 0
+; CHECK-NEXT:    v128.load64_zero 8
 ; CHECK-NEXT:    f64x2.promote_low_f32x4
 ; CHECK-NEXT:    # fallthrough-return
   %s = getelementptr inbounds <2 x float>, ptr %p, i32 1
@@ -3483,8 +3479,8 @@ define <2 x double> @load_promote_v2f64_from_numeric_address() {
 ; CHECK-LABEL: load_promote_v2f64_from_numeric_address:
 ; CHECK:         .functype load_promote_v2f64_from_numeric_address () -> (v128)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    i32.const 32
-; CHECK-NEXT:    v128.load64_zero 0
+; CHECK-NEXT:    i32.const 0
+; CHECK-NEXT:    v128.load64_zero 32
 ; CHECK-NEXT:    f64x2.promote_low_f32x4
 ; CHECK-NEXT:    # fallthrough-return
   %s = inttoptr i32 32 to ptr
@@ -3524,8 +3520,8 @@ define <2 x double> @load_promote_v2f64_from_global_address() {
 ; CHECK-LABEL: load_promote_v2f64_from_global_address:
 ; CHECK:         .functype load_promote_v2f64_from_global_address () -> (v128)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    i32.const gv_v2f32
-; CHECK-NEXT:    v128.load64_zero 0
+; CHECK-NEXT:    i32.const 0
+; CHECK-NEXT:    v128.load64_zero gv_v2f32
 ; CHECK-NEXT:    f64x2.promote_low_f32x4
 ; CHECK-NEXT:    # fallthrough-return
   %e = load <2 x float>, ptr @gv_v2f32


### PR DESCRIPTION
I saw this TODO and realized that instead of lowering to 
```
local.get 0
i32.const 8
i32.add
v128.load64_zero 0
f64x2.promote_low_f32x4
```
We could choose 
```
local.get 0
v128.load64_zero 8
f64x2.promote_low_f32x4
```

So I used the existing WebAssembly address operand patterns when lowering v2f32-to-v2f64 extending loads.

This allows constant address offsets to be folded into `v128.load64_zero`, avoiding a separate constant and add instruction. The existing no-offset case continues to work with an offset of zero.