### PR TITLE
[DWARFLinker] Point DW_AT_import at the unit root, not the unit header

### DIFF
--- a/llvm/include/llvm/CodeGen/DIE.h
+++ b/llvm/include/llvm/CodeGen/DIE.h
@@ -937,18 +937,16 @@ public:
   computeOffsetsAndAbbrevs(const dwarf::FormParams &FormParams,
                            DIEAbbrevSet &AbbrevSet, unsigned CUOffset);
 
-  /// Climb up the parent chain to get the compile unit or type unit DIE that
-  /// this DIE belongs to.
+  /// Climb up the parent chain to get the unit DIE that this DIE belongs to.
   ///
-  /// \returns the compile or type unit DIE that owns this DIE, or NULL if
-  /// this DIE hasn't been added to a unit DIE.
+  /// \returns the unit DIE that owns this DIE, or NULL if this DIE hasn't been
+  /// added to a unit DIE.
   LLVM_ABI const DIE *getUnitDie() const;
 
-  /// Climb up the parent chain to get the compile unit or type unit that this
-  /// DIE belongs to.
+  /// Climb up the parent chain to get the unit that this DIE belongs to.
   ///
-  /// \returns the DIEUnit that represents the compile or type unit that owns
-  /// this DIE, or NULL if this DIE hasn't been added to a unit DIE.
+  /// \returns the DIEUnit that represents the unit that owns this DIE, or NULL
+  /// if this DIE hasn't been added to a unit DIE.
   LLVM_ABI DIEUnit *getUnit() const;
 
   void setOffset(unsigned O) { Offset = O; }

--- a/llvm/include/llvm/DWARFLinker/Classic/DWARFLinkerCompileUnit.h
+++ b/llvm/include/llvm/DWARFLinker/Classic/DWARFLinkerCompileUnit.h
@@ -131,13 +131,7 @@ public:
 
   unsigned getUniqueID() const { return ID; }
 
