### PR TITLE
AMDGPU: Pass instruction and operand to isKImmOperand/isKUImmOperand

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIShrinkInstructions.cpp
+++ b/llvm/lib/Target/AMDGPU/SIShrinkInstructions.cpp
@@ -40,8 +40,8 @@ class SIShrinkInstructions {
 
   bool foldImmediates(MachineInstr &MI, bool TryToCommute = true) const;
   bool shouldShrinkTrue16(MachineInstr &MI) const;
-  bool isKImmOperand(const MachineOperand &Src) const;
-  bool isKUImmOperand(const MachineOperand &Src) const;
+  bool isKImmOperand(const MachineInstr &MI, const MachineOperand &Src) const;
+  bool isKUImmOperand(const MachineInstr &MI, const MachineOperand &Src) const;
   bool isKImmOrKUImmOperand(const MachineOperand &Src, bool &IsUnsigned) const;
   void copyExtraImplicitOps(MachineInstr &NewMI, MachineInstr &MI) const;
   bool shrinkScalarCompare(MachineInstr &MI) const;
@@ -171,14 +171,16 @@ bool SIShrinkInstructions::shouldShrinkTrue16(MachineInstr &MI) const {
   return true;
 }
 
-bool SIShrinkInstructions::isKImmOperand(const MachineOperand &Src) const {
+bool SIShrinkInstructions::isKImmOperand(const MachineInstr &MI,
+                                         const MachineOperand &Src) const {
   return isInt<16>(SignExtend64(Src.getImm(), 32)) &&
-         !TII->isInlineConstant(*Src.getParent(), Src.getOperandNo());
+         !TII->isInlineConstant(MI, MI.getOperandNo(&Src));
 }
 
-bool SIShrinkInstructions::isKUImmOperand(const MachineOperand &Src) const {
+bool SIShrinkInstructions::isKUImmOperand(const MachineInstr &MI,
+                                          const MachineOperand &Src) const {
   return isUInt<16>(Src.getImm()) &&
-         !TII->isInlineConstant(*Src.getParent(), Src.getOperandNo());
+         !TII->isInlineConstant(MI, MI.getOperandNo(&Src));
 }
 
 bool SIShrinkInstructions::isKImmOrKUImmOperand(const MachineOperand &Src,
@@ -289,8 +291,8 @@ bool SIShrinkInstructions::shrinkScalarCompare(MachineInstr &MI) const {
 
   const MCInstrDesc &NewDesc = TII->get(SOPKOpc);
 
-  if ((SIInstrInfo::sopkIsZext(SOPKOpc) && isKUImmOperand(Src1)) ||
-      (!SIInstrInfo::sopkIsZext(SOPKOpc) && isKImmOperand(Src1))) {
+  if ((SIInstrInfo::sopkIsZext(SOPKOpc) && isKUImmOperand(MI, Src1)) ||
+      (!SIInstrInfo::sopkIsZext(SOPKOpc) && isKImmOperand(MI, Src1))) {
     if (!SIInstrInfo::sopkIsZext(SOPKOpc))
       Src1.setImm(SignExtend64(Src1.getImm(), 32));
     MI.setDesc(NewDesc);
@@ -952,7 +954,7 @@ bool SIShrinkInstructions::run(MachineFunction &MF) {
           continue;
         }
         if (Src0->isReg() && Src0->getReg() == Dest->getReg()) {
-          if (Src1->isImm() && isKImmOperand(*Src1)) {
+          if (Src1->isImm() && isKImmOperand(MI, *Src1)) {
             unsigned Opc = (MI.getOpcode() == AMDGPU::S_MUL_I32)
                                ? AMDGPU::S_MULK_I32
                                : AMDGPU::S_ADDK_I32;
@@ -978,7 +980,7 @@ bool SIShrinkInstructions::run(MachineFunction &MF) {
         if (Src.isImm() && Dst.getReg().isPhysical()) {
           unsigned ModOpc;
           int32_t ModImm;
-          if (isKImmOperand(Src)) {
+          if (isKImmOperand(MI, Src)) {
             MI.setDesc(TII->get(AMDGPU::S_MOVK_I32));
             Src.setImm(SignExtend64(Src.getImm(), 32));
             Changed = true;


### PR DESCRIPTION
These helpers recovered the instruction and operand index from the operand's
parent to call isInlineConstant. Pass the containing instruction and the
operand directly so they no longer depend on MachineOperand::getParent().

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>