### PR TITLE
[MSAN] Handle PtrToAddrInst in MemorySanitizer

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -2609,6 +2609,13 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     setOrigin(&I, getOrigin(&I, 0));
   }
 
+  void visitPtrToAddrInst(PtrToAddrInst &I) {
+    IRBuilder<> IRB(&I);
+    setShadow(&I, IRB.CreateIntCast(getShadow(&I, 0), getShadowTy(&I), false,
+                                    "_msprop_ptrtoaddr"));
+    setOrigin(&I, getOrigin(&I, 0));
+  }
+
   void visitIntToPtrInst(IntToPtrInst &I) {
     IRBuilder<> IRB(&I);
     setShadow(&I, IRB.CreateIntCast(getShadow(&I, 0), getShadowTy(&I), false,

--- a/llvm/test/Instrumentation/MemorySanitizer/ptrtoaddr.ll
+++ b/llvm/test/Instrumentation/MemorySanitizer/ptrtoaddr.ll
@@ -1,0 +1,14 @@
+; RUN: opt < %s -msan-check-access-address=0 -S -passes=msan 2>&1 | FileCheck %s
+
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; CHECK-LABEL: @ptrtoaddr_propagate(
+; CHECK:       %[[SHADOW:.*]] = load i64, ptr @__msan_param_tls
+; CHECK-NOT:   __msan_warning
+; CHECK:       store i64 %[[SHADOW]], ptr @__msan_retval_tls
+; CHECK:       ret i64
+define i64 @ptrtoaddr_propagate(ptr %p) sanitize_memory {
+  %addr = ptrtoaddr ptr %p to i64
+  ret i64 %addr
+}

--- a/llvm/test/Instrumentation/MemorySanitizer/ptrtoaddr.ll
+++ b/llvm/test/Instrumentation/MemorySanitizer/ptrtoaddr.ll
@@ -1,4 +1,4 @@
-; RUN: opt < %s -msan-check-access-address=0 -S -passes=msan 2>&1 | FileCheck %s
+; RUN: opt < %s -S -passes=msan 2>&1 | FileCheck %s
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"


### PR DESCRIPTION
PR #210729 changed how pointer diffs are handled, specifically when
pointer overflow isn't defined it sometimes emits CreatePtrToAddr, which
MSAN currently doesn't handle. This PR adds a visitor for PtrToAddrInst
which fixes the issue as well as a regression test.

https://github.com/llvm/llvm-project/pull/210729#issuecomment-5445402022
has my minimal reproducer.

Assisted-By: Automated tooling, human reviewed
