### PR TITLE
[Flang] Diagnose nonvariable STAT= specifiers

### DIFF
--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -1620,6 +1620,10 @@ MaybeExpr ExpressionAnalyzer::Analyze(const parser::CoindexedNamedObject &x) {
                           std::get_if<Expr<SomeInteger>>(&expr->u)}) {
                     if (coarrayRef.stat()) {
                       Say("coindexed reference has multiple STAT= specifiers"_err_en_US);
+                    } else if (!IsVariable(*intExpr)) {
+                      // A parser::Variable may resolve to a nonpointer
+                      // function reference.
+                      Say("STAT= specifier must be a scalar integer variable"_err_en_US);
                     } else {
                       coarrayRef.set_stat(Expr<SomeInteger>{*intExpr});
                     }

--- a/flang/test/Semantics/resolve94.f90
+++ b/flang/test/Semantics/resolve94.f90
@@ -47,6 +47,8 @@ subroutine s1()
   rVar1 = rCoarray[1,2,3,STAT=rVar2]
   !ERROR: Must be a scalar value, but is a rank-1 array
   rVar1 = rCoarray[1,2,3,STAT=intArray]
+  !ERROR: STAT= specifier must be a scalar integer variable
+  rVar1 = rCoarray[1,2,3,STAT=MASK(2)]
   ! Error on C929, no specifier can appear more than once
   !ERROR: coindexed reference has multiple STAT= specifiers
   rVar1 = rCoarray[1,2,3,STAT=iVar1, STAT=iVar2]


### PR DESCRIPTION
An image selector STAT= operand can be parsed as a variable but later resolve to a nonpointer function reference. Passing this expression to CoarrayRef::set_stat() violates its invariant and triggers a CHECK.

Verify that the analyzed STAT= expression is a variable before calling set_stat(), and emit a semantic error when it is not.

Add a regression test to resolve94.f90 covering an implicitly typed nonpointer function reference used as a STAT= specifier.

Fixes https://github.com/llvm/llvm-project/issues/208889