### PR TITLE
[lldb] When a user re-enables a disabled watchpoint, reset values

### DIFF
--- a/lldb/include/lldb/Breakpoint/Watchpoint.h
+++ b/lldb/include/lldb/Breakpoint/Watchpoint.h
@@ -65,9 +65,21 @@ public:
 
   bool IsEnabled() const;
 
-  // This doesn't really enable/disable the watchpoint.   It is currently just
-  // for use in the Process plugin's {Enable,Disable}Watchpoint, which should
-  // be used instead.
+  // Enable or disable this watchpoint.
+  // Most callers should use Process::EnableWatchpoint/DisableWatchpoint.
+  //
+  // If a disabled watchpoint is being re-enabled, we may need to
+  // read the contents of the watched memory range to a local buffer
+  // at this point.
+  //
+  // \param[in] enabled
+  //     Whether to enable or disable this watchpoint.
+  //
+  // \param[in] notify
+  //     When this is is reflecting a user command, notify should be true.
+  //     To handle watchpoints on some targets, we need to disable the wp,
+  //     instruction-step, re-enable the wp (all private stops).  These
+  //     private stop enable/disablings are notify false.
   void SetEnabled(bool enabled, bool notify = true);
 
   bool IsHardware() const override;

--- a/lldb/source/Breakpoint/Watchpoint.cpp
+++ b/lldb/source/Breakpoint/Watchpoint.cpp
@@ -421,6 +421,17 @@ void Watchpoint::SetEnabled(bool enabled, bool notify) {
   }
   bool changed = enabled != m_enabled;
   m_enabled = enabled;
+  // Update the current value, if this is a user enabling
+  // a watchpoint that was disabled.
+  // (lldb will disable and re-enable watchpoints as we step over
+  // the accesses, those will have notify==false)
+  if (notify && changed && enabled && m_target.GetProcessSP()) {
+    m_old_value_sp.reset();
+    m_new_value_sp.reset();
+    ExecutionContext exe_ctx;
+    m_target.GetProcessSP()->CalculateExecutionContext(exe_ctx);
+    CaptureWatchedValue(exe_ctx);
+  }
   if (notify && !m_is_ephemeral && changed)
     SendWatchpointChangedEvent(enabled ? eWatchpointEventTypeEnabled
                                        : eWatchpointEventTypeDisabled);

--- a/lldb/source/Target/StopInfo.cpp
+++ b/lldb/source/Target/StopInfo.cpp
@@ -890,7 +890,7 @@ protected:
       if (!m_did_disable_wp)
         return;
       m_did_disable_wp = true;
-      GetThread().GetProcess()->EnableWatchpoint(m_watch_sp, true);
+      GetThread().GetProcess()->EnableWatchpoint(m_watch_sp, /*notify=*/false);
     }
 
   private:

