### PR TITLE
[mlir][OpenACC] Skip the copy-back for a scalar a kernels region only reads

### DIFF
--- a/flang/test/Transforms/OpenACC/acc-implicit-data-fortran.F90
+++ b/flang/test/Transforms/OpenACC/acc-implicit-data-fortran.F90
@@ -51,8 +51,8 @@ end program
 !CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) dataClause(acc_copy) implicit(true) name("aggrvar") -> !fir.ref<!fir.type<_QFTaggr{field:f32}>>
 !CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) implicit(true) name("arrayvar") -> !fir.ref<!fir.array<10xf32>>
 !CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.type<_QFTnested{outer:!fir.type<_QFTaggr{field:f32}>}>>) dataClause(acc_copy) implicit(true) name("nestaggrvar") -> !fir.ref<!fir.type<_QFTnested{outer:!fir.type<_QFTaggr{field:f32}>}>>
-!CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<complex<f32>>) dataClause(acc_copy) implicit(true) name("scalarcomp") -> !fir.ref<complex<f32>>
-!CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) dataClause(acc_copy) implicit(true) name("scalarvar") -> !fir.ref<f32>
+!CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<complex<f32>>) implicit(true) name("scalarcomp") -> !fir.ref<complex<f32>>
+!CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) implicit(true) name("scalarvar") -> !fir.ref<f32>
 !CHECKHLFIR: acc.kernels
 !CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}}  : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) dataClause(acc_copy) implicit(true) name("aggrvar") -> !fir.ref<!fir.type<_QFTaggr{field:f32}>>
 !CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}}  : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) implicit(true) name("arrayvar") -> !fir.ref<!fir.array<10xf32>>
@@ -63,8 +63,8 @@ end program
 
 !CHECKCSE-LABEL: @_QQmain
 !CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) implicit(true) name("arrayvar") -> !fir.ref<!fir.array<10xf32>>
-!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<complex<f32>>) dataClause(acc_copy) implicit(true) name("scalarcomp") -> !fir.ref<complex<f32>>
-!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) dataClause(acc_copy) implicit(true) name("scalarvar") -> !fir.ref<f32>
+!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<complex<f32>>) implicit(true) name("scalarcomp") -> !fir.ref<complex<f32>>
+!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) implicit(true) name("scalarvar") -> !fir.ref<f32>
 !CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) dataClause(acc_copy) implicit(true) name("aggrvar%field") -> !fir.ref<f32>
 !CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) dataClause(acc_copy) implicit(true) name("nestaggrvar%outer%field") -> !fir.ref<f32>
 !CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) dataClause(acc_copy) implicit(true) name("arrayvar(2)") -> !fir.ref<f32>

