### PR TITLE
[clang][Sema] Crash due to asm labeled incomplete global register decls

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -511,6 +511,7 @@ features cannot lower the translation-unit ABI level;
 - Fixed a crash when declaring a member template within a local class inside an OpenMP region. (#GH216052)
 - Fixed a bug where repeated #imports of modular headers in non-modular compilation were translated to #pragma clang module import. (#GH216924)
 - Fixed an assertion when `#pragma omp declare simd` or `#pragma omp declare variant` is followed by another OpenMP declarative directive containing a qualified identifier. (#GH217204)
+- Fixed a crash when an `asm` label names the register for a global variable of incomplete type. (#GH219746)
 
 #### Bug Fixes to Compiler Builtins
 

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -7756,6 +7756,8 @@ void Sema::CheckAsmLabel(Scope *S, Expr *E, StorageClass SC,
   StringLiteral *SE = cast<StringLiteral>(E);
   StringRef Label = SE->getString();
   QualType R = TInfo->getType();
+  if (R->isIncompleteType())
+    return;
   if (S->getFnParent() != nullptr) {
     switch (SC) {
     case SC_None:

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -7760,6 +7760,8 @@ void Sema::CheckAsmLabel(Scope *S, Expr *E, StorageClass SC,
   StringLiteral *SE = cast<StringLiteral>(E);
   StringRef Label = SE->getString();
   QualType R = TInfo->getType();
+  if (R->isIncompleteType())
+    return;
   if (S->getFnParent() != nullptr) {
     switch (SC) {
     case SC_None:

--- a/clang/test/Sema/global-explicit-register-undefined-type.c
+++ b/clang/test/Sema/global-explicit-register-undefined-type.c
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 %s -triple arm64-apple-macosx -fsyntax-only -verify
+
+register struct Undefined1 bar1 asm("x1"); // #inline-type-def
+// expected-error@#inline-type-def {{tentative definition has type 'struct Undefined1' that is never completed}}
+// expected-note@#inline-type-def {{forward declaration of 'struct Undefined1'}}
+struct Undefined2; // #outline-type-def
+register struct Undefined2 bar2 asm("x1"); // #outline-type-label
+// expected-error@#outline-type-label {{tentative definition has type 'struct Undefined2' that is never completed}}
+// expected-note@#outline-type-def {{forward declaration of 'struct Undefined2'}}

--- a/clang/test/Sema/global-explicit-register-undefined-type.c
+++ b/clang/test/Sema/global-explicit-register-undefined-type.c
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 %s -triple arm64-apple-macosx -fsyntax-only -verify
+
+register struct Undefined1 bar1 asm("x1"); // #inline-type-def
+// expected-error@#inline-type-def {{tentative definition has type 'struct Undefined1' that is never completed}}
+// expected-note@#inline-type-def {{forward declaration of 'struct Undefined1'}}
+struct Undefined2; // #outline-type-def
+register struct Undefined2 bar2 asm("x1"); // #outline-type-label
+// expected-error@#outline-type-label {{tentative definition has type 'struct Undefined2' that is never completed}}
+// expected-note@#outline-type-def {{forward declaration of 'struct Undefined2'}}
+
+register struct Undefined3 *bar3 asm("x1"); // #invalid-type
+
+struct ToBeDefined;
+register struct ToBeDefined bar4 asm("x1");
+struct ToBeDefined { double d; int i; };
+
+register struct ToBeDefined bar5 asm("x1");


### PR DESCRIPTION
CheckAsmLabel fails to check for an incomplete type before attempting to get the type layout. Short circuit on an incomplete type as Sema will already reject a global with an incomplete type.