### PR TITLE
[SCEV] Update comment for check BE formula in howManyLT (NFC)

### DIFF
--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -13578,16 +13578,16 @@ ScalarEvolution::howManyLessThans(const SCEV *LHS, const SCEV *RHS,
       // Let's do a quick case analysis to show these are equivalent under
       // our preconditions that Start - Stride is below both Start and RHS.
       // * For RHS <= Start (End is Start), the backedge-taken count must be
-      //   zero.
-      //   "((RHS - 1) - (Start - Stride)) /u Stride" is <=
-      //   "((Start - 1) - (Start - Stride)) /u Stride" which simplies to
-      //   "Stride - 1 /u Stride" which is indeed zero for all non-zero values
-      //    of Stride.  For 0 stride, we've used umax(Stride,1) above.
-      // * For RHS >= Start (End is RHS), the backedge count must be
-      //   "RHS-Start /uceil Stride".
-      //   "((RHS - 1) - (Start - Stride)) /u Stride" reassociates to
-      //   "(RHS - (Start - Stride) - 1) /u Stride".
-      //   Our preconditions trivially imply no overflow in that form.
+      //   zero. Together with the preconditions, we have
+      //   "Start - Stride < RHS <= Start". Subtracting Start - Stride from
+      //   all sides we get "0 < RHS - (Start - Stride) <= Stride".
+      //   Subtracting 1 we get "0 <= (RHS - 1) - (Start - Stride) < Stride".
+      //   So dividing that by Stride gives zero.
+      //
+      // * For RHS > Start (End is RHS), the backedge count must be
+      //   "RHS-Start /uceil Stride". Together with the preconditions, we have
+      //   "RHS > Start > Start - Stride". As such RHS - (Start - Stride) - 1
+      //   does not overflow.
       const SCEV *MinusOne = getMinusOne(Stride->getType());
       const SCEV *Numerator =
           getMinusSCEV(getAddExpr(RHS, MinusOne), getMinusSCEV(Start, Stride));

--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -13579,11 +13579,10 @@ ScalarEvolution::howManyLessThans(const SCEV *LHS, const SCEV *RHS,
       // our preconditions that Start - Stride is below both Start and RHS.
       // * For RHS <= Start (End is Start), the backedge-taken count must be
       //   zero.
-      //   "((End - 1) - (Start - Stride)) /u Stride" is <=
+      //   "((RHS - 1) - (Start - Stride)) /u Stride" is <=
       //   "((Start - 1) - (Start - Stride)) /u Stride" which simplies to
       //   "Stride - 1 /u Stride" which is indeed zero for all non-zero values
-      //     of Stride.  For 0 stride, we've used umax(Stride,1) above,
-      //     reducing this to the stride of 1 case.
+      //    of Stride.  For 0 stride, we've used umax(Stride,1) above.
       // * For RHS >= Start (End is RHS), the backedge count must be
       //   "RHS-Start /uceil Stride".
       //   "((RHS - 1) - (Start - Stride)) /u Stride" reassociates to

--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -13560,35 +13560,34 @@ ScalarEvolution::howManyLessThans(const SCEV *LHS, const SCEV *RHS,
                        MaxBECount, false /*MaxOrZero*/, Predicates);
     }
   } else {
-    // We use the expression (max(End,Start)-Start)/Stride to describe the
-    // backedge count, as if the backedge is taken at least once
-    // max(End,Start) is End and so the result is as above, and if not
-    // max(End,Start) is Start so we get a backedge count of zero.
+    // Let End = max(RHS,Start).  We use the expression (End-Start)/Stride to
+    // describe the backedge count: if the backedge is taken at least once then
+    // End is RHS, and if not End is Start so we get a backedge count of zero.
     auto *OrigStartMinusStride = getMinusSCEV(OrigStart, Stride);
     assert(isAvailableAtLoopEntry(OrigStartMinusStride, L) && "Must be!");
     assert(isAvailableAtLoopEntry(OrigStart, L) && "Must be!");
     assert(isAvailableAtLoopEntry(OrigRHS, L) && "Must be!");
-    // Can we prove (max(RHS,Start) > Start - Stride?
+    // Can we prove Start - Stride < Start and Start - Stride < RHS?
     if (isLoopEntryGuardedByCond(L, Cond, OrigStartMinusStride, OrigStart) &&
         isLoopEntryGuardedByCond(L, Cond, OrigStartMinusStride, OrigRHS)) {
       // In this case, we can use a refined formula for computing backedge
       // taken count.  The general formula remains:
-      //   "End-Start /uceiling Stride" where "End = max(RHS,Start)"
+      //   "End-Start /uceiling Stride"
       // We want to use the alternate formula:
-      //   "((End - 1) - (Start - Stride)) /u Stride"
+      //   "((RHS - 1) - (Start - Stride)) /u Stride"
       // Let's do a quick case analysis to show these are equivalent under
-      // our precondition that max(RHS,Start) > Start - Stride.
-      // * For RHS <= Start, the backedge-taken count must be zero.
-      //   "((End - 1) - (Start - Stride)) /u Stride" reduces to
+      // our preconditions that Start - Stride is below both Start and RHS.
+      // * For RHS <= Start (End is Start), the backedge-taken count must be
+      //   zero.
+      //   "((End - 1) - (Start - Stride)) /u Stride" is <=
       //   "((Start - 1) - (Start - Stride)) /u Stride" which simplies to
       //   "Stride - 1 /u Stride" which is indeed zero for all non-zero values
-      //     of Stride.  For 0 stride, we've use umin(1,Stride) above,
+      //     of Stride.  For 0 stride, we've used umax(Stride,1) above,
       //     reducing this to the stride of 1 case.
-      // * For RHS >= Start, the backedge count must be "RHS-Start /uceil
-      // Stride".
-      //   "((End - 1) - (Start - Stride)) /u Stride" reduces to
+      // * For RHS >= Start (End is RHS), the backedge count must be
+      //   "RHS-Start /uceil Stride".
       //   "((RHS - 1) - (Start - Stride)) /u Stride" reassociates to
-      //   "((RHS - (Start - Stride) - 1) /u Stride".
+      //   "(RHS - (Start - Stride) - 1) /u Stride".
       //   Our preconditions trivially imply no overflow in that form.
       const SCEV *MinusOne = getMinusOne(Stride->getType());
       const SCEV *Numerator =

--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -13578,16 +13578,16 @@ ScalarEvolution::howManyLessThans(const SCEV *LHS, const SCEV *RHS,
       // Let's do a quick case analysis to show these are equivalent under
       // our preconditions that Start - Stride is below both Start and RHS.
       // * For RHS <= Start (End is Start), the backedge-taken count must be
-      //   zero. Together with the preconditions, we have
+      //   zero. Together with the precondition "Start - Stride < RHS", we have
       //   "Start - Stride < RHS <= Start". Subtracting Start - Stride from
       //   all sides we get "0 < RHS - (Start - Stride) <= Stride".
       //   Subtracting 1 we get "0 <= (RHS - 1) - (Start - Stride) < Stride".
       //   So dividing that by Stride gives zero.
       //
       // * For RHS > Start (End is RHS), the backedge count must be
-      //   "RHS-Start /uceil Stride". Together with the preconditions, we have
-      //   "RHS > Start > Start - Stride". As such RHS - (Start - Stride) - 1
-      //   does not overflow.
+      //   "RHS-Start /uceil Stride". Together with the precondition
+      //   "Start - Stride < Start", we have "RHS > Start > Start - Stride".
+      //   As such RHS - (Start - Stride) - 1 does not overflow.
       const SCEV *MinusOne = getMinusOne(Stride->getType());
       const SCEV *Numerator =
           getMinusSCEV(getAddExpr(RHS, MinusOne), getMinusSCEV(Start, Stride));


### PR DESCRIPTION
Update outdate comments around the code for picking the check BE formula. It includes the following updates:

* define End = max(RHS,Start), as used later, use instead of incorrect max(End,Start)
* precondition for the code use check min(RHS,Start) > Start - Stride
* update remaining test to be consistent
* Stride = umax(1, Stride) instead of umin, which matches the code above; umin would not avoid divide by 0.


Preparation for https://github.com/llvm/llvm-project/pull/218694