### PR TITLE
[IR] `select` should reject token-like types

### DIFF
--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -2738,6 +2738,7 @@ class PHINode : public Instruction, public FastMathFlagsStorage {
                    InsertPosition InsertBefore = nullptr)
       : Instruction(Ty, Instruction::PHI, AllocMarker, InsertBefore),
         ReservedSpace(NumReservedValues) {
+    assert(!isInvalidType(Ty) && "Invalid type for PHI node");
     setName(NameStr);
     allocHungoffUses(ReservedSpace);
   }
@@ -2764,6 +2765,10 @@ public:
     return new (AllocMarker)
         PHINode(Ty, NumReservedValues, NameStr, InsertBefore);
   }
+
+  /// Return a string if the specified type is invalid for a PHI node,
+  /// otherwise return null.
+  LLVM_ABI static const char *isInvalidType(Type *Ty);
 
   /// Provide fast operand accessors
   DECLARE_TRANSPARENT_OPERAND_ACCESSORS(Value);

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -8698,6 +8698,9 @@ int LLParser::parsePHI(Instruction *&Inst, PerFunctionState &PFS) {
   if (!Ty->isFirstClassType())
     return error(TypeLoc, "phi node must have first class type");
 
+  if (const char *Reason = PHINode::isInvalidType(Ty))
+    return error(TypeLoc, Reason);
+
   bool First = true;
   bool AteExtraComma = false;
   SmallVector<std::pair<Value*, BasicBlock*>, 16> PHIVals;

--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -110,7 +110,7 @@ const char *SelectInst::areInvalidOperands(Value *Op0, Value *Op1, Value *Op2) {
   if (Op1->getType() != Op2->getType())
     return "both values to select must have same type";
 
-  if (Op1->getType()->isTokenTy())
+  if (Op1->getType()->isTokenLikeTy())
     return "select values cannot have token type";
 
   if (VectorType *VT = dyn_cast<VectorType>(Op0->getType())) {
@@ -132,6 +132,14 @@ const char *SelectInst::areInvalidOperands(Value *Op0, Value *Op1, Value *Op2) {
 //===----------------------------------------------------------------------===//
 //                               PHINode Class
 //===----------------------------------------------------------------------===//
+
+/// isInvalidType - Return a string if the specified type is invalid for a
+/// PHI node, otherwise return null.
+const char *PHINode::isInvalidType(Type *Ty) {
+  if (Ty->isTokenLikeTy())
+    return "PHI nodes cannot have token type!";
+  return nullptr;
+}
 
 PHINode::PHINode(const PHINode &PN)
     : Instruction(PN.getType(), Instruction::PHI, AllocMarker),

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -3860,7 +3860,8 @@ void Verifier::visitPHINode(PHINode &PN) {
         "PHI nodes not grouped at top of basic block!", &PN, PN.getParent());
 
   // Check that a PHI doesn't yield a Token.
-  Check(!PN.getType()->isTokenLikeTy(), "PHI nodes cannot have token type!");
+  Check(!PHINode::isInvalidType(PN.getType()),
+        "PHI nodes cannot have token type!");
 
   // Check that all of the values of the PHI node have the same type as the
   // result.

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -3571,6 +3571,9 @@ void Verifier::visitSelectInst(SelectInst &SI) {
                                         SI.getOperand(2)),
         "Invalid operands for select instruction!", &SI);
 
+  Check(!SI.getType()->isTokenLikeTy(),
+        "Select values cannot have token type!", &SI);
+
   Check(SI.getTrueValue()->getType() == SI.getType(),
         "Select values must have same type as select instruction!", &SI);
   visitInstruction(SI);

--- a/llvm/test/CodeGen/DirectX/ResourceAccess/non-unique.ll
+++ b/llvm/test/CodeGen/DirectX/ResourceAccess/non-unique.ll
@@ -1,4 +1,5 @@
-; RUN: not opt -S -dxil-resource-access -mtriple=dxil--shadermodel6.3-library %s 2>&1 | FileCheck %s
+; RUN: not opt -S -dxil-resource-access -disable-verify \
+; RUN:   -mtriple=dxil--shadermodel6.3-library %s 2>&1 | FileCheck %s
 
 ; Test that a error message is generated for illegal resource accesses that do
 ; not access a unique global resource.

--- a/llvm/test/Verifier/tokenlike2.ll
+++ b/llvm/test/Verifier/tokenlike2.ll
@@ -1,0 +1,9 @@
+; RUN: not llvm-as %s -o /dev/null 2>&1 | FileCheck %s
+
+define void @f(i1 %cond, target("dx.RawBuffer", half, 1, 0) %A,
+               target("dx.RawBuffer", half, 1, 0) %B) {
+  %sel = select i1 %cond, target("dx.RawBuffer", half, 1, 0) %A,
+                          target("dx.RawBuffer", half, 1, 0) %B
+; CHECK: select values cannot have token type
+  ret void
+}

--- a/llvm/test/Verifier/tokenlike2.ll
+++ b/llvm/test/Verifier/tokenlike2.ll
@@ -1,0 +1,9 @@
+; RUN: not llvm-as %s -o /dev/null 2>&1 | FileCheck %s
+
+define void @f(i1 %cond, target("dx.RawBuffer", half, 1, 0) %A,
+               target("dx.RawBuffer", half, 1, 0) %B) {
+  %sel = select i1 %cond, target("dx.RawBuffer", half, 1, 0) %A,
+                          target("dx.RawBuffer", half, 1, 0) %B
+; CHECK: Select values cannot have token type!
+  ret void
+}


### PR DESCRIPTION
Target extension types with the IsTokenLike property are meant to behave like
tokens. The change in #154620 already rejected such types in phi nodes, function
arguments, function return types and call parameters. Added this missing check
in SelectInst::areInvalidOperands().

Also refactored PHINode to follow the same pattern, so that the token type is
checked in the constructor, LLParser and Verifier.

Some DirectX lit tests deliberately use token-like types in Phi or Select
instructions, while disabling the verifier. This change breaks all of them
because the check is in more places than just the verifier.

Assisted-By: AI Code Assistant