### PR TITLE
[analyzer] Resolve lambda captures for explicit object parameters

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -677,6 +677,10 @@ public:
   static std::pair<const ProgramPointTag *, const ProgramPointTag *>
   getEagerlyAssumeBifurcationTags();
 
+  std::optional<std::pair<SVal, QualType>>
+  resolveAsLambdaCapturedVar(const Expr *Ex, const ValueDecl *VD,
+                             ExplodedNode *Pred);
+
   ProgramStateRef handleLValueBitCast(ProgramStateRef state, const Expr *Ex,
                                       const StackFrame *SF, QualType T,
                                       QualType ExTy, const CastExpr *CastE,

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -684,7 +684,7 @@ public:
 
 private:
   /// Resolve a lambda-captured variable's address based on whether the
-  /// enclosing method has an implicit or explicit object paramter.
+  /// enclosing method has an implicit or explicit object parameter.
   std::optional<std::pair<SVal, QualType>>
   resolveAsLambdaCapturedVar(const Expr *Ex, const ValueDecl *VD,
                              ExplodedNode *Pred) const;

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -679,7 +679,7 @@ public:
 
   std::optional<std::pair<SVal, QualType>>
   resolveAsLambdaCapturedVar(const Expr *Ex, const ValueDecl *VD,
-                             ExplodedNode *Pred);
+                             ExplodedNode *Pred) const;
 
   ProgramStateRef handleLValueBitCast(ProgramStateRef state, const Expr *Ex,
                                       const StackFrame *SF, QualType T,

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -687,7 +687,7 @@ private:
   /// enclosing method has an implicit or explicit object parameter.
   std::optional<std::pair<SVal, QualType>>
   resolveAsLambdaCapturedVar(const Expr *Ex, const ValueDecl *VD,
-                             ExplodedNode *Pred) const;
+                             const ExplodedNode *Pred) const;
 
 public:
   SVal evalBinOp(ProgramStateRef ST, BinaryOperator::Opcode Op,

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -677,14 +677,17 @@ public:
   static std::pair<const ProgramPointTag *, const ProgramPointTag *>
   getEagerlyAssumeBifurcationTags();
 
-  std::optional<std::pair<SVal, QualType>>
-  resolveAsLambdaCapturedVar(const Expr *Ex, const ValueDecl *VD,
-                             ExplodedNode *Pred) const;
-
   ProgramStateRef handleLValueBitCast(ProgramStateRef state, const Expr *Ex,
                                       const StackFrame *SF, QualType T,
                                       QualType ExTy, const CastExpr *CastE,
                                       ExplodedNodeSet &Dst, ExplodedNode *Pred);
+
+private:
+  /// Resolve a lambda-captured variable's address based on whether the
+  /// enclosing method has an implicit or explicit object paramter.
+  std::optional<std::pair<SVal, QualType>>
+  resolveAsLambdaCapturedVar(const Expr *Ex, const ValueDecl *VD,
+                             ExplodedNode *Pred) const;
 
 public:
   SVal evalBinOp(ProgramStateRef ST, BinaryOperator::Opcode Op,

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3040,12 +3040,30 @@ void ExprEngine::VisitCommonDeclRefExpr(const Expr *Ex, const NamedDecl *D,
       // Sema follows a sequence of complex rules to determine whether the
       // variable should be captured.
       if (const FieldDecl *FD = LambdaCaptureFields[VD]) {
-        Loc CXXThis = svalBuilder.getCXXThis(MD, SF);
-        SVal CXXThisVal = state->getSVal(CXXThis);
-        return std::make_pair(state->getLValue(FD, CXXThisVal), FD->getType());
+        if (MD->isImplicitObjectMemberFunction()) {
+          Loc CXXThis = svalBuilder.getCXXThis(MD, SF);
+          SVal CXXThisVal = state->getSVal(CXXThis);
+          return std::make_pair(state->getLValue(FD, CXXThisVal),
+                                FD->getType());
+        }
+        const ParmVarDecl *PVD = MD->getParamDecl(0);
+        if (const Expr *CallSite = SF->getCallSite()) {
+          unsigned Idx = PVD->getFunctionScopeIndex();
+          const ParamVarRegion *PVR =
+              state->getStateManager().getRegionManager().getParamVarRegion(
+                  CallSite, Idx, SF);
+          const Expr *SelfArgExpr = cast<CallExpr>(CallSite)->getArg(0);
+          state =
+              state->bindLoc(loc::MemRegionVal(PVR),
+                             state->getSVal(SelfArgExpr, SF->getParent()), SF);
+          SVal ParamSVal = state->getSVal(loc::MemRegionVal(PVR));
+          if (!PVD->getType()->isReferenceType())
+            return std::make_pair(state->getLValue(FD, loc::MemRegionVal(PVR)),
+                                  FD->getType());
+          return std::make_pair(state->getLValue(FD, ParamSVal), FD->getType());
+        }
       }
     }
-
     return std::nullopt;
   };
 

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3018,63 +3018,62 @@ void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
 // Transfer functions: Loads and stores.
 //===----------------------------------------------------------------------===//
 
+std::optional<std::pair<SVal, QualType>>
+ExprEngine::resolveAsLambdaCapturedVar(const Expr *Ex, const ValueDecl *VD,
+                                       ExplodedNode *Pred) {
+  ProgramStateRef state = Pred->getState();
+  const StackFrame *SF = Pred->getStackFrame();
+
+  const auto *MD = dyn_cast<CXXMethodDecl>(SF->getDecl());
+  const auto *DeclRefEx = dyn_cast<DeclRefExpr>(Ex);
+  if (AMgr.options.ShouldInlineLambdas && DeclRefEx &&
+      DeclRefEx->refersToEnclosingVariableOrCapture() && MD &&
+      MD->getParent()->isLambda()) {
+    // Lookup the field of the lambda.
+    const CXXRecordDecl *CXXRec = MD->getParent();
+    llvm::DenseMap<const ValueDecl *, FieldDecl *> LambdaCaptureFields;
+    FieldDecl *LambdaThisCaptureField;
+    CXXRec->getCaptureFields(LambdaCaptureFields, LambdaThisCaptureField);
+
+    // Sema follows a sequence of complex rules to determine whether the
+    // variable should be captured.
+    if (const FieldDecl *FD = LambdaCaptureFields[VD]) {
+      if (MD->isImplicitObjectMemberFunction()) {
+        Loc CXXThis = svalBuilder.getCXXThis(MD, SF);
+        SVal CXXThisVal = state->getSVal(CXXThis);
+        return {{state->getLValue(FD, CXXThisVal), FD->getType()}};
+      }
+      const ParmVarDecl *PVD = MD->getParamDecl(0);
+      if (const Expr *CallSite = SF->getCallSite()) {
+        const ParamVarRegion *PVR =
+            MRMgr.getParamVarRegion(CallSite, /*Index=*/0, SF);
+        const Expr *SelfArgExpr = cast<CallExpr>(CallSite)->getArg(0);
+        if (PVD->getType()->isReferenceType()) {
+          state =
+              state->bindLoc(loc::MemRegionVal(PVR),
+                             state->getSVal(SelfArgExpr, SF->getParent()), SF);
+          SVal ParamSVal = state->getSVal(loc::MemRegionVal(PVR));
+          return {{state->getLValue(FD, ParamSVal), FD->getType()}};
+        }
+        return {{state->getLValue(FD, loc::MemRegionVal(PVR)), FD->getType()}};
+      }
+    }
+  }
+  return std::nullopt;
+}
+
 void ExprEngine::VisitCommonDeclRefExpr(const Expr *Ex, const NamedDecl *D,
                                         ExplodedNode *Pred,
                                         ExplodedNodeSet &Dst) {
   ProgramStateRef state = Pred->getState();
   const StackFrame *SF = Pred->getStackFrame();
 
-  auto resolveAsLambdaCapturedVar =
-      [&](const ValueDecl *VD) -> std::optional<std::pair<SVal, QualType>> {
-    const auto *MD = dyn_cast<CXXMethodDecl>(SF->getDecl());
-    const auto *DeclRefEx = dyn_cast<DeclRefExpr>(Ex);
-    if (AMgr.options.ShouldInlineLambdas && DeclRefEx &&
-        DeclRefEx->refersToEnclosingVariableOrCapture() && MD &&
-        MD->getParent()->isLambda()) {
-      // Lookup the field of the lambda.
-      const CXXRecordDecl *CXXRec = MD->getParent();
-      llvm::DenseMap<const ValueDecl *, FieldDecl *> LambdaCaptureFields;
-      FieldDecl *LambdaThisCaptureField;
-      CXXRec->getCaptureFields(LambdaCaptureFields, LambdaThisCaptureField);
-
-      // Sema follows a sequence of complex rules to determine whether the
-      // variable should be captured.
-      if (const FieldDecl *FD = LambdaCaptureFields[VD]) {
-        if (MD->isImplicitObjectMemberFunction()) {
-          Loc CXXThis = svalBuilder.getCXXThis(MD, SF);
-          SVal CXXThisVal = state->getSVal(CXXThis);
-          return std::make_pair(state->getLValue(FD, CXXThisVal),
-                                FD->getType());
-        }
-        const ParmVarDecl *PVD = MD->getParamDecl(0);
-        if (const Expr *CallSite = SF->getCallSite()) {
-          unsigned Idx = PVD->getFunctionScopeIndex();
-          const ParamVarRegion *PVR =
-              state->getStateManager().getRegionManager().getParamVarRegion(
-                  CallSite, Idx, SF);
-          const Expr *SelfArgExpr = cast<CallExpr>(CallSite)->getArg(0);
-          if (PVD->getType()->isReferenceType()) {
-            state = state->bindLoc(loc::MemRegionVal(PVR),
-                                   state->getSVal(SelfArgExpr, SF->getParent()),
-                                   SF);
-            SVal ParamSVal = state->getSVal(loc::MemRegionVal(PVR));
-            return std::make_pair(state->getLValue(FD, ParamSVal),
-                                  FD->getType());
-          }
-          return std::make_pair(state->getLValue(FD, loc::MemRegionVal(PVR)),
-                                FD->getType());
-        }
-      }
-    }
-    return std::nullopt;
-  };
-
   if (const auto *VD = dyn_cast<VarDecl>(D)) {
     // C permits "extern void v", and if you cast the address to a valid type,
     // you can even do things with it. We simply pretend
     assert(Ex->isGLValue() || VD->getType()->isVoidType());
     std::optional<std::pair<SVal, QualType>> VInfo =
-        resolveAsLambdaCapturedVar(VD);
+        resolveAsLambdaCapturedVar(Ex, VD, Pred);
 
     if (!VInfo)
       VInfo = std::make_pair(state->getLValue(VD, SF), VD->getType());
@@ -3116,7 +3115,7 @@ void ExprEngine::VisitCommonDeclRefExpr(const Expr *Ex, const NamedDecl *D,
   if (const auto *BD = dyn_cast<BindingDecl>(D)) {
     // Handle structured bindings captured by lambda.
     if (std::optional<std::pair<SVal, QualType>> VInfo =
-            resolveAsLambdaCapturedVar(BD)) {
+            resolveAsLambdaCapturedVar(Ex, BD, Pred)) {
       auto [V, T] = VInfo.value();
 
       if (T->isReferenceType()) {

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3061,7 +3061,8 @@ void ExprEngine::VisitCommonDeclRefExpr(const Expr *Ex, const NamedDecl *D,
             return std::make_pair(state->getLValue(FD, ParamSVal),
                                   FD->getType());
           }
-          return std::make_pair(state->getLValue(FD, loc::MemRegionVal(PVR)), FD->getType());
+          return std::make_pair(state->getLValue(FD, loc::MemRegionVal(PVR)),
+                                FD->getType());
         }
       }
     }

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3053,14 +3053,15 @@ void ExprEngine::VisitCommonDeclRefExpr(const Expr *Ex, const NamedDecl *D,
               state->getStateManager().getRegionManager().getParamVarRegion(
                   CallSite, Idx, SF);
           const Expr *SelfArgExpr = cast<CallExpr>(CallSite)->getArg(0);
-          state =
-              state->bindLoc(loc::MemRegionVal(PVR),
-                             state->getSVal(SelfArgExpr, SF->getParent()), SF);
-          SVal ParamSVal = state->getSVal(loc::MemRegionVal(PVR));
-          if (!PVD->getType()->isReferenceType())
-            return std::make_pair(state->getLValue(FD, loc::MemRegionVal(PVR)),
+          if (PVD->getType()->isReferenceType()) {
+            state = state->bindLoc(loc::MemRegionVal(PVR),
+                                   state->getSVal(SelfArgExpr, SF->getParent()),
+                                   SF);
+            SVal ParamSVal = state->getSVal(loc::MemRegionVal(PVR));
+            return std::make_pair(state->getLValue(FD, ParamSVal),
                                   FD->getType());
-          return std::make_pair(state->getLValue(FD, ParamSVal), FD->getType());
+          }
+          return std::make_pair(state->getLValue(FD, loc::MemRegionVal(PVR)), FD->getType());
         }
       }
     }

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3020,43 +3020,43 @@ void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
 
 std::optional<std::pair<SVal, QualType>>
 ExprEngine::resolveAsLambdaCapturedVar(const Expr *Ex, const ValueDecl *VD,
-                                       ExplodedNode *Pred) {
-  ProgramStateRef state = Pred->getState();
+                                       ExplodedNode *Pred) const {
+  ProgramStateRef State = Pred->getState();
   const StackFrame *SF = Pred->getStackFrame();
 
   const auto *MD = dyn_cast<CXXMethodDecl>(SF->getDecl());
   const auto *DeclRefEx = dyn_cast<DeclRefExpr>(Ex);
-  if (AMgr.options.ShouldInlineLambdas && DeclRefEx &&
-      DeclRefEx->refersToEnclosingVariableOrCapture() && MD &&
-      MD->getParent()->isLambda()) {
-    // Lookup the field of the lambda.
-    const CXXRecordDecl *CXXRec = MD->getParent();
-    llvm::DenseMap<const ValueDecl *, FieldDecl *> LambdaCaptureFields;
-    FieldDecl *LambdaThisCaptureField;
-    CXXRec->getCaptureFields(LambdaCaptureFields, LambdaThisCaptureField);
+  if (!(AMgr.options.ShouldInlineLambdas && DeclRefEx &&
+        DeclRefEx->refersToEnclosingVariableOrCapture() && MD &&
+        MD->getParent()->isLambda()))
+    return std::nullopt;
+  // Lookup the field of the lambda.
+  const CXXRecordDecl *CXXRec = MD->getParent();
+  llvm::DenseMap<const ValueDecl *, FieldDecl *> LambdaCaptureFields;
+  FieldDecl *LambdaThisCaptureField;
+  CXXRec->getCaptureFields(LambdaCaptureFields, LambdaThisCaptureField);
 
-    // Sema follows a sequence of complex rules to determine whether the
-    // variable should be captured.
-    if (const FieldDecl *FD = LambdaCaptureFields[VD]) {
-      if (MD->isImplicitObjectMemberFunction()) {
-        Loc CXXThis = svalBuilder.getCXXThis(MD, SF);
-        SVal CXXThisVal = state->getSVal(CXXThis);
-        return {{state->getLValue(FD, CXXThisVal), FD->getType()}};
+  // Sema follows a sequence of complex rules to determine whether the
+  // variable should be captured.
+  if (const FieldDecl *FD = LambdaCaptureFields[VD]) {
+    if (MD->isImplicitObjectMemberFunction()) {
+      Loc CXXThis = svalBuilder.getCXXThis(MD, SF);
+      SVal CXXThisVal = State->getSVal(CXXThis);
+      return {{State->getLValue(FD, CXXThisVal), FD->getType()}};
+    }
+    const ParmVarDecl *PVD = MD->getParamDecl(0);
+    if (const Expr *CallSite = SF->getCallSite()) {
+      const ParamVarRegion *PVR =
+          MRMgr.getParamVarRegion(CallSite, /*Index=*/0, SF);
+      const Expr *SelfArgExpr = cast<CallExpr>(CallSite)->getArg(0);
+      if (PVD->getType()->isReferenceType()) {
+        State =
+            State->bindLoc(loc::MemRegionVal(PVR),
+                           State->getSVal(SelfArgExpr, SF->getParent()), SF);
+        SVal ParamSVal = State->getSVal(loc::MemRegionVal(PVR));
+        return {{State->getLValue(FD, ParamSVal), FD->getType()}};
       }
-      const ParmVarDecl *PVD = MD->getParamDecl(0);
-      if (const Expr *CallSite = SF->getCallSite()) {
-        const ParamVarRegion *PVR =
-            MRMgr.getParamVarRegion(CallSite, /*Index=*/0, SF);
-        const Expr *SelfArgExpr = cast<CallExpr>(CallSite)->getArg(0);
-        if (PVD->getType()->isReferenceType()) {
-          state =
-              state->bindLoc(loc::MemRegionVal(PVR),
-                             state->getSVal(SelfArgExpr, SF->getParent()), SF);
-          SVal ParamSVal = state->getSVal(loc::MemRegionVal(PVR));
-          return {{state->getLValue(FD, ParamSVal), FD->getType()}};
-        }
-        return {{state->getLValue(FD, loc::MemRegionVal(PVR)), FD->getType()}};
-      }
+      return {{State->getLValue(FD, loc::MemRegionVal(PVR)), FD->getType()}};
     }
   }
   return std::nullopt;

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3026,10 +3026,11 @@ ExprEngine::resolveAsLambdaCapturedVar(const Expr *Ex, const ValueDecl *VD,
 
   const auto *MD = dyn_cast<CXXMethodDecl>(SF->getDecl());
   const auto *DeclRefEx = dyn_cast<DeclRefExpr>(Ex);
-  if (!(AMgr.options.ShouldInlineLambdas && DeclRefEx &&
-        DeclRefEx->refersToEnclosingVariableOrCapture() && MD &&
-        MD->getParent()->isLambda()))
+  if (!AMgr.options.ShouldInlineLambdas || !DeclRefEx ||
+      !DeclRefEx->refersToEnclosingVariableOrCapture() || !MD ||
+      !MD->getParent()->isLambda()) {
     return std::nullopt;
+  }
   // Lookup the field of the lambda.
   const CXXRecordDecl *CXXRec = MD->getParent();
   llvm::DenseMap<const ValueDecl *, FieldDecl *> LambdaCaptureFields;
@@ -3050,6 +3051,12 @@ ExprEngine::resolveAsLambdaCapturedVar(const Expr *Ex, const ValueDecl *VD,
           MRMgr.getParamVarRegion(CallSite, /*Index=*/0, SF);
       const Expr *SelfArgExpr = cast<CallExpr>(CallSite)->getArg(0);
       if (PVD->getType()->isReferenceType()) {
+        // TODO: This binding should happen at call entry instead. The same way
+        // it does for the implicit object parameter (CXXThisRegion, bound in
+        // CXXInstanceCall::getInitialStackFrameContents). The explicit object
+        // parameter's ParamVarRegion is never bound there today, so this
+        // binding is just a workaround. A follow-up PR should properly bind it
+        // at call entry, so it is no longer needed here.
         State =
             State->bindLoc(loc::MemRegionVal(PVR),
                            State->getSVal(SelfArgExpr, SF->getParent()), SF);

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3020,7 +3020,7 @@ void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
 
 std::optional<std::pair<SVal, QualType>>
 ExprEngine::resolveAsLambdaCapturedVar(const Expr *Ex, const ValueDecl *VD,
-                                       ExplodedNode *Pred) const {
+                                       const ExplodedNode *Pred) const {
   ProgramStateRef State = Pred->getState();
   const StackFrame *SF = Pred->getStackFrame();
 

--- a/clang/test/Analysis/explicit-lambda-capture.cpp
+++ b/clang/test/Analysis/explicit-lambda-capture.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -analyze -std=c++23 -analyzer-checker=core.DivideZero -verify %s
+// RUN: %clang_analyze_cc1 -std=c++23 -analyzer-checker=core -verify %s
 
 int implicit_capture_by_value() {
   int d = 0;
@@ -32,12 +32,12 @@ int gh218708_explicit_by_value_self() {
 
 int explicit_rvalue_no_error() {
   int d = 5;
-  auto lam = [d](this auto &&self) { return 1 / d; }; // 'd' is non-zero so there is no division by zero error. 
+  auto lam = [d](this auto &&self) { return 1 / d; }; // no-warning 
   return lam(); 
 }
 
 int explicit_by_value_no_error() {
   int d = 9;
-  auto lam = [d](this auto self) { return 1 / d; }; // 'd' is non-zero so there is no division by zero error.
+  auto lam = [d](this auto self) { return 1 / d; }; // no-warning 
   return lam();
 }

--- a/clang/test/Analysis/explicit-lambda-capture.cpp
+++ b/clang/test/Analysis/explicit-lambda-capture.cpp
@@ -1,4 +1,6 @@
-// RUN: %clang_analyze_cc1 -std=c++23 -analyzer-checker=core -verify %s
+// RUN: %clang_analyze_cc1 -std=c++23 -analyzer-checker=core,cplusplus.Move -verify %s
+
+#include "Inputs/system-header-simulator-cxx.h"
 
 int implicit_capture_by_value() {
   int d = 0;
@@ -40,4 +42,37 @@ int explicit_by_value_no_error() {
   int d = 9;
   auto lam = [d](this auto self) { return 1 / d; }; // no-warning 
   return lam();
+}
+
+auto by_val() {
+  std::vector<int> v;
+  auto lam = [v](this auto self) {
+    auto res = std::move(v);
+    return res;
+  };
+
+  lam();
+  lam();
+}
+
+auto by_lval() {
+  std::vector<int> v;
+  auto lam = [v](this auto &self) {
+    auto res = std::move(v); // expected-warning {{Moved-from object '' of type 'std::vector' is moved}}
+    return res;
+  };
+
+  lam();
+  lam();
+}
+
+auto by_rval() {
+  std::vector<int> v;
+  auto lam = [v](this auto &&self) {
+    auto res = std::move(v); // expected-warning {{Moved-from object '' of type 'std::vector' is moved}}
+    return res;
+  };
+
+  std::move(lam)();
+  std::move(lam)();
 }

--- a/clang/test/Analysis/explicit-lambda-capture.cpp
+++ b/clang/test/Analysis/explicit-lambda-capture.cpp
@@ -1,0 +1,43 @@
+// RUN: %clang_cc1 -analyze -std=c++23 -analyzer-checker=core.DivideZero -verify %s
+
+int implicit_capture_by_value() {
+  int d = 0;
+  auto lam = [d]() { return 1 / d; }; // expected-warning {{Division by zero}}
+  return lam(); 
+}
+
+int explicit_rvalue_self_capture_by_reference() {
+  int d = 0;
+  auto lam = [&d](this auto &&self) { return 1 / d; }; // expected-warning {{Division by zero}}
+  return lam(); 
+}
+
+int gh218708_explicit_rvalue_self() {
+  int d = 0;
+  auto lam = [d](this auto &&self) { return 1 / d; }; // expected-warning {{Division by zero}}
+  return lam(); 
+}
+
+int gh218708_explicit_lvalue_self() {
+  int d = 0;
+  auto lam = [d](this auto &self) { return 1 / d; }; // expected-warning {{Division by zero}}
+  return lam(); 
+}
+
+int gh218708_explicit_by_value_self() {
+  int d = 0;
+  auto lam = [d](this auto self) { return 1 / d; }; // expected-warning {{Division by zero}}
+  return lam();
+}
+
+int explicit_rvalue_no_error() {
+  int d = 5;
+  auto lam = [d](this auto &&self) { return 1 / d; }; // 'd' is non-zero so there is no division by zero error. 
+  return lam(); 
+}
+
+int explicit_by_value_no_error() {
+  int d = 9;
+  auto lam = [d](this auto self) { return 1 / d; }; // 'd' is non-zero so there is no division by zero error.
+  return lam();
+}

--- a/clang/test/Analysis/explicit-lambda-capture.cpp
+++ b/clang/test/Analysis/explicit-lambda-capture.cpp
@@ -5,25 +5,25 @@
 int implicit_capture_by_value() {
   int d = 0;
   auto lam = [d]() { return 1 / d; }; // expected-warning {{Division by zero}}
-  return lam(); 
+  return lam();
 }
 
 int explicit_rvalue_self_capture_by_reference() {
   int d = 0;
   auto lam = [&d](this auto &&self) { return 1 / d; }; // expected-warning {{Division by zero}}
-  return lam(); 
+  return lam();
 }
 
 int gh218708_explicit_rvalue_self() {
   int d = 0;
   auto lam = [d](this auto &&self) { return 1 / d; }; // expected-warning {{Division by zero}}
-  return lam(); 
+  return lam();
 }
 
 int gh218708_explicit_lvalue_self() {
   int d = 0;
   auto lam = [d](this auto &self) { return 1 / d; }; // expected-warning {{Division by zero}}
-  return lam(); 
+  return lam();
 }
 
 int gh218708_explicit_by_value_self() {
@@ -34,13 +34,13 @@ int gh218708_explicit_by_value_self() {
 
 int explicit_rvalue_no_error() {
   int d = 5;
-  auto lam = [d](this auto &&self) { return 1 / d; }; // no-warning 
-  return lam(); 
+  auto lam = [d](this auto &&self) { return 1 / d; }; // no-warning
+  return lam();
 }
 
 int explicit_by_value_no_error() {
   int d = 9;
-  auto lam = [d](this auto self) { return 1 / d; }; // no-warning 
+  auto lam = [d](this auto self) { return 1 / d; }; // no-warning
   return lam();
 }
 


### PR DESCRIPTION
Currently explicit object parameters are not modeled in the `VisitCommonDeclRefExpr` function in `ExprEngine`. Because of this when a lambda has an explicit object parameter and a possible division by zero the `core.DivideZero` checker does not emit warning. This PR solves that issue by deciding if the lambda has an explicit object parameter and then records the binding (if the parameter has the reference type) between the parameter and the argument's expression otherwise it returns the captured field's lvalue.

This PR fixes #218708