### PR TITLE
[clang][AST] Un-template `LazyGenerationalUpdatePtr`

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -4063,19 +4063,6 @@ inline void operator delete[](void *Ptr, const clang::ASTContext &C, size_t) {
   C.Deallocate(Ptr);
 }
 
-/// Create the representation of a LazyGenerationalUpdatePtr.
-template <typename Owner, typename T,
-          void (clang::ExternalASTSource::*Update)(Owner)>
-typename clang::LazyGenerationalUpdatePtr<Owner, T, Update>::ValueType
-    clang::LazyGenerationalUpdatePtr<Owner, T, Update>::makeValue(
-        const clang::ASTContext &Ctx, T Value) {
-  // Note, this is implemented here so that ExternalASTSource.h doesn't need to
-  // include ASTContext.h. We explicitly instantiate it for all relevant types
-  // in ASTContext.cpp.
-  if (auto *Source = Ctx.getExternalSource())
-    return new (Ctx) LazyData(Source, Value);
-  return Value;
-}
 template <> struct llvm::DenseMapInfo<llvm::FoldingSetNodeID> {
   static unsigned getHashValue(const FoldingSetNodeID &Val) {
     return Val.ComputeHash();

--- a/clang/include/clang/AST/ExternalASTSource.h
+++ b/clang/include/clang/AST/ExternalASTSource.h
@@ -460,7 +460,6 @@ struct LazyGenerationalDeclPtr {
 
   LazyGenerationalDeclPtr(ValueType V) : Value(V) {}
 
-  // Defined in ASTContext.cpp
   static ValueType makeValue(const ASTContext &Ctx, Decl *Value);
 
 public:

--- a/clang/include/clang/AST/ExternalASTSource.h
+++ b/clang/include/clang/AST/ExternalASTSource.h
@@ -467,12 +467,6 @@ public:
   explicit LazyGenerationalDeclPtr(const ASTContext &Ctx, Decl *Value = nullptr)
       : Value(makeValue(Ctx, Value)) {}
 
-  /// Create a pointer that is not potentially updated by later generations of
-  /// the external AST source.
-  enum NotUpdatedTag { NotUpdated };
-  LazyGenerationalDeclPtr(NotUpdatedTag, Decl *Value = nullptr)
-      : Value(Value) {}
-
   /// Forcibly set this pointer (which must be lazy) as needing updates.
   void markIncomplete() { cast<LazyData *>(Value)->LastGeneration = 0; }
 
@@ -484,9 +478,6 @@ public:
     }
     Value = NewValue;
   }
-
-  /// Set the value of this pointer, for this and all future generations.
-  void setNotUpdated(Decl *NewValue) { Value = NewValue; }
 
   /// Get the value of this pointer, updating its owner if necessary.
   Decl *get(const Decl *O) {

--- a/clang/include/clang/AST/ExternalASTSource.h
+++ b/clang/include/clang/AST/ExternalASTSource.h
@@ -439,46 +439,45 @@ public:
   }
 };
 
