### PR TITLE
[NVPTX] Use MCSymbols in Isel, remove mutable StrPool (NFC)

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXAddressFolder.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAddressFolder.cpp
@@ -51,7 +51,7 @@ static bool foldAddress(MachineInstr &MI, MachineOperand &Addr,
     return false;
 
   const MachineOperand &Sym = Mov->getOperand(1);
-  if (!Sym.isGlobal() && !Sym.isSymbol())
+  if (!Sym.isGlobal() && !Sym.isSymbol() && !Sym.isMCSymbol())
     return false;
 
   // The accessed address space must be known and must not be shared.
@@ -64,11 +64,12 @@ static bool foldAddress(MachineInstr &MI, MachineOperand &Addr,
       AddrSpace == NVPTX::AddressSpace::SharedCluster)
     return false;
 
-  if (Sym.isGlobal()) {
+  if (Sym.isGlobal())
     Addr.ChangeToGA(Sym.getGlobal(), Sym.getOffset(), Sym.getTargetFlags());
-  } else {
+  else if (Sym.isSymbol())
     Addr.ChangeToES(Sym.getSymbolName(), Sym.getTargetFlags());
-  }
+  else
+    Addr.ChangeToMCSymbol(Sym.getMCSymbol(), Sym.getTargetFlags());
 
   if (MRI.use_empty(Mov->getOperand(0).getReg()))
     Mov->eraseFromParent();

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -607,6 +607,8 @@ MCOperand NVPTXAsmPrinter::lowerOperand(const MachineOperand &MO) {
         MCSymbolRefExpr::create(MO.getMBB()->getSymbol(), OutContext));
   case MachineOperand::MO_ExternalSymbol:
     return GetSymbolRef(GetExternalSymbolSymbol(MO.getSymbolName()));
+  case MachineOperand::MO_MCSymbol:
+    return GetSymbolRef(MO.getMCSymbol());
   case MachineOperand::MO_JumpTableIndex:
     // The jump table index names the .branchtargets list emitted for a brx.idx
     // (see emitJumpTable); reference it by that label.
@@ -1918,7 +1920,7 @@ void NVPTXAsmPrinter::emitFunctionParamList(const Function *F, raw_ostream &O) {
 
   for (const auto &[ParamIndex, Arg] : enumerate(NonEmptyArgs)) {
     Type *Ty = Arg.getType();
-    const std::string ParamSym = TLI->getParamName(F, ParamIndex);
+    MCSymbol *const ParamSym = TLI->getParamSymbol(OutContext, F, ParamIndex);
 
     if (!IsFirst)
       O << ",\n";
@@ -1947,7 +1949,7 @@ void NVPTXAsmPrinter::emitFunctionParamList(const Function *F, raw_ostream &O) {
         case PTXOpaqueType::None:
           llvm_unreachable("handled above");
         }
-        O << ParamSym;
+        O << *ParamSym;
         continue;
       }
     }
@@ -1966,7 +1968,7 @@ void NVPTXAsmPrinter::emitFunctionParamList(const Function *F, raw_ostream &O) {
           IsKernelFunc ? getPTXParamAlign(F, ETy, ParamIdx, DL)
                        : getDeviceByValParamAlign(F, ETy, ParamIdx, DL);
 
-      O << "\t.param .align " << OptimalAlign.value() << " .b8 " << ParamSym
+      O << "\t.param .align " << OptimalAlign.value() << " .b8 " << *ParamSym
         << "[" << DL.getTypeAllocSize(ETy) << "]";
       continue;
     }
@@ -1979,7 +1981,7 @@ void NVPTXAsmPrinter::emitFunctionParamList(const Function *F, raw_ostream &O) {
       Align OptimalAlign = getPTXParamAlign(
           F, Ty, Arg.getArgNo() + AttributeList::FirstArgIndex, DL);
 
-      O << "\t.param .align " << OptimalAlign.value() << " .b8 " << ParamSym
+      O << "\t.param .align " << OptimalAlign.value() << " .b8 " << *ParamSym
         << "[" << DL.getTypeAllocSize(Ty) << "]";
 
       continue;
@@ -2015,7 +2017,7 @@ void NVPTXAsmPrinter::emitFunctionParamList(const Function *F, raw_ostream &O) {
         }
 
         O << " .align " << Arg.getParamAlign().valueOrOne().value() << " "
-          << ParamSym;
+          << *ParamSym;
         continue;
       }
 
@@ -2026,7 +2028,7 @@ void NVPTXAsmPrinter::emitFunctionParamList(const Function *F, raw_ostream &O) {
         O << "u8";
       else
         O << getPTXFundamentalTypeStr(Ty);
-      O << " " << ParamSym;
+      O << " " << *ParamSym;
       continue;
     }
     // Non-kernel function, just print .param .b<size> for ABI
@@ -2039,14 +2041,14 @@ void NVPTXAsmPrinter::emitFunctionParamList(const Function *F, raw_ostream &O) {
       Size = PTySizeInBits;
     } else
       Size = Ty->getPrimitiveSizeInBits();
-    O << "\t.param .b" << Size << " " << ParamSym;
+    O << "\t.param .b" << Size << " " << *ParamSym;
   }
 
   if (F->isVarArg()) {
     if (!IsFirst)
       O << ",\n";
     O << "\t.param .align " << STI.getMaxRequiredAlignment() << " .b8 "
-      << TLI->getParamName(F, /* vararg */ -1) << "[]";
+      << *TLI->getParamSymbol(OutContext, F, /* vararg */ -1) << "[]";
   }
 
   O << "\n)";
