### PR TITLE
[CodeGenTypes] Make LLT::ExtendedLLT atomic

### DIFF
--- a/llvm/include/llvm/CodeGenTypes/LowLevelType.h
+++ b/llvm/include/llvm/CodeGenTypes/LowLevelType.h
@@ -35,6 +35,7 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
+#include <atomic>
 #include <cassert>
 
 namespace llvm {
@@ -704,11 +705,20 @@ public:
     return ((uint64_t)RawData) | ((uint64_t)Info) << 60;
   }
 
-  static bool getUseExtended() { return ExtendedLLT; }
-  static void setUseExtended(bool Enable) { ExtendedLLT = Enable; }
+  static bool getUseExtended() {
+    return ExtendedLLT.load(std::memory_order_relaxed);
+  }
+  static void setUseExtended(bool Enable) {
+    ExtendedLLT.store(Enable, std::memory_order_relaxed);
+  }
 
 private:
-  LLVM_ABI static bool ExtendedLLT;
+  // Enabled during target construction, which may run concurrently. Relaxed
+  // ordering suffices because the flag publishes no other state.
+  //
+  // FIXME: Scope this per target rather than globally:
+  // https://github.com/llvm/llvm-project/issues/219517.
+  LLVM_ABI static std::atomic<bool> ExtendedLLT;
 };
 
 inline raw_ostream &operator<<(raw_ostream &OS, const LLT &Ty) {

--- a/llvm/lib/CodeGenTypes/LowLevelType.cpp
+++ b/llvm/lib/CodeGenTypes/LowLevelType.cpp
@@ -16,7 +16,7 @@
 #include "llvm/Support/raw_ostream.h"
 using namespace llvm;
 
-bool LLT::ExtendedLLT = false;
+std::atomic<bool> LLT::ExtendedLLT = false;
 
 static LLT::FpSemantics getFpSemanticsForMVT(MVT VT) {
   switch (VT.getScalarType().SimpleTy) {
@@ -40,7 +40,7 @@ static LLT::FpSemantics getFpSemanticsForMVT(MVT VT) {
 }
 
 LLT::LLT(MVT VT) {
-  if (!ExtendedLLT) {
+  if (!getUseExtended()) {
     if (VT.isVector()) {
       bool AsVector = VT.getVectorMinNumElements() > 1 || VT.isScalableVector();
       Kind Info = AsVector ? Kind::VECTOR_ANY : Kind::ANY_SCALAR;


### PR DESCRIPTION
ExtendedLLT is a process-global mutable bool that the AArch64, AMDGPU and WebAssembly TargetMachine constructors write unconditionally, so constructing two of those target machines on different threads is a data race.

Every writer stores the same value and nothing resets it, so the race is on an idempotent write and is unlikely to misbehave. It is still undefined behavior, and trips up ThreadSanitizer.

Relaxed ordering suffices because the flag publishes no other state, and a relaxed load compiles to the same plain load everywhere, so the inline LLT accessors that consult it are unaffected. No caller of getUseExtended() is constexpr.

This is a workaround rather than a fix. This seems like it should be a target property instead: https://github.com/llvm/llvm-project/issues/219517.

Assisted-by: Claude