### PR TITLE
[clang][ssaf] Fix Windows link error by adding clangAST dependency

### DIFF
--- a/clang-tools-extra/clang-ssaf-src-edit-merge/CMakeLists.txt
+++ b/clang-tools-extra/clang-ssaf-src-edit-merge/CMakeLists.txt
@@ -8,5 +8,6 @@ add_clang_tool(clang-ssaf-src-edit-merge
 
 clang_target_link_libraries(clang-ssaf-src-edit-merge
   PRIVATE
+  clangAST
   clangToolingCore
   )


### PR DESCRIPTION
Fixes link failure in SrcEditMerge(Introduced in #216183) on Windows due to a missing clangAST dependency.

rdar://179151250