### PR TITLE
[llvm][Debuginfod] Fix DEBUGINFOD_CACHE_PATH usage in tests

### DIFF
--- a/llvm/test/tools/llvm-debuginfod-find/headers-curl.test
+++ b/llvm/test/tools/llvm-debuginfod-find/headers-curl.test
@@ -4,15 +4,15 @@ RUN: rm -rf %t
 RUN: mkdir -p %t/debuginfod-cache
 RUN: %python %S/Inputs/capture_req.py llvm-debuginfod-find --debuginfo 0 \
 RUN:   | FileCheck --check-prefix NO-HEADERS %s
-RUN: env DEBUGINFOD_CACHE=%t/debuginfod-cache DEBUGINFOD_HEADERS_FILE=bad %python %S/Inputs/capture_req.py \
+RUN: env DEBUGINFOD_CACHE_PATH=%t/debuginfod-cache DEBUGINFOD_HEADERS_FILE=bad %python %S/Inputs/capture_req.py \
 RUN:   llvm-debuginfod-find --debuginfo 0 \
 RUN:   | FileCheck --check-prefix NO-HEADERS %s
 RUN: rm -rf %t/debuginfod-cache/*
-RUN: env DEBUGINFOD_CACHE=%t/debuginfod-cache DEBUGINFOD_HEADERS_FILE=%S/Inputs/headers %python %S/Inputs/capture_req.py \
+RUN: env DEBUGINFOD_CACHE_PATH=%t/debuginfod-cache DEBUGINFOD_HEADERS_FILE=%S/Inputs/headers %python %S/Inputs/capture_req.py \
 RUN:   llvm-debuginfod-find --debuginfo 0 \
 RUN:   | FileCheck --check-prefix HEADERS %s
 RUN: rm -rf %t/debuginfod-cache/*
-RUN: env DEBUGINFOD_CACHE=%t/debuginfod-cache DEBUGINFOD_HEADERS_FILE=%S/Inputs/headers DEBUGINFOD_URLS=fake not llvm-debuginfod-find --debuginfo 0 2>&1 \
+RUN: env DEBUGINFOD_CACHE_PATH=%t/debuginfod-cache DEBUGINFOD_HEADERS_FILE=%S/Inputs/headers DEBUGINFOD_URLS=fake not llvm-debuginfod-find --debuginfo 0 2>&1 \
 RUN:   | FileCheck --check-prefix ERR -DHEADER_FILE=%S/Inputs/headers %s
 
 NO-HEADERS: Accept: */*

--- a/llvm/test/tools/llvm-debuginfod-find/headers-winhttp.test
+++ b/llvm/test/tools/llvm-debuginfod-find/headers-winhttp.test
@@ -7,15 +7,15 @@ RUN: rm -rf %t
 RUN: mkdir -p %t/debuginfod-cache
 RUN: %python %S/Inputs/capture_req.py llvm-debuginfod-find --debuginfo 0 \
 RUN:   | FileCheck --check-prefix NO-HEADERS %s
-RUN: env DEBUGINFOD_CACHE=%t/debuginfod-cache DEBUGINFOD_HEADERS_FILE=bad %python %S/Inputs/capture_req.py \
+RUN: env DEBUGINFOD_CACHE_PATH=%t/debuginfod-cache DEBUGINFOD_HEADERS_FILE=bad %python %S/Inputs/capture_req.py \
 RUN:   llvm-debuginfod-find --debuginfo 0 \
 RUN:   | FileCheck --check-prefix NO-HEADERS %s
 RUN: rm -rf %t/debuginfod-cache/*
-RUN: env DEBUGINFOD_CACHE=%t/debuginfod-cache DEBUGINFOD_HEADERS_FILE=%S/Inputs/headers %python %S/Inputs/capture_req.py \
+RUN: env DEBUGINFOD_CACHE_PATH=%t/debuginfod-cache DEBUGINFOD_HEADERS_FILE=%S/Inputs/headers %python %S/Inputs/capture_req.py \
 RUN:   llvm-debuginfod-find --debuginfo 0 \
 RUN:   | FileCheck --check-prefix HEADERS %s
 RUN: rm -rf %t/debuginfod-cache/*
-RUN: env DEBUGINFOD_CACHE=%t/debuginfod-cache DEBUGINFOD_HEADERS_FILE=%S/Inputs/headers DEBUGINFOD_URLS=fake not llvm-debuginfod-find --debuginfo 0 2>&1 \
+RUN: env DEBUGINFOD_CACHE_PATH=%t/debuginfod-cache DEBUGINFOD_HEADERS_FILE=%S/Inputs/headers DEBUGINFOD_URLS=fake not llvm-debuginfod-find --debuginfo 0 2>&1 \
 RUN:   | FileCheck --check-prefix ERR -DHEADER_FILE=%S/Inputs/headers %s
 
 NO-HEADERS:      User-Agent: LLVM-HTTPClient/1.0

--- a/llvm/test/tools/llvm-debuginfod-find/timeout.test
+++ b/llvm/test/tools/llvm-debuginfod-find/timeout.test
@@ -5,7 +5,7 @@ RUN: mkdir -p %t/debuginfod-cache
 
 # We hit the timeout because the Python script delays the response by 2 seconds
 RUN: env DEBUGINFOD_TIMEOUT=1 \
-RUN: env DEBUGINFOD_CACHE=%t/debuginfod-cache \
+RUN: env DEBUGINFOD_CACHE_PATH=%t/debuginfod-cache \
 RUN: env DEBUGINFOD_HEADERS_FILE=%S/Inputs/headers \
 RUN:   %python %S/Inputs/delay_req.py llvm-debuginfod-find --debuginfo 0 | FileCheck %s
 


### PR DESCRIPTION
Update three tests which currently set DEBUGINFOD_CACHE instead of DEBUGINFO_CACHE_PATH.

These typos were discovered when testing with a build environment in which the fallback of using the default `sys::path::cache_directory` also fails in `getDefaultDebuginfodCacheDirectory`, which these tests had been relying on.