### PR TITLE
[DWARFLinker][Parallel] Stop the qualified name walk at the unit root

### DIFF
--- a/llvm/lib/DWARFLinker/Parallel/AcceleratorRecordsSaver.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/AcceleratorRecordsSaver.cpp
@@ -51,7 +51,8 @@ static uint32_t hashFullyQualifiedName(CompileUnit &InputCU, DWARFDie &InputDIE,
     Name = "(anonymous namespace)";
 
   DWARFDie ParentDie = InputDIE.getParent();
-  if (!ParentDie.isValid() || ParentDie.getTag() == dwarf::DW_TAG_compile_unit)
+  if (!ParentDie.isValid() ||
+      CompileUnit::isUnitRootDIE(CU->getDIEIndex(ParentDie)))
     return djbHash(Name ? Name : "", djbHash(ChildRecurseDepth ? "" : "::"));
 
   return djbHash(
@@ -64,6 +65,13 @@ void AcceleratorRecordsSaver::save(const DWARFDebugInfoEntry *InputDieEntry,
                                    DIE *OutDIE, AttributesInfo &AttrInfo,
                                    TypeEntry *TypeEntry) {
   if (GlobalData.getOptions().AccelTables.empty())
+    return;
+
+  // A unit root's DW_AT_name is the path of a source file rather than an
+  // identifier, so it is never an accelerator record. Index zero is the unit
+  // root whatever tag it carries, which is the invariant a tag comparison
+  // against DW_TAG_compile_unit alone stood in for.
+  if (CompileUnit::isUnitRootDIE(InUnit.getDIEIndex(InputDieEntry)))
     return;
 
   DWARFDie InputDIE = InUnit.getDIE(InputDieEntry);
@@ -156,7 +164,6 @@ void AcceleratorRecordsSaver::save(const DWARFDebugInfoEntry *InputDieEntry,
       saveNamespaceRecord(InputDieEntry, AttrInfo.Name, OutDIE,
                           InputDieEntry->getTag(), TypeEntry);
   } break;
-  case dwarf::DW_TAG_compile_unit:
   case dwarf::DW_TAG_lexical_block: {
     // Nothing to do.
   } break;

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.cpp
@@ -1419,8 +1419,7 @@ std::pair<DIE *, TypeEntry *> CompileUnit::cloneDIE(
 
   bool NeedToClonePlainDIE = Info.needToKeepInPlainDwarf();
   bool NeedToCloneTypeDIE =
-      (InputDieEntry->getTag() != dwarf::DW_TAG_compile_unit) &&
-      Info.needToPlaceInTypeTable();
+      !isUnitRootDIE(InputDieIdx) && Info.needToPlaceInTypeTable();
   std::pair<DIE *, TypeEntry *> ClonedDIE;
 
   DIEGenerator PlainDIEGenerator(Allocator, *this);
@@ -1449,8 +1448,7 @@ std::pair<DIE *, TypeEntry *> CompileUnit::cloneDIE(
       (ClonedDIE.first && Info.getKeepPlainChildren());
 
   bool HasTypeChildrenToClone =
-      ((ClonedDIE.second ||
-        InputDieEntry->getTag() == dwarf::DW_TAG_compile_unit) &&
+      ((ClonedDIE.second || isUnitRootDIE(InputDieIdx)) &&
        Info.getKeepTypeChildren());
 
   // Recursively clone children.

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.h
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.h
@@ -335,6 +335,11 @@ public:
   ///
   /// @{
 
+  /// \p DieIdx index of the DIE.
+  /// \returns true if the DIE is the unit's root, which is always at index
+  /// zero, whatever tag it carries.
+  static bool isUnitRootDIE(uint32_t DieIdx) { return DieIdx == 0; }
+
   /// \p Idx index of the DIE.
   /// \returns DieInfo descriptor.
   DIEInfo &getDIEInfo(unsigned Idx) { return DieInfoArray[Idx]; }

--- a/llvm/test/tools/dsymutil/X86/apple-types-qualified-name-hash-partial-unit.s
+++ b/llvm/test/tools/dsymutil/X86/apple-types-qualified-name-hash-partial-unit.s
@@ -1,0 +1,181 @@
+## The Apple accelerator tables carry a DW_ATOM_qual_name_hash for every type,
+## a hash of the type's fully qualified name built by walking up the parents and
+## stopping at the unit root. A partial unit is a unit root that contributes no
+## scope of its own: DWARFv5 section 3.1.1 places the containing scope of a
+## partial unit's declarations at the entries that import it, not at the unit,
+## and section 3.1.1 item 2 makes the root's own DW_AT_name a source file path
+## rather than an identifier. The walk therefore has to end on a partial unit
+## root exactly as it does on a compile unit root, and the hash has to come out
+## the same either way.
+
+# RUN: llvm-mc -triple x86_64-apple-darwin -filetype=obj --defsym ROOT=17 --defsym UNITTYPE=1 %s -o %t.cu.o
+# RUN: llvm-mc -triple x86_64-apple-darwin -filetype=obj --defsym ROOT=60 --defsym UNITTYPE=3 %s -o %t.pu.o
+
+# RUN: echo '---' > %t.cu.map
+# RUN: echo "triple:          'x86_64-apple-darwin'" >> %t.cu.map
+# RUN: echo 'objects:'  >> %t.cu.map
+# RUN: echo " -  filename: '%t.cu.o'" >> %t.cu.map
+# RUN: echo '    symbols:' >> %t.cu.map
+# RUN: echo '      - { sym: _foo, objAddr: 0x0, binAddr: 0x10000, size: 0x1 }' >> %t.cu.map
+# RUN: echo '...' >> %t.cu.map
+
+# RUN: echo '---' > %t.pu.map
+# RUN: echo "triple:          'x86_64-apple-darwin'" >> %t.pu.map
+# RUN: echo 'objects:'  >> %t.pu.map
+# RUN: echo " -  filename: '%t.pu.o'" >> %t.pu.map
+# RUN: echo '    symbols:' >> %t.pu.map
+# RUN: echo '      - { sym: _foo, objAddr: 0x0, binAddr: 0x10000, size: 0x1 }' >> %t.pu.map
+# RUN: echo '...' >> %t.pu.map
+
+# RUN: dsymutil --linker=parallel -accelerator=Apple --verify-dwarf=all -y %t.cu.map -f -o %t.cu.parallel.dSYM
+# RUN: llvm-dwarfdump --apple-types %t.cu.parallel.dSYM | FileCheck %s
+
+# RUN: dsymutil --linker=parallel -accelerator=Apple --verify-dwarf=none -y %t.pu.map -f -o %t.pu.parallel.dSYM
+# RUN: llvm-dwarfdump --apple-types %t.pu.parallel.dSYM | FileCheck %s
+
+# RUN: dsymutil --linker=classic -accelerator=Apple --verify-dwarf=all -y %t.cu.map -f -o %t.cu.classic.dSYM
+# RUN: llvm-dwarfdump --apple-types %t.cu.classic.dSYM | FileCheck %s
+
+# RUN: dsymutil --linker=classic -accelerator=Apple --verify-dwarf=none -y %t.pu.map -f -o %t.pu.classic.dSYM
+# RUN: llvm-dwarfdump --apple-types %t.pu.classic.dSYM | FileCheck %s
+
+## The two partial unit runs disable output verification, which is unrelated to
+## the hash. Both backends leave a partial unit root without a
+## DW_AT_str_offsets_base and record DW_UT_compile in the unit header whatever
+## the root tag is, so --verify rejects either output on grounds this test is
+## not about. That is issue #219365. The compile unit control runs ask for
+## verification explicitly instead of relying on the default, which dsymutil
+## enables only in assertions builds, so the input and the tool are held to it
+## in every configuration.
+
+## One CHECK block serves all four runs, which is the claim being made: the two
+## backends agree with each other, and neither varies with the root tag. Atom[0]
+## is the output DIE offset and is deliberately left unmatched, since the two
+## backends lay out the linked unit differently.
+
+## Foo sits at unit scope, so its qualified name is "Foo" alone and the root
+## contributes nothing to it. Bar sits inside a namespace, so "ns" has to be
+## folded in. The pair is what separates ending the walk at the unit root from
+## ending it unconditionally: a fix that simply stopped recursing would get Foo
+## right and Bar wrong.
+
+## Bucket assignment is the djb hash of the short name, so the two names land in
+## this order in every run.
+
+# CHECK:      String: {{.*}} "Bar"
+# CHECK-NEXT: Data 0 [
+# CHECK-NEXT:   Atom[0]:
+# CHECK-NEXT:   Atom[1]: 0x0013 (DW_TAG_structure_type)
+# CHECK-NEXT:   Atom[2]: 0x00
+# CHECK-NEXT:   Atom[3]: 0x27c1798f
+
+# CHECK:      String: {{.*}} "Foo"
+# CHECK-NEXT: Data 0 [
+# CHECK-NEXT:   Atom[0]:
+# CHECK-NEXT:   Atom[1]: 0x0013 (DW_TAG_structure_type)
+# CHECK-NEXT:   Atom[2]: 0x00
+# CHECK-NEXT:   Atom[3]: 0x0c3993dd
+
+	.section	__TEXT,__text,regular,pure_instructions
+	.globl	_foo
+_foo:
+Lfunc_begin0:
+	retq
+Lfunc_end0:
+
+	.section	__DWARF,__debug_abbrev,regular,debug
+Lsection_abbrev:
+	.byte	1                       ## Abbreviation Code
+	.byte	ROOT                    ## DW_TAG_compile_unit / DW_TAG_partial_unit
+	.byte	1                       ## DW_CHILDREN_yes
+	.byte	37                      ## DW_AT_producer
+	.byte	8                       ## DW_FORM_string
+	.byte	19                      ## DW_AT_language
+	.byte	5                       ## DW_FORM_data2
+	.byte	3                       ## DW_AT_name
+	.byte	8                       ## DW_FORM_string
+	.byte	0, 0
+
+	.byte	2                       ## Abbreviation Code
+	.byte	46                      ## DW_TAG_subprogram
+	.byte	1                       ## DW_CHILDREN_yes
+	.byte	3                       ## DW_AT_name
+	.byte	8                       ## DW_FORM_string
+	.byte	73                      ## DW_AT_type
+	.byte	19                      ## DW_FORM_ref4
+	.byte	17                      ## DW_AT_low_pc
+	.byte	1                       ## DW_FORM_addr
+	.byte	18                      ## DW_AT_high_pc
+	.byte	6                       ## DW_FORM_data4
+	.byte	0, 0
+
+	.byte	3                       ## Abbreviation Code
+	.byte	5                       ## DW_TAG_formal_parameter
+	.byte	0                       ## DW_CHILDREN_no
+	.byte	3                       ## DW_AT_name
+	.byte	8                       ## DW_FORM_string
+	.byte	73                      ## DW_AT_type
+	.byte	19                      ## DW_FORM_ref4
+	.byte	0, 0
+
+	.byte	4                       ## Abbreviation Code
+	.byte	19                      ## DW_TAG_structure_type
+	.byte	0                       ## DW_CHILDREN_no
+	.byte	3                       ## DW_AT_name
+	.byte	8                       ## DW_FORM_string
+	.byte	11                      ## DW_AT_byte_size
+	.byte	11                      ## DW_FORM_data1
+	.byte	0, 0
+
+	.byte	5                       ## Abbreviation Code
+	.byte	57                      ## DW_TAG_namespace
+	.byte	1                       ## DW_CHILDREN_yes
+	.byte	3                       ## DW_AT_name
+	.byte	8                       ## DW_FORM_string
+	.byte	0, 0
+
+	.byte	0                       ## EOM(3)
+
+	.section	__DWARF,__debug_info,regular,debug
+Lsection_info:
+	.long	Lcu_end - Lcu_start     ## Length of Unit
+Lcu_start:
+	.short	5                       ## DWARF version number
+	.byte	UNITTYPE                ## DW_UT_compile / DW_UT_partial
+	.byte	8                       ## Address Size (in bytes)
+	.long	0                       ## Offset Into Abbrev. Section
+
+	.byte	1                       ## Abbrev [1] root
+	.asciz	"hand-written"          ## DW_AT_producer
+	.short	0x0004                  ## DW_AT_language (DW_LANG_C_plus_plus)
+	.asciz	"dwz-common.h"          ## DW_AT_name
+
+	.byte	2                       ## Abbrev [2] DW_TAG_subprogram
+	.asciz	"foo"                   ## DW_AT_name
+	.long	Lfootype - Lsection_info ## DW_AT_type
+	.quad	Lfunc_begin0            ## DW_AT_low_pc
+	.long	Lfunc_end0 - Lfunc_begin0 ## DW_AT_high_pc
+
+	.byte	3                       ## Abbrev [3] DW_TAG_formal_parameter
+	.asciz	"b"                     ## DW_AT_name
+	.long	Lbartype - Lsection_info ## DW_AT_type
+
+	.byte	0                       ## End Of Children Mark (subprogram)
+
+Lfootype:
+	.byte	4                       ## Abbrev [4] DW_TAG_structure_type
+	.asciz	"Foo"                   ## DW_AT_name
+	.byte	8                       ## DW_AT_byte_size
+
+	.byte	5                       ## Abbrev [5] DW_TAG_namespace
+	.asciz	"ns"                    ## DW_AT_name
+
+Lbartype:
+	.byte	4                       ## Abbrev [4] DW_TAG_structure_type
+	.asciz	"Bar"                   ## DW_AT_name
+	.byte	4                       ## DW_AT_byte_size
+
+	.byte	0                       ## End Of Children Mark (namespace)
+
+	.byte	0                       ## End Of Children Mark (root)
+Lcu_end:

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-accelerator-root-name.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-accelerator-root-name.test
@@ -1,0 +1,106 @@
+## A unit root's DW_AT_name is a source file path, not an identifier, so it must
+## never become an accelerator name record. The parallel backend decided that by
+## testing the root's tag against DW_TAG_compile_unit, which a DW_TAG_partial_unit
+## root - what dwz emits, and what Fedora, RHEL and Debian debuginfo packaging
+## therefore ships - does not match. The partial unit root fell through to the arm
+## that emits a name record for any DIE carrying a live address or a range, and a
+## unit root carries DW_AT_low_pc, so the file path was indexed as though it were
+## an identifier. A DW_TAG_compile_unit root is linked alongside as the control.
+
+# RUN: yaml2obj %s -DROOT=DW_TAG_compile_unit -DUNITTYPE=DW_UT_compile -o %t.cu.o
+# RUN: llvm-dwarfutil --linker parallel --build-accelerator=DWARF %t.cu.o %t.cu.out
+# RUN: llvm-dwarfdump --debug-names %t.cu.out | FileCheck %s
+
+# RUN: yaml2obj %s -DROOT=DW_TAG_partial_unit -DUNITTYPE=DW_UT_partial -o %t.pu.o
+# RUN: llvm-dwarfutil --linker parallel --build-accelerator=DWARF %t.pu.o %t.pu.out
+# RUN: llvm-dwarfdump --debug-names %t.pu.out | FileCheck %s
+
+## One CHECK block serves both runs, which is the claim being made: the name
+## table does not vary with the root tag. The count and the two identifications
+## together are what excludes the root's name: if "U01" were indexed the count
+## would be three, and pinning the count alone would not say which names
+## survived. The CHECK-NOT is belt and braces on top of that.
+
+# CHECK:      Name count: 2
+# CHECK-DAG:  String: {{.*}} "foo1"
+# CHECK-DAG:  String: {{.*}} "int"
+# CHECK-NOT:  "U01"
+
+## One DWARFv5 unit with a function in .text returning int. The root carries
+## DW_AT_low_pc, which is what sets the live-address flag that the emitting arm
+## keys on, and its own DW_AT_str_offsets_base, so the strings the linker
+## rewrites into DW_FORM_strx stay resolvable on output; the linker does not
+## synthesize that attribute for a partial unit root by itself.
+--- !ELF
+FileHeader:
+  Class:    ELFCLASS64
+  Data:     ELFDATA2LSB
+  Type:     ET_REL
+  Machine:  EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1130
+    Size:            0x10
+  - Name:            .debug_str_offsets
+    Type:            SHT_PROGBITS
+    Flags:           [  ]
+    Content:        "0400000005000000"
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      [[ROOT]]
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_str_offsets_base
+            Form:      DW_FORM_sec_offset
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+  debug_info:
+    - Version:  5
+      UnitType: [[UNITTYPE]]
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: by_hand
+            - CStr: U01
+            - Value: 0x04
+            - Value: 0x1130
+            - Value: 0x10
+            - Value: 0x8
+        - AbbrCode: 2
+          Values:
+            - CStr: foo1
+            - Value: 0x1130
+            - Value: 0x10
+            - Value: 0x49
+        - AbbrCode: 3
+          Values:
+            - CStr: int
+        - AbbrCode: 0
+...

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-namespace.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-namespace.test
@@ -1,0 +1,178 @@
+## A DW_TAG_partial_unit root - what dwz emits, and what Fedora, RHEL and
+## Debian debuginfo packaging therefore ships - was kept out of the artificial
+## type unit by nothing but a test on its tag, so it was cloned as a type DIE
+## and asked for the type entry that no unit root is ever assigned. Reaching
+## that point needs a scope between the type and the unit root, because the
+## walk that looks for a type's enclosing scope stops at a namespace but runs
+## past a unit root. A DW_TAG_compile_unit root is linked alongside as the
+## control.
+##
+## namespace ns {
+##   struct S { int m1; };
+## }
+##
+## ns::S foo1() { ... }
+
+# RUN: yaml2obj %s -DROOT=DW_TAG_compile_unit -DUNITTYPE=DW_UT_compile -o %t.cu.o
+# RUN: llvm-dwarfutil %t.cu.o %t.cu.classic
+# RUN: llvm-dwarfdump --debug-info %t.cu.classic | FileCheck %s --check-prefixes=CLASSIC,CLASSIC-CU
+# RUN: llvm-dwarfutil --linker parallel %t.cu.o %t.cu.parallel
+# RUN: llvm-dwarfdump --debug-info %t.cu.parallel | FileCheck %s --check-prefixes=PARALLEL,PARALLEL-CU
+
+# RUN: yaml2obj %s -DROOT=DW_TAG_partial_unit -DUNITTYPE=DW_UT_partial -o %t.pu.o
+# RUN: llvm-dwarfutil %t.pu.o %t.pu.classic
+# RUN: llvm-dwarfdump --debug-info %t.pu.classic | FileCheck %s --check-prefixes=CLASSIC,CLASSIC-PU
+# RUN: llvm-dwarfutil --linker parallel %t.pu.o %t.pu.parallel
+# RUN: llvm-dwarfdump --debug-info %t.pu.parallel | FileCheck %s --check-prefixes=PARALLEL,PARALLEL-PU
+
+## The classic backend leaves the type where it found it, and the root tag
+## survives linking. llvm-dwarfdump qualifies a type name with the names of its
+## enclosing scopes and a partial unit root is one, which a compile unit root
+## is not, so the type is printed as "U01::ns::S" for the partial unit run and
+## as "ns::S" for the control. The reference target is the same DIE either way.
+# CLASSIC-CU:     DW_TAG_compile_unit
+# CLASSIC-PU:     DW_TAG_partial_unit
+# CLASSIC:        DW_TAG_subprogram
+# CLASSIC-NEXT:     DW_AT_name ("foo1")
+# CLASSIC-CU:       DW_AT_type (0x00000000[[S:[0-9a-f]{8}]] "ns::S")
+# CLASSIC-PU:       DW_AT_type (0x00000000[[S:[0-9a-f]{8}]] "U01::ns::S")
+# CLASSIC:        DW_TAG_namespace
+# CLASSIC-NEXT:     DW_AT_name ("ns")
+# CLASSIC:      0x[[S]]:     DW_TAG_structure_type
+# CLASSIC-NEXT:   DW_AT_name ("S")
+# CLASSIC:          DW_TAG_member
+# CLASSIC-NEXT:       DW_AT_name ("m1")
+
+## The parallel backend puts the type in the artificial type unit, under a copy
+## of the namespace that held it, and the unit's reference resolves there. The
+## unit root itself stays out of that unit, which is what this pins: it has no
+## name of its own to be deduplicated under, and cloning it as a type DIE is
+## what used to crash.
+# PARALLEL:      DW_AT_name ("__artificial_type_unit")
+# PARALLEL:      DW_TAG_namespace
+# PARALLEL-NEXT:   DW_AT_name ("ns")
+# PARALLEL:      0x[[S:[0-9a-f]{8}]]:     DW_TAG_structure_type
+# PARALLEL-NEXT:   DW_AT_name ("S")
+# PARALLEL:          DW_TAG_member
+# PARALLEL-NEXT:       DW_AT_name ("m1")
+# PARALLEL-CU:   DW_TAG_compile_unit
+# PARALLEL-PU:   DW_TAG_partial_unit
+# PARALLEL-NEXT:   DW_AT_producer ("by_hand")
+# PARALLEL-NEXT:   DW_AT_name ("U01")
+# PARALLEL:      DW_TAG_subprogram
+# PARALLEL-NEXT:   DW_AT_name ("foo1")
+# PARALLEL:        DW_AT_type (0x00000000[[S]] "ns::S")
+
+## One DWARFv5 unit with a function in .text returning struct S, which is
+## defined in namespace ns. The root carries its own DW_AT_str_offsets_base, so
+## the strings the linker rewrites into DW_FORM_strx stay resolvable on output;
+## the linker does not synthesize that attribute for a partial unit root by
+## itself.
+--- !ELF
+FileHeader:
+  Class:    ELFCLASS64
+  Data:     ELFDATA2LSB
+  Type:     ET_REL
+  Machine:  EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1130
+    Size:            0x10
+  - Name:            .debug_str_offsets
+    Type:            SHT_PROGBITS
+    Flags:           [  ]
+    Content:        "0400000005000000"
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      [[ROOT]]
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_str_offsets_base
+            Form:      DW_FORM_sec_offset
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_namespace
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_member
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+          - Attribute: DW_AT_data_member_location
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+  debug_info:
+    - Version:  5
+      UnitType: [[UNITTYPE]]
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: by_hand
+            - CStr: U01
+            - Value: 0x04
+            - Value: 0x1130
+            - Value: 0x10
+            - Value: 0x8
+        - AbbrCode: 2
+          Values:
+            - CStr: foo1
+            - Value: 0x1130
+            - Value: 0x10
+            - Value: 0x4d
+        - AbbrCode: 3
+          Values:
+            - CStr: ns
+        - AbbrCode: 4
+          Values:
+            - CStr: S
+            - Value: 0x8
+        - AbbrCode: 5
+          Values:
+            - CStr: m1
+            - Value: 0x5c
+            - Value: 0x0
+        - AbbrCode: 0
+        - AbbrCode: 0
+        - AbbrCode: 6
+          Values:
+            - CStr: int
+        - AbbrCode: 0
+...

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-types-only.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-types-only.test
@@ -1,0 +1,168 @@
+## A unit root is never assigned a type entry, so it is never cloned into the
+## artificial type unit and the recursion into its type children is allowed by
+## a separate test - which named DW_TAG_compile_unit only. A
+## DW_TAG_partial_unit root holding types and no code, the unit dwz produces to
+## carry the definitions it hoisted out of the compile units, therefore reached
+## neither branch and its subtree was dropped after the type name had already
+## been registered. A DW_TAG_compile_unit root is linked alongside as the
+## control.
+##
+## U01:  namespace ns { struct S {}; }
+## U02:  ns::S foo1() { ... }   // DW_FORM_ref_addr reference into U01
+##
+## The classic backend is not linked here. It fails on this input for an
+## unrelated reason, a cross-unit reference to a DIE it never gave an output
+## unit, which is a separate defect from the one this test covers.
+
+# RUN: yaml2obj %s -DROOT=DW_TAG_compile_unit -DUNITTYPE=DW_UT_compile -o %t.cu.o
+# RUN: llvm-dwarfutil --linker parallel %t.cu.o %t.cu.out
+# RUN: llvm-dwarfdump --debug-info %t.cu.out | FileCheck %s --implicit-check-not='DW_AT_name ("U01")'
+
+# RUN: yaml2obj %s -DROOT=DW_TAG_partial_unit -DUNITTYPE=DW_UT_partial -o %t.pu.o
+# RUN: llvm-dwarfutil --linker parallel %t.pu.o %t.pu.out
+# RUN: llvm-dwarfdump --debug-info %t.pu.out | FileCheck %s --check-prefixes=CHECK,CHECK-PU
+
+## The type reaches the artificial type unit under a copy of the namespace that
+## held it, and the second unit's reference resolves into the type unit rather
+## than to a dropped DIE.
+# CHECK:           DW_AT_name ("__artificial_type_unit")
+# CHECK:           DW_TAG_namespace
+# CHECK-NEXT:        DW_AT_name ("ns")
+# CHECK:         0x[[S:[0-9a-f]{8}]]:     DW_TAG_structure_type
+# CHECK-NEXT:        DW_AT_name ("S")
+# CHECK-NEXT:        DW_AT_byte_size (0x08)
+
+## The first unit is emptied either way, since its only child moved to the type
+## unit, but the two roots are then treated differently: a compile unit with
+## nothing left is dropped whole, while a partial unit root is still emitted.
+## That difference is the linker's existing behaviour for a unit with no live
+## contents, not something this fix introduces, so it is pinned rather than
+## made uniform.
+# CHECK-PU:        DW_TAG_partial_unit
+# CHECK-PU-NEXT:     DW_AT_producer ("by_hand")
+# CHECK-PU-NEXT:     DW_AT_name ("U01")
+# CHECK:           DW_TAG_compile_unit
+# CHECK-NEXT:        DW_AT_producer ("by_hand")
+# CHECK-NEXT:        DW_AT_name ("U02")
+# CHECK:           DW_TAG_subprogram
+# CHECK-NEXT:        DW_AT_name ("foo1")
+# CHECK:             DW_AT_type (0x00000000[[S]] "ns::S")
+
+## Two DWARFv5 units. The first defines struct S in namespace ns and has no
+## code of its own; the second has the only function, which returns S through a
+## DW_FORM_ref_addr reference into the first. S is deliberately memberless, so
+## that the first unit holds nothing the linker would keep in plain DWARF - a
+## member would pull in a DW_TAG_base_type, which is always kept, and that
+## alone would give the root plain children to descend for. Each root carries
+## its own DW_AT_str_offsets_base, so the strings the linker rewrites into
+## DW_FORM_strx stay resolvable on output; the linker does not synthesize that
+## attribute for a partial unit root by itself.
+--- !ELF
+FileHeader:
+  Class:    ELFCLASS64
+  Data:     ELFDATA2LSB
+  Type:     ET_REL
+  Machine:  EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1130
+    Size:            0x10
+  - Name:            .debug_str_offsets
+    Type:            SHT_PROGBITS
+    Flags:           [  ]
+    Content:        "0400000005000000"
+DWARF:
+  debug_abbrev:
+    - ID:    0
+      Table:
+      - Tag:      [[ROOT]]
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+          - Attribute: DW_AT_str_offsets_base
+            Form:      DW_FORM_sec_offset
+      - Tag:      DW_TAG_namespace
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_str_offsets_base
+            Form:      DW_FORM_sec_offset
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref_addr
+  debug_info:
+    - Version:  5
+      UnitType: [[UNITTYPE]]
+      AbbrevTableID: 0
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: by_hand
+            - CStr: U01
+            - Value: 0x04
+            - Value: 0x8
+        - AbbrCode: 2
+          Values:
+            - CStr: ns
+        - AbbrCode: 3
+          Values:
+            - CStr: S
+            - Value: 0x8
+        - AbbrCode: 0
+        - AbbrCode: 0
+    - Version:  5
+      UnitType: DW_UT_compile
+      AbbrevTableID: 0
+      Entries:
+        - AbbrCode: 4
+          Values:
+            - CStr: by_hand
+            - CStr: U02
+            - Value: 0x04
+            - Value: 0x1130
+            - Value: 0x10
+            - Value: 0x8
+        - AbbrCode: 5
+          Values:
+            - CStr: foo1
+            - Value: 0x1130
+            - Value: 0x10
+            - Value: 0x23
+        - AbbrCode: 0
+...


### PR DESCRIPTION
**Summary**

- **Broken:** `hashFullyQualifiedName` must stop the walk at the unit root. It tested the parent's tag against `DW_TAG_compile_unit` alone, in error missing `DW_TAG_partial_unit`. A partial unit's declarations take their scope from the entries that import it (DWARFv5 spec §3.1.1), so a type at unit scope has no component above it, but the walk folded the root's `DW_AT_name`, a source file path, into the hash: `0xf9a84c7e` against `0x0c3993dd` for the same `struct Foo`, and against classic, which stops on `ParentIdx == 0` and was right all along.
- **Fix:** test the parent's position rather than its tag, at both root tests in the file.
- **Implementation:** `hashFullyQualifiedName` reuses `CompileUnit::isUnitRootDIE` (from #219615), and the second root test moves above the switch in `AcceleratorRecordsSaver::save()`, where it holds for every root tag and replaces the `DW_TAG_compile_unit` case that let a partial unit root's file name be indexed as an identifier.

Depends on #219615.

The Apple accelerator tables carry a `DW_ATOM_qual_name_hash` for every type, a hash of the type's fully qualified name that a consumer looks types up by. `hashFullyQualifiedName` builds it by walking up the parents and stopping at the unit root, and it recognized the unit root by testing the parent's tag against `DW_TAG_compile_unit` alone.

`DW_TAG_partial_unit` is the root tag `dwz` emits, so this is the ordinary shape of a Fedora, RHEL or Debian debuginfo package. A partial unit root is a valid parent that is not tagged `DW_TAG_compile_unit`, so the walk did not stop there. It recursed into the root and folded the root's `DW_AT_name` — a source file path, not an identifier — into the hash as though the unit were an enclosing scope of the type.

The classic backend ends the same walk on `ParentIdx == 0` and is already correct whatever tag the root carries. The two backends therefore produced different hashes for the same type on the same input, which is the one thing an accelerator table hash cannot afford.

`hashFullyQualifiedName` now tests the parent's position. `CompileUnit::isUnitRootDIE` is the helper #219615 introduces for the two `cloneDIE()` gates, reused here rather than respelled; index zero is the unit root whatever tag it carries, which is the invariant the tag comparison stood in for.

DWARFv5 section 3.1.1 settles which of the two backends was right. It places the containing scope of a partial unit's declarations at the entries that import it rather than at the unit itself, and item 2 of the same section makes the root's `DW_AT_name` the path of a source file. A type at unit scope in a partial unit therefore has no enclosing scope to contribute a component, and classic's hash was the correct one all along.

Measured on the test input's `struct Foo` at unit scope, the parallel backend produced `0xf9a84c7e` under a partial unit root against `0x0c3993dd` under a compile unit root. Both roots now give `0x0c3993dd`, which is what classic gives for both and what the qualified name `Foo` hashes to.

`AcceleratorRecordsSaver` tested the unit root a second time, a hundred lines below in `save()`, and that one was still tagged. The switch there routed `DW_TAG_compile_unit` into the arm that does nothing and let every other tag fall through to the arm that emits a name record for any DIE carrying a live address or a range. A unit root carries `DW_AT_low_pc`, so a partial unit root had its `DW_AT_name`, a source file path, indexed as though it were an identifier. The positional test moves above the switch, where it holds for every root tag, and the `DW_TAG_compile_unit` case it replaces comes out; a compile unit root took the do-nothing arm before and takes the early return now.

That second site is not confined to the Apple tables, so unlike the hash it is reachable through `llvm-dwarfutil`. `dwarf5-partial-unit-accelerator-root-name.test` links one unit under each root tag with `--build-accelerator=DWARF` and holds both to one expectation; without the change the partial unit run reports a name count of three against the control's two, the extra name being the root's own.

Only `dsymutil` reaches this code. `llvm-dwarfutil` accepts `--build-accelerator=none` and `--build-accelerator=DWARF` and nothing else, and the hash is written solely into the Apple tables, so it is computed and discarded there.

The test assembles one source twice with `llvm-mc --defsym`, changing only the root tag and the unit type, and links each of the two objects with both backends. All four runs are checked against a single `CHECK` block, which is the claim being made: the two backends agree with each other, and neither varies with the root tag. The block pins the first hash data record of each name, and the parallel partial unit run emits a second record per name that nothing constrains. Both records come from the same `hashFullyQualifiedName` call on the same input DIE and cannot disagree on `Atom[3]`, so what the test enforces is agreement over first records rather than over the whole table.

The input carries a `struct Foo` at unit scope and a `struct Bar` inside a namespace, and both are pinned. The pair is what separates ending the walk at the unit root from ending it unconditionally — a fix that simply stopped recursing gets `Foo` right and `Bar` wrong, since `ns` has to be folded in. Only `Atom[0]`, the output DIE offset, is left unmatched, because the two backends lay the linked unit out differently.

The two partial unit runs pass `--verify-dwarf=none`. Both backends leave a partial unit root without a `DW_AT_str_offsets_base` and record `DW_UT_compile` in the unit header whatever tag the root carries, so `dsymutil`'s default output verification rejects either link on grounds unrelated to this hash. That is #219365, fixed by #219398, and stacking this change on that one as well seemed the wrong trade for a check the fix here does not need. The two compile unit control runs ask for verification explicitly with `--verify-dwarf=all` rather than relying on the default, which `dsymutil` enables only in assertions builds, so the input and the tool are held to it in every configuration.

Known limit, since it will be asked: the test cannot distinguish the positional predicate from a tag list naming all four unit root tags. Those four are every root tag that exists, so there is no fifth to feed it.

Fixes #219636.

This change was produced with AI assistance; I have reviewed it and am accountable for it.

Assisted-by: Claude Code

