### PR TITLE
[mlir][SCFToControlFlow] Carry LLVM attributes through scf.parallel lowering

### DIFF
--- a/mlir/lib/Conversion/SCFToControlFlow/SCFToControlFlow.cpp
+++ b/mlir/lib/Conversion/SCFToControlFlow/SCFToControlFlow.cpp
@@ -535,8 +535,10 @@ ParallelLowering::matchAndRewrite(ParallelOp parallelOp,
     rewriter.setInsertionPointToStart(forOp.getBody());
   }
 
-  // Carry LLVM attributes such as llvm.loop_annotation over to the innermost
-  // generated loop, which is the one whose latch will hold the loop metadata.
+  // Carry LLVM attributes such as llvm.loop_annotation over to the generated
+  // nest. A multi-dimensional scf.parallel has a single attribute dictionary
+  // but becomes several loops, so the attributes go to the innermost one, whose
+  // latch is where ForLowering will attach the loop metadata.
   if (innermostForOp)
     copyLLVMDialectAttrs(parallelOp, innermostForOp);
 

--- a/mlir/lib/Conversion/SCFToControlFlow/SCFToControlFlow.cpp
+++ b/mlir/lib/Conversion/SCFToControlFlow/SCFToControlFlow.cpp
@@ -535,10 +535,9 @@ ParallelLowering::matchAndRewrite(ParallelOp parallelOp,
     rewriter.setInsertionPointToStart(forOp.getBody());
   }
 
-  // Carry LLVM attributes such as llvm.loop_annotation over to the generated
-  // nest. A multi-dimensional scf.parallel has a single attribute dictionary
-  // but becomes several loops, so the attributes go to the innermost one, whose
-  // latch is where ForLowering will attach the loop metadata.
+  // Serializing into the for nest would drop attributes such as
+  // llvm.loop_annotation. The loop above emits one scf.for per dimension, so
+  // the attributes go to the innermost one, which runs the body.
   if (innermostForOp)
     copyLLVMDialectAttrs(parallelOp, innermostForOp);
 

--- a/mlir/lib/Conversion/SCFToControlFlow/SCFToControlFlow.cpp
+++ b/mlir/lib/Conversion/SCFToControlFlow/SCFToControlFlow.cpp
@@ -313,17 +313,20 @@ struct ForallLowering : public OpRewritePattern<mlir::scf::ForallOp> {
 
 } // namespace
 
