### PR TITLE
[AMDGPU] Gate 64-bit VGPR copy lowering on operand register class in copyPhysReg

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -1119,13 +1119,24 @@ void SIInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
     return;
   }
 
+  // Returns true if \p Opc can encode \p Dst as its destination, i.e. \p Dst is
+  // a member of \p Opc's HwMode-resolved destination operand class. A wide VALU
+  // copy is used only when this holds; otherwise the copy is expanded
+  // element-wise with V_MOV_B32 below.
+  auto IsDstInCopyInstrClass = [&](unsigned Opc, MCRegister Dst) {
+    int16_t RCID = getOpRegClassID(get(Opc).operands()[0]);
+    return RCID >= 0 && RI.getRegClass(RCID)->contains(Dst);
+  };
+
   if (RC == RI.getVGPR64Class() && (SrcRC == RC || RI.isSGPRClass(SrcRC))) {
-    if (ST.hasVMovB64Inst()) {
+    if (ST.hasVMovB64Inst() &&
+        IsDstInCopyInstrClass(AMDGPU::V_MOV_B64_e32, DestReg)) {
       BuildMI(MBB, MI, DL, get(AMDGPU::V_MOV_B64_e32), DestReg)
         .addReg(SrcReg, getKillRegState(KillSrc));
       return;
     }
-    if (ST.hasPkMovB32()) {
+    if (ST.hasPkMovB32() &&
+        IsDstInCopyInstrClass(AMDGPU::V_PK_MOV_B32, DestReg)) {
       BuildMI(MBB, MI, DL, get(AMDGPU::V_PK_MOV_B32), DestReg)
         .addImm(SISrcMods::OP_SEL_1)
         .addReg(SrcReg)
@@ -1166,15 +1177,29 @@ void SIInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
   } else if (RI.hasVGPRs(RC) && RI.isAGPRClass(SrcRC)) {
     Opcode = AMDGPU::V_ACCVGPR_READ_B32_e64;
   } else if ((Size % 64 == 0) && RI.hasVGPRs(RC) &&
-             (RI.isProperlyAlignedRC(*RC) &&
-              (SrcRC == RC || RI.isSGPRClass(SrcRC)))) {
+             (SrcRC == RC || RI.isSGPRClass(SrcRC))) {
     // TODO: In 96-bit case, could do a 64-bit mov and then a 32-bit mov.
-    if (ST.hasVMovB64Inst()) {
-      Opcode = AMDGPU::V_MOV_B64_e32;
-      EltSize = 8;
-    } else if (ST.hasPkMovB32()) {
-      Opcode = AMDGPU::V_PK_MOV_B32;
-      EltSize = 8;
+    unsigned NewOpcode = AMDGPU::INSTRUCTION_LIST_END;
+    if (ST.hasVMovB64Inst())
+      NewOpcode = AMDGPU::V_MOV_B64_e32;
+    else if (ST.hasPkMovB32())
+      NewOpcode = AMDGPU::V_PK_MOV_B32;
+
+    if (NewOpcode != AMDGPU::INSTRUCTION_LIST_END) {
+      // The copy is expanded into 64-bit component moves below, so the wide
+      // move is usable only if it can encode each component. Components of a
+      // contiguous tuple share the base register's alignment, so it is enough
+      // to test the low component (sub0_sub1); for a 64-bit destination that
+      // component is the whole register. Otherwise fall through to the
+      // element-wise V_MOV_B32 expansion below (a Size == 64 copy reaches here
+      // when the wide moves above rejected its destination).
+      MCRegister WideDst = Size == 64
+                               ? DestReg.asMCReg()
+                               : RI.getSubReg(DestReg, AMDGPU::sub0_sub1);
+      if (IsDstInCopyInstrClass(NewOpcode, WideDst)) {
+        Opcode = NewOpcode;
+        EltSize = 8;
+      }
     }
   }
 

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -1119,13 +1119,26 @@ void SIInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
     return;
   }
 
+  // Returns true if Dst and Src are in Opc's HwMode-resolved destination and
+  // source operand classes.
+  auto CanCopyWith = [&](unsigned Opc, MCRegister Dst, MCRegister Src,
+                         unsigned SrcOp = 1) {
+    const MCInstrDesc &Desc = get(Opc);
+    const TargetRegisterClass *DstOpRC = getRegClass(Desc, 0);
+    const TargetRegisterClass *SrcOpRC = getRegClass(Desc, SrcOp);
+    return DstOpRC && SrcOpRC && DstOpRC->contains(Dst) &&
+           SrcOpRC->contains(Src);
+  };
+
   if (RC == RI.getVGPR64Class() && (SrcRC == RC || RI.isSGPRClass(SrcRC))) {
-    if (ST.hasVMovB64Inst()) {
+    if (ST.hasVMovB64Inst() &&
+        CanCopyWith(AMDGPU::V_MOV_B64_e32, DestReg, SrcReg)) {
       BuildMI(MBB, MI, DL, get(AMDGPU::V_MOV_B64_e32), DestReg)
         .addReg(SrcReg, getKillRegState(KillSrc));
       return;
     }
-    if (ST.hasPkMovB32()) {
+    if (ST.hasPkMovB32() &&
+        CanCopyWith(AMDGPU::V_PK_MOV_B32, DestReg, SrcReg, /*SrcOp=*/2)) {
       BuildMI(MBB, MI, DL, get(AMDGPU::V_PK_MOV_B32), DestReg)
         .addImm(SISrcMods::OP_SEL_1)
         .addReg(SrcReg)


### PR DESCRIPTION
copyPhysReg lowers a 64-bit VGPR copy to V_MOV_B64_e32 / V_PK_MOV_B32 when available. Emit the wide move only when the destination and source are members of the move's HwMode-resolved operand classes; otherwise fall through to the element-wise V_MOV_B32 expansion, to respect alignment requirements.