### PR TITLE
[ADT] Fix FoldingSetIterator::operator* pointer adjustment for multiple inheritance

### DIFF
--- a/llvm/include/llvm/ADT/FoldingSet.h
+++ b/llvm/include/llvm/ADT/FoldingSet.h
@@ -659,7 +659,7 @@ public:
 
   T &operator*() const {
     assert(isHandleInSync() && "invalid iterator access!");
-    return *static_cast<T *>(*Bucket);
+    return *static_cast<T *>(static_cast<FoldingSetNode *>(*Bucket));
   }
 
   T *operator->() const { return &operator*(); }

--- a/llvm/include/llvm/ADT/FoldingSet.h
+++ b/llvm/include/llvm/ADT/FoldingSet.h
@@ -659,7 +659,7 @@ public:
 
   T &operator*() const {
     assert(isHandleInSync() && "invalid iterator access!");
-    return *static_cast<T *>(static_cast<FoldingSetNode *>(*Bucket));
+    return *static_cast<T *>(*Bucket);
   }
 
   T *operator->() const { return &operator*(); }

--- a/llvm/unittests/ADT/FoldingSet.cpp
+++ b/llvm/unittests/ADT/FoldingSet.cpp
@@ -272,6 +272,23 @@ TEST(FoldingSetTest, Iterator) {
   EXPECT_NE(It, ItCopy);
 }
 
+// FoldingSetNode has a non-zero offset here, so operator* must adjust it.
+struct PolymorphicBase {
+  virtual ~PolymorphicBase() = default;
+};
+
+struct MultiplyInheritedNode : public PolymorphicBase, public FoldingSetNode {
+  void Profile(FoldingSetNodeID &ID) const { ID.AddInteger(0); }
+};
+
+TEST(FoldingSetTest, IteratorMultipleInheritance) {
+  FoldingSet<MultiplyInheritedNode> Set;
+  MultiplyInheritedNode N;
+  Set.InsertNode(&N);
+
+  EXPECT_EQ(&*Set.begin(), &N);
+}
+
 TEST(FoldingSetTest, FoldingSetVectorBasic) {
   FoldingSetVector<TrivialPair> Vec;
   EXPECT_THAT(Vec, IsEmpty());

--- a/llvm/unittests/ADT/FoldingSet.cpp
+++ b/llvm/unittests/ADT/FoldingSet.cpp
@@ -273,11 +273,11 @@ TEST(FoldingSetTest, Iterator) {
 }
 
 // FoldingSetNode has a non-zero offset here, so operator* must adjust it.
-struct PolymorphicBase {
-  virtual ~PolymorphicBase() = default;
+struct NonEmptyBase {
+  int Dummy = 0;
 };
 
-struct MultiplyInheritedNode : public PolymorphicBase, public FoldingSetNode {
+struct MultiplyInheritedNode : public NonEmptyBase, public FoldingSetNode {
   void Profile(FoldingSetNodeID &ID) const { ID.AddInteger(0); }
 };
 


### PR DESCRIPTION
b7dc8e356b89 replaced the void*->FoldingSetNode*->T* cast in FoldingSetIteratorImpl::getNode() with a direct void*->T* cast, dropping the base-to-derived adjustment needed when FoldingSetNode isn't T's first base. Restore the FoldingSetNode* intermediate cast.

Found via a downstream user with a multiply-inherited FoldingSetNode type that iterates its FoldingSet directly (via find_if over begin()/end()), corrupting the dereferenced pointer and crashing.