### PR TITLE
[DWARFLinker][Parallel] Decide collection by the option, not the root tag

### DIFF
--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.cpp
@@ -1419,8 +1419,7 @@ std::pair<DIE *, TypeEntry *> CompileUnit::cloneDIE(
 
   bool NeedToClonePlainDIE = Info.needToKeepInPlainDwarf();
   bool NeedToCloneTypeDIE =
-      (InputDieEntry->getTag() != dwarf::DW_TAG_compile_unit) &&
-      Info.needToPlaceInTypeTable();
+      !isUnitRootDIE(InputDieIdx) && Info.needToPlaceInTypeTable();
   std::pair<DIE *, TypeEntry *> ClonedDIE;
 
   DIEGenerator PlainDIEGenerator(Allocator, *this);
@@ -1449,8 +1448,7 @@ std::pair<DIE *, TypeEntry *> CompileUnit::cloneDIE(
       (ClonedDIE.first && Info.getKeepPlainChildren());
 
   bool HasTypeChildrenToClone =
-      ((ClonedDIE.second ||
-        InputDieEntry->getTag() == dwarf::DW_TAG_compile_unit) &&
+      ((ClonedDIE.second || isUnitRootDIE(InputDieIdx)) &&
        Info.getKeepTypeChildren());
 
   // Recursively clone children.

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.h
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.h
@@ -335,6 +335,11 @@ public:
   ///
   /// @{
 
+  /// \p DieIdx index of the DIE.
+  /// \returns true if the DIE is the unit's root, which is always at index
+  /// zero, whatever tag it carries.
+  static bool isUnitRootDIE(uint32_t DieIdx) { return DieIdx == 0; }
+
   /// \p Idx index of the DIE.
   /// \returns DieInfo descriptor.
   DIEInfo &getDIEInfo(unsigned Idx) { return DieInfoArray[Idx]; }

--- a/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
@@ -108,13 +108,14 @@ void DependencyTracker::verifyKeepChain() {
 
 static bool isNamespaceLikeEntry(const DWARFDebugInfoEntry *Entry) {
   switch (Entry->getTag()) {
-  case dwarf::DW_TAG_compile_unit:
   case dwarf::DW_TAG_module:
   case dwarf::DW_TAG_namespace:
     return true;
 
   default:
-    return false;
+    // A unit root is a scope that its children merely sit in, whatever tag it
+    // carries, and never an entity that needs all of them.
+    return dwarf::isUnitType(Entry->getTag());
   }
 }
 
@@ -132,10 +133,20 @@ bool DependencyTracker::resolveDependenciesAndMarkLiveness(
   InterCUProcessingWasStarted = InterCUProcessingStarted;
 
   // Search for live root DIEs.
-  CompileUnit::DIEInfo &CUInfo = CU.getDIEInfo(CU.getDebugInfoEntry(0));
+  UnitEntryPairTy UnitRootEntry{&CU, CU.getDebugInfoEntry(0)};
+  CompileUnit::DIEInfo &CUInfo = CU.getDIEInfo(UnitRootEntry.DieEntry);
   CUInfo.setPlacement(CompileUnit::PlainDwarf);
-  collectRootsToKeep(UnitEntryPairTy{&CU, CU.getDebugInfoEntry(0)},
-                     std::nullopt, false);
+  collectRootsToKeep(UnitRootEntry, std::nullopt, false);
+
+  // Updating the index tables reproduces the input's debug info rather than
+  // selecting from it, so the unit root is itself the live root and nothing
+  // below it is collected. This is the counterpart of analyzeDWARFStructureRec
+  // withholding TrackLiveness for the same option. The search above still has
+  // to run, and to run first: it is what sets HasAnAddress on the subprograms,
+  // variables and labels, which is what makes the walk below skip them.
+  if (CU.getGlobalData().getOptions().UpdateIndexTablesOnly)
+    addActionToRootEntriesWorkList(LiveRootWorklistActionTy::MarkLiveEntryRec,
+                                   UnitRootEntry, std::nullopt);
 
   // Mark live DIEs as kept.
   return markCollectedLiveRootsAsKept(InterCUProcessingStarted,

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/empty-CU.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/empty-CU.test
@@ -1,5 +1,11 @@
 RUN: llvm-mc %p/../../Inputs/empty-CU.s -filetype obj -triple x86_64-apple-darwin -o %t.o
 RUN: dsymutil --linker parallel --update -f %t.o -o - | llvm-dwarfdump -v - -debug-info | FileCheck %s
 
+## --update reproduces the input rather than selecting from it, so a unit whose
+## root DIE has no children survives with nothing in it. This is what the
+## classic backend has always emitted for this input; see ../empty-CU.test.
+
 CHECK: .debug_info contents:
-CHECK-NOT: DW_TAG_compile_unit
+CHECK: 0x00000000: Compile Unit: length = 0x00000008, format = DWARF32, version = 0x0003, abbr_offset = 0x0000, addr_size = 0x04 (next unit at 0x0000000c)
+
+CHECK: 0x0000000b: DW_TAG_compile_unit [1]

--- a/llvm/test/tools/dsymutil/X86/empty-CU.test
+++ b/llvm/test/tools/dsymutil/X86/empty-CU.test
@@ -6,4 +6,5 @@ CHECK: 0x00000000: Compile Unit: length = 0x00000008, format = DWARF32, version 
 
 CHECK: 0x0000000b: DW_TAG_compile_unit [1]
 
-## FIXME: Support --linker parallel
+## The parallel backend produces the same output; see
+## DWARFLinkerParallel/empty-CU.test.

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-garbage-collection.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-garbage-collection.test
@@ -1,0 +1,228 @@
+## Garbage collection is decided by --garbage-collection and nothing else, but
+## the parallel linker got it wrong in both directions at once. The option was
+## never consulted by the walk that marks DIEs, so --no-garbage-collection
+## collected anyway; and the walk treated a DW_TAG_partial_unit root as an
+## entity whose children are all needed rather than as a scope, so a partial
+## unit was never collected at all. The two errors cancelled on the one
+## combination where both applied, which is why either alone looked correct.
+##
+## U02:  void foo2();                             // the only live code
+##       namespace ns { struct S { int m1; }; }   // nothing refers to it
+##       struct Outer { int m2; };                // nor to this one
+##
+## Outer is the guard against a fix that stops the recursive marking outright
+## instead of exempting unit roots from it. The "int" DW_TAG_base_type is
+## written as a child of Outer rather than at unit scope, and a base type is
+## kept unconditionally whatever the option says, so keeping it obliges the
+## linker to keep the rest of Outer - a structure is not a scope, and half of
+## one is not a type. That obligation must survive, while the
+## identical-looking one a unit root would impose must not.
+
+# RUN: yaml2obj %s -DROOT=DW_TAG_compile_unit -DUNITTYPE=DW_UT_compile -o %t.cu.o
+# RUN: yaml2obj %s -DROOT=DW_TAG_partial_unit -DUNITTYPE=DW_UT_partial -o %t.pu.o
+
+## Collection enabled, which is the default. ns, S and m1 go, Outer stays.
+# RUN: llvm-dwarfutil %t.cu.o %t.cu.gc.classic
+# RUN: llvm-dwarfdump --debug-info %t.cu.gc.classic | FileCheck %s --check-prefixes=CHECK,CU --implicit-check-not='DW_AT_name ("{{(ns|S|m1)}}")'
+# RUN: llvm-dwarfutil %t.pu.o %t.pu.gc.classic
+# RUN: llvm-dwarfdump --debug-info %t.pu.gc.classic | FileCheck %s --check-prefixes=CHECK,PU --implicit-check-not='DW_AT_name ("{{(ns|S|m1)}}")'
+# RUN: llvm-dwarfutil --linker parallel %t.cu.o %t.cu.gc.parallel
+# RUN: llvm-dwarfdump --debug-info %t.cu.gc.parallel | FileCheck %s --check-prefixes=CHECK,CU --implicit-check-not='DW_AT_name ("{{(ns|S|m1)}}")'
+# RUN: llvm-dwarfutil --linker parallel %t.pu.o %t.pu.gc.parallel
+# RUN: llvm-dwarfdump --debug-info %t.pu.gc.parallel | FileCheck %s --check-prefixes=CHECK,PU --implicit-check-not='DW_AT_name ("{{(ns|S|m1)}}")'
+
+## Collection disabled, so every DIE the input carries reaches the output.
+## --build-accelerator=DWARF is what makes these runs test anything:
+## --no-garbage-collection on its own copies the file without running the
+## linker, and a copy keeps the input's DIEs trivially.
+# RUN: llvm-dwarfutil --no-garbage-collection --build-accelerator=DWARF %t.cu.o %t.cu.nogc.classic
+# RUN: llvm-dwarfdump --debug-info %t.cu.nogc.classic | FileCheck %s --check-prefixes=CHECK,NOGC,CU
+# RUN: llvm-dwarfutil --no-garbage-collection --build-accelerator=DWARF %t.pu.o %t.pu.nogc.classic
+# RUN: llvm-dwarfdump --debug-info %t.pu.nogc.classic | FileCheck %s --check-prefixes=CHECK,NOGC,PU
+# RUN: llvm-dwarfutil --linker parallel --no-garbage-collection --build-accelerator=DWARF %t.cu.o %t.cu.nogc.parallel
+# RUN: llvm-dwarfdump --debug-info %t.cu.nogc.parallel | FileCheck %s --check-prefixes=CHECK,NOGC,CU
+# RUN: llvm-dwarfutil --linker parallel --no-garbage-collection --build-accelerator=DWARF %t.pu.o %t.pu.nogc.parallel
+# RUN: llvm-dwarfdump --debug-info %t.pu.nogc.parallel | FileCheck %s --check-prefixes=CHECK,NOGC,PU
+
+## One expectation set for all eight runs: CHECK is what every run must show,
+## NOGC adds the three DIEs that only survive with collection disabled, and
+## CU/PU pin U02's root tag, which also proves the two objects really differ.
+## The output with collection disabled is the collected output plus ns, S and
+## m1, and writing it that way is the claim rather than a coincidence.
+# CHECK:           DW_AT_name ("U01")
+# CHECK:           DW_TAG_subprogram
+# CHECK-NEXT:        DW_AT_name ("foo1")
+# CU:              DW_TAG_compile_unit
+# PU:              DW_TAG_partial_unit
+# CHECK:           DW_AT_name ("U02")
+# CHECK:           DW_TAG_subprogram
+# CHECK-NEXT:        DW_AT_name ("foo2")
+# NOGC:            DW_TAG_namespace
+# NOGC-NEXT:         DW_AT_name ("ns")
+# NOGC:            DW_TAG_structure_type
+# NOGC-NEXT:         DW_AT_name ("S")
+# NOGC:            DW_TAG_member
+# NOGC-NEXT:         DW_AT_name ("m1")
+# CHECK:           DW_TAG_structure_type
+# CHECK-NEXT:        DW_AT_name ("Outer")
+# CHECK:           DW_TAG_member
+# CHECK-NEXT:        DW_AT_name ("m2")
+# CHECK:           DW_TAG_base_type
+# CHECK-NEXT:        DW_AT_name ("int")
+
+## Two DWARFv5 units, each with a function of its own in .text so that neither
+## is dropped for having no live code. Only U02's root tag is parameterized;
+## U01 stays a compile unit throughout and shows that a sibling unit is not
+## disturbed. Each root carries its own DW_AT_str_offsets_base, so the strings
+## the linker rewrites into DW_FORM_strx stay resolvable on output; the linker
+## does not synthesize that attribute for a partial unit root by itself.
+--- !ELF
+FileHeader:
+  Class:    ELFCLASS64
+  Data:     ELFDATA2LSB
+  Type:     ET_REL
+  Machine:  EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1130
+    Size:            0x20
+  - Name:            .debug_str_offsets
+    Type:            SHT_PROGBITS
+    Flags:           [  ]
+    Content:        "0400000005000000"
+DWARF:
+  debug_abbrev:
+    - ID: 0
+      Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_str_offsets_base
+            Form:      DW_FORM_sec_offset
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+      - Tag:      DW_TAG_namespace
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_member
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+          - Attribute: DW_AT_data_member_location
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      [[ROOT]]
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_str_offsets_base
+            Form:      DW_FORM_sec_offset
+  debug_info:
+    - Version:  5
+      AbbrevTableID: 0
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: by_hand
+            - CStr: U01
+            - Value: 0x04
+            - Value: 0x1130
+            - Value: 0x10
+            - Value: 0x8
+        - AbbrCode: 2
+          Values:
+            - CStr: foo1
+            - Value: 0x1130
+            - Value: 0x10
+        - AbbrCode: 0
+    - Version:  5
+      AbbrevTableID: 0
+      UnitType: [[UNITTYPE]]
+      Entries:
+        - AbbrCode: 7
+          Values:
+            - CStr: by_hand
+            - CStr: U02
+            - Value: 0x04
+            - Value: 0x1140
+            - Value: 0x10
+            - Value: 0x8
+        - AbbrCode: 2
+          Values:
+            - CStr: foo2
+            - Value: 0x1140
+            - Value: 0x10
+        - AbbrCode: 3
+          Values:
+            - CStr: ns
+        - AbbrCode: 4
+          Values:
+            - CStr: S
+            - Value: 0x4
+        - AbbrCode: 5
+          Values:
+            - CStr: m1
+            - Value: 0x69
+            - Value: 0x0
+        - AbbrCode: 0
+        - AbbrCode: 0
+        - AbbrCode: 4
+          Values:
+            - CStr: Outer
+            - Value: 0x4
+        - AbbrCode: 5
+          Values:
+            - CStr: m2
+            - Value: 0x69
+            - Value: 0x0
+        - AbbrCode: 6
+          Values:
+            - CStr: int
+        - AbbrCode: 0
+        - AbbrCode: 0
+...

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-namespace.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-namespace.test
@@ -1,0 +1,178 @@
+## A DW_TAG_partial_unit root - what dwz emits, and what Fedora, RHEL and
+## Debian debuginfo packaging therefore ships - was kept out of the artificial
+## type unit by nothing but a test on its tag, so it was cloned as a type DIE
+## and asked for the type entry that no unit root is ever assigned. Reaching
+## that point needs a scope between the type and the unit root, because the
+## walk that looks for a type's enclosing scope stops at a namespace but runs
+## past a unit root. A DW_TAG_compile_unit root is linked alongside as the
+## control.
+##
+## namespace ns {
+##   struct S { int m1; };
+## }
+##
+## ns::S foo1() { ... }
+
+# RUN: yaml2obj %s -DROOT=DW_TAG_compile_unit -DUNITTYPE=DW_UT_compile -o %t.cu.o
+# RUN: llvm-dwarfutil %t.cu.o %t.cu.classic
+# RUN: llvm-dwarfdump --debug-info %t.cu.classic | FileCheck %s --check-prefixes=CLASSIC,CLASSIC-CU
+# RUN: llvm-dwarfutil --linker parallel %t.cu.o %t.cu.parallel
+# RUN: llvm-dwarfdump --debug-info %t.cu.parallel | FileCheck %s --check-prefixes=PARALLEL,PARALLEL-CU
+
+# RUN: yaml2obj %s -DROOT=DW_TAG_partial_unit -DUNITTYPE=DW_UT_partial -o %t.pu.o
+# RUN: llvm-dwarfutil %t.pu.o %t.pu.classic
+# RUN: llvm-dwarfdump --debug-info %t.pu.classic | FileCheck %s --check-prefixes=CLASSIC,CLASSIC-PU
+# RUN: llvm-dwarfutil --linker parallel %t.pu.o %t.pu.parallel
+# RUN: llvm-dwarfdump --debug-info %t.pu.parallel | FileCheck %s --check-prefixes=PARALLEL,PARALLEL-PU
+
+## The classic backend leaves the type where it found it, and the root tag
+## survives linking. llvm-dwarfdump qualifies a type name with the names of its
+## enclosing scopes and a partial unit root is one, which a compile unit root
+## is not, so the type is printed as "U01::ns::S" for the partial unit run and
+## as "ns::S" for the control. The reference target is the same DIE either way.
+# CLASSIC-CU:     DW_TAG_compile_unit
+# CLASSIC-PU:     DW_TAG_partial_unit
+# CLASSIC:        DW_TAG_subprogram
+# CLASSIC-NEXT:     DW_AT_name ("foo1")
+# CLASSIC-CU:       DW_AT_type (0x00000000[[S:[0-9a-f]{8}]] "ns::S")
+# CLASSIC-PU:       DW_AT_type (0x00000000[[S:[0-9a-f]{8}]] "U01::ns::S")
+# CLASSIC:        DW_TAG_namespace
+# CLASSIC-NEXT:     DW_AT_name ("ns")
+# CLASSIC:      0x[[S]]:     DW_TAG_structure_type
+# CLASSIC-NEXT:   DW_AT_name ("S")
+# CLASSIC:          DW_TAG_member
+# CLASSIC-NEXT:       DW_AT_name ("m1")
+
+## The parallel backend puts the type in the artificial type unit, under a copy
+## of the namespace that held it, and the unit's reference resolves there. The
+## unit root itself stays out of that unit, which is what this pins: it has no
+## name of its own to be deduplicated under, and cloning it as a type DIE is
+## what used to crash.
+# PARALLEL:      DW_AT_name ("__artificial_type_unit")
+# PARALLEL:      DW_TAG_namespace
+# PARALLEL-NEXT:   DW_AT_name ("ns")
+# PARALLEL:      0x[[S:[0-9a-f]{8}]]:     DW_TAG_structure_type
+# PARALLEL-NEXT:   DW_AT_name ("S")
+# PARALLEL:          DW_TAG_member
+# PARALLEL-NEXT:       DW_AT_name ("m1")
+# PARALLEL-CU:   DW_TAG_compile_unit
+# PARALLEL-PU:   DW_TAG_partial_unit
+# PARALLEL-NEXT:   DW_AT_producer ("by_hand")
+# PARALLEL-NEXT:   DW_AT_name ("U01")
+# PARALLEL:      DW_TAG_subprogram
+# PARALLEL-NEXT:   DW_AT_name ("foo1")
+# PARALLEL:        DW_AT_type (0x00000000[[S]] "ns::S")
+
+## One DWARFv5 unit with a function in .text returning struct S, which is
+## defined in namespace ns. The root carries its own DW_AT_str_offsets_base, so
+## the strings the linker rewrites into DW_FORM_strx stay resolvable on output;
+## the linker does not synthesize that attribute for a partial unit root by
+## itself.
+--- !ELF
+FileHeader:
+  Class:    ELFCLASS64
+  Data:     ELFDATA2LSB
+  Type:     ET_REL
+  Machine:  EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1130
+    Size:            0x10
+  - Name:            .debug_str_offsets
+    Type:            SHT_PROGBITS
+    Flags:           [  ]
+    Content:        "0400000005000000"
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      [[ROOT]]
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_str_offsets_base
+            Form:      DW_FORM_sec_offset
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_namespace
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_member
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+          - Attribute: DW_AT_data_member_location
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+  debug_info:
+    - Version:  5
+      UnitType: [[UNITTYPE]]
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: by_hand
+            - CStr: U01
+            - Value: 0x04
+            - Value: 0x1130
+            - Value: 0x10
+            - Value: 0x8
+        - AbbrCode: 2
+          Values:
+            - CStr: foo1
+            - Value: 0x1130
+            - Value: 0x10
+            - Value: 0x4d
+        - AbbrCode: 3
+          Values:
+            - CStr: ns
+        - AbbrCode: 4
+          Values:
+            - CStr: S
+            - Value: 0x8
+        - AbbrCode: 5
+          Values:
+            - CStr: m1
+            - Value: 0x5c
+            - Value: 0x0
+        - AbbrCode: 0
+        - AbbrCode: 0
+        - AbbrCode: 6
+          Values:
+            - CStr: int
+        - AbbrCode: 0
+...

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-types-only.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-types-only.test
@@ -1,0 +1,168 @@
+## A unit root is never assigned a type entry, so it is never cloned into the
+## artificial type unit and the recursion into its type children is allowed by
+## a separate test - which named DW_TAG_compile_unit only. A
+## DW_TAG_partial_unit root holding types and no code, the unit dwz produces to
+## carry the definitions it hoisted out of the compile units, therefore reached
+## neither branch and its subtree was dropped after the type name had already
+## been registered. A DW_TAG_compile_unit root is linked alongside as the
+## control.
+##
+## U01:  namespace ns { struct S {}; }
+## U02:  ns::S foo1() { ... }   // DW_FORM_ref_addr reference into U01
+##
+## The classic backend is not linked here. It fails on this input for an
+## unrelated reason, a cross-unit reference to a DIE it never gave an output
+## unit, which is a separate defect from the one this test covers.
+
+# RUN: yaml2obj %s -DROOT=DW_TAG_compile_unit -DUNITTYPE=DW_UT_compile -o %t.cu.o
+# RUN: llvm-dwarfutil --linker parallel %t.cu.o %t.cu.out
+# RUN: llvm-dwarfdump --debug-info %t.cu.out | FileCheck %s --implicit-check-not='DW_AT_name ("U01")'
+
+# RUN: yaml2obj %s -DROOT=DW_TAG_partial_unit -DUNITTYPE=DW_UT_partial -o %t.pu.o
+# RUN: llvm-dwarfutil --linker parallel %t.pu.o %t.pu.out
+# RUN: llvm-dwarfdump --debug-info %t.pu.out | FileCheck %s --check-prefixes=CHECK,CHECK-PU
+
+## The type reaches the artificial type unit under a copy of the namespace that
+## held it, and the second unit's reference resolves into the type unit rather
+## than to a dropped DIE.
+# CHECK:           DW_AT_name ("__artificial_type_unit")
+# CHECK:           DW_TAG_namespace
+# CHECK-NEXT:        DW_AT_name ("ns")
+# CHECK:         0x[[S:[0-9a-f]{8}]]:     DW_TAG_structure_type
+# CHECK-NEXT:        DW_AT_name ("S")
+# CHECK-NEXT:        DW_AT_byte_size (0x08)
+
+## The first unit is emptied either way, since its only child moved to the type
+## unit, but the two roots are then treated differently: a compile unit with
+## nothing left is dropped whole, while a partial unit root is still emitted.
+## That difference is the linker's existing behaviour for a unit with no live
+## contents, not something this fix introduces, so it is pinned rather than
+## made uniform.
+# CHECK-PU:        DW_TAG_partial_unit
+# CHECK-PU-NEXT:     DW_AT_producer ("by_hand")
+# CHECK-PU-NEXT:     DW_AT_name ("U01")
+# CHECK:           DW_TAG_compile_unit
+# CHECK-NEXT:        DW_AT_producer ("by_hand")
+# CHECK-NEXT:        DW_AT_name ("U02")
+# CHECK:           DW_TAG_subprogram
+# CHECK-NEXT:        DW_AT_name ("foo1")
+# CHECK:             DW_AT_type (0x00000000[[S]] "ns::S")
+
+## Two DWARFv5 units. The first defines struct S in namespace ns and has no
+## code of its own; the second has the only function, which returns S through a
+## DW_FORM_ref_addr reference into the first. S is deliberately memberless, so
+## that the first unit holds nothing the linker would keep in plain DWARF - a
+## member would pull in a DW_TAG_base_type, which is always kept, and that
+## alone would give the root plain children to descend for. Each root carries
+## its own DW_AT_str_offsets_base, so the strings the linker rewrites into
+## DW_FORM_strx stay resolvable on output; the linker does not synthesize that
+## attribute for a partial unit root by itself.
+--- !ELF
+FileHeader:
+  Class:    ELFCLASS64
+  Data:     ELFDATA2LSB
+  Type:     ET_REL
+  Machine:  EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1130
+    Size:            0x10
+  - Name:            .debug_str_offsets
+    Type:            SHT_PROGBITS
+    Flags:           [  ]
+    Content:        "0400000005000000"
+DWARF:
+  debug_abbrev:
+    - ID:    0
+      Table:
+      - Tag:      [[ROOT]]
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+          - Attribute: DW_AT_str_offsets_base
+            Form:      DW_FORM_sec_offset
+      - Tag:      DW_TAG_namespace
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_producer
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_str_offsets_base
+            Form:      DW_FORM_sec_offset
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_low_pc
+            Form:      DW_FORM_addr
+          - Attribute: DW_AT_high_pc
+            Form:      DW_FORM_data8
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref_addr
+  debug_info:
+    - Version:  5
+      UnitType: [[UNITTYPE]]
+      AbbrevTableID: 0
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: by_hand
+            - CStr: U01
+            - Value: 0x04
+            - Value: 0x8
+        - AbbrCode: 2
+          Values:
+            - CStr: ns
+        - AbbrCode: 3
+          Values:
+            - CStr: S
+            - Value: 0x8
+        - AbbrCode: 0
+        - AbbrCode: 0
+    - Version:  5
+      UnitType: DW_UT_compile
+      AbbrevTableID: 0
+      Entries:
+        - AbbrCode: 4
+          Values:
+            - CStr: by_hand
+            - CStr: U02
+            - Value: 0x04
+            - Value: 0x1130
+            - Value: 0x10
+            - Value: 0x8
+        - AbbrCode: 5
+          Values:
+            - CStr: foo1
+            - Value: 0x1130
+            - Value: 0x10
+            - Value: 0x23
+        - AbbrCode: 0
+...

--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-types-only.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-types-only.test
@@ -20,7 +20,7 @@
 
 # RUN: yaml2obj %s -DROOT=DW_TAG_partial_unit -DUNITTYPE=DW_UT_partial -o %t.pu.o
 # RUN: llvm-dwarfutil --linker parallel %t.pu.o %t.pu.out
-# RUN: llvm-dwarfdump --debug-info %t.pu.out | FileCheck %s --check-prefixes=CHECK,CHECK-PU
+# RUN: llvm-dwarfdump --debug-info %t.pu.out | FileCheck %s --implicit-check-not='DW_AT_name ("U01")'
 
 ## The type reaches the artificial type unit under a copy of the namespace that
 ## held it, and the second unit's reference resolves into the type unit rather
@@ -33,14 +33,9 @@
 # CHECK-NEXT:        DW_AT_byte_size (0x08)
 
 ## The first unit is emptied either way, since its only child moved to the type
-## unit, but the two roots are then treated differently: a compile unit with
-## nothing left is dropped whole, while a partial unit root is still emitted.
-## That difference is the linker's existing behaviour for a unit with no live
-## contents, not something this fix introduces, so it is pinned rather than
-## made uniform.
-# CHECK-PU:        DW_TAG_partial_unit
-# CHECK-PU-NEXT:     DW_AT_producer ("by_hand")
-# CHECK-PU-NEXT:     DW_AT_name ("U01")
+## unit, and a unit left with nothing is dropped whole whatever tag its root
+## carried. Both runs therefore expect the same output, which is what the
+## shared --implicit-check-not on U01 pins.
 # CHECK:           DW_TAG_compile_unit
 # CHECK-NEXT:        DW_AT_producer ("by_hand")
 # CHECK-NEXT:        DW_AT_name ("U02")


### PR DESCRIPTION
**Summary**

- **Broken:** garbage collection must be decided by `--garbage-collection` alone. The parallel backend's liveness marking pass gets two decisions wrong, in opposite directions. `--no-garbage-collection` never reached that pass, so namespaces, types and everything beneath them were collected anyway; and `isNamespaceLikeEntry` named `DW_TAG_compile_unit` alone among the unit roots, so a partial unit root counted as an entity needing all its children and no partial unit was ever collected. The two cancel on a partial unit with collection disabled, which is why each half alone looks correct.
- **Fix:** honour the option by marking the unit root's subtree live when collection is off, and treat every unit root as a scope.
- **Implementation:** `UpdateIndexTablesOnly` now schedules a recursive live mark on the unit root, with `collectRootsToKeep` still running first because it is what sets `HasAnAddress`, and `isNamespaceLikeEntry` uses `dwarf::isUnitType` — tested by tag rather than by position, since its callers hand it arbitrary ancestors.

Depends on #219615.

Garbage collection is decided by `--garbage-collection` and nothing else, but the parallel linker's keep walk got two decisions wrong at once, in opposite directions. `--no-garbage-collection` never reached the walk, so it collected anyway. The walk also treated a `DW_TAG_partial_unit` root as an entity whose children are all needed rather than as a scope, so it never collected a partial unit at all. A partial unit with collection disabled was the only one of the four combinations that produced the right output, and it produced it by accident — those DIEs survived because the unit was never collected, not because the option was honoured. That cancellation is why either half alone looks correct, and why the second half went unexplained when #219615 ran into it.

`--no-garbage-collection` arrives as `UpdateIndexTablesOnly`, and its entire effect on marking was to withhold `TrackLiveness`. That flag is read only by `isLiveVariableEntry` and `isLiveSubprogramEntry`, so all it achieved was making subprograms, variables and labels unconditionally live. `collectRootsToKeep` still selected roots by tag, so a namespace, a type, and everything beneath them was never marked and was dropped exactly as before. `DW_TAG_base_type` survived only because of its own "always keep" case, which is how an `int` outlived the `struct` whose member referenced it.

The classic backend replaces its whole keep walk with `markEverythingAsKept()` in this mode. The parallel backend now schedules a recursive live mark on the unit root, with `collectRootsToKeep` still running before it. That ordering is deliberate and is the one place this differs from classic: the search no longer decides what survives, but it is what sets `HasAnAddress` on the subprograms, variables and labels, and that is what makes the new walk skip them and leave them to the roots the search scheduled for them.

Classic's shape is not available here, which is worth saying since it is the obvious question. `markEverythingAsKept()` is a flat `for (auto &I : Info) I.Keep = !I.Prune;` over a single boolean. The parallel `DIEInfo` also carries placement and the `KeepPlainChildren`/`KeepTypeChildren` state that `markParentsAsKeepingChildren` maintains on every ancestor, so the equivalent would be a rewrite of `DependencyTracker` rather than a fix.

`isNamespaceLikeEntry` answers whether a DIE is a scope its children merely sit in or an entity that needs all of them, and among the unit roots it named `DW_TAG_compile_unit` alone. `markParentsAsKeepingChildren` consults it on every ancestor of a newly marked DIE, so the first live child anywhere in a partial unit scheduled `MarkLiveChildrenRec` on the root itself and marked every DIE in the unit. `dwarf::isUnitType` covers all four unit root tags.

The predicate is tested by tag rather than by position, unlike #219615 and #219747. All of its callers hand it arbitrary ancestors rather than unit roots, so this is the `appendScopes` situation from #219729, not the `cloneDIE` one: a positional test would refine one arm, still need the module and namespace tag test beside it, and require threading a `CompileUnit` into a predicate that currently takes a bare `DWARFDebugInfoEntry *`. `DWARFDebugInfoEntry::getTag()` returns `dwarf::Tag`, so the `isUnitType(dwarf::Tag)` overload is selected and not the `uint8_t` `DW_UT_*` one.

One unit-root test in the same file is deliberately left alone: the `DW_TAG_imported_unit` arm of `collectRootsToKeep` still compares against `DW_TAG_compile_unit`. That is #219622, fixed by #219732, and this change does not depend on it.

The new test runs the whole matrix — both backends, both root tags, both collection modes, eight runs against one expectation set. That is the claim being made: the mode decides what survives, and the root tag and the backend decide nothing. Before this, two of those eight cells were wrong, one in each direction. Writing the uncollected expectation as the collected one plus `ns`, `S` and `m1` is deliberate, so the relationship between the two modes is structural rather than something a reader has to diff by eye.

The input carries a dead `struct Outer` holding a `DW_TAG_base_type`, which is the guard against a fix that stops the recursive marking outright instead of exempting unit roots from it. That base type is kept whatever the option says, and keeping it obliges the linker to keep the rest of `Outer`, since a structure is not a scope and half of one is not a type. That obligation has to survive while the identical-looking one a unit root imposed must not. Both backends already agree on `Outer`, so it is a live control rather than an assumption.

`--build-accelerator=DWARF` on the four runs with collection disabled is what makes them test anything: `--no-garbage-collection` on its own copies the file without running the linker, and a copy keeps the input's DIEs trivially.

Marking the whole tree also means references are now followed from every DIE under `--update`, so a cross-unit `DW_FORM_ref_addr` puts both units into the inter-connected set on the first pass. Checked against the classic backend on an input where `foo1` in a compile unit takes its type from a structure in a partial unit: the two backends produce the same DIE tree with the reference resolved, differing only in parallel emitting one abbrev and string-offsets table per unit.

Two existing tests pinned the old behaviour and change here. `dsymutil/X86/DWARFLinkerParallel/empty-CU.test` expected no compile unit at all under `--update`, against a classic twin that expects the root to be present and carries `## FIXME: Support --linker parallel`. The two backends now produce identical output for that input, so the parallel test takes the classic expectations and the FIXME comes off.

`llvm-dwarfutil/ELF/X86/dwarf5-partial-unit-types-only.test`, which #219615 adds, pinned a partial unit root still being emitted where a compile unit root with nothing left was dropped whole, and said in prose that this was existing behaviour "pinned rather than made uniform". It is uniform now. Its `CHECK-PU` prefix has nothing left to check, and FileCheck errors on a prefix with no check strings, so its partial unit run drops to the same invocation as the control.

Fixes #219652.

This change was produced with AI assistance; I have reviewed it and am accountable for it.

Assisted-by: Claude Code

