### PR TITLE
[MC] Diagnose applying a specifier to an already-specified expression

### DIFF
--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -1360,7 +1360,9 @@ const MCExpr *MCAsmParser::applySpecifier(const MCExpr *E, uint32_t Spec) {
   // if there is exactly one symbol.
   switch (E->getKind()) {
   case MCExpr::Specifier:
-    llvm_unreachable("cannot apply another specifier to MCSpecifierExpr");
+    TokError("invalid variant on expression '" + getTok().getIdentifier() +
+             "' (already modified)");
+    return E;
   case MCExpr::Target:
   case MCExpr::Constant:
     return nullptr;

--- a/llvm/test/MC/AArch64/nested-specifier-error.s
+++ b/llvm/test/MC/AArch64/nested-specifier-error.s
@@ -1,0 +1,7 @@
+// REQUIRES: asserts
+// RUN: not --crash llvm-mc -triple arm64e-apple-macosx -filetype obj %s -o /dev/null 2>&1 | FileCheck %s
+
+// CHECK: cannot apply another specifier to MCSpecifierExpr
+  ldr q4, [x8, :lo12:sym@PAGEOFF]
+  add x8, x8, :lo12:sym@PAGEOFF
+  add x8, x8, :lo12:sym@PAGEOFF + 4

--- a/llvm/test/MC/AArch64/nested-specifier-error.s
+++ b/llvm/test/MC/AArch64/nested-specifier-error.s
@@ -1,7 +1,10 @@
-// REQUIRES: asserts
-// RUN: not --crash llvm-mc -triple arm64e-apple-macosx -filetype obj %s -o /dev/null 2>&1 | FileCheck %s
+// RUN: not llvm-mc -triple arm64e-apple-macosx -filetype obj %s -o /dev/null 2>&1 | FileCheck %s
 
-// CHECK: cannot apply another specifier to MCSpecifierExpr
+// CHECK: [[@LINE+1]]:26: error: invalid variant on expression 'PAGEOFF' (already modified)
   ldr q4, [x8, :lo12:sym@PAGEOFF]
+
+// CHECK: [[@LINE+1]]:25: error: invalid variant on expression 'PAGEOFF' (already modified)
   add x8, x8, :lo12:sym@PAGEOFF
+
+// CHECK: [[@LINE+1]]:25: error: invalid variant on expression 'PAGEOFF' (already modified)
   add x8, x8, :lo12:sym@PAGEOFF + 4


### PR DESCRIPTION
MCAsmParser::applySpecifier() hit llvm_unreachable() when asked to apply a relocation specifier to an expression that already carries one, which caused a crash.

Assisted-by: Opus 5.0