### PR TITLE
[flang][Parser][NFC] Don't build a discarded list while scanning identifiers

### DIFF
--- a/flang/lib/Parser/Fortran-parsers.cpp
+++ b/flang/lib/Parser/Fortran-parsers.cpp
@@ -44,7 +44,7 @@ namespace Fortran::parser {
 // R601 alphanumeric-character -> letter | digit | underscore
 // R603 name -> letter [alphanumeric-character]...
 constexpr auto nonDigitIdChar{letter || otherIdChar};
-constexpr auto rawName{nonDigitIdChar >> many(nonDigitIdChar || digit)};
+constexpr auto rawName{nonDigitIdChar >> skipMany(nonDigitIdChar || digit)};
 TYPE_PARSER(space >> sourced(rawName >> construct<Name>()))
 
 // R608 intrinsic-operator ->


### PR DESCRIPTION
```c++
constexpr auto rawName{nonDigitIdChar >> many(nonDigitIdChar || digit)};
TYPE_PARSER(space >> sourced(rawName >> construct<Name>()))
```

`many()` has resultType `std::list<const char *>`, so scanning an
identifier heap-allocates one node per character after the first -- the
leading `nonDigitIdChar` is outside `many()`. The `>>` operator discards
its left operand's value, so that list is destroyed unread; `sourced()`
recovers the text from the cursor span instead. Backtracking rescans
identifiers, so CloverLeaf_Serial (401KB) does 3.9M unnecessary
allocations.

Fix: use `skipMany`, documented as "equivalent to many(x) but with no
result", with the same `BacktrackingParser` wrapper. -0.88%
instructions:u; emitted code byte-identical with CloverLeaf_Serial.