### PR TITLE
[Driver] Reject the joined form -exxx

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -1689,7 +1689,7 @@ def emit_pretty_sgf: Flag<["--"], "pretty-sgf">,
 def emit_sgf_symbol_labels_for_testing: Flag<["--"], "emit-sgf-symbol-labels-for-testing">,
    Visibility<[CC1Option]>,
    MarshallingInfoFlag<FrontendOpts<"EmitSymbolGraphSymbolLabelsForTesting">>;
-def e : JoinedOrSeparate<["-"], "e">, Flags<[LinkerInput]>, Group<Link_Group>;
+def e : Separate<["-"], "e">, Flags<[LinkerInput]>, Group<Link_Group>;
 def fmax_tokens_EQ : Joined<["-"], "fmax-tokens=">, Group<f_Group>,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Max total number of preprocessed tokens for -Wmax-tokens.">,

--- a/clang/test/Driver/entry.s
+++ b/clang/test/Driver/entry.s
@@ -1,5 +1,11 @@
+// RUN: %clang -### --target=x86_64-linux-gnu -e foo %s 2>&1 | FileCheck %s
+// RUN: %clang -### --target=x86_64-linux-gnu --entry foo %s 2>&1 | FileCheck %s
+// RUN: %clang -### --target=x86_64-linux-gnu --entry=foo %s 2>&1 | FileCheck %s
+
+// CHECK: "-e" "foo"
+
 /// To prevent mistaking -exxx as --entry=xxx, we allow -e xxx but reject -exxx.
 /// GCC -export-dynamic is rejected as well.
-// RUN: not %clang -### --target=x86_64-linux-gnu -export-dynamic %s 2>&1 | FileCheck %s
+// RUN: not %clang -### --target=x86_64-linux-gnu -export-dynamic %s 2>&1 | FileCheck %s --check-prefix=ERR
 
-// CHECK: error: unknown argument: '-export-dynamic'
+// ERR: error: unknown argument: '-export-dynamic'

--- a/clang/test/Driver/linker-opts.c
+++ b/clang/test/Driver/linker-opts.c
@@ -20,9 +20,3 @@
 // Make sure that we do warn in other cases.
 // RUN: %clang %s -lfoo -c -o %t/tmp2.o -### 2>&1 | FileCheck %s --check-prefix=UNUSED
 // UNUSED: warning:{{.*}}unused
-
-// Make sure -e and its aliases --entry and --entry= are properly passed on.
-// RUN: %clang -### --target=x86_64-unknown-linux-gnu --entry test %s 2>&1 | FileCheck --check-prefix=ENTRY %s
-// RUN: %clang -### --target=x86_64-unknown-linux-gnu --entry=test %s 2>&1 | FileCheck --check-prefix=ENTRY %s
-
-// ENTRY: "-e" "test"


### PR DESCRIPTION
PR #69114 changed -e to JoinedOrSeparate so that the new --entry aliases
would work. This also accepts -exxx, silently treating a typo or GCC's
-export-dynamic as an entry name (rejected by #72804).

Make -e Separate again.