+static void copyLLVMDialectAttrs(Operation *from, Operation *to) {
+  SmallVector<NamedAttribute> llvmAttrs;
+  llvm::copy_if(from->getAttrs(), std::back_inserter(llvmAttrs), [](auto attr) {
+    return isa<LLVM::LLVMDialect>(attr.getValue().getDialect());
+  });
+  to->setDiscardableAttrs(llvmAttrs);
+}
+
 static void propagateLoopAttrs(Operation *scfOp, Operation *brOp) {
   // Let the CondBranchOp carry the LLVM attributes from the ForOp, such as the
   // llvm.loop_annotation attribute.
   // LLVM requires the loop metadata to be attached on the "latch" block. Which
   // is the back-edge to the header block (conditionBlock)
-  SmallVector<NamedAttribute> llvmAttrs;
-  llvm::copy_if(scfOp->getAttrs(), std::back_inserter(llvmAttrs),
-                [](auto attr) {
-                  return isa<LLVM::LLVMDialect>(attr.getValue().getDialect());
-                });
-  brOp->setDiscardableAttrs(llvmAttrs);
+  copyLLVMDialectAttrs(scfOp, brOp);
 }
 
 LogicalResult ForLowering::matchAndRewrite(ForOp forOp,
@@ -507,10 +510,12 @@ ParallelLowering::matchAndRewrite(ParallelOp parallelOp,
   ivs.reserve(parallelOp.getNumLoops());
   bool first = true;
   SmallVector<Value, 4> loopResults(iterArgs);
+  ForOp innermostForOp;
   for (auto [iv, lower, upper, step] :
        llvm::zip(parallelOp.getInductionVars(), parallelOp.getLowerBound(),
                  parallelOp.getUpperBound(), parallelOp.getStep())) {
     ForOp forOp = ForOp::create(rewriter, loc, lower, upper, step, iterArgs);
+    innermostForOp = forOp;
     ivs.push_back(forOp.getInductionVar());
     auto iterRange = forOp.getRegionIterArgs();
     iterArgs.assign(iterRange.begin(), iterRange.end());
@@ -529,6 +534,11 @@ ParallelLowering::matchAndRewrite(ParallelOp parallelOp,
 
     rewriter.setInsertionPointToStart(forOp.getBody());
   }
+
+  // Carry LLVM attributes such as llvm.loop_annotation over to the innermost
+  // generated loop, which is the one whose latch will hold the loop metadata.
+  if (innermostForOp)
+    copyLLVMDialectAttrs(parallelOp, innermostForOp);
 
   // First, merge reduction blocks into the main region.
   SmallVector<Value> yieldOperands;

--- a/mlir/test/Conversion/SCFToControlFlow/convert-to-cfg.mlir
+++ b/mlir/test/Conversion/SCFToControlFlow/convert-to-cfg.mlir
@@ -795,3 +795,21 @@ func.func @do_while_loops_annotation() {
   return
 }
 
+// -----
+
+// CHECK: #[[LOOP_UNROLL_DISABLE:.*]] = #llvm.loop_unroll<disable = true>
+// CHECK: #[[NO_UNROLL:.*]] = #llvm.loop_annotation<unroll = #[[LOOP_UNROLL_DISABLE]]>
+// CHECK: func @parallel_loop_annotation
+// CHECK: cf.cond_br
+// CHECK: cf.br {{.*}} {llvm.loop_annotation = #[[NO_UNROLL]]}
+// CHECK: return
+#no_unroll = #llvm.loop_annotation<unroll = <disable = true>>
+func.func @parallel_loop_annotation(%arg0 : index, %arg1 : index, %arg2 : index, %arg3 : memref<?xf32>) {
+  %cst = arith.constant 1.0 : f32
+  scf.parallel (%i) = (%arg0) to (%arg1) step (%arg2) {
+    memref.store %cst, %arg3[%i] : memref<?xf32>
+    scf.reduce
+  } {llvm.loop_annotation = #no_unroll}
+  return
+}
+

--- a/mlir/test/Conversion/SCFToControlFlow/convert-to-cfg.mlir
+++ b/mlir/test/Conversion/SCFToControlFlow/convert-to-cfg.mlir
@@ -813,3 +813,24 @@ func.func @parallel_loop_annotation(%arg0 : index, %arg1 : index, %arg2 : index,
   return
 }
 
+// -----
+
+// A multi-dimensional scf.parallel lowers to a loop nest, and the metadata goes
+// to the innermost loop's latch only.
+// CHECK: #[[LOOP_UNROLL_DISABLE:.*]] = #llvm.loop_unroll<disable = true>
+// CHECK: #[[NO_UNROLL:.*]] = #llvm.loop_annotation<unroll = #[[LOOP_UNROLL_DISABLE]]>
+// CHECK: func @parallel_loop_annotation_2d
+// CHECK: cf.cond_br
+// CHECK: cf.cond_br
+// CHECK: cf.br {{.*}} {llvm.loop_annotation = #[[NO_UNROLL]]}
+// CHECK-NOT: llvm.loop_annotation
+// CHECK: return
+#no_unroll = #llvm.loop_annotation<unroll = <disable = true>>
+func.func @parallel_loop_annotation_2d(%arg0 : index, %arg1 : index, %arg2 : index, %arg3 : memref<?x?xf32>) {
+  %cst = arith.constant 1.0 : f32
+  scf.parallel (%i, %j) = (%arg0, %arg0) to (%arg1, %arg1) step (%arg2, %arg2) {
+    memref.store %cst, %arg3[%i, %j] : memref<?x?xf32>
+    scf.reduce
+  } {llvm.loop_annotation = #no_unroll}
+  return
+}


### PR DESCRIPTION
`ParallelLowering` builds its `scf.for` nest without copying anything from the
`scf.parallel`, so an `llvm.loop_annotation` placed on a parallel loop is
silently dropped before `ForLowering` can move it onto the latch branch.

`scf.for` and `scf.while` already propagate LLVM-dialect attributes via
`propagateLoopAttrs`, so do the same for `scf.parallel`. A multi-dimensional
`scf.parallel` carries a single attribute dictionary but becomes several loops,
so the attributes go to the innermost one, whose latch is where `ForLowering`
attaches the loop metadata.

Tests cover the 1-D case and a 2-D nest, where the outer latch is checked to
stay unannotated. Verified that the new tests fail without the fix and pass with
it, and that the pre-existing expectations in `convert-to-cfg.mlir` are
unchanged.