### PR TITLE
[MLIR][XeGPU][NFC]  Fix WG integration tests for strict property assembly format

### DIFF
--- a/mlir/test/Integration/Dialect/XeGPU/WG/load_store_matrix.mlir
+++ b/mlir/test/Integration/Dialect/XeGPU/WG/load_store_matrix.mlir
@@ -17,8 +17,8 @@ gpu.module @test {
   gpu.func @test_load_store_matrix_1d(%src: memref<8192xi8, 3>) {
     %c0 = arith.constant 0 : index
     %mdesc = xegpu.create_mem_desc %src : memref<8192xi8, 3> -> !xegpu.mem_desc<4096xbf16>
-    %data = xegpu.load_matrix %mdesc[%c0] {layout = #layout_1d} : !xegpu.mem_desc<4096xbf16>, index -> vector<4096xbf16>
-    xegpu.store_matrix %data, %mdesc[%c0] {layout = #layout_1d} : vector<4096xbf16>, !xegpu.mem_desc<4096xbf16>, index
+    %data = xegpu.load_matrix %mdesc[%c0] <{layout = #layout_1d}> : !xegpu.mem_desc<4096xbf16>, index -> vector<4096xbf16>
+    xegpu.store_matrix %data, %mdesc[%c0] <{layout = #layout_1d}> : vector<4096xbf16>, !xegpu.mem_desc<4096xbf16>, index
     gpu.return
   }
 
@@ -33,8 +33,8 @@ gpu.module @test {
   gpu.func @test_load_store_matrix_2d(%src: memref<16384xi8, 3>) {
     %c0 = arith.constant 0 : index
     %mdesc = xegpu.create_mem_desc %src : memref<16384xi8, 3> -> !xegpu.mem_desc<64x128xbf16>
-    %data = xegpu.load_matrix %mdesc[%c0, %c0] {layout = #layout_2d} : !xegpu.mem_desc<64x128xbf16>, index, index -> vector<64x128xbf16>
-    xegpu.store_matrix %data, %mdesc[%c0, %c0] {layout = #layout_2d} : vector<64x128xbf16>, !xegpu.mem_desc<64x128xbf16>, index, index
+    %data = xegpu.load_matrix %mdesc[%c0, %c0] <{layout = #layout_2d}> : !xegpu.mem_desc<64x128xbf16>, index, index -> vector<64x128xbf16>
+    xegpu.store_matrix %data, %mdesc[%c0, %c0] <{layout = #layout_2d}> : vector<64x128xbf16>, !xegpu.mem_desc<64x128xbf16>, index, index
     gpu.return
   }
 }

--- a/mlir/test/Integration/Dialect/XeGPU/WG/simple_mxfp_gemm_dequantizeB_F4.mlir
+++ b/mlir/test/Integration/Dialect/XeGPU/WG/simple_mxfp_gemm_dequantizeB_F4.mlir
@@ -44,14 +44,14 @@ module @gemm attributes {gpu.container_module} {
 
       // Load initial C
       %cd_tdesc = xegpu.create_nd_tdesc %arg4 : memref<256x256xf32> -> !xegpu.tensor_desc<32x32xf32, #c>
-      %c_init = xegpu.load_nd %cd_tdesc[%m, %n] {layout = #c}: !xegpu.tensor_desc<32x32xf32, #c> -> vector<32x32xf32>
+      %c_init = xegpu.load_nd %cd_tdesc[%m, %n] <{layout = #c}>: !xegpu.tensor_desc<32x32xf32, #c> -> vector<32x32xf32>
 
       %res:3 = scf.for %k = %c0 to %kbound step %kstep
         iter_args(%c_partial = %c_init, %kb = %c0, %kscale = %c0) -> (vector<32x32xf32>, index, index) {
         // -------- Load A (bf16) --------
-        %a = xegpu.load_nd %a_tdesc[%m, %k] {layout = #a}: !xegpu.tensor_desc<32x1024xbf16> -> vector<32x1024xbf16>
+        %a = xegpu.load_nd %a_tdesc[%m, %k] <{layout = #a}>: !xegpu.tensor_desc<32x1024xbf16> -> vector<32x1024xbf16>
 
-        %bp = xegpu.load_nd %bp_tdesc[%kb, %n] {layout = #b_packed}: !xegpu.tensor_desc<512x32xi8> -> vector<512x32xi8>
+        %bp = xegpu.load_nd %bp_tdesc[%kb, %n] <{layout = #b_packed}>: !xegpu.tensor_desc<512x32xi8> -> vector<512x32xi8>
 
         // Bitcast to fp4: 512x32 uint8 -> 512x64 fp4 (each uint8 holds 2 fp4 values)
         %b_bitcast = vector.bitcast %bp : vector<512x32xi8> to vector<512x64xf4E2M1FN>
@@ -69,7 +69,7 @@ module @gemm attributes {gpu.container_module} {
         %b = vector.transpose %b_interleaved, [1, 0] : vector<32x1024xf4E2M1FN> to vector<1024x32xf4E2M1FN>
 
 
-        %scale_b = xegpu.load_nd %b_scale_tdesc[%kscale, %n] {layout = #b_scale}: !xegpu.tensor_desc<32x32xf8E8M0FNU> -> vector<32x32xf8E8M0FNU>
+        %scale_b = xegpu.load_nd %b_scale_tdesc[%kscale, %n] <{layout = #b_scale}>: !xegpu.tensor_desc<32x32xf8E8M0FNU> -> vector<32x32xf8E8M0FNU>
         // Broadcast scale_b from <16x128> to <512x128>: each scale value applies to
         // 32 consecutive K rows of B.
         %scale_b_bcast = vector.broadcast %scale_b : vector<32x32xf8E8M0FNU> to vector<32x32x32xf8E8M0FNU>
@@ -80,9 +80,9 @@ module @gemm attributes {gpu.container_module} {
         %b_bf16 = arith.scaling_extf %b, %scale_b_full : vector<1024x32xf4E2M1FN>, vector<1024x32xf8E8M0FNU> to vector<1024x32xbf16>
 
         %new_c_partial = xegpu.dpas %a, %b_bf16, %c_partial
-              {layout_a = #a,
+              <{layout_a = #a,
                layout_b = #b_f16,
-               layout_cd = #c}
+               layout_cd = #c}>
             : vector<32x1024xbf16>, vector<1024x32xbf16>,
               vector<32x32xf32>
             -> vector<32x32xf32>
@@ -95,7 +95,7 @@ module @gemm attributes {gpu.container_module} {
       }
 
       // store_nd with offset
-      xegpu.store_nd %res#0, %cd_tdesc[%m, %n] {layout = #c} : vector<32x32xf32>, !xegpu.tensor_desc<32x32xf32, #c>
+      xegpu.store_nd %res#0, %cd_tdesc[%m, %n] <{layout = #c}> : vector<32x32xf32>, !xegpu.tensor_desc<32x32xf32, #c>
       gpu.return
     }
   }


### PR DESCRIPTION
b73a8b8d8c17 ("[MLIR][XeGPU] Enable strict property assembly format", #217281) made inherent attributes stored as properties unparseable from the trailing attr-dict, but two XeGPU workgroup integration tests still write `layout` that way, so they fail to parse. 

Move the affected `layout`/`layout_a`/`layout_b`/`layout_cd` operands into the prop-dict position, `{...}` -> `<{...}>`, for xegpu.load_matrix, store_matrix, load_nd, store_nd and dpas.

These tests only run when the Level Zero or SYCL runner is enabled (MLIR_ENABLE_LEVELZERO_RUNNER / MLIR_ENABLE_SYCL_RUNNER), which is why the breakage was not caught by the default CI configuration.