### PR TITLE
[flang-rt] Implement ERFC_SCALED for REAL(16)

### DIFF
--- a/flang-rt/lib/quadmath/CMakeLists.txt
+++ b/flang-rt/lib/quadmath/CMakeLists.txt
@@ -31,6 +31,7 @@ set(sources
   cosh.cpp
   erf.cpp
   erfc.cpp
+  erfc-scaled.cpp
   exp.cpp
   exponent.cpp
   floor.cpp

--- a/flang-rt/lib/quadmath/erfc-scaled.cpp
+++ b/flang-rt/lib/quadmath/erfc-scaled.cpp
@@ -1,0 +1,111 @@
+//===-- lib/quadmath/erfc-scaled.cpp -----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// ERFC_SCALED at REAL(16).
+//
+// The other kinds share a Cody rational approximation in
+// flang/include/flang/Common/erfc-scaled.h. It is not used here, deliberately.
+// Its coefficient arrays carry about seventeen significant digits and its
+// sqrtpi/rsqrtpi are long double literals, so evaluated at __float128 it
+// returns a plausible answer that is wrong by up to 2.8e-17 relative - some
+// 1.5e17 epsilons of binary128, which is the accuracy of double precision
+// delivered in a container that promises thirty-three digits. That was measured
+// against mpmath at 50 decimal places before this file was written; gfortran on
+// the same points is correctly rounded to within 0.91 eps.
+//
+// This uses the exact entry points the quadmath build already provides.
+//
+//===----------------------------------------------------------------------===//
+
+#include "math-entries.h"
+
+namespace Fortran::runtime {
+extern "C" {
+
+#if HAS_LDBL128 || HAS_FLOAT128
+
+using F128Ty = CppTypeFor<TypeCategory::Real, 16>;
+
+// Where the two branches meet.
+//
+// Below it, ERFC_SCALED is exp(x*x)*erfc(x) evaluated directly, which is only
+// possible while neither factor leaves the format: exp(x*x) overflows binary128
+// above x = 106.567 (x*x > 16384*ln2) and erfc underflows above x = 106.536.
+//
+// Above it, the asymptotic expansion is used. That reaches one epsilon of
+// binary128 from about x = 12 upwards - 1.4e-6 eps at x = 12, but still 1.3e8
+// eps at x = 8 - so it must not be used below there.
+//
+// The usable window is therefore [12, 106.5], and sixteen sits with margin on
+// both sides: the series is already good to 0.59 eps there, and the direct form
+// is a factor of six short of overflowing.
+static constexpr F128Ty kThreshold{16};
+
+// Terms of the asymptotic series. Twenty-two are needed at the threshold; the
+// series does not begin to diverge until k ~ x*x = 256, so the same count is
+// safe everywhere above it and only grows more accurate.
+static constexpr int kTerms{22};
+
+// sqrt(pi), as the sum of three doubles.
+//
+// Not one literal: an unsuffixed literal is a double, and an L suffix would cap
+// this at the 64-bit mantissa of x86-64 long double and put a 1e-19 floor under
+// every result. A Q suffix would be wrong when this type is long double. Three
+// exactly representable doubles sum to sqrt(pi) within 7.6e-17 eps of binary128
+// and need no suffix at all.
+static constexpr F128Ty kSqrtPi{static_cast<F128Ty>(1.772453850905516) +
+    static_cast<F128Ty>(-7.666586499825799e-17) +
+    static_cast<F128Ty>(-1.3058334907945429e-33)};
+
+// exp() amplifies the rounding error of a squaring by a factor of x*x - some
+// 250 epsilons near the threshold. So the square is taken exactly: x*x = u + e
+// with e the FMA residual, and exp(u + e) = exp(u)*exp(e) is expanded as
+// exp(u)*(1 + e), which suffices because e is below 1e-30 here and the dropped
+// e*e/2 is below 1e-60.
+//
+// Without this the error reaches 123 eps on arguments whose square is not
+// exactly representable - and stays near 0.4 eps on arguments whose square is,
+// which is exactly why an accuracy test must not step by 0.5.
+static F128Ty ScaledExpOfSquare(F128Ty x) {
+  F128Ty u{x * x};
+  F128Ty e{Fma<true>::invoke(x, x, -u)};
+  return Exp<true>::invoke(u) * (1 + e);
+}
+
+static F128Ty ErfcScaledPositive(F128Ty x) {
+  if (x < kThreshold) {
+    return ScaledExpOfSquare(x) * Erfc<true>::invoke(x);
+  }
+  // 1/(x*sqrt(pi)) * (1 - 1/(2x^2) + 3/(4x^4) - 15/(8x^6) + ...)
+  F128Ty inv2x2{1 / (2 * x * x)};
+  F128Ty sum{1}, term{1};
+  for (int k{1}; k <= kTerms; ++k) {
+    term *= -static_cast<F128Ty>(2 * k - 1) * inv2x2;
+    sum += term;
+  }
+  return sum / (x * kSqrtPi);
+}
+
+F128Ty RTDEF(ErfcScaled16)(F128Ty x) {
+  if (x >= 0) {
+    return ErfcScaledPositive(x);
+  }
+  // erfc(-x) = 2 - erfc(x), so ERFC_SCALED(-x) = 2*exp(x*x) - ERFC_SCALED(x).
+  // The asymptotic branch describes the decaying tail only and must never see a
+  // negative argument; this side grows instead, and leaves the format at the
+  // same place the direct branch does.
+  F128Ty ax{-x};
+  if (ax >= 106) {
+    return F128_RT_INFINITY;
+  }
+  return 2 * ScaledExpOfSquare(ax) - ErfcScaledPositive(ax);
+}
+#endif
+
+} // extern "C"
+} // namespace Fortran::runtime

--- a/flang-rt/lib/quadmath/erfc-scaled.cpp
+++ b/flang-rt/lib/quadmath/erfc-scaled.cpp
@@ -1,4 +1,4 @@
-//===-- lib/quadmath/erfc-scaled.cpp -----------------------------*- C++ -*-===//
+//===-- lib/quadmath/erfc-scaled.cpp ----------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/flang-rt/lib/runtime/numeric.cpp
+++ b/flang-rt/lib/runtime/numeric.cpp
@@ -356,12 +356,10 @@ CppTypeFor<TypeCategory::Real, 10> RTDEF(ErfcScaled10)(
   return ErfcScaled(x);
 }
 #endif
-#if HAS_LDBL128
-CppTypeFor<TypeCategory::Real, 16> RTDEF(ErfcScaled16)(
-    CppTypeFor<TypeCategory::Real, 16> x) {
-  return ErfcScaled(x);
-}
-#endif
+// ErfcScaled16 is not defined here. The shared approximation this file uses is
+// accurate to about seventeen digits, which is a thousand times short of what
+// binary128 holds, so REAL(16) has its own implementation over the exact
+// quadmath entry points - see flang-rt/lib/quadmath/erfc-scaled.cpp.
 
 CppTypeFor<TypeCategory::Integer, 4> RTDEF(Exponent4_4)(
     CppTypeFor<TypeCategory::Real, 4> x) {

--- a/flang-rt/test/Runtime/erfc-scaled-real16.f90
+++ b/flang-rt/test/Runtime/erfc-scaled-real16.f90
@@ -1,0 +1,71 @@
+! Accuracy of ERFC_SCALED at REAL(16), against values computed independently.
+!
+! REQUIRES: flang-supports-f128-math
+! RUN: %flang %s -o %t && %t | FileCheck %s
+!
+! The reference values below are from mpmath at 50 decimal places, not from
+! another Fortran compiler. ERFC_SCALED is not a libm entry point: every
+! implementation is somebody's approximation, so two of them agreeing would
+! show common ancestry rather than correctness. Only an independent ground
+! truth distinguishes "both right" from "both wrong the same way".
+!
+! THE GRID IS DELIBERATELY NOT REGULAR, AND MUST STAY THAT WAY. A step of 0.5
+! -- or any of the tidy values 0.125, 0.5, 1.0, 2.0, 5.0, 13.75 -- gives an
+! exactly representable square, and exp(x*x) amplifies the rounding of that
+! squaring by a factor of x*x. On such points the error is zero by
+! construction and an uncompensated implementation measures 0.4 epsilons; off
+! them it measures 123. Tidying this grid would blind the test to the defect
+! the implementation exists to avoid.
+!
+! Both sides of the branch threshold are here, against the same references, so
+! that the switch at x = 16 cannot hide a discontinuity.
+!
+! The tolerance is 2 epsilons rather than 1. Both independently chosen grids
+! measured under 1 during development, but erfc at binary128 comes from an
+! external library whose future versions may move the last place.
+
+program erfc_scaled_real16
+  implicit none
+  integer, parameter :: qp = selected_real_kind(33)
+  integer, parameter :: n = 11
+  real(qp), parameter :: delta = 1.0e-10_qp
+  ! Not tidy on purpose: see above.
+  real(qp), parameter :: x(n) = [ &
+      0.1_qp, 1.7_qp, 15.9_qp, &
+      16.0_qp - delta, 16.0_qp + delta, &
+      20.0_qp, 64.0_qp, 1000.0_qp, &
+      -1.7_qp, -13.75_qp, 0.0_qp]
+  ! exp(x*x)*erfc(x), mpmath, 50 dps, rounded to binary128.
+  real(qp), parameter :: want(n) = [ &
+      0.89645697996912664193188374864404227_qp, &
+      0.291663297075343466454843377681505751_qp, &
+      0.0354138554979901787367777955827486539_qp, &
+      0.0351933778251499452361469135833690837_qp, &
+      0.0351933778247117298966017592289243255_qp, &
+      0.0281743487410513193186491545344707584_qp, &
+      0.00881438653054441357566924341796977317_qp, &
+      0.000564189301453387654199745028061695727_qp, &
+      35.6949559060252863357458060477745282_qp, &
+      2.56939266805496674962846043540050838e+82_qp, &
+      1.0_qp]
+  real(qp) :: got, rel, worst
+  integer :: i
+
+  worst = 0.0_qp
+  do i = 1, n
+    got = erfc_scaled(x(i))
+    if (want(i) == 0.0_qp) then
+      rel = abs(got)
+    else
+      rel = abs(got - want(i))/abs(want(i))
+    end if
+    worst = max(worst, rel)
+  end do
+
+  ! CHECK: worst deviation in epsilons:
+  ! CHECK-SAME: within tolerance
+  write(*,'(A,ES12.5,A)') 'worst deviation in epsilons: ', &
+      worst/epsilon(1.0_qp), &
+      merge(' within tolerance', ' TOO LARGE       ', &
+            worst <= 2.0_qp*epsilon(1.0_qp))
+end program erfc_scaled_real16

--- a/flang-rt/test/lit.cfg.py
+++ b/flang-rt/test/lit.cfg.py
@@ -111,3 +111,11 @@ if config.flang_rt_fortran_modules:
 # Set OBJECT_MODE=64 as tools on AIX default to 32-bit.
 if "system-aix" in config.available_features:
     config.environment["OBJECT_MODE"] = "64"
+
+# Tests that need REAL(16) require the runtime to have been built with a
+# quad-precision math library. The condition is the same one flang/test uses
+# (see flang/test/lit.cfg.py), and it must stay the same: the compiler and the
+# runtime derive REAL(16) support from this single CMake value, and a test that
+# disagreed with either would report a configuration difference as a defect.
+if config.flang_runtime_f128_math_lib or config.have_ldbl_mant_dig_113:
+    config.available_features.add("flang-supports-f128-math")

--- a/flang-rt/test/lit.site.cfg.py.in
+++ b/flang-rt/test/lit.site.cfg.py.in
@@ -15,6 +15,8 @@ config.cc = "@CMAKE_C_COMPILER@"
 config.flang = "@CMAKE_Fortran_COMPILER@"
 config.osx_sysroot = path(r"@CMAKE_OSX_SYSROOT@")
 config.target_triple = "@LLVM_TARGET_TRIPLE@"
+config.flang_runtime_f128_math_lib = "@FLANG_RUNTIME_F128_MATH_LIB@"
+config.have_ldbl_mant_dig_113 = "@HAVE_LDBL_MANT_DIG_113@"
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/flang/docs/ReleaseNotes.md
+++ b/flang/docs/ReleaseNotes.md
@@ -31,6 +31,12 @@ page](https://llvm.org/releases/).
 
 ## Bug Fixes
 
+- `ERFC_SCALED` no longer aborts at run time when called on a `REAL(16)`
+  argument. The entry point was only compiled where `long double` is itself
+  binary128, so on x86-64 a program using it built and linked and then died
+  inside the runtime. It is now implemented over the quad-precision math
+  library, to an accuracy the existing shared approximation could not reach.
+
 ## Non-comprehensive list of changes in this release
 
 - Added support for the OpenMP implementation-defined extension sentinels


### PR DESCRIPTION
## Problem

`ERFC_SCALED` has no implementation at `REAL(16)` on x86-64. `ErfcScaled16` in `flang-rt/lib/runtime/numeric.cpp` is guarded by `HAS_LDBL128`, which is false wherever `long double` is the 80-bit format — so on the platform where `REAL(16)` is most likely to be asked for, the entry point simply is not there.

The failure is not a diagnostic. An unaliased `DEFINE_FALLBACK` name reaches `Terminator::Crash` (`flang-rt/lib/quadmath/math-entries.h`), so a program that uses `ERFC_SCALED` at `REAL(16)` compiles, links, and then aborts at run time.

Reusing the shared approximation would not fix it. That code is accurate to roughly seventeen digits — about a thousand times short of what binary128 holds — so this adds a separate implementation over the exact quad entry points rather than widening the existing one.

## Implementation

`erfc-scaled.cpp` computes `exp(x*x)*erfc(x)` directly below `x = 16` and switches to the asymptotic series `1/(x*sqrt(pi)) * (1 - 1/(2x^2) + 3/(4x^4) - ...)` above it, taking 22 terms; the series diverges only after `k ~ x^2`, so at the threshold it is far from its turning point.

Two details are load-bearing:

- **`x*x` is computed with FMA compensation.** `exp` amplifies the rounding of the squaring by a factor of `x^2`, so an uncompensated square is the whole error budget by itself. `u = x*x; e = fma(x, x, -u)` recovers the lost bits and `exp(u)*(1+e)` applies them.
- **`sqrt(pi)` is a sum of three doubles**, not a literal with a `Q` or `L` suffix — those suffixes do not mean binary128 on every host/compiler pair, and a silently narrowed constant is exactly the kind of defect this routine exists to avoid.

## Testing

`flang-rt/test/Runtime/erfc-scaled-real16.f90` checks 11 points against references computed independently with mpmath at 50 decimal places, not against another Fortran compiler: `ERFC_SCALED` is not a libm entry point, so two implementations agreeing would show common ancestry rather than correctness. Tolerance is 2 epsilons; the measurement during development was under 1.

**The grid is deliberately irregular and there is a comment saying so.** A step of 0.5 — or any of 0.125, 1.0, 2.0, 5.0 — gives an exactly representable square, on which the compensation is unnecessary and the error is zero by construction. On such a grid an uncompensated implementation measures 0.4 epsilons; off it, 123. Tidying the grid would blind the test to the defect it exists to catch.

The test needs `REAL(16)`, so it needs a feature gate, and `flang-rt/test` had none. This adds `flang-supports-f128-math` using the same condition `flang/test` already uses, so the two cannot disagree about what the build supports.

Measured on `main` at `87b1a2f7246b`, Release, x86-64 Linux, glibc 2.42:

| build | `check-flang` | `check-flang-rt` |
|---|---|---|
| unpatched `main`, libquadmath | 4757 passed, 0 failed | 346 / 346 |
| this PR, libquadmath | 4757 passed, 0 failed | **347 passed, 0 failed** |
| this PR, default (no `FLANG_RUNTIME_F128_MATH_LIB`) | 4671 passed, 0 failed | 346 passed, 0 failed, **1 unsupported** |

Nothing fails anywhere and the entire delta is the one added test. The gate is shown working in **both** directions, which is the point of including the default build: with libquadmath the test is `PASS: flang-rt :: Runtime/erfc-scaled-real16.f90`, and without a quad math library it is the single `unsupported`. A feature-gated test that has only ever been seen green could be green because it never ran.

Perturbing one digit of one reference value makes it fail, so the tolerance is tight enough to mean something.

## Relation to #219698

Independent of #219698, which adds a libm route for `REAL(16)`. Both apply to `main` on their own and were built and tested separately. They touch one file in common, `flang-rt/lib/quadmath/CMakeLists.txt`, so whichever lands second will need a trivial conflict resolution there.