### PR TITLE
[RISCV] Infer vl > 0 if AVL > 0 in range attributes

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
@@ -3787,17 +3787,19 @@ RISCVTTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
     ConstantRange VLRange = VLMAXRange;
     if (HasAVL) {
       APInt MaxVL = VLMAXRange.getUnsignedMax();
-      if (auto *AVL = dyn_cast<ConstantInt>(II.getArgOperand(0))) {
-        const APInt &C = AVL->getValue();
+      Value *AVL = II.getArgOperand(0);
+      // vl > 0 if AVL > 0
+      APInt MinVL = APInt(BitWidth, isKnownNonZero(AVL, DL) ? 1 : 0);
+      if (auto *AVLC = dyn_cast<ConstantInt>(AVL)) {
+        const APInt &C = AVLC->getValue();
         // A constant AVL not exceeding the smallest possible VLMAX means vl is
         // exactly AVL, so replace the intrinsic with that constant.
         if (C.ule(VLMAXRange.getUnsignedMin()))
           return IC.replaceInstUsesWith(II, ConstantInt::get(II.getType(), C));
-        VLRange = ConstantRange::getNonEmpty(APInt::getZero(BitWidth),
-                                             APIntOps::umin(C, MaxVL) + 1);
-      } else {
         VLRange =
-            ConstantRange::getNonEmpty(APInt::getZero(BitWidth), MaxVL + 1);
+            ConstantRange::getNonEmpty(MinVL, APIntOps::umin(C, MaxVL) + 1);
+      } else {
+        VLRange = ConstantRange::getNonEmpty(MinVL, MaxVL + 1);
       }
     }
 

--- a/llvm/test/Transforms/InstCombine/RISCV/riscv-vsetvli-range.ll
+++ b/llvm/test/Transforms/InstCombine/RISCV/riscv-vsetvli-range.ll
@@ -38,7 +38,7 @@ define i64 @vsetvli_const_avl_at_min128() {
 define i64 @vsetvli_const_avl_mid() {
 ; VLEN128-LABEL: define i64 @vsetvli_const_avl_mid(
 ; VLEN128-SAME: ) #[[ATTR0]] {
-; VLEN128-NEXT:    [[VL:%.*]] = call range(i64 0, 21) i64 @llvm.riscv.vsetvli.i64(i64 20, i64 0, i64 0)
+; VLEN128-NEXT:    [[VL:%.*]] = call range(i64 1, 21) i64 @llvm.riscv.vsetvli.i64(i64 20, i64 0, i64 0)
 ; VLEN128-NEXT:    ret i64 [[VL]]
 ;
 ; VLEN512-LABEL: define i64 @vsetvli_const_avl_mid(
@@ -54,7 +54,7 @@ define i64 @vsetvli_const_avl_mid() {
 define i64 @vsetvli_const_avl_above_max() {
 ; CHECK-LABEL: define i64 @vsetvli_const_avl_above_max(
 ; CHECK-SAME: ) #[[ATTR0]] {
-; CHECK-NEXT:    [[VL:%.*]] = call range(i64 0, 8193) i64 @llvm.riscv.vsetvli.i64(i64 100000, i64 0, i64 0)
+; CHECK-NEXT:    [[VL:%.*]] = call range(i64 1, 8193) i64 @llvm.riscv.vsetvli.i64(i64 100000, i64 0, i64 0)
 ; CHECK-NEXT:    ret i64 [[VL]]
 ;
   %vl = call i64 @llvm.riscv.vsetvli.i64(i64 100000, i64 0, i64 0)
@@ -129,7 +129,7 @@ define i64 @vsetvli_vl_known_nonzero(i64 %x) {
 ; CHECK-LABEL: define i64 @vsetvli_vl_known_nonzero(
 ; CHECK-SAME: i64 [[X:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[AVL:%.*]] = add nuw i64 [[X]], 1
-; CHECK-NEXT:    [[VL:%.*]] = call range(i64 0, 8193) i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 0)
+; CHECK-NEXT:    [[VL:%.*]] = call range(i64 1, 8193) i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 0)
 ; CHECK-NEXT:    ret i64 [[VL]]
 ;
   %avl = add nuw i64 %x, 1

--- a/llvm/test/Transforms/InstCombine/RISCV/riscv-vsetvli-range.ll
+++ b/llvm/test/Transforms/InstCombine/RISCV/riscv-vsetvli-range.ll
@@ -124,7 +124,7 @@ define i1 @vsetvli_runtime_avl_gt_max_folds(i64 %avl) {
   ret i1 %c
 }
 
-; vl known > 0, so range must be 0
+; vl known > 0, so range must be > 0
 define i64 @vsetvli_vl_known_nonzero(i64 %x) {
 ; CHECK-LABEL: define i64 @vsetvli_vl_known_nonzero(
 ; CHECK-SAME: i64 [[X:%.*]]) #[[ATTR0]] {

--- a/llvm/test/Transforms/InstCombine/RISCV/riscv-vsetvli-range.ll
+++ b/llvm/test/Transforms/InstCombine/RISCV/riscv-vsetvli-range.ll
@@ -123,3 +123,16 @@ define i1 @vsetvli_runtime_avl_gt_max_folds(i64 %avl) {
   %c = icmp ugt i64 %vl, 8192
   ret i1 %c
 }
+
+; vl known > 0, so range must be 0
+define i64 @vsetvli_vl_known_nonzero(i64 %x) {
+; CHECK-LABEL: define i64 @vsetvli_vl_known_nonzero(
+; CHECK-SAME: i64 [[X:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[AVL:%.*]] = add nuw i64 [[X]], 1
+; CHECK-NEXT:    [[VL:%.*]] = call range(i64 0, 8193) i64 @llvm.riscv.vsetvli.i64(i64 [[AVL]], i64 0, i64 0)
+; CHECK-NEXT:    ret i64 [[VL]]
+;
+  %avl = add nuw i64 %x, 1
+  %vl = call i64 @llvm.riscv.vsetvli.i64(i64 %avl, i64 0, i64 0)
+  ret i64 %vl
+}


### PR DESCRIPTION
A follow up from #218652, a non-zero AVL guarantees a non-zero vl per
the spec