### PR TITLE
[CIR][OpenCL][NFC] Add language address-space preservation coverage

### DIFF
--- a/clang/test/CIR/CodeGenOpenCL/address-space-conversions.cl
+++ b/clang/test/CIR/CodeGenOpenCL/address-space-conversions.cl
@@ -1,0 +1,23 @@
+// RUN: %clang_cc1 -x cl -triple spir64 -cl-std=CL2.0 -fclangir -emit-cir \
+// RUN:   -mmlir --mlir-print-ir-before=cir-target-lowering \
+// RUN:   %s -o %t.cir 2> %t.pre.cir
+// RUN: FileCheck %s --check-prefix=CIR --input-file=%t.pre.cir
+
+void address_space_conversions(global int *global_ptr,
+                               generic int *generic_ptr,
+                               private int *private_ptr) {
+  generic_ptr = global_ptr;
+  generic_ptr = private_ptr;
+  global_ptr = (global int *)generic_ptr;
+}
+
+// CIR-LABEL: cir.func dso_local @address_space_conversions
+// CIR: cir.cast address_space
+// CIR-SAME: !cir.ptr<!s32i, lang_address_space(offload_global)>
+// CIR-SAME: !cir.ptr<!s32i, lang_address_space(offload_generic)>
+// CIR: cir.cast address_space
+// CIR-SAME: !cir.ptr<!s32i, lang_address_space(offload_private)>
+// CIR-SAME: !cir.ptr<!s32i, lang_address_space(offload_generic)>
+// CIR: cir.cast address_space
+// CIR-SAME: !cir.ptr<!s32i, lang_address_space(offload_generic)>
+// CIR-SAME: !cir.ptr<!s32i, lang_address_space(offload_global)>

--- a/clang/test/CIR/CodeGenOpenCL/address-spaces.cl
+++ b/clang/test/CIR/CodeGenOpenCL/address-spaces.cl
@@ -1,0 +1,43 @@
+// RUN: %clang_cc1 -x cl -triple spir64 -cl-std=CL2.0 -fclangir -emit-cir \
+// RUN:   -Wno-deprecated-attributes -mmlir \
+// RUN:   --mlir-print-ir-before=cir-target-lowering %s -o %t.cir 2> %t.pre.cir
+// RUN: FileCheck %s --check-prefix=CIR --input-file=%t.pre.cir
+
+typedef global int *global_int_ptr;
+
+void pointer_types(
+    private int *private_ptr, local int *local_ptr, global int *global_ptr,
+    constant int *constant_ptr, generic int *generic_ptr,
+    __attribute__((opencl_global_device)) int *global_device_ptr,
+    __attribute__((opencl_global_host)) int *global_host_ptr) {}
+
+// CIR-LABEL: cir.func dso_local @pointer_types
+// CIR-SAME: !cir.ptr<!s32i, lang_address_space(offload_private)>
+// CIR-SAME: !cir.ptr<!s32i, lang_address_space(offload_local)>
+// CIR-SAME: !cir.ptr<!s32i, lang_address_space(offload_global)>
+// CIR-SAME: !cir.ptr<!s32i, lang_address_space(offload_constant)>
+// CIR-SAME: !cir.ptr<!s32i, lang_address_space(offload_generic)>
+// CIR-SAME: !cir.ptr<!s32i, lang_address_space(offload_global_device)>
+// CIR-SAME: !cir.ptr<!s32i, lang_address_space(offload_global_host)>
+
+// The outer pointer addresses a private pointer object, whose stored pointer
+// value addresses global memory.
+void nested_pointer(global_int_ptr private *ptr) {}
+
+// CIR-LABEL: cir.func dso_local @nested_pointer
+// CIR-SAME: !cir.ptr<!cir.ptr<!s32i, lang_address_space(offload_global)>, lang_address_space(offload_private)>
+
+void local_pointer_value(global int *ptr) {
+  global int *saved = ptr;
+  (void)saved;
+}
+
+// CIR-LABEL: cir.func dso_local @local_pointer_value
+// CIR: %[[SAVED:.*]] = cir.alloca "saved"
+// CIR-SAME: !cir.ptr<!cir.ptr<!s32i, lang_address_space(offload_global)>>
+// CIR: %[[SAVED_ADDR:.*]] = cir.cast address_space %[[SAVED]]
+// CIR-SAME: !cir.ptr<!cir.ptr<!s32i, lang_address_space(offload_global)>>
+// CIR-SAME: !cir.ptr<!cir.ptr<!s32i, lang_address_space(offload_global)>, lang_address_space(offload_private)>
+// CIR: cir.store {{.*}}, %[[SAVED_ADDR]]
+// CIR-SAME: !cir.ptr<!s32i, lang_address_space(offload_global)>
+// CIR-SAME: !cir.ptr<!cir.ptr<!s32i, lang_address_space(offload_global)>, lang_address_space(offload_private)>

--- a/clang/test/CIR/IR/address-space.cir
+++ b/clang/test/CIR/IR/address-space.cir
@@ -29,6 +29,26 @@ module {
     cir.return
   }
 
