### PR TITLE
AMDGPU: Pass MachineRegisterInfo to getImmOrMaterializedImm

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
@@ -1702,7 +1702,7 @@ bool SIFoldOperandsImpl::tryConstantFoldOp(MachineInstr *MI) const {
     return false;
 
   MachineOperand *Src0 = &MI->getOperand(Src0Idx);
-  std::optional<int64_t> Src0Imm = TII->getImmOrMaterializedImm(*Src0);
+  std::optional<int64_t> Src0Imm = TII->getImmOrMaterializedImm(*MRI, *Src0);
 
   if ((Opc == AMDGPU::V_NOT_B32_e64 || Opc == AMDGPU::V_NOT_B32_e32 ||
        Opc == AMDGPU::S_NOT_B32) &&
@@ -1718,7 +1718,7 @@ bool SIFoldOperandsImpl::tryConstantFoldOp(MachineInstr *MI) const {
     return false;
 
   MachineOperand *Src1 = &MI->getOperand(Src1Idx);
-  std::optional<int64_t> Src1Imm = TII->getImmOrMaterializedImm(*Src1);
+  std::optional<int64_t> Src1Imm = TII->getImmOrMaterializedImm(*MRI, *Src1);
 
   if (!Src0Imm && !Src1Imm)
     return false;
@@ -1831,11 +1831,11 @@ bool SIFoldOperandsImpl::tryFoldCndMask(MachineInstr &MI) const {
   MachineOperand *Src0 = TII->getNamedOperand(MI, AMDGPU::OpName::src0);
   MachineOperand *Src1 = TII->getNamedOperand(MI, AMDGPU::OpName::src1);
   if (!Src1->isIdenticalTo(*Src0)) {
-    std::optional<int64_t> Src1Imm = TII->getImmOrMaterializedImm(*Src1);
+    std::optional<int64_t> Src1Imm = TII->getImmOrMaterializedImm(*MRI, *Src1);
     if (!Src1Imm)
       return false;
 
-    std::optional<int64_t> Src0Imm = TII->getImmOrMaterializedImm(*Src0);
+    std::optional<int64_t> Src0Imm = TII->getImmOrMaterializedImm(*MRI, *Src0);
     if (!Src0Imm || *Src0Imm != *Src1Imm)
       return false;
   }
@@ -1874,11 +1874,11 @@ SIFoldOperandsImpl::getANDMaskRegOperand(MachineInstr &AndMI) const {
     return std::nullopt;
 
   std::optional<int64_t> MaskImm =
-      TII->getImmOrMaterializedImm(AndMI.getOperand(1));
+      TII->getImmOrMaterializedImm(*MRI, AndMI.getOperand(1));
   if (MaskImm && AndMI.getOperand(2).isReg())
     return ANDMaskResult{*MaskImm, AndMI.getOperand(2).getReg(), 2};
 
-  MaskImm = TII->getImmOrMaterializedImm(AndMI.getOperand(2));
+  MaskImm = TII->getImmOrMaterializedImm(*MRI, AndMI.getOperand(2));
   if (MaskImm && AndMI.getOperand(1).isReg())
     return ANDMaskResult{*MaskImm, AndMI.getOperand(1).getReg(), 1};
 
@@ -2460,7 +2460,7 @@ SIFoldOperandsImpl::isOMod(const MachineInstr &MI) const {
 
     // If there is an immediate operand, it must be Src1
     std::optional<int64_t> Src1Imm =
-        TII->getImmOrMaterializedImm(const_cast<MachineOperand &>(*Src1));
+        TII->getImmOrMaterializedImm(*MRI, const_cast<MachineOperand &>(*Src1));
     if (!Src1Imm)
       return {nullptr, SIOutMods::NONE};
 
@@ -2514,7 +2514,7 @@ SIFoldOperandsImpl::isOMod(const MachineInstr &MI) const {
 
     // If there is an immediate operand, it must be Src1
     std::optional<int64_t> Src1Imm =
-        TII->getImmOrMaterializedImm(const_cast<MachineOperand &>(*Src1));
+        TII->getImmOrMaterializedImm(*MRI, const_cast<MachineOperand &>(*Src1));
     if (!Src1Imm)
       return {nullptr, SIOutMods::NONE};
 

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -1309,13 +1309,13 @@ bool SIInstrInfo::getConstValDefinedInReg(const MachineInstr &MI,
 }
 
 std::optional<int64_t>
-SIInstrInfo::getImmOrMaterializedImm(MachineOperand &Op) const {
+SIInstrInfo::getImmOrMaterializedImm(const MachineRegisterInfo &MRI,
+                                     MachineOperand &Op) const {
   if (Op.isImm())
     return Op.getImm();
 
   if (!Op.isReg() || !Op.getReg().isVirtual())
     return std::nullopt;
-  MachineRegisterInfo &MRI = Op.getParent()->getMF()->getRegInfo();
   const MachineInstr *Def = MRI.getVRegDef(Op.getReg());
   if (Def && Def->isMoveImmediate()) {
     const MachineOperand &ImmSrc = Def->getOperand(1);

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -325,7 +325,8 @@ public:
   bool getConstValDefinedInReg(const MachineInstr &MI, const Register Reg,
                                int64_t &ImmVal) const override;
 
-  std::optional<int64_t> getImmOrMaterializedImm(MachineOperand &Op) const;
+  std::optional<int64_t> getImmOrMaterializedImm(const MachineRegisterInfo &MRI,
+                                                 MachineOperand &Op) const;
 
   unsigned getVectorRegSpillSaveOpcode(Register Reg,
                                        const TargetRegisterClass *RC,

--- a/llvm/lib/Target/AMDGPU/SILoadStoreOptimizer.cpp
+++ b/llvm/lib/Target/AMDGPU/SILoadStoreOptimizer.cpp
@@ -2272,7 +2272,7 @@ bool SILoadStoreOptimizer::processBaseWithConstOffset64(
 
   const MachineOperand *BaseOp = nullptr;
 
-  auto Offset = TII->getImmOrMaterializedImm(*Src1);
+  auto Offset = TII->getImmOrMaterializedImm(*MRI, *Src1);
 
   if (Offset) {
     BaseOp = Src0;
@@ -2336,11 +2336,11 @@ void SILoadStoreOptimizer::processBaseWithConstOffset(const MachineOperand &Base
   MachineOperand *Src0 = TII->getNamedOperand(*BaseLoDef, AMDGPU::OpName::src0);
   MachineOperand *Src1 = TII->getNamedOperand(*BaseLoDef, AMDGPU::OpName::src1);
 
-  auto Offset0P = TII->getImmOrMaterializedImm(*Src0);
+  auto Offset0P = TII->getImmOrMaterializedImm(*MRI, *Src0);
   if (Offset0P)
     BaseLo = *Src1;
   else {
-    if (!(Offset0P = TII->getImmOrMaterializedImm(*Src1)))
+    if (!(Offset0P = TII->getImmOrMaterializedImm(*MRI, *Src1)))
       return;
     BaseLo = *Src0;
   }


### PR DESCRIPTION
The only used the operand to reach the MachineRegisterInfo. Pass it
directly so it no longer depends on MachineOperand::getParent().

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>