### PR TITLE
[mlir] Print unit prop-dict entries by presence

### DIFF
--- a/mlir/docs/DefiningDialects/Operations.md
+++ b/mlir/docs/DefiningDialects/Operations.md
@@ -767,6 +767,9 @@ The available directives are as follows:
         on the default parser use attribute conversion instead when no
         `FieldParser` specialization is available or when the selected
         specialization declares `isKeyValueCompositional = false`.
+        `UnitAttr` and `UnitProp` entries use a presence-only `<key>` spelling
+        and are omitted when absent. The parser also accepts `<key = unit>` for
+        compatibility.
     -   The legacy `<{key = attribute, ...}>` dictionary spelling is also
         accepted when parsing. The generated printer uses the key-value
         spelling and the same custom-printer or attribute-conversion choice.

--- a/mlir/test/IR/properties.mlir
+++ b/mlir/test/IR/properties.mlir
@@ -50,10 +50,23 @@ test.with_custom_prop_dict <optional = "set", defaulted = 43, prop = 6, attr = 5
 
 // A field name that is also the start of an attribute must not be consumed by
 // the legacy DictionaryAttr compatibility probe.
-// CHECK: test.with_custom_prop_dict <prop = 8, unit = unit, attr = 7>
+// CHECK: test.with_custom_prop_dict <prop = 8, unit, attr = 7>
 // GENERIC: "test.with_custom_prop_dict"()
 // GENERIC-SAME: <{attr = 7 : i32, defaulted = 42 : i64, prop = 8 : i64, unit}>
-test.with_custom_prop_dict <unit = unit, attr = 7, prop = 8>
+test.with_custom_prop_dict <unit, attr = 7, prop = 8>
+
+// UnitAttr entries use the same presence-only spelling as attribute
+// dictionaries. The explicit value spelling remains accepted and is
+// canonicalized by the printer.
+// CHECK: test.with_custom_prop_dict <prop = 10, attr = 9, unit_attr>
+// GENERIC: "test.with_custom_prop_dict"()
+// GENERIC-SAME: <{attr = 9 : i32, defaulted = 42 : i64, prop = 10 : i64, unit = false, unit_attr}>
+test.with_custom_prop_dict <unit_attr, attr = 9, prop = 10>
+
+// CHECK: test.with_custom_prop_dict <prop = 12, unit, attr = 11, unit_attr>
+// GENERIC: "test.with_custom_prop_dict"()
+// GENERIC-SAME: <{attr = 11 : i32, defaulted = 42 : i64, prop = 12 : i64, unit, unit_attr}>
+test.with_custom_prop_dict <attr = 11, unit_attr = unit, unit = unit, prop = 12>
 
 // Inherent attributes use their custom assembly printer in the key-value
 // spelling. Optional enum attributes compile and are omitted when absent.

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -3677,7 +3677,8 @@ def TestOpWithCustomPropDict : TEST_Op<"with_custom_prop_dict"> {
     I64Prop:$prop,
     DefaultValuedProp<I64Prop, "42">:$defaulted,
     OptionalAttr<StrAttr>:$optional,
-    UnitProp:$unit
+    UnitProp:$unit,
+    UnitAttr:$unit_attr
   );
 }
 