-/// A lazy value (of type T) that is within an AST node of type Owner,
-/// where the value might change in later generations of the external AST
-/// source.
-template<typename Owner, typename T, void (ExternalASTSource::*Update)(Owner)>
-struct LazyGenerationalUpdatePtr {
+/// A lazy Decl value where the value might change in later generations of the
+/// external AST source.
+struct LazyGenerationalDeclPtr {
   /// A cache of the value of this pointer, in the most recent generation in
   /// which we queried it.
   struct LazyData {
     ExternalASTSource *ExternalSource;
     uint32_t LastGeneration = 0;
-    T LastValue;
+    Decl *LastValue;
 
-    LazyData(ExternalASTSource *Source, T Value)
+    LazyData(ExternalASTSource *Source, Decl *Value)
         : ExternalSource(Source), LastValue(Value) {}
   };
 
-  // Our value is represented as simply T if there is no external AST source.
-  using ValueType = llvm::PointerUnion<T, LazyData*>;
+  // Our value is represented as simply a Decl pointer if there is no external
+  // AST source.
+  using ValueType = llvm::PointerUnion<Decl *, LazyData *>;
   ValueType Value;
 
-  LazyGenerationalUpdatePtr(ValueType V) : Value(V) {}
+  LazyGenerationalDeclPtr(ValueType V) : Value(V) {}
 
-  // Defined in ASTContext.h
-  static ValueType makeValue(const ASTContext &Ctx, T Value);
+  // Defined in ASTContext.cpp
+  static ValueType makeValue(const ASTContext &Ctx, Decl *Value);
 
 public:
-  explicit LazyGenerationalUpdatePtr(const ASTContext &Ctx, T Value = T())
+  explicit LazyGenerationalDeclPtr(const ASTContext &Ctx, Decl *Value = nullptr)
       : Value(makeValue(Ctx, Value)) {}
 
   /// Create a pointer that is not potentially updated by later generations of
   /// the external AST source.
   enum NotUpdatedTag { NotUpdated };
-  LazyGenerationalUpdatePtr(NotUpdatedTag, T Value = T())
+  LazyGenerationalDeclPtr(NotUpdatedTag, Decl *Value = nullptr)
       : Value(Value) {}
 
   /// Forcibly set this pointer (which must be lazy) as needing updates.
   void markIncomplete() { cast<LazyData *>(Value)->LastGeneration = 0; }
 
   /// Set the value of this pointer, in the current generation.
-  void set(T NewValue) {
+  void set(Decl *NewValue) {
     if (auto *LazyVal = Value.template dyn_cast<LazyData *>()) {
       LazyVal->LastValue = NewValue;
       return;
@@ -487,30 +486,30 @@ public:
   }
 
   /// Set the value of this pointer, for this and all future generations.
-  void setNotUpdated(T NewValue) { Value = NewValue; }
+  void setNotUpdated(Decl *NewValue) { Value = NewValue; }
 
   /// Get the value of this pointer, updating its owner if necessary.
-  T get(Owner O) {
+  Decl *get(const Decl *O) {
     if (auto *LazyVal = Value.template dyn_cast<LazyData *>()) {
       if (LazyVal->LastGeneration != LazyVal->ExternalSource->getGeneration()) {
         LazyVal->LastGeneration = LazyVal->ExternalSource->getGeneration();
-        (LazyVal->ExternalSource->*Update)(O);
+        LazyVal->ExternalSource->CompleteRedeclChain(O);
       }
       return LazyVal->LastValue;
     }
-    return cast<T>(Value);
+    return cast<Decl *>(Value);
   }
 
   /// Get the most recently computed value of this pointer without updating it.
-  T getNotUpdated() const {
+  Decl *getNotUpdated() const {
     if (auto *LazyVal = Value.template dyn_cast<LazyData *>())
       return LazyVal->LastValue;
-    return cast<T>(Value);
+    return cast<Decl *>(Value);
   }
 
   void *getOpaqueValue() { return Value.getOpaqueValue(); }
-  static LazyGenerationalUpdatePtr getFromOpaqueValue(void *Ptr) {
-    return LazyGenerationalUpdatePtr(ValueType::getFromOpaqueValue(Ptr));
+  static LazyGenerationalDeclPtr getFromOpaqueValue(void *Ptr) {
+    return LazyGenerationalDeclPtr(ValueType::getFromOpaqueValue(Ptr));
   }
 };
 
@@ -518,13 +517,10 @@ public:
 
 namespace llvm {
 
-/// Specialize PointerLikeTypeTraits to allow LazyGenerationalUpdatePtr to be
+/// Specialize PointerLikeTypeTraits to allow LazyGenerationalDeclPtr to be
 /// placed into a PointerUnion.
-template<typename Owner, typename T,
-         void (clang::ExternalASTSource::*Update)(Owner)>
-struct PointerLikeTypeTraits<
-    clang::LazyGenerationalUpdatePtr<Owner, T, Update>> {
-  using Ptr = clang::LazyGenerationalUpdatePtr<Owner, T, Update>;
+template <> struct PointerLikeTypeTraits<clang::LazyGenerationalDeclPtr> {
+  using Ptr = clang::LazyGenerationalDeclPtr;
 
   static void *getAsVoidPointer(Ptr P) { return P.getOpaqueValue(); }
   static Ptr getFromVoidPointer(void *P) { return Ptr::getFromOpaqueValue(P); }

--- a/clang/include/clang/AST/Redeclarable.h
+++ b/clang/include/clang/AST/Redeclarable.h
@@ -86,9 +86,7 @@ protected:
   class DeclLink {
     /// A pointer to a known latest declaration, either statically known or
     /// generationally updated as decls are added by an external source.
-    using KnownLatest =
-        LazyGenerationalUpdatePtr<const Decl *, Decl *,
-                                  &ExternalASTSource::CompleteRedeclChain>;
+    using KnownLatest = LazyGenerationalDeclPtr;
 
     /// We store a pointer to the ASTContext in the UninitializedLatest
     /// pointer, but to avoid circular type dependencies when we steal the low

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -15171,7 +15171,7 @@ LangAS ASTContext::getLangASForBuiltinAddressSpace(unsigned AS) const {
   return getLangASFromTargetAS(AS);
 }
 
-typename clang::LazyGenerationalDeclPtr::ValueType
+clang::LazyGenerationalDeclPtr::ValueType
 clang::LazyGenerationalDeclPtr::makeValue(const clang::ASTContext &Ctx,
                                           Decl *Value) {
   if (auto *Source = Ctx.getExternalSource())

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -15171,14 +15171,6 @@ LangAS ASTContext::getLangASForBuiltinAddressSpace(unsigned AS) const {
   return getLangASFromTargetAS(AS);
 }
 
-clang::LazyGenerationalDeclPtr::ValueType
-clang::LazyGenerationalDeclPtr::makeValue(const clang::ASTContext &Ctx,
-                                          Decl *Value) {
-  if (auto *Source = Ctx.getExternalSource())
-    return new (Ctx) LazyData(Source, Value);
-  return Value;
-}
-
 unsigned char ASTContext::getFixedPointScale(QualType Ty) const {
   assert(Ty->isFixedPointType());
 

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -15171,14 +15171,13 @@ LangAS ASTContext::getLangASForBuiltinAddressSpace(unsigned AS) const {
   return getLangASFromTargetAS(AS);
 }
 
-// Explicitly instantiate this in case a Redeclarable<T> is used from a TU that
-// doesn't include ASTContext.h
-template
-clang::LazyGenerationalUpdatePtr<
-    const Decl *, Decl *, &ExternalASTSource::CompleteRedeclChain>::ValueType
-clang::LazyGenerationalUpdatePtr<
-    const Decl *, Decl *, &ExternalASTSource::CompleteRedeclChain>::makeValue(
-        const clang::ASTContext &Ctx, Decl *Value);
+typename clang::LazyGenerationalDeclPtr::ValueType
+clang::LazyGenerationalDeclPtr::makeValue(const clang::ASTContext &Ctx,
+                                          Decl *Value) {
+  if (auto *Source = Ctx.getExternalSource())
+    return new (Ctx) LazyData(Source, Value);
+  return Value;
+}
 
 unsigned char ASTContext::getFixedPointScale(QualType Ty) const {
   assert(Ty->isFixedPointType());

--- a/clang/lib/AST/ExternalASTSource.cpp
+++ b/clang/lib/AST/ExternalASTSource.cpp
@@ -134,3 +134,10 @@ uint32_t ExternalASTSource::incrementGeneration(ASTContext &C) {
 
   return OldGeneration;
 }
+
+LazyGenerationalDeclPtr::ValueType
+LazyGenerationalDeclPtr::makeValue(const ASTContext &Ctx, Decl *Value) {
+  if (auto *Source = Ctx.getExternalSource())
+    return new (Ctx) LazyData(Source, Value);
+  return Value;
+}

--- a/llvm/unittests/ADT/PointerUnionTest.cpp
+++ b/llvm/unittests/ADT/PointerUnionTest.cpp
@@ -310,7 +310,7 @@ struct alignas(4) LowAlign {
 };
 
 // Wrapper around a PointerUnion that over-claims NumLowBitsAvailable,
-// mimicking LazyGenerationalUpdatePtr's PLTT on 32-bit.
+// mimicking LazyGenerationalDeclPtr's PLTT on 32-bit.
 struct OverClaimWrapper {
   PointerUnion<HighAlign *, LowAlign *> Value;
 


### PR DESCRIPTION
It is only used in `Redeclarable` with a single set of template arguments. Rename to `LazyGenerationalDeclPtr` and simplify the code.