### PR TITLE
[InstCombine] Remove INT_MIN poison check from abs(X) u< C --> X + (C-1) u<= 2*(C-1) fold.

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -4432,8 +4432,6 @@ Instruction *InstCombinerImpl::foldICmpIntrinsicWithConstant(ICmpInst &Cmp,
       return nullptr;
 
     Value *X = II->getArgOperand(0);
-    bool IsIntMinPoison =
-        cast<ConstantInt>(II->getArgOperand(1))->getValue().isOne();
 
     // If C >= 0:
     // abs(X) u> C --> X + C u> 2 * C
@@ -4443,13 +4441,12 @@ Instruction *InstCombinerImpl::foldICmpIntrinsicWithConstant(ICmpInst &Cmp,
                           ConstantInt::get(Ty, 2 * C));
     }
 
-    // If abs(INT_MIN) is poison and C >= 1:
+    // If C >= 1:
     // abs(X) u< C --> X + (C - 1) u<= 2 * (C - 1)
-    if (IsIntMinPoison && Pred == CmpInst::ICMP_ULT && C.sge(1)) {
+    if (Pred == CmpInst::ICMP_ULT && C.sge(1))
       return new ICmpInst(ICmpInst::ICMP_ULE,
                           Builder.CreateAdd(X, ConstantInt::get(Ty, C - 1)),
                           ConstantInt::get(Ty, 2 * (C - 1)));
-    }
 
     break;
   }

--- a/llvm/test/Transforms/InstCombine/abs-intrinsic.ll
+++ b/llvm/test/Transforms/InstCombine/abs-intrinsic.ll
@@ -1010,8 +1010,8 @@ define i8 @abs_diff_sle_y_x(i8 %x, i8 %y) {
 
 define i1 @abs_cmp_ule_no_poison(i32 %x) {
 ; CHECK-LABEL: @abs_cmp_ule_no_poison(
-; CHECK-NEXT:    [[X_ABS:%.*]] = call i32 @llvm.abs.i32(i32 [[X:%.*]], i1 false)
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[X_ABS]], 32
+; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[X:%.*]], 31
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[TMP1]], 63
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 false)
@@ -1058,8 +1058,8 @@ define i1 @abs_cmp_ule_poison_multiuse(i32 %x) {
 
 define i1 @abs_cmp_ult_no_poison(i32 %x) {
 ; CHECK-LABEL: @abs_cmp_ult_no_poison(
-; CHECK-NEXT:    [[X_ABS:%.*]] = call i32 @llvm.abs.i32(i32 [[X:%.*]], i1 false)
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[X_ABS]], 32
+; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[X:%.*]], 31
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[TMP1]], 63
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 false)


### PR DESCRIPTION
Removed the check from this fold for the second argument of abs being true (meaning the call returns poison for INT_MIN). This works because if the second argument of abs is false, abs will return INT_MIN when called on INT_MIN which results in false for both the original form and the folded form due to the use of unsigned comparisons.

Proof: https://alive2.llvm.org/ce/z/qJRB-b

Closes #219163