### PR TITLE
[RISCV] Remove dead declarations

### DIFF
--- a/llvm/lib/Target/RISCV/GISel/RISCVLegalizerInfo.h
+++ b/llvm/lib/Target/RISCV/GISel/RISCVLegalizerInfo.h
@@ -39,8 +39,6 @@ public:
 
 private:
   bool shouldBeInConstantPool(const APInt &APImm, bool ShouldOptForSize) const;
-  bool legalizeShlAshrLshr(MachineInstr &MI, MachineIRBuilder &MIRBuilder,
-                           GISelChangeObserver &Observer) const;
 
   bool legalizeBitreverse(MachineInstr &MI, MachineIRBuilder &MIB) const;
   bool legalizeBRJT(MachineInstr &MI, MachineIRBuilder &MIRBuilder) const;

--- a/llvm/lib/Target/RISCV/RISCVFrameLowering.h
+++ b/llvm/lib/Target/RISCV/RISCVFrameLowering.h
@@ -105,9 +105,6 @@ private:
                                    bool HasFP) const;
   void emitCalleeSavedRVVEpilogCFI(MachineBasicBlock &MBB,
                                    MachineBasicBlock::iterator MI) const;
-  template <typename Emitter>
-  void emitCFIForCSI(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI,
-                     const SmallVector<CalleeSavedInfo, 8> &CSI) const;
   void deallocateStack(MachineFunction &MF, MachineBasicBlock &MBB,
                        MachineBasicBlock::iterator MBBI, const DebugLoc &DL,
                        uint64_t &StackSize, int64_t CFAOffset) const;

--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.h
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.h
@@ -229,7 +229,6 @@ private:
   bool doPeepholeSExtW(SDNode *Node);
   bool doPeepholeMaskedRVV(MachineSDNode *Node);
   bool doPeepholeNoRegPassThru();
-  bool performCombineVMergeAndVOps(SDNode *N);
   bool selectImm64IfCheaper(int64_t Imm, int64_t OrigImm, SDValue N,
                             SDValue &Val);
 };

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.h
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.h
@@ -541,8 +541,6 @@ private:
   SDValue lowerLoadFF(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerMaskedStore(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerVectorCompress(SDValue Op, SelectionDAG &DAG) const;
-  SDValue lowerFixedLengthVectorFCOPYSIGNToRVV(SDValue Op,
-                                               SelectionDAG &DAG) const;
   SDValue lowerMaskedGather(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerMaskedScatter(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerFixedLengthVectorLoadToRVV(SDValue Op, SelectionDAG &DAG) const;


### PR DESCRIPTION
legalizeShlAshrLshr: The corresponding function definition was
removed on October 1, 2024 in commit
1053b3ea24f2401b6c8f143b9c1bd45032bc93ba.

emitCFIForCSI: The corresponding function definition was removed on
April 16, 2025 in commit ed9bcb52954f8e6171563d2b8310b0ca6d03d655.

performCombineVMergeAndVOps: The corresponding function definition was
removed on July 4, 2025 in commit
07ae19c132e1b0adbdb3cc036b9f50624e2ed1b7.

lowerFixedLengthVectorFCOPYSIGNToRVV: The corresponding function
definition was removed on August 5, 2025 in commit
5a80274cae3c5d19cf5058550139cb857513ae02.
