### PR TITLE
[InstCombine] Add fold combining adjacent extracted bit fields to restore optimization for separate truncations

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -4319,6 +4319,29 @@ Instruction *InstCombinerImpl::visitOr(BinaryOperator &I) {
           return BinaryOperator::CreateAnd(Or, C01);
         }
       }
+
+      // (trunc (lshr X, S) & C0) | (lshr (trunc X), S & C1)
+      // --> (trunc (lshr X, S) & (C0 | C1) (and similar cases) 
+      // A = trunc (lshr X, S) B = lshr (trunc X), S
+      const APInt *ShiftAmt;
+      if (match(A, m_OneUse(m_Trunc(m_LShr(m_Value(X), m_APInt(ShiftAmt))))) &&
+          match(B, m_LShr(m_Trunc(m_Specific(X)),
+                          m_SpecificInt(ShiftAmt->getZExtValue())))) {
+        APInt CombinedMask = *C0 | *C1;
+        return BinaryOperator::CreateAnd(
+            A, ConstantInt::get(I.getType(), CombinedMask));
+      }
+      // A = lshr (trunc X), S
+      // B = trunc (lshr X, S)
+      const APInt *ReverseShiftAmt;
+      if (match(B, m_OneUse(m_Trunc(
+                       m_LShr(m_Value(X), m_APInt(ReverseShiftAmt))))) &&
+          match(A, m_LShr(m_Trunc(m_Specific(X)),
+                          m_SpecificInt(ReverseShiftAmt->getZExtValue())))) {
+        APInt CombinedMask = *C0 | *C1;
+        return BinaryOperator::CreateAnd(
+            B, ConstantInt::get(I.getType(), CombinedMask));
+      }
     }
 
     // Don't try to form a select if it's unlikely that we'll get rid of at

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -4321,27 +4321,28 @@ Instruction *InstCombinerImpl::visitOr(BinaryOperator &I) {
       }
 
       // (trunc (lshr X, S) & C0) | (lshr (trunc X), S & C1)
-      // --> (trunc (lshr X, S) & (C0 | C1) (and similar cases) 
+      // --> (trunc (lshr X, S) & (C0 | C1) (and similar cases)
       // A = trunc (lshr X, S) B = lshr (trunc X), S
       const APInt *ShiftAmt;
