### PR TITLE
[MachineScheduler] Order fixed-FI memory operations by object offset

### DIFF
--- a/llvm/lib/CodeGen/MachineScheduler.cpp
+++ b/llvm/lib/CodeGen/MachineScheduler.cpp
@@ -25,6 +25,7 @@
 #include "llvm/CodeGen/LiveInterval.h"
 #include "llvm/CodeGen/LiveIntervals.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineFrameInfo.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachineInstr.h"
@@ -1982,6 +1983,18 @@ class BaseMemOpClusterMutation : public ScheduleDAGMutation {
         return A->getReg() < B->getReg();
       if (A->isFI()) {
         const MachineFunction &MF = *A->getParent()->getParent()->getParent();
+        const MachineFrameInfo &MFI = MF.getFrameInfo();
+        if (MFI.isFixedObjectIndex(A->getIndex()) &&
+            MFI.isFixedObjectIndex(B->getIndex())) {
+          // Fixed objects have explicit offsets, and targets may create their
+          // frame indices in an order unrelated to those offsets. Sort by the
+          // actual object offsets so target clustering hooks see memory
+          // operations in address order.
+          int64_t AOffset = MFI.getObjectOffset(A->getIndex());
+          int64_t BOffset = MFI.getObjectOffset(B->getIndex());
+          if (AOffset != BOffset)
+            return AOffset < BOffset;
+        }
         const TargetFrameLowering &TFI = *MF.getSubtarget().getFrameLowering();
         bool StackGrowsDown = TFI.getStackGrowthDirection() ==
                               TargetFrameLowering::StackGrowsDown;

--- a/llvm/lib/CodeGen/MachineScheduler.cpp
+++ b/llvm/lib/CodeGen/MachineScheduler.cpp
@@ -25,6 +25,7 @@
 #include "llvm/CodeGen/LiveInterval.h"
 #include "llvm/CodeGen/LiveIntervals.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineFrameInfo.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachineInstr.h"
@@ -1982,9 +1983,27 @@ class BaseMemOpClusterMutation : public ScheduleDAGMutation {
         return A->getReg() < B->getReg();
       if (A->isFI()) {
         const MachineFunction &MF = *A->getParent()->getParent()->getParent();
+        const MachineFrameInfo &MFI = MF.getFrameInfo();
         const TargetFrameLowering &TFI = *MF.getSubtarget().getFrameLowering();
         bool StackGrowsDown = TFI.getStackGrowthDirection() ==
                               TargetFrameLowering::StackGrowsDown;
+        bool AIsFixed = MFI.isFixedObjectIndex(A->getIndex());
+        bool BIsFixed = MFI.isFixedObjectIndex(B->getIndex());
+        // Sort fixed and non-fixed bases as separate groups, preserving the
+        // existing frame-index ordering between the groups. Do not rely on
+        // non-fixed object offsets before frame layout.
+        if (AIsFixed != BIsFixed)
+          return StackGrowsDown ? !AIsFixed : AIsFixed;
+        if (AIsFixed) {
+          // Fixed objects have explicit offsets, and targets may create their
+          // frame indices in an order unrelated to those offsets. Sort by the
+          // actual object offsets so target clustering hooks see fixed object
+          // bases in address order.
+          int64_t AOffset = MFI.getObjectOffset(A->getIndex());
+          int64_t BOffset = MFI.getObjectOffset(B->getIndex());
+          if (AOffset != BOffset)
+            return AOffset < BOffset;
+        }
         return StackGrowsDown ? A->getIndex() > B->getIndex()
                               : A->getIndex() < B->getIndex();
       }

--- a/llvm/test/CodeGen/AArch64/cluster-frame-index.mir
+++ b/llvm/test/CodeGen/AArch64/cluster-frame-index.mir
@@ -27,6 +27,29 @@ body:             |
     ; CHECK-NEXT: RET
 ...
 ---
+name:            merge_out_of_order_fixedstack
+# CHECK-LABEL: name: merge_out_of_order_fixedstack
+tracksRegLiveness: true
+fixedStack:
+  # Fixed object indices are allocated in reverse id order. Deliberately keep
+  # their explicit offsets in the opposite order: the scheduler must use the
+  # fixed object offsets, not frame-index creation order, when sorting memory
+  # operations for clustering.
+  - { id: 0, size: 8, alignment: 8, offset: -8 }
+  - { id: 1, size: 8, alignment: 8, offset: -16 }
+body:             |
+  bb.0:
+    %0:gpr64 = LDRXui %fixed-stack.0, 0 :: (load (s64))
+    %1:gpr64 = LDRXui %fixed-stack.1, 0 :: (load (s64))
+    $x0 = ADDXrr %0, %1
+    RET_ReallyLR implicit $x0
+
+    ; CHECK: LDRXui %fixed-stack.1
+    ; CHECK-NEXT: LDRXui %fixed-stack.0
+    ; CHECK: ADDXrr
+    ; CHECK: RET
+...
+---
 name:            merge_fixedstack
 # CHECK-LABEL: name: merge_fixedstack
 tracksRegLiveness: true

--- a/llvm/test/CodeGen/AArch64/cluster-frame-index.mir
+++ b/llvm/test/CodeGen/AArch64/cluster-frame-index.mir
@@ -27,6 +27,55 @@ body:             |
     ; CHECK-NEXT: RET
 ...
 ---
+name:            merge_out_of_order_fixedstack
+# CHECK-LABEL: name: merge_out_of_order_fixedstack
+tracksRegLiveness: true
+fixedStack:
+  # Fixed object indices are allocated in reverse id order. Deliberately keep
+  # their explicit offsets in the opposite order: the scheduler must use the
+  # fixed object offsets, not frame-index creation order, when sorting memory
+  # operations for clustering.
+  - { id: 0, size: 8, alignment: 8, offset: -8 }
+  - { id: 1, size: 8, alignment: 8, offset: -16 }
+body:             |
+  bb.0:
+    %0:gpr64 = LDRXui %fixed-stack.0, 0 :: (load (s64))
+    %1:gpr64 = LDRXui %fixed-stack.1, 0 :: (load (s64))
+    $x0 = ADDXrr %0, %1
+    RET_ReallyLR implicit $x0
+
+    ; CHECK: LDRXui %fixed-stack.1
+    ; CHECK-NEXT: LDRXui %fixed-stack.0
+    ; CHECK: ADDXrr
+    ; CHECK: RET
+...
+---
+name:            merge_mixed_stack_objects
+# CHECK-LABEL: name: merge_mixed_stack_objects
+tracksRegLiveness: true
+# Keep fixed and non-fixed bases grouped for clustering, even when their
+# accesses are interleaved and the fixed objects are created out of offset order.
+fixedStack:
+  - { id: 0, size: 8, alignment: 8, offset: -8 }
+  - { id: 1, size: 8, alignment: 8, offset: -16 }
+stack:
+  - { id: 0, size: 8, alignment: 8 }
+body:             |
+  bb.0:
+    %0:gpr64 = LDRXui %fixed-stack.0, 0 :: (load (s64))
+    %1:gpr64 = LDRXui %stack.0, 0 :: (load (s64))
+    %2:gpr64 = LDRXui %fixed-stack.1, 0 :: (load (s64))
+    %3:gpr64 = ADDXrr %0, %1
+    $x0 = ADDXrr %3, %2
+    RET_ReallyLR implicit $x0
+
+    ; CHECK: LDRXui %stack.0
+    ; CHECK: LDRXui %fixed-stack.1
+    ; CHECK-NEXT: LDRXui %fixed-stack.0
+    ; CHECK: ADDXrr
+    ; CHECK: RET
+...
+---
 name:            merge_fixedstack
 # CHECK-LABEL: name: merge_fixedstack
 tracksRegLiveness: true


### PR DESCRIPTION
## Summary

- sort fixed frame-index memory operands by their explicit stack offsets
- preserve the existing frame-index ordering for ordinary stack objects and as a tie-breaker
- add an AArch64 MIR regression with fixed objects created out of offset order

## Background

`BaseMemOpClusterMutation` currently orders frame-index bases by frame-index number, adjusted for the stack growth direction. Fixed frame objects are different from ordinary stack objects: they carry explicit offsets, and their creation order is not required to match address order.

As a result, a target clustering hook can receive two fixed objects in reverse address order. AArch64's `shouldClusterFI` expects the incoming fixed-object offsets to be ordered and aborts with `Object offsets are not ordered` in an assertions-enabled build.

When both operands refer to fixed frame objects, compare their `MachineFrameInfo` object offsets first. The existing frame-index comparison remains the fallback, so the ordering of ordinary stack objects is unchanged.

Make the ordering between fixed and non-fixed frame-index bases explicit: non-fixed bases precede fixed bases for downward-growing stacks, while fixed bases precede non-fixed bases for upward-growing stacks. This preserves the existing cross-category ordering without relying on non-fixed object offsets before frame layout.

The regression deliberately creates two fixed objects in an order that disagrees with their explicit offsets. It covers both the legacy and new machine-scheduler pass forms.

## AI assistance

OpenAI Codex was used to assist with the investigation, patch preparation, testing, and drafting this PR description.
