### PR TITLE
[ADT] Inline FoldingSet's equality dispatch

### DIFF
--- a/llvm/include/llvm/ADT/FoldingSet.h
+++ b/llvm/include/llvm/ADT/FoldingSet.h
@@ -361,31 +361,10 @@ public:
   /// before rebucketing. May allocate more space than requested.
   LLVM_ABI void reserve(unsigned N);
 
-protected:
-  /// Functions provided by the derived class to compute folding properties.
-  /// This is effectively a vtable for FoldingSetBase, except that we don't
-  /// actually store a pointer to it in the object.
-  struct FoldingSetInfo {
-    /// Instantiations of the FoldingSet template implement this function to
-    /// gather data bits for the given node.
-    void (*GetNodeProfile)(const FoldingSetBase *Self, Node *N,
-                           FoldingSetNodeID &ID);
-
-    /// Instantiations of the FoldingSet template implement this function to
-    /// compare the given node with the given ID.
-    bool (*NodeEquals)(const FoldingSetBase *Self, Node *N,
-                       const FoldingSetNodeID &ID, FoldingSetNodeID &TempID);
-  };
-
 private:
   /// Put \p N in the first empty slot following its home, without checking
   /// capacity. Does not touch \p N, so a rehash need not dirty every node.
   void placeNode(Node *N, uint32_t Hash);
-
-  /// Compare \p N against \p ID. Out of line to keep FoldingSetNodeID's inline
-  /// storage out of the probe loop's frame.
-  static bool nodeEquals(const FoldingSetInfo &Info, const FoldingSetBase *Self,
-                         Node *N, const FoldingSetNodeID &ID);
 
   /// Rehash into at least \p MinNumBuckets buckets, rounded up to a power of
   /// two and floored at the constructor's minimum.
@@ -399,24 +378,40 @@ protected:
   /// was removed or false if the node was not in the folding set.
   LLVM_ABI bool RemoveNode(Node *N);
 
-  /// If there is an existing node exactly equal to the node \p N,
-  /// return it.  Otherwise, insert \p N and return it instead.
-  LLVM_ABI Node *GetOrInsertNode(Node *N, const FoldingSetInfo &Info);
+  /// Walk the probe chain for \p Hash, offering each node whose cached hash
+  /// matches to \p IsMatch. \p IsMatch is a template parameter so that it, and
+  /// the profile it may build, inline into the loop.
+  template <typename MatchFn>
+  Node *probe(uint32_t Hash, FoldingSetInsertToken &Token, MatchFn IsMatch) {
+    assert(Hash != FoldingSetNodeIDRef::NotAHash && "Hash must be normalized");
+    unsigned Mask = NumBuckets - 1;
+    for (unsigned I = Hash & Mask; Buckets[I]; I = (I + 1) & Mask) {
+      Node *N = static_cast<Node *>(Buckets[I]);
+      if (N->getFoldingSetHash() == Hash && IsMatch(N)) {
+        Token = {};
+        return N;
+      }
+    }
 
-  /// Look up the node specified by ID. If it exists, return it and clear
-  /// \p Token; otherwise return null and set \p Token for a subsequent insert.
-  LLVM_ABI Node *lookup(const FoldingSetNodeID &ID,
-                        FoldingSetInsertToken &Token,
-                        const FoldingSetInfo &Info);
-  LLVM_ABI Node *FindNodeOrInsertPos(const FoldingSetNodeID &ID,
-                                     void *&InsertPos,
-                                     const FoldingSetInfo &Info);
+    Token = FoldingSetInsertToken(Hash);
+    return nullptr;
+  }
 
   /// Insert the specified node into the folding set, knowing that it is not
   /// already in the folding set.  \p Token must come from lookup for an ID that
   /// \p N profiles identically to.
   LLVM_ABI void insert(Node *N, FoldingSetInsertToken Token);
   LLVM_ABI void InsertNode(Node *N, void *InsertPos);
+
+  /// Convert between a token and the opaque InsertPos of the legacy API. The
+  /// empty token is null, so decoding null asserts as InsertNode requires.
+  static void *encodeInsertPos(FoldingSetInsertToken Token) {
+    return reinterpret_cast<void *>(static_cast<uintptr_t>(Token.Hash));
+  }
+  static FoldingSetInsertToken decodeInsertPos(void *InsertPos) {
+    return FoldingSetInsertToken(
+        static_cast<uint32_t>(reinterpret_cast<uintptr_t>(InsertPos)));
+  }
 };
 
 // Convenience type to hide the implementation of the folding set.
