### PR TITLE
[SelectionDAG] Unique extended single-element VT lists with VTLists (NFC)

### DIFF
--- a/llvm/include/llvm/CodeGen/SelectionDAG.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAG.h
@@ -208,9 +208,6 @@ class SelectionDAG {
   BlockFrequencyInfo *BFI = nullptr;
   MachineModuleInfo *MMI = nullptr;
 
-  /// Extended EVTs used for single value VTLists.
-  std::set<EVT, EVT::compareRawBits> EVTs;
-
   /// Uniquing of VT lists.  Each key aliases the EVT array that the returned
   /// SDVTList points at, allocated from \p Allocator.
   struct VTListInfo {

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -12262,7 +12262,8 @@ SDVTList SelectionDAG::getVTList(EVT VT) {
   if (!VT.isExtended())
     return makeVTList(SDNode::getValueTypeList(VT.getSimpleVT()), 1);
 
-  return makeVTList(&(*EVTs.insert(VT).first), 1);
+  EVT VTs[] = {VT};
+  return getVTList(VTs);
 }
 
 SDVTList SelectionDAG::getVTList(EVT VT1, EVT VT2) {


### PR DESCRIPTION
This patch uniques single-element lists containing an extended EVT in
DenseSet-based VTLists, added on August 28, 2026 in commit 1829cfa8daf2.

Assisted-by: Antigravity
