### PR TITLE
[AArch64] Fix extern_weak function calls on Windows

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
@@ -503,6 +503,12 @@ unsigned AArch64Subtarget::classifyGlobalFunctionReference(
       }
     }
 
+    // extern_weak dso_local ptr function references on Windows should not go
+    // through GOT/COFFSTUB. The linker resolves extern_weak to either the real
+    // symbol or null, so a direct call is correct.
+    if (GV->hasExternalWeakLinkage() && GV->isDSOLocal())
+      return AArch64II::MO_NO_FLAG;
+
     // Use ClassifyGlobalReference for setting MO_DLLIMPORT/MO_COFFSTUB.
     return ClassifyGlobalReference(GV, TM);
   }

--- a/llvm/test/CodeGen/AArch64/windows-extern-weak.ll
+++ b/llvm/test/CodeGen/AArch64/windows-extern-weak.ll
@@ -41,3 +41,24 @@ define void @func() nounwind {
 }
 
 declare extern_weak void @weakfunc()
+
+define ptr @use() {
+; CHECK-LABEL: use:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
+; CHECK:    bl foo
+; CHECK:    ldr x30, [sp], #16 // 8-byte Folded Reload
+; CHECK:    ret
+;
+; FISEL-LABEL: use:
+; FISEL:       // %bb.0: // %entry
+; FISEL-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
+; FISEL:    bl foo
+; FISEL:    ldr x30, [sp], #16 // 8-byte Folded Reload
+; FISEL:    ret
+entry:
+  %r = call ptr @foo()
+  ret ptr %r
+}
+
+declare extern_weak dso_local ptr @foo()


### PR DESCRIPTION
On aarch64-windows-gnu/msvc, calls to extern_weak functions were incorrectly going through a GOT/COFFSTUB load (adrp/ldr/blr) instead of using a direct BL instruction. This happened because classifyGlobalFunctionReference delegated to ClassifyGlobalReference for Windows, which returned MO_GOT | MO_COFFSTUB for extern_weak symbols.

The fix adds an early return of MO_NO_FLAG for extern_weak function references on Windows, allowing a direct call. The linker handles extern_weak by resolving to either the real symbol or null, so a direct BL is correct (matching ELF behavior).

issue: #218899