### PR TITLE
[clang-tidy] Fix readability-trailing-comma false positive on #endif

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/TrailingCommaCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/TrailingCommaCheck.cpp
@@ -44,18 +44,6 @@ static bool isSingleLine(SourceRange Range, const SourceManager &SM) {
          SM.getExpansionLineNumber(Range.getEnd());
 }
 
-namespace {
-
-AST_POLYMORPHIC_MATCHER(isMacro,
-                        AST_POLYMORPHIC_SUPPORTED_TYPES(EnumDecl,
-                                                        InitListExpr)) {
-  return Node.getBeginLoc().isMacroID() || Node.getEndLoc().isMacroID();
-}
-
-AST_MATCHER(EnumDecl, isEmptyEnum) { return Node.enumerators().empty(); }
-
-AST_MATCHER(InitListExpr, isEmptyInitList) { return Node.getNumInits() == 0; }
-
 // True when Tok is a preprocessor directive (the '#' or the directive
 // identifier such as 'endif'). Those tokens can sit between the last
 // enumerator and '}', and must not be treated as a missing trailing comma.
@@ -68,6 +56,18 @@ static bool isPreprocessorDirectiveToken(const Token &Tok,
       Tok.getLocation(), SM, LangOpts, /*IncludeComments=*/false);
   return Prev && Prev->is(tok::hash);
 }
+
+namespace {
+
+AST_POLYMORPHIC_MATCHER(isMacro,
+                        AST_POLYMORPHIC_SUPPORTED_TYPES(EnumDecl,
+                                                        InitListExpr)) {
+  return Node.getBeginLoc().isMacroID() || Node.getEndLoc().isMacroID();
+}
+
+AST_MATCHER(EnumDecl, isEmptyEnum) { return Node.enumerators().empty(); }
+
+AST_MATCHER(InitListExpr, isEmptyInitList) { return Node.getNumInits() == 0; }
 
 } // namespace
 

--- a/clang-tools-extra/clang-tidy/readability/TrailingCommaCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/TrailingCommaCheck.cpp
@@ -56,6 +56,19 @@ AST_MATCHER(EnumDecl, isEmptyEnum) { return Node.enumerators().empty(); }
 
 AST_MATCHER(InitListExpr, isEmptyInitList) { return Node.getNumInits() == 0; }
 
