### PR TITLE
AMDGPU: Harden assumed subarch triple spelling

### DIFF
--- a/llvm/test/TableGen/AMDGPUTargetDefErrors.td
+++ b/llvm/test/TableGen/AMDGPUTargetDefErrors.td
@@ -7,6 +7,14 @@
 // RUN:   | FileCheck %t/alias-shadows-processor.td -DFILE=%t/alias-shadows-processor.td --implicit-check-not="error:"
 // RUN: not llvm-tblgen -gen-amdgpu-target-def -I %p/../../include %t/bad-isa-version.td 2>&1 \
 // RUN:   | FileCheck %t/bad-isa-version.td -DFILE=%t/bad-isa-version.td --implicit-check-not="error:"
+// RUN: not llvm-tblgen -gen-amdgpu-target-def -I %p/../../include %t/oversized-major.td 2>&1 \
+// RUN:   | FileCheck %t/oversized-major.td -DFILE=%t/oversized-major.td --implicit-check-not="error:"
+// RUN: not llvm-tblgen -gen-amdgpu-target-def -I %p/../../include %t/oversized-minor.td 2>&1 \
+// RUN:   | FileCheck %t/oversized-minor.td -DFILE=%t/oversized-minor.td --implicit-check-not="error:"
+// RUN: not llvm-tblgen -gen-amdgpu-target-def -I %p/../../include %t/oversized-stepping.td 2>&1 \
+// RUN:   | FileCheck %t/oversized-stepping.td -DFILE=%t/oversized-stepping.td --implicit-check-not="error:"
+// RUN: not llvm-tblgen -gen-amdgpu-target-def -I %p/../../include %t/negative-component.td 2>&1 \
+// RUN:   | FileCheck %t/negative-component.td -DFILE=%t/negative-component.td --implicit-check-not="error:"
 // RUN: not llvm-tblgen -gen-amdgpu-target-def -I %p/../../include %t/bad-stepping.td 2>&1 \
 // RUN:   | FileCheck %t/bad-stepping.td -DFILE=%t/bad-stepping.td --implicit-check-not="error:"
 // RUN: not llvm-tblgen -gen-amdgpu-target-def -I %p/../../include %t/generic-feature-superset.td 2>&1 \
