### PR TITLE
[clang][bytecode] Clean up diagnostic location getters

### DIFF
--- a/clang/lib/AST/ByteCode/InterpFrame.cpp
+++ b/clang/lib/AST/ByteCode/InterpFrame.cpp
@@ -218,8 +218,9 @@ void InterpFrame::describe(llvm::raw_ostream &OS) const {
 
 SourceRange InterpFrame::getCallRange() const {
   if (!Caller->Func) {
-    if (SourceRange NullRange = S.getRange({}); NullRange.isValid())
+    if (SourceRange NullRange = S.getSource({}).getRange(); NullRange.isValid())
       return NullRange;
+
     return S.EvalLocation;
   }
 
@@ -294,35 +295,6 @@ SourceInfo InterpFrame::getSource(CodePtr PC) const {
     return Caller->getSource(getRetOpPC());
 
   return Result;
-}
-
-const Expr *InterpFrame::getExpr(CodePtr PC) const {
-  if (!Func)
-    return S.getExpr(PC);
-
-  if (!funcHasUsableBody(Func) && Caller)
-    return Caller->getExpr(getRetOpPC());
-
-  return Func->getSource(PC).asExpr();
-}
-
-SourceLocation InterpFrame::getLocation(CodePtr PC) const {
-  if (!Func)
-    return S.getLocation(PC);
-  if (!funcHasUsableBody(Func) && Caller)
-    return Caller->getLocation(getRetOpPC());
-
-  return Func->getSource(PC).getLoc();
-}
-
-SourceRange InterpFrame::getRange(CodePtr PC) const {
-  if (!Func)
-    return S.getRange(PC);
-
-  if (!funcHasUsableBody(Func) && Caller)
-    return Caller->getRange(getRetOpPC());
-
-  return Func->getSource(PC).getRange();
 }
 
 bool InterpFrame::isStdFunction() const {

--- a/clang/lib/AST/ByteCode/InterpFrame.h
+++ b/clang/lib/AST/ByteCode/InterpFrame.h
@@ -161,9 +161,11 @@ public:
 
   /// Map a location to a source.
   SourceInfo getSource(CodePtr PC) const;
-  const Expr *getExpr(CodePtr PC) const;
-  SourceLocation getLocation(CodePtr PC) const;
-  SourceRange getRange(CodePtr PC) const;
+  const Expr *getExpr(CodePtr PC) const { return getSource(PC).asExpr(); }
+  SourceLocation getLocation(CodePtr PC) const {
+    return getSource(PC).getLoc();
+  }
+  SourceRange getRange(CodePtr PC) const { return getSource(PC).getRange(); }
 
   unsigned getDepth() const { return Depth; }
   unsigned getArgSize() const { return ArgSize; }

--- a/clang/lib/AST/ByteCode/InterpState.h
+++ b/clang/lib/AST/ByteCode/InterpState.h
@@ -69,11 +69,6 @@ public:
 
   /// Delegates source mapping to the mapper.
   SourceInfo getSource(CodePtr PC) const { return M->getSource(PC); }
-  const Expr *getExpr(CodePtr PC) const { return getSource(PC).asExpr(); }
-  SourceLocation getLocation(CodePtr PC) const {
-    return getSource(PC).getLoc();
-  }
-  SourceRange getRange(CodePtr PC) const { return getSource(PC).getRange(); }
 
   Context &getContext() const { return Ctx; }
 


### PR DESCRIPTION
Implement `getRange()` etc. in terms of `getSource()` to reduce code duplication.