### PR TITLE
[CodeGen] Reuse one LiveIntervalCalc across all subranges (NFC)

### DIFF
--- a/llvm/lib/CodeGen/LiveIntervalCalc.cpp
+++ b/llvm/lib/CodeGen/LiveIntervalCalc.cpp
@@ -89,8 +89,8 @@ void LiveIntervalCalc::calculate(LiveInterval &LI, bool TrackSubRegs) {
   // Step 2: Extend live segments to all uses, constructing SSA form as
   // necessary.
   if (LI.hasSubRanges()) {
+    LiveIntervalCalc SubLIC;
     for (LiveInterval::SubRange &S : LI.subranges()) {
-      LiveIntervalCalc SubLIC;
       SubLIC.reset(MF, Indexes, DomTree, Alloc);
       SubLIC.extendToUses(S, Reg, S.LaneMask, &LI);
     }


### PR DESCRIPTION
`SplitKit` already reuses a single `SubLIC` this way:
https://github.com/llvm/llvm-project/blob/aa198f8668e578cf11068c9a47559dfd3cc04bc7/llvm/lib/CodeGen/SplitKit.cpp#L1452-L1471
