### PR TITLE
[flang][Semantics] Enforce F2023 C1545 only for generic references

### DIFF
--- a/flang/include/flang/Evaluate/intrinsics.h
+++ b/flang/include/flang/Evaluate/intrinsics.h
@@ -87,6 +87,11 @@ public:
   bool IsIntrinsicSubroutine(const std::string &) const;
   bool IsDualIntrinsic(const std::string &) const;
 
+  // True when a reference to this name is a reference to a generic procedure.
+  // A name that is only a specific intrinsic name, such as DSIN, is not; a
+  // name that is both, such as SIN, is.
+  bool IsGenericIntrinsic(const std::string &) const;
+
   // Inquiry intrinsics are defined in section 16.7, table 16.1
   IntrinsicClass GetIntrinsicClass(const std::string &) const;
 

--- a/flang/include/flang/Semantics/expression.h
+++ b/flang/include/flang/Semantics/expression.h
@@ -375,10 +375,24 @@ private:
     const Symbol *specific{nullptr};
     bool failedDueToAmbiguity{false};
     SymbolVector tried{};
+    // Resolution was not attempted because the reference is already in error;
+    // callers must not report a resolution failure too.
+    bool errorReported{false};
   };
+  // Resolves a generic identifier against an argument list.  Does not report
+  // resolution failure; callers do that with EmitGenericResolutionError.  It
+  // is not side-effect free, though: ResolveForward can emit a message and can
+  // set a durable error flag, so speculative callers buffer messages around it.
   GenericResolution ResolveGeneric(const Symbol &, const ActualArguments &,
       const AdjustActuals &, bool isSubroutine, SymbolVector &&tried,
       bool mightBeStructureConstructor = false);
+  // Use this rather than ResolveGeneric for a generic reference that appears in
+  // the source: it also applies the constraints that hold only for such a
+  // reference (F2023 C1545), so it must not be called speculatively.  A
+  // violation sets errorReported and skips resolution.
+  GenericResolution CheckAndResolveGenericReference(const Symbol &,
+      const ActualArguments &, const AdjustActuals &, bool isSubroutine,
+      SymbolVector &&tried, bool mightBeStructureConstructor = false);
   void EmitGenericResolutionError(const Symbol &, bool dueToNullActuals,
       bool isSubroutine, const ActualArguments &, const SymbolVector &,
       const AdjustActuals &);

--- a/flang/include/flang/Semantics/expression.h
+++ b/flang/include/flang/Semantics/expression.h
@@ -375,10 +375,23 @@ private:
     const Symbol *specific{nullptr};
     bool failedDueToAmbiguity{false};
     SymbolVector tried{};
+    // Set when F2023 C1545 was reported.  The reference then keeps its generic
+    // symbol, so that a second analysis of the expression reports it again.
+    bool isBadConditionalArg{false};
   };
+  // Resolves a generic identifier against an argument list.  Does not report
+  // resolution failure; callers do that with EmitGenericResolutionError.  It
+  // is not side-effect free, though: ResolveForward can emit a message and can
+  // set a durable error flag, so speculative callers buffer messages around it.
   GenericResolution ResolveGeneric(const Symbol &, const ActualArguments &,
       const AdjustActuals &, bool isSubroutine, SymbolVector &&tried,
       bool mightBeStructureConstructor = false);
+  // Use this rather than ResolveGeneric for a generic reference that appears in
+  // the source: it also applies the constraints that hold only for such a
+  // reference (F2023 C1545), so it must not be called speculatively.
+  GenericResolution CheckAndResolveGenericReference(const Symbol &,
+      const ActualArguments &, const AdjustActuals &, bool isSubroutine,
+      SymbolVector &&tried, bool mightBeStructureConstructor = false);
   void EmitGenericResolutionError(const Symbol &, bool dueToNullActuals,
       bool isSubroutine, const ActualArguments &, const SymbolVector &,
       const AdjustActuals &);

--- a/flang/lib/Evaluate/intrinsics.cpp
+++ b/flang/lib/Evaluate/intrinsics.cpp
@@ -2923,6 +2923,7 @@ public:
   bool IsIntrinsicFunction(const std::string &) const;
   bool IsIntrinsicSubroutine(const std::string &) const;
   bool IsDualIntrinsic(const std::string &) const;
+  bool IsGenericIntrinsic(const std::string &) const;
 
   IntrinsicClass GetIntrinsicClass(const std::string &) const;
   std::string GetGenericIntrinsicName(const std::string &) const;
@@ -2989,6 +2990,18 @@ bool IntrinsicProcTable::Implementation::IsIntrinsicSubroutine(
 bool IntrinsicProcTable::Implementation::IsIntrinsic(
     const std::string &name) const {
   return IsIntrinsicFunction(name) || IsIntrinsicSubroutine(name);
+}
+bool IntrinsicProcTable::Implementation::IsGenericIntrinsic(
+    const std::string &name0) const {
+  const std::string &name{ResolveAlias(name0)};
+  // Intrinsic subroutines have no specific names, so a reference to one is
+  // always a reference to a generic procedure.
+  // Unlike IsIntrinsicFunction() and IsIntrinsicSubroutine(), the names that
+  // Probe() special-cases ahead of these tables are deliberately omitted here:
+  // each of them has a single interface, so nothing about such a reference can
+  // depend on which arguments it is given.
+  return genericFuncs_.find(name) != genericFuncs_.end() ||
+      subroutines_.find(name) != subroutines_.end();
 }
 bool IntrinsicProcTable::Implementation::IsDualIntrinsic(
     const std::string &name) const {
@@ -4177,6 +4190,9 @@ bool IntrinsicProcTable::IsIntrinsicSubroutine(const std::string &name) const {
 }
 bool IntrinsicProcTable::IsDualIntrinsic(const std::string &name) const {
   return DEREF(impl_.get()).IsDualIntrinsic(name);
+}
+bool IntrinsicProcTable::IsGenericIntrinsic(const std::string &name) const {
+  return DEREF(impl_.get()).IsGenericIntrinsic(name);
 }
 
 IntrinsicClass IntrinsicProcTable::GetIntrinsicClass(

--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -1437,8 +1437,9 @@ static void CheckProcedureArg(evaluate::ActualArgument &arg,
   }
 }
 
-// F2023 C1540-C1543, C1545: Check conditional argument against dummy data
-// object
+// F2023 C1540-C1543: Check a conditional argument against a dummy data object.
+// C1544 is absent by design: it is a grammar disambiguation rule that the
+// parser satisfies automatically, see "consequent" in program-parsers.cpp.
 static void CheckConditionalArg(
     const evaluate::ActualArgument::ConditionalArg &condArg,
     const characteristics::DummyDataObject &object,
@@ -1479,54 +1480,69 @@ static void CheckConditionalArg(
           "Each consequent-arg in conditional argument associated with a coarray %s must be a coarray"_err_en_US,
           dummyName);
     }
-    // C1544: the requirement that each consequent-arg match the dummy's
-    // ALLOCATABLE/POINTER attribute is enforced by the standard
-    // explicit-interface check (checkOneExpr) run on each non-.NIL.
-    // consequent below.
   }};
   condArg.ForEachConsequent(checkOneConsequent);