@@ -443,32 +438,22 @@ inline bool DefaultContextualFoldingSetTrait<T, Ctx>::Equals(
 /// ContextualFoldingSet.
 template <class T, class Trait = FoldingSetTrait<T>>
 class FoldingSetImpl : public FoldingSetBase, public Trait::ContextStorage {
-  // We define Info inside a static member function rather than as a static
-  // constexpr member variable to avoid eager instantiation on MSVC when T is an
-  // incomplete type.
-  static const FoldingSetBase::FoldingSetInfo &getFoldingSetInfo() {
-    static constexpr FoldingSetBase::FoldingSetInfo Info = {
-        // GetNodeProfile
-        [](const FoldingSetBase *Base, FoldingSetNode *N,
-           FoldingSetNodeID &ID) {
-          if constexpr (std::is_empty_v<typename Trait::ContextStorage>)
-            Trait::Profile(*static_cast<T *>(N), ID);
-          else
-            Trait::Profile(
-                *static_cast<T *>(N), ID,
-                static_cast<const FoldingSetImpl *>(Base)->getContext());
-        },
-        // NodeEquals
-        [](const FoldingSetBase *Base, FoldingSetNode *N,
-           const FoldingSetNodeID &ID, FoldingSetNodeID &TempID) {
-          if constexpr (std::is_empty_v<typename Trait::ContextStorage>)
-            return Trait::Equals(*static_cast<T *>(N), ID, TempID);
-          else
-            return Trait::Equals(
-                *static_cast<T *>(N), ID, TempID,
-                static_cast<const FoldingSetImpl *>(Base)->getContext());
-        }};
-    return Info;
+  void nodeProfile(FoldingSetNode *N, FoldingSetNodeID &ID) const {
+    if constexpr (std::is_empty_v<typename Trait::ContextStorage>)
+      Trait::Profile(*static_cast<T *>(N), ID);
+    else
+      Trait::Profile(*static_cast<T *>(N), ID, this->getContext());
+  }
+
+  bool nodeEquals(FoldingSetNode *N, const FoldingSetNodeID &ID) const {
+    // Trait::Equals profiles into TempID without clearing it first, so each
+    // candidate needs its own.
+    FoldingSetNodeID TempID;
+    if constexpr (std::is_empty_v<typename Trait::ContextStorage>)
+      return Trait::Equals(*static_cast<T *>(N), ID, TempID);
+    else
+      return Trait::Equals(*static_cast<T *>(N), ID, TempID,
+                           this->getContext());
   }
 
 public:
@@ -509,9 +494,17 @@ public:
 
   /// If there is an existing node exactly equal to the specified node,
   /// return it.  Otherwise, insert 'N' and return it instead.
-  T *getOrInsert(T *N) {
-    return static_cast<T *>(
-        FoldingSetBase::GetOrInsertNode(N, getFoldingSetInfo()));
+  ///
+  /// Out of line so that callers do not inherit the ID's inline storage; some
+  /// of them recurse.
+  LLVM_ATTRIBUTE_NOINLINE T *getOrInsert(T *N) {
+    FoldingSetNodeID ID;
+    nodeProfile(N, ID);
+    FoldingSetInsertToken Token;
+    if (T *E = lookup(ID, Token))
+      return E;
+    FoldingSetBase::insert(N, Token);
+    return N;
   }
   T *GetOrInsertNode(T *N) { return getOrInsert(N); }
 
@@ -519,11 +512,14 @@ public:
   /// \p Token; otherwise return null and set \p Token for a subsequent insert.
   T *lookup(const FoldingSetNodeID &ID, FoldingSetInsertToken &Token) {
     return static_cast<T *>(
-        FoldingSetBase::lookup(ID, Token, getFoldingSetInfo()));
+        probe(ID.ComputeHash(), Token,
+              [&](FoldingSetNode *N) { return nodeEquals(N, ID); }));
   }
   T *FindNodeOrInsertPos(const FoldingSetNodeID &ID, void *&InsertPos) {
-    return static_cast<T *>(FoldingSetBase::FindNodeOrInsertPos(
-        ID, InsertPos, getFoldingSetInfo()));
+    FoldingSetInsertToken Token;
+    T *N = lookup(ID, Token);
+    InsertPos = encodeInsertPos(Token);
+    return N;
   }
 
   /// Insert the specified node into the folding set, knowing that it is not

--- a/llvm/lib/Support/FoldingSet.cpp
+++ b/llvm/lib/Support/FoldingSet.cpp
@@ -133,15 +133,6 @@ FoldingSetNodeID::Intern(BumpPtrAllocator &Allocator) const {
 //===----------------------------------------------------------------------===//
 // FoldingSetBase Implementation
 
-/// Encode a 32-bit hash as an opaque non-null token for InsertPos.
-static void *encodeHash(uint32_t Hash) {
-  return reinterpret_cast<void *>(static_cast<uintptr_t>(Hash));
-}
-
-static uint32_t decodeHash(void *InsertPos) {
-  return static_cast<uint32_t>(reinterpret_cast<uintptr_t>(InsertPos));
-}
-
 FoldingSetBase::FoldingSetBase(unsigned Log2InitSize) {
   assert(5 < Log2InitSize && Log2InitSize < 32 &&
          "Initial hash table size out of range");
@@ -211,39 +202,6 @@ void FoldingSetBase::reserve(unsigned N) {
   grow(N + (N + 2) / 3);
 }
 
-LLVM_ATTRIBUTE_NOINLINE bool
-FoldingSetBase::nodeEquals(const FoldingSetInfo &Info,
-                           const FoldingSetBase *Self, Node *N,
-                           const FoldingSetNodeID &ID) {
-  FoldingSetNodeID TempID;
-  return Info.NodeEquals(Self, N, ID, TempID);
-}
-
-FoldingSetBase::Node *FoldingSetBase::lookup(const FoldingSetNodeID &ID,
-                                             FoldingSetInsertToken &Token,
-                                             const FoldingSetInfo &Info) {
-  unsigned IDHash = ID.ComputeHash();
-  unsigned Mask = NumBuckets - 1;
-  for (unsigned I = IDHash & Mask; Buckets[I]; I = (I + 1) & Mask) {
-    Node *N = static_cast<Node *>(Buckets[I]);
-    if (N->getFoldingSetHash() == IDHash && nodeEquals(Info, this, N, ID)) {
-      Token = {};
-      return N;
-    }
-  }
-
-  Token = FoldingSetInsertToken(IDHash);
-  return nullptr;
-}
-
-FoldingSetBase::Node *FoldingSetBase::FindNodeOrInsertPos(
-    const FoldingSetNodeID &ID, void *&InsertPos, const FoldingSetInfo &Info) {
-  FoldingSetInsertToken Token;
-  Node *N = lookup(ID, Token, Info);
-  InsertPos = Token ? encodeHash(Token.Hash) : nullptr;
-  return N;
-}
-
 void FoldingSetBase::insert(Node *N, FoldingSetInsertToken Token) {
   assert(N && "Cannot insert a null node");
   assert(Token && "Invalid token!");
@@ -256,7 +214,7 @@ void FoldingSetBase::insert(Node *N, FoldingSetInsertToken Token) {
 }
 
 void FoldingSetBase::InsertNode(Node *N, void *InsertPos) {
-  insert(N, FoldingSetInsertToken(decodeHash(InsertPos)));
+  insert(N, decodeInsertPos(InsertPos));
 }
 
 bool FoldingSetBase::RemoveNode(Node *N) {
@@ -287,15 +245,4 @@ bool FoldingSetBase::RemoveNode(Node *N) {
   N->setFoldingSetHash(FoldingSetNodeIDRef::NotAHash);
   --NumNodes;
   return true;
-}
-
-FoldingSetBase::Node *
-FoldingSetBase::GetOrInsertNode(Node *N, const FoldingSetInfo &Info) {
-  FoldingSetNodeID ID;
-  Info.GetNodeProfile(this, N, ID);
-  FoldingSetInsertToken Token;
-  if (Node *E = lookup(ID, Token, Info))
-    return E;
-  insert(N, Token);
-  return N;
 }


### PR DESCRIPTION
FoldingSetBase compares nodes through a FoldingSetInfo table of function
pointers, which the compiler cannot inline through to the node's Profile().
Add a probe() template taking the match test as a template parameter, and
build lookup, FindNodeOrInsertPos and getOrInsert on it in FoldingSetImpl
where the trait is known.

LLM-aided