### PR TITLE
CodeGen: Pass instruction and operand index to isPCRelRegisterOperandLegal

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -1098,10 +1098,12 @@ public:
   /// (non-PC) registers as offsets or scaling values, which inherently
   /// tags the corresponding MachineOperand with OPERAND_PCREL.
   ///
-  /// @param MO The MachineOperand in question. MO.isReg() should always
-  /// be true.
+  /// @param MI The instruction containing the operand in question.
+  /// @param OpIdx The index of the operand in question. It should always be a
+  /// register operand.
   /// @return Whether this operand is allowed to be used PC-relatively.
-  virtual bool isPCRelRegisterOperandLegal(const MachineOperand &MO) const {
+  virtual bool isPCRelRegisterOperandLegal(const MachineInstr &MI,
+                                           unsigned OpIdx) const {
     return false;
   }
 

--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -2650,7 +2650,7 @@ MachineVerifier::visitMachineOperand(const MachineOperand *MO, unsigned MONum) {
       if (MO->isReg()) {
         if (MCOI.OperandType == MCOI::OPERAND_IMMEDIATE ||
             (MCOI.OperandType == MCOI::OPERAND_PCREL &&
-             !TII->isPCRelRegisterOperandLegal(*MO)))
+             !TII->isPCRelRegisterOperandLegal(*MI, MONum)))
           report("Expected a non-register operand.", MO, MONum);
       }
     }

--- a/llvm/lib/Target/M68k/M68kInstrInfo.cpp
+++ b/llvm/lib/Target/M68k/M68kInstrInfo.cpp
@@ -710,26 +710,24 @@ bool M68kInstrInfo::expandPostRAPseudo(MachineInstr &MI) const {
   return false;
 }
 
-bool M68kInstrInfo::isPCRelRegisterOperandLegal(
-    const MachineOperand &MO) const {
-  assert(MO.isReg());
+bool M68kInstrInfo::isPCRelRegisterOperandLegal(const MachineInstr &MI,
+                                                unsigned OpIdx) const {
+  assert(MI.getOperand(OpIdx).isReg());
 
-  // Check whether this MO belongs to an instruction with addressing mode 'k',
-  // Refer to TargetInstrInfo.h for more information about this function.
+  // Check whether this operand belongs to an instruction with addressing mode
+  // 'k', Refer to TargetInstrInfo.h for more information about this function.
 
-  const MachineInstr *MI = MO.getParent();
-  const unsigned NameIndices = M68kInstrNameIndices[MI->getOpcode()];
+  const unsigned NameIndices = M68kInstrNameIndices[MI.getOpcode()];
   StringRef InstrName(&M68kInstrNameData[NameIndices]);
-  const unsigned OperandNo = MO.getOperandNo();
 
   // If this machine operand is the 2nd operand, then check
   // whether the instruction has destination addressing mode 'k'.
-  if (OperandNo == 1)
+  if (OpIdx == 1)
     return Regex("[A-Z]+(8|16|32)k[a-z](_TC)?$").match(InstrName);
 
   // If this machine operand is the last one, then check
   // whether the instruction has source addressing mode 'k'.
-  if (OperandNo == MI->getNumExplicitOperands() - 1)
+  if (OpIdx == MI.getNumExplicitOperands() - 1)
     return Regex("[A-Z]+(8|16|32)[a-z]k(_TC)?$").match(InstrName);
 
   return false;

--- a/llvm/lib/Target/M68k/M68kInstrInfo.h
+++ b/llvm/lib/Target/M68k/M68kInstrInfo.h
@@ -291,7 +291,8 @@ public:
 
   bool expandPostRAPseudo(MachineInstr &MI) const override;
 
-  bool isPCRelRegisterOperandLegal(const MachineOperand &MO) const override;
+  bool isPCRelRegisterOperandLegal(const MachineInstr &MI,
+                                   unsigned OpIdx) const override;
 
   /// Add appropriate SExt nodes
   void AddSExt(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,


### PR DESCRIPTION
Replace the MachineOperand argument to the
TargetInstrInfo::isPCRelRegisterOperandLegal hook with the containing
instruction and operand index. The M68k implementation only used the operand
to recover its parent instruction and operand number, so this drops the
dependence on MachineOperand::getParent().

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>