### PR TITLE
[RISCV][P-ext][NFC] Overload scalar mqacc/mqracc intrinsics by element width

### DIFF
--- a/clang/lib/CodeGen/TargetBuiltins/RISCV.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/RISCV.cpp
@@ -1648,24 +1648,6 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
     switch (BuiltinID) {
     default:
       llvm_unreachable("unexpected builtin ID");
-    case RISCV::BI__builtin_riscv_mqacc_h00_i32:
-      ID = Intrinsic::riscv_mqacc_h00;
-      break;
-    case RISCV::BI__builtin_riscv_mqacc_h01_i32:
-      ID = Intrinsic::riscv_mqacc_h01;
-      break;
-    case RISCV::BI__builtin_riscv_mqacc_h11_i32:
-      ID = Intrinsic::riscv_mqacc_h11;
-      break;
-    case RISCV::BI__builtin_riscv_mqracc_h00_i32:
-      ID = Intrinsic::riscv_mqracc_h00;
-      break;
-    case RISCV::BI__builtin_riscv_mqracc_h01_i32:
-      ID = Intrinsic::riscv_mqracc_h01;
-      break;
-    case RISCV::BI__builtin_riscv_mqracc_h11_i32:
-      ID = Intrinsic::riscv_mqracc_h11;
-      break;
     case RISCV::BI__builtin_riscv_pmqacc_h00_i32x2:
       ID = Intrinsic::riscv_pmqacc_h00;
       break;
@@ -1684,23 +1666,30 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
     case RISCV::BI__builtin_riscv_pmqracc_h11_i32x2:
       ID = Intrinsic::riscv_pmqracc_h11;
       break;
+    // Scalar "Q-format" Multiply Parts Accumulate
+    case RISCV::BI__builtin_riscv_mqacc_h00_i32:
     case RISCV::BI__builtin_riscv_mqacc_w00_i64:
-      ID = Intrinsic::riscv_mqacc_w00;
+      ID = Intrinsic::riscv_mqacc_00;
       break;
+    case RISCV::BI__builtin_riscv_mqacc_h01_i32:
     case RISCV::BI__builtin_riscv_mqacc_w01_i64:
-      ID = Intrinsic::riscv_mqacc_w01;
+      ID = Intrinsic::riscv_mqacc_01;
       break;
+    case RISCV::BI__builtin_riscv_mqacc_h11_i32:
     case RISCV::BI__builtin_riscv_mqacc_w11_i64:
-      ID = Intrinsic::riscv_mqacc_w11;
+      ID = Intrinsic::riscv_mqacc_11;
       break;
+    case RISCV::BI__builtin_riscv_mqracc_h00_i32:
     case RISCV::BI__builtin_riscv_mqracc_w00_i64:
-      ID = Intrinsic::riscv_mqracc_w00;
+      ID = Intrinsic::riscv_mqracc_00;
       break;
+    case RISCV::BI__builtin_riscv_mqracc_h01_i32:
     case RISCV::BI__builtin_riscv_mqracc_w01_i64:
-      ID = Intrinsic::riscv_mqracc_w01;
+      ID = Intrinsic::riscv_mqracc_01;
       break;
+    case RISCV::BI__builtin_riscv_mqracc_h11_i32:
     case RISCV::BI__builtin_riscv_mqracc_w11_i64:
-      ID = Intrinsic::riscv_mqracc_w11;
+      ID = Intrinsic::riscv_mqracc_11;
       break;
     }
 

