### PR TITLE
[AArch64][PowerPC][RISCV] Ignore debug instructions when trimming stackmap shadows

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -1785,8 +1785,11 @@ void AArch64AsmPrinter::LowerSTACKMAP(MCStreamer &OutStreamer, StackMaps &SM,
   MachineBasicBlock::const_iterator MII(MI);
   ++MII;
   while (NumNOPBytes > 0) {
+    if (MII != MBB.end() && MII->isDebugInstr()) {
+      ++MII;
+      continue;
+    }
     if (MII == MBB.end() || MII->isCall() ||
-        MII->getOpcode() == AArch64::DBG_VALUE ||
         MII->getOpcode() == TargetOpcode::PATCHPOINT ||
         MII->getOpcode() == TargetOpcode::STACKMAP)
       break;

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -554,8 +554,11 @@ void PPCAsmPrinter::LowerSTACKMAP(StackMaps &SM, const MachineInstr &MI) {
   MachineBasicBlock::const_iterator MII(MI);
   ++MII;
   while (NumNOPBytes > 0) {
+    if (MII != MBB.end() && MII->isDebugInstr()) {
+      ++MII;
+      continue;
+    }
     if (MII == MBB.end() || MII->isCall() ||
-        MII->getOpcode() == PPC::DBG_VALUE ||
         MII->getOpcode() == TargetOpcode::PATCHPOINT ||
         MII->getOpcode() == TargetOpcode::STACKMAP)
       break;

--- a/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
+++ b/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
@@ -160,8 +160,11 @@ void RISCVAsmPrinter::LowerSTACKMAP(MCStreamer &OutStreamer, StackMaps &SM,
   MachineBasicBlock::const_iterator MII(MI);
   ++MII;
   while (NumNOPBytes > 0) {
+    if (MII != MBB.end() && MII->isDebugInstr()) {
+      ++MII;
+      continue;
+    }
     if (MII == MBB.end() || MII->isCall() ||
-        MII->getOpcode() == RISCV::DBG_VALUE ||
         MII->getOpcode() == TargetOpcode::PATCHPOINT ||
         MII->getOpcode() == TargetOpcode::STACKMAP)
       break;

--- a/llvm/test/CodeGen/AArch64/arm64-stackmap-nops.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-stackmap-nops.ll
@@ -13,3 +13,41 @@ entry:
 }
 
 declare void @llvm.experimental.stackmap(i64, i32, ...)
+
+define void @test_shadow_optimization_dbg_label() !dbg !4 {
+entry:
+; CHECK-LABEL: test_shadow_optimization_dbg_label:
+; CHECK:      nop
+; CHECK-NEXT: nop
+; CHECK-NOT:  nop
+  tail call void (i64, i32, ...) @llvm.experimental.stackmap(i64 0, i32 16)
+  #dbg_label(!6, !7)
+  ret void
+}
+
+define void @test_shadow_optimization_dbg_value() !dbg !8 {
+entry:
+; CHECK-LABEL: test_shadow_optimization_dbg_value:
+; CHECK:      nop
+; CHECK-NEXT: nop
+; CHECK-NOT:  nop
+  tail call void (i64, i32, ...) @llvm.experimental.stackmap(i64 0, i32 16)
+  #dbg_value(i32 0, !9, !DIExpression(), !10)
+  ret void
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug)
+!1 = !DIFile(filename: "stackmap-shadow.c", directory: "/")
+!2 = !{}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = distinct !DISubprogram(name: "test_shadow_optimization_dbg_label", scope: !1, file: !1, line: 1, type: !5, scopeLine: 1, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0)
+!5 = !DISubroutineType(types: !2)
+!6 = !DILabel(scope: !4, name: "after_stackmap", file: !1, line: 2)
+!7 = !DILocation(line: 2, column: 1, scope: !4)
+!8 = distinct !DISubprogram(name: "test_shadow_optimization_dbg_value", scope: !1, file: !1, line: 4, type: !5, scopeLine: 4, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0)
+!9 = !DILocalVariable(name: "value", scope: !8, file: !1, line: 5, type: !11)
+!10 = !DILocation(line: 5, column: 1, scope: !8)
+!11 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)

--- a/llvm/test/CodeGen/PowerPC/ppc64-stackmap-nops.ll
+++ b/llvm/test/CodeGen/PowerPC/ppc64-stackmap-nops.ll
@@ -22,3 +22,44 @@ entry:
 
 declare void @llvm.experimental.stackmap(i64, i32, ...)
 
+define void @test_shadow_optimization_dbg_label() !dbg !4 {
+entry:
+; CHECK-LABEL: test_shadow_optimization_dbg_label:
+; CHECK:      nop
+; CHECK-NEXT: nop
+; CHECK-NEXT: nop
+; CHECK-NOT:  nop
+; CHECK:      blr
+  tail call void (i64, i32, ...) @llvm.experimental.stackmap(i64 0, i32 32)
+  #dbg_label(!6, !7)
+  ret void
+}
+
+define void @test_shadow_optimization_dbg_value() !dbg !8 {
+entry:
+; CHECK-LABEL: test_shadow_optimization_dbg_value:
+; CHECK:      nop
+; CHECK-NEXT: nop
+; CHECK-NEXT: nop
+; CHECK-NOT:  nop
+; CHECK:      blr
+  tail call void (i64, i32, ...) @llvm.experimental.stackmap(i64 0, i32 32)
+  #dbg_value(i32 0, !9, !DIExpression(), !10)
+  ret void
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug)
+!1 = !DIFile(filename: "stackmap-shadow.c", directory: "/")
+!2 = !{}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = distinct !DISubprogram(name: "test_shadow_optimization_dbg_label", scope: !1, file: !1, line: 1, type: !5, scopeLine: 1, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0)
+!5 = !DISubroutineType(types: !2)
+!6 = !DILabel(scope: !4, name: "after_stackmap", file: !1, line: 2)
+!7 = !DILocation(line: 2, column: 1, scope: !4)
+!8 = distinct !DISubprogram(name: "test_shadow_optimization_dbg_value", scope: !1, file: !1, line: 4, type: !5, scopeLine: 4, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0)
+!9 = !DILocalVariable(name: "value", scope: !8, file: !1, line: 5, type: !11)
+!10 = !DILocation(line: 5, column: 1, scope: !8)
+!11 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)

--- a/llvm/test/CodeGen/RISCV/rv64-stackmap-nops.ll
+++ b/llvm/test/CodeGen/RISCV/rv64-stackmap-nops.ll
@@ -26,3 +26,83 @@ entry:
   tail call void (i64, i32, ...) @llvm.experimental.stackmap(i64  0, i32  16)
   ret void
 }
+
+define void @test_shadow_optimization_dbg_label() !dbg !4 {
+; CHECK-LABEL: test_shadow_optimization_dbg_label:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    .file 1 "/" "stackmap-shadow.c"
+; CHECK-NEXT:    .loc 1 1 0 prologue_end # stackmap-shadow.c:1:0
+; CHECK-NEXT:  .Ltmp1:
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    #DEBUG_LABEL: test_shadow_optimization_dbg_label:after_stackmap
+; CHECK-NEXT:    ret
+;
+; RVC-LABEL: test_shadow_optimization_dbg_label:
+; RVC:       # %bb.0: # %entry
+; RVC-NEXT:    .file 1 "/" "stackmap-shadow.c"
+; RVC-NEXT:    .loc 1 1 0 prologue_end # stackmap-shadow.c:1:0
+; RVC-NEXT:  .Ltmp1:
+; RVC-NEXT:    nop
+; RVC-NEXT:    nop
+; RVC-NEXT:    nop
+; RVC-NEXT:    nop
+; RVC-NEXT:    nop
+; RVC-NEXT:    nop
+; RVC-NEXT:    nop
+; RVC-NEXT:    #DEBUG_LABEL: test_shadow_optimization_dbg_label:after_stackmap
+; RVC-NEXT:    ret
+entry:
+  tail call void (i64, i32, ...) @llvm.experimental.stackmap(i64 0, i32 16)
+  #dbg_label(!6, !7)
+  ret void
+}
+
+define void @test_shadow_optimization_dbg_value() !dbg !8 {
+; CHECK-LABEL: test_shadow_optimization_dbg_value:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    .loc 1 4 0 prologue_end # stackmap-shadow.c:4:0
+; CHECK-NEXT:  .Ltmp2:
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    #DEBUG_VALUE: test_shadow_optimization_dbg_value:value <- 0
+; CHECK-NEXT:    ret
+;
+; RVC-LABEL: test_shadow_optimization_dbg_value:
+; RVC:       # %bb.0: # %entry
+; RVC-NEXT:    .loc 1 4 0 prologue_end # stackmap-shadow.c:4:0
+; RVC-NEXT:  .Ltmp2:
+; RVC-NEXT:    nop
+; RVC-NEXT:    nop
+; RVC-NEXT:    nop
+; RVC-NEXT:    nop
+; RVC-NEXT:    nop
+; RVC-NEXT:    nop
+; RVC-NEXT:    nop
+; RVC-NEXT:    #DEBUG_VALUE: test_shadow_optimization_dbg_value:value <- 0
+; RVC-NEXT:    ret
+entry:
+  tail call void (i64, i32, ...) @llvm.experimental.stackmap(i64 0, i32 16)
+  #dbg_value(i32 0, !9, !DIExpression(), !10)
+  ret void
+}
+
+declare void @llvm.experimental.stackmap(i64, i32, ...)
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug)
+!1 = !DIFile(filename: "stackmap-shadow.c", directory: "/")
+!2 = !{}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = distinct !DISubprogram(name: "test_shadow_optimization_dbg_label", scope: !1, file: !1, line: 1, type: !5, scopeLine: 1, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0)
+!5 = !DISubroutineType(types: !2)
+!6 = !DILabel(scope: !4, name: "after_stackmap", file: !1, line: 2)
+!7 = !DILocation(line: 2, column: 1, scope: !4)
+!8 = distinct !DISubprogram(name: "test_shadow_optimization_dbg_value", scope: !1, file: !1, line: 4, type: !5, scopeLine: 4, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0)
+!9 = !DILocalVariable(name: "value", scope: !8, file: !1, line: 5, type: !11)
+!10 = !DILocation(line: 5, column: 1, scope: !8)
+!11 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)


### PR DESCRIPTION
Debug instructions do not emit code and therefore must not consume stackmap
shadow bytes.

The AArch64, PowerPC, and RISC-V `LowerSTACKMAP` implementations scan
subsequent fixed-width instructions to determine how many NOP bytes are still
required. Previously, `DBG_VALUE` stopped this scan, while other debug
instructions such as `DBG_LABEL` were incorrectly counted as encoded
instructions. This could either inhibit shadow optimization or underfill the
requested shadow.

Skip all debug instructions without decrementing the remaining shadow size.
Add `DBG_LABEL` and `DBG_VALUE` regression coverage for all three targets.

Fixes #219750.

AI disclosure: This patch was developed with OpenAI Codex 5.6 Sol and
co-reviewed by Claude and Yongqiang Tian.
