### PR TITLE
[llvm-reduce] Skip landingpad clauses in operands-to-args

### DIFF
--- a/llvm/test/tools/llvm-reduce/operands-to-args-landingpad.ll
+++ b/llvm/test/tools/llvm-reduce/operands-to-args-landingpad.ll
@@ -1,0 +1,29 @@
+; RUN: llvm-reduce %s -o %t --abort-on-invalid-reduction \
+; RUN:   --delta-passes=operands-to-args \
+; RUN:   --test FileCheck --test-arg %s --test-arg --check-prefix=INTERESTING \
+; RUN:   --test-arg --input-file
+; RUN: FileCheck %s --input-file %t --check-prefix=REDUCED
+
+; INTERESTING: landingpad
+; REDUCED-LABEL: define void @f()
+; REDUCED:       landingpad { ptr, i32 }
+; REDUCED-NEXT:    catch ptr @typeinfo
+
+@typeinfo = external constant ptr
+
+declare void @g()
+declare i32 @personality(...)
+
+define void @f() personality ptr @personality {
+entry:
+  invoke void @g()
+          to label %return unwind label %lpad
+
+lpad:
+  %result = landingpad { ptr, i32 }
+          catch ptr @typeinfo
+  unreachable
+
+return:
+  ret void
+}

--- a/llvm/tools/llvm-reduce/deltas/ReduceOperandsToArgs.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceOperandsToArgs.cpp
@@ -55,6 +55,10 @@ static bool canReduceUse(Use &Op) {
   if (isa<LifetimeIntrinsic>(Op.getUser()))
     return false;
 
+  // Landing pad clauses must remain constants.
+  if (isa<LandingPadInst>(Op.getUser()))
+    return false;
+
   return true;
 }
 


### PR DESCRIPTION
Fixes #219667.

The operands-to-args delta pass could select a landingpad clause for
replacement with a function argument. Landingpad clauses must remain
constants, so this produced invalid IR and triggered the `cast<Constant>`
assertion while the reducer verified a candidate.

Skip operands owned by `LandingPadInst`. The regression test runs only the
operands-to-args pass with `--abort-on-invalid-reduction` and verifies that
the function remains argument-free and that its catch clause remains
constant.

AI assistance disclosure: OpenAI Codex 5.6 Sol assisted with implementation
and testing. Claude was used for an additional private review. Yongqiang Tian
reviewed the complete patch and is responsible for the contribution.
