### PR TITLE
[LLVM][NFC] Make metadata-number checks robust

### DIFF
--- a/llvm/test/Analysis/BasicAA/noalias-scope-decl.ll
+++ b/llvm/test/Analysis/BasicAA/noalias-scope-decl.ll
@@ -14,12 +14,12 @@ define void @test1(ptr %P, ptr %Q) nounwind ssp {
 ; CHECK-LABEL: Function: test1:
 
 ; CHECK: MayAlias:	i8* %P, i8* %Q
-; CHECK: NoModRef:  Ptr: i8* %P	<->  tail call void @llvm.experimental.noalias.scope.decl(metadata !0)
-; CHECK: NoModRef:  Ptr: i8* %Q	<->  tail call void @llvm.experimental.noalias.scope.decl(metadata !0)
+; CHECK: NoModRef:  Ptr: i8* %P	<->  tail call void @llvm.experimental.noalias.scope.decl(metadata ![[SCOPE:[0-9]+]])
+; CHECK: NoModRef:  Ptr: i8* %Q	<->  tail call void @llvm.experimental.noalias.scope.decl(metadata ![[SCOPE]])
 ; CHECK: Both ModRef:  Ptr: i8* %P	<->  tail call void @llvm.memcpy.p0.p0.i64(ptr %P, ptr %Q, i64 12, i1 false)
 ; CHECK: Both ModRef:  Ptr: i8* %Q	<->  tail call void @llvm.memcpy.p0.p0.i64(ptr %P, ptr %Q, i64 12, i1 false)
-; CHECK: NoModRef:   tail call void @llvm.experimental.noalias.scope.decl(metadata !0) <->   tail call void @llvm.memcpy.p0.p0.i64(ptr %P, ptr %Q, i64 12, i1 false)
-; CHECK: NoModRef:   tail call void @llvm.memcpy.p0.p0.i64(ptr %P, ptr %Q, i64 12, i1 false) <->   tail call void @llvm.experimental.noalias.scope.decl(metadata !0)
+; CHECK: NoModRef:   tail call void @llvm.experimental.noalias.scope.decl(metadata ![[SCOPE]]) <->   tail call void @llvm.memcpy.p0.p0.i64(ptr %P, ptr %Q, i64 12, i1 false)
+; CHECK: NoModRef:   tail call void @llvm.memcpy.p0.p0.i64(ptr %P, ptr %Q, i64 12, i1 false) <->   tail call void @llvm.experimental.noalias.scope.decl(metadata ![[SCOPE]])
 }
 
 