-  // C1545: in a reference to a generic procedure, each consequent-arg shall
-  // have the same corank, and if any has the ALLOCATABLE or POINTER attribute,
-  // each shall have it.  Strictly, this requirement applies only to references
-  // to generic procedures, where it avoids ambiguity when resolving the generic
-  // to a specific procedure; for a specific procedure reference these
-  // combinations are otherwise allowed.  For now it is enforced unconditionally
-  // here.
-  // TODO: move this check into generic resolution (ResolveGeneric) and enforce
-  // it precisely, i.e. only for references to generic procedures, where the
-  // ambiguity it guards against can actually arise.
-  std::optional<int> firstCorank;
-  std::optional<bool> firstIsAllocatable;
-  std::optional<bool> firstIsPointer;
-  auto checkConsistency{[&](const evaluate::ActualArgument::ConditionalArg::
-                                Consequent &cons) {
-    if (!cons) {
-      return;
+}
+
+// F2023 C1545: in a reference to a generic procedure, each consequent-arg
+// shall have the same corank, and if any consequent-arg has the ALLOCATABLE
+// or POINTER attribute, each consequent-arg shall have that attribute.
+// These properties decide which specific procedures an actual argument may be
+// associated with, so letting them differ would make generic resolution depend
+// on a condition whose value is not known until run time.  A reference to a
+// specific procedure has nothing to resolve, and these combinations are
+// allowed there.
+bool CheckConditionalArgsInGenericReference(
+    const evaluate::ActualArguments &actuals,
+    parser::ContextualMessages &messages) {
+  bool anyReported{false};
+  for (const std::optional<evaluate::ActualArgument> &arg : actuals) {
+    const auto *condArg{arg ? arg->GetConditionalArg() : nullptr};
+    if (!condArg) {
+      continue;
     }
-    auto &consExpr{cons->value()};
-    int corank{evaluate::GetCorank(consExpr)};
-    bool isAlloc{evaluate::IsAllocatableDesignator(consExpr)};
-    bool isPtr{evaluate::IsObjectPointer(consExpr)};
-    if (!firstCorank) {
-      firstCorank = corank;
-      firstIsAllocatable = isAlloc;
-      firstIsPointer = isPtr;
-    } else {
-      if (corank != *firstCorank) {
-        messages.Say(
-            "All consequent-args in a conditional argument must have the same corank"_err_en_US);
-      }
-      if (isAlloc != *firstIsAllocatable) {
-        messages.Say(
-            "If any consequent-arg in a conditional argument has the ALLOCATABLE attribute, each must have it"_err_en_US);
-      }
-      if (isPtr != *firstIsPointer) {
-        messages.Say(
-            "If any consequent-arg in a conditional argument has the POINTER attribute, each must have it"_err_en_US);
-      }
+    const auto *first{condArg->FirstNonNilConsequent()};
+    if (!first) { // every consequent-arg is .NIL.
+      continue;
     }
-  }};
-  condArg.ForEachConsequent(checkConsistency);
+    const int firstCorank{evaluate::GetCorank(*first)};
+    const bool firstIsAllocatable{evaluate::IsAllocatableDesignator(*first)};
+    // Use the same POINTER test as generic resolution, which accepts a
+    // pointer-valued function reference.
+    const bool firstIsPointer{evaluate::IsObjectPointer(*first)};
+    bool corankDiffers{false};
+    bool allocatableDiffers{false};
+    bool pointerDiffers{false};
+    // Comparing the first consequent-arg against itself is a no-op, so it needs
+    // no special case here.
+    condArg->ForEachConsequent(
+        [&](const evaluate::ActualArgument::ConditionalArg::Consequent &cons) {
+          if (!cons) { // .NIL. has no corank or attributes to compare
+            return;
+          }
+          const auto &consExpr{cons->value()};
+          corankDiffers |= evaluate::GetCorank(consExpr) != firstCorank;
+          allocatableDiffers |=
+              evaluate::IsAllocatableDesignator(consExpr) != firstIsAllocatable;
+          pointerDiffers |=
+              evaluate::IsObjectPointer(consExpr) != firstIsPointer;
+        });
+    // Report each violated requirement once, however long the chain is.
+    if (corankDiffers) {
+      messages.Say(
+          "In a reference to a generic procedure, all consequent-args in a conditional argument must have the same corank"_err_en_US);
+    }
+    if (allocatableDiffers) {
+      messages.Say(
+          "In a reference to a generic procedure, if any consequent-arg in a conditional argument has the ALLOCATABLE attribute, each must have it"_err_en_US);
+    }
+    if (pointerDiffers) {
+      messages.Say(
+          "In a reference to a generic procedure, if any consequent-arg in a conditional argument has the POINTER attribute, each must have it"_err_en_US);
+    }
+    anyReported |= corankDiffers || allocatableDiffers || pointerDiffers;
+  }
+  return anyReported;
 }
 
 // Allow BOZ literal actual arguments when they can be converted to a known
@@ -1648,8 +1664,9 @@ static void CheckExplicitInterfaceArg(evaluate::ActualArgument &arg,
               }};
               if (auto *condArg{arg.GetConditionalArg()}) {
                 CheckConditionalArg(*condArg, object, dummyName, messages);
-                // Also run standard explicit-interface checks on each
-                // non-.NIL. consequent expression (recursive).
+                // Each non-.NIL. consequent-arg is itself an actual argument,
+                // so these checks are what enforce the dummy's ALLOCATABLE and
+                // POINTER requirements (F2023 15.5.2.6, 15.5.2.7).
                 condArg->ForEachConsequent(
                     [&](evaluate::ActualArgument::ConditionalArg::Consequent
                             &cons) {

--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -1418,8 +1418,9 @@ static void CheckProcedureArg(evaluate::ActualArgument &arg,
   }
 }
 
-// F2023 C1540-C1543, C1545: Check conditional argument against dummy data
-// object
+// F2023 C1540-C1543: Check a conditional argument against a dummy data object.
+// C1544 is absent by design: it is a grammar disambiguation rule that the
+// parser satisfies automatically, see "consequent" in program-parsers.cpp.
 static void CheckConditionalArg(
     const evaluate::ActualArgument::ConditionalArg &condArg,
     const characteristics::DummyDataObject &object,
@@ -1460,54 +1461,74 @@ static void CheckConditionalArg(
           "Each consequent-arg in conditional argument associated with a coarray %s must be a coarray"_err_en_US,
           dummyName);
     }
-    // C1544: the requirement that each consequent-arg match the dummy's
-    // ALLOCATABLE/POINTER attribute is enforced by the standard
-    // explicit-interface check (checkOneExpr) run on each non-.NIL.
-    // consequent below.
   }};
   condArg.ForEachConsequent(checkOneConsequent);
