### PR TITLE
VirtRegMap: Pass instruction and operand to readsUndefSubreg

### DIFF
--- a/llvm/lib/CodeGen/VirtRegMap.cpp
+++ b/llvm/lib/CodeGen/VirtRegMap.cpp
@@ -226,7 +226,7 @@ class VirtRegRewriter {
 
   void rewrite();
   void addMBBLiveIns();
-  bool readsUndefSubreg(const MachineOperand &MO) const;
+  bool readsUndefSubreg(const MachineInstr &MI, const MachineOperand &MO) const;
   void addLiveInsForSubRanges(const LiveInterval &LI, MCRegister PhysReg) const;
   void handleIdentityCopy(MachineInstr &MI);
   void expandCopyBundle(MachineInstr &MI) const;
@@ -464,14 +464,14 @@ void VirtRegRewriter::addMBBLiveIns() {
 
 /// Returns true if the given machine operand \p MO only reads undefined lanes.
 /// The function only works for use operands with a subregister set.
-bool VirtRegRewriter::readsUndefSubreg(const MachineOperand &MO) const {
+bool VirtRegRewriter::readsUndefSubreg(const MachineInstr &MI,
+                                       const MachineOperand &MO) const {
   // Shortcut if the operand is already marked undef.
   if (MO.isUndef())
     return true;
 
   Register Reg = MO.getReg();
   const LiveInterval &LI = LIS->getInterval(Reg);
-  const MachineInstr &MI = *MO.getParent();
   SlotIndex BaseIndex = LIS->getInstructionIndex(MI);
   // This code is only meant to handle reading undefined subregisters which
   // we couldn't properly detect before.
@@ -697,7 +697,7 @@ void VirtRegRewriter::rewrite() {
             }
           } else {
             if (MO.isUse()) {
-              if (readsUndefSubreg(MO))
+              if (readsUndefSubreg(MI, MO))
                 // We need to add an <undef> flag if the subregister is
                 // completely undefined (and we are not adding super-register
                 // defs).

--- a/llvm/lib/CodeGen/VirtRegMap.cpp
+++ b/llvm/lib/CodeGen/VirtRegMap.cpp
@@ -462,8 +462,9 @@ void VirtRegRewriter::addMBBLiveIns() {
     MBB.sortUniqueLiveIns();
 }
 
-/// Returns true if the given machine operand \p MO only reads undefined lanes.
-/// The function only works for use operands with a subregister set.
+/// Returns true if the given machine operand \p MO of \p MI only reads
+/// undefined lanes.  The function only works for use operands with a
+/// subregister set.
 bool VirtRegRewriter::readsUndefSubreg(const MachineInstr &MI,
                                        const MachineOperand &MO) const {
   // Shortcut if the operand is already marked undef.


### PR DESCRIPTION
The helper recovered the instruction from the operand's parent to look up its
slot index. Pass the containing instruction and the operand directly so it no
longer depends on MachineOperand::getParent().

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>