### PR TITLE
[AMDGPU] Remove dead declarations

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPU.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.h
@@ -51,7 +51,6 @@ FunctionPass *createSILowerI1CopiesLegacyPass();
 FunctionPass *createSIShrinkInstructionsLegacyPass();
 FunctionPass *createSILoadStoreOptimizerLegacyPass();
 FunctionPass *createSIWholeQuadModeLegacyPass();
-FunctionPass *createSIFixControlFlowLiveIntervalsPass();
 FunctionPass *createSIOptimizeExecMaskingPreRAPass();
 FunctionPass *createSIOptimizeVGPRLiveRangeLegacyPass();
 FunctionPass *createAMDGPUNextUseAnalysisLegacyPass();

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.h
@@ -287,7 +287,6 @@ private:
 
   SDValue getMaterializedScalarImm32(int64_t Val, const SDLoc &DL) const;
 
-  void SelectADD_SUB_I64(SDNode *N);
   void SelectAddcSubb(SDNode *N);
   void SelectAddcSubbI64(SDNode *N);
   void SelectUADDO_USUBO(SDNode *N);

--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.h
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.h
@@ -488,9 +488,6 @@ public:
   void setScalarizeGlobalBehavior(bool b) { ScalarizeGlobal = b; }
   bool getScalarizeGlobalBehavior() const { return ScalarizeGlobal; }
 
-  // static wrappers
-  static bool hasHalfRate64Ops(const TargetSubtargetInfo &STI);
-
   // XXX - Why is this here if it isn't in the default pass set?
   bool enableEarlyIfConversion() const override { return true; }
 

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUInstPrinter.h
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUInstPrinter.h
@@ -202,11 +202,8 @@ public:
                          StringRef Asm, StringRef Default = "");
   static void printIfSet(const MCInst *MI, unsigned OpNo, raw_ostream &O,
                          char Asm);
+
 protected:
-  void printAbs(const MCInst *MI, unsigned OpNo, const MCSubtargetInfo &STI,
-                raw_ostream &O);
-  void printClamp(const MCInst *MI, unsigned OpNo, const MCSubtargetInfo &STI,
-                  raw_ostream &O);
   void printOModSI(const MCInst *MI, unsigned OpNo, const MCSubtargetInfo &STI,
                    raw_ostream &O);
   void printLiteral(const MCInst *MI, unsigned OpNo, const MCSubtargetInfo &STI,

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -1880,9 +1880,6 @@ namespace AMDGPU {
   LLVM_READONLY
   int32_t getGlobalVaddrOp(uint32_t Opcode);
 
-  LLVM_READONLY
-  int32_t getVCMPXNoSDstOp(uint32_t Opcode);
-
   /// \returns ST form with only immediate offset of a FLAT Scratch instruction
   /// given an \p Opcode of an SS (SADDR) form.
   LLVM_READONLY


### PR DESCRIPTION
createSIFixControlFlowLiveIntervalsPass: The corresponding function
definition was removed on August 7, 2017 in commit
3db456820dcb89fc8bab58414de801fdfcfb0e88.

SelectADD_SUB_I64: The corresponding function definition was removed on
June 22, 2026 in commit 8062e6dc822b7832d8d988bd9cc70a04a327848a.

hasHalfRate64Ops: The corresponding function definition was removed on
January 21, 2026 in commit 2692f5ed537ff81f057340aeaba933428ba3bdd8.

printAbs, printClamp: The corresponding function definitions were
removed on June 28, 2018 in commit
c5a154db48c3cd9e16b5c74977d506415414daf7.

getVCMPXNoSDstOp: The corresponding function definition was removed on
February 11, 2021 in commit c16f776028ddd39a4d5ea39d5c3831b1bcbb8c02.
