### PR TITLE
CodeGen: Use getVRegDef in DetectDeadLanes

### DIFF
--- a/llvm/lib/CodeGen/DetectDeadLanes.cpp
+++ b/llvm/lib/CodeGen/DetectDeadLanes.cpp
@@ -265,7 +265,7 @@ LaneBitmask DeadLaneDetector::determineInitialDefinedLanes(Register Reg) {
     return LaneBitmask::getAll();
 
   const MachineOperand &Def = *MRI->def_begin(Reg);
-  const MachineInstr &DefMI = *Def.getParent();
+  const MachineInstr &DefMI = *MRI->getVRegDef(Reg);
   if (lowersToCopies(DefMI)) {
     // Start optimisatically with no used or defined lanes for copy
     // instructions. The following dataflow analysis will add more bits.
@@ -298,8 +298,7 @@ LaneBitmask DeadLaneDetector::determineInitialDefinedLanes(Register Reg) {
       } else {
         assert(MOReg.isVirtual());
         if (MRI->hasOneDef(MOReg)) {
-          const MachineOperand &MODef = *MRI->def_begin(MOReg);
-          const MachineInstr &MODefMI = *MODef.getParent();
+          const MachineInstr &MODefMI = *MRI->getVRegDef(MOReg);
           // Bits from copy-like operations will be added later.
           if (lowersToCopies(MODefMI) || MODefMI.isImplicitDef())
             continue;
@@ -471,8 +470,7 @@ void DeadLaneDetector::computeSubRegisterLaneBitInfo() {
     Register Reg = Register::index2VirtReg(RegIdx);
 
     // Transfer UsedLanes to operands of DefMI (backwards dataflow).
-    MachineOperand &Def = *MRI->def_begin(Reg);
-    const MachineInstr &MI = *Def.getParent();
+    const MachineInstr &MI = *MRI->getVRegDef(Reg);
     transferUsedLanesStep(MI, Info.UsedLanes);
     // Transfer DefinedLanes to users of Reg (forward dataflow).
     for (const MachineOperand &MO : MRI->use_nodbg_operands(Reg))


### PR DESCRIPTION
Look up the defining instruction of a single-def virtual register with
getVRegDef instead of the parent of its first def operand, so this no longer
depends on MachineOperand::getParent().

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>