### PR TITLE
Hexagon: Use use_instructions in EarlyIfConversion predicate check

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonEarlyIfConv.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonEarlyIfConv.cpp
@@ -383,8 +383,8 @@ bool HexagonEarlyIfConversion::isValidCandidate(const MachineBasicBlock *B)
         continue;
       if (!isPredicate(R))
         continue;
-      for (const MachineOperand &U : MRI->use_operands(R))
-        if (U.getParent()->isPHI())
+      for (const MachineInstr &UseMI : MRI->use_instructions(R))
+        if (UseMI.isPHI())
           return false;
     }
   }


### PR DESCRIPTION
The loop only checks whether any user is a PHI, so iterate
use_instructions() instead of the operands to query the parents.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>