--- a/mlir/test/mlir-tblgen/op-format-custom-properties-printer.td
+++ b/mlir/test/mlir-tblgen/op-format-custom-properties-printer.td
@@ -25,7 +25,7 @@ def CustomPropertiesPrinterOp : Op<TestDialect, "custom_properties_printer"> {
 // Absent default-valued attributes are not printed from property storage.
 // CHECK: void DefaultValuedAttrOp::_odsPrintPropertiesAsKeyValueList
 // CHECK: if (shouldPrint("attr") && prop.attr) {
-// CHECK-NEXT: printKey("attr");
+// CHECK-NEXT: printKey("attr", /*printValue=*/true);
 def DefaultValuedAttrOp : Op<TestDialect, "default_valued_attr"> {
   let arguments = (ins DefaultValuedAttr<I64Attr, "0">:$attr);
   let assemblyFormat = "prop-dict attr-dict";

--- a/mlir/test/mlir-tblgen/op-format.mlir
+++ b/mlir/test/mlir-tblgen/op-format.mlir
@@ -534,7 +534,7 @@ test.format_optional_operand_type(%i64) : i64
 // CHECK: test.with_properties_and_attr 16 <rhs = 16>
 test.with_properties_and_attr 16 <{rhs = 16 : i64}>
 
-// CHECK: test.with_properties_and_inferred_type 16 <rhs = 16, packed = unit>
+// CHECK: test.with_properties_and_inferred_type 16 <rhs = 16, packed>
 %should_be_i32 = test.with_properties_and_inferred_type 16 <{packed, rhs = 16 : i64}>
 // Assert through the verifier that its inferred as i32.
 test.format_all_types_match_var %should_be_i32, %i32 : i32

--- a/mlir/tools/mlir-tblgen/OpFormatGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpFormatGen.cpp
@@ -1503,6 +1503,12 @@ return ::mlir::success();
 
 /// Generate the parser for the key-value spelling of `prop-dict`. The generic
 /// DictionaryAttr spelling remains supported as a compatibility path.
+static bool isPresenceOnlyUnitProp(const Property &property) {
+  StringRef propertyDefName = property.getBaseProperty().getPropertyDefName();
+  return (propertyDefName == "UnitProp" || propertyDefName == "UnitProperty") &&
+         property.getDefaultValue() == "false";
+}
+
 static void genKeyValuePropDictParser(OperationFormat &fmt, Operator &op,
                                       OpClass &opClass) {
   if (!fmt.hasPropDict || !fmt.useProperties)
@@ -1572,9 +1578,29 @@ if (succeeded(parser.parseOptionalLess())) {
   while (!reachedEnd) {
     ::llvm::SMLoc keyLoc = parser.getCurrentLocation();
     ::llvm::StringRef key;
-    if (parser.parseKeyword(&key) || parser.parseEqual())
+    if (parser.parseKeyword(&key))
       return ::mlir::failure();
 )decl";
+
+  SmallVector<StringRef> unitKeys;
+  for (const NamedProperty &property : op.getProperties())
+    if (shouldParseProperty(property) && isPresenceOnlyUnitProp(property.prop))
+      unitKeys.push_back(property.name);
+  for (const NamedAttribute &attribute : op.getAttributes())
+    if (shouldParseAttribute(attribute) &&
+        attribute.attr.getBaseAttr().getAttrDefName() == "UnitAttr")
+      unitKeys.push_back(attribute.name);
+
+  if (unitKeys.empty()) {
+    body << "    if (parser.parseEqual())\n";
+  } else {
+    body << "    bool isUnitKey = ";
+    for (auto [index, key] : llvm::enumerate(unitKeys))
+      body << (index == 0 ? "" : " || ") << "key == \"" << key << "\"";
+    body << ";\n"
+         << "    if (!isUnitKey && parser.parseEqual())\n";
+  }
+  body << "      return ::mlir::failure();\n";
 
   bool isFirst = true;
   FmtContext attrTypeCtx;
@@ -1616,10 +1642,19 @@ if (succeeded(parser.parseOptionalLess())) {
   for (const NamedProperty &property : op.getProperties()) {
     if (!shouldParseProperty(property))
       continue;
+    bool isUnitProp = isPresenceOnlyUnitProp(property.prop);
     body << (isFirst ? "    if" : "    else if") << " (!seen_" << property.name
          << " && key == \"" << property.name << "\") {\n"
          << "      seen_" << property.name << " = true;\n";
-    if (!property.prop.usesDefaultParser()) {
+    if (isUnitProp) {
+      PropertyVariable propertyVariable(&property);
+      body << "      if (succeeded(parser.parseOptionalEqual())) {\n";
+      genPropertyParser(&propertyVariable, body.indent().indent(),
+                        fmt.opCppClassName);
+      body.unindent() << "      } else {\n"
+                      << "        prop." << property.name << " = true;\n"
+                      << "      }\n";
+    } else if (!property.prop.usesDefaultParser()) {
       PropertyVariable propertyVariable(&property);
       genPropertyParser(&propertyVariable, body.indent(), fmt.opCppClassName);
     } else {
@@ -1651,15 +1686,30 @@ auto parseResult = ::mlir::detail::parsePropertyWithFallback(
   for (const NamedAttribute &attribute : op.getAttributes()) {
     if (!shouldParseAttribute(attribute))
       continue;
+    AttributeVariable attributeVariable(&attribute);
+    bool isUnitAttr =
+        attribute.attr.getBaseAttr().getAttrDefName() == "UnitAttr";
     body << (isFirst ? "    if" : "    else if") << " (!seen_" << attribute.name
          << " && key == \"" << attribute.name << "\") {\n"
-         << "      seen_" << attribute.name << " = true;\n"
-         << "      " << attribute.attr.getStorageType() << " " << attribute.name
-         << "Attr;\n";
-    AttributeVariable attributeVariable(&attribute);
-    genAttrParser(&attributeVariable, body.indent(), attrTypeCtx,
-                  /*parseAsOptional=*/false, /*useProperties=*/true,
-                  fmt.opCppClassName);
+         << "      seen_" << attribute.name << " = true;\n";
+    if (isUnitAttr) {
+      body << "      if (succeeded(parser.parseOptionalEqual())) {\n"
+           << "        " << attribute.attr.getStorageType() << " "
+           << attribute.name << "Attr;\n";
+      genAttrParser(&attributeVariable, body.indent().indent(), attrTypeCtx,
+                    /*parseAsOptional=*/false, /*useProperties=*/true,
+                    fmt.opCppClassName);
+      body.unindent() << "      } else {\n"
+                      << "        prop." << attribute.name
+                      << " = parser.getBuilder().getUnitAttr();\n"
+                      << "      }\n";
+    } else {
+      body << "      " << attribute.attr.getStorageType() << " "
+           << attribute.name << "Attr;\n";
+      genAttrParser(&attributeVariable, body.indent(), attrTypeCtx,
+                    /*parseAsOptional=*/false, /*useProperties=*/true,
+                    fmt.opCppClassName);
+    }
     body.unindent() << "    }\n";
     isFirst = false;
   }
@@ -2431,8 +2481,10 @@ static void genKeyValuePropDictPrinter(OperationFormat &fmt, Operator &op,
 
   body << R"decl(
 bool first = true;
-auto printKey = [&](::llvm::StringRef name) {
-  _odsPrinter << (first ? " <" : ", ") << name << " = ";
+auto printKey = [&](::llvm::StringRef name, bool printValue) {
+  _odsPrinter << (first ? " <" : ", ") << name;
+  if (printValue)
+    _odsPrinter << " = ";
   first = false;
 };
 auto shouldPrint = [&](::llvm::StringRef name) {
@@ -2442,7 +2494,7 @@ auto shouldPrint = [&](::llvm::StringRef name) {
 
   auto genSegmentSizesPrinter = [&](StringRef name) {
     body << "if (shouldPrint(\"" << name << "\")) {\n"
-         << "  printKey(\"" << name << "\");\n"
+         << "  printKey(\"" << name << "\", /*printValue=*/true);\n"
          << "  _odsPrinter << \"[\";\n"
          << "  ::llvm::interleaveComma(prop." << name << ", _odsPrinter);\n"
          << "  _odsPrinter << \"]\";\n"
@@ -2457,13 +2509,17 @@ auto shouldPrint = [&](::llvm::StringRef name) {
 
   for (const NamedProperty &namedProperty : op.getProperties()) {
     const Property &property = namedProperty.prop;
+    bool isUnitProp = isPresenceOnlyUnitProp(property);
     body << "if (shouldPrint(\"" << namedProperty.name << "\")) {\n"
-         << "  printKey(\"" << namedProperty.name << "\");\n";
+         << "  printKey(\"" << namedProperty.name << "\", /*printValue=*/"
+         << (isUnitProp ? "false" : "true") << ");\n";
     FmtContext printerContext;
     printerContext.addSubst("_printer", "_odsPrinter");
     printerContext.addSubst("_ctxt", "_odsContext");
     printerContext.addSubst("_storage", "prop." + namedProperty.name);
-    if (property.usesDefaultParser()) {
+    if (isUnitProp) {
+      // Unit properties are represented by the presence of their key.
+    } else if (property.usesDefaultParser()) {
       body << "  if constexpr (::mlir::detail::HasKeyValueFieldParser<"
               "std::remove_cv_t<std::remove_reference_t<decltype(prop."
            << namedProperty.name << ")>>>::value) {\n"
@@ -2490,13 +2546,19 @@ auto shouldPrint = [&](::llvm::StringRef name) {
     if (namedAttr.attr.isDerivedAttr())
       continue;
     StringRef name = namedAttr.name;
+    AttributeVariable attrVariable(&namedAttr);
+    bool isUnitAttr =
+        namedAttr.attr.getBaseAttr().getAttrDefName() == "UnitAttr";
     body << "if (shouldPrint(\"" << name << "\")";
     if (namedAttr.attr.isOptional() || namedAttr.attr.hasDefaultValue())
       body << " && prop." << name;
     body << ") {\n"
-         << "  printKey(\"" << name << "\");\n";
+         << "  printKey(\"" << name << "\", /*printValue=*/"
+         << (isUnitAttr ? "false" : "true") << ");\n";
 
-    if (canFormatEnumAttr(&namedAttr)) {
+    if (isUnitAttr) {
+      // Unit attributes are represented by the presence of their key.
+    } else if (canFormatEnumAttr(&namedAttr)) {
       FmtContext conversionContext;
       conversionContext.withSelf("prop." + name);
       std::string valueExpression = std::string(tgfmt(
@@ -2506,7 +2568,6 @@ auto shouldPrint = [&](::llvm::StringRef name) {
       body << "  _odsPrinter.printSymbolName(prop." << name
            << ".getValue());\n";
     } else {
-      AttributeVariable attrVariable(&namedAttr);
       if (attrVariable.getTypeBuilder())
         body << "  _odsPrinter.printAttributeWithoutType(prop." << name
              << ");\n";


### PR DESCRIPTION
Teach generated prop-dict parsers and printers to use a bare key for `UnitAttr` and false-default `UnitProp` entries while retaining the explicit value spelling for compatibility.

Assisted-by: Codex