@@ -2612,6 +2614,10 @@ void NVPTXAsmPrinter::printOperand(const MachineInstr *MI, unsigned OpNum,
 
   case MachineOperand::MO_GlobalAddress:
     PrintSymbolOperand(MO, O);
+    break;
+
+  case MachineOperand::MO_MCSymbol:
+    MO.getMCSymbol()->print(O, MAI);
     break;
 
   case MachineOperand::MO_MachineBasicBlock:

--- a/llvm/lib/Target/NVPTX/NVPTXForwardParams.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXForwardParams.cpp
@@ -94,13 +94,13 @@ static bool eliminateMove(MachineInstr &Mov, const MachineRegisterInfo &MRI,
   RemoveList.push_back(&Mov);
 
   const MachineOperand *ParamSymbol = Mov.uses().begin();
-  assert(ParamSymbol->isSymbol());
+  assert(ParamSymbol->isMCSymbol());
 
   for (MachineInstr *LI : LoadInsts) {
     unsigned Opc = LI->getOpcode();
     int Idx = getNamedOperandIdx(Opc, NVPTX::OpName::addr);
     assert(Idx != -1 && "no addr operand");
-    LI->getOperand(Idx).ChangeToES(ParamSymbol->getSymbolName());
+    LI->getOperand(Idx).ChangeToMCSymbol(ParamSymbol->getMCSymbol());
 
     Idx = getNamedOperandIdx(Opc, NVPTX::OpName::addsp);
     assert(Idx != -1 && "no addsp operand");

--- a/llvm/lib/Target/NVPTX/NVPTXISelDAGToDAG.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXISelDAGToDAG.cpp
@@ -1103,6 +1103,8 @@ static SDValue selectBaseADDR(SDValue N, SelectionDAG *DAG) {
                                         ES->getTargetFlags());
   if (const auto *FIN = dyn_cast<FrameIndexSDNode>(N))
     return DAG->getTargetFrameIndex(FIN->getIndex(), FIN->getValueType(0));
+  if (N.getOpcode() == NVPTXISD::Symbol)
+    return N.getOperand(0);
 
   return N;
 }

--- a/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
@@ -55,6 +55,8 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Type.h"
 #include "llvm/IR/Value.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCSymbol.h"
 #include "llvm/Support/Alignment.h"
 #include "llvm/Support/AtomicOrdering.h"
 #include "llvm/Support/Casting.h"
@@ -63,7 +65,6 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/KnownBits.h"
 #include "llvm/Support/NVPTXAddrSpace.h"
-#include "llvm/Support/raw_ostream.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Target/TargetOptions.h"
 #include <algorithm>
@@ -72,7 +73,6 @@
 #include <cstdint>
 #include <iterator>
 #include <optional>
-#include <string>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -522,7 +522,7 @@ VectorizePTXValueVTs(const SmallVectorImpl<EVT> &ValueVTs,
 // NVPTXTargetLowering Constructor.
 NVPTXTargetLowering::NVPTXTargetLowering(const NVPTXTargetMachine &TM,
                                          const NVPTXSubtarget &STI)
-    : TargetLowering(TM, STI), nvTM(&TM), STI(STI), GlobalUniqueCallSite(0) {
+    : TargetLowering(TM, STI), STI(STI), GlobalUniqueCallSite(0) {
   // always lower memset, memcpy, and memmove intrinsics to load/store
   // instructions, rather
   // then generating calls to memset, mempcy or memmove.
@@ -1276,6 +1276,15 @@ static SDValue correctParamType(SDValue V, EVT ExpectedVT,
   return V;
 }
 
+static SDValue getSymbolNode(SelectionDAG &DAG, MCSymbol *Sym, EVT T) {
+  return DAG.getNode(NVPTXISD::Symbol, SDLoc(), T, DAG.getMCSymbol(Sym, T));
+}
+
+static SDValue getSymbolNode(SelectionDAG &DAG, const Twine &Name, EVT T) {
+  MCContext &Ctx = DAG.getMachineFunction().getContext();
+  return getSymbolNode(DAG, Ctx.getOrCreateSymbol(Name), T);
+}
+
 SDValue NVPTXTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
                                        SmallVectorImpl<SDValue> &InVals) const {
 
@@ -1352,8 +1361,9 @@ SDValue NVPTXTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
 
   const SDValue VADeclareParam =
       CLI.Args.size() > FirstVAArg
-          ? MakeDeclareArrayParam(getCallParamSymbol(DAG, FirstVAArg, MVT::i32),
-                                  Align(STI.getMaxRequiredAlignment()), 0)
+          ? MakeDeclareArrayParam(
+                getCallParamSymbolNode(DAG, FirstVAArg, MVT::i32),
+                Align(STI.getMaxRequiredAlignment()), 0)
           : SDValue();
 
   // Args.size() and Outs.size() need not match.
@@ -1384,7 +1394,7 @@ SDValue NVPTXTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
     const bool IsByVal = Arg.IsByVal;
 
     const SDValue ParamSymbol =
-        getCallParamSymbol(DAG, IsVAArg ? FirstVAArg : ArgI, MVT::i32);
+        getCallParamSymbolNode(DAG, IsVAArg ? FirstVAArg : ArgI, MVT::i32);
 
     assert((!IsByVal || Arg.IndirectType) &&
            "byval arg must have indirect type");
@@ -1538,7 +1548,7 @@ SDValue NVPTXTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
 
   // Handle Result
   if (!Ins.empty()) {
-    const SDValue RetSymbol = DAG.getExternalSymbol("retval0", MVT::i32);
+    const SDValue RetSymbol = getSymbolNode(DAG, "retval0", MVT::i32);
     const unsigned ResultSize = DL.getTypeAllocSize(RetTy);
     if (shouldPassAsArray(RetTy)) {
       const Align RetAlign =
@@ -1627,7 +1637,7 @@ SDValue NVPTXTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
 
     const Align RetAlign =
         getPTXParamAlign(CB, RetTy, AttributeList::ReturnIndex, DL);
-    const SDValue RetSymbol = DAG.getExternalSymbol("retval0", MVT::i32);
+    const SDValue RetSymbol = getSymbolNode(DAG, "retval0", MVT::i32);
 
     // PTX Interoperability Guide 3.3(A): [Integer] Values shorter than
     // 32-bits are sign extended or zero extended, depending on whether
@@ -3638,7 +3648,7 @@ SDValue NVPTXTargetLowering::LowerVASTART(SDValue Op, SelectionDAG &DAG) const {
   EVT PtrVT = TLI->getPointerTy(DAG.getDataLayout());
 
   // Store the address of unsized array <function>_vararg[] in the ap object.
-  SDValue VAReg = getParamSymbol(DAG, /* vararg */ -1, PtrVT);
+  SDValue VAReg = getParamSymbolNode(DAG, /* vararg */ -1, PtrVT);
 
   const Value *SV = cast<SrcValueSDNode>(Op.getOperand(2))->getValue();
   return DAG.getStore(Op.getOperand(0), DL, VAReg, Op.getOperand(1),
@@ -4063,21 +4073,16 @@ bool NVPTXTargetLowering::splitValueIntoRegisterParts(
   return false;
 }
 
-// This creates target external symbol for a function parameter.
-// Name of the symbol is composed from its index and the function name.
-// Negative index corresponds to special parameter (unsized array) used for
-// passing variable arguments.
-SDValue NVPTXTargetLowering::getParamSymbol(SelectionDAG &DAG, int I,
-                                            EVT T) const {
-  StringRef SavedStr = nvTM->getStrPool().save(
-      getParamName(&DAG.getMachineFunction().getFunction(), I));
-  return DAG.getExternalSymbol(SavedStr.data(), T);
+SDValue NVPTXTargetLowering::getParamSymbolNode(SelectionDAG &DAG, int I,
+                                                EVT T) const {
+  const MachineFunction &MF = DAG.getMachineFunction();
+  return getSymbolNode(
+      DAG, getParamSymbol(MF.getContext(), &MF.getFunction(), I), T);
 }
 
-SDValue NVPTXTargetLowering::getCallParamSymbol(SelectionDAG &DAG, int I,
-                                                EVT T) const {
-  const StringRef SavedStr = nvTM->getStrPool().save("param" + Twine(I));
-  return DAG.getExternalSymbol(SavedStr.data(), T);
+SDValue NVPTXTargetLowering::getCallParamSymbolNode(SelectionDAG &DAG, int I,
+                                                    EVT T) const {
+  return getSymbolNode(DAG, "param" + Twine(I), T);
 }
 
 SDValue NVPTXTargetLowering::LowerFormalArguments(
@@ -4128,7 +4133,7 @@ SDValue NVPTXTargetLowering::LowerFormalArguments(
       continue;
     }
 
-    SDValue ArgSymbol = getParamSymbol(DAG, ParamI, PtrVT);
+    SDValue ArgSymbol = getParamSymbolNode(DAG, ParamI, PtrVT);
 
     // In the following cases, assign a node order of "i+1"
     // to newly created nodes. The SDNodes for params have to
@@ -4225,7 +4230,7 @@ NVPTXTargetLowering::LowerReturn(SDValue Chain, CallingConv::ID CallConv,
   const DataLayout &DL = DAG.getDataLayout();
   LLVMContext &Ctx = *DAG.getContext();
 
-  const SDValue RetSymbol = DAG.getExternalSymbol("func_retval0", MVT::i32);
+  const SDValue RetSymbol = getSymbolNode(DAG, "func_retval0", MVT::i32);
   const auto RetAlign =
       getPTXParamAlign(&F, RetTy, AttributeList::ReturnIndex, DL);
 
@@ -5587,21 +5592,15 @@ void NVPTXTargetLowering::getTgtMemIntrinsic(
   }
 }
 
-// Helper for getting a function parameter name. Name is composed from
-// its index and the function name. Negative index corresponds to special
-// parameter (unsized array) used for passing variable arguments.
-std::string NVPTXTargetLowering::getParamName(const Function *F,
+// Helper for getting a function parameter symbol. Its name is composed from
+// the function name and the parameter index. Negative index corresponds to the
+// special parameter (unsized array) used for passing variable arguments.
+MCSymbol *NVPTXTargetLowering::getParamSymbol(MCContext &Ctx, const Function *F,
                                               int Idx) const {
-  std::string ParamName;
-  raw_string_ostream ParamStr(ParamName);
-
-  ParamStr << getTargetMachine().getSymbol(F)->getName();
+  const StringRef FuncName = getTargetMachine().getSymbol(F)->getName();
   if (Idx < 0)
-    ParamStr << "_vararg";
-  else
-    ParamStr << "_param_" << Idx;
-
-  return ParamName;
+    return Ctx.getOrCreateSymbol(FuncName + "_vararg");
+  return Ctx.getOrCreateSymbol(FuncName + "_param_" + Twine(Idx));
 }
 
 /// isLegalAddressingMode - Return true if the addressing mode represented

--- a/llvm/lib/Target/NVPTX/NVPTXISelLowering.h
+++ b/llvm/lib/Target/NVPTX/NVPTXISelLowering.h
@@ -21,6 +21,8 @@
 
 namespace llvm {
 
+class MCContext;
+class MCSymbol;
 class NVPTXSubtarget;
 
 //===--------------------------------------------------------------------===//
@@ -39,7 +41,7 @@ public:
   // Helper for getting a function parameter name. Name is composed from
   // its index and the function name. Negative index corresponds to special
   // parameter (unsized array) used for passing variable arguments.
-  std::string getParamName(const Function *F, int Idx) const;
+  MCSymbol *getParamSymbol(MCContext &Ctx, const Function *F, int Idx) const;
 
   /// isLegalAddressingMode - Return true if the addressing mode represented
   /// by AM is legal for this target, for a load/store of the specified type
@@ -91,8 +93,6 @@ public:
   void LowerAsmOperandForConstraint(SDValue Op, StringRef Constraint,
                                     std::vector<SDValue> &Ops,
                                     SelectionDAG &DAG) const override;
-
-  const NVPTXTargetMachine *nvTM;
 
   // PTX always uses 32-bit shift amounts
   MVT getScalarShiftAmountTy(const DataLayout &, EVT) const override {
@@ -185,8 +185,8 @@ private:
   const NVPTXSubtarget &STI; // cache the subtarget here
   mutable unsigned GlobalUniqueCallSite;
 
-  SDValue getParamSymbol(SelectionDAG &DAG, int I, EVT T) const;
-  SDValue getCallParamSymbol(SelectionDAG &DAG, int I, EVT T) const;
+  SDValue getParamSymbolNode(SelectionDAG &DAG, int I, EVT T) const;
+  SDValue getCallParamSymbolNode(SelectionDAG &DAG, int I, EVT T) const;
   SDValue LowerADDRSPACECAST(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerBITCAST(SDValue Op, SelectionDAG &DAG) const;
 

--- a/llvm/lib/Target/NVPTX/NVPTXInstrInfo.td
+++ b/llvm/lib/Target/NVPTX/NVPTXInstrInfo.td
@@ -1859,11 +1859,17 @@ def to_tjumptable : SDNodeXForm<jumptable, [{
   return CurDAG->getTargetJumpTable(N->getIndex(), N->getValueType(0));
 }]>;
 
+def SDTSymbol : SDTypeProfile<1, 1, [SDTCisInt<0>, SDTCisSameAs<0, 1>]>;
+def symbol : SDNode<"NVPTXISD::Symbol", SDTSymbol, []>;
+
 def : Pat<(i32 globaladdr:$dst), (MOV_B32_sym (to_tglobaladdr $dst))>;
 def : Pat<(i64 globaladdr:$dst), (MOV_B64_sym (to_tglobaladdr $dst))>;
 
 def : Pat<(i32 externalsym:$dst), (MOV_B32_sym (to_texternsym $dst))>;
 def : Pat<(i64 externalsym:$dst), (MOV_B64_sym (to_texternsym $dst))>;
+
+def : Pat<(i32 (symbol mcsym:$dst)), (MOV_B32_sym mcsym:$dst)>;
+def : Pat<(i64 (symbol mcsym:$dst)), (MOV_B64_sym mcsym:$dst)>;
 
 //---- Copy Frame Index ----
 def LEA_ADDRi :   NVPTXInst<(outs B32:$dst), (ins ADDR:$addr),
@@ -1906,8 +1912,8 @@ def SDTProxyReg : SDTypeProfile<1, 1, [SDTCisSameAs<0, 1>]>;
 //   .param .align 16 .b8 param0[1024];
 //   .param .b32 retval0;
 //
-// DeclareArrayParam(Chain, Externalsym, Align, Size, Glue)
-// DeclareScalarParam(Chain, Externalsym, Size, Glue)
+// DeclareArrayParam(Chain, Symbol, Align, Size, Glue)
+// DeclareScalarParam(Chain, Symbol, Size, Glue)
 def declare_array_param :
   SDNode<"NVPTXISD::DeclareArrayParam", SDTDeclareArrayParam,
          [SDNPHasChain, SDNPOutGlue, SDNPInGlue, SDNPSideEffect]>;
@@ -1966,16 +1972,16 @@ def DECLARE_PARAM_scalar :
   NVPTXInst<(outs), (ins i32imm:$a, i32imm:$size),
             ".param .b$size \t$a;">;
 
-def : Pat<(declare_array_param externalsym:$a, imm:$align, imm:$size),
-          (DECLARE_PARAM_array (to_texternsym $a), imm:$align, imm:$size)>;
-def : Pat<(declare_scalar_param externalsym:$a, imm:$size),
-          (DECLARE_PARAM_scalar (to_texternsym $a), imm:$size)>;
+def : Pat<(declare_array_param (symbol mcsym:$a), imm:$align, imm:$size),
+          (DECLARE_PARAM_array mcsym:$a, imm:$align, imm:$size)>;
+def : Pat<(declare_scalar_param (symbol mcsym:$a), imm:$size),
+          (DECLARE_PARAM_scalar mcsym:$a, imm:$size)>;
 
 foreach t = [I32RT, I64RT] in {
   defvar inst_name = "MOV" # t.Size # "_PARAM";
   def inst_name : BasicNVPTXInst<(outs t.RC:$dst), (ins t.RC:$src), "mov.b" # t.Size>;
-  def : Pat<(MoveParam (t.Ty externalsym:$src)),
-            (!cast<NVPTXInst>(inst_name) (t.Ty (to_texternsym $src)))>;
+  def : Pat<(MoveParam (t.Ty (symbol mcsym:$src))),
+            (!cast<NVPTXInst>(inst_name) (t.Ty mcsym:$src))>;
 }
 
 multiclass ProxyRegInst<string SzStr, NVPTXRegClass rc> {

--- a/llvm/lib/Target/NVPTX/NVPTXMachineFunctionInfo.h
+++ b/llvm/lib/Target/NVPTX/NVPTXMachineFunctionInfo.h
@@ -14,18 +14,19 @@
 #ifndef LLVM_LIB_TARGET_NVPTX_NVPTXMACHINEFUNCTIONINFO_H
 #define LLVM_LIB_TARGET_NVPTX_NVPTXMACHINEFUNCTIONINFO_H
 
-#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include <map>
 
 namespace llvm {
 class CallBase;
+class MCSymbol;
 
 class NVPTXMachineFunctionInfo : public MachineFunctionInfo {
 private:
-  /// Stores a mapping from index to symbol name for image handles that are
-  /// replaced with image references
-  SmallVector<std::string, 8> ImageHandleList;
+  /// The parameter symbols whose image handles were replaced with image
+  /// references.
+  SmallPtrSet<const MCSymbol *, 8> ImageHandleSymbols;
 
   /// Stores a mapping from a unique call-site id to the call instruction that
   /// needs an indirect-call prototype emitted.
@@ -41,23 +42,14 @@ public:
     return DestMF.cloneInfo<NVPTXMachineFunctionInfo>(*this);
   }
 
-  /// Returns the index for the symbol \p Symbol. If the symbol was previously,
-  /// added, the same index is returned. Otherwise, the symbol is added and the
-  /// new index is returned.
-  unsigned getImageHandleSymbolIndex(StringRef Symbol) {
-    // Is the symbol already present?
-    for (unsigned i = 0, e = ImageHandleList.size(); i != e; ++i)
-      if (ImageHandleList[i] == Symbol)
-        return i;
-    // Nope, insert it
-    ImageHandleList.push_back(Symbol.str());
-    return ImageHandleList.size()-1;
+  /// Record that \p Symbol's handle was replaced with an image reference.
+  void addImageHandleSymbol(const MCSymbol *Symbol) {
+    ImageHandleSymbols.insert(Symbol);
   }
 
-  /// Check if the symbol has a mapping. Having a mapping means the handle is
-  /// replaced with a reference
-  bool checkImageHandleSymbol(StringRef Symbol) const {
-    return llvm::is_contained(ImageHandleList, Symbol);
+  /// Check whether \p Symbol's handle was replaced with an image reference.
+  bool checkImageHandleSymbol(const MCSymbol *Symbol) const {
+    return ImageHandleSymbols.contains(Symbol);
   }
 
   void addCallPrototype(unsigned Id, const CallBase *CB) {

--- a/llvm/lib/Target/NVPTX/NVPTXReplaceImageHandles.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXReplaceImageHandles.cpp
@@ -1796,11 +1796,11 @@ bool NVPTXReplaceImageHandles::replaceImageHandle(MachineOperand &Op,
       // For CUDA, we preserve the param loads coming from function arguments
       return false;
 
-    assert(TexHandleDef.getOperand(7).isSymbol() && "Load is not a symbol!");
-    StringRef Sym = TexHandleDef.getOperand(7).getSymbolName();
+    assert(TexHandleDef.getOperand(7).isMCSymbol() && "Load is not a symbol!");
+    MCSymbol *Sym = TexHandleDef.getOperand(7).getMCSymbol();
     InstrsToRemove.insert(&TexHandleDef);
-    Op.ChangeToES(Sym.data());
-    MFI->getImageHandleSymbolIndex(Sym);
+    Op.ChangeToMCSymbol(Sym);
+    MFI->addImageHandleSymbol(Sym);
     return true;
   }
   case NVPTX::texsurf_handles: {

--- a/llvm/lib/Target/NVPTX/NVPTXTargetMachine.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXTargetMachine.cpp
@@ -107,7 +107,7 @@ NVPTXTargetMachine::NVPTXTargetMachine(const Target &T, const Triple &TT,
                                TT, CPU, FS, Options, Reloc::PIC_,
                                getEffectiveCodeModel(CM, CodeModel::Small), OL),
       TLOF(std::make_unique<NVPTXTargetObjectFile>()),
-      Subtarget(TT, CPU, FS, *this), StrPool(StrAlloc) {
+      Subtarget(TT, CPU, FS, *this) {
   if (!DisableRequireStructuredCFG)
     setRequiresStructuredCFG(true);
   // NVPTX does not produce verifier-clean MIR yet; see isMachineVerifierClean()

--- a/llvm/lib/Target/NVPTX/NVPTXTargetMachine.h
+++ b/llvm/lib/Target/NVPTX/NVPTXTargetMachine.h
@@ -26,10 +26,6 @@ class NVPTXTargetMachine : public CodeGenTargetMachineImpl {
   std::unique_ptr<TargetLoweringObjectFile> TLOF;
   NVPTXSubtarget Subtarget;
 
-  // Hold Strings that can be free'd all together with NVPTXTargetMachine
-  mutable BumpPtrAllocator StrAlloc;
-  mutable UniqueStringSaver StrPool;
-
 public:
   NVPTXTargetMachine(const Target &T, const Triple &TT, StringRef CPU,
                      StringRef FS, const TargetOptions &Options,
@@ -45,8 +41,6 @@ public:
     return getTargetTriple().getOS() == Triple::NVCL ? NVPTX::NVCL
                                                      : NVPTX::CUDA;
   }
-  UniqueStringSaver &getStrPool() const { return StrPool; }
-
   TargetPassConfig *createPassConfig(PassManagerBase &PM) override;
 
   // Emission of machine code through MCJIT is not supported.

--- a/llvm/test/CodeGen/NVPTX/machinelicm-no-preheader.mir
+++ b/llvm/test/CodeGen/NVPTX/machinelicm-no-preheader.mir
@@ -26,10 +26,10 @@ body:             |
   ; CHECK: bb.0.entry:
   ; CHECK-NEXT:   successors: %bb.2(0x30000000), %bb.3(0x50000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[LD_i32_:%[0-9]+]]:b32 = LD_i32 0, 0, 101, 3, 32, -1, 0, 0, &test_hoist_param_1, 0 :: (dereferenceable invariant load (s32), addrspace 101)
-  ; CHECK-NEXT:   [[LD_i64_:%[0-9]+]]:b64 = LD_i64 0, 0, 101, 3, 64, -1, 0, 0, &test_hoist_param_0, 0 :: (dereferenceable invariant load (s64), addrspace 101)
+  ; CHECK-NEXT:   [[LD_i32_:%[0-9]+]]:b32 = LD_i32 0, 0, 101, 3, 32, -1, <mcsymbol test_hoist_param_1>, 0, 0, $noreg :: (dereferenceable invariant load (s32), addrspace 101)
+  ; CHECK-NEXT:   [[LD_i64_:%[0-9]+]]:b64 = LD_i64 0, 0, 101, 3, 64, -1, <mcsymbol test_hoist_param_0>, 0, 0, $noreg :: (dereferenceable invariant load (s64), addrspace 101)
   ; CHECK-NEXT:   [[ADD64ri:%[0-9]+]]:b64 = nuw ADD64ri killed [[LD_i64_]], 2
-  ; CHECK-NEXT:   [[LD_i32_1:%[0-9]+]]:b32 = LD_i32 0, 0, 1, 3, 32, -1, 0, 0, [[ADD64ri]], 0
+  ; CHECK-NEXT:   [[LD_i32_1:%[0-9]+]]:b32 = LD_i32 0, 0, 1, 3, 32, -1, [[ADD64ri]], 0, 0, $noreg
   ; CHECK-NEXT:   [[SETP_i32ri:%[0-9]+]]:b1 = SETP_i32ri [[LD_i32_]], 0, 0
   ; CHECK-NEXT:   CBranch killed [[SETP_i32ri]], %bb.2, 0
   ; CHECK-NEXT: {{  $}}
@@ -49,15 +49,15 @@ body:             |
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2:
   ; CHECK-NEXT:   [[PHI1:%[0-9]+]]:b32 = PHI [[LD_i32_1]], %bb.0, [[SREM32rr]], %bb.1
-  ; CHECK-NEXT:   ST_i32 [[PHI1]], 0, 0, 1, 32, 0, [[ADD64ri]], 0, 0
+  ; CHECK-NEXT:   ST_i32 [[PHI1]], 0, 0, 1, 32, [[ADD64ri]], 0, 0, $noreg
   ; CHECK-NEXT:   Return
   bb.0.entry:
     successors: %bb.2(0x30000000), %bb.1(0x50000000)
 
-    %5:b32 = LD_i32 0, 0, 101, 3, 32, -1, 0, 0, &test_hoist_param_1, 0 :: (dereferenceable invariant load (s32), addrspace 101)
-    %6:b64 = LD_i64 0, 0, 101, 3, 64, -1, 0, 0, &test_hoist_param_0, 0 :: (dereferenceable invariant load (s64), addrspace 101)
+    %5:b32 = LD_i32 0, 0, 101, 3, 32, -1, <mcsymbol test_hoist_param_1>, 0, 0, $noreg :: (dereferenceable invariant load (s32), addrspace 101)
+    %6:b64 = LD_i64 0, 0, 101, 3, 64, -1, <mcsymbol test_hoist_param_0>, 0, 0, $noreg :: (dereferenceable invariant load (s64), addrspace 101)
     %0:b64 = nuw ADD64ri killed %6, 2
-    %1:b32 = LD_i32 0, 0, 1, 3, 32, -1, 0, 0, %0, 0
+    %1:b32 = LD_i32 0, 0, 1, 3, 32, -1, %0, 0, 0, $noreg
     %7:b1 = SETP_i32ri %5, 0, 0
     CBranch killed %7, %bb.2, 0
     GOTO %bb.1
@@ -75,6 +75,6 @@ body:             |
 
   bb.2:
     %4:b32 = PHI %1, %bb.0, %3, %bb.1
-    ST_i32 %4, 0, 0, 1, 32, 0, %0, 0, 0
+    ST_i32 %4, 0, 0, 1, 32, %0, 0, 0, $noreg
     Return
 ...

--- a/llvm/test/CodeGen/NVPTX/proxy-reg-erasure.mir
+++ b/llvm/test/CodeGen/NVPTX/proxy-reg-erasure.mir
@@ -77,22 +77,22 @@ constants:       []
 machineFunctionInfo: {}
 body:             |
   bb.0:
-    %0:b32, %1:b32, %2:b32, %3:b32 = LDV_i32_v4 0, 0, 101, 3, 32, -1, 0, 0, &retval0, 0 :: (load (s128), addrspace 101)
+    %0:b32, %1:b32, %2:b32, %3:b32 = LDV_i32_v4 0, 0, 101, 3, 32, -1, <mcsymbol retval0>, 0, 0, $noreg :: (load (s128), addrspace 101)
     ; CHECK-NOT: ProxyReg
     %4:b32 = ProxyRegB32 killed %0
     %5:b32 = ProxyRegB32 killed %1
     %6:b32 = ProxyRegB32 killed %2
     %7:b32 = ProxyRegB32 killed %3
     ; CHECK: STV_i32_v4 %0, %1, %2, %3
-    STV_i32_v4 killed %4, killed %5, killed %6, killed %7, 0, 0, 101, 32, 0, &func_retval0, 0, 0 :: (store (s128), addrspace 101)
+    STV_i32_v4 killed %4, killed %5, killed %6, killed %7, 0, 0, 101, 32, <mcsymbol func_retval0>, 0, 0, $noreg :: (store (s128), addrspace 101)
 
-    %8:b32 = LD_i32 0, 0, 101, 3, 32, -1, 0, 0, &retval0, 0 :: (load (s32), addrspace 101)
+    %8:b32 = LD_i32 0, 0, 101, 3, 32, -1, <mcsymbol retval0>, 0, 0, $noreg :: (load (s32), addrspace 101)
     ; CHECK-NOT: ProxyReg
     %9:b32 = ProxyRegB32 killed %8
     %10:b32 = ProxyRegB32 killed %9
     %11:b32 = ProxyRegB32 killed %10
     ; CHECK: ST_i32 %8
-    ST_i32 killed %11, 0, 0, 101, 32, 0, &func_retval0, 0, 0 :: (store (s32), addrspace 101)
+    ST_i32 killed %11, 0, 0, 101, 32, <mcsymbol func_retval0>, 0, 0, $noreg :: (store (s32), addrspace 101)
     Return
 
 ...

--- a/llvm/test/CodeGen/NVPTX/stop-after-npm.ll
+++ b/llvm/test/CodeGen/NVPTX/stop-after-npm.ll
@@ -4,7 +4,7 @@
 ; RUN: llc -mtriple=nvptx64 -enable-new-pm -stop-after=finalize-isel -o - %s | FileCheck %s
 
 ; CHECK: name: test
-; CHECK: LD_i32 {{.*}}&test_param_0
+; CHECK: LD_i32 {{.*}}<mcsymbol test_param_0>
 define i32 @test(i32 %a) {
   ret i32 %a
 }


### PR DESCRIPTION
Using MCSymbols is more idiomatic and allows us to remove mutable members from the TM and simplifies MFI data structures. 