### PR TITLE
[InstrProf] Fix tests broken on some platforms

### DIFF
--- a/llvm/test/Transforms/PGOProfile/memprof.ll
+++ b/llvm/test/Transforms/PGOProfile/memprof.ll
@@ -1,6 +1,8 @@
 ;; Tests memprof profile matching (with and without instrumentation profiles).
 ; RUN: rm -rf %t && split-file %s %t
 
+;; Our memprof stack ID algorithm is inconsistent across platforms
+; REQUIRES: x86_64-linux
 ;; -stats requires asserts
 ; REQUIRES: asserts
 

--- a/llvm/test/tools/llvm-profdata/merge-traces-seed.proftext
+++ b/llvm/test/tools/llvm-profdata/merge-traces-seed.proftext
@@ -1,3 +1,6 @@
+# Our random sample implementation is not consistent across platforms
+# REQUIRES: x86_64-linux
+
 # RUN: llvm-profdata merge --random-seed=1234 --temporal-profile-trace-reservoir-size=2 %s --text | FileCheck %s
 
 # RUN: llvm-profdata merge --random-seed=5678 --temporal-profile-trace-reservoir-size=2 %s --text -o %t-1.profdata

--- a/llvm/test/tools/llvm-profdata/merge-traces-seed.proftext
+++ b/llvm/test/tools/llvm-profdata/merge-traces-seed.proftext
@@ -1,4 +1,4 @@
-# Our random sample implementation is not consistent across platforms
+# Our random sample implementation is inconsistent across platforms
 # REQUIRES: x86_64-linux
 
 # RUN: llvm-profdata merge --random-seed=1234 --temporal-profile-trace-reservoir-size=2 %s --text | FileCheck %s


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/217083 broke some tests on some platforms. Require `x86_64-linux` for these tests to fix the bots.

* `memprof.ll`: MemProf's stack id hash algorithm apparently gives different hashes depending on the platform
* `merge-traces-seed.proftext`: Apparently `std::uniform_int_distribution` is different on some platforms, causing our random sampling algorithm to give a different set on some platforms