### PR TITLE
[C++20] [Modules] Handling merging predefined decls from std

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -18506,7 +18506,7 @@ Sema::ActOnTag(Scope *S, unsigned TagSpec, TagUseKind TUK, SourceLocation KWLoc,
   }
 
   if (getLangOpts().CPlusPlus && Name && DC && StdNamespace &&
-      DC->Equals(getStdNamespace())) {
+      DC->getRedeclContext()->Equals(getStdNamespace())) {
     if (Name->isStr("bad_alloc")) {
       // This is a declaration of or a reference to "std::bad_alloc".
       isStdBadAlloc = true;

--- a/clang/test/Modules/pr218152.cppm
+++ b/clang/test/Modules/pr218152.cppm
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify %s
+
+// expected-no-diagnostics
+export module fake_std;
+
+extern "C++" {
+namespace std {
+  using size_t = decltype(sizeof 0);
+  export enum class align_val_t : size_t {};
+} // namespace std
+
+export void *operator new(std::size_t, std::align_val_t);
+
+namespace std {
+void foo() { align_val_t x{}; }
+} // namespace std
+} // extern "C++"


### PR DESCRIPTION
Close https://github.com/llvm/llvm-project/issues/218152

This was only reported in windows as MSSTL chose to implement std module by wrapping the STL into extern "C++", which is different from libstdc++ and libc++.

But technically this is not specific to windows and we're able to preoduce it in linux although we won't face it in linux.