+// True when Tok is a preprocessor directive (the '#' or the directive
+// identifier such as 'endif'). Those tokens can sit between the last
+// enumerator and '}', and must not be treated as a missing trailing comma.
+static bool isPreprocessorDirectiveToken(const Token &Tok,
+                                         const SourceManager &SM,
+                                         const LangOptions &LangOpts) {
+  if (Tok.is(tok::hash))
+    return true;
+  const std::optional<Token> Prev = Lexer::findPreviousToken(
+      Tok.getLocation(), SM, LangOpts, /*IncludeComments=*/false);
+  return Prev && Prev->is(tok::hash);
+}
+
 } // namespace
 
 TrailingCommaCheck::TrailingCommaCheck(StringRef Name,
@@ -110,10 +123,19 @@ void TrailingCommaCheck::checkEnumDecl(const EnumDecl *Enum,
   if (Policy == CommaPolicyKind::Ignore)
     return;
 
-  const std::optional<Token> LastTok =
-      Lexer::findPreviousToken(Enum->getBraceRange().getEnd(),
-                               *Result.SourceManager, getLangOpts(), false);
+  const std::optional<Token> LastTok = Lexer::findPreviousToken(
+      Enum->getBraceRange().getEnd(), *Result.SourceManager, getLangOpts(),
+      /*IncludeComments=*/false);
   if (!LastTok)
+    return;
+
+  // `#endif` (and similar directives) can appear immediately before the
+  // closing brace when enumerators are guarded by `#ifdef`. Walking back from
+  // `}` would otherwise treat that directive as the last enumerator and insert
+  // a comma after it, even when every active enumerator already has a trailing
+  // comma.
+  if (isPreprocessorDirectiveToken(*LastTok, *Result.SourceManager,
+                                   getLangOpts()))
     return;
 
   emitDiag(LastTok->getLocation(), LastTok, DiagKind::Enum, Result, Policy);

--- a/clang-tools-extra/clang-tidy/readability/TrailingCommaCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/TrailingCommaCheck.cpp
@@ -44,9 +44,6 @@ static bool isSingleLine(SourceRange Range, const SourceManager &SM) {
          SM.getExpansionLineNumber(Range.getEnd());
 }
 
-// True when Tok is a preprocessor directive (the '#' or the directive
-// identifier such as 'endif'). Those tokens can sit between the last
-// enumerator and '}', and must not be treated as a missing trailing comma.
 static bool isPreprocessorDirectiveToken(const Token &Tok,
                                          const SourceManager &SM,
                                          const LangOptions &LangOpts) {
@@ -54,7 +51,9 @@ static bool isPreprocessorDirectiveToken(const Token &Tok,
     return true;
   const std::optional<Token> Prev = Lexer::findPreviousToken(
       Tok.getLocation(), SM, LangOpts, /*IncludeComments=*/false);
-  return Prev && Prev->is(tok::hash);
+  return Prev && Prev->is(tok::hash) &&
+         SM.getExpansionLineNumber(Prev->getLocation()) ==
+             SM.getExpansionLineNumber(Tok.getLocation());
 }
 
 namespace {
@@ -129,11 +128,6 @@ void TrailingCommaCheck::checkEnumDecl(const EnumDecl *Enum,
   if (!LastTok)
     return;
 
-  // `#endif` (and similar directives) can appear immediately before the
-  // closing brace when enumerators are guarded by `#ifdef`. Walking back from
-  // `}` would otherwise treat that directive as the last enumerator and insert
-  // a comma after it, even when every active enumerator already has a trailing
-  // comma.
   if (isPreprocessorDirectiveToken(*LastTok, *Result.SourceManager,
                                    getLangOpts()))
     return;

--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -219,6 +219,12 @@ infrastructure are described first, followed by tool-specific sections.
   for intermediate subobjects caused the trailing comma of the enclosing
   list to be incorrectly rewritten.
 
+- Improved {doc}`readability-trailing-comma
+  <clang-tidy/checks/readability/trailing-comma>` check by ignoring
+  preprocessor directives such as `#endif` that appear immediately before an
+  enum's closing brace, which previously produced a false positive and a
+  fix-it that inserted a comma after the directive.
+
 - Improved {doc}`readability-use-std-min-max
   <clang-tidy/checks/readability/use-std-min-max>` check by fixing spurious
   trailing semicolons and lost comments when the `if` body has no braces.

--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -214,16 +214,15 @@ infrastructure are described first, followed by tool-specific sections.
   option to allow customizing the set of ignored types.
 
 - Improved {doc}`readability-trailing-comma
-  <clang-tidy/checks/readability/trailing-comma>` check by fixing false
-  positives on designated initializers, where initializer lists synthesized
-  for intermediate subobjects caused the trailing comma of the enclosing
-  list to be incorrectly rewritten.
+  <clang-tidy/checks/readability/trailing-comma>` check:
 
-- Improved {doc}`readability-trailing-comma
-  <clang-tidy/checks/readability/trailing-comma>` check by ignoring
-  preprocessor directives such as `#endif` that appear immediately before an
-  enum's closing brace, which previously produced a false positive and a
-  fix-it that inserted a comma after the directive.
+  - Fixed false positives on designated initializers, where initializer lists
+    synthesized for intermediate subobjects caused the trailing comma of the
+    enclosing list to be incorrectly rewritten.
+
+  - Ignored preprocessor directives such as `#endif` that appear immediately
+    before an enum's closing brace, which previously produced a false positive
+    and a fix-it that inserted a comma after the directive.
 
 - Improved {doc}`readability-use-std-min-max
   <clang-tidy/checks/readability/use-std-min-max>` check by fixing spurious

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/trailing-comma-cxx11.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/trailing-comma-cxx11.cpp
@@ -54,3 +54,17 @@ struct PackSingle {
 
 PackSingle<int> p1;
 PackSingle<int, double, char> p3;
+
+// Preprocessor-guarded enumerators already have trailing commas; do not insert
+// a comma after '#endif'.
+enum class color_t : unsigned {
+  RED = 0,
+  GREEN = 1,
+  BLUE = 2,
+  CYAN = 3,
+#ifdef USE_MAGENTA
+  LAST = CYAN,
+#else
+  LAST = BLUE,
+#endif
+};

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/trailing-comma-cxx11.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/trailing-comma-cxx11.cpp
@@ -55,8 +55,7 @@ struct PackSingle {
 PackSingle<int> p1;
 PackSingle<int, double, char> p3;
 
-// Preprocessor-guarded enumerators already have trailing commas; do not insert
-// a comma after '#endif'.
+// #endif before '}' is not a missing trailing comma.
 enum class color_t : unsigned {
   RED = 0,
   GREEN = 1,

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/trailing-comma.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/trailing-comma.cpp
@@ -144,6 +144,40 @@ void nestedMultiLine() {
   // CHECK-FIXES-NEXT:   };
 }
 
+// Preprocessor directives immediately before '}' must not be treated as the
+// last enumerator. Both branches already have trailing commas; a false
+// positive would insert a comma after '#endif'.
+enum color_t {
+  COLOR_RED = 0,
+  COLOR_GREEN = 1,
+  COLOR_BLUE = 2,
+  COLOR_CYAN = 3,
+#ifdef USE_MAGENTA
+  COLOR_LAST = COLOR_CYAN,
+#else
+  COLOR_LAST = COLOR_BLUE,
+#endif
+};
+
+enum GuardedEnumerator {
+  GE_A,
+  GE_B,
+#ifdef USE_EXTRA
+  GE_C,
+#endif
+};
+
+// An enumerator named 'endif' is still diagnosed; only '#endif' is ignored.
+enum EndsWithEndifName {
+  foo,
+  endif
+};
+// CHECK-MESSAGES: :[[@LINE-2]]:8: warning: enum should have a trailing comma
+// CHECK-FIXES: enum EndsWithEndifName {
+// CHECK-FIXES-NEXT:   foo,
+// CHECK-FIXES-NEXT:   endif,
+// CHECK-FIXES-NEXT: };
+
 // Macros are ignored
 #define ENUM(n, a, b) enum n { a, b }
 #define INIT {1, 2}

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/trailing-comma.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/trailing-comma.cpp
@@ -144,9 +144,7 @@ void nestedMultiLine() {
   // CHECK-FIXES-NEXT:   };
 }
 
-// Preprocessor directives immediately before '}' must not be treated as the
-// last enumerator. Both branches already have trailing commas; a false
-// positive would insert a comma after '#endif'.
+// #endif before '}' is not a missing trailing comma.
 enum color_t {
   COLOR_RED = 0,
   COLOR_GREEN = 1,
@@ -167,7 +165,6 @@ enum GuardedEnumerator {
 #endif
 };
 
-// An enumerator named 'endif' is still diagnosed; only '#endif' is ignored.
 enum EndsWithEndifName {
   foo,
   endif
@@ -177,6 +174,21 @@ enum EndsWithEndifName {
 // CHECK-FIXES-NEXT:   foo,
 // CHECK-FIXES-NEXT:   endif,
 // CHECK-FIXES-NEXT: };
+
+enum NullDirectiveBefore {
+#
+  ND_A
+};
+// CHECK-MESSAGES: :[[@LINE-2]]:7: warning: enum should have a trailing comma
+// CHECK-FIXES: enum NullDirectiveBefore {
+// CHECK-FIXES-NEXT: #
+// CHECK-FIXES-NEXT:   ND_A,
+// CHECK-FIXES-NEXT: };
+
+enum NullDirectiveAfter {
+  ND_B,
+#
+};
 
 // Macros are ignored
 #define ENUM(n, a, b) enum n { a, b }


### PR DESCRIPTION
The `readability-trailing-comma` check looks at the token immediately before an enum's closing brace to decide whether a trailing comma is present. When the last enumerators are wrapped in `#ifdef` / `#else` / `#endif`, that token is the directive identifier `endif`, so the check reports a missing comma and `-fix` inserts `,` after `#endif`. That is outside the enumerator list and corrupts the source even when every enumerator already has a trailing comma.

Skip the diagnostic when the token before `}` is a preprocessor directive (`#` or a token preceded by `#`). An enumerator whose name happens to be `endif` is still diagnosed, because it is not preceded by `#`.

Fixes #218957