-  // C1545: in a reference to a generic procedure, each consequent-arg shall
-  // have the same corank, and if any has the ALLOCATABLE or POINTER attribute,
-  // each shall have it.  Strictly, this requirement applies only to references
-  // to generic procedures, where it avoids ambiguity when resolving the generic
-  // to a specific procedure; for a specific procedure reference these
-  // combinations are otherwise allowed.  For now it is enforced unconditionally
-  // here.
-  // TODO: move this check into generic resolution (ResolveGeneric) and enforce
-  // it precisely, i.e. only for references to generic procedures, where the
-  // ambiguity it guards against can actually arise.
-  std::optional<int> firstCorank;
-  std::optional<bool> firstIsAllocatable;
-  std::optional<bool> firstIsPointer;
-  auto checkConsistency{[&](const evaluate::ActualArgument::ConditionalArg::
-                                Consequent &cons) {
-    if (!cons) {
-      return;
+}
+
+// A pointer-valued function reference is an expression, not an entity with the
+// POINTER attribute, and may not be a POINTER actual argument;
+// IsObjectPointer() accepts it, IsAllocatableDesignator() does not.
+static bool HasPointerAttribute(
+    const evaluate::Expr<evaluate::SomeType> &expr) {
+  return evaluate::IsObjectPointer(expr) && !evaluate::UnwrapProcedureRef(expr);
+}
+
+// F2023 C1545: in a reference to a generic procedure, each consequent-arg
+// shall have the same corank, and if any consequent-arg has the ALLOCATABLE
+// or POINTER attribute, each consequent-arg shall have that attribute.
+// These properties decide which specific procedures an actual argument may be
+// associated with, so letting them differ would make generic resolution depend
+// on a condition whose value is not known until run time.  A reference to a
+// specific procedure has nothing to resolve, and these combinations are
+// allowed there.
+bool CheckConditionalArgsInGenericReference(
+    const evaluate::ActualArguments &actuals,
+    parser::ContextualMessages &messages) {
+  bool anyReported{false};
+  for (const std::optional<evaluate::ActualArgument> &arg : actuals) {
+    const auto *condArg{arg ? arg->GetConditionalArg() : nullptr};
+    if (!condArg) {
+      continue;
     }
-    auto &consExpr{cons->value()};
-    int corank{evaluate::GetCorank(consExpr)};
-    bool isAlloc{evaluate::IsAllocatableDesignator(consExpr)};
-    bool isPtr{evaluate::IsObjectPointer(consExpr)};
-    if (!firstCorank) {
-      firstCorank = corank;
-      firstIsAllocatable = isAlloc;
-      firstIsPointer = isPtr;
-    } else {
-      if (corank != *firstCorank) {
-        messages.Say(
-            "All consequent-args in a conditional argument must have the same corank"_err_en_US);
-      }
-      if (isAlloc != *firstIsAllocatable) {
-        messages.Say(
-            "If any consequent-arg in a conditional argument has the ALLOCATABLE attribute, each must have it"_err_en_US);
-      }
-      if (isPtr != *firstIsPointer) {
-        messages.Say(
-            "If any consequent-arg in a conditional argument has the POINTER attribute, each must have it"_err_en_US);
-      }
+    const auto *first{condArg->FirstNonNilConsequent()};
+    if (!first) { // every consequent-arg is .NIL.
+      continue;
     }
-  }};
-  condArg.ForEachConsequent(checkConsistency);
+    const int firstCorank{evaluate::GetCorank(*first)};
+    const bool firstIsAllocatable{evaluate::IsAllocatableDesignator(*first)};
+    const bool firstIsPointer{HasPointerAttribute(*first)};
+    bool corankDiffers{false};
+    bool allocatableDiffers{false};
+    bool pointerDiffers{false};
+    // Comparing the first consequent-arg against itself is a no-op, so it needs
+    // no special case here.
+    condArg->ForEachConsequent(
+        [&](const evaluate::ActualArgument::ConditionalArg::Consequent &cons) {
+          if (!cons) { // .NIL. has no corank or attributes to compare
+            return;
+          }
+          const auto &consExpr{cons->value()};
+          corankDiffers |= evaluate::GetCorank(consExpr) != firstCorank;
+          allocatableDiffers |=
+              evaluate::IsAllocatableDesignator(consExpr) != firstIsAllocatable;
+          pointerDiffers |= HasPointerAttribute(consExpr) != firstIsPointer;
+        });
+    // Report each violated requirement once, however long the chain is.
+    if (corankDiffers) {
+      messages.Say(
+          "In a reference to a generic procedure, all consequent-args in a conditional argument must have the same corank"_err_en_US);
+    }
+    if (allocatableDiffers) {
+      messages.Say(
+          "In a reference to a generic procedure, if any consequent-arg in a conditional argument has the ALLOCATABLE attribute, each must have it"_err_en_US);
+    }
+    if (pointerDiffers) {
+      messages.Say(
+          "In a reference to a generic procedure, if any consequent-arg in a conditional argument has the POINTER attribute, each must have it"_err_en_US);
+    }
+    anyReported |= corankDiffers || allocatableDiffers || pointerDiffers;
+  }
+  return anyReported;
 }
 
 // Allow BOZ literal actual arguments when they can be converted to a known
@@ -1629,8 +1650,9 @@ static void CheckExplicitInterfaceArg(evaluate::ActualArgument &arg,
               }};
               if (auto *condArg{arg.GetConditionalArg()}) {
                 CheckConditionalArg(*condArg, object, dummyName, messages);
-                // Also run standard explicit-interface checks on each
-                // non-.NIL. consequent expression (recursive).
+                // Each non-.NIL. consequent-arg is itself an actual argument,
+                // so these checks are what enforce the dummy's ALLOCATABLE and
+                // POINTER requirements (F2023 15.5.2.6, 15.5.2.7).
                 condArg->ForEachConsequent(
                     [&](evaluate::ActualArgument::ConditionalArg::Consequent
                             &cons) {

--- a/flang/lib/Semantics/check-call.h
+++ b/flang/lib/Semantics/check-call.h
@@ -64,5 +64,13 @@ parser::Messages CheckExplicitInterface(
 bool CheckInterfaceForGeneric(const evaluate::characteristics::Procedure &,
     evaluate::ActualArguments &, SemanticsContext &,
     bool allowActualArgumentConversions = false);
+
+// F2023 C1545: reports the cross-consequent-arg inconsistencies that a
+// conditional argument may not have in a reference to a generic procedure, and
+// returns whether any were reported.  C1545 does not apply to a reference to a
+// specific procedure, though the ordinary argument-association rules may still
+// reject the same combinations there.
+bool CheckConditionalArgsInGenericReference(
+    const evaluate::ActualArguments &, parser::ContextualMessages &);
 } // namespace Fortran::semantics
 #endif

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -2720,12 +2720,14 @@ auto ExpressionAnalyzer::AnalyzeProcedureComponentRef(
                 }
                 return true;
               }};
-          auto result{ResolveGeneric(
+          auto result{CheckAndResolveGenericReference(
               generic, arguments, adjustment, isSubroutine, SymbolVector{})};
           sym = result.specific;
           if (!sym) {
-            EmitGenericResolutionError(generic, result.failedDueToAmbiguity,
-                isSubroutine, arguments, result.tried, adjustment);
+            if (!result.errorReported) {
+              EmitGenericResolutionError(generic, result.failedDueToAmbiguity,
+                  isSubroutine, arguments, result.tried, adjustment);
+            }
             return std::nullopt;
           }
           // re-resolve the name to the specific binding
@@ -3339,6 +3341,29 @@ auto ExpressionAnalyzer::ResolveGeneric(const Symbol &symbol,
   return {nullptr, false, std::move(tried)};
 }
 
+auto ExpressionAnalyzer::CheckAndResolveGenericReference(const Symbol &symbol,
+    const ActualArguments &actuals, const AdjustActuals &adjustActuals,
+    bool isSubroutine, SymbolVector &&tried, bool mightBeStructureConstructor)
+    -> GenericResolution {
+  const Symbol &ultimate{symbol.GetUltimate()};
+  // Attr::INTRINSIC is set for specific intrinsic names such as DSIN as well,
+  // and a reference to one of those is not a reference to a generic procedure.
+  if ((ultimate.has<semantics::GenericDetails>() ||
+          (ultimate.attrs().test(semantics::Attr::INTRINSIC) &&
+              context_.intrinsics().IsGenericIntrinsic(
+                  ultimate.name().ToString()))) &&
+      semantics::CheckConditionalArgsInGenericReference(
+          actuals, GetContextualMessages())) {
+    // Not resolving also leaves the parse tree symbol generic, so a second
+    // analysis of the expression reports the violation again.
+    GenericResolution result;
+    result.errorReported = true;
+    return result;
+  }
+  return ResolveGeneric(symbol, actuals, adjustActuals, isSubroutine,
+      std::move(tried), mightBeStructureConstructor);
+}
+
 const Symbol &ExpressionAnalyzer::AccessSpecific(
     const Symbol &originalGeneric, const Symbol &specific) {
   if (const auto *hosted{
@@ -3454,12 +3479,15 @@ auto ExpressionAnalyzer::GetCalleeAndArguments(const parser::Name &name,
   bool isExplicitIntrinsic{ultimate.attrs().test(semantics::Attr::INTRINSIC)};
   const Symbol *resolution{nullptr};
   SymbolVector tried;
+  bool errorReported{false};
   if (isGenericInterface || isExplicitIntrinsic) {
     ExpressionAnalyzer::AdjustActuals noAdjustment;
-    auto result{ResolveGeneric(*symbol, arguments, noAdjustment, isSubroutine,
-        SymbolVector{}, mightBeStructureConstructor)};
+    auto result{
+        CheckAndResolveGenericReference(*symbol, arguments, noAdjustment,
+            isSubroutine, SymbolVector{}, mightBeStructureConstructor)};
     resolution = result.specific;
     dueToAmbiguity = result.failedDueToAmbiguity;
+    errorReported = result.errorReported;
     tried = std::move(result.tried);
     if (IsCudaDeviceIntrinsicShadowedByHostProcedure(
             name.source, context_, resolution, isSubroutine)) {
@@ -3502,7 +3530,7 @@ auto ExpressionAnalyzer::GetCalleeAndArguments(const parser::Name &name,
           ProcedureDesignator{std::move(specificCall->specificIntrinsic)},
           std::move(specificCall->arguments)};
     } else {
-      if (isGenericInterface) {
+      if (isGenericInterface && !errorReported) {
         AdjustActuals noAdjustment;
         EmitGenericResolutionError(*symbol, dueToAmbiguity, isSubroutine,
             arguments, tried, noAdjustment);

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -2695,7 +2695,7 @@ auto ExpressionAnalyzer::AnalyzeProcedureComponentRef(
                 }
                 return true;
               }};
-          auto result{ResolveGeneric(
+          auto result{CheckAndResolveGenericReference(
               generic, arguments, adjustment, isSubroutine, SymbolVector{})};
           sym = result.specific;
           if (!sym) {
@@ -2735,7 +2735,11 @@ auto ExpressionAnalyzer::AnalyzeProcedureComponentRef(
               sym = latest;
             }
           }
-          sc.Component().symbol = const_cast<Symbol *>(sym);
+          // Leave the binding generic when C1545 was reported, for the reason
+          // given at the matching guard in GetCalleeAndArguments().
+          if (!result.isBadConditionalArg) {
+            sc.Component().symbol = const_cast<Symbol *>(sym);
+          }
         }
         std::optional<DataRef> dataRef{ExtractDataRef(std::move(*dtExpr))};
         if (dataRef && !CheckDataRef(*dataRef)) {
@@ -3314,6 +3318,27 @@ auto ExpressionAnalyzer::ResolveGeneric(const Symbol &symbol,
   return {nullptr, false, std::move(tried)};
 }
 
+auto ExpressionAnalyzer::CheckAndResolveGenericReference(const Symbol &symbol,
+    const ActualArguments &actuals, const AdjustActuals &adjustActuals,
+    bool isSubroutine, SymbolVector &&tried, bool mightBeStructureConstructor)
+    -> GenericResolution {
+  const Symbol &ultimate{symbol.GetUltimate()};
+  // Attr::INTRINSIC is set for specific intrinsic names such as DSIN as well,
+  // and a reference to one of those is not a reference to a generic procedure.
+  bool isBadConditionalArg{false};
+  if (ultimate.has<semantics::GenericDetails>() ||
+      (ultimate.attrs().test(semantics::Attr::INTRINSIC) &&
+          context_.intrinsics().IsGenericIntrinsic(
+              ultimate.name().ToString()))) {
+    isBadConditionalArg = semantics::CheckConditionalArgsInGenericReference(
+        actuals, GetContextualMessages());
+  }
+  auto result{ResolveGeneric(symbol, actuals, adjustActuals, isSubroutine,
+      std::move(tried), mightBeStructureConstructor)};
+  result.isBadConditionalArg = isBadConditionalArg;
+  return result;
+}
+
 const Symbol &ExpressionAnalyzer::AccessSpecific(
     const Symbol &originalGeneric, const Symbol &specific) {
   if (const auto *hosted{
@@ -3429,12 +3454,15 @@ auto ExpressionAnalyzer::GetCalleeAndArguments(const parser::Name &name,
   bool isExplicitIntrinsic{ultimate.attrs().test(semantics::Attr::INTRINSIC)};
   const Symbol *resolution{nullptr};
   SymbolVector tried;
+  bool isBadConditionalArg{false};
   if (isGenericInterface || isExplicitIntrinsic) {
     ExpressionAnalyzer::AdjustActuals noAdjustment;
-    auto result{ResolveGeneric(*symbol, arguments, noAdjustment, isSubroutine,
-        SymbolVector{}, mightBeStructureConstructor)};
+    auto result{
+        CheckAndResolveGenericReference(*symbol, arguments, noAdjustment,
+            isSubroutine, SymbolVector{}, mightBeStructureConstructor)};
     resolution = result.specific;
     dueToAmbiguity = result.failedDueToAmbiguity;
+    isBadConditionalArg = result.isBadConditionalArg;
     tried = std::move(result.tried);
     if (IsCudaDeviceIntrinsicShadowedByHostProcedure(
             name.source, context_, resolution, isSubroutine)) {
@@ -3454,8 +3482,16 @@ auto ExpressionAnalyzer::GetCalleeAndArguments(const parser::Name &name,
         semantics::CheckPPCIntrinsic(
             *symbol, *resolution, arguments, GetFoldingContext());
       }
-      // re-resolve name to the specific procedure
-      name.symbol = const_cast<Symbol *>(resolution);
+      // Re-resolve the name to the specific procedure, unless C1545 was
+      // reported for this reference: an expression can be analyzed more than
+      // once (ArrayConstructorContext::UnrollConstantImpliedDo re-walks the
+      // parse tree when an implied-DO has constant bounds), and the second
+      // pass repeats the C1545 diagnostic only while the reference still
+      // resolves to the generic symbol.  Leaving it generic is safe because
+      // the reference is already in error and so is never lowered.
+      if (!isBadConditionalArg) {
+        name.symbol = const_cast<Symbol *>(resolution);
+      }
     }
   } else if (IsProcedure(ultimate) &&
       ultimate.attrs().test(semantics::Attr::ABSTRACT)) {

--- a/flang/test/Semantics/conditional-arg.f90
+++ b/flang/test/Semantics/conditional-arg.f90
@@ -68,6 +68,51 @@ module m_conditional_arg
     end function
   end interface
 
+  ! Generic identifiers, used by the F2023 C1545 tests below.  C1545 applies
+  ! only to a reference to a generic procedure.
+  interface gen_plain
+    subroutine gen_plain_int(x)
+      integer, intent(in) :: x
+    end subroutine
+    subroutine gen_plain_real(x)
+      real, intent(in) :: x
+    end subroutine
+  end interface
+
+  interface gen_opt
+    subroutine gen_opt_int(x)
+      integer, intent(in), optional :: x
+    end subroutine
+    subroutine gen_opt_real(x)
+      real, intent(in), optional :: x
+    end subroutine
+  end interface
+
+  interface gen_func
+    pure integer function gen_func_int(x)
+      integer, intent(in) :: x
+    end function
+    pure real function gen_func_real(x)
+      real, intent(in) :: x
+    end function
+  end interface
+
+  interface
+    function func_ptr_result()
+      integer, pointer :: func_ptr_result
+    end function
+  end interface
+
+  type :: t_gen
+  contains
+    procedure, nopass :: tbp_gen_int
+    procedure, nopass :: tbp_gen_real
+    procedure, nopass :: tbp_fn_int
+    procedure, nopass :: tbp_fn_real
+    generic :: gen => tbp_gen_int, tbp_gen_real
+    generic :: gen_fn => tbp_fn_int, tbp_fn_real
+  end type
+
 contains
 
   ! =========================================================================
@@ -424,38 +469,220 @@ contains
   !              shall have the same corank, and if any consequent-arg has the
   !              ALLOCATABLE or POINTER attribute, each consequent-arg shall
   !              have that attribute.
+  !
+  !              The constraint is scoped to generic references, where these
+  !              attributes decide which specific procedures the actual
+  !              argument may associate with.  A reference to a specific
+  !              procedure has nothing to resolve and is not constrained.
   ! =========================================================================
 
-  subroutine test_f2023_c1545_allocatable_inconsistency
+  ! Bindings for the type-bound generic 'gen' of t_gen.
+  subroutine tbp_gen_int(x)
+    integer, intent(in) :: x
+  end subroutine
+
+  subroutine tbp_gen_real(x)
+    real, intent(in) :: x
+  end subroutine
+
+  pure integer function tbp_fn_int(x)
+    integer, intent(in) :: x
+    tbp_fn_int = x
+  end function
+
+  pure real function tbp_fn_real(x)
+    real, intent(in) :: x
+    tbp_fn_real = x
+  end function
+
+  subroutine test_f2023_c1545_generic_allocatable_inconsistency
     integer, allocatable :: a
     integer :: b
     logical :: flag
-    !ERROR: If any consequent-arg in a conditional argument has the ALLOCATABLE attribute, each must have it
+    !ERROR: In a reference to a generic procedure, if any consequent-arg in a conditional argument has the ALLOCATABLE attribute, each must have it
+    call gen_plain((flag ? a : b))
+  end subroutine
+
+  subroutine test_f2023_c1545_generic_pointer_inconsistency
+    integer, pointer :: p
+    integer :: b
+    logical :: flag
+    !ERROR: In a reference to a generic procedure, if any consequent-arg in a conditional argument has the POINTER attribute, each must have it
+    call gen_plain((flag ? p : b))
+  end subroutine
+
+  subroutine test_f2023_c1545_generic_corank_inconsistency(c, d, flag)
+    integer, intent(in) :: c[*], d
+    logical, intent(in) :: flag
+    !ERROR: In a reference to a generic procedure, all consequent-args in a conditional argument must have the same corank
+    call gen_plain((flag ? c : d))
+  end subroutine
+
+  subroutine test_f2023_c1545_generic_corank_consistent(c, d, flag)
+    integer, intent(in) :: c[*], d[*]
+    logical, intent(in) :: flag
+    ! Both consequent-args have corank 1 -- no C1545 error
+    call gen_plain((flag ? c : d))
+  end subroutine
+
+  subroutine test_f2023_c1545_generic_three_way(f1, f2)
+    logical :: f1, f2
+    integer, allocatable :: c
+    integer :: a, b
+    ! The offending consequent-arg is in the tail of the chain
+    !ERROR: In a reference to a generic procedure, if any consequent-arg in a conditional argument has the ALLOCATABLE attribute, each must have it
+    call gen_plain((f1 ? a : f2 ? b : c))
+  end subroutine
+
+  ! .NIL. is not an entity, so it neither seeds nor participates in the C1545
+  ! comparison; the mismatch between the remaining two is still reported.
+  subroutine test_f2023_c1545_generic_nil_ignored(f1, f2)
+    logical :: f1, f2
+    integer, allocatable :: a
+    integer :: b
+    !ERROR: In a reference to a generic procedure, if any consequent-arg in a conditional argument has the ALLOCATABLE attribute, each must have it
+    call gen_opt((f1 ? .NIL. : f2 ? a : b))
+  end subroutine
+
+  subroutine test_f2023_c1545_generic_nil_consistent(f1, f2)
+    logical :: f1, f2
+    integer, allocatable :: a, b
+    ! Both non-.NIL. consequent-args are allocatable -- no C1545 error
+    call gen_opt((f1 ? .NIL. : f2 ? a : b))
+  end subroutine
+
+  ! A specific type-bound procedure is not a generic reference.
+  subroutine test_c1545_specific_type_bound
+    type(t_gen) :: obj
+    integer, allocatable :: a
+    integer :: b
+    logical :: flag
+    call obj%tbp_gen_int((flag ? a : b))
+  end subroutine
+
+  ! Constant implied-DO bounds make the array constructor body be analyzed a
+  ! second time; the diagnostic must survive that.
+  subroutine test_f2023_c1545_generic_in_array_constructor
+    integer, allocatable :: a
+    integer :: b, i
+    integer :: arr(3)
+    logical :: flag
+    !ERROR: In a reference to a generic procedure, if any consequent-arg in a conditional argument has the ALLOCATABLE attribute, each must have it
+    arr = [(gen_func((flag ? a : b)), i=1,3)]
+  end subroutine
+
+  ! Same, for a type-bound generic: it is re-resolved on a different symbol.
+  subroutine test_f2023_c1545_type_bound_generic_in_array_constructor
+    type(t_gen) :: obj
+    integer, allocatable :: a
+    integer :: b, i
+    integer :: arr(3)
+    logical :: flag
+    !ERROR: In a reference to a generic procedure, if any consequent-arg in a conditional argument has the ALLOCATABLE attribute, each must have it
+    arr = [(obj%gen_fn((flag ? a : b)), i=1,3)]
+  end subroutine
+
+  ! A pointer-valued function reference has the POINTER attribute here, as it
+  ! does in generic resolution, so mixing it with a non-pointer violates C1545.
+  subroutine test_c1545_pointer_function_result_differs
+    integer :: b, r
+    logical :: flag
+    !ERROR: In a reference to a generic procedure, if any consequent-arg in a conditional argument has the POINTER attribute, each must have it
+    r = gen_func((flag ? func_ptr_result() : b))
+  end subroutine
+
+  ! gen_func(p) and gen_func(func_ptr_result()) resolve to the same specific,
+  ! so the conditional argument has nothing to make ambiguous.
+  subroutine test_c1545_pointer_function_result_agrees
+    integer, pointer :: p
+    integer :: r
+    logical :: flag
+    r = gen_func((flag ? p : func_ptr_result()))
+  end subroutine
+
+  ! Resolution is skipped once C1545 is violated, so the reference gets one
+  ! error rather than a cascade from a resolution that could not succeed.
+  subroutine test_c1545_generic_with_independent_error(flag)
+    logical :: flag
+    integer, allocatable :: a
+    integer :: b
+    !ERROR: In a reference to a generic procedure, if any consequent-arg in a conditional argument has the ALLOCATABLE attribute, each must have it
+    call gen_plain((flag ? a : b), b)
+  end subroutine
+
+  ! A generic intrinsic procedure is a generic procedure, so C1545 applies.
+  subroutine test_f2023_c1545_generic_intrinsic
+    integer, allocatable :: a
+    integer :: b, c, r
+    logical :: flag
+    !ERROR: In a reference to a generic procedure, if any consequent-arg in a conditional argument has the ALLOCATABLE attribute, each must have it
+    r = max((flag ? a : b), c)
+  end subroutine
+
+  ! DSIN is only a specific intrinsic name, so a reference to it is not a
+  ! reference to a generic procedure and C1545 does not apply.
+  subroutine test_c1545_specific_intrinsic
+    double precision, allocatable :: a
+    double precision :: b, r
+    logical :: flag
+    r = dsin((flag ? a : b))
+  end subroutine
+
+  subroutine test_f2023_c1545_type_bound_generic
+    type(t_gen) :: obj
+    integer, allocatable :: a
+    integer :: b
+    logical :: flag
+    !ERROR: In a reference to a generic procedure, if any consequent-arg in a conditional argument has the ALLOCATABLE attribute, each must have it
+    call obj%gen((flag ? a : b))
+  end subroutine
+
+  subroutine test_f2023_c1545_generic_allocatable_consistent_valid
+    integer, allocatable :: a, b
+    logical :: flag
+    ! Both consequent-args are allocatable -- no C1545 error
+    call gen_plain((flag ? a : b))
+  end subroutine
+
+  subroutine test_f2023_c1545_generic_pointer_consistent_valid
+    integer, pointer :: p, q
+    logical :: flag
+    ! Both consequent-args are pointer -- no C1545 error
+    call gen_plain((flag ? p : q))
+  end subroutine
+
+  ! A reference to a specific procedure is not constrained by C1545, so mixing
+  ! ALLOCATABLE or POINTER consequent-args with plain ones is conforming.
+  subroutine test_c1545_specific_allocatable_mix
+    integer, allocatable :: a
+    integer :: b
+    logical :: flag
+    call sub_int((flag ? a : b))
+  end subroutine
+
+  subroutine test_c1545_specific_pointer_mix
+    integer, pointer :: p
+    integer :: b
+    logical :: flag
+    call sub_int((flag ? p : b))
+  end subroutine
+
+  ! The diagnostics below come from argument association (F2023 15.5.2), not
+  ! from C1545: the dummy argument itself is ALLOCATABLE or POINTER.
+  subroutine test_specific_allocatable_dummy_mismatch
+    integer, allocatable :: a
+    integer :: b
+    logical :: flag
     !ERROR: ALLOCATABLE dummy argument 'x=' must be associated with an ALLOCATABLE actual argument
     call sub_alloc((flag ? a : b))
   end subroutine
 
-  subroutine test_f2023_c1545_pointer_inconsistency
+  subroutine test_specific_pointer_dummy_mismatch
     integer, pointer :: p
     integer :: b
     logical :: flag
-    !ERROR: If any consequent-arg in a conditional argument has the POINTER attribute, each must have it
     !ERROR: Actual argument associated with POINTER dummy argument 'x=' must also be POINTER unless INTENT(IN)
     call sub_pointer((flag ? p : b))
-  end subroutine
-
-  subroutine test_f2023_c1545_allocatable_consistent_valid
-    integer, allocatable :: a, b
-    logical :: flag
-    ! Both consequent-args are allocatable -- no C1545 error
-    call sub_alloc((flag ? a : b))
-  end subroutine
-
-  subroutine test_f2023_c1545_pointer_consistent_valid
-    integer, pointer :: p, q
-    logical :: flag
-    ! Both consequent-args are pointer -- no C1545 error
-    call sub_pointer((flag ? p : q))
   end subroutine
 
   ! =========================================================================

--- a/flang/test/Semantics/conditional-arg.f90
+++ b/flang/test/Semantics/conditional-arg.f90
@@ -68,6 +68,51 @@ module m_conditional_arg
     end function
   end interface
 
+  ! Generic identifiers, used by the F2023 C1545 tests below.  C1545 applies
+  ! only to a reference to a generic procedure.
+  interface gen_plain
+    subroutine gen_plain_int(x)
+      integer, intent(in) :: x
+    end subroutine
+    subroutine gen_plain_real(x)
+      real, intent(in) :: x
+    end subroutine
+  end interface
+
+  interface gen_opt
+    subroutine gen_opt_int(x)
+      integer, intent(in), optional :: x
+    end subroutine
+    subroutine gen_opt_real(x)
+      real, intent(in), optional :: x
+    end subroutine
+  end interface
+
+  interface gen_func
+    pure integer function gen_func_int(x)
+      integer, intent(in) :: x
+    end function
+    pure real function gen_func_real(x)
+      real, intent(in) :: x
+    end function
+  end interface
+
+  interface
+    function func_ptr_result()
+      integer, pointer :: func_ptr_result
+    end function
+  end interface
+
+  type :: t_gen
+  contains
+    procedure, nopass :: tbp_gen_int
+    procedure, nopass :: tbp_gen_real
+    procedure, nopass :: tbp_fn_int
+    procedure, nopass :: tbp_fn_real
+    generic :: gen => tbp_gen_int, tbp_gen_real
+    generic :: gen_fn => tbp_fn_int, tbp_fn_real
+  end type
+
 contains
 
   ! =========================================================================
@@ -424,38 +469,210 @@ contains
   !              shall have the same corank, and if any consequent-arg has the
   !              ALLOCATABLE or POINTER attribute, each consequent-arg shall
   !              have that attribute.
+  !
+  !              The constraint is scoped to generic references, where these
+  !              attributes decide which specific procedures the actual
+  !              argument may associate with.  A reference to a specific
+  !              procedure has nothing to resolve and is not constrained.
   ! =========================================================================
 
-  subroutine test_f2023_c1545_allocatable_inconsistency
+  ! Bindings for the type-bound generic 'gen' of t_gen.
+  subroutine tbp_gen_int(x)
+    integer, intent(in) :: x
+  end subroutine
+
+  subroutine tbp_gen_real(x)
+    real, intent(in) :: x
+  end subroutine
+
+  pure integer function tbp_fn_int(x)
+    integer, intent(in) :: x
+    tbp_fn_int = x
+  end function
+
+  pure real function tbp_fn_real(x)
+    real, intent(in) :: x
+    tbp_fn_real = x
+  end function
+
+  subroutine test_f2023_c1545_generic_allocatable_inconsistency
     integer, allocatable :: a
     integer :: b
     logical :: flag
-    !ERROR: If any consequent-arg in a conditional argument has the ALLOCATABLE attribute, each must have it
+    !ERROR: In a reference to a generic procedure, if any consequent-arg in a conditional argument has the ALLOCATABLE attribute, each must have it
+    call gen_plain((flag ? a : b))
+  end subroutine
+
+  subroutine test_f2023_c1545_generic_pointer_inconsistency
+    integer, pointer :: p
+    integer :: b
+    logical :: flag
+    !ERROR: In a reference to a generic procedure, if any consequent-arg in a conditional argument has the POINTER attribute, each must have it
+    call gen_plain((flag ? p : b))
+  end subroutine
+
+  subroutine test_f2023_c1545_generic_corank_inconsistency(c, d, flag)
+    integer, intent(in) :: c[*], d
+    logical, intent(in) :: flag
+    !ERROR: In a reference to a generic procedure, all consequent-args in a conditional argument must have the same corank
+    call gen_plain((flag ? c : d))
+  end subroutine
+
+  subroutine test_f2023_c1545_generic_corank_consistent(c, d, flag)
+    integer, intent(in) :: c[*], d[*]
+    logical, intent(in) :: flag
+    ! Both consequent-args have corank 1 -- no C1545 error
+    call gen_plain((flag ? c : d))
+  end subroutine
+
+  subroutine test_f2023_c1545_generic_three_way(f1, f2)
+    logical :: f1, f2
+    integer, allocatable :: c
+    integer :: a, b
+    ! The offending consequent-arg is in the tail of the chain
+    !ERROR: In a reference to a generic procedure, if any consequent-arg in a conditional argument has the ALLOCATABLE attribute, each must have it
+    call gen_plain((f1 ? a : f2 ? b : c))
+  end subroutine
+
+  ! .NIL. is not an entity, so it neither seeds nor participates in the C1545
+  ! comparison; the mismatch between the remaining two is still reported.
+  subroutine test_f2023_c1545_generic_nil_ignored(f1, f2)
+    logical :: f1, f2
+    integer, allocatable :: a
+    integer :: b
+    !ERROR: In a reference to a generic procedure, if any consequent-arg in a conditional argument has the ALLOCATABLE attribute, each must have it
+    call gen_opt((f1 ? .NIL. : f2 ? a : b))
+  end subroutine
+
+  subroutine test_f2023_c1545_generic_nil_consistent(f1, f2)
+    logical :: f1, f2
+    integer, allocatable :: a, b
+    ! Both non-.NIL. consequent-args are allocatable -- no C1545 error
+    call gen_opt((f1 ? .NIL. : f2 ? a : b))
+  end subroutine
+
+  ! A specific type-bound procedure is not a generic reference.
+  subroutine test_c1545_specific_type_bound
+    type(t_gen) :: obj
+    integer, allocatable :: a
+    integer :: b
+    logical :: flag
+    call obj%tbp_gen_int((flag ? a : b))
+  end subroutine
+
+  ! Constant implied-DO bounds make the array constructor body be analyzed a
+  ! second time; the diagnostic must survive that.
+  subroutine test_f2023_c1545_generic_in_array_constructor
+    integer, allocatable :: a
+    integer :: b, i
+    integer :: arr(3)
+    logical :: flag
+    !ERROR: In a reference to a generic procedure, if any consequent-arg in a conditional argument has the ALLOCATABLE attribute, each must have it
+    arr = [(gen_func((flag ? a : b)), i=1,3)]
+  end subroutine
+
+  ! Same, for a type-bound generic: it is re-resolved on a different symbol.
+  subroutine test_f2023_c1545_type_bound_generic_in_array_constructor
+    type(t_gen) :: obj
+    integer, allocatable :: a
+    integer :: b, i
+    integer :: arr(3)
+    logical :: flag
+    !ERROR: In a reference to a generic procedure, if any consequent-arg in a conditional argument has the ALLOCATABLE attribute, each must have it
+    arr = [(obj%gen_fn((flag ? a : b)), i=1,3)]
+  end subroutine
+
+  ! A pointer-valued function reference is an expression, not an entity with
+  ! the POINTER attribute, so it does not make the consequent-args differ.
+  subroutine test_c1545_pointer_function_result
+    integer :: b, r
+    logical :: flag
+    r = gen_func((flag ? func_ptr_result() : b))
+  end subroutine
+
+  ! An error that is independent of C1545 must still be reported alongside it.
+  subroutine test_c1545_generic_with_independent_error(flag)
+    logical :: flag
+    integer, allocatable :: a
+    integer :: b
+    !ERROR: In a reference to a generic procedure, if any consequent-arg in a conditional argument has the ALLOCATABLE attribute, each must have it
+    !ERROR: No specific subroutine of generic 'gen_plain' matches the actual arguments
+    call gen_plain((flag ? a : b), b)
+  end subroutine
+
+  ! A generic intrinsic procedure is a generic procedure, so C1545 applies.
+  subroutine test_f2023_c1545_generic_intrinsic
+    integer, allocatable :: a
+    integer :: b, c, r
+    logical :: flag
+    !ERROR: In a reference to a generic procedure, if any consequent-arg in a conditional argument has the ALLOCATABLE attribute, each must have it
+    r = max((flag ? a : b), c)
+  end subroutine
+
+  ! DSIN is only a specific intrinsic name, so a reference to it is not a
+  ! reference to a generic procedure and C1545 does not apply.
+  subroutine test_c1545_specific_intrinsic
+    double precision, allocatable :: a
+    double precision :: b, r
+    logical :: flag
+    r = dsin((flag ? a : b))
+  end subroutine
+
+  subroutine test_f2023_c1545_type_bound_generic
+    type(t_gen) :: obj
+    integer, allocatable :: a
+    integer :: b
+    logical :: flag
+    !ERROR: In a reference to a generic procedure, if any consequent-arg in a conditional argument has the ALLOCATABLE attribute, each must have it
+    call obj%gen((flag ? a : b))
+  end subroutine
+
+  subroutine test_f2023_c1545_generic_allocatable_consistent_valid
+    integer, allocatable :: a, b
+    logical :: flag
+    ! Both consequent-args are allocatable -- no C1545 error
+    call gen_plain((flag ? a : b))
+  end subroutine
+
+  subroutine test_f2023_c1545_generic_pointer_consistent_valid
+    integer, pointer :: p, q
+    logical :: flag
+    ! Both consequent-args are pointer -- no C1545 error
+    call gen_plain((flag ? p : q))
+  end subroutine
+
+  ! A reference to a specific procedure is not constrained by C1545, so mixing
+  ! ALLOCATABLE or POINTER consequent-args with plain ones is conforming.
+  subroutine test_c1545_specific_allocatable_mix
+    integer, allocatable :: a
+    integer :: b
+    logical :: flag
+    call sub_int((flag ? a : b))
+  end subroutine
+
+  subroutine test_c1545_specific_pointer_mix
+    integer, pointer :: p
+    integer :: b
+    logical :: flag
+    call sub_int((flag ? p : b))
+  end subroutine
+
+  ! The diagnostics below come from argument association (F2023 15.5.2), not
+  ! from C1545: the dummy argument itself is ALLOCATABLE or POINTER.
+  subroutine test_specific_allocatable_dummy_mismatch
+    integer, allocatable :: a
+    integer :: b
+    logical :: flag
     !ERROR: ALLOCATABLE dummy argument 'x=' must be associated with an ALLOCATABLE actual argument
     call sub_alloc((flag ? a : b))
   end subroutine
 
-  subroutine test_f2023_c1545_pointer_inconsistency
+  subroutine test_specific_pointer_dummy_mismatch
     integer, pointer :: p
     integer :: b
     logical :: flag
-    !ERROR: If any consequent-arg in a conditional argument has the POINTER attribute, each must have it
     !ERROR: Actual argument associated with POINTER dummy argument 'x=' must also be POINTER unless INTENT(IN)
     call sub_pointer((flag ? p : b))
-  end subroutine
-
-  subroutine test_f2023_c1545_allocatable_consistent_valid
-    integer, allocatable :: a, b
-    logical :: flag
-    ! Both consequent-args are allocatable -- no C1545 error
-    call sub_alloc((flag ? a : b))
-  end subroutine
-
-  subroutine test_f2023_c1545_pointer_consistent_valid
-    integer, pointer :: p, q
-    logical :: flag
-    ! Both consequent-args are pointer -- no C1545 error
-    call sub_pointer((flag ? p : q))
   end subroutine
 
   ! =========================================================================


### PR DESCRIPTION
C1545 requires the consequent-args of a conditional argument to agree on corank and on the ALLOCATABLE and POINTER attributes, but only in a reference to a generic procedure, where letting them differ would make resolution depend on a condition whose value is not known until run time.  flang applied it to every reference containing a conditional argument, and so rejected conforming code.

Report C1545 from a new CheckAndResolveGenericReference(), before ResolveGeneric() and only when the reference is generic.  Resolution itself is unchanged: C1545 is a constraint, not one of the rules of F2023 15.5.5, so a violation must not disqualify a candidate.

Attr::INTRINSIC is also set for specific names such as DSIN, so add IntrinsicProcTable::IsGenericIntrinsic() to tell the two apart.

The check runs only while the reference still resolves to the generic symbol, and an expression can be analyzed more than once, so GenericResolution::isBadConditionalArg guards the two sites that rewrite the parse-tree symbol to the resolved specific.  Leaving the reference generic is safe: it is already in error, and so is never lowered.

Also correct the POINTER test.  IsObjectPointer() accepts a pointer-valued function reference, which is an expression rather than an entity with the POINTER attribute; a new HasPointerAttribute() excludes those.

These changes were generated with the assistance of AI tooling and have been reviewed, tested, and validated by the author.

Fixes llvm/llvm-project #209840