### PR TITLE
[libc++] Provide aligned allocation function iff the compiler claims support

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -157,24 +157,10 @@ typedef __char32_t char32_t;
 #    define _DECLARE_C99_LDBL_MATH 1
 #  endif
 
-// If we are getting operator new from the MSVC CRT, then allocation overloads
-// for align_val_t were added in 19.12, aka VS 2017 version 15.3.
-#  if defined(_LIBCPP_MSVCRT) && defined(_MSC_VER) && _MSC_VER < 1912
-#    define _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION 0
-#  elif defined(_LIBCPP_ABI_VCRUNTIME) && !defined(__cpp_aligned_new)
-// We're deferring to Microsoft's STL to provide aligned new et al. We don't
-// have it unless the language feature test macro is defined.
-#    define _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION 0
-#  elif defined(__MVS__)
-#    define _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION 0
-#  else
-#    define _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION 1
-#  endif
-
-#  if !_LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION || (!defined(__cpp_aligned_new) || __cpp_aligned_new < 201606)
-#    define _LIBCPP_HAS_ALIGNED_ALLOCATION 0
-#  else
+#  if defined(__cpp_aligned_new) && __cpp_aligned_new >= 201606
 #    define _LIBCPP_HAS_ALIGNED_ALLOCATION 1
+#  else
+#    define _LIBCPP_HAS_ALIGNED_ALLOCATION 0
 #  endif
 
 #  if defined(__APPLE__) || defined(__FreeBSD__)

--- a/libcxx/include/__new/align_val_t.h
+++ b/libcxx/include/__new/align_val_t.h
@@ -18,18 +18,18 @@
 
 // <vcruntime_exception.h> defines its own std::align_val_t type,
 // which we use in order to be ABI-compatible with other STLs on Windows.
-#if _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION && defined(_LIBCPP_ABI_VCRUNTIME)
+#if defined(_LIBCPP_ABI_VCRUNTIME)
 #  include <vcruntime_new.h>
-#endif
+#elif _LIBCPP_HAS_ALIGNED_ALLOCATION
 
 _LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
-#if _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION && !defined(_LIBCPP_ABI_VCRUNTIME)
 #  ifndef _LIBCPP_CXX03_LANG
 enum class align_val_t : size_t {};
 #  else
 enum align_val_t { __zero = 0, __max = (size_t)-1 };
 #  endif
-#endif
 _LIBCPP_END_UNVERSIONED_NAMESPACE_STD
+
+#endif
 
 #endif // _LIBCPP___NEW_ALIGN_VAL_T_H

