### PR TITLE
[libc++] Replace __uninitialized_allocator_copy with __uninitialized_allocator_copy_n

### DIFF
--- a/libcxx/include/__memory/uninitialized_algorithms.h
+++ b/libcxx/include/__memory/uninitialized_algorithms.h
@@ -10,10 +10,8 @@
 #ifndef _LIBCPP___MEMORY_UNINITIALIZED_ALGORITHMS_H
 #define _LIBCPP___MEMORY_UNINITIALIZED_ALGORITHMS_H
 
-#include <__algorithm/copy.h>
 #include <__algorithm/in_out_result.h>
 #include <__algorithm/unwrap_iter.h>
-#include <__algorithm/unwrap_range.h>
 #include <__config>
 #include <__fwd/memory.h>
 #include <__iterator/iterator_traits.h>
@@ -23,7 +21,9 @@
 #include <__memory/construct_at.h>
 #include <__memory/destroy.h>
 #include <__memory/pointer_traits.h>
+#include <__string/constexpr_c_functions.h>
 #include <__type_traits/enable_if.h>
+#include <__type_traits/is_always_bitcastable.h>
 #include <__type_traits/is_constant_evaluated.h>
 #include <__type_traits/is_nothrow_constructible.h>
 #include <__type_traits/is_reference.h>
@@ -358,13 +358,13 @@ private:
 //
 // The caller has to ensure that __first2 can hold at least N uninitialized elements. If an exception is thrown the
 // already copied elements are destroyed in reverse order of their construction.
