### PR TITLE
[lld][WebAssembly] Do not coalesce segments with differing flags in -r

### DIFF
--- a/lld/test/wasm/relocatable-strings-conflict.s
+++ b/lld/test/wasm/relocatable-strings-conflict.s
@@ -1,0 +1,46 @@
+# RUN: split-file %s %t
+# RUN: llvm-mc -filetype=obj --triple=wasm32-unknown-unknown -o %t/main.o %t/main.s
+# RUN: llvm-mc -filetype=obj --triple=wasm32-unknown-unknown -o %t/extra.o %t/extra.s
+# RUN: wasm-ld --relocatable -o %t/reloc.o %t/main.o %t/extra.o
+# RUN: obj2yaml %t/reloc.o | FileCheck %s --check-prefix=RELOC
+# RUN: wasm-ld --export-all %t/reloc.o -o %t/final.wasm
+# RUN: obj2yaml %t/final.wasm | FileCheck %s --check-prefix=FINAL
+
+# A non-STRINGS segment (such as an embedded-null string literal) must not have
+# the STRINGS flag applied when coalesced with a STRINGS segment of the same
+# name in a relocatable link. Otherwise, downstream links will treat the entire
+# segment as mergeable strings, splitting the embedded-null string at '\0' and
+# reordering/corrupting it.
+
+#--- main.s
+  .globl _start
+_start:
+  .functype _start () -> ()
+  end_function
+
+  .section .rodata.str,"S",@
+  .asciz "hello"
+  .asciz "apple"
+
+#--- extra.s
+  .section .rodata.str,"",@
+  .globl str_with_null
+str_with_null:
+  .asciz "hello\000world"
+  .size str_with_null, 12
+
+# RELOC:      SegmentInfo:
+# RELOC:        - Index:           0
+# RELOC-NEXT:     Name:            .rodata.str
+# RELOC-NEXT:     Alignment:       0
+# RELOC-NEXT:     Flags:           [ STRINGS ]
+# RELOC-NEXT:   - Index:           1
+# RELOC-NEXT:     Name:            .rodata.str
+# RELOC-NEXT:     Alignment:       0
+# RELOC-NEXT:     Flags:           [ ]
+
+# In the final binary, "hello\0world\0" must remain contiguous, and not be
+# split apart by string-table merging inserting "apple" between "hello" and "world".
+# FINAL:      - Type:            DATA
+# FINAL-NEXT:   Segments:
+# FINAL:          Content:         68656C6C6F00776F726C6400

--- a/lld/wasm/Writer.cpp
+++ b/lld/wasm/Writer.cpp
@@ -121,7 +121,8 @@ private:
   std::unique_ptr<FileOutputBuffer> buffer;
 
   std::vector<OutputSegment *> segments;
-  llvm::SmallDenseMap<StringRef, OutputSegment *> segmentMap;
+  using SegmentKey = std::pair<StringRef, uint32_t>;
+  llvm::SmallDenseMap<SegmentKey, OutputSegment *> segmentMap;
 };
 
 void writeSetTLSBase(const Ctx &ctx, raw_ostream &os) {
@@ -1120,6 +1121,15 @@ void Writer::allocateCommonSymbols() {
 }
 
 void Writer::createOutputSegments() {
+  // In relocatable mode, segments with differing flags must not be coalesced
+  // into the same output segment; otherwise chunks would inherit flags from
+  // other chunks sharing the same name (e.g. non-STRINGS strings inheriting
+  // STRINGS and being corrupted by splitStrings, or non-RETAIN data inheriting
+  // RETAIN and preventing dead-code elimination).
+  auto getSegmentKey = [&](StringRef name, uint32_t flags) {
+    return SegmentKey(name, ctx.arg.relocatable ? flags : 0);
+  };
+
   for (ObjFile *file : ctx.objectFiles) {
     for (InputChunk *segment : file->segments) {
       if (!segment->live)
@@ -1132,9 +1142,10 @@ void Writer::createOutputSegments() {
       if (ctx.arg.relocatable && !segment->getComdatName().empty()) {
         s = createOutputSegment(name);
       } else {
-        if (!segmentMap.contains(name))
-          segmentMap[name] = createOutputSegment(name);
-        s = segmentMap[name];
+        auto key = getSegmentKey(name, segment->flags);
+        if (!segmentMap.contains(key))
+          segmentMap[key] = createOutputSegment(name);
+        s = segmentMap[key];
       }
       s->addInputSegment(segment);
     }
@@ -1146,9 +1157,10 @@ void Writer::createOutputSegments() {
       continue;
     StringRef name = getOutputDataSegmentName(*segment);
     OutputSegment *s = nullptr;
-    if (!segmentMap.contains(name))
-      segmentMap[name] = createOutputSegment(name);
-    s = segmentMap[name];
+    auto key = getSegmentKey(name, segment->flags);
+    if (!segmentMap.contains(key))
+      segmentMap[key] = createOutputSegment(name);
+    s = segmentMap[key];
     s->addInputSegment(segment);
   }
 


### PR DESCRIPTION
In PR #210747 (commit 162d9f09299d), `addInputSegment` was changed to
union segment linking flags (`linkingFlags |= inSeg->flags`) so that
flags like `RETAIN` and `STRINGS` are preserved in `--relocatable`
output.

However, coalescing segments with differing linking flags by name alone
forces one chunk's semantics onto another:
- Clang emits ordinary string literals (`STRINGS`) and string literals
  containing embedded null characters (non-`STRINGS`) into sections
  named `.rodata..L.str`. When coalesced, non-mergeable segments
  received the `STRINGS` flag, causing downstream links to split and
  corrupt them.
- Similarly, coalescing a chunk with `RETAIN` and a chunk without
  `RETAIN` forces the un-retained chunk to inherit `RETAIN`, preventing
  `--gc-sections` from discarding it if it is unused.

Fix this by distinguishing segments by their linking flags in
relocatable mode so that segments with differing flags are emitted as
separate output segments rather than coalesced.

Fixes: https://github.com/emscripten-core/emscripten/issues/27619