### PR TITLE
[clang-tidy] Fix crash and infinite loop on incomplete types

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/MultipleInheritanceCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/MultipleInheritanceCheck.cpp
@@ -26,12 +26,15 @@ bool MultipleInheritanceCheck::isInterface(const CXXBaseSpecifier &Base) {
   if (!Node)
     return true;
 
-  assert(Node->isCompleteDefinition());
+  if (!Node->hasDefinition())
+    return false;
 
   // Short circuit the lookup if we have analyzed this record before.
   if (const auto CachedValue = InterfaceMap.find(Node);
       CachedValue != InterfaceMap.end())
     return CachedValue->second;
+
+  InterfaceMap.try_emplace(Node, false);
 
   // To be an interface, a class must have...
   const bool CurrentClassIsInterface =
@@ -47,7 +50,7 @@ bool MultipleInheritanceCheck::isInterface(const CXXBaseSpecifier &Base) {
         return M->isUserProvided() && !M->isPureVirtual() && !M->isStatic();
       });
 
-  InterfaceMap.try_emplace(Node, CurrentClassIsInterface);
+  InterfaceMap[Node] = CurrentClassIsInterface;
   return CurrentClassIsInterface;
 }
 

--- a/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
@@ -1259,7 +1259,7 @@ StyleKind IdentifierNamingCheck::findStyleKind(
     // necessary even if it's not an override. e.g. CRTP.
     for (const CXXBaseSpecifier &Base : Decl->getParent()->bases())
       if (const auto *RD = Base.getType()->getAsCXXRecordDecl();
-          RD && RD->hasMemberName(Decl->getDeclName()))
+          RD && RD->hasDefinition() && RD->hasMemberName(Decl->getDeclName()))
         return SK_Invalid;
 
     if (Decl->isConstexpr() && NamingStyles[SK_ConstexprMethod])

--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -164,6 +164,10 @@ infrastructure are described first, followed by tool-specific sections.
   - Fixed false positives when the pointee is written through a pointer
     assignment, such as `*(p = q) = 0`.
 
+- Fixed an infinite loop in {doc}`misc-multiple-inheritance
+  <clang-tidy/checks/misc/multiple-inheritance>` check when resolving circular
+  inheritance.
+
 - Improved {doc}`misc-redundant-expression
   <clang-tidy/checks/misc/redundant-expression>` by fixing false positives in
   nested expressions involving different macros or a mix of macro and
@@ -199,6 +203,9 @@ infrastructure are described first, followed by tool-specific sections.
 
 - Improved {doc}`readability-identifier-naming
   <clang-tidy/checks/readability/identifier-naming>` check:
+
+  - Fixed a crash when checking a class that inherits from a forward-declared
+    base class.
 
   - Fixed a crash when checking forward-declared classes with
     {option}`DefaultHungarianPrefix` enabled.

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/multiple-inheritance-incomplete-type.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/multiple-inheritance-incomplete-type.cpp
@@ -1,0 +1,7 @@
+// RUN: %check_clang_tidy "%s" misc-multiple-inheritance "%t"
+
+template<class T> struct X {
+  struct B;
+  struct A : public B { virtual void foo() {} };
+};
+template<class T> struct X<T>::B : public A { virtual void foo() {} };

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-incomplete-type.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-incomplete-type.cpp
@@ -1,0 +1,9 @@
+// RUN: %check_clang_tidy "%s" readability-identifier-naming "%t"
+
+template<class T>
+struct X {
+  struct B;
+  struct A : public B {
+    virtual void foo() { }
+  };
+};


### PR DESCRIPTION
Fixes #213948

clang-tidy crashes when a class inherits from a forward-declared base class. This happens because hasMemberName() is called on an incomplete type in readability-identifier-naming check.

There's also an infinite loop in misc-multiple-inheritance check when there's circular inheritance (A inherits B, B inherits A). The isInterface() function keeps calling itself forever.

Fixed by adding hasDefinition() checks before accessing base class members, and by inserting a provisional cache entry to break cycles.

Added regression tests for both cases.

I used an AI assistant for understanding the codebase and the crash backtraces. The bug was fixed by me.