### PR TITLE
[AMDGPU] Fully remove the old renamedInGFX9 flag from TSFlags. NFC.

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIDefines.h
+++ b/llvm/lib/Target/AMDGPU/SIDefines.h
@@ -128,7 +128,6 @@ enum : uint64_t {
 
   VOP3_OPSEL = UINT64_C(1) << 42,
   maybeAtomic = UINT64_C(1) << 43,
-  renamedInGFX9 = UINT64_C(1) << 44,
 
   // Is a clamp on FP type.
   FPClamp = UINT64_C(1) << 45,

--- a/llvm/lib/Target/AMDGPU/SIInstrFormats.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrFormats.td
@@ -218,9 +218,6 @@ class InstSI <dag outs, dag ins, string asm = "",
 
   let TSFlags{43} = maybeAtomic;
 
-  // Reserved, must be 0.
-  let TSFlags{44} = 0;
-
   let TSFlags{45} = FPClamp;
   let TSFlags{46} = IntClamp;
   let TSFlags{47} = ClampLo;


### PR DESCRIPTION
Left over from #82787.
