### PR TITLE
[MachO] Preserve weak attributes on aliases

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2685,7 +2685,9 @@ void AsmPrinter::emitGlobalAlias(const Module &M, const GlobalAlias &GA) {
     return;
   }
 
-  if (GA.hasExternalLinkage() || !MAI.getWeakRefDirective())
+  if (MAI.isMachO())
+    emitLinkage(&GA, Name);
+  else if (GA.hasExternalLinkage() || !MAI.getWeakRefDirective())
     OutStreamer->emitSymbolAttribute(Name, MCSA_Global);
   else if (GA.hasWeakLinkage() || GA.hasLinkOnceLinkage())
     OutStreamer->emitSymbolAttribute(Name, MCSA_WeakReference);

--- a/llvm/lib/MC/MachObjectWriter.cpp
+++ b/llvm/lib/MC/MachObjectWriter.cpp
@@ -443,7 +443,11 @@ void MachObjectWriter::writeNlist(MachSymbolData &MSD, const MCAssembler &Asm) {
   // The Mach-O streamer uses the lowest 16-bits of the flags for the 'desc'
   // value.
   bool EncodeAsAltEntry = IsAlias && OrigSymbol.isAltEntry();
-  W.write<uint16_t>(Symbol->getEncodedFlags(EncodeAsAltEntry));
+  uint16_t Flags = Symbol->getEncodedFlags(EncodeAsAltEntry);
+  if (IsAlias)
+    Flags |= OrigSymbol.getEncodedFlags(false) &
+             (MachO::N_WEAK_DEF | MachO::N_WEAK_REF);
+  W.write<uint16_t>(Flags);
   if (is64Bit())
     W.write<uint64_t>(Address);
   else

--- a/llvm/test/CodeGen/AArch64/macho-weak-alias.ll
+++ b/llvm/test/CodeGen/AArch64/macho-weak-alias.ll
@@ -1,0 +1,26 @@
+; RUN: llc -mtriple=aarch64-apple-macosx13.0.0 %s -o - | FileCheck %s
+
+@foo = internal global i32 0
+@external_alias = alias i32, ptr @foo
+@internal_alias = internal alias i32, ptr @foo
+@weak_alias = weak alias i32, ptr @foo
+@hidden_weak_alias = weak hidden alias i32, ptr @foo
+@linkonce_alias = linkonce alias i32, ptr @foo
+@auto_hide_alias = linkonce_odr unnamed_addr alias i32, ptr @foo
+
+; CHECK:      .globl _external_alias
+; CHECK-NEXT: _external_alias = _foo
+; CHECK:      _internal_alias = _foo
+; CHECK:      .globl _weak_alias
+; CHECK-NEXT: .weak_definition _weak_alias
+; CHECK-NEXT: _weak_alias = _foo
+; CHECK:      .globl _hidden_weak_alias
+; CHECK-NEXT: .weak_definition _hidden_weak_alias
+; CHECK-NEXT: .private_extern _hidden_weak_alias
+; CHECK-NEXT: _hidden_weak_alias = _foo
+; CHECK:      .globl _linkonce_alias
+; CHECK-NEXT: .weak_definition _linkonce_alias
+; CHECK-NEXT: _linkonce_alias = _foo
+; CHECK:      .globl _auto_hide_alias
+; CHECK-NEXT: .weak_def_can_be_hidden _auto_hide_alias
+; CHECK-NEXT: _auto_hide_alias = _foo

--- a/llvm/test/MC/MachO/alias-flags.s
+++ b/llvm/test/MC/MachO/alias-flags.s
@@ -1,0 +1,177 @@
+// RUN: llvm-mc -triple x86_64-apple-macosx13.0.0 -filetype=obj %s -o - | llvm-readobj --symbols - | FileCheck %s
+
+// Aliases inherit these n_desc fields from their aliasees. Of these flags,
+// only N_ALT_ENTRY is also preserved when set on the alias itself.
+.text
+_plain:
+  nop
+
+.alt_entry _alt_entry_target
+_alt_entry_target:
+  nop
+
+.cold _cold_target
+_cold_target:
+  nop
+
+.no_dead_strip _no_dead_strip_target
+_no_dead_strip_target:
+  nop
+
+_reference_type_target:
+  nop
+// Set the reference type after the label, which would otherwise clear it.
+.desc _reference_type_target, 2
+
+.symbol_resolver _resolver_target
+_resolver_target:
+  nop
+
+.globl _alt_entry_on_alias
+.alt_entry _alt_entry_on_alias
+_alt_entry_on_alias = _plain
+
+.globl _alt_entry_on_target
+_alt_entry_on_target = _alt_entry_target
+
+.globl _cold_on_alias
+.cold _cold_on_alias
+_cold_on_alias = _plain
+
+.globl _cold_on_target
+_cold_on_target = _cold_target
+
+.globl _no_dead_strip_on_alias
+.no_dead_strip _no_dead_strip_on_alias
+_no_dead_strip_on_alias = _plain
+
+.globl _no_dead_strip_on_target
+_no_dead_strip_on_target = _no_dead_strip_target
+
+// Different reference types must not be ORed together: the aliasee wins.
+.globl _reference_type_both
+.desc _reference_type_both, 1
+_reference_type_both = _reference_type_target
+
+.globl _reference_type_on_alias
+.desc _reference_type_on_alias, 1
+_reference_type_on_alias = _plain
+
+.globl _reference_type_on_target
+_reference_type_on_target = _reference_type_target
+
+.globl _resolver_on_alias
+.symbol_resolver _resolver_on_alias
+_resolver_on_alias = _plain
+
+.globl _resolver_on_target
+_resolver_on_target = _resolver_target
+
+// Preserve the aliasee's alt-entry bit along with both weak bits on the alias.
+.globl _auto_to_alt_entry
+.weak_def_can_be_hidden _auto_to_alt_entry
+_auto_to_alt_entry = _alt_entry_target
+
+// Only the weak bits are taken from the alias, not its no-dead-strip bit.
+.globl _weak_no_dead_strip
+.weak_definition _weak_no_dead_strip
+.no_dead_strip _weak_no_dead_strip
+_weak_no_dead_strip = _plain
+
+// Preserve the aliasee's no-dead-strip bit when adding the alias's weak bit.
+.globl _weak_to_no_dead_strip
+.weak_definition _weak_to_no_dead_strip
+_weak_to_no_dead_strip = _no_dead_strip_target
+
+// CHECK-LABEL: Name: _alt_entry_on_alias
+// CHECK:       RefType: UndefinedNonLazy (0x0)
+// CHECK-NEXT:  Flags [ (0x200)
+// CHECK-NEXT:    AltEntry (0x200)
+// CHECK-NEXT:  ]
+
+// CHECK-LABEL: Name: _alt_entry_on_target
+// CHECK:       RefType: UndefinedNonLazy (0x0)
+// CHECK-NEXT:  Flags [ (0x200)
+// CHECK-NEXT:    AltEntry (0x200)
+// CHECK-NEXT:  ]
+
+// CHECK-LABEL: Name: _auto_to_alt_entry
+// CHECK-NEXT:  Extern
+// CHECK-NEXT:  Type: Section (0xE)
+// CHECK-NEXT:  Section: __text (0x1)
+// CHECK-NEXT:  RefType: UndefinedNonLazy (0x0)
+// CHECK-NEXT:  Flags [ (0x2C0)
+// CHECK-NEXT:    AltEntry (0x200)
+// CHECK-NEXT:    WeakDef (0x80)
+// CHECK-NEXT:    WeakRef (0x40)
+// CHECK-NEXT:  ]
+// CHECK-NEXT:  Value: 0x1
+
+// CHECK-LABEL: Name: _cold_on_alias
+// CHECK:       RefType: UndefinedNonLazy (0x0)
+// CHECK-NEXT:  Flags [ (0x0)
+// CHECK-NEXT:  ]
+
+// CHECK-LABEL: Name: _cold_on_target
+// CHECK:       RefType: UndefinedNonLazy (0x0)
+// CHECK-NEXT:  Flags [ (0x400)
+// CHECK-NEXT:    ColdFunc (0x400)
+// CHECK-NEXT:  ]
+
+// CHECK-LABEL: Name: _no_dead_strip_on_alias
+// CHECK:       RefType: UndefinedNonLazy (0x0)
+// CHECK-NEXT:  Flags [ (0x0)
+// CHECK-NEXT:  ]
+
+// CHECK-LABEL: Name: _no_dead_strip_on_target
+// CHECK:       RefType: UndefinedNonLazy (0x0)
+// CHECK-NEXT:  Flags [ (0x20)
+// CHECK-NEXT:    NoDeadStrip (0x20)
+// CHECK-NEXT:  ]
+
+// CHECK-LABEL: Name: _reference_type_both
+// CHECK:       RefType: ReferenceFlagDefined (0x2)
+// CHECK-NEXT:  Flags [ (0x0)
+// CHECK-NEXT:  ]
+
+// CHECK-LABEL: Name: _reference_type_on_alias
+// CHECK:       RefType: UndefinedNonLazy (0x0)
+// CHECK-NEXT:  Flags [ (0x0)
+// CHECK-NEXT:  ]
+
+// CHECK-LABEL: Name: _reference_type_on_target
+// CHECK:       RefType: ReferenceFlagDefined (0x2)
+// CHECK-NEXT:  Flags [ (0x0)
+// CHECK-NEXT:  ]
+
+// CHECK-LABEL: Name: _resolver_on_alias
+// CHECK:       RefType: UndefinedNonLazy (0x0)
+// CHECK-NEXT:  Flags [ (0x0)
+// CHECK-NEXT:  ]
+
+// CHECK-LABEL: Name: _resolver_on_target
+// CHECK:       RefType: UndefinedNonLazy (0x0)
+// CHECK-NEXT:  Flags [ (0x100)
+// CHECK-NEXT:    SymbolResolver (0x100)
+// CHECK-NEXT:  ]
+
+// CHECK-LABEL: Name: _weak_no_dead_strip
+// CHECK-NEXT:  Extern
+// CHECK-NEXT:  Type: Section (0xE)
+// CHECK-NEXT:  Section: __text (0x1)
+// CHECK-NEXT:  RefType: UndefinedNonLazy (0x0)
+// CHECK-NEXT:  Flags [ (0x80)
+// CHECK-NEXT:    WeakDef (0x80)
+// CHECK-NEXT:  ]
+// CHECK-NEXT:  Value: 0x0
+
+// CHECK-LABEL: Name: _weak_to_no_dead_strip
+// CHECK-NEXT:  Extern
+// CHECK-NEXT:  Type: Section (0xE)
+// CHECK-NEXT:  Section: __text (0x1)
+// CHECK-NEXT:  RefType: UndefinedNonLazy (0x0)
+// CHECK-NEXT:  Flags [ (0xA0)
+// CHECK-NEXT:    NoDeadStrip (0x20)
+// CHECK-NEXT:    WeakDef (0x80)
+// CHECK-NEXT:  ]
+// CHECK-NEXT:  Value: 0x3

--- a/llvm/test/MC/MachO/weak-alias.s
+++ b/llvm/test/MC/MachO/weak-alias.s
@@ -1,0 +1,84 @@
+// RUN: llvm-mc -triple x86_64-apple-macosx13.0.0 -filetype=obj %s -o - | llvm-readobj --symbols - | FileCheck %s
+
+.text
+_foo:
+  nop
+
+.globl _external
+_external = _foo
+
+.globl _weak
+.weak_definition _weak
+_weak = _foo
+
+.globl _auto
+.weak_def_can_be_hidden _auto
+_auto = _foo
+
+_local = _foo
+
+.globl _weak_target
+.weak_definition _weak_target
+_weak_target:
+  nop
+
+.globl _strong_to_weak
+_strong_to_weak = _weak_target
+
+// CHECK:      Name: _local
+// CHECK-NEXT: Type: Section (0xE)
+// CHECK-NEXT: Section: __text (0x1)
+// CHECK-NEXT: RefType: UndefinedNonLazy (0x0)
+// CHECK-NEXT: Flags [ (0x0)
+// CHECK-NEXT: ]
+// CHECK-NEXT: Value: 0x0
+
+// CHECK:      Name: _auto
+// CHECK-NEXT: Extern
+// CHECK-NEXT: Type: Section (0xE)
+// CHECK-NEXT: Section: __text (0x1)
+// CHECK-NEXT: RefType: UndefinedNonLazy (0x0)
+// CHECK-NEXT: Flags [ (0xC0)
+// CHECK-NEXT:   WeakDef (0x80)
+// CHECK-NEXT:   WeakRef (0x40)
+// CHECK-NEXT: ]
+// CHECK-NEXT: Value: 0x0
+
+// CHECK:      Name: _external
+// CHECK-NEXT: Extern
+// CHECK-NEXT: Type: Section (0xE)
+// CHECK-NEXT: Section: __text (0x1)
+// CHECK-NEXT: RefType: UndefinedNonLazy (0x0)
+// CHECK-NEXT: Flags [ (0x0)
+// CHECK-NEXT: ]
+// CHECK-NEXT: Value: 0x0
+
+// CHECK:      Name: _strong_to_weak
+// CHECK-NEXT: Extern
+// CHECK-NEXT: Type: Section (0xE)
+// CHECK-NEXT: Section: __text (0x1)
+// CHECK-NEXT: RefType: UndefinedNonLazy (0x0)
+// CHECK-NEXT: Flags [ (0x80)
+// CHECK-NEXT:   WeakDef (0x80)
+// CHECK-NEXT: ]
+// CHECK-NEXT: Value: 0x1
+
+// CHECK:      Name: _weak
+// CHECK-NEXT: Extern
+// CHECK-NEXT: Type: Section (0xE)
+// CHECK-NEXT: Section: __text (0x1)
+// CHECK-NEXT: RefType: UndefinedNonLazy (0x0)
+// CHECK-NEXT: Flags [ (0x80)
+// CHECK-NEXT:   WeakDef (0x80)
+// CHECK-NEXT: ]
+// CHECK-NEXT: Value: 0x0
+
+// CHECK:      Name: _weak_target
+// CHECK-NEXT: Extern
+// CHECK-NEXT: Type: Section (0xE)
+// CHECK-NEXT: Section: __text (0x1)
+// CHECK-NEXT: RefType: UndefinedNonLazy (0x0)
+// CHECK-NEXT: Flags [ (0x80)
+// CHECK-NEXT:   WeakDef (0x80)
+// CHECK-NEXT: ]
+// CHECK-NEXT: Value: 0x1


### PR DESCRIPTION
Supersedes #212001

Fixes #111321

1. Use `emitLinkage` for Mach-O aliases so weak aliases are emitted as public weak definitions.
2. `MachObjectWriter` derives an alias's `n_desc` from its aliasee, which drops weak-definition bits set on the alias itself. Preserve `N_WEAK_DEF` and `N_WEAK_REF` from the alias while leaving the existing aliasee-derived flags unchanged.

AI-assisted tools are primarily used for writing tests and other mechanical tasks, including automating builds and verifications, particularly verifying the behavior of different Xcode versions (based on comments from the Apple Linker team under the original PR) and verifying the behavior of EII on Rust source code tree.