### PR TITLE
[lldb] Parse GDB remote register vector types

### DIFF
--- a/lldb/include/lldb/Utility/RegisterType.h
+++ b/lldb/include/lldb/Utility/RegisterType.h
@@ -29,6 +29,7 @@ public:
     eRegisterTypeKindFlags,
     eRegisterTypeKindEnum,
     eRegisterTypeKindBuiltin,
+    eRegisterTypeKindVector,
   };
 
   RegisterTypeKind getKind() const { return m_kind; }
@@ -104,6 +105,31 @@ private:
   const lldb::Encoding m_encoding;
   const lldb::Format m_format;
   const std::optional<uint64_t> m_byte_size;
+};
+
+/// A GDB target-description vector type. The element type must outlive it.
+class RegisterTypeVector : public RegisterType {
+public:
+  RegisterTypeVector(std::string id, const RegisterType *element_type,
+                     uint32_t count);
+
+  const RegisterType *GetElementType() const { return m_element_type; }
+  uint32_t GetCount() const { return m_count; }
+  std::optional<uint64_t> GetByteSize() const override;
+  bool IsByteSizeCompatible(uint64_t byte_size) const;
+
+  void DumpToLog(Log *log) const;
+
+  void ToXMLElement(Stream &strm,
+                    const RegisterType *user = nullptr) const override;
+
+  static bool classof(const RegisterType *type) {
+    return type->getKind() == eRegisterTypeKindVector;
+  }
+
+private:
+  const RegisterType *m_element_type;
+  const uint32_t m_count;
 };
 
 } // namespace lldb_private

--- a/lldb/source/Core/DumpRegisterInfo.cpp
+++ b/lldb/source/Core/DumpRegisterInfo.cpp
@@ -8,6 +8,7 @@
 
 #include "lldb/Core/DumpRegisterInfo.h"
 #include "lldb/Target/RegisterContext.h"
+#include "lldb/Utility/RegisterType.h"
 #include "lldb/Utility/RegisterTypeFlags.h"
 #include "lldb/Utility/Stream.h"
 
@@ -120,5 +121,8 @@ void lldb_private::DoDumpRegisterInfo(
     std::string enumerators = flags_type->DumpEnums(terminal_width);
     if (enumerators.size())
       strm << "\n\n" << enumerators;
+  } else if (auto *vector_type =
+                 llvm::dyn_cast_if_present<RegisterTypeVector>(register_type)) {
+    strm.Printf("\n\n  Vector elements: %u", vector_type->GetCount());
   }
 }

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -75,7 +75,9 @@
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/FileSpecList.h"
 #include "lldb/Utility/LLDBLog.h"
+#include "lldb/Utility/RegisterType.h"
 #include "lldb/Utility/RegisterTypeFlags.h"
+#include "lldb/Utility/RegisterValue.h"
 #include "lldb/Utility/State.h"
 #include "lldb/Utility/StreamString.h"
 #include "lldb/Utility/Timer.h"
@@ -5313,6 +5315,172 @@ void ParseFlags(
       });
 }
 
