### PR TITLE
Remove two declarations without definitions

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
@@ -1174,8 +1174,6 @@ extern unsigned struct_kbkeycode_sz;
 extern unsigned struct_kbsentry_sz;
 extern unsigned struct_mtconfiginfo_sz;
 extern unsigned struct_nr_parms_struct_sz;
-extern unsigned struct_scc_modem_sz;
-extern unsigned struct_scc_stat_sz;
 extern unsigned struct_serial_multiport_struct_sz;
 extern unsigned struct_serial_struct_sz;
 extern unsigned struct_sockaddr_ax25_sz;


### PR DESCRIPTION
Commit 3dc4fd6d removed the definitions of struct_scc_modem_sz and struct_scc_stat_sz, but left the declarations in a header.  This patch removes the leftovers.