### PR TITLE
[flang-rt] Fix misspelled feraiseexcept guard in edit-input.cpp

### DIFF
--- a/flang-rt/lib/runtime/edit-input.cpp
+++ b/flang-rt/lib/runtime/edit-input.cpp
@@ -566,7 +566,7 @@ static RT_API_ATTRS void RaiseFPExceptions(
   terminator.Crash( \
       "not implemented yet: raising FP exception in device code: %s", #e);
 #else // !defined(RT_DEVICE_COMPILATION)
-#ifdef feraisexcept // a macro in some environments; omit std::
+#ifdef feraiseexcept // a macro in some environments; omit std::
 #define RAISE feraiseexcept
 #else
 #define RAISE std::feraiseexcept


### PR DESCRIPTION
The guard that selects between the unqualified and `std::`-qualified spellings of `feraiseexcept` in `flang-rt/lib/runtime/edit-input.cpp` tests `feraisexcept` — missing the second `e`. Fixed the typo.

Note that the sibling guards in `flang-rt/lib/runtime/main.cpp` and `flang-rt/lib/runtime/stop.cpp` spell their tokens correctly.

Assisted-by: AI