### PR TITLE
CodeGen: Use getOneNonDBGUser in PeepholeOptimizer

### DIFF
--- a/llvm/lib/CodeGen/PeepholeOptimizer.cpp
+++ b/llvm/lib/CodeGen/PeepholeOptimizer.cpp
@@ -968,8 +968,8 @@ bool PeepholeOptimizer::optimizeCmpInstr(
 
   // The eliminated compare may have been the extra use preventing a
   // load from being folded into the flag-setting instruction.
-  if (SrcReg.isVirtual() && MRI->hasOneNonDBGUser(SrcReg)) {
-    MachineInstr *FlagProducer = MRI->use_nodbg_begin(SrcReg)->getParent();
+  if (MachineInstr *FlagProducer =
+          SrcReg.isVirtual() ? MRI->getOneNonDBGUser(SrcReg) : nullptr) {
     MachineInstr *LoadMI = MRI->getVRegDef(SrcReg);
     // No store between LoadMI and FlagProducer that could change the value.
     if (LocalMIs.count(FlagProducer) && LoadMI && LoadMI->canFoldAsLoad() &&


### PR DESCRIPTION
Use getOneNonDBGUser instead of the parent of the first non-debug use operand,
so this no longer depends on MachineOperand::getParent().

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>