### PR TITLE
select the greater symbol to display

### DIFF
--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -2251,7 +2251,9 @@ disassembleObject(ObjectFile &Obj, const ObjectFile &DbgObj,
           uint8_t SymTy = SymbolsHere[i].Type;
           if (SymTy != ELF::STT_OBJECT && SymTy != ELF::STT_COMMON) {
             DisassembleAsELFData = false;
-            DisplaySymIndex = i;
+            if(SymTy != ELF::STT_NOTYPE || SymbolsHere[DisplaySymIndex].Type == ELF::STT_NOTYPE) {
+              DisplaySymIndex = i;
+            }
           }
         }
       }


### PR DESCRIPTION
when multiple symbols share the same address,prefer a non-NOTYPE symbol (e.g. STT_FUNC) as the display label.