### PR TITLE
[DAGCombiner] Make sure VT > SrcVT before doing ANY_EXTEND

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -18468,7 +18468,8 @@ SDValue DAGCombiner::visitBITCAST(SDNode *N) {
   //   => int_vt (any_extend elt_vt:x)
   if (N0.getOpcode() == ISD::SCALAR_TO_VECTOR && VT.isScalarInteger()) {
     SDValue SrcScalar = N0.getOperand(0);
-    if (SrcScalar.getValueType().isScalarInteger())
+    EVT SrcVT = SrcScalar.getValueType();
+    if (SrcVT.isScalarInteger() && VT.bitsGT(SrcVT))
       return DAG.getNode(ISD::ANY_EXTEND, SDLoc(N), VT, SrcScalar);
   }
 

--- a/llvm/test/CodeGen/X86/apx/cf.ll
+++ b/llvm/test/CodeGen/X86/apx/cf.ll
@@ -265,3 +265,15 @@ define i64 @redundant_test(i64 %num, ptr %p1, i64 %in) {
   %sel = select i1 %cmp, i64 %add, i64 %num
   ret i64 %sel
 }
+
+define void @pr219637(ptr %a, ptr %b, <1 x i1> %c) {
+; CHECK-LABEL: pr219637:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    testb $1, %dl
+; CHECK-NEXT:    cfcmovnel (%rsi), %eax
+; CHECK-NEXT:    cfcmovnel %eax, (%rdi)
+; CHECK-NEXT:    retq
+  %1 = call <1 x i32> @llvm.masked.load.v1i32.p0(ptr %b, i32 4, <1 x i1> %c, <1 x i32> poison)
+  call void @llvm.masked.store.v1i32.p0(<1 x i32> %1, ptr %a, i32 4, <1 x i1> %c)
+  ret void
+}


### PR DESCRIPTION
This happens when we have i1 (bitcast (v1i1 (scalar_to_vector i1))).

Fixes: #219637

Assisted-by: Claude Opus 4.8