### PR TITLE
[AMDGPU] Select the GFX80 encoding family from the subtarget. NFCI.

### DIFF
--- a/llvm/lib/Target/AMDGPU/BUFInstructions.td
+++ b/llvm/lib/Target/AMDGPU/BUFInstructions.td
@@ -933,7 +933,7 @@ defm BUFFER_STORE_FORMAT_XYZW : MUBUF_Pseudo_Stores <
   "buffer_store_format_xyzw", v4f32
 >;
 
-let OtherPredicates = [HasUnpackedD16VMem], D16Buf = 1 in {
+let OtherPredicates = [HasUnpackedD16VMem] in {
 let TiedSourceNotRead = 1 in {
   defm BUFFER_LOAD_FORMAT_D16_X_gfx80 : MUBUF_Pseudo_Loads <
     "buffer_load_format_d16_x", i32
@@ -960,7 +960,7 @@ let TiedSourceNotRead = 1 in {
   defm BUFFER_STORE_FORMAT_D16_XYZW_gfx80 : MUBUF_Pseudo_Stores <
     "buffer_store_format_d16_xyzw", v4i32
   >;
-} // End OtherPredicates = [HasUnpackedD16VMem], D16Buf = 1.
+} // End OtherPredicates = [HasUnpackedD16VMem].
 
 
 let TiedSourceNotRead = 1, SubtargetPredicate = HasD16LoadStore, OtherPredicates = [HasFormattedMUBUFInsts] in
@@ -968,7 +968,7 @@ defm BUFFER_LOAD_FORMAT_D16_HI_X : MUBUF_Pseudo_Loads <
   "buffer_load_format_d16_hi_x", i32
 >;
 
-let OtherPredicates = [HasPackedD16VMem], D16Buf = 1 in {
+let OtherPredicates = [HasPackedD16VMem] in {
 let TiedSourceNotRead = 1 in {
   defm BUFFER_LOAD_FORMAT_D16_X : MUBUF_Pseudo_Loads_t16 <
     "buffer_load_format_d16_x", f16, 0, 0, "BUFFER_LOAD_FORMAT_D16_HI_X"
@@ -995,7 +995,7 @@ let TiedSourceNotRead = 1 in {
   defm BUFFER_STORE_FORMAT_D16_XYZW : MUBUF_Pseudo_Stores <
     "buffer_store_format_d16_xyzw", v4f16
   >;
-} // End OtherPredicates = [HasPackedD16VMem], D16Buf = 1.
+} // End OtherPredicates = [HasPackedD16VMem].
 } // End SubtargetPredicate = HasFormattedMUBUFInsts.
 
 defm BUFFER_LOAD_UBYTE : MUBUF_Pseudo_Loads_Lds <
@@ -1321,7 +1321,7 @@ defm TBUFFER_STORE_FORMAT_XY   : MTBUF_Pseudo_Stores <"tbuffer_store_format_xy",
 defm TBUFFER_STORE_FORMAT_XYZ  : MTBUF_Pseudo_Stores <"tbuffer_store_format_xyz",  AVLdSt_96,  3>;
 defm TBUFFER_STORE_FORMAT_XYZW : MTBUF_Pseudo_Stores <"tbuffer_store_format_xyzw", AVLdSt_128, 4>;
 
-let SubtargetPredicate = HasUnpackedD16VMem, D16Buf = 1 in {
+let SubtargetPredicate = HasUnpackedD16VMem in {
 let TiedSourceNotRead = 1 in {
   defm TBUFFER_LOAD_FORMAT_D16_X_gfx80     : MTBUF_Pseudo_Loads  <"tbuffer_load_format_d16_x",     AVLdSt_32,  1>;
   defm TBUFFER_LOAD_FORMAT_D16_XY_gfx80    : MTBUF_Pseudo_Loads  <"tbuffer_load_format_d16_xy",    AVLdSt_64,  2>;
@@ -1334,7 +1334,7 @@ let TiedSourceNotRead = 1 in {
   defm TBUFFER_STORE_FORMAT_D16_XYZW_gfx80 : MTBUF_Pseudo_Stores <"tbuffer_store_format_d16_xyzw", AVLdSt_128, 4>;
 } // End HasUnpackedD16VMem.
 
-let SubtargetPredicate = HasPackedD16VMem, D16Buf = 1 in {
+let SubtargetPredicate = HasPackedD16VMem in {
 let TiedSourceNotRead = 1 in {
   defm TBUFFER_LOAD_FORMAT_D16_X     : MTBUF_Pseudo_Loads  <"tbuffer_load_format_d16_x",     AVLdSt_32, 1>;
   defm TBUFFER_LOAD_FORMAT_D16_XY    : MTBUF_Pseudo_Loads  <"tbuffer_load_format_d16_xy",    AVLdSt_32, 2>;

--- a/llvm/lib/Target/AMDGPU/SIDefines.h
+++ b/llvm/lib/Target/AMDGPU/SIDefines.h
@@ -146,9 +146,6 @@ enum : uint64_t {
   // Is a packed VOP3P instruction.
   IsPacked = UINT64_C(1) << 49,
 
-  // Is a D16 buffer instruction.
-  D16Buf = UINT64_C(1) << 50,
-
   // FLAT instruction accesses FLAT_GLBL segment.
   FlatGlobal = UINT64_C(1) << 51,
 
@@ -340,9 +337,6 @@ template <typename... T> constexpr bool hasClampHi(const T &...O) {
 }
 template <typename... T> constexpr bool isPacked(const T &...O) {
   return getTSFlags(O...) & DontUseRawTSFlags::IsPacked;
-}
-template <typename... T> constexpr bool isD16Buf(const T &...O) {
-  return getTSFlags(O...) & DontUseRawTSFlags::D16Buf;
 }
 template <typename... T> constexpr bool isFlatGlobal(const T &...O) {
   return getTSFlags(O...) & DontUseRawTSFlags::FlatGlobal;

--- a/llvm/lib/Target/AMDGPU/SIInstrFormats.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrFormats.td
@@ -111,9 +111,6 @@ class InstSI <dag outs, dag ins, string asm = "",
   // This bit indicates that this is a packed VOP3P instruction
   field bit IsPacked = 0;
 
-  // This bit indicates that this is a D16 buffer instruction.
-  field bit D16Buf = 0;
-
   // This field indicates that FLAT instruction accesses FLAT_GLBL segment.
   // Must be 0 for non-FLAT instructions.
   field bit FlatGlobal = 0;
@@ -227,8 +224,6 @@ class InstSI <dag outs, dag ins, string asm = "",
   let TSFlags{48} = ClampHi;
 
   let TSFlags{49} = IsPacked;
-
-  let TSFlags{50} = D16Buf;
 
   let TSFlags{51} = FlatGlobal;
 

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -10708,6 +10708,11 @@ static unsigned subtargetEncodingFamily(const GCNSubtarget &ST) {
   case AMDGPUSubtarget::SEA_ISLANDS:
     return SIEncodingFamily::SI;
   case AMDGPUSubtarget::VOLCANIC_ISLANDS:
+    // The GFX80 encoding family only contains buffer instructions with unpacked
+    // D16 data; pseudoToMCOpcode falls back on VI for everything else.
+    // TODO: remove this when we discard GFX80 encoding.
+    return ST.hasUnpackedD16VMem() ? SIEncodingFamily::GFX80
+                                   : SIEncodingFamily::VI;
   case AMDGPUSubtarget::GFX9:
     return SIEncodingFamily::VI;
   case AMDGPUSubtarget::GFX10:
@@ -10786,12 +10791,6 @@ int SIInstrInfo::pseudoToMCOpcode(int Opcode) const {
   if (ST.getGeneration() == AMDGPUSubtarget::GFX9 && isRenamedInGFX9(Opcode))
     Gen = SIEncodingFamily::GFX9;
 
-  // Adjust the encoding family to GFX80 for D16 buffer instructions when the
-  // subtarget has UnpackedD16VMem feature.
-  // TODO: remove this when we discard GFX80 encoding.
-  if (ST.hasUnpackedD16VMem() && SIInstrFlags::isD16Buf(get(Opcode)))
-    Gen = SIEncodingFamily::GFX80;
-
   if (SIInstrFlags::isSDWA(get(Opcode))) {
     switch (ST.getGeneration()) {
     default:
@@ -10813,6 +10812,12 @@ int SIInstrInfo::pseudoToMCOpcode(int Opcode) const {
   }
 
   int32_t MCOp = AMDGPU::getMCOpcode(Opcode, Gen);
+
+  // Only buffer instructions with unpacked D16 data have a GFX80 encoding.
+  // Anything else on such a subtarget uses the plain VI encoding.
+  // TODO: remove this when we discard GFX80 encoding.
+  if (MCOp == AMDGPU::INSTRUCTION_LIST_END && Gen == SIEncodingFamily::GFX80)
+    MCOp = AMDGPU::getMCOpcode(Opcode, SIEncodingFamily::VI);
 
   if (MCOp == AMDGPU::INSTRUCTION_LIST_END && ST.hasGFX11_7Insts())
     MCOp = AMDGPU::getMCOpcode(Opcode, SIEncodingFamily::GFX11);


### PR DESCRIPTION
pseudoToMCOpcode() used the D16Buf TSFlag to switch individual instructions to
the GFX80 encoding family on subtargets with UnpackedD16VMem. Select GFX80 for
the whole subtarget instead, and fall back on VI when a pseudo has no GFX80
real. That is what the flag was encoding anyway: only buffer instructions with
unpacked D16 data have a GFX80 encoding.

D16Buf is now unused, so remove it and free up TSFlags bit 50.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
