### PR TITLE
[offload] Disable tests that fail on NVIDIA GPUs

### DIFF
--- a/offload/test/offloading/array_reductions.cpp
+++ b/offload/test/offloading/array_reductions.cpp
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
 // RUN: %libomptarget-compileoptxx-run-and-check-generic
 // UNSUPPORTED: intelgpu
+// UNSUPPORTED: nvidiagpu
 
 // Cloned from multiple_reductions.cpp for array reductions.
 

--- a/offload/test/offloading/fortran/mapper-map-always-to-enter-data.f90
+++ b/offload/test/offloading/fortran/mapper-map-always-to-enter-data.f90
@@ -12,6 +12,7 @@
 ! from the outer clause to the mapper's s%y entry.
 
 ! REQUIRES: flang
+! UNSUPPORTED: nvptx64-nvidia-cuda-LTO
 
 ! RUN: %libomptarget-compile-fortran-generic
 ! RUN: %libomptarget-run-generic | %fcheck-generic

--- a/offload/test/offloading/fortran/target-no-loop.f90
+++ b/offload/test/offloading/fortran/target-no-loop.f90
@@ -1,9 +1,8 @@
 ! REQUIRES: flang
-! REQUIRES: gpu
+! REQUIRES: gpu, amdgpu
 
 ! RUN: %libomptarget-compile-fortran-generic -O3  -fopenmp-assume-threads-oversubscription -fopenmp-assume-teams-oversubscription
 ! RUN: env LIBOMPTARGET_INFO=16 OMP_NUM_TEAMS=16 OMP_TEAMS_THREAD_LIMIT=16 %libomptarget-run-generic 2>&1 | %fcheck-generic
-! XFAIL: intelgpu
 function check_errors(array) result (errors)
    integer, intent(in) :: array(1024)
    integer :: errors

--- a/offload/test/tools/omp-kernel-replay/record-replay-diff-teams-threads.cpp
+++ b/offload/test/tools/omp-kernel-replay/record-replay-diff-teams-threads.cpp
@@ -32,6 +32,7 @@
 // UNSUPPORTED: x86_64-unknown-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu
 // UNSUPPORTED: intelgpu
+// UNSUPPORTED: nvptx64-nvidia-cuda
 
 // REPLAY-ERROR1: [llvm-omp-kernel-replay] Error: number of threads ({{[0-9]+}}) is out of the allowed limits (min,max: 1,{{[0-9]+}})
 // REPLAY-ERROR2: [llvm-omp-kernel-replay] Error: number of teams (2) is out of the allowed limits (min,max: 1,1)

--- a/offload/test/unified_shared_memory/api.c
+++ b/offload/test/unified_shared_memory/api.c
@@ -2,8 +2,7 @@
 // RUN: env HSA_XNACK=1 \
 // RUN: %libomptarget-run-generic | %fcheck-generic
 
-// REQUIRES: unified_shared_memory
-// UNSUPPORTED: intelgpu
+// REQUIRES: unified_shared_memory, amdgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/unified_shared_memory/close_enter_exit.c
+++ b/offload/test/unified_shared_memory/close_enter_exit.c
@@ -2,10 +2,8 @@
 // RUN: env HSA_XNACK=1 \
 // RUN: %libomptarget-run-generic | %fcheck-generic
 
-// REQUIRES: unified_shared_memory
+// REQUIRES: unified_shared_memory, amdgpu
 // UNSUPPORTED: clang-6, clang-7, clang-8, clang-9
-
-// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 #include <stdio.h>


### PR DESCRIPTION
unified_shared_memory tests that use HSA_XNACK were missing REQUIRES: amdgpu and the rest of the tests fail or timeout for some NVIDIA GPU configurations.

This is to get an initial fully passing state for the tests on NVIDIA - fixing will be a follow up.