### PR TITLE
[clang][Parse] Improve diagnostics for '>>>' closing template parameter lists in CUDA.

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -416,6 +416,8 @@ features cannot lower the translation-unit ABI level;
 - `-Wc++98-compat` now diagnoses explicit conversion functions in C++20 and
   later, matching the behavior in C++11 through C++17. (#GH161689)
 
+- Fixed incorrect diagnostics for nested template parameter lists containing ``>>>`` when parsing in CUDA mode.
+
 ### Improvements to Clang's time-trace
 
 ### Improvements to Coverage Mapping

--- a/clang/lib/Parse/ParseTemplate.cpp
+++ b/clang/lib/Parse/ParseTemplate.cpp
@@ -327,8 +327,8 @@ bool Parser::ParseTemplateParameters(
 
   // Try to parse the template parameter list.
   bool Failed = false;
-  // FIXME: Missing greatergreatergreater support.
-  if (!Tok.is(tok::greater) && !Tok.is(tok::greatergreater)) {
+  if (!Tok.is(tok::greater) && !Tok.is(tok::greatergreater) &&
+      !Tok.is(tok::greatergreatergreater)) {
     TemplateScopes.Enter(Scope::TemplateParamScope);
     Failed = ParseTemplateParameterList(Depth, TemplateParams);
   }
@@ -340,6 +340,10 @@ bool Parser::ParseTemplateParameters(
     // This matters for elegant diagnosis of:
     //   template<template<typename>> struct S;
     Tok.setKind(tok::greater);
+    RAngleLoc = Tok.getLocation();
+    Tok.setLocation(Tok.getLocation().getLocWithOffset(1));
+  } else if (Tok.is(tok::greatergreatergreater)) {
+    Tok.setKind(tok::greatergreater);
     RAngleLoc = Tok.getLocation();
     Tok.setLocation(Tok.getLocation().getLocWithOffset(1));
   } else if (!TryConsumeToken(tok::greater, RAngleLoc) && Failed) {
@@ -367,7 +371,8 @@ Parser::ParseTemplateParameterList(const unsigned Depth,
     // Did we find a comma or the end of the template parameter list?
     if (Tok.is(tok::comma)) {
       ConsumeToken();
-    } else if (Tok.isOneOf(tok::greater, tok::greatergreater)) {
+    } else if (Tok.isOneOf(tok::greater, tok::greatergreater,
+                           tok::greatergreatergreater)) {
       // Don't consume this... that's done by template parser.
       break;
     } else {

--- a/clang/test/Parser/cuda-template-angle-brackets.cu
+++ b/clang/test/Parser/cuda-template-angle-brackets.cu
@@ -1,0 +1,3 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+template <template <template <int>>> struct S; // expected-error 2 {{template template parameter requires 'class' or 'typename' after the parameter list}}

--- a/clang/test/Parser/cuda-version-control-conflict.cu
+++ b/clang/test/Parser/cuda-version-control-conflict.cu
@@ -1,0 +1,12 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+// this exercises the CUDA tokenization where >>> is treated
+// as a single token, ensuring that the <<<< and >>>> sequences from
+// conflict markers are not incorrectly interpreted as C++/CUDA syntax. 
+
+// expected-error@+1 {{version control conflict marker in file}}
+<<<<<<< HEAD 
+int x = 5;
+=======
+int y = 0;
+>>>>>>> other-branch


### PR DESCRIPTION
problem:
when using CUDA extension `>>>` gets lexed as a single `tok::greatergreatergreater` 
to support the kernel-launch syntax.  so with code like:
```c++
template <template <template <int>>> struct S; 
``` 
When three `>` instead close nested template parameter lists, `ParseTemplateParameters`  did not split that token the way it already splits `>>`, so the parser desynced. For:

```c++
template <template <template <int>>> struct S;
```
generating unclear diagnostics. 

before fix:
```bash
 clang++ -x cuda --cuda-host-only -nocudainc -nocudalib -std=c++17 \
              -fsyntax-only ../repro/reprofixme.cpp
../repro/reprofixme.cpp:1:39: error: expected a qualified name after 'typename'
    1 | template <template <template <typename>>> struct S;
      |                                       ^
../repro/reprofixme.cpp:1:39: error: expected ',' or '>' in template-parameter-list
../repro/reprofixme.cpp:1:51: error: expected identifier
    1 | template <template <template <typename>>> struct S;
      |                                                   ^
../repro/reprofixme.cpp:1:51: error: expected ',' or '>' in template-parameter-list
../repro/reprofixme.cpp:1:51: error: expected identifier
../repro/reprofixme.cpp:1:51: error: expected ',' or '>' in template-parameter-list
../repro/reprofixme.cpp:1:51: error: declaration does not declare anything
7 errors generated when compiling for host.
```

after: 
```bash
 bin/clang++ -x cuda --cuda-host-only -nocudainc -nocudalib -std=c++17 \
                    -fsyntax-only ../repro/reprofixme.cpp
../repro/reprofixme.cpp:1:35: error: template template parameter requires 'class' or 'typename' after the parameter list
    1 | template <template <template <int>>> struct S;
      |                                   ^
      |                                   class 
../repro/reprofixme.cpp:1:36: error: template template parameter requires 'class' or 'typename' after the parameter list
    1 | template <template <template <int>>> struct S;
      |                                    ^
      |                                    class 
2 errors generated when compiling for host.
```

matching what non-CUDA mode output.