### PR TITLE
[AArch64] Report SEH pseudos as zero-size

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -220,6 +220,11 @@ unsigned AArch64InstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
   if (MI.isMetaInstruction())
     return 0;
 
+  // SEH pseudos only emit unwind opcodes into .xdata. Size = 0 in the .td does
+  // not work: the default case below treats getSize() == 0 as "unset".
+  if (isSEHInstruction(MI))
+    return 0;
+
   // FIXME: We currently only handle pseudoinstructions that don't get expanded
   //        before the assembly printer.
   unsigned NumBytes = 0;

--- a/llvm/test/CodeGen/AArch64/wineh-seh-pseudo-size.mir
+++ b/llvm/test/CodeGen/AArch64/wineh-seh-pseudo-size.mir
@@ -1,0 +1,46 @@
+# SEH pseudos only emit unwind opcodes into .xdata, so they must not be counted
+# as 4-byte instructions. The branch range is narrowed so that counting the ten
+# SEH_Nops here would push the TBZ out of range and relax it needlessly.
+# RUN: llc -mtriple=aarch64-pc-windows-msvc -run-pass branch-relaxation \
+# RUN:     -aarch64-tbz-offset-bits=5 %s -o - | FileCheck %s
+
+# CHECK-LABEL: name: seh
+# CHECK:     TBZW renamable $w0, 0, %bb.2
+# CHECK-NOT: TBNZW
+
+--- |
+  define void @seh(i32 %x, ptr %p) {
+    ret void
+  }
+...
+---
+name:            seh
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $x1
+    TBZW renamable $w0, 0, %bb.2
+
+  bb.1:
+    successors: %bb.2
+    liveins: $x1
+    renamable $x2 = LDRXui renamable $x1, 0
+    renamable $x2 = LDRXui renamable $x1, 1
+    renamable $x2 = LDRXui renamable $x1, 2
+    renamable $x2 = LDRXui renamable $x1, 3
+    frame-setup SEH_Nop
+    frame-setup SEH_Nop
+    frame-setup SEH_Nop
+    frame-setup SEH_Nop
+    frame-setup SEH_Nop
+    frame-setup SEH_Nop
+    frame-setup SEH_Nop
+    frame-setup SEH_Nop
+    frame-setup SEH_Nop
+    frame-setup SEH_Nop
+    B %bb.2
+
+  bb.2:
+    RET undef $lr
+...


### PR DESCRIPTION
The `SEH_*` pseudos only emit unwind opcodes into `.xdata`. They never emit a
code byte. They are not meta-instructions though, so `getInstSizeInBytes` falls
through to its default case and reports each one as a normal 4-byte
instruction.

A prologue emits one unwind directive per saved register, so on Windows every
function's size estimate is inflated by 4 bytes per directive.

This one is conservative, not a miscompile. `BranchRelaxation` relaxes branches
it does not need to, and `AArch64CompressJumpTables` leaves jump tables wider
than they have to be. It costs code quality, not correctness.

## Size = 0 in the .td does not work

That is the obvious fix and it does nothing. The default case is:

```cpp
default:
  if (Desc.getSize())
    return Desc.getSize();
  NumBytes = 4;
```

Zero is falsy, so a declared `Size = 0` is indistinguishable from "unset" and
you still get 4. I tried it first and measured no change at all — the mismatch
count stayed exactly where it was. It has to be a C++ early return, and
`isSEHInstruction()` already exists and already covers all 25 opcodes.

## Numbers

Measured over `test/CodeGen/AArch64` at `aarch64-pc-windows-msvc`, with the
AsmPrinter size verifier turned on locally in **ExactSize** mode. Note the
companion patch ships it as `AllowOverEstimate`, which by design does not report
an over-estimate — so you need the stricter mode to see these numbers:

| | reported size mismatches |
|---|---|
| before | **558** — 537 SEH frame directives, 9 `SEH_Nop`, 12 others |
| after | **45** |

All 45 that remain are over-estimates in unrelated pseudos: `SPACE`,
`EMITBKEY`, `LOCAL_ESCAPE`, `INIT_UNDEF`, `PATCHABLE_*`. Those are the safe
direction and I have left them alone.

## Test

`wineh-seh-pseudo-size.mir`, the same shape as the companion patch but the other
way round. `-aarch64-tbz-offset-bits=5` narrows the branch range so that
counting ten `SEH_Nop`s would push a `TBZ` out of range.

Unpatched, they are counted and the branch is relaxed for no reason:

```
TBNZW renamable $w0, 0, %bb.1
```

Patched, it stays as it was:

```
TBZW renamable $w0, 0, %bb.2
```

The test fails against unpatched `llc`.

## Verification

This patch alone on top of `main`. Windows host, Release + assertions,
`LLVM_TARGETS_TO_BUILD=AArch64` only, built with GCC 13 (MinGW).

`check-llvm-codegen-aarch64`:

```
Total Discovered Tests: 4203
  Passed           : 4198 (99.88%)
  Expectedly Failed:    5 (0.12%)
  Failed           :    0
```

`check-llvm-mc-aarch64`: 2364 tests, all passed.

`check-llvm`: 5 failures, everything else passing or unsupported (this build has
only the AArch64 target). The same five that fail on unpatched `llc`, all of
them wanting an x86 default triple this build does not have.

`git clang-format` against the base reports no changes.

No existing test output moves. Estimates get tighter, but only in the direction
that was already too conservative.

## AI disclosure

Per the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html): this
patch was developed with AI assistance (Claude). The commit carries an
`Assisted-by: Claude (Anthropic)` trailer. The root-cause investigation, the fix
and the test were produced with that assistance, and every measurement quoted
above was run on the build described in the Verification section.
