### PR TITLE
[AsmParser] Fixed `assembler local symbol not defined` unable to locate the exact line number.

### DIFF
--- a/llvm/include/llvm/MC/MCContext.h
+++ b/llvm/include/llvm/MC/MCContext.h
@@ -162,6 +162,9 @@ private:
   /// We have three labels represented by the pairs (1, 0), (2, 0) and (1, 1)
   DenseMap<std::pair<unsigned, unsigned>, MCSymbol *> LocalSymbols;
 
+  /// Recording SymbolLocs.
+  DenseMap<const MCSymbol *, SMLoc> SymbolLocs;
+
   /// Keeps track of labels that are used in inline assembly.
   StringMap<MCSymbol *, BumpPtrAllocator &> InlineAsmUsedLabelNames;
 
@@ -480,6 +483,17 @@ public:
   ///
   /// \param Name - The symbol name, which must be unique across all symbols.
   LLVM_ABI MCSymbol *getOrCreateSymbol(const Twine &Name);
+
+  /// Set the initial source location for a symbol.
+  void setSymbolLoc(const MCSymbol *Sym, SMLoc Loc) {
+    if (Sym && Loc.isValid() && !SymbolLocs.count(Sym))
+      SymbolLocs[Sym] = Loc;
+  }
+
+  /// Get the recorded source location for a symbol.
+  SMLoc getSymbolLoc(const MCSymbol *Sym) const {
+    return SymbolLocs.lookup(Sym);
+  }
 
   /// Variant of getOrCreateSymbol that handles backslash-escaped symbols.
   /// For example, parse "a\"b\\" as a"\.

--- a/llvm/lib/MC/MCExpr.cpp
+++ b/llvm/lib/MC/MCExpr.cpp
@@ -226,6 +226,9 @@ MCSymbolRefExpr::MCSymbolRefExpr(const MCSymbol *Symbol, Spec specifier,
 const MCSymbolRefExpr *MCSymbolRefExpr::create(const MCSymbol *Sym,
                                                uint16_t specifier,
                                                MCContext &Ctx, SMLoc Loc) {
+  // If it exists, record the position of this character.
+  if (Sym && Loc.isValid())
+    Ctx.setSymbolLoc(Sym, Loc);
   return new (Ctx) MCSymbolRefExpr(Sym, specifier, Loc);
 }
 

--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -1044,12 +1044,29 @@ bool AsmParser::Run(bool NoInitialTextSection, bool NoFinalize) {
         // explicitly. If we know it's a variable, we have a definition for
         // the purposes of this check.
         if (Sym && Sym->isTemporary() && !Sym->isVariable() &&
-            !Sym->isDefined())
-          // FIXME: We would really like to refer back to where the symbol was
-          // first referenced for a source location. We need to add something
-          // to track that. Currently, we just point to the end of the file.
-          printError(getTok().getLoc(), "assembler local symbol '" +
-                                            Sym->getName() + "' not defined");
+            !Sym->isDefined()) {
+          // Check if the character position exists; if not, retrieve it.
+          SMLoc ErrorLoc = getContext().getSymbolLoc(Sym);
+          if (!ErrorLoc.isValid())
+            ErrorLoc = getTok().getLoc();
+
+          // Achieve underline annotation effect.
+          // If the start and end positions exist, retrieve the markers;
+          // otherwise, do nothing. Important: To reproduce this error, please
+          // specify the macOS platform.
+          SMRange SymbolRange;
+          if (ErrorLoc.isValid()) {
+            const char *StartPtr = ErrorLoc.getPointer();
+            SMLoc EndLoc =
+                SMLoc::getFromPointer(StartPtr + Sym->getName().size());
+            SymbolRange = SMRange(ErrorLoc, EndLoc);
+          }
+
+          printError(ErrorLoc,
+                     "assembler local symbol '" + Sym->getName() +
+                         "' not defined",
+                     SymbolRange);
+        }
       }
     }
 

--- a/llvm/test/MC/AsmParser/undefined-local-symbol-location.s
+++ b/llvm/test/MC/AsmParser/undefined-local-symbol-location.s
@@ -1,0 +1,6 @@
+// RUN: not llvm-mc -triple=x86_64-apple-macos -show-encoding < %s 2>&1 | FileCheck %s
+
+movl %eax
+// CHECK: :[[@LINE-1]]:1: error: too few operands for instruction
+jmp L_undefined_temporary_symbol
+// CHECK: :[[@LINE-1]]:5: error: assembler local symbol 'L_undefined_temporary_symbol' not defined


### PR DESCRIPTION
To be honest, when I was fixing this problem, my initial approach was limited by the `AsmParser.cpp` file. Later, I used the language server to locate the header file `llvm/include/llvm/MC/MCSymbol.h` based on the variable `isTemporary`, and found that it contained bit field variable declarations. Of course, I think the purpose of this design is to save memory.

During this period, I tried to save the parsed symbol names into the `Loc` variable within the `parsePrimaryExpr` function body or the `parseIdentifier` branch, but unfortunately, these methods all failed.

Later, when I used gdb to set breakpoints and analyze the stack trace of the function, I found that the `AsmParser.cpp` module called the `MCContext.h` and `MCExpr.cpp` modules. Since all referenced symbols must generate AST nodes in the `MCSymbolRefExpr::create()` function, I chose to intercept it directly at this entry point. The added logic is that whenever a symbol reference node is created, the `Loc` of the current expression is stored in the `Context`.