### PR TITLE
[SandboxVec][Scheduler][NFC] Assert scheduling direction

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
@@ -277,6 +277,22 @@ public:
     return Where == Other.Where;
   }
 #ifndef NDEBUG
+  /// Returns true if the scheduling point is after \p I in program order.
+  bool comesBefore(Instruction &I) const {
+    if (BasicBlock *BB = atEndOrNull()) {
+      // All instructions are before BB end.
+      assert(BB == I.getParent() && "We don't support crossing BBs!");
+      return false;
+    }
+    if (BasicBlock *BB = atBeforeBeginOrNull()) {
+      // Before begin is always before any instruction.
+      assert(BB == I.getParent() && "We don't support crossing BBs!");
+      return true;
+    }
+    Instruction *SchedPointI = atInstrOrNull();
+    assert(SchedPointI != nullptr && "Should have been already handled!");
+    return SchedPointI->comesBefore(&I);
+  }
   void print(raw_ostream &OS) const;
   LLVM_DUMP_METHOD void dump() const;
 #endif
@@ -340,8 +356,12 @@ class Scheduler {
   Scheduler(const Scheduler &) = delete;
   Scheduler &operator=(const Scheduler &) = delete;
 
-private:
   SchedDirection Dir = SchedDirection::BottomUp;
+#ifndef NDEBUG
+  /// Asserts that \p Instrs are above the scheduling frontier if scheduling
+  /// bottom-up or below it if scheduling top-down.
+  void assertSameDirection(ArrayRef<Instruction *> Instrs) const;
+#endif
 
 public:
   Scheduler(AAResults &AA, Context &Ctx, SchedDirection Dir)

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
@@ -347,6 +347,28 @@ void Scheduler::trimSchedule(ArrayRef<Instruction *> Instrs) {
   }
 }
 
+#ifndef NDEBUG
+void Scheduler::assertSameDirection(ArrayRef<Instruction *> Instrs) const {
+  // Check that we are not switching scheduling direction.
+  switch (Dir) {
+  case SchedDirection::BottomUp:
+    assert(none_of(Instrs,
+                   [this](Instruction *I) {
+                     return ScheduleTopItOpt->comesBefore(*I);
+                   }) &&
+           "Wrong scheduling direction!");
+    break;
+  case SchedDirection::TopDown:
+    assert(all_of(Instrs,
+                  [this](Instruction *I) {
+                    return ScheduleTopItOpt->comesBefore(*I);
+                  }) &&
+           "Wrong scheduling direction!");
+    break;
+  }
+}
+#endif // NDEBUG
+
 bool Scheduler::trySchedule(ArrayRef<Instruction *> Instrs) {
   assert(all_of(drop_begin(Instrs),
                 [Instrs](Instruction *I) {
@@ -398,9 +420,14 @@ bool Scheduler::trySchedule(ArrayRef<Instruction *> Instrs) {
     return tryScheduleUntil(Instrs);
   case BndlSchedState::NoneScheduled: {
     // TODO: Set the window of the DAG that we are interested in.
-    if (!ScheduleTopItOpt)
+    if (!ScheduleTopItOpt) {
       // We start scheduling at the bottom instr of Instrs (top in TopDown).
       ScheduleTopItOpt = GetSchedPoint(Dir, Instrs);
+    } else {
+#ifndef NDEBUG
+      assertSameDirection(Instrs);
+#endif
+    }
     // Extend the DAG to include Instrs.
     Interval<Instruction> Extension = DAG.extend(Instrs);
     // Add nodes from the new interval to ready list if they are ready.

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
@@ -359,8 +359,8 @@ define void @foo(ptr noalias %ptr0, ptr noalias %ptr1) {
     Ctx.save();
     sandboxir::Scheduler Sched(getAA(*LLVMF), Ctx,
                                sandboxir::SchedDirection::TopDown);
-    EXPECT_TRUE(Sched.trySchedule({L1}));
     EXPECT_TRUE(Sched.trySchedule({L0}));
+    EXPECT_TRUE(Sched.trySchedule({L1}));
     EXPECT_TRUE(Sched.trySchedule({S0, S1}));
     EXPECT_TRUE(Sched.trySchedule({Ret}));
     Ctx.revert();
@@ -1139,5 +1139,45 @@ define void @foo(ptr %ptr, i8 %v0) {
 
   // Check assertion before begin.
   EXPECT_DEATH(BeforeBegin.getIterator(), ".*Expected.*");
+
+  // Check comesBefore().
+  auto SPS0 = sandboxir::SchedulingPoint::createAt(S0->getIterator());
+  auto SPRet = sandboxir::SchedulingPoint::createAt(Ret->getIterator());
+  EXPECT_FALSE(SPS0.comesBefore(*S0));
+  EXPECT_TRUE(SPS0.comesBefore(*Ret));
+  EXPECT_FALSE(SPRet.comesBefore(*S0));
+  EXPECT_FALSE(SPRet.comesBefore(*SPRet));
+
+  EXPECT_TRUE(BeforeBegin.comesBefore(*BB->begin()));
+  EXPECT_TRUE(!AtEnd.comesBefore(BB->back()));
+#endif
+}
+
+// When we initialize the scheduler to operate towards one direction we should
+// detect an attempt to schedule towards the reverse direction and cause an a
+// assertion failure with a descriptive comment.
+TEST_F(SchedulerTest, DetectSchedulingInWrongDirection) {
+  parseIR(C, R"IR(
+define void @foo(ptr %ptr, i8 %v0, i8 %v1) {
+  store i8 %v0, ptr %ptr
+  store i8 %v1, ptr %ptr
+  ret void
+}
+)IR");
+  llvm::Function *LLVMF = &*M->getFunction("foo");
+  sandboxir::Context Ctx(C);
+  auto *F = Ctx.createFunction(LLVMF);
+  auto *BB = &*F->begin();
+  auto It = BB->begin();
+  auto *S0 = cast<sandboxir::StoreInst>(&*It++);
+  auto *S1 = cast<sandboxir::StoreInst>(&*It++);
+  auto *Ret = cast<sandboxir::ReturnInst>(&*It++);
+
+  sandboxir::Scheduler Sched(getAA(*LLVMF), Ctx,
+                             sandboxir::SchedDirection::BottomUp);
+  Sched.trySchedule(S1);
+  Sched.trySchedule(S0);
+#ifndef NDEBUG
+  EXPECT_DEATH(Sched.trySchedule(Ret), ".*Wrong scheduling direction.*");
 #endif
 }


### PR DESCRIPTION
This patch implements a check that will cause a crash if we attempt to schedule in the direction opposite to the one set when initializing the scheduler. Crashing early with a helpful error message is better than what we currently do, which is silently accepting the scheduling attempt which may not even cause an immediate crash but could cause a crash sometime later, providing few clues about what went wrong.

The vectorizer won't exercise switching directions, so this is tested with unittests.