### PR TITLE
[Clang] Only omit deprecation warnings for implicit special members

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -533,6 +533,9 @@ features cannot lower the translation-unit ABI level;
 
 - Fixed an assertion during template argument deduction where a function parameter pack is referenced by other types in the function type. (#GH28877), (#GH213760)
 
+- Fixed a regression where deprecation warnings were omitted for synthesized
+  deduction guide. (#GH160543)
+
 - Fixed an assertion when a redeclaration of a function template or an out-of-line
   definition of a member of a class template added a default argument to a
   parameter that follows a parameter pack (e.g.

--- a/clang/lib/Sema/SemaAvailability.cpp
+++ b/clang/lib/Sema/SemaAvailability.cpp
@@ -212,6 +212,10 @@ static bool ShouldDiagnoseAvailabilityInContext(
     } else if (K == AR_Deprecated) {
       if (C->isDeprecated())
         return true;
+      // Don't emit deprecated warnings when defining special member functions.
+      if (const auto *FD = dyn_cast<FunctionDecl>(C);
+          FD && FD->isDefaulted() && FD->isImplicit())
+        return true;
     } else if (K == AR_Unavailable) {
       // It is perfectly fine to refer to an 'unavailable' Objective-C method
       // when it is referenced from within the @implementation itself. In this
@@ -548,12 +552,6 @@ static void DoEmitAvailabilityWarning(Sema &S, AvailabilityResult K,
     return;
   }
   case AR_Deprecated:
-    // Suppress -Wdeprecated-declarations in implicit
-    // functions.
-    if (const auto *FD = dyn_cast_or_null<FunctionDecl>(S.getCurFunctionDecl());
-        FD && FD->isImplicit())
-      return;
-
     if (ObjCPropertyAccess)
       diag = diag::warn_property_method_deprecated;
     else if (S.currentEvaluationContext().IsCaseExpr)

--- a/clang/lib/Sema/SemaAvailability.cpp
+++ b/clang/lib/Sema/SemaAvailability.cpp
@@ -213,8 +213,7 @@ static bool ShouldDiagnoseAvailabilityInContext(
       if (C->isDeprecated())
         return true;
       // Don't emit deprecated warnings when defining special member functions.
-      if (const auto *FD = dyn_cast<FunctionDecl>(C);
-          FD && FD->isDefaulted() && FD->isImplicit())
+      if (const auto *FD = dyn_cast<FunctionDecl>(C); FD && FD->isDefaulted())
         return true;
     } else if (K == AR_Unavailable) {
       // It is perfectly fine to refer to an 'unavailable' Objective-C method

--- a/clang/test/Sema/implicit-special-member-deprecated.cpp
+++ b/clang/test/Sema/implicit-special-member-deprecated.cpp
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 -std=c++20 -Wdeprecated-declarations -verify %s
 
+namespace GH147293 {
 struct A {
   [[deprecated("use something else")]] int x = 42; // expected-note {{marked deprecated here}}
 };
@@ -22,3 +23,16 @@ struct B {
   [[deprecated]] int y;
   B() = default;                   // no warning under new policy
 };
+
+}
+
+namespace GH160543 {
+
+template<class F>
+struct [[deprecated]] X { X(F);}; // expected-warning {{is deprecated}} expected-note {{deprecated here}}
+
+void f() {
+  X x{0}; // expected-note {{while substituting}}
+}
+
+}

--- a/clang/test/SemaCXX/implicit-special-member-deprecated.cpp
+++ b/clang/test/SemaCXX/implicit-special-member-deprecated.cpp
@@ -7,12 +7,12 @@ struct A {
   [[deprecated("use something else")]] int x = 42; // expected-note {{marked deprecated here}}
 };
 
-A makeDefaultA() { return {}; }    // ctor is implicit → no warn
-A copyA(const A &a) { return a; }  // copy-ctor implicit → no warn
+A makeDefaultA() { return {}; }    // ctor is implicit -> no warn
+A copyA(const A &a) { return a; }  // copy-ctor implicit -> no warn
 
 void assignA() {
   A a, b;
-  a = b;                           // copy-assign implicit → no warn
+  a = b;                           // copy-assign implicit -> no warn
 }
 
 void useA() {

--- a/clang/test/SemaCXX/implicit-special-member-deprecated.cpp
+++ b/clang/test/SemaCXX/implicit-special-member-deprecated.cpp
@@ -1,4 +1,6 @@
-// RUN: %clang_cc1 -std=c++20 -Wdeprecated-declarations -verify %s
+// RUN: %clang_cc1 -std=c++20 -Wdeprecated-declarations -I%S/Inputs -verify %s
+
+#include "std-compare.h"
 
 namespace GH147293 {
 struct A {
@@ -26,6 +28,22 @@ struct B {
 
 }
 
+namespace GH147293_regression {
+
+struct A {
+  [[deprecated("use something else")]] int x = 42;
+
+  auto operator<=>(const A&) const = default;
+};
+
+void foo() {
+  A x, y;
+  // FIXME: We want the deprecation warnings because operator<=> uses A.x!
+  (void)(x == y);
+}
+
+}
+
 namespace GH160543 {
 
 template<class F>
@@ -36,3 +54,4 @@ void f() {
 }
 
 }
+

--- a/clang/test/SemaCXX/implicit-special-member-deprecated.cpp
+++ b/clang/test/SemaCXX/implicit-special-member-deprecated.cpp
@@ -32,14 +32,20 @@ namespace GH147293_regression {
 
 struct A {
   [[deprecated("use something else")]] int x = 42;
-
   auto operator<=>(const A&) const = default;
+};
+
+struct B : A {
+  bool operator==(const B&) const = default;
 };
 
 void foo() {
   A x, y;
-  // FIXME: We want the deprecation warnings because operator<=> uses A.x!
   (void)(x == y);
+  (void)(x < y);
+
+  B bx, by;
+  (void)(bx != by);
 }
 
 }


### PR DESCRIPTION
31db0f0a7ae isn't very correct because synthesized deduction guides are also marked 'implicit', and it's supposed to apply to only non-user-defined special members.

This patch corrects that behavior.

Fixes #160543