### PR TITLE
[AArch64][GlobalISel] Create zip in shuffle(v, undefined) situations

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -35527,8 +35527,7 @@ SDValue AArch64TargetLowering::LowerFixedLengthVECTOR_SHUFFLEToSVE(
   unsigned WhichResult;
   unsigned OperandOrder;
   unsigned NumElts = VT.getVectorNumElements();
-  if (isZIPMask(ShuffleMask, NumElts, WhichResult,
-                OperandOrder) &&
+  if (isZIPMask(ShuffleMask, NumElts, WhichResult, OperandOrder) &&
       WhichResult == 0) {
     SDValue ZIP = DAG.getNode(AArch64ISD::ZIP1, DL, ContainerVT,
                               OperandOrder == 0 ? Op1 : Op2,
@@ -35583,8 +35582,7 @@ SDValue AArch64TargetLowering::LowerFixedLengthVECTOR_SHUFFLEToSVE(
     }
 
     unsigned NumElts = VT.getVectorNumElements();
-    if (isZIPMask(ShuffleMask, NumElts, WhichResult,
-                  OperandOrder) &&
+    if (isZIPMask(ShuffleMask, NumElts, WhichResult, OperandOrder) &&
         WhichResult != 0) {
       SDValue ZIP = DAG.getNode(AArch64ISD::ZIP2, DL, ContainerVT,
                                 OperandOrder == 0 ? Op1 : Op2,
@@ -35598,7 +35596,8 @@ SDValue AArch64TargetLowering::LowerFixedLengthVECTOR_SHUFFLEToSVE(
           DAG, VT, DAG.getNode(Opc, DL, ContainerVT, Op1, Op2));
     }
 
-    if (isZIP_v_undef_Mask(ShuffleMask, NumElts, WhichResult) && WhichResult != 0)
+    if (isZIP_v_undef_Mask(ShuffleMask, NumElts, WhichResult) &&
+        WhichResult != 0)
       return convertFromScalableVector(
           DAG, VT, DAG.getNode(AArch64ISD::ZIP2, DL, ContainerVT, Op1, Op1));
 

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -15462,25 +15462,6 @@ static bool isEXTMaskWithSplat(ArrayRef<int> M, EVT VT, unsigned SplatOperand,
   return false;
 }
 
-/// isZIP_v_undef_Mask - Special case of isZIPMask for canonical form of
-/// "vector_shuffle v, v", i.e., "vector_shuffle v, undef".
-/// Mask is e.g., <0, 0, 1, 1> instead of <0, 4, 1, 5>.
-static bool isZIP_v_undef_Mask(ArrayRef<int> M, EVT VT, unsigned &WhichResult) {
-  unsigned NumElts = VT.getVectorNumElements();
-  if (NumElts % 2 != 0)
-    return false;
-  WhichResult = (M[0] == 0 ? 0 : 1);
-  unsigned Idx = WhichResult * NumElts / 2;
-  for (unsigned i = 0; i != NumElts; i += 2) {
-    if ((M[i] >= 0 && (unsigned)M[i] != Idx) ||
-        (M[i + 1] >= 0 && (unsigned)M[i + 1] != Idx))
-      return false;
-    Idx += 1;
-  }
-
-  return true;
-}
-
 /// isUZP_v_undef_Mask - Special case of isUZPMask for canonical form of
 /// "vector_shuffle v, v", i.e., "vector_shuffle v, undef".
 /// Mask is e.g., <0, 2, 0, 2> instead of <0, 2, 4, 6>,
@@ -16229,7 +16210,7 @@ SDValue AArch64TargetLowering::LowerVECTOR_SHUFFLE(SDValue Op,
                        OperandOrder == 0 ? V2 : V1);
   }
 
-  if (isZIP_v_undef_Mask(ShuffleMask, VT, WhichResult)) {
+  if (isZIP_v_undef_Mask(ShuffleMask, NumElts, WhichResult)) {
     unsigned Opc = (WhichResult == 0) ? AArch64ISD::ZIP1 : AArch64ISD::ZIP2;
     return DAG.getNode(Opc, DL, V1.getValueType(), V1, V1);
   }
@@ -18022,7 +18003,7 @@ bool AArch64TargetLowering::isShuffleMaskLegal(ArrayRef<int> M, EVT VT) const {
           isZIPMask(M, NumElts, DummyUnsigned, DummyUnsigned) ||
           isTRN_v_undef_Mask(M, VT, DummyUnsigned) ||
           isUZP_v_undef_Mask(M, VT, DummyUnsigned) ||
-          isZIP_v_undef_Mask(M, VT, DummyUnsigned) ||
+          isZIP_v_undef_Mask(M, NumElts, DummyUnsigned) ||
           isINSMask(M, NumElts, DummyBool, DummyInt) ||
           isConcatMask(M, VT, VT.getSizeInBits() == 128));
 }
@@ -35545,7 +35526,8 @@ SDValue AArch64TargetLowering::LowerFixedLengthVECTOR_SHUFFLEToSVE(
 
   unsigned WhichResult;
   unsigned OperandOrder;
-  if (isZIPMask(ShuffleMask, VT.getVectorNumElements(), WhichResult,
+  unsigned NumElts = VT.getVectorNumElements();
+  if (isZIPMask(ShuffleMask, NumElts, WhichResult,
                 OperandOrder) &&
       WhichResult == 0) {
     SDValue ZIP = DAG.getNode(AArch64ISD::ZIP1, DL, ContainerVT,
@@ -35563,7 +35545,7 @@ SDValue AArch64TargetLowering::LowerFixedLengthVECTOR_SHUFFLEToSVE(
     return convertFromScalableVector(DAG, VT, TRN);
   }
 
-  if (isZIP_v_undef_Mask(ShuffleMask, VT, WhichResult) && WhichResult == 0)
+  if (isZIP_v_undef_Mask(ShuffleMask, NumElts, WhichResult) && WhichResult == 0)
     return convertFromScalableVector(
         DAG, VT, DAG.getNode(AArch64ISD::ZIP1, DL, ContainerVT, Op1, Op1));
 
@@ -35600,7 +35582,8 @@ SDValue AArch64TargetLowering::LowerFixedLengthVECTOR_SHUFFLEToSVE(
       return convertFromScalableVector(DAG, VT, Op);
     }
 
-    if (isZIPMask(ShuffleMask, VT.getVectorNumElements(), WhichResult,
+    unsigned NumElts = VT.getVectorNumElements();
+    if (isZIPMask(ShuffleMask, NumElts, WhichResult,
                   OperandOrder) &&
         WhichResult != 0) {
       SDValue ZIP = DAG.getNode(AArch64ISD::ZIP2, DL, ContainerVT,
@@ -35609,13 +35592,13 @@ SDValue AArch64TargetLowering::LowerFixedLengthVECTOR_SHUFFLEToSVE(
       return convertFromScalableVector(DAG, VT, ZIP);
     }
 
-    if (isUZPMask(ShuffleMask, VT.getVectorNumElements(), WhichResult)) {
+    if (isUZPMask(ShuffleMask, NumElts, WhichResult)) {
       unsigned Opc = (WhichResult == 0) ? AArch64ISD::UZP1 : AArch64ISD::UZP2;
       return convertFromScalableVector(
           DAG, VT, DAG.getNode(Opc, DL, ContainerVT, Op1, Op2));
     }
 
-    if (isZIP_v_undef_Mask(ShuffleMask, VT, WhichResult) && WhichResult != 0)
+    if (isZIP_v_undef_Mask(ShuffleMask, NumElts, WhichResult) && WhichResult != 0)
       return convertFromScalableVector(
           DAG, VT, DAG.getNode(AArch64ISD::ZIP2, DL, ContainerVT, Op1, Op1));
 

--- a/llvm/lib/Target/AArch64/AArch64PerfectShuffle.h
+++ b/llvm/lib/Target/AArch64/AArch64PerfectShuffle.h
@@ -107,7 +107,6 @@ inline bool isZIPMask(ArrayRef<int> M, unsigned NumElts,
 /// isZIP_v_undef_Mask - Special case of isZIPMask for canonical form of
 /// "vector_shuffle v, v", i.e., "vector_shuffle v, undef".
 /// Mask is e.g., <0, 0, 1, 1> instead of <0, 4, 1, 5>.
-//GlobalISel
 inline bool isZIP_v_undef_Mask(ArrayRef<int> M, unsigned NumElts,
                                unsigned &WhichResult) {
   if (NumElts % 2 != 0)

--- a/llvm/lib/Target/AArch64/AArch64PerfectShuffle.h
+++ b/llvm/lib/Target/AArch64/AArch64PerfectShuffle.h
@@ -104,6 +104,26 @@ inline bool isZIPMask(ArrayRef<int> M, unsigned NumElts,
   return true;
 }
 
+/// isZIP_v_undef_Mask - Special case of isZIPMask for canonical form of
+/// "vector_shuffle v, v", i.e., "vector_shuffle v, undef".
+/// Mask is e.g., <0, 0, 1, 1> instead of <0, 4, 1, 5>.
+//GlobalISel
+inline bool isZIP_v_undef_Mask(ArrayRef<int> M, unsigned NumElts,
+                               unsigned &WhichResult) {
+  if (NumElts % 2 != 0)
+    return false;
+  WhichResult = (M[0] == 0 ? 0 : 1);
+  unsigned Idx = WhichResult * NumElts / 2;
+  for (unsigned i = 0; i != NumElts; i += 2) {
+    if ((M[i] >= 0 && (unsigned)M[i] != Idx) ||
+        (M[i + 1] >= 0 && (unsigned)M[i + 1] != Idx))
+      return false;
+    Idx += 1;
+  }
+
+  return true;
+}
+
 /// Return true for uzp1 or uzp2 masks of the form:
 ///  <0, 2, 4, 6, 8, 10, 12, 14> or
 ///  <1, 3, 5, 7, 9, 11, 13, 15>

--- a/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerLowering.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerLowering.cpp
@@ -229,7 +229,8 @@ bool matchUZP(MachineInstr &MI, MachineRegisterInfo &MRI,
 /// isZIP_v_undef_Mask - Special case of isZIPMask for canonical form of
 /// "vector_shuffle v, v", i.e., "vector_shuffle v, undef".
 /// Mask is e.g., <0, 0, 1, 1> instead of <0, 4, 1, 5>.
-static bool isZIP_v_undef_Mask(ArrayRef<int> M, unsigned NumElts, unsigned &WhichResult) {
+static bool isZIP_v_undef_Mask(ArrayRef<int> M, unsigned NumElts,
+                               unsigned &WhichResult) {
   if (NumElts % 2 != 0)
     return false;
   WhichResult = (M[0] == 0 ? 0 : 1);
@@ -252,8 +253,8 @@ bool matchZip(MachineInstr &MI, MachineRegisterInfo &MRI,
   ArrayRef<int> ShuffleMask = MI.getOperand(3).getShuffleMask();
   Register Dst = MI.getOperand(0).getReg();
   unsigned NumElts = MRI.getType(Dst).getNumElements();
-  if (!isZIPMask(ShuffleMask, NumElts, WhichResult, OperandOrder)
-      && !isZIP_v_undef_Mask(ShuffleMask, NumElts,  WhichResult))
+  if (!isZIPMask(ShuffleMask, NumElts, WhichResult, OperandOrder) &&
+      !isZIP_v_undef_Mask(ShuffleMask, NumElts, WhichResult))
     return false;
   unsigned Opc = (WhichResult == 0) ? AArch64::G_ZIP1 : AArch64::G_ZIP2;
   Register V1 = MI.getOperand(OperandOrder == 0 ? 1 : 2).getReg();

--- a/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerLowering.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerLowering.cpp
@@ -226,6 +226,24 @@ bool matchUZP(MachineInstr &MI, MachineRegisterInfo &MRI,
   return true;
 }
 
+/// isZIP_v_undef_Mask - Special case of isZIPMask for canonical form of
+/// "vector_shuffle v, v", i.e., "vector_shuffle v, undef".
+/// Mask is e.g., <0, 0, 1, 1> instead of <0, 4, 1, 5>.
+static bool isZIP_v_undef_Mask(ArrayRef<int> M, unsigned NumElts, unsigned &WhichResult) {
+  if (NumElts % 2 != 0)
+    return false;
+  WhichResult = (M[0] == 0 ? 0 : 1);
+  unsigned Idx = WhichResult * NumElts / 2;
+  for (unsigned i = 0; i != NumElts; i += 2) {
+    if ((M[i] >= 0 && (unsigned)M[i] != Idx) ||
+        (M[i + 1] >= 0 && (unsigned)M[i + 1] != Idx))
+      return false;
+    Idx += 1;
+  }
+
+  return true;
+}
+
 bool matchZip(MachineInstr &MI, MachineRegisterInfo &MRI,
               ShuffleVectorPseudo &MatchInfo) {
   assert(MI.getOpcode() == TargetOpcode::G_SHUFFLE_VECTOR);
@@ -234,7 +252,8 @@ bool matchZip(MachineInstr &MI, MachineRegisterInfo &MRI,
   ArrayRef<int> ShuffleMask = MI.getOperand(3).getShuffleMask();
   Register Dst = MI.getOperand(0).getReg();
   unsigned NumElts = MRI.getType(Dst).getNumElements();
-  if (!isZIPMask(ShuffleMask, NumElts, WhichResult, OperandOrder))
+  if (!isZIPMask(ShuffleMask, NumElts, WhichResult, OperandOrder)
+      && !isZIP_v_undef_Mask(ShuffleMask, NumElts,  WhichResult))
     return false;
   unsigned Opc = (WhichResult == 0) ? AArch64::G_ZIP1 : AArch64::G_ZIP2;
   Register V1 = MI.getOperand(OperandOrder == 0 ? 1 : 2).getReg();

--- a/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerLowering.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerLowering.cpp
@@ -239,7 +239,12 @@ bool matchZip(MachineInstr &MI, MachineRegisterInfo &MRI,
     return false;
   unsigned Opc = (WhichResult == 0) ? AArch64::G_ZIP1 : AArch64::G_ZIP2;
   Register V1 = MI.getOperand(OperandOrder == 0 ? 1 : 2).getReg();
-  Register V2 = MI.getOperand(OperandOrder == 0 && isZIPMask(ShuffleMask, NumElts, WhichResult, OperandOrder) ? 2 : 1).getReg();
+  Register V2 =
+      MI.getOperand(OperandOrder == 0 && isZIPMask(ShuffleMask, NumElts,
+                                                   WhichResult, OperandOrder)
+                        ? 2
+                        : 1)
+          .getReg();
   MatchInfo = ShuffleVectorPseudo(Opc, Dst, {V1, V2});
   return true;
 }

--- a/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerLowering.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerLowering.cpp
@@ -239,7 +239,7 @@ bool matchZip(MachineInstr &MI, MachineRegisterInfo &MRI,
     return false;
   unsigned Opc = (WhichResult == 0) ? AArch64::G_ZIP1 : AArch64::G_ZIP2;
   Register V1 = MI.getOperand(OperandOrder == 0 ? 1 : 2).getReg();
-  Register V2 = MI.getOperand(OperandOrder == 0 ? 2 : 1).getReg();
+  Register V2 = MI.getOperand(OperandOrder == 0 && isZIPMask(ShuffleMask, NumElts, WhichResult, OperandOrder) ? 2 : 1).getReg();
   MatchInfo = ShuffleVectorPseudo(Opc, Dst, {V1, V2});
   return true;
 }

--- a/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerLowering.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerLowering.cpp
@@ -226,25 +226,6 @@ bool matchUZP(MachineInstr &MI, MachineRegisterInfo &MRI,
   return true;
 }
 
-/// isZIP_v_undef_Mask - Special case of isZIPMask for canonical form of
-/// "vector_shuffle v, v", i.e., "vector_shuffle v, undef".
-/// Mask is e.g., <0, 0, 1, 1> instead of <0, 4, 1, 5>.
-static bool isZIP_v_undef_Mask(ArrayRef<int> M, unsigned NumElts,
-                               unsigned &WhichResult) {
-  if (NumElts % 2 != 0)
-    return false;
-  WhichResult = (M[0] == 0 ? 0 : 1);
-  unsigned Idx = WhichResult * NumElts / 2;
-  for (unsigned i = 0; i != NumElts; i += 2) {
-    if ((M[i] >= 0 && (unsigned)M[i] != Idx) ||
-        (M[i + 1] >= 0 && (unsigned)M[i + 1] != Idx))
-      return false;
-    Idx += 1;
-  }
-
-  return true;
-}
-
 bool matchZip(MachineInstr &MI, MachineRegisterInfo &MRI,
               ShuffleVectorPseudo &MatchInfo) {
   assert(MI.getOpcode() == TargetOpcode::G_SHUFFLE_VECTOR);

--- a/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerLowering.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerLowering.cpp
@@ -230,7 +230,7 @@ bool matchZip(MachineInstr &MI, MachineRegisterInfo &MRI,
               ShuffleVectorPseudo &MatchInfo) {
   assert(MI.getOpcode() == TargetOpcode::G_SHUFFLE_VECTOR);
   unsigned WhichResult;
-  unsigned OperandOrder;
+  unsigned OperandOrder = 0;
   ArrayRef<int> ShuffleMask = MI.getOperand(3).getShuffleMask();
   Register Dst = MI.getOperand(0).getReg();
   unsigned NumElts = MRI.getType(Dst).getNumElements();

--- a/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerLowering.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerLowering.cpp
@@ -234,17 +234,12 @@ bool matchZip(MachineInstr &MI, MachineRegisterInfo &MRI,
   ArrayRef<int> ShuffleMask = MI.getOperand(3).getShuffleMask();
   Register Dst = MI.getOperand(0).getReg();
   unsigned NumElts = MRI.getType(Dst).getNumElements();
-  if (!isZIPMask(ShuffleMask, NumElts, WhichResult, OperandOrder) &&
-      !isZIP_v_undef_Mask(ShuffleMask, NumElts, WhichResult))
+  bool ZIPMask = isZIPMask(ShuffleMask, NumElts, WhichResult, OperandOrder);
+  if (!ZIPMask && !isZIP_v_undef_Mask(ShuffleMask, NumElts, WhichResult))
     return false;
   unsigned Opc = (WhichResult == 0) ? AArch64::G_ZIP1 : AArch64::G_ZIP2;
   Register V1 = MI.getOperand(OperandOrder == 0 ? 1 : 2).getReg();
-  Register V2 =
-      MI.getOperand(OperandOrder == 0 && isZIPMask(ShuffleMask, NumElts,
-                                                   WhichResult, OperandOrder)
-                        ? 2
-                        : 1)
-          .getReg();
+  Register V2 = MI.getOperand(OperandOrder == 0 && ZIPMask ? 2 : 1).getReg();
   MatchInfo = ShuffleVectorPseudo(Opc, Dst, {V1, V2});
   return true;
 }

--- a/llvm/test/CodeGen/AArch64/arm64-neon-aba-abd.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-neon-aba-abd.ll
@@ -503,27 +503,15 @@ define <4 x i32> @test_sabd_knownbits_vec4i32(<4 x i32> %lhs, <4 x i32> %rhs) {
 }
 
 define <4 x i32> @knownbits_sabd_and_mask(<4 x i32> %a0, <4 x i32> %a1) {
-; CHECK-SD-LABEL: knownbits_sabd_and_mask:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    adrp x8, .LCPI44_0
-; CHECK-SD-NEXT:    ldr q2, [x8, :lo12:.LCPI44_0]
-; CHECK-SD-NEXT:    and v0.16b, v0.16b, v2.16b
-; CHECK-SD-NEXT:    and v1.16b, v1.16b, v2.16b
-; CHECK-SD-NEXT:    sabd v0.4s, v0.4s, v1.4s
-; CHECK-SD-NEXT:    zip2 v0.4s, v0.4s, v0.4s
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: knownbits_sabd_and_mask:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    adrp x8, .LCPI44_1
-; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI44_1]
-; CHECK-GI-NEXT:    adrp x8, .LCPI44_0
-; CHECK-GI-NEXT:    and v0.16b, v0.16b, v2.16b
-; CHECK-GI-NEXT:    and v1.16b, v1.16b, v2.16b
-; CHECK-GI-NEXT:    sabd v0.4s, v0.4s, v1.4s
-; CHECK-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI44_0]
-; CHECK-GI-NEXT:    tbl v0.16b, { v0.16b }, v1.16b
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: knownbits_sabd_and_mask:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    adrp x8, .LCPI44_0
+; CHECK-NEXT:    ldr q2, [x8, :lo12:.LCPI44_0]
+; CHECK-NEXT:    and v0.16b, v0.16b, v2.16b
+; CHECK-NEXT:    and v1.16b, v1.16b, v2.16b
+; CHECK-NEXT:    sabd v0.4s, v0.4s, v1.4s
+; CHECK-NEXT:    zip2 v0.4s, v0.4s, v0.4s
+; CHECK-NEXT:    ret
   %1 = and <4 x i32> %a0, <i32 -1, i32 -1, i32 255, i32 4085>
   %2 = and <4 x i32> %a1, <i32 -1, i32 -1, i32 255, i32 4085>
   %3 = call <4 x i32> @llvm.aarch64.neon.sabd.v4i32(<4 x i32> %1, <4 x i32> %2)
@@ -539,17 +527,15 @@ define <4 x i32> @knownbits_sabd_and_or_mask(<4 x i32> %a0, <4 x i32> %a1) {
 ;
 ; CHECK-GI-LABEL: knownbits_sabd_and_or_mask:
 ; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    adrp x8, .LCPI45_1
-; CHECK-GI-NEXT:    movi v3.2d, #0x00ffff0000ffff
-; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI45_1]
 ; CHECK-GI-NEXT:    adrp x8, .LCPI45_0
+; CHECK-GI-NEXT:    movi v3.2d, #0x00ffff0000ffff
+; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI45_0]
 ; CHECK-GI-NEXT:    and v0.16b, v0.16b, v2.16b
 ; CHECK-GI-NEXT:    and v1.16b, v1.16b, v2.16b
 ; CHECK-GI-NEXT:    orr v0.16b, v0.16b, v3.16b
 ; CHECK-GI-NEXT:    orr v1.16b, v1.16b, v3.16b
 ; CHECK-GI-NEXT:    uabd v0.4s, v0.4s, v1.4s
-; CHECK-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI45_0]
-; CHECK-GI-NEXT:    tbl v0.16b, { v0.16b }, v1.16b
+; CHECK-GI-NEXT:    zip2 v0.4s, v0.4s, v0.4s
 ; CHECK-GI-NEXT:    ret
   %1 = and <4 x i32> %a0, <i32 -1, i32 -1, i32 255, i32 4085>
   %2 = or <4 x i32> %1, <i32 65535, i32 65535, i32 65535, i32 65535>
@@ -561,33 +547,18 @@ define <4 x i32> @knownbits_sabd_and_or_mask(<4 x i32> %a0, <4 x i32> %a1) {
 }
 
 define <4 x i32> @knownbits_sabd_and_xor_mask(<4 x i32> %a0, <4 x i32> %a1) {
-; CHECK-SD-LABEL: knownbits_sabd_and_xor_mask:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    adrp x8, .LCPI46_0
-; CHECK-SD-NEXT:    movi v3.2d, #0x00ffff0000ffff
-; CHECK-SD-NEXT:    ldr q2, [x8, :lo12:.LCPI46_0]
-; CHECK-SD-NEXT:    and v0.16b, v0.16b, v2.16b
-; CHECK-SD-NEXT:    and v1.16b, v1.16b, v2.16b
-; CHECK-SD-NEXT:    eor v0.16b, v0.16b, v3.16b
-; CHECK-SD-NEXT:    eor v1.16b, v1.16b, v3.16b
-; CHECK-SD-NEXT:    sabd v0.4s, v0.4s, v1.4s
-; CHECK-SD-NEXT:    zip2 v0.4s, v0.4s, v0.4s
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: knownbits_sabd_and_xor_mask:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    adrp x8, .LCPI46_1
-; CHECK-GI-NEXT:    movi v3.2d, #0x00ffff0000ffff
-; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI46_1]
-; CHECK-GI-NEXT:    adrp x8, .LCPI46_0
-; CHECK-GI-NEXT:    and v0.16b, v0.16b, v2.16b
-; CHECK-GI-NEXT:    and v1.16b, v1.16b, v2.16b
-; CHECK-GI-NEXT:    eor v0.16b, v0.16b, v3.16b
-; CHECK-GI-NEXT:    eor v1.16b, v1.16b, v3.16b
-; CHECK-GI-NEXT:    sabd v0.4s, v0.4s, v1.4s
-; CHECK-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI46_0]
-; CHECK-GI-NEXT:    tbl v0.16b, { v0.16b }, v1.16b
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: knownbits_sabd_and_xor_mask:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    adrp x8, .LCPI46_0
+; CHECK-NEXT:    movi v3.2d, #0x00ffff0000ffff
+; CHECK-NEXT:    ldr q2, [x8, :lo12:.LCPI46_0]
+; CHECK-NEXT:    and v0.16b, v0.16b, v2.16b
+; CHECK-NEXT:    and v1.16b, v1.16b, v2.16b
+; CHECK-NEXT:    eor v0.16b, v0.16b, v3.16b
+; CHECK-NEXT:    eor v1.16b, v1.16b, v3.16b
+; CHECK-NEXT:    sabd v0.4s, v0.4s, v1.4s
+; CHECK-NEXT:    zip2 v0.4s, v0.4s, v0.4s
+; CHECK-NEXT:    ret
   %1 = and <4 x i32> %a0, <i32 -1, i32 -1, i32 255, i32 4085>
   %2 = xor <4 x i32> %1, <i32 65535, i32 65535, i32 65535, i32 65535>
   %3 = and <4 x i32> %a1, <i32 -1, i32 -1, i32 255, i32 4085>

--- a/llvm/test/CodeGen/AArch64/arm64-zip.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-zip.ll
@@ -212,6 +212,24 @@ define <8 x i16> @vzip2_undef_012(<8 x i16> %A, <8 x i16> %B) nounwind {
   ret <8 x i16> %s
 }
 
+define <8 x i8> @vzip1_poison_v8i8(<8 x i8> %a) {
+; CHECK-LABEL: vzip1_poison_v8i8:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    zip1.8b v0, v0, v0
+; CHECK-NEXT:    ret
+  %s = shufflevector <8 x i8> %a, <8 x i8> poison, <8 x i32> <i32 0, i32 0, i32 1, i32 1, i32 2, i32 2, i32 3, i32 3>
+  ret <8 x i8> %s
+}
+
+define <8 x i8> @vzip2_poison_v8i8(<8 x i8> %a) {
+; CHECK-LABEL: vzip2_poison_v8i8:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    zip2.8b v0, v0, v0
+; CHECK-NEXT:    ret
+  %s = shufflevector <8 x i8> %a, <8 x i8> poison, <8 x i32> <i32 4, i32 4, i32 5, i32 5, i32 6, i32 6, i32 7, i32 7>
+  ret <8 x i8> %s
+}
+
 define <16 x i8> @combine_v16i8(<8 x i8> %0, <8 x i8> %1) {
 ; CHECK-LABEL: combine_v16i8:
 ; CHECK:       // %bb.0:
@@ -391,9 +409,9 @@ define <4 x float> @shuffle_zip1(<4 x float> %arg) {
 ; CHECK-GI-LABEL: shuffle_zip1:
 ; CHECK-GI:       // %bb.0: // %bb
 ; CHECK-GI-NEXT:    fcmgt.4s v0, v0, #0.0
-; CHECK-GI-NEXT:    adrp x8, .LCPI27_0
+; CHECK-GI-NEXT:    adrp x8, .LCPI29_0
 ; CHECK-GI-NEXT:    fmov.4s v2, #1.00000000
-; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI27_0]
+; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI29_0]
 ; CHECK-GI-NEXT:    mov.s w9, v0[1]
 ; CHECK-GI-NEXT:    mov.s w10, v0[2]
 ; CHECK-GI-NEXT:    mov.s w11, v0[3]
@@ -448,8 +466,8 @@ define <4 x i32> @shuffle_zip2(<4 x i32> %arg) {
 ; CHECK-GI-NEXT:    mov.s w9, v0[2]
 ; CHECK-GI-NEXT:    mov.s w10, v0[3]
 ; CHECK-GI-NEXT:    mov.b v0[1], w8
-; CHECK-GI-NEXT:    adrp x8, .LCPI28_0
-; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI28_0]
+; CHECK-GI-NEXT:    adrp x8, .LCPI30_0
+; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI30_0]
 ; CHECK-GI-NEXT:    mov.b v0[2], w9
 ; CHECK-GI-NEXT:    mov.b v0[3], w10
 ; CHECK-GI-NEXT:    mov.d v0[1], v0[0]
@@ -495,8 +513,8 @@ define <4 x i32> @shuffle_zip3(<4 x i32> %arg) {
 ; CHECK-GI-LABEL: shuffle_zip3:
 ; CHECK-GI:       // %bb.0: // %bb
 ; CHECK-GI-NEXT:    cmgt.4s v0, v0, #0
-; CHECK-GI-NEXT:    adrp x8, .LCPI29_0
-; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI29_0]
+; CHECK-GI-NEXT:    adrp x8, .LCPI31_0
+; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI31_0]
 ; CHECK-GI-NEXT:    mov.s w9, v0[1]
 ; CHECK-GI-NEXT:    mov.s w10, v0[2]
 ; CHECK-GI-NEXT:    mov.s w11, v0[3]

--- a/llvm/test/CodeGen/AArch64/arm64-zip.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-zip.ll
@@ -391,23 +391,20 @@ define <4 x float> @shuffle_zip1(<4 x float> %arg) {
 ; CHECK-GI-LABEL: shuffle_zip1:
 ; CHECK-GI:       // %bb.0: // %bb
 ; CHECK-GI-NEXT:    fcmgt.4s v0, v0, #0.0
-; CHECK-GI-NEXT:    fmov.4s v2, #1.00000000
-; CHECK-GI-NEXT:    mov.s w8, v0[1]
-; CHECK-GI-NEXT:    mov.s w9, v0[2]
-; CHECK-GI-NEXT:    mov.s w10, v0[3]
-; CHECK-GI-NEXT:    mov.b v0[1], w8
-; CHECK-GI-NEXT:    adrp x8, .LCPI27_1
-; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI27_1]
 ; CHECK-GI-NEXT:    adrp x8, .LCPI27_0
-; CHECK-GI-NEXT:    mov.b v0[2], w9
-; CHECK-GI-NEXT:    mov.b v0[3], w10
+; CHECK-GI-NEXT:    fmov.4s v2, #1.00000000
+; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI27_0]
+; CHECK-GI-NEXT:    mov.s w9, v0[1]
+; CHECK-GI-NEXT:    mov.s w10, v0[2]
+; CHECK-GI-NEXT:    mov.s w11, v0[3]
+; CHECK-GI-NEXT:    mov.b v0[1], w9
+; CHECK-GI-NEXT:    mov.b v0[2], w10
+; CHECK-GI-NEXT:    mov.b v0[3], w11
 ; CHECK-GI-NEXT:    mov.d v0[1], v0[0]
 ; CHECK-GI-NEXT:    tbl.16b v0, { v0 }, v1
 ; CHECK-GI-NEXT:    mov.b v1[0], v0[0]
 ; CHECK-GI-NEXT:    mov.b v1[1], v0[1]
-; CHECK-GI-NEXT:    mov.d v1[1], v0[0]
-; CHECK-GI-NEXT:    ldr d0, [x8, :lo12:.LCPI27_0]
-; CHECK-GI-NEXT:    tbl.16b v0, { v1 }, v0
+; CHECK-GI-NEXT:    zip1.8b v0, v0, v1
 ; CHECK-GI-NEXT:    umov.b w8, v0[0]
 ; CHECK-GI-NEXT:    umov.b w9, v0[1]
 ; CHECK-GI-NEXT:    fmov s1, w8
@@ -451,18 +448,15 @@ define <4 x i32> @shuffle_zip2(<4 x i32> %arg) {
 ; CHECK-GI-NEXT:    mov.s w9, v0[2]
 ; CHECK-GI-NEXT:    mov.s w10, v0[3]
 ; CHECK-GI-NEXT:    mov.b v0[1], w8
-; CHECK-GI-NEXT:    adrp x8, .LCPI28_1
-; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI28_1]
 ; CHECK-GI-NEXT:    adrp x8, .LCPI28_0
+; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI28_0]
 ; CHECK-GI-NEXT:    mov.b v0[2], w9
 ; CHECK-GI-NEXT:    mov.b v0[3], w10
 ; CHECK-GI-NEXT:    mov.d v0[1], v0[0]
 ; CHECK-GI-NEXT:    tbl.16b v0, { v0 }, v1
 ; CHECK-GI-NEXT:    mov.b v1[0], v0[0]
 ; CHECK-GI-NEXT:    mov.b v1[1], v0[1]
-; CHECK-GI-NEXT:    mov.d v1[1], v0[0]
-; CHECK-GI-NEXT:    ldr d0, [x8, :lo12:.LCPI28_0]
-; CHECK-GI-NEXT:    tbl.16b v0, { v1 }, v0
+; CHECK-GI-NEXT:    zip1.8b v0, v0, v1
 ; CHECK-GI-NEXT:    umov.b w8, v0[0]
 ; CHECK-GI-NEXT:    umov.b w9, v0[1]
 ; CHECK-GI-NEXT:    fmov s1, w8
@@ -501,22 +495,19 @@ define <4 x i32> @shuffle_zip3(<4 x i32> %arg) {
 ; CHECK-GI-LABEL: shuffle_zip3:
 ; CHECK-GI:       // %bb.0: // %bb
 ; CHECK-GI-NEXT:    cmgt.4s v0, v0, #0
-; CHECK-GI-NEXT:    mov.s w8, v0[1]
-; CHECK-GI-NEXT:    mov.s w9, v0[2]
-; CHECK-GI-NEXT:    mov.s w10, v0[3]
-; CHECK-GI-NEXT:    mov.b v0[1], w8
-; CHECK-GI-NEXT:    adrp x8, .LCPI29_1
-; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI29_1]
 ; CHECK-GI-NEXT:    adrp x8, .LCPI29_0
-; CHECK-GI-NEXT:    mov.b v0[2], w9
-; CHECK-GI-NEXT:    mov.b v0[3], w10
+; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI29_0]
+; CHECK-GI-NEXT:    mov.s w9, v0[1]
+; CHECK-GI-NEXT:    mov.s w10, v0[2]
+; CHECK-GI-NEXT:    mov.s w11, v0[3]
+; CHECK-GI-NEXT:    mov.b v0[1], w9
+; CHECK-GI-NEXT:    mov.b v0[2], w10
+; CHECK-GI-NEXT:    mov.b v0[3], w11
 ; CHECK-GI-NEXT:    mov.d v0[1], v0[0]
 ; CHECK-GI-NEXT:    tbl.16b v0, { v0 }, v1
 ; CHECK-GI-NEXT:    mov.b v1[0], v0[0]
 ; CHECK-GI-NEXT:    mov.b v1[1], v0[1]
-; CHECK-GI-NEXT:    mov.d v1[1], v0[0]
-; CHECK-GI-NEXT:    ldr d0, [x8, :lo12:.LCPI29_0]
-; CHECK-GI-NEXT:    tbl.16b v0, { v1 }, v0
+; CHECK-GI-NEXT:    zip1.8b v0, v0, v1
 ; CHECK-GI-NEXT:    umov.b w8, v0[0]
 ; CHECK-GI-NEXT:    umov.b w9, v0[1]
 ; CHECK-GI-NEXT:    fmov s1, w8

--- a/llvm/test/CodeGen/AArch64/arm64-zip.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-zip.ll
@@ -422,7 +422,7 @@ define <4 x float> @shuffle_zip1(<4 x float> %arg) {
 ; CHECK-GI-NEXT:    tbl.16b v0, { v0 }, v1
 ; CHECK-GI-NEXT:    mov.b v1[0], v0[0]
 ; CHECK-GI-NEXT:    mov.b v1[1], v0[1]
-; CHECK-GI-NEXT:    zip1.8b v0, v0, v1
+; CHECK-GI-NEXT:    zip1.8b v0, v1, v1
 ; CHECK-GI-NEXT:    umov.b w8, v0[0]
 ; CHECK-GI-NEXT:    umov.b w9, v0[1]
 ; CHECK-GI-NEXT:    fmov s1, w8
@@ -474,7 +474,7 @@ define <4 x i32> @shuffle_zip2(<4 x i32> %arg) {
 ; CHECK-GI-NEXT:    tbl.16b v0, { v0 }, v1
 ; CHECK-GI-NEXT:    mov.b v1[0], v0[0]
 ; CHECK-GI-NEXT:    mov.b v1[1], v0[1]
-; CHECK-GI-NEXT:    zip1.8b v0, v0, v1
+; CHECK-GI-NEXT:    zip1.8b v0, v1, v1
 ; CHECK-GI-NEXT:    umov.b w8, v0[0]
 ; CHECK-GI-NEXT:    umov.b w9, v0[1]
 ; CHECK-GI-NEXT:    fmov s1, w8
@@ -525,7 +525,7 @@ define <4 x i32> @shuffle_zip3(<4 x i32> %arg) {
 ; CHECK-GI-NEXT:    tbl.16b v0, { v0 }, v1
 ; CHECK-GI-NEXT:    mov.b v1[0], v0[0]
 ; CHECK-GI-NEXT:    mov.b v1[1], v0[1]
-; CHECK-GI-NEXT:    zip1.8b v0, v0, v1
+; CHECK-GI-NEXT:    zip1.8b v0, v1, v1
 ; CHECK-GI-NEXT:    umov.b w8, v0[0]
 ; CHECK-GI-NEXT:    umov.b w9, v0[1]
 ; CHECK-GI-NEXT:    fmov s1, w8


### PR DESCRIPTION
In SDAG, the aarch64-isel phase checks if vector shuffles can be expressed as a zips. To do this, it checks shuffles of type shuffle(v, v), and shuffle(v, undefined). 
GlobalISel previously only checked shuffles of type shuffle(v, v). Add a check for the situation where one of the operands in undefined.

Notes:
A zip interleaves two vectors together.
e.g: `zip <A, B, C, D>, <1, 2, 3, 4> => <A, 1, B, 2, C, 3, D, 4>`.
A zip1 takes the bottom half of the result.
e.g: `zip1 <A, B, C, D>, <1, 2, 3, 4> => <A, 1, B, 2>`. 

A shuffle is an LLVM IR generic opcode that takes 2 vectors, and places elements of each into a single vector. The elements are selected based on a mask.
e.g: `G_SHUFFLE_VECTOR <A, B, C, D>, <E, F, G, H>, <0, 4, 6, 3> => <A, E, G, D>`.
A shuffle can be represented as a zip when the result of the shuffle is just an interleaving of the two vectors.
e.g: `G_SHUFFLE_VECTOR <A, B, C, D>, <A, B, C, D>, <0, 4, 1, 5> => zip1 <A, B, C, D>`.