### PR TITLE
[flang-rt][test] Fix Exceptions.cpp compilation on FreeBSD

### DIFF
--- a/flang-rt/unittests/Runtime/Exceptions.cpp
+++ b/flang-rt/unittests/Runtime/Exceptions.cpp
@@ -34,11 +34,11 @@ class FenvScope {
 public:
   FenvScope() {
     FLANG_FP_TRAP_ON
-    std::fegetenv(&saved_);
+    fegetenv(&saved_);
   }
   ~FenvScope() {
     FLANG_FP_TRAP_ON
-    std::fesetenv(&saved_);
+    fesetenv(&saved_);
   }
 
 private:

--- a/flang-rt/unittests/Runtime/Exceptions.cpp
+++ b/flang-rt/unittests/Runtime/Exceptions.cpp
@@ -30,6 +30,8 @@ namespace {
 
 // Saves and restores the host floating-point environment so tests do not
 // leak exception flags into each other or into the rest of the suite.
+// Omit std qualifier on fegetenv, fesetenv: FreeBSD 15.1 defines them as
+// macros.
 class FenvScope {
 public:
   FenvScope() {


### PR DESCRIPTION
The `Runtime/Exceptions.cpp` test doesn't compile on FreeBSD:

```
unittests/Runtime/Exceptions.cpp:41:10: error: no type named '__fesetenv_int' in namespace 'std'
   41 |     std::fesetenv(&saved_);
      |     ~~~~~^
/usr/include/fenv.h:158:22: note: expanded from macro 'fesetenv'
  158 | #define fesetenv(a)             __fesetenv_int(a)
unittests/Runtime/Exceptions.cpp:41:20: error: declaration of reference variable 'saved_' requires an initializer
   41 |     std::fesetenv(&saved_);
      |                    ^~~~~~
```

`<fenv.h>` defines

```
#define fesetenv(a)             __fesetenv_int(a)
```

Fixed by removing the namespace qualifier, matching other cases.

Tested on `x86_64-pc-freebsd15.1` and `x86_64-pc-linux-gnu`.