-      if (match(A, m_OneUse(m_Trunc(m_LShr(m_Value(X), m_APInt(ShiftAmt))))) &&
-          match(B, m_LShr(m_Trunc(m_Specific(X)),
-                          m_SpecificInt(ShiftAmt->getZExtValue())))) {
-        APInt CombinedMask = *C0 | *C1;
-        return BinaryOperator::CreateAnd(
-            A, ConstantInt::get(I.getType(), CombinedMask));
+      Value *Wide, *Narrow;
+      if (match(A, m_Trunc(m_LShr(m_Value(X), m_APInt(ShiftAmt))))) {
+        Wide = A;
+        Narrow = B;
+      } else if (match(B, m_Trunc(m_LShr(m_Value(X), m_APInt(ShiftAmt))))) {
+        Wide = B;
+        Narrow = A;
+      } else {
+        return nullptr;
       }
-      // A = lshr (trunc X), S
-      // B = trunc (lshr X, S)
-      const APInt *ReverseShiftAmt;
-      if (match(B, m_OneUse(m_Trunc(
-                       m_LShr(m_Value(X), m_APInt(ReverseShiftAmt))))) &&
-          match(A, m_LShr(m_Trunc(m_Specific(X)),
-                          m_SpecificInt(ReverseShiftAmt->getZExtValue())))) {
-        APInt CombinedMask = *C0 | *C1;
-        return BinaryOperator::CreateAnd(
-            B, ConstantInt::get(I.getType(), CombinedMask));
+
+      if (!match(Narrow,
+                 m_LShr(m_Trunc(m_Specific(X)), m_SpecificInt(*ShiftAmt)))) {
+        return nullptr;
       }
+
+      APInt CombinedMask = *C0 | *C1;
+      return BinaryOperator::CreateAnd(
+          Wide, ConstantInt::get(I.getType(), CombinedMask));
     }
 
     // Don't try to form a select if it's unlikely that we'll get rid of at

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -4326,21 +4326,21 @@ Instruction *InstCombinerImpl::visitOr(BinaryOperator &I) {
       const APInt *ShiftAmt;
       if (match(A, m_Trunc(m_LShr(m_Value(X), m_APInt(ShiftAmt)))) &&
           match(B, m_LShr(m_Trunc(m_Specific(X)), m_SpecificInt(*ShiftAmt))) &&
-          ShiftAmt->ult(A->getType()->getIntegerBitWidth()) &&
+          ShiftAmt->ult(A->getType()->getScalarSizeInBits()) &&
           !C1->intersects(APInt::getHighBitsSet(
-              A->getType()->getIntegerBitWidth(), ShiftAmt->getZExtValue()))) {
+              A->getType()->getScalarSizeInBits(), ShiftAmt->getZExtValue()))) {
         return BinaryOperator::CreateAnd(
-            A, ConstantInt::get(I.getType(), *C0 | *C1));
+            A, ConstantInt::getIntegerValue(I.getType(), *C0 | *C1));
       }
       // A = lshr (trunc X), S
       // B = trunc (lshr X, S)
       if (match(B, m_Trunc(m_LShr(m_Value(X), m_APInt(ShiftAmt)))) &&
           match(A, m_LShr(m_Trunc(m_Specific(X)), m_SpecificInt(*ShiftAmt))) &&
-          ShiftAmt->ult(A->getType()->getIntegerBitWidth()) &&
+          ShiftAmt->ult(A->getType()->getScalarSizeInBits()) &&
           !C0->intersects(APInt::getHighBitsSet(
-              A->getType()->getIntegerBitWidth(), ShiftAmt->getZExtValue()))) {
+              A->getType()->getScalarSizeInBits(), ShiftAmt->getZExtValue()))) {
         return BinaryOperator::CreateAnd(
-            B, ConstantInt::get(I.getType(), *C0 | *C1));
+            B, ConstantInt::getIntegerValue(I.getType(), *C0 | *C1));
       }
     }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -4325,14 +4325,20 @@ Instruction *InstCombinerImpl::visitOr(BinaryOperator &I) {
       // A = trunc (lshr X, S) B = lshr (trunc X), S
       const APInt *ShiftAmt;
       if (match(A, m_Trunc(m_LShr(m_Value(X), m_APInt(ShiftAmt)))) &&
-          match(B, m_LShr(m_Trunc(m_Specific(X)), m_SpecificInt(*ShiftAmt)))) {
+          match(B, m_LShr(m_Trunc(m_Specific(X)), m_SpecificInt(*ShiftAmt))) &&
+          ShiftAmt->ult(A->getType()->getIntegerBitWidth()) &&
+          !C1->intersects(APInt::getHighBitsSet(
+              A->getType()->getIntegerBitWidth(), ShiftAmt->getZExtValue()))) {
         return BinaryOperator::CreateAnd(
             A, ConstantInt::get(I.getType(), *C0 | *C1));
       }
       // A = lshr (trunc X), S
       // B = trunc (lshr X, S)
       if (match(B, m_Trunc(m_LShr(m_Value(X), m_APInt(ShiftAmt)))) &&
-          match(A, m_LShr(m_Trunc(m_Specific(X)), m_SpecificInt(*ShiftAmt)))) {
+          match(A, m_LShr(m_Trunc(m_Specific(X)), m_SpecificInt(*ShiftAmt))) &&
+          ShiftAmt->ult(A->getType()->getIntegerBitWidth()) &&
+          !C0->intersects(APInt::getHighBitsSet(
+              A->getType()->getIntegerBitWidth(), ShiftAmt->getZExtValue()))) {
         return BinaryOperator::CreateAnd(
             B, ConstantInt::get(I.getType(), *C0 | *C1));
       }

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -4320,27 +4320,27 @@ Instruction *InstCombinerImpl::visitOr(BinaryOperator &I) {
         }
       }
 
