### PR TITLE
[ORC] Have ProxySpec call callWrapperAsync directly

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/SPSProxySpec.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/SPSProxySpec.h
@@ -50,14 +50,21 @@ public:
   static void dispatch(unique_function<void(ErrorRetT)> OnComplete,
                        ExecutionSession &ES, ExecutorAddr CalleeAddr,
                        const ArgTs &...Args) {
+    auto Caller = [&ES, CalleeAddr](auto &&SendResult, const char *ArgData,
+                                    size_t ArgSize) {
+      ES.callWrapperAsync(CalleeAddr,
+                          std::forward<decltype(SendResult)>(SendResult),
+                          ArrayRef<char>(ArgData, ArgSize));
+    };
+
     if constexpr (std::is_void_v<CalleeRetT>) {
       // Void result: the executor-side function produces no value, so the only
       // thing to report is the dispatch error (success if the call ran).
-      ES.callSPSWrapperAsync<SPSSigT>(CalleeAddr, std::move(OnComplete),
-                                      Args...);
+      shared::WrapperFunction<SPSSigT>::callAsync(Caller, std::move(OnComplete),
+                                                  Args...);
     } else {
-      ES.callSPSWrapperAsync<SPSSigT>(
-          CalleeAddr,
+      shared::WrapperFunction<SPSSigT>::callAsync(
+          Caller,
           [OnComplete = std::move(OnComplete)](Error SerErr,
                                                CalleeRetT Result) mutable {
             if (SerErr) {


### PR DESCRIPTION
ProxySpec now drives shared::WrapperFunction<SPSSigT>::callAsync itself, supplying a Caller that forwards to ExecutionSession::callWrapperAsync, rather than going through ExecutionSession::callSPSWrapperAsync (which does the same thing internally). This is a step towards removing callSPSWrapperAsync (and other SPS-specific call APIs) from ExecutionSession, so that callWrapperAsync remains the only core call primitive and SPS is not baked into the core APIs.