--- a/llvm/test/Analysis/CostModel/X86/free-intrinsics.ll
+++ b/llvm/test/Analysis/CostModel/X86/free-intrinsics.ll
@@ -7,7 +7,7 @@ define i32 @trivially_free() {
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %alloca = alloca i8, align 1
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a0 = call i32 @llvm.annotation.i32.p0(i32 undef, ptr undef, ptr undef, i32 undef)
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.assume(i1 undef)
-; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.experimental.noalias.scope.decl(metadata !3)
+; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.experimental.noalias.scope.decl(metadata !{{[0-9]+}})
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.sideeffect()
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a1 = call ptr @llvm.invariant.start.p0(i64 1, ptr undef)
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.invariant.end.p0(ptr undef, i64 1, ptr undef)
@@ -25,7 +25,7 @@ define i32 @trivially_free() {
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %alloca = alloca i8, align 1
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a0 = call i32 @llvm.annotation.i32.p0(i32 undef, ptr undef, ptr undef, i32 undef)
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.assume(i1 undef)
-; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.experimental.noalias.scope.decl(metadata !3)
+; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.experimental.noalias.scope.decl(metadata !{{[0-9]+}})
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.sideeffect()
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a1 = call ptr @llvm.invariant.start.p0(i64 1, ptr undef)
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.invariant.end.p0(ptr undef, i64 1, ptr undef)

--- a/llvm/test/Analysis/CostModel/free-intrinsics-datalayout.ll
+++ b/llvm/test/Analysis/CostModel/free-intrinsics-datalayout.ll
@@ -9,7 +9,7 @@ define i32 @trivially_free() {
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %alloca = alloca i8, align 4
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a0 = call i32 @llvm.annotation.i32.p0(i32 undef, ptr undef, ptr undef, i32 undef)
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.assume(i1 undef)
-; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.experimental.noalias.scope.decl(metadata !3)
+; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.experimental.noalias.scope.decl(metadata !{{[0-9]+}})
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.sideeffect()
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a1 = call ptr @llvm.invariant.start.p0(i64 1, ptr undef)
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.invariant.end.p0(ptr undef, i64 1, ptr undef)
@@ -29,7 +29,7 @@ define i32 @trivially_free() {
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %alloca = alloca i8, align 4
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a0 = call i32 @llvm.annotation.i32.p0(i32 undef, ptr undef, ptr undef, i32 undef)
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.assume(i1 undef)
-; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.experimental.noalias.scope.decl(metadata !3)
+; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.experimental.noalias.scope.decl(metadata !{{[0-9]+}})
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.sideeffect()
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a1 = call ptr @llvm.invariant.start.p0(i64 1, ptr undef)
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.invariant.end.p0(ptr undef, i64 1, ptr undef)

--- a/llvm/test/Analysis/CostModel/free-intrinsics-no_info.ll
+++ b/llvm/test/Analysis/CostModel/free-intrinsics-no_info.ll
@@ -7,7 +7,7 @@ define i32 @trivially_free() {
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %alloca = alloca i8, align 1
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a0 = call i32 @llvm.annotation.i32.p0(i32 undef, ptr undef, ptr undef, i32 undef)
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.assume(i1 undef)
-; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.experimental.noalias.scope.decl(metadata !3)
+; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.experimental.noalias.scope.decl(metadata !{{[0-9]+}})
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.sideeffect()
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a1 = call ptr @llvm.invariant.start.p0(i64 1, ptr undef)
 ; CHECK-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.invariant.end.p0(ptr undef, i64 1, ptr undef)
@@ -27,7 +27,7 @@ define i32 @trivially_free() {
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %alloca = alloca i8, align 1
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a0 = call i32 @llvm.annotation.i32.p0(i32 undef, ptr undef, ptr undef, i32 undef)
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.assume(i1 undef)
-; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.experimental.noalias.scope.decl(metadata !3)
+; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.experimental.noalias.scope.decl(metadata !{{[0-9]+}})
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.sideeffect()
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %a1 = call ptr @llvm.invariant.start.p0(i64 1, ptr undef)
 ; CHECK-THROUGHPUT-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: call void @llvm.invariant.end.p0(ptr undef, i64 1, ptr undef)

--- a/llvm/test/Analysis/DependenceAnalysis/AA.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/AA.ll
@@ -99,11 +99,11 @@ define void @test_global_size() {
 
 define void @test_tbaa_same(ptr %A, ptr %B) {
 ; CHECK-LABEL: 'test_tbaa_same'
-; CHECK-NEXT:  Src: store i32 1, ptr %A, align 4, !tbaa !0 --> Dst: store i32 1, ptr %A, align 4, !tbaa !0
+; CHECK-NEXT:  Src: store i32 1, ptr %A, align 4, !tbaa !{{[0-9]+}} --> Dst: store i32 1, ptr %A, align 4, !tbaa !{{[0-9]+}}
 ; CHECK-NEXT:    da analyze - none!
-; CHECK-NEXT:  Src: store i32 1, ptr %A, align 4, !tbaa !0 --> Dst: store i32 2, ptr %B, align 4, !tbaa !0
+; CHECK-NEXT:  Src: store i32 1, ptr %A, align 4, !tbaa !{{[0-9]+}} --> Dst: store i32 2, ptr %B, align 4, !tbaa !{{[0-9]+}}
 ; CHECK-NEXT:    da analyze - confused!
-; CHECK-NEXT:  Src: store i32 2, ptr %B, align 4, !tbaa !0 --> Dst: store i32 2, ptr %B, align 4, !tbaa !0
+; CHECK-NEXT:  Src: store i32 2, ptr %B, align 4, !tbaa !{{[0-9]+}} --> Dst: store i32 2, ptr %B, align 4, !tbaa !{{[0-9]+}}
 ; CHECK-NEXT:    da analyze - none!
 ;
   store i32 1, ptr %A, !tbaa !5
@@ -113,11 +113,11 @@ define void @test_tbaa_same(ptr %A, ptr %B) {
 
 define void @test_tbaa_diff(ptr %A, ptr %B) {
 ; CHECK-LABEL: 'test_tbaa_diff'
-; CHECK-NEXT:  Src: store i32 1, ptr %A, align 4, !tbaa !0 --> Dst: store i32 1, ptr %A, align 4, !tbaa !0
+; CHECK-NEXT:  Src: store i32 1, ptr %A, align 4, !tbaa !{{[0-9]+}} --> Dst: store i32 1, ptr %A, align 4, !tbaa !{{[0-9]+}}
 ; CHECK-NEXT:    da analyze - none!
-; CHECK-NEXT:  Src: store i32 1, ptr %A, align 4, !tbaa !0 --> Dst: store i16 2, ptr %B, align 2, !tbaa !4
+; CHECK-NEXT:  Src: store i32 1, ptr %A, align 4, !tbaa !{{[0-9]+}} --> Dst: store i16 2, ptr %B, align 2, !tbaa !{{[0-9]+}}
 ; CHECK-NEXT:    da analyze - none!
-; CHECK-NEXT:  Src: store i16 2, ptr %B, align 2, !tbaa !4 --> Dst: store i16 2, ptr %B, align 2, !tbaa !4
+; CHECK-NEXT:  Src: store i16 2, ptr %B, align 2, !tbaa !{{[0-9]+}} --> Dst: store i16 2, ptr %B, align 2, !tbaa !{{[0-9]+}}
 ; CHECK-NEXT:    da analyze - none!
 ;
   store i32 1, ptr %A, !tbaa !5
@@ -127,11 +127,11 @@ define void @test_tbaa_diff(ptr %A, ptr %B) {
 
 define void @tbaa_loop(i32 %I, i32 %J, ptr nocapture %A, ptr nocapture readonly %B) {
 ; CHECK-LABEL: 'tbaa_loop'
-; CHECK-NEXT:  Src: %0 = load i16, ptr %arrayidx.us, align 4, !tbaa !0 --> Dst: %0 = load i16, ptr %arrayidx.us, align 4, !tbaa !0
+; CHECK-NEXT:  Src: %0 = load i16, ptr %arrayidx.us, align 4, !tbaa !{{[0-9]+}} --> Dst: %0 = load i16, ptr %arrayidx.us, align 4, !tbaa !{{[0-9]+}}
 ; CHECK-NEXT:    da analyze - input [* *]!
-; CHECK-NEXT:  Src: %0 = load i16, ptr %arrayidx.us, align 4, !tbaa !0 --> Dst: store i32 %add.us.lcssa, ptr %arrayidx6.us, align 4, !tbaa !4
+; CHECK-NEXT:  Src: %0 = load i16, ptr %arrayidx.us, align 4, !tbaa !{{[0-9]+}} --> Dst: store i32 %add.us.lcssa, ptr %arrayidx6.us, align 4, !tbaa !{{[0-9]+}}
 ; CHECK-NEXT:    da analyze - none!
-; CHECK-NEXT:  Src: store i32 %add.us.lcssa, ptr %arrayidx6.us, align 4, !tbaa !4 --> Dst: store i32 %add.us.lcssa, ptr %arrayidx6.us, align 4, !tbaa !4
+; CHECK-NEXT:  Src: store i32 %add.us.lcssa, ptr %arrayidx6.us, align 4, !tbaa !{{[0-9]+}} --> Dst: store i32 %add.us.lcssa, ptr %arrayidx6.us, align 4, !tbaa !{{[0-9]+}}
 ; CHECK-NEXT:    da analyze - output [*]!
 ;
 entry:

--- a/llvm/test/Analysis/LoopAccessAnalysis/loops-with-indirect-reads-and-writes.ll
+++ b/llvm/test/Analysis/LoopAccessAnalysis/loops-with-indirect-reads-and-writes.ll
@@ -25,12 +25,12 @@ define void @test_indirect_read_write_loop_also_modifies_pointer_array(ptr nound
 ; CHECK-NEXT:  Unsafe indirect dependence.
 ; CHECK-NEXT:      Dependences:
 ; CHECK-NEXT:        IndirectUnsafe:
-; CHECK-NEXT:            %l.2 = load i64, ptr %l.1, align 8, !tbaa !4 ->
-; CHECK-NEXT:            store i64 %inc, ptr %l.1, align 8, !tbaa !4
+; CHECK-NEXT:            %l.2 = load i64, ptr %l.1, align 8, !tbaa !{{[0-9]+}} ->
+; CHECK-NEXT:            store i64 %inc, ptr %l.1, align 8, !tbaa !{{[0-9]+}}
 ; CHECK-EMPTY:
 ; CHECK-NEXT:        Unknown:
-; CHECK-NEXT:            %l.1 = load ptr, ptr %gep.iv.1, align 8, !tbaa !0 ->
-; CHECK-NEXT:            store ptr %l.1, ptr %gep.iv.2, align 8, !tbaa !0
+; CHECK-NEXT:            %l.1 = load ptr, ptr %gep.iv.1, align 8, !tbaa !{{[0-9]+}} ->
+; CHECK-NEXT:            store ptr %l.1, ptr %gep.iv.2, align 8, !tbaa !{{[0-9]+}}
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Run-time memory checks:
 ; CHECK-NEXT:      Grouped accesses:
@@ -230,12 +230,12 @@ define void @test_indirect_read_write_loop_does_not_modify_pointer_array(ptr nou
 ; CHECK-NEXT:  Unsafe indirect dependence.
 ; CHECK-NEXT:      Dependences:
 ; CHECK-NEXT:        IndirectUnsafe:
-; CHECK-NEXT:            %l.2 = load i64, ptr %l.1, align 8, !tbaa !4 ->
-; CHECK-NEXT:            store i64 %inc, ptr %l.1, align 8, !tbaa !4
+; CHECK-NEXT:            %l.2 = load i64, ptr %l.1, align 8, !tbaa !{{[0-9]+}} ->
+; CHECK-NEXT:            store i64 %inc, ptr %l.1, align 8, !tbaa !{{[0-9]+}}
 ; CHECK-EMPTY:
 ; CHECK-NEXT:        Unknown:
 ; CHECK-NEXT:            %l.3 = load i64, ptr %gep.arr2.iv.1, align 8 ->
-; CHECK-NEXT:            store i64 %inc.2, ptr %gep.arr2.iv.2, align 8, !tbaa !0
+; CHECK-NEXT:            store i64 %inc.2, ptr %gep.arr2.iv.2, align 8, !tbaa !{{[0-9]+}}
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Run-time memory checks:
 ; CHECK-NEXT:      Grouped accesses:

--- a/llvm/test/Analysis/LoopAccessAnalysis/noalias-scope-decl.ll
+++ b/llvm/test/Analysis/LoopAccessAnalysis/noalias-scope-decl.ll
@@ -11,12 +11,12 @@ define void @test_scope_in_loop(ptr %arg, i64 %num) {
 ; CHECK-NEXT:  Backward loop carried data dependence.
 ; CHECK-NEXT:      Dependences:
 ; CHECK-NEXT:        Backward:
-; CHECK-NEXT:            %load.prev = load i8, ptr %prev.ptr, align 1, !alias.scope !0, !noalias !3 ->
-; CHECK-NEXT:            store i8 %add, ptr %cur.ptr, align 1, !alias.scope !3
+; CHECK-NEXT:            %load.prev = load i8, ptr %prev.ptr, align 1, !alias.scope !{{[0-9]+}}, !noalias !{{[0-9]+}} ->
+; CHECK-NEXT:            store i8 %add, ptr %cur.ptr, align 1, !alias.scope !{{[0-9]+}}
 ; CHECK-EMPTY:
 ; CHECK-NEXT:        Forward:
-; CHECK-NEXT:            %load.cur = load i8, ptr %cur.ptr, align 1, !alias.scope !3 ->
-; CHECK-NEXT:            store i8 %add, ptr %cur.ptr, align 1, !alias.scope !3
+; CHECK-NEXT:            %load.cur = load i8, ptr %cur.ptr, align 1, !alias.scope !{{[0-9]+}} ->
+; CHECK-NEXT:            store i8 %add, ptr %cur.ptr, align 1, !alias.scope !{{[0-9]+}}
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Run-time memory checks:
 ; CHECK-NEXT:      Grouped accesses:

--- a/llvm/test/Analysis/LoopAccessAnalysis/underlying-object-loop-varying-phi.ll
+++ b/llvm/test/Analysis/LoopAccessAnalysis/underlying-object-loop-varying-phi.ll
@@ -11,8 +11,8 @@ define void @indirect_ptr_recurrences_read_write(ptr %A, ptr %B) {
 ; CHECK-NEXT:  Unsafe indirect dependence.
 ; CHECK-NEXT:      Dependences:
 ; CHECK-NEXT:        IndirectUnsafe:
-; CHECK-NEXT:            %l = load i32, ptr %ptr.recur, align 4, !tbaa !4 ->
-; CHECK-NEXT:            store i32 %xor, ptr %ptr.recur, align 4, !tbaa !4
+; CHECK-NEXT:            %l = load i32, ptr %ptr.recur, align 4, !tbaa !{{[0-9]+}} ->
+; CHECK-NEXT:            store i32 %xor, ptr %ptr.recur, align 4, !tbaa !{{[0-9]+}}
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Run-time memory checks:
 ; CHECK-NEXT:      Grouped accesses:

--- a/llvm/test/Analysis/MemorySSA/invariant-groups.ll
+++ b/llvm/test/Analysis/MemorySSA/invariant-groups.ll
@@ -348,7 +348,7 @@ define i8 @optimizable() {
 entry:
   %ptr = alloca i8
 ; CHECK: 1 = MemoryDef(liveOnEntry)
-; CHECK-NEXT: store i8 42, ptr %ptr, align 1, !invariant.group !0
+; CHECK-NEXT: store i8 42, ptr %ptr, align 1, !invariant.group !{{[0-9]+}}
   store i8 42, ptr %ptr, !invariant.group !0
 ; CHECK: 2 = MemoryDef(1)
 ; CHECK-NEXT: call ptr @llvm.launder.invariant.group
@@ -377,7 +377,7 @@ entry:
 define i8 @unoptimizable2() {
   %ptr = alloca i8
 ; CHECK: 1 = MemoryDef(liveOnEntry)
-; CHECK-NEXT: store i8 42, ptr %ptr, align 1, !invariant.group !0
+; CHECK-NEXT: store i8 42, ptr %ptr, align 1, !invariant.group !{{[0-9]+}}
   store i8 42, ptr %ptr, !invariant.group !0
 ; CHECK: 2 = MemoryDef(1)
 ; CHECK-NEXT: call ptr @llvm.launder.invariant.group
@@ -397,7 +397,7 @@ define i8 @unoptimizable2() {
 ; CHECK-NEXT: call void @use(ptr %ptr3)
   call void @use(ptr %ptr3)
 ; CHECK: MemoryUse(7)
-; CHECK-NEXT: %v = load i8, ptr %ptr3, align 1, !invariant.group !0
+; CHECK-NEXT: %v = load i8, ptr %ptr3, align 1, !invariant.group !{{[0-9]+}}
   %v = load i8, ptr %ptr3, !invariant.group !0
   ret i8 %v
 }

--- a/llvm/test/Analysis/MemorySSA/invariant-load-intrinsic.ll
+++ b/llvm/test/Analysis/MemorySSA/invariant-load-intrinsic.ll
@@ -7,7 +7,7 @@ define <4 x i32> @masked_load_invariant(ptr %p, <4 x i1> %mask, <4 x i32> %passt
 ; CHECK: 1 = MemoryDef(liveOnEntry)
 ; CHECK-NEXT: call void @clobber(ptr %p)
 ; CHECK: MemoryUse(liveOnEntry)
-; CHECK-NEXT: %v = call <4 x i32> @llvm.masked.load.v4i32.p0(ptr align 4 %p, <4 x i1> %mask, <4 x i32> %passthru), !invariant.load !0
+; CHECK-NEXT: %v = call <4 x i32> @llvm.masked.load.v4i32.p0(ptr align 4 %p, <4 x i1> %mask, <4 x i32> %passthru), !invariant.load !{{[0-9]+}}
   call void @clobber(ptr %p)
   %v = call <4 x i32> @llvm.masked.load.v4i32.p0(ptr align 4 %p, <4 x i1> %mask, <4 x i32> %passthru), !invariant.load !0
   ret <4 x i32> %v
@@ -29,7 +29,7 @@ define <4 x i32> @masked_gather_invariant(ptr %p, <4 x ptr> %ptrs, <4 x i1> %mas
 ; CHECK: 1 = MemoryDef(liveOnEntry)
 ; CHECK-NEXT: call void @clobber(ptr %p)
 ; CHECK: MemoryUse(liveOnEntry)
-; CHECK-NEXT: %v = call <4 x i32> @llvm.masked.gather.v4i32.v4p0(<4 x ptr> align 4 %ptrs, <4 x i1> %mask, <4 x i32> %passthru), !invariant.load !0
+; CHECK-NEXT: %v = call <4 x i32> @llvm.masked.gather.v4i32.v4p0(<4 x ptr> align 4 %ptrs, <4 x i1> %mask, <4 x i32> %passthru), !invariant.load !{{[0-9]+}}
   call void @clobber(ptr %p)
   %v = call <4 x i32> @llvm.masked.gather.v4i32.v4p0(<4 x ptr> align 4 %ptrs, <4 x i1> %mask, <4 x i32> %passthru), !invariant.load !0
   ret <4 x i32> %v
@@ -40,7 +40,7 @@ define <4 x i32> @masked_expandload_invariant(ptr %p, <4 x i1> %mask, <4 x i32> 
 ; CHECK: 1 = MemoryDef(liveOnEntry)
 ; CHECK-NEXT: call void @clobber(ptr %p)
 ; CHECK: MemoryUse(liveOnEntry)
-; CHECK-NEXT: %v = call <4 x i32> @llvm.masked.expandload.v4i32.p0(ptr %p, <4 x i1> %mask, <4 x i32> %passthru), !invariant.load !0
+; CHECK-NEXT: %v = call <4 x i32> @llvm.masked.expandload.v4i32.p0(ptr %p, <4 x i1> %mask, <4 x i32> %passthru), !invariant.load !{{[0-9]+}}
   call void @clobber(ptr %p)
   %v = call <4 x i32> @llvm.masked.expandload.v4i32.p0(ptr %p, <4 x i1> %mask, <4 x i32> %passthru), !invariant.load !0
   ret <4 x i32> %v
@@ -51,7 +51,7 @@ define <4 x i32> @vp_gather_invariant(ptr %p, <4 x ptr> %ptrs, <4 x i1> %mask, i
 ; CHECK: 1 = MemoryDef(liveOnEntry)
 ; CHECK-NEXT: call void @clobber(ptr %p)
 ; CHECK: MemoryUse(liveOnEntry)
-; CHECK-NEXT: %v = call <4 x i32> @llvm.vp.gather.v4i32.v4p0(<4 x ptr> %ptrs, <4 x i1> %mask, i32 %vl), !invariant.load !0
+; CHECK-NEXT: %v = call <4 x i32> @llvm.vp.gather.v4i32.v4p0(<4 x ptr> %ptrs, <4 x i1> %mask, i32 %vl), !invariant.load !{{[0-9]+}}
   call void @clobber(ptr %p)
   %v = call <4 x i32> @llvm.vp.gather.v4i32.v4p0(<4 x ptr> %ptrs, <4 x i1> %mask, i32 %vl), !invariant.load !0
   ret <4 x i32> %v

--- a/llvm/test/Analysis/ScalarEvolution/cycled_phis.ll
+++ b/llvm/test/Analysis/ScalarEvolution/cycled_phis.ll
@@ -35,13 +35,13 @@ exit:
 define void @test_02(ptr %p, ptr %q) {
 ; CHECK-LABEL: 'test_02'
 ; CHECK-NEXT:  Classifying expressions for: @test_02
-; CHECK-NEXT:    %start = load i32, ptr %p, align 4, !range !0
+; CHECK-NEXT:    %start = load i32, ptr %p, align 4, !range !{{[0-9]+}}
 ; CHECK-NEXT:    --> %start U: [0,1000) S: [0,1000)
 ; CHECK-NEXT:    %outer_phi = phi i32 [ %start, %entry ], [ %inner_lcssa, %outer_backedge ]
 ; CHECK-NEXT:    --> %outer_phi U: full-set S: full-set Exits: <<Unknown>> LoopDispositions: { %outer_loop: Variant, %inner_loop: Invariant }
 ; CHECK-NEXT:    %inner_phi = phi i32 [ %outer_phi, %outer_loop ], [ %inner_load, %inner_loop ]
 ; CHECK-NEXT:    --> %inner_phi U: full-set S: full-set Exits: <<Unknown>> LoopDispositions: { %inner_loop: Variant, %outer_loop: Variant }
-; CHECK-NEXT:    %inner_load = load i32, ptr %q, align 4, !range !1
+; CHECK-NEXT:    %inner_load = load i32, ptr %q, align 4, !range !{{[0-9]+}}
 ; CHECK-NEXT:    --> %inner_load U: [2000,3000) S: [2000,3000) Exits: <<Unknown>> LoopDispositions: { %inner_loop: Variant, %outer_loop: Variant }
 ; CHECK-NEXT:    %inner_cond = call i1 @cond()
 ; CHECK-NEXT:    --> %inner_cond U: full-set S: full-set Exits: <<Unknown>> LoopDispositions: { %inner_loop: Variant, %outer_loop: Variant }
@@ -84,9 +84,9 @@ exit:
 define void @test_03(ptr %p, ptr %q) {
 ; CHECK-LABEL: 'test_03'
 ; CHECK-NEXT:  Classifying expressions for: @test_03
-; CHECK-NEXT:    %start_1 = load i32, ptr %p, align 4, !range !0
+; CHECK-NEXT:    %start_1 = load i32, ptr %p, align 4, !range !{{[0-9]+}}
 ; CHECK-NEXT:    --> %start_1 U: [0,1000) S: [0,1000)
-; CHECK-NEXT:    %start_2 = load i32, ptr %q, align 4, !range !1
+; CHECK-NEXT:    %start_2 = load i32, ptr %q, align 4, !range !{{[0-9]+}}
 ; CHECK-NEXT:    --> %start_2 U: [2000,3000) S: [2000,3000)
 ; CHECK-NEXT:    %outer_phi = phi i32 [ %start_1, %entry ], [ %inner_lcssa, %outer_backedge ]
 ; CHECK-NEXT:    --> %outer_phi U: full-set S: full-set Exits: <<Unknown>> LoopDispositions: { %outer_loop: Variant, %inner_loop: Invariant }

--- a/llvm/test/Analysis/ScalarEvolution/unknown_phis.ll
+++ b/llvm/test/Analysis/ScalarEvolution/unknown_phis.ll
@@ -4,9 +4,9 @@
 define void @merge_values_with_ranges(ptr %a_len_ptr, ptr %b_len_ptr, i1 %unknown_cond) {
 ; CHECK-LABEL: 'merge_values_with_ranges'
 ; CHECK-NEXT:  Classifying expressions for: @merge_values_with_ranges
-; CHECK-NEXT:    %len_a = load i32, ptr %a_len_ptr, align 4, !range !0
+; CHECK-NEXT:    %len_a = load i32, ptr %a_len_ptr, align 4, !range !{{[0-9]+}}
 ; CHECK-NEXT:    --> %len_a U: [0,2147483647) S: [0,2147483647)
-; CHECK-NEXT:    %len_b = load i32, ptr %b_len_ptr, align 4, !range !0
+; CHECK-NEXT:    %len_b = load i32, ptr %b_len_ptr, align 4, !range !{{[0-9]+}}
 ; CHECK-NEXT:    --> %len_b U: [0,2147483647) S: [0,2147483647)
 ; CHECK-NEXT:    %len = phi i32 [ %len_a, %if.true ], [ %len_b, %if.false ]
 ; CHECK-NEXT:    --> %len U: [0,2147483647) S: [0,2147483647)
@@ -34,9 +34,9 @@ define void @merge_values_with_ranges_looped(ptr %a_len_ptr, ptr %b_len_ptr) {
 ;       go into infinite loop analyzing these Phis.
 ; CHECK-LABEL: 'merge_values_with_ranges_looped'
 ; CHECK-NEXT:  Classifying expressions for: @merge_values_with_ranges_looped
-; CHECK-NEXT:    %len_a = load i32, ptr %a_len_ptr, align 4, !range !0
+; CHECK-NEXT:    %len_a = load i32, ptr %a_len_ptr, align 4, !range !{{[0-9]+}}
 ; CHECK-NEXT:    --> %len_a U: [0,2147483647) S: [0,2147483647)
-; CHECK-NEXT:    %len_b = load i32, ptr %b_len_ptr, align 4, !range !0
+; CHECK-NEXT:    %len_b = load i32, ptr %b_len_ptr, align 4, !range !{{[0-9]+}}
 ; CHECK-NEXT:    --> %len_b U: [0,2147483647) S: [0,2147483647)
 ; CHECK-NEXT:    %p1 = phi i32 [ %len_a, %entry ], [ %p2, %loop ]
 ; CHECK-NEXT:    --> %p1 U: [0,-2147483648) S: [0,-2147483648) Exits: <<Unknown>> LoopDispositions: { %loop: Variant }

--- a/llvm/test/Analysis/ScopedNoAliasAA/basic-domains.ll
+++ b/llvm/test/Analysis/ScopedNoAliasAA/basic-domains.ll
@@ -40,16 +40,16 @@ attributes #0 = { nounwind uwtable }
 ; A list of scopes from both domains.
 !0 = !{!1, !3, !4}
 
-; CHECK: NoAlias:   %0 = load float, ptr %c, align 4, !alias.scope !0 <->   store float %0, ptr %arrayidx.i, align 4, !noalias !6
-; CHECK: NoAlias:   %0 = load float, ptr %c, align 4, !alias.scope !0 <->   store float %1, ptr %arrayidx.i2, align 4, !noalias !6
-; CHECK: MayAlias:   %0 = load float, ptr %c, align 4, !alias.scope !0 <->   store float %2, ptr %arrayidx.i3, align 4, !noalias !7
-; CHECK: NoAlias:   %1 = load float, ptr %c, align 4, !alias.scope !7 <->   store float %0, ptr %arrayidx.i, align 4, !noalias !6
-; CHECK: NoAlias:   %1 = load float, ptr %c, align 4, !alias.scope !7 <->   store float %1, ptr %arrayidx.i2, align 4, !noalias !6
-; CHECK: NoAlias:   %1 = load float, ptr %c, align 4, !alias.scope !7 <->   store float %2, ptr %arrayidx.i3, align 4, !noalias !7
-; CHECK: NoAlias:   %2 = load float, ptr %c, align 4, !alias.scope !6 <->   store float %0, ptr %arrayidx.i, align 4, !noalias !6
-; CHECK: NoAlias:   %2 = load float, ptr %c, align 4, !alias.scope !6 <->   store float %1, ptr %arrayidx.i2, align 4, !noalias !6
-; CHECK: MayAlias:   %2 = load float, ptr %c, align 4, !alias.scope !6 <->   store float %2, ptr %arrayidx.i3, align 4, !noalias !7
-; CHECK: NoAlias:   store float %1, ptr %arrayidx.i2, align 4, !noalias !6 <->   store float %0, ptr %arrayidx.i, align 4, !noalias !6
-; CHECK: NoAlias:   store float %2, ptr %arrayidx.i3, align 4, !noalias !7 <->   store float %0, ptr %arrayidx.i, align 4, !noalias !6
-; CHECK: NoAlias:   store float %2, ptr %arrayidx.i3, align 4, !noalias !7 <->   store float %1, ptr %arrayidx.i2, align 4, !noalias !6
+; CHECK: NoAlias:   %0 = load float, ptr %c, align 4, !alias.scope !{{[0-9]+}} <->   store float %0, ptr %arrayidx.i, align 4, !noalias !{{[0-9]+}}
+; CHECK: NoAlias:   %0 = load float, ptr %c, align 4, !alias.scope !{{[0-9]+}} <->   store float %1, ptr %arrayidx.i2, align 4, !noalias !{{[0-9]+}}
+; CHECK: MayAlias:   %0 = load float, ptr %c, align 4, !alias.scope !{{[0-9]+}} <->   store float %2, ptr %arrayidx.i3, align 4, !noalias !{{[0-9]+}}
+; CHECK: NoAlias:   %1 = load float, ptr %c, align 4, !alias.scope !{{[0-9]+}} <->   store float %0, ptr %arrayidx.i, align 4, !noalias !{{[0-9]+}}
+; CHECK: NoAlias:   %1 = load float, ptr %c, align 4, !alias.scope !{{[0-9]+}} <->   store float %1, ptr %arrayidx.i2, align 4, !noalias !{{[0-9]+}}
+; CHECK: NoAlias:   %1 = load float, ptr %c, align 4, !alias.scope !{{[0-9]+}} <->   store float %2, ptr %arrayidx.i3, align 4, !noalias !{{[0-9]+}}
+; CHECK: NoAlias:   %2 = load float, ptr %c, align 4, !alias.scope !{{[0-9]+}} <->   store float %0, ptr %arrayidx.i, align 4, !noalias !{{[0-9]+}}
+; CHECK: NoAlias:   %2 = load float, ptr %c, align 4, !alias.scope !{{[0-9]+}} <->   store float %1, ptr %arrayidx.i2, align 4, !noalias !{{[0-9]+}}
+; CHECK: MayAlias:   %2 = load float, ptr %c, align 4, !alias.scope !{{[0-9]+}} <->   store float %2, ptr %arrayidx.i3, align 4, !noalias !{{[0-9]+}}
+; CHECK: NoAlias:   store float %1, ptr %arrayidx.i2, align 4, !noalias !{{[0-9]+}} <->   store float %0, ptr %arrayidx.i, align 4, !noalias !{{[0-9]+}}
+; CHECK: NoAlias:   store float %2, ptr %arrayidx.i3, align 4, !noalias !{{[0-9]+}} <->   store float %0, ptr %arrayidx.i, align 4, !noalias !{{[0-9]+}}
+; CHECK: NoAlias:   store float %2, ptr %arrayidx.i3, align 4, !noalias !{{[0-9]+}} <->   store float %1, ptr %arrayidx.i2, align 4, !noalias !{{[0-9]+}}
 

--- a/llvm/test/Analysis/ScopedNoAliasAA/basic.ll
+++ b/llvm/test/Analysis/ScopedNoAliasAA/basic.ll
@@ -13,11 +13,11 @@ entry:
   store float %1, ptr %arrayidx, align 4
   ret void
 
-; CHECK: NoAlias:   %0 = load float, ptr %c, align 4, !alias.scope !0 <->   store float %0, ptr %arrayidx.i, align 4, !noalias !0
-; CHECK: MayAlias:   %0 = load float, ptr %c, align 4, !alias.scope !0 <->   store float %1, ptr %arrayidx, align 4
-; CHECK: MayAlias:   %1 = load float, ptr %c, align 4 <->   store float %0, ptr %arrayidx.i, align 4, !noalias !0
+; CHECK: NoAlias:   %0 = load float, ptr %c, align 4, !alias.scope !{{[0-9]+}} <->   store float %0, ptr %arrayidx.i, align 4, !noalias !{{[0-9]+}}
+; CHECK: MayAlias:   %0 = load float, ptr %c, align 4, !alias.scope !{{[0-9]+}} <->   store float %1, ptr %arrayidx, align 4
+; CHECK: MayAlias:   %1 = load float, ptr %c, align 4 <->   store float %0, ptr %arrayidx.i, align 4, !noalias !{{[0-9]+}}
 ; CHECK: MayAlias:   %1 = load float, ptr %c, align 4 <->   store float %1, ptr %arrayidx, align 4
-; CHECK: NoAlias:   store float %1, ptr %arrayidx, align 4 <->   store float %0, ptr %arrayidx.i, align 4, !noalias !0
+; CHECK: NoAlias:   store float %1, ptr %arrayidx, align 4 <->   store float %0, ptr %arrayidx.i, align 4, !noalias !{{[0-9]+}}
 }
 
 attributes #0 = { nounwind uwtable }

--- a/llvm/test/Analysis/ScopedNoAliasAA/basic2.ll
+++ b/llvm/test/Analysis/ScopedNoAliasAA/basic2.ll
@@ -15,19 +15,19 @@ entry:
   store float %1, ptr %arrayidx, align 4
   ret void
 
-; CHECK: MayAlias:   %0 = load float, ptr %c, align 4, !alias.scope !0 <->   store float %0, ptr %arrayidx.i, align 4, !alias.scope !4, !noalia
-; CHECK: s !5
-; CHECK: MayAlias:   %0 = load float, ptr %c, align 4, !alias.scope !0 <->   store float %0, ptr %arrayidx1.i, align 4, !alias.scope !0, !noali
-; CHECK: as !4
-; CHECK: MayAlias:   %0 = load float, ptr %c, align 4, !alias.scope !0 <->   store float %1, ptr %arrayidx, align 4
-; CHECK: MayAlias:   %1 = load float, ptr %c, align 4 <->   store float %0, ptr %arrayidx.i, align 4, !alias.scope !4, !noalias !5
-; CHECK: MayAlias:   %1 = load float, ptr %c, align 4 <->   store float %0, ptr %arrayidx1.i, align 4, !alias.scope !0, !noalias !4
+; CHECK: MayAlias:   %0 = load float, ptr %c, align 4, !alias.scope !{{[0-9]+}} <->   store float %0, ptr %arrayidx.i, align 4, !alias.scope !{{[0-9]+}}, !noalia
+; CHECK: s !{{[0-9]+}}
+; CHECK: MayAlias:   %0 = load float, ptr %c, align 4, !alias.scope !{{[0-9]+}} <->   store float %0, ptr %arrayidx1.i, align 4, !alias.scope !{{[0-9]+}}, !noali
+; CHECK: as !{{[0-9]+}}
+; CHECK: MayAlias:   %0 = load float, ptr %c, align 4, !alias.scope !{{[0-9]+}} <->   store float %1, ptr %arrayidx, align 4
+; CHECK: MayAlias:   %1 = load float, ptr %c, align 4 <->   store float %0, ptr %arrayidx.i, align 4, !alias.scope !{{[0-9]+}}, !noalias !{{[0-9]+}}
+; CHECK: MayAlias:   %1 = load float, ptr %c, align 4 <->   store float %0, ptr %arrayidx1.i, align 4, !alias.scope !{{[0-9]+}}, !noalias !{{[0-9]+}}
 ; CHECK: MayAlias:   %1 = load float, ptr %c, align 4 <->   store float %1, ptr %arrayidx, align 4
-; CHECK: NoAlias:   store float %0, ptr %arrayidx1.i, align 4, !alias.scope !0, !noalias !4 <->   store float %0, ptr %arrayidx.i, align
-; CHECK: 4, !alias.scope !4, !noalias !5
-; CHECK: NoAlias:   store float %1, ptr %arrayidx, align 4 <->   store float %0, ptr %arrayidx.i, align 4, !alias.scope !4, !noalias !5
-; CHECK: MayAlias:   store float %1, ptr %arrayidx, align 4 <->   store float %0, ptr %arrayidx1.i, align 4, !alias.scope !0, !noalias !
-; CHECK: 4
+; CHECK: NoAlias:   store float %0, ptr %arrayidx1.i, align 4, !alias.scope !{{[0-9]+}}, !noalias !{{[0-9]+}} <->   store float %0, ptr %arrayidx.i, align
+; CHECK: 4, !alias.scope !{{[0-9]+}}, !noalias !{{[0-9]+}}
+; CHECK: NoAlias:   store float %1, ptr %arrayidx, align 4 <->   store float %0, ptr %arrayidx.i, align 4, !alias.scope !{{[0-9]+}}, !noalias !{{[0-9]+}}
+; CHECK: MayAlias:   store float %1, ptr %arrayidx, align 4 <->   store float %0, ptr %arrayidx1.i, align 4, !alias.scope !{{[0-9]+}}, !noalias !
+; CHECK: {{[0-9]+}}
 }
 
 attributes #0 = { nounwind uwtable }

--- a/llvm/test/Analysis/TypeBasedAliasAnalysis/placement-tbaa.ll
+++ b/llvm/test/Analysis/TypeBasedAliasAnalysis/placement-tbaa.ll
@@ -18,7 +18,7 @@
 
 ; Basic AA says MayAlias, TBAA says NoAlias
 ; CHECK: MayAlias: ptr* %5, i64* %9
-; CHECK: NoAlias: store i64 %conv, ptr %9, align 8, !tbaa !6 <->   store ptr null, ptr %5, align 8, !tbaa !9
+; CHECK: NoAlias: store i64 %conv, ptr %9, align 8, !tbaa !{{[0-9]+}} <->   store ptr null, ptr %5, align 8, !tbaa !{{[0-9]+}}
 
 %struct.Foo = type { i64 }
 %struct.Bar = type { ptr }

--- a/llvm/test/Analysis/TypeBasedAliasAnalysis/tbaa-path.ll
+++ b/llvm/test/Analysis/TypeBasedAliasAnalysis/tbaa-path.ll
@@ -13,7 +13,7 @@ define i32 @_Z1gPjP7StructAy(ptr %s, ptr %A, i64 %count) {
 entry:
 ; Access to ptr and &(A->f32).
 ; CHECK: Function
-; CHECK: MayAlias:   store i32 4, ptr %f32, align 4, !tbaa !8 <->   store i32 1, ptr %0, align 4, !tbaa !6
+; CHECK: MayAlias:   store i32 4, ptr %f32, align 4, !tbaa !{{[0-9]+}} <->   store i32 1, ptr %0, align 4, !tbaa !{{[0-9]+}}
 ; OPT: define
 ; OPT: store i32 1
 ; OPT: store i32 4
@@ -39,7 +39,7 @@ define i32 @_Z2g2PjP7StructAy(ptr %s, ptr %A, i64 %count) {
 entry:
 ; Access to ptr and &(A->f16).
 ; CHECK: Function
-; CHECK: NoAlias:   store i16 4, ptr %1, align 2, !tbaa !8 <->   store i32 1, ptr %0, align 4, !tbaa !6
+; CHECK: NoAlias:   store i16 4, ptr %1, align 2, !tbaa !{{[0-9]+}} <->   store i32 1, ptr %0, align 4, !tbaa !{{[0-9]+}}
 ; OPT: define
 ; OPT: store i32 1
 ; OPT: store i16 4
@@ -64,7 +64,7 @@ define i32 @_Z2g3P7StructAP7StructBy(ptr %A, ptr %B, i64 %count) {
 entry:
 ; Access to &(A->f32) and &(B->a.f32).
 ; CHECK: Function
-; CHECK: MayAlias:   store i32 4, ptr %f321, align 4, !tbaa !10 <->   store i32 1, ptr %f32, align 4, !tbaa !6
+; CHECK: MayAlias:   store i32 4, ptr %f321, align 4, !tbaa !{{[0-9]+}} <->   store i32 1, ptr %f32, align 4, !tbaa !{{[0-9]+}}
 ; OPT: define
 ; OPT: store i32 1
 ; OPT: store i32 4
@@ -93,7 +93,7 @@ define i32 @_Z2g4P7StructAP7StructBy(ptr %A, ptr %B, i64 %count) {
 entry:
 ; Access to &(A->f32) and &(B->a.f16).
 ; CHECK: Function
-; CHECK: NoAlias:   store i16 4, ptr %a, align 2, !tbaa !10 <->   store i32 1, ptr %f32, align 4, !tbaa !6
+; CHECK: NoAlias:   store i16 4, ptr %a, align 2, !tbaa !{{[0-9]+}} <->   store i32 1, ptr %f32, align 4, !tbaa !{{[0-9]+}}
 ; OPT: define
 ; OPT: store i32 1
 ; OPT: store i16 4
@@ -121,7 +121,7 @@ define i32 @_Z2g5P7StructAP7StructBy(ptr %A, ptr %B, i64 %count) {
 entry:
 ; Access to &(A->f32) and &(B->f32).
 ; CHECK: Function
-; CHECK: NoAlias:   store i32 4, ptr %f321, align 4, !tbaa !10 <->   store i32 1, ptr %f32, align 4, !tbaa !6
+; CHECK: NoAlias:   store i32 4, ptr %f321, align 4, !tbaa !{{[0-9]+}} <->   store i32 1, ptr %f32, align 4, !tbaa !{{[0-9]+}}
 ; OPT: define
 ; OPT: store i32 1
 ; OPT: store i32 4
@@ -149,7 +149,7 @@ define i32 @_Z2g6P7StructAP7StructBy(ptr %A, ptr %B, i64 %count) {
 entry:
 ; Access to &(A->f32) and &(B->a.f32_2).
 ; CHECK: Function
-; CHECK: NoAlias:   store i32 4, ptr %f32_2, align 4, !tbaa !10 <->   store i32 1, ptr %f32, align 4, !tbaa !6
+; CHECK: NoAlias:   store i32 4, ptr %f32_2, align 4, !tbaa !{{[0-9]+}} <->   store i32 1, ptr %f32, align 4, !tbaa !{{[0-9]+}}
 ; OPT: define
 ; OPT: store i32 1
 ; OPT: store i32 4
@@ -178,7 +178,7 @@ define i32 @_Z2g7P7StructAP7StructSy(ptr %A, ptr %S, i64 %count) {
 entry:
 ; Access to &(A->f32) and &(S->f32).
 ; CHECK: Function
-; CHECK: NoAlias:   store i32 4, ptr %f321, align 4, !tbaa !10 <->   store i32 1, ptr %f32, align 4, !tbaa !6
+; CHECK: NoAlias:   store i32 4, ptr %f321, align 4, !tbaa !{{[0-9]+}} <->   store i32 1, ptr %f32, align 4, !tbaa !{{[0-9]+}}
 ; OPT: define
 ; OPT: store i32 1
 ; OPT: store i32 4
@@ -206,7 +206,7 @@ define i32 @_Z2g8P7StructAP7StructSy(ptr %A, ptr %S, i64 %count) {
 entry:
 ; Access to &(A->f32) and &(S->f16).
 ; CHECK: Function
-; CHECK: NoAlias:   store i16 4, ptr %1, align 2, !tbaa !10 <->   store i32 1, ptr %f32, align 4, !tbaa !6
+; CHECK: NoAlias:   store i16 4, ptr %1, align 2, !tbaa !{{[0-9]+}} <->   store i32 1, ptr %f32, align 4, !tbaa !{{[0-9]+}}
 ; OPT: define
 ; OPT: store i32 1
 ; OPT: store i16 4
@@ -233,7 +233,7 @@ define i32 @_Z2g9P7StructSP8StructS2y(ptr %S, ptr %S2, i64 %count) {
 entry:
 ; Access to &(S->f32) and &(S2->f32).
 ; CHECK: Function
-; CHECK: NoAlias:   store i32 4, ptr %f321, align 4, !tbaa !10 <->   store i32 1, ptr %f32, align 4, !tbaa !6
+; CHECK: NoAlias:   store i32 4, ptr %f321, align 4, !tbaa !{{[0-9]+}} <->   store i32 1, ptr %f32, align 4, !tbaa !{{[0-9]+}}
 ; OPT: define
 ; OPT: store i32 1
 ; OPT: store i32 4
@@ -261,7 +261,7 @@ define i32 @_Z3g10P7StructSP8StructS2y(ptr %S, ptr %S2, i64 %count) {
 entry:
 ; Access to &(S->f32) and &(S2->f16).
 ; CHECK: Function
-; CHECK: NoAlias:   store i16 4, ptr %1, align 2, !tbaa !10 <->   store i32 1, ptr %f32, align 4, !tbaa !6
+; CHECK: NoAlias:   store i16 4, ptr %1, align 2, !tbaa !{{[0-9]+}} <->   store i32 1, ptr %f32, align 4, !tbaa !{{[0-9]+}}
 ; OPT: define
 ; OPT: store i32 1
 ; OPT: store i16 4
@@ -288,7 +288,7 @@ define i32 @_Z3g11P7StructCP7StructDy(ptr %C, ptr %D, i64 %count) {
 entry:
 ; Access to &(C->b.a.f32) and &(D->b.a.f32).
 ; CHECK: Function
-; CHECK: NoAlias:   store i32 4, ptr %f323, align 4, !tbaa !12 <->   store i32 1, ptr %f32, align 4, !tbaa !6
+; CHECK: NoAlias:   store i32 4, ptr %f323, align 4, !tbaa !{{[0-9]+}} <->   store i32 1, ptr %f32, align 4, !tbaa !{{[0-9]+}}
 ; OPT: define
 ; OPT: store i32 1
 ; OPT: store i32 4
@@ -322,7 +322,7 @@ define i32 @_Z3g12P7StructCP7StructDy(ptr %C, ptr %D, i64 %count) {
 entry:
 ; Access to &(b1->a.f32) and &(b2->a.f32).
 ; CHECK: Function
-; CHECK: MayAlias:   store i32 4, ptr %f325, align 4, !tbaa !6 <->   store i32 1, ptr %f32, align 4, !tbaa !6
+; CHECK: MayAlias:   store i32 4, ptr %f325, align 4, !tbaa !{{[0-9]+}} <->   store i32 1, ptr %f32, align 4, !tbaa !{{[0-9]+}}
 ; OPT: define
 ; OPT: store i32 1
 ; OPT: store i32 4

--- a/llvm/test/Analysis/ValueTracking/memory-dereferenceable.ll
+++ b/llvm/test/Analysis/ValueTracking/memory-dereferenceable.ll
@@ -230,8 +230,8 @@ define void @byval(ptr byval(i8) %i8_byval,
 }
 
 ; CHECK-LABEL: 'f_0'
-; GLOBAL: %ptr = inttoptr i32 %val to ptr, !dereferenceable !0
-; POINT-NOT: %ptr = inttoptr i32 %val to ptr, !dereferenceable !0
+; GLOBAL: %ptr = inttoptr i32 %val to ptr, !dereferenceable !{{[0-9]+}}
+; POINT-NOT: %ptr = inttoptr i32 %val to ptr, !dereferenceable !{{[0-9]+}}
 define i32 @f_0(i32 %val) {
   %ptr = inttoptr i32 %val to ptr, !dereferenceable !0
   call void @mayfree()

--- a/llvm/test/CodeGen/AArch64/GlobalISel/irtranslator-dilocation.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/irtranslator-dilocation.ll
@@ -7,10 +7,10 @@
 ; CHECK: Checking DILocation from   %rv = alloca i32, align 4{{.*}} was copied to G_FRAME_INDEX
 ; CHECK: Checking DILocation from   store i32 0, ptr %retval, align 4{{.*}} was copied to G_CONSTANT
 ; CHECK: Checking DILocation from   store i32 0, ptr %retval, align 4{{.*}} was copied to G_STORE
-; CHECK: Checking DILocation from   store i32 0, ptr %rv, align 4, !dbg !12{{.*}} was copied to G_STORE debug-location !12; t.cpp:2:5
-; CHECK: Checking DILocation from   %0 = load i32, ptr %rv, align 4, !dbg !13{{.*}} was copied to G_LOAD debug-location !13; t.cpp:3:8
-; CHECK: Checking DILocation from   ret i32 %0, !dbg !14{{.*}} was copied to COPY debug-location !14; t.cpp:3:1
-; CHECK: Checking DILocation from   ret i32 %0, !dbg !14{{.*}} was copied to RET_ReallyLR implicit $w0, debug-location !14; t.cpp:3:1
+; CHECK: Checking DILocation from   store i32 0, ptr %rv, align 4, !dbg ![[STORE_LOC:[0-9]+]]{{.*}} was copied to G_STORE debug-location ![[STORE_LOC]]; t.cpp:2:5
+; CHECK: Checking DILocation from   %0 = load i32, ptr %rv, align 4, !dbg ![[LOAD_LOC:[0-9]+]]{{.*}} was copied to G_LOAD debug-location ![[LOAD_LOC]]; t.cpp:3:8
+; CHECK: Checking DILocation from   ret i32 %0, !dbg ![[RET_LOC:[0-9]+]]{{.*}} was copied to COPY debug-location ![[RET_LOC]]; t.cpp:3:1
+; CHECK: Checking DILocation from   ret i32 %0, !dbg ![[RET_LOC]]{{.*}} was copied to RET_ReallyLR implicit $w0, debug-location ![[RET_LOC]]; t.cpp:3:1
 
 source_filename = "t.cpp"
 target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"

--- a/llvm/test/CodeGen/SPIRV/passes/translate-aggregate-uaddo.ll
+++ b/llvm/test/CodeGen/SPIRV/passes/translate-aggregate-uaddo.ll
@@ -14,9 +14,9 @@
 ; CHECK-IR: %math = extractvalue { i32, i1 } %[[R1]], 0
 ; CHECK-IR: %ov = extractvalue { i32, i1 } %[[R1]], 1
 ; Type/Name attributes of the value.
-; CHECK-IR: ![[#MD1]] = !{{[{]}}![[#MD2:]], !""{{[}]}}
+; CHECK-IR-DAG: ![[#MD1]] = !{{[{]}}![[#MD2:]], !""{{[}]}}
 ; Origin data type of the value.
-; CHECK-IR: ![[#MD2]] = !{{[{]}}{{[{]}} i32, i1 {{[}]}} poison{{[}]}}
+; CHECK-IR-DAG: ![[#MD2]] = !{{[{]}}{{[{]}} i32, i1 {{[}]}} poison{{[}]}}
 
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -print-after=irtranslator 2>&1 | FileCheck %s  --check-prefix=CHECK-GMIR
 ; Required info succeeded to get through IRTranslator.

--- a/llvm/test/DebugInfo/Generic/debug-label-mi.ll
+++ b/llvm/test/DebugInfo/Generic/debug-label-mi.ll
@@ -7,8 +7,8 @@
 ; RUN: llc -debug-only=isel %s -o /dev/null 2> %t.debug
 ; RUN: cat %t.debug | FileCheck %s --check-prefix=CHECKMI
 ;
-; CHECKMI: DBG_LABEL "top", debug-location !9
-; CHECKMI: DBG_LABEL "done", debug-location !11
+; CHECKMI: DBG_LABEL "top", debug-location !{{[0-9]+}}
+; CHECKMI: DBG_LABEL "done", debug-location !{{[0-9]+}}
 ;
 ; RUN: llc %s -o - | FileCheck %s --check-prefix=CHECKASM
 ;

--- a/llvm/test/DebugInfo/Generic/debug-label-opt.ll
+++ b/llvm/test/DebugInfo/Generic/debug-label-opt.ll
@@ -4,8 +4,8 @@
 ; RUN: llc -debug-only=isel %s -o /dev/null 2> %t.debug
 ; RUN: cat %t.debug | FileCheck %s --check-prefix=CHECKMI
 ;
-; CHECKMI: DBG_LABEL "end_sum", debug-location !17
-; CHECKMI: DBG_LABEL "end", debug-location !19
+; CHECKMI: DBG_LABEL "end_sum", debug-location !{{[0-9]+}}
+; CHECKMI: DBG_LABEL "end", debug-location !{{[0-9]+}}
 source_filename = "debug-label-opt.c"
 
 define i32 @foo(ptr nocapture readonly %a, i32 %n) local_unnamed_addr !dbg !7 {

--- a/llvm/test/DebugInfo/Generic/invalid.ll
+++ b/llvm/test/DebugInfo/Generic/invalid.ll
@@ -3,9 +3,9 @@
 ; Make sure we emit this diagnostic only once (which means we don't visit the
 ; same DISubprogram twice.
 ; CHECK: subprogram definitions must have a compile unit
-; CHECK-NEXT: !3 = distinct !DISubprogram(name: "patatino", scope: null, type: !4, spFlags: DISPFlagDefinition)
+; CHECK-NEXT: !{{[0-9]+}} = distinct !DISubprogram(name: "patatino", scope: null, type: !{{[0-9]+}}, spFlags: DISPFlagDefinition)
 ; CHECK-NOT: subprogram definitions must have a compile unit
-; CHECK-NOT: !3 = distinct !DISubprogram(name: "patatino", scope: null, type: !4, spFlags: DISPFlagDefinition)
+; CHECK-NOT: !{{[0-9]+}} = distinct !DISubprogram(name: "patatino", scope: null, type: !{{[0-9]+}}, spFlags: DISPFlagDefinition)
 ; CHECK: warning: ignoring invalid debug info
 
 define void @tinkywinky() !dbg !3 { ret void }

--- a/llvm/test/DebugInfo/X86/machinecse-wrongdebug-hoist.ll
+++ b/llvm/test/DebugInfo/X86/machinecse-wrongdebug-hoist.ll
@@ -1,8 +1,8 @@
 ; RUN: llc %s -o - -print-after=machine-cse -mtriple=x86_64-- 2>&1 | FileCheck %s --match-full-lines
 
-; CHECK: %5:gr32 = SUB32ri %0:gr32(tied-def 0), 1, implicit-def $eflags, debug-location !24; a.c:3:13
+; CHECK: %5:gr32 = SUB32ri %0:gr32(tied-def 0), 1, implicit-def $eflags, debug-location !{{[0-9]+}}; a.c:3:13
 ; CHECK-NEXT: %10:gr32 = MOVSX32rr8 %4:gr8
-; CHECK-NEXT: JCC_1 %bb.2, 15, implicit $eflags, debug-location !25; a.c:3:18
+; CHECK-NEXT: JCC_1 %bb.2, 15, implicit $eflags, debug-location !{{[0-9]+}}; a.c:3:18
 
 target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-apple-macosx10.15.0"

--- a/llvm/test/SafepointIRVerifier/unrecorded-live-at-sp.ll
+++ b/llvm/test/SafepointIRVerifier/unrecorded-live-at-sp.ll
@@ -1,7 +1,7 @@
 ; RUN: opt %s -safepoint-ir-verifier-print-only -verify-safepoint-ir -S 2>&1 | FileCheck %s
 
 ; CHECK:      Illegal use of unrelocated value found!
-; CHECK-NEXT: Def:   %base_phi4 = phi ptr addrspace(1) [ %addr98.relocated, %not_zero146 ], [ %base_phi2, %bci_37-aload ], !is_base_value !0
+; CHECK-NEXT: Def:   %base_phi4 = phi ptr addrspace(1) [ %addr98.relocated, %not_zero146 ], [ %base_phi2, %bci_37-aload ], !is_base_value !{{[0-9]+}}
 ; CHECK-NEXT: Use:   %safepoint_token = tail call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 0, i32 0, ptr elementtype(i32 ()) undef, i32 0, i32 0, i32 0, i32 0) [ "gc-live"(ptr addrspace(1) %base_phi1, ptr addrspace(1) %base_phi4, ptr addrspace(1) %relocated4, ptr addrspace(1) %relocated7) ]
 
 

--- a/llvm/test/Transforms/IRCE/only-lower-check.ll
+++ b/llvm/test/Transforms/IRCE/only-lower-check.ll
@@ -4,7 +4,7 @@
 ; CHECK: irce: loop has 1 inductive range checks:
 ; CHECK-NEXT: InductiveRangeCheck:
 ; CHECK-NEXT:   Begin: (-1 + %n)  Step: -1  End: 2147483647
-; CHECK-NEXT:   CheckUse:   br i1 %abc, label %in.bounds, label %out.of.bounds, !prof !1 Operand: 0
+; CHECK-NEXT:   CheckUse:   br i1 %abc, label %in.bounds, label %out.of.bounds, !prof !{{[0-9]+}} Operand: 0
 ; CHECK-NEXT: irce: in function only_lower_check: constrained Loop at depth 1 containing: %loop<header><exiting>,%in.bounds<latch><exiting>
 
 define void @only_lower_check(ptr %arr, ptr %a_len_ptr, i32 %n) {

--- a/llvm/test/Transforms/IRCE/only-upper-check.ll
+++ b/llvm/test/Transforms/IRCE/only-upper-check.ll
@@ -4,7 +4,7 @@
 ; CHECK: irce: loop has 1 inductive range checks:
 ; CHECK-NEXT:InductiveRangeCheck:
 ; CHECK-NEXT:  Begin: %offset  Step: 1  End:   %len
-; CHECK-NEXT:  CheckUse:   br i1 %abc, label %in.bounds, label %out.of.bounds, !prof !1 Operand: 0
+; CHECK-NEXT:  CheckUse:   br i1 %abc, label %in.bounds, label %out.of.bounds, !prof !{{[0-9]+}} Operand: 0
 ; CHECK-NEXT: irce: in function incrementing: constrained Loop at depth 1 containing: %loop<header><exiting>,%in.bounds<latch><exiting>
 
 define void @incrementing(ptr %arr, ptr %a_len_ptr, i32 %n, i32 %offset) {

--- a/llvm/test/Transforms/LoopVectorize/VPlan/vplan-printing-metadata.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/vplan-printing-metadata.ll
@@ -23,13 +23,13 @@ define void @test_widen_metadata(ptr noalias %A, ptr noalias %B, i32 %n) {
 ; CHECK-NEXT:      vp<[[VP4:%[0-9]+]]> = SCALAR-STEPS vp<[[VP3]]>, ir<1>, vp<[[VP0]]>
 ; CHECK-NEXT:      CLONE ir<%gep.A> = getelementptr inbounds ir<%A>, vp<[[VP4]]>
 ; CHECK-NEXT:      vp<[[VP5:%[0-9]+]]> = vector-pointer inbounds i32, ir<%gep.A>, ir<1>
-; CHECK-NEXT:      WIDEN ir<%lv> = load vp<[[VP5]]> (!tbaa !0)
-; CHECK-NEXT:      WIDEN-CAST ir<%conv> = sitofp ir<%lv> to float (!fpmath !4)
-; CHECK-NEXT:      WIDEN ir<%mul> = fmul ir<%conv>, ir<2.000000e+00> (!fpmath !4)
+; CHECK-NEXT:      WIDEN ir<%lv> = load vp<[[VP5]]> (!tbaa !{{[0-9]+}})
+; CHECK-NEXT:      WIDEN-CAST ir<%conv> = sitofp ir<%lv> to float (!fpmath !{{[0-9]+}})
+; CHECK-NEXT:      WIDEN ir<%mul> = fmul ir<%conv>, ir<2.000000e+00> (!fpmath !{{[0-9]+}})
 ; CHECK-NEXT:      WIDEN-CAST ir<%conv.back> = fptosi ir<%mul> to i32
 ; CHECK-NEXT:      CLONE ir<%gep.B> = getelementptr inbounds ir<%B>, vp<[[VP4]]>
 ; CHECK-NEXT:      vp<[[VP6:%[0-9]+]]> = vector-pointer inbounds i32, ir<%gep.B>, ir<1>
-; CHECK-NEXT:      WIDEN store vp<[[VP6]]>, ir<%conv.back> (!tbaa !0)
+; CHECK-NEXT:      WIDEN store vp<[[VP6]]>, ir<%conv.back> (!tbaa !{{[0-9]+}})
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2]]>
 ; CHECK-NEXT:    No successors
@@ -51,12 +51,12 @@ define void @test_widen_metadata(ptr noalias %A, ptr noalias %B, i32 %n) {
 ; CHECK-NEXT:  ir-bb<loop>:
 ; CHECK-NEXT:    IR   %i = phi i32 [ 0, %entry ], [ %i.next, %loop ] (extra operand: vp<%bc.resume.val> from scalar.ph)
 ; CHECK-NEXT:    IR   %gep.A = getelementptr inbounds i32, ptr %A, i32 %i
-; CHECK-NEXT:    IR   %lv = load i32, ptr %gep.A, align 4, !tbaa !0, !range !3
-; CHECK-NEXT:    IR   %conv = sitofp i32 %lv to float, !fpmath !4
-; CHECK-NEXT:    IR   %mul = fmul float %conv, 2.000000e+00, !fpmath !4
+; CHECK-NEXT:    IR   %lv = load i32, ptr %gep.A, align 4, !tbaa !{{[0-9]+}}, !range !{{[0-9]+}}
+; CHECK-NEXT:    IR   %conv = sitofp i32 %lv to float, !fpmath !{{[0-9]+}}
+; CHECK-NEXT:    IR   %mul = fmul float %conv, 2.000000e+00, !fpmath !{{[0-9]+}}
 ; CHECK-NEXT:    IR   %conv.back = fptosi float %mul to i32
 ; CHECK-NEXT:    IR   %gep.B = getelementptr inbounds i32, ptr %B, i32 %i
-; CHECK-NEXT:    IR   store i32 %conv.back, ptr %gep.B, align 4, !tbaa !0
+; CHECK-NEXT:    IR   store i32 %conv.back, ptr %gep.B, align 4, !tbaa !{{[0-9]+}}
 ; CHECK-NEXT:    IR   %i.next = add i32 %i, 1
 ; CHECK-NEXT:    IR   %cond = icmp eq i32 %i.next, %n
 ; CHECK-NEXT:  No successors
@@ -104,11 +104,11 @@ define void @test_intrinsic_with_metadata(ptr noalias %A, ptr noalias %B, i32 %n
 ; CHECK-NEXT:      vp<[[VP4:%[0-9]+]]> = SCALAR-STEPS vp<[[VP3]]>, ir<1>, vp<[[VP0]]>
 ; CHECK-NEXT:      CLONE ir<%gep.A> = getelementptr inbounds ir<%A>, vp<[[VP4]]>
 ; CHECK-NEXT:      vp<[[VP5:%[0-9]+]]> = vector-pointer inbounds float, ir<%gep.A>, ir<1>
-; CHECK-NEXT:      WIDEN ir<%lv> = load vp<[[VP5]]> (!tbaa !0)
-; CHECK-NEXT:      WIDEN-INTRINSIC ir<%sqrt> = call llvm.sqrt(ir<%lv>) (!fpmath !3)
+; CHECK-NEXT:      WIDEN ir<%lv> = load vp<[[VP5]]> (!tbaa !{{[0-9]+}})
+; CHECK-NEXT:      WIDEN-INTRINSIC ir<%sqrt> = call llvm.sqrt(ir<%lv>) (!fpmath !{{[0-9]+}})
 ; CHECK-NEXT:      CLONE ir<%gep.B> = getelementptr inbounds ir<%B>, vp<[[VP4]]>
 ; CHECK-NEXT:      vp<[[VP6:%[0-9]+]]> = vector-pointer inbounds float, ir<%gep.B>, ir<1>
-; CHECK-NEXT:      WIDEN store vp<[[VP6]]>, ir<%sqrt> (!tbaa !0)
+; CHECK-NEXT:      WIDEN store vp<[[VP6]]>, ir<%sqrt> (!tbaa !{{[0-9]+}})
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2]]>
 ; CHECK-NEXT:    No successors
@@ -130,10 +130,10 @@ define void @test_intrinsic_with_metadata(ptr noalias %A, ptr noalias %B, i32 %n
 ; CHECK-NEXT:  ir-bb<loop>:
 ; CHECK-NEXT:    IR   %i = phi i32 [ 0, %entry ], [ %i.next, %loop ] (extra operand: vp<%bc.resume.val> from scalar.ph)
 ; CHECK-NEXT:    IR   %gep.A = getelementptr inbounds float, ptr %A, i32 %i
-; CHECK-NEXT:    IR   %lv = load float, ptr %gep.A, align 4, !tbaa !0
-; CHECK-NEXT:    IR   %sqrt = call float @llvm.sqrt.f32(float %lv), !fpmath !3
+; CHECK-NEXT:    IR   %lv = load float, ptr %gep.A, align 4, !tbaa !{{[0-9]+}}
+; CHECK-NEXT:    IR   %sqrt = call float @llvm.sqrt.f32(float %lv), !fpmath !{{[0-9]+}}
 ; CHECK-NEXT:    IR   %gep.B = getelementptr inbounds float, ptr %B, i32 %i
-; CHECK-NEXT:    IR   store float %sqrt, ptr %gep.B, align 4, !tbaa !0
+; CHECK-NEXT:    IR   store float %sqrt, ptr %gep.B, align 4, !tbaa !{{[0-9]+}}
 ; CHECK-NEXT:    IR   %i.next = add i32 %i, 1
 ; CHECK-NEXT:    IR   %cond = icmp eq i32 %i.next, %n
 ; CHECK-NEXT:  No successors
@@ -178,13 +178,13 @@ define void @test_widen_with_multiple_metadata(ptr noalias %A, ptr noalias %B, i
 ; CHECK-NEXT:      vp<[[VP4:%[0-9]+]]> = SCALAR-STEPS vp<[[VP3]]>, ir<1>, vp<[[VP0]]>
 ; CHECK-NEXT:      CLONE ir<%gep.A> = getelementptr inbounds ir<%A>, vp<[[VP4]]>
 ; CHECK-NEXT:      vp<[[VP5:%[0-9]+]]> = vector-pointer inbounds i32, ir<%gep.A>, ir<1>
-; CHECK-NEXT:      WIDEN ir<%lv> = load vp<[[VP5]]> (!tbaa !0)
+; CHECK-NEXT:      WIDEN ir<%lv> = load vp<[[VP5]]> (!tbaa !{{[0-9]+}})
 ; CHECK-NEXT:      WIDEN-CAST ir<%conv> = sitofp ir<%lv> to float
 ; CHECK-NEXT:      WIDEN ir<%mul> = fmul ir<%conv>, ir<2.000000e+00>
 ; CHECK-NEXT:      WIDEN-CAST ir<%conv.back> = fptosi ir<%mul> to i32
 ; CHECK-NEXT:      CLONE ir<%gep.B> = getelementptr inbounds ir<%B>, vp<[[VP4]]>
 ; CHECK-NEXT:      vp<[[VP6:%[0-9]+]]> = vector-pointer inbounds i32, ir<%gep.B>, ir<1>
-; CHECK-NEXT:      WIDEN store vp<[[VP6]]>, ir<%conv.back> (!tbaa !0)
+; CHECK-NEXT:      WIDEN store vp<[[VP6]]>, ir<%conv.back> (!tbaa !{{[0-9]+}})
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2]]>
 ; CHECK-NEXT:    No successors
@@ -206,12 +206,12 @@ define void @test_widen_with_multiple_metadata(ptr noalias %A, ptr noalias %B, i
 ; CHECK-NEXT:  ir-bb<loop>:
 ; CHECK-NEXT:    IR   %i = phi i32 [ 0, %entry ], [ %i.next, %loop ] (extra operand: vp<%bc.resume.val> from scalar.ph)
 ; CHECK-NEXT:    IR   %gep.A = getelementptr inbounds i32, ptr %A, i32 %i
-; CHECK-NEXT:    IR   %lv = load i32, ptr %gep.A, align 4, !tbaa !0, !range !3
+; CHECK-NEXT:    IR   %lv = load i32, ptr %gep.A, align 4, !tbaa !{{[0-9]+}}, !range !{{[0-9]+}}
 ; CHECK-NEXT:    IR   %conv = sitofp i32 %lv to float
 ; CHECK-NEXT:    IR   %mul = fmul float %conv, 2.000000e+00
 ; CHECK-NEXT:    IR   %conv.back = fptosi float %mul to i32
 ; CHECK-NEXT:    IR   %gep.B = getelementptr inbounds i32, ptr %B, i32 %i
-; CHECK-NEXT:    IR   store i32 %conv.back, ptr %gep.B, align 4, !tbaa !0
+; CHECK-NEXT:    IR   store i32 %conv.back, ptr %gep.B, align 4, !tbaa !{{[0-9]+}}
 ; CHECK-NEXT:    IR   %i.next = add i32 %i, 1
 ; CHECK-NEXT:    IR   %cond = icmp eq i32 %i.next, %n
 ; CHECK-NEXT:  No successors

--- a/llvm/test/Transforms/LoopVectorize/VPlan/vplan-printing.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/vplan-printing.ll
@@ -435,10 +435,10 @@ define void @recipe_debug_loc_location(ptr nocapture %src) !dbg !5 {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  ir-bb<loop>:
 ; CHECK-NEXT:    IR   %iv = phi i64 [ 0, %entry ], [ %iv.next, %if.end ] (extra operand: vp<%bc.resume.val> from scalar.ph)
-; CHECK-NEXT:    IR   %isd = getelementptr inbounds i32, ptr %src, i64 %iv, !dbg !7
-; CHECK-NEXT:    IR   %lsd = load i32, ptr %isd, align 4, !dbg !8
-; CHECK-NEXT:    IR   %psd = add nuw nsw i32 %lsd, 23, !dbg !9
-; CHECK-NEXT:    IR   %cmp1 = icmp slt i32 %lsd, 100, !dbg !10
+; CHECK-NEXT:    IR   %isd = getelementptr inbounds i32, ptr %src, i64 %iv, !dbg !{{[0-9]+}}
+; CHECK-NEXT:    IR   %lsd = load i32, ptr %isd, align 4, !dbg !{{[0-9]+}}
+; CHECK-NEXT:    IR   %psd = add nuw nsw i32 %lsd, 23, !dbg !{{[0-9]+}}
+; CHECK-NEXT:    IR   %cmp1 = icmp slt i32 %lsd, 100, !dbg !{{[0-9]+}}
 ; CHECK-NEXT:  No successors
 ; CHECK-NEXT:  }
 ;

--- a/llvm/test/Transforms/MemProfContextDisambiguation/inlined2.ll
+++ b/llvm/test/Transforms/MemProfContextDisambiguation/inlined2.ll
@@ -111,7 +111,7 @@ attributes #7 = { builtin }
 ; DUMP: CCG before cloning:
 ; DUMP: Callsite Context Graph:
 ; DUMP: Node [[BAR:0x[a-z0-9]+]]
-; DUMP: 	  %call = call noalias noundef nonnull dereferenceable(10) ptr @_Znam(i64 noundef 10) #7, !heapallocsite !7	(clone 0)
+; DUMP: 	  %call = call noalias noundef nonnull dereferenceable(10) ptr @_Znam(i64 noundef 10) #7, !heapallocsite !{{[0-9]+}}	(clone 0)
 ; DUMP: 	AllocTypes: NotColdCold
 ; DUMP: 	ContextIds: 1 2
 ; DUMP: 	CalleeEdges:

--- a/llvm/test/Transforms/SandboxVectorizer/Passes/Other/print_region_pass.ll
+++ b/llvm/test/Transforms/SandboxVectorizer/Passes/Other/print_region_pass.ll
@@ -3,15 +3,15 @@
 
 define void @foo(i8 %v) {
 ; CHECK: -- Region --
-; CHECK-NEXT:  %add0 = add i8 %v, 0, !sandboxvec !0 {{.*}}
+; CHECK-NEXT:  %add0 = add i8 %v, 0, !sandboxvec !{{[0-9]+}} {{.*}}
 ; CHECK: -- Region --
-; CHECK-NEXT:  %add1 = add i8 %v, 1, !sandboxvec !1 {{.*}}
-; CHECK-NEXT:  %add2 = add i8 %v, 2, !sandboxvec !1 {{.*}}
-; CHECK-NEXT:  %add3 = add i8 %v, 3, !sandboxvec !1, !sandboxaux !2 {{.*}}
-; CHECK-NEXT:  %add4 = add i8 %v, 4, !sandboxvec !1, !sandboxaux !3 {{.*}}
+; CHECK-NEXT:  %add1 = add i8 %v, 1, !sandboxvec !{{[0-9]+}} {{.*}}
+; CHECK-NEXT:  %add2 = add i8 %v, 2, !sandboxvec !{{[0-9]+}} {{.*}}
+; CHECK-NEXT:  %add3 = add i8 %v, 3, !sandboxvec !{{[0-9]+}}, !sandboxaux !{{[0-9]+}} {{.*}}
+; CHECK-NEXT:  %add4 = add i8 %v, 4, !sandboxvec !{{[0-9]+}}, !sandboxaux !{{[0-9]+}} {{.*}}
 ; CHECK: Aux:
-; CHECK-NEXT:  %add3 = add i8 %v, 3, !sandboxvec !1, !sandboxaux !2 {{.*}}
-; CHECK-NEXT:  %add4 = add i8 %v, 4, !sandboxvec !1, !sandboxaux !3 {{.*}}
+; CHECK-NEXT:  %add3 = add i8 %v, 3, !sandboxvec !{{[0-9]+}}, !sandboxaux !{{[0-9]+}} {{.*}}
+; CHECK-NEXT:  %add4 = add i8 %v, 4, !sandboxvec !{{[0-9]+}}, !sandboxaux !{{[0-9]+}} {{.*}}
   %add0 = add i8 %v, 0, !sandboxvec !0
   %add1 = add i8 %v, 1, !sandboxvec !1
   %add2 = add i8 %v, 2, !sandboxvec !1

--- a/llvm/test/Verifier/RemoveDI/di-subroutine-localvar.ll
+++ b/llvm/test/Verifier/RemoveDI/di-subroutine-localvar.ll
@@ -1,7 +1,7 @@
 ; RUN: opt %s -passes=verify 2>&1 | FileCheck %s
 ; CHECK: invalid type
-; CHECK: !20 = !DILocalVariable(name: "f", scope: !21, file: !13, line: 970, type: !14)
-; CHECK: !14 = !DISubroutineType(types: !15)
+; CHECK: !{{[0-9]+}} = !DILocalVariable(name: "f", scope: !{{[0-9]+}}, file: !{{[0-9]+}}, line: 970, type: !{{[0-9]+}})
+; CHECK: !{{[0-9]+}} = !DISubroutineType(types: !{{[0-9]+}})
 
 
 %timespec.0.1.2.3.0.1.2 = type { i64, i64 }

--- a/llvm/test/Verifier/absolute_symbol.ll
+++ b/llvm/test/Verifier/absolute_symbol.ll
@@ -37,21 +37,21 @@ define void @absolute_func_empty_arguments() !absolute_symbol !0 {
 @absolute_wrong_order = external global i32, !absolute_symbol !15
 
 ; CHECK: It should have at least one range!
-; CHECK-NEXT: !0 = !{}
+; CHECK-NEXT: !{{[0-9]+}} = !{}
 ; CHECK: It should have at least one range!
-; CHECK-NEXT: !0 = !{}
+; CHECK-NEXT: !{{[0-9]+}} = !{}
 !0 = !{}
 
 ; CHECK-NEXT: Unfinished range!
-; CHECK-NEXT: !1 = !{i64 128}
+; CHECK-NEXT: !{{[0-9]+}} = !{i64 128}
 !1 = !{i64 128}
 
 ; CHECK-NEXT: Unfinished range!
-; CHECK-NEXT: !2 = !{i64 128, i64 256, i64 512}
+; CHECK-NEXT: !{{[0-9]+}} = !{i64 128, i64 256, i64 512}
 !2 = !{i64 128, i64 256, i64 512}
 
 ; CHECK-NEXT: Unfinished range!
-; CHECK-NEXT: !3 = !{i32 256}
+; CHECK-NEXT: !{{[0-9]+}} = !{i32 256}
 !3 = !{i32 256}
 
 ; CHECK-NEXT: Range types must match instruction type!
@@ -67,7 +67,7 @@ define void @absolute_func_empty_arguments() !absolute_symbol !0 {
 !6 = !{i64 256, i32 512}
 
 ; CHECK-NEXT: Range must not be empty!
-; CHECK-NEXT: !7 = !{i64 0, i64 0}
+; CHECK-NEXT: !{{[0-9]+}} = !{i64 0, i64 0}
 !7 = !{i64 0, i64 0}
 
 ; CHECK-NEXT: The upper and lower limits cannot be the same value

--- a/llvm/test/Verifier/associated-metadata.ll
+++ b/llvm/test/Verifier/associated-metadata.ll
@@ -2,37 +2,37 @@
 
 ; CHECK: associated value must be pointer typed
 ; CHECK-NEXT: ptr addrspace(1) @associated.int
-; CHECK-NEXT: !0 = !{i32 1}
+; CHECK-NEXT: !{{[0-9]+}} = !{i32 1}
 @associated.int = external addrspace(1) constant [8 x i8], !associated !0
 
 ; CHECK: associated value must be pointer typed
 ; CHECK-NEXT: ptr addrspace(1) @associated.float
-; CHECK-NEXT: !1 = !{float 1.000000e+00}
+; CHECK-NEXT: !{{[0-9]+}} = !{float 1.000000e+00}
 @associated.float = external addrspace(1) constant [8 x i8], !associated !1
 
 ; CHECK: associated metadata must have one operand
 ; CHECK-NEXT: ptr addrspace(1) @associated.too.many.ops
-; CHECK-NEXT: !2 = !{ptr @gv.decl0, ptr @gv.decl1}
+; CHECK-NEXT: !{{[0-9]+}} = !{ptr @gv.decl0, ptr @gv.decl1}
 @associated.too.many.ops = external addrspace(1) constant [8 x i8], !associated !2
 
 ; CHECK: associated metadata must have one operand
 ; CHECK-NEXT: ptr addrspace(1) @associated.empty
-; CHECK-NEXT: !3 = !{}
+; CHECK-NEXT: !{{[0-9]+}} = !{}
 @associated.empty = external addrspace(1) constant [8 x i8], !associated !3
 
 ; CHECK: associated metadata must have a global value
 ; CHECK-NEXT: ptr addrspace(1) @associated.null.metadata
-; CHECK-NEXT: !4 = !{null}
+; CHECK-NEXT: !{{[0-9]+}} = !{null}
 @associated.null.metadata = external addrspace(1) constant [8 x i8], !associated !4
 
 ; CHECK: global values should not associate to themselves
 ; CHECK-NEXT: ptr @associated.self
-; CHECK-NEXT: !5 = !{ptr @associated.self}
+; CHECK-NEXT: !{{[0-9]+}} = !{ptr @associated.self}
 @associated.self = external constant [8 x i8], !associated !5
 
 ; CHECK: associated metadata must be ValueAsMetadata
 ; CHECK-NEXT: ptr @associated.string
-; CHECK-NEXT: !6 = !{!"string"}
+; CHECK-NEXT: !{{[0-9]+}} = !{!"string"}
 @associated.string = external constant [8 x i8], !associated !6
 
 @gv.decl0 = external constant [8 x i8]

--- a/llvm/test/Verifier/commandline-meta1.ll
+++ b/llvm/test/Verifier/commandline-meta1.ll
@@ -7,4 +7,4 @@
 !0 = !{!"string1", !"string2"}
 ; CHECK: assembly parsed, but does not verify as correct!
 ; CHECK-NEXT: incorrect number of operands in llvm.commandline metadata
-; CHECK-NEXT: !0
+; CHECK-NEXT: !{{[0-9]+}}

--- a/llvm/test/Verifier/dbg-orphaned-compileunit.ll
+++ b/llvm/test/Verifier/dbg-orphaned-compileunit.ll
@@ -1,7 +1,7 @@
 ; RUN: not llvm-as -disable-output <%s 2>&1 | FileCheck %s
 ; CHECK:      assembly parsed, but does not verify
 ; CHECK-NEXT: DICompileUnit not listed in llvm.dbg.cu
-; CHECK-NEXT: !0 = distinct !DICompileUnit(language: DW_LANG_Fortran77, file: !1, isOptimized: false, runtimeVersion: 0, emissionKind: NoDebug)
+; CHECK-NEXT: !{{[0-9]+}} = distinct !DICompileUnit(language: DW_LANG_Fortran77, file: !{{[0-9]+}}, isOptimized: false, runtimeVersion: 0, emissionKind: NoDebug)
 
 !named = !{!1}
 !llvm.module.flags = !{!0}

--- a/llvm/test/Verifier/di-subroutine-localvar.ll
+++ b/llvm/test/Verifier/di-subroutine-localvar.ll
@@ -1,7 +1,7 @@
 ; RUN: opt %s -passes=verify 2>&1 | FileCheck %s
 ; CHECK: invalid type
-; CHECK: !20 = !DILocalVariable(name: "f", scope: !21, file: !13, line: 970, type: !14)
-; CHECK: !14 = !DISubroutineType(types: !15)
+; CHECK: !{{[0-9]+}} = !DILocalVariable(name: "f", scope: !{{[0-9]+}}, file: !{{[0-9]+}}, line: 970, type: !{{[0-9]+}})
+; CHECK: !{{[0-9]+}} = !DISubroutineType(types: !{{[0-9]+}})
 
 
 %timespec.0.1.2.3.0.1.2 = type { i64, i64 }

--- a/llvm/test/Verifier/function-metadata-bad.ll
+++ b/llvm/test/Verifier/function-metadata-bad.ll
@@ -7,7 +7,7 @@ define i32 @bad1() !prof !0 {
 !0 = !{i32 123, i32 3}
 ; CHECK: assembly parsed, but does not verify as correct!
 ; CHECK-NEXT: expected string with name of the !prof annotation
-; CHECK-NEXT: !0 = !{i32 123, i32 3}
+; CHECK-NEXT: !{{[0-9]+}} = !{i32 123, i32 3}
 
 define i32 @bad2() !prof !1 {
   ret i32 0
@@ -15,7 +15,7 @@ define i32 @bad2() !prof !1 {
 
 !1 = !{!"function_entry_count"}
 ; CHECK-NEXT: !prof annotations should have no less than 2 operands
-; CHECK-NEXT: !1 = !{!"function_entry_count"}
+; CHECK-NEXT: !{{[0-9]+}} = !{!"function_entry_count"}
 
 
 define i32 @bad3() !prof !2 {
@@ -24,7 +24,7 @@ define i32 @bad3() !prof !2 {
 
 !2 = !{!"some_other_count", i64 200}
 ; CHECK-NEXT: first operand should be 'function_entry_count'
-; CHECK-NEXT: !2 = !{!"some_other_count", i64 200}
+; CHECK-NEXT: !{{[0-9]+}} = !{!"some_other_count", i64 200}
 
 define i32 @bad4() !prof !3 {
   ret i32 0
@@ -32,4 +32,4 @@ define i32 @bad4() !prof !3 {
 
 !3 = !{!"function_entry_count", !"string"}
 ; CHECK-NEXT: expected integer argument to function_entry_count
-; CHECK-NEXT: !3 = !{!"function_entry_count", !"string"}
+; CHECK-NEXT: !{{[0-9]+}} = !{!"function_entry_count", !"string"}

--- a/llvm/test/Verifier/ident-meta1.ll
+++ b/llvm/test/Verifier/ident-meta1.ll
@@ -8,5 +8,5 @@
 !1 = !{!"string1", !"string2"}
 ; CHECK: assembly parsed, but does not verify as correct!
 ; CHECK-NEXT: incorrect number of operands in llvm.ident metadata
-; CHECK-NEXT: !1
+; CHECK-NEXT: !{{[0-9]+}}
 

--- a/llvm/test/Verifier/llvm.loop.estimated_trip_count.ll
+++ b/llvm/test/Verifier/llvm.loop.estimated_trip_count.ll
@@ -16,13 +16,13 @@ exit:
 ; GOOD-NOT: {{.}}
 
 ;      BAD-VALUE: Expected second operand to be an integer constant of type i32 or smaller
-; BAD-VALUE-NEXT: !1 = !{!"llvm.loop.estimated_trip_count",
+; BAD-VALUE-NEXT: !{{[0-9]+}} = !{!"llvm.loop.estimated_trip_count",
 
 ;      TOO-FEW: Expected two operands
-; TOO-FEW-NEXT: !1 = !{!"llvm.loop.estimated_trip_count"}
+; TOO-FEW-NEXT: !{{[0-9]+}} = !{!"llvm.loop.estimated_trip_count"}
 
 ;      TOO-MANY: Expected two operands
-; TOO-MANY-NEXT: !1 = !{!"llvm.loop.estimated_trip_count", i32 5, i32 5}
+; TOO-MANY-NEXT: !{{[0-9]+}} = !{!"llvm.loop.estimated_trip_count", i32 5, i32 5}
 
 ; No value.
 ; RUN: cp %s %t

--- a/llvm/test/Verifier/mdcompositetype-templateparams-tuple.ll
+++ b/llvm/test/Verifier/mdcompositetype-templateparams-tuple.ll
@@ -1,9 +1,9 @@
 ; RUN: not llvm-as < %s -disable-output 2>&1 | FileCheck %s
 
 ; CHECK:      invalid template params
-; CHECK-NEXT: !2 = !DICompositeType(
-; CHECK-SAME:                       templateParams: !1
-; CHECK-NEXT: !1 = !DITemplateTypeParameter(
+; CHECK-NEXT: !{{[0-9]+}} = !DICompositeType(
+; CHECK-SAME:                       templateParams: !{{[0-9]+}}
+; CHECK-NEXT: !{{[0-9]+}} = !DITemplateTypeParameter(
 
 !named = !{!0, !1, !2}
 !0 = !DIBasicType(name: "int", size: 32, align: 32, encoding: DW_ATE_signed)

--- a/llvm/test/Verifier/mdcompositetype-templateparams.ll
+++ b/llvm/test/Verifier/mdcompositetype-templateparams.ll
@@ -1,10 +1,10 @@
 ; RUN: not llvm-as < %s -disable-output 2>&1 | FileCheck %s
 
 ; CHECK:      invalid template parameter
-; CHECK-NEXT: !2 = !DICompositeType(
-; CHECK-SAME:                       templateParams: !1
-; CHECK-NEXT: !1 = !{!0}
-; CHECK-NEXT: !0 = !DIBasicType(
+; CHECK-NEXT: !{{[0-9]+}} = !DICompositeType(
+; CHECK-SAME:                       templateParams: !{{[0-9]+}}
+; CHECK-NEXT: !{{[0-9]+}} = !{!{{[0-9]+}}}
+; CHECK-NEXT: !{{[0-9]+}} = !DIBasicType(
 
 !named = !{!0, !1, !2}
 !0 = !DIBasicType(name: "int", size: 32, align: 32, encoding: DW_ATE_signed)

--- a/llvm/test/Verifier/module-flags-cgprofile.ll
+++ b/llvm/test/Verifier/module-flags-cgprofile.ll
@@ -18,9 +18,9 @@ declare void @a()
 ; CHECK: expected a MDNode triple
 ; CHECK: !""
 ; CHECK: expected a MDNode triple
-; CHECK: !3 = !{ptr @a, ptr @b}
+; CHECK: !{{[0-9]+}} = !{ptr @a, ptr @b}
 ; CHECK: expected a MDNode triple
-; CHECK: !4 = !{ptr @a, ptr @b, i64 32, i64 32}
+; CHECK: !{{[0-9]+}} = !{ptr @a, ptr @b, i64 32, i64 32}
 ; CHECK: expected a Function or null
 ; CHECK: !"a"
 ; CHECK: expected a Function or null

--- a/llvm/test/Verifier/noalias-addrspace.ll
+++ b/llvm/test/Verifier/noalias-addrspace.ll
@@ -1,28 +1,28 @@
 ; RUN: not llvm-as < %s -o /dev/null 2>&1 | FileCheck %s
 
 ; CHECK: It should have at least one range!
-; CHECK-NEXT: !0 = !{}
+; CHECK-NEXT: !{{[0-9]+}} = !{}
 define i64 @noalias_addrspace__empty(ptr %ptr, i64 %val) {
   %ret = atomicrmw add ptr %ptr, i64 %val seq_cst, !noalias.addrspace !0
   ret i64 %ret
 }
 
 ; CHECK: Unfinished range!
-; CHECK-NEXT: !1 = !{i32 0}
+; CHECK-NEXT: !{{[0-9]+}} = !{i32 0}
 define i64 @noalias_addrspace__single_field(ptr %ptr, i64 %val) {
   %ret = atomicrmw add ptr %ptr, i64 %val seq_cst, !noalias.addrspace !1
   ret i64 %ret
 }
 
 ; CHECK: Range must not be empty!
-; CHECK-NEXT: !2 = !{i32 0, i32 0}
+; CHECK-NEXT: !{{[0-9]+}} = !{i32 0, i32 0}
 define i64 @noalias_addrspace__0_0(ptr %ptr, i64 %val) {
   %ret = atomicrmw add ptr %ptr, i64 %val seq_cst, !noalias.addrspace !2
   ret i64 %ret
 }
 
 ; CHECK: noalias.addrspace type must be i32!
-; CHECK-NEXT: %ret = atomicrmw add ptr %ptr, i64 %val seq_cst, align 8, !noalias.addrspace !3
+; CHECK-NEXT: %ret = atomicrmw add ptr %ptr, i64 %val seq_cst, align 8, !noalias.addrspace !{{[0-9]+}}
 define i64 @noalias_addrspace__i64(ptr %ptr, i64 %val) {
   %ret = atomicrmw add ptr %ptr, i64 %val seq_cst, !noalias.addrspace !3
   ret i64 %ret

--- a/llvm/test/Verifier/noalias_scope_decl.ll
+++ b/llvm/test/Verifier/noalias_scope_decl.ll
@@ -10,7 +10,7 @@ define void @test_single_scope02() nounwind ssp {
   ret void
 }
 ; CHECK: !id.scope.list must point to a list with a single scope
-; CHECK-NEXT:   tail call void @llvm.experimental.noalias.scope.decl(metadata !5)
+; CHECK-NEXT:   tail call void @llvm.experimental.noalias.scope.decl(metadata !{{[0-9]+}})
 
 define void @test_single_scope03() nounwind ssp {
   tail call void @llvm.experimental.noalias.scope.decl(metadata !"test")
@@ -31,7 +31,7 @@ define void @test_dom02() nounwind ssp {
   ret void
 }
 ; CHECK-NEXT: llvm.experimental.noalias.scope.decl dominates another one with the same scope
-; CHECK-NEXT:   tail call void @llvm.experimental.noalias.scope.decl(metadata !2)
+; CHECK-NEXT:   tail call void @llvm.experimental.noalias.scope.decl(metadata !{{[0-9]+}})
 
 define void @test_dom03() nounwind ssp {
   tail call void @llvm.experimental.noalias.scope.decl(metadata !2)
@@ -39,7 +39,7 @@ define void @test_dom03() nounwind ssp {
   ret void
 }
 ; CHECK-NEXT: llvm.experimental.noalias.scope.decl dominates another one with the same scope
-; CHECK-NEXT:   tail call void @llvm.experimental.noalias.scope.decl(metadata !2)
+; CHECK-NEXT:   tail call void @llvm.experimental.noalias.scope.decl(metadata !{{[0-9]+}})
 
 ; CHECK-NOT: llvm.experimental.noalias.scope.decl
 

--- a/llvm/test/Verifier/ref.ll
+++ b/llvm/test/Verifier/ref.ll
@@ -13,19 +13,19 @@
 
 ; CHECK: ref value must be pointer typed
 ; CHECK: ptr @a
-; CHECK: !0 = !{i32 1}
+; CHECK: !{{[0-9]+}} = !{i32 1}
 
 ; CHECK: values should not reference themselves
 ; CHECK: ptr @b
-; CHECK: !1 = !{ptr @b}
+; CHECK: !{{[0-9]+}} = !{ptr @b}
 
 ; CHECK: ref metadata must be ValueAsMetadata
 ; CHECK: ptr @c
-; CHECK: !2 = !{!"Hello World!"}
+; CHECK: !{{[0-9]+}} = !{!"Hello World!"}
 
 ; CHECK: ref metadata must have one operand
 ; CHECK: ptr @d
-; CHECK: !3 = !{ptr @c, ptr @a}
+; CHECK: !{{[0-9]+}} = !{ptr @c, ptr @a}
 
 ; CHECK: ref metadata must not be placed on a declaration
 ; CHECK: @e

--- a/llvm/test/Verifier/reloc-none.ll
+++ b/llvm/test/Verifier/reloc-none.ll
@@ -1,7 +1,7 @@
 ; RUN: not llvm-as -disable-output 2>&1 %s | FileCheck %s
 
 ; CHECK: llvm.reloc.none argument must be a metadata string
-; CHECK-NEXT: call void @llvm.reloc.none(metadata !0)
+; CHECK-NEXT: call void @llvm.reloc.none(metadata !{{[0-9]+}})
 
 define void @test_reloc_none_bad_arg() {
   call void @llvm.reloc.none(metadata !0)

--- a/llvm/test/tools/llubi/metadata.ll
+++ b/llvm/test/tools/llubi/metadata.ll
@@ -39,27 +39,27 @@ define void @main() {
 ; CHECK: Entering function: main
 ; CHECK-NEXT:   %alloc = alloca i32, align 4 => ptr 0x8 [alloc]
 ; CHECK-NEXT:   store i32 1, ptr %alloc, align 4
-; CHECK-NEXT:   %range_load_valid = load i32, ptr %alloc, align 4, !range !0, !noundef !1 => i32 1
-; CHECK-NEXT:   %range_load_invalid = load i32, ptr %alloc, align 4, !range !2 => poison
+; CHECK-NEXT:   %range_load_valid = load i32, ptr %alloc, align 4, !range !{{[0-9]+}}, !noundef !{{[0-9]+}} => i32 1
+; CHECK-NEXT:   %range_load_invalid = load i32, ptr %alloc, align 4, !range !{{[0-9]+}} => poison
 ; CHECK-NEXT:   %alloc_vec = alloca <8 x i32>, align 32 => ptr 0x20 [alloc_vec]
 ; CHECK-NEXT:   store <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>, ptr %alloc_vec, align 32
-; CHECK-NEXT:   %range_list_load_vec = load <8 x i32>, ptr %alloc_vec, align 32, !range !3 => { i32 0, i32 1, poison, i32 3, poison, i32 5, poison, i32 7 }
+; CHECK-NEXT:   %range_list_load_vec = load <8 x i32>, ptr %alloc_vec, align 32, !range !{{[0-9]+}} => { i32 0, i32 1, poison, i32 3, poison, i32 5, poison, i32 7 }
 ; CHECK-NEXT:   store float 0.000000e+00, ptr %alloc, align 4
-; CHECK-NEXT:   %nofpclass_load_valid = load float, ptr %alloc, align 4, !noundef !1, !nofpclass !4 => float 0.000000e+00
-; CHECK-NEXT:   %nofpclass_load_invalid = load float, ptr %alloc, align 4, !nofpclass !5 => poison
+; CHECK-NEXT:   %nofpclass_load_valid = load float, ptr %alloc, align 4, !noundef !{{[0-9]+}}, !nofpclass !{{[0-9]+}} => float 0.000000e+00
+; CHECK-NEXT:   %nofpclass_load_invalid = load float, ptr %alloc, align 4, !nofpclass !{{[0-9]+}} => poison
 ; CHECK-NEXT:   %alloc_ptr = alloca ptr, align 8 => ptr 0x48 [alloc_ptr]
 ; CHECK-NEXT:   store ptr %alloc_ptr, ptr %alloc_ptr, align 8
-; CHECK-NEXT:   %align_nonnull_load_valid = load ptr, ptr %alloc_ptr, align 8, !nonnull !1, !dereferenceable !6, !dereferenceable_or_null !6, !align !6, !noundef !1 => ptr 0x48 [alloc_ptr]
+; CHECK-NEXT:   %align_nonnull_load_valid = load ptr, ptr %alloc_ptr, align 8, !nonnull !{{[0-9]+}}, !dereferenceable !{{[0-9]+}}, !dereferenceable_or_null !{{[0-9]+}}, !align !{{[0-9]+}}, !noundef !{{[0-9]+}} => ptr 0x48 [alloc_ptr]
 ; CHECK-NEXT:   store ptr null, ptr %alloc_ptr, align 8
-; CHECK-NEXT:   %align_load_valid = load ptr, ptr %alloc_ptr, align 8, !dereferenceable_or_null !6, !align !6, !noundef !1 => ptr 0x0 [nullary]
-; CHECK-NEXT:   %nonnull_load_invalid = load ptr, ptr %alloc_ptr, align 8, !nonnull !1 => poison
+; CHECK-NEXT:   %align_load_valid = load ptr, ptr %alloc_ptr, align 8, !dereferenceable_or_null !{{[0-9]+}}, !align !{{[0-9]+}}, !noundef !{{[0-9]+}} => ptr 0x0 [nullary]
+; CHECK-NEXT:   %nonnull_load_invalid = load ptr, ptr %alloc_ptr, align 8, !nonnull !{{[0-9]+}} => poison
 ; CHECK-NEXT: Entering function: callee
 ; CHECK-NEXT:   ret i32 10
 ; CHECK-NEXT: Exiting function: callee
-; CHECK-NEXT:   %range_call_valid = call i32 @callee(), !range !7 => i32 10
+; CHECK-NEXT:   %range_call_valid = call i32 @callee(), !range !{{[0-9]+}} => i32 10
 ; CHECK-NEXT: Entering function: callee
 ; CHECK-NEXT:   ret i32 10
 ; CHECK-NEXT: Exiting function: callee
-; CHECK-NEXT:   %range_call_invalid = call i32 @callee(), !range !0 => poison
+; CHECK-NEXT:   %range_call_invalid = call i32 @callee(), !range !{{[0-9]+}} => poison
 ; CHECK-NEXT:   ret void
 ; CHECK-NEXT: Exiting function: main

--- a/llvm/test/tools/llubi/metadata_noundef_ub.ll
+++ b/llvm/test/tools/llubi/metadata_noundef_ub.ll
@@ -11,6 +11,6 @@ define void @main() {
 ; CHECK-NEXT:   %alloc = alloca i32, align 4 => ptr 0x8 [alloc]
 ; CHECK-NEXT:   store i32 -1, ptr %alloc, align 4
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   %res = load i32, ptr %alloc, align 4, !range !0, !noundef !1 at @main <stdin>:7
+; CHECK-NEXT: #0   %res = load i32, ptr %alloc, align 4, !range !{{[0-9]+}}, !noundef !{{[0-9]+}} at @main <stdin>:7
 ; CHECK-NEXT: Immediate UB detected: The value poison violates !noundef metadata.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/noalias_scope.ll
+++ b/llvm/test/tools/llubi/noalias_scope.ll
@@ -11,6 +11,6 @@ entry:
 !1 = distinct !{!1, !2, !"func: %agg.result"}
 !2 = distinct !{!2, !"func"}
 ; CHECK: Entering function: main
-; CHECK-NEXT:   tail call void @llvm.experimental.noalias.scope.decl(metadata !0)
+; CHECK-NEXT:   tail call void @llvm.experimental.noalias.scope.decl(metadata !{{[0-9]+}})
 ; CHECK-NEXT:   ret void
 ; CHECK-NEXT: Exiting function: main


### PR DESCRIPTION
These checks care about the metadata attached to an instruction or reported in a diagnostic, not the incidental numeric slot assigned while printing. Match metadata slot numbers with FileCheck patterns so numbering changes do not require unrelated test updates.
