### PR TITLE
[lldb-dap] Return an error on evaluation failure

### DIFF
--- a/lldb/test/API/tools/lldb-dap/send-event/TestDAP_sendEvent.py
+++ b/lldb/test/API/tools/lldb-dap/send-event/TestDAP_sendEvent.py
@@ -66,9 +66,10 @@ class TestDAP_sendEvent(DAPTestCaseBase):
         process_event = session.launch(LaunchArgs(program, stopOnEntry=True))
 
         session.verify_stopped_on_entry(after=process_event)
-        expr_resp = session.do_evaluate("`lldb-dap send-event stopped").result()
+        error_resp = session.do_evaluate("`lldb-dap send-event stopped").error()
 
+        error = self.expect_not_none(error_resp.body and error_resp.body.error)
         self.assertRegex(
-            expr_resp.body.result,
+            error.format,
             r"Invalid use of lldb-dap send-event, event \"stopped\" should be handled by lldb-dap internally.",
         )

--- a/lldb/tools/lldb-dap/Handler/EvaluateRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/EvaluateRequestHandler.cpp
@@ -15,11 +15,15 @@
 #include "Protocol/ProtocolRequests.h"
 #include "Protocol/ProtocolTypes.h"
 #include "RequestHandler.h"
+#include "lldb/API/SBCommandInterpreter.h"
+#include "lldb/API/SBCommandReturnObject.h"
+#include "lldb/API/SBExecutionContext.h"
 #include "lldb/lldb-enumerations.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 
 using namespace llvm;
+using namespace lldb;
 using namespace lldb_dap;
 using namespace lldb_dap::protocol;
 
@@ -91,11 +95,20 @@ EvaluateRequestHandler::Run(const EvaluateArguments &arguments) const {
       dap.focus_tid = frame.GetThread().GetThreadID();
     }
 
-    bool required_command_failed = false;
-    body.result = RunLLDBCommands(
-        dap.debugger, dap.GetAPIMutex(), llvm::StringRef(), {expression},
-        required_command_failed,
-        /*parse_command_directives=*/false, /*echo_commands=*/false);
+    SBCommandInterpreter interp = dap.debugger.GetCommandInterpreter();
+    auto ctx = frame ? SBExecutionContext(frame) : SBExecutionContext();
+    SBCommandReturnObject result{};
+    interp.HandleCommand(expression.c_str(), ctx, result,
+                         /*add_to_history=*/true);
+
+    if (!result.Succeeded()) {
+      return llvm::make_error<DAPError>(
+          std::string(result.GetError(), result.GetErrorSize()),
+          /**error_code=*/llvm::inconvertibleErrorCode(),
+          /**show_user= */ false);
+    }
+
+    body.result = std::string(result.GetOutput(), result.GetOutputSize());
     return body;
   }
 


### PR DESCRIPTION
We currently return an error response a command doesn't exist. We should do the same when a command fails. This allow the client differentiate failed commands and hint them properly.