### PR TITLE
[ADT] Remove unused IDHash parameter from Equals (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/FoldingSet.h
+++ b/llvm/include/llvm/ADT/FoldingSet.h
@@ -126,7 +126,7 @@ template <typename T> struct DefaultFoldingSetTrait {
   // to compute a temporary ID if necessary. The default implementation
   // just calls Profile and does a regular comparison. Implementations
   // can override this to provide more efficient implementations.
-  static inline bool Equals(T &X, const FoldingSetNodeID &ID, unsigned IDHash,
+  static inline bool Equals(T &X, const FoldingSetNodeID &ID,
                             FoldingSetNodeID &TempID);
 };
 
@@ -151,7 +151,7 @@ template <typename T, typename Ctx> struct DefaultContextualFoldingSetTrait {
     X.Profile(ID, Context);
   }
 
-  static inline bool Equals(T &X, const FoldingSetNodeID &ID, unsigned IDHash,
+  static inline bool Equals(T &X, const FoldingSetNodeID &ID,
                             FoldingSetNodeID &TempID, Ctx Context);
 };
 
@@ -350,8 +350,7 @@ protected:
     /// Instantiations of the FoldingSet template implement this function to
     /// compare the given node with the given ID.
     bool (*NodeEquals)(const FoldingSetBase *Self, Node *N,
-                       const FoldingSetNodeID &ID, unsigned IDHash,
-                       FoldingSetNodeID &TempID);
+                       const FoldingSetNodeID &ID, FoldingSetNodeID &TempID);
   };
 
 private:
@@ -362,7 +361,7 @@ private:
   /// Compare \p N against \p ID. Out of line to keep FoldingSetNodeID's inline
   /// storage out of the probe loop's frame.
   static bool nodeEquals(const FoldingSetInfo &Info, const FoldingSetBase *Self,
-                         Node *N, const FoldingSetNodeID &ID, unsigned IDHash);
+                         Node *N, const FoldingSetNodeID &ID);
 
   /// Rehash into at least \p MinNumBuckets buckets, rounded up to a power of
   /// two and floored at the constructor's minimum.
@@ -400,15 +399,13 @@ template <class T> class FoldingSetIterator;
 // require the definition of FoldingSetNodeID.
 template <typename T>
 inline bool DefaultFoldingSetTrait<T>::Equals(T &X, const FoldingSetNodeID &ID,
-                                              unsigned /*IDHash*/,
                                               FoldingSetNodeID &TempID) {
   FoldingSetTrait<T>::Profile(X, TempID);
   return TempID == ID;
 }
 template <typename T, typename Ctx>
 inline bool DefaultContextualFoldingSetTrait<T, Ctx>::Equals(
-    T &X, const FoldingSetNodeID &ID, unsigned /*IDHash*/,
-    FoldingSetNodeID &TempID, Ctx Context) {
+    T &X, const FoldingSetNodeID &ID, FoldingSetNodeID &TempID, Ctx Context) {
   ContextualFoldingSetTrait<T, Ctx>::Profile(X, TempID, Context);
   return TempID == ID;
 }
@@ -435,13 +432,12 @@ class FoldingSetImpl : public FoldingSetBase, public Trait::ContextStorage {
         },
         // NodeEquals
         [](const FoldingSetBase *Base, FoldingSetNode *N,
-           const FoldingSetNodeID &ID, unsigned IDHash,
-           FoldingSetNodeID &TempID) {
+           const FoldingSetNodeID &ID, FoldingSetNodeID &TempID) {
           if constexpr (std::is_empty_v<typename Trait::ContextStorage>)
-            return Trait::Equals(*static_cast<T *>(N), ID, IDHash, TempID);
+            return Trait::Equals(*static_cast<T *>(N), ID, TempID);
           else
             return Trait::Equals(
-                *static_cast<T *>(N), ID, IDHash, TempID,
+                *static_cast<T *>(N), ID, TempID,
                 static_cast<const FoldingSetImpl *>(Base)->getContext());
         }};
     return Info;

--- a/llvm/include/llvm/Analysis/ScalarEvolution.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolution.h
@@ -347,7 +347,7 @@ public:
 template <> struct FoldingSetTrait<SCEV> : DefaultFoldingSetTrait<SCEV> {
   static void Profile(const SCEV &X, FoldingSetNodeID &ID) { ID = X.FastID; }
 
-  static bool Equals(const SCEV &X, const FoldingSetNodeID &ID, unsigned IDHash,
+  static bool Equals(const SCEV &X, const FoldingSetNodeID &ID,
                      FoldingSetNodeID &TempID) {
     return ID == X.FastID;
   }
@@ -427,7 +427,7 @@ struct FoldingSetTrait<SCEVPredicate> : DefaultFoldingSetTrait<SCEVPredicate> {
   }
 
   static bool Equals(const SCEVPredicate &X, const FoldingSetNodeID &ID,
-                     unsigned IDHash, FoldingSetNodeID &TempID) {
+                     FoldingSetNodeID &TempID) {
     return ID == X.FastID;
   }
 };

--- a/llvm/include/llvm/CodeGen/SelectionDAG.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAG.h
@@ -129,7 +129,7 @@ template<> struct FoldingSetTrait<SDVTListNode> : DefaultFoldingSetTrait<SDVTLis
   }
 
   static bool Equals(const SDVTListNode &X, const FoldingSetNodeID &ID,
-                     unsigned IDHash, FoldingSetNodeID &TempID) {
+                     FoldingSetNodeID &TempID) {
     return ID == X.FastID;
   }
 };

--- a/llvm/lib/Support/FoldingSet.cpp
+++ b/llvm/lib/Support/FoldingSet.cpp
@@ -214,9 +214,9 @@ void FoldingSetBase::reserve(unsigned N) {
 LLVM_ATTRIBUTE_NOINLINE bool
 FoldingSetBase::nodeEquals(const FoldingSetInfo &Info,
                            const FoldingSetBase *Self, Node *N,
-                           const FoldingSetNodeID &ID, unsigned IDHash) {
+                           const FoldingSetNodeID &ID) {
   FoldingSetNodeID TempID;
-  return Info.NodeEquals(Self, N, ID, IDHash, TempID);
+  return Info.NodeEquals(Self, N, ID, TempID);
 }
 
 FoldingSetBase::Node *FoldingSetBase::FindNodeOrInsertPos(
@@ -225,8 +225,7 @@ FoldingSetBase::Node *FoldingSetBase::FindNodeOrInsertPos(
   unsigned Mask = NumBuckets - 1;
   for (unsigned I = IDHash & Mask; Buckets[I]; I = (I + 1) & Mask) {
     Node *N = static_cast<Node *>(Buckets[I]);
-    if (N->getFoldingSetHash() == IDHash &&
-        nodeEquals(Info, this, N, ID, IDHash)) {
+    if (N->getFoldingSetHash() == IDHash && nodeEquals(Info, this, N, ID)) {
       InsertPos = nullptr;
       return N;
     }


### PR DESCRIPTION
This patch removes the unused IDHash parameter from several functions.
Now that FoldingSetTrait<SDVTListNode>::Equals no longer checks IDHash,
no implementation of Equals uses this parameter.

Assisted-by: Antigravity