@@ -77,6 +85,64 @@ class AMDGPUGPUInfo<list<int> isa = []> {
 // CHECK: [[FILE]]:[[#@LINE+1]]:1: error: GPU 'gfx900' must have a 3-element [major, minor, stepping] IsaVersion
 def : ProcessorModel<"gfx900", NoSchedModel, []>, AMDGPUGPUInfo<[9, 0]>;
 
+//--- oversized-major.td
+include "llvm/Target/Target.td"
+def MyTarget : Target;
+class AMDGPUArchFeature<string spelling> { string Spelling = spelling; }
+class AMDGPUGPUInfo<list<int> isa = []> {
+  list<AMDGPUArchFeature> ArchFeatures = [];
+  list<int> IsaVersion = isa;
+  list<Processor> CoveredGPUs = [];
+  bit IsPseudoTarget = false;
+}
+// A major that does not fit in the uint8_t table field is rejected rather than
+// silently truncated.
+// CHECK: [[FILE]]:[[#@LINE+1]]:1: error: GPU 'gfx900' IsaVersion components must each fit in a byte
+def : ProcessorModel<"gfx900", NoSchedModel, []>, AMDGPUGPUInfo<[256, 0, 0]>;
+
+//--- oversized-minor.td
+include "llvm/Target/Target.td"
+def MyTarget : Target;
+class AMDGPUArchFeature<string spelling> { string Spelling = spelling; }
+class AMDGPUGPUInfo<list<int> isa = []> {
+  list<AMDGPUArchFeature> ArchFeatures = [];
+  list<int> IsaVersion = isa;
+  list<Processor> CoveredGPUs = [];
+  bit IsPseudoTarget = false;
+}
+// A minor that does not fit in the uint8_t table field is likewise rejected.
+// CHECK: [[FILE]]:[[#@LINE+1]]:1: error: GPU 'gfx900' IsaVersion components must each fit in a byte
+def : ProcessorModel<"gfx900", NoSchedModel, []>, AMDGPUGPUInfo<[9, 256, 0]>;
+
+//--- oversized-stepping.td
+include "llvm/Target/Target.td"
+def MyTarget : Target;
+class AMDGPUArchFeature<string spelling> { string Spelling = spelling; }
+class AMDGPUGPUInfo<list<int> isa = []> {
+  list<AMDGPUArchFeature> ArchFeatures = [];
+  list<int> IsaVersion = isa;
+  list<Processor> CoveredGPUs = [];
+  bit IsPseudoTarget = false;
+}
+// A stepping that does not fit in the uint8_t table field is likewise rejected.
+// The byte check fires before the single-hex-digit check.
+// CHECK: [[FILE]]:[[#@LINE+1]]:1: error: GPU 'gfx900' IsaVersion components must each fit in a byte
+def : ProcessorModel<"gfx900", NoSchedModel, []>, AMDGPUGPUInfo<[9, 0, 256]>;
+
+//--- negative-component.td
+include "llvm/Target/Target.td"
+def MyTarget : Target;
+class AMDGPUArchFeature<string spelling> { string Spelling = spelling; }
+class AMDGPUGPUInfo<list<int> isa = []> {
+  list<AMDGPUArchFeature> ArchFeatures = [];
+  list<int> IsaVersion = isa;
+  list<Processor> CoveredGPUs = [];
+  bit IsPseudoTarget = false;
+}
+// A negative component is likewise rejected (it does not fit an unsigned byte).
+// CHECK: [[FILE]]:[[#@LINE+1]]:1: error: GPU 'gfx900' IsaVersion components must each fit in a byte
+def : ProcessorModel<"gfx900", NoSchedModel, []>, AMDGPUGPUInfo<[9, 0, -1]>;
+
 //--- bad-stepping.td
 include "llvm/Target/Target.td"
 def MyTarget : Target;
@@ -87,8 +153,8 @@ class AMDGPUGPUInfo<list<int> isa = []> {
   list<Processor> CoveredGPUs = [];
   bit IsPseudoTarget = false;
 }
-// The stepping must fit in a single hex digit so it can be spelled in the
-// triple subarch name (e.g. "amdgpu9.0c").
+// The stepping is spelled as one hex digit in the device/subarch names, so it
+// must fit in a nibble even though the table field is a full byte.
 // CHECK: [[FILE]]:[[#@LINE+1]]:1: error: GPU 'gfx900' stepping must be a single hex digit
 def : ProcessorModel<"gfx900", NoSchedModel, []>, AMDGPUGPUInfo<[9, 0, 16]>;
 

--- a/llvm/test/TableGen/AMDGPUTargetDefSubArchSpelling.td
+++ b/llvm/test/TableGen/AMDGPUTargetDefSubArchSpelling.td
@@ -22,9 +22,15 @@ def GFX888_AMAZING : ProcessorModel<"gfx888-amazing", NoSchedModel, []>,
   let SubArchSpelling = "8.88a";
 }
 
+// A concrete GPU whose stepping is a hex digit above 9: it is spelled as a
+// single lowercase hex character in both the device and subarch names.
+def GFX88F : ProcessorModel<"gfx88f", NoSchedModel, []>,
+    AMDGPUGPUInfo<[8, 8, 0xF]>;
+
 // The variant contributes a distinct GPUKind.
 // CHECK: GK_GFX888
 // CHECK: GK_GFX888_AMAZING
+// CHECK: GK_GFX88F
 
 // The variant is its own major subarch, so it produces no override entry.
 // CHECK: AMDGPUMajorSubArchEntry, 0>{{ }}AMDGPUMajorSubArch
@@ -35,9 +41,14 @@ def GFX888_AMAZING : ProcessorModel<"gfx888-amazing", NoSchedModel, []>,
 // CHECK: "gfx888-amazing\0"
 // CHECK: "amdgpu8.88a\0"
 
