### PR TITLE
[libc++] Correct mask_array assignment

### DIFF
--- a/libcxx/include/__cxx03/valarray
+++ b/libcxx/include/__cxx03/valarray
@@ -1543,7 +1543,7 @@ template <class _Tp>
 inline const mask_array<_Tp>& mask_array<_Tp>::operator=(const mask_array& __ma) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
-    __vp_[__1d_[__i]] = __ma.__vp_[__1d_[__i]];
+    __vp_[__1d_[__i]] = __ma.__vp_[__ma.__1d_[__i]];
   return *this;
 }
 

--- a/libcxx/include/valarray
+++ b/libcxx/include/valarray
@@ -1614,7 +1614,7 @@ template <class _Tp>
 inline const mask_array<_Tp>& mask_array<_Tp>::operator=(const mask_array& __ma) const {
   size_t __n = __1d_.size();
   for (size_t __i = 0; __i < __n; ++__i)
-    __vp_[__1d_[__i]] = __ma.__vp_[__1d_[__i]];
+    __vp_[__1d_[__i]] = __ma.__vp_[__ma.__1d_[__i]];
   return *this;
 }
 

--- a/libcxx/test/std/numerics/numarray/template.mask.array/mask.array.assign/mask_array.pass.cpp
+++ b/libcxx/test/std/numerics/numarray/template.mask.array/mask.array.assign/mask_array.pass.cpp
@@ -29,7 +29,7 @@ int main(int, char**)
     bool b2[N2] = {true,  false, true, true,
                    false, false, true, true};
     std::valarray<int> v1(a1, N1);
-    const std::valarray<int> v2(a2, N2);
+    std::valarray<int> v2(a2, N2);
     std::valarray<bool> vb1(b1, N1);
     std::valarray<bool> vb2(b2, N2);
     v1[vb1] = v2[vb2];


### PR DESCRIPTION
The index array from `__ma` should be used for indexing, instead of the index array from `this`.