### PR TITLE
[MIR] Round-trip all machine metadata nodes

### DIFF
--- a/llvm/include/llvm/AsmParser/LLLexer.h
+++ b/llvm/include/llvm/AsmParser/LLLexer.h
@@ -69,6 +69,7 @@ namespace llvm {
 
     typedef SMLoc LocTy;
     LocTy getLoc() const { return SMLoc::getFromPointer(TokStart); }
+    LocTy getPrevTokEndLoc() const { return SMLoc::getFromPointer(PrevTokEnd); }
     lltok::Kind getKind() const { return CurKind; }
     const std::string &getStrVal() const { return StrVal; }
     Type *getTyVal() const { return TyVal; }

--- a/llvm/include/llvm/AsmParser/LLParser.h
+++ b/llvm/include/llvm/AsmParser/LLParser.h
@@ -235,6 +235,9 @@ namespace llvm {
                                                    unsigned &Read,
                                                    const SlotMapping *Slots);
 
+    LLVM_ABI bool parseMetadataDefinitions(SlotMapping &Slots,
+                                           ArrayRef<SMLoc> DefinitionEnds);
+
     LLVMContext &getContext() { return Context; }
 
   private:

--- a/llvm/include/llvm/AsmParser/Parser.h
+++ b/llvm/include/llvm/AsmParser/Parser.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_ASMPARSER_PARSER_H
 #define LLVM_ASMPARSER_PARSER_H
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/AsmParser/AsmParserContext.h"
@@ -210,6 +211,15 @@ LLVM_ABI DIExpression *
 parseDIExpressionBodyAtBeginning(StringRef Asm, unsigned &Read,
                                  SMDiagnostic &Err, const Module &M,
                                  const SlotMapping *Slots);
+
+/// Parse standalone metadata definitions using and updating the supplied slot
+/// mapping. Each string must contain exactly one complete definition.
+/// \param ErrorDefinitionIndex The index of the definition containing an error.
+/// \return true on error.
+LLVM_ABI bool parseMetadataDefinitions(ArrayRef<StringRef> Definitions,
+                                       SMDiagnostic &Err, const Module &M,
+                                       SlotMapping &Slots,
+                                       unsigned &ErrorDefinitionIndex);
 
 } // End llvm namespace
 

--- a/llvm/include/llvm/CodeGen/MIRParser/MIParser.h
+++ b/llvm/include/llvm/CodeGen/MIRParser/MIParser.h
@@ -173,7 +173,6 @@ struct PerFunctionMIParsingState {
   PerTargetMIParsingState &Target;
 
   std::map<unsigned, TrackingMDNodeRef> MachineMetadataNodes;
-  std::map<unsigned, std::pair<TempMDTuple, SMLoc>> MachineForwardRefMDNodes;
 
   DenseMap<unsigned, MachineBasicBlock *> MBBSlots;
   DenseMap<Register, VRegInfo *> VRegInfos;
@@ -248,10 +247,6 @@ LLVM_ABI bool parsePrefetchTarget(PerFunctionMIParsingState &PFS,
                                   SMDiagnostic &Error);
 LLVM_ABI bool parseMDNode(PerFunctionMIParsingState &PFS, MDNode *&Node,
                           StringRef Src, SMDiagnostic &Error);
-
-LLVM_ABI bool parseMachineMetadata(PerFunctionMIParsingState &PFS,
-                                   StringRef Src, SMRange SourceRange,
-                                   SMDiagnostic &Error);
 
 } // end namespace llvm
 

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -72,6 +72,52 @@ static std::string getTypeString(Type *T) {
   return Tmp.str();
 }
 