--- a/clang/test/CodeGen/RISCV/rvp-intrinsics.c
+++ b/clang/test/CodeGen/RISCV/rvp-intrinsics.c
@@ -10113,7 +10113,7 @@ uint32x2_t test_pnclipup_u32x2(uint64_t rs1, uint64_t rs2) {
 // RV32-NEXT:  [[ENTRY:.*:]]
 // RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[RS1_COERCE]] to <2 x i16>
 // RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[RS2_COERCE]] to <2 x i16>
-// RV32-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqacc.h00.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
+// RV32-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqacc.00.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
 // RV32-NEXT:    ret i32 [[TMP2]]
 //
 // RV64-LABEL: define dso_local signext i32 @test_mqacc_h00_i32(
@@ -10121,7 +10121,7 @@ uint32x2_t test_pnclipup_u32x2(uint64_t rs1, uint64_t rs2) {
 // RV64-NEXT:  [[ENTRY:.*:]]
 // RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[RS1_COERCE]] to <2 x i16>
 // RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[RS2_COERCE]] to <2 x i16>
-// RV64-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqacc.h00.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
+// RV64-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqacc.00.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
 // RV64-NEXT:    ret i32 [[TMP2]]
 //
 
@@ -10133,7 +10133,7 @@ int32_t test_mqacc_h00_i32(int32_t rd, int16x2_t rs1, int16x2_t rs2) {
 // RV32-NEXT:  [[ENTRY:.*:]]
 // RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[RS1_COERCE]] to <2 x i16>
 // RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[RS2_COERCE]] to <2 x i16>
-// RV32-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqacc.h01.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
+// RV32-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqacc.01.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
 // RV32-NEXT:    ret i32 [[TMP2]]
 //
 // RV64-LABEL: define dso_local signext i32 @test_mqacc_h01_i32(
@@ -10141,7 +10141,7 @@ int32_t test_mqacc_h00_i32(int32_t rd, int16x2_t rs1, int16x2_t rs2) {
 // RV64-NEXT:  [[ENTRY:.*:]]
 // RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[RS1_COERCE]] to <2 x i16>
 // RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[RS2_COERCE]] to <2 x i16>
-// RV64-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqacc.h01.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
+// RV64-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqacc.01.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
 // RV64-NEXT:    ret i32 [[TMP2]]
 //
 int32_t test_mqacc_h01_i32(int32_t rd, int16x2_t rs1, int16x2_t rs2) {
@@ -10153,7 +10153,7 @@ int32_t test_mqacc_h01_i32(int32_t rd, int16x2_t rs1, int16x2_t rs2) {
 // RV32-NEXT:  [[ENTRY:.*:]]
 // RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[RS1_COERCE]] to <2 x i16>
 // RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[RS2_COERCE]] to <2 x i16>
-// RV32-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqacc.h11.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
+// RV32-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqacc.11.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
 // RV32-NEXT:    ret i32 [[TMP2]]
 //
 // RV64-LABEL: define dso_local signext i32 @test_mqacc_h11_i32(
@@ -10161,7 +10161,7 @@ int32_t test_mqacc_h01_i32(int32_t rd, int16x2_t rs1, int16x2_t rs2) {
 // RV64-NEXT:  [[ENTRY:.*:]]
 // RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[RS1_COERCE]] to <2 x i16>
 // RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[RS2_COERCE]] to <2 x i16>
-// RV64-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqacc.h11.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
+// RV64-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqacc.11.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
 // RV64-NEXT:    ret i32 [[TMP2]]
 //
 int32_t test_mqacc_h11_i32(int32_t rd, int16x2_t rs1, int16x2_t rs2) {
@@ -10173,7 +10173,7 @@ int32_t test_mqacc_h11_i32(int32_t rd, int16x2_t rs1, int16x2_t rs2) {
 // RV32-NEXT:  [[ENTRY:.*:]]
 // RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[RS1_COERCE]] to <2 x i16>
 // RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[RS2_COERCE]] to <2 x i16>
-// RV32-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqracc.h00.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
+// RV32-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqracc.00.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
 // RV32-NEXT:    ret i32 [[TMP2]]
 //
 // RV64-LABEL: define dso_local signext i32 @test_mqracc_h00_i32(
@@ -10181,7 +10181,7 @@ int32_t test_mqacc_h11_i32(int32_t rd, int16x2_t rs1, int16x2_t rs2) {
 // RV64-NEXT:  [[ENTRY:.*:]]
 // RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[RS1_COERCE]] to <2 x i16>
 // RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[RS2_COERCE]] to <2 x i16>
-// RV64-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqracc.h00.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
+// RV64-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqracc.00.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
 // RV64-NEXT:    ret i32 [[TMP2]]
 //
 int32_t test_mqracc_h00_i32(int32_t rd, int16x2_t rs1, int16x2_t rs2) {
@@ -10193,7 +10193,7 @@ int32_t test_mqracc_h00_i32(int32_t rd, int16x2_t rs1, int16x2_t rs2) {
 // RV32-NEXT:  [[ENTRY:.*:]]
 // RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[RS1_COERCE]] to <2 x i16>
 // RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[RS2_COERCE]] to <2 x i16>
-// RV32-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqracc.h01.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
+// RV32-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqracc.01.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
 // RV32-NEXT:    ret i32 [[TMP2]]
 //
 // RV64-LABEL: define dso_local signext i32 @test_mqracc_h01_i32(
@@ -10201,7 +10201,7 @@ int32_t test_mqracc_h00_i32(int32_t rd, int16x2_t rs1, int16x2_t rs2) {
 // RV64-NEXT:  [[ENTRY:.*:]]
 // RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[RS1_COERCE]] to <2 x i16>
 // RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[RS2_COERCE]] to <2 x i16>
-// RV64-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqracc.h01.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
+// RV64-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqracc.01.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
 // RV64-NEXT:    ret i32 [[TMP2]]
 //
 int32_t test_mqracc_h01_i32(int32_t rd, int16x2_t rs1, int16x2_t rs2) {
@@ -10213,7 +10213,7 @@ int32_t test_mqracc_h01_i32(int32_t rd, int16x2_t rs1, int16x2_t rs2) {
 // RV32-NEXT:  [[ENTRY:.*:]]
 // RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[RS1_COERCE]] to <2 x i16>
 // RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[RS2_COERCE]] to <2 x i16>
-// RV32-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqracc.h11.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
+// RV32-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqracc.11.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
 // RV32-NEXT:    ret i32 [[TMP2]]
 //
 // RV64-LABEL: define dso_local signext i32 @test_mqracc_h11_i32(
@@ -10221,7 +10221,7 @@ int32_t test_mqracc_h01_i32(int32_t rd, int16x2_t rs1, int16x2_t rs2) {
 // RV64-NEXT:  [[ENTRY:.*:]]
 // RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[RS1_COERCE]] to <2 x i16>
 // RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[RS2_COERCE]] to <2 x i16>
-// RV64-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqracc.h11.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
+// RV64-NEXT:    [[TMP2:%.*]] = call i32 @llvm.riscv.mqracc.11.i32.v2i16(i32 [[RD]], <2 x i16> [[TMP0]], <2 x i16> [[TMP1]])
 // RV64-NEXT:    ret i32 [[TMP2]]
 //
 int32_t test_mqracc_h11_i32(int32_t rd, int16x2_t rs1, int16x2_t rs2) {
@@ -10379,7 +10379,7 @@ int32x2_t test_pmqracc_h11_i32x2(int32x2_t rd, int16x4_t rs1, int16x4_t rs2) {
 // RV32-NEXT:  [[ENTRY:.*:]]
 // RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[RS1_COERCE]] to <2 x i32>
 // RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[RS2_COERCE]] to <2 x i32>
-// RV32-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqacc.w00.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
+// RV32-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqacc.00.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
 // RV32-NEXT:    ret i64 [[TMP2]]
 //
 // RV64-LABEL: define dso_local i64 @test_mqacc_w00_i64(
@@ -10387,7 +10387,7 @@ int32x2_t test_pmqracc_h11_i32x2(int32x2_t rd, int16x4_t rs1, int16x4_t rs2) {
 // RV64-NEXT:  [[ENTRY:.*:]]
 // RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[RS1_COERCE]] to <2 x i32>
 // RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[RS2_COERCE]] to <2 x i32>
-// RV64-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqacc.w00.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
+// RV64-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqacc.00.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
 // RV64-NEXT:    ret i64 [[TMP2]]
 //
 int64_t test_mqacc_w00_i64(int64_t rd, int32x2_t rs1, int32x2_t rs2) {
@@ -10399,7 +10399,7 @@ int64_t test_mqacc_w00_i64(int64_t rd, int32x2_t rs1, int32x2_t rs2) {
 // RV32-NEXT:  [[ENTRY:.*:]]
 // RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[RS1_COERCE]] to <2 x i32>
 // RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[RS2_COERCE]] to <2 x i32>
-// RV32-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqacc.w01.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
+// RV32-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqacc.01.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
 // RV32-NEXT:    ret i64 [[TMP2]]
 //
 // RV64-LABEL: define dso_local i64 @test_mqacc_w01_i64(
@@ -10407,7 +10407,7 @@ int64_t test_mqacc_w00_i64(int64_t rd, int32x2_t rs1, int32x2_t rs2) {
 // RV64-NEXT:  [[ENTRY:.*:]]
 // RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[RS1_COERCE]] to <2 x i32>
 // RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[RS2_COERCE]] to <2 x i32>
-// RV64-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqacc.w01.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
+// RV64-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqacc.01.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
 // RV64-NEXT:    ret i64 [[TMP2]]
 //
 int64_t test_mqacc_w01_i64(int64_t rd, int32x2_t rs1, int32x2_t rs2) {
@@ -10419,7 +10419,7 @@ int64_t test_mqacc_w01_i64(int64_t rd, int32x2_t rs1, int32x2_t rs2) {
 // RV32-NEXT:  [[ENTRY:.*:]]
 // RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[RS1_COERCE]] to <2 x i32>
 // RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[RS2_COERCE]] to <2 x i32>
-// RV32-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqacc.w11.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
+// RV32-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqacc.11.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
 // RV32-NEXT:    ret i64 [[TMP2]]
 //
 // RV64-LABEL: define dso_local i64 @test_mqacc_w11_i64(
@@ -10427,7 +10427,7 @@ int64_t test_mqacc_w01_i64(int64_t rd, int32x2_t rs1, int32x2_t rs2) {
 // RV64-NEXT:  [[ENTRY:.*:]]
 // RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[RS1_COERCE]] to <2 x i32>
 // RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[RS2_COERCE]] to <2 x i32>
-// RV64-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqacc.w11.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
+// RV64-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqacc.11.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
 // RV64-NEXT:    ret i64 [[TMP2]]
 //
 int64_t test_mqacc_w11_i64(int64_t rd, int32x2_t rs1, int32x2_t rs2) {
@@ -10439,7 +10439,7 @@ int64_t test_mqacc_w11_i64(int64_t rd, int32x2_t rs1, int32x2_t rs2) {
 // RV32-NEXT:  [[ENTRY:.*:]]
 // RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[RS1_COERCE]] to <2 x i32>
 // RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[RS2_COERCE]] to <2 x i32>
-// RV32-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqracc.w00.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
+// RV32-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqracc.00.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
 // RV32-NEXT:    ret i64 [[TMP2]]
 //
 // RV64-LABEL: define dso_local i64 @test_mqracc_w00_i64(
@@ -10447,7 +10447,7 @@ int64_t test_mqacc_w11_i64(int64_t rd, int32x2_t rs1, int32x2_t rs2) {
 // RV64-NEXT:  [[ENTRY:.*:]]
 // RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[RS1_COERCE]] to <2 x i32>
 // RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[RS2_COERCE]] to <2 x i32>
-// RV64-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqracc.w00.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
+// RV64-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqracc.00.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
 // RV64-NEXT:    ret i64 [[TMP2]]
 //
 int64_t test_mqracc_w00_i64(int64_t rd, int32x2_t rs1, int32x2_t rs2) {
@@ -10459,7 +10459,7 @@ int64_t test_mqracc_w00_i64(int64_t rd, int32x2_t rs1, int32x2_t rs2) {
 // RV32-NEXT:  [[ENTRY:.*:]]
 // RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[RS1_COERCE]] to <2 x i32>
 // RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[RS2_COERCE]] to <2 x i32>
-// RV32-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqracc.w01.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
+// RV32-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqracc.01.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
 // RV32-NEXT:    ret i64 [[TMP2]]
 //
 // RV64-LABEL: define dso_local i64 @test_mqracc_w01_i64(
@@ -10467,7 +10467,7 @@ int64_t test_mqracc_w00_i64(int64_t rd, int32x2_t rs1, int32x2_t rs2) {
 // RV64-NEXT:  [[ENTRY:.*:]]
 // RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[RS1_COERCE]] to <2 x i32>
 // RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[RS2_COERCE]] to <2 x i32>
-// RV64-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqracc.w01.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
+// RV64-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqracc.01.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
 // RV64-NEXT:    ret i64 [[TMP2]]
 //
 int64_t test_mqracc_w01_i64(int64_t rd, int32x2_t rs1, int32x2_t rs2) {
@@ -10479,7 +10479,7 @@ int64_t test_mqracc_w01_i64(int64_t rd, int32x2_t rs1, int32x2_t rs2) {
 // RV32-NEXT:  [[ENTRY:.*:]]
 // RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[RS1_COERCE]] to <2 x i32>
 // RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[RS2_COERCE]] to <2 x i32>
-// RV32-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqracc.w11.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
+// RV32-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqracc.11.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
 // RV32-NEXT:    ret i64 [[TMP2]]
 //
 // RV64-LABEL: define dso_local i64 @test_mqracc_w11_i64(
@@ -10487,7 +10487,7 @@ int64_t test_mqracc_w01_i64(int64_t rd, int32x2_t rs1, int32x2_t rs2) {
 // RV64-NEXT:  [[ENTRY:.*:]]
 // RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[RS1_COERCE]] to <2 x i32>
 // RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[RS2_COERCE]] to <2 x i32>
-// RV64-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqracc.w11.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
+// RV64-NEXT:    [[TMP2:%.*]] = call i64 @llvm.riscv.mqracc.11.i64.v2i32(i64 [[RD]], <2 x i32> [[TMP0]], <2 x i32> [[TMP1]])
 // RV64-NEXT:    ret i64 [[TMP2]]
 //
 int64_t test_mqracc_w11_i64(int64_t rd, int32x2_t rs1, int32x2_t rs2) {

--- a/llvm/include/llvm/IR/IntrinsicsRISCV.td
+++ b/llvm/include/llvm/IR/IntrinsicsRISCV.td
@@ -2162,30 +2162,24 @@ class RVPBinaryIntrinsic
   def int_riscv_pnclipp  : RVPNarrowingClipIntrinsic;
   def int_riscv_pnclipup : RVPNarrowingClipIntrinsic;
 
-  // Packed "Q-format" Multiply Parts Accumulate
+  // Packed "Q-format" Multiply Parts Accumulate.
   class RVPQFormatAccIntrinsic
       : DefaultAttrsIntrinsic<[llvm_anyint_ty],
                               [LLVMMatchType<0>, llvm_any_ty,
                                LLVMMatchType<1>],
                               [IntrNoMem, IntrSpeculatable]>;
-  def int_riscv_mqacc_h00  : RVPQFormatAccIntrinsic;
-  def int_riscv_mqacc_h01  : RVPQFormatAccIntrinsic;
-  def int_riscv_mqacc_h11  : RVPQFormatAccIntrinsic;
-  def int_riscv_mqracc_h00 : RVPQFormatAccIntrinsic;
-  def int_riscv_mqracc_h01 : RVPQFormatAccIntrinsic;
-  def int_riscv_mqracc_h11 : RVPQFormatAccIntrinsic;
+  def int_riscv_mqacc_00  : RVPQFormatAccIntrinsic;
+  def int_riscv_mqacc_01  : RVPQFormatAccIntrinsic;
+  def int_riscv_mqacc_11  : RVPQFormatAccIntrinsic;
+  def int_riscv_mqracc_00 : RVPQFormatAccIntrinsic;
+  def int_riscv_mqracc_01 : RVPQFormatAccIntrinsic;
+  def int_riscv_mqracc_11 : RVPQFormatAccIntrinsic;
   def int_riscv_pmqacc_h00  : RVPQFormatAccIntrinsic;
   def int_riscv_pmqacc_h01  : RVPQFormatAccIntrinsic;
   def int_riscv_pmqacc_h11  : RVPQFormatAccIntrinsic;
   def int_riscv_pmqracc_h00 : RVPQFormatAccIntrinsic;
   def int_riscv_pmqracc_h01 : RVPQFormatAccIntrinsic;
   def int_riscv_pmqracc_h11 : RVPQFormatAccIntrinsic;
-  def int_riscv_mqacc_w00  : RVPQFormatAccIntrinsic;
-  def int_riscv_mqacc_w01  : RVPQFormatAccIntrinsic;
-  def int_riscv_mqacc_w11  : RVPQFormatAccIntrinsic;
-  def int_riscv_mqracc_w00 : RVPQFormatAccIntrinsic;
-  def int_riscv_mqracc_w01 : RVPQFormatAccIntrinsic;
-  def int_riscv_mqracc_w11 : RVPQFormatAccIntrinsic;
 } // TargetPrefix = "riscv"
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -12270,28 +12270,22 @@ static unsigned getRVPQFormatAccScalarOpcode(Intrinsic::ID IntNo) {
   switch (IntNo) {
   default:
     llvm_unreachable("Unexpected RISC-V packed Q-format accumulate intrinsic");
-  case Intrinsic::riscv_mqacc_h00:
-  case Intrinsic::riscv_mqacc_w00:
+  case Intrinsic::riscv_mqacc_00:
   case Intrinsic::riscv_pmqacc_h00:
     return RISCVISD::MQACC_00;
-  case Intrinsic::riscv_mqacc_h01:
-  case Intrinsic::riscv_mqacc_w01:
+  case Intrinsic::riscv_mqacc_01:
   case Intrinsic::riscv_pmqacc_h01:
     return RISCVISD::MQACC_01;
-  case Intrinsic::riscv_mqacc_h11:
-  case Intrinsic::riscv_mqacc_w11:
+  case Intrinsic::riscv_mqacc_11:
   case Intrinsic::riscv_pmqacc_h11:
     return RISCVISD::MQACC_11;
-  case Intrinsic::riscv_mqracc_h00:
-  case Intrinsic::riscv_mqracc_w00:
+  case Intrinsic::riscv_mqracc_00:
   case Intrinsic::riscv_pmqracc_h00:
     return RISCVISD::MQRACC_00;
-  case Intrinsic::riscv_mqracc_h01:
-  case Intrinsic::riscv_mqracc_w01:
+  case Intrinsic::riscv_mqracc_01:
   case Intrinsic::riscv_pmqracc_h01:
     return RISCVISD::MQRACC_01;
-  case Intrinsic::riscv_mqracc_h11:
-  case Intrinsic::riscv_mqracc_w11:
+  case Intrinsic::riscv_mqracc_11:
   case Intrinsic::riscv_pmqracc_h11:
     return RISCVISD::MQRACC_11;
   }
@@ -12301,22 +12295,22 @@ static unsigned getRVPQFormatAccOpcode(Intrinsic::ID IntNo) {
   switch (IntNo) {
   default:
     llvm_unreachable("Unexpected RISC-V packed Q-format accumulate intrinsic");
-  case Intrinsic::riscv_mqacc_h00:
+  case Intrinsic::riscv_mqacc_00:
   case Intrinsic::riscv_pmqacc_h00:
     return RISCVISD::PMQACC_W_H00;
-  case Intrinsic::riscv_mqacc_h01:
+  case Intrinsic::riscv_mqacc_01:
   case Intrinsic::riscv_pmqacc_h01:
     return RISCVISD::PMQACC_W_H01;
-  case Intrinsic::riscv_mqacc_h11:
+  case Intrinsic::riscv_mqacc_11:
   case Intrinsic::riscv_pmqacc_h11:
     return RISCVISD::PMQACC_W_H11;
-  case Intrinsic::riscv_mqracc_h00:
+  case Intrinsic::riscv_mqracc_00:
   case Intrinsic::riscv_pmqracc_h00:
     return RISCVISD::PMQRACC_W_H00;
-  case Intrinsic::riscv_mqracc_h01:
+  case Intrinsic::riscv_mqracc_01:
   case Intrinsic::riscv_pmqracc_h01:
     return RISCVISD::PMQRACC_W_H01;
-  case Intrinsic::riscv_mqracc_h11:
+  case Intrinsic::riscv_mqracc_11:
   case Intrinsic::riscv_pmqracc_h11:
     return RISCVISD::PMQRACC_W_H11;
   }
@@ -12535,36 +12529,25 @@ SDValue RISCVTargetLowering::LowerINTRINSIC_WO_CHAIN(SDValue Op,
 
     llvm_unreachable("unexpected VT for pnclipp/pnclipup on RV32");
   }
-  case Intrinsic::riscv_mqacc_h00:
-  case Intrinsic::riscv_mqacc_h01:
-  case Intrinsic::riscv_mqacc_h11:
-  case Intrinsic::riscv_mqracc_h00:
-  case Intrinsic::riscv_mqracc_h01:
-  case Intrinsic::riscv_mqracc_h11:
+  case Intrinsic::riscv_mqacc_00:
+  case Intrinsic::riscv_mqacc_01:
+  case Intrinsic::riscv_mqacc_11:
+  case Intrinsic::riscv_mqracc_00:
+  case Intrinsic::riscv_mqracc_01:
+  case Intrinsic::riscv_mqracc_11:
   case Intrinsic::riscv_pmqacc_h00:
   case Intrinsic::riscv_pmqacc_h01:
   case Intrinsic::riscv_pmqacc_h11:
   case Intrinsic::riscv_pmqracc_h00:
   case Intrinsic::riscv_pmqracc_h01:
-  case Intrinsic::riscv_pmqracc_h11:
-  case Intrinsic::riscv_mqacc_w00:
-  case Intrinsic::riscv_mqacc_w01:
-  case Intrinsic::riscv_mqacc_w11:
-  case Intrinsic::riscv_mqracc_w00:
-  case Intrinsic::riscv_mqracc_w01:
-  case Intrinsic::riscv_mqracc_w11: {
+  case Intrinsic::riscv_pmqracc_h11: {
     EVT VT = Op.getValueType();
     SDValue Rd = Op.getOperand(1);
     SDValue Rs1 = Op.getOperand(2);
     SDValue Rs2 = Op.getOperand(3);
     MVT XLenVT = Subtarget.getXLenVT();
 
-    bool IsScalarHalfword = IntNo == Intrinsic::riscv_mqacc_h00 ||
-                            IntNo == Intrinsic::riscv_mqacc_h01 ||
-                            IntNo == Intrinsic::riscv_mqacc_h11 ||
-                            IntNo == Intrinsic::riscv_mqracc_h00 ||
-                            IntNo == Intrinsic::riscv_mqracc_h01 ||
-                            IntNo == Intrinsic::riscv_mqracc_h11;
+    bool IsScalarHalfword = VT == MVT::i32;
     if (Subtarget.is64Bit() && IsScalarHalfword)
       return SDValue();
 
@@ -17092,56 +17075,52 @@ void RISCVTargetLowering::ReplaceNodeResults(SDNode *N,
       Results.push_back(DAG.getNode(ISD::TRUNCATE, DL, MVT::i32, Res));
       return;
     }
-    case Intrinsic::riscv_mqacc_h00:
-    case Intrinsic::riscv_mqacc_h01:
-    case Intrinsic::riscv_mqacc_h11:
-    case Intrinsic::riscv_mqracc_h00:
-    case Intrinsic::riscv_mqracc_h01:
-    case Intrinsic::riscv_mqracc_h11: {
+    case Intrinsic::riscv_mqacc_00:
+    case Intrinsic::riscv_mqacc_01:
+    case Intrinsic::riscv_mqacc_11:
+    case Intrinsic::riscv_mqracc_00:
+    case Intrinsic::riscv_mqracc_01:
+    case Intrinsic::riscv_mqracc_11: {
       EVT VT = N->getValueType(0);
-      if (!Subtarget.is64Bit() || VT != MVT::i32)
+      if (Subtarget.is64Bit() && VT == MVT::i32) {
+        SDValue Rd = DAG.getNode(ISD::SCALAR_TO_VECTOR, DL, MVT::v2i32,
+                                 N->getOperand(1));
+        auto WidenSrc = [&](SDValue V) {
+          return DAG.getNode(ISD::CONCAT_VECTORS, DL, MVT::v4i16,
+                             {V, DAG.getUNDEF(MVT::v2i16)});
+        };
+        SDValue Rs1 = WidenSrc(N->getOperand(2));
+        SDValue Rs2 = WidenSrc(N->getOperand(3));
+        unsigned Opc = getRVPQFormatAccOpcode(IntNo);
+        SDValue Res = DAG.getNode(Opc, DL, MVT::v2i32, Rd, Rs1, Rs2);
+        Results.push_back(DAG.getExtractVectorElt(DL, MVT::i32, Res, 0));
         return;
-      SDValue Rd =
-          DAG.getNode(ISD::SCALAR_TO_VECTOR, DL, MVT::v2i32, N->getOperand(1));
-      auto WidenSrc = [&](SDValue V) {
-        return DAG.getNode(ISD::CONCAT_VECTORS, DL, MVT::v4i16,
-                           {V, DAG.getUNDEF(MVT::v2i16)});
-      };
-      SDValue Rs1 = WidenSrc(N->getOperand(2));
-      SDValue Rs2 = WidenSrc(N->getOperand(3));
-      unsigned Opc = getRVPQFormatAccOpcode(IntNo);
-      SDValue Res = DAG.getNode(Opc, DL, MVT::v2i32, Rd, Rs1, Rs2);
-      Results.push_back(DAG.getExtractVectorElt(DL, MVT::i32, Res, 0));
-      return;
-    }
-    case Intrinsic::riscv_mqacc_w00:
-    case Intrinsic::riscv_mqacc_w01:
-    case Intrinsic::riscv_mqacc_w11:
-    case Intrinsic::riscv_mqracc_w00:
-    case Intrinsic::riscv_mqracc_w01:
-    case Intrinsic::riscv_mqracc_w11: {
-      if (Subtarget.is64Bit() || N->getValueType(0) != MVT::i64)
+      }
+
+      if (!Subtarget.is64Bit() && VT == MVT::i64) {
+        bool IsRound = IntNo == Intrinsic::riscv_mqracc_00 ||
+                       IntNo == Intrinsic::riscv_mqracc_01 ||
+                       IntNo == Intrinsic::riscv_mqracc_11;
+        bool Hi1 = IntNo == Intrinsic::riscv_mqacc_11 ||
+                   IntNo == Intrinsic::riscv_mqracc_11;
+        bool Hi2 = IntNo == Intrinsic::riscv_mqacc_01 ||
+                   IntNo == Intrinsic::riscv_mqacc_11 ||
+                   IntNo == Intrinsic::riscv_mqracc_01 ||
+                   IntNo == Intrinsic::riscv_mqracc_11;
+        MVT XLenVT = Subtarget.getXLenVT();
+        SDValue Rs1 = N->getOperand(2);
+        SDValue Rs2 = N->getOperand(3);
+        SDValue A = DAG.getExtractVectorElt(DL, XLenVT, Rs1, Hi1 ? 1 : 0);
+        SDValue B = DAG.getExtractVectorElt(DL, XLenVT, Rs2, Hi2 ? 1 : 0);
+        auto [RdLo, RdHi] =
+            DAG.SplitScalar(N->getOperand(1), DL, XLenVT, XLenVT);
+        unsigned Opc = IsRound ? RISCVISD::MQRWACC : RISCVISD::MQWACC;
+        SDVTList VTs = DAG.getVTList(XLenVT, XLenVT);
+        SDValue Acc = DAG.getNode(Opc, DL, VTs, {RdLo, RdHi, A, B});
+        Results.push_back(DAG.getNode(ISD::BUILD_PAIR, DL, MVT::i64,
+                                      Acc.getValue(0), Acc.getValue(1)));
         return;
-      bool IsRound = IntNo == Intrinsic::riscv_mqracc_w00 ||
-                     IntNo == Intrinsic::riscv_mqracc_w01 ||
-                     IntNo == Intrinsic::riscv_mqracc_w11;
-      bool Hi1 = IntNo == Intrinsic::riscv_mqacc_w11 ||
-                 IntNo == Intrinsic::riscv_mqracc_w11;
-      bool Hi2 = IntNo == Intrinsic::riscv_mqacc_w01 ||
-                 IntNo == Intrinsic::riscv_mqacc_w11 ||
-                 IntNo == Intrinsic::riscv_mqracc_w01 ||
-                 IntNo == Intrinsic::riscv_mqracc_w11;
-      MVT XLenVT = Subtarget.getXLenVT();
-      SDValue Rs1 = N->getOperand(2);
-      SDValue Rs2 = N->getOperand(3);
-      SDValue A = DAG.getExtractVectorElt(DL, XLenVT, Rs1, Hi1 ? 1 : 0);
-      SDValue B = DAG.getExtractVectorElt(DL, XLenVT, Rs2, Hi2 ? 1 : 0);
-      auto [RdLo, RdHi] = DAG.SplitScalar(N->getOperand(1), DL, XLenVT, XLenVT);
-      unsigned Opc = IsRound ? RISCVISD::MQRWACC : RISCVISD::MQWACC;
-      SDVTList VTs = DAG.getVTList(XLenVT, XLenVT);
-      SDValue Acc = DAG.getNode(Opc, DL, VTs, {RdLo, RdHi, A, B});
-      Results.push_back(DAG.getNode(ISD::BUILD_PAIR, DL, MVT::i64,
-                                    Acc.getValue(0), Acc.getValue(1)));
+      }
       return;
     }
     case Intrinsic::riscv_orc_b:

--- a/llvm/test/CodeGen/RISCV/rvp-simd-32.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-simd-32.ll
@@ -3167,7 +3167,7 @@ define i32 @test_mqacc_h00_i32(i32 %rd, <2 x i16> %a, <2 x i16> %b) {
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    pmqacc.w.h00 a0, a1, a2
 ; RV64-NEXT:    ret
-  %r = call i32 @llvm.riscv.mqacc.h00.i32.v2i16(i32 %rd, <2 x i16> %a, <2 x i16> %b)
+  %r = call i32 @llvm.riscv.mqacc.00.i32.v2i16(i32 %rd, <2 x i16> %a, <2 x i16> %b)
   ret i32 %r
 }
 
@@ -3181,7 +3181,7 @@ define i32 @test_mqacc_h01_i32(i32 %rd, <2 x i16> %a, <2 x i16> %b) {
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    pmqacc.w.h01 a0, a1, a2
 ; RV64-NEXT:    ret
-  %r = call i32 @llvm.riscv.mqacc.h01.i32.v2i16(i32 %rd, <2 x i16> %a, <2 x i16> %b)
+  %r = call i32 @llvm.riscv.mqacc.01.i32.v2i16(i32 %rd, <2 x i16> %a, <2 x i16> %b)
   ret i32 %r
 }
 
@@ -3195,7 +3195,7 @@ define i32 @test_mqacc_h11_i32(i32 %rd, <2 x i16> %a, <2 x i16> %b) {
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    pmqacc.w.h11 a0, a1, a2
 ; RV64-NEXT:    ret
-  %r = call i32 @llvm.riscv.mqacc.h11.i32.v2i16(i32 %rd, <2 x i16> %a, <2 x i16> %b)
+  %r = call i32 @llvm.riscv.mqacc.11.i32.v2i16(i32 %rd, <2 x i16> %a, <2 x i16> %b)
   ret i32 %r
 }
 
@@ -3209,7 +3209,7 @@ define i32 @test_mqracc_h00_i32(i32 %rd, <2 x i16> %a, <2 x i16> %b) {
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    pmqracc.w.h00 a0, a1, a2
 ; RV64-NEXT:    ret
-  %r = call i32 @llvm.riscv.mqracc.h00.i32.v2i16(i32 %rd, <2 x i16> %a, <2 x i16> %b)
+  %r = call i32 @llvm.riscv.mqracc.00.i32.v2i16(i32 %rd, <2 x i16> %a, <2 x i16> %b)
   ret i32 %r
 }
 
@@ -3223,7 +3223,7 @@ define i32 @test_mqracc_h01_i32(i32 %rd, <2 x i16> %a, <2 x i16> %b) {
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    pmqracc.w.h01 a0, a1, a2
 ; RV64-NEXT:    ret
-  %r = call i32 @llvm.riscv.mqracc.h01.i32.v2i16(i32 %rd, <2 x i16> %a, <2 x i16> %b)
+  %r = call i32 @llvm.riscv.mqracc.01.i32.v2i16(i32 %rd, <2 x i16> %a, <2 x i16> %b)
   ret i32 %r
 }
 
@@ -3237,6 +3237,6 @@ define i32 @test_mqracc_h11_i32(i32 %rd, <2 x i16> %a, <2 x i16> %b) {
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    pmqracc.w.h11 a0, a1, a2
 ; RV64-NEXT:    ret
-  %r = call i32 @llvm.riscv.mqracc.h11.i32.v2i16(i32 %rd, <2 x i16> %a, <2 x i16> %b)
+  %r = call i32 @llvm.riscv.mqracc.11.i32.v2i16(i32 %rd, <2 x i16> %a, <2 x i16> %b)
   ret i32 %r
 }

--- a/llvm/test/CodeGen/RISCV/rvp-simd-64.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-simd-64.ll
@@ -7040,7 +7040,7 @@ define i64 @test_mqacc_w00_i64(i64 %rd, <2 x i32> %a, <2 x i32> %b) {
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    mqacc.w00 a0, a1, a2
 ; RV64-NEXT:    ret
-  %r = call i64 @llvm.riscv.mqacc.w00.i64.v2i32(i64 %rd, <2 x i32> %a, <2 x i32> %b)
+  %r = call i64 @llvm.riscv.mqacc.00.i64.v2i32(i64 %rd, <2 x i32> %a, <2 x i32> %b)
   ret i64 %r
 }
 
@@ -7054,7 +7054,7 @@ define i64 @test_mqacc_w01_i64(i64 %rd, <2 x i32> %a, <2 x i32> %b) {
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    mqacc.w01 a0, a1, a2
 ; RV64-NEXT:    ret
-  %r = call i64 @llvm.riscv.mqacc.w01.i64.v2i32(i64 %rd, <2 x i32> %a, <2 x i32> %b)
+  %r = call i64 @llvm.riscv.mqacc.01.i64.v2i32(i64 %rd, <2 x i32> %a, <2 x i32> %b)
   ret i64 %r
 }
 
@@ -7068,7 +7068,7 @@ define i64 @test_mqacc_w11_i64(i64 %rd, <2 x i32> %a, <2 x i32> %b) {
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    mqacc.w11 a0, a1, a2
 ; RV64-NEXT:    ret
-  %r = call i64 @llvm.riscv.mqacc.w11.i64.v2i32(i64 %rd, <2 x i32> %a, <2 x i32> %b)
+  %r = call i64 @llvm.riscv.mqacc.11.i64.v2i32(i64 %rd, <2 x i32> %a, <2 x i32> %b)
   ret i64 %r
 }
 
@@ -7082,7 +7082,7 @@ define i64 @test_mqracc_w00_i64(i64 %rd, <2 x i32> %a, <2 x i32> %b) {
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    mqracc.w00 a0, a1, a2
 ; RV64-NEXT:    ret
-  %r = call i64 @llvm.riscv.mqracc.w00.i64.v2i32(i64 %rd, <2 x i32> %a, <2 x i32> %b)
+  %r = call i64 @llvm.riscv.mqracc.00.i64.v2i32(i64 %rd, <2 x i32> %a, <2 x i32> %b)
   ret i64 %r
 }
 
@@ -7096,7 +7096,7 @@ define i64 @test_mqracc_w01_i64(i64 %rd, <2 x i32> %a, <2 x i32> %b) {
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    mqracc.w01 a0, a1, a2
 ; RV64-NEXT:    ret
-  %r = call i64 @llvm.riscv.mqracc.w01.i64.v2i32(i64 %rd, <2 x i32> %a, <2 x i32> %b)
+  %r = call i64 @llvm.riscv.mqracc.01.i64.v2i32(i64 %rd, <2 x i32> %a, <2 x i32> %b)
   ret i64 %r
 }
 
@@ -7110,6 +7110,6 @@ define i64 @test_mqracc_w11_i64(i64 %rd, <2 x i32> %a, <2 x i32> %b) {
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    mqracc.w11 a0, a1, a2
 ; RV64-NEXT:    ret
-  %r = call i64 @llvm.riscv.mqracc.w11.i64.v2i32(i64 %rd, <2 x i32> %a, <2 x i32> %b)
+  %r = call i64 @llvm.riscv.mqracc.11.i64.v2i32(i64 %rd, <2 x i32> %a, <2 x i32> %b)
   ret i64 %r
 }


### PR DESCRIPTION
Collapse the scalar halfword (`mqacc.h*`, i32) and word (`mqacc.w*`, i64) forms of the Packed Q-format Multiply Parts Accumulate intrinsics into one overloaded intrinsic per element selection (`int_riscv_mqacc_00` covers both `mqacc.h00` and `mqacc.w00`, via result/operand types), mirroring #218875. Packed form (`pmqacc_h*`) and C builtins stay split. No functional change to the generated code.