### PR TITLE
[lldb] Fix iterator invalidation in SigchldHandler

### DIFF
--- a/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
@@ -403,6 +403,8 @@ void NativeProcessLinux::Manager::SigchldHandler() {
     // vice-versa. This means that if the child event arrives first, it may not
     // be handled by any process (because it doesn't know the thread belongs to
     // it).
+    // The loop below may modify m_processes (create or delete entries), so
+    // operate on a temporary copy.
     auto processes = llvm::to_vector(m_processes);
     bool handled = llvm::any_of(processes, [&](NativeProcessLinux *process) {
       return process->TryHandleWaitStatus(pid, status);

--- a/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
@@ -403,7 +403,8 @@ void NativeProcessLinux::Manager::SigchldHandler() {
     // vice-versa. This means that if the child event arrives first, it may not
     // be handled by any process (because it doesn't know the thread belongs to
     // it).
-    bool handled = llvm::any_of(m_processes, [&](NativeProcessLinux *process) {
+    auto processes = llvm::to_vector(m_processes);
+    bool handled = llvm::any_of(processes, [&](NativeProcessLinux *process) {
       return process->TryHandleWaitStatus(pid, status);
     });
     if (!handled) {


### PR DESCRIPTION
While SigchldHandler iterates over m_processes with llvm::any_of to
find the process that owns a waitpid event, handling an event can
create or destroy a NativeProcessLinux instance, mutating m_processes.
Comparing iterators after m_processes is mutated (such as the
find_if(...) != end() check in libstdc++'s std::any_of) triggers
assertion failures under epoch checks.

Operating on a temporary copy of m_processes via llvm::to_vector
ensures that iterator traversal is safe from container mutations.

This bug was discovered with tightened epoch checks in
SmallPtrSetIterator.

Assisted-by: Antigravity