-      // (trunc (lshr X, S) & C0) | (lshr (trunc X), S & C1)
-      // --> (trunc (lshr X, S) & (C0 | C1) (and similar cases)
+      // ((trunc (lshr X, S)) & C0) | ((lshr (trunc X), S) & C1)
+      // --> (trunc (lshr X, S) & (C0 | C1)) (and similar cases)
       // A = trunc (lshr X, S) B = lshr (trunc X), S
       const APInt *ShiftAmt;
       if (match(A, m_Trunc(m_LShr(m_Value(X), m_APInt(ShiftAmt)))) &&
           match(B, m_LShr(m_Trunc(m_Specific(X)), m_SpecificInt(*ShiftAmt))) &&
-          ShiftAmt->ult(A->getType()->getScalarSizeInBits()) &&
+          ShiftAmt->isIntN(A->getType()->getScalarSizeInBits()) &&
           !C1->intersects(APInt::getHighBitsSet(
               A->getType()->getScalarSizeInBits(), ShiftAmt->getZExtValue()))) {
         return BinaryOperator::CreateAnd(
-            A, ConstantInt::getIntegerValue(I.getType(), *C0 | *C1));
+            A, ConstantInt::get(I.getType(), *C0 | *C1));
       }
       // A = lshr (trunc X), S
       // B = trunc (lshr X, S)
       if (match(B, m_Trunc(m_LShr(m_Value(X), m_APInt(ShiftAmt)))) &&
           match(A, m_LShr(m_Trunc(m_Specific(X)), m_SpecificInt(*ShiftAmt))) &&
-          ShiftAmt->ult(A->getType()->getScalarSizeInBits()) &&
+          ShiftAmt->isIntN(A->getType()->getScalarSizeInBits()) &&
           !C0->intersects(APInt::getHighBitsSet(
               A->getType()->getScalarSizeInBits(), ShiftAmt->getZExtValue()))) {
         return BinaryOperator::CreateAnd(
-            B, ConstantInt::getIntegerValue(I.getType(), *C0 | *C1));
+            B, ConstantInt::get(I.getType(), *C0 | *C1));
       }
     }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -4321,7 +4321,7 @@ Instruction *InstCombinerImpl::visitOr(BinaryOperator &I) {
       }
 
       // ((trunc (lshr X, S)) & C0) | ((lshr (trunc X), S) & C1)
