### PR TITLE
[orc-rt] Drop reserveMemory's /dev/zero fallback.

### DIFF
--- a/orc-rt/lib/bedrock/posix/Memory.cpp
+++ b/orc-rt/lib/bedrock/posix/Memory.cpp
@@ -15,14 +15,21 @@
 
 #include "orc-rt-internal/support/sys/CacheControl.h"
 
-#include <fcntl.h>
+#include <errno.h>
 #include <string.h>
-#include <sys/errno.h>
 #include <sys/mman.h>
 
 namespace orc_rt::sys {
 
 namespace {
+
+#if defined(MAP_ANON)
+constexpr int MapAnonFlag = MAP_ANON;
+#elif defined(MAP_ANONYMOUS)
+constexpr int MapAnonFlag = MAP_ANONYMOUS;
+#else
+#error "orc-rt requires anonymous mmap (MAP_ANON / MAP_ANONYMOUS)"
+#endif
 
 int toNativeProtFlags(MemProt MP) {
   int Prot = PROT_NONE;
@@ -41,25 +48,8 @@ Expected<void *> reserveMemory(size_t Size) {
   if (Size == 0)
     return nullptr;
 
-  int FD = 0;
-  int MapFlags = MAP_PRIVATE;
-
-#if defined(MAP_ANON)
-  // If MAP_ANON is available then use it.
-  FD = -1;
-  MapFlags |= MAP_ANON;
-#else // !defined(MAP_ANON)
-  // Fall back to /dev/zero for strict POSIX.
-  FD = open("/dev/zero", O_RDWR);
-  if (FD == -1) {
-    auto ErrNum = errno;
-    return make_error<StringError>(
-        std::string("Could not open /dev/zero for memory reserve: ") +
-        strerror(ErrNum));
-  }
-#endif
-
-  void *Addr = mmap(nullptr, Size, PROT_READ | PROT_WRITE, MapFlags, FD, 0);
+  void *Addr = mmap(nullptr, Size, PROT_READ | PROT_WRITE,
+                    MAP_PRIVATE | MapAnonFlag, -1, 0);
   if (Addr == MAP_FAILED) {
     auto ErrNum = errno;
     return make_error<StringError>(


### PR DESCRIPTION
Just use MAP_ANON / MAP_ANONYMOUS as available.

Also replaces <sys/errno.h> with <errno.h> and drops the now-unused <fcntl.h>.