### PR TITLE
[clang][OffloadBundler] Fix uninitialized iterator in BinaryFileHandler

### DIFF
--- a/clang/lib/Driver/OffloadBundler.cpp
+++ b/clang/lib/Driver/OffloadBundler.cpp
@@ -357,8 +357,10 @@ public:
   ~BinaryFileHandler() final {}
 
   Error ReadHeader(StringRef FC) final {
-    // Initialize the current bundle with the end of the container.
+    // Ensure iterators indicate an empty bundle range in case header parsing
+    // exits early.
     CurBundleInfo = BundlesInfo.end();
+    NextBundleInfo = BundlesInfo.end();
 
     // Check if buffer is smaller than magic string.
     size_t ReadChars = sizeof(OFFLOAD_BUNDLER_MAGIC_STR) - 1;


### PR DESCRIPTION
This patch initializes NextBundleInfo at the top of ReadHeader to
prevent an uninitialized iterator comparison.

ReadHeader has several early return points where it exits without
reading any bundles.  Upon an early return, NextBundleInfo never reaches
the assignment at the bottom of ReadHeader:

  NextBundleInfo = BundlesInfo.begin();

leaving NextBundleInfo default-constructed.  A subsequent call to
ReadBundleStart then attempts an invalid iterator comparison:

  if (NextBundleInfo == BundlesInfo.end())

where NextBundleInfo is still default-constructed.

This bug was discovered with tightened epoch checks in
StringMapIterBase.

Assisted-by: Antigravity
