### PR TITLE
[AArch64] Fix crash parsing an operand with both :specifier: and `@specifier`

### DIFF
--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -4480,7 +4480,8 @@ bool AArch64AsmParser::parseSymbolicImmVal(const MCExpr *&ImmVal) {
     ImmVal = MCSpecifierExpr::create(ImmVal, RefKind, getContext(), Loc);
 
   SMLoc EndLoc;
-  if (getContext().getAsmInfo().hasSubsectionsViaSymbols()) {
+  // :specifier: and @specifier are alternative syntaxes; nesting them is invalid.
+  if (!HasELFModifier && getContext().getAsmInfo().hasSubsectionsViaSymbols()) {
     if (getParser().parseAtSpecifier(ImmVal, EndLoc))
       return true;
     const MCExpr *Term;

--- a/llvm/test/MC/AArch64/arm64-diags.s
+++ b/llvm/test/MC/AArch64/arm64-diags.s
@@ -369,6 +369,9 @@ subs x20, x30, sym@PAGEOFF
 add w3, w5, sym@PAGEOFF - 3-2
 ; CHECK-ERRORS: [[#@LINE-1]]:28: error: unexpected token in argument list
 
+add x3, x5, :lo12:sym@PAGEOFF
+; CHECK-ERRORS: [[#@LINE-1]]:22: error: unexpected token in argument list
+
 tbl v0.8b, { v1 }, v0.8b
 tbl v0.16b, { v1.8b, v2.8b, v3.8b }, v0.16b
 tbx v3.16b, { v12.8b, v13.8b, v14.8b }, v6.8b


### PR DESCRIPTION
`add x3, x5, :lo12:sym@PAGEOFF` hits llvm_unreachable in applySpecifier:
Mach-O accepts both ELF style `:specifier:` and its own `@specifier`.
When an ELF-style :specifier already wraps the expression,
applySpecifier then receives an unexpected MCSpecifierExpr.

Parse `@specifier` only when no :specifier: is present.