### PR TITLE
[clang] don't look for the current instantiation in a non-dependent class

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -578,6 +578,11 @@ features cannot lower the translation-unit ABI level;
   in a token that was lexed and cached before the first occurrence was parsed.
   (#GH214128)
 
+- Fixed an assertion when looking up a name in a dependent type whose canonical
+  type is a class that does not depend on any template parameter, such as
+  ``__typeof(e)`` where ``e`` merely involves a template parameter (e.g.
+  ``__typeof(f(sizeof(T))) a = f(0); a.member;``). (#GH207483)
+
 #### Bug Fixes to AST Handling
 
 - Fixed a non-deterministic ordering of unused local typedefs that made

--- a/clang/lib/Sema/SemaCXXScopeSpec.cpp
+++ b/clang/lib/Sema/SemaCXXScopeSpec.cpp
@@ -34,7 +34,7 @@ static CXXRecordDecl *getCurrentInstantiationOf(QualType T,
     return nullptr;
   auto *RD = cast<CXXRecordDecl>(TagTy->getDecl())->getDefinitionOrSelf();
   if (isa<InjectedClassNameType>(TagTy) ||
-      RD->isCurrentInstantiation(CurContext))
+      (RD->isDependentContext() && RD->isCurrentInstantiation(CurContext)))
     return RD;
   return nullptr;
 }

--- a/clang/test/SemaCXX/cxx2c-pack-indexing.cpp
+++ b/clang/test/SemaCXX/cxx2c-pack-indexing.cpp
@@ -378,3 +378,14 @@ int test(){
 
 }
 }
+
+namespace GH207483 {
+struct S;
+// The recovery type for this invalid pack index is dependent, but canonicalizes
+// to the non-dependent class 'S', which is not a current instantiation.
+template <template <typename> typename T> void foo() { S...[0] ::bar; } // expected-error {{'S' does not refer to the name of a parameter pack}}
+
+template <typename T> struct U;
+
+void baz() { foo<U>(); }
+}

--- a/clang/test/SemaTemplate/current-instantiation.cpp
+++ b/clang/test/SemaTemplate/current-instantiation.cpp
@@ -247,3 +247,25 @@ namespace RebuildDependentScopeDeclRefExpr {
   // FIXME: We should issue a typo-correction here.
   template<typename T> N<X<T>::think> X<T>::foo() {} // expected-error {{no member named 'think' in 'RebuildDependentScopeDeclRefExpr::X<T>'}}
 }
+
+namespace GH207483 {
+  struct A { int value() const; };
+  A f(unsigned);
+
+  // '__typeof(e)' is treated as dependent whenever 'e' involves a template
+  // parameter, but it still canonicalizes to the type of 'e'. So this is a
+  // dependent type whose canonical type is the non-dependent class 'A', which
+  // is not a current instantiation.
+  template<typename T> struct B {
+    int g() {
+      __typeof(f(sizeof(T))) a = f(0);
+      return a.value();
+    }
+    int h() {
+      __typeof(f(sizeof(T))) a = f(0);
+      return a.nope(); // expected-error {{no member named 'nope' in 'GH207483::A'}}
+    }
+  };
+
+  int i() { return B<int>().g() + B<int>().h(); } // expected-note {{in instantiation of member function 'GH207483::B<int>::h' requested here}}
+}


### PR DESCRIPTION
When a dependent type canonicalizes to a `RecordType`, `computeDeclContext()` calls `CXXRecordDecl::isCurrentInstantiation()`, which asserts `isDependentContext()`.  That assumption does not always hold: `__typeof(e)` canonicalizes to the type of `e` as soon as `e` is not type-dependent, but its dependence bits are derived from the full expression dependence, so a value-dependent operand still marks it dependent:
```
  struct Opt { int value() const; };
  Opt g(unsigned);
  template <class T> struct S {
    void f() {
      __typeof(g(sizeof(T))) r = g(0);  // dependent, canonically 'Opt'
      r.value();                        // assertion
    }
  };
```
`Opt` is not a dependent context, so the assertion fires. The recovery type of an invalid pack index hits this the same way, since it canonicalizes to the named class.

This prevents the assertion by only checking whether a class is the current instantiation when it is a dependent context.

Fixes #207483

rdar://184775733