+// The stepping is spelled as a single lowercase hex digit in the triple name.
+// CHECK: "amdgpu8.8f\0"
+
 // The GPU table: the base GPU has no base name (offset 0); the variant uses
-// AMDGPUSubArch8_88A and records "gfx888" as its base name.
+// AMDGPUSubArch888A and records "gfx888" as its base name.
 // CHECK: {[[#]], Triple::AMDGPUSubArch888, {{.*}}, {8, 8, 8}, [[FAM:[0-9]+]], 0, [[#]], [[#]]},
+// CHECK: {[[#]], Triple::AMDGPUSubArch888A, {{.*}}, {8, 8, 8}, [[FAM]], [[#]], [[#]], [[#]]},
+// CHECK: {[[#]], Triple::AMDGPUSubArch88F, {{.*}}, {8, 8, 15}, [[#]], 0, [[#]], [[#]]},
 
 // The subarch-name table maps the variant's own subarch to its triple name.
 // CHECK: {Triple::AMDGPUSubArch888A, [[#]], [[#]]},

--- a/llvm/utils/TableGen/Basic/AMDGPUTargetDefEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/AMDGPUTargetDefEmitter.cpp
@@ -18,6 +18,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TableGen/Error.h"
 #include "llvm/TableGen/Record.h"
@@ -112,7 +113,9 @@ static void emitArchFamily(raw_ostream &OS, const Record *Rec) {
   OS << "gfx" << Rec->getValueAsListOfInts("IsaVersion")[0];
 }
 
-// Emit the canonical GPU name for a variant (empty for a non-variant GPU).
+// Emit the canonical GPU name for a variant (empty for a non-variant GPU). The
+// stepping is the trailing single hex character of the device name (validated
+// by emitIsaVersion).
 static void emitBaseName(raw_ostream &OS, const Record *Rec) {
   if (!getSubArchSpelling(Rec))
     return;
@@ -133,20 +136,30 @@ static void emitIsaVersion(raw_ostream &OS, const Record *Rec, char Open,
                         "IsaVersion");
   }
 
-  OS << Open << V[0] << ", " << V[1] << ", " << V[2] << Close;
-}
+  // Each component is stored in a uint8_t field, and the stepping is
+  // additionally spelled as a single lowercase hex digit in the device and
+  // subarch names. Reject out-of-range values.
+  for (int64_t Component : V) {
+    if (!isUInt<8>(Component)) {
+      PrintFatalError(Rec->getLoc(),
+                      "GPU '" + Rec->getValueAsString("Name") +
+                          "' IsaVersion components must each fit in a byte");
+    }
+  }
 
-// Emit the triple subarch name for a concrete GPU, e.g. gfx90c / [9, 0, 12] ->
-// "amdgpu9.0c" (stepping is a single lowercase hex digit).
-static void emitConcreteSubArchTripleName(raw_ostream &OS, const Record *Rec) {
-  std::vector<int64_t> V = Rec->getValueAsListOfInts("IsaVersion");
-
-  // Assuming emitIsaVersion validated the number of elements.
-  if (V[2] < 0 || V[2] > 15) {
+  if (!isUInt<4>(V[2])) {
     PrintFatalError(Rec->getLoc(), "GPU '" + Rec->getValueAsString("Name") +
                                        "' stepping must be a single hex digit");
   }
 
+  OS << Open << V[0] << ", " << V[1] << ", " << V[2] << Close;
+}
+
+// Emit the triple subarch name for a concrete GPU, e.g. gfx90c / [9, 0, 12] ->
+// "amdgpu9.0c". The stepping is spelled as a single lowercase hex digit
+// (validated by emitIsaVersion).
+static void emitConcreteSubArchTripleName(raw_ostream &OS, const Record *Rec) {
+  std::vector<int64_t> V = Rec->getValueAsListOfInts("IsaVersion");
   OS << "amdgpu" << V[0] << '.' << V[1] << hexdigit(V[2], /*LowerCase=*/true);
 }
 


### PR DESCRIPTION
Guard against values that require multiple hex digits or
don't fit in the IsaVersion struct fields.

Co-Authored-By: Claude <noreply@anthropic.com> (Claude Opus 4.8)