### PR TITLE
[flang] Fix diagnostic order for invalid coarray dimension declarations

### DIFF
--- a/flang/lib/Parser/Fortran-parsers.cpp
+++ b/flang/lib/Parser/Fortran-parsers.cpp
@@ -734,7 +734,9 @@ TYPE_PARSER(
         "nonstandard usage: ',' in place of '::'"_port_en_US,
         construct<TypeDeclarationStmt>(declarationTypeSpec,
             defaulted("," >> nonemptyList(Parser<AttrSpec>{})),
-            withMessage("expected entity declarations"_err_en_US,
+            // Anchor at the failure point so this nonstandard-path message does
+            // not tie with and outrank the standard "expected '::'".
+            withMessageAtFailure("expected entity declarations"_err_en_US,
                 "," >> nonemptyList(entityDecl)))))
 
 // R802 attr-spec ->

--- a/flang/lib/Parser/basic-parsers.h
+++ b/flang/lib/Parser/basic-parsers.h
@@ -203,8 +203,8 @@ template <typename PA> class WithMessageParser {
 public:
   using resultType = typename PA::resultType;
   constexpr WithMessageParser(const WithMessageParser &) = default;
-  constexpr WithMessageParser(MessageFixedText t, PA p)
-      : text_{t}, parser_{p} {}
+  constexpr WithMessageParser(MessageFixedText t, PA p, bool atStart = true)
+      : text_{t}, parser_{p}, emitAtStart_{atStart} {}
   std::optional<resultType> Parse(ParseState &state) const {
     if (state.deferMessages()) { // fast path
       std::optional<resultType> result{parser_.Parse(state)};
@@ -230,7 +230,7 @@ public:
       messages.Annex(std::move(state.messages()));
     } else {
       emitMessage = true;
-      emitAtStart = true;
+      emitAtStart = emitAtStart_;
       if (hadAnyTokenMatched) {
         state.set_anyTokenMatched();
       }
@@ -249,11 +249,23 @@ public:
 private:
   const MessageFixedText text_;
   const PA parser_;
+  // When true (the default), a failure that matched no tokens reports the
+  // message at the location where this parser started rather than where it
+  // stopped. Opt out with withMessageAtFailure() where a start-anchored
+  // message would collide with and outrank a more specific diagnostic.
+  const bool emitAtStart_{true};
 };
 
 template <typename PA>
 inline constexpr auto withMessage(MessageFixedText msg, PA parser) {
   return WithMessageParser{msg, parser};
+}
+
+// Like withMessage(), but anchors the overriding message where the parse
+// failed instead of at its start location.
+template <typename PA>
+inline constexpr auto withMessageAtFailure(MessageFixedText msg, PA parser) {
+  return WithMessageParser{msg, parser, /*atStart=*/false};
 }
 
 // If a and b are parsers, then a >> b returns a parser that succeeds when


### PR DESCRIPTION
When a `TypeDeclarationStmt` falls back to the nonstandard "`,` instead of `::`"
recovery path and that recovery also fails, the fallback used
`withMessage()`, which anchors its "expected entity declarations" message at
the *start* of the recovery attempt. That start position coincided with the
location of the primary "expected '::'" diagnostic, so the two messages tied
and were emitted out of order (and the wrong column) instead of appearing at
their proper source locations in sequence.

```fortran
integer :: d
real, dimension (0:d)[0:d] :: ra
```

Before the fix, this emitted "expected entity declarations" before "expected
'::'", both pointing at column 30 instead of their respective failure points:

```
r547_1f.f90:33:30: error: expected entity declarations
r547_1f.f90:33:30: error: expected '::'
```

After the fix, the messages appear in the correct order and at the correct
columns:

```
r547_1f.f90:33:30: error: expected '::'
r547_1f.f90:33:31: error: expected entity declarations
```

Added `withMessageAtFailure()`, a variant of `withMessage()` that anchors its
override message at the parser's failure location rather than its start,
and used it for the nonstandard comma-declaration fallback so it no longer
outranks the more specific `expected '::'` diagnostic.

This fixes the issue https://github.com/llvm/llvm-project/issues/219003

Assisted-by: AI (Claude)