### PR TITLE
workflow/release-binaries: Hard-code Wix install path

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -287,7 +287,7 @@ jobs:
       run: |
         choco install wixtoolset --version 3.14.1.20250415
         # Add wix install directory to PATH.
-        Split-Path (Get-ChildItem -Path "C:\" -Filter candle.exe -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1).FullName >> $env:GITHUB_PATH
+        echo "C:\Program Files (x86)\WiX Toolset v3.14\bin" >> $env:GITHUB_PATH
 
     - name: Build Windows
       id: build-windows

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -287,9 +287,9 @@ jobs:
         WIX_VERSION: 3.14
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       run: |
-        choco install wixtoolset --version $env:WIX_VERSION.1.20250415
+        choco install wixtoolset --version $($env:WIX_VERSION).1.20250415
         # Add wix install directory to PATH.
-        echo "C:\Program Files (x86)\WiX Toolset v$env:WIX_VERSION\bin" >> $env:GITHUB_PATH
+        echo "C:\Program Files (x86)\WiX Toolset v$($env:WIX_VERSION\bin)" >> $env:GITHUB_PATH
 
     - name: Build Windows
       id: build-windows

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -289,7 +289,7 @@ jobs:
       run: |
         choco install wixtoolset --version $($env:WIX_VERSION).1.20250415
         # Add wix install directory to PATH.
-        echo "C:\Program Files (x86)\WiX Toolset v$($env:WIX_VERSION\bin)" >> $env:GITHUB_PATH
+        echo "C:\Program Files (x86)\WiX Toolset v$($env:WIX_VERSION)\bin" >> $env:GITHUB_PATH
 
     - name: Build Windows
       id: build-windows

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -287,7 +287,7 @@ jobs:
         WIX_VERSION: 3.14
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       run: |
-        choco install wixtoolset --version $($env:WIX_VERSION).1.20250415
+        choco install wixtoolset --version "$($env:WIX_VERSION).1.20250415"
         # Add wix install directory to PATH.
         echo "C:\Program Files (x86)\WiX Toolset v$($env:WIX_VERSION)\bin" >> $env:GITHUB_PATH
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -283,11 +283,13 @@ jobs:
 
     # Wix is not installed by default on Windows ARM64
     - name: Install Wix (Windows ARM64)
+      env:
+        WIX_VERSION: 3.14
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       run: |
-        choco install wixtoolset --version 3.14.1.20250415
+        choco install wixtoolset --version $env:WIX_VERSION.1.20250415
         # Add wix install directory to PATH.
-        echo "C:\Program Files (x86)\WiX Toolset v3.14\bin" >> $env:GITHUB_PATH
+        echo "C:\Program Files (x86)\WiX Toolset v$env:WIX_VERSION\bin" >> $env:GITHUB_PATH
 
     - name: Build Windows
       id: build-windows


### PR DESCRIPTION
Searching for the candle.exe executable is very slow and we know the install path will always be the same since we have version pinned the install.