--- a/flang/test/Transforms/OpenACC/acc-implicit-data.fir
+++ b/flang/test/Transforms/OpenACC/acc-implicit-data.fir
@@ -58,6 +58,29 @@ func.func @test_fir_scalar_written_in_kernels() {
 
 // -----
 
+// A store through a pointer that may alias the target scalar has to keep the
+// copy-back - the write does not appear on the scalar's own uses.
+func.func @test_fir_target_scalar_written_through_pointer_in_kernels() {
+  %0 = fir.alloca i32 {bindc_name = "n"}
+  %n = fir.declare %0 {fortran_attrs = #fir.var_attrs<target>, uniq_name = "_QFEn"} : (!fir.ref<i32>) -> !fir.ref<i32>
+  %1 = fir.alloca !fir.box<!fir.ptr<i32>> {bindc_name = "p"}
+  %p = fir.declare %1 {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QFEp"} : (!fir.ref<!fir.box<!fir.ptr<i32>>>) -> !fir.ref<!fir.box<!fir.ptr<i32>>>
+  acc.kernels {
+    %c5 = arith.constant 5 : i32
+    %box = fir.load %p : !fir.ref<!fir.box<!fir.ptr<i32>>>
+    %addr = fir.box_addr %box : (!fir.box<!fir.ptr<i32>>) -> !fir.ptr<i32>
+    fir.store %c5 to %addr : !fir.ptr<i32>
+    %v = fir.load %n : !fir.ref<i32>
+    acc.terminator
+  }
+  return
+}
+
+// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<i32>) dataClause(acc_copy) implicit(true) name("n") -> !fir.ref<i32>
+// CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<i32>) to varPtr({{.*}} : !fir.ref<i32>) dataClause(acc_copy) implicit(true) name("n")
+
+// -----
+
 // The store goes through a fir.convert - the write still has to be seen.
 func.func @test_fir_scalar_written_through_convert_in_kernels() {
   %livein = fir.alloca f64 {bindc_name = "scalarvar"}

--- a/flang/test/Transforms/OpenACC/acc-implicit-data.fir
+++ b/flang/test/Transforms/OpenACC/acc-implicit-data.fir
@@ -37,6 +37,39 @@ func.func @test_fir_scalar_in_kernels() {
   return
 }
 
+// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<f64>) implicit(true) name("scalarvar") -> !fir.ref<f64>
+// CHECK-NOT: acc.copyout
+// CHECK: acc.delete accPtr(%[[COPYIN]] : !fir.ref<f64>) dataClause(acc_copyin) implicit(true) name("scalarvar")
+
+// -----
+
+func.func @test_fir_scalar_written_in_kernels() {
+  %livein = fir.alloca f64 {bindc_name = "scalarvar"}
+  acc.kernels {
+    %cst = arith.constant 1.000000e+00 : f64
+    fir.store %cst to %livein : !fir.ref<f64>
+    acc.terminator
+  }
+  return
+}
+
+// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<f64>) dataClause(acc_copy) implicit(true) name("scalarvar") -> !fir.ref<f64>
+// CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<f64>) to varPtr({{.*}} : !fir.ref<f64>) dataClause(acc_copy) implicit(true) name("scalarvar")
+
+// -----
+
+// The store goes through a fir.convert - the write still has to be seen.
+func.func @test_fir_scalar_written_through_convert_in_kernels() {
+  %livein = fir.alloca f64 {bindc_name = "scalarvar"}
+  acc.kernels {
+    %cst = arith.constant 1.000000e+00 : f64
+    %ptr = fir.convert %livein : (!fir.ref<f64>) -> !fir.ptr<f64>
+    fir.store %cst to %ptr : !fir.ptr<f64>
+    acc.terminator
+  }
+  return
+}
+
 // CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<f64>) dataClause(acc_copy) implicit(true) name("scalarvar") -> !fir.ref<f64>
 // CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<f64>) to varPtr({{.*}} : !fir.ref<f64>) dataClause(acc_copy) implicit(true) name("scalarvar")
 
@@ -202,8 +235,9 @@ func.func @test_fir_scalar_in_kernels_defaultpresent() {
   return
 }
 
-// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<f64>) dataClause(acc_copy) implicit(true) name("scalarvar") -> !fir.ref<f64>
-// CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<f64>) to varPtr({{.*}} : !fir.ref<f64>) dataClause(acc_copy) implicit(true) name("scalarvar")
+// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<f64>) implicit(true) name("scalarvar") -> !fir.ref<f64>
+// CHECK-NOT: acc.copyout
+// CHECK: acc.delete accPtr(%[[COPYIN]] : !fir.ref<f64>) dataClause(acc_copyin) implicit(true) name("scalarvar")
 
 // -----
 

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCImplicitData.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCImplicitData.cpp
@@ -208,13 +208,11 @@
 #include "mlir/IR/Dominance.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/Value.h"
-#include "mlir/Interfaces/CastInterfaces.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Transforms/RegionUtils.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -427,38 +425,21 @@ void ACCImplicitData::generateRecipes(ModuleOp &module, OpBuilder &builder,
   }
 }
 
-/// Returns true when no operation in `region` can write to `var`. Views and
-/// casts of the variable are followed; a user whose effect on it cannot be
-/// established is treated as a write.
-static bool isNeverWrittenInRegion(Value var, Region &region) {
-  SmallVector<Value> worklist{var};
-  llvm::SmallPtrSet<Value, 8> visited;
-  while (!worklist.empty()) {
-    Value val = worklist.pop_back_val();
-    if (!visited.insert(val).second)
-      continue;
-    for (Operation *user : val.getUsers()) {
-      if (!region.isAncestor(user->getParentRegion()))
-        continue;
-      if (isa<ViewLikeOpInterface, CastOpInterface>(user)) {
-        worklist.append(user->result_begin(), user->result_end());
-        continue;
-      }
-      auto memInterface = dyn_cast<MemoryEffectOpInterface>(user);
-      if (!memInterface)
-        return false;
-      SmallVector<MemoryEffects::EffectInstance> effects;
-      memInterface.getEffectsOnValue(val, effects);
-      if (effects.empty())
-        return false;
-      if (llvm::any_of(effects, [](const MemoryEffects::EffectInstance &e) {
-            return isa<MemoryEffects::Write, MemoryEffects::Free>(
-                e.getEffect());
-          }))
-        return false;
-    }
-  }
-  return true;
+/// Returns true when no operation in `region` can write to `var`. Ops with
+/// nested effects are skipped because the walk visits their bodies. Alias
+/// analysis answers ModRef when it cannot tell, so a write reaching `var`
+/// through an alias keeps the copy.
+static bool isNeverWrittenInRegion(Value var, Region &region,
+                                   AliasAnalysis &aliasAnalysis) {
+  return !region
+              .walk([&](Operation *op) {
+                if (op->hasTrait<OpTrait::HasRecursiveMemoryEffects>())
+                  return WalkResult::advance();
+                return aliasAnalysis.getModRef(op, var).isMod()
+                           ? WalkResult::interrupt()
+                           : WalkResult::advance();
+              })
+              .wasInterrupted();
 }
 
 // Generates the data entry data op clause so that it adheres to OpenACC
@@ -551,7 +532,8 @@ Operation *ACCImplicitData::generateDataClauseOpForCandidate(
                                 accSupport.getVariableName(var));
       // Keep the copy-back only when the region can actually write the scalar.
       // Otherwise it is an async race against the host code that follows.
-      if (!isNeverWrittenInRegion(var, computeConstructOp->getRegion(0)))
+      if (!isNeverWrittenInRegion(var, computeConstructOp->getRegion(0),
+                                  this->getAnalysis<AliasAnalysis>()))
         copyinOp.setDataClause(acc::DataClause::acc_copy);
       return copyinOp.getOperation();
     } else {

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCImplicitData.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCImplicitData.cpp
@@ -23,7 +23,8 @@
 //    - In a copy clause otherwise.
 //
 // 3. A scalar variable will be treated as if it appears in:
-//    - A copy clause if the compute construct is a kernels construct.
+//    - A copy clause if the compute construct is a kernels construct, or a
+//      copyin clause when the construct cannot write the scalar.
 //    - A firstprivate clause otherwise (parallel, serial).
 //
 // Requirements:
@@ -109,7 +110,7 @@
 //     }
 //   }
 //
-// Example 2: Scalar in kernels construct (implicit copy)
+// Example 2: Scalar only read in kernels construct (implicit copyin)
 //
 // Before:
 //   func.func @test() {
@@ -124,16 +125,14 @@
 //   func.func @test() {
 //     %scalar = memref.alloca() {acc.var_name = "n"} : memref<i32>
 //     %copyin = acc.copyin varPtr(%scalar : memref<i32>) -> memref<i32>
-//                 {dataClause = #acc<data_clause acc_copy>,
-//                  implicit = true, name = "n"}
+//                 {implicit = true, name = "n"}
 //     acc.kernels dataOperands(%copyin : memref<i32>) {
 //       %val = memref.load %copyin[] : memref<i32>
 //       acc.terminator
 //     }
-//     acc.copyout accPtr(%copyin : memref<i32>)
-//                 to varPtr(%scalar : memref<i32>)
-//                 {dataClause = #acc<data_clause acc_copy>,
-//                  implicit = true, name = "n"}
+//     acc.delete accPtr(%copyin : memref<i32>)
+//                {dataClause = #acc<data_clause acc_copyin>,
+//                 implicit = true, name = "n"}
 //   }
 //
 // Example 3: Array (aggregate) in parallel (implicit copy)
@@ -209,10 +208,13 @@
 #include "mlir/IR/Dominance.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/Value.h"
+#include "mlir/Interfaces/CastInterfaces.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Transforms/RegionUtils.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -425,6 +427,40 @@ void ACCImplicitData::generateRecipes(ModuleOp &module, OpBuilder &builder,
   }
 }
 
+/// Returns true when no operation in `region` can write to `var`. Views and
+/// casts of the variable are followed; a user whose effect on it cannot be
+/// established is treated as a write.
+static bool isNeverWrittenInRegion(Value var, Region &region) {
+  SmallVector<Value> worklist{var};
+  llvm::SmallPtrSet<Value, 8> visited;
+  while (!worklist.empty()) {
+    Value val = worklist.pop_back_val();
+    if (!visited.insert(val).second)
+      continue;
+    for (Operation *user : val.getUsers()) {
+      if (!region.isAncestor(user->getParentRegion()))
+        continue;
+      if (isa<ViewLikeOpInterface, CastOpInterface>(user)) {
+        worklist.append(user->result_begin(), user->result_end());
+        continue;
+      }
+      auto memInterface = dyn_cast<MemoryEffectOpInterface>(user);
+      if (!memInterface)
+        return false;
+      SmallVector<MemoryEffects::EffectInstance> effects;
+      memInterface.getEffectsOnValue(val, effects);
+      if (effects.empty())
+        return false;
+      if (llvm::any_of(effects, [](const MemoryEffects::EffectInstance &e) {
+            return isa<MemoryEffects::Write, MemoryEffects::Free>(
+                e.getEffect());
+          }))
+        return false;
+    }
+  }
+  return true;
+}
+
 // Generates the data entry data op clause so that it adheres to OpenACC
 // rules as follows (line numbers and specification from OpenACC 3.4):
 // 1388 An aggregate variable will be treated as if it appears either:
@@ -513,7 +549,10 @@ Operation *ACCImplicitData::generateDataClauseOpForCandidate(
           acc::CopyinOp::create(builder, loc, var,
                                 /*structured=*/true, /*implicit=*/true,
                                 accSupport.getVariableName(var));
-      copyinOp.setDataClause(acc::DataClause::acc_copy);
+      // Keep the copy-back only when the region can actually write the scalar.
+      // Otherwise it is an async race against the host code that follows.
+      if (!isNeverWrittenInRegion(var, computeConstructOp->getRegion(0)))
+        copyinOp.setDataClause(acc::DataClause::acc_copy);
       return copyinOp.getOperation();
     } else {
       // Scalars are implicit firstprivate in parallel and serial construct.
@@ -605,6 +644,8 @@ static Operation *findDataExitOp(Operation *dataEntryOp) {
 // Key ones used here:
 // * acc {construct} copy -> acc.copyin (before region) + acc.copyout (after
 // region)
+// * acc {construct} copyin -> acc.copyin (before region) + acc.delete (after
+// region)
 // * acc {construct} present -> acc.present (before region) + acc.delete
 // (after region)
 static void
@@ -626,11 +667,20 @@ generateDataExitOperations(OpBuilder &builder, Operation *accOp,
         builder.setInsertionPointAfter(dataExitOp);
     Operation *dataEntryOp = dataEntry.getDefiningOp();
     if (isa<acc::CopyinOp>(dataEntryOp)) {
-      auto copyoutOp = acc::CopyoutOp::create(
-          builder, dataEntryOp->getLoc(), dataEntry, acc::getVar(dataEntryOp),
-          /*structured=*/true, /*implicit=*/true,
-          acc::getVarName(dataEntryOp).value(), acc::getBounds(dataEntryOp));
-      copyoutOp.setDataClause(acc::DataClause::acc_copy);
+      // A copyin entry has no copy-back - just release the device copy.
+      if (acc::getDataClause(dataEntryOp) == acc::DataClause::acc_copyin) {
+        auto deleteOp = acc::DeleteOp::create(
+            builder, dataEntryOp->getLoc(), dataEntry,
+            /*structured=*/true, /*implicit=*/true,
+            acc::getVarName(dataEntryOp).value(), acc::getBounds(dataEntryOp));
+        deleteOp.setDataClause(acc::DataClause::acc_copyin);
+      } else {
+        auto copyoutOp = acc::CopyoutOp::create(
+            builder, dataEntryOp->getLoc(), dataEntry, acc::getVar(dataEntryOp),
+            /*structured=*/true, /*implicit=*/true,
+            acc::getVarName(dataEntryOp).value(), acc::getBounds(dataEntryOp));
+        copyoutOp.setDataClause(acc::DataClause::acc_copy);
+      }
     } else if (isa<acc::PresentOp, acc::NoCreateOp>(dataEntryOp)) {
       auto deleteOp = acc::DeleteOp::create(
           builder, dataEntryOp->getLoc(), dataEntry,

--- a/mlir/test/Dialect/OpenACC/acc-implicit-data.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-implicit-data.mlir
@@ -32,7 +32,7 @@ func.func @test_scalar_in_parallel() {
 
 // -----
 
-// Test scalar in kernels construct - should generate copyin/copyout
+// Test scalar only read in kernels construct - should generate copyin/delete
 func.func @test_scalar_in_kernels() {
   %alloc = memref.alloca() : memref<f64>
   acc.kernels {
@@ -43,6 +43,42 @@ func.func @test_scalar_in_kernels() {
 }
 
 // CHECK-LABEL: func.func @test_scalar_in_kernels
+// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : memref<f64>) implicit(true) name("") -> memref<f64>
+// CHECK-NOT: acc.copyout
+// CHECK: acc.delete accPtr(%[[COPYIN]] : memref<f64>) dataClause(acc_copyin) implicit(true) name("")
+
+// -----
+
+// Test scalar written in kernels construct - should generate copyin/copyout
+func.func @test_scalar_written_in_kernels() {
+  %alloc = memref.alloca() : memref<f64>
+  acc.kernels {
+    %cst = arith.constant 1.000000e+00 : f64
+    memref.store %cst, %alloc[] : memref<f64>
+    acc.terminator
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @test_scalar_written_in_kernels
+// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : memref<f64>) dataClause(acc_copy) implicit(true) name("") -> memref<f64>
+// CHECK: acc.copyout accPtr(%[[COPYIN]] : memref<f64>) to varPtr({{.*}} : memref<f64>) dataClause(acc_copy) implicit(true) name("")
+
+// -----
+
+// Test scalar passed to a call in kernels construct - the effect on it cannot
+// be established so the copy-back is kept
+func.func private @use_scalar(memref<f64>)
+func.func @test_scalar_escapes_call_in_kernels() {
+  %alloc = memref.alloca() : memref<f64>
+  acc.kernels {
+    func.call @use_scalar(%alloc) : (memref<f64>) -> ()
+    acc.terminator
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @test_scalar_escapes_call_in_kernels
 // CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : memref<f64>) dataClause(acc_copy) implicit(true) name("") -> memref<f64>
 // CHECK: acc.copyout accPtr(%[[COPYIN]] : memref<f64>) to varPtr({{.*}} : memref<f64>) dataClause(acc_copy) implicit(true) name("")
 


### PR DESCRIPTION
Example:
```fortran
do while (k <= n)
   !$acc kernels present(buf) async(1)
   buf(:, :, k) = real(k, kind=8)
   !$acc end kernels
   k = k + 2
end do
```

In this code k is only read in the region, but a scalar in a kernels construct
is implicitly copy, so ACCImplicitData paired every implicit acc.copyin with an
acc.copyout. With async that copy-back is queued behind the kernel and lands
after the host has advanced k, overwriting it with the stale value.

Fix: emit acc.copyin + acc.delete when AliasAnalysis::getModRef proves no
operation in the region writes the scalar.