### PR TITLE
[clang-tidy] Fix crash in readability-identifier-naming with forward-…

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
@@ -1259,7 +1259,7 @@ StyleKind IdentifierNamingCheck::findStyleKind(
     // necessary even if it's not an override. e.g. CRTP.
     for (const CXXBaseSpecifier &Base : Decl->getParent()->bases())
       if (const auto *RD = Base.getType()->getAsCXXRecordDecl();
-          RD && RD->hasMemberName(Decl->getDeclName()))
+          RD && RD->hasDefinition() && RD->hasMemberName(Decl->getDeclName()))
         return SK_Invalid;
 
     if (Decl->isConstexpr() && NamingStyles[SK_ConstexprMethod])

--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -162,6 +162,9 @@ infrastructure are described first, followed by tool-specific sections.
 
   - Fixed {option}`DefaultHungarianPrefix` being incorrectly diagnosed as an
     invalid option.
+    
+  - Fixed a crash when a method's enclosing class inherits from a base
+    class that is only forward-declared and not yet defined.
 
 - Improved {doc}`readability-named-parameter
   <clang-tidy/checks/readability/named-parameter>` check by ignoring

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming.cpp
@@ -834,3 +834,15 @@ Some_struct g_s1{ .SomeMember = 1 };
 // CHECK-FIXES: Some_struct g_s1{ .some_member = 1 };
 Some_struct g_s2{.SomeMember=1};
 // CHECK-FIXES: Some_struct g_s2{.some_member=1};
+
+// Regression test for https://github.com/llvm/llvm-project/issues/213948:
+// a base class that is only forward-declared must not be dereferenced
+// as if it were complete.
+
+template<class t_t>
+struct Issue_213948_outer {
+  struct Issue_213948_base;
+  struct Issue_213948_derived : public Issue_213948_base {
+    virtual void v_Foo() { }
+  };
+};


### PR DESCRIPTION
Fixes #213948

`IdentifierNamingCheck::findStyleKind()` calls `CXXRecordDecl::hasMemberName()`
on each base class of a method's enclosing class, to detect same-named
methods in bases (e.g. for CRTP). If a base class is only
forward-declared (incomplete) at that point — which can legitimately
happen for nested classes of a class template, since base-class
completeness isn't required until instantiation — `hasMemberName()`'s
underlying `CXXBasePaths::lookupInBases()` assumes the base is complete
and segfaults.

This adds a check for `RD->hasDefinition()` before calling
`hasMemberName()`, matching the existing pattern already used in this
file (`HungarianNotation::getClassPrefix()`).

Repro from the fuzzer-reported issue:

​```cpp
template<class T>
struct X {
  struct B;
  struct A : public B {
    virtual void foo() { }
  };
};
​```

Added a regression test (`identifier-naming-crash-incomplete-base.cpp`),
verified with `llvm-lit`.