### PR TITLE
[lldb][Linux][ARM] Fix build after ptrace header removal

### DIFF
--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm.cpp
@@ -26,7 +26,6 @@
 
 // System includes - They have to be included after framework includes because
 // they define some macros which collide with variable names in other modules.
-#include <asm/ptrace.h>
 #include <elf.h>
 #include <sys/ptrace.h>
 #include <sys/uio.h>


### PR DESCRIPTION
f69fbd6415ab3a0743d14f0e345f9b61720ce187 / #218045 removed our own ptrace header, which was fine elsewhere but on Arm we also included asm/ptrace.h.

We don't have to though, and removing it fixes build errors like:
```
In file included from /buildbot/lldb-arm-ubuntu/llvmproject/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm.cpp:31:
/usr/include/arm-linux-gnueabihf/sys/ptrace.h:74:3: error: expected identifier
   74 |   PTRACE_GETREGS = 12,
      |   ^
```
Which is because asm/ptrace.h has already defined PTRACE_GETREGS to 12.