### PR TITLE
[mlir][llvm] verify external llvm.func not have `function_entry_count` attr

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -3325,6 +3325,10 @@ LogicalResult LLVMFuncOp::verify() {
     return failure();
 
   if (isExternal()) {
+    if (getFunctionEntryCountAttr())
+      return emitOpError() << "external functions cannot have "
+                           << getFunctionEntryCountAttrName() << " attribute";
+
     if (getLinkage() != LLVM::Linkage::External &&
         getLinkage() != LLVM::Linkage::ExternWeak)
       return emitOpError() << "external functions must have '"

--- a/mlir/test/Dialect/LLVMIR/func.mlir
+++ b/mlir/test/Dialect/LLVMIR/func.mlir
@@ -508,6 +508,13 @@ module {
 // -----
 
 module {
+  // expected-error@+1 {{external functions cannot have "function_entry_count" attribute}}
+  llvm.func @external_func() attributes {function_entry_count = #llvm.function_entry_count<entry_count = 1>}
+}
+
+// -----
+
+module {
   // expected-error@+1 {{functions cannot have 'common' linkage}}
   llvm.func common @common_linkage_func()
 }


### PR DESCRIPTION
Fixes #218625.