### PR TITLE
[LoongArch] Add LASX sext_invec pattern for v16i8 to v4i64

### DIFF
--- a/llvm/lib/Target/LoongArch/LoongArchLASXInstrInfo.td
+++ b/llvm/lib/Target/LoongArch/LoongArchLASXInstrInfo.td
@@ -2361,6 +2361,9 @@ def : Pat<(v4i32 (sext_invec v16i8:$vj)),
 def : Pat<(v4i32 (sext_invec v8i16:$vj)),
           (v4i32 (EXTRACT_SUBREG (VEXT2XV_W_H (SUBREG_TO_REG v8i16:$vj, sub_128)),
                                  sub_128))>;
+def : Pat<(v4i64 (sext_invec v16i8:$vj)),
+          (v4i64 (VEXT2XV_D_B
+                    (SUBREG_TO_REG v16i8:$vj, sub_128)))>;
 def : Pat<(v4i64 (sext_invec v32i8:$xj)), (v4i64 (VEXT2XV_D_B v32i8:$xj))>;
 def : Pat<(v4i64 (sext_invec v16i16:$xj)), (v4i64 (VEXT2XV_D_H v16i16:$xj))>;
 def : Pat<(v4i64 (sext_invec v8i32:$xj)), (v4i64 (VEXT2XV_D_W v8i32:$xj))>;

--- a/llvm/test/CodeGen/LoongArch/lasx/vxi1-masks.ll
+++ b/llvm/test/CodeGen/LoongArch/lasx/vxi1-masks.ll
@@ -463,3 +463,16 @@ define void @and_sext_masks_v16i16(ptr %res, ptr %a, ptr %b) nounwind {
   store <16 x i16> %r, ptr %res
   ret void
 }
+
+define <4 x i64> @or_zext_cmp_masks_v4i64(<4 x i8> %x) {
+; LA32-LABEL: or_zext_cmp_masks_v4i64:
+; LA32:       vext2xv.d.b
+;
+; LA64-LABEL: or_zext_cmp_masks_v4i64:
+; LA64:       vext2xv.d.b
+  %a = icmp ult <4 x i8> %x, splat (i8 1)
+  %b = icmp eq <4 x i8> %x, zeroinitializer
+  %m = or <4 x i1> %a, %b
+  %ext = zext <4 x i1> %m to <4 x i64>
+  ret <4 x i64> %ext
+}


### PR DESCRIPTION
## Summary

Add the missing LASX SelectionDAG pattern for:

    v4i64 (sext_invec v16i8)

The pattern lowers through `VEXT2XV_D_B` with `SUBREG_TO_REG`, consistent with the neighboring LASX extension patterns.

This fixes #219224.

## Testing

- Added a regression test in `llvm/test/CodeGen/LoongArch/lasx/vxi1-masks.ll`.
- Verified the test passes for both LA32 and LA64.
- Verified the reduced reproducer from #219224 no longer fails and exits successfully.

Fixes #219224