--- a/lldb/test/API/functionalities/watchpoint/re-enable-watchpoint/Makefile
+++ b/lldb/test/API/functionalities/watchpoint/re-enable-watchpoint/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/watchpoint/re-enable-watchpoint/TestReEnableWatchpoint.py
+++ b/lldb/test/API/functionalities/watchpoint/re-enable-watchpoint/TestReEnableWatchpoint.py
@@ -1,0 +1,92 @@
+"""
+Test that a watchpoint refreshes its "current value"
+when re-enabled.
+"""
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class ReEnableWatchpointTestCase(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def continue_and_report_stop_reason(self, process, iter_str):
+        process.Continue()
+        self.assertIn(
+            process.GetState(), [lldb.eStateStopped, lldb.eStateExited], iter_str
+        )
+        thread = process.GetSelectedThread()
+        return thread.GetStopReason()
+
+    def test_reenable_watchpoint(self):
+        """Test that re-enabling a watchpoint updates its saved value."""
+        self.build()
+        src = lldb.SBFileSpec("main.c")
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "break", src
+        )
+
+        #
+        # Variable c has value 0.
+        # Add watchpoint, check that it has cached value 0.
+        #
+        frame = thread.GetFrameAtIndex(0)
+        self.assertEqual(frame.GetValueForVariablePath("c").GetValueAsUnsigned(), 0)
+
+        interp = self.dbg.GetCommandInterpreter()
+        result = lldb.SBCommandReturnObject()
+        interp.HandleCommand("watch set variable c", result)
+        self.assertTrue(result.Succeeded(), "watch set ran successfully")
+        results = result.GetOutput()
+        self.assertIn("new value: 0", results)
+
+        #
+        # We've hit the watchpoint, confirm c has value 1 now.
+        #
+        reason = self.continue_and_report_stop_reason(
+            process, "continue to first watchpoint"
+        )
+        self.assertEqual(reason, lldb.eStopReasonWatchpoint)
+        self.assertEqual(frame.GetValueForVariablePath("c").GetValueAsUnsigned(), 1)
+
+        self.runCmd("watch disable 1")
+
+        # Continue to second breakpoint.
+        # Confirm variable c has value 3.
+        reason = self.continue_and_report_stop_reason(
+            process, "continue to second breakpoint"
+        )
+        self.assertEqual(reason, lldb.eStopReasonBreakpoint)
+        self.assertEqual(frame.GetValueForVariablePath("c").GetValueAsUnsigned(), 3)
+
+        #
+        # Re-enable watchpoint.
+        # Confirm watchpoint has cached value 3.
+        #
+        self.runCmd("watch enable 1")
+
+        result = lldb.SBCommandReturnObject()
+        interp.HandleCommand("watch list", result)
+        self.assertTrue(result.Succeeded(), "watch list ran successfully")
+        results = result.GetOutput()
+        self.assertNotIn("old value", results)
+        self.assertIn("new value: 3", results)
+
+        #
+        # Resume execution and expect to hit the watchpoint.
+        # Variable c now has value 4.
+        #
+        reason = self.continue_and_report_stop_reason(
+            process, "continue to second watchpoint"
+        )
+        self.assertEqual(reason, lldb.eStopReasonWatchpoint)
+        self.assertEqual(frame.GetValueForVariablePath("c").GetValueAsUnsigned(), 4)
+
+        result = lldb.SBCommandReturnObject()
+        interp.HandleCommand("watch list", result)
+        self.assertTrue(result.Succeeded(), "watch list ran successfully")
+        results = result.GetOutput()
+        self.assertIn("old value: 3", results)
+        self.assertIn("new value: 4", results)

--- a/lldb/test/API/functionalities/watchpoint/re-enable-watchpoint/main.c
+++ b/lldb/test/API/functionalities/watchpoint/re-enable-watchpoint/main.c
@@ -1,0 +1,11 @@
+int main() {
+  int c = 0;
+  c++; // break here 1
+  c++;
+  c++;
+  c++; // break here 2
+  c++;
+  c++;
+  c++;
+  return c;
+}


### PR DESCRIPTION
A watchpoint stores the current value of the byte range being watched, so it can show the old-versus-new values when a watchpoint exception is received.

If a watchpoint is disabled by the user, we do more execution, and then the user re-enables that watchpoint, the most recently saved value may be out of date.  So when we next hit the watchpoint event, we will show an old/new value that doesn't actually reflect the change of the latest instruction.

In Watchpoint::SetEnabled, when we see a disabled watchpoint being enabled, by a user (notify==true), release any values currently being held and re-fetch the current value for the Watchpoint.

Watchpoints are disabled & re-enabled when we instruction step over the excepting instruction (on AArch64 et al where watchpoint exceptions are received "before" the instruction executes).  Those calls to Enable are done with notify==false, except for one incorrectly doing that from StopInfoWatchpoint.  This would lead to a broadcast event about watchpoint state changing, while handling a private stop, and was incorrect.

Added a testcase.

rdar://184927603