+  cir.func @lang_address_space_offload_global_device(%p: !cir.ptr<!s32i, lang_address_space(offload_global_device)>) {
+    cir.return
+  }
+
+  cir.func @lang_address_space_offload_global_host(%p: !cir.ptr<!s32i, lang_address_space(offload_global_host)>) {
+    cir.return
+  }
+
+  cir.func @nested_pointer_address_spaces(%p: !cir.ptr<!cir.ptr<!s32i, lang_address_space(offload_local)>, lang_address_space(offload_global)>) {
+    cir.return
+  }
+
+  cir.func @array_element_address_space(%p: !cir.ptr<!cir.array<!cir.ptr<!s32i, lang_address_space(offload_global)> x 4>, lang_address_space(offload_constant)>) {
+    cir.return
+  }
+
+  cir.func @function_type_address_spaces(%p: !cir.ptr<!cir.func<(!cir.ptr<!s32i, lang_address_space(offload_global)>) -> !cir.ptr<!s32i, lang_address_space(offload_generic)>>>) {
+    cir.return
+  }
+
   cir.func @default_address_space(%p: !cir.ptr<!s32i>) {
     cir.return
   }
@@ -51,21 +71,41 @@ module {
   }
 }
 
-// CHECK: cir.func @target_address_space_ptr(%arg0: !cir.ptr<!s32i, target_address_space(1)>)
-// CHECK: cir.func @lang_address_space_offload_local(%arg0: !cir.ptr<!s32i, lang_address_space(offload_local)>)
-// CHECK: cir.func @lang_address_space_offload_global(%arg0: !cir.ptr<!s32i, lang_address_space(offload_global)>)
-// CHECK: cir.func @lang_address_space_offload_constant(%arg0: !cir.ptr<!s32i, lang_address_space(offload_constant)>)
-// CHECK: cir.func @lang_address_space_offload_private(%arg0: !cir.ptr<!s32i, lang_address_space(offload_private)>)
-// CHECK: cir.func @lang_address_space_offload_generic(%arg0: !cir.ptr<!s32i, lang_address_space(offload_generic)>)
-// CHECK: cir.func @default_address_space(%arg0: !cir.ptr<!s32i>)
+// CHECK-LABEL: cir.func @target_address_space_ptr
+// CHECK-SAME: !cir.ptr<!s32i, target_address_space(1)>
+// CHECK-LABEL: cir.func @lang_address_space_offload_local
+// CHECK-SAME: !cir.ptr<!s32i, lang_address_space(offload_local)>
+// CHECK-LABEL: cir.func @lang_address_space_offload_global
+// CHECK-SAME: !cir.ptr<!s32i, lang_address_space(offload_global)>
+// CHECK-LABEL: cir.func @lang_address_space_offload_constant
+// CHECK-SAME: !cir.ptr<!s32i, lang_address_space(offload_constant)>
+// CHECK-LABEL: cir.func @lang_address_space_offload_private
+// CHECK-SAME: !cir.ptr<!s32i, lang_address_space(offload_private)>
+// CHECK-LABEL: cir.func @lang_address_space_offload_generic
+// CHECK-SAME: !cir.ptr<!s32i, lang_address_space(offload_generic)>
+// CHECK-LABEL: cir.func @lang_address_space_offload_global_device
+// CHECK-SAME: !cir.ptr<!s32i, lang_address_space(offload_global_device)>
+// CHECK-LABEL: cir.func @lang_address_space_offload_global_host
+// CHECK-SAME: !cir.ptr<!s32i, lang_address_space(offload_global_host)>
+// CHECK-LABEL: cir.func @nested_pointer_address_spaces
+// CHECK-SAME: !cir.ptr<!cir.ptr<!s32i, lang_address_space(offload_local)>, lang_address_space(offload_global)>
+// CHECK-LABEL: cir.func @array_element_address_space
+// CHECK-SAME: !cir.ptr<!cir.array<!cir.ptr<!s32i, lang_address_space(offload_global)> x 4>, lang_address_space(offload_constant)>
+// CHECK-LABEL: cir.func @function_type_address_spaces
+// CHECK-SAME: !cir.ptr<!cir.func<(!cir.ptr<!s32i, lang_address_space(offload_global)>) -> !cir.ptr<!s32i, lang_address_space(offload_generic)>>>
+// CHECK-LABEL: cir.func @default_address_space
+// CHECK-SAME: !cir.ptr<!s32i>
 
-// CHECK: cir.global external target_address_space(1) @global_target_as = #cir.int<42> : !s32i
-// CHECK: cir.global "private" internal lang_address_space(offload_local) @global_lang_local : !s32i
-// CHECK: cir.global external lang_address_space(offload_global) @global_lang_global = #cir.int<1> : !s32i
-// CHECK: cir.global external lang_address_space(offload_constant) @global_lang_constant = #cir.int<2> : !s32i
-// CHECK: cir.global external @global_default_as = #cir.int<0> : !s32i
+// CHECK: cir.global external target_address_space(1) @global_target_as
+// CHECK: cir.global "private" internal lang_address_space(offload_local)
+// CHECK-SAME: @global_lang_local
+// CHECK: cir.global external lang_address_space(offload_global)
+// CHECK-SAME: @global_lang_global
+// CHECK: cir.global external lang_address_space(offload_constant)
+// CHECK-SAME: @global_lang_constant
+// CHECK: cir.global external @global_default_as
 
-// CHECK: cir.func @get_global_with_address_space()
+// CHECK-LABEL: cir.func @get_global_with_address_space
 // CHECK:   cir.get_global @global_target_as : !cir.ptr<!s32i, target_address_space(1)>
 // CHECK:   cir.get_global @global_lang_global : !cir.ptr<!s32i, lang_address_space(offload_global)>
 // CHECK:   cir.get_global @global_default_as : !cir.ptr<!s32i>


### PR DESCRIPTION
Expand coverage for preserving OpenCL language address spaces across CIR textual representation and source emission before target lowering.

Assisted-by: Codex / GPT-5.6 Sol