### PR TITLE
[DWARFLinker] Key accelerator entries on the unit root, not on its tag

### DIFF
--- a/llvm/include/llvm/DWARFLinker/Classic/DWARFLinkerCompileUnit.h
+++ b/llvm/include/llvm/DWARFLinker/Classic/DWARFLinkerCompileUnit.h
@@ -145,6 +145,15 @@ public:
     return nullptr;
   }
 
+  /// Check whether \p Die is this unit's root DIE, identified by being the
+  /// output unit DIE rather than by its tag: DWARFContext::compile_units()
+  /// hands a full and a partial compilation unit to the linker on the same
+  /// path, and their roots differ only in that tag.
+  bool isUnitRootDIE(const DIE &Die) const {
+    assert(getOutputUnitDIE() && "no output unit DIE to compare against");
+    return &Die == getOutputUnitDIE();
+  }
+
   dwarf::Tag getTag() const { return OrigUnit.getUnitDIE().getTag(); }
 
   bool hasODR() const { return HasODR; }

--- a/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
@@ -1952,8 +1952,11 @@ DIE *DWARFLinker::DIECloner::cloneDIE(const DWARFDie &InputDIE,
   // FIXME: This is slightly wrong. An inline_subroutine without a
   // low_pc, but with AT_ranges might be interesting to get into the
   // accelerator tables too. For now stick with dsymutil's behavior.
+
+  // A unit root is none of the named entities DWARFv5 section 6.1.1.1 indexes;
+  // its DW_AT_name is the source file. Recognized by position, not by tag.
   if ((Info.InDebugMap || AttrInfo.HasLowPc || AttrInfo.HasRanges) &&
-      Tag != dwarf::DW_TAG_compile_unit &&
+      !Unit.isUnitRootDIE(*Die) &&
       getDIENames(InputDIE, AttrInfo, DebugStrPool, File, Unit,
                   Tag != dwarf::DW_TAG_inlined_subroutine)) {
     if (AttrInfo.MangledName && AttrInfo.MangledName != AttrInfo.Name)

--- a/llvm/lib/DWARFLinker/Parallel/AcceleratorRecordsSaver.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/AcceleratorRecordsSaver.cpp
@@ -73,6 +73,11 @@ void AcceleratorRecordsSaver::save(const DWARFDebugInfoEntry *InputDieEntry,
     if (const char *ShortName = InputDIE.getShortName())
       AttrInfo.Name = GlobalData.getStringPool().insert(ShortName).first;
 
+  // A unit root is none of the named entities DWARFv5 section 6.1.1.1 indexes;
+  // its DW_AT_name is the source file. Recognized by position, not by tag.
+  if (CompileUnit::isUnitRootDIE(InUnit.getDIEIndex(InputDieEntry)))
+    return;
+
   switch (InputDieEntry->getTag()) {
   case dwarf::DW_TAG_array_type:
   case dwarf::DW_TAG_class_type:
@@ -156,7 +161,6 @@ void AcceleratorRecordsSaver::save(const DWARFDebugInfoEntry *InputDieEntry,
       saveNamespaceRecord(InputDieEntry, AttrInfo.Name, OutDIE,
                           InputDieEntry->getTag(), TypeEntry);
   } break;
-  case dwarf::DW_TAG_compile_unit:
   case dwarf::DW_TAG_lexical_block: {
     // Nothing to do.
   } break;

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.h
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.h
@@ -335,6 +335,11 @@ public:
   ///
   /// @{
 
+  /// \p DieIdx index of the DIE.
+  /// \returns true if the DIE is the unit's root, which is always at index
+  /// zero, whatever tag it carries.
+  static bool isUnitRootDIE(uint32_t DieIdx) { return DieIdx == 0; }
+
   /// \p Idx index of the DIE.
   /// \returns DieInfo descriptor.
   DIEInfo &getDIEInfo(unsigned Idx) { return DieInfoArray[Idx]; }

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-debug-names.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-debug-names.test
@@ -1,0 +1,171 @@
+## A unit root earns no .debug_names entry - DWARFv5 section 6.1.1.1 indexes
+## named subprograms, labels, variables, types and namespaces, and a root is
+## none of those. Both backends excluded it by tag, so a DW_TAG_partial_unit
+## root was indexed under its own DW_AT_name and became the DW_IDX_parent of
+## everything below it. The same input with a compile unit root is the control,
+## and both are held to the one set of expectations below.
+
+## DEFINE covers the two spellings the index must never contain: the root's own
+## name, and the tag it would carry as an entry.
+# DEFINE: %{check} = FileCheck %s --implicit-check-not='dwz-common.h' \
+# DEFINE:   --implicit-check-not=DW_TAG_partial_unit
+
+# RUN: yaml2obj %s -DROOT=DW_TAG_compile_unit -DUNITTYPE=DW_UT_compile -o %t.cu.o
+# RUN: yaml2obj %s -DROOT=DW_TAG_partial_unit -DUNITTYPE=DW_UT_partial -o %t.pu.o
+
+# RUN: llvm-dwarfutil --build-accelerator=DWARF %t.cu.o %t.cu.classic
+# RUN: llvm-dwarfdump --debug-names %t.cu.classic | %{check}
+# RUN: llvm-dwarfutil --build-accelerator=DWARF %t.pu.o %t.pu.classic
+# RUN: llvm-dwarfdump --debug-names %t.pu.classic | %{check}
+
+# RUN: llvm-dwarfutil --linker parallel --build-accelerator=DWARF %t.cu.o %t.cu.parallel
+# RUN: llvm-dwarfdump --debug-names %t.cu.parallel | %{check}
+# RUN: llvm-dwarfutil --linker parallel --build-accelerator=DWARF %t.pu.o %t.pu.parallel
+# RUN: llvm-dwarfdump --debug-names %t.pu.parallel | %{check}
+
+## Update mode reaches the same code with garbage collection turned off. It
+## needs --build-accelerator as well, since --no-garbage-collection on its own
+## copies the file without running the linker at all.
+# RUN: llvm-dwarfutil --no-garbage-collection --build-accelerator=DWARF %t.cu.o %t.cu.classic.upd
+# RUN: llvm-dwarfdump --debug-names %t.cu.classic.upd | %{check}
+# RUN: llvm-dwarfutil --no-garbage-collection --build-accelerator=DWARF %t.pu.o %t.pu.classic.upd
+# RUN: llvm-dwarfdump --debug-names %t.pu.classic.upd | %{check}
+
+# RUN: llvm-dwarfutil --linker parallel --no-garbage-collection \
+# RUN:   --build-accelerator=DWARF %t.cu.o %t.cu.parallel.upd
+# RUN: llvm-dwarfdump --debug-names %t.cu.parallel.upd | %{check}
+# RUN: llvm-dwarfutil --linker parallel --no-garbage-collection \
+# RUN:   --build-accelerator=DWARF %t.pu.o %t.pu.parallel.upd
+# RUN: llvm-dwarfdump --debug-names %t.pu.parallel.upd | %{check}
+
+## Four names, and three abbreviations pinned exhaustively so that a fourth one
+## for the root cannot appear. Only the DIE inside the namespace carries a
+## parent reference; everything whose parent is the unit root uses
+## DW_FORM_flag_present, which the dumper reports as <parent not indexed>.
+# CHECK:      Name Index @ 0x0 {
+# CHECK:        Bucket count: 4
+# CHECK-NEXT:   Name count: 4
+# CHECK:      Abbreviations [
+# CHECK-NEXT:   Abbreviation 0x1 {
+# CHECK-NEXT:     Tag: DW_TAG_subprogram
+# CHECK-NEXT:     DW_IDX_die_offset: DW_FORM_ref4
+# CHECK-NEXT:     DW_IDX_parent: DW_FORM_ref4
+# CHECK-NEXT:   }
+# CHECK-NEXT:   Abbreviation 0x2 {
+# CHECK-NEXT:     Tag: DW_TAG_namespace
+# CHECK-NEXT:     DW_IDX_die_offset: DW_FORM_ref4
+# CHECK-NEXT:     DW_IDX_parent: DW_FORM_flag_present
+# CHECK-NEXT:   }
+# CHECK-NEXT:   Abbreviation 0x3 {
+# CHECK-NEXT:     Tag: DW_TAG_subprogram
+# CHECK-NEXT:     DW_IDX_die_offset: DW_FORM_ref4
+# CHECK-NEXT:     DW_IDX_parent: DW_FORM_flag_present
+# CHECK-NEXT:   }
+# CHECK-NEXT: ]
+
+## The one parent reference in the table points at the namespace's own entry,
+## so the chain a consumer walks from foo3 stops at ns rather than continuing
+## into a file name.
+# CHECK:        String: {{.*}} "foo3"
+# CHECK:          Tag: DW_TAG_subprogram
+# CHECK-NEXT:     DW_IDX_die_offset: 0x00000048
+# CHECK-NEXT:     DW_IDX_parent: Entry @ 0x[[NS:[0-9a-f]+]]
+# CHECK:        String: {{.*}} "ns"
+# CHECK-NEXT:   Entry @ 0x[[NS]] {
+# CHECK-NEXT:     Abbrev: 0x2
+# CHECK-NEXT:     Tag: DW_TAG_namespace
+# CHECK-NEXT:     DW_IDX_die_offset: 0x00000046
+# CHECK-NEXT:     DW_IDX_parent: <parent not indexed>
+# CHECK:        String: {{.*}} "foo1"
+# CHECK:          Tag: DW_TAG_subprogram
+# CHECK-NEXT:     DW_IDX_die_offset: 0x00000022
+# CHECK-NEXT:     DW_IDX_parent: <parent not indexed>
+# CHECK:        String: {{.*}} "foo2"
+# CHECK:          Tag: DW_TAG_subprogram
+# CHECK-NEXT:     DW_IDX_die_offset: 0x00000034
+# CHECK-NEXT:     DW_IDX_parent: <parent not indexed>
+
+## One DWARFv5 unit whose root carries the address range of the code below it,
+## which is what admits the root to the name index in the first place. The
+## root's DW_AT_name is a header file path, the name a consumer would wrongly
+## recover from the index or from a DW_IDX_parent walk. Two subprograms sit at
+## unit scope, where the root is the only DIE above them, and a third sits in a
+## namespace, which is a scope the index does record - so the output
+## distinguishes a parent that must not be indexed from one that must.
+--- !ELF
+FileHeader:
+  Class:    ELFCLASS64
+  Data:     ELFDATA2LSB
+  Type:     ET_REL
+  Machine:  EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1130
+    Size:            0x40
+  - Name:            .debug_str_offsets
+    Type:            SHT_PROGBITS
+    Flags:           [  ]
+    Content:        "0400000005000000"
+DWARF:
+  debug_abbrev:
+    - ID:    0
+      Table:
+      - Tag:      [[ROOT]]
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_str_offsets_base
+            Form:      DW_FORM_sec_offset
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+      - Tag:      DW_TAG_namespace
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+  debug_info:
+    - Version:  5
+      UnitType: [[UNITTYPE]]
+      AbbrevTableID: 0
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: dwz-common.h
+            - Value: 0x1130
+            - Value: 0x1170
+            - Value: 0x8
+        - AbbrCode: 2
+          Values:
+            - CStr: foo1
+            - Value: 0x1130
+            - Value: 0x10
+        - AbbrCode: 2
+          Values:
+            - CStr: foo2
+            - Value: 0x1150
+            - Value: 0x10
+        - AbbrCode: 3
+          Values:
+            - CStr: ns
+        - AbbrCode: 2
+          Values:
+            - CStr: foo3
+            - Value: 0x1160
+            - Value: 0x10
+        - AbbrCode: 0
+        - AbbrCode: 0
+...


### PR DESCRIPTION
**Summary**

- **Broken:** the index covers named subprograms, labels, variables, types and namespaces (DWARFv5 spec §6.1.1.1), but not unit roots — a unit root's `DW_AT_name` is the path of the primary source file (§3.1.1). Both backends excluded the unit root by testing its tag against `DW_TAG_compile_unit` only, missing `DW_TAG_partial_unit`, so a partial unit root was indexed in error: a lookup for a program identifier can return a file name, and everything directly below the root pointed `DW_IDX_parent` at it, so walking that chain recovers `dwz-common.h::ns::foo3`.
- **Fix:** exclude the unit root by identity rather than by tag.
- **Implementation:** classic tests `CompileUnit::isUnitRootDIE(const DIE &)` against the output unit DIE, asserting that DIE exists so a caller placed too early fails loudly instead of reintroducing the bug; parallel returns early from `AcceleratorRecordsSaver::save()` ahead of the tag switch, so one test dominates all five record-saving helpers and the switch's `DW_TAG_compile_unit` case is removed.

A unit root earns no `.debug_names` entry. DWARFv5 section 6.1.1.1 indexes named subprograms, labels, variables, types and namespaces, and a root defines none of those — its `DW_AT_name` is the path of the primary source file, per section 3.1.1. The classic and parallel DWARFLinker backends both excluded it, and both did so by testing the root's tag against `DW_TAG_compile_unit` alone.

A `DW_TAG_partial_unit` root does not carry `DW_TAG_compile_unit`, so it survived that test and was indexed. The file name became a name in its own right, so a lookup for a program identifier can return a header. And since `DW_IDX_parent` is the index of the parent's name table entry, everything directly below the root pointed at it where the compile unit control reports `<parent not indexed>` — including a namespace, so a consumer reconstructing a qualified name by walking the parent chain recovers `dwz-common.h::ns::foo3` for a function in a namespace.

`DW_TAG_partial_unit` is what `dwz` leaves behind, and `dwz` is a standard step in Fedora, RHEL and Debian debuginfo packaging, so this is the ordinary shape of a distribution debuginfo file rather than a corner case. `DWARFContext::compile_units()` filters out only type units, so such a unit reaches this code on exactly the same path a full compilation unit does; the tag test was the only thing separating them.

**Classic.** `CompileUnit::isUnitRootDIE(const DIE &)` compares against the output unit DIE. The test is on the output DIE rather than on the input one because the whole block around it is: `addNameAccelerator(Die, ...)`, `addNamespaceAccelerator(Die, ...)` and `addTypeAccelerator(Die, ...)` all take that DIE. The helper asserts that the output unit DIE exists, since a caller placed before `createOutputDIE()` would otherwise get `false` for every DIE and quietly reintroduce this bug rather than failing.

**Parallel.** The root returns early from `AcceleratorRecordsSaver::save()`, before the tag switch, so the one test dominates all five record-saving helpers from a single point rather than being repeated in each. The `DW_TAG_compile_unit` case that switch carried is removed: the early return subsumes it for every root that can occur, and a non-root DIE carrying that tag is not something a conformant producer can emit.

**Tests.** `dwarf5-partial-unit-debug-names.test` links a partial unit root and a compile unit control through both backends, under garbage collection and in update mode, and holds all eight runs to one set of expectations — the control and the case must produce the same index. Update mode needs `--build-accelerator` as well, because `--no-garbage-collection` on its own copies the file without running the linker at all.

Two details of the input are load-bearing. The root carries an address range, which is what admits it to the index in the first place. And a third function sits inside a namespace, which is a scope the index does record, so one entry must keep a parent reference while the rest must not; without it, a fix that suppressed `DW_IDX_parent` wholesale under a partial unit would pass. The abbreviation table is pinned exhaustively so a fourth abbreviation for the root cannot appear, and the parent of the namespaced function is captured and matched against the namespace's own entry offset.

One limit of the test is worth stating rather than leaving to be discovered: it does not distinguish this change from one that merely adds `DW_TAG_partial_unit` to the two tag tests. There is no third root tag available to feed it — `DWARFContext::compile_units()` filters type units out before the linker sees them, and a `DW_TAG_skeleton_unit` root breaks the hardcoded 12-byte unit header in both backends before it reaches this code.

One tag-keyed root test remains in `AcceleratorRecordsSaver.cpp`, in `hashFullyQualifiedName`. It is deliberately untouched here: it feeds only the Apple `DW_ATOM_qual_name_hash`, which `llvm-dwarfutil` never emits, and it cannot be reproduced without the fix for #219613. It is filed separately as #219636.

**This change should land after #219727.** `llvm-dwarfdump --verify` excludes `DW_TAG_compile_unit` and `DW_TAG_module` from the `.debug_names` completeness check but not `DW_TAG_partial_unit`, so the verifier demands an index entry for a named partial unit root — that is #219720, the same spec question answered from the consumer side. The producer defect fixed here and that verifier defect currently cancel in part: a partial unit root carrying an address range is wrongly indexed and `--verify` is therefore satisfied, while a root without one, which is the real `dwz` shape, is correctly absent and `--verify` already fails. Landing this change on its own moves every partial unit carrying an accelerator table into the second case — the test input added here fails that check with this patch applied and the verifier unfixed. With #219727 in first, the eight runs above can add `--verify`.

Fixes #219599.

This change was produced with AI assistance; I have reviewed it and am accountable for it.

Assisted-by: Claude Code

