### PR TITLE
[TableGen] Diagnose register classes without pressure units

### DIFF
--- a/llvm/test/TableGen/artificial-subregs-empty-pset.td
+++ b/llvm/test/TableGen/artificial-subregs-empty-pset.td
@@ -1,0 +1,30 @@
+// RUN: not llvm-tblgen -gen-register-info -I %p/../../include %s 2>&1 | FileCheck %s
+
+include "llvm/Target/Target.td"
+
+def sub_8 : SubRegIndex<8>;
+def sub_16 : SubRegIndex<16>;
+
+class TestReg<string Name, list<Register> SubRegs = []>
+    : RegisterWithSubRegs<Name, SubRegs> {
+  let Namespace = "Test";
+}
+
+def R0B : TestReg<"r0.b"> {
+  let isArtificial = 1;
+}
+
+def R0W : TestReg<"r0.w", [R0B]> {
+  let isArtificial = 1;
+  let SubRegIndices = [sub_8];
+}
+
+def R0 : TestReg<"r0", [R0W]> {
+  let SubRegIndices = [sub_16];
+}
+
+def GPR32 : RegisterClass<"Test", [i32], 32, (add R0)>;
+
+def TestTarget : Target;
+
+// CHECK: error: allocatable register class 'GPR32' has no non-artificial register units

--- a/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
@@ -2237,6 +2237,14 @@ void CodeGenRegBank::computeRegUnitSets() {
     RegUnitSet RUSet(RC.getName());
     RC.buildRegUnitSet(*this, RUSet.Units);
 
+    if (RUSet.Units.empty()) {
+      std::string Message = "allocatable register class '" + RC.getName() +
+                            "' has no non-artificial register units";
+      if (const Record *Def = RC.getDef())
+        PrintFatalError(Def->getLoc(), Message);
+      PrintFatalError(Message);
+    }
+
     // Find an existing RegUnitSet.
     if (findRegUnitSet(RegUnitSets, RUSet) == RegUnitSets.end())
       RegUnitSets.push_back(std::move(RUSet));


### PR DESCRIPTION
An allocatable, non-artificial register class can have no non-artificial register units when all of its members' leaf subregisters are artificial. In that case, buildRegUnitSet produces an empty set, which pruneUnitSets later indexes unconditionally and crashes.
Diagnose the empty set where it is created instead. This avoids the crash and identifies the affected register class and source location. A follow-up can decide whether and how register-pressure modeling should support this hierarchy.
Add a regression test based on the register hierarchy reported in #218854.