### PR TITLE
[lld][MachO] Fix ObjC stubs from autolinked archives

### DIFF
--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -2453,7 +2453,6 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
 
     createSyntheticSections();
     createSyntheticSymbols();
-    addSynthenticMethnames();
 
     createAliases();
     // If we are in "explicit exports" mode, hide everything that isn't
@@ -2470,6 +2469,8 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
     // compileBitcodeFiles, so we are done if that's the case.
     if (config->thinLTOIndexOnly || config->emitLLVM)
       return errorCount() == 0;
+
+    addSynthenticMethnames();
 
     // LTO may emit a non-hidden (extern) object file symbol even if the
     // corresponding bitcode symbol is hidden. In particular, this happens for

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -2441,7 +2441,6 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
 
     createSyntheticSections();
     createSyntheticSymbols();
-    addSynthenticMethnames();
 
     createAliases();
     // If we are in "explicit exports" mode, hide everything that isn't
@@ -2458,6 +2457,8 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
     // compileBitcodeFiles, so we are done if that's the case.
     if (config->thinLTOIndexOnly || config->emitLLVM)
       return errorCount() == 0;
+
+    addSynthenticMethnames();
 
     // LTO may emit a non-hidden (extern) object file symbol even if the
     // corresponding bitcode symbol is hidden. In particular, this happens for

--- a/lld/test/MachO/arm64-objc-stubs-autolink.s
+++ b/lld/test/MachO/arm64-objc-stubs-autolink.s
@@ -1,0 +1,35 @@
+# REQUIRES: aarch64
+
+# RUN: rm -rf %t && split-file %s %t
+# RUN: llvm-mc -filetype=obj -triple=arm64-apple-darwin %t/main.s \
+# RUN:   -o %t/main.o
+# RUN: llvm-mc -filetype=obj -triple=arm64-apple-darwin %t/dep.s \
+# RUN:   -o %t/dep.o
+# RUN: llvm-ar rcs %t/libdep.a %t/dep.o
+# RUN: %lld -arch arm64 -lSystem -o %t/out %t/main.o -L%t \
+# RUN:   -objc_stubs_fast -U _objc_msgSend
+# RUN: llvm-objdump --no-show-raw-insn --section=__TEXT,__objc_stubs \
+# RUN:   --macho %t/out | FileCheck %s
+
+# CHECK:      Contents of (__TEXT,__objc_stubs) section
+# CHECK-NEXT: _objc_msgSend$plain:
+# CHECK-NEXT: adrp    x1,
+# CHECK-NEXT: ldr     x1, {{.*}} ; Objc selector ref: plain
+# CHECK-NEXT: adrp    x16,
+# CHECK-NEXT: ldr     x16, {{.*}} ; literal pool symbol address: _objc_msgSend
+# CHECK-NEXT: br      x16
+
+#--- main.s
+.linker_option "-ldep"
+.text
+.globl _main
+_main:
+  bl _dep
+  ret
+
+#--- dep.s
+.text
+.globl _dep
+_dep:
+  bl _objc_msgSend$plain
+  ret


### PR DESCRIPTION
Move ObjC stub preparation after LC_LINKER_OPTION processing so archive members loaded through autolink can contribute `_objc_msgSend$` selector stubs before selector references are finalized.

Otherwise, stubs discovered from autolinked archives may not get matching `__objc_methname` and `__objc_selrefs` entries needed during stub emission.
