### PR TITLE
[clang][bytecode] Divide `noteStep()` in hot and cold paths

### DIFF
--- a/clang/lib/AST/ByteCode/InterpState.cpp
+++ b/clang/lib/AST/ByteCode/InterpState.cpp
@@ -157,14 +157,7 @@ StdAllocatorCaller InterpState::getStdAllocatorCaller(StringRef Name) const {
   return {};
 }
 
-bool InterpState::noteStep(CodePtr OpPC) {
-  if (InfiniteSteps)
-    return true;
-
-  --StepsLeft;
-  if (StepsLeft != 0)
-    return true;
-
+bool InterpState::diagnoseStepLimitExceeded(CodePtr OpPC) {
   FFDiag(Current->getSource(OpPC), diag::note_constexpr_step_limit_exceeded, 1)
       << getLangOpts().ConstexprStepLimit;
   Note(Current->getSource(OpPC), diag::note_constexpr_steps);

--- a/clang/lib/AST/ByteCode/InterpState.h
+++ b/clang/lib/AST/ByteCode/InterpState.h
@@ -129,7 +129,16 @@ public:
 
   /// Note that a step has been executed. If there are no more steps remaining,
   /// diagnoses and returns \c false.
-  bool noteStep(CodePtr OpPC);
+  bool noteStep(CodePtr OpPC) {
+    if (InfiniteSteps)
+      return true;
+
+    --StepsLeft;
+    if (LLVM_LIKELY(StepsLeft != 0))
+      return true;
+
+    return diagnoseStepLimitExceeded(OpPC);
+  }
 
   bool initializingBlock(const Block *B) const {
     for (PtrView V : InitializingPtrs)
@@ -176,6 +185,8 @@ private:
   std::unique_ptr<DynamicAllocator> Alloc;
   /// Allocator for everything else, e.g. floating-point values.
   mutable std::optional<llvm::BumpPtrAllocator> Allocator;
+  /// Diagnose that we've reached the constexpr step limit.
+  bool diagnoseStepLimitExceeded(CodePtr OpPC);
 
 public:
   CodePtr PC;


### PR DESCRIPTION
Move the hot success path into the header file to encourage inlining. Also add a likeliness-hint since the steps check should _almost_ never hit.