### PR TITLE
[AMDGPU] Ignore CU mode on targets without WGP mode

### DIFF
--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -2599,7 +2599,9 @@ bool isGFX1250(const MCSubtargetInfo &STI) {
 }
 
 bool isFullSIMDMode(const MCSubtargetInfo &STI) {
-  return isGFX1250(STI) || !STI.getFeatureBits().test(FeatureCuMode);
+  // CU mode is only meaningful on targets that have WGP mode. Elsewhere the
+  // feature may still be requested (e.g. -mcumode), but it has no effect.
+  return !supportsWGP(STI) || !STI.getFeatureBits().test(FeatureCuMode);
 }
 
 bool isGFX1250Plus(const MCSubtargetInfo &STI) {

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -2615,9 +2615,7 @@ bool isGFX13(const MCSubtargetInfo &STI) {
 bool isGFX13Plus(const MCSubtargetInfo &STI) { return isGFX13(STI); }
 
 bool supportsWGP(const MCSubtargetInfo &STI) {
-  if (isGFX1250(STI))
-    return false;
-  return isGFX10Plus(STI);
+  return STI.getFeatureBits().test(FeatureSupportsWGP);
 }
 
 bool isNotGFX11Plus(const MCSubtargetInfo &STI) { return !isGFX11Plus(STI); }

--- a/llvm/test/CodeGen/AMDGPU/lds-limit-diagnostics.ll
+++ b/llvm/test/CodeGen/AMDGPU/lds-limit-diagnostics.ll
@@ -15,6 +15,11 @@
 ; RUN: not llc -mtriple=amdgpu7.00-amd-amdhsa -filetype=null %s 2>&1 | FileCheck -check-prefix=ERROR-LIMIT64K %s
 ; RUN: not llc -mtriple=amdgpu6.00-amd-amdpal -filetype=null %s 2>&1 | FileCheck -check-prefix=ERROR-LIMIT32K %s
 
+; Pre-gfx10 has no WGP mode, so +cumode must not change the limit.
+; RUN: not llc -mtriple=amdgpu9.42-amd-amdhsa -mattr=+cumode -filetype=null %s 2>&1 | FileCheck -check-prefix=ERROR-LIMIT64K %s
+; RUN: not llc -mtriple=amdgpu9.0a-amd-amdhsa -mattr=+cumode -filetype=null %s 2>&1 | FileCheck -check-prefix=ERROR-LIMIT64K %s
+; RUN: not llc -mtriple=amdgpu9.50-amd-amdhsa -mattr=+cumode -filetype=null %s 2>&1 | FileCheck -check-prefix=ERROR-LIMIT160K %s
+
 ; gfx950 supports upto 160 KB LDS memory. The generic target does not.
 ; This is a negative test to check when the LDS size exceeds the max usable limit.
 


### PR DESCRIPTION
`isFullSIMDMode()` treated `+cumode` as meaningful on every generation, so on pre-gfx10 targets it halved both the physical and the addressable LDS size and dropped `getNumWorkGroupSIMDs()` from 4 to 2.

Before the LDS size rework the CU/WGP adjustment was gated on `isGFX10Plus()`, and `+cumode` was simply ignored elsewhere.

---

rocFFT passes `-mcumode` to hipRTC unconditionally, so its Bluestein kernels started failing to compile on gfx942 with "local memory (65536) exceeds limit (32768)".