### PR TITLE
[X86] Properly inherit all section flags from parent for basic block sections

### DIFF
--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -1154,7 +1154,9 @@ MCSection *TargetLoweringObjectFileELF::getSectionForMachineBasicBlock(
     UniqueID = NextUniqueID++;
   }
 
-  unsigned Flags = ELF::SHF_ALLOC | ELF::SHF_EXECINSTR;
+  unsigned Flags =
+      static_cast<const MCSectionELF *>(MBB.getParent()->getSection())
+          ->getFlags();
   std::string GroupName;
   if (F.hasComdat()) {
     Flags |= ELF::SHF_GROUP;

--- a/llvm/test/CodeGen/X86/code-model-elf-text-sections.ll
+++ b/llvm/test/CodeGen/X86/code-model-elf-text-sections.ll
@@ -11,6 +11,8 @@
 ; RUN: llvm-readelf -S %t | FileCheck %s --check-prefix=SMALL-DS
 ; RUN: llc < %s -relocation-model=pic -filetype=obj -code-model=large -function-sections -o %t
 ; RUN: llvm-readelf -S %t | FileCheck %s --check-prefix=LARGE-DS
+; RUN: llc < %s -relocation-model=pic -filetype=obj -code-model=large -function-sections -basic-block-sections=all -o %t
+; RUN: llvm-readelf -S %t | FileCheck %s --check-prefix=LARGE-BB
 
 ; SMALL: .text {{.*}} AX {{.*}}
 ; SMALL: .ltext {{.*}} AXl {{.*}}
@@ -27,6 +29,10 @@
 ; LARGE-DS: .ltext {{.*}} AXl {{.*}}
 ; LARGE-DS: .ltext.2 {{.*}} AXl {{.*}}
 ; LARGE-DS: .foo {{.*}} AX {{.*}}
+
+; LARGE-BB: .ltext.func_bb {{.*}} AXl {{.*}}
+; LARGE-BB: .ltext.func_bb {{.*}} AXl {{.*}}
+; LARGE-BB: .ltext.func_bb {{.*}} AXl {{.*}}
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64--linux"
@@ -45,4 +51,16 @@ define void @ltext2() section ".ltext.2" {
 
 define void @foo() section ".foo" {
   ret void
+}
+
+define i32 @func_bb(i32 %x) {
+entry:
+  %tobool = icmp ne i32 %x, 0
+  br i1 %tobool, label %if.then, label %if.end
+
+if.then:
+  ret i32 1
+
+if.end:
+  ret i32 0
 }


### PR DESCRIPTION
Or else we miss flags like SHF_X86_64_LARGE.