### PR TITLE
 [clang][Modules] Restore module search on the MODULE_MAP_FILE relocation check

### DIFF
--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -3243,7 +3243,7 @@ ASTReader::getModuleForRelocationChecks(ModuleFile &F, bool DirectoryCheck) {
   // check).
   Module *M = PP.getHeaderSearchInfo().lookupModule(
       F.ModuleName, DirectoryCheck ? SourceLocation() : F.ImportLoc,
-      /*AllowSearch=*/DirectoryCheck,
+      /*AllowSearch=*/true,
       /*AllowExtraModuleMapSearch=*/DirectoryCheck);
 
   return {M, IgnoreError};

--- a/clang/test/Modules/relocation-check-no-module-directory.c
+++ b/clang/test/Modules/relocation-check-no-module-directory.c
@@ -1,0 +1,29 @@
+// Check that a transitively imported module can still be resolved when the PCM
+// has no MODULE_DIRECTORY record, which -fmodule-file-home-is-cwd suppresses.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// Case 1: the load of the transitively imported 'Other' should succeed.
+// RUN: %clang -fmodules -fimplicit-module-maps -fsyntax-only %t/tu.c \
+// RUN:   -fmodules-cache-path=%t/cache -I%t/pathB -I%t/pathC \
+// RUN:   -Xclang -fmodule-file-home-is-cwd
+
+// Case 2: the same load must not crash when module validation is disabled.
+// RUN: %clang -fmodules -fimplicit-module-maps -fsyntax-only %t/tu.c \
+// RUN:   -fmodules-cache-path=%t/cache-novalidate -I%t/pathB -I%t/pathC \
+// RUN:   -Xclang -fmodule-file-home-is-cwd -Xclang -fno-validate-pch
+
+//--- pathB/module.modulemap
+module Dep { header "Dep.h" export * }
+//--- pathB/Dep.h
+#include "Other.h"
+int dep(void);
+
+//--- pathC/module.modulemap
+module Other { header "Other.h" }
+//--- pathC/Other.h
+int other(void);
+
+//--- tu.c
+#include "Dep.h"


### PR DESCRIPTION
 cf8597bd3b87 (#181836) refactored the two relocation-check call sites in ASTReader into `getModuleForRelocationChecks` with the `DirectoryCheck` flag passed to `lookupModule`. The change did not preserve the original functionality for `ASTReader::ReadModuleMapFileBlock` (https://github.com/llvm/llvm-project/commit/cf8597bd3b87aeed6696454f22311e86ed70138f#diff-c61a3cce4bfa099b5af032fa83cbf1563f0af4bf58dc112b39571d74b6b681c1L4586). `ASTReader::ReadModuleMapFileBlock`'s `lookupModule` relied on the default value of `AllowSearch`, which is `true`. Passing `false` to `getModuleForRelocationChecks` changes how module lookup works, and clang can prematurely stop looking when a `MODULE_DIRECTORY` record is not present in the pcm (e.g. when `-fmodule-file-home-is-cwd` is in effect). 

Assisted-by: Claude (Claude-Opus-5)