### PR TITLE
[alpha.webkit.UncountedLocalVarsChecker] Support obtaining guardian's value via operator*

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -357,10 +357,13 @@ std::optional<bool> isGetterOfSafePtr(const CXXMethodDecl *M) {
   std::string className = safeGetName(calleeMethodsClass);
   std::string method = safeGetName(M);
 
-  if (isCheckedPtr(className) && (method == "get" || method == "ptr"))
+  auto OpType = M->getOverloadedOperator();
+  if (isCheckedPtr(className) &&
+      (method == "get" || method == "ptr" || OpType == OO_Star))
     return true;
 
-  if ((isRefType(className) && (method == "get" || method == "ptr")) ||
+  if ((isRefType(className) &&
+       (method == "get" || method == "ptr" || OpType == OO_Star)) ||
       ((className == "String" || className == "AtomString" ||
         className == "AtomStringImpl" || className == "UniqueString" ||
         className == "UniqueStringImpl" || className == "Identifier") &&

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
@@ -89,6 +89,11 @@ struct GuardianVisitor : DynamicRecursiveASTVisitor {
       return false;
     if (isPtrConversion(Callee))
       return true;
+    if (auto *Method = dyn_cast<CXXMethodDecl>(Callee)) {
+      auto IsGetter = isGetterOfSafePtr(Method);
+      if (IsGetter && *IsGetter)
+        return true;
+    }
     unsigned ArgIndex = 0;
     unsigned ArgOffset = isa<CXXOperatorCallExpr>(CE);
     for (auto *Arg : CE->arguments()) {

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
@@ -90,8 +90,7 @@ struct GuardianVisitor : DynamicRecursiveASTVisitor {
     if (isPtrConversion(Callee))
       return true;
     if (auto *Method = dyn_cast<CXXMethodDecl>(Callee)) {
-      auto IsGetter = isGetterOfSafePtr(Method);
-      if (IsGetter && *IsGetter)
+      if (isGetterOfSafePtr(Method).value_or(false))
         return true;
     }
     unsigned ArgIndex = 0;

--- a/clang/test/Analysis/Checkers/WebKit/mock-types.h
+++ b/clang/test/Analysis/Checkers/WebKit/mock-types.h
@@ -435,7 +435,8 @@ private:
   unsigned m_refCount { 0 };
 };
 
-template <typename T> T *downcast(T *t) { return t; }
+template <typename U, typename T> U [[clang::annotate_type("webkit.pointerconversion")]] *downcast(T *t) { return static_cast<U*>(t); }
+template <typename U, typename T> U [[clang::annotate_type("webkit.pointerconversion")]] &downcast(T &t) { return static_cast<U&>(t); }
 
 template <typename T> struct CheckedRef {
 private:

--- a/clang/test/Analysis/Checkers/WebKit/objc-mock-types.h
+++ b/clang/test/Analysis/Checkers/WebKit/objc-mock-types.h
@@ -273,8 +273,6 @@ template<typename T> RetainPtr<T> adoptNSNullable(T*);
 template<typename T> RetainPtr<T> adoptCF(T);
 template<typename T> RetainPtr<T> adoptCFNullable(T);
 
-template <typename T, typename S> T *downcast(S *t) { return static_cast<T*>(t); }
-
 template <typename T> struct RemovePointer {
   typedef T Type;
 };
@@ -713,7 +711,6 @@ using WTF::adoptCFNullable;
 using WTF::retainPtr;
 using WTF::OSObjectPtr;
 using WTF::adoptOSObject;
-using WTF::downcast;
 using WTF::bridge_cast;
 using WTF::bridge_id_cast;
 using WTF::is_objc;

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
@@ -214,6 +214,23 @@ void foo9(RefCountable& o) {
   }
 }
 
+RefCountable* provide();
+
+struct Derived : public RefCountable {
+};
+
+void foo10() {
+  RefPtr<RefCountable> obj = provide();
+  if (obj) {
+    auto* ptr = downcast<Derived>(obj.get());
+    ptr->method();
+  }
+  if (obj) {
+    auto& ref = downcast<Derived>(*obj);
+    ref.method();
+  }
+}
+
 } // namespace guardian_scopes
 
 namespace auto_keyword {

--- a/clang/test/Analysis/Checkers/WebKit/unretained-call-args.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-call-args.mm
@@ -2,6 +2,7 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.UnretainedCallArgsChecker -verify %s
 
 #include "objc-mock-types.h"
+#include "mock-types.h"
 
 SomeObj *provide();
 void consume_obj(SomeObj*);

--- a/clang/test/Analysis/Checkers/WebKit/unretained-local-vars.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-local-vars.mm
@@ -1,6 +1,7 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.UnretainedLocalVarsChecker -verify %s
 
 #import "objc-mock-types.h"
+#import "mock-types.h"
 #import "mock-system-header.h"
 
 void someFunction();


### PR DESCRIPTION
This PR fixes a bug in alpha.webkit.UncountedLocalVarsChecker that it wasn't allowing a guardian variable's getter to be called when initializing a raw pointer/reference.

Also fix a bug that operator* wasn't recognized as a valid getter on a smart pointer.