### PR TITLE
[clang][OpenMP] Don't drop debug location when handing off to OMPIRBuilder.

### DIFF
--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -1417,7 +1417,7 @@ llvm::Value *CGOpenMPRuntime::getThreadID(CodeGenFunction &CGF,
   // the clang invariants used below might be broken.
   if (CGM.getLangOpts().OpenMPIRBuilder) {
     SmallString<128> Buffer;
-    OMPBuilder.updateToLocation(CGF.Builder.saveIP());
+    OMPBuilder.updateToLocation(CGF.Builder);
     uint32_t SrcLocStrSize;
     auto *SrcLocStr = OMPBuilder.getOrCreateSrcLocStr(
         getIdentStringFromSourceLocation(CGF, Loc, Buffer), SrcLocStrSize);
@@ -11781,7 +11781,7 @@ void CGOpenMPRuntime::emitTargetDataCalls(
                          CGF.AllocaInsertPt->getIterator());
   InsertPointTy CodeGenIP(CGF.Builder.GetInsertBlock(),
                           CGF.Builder.GetInsertPoint());
-  llvm::OpenMPIRBuilder::LocationDescription OmpLoc(CodeGenIP);
+  llvm::OpenMPIRBuilder::LocationDescription OmpLoc(CGF.Builder);
   llvm::OpenMPIRBuilder::InsertPointTy AfterIP =
       cantFail(OMPBuilder.createTargetData(
           OmpLoc, AllocaIP, CodeGenIP, /*DeallocBlocks=*/{}, DeviceID,

--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -1422,7 +1422,7 @@ llvm::Value *CGOpenMPRuntime::getThreadID(CodeGenFunction &CGF,
   // the clang invariants used below might be broken.
   if (CGM.getLangOpts().OpenMPIRBuilder) {
     SmallString<128> Buffer;
-    OMPBuilder.updateToLocation(CGF.Builder.saveIP());
+    OMPBuilder.updateToLocation(CGF.Builder);
     uint32_t SrcLocStrSize;
     auto *SrcLocStr = OMPBuilder.getOrCreateSrcLocStr(
         getIdentStringFromSourceLocation(CGF, Loc, Buffer), SrcLocStrSize);
@@ -11811,7 +11811,7 @@ void CGOpenMPRuntime::emitTargetDataCalls(
                          CGF.AllocaInsertPt->getIterator());
   InsertPointTy CodeGenIP(CGF.Builder.GetInsertBlock(),
                           CGF.Builder.GetInsertPoint());
-  llvm::OpenMPIRBuilder::LocationDescription OmpLoc(CodeGenIP);
+  llvm::OpenMPIRBuilder::LocationDescription OmpLoc(CGF.Builder);
   llvm::OpenMPIRBuilder::InsertPointTy AfterIP =
       cantFail(OMPBuilder.createTargetData(
           OmpLoc, AllocaIP, CodeGenIP, /*DeallocBlocks=*/{}, DeviceID,

--- a/clang/test/OpenMP/debug-info-ompirbuilder-handoff.c
+++ b/clang/test/OpenMP/debug-info-ompirbuilder-handoff.c
@@ -1,0 +1,35 @@
+// Check that the debug location clang has established survives the hand-off to
+// the OpenMPIRBuilder, so that the IR the builder emits on clang's behalf still
+// carries a !dbg attachment.
+
+// RUN: %clang_cc1 -fopenmp -fopenmp-enable-irbuilder -triple x86_64-unknown-unknown \
+// RUN:   -debug-info-kind=limited -emit-llvm %s -o - | FileCheck %s --check-prefix=GTID
+
+// RUN: %clang_cc1 -fopenmp -triple x86_64-unknown-unknown \
+// RUN:   -fopenmp-targets=x86_64-unknown-linux-gnu -debug-info-kind=limited \
+// RUN:   -emit-llvm %s -o - | FileCheck %s --check-prefix=TDATA
+
+int cond;
+void use(int);
+
+// CGOpenMPRuntime::getThreadID() defers to the OpenMPIRBuilder when it is
+// enabled, so the thread-num call is emitted by the builder.
+
+// GTID-LABEL: define {{.*}}@single_region
+// GTID:       entry:
+// GTID-NEXT:    call i32 @__kmpc_global_thread_num({{.*}}), !dbg
+void single_region(void) {
+#pragma omp single
+  use(1);
+}
+
+// CGOpenMPRuntime::emitTargetDataCalls() passes the 'if' condition down to
+// OpenMPIRBuilder::createTargetData(), which emits the branch on it.
+
+// TDATA-LABEL: define {{.*}}@target_data_if
+// TDATA:        %[[TOBOOL:.+]] = icmp ne i32 %{{.+}}, 0, !dbg
+// TDATA-NEXT:   br i1 %[[TOBOOL]], label %{{.+}}, label %{{.+}}, !dbg
+void target_data_if(int *p) {
+#pragma omp target data map(tofrom : p[0 : 4]) if (cond)
+  use(2);
+}

--- a/clang/test/OpenMP/debug-info-ompirbuilder-handoff.c
+++ b/clang/test/OpenMP/debug-info-ompirbuilder-handoff.c
@@ -3,32 +3,35 @@
 // carries a !dbg attachment.
 
 // RUN: %clang_cc1 -fopenmp -fopenmp-enable-irbuilder -triple x86_64-unknown-unknown \
-// RUN:   -debug-info-kind=limited -emit-llvm %s -o - | FileCheck %s --check-prefix=GTID
-
-// RUN: %clang_cc1 -fopenmp -triple x86_64-unknown-unknown \
 // RUN:   -fopenmp-targets=x86_64-unknown-linux-gnu -debug-info-kind=limited \
-// RUN:   -emit-llvm %s -o - | FileCheck %s --check-prefix=TDATA
+// RUN:   -emit-llvm %s -o - | FileCheck %s
 
 int cond;
 void use(int);
 
 // CGOpenMPRuntime::getThreadID() defers to the OpenMPIRBuilder when it is
-// enabled, so the thread-num call is emitted by the builder.
+// enabled, so the thread-num call is emitted by the builder and must inherit
+// the location clang was holding.
 
-// GTID-LABEL: define {{.*}}@single_region
-// GTID:       entry:
-// GTID-NEXT:    call i32 @__kmpc_global_thread_num({{.*}}), !dbg
+// CHECK-LABEL: define {{.*}}@single_region
+// CHECK:       entry:
+// CHECK-NEXT:    call i32 @__kmpc_global_thread_num({{.*}}), !dbg ![[LOC:[0-9]+]]
+// CHECK-NEXT:    call i32 @__kmpc_single({{.*}}), !dbg ![[LOC]]
 void single_region(void) {
 #pragma omp single
   use(1);
 }
 
 // CGOpenMPRuntime::emitTargetDataCalls() passes the 'if' condition down to
-// OpenMPIRBuilder::createTargetData(), which emits the branch on it.
+// OpenMPIRBuilder::createTargetData(), which emits the branch on it. The mapper
+// calls of the region are not useful here because restoreIP() reinstalls a
+// location from the instruction at the insertion point, so they keep their !dbg
+// either way; this branch is emitted before that happens and is the only
+// observable witness on that path.
 
-// TDATA-LABEL: define {{.*}}@target_data_if
-// TDATA:        %[[TOBOOL:.+]] = icmp ne i32 %{{.+}}, 0, !dbg
-// TDATA-NEXT:   br i1 %[[TOBOOL]], label %{{.+}}, label %{{.+}}, !dbg
+// CHECK-LABEL: define {{.*}}@target_data_if
+// CHECK:         %[[TOBOOL:.+]] = icmp ne i32 %{{.+}}, 0, !dbg ![[LOC2:[0-9]+]]
+// CHECK-NEXT:    br i1 %[[TOBOOL]], label %{{.+}}, label %{{.+}}, !dbg ![[LOC2]]
 void target_data_if(int *p) {
 #pragma omp target data map(tofrom : p[0 : 4]) if (cond)
   use(2);


### PR DESCRIPTION
All the clang callsites that hand a `LocationDescription` to the `OpenMPIRBuilder` pass `CGF.Builder`. That selects `LocationDescription(const IRBuilderBase &)`, which carries both the insertion point and the current debug location.

The 2 call sites fixed in this PR used `CGF.Builder.saveIP()` which passes only an insertion point, selecting `LocationDescription(const InsertPointTy &)`, which leaves `DL` empty. As a result,  the IR the builder emitted on clang's behalf came out without `!dbg`.

Fixed by passing `CGF.Builder`, as the other callsites do.