### PR TITLE
[DWARFVerifier] Do not demand a .debug_names entry for a unit root

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -1966,14 +1966,21 @@ void DWARFVerifier::verifyNameIndexCompleteness(
   if (EntryNames.empty())
     return;
 
+  // A unit root has a name, the path of its primary source file, but it defines
+  // no subprogram, label, variable, type or namespace, so the index owes it no
+  // entry. The root is the only DIE in a unit without a parent; testing that
+  // rather than a tag covers DW_TAG_partial_unit, which dwz emits, alongside
+  // DW_TAG_compile_unit.
+  if (!Die.getParent())
+    return;
+
   // We deviate from the specification here, which says:
   // "The name index must contain an entry for each debugging information entry
   // that defines a named subprogram, label, variable, type, or namespace,
   // subject to ..."
   // Explicitly exclude all TAGs that we know shouldn't be indexed.
   switch (Die.getTag()) {
-  // Compile units and modules have names but shouldn't be indexed.
-  case DW_TAG_compile_unit:
+  // Modules have names but shouldn't be indexed.
   case DW_TAG_module:
     return;
 

--- a/llvm/test/tools/llvm-dwarfdump/X86/debug-names-verify-completeness-partial-unit.s
+++ b/llvm/test/tools/llvm-dwarfdump/X86/debug-names-verify-completeness-partial-unit.s
@@ -1,0 +1,181 @@
+# The .debug_names completeness check treats the root of a DW_TAG_partial_unit
+# the way it already treats the root of a DW_TAG_compile_unit: its DW_AT_name is
+# the path of a source file rather than a named subprogram, label, variable,
+# type or namespace, so the index owes it no entry.
+#
+# One index covers two units. U01 is the DW_TAG_partial_unit that dwz produces
+# and U02 is an ordinary compilation unit, the control. Neither root appears in
+# the index and both subprograms do.
+
+# RUN: llvm-mc -triple x86_64-pc-linux %s -filetype=obj -o %t.o
+# RUN: llvm-dwarfdump --verify %t.o | FileCheck %s --implicit-check-not=error:
+
+# CHECK: No errors.
+
+# Excluding the root does not excuse the rest of the unit. A subprogram under
+# the partial unit root that the index leaves out is still reported, and the
+# aggregate count pins it as the only error, so the root is still not demanded.
+
+# RUN: llvm-mc -triple x86_64-pc-linux --defsym UNINDEXED=1 %s -filetype=obj -o %t.unindexed.o
+# RUN: not llvm-dwarfdump --verify %t.unindexed.o | FileCheck %s --check-prefix=UNINDEXED \
+# RUN:   --implicit-check-not="dwz-common.h missing"
+
+# UNINDEXED:      error: Name Index @ 0x0: Entry for DIE @ {{.*}} (DW_TAG_subprogram) with name unindexed missing.
+# UNINDEXED:      error: Aggregated error counts:
+# UNINDEXED-NEXT: error: Name Index DIE entry missing name occurred 1 time(s).
+
+	.section	.debug_str,"MS",@progbits,1
+.Lstring_producer:
+	.asciz	"Hand-written DWARF"
+.Lstring_dwz_common:
+	.asciz	"dwz-common.h"
+.Lstring_main:
+	.asciz	"main.c"
+.Lstring_foo:
+	.asciz	"foo"
+.Lstring_bar:
+	.asciz	"bar"
+.Lstring_unindexed:
+	.asciz	"unindexed"
+
+	.section	.debug_abbrev,"",@progbits
+.Lsection_abbrev:
+	.byte	1                       # Abbreviation Code
+	.byte	60                      # DW_TAG_partial_unit
+	.byte	1                       # DW_CHILDREN_yes
+	.byte	37                      # DW_AT_producer
+	.byte	14                      # DW_FORM_strp
+	.byte	3                       # DW_AT_name
+	.byte	14                      # DW_FORM_strp
+	.byte	19                      # DW_AT_language
+	.byte	5                       # DW_FORM_data2
+	.byte	0                       # EOM(1)
+	.byte	0                       # EOM(2)
+
+	.byte	2                       # Abbreviation Code
+	.byte	46                      # DW_TAG_subprogram
+	.byte	0                       # DW_CHILDREN_no
+	.byte	3                       # DW_AT_name
+	.byte	14                      # DW_FORM_strp
+	.byte	17                      # DW_AT_low_pc
+	.byte	1                       # DW_FORM_addr
+	.byte	18                      # DW_AT_high_pc
+	.byte	6                       # DW_FORM_data4
+	.byte	0                       # EOM(1)
+	.byte	0                       # EOM(2)
+
+	.byte	3                       # Abbreviation Code
+	.byte	17                      # DW_TAG_compile_unit
+	.byte	1                       # DW_CHILDREN_yes
+	.byte	37                      # DW_AT_producer
+	.byte	14                      # DW_FORM_strp
+	.byte	3                       # DW_AT_name
+	.byte	14                      # DW_FORM_strp
+	.byte	19                      # DW_AT_language
+	.byte	5                       # DW_FORM_data2
+	.byte	17                      # DW_AT_low_pc
+	.byte	1                       # DW_FORM_addr
+	.byte	18                      # DW_AT_high_pc
+	.byte	6                       # DW_FORM_data4
+	.byte	0                       # EOM(1)
+	.byte	0                       # EOM(2)
+
+	.byte	0                       # EOM(3)
+
+	.section	.debug_info,"",@progbits
+# U01, the partial unit. Its root carries no address range, which is the shape
+# dwz emits: a partial unit holds no code of its own.
+.Lcu_begin0:
+	.long	.Lcu_end0-.Lcu_start0   # Length of Unit
+.Lcu_start0:
+	.short	5                       # DWARF version number
+	.byte	3                       # DW_UT_partial
+	.byte	8                       # Address Size (in bytes)
+	.long	.Lsection_abbrev        # Offset Into Abbrev. Section
+	.byte	1                       # Abbrev [1] DW_TAG_partial_unit
+	.long	.Lstring_producer       # DW_AT_producer
+	.long	.Lstring_dwz_common     # DW_AT_name
+	.short	12                      # DW_AT_language
+.Ldie_foo:
+	.byte	2                       # Abbrev [2] DW_TAG_subprogram
+	.long	.Lstring_foo            # DW_AT_name
+	.quad	0x1000                  # DW_AT_low_pc
+	.long	0x10                    # DW_AT_high_pc
+.ifdef UNINDEXED
+.Ldie_unindexed:
+	.byte	2                       # Abbrev [2] DW_TAG_subprogram
+	.long	.Lstring_unindexed      # DW_AT_name
+	.quad	0x1010                  # DW_AT_low_pc
+	.long	0x10                    # DW_AT_high_pc
+.endif
+	.byte	0                       # End Of Children Mark
+.Lcu_end0:
+
+# U02, the control.
+.Lcu_begin1:
+	.long	.Lcu_end1-.Lcu_start1   # Length of Unit
+.Lcu_start1:
+	.short	5                       # DWARF version number
+	.byte	1                       # DW_UT_compile
+	.byte	8                       # Address Size (in bytes)
+	.long	.Lsection_abbrev        # Offset Into Abbrev. Section
+	.byte	3                       # Abbrev [3] DW_TAG_compile_unit
+	.long	.Lstring_producer       # DW_AT_producer
+	.long	.Lstring_main           # DW_AT_name
+	.short	12                      # DW_AT_language
+	.quad	0x2000                  # DW_AT_low_pc
+	.long	0x100                   # DW_AT_high_pc
+.Ldie_bar:
+	.byte	2                       # Abbrev [2] DW_TAG_subprogram
+	.long	.Lstring_bar            # DW_AT_name
+	.quad	0x2000                  # DW_AT_low_pc
+	.long	0x10                    # DW_AT_high_pc
+	.byte	0                       # End Of Children Mark
+.Lcu_end1:
+
+	.section	.debug_names,"",@progbits
+	.long	.Lnames_end0-.Lnames_start0 # Header: contribution length
+.Lnames_start0:
+	.short	5                       # Header: version
+	.short	0                       # Header: padding
+	.long	2                       # Header: compilation unit count
+	.long	0                       # Header: local type unit count
+	.long	0                       # Header: foreign type unit count
+	.long	2                       # Header: bucket count
+	.long	2                       # Header: name count
+	.long	.Lnames_abbrev_end0-.Lnames_abbrev_start0 # Header: abbreviation table size
+	.long	0                       # Header: augmentation length
+	.long	.Lcu_begin0             # Compilation unit 0
+	.long	.Lcu_begin1             # Compilation unit 1
+	.long	1                       # Bucket 0
+	.long	2                       # Bucket 1
+	.long	193487034               # Hash in Bucket 0: bar
+	.long	193491849               # Hash in Bucket 1: foo
+	.long	.Lstring_bar            # String in Bucket 0: bar
+	.long	.Lstring_foo            # String in Bucket 1: foo
+	.long	.Lnames_bar-.Lnames_entries0 # Offset in Bucket 0
+	.long	.Lnames_foo-.Lnames_entries0 # Offset in Bucket 1
+.Lnames_abbrev_start0:
+	.byte	46                      # Abbrev code
+	.byte	46                      # DW_TAG_subprogram
+	.byte	1                       # DW_IDX_compile_unit
+	.byte	11                      # DW_FORM_data1
+	.byte	3                       # DW_IDX_die_offset
+	.byte	19                      # DW_FORM_ref4
+	.byte	0                       # End of abbrev
+	.byte	0                       # End of abbrev
+	.byte	0                       # End of abbrev list
+.Lnames_abbrev_end0:
+.Lnames_entries0:
+.Lnames_bar:
+	.byte	46                      # Abbrev code
+	.byte	1                       # DW_IDX_compile_unit
+	.long	.Ldie_bar-.Lcu_begin1   # DW_IDX_die_offset
+	.long	0                       # End of list: bar
+.Lnames_foo:
+	.byte	46                      # Abbrev code
+	.byte	0                       # DW_IDX_compile_unit
+	.long	.Ldie_foo-.Lcu_begin0   # DW_IDX_die_offset
+	.long	0                       # End of list: foo
+	.p2align	2
+.Lnames_end0:


### PR DESCRIPTION
**Summary**

- **Broken:** the `.debug_names` completeness check demands an index entry for every DIE defining a named subprogram, label, variable, type or namespace (DWARFv5 spec §6.1.1.1), but not for unit roots — a unit root's `DW_AT_name` is the path of the primary source file (§3.1.1). The check excludes roots by tag and lists `DW_TAG_compile_unit` and `DW_TAG_module` only, missing `DW_TAG_partial_unit`, so it demands an entry for a named partial unit root and reports every `dwz`-produced file that correctly omits one as broken.
- **Fix:** exclude the unit root by position rather than by tag.
- **Implementation:** the check asks whether the DIE has no parent, which is true of the unit root alone and therefore cannot miss a root tag the way a list can, and `DW_TAG_module` stays in the switch because a module entry is not a root.

The `.debug_names` completeness check decides which DIEs the index owes an entry by testing tags, and it excludes `DW_TAG_compile_unit` and `DW_TAG_module`. `DW_TAG_partial_unit` is absent from that list, so a named partial unit root is demanded of the index, and every file that leaves it out is reported as broken:

```console
$ llvm-dwarfdump --verify pu.o
error: Name Index @ 0x0: Entry for DIE @ 0xc (DW_TAG_partial_unit) with name dwz-common.h missing.
```

`dwz` is what produces partial units, and it is a standard step in Fedora, RHEL and Debian debuginfo packaging, so this is the ordinary shape of a distribution debuginfo file rather than a corner case. It reproduces on stock Fedora `llvm-dwarfdump` 22.1.8 and needs no linking at all.

**Specification.** DWARFv5 §6.1.1.1 requires an index entry for each debugging information entry "that defines a named subprogram, label, variable, type, or namespace". A unit root defines none of those. §3.1.1 item 2 says its `DW_AT_name` is the path of the primary source file, and that wording covers full and partial compilation units alike, so demanding an entry for one root tag and not for the other has no basis in the standard.

**The fix.** Exclude the unit root by position rather than by tag. What the check needs to know is whether the DIE is the root of its unit, and the root is the only DIE in a unit without a parent, so a tag list has to enumerate every unit root tag and is wrong as soon as one is missing. `DW_TAG_module` stays in the switch, since a module entry is not a root.

**Tests.** One hand-written index covers two units: a `DW_TAG_partial_unit` in the shape `dwz` emits, and an ordinary compilation unit as the control. Neither root is in the index and both subprograms are, so the file verifies clean once the root is excluded.

A second run assembles the same file with `--defsym UNINDEXED=1`, adding a subprogram under the partial unit root that the index deliberately leaves out. That run still reports it, and the aggregate count pins it as the only error, so a fix that skipped the whole unit rather than just its root would fail here. There is no third unit root tag that can reach this code — `dyn_cast<DWARFCompileUnit>` filters type units out and skeleton roots go down the split-DWARF path — so the test cannot distinguish the positional form from a tag list that happens to name both tags.

**Interaction with #219641.** Issue #219599 is the same spec question from the producer side: the linker puts a partial unit root into `.debug_names`, which it should not. The two currently cancel in part. A partial unit root with an address range is wrongly indexed and `--verify` is therefore satisfied; a root without one, which is the real `dwz` shape, is correctly absent and `--verify` already fails. #219641 fixes the producer, and with that patch applied its own test input fails this check, so it would make every partial unit carrying an accelerator table fail `--verify`. This change should land first; #219641 can then add `--verify` to its runs.

Fixes #219720.

This change was produced with AI assistance; I have reviewed it and am accountable for it.

Assisted-by: Claude Code

