### PR TITLE
[flang][cuda] Extend CUF kernel host stub line table to the END statement

### DIFF
--- a/flang/lib/Optimizer/Transforms/CUDA/CUFDeviceFuncTransform.cpp
+++ b/flang/lib/Optimizer/Transforms/CUDA/CUFDeviceFuncTransform.cpp
@@ -162,6 +162,11 @@ class CUFDeviceFuncTransform
   static void createHostStub(mlir::func::FuncOp funcOp,
                              mlir::SymbolTable &symTab, mlir::ModuleOp mod) {
     mlir::Location loc = funcOp.getLoc();
+    // Host stub's line table needs to span the procedure body.
+    mlir::Location endLoc = loc;
+    if (!funcOp.getBody().empty())
+      if (mlir::Operation *terminator = funcOp.getBody().back().getTerminator())
+        endLoc = terminator->getLoc();
     mlir::OpBuilder modBuilder(mod.getBodyRegion());
     modBuilder.setInsertionPointToEnd(mod.getBody());
     auto emptyStub = func::FuncOp::create(modBuilder, loc, funcOp.getName(),
@@ -170,7 +175,9 @@ class CUFDeviceFuncTransform
     emptyStub->setAttrs(funcOp->getAttrs());
     auto entryBlock = emptyStub.addEntryBlock();
     modBuilder.setInsertionPointToEnd(entryBlock);
-    func::ReturnOp::create(modBuilder, loc);
+    // Add a return operation at the end of the stub with the location of the
+    // original procedure's terminator.
+    func::ReturnOp::create(modBuilder, endLoc);
 
     symTab.erase(funcOp);
     symTab.insert(emptyStub);

--- a/flang/test/Fir/CUDA/cuda-device-func-transform.mlir
+++ b/flang/test/Fir/CUDA/cuda-device-func-transform.mlir
@@ -1,4 +1,6 @@
 // RUN: fir-opt --split-input-file --cuf-transform-device-func %s | FileCheck %s
+// RUN: fir-opt --split-input-file --cuf-transform-device-func --mlir-print-debuginfo \
+// RUN:   --mlir-print-local-scope %s | FileCheck %s --check-prefix=LOC
 
 func.func @_QPsub_device1() attributes {cuf.proc_attr = #cuf.cuda_proc<device>} {
   return
@@ -221,3 +223,17 @@ func.func @cuda_global() attributes {cuf.proc_attr = #cuf.cuda_proc<global>} {
 // CHECK-NOT: gpu.func @acc_routine()
 // CHECK: gpu.func @cuda_global() kernel
 // CHECK: fir.call @acc_routine() : () -> ()
+
+// -----
+
+func.func @_QPsub_global_endline() attributes {cuf.proc_attr = #cuf.cuda_proc<global>} {
+  %cst = arith.constant 2.000000e+00 : f32 loc(#loc_body)
+  return loc(#loc_end)
+} loc(#loc_decl)
+#loc_decl = loc("test.cuf":4:3)
+#loc_body = loc("test.cuf":10:5)
+#loc_end = loc("test.cuf":15:3)
+
+// LOC-LABEL: func.func @_QPsub_global_endline()
+// LOC: return loc("test.cuf":15:3)
+// LOC-NEXT: } loc("test.cuf":4:3)


### PR DESCRIPTION
`CUFDeviceFuncTransform` creates a host stub for a kernel, with an empty body holding nothing but a `return`. Both the stub and its `return` keep only the original declaration location, so the stub's line table ends up with rows only for the declaration line.

This change extends the line table to span the procedure's whole source line range, by using the location of the original `END` statement for the stub's `return`. A debugger can then set a breakpoint on a line inside the kernel body and stop there.

Lit test `cuda-device-func-transform.mlir` is enhanced to guard this change.