### PR TITLE
[AMDGPU][GIsel] Make getBaseWithConstantantOffset see `or disjoint`

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUGlobalISelUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUGlobalISelUtils.cpp
@@ -56,9 +56,10 @@ AMDGPU::getBaseWithConstantOffset(MachineRegisterInfo &MRI, Register Reg,
   }
 
   Register Base;
-  if (ValueTracking && mi_match(Reg, MRI, m_GOr(m_Reg(Base), m_ICst(Offset))) &&
-      ValueTracking->maskedValueIsZero(Base,
-                                       APInt(32, Offset, /*isSigned=*/true)))
+  if (mi_match(Reg, MRI, m_GOr(m_Reg(Base), m_ICst(Offset))) &&
+      (Def->getFlag(MachineInstr::Disjoint) ||
+       (ValueTracking && ValueTracking->maskedValueIsZero(
+                             Base, APInt(32, Offset, /*isSigned=*/true)))))
     return std::pair(Base, Offset);
 
   // Handle G_PTRTOINT (G_PTR_ADD base, const) case

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/llvm.amdgcn.raw.ptr.buffer.offset-split.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/llvm.amdgcn.raw.ptr.buffer.offset-split.ll
@@ -72,8 +72,8 @@ define amdgpu_ps float @raw_ptr_buffer_load_f32__sgpr_rsrc__vgpr_voffset__or6710
 ; GFX8-NEXT:    s_mov_b32 s1, s3
 ; GFX8-NEXT:    s_mov_b32 s2, s4
 ; GFX8-NEXT:    s_mov_b32 s3, s5
-; GFX8-NEXT:    v_or_b32_e32 v0, 0x3fffffc, v0
-; GFX8-NEXT:    buffer_load_dword v0, v0, s[0:3], 16 offen
+; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 0x3fff000, v0
+; GFX8-NEXT:    buffer_load_dword v0, v0, s[0:3], 16 offen offset:4092
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
 ; GFX8-NEXT:    ; return to shader part epilog
 ;
@@ -83,14 +83,14 @@ define amdgpu_ps float @raw_ptr_buffer_load_f32__sgpr_rsrc__vgpr_voffset__or6710
 ; GFX1250-NEXT:    s_mov_b64 s[64:65], 0
 ; GFX1250-NEXT:    v_nop
 ; GFX1250-NEXT:    global_prefetch_b8 v0, s[64:65] scope:SCOPE_SE
-; GFX1250-NEXT:    v_mov_b32_e32 v1, 0x3fffffc
+; GFX1250-NEXT:    v_and_b32_e32 v0, 0xfc000000, v0
 ; GFX1250-NEXT:    s_mov_b32 s0, s2
 ; GFX1250-NEXT:    s_mov_b32 s1, s3
 ; GFX1250-NEXT:    s_mov_b32 s2, s4
 ; GFX1250-NEXT:    s_mov_b32 s3, s5
-; GFX1250-NEXT:    v_and_or_b32 v0, 0xfc000000, v0, v1
+; GFX1250-NEXT:    v_add_nc_u32_e32 v0, 0x3800000, v0
 ; GFX1250-NEXT:    s_mov_b32 s4, 16
-; GFX1250-NEXT:    buffer_load_b32 v0, v0, s[0:3], s4 offen
+; GFX1250-NEXT:    buffer_load_b32 v0, v0, s[0:3], s4 offen offset:8388604
 ; GFX1250-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
   %voffset.masked = and i32 %voffset.base, -67108864


### PR DESCRIPTION
This change is split from #207821, where it was made in the process of implementing that change to make getBaseWithConstantOffset() have the same behavior as the SelectionDAG version.

AI disclosure: I'm pretty sure this was Codex code, and I do recall it being an AI-found discrepancy.