+static const RegisterTypeBuiltin *
+ResolveGDBBuiltinType(llvm::StringRef type_name) {
+  // These names and sizes follow GDB's predefined target-description types in
+  // gdbsupport/tdesc.cc. ARM FPA is intentionally omitted because GCC removed
+  // support for it in 2012.
+  static const RegisterTypeBuiltin bool_type("bool", eEncodingUint,
+                                             eFormatBoolean, 1);
+  static const RegisterTypeBuiltin int8_type("int8", eEncodingSint,
+                                             eFormatDecimal, 1);
+  static const RegisterTypeBuiltin int16_type("int16", eEncodingSint,
+                                              eFormatDecimal, 2);
+  static const RegisterTypeBuiltin int32_type("int32", eEncodingSint,
+                                              eFormatDecimal, 4);
+  static const RegisterTypeBuiltin int64_type("int64", eEncodingSint,
+                                              eFormatDecimal, 8);
+  static const RegisterTypeBuiltin int128_type("int128", eEncodingSint,
+                                               eFormatDecimal, 16);
+  static const RegisterTypeBuiltin uint8_type("uint8", eEncodingUint,
+                                              eFormatHex, 1);
+  static const RegisterTypeBuiltin uint16_type("uint16", eEncodingUint,
+                                               eFormatHex, 2);
+  static const RegisterTypeBuiltin uint32_type("uint32", eEncodingUint,
+                                               eFormatHex, 4);
+  static const RegisterTypeBuiltin uint64_type("uint64", eEncodingUint,
+                                               eFormatHex, 8);
+  static const RegisterTypeBuiltin uint128_type("uint128", eEncodingUint,
+                                                eFormatHex, 16);
+  static const RegisterTypeBuiltin code_ptr_type(
+      "code_ptr", eEncodingUint, eFormatAddressInfo, std::nullopt);
+  static const RegisterTypeBuiltin data_ptr_type(
+      "data_ptr", eEncodingUint, eFormatAddressInfo, std::nullopt);
+  static const RegisterTypeBuiltin ieee_half_type("ieee_half", eEncodingIEEE754,
+                                                  eFormatFloat, 2);
+  static const RegisterTypeBuiltin ieee_single_type(
+      "ieee_single", eEncodingIEEE754, eFormatFloat, 4);
+  static const RegisterTypeBuiltin ieee_double_type(
+      "ieee_double", eEncodingIEEE754, eFormatFloat, 8);
+  static const RegisterTypeBuiltin i387_ext_type("i387_ext", eEncodingIEEE754,
+                                                 eFormatFloat, 10);
+  static const RegisterTypeBuiltin bfloat16_type("bfloat16", eEncodingIEEE754,
+                                                 eFormatFloat, 2);
+
+  return llvm::StringSwitch<const RegisterTypeBuiltin *>(type_name)
+      .Case("bool", &bool_type)
+      .Case("int8", &int8_type)
+      .Case("int16", &int16_type)
+      .Case("int32", &int32_type)
+      .Case("int64", &int64_type)
+      .Case("int128", &int128_type)
+      .Case("uint8", &uint8_type)
+      .Case("uint16", &uint16_type)
+      .Case("uint32", &uint32_type)
+      .Case("uint64", &uint64_type)
+      .Case("uint128", &uint128_type)
+      .Case("code_ptr", &code_ptr_type)
+      .Case("data_ptr", &data_ptr_type)
+      .Case("ieee_half", &ieee_half_type)
+      .Case("ieee_single", &ieee_single_type)
+      .Case("ieee_double", &ieee_double_type)
+      .Case("i387_ext", &i387_ext_type)
+      .Case("bfloat16", &bfloat16_type)
+      .Default(nullptr);
+}
+
+static const RegisterType *
+ResolveGDBType(llvm::StringRef type_name,
+               const RegisterTypeMap &feature_register_types) {
+  auto type_it = feature_register_types.find(type_name);
+  if (type_it != feature_register_types.end())
+    return type_it->second;
+  return ResolveGDBBuiltinType(type_name);
+}
+
+static void
+ParseVector(const XMLNode &vector_node, RegisterTypeMap &feature_register_types,
+            std::vector<std::unique_ptr<RegisterType>> &owned_register_types) {
+  Log *log(GetLog(GDBRLog::Process));
+  std::optional<llvm::StringRef> id;
+  std::optional<llvm::StringRef> element_type_name;
+  std::optional<uint32_t> count;
+
+  vector_node.ForEachAttribute(
+      [&id, &element_type_name, &count, log](llvm::StringRef name,
+                                             llvm::StringRef value) {
+        if (name == "id") {
+          id = value;
+        } else if (name == "type") {
+          element_type_name = value;
+        } else if (name == "count") {
+          uint32_t parsed_count = 0;
+          if (llvm::to_integer(value, parsed_count))
+            count = parsed_count;
+          else
+            LLDB_LOG(log, "ProcessGDBRemote::ParseVector Invalid count \"{0}\"",
+                     value);
+        } else {
+          LLDB_LOG(log,
+                   "ProcessGDBRemote::ParseVector Ignoring unknown attribute "
+                   "\"{0}\"",
+                   name);
+        }
+        return true;
+      });
+
+  // GDB limits vectors to 65536 elements. This is also LLDB's maximum
+  // register size in bytes, so use the existing named limit.
+  constexpr uint32_t max_vector_count = RegisterValue::kMaxRegisterByteSize;
+  if (!id || id->empty() || !element_type_name || element_type_name->empty() ||
+      !count || *count == 0 || *count > max_vector_count) {
+    LLDB_LOG(log, "ProcessGDBRemote::ParseVector Ignoring vector with invalid "
+                  "id, type, or count");
+    return;
+  }
+
+  if (feature_register_types.contains(*id)) {
+    LLDB_LOG(log,
+             "ProcessGDBRemote::ParseVector Ignoring duplicate type \"{0}\"",
+             *id);
+    return;
+  }
+
+  const RegisterType *element_type =
+      ResolveGDBType(*element_type_name, feature_register_types);
+  if (!element_type) {
+    LLDB_LOG(log,
+             "ProcessGDBRemote::ParseVector Could not resolve element type "
+             "\"{0}\" for vector \"{1}\"",
+             *element_type_name, *id);
+    return;
+  }
+
+  if (!llvm::isa<RegisterTypeBuiltin, RegisterTypeVector>(element_type)) {
+    LLDB_LOG(log,
+             "ProcessGDBRemote::ParseVector Found element type \"{0}\" for "
+             "vector \"{1}\", but it is not a builtin or vector type",
+             *element_type_name, *id);
+    return;
+  }
+
+  std::optional<uint64_t> element_size = element_type->GetByteSize();
+  if (element_size &&
+      *element_size > RegisterValue::kMaxRegisterByteSize / *count) {
+    LLDB_LOG(log,
+             "ProcessGDBRemote::ParseVector Size of vector \"{0}\" is too "
+             "large",
+             *id);
+    return;
+  }
+
+  auto vector_type =
+      std::make_unique<RegisterTypeVector>(id->str(), element_type, *count);
+  feature_register_types.try_emplace(*id, vector_type.get());
+  owned_register_types.push_back(std::move(vector_type));
+}
+
+static void
+ParseVectors(XMLNode feature_node, RegisterTypeMap &feature_register_types,
+             std::vector<std::unique_ptr<RegisterType>> &owned_register_types) {
+  feature_node.ForEachChildElementWithName(
+      "vector", [&feature_register_types,
+                 &owned_register_types](const XMLNode &vector_node) {
+        ParseVector(vector_node, feature_register_types, owned_register_types);
+        return true;
+      });
+}
+
 bool ParseRegisters(
     XMLNode feature_node, GdbServerTargetInfo &target_info,
     std::vector<DynamicRegisterInfo::Register> &registers,
@@ -5335,6 +5503,12 @@ bool ParseRegisters(
     if (const auto *flags_type =
             llvm::dyn_cast<RegisterTypeFlags>(register_type.second))
       flags_type->DumpToLog(log);
+
+  ParseVectors(feature_node, feature_register_types, owned_register_types);
+  for (const auto &register_type : feature_register_types)
+    if (const auto *vector_type =
+            llvm::dyn_cast<RegisterTypeVector>(register_type.second))
+      vector_type->DumpToLog(log);
 
   feature_node.ForEachChildElementWithName(
       "reg",
@@ -5416,11 +5590,46 @@ bool ParseRegisters(
         });
 
         if (!gdb_type.empty()) {
-          // gdb_type could reference some flags type defined in XML.
+          // gdb_type could reference a type defined in this feature.
           auto it = feature_register_types.find(gdb_type);
           if (it != feature_register_types.end()) {
-            if (const auto *flags_type =
-                    llvm::dyn_cast<RegisterTypeFlags>(it->second)) {
+            if (const auto *vector_type =
+                    llvm::dyn_cast<RegisterTypeVector>(it->second)) {
+              std::optional<uint64_t> type_size = vector_type->GetByteSize();
+              if (reg_info.byte_size > RegisterValue::kMaxRegisterByteSize) {
+                LLDB_LOG(log,
+                         "ProcessGDBRemote::ParseRegisters Register {0} is "
+                         "too large for vector type {1}",
+                         reg_info.name, vector_type->GetID());
+              } else if (!vector_type->IsByteSizeCompatible(
+                             reg_info.byte_size)) {
+                if (!type_size) {
+                  LLDB_LOG(log,
+                           "ProcessGDBRemote::ParseRegisters Size of register "
+                           "{0} is incompatible with vector type {1}",
+                           reg_info.name, vector_type->GetID());
+                } else {
+                  LLDB_LOG(
+                      log,
+                      "ProcessGDBRemote::ParseRegisters Size of register type "
+                      "{0} ({1} bytes) for register {2} does not match the "
+                      "register size ({3} bytes). Ignoring this type.",
+                      vector_type->GetID(), *type_size, reg_info.name,
+                      reg_info.byte_size);
+                }
+              } else {
+                reg_info.register_type = vector_type;
+                if (!encoding_set) {
+                  reg_info.encoding = eEncodingVector;
+                  encoding_set = true;
+                }
+                if (!format_set) {
+                  reg_info.format = eFormatVectorOfUInt8;
+                  format_set = true;
+                }
+              }
+            } else if (const auto *flags_type =
+                           llvm::dyn_cast<RegisterTypeFlags>(it->second)) {
               if (reg_info.byte_size == flags_type->GetSize())
                 reg_info.register_type = flags_type;
               else

--- a/lldb/source/Plugins/RegisterTypeBuilder/RegisterTypeBuilderClang.cpp
+++ b/lldb/source/Plugins/RegisterTypeBuilder/RegisterTypeBuilderClang.cpp
@@ -172,6 +172,8 @@ RegisterTypeBuilderClang::GetRegisterType(const RegisterInfo &reg_info) {
     return BuildEnumType(
         llvm::dyn_cast<RegisterTypeEnum>(reg_info.register_type),
         reg_info.byte_size, type_system);
+  case RegisterType::eRegisterTypeKindVector:
+    return {};
   }
 }
 

--- a/lldb/source/Utility/RegisterType.cpp
+++ b/lldb/source/Utility/RegisterType.cpp
@@ -8,11 +8,16 @@
 
 #include "lldb/Utility/RegisterType.h"
 
+#include "lldb/Utility/Log.h"
 #include "lldb/Utility/Stream.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <atomic>
+#include <cassert>
+#include <cinttypes>
+#include <limits>
 
 using namespace lldb_private;
 
@@ -55,3 +60,48 @@ void RegisterTypeBuiltin::ToXML(Stream &, std::unordered_set<std::string> &,
                                 const RegisterType *) const {}
 
 void RegisterTypeBuiltin::ToXMLElement(Stream &, const RegisterType *) const {}
+
+RegisterTypeVector::RegisterTypeVector(std::string id,
+                                       const RegisterType *element_type,
+                                       uint32_t count)
+    : RegisterType(eRegisterTypeKindVector, std::move(id)),
+      m_element_type(element_type), m_count(count) {
+  assert(m_element_type && "Vector element type cannot be null");
+  assert(m_count && "Vector element count cannot be zero");
+  SetDependencies({m_element_type});
+}
+
+std::optional<uint64_t> RegisterTypeVector::GetByteSize() const {
+  std::optional<uint64_t> element_size = m_element_type->GetByteSize();
+  if (!element_size ||
+      *element_size > std::numeric_limits<uint64_t>::max() / m_count)
+    return std::nullopt;
+  return *element_size * m_count;
+}
+
+bool RegisterTypeVector::IsByteSizeCompatible(uint64_t byte_size) const {
+  if (!byte_size || byte_size % m_count)
+    return false;
+
+  uint64_t element_byte_size = byte_size / m_count;
+  if (std::optional<uint64_t> fixed_size = m_element_type->GetByteSize())
+    return *fixed_size == element_byte_size;
+  if (const auto *vector = llvm::dyn_cast<RegisterTypeVector>(m_element_type))
+    return vector->IsByteSizeCompatible(element_byte_size);
+  return llvm::isa<RegisterTypeBuiltin>(m_element_type);
+}
+
+void RegisterTypeVector::DumpToLog(Log *log) const {
+  LLDB_LOG(log, "ID: \"{0}\" Element type: \"{1}\" Count: {2}", GetID().c_str(),
+           m_element_type->GetID().c_str(), m_count);
+}
+
+void RegisterTypeVector::ToXMLElement(Stream &strm,
+                                      const RegisterType *) const {
+  strm.Indent();
+  strm << "<vector id=\"";
+  PrintXMLAttributeValue(strm, GetID());
+  strm << "\" type=\"";
+  PrintXMLAttributeValue(strm, m_element_type->GetID());
+  strm.Printf("\" count=\"%" PRIu32 "\"/>\n", m_count);
+}

--- a/lldb/test/API/functionalities/gdb_remote_client/TestXMLRegisterVector.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestXMLRegisterVector.py
@@ -177,9 +177,7 @@ class TestXMLRegisterVector(GDBRemoteTestBase):
         )
 
         self.assert_vector_info("v0", 8, 2)
-        self.expect(
-            "register info v0", matching=False, substrs=["Vector elements: 4"]
-        )
+        self.expect("register info v0", matching=False, substrs=["Vector elements: 4"])
 
     @skipIfXmlSupportMissing
     @skipIfRemote

--- a/lldb/test/API/functionalities/gdb_remote_client/TestXMLRegisterVector.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestXMLRegisterVector.py
@@ -1,0 +1,243 @@
+"""Test vector metadata from GDB remote target description XML."""
+
+from textwrap import dedent
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.gdbclientutils import *
+from lldbsuite.test.lldbgdbclient import GDBRemoteTestBase
+from lldbsuite.test.lldbtest import *
+
+
+class MultiDocResponder(MockGDBServerResponder):
+    def __init__(self, docs, register_data):
+        super().__init__()
+        self.docs = docs
+        self.register_data = register_data
+
+    def qXferRead(self, obj, annex, offset, length):
+        try:
+            return self.docs[annex], False
+        except KeyError:
+            return (None,)
+
+    def readRegister(self, regnum):
+        return "E01"
+
+    def readRegisters(self):
+        return self.register_data
+
+
+class TestXMLRegisterVector(GDBRemoteTestBase):
+    def setup_multidoc_test(self, docs, register_data):
+        self.server.responder = MultiDocResponder(docs, register_data)
+        target = self.dbg.CreateTarget("")
+
+        if self.TraceOn():
+            self.runCmd("log enable gdb-remote packets process")
+            self.addTearDownHook(
+                lambda: self.runCmd("log disable gdb-remote packets process")
+            )
+
+        process = self.connect(target)
+        lldbutil.expect_state_changes(
+            self, self.dbg.GetListener(), process, [lldb.eStateStopped]
+        )
+
+    def setup_register_test(self, definitions, register_data):
+        self.setup_multidoc_test(
+            {
+                "target.xml": dedent(
+                    """\
+                <?xml version="1.0"?>
+                <target version="1.0">
+                  <architecture>aarch64</architecture>
+                  <feature name="test.register.vectors">
+                    {}
+                  </feature>
+                </target>"""
+                ).format(definitions)
+            },
+            register_data,
+        )
+
+    def assert_vector_info(self, name, byte_size, count):
+        self.expect(
+            "register info {}".format(name),
+            substrs=[
+                "Size: {} bytes".format(byte_size),
+                "Vector elements: {}".format(count),
+            ],
+        )
+
+    def assert_no_vector_info(self, name):
+        self.expect("register info {}".format(name), substrs=["Name: {}".format(name)])
+        self.expect(
+            "register info {}".format(name),
+            matching=False,
+            substrs=["Vector elements:"],
+        )
+
+    @skipIfXmlSupportMissing
+    @skipIfRemote
+    def test_direct_and_nested_vector_metadata(self):
+        self.setup_register_test(
+            """\
+            <vector id="v2f" type="ieee_single" count="2"/>
+            <vector id="v3v2f" type="v2f" count="3"/>
+            <reg name="direct" regnum="0" bitsize="64" type="v2f"/>
+            <reg name="nested" regnum="1" bitsize="192" type="v3v2f"/>
+            <reg name="pc" bitsize="64"/>""",
+            "00" * 40,
+        )
+
+        self.assert_vector_info("direct", 8, 2)
+        self.assert_vector_info("nested", 24, 3)
+
+    @skipIfXmlSupportMissing
+    @skipIfRemote
+    def test_invalid_vectors_are_ignored(self):
+        self.setup_register_test(
+            """\
+            <vector id="bad_count" type="ieee_single" count="nope"/>
+            <vector id="zero" type="ieee_single" count="0"/>
+            <vector id="too_many" type="ieee_single" count="65537"/>
+            <vector id="unknown" type="missing" count="2"/>
+            <vector id="forward" type="later" count="1"/>
+            <vector id="missing_type" count="2"/>
+            <vector id="missing_count" type="ieee_single"/>
+            <vector id="too_large" type="uint128" count="4097"/>
+            <vector type="ieee_single" count="2"/>
+            <vector id="later" type="ieee_single" count="2"/>
+            <enum id="enumeration" size="4">
+              <evalue name="zero" value="0"/>
+            </enum>
+            <flags id="flags" size="4">
+              <field name="bit" start="0" end="0"/>
+            </flags>
+            <vector id="enum_vector" type="enumeration" count="2"/>
+            <vector id="flags_vector" type="flags" count="2"/>
+            <vector id="bad_pointer_size" type="data_ptr" count="3"/>
+            <vector id="pointer_pair" type="data_ptr" count="2"/>
+            <vector id="bad_nested_pointer_size" type="pointer_pair" count="3"/>
+            <vector id="v4f" type="ieee_single" count="4"/>
+            <reg name="bad_count" regnum="0" bitsize="64" type="bad_count"/>
+            <reg name="zero" regnum="1" bitsize="64" type="zero"/>
+            <reg name="too_many" regnum="2" bitsize="64" type="too_many"/>
+            <reg name="unknown" regnum="3" bitsize="64" type="unknown"/>
+            <reg name="forward" regnum="4" bitsize="64" type="forward"/>
+            <reg name="missing_type" regnum="5" bitsize="64"
+                 type="missing_type"/>
+            <reg name="missing_count" regnum="6" bitsize="64"
+                 type="missing_count"/>
+            <reg name="too_large" regnum="7" bitsize="64" type="too_large"/>
+            <reg name="later" regnum="8" bitsize="64" type="later"/>
+            <reg name="enum_vector" regnum="9" bitsize="64"
+                 type="enum_vector"/>
+            <reg name="flags_vector" regnum="10" bitsize="64"
+                 type="flags_vector"/>
+            <reg name="bad_size" regnum="11" bitsize="64" type="v4f"/>
+            <reg name="bad_pointer_size" regnum="12" bitsize="80"
+                 type="bad_pointer_size"/>
+            <reg name="bad_nested_pointer_size" regnum="13" bitsize="120"
+                 type="bad_nested_pointer_size"/>
+            <reg name="pc" bitsize="64"/>""",
+            "00" * 129,
+        )
+
+        for name in [
+            "bad_count",
+            "zero",
+            "too_many",
+            "unknown",
+            "forward",
+            "missing_type",
+            "missing_count",
+            "too_large",
+            "enum_vector",
+            "flags_vector",
+            "bad_size",
+            "bad_pointer_size",
+            "bad_nested_pointer_size",
+        ]:
+            self.assert_no_vector_info(name)
+
+        self.assert_vector_info("later", 8, 2)
+
+    @skipIfXmlSupportMissing
+    @skipIfRemote
+    def test_duplicate_vector_id_uses_first_definition(self):
+        self.setup_register_test(
+            """\
+            <vector id="shared" type="ieee_single" count="2"/>
+            <vector id="shared" type="uint16" count="4"/>
+            <reg name="v0" regnum="0" bitsize="64" type="shared"/>
+            <reg name="pc" bitsize="64"/>""",
+            "00" * 16,
+        )
+
+        self.assert_vector_info("v0", 8, 2)
+        self.expect(
+            "register info v0", matching=False, substrs=["Vector elements: 4"]
+        )
+
+    @skipIfXmlSupportMissing
+    @skipIfRemote
+    def test_target_type_precedes_builtin_type(self):
+        self.setup_register_test(
+            """\
+            <vector id="ieee_single" type="uint8" count="2"/>
+            <vector id="nested" type="ieee_single" count="3"/>
+            <reg name="v0" regnum="0" bitsize="48" type="nested"/>
+            <reg name="pc" bitsize="64"/>""",
+            "00" * 14,
+        )
+
+        self.assert_vector_info("v0", 6, 3)
+
+    @skipIfXmlSupportMissing
+    @skipIfRemote
+    def test_vector_ids_are_scoped_to_included_feature(self):
+        self.setup_multidoc_test(
+            {
+                "target.xml": dedent(
+                    """\
+                <?xml version="1.0"?>
+                <target version="1.0">
+                  <architecture>aarch64</architecture>
+                  <xi:include href="first.xml"/>
+                  <xi:include href="second.xml"/>
+                  <xi:include href="third.xml"/>
+                </target>"""
+                ),
+                "first.xml": dedent(
+                    """\
+                <?xml version="1.0"?>
+                <feature name="feature.first">
+                  <vector id="shared" type="ieee_single" count="2"/>
+                  <reg name="first" regnum="0" bitsize="64" type="shared"/>
+                </feature>"""
+                ),
+                "second.xml": dedent(
+                    """\
+                <?xml version="1.0"?>
+                <feature name="feature.second">
+                  <vector id="shared" type="ieee_single" count="4"/>
+                  <reg name="second" regnum="1" bitsize="128" type="shared"/>
+                </feature>"""
+                ),
+                "third.xml": dedent(
+                    """\
+                <?xml version="1.0"?>
+                <feature name="feature.third">
+                  <reg name="unresolved" regnum="2" bitsize="64" type="shared"/>
+                  <reg name="pc" bitsize="64"/>
+                </feature>"""
+                ),
+            },
+            "00" * 40,
+        )
+
+        self.assert_vector_info("first", 8, 2)
+        self.assert_vector_info("second", 16, 4)
+        self.assert_no_vector_info("unresolved")

--- a/lldb/unittests/Core/DumpRegisterInfoTest.cpp
+++ b/lldb/unittests/Core/DumpRegisterInfoTest.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Core/DumpRegisterInfo.h"
+#include "lldb/Utility/RegisterType.h"
 #include "lldb/Utility/RegisterTypeFlags.h"
 #include "lldb/Utility/StreamString.h"
 #include "gtest/gtest.h"
@@ -132,4 +133,17 @@ TEST(DoDumpRegisterInfoTest, Enumerators) {
             "A: 0 = an_enumerator\n"
             "\n"
             "C: 1 = another_enumerator, 2 = another_enumerator_2");
+}
+
+TEST(DoDumpRegisterInfoTest, VectorElements) {
+  StreamString strm;
+  RegisterTypeBuiltin element_type("ieee_single", lldb::eEncodingIEEE754,
+                                   lldb::eFormatFloat, 4);
+  RegisterTypeVector vector_type("v4f", &element_type, 4);
+
+  DoDumpRegisterInfo(strm, "v0", nullptr, 16, {}, {}, {}, &vector_type, 100);
+  ASSERT_EQ(strm.GetString(), "       Name: v0\n"
+                              "       Size: 16 bytes (128 bits)\n"
+                              "\n"
+                              "  Vector elements: 4");
 }

--- a/lldb/unittests/Utility/RegisterTypeTest.cpp
+++ b/lldb/unittests/Utility/RegisterTypeTest.cpp
@@ -629,3 +629,75 @@ TEST(RegisterTypeBuiltinTest, DoesNotSerialize) {
   type.ToXMLElement(strm);
   EXPECT_TRUE(strm.GetString().empty());
 }
+
+TEST(RegisterTypeVectorTest, ConstructionAndXML) {
+  RegisterTypeBuiltin element_type("ieee_single", eEncodingIEEE754,
+                                   eFormatFloat, 4);
+  RegisterTypeVector vector_type("v4f", &element_type, 4);
+
+  EXPECT_EQ(vector_type.GetID(), "v4f");
+  EXPECT_EQ(vector_type.GetElementType(), &element_type);
+  EXPECT_EQ(vector_type.GetCount(), 4u);
+  ASSERT_TRUE(vector_type.GetByteSize());
+  EXPECT_EQ(*vector_type.GetByteSize(), 16u);
+  EXPECT_TRUE(vector_type.IsByteSizeCompatible(16));
+  EXPECT_FALSE(vector_type.IsByteSizeCompatible(12));
+
+  StreamString strm;
+  std::unordered_set<std::string> previously_emitted;
+  vector_type.ToXML(strm, previously_emitted);
+  EXPECT_EQ(strm.GetString(),
+            "<vector id=\"v4f\" type=\"ieee_single\" count=\"4\"/>\n");
+}
+
+TEST(RegisterTypeVectorTest, NestedVectorXML) {
+  RegisterTypeBuiltin element_type("ieee_single", eEncodingIEEE754,
+                                   eFormatFloat, 4);
+  RegisterTypeVector inner_type("v2f", &element_type, 2);
+  RegisterTypeVector outer_type("v2v2f", &inner_type, 2);
+
+  ASSERT_TRUE(outer_type.GetByteSize());
+  EXPECT_EQ(*outer_type.GetByteSize(), 16u);
+
+  StreamString strm;
+  std::unordered_set<std::string> previously_emitted;
+  outer_type.ToXML(strm, previously_emitted);
+  EXPECT_EQ(strm.GetString(),
+            "<vector id=\"v2f\" type=\"ieee_single\" count=\"2\"/>\n"
+            "<vector id=\"v2v2f\" type=\"v2f\" count=\"2\"/>\n");
+}
+
+TEST(RegisterTypeVectorTest, ByteSizeOverflow) {
+  RegisterTypeBuiltin large_element("large", eEncodingUint, eFormatHex,
+                                    UINT32_MAX);
+  RegisterTypeVector large_vector("large_vector", &large_element, UINT32_MAX);
+  ASSERT_TRUE(large_vector.GetByteSize());
+
+  RegisterTypeVector overflow("overflow", &large_vector, 2);
+  EXPECT_FALSE(overflow.GetByteSize());
+}
+
+TEST(RegisterTypeVectorTest, TargetDependentByteSize) {
+  RegisterTypeBuiltin pointer_type("data_ptr", eEncodingUint,
+                                   eFormatAddressInfo, std::nullopt);
+  RegisterTypeVector inner_type("pointer_pair", &pointer_type, 2);
+  RegisterTypeVector outer_type("pointer_pairs", &inner_type, 3);
+
+  EXPECT_FALSE(inner_type.GetByteSize());
+  EXPECT_TRUE(inner_type.IsByteSizeCompatible(16));
+  EXPECT_FALSE(inner_type.IsByteSizeCompatible(15));
+  EXPECT_TRUE(outer_type.IsByteSizeCompatible(48));
+  EXPECT_FALSE(outer_type.IsByteSizeCompatible(15));
+}
+
+TEST(RegisterTypeVectorTest, XMLAttributeEscaping) {
+  RegisterTypeBuiltin element_type("u<&\"'", eEncodingUint, eFormatHex, 1);
+  RegisterTypeVector vector_type("v<&\"'", &element_type, 4);
+
+  StreamString strm;
+  std::unordered_set<std::string> previously_emitted;
+  vector_type.ToXML(strm, previously_emitted);
+  EXPECT_EQ(strm.GetString(),
+            "<vector id=\"v&lt;&amp;&quot;&apos;\" "
+            "type=\"u&lt;&amp;&quot;&apos;\" count=\"4\"/>\n");
+}


### PR DESCRIPTION
- Add the `RegisterTypeVector` metadata representation.
- Parse `<vector>` elements from GDB target-description XML.
- Support builtin elements and previously defined nested vectors.
- Validate counts, sizes, duplicates, unsupported types, and feature scoping.
- Display the vector element count in `register info`.
- Add parsing, serialization, nesting, and invalid-input tests.

Nested example:
```
<vector id="v2f" type="ieee_single" count="2"/>
<vector id="v2v2f" type="v2f" count="2"/>
```
`v2v2f` contains two elements, each containing two floats.