### PR TITLE
[LoopUnroll] Use MapVector for deterministic iteration order. (#188821)

### DIFF
--- a/llvm/lib/Transforms/Utils/LoopPeel.cpp
+++ b/llvm/lib/Transforms/Utils/LoopPeel.cpp
@@ -11,6 +11,7 @@
 
 #include "llvm/Transforms/Utils/LoopPeel.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Analysis/Loads.h"
@@ -1121,7 +1122,7 @@ bool llvm::peelLoop(Loop *L, unsigned PeelCount, bool PeelLast, LoopInfo *LI,
   // later. Immediate dominator of such block might change, because we add more
   // routes which can lead to the exit: we can reach it from the peeled
   // iterations too.
-  DenseMap<BasicBlock *, BasicBlock *> NonLoopBlocksIDom;
+  MapVector<BasicBlock *, BasicBlock *> NonLoopBlocksIDom;
   for (auto *BB : L->blocks()) {
     auto *BBDomNode = DT.getNode(BB);
     SmallVector<BasicBlock *, 16> ChildrenToUpdate;

--- a/llvm/lib/Transforms/Utils/LoopUnroll.cpp
+++ b/llvm/lib/Transforms/Utils/LoopUnroll.cpp
@@ -17,6 +17,7 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/ScopedHashTable.h"
 #include "llvm/ADT/SetVector.h"
@@ -515,7 +516,7 @@ llvm::UnrollLoop(Loop *L, UnrollLoopOptions ULO, LoopInfo *LI,
     BasicBlock *FirstExitingBlock = nullptr;
     SmallVector<BasicBlock *> ExitingBlocks;
   };
-  DenseMap<BasicBlock *, ExitInfo> ExitInfos;
+  MapVector<BasicBlock *, ExitInfo> ExitInfos;
   SmallVector<BasicBlock *, 4> ExitingBlocks;
   L->getExitingBlocks(ExitingBlocks);
   for (auto *ExitingBlock : ExitingBlocks) {


### PR DESCRIPTION
_note: this backport helps reproducible builds of openSUSE's `cosmic-bg` package and likely other rust software as well._  @efriedma-quic @fhahn 

NonLoopBlocksIDom determines the order we adjust the DT, impacting DRT child ordering.

Similarly, ExitInfos order impacts the order of SetDest, which applies DT updates.

The order impacts collectChildrenInLoop, which in turn impacts the we process BBs in LICM. And this in turn impacts the order in which we perform alias queries.

If the order is not deterministic, we sometimes get different NumNoAlias statistic counts for the same input, and possibly also different IR, although I have not confirmed the latter.

Compile-time impact is neutral:
https://llvm-compile-time-tracker.com/compare.php?from=77710f14202a8684e12d68d08d2cd3738bbd0e1d&to=066ac6284041aac454c8ffa2894b866acbf96fd3&stat=instructions:u

On interesting change to highlight for stage1-O3, although this is probably just noise : ClamAV 55233M 55190M (-0.08%)

PR: https://github.com/llvm/llvm-project/pull/188821
(cherry picked from commit 965f9d87adb0a7376454374fbc140ab69bd796a9)