### PR TITLE
[Driver][Clang] Add -nodefaultrtlibs

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -6601,6 +6601,8 @@ def gpulibc : Flag<["-"], "gpulibc">, Visibility<[ClangOption, CC1Option, FlangO
 def nogpulibc : Flag<["-"], "nogpulibc">, Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>;
 def nodefaultlibs : Flag<["-"], "nodefaultlibs">,
   Visibility<[ClangOption, FlangOption]>;
+def nodefaultrtlibs : Flag<["-"], "nodefaultrtlibs">,
+  Visibility<[ClangOption]>;
 def nodriverkitlib : Flag<["-"], "nodriverkitlib">;
 def nofixprebinding : Flag<["-"], "nofixprebinding">;
 def nolibc : Flag<["-"], "nolibc">;

--- a/clang/lib/Driver/ToolChains/ZOS.cpp
+++ b/clang/lib/Driver/ToolChains/ZOS.cpp
@@ -224,7 +224,7 @@ void zos::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   }
 
   // Specify compiler-rt library path for linker
-  if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs))
+  if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs, options::OPT_nodefaultrtlibs))
     AddRunTimeLibs(ToolChain, ToolChain.getDriver(), CmdArgs, Args);
 
   const char *Exec = Args.MakeArgString(ToolChain.GetLinkerPath());

--- a/clang/lib/Driver/ToolChains/ZOS.cpp
+++ b/clang/lib/Driver/ToolChains/ZOS.cpp
@@ -224,7 +224,8 @@ void zos::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   }
 
   // Specify compiler-rt library path for linker
-  if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs, options::OPT_nodefaultrtlibs))
+  if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs,
+                   options::OPT_nodefaultrtlibs))
     AddRunTimeLibs(ToolChain, ToolChain.getDriver(), CmdArgs, Args);
 
   const char *Exec = Args.MakeArgString(ToolChain.GetLinkerPath());

--- a/clang/test/Driver/nodefaultrtlibs.c
+++ b/clang/test/Driver/nodefaultrtlibs.c
@@ -1,0 +1,6 @@
+// RUN: %clang -### -target s390x-ibm-zos %s 2>&1 | FileCheck %s
+// CHECK: SCEELIB(CELQS003)
+// CHECK: libclang_rt.builtins.a
+// RUN: %clang -### -target s390x-ibm-zos -nodefaultrtlibs %s 2>&1 | FileCheck %s -check-prefix=NORTLIB
+// NORTLIB: SCEELIB(CELQS003)
+// NORTLIB-NOT: libclang_rt.builtins.a


### PR DESCRIPTION
On z/OS testing compiler-rt does not work with the -nodefaultlibs since that option remove both the standard libraries like libc and the compiler-rt library.  On other platforms adding an argument like `-lc` back to the command line in the test scripts works because the path for libc (eg. `-L<path>`) hadn't been removed.  On z/OS, the standard libraries are located in data sets and you need to specify them by complete name (eg. `<HLQ>.SCEELIB(CELQS003)`).  

This is adding the option `-nodefaultrtlibs` so the compiler-rt tests can remove just the compiler-rt libs from the link step. 