### PR TITLE
[gold] Switch section-ordering-file tests to use ld.bfd

### DIFF
--- a/llvm/test/tools/gold/X86/Inputs/multiple-data-section-ordering.txt
+++ b/llvm/test/tools/gold/X86/Inputs/multiple-data-section-ordering.txt
@@ -1,0 +1,5 @@
+.data : {
+    *(.data.tin)
+    *(.data.dipsy)
+    *(.data.pat)
+}

--- a/llvm/test/tools/gold/X86/multiple-data.s
+++ b/llvm/test/tools/gold/X86/multiple-data.s
@@ -1,20 +1,15 @@
-# RUN: echo ".data.tin" > %t_order_lto.txt
-# RUN: echo ".data.dipsy" >> %t_order_lto.txt
-# RUN: echo ".data.pat" >> %t_order_lto.txt
-
 # RUN: llvm-mc %s -o %t.o -filetype=obj -triple=x86_64-unknown-linux-gnu
 # RUN: llvm-as %p/Inputs/multiple-data.ll -o %t2.o
-# RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+# RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 # RUN:     -m elf_x86_64 -o %t.exe %t2.o %t.o  \
-# RUN:     --section-ordering-file=%t_order_lto.txt
+# RUN:     --section-ordering-file=%S/Inputs/multiple-data-section-ordering.txt
 # RUN: llvm-readelf -s %t.exe | FileCheck %s
 
-# --section-ordering-file is not supported by ld.bfd, use gold instead.
-# REQUIRES: gold_linker
+# REQUIRES: ld-bfd-supports-section-ordering-file
 
-# CHECK-DAG:      00000000004010fc     4 OBJECT  GLOBAL DEFAULT    2 dipsy
-# CHECK-DAG:      00000000004010f8     4 OBJECT  GLOBAL DEFAULT    2 tin
-# CHECK-DAG:      0000000000401100     4 OBJECT  GLOBAL DEFAULT    2 pat
+# CHECK-DAG:      [[#%x, ADDR:]]       4 OBJECT  GLOBAL DEFAULT    2 tin
+# CHECK-DAG:      [[#%x, ADDR + 4]]    4 OBJECT  GLOBAL DEFAULT    2 dipsy
+# CHECK-DAG:      [[#%x, ADDR + 8]]    4 OBJECT  GLOBAL DEFAULT    2 pat
 
 .globl _start
 _start:

--- a/llvm/test/tools/gold/X86/multiple-sections.ll
+++ b/llvm/test/tools/gold/X86/multiple-sections.ll
@@ -1,23 +1,24 @@
 ; RUN: split-file %s %t
 ; RUN: llvm-as %t/a.ll -o %t.o
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:     -m elf_x86_64 -o %t.exe %t.o \
 ; RUN:     --section-ordering-file=%t/order
 ; RUN: llvm-readelf -s %t.exe | FileCheck %s
 
-; --section-ordering-file is not supported by ld.bfd, use gold instead.
-; REQUIRES: gold_linker
+# REQUIRES: ld-bfd-supports-section-ordering-file
 
 ; Check that the order of the sections is tin -> _start -> pat.
 
-; CHECK:      00000000004000cf     1 FUNC    LOCAL  DEFAULT    1 pat
-; CHECK:      00000000004000b0     1 FUNC    LOCAL  DEFAULT    1 tin
-; CHECK:      00000000004000c0    15 FUNC    GLOBAL DEFAULT    1 _start
+; CHECK:      [[#%x, ADDR:]]       1  FUNC    LOCAL  DEFAULT    1 pat
+; CHECK:      [[#%x, ADDR - 31]]   1  FUNC    LOCAL  DEFAULT    1 tin
+; CHECK:      [[#%x, ADDR - 15]]   15 FUNC    GLOBAL DEFAULT    1 _start
 
 ;--- order
-.text.tin
-.text._start
-.text.pat
+.text : {
+    *(.text.tin)
+    *(.text._start)
+    *(.text.pat)
+}
 
 ;--- a.ll
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"

--- a/llvm/test/tools/gold/lit.local.cfg
+++ b/llvm/test/tools/gold/lit.local.cfg
@@ -1,3 +1,6 @@
+import re
+import subprocess
+
 if not "ld_plugin" in config.available_features:
     config.unsupported = True
 
@@ -5,3 +8,27 @@ if not "ld_plugin" in config.available_features:
 for san in ["asan", "msan", "ubsan"]:
     if san in config.available_features:
         config.unsupported = True
+
+def get_ld_bfd_version():
+    try:
+        ld_cmd = subprocess.Popen(
+            [config.ld_bfd_executable, "-v"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        ld_out, _ = ld_cmd.communicate()
+        ld_out = ld_out.decode()
+    except:
+        return (0, 0)
+
+    match = re.search(r"GNU ld .* (\d+)\.(\d+)", ld_out)
+    if not match:
+        return (0, 0)
+    major = int(match.group(1))
+    minor = int(match.group(2))
+    return (major, minor)
+
+if not config.unsupported:
+    version = get_ld_bfd_version()
+    if version >= (2, 43):
+        config.available_features.add("ld-bfd-supports-section-ordering-file")


### PR DESCRIPTION
ld.bfd supports `--section-ordering-file` since 2.43. Use it if the binutils version is sufficiently recent.

The implementation in ld.bfd is significantly different, with the section ordering file looking more like an incomplete linker script, rather than a plain section listing.

The addresses of the sections are also slightly different than with ld.gold. Use hex matches + arithmetic to just check the correct order/offsets instead of hardcoding the exact choice of address.

ld.bfd also supports --start-lib/--end-lib since 2.47, but it seems like those don't actually work with linker plugins, so I'm not migrating them (https://sourceware.org/bugzilla/show_bug.cgi?id=34572).

Followup to https://github.com/llvm/llvm-project/pull/130981.