+/// Return whether skipped trivia contains a block comment that crosses the
+/// boundary between two metadata definitions.
+static bool blockCommentCrossesBoundary(SMLoc BeginLoc, SMLoc EndLoc,
+                                        SMLoc BoundaryLoc) {
+  const char *Begin = BeginLoc.getPointer();
+  const char *End = EndLoc.getPointer();
+  const char *Boundary = BoundaryLoc.getPointer();
+  const char *BlockCommentStart = nullptr;
+  bool InLineComment = false;
+
+  for (const char *Ptr = Begin; Ptr < End;) {
+    if (BlockCommentStart) {
+      if (Ptr + 1 < End && Ptr[0] == '*' && Ptr[1] == '/') {
+        Ptr += 2;
+        if (BlockCommentStart < Boundary && Ptr > Boundary)
+          return true;
+        BlockCommentStart = nullptr;
+        continue;
+      }
+      ++Ptr;
+      continue;
+    }
+
+    if (InLineComment) {
+      if (*Ptr == '\n' || *Ptr == '\r')
+        InLineComment = false;
+      ++Ptr;
+      continue;
+    }
+
+    if (*Ptr == ';') {
+      InLineComment = true;
+      ++Ptr;
+      continue;
+    }
+    if (Ptr + 1 < End && Ptr[0] == '/' && Ptr[1] == '*') {
+      BlockCommentStart = Ptr;
+      Ptr += 2;
+      continue;
+    }
+    ++Ptr;
+  }
+
+  return BlockCommentStart && BlockCommentStart < Boundary && End > Boundary;
+}
+
 /// Run: module ::= toplevelentity*
 bool LLParser::Run(bool UpgradeDebugInfo,
                    DataLayoutCallbackTy DataLayoutCallback) {
@@ -134,6 +180,43 @@ bool LLParser::parseDIExpressionBodyAtBeginning(MDNode *&Result, unsigned &Read,
   Read = End.getPointer() - Start.getPointer();
 
   return Status;
+}
+
+bool LLParser::parseMetadataDefinitions(SlotMapping &Slots,
+                                        ArrayRef<SMLoc> DefinitionEnds) {
+  restoreParsingState(&Slots);
+  Lex.Lex();
+
+  for (SMLoc End : DefinitionEnds) {
+    if (Lex.getLoc().getPointer() >= End.getPointer())
+      return error(End, "expected end of metadata definition");
+    if (Lex.getKind() != lltok::exclaim)
+      return tokError("expected a metadata definition");
+    if (parseStandaloneMetadata())
+      return true;
+    if (Lex.getPrevTokEndLoc().getPointer() > End.getPointer() ||
+        (Lex.getKind() != lltok::Eof &&
+         Lex.getLoc().getPointer() < End.getPointer()) ||
+        blockCommentCrossesBoundary(Lex.getPrevTokEndLoc(), Lex.getLoc(), End))
+      return error(End, "expected end of metadata definition");
+  }
+
+  if (Lex.getKind() != lltok::Eof)
+    return tokError("expected end of metadata definitions");
+
+  if (!ForwardRefMDNodes.empty())
+    return error(ForwardRefMDNodes.begin()->second.second,
+                 "use of undefined metadata '!" +
+                     Twine(ForwardRefMDNodes.begin()->first) + "'");
+
+  for (auto &[_, MD] : NumberedMetadata)
+    if (MD && !MD->isResolved())
+      MD->resolveCycles();
+  DISubprogram::cleanupRetainedNodes(NewDistinctSPs);
+  NewDistinctSPs.clear();
+
+  Slots.MetadataNodes = std::move(NumberedMetadata);
+  return false;
 }
 
 void LLParser::restoreParsingState(const SlotMapping *Slots) {

--- a/llvm/lib/AsmParser/Parser.cpp
+++ b/llvm/lib/AsmParser/Parser.cpp
@@ -11,12 +11,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/AsmParser/Parser.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/AsmParser/LLParser.h"
 #include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/ModuleSummaryIndex.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/SourceMgr.h"
+#include <algorithm>
 #include <system_error>
 
 using namespace llvm;
@@ -246,4 +248,51 @@ DIExpression *llvm::parseDIExpressionBodyAtBeginning(StringRef Asm,
           .parseDIExpressionBodyAtBeginning(MD, Read, Slots))
     return nullptr;
   return dyn_cast<DIExpression>(MD);
+}
+
+bool llvm::parseMetadataDefinitions(ArrayRef<StringRef> Definitions,
+                                    SMDiagnostic &Err, const Module &M,
+                                    SlotMapping &Slots,
+                                    unsigned &ErrorDefinitionIndex) {
+  std::string Asm;
+  SmallVector<std::pair<size_t, size_t>> DefinitionRanges;
+  for (StringRef Definition : Definitions) {
+    size_t Start = Asm.size();
+    Asm.append(Definition);
+    DefinitionRanges.emplace_back(Start, Asm.size());
+    Asm.push_back('\n');
+  }
+
+  SourceMgr SM;
+  std::unique_ptr<MemoryBuffer> Buf = MemoryBuffer::getMemBuffer(Asm);
+  SM.AddNewSourceBuffer(std::move(Buf), SMLoc());
+  SmallVector<SMLoc> DefinitionEnds;
+  for (auto [_, End] : DefinitionRanges)
+    DefinitionEnds.push_back(SMLoc::getFromPointer(Asm.data() + End));
+  if (!LLParser(Asm, SM, Err, const_cast<Module *>(&M), nullptr, M.getContext())
+           .parseMetadataDefinitions(Slots, DefinitionEnds))
+    return false;
+
+  const char *ErrorPtr = Err.getLoc().getPointer();
+  size_t ErrorOffset =
+      ErrorPtr ? std::min<size_t>(ErrorPtr - Asm.data(), Asm.size()) : 0;
+  ErrorDefinitionIndex = DefinitionRanges.size() - 1;
+  for (unsigned I = 0; I != DefinitionRanges.size(); ++I) {
+    if (ErrorOffset <= DefinitionRanges[I].second) {
+      ErrorDefinitionIndex = I;
+      break;
+    }
+  }
+
+  auto [Start, End] = DefinitionRanges[ErrorDefinitionIndex];
+  size_t DefinitionOffset = std::clamp(ErrorOffset, Start, End) - Start;
+  SourceMgr DefinitionSM;
+  std::unique_ptr<MemoryBuffer> DefinitionBuf = MemoryBuffer::getMemBuffer(
+      Definitions[ErrorDefinitionIndex], "", /*RequiresNullTerminator=*/false);
+  StringRef Definition = DefinitionBuf->getBuffer();
+  DefinitionSM.AddNewSourceBuffer(std::move(DefinitionBuf), SMLoc());
+  Err = DefinitionSM.GetMessage(
+      SMLoc::getFromPointer(Definition.data() + DefinitionOffset),
+      Err.getKind(), Err.getMessage());
+  return true;
 }

--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -401,7 +401,6 @@ class MIParser {
   MachineFunction &MF;
   SMDiagnostic &Error;
   StringRef Source, CurrentSource;
-  SMRange SourceRange;
   MIToken Token;
   PerFunctionMIParsingState &PFS;
   /// Maps from slot numbers to function's unnamed basic blocks.
@@ -410,8 +409,6 @@ class MIParser {
 public:
   MIParser(PerFunctionMIParsingState &PFS, SMDiagnostic &Error,
            StringRef Source);
-  MIParser(PerFunctionMIParsingState &PFS, SMDiagnostic &Error,
-           StringRef Source, SMRange SourceRange);
 
   /// \p SkipChar gives the number of characters to skip before looking
   /// for the next token.
@@ -437,10 +434,6 @@ public:
   bool parseStandaloneRegister(Register &Reg);
   bool parseStandaloneStackObject(int &FI);
   bool parseStandaloneMDNode(MDNode *&Node);
-  bool parseMachineMetadata();
-  bool parseMDTuple(MDNode *&MD, bool IsDistinct);
-  bool parseMDNodeVector(SmallVectorImpl<Metadata *> &Elts);
-  bool parseMetadata(Metadata *&MD);
 
   bool
   parseBasicBlockDefinition(DenseMap<unsigned, MachineBasicBlock *> &MBBSlots);
@@ -574,10 +567,6 @@ private:
   /// parseStringConstant
   ///   ::= StringConstant
   bool parseStringConstant(std::string &Result);
-
-  /// Map the location in the MI string to the corresponding location specified
-  /// in `SourceRange`.
-  SMLoc mapSMLoc(StringRef::iterator Loc);
 };
 
 } // end anonymous namespace
@@ -586,11 +575,6 @@ MIParser::MIParser(PerFunctionMIParsingState &PFS, SMDiagnostic &Error,
                    StringRef Source)
     : MF(PFS.MF), Error(Error), Source(Source), CurrentSource(Source), PFS(PFS)
 {}
-
-MIParser::MIParser(PerFunctionMIParsingState &PFS, SMDiagnostic &Error,
-                   StringRef Source, SMRange SourceRange)
-    : MF(PFS.MF), Error(Error), Source(Source), CurrentSource(Source),
-      SourceRange(SourceRange), PFS(PFS) {}
 
 void MIParser::lex(unsigned SkipChar) {
   CurrentSource = lexMIToken(
@@ -615,13 +599,6 @@ bool MIParser::error(StringRef::iterator Loc, const Twine &Msg) {
                        Loc - Source.data(), SourceMgr::DK_Error, Msg.str(),
                        Source, {}, {});
   return true;
-}
-
-SMLoc MIParser::mapSMLoc(StringRef::iterator Loc) {
-  assert(SourceRange.isValid() && "Invalid source range");
-  assert(Loc >= Source.data() && Loc <= (Source.data() + Source.size()));
-  return SMLoc::getFromPointer(SourceRange.Start.getPointer() +
-                               (Loc - Source.data()));
 }
 
 typedef function_ref<bool(StringRef::iterator Loc, const Twine &)>
@@ -1338,131 +1315,6 @@ bool MIParser::parseStandaloneMDNode(MDNode *&Node) {
   }
   if (Token.isNot(MIToken::Eof))
     return error("expected end of string after the metadata node");
-  return false;
-}
-
-bool MIParser::parseMachineMetadata() {
-  lex();
-  if (Token.isNot(MIToken::exclaim))
-    return error("expected a metadata node");
-
-  lex();
-  if (Token.isNot(MIToken::IntegerLiteral) || Token.integerValue().isSigned())
-    return error("expected metadata id after '!'");
-  unsigned ID = 0;
-  if (getUnsigned(ID))
-    return true;
-  lex();
-  if (expectAndConsume(MIToken::equal))
-    return true;
-  bool IsDistinct = Token.is(MIToken::kw_distinct);
-  if (IsDistinct)
-    lex();
-  if (Token.isNot(MIToken::exclaim))
-    return error("expected a metadata node");
-  lex();
-
-  MDNode *MD;
-  if (parseMDTuple(MD, IsDistinct))
-    return true;
-
-  auto FI = PFS.MachineForwardRefMDNodes.find(ID);
-  if (FI != PFS.MachineForwardRefMDNodes.end()) {
-    FI->second.first->replaceAllUsesWith(MD);
-    PFS.MachineForwardRefMDNodes.erase(FI);
-
-    assert(PFS.MachineMetadataNodes[ID] == MD && "Tracking VH didn't work");
-  } else {
-    auto [It, Inserted] = PFS.MachineMetadataNodes.try_emplace(ID);
-    if (!Inserted)
-      return error("Metadata id is already used");
-    It->second.reset(MD);
-  }
-
-  return false;
-}
-
-bool MIParser::parseMDTuple(MDNode *&MD, bool IsDistinct) {
-  SmallVector<Metadata *, 16> Elts;
-  if (parseMDNodeVector(Elts))
-    return true;
-  MD = (IsDistinct ? MDTuple::getDistinct
-                   : MDTuple::get)(MF.getFunction().getContext(), Elts);
-  return false;
-}
-
-bool MIParser::parseMDNodeVector(SmallVectorImpl<Metadata *> &Elts) {
-  if (Token.isNot(MIToken::lbrace))
-    return error("expected '{' here");
-  lex();
-
-  if (Token.is(MIToken::rbrace)) {
-    lex();
-    return false;
-  }
-
-  do {
-    Metadata *MD;
-    if (parseMetadata(MD))
-      return true;
-
-    Elts.push_back(MD);
-
-    if (Token.isNot(MIToken::comma))
-      break;
-    lex();
-  } while (true);
-
-  if (Token.isNot(MIToken::rbrace))
-    return error("expected end of metadata node");
-  lex();
-
-  return false;
-}
-
-// ::= !42
-// ::= !"string"
-bool MIParser::parseMetadata(Metadata *&MD) {
-  if (Token.isNot(MIToken::exclaim))
-    return error("expected '!' here");
-  lex();
-
-  if (Token.is(MIToken::StringConstant)) {
-    std::string Str;
-    if (parseStringConstant(Str))
-      return true;
-    MD = MDString::get(MF.getFunction().getContext(), Str);
-    return false;
-  }
-
-  if (Token.isNot(MIToken::IntegerLiteral) || Token.integerValue().isSigned())
-    return error("expected metadata id after '!'");
-
-  SMLoc Loc = mapSMLoc(Token.location());
-
-  unsigned ID = 0;
-  if (getUnsigned(ID))
-    return true;
-  lex();
-
-  auto NodeInfo = PFS.IRSlots.MetadataNodes.find(ID);
-  if (NodeInfo != PFS.IRSlots.MetadataNodes.end()) {
-    MD = NodeInfo->second.get();
-    return false;
-  }
-  // Check machine metadata.
-  NodeInfo = PFS.MachineMetadataNodes.find(ID);
-  if (NodeInfo != PFS.MachineMetadataNodes.end()) {
-    MD = NodeInfo->second.get();
-    return false;
-  }
-  // Forward reference.
-  auto &FwdRef = PFS.MachineForwardRefMDNodes[ID];
-  FwdRef = std::make_pair(
-      MDTuple::getTemporary(MF.getFunction().getContext(), {}), Loc);
-  PFS.MachineMetadataNodes[ID].reset(FwdRef.first.get());
-  MD = FwdRef.first.get();
-
   return false;
 }
 
@@ -4058,11 +3910,6 @@ bool llvm::parsePrefetchTarget(PerFunctionMIParsingState &PFS,
 bool llvm::parseMDNode(PerFunctionMIParsingState &PFS, MDNode *&Node,
                        StringRef Src, SMDiagnostic &Error) {
   return MIParser(PFS, Error, Src).parseStandaloneMDNode(Node);
-}
-
-bool llvm::parseMachineMetadata(PerFunctionMIParsingState &PFS, StringRef Src,
-                                SMRange SrcRange, SMDiagnostic &Error) {
-  return MIParser(PFS, Error, Src, SrcRange).parseMachineMetadata();
 }
 
 bool MIRFormatter::parseIRValue(StringRef Src, MachineFunction &MF,

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -178,9 +178,6 @@ private:
                          MachineBasicBlock *&MBB,
                          const yaml::StringValue &Source);
 
-  bool parseMachineMetadata(PerFunctionMIParsingState &PFS,
-                            const yaml::StringValue &Source);
-
   /// Return a MIR diagnostic converted from an MI string diagnostic.
   SMDiagnostic diagFromMIStringDiag(const SMDiagnostic &Error,
                                     SMRange SourceRange);
@@ -1226,26 +1223,31 @@ bool MIRParserImpl::parseMBBReference(PerFunctionMIParsingState &PFS,
   return false;
 }
 
-bool MIRParserImpl::parseMachineMetadata(PerFunctionMIParsingState &PFS,
-                                         const yaml::StringValue &Source) {
-  SMDiagnostic Error;
-  if (llvm::parseMachineMetadata(PFS, Source.Value, Source.SourceRange, Error))
-    return error(Error, Source.SourceRange);
-  return false;
-}
-
 bool MIRParserImpl::parseMachineMetadataNodes(
     PerFunctionMIParsingState &PFS, MachineFunction &MF,
     const yaml::MachineFunction &YMF) {
-  for (const auto &MDS : YMF.MachineMetadataNodes) {
-    if (parseMachineMetadata(PFS, MDS))
+  SmallVector<StringRef> Definitions;
+  for (const auto &MDS : YMF.MachineMetadataNodes)
+    Definitions.push_back(MDS.Value);
+
+  SlotMapping Slots = PFS.IRSlots;
+  SMDiagnostic Error;
+  unsigned ErrorDefinitionIndex = 0;
+  if (parseMetadataDefinitions(Definitions, Error,
+                               *MF.getFunction().getParent(), Slots,
+                               ErrorDefinitionIndex)) {
+    const yaml::StringValue &Source =
+        YMF.MachineMetadataNodes[ErrorDefinitionIndex];
+    if (StringRef(Source.Value).contains('\n')) {
+      reportDiagnostic(diagFromBlockStringDiag(Error, Source.SourceRange));
       return true;
+    }
+    return error(Error, Source.SourceRange);
   }
-  // Report missing definitions from forward referenced nodes.
-  if (!PFS.MachineForwardRefMDNodes.empty())
-    return error(PFS.MachineForwardRefMDNodes.begin()->second.second,
-                 "use of undefined metadata '!" +
-                     Twine(PFS.MachineForwardRefMDNodes.begin()->first) + "'");
+
+  for (auto &[ID, MD] : Slots.MetadataNodes)
+    if (PFS.IRSlots.MetadataNodes.find(ID) == PFS.IRSlots.MetadataNodes.end())
+      PFS.MachineMetadataNodes.try_emplace(ID, MD);
   return false;
 }
 

--- a/llvm/lib/CodeGen/MachineModuleSlotTracker.cpp
+++ b/llvm/lib/CodeGen/MachineModuleSlotTracker.cpp
@@ -8,7 +8,10 @@
 
 #include "llvm/CodeGen/MachineModuleSlotTracker.h"
 #include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineInstr.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
+#include "llvm/CodeGen/MachineOperand.h"
+#include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/Module.h"
 
 using namespace llvm;
@@ -17,7 +20,18 @@ void MachineModuleSlotTracker::processMachineFunctionMetadata(
     AbstractSlotTrackerStorage *AST, const MachineFunction &MF) {
   // Create metadata created within the backend.
   for (const MachineBasicBlock &MBB : MF)
-    for (const MachineInstr &MI : MBB.instrs())
+    for (const MachineInstr &MI : MBB.instrs()) {
+      if (MDNode *N = MI.getHeapAllocMarker())
+        AST->createMetadataSlot(N);
+      if (MDNode *N = MI.getPCSections())
+        AST->createMetadataSlot(N);
+      if (MDNode *N = MI.getMMRAMetadata())
+        AST->createMetadataSlot(N);
+
+      for (const MachineOperand &MO : MI.operands())
+        if (MO.isMetadata())
+          AST->createMetadataSlot(MO.getMetadata());
+
       for (const MachineMemOperand *MMO : MI.memoperands()) {
         AAMDNodes AAInfo = MMO->getAAInfo();
         if (AAInfo.TBAA)
@@ -28,7 +42,19 @@ void MachineModuleSlotTracker::processMachineFunctionMetadata(
           AST->createMetadataSlot(AAInfo.Scope);
         if (AAInfo.NoAlias)
           AST->createMetadataSlot(AAInfo.NoAlias);
+        if (AAInfo.NoAliasAddrSpace)
+          AST->createMetadataSlot(AAInfo.NoAliasAddrSpace);
+        if (const MDNode *N = MMO->getRanges())
+          AST->createMetadataSlot(N);
+        if (const MDNode *N = MMO->getMemCacheHint())
+          AST->createMetadataSlot(N);
       }
+    }
+
+  for (const MachineFunction::VariableDbgInfo &DebugVar :
+       MF.getVariableDbgInfo()) {
+    AST->createMetadataSlot(DebugVar.Var);
+  }
 }
 
 void MachineModuleSlotTracker::processMachineModule(

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-metadata.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-metadata.ll
@@ -7,7 +7,7 @@ define i32 @reloc_constant() {
   ; CHECK-LABEL: name: reloc_constant
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[INT:%[0-9]+]]:_(i32) = G_INTRINSIC intrinsic(@llvm.amdgcn.reloc.constant), !0
-  ; CHECK-NEXT:   [[INT1:%[0-9]+]]:_(i32) = G_INTRINSIC intrinsic(@llvm.amdgcn.reloc.constant), <{{0x[0-9a-f]+}}>
+  ; CHECK-NEXT:   [[INT1:%[0-9]+]]:_(i32) = G_INTRINSIC intrinsic(@llvm.amdgcn.reloc.constant), !1
   ; CHECK-NEXT:   [[ADD:%[0-9]+]]:_(i32) = G_ADD [[INT]], [[INT1]]
   ; CHECK-NEXT:   $vgpr0 = COPY [[ADD]](i32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0

--- a/llvm/test/CodeGen/AMDGPU/dbg-value-ends-sched-region.mir
+++ b/llvm/test/CodeGen/AMDGPU/dbg-value-ends-sched-region.mir
@@ -90,7 +90,7 @@ body:             |
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   dead [[COPY7:%[0-9]+]]:sreg_64 = COPY $exec
   ; CHECK-NEXT:   dead [[GLOBAL_LOAD_DWORDX4_:%[0-9]+]]:vreg_128 = GLOBAL_LOAD_DWORDX4 [[COPY1]], 0, 0, implicit $exec :: (load (s128), addrspace 1)
-  ; CHECK-NEXT:   DBG_VALUE [[GLOBAL_LOAD_DWORDX4_]], $noreg, <0x{{[0-9a-f]+}}>, !DIExpression(DW_OP_constu, 1, DW_OP_swap, DW_OP_xderef), debug-location !DILocation(line: 0, scope: <0x{{[0-9a-f]+}}>)
+  ; CHECK-NEXT:   DBG_VALUE [[GLOBAL_LOAD_DWORDX4_]], $noreg, !5, !DIExpression(DW_OP_constu, 1, DW_OP_swap, DW_OP_xderef), debug-location !DILocation(line: 0, scope: !6)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.5:
   ; CHECK-NEXT:   successors: %bb.3(0x40000000), %bb.1(0x40000000)

--- a/llvm/test/CodeGen/AMDGPU/sgpr-spill-fi-skip-processing-stack-arg-dbg-value-list.mir
+++ b/llvm/test/CodeGen/AMDGPU/sgpr-spill-fi-skip-processing-stack-arg-dbg-value-list.mir
@@ -40,8 +40,11 @@ machineFunctionInfo:
     privateSegmentWaveByteOffset: { reg: '$sgpr9' }
 body:             |
   ; CHECK-LABEL: name: test
+  ; CHECK: machineMetadataNodes:
+  ; CHECK-DAG: '![[SP:[0-9]+]] = distinct !DISubprogram
+  ; CHECK-DAG: '![[VAR:[0-9]+]] = !DILocalVariable(name: "a", scope: ![[SP]],
   ; CHECK: bb.0:
-  ; CHECK:   DBG_VALUE_LIST <{{.*}}>, !DIExpression(), $noreg, 0, debug-location !DILocation(line: 10, column: 9, scope: <{{.*}}>)
+  ; CHECK:   DBG_VALUE_LIST ![[VAR]], !DIExpression(), $noreg, 0, debug-location !DILocation(line: 10, column: 9, scope: ![[SP]])
 
   bb.0:
     renamable $sgpr10 = IMPLICIT_DEF

--- a/llvm/test/CodeGen/AMDGPU/vgpr-spill-fi-skip-processing-stack-arg-dbg-value-list.mir
+++ b/llvm/test/CodeGen/AMDGPU/vgpr-spill-fi-skip-processing-stack-arg-dbg-value-list.mir
@@ -40,8 +40,11 @@ machineFunctionInfo:
     privateSegmentWaveByteOffset: { reg: '$sgpr9' }
 body:             |
   ; CHECK-LABEL: name: test
+  ; CHECK: machineMetadataNodes:
+  ; CHECK-DAG: '![[SP:[0-9]+]] = distinct !DISubprogram
+  ; CHECK-DAG: '![[VAR:[0-9]+]] = !DILocalVariable(name: "a", scope: ![[SP]],
   ; CHECK: bb.0:
-  ; CHECK:   DBG_VALUE_LIST <{{.*}}>, !DIExpression(), $noreg, 0, debug-location !DILocation(line: 10, column: 9, scope: <{{.*}}>)
+  ; CHECK:   DBG_VALUE_LIST ![[VAR]], !DIExpression(), $noreg, 0, debug-location !DILocation(line: 10, column: 9, scope: ![[SP]])
   bb.0:
     $vgpr2 = IMPLICIT_DEF
     SI_SPILL_V32_SAVE $vgpr2, %stack.0, $sgpr32, 0, implicit $exec :: (store (s32) into %stack.0, align 4, addrspace 5)

--- a/llvm/test/CodeGen/MIR/Generic/machine-metadata-err0.mir
+++ b/llvm/test/CodeGen/MIR/Generic/machine-metadata-err0.mir
@@ -12,4 +12,4 @@ name: t0
 machineMetadataNodes:
   - '9 = distinct !{!9, !7, !"Dst"}'
 ...
-# CHECK: [[@LINE-2]]:6: expected a metadata node
+# CHECK: [[@LINE-2]]:6: expected a metadata definition

--- a/llvm/test/CodeGen/MIR/Generic/machine-metadata-err1.mir
+++ b/llvm/test/CodeGen/MIR/Generic/machine-metadata-err1.mir
@@ -12,4 +12,4 @@ name: t0
 machineMetadataNodes:
   - '! = distinct !{!9, !7, !"Dst"}'
 ...
-# CHECK: [[@LINE-2]]:8: expected metadata id after '!'
+# CHECK: [[@LINE-2]]:8: expected integer

--- a/llvm/test/CodeGen/MIR/Generic/machine-metadata-err10.mir
+++ b/llvm/test/CodeGen/MIR/Generic/machine-metadata-err10.mir
@@ -1,0 +1,15 @@
+# RUN: not llc -run-pass none -o /dev/null %s 2>&1 | FileCheck %s
+# This test ensures that each machine metadata list item contains exactly one
+# definition.
+
+--- |
+  define i32 @t0() {
+    ret i32 0
+  }
+...
+---
+name: t0
+machineMetadataNodes:
+  - '!9 = !{} !10 = !{}'
+...
+# CHECK: [[@LINE-2]]:{{[0-9]+}}: expected end of metadata definition

--- a/llvm/test/CodeGen/MIR/Generic/machine-metadata-err11.mir
+++ b/llvm/test/CodeGen/MIR/Generic/machine-metadata-err11.mir
@@ -1,0 +1,16 @@
+# RUN: not llc -run-pass none -o /dev/null %s 2>&1 | FileCheck %s
+# This test ensures that comments cannot cross machine metadata list item
+# boundaries.
+
+--- |
+  define i32 @t0() {
+    ret i32 0
+  }
+...
+---
+name: t0
+machineMetadataNodes:
+  - '!9 = !{} /*'
+  - '*/ !10 = !{}'
+...
+# CHECK: [[@LINE-3]]:{{[0-9]+}}: expected end of metadata definition

--- a/llvm/test/CodeGen/MIR/Generic/machine-metadata-err12.mir
+++ b/llvm/test/CodeGen/MIR/Generic/machine-metadata-err12.mir
@@ -1,0 +1,19 @@
+# RUN: not llc -run-pass none -o /dev/null %s 2>&1 | FileCheck %s
+# This test ensures that diagnostics for multiline machine metadata definitions
+# point into the correct list item.
+
+--- |
+  define i32 @t0() {
+    ret i32 0
+  }
+...
+---
+name: t0
+machineMetadataNodes:
+  - |
+    !9 = !{
+      invalid
+    }
+  - '!10 = !{}'
+...
+# CHECK: [[@LINE-4]]:{{[0-9]+}}: expected metadata operand

--- a/llvm/test/CodeGen/MIR/Generic/machine-metadata-err2.mir
+++ b/llvm/test/CodeGen/MIR/Generic/machine-metadata-err2.mir
@@ -12,4 +12,4 @@ name: t0
 machineMetadataNodes:
   - '!9 = distinct {!9, !7, !"Dst"}'
 ...
-# CHECK: [[@LINE-2]]:20: expected a metadata node
+# CHECK: [[@LINE-2]]:20: Expected '!' here

--- a/llvm/test/CodeGen/MIR/Generic/machine-metadata-err7.mir
+++ b/llvm/test/CodeGen/MIR/Generic/machine-metadata-err7.mir
@@ -12,4 +12,4 @@ name: t0
 machineMetadataNodes:
   - '!9 = distinct !{!, !7, !"Dst"}'
 ...
-# CHECK: [[@LINE-2]]:23: expected metadata id after '!'
+# CHECK: [[@LINE-2]]:23: expected integer

--- a/llvm/test/CodeGen/MIR/Generic/machine-metadata-err8.mir
+++ b/llvm/test/CodeGen/MIR/Generic/machine-metadata-err8.mir
@@ -12,4 +12,4 @@ name: t0
 machineMetadataNodes:
   - '!9 = distinct !{!9, !7, !"Dst"}'
 ...
-# CHECK: [[@LINE-2]]:26: use of undefined metadata '!7'
+# CHECK: [[@LINE-2]]:27: use of undefined metadata '!7'

--- a/llvm/test/CodeGen/MIR/Generic/machine-metadata-err9.mir
+++ b/llvm/test/CodeGen/MIR/Generic/machine-metadata-err9.mir
@@ -10,6 +10,7 @@
 ---
 name: t0
 machineMetadataNodes:
-  - '!9 = distinct !{9, !7, !"Dst"}'
+  - '!9 = distinct !{!9, !7,'
+  - '!"Dst"}'
 ...
-# CHECK: [[@LINE-2]]:22: expected metadata operand
+# CHECK: [[@LINE-3]]:{{[0-9]+}}: expected end of metadata definition

--- a/llvm/test/CodeGen/MIR/X86/machine-metadata-round-trip.mir
+++ b/llvm/test/CodeGen/MIR/X86/machine-metadata-round-trip.mir
@@ -1,0 +1,35 @@
+# RUN: llc -mtriple=x86_64 -run-pass=none -o - %s | FileCheck %s
+# RUN: llc -mtriple=x86_64 -run-pass=none -o - %s | llc -mtriple=x86_64 -x mir -run-pass=none -filetype=null
+
+--- |
+  define i8 @test(ptr %p) {
+    %value = load i8, ptr %p
+    ret i8 %value
+  }
+...
+---
+name: test
+machineMetadataNodes:
+  - '!0 = !{!"heap"}'
+  - '!1 = !{!"pcsections"}'
+  - '!2 = !{!"tag", !"value"}'
+  - '!3 = !{i32 1}'
+  - '!4 = !{i8 0, i8 10}'
+  - '!5 = !{i32 0, !6}'
+  - '!6 = !{!"cache", !"streaming"}'
+body: |
+  bb.0:
+    liveins: $rdi
+
+    ; CHECK: machineMetadataNodes:
+    ; CHECK-DAG: - '![[HEAP:[0-9]+]] = !{!"heap"}'
+    ; CHECK-DAG: - '![[PCSECTIONS:[0-9]+]] = !{!"pcsections"}'
+    ; CHECK-DAG: - '![[MMRA:[0-9]+]] = !{!"tag", !"value"}'
+    ; CHECK-DAG: - '![[NOALIAS:[0-9]+]] = !{i32 1}'
+    ; CHECK-DAG: - '![[RANGE:[0-9]+]] = !{i8 0, i8 10}'
+    ; CHECK-DAG: - '![[CACHE:[0-9]+]] = !{i32 0, ![[CACHE_HINT:[0-9]+]]}'
+    ; CHECK-DAG: - '![[CACHE_HINT]] = !{!"cache", !"streaming"}'
+    ; CHECK: renamable $al = MOV8rm killed renamable $rdi, 1, $noreg, 0, $noreg, heap-alloc-marker ![[HEAP]], pcsections ![[PCSECTIONS]], mmra ![[MMRA]] :: (load (s8) from %ir.p, !noalias.addrspace ![[NOALIAS]], !range ![[RANGE]], !mem.cache_hint ![[CACHE]])
+    renamable $al = MOV8rm killed renamable $rdi, 1, $noreg, 0, $noreg, heap-alloc-marker !0, pcsections !1, mmra !2 :: (load (s8) from %ir.p, !noalias.addrspace !3, !range !4, !mem.cache_hint !5)
+    RET64 implicit killed $al
+...

--- a/llvm/test/CodeGen/MIR/X86/machine-metadata-specialized.mir
+++ b/llvm/test/CodeGen/MIR/X86/machine-metadata-specialized.mir
@@ -1,0 +1,38 @@
+# RUN: llc -mtriple=x86_64 -run-pass=none -o - %s | FileCheck %s
+# RUN: llc -mtriple=x86_64 -run-pass=none -o - %s | llc -mtriple=x86_64 -x mir -run-pass=none -filetype=null
+
+--- |
+  define void @test() {
+    ret void
+  }
+...
+---
+name: test
+machineMetadataNodes:
+  - '!0 = !DILocation(line: 1, scope: !1)'
+  - '!1 = distinct !DISubprogram(name: "test", scope: !2, file: !2, line: 1, type: !3, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !6, retainedNodes: !7)'
+  - '!2 = !DIFile(filename: "test.c", directory: "/tmp")'
+  - '!3 = !DISubroutineType(types: !4)'
+  - '!4 = !{null}'
+  - '!5 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)'
+  - '!6 = distinct !DICompileUnit(language: DW_LANG_C99, file: !2, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)'
+  - '!7 = !{}'
+  - '!8 = !DILocalVariable(name: "x", scope: !1, file: !2, line: 1, type: !5)'
+  - '!9 = !DILocalVariable(name: "y", scope: !1, file: !2, line: 2, type: !5)'
+  - '!10 = !DILocation(line: 2, scope: !1)'
+entry_values:
+  - { entry-value-register: '$rax', debug-info-variable: '!9', debug-info-expression: '!DIExpression(DW_OP_LLVM_entry_value, 1)',
+      debug-info-location: '!10' }
+# CHECK: entry_values:
+# CHECK:   - { entry-value-register: '$rax', debug-info-variable: '![[ENTRY_VAR:[0-9]+]]', debug-info-expression: '!DIExpression(DW_OP_LLVM_entry_value, 1)',
+# CHECK:       debug-info-location: '!DILocation(line: 2, scope: ![[SP:[0-9]+]])' }
+body: |
+  bb.0:
+    ; CHECK: machineMetadataNodes:
+    ; CHECK-DAG: - '![[SP]] = distinct !DISubprogram(name: "test"
+    ; CHECK-DAG: - '![[VAR:[0-9]+]] = !DILocalVariable(name: "x", scope: ![[SP]]
+    ; CHECK-DAG: - '![[ENTRY_VAR]] = !DILocalVariable(name: "y", scope: ![[SP]]
+    ; CHECK: DBG_VALUE $rax, $noreg, ![[VAR]], !DIExpression(), debug-location !DILocation(line: 1, scope: ![[SP]])
+    DBG_VALUE $rax, $noreg, !8, !DIExpression(), debug-location !0
+    RET 0
+...


### PR DESCRIPTION
MIR only emitted definitions for a subset of metadata referenced by machine
functions. Other nodes were printed as pointer values and could not be parsed
back.

Collect metadata referenced by machine instructions, memory operands, and
variable debug information. Keep debug locations inline so the output remains
readable.

Parse each machine metadata item with LLVM IR's metadata parser while
preserving the YAML item boundaries. This supports specialized nodes, cycles,
and forward references without accepting definitions split across list items,
and removes the old tuple-only parser.
