### PR TITLE
[flang] Support REAL(16) through glibc's *f128 entry points

### DIFF
--- a/flang-rt/README.md
+++ b/flang-rt/README.md
@@ -141,8 +141,10 @@ CMake itself provide.
 
    Determines the implementation of `REAL(16)` math functions. If set to
    `libquadmath`, uses `quadmath.h` and `-lquadmath` typically distributed with
-   gcc. If empty, disables `REAL(16)` support. For any other value, introspects
-   the compiler for `__float128` or 128-bit `long double` support.
+   gcc. If set to `libm`, uses the `*f128` entry points that glibc 2.26 and
+   later export from `libm`, which needs no third-party library. If empty,
+   disables `REAL(16)` support, except on targets where `long double` is itself
+   binary128. Any other value is an error.
    [More details](docs/Real16MathSupport.md).
 
  * `FLANG_RT_EXPERIMENTAL_OFFLOAD_SUPPORT` (values: `"CUDA"`, `""` default: `""`)

--- a/flang-rt/lib/quadmath/CMakeLists.txt
+++ b/flang-rt/lib/quadmath/CMakeLists.txt
@@ -16,6 +16,8 @@
 
 include(CheckLibraryExists)
 include(CheckIncludeFile)
+include(CheckCSourceCompiles)
+include(CMakePushCheckState)
 
 set(sources
   acos.cpp
@@ -89,8 +91,29 @@ if (FLANG_RUNTIME_F128_MATH_LIB)
   elseif (${FLANG_RUNTIME_F128_MATH_LIB} STREQUAL "libm")
     # glibc 2.26 and later export the *f128 entry points from libm itself, so
     # this route pulls in no third-party library at all.
-    check_library_exists(m sinf128 "" FOUND_LIBMF128_EXPLICIT)
-    if (FOUND_LIBMF128_EXPLICIT)
+    #
+    # This compiles rather than looking for a symbol, because a symbol in libm
+    # is not the same thing as a declaration in a header and the two really do
+    # come apart. On the LLVM premerge Linux runner sinf128 is present in libm
+    # while <complex.h> declares no cabsf128: a check_library_exists test
+    # passes there and every complex entry point then fails to compile.
+    #
+    # Both halves are tested because they are gated separately and it is the
+    # complex half that goes missing. Taking the addresses is the point - that
+    # needs a declaration and nothing else, so the check cannot be satisfied by
+    # an implicit declaration or by the linker finding the symbol anyway.
+    cmake_push_check_state()
+    set(CMAKE_REQUIRED_DEFINITIONS -D__STDC_WANT_IEC_60559_TYPES_EXT__=1)
+    set(CMAKE_REQUIRED_LIBRARIES m)
+    check_c_source_compiles("
+#include <complex.h>
+#include <math.h>
+void *scalar = (void *)&sinf128;
+void *complex_ = (void *)&cabsf128;
+int main(void) { return scalar == complex_; }
+" HAVE_LIBM_F128_DECLARATIONS)
+    cmake_pop_check_state()
+    if (HAVE_LIBM_F128_DECLARATIONS)
       add_compile_definitions(HAS_LIBMF128)
       # glibc gates the *f128 prototypes behind this, and it has to be on the
       # command line rather than in a header: no header can guarantee it is
@@ -102,8 +125,10 @@ if (FLANG_RUNTIME_F128_MATH_LIB)
       add_compile_definitions(__STDC_WANT_IEC_60559_TYPES_EXT__=1)
     else()
       message(FATAL_ERROR
-        "FLANG_RUNTIME_F128_MATH_LIB=libm requires a libm that exports the "
-        "*f128 entry points (glibc 2.26 or later)"
+        "FLANG_RUNTIME_F128_MATH_LIB=libm requires a libm whose headers "
+        "declare both the scalar and the complex *f128 entry points "
+        "(glibc 2.26 or later, with a compiler it recognises as supporting "
+        "_Float128). The symbols being present in libm is not enough."
         )
     endif()
   else()
@@ -145,18 +170,11 @@ else()
   if (FOUND_LIBMF128)
     target_compile_definitions(FortranFloat128MathILib INTERFACE
       HAS_LIBMF128
-      # glibc gates the *f128 prototypes behind this. It must be on the command
-      # line, not in a header: a header cannot guarantee it is seen before
-      # <cmath> or <complex.h> in every translation unit, and when it is not,
-      # the prototypes silently do not appear. Measured on glibc 2.43: <cmath>
-      # exposes sqrtf128 without it, <complex.h> does not expose cabsf128 - so
-      # a header-based definition would look correct on the scalar half and
-      # fail on the complex half of the same build.
-      __STDC_WANT_IEC_60559_TYPES_EXT__=1
       )
     target_include_directories(FortranFloat128MathILib INTERFACE
       "${FLANG_RT_SOURCE_DIR}/lib/flang_rt"
       )
-    target_sources(FortranFloat128MathILib INTERFACE ${sources})
+    # Enable this, when math-entries.h and complex-math.h is ready.
+    # target_sources(FortranFloat128MathILib INTERFACE ${sources})
   endif()
 endif()

--- a/flang-rt/lib/quadmath/CMakeLists.txt
+++ b/flang-rt/lib/quadmath/CMakeLists.txt
@@ -86,6 +86,26 @@ if (FLANG_RUNTIME_F128_MATH_LIB)
         "to be available: ${FLANG_RUNTIME_F128_MATH_LIB}"
         )
     endif()
+  elseif (${FLANG_RUNTIME_F128_MATH_LIB} STREQUAL "libm")
+    # glibc 2.26 and later export the *f128 entry points from libm itself, so
+    # this route pulls in no third-party library at all.
+    check_library_exists(m sinf128 "" FOUND_LIBMF128_EXPLICIT)
+    if (FOUND_LIBMF128_EXPLICIT)
+      add_compile_definitions(HAS_LIBMF128)
+      # glibc gates the *f128 prototypes behind this, and it has to be on the
+      # command line rather than in a header: no header can guarantee it is
+      # seen before <cmath> or <complex.h> in every translation unit, and when
+      # it is not, the prototypes silently do not appear. Measured on glibc
+      # 2.43: <cmath> exposes sqrtf128 without it but <complex.h> does not
+      # expose cabsf128, so a header-based definition looks correct on the
+      # scalar half and fails on the complex half of the same build.
+      add_compile_definitions(__STDC_WANT_IEC_60559_TYPES_EXT__=1)
+    else()
+      message(FATAL_ERROR
+        "FLANG_RUNTIME_F128_MATH_LIB=libm requires a libm that exports the "
+        "*f128 entry points (glibc 2.26 or later)"
+        )
+    endif()
   else()
     message(FATAL_ERROR
       "Unsupported third-party library for Fortran F128 math runtime: "
@@ -125,11 +145,18 @@ else()
   if (FOUND_LIBMF128)
     target_compile_definitions(FortranFloat128MathILib INTERFACE
       HAS_LIBMF128
+      # glibc gates the *f128 prototypes behind this. It must be on the command
+      # line, not in a header: a header cannot guarantee it is seen before
+      # <cmath> or <complex.h> in every translation unit, and when it is not,
+      # the prototypes silently do not appear. Measured on glibc 2.43: <cmath>
+      # exposes sqrtf128 without it, <complex.h> does not expose cabsf128 - so
+      # a header-based definition would look correct on the scalar half and
+      # fail on the complex half of the same build.
+      __STDC_WANT_IEC_60559_TYPES_EXT__=1
       )
     target_include_directories(FortranFloat128MathILib INTERFACE
       "${FLANG_RT_SOURCE_DIR}/lib/flang_rt"
       )
-    # Enable this, when math-entries.h and complex-math.h is ready.
-    # target_sources(FortranFloat128MathILib INTERFACE ${sources})
+    target_sources(FortranFloat128MathILib INTERFACE ${sources})
   endif()
 endif()

--- a/flang-rt/lib/quadmath/complex-math.h
+++ b/flang-rt/lib/quadmath/complex-math.h
@@ -53,10 +53,47 @@
 #define CTan(x) ctanl(x)
 #define CTanh(x) ctanhl(x)
 #elif HAS_LIBMF128
-/* We can use __float128 versions of libm functions.
- * __STDC_WANT_IEC_60559_TYPES_EXT__ needs to be defined
- * before including math.h to enable the *f128 prototypes. */
-#error "Float128Math build with glibc>=2.26 is unsupported yet"
+/* glibc 2.26 and later export the complex *f128 entry points from libm, so
+ * this route needs no third-party library.
+ *
+ * __STDC_WANT_IEC_60559_TYPES_EXT__ must be defined before <complex.h> and is
+ * set on the target in this directory's CMakeLists.txt, not here: a header
+ * cannot guarantee it is included first, and the failure is silent. Unlike the
+ * scalar half, <complex.h> on glibc 2.43 really does hide cabsf128 without the
+ * macro, so this is the half that would break.
+ *
+ * The argument type is CFloat128ComplexType from flang/Common/float128.h,
+ * which is _Complex float __attribute__((mode(TC))). That is what the
+ * libquadmath branch already passes to the *q functions, and it is ABI
+ * compatible with the _Float128 _Complex these take: verified with the build
+ * clang under -Wall, sizeof 32, cabs(2+i) correct to nine places. The C23
+ * spelling _Complex _Float128 is not accepted by this clang, and the GNU
+ * spelling __complex__ _Float128 is accepted only with a warning that it is
+ * being read as _Complex double - which would silently halve the precision. */
+#include <complex.h>
+
+/* Compile-time canary: see the note in math-entries.h. If the prototypes are
+ * not visible, this fails here rather than at link time. */
+__attribute__((unused)) static CFloat128Type (*const c_f128_prototype_canary)(
+    CFloat128ComplexType) = &cabsf128;
+
+#define CAbs(x) cabsf128(x)
+#define CAcos(x) cacosf128(x)
+#define CAcosh(x) cacoshf128(x)
+#define CAsin(x) casinf128(x)
+#define CAsinh(x) casinhf128(x)
+#define CAtan(x) catanf128(x)
+#define CAtanh(x) catanhf128(x)
+#define CCos(x) ccosf128(x)
+#define CCosh(x) ccoshf128(x)
+#define CExp(x) cexpf128(x)
+#define CLog(x) clogf128(x)
+#define CSin(x) csinf128(x)
+#define CSinh(x) csinhf128(x)
+#define CSqrt(x) csqrtf128(x)
+#define CTan(x) ctanf128(x)
+#define CTanh(x) ctanhf128(x)
+#define CPow(x, p) cpowf128(x, p)
 #endif
 
 #endif /* FLANG_RT_QUADMATH_COMPLEX_MATH_H_ */

--- a/flang-rt/lib/quadmath/math-entries.h
+++ b/flang-rt/lib/quadmath/math-entries.h
@@ -224,10 +224,89 @@ DEFINE_SIMPLE_ALIAS(Yn, ynl)
 #define F128_RT_QNAN \
   (std::numeric_limits<CppTypeFor<TypeCategory::Real, 16>>::quiet_NaN())
 #elif HAS_LIBMF128
-// We can use __float128 versions of libm functions.
-// __STDC_WANT_IEC_60559_TYPES_EXT__ needs to be defined
-// before including cmath to enable the *f128 prototypes.
-#error "Float128Math build with glibc>=2.26 is unsupported yet"
+// glibc 2.26 and later export *f128 entry points from libm. They are the same
+// IEEE-754 binary128 functions libquadmath provides as *q, so this route needs
+// no third-party library: libm is already linked into everything.
+//
+// __STDC_WANT_IEC_60559_TYPES_EXT__ must be defined before any header pulls in
+// <cmath>, and it is set on the target in this directory's CMakeLists.txt
+// rather than here. In a header it would depend on this file being included
+// before <cmath> in every translation unit, which no header can guarantee -
+// and the failure is silent, because the prototypes simply do not appear.
+//
+// Measured on glibc 2.43 with clang: <cmath> exposes sqrtf128 even without the
+// macro, while <complex.h> does not expose cabsf128 without it. Relying on that
+// asymmetry would give a scalar half that appears to work beside a complex half
+// that does not compile, in the same build.
+#include <cmath>
+#include <limits>
+
+// Compile-time canary. If the *f128 prototypes are not visible here - a macro
+// lost, an include reordered, a future libc spelling them differently - the
+// aliases below would resolve to nothing and the failure would surface at link
+// time or in the field. This makes it surface at the line that owns the
+// assumption.
+[[maybe_unused]] static CppTypeFor<TypeCategory::Real, 16> (
+    *const f128_prototype_canary)(CppTypeFor<TypeCategory::Real, 16>) =
+    &sqrtf128;
+
+DEFINE_SIMPLE_ALIAS(Abs, fabsf128)
+DEFINE_SIMPLE_ALIAS(Acos, acosf128)
+DEFINE_SIMPLE_ALIAS(Acosh, acoshf128)
+DEFINE_SIMPLE_ALIAS(Asin, asinf128)
+DEFINE_SIMPLE_ALIAS(Asinh, asinhf128)
+DEFINE_SIMPLE_ALIAS(Atan, atanf128)
+DEFINE_SIMPLE_ALIAS(Atan2, atan2f128)
+DEFINE_SIMPLE_ALIAS(Atanh, atanhf128)
+DEFINE_SIMPLE_ALIAS(Ceil, ceilf128)
+DEFINE_SIMPLE_ALIAS(Cos, cosf128)
+DEFINE_SIMPLE_ALIAS(Cosh, coshf128)
+DEFINE_SIMPLE_ALIAS(Erf, erff128)
+DEFINE_SIMPLE_ALIAS(Erfc, erfcf128)
+DEFINE_SIMPLE_ALIAS(Exp, expf128)
+DEFINE_SIMPLE_ALIAS(Floor, floorf128)
+DEFINE_SIMPLE_ALIAS(Fma, fmaf128)
+DEFINE_SIMPLE_ALIAS(Frexp, frexpf128)
+DEFINE_SIMPLE_ALIAS(Hypot, hypotf128)
+DEFINE_SIMPLE_ALIAS(Ilogb, ilogbf128)
+DEFINE_SIMPLE_ALIAS(J0, j0f128)
+DEFINE_SIMPLE_ALIAS(J1, j1f128)
+DEFINE_SIMPLE_ALIAS(Jn, jnf128)
+DEFINE_SIMPLE_ALIAS(Ldexp, ldexpf128)
+DEFINE_SIMPLE_ALIAS(Lgamma, lgammaf128)
+DEFINE_SIMPLE_ALIAS(Log, logf128)
+DEFINE_SIMPLE_ALIAS(Log10, log10f128)
+DEFINE_SIMPLE_ALIAS(Lround, lroundf128)
+DEFINE_SIMPLE_ALIAS(Nearbyint, nearbyintf128)
+DEFINE_SIMPLE_ALIAS(Nextafter, nextafterf128)
+DEFINE_SIMPLE_ALIAS(Pow, powf128)
+DEFINE_SIMPLE_ALIAS(Remainder, remainderf128)
+DEFINE_SIMPLE_ALIAS(Round, roundf128)
+DEFINE_SIMPLE_ALIAS(Sin, sinf128)
+DEFINE_SIMPLE_ALIAS(Sinh, sinhf128)
+DEFINE_SIMPLE_ALIAS(Sqrt, sqrtf128)
+DEFINE_SIMPLE_ALIAS(Tan, tanf128)
+DEFINE_SIMPLE_ALIAS(Tanh, tanhf128)
+DEFINE_SIMPLE_ALIAS(Tgamma, tgammaf128)
+DEFINE_SIMPLE_ALIAS(Trunc, truncf128)
+DEFINE_SIMPLE_ALIAS(Y0, y0f128)
+DEFINE_SIMPLE_ALIAS(Y1, y1f128)
+DEFINE_SIMPLE_ALIAS(Yn, ynf128)
+
+// Isinf, Isnan and the quiet NaN are not libm entry points in any width, but
+// they still need implementations: the fallback for an unaliased name is a
+// runtime Crash, not a default. The builtins are type-generic and correct for
+// binary128; the libquadmath branch reaches the same place through isinfq and
+// isnanq.
+DEFINE_SIMPLE_ALIAS(Isinf, __builtin_isinf)
+DEFINE_SIMPLE_ALIAS(Isnan, __builtin_isnan)
+
+// Not libm calls: isinf and isnan are type-generic macros, and the quiet NaN
+// comes from numeric_limits rather than from a function.
+#define F128_RT_INFINITY \
+  (std::numeric_limits<CppTypeFor<TypeCategory::Real, 16>>::infinity())
+#define F128_RT_QNAN \
+  (std::numeric_limits<CppTypeFor<TypeCategory::Real, 16>>::quiet_NaN())
 #endif
 
 } // namespace Fortran::runtime

--- a/flang-rt/lib/quadmath/math-entries.h
+++ b/flang-rt/lib/quadmath/math-entries.h
@@ -246,9 +246,8 @@ DEFINE_SIMPLE_ALIAS(Yn, ynl)
 // aliases below would resolve to nothing and the failure would surface at link
 // time or in the field. This makes it surface at the line that owns the
 // assumption.
-[[maybe_unused]] static CppTypeFor<TypeCategory::Real, 16> (
-    *const f128_prototype_canary)(CppTypeFor<TypeCategory::Real, 16>) =
-    &sqrtf128;
+[[maybe_unused]] static CppTypeFor<TypeCategory::Real, 16> (*const
+        f128_prototype_canary)(CppTypeFor<TypeCategory::Real, 16>) = &sqrtf128;
 
 DEFINE_SIMPLE_ALIAS(Abs, fabsf128)
 DEFINE_SIMPLE_ALIAS(Acos, acosf128)

--- a/flang/cmake/modules/FlangCommon.cmake
+++ b/flang/cmake/modules/FlangCommon.cmake
@@ -19,10 +19,11 @@ include(CMakePushCheckState)
 # to be composable. Failure to synchronize this setting may result
 # in linking errors or fatal failures in F128 runtime functions.
 set(FLANG_RUNTIME_F128_MATH_LIB "" CACHE STRING
-  "Specifies the target library used for implementing IEEE-754 128-bit float \
-  math in F18 runtime, e.g. it might be libquadmath for targets where \
-  REAL(16) is mapped to __float128, or libm for targets where REAL(16) \
-  is mapped to long double, etc."
+  "Library implementing IEEE-754 binary128 math in the Fortran runtime. \
+  Accepted values: libquadmath, for GCC's __float128 support; or libm, on a \
+  glibc 2.26 or later that exports the *f128 entry points, which needs no \
+  third-party library. Leave empty to build without REAL(16) support - the \
+  type is then disabled in the compiler as well as the runtime."
   )
 if (FLANG_RUNTIME_F128_MATH_LIB)
   add_compile_definitions(FLANG_RUNTIME_F128_MATH_LIB="${FLANG_RUNTIME_F128_MATH_LIB}")

--- a/flang/docs/GettingStarted.md
+++ b/flang/docs/GettingStarted.md
@@ -318,6 +318,10 @@ One may provide optional CMake variables to customize the build. Available optio
   `quadmath.h` must be available to the build compiler.
   [More details](Real16MathSupport.md).
 
+* `-DFLANG_RUNTIME_F128_MATH_LIB=libm`: the same `REAL(16)` math APIs, taken
+  from the `*f128` entry points that glibc 2.26 and later export from `libm`.
+  This needs no third-party library. [More details](Real16MathSupport.md).
+
 ## Supported C++ compilers
 
 Flang is written in C++17.

--- a/flang/docs/Real16MathSupport.md
+++ b/flang/docs/Real16MathSupport.md
@@ -9,12 +9,29 @@
 # Flang support for REAL(16) math intrinsics
 
 To support most `REAL(16)` (i.e. 128-bit float) math intrinsics Flang relies
-on third-party libraries providing the implementation.
+on an external library providing the implementation. There are two choices,
+selected with the `FLANG_RUNTIME_F128_MATH_LIB` CMake option.
 
-`-DFLANG_RUNTIME_F128_MATH_LIB=libquadmath` CMake option can be used
-to build `libflang_rt.quadmath` library that has unresolved references
-to GCC `libquadmath` library. A Flang driver built with this option
-will automatically link `libflang_rt.quadmath` and `libquadmath` libraries
+## `-DFLANG_RUNTIME_F128_MATH_LIB=libm`
+
+On a glibc of version 2.26 or later, the `*f128` entry points are exported by
+`libm` itself, and this option builds `libflang_rt.quadmath` against those.
+No third-party library is involved: `libm` is linked into every program
+already, so nothing has to be distributed alongside the compiler and no extra
+library has to be found on the library path.
+
+The prototypes are guarded by `__STDC_WANT_IEC_60559_TYPES_EXT__`, which the
+build sets. Both the scalar and the complex entry points are required, and
+they are gated separately in glibc, so the CMake configuration checks them by
+compiling a program that takes the address of one of each. The check fails at
+configuration time, naming what is missing, on a libc that exports the symbols
+but does not declare them.
+
+## `-DFLANG_RUNTIME_F128_MATH_LIB=libquadmath`
+
+This builds `libflang_rt.quadmath` with unresolved references to GCC's
+`libquadmath` library. A Flang driver built with this option will
+automatically link `libflang_rt.quadmath` and `libquadmath` libraries
 to any Fortran program. This implies that `libquadmath` library
 has to be available in the standard library paths, so that linker
 can find it. The `libquadmath` library installation into Flang project
@@ -29,10 +46,20 @@ with `REAL(16)` support via `libquadmath` because of its licensing
 under the GNU Library General Public License. Moreover, static linking
 of `libquadmath` to the Flang users' programs may imply some
 restrictions/requirements. This document is not intended to give
-any legal advice on distributing such a Flang compiler.
+any legal advice on distributing such a Flang compiler. Where the `libm`
+option above is available, it avoids the question entirely.
+
+## Targets where `long double` is already binary128
 
 Flang compiler targeting systems with `LDBL_MANT_DIG == 113`
 may provide `REAL(16)` math support without a `libquadmath`
 dependency, using standard `libc` APIs for the `long double`
-data type. It is not recommended to use the above CMake option
+data type. It is not recommended to use either of the above CMake options
 for building Flang compilers for such targets.
+
+## Constant folding
+
+Whichever library is selected is also the one the compiler folds `REAL(16)`
+constant expressions through, so `parameter :: v = sin(x)` and `y = sin(x)`
+are evaluated by the same implementation. If the option is left empty,
+`REAL(16)` is unsupported in the compiler and no folding library is linked.

--- a/flang/docs/ReleaseNotes.md
+++ b/flang/docs/ReleaseNotes.md
@@ -29,6 +29,16 @@ page](https://llvm.org/releases/).
 
 ## Major New Features
 
+- `REAL(16)` math support can now be built against glibc rather than
+  libquadmath, with `-DFLANG_RUNTIME_F128_MATH_LIB=libm`. glibc 2.26 and later
+  export the `*f128` entry points from `libm`, which is linked into every
+  program already, so this route needs no third-party library at either build
+  or run time and avoids the licensing question libquadmath raises for
+  distributors. The same library is used for compile-time constant folding as
+  for the runtime, so `parameter :: v = sin(x)` and `y = sin(x)` are computed
+  by one implementation rather than two. See
+  [Real16MathSupport](Real16MathSupport.md).
+
 ## Bug Fixes
 
 ## Non-comprehensive list of changes in this release

--- a/flang/include/flang/Tools/TargetSetup.h
+++ b/flang/include/flang/Tools/TargetSetup.h
@@ -57,12 +57,13 @@ namespace Fortran::tools {
     break;
   }
 
-  // Check for kind=16 support. See flang/runtime/Float128Math/math-entries.h.
+  // Check for kind=16 support. See flang-rt/lib/quadmath/math-entries.h.
   // TODO: Take this from TargetInfo::getLongDoubleFormat for cross compilation.
 #ifdef FLANG_RUNTIME_F128_MATH_LIB
-  constexpr bool f128Support = true; // use libquadmath wrappers
+  // libquadmath, or libm on a glibc that exports the *f128 entry points.
+  constexpr bool f128Support = true;
 #elif HAS_LDBL128
-  constexpr bool f128Support = true; // use libm wrappers
+  constexpr bool f128Support = true; // long double is itself binary128
 #else
   constexpr bool f128Support = false;
 #endif

--- a/flang/lib/Evaluate/CMakeLists.txt
+++ b/flang/lib/Evaluate/CMakeLists.txt
@@ -40,6 +40,22 @@ if (FLANG_RUNTIME_F128_MATH_LIB STREQUAL "libquadmath")
     add_compile_definitions(HAS_QUADMATHLIB)
     set(QUADMATHLIB quadmath)
   else()
+    # BEHAVIOUR CHANGE, and a deliberate one. Previously this condition was
+    # silent: the folding table was simply not built, configuration carried on,
+    # and the resulting compiler evaluated REAL(16) constant expressions at run
+    # time instead of folding them - with no message at any point saying so.
+    #
+    # That silence is only harmless while nobody asked. Here the user has named
+    # libquadmath explicitly, so the absence of quadmath.h or of the library is
+    # a request that cannot be honoured, and continuing would hand back a
+    # compiler quietly missing the capability that was asked for. The same
+    # reasoning does not apply when the option is left empty: REAL(16) is then
+    # disabled outright and there is nothing to be quiet about.
+    #
+    # A configuration that relied on the old behaviour - naming libquadmath on
+    # a machine that does not have it - will now stop here. The fix is to leave
+    # FLANG_RUNTIME_F128_MATH_LIB empty, which is what such a build was
+    # effectively getting anyway.
     message(FATAL_ERROR
       "FLANG_RUNTIME_F128_MATH_LIB=libquadmath but quadmath.h or libquadmath "
       "was not found; the compiler could not fold REAL(16) constants")

--- a/flang/lib/Evaluate/CMakeLists.txt
+++ b/flang/lib/Evaluate/CMakeLists.txt
@@ -21,11 +21,36 @@ if (LIBPGMATH_DIR)
   endif()
 endif()
 
-check_library_exists(quadmath sinq "" FOUND_QUADMATH_LIB)
-if (FLANG_INCLUDE_QUADMATH_H AND FOUND_QUADMATH_LIB)
-  configure_file("${FLANG_SOURCE_DIR}/cmake/quadmath_wrapper.h.in" "${CMAKE_CURRENT_BINARY_DIR}/quadmath_wrapper.h")
-  add_compile_definitions(HAS_QUADMATHLIB)
-  set(QUADMATHLIB quadmath)
+# Compile-time folding of REAL(16) constants needs a binary128 math library on
+# the host. Which one is not a separate question from which one the runtime
+# uses: before this was tied to FLANG_RUNTIME_F128_MATH_LIB, the folder was
+# enabled purely by libquadmath being installed on the build machine, so every
+# flang binary linked it - including one configured for the libm route, and one
+# configured with REAL(16) disabled entirely, where the table was unreachable
+# dead weight.
+#
+# Worse, on the libm route the two halves then disagreed about who computes:
+# `parameter :: v = sin(x)` folded through sinq while `y = sin(x)` ran through
+# sinf128. They agree on every point measured, but nothing makes them agree in
+# the last place.
+if (FLANG_RUNTIME_F128_MATH_LIB STREQUAL "libquadmath")
+  check_library_exists(quadmath sinq "" FOUND_QUADMATH_LIB)
+  if (FLANG_INCLUDE_QUADMATH_H AND FOUND_QUADMATH_LIB)
+    configure_file("${FLANG_SOURCE_DIR}/cmake/quadmath_wrapper.h.in" "${CMAKE_CURRENT_BINARY_DIR}/quadmath_wrapper.h")
+    add_compile_definitions(HAS_QUADMATHLIB)
+    set(QUADMATHLIB quadmath)
+  else()
+    message(FATAL_ERROR
+      "FLANG_RUNTIME_F128_MATH_LIB=libquadmath but quadmath.h or libquadmath "
+      "was not found; the compiler could not fold REAL(16) constants")
+  endif()
+elseif (FLANG_RUNTIME_F128_MATH_LIB STREQUAL "libm")
+  # glibc 2.26 and later carry the same functions as *f128 in libm, which is
+  # linked anyway. The macro that reveals their prototypes has to be on the
+  # command line for the same reason as in flang-rt: no header can guarantee it
+  # is seen before <cmath> in every translation unit.
+  add_compile_definitions(HAS_LIBMF128_HOST)
+  add_compile_definitions(__STDC_WANT_IEC_60559_TYPES_EXT__=1)
 endif ()
 
 add_flang_library(FortranEvaluate

--- a/flang/lib/Evaluate/host.h
+++ b/flang/lib/Evaluate/host.h
@@ -20,6 +20,8 @@
 #if HAS_QUADMATHLIB
 #include "quadmath_wrapper.h"
 #include "flang/Common/float128.h"
+#elif HAS_LIBMF128_HOST
+#include "flang/Common/float128.h"
 #endif
 #include "flang/Evaluate/type.h"
 #include <cfenv>
@@ -159,9 +161,13 @@ struct HostTypeHelper<
       long double, UnsupportedType>;
 };
 
-#if HAS_QUADMATHLIB
+#if HAS_QUADMATHLIB || HAS_LIBMF128_HOST
 template <> struct HostTypeHelper<Type<TypeCategory::Real, 16>> {
-  // IEEE 754 128bits
+  // IEEE 754 128bits.
+  //
+  // Both routes use the same host type; only the library the folding table
+  // calls differs - libquadmath's *q or glibc's *f128. Keeping the type common
+  // is what lets the two share everything above this line.
   using Type = __float128;
 };
 #else
@@ -184,6 +190,21 @@ template <int KIND> struct HostTypeHelper<Type<TypeCategory::Complex, KIND>> {
 template <> struct HostTypeHelper<Type<TypeCategory::Complex, 16>> {
   using RealT = Fortran::evaluate::Type<TypeCategory::Real, 16>;
   using Type = __complex128;
+};
+#elif HAS_LIBMF128_HOST
+// __complex128 is libquadmath's typedef and is not available here. The mode
+// attribute is how flang already spells this type in flang/Common/float128.h
+// for the runtime, and glibc's complex *f128 functions take the same ABI.
+// The C-style typedef, not `using`: with an alias declaration the mode
+// attribute is silently dropped and the type degrades to _Complex float. The
+// static_assert below caught exactly that during development.
+typedef _Complex float __attribute__((mode(TC))) HostComplex128;
+static_assert(sizeof(HostComplex128) == 32,
+    "mode(TC) must be a pair of binary128 values; if it is not, the complex "
+    "folding table below is calling libm with the wrong ABI");
+template <> struct HostTypeHelper<Type<TypeCategory::Complex, 16>> {
+  using RealT = Fortran::evaluate::Type<TypeCategory::Real, 16>;
+  using Type = HostComplex128;
 };
 #endif
 

--- a/flang/lib/Evaluate/intrinsics-library.cpp
+++ b/flang/lib/Evaluate/intrinsics-library.cpp
@@ -576,7 +576,95 @@ template <> struct HostRuntimeLibrary<__complex128, LibraryVersion::Libm> {
   static constexpr HostRuntimeMap map{table};
   static_assert(map.Verify(), "map must be sorted");
 };
-#endif // HAS_QUADMATHLIB
+
+#elif HAS_LIBMF128_HOST
+template <> struct HostRuntimeLibrary<__float128, LibraryVersion::Libm> {
+  using F = FuncPointer<__float128, __float128>;
+  using F2 = FuncPointer<__float128, __float128, __float128>;
+  using FN = FuncPointer<__float128, int, __float128>;
+  static constexpr HostRuntimeFunction table[]{
+      FolderFactory<F, F{::acosf128}>::Create("acos"),
+      FolderFactory<F, F{::acoshf128}>::Create("acosh"),
+      FolderFactory<F, F{::asinf128}>::Create("asin"),
+      FolderFactory<F, F{::asinhf128}>::Create("asinh"),
+      FolderFactory<F, F{::atanf128}>::Create("atan"),
+      FolderFactory<F2, F2{::atan2f128}>::Create("atan2"),
+      FolderFactory<F, F{::atanhf128}>::Create("atanh"),
+      FolderFactory<F, F{::j0f128}>::Create("bessel_j0"),
+      FolderFactory<F, F{::j1f128}>::Create("bessel_j1"),
+      FolderFactory<FN, FN{::jnf128}>::Create("bessel_jn"),
+      FolderFactory<F, F{::y0f128}>::Create("bessel_y0"),
+      FolderFactory<F, F{::y1f128}>::Create("bessel_y1"),
+      FolderFactory<FN, FN{::ynf128}>::Create("bessel_yn"),
+      FolderFactory<F, F{cosf128}>::Create("cos"),
+      FolderFactory<F, F{coshf128}>::Create("cosh"),
+      FolderFactory<F, F{::erff128}>::Create("erf"),
+      FolderFactory<F, F{::erfcf128}>::Create("erfc"),
+      FolderFactory<F, F{::expf128}>::Create("exp"),
+      FolderFactory<F, F{::tgammaf128}>::Create("gamma"),
+      FolderFactory<F, F{::logf128}>::Create("log"),
+      FolderFactory<F, F{::log10f128}>::Create("log10"),
+      FolderFactory<F, F{::lgammaf128}>::Create("log_gamma"),
+      FolderFactory<F2, F2{::powf128}>::Create("pow"),
+      FolderFactory<F, F{::sinf128}>::Create("sin"),
+      FolderFactory<F, F{::sinhf128}>::Create("sinh"),
+      FolderFactory<F, F{::tanf128}>::Create("tan"),
+      FolderFactory<F, F{::tanhf128}>::Create("tanh"),
+  };
+  static constexpr HostRuntimeMap map{table};
+  static_assert(map.Verify(), "map must be sorted");
+};
+
+// glibc declares the complex *f128 entry points in <complex.h> for C only; in
+// C++ they are hidden, though the symbols are in libm and the ABI is the one
+// mode(TC) produces. Declaring them here is deliberate. The signatures are
+// fixed by TS 18661-3 and the glibc ABI, and no separate canary is needed: the
+// table below takes each function's address, so a change in visibility or
+// signature is a build error at that line rather than a silent drift back to
+// libquadmath. Do not delete this block expecting the headers to provide them.
+extern "C" {
+host::HostComplex128 cacosf128(host::HostComplex128);
+host::HostComplex128 cacoshf128(host::HostComplex128);
+host::HostComplex128 casinf128(host::HostComplex128);
+host::HostComplex128 casinhf128(host::HostComplex128);
+host::HostComplex128 catanf128(host::HostComplex128);
+host::HostComplex128 catanhf128(host::HostComplex128);
+host::HostComplex128 ccosf128(host::HostComplex128);
+host::HostComplex128 ccoshf128(host::HostComplex128);
+host::HostComplex128 cexpf128(host::HostComplex128);
+host::HostComplex128 clogf128(host::HostComplex128);
+host::HostComplex128 cpowf128(host::HostComplex128, host::HostComplex128);
+host::HostComplex128 csinf128(host::HostComplex128);
+host::HostComplex128 csinhf128(host::HostComplex128);
+host::HostComplex128 csqrtf128(host::HostComplex128);
+host::HostComplex128 ctanf128(host::HostComplex128);
+host::HostComplex128 ctanhf128(host::HostComplex128);
+}
+template <> struct HostRuntimeLibrary<host::HostComplex128, LibraryVersion::Libm> {
+  using F = FuncPointer<host::HostComplex128, host::HostComplex128>;
+  using F2 = FuncPointer<host::HostComplex128, host::HostComplex128, host::HostComplex128>;
+  static constexpr HostRuntimeFunction table[]{
+      FolderFactory<F, F{cacosf128}>::Create("acos"),
+      FolderFactory<F, F{cacoshf128}>::Create("acosh"),
+      FolderFactory<F, F{casinf128}>::Create("asin"),
+      FolderFactory<F, F{casinhf128}>::Create("asinh"),
+      FolderFactory<F, F{catanf128}>::Create("atan"),
+      FolderFactory<F, F{catanhf128}>::Create("atanh"),
+      FolderFactory<F, F{ccosf128}>::Create("cos"),
+      FolderFactory<F, F{ccoshf128}>::Create("cosh"),
+      FolderFactory<F, F{cexpf128}>::Create("exp"),
+      FolderFactory<F, F{clogf128}>::Create("log"),
+      FolderFactory<F2, F2{cpowf128}>::Create("pow"),
+      FolderFactory<F, F{csinf128}>::Create("sin"),
+      FolderFactory<F, F{csinhf128}>::Create("sinh"),
+      FolderFactory<F, F{csqrtf128}>::Create("sqrt"),
+      FolderFactory<F, F{ctanf128}>::Create("tan"),
+      FolderFactory<F, F{ctanhf128}>::Create("tanh"),
+  };
+  static constexpr HostRuntimeMap map{table};
+  static_assert(map.Verify(), "map must be sorted");
+};
+#endif // HAS_QUADMATHLIB || HAS_LIBMF128_HOST
 
 /// Define pgmath description
 #if LINK_WITH_LIBPGMATH
@@ -686,7 +774,11 @@ static const HostRuntimeMap *GetHostRuntimeMapVersion(DynamicType resultType) {
             GetHostRuntimeMapHelper<long double, version>(resultType)}) {
       return map;
     }
-#if HAS_QUADMATHLIB
+#if HAS_QUADMATHLIB || HAS_LIBMF128_HOST
+    // Both routes present __float128 here; only the library behind the table
+    // differs. Guarding this on HAS_QUADMATHLIB alone compiled the libm tables
+    // and then never reached them, so REAL(16) folding failed on a build that
+    // had everything it needed.
     if (const auto *map{
             GetHostRuntimeMapHelper<__float128, version>(resultType)}) {
       return map;
@@ -710,6 +802,11 @@ static const HostRuntimeMap *GetHostRuntimeMapVersion(DynamicType resultType) {
 #if HAS_QUADMATHLIB
     if (const auto *map{
             GetHostRuntimeMapHelper<__complex128, version>(resultType)}) {
+      return map;
+    }
+#elif HAS_LIBMF128_HOST
+    if (const auto *map{GetHostRuntimeMapHelper<host::HostComplex128, version>(
+            resultType)}) {
       return map;
     }
 #endif

--- a/flang/lib/Evaluate/intrinsics-library.cpp
+++ b/flang/lib/Evaluate/intrinsics-library.cpp
@@ -640,9 +640,11 @@ host::HostComplex128 csqrtf128(host::HostComplex128);
 host::HostComplex128 ctanf128(host::HostComplex128);
 host::HostComplex128 ctanhf128(host::HostComplex128);
 }
-template <> struct HostRuntimeLibrary<host::HostComplex128, LibraryVersion::Libm> {
+template <>
+struct HostRuntimeLibrary<host::HostComplex128, LibraryVersion::Libm> {
   using F = FuncPointer<host::HostComplex128, host::HostComplex128>;
-  using F2 = FuncPointer<host::HostComplex128, host::HostComplex128, host::HostComplex128>;
+  using F2 = FuncPointer<host::HostComplex128, host::HostComplex128,
+      host::HostComplex128>;
   static constexpr HostRuntimeFunction table[]{
       FolderFactory<F, F{cacosf128}>::Create("acos"),
       FolderFactory<F, F{cacoshf128}>::Create("acosh"),

--- a/flang/test/Driver/linker-flags.f90
+++ b/flang/test/Driver/linker-flags.f90
@@ -44,7 +44,9 @@
 ! UNIX-F128NONE-NOT: lang_rt.quadmath
 ! SOLARIS-F128NONE-NOT: flang_rt.quadmath
 ! UNIX-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "--as-needed" "-lquadmath" "--no-as-needed"
+! UNIX-F128LIBM-SAME: "-lflang_rt.quadmath" "--as-needed" "-lm" "--no-as-needed"
 ! SOLARIS-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "-z" "ignore" "-lquadmath" "-z" "record"
+! SOLARIS-F128LIBM-SAME: "-lflang_rt.quadmath" "-z" "ignore" "-lm" "-z" "record"
 ! UNIX-SAME: "-lflang_rt.runtime" "-lm"
 ! COMPILER-RT: "{{.*}}{{\\|/}}libclang_rt.builtins.a"
 ! UNIX-STATIC-FLANGRT:   "{{.*}}{{\\|/}}libflang_rt.runtime.a"
@@ -53,6 +55,7 @@
 ! BSD-SAME: "[[object_file]]"
 ! BSD-F128NONE-NOT: flang_rt.quadmath
 ! BSD-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "--as-needed" "-lquadmath" "--no-as-needed"
+! BSD-F128LIBM-SAME: "-lflang_rt.quadmath" "--as-needed" "-lm" "--no-as-needed"
 ! BSD-SAME: -lflang_rt.runtime
 ! BSD-SAME: -lexecinfo
 ! BSD-STATIC-FLANGRT: "{{.*}}{{\\|/}}libflang_rt.runtime.a"
@@ -61,6 +64,7 @@
 ! DARWIN-SAME: "[[object_file]]"
 ! DARWIN-F128NONE-NOT: libflang_rt.quadmath
 ! DARWIN-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "--as-needed" "-lquadmath" "--no-as-needed"
+! DARWIN-F128LIBM-SAME: "-lflang_rt.quadmath" "--as-needed" "-lm" "--no-as-needed"
 ! DARWIN-SAME: -lflang_rt.runtime
 ! DARWIN-STATIC-FLANGRT: "{{.*}}{{\\|/}}libclang_rt.runtime_osx.a"
 
@@ -68,6 +72,7 @@
 ! HAIKU-SAME: "[[object_file]]"
 ! HAIKU-F128NONE-NOT: libflang_rt.quadmath
 ! HAIKU-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "--as-needed" "-lquadmath" "--no-as-needed"
+! HAIKU-F128LIBM-SAME: "-lflang_rt.quadmath" "--as-needed" "-lm" "--no-as-needed"
 ! HAIKU-SAME: "-lflang_rt.runtime"
 ! HAIKU-STATIC-FLANGRT: "{{.*}}{{\\|/}}libflang_rt.runtime.a"
 
@@ -75,6 +80,7 @@
 ! MINGW-SAME: "[[object_file]]"
 ! MINGW-F128NONE-NOT: libflang_rt.quadmath
 ! MINGW-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "--as-needed" "-lquadmath" "--no-as-needed"
+! MINGW-F128LIBM-SAME: "-lflang_rt.quadmath" "--as-needed" "-lm" "--no-as-needed"
 ! MINGW-SAME: -lflang_rt.runtime
 ! MINGW-STATIC-FLANGRT: "{{.*}}{{\\|/}}libflang_rt.runtime.a"
 


### PR DESCRIPTION
## Problem

`REAL(16)` currently requires libquadmath. On a target where `long double` is not binary128, `flang/cmake/modules/FlangCommon.cmake` accepts only `FLANG_RUNTIME_F128_MATH_LIB=libquadmath`, and `math-entries.h` ends in an `#error` for anything else.

glibc has exported the `*f128` entry points from libm since 2.26. They are the same functions, in the C library that is already linked. Nothing needed them to be unavailable — the route was simply never wired up.

This matters beyond tidiness: libquadmath is GPL-3.0-or-later WITH GCC-exception-3.1, and whether that is acceptable is a question some users have to ask their lawyers. With this change they do not have to ask it.

This is opt-in. It adds a value to `FLANG_RUNTIME_F128_MATH_LIB` and changes nothing for a build that does not ask for it — the autodetected branch in `flang-rt/lib/quadmath/CMakeLists.txt` is left exactly as it is upstream.

## Implementation

- `math-entries.h` gains a glibc branch alongside the libquadmath one: 42 `DEFINE_SIMPLE_ALIAS` entries plus `Isinf`/`Isnan` to builtins. The alias table was derived by intersecting the names flang-rt actually declares with what libm actually exports, rather than by transcription.
- The `*f128` prototypes are gated behind `__STDC_WANT_IEC_60559_TYPES_EXT__`, which is set on the build target — a header-local `#define` arrives too late. Measured on glibc 2.43: `cmath` exposes `sqrtf128` without the macro, while `complex.h` does not expose `cabsf128`, so a header-based definition would look correct on the scalar half and fail on the complex half of the same build.
- **The configure test compiles, it does not look for a symbol.** A symbol in libm is not the same thing as a declaration in a header, and the two come apart in practice: on the premerge Linux runner `sinf128` is present in libm while `complex.h` declares no `cabsf128`. A `check_library_exists` test passes there and every complex entry point then fails to compile — which is exactly what the first revision of this PR did. The check now takes the addresses of one scalar and one complex entry point, which needs declarations and cannot be satisfied by the linker finding the symbols anyway. Verified to discriminate: the same snippet compiles with the macro and fails with `use of undeclared identifier` without it.
- `intrinsics-library.cpp` gains the matching host folding tables, so constant folding at `REAL(16)` goes through the same library the runtime does. This is the part that is easy to get wrong quietly: with the folder on libquadmath and the runtime on libm, `parameter :: v = sin(x)` and `y = sin(x)` are computed by two different libraries. They agree on every point measured here, but nothing *makes* them agree in the last place.
- The complex `*f128` entry points are declared explicitly. glibc declares them in `complex.h` for C only; in C++ they are hidden, though the symbols are in libm and the ABI is the one `mode(TC)` produces. The tables take each function's address, so a change in visibility or signature is a build error at that line rather than a silent drift back to libquadmath.

Note the complex host type must be a C-style `typedef` of `_Complex float __attribute__((mode(TC)))`. Spelled as a `using` alias the attribute is silently dropped and the type degrades to `_Complex double` with only a warning — so there is a `static_assert` on `sizeof == 32`.

## Testing

Measured on `main` at `87b1a2f7246b`, Release, x86-64 Linux, glibc 2.42.

| build | `check-flang` | `check-flang-rt` | libquadmath in `flang` (`nm -D`) |
|---|---|---|---|
| unpatched `main`, libquadmath | 4757 passed, 0 failed | 346 / 346 | 43 |
| this PR, libquadmath | 4757 passed, 0 failed | 346 / 346 | 43 |
| this PR, **libm** | 4757 passed, 0 failed | 346 / 346 | **0** |
| this PR, default (no `FLANG_RUNTIME_F128_MATH_LIB`) | 4671 passed, 0 failed | 346 / 346 | **0** |

The default row is there because its absence is what let the first revision break: only the two explicit routes had been built, and premerge CI builds the default one. It is included from now on.

On the libm route neither the compiler nor an application it produces references libquadmath — `ldd` reports none and `nm -D` finds zero, against 43 on the libquadmath builds. The same probe returning 43 where libquadmath *is* expected is what makes the 0 meaningful; a zero from an instrument never seen to return non-zero is not evidence of absence.

The zero in the default row is a consequence of tying the folder to the chosen route: with no route selected, `REAL(16)` is disabled in the compiler anyway, so the folding table was unreachable and libquadmath was being linked for nothing.

`flang/test/Driver/linker-flags.f90` gains the libm check prefixes so the driver's behaviour on this route is asserted rather than assumed.

## Known gap

`ERFC_SCALED` is not folded at `REAL(16)` on either route, because the folder registers it on host types only. That is pre-existing and unchanged here.

## Relation to #219697

Independent of #219697 — both apply to `main` on their own and were built and tested separately. They touch one file in common, `flang-rt/lib/quadmath/CMakeLists.txt`, so whichever lands second will need a trivial conflict resolution there.