### PR TITLE
[SPIRV] Fix -Wunused-variable

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -635,7 +635,7 @@ Register SPIRVGlobalRegistry::getOrCreateConstVector(const APInt &Val,
          "Expected vector type for constant vector creation");
   const FixedVectorType *LLVMVecTy = cast<FixedVectorType>(LLVMTy);
   Type *LLVMBaseTy = LLVMVecTy->getElementType();
-  const auto &ST = I.getMF()->getSubtarget<SPIRVSubtarget>();
+  [[maybe_unused]] const auto &ST = I.getMF()->getSubtarget<SPIRVSubtarget>();
   assert((LLVMBaseTy->isIntegerTy() ||
           (LLVMBaseTy->isPointerTy() &&
            ST.canUseExtension(

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -6745,7 +6745,7 @@ bool SPIRVInstructionSelector::extractSubvector(
   [[maybe_unused]] uint64_t InputSize =
       GR.getScalarOrVectorComponentCount(InputType);
   uint64_t ResultSize = GR.getScalarOrVectorComponentCount(ResType);
-  bool IsLongVectorEXT =
+  [[maybe_unused]] bool IsLongVectorEXT =
       STI.canUseExtension(SPIRV::Extension::SPV_EXT_long_vector);
   assert((InputSize > 1 || IsLongVectorEXT) && "The input must be a vector.");
   assert((ResultSize > 1 || IsLongVectorEXT) && "The result must be a vector.");


### PR DESCRIPTION
These variables are only used in assertions but are used multiple times/do not make sense to inline, so mark them [[maybe_unused]].