### PR TITLE
[Mips] Strip \x01 no-mangle prefix from R_MIPS_JALR symbol name

### DIFF
--- a/llvm/lib/Target/Mips/MipsAsmPrinter.cpp
+++ b/llvm/lib/Target/Mips/MipsAsmPrinter.cpp
@@ -43,6 +43,7 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/Mangler.h"
 #include "llvm/IR/Module.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCExpr.h"
@@ -147,21 +148,23 @@ void MipsAsmPrinter::emitPseudoIndirectBranch(MCStreamer &OutStreamer,
 //
 // This is an optimization hint for the linker which may then replace
 // an indirect call with a direct branch.
-static void emitDirectiveRelocJalr(const MachineInstr &MI,
-                                   MCContext &OutContext,
-                                   TargetMachine &TM,
-                                   MCStreamer &OutStreamer,
-                                   const MipsSubtarget &Subtarget) {
+void emitDirectiveRelocJalr(const MachineInstr &MI, MCContext &OutContext,
+                            TargetMachine &TM, MCStreamer &OutStreamer,
+                            const MipsSubtarget &Subtarget,
+                            const DataLayout &DL) {
   for (const MachineOperand &MO :
        llvm::drop_begin(MI.operands(), MI.getDesc().getNumOperands())) {
     if (MO.isMCSymbol() && (MO.getTargetFlags() & MipsII::MO_JALR)) {
       MCSymbol *Callee = MO.getMCSymbol();
       if (Callee && !Callee->getName().empty()) {
+        SmallString<128> Name;
+        MCSymbol *Sym = nullptr;
+        Mangler::getNameWithPrefix(Name, Callee->getName(), DL);
+        Sym = OutContext.getOrCreateSymbol(Name);
         MCSymbol *OffsetLabel = OutContext.createTempSymbol();
         const MCExpr *OffsetExpr =
             MCSymbolRefExpr::create(OffsetLabel, OutContext);
-        const MCExpr *CaleeExpr =
-            MCSymbolRefExpr::create(Callee, OutContext);
+        const MCExpr *CaleeExpr = MCSymbolRefExpr::create(Sym, OutContext);
         OutStreamer.emitRelocDirective(
             *OffsetExpr,
             Subtarget.inMicroMipsMode() ? "R_MICROMIPS_JALR" : "R_MIPS_JALR",
@@ -238,7 +241,8 @@ void MipsAsmPrinter::emitInstruction(const MachineInstr *MI) {
 
   if (EmitJalrReloc &&
       (MI->isReturn() || MI->isCall() || MI->isIndirectBranch())) {
-    emitDirectiveRelocJalr(*MI, OutContext, TM, *OutStreamer, *Subtarget);
+    emitDirectiveRelocJalr(*MI, OutContext, TM, *OutStreamer, *Subtarget,
+                           MF->getDataLayout());
   }
 
   MachineBasicBlock::const_instr_iterator I = MI->getIterator();

--- a/llvm/lib/Target/Mips/MipsAsmPrinter.cpp
+++ b/llvm/lib/Target/Mips/MipsAsmPrinter.cpp
@@ -157,8 +157,7 @@ void MipsAsmPrinter::emitDirectiveRelocJalr(const MachineInstr &MI,
     if (MO.isMCSymbol() && (MO.getTargetFlags() & MipsII::MO_JALR)) {
       MCSymbol *Callee = MO.getMCSymbol();
       if (Callee && !Callee->getName().empty()) {
-        MCSymbol *Sym = nullptr;
-        Sym = GetExternalSymbolSymbol(Callee->getName());
+        MCSymbol *Sym = GetExternalSymbolSymbol(Callee->getName());
         MCSymbol *OffsetLabel = OutContext.createTempSymbol();
         const MCExpr *OffsetExpr =
             MCSymbolRefExpr::create(OffsetLabel, OutContext);

--- a/llvm/lib/Target/Mips/MipsAsmPrinter.cpp
+++ b/llvm/lib/Target/Mips/MipsAsmPrinter.cpp
@@ -148,19 +148,16 @@ void MipsAsmPrinter::emitPseudoIndirectBranch(MCStreamer &OutStreamer,
 //
 // This is an optimization hint for the linker which may then replace
 // an indirect call with a direct branch.
-void emitDirectiveRelocJalr(const MachineInstr &MI, MCContext &OutContext,
+void MipsAsmPrinter::emitDirectiveRelocJalr(const MachineInstr &MI, MCContext &OutContext,
                             TargetMachine &TM, MCStreamer &OutStreamer,
-                            const MipsSubtarget &Subtarget,
-                            const DataLayout &DL) {
+                            const MipsSubtarget &Subtarget) {
   for (const MachineOperand &MO :
        llvm::drop_begin(MI.operands(), MI.getDesc().getNumOperands())) {
     if (MO.isMCSymbol() && (MO.getTargetFlags() & MipsII::MO_JALR)) {
       MCSymbol *Callee = MO.getMCSymbol();
       if (Callee && !Callee->getName().empty()) {
-        SmallString<128> Name;
         MCSymbol *Sym = nullptr;
-        Mangler::getNameWithPrefix(Name, Callee->getName(), DL);
-        Sym = OutContext.getOrCreateSymbol(Name);
+	Sym = GetExternalSymbolSymbol(Callee->getName());
         MCSymbol *OffsetLabel = OutContext.createTempSymbol();
         const MCExpr *OffsetExpr =
             MCSymbolRefExpr::create(OffsetLabel, OutContext);
@@ -241,8 +238,7 @@ void MipsAsmPrinter::emitInstruction(const MachineInstr *MI) {
 
   if (EmitJalrReloc &&
       (MI->isReturn() || MI->isCall() || MI->isIndirectBranch())) {
-    emitDirectiveRelocJalr(*MI, OutContext, TM, *OutStreamer, *Subtarget,
-                           MF->getDataLayout());
+    emitDirectiveRelocJalr(*MI, OutContext, TM, *OutStreamer, *Subtarget);
   }
 
   MachineBasicBlock::const_instr_iterator I = MI->getIterator();

--- a/llvm/lib/Target/Mips/MipsAsmPrinter.cpp
+++ b/llvm/lib/Target/Mips/MipsAsmPrinter.cpp
@@ -43,7 +43,6 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/Instructions.h"
-#include "llvm/IR/Mangler.h"
 #include "llvm/IR/Module.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCExpr.h"

--- a/llvm/lib/Target/Mips/MipsAsmPrinter.cpp
+++ b/llvm/lib/Target/Mips/MipsAsmPrinter.cpp
@@ -148,16 +148,18 @@ void MipsAsmPrinter::emitPseudoIndirectBranch(MCStreamer &OutStreamer,
 //
 // This is an optimization hint for the linker which may then replace
 // an indirect call with a direct branch.
-void MipsAsmPrinter::emitDirectiveRelocJalr(const MachineInstr &MI, MCContext &OutContext,
-                            TargetMachine &TM, MCStreamer &OutStreamer,
-                            const MipsSubtarget &Subtarget) {
+void MipsAsmPrinter::emitDirectiveRelocJalr(const MachineInstr &MI,
+                                            MCContext &OutContext,
+                                            TargetMachine &TM,
+                                            MCStreamer &OutStreamer,
+                                            const MipsSubtarget &Subtarget) {
   for (const MachineOperand &MO :
        llvm::drop_begin(MI.operands(), MI.getDesc().getNumOperands())) {
     if (MO.isMCSymbol() && (MO.getTargetFlags() & MipsII::MO_JALR)) {
       MCSymbol *Callee = MO.getMCSymbol();
       if (Callee && !Callee->getName().empty()) {
         MCSymbol *Sym = nullptr;
-	Sym = GetExternalSymbolSymbol(Callee->getName());
+        Sym = GetExternalSymbolSymbol(Callee->getName());
         MCSymbol *OffsetLabel = OutContext.createTempSymbol();
         const MCExpr *OffsetExpr =
             MCSymbolRefExpr::create(OffsetLabel, OutContext);

--- a/llvm/lib/Target/Mips/MipsAsmPrinter.h
+++ b/llvm/lib/Target/Mips/MipsAsmPrinter.h
@@ -159,6 +159,9 @@ public:
   void emitEndOfAsmFile(Module &M) override;
   void PrintDebugValueComment(const MachineInstr *MI, raw_ostream &OS);
   void emitDebugValue(const MCExpr *Value, unsigned Size) const override;
+  void emitDirectiveRelocJalr(const MachineInstr &MI, MCContext &OutContext,
+                             TargetMachine &TM, MCStreamer &OutStreamer,
+                             const MipsSubtarget &Subtarget);
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/Mips/MipsAsmPrinter.h
+++ b/llvm/lib/Target/Mips/MipsAsmPrinter.h
@@ -160,8 +160,8 @@ public:
   void PrintDebugValueComment(const MachineInstr *MI, raw_ostream &OS);
   void emitDebugValue(const MCExpr *Value, unsigned Size) const override;
   void emitDirectiveRelocJalr(const MachineInstr &MI, MCContext &OutContext,
-                             TargetMachine &TM, MCStreamer &OutStreamer,
-                             const MipsSubtarget &Subtarget);
+                              TargetMachine &TM, MCStreamer &OutStreamer,
+                              const MipsSubtarget &Subtarget);
 };
 
 } // end namespace llvm

--- a/llvm/test/CodeGen/Mips/jalr-no-mangle.ll
+++ b/llvm/test/CodeGen/Mips/jalr-no-mangle.ll
@@ -1,0 +1,30 @@
+; RUN: llc -mtriple=mipsel-unknown-linux-gnu -relocation-model=pic < %s | FileCheck %s --check-prefix=ASM
+; RUN: llc -mtriple=mipsel-unknown-linux-gnu -relocation-model=pic -filetype=obj -o %t %s
+; RUN: llvm-readelf -r %t | FileCheck %s --check-prefix=RELOC
+; RUN: llvm-readelf -s %t | FileCheck %s --check-prefix=SYM
+
+declare i32 @"\01my_target_sym"()
+
+define i32 @caller() nounwind {
+; ASM-LABEL: caller:
+; ASM:       # %bb.0: # %entry
+; ASM-NEXT:    lui $2, %hi(_gp_disp)
+; ASM-NEXT:    addiu $2, $2, %lo(_gp_disp)
+; ASM-NEXT:    addiu $sp, $sp, -24
+; ASM-NEXT:    sw $ra, 20($sp)
+; ASM-NEXT:    addu $gp, $2, $25
+; ASM-NEXT:    lw $25, %call16(my_target_sym)($gp)
+; ASM-NEXT:    .reloc $tmp0, R_MIPS_JALR, my_target_sym
+; ASM-NEXT:  $tmp0:
+; ASM-NEXT:    jalr $25
+; ASM-NEXT:    nop
+
+; RELOC: R_MIPS_JALR{{.*}}my_target_sym
+
+; SYM: UND{{.*}}my_target_sym
+; SYM-NOT: UND{{.*}}my_target_sym
+
+entry:
+  %call = call i32 @"\01my_target_sym"()
+  ret i32 %call
+}


### PR DESCRIPTION
R_MIPS_JALR relocation did not strip the \x01 no-mangle prefix, causing linker to see two different symbols: my_target_sym and \x01my_target_sym.

Use Mangler::getNameWithPrefix() to process the symbol name.

Fix #207470.