### PR TITLE
[LTO] Enable `PrepareForLTO` for `LoopUnrollPass`

### DIFF
--- a/llvm/include/llvm/Transforms/Scalar/LoopUnrollPass.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopUnrollPass.h
@@ -88,9 +88,9 @@ struct LoopUnrollOptions {
   bool PrepareForLTO = false;
 
   LoopUnrollOptions(int OptLevel = 2, bool OnlyWhenForced = false,
-                    bool ForgetSCEV = false)
+                    bool ForgetSCEV = false, bool PrepareForLTO = false)
       : OptLevel(OptLevel), OnlyWhenForced(OnlyWhenForced),
-        ForgetSCEV(ForgetSCEV) {}
+        ForgetSCEV(ForgetSCEV), PrepareForLTO(PrepareForLTO) {}
 
   /// Enables or disables partial unrolling. When disabled only full unrolling
   /// is allowed.

--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -1468,8 +1468,9 @@ void PassBuilder::addVectorPasses(OptimizationLevel Level,
           LoopUnrollAndJamPass(static_cast<int>(Level))));
     }
     FPM.addPass(LoopUnrollPass(LoopUnrollOptions(
-        static_cast<int>(Level), /*OnlyWhenForced=*/!PTO.LoopUnrolling,
-        PTO.ForgetAllSCEVInLoopUnroll)));
+        static_cast<int>(Level),
+        /*OnlyWhenForced=*/!PTO.LoopUnrolling, PTO.ForgetAllSCEVInLoopUnroll,
+        /*PrepareForLTO=*/isLTOPreLink(LTOPhase))));
     FPM.addPass(WarnMissedTransformationsPass());
     // Now that we are done with loop unrolling, be it either by LoopVectorizer,
     // or LoopUnroll passes, some variable-offset GEP's into alloca's could have


### PR DESCRIPTION
#192155 overlooked this invocation of `LoopUnrollPass` in `addVectorPasses()`. This PR addresses that. 