### PR TITLE
[CodeGen][AMDGPU] Fixed FileCheck patterns in #212201 regression test

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/si-pre-allocate-wwm-regs-preserve-rci.mir
+++ b/llvm/test/CodeGen/AMDGPU/si-pre-allocate-wwm-regs-preserve-rci.mir
@@ -8,10 +8,10 @@
 # MachineRegisterClassAnalysis result in place. The second require must reuse
 # the result computed by the first.
 
-# CHECK:      Running pass: RequireAnalysisPass<llvm::MachineRegisterClassAnalysis, llvm::MachineFunction{{.*}}> on test_wwm_reserved
+# CHECK:      Running pass: RequireAnalysisPass<MachineRegisterClassAnalysis, MachineFunction> on test_wwm_reserved
 # CHECK-NEXT: Running analysis: MachineRegisterClassAnalysis on test_wwm_reserved
 # CHECK-NEXT: Running pass: SIPreAllocateWWMRegsPass on test_wwm_reserved
-# CHECK:      Running pass: RequireAnalysisPass<llvm::MachineRegisterClassAnalysis, llvm::MachineFunction{{.*}}> on test_wwm_reserved
+# CHECK:      Running pass: RequireAnalysisPass<MachineRegisterClassAnalysis, MachineFunction> on test_wwm_reserved
 # CHECK-NEXT: Running pass: PrintMIRPreparePass on [module]
 
 # MIR: wwmReservedRegs:

--- a/llvm/test/CodeGen/AMDGPU/si-pre-allocate-wwm-regs-preserve-rci.mir
+++ b/llvm/test/CodeGen/AMDGPU/si-pre-allocate-wwm-regs-preserve-rci.mir
@@ -8,10 +8,10 @@
 # MachineRegisterClassAnalysis result in place. The second require must reuse
 # the result computed by the first.
 
-# CHECK:      Running pass: RequireAnalysisPass<MachineRegisterClassAnalysis, MachineFunction> on test_wwm_reserved
+# CHECK:      Running pass: RequireAnalysisPass<{{.*}}MachineRegisterClassAnalysis, {{.*}}MachineFunction{{.*}}> on test_wwm_reserved
 # CHECK-NEXT: Running analysis: MachineRegisterClassAnalysis on test_wwm_reserved
 # CHECK-NEXT: Running pass: SIPreAllocateWWMRegsPass on test_wwm_reserved
-# CHECK:      Running pass: RequireAnalysisPass<MachineRegisterClassAnalysis, MachineFunction> on test_wwm_reserved
+# CHECK:      Running pass: RequireAnalysisPass<{{.*}}MachineRegisterClassAnalysis, {{.*}}MachineFunction{{.*}}> on test_wwm_reserved
 # CHECK-NEXT: Running pass: PrintMIRPreparePass on [module]
 
 # MIR: wwmReservedRegs:


### PR DESCRIPTION
Quick follow up to fix failures from merging #212201. Removes `llvm::` from FileCheck in `si-preallocate-wwm-regs-preserve.mir` test.