### PR TITLE
[XRay] Ignore debug instructions in instruction threshold

### DIFF
--- a/llvm/lib/CodeGen/XRayInstrumentation.cpp
+++ b/llvm/lib/CodeGen/XRayInstrumentation.cpp
@@ -217,10 +217,12 @@ bool XRayInstrumentation::run(MachineFunction &MF) {
     if (XRayThreshold == std::numeric_limits<uint64_t>::max())
       return false;
 
-    // Count the number of MachineInstr`s in MachineFunction
+    // Count the number of non-debug MachineInstrs in MachineFunction.
     uint64_t MICount = 0;
     for (const auto &MBB : MF)
-      MICount += MBB.size();
+      MICount += llvm::count_if(MBB.instrs(), [](const MachineInstr &MI) {
+        return !MI.isDebugInstr();
+      });
 
     bool TooFewInstrs = MICount < XRayThreshold;
 

--- a/llvm/test/CodeGen/X86/xray-debug-instruction-threshold.mir
+++ b/llvm/test/CodeGen/X86/xray-debug-instruction-threshold.mir
@@ -1,10 +1,10 @@
 # RUN: llc -mtriple=x86_64-unknown-linux-gnu -verify-machineinstrs -run-pass=xray-instrumentation -o - %s | FileCheck %s
 # RUN: llc -mtriple=x86_64-unknown-linux-gnu -verify-machineinstrs -passes=xray-instrumentation -o - %s | FileCheck %s
 #
-# Document the current threshold behavior with and without a debug instruction.
-# All functions have three non-debug instructions. At threshold four, the
-# function without debug information is not instrumented, while the additional
-# DBG_VALUE causes the function with debug information to be instrumented.
+# Debug instructions should not count toward the XRay instruction threshold.
+# All functions have three non-debug instructions. The two functions with a
+# threshold of four should not be instrumented, while the positive control at
+# threshold three should be instrumented.
 
 --- |
   define i32 @without_debug(i32 %x) noinline uwtable "xray-instruction-threshold"="4" {
@@ -57,8 +57,8 @@ body: |
 ---
 # CHECK-LABEL: name: with_debug
 # CHECK: bb.0.entry:
-# CHECK: PATCHABLE_FUNCTION_ENTER
-# CHECK: PATCHABLE_RET
+# CHECK-NOT: PATCHABLE_
+# CHECK: RET64
 name: with_debug
 tracksRegLiveness: true
 body: |

--- a/llvm/test/CodeGen/X86/xray-debug-instruction-threshold.mir
+++ b/llvm/test/CodeGen/X86/xray-debug-instruction-threshold.mir
@@ -1,0 +1,86 @@
+# RUN: llc -mtriple=x86_64-unknown-linux-gnu -verify-machineinstrs -run-pass=xray-instrumentation -o - %s | FileCheck %s
+# RUN: llc -mtriple=x86_64-unknown-linux-gnu -verify-machineinstrs -passes=xray-instrumentation -o - %s | FileCheck %s
+#
+# Document the current threshold behavior with and without a debug instruction.
+# All functions have three non-debug instructions. At threshold four, the
+# function without debug information is not instrumented, while the additional
+# DBG_VALUE causes the function with debug information to be instrumented.
+
+--- |
+  define i32 @without_debug(i32 %x) noinline uwtable "xray-instruction-threshold"="4" {
+  entry:
+    %result = add i32 %x, 1
+    ret i32 %result
+  }
+
+  define i32 @with_debug(i32 %x) noinline uwtable "xray-instruction-threshold"="4" !dbg !4 {
+  entry:
+    %result = add i32 %x, 1
+    ret i32 %result
+  }
+
+  define i32 @with_debug_at_threshold(i32 %x) noinline uwtable "xray-instruction-threshold"="3" !dbg !9 {
+  entry:
+    %result = add i32 %x, 1
+    ret i32 %result
+  }
+
+  !llvm.dbg.cu = !{!0}
+  !llvm.module.flags = !{!3}
+  !0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, emissionKind: FullDebug)
+  !1 = !DIFile(filename: "x.c", directory: "/")
+  !2 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+  !3 = !{i32 2, !"Debug Info Version", i32 3}
+  !4 = distinct !DISubprogram(name: "with_debug", scope: !1, file: !1, line: 1, type: !5, unit: !0, spFlags: DISPFlagDefinition)
+  !5 = !DISubroutineType(types: !6)
+  !6 = !{!2, !2}
+  !7 = !DILocalVariable(name: "x", arg: 1, scope: !4, file: !1, line: 1, type: !2)
+  !8 = !DILocation(line: 1, scope: !4)
+  !9 = distinct !DISubprogram(name: "with_debug_at_threshold", scope: !1, file: !1, line: 2, type: !5, unit: !0, spFlags: DISPFlagDefinition)
+  !10 = !DILocalVariable(name: "x", arg: 1, scope: !9, file: !1, line: 2, type: !2)
+  !11 = !DILocation(line: 2, scope: !9)
+...
+---
+# CHECK-LABEL: name: without_debug
+# CHECK: bb.0.entry:
+# CHECK-NOT: PATCHABLE_
+# CHECK: RET64
+name: without_debug
+tracksRegLiveness: true
+body: |
+  bb.0.entry:
+    liveins: $edi
+    renamable $edi = KILL $edi, implicit-def $rdi
+    renamable $eax = LEA64_32r killed renamable $rdi, 1, $noreg, 1, $noreg
+    RET64 $eax
+...
+---
+# CHECK-LABEL: name: with_debug
+# CHECK: bb.0.entry:
+# CHECK: PATCHABLE_FUNCTION_ENTER
+# CHECK: PATCHABLE_RET
+name: with_debug
+tracksRegLiveness: true
+body: |
+  bb.0.entry:
+    liveins: $edi
+    DBG_VALUE $edi, $noreg, !7, !DIExpression(), debug-location !8
+    renamable $edi = KILL $edi, implicit-def $rdi
+    renamable $eax = LEA64_32r killed renamable $rdi, 1, $noreg, 1, $noreg
+    RET64 $eax
+...
+---
+# CHECK-LABEL: name: with_debug_at_threshold
+# CHECK: bb.0.entry:
+# CHECK: PATCHABLE_FUNCTION_ENTER
+# CHECK: PATCHABLE_RET
+name: with_debug_at_threshold
+tracksRegLiveness: true
+body: |
+  bb.0.entry:
+    liveins: $edi
+    DBG_VALUE $edi, $noreg, !10, !DIExpression(), debug-location !11
+    renamable $edi = KILL $edi, implicit-def $rdi
+    renamable $eax = LEA64_32r killed renamable $rdi, 1, $noreg, 1, $noreg
+    RET64 $eax
+...


### PR DESCRIPTION
Debug instructions currently contribute to `xray-instruction-threshold`, so
enabling debug information can change whether a function is instrumented.

Count raw machine instructions while excluding only debug instructions. Using
the raw instruction range preserves the existing treatment of bundled
instructions and non-debug meta instructions.

The first commit records the existing behavior. The second applies the fix and
updates the test expectations.

Fixes #219376

Assisted-by: OpenAI Codex 5.6 Sol, co-reviewed by Claude and Yongqiang Tian.
