### PR TITLE
[Clang] Add MaterializeTemporaryExpr for __builtin_bit_cast on lvalues

### DIFF
--- a/clang/lib/Sema/SemaCast.cpp
+++ b/clang/lib/Sema/SemaCast.cpp
@@ -446,6 +446,13 @@ ExprResult Sema::BuildBuiltinBitCastExpr(SourceLocation KWLoc,
     Operand = PR.get();
   }
 
+  if (Operand->isLValue()) {
+    Operand = CreateMaterializeTemporaryExpr(Operand->getType(), Operand,
+                                             /*BoundToLvalue=*/false);
+    if (!Operand)
+      return ExprError();
+  }
+
   CastOperation Op(*this, TSI->getType(), Operand);
   Op.OpRange = CastOperation::OpRangeType(KWLoc, KWLoc, RParenLoc);
   TypeLoc TL = TSI->getTypeLoc();


### PR DESCRIPTION
This patch fixes #219531.

__builtin_bit_cast on an lvalue, such as a vector element access (v.y),
was missing a MaterializeTemporaryExpr in the AST. This caused code
generation to load from the start of the vector instead of the
specified lane.

This patch wraps the operand in a MaterializeTemporaryExpr when it
is an lvalue, ensuring the correct lane is materialized before the
bitcast.

Tested on Windows (x64) with the provided reproducer.