### PR TITLE
[libc++] Add missing noexcept on shared_ptr assignment

### DIFF
--- a/libcxx/include/__memory/shared_ptr.h
+++ b/libcxx/include/__memory/shared_ptr.h
@@ -474,7 +474,7 @@ public:
   }
 
   template <class _Yp, __enable_if_t<__compatible_with_v<_Yp, _Tp>, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI shared_ptr<_Tp>& operator=(shared_ptr<_Yp>&& __r) {
+  _LIBCPP_HIDE_FROM_ABI shared_ptr<_Tp>& operator=(shared_ptr<_Yp>&& __r) _NOEXCEPT {
     shared_ptr(std::move(__r)).swap(*this);
     return *this;
   }

--- a/libcxx/include/memory
+++ b/libcxx/include/memory
@@ -613,7 +613,7 @@ public:
     shared_ptr& operator=(const shared_ptr& r) noexcept;
     template<class Y> shared_ptr& operator=(const shared_ptr<Y>& r) noexcept;
     shared_ptr& operator=(shared_ptr&& r) noexcept;
-    template<class Y> shared_ptr& operator=(shared_ptr<Y>&& r);
+    template<class Y> shared_ptr& operator=(shared_ptr<Y>&& r) noexcept;
     template<class Y> shared_ptr& operator=(auto_ptr<Y>&& r); // removed in C++17
     template <class Y, class D> shared_ptr& operator=(unique_ptr<Y, D>&& r);
 

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.assign/shared_ptr.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.assign/shared_ptr.pass.cpp
@@ -10,7 +10,7 @@
 
 // shared_ptr
 
-// shared_ptr& operator=(const shared_ptr& r);
+// shared_ptr& operator=(const shared_ptr& r) noexcept;
 
 // ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
 
@@ -45,6 +45,8 @@ int A::count = 0;
 
 int main(int, char**)
 {
+    static_assert(std::is_nothrow_assignable<std::shared_ptr<A>&, const std::shared_ptr<A>&>::value, "");
+
     {
         const std::shared_ptr<A> pA(new A);
         A* ptrA = pA.get();

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.assign/shared_ptr_Y.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.assign/shared_ptr_Y.pass.cpp
@@ -10,7 +10,7 @@
 
 // shared_ptr
 
-// template<class Y> shared_ptr& operator=(const shared_ptr<Y>& r);
+// template<class Y> shared_ptr& operator=(const shared_ptr<Y>& r) noexcept;
 
 #include <memory>
 #include <type_traits>
@@ -43,6 +43,8 @@ int A::count = 0;
 
 int main(int, char**)
 {
+    static_assert(std::is_nothrow_assignable<std::shared_ptr<B>&, const std::shared_ptr<A>&>::value, "");
+
     {
         const std::shared_ptr<A> pA(new A);
         A* ptrA = pA.get();

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.assign/shared_ptr_Y_rv.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.assign/shared_ptr_Y_rv.pass.cpp
@@ -12,7 +12,7 @@
 
 // shared_ptr
 
-// template<class Y> shared_ptr& operator=(shared_ptr<Y>&& r);
+// template<class Y> shared_ptr& operator=(shared_ptr<Y>&& r) noexcept;
 
 #include <memory>
 #include <type_traits>
@@ -46,6 +46,8 @@ int A::count = 0;
 
 int main(int, char**)
 {
+    static_assert(std::is_nothrow_assignable<std::shared_ptr<B>&, std::shared_ptr<A>&&>::value, "");
+
     {
         std::shared_ptr<A> pA(new A);
         A* ptrA = pA.get();

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.assign/shared_ptr_rv.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.assign/shared_ptr_rv.pass.cpp
@@ -12,7 +12,7 @@
 
 // shared_ptr
 
-// shared_ptr& operator=(shared_ptr&& r);
+// shared_ptr& operator=(shared_ptr&& r) noexcept;
 
 #include <memory>
 #include <type_traits>
@@ -46,6 +46,8 @@ int A::count = 0;
 
 int main(int, char**)
 {
+    static_assert(std::is_nothrow_assignable<std::shared_ptr<A>&, std::shared_ptr<A>&&>::value, "");
+
     {
         std::shared_ptr<A> pA(new A);
         A* ptrA = pA.get();


### PR DESCRIPTION
The Standard declares it as noexcept in [util.smartptr.shared.assign]. Also add a couple of missing tests.