-      // --> (trunc (lshr X, S) & (C0 | C1)) (and similar cases)
+      // --> ((trunc (lshr X, S)) & (C0 | C1)) (and similar cases)
       // A = trunc (lshr X, S) B = lshr (trunc X), S
       const APInt *ShiftAmt;
       if (match(A, m_Trunc(m_LShr(m_Value(X), m_APInt(ShiftAmt)))) &&

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -4324,25 +4324,18 @@ Instruction *InstCombinerImpl::visitOr(BinaryOperator &I) {
       // --> (trunc (lshr X, S) & (C0 | C1) (and similar cases)
       // A = trunc (lshr X, S) B = lshr (trunc X), S
       const APInt *ShiftAmt;
-      Value *Wide, *Narrow;
-      if (match(A, m_Trunc(m_LShr(m_Value(X), m_APInt(ShiftAmt))))) {
-        Wide = A;
-        Narrow = B;
-      } else if (match(B, m_Trunc(m_LShr(m_Value(X), m_APInt(ShiftAmt))))) {
-        Wide = B;
-        Narrow = A;
-      } else {
-        return nullptr;
+      if (match(A, m_Trunc(m_LShr(m_Value(X), m_APInt(ShiftAmt)))) &&
+          match(B, m_LShr(m_Trunc(m_Specific(X)), m_SpecificInt(*ShiftAmt)))) {
+        return BinaryOperator::CreateAnd(
+            A, ConstantInt::get(I.getType(), *C0 | *C1));
       }
-
-      if (!match(Narrow,
-                 m_LShr(m_Trunc(m_Specific(X)), m_SpecificInt(*ShiftAmt)))) {
-        return nullptr;
+      // A = lshr (trunc X), S
+      // B = trunc (lshr X, S)
+      if (match(B, m_Trunc(m_LShr(m_Value(X), m_APInt(ShiftAmt)))) &&
+          match(A, m_LShr(m_Trunc(m_Specific(X)), m_SpecificInt(*ShiftAmt)))) {
+        return BinaryOperator::CreateAnd(
+            B, ConstantInt::get(I.getType(), *C0 | *C1));
       }
-
-      APInt CombinedMask = *C0 | *C1;
-      return BinaryOperator::CreateAnd(
-          Wide, ConstantInt::get(I.getType(), CombinedMask));
     }
 
     // Don't try to form a select if it's unlikely that we'll get rid of at

--- a/llvm/test/Transforms/InstCombine/trunc.ll
+++ b/llvm/test/Transforms/InstCombine/trunc.ll
@@ -1462,3 +1462,41 @@ define i1 @neg_trunc_nuw_lshr(i8 %x, i8 %c) {
   %ret = trunc nuw i8 %lshr to i1
   ret i1 %ret
 }
+
+define i32 @separate_truncs_i32(i64 %x) {
+; CHECK-LABEL: @separate_truncs_i32(
+; CHECK-NEXT:    %[[SHIFT:.*]] = lshr i64 %x, 16
+; CHECK-NEXT:    %[[TRUNC:.*]] = trunc i64 %[[SHIFT]] to i32
+; CHECK-NEXT:    %[[MASK:.*]] = and i32 %[[TRUNC]], 130816
+; CHECK-NEXT:    ret i32 %[[MASK]]
+;
+  %wide.shift = lshr i64 %x, 16
+  %wide = trunc i64 %wide.shift to i32
+  %field.hi = and i32 %wide, 65536
+
+  %x.narrow = trunc i64 %x to i32
+  %narrow.shift = lshr i32 %x.narrow, 16
+  %field.lo = and i32 %narrow.shift, 65280
+
+  %result = or i32 %field.hi, %field.lo
+  ret i32 %result
+}
+
+define i32 @separate_truncs_i32_reverse(i64 %x) {
+; CHECK-LABEL: @separate_truncs_i32_reverse(
+; CHECK-NEXT:    %[[SHIFT:.*]] = lshr i64 %x, 16
+; CHECK-NEXT:    %[[TRUNC:.*]] = trunc i64 %[[SHIFT]] to i32
+; CHECK-NEXT:    %[[MASK:.*]] = and i32 %[[TRUNC]], 130816
+; CHECK-NEXT:    ret i32 %[[MASK]]
+;
+  %x.narrow = trunc i64 %x to i32
+  %narrow.shift = lshr i32 %x.narrow, 16
+  %field.lo = and i32 %narrow.shift, 65280
+
+  %wide.shift = lshr i64 %x, 16 
+  %wide = trunc i64 %wide.shift to i32
+  %field.hi = and i32 %wide, 65536
+
+  %result = or i32 %field.lo, %field.hi
+  ret i32 %result
+}

--- a/llvm/test/Transforms/InstCombine/trunc.ll
+++ b/llvm/test/Transforms/InstCombine/trunc.ll
@@ -1544,3 +1544,57 @@ define i32 @separate_truncs_i32_reverse_multiuse(i64 %x) {
   ret i32 %result
 }
 
+define <2 x i32> @separate_truncs_i32_reverse_vec(<2 x i64> %x) {
+; CHECK-LABEL: @separate_truncs_i32_reverse_vec(
+; CHECK-NEXT:    %[[SHIFT:.*]] = lshr <2 x i64> %x, splat (i64 16)
+; CHECK-NEXT:    %[[TRUNC:.*]] = trunc <2 x i64> %[[SHIFT]] to <2 x i32>
+; CHECK-NEXT:    %[[MASK:.*]] = and <2 x i32> %[[TRUNC]], splat (i32 130816)
+; CHECK-NEXT:    ret <2 x i32> %[[MASK]]
+; 
+  %x.narrow = trunc <2 x i64> %x to <2 x i32>
+  %narrow.shift = lshr <2 x i32> %x.narrow, <i32 16, i32 16>
+  %field.lo = and <2 x i32> %narrow.shift, <i32 65280, i32 65280>
+
+  %wide.shift = lshr <2 x i64> %x, <i64 16, i64 16>
+  %wide = trunc <2 x i64> %wide.shift to <2 x i32>
+  %field.hi = and <2 x i32> %wide, <i32 65536, i32 65536>
+
+  %result = or <2 x i32> %field.lo, %field.hi
+  ret <2 x i32> %result
+}
+
+define i32 @neg_separate_truncs_i32_shift_geq_32(i64 %x) {
+; CHECK-LABEL: @neg_separate_truncs_i32_shift_geq_32(
+; CHECK-NEXT:    ret i32 poison
+;
+  %wide.shift = lshr i64 %x, 32
+  %wide = trunc i64 %wide.shift to i32
+  %field.hi = and i32 %wide, 65536
+
+  %x.narrow = trunc i64 %x to i32
+  %narrow.shift = lshr i32 %x.narrow, 32
+  %field.lo = and i32 %narrow.shift, 65280
+
+  %result = or i32 %field.hi, %field.lo
+  ret i32 %result
+}
+
+; negative test: narrow mask 131072
+define i32 @neg_separate_truncs_i32_upper_bits(i64 %x) {
+; CHECK-LABEL: @neg_separate_truncs_i32_upper_bits(
+; CHECK-NEXT:    %[[SHIFT:.*]] = lshr i64 %x, 16
+; CHECK-NEXT:    %[[TRUNC:.*]] = trunc i64 %[[SHIFT]] to i32
+; CHECK-NEXT:    %[[MASK:.*]] = and i32 %[[TRUNC]], 65536
+; CHECK-NEXT:    ret i32 %[[MASK]]
+;
+  %wide.shift = lshr i64 %x, 16
+  %wide = trunc i64 %wide.shift to i32
+  %field.hi = and i32 %wide, 65536
+
+  %x.narrow = trunc i64 %x to i32
+  %narrow.shift = lshr i32 %x.narrow, 16
+  %field.lo = and i32 %narrow.shift, 131072
+
+  %result = or i32 %field.hi, %field.lo
+  ret i32 %result
+}

--- a/llvm/test/Transforms/InstCombine/trunc.ll
+++ b/llvm/test/Transforms/InstCombine/trunc.ll
@@ -1500,3 +1500,46 @@ define i32 @separate_truncs_i32_reverse(i64 %x) {
   %result = or i32 %field.lo, %field.hi
   ret i32 %result
 }
+
+define i32 @separate_truncs_i32_multiuse(i64 %x) {
+; CHECK-LABEL: @separate_truncs_i32_multiuse(
+; CHECK-NEXT:    %[[SHIFT:.*]] = lshr i64 %x, 16
+; CHECK-NEXT:    %[[TRUNC:.*]] = trunc i64 %[[SHIFT]] to i32
+; CHECK-NEXT:    call void @use(i32 %[[TRUNC]])
+; CHECK-NEXT:    %[[MASK:.*]] = and i32 %[[TRUNC]], 130816
+; CHECK-NEXT:    ret i32 %[[MASK]]
+; 
+  %wide.shift = lshr i64 %x, 16
+  %wide = trunc i64 %wide.shift to i32
+  call void @use(i32 %wide)
+  %field.hi = and i32 %wide, 65536
+
+  %x.narrow = trunc i64 %x to i32
+  %narrow.shift = lshr i32 %x.narrow, 16
+  %field.lo = and i32 %narrow.shift, 65280
+
+  %result = or i32 %field.hi, %field.lo
+  ret i32 %result
+}
+
+define i32 @separate_truncs_i32_reverse_multiuse(i64 %x) {
+; CHECK-LABEL: @separate_truncs_i32_reverse_multiuse(
+; CHECK-NEXT:    %[[NARROW:.*]] = trunc i64 %x to i32
+; CHECK-NEXT:    call void @use(i32 %[[NARROW]])
+; CHECK-NEXT:    %[[SHIFT:.*]] = lshr i64 %x, 16
+; CHECK-NEXT:    %[[TRUNC:.*]] = trunc i64 %[[SHIFT]] to i32
+; CHECK-NEXT:    %[[MASK:.*]] = and i32 %[[TRUNC]], 130816
+; CHECK-NEXT:    ret i32 %[[MASK]]
+;
+  %x.narrow = trunc i64 %x to i32
+  call void @use(i32 %x.narrow)
+  %narrow.shift = lshr i32 %x.narrow, 16
+  %field.lo = and i32 %narrow.shift, 65280
+
+  %wide.shift = lshr i64 %x, 16 
+  %wide = trunc i64 %wide.shift to i32
+  %field.hi = and i32 %wide, 65536
+
+  %result = or i32 %field.lo, %field.hi
+  ret i32 %result
+}

--- a/llvm/test/Transforms/InstCombine/trunc.ll
+++ b/llvm/test/Transforms/InstCombine/trunc.ll
@@ -1543,3 +1543,4 @@ define i32 @separate_truncs_i32_reverse_multiuse(i64 %x) {
   %result = or i32 %field.lo, %field.hi
   ret i32 %result
 }
+


### PR DESCRIPTION
This restores the InstCombine optimization that was lost (regression) starting from Clang 14, when assembling adjacent bit fields extracted from a wider integer. 

The fold combines:
```
(trunc (lshr X, S) & M0) | (lshr (trunc X), S & M1) --> (trunc (lshr X, S) & (C0 | C1))
```
The fold handles both orderings. I implemented tests for this fold in trunc.ll

alive2 proof: https://alive2.llvm.org/ce/z/rPQN4D 

Fixes #215254  