### PR TITLE
[libc++] Remove NaCl support from __cxx03 headers

### DIFF
--- a/libcxx/include/__cxx03/__config
+++ b/libcxx/include/__cxx03/__config
@@ -258,13 +258,6 @@ _LIBCPP_HARDENING_MODE_DEBUG
 //      When this option is used, the token passed to `std::random_device`'s
 //      constructor *must* be "/dev/urandom" -- anything else is an error.
 //
-// _LIBCPP_USING_NACL_RANDOM
-//      NaCl's sandbox (which PNaCl also runs in) doesn't allow filesystem access,
-//      including accesses to the special files under `/dev`. This implementation
-//      uses the NaCL syscall `nacl_secure_random_init()` to get entropy.
-//      When this option is used, the token passed to `std::random_device`'s
-//      constructor *must* be "/dev/urandom" -- anything else is an error.
-//
 // _LIBCPP_USING_WIN32_RANDOM
 //      Use rand_s(), for use on Windows.
 //      When this option is used, the token passed to `std::random_device`'s
@@ -276,8 +269,6 @@ _LIBCPP_HARDENING_MODE_DEBUG
 #    define _LIBCPP_USING_GETENTROPY
 #  elif defined(__Fuchsia__)
 #    define _LIBCPP_USING_FUCHSIA_CPRNG
-#  elif defined(__native_client__)
-#    define _LIBCPP_USING_NACL_RANDOM
 #  elif defined(_LIBCPP_WIN32API)
 #    define _LIBCPP_USING_WIN32_RANDOM
 #  else

--- a/libcxx/include/__cxx03/limits
+++ b/libcxx/include/__cxx03/limits
@@ -224,7 +224,7 @@ protected:
   static const bool is_bounded = true;
   static const bool is_modulo  = !std::is_signed<_Tp>::value;
 
-#if defined(__i386__) || defined(__x86_64__) || defined(__pnacl__) || defined(__wasm__)
+#if defined(__i386__) || defined(__x86_64__) || defined(__wasm__)
   static const bool traps = is_same<decltype(+_Tp(0)), _Tp>::value;
 #else
   static const bool traps = false;


### PR DESCRIPTION
Completes the NaCl cleanup started in #148983 by removing the remaining
references from the frozen `__cxx03/` headers.

Changes:

* Remove the `_LIBCPP_USING_NACL_RANDOM` comment block and
  `#elif defined(__native_client__)` branch from `include/__cxx03/__config`
* Remove `defined(__pnacl__)` from the `#if` condition in
  `include/__cxx03/limits`

The `_LIBCPP_USING_NACL_RANDOM` macro was defined but never consumed; its
previous consumer in `src/random.cpp` was already removed in #148983.

Fixes #219588
