### PR TITLE
PowerPC: Use use_instructions in TLSDynamicCall user collection

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCTLSDynamicCall.cpp
+++ b/llvm/lib/Target/PowerPC/PPCTLSDynamicCall.cpp
@@ -180,8 +180,8 @@ protected:
             if (!RegInfo.use_empty(OutReg)) {
               std::set<MachineInstr *> Uses;
               // Collect all instructions that use the OutReg.
-              for (MachineOperand &MO : RegInfo.use_operands(OutReg))
-                Uses.insert(MO.getParent());
+              for (MachineInstr &UseMI : RegInfo.use_instructions(OutReg))
+                Uses.insert(&UseMI);
               // Find the first user (e.g.: lwax/stfdx) of the OutReg within the
               // current BB.
               MachineBasicBlock::iterator UseIter = MBB.begin();


### PR DESCRIPTION
The loop only collects the using instructions, so iterate
use_instructions() instead of the operands to get their parents.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>