-  void createOutputDIE() {
-    NewUnit.emplace(OrigUnit.getUnitDIE().getTag());
-
-    // Propogate the section offset so that DIEntry can compute
-    // correct absolute offsets for DW_FORM_ref_addr references
-    NewUnit->setDebugSectionOffset(StartOffset);
-  }
+  void createOutputDIE() { NewUnit.emplace(OrigUnit.getUnitDIE().getTag()); }
 
   DIE *getOutputUnitDIE() const {
     if (NewUnit)
@@ -295,8 +289,8 @@ private:
   std::optional<BasicDIEUnit> NewUnit;
   MCSymbol *LabelBegin = nullptr;
 
-  uint64_t StartOffset;
-  uint64_t NextUnitOffset;
+  uint64_t StartOffset = 0;
+  uint64_t NextUnitOffset = 0;
 
   std::optional<uint64_t> LowPc;
   uint64_t HighPc = 0;

--- a/llvm/lib/CodeGen/AsmPrinter/DIE.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DIE.cpp
@@ -188,23 +188,16 @@ uint64_t DIE::getDebugSectionOffset() const {
   return Unit->getDebugSectionOffset() + getOffset();
 }
 
-const DIE *DIE::getUnitDie() const {
-  const DIE *p = this;
-  while (p) {
-    if (p->getTag() == dwarf::DW_TAG_compile_unit ||
-        p->getTag() == dwarf::DW_TAG_skeleton_unit ||
-        p->getTag() == dwarf::DW_TAG_type_unit)
-      return p;
-    p = p->getParent();
-  }
+DIEUnit *DIE::getUnit() const {
+  for (const DIE *P = this; P; P = P->getParent())
+    if (auto *Unit = dyn_cast_if_present<DIEUnit *>(P->Owner))
+      return Unit;
   return nullptr;
 }
 
-DIEUnit *DIE::getUnit() const {
-  const DIE *UnitDie = getUnitDie();
-  if (UnitDie)
-    return dyn_cast_if_present<DIEUnit *>(UnitDie->Owner);
-  return nullptr;
+const DIE *DIE::getUnitDie() const {
+  const DIEUnit *Unit = getUnit();
+  return Unit ? &Unit->getUnitDie() : nullptr;
 }
 
 DIEValue DIE::findAttribute(dwarf::Attribute Attribute) const {
@@ -305,11 +298,7 @@ unsigned DIE::computeOffsetsAndAbbrevs(const dwarf::FormParams &FormParams,
 //===----------------------------------------------------------------------===//
 DIEUnit::DIEUnit(dwarf::Tag UnitTag) : Die(UnitTag) {
   Die.Owner = this;
-  assert((UnitTag == dwarf::DW_TAG_compile_unit ||
-          UnitTag == dwarf::DW_TAG_skeleton_unit ||
-          UnitTag == dwarf::DW_TAG_type_unit ||
-          UnitTag == dwarf::DW_TAG_partial_unit) &&
-         "expected a unit TAG");
+  assert(dwarf::isUnitType(UnitTag) && "expected a unit TAG");
 }
 
 void DIEValue::emitValue(const AsmPrinter *AP) const {

--- a/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
@@ -2013,9 +2013,15 @@ DIE *DWARFLinker::DIECloner::cloneDIE(const DWARFDie &InputDIE,
     }
   }
 
-  if (Unit.getOrigUnit().getVersion() >= 5 && !AttrInfo.AttrStrOffsetBaseSeen &&
-      Die->getTag() == dwarf::DW_TAG_compile_unit) {
-    // No DW_AT_str_offsets_base seen, add it to the DIE.
+  // Comparing against the output unit DIE identifies the root of the unit,
+  // whatever its tag. cloneStringAttribute() rewrites strings into
+  // DW_FORM_strx for every DWARFv5 unit without consulting the root tag, and
+  // DWARFv5 section 7.26 resolves those indices only through
+  // DW_AT_str_offsets_base, so a DW_TAG_partial_unit or DW_TAG_skeleton_unit
+  // root needs the attribute on the same terms as a full compilation unit
+  // (DWARFv5 sections 3.1.1 and 3.1.2).
+  if (Die == Unit.getOutputUnitDIE() && Unit.getOrigUnit().getVersion() >= 5 &&
+      !AttrInfo.AttrStrOffsetBaseSeen) {
     Die->addValue(DIEAlloc, dwarf::DW_AT_str_offsets_base,
                   dwarf::DW_FORM_sec_offset, DIEInteger(8));
     OutOffset += 4;

--- a/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
@@ -1204,13 +1204,26 @@ unsigned DWARFLinker::DIECloner::cloneDieReferenceAttribute(
     return U.getRefAddrByteSize();
   }
 
-  if (!RefInfo.Clone) {
-    // We haven't cloned this DIE yet. Just create an empty one and
-    // store it. It'll get really cloned when we process it.
-    RefInfo.UnclonedReference = true;
-    RefInfo.Clone = DIE::get(DIEAlloc, dwarf::Tag(RefDie.getTag()));
+  if (RefUnit->getOrigUnit().getDIEIndex(RefDie) == 0) {
+    // A unit root is cloned into its unit's own output DIE rather than into a
+    // DIEInfo::Clone, so resolve the reference through that DIE. The
+    // placeholder below would instead manufacture a DIE that is never adopted
+    // into a unit tree and so never gets an offset assigned.
+    NewRefDie = RefUnit->getOutputUnitDIE();
+
+    // The referenced unit is not in the output, so there is nothing left for
+    // this attribute to name.
+    if (!NewRefDie)
+      return 0;
+  } else {
+    if (!RefInfo.Clone) {
+      // We haven't cloned this DIE yet. Just create an empty one and
+      // store it. It'll get really cloned when we process it.
+      RefInfo.UnclonedReference = true;
+      RefInfo.Clone = DIE::get(DIEAlloc, dwarf::Tag(RefDie.getTag()));
+    }
+    NewRefDie = RefInfo.Clone;
   }
-  NewRefDie = RefInfo.Clone;
 
   if (AttrSpec.Form == dwarf::DW_FORM_ref_addr ||
       (Unit.hasODR() && isODRAttribute(AttrSpec.Attr))) {
@@ -2906,6 +2919,13 @@ Expected<uint64_t> DWARFLinker::DIECloner::cloneAllCompileUnits(
       (Emitter == nullptr) ? 0 : Emitter->getDebugInfoSectionSize();
   const uint64_t StartOutputDebugInfoSize = OutputDebugInfoSize;
 
+  // A reference to a unit root resolves through that unit's output DIE, and
+  // the referring unit may be cloned first, so every unit that will be emitted
+  // needs its output DIE before any cloning starts.
+  for (auto &CurrentUnit : CompileUnits)
+    if (CurrentUnit->getOrigUnit().getUnitDIE() && CurrentUnit->getInfo(0).Keep)
+      CurrentUnit->createOutputDIE();
+
   for (auto &CurrentUnit : CompileUnits) {
     const uint16_t DwarfVersion = CurrentUnit->getOrigUnit().getVersion();
     const uint32_t UnitHeaderSize = DwarfVersion >= 5 ? 12 : 11;
@@ -2915,13 +2935,15 @@ Expected<uint64_t> DWARFLinker::DIECloner::cloneAllCompileUnits(
       OutputDebugInfoSize = CurrentUnit->computeNextUnitOffset(DwarfVersion);
       continue;
     }
-    if (CurrentUnit->getInfo(0).Keep) {
+    // The pre-pass gave an output DIE to exactly the units this loop clones,
+    // so having one is the same condition, spelled the way the emission loop
+    // below already spells it.
+    if (DIE *OutputDIE = CurrentUnit->getOutputUnitDIE()) {
       // Clone the InputDIE into your Unit DIE in our compile unit since it
       // already has a DIE inside of it.
-      CurrentUnit->createOutputDIE();
       rememberUnitForMacroOffset(*CurrentUnit);
       cloneDIE(InputDIE, File, *CurrentUnit, 0 /* PC offset */, UnitHeaderSize,
-               0, IsLittleEndian, CurrentUnit->getOutputUnitDIE());
+               0, IsLittleEndian, OutputDIE);
     }
 
     OutputDebugInfoSize = CurrentUnit->computeNextUnitOffset(DwarfVersion);

--- a/llvm/lib/DWARFLinker/Classic/DWARFStreamer.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFStreamer.cpp
@@ -188,7 +188,18 @@ void DwarfStreamer::emitCompileUnitHeader(CompileUnit &Unit,
   Asm->emitInt16(DwarfVersion);
 
   if (DwarfVersion >= 5) {
-    Asm->emitInt8(dwarf::DW_UT_compile);
+    // The header has to agree with the root DIE that was actually cloned, or
+    // llvm-dwarfdump --verify rejects the unit with "Mismatched unit type".
+    // Reading the tag off the output root covers DW_TAG_partial_unit without
+    // plumbing the input unit type through the DwarfEmitter interface. DWARFv5
+    // section 7.5.1.1 gives full and partial units the same five-field header,
+    // so the size below is unchanged. Skeleton roots are deliberately not
+    // mapped to DW_UT_skeleton: section 7.5.1.2 adds an 8-byte dwo_id to that
+    // header, which the 12-byte constant here and in computeNextUnitOffset()
+    // does not account for.
+    dwarf::Tag RootTag = Unit.getOutputUnitDIE()->getTag();
+    Asm->emitInt8(RootTag == dwarf::DW_TAG_partial_unit ? dwarf::DW_UT_partial
+                                                        : dwarf::DW_UT_compile);
     Asm->emitInt8(Unit.getOrigUnit().getAddressByteSize());
     // We share one abbreviations table across all units so it's always at the
     // start of the section.

--- a/llvm/lib/DWARFLinker/Parallel/DIEAttributeCloner.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DIEAttributeCloner.cpp
@@ -114,11 +114,18 @@ void DIEAttributeCloner::clone() {
     }
   }
 
-  // We convert source strings into the indexed form for DWARFv5.
-  // Check if original compile unit already has DW_AT_str_offsets_base
-  // attribute.
-  if (InputDieEntry->getTag() == dwarf::DW_TAG_compile_unit &&
-      InUnit.getVersion() >= 5 && !AttrInfo.HasStringOffsetBaseAttr) {
+  // Index 0 is the root DIE of the unit, whatever its tag. cloneStringAttr()
+  // rewrites strings into DW_FORM_strx for every DWARFv5 unit without
+  // consulting the root tag, and DWARFv5 section 7.26 resolves those indices
+  // only through DW_AT_str_offsets_base, so a DW_TAG_partial_unit or
+  // DW_TAG_skeleton_unit root needs the attribute on the same terms as a full
+  // compilation unit (DWARFv5 sections 3.1.1 and 3.1.2).
+  //
+  // The isCompileUnit() test is not redundant: index 0 can also reach the
+  // artificial type unit, where AttrOutOffset is DIE-relative rather than
+  // section-relative, so the patch registered below would be misplaced.
+  if (InputDIEIdx == 0 && InUnit.getVersion() >= 5 &&
+      !AttrInfo.HasStringOffsetBaseAttr && OutUnit.isCompileUnit()) {
     DebugInfoOutputSection.notePatchWithOffsetUpdate(
         DebugOffsetPatch{AttrOutOffset,
                          &OutUnit->getOrCreateSectionDescriptor(

--- a/llvm/lib/DWARFLinker/Parallel/DWARFEmitterImpl.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFEmitterImpl.cpp
@@ -141,7 +141,18 @@ void DwarfEmitterImpl::emitCompileUnitHeader(DwarfUnit &Unit) {
   Asm->emitInt16(Unit.getVersion());
 
   if (Unit.getVersion() >= 5) {
-    Asm->emitInt8(dwarf::DW_UT_compile);
+    // The header has to agree with the root DIE that was actually cloned, or
+    // llvm-dwarfdump --verify rejects the unit with "Mismatched unit type".
+    // getTag() is the tag of that root, cached by setOutUnitDIE(); a TypeUnit's
+    // artificial root is a DW_TAG_compile_unit, so type units keep emitting
+    // DW_UT_compile. DWARFv5 section 7.5.1.1 gives full and partial units the
+    // same five-field header, so the size below is unchanged. Skeleton roots
+    // are deliberately not mapped to DW_UT_skeleton: section 7.5.1.2 adds an
+    // 8-byte dwo_id to that header, which the 12-byte constant here and in
+    // getDebugInfoHeaderSize() does not account for.
+    dwarf::Tag RootTag = Unit.getTag();
+    Asm->emitInt8(RootTag == dwarf::DW_TAG_partial_unit ? dwarf::DW_UT_partial
+                                                        : dwarf::DW_UT_compile);
     Asm->emitInt8(Unit.getFormParams().AddrSize);
     // Proper offset to the abbreviations table will be set later.
     Asm->emitInt32(0);

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-ref-addr.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-ref-addr.test
@@ -1,0 +1,303 @@
+## This test checks that a cross-unit DW_FORM_ref_addr reference into a
+## DW_TAG_partial_unit is rewritten to the section-absolute offset of the
+## referenced DIE, as it already is for a DW_TAG_compile_unit.
+##
+## The two documents differ only in the root tag and unit type of the unit
+## holding the referenced type, so the compile unit document is the control.
+##
+## Only the classic linker is exercised. The parallel linker asserts on a type
+## under a partial unit root, which is issue #219613, and --verify rejects the
+## output because a partial unit still ships under a DW_UT_compile header,
+## which is issue #219365.
+
+# RUN: yaml2obj --docnum=1 %s -o %t-cu.o
+# RUN: yaml2obj --docnum=2 %s -o %t-pu.o
+
+# RUN: llvm-dwarfutil %t-cu.o %t-cu.out
+# RUN: llvm-dwarfdump --debug-info %t-cu.out | FileCheck %s
+
+# RUN: llvm-dwarfutil %t-pu.o %t-pu.out
+# RUN: llvm-dwarfdump --debug-info %t-pu.out | FileCheck %s
+
+## Update mode keeps every DIE, so the same reference has to be resolved there.
+
+# RUN: llvm-dwarfutil --no-garbage-collection --build-accelerator=DWARF \
+# RUN:   %t-cu.o %t-cu.upd
+# RUN: llvm-dwarfdump --debug-info %t-cu.upd | FileCheck %s
+
+# RUN: llvm-dwarfutil --no-garbage-collection --build-accelerator=DWARF \
+# RUN:   %t-pu.o %t-pu.upd
+# RUN: llvm-dwarfdump --debug-info %t-pu.upd | FileCheck %s
+
+## U01 owns the type, U02 names it across the unit boundary.
+# CHECK: DW_AT_name{{.*}}"U01"
+
+# CHECK: 0x[[S:[0-9a-f]*]]: DW_TAG_structure_type
+# CHECK-NEXT: DW_AT_name{{.*}}"S"
+
+# CHECK: DW_AT_name{{.*}}"U02"
+
+# CHECK: DW_TAG_subprogram
+# CHECK-NEXT: DW_AT_name{{.*}}"foo2"
+# CHECK-NEXT: DW_AT_type{{.*}}(0x00000000[[S]] "{{.*}}S")
+
+## The control: U01 is an ordinary compilation unit.
+--- !ELF
+FileHeader:
+  Class:    ELFCLASS64
+  Data:     ELFDATA2LSB
+  Type:     ET_REL
+  Machine:  EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1130
+    Size:            0x20
+  - Name:            .debug_str_offsets
+    Type:            SHT_PROGBITS
+    Flags:           [  ]
+    Content:        "0400000005000000"
+DWARF:
+  debug_abbrev:
+    - ID:    0
+      Table:
+      - Tag:      DW_TAG_partial_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_str_offsets_base
+            Form:      DW_FORM_sec_offset
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+      - Tag:      DW_TAG_namespace
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_str_offsets_base
+            Form:      DW_FORM_sec_offset
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref_addr
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      AbbrevTableID: 0
+      Entries:
+        - AbbrCode: 5
+          Values:
+            - CStr: by_hand
+            - CStr: U01
+            - Value: 0x04
+            - Value: 0x1130
+            - Value: 0x10
+            - Value: 0x8
+        - AbbrCode: 2
+          Values:
+            - CStr: foo1
+            - Value: 0x1130
+            - Value: 0x10
+        - AbbrCode: 3
+          Values:
+            - CStr: ns
+        - AbbrCode: 4
+          Values:
+            - CStr: S
+            - Value: 0x8
+        - AbbrCode: 0
+        - AbbrCode: 0
+    - Version:  5
+      UnitType: DW_UT_compile
+      AbbrevTableID: 0
+      Entries:
+        - AbbrCode: 5
+          Values:
+            - CStr: by_hand
+            - CStr: U02
+            - Value: 0x04
+            - Value: 0x1140
+            - Value: 0x10
+            - Value: 0x8
+        - AbbrCode: 6
+          Values:
+            - CStr: foo2
+            - Value: 0x49
+            - Value: 0x1140
+            - Value: 0x10
+        - AbbrCode: 0
+
+## The case: U01 is a partial unit, and nothing else changes.
+--- !ELF
+FileHeader:
+  Class:    ELFCLASS64
+  Data:     ELFDATA2LSB
+  Type:     ET_REL
+  Machine:  EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1130
+    Size:            0x20
+  - Name:            .debug_str_offsets
+    Type:            SHT_PROGBITS
+    Flags:           [  ]
+    Content:        "0400000005000000"
+DWARF:
+  debug_abbrev:
+    - ID:    0
+      Table:
+      - Tag:      DW_TAG_partial_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_str_offsets_base
+            Form:      DW_FORM_sec_offset
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+      - Tag:      DW_TAG_namespace
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_str_offsets_base
+            Form:      DW_FORM_sec_offset
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref_addr
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_partial
+      AbbrevTableID: 0
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: by_hand
+            - CStr: U01
+            - Value: 0x04
+            - Value: 0x1130
+            - Value: 0x10
+            - Value: 0x8
+        - AbbrCode: 2
+          Values:
+            - CStr: foo1
+            - Value: 0x1130
+            - Value: 0x10
+        - AbbrCode: 3
+          Values:
+            - CStr: ns
+        - AbbrCode: 4
+          Values:
+            - CStr: S
+            - Value: 0x8
+        - AbbrCode: 0
+        - AbbrCode: 0
+    - Version:  5
+      UnitType: DW_UT_compile
+      AbbrevTableID: 0
+      Entries:
+        - AbbrCode: 5
+          Values:
+            - CStr: by_hand
+            - CStr: U02
+            - Value: 0x04
+            - Value: 0x1140
+            - Value: 0x10
+            - Value: 0x8
+        - AbbrCode: 6
+          Values:
+            - CStr: foo2
+            - Value: 0x49
+            - Value: 0x1140
+            - Value: 0x10
+        - AbbrCode: 0
+...

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit.test
@@ -1,0 +1,143 @@
+## A DWARFv5 unit whose root is DW_TAG_partial_unit, which is the shape dwz
+## leaves behind. DWARFContext::compile_units() filters out only type units, so
+## such a unit reaches the linker exactly as a full compilation unit does, and
+## both backends used to key two decisions on the DW_TAG_compile_unit tag
+## rather than on the DIE being the unit root:
+##
+##   1. DW_AT_str_offsets_base was not synthesized, while the strings were
+##      still rewritten into DW_FORM_strx, so every indexed string in the
+##      output read back empty.
+##   2. The unit header was emitted with unit_type DW_UT_compile whatever the
+##      root tag was, contradicting the root DIE.
+##
+## Both backends exited 0 and produced output that llvm-dwarfdump --verify
+## rejected on both counts.
+
+# RUN: yaml2obj %s -o %t.o
+
+# RUN: llvm-dwarfutil %t.o %t1
+# RUN: llvm-dwarfdump -a --verbose %t1 | FileCheck %s
+# RUN: llvm-dwarfdump --verify %t1 | FileCheck %s --check-prefix=VERIFY
+
+# RUN: llvm-dwarfutil --linker parallel %t.o %t2
+# RUN: llvm-dwarfdump -a --verbose %t2 | FileCheck %s
+# RUN: llvm-dwarfdump --verify %t2 | FileCheck %s --check-prefix=VERIFY
+
+## Update mode preserves the input index tables rather than regenerating them,
+## but the strings are still converted and the header comes from the same
+## emitter, so both defects reach it as well. It is paired with
+## --build-accelerator here because --no-garbage-collection on its own copies
+## the file without running the linker at all. The empty string table also
+## corrupted the accelerator entries, since .debug_names records the names it
+## reads back out of .debug_info.
+# RUN: llvm-dwarfutil --no-garbage-collection --build-accelerator=DWARF %t.o %t3
+# RUN: llvm-dwarfdump -a --verbose %t3 | FileCheck %s
+# RUN: llvm-dwarfdump --verify %t3 | FileCheck %s --check-prefix=VERIFY
+
+# RUN: llvm-dwarfutil --linker parallel --no-garbage-collection --build-accelerator=DWARF %t.o %t4
+# RUN: llvm-dwarfdump -a --verbose %t4 | FileCheck %s
+# RUN: llvm-dwarfdump --verify %t4 | FileCheck %s --check-prefix=VERIFY
+
+#CHECK: .debug_info contents:
+#CHECK: Compile Unit: {{.*}} version = 0x0005, unit_type = DW_UT_partial
+
+#CHECK: DW_TAG_partial_unit
+#CHECK: DW_AT_producer [DW_FORM_strx] {{.*}} "by_hand"
+#CHECK: DW_AT_name [DW_FORM_strx] {{.*}} "PU1"
+#CHECK: DW_AT_str_offsets_base [DW_FORM_sec_offset] (0x00000008)
+
+#CHECK: DW_TAG_subprogram
+#CHECK: DW_AT_name [DW_FORM_strx] {{.*}} "foo1"
+#CHECK: DW_TAG_subprogram
+#CHECK: DW_AT_name [DW_FORM_strx] {{.*}} "foo2"
+
+#VERIFY: No errors.
+
+## A DWARFv5 partial unit carrying two function ranges. The .debug_addr
+## contribution and DW_AT_addr_base are required, not incidental: without them
+## the rewritten ranges resolve from 0 and the unit fails verification for an
+## unrelated reason. DW_AT_ranges and .debug_rnglists are likewise required,
+## since otherwise garbage collection drops the whole unit and the collecting
+## RUN lines stop testing anything.
+--- !ELF
+FileHeader:
+  Class:    ELFCLASS64
+  Data:     ELFDATA2LSB
+  Type:     ET_REL
+  Machine:  EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1130
+    Size:            0x30
+  - Name:            .debug_rnglists
+    Type:            SHT_PROGBITS
+    Flags:           [  ]
+    Content:        "1d0000000500080000000000073011000000000000100750110000000000001000"
+  - Name:            .debug_addr
+    Type:            SHT_PROGBITS
+    Flags:           [  ]
+    Content:        "0c000000050008003011000000000000"
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_partial_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_ranges
+            Form:      DW_FORM_sec_offset
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_addr_base
+            Form:      DW_FORM_sec_offset
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+  debug_info:
+    - Version: 5
+      UnitType:   DW_UT_partial
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: by_hand
+            - CStr: PU1
+            - Value:  0xc
+            - Value:  0x0
+            - Value:  0x8
+        - AbbrCode: 2
+          Values:
+            - CStr: foo1
+            - Value: 0x1130
+            - Value: 0x10
+## 0x5d is the .debug_info offset of the DW_TAG_base_type DIE below; it shifts
+## if the root DIE's attributes change.
+            - Value: 0x5d
+        - AbbrCode: 2
+          Values:
+            - CStr: foo2
+            - Value: 0x1150
+            - Value: 0x10
+            - Value: 0x5d
+        - AbbrCode: 3
+          Values:
+            - CStr: int
+        - AbbrCode: 0
+...

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/imported-unit.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/imported-unit.test
@@ -1,0 +1,457 @@
+## DW_AT_import must hold the .debug_info offset of the referenced unit's root
+## DIE. The classic linker rewrote it to that unit's header offset instead,
+## short of the root by the size of the header, leaving every
+## DW_TAG_imported_unit in the output pointing between DIEs.
+##
+## Both reference directions are covered in every document. U01 imports U02,
+## which is cloned after it, and U03 imports U02, which is cloned before it. A
+## single capture pins both against U02's root, so neither direction can be
+## satisfied alone.
+##
+## The defect does not depend on the imported unit's root tag, so the three
+## documents hold one set of expectations. They differ in U02's root tag, in
+## the DWARF version, and in whether U02's root carries DW_AT_low_pc, which a
+## DW_TAG_partial_unit root cannot. U02 carries code in all three. The DWARFv4
+## document also has no .debug_str_offsets and no DW_AT_str_offsets_base,
+## which DWARFv4 has no use for.
+
+## DWARFv5 with DW_TAG_compile_unit roots, through both linkers, under garbage
+## collection and in update mode.
+# RUN: yaml2obj --docnum=1 %s -o %t1.o
+
+# RUN: llvm-dwarfutil %t1.o %t1.classic
+# RUN: llvm-dwarfdump --debug-info %t1.classic | FileCheck %s -DU02TAG=compile_unit
+# RUN: llvm-dwarfdump --verify %t1.classic
+
+# RUN: llvm-dwarfutil --no-garbage-collection --build-accelerator=DWARF %t1.o %t1.classic.upd
+# RUN: llvm-dwarfdump --debug-info %t1.classic.upd | FileCheck %s -DU02TAG=compile_unit
+# RUN: llvm-dwarfdump --verify %t1.classic.upd
+
+# RUN: llvm-dwarfutil --linker parallel %t1.o %t1.parallel
+# RUN: llvm-dwarfdump --debug-info %t1.parallel | FileCheck %s -DU02TAG=compile_unit
+# RUN: llvm-dwarfdump --verify %t1.parallel
+
+# RUN: llvm-dwarfutil --linker parallel --no-garbage-collection --build-accelerator=DWARF %t1.o %t1.parallel.upd
+# RUN: llvm-dwarfdump --debug-info %t1.parallel.upd | FileCheck %s -DU02TAG=compile_unit
+# RUN: llvm-dwarfdump --verify %t1.parallel.upd
+
+## DWARFv4, whose unit header is eleven bytes where DWARFv5's is twelve, so an
+## offset derived from a hardcoded header size does not survive this document.
+# RUN: yaml2obj --docnum=2 %s -o %t2.o
+
+# RUN: llvm-dwarfutil %t2.o %t2.classic
+# RUN: llvm-dwarfdump --debug-info %t2.classic | FileCheck %s -DU02TAG=compile_unit
+# RUN: llvm-dwarfdump --verify %t2.classic
+
+# RUN: llvm-dwarfutil --linker parallel %t2.o %t2.parallel
+# RUN: llvm-dwarfdump --debug-info %t2.parallel | FileCheck %s -DU02TAG=compile_unit
+# RUN: llvm-dwarfdump --verify %t2.parallel
+
+## The dwz shape: the imported unit is a DW_TAG_partial_unit, which is what dwz
+## produces. Its root carries no code, so it has no DW_AT_low_pc.
+# RUN: yaml2obj --docnum=3 %s -o %t3.o
+
+# RUN: llvm-dwarfutil %t3.o %t3.classic
+# RUN: llvm-dwarfdump --debug-info %t3.classic | FileCheck %s -DU02TAG=partial_unit
+# RUN: llvm-dwarfdump --verify %t3.classic
+
+# RUN: llvm-dwarfutil --linker parallel %t3.o %t3.parallel
+# RUN: llvm-dwarfdump --debug-info %t3.parallel | FileCheck %s -DU02TAG=partial_unit
+# RUN: llvm-dwarfdump --verify %t3.parallel
+
+## Update mode runs without --verify: it builds .debug_names, and the verifier
+## demands an index entry for a named DW_TAG_partial_unit root where it excuses
+## a DW_TAG_compile_unit one.
+# RUN: llvm-dwarfutil --no-garbage-collection --build-accelerator=DWARF %t3.o %t3.classic.upd
+# RUN: llvm-dwarfdump --debug-info %t3.classic.upd | FileCheck %s -DU02TAG=partial_unit
+
+# RUN: llvm-dwarfutil --linker parallel --no-garbage-collection --build-accelerator=DWARF %t3.o %t3.parallel.upd
+# RUN: llvm-dwarfdump --debug-info %t3.parallel.upd | FileCheck %s -DU02TAG=partial_unit
+
+# CHECK: DW_TAG_compile_unit
+# CHECK: DW_AT_name{{.*}}"U01"
+
+## Forward reference: U02 has not been cloned yet when this is emitted.
+# CHECK: DW_TAG_imported_unit
+# CHECK-NEXT: DW_AT_import{{.*}}(0x00000000[[U02ROOT:[0-9a-f]{8}]] "U02")
+
+# CHECK: 0x[[U02ROOT]]: DW_TAG_[[U02TAG]]
+# CHECK: DW_AT_name{{.*}}"U02"
+
+# CHECK: DW_TAG_compile_unit
+# CHECK: DW_AT_name{{.*}}"U03"
+
+## Backward reference: U02 already carries an output DIE at this point.
+# CHECK: DW_TAG_imported_unit
+# CHECK-NEXT: DW_AT_import{{.*}}(0x00000000[[U02ROOT]] "U02")
+
+--- !ELF
+FileHeader:
+  Class:    ELFCLASS64
+  Data:     ELFDATA2LSB
+  Type:     ET_REL
+  Machine:  EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1130
+    Size:            0x30
+  - Name:            .debug_str_offsets
+    Type:            SHT_PROGBITS
+    Flags:           [  ]
+    Content:        "0400000005000000"
+DWARF:
+  debug_abbrev:
+    - ID:    0
+      Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_str_offsets_base
+            Form:      DW_FORM_sec_offset
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+      - Tag:      DW_TAG_imported_unit
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_import
+            Form:      DW_FORM_ref_addr
+      - Tag:      DW_TAG_namespace
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      AbbrevTableID: 0
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: by_hand
+            - CStr: U01
+            - Value: 0x04
+            - Value: 0x1130
+            - Value: 0x10
+            - Value: 0x8
+        - AbbrCode: 3
+          Values:
+            - Value: 0x57
+        - AbbrCode: 2
+          Values:
+            - CStr: foo1
+            - Value: 0x1130
+            - Value: 0x10
+        - AbbrCode: 0
+    - Version:  5
+      UnitType: DW_UT_compile
+      AbbrevTableID: 0
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: by_hand
+            - CStr: U02
+            - Value: 0x04
+            - Value: 0x1140
+            - Value: 0x10
+            - Value: 0x8
+        - AbbrCode: 2
+          Values:
+            - CStr: foo2
+            - Value: 0x1140
+            - Value: 0x10
+        - AbbrCode: 4
+          Values:
+            - CStr: ns
+        - AbbrCode: 5
+          Values:
+            - CStr: S
+            - Value: 0x8
+        - AbbrCode: 0
+        - AbbrCode: 0
+    - Version:  5
+      UnitType: DW_UT_compile
+      AbbrevTableID: 0
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: by_hand
+            - CStr: U03
+            - Value: 0x04
+            - Value: 0x1150
+            - Value: 0x10
+            - Value: 0x8
+        - AbbrCode: 3
+          Values:
+            - Value: 0x57
+        - AbbrCode: 2
+          Values:
+            - CStr: foo3
+            - Value: 0x1150
+            - Value: 0x10
+        - AbbrCode: 0
+...
+--- !ELF
+FileHeader:
+  Class:    ELFCLASS64
+  Data:     ELFDATA2LSB
+  Type:     ET_REL
+  Machine:  EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1130
+    Size:            0x30
+DWARF:
+  debug_abbrev:
+    - ID:    0
+      Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+      - Tag:      DW_TAG_imported_unit
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_import
+            Form:      DW_FORM_ref_addr
+  debug_info:
+    - Version:  4
+      AbbrevTableID: 0
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: by_hand
+            - CStr: U01
+            - Value: 0x04
+            - Value: 0x1130
+            - Value: 0x10
+        - AbbrCode: 3
+          Values:
+            - Value: 0x51
+        - AbbrCode: 2
+          Values:
+            - CStr: foo1
+            - Value: 0x1130
+            - Value: 0x10
+        - AbbrCode: 0
+    - Version:  4
+      AbbrevTableID: 0
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: by_hand
+            - CStr: U02
+            - Value: 0x04
+            - Value: 0x1140
+            - Value: 0x10
+        - AbbrCode: 2
+          Values:
+            - CStr: foo2
+            - Value: 0x1140
+            - Value: 0x10
+        - AbbrCode: 0
+    - Version:  4
+      AbbrevTableID: 0
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: by_hand
+            - CStr: U03
+            - Value: 0x04
+            - Value: 0x1150
+            - Value: 0x10
+        - AbbrCode: 3
+          Values:
+            - Value: 0x51
+        - AbbrCode: 2
+          Values:
+            - CStr: foo3
+            - Value: 0x1150
+            - Value: 0x10
+        - AbbrCode: 0
+...
+--- !ELF
+FileHeader:
+  Class:    ELFCLASS64
+  Data:     ELFDATA2LSB
+  Type:     ET_REL
+  Machine:  EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1130
+    Size:            0x30
+  - Name:            .debug_str_offsets
+    Type:            SHT_PROGBITS
+    Flags:           [  ]
+    Content:        "0400000005000000"
+DWARF:
+  debug_abbrev:
+    - ID:    0
+      Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_str_offsets_base
+            Form:      DW_FORM_sec_offset
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+      - Tag:      DW_TAG_imported_unit
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_import
+            Form:      DW_FORM_ref_addr
+      - Tag:      DW_TAG_namespace
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_partial_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+          - Attribute: DW_AT_str_offsets_base
+            Form:      DW_FORM_sec_offset
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      AbbrevTableID: 0
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: by_hand
+            - CStr: U01
+            - Value: 0x04
+            - Value: 0x1130
+            - Value: 0x10
+            - Value: 0x8
+        - AbbrCode: 3
+          Values:
+            - Value: 0x57
+        - AbbrCode: 2
+          Values:
+            - CStr: foo1
+            - Value: 0x1130
+            - Value: 0x10
+        - AbbrCode: 0
+    - Version:  5
+      UnitType: DW_UT_partial
+      AbbrevTableID: 0
+      Entries:
+        - AbbrCode: 6
+          Values:
+            - CStr: by_hand
+            - CStr: U02
+            - Value: 0x04
+            - Value: 0x8
+        - AbbrCode: 2
+          Values:
+            - CStr: foo2
+            - Value: 0x1140
+            - Value: 0x10
+        - AbbrCode: 4
+          Values:
+            - CStr: ns
+        - AbbrCode: 5
+          Values:
+            - CStr: S
+            - Value: 0x8
+        - AbbrCode: 0
+        - AbbrCode: 0
+    - Version:  5
+      UnitType: DW_UT_compile
+      AbbrevTableID: 0
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: by_hand
+            - CStr: U03
+            - Value: 0x04
+            - Value: 0x1150
+            - Value: 0x10
+            - Value: 0x8
+        - AbbrCode: 3
+          Values:
+            - Value: 0x57
+        - AbbrCode: 2
+          Values:
+            - CStr: foo3
+            - Value: 0x1150
+            - Value: 0x10
+        - AbbrCode: 0
+...

--- a/llvm/unittests/CodeGen/DIETest.cpp
+++ b/llvm/unittests/CodeGen/DIETest.cpp
@@ -222,4 +222,42 @@ TEST(DIEValueListTest, DeleteValue) {
   EXPECT_FALSE(List.deleteValue(dwarf::DW_AT_high_pc));
 }
 
+TEST(DIETest, GetUnitDie) {
+  // A DIEUnit owns exactly one DIE, its unit DIE, whatever the root tag is, so
+  // the walk up from a nested DIE has to reach the unit for every unit root
+  // tag.
+  static const dwarf::Tag UnitTags[] = {
+      dwarf::DW_TAG_compile_unit, dwarf::DW_TAG_partial_unit,
+      dwarf::DW_TAG_type_unit, dwarf::DW_TAG_skeleton_unit};
+
+  BumpPtrAllocator Alloc;
+  for (dwarf::Tag UnitTag : UnitTags) {
+    BasicDIEUnit Unit(UnitTag);
+    Unit.setDebugSectionOffset(0x100);
+
+    DIE &Root = Unit.getUnitDie();
+    DIE &Namespace = Root.addChild(DIE::get(Alloc, dwarf::DW_TAG_namespace));
+    DIE &Struct =
+        Namespace.addChild(DIE::get(Alloc, dwarf::DW_TAG_structure_type));
+    Struct.setOffset(0x20);
+
+    EXPECT_EQ(&Root, Struct.getUnitDie());
+    EXPECT_EQ(static_cast<DIEUnit *>(&Unit), Struct.getUnit());
+    EXPECT_EQ(0x120u, Struct.getDebugSectionOffset());
+  }
+}
+
+TEST(DIETest, GetUnitDieWithoutUnit) {
+  // A tree carrying a unit root tag that was never handed to a DIEUnit belongs
+  // to no unit, so there is no absolute offset to compute for anything in it.
+  BumpPtrAllocator Alloc;
+  DIE *Root = DIE::get(Alloc, dwarf::DW_TAG_compile_unit);
+  DIE &Struct = Root->addChild(DIE::get(Alloc, dwarf::DW_TAG_structure_type));
+
+  EXPECT_EQ(nullptr, Root->getUnitDie());
+  EXPECT_EQ(nullptr, Root->getUnit());
+  EXPECT_EQ(nullptr, Struct.getUnitDie());
+  EXPECT_EQ(nullptr, Struct.getUnit());
+}
+
 } // end namespace


### PR DESCRIPTION
**Summary**

- **Broken:** `DW_AT_import` must reference the root debugging information entry of the imported unit (DWARFv5 spec §3.2.5, whose wording is clarified to read "unit entry" by dwarfstd issue 181019.1, accepted for DWARF v6), but the classic linker rewrote it to the offset of that unit's header, so every `DW_TAG_imported_unit` in the output pointed at the bytes before a DIE — `0x0` when the imported unit came first, otherwise short of the root by the header size; `--verify` reports "invalid DIE reference ... Offset is in between DIEs", a released build emits it and exits 0, and an assertions build aborts in `fixupForwardReferences()`.
- **Fix:** resolve a reference whose target is the unit root through that unit's output DIE, and create every such output DIE before any unit is cloned.
- **Implementation:** the root is identified positionally as index 0, the attribute is dropped when the referenced unit is not in the output, `createOutputDIE()` moved into a pre-pass guarded by the same condition the emission loop uses, and its now-indeterminate section offset propagation came out in favour of `setStartOffset()`, which already re-propagates unconditionally.

Depends on #219660.
Depends on #219398.

---

`DW_AT_import` names the root debugging information entry of the imported unit. The classic linker rewrote it to the offset of that unit's *header* instead, so every `DW_TAG_imported_unit` in the output pointed at the bytes before a DIE rather than at one. When the imported unit came first the value was `0x0`; otherwise it was short of the root by the size of the header.

`llvm-dwarfdump --verify` calls the result `invalid DIE reference ... Offset is in between DIEs`. A released build emits it and exits 0, so the corruption is silent; an assertions build aborts in `fixupForwardReferences()` instead, at `DIE.h:882`.

**Specification.** DWARFv5 §3.2.5 gives the attribute's value as "a reference to the normal or partial compilation unit whose declarations logically belong at the place of the imported unit entry", where §3.2.3 and §3.2.4 both say "the debugging information entry to be imported". Reading §3.2.5 on its own, "the unit" can be taken for the unit header rather than the unit entry, which is the offset the linker was writing. That inconsistency is dwarfstd issue [181019.1](https://dwarfstd.org/issues/181019.1.html), closed as accepted for DWARF v6 on 2021-09-20: the resolution inserts "entry" after "unit" on page 74 line 21, so the attribute references the root DIE under either version's wording.

**Cause.** A unit root never gets a `DIEInfo::Clone`. `createOutputDIE()` makes the output root a DIE owned by the unit's own `BasicDIEUnit`, and `cloneDIE()` is handed that DIE directly rather than allocating one. `cloneDieReferenceAttribute()` only knew about the `DIEInfo::Clone` path, so for a reference to a root it took the "not cloned yet" branch and manufactured a placeholder. That placeholder is never adopted into a unit tree, so nothing ever assigns it an offset, and the reference resolved to whatever the unit started at.

**The fix, first half.** A reference whose target is the unit root resolves through that unit's output DIE, identified positionally as index 0 rather than by tag. Dropping the attribute when the referenced unit is not in the output keeps a reference to a discarded unit from naming something arbitrary.

**The fix, second half.** That output DIE has to exist before any unit is cloned, because the unit holding the reference may be cloned before the unit it names. Creating it therefore moves out of the per-unit loop into a pre-pass over exactly the units the loop goes on to emit. The guard is deliberately the same one the emission loop uses, so no unit that will be dropped gains an output DIE — creating one for a dropped unit leaves `getDebugInfoSectionSize()` disagreeing with the recorded start offset, which is asserted.

Hoisting the creation ahead of the loop leaves `createOutputDIE()` propagating a section offset that nothing has assigned yet, because `setStartOffset()` is what assigns `StartOffset` and it now runs after the pre-pass rather than before it. That propagation was dead as well as indeterminate: `setStartOffset()` re-propagates into the output unit whenever one exists, and it runs unconditionally for every unit, so the correct offset always lands. It comes out, and `StartOffset` and `NextUnitOffset` gain in-class initializers so that neither member is indeterminate whatever the call order later becomes.

The clone loop now asks whether the unit has an output DIE rather than re-testing the flag the pre-pass keyed on. Past the empty-unit `continue` those are the same condition, and it is the one the emission loop already uses, so "will this unit be emitted" is spelled once instead of three times in the same function.

Both halves are load-bearing, checked by reverting each on its own against the full test: without the pre-pass the forward import silently resolves to the wrong offset and the `CHECK-NEXT` fails, and without the reference change the linker aborts in `cloneDIE()` on `Can't supply a DIE and a cloned DIE`.

**Tests.** The tag plays no part in any of this, so `imported-unit.test` covers a `DW_TAG_compile_unit` root as well as the `DW_TAG_partial_unit` root that `dwz` produces. Each document carries both reference directions — U01 imports a unit cloned after it, U03 imports a unit cloned before it — pinned by a single capture, so neither direction can be satisfied alone. The DWARFv4 document is there because its unit header is eleven bytes where DWARFv5's is twelve, which no offset derived from a hardcoded header size survives. `llvm-dwarfdump` resolves `DW_AT_import` and prints the target's name, so the check asserts identity rather than only an offset.

There was no `DW_TAG_imported_unit` coverage anywhere in `llvm-dwarfutil` or `dsymutil` before this.

The partial unit document needs both dependencies: #219660 so that a `DW_FORM_ref_addr` into a partial unit can be given a section offset at all, and #219398 so that the unit ships under a `DW_UT_partial` header and passes `--verify`.

Its update-mode runs are the one place `--verify` is left off. Those runs build `.debug_names`, and `DWARFVerifier` excludes `DW_TAG_compile_unit` and `DW_TAG_module` from the name index completeness check but not `DW_TAG_partial_unit`, so it demands an index entry for a named partial unit root. That is unrelated to this change and is filed as #219720.

Fixes #219621.

This change was produced with AI assistance; I have reviewed it and am accountable for it.

Assisted-by: Claude Code


