### PR TITLE
[LoopSink] Do not sink instructions with side effects

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopSink.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopSink.cpp
@@ -341,6 +341,11 @@ static bool sinkLoopInvariantInstructions(Loop &L, AAResults &AA, LoopInfo &LI,
     // No need to check for instruction's operands are loop invariant.
     assert(L.hasLoopInvariantOperands(&I) &&
            "Insts in a loop's preheader should have loop invariant operands!");
+    // Sinking into a loop may change how many times an instruction executes.
+    // Do not move instructions with observable side effects from the
+    // preheader, where they execute exactly once, into the loop.
+    if (I.mayHaveSideEffects())
+      continue;
     if (!canSinkOrHoistInst(I, &AA, &DT, &L, MSSAU, false, LICMFlags))
       continue;
     if (sinkInstruction(L, I, ColdLoopBBs, LoopBlockNumber, LI, DT, BFI,

--- a/llvm/test/Transforms/LICM/loopsink-writeonly-call.ll
+++ b/llvm/test/Transforms/LICM/loopsink-writeonly-call.ll
@@ -25,7 +25,7 @@ exit:
   ret void
 }
 
-declare i32 @write() nounwind memory(write)
+declare i32 @write() nounwind willreturn memory(write)
 
 ; A call without willreturn cannot move to a path that may not execute.
 ;

--- a/llvm/test/Transforms/LICM/loopsink-writeonly-call.ll
+++ b/llvm/test/Transforms/LICM/loopsink-writeonly-call.ll
@@ -1,0 +1,82 @@
+; RUN: opt -S -verify-memoryssa -passes=loop-sink < %s | FileCheck %s
+
+; A call that writes memory is observable even when its return value is only
+; used on a cold path through the loop. It must not be sunk from the preheader.
+;
+; CHECK-LABEL: define void @writeonly_call(
+; CHECK:       entry:
+; CHECK-NEXT:    [[VALUE:%.*]] = call i32 @write()
+; CHECK-NEXT:    br label %loop
+; CHECK:       cold:
+; CHECK-NOT:     call i32 @write()
+define void @writeonly_call(i1 %condition) !prof !0 {
+entry:
+  %value = call i32 @write()
+  br label %loop
+
+loop:
+  br i1 %condition, label %cold, label %exit, !prof !1
+
+cold:
+  %unused = icmp eq i32 %value, 0
+  br label %loop
+
+exit:
+  ret void
+}
+
+declare i32 @write() nounwind memory(write)
+
+; A call without willreturn cannot move to a path that may not execute.
+;
+; CHECK-LABEL: define void @call_without_willreturn(
+; CHECK:       entry:
+; CHECK-NEXT:    [[VALUE:%.*]] = call i32 @may_not_return()
+; CHECK-NEXT:    br label %loop
+; CHECK:       cold:
+; CHECK-NOT:     call i32 @may_not_return()
+define void @call_without_willreturn(i1 %condition) !prof !0 {
+entry:
+  %value = call i32 @may_not_return()
+  br label %loop
+
+loop:
+  br i1 %condition, label %cold, label %exit, !prof !1
+
+cold:
+  %unused = icmp eq i32 %value, 0
+  br label %loop
+
+exit:
+  ret void
+}
+
+declare i32 @may_not_return() nounwind memory(none)
+
+; A side-effect-free call that is guaranteed to return remains sinkable.
+;
+; CHECK-LABEL: define void @readonly_willreturn_call(
+; CHECK:       entry:
+; CHECK-NEXT:    br label %loop
+; CHECK:       cold:
+; CHECK-NEXT:    [[VALUE:%.*]] = call i32 @read()
+define void @readonly_willreturn_call(i1 %condition) !prof !0 {
+entry:
+  %value = call i32 @read()
+  br label %loop
+
+loop:
+  br i1 %condition, label %cold, label %exit, !prof !1
+
+cold:
+  %unused = icmp eq i32 %value, 0
+  br label %loop
+
+exit:
+  ret void
+}
+
+declare i32 @read() nounwind willreturn memory(read)
+
+!0 = !{!"function_entry_count", i64 1}
+!1 = !{!"branch_weights", i32 1, i32 2000}


### PR DESCRIPTION
LoopSink uses LICM's `canSinkOrHoistInst` helper to establish mechanical and aliasing legality, but moving an instruction from the preheader into a cold loop block can change its execution count from once to zero or many times. A write-only call can pass the helper when the loop has no conflicting accesses, causing observable wrong code under profile-guided builds.

Reject instructions with observable side effects before consulting the helper. `Instruction::mayHaveSideEffects()` covers memory writes, unwinding, and calls that may not return, while side-effect-free `willreturn` calls remain eligible for sinking.

The regression test covers a write-only call and a call that may not return, with a read-only `willreturn` call as a positive control.

Fixes #213025.

## Tool use

Per the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html): AI tools were involved throughout the preparation of this change. I am the author and accountable for the contribution.

Assisted-by: OpenAI Codex
Assisted-by: Claude Code
Assisted-by: Kimi
Assisted-by: DeepSeek
