### PR TITLE
[clang][bytecode] Shrink `InterpFrame` size a bit

### DIFF
--- a/clang/lib/AST/ByteCode/InterpFrame.cpp
+++ b/clang/lib/AST/ByteCode/InterpFrame.cpp
@@ -24,13 +24,14 @@ using namespace clang;
 using namespace clang::interp;
 
 InterpFrame::InterpFrame(InterpState &S)
-    : Caller(nullptr), S(S), Depth(0), Func(nullptr), RetPC(CodePtr()),
-      ArgSize(0), Args(nullptr) {}
+    : Caller(nullptr), S(S), Func(nullptr), RetPC(CodePtr()), Args(nullptr),
+      ArgSize(0), Depth(0) {}
 
 InterpFrame::InterpFrame(InterpState &S, const Function *Func,
                          InterpFrame *Caller, CodePtr RetPC, unsigned ArgSize)
-    : Caller(Caller), S(S), Depth(Caller ? Caller->Depth + 1 : 0), Func(Func),
-      RetPC(RetPC), ArgSize(ArgSize), Args(static_cast<char *>(S.Stk.top())) {
+    : Caller(Caller), S(S), Func(Func), RetPC(RetPC),
+      Args(static_cast<char *>(S.Stk.top())), ArgSize(ArgSize),
+      Depth(Caller ? Caller->Depth + 1 : 0) {
 #ifndef NDEBUG
   FrameOffset = S.Stk.size();
 #endif

--- a/clang/lib/AST/ByteCode/InterpFrame.h
+++ b/clang/lib/AST/ByteCode/InterpFrame.h
@@ -26,9 +26,6 @@ class Pointer;
 /// Frame storing local variables.
 class InterpFrame final : public Frame {
 public:
-  /// The frame of the previous function.
-  InterpFrame *Caller;
-
   /// Bottom Frame.
   InterpFrame(InterpState &S);
 
@@ -218,23 +215,27 @@ private:
     return reinterpret_cast<InlineDescriptor *>(locals() + Offset);
   }
 
+public:
+  /// The frame of the previous function.
+  InterpFrame *Caller;
+
 private:
   /// Reference to the interpreter state.
   InterpState &S;
-  /// Depth of this frame.
-  unsigned Depth;
   /// Reference to the function being executed.
   const Function *Func;
   /// Return address.
   CodePtr RetPC;
-  /// The size of all the arguments.
-  const unsigned ArgSize;
   /// Pointer to the arguments in the callee's frame.
   char *Args = nullptr;
 #ifndef NDEBUG
   /// Offset on the stack at entry.
   size_t FrameOffset = 0;
 #endif
+  /// The size of all the arguments.
+  const unsigned ArgSize;
+  /// Depth of this frame.
+  unsigned Depth;
 
 public:
   unsigned MSVCConstexprAllowed = 0;


### PR DESCRIPTION
Reorder members to reduce the size from 80 to 72 bytes (debug builds on 64bit systems).