### PR TITLE
[clang][bytecode] Reduce `EvalEmitter::Descriptors` inline size

### DIFF
--- a/clang/lib/AST/ByteCode/EvalEmitter.h
+++ b/clang/lib/AST/ByteCode/EvalEmitter.h
@@ -105,7 +105,7 @@ protected:
   /// Parameter indices.
   llvm::DenseMap<const ParmVarDecl *, FuncParam> Params;
   /// Local descriptors.
-  llvm::SmallVector<SmallVector<Local, 8>, 2> Descriptors;
+  llvm::SmallVector<SmallVector<Local, 2>, 1> Descriptors;
   std::optional<SourceInfo> LocOverride = std::nullopt;
 
 private:


### PR DESCRIPTION
For pure expressions, we usually have few locals and few scopes. Reduce the inline size here.