### PR TITLE
[ORC] Drop redundant ExecutionSession& arg from lookupAndApply

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/LookupAndApply.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LookupAndApply.h
@@ -63,16 +63,21 @@ using LookupPrepareFn = unique_function<LookupApplyFn(
 /// Asynchronous version: OnApplied is called once every applicator has run, or
 /// with an error if the lookup failed (in which case none of them run).
 ///
+/// The ExecutionSession is taken from the first entry in SearchOrder (every
+/// entry must share the same session). If SearchOrder is empty then the lookup
+/// fails unconditionally. The only exception is an empty PrepareFns list, which
+/// trivially succeeds.
+///
 /// The prepare functions are only used during this call -- they are asked for
 /// their symbols up front, and only their applicators are retained -- so a
 /// braced list or other temporary is safe here.
 LLVM_ABI void lookupAndApply(unique_function<void(Error)> OnApplied,
-                             ExecutionSession &ES, LookupKind K,
+                             LookupKind K,
                              const JITDylibSearchOrder &SearchOrder,
                              ArrayRef<LookupPrepareFn> PrepareFns);
 
 /// Blocking version of lookupAndApply above.
-LLVM_ABI Error lookupAndApply(ExecutionSession &ES, LookupKind K,
+LLVM_ABI Error lookupAndApply(LookupKind K,
                               const JITDylibSearchOrder &SearchOrder,
                               ArrayRef<LookupPrepareFn> PrepareFns);
 

--- a/llvm/lib/ExecutionEngine/Orc/LookupAndApply.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/LookupAndApply.cpp
@@ -14,10 +14,23 @@
 
 namespace llvm::orc {
 
-void lookupAndApply(unique_function<void(Error)> OnApplied,
-                    ExecutionSession &ES, LookupKind K,
+void lookupAndApply(unique_function<void(Error)> OnApplied, LookupKind K,
                     const JITDylibSearchOrder &SearchOrder,
                     ArrayRef<LookupPrepareFn> PrepareFns) {
+
+  /// Empty PrepareFns list trivially succeeds.
+  if (PrepareFns.empty())
+    return OnApplied(Error::success());
+
+  /// Otherwise an empty SearchOrder trivially fails: Without it we don't have
+  /// the ExecutionSession that we need to pass into the prepare functions.
+  if (SearchOrder.empty())
+    return OnApplied(
+        make_error<StringError>("lookupAndApply failed: search order is empty",
+                                inconvertibleErrorCode()));
+
+  auto &ES = SearchOrder.front().first->getExecutionSession();
+
   // Collect the symbols to look up. Each prepare function hands back the
   // applicator that will act on the result; the prepare functions themselves
   // are not needed beyond this point.
@@ -46,25 +59,24 @@ void lookupAndApply(unique_function<void(Error)> OnApplied,
       NoDependenciesToRegister);
 }
 
-Error lookupAndApply(ExecutionSession &ES, LookupKind K,
-                     const JITDylibSearchOrder &SearchOrder,
+Error lookupAndApply(LookupKind K, const JITDylibSearchOrder &SearchOrder,
                      ArrayRef<LookupPrepareFn> PrepareFns) {
   std::promise<MSVCPError> ResultP;
   auto ResultF = ResultP.get_future();
-  lookupAndApply([&](Error Err) { ResultP.set_value(std::move(Err)); }, ES, K,
+  lookupAndApply([&](Error Err) { ResultP.set_value(std::move(Err)); }, K,
                  SearchOrder, PrepareFns);
   return ResultF.get();
 }
 
 void lookupAndApply(unique_function<void(Error)> OnApplied, JITDylib &JD,
                     ArrayRef<LookupPrepareFn> PrepareFns) {
-  lookupAndApply(std::move(OnApplied), JD.getExecutionSession(),
-                 LookupKind::Static, makeJITDylibSearchOrder(&JD), PrepareFns);
+  lookupAndApply(std::move(OnApplied), LookupKind::Static,
+                 makeJITDylibSearchOrder(&JD), PrepareFns);
 }
 
 Error lookupAndApply(JITDylib &JD, ArrayRef<LookupPrepareFn> PrepareFns) {
-  return lookupAndApply(JD.getExecutionSession(), LookupKind::Static,
-                        makeJITDylibSearchOrder(&JD), PrepareFns);
+  return lookupAndApply(LookupKind::Static, makeJITDylibSearchOrder(&JD),
+                        PrepareFns);
 }
 
 } // namespace llvm::orc

--- a/llvm/unittests/ExecutionEngine/Orc/LookupAndApplyTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/LookupAndApplyTest.cpp
@@ -35,6 +35,28 @@ static void defineAddr(JITDylib &JD, StringRef Name, ExecutorAddr Addr) {
 
 } // namespace
 
+// An empty PrepareFns list trivially succeeds, even with an empty
+// SearchOrder: there's nothing to look up, so no ExecutionSession is needed.
+TEST(LookupAndApplyTest, EmptyPrepareFnsTriviallySucceeds) {
+  EXPECT_THAT_ERROR(lookupAndApply(LookupKind::Static, {}, {}), Succeeded());
+}
+
+// An empty SearchOrder fails outright, even for a symbol that is only weakly
+// referenced (which would otherwise resolve to null rather than failing the
+// lookup, see RecordAddrWeaklyReferencedAbsent below): there is no
+// ExecutionSession to intern the symbol's name with, so the prepare function
+// is never run, and so the lookup never gets far enough to see that the
+// symbol was only weakly referenced.
+TEST(LookupAndApplyTest, EmptySearchOrderFailsEvenForWeakReference) {
+  ExecutorAddr A(AddrAValue);
+  EXPECT_THAT_ERROR(
+      lookupAndApply(LookupKind::Static, {},
+                     {recordAddr("addr_a", &A,
+                                 SymbolLookupFlags::WeaklyReferencedSymbol)}),
+      Failed());
+  EXPECT_EQ(A, ExecutorAddr(AddrAValue));
+}
+
 // recordAddr writes the resolved address of a required symbol.
 TEST(LookupAndApplyTest, RecordAddr) {
   ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));


### PR DESCRIPTION
The ExecutionSession& can be retrieved from the first element of the SearchOrder.

This changes behavior in a corner case: An empty SearchOrder always fails on a non-empty PrepareFns list, even if all symbols added would have been weakly referenced, because no ExecutionSession& is available to intern the symbol names. An empty SearchOrder is pathological, so this seems like a reasonable trade-off.