### PR TITLE
[orc-rt] Group SPS headers under sps/ subdirectories. NFC.

### DIFF
--- a/orc-rt/include/CMakeLists.txt
+++ b/orc-rt/include/CMakeLists.txt
@@ -18,7 +18,6 @@ set(ORC_RT_HEADERS
     orc-rt/bedrock/Service.h
     orc-rt/bedrock/Session.h
     orc-rt/bedrock/SimpleNativeMemoryMap.h
-    orc-rt/bedrock/SimpleRemoteCA.h
     orc-rt/bedrock/SimpleSymbolTable.h
     orc-rt/bedrock/StandaloneMachOUnwindInfoRegistrar.h
     orc-rt/bedrock/TaskGroup.h
@@ -29,6 +28,7 @@ set(ORC_RT_HEADERS
     orc-rt/bedrock/sps/MemoryAccessSPSCI.h
     orc-rt/bedrock/sps/NativeDylibManagerSPSCI.h
     orc-rt/bedrock/sps/SimpleNativeMemoryMapSPSCI.h
+    orc-rt/bedrock/sps/SimpleRemoteCA.h
     orc-rt/bedrock/sps/StandaloneMachOUnwindInfoRegistrarSPSCI.h
     orc-rt/support/AllocAction.h
     orc-rt/support/BitmaskEnum.h
@@ -44,11 +44,6 @@ set(ORC_RT_HEADERS
     orc-rt/support/MemoryFlags.h
     orc-rt/support/Proxy.h
     orc-rt/support/RTTI.h
-    orc-rt/support/SPSAllocAction.h
-    orc-rt/support/SPSMemoryFlags.h
-    orc-rt/support/SPSWrapperFunction.h
-    orc-rt/support/SPSWrapperFunctionBuffer.h
-    orc-rt/support/SimplePackedSerialization.h
     orc-rt/support/StringPool.h
     orc-rt/support/WrapperFunction.h
     orc-rt/support/bind.h
@@ -57,6 +52,11 @@ set(ORC_RT_HEADERS
     orc-rt/support/move_only_function.h
     orc-rt/support/scope_exit.h
     orc-rt/support/span.h
+    orc-rt/support/sps/SPSAllocAction.h
+    orc-rt/support/sps/SPSMemoryFlags.h
+    orc-rt/support/sps/SPSWrapperFunction.h
+    orc-rt/support/sps/SPSWrapperFunctionBuffer.h
+    orc-rt/support/sps/SimplePackedSerialization.h
 )
 
 # Add generated config header

--- a/orc-rt/include/orc-rt/bedrock/sps/SimpleRemoteCA.h
+++ b/orc-rt/include/orc-rt/bedrock/sps/SimpleRemoteCA.h
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef ORC_RT_BEDROCK_SIMPLEREMOTECA_H
-#define ORC_RT_BEDROCK_SIMPLEREMOTECA_H
+#ifndef ORC_RT_BEDROCK_SPS_SIMPLEREMOTECA_H
+#define ORC_RT_BEDROCK_SPS_SIMPLEREMOTECA_H
 
 #include "orc-rt/bedrock/BootstrapInfo.h"
 #include "orc-rt/bedrock/Session.h"
@@ -111,4 +111,4 @@ private:
 
 } // namespace orc_rt
 
-#endif // ORC_RT_BEDROCK_SIMPLEREMOTECA_H
+#endif // ORC_RT_BEDROCK_SPS_SIMPLEREMOTECA_H

--- a/orc-rt/include/orc-rt/support/sps/SPSAllocAction.h
+++ b/orc-rt/include/orc-rt/support/sps/SPSAllocAction.h
@@ -11,13 +11,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef ORC_RT_SUPPORT_SPSALLOCACTION_H
-#define ORC_RT_SUPPORT_SPSALLOCACTION_H
+#ifndef ORC_RT_SUPPORT_SPS_SPSALLOCACTION_H
+#define ORC_RT_SUPPORT_SPS_SPSALLOCACTION_H
 
 #include "orc-rt/support/AllocAction.h"
 #include "orc-rt/support/MacroUtils.h"
-#include "orc-rt/support/SPSWrapperFunctionBuffer.h"
-#include "orc-rt/support/SimplePackedSerialization.h"
+#include "orc-rt/support/sps/SPSWrapperFunctionBuffer.h"
+#include "orc-rt/support/sps/SimplePackedSerialization.h"
 
 /// Define an allocation-action wrapper function with the given Name that
 /// uses SPS to deserialize its arguments and dispatches to Handle.
@@ -125,4 +125,4 @@ template <typename... SPSArgTs> struct SPSAllocActionFunction {
 
 } // namespace orc_rt
 
-#endif // ORC_RT_SUPPORT_SPSALLOCACTION_H
+#endif // ORC_RT_SUPPORT_SPS_SPSALLOCACTION_H

--- a/orc-rt/include/orc-rt/support/sps/SPSMemoryFlags.h
+++ b/orc-rt/include/orc-rt/support/sps/SPSMemoryFlags.h
@@ -10,11 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef ORC_RT_SUPPORT_SPSMEMORYFLAGS_H
-#define ORC_RT_SUPPORT_SPSMEMORYFLAGS_H
+#ifndef ORC_RT_SUPPORT_SPS_SPSMEMORYFLAGS_H
+#define ORC_RT_SUPPORT_SPS_SPSMEMORYFLAGS_H
 
 #include "orc-rt/support/MemoryFlags.h"
-#include "orc-rt/support/SimplePackedSerialization.h"
+#include "orc-rt/support/sps/SimplePackedSerialization.h"
 
 namespace orc_rt {
 
@@ -46,4 +46,4 @@ public:
 
 } // namespace orc_rt
 
-#endif // ORC_RT_SUPPORT_SPSMEMORYFLAGS_H
+#endif // ORC_RT_SUPPORT_SPS_SPSMEMORYFLAGS_H

--- a/orc-rt/include/orc-rt/support/sps/SPSWrapperFunction.h
+++ b/orc-rt/include/orc-rt/support/sps/SPSWrapperFunction.h
@@ -11,12 +11,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef ORC_RT_SUPPORT_SPSWRAPPERFUNCTION_H
-#define ORC_RT_SUPPORT_SPSWRAPPERFUNCTION_H
+#ifndef ORC_RT_SUPPORT_SPS_SPSWRAPPERFUNCTION_H
+#define ORC_RT_SUPPORT_SPS_SPSWRAPPERFUNCTION_H
 
 #include "orc-rt/support/Compiler.h"
-#include "orc-rt/support/SimplePackedSerialization.h"
 #include "orc-rt/support/WrapperFunction.h"
+#include "orc-rt/support/sps/SimplePackedSerialization.h"
 
 #define ORC_RT_SPS_WRAPPER(Name, SPSSig, Handle)                               \
   static void Name(orc_rt_SessionRef S, orc_rt_WrapperFunctionBuffer ArgBytes, \
@@ -150,4 +150,4 @@ template <typename SPSSig> struct SPSWrapperFunction {
 
 } // namespace orc_rt
 
-#endif // ORC_RT_SUPPORT_SPSWRAPPERFUNCTION_H
+#endif // ORC_RT_SUPPORT_SPS_SPSWRAPPERFUNCTION_H

--- a/orc-rt/include/orc-rt/support/sps/SPSWrapperFunctionBuffer.h
+++ b/orc-rt/include/orc-rt/support/sps/SPSWrapperFunctionBuffer.h
@@ -10,11 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef ORC_RT_SUPPORT_SPSWRAPPERFUNCTIONBUFFER_H
-#define ORC_RT_SUPPORT_SPSWRAPPERFUNCTIONBUFFER_H
+#ifndef ORC_RT_SUPPORT_SPS_SPSWRAPPERFUNCTIONBUFFER_H
+#define ORC_RT_SUPPORT_SPS_SPSWRAPPERFUNCTIONBUFFER_H
 
-#include "orc-rt/support/SimplePackedSerialization.h"
 #include "orc-rt/support/WrapperFunction.h"
+#include "orc-rt/support/sps/SimplePackedSerialization.h"
 
 namespace orc_rt {
 
@@ -45,4 +45,4 @@ public:
 
 } // namespace orc_rt
 
-#endif // ORC_RT_SUPPORT_SPSWRAPPERFUNCTIONBUFFER_H
+#endif // ORC_RT_SUPPORT_SPS_SPSWRAPPERFUNCTIONBUFFER_H

--- a/orc-rt/include/orc-rt/support/sps/SimplePackedSerialization.h
+++ b/orc-rt/include/orc-rt/support/sps/SimplePackedSerialization.h
@@ -31,8 +31,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef ORC_RT_SUPPORT_SIMPLEPACKEDSERIALIZATION_H
-#define ORC_RT_SUPPORT_SIMPLEPACKEDSERIALIZATION_H
+#ifndef ORC_RT_SUPPORT_SPS_SIMPLEPACKEDSERIALIZATION_H
+#define ORC_RT_SUPPORT_SPS_SIMPLEPACKEDSERIALIZATION_H
 
 #include "orc-rt/support/Error.h"
 #include "orc-rt/support/ExecutorAddress.h"
@@ -823,4 +823,4 @@ public:
 
 } // namespace orc_rt
 
-#endif // ORC_RT_SUPPORT_SIMPLEPACKEDSERIALIZATION_H
+#endif // ORC_RT_SUPPORT_SPS_SIMPLEPACKEDSERIALIZATION_H

--- a/orc-rt/lib/bedrock/CMakeLists.txt
+++ b/orc-rt/lib/bedrock/CMakeLists.txt
@@ -12,7 +12,6 @@ set(ORC_RT_SOURCES
   Service.cpp
   Session.cpp
   SimpleNativeMemoryMap.cpp
-  SimpleRemoteCA.cpp
   SimpleSymbolTable.cpp
   StandaloneMachOUnwindInfoRegistrar.cpp
   ThreadPoolRunner.cpp
@@ -22,6 +21,7 @@ set(ORC_RT_SOURCES
   sps/MemoryAccessSPSCI.cpp
   sps/NativeDylibManagerSPSCI.cpp
   sps/SimpleNativeMemoryMapSPSCI.cpp
+  sps/SimpleRemoteCA.cpp
   sps/StandaloneMachOUnwindInfoRegistrarSPSCI.cpp
   )
 

--- a/orc-rt/lib/bedrock/sps/CallSPSCI.cpp
+++ b/orc-rt/lib/bedrock/sps/CallSPSCI.cpp
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "orc-rt/bedrock/sps/CallSPSCI.h"
-#include "orc-rt/support/SPSWrapperFunction.h"
 #include "orc-rt/support/move_only_function.h"
+#include "orc-rt/support/sps/SPSWrapperFunction.h"
 
 #include <string>
 #include <vector>

--- a/orc-rt/lib/bedrock/sps/GDBJITRegistrarSPSCI.cpp
+++ b/orc-rt/lib/bedrock/sps/GDBJITRegistrarSPSCI.cpp
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "orc-rt/bedrock/sps/GDBJITRegistrarSPSCI.h"
-#include "orc-rt/support/SPSAllocAction.h"
+#include "orc-rt/support/sps/SPSAllocAction.h"
 
 #include "orc-rt-internal/bedrock/GDBJITRegistrar.h"
 

--- a/orc-rt/lib/bedrock/sps/MemoryAccessSPSCI.cpp
+++ b/orc-rt/lib/bedrock/sps/MemoryAccessSPSCI.cpp
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "orc-rt/bedrock/sps/MemoryAccessSPSCI.h"
-#include "orc-rt/support/SPSWrapperFunction.h"
 #include "orc-rt/support/move_only_function.h"
+#include "orc-rt/support/sps/SPSWrapperFunction.h"
 
 #include <cstring>
 #include <vector>

--- a/orc-rt/lib/bedrock/sps/NativeDylibManagerSPSCI.cpp
+++ b/orc-rt/lib/bedrock/sps/NativeDylibManagerSPSCI.cpp
@@ -12,7 +12,7 @@
 
 #include "orc-rt/bedrock/sps/NativeDylibManagerSPSCI.h"
 #include "orc-rt/bedrock/NativeDylibManager.h"
-#include "orc-rt/support/SPSWrapperFunction.h"
+#include "orc-rt/support/sps/SPSWrapperFunction.h"
 
 namespace orc_rt {
 

--- a/orc-rt/lib/bedrock/sps/SimpleNativeMemoryMapSPSCI.cpp
+++ b/orc-rt/lib/bedrock/sps/SimpleNativeMemoryMapSPSCI.cpp
@@ -13,9 +13,9 @@
 #include "orc-rt/bedrock/sps/SimpleNativeMemoryMapSPSCI.h"
 
 #include "orc-rt/bedrock/SimpleNativeMemoryMap.h"
-#include "orc-rt/support/SPSAllocAction.h"
-#include "orc-rt/support/SPSMemoryFlags.h"
-#include "orc-rt/support/SPSWrapperFunction.h"
+#include "orc-rt/support/sps/SPSAllocAction.h"
+#include "orc-rt/support/sps/SPSMemoryFlags.h"
+#include "orc-rt/support/sps/SPSWrapperFunction.h"
 
 namespace orc_rt {
 

--- a/orc-rt/lib/bedrock/sps/SimpleRemoteCA.cpp
+++ b/orc-rt/lib/bedrock/sps/SimpleRemoteCA.cpp
@@ -10,10 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "orc-rt/bedrock/SimpleRemoteCA.h"
+#include "orc-rt/bedrock/sps/SimpleRemoteCA.h"
 
 #include "orc-rt/support/Compiler.h"
-#include "orc-rt/support/SimplePackedSerialization.h"
+#include "orc-rt/support/sps/SimplePackedSerialization.h"
 
 #include <string>
 

--- a/orc-rt/lib/bedrock/sps/StandaloneMachOUnwindInfoRegistrarSPSCI.cpp
+++ b/orc-rt/lib/bedrock/sps/StandaloneMachOUnwindInfoRegistrarSPSCI.cpp
@@ -13,7 +13,7 @@
 
 #include "orc-rt/bedrock/sps/StandaloneMachOUnwindInfoRegistrarSPSCI.h"
 #include "orc-rt/bedrock/StandaloneMachOUnwindInfoRegistrar.h"
-#include "orc-rt/support/SPSAllocAction.h"
+#include "orc-rt/support/sps/SPSAllocAction.h"
 
 namespace orc_rt::sps_ci {
 

--- a/orc-rt/test/unit/CMakeLists.txt
+++ b/orc-rt/test/unit/CMakeLists.txt
@@ -30,11 +30,6 @@ add_orc_rt_unittest(CoreTests
   support/MemoryFlagsTest.cpp
   support/ProxyTest.cpp
   support/RTTITest.cpp
-  support/SPSAllocActionTest.cpp
-  support/SPSMemoryFlagsTest.cpp
-  support/SPSWrapperFunctionBufferTest.cpp
-  support/SPSWrapperFunctionTest.cpp
-  support/SimplePackedSerializationTest.cpp
   support/StringExtrasTest.cpp
   support/StringPoolTest.cpp
   support/WrapperFunctionBufferTest.cpp
@@ -45,6 +40,12 @@ add_orc_rt_unittest(CoreTests
   support/scope_exit-test.cpp
   support/span-test.cpp
 
+  support/sps/SPSAllocActionTest.cpp
+  support/sps/SPSMemoryFlagsTest.cpp
+  support/sps/SPSWrapperFunctionBufferTest.cpp
+  support/sps/SPSWrapperFunctionTest.cpp
+  support/sps/SimplePackedSerializationTest.cpp
+
   bedrock/BootstrapInfoTest.cpp
   bedrock/ExecutorProcessInfoTest.cpp
   bedrock/InProcessControllerAccessTest.cpp
@@ -52,7 +53,6 @@ add_orc_rt_unittest(CoreTests
   bedrock/QueueingRunnerTest.cpp
   bedrock/SessionTest.cpp
   bedrock/SimpleNativeMemoryMapTest.cpp
-  bedrock/SimpleRemoteCATest.cpp
   bedrock/SimpleSymbolTableTest.cpp
   bedrock/StandaloneMachOUnwindInfoRegistrarTest.cpp
   bedrock/TaskGroupTest.cpp
@@ -62,6 +62,7 @@ add_orc_rt_unittest(CoreTests
   bedrock/sps/MemoryAccessSPSCITest.cpp
   bedrock/sps/NativeDylibManagerSPSCITest.cpp
   bedrock/sps/SimpleNativeMemoryMapSPSCITest.cpp
+  bedrock/sps/SimpleRemoteCATest.cpp
 
   utils/CommandLineTest.cpp
 

--- a/orc-rt/test/unit/SimplePackedSerializationTestUtils.h
+++ b/orc-rt/test/unit/SimplePackedSerializationTestUtils.h
@@ -9,8 +9,8 @@
 #ifndef ORC_RT_UNITTEST_SIMPLEPACKEDSERIALIZATIONTESTUTILS_H
 #define ORC_RT_UNITTEST_SIMPLEPACKEDSERIALIZATIONTESTUTILS_H
 
-#include "orc-rt/support/SimplePackedSerialization.h"
 #include "orc-rt/support/WrapperFunction.h"
+#include "orc-rt/support/sps/SimplePackedSerialization.h"
 #include "gtest/gtest.h"
 
 #include <optional>

--- a/orc-rt/test/unit/bedrock/SessionTest.cpp
+++ b/orc-rt/test/unit/bedrock/SessionTest.cpp
@@ -12,7 +12,7 @@
 
 #include "orc-rt/bedrock/Session.h"
 #include "orc-rt/bedrock/QueueingRunner.h"
-#include "orc-rt/support/SPSWrapperFunction.h"
+#include "orc-rt/support/sps/SPSWrapperFunction.h"
 
 #include "orc-rt-c/bedrock/Session.h"
 

--- a/orc-rt/test/unit/bedrock/SimpleNativeMemoryMapTest.cpp
+++ b/orc-rt/test/unit/bedrock/SimpleNativeMemoryMapTest.cpp
@@ -12,7 +12,7 @@
 
 #include "orc-rt/bedrock/SimpleNativeMemoryMap.h"
 #include "orc-rt/bedrock/Session.h"
-#include "orc-rt/support/SPSAllocAction.h"
+#include "orc-rt/support/sps/SPSAllocAction.h"
 
 #include "AllocActionTestUtils.h"
 #include "CommonTestUtils.h"

--- a/orc-rt/test/unit/bedrock/sps/CallSPSCITest.cpp
+++ b/orc-rt/test/unit/bedrock/sps/CallSPSCITest.cpp
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "orc-rt/bedrock/sps/CallSPSCI.h"
-#include "orc-rt/support/SPSWrapperFunction.h"
+#include "orc-rt/support/sps/SPSWrapperFunction.h"
 
 #include "DirectCaller.h"
 #include "gtest/gtest.h"

--- a/orc-rt/test/unit/bedrock/sps/MemoryAccessSPSCITest.cpp
+++ b/orc-rt/test/unit/bedrock/sps/MemoryAccessSPSCITest.cpp
@@ -12,7 +12,7 @@
 
 #include "orc-rt/bedrock/sps/MemoryAccessSPSCI.h"
 #include "orc-rt/bedrock/SimpleSymbolTable.h"
-#include "orc-rt/support/SPSWrapperFunction.h"
+#include "orc-rt/support/sps/SPSWrapperFunction.h"
 
 #include "DirectCaller.h"
 #include "gtest/gtest.h"

--- a/orc-rt/test/unit/bedrock/sps/NativeDylibManagerSPSCITest.cpp
+++ b/orc-rt/test/unit/bedrock/sps/NativeDylibManagerSPSCITest.cpp
@@ -13,7 +13,7 @@
 #include "orc-rt/bedrock/sps/NativeDylibManagerSPSCI.h"
 #include "orc-rt/bedrock/NativeDylibManager.h"
 #include "orc-rt/bedrock/Session.h"
-#include "orc-rt/support/SPSWrapperFunction.h"
+#include "orc-rt/support/sps/SPSWrapperFunction.h"
 
 #include "CommonTestUtils.h"
 #include "DirectCaller.h"

--- a/orc-rt/test/unit/bedrock/sps/SimpleNativeMemoryMapSPSCITest.cpp
+++ b/orc-rt/test/unit/bedrock/sps/SimpleNativeMemoryMapSPSCITest.cpp
@@ -13,9 +13,9 @@
 #include "orc-rt/bedrock/sps/SimpleNativeMemoryMapSPSCI.h"
 #include "orc-rt/bedrock/Session.h"
 #include "orc-rt/bedrock/SimpleNativeMemoryMap.h"
-#include "orc-rt/support/SPSAllocAction.h"
-#include "orc-rt/support/SPSMemoryFlags.h"
-#include "orc-rt/support/SPSWrapperFunction.h"
+#include "orc-rt/support/sps/SPSAllocAction.h"
+#include "orc-rt/support/sps/SPSMemoryFlags.h"
+#include "orc-rt/support/sps/SPSWrapperFunction.h"
 
 #include "AllocActionTestUtils.h"
 #include "CommonTestUtils.h"

--- a/orc-rt/test/unit/bedrock/sps/SimpleRemoteCATest.cpp
+++ b/orc-rt/test/unit/bedrock/sps/SimpleRemoteCATest.cpp
@@ -14,13 +14,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "orc-rt/bedrock/SimpleRemoteCA.h"
+#include "orc-rt/bedrock/sps/SimpleRemoteCA.h"
 
 #include "gtest/gtest.h"
 
 #include "CommonTestUtils.h"
 
-#include "orc-rt/support/SimplePackedSerialization.h"
+#include "orc-rt/support/sps/SimplePackedSerialization.h"
 
 #include <optional>
 #include <string>

--- a/orc-rt/test/unit/support/sps/SPSAllocActionTest.cpp
+++ b/orc-rt/test/unit/support/sps/SPSAllocActionTest.cpp
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "orc-rt/support/SPSAllocAction.h"
+#include "orc-rt/support/sps/SPSAllocAction.h"
 
 #include "orc-rt/support/ExecutorAddress.h"
 

--- a/orc-rt/test/unit/support/sps/SPSMemoryFlagsTest.cpp
+++ b/orc-rt/test/unit/support/sps/SPSMemoryFlagsTest.cpp
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "orc-rt/support/SPSMemoryFlags.h"
+#include "orc-rt/support/sps/SPSMemoryFlags.h"
 
 #include "SimplePackedSerializationTestUtils.h"
 #include "gtest/gtest.h"

--- a/orc-rt/test/unit/support/sps/SPSWrapperFunctionBufferTest.cpp
+++ b/orc-rt/test/unit/support/sps/SPSWrapperFunctionBufferTest.cpp
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "orc-rt/support/SPSWrapperFunctionBuffer.h"
+#include "orc-rt/support/sps/SPSWrapperFunctionBuffer.h"
 
 #include "SimplePackedSerializationTestUtils.h"
 #include "gtest/gtest.h"

--- a/orc-rt/test/unit/support/sps/SPSWrapperFunctionTest.cpp
+++ b/orc-rt/test/unit/support/sps/SPSWrapperFunctionTest.cpp
@@ -12,9 +12,9 @@
 
 #include "CommonTestUtils.h"
 
-#include "orc-rt/support/SPSWrapperFunction.h"
 #include "orc-rt/support/WrapperFunction.h"
 #include "orc-rt/support/move_only_function.h"
+#include "orc-rt/support/sps/SPSWrapperFunction.h"
 
 #include "DirectCaller.h"
 

--- a/orc-rt/test/unit/support/sps/SimplePackedSerializationTest.cpp
+++ b/orc-rt/test/unit/support/sps/SimplePackedSerializationTest.cpp
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "orc-rt/support/SimplePackedSerialization.h"
+#include "orc-rt/support/sps/SimplePackedSerialization.h"
 
 #include "SimplePackedSerializationTestUtils.h"
 #include "gtest/gtest.h"


### PR DESCRIPTION
The SPS format headers move from support/ to support/sps/, and SimpleRemoteCA -- whose wire format is SPS, fixed by compatibility with LLVM's SimpleRemoteEPC -- moves from bedrock/ to bedrock/sps/. Every file whose contents are SPS-specific now lives under an sps/ directory in its layer, matching what the sps-ci -> sps rename set up. Tests and include guards follow.