### PR TITLE
[orc-rt] Add include/orc-rt-internal for internal APIs.

### DIFF
--- a/orc-rt/include/CMakeLists.txt
+++ b/orc-rt/include/CMakeLists.txt
@@ -1,3 +1,8 @@
+# Headers installed with the runtime.
+#
+# Headers under orc-rt-internal/ are deliberately not listed: they are not
+# installed. Don't add them here to "complete" the list. An installed header
+# must not include an internal one, or the installed tree won't compile.
 set(ORC_RT_HEADERS
     orc-rt-c/bedrock/Session.h
     orc-rt-c/support/Compiler.h
@@ -5,7 +10,6 @@ set(ORC_RT_HEADERS
     orc-rt-c/support/Error.h
     orc-rt-c/support/Logging.h
     orc-rt-c/support/WrapperFunction.h
-    orc-rt-utils/CommandLine.h
     orc-rt/bedrock/BootstrapInfo.h
     orc-rt/bedrock/ExecutorProcessInfo.h
     orc-rt/bedrock/InProcessControllerAccess.h
@@ -31,7 +35,6 @@ set(ORC_RT_HEADERS
     orc-rt/support/CCallback.h
     orc-rt/support/CallableTraitsHelper.h
     orc-rt/support/Compiler.h
-    orc-rt/support/Endian.h
     orc-rt/support/Error.h
     orc-rt/support/ExecutorAddress.h
     orc-rt/support/IntervalMap.h
@@ -47,7 +50,6 @@ set(ORC_RT_HEADERS
     orc-rt/support/SPSWrapperFunction.h
     orc-rt/support/SPSWrapperFunctionBuffer.h
     orc-rt/support/SimplePackedSerialization.h
-    orc-rt/support/StringExtras.h
     orc-rt/support/StringPool.h
     orc-rt/support/WrapperFunction.h
     orc-rt/support/bind.h

--- a/orc-rt/include/orc-rt-internal/bedrock/Environment.h
+++ b/orc-rt/include/orc-rt-internal/bedrock/Environment.h
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef ORC_RT_LIB_EXECUTOR_ENVIRONMENT_H
-#define ORC_RT_LIB_EXECUTOR_ENVIRONMENT_H
+#ifndef ORC_RT_INTERNAL_BEDROCK_ENVIRONMENT_H
+#define ORC_RT_INTERNAL_BEDROCK_ENVIRONMENT_H
 
 namespace orc_rt {
 
@@ -25,4 +25,4 @@ const char *secureGetenv(const char *Name);
 
 } // namespace orc_rt
 
-#endif // ORC_RT_LIB_EXECUTOR_ENVIRONMENT_H
+#endif // ORC_RT_INTERNAL_BEDROCK_ENVIRONMENT_H

--- a/orc-rt/include/orc-rt-internal/bedrock/GDBJITRegistrar.h
+++ b/orc-rt/include/orc-rt-internal/bedrock/GDBJITRegistrar.h
@@ -10,16 +10,12 @@
 // interface (also implemented by LLDB and other tools).
 //
 // These functions exist to implement the GDBJITRegistrar allocation actions in
-// the SPS controller interface (see sps-ci/GDBJITRegistrarSPSCI.cpp). They can
-// be called directly, but that isn't their purpose: this is a private
-// implementation header, not part of the public orc-rt API. If a direct client
-// ever appears, promote this header to include/orc-rt/ rather than reaching
-// into lib/.
+// the SPS controller interface (see sps/GDBJITRegistrarSPSCI.cpp).
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef ORC_RT_GDBJITREGISTRAR_H
-#define ORC_RT_GDBJITREGISTRAR_H
+#ifndef ORC_RT_INTERNAL_BEDROCK_GDBJITREGISTRAR_H
+#define ORC_RT_INTERNAL_BEDROCK_GDBJITREGISTRAR_H
 
 #include "orc-rt/support/Error.h"
 #include "orc-rt/support/span.h"
@@ -43,4 +39,4 @@ Error deregisterObject(span<char> Obj);
 
 } // namespace orc_rt::gdb_jit
 
-#endif // ORC_RT_GDBJITREGISTRAR_H
+#endif // ORC_RT_INTERNAL_BEDROCK_GDBJITREGISTRAR_H

--- a/orc-rt/include/orc-rt-internal/bedrock/TargetDetails.h
+++ b/orc-rt/include/orc-rt-internal/bedrock/TargetDetails.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef ORC_RT_TARGETDETAILS_H
-#define ORC_RT_TARGETDETAILS_H
+#ifndef ORC_RT_INTERNAL_BEDROCK_TARGETDETAILS_H
+#define ORC_RT_INTERNAL_BEDROCK_TARGETDETAILS_H
 
 #include <string_view>
 
@@ -48,4 +48,4 @@ inline constexpr std::string_view sha3 = "sha3";
 
 } // namespace orc_rt::target_detail
 
-#endif // ORC_RT_TARGETDETAILS_H
+#endif // ORC_RT_INTERNAL_BEDROCK_TARGETDETAILS_H

--- a/orc-rt/include/orc-rt-internal/support/Endian.h
+++ b/orc-rt/include/orc-rt-internal/support/Endian.h
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef ORC_RT_SUPPORT_ENDIAN_H
-#define ORC_RT_SUPPORT_ENDIAN_H
+#ifndef ORC_RT_INTERNAL_SUPPORT_ENDIAN_H
+#define ORC_RT_INTERNAL_SUPPORT_ENDIAN_H
 
 #include "orc-rt/support/bit.h"
 #include <cstring>
@@ -41,4 +41,4 @@ endian_write(void *Dst, T Val, orc_rt::endian E) noexcept {
 
 } // namespace orc_rt
 
-#endif // ORC_RT_SUPPORT_ENDIAN_H
+#endif // ORC_RT_INTERNAL_SUPPORT_ENDIAN_H

--- a/orc-rt/include/orc-rt-internal/support/StringExtras.h
+++ b/orc-rt/include/orc-rt-internal/support/StringExtras.h
@@ -6,8 +6,8 @@
 //
 //===---------------------------------------------------------------------===//
 
-#ifndef ORC_RT_SUPPORT_STRINGEXTRAS_H
-#define ORC_RT_SUPPORT_STRINGEXTRAS_H
+#ifndef ORC_RT_INTERNAL_SUPPORT_STRINGEXTRAS_H
+#define ORC_RT_INTERNAL_SUPPORT_STRINGEXTRAS_H
 
 #include <cassert>
 #include <charconv>

--- a/orc-rt/include/orc-rt-internal/tools/CommandLine.h
+++ b/orc-rt/include/orc-rt-internal/tools/CommandLine.h
@@ -11,8 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef ORC_RT_UTILS_COMMANDLINE_H
-#define ORC_RT_UTILS_COMMANDLINE_H
+#ifndef ORC_RT_INTERNAL_TOOLS_COMMANDLINE_H
+#define ORC_RT_INTERNAL_TOOLS_COMMANDLINE_H
 
 #include <algorithm>
 #include <charconv>
@@ -22,8 +22,8 @@
 #include <string_view>
 #include <vector>
 
+#include "orc-rt-internal/support/StringExtras.h"
 #include "orc-rt/support/Error.h"
-#include "orc-rt/support/StringExtras.h"
 
 namespace orc_rt {
 namespace detail {
@@ -261,4 +261,4 @@ private:
 
 } // namespace orc_rt
 
-#endif // ORC_RT_UTILS_COMMANDLINE_H
+#endif // ORC_RT_INTERNAL_TOOLS_COMMANDLINE_H

--- a/orc-rt/lib/bedrock/CMakeLists.txt
+++ b/orc-rt/lib/bedrock/CMakeLists.txt
@@ -65,13 +65,6 @@ add_library(orc-rt-bedrock STATIC ${ORC_RT_SOURCES})
 
 target_link_libraries(orc-rt-bedrock PUBLIC orc-rt-headers)
 
-add_library(orc-rt-bedrock-impl-headers INTERFACE)
-# Add it via lib so that to include impl details its "bedrock/"
-# to prevent collisions down the line
-target_include_directories(orc-rt-bedrock-impl-headers INTERFACE
-  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib>
-)
-
 # Apply RTTI and exceptions compile flags
 target_compile_options(orc-rt-bedrock PRIVATE ${ORC_RT_COMPILE_FLAGS})
 # TODO: Use common runtimes infrastructure for output and install paths

--- a/orc-rt/lib/bedrock/Environment.cpp
+++ b/orc-rt/lib/bedrock/Environment.cpp
@@ -15,7 +15,7 @@
 #define _GNU_SOURCE
 #endif
 
-#include "Environment.h"
+#include "orc-rt-internal/bedrock/Environment.h"
 
 #include <stdlib.h>
 

--- a/orc-rt/lib/bedrock/ExecutorProcessInfo.cpp
+++ b/orc-rt/lib/bedrock/ExecutorProcessInfo.cpp
@@ -12,8 +12,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "orc-rt/bedrock/ExecutorProcessInfo.h"
+#include "orc-rt-internal/support/StringExtras.h"
 #include "orc-rt/support/Math.h"
-#include "orc-rt/support/StringExtras.h"
 
 #include <cassert>
 #include <cstring>

--- a/orc-rt/lib/bedrock/GDBJITRegistrar.cpp
+++ b/orc-rt/lib/bedrock/GDBJITRegistrar.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "GDBJITRegistrar.h"
+#include "orc-rt-internal/bedrock/GDBJITRegistrar.h"
 #include "orc-rt/support/Compiler.h"
 
 #include <cstdint>

--- a/orc-rt/lib/bedrock/Logging_printf.cpp
+++ b/orc-rt/lib/bedrock/Logging_printf.cpp
@@ -13,7 +13,7 @@
 
 #include "orc-rt-c/support/Logging.h"
 
-#include "Environment.h"
+#include "orc-rt-internal/bedrock/Environment.h"
 
 #include <algorithm>
 #include <cstdarg>

--- a/orc-rt/lib/bedrock/SimpleNativeMemoryMap.cpp
+++ b/orc-rt/lib/bedrock/SimpleNativeMemoryMap.cpp
@@ -14,8 +14,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "orc-rt/bedrock/SimpleNativeMemoryMap.h"
+#include "orc-rt-internal/support/StringExtras.h"
 #include "orc-rt/bedrock/Session.h"
-#include "orc-rt/support/StringExtras.h"
 
 #include <optional>
 

--- a/orc-rt/lib/bedrock/Unix/NativeDylibAPIs.inc
+++ b/orc-rt/lib/bedrock/Unix/NativeDylibAPIs.inc
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "orc-rt-internal/support/StringExtras.h"
 #include "orc-rt/support/Error.h"
-#include "orc-rt/support/StringExtras.h"
 
 #include <dlfcn.h>
 

--- a/orc-rt/lib/bedrock/darwin/CPUFeatures.cpp
+++ b/orc-rt/lib/bedrock/darwin/CPUFeatures.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 #include "orc-rt/bedrock/ExecutorProcessInfo.h"
 
-#include "../TargetDetails.h"
+#include "orc-rt-internal/bedrock/TargetDetails.h"
 
 #include <cstdint>
 #include <sys/sysctl.h>

--- a/orc-rt/lib/bedrock/darwin/TargetTriple.cpp
+++ b/orc-rt/lib/bedrock/darwin/TargetTriple.cpp
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "../TargetDetails.h"
+#include "orc-rt-internal/bedrock/TargetDetails.h"
 #include "orc-rt/bedrock/ExecutorProcessInfo.h"
 
 #include <TargetConditionals.h>

--- a/orc-rt/lib/bedrock/sps/GDBJITRegistrarSPSCI.cpp
+++ b/orc-rt/lib/bedrock/sps/GDBJITRegistrarSPSCI.cpp
@@ -13,7 +13,7 @@
 #include "orc-rt/bedrock/sps/GDBJITRegistrarSPSCI.h"
 #include "orc-rt/support/SPSAllocAction.h"
 
-#include "../GDBJITRegistrar.h"
+#include "orc-rt-internal/bedrock/GDBJITRegistrar.h"
 
 using namespace orc_rt;
 

--- a/orc-rt/test/tools/orc-rt-log-check.cpp
+++ b/orc-rt/test/tools/orc-rt-log-check.cpp
@@ -25,7 +25,7 @@
 
 #include "orc-rt-c/support/Logging.h"
 
-#include "orc-rt-utils/CommandLine.h"
+#include "orc-rt-internal/tools/CommandLine.h"
 
 #include <iostream>
 

--- a/orc-rt/test/tools/orc-rt-process-info-check.cpp
+++ b/orc-rt/test/tools/orc-rt-process-info-check.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "orc-rt-utils/CommandLine.h"
+#include "orc-rt-internal/tools/CommandLine.h"
 #include "orc-rt/bedrock/ExecutorProcessInfo.h"
 #include <iostream>
 

--- a/orc-rt/test/unit/CMakeLists.txt
+++ b/orc-rt/test/unit/CMakeLists.txt
@@ -75,7 +75,6 @@ target_compile_options(CoreTests PRIVATE ${ORC_RT_COMPILE_FLAGS})
 target_include_directories(CoreTests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(CoreTests PRIVATE
   orc-rt-bedrock
-  orc-rt-bedrock-impl-headers
   )
 
 # Build a shared library for NativeDylibManager tests.

--- a/orc-rt/test/unit/bedrock/ExecutorProcessInfoTest.cpp
+++ b/orc-rt/test/unit/bedrock/ExecutorProcessInfoTest.cpp
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "orc-rt/bedrock/ExecutorProcessInfo.h"
-#include "bedrock/TargetDetails.h"
+#include "orc-rt-internal/bedrock/TargetDetails.h"
 #include "orc-rt/support/Math.h"
 #include "gtest/gtest.h"
 

--- a/orc-rt/test/unit/support/EndianTest.cpp
+++ b/orc-rt/test/unit/support/EndianTest.cpp
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "orc-rt/support/Endian.h"
+#include "orc-rt-internal/support/Endian.h"
 #include "orc-rt/support/bit.h"
 #include "gtest/gtest.h"
 

--- a/orc-rt/test/unit/support/StringExtrasTest.cpp
+++ b/orc-rt/test/unit/support/StringExtrasTest.cpp
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "orc-rt/support/StringExtras.h"
+#include "orc-rt-internal/support/StringExtras.h"
 #include "gtest/gtest.h"
 
 #include <cstdint>

--- a/orc-rt/test/unit/utils/CommandLineTest.cpp
+++ b/orc-rt/test/unit/utils/CommandLineTest.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "orc-rt-utils/CommandLine.h"
+#include "orc-rt-internal/tools/CommandLine.h"
 #include "orc-rt/support/Error.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"


### PR DESCRIPTION
Headers here are not installed. A prefix directory rather than a separate include root, so that internality is visible at each #include site.

Moved in: support/{Endian,StringExtras}.h; orc-rt-utils/CommandLine.h becomes orc-rt-internal/tools/CommandLine.h, retiring orc-rt-utils/ as a third include root; and lib/bedrock/{Environment,GDBJITRegistrar, TargetDetails}.h, so lib/ now holds only translation units and the two Unix/*.inc fragments. That also removes the last "../" include, and orc-rt-bedrock-impl-headers, which existed only to expose lib/ for cross-directory includes.