### PR TITLE
lldb: Linux: restore __ptrace_request typedef for bionic+musl

### DIFF
--- a/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
@@ -82,6 +82,13 @@
 #define PTRACE_SETREGSET 0x4205
 #endif
 
+// glibc declares ptrace taking enum __ptrace_request (which requires a cast in
+// C++), whereas bionic and musl declare it taking int and do not define
+// __ptrace_request.
+#ifndef __GLIBC__
+typedef int __ptrace_request;
+#endif
+
 using namespace lldb;
 using namespace lldb_private;
 using namespace lldb_private::process_linux;


### PR DESCRIPTION
glibc declares ptrace as taking an enum __ptrace_request as its first
argument. Because C++ does not allow implicit conversion from int to an
enumeration type, callers must cast int arguments to __ptrace_request
(e.g., static_cast<__ptrace_request>(req)).
    
However, bionic and musl declare ptrace as taking an int and do not
define __ptrace_request. Providing a fallback typedef int __ptrace_request
allows the static_cast to compile across all three libcs.

I removed this typedef by accident in ef9085f5bdb52b27258c150bd7e1fd812fc406c8.

Fixes: commit ef9085f5bdb5 ("lldb: Linux: empty Ptrace.h pollyfill")
Link: https://github.com/llvm/llvm-project/issues/217413