--- a/libcxx/include/__new/global_new_delete.h
+++ b/libcxx/include/__new/global_new_delete.h
@@ -45,7 +45,7 @@ _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete[](void* __p, const std::nothro
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete[](void* __p, std::size_t __sz) _NOEXCEPT;
 #  endif
 
-#  if _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION
+#  if _LIBCPP_HAS_ALIGNED_ALLOCATION
 [[__nodiscard__]] _LIBCPP_OVERRIDABLE_FUNC_VIS void* operator new(std::size_t __sz, std::align_val_t) _THROW_BAD_ALLOC;
 [[__nodiscard__]] _LIBCPP_OVERRIDABLE_FUNC_VIS void*
 operator new(std::size_t __sz, std::align_val_t, const std::nothrow_t&) _NOEXCEPT _LIBCPP_NOALIAS;

--- a/libcxx/src/include/aligned_alloc.h
+++ b/libcxx/src/include/aligned_alloc.h
@@ -18,7 +18,7 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION
+#if _LIBCPP_HAS_ALIGNED_ALLOCATION
 
 // Low-level helpers to call the aligned allocation and deallocation functions
 // on the target platform. This is used to implement libc++'s own memory
@@ -58,7 +58,7 @@ inline _LIBCPP_HIDE_FROM_ABI void __libcpp_aligned_free(void* __ptr) {
 #  endif
 }
 
-#endif // _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION
+#endif // _LIBCPP_HAS_ALIGNED_ALLOCATION
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/src/support/new.ipp
+++ b/libcxx/src/support/new.ipp
@@ -113,7 +113,7 @@ OVERRIDABLE_FUNCTION void* operator new[](size_t size) _THROW_BAD_ALLOC { return
 
 [[gnu::weak]] void operator delete[](void* ptr, size_t) noexcept { ::operator delete[](ptr); }
 
-#if _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION
+#if _LIBCPP_HAS_ALIGNED_ALLOCATION
 
 template <on_failure failure_mode>
 static void* operator_new_aligned_impl(std::size_t size, std::align_val_t alignment) {
@@ -215,4 +215,4 @@ OVERRIDABLE_FUNCTION void* operator new[](size_t size, std::align_val_t alignmen
 [[gnu::weak]] void operator delete[](void* ptr, size_t, std::align_val_t alignment) noexcept {
   ::operator delete[](ptr, alignment);
 }
-#endif // _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION
+#endif // _LIBCPP_HAS_ALIGNED_ALLOCATION

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/new.size_align.except.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/new.size_align.except.pass.cpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: c++03, c++11, c++14
+
 // UNSUPPORTED: no-exceptions
 // UNSUPPORTED: sanitizer-new-delete
 

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/new.size_align_nothrow.except.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/new.size_align_nothrow.except.pass.cpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: c++03, c++11, c++14
+
 // UNSUPPORTED: no-exceptions
 // UNSUPPORTED: sanitizer-new-delete
 

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/new.size_align.except.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/new.size_align.except.pass.cpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: c++03, c++11, c++14
+
 // UNSUPPORTED: no-exceptions
 // UNSUPPORTED: sanitizer-new-delete
 

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/new.size_align_nothrow.except.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/new.size_align_nothrow.except.pass.cpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: c++03, c++11, c++14
+
 // UNSUPPORTED: no-exceptions
 // UNSUPPORTED: sanitizer-new-delete
 

--- a/libcxx/test/support/test_macros.h
+++ b/libcxx/test/support/test_macros.h
@@ -231,11 +231,7 @@
 #  define TEST_IS_EXECUTED_IN_A_SLOW_ENVIRONMENT
 #endif
 
-#if defined(_LIBCPP_VERSION) && defined(_LIBCPP_HAS_ALIGNED_ALLOCATION) && !_LIBCPP_HAS_ALIGNED_ALLOCATION
-#  define TEST_HAS_NO_ALIGNED_ALLOCATION
-#elif defined(_LIBCPP_VERSION) && defined(_LIBCPP_HAS_NO_ALIGNED_ALLOCATION) /* old libc++ version */
-#  define TEST_HAS_NO_ALIGNED_ALLOCATION
-#elif TEST_STD_VER < 17 && (!defined(__cpp_aligned_new) || __cpp_aligned_new < 201606L)
+#if (!defined(__cpp_aligned_new) || __cpp_aligned_new < 201606L)
 #  define TEST_HAS_NO_ALIGNED_ALLOCATION
 #endif
 

--- a/libcxxabi/src/fallback_malloc.cpp
+++ b/libcxxabi/src/fallback_malloc.cpp
@@ -259,7 +259,7 @@ void* __aligned_malloc_with_fallback(size_t size) {
 #if defined(_WIN32)
   if (void* dest = std::__libcpp_aligned_alloc(alignof(__aligned_type), size))
     return dest;
-#elif !_LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION
+#elif !_LIBCPP_HAS_ALIGNED_ALLOCATION
   if (void* dest = ::malloc(size))
     return dest;
 #else
@@ -286,7 +286,7 @@ void __aligned_free_with_fallback(void* ptr) {
   if (is_fallback_ptr(ptr))
     fallback_free(ptr);
   else {
-#if !_LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION
+#if !_LIBCPP_HAS_ALIGNED_ALLOCATION
     ::free(ptr);
 #else
     std::__libcpp_aligned_free(ptr);


### PR DESCRIPTION
There isn't much of a point to providing declarations for aligned allocation functions but not allowing the compiler to use them. So either aligned allocations should be allowed to be used via `-faligned-allocation` or not provided at all.