### PR TITLE
[clang-format] Recognize the signed modifier for Verilog struct

### DIFF
--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -4150,7 +4150,9 @@ void UnwrappedLineParser::parseRecord(bool ParseAsExpr, bool IsJavaRecord) {
                             tok::kw_alignas, tok::l_square) ||
          FormatTok->isAttribute() ||
          ((Style.isJava() || Style.isJavaScript()) &&
-          FormatTok->isOneOf(tok::period, tok::comma))) {
+          FormatTok->isOneOf(tok::period, tok::comma)) ||
+         (Style.isVerilog() &&
+          FormatTok->isOneOf(tok::kw_signed, tok::kw_unsigned))) {
     if (Style.isJavaScript() &&
         FormatTok->isOneOf(Keywords.kw_extends, Keywords.kw_implements)) {
       JSPastExtendsOrImplements = true;

--- a/clang/unittests/Format/FormatTestVerilog.cpp
+++ b/clang/unittests/Format/FormatTestVerilog.cpp
@@ -1412,6 +1412,27 @@ TEST_F(FormatTestVerilog, StringLiteral) {
                  getStyleWithColumns(getDefaultStyle(), 29));
 }
 
+TEST_F(FormatTestVerilog, Struct) {
+  verifyFormat("struct packed signed {\n"
+               "  int a;\n"
+               "} pack1;");
+  verifyFormat("struct packed {\n"
+               "  int a;\n"
+               "} pack1;");
+  verifyFormat("struct {\n"
+               "  int a;\n"
+               "} pack1;");
+  verifyFormat("typedef struct packed signed {\n"
+               "  bit [3 : 0] GFC;\n"
+               "} s_atmcell;");
+  verifyFormat("typedef struct {\n"
+               "  bit [3 : 0] GFC;\n"
+               "} s_atmcell;");
+  verifyFormat("typedef struct packed {\n"
+               "  bit [3 : 0] GFC;\n"
+               "} s_atmcell;");
+}
+
 TEST_F(FormatTestVerilog, StructLiteral) {
   verifyFormat("c = '{0, 0.0};");
   verifyFormat("c = '{'{1, 1.0}, '{2, 2.0}};");


### PR DESCRIPTION
after

```SystemVerilog
struct packed signed {
  int a;
} pack1;
```

before

```SystemVerilog
struct packed signed { int a; }
pack1;
```