### PR TITLE
[MLIR][OpenMP] Replace target-data assert with error

### DIFF
--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -8327,8 +8327,10 @@ convertOmpTargetData(Operation *op, llvm::IRBuilderBase &builder,
   llvm::OpenMPIRBuilder::TargetDataInfo info(
       /*RequiresDevicePointerInfo=*/true,
       /*SeparateBeginEndCalls=*/true);
-  assert(!ompBuilder->Config.isTargetDevice() &&
-         "target data/enter/exit/update are host ops");
+
+  if (ompBuilder->Config.isTargetDevice())
+    return op->emitOpError() << "not allowed in a target device";
+
   bool isOffloadEntry = !ompBuilder->Config.TargetTriples.empty();
 
   auto getDeviceID = [&](mlir::Value dev) -> llvm::Value * {

--- a/mlir/test/Target/LLVMIR/openmp-llvm-invalid.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-llvm-invalid.mlir
@@ -187,3 +187,24 @@ module attributes {llvm.target_triple = "amdgcn-amd-amdhsa", omp.is_target_devic
     llvm.return
   }
 }
+
+// -----
+
+module attributes {llvm.target_triple = "amdgcn-amd-amdhsa", omp.is_target_device = true} {
+  llvm.func @target_data_in_device(%arg0 : !llvm.ptr) attributes {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (enter)>} {
+    %0 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.array<1024 x i32>) map_clauses(tofrom) capture(ByRef) name("") -> !llvm.ptr
+    %1 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.array<1024 x i32>) map_clauses(to) capture(ByRef) name("") -> !llvm.ptr
+    %2 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.array<1024 x i32>) map_clauses(from) capture(ByRef) name("") -> !llvm.ptr
+    // expected-error @below {{op not allowed in a target device}}
+    omp.target_data map_entries(%0 : !llvm.ptr) {
+      omp.terminator
+    }
+    // expected-error @below {{op not allowed in a target device}}
+    omp.target_update map_entries(%1 : !llvm.ptr)
+    // expected-error @below {{op not allowed in a target device}}
+    omp.target_enter_data map_entries(%1 : !llvm.ptr)
+    // expected-error @below {{op not allowed in a target device}}
+    omp.target_exit_data map_entries(%2 : !llvm.ptr)
+    llvm.return
+  }
+}

--- a/mlir/test/Target/LLVMIR/openmp-llvm-invalid.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-llvm-invalid.mlir
@@ -193,18 +193,47 @@ module attributes {llvm.target_triple = "amdgcn-amd-amdhsa", omp.is_target_devic
 module attributes {llvm.target_triple = "amdgcn-amd-amdhsa", omp.is_target_device = true} {
   llvm.func @target_data_in_device(%arg0 : !llvm.ptr) attributes {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (enter)>} {
     %0 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.array<1024 x i32>) map_clauses(tofrom) capture(ByRef) name("") -> !llvm.ptr
-    %1 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.array<1024 x i32>) map_clauses(to) capture(ByRef) name("") -> !llvm.ptr
-    %2 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.array<1024 x i32>) map_clauses(from) capture(ByRef) name("") -> !llvm.ptr
     // expected-error @below {{op not allowed in a target device}}
+    // expected-error @below {{LLVM Translation failed for operation: omp.target_data}}
     omp.target_data map_entries(%0 : !llvm.ptr) {
       omp.terminator
     }
+    llvm.return
+  }
+}
+
+// -----
+
+module attributes {llvm.target_triple = "amdgcn-amd-amdhsa", omp.is_target_device = true} {
+  llvm.func @target_update_in_device(%arg0 : !llvm.ptr) attributes {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (enter)>} {
+    %0 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.array<1024 x i32>) map_clauses(to) capture(ByRef) name("") -> !llvm.ptr
     // expected-error @below {{op not allowed in a target device}}
-    omp.target_update map_entries(%1 : !llvm.ptr)
+    // expected-error @below {{LLVM Translation failed for operation: omp.target_update}}
+    omp.target_update map_entries(%0 : !llvm.ptr)
+    llvm.return
+  }
+}
+
+// -----
+
+module attributes {llvm.target_triple = "amdgcn-amd-amdhsa", omp.is_target_device = true} {
+  llvm.func @target_enter_data_in_device(%arg0 : !llvm.ptr) attributes {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (enter)>} {
+    %0 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.array<1024 x i32>) map_clauses(to) capture(ByRef) name("") -> !llvm.ptr
     // expected-error @below {{op not allowed in a target device}}
-    omp.target_enter_data map_entries(%1 : !llvm.ptr)
+    // expected-error @below {{LLVM Translation failed for operation: omp.target_enter_data}}
+    omp.target_enter_data map_entries(%0 : !llvm.ptr)
+    llvm.return
+  }
+}
+
+// -----
+
+module attributes {llvm.target_triple = "amdgcn-amd-amdhsa", omp.is_target_device = true} {
+  llvm.func @target_exit_data_in_device(%arg0 : !llvm.ptr) attributes {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (enter)>} {
+    %0 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.array<1024 x i32>) map_clauses(from) capture(ByRef) name("") -> !llvm.ptr
     // expected-error @below {{op not allowed in a target device}}
-    omp.target_exit_data map_entries(%2 : !llvm.ptr)
+    // expected-error @below {{LLVM Translation failed for operation: omp.target_exit_data}}
+    omp.target_exit_data map_entries(%0 : !llvm.ptr)
     llvm.return
   }
 }


### PR DESCRIPTION
If a user incorrectly puts a `target data`, `target enter data`, `target exit data` or `target update` directive inside of target device code, this will get lowered to MLIR and trigger an assert while translating the corresponding operations to LLVM IR.

Part of the issue is that there are no semantics checks to prevent this but, even if they were added, they wouldn't be able to incorporate implicit `declare target` information, as that is added later. This patch replaces the assert with a more informative compile error during MLIR to LLVM IR translation to catch any of these cases that make it past semantics.