### PR TITLE
CodeGen: Pass instruction to LiveRangeEdit::useIsKill

### DIFF
--- a/llvm/include/llvm/CodeGen/LiveRangeEdit.h
+++ b/llvm/include/llvm/CodeGen/LiveRangeEdit.h
@@ -96,9 +96,10 @@ private:
   /// registers are created.
   void MRI_NoteNewVirtualRegister(Register VReg) override;
 
-  /// Check if MachineOperand \p MO is a last use/kill either in the
+  /// Check if operand \p MO of \p MI is a last use/kill either in the
   /// main live range of \p LI or in one of the matching subregister ranges.
-  bool useIsKill(const LiveInterval &LI, const MachineOperand &MO) const;
+  bool useIsKill(const LiveInterval &LI, const MachineInstr &MI,
+                 const MachineOperand &MO) const;
 
   /// Create a new empty interval based on OldReg.
   LiveInterval &createEmptyIntervalFrom(Register OldReg, bool createSubRanges);

--- a/llvm/lib/CodeGen/LiveRangeEdit.cpp
+++ b/llvm/lib/CodeGen/LiveRangeEdit.cpp
@@ -192,9 +192,8 @@ bool LiveRangeEdit::foldAsLoad(LiveInterval *LI,
   return true;
 }
 
-bool LiveRangeEdit::useIsKill(const LiveInterval &LI,
+bool LiveRangeEdit::useIsKill(const LiveInterval &LI, const MachineInstr &MI,
                               const MachineOperand &MO) const {
-  const MachineInstr &MI = *MO.getParent();
   SlotIndex Idx = LIS.getInstructionIndex(MI).getRegSlot();
   if (LI.Query(Idx).isKill())
     return true;
@@ -283,7 +282,7 @@ void LiveRangeEdit::eliminateDeadDef(MachineInstr *MI, ToShrinkSet &ToShrink) {
     // Always shrink COPY uses that probably come from live range splitting.
     if ((MI->readsVirtualRegister(Reg) &&
          (MO.isDef() || TII.isCopyInstr(*MI))) ||
-        (MO.readsReg() && (MRI.hasOneNonDBGUse(Reg) || useIsKill(LI, MO))))
+        (MO.readsReg() && (MRI.hasOneNonDBGUse(Reg) || useIsKill(LI, *MI, MO))))
       ToShrink.insert(&LI);
     else if (MO.readsReg())
       HasLiveVRegUses = true;


### PR DESCRIPTION
The helper only used the operand to recover its parent instruction. Pass the
containing instruction directly so it no longer depends on the
MachineOperand parent.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>