### PR TITLE
[AMDGPU][GlobalISel] Use MIR patterns for multi-opcode combiner rules.

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUCombine.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCombine.td
@@ -21,18 +21,53 @@ def fcmp_select_to_fmin_fmax_legacy : GICombineRule<
   (apply [{ applySelectFCmpToFMinFMaxLegacy(*${select}, ${matchinfo}); }])>;
 
 
+def uchar_to_float_frags : GICombinePatFrag<
+  (outs root:$dst), (ins),
+  !foreach(op, [G_UITOFP, G_SITOFP],
+           (pattern (op $dst, $src)))>;
+
 def uchar_to_float : GICombineRule<
-  (defs root:$itofp),
-  (match (wip_match_opcode G_UITOFP, G_SITOFP):$itofp,
+  (defs root:$dst),
+  (match (uchar_to_float_frags $dst):$itofp,
          [{ return matchUCharToFloat(*${itofp}); }]),
   (apply [{ applyUCharToFloat(*${itofp}); }])>;
 
 
-def rcp_sqrt_to_rsq : GICombineRule<
-  (defs root:$rcp, build_fn_matchinfo:$matchinfo),
-  (match (wip_match_opcode G_INTRINSIC, G_FSQRT):$rcp,
-         [{ return matchRcpSqrtToRsq(*${rcp}, ${matchinfo}); }]),
-  (apply [{ Helper.applyBuildFn(*${rcp}, ${matchinfo}); }])>;
+// Fold rcp(sqrt(x)) and sqrt(rcp(x)) into rsq(x) when contraction is allowed.
+// The square root may be either the native G_FSQRT or the amdgcn.sqrt
+// intrinsic, so each direction is spelled out for both forms.
+
+// rcp(fsqrt(x)) -> rsq(x)
+def rcp_of_fsqrt_to_rsq : GICombineRule<
+  (defs root:$dst),
+  (match (G_FSQRT $sqrt, $x, (MIFlags FmContract)),
+         (int_amdgcn_rcp $dst, $sqrt, (MIFlags FmContract)):$rcp),
+  (apply (int_amdgcn_rsq $dst, $x, (MIFlags $rcp)))>;
+
+// rcp(amdgcn.sqrt(x)) -> rsq(x)
+def rcp_of_amdgcn_sqrt_to_rsq : GICombineRule<
+  (defs root:$dst),
+  (match (int_amdgcn_sqrt $sqrt, $x, (MIFlags FmContract)),
+         (int_amdgcn_rcp $dst, $sqrt, (MIFlags FmContract)):$rcp),
+  (apply (int_amdgcn_rsq $dst, $x, (MIFlags $rcp)))>;
+
+// fsqrt(rcp(x)) -> rsq(x)
+def fsqrt_of_rcp_to_rsq : GICombineRule<
+  (defs root:$dst),
+  (match (int_amdgcn_rcp $rcp, $x, (MIFlags FmContract)),
+         (G_FSQRT $dst, $rcp, (MIFlags FmContract)):$sqrt),
+  (apply (int_amdgcn_rsq $dst, $x, (MIFlags $sqrt)))>;
+
+// amdgcn.sqrt(rcp(x)) -> rsq(x)
+def amdgcn_sqrt_of_rcp_to_rsq : GICombineRule<
+  (defs root:$dst),
+  (match (int_amdgcn_rcp $rcp, $x, (MIFlags FmContract)),
+         (int_amdgcn_sqrt $dst, $rcp, (MIFlags FmContract)):$sqrt),
+  (apply (int_amdgcn_rsq $dst, $x, (MIFlags $sqrt)))>;
+
+def rcp_sqrt_to_rsq : GICombineGroup<[
+  rcp_of_fsqrt_to_rsq, rcp_of_amdgcn_sqrt_to_rsq,
+  fsqrt_of_rcp_to_rsq, amdgcn_sqrt_of_rcp_to_rsq]>;
 
 def fdiv_by_sqrt_to_rsq_f16 : GICombineRule<
   (defs root:$root),
@@ -43,12 +78,15 @@ def fdiv_by_sqrt_to_rsq_f16 : GICombineRule<
 
 def cvt_f32_ubyteN_matchdata : GIDefMatchData<"CvtF32UByteMatchInfo">;
 
+def cvt_f32_ubyteN_frags : GICombinePatFrag<
+  (outs root:$dst), (ins),
+  !foreach(op, [G_AMDGPU_CVT_F32_UBYTE0, G_AMDGPU_CVT_F32_UBYTE1,
+                G_AMDGPU_CVT_F32_UBYTE2, G_AMDGPU_CVT_F32_UBYTE3],
+           (pattern (op $dst, $src)))>;
+
 def cvt_f32_ubyteN : GICombineRule<
-  (defs root:$cvt_f32_ubyteN, cvt_f32_ubyteN_matchdata:$matchinfo),
-  (match (wip_match_opcode G_AMDGPU_CVT_F32_UBYTE0,
-                           G_AMDGPU_CVT_F32_UBYTE1,
-                           G_AMDGPU_CVT_F32_UBYTE2,
-                           G_AMDGPU_CVT_F32_UBYTE3):$cvt_f32_ubyteN,
+  (defs root:$dst, cvt_f32_ubyteN_matchdata:$matchinfo),
+  (match (cvt_f32_ubyteN_frags $dst):$cvt_f32_ubyteN,
          [{ return matchCvtF32UByteN(*${cvt_f32_ubyteN}, ${matchinfo}); }]),
   (apply [{ applyCvtF32UByteN(*${cvt_f32_ubyteN}, ${matchinfo}); }])>;
 
@@ -62,12 +100,14 @@ def clamp_i64_to_i16 : GICombineRule<
 
 def med3_matchdata : GIDefMatchData<"Med3MatchInfo">;
 
+def int_minmax_to_med3_frags : GICombinePatFrag<
+  (outs root:$dst), (ins),
+  !foreach(op, [G_SMAX, G_SMIN, G_UMAX, G_UMIN],
+           (pattern (op $dst, $lhs, $rhs)))>;
+
 def int_minmax_to_med3 : GICombineRule<
-  (defs root:$min_or_max, med3_matchdata:$matchinfo),
-  (match (wip_match_opcode G_SMAX,
-                           G_SMIN,
-                           G_UMAX,
-                           G_UMIN):$min_or_max,
+  (defs root:$dst, med3_matchdata:$matchinfo),
+  (match (int_minmax_to_med3_frags $dst):$min_or_max,
          [{ return matchIntMinMaxToMed3(*${min_or_max}, ${matchinfo}); }]),
   (apply [{ applyMed3(*${min_or_max}, ${matchinfo}); }])>;
 
@@ -77,21 +117,20 @@ def d16_load : GICombineRule<
   (combine (G_BITCAST $dst, $src):$bitcast,
            [{ return combineD16Load(*${bitcast} ); }])>;
 
+def fp_minmax_frags : GICombinePatFrag<
+  (outs root:$dst), (ins),
+  !foreach(op, [G_FMAXNUM, G_FMINNUM, G_FMAXNUM_IEEE, G_FMINNUM_IEEE],
+           (pattern (op $dst, $lhs, $rhs)))>;
+
 def fp_minmax_to_med3 : GICombineRule<
-  (defs root:$min_or_max, med3_matchdata:$matchinfo),
-  (match (wip_match_opcode G_FMAXNUM,
-                           G_FMINNUM,
-                           G_FMAXNUM_IEEE,
-                           G_FMINNUM_IEEE):$min_or_max,
+  (defs root:$dst, med3_matchdata:$matchinfo),
+  (match (fp_minmax_frags $dst):$min_or_max,
          [{ return matchFPMinMaxToMed3(*${min_or_max}, ${matchinfo}); }]),
   (apply [{ applyMed3(*${min_or_max}, ${matchinfo}); }])>;
 
 def fp_minmax_to_clamp : GICombineRule<
-  (defs root:$min_or_max, register_matchinfo:$matchinfo),
-  (match (wip_match_opcode G_FMAXNUM,
-                           G_FMINNUM,
-                           G_FMAXNUM_IEEE,
-                           G_FMINNUM_IEEE):$min_or_max,
+  (defs root:$dst, register_matchinfo:$matchinfo),
+  (match (fp_minmax_frags $dst):$min_or_max,
          [{ return matchFPMinMaxToClamp(*${min_or_max}, ${matchinfo}); }]),
   (apply [{ applyClamp(*${min_or_max}, ${matchinfo}); }])>;
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUPostLegalizerCombiner.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPostLegalizerCombiner.cpp
@@ -78,10 +78,6 @@ public:
   bool matchUCharToFloat(MachineInstr &MI) const;
   void applyUCharToFloat(MachineInstr &MI) const;
 
-  bool
-  matchRcpSqrtToRsq(MachineInstr &MI,
-                    std::function<void(MachineIRBuilder &)> &MatchInfo) const;
-
   bool matchFDivSqrtToRsqF16(MachineInstr &MI) const;
   void applyFDivSqrtToRsqF16(MachineInstr &MI, const Register &X) const;
 
@@ -245,57 +241,6 @@ void AMDGPUPostLegalizerCombinerImpl::applyUCharToFloat(
   }
 
   MI.eraseFromParent();
-}
-
-bool AMDGPUPostLegalizerCombinerImpl::matchRcpSqrtToRsq(
-    MachineInstr &MI,
-    std::function<void(MachineIRBuilder &)> &MatchInfo) const {
-  auto getRcpSrc = [=](const MachineInstr &MI) -> MachineInstr * {
-    if (!MI.getFlag(MachineInstr::FmContract))
-      return nullptr;
-
-    if (auto *GI = dyn_cast<GIntrinsic>(&MI)) {
-      if (GI->is(Intrinsic::amdgcn_rcp))
-        return MRI.getVRegDef(MI.getOperand(2).getReg());
-    }
-    return nullptr;
-  };
-
-  auto getSqrtSrc = [=](const MachineInstr &MI) -> MachineInstr * {
-    if (!MI.getFlag(MachineInstr::FmContract))
-      return nullptr;
-    if (auto *GI = dyn_cast<GIntrinsic>(&MI)) {
-      if (GI->is(Intrinsic::amdgcn_sqrt))
-        return MRI.getVRegDef(MI.getOperand(2).getReg());
-    }
-    MachineInstr *SqrtSrcMI = nullptr;
-    auto Match =
-        mi_match(MI.getOperand(0).getReg(), MRI, m_GFSqrt(m_MInstr(SqrtSrcMI)));
-    (void)Match;
-    return SqrtSrcMI;
-  };
-
-  MachineInstr *RcpSrcMI = nullptr, *SqrtSrcMI = nullptr;
-  // rcp(sqrt(x))
-  if ((RcpSrcMI = getRcpSrc(MI)) && (SqrtSrcMI = getSqrtSrc(*RcpSrcMI))) {
-    MatchInfo = [SqrtSrcMI, &MI](MachineIRBuilder &B) {
-      B.buildIntrinsic(Intrinsic::amdgcn_rsq, {MI.getOperand(0)})
-          .addUse(SqrtSrcMI->getOperand(0).getReg())
-          .setMIFlags(MI.getFlags());
-    };
-    return true;
-  }
-
-  // sqrt(rcp(x))
-  if ((SqrtSrcMI = getSqrtSrc(MI)) && (RcpSrcMI = getRcpSrc(*SqrtSrcMI))) {
-    MatchInfo = [RcpSrcMI, &MI](MachineIRBuilder &B) {
-      B.buildIntrinsic(Intrinsic::amdgcn_rsq, {MI.getOperand(0)})
-          .addUse(RcpSrcMI->getOperand(0).getReg())
-          .setMIFlags(MI.getFlags());
-    };
-    return true;
-  }
-  return false;
 }
 
 bool AMDGPUPostLegalizerCombinerImpl::matchFDivSqrtToRsqF16(

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/no-ctlz-from-umul-to-lshr-in-postlegalizer.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/no-ctlz-from-umul-to-lshr-in-postlegalizer.ll
@@ -9,49 +9,48 @@ define void @test(ptr %p) {
 ; CHECK-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; CHECK-NEXT:    v_mov_b32_e32 v1, v2
 ; CHECK-NEXT:    s_mov_b32 s8, 16
-; CHECK-NEXT:    s_mov_b32 s6, 0
-; CHECK-NEXT:    v_mov_b32_e32 v2, s6
-; CHECK-NEXT:    v_cvt_f32_ubyte0_e64 v2, v2
+; CHECK-NEXT:    s_mov_b32 s4, 0
+; CHECK-NEXT:    v_mov_b32_e32 v2, s4
 ; CHECK-NEXT:    v_rcp_iflag_f32_e64 v2, v2
 ; CHECK-NEXT:    s_mov_b32 s5, 0x4f7ffffe
 ; CHECK-NEXT:    v_mov_b32_e32 v3, s5
 ; CHECK-NEXT:    v_mul_f32_e64 v2, v2, v3
 ; CHECK-NEXT:    v_cvt_u32_f32_e64 v2, v2
 ; CHECK-NEXT:    v_readfirstlane_b32 s4, v2
-; CHECK-NEXT:    s_mov_b32 s7, 0
-; CHECK-NEXT:    s_mul_hi_u32 s7, s4, s7
-; CHECK-NEXT:    s_add_i32 s4, s4, s7
+; CHECK-NEXT:    s_mov_b32 s6, 0
+; CHECK-NEXT:    s_mul_hi_u32 s6, s4, s6
+; CHECK-NEXT:    s_add_i32 s4, s4, s6
 ; CHECK-NEXT:    s_mul_hi_u32 s4, s4, s8
+; CHECK-NEXT:    s_mov_b32 s6, 2
+; CHECK-NEXT:    s_add_i32 s4, s4, s6
+; CHECK-NEXT:    s_mov_b32 s6, 0
+; CHECK-NEXT:    v_mov_b32_e32 v2, s6
+; CHECK-NEXT:    v_rcp_iflag_f32_e64 v2, v2
+; CHECK-NEXT:    v_mov_b32_e32 v3, s5
+; CHECK-NEXT:    v_mul_f32_e64 v2, v2, v3
+; CHECK-NEXT:    v_cvt_u32_f32_e64 v2, v2
+; CHECK-NEXT:    v_readfirstlane_b32 s6, v2
+; CHECK-NEXT:    s_mov_b32 s7, 0
+; CHECK-NEXT:    s_mul_hi_u32 s7, s6, s7
+; CHECK-NEXT:    s_add_i32 s6, s6, s7
+; CHECK-NEXT:    s_mul_hi_u32 s6, s6, s8
 ; CHECK-NEXT:    s_mov_b32 s7, 2
-; CHECK-NEXT:    s_add_i32 s4, s4, s7
+; CHECK-NEXT:    s_add_i32 s9, s6, s7
+; CHECK-NEXT:    s_mov_b32 s6, 0
 ; CHECK-NEXT:    v_mov_b32_e32 v2, s6
-; CHECK-NEXT:    v_cvt_f32_ubyte0_e64 v2, v2
 ; CHECK-NEXT:    v_rcp_iflag_f32_e64 v2, v2
 ; CHECK-NEXT:    v_mov_b32_e32 v3, s5
 ; CHECK-NEXT:    v_mul_f32_e64 v2, v2, v3
 ; CHECK-NEXT:    v_cvt_u32_f32_e64 v2, v2
-; CHECK-NEXT:    v_readfirstlane_b32 s7, v2
-; CHECK-NEXT:    s_mov_b32 s9, 0
-; CHECK-NEXT:    s_mul_hi_u32 s9, s7, s9
-; CHECK-NEXT:    s_add_i32 s7, s7, s9
-; CHECK-NEXT:    s_mul_hi_u32 s7, s7, s8
-; CHECK-NEXT:    s_mov_b32 s9, 2
-; CHECK-NEXT:    s_add_i32 s9, s7, s9
+; CHECK-NEXT:    v_readfirstlane_b32 s6, v2
+; CHECK-NEXT:    s_mov_b32 s7, 0
+; CHECK-NEXT:    s_mul_hi_u32 s7, s6, s7
+; CHECK-NEXT:    s_add_i32 s6, s6, s7
+; CHECK-NEXT:    s_mul_hi_u32 s6, s6, s8
+; CHECK-NEXT:    s_mov_b32 s7, 2
+; CHECK-NEXT:    s_add_i32 s7, s6, s7
+; CHECK-NEXT:    s_mov_b32 s6, 0
 ; CHECK-NEXT:    v_mov_b32_e32 v2, s6
-; CHECK-NEXT:    v_cvt_f32_ubyte0_e64 v2, v2
-; CHECK-NEXT:    v_rcp_iflag_f32_e64 v2, v2
-; CHECK-NEXT:    v_mov_b32_e32 v3, s5
-; CHECK-NEXT:    v_mul_f32_e64 v2, v2, v3
-; CHECK-NEXT:    v_cvt_u32_f32_e64 v2, v2
-; CHECK-NEXT:    v_readfirstlane_b32 s7, v2
-; CHECK-NEXT:    s_mov_b32 s10, 0
-; CHECK-NEXT:    s_mul_hi_u32 s10, s7, s10
-; CHECK-NEXT:    s_add_i32 s7, s7, s10
-; CHECK-NEXT:    s_mul_hi_u32 s7, s7, s8
-; CHECK-NEXT:    s_mov_b32 s10, 2
-; CHECK-NEXT:    s_add_i32 s7, s7, s10
-; CHECK-NEXT:    v_mov_b32_e32 v2, s6
-; CHECK-NEXT:    v_cvt_f32_ubyte0_e64 v2, v2
 ; CHECK-NEXT:    v_rcp_iflag_f32_e64 v2, v2
 ; CHECK-NEXT:    v_mov_b32_e32 v3, s5
 ; CHECK-NEXT:    v_mul_f32_e64 v2, v2, v3

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/sdiv.i64.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/sdiv.i64.ll
@@ -1088,10 +1088,10 @@ define i64 @v_sdiv_i64_oddk_denom(i64 %num) {
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    v_cvt_f32_u32_e32 v3, 0x12d8fb
-; CHECK-NEXT:    v_cvt_f32_ubyte0_e32 v4, 0
+; CHECK-NEXT:    v_mov_b32_e32 v4, 0x4f800000
 ; CHECK-NEXT:    v_ashrrev_i32_e32 v2, 31, v1
 ; CHECK-NEXT:    v_add_i32_e32 v0, vcc, v0, v2
-; CHECK-NEXT:    v_mac_f32_e32 v3, 0x4f800000, v4
+; CHECK-NEXT:    v_mac_f32_e32 v3, 0, v4
 ; CHECK-NEXT:    v_rcp_iflag_f32_e32 v3, v3
 ; CHECK-NEXT:    v_xor_b32_e32 v5, v0, v2
 ; CHECK-NEXT:    v_addc_u32_e32 v1, vcc, v1, v2, vcc
@@ -1237,10 +1237,10 @@ define <2 x i64> @v_sdiv_v2i64_oddk_denom(<2 x i64> %num) {
 ; GISEL:       ; %bb.0:
 ; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GISEL-NEXT:    v_cvt_f32_u32_e32 v4, 0x12d8fb
-; GISEL-NEXT:    v_cvt_f32_ubyte0_e32 v5, 0
+; GISEL-NEXT:    v_mov_b32_e32 v5, 0x4f800000
 ; GISEL-NEXT:    s_mov_b32 s8, 1
 ; GISEL-NEXT:    s_cmp_lg_u32 s8, 0
-; GISEL-NEXT:    v_mac_f32_e32 v4, 0x4f800000, v5
+; GISEL-NEXT:    v_mac_f32_e32 v4, 0, v5
 ; GISEL-NEXT:    v_rcp_iflag_f32_e32 v5, v4
 ; GISEL-NEXT:    v_ashrrev_i32_e32 v4, 31, v1
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v4
@@ -1505,10 +1505,10 @@ define <2 x i64> @v_sdiv_v2i64_oddk_denom(<2 x i64> %num) {
 ; CGP:       ; %bb.0:
 ; CGP-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CGP-NEXT:    v_cvt_f32_u32_e32 v4, 0x12d8fb
-; CGP-NEXT:    v_cvt_f32_ubyte0_e32 v6, 0
+; CGP-NEXT:    v_mov_b32_e32 v6, 0x4f800000
 ; CGP-NEXT:    v_ashrrev_i32_e32 v5, 31, v1
 ; CGP-NEXT:    v_add_i32_e32 v0, vcc, v0, v5
-; CGP-NEXT:    v_mac_f32_e32 v4, 0x4f800000, v6
+; CGP-NEXT:    v_mac_f32_e32 v4, 0, v6
 ; CGP-NEXT:    v_rcp_iflag_f32_e32 v4, v4
 ; CGP-NEXT:    v_xor_b32_e32 v9, v0, v5
 ; CGP-NEXT:    v_addc_u32_e32 v1, vcc, v1, v5, vcc

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/srem.i64.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/srem.i64.ll
@@ -1075,10 +1075,10 @@ define i64 @v_srem_i64_oddk_denom(i64 %num) {
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    v_cvt_f32_u32_e32 v3, 0x12d8fb
-; CHECK-NEXT:    v_cvt_f32_ubyte0_e32 v4, 0
+; CHECK-NEXT:    v_mov_b32_e32 v4, 0x4f800000
 ; CHECK-NEXT:    v_ashrrev_i32_e32 v2, 31, v1
 ; CHECK-NEXT:    v_add_i32_e32 v0, vcc, v0, v2
-; CHECK-NEXT:    v_mac_f32_e32 v3, 0x4f800000, v4
+; CHECK-NEXT:    v_mac_f32_e32 v3, 0, v4
 ; CHECK-NEXT:    v_rcp_iflag_f32_e32 v3, v3
 ; CHECK-NEXT:    v_xor_b32_e32 v5, v0, v2
 ; CHECK-NEXT:    v_addc_u32_e32 v1, vcc, v1, v2, vcc
@@ -1222,10 +1222,10 @@ define <2 x i64> @v_srem_v2i64_oddk_denom(<2 x i64> %num) {
 ; GISEL:       ; %bb.0:
 ; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GISEL-NEXT:    v_cvt_f32_u32_e32 v4, 0x12d8fb
-; GISEL-NEXT:    v_cvt_f32_ubyte0_e32 v5, 0
+; GISEL-NEXT:    v_mov_b32_e32 v5, 0x4f800000
 ; GISEL-NEXT:    s_mov_b32 s8, 1
 ; GISEL-NEXT:    s_cmp_lg_u32 s8, 0
-; GISEL-NEXT:    v_mac_f32_e32 v4, 0x4f800000, v5
+; GISEL-NEXT:    v_mac_f32_e32 v4, 0, v5
 ; GISEL-NEXT:    v_rcp_iflag_f32_e32 v5, v4
 ; GISEL-NEXT:    v_ashrrev_i32_e32 v4, 31, v1
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v4
@@ -1486,10 +1486,10 @@ define <2 x i64> @v_srem_v2i64_oddk_denom(<2 x i64> %num) {
 ; CGP:       ; %bb.0:
 ; CGP-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CGP-NEXT:    v_cvt_f32_u32_e32 v4, 0x12d8fb
-; CGP-NEXT:    v_cvt_f32_ubyte0_e32 v6, 0
+; CGP-NEXT:    v_mov_b32_e32 v6, 0x4f800000
 ; CGP-NEXT:    v_ashrrev_i32_e32 v5, 31, v1
 ; CGP-NEXT:    v_add_i32_e32 v0, vcc, v0, v5
-; CGP-NEXT:    v_mac_f32_e32 v4, 0x4f800000, v6
+; CGP-NEXT:    v_mac_f32_e32 v4, 0, v6
 ; CGP-NEXT:    v_rcp_iflag_f32_e32 v4, v4
 ; CGP-NEXT:    v_xor_b32_e32 v9, v0, v5
 ; CGP-NEXT:    v_addc_u32_e32 v1, vcc, v1, v5, vcc


### PR DESCRIPTION
Match several AMDGPU GlobalISel combiner rules with MIR patterns inplace of wip_match_opcode mechanism:

- uchar_to_float, cvt_f32_ubyteN, int_minmax_to_med3 and fp_minmax_to_med3 / fp_minmax_to_clamp now match via a GICombinePatFrag that fans out over their opcodes with !foreach, keeping the existing C++ match/apply.
- rcp_sqrt_to_rsq becomes fully declarative: a group of four intrinsic patterns folding rcp(sqrt(x)) and sqrt(rcp(x)) into rsq(x) for both G_FSQRT and amdgcn.sqrt, removing matchRcpSqrtToRsq.

It also includes some regenerated LIT tests changes which accounts for making uchar_to_float a MIR pattern resulting in its reorders after the generic itof_const_zero_fold_ui pattern on the G_UITOFP root; they only race on uitofp(0), where folding to fconstant 0.0 instead of cvt_f32_ubyte0 is value-identical.