### PR TITLE
[libc] Disable float16 on 32-bit x86 without SSE2

### DIFF
--- a/libc/include/llvm-libc-macros/float16-macros.h
+++ b/libc/include/llvm-libc-macros/float16-macros.h
@@ -15,7 +15,7 @@
     (!defined(__GNUC__) || __GNUC__ >= 13 ||                                   \
      (defined(__clang__) && __clang_major__ >= 12)) &&                         \
     !defined(__arm__) && !defined(_M_ARM) && !defined(__riscv) &&              \
-    !defined(_WIN32)
+    !defined(_WIN32) && (!defined(__i386__) || defined(__SSE2__))
 #define LIBC_TYPES_HAS_FLOAT16
 
 // TODO: This would no longer be required if HdrGen let us guard function


### PR DESCRIPTION
Fixes #219668

Building llvm 23.1.0 (and current main) for 32-bit x86 without SSE2 fails since APFloat.cpp started including libc's shared/math.h. All the errors come from the float16 headers:

```
libc/src/__support/FPUtil/BasicOperations.h:63:67: error: SSE register return with SSE2 disabled
libc/src/__support/math/acosf16.h:73:14: error: invalid conversion from type '_Float16' without option '-msse2'
```

The float16 detection in float16-macros.h checks __FLT16_MANT_DIG__. Since GCC 14 that macro is defined on ia32 even without SSE2, where _Float16 is storage-only and any arithmetic or returning by value is an error. 
The GCC 14 release notes say to check __SSE2__ for arithmetic support instead: https://gcc.gnu.org/gcc-14/changes.html

So require SSE2 on 32-bit x86 in the guard, same as the existing arm32 and riscv exclusions in this file. x86-64 is not affected (__i386__ is not defined there), and i386 with -msse2 keeps float16.

Tested with gcc 16.2 targeting i686: the reproducer from the issue goes from ~340 errors to compiling clean, and a full 32-bit multilib build of llvm 23.1.0 in Yocto succeeds with this change. Since 23.1.0 is affected, I would like to request a backport to release/23.x once this lands.