### PR TITLE
[orc-rt] Add context to detectPageSize's sysconf error.

### DIFF
--- a/orc-rt/lib/bedrock/ExecutorProcessInfo.cpp
+++ b/orc-rt/lib/bedrock/ExecutorProcessInfo.cpp
@@ -75,7 +75,10 @@ std::string ExecutorProcessInfo::makeTargetTriple(
 Expected<size_t> ExecutorProcessInfo::detectPageSize() noexcept {
   long PageSize = sysconf(_SC_PAGESIZE);
   if (PageSize == -1)
-    return make_error<StringError>(sys::strError(errno));
+    return make_error<StringError>((StringOutputStream()
+                                    << "sysconf did not return a page size: "
+                                    << sys::strError(errno))
+                                       .str());
   if (PageSize <= 0 || !has_single_bit(static_cast<size_t>(PageSize)))
     return make_error<StringError>((StringOutputStream()
                                     << "reported page size " << PageSize


### PR DESCRIPTION
It only reported the strerror text without context, so failure would surface as a bare "Invalid argument" with nothing to say what failed.