### PR TITLE
AMDGPU: Use use_nodbg_instructions in GCNSchedStrategy MFMA check

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -2381,8 +2381,8 @@ bool RewriteMFMAFormStage::isRewriteCandidate(MachineInstr *MI) const {
     return false;
   // Reject candidates whose users force an unavoidable bridge copy.
   Register DstReg = MI->getOperand(0).getReg();
-  for (const MachineOperand &Use : DAG.MRI.use_nodbg_operands(DstReg)) {
-    if (!TII->isMAI(*Use.getParent()) && !Use.getParent()->isCopy())
+  for (const MachineInstr &UseMI : DAG.MRI.use_nodbg_instructions(DstReg)) {
+    if (!TII->isMAI(UseMI) && !UseMI.isCopy())
       return false;
   }
   return true;


### PR DESCRIPTION
The loop only inspects the using instruction, so iterate
use_nodbg_instructions() instead of the operands and their parents.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>