### PR TITLE
X86: Use use_instructions in CompressEVEX cross-block check

### DIFF
--- a/llvm/lib/Target/X86/X86CompressEVEX.cpp
+++ b/llvm/lib/Target/X86/X86CompressEVEX.cpp
@@ -372,8 +372,8 @@ static bool tryCompressVPMOVPattern(MachineInstr &MI, MachineBasicBlock &MBB,
     return false;
 
   // Check if MaskReg is used in any other basic blocks
-  for (const MachineOperand &MO : MRI->use_operands(MaskReg))
-    if (MO.getParent()->getParent() != &MBB)
+  for (const MachineInstr &UseMI : MRI->use_instructions(MaskReg))
+    if (UseMI.getParent() != &MBB)
       return false;
 
   // Apply the transformation


### PR DESCRIPTION
The loop only checks the using instruction's parent block, so iterate
use_instructions() instead of the operands and checking their parents.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>