### PR TITLE
[DWARFTypePrinter] Stop the scope walk at any unit root

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFTypePrinter.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFTypePrinter.h
@@ -836,11 +836,10 @@ void DWARFTypePrinter<DieType>::appendSubroutineNameAfter(
 
 template <typename DieType>
 void DWARFTypePrinter<DieType>::appendScopes(DieType D) {
-  if (D.getTag() == dwarf::DW_TAG_compile_unit)
-    return;
-  if (D.getTag() == dwarf::DW_TAG_type_unit)
-    return;
-  if (D.getTag() == dwarf::DW_TAG_skeleton_unit)
+  // A unit root is not an enclosing scope: its DW_AT_name is the path of a
+  // source file rather than an identifier. isUnitType covers all four unit root
+  // tags, including DW_TAG_partial_unit, which dwz emits.
+  if (dwarf::isUnitType(D.getTag()))
     return;
   if (D.getTag() == dwarf::DW_TAG_subprogram)
     return;

--- a/llvm/lib/DWARFLinker/Classic/DWARFLinkerDeclContext.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFLinkerDeclContext.cpp
@@ -60,11 +60,20 @@ bool DeclContext::setLastSeenDIE(CompileUnit &U, const DWARFDie &Die) {
 PointerIntPair<DeclContext *, 1>
 DeclContextTree::getChildDeclContext(DeclContext &Context, const DWARFDie &DIE,
                                      CompileUnit &U, bool InClangModule) {
-  unsigned Tag = DIE.getTag();
+  dwarf::Tag Tag = DIE.getTag();
 
   // FIXME: dsymutil-classic compat: We should bail out here if we
   // have a specification or an abstract_origin. We will get the
   // parent context wrong here.
+
+  // A unit root is the root of the unit's context tree, whatever tag it
+  // carries: a null context here would propagate to every descendant and take
+  // the whole unit out of uniquing. The tag recognizes the root because this
+  // API is handed a DIE rather than its index, and it degrades safely - a
+  // nested DIE carrying a unit tag would merely be transparent to its
+  // enclosing context.
+  if (dwarf::isUnitType(Tag))
+    return PointerIntPair<DeclContext *, 1>(&Context);
 
   switch (Tag) {
   default:
@@ -72,10 +81,10 @@ DeclContextTree::getChildDeclContext(DeclContext &Context, const DWARFDie &DIE,
     return PointerIntPair<DeclContext *, 1>(nullptr);
   case dwarf::DW_TAG_module:
     break;
-  case dwarf::DW_TAG_compile_unit:
-    return PointerIntPair<DeclContext *, 1>(&Context);
   case dwarf::DW_TAG_subprogram:
-    // Do not unique anything inside CU local functions.
+    // Do not unique anything inside CU local functions. The root context is
+    // default constructed, and DeclContext's Tag defaults to
+    // DW_TAG_compile_unit, so this covers a partial unit root too.
     if ((Context.getTag() == dwarf::DW_TAG_namespace ||
          Context.getTag() == dwarf::DW_TAG_compile_unit) &&
         !dwarf::toUnsigned(DIE.find(dwarf::DW_AT_external), 0))

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.cpp
@@ -1419,8 +1419,7 @@ std::pair<DIE *, TypeEntry *> CompileUnit::cloneDIE(
 
   bool NeedToClonePlainDIE = Info.needToKeepInPlainDwarf();
   bool NeedToCloneTypeDIE =
-      (InputDieEntry->getTag() != dwarf::DW_TAG_compile_unit) &&
-      Info.needToPlaceInTypeTable();
+      !isUnitRootDIE(InputDieIdx) && Info.needToPlaceInTypeTable();
   std::pair<DIE *, TypeEntry *> ClonedDIE;
 
   DIEGenerator PlainDIEGenerator(Allocator, *this);
@@ -1449,8 +1448,7 @@ std::pair<DIE *, TypeEntry *> CompileUnit::cloneDIE(
       (ClonedDIE.first && Info.getKeepPlainChildren());
 
   bool HasTypeChildrenToClone =
-      ((ClonedDIE.second ||
-        InputDieEntry->getTag() == dwarf::DW_TAG_compile_unit) &&
+      ((ClonedDIE.second || isUnitRootDIE(InputDieIdx)) &&
        Info.getKeepTypeChildren());
 
   // Recursively clone children.

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.h
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.h
@@ -335,6 +335,11 @@ public:
   ///
   /// @{
 
+  /// \p DieIdx index of the DIE.
+  /// \returns true if the DIE is the unit's root, which is always at index
+  /// zero, whatever tag it carries.
+  static bool isUnitRootDIE(uint32_t DieIdx) { return DieIdx == 0; }
+
   /// \p Idx index of the DIE.
   /// \returns DieInfo descriptor.
   DIEInfo &getDIEInfo(unsigned Idx) { return DieInfoArray[Idx]; }

--- a/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
@@ -106,6 +106,11 @@ void DependencyTracker::verifyKeepChain() {
 #endif
 }
 
+/// \returns true if \p Entry names a scope a DW_AT_import may refer to, whose
+/// contents that import then pulls in wholesale. Deliberately narrow: widening
+/// it to the other unit root tags makes a DW_TAG_imported_unit of a partial
+/// unit mark only the root and drop everything the imported unit holds. See
+/// dwarf5-partial-unit-imported-unit.test.
 static bool isNamespaceLikeEntry(const DWARFDebugInfoEntry *Entry) {
   switch (Entry->getTag()) {
   case dwarf::DW_TAG_compile_unit:
@@ -116,6 +121,14 @@ static bool isNamespaceLikeEntry(const DWARFDebugInfoEntry *Entry) {
   default:
     return false;
   }
+}
+
+/// \returns true if the DIE at \p Idx bounds the scope of the DIEs below it.
+/// The unit root bounds that scope whatever tag it carries, and
+/// DW_TAG_partial_unit - what dwz emits - is not namespace-like.
+static bool isUnitRootOrNamespaceLikeEntry(uint32_t Idx,
+                                           const DWARFDebugInfoEntry *Entry) {
+  return CompileUnit::isUnitRootDIE(Idx) || isNamespaceLikeEntry(Entry);
 }
 
 bool DependencyTracker::resolveDependenciesAndMarkLiveness(
@@ -482,7 +495,8 @@ void DependencyTracker::markParentsAsKeepingChildren(
         bool AddToWorklist = !isAlreadyMarked(
             ParentInfo, CompileUnit::DieOutputPlacement::TypeTable);
         ParentInfo.setKeepTypeChildren();
-        if (AddToWorklist && !isNamespaceLikeEntry(ParentEntry)) {
+        if (AddToWorklist &&
+            !isUnitRootOrNamespaceLikeEntry(*ParentIdx, ParentEntry)) {
           addActionToRootEntriesWorkList(
               LiveRootWorklistActionTy::MarkTypeChildrenRec,
               UnitEntryPairTy{Entry.CU, ParentEntry}, std::nullopt);
@@ -497,7 +511,8 @@ void DependencyTracker::markParentsAsKeepingChildren(
         bool AddToWorklist = !isAlreadyMarked(
             ParentInfo, CompileUnit::DieOutputPlacement::PlainDwarf);
         ParentInfo.setKeepPlainChildren();
-        if (AddToWorklist && !isNamespaceLikeEntry(ParentEntry)) {
+        if (AddToWorklist &&
+            !isUnitRootOrNamespaceLikeEntry(*ParentIdx, ParentEntry)) {
           addActionToRootEntriesWorkList(
               LiveRootWorklistActionTy::MarkLiveChildrenRec,
               UnitEntryPairTy{Entry.CU, ParentEntry}, std::nullopt);
@@ -952,7 +967,7 @@ DependencyTracker::getRootForSpecifiedEntry(UnitEntryPairTy Entry) {
 
     const DWARFDebugInfoEntry *ParentEntry =
         Result.CU->getDebugInfoEntry(*ParentIdx);
-    if (isNamespaceLikeEntry(ParentEntry))
+    if (isUnitRootOrNamespaceLikeEntry(*ParentIdx, ParentEntry))
       break;
     Result.DieEntry = ParentEntry;
   } while (true);

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-imported-unit.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-imported-unit.test
@@ -1,0 +1,162 @@
+## Deciding which types are deduplication candidates means asking where the
+## scope holding a type ends, and a unit root ends it whatever tag it carries.
+## Answering that with "is this entry namespace-like", which the linker already
+## had, would also answer a second question asked of the same predicate: how
+## much of an imported unit a DW_TAG_imported_unit drags in. A partial unit is
+## what dwz emits and what DW_TAG_imported_unit names, so this test pins the
+## import path against the scope change.
+##
+## U01:  namespace ns { struct S {}; }
+## U02:  // DW_TAG_imported_unit of U01
+##       void foo1() { ... }
+##
+## Nothing in U01 is referenced from U02, so the import is the only thing
+## keeping it alive and its contents disappear if the import stops recursing.
+## This test passes both before and after the fix: it exists to fail if the two
+## predicates are ever merged back together.
+##
+## Only the parallel backend is linked. The classic backend aborts on
+## DW_TAG_imported_unit in fixupForwardReferences() with "Offset being queried
+## before it's been computed", for a DW_TAG_compile_unit root just as much as
+## for a DW_TAG_partial_unit one, which makes it a separate defect from
+## anything about partial units.
+
+# RUN: yaml2obj %s -o %t.o
+# RUN: llvm-dwarfutil --linker parallel %t.o %t.out
+# RUN: llvm-dwarfdump --debug-info %t.out | FileCheck %s
+
+# CHECK:      0x[[U01:[0-9a-f]{8}]]: DW_TAG_partial_unit
+# CHECK-NEXT:   DW_AT_producer ("by_hand")
+# CHECK-NEXT:   DW_AT_name ("U01")
+# CHECK:        DW_TAG_namespace
+# CHECK-NEXT:     DW_AT_name ("ns")
+# CHECK:          DW_TAG_structure_type
+# CHECK-NEXT:       DW_AT_name ("S")
+# CHECK:      DW_TAG_compile_unit
+# CHECK-NEXT:   DW_AT_producer ("by_hand")
+# CHECK-NEXT:   DW_AT_name ("U02")
+# CHECK:        DW_TAG_imported_unit
+# CHECK-NEXT:     DW_AT_import (0x00000000[[U01]] "U01")
+# CHECK:        DW_TAG_subprogram
+# CHECK-NEXT:     DW_AT_name ("foo1")
+
+## Two DWARFv5 units. The first is a partial unit defining struct S in
+## namespace ns and holding no code; the second is a compile unit that imports
+## it and has the only function. Each root carries its own
+## DW_AT_str_offsets_base, so the strings the linker rewrites into
+## DW_FORM_strx stay resolvable on output; the linker does not synthesize that
+## attribute for a partial unit root by itself.
+--- !ELF
+FileHeader:
+  Class:    ELFCLASS64
+  Data:     ELFDATA2LSB
+  Type:     ET_REL
+  Machine:  EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1130
+    Size:            0x10
+  - Name:            .debug_str_offsets
+    Type:            SHT_PROGBITS
+    Flags:           [  ]
+    Content:        "0400000005000000"
+DWARF:
+  debug_abbrev:
+    - ID:    0
+      Table:
+      - Tag:      DW_TAG_partial_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+          - Attribute: DW_AT_str_offsets_base
+            Form:      DW_FORM_sec_offset
+      - Tag:      DW_TAG_namespace
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_str_offsets_base
+            Form:      DW_FORM_sec_offset
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+      - Tag:      DW_TAG_imported_unit
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_import
+            Form:      DW_FORM_ref_addr
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_partial
+      AbbrevTableID: 0
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: by_hand
+            - CStr: U01
+            - Value: 0x04
+            - Value: 0x8
+        - AbbrCode: 2
+          Values:
+            - CStr: ns
+        - AbbrCode: 3
+          Values:
+            - CStr: S
+            - Value: 0x8
+        - AbbrCode: 0
+        - AbbrCode: 0
+    - Version:  5
+      UnitType: DW_UT_compile
+      AbbrevTableID: 0
+      Entries:
+        - AbbrCode: 4
+          Values:
+            - CStr: by_hand
+            - CStr: U02
+            - Value: 0x04
+            - Value: 0x1130
+            - Value: 0x10
+            - Value: 0x8
+        - AbbrCode: 6
+          Values:
+            - Value: 0x0c
+        - AbbrCode: 5
+          Values:
+            - CStr: foo1
+            - Value: 0x1130
+            - Value: 0x10
+        - AbbrCode: 0
+...

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-namespace.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-namespace.test
@@ -1,0 +1,178 @@
+## A DW_TAG_partial_unit root - what dwz emits, and what Fedora, RHEL and
+## Debian debuginfo packaging therefore ships - was kept out of the artificial
+## type unit by nothing but a test on its tag, so it was cloned as a type DIE
+## and asked for the type entry that no unit root is ever assigned. Reaching
+## that point needs a scope between the type and the unit root, because the
+## walk that looks for a type's enclosing scope stops at a namespace but runs
+## past a unit root. A DW_TAG_compile_unit root is linked alongside as the
+## control.
+##
+## namespace ns {
+##   struct S { int m1; };
+## }
+##
+## ns::S foo1() { ... }
+
+# RUN: yaml2obj %s -DROOT=DW_TAG_compile_unit -DUNITTYPE=DW_UT_compile -o %t.cu.o
+# RUN: llvm-dwarfutil %t.cu.o %t.cu.classic
+# RUN: llvm-dwarfdump --debug-info %t.cu.classic | FileCheck %s --check-prefixes=CLASSIC,CLASSIC-CU
+# RUN: llvm-dwarfutil --linker parallel %t.cu.o %t.cu.parallel
+# RUN: llvm-dwarfdump --debug-info %t.cu.parallel | FileCheck %s --check-prefixes=PARALLEL,PARALLEL-CU
+
+# RUN: yaml2obj %s -DROOT=DW_TAG_partial_unit -DUNITTYPE=DW_UT_partial -o %t.pu.o
+# RUN: llvm-dwarfutil %t.pu.o %t.pu.classic
+# RUN: llvm-dwarfdump --debug-info %t.pu.classic | FileCheck %s --check-prefixes=CLASSIC,CLASSIC-PU
+# RUN: llvm-dwarfutil --linker parallel %t.pu.o %t.pu.parallel
+# RUN: llvm-dwarfdump --debug-info %t.pu.parallel | FileCheck %s --check-prefixes=PARALLEL,PARALLEL-PU
+
+## The classic backend leaves the type where it found it, and the root tag
+## survives linking. llvm-dwarfdump qualifies a type name with the names of its
+## enclosing scopes and a partial unit root is one, which a compile unit root
+## is not, so the type is printed as "U01::ns::S" for the partial unit run and
+## as "ns::S" for the control. The reference target is the same DIE either way.
+# CLASSIC-CU:     DW_TAG_compile_unit
+# CLASSIC-PU:     DW_TAG_partial_unit
+# CLASSIC:        DW_TAG_subprogram
+# CLASSIC-NEXT:     DW_AT_name ("foo1")
+# CLASSIC-CU:       DW_AT_type (0x00000000[[S:[0-9a-f]{8}]] "ns::S")
+# CLASSIC-PU:       DW_AT_type (0x00000000[[S:[0-9a-f]{8}]] "U01::ns::S")
+# CLASSIC:        DW_TAG_namespace
+# CLASSIC-NEXT:     DW_AT_name ("ns")
+# CLASSIC:      0x[[S]]:     DW_TAG_structure_type
+# CLASSIC-NEXT:   DW_AT_name ("S")
+# CLASSIC:          DW_TAG_member
+# CLASSIC-NEXT:       DW_AT_name ("m1")
+
+## The parallel backend puts the type in the artificial type unit, under a copy
+## of the namespace that held it, and the unit's reference resolves there. The
+## unit root itself stays out of that unit, which is what this pins: it has no
+## name of its own to be deduplicated under, and cloning it as a type DIE is
+## what used to crash.
+# PARALLEL:      DW_AT_name ("__artificial_type_unit")
+# PARALLEL:      DW_TAG_namespace
+# PARALLEL-NEXT:   DW_AT_name ("ns")
+# PARALLEL:      0x[[S:[0-9a-f]{8}]]:     DW_TAG_structure_type
+# PARALLEL-NEXT:   DW_AT_name ("S")
+# PARALLEL:          DW_TAG_member
+# PARALLEL-NEXT:       DW_AT_name ("m1")
+# PARALLEL-CU:   DW_TAG_compile_unit
+# PARALLEL-PU:   DW_TAG_partial_unit
+# PARALLEL-NEXT:   DW_AT_producer ("by_hand")
+# PARALLEL-NEXT:   DW_AT_name ("U01")
+# PARALLEL:      DW_TAG_subprogram
+# PARALLEL-NEXT:   DW_AT_name ("foo1")
+# PARALLEL:        DW_AT_type (0x00000000[[S]] "ns::S")
+
+## One DWARFv5 unit with a function in .text returning struct S, which is
+## defined in namespace ns. The root carries its own DW_AT_str_offsets_base, so
+## the strings the linker rewrites into DW_FORM_strx stay resolvable on output;
+## the linker does not synthesize that attribute for a partial unit root by
+## itself.
+--- !ELF
+FileHeader:
+  Class:    ELFCLASS64
+  Data:     ELFDATA2LSB
+  Type:     ET_REL
+  Machine:  EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1130
+    Size:            0x10
+  - Name:            .debug_str_offsets
+    Type:            SHT_PROGBITS
+    Flags:           [  ]
+    Content:        "0400000005000000"
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      [[ROOT]]
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_str_offsets_base
+            Form:      DW_FORM_sec_offset
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_namespace
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_member
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+          - Attribute: DW_AT_data_member_location
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+  debug_info:
+    - Version:  5
+      UnitType: [[UNITTYPE]]
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: by_hand
+            - CStr: U01
+            - Value: 0x04
+            - Value: 0x1130
+            - Value: 0x10
+            - Value: 0x8
+        - AbbrCode: 2
+          Values:
+            - CStr: foo1
+            - Value: 0x1130
+            - Value: 0x10
+            - Value: 0x4d
+        - AbbrCode: 3
+          Values:
+            - CStr: ns
+        - AbbrCode: 4
+          Values:
+            - CStr: S
+            - Value: 0x8
+        - AbbrCode: 5
+          Values:
+            - CStr: m1
+            - Value: 0x5c
+            - Value: 0x0
+        - AbbrCode: 0
+        - AbbrCode: 0
+        - AbbrCode: 6
+          Values:
+            - CStr: int
+        - AbbrCode: 0
+...

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-namespace.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-namespace.test
@@ -27,15 +27,13 @@
 
 ## The classic backend leaves the type where it found it, and the root tag
 ## survives linking. llvm-dwarfdump qualifies a type name with the names of its
-## enclosing scopes and a partial unit root is one, which a compile unit root
-## is not, so the type is printed as "U01::ns::S" for the partial unit run and
-## as "ns::S" for the control. The reference target is the same DIE either way.
+## enclosing scopes and stops that walk at either unit root, so both runs print
+## the type as "ns::S" and both resolve to the same DIE.
 # CLASSIC-CU:     DW_TAG_compile_unit
 # CLASSIC-PU:     DW_TAG_partial_unit
 # CLASSIC:        DW_TAG_subprogram
 # CLASSIC-NEXT:     DW_AT_name ("foo1")
-# CLASSIC-CU:       DW_AT_type (0x00000000[[S:[0-9a-f]{8}]] "ns::S")
-# CLASSIC-PU:       DW_AT_type (0x00000000[[S:[0-9a-f]{8}]] "U01::ns::S")
+# CLASSIC:          DW_AT_type (0x00000000[[S:[0-9a-f]{8}]] "ns::S")
 # CLASSIC:        DW_TAG_namespace
 # CLASSIC-NEXT:     DW_AT_name ("ns")
 # CLASSIC:      0x[[S]]:     DW_TAG_structure_type

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-odr.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-odr.test
@@ -16,14 +16,14 @@
 ## DW_TAG_compile_unit roots.
 # RUN: yaml2obj %s -DROOT=DW_TAG_compile_unit -DUNITTYPE=DW_UT_compile -o %t.cu.o
 # RUN: llvm-dwarfutil %t.cu.o %t.cu.classic
-# RUN: llvm-dwarfdump --debug-info %t.cu.classic | FileCheck %s --check-prefixes=CLASSIC,CLASSIC-CU --implicit-check-not=DW_TAG_structure_type
+# RUN: llvm-dwarfdump --debug-info %t.cu.classic | FileCheck %s --check-prefix=CLASSIC --implicit-check-not=DW_TAG_structure_type
 # RUN: llvm-dwarfutil --linker parallel %t.cu.o %t.cu.parallel
 # RUN: llvm-dwarfdump --debug-info %t.cu.parallel | FileCheck %s --check-prefix=PARALLEL --implicit-check-not=DW_TAG_structure_type
 
 ## DW_TAG_partial_unit roots.
 # RUN: yaml2obj %s -DROOT=DW_TAG_partial_unit -DUNITTYPE=DW_UT_partial -o %t.pu.o
 # RUN: llvm-dwarfutil %t.pu.o %t.pu.classic
-# RUN: llvm-dwarfdump --debug-info %t.pu.classic | FileCheck %s --check-prefixes=CLASSIC,CLASSIC-PU --implicit-check-not=DW_TAG_structure_type
+# RUN: llvm-dwarfdump --debug-info %t.pu.classic | FileCheck %s --check-prefix=CLASSIC --implicit-check-not=DW_TAG_structure_type
 # RUN: llvm-dwarfutil --linker parallel %t.pu.o %t.pu.parallel
 # RUN: llvm-dwarfdump --debug-info %t.pu.parallel | FileCheck %s --check-prefix=PARALLEL --implicit-check-not=DW_TAG_structure_type
 
@@ -37,18 +37,15 @@
 ## The classic backend keeps the first definition it saw and redirects the
 ## other unit's references to it, so U01 owns both definitions and U02 owns
 ## none. llvm-dwarfdump qualifies a type name with the names of its enclosing
-## scopes and a partial unit root is one, which a compile unit root is not.
-## The reference target is the same DIE either way, and that is what the
-## captured offsets pin.
+## scopes and stops that walk at either unit root, so the two runs print the
+## same names and pin the same captured offsets.
 # CLASSIC:        DW_AT_name ("U01")
 # CLASSIC:        DW_TAG_subprogram
 # CLASSIC-NEXT:     DW_AT_name ("foo1")
-# CLASSIC-CU:       DW_AT_type (0x00000000[[S:[0-9a-f]{8}]] "S")
-# CLASSIC-PU:       DW_AT_type (0x00000000[[S:[0-9a-f]{8}]] "U01::S")
+# CLASSIC:          DW_AT_type (0x00000000[[S:[0-9a-f]{8}]] "S")
 # CLASSIC:        DW_TAG_subprogram
 # CLASSIC-NEXT:     DW_AT_name ("foo2")
-# CLASSIC-CU:       DW_AT_type (0x00000000[[NSS:[0-9a-f]{8}]] "ns::S")
-# CLASSIC-PU:       DW_AT_type (0x00000000[[NSS:[0-9a-f]{8}]] "U01::ns::S")
+# CLASSIC:          DW_AT_type (0x00000000[[NSS:[0-9a-f]{8}]] "ns::S")
 # CLASSIC:      0x[[S]]:   DW_TAG_structure_type
 # CLASSIC-NEXT:   DW_AT_name ("S")
 # CLASSIC:        DW_TAG_member
@@ -66,12 +63,10 @@
 # CLASSIC:        DW_AT_name ("U02")
 # CLASSIC:        DW_TAG_subprogram
 # CLASSIC-NEXT:     DW_AT_name ("bar1")
-# CLASSIC-CU:       DW_AT_type (0x00000000[[S]] "S")
-# CLASSIC-PU:       DW_AT_type (0x00000000[[S]] "U01::S")
+# CLASSIC:          DW_AT_type (0x00000000[[S]] "S")
 # CLASSIC:        DW_TAG_subprogram
 # CLASSIC-NEXT:     DW_AT_name ("bar2")
-# CLASSIC-CU:       DW_AT_type (0x00000000[[NSS]] "ns::S")
-# CLASSIC-PU:       DW_AT_type (0x00000000[[NSS]] "U01::ns::S")
+# CLASSIC:          DW_AT_type (0x00000000[[NSS]] "ns::S")
 
 ## The parallel backend moves the deduplicated types into an artificial type
 ## unit that precedes both input units, and every reference resolves there. It

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-odr.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-odr.test
@@ -1,0 +1,334 @@
+## ODR deduplication gives every type a single definition shared by the units
+## that use it. Both backends decided which types were candidates by walking up
+## to the enclosing DW_TAG_compile_unit, so under a DW_TAG_partial_unit root -
+## what dwz emits, and what Fedora, RHEL and Debian debuginfo packaging
+## therefore ships - no type was ever a candidate and every unit kept its own
+## copy, on exactly the input where duplicate definitions are most abundant.
+##
+## The input holds two units that each define a struct S at unit scope and a
+## second, unrelated struct S inside namespace ns, and each returns both from a
+## function. A deduplicated link therefore keeps exactly two definitions, one
+## per scope, and points all four references at them; a link that stopped
+## distinguishing scopes would keep one, and a link that deduplicates nothing
+## keeps four. A DW_TAG_compile_unit root is linked alongside as the control:
+## the partial unit output below is what the compile unit output already was.
+
+## DW_TAG_compile_unit roots.
+# RUN: yaml2obj %s -DROOT=DW_TAG_compile_unit -DUNITTYPE=DW_UT_compile -o %t.cu.o
+# RUN: llvm-dwarfutil %t.cu.o %t.cu.classic
+# RUN: llvm-dwarfdump --debug-info %t.cu.classic | FileCheck %s --check-prefixes=CLASSIC,CLASSIC-CU --implicit-check-not=DW_TAG_structure_type
+# RUN: llvm-dwarfutil --linker parallel %t.cu.o %t.cu.parallel
+# RUN: llvm-dwarfdump --debug-info %t.cu.parallel | FileCheck %s --check-prefix=PARALLEL --implicit-check-not=DW_TAG_structure_type
+
+## DW_TAG_partial_unit roots.
+# RUN: yaml2obj %s -DROOT=DW_TAG_partial_unit -DUNITTYPE=DW_UT_partial -o %t.pu.o
+# RUN: llvm-dwarfutil %t.pu.o %t.pu.classic
+# RUN: llvm-dwarfdump --debug-info %t.pu.classic | FileCheck %s --check-prefixes=CLASSIC,CLASSIC-PU --implicit-check-not=DW_TAG_structure_type
+# RUN: llvm-dwarfutil --linker parallel %t.pu.o %t.pu.parallel
+# RUN: llvm-dwarfdump --debug-info %t.pu.parallel | FileCheck %s --check-prefix=PARALLEL --implicit-check-not=DW_TAG_structure_type
+
+## The same partial unit input with deduplication turned off, which is what
+## tells a deduplicated link apart from one that merely dropped a definition.
+# RUN: llvm-dwarfutil --no-odr-deduplication %t.pu.o %t.pu-noodr.classic
+# RUN: llvm-dwarfdump --debug-info %t.pu-noodr.classic | FileCheck %s --check-prefix=NOODR
+# RUN: llvm-dwarfutil --linker parallel --no-odr-deduplication %t.pu.o %t.pu-noodr.parallel
+# RUN: llvm-dwarfdump --debug-info %t.pu-noodr.parallel | FileCheck %s --check-prefix=NOODR
+
+## The classic backend keeps the first definition it saw and redirects the
+## other unit's references to it, so U01 owns both definitions and U02 owns
+## none. llvm-dwarfdump qualifies a type name with the names of its enclosing
+## scopes and a partial unit root is one, which a compile unit root is not.
+## The reference target is the same DIE either way, and that is what the
+## captured offsets pin.
+# CLASSIC:        DW_AT_name ("U01")
+# CLASSIC:        DW_TAG_subprogram
+# CLASSIC-NEXT:     DW_AT_name ("foo1")
+# CLASSIC-CU:       DW_AT_type (0x00000000[[S:[0-9a-f]{8}]] "S")
+# CLASSIC-PU:       DW_AT_type (0x00000000[[S:[0-9a-f]{8}]] "U01::S")
+# CLASSIC:        DW_TAG_subprogram
+# CLASSIC-NEXT:     DW_AT_name ("foo2")
+# CLASSIC-CU:       DW_AT_type (0x00000000[[NSS:[0-9a-f]{8}]] "ns::S")
+# CLASSIC-PU:       DW_AT_type (0x00000000[[NSS:[0-9a-f]{8}]] "U01::ns::S")
+# CLASSIC:      0x[[S]]:   DW_TAG_structure_type
+# CLASSIC-NEXT:   DW_AT_name ("S")
+# CLASSIC:        DW_TAG_member
+# CLASSIC-NEXT:     DW_AT_name ("m1")
+# CLASSIC:        DW_TAG_member
+# CLASSIC-NEXT:     DW_AT_name ("m2")
+# CLASSIC:        DW_TAG_namespace
+# CLASSIC-NEXT:     DW_AT_name ("ns")
+# CLASSIC:      0x[[NSS]]:   DW_TAG_structure_type
+# CLASSIC-NEXT:   DW_AT_name ("S")
+# CLASSIC:        DW_TAG_member
+# CLASSIC-NEXT:     DW_AT_name ("m1")
+# CLASSIC:        DW_TAG_member
+# CLASSIC-NEXT:     DW_AT_name ("m2")
+# CLASSIC:        DW_AT_name ("U02")
+# CLASSIC:        DW_TAG_subprogram
+# CLASSIC-NEXT:     DW_AT_name ("bar1")
+# CLASSIC-CU:       DW_AT_type (0x00000000[[S]] "S")
+# CLASSIC-PU:       DW_AT_type (0x00000000[[S]] "U01::S")
+# CLASSIC:        DW_TAG_subprogram
+# CLASSIC-NEXT:     DW_AT_name ("bar2")
+# CLASSIC-CU:       DW_AT_type (0x00000000[[NSS]] "ns::S")
+# CLASSIC-PU:       DW_AT_type (0x00000000[[NSS]] "U01::ns::S")
+
+## The parallel backend moves the deduplicated types into an artificial type
+## unit that precedes both input units, and every reference resolves there. It
+## emits that unit's children in its own order, namespaces before the types at
+## unit scope, rather than in the order the input listed them.
+# PARALLEL:      DW_AT_name ("__artificial_type_unit")
+# PARALLEL:      DW_TAG_namespace
+# PARALLEL-NEXT:   DW_AT_name ("ns")
+# PARALLEL:      0x[[NSS:[0-9a-f]{8}]]:   DW_TAG_structure_type
+# PARALLEL-NEXT:   DW_AT_name ("S")
+# PARALLEL:        DW_TAG_member
+# PARALLEL-NEXT:     DW_AT_name ("m1")
+# PARALLEL:        DW_TAG_member
+# PARALLEL-NEXT:     DW_AT_name ("m2")
+# PARALLEL:      0x[[S:[0-9a-f]{8}]]:   DW_TAG_structure_type
+# PARALLEL-NEXT:   DW_AT_name ("S")
+# PARALLEL:        DW_TAG_member
+# PARALLEL-NEXT:     DW_AT_name ("m1")
+# PARALLEL:        DW_TAG_member
+# PARALLEL-NEXT:     DW_AT_name ("m2")
+# PARALLEL:      DW_AT_name ("U01")
+# PARALLEL:      DW_TAG_subprogram
+# PARALLEL-NEXT:   DW_AT_name ("foo1")
+# PARALLEL:        DW_AT_type (0x00000000[[S]] "S")
+# PARALLEL:      DW_TAG_subprogram
+# PARALLEL-NEXT:   DW_AT_name ("foo2")
+# PARALLEL:        DW_AT_type (0x00000000[[NSS]] "ns::S")
+# PARALLEL:      DW_AT_name ("U02")
+# PARALLEL:      DW_TAG_subprogram
+# PARALLEL-NEXT:   DW_AT_name ("bar1")
+# PARALLEL:        DW_AT_type (0x00000000[[S]] "S")
+# PARALLEL:      DW_TAG_subprogram
+# PARALLEL-NEXT:   DW_AT_name ("bar2")
+# PARALLEL:        DW_AT_type (0x00000000[[NSS]] "ns::S")
+
+## Without deduplication each unit keeps the definitions it came in with, and
+## no artificial type unit is produced.
+# NOODR:      DW_AT_name ("U01")
+# NOODR:      DW_TAG_structure_type
+# NOODR-NEXT:   DW_AT_name ("S")
+# NOODR:      DW_TAG_namespace
+# NOODR-NEXT:   DW_AT_name ("ns")
+# NOODR:      DW_TAG_structure_type
+# NOODR-NEXT:   DW_AT_name ("S")
+# NOODR:      DW_AT_name ("U02")
+# NOODR:      DW_TAG_structure_type
+# NOODR-NEXT:   DW_AT_name ("S")
+# NOODR:      DW_TAG_namespace
+# NOODR-NEXT:   DW_AT_name ("ns")
+# NOODR:      DW_TAG_structure_type
+# NOODR-NEXT:   DW_AT_name ("S")
+# NOODR-NOT:  __artificial_type_unit
+
+## Two DWARFv5 units, each with two functions in .text, one returning the
+## struct S defined at unit scope and one returning the unrelated struct S
+## defined in namespace ns. The units cover disjoint halves of .text so that
+## neither is dropped and neither overlaps the other. Each root carries its own
+## DW_AT_str_offsets_base, so the strings the linker rewrites into
+## DW_FORM_strx stay resolvable on output; the linker does not synthesize that
+## attribute for a partial unit root by itself.
+--- !ELF
+FileHeader:
+  Class:    ELFCLASS64
+  Data:     ELFDATA2LSB
+  Type:     ET_REL
+  Machine:  EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1130
+    Size:            0x60
+  - Name:            .debug_str_offsets
+    Type:            SHT_PROGBITS
+    Flags:           [  ]
+    Content:        "0400000005000000"
+DWARF:
+  debug_abbrev:
+    - ID:    0
+      Table:
+      - Tag:      [[ROOT]]
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_str_offsets_base
+            Form:      DW_FORM_sec_offset
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_member
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+          - Attribute: DW_AT_data_member_location
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_namespace
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+  debug_info:
+    - Version:  5
+      UnitType: [[UNITTYPE]]
+      AbbrevTableID: 0
+      AbbrOffset: 0x0
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: by_hand
+            - CStr: U01
+            - Value: 0x04
+            - Value: 0x1130
+            - Value: 0x30
+            - Value: 0x8
+        - AbbrCode: 2
+          Values:
+            - CStr: foo1
+            - Value: 0x1130
+            - Value: 0x10
+            - Value: 0x63
+        - AbbrCode: 2
+          Values:
+            - CStr: foo2
+            - Value: 0x1150
+            - Value: 0x10
+            - Value: 0x7e
+        - AbbrCode: 3
+          Values:
+            - CStr: S
+            - Value: 0x8
+        - AbbrCode: 4
+          Values:
+            - CStr: m1
+            - Value: 0x96
+            - Value: 0x0
+        - AbbrCode: 4
+          Values:
+            - CStr: m2
+            - Value: 0x96
+            - Value: 0x4
+        - AbbrCode: 0
+        - AbbrCode: 6
+          Values:
+            - CStr: ns
+        - AbbrCode: 3
+          Values:
+            - CStr: S
+            - Value: 0x8
+        - AbbrCode: 4
+          Values:
+            - CStr: m1
+            - Value: 0x96
+            - Value: 0x0
+        - AbbrCode: 4
+          Values:
+            - CStr: m2
+            - Value: 0x96
+            - Value: 0x4
+        - AbbrCode: 0
+        - AbbrCode: 0
+        - AbbrCode: 5
+          Values:
+            - CStr: int
+        - AbbrCode: 0
+    - Version:  5
+      UnitType: [[UNITTYPE]]
+      AbbrevTableID: 0
+      AbbrOffset: 0x0
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: by_hand
+            - CStr: U02
+            - Value: 0x04
+            - Value: 0x1160
+            - Value: 0x30
+            - Value: 0x8
+        - AbbrCode: 2
+          Values:
+            - CStr: bar1
+            - Value: 0x1160
+            - Value: 0x10
+            - Value: 0x63
+        - AbbrCode: 2
+          Values:
+            - CStr: bar2
+            - Value: 0x1180
+            - Value: 0x10
+            - Value: 0x7e
+        - AbbrCode: 3
+          Values:
+            - CStr: S
+            - Value: 0x8
+        - AbbrCode: 4
+          Values:
+            - CStr: m1
+            - Value: 0x96
+            - Value: 0x0
+        - AbbrCode: 4
+          Values:
+            - CStr: m2
+            - Value: 0x96
+            - Value: 0x4
+        - AbbrCode: 0
+        - AbbrCode: 6
+          Values:
+            - CStr: ns
+        - AbbrCode: 3
+          Values:
+            - CStr: S
+            - Value: 0x8
+        - AbbrCode: 4
+          Values:
+            - CStr: m1
+            - Value: 0x96
+            - Value: 0x0
+        - AbbrCode: 4
+          Values:
+            - CStr: m2
+            - Value: 0x96
+            - Value: 0x4
+        - AbbrCode: 0
+        - AbbrCode: 0
+        - AbbrCode: 5
+          Values:
+            - CStr: int
+        - AbbrCode: 0
+...

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-types-only.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-types-only.test
@@ -1,0 +1,168 @@
+## A unit root is never assigned a type entry, so it is never cloned into the
+## artificial type unit and the recursion into its type children is allowed by
+## a separate test - which named DW_TAG_compile_unit only. A
+## DW_TAG_partial_unit root holding types and no code, the unit dwz produces to
+## carry the definitions it hoisted out of the compile units, therefore reached
+## neither branch and its subtree was dropped after the type name had already
+## been registered. A DW_TAG_compile_unit root is linked alongside as the
+## control.
+##
+## U01:  namespace ns { struct S {}; }
+## U02:  ns::S foo1() { ... }   // DW_FORM_ref_addr reference into U01
+##
+## The classic backend is not linked here. It fails on this input for an
+## unrelated reason, a cross-unit reference to a DIE it never gave an output
+## unit, which is a separate defect from the one this test covers.
+
+# RUN: yaml2obj %s -DROOT=DW_TAG_compile_unit -DUNITTYPE=DW_UT_compile -o %t.cu.o
+# RUN: llvm-dwarfutil --linker parallel %t.cu.o %t.cu.out
+# RUN: llvm-dwarfdump --debug-info %t.cu.out | FileCheck %s --implicit-check-not='DW_AT_name ("U01")'
+
+# RUN: yaml2obj %s -DROOT=DW_TAG_partial_unit -DUNITTYPE=DW_UT_partial -o %t.pu.o
+# RUN: llvm-dwarfutil --linker parallel %t.pu.o %t.pu.out
+# RUN: llvm-dwarfdump --debug-info %t.pu.out | FileCheck %s --check-prefixes=CHECK,CHECK-PU
+
+## The type reaches the artificial type unit under a copy of the namespace that
+## held it, and the second unit's reference resolves into the type unit rather
+## than to a dropped DIE.
+# CHECK:           DW_AT_name ("__artificial_type_unit")
+# CHECK:           DW_TAG_namespace
+# CHECK-NEXT:        DW_AT_name ("ns")
+# CHECK:         0x[[S:[0-9a-f]{8}]]:     DW_TAG_structure_type
+# CHECK-NEXT:        DW_AT_name ("S")
+# CHECK-NEXT:        DW_AT_byte_size (0x08)
+
+## The first unit is emptied either way, since its only child moved to the type
+## unit, but the two roots are then treated differently: a compile unit with
+## nothing left is dropped whole, while a partial unit root is still emitted.
+## That difference is the linker's existing behaviour for a unit with no live
+## contents, not something this fix introduces, so it is pinned rather than
+## made uniform.
+# CHECK-PU:        DW_TAG_partial_unit
+# CHECK-PU-NEXT:     DW_AT_producer ("by_hand")
+# CHECK-PU-NEXT:     DW_AT_name ("U01")
+# CHECK:           DW_TAG_compile_unit
+# CHECK-NEXT:        DW_AT_producer ("by_hand")
+# CHECK-NEXT:        DW_AT_name ("U02")
+# CHECK:           DW_TAG_subprogram
+# CHECK-NEXT:        DW_AT_name ("foo1")
+# CHECK:             DW_AT_type (0x00000000[[S]] "ns::S")
+
+## Two DWARFv5 units. The first defines struct S in namespace ns and has no
+## code of its own; the second has the only function, which returns S through a
+## DW_FORM_ref_addr reference into the first. S is deliberately memberless, so
+## that the first unit holds nothing the linker would keep in plain DWARF - a
+## member would pull in a DW_TAG_base_type, which is always kept, and that
+## alone would give the root plain children to descend for. Each root carries
+## its own DW_AT_str_offsets_base, so the strings the linker rewrites into
+## DW_FORM_strx stay resolvable on output; the linker does not synthesize that
+## attribute for a partial unit root by itself.
+--- !ELF
+FileHeader:
+  Class:    ELFCLASS64
+  Data:     ELFDATA2LSB
+  Type:     ET_REL
+  Machine:  EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1130
+    Size:            0x10
+  - Name:            .debug_str_offsets
+    Type:            SHT_PROGBITS
+    Flags:           [  ]
+    Content:        "0400000005000000"
+DWARF:
+  debug_abbrev:
+    - ID:    0
+      Table:
+      - Tag:      [[ROOT]]
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+          - Attribute: DW_AT_str_offsets_base
+            Form:      DW_FORM_sec_offset
+      - Tag:      DW_TAG_namespace
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_str_offsets_base
+            Form:      DW_FORM_sec_offset
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref_addr
+  debug_info:
+    - Version:  5
+      UnitType: [[UNITTYPE]]
+      AbbrevTableID: 0
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: by_hand
+            - CStr: U01
+            - Value: 0x04
+            - Value: 0x8
+        - AbbrCode: 2
+          Values:
+            - CStr: ns
+        - AbbrCode: 3
+          Values:
+            - CStr: S
+            - Value: 0x8
+        - AbbrCode: 0
+        - AbbrCode: 0
+    - Version:  5
+      UnitType: DW_UT_compile
+      AbbrevTableID: 0
+      Entries:
+        - AbbrCode: 4
+          Values:
+            - CStr: by_hand
+            - CStr: U02
+            - Value: 0x04
+            - Value: 0x1130
+            - Value: 0x10
+            - Value: 0x8
+        - AbbrCode: 5
+          Values:
+            - CStr: foo1
+            - Value: 0x1130
+            - Value: 0x10
+            - Value: 0x23
+        - AbbrCode: 0
+...

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-types-only.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-types-only.test
@@ -33,8 +33,8 @@
 
 ## The classic backend leaves the type where it found it, so the first unit
 ## survives and the cross-unit reference resolves to the definition under it.
-## llvm-dwarfdump qualifies a type name with the names of its enclosing scopes
-## and a partial unit root is one, which a compile unit root is not.
+## llvm-dwarfdump stops the scope walk that qualifies a type name at either
+## unit root, so both runs print the type as "ns::S".
 # CLASSIC-CU:     DW_TAG_compile_unit
 # CLASSIC-PU:     DW_TAG_partial_unit
 # CLASSIC-NEXT:     DW_AT_producer ("by_hand")
@@ -48,8 +48,7 @@
 # CLASSIC-NEXT:     DW_AT_name ("U02")
 # CLASSIC:        DW_TAG_subprogram
 # CLASSIC-NEXT:     DW_AT_name ("foo1")
-# CLASSIC-CU:       DW_AT_type (0x00000000[[S]] "ns::S")
-# CLASSIC-PU:       DW_AT_type (0x00000000[[S]] "U01::ns::S")
+# CLASSIC:          DW_AT_type (0x00000000[[S]] "ns::S")
 
 ## The type reaches the artificial type unit under a copy of the namespace that
 ## held it, and the second unit's reference resolves into the type unit rather

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-types-only.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-types-only.test
@@ -10,43 +10,66 @@
 ## U01:  namespace ns { struct S {}; }
 ## U02:  ns::S foo1() { ... }   // DW_FORM_ref_addr reference into U01
 ##
-## The classic backend is not linked here. It fails on this input for an
-## unrelated reason, a cross-unit reference to a DIE it never gave an output
-## unit, which is a separate defect from the one this test covers.
+## The classic backend links the same input. Until types under a partial unit
+## root were given a declaration context, this shape aborted there too: the
+## definition was dropped and the second unit's DW_FORM_ref_addr into it hit
+## "DIE must be owned by a DIEUnit to get its absolute offset". The compile
+## unit control was clean, so that was the same defect wearing another symptom.
 
 # RUN: yaml2obj %s -DROOT=DW_TAG_compile_unit -DUNITTYPE=DW_UT_compile -o %t.cu.o
-# RUN: llvm-dwarfutil --linker parallel %t.cu.o %t.cu.out
-# RUN: llvm-dwarfdump --debug-info %t.cu.out | FileCheck %s --implicit-check-not='DW_AT_name ("U01")'
+# RUN: llvm-dwarfutil %t.cu.o %t.cu.classic
+# RUN: llvm-dwarfdump --debug-info %t.cu.classic | FileCheck %s --check-prefixes=CLASSIC,CLASSIC-CU
+# RUN: llvm-dwarfutil --linker parallel %t.cu.o %t.cu.parallel
+# RUN: llvm-dwarfdump --debug-info %t.cu.parallel | FileCheck %s --check-prefix=PARALLEL --implicit-check-not='DW_AT_name ("U01")'
 
 # RUN: yaml2obj %s -DROOT=DW_TAG_partial_unit -DUNITTYPE=DW_UT_partial -o %t.pu.o
-# RUN: llvm-dwarfutil --linker parallel %t.pu.o %t.pu.out
-# RUN: llvm-dwarfdump --debug-info %t.pu.out | FileCheck %s --check-prefixes=CHECK,CHECK-PU
+# RUN: llvm-dwarfutil %t.pu.o %t.pu.classic
+# RUN: llvm-dwarfdump --debug-info %t.pu.classic | FileCheck %s --check-prefixes=CLASSIC,CLASSIC-PU
+# RUN: llvm-dwarfutil --linker parallel %t.pu.o %t.pu.parallel
+# RUN: llvm-dwarfdump --debug-info %t.pu.parallel | FileCheck %s --check-prefix=PARALLEL --implicit-check-not='DW_AT_name ("U01")'
+
+## The two parallel links agree byte for byte.
+# RUN: cmp %t.cu.parallel %t.pu.parallel
+
+## The classic backend leaves the type where it found it, so the first unit
+## survives and the cross-unit reference resolves to the definition under it.
+## llvm-dwarfdump qualifies a type name with the names of its enclosing scopes
+## and a partial unit root is one, which a compile unit root is not.
+# CLASSIC-CU:     DW_TAG_compile_unit
+# CLASSIC-PU:     DW_TAG_partial_unit
+# CLASSIC-NEXT:     DW_AT_producer ("by_hand")
+# CLASSIC-NEXT:     DW_AT_name ("U01")
+# CLASSIC:        DW_TAG_namespace
+# CLASSIC-NEXT:     DW_AT_name ("ns")
+# CLASSIC:      0x[[S:[0-9a-f]{8}]]:     DW_TAG_structure_type
+# CLASSIC-NEXT:   DW_AT_name ("S")
+# CLASSIC:        DW_TAG_compile_unit
+# CLASSIC-NEXT:     DW_AT_producer ("by_hand")
+# CLASSIC-NEXT:     DW_AT_name ("U02")
+# CLASSIC:        DW_TAG_subprogram
+# CLASSIC-NEXT:     DW_AT_name ("foo1")
+# CLASSIC-CU:       DW_AT_type (0x00000000[[S]] "ns::S")
+# CLASSIC-PU:       DW_AT_type (0x00000000[[S]] "U01::ns::S")
 
 ## The type reaches the artificial type unit under a copy of the namespace that
 ## held it, and the second unit's reference resolves into the type unit rather
 ## than to a dropped DIE.
-# CHECK:           DW_AT_name ("__artificial_type_unit")
-# CHECK:           DW_TAG_namespace
-# CHECK-NEXT:        DW_AT_name ("ns")
-# CHECK:         0x[[S:[0-9a-f]{8}]]:     DW_TAG_structure_type
-# CHECK-NEXT:        DW_AT_name ("S")
-# CHECK-NEXT:        DW_AT_byte_size (0x08)
+# PARALLEL:      DW_AT_name ("__artificial_type_unit")
+# PARALLEL:      DW_TAG_namespace
+# PARALLEL-NEXT:   DW_AT_name ("ns")
+# PARALLEL:      0x[[S:[0-9a-f]{8}]]:     DW_TAG_structure_type
+# PARALLEL-NEXT:   DW_AT_name ("S")
+# PARALLEL-NEXT:   DW_AT_byte_size (0x08)
 
-## The first unit is emptied either way, since its only child moved to the type
-## unit, but the two roots are then treated differently: a compile unit with
-## nothing left is dropped whole, while a partial unit root is still emitted.
-## That difference is the linker's existing behaviour for a unit with no live
-## contents, not something this fix introduces, so it is pinned rather than
-## made uniform.
-# CHECK-PU:        DW_TAG_partial_unit
-# CHECK-PU-NEXT:     DW_AT_producer ("by_hand")
-# CHECK-PU-NEXT:     DW_AT_name ("U01")
-# CHECK:           DW_TAG_compile_unit
-# CHECK-NEXT:        DW_AT_producer ("by_hand")
-# CHECK-NEXT:        DW_AT_name ("U02")
-# CHECK:           DW_TAG_subprogram
-# CHECK-NEXT:        DW_AT_name ("foo1")
-# CHECK:             DW_AT_type (0x00000000[[S]] "ns::S")
+## The first unit is emptied, since its only child moved to the type unit, and
+## a unit root with nothing left under it is dropped whole - a partial unit
+## root exactly as a compile unit root - so only the second unit survives.
+# PARALLEL:      DW_TAG_compile_unit
+# PARALLEL-NEXT:   DW_AT_producer ("by_hand")
+# PARALLEL-NEXT:   DW_AT_name ("U02")
+# PARALLEL:      DW_TAG_subprogram
+# PARALLEL-NEXT:   DW_AT_name ("foo1")
+# PARALLEL:        DW_AT_type (0x00000000[[S]] "ns::S")
 
 ## Two DWARFv5 units. The first defines struct S in namespace ns and has no
 ## code of its own; the second has the only function, which returns S through a

--- a/llvm/unittests/DebugInfo/DWARF/DWARFDieTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFDieTest.cpp
@@ -840,6 +840,136 @@ TEST(DWARFDie, DWARFTypePrinterTest) {
   testAppendQualifiedName(Ctx->getDIEForOffset(0x28), "t3<int>::my_int");
 }
 
+void testUnitRootIsNotAScope(DWARFUnit *U) {
+  ASSERT_NE(nullptr, U);
+  DWARFDie Root = U->getUnitDIE(/*ExtractUnitDIEOnly=*/false);
+  ASSERT_TRUE(Root.isValid());
+
+  DWARFDie Bar = Root.getFirstChild();
+  ASSERT_TRUE(Bar.isValid());
+  DWARFDie Namespace = Bar.getSibling();
+  ASSERT_TRUE(Namespace.isValid());
+  DWARFDie Foo = Namespace.getFirstChild();
+  ASSERT_TRUE(Foo.isValid());
+
+  testAppendQualifiedName(Bar, "Bar");
+  testAppendQualifiedName(Foo, "ns::Foo");
+}
+
+TEST(DWARFDie, DWARFTypePrinterUnitRootTest) {
+  // A unit root is not an enclosing scope, whatever tag it carries: its
+  // DW_AT_name is the path of a source file rather than an identifier. The two
+  // units below hold the same two declarations, a structure at unit scope and
+  // a structure inside a namespace, and differ only in the root tag and the
+  // matching unit type.
+
+  // 0x0000000c: DW_TAG_partial_unit
+  //               DW_AT_name      ("dwz-common.h")
+  // 0x0000001a:   DW_TAG_structure_type
+  //                 DW_AT_name    ("Bar")
+  // 0x0000001f:   DW_TAG_namespace
+  //                 DW_AT_name    ("ns")
+  // 0x00000023:     DW_TAG_structure_type
+  //                   DW_AT_name  ("Foo")
+  // 0x00000028:     NULL
+  // 0x00000029:   NULL
+  // 0x00000036: DW_TAG_compile_unit
+  //               DW_AT_name      ("main.cpp")
+  // 0x00000040:   DW_TAG_structure_type
+  //                 DW_AT_name    ("Bar")
+  // 0x00000045:   DW_TAG_namespace
+  //                 DW_AT_name    ("ns")
+  // 0x00000049:     DW_TAG_structure_type
+  //                   DW_AT_name  ("Foo")
+  // 0x0000004e:     NULL
+  // 0x0000004f:   NULL
+  const char *yamldata = R"(
+  debug_abbrev:
+    - ID:              0
+      Table:
+        - Code:            0x1
+          Tag:             DW_TAG_partial_unit
+          Children:        DW_CHILDREN_yes
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_string
+        - Code:            0x2
+          Tag:             DW_TAG_compile_unit
+          Children:        DW_CHILDREN_yes
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_string
+        - Code:            0x3
+          Tag:             DW_TAG_namespace
+          Children:        DW_CHILDREN_yes
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_string
+        - Code:            0x4
+          Tag:             DW_TAG_structure_type
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_string
+  debug_info:
+    - Version:         5
+      UnitType:        DW_UT_partial
+      AbbrevTableID:   0
+      Entries:
+        - AbbrCode:        0x1
+          Values:
+            - CStr:            dwz-common.h
+        - AbbrCode:        0x4
+          Values:
+            - CStr:            Bar
+        - AbbrCode:        0x3
+          Values:
+            - CStr:            ns
+        - AbbrCode:        0x4
+          Values:
+            - CStr:            Foo
+        - AbbrCode:        0x0
+        - AbbrCode:        0x0
+    - Version:         5
+      UnitType:        DW_UT_compile
+      AbbrevTableID:   0
+      Entries:
+        - AbbrCode:        0x2
+          Values:
+            - CStr:            main.cpp
+        - AbbrCode:        0x4
+          Values:
+            - CStr:            Bar
+        - AbbrCode:        0x3
+          Values:
+            - CStr:            ns
+        - AbbrCode:        0x4
+          Values:
+            - CStr:            Foo
+        - AbbrCode:        0x0
+        - AbbrCode:        0x0)";
+  Expected<StringMap<std::unique_ptr<MemoryBuffer>>> Sections =
+      DWARFYAML::emitDebugSections(StringRef(yamldata),
+                                   /*IsLittleEndian=*/true,
+                                   /*Is64BitAddrSize=*/true);
+  ASSERT_THAT_EXPECTED(Sections, Succeeded());
+  std::unique_ptr<DWARFContext> Ctx =
+      DWARFContext::create(*Sections, 4, /*isLittleEndian=*/true);
+  ASSERT_EQ(2u, Ctx->getNumCompileUnits());
+
+  DWARFUnit *PartialUnit = Ctx->getUnitAtIndex(0);
+  ASSERT_NE(nullptr, PartialUnit);
+  EXPECT_EQ(dwarf::DW_TAG_partial_unit,
+            PartialUnit->getUnitDIE(/*ExtractUnitDIEOnly=*/false).getTag());
+  testUnitRootIsNotAScope(PartialUnit);
+
+  DWARFUnit *CompileUnit = Ctx->getUnitAtIndex(1);
+  ASSERT_NE(nullptr, CompileUnit);
+  EXPECT_EQ(dwarf::DW_TAG_compile_unit,
+            CompileUnit->getUnitDIE(/*ExtractUnitDIEOnly=*/false).getTag());
+  testUnitRootIsNotAScope(CompileUnit);
+}
+
 TEST(DWARFDie, getLanguage) {
   const char *yamldata = R"(
     debug_abbrev:


### PR DESCRIPTION
**Summary**

- **Broken:** `DWARFTypePrinter::appendScopes` must stop the scope walk at any unit root. It stops at `DW_TAG_compile_unit`, `DW_TAG_type_unit` and `DW_TAG_skeleton_unit` only, in error missing `DW_TAG_partial_unit`. A partial unit's declarations take their containing scope from the entries that import it, not from the unit itself (DWARFv5 spec §3.1.1), but the walk takes such a root for an ordinary scope and prefixes the type name with its `DW_AT_name`, a source file path: `dwz-common.h::Foo` where the control names it `Foo`.
- **Fix:** stop the walk at any unit root.
- **Implementation:** `dwarf::isUnitType()` replaced the three tag comparisons, both instantiations pass a `dwarf::Tag` so neither picks up the `uint8_t` overload, and the `DW_TAG_subprogram` and `DW_TAG_lexical_block` stops below are unrelated and stay.

Depends on #219615 and #219619.

#219615 and #219619 add the three `llvm-dwarfutil` tests whose classic runs print the type names this change corrects, so the CHECK-line update lands here rather than in either of them. All three patches are green on their own bases today, and any other landing order would have broken the tree.

The update is a collapse. `dwarf5-partial-unit-namespace.test`, `dwarf5-partial-unit-odr.test` and `dwarf5-partial-unit-types-only.test` each pinned the root-qualified spelling for their partial unit run, as a known-wrong observation that was out of scope in the patches that added them. With the scope walk stopping at the root, the two classic runs in each test print the same names whatever tag the root carries, so every paired `CLASSIC-CU` and `CLASSIC-PU` line becomes a single `CLASSIC` line checked against both. `dwarf5-partial-unit-odr.test` has no other use for those two prefixes and drops them from its RUN lines.

`DWARFTypePrinter::appendScopes` builds a type's qualified name by walking up its parents and prefixing each enclosing scope. It recognizes a unit root by tag, and it enumerates `DW_TAG_compile_unit`, `DW_TAG_type_unit` and `DW_TAG_skeleton_unit`. `DW_TAG_partial_unit`, the fourth unit root tag and the one `dwz` produces, is absent, so the walk does not stop there. It takes the root for an ordinary enclosing scope and emits the root's `DW_AT_name`, a source file path, as the outermost component of the name:

```console
$ llvm-dwarfdump --debug-info pu.o
0x00000029:   DW_TAG_subprogram
                DW_AT_name	("foo")
                DW_AT_type	(0x0000003e "dwz-common.h::Foo")
```

The control, the same input with only the root tag and its matching unit type changed, names it `Foo`. `dwz` is a standard step in Fedora, RHEL and Debian debuginfo packaging, so this is the ordinary shape of a distribution debuginfo file rather than a corner case. It reproduces on stock Fedora `llvm-dwarfdump` 22.1.8 and involves no linking at all.

**Specification.** DWARFv5 §3.1.1 says that for a partial compilation unit "the containing scope of its owned declarations is indicated by imported unit entries in one or more other compilation unit entries that refer to that partial compilation unit". The scope comes from the importers, not from the partial unit, so its root contributes no scope component of its own. §3.1.1 item 2 says the root's `DW_AT_name` is the path of the primary source file, which is not an identifier under any reading, and it is the same attribute for both root tags — which is why nothing downstream can tell the difference once it has been emitted as a scope. §3.2.2 settles what the name should be instead: the C++ global namespace has no DWARF entry at all, so a type directly under a unit root has no scope component above it.

**The fix.** `dwarf::isUnitType()` already answers exactly this question for all four unit root tags, so it replaces the three comparisons. The `DW_TAG_subprogram` and `DW_TAG_lexical_block` stops below it are unrelated and stay as they are. Both instantiations of the printer pass a `dwarf::Tag` — LLDB's `dw_tag_t` is a typedef for it — so neither picks up the `uint8_t` overload that compares tag numbers against the `DW_UT_*` codes.

**Tests.** A new `DWARFDie.DWARFTypePrinterUnitRootTest` in `DWARFDieTest.cpp`, alongside the existing printer tests, builds one index-free object holding two units that differ only in the root tag and the unit type. Each carries a structure at unit scope and a structure inside a namespace, so the partial unit case is pinned against a compile unit control and against a scope that must still be printed: a fix that stopped the walk unconditionally would name the second one `Foo` rather than `ns::Foo`.

The printer has two other consumers that share this root cause and are not covered here. `makeSimpleTemplateNameWithParams` (`Classic/DWARFLinkerDeclContext.cpp`) puts the qualified name of every template type parameter into the classic DWARFLinker's ODR key, so an instantiation whose argument lives under a partial unit root does not unique against the same instantiation from another object; LLDB computes simple template names the same way in `DWARFASTParserClang.cpp`. Both follow from the same walk and neither has a reproducer here.

Fixes #219635.

This change was produced with AI assistance; I have reviewed it and am accountable for it.

Assisted-by: Claude Code

