### PR TITLE
[flang-rt] Fix runtime/environment.cpp compilation on FreeBSD

### DIFF
--- a/flang-rt/lib/runtime/environment.cpp
+++ b/flang-rt/lib/runtime/environment.cpp
@@ -21,6 +21,8 @@
 // FreeBSD has environ in crt rather than libc. Using "extern char** environ"
 // in the code of a shared library makes it fail to link with -Wl,--no-undefined
 // See https://reviews.freebsd.org/D30842#840642
+#include <dlfcn.h>
+#elif RT_GPU_TARGET
 // GPU targets do not provide environ.
 #else
 extern char **environ;

--- a/flang-rt/lib/runtime/environment.cpp
+++ b/flang-rt/lib/runtime/environment.cpp
@@ -17,7 +17,7 @@
 
 #ifdef _WIN32
 #include <stdlib.h>
-#elif defined(__FreeBSD__) || RT_GPU_TARGET
+#elif defined(__FreeBSD__)
 // FreeBSD has environ in crt rather than libc. Using "extern char** environ"
 // in the code of a shared library makes it fail to link with -Wl,--no-undefined
 // See https://reviews.freebsd.org/D30842#840642


### PR DESCRIPTION
`runtime/environment.cpp` doesn't compile on FreeBSD:

```
runtime/environment.cpp:115:47: error: use of undeclared identifier 'RTLD_DEFAULT'
  115 |   auto envpp{reinterpret_cast<char ***>(dlsym(RTLD_DEFAULT, "environ"))};
      |                                               ^~~~~~~~~~~~
```

`<dlfcn.h>` needs to be included.

Tested on `x86_64-pc-freebsd15.1` and `x86_64-pc-linux-gnu`.