### PR TITLE
[SLPVectorizer] Avoid invalid perfect-diamond reuse for undef lanes

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -22863,17 +22863,33 @@ ResTy BoUpSLP::processBuildVector(const TreeEntry *E, Type *ScalarTy,
         // process to keep correct order.
         return *Delayed;
       }
+      const TreeEntry *FrontTE = Entries.front().front();
+      auto IsRepresentedByFrontTE = [&](Value *V) {
+        if (isa<PoisonValue>(V))
+          return true;
+        for (auto [I, Scalar] : enumerate(FrontTE->Scalars)) {
+          if (V != Scalar)
+            continue;
+          unsigned Lane = FrontTE->ReorderIndices.empty()
+                              ? I
+                              : FrontTE->ReorderIndices[I];
+          if (FrontTE->ReuseShuffleIndices.empty() ||
+              is_contained(FrontTE->ReuseShuffleIndices, Lane))
+            return true;
+        }
+        return false;
+      };
       if (GatherShuffles.size() == 1 &&
           *GatherShuffles.front() == TTI::SK_PermuteSingleSrc &&
           (Entries.front().front()->isSame(E->Scalars) ||
-           E->isSame(Entries.front().front()->Scalars))) {
+           E->isSame(Entries.front().front()->Scalars)) &&
+          all_of(E->Scalars, IsRepresentedByFrontTE)) {
         // Perfect match in the graph, will reuse the previously vectorized
         // node. Cost is 0.
         LLVM_DEBUG(dbgs() << "SLP: perfect diamond match for gather bundle "
                           << shortBundleName(E->Scalars, E->Idx) << ".\n");
         // Restore the mask for previous partially matched values.
         Mask.resize(E->Scalars.size());
-        const TreeEntry *FrontTE = Entries.front().front();
         if (FrontTE->ReorderIndices.empty() && E->ReorderIndices.empty() &&
             ((FrontTE->ReuseShuffleIndices.empty() &&
               E->Scalars.size() == FrontTE->Scalars.size()) ||

--- a/llvm/test/Transforms/SLPVectorizer/X86/undef-reorder-reuse.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/undef-reorder-reuse.ll
@@ -1,0 +1,30 @@
+; RUN: opt -passes=slp-vectorizer -disable-output < %s
+
+; The undef lane matches a poison lane in a reordered, reused TreeEntry. It
+; must remain poison rather than being looked up as a concrete scalar lane.
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define i8 @undef_in_reordered_reuse() {
+entry:
+  %load.0 = load i8, ptr null, align 1
+  %load.1 = load i8, ptr getelementptr inbounds nuw (i8, ptr null, i64 1), align 1
+  br label %entry.next
+
+entry.next:
+  br i1 false, label %if, label %merge
+
+if:
+  %phi.load.1 = phi i8 [ %load.1, %entry.next ]
+  %phi.load.0 = phi i8 [ %load.0, %entry.next ]
+  %phi.undef = phi i8 [ undef, %entry.next ]
+  br label %merge
+
+merge:
+  %phi.0 = phi i8 [ %phi.load.1, %if ], [ %load.1, %entry.next ]
+  %phi.1 = phi i8 [ %phi.load.0, %if ], [ %load.0, %entry.next ]
+  %phi.2 = phi i8 [ %phi.load.1, %if ], [ %load.1, %entry.next ]
+  %result = phi i8 [ %phi.undef, %if ], [ poison, %entry.next ]
+  ret i8 %result
+}


### PR DESCRIPTION
Fixes #219631.

`TreeEntry::isSame()` may accept an `undef` value against a poison lane in a
reordered/reused TreeEntry. That is sufficient for matching, but it does not
guarantee that the TreeEntry can be safely reused to reconstruct the gather
without changing semantics.

In the failing case, the perfect-diamond reuse path attempted to look up the
`undef` with `findLaneForValue()`. Since that `undef` had no concrete scalar
lane in the reused TreeEntry, the lookup hit the assertion:

`FoundLane < getVectorFactor() && "Unable to find given value."`

This patch restricts the perfect-diamond reuse candidate to cases where every
non-poison scalar is actually representable by the reused TreeEntry after
reorder/reuse mapping.

If an `undef` only matched through the permissive poison rule in `isSame()`,
the fast path is rejected and normal build-vector handling is used instead,
preserving the original undef semantics and avoiding additional poison.

A reduced regression test for #219631 is included.