### PR TITLE
[AMDGPU][GlobalIsel] Replace wip_match_opcode with MIR patterns with basic match and apply clauses.

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUCombine.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCombine.td
@@ -56,7 +56,7 @@ def clamp_i64_to_i16_matchdata : GIDefMatchData<"ClampI64ToI16MatchInfo">;
 
 def clamp_i64_to_i16 : GICombineRule<
   (defs root:$clamp_i64_to_i16, clamp_i64_to_i16_matchdata:$matchinfo),
-  (match (wip_match_opcode G_TRUNC):$clamp_i64_to_i16,
+  (match (G_TRUNC $dst, $src):$clamp_i64_to_i16,
       [{ return matchClampI64ToI16(*${clamp_i64_to_i16}, MRI, MF, ${matchinfo}); }]),
   (apply [{ applyClampI64ToI16(*${clamp_i64_to_i16}, ${matchinfo}); }])>;
 
@@ -97,21 +97,21 @@ def fp_minmax_to_clamp : GICombineRule<
 
 def fmed3_intrinsic_to_clamp : GICombineRule<
   (defs root:$fmed3, register_matchinfo:$matchinfo),
-  (match (wip_match_opcode G_AMDGPU_FMED3):$fmed3,
+  (match (G_AMDGPU_FMED3 $dst, $src0, $src1, $src2):$fmed3,
          [{ return matchFPMed3ToClamp(*${fmed3}, ${matchinfo}); }]),
   (apply [{ applyClamp(*${fmed3}, ${matchinfo}); }])>;
 
 def remove_fcanonicalize : GICombineRule<
-  (defs root:$fcanonicalize, register_matchinfo:$matchinfo),
-  (match (wip_match_opcode G_FCANONICALIZE):$fcanonicalize,
-         [{ return matchRemoveFcanonicalize(*${fcanonicalize}, ${matchinfo}); }]),
-  (apply [{ Helper.replaceSingleDefInstWithReg(*${fcanonicalize}, ${matchinfo}); }])>;
+  (defs root:$fcanonicalize),
+  (match (G_FCANONICALIZE $dst, $src):$fcanonicalize,
+         [{ return matchRemoveFcanonicalize(*${fcanonicalize}); }]),
+  (apply (GIReplaceReg $dst, $src))>;
 
 def foldable_fneg_matchdata : GIDefMatchData<"MachineInstr *">;
 
 def foldable_fneg : GICombineRule<
   (defs root:$ffn, foldable_fneg_matchdata:$matchinfo),
-  (match (wip_match_opcode G_FNEG):$ffn,
+  (match (G_FNEG $dst, $src):$ffn,
          [{ return Helper.matchFoldableFneg(*${ffn}, ${matchinfo}); }]),
   (apply [{ Helper.applyFoldableFneg(*${ffn}, ${matchinfo}); }])>;
 
@@ -126,7 +126,7 @@ def fold_fabs_fptrunc : GICombineRule<
 // Detects s_mul_u64 instructions whose higher bits are zero/sign extended.
 def smulu64 : GICombineRule<
   (defs root:$smul, unsigned_matchinfo:$matchinfo),
-  (match (wip_match_opcode G_MUL):$smul,
+  (match (G_MUL $dst, $src0, $src1):$smul,
          [{ return matchCombine_s_mul_u64(*${smul}, ${matchinfo}); }]),
   (apply [{ Helper.replaceOpcodeWith(*${smul}, ${matchinfo}); }])>;
 
@@ -134,7 +134,7 @@ def sign_exension_in_reg_matchdata : GIDefMatchData<"std::pair<MachineInstr *, u
 
 def sign_extension_in_reg : GICombineRule<
   (defs root:$sign_inreg, sign_exension_in_reg_matchdata:$matchinfo),
-  (match (wip_match_opcode G_SEXT_INREG):$sign_inreg,
+  (match (G_SEXT_INREG $dst, $src, $width):$sign_inreg,
          [{ return matchCombineSignExtendInReg(*${sign_inreg}, ${matchinfo}); }]),
   (apply [{ applyCombineSignExtendInReg(*${sign_inreg}, ${matchinfo}); }])>;
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUPostLegalizerCombiner.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPostLegalizerCombiner.cpp
@@ -97,7 +97,7 @@ public:
   void applyCvtF32UByteN(MachineInstr &MI,
                          const CvtF32UByteMatchInfo &MatchInfo) const;
 
-  bool matchRemoveFcanonicalize(MachineInstr &MI, Register &Reg) const;
+  bool matchRemoveFcanonicalize(MachineInstr &MI) const;
 
   // Combine unsigned buffer load and signed extension instructions to generate
   // signed buffer load instructions.
@@ -364,11 +364,10 @@ void AMDGPUPostLegalizerCombinerImpl::applyCvtF32UByteN(
 }
 
 bool AMDGPUPostLegalizerCombinerImpl::matchRemoveFcanonicalize(
-    MachineInstr &MI, Register &Reg) const {
+    MachineInstr &MI) const {
   const SITargetLowering *TLI = static_cast<const SITargetLowering *>(
       MF.getSubtarget().getTargetLowering());
-  Reg = MI.getOperand(1).getReg();
-  return TLI->isCanonicalized(Reg, MF);
+  return TLI->isCanonicalized(MI.getOperand(1).getReg(), MF);
 }
 
 // The buffer_load_{i8, i16} intrinsics are initially lowered as


### PR DESCRIPTION
This patch replaces wip_match_opcode mechanism with MIR-pattern matching for opcodes with no or partial possibility for declarative pattern match/apply clause for the AMDGPU-specifc GICombines.

The following opcodes are covered : `G_TRUNC`, `G_AMDGPU_FMED3`, `G_FCANONICALIZE`, `G_FNEG`, `G_MUL` and `G_SEXT_INREG`.