### PR TITLE
WebAssembly: Take GlobalValue and DebugLoc in GetGlobalAddressSymbol

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyMCInstLower.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyMCInstLower.cpp
@@ -68,26 +68,23 @@ static std::optional<bool> getWasmGlobalMutable(const GlobalValue *Global,
 static void removeRegisterOperands(const MachineInstr *MI, MCInst &OutMI);
 
 MCSymbol *
-WebAssemblyMCInstLower::GetGlobalAddressSymbol(const MachineOperand &MO) const {
-  const GlobalValue *Global = MO.getGlobal();
+WebAssemblyMCInstLower::GetGlobalAddressSymbol(const GlobalValue &Global,
+                                               const DebugLoc &DL) const {
+  const TargetMachine &TM = Printer.TM;
+  const Function &CurrentFunc = Printer.MF->getFunction();
   if (!isa<Function>(Global)) {
-    auto *WasmSym = static_cast<MCSymbolWasm *>(Printer.getSymbol(Global));
+    auto *WasmSym = static_cast<MCSymbolWasm *>(Printer.getSymbol(&Global));
     // If the symbol doesn't have an explicit WasmSymbolType yet and the
     // GlobalValue is actually a WebAssembly global, then ensure the symbol is a
     // WASM_SYMBOL_TYPE_GLOBAL.
-    if (WebAssembly::isWasmVarAddressSpace(Global->getAddressSpace()) &&
+    if (WebAssembly::isWasmVarAddressSpace(Global.getAddressSpace()) &&
         !WasmSym->getType()) {
-      const MachineInstr &MI = *MO.getParent();
-      const MachineFunction &MF = *MO.getParent()->getParent()->getParent();
-      const TargetMachine &TM = MF.getTarget();
-      const Function &CurrentFunc = MF.getFunction();
-
       std::optional<bool> Mutable =
-          getWasmGlobalMutable(Global, CurrentFunc, MI.getDebugLoc());
+          getWasmGlobalMutable(&Global, CurrentFunc, DL);
       if (!Mutable.has_value())
         return WasmSym;
 
-      Type *GlobalVT = Global->getValueType();
+      Type *GlobalVT = Global.getValueType();
       SmallVector<MVT, 1> VTs;
       computeLegalValueVTs(CurrentFunc, TM, GlobalVT, VTs);
 
@@ -96,14 +93,11 @@ WebAssemblyMCInstLower::GetGlobalAddressSymbol(const MachineOperand &MO) const {
     return WasmSym;
   }
 
-  const auto *FuncTy = cast<FunctionType>(Global->getValueType());
-  const MachineFunction &MF = *MO.getParent()->getParent()->getParent();
-  const TargetMachine &TM = MF.getTarget();
-  const Function &CurrentFunc = MF.getFunction();
+  const auto *FuncTy = cast<FunctionType>(Global.getValueType());
 
   SmallVector<MVT, 1> ResultMVTs;
   SmallVector<MVT, 4> ParamMVTs;
-  const auto *const F = dyn_cast<Function>(Global);
+  const auto *const F = dyn_cast<Function>(&Global);
   computeSignatureVTs(FuncTy, F, CurrentFunc, TM, ParamMVTs, ResultMVTs);
   auto Signature = signatureFromMVTs(Ctx, ResultMVTs, ParamMVTs);
 
@@ -348,7 +342,8 @@ void WebAssemblyMCInstLower::lower(const MachineInstr *MI,
       break;
     }
     case MachineOperand::MO_GlobalAddress:
-      MCOp = lowerSymbolOperand(MO, GetGlobalAddressSymbol(MO));
+      MCOp = lowerSymbolOperand(
+          MO, GetGlobalAddressSymbol(*MO.getGlobal(), MI->getDebugLoc()));
       break;
     case MachineOperand::MO_ExternalSymbol:
       MCOp = lowerSymbolOperand(MO, GetExternalSymbolSymbol(MO));

--- a/llvm/lib/Target/WebAssembly/WebAssemblyMCInstLower.h
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyMCInstLower.h
@@ -21,6 +21,8 @@
 
 namespace llvm {
 class WebAssemblyAsmPrinter;
+class DebugLoc;
+class GlobalValue;
 class MCContext;
 class MCSymbol;
 class MachineInstr;
@@ -31,7 +33,8 @@ class LLVM_LIBRARY_VISIBILITY WebAssemblyMCInstLower {
   MCContext &Ctx;
   WebAssemblyAsmPrinter &Printer;
 
-  MCSymbol *GetGlobalAddressSymbol(const MachineOperand &MO) const;
+  MCSymbol *GetGlobalAddressSymbol(const GlobalValue &Global,
+                                   const DebugLoc &DL) const;
   MCSymbol *GetExternalSymbolSymbol(const MachineOperand &MO) const;
   MCOperand lowerSymbolOperand(const MachineOperand &MO, MCSymbol *Sym) const;
   MCOperand lowerTypeIndexOperand(SmallVectorImpl<wasm::ValType> &&,


### PR DESCRIPTION
GetGlobalAddressSymbol only needed the IR GlobalValue from the operand
and the instruction's DebugLoc for a diagnostic. Directly pass these instead
of depending on looking at the MachineOperand's parent to find the instruction
and function.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>