### PR TITLE
CodeGen: Pass instruction to DetectDeadLanes::isUndefInput

### DIFF
--- a/llvm/lib/CodeGen/DetectDeadLanes.cpp
+++ b/llvm/lib/CodeGen/DetectDeadLanes.cpp
@@ -383,8 +383,8 @@ private:
   bool isUndefRegAtInput(const MachineOperand &MO,
                          const DeadLaneDetector::VRegInfo &RegInfo) const;
 
-  bool isUndefInput(const DeadLaneDetector &DLD, const MachineOperand &MO,
-                    bool *CrossCopy) const;
+  bool isUndefInput(const DeadLaneDetector &DLD, const MachineInstr &MI,
+                    const MachineOperand &MO, bool *CrossCopy) const;
 
   const MachineRegisterInfo *MRI = nullptr;
   const TargetRegisterInfo *TRI = nullptr;
@@ -422,11 +422,11 @@ bool DetectDeadLanes::isUndefRegAtInput(
 }
 
 bool DetectDeadLanes::isUndefInput(const DeadLaneDetector &DLD,
+                                   const MachineInstr &MI,
                                    const MachineOperand &MO,
                                    bool *CrossCopy) const {
   if (!MO.isUse())
     return false;
-  const MachineInstr &MI = *MO.getParent();
   if (!lowersToCopies(MI))
     return false;
   const MachineOperand &Def = MI.getOperand(0);
@@ -521,7 +521,7 @@ DetectDeadLanes::modifySubRegisterOperandStatus(const DeadLaneDetector &DLD,
                        << "Marking operand '" << MO << "' as undef in " << MI);
             MO.setIsUndef();
             Changed = true;
-          } else if (isUndefInput(DLD, MO, &CrossCopy)) {
+          } else if (isUndefInput(DLD, MI, MO, &CrossCopy)) {
             LLVM_DEBUG(dbgs()
                        << "Marking operand '" << MO << "' as undef in " << MI);
             MO.setIsUndef();


### PR DESCRIPTION
The helper only used the operand to recover its parent instruction. Pass the
containing instruction directly so it no longer depends on the
MachineOperand's parent.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>