-template <class _Alloc, class _Iter1, class _Sent1, class _Iter2>
+template <class _Alloc, class _Iter1, class _Size, class _Iter2>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _Iter2
-__uninitialized_allocator_copy_impl(_Alloc& __alloc, _Iter1 __first1, _Sent1 __last1, _Iter2 __first2) {
+__uninitialized_allocator_copy_n_impl(_Alloc& __alloc, _Iter1 __first1, _Size __count, _Iter2 __first2) {
   auto __destruct_first = __first2;
   auto __guard =
       std::__make_exception_guard(_AllocatorDestroyRangeReverse<_Alloc, _Iter2>(__alloc, __destruct_first, __first2));
-  while (__first1 != __last1) {
+  for (_Size __i = 0; __i != __count; ++__i) {
     allocator_traits<_Alloc>::construct(__alloc, std::__to_address(__first2), *__first1);
     ++__first1;
     ++__first2;
@@ -381,31 +381,33 @@ inline const bool __allocator_has_trivial_copy_construct_v<allocator<_Type>, _Ty
 
 template <class _Alloc,
           class _In,
+          class _Size,
           class _Out,
-          __enable_if_t<is_trivially_copy_constructible<_In>::value && is_trivially_assignable<_Out&, _In&>::value &&
+          __enable_if_t<__is_always_bitcastable<_In, _Out>::value && is_trivially_constructible<_Out, _In>::value &&
+                            is_trivially_assignable<_Out&, _In&>::value &&
                             is_same<__remove_const_t<_In>, __remove_const_t<_Out> >::value &&
                             __allocator_has_trivial_copy_construct_v<_Alloc, _In>,
                         int> = 0>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _Out*
-__uninitialized_allocator_copy_impl(_Alloc&, _In* __first1, _In* __last1, _Out* __first2) {
+__uninitialized_allocator_copy_n_impl(_Alloc&, _In* __first1, _Size __count, _Out* __first2) {
   if (__libcpp_is_constant_evaluated()) {
-    while (__first1 != __last1) {
+    for (_Size __i = 0; __i != __count; ++__i) {
       std::__construct_at(std::__to_address(__first2), *__first1);
       ++__first1;
       ++__first2;
     }
     return __first2;
   } else {
-    return std::copy(__first1, __last1, __first2);
+    std::__constexpr_memmove(__first2, __first1, __element_count(__count));
+    return __first2 + __count;
   }
 }
 
-template <class _Alloc, class _Iter1, class _Sent1, class _Iter2>
+template <class _Alloc, class _Iter1, class _Size, class _Iter2>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _Iter2
-__uninitialized_allocator_copy(_Alloc& __alloc, _Iter1 __first1, _Sent1 __last1, _Iter2 __first2) {
-  auto __unwrapped_range = std::__unwrap_range(std::move(__first1), std::move(__last1));
-  auto __result          = std::__uninitialized_allocator_copy_impl(
-      __alloc, std::move(__unwrapped_range.first), std::move(__unwrapped_range.second), std::__unwrap_iter(__first2));
+__uninitialized_allocator_copy_n(_Alloc& __alloc, _Iter1 __first1, _Size __count, _Iter2 __first2) {
+  auto __result = std::__uninitialized_allocator_copy_n_impl(
+      __alloc, std::__unwrap_iter(std::move(__first1)), __count, std::__unwrap_iter(__first2));
   return std::__rewrap_iter(__first2, __result);
 }
 

--- a/libcxx/include/__vector/vector.h
+++ b/libcxx/include/__vector/vector.h
@@ -933,10 +933,9 @@ vector<_Tp, _Allocator>::__construct_at_end(size_type __n, const_reference __x) 
 template <class _Tp, class _Allocator>
 template <class _InputIterator, class _Sentinel>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 void
-vector<_Tp, _Allocator>::__construct_at_end(_InputIterator __first, _Sentinel __last, size_type __n) {
+vector<_Tp, _Allocator>::__construct_at_end(_InputIterator __first, _Sentinel, size_type __n) {
   _ConstructTransaction __tx(*this, __n);
-  __tx.__pos_ = std::__uninitialized_allocator_copy(
-      this->__layout_.__alloc(), std::move(__first), std::move(__last), __tx.__pos_);
+  __tx.__pos_ = std::__uninitialized_allocator_copy_n(this->__layout_.__alloc(), std::move(__first), __n, __tx.__pos_);
 }
 
 template <class _Tp, class _Allocator>

--- a/libcxx/include/condition_variable
+++ b/libcxx/include/condition_variable
@@ -350,6 +350,10 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 23
+#    include <initializer_list>
+#  endif
+
 #endif // __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)
 
 #endif // _LIBCPP_CONDITION_VARIABLE

--- a/libcxx/include/memory
+++ b/libcxx/include/memory
@@ -1019,6 +1019,10 @@ template<class Pointer = void, class Smart, class... Args>
 #    pragma GCC system_header
 #  endif
 
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 23
+#    include <initializer_list>
+#  endif
+
 #endif // __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)
 
 #endif // _LIBCPP_MEMORY

--- a/libcxx/test/libcxx/memory/uninitialized_allocator_copy_n.pass.cpp
+++ b/libcxx/test/libcxx/memory/uninitialized_allocator_copy_n.pass.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: no-exceptions
 
-// ensure that __uninitialized_allocator_copy calls the proper construct and destruct functions
+// ensure that __uninitialized_allocator_copy_n calls the proper construct and destruct functions
 
 #include <algorithm>
 #include <cassert>
@@ -58,8 +58,8 @@ int main(int, char**) {
   ThrowSometimes in[20];
   TEST_ALIGNAS_TYPE(ThrowSometimes) char out[sizeof(ThrowSometimes) * 20];
   try {
-    std::__uninitialized_allocator_copy(
-        alloc, std::begin(in), std::end(in), reinterpret_cast<ThrowSometimes*>(std::begin(out)));
+    std::__uninitialized_allocator_copy_n(
+        alloc, std::begin(in), 20, reinterpret_cast<ThrowSometimes*>(std::begin(out)));
   } catch (...) {
   }
 

--- a/libcxx/test/libcxx/transitive_includes/cxx26.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx26.csv
@@ -187,7 +187,6 @@ condition_variable climits
 condition_variable cstdint
 condition_variable cstring
 condition_variable ctime
-condition_variable initializer_list
 condition_variable limits
 condition_variable ratio
 condition_variable typeinfo

--- a/libcxx/test/libcxx/transitive_includes/cxx29.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx29.csv
@@ -187,7 +187,6 @@ condition_variable climits
 condition_variable cstdint
 condition_variable cstring
 condition_variable ctime
-condition_variable initializer_list
 condition_variable limits
 condition_variable ratio
 condition_variable typeinfo


### PR DESCRIPTION
We can simplify our code by using an iterator/size version instead of the iterator pair.

This was originally part of #214132. However, that patch has a difficult to track down performance issue. I'm splitting it up to make the search easier.