### PR TITLE
[SCEV] Remove unreachable visitMulExpr in SCEVCastSinkingRewriter (NFC)

### DIFF
--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -1051,16 +1051,6 @@ public:
     return !Changed ? Expr : SE.getAddExpr(Operands, Expr->getNoWrapFlags());
   }
 
-  const SCEV *visitMulExpr(const SCEVMulExpr *Expr) {
-    SmallVector<SCEVUse, 2> Operands;
-    bool Changed = false;
-    for (SCEVUse Op : Expr->operands()) {
-      Operands.push_back(visit(Op.getPointer()));
-      Changed |= Op.getPointer() != Operands.back();
-    }
-    return !Changed ? Expr : SE.getMulExpr(Operands, Expr->getNoWrapFlags());
-  }
-
   const SCEV *visitUnknown(const SCEVUnknown *Expr) {
     assert(Expr->getType()->isPointerTy() &&
            "Should only reach pointer-typed SCEVUnknown's.");


### PR DESCRIPTION
SCEVCastSinkingRewriter::visit() returns S unchanged unless S->getType() is a pointer type. So visitMulExpr can never be entered.