### PR TITLE
Rematerializer: Use def_instructions instead of def_operands + getParent

### DIFF
--- a/llvm/lib/CodeGen/Rematerializer.cpp
+++ b/llvm/lib/CodeGen/Rematerializer.cpp
@@ -529,8 +529,7 @@ void Rematerializer::addRegIfRematerializable(
 
   // Check that the register's definitions can be rematerialized.
   SmallPtrSet<MachineInstr *, 1> DefSet;
-  for (MachineOperand &MO : MRI.def_operands(DefReg)) {
-    MachineInstr &DefMI = *MO.getParent();
+  for (MachineInstr &DefMI : MRI.def_instructions(DefReg)) {
     // If a single MI has multiple defs for the same register, we don't need to
     // redo MI-based checks.
     if (!DefSet.insert(&DefMI).second)
@@ -631,8 +630,7 @@ void Rematerializer::addRegIfRematerializable(
     // register under consideration makes the latter unrematerializable.
     SlotIndex FirstDefSlot = LIS.getInstructionIndex(*RematReg.getFirstDef());
     for (const auto &[UnrematDepReg, _] : UnrematDeps) {
-      for (MachineOperand &UnrematMODef : MRI.def_operands(UnrematDepReg)) {
-        MachineInstr &UnrematDefMI = *UnrematMODef.getParent();
+      for (MachineInstr &UnrematDefMI : MRI.def_instructions(UnrematDepReg)) {
         SlotIndex UnrematDefSlot = LIS.getInstructionIndex(UnrematDefMI);
         if (UnrematDefSlot > FirstDefSlot || UnrematDefSlot < LastDefSlot)
           return;


### PR DESCRIPTION
Directly iterate the user instructions instead of querying the same
parent for each use.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>