### PR TITLE
[VPlan] Compute SCEV for SDiv with non-negative operands.

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
@@ -674,6 +674,12 @@ m_URem(const Op0_t &Op0, const Op1_t &Op1) {
 }
 
 template <typename Op0_t, typename Op1_t>
+inline AllRecipe_match<Instruction::SDiv, Op0_t, Op1_t>
+m_SDiv(const Op0_t &Op0, const Op1_t &Op1) {
+  return m_Binary<Instruction::SDiv, Op0_t, Op1_t>(Op0, Op1);
+}
+
+template <typename Op0_t, typename Op1_t>
 inline AllRecipe_match<Instruction::SRem, Op0_t, Op1_t>
 m_SRem(const Op0_t &Op0, const Op1_t &Op1) {
   return m_Binary<Instruction::SRem, Op0_t, Op1_t>(Op0, Op1);

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -209,6 +209,14 @@ const SCEV *vputils::getSCEVExprForVPValue(const VPValue *V,
     return CreateSCEV({LHSVal, RHSVal}, [&](ArrayRef<SCEVUse> Ops) {
       return SE.getURemExpr(Ops[0], Ops[1]);
     });
+  // A SDiv with non-negative operands is equivalent to an UDiv.
+  if (match(V, m_SDiv(m_VPValue(LHSVal), m_VPValue(RHSVal)))) {
+    return CreateSCEV({LHSVal, RHSVal}, [&](ArrayRef<SCEVUse> Ops) {
+      if (!SE.isKnownNonNegative(Ops[0]) || !SE.isKnownNonNegative(Ops[1]))
+        return SE.getCouldNotCompute();
+      return SE.getUDivExpr(Ops[0], Ops[1]);
+    });
+  }
   // A SRem with non-negative operands is equivalent to an URem.
   if (match(V, m_SRem(m_VPValue(LHSVal), m_VPValue(RHSVal)))) {
     return CreateSCEV({LHSVal, RHSVal}, [&](ArrayRef<SCEVUse> Ops) {

--- a/llvm/test/Transforms/LoopVectorize/VPlan/AArch64/vplan-memory-op-decisions.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/AArch64/vplan-memory-op-decisions.ll
@@ -583,9 +583,11 @@ define void @sdiv_with_nonnegative_operands_address(ptr noalias %A) {
 ; CHECK-NEXT:      EMIT ir<%mul> = mul nuw nsw ir<%iv>, ir<4>
 ; CHECK-NEXT:      EMIT ir<%div> = sdiv ir<%mul>, ir<4>
 ; CHECK-NEXT:      EMIT ir<%gep> = getelementptr inbounds ir<%A>, ir<%div>
-; CHECK-NEXT:      EMIT-SCALAR ir<%lv> = load ir<%gep>
+; CHECK-NEXT:      vp<[[VP4:%[0-9]+]]> = vector-pointer inbounds i32, ir<%gep>, ir<1>
+; CHECK-NEXT:      WIDEN ir<%lv> = load vp<[[VP4]]>
 ; CHECK-NEXT:      EMIT ir<%add> = add ir<%lv>, ir<1>
-; CHECK-NEXT:      EMIT store ir<%add>, ir<%gep>
+; CHECK-NEXT:      vp<[[VP5:%[0-9]+]]> = vector-pointer inbounds i32, ir<%gep>, ir<1>
+; CHECK-NEXT:      WIDEN store vp<[[VP5]]>, ir<%add>
 ; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
 ; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv>, ir<100>
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1]]>


### PR DESCRIPTION
If both operands of an SDiv are known non-negative, it is equivalent to an UDiv, mirroring ScalarEvolution's handling in createSCEV.

Adds m_SDiv to VPlanPatternMatch.

Alive2 Proof: https://alive2.llvm.org/ce/z/NYa6Vd