### PR TITLE
[mlir] Skip the promised-interface lookup for an emptied dialect set (NFC)

### DIFF
--- a/mlir/include/mlir/IR/Dialect.h
+++ b/mlir/include/mlir/IR/Dialect.h
@@ -228,6 +228,9 @@ public:
   void handleUseOfUndefinedPromisedInterface(TypeID interfaceRequestorID,
                                              TypeID interfaceID,
                                              StringRef interfaceName = "") {
+    // Most dialects promise nothing; skip hashing a key and probing the set.
+    if (unresolvedPromisedInterfaces.empty())
+      return;
     if (unresolvedPromisedInterfaces.count(
             {interfaceRequestorID, interfaceID})) {
       llvm::report_fatal_error(


### PR DESCRIPTION
```c++
  void handleUseOfUndefinedPromisedInterface(TypeID interfaceRequestorID,
                                             TypeID interfaceID,
                                             StringRef interfaceName = "") {
    if (unresolvedPromisedInterfaces.count(
            {interfaceRequestorID, interfaceID})) {
      llvm::report_fatal_error(...);
    }
  }
```

`Dialect` has a private member
`DenseSet<std::pair<TypeID, TypeID>> unresolvedPromisedInterfaces`. In a
build with assertions, `isa`/`cast`/`dyn_cast` to an `OpInterface`,
`AttributeInterface` or `TypeInterface` probes it with `count()` -- twice
per successful `dyn_cast`, once in `classof` and once in the interface
constructor.

An entry is inserted by `declarePromisedInterface()` when a dialect says
an interface will be implemented later, and erased once it is, by
`Dialect::addInterface` or `attachInterface`. `erase()` keeps the bucket
array, so the set ends up empty but still bucketed.

That is more work than the answer needs. `count()` loads `NumBuckets`, and
because it is non-zero it goes on to hash both `TypeID`s, mask, and probe
the used-bits, only to find nothing. `empty()` is one load of
`NumEntries`.

25 of the 47 dialects under `mlir/lib/Dialect` declare promised
interfaces (Arith, Func, LLVM, Linalg, MemRef, SCF, Tensor, Vector and
more), so this is the common state. `perf annotate` puts ~25% of the
function in that hash and probe, and the `NumBuckets` test drops from 17%
to 2% with the patch, i.e. most calls now exit at `empty()`.

Fix: return early if `empty()`. `count()` on an empty set returns 0
anyway, so the error still fires when a promise is unimplemented.

| workload | instructions:u |
|---|---:|
| `mlir-opt` canonicalize/cse, 1060 `mlir/test` files >4KB | **-0.29%** |
| `iree-compile`, 46 IREE programs incl. mnist, llvm-cpu | **-0.40%** |
| flang `-fc1 -O2`, 44 CloverLeaf_Serial sources | **-0.40%** |