### PR TITLE
[mlir][IR][NFC] Disambiguate `SymbolTable::Visibility` references

### DIFF
--- a/mlir/include/mlir/IR/SymbolTable.h
+++ b/mlir/include/mlir/IR/SymbolTable.h
@@ -463,28 +463,29 @@ public:
 template <typename ConcreteType>
 class SymbolVisibility : public TraitBase<ConcreteType, SymbolVisibility> {
 public:
-  SymbolTable::Visibility getVisibility() {
+  ::mlir::SymbolTable::Visibility getVisibility() {
     auto concrete = cast<ConcreteType>(this->getOperation());
     StringAttr visibility = concrete.getSymVisibilityAttr();
     if (!visibility || visibility.getValue() == "public")
-      return SymbolTable::Visibility::Public;
+      return ::mlir::SymbolTable::Visibility::Public;
     if (visibility.getValue() == "private")
-      return SymbolTable::Visibility::Private;
+      return ::mlir::SymbolTable::Visibility::Private;
     assert(visibility.getValue() == "nested" && "invalid symbol visibility");
-    return SymbolTable::Visibility::Nested;
+    return ::mlir::SymbolTable::Visibility::Nested;
   }
 
-  void setVisibility(SymbolTable::Visibility visibility) {
+  void setVisibility(::mlir::SymbolTable::Visibility visibility) {
     auto concrete = cast<ConcreteType>(this->getOperation());
-    if (visibility == SymbolTable::Visibility::Public) {
+    if (visibility == ::mlir::SymbolTable::Visibility::Public) {
       concrete.setSymVisibilityAttr({});
       return;
     }
-    assert((visibility == SymbolTable::Visibility::Private ||
-            visibility == SymbolTable::Visibility::Nested) &&
+    assert((visibility == ::mlir::SymbolTable::Visibility::Private ||
+            visibility == ::mlir::SymbolTable::Visibility::Nested) &&
            "invalid symbol visibility");
-    StringRef value =
-        visibility == SymbolTable::Visibility::Private ? "private" : "nested";
+    StringRef value = visibility == ::mlir::SymbolTable::Visibility::Private
+                          ? "private"
+                          : "nested";
     concrete.setSymVisibilityAttr(
         StringAttr::get(this->getOperation()->getContext(), value));
   }


### PR DESCRIPTION
As a follow-up to 979b722, address MSVC's confusion when it's trying to resolve the underqualified enum name:
```
error C2955: 'mlir::OpTrait::SymbolTable': use of class template requires template argument list
```

Assisted-by: OpenAI Codex