### PR TITLE
[lldb] Do not break lldb SBAPI

### DIFF
--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -661,7 +661,8 @@ enum InstrumentationRuntimeType {
   eInstrumentationRuntimeTypeUndefinedBehaviorSanitizer = 0x0002,
   eInstrumentationRuntimeTypeMainThreadChecker = 0x0003,
   eInstrumentationRuntimeTypeSwiftRuntimeReporting = 0x0004,
-  eInstrumentationRuntimeTypeUnused = 0x0005, // Free to reuse
+  /// DEPRECATED:  use eInstrumentationRuntimeTypeAddressSanitizer.
+  eInstrumentationRuntimeTypeLibsanitizersAsan = 0x0005,
   eInstrumentationRuntimeTypeBoundsSafety = 0x0006,
   eNumInstrumentationRuntimeTypes
 };


### PR DESCRIPTION
libsanitizers ASan integration was removed in commit 8921ec7e89e024c6185bc99cc195d787b3537ea6.
The flag `eInstrumentationRuntimeTypeLibsanitizersAsan` should not be renamed since it is part of the public SBAPI.