### PR TITLE
[Support] Don't take a lock in CrashRecoverySignalHandler

### DIFF
--- a/llvm/lib/Support/CrashRecoveryContext.cpp
+++ b/llvm/lib/Support/CrashRecoveryContext.cpp
@@ -369,8 +369,12 @@ static void CrashRecoverySignalHandler(int Signal) {
     // that the enclosing application will terminate soon, and we won't want to
     // attempt crash recovery again.
     //
-    // This call of Disable isn't thread safe, but it doesn't actually matter.
-    CrashRecoveryContext::Disable();
+    // Uninstall directly rather than through Disable(): a signal handler must
+    // not take a lock, and a lock with static storage duration may already be
+    // destroyed by the time a signal is delivered during exit(). Racing with
+    // another thread here doesn't matter.
+    gCrashRecoveryEnabled = false;
+    uninstallExceptionOrSignalHandlers();
     raise(Signal);
 
     // The signal will be thrown once the signal mask is restored.


### PR DESCRIPTION
Disable() locks a mutex with static storage duration, which is not safe from a signal handler. When the signal arrives during exit(), after static destructors have run, the mutex is already destroyed, causing pthread_mutex_lock returns EINVAL and in turn causing libc++ to throw.

To make matters worse, without exceptions, the throw becomes a std::terminate, which happens before uninstallExceptionOrSignalHandlers. Because the signal handler is installed without SA_RESETHAND, every call to abort() re-enters the handler and throws again.

Inline the two statements Disable() performs. Racing with another thread here doesn't matter, as the previous comment noted.