### PR TITLE
[OpenMP] Make OpenMP version have separate type

### DIFF
--- a/clang/lib/AST/StmtPrinter.cpp
+++ b/clang/lib/AST/StmtPrinter.cpp
@@ -780,7 +780,8 @@ void StmtPrinter::VisitOMPCanonicalLoop(OMPCanonicalLoop *Node) {
 void StmtPrinter::PrintOMPExecutableDirective(OMPExecutableDirective *S,
                                               bool ForceNoStmt) {
   unsigned OpenMPVersion =
-      Context ? Context->getLangOpts().OpenMP : llvm::omp::FallbackVersion;
+      Context ? Context->getLangOpts().OpenMP
+              : static_cast<unsigned>(llvm::omp::FallbackVersion);
   OMPClausePrinter Printer(OS, Policy, OpenMPVersion);
   ArrayRef<OMPClause *> Clauses = S->clauses();
   for (auto *Clause : Clauses)
@@ -1026,7 +1027,8 @@ void StmtPrinter::VisitOMPTeamsDirective(OMPTeamsDirective *Node) {
 void StmtPrinter::VisitOMPCancellationPointDirective(
     OMPCancellationPointDirective *Node) {
   unsigned OpenMPVersion =
-      Context ? Context->getLangOpts().OpenMP : llvm::omp::FallbackVersion;
+      Context ? Context->getLangOpts().OpenMP
+              : static_cast<unsigned>(llvm::omp::FallbackVersion);
   Indent() << "#pragma omp cancellation point "
            << getOpenMPDirectiveName(Node->getCancelRegion(), OpenMPVersion);
   PrintOMPExecutableDirective(Node);
@@ -1034,7 +1036,8 @@ void StmtPrinter::VisitOMPCancellationPointDirective(
 
 void StmtPrinter::VisitOMPCancelDirective(OMPCancelDirective *Node) {
   unsigned OpenMPVersion =
-      Context ? Context->getLangOpts().OpenMP : llvm::omp::FallbackVersion;
+      Context ? Context->getLangOpts().OpenMP
+              : static_cast<unsigned>(llvm::omp::FallbackVersion);
   Indent() << "#pragma omp cancel "
            << getOpenMPDirectiveName(Node->getCancelRegion(), OpenMPVersion);
   PrintOMPExecutableDirective(Node);

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -1308,7 +1308,8 @@ static bool parseOpenMPArgs(CompilerInvocation &res, llvm::opt::ArgList &args,
   res.getFrontendOpts().features.Enable(
       Fortran::common::LanguageFeature::OpenMP);
   if (auto *arg = args.getLastArg(clang::options::OPT_fopenmp_version_EQ)) {
-    llvm::ArrayRef<unsigned> ompVersions = llvm::omp::getOpenMPVersions();
+    llvm::ArrayRef<llvm::omp::Version> ompVersions =
+        llvm::omp::getOpenMPVersions();
     unsigned oldVersions[] = {11, 20, 25, 30};
     unsigned version = 0;
 

--- a/llvm/include/llvm/Frontend/OpenMP/ConstructDecompositionT.h
+++ b/llvm/include/llvm/Frontend/OpenMP/ConstructDecompositionT.h
@@ -97,7 +97,7 @@ struct ConstructDecompositionT {
 
   using ClauseSet = std::unordered_set<const ClauseTy *>;
 
-  ConstructDecompositionT(uint32_t ver, HelperType &helper,
+  ConstructDecompositionT(llvm::omp::Version ver, HelperType &helper,
                           llvm::omp::Directive dir,
                           llvm::ArrayRef<ClauseTy> clauses)
       : version(ver), helper(helper), inputDirective(dir) {
@@ -263,7 +263,7 @@ private:
   applyClause(const tomp::clause::ThreadLimitT<TypeTy, IdTy, ExprTy> &clause,
               const ClauseTy *);
 
-  uint32_t version;
+  llvm::omp::Version version;
   HelperType &helper;
   llvm::omp::Directive inputDirective;
   tomp::ListT<const ClauseTy *> inputClauses;
@@ -277,7 +277,7 @@ private:
 
 // Deduction guide
 template <typename ClauseType, typename HelperType>
-ConstructDecompositionT(uint32_t, HelperType &, llvm::omp::Directive,
+ConstructDecompositionT(llvm::omp::Version, HelperType &, llvm::omp::Directive,
                         llvm::ArrayRef<ClauseType>)
     -> ConstructDecompositionT<ClauseType, HelperType>;
 

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.h
@@ -13,14 +13,17 @@
 #ifndef LLVM_FRONTEND_OPENMP_OMP_H
 #define LLVM_FRONTEND_OPENMP_OMP_H
 
-#include "llvm/Frontend/OpenMP/OMP.h.inc"
 #include "llvm/Support/Compiler.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Bitset.h"
+#include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Frontend/OpenMP/OMPVersion.h"
+
+#include "llvm/Frontend/OpenMP/OMP.h.inc"
 
 namespace llvm::omp {
 template <typename Enum, size_t Size> struct EnumSet;
@@ -187,7 +190,7 @@ static constexpr inline bool canHaveIterator(Clause C) {
 }
 
 // Can clause C create a private copy of a variable.
-static constexpr inline bool isPrivatizingClause(Clause C, unsigned Version) {
+static constexpr inline bool isPrivatizingClause(Clause C, Version V) {
   switch (C) {
   case OMPC_firstprivate:
   case OMPC_in_reduction:
@@ -201,17 +204,16 @@ static constexpr inline bool isPrivatizingClause(Clause C, unsigned Version) {
   case OMPC_induction:
   case OMPC_is_device_ptr:
   case OMPC_use_device_ptr:
-    return Version >= 60;
+    return V >= 60;
   default:
     return false;
   }
 }
 
-static constexpr inline bool isDataSharingAttributeClause(Clause C,
-                                                          unsigned Version) {
+static constexpr inline bool isDataSharingAttributeClause(Clause C, Version V) {
   // The "Version" parameter is in case the result is version-depenent
   // in the future.
-  (void)Version;
+  (void)V;
   switch (C) {
   case OMPC_detach:
   case OMPC_firstprivate:
@@ -244,12 +246,12 @@ static constexpr inline bool isEndClause(Clause C) {
   }
 }
 
-static constexpr unsigned FallbackVersion = 52;
-LLVM_ABI ArrayRef<unsigned> getOpenMPVersions();
+static constexpr Version FallbackVersion(52);
+LLVM_ABI ArrayRef<Version> getOpenMPVersions();
 
 /// Can directive D, under some circumstances, create a private copy
 /// of a variable in given OpenMP version?
-LLVM_ABI bool isPrivatizingConstruct(Directive D, unsigned Version);
+LLVM_ABI bool isPrivatizingConstruct(Directive D, Version V);
 
 LLVM_ABI ArrayRef<StringRef> getReservedLocatorNames();
 

--- a/llvm/include/llvm/Frontend/OpenMP/OMPDescriptors.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPDescriptors.h
@@ -62,7 +62,7 @@ struct Modifier : public Base {
 };
 } // namespace details
 
-template <typename DetailsTy> using DetailsMap = DenseMap<unsigned, DetailsTy>;
+template <typename DetailsTy> using DetailsMap = DenseMap<Version, DetailsTy>;
 
 template <typename DetailsTy> struct Descriptor {
   Descriptor(const Descriptor &) = default;
@@ -73,9 +73,9 @@ template <typename DetailsTy> struct Descriptor {
   StringRef getName() const { return Name; }
   const DetailsMap<DetailsTy> &getDetails() const { return Details; }
 
-  SmallVector<unsigned> getVersions() const {
-    SmallVector<unsigned> Vs;
-    for (unsigned V : llvm::omp::getOpenMPVersions()) {
+  SmallVector<Version> getVersions() const {
+    SmallVector<Version> Vs;
+    for (Version V : llvm::omp::getOpenMPVersions()) {
       if (auto F = Details.find(V); F != Details.end())
         Vs.push_back(V);
     }
@@ -92,16 +92,16 @@ protected:
 struct Clause : public Descriptor<details::Clause> {
   using Base = Descriptor<details::Clause>;
   using Base::Base;
-  LLVM_ABI Properties getProperties(unsigned V) const;
-  LLVM_ABI Directives getDirectives(unsigned V) const;
-  LLVM_ABI Modifiers getModifiers(unsigned V) const;
+  LLVM_ABI Properties getProperties(Version V) const;
+  LLVM_ABI Directives getDirectives(Version V) const;
+  LLVM_ABI Modifiers getModifiers(Version V) const;
 };
 
 struct Modifier : public Descriptor<details::Modifier> {
   using Base = Descriptor<details::Modifier>;
   using Base::Base;
-  LLVM_ABI Properties getProperties(unsigned V) const;
-  LLVM_ABI Clauses getClauses(unsigned V) const;
+  LLVM_ABI Properties getProperties(Version V) const;
+  LLVM_ABI Clauses getClauses(Version V) const;
 };
 } // namespace descriptor
 
@@ -111,7 +111,7 @@ using DescriptorMap = DenseMap<Enum, DescriptorTy>;
 LLVM_ABI const descriptor::Clause &getDescriptor(llvm::omp::Clause C);
 LLVM_ABI const descriptor::Modifier &getDescriptor(llvm::omp::Modifier M);
 
-LLVM_ABI Properties getProperties(Clause C, unsigned Version);
+LLVM_ABI Properties getProperties(Clause C, Version V);
 } // namespace llvm::omp
 
 #endif // LLVM_FRONTEND_OPENMP_OMPDESCRIPTORS_H

--- a/llvm/include/llvm/Frontend/OpenMP/OMPVersion.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPVersion.h
@@ -1,0 +1,63 @@
+//===-- OMPVersion.h - OpenMP version definition ------------------ C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains the core set of OpenMP definitions and declarations.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_FRONTEND_OPENMP_OMPVERSION_H
+#define LLVM_FRONTEND_OPENMP_OMPVERSION_H
+
+#include "llvm/ADT/DenseMapInfo.h"
+
+namespace llvm {
+namespace omp {
+struct Version {
+  using value_type = unsigned;
+  constexpr Version(value_type Ver = 0) : V(Ver) {}
+  constexpr operator value_type() const { return V; }
+  constexpr explicit operator bool() const { return V != 0; }
+
+  friend constexpr bool operator<(Version A, Version B);
+  friend constexpr bool operator==(Version A, Version B);
+
+private:
+  value_type V;
+};
+
+inline constexpr bool operator==(Version A, Version B) { return A.V == B.V; }
+inline constexpr bool operator!=(Version A, Version B) { return !(A == B); }
+inline constexpr bool operator<(Version A, Version B) { return A.V < B.V; }
+inline constexpr bool operator<=(Version A, Version B) {
+  return A < B || A == B;
+}
+inline constexpr bool operator>(Version A, Version B) { return !(A <= B); }
+inline constexpr bool operator>=(Version A, Version B) { return !(A < B); }
+
+inline constexpr bool operator==(Version A, int B) { return A == Version(B); }
+inline constexpr bool operator==(Version A, unsigned B) {
+  return A == Version(B);
+}
+inline constexpr bool operator!=(Version A, int B) { return A != Version(B); }
+inline constexpr bool operator<(Version A, int B) { return A < Version(B); }
+inline constexpr bool operator<=(Version A, int B) { return A <= Version(B); }
+inline constexpr bool operator>(Version A, int B) { return A > Version(B); }
+inline constexpr bool operator>=(Version A, int B) { return A >= Version(B); }
+} // namespace omp
+
+template <> struct DenseMapInfo<omp::Version> {
+  static unsigned getHashValue(omp::Version V) {
+    using UnderlyingTy = omp::Version::value_type;
+    return DenseMapInfo<UnderlyingTy>::getHashValue(
+        static_cast<UnderlyingTy>(V));
+  }
+  static bool isEqual(omp::Version LHS, omp::Version RHS) { return LHS == RHS; }
+};
+} // namespace llvm
+
+#endif // LLVM_FRONTEND_OPENMP_OMPVERSION_H

--- a/llvm/include/llvm/Frontend/OpenMP/OMPVersion.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPVersion.h
@@ -19,8 +19,8 @@ namespace llvm {
 namespace omp {
 struct Version {
   using value_type = unsigned;
-  constexpr Version(value_type Ver = 0) : V(Ver) {}
-  constexpr operator value_type() const { return V; }
+  constexpr /*TODO explicit*/ Version(value_type Ver = 0) : V(Ver) {}
+  constexpr /*TODO explicit*/ operator value_type() const { return V; }
   constexpr explicit operator bool() const { return V != 0; }
 
   friend constexpr bool operator<(Version A, Version B);

--- a/llvm/lib/Frontend/OpenMP/DirectiveNameParser.cpp
+++ b/llvm/lib/Frontend/OpenMP/DirectiveNameParser.cpp
@@ -24,8 +24,8 @@ DirectiveNameParser::DirectiveNameParser(SourceLanguage L) {
     // Parse "ORDERED" as OMPD_ordered_standalone.
     if (D == OMPD_ordered_blockassoc)
       continue;
-    for (unsigned Ver : getOpenMPVersions())
-      insertName(getOpenMPDirectiveName(D, Ver), D);
+    for (Version V : getOpenMPVersions())
+      insertName(getOpenMPDirectiveName(D, V), D);
   }
 }
 

--- a/llvm/lib/Frontend/OpenMP/OMP.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMP.cpp
@@ -78,16 +78,16 @@ getFirstCompositeRange(iterator_range<ArrayRef<Directive>::iterator> Leafs) {
 
 static void
 collectPrivatizingConstructs(llvm::SmallSet<Directive, 16> &Constructs,
-                             unsigned Version) {
+                             Version V) {
   llvm::SmallSet<Clause, 16> Privatizing;
   for (auto C : clauses()) {
-    if (isPrivatizingClause(C, Version))
+    if (isPrivatizingClause(C, V))
       Privatizing.insert(C);
   }
 
   for (auto D : directives()) {
     bool AllowsPrivatizing = llvm::any_of(Privatizing, [&](Clause C) {
-      return isAllowedClauseForDirective(D, C, Version);
+      return isAllowedClauseForDirective(D, C, V);
     });
     if (AllowsPrivatizing)
       Constructs.insert(D);
@@ -208,15 +208,17 @@ bool isCombinedConstruct(Directive D) {
   return !getLeafConstructs(D).empty() && !isCompositeConstruct(D);
 }
 
-ArrayRef<unsigned> getOpenMPVersions() {
-  static unsigned Versions[]{31, 40, 45, 50, 51, 52, 60, 61};
+ArrayRef<Version> getOpenMPVersions() {
+  // static Version Versions[]{31, 40, 45, 50, 51, 52, 60, 61};
+  static Version Versions[]{Version(31), Version(40), Version(45), Version(50),
+                            Version(51), Version(52), Version(60), Version(61)};
   return Versions;
 }
 
-bool isPrivatizingConstruct(Directive D, unsigned Version) {
+bool isPrivatizingConstruct(Directive D, Version V) {
   static llvm::SmallSet<Directive, 16> Privatizing;
   [[maybe_unused]] static bool Init =
-      (collectPrivatizingConstructs(Privatizing, Version), true);
+      (collectPrivatizingConstructs(Privatizing, V), true);
 
   // As of OpenMP 6.0, privatizing constructs (with the test being if they
   // allow a privatizing clause) are: dispatch, distribute, do, for, loop,

--- a/llvm/lib/Frontend/OpenMP/OMP.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMP.cpp
@@ -209,7 +209,6 @@ bool isCombinedConstruct(Directive D) {
 }
 
 ArrayRef<Version> getOpenMPVersions() {
-  // static Version Versions[]{31, 40, 45, 50, 51, 52, 60, 61};
   static Version Versions[]{Version(31), Version(40), Version(45), Version(50),
                             Version(51), Version(52), Version(60), Version(61)};
   return Versions;

--- a/llvm/lib/Frontend/OpenMP/OMPDescriptors.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPDescriptors.cpp
@@ -33,8 +33,8 @@ const DescriptorMap<Modifier, descriptor::Modifier> &getModifierMap() {
 
 #define GET_THING_OR_EMPTY(Thing, Member)                                      \
   template <typename DetailsTy>                                                \
-  static Thing get##Thing##OrEmpty(const DetailsTy &D, unsigned V) {           \
-    V = std::max(V, 45u);                                                      \
+  static Thing get##Thing##OrEmpty(const DetailsTy &D, Version V) {            \
+    V = std::max(V, Version(45));                                              \
     if (auto Found = D.find(V); Found != D.end())                              \
       return Found->second.Member;                                             \
     return Thing{};                                                            \
@@ -47,19 +47,19 @@ GET_THING_OR_EMPTY(Properties, Props)
 
 #undef GET_THING_OR_EMPTY
 
-Properties descriptor::Clause::getProperties(unsigned V) const {
+Properties descriptor::Clause::getProperties(Version V) const {
   return getPropertiesOrEmpty(Details, V);
 }
-Directives descriptor::Clause::getDirectives(unsigned V) const {
+Directives descriptor::Clause::getDirectives(Version V) const {
   return getDirectivesOrEmpty(Details, V);
 }
-Modifiers descriptor::Clause::getModifiers(unsigned V) const {
+Modifiers descriptor::Clause::getModifiers(Version V) const {
   return getModifiersOrEmpty(Details, V);
 }
-Properties descriptor::Modifier::getProperties(unsigned V) const {
+Properties descriptor::Modifier::getProperties(Version V) const {
   return getPropertiesOrEmpty(Details, V);
 }
-Clauses descriptor::Modifier::getClauses(unsigned V) const {
+Clauses descriptor::Modifier::getClauses(Version V) const {
   return getClausesOrEmpty(Details, V);
 }
 
@@ -71,7 +71,7 @@ const descriptor::Modifier &getDescriptor(llvm::omp::Modifier M) {
   return getModifierMap().at(M);
 }
 
-Properties getProperties(Clause C, unsigned Version) {
-  return getDescriptor(C).getProperties(std::max(Version, 45u));
+Properties getProperties(Clause C, Version V) {
+  return getDescriptor(C).getProperties(std::max(V, Version(45)));
 }
 } // namespace llvm::omp

--- a/llvm/lib/Frontend/OpenMP/OMPDescriptors.inc
+++ b/llvm/lib/Frontend/OpenMP/OMPDescriptors.inc
@@ -13,10 +13,10 @@
     descriptor::Clause(
       "absent",
       {
-        {51, {{{Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -25,11 +25,11 @@
     descriptor::Clause(
       "acq_rel",
       {
-        {50, {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(50), {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -38,11 +38,11 @@
     descriptor::Clause(
       "acquire",
       {
-        {50, {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(50), {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -51,10 +51,10 @@
     descriptor::Clause(
       "adjust_args",
       {
-        {51, {{{Property::DispatchCompliant}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AdjustOp}}},
-        {52, {{{Property::DispatchCompliant}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AdjustOp}}},
-        {60, {{{Property::DispatchCompliant}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AdjustOp, Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DispatchCompliant}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{Property::DispatchCompliant}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AdjustOp}}},
+        {Version(52), {{{Property::DispatchCompliant}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AdjustOp}}},
+        {Version(60), {{{Property::DispatchCompliant}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AdjustOp, Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::DispatchCompliant}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -63,11 +63,11 @@
     descriptor::Clause(
       "affinity",
       {
-        {50, {{{}}, "affinity", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator}}},
-        {51, {{{}}, "affinity", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator}}},
-        {52, {{{Property::Unique}}, "affinity", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator}}},
-        {60, {{{Property::TaskInherited}}, "affinity", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator}}},
-        {61, {{{Property::TaskInherited}}, "affinity", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator}}},
+        {Version(50), {{{}}, "affinity", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator}}},
+        {Version(51), {{{}}, "affinity", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator}}},
+        {Version(52), {{{Property::Unique}}, "affinity", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator}}},
+        {Version(60), {{{Property::TaskInherited}}, "affinity", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator}}},
+        {Version(61), {{{Property::TaskInherited}}, "affinity", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator}}},
       }
     ),
   },
@@ -76,10 +76,10 @@
     descriptor::Clause(
       "align",
       {
-        {51, {{{Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -88,12 +88,12 @@
     descriptor::Clause(
       "aligned",
       {
-        {45, {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}}},
-        {50, {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment, Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment, Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}}},
+        {Version(50), {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}}},
+        {Version(51), {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}}},
+        {Version(52), {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}}},
+        {Version(60), {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment, Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment, Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -102,11 +102,11 @@
     descriptor::Clause(
       "allocate",
       {
-        {50, {{{Property::AllPrivatizing}}, "allocate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AllocatorSimpleModifier}}},
-        {51, {{{Property::AllPrivatizing}}, "allocate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorSimpleModifier}}},
-        {52, {{{Property::AllPrivatizing}}, "allocate", {Directive::OMPD_allocators, Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorComplexModifier, Modifier::AllocatorSimpleModifier}}},
-        {60, {{{Property::AllPrivatizing}}, "allocate", {Directive::OMPD_allocators, Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorComplexModifier, Modifier::AllocatorSimpleModifier, Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::AllPrivatizing, Property::TargetConsistent}}, "allocate", {Directive::OMPD_allocators, Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorComplexModifier, Modifier::AllocatorSimpleModifier, Modifier::DirectiveNameModifier}}},
+        {Version(50), {{{Property::AllPrivatizing}}, "allocate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AllocatorSimpleModifier}}},
+        {Version(51), {{{Property::AllPrivatizing}}, "allocate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorSimpleModifier}}},
+        {Version(52), {{{Property::AllPrivatizing}}, "allocate", {Directive::OMPD_allocators, Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorComplexModifier, Modifier::AllocatorSimpleModifier}}},
+        {Version(60), {{{Property::AllPrivatizing}}, "allocate", {Directive::OMPD_allocators, Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorComplexModifier, Modifier::AllocatorSimpleModifier, Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::AllPrivatizing, Property::TargetConsistent}}, "allocate", {Directive::OMPD_allocators, Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorComplexModifier, Modifier::AllocatorSimpleModifier, Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -115,11 +115,11 @@
     descriptor::Clause(
       "allocator",
       {
-        {50, {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(50), {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -128,10 +128,10 @@
     descriptor::Clause(
       "append_args",
       {
-        {51, {{{Property::DispatchCompliant, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DispatchCompliant, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DispatchCompliant, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DispatchCompliant, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{Property::DispatchCompliant, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::DispatchCompliant, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::DispatchCompliant, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::DispatchCompliant, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -140,8 +140,8 @@
     descriptor::Clause(
       "apply",
       {
-        {60, {{{}}, "apply", {Directive::OMPD_fuse, Directive::OMPD_interchange, Directive::OMPD_nothing, Directive::OMPD_reverse, Directive::OMPD_split, Directive::OMPD_stripe, Directive::OMPD_tile, Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LoopModifier}}},
-        {61, {{{}}, "apply", {Directive::OMPD_flatten, Directive::OMPD_fuse, Directive::OMPD_interchange, Directive::OMPD_nothing, Directive::OMPD_reverse, Directive::OMPD_split, Directive::OMPD_stripe, Directive::OMPD_tile, Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LoopModifier}}},
+        {Version(60), {{{}}, "apply", {Directive::OMPD_fuse, Directive::OMPD_interchange, Directive::OMPD_nothing, Directive::OMPD_reverse, Directive::OMPD_split, Directive::OMPD_stripe, Directive::OMPD_tile, Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LoopModifier}}},
+        {Version(61), {{{}}, "apply", {Directive::OMPD_flatten, Directive::OMPD_fuse, Directive::OMPD_interchange, Directive::OMPD_nothing, Directive::OMPD_reverse, Directive::OMPD_split, Directive::OMPD_stripe, Directive::OMPD_tile, Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LoopModifier}}},
       }
     ),
   },
@@ -150,10 +150,10 @@
     descriptor::Clause(
       "at",
       {
-        {51, {{{Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -162,11 +162,11 @@
     descriptor::Clause(
       "atomic_default_mem_order",
       {
-        {50, {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(50), {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -175,11 +175,11 @@
     descriptor::Clause(
       "bind",
       {
-        {50, {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(50), {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -188,12 +188,12 @@
     descriptor::Clause(
       "capture",
       {
-        {45, {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -202,12 +202,12 @@
     descriptor::Clause(
       "collapse",
       {
-        {45, {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -216,8 +216,8 @@
     descriptor::Clause(
       "collector",
       {
-        {60, {{{Property::Required, Property::Unique}}, "collector", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Required, Property::Unique}}, "collector", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(60), {{{Property::Required, Property::Unique}}, "collector", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Required, Property::Unique}}, "collector", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -226,8 +226,8 @@
     descriptor::Clause(
       "combiner",
       {
-        {60, {{{Property::Required, Property::Unique}}, "combiner", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Required, Property::Unique}}, "combiner", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(60), {{{Property::Required, Property::Unique}}, "combiner", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Required, Property::Unique}}, "combiner", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -236,10 +236,10 @@
     descriptor::Clause(
       "compare",
       {
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -248,10 +248,10 @@
     descriptor::Clause(
       "contains",
       {
-        {51, {{{Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -260,12 +260,12 @@
     descriptor::Clause(
       "copyin",
       {
-        {45, {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -274,12 +274,12 @@
     descriptor::Clause(
       "copyprivate",
       {
-        {45, {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -288,8 +288,8 @@
     descriptor::Clause(
       "counts",
       {
-        {60, {{{Property::Required, Property::Unique}}, "counts", {Directive::OMPD_split}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Required, Property::Unique}}, "counts", {Directive::OMPD_split}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(60), {{{Property::Required, Property::Unique}}, "counts", {Directive::OMPD_split}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Required, Property::Unique}}, "counts", {Directive::OMPD_split}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -298,12 +298,12 @@
     descriptor::Clause(
       "default",
       {
-        {45, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}}},
-        {51, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}}},
-        {52, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}}},
-        {60, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::VariableCategory}}},
-        {61, {{{Property::DefaultAttribute, Property::PostModified}}, "default", {Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}}},
+        {Version(51), {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}}},
+        {Version(52), {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}}},
+        {Version(60), {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::VariableCategory}}},
+        {Version(61), {{{Property::DefaultAttribute, Property::PostModified}}, "default", {Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -312,8 +312,8 @@
     descriptor::Clause(
       "default-variant",
       {
-        {50, {{{Property::Ultimate, Property::Unique}}, "default-variant", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Ultimate, Property::Unique}}, "default-variant", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::Ultimate, Property::Unique}}, "default-variant", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Ultimate, Property::Unique}}, "default-variant", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
       }
     ),
   },
@@ -322,12 +322,12 @@
     descriptor::Clause(
       "defaultmap",
       {
-        {45, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}}},
-        {50, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}}},
-        {51, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}}},
-        {52, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}}},
-        {60, {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::VariableCategory}}},
-        {61, {{{Property::DefaultAttribute, Property::PostModified}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}}},
+        {Version(50), {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}}},
+        {Version(51), {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}}},
+        {Version(52), {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}}},
+        {Version(60), {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::VariableCategory}}},
+        {Version(61), {{{Property::DefaultAttribute, Property::PostModified}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -336,12 +336,12 @@
     descriptor::Clause(
       "depend",
       {
-        {45, {{{}}, "depend", {Directive::OMPD_ordered_standalone, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::TaskDependenceType}}},
-        {50, {{{}}, "depend", {Directive::OMPD_depobj, Directive::OMPD_ordered_standalone, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::Iterator, Modifier::TaskDependenceType}}},
-        {51, {{{Property::DispatchRequirement}}, "depend", {Directive::OMPD_depobj, Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_ordered_standalone, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::Iterator, Modifier::TaskDependenceType}}},
-        {52, {{{Property::DispatchRequirement}}, "depend", {Directive::OMPD_depobj, Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::TaskDependenceType}}},
-        {60, {{{Property::DispatchRequirement, Property::TaskInherited, Property::TaskgraphAltering}}, "depend", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::TaskDependenceType}}},
-        {61, {{{Property::DispatchRequirement, Property::TaskInherited, Property::TaskSynchronizing, Property::TaskgraphAltering}}, "depend", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::TaskDependenceType}}},
+        {Version(45), {{{}}, "depend", {Directive::OMPD_ordered_standalone, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::TaskDependenceType}}},
+        {Version(50), {{{}}, "depend", {Directive::OMPD_depobj, Directive::OMPD_ordered_standalone, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::Iterator, Modifier::TaskDependenceType}}},
+        {Version(51), {{{Property::DispatchRequirement}}, "depend", {Directive::OMPD_depobj, Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_ordered_standalone, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::Iterator, Modifier::TaskDependenceType}}},
+        {Version(52), {{{Property::DispatchRequirement}}, "depend", {Directive::OMPD_depobj, Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::TaskDependenceType}}},
+        {Version(60), {{{Property::DispatchRequirement, Property::TaskInherited, Property::TaskgraphAltering}}, "depend", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::TaskDependenceType}}},
+        {Version(61), {{{Property::DispatchRequirement, Property::TaskInherited, Property::TaskSynchronizing, Property::TaskgraphAltering}}, "depend", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::TaskDependenceType}}},
       }
     ),
   },
@@ -350,7 +350,7 @@
     descriptor::Clause(
       "depth",
       {
-        {61, {{{Property::Unique}}, "depth", {Directive::OMPD_flatten, Directive::OMPD_fuse}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "depth", {Directive::OMPD_flatten, Directive::OMPD_fuse}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -359,11 +359,11 @@
     descriptor::Clause(
       "destroy",
       {
-        {50, {{{}}, "destroy", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(50), {{{}}, "destroy", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -372,11 +372,11 @@
     descriptor::Clause(
       "detach",
       {
-        {50, {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(50), {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -385,12 +385,12 @@
     descriptor::Clause(
       "device",
       {
-        {45, {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier}}},
-        {51, {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier}}},
-        {52, {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier}}},
-        {60, {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier, Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier, Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier}}},
+        {Version(51), {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier}}},
+        {Version(52), {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier}}},
+        {Version(60), {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier, Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier, Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -399,8 +399,8 @@
     descriptor::Clause(
       "device_safesync",
       {
-        {60, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "device_safesync", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "device_safesync", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(60), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "device_safesync", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "device_safesync", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -409,11 +409,11 @@
     descriptor::Clause(
       "device_type",
       {
-        {50, {{{Property::Unique}}, "device_type", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target, Directive::OMPD_groupprivate, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target, Directive::OMPD_groupprivate, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(50), {{{Property::Unique}}, "device_type", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target, Directive::OMPD_groupprivate, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target, Directive::OMPD_groupprivate, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -422,12 +422,12 @@
     descriptor::Clause(
       "dist_schedule",
       {
-        {45, {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -436,9 +436,9 @@
     descriptor::Clause(
       "doacross",
       {
-        {52, {{{Property::Required}}, "doacross", {Directive::OMPD_ordered_standalone}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType}}},
-        {60, {{{Property::Required}}, "doacross", {Directive::OMPD_ordered_standalone}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Required}}, "doacross", {Directive::OMPD_ordered_standalone}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::DirectiveNameModifier}}},
+        {Version(52), {{{Property::Required}}, "doacross", {Directive::OMPD_ordered_standalone}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType}}},
+        {Version(60), {{{Property::Required}}, "doacross", {Directive::OMPD_ordered_standalone}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Required}}, "doacross", {Directive::OMPD_ordered_standalone}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -447,7 +447,7 @@
     descriptor::Clause(
       "dyn_groupprivate",
       {
-        {61, {{{Property::TargetConsistent}}, "dyn_groupprivate", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AccessGroup, Modifier::DirectiveNameModifier, Modifier::FallbackModifier}}},
+        {Version(61), {{{Property::TargetConsistent}}, "dyn_groupprivate", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AccessGroup, Modifier::DirectiveNameModifier, Modifier::FallbackModifier}}},
       }
     ),
   },
@@ -456,11 +456,11 @@
     descriptor::Clause(
       "dynamic_allocators",
       {
-        {50, {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(50), {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -469,9 +469,9 @@
     descriptor::Clause(
       "enter",
       {
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "enter", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "enter", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AutomapModifier, Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "enter", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AutomapModifier, Modifier::DirectiveNameModifier}}},
+        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "enter", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "enter", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AutomapModifier, Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "enter", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AutomapModifier, Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -480,11 +480,11 @@
     descriptor::Clause(
       "exclusive",
       {
-        {50, {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(50), {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -493,10 +493,10 @@
     descriptor::Clause(
       "fail",
       {
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -505,10 +505,10 @@
     descriptor::Clause(
       "filter",
       {
-        {51, {{{Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -517,12 +517,12 @@
     descriptor::Clause(
       "final",
       {
-        {45, {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -531,12 +531,12 @@
     descriptor::Clause(
       "firstprivate",
       {
-        {45, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Saved}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Saved}}},
+        {Version(45), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Saved}}},
+        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Saved}}},
       }
     ),
   },
@@ -545,12 +545,12 @@
     descriptor::Clause(
       "from",
       {
-        {45, {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Mapper}}},
-        {51, {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::Mapper, Modifier::MotionModifier}}},
-        {52, {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Expectation, Modifier::Iterator, Modifier::Mapper}}},
-        {60, {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}}},
-        {61, {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}}},
+        {Version(45), {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Mapper}}},
+        {Version(51), {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::Mapper, Modifier::MotionModifier}}},
+        {Version(52), {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Expectation, Modifier::Iterator, Modifier::Mapper}}},
+        {Version(60), {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}}},
+        {Version(61), {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}}},
       }
     ),
   },
@@ -559,10 +559,10 @@
     descriptor::Clause(
       "full",
       {
-        {51, {{{Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -571,12 +571,12 @@
     descriptor::Clause(
       "grainsize",
       {
-        {45, {{{Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}}},
-        {52, {{{Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}}},
-        {60, {{{Property::TaskgraphAltering, Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}}},
-        {61, {{{Property::TaskgraphAltering, Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}}},
+        {Version(45), {{{Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}}},
+        {Version(52), {{{Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}}},
+        {Version(60), {{{Property::TaskgraphAltering, Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}}},
+        {Version(61), {{{Property::TaskgraphAltering, Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}}},
       }
     ),
   },
@@ -585,8 +585,8 @@
     descriptor::Clause(
       "graph_id",
       {
-        {60, {{{Property::Unique}}, "graph_id", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "graph_id", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(60), {{{Property::Unique}}, "graph_id", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "graph_id", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -595,8 +595,8 @@
     descriptor::Clause(
       "graph_reset",
       {
-        {60, {{{Property::Unique}}, "graph_reset", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "graph_reset", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(60), {{{Property::Unique}}, "graph_reset", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "graph_reset", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -605,10 +605,10 @@
     descriptor::Clause(
       "has_device_addr",
       {
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::OutermostLeaf}}, "has_device_addr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::OutermostLeaf}}, "has_device_addr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::OutermostLeaf}}, "has_device_addr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::OutermostLeaf}}, "has_device_addr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::OutermostLeaf}}, "has_device_addr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::OutermostLeaf}}, "has_device_addr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::OutermostLeaf}}, "has_device_addr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::OutermostLeaf}}, "has_device_addr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -617,12 +617,12 @@
     descriptor::Clause(
       "hint",
       {
-        {45, {{{Property::Unique}}, "hint", {Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::Unique}}, "hint", {Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -631,10 +631,10 @@
     descriptor::Clause(
       "holds",
       {
-        {51, {{{Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -643,12 +643,12 @@
     descriptor::Clause(
       "if",
       {
-        {45, {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {50, {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {51, {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {52, {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {60, {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(50), {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(52), {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(60), {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -657,11 +657,11 @@
     descriptor::Clause(
       "in_reduction",
       {
-        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}}},
+        {Version(50), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}}},
+        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}}},
+        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}}},
+        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}}},
+        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}}},
       }
     ),
   },
@@ -670,12 +670,12 @@
     descriptor::Clause(
       "inbranch",
       {
-        {45, {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -684,11 +684,11 @@
     descriptor::Clause(
       "inclusive",
       {
-        {50, {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(50), {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -697,10 +697,10 @@
     descriptor::Clause(
       "indirect",
       {
-        {51, {{{Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -709,8 +709,8 @@
     descriptor::Clause(
       "induction",
       {
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "induction", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::InductionIdentifier, Modifier::InductionModifier, Modifier::StepModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "induction", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::InductionIdentifier, Modifier::InductionModifier, Modifier::StepModifier}}},
+        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "induction", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::InductionIdentifier, Modifier::InductionModifier, Modifier::StepModifier}}},
+        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "induction", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::InductionIdentifier, Modifier::InductionModifier, Modifier::StepModifier}}},
       }
     ),
   },
@@ -719,8 +719,8 @@
     descriptor::Clause(
       "inductor",
       {
-        {60, {{{Property::Required, Property::Unique}}, "inductor", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Required, Property::Unique}}, "inductor", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(60), {{{Property::Required, Property::Unique}}, "inductor", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Required, Property::Unique}}, "inductor", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -729,10 +729,10 @@
     descriptor::Clause(
       "init",
       {
-        {51, {{{Property::InnermostLeaf}}, "init", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::InteropType}}},
-        {52, {{{Property::InnermostLeaf}}, "init", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::InteropType}}},
-        {60, {{{Property::InnermostLeaf}}, "init", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DepinfoModifier, Modifier::DirectiveNameModifier, Modifier::InteropType, Modifier::PreferType}}},
-        {61, {{{Property::InnermostLeaf}}, "init", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DepinfoModifier, Modifier::DirectiveNameModifier, Modifier::PreferType}}},
+        {Version(51), {{{Property::InnermostLeaf}}, "init", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::InteropType}}},
+        {Version(52), {{{Property::InnermostLeaf}}, "init", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::InteropType}}},
+        {Version(60), {{{Property::InnermostLeaf}}, "init", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DepinfoModifier, Modifier::DirectiveNameModifier, Modifier::InteropType, Modifier::PreferType}}},
+        {Version(61), {{{Property::InnermostLeaf}}, "init", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DepinfoModifier, Modifier::DirectiveNameModifier, Modifier::PreferType}}},
       }
     ),
   },
@@ -741,8 +741,8 @@
     descriptor::Clause(
       "init_complete",
       {
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "init_complete", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "init_complete", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "init_complete", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "init_complete", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -751,11 +751,11 @@
     descriptor::Clause(
       "initializer",
       {
-        {50, {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(50), {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -764,8 +764,8 @@
     descriptor::Clause(
       "interop",
       {
-        {60, {{{Property::DispatchRequirement, Property::Unique}}, "interop", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DispatchRequirement, Property::Unique}}, "interop", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(60), {{{Property::DispatchRequirement, Property::Unique}}, "interop", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::DispatchRequirement, Property::Unique}}, "interop", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -774,12 +774,12 @@
     descriptor::Clause(
       "is_device_ptr",
       {
-        {45, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -788,12 +788,12 @@
     descriptor::Clause(
       "lastprivate",
       {
-        {45, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LastprivateModifier}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LastprivateModifier}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LastprivateModifier}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LastprivateModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LastprivateModifier}}},
+        {Version(45), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LastprivateModifier}}},
+        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LastprivateModifier}}},
+        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LastprivateModifier}}},
+        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LastprivateModifier}}},
+        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LastprivateModifier}}},
       }
     ),
   },
@@ -802,12 +802,12 @@
     descriptor::Clause(
       "linear",
       {
-        {45, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::LinearStep}}},
-        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::LinearStep}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::LinearStep}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::StepComplexModifier, Modifier::StepSimpleModifier}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LinearModifier, Modifier::StepComplexModifier, Modifier::StepSimpleModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LinearModifier, Modifier::StepComplexModifier, Modifier::StepSimpleModifier}}},
+        {Version(45), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::LinearStep}}},
+        {Version(50), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::LinearStep}}},
+        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::LinearStep}}},
+        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::StepComplexModifier, Modifier::StepSimpleModifier}}},
+        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LinearModifier, Modifier::StepComplexModifier, Modifier::StepSimpleModifier}}},
+        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LinearModifier, Modifier::StepComplexModifier, Modifier::StepSimpleModifier}}},
       }
     ),
   },
@@ -816,12 +816,12 @@
     descriptor::Clause(
       "link",
       {
-        {45, {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -830,8 +830,8 @@
     descriptor::Clause(
       "local",
       {
-        {60, {{{Property::DataEnvironmentAttribute}}, "local", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute}}, "local", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(60), {{{Property::DataEnvironmentAttribute}}, "local", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::DataEnvironmentAttribute}}, "local", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -840,8 +840,8 @@
     descriptor::Clause(
       "looprange",
       {
-        {60, {{{Property::Unique}}, "looprange", {Directive::OMPD_fuse}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "looprange", {Directive::OMPD_fuse}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(60), {{{Property::Unique}}, "looprange", {Directive::OMPD_fuse}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "looprange", {Directive::OMPD_fuse}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -850,12 +850,12 @@
     descriptor::Clause(
       "map",
       {
-        {45, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::MapType, Modifier::MapTypeModifier, Modifier::OmpxHoldModifier}}},
-        {50, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::MapType, Modifier::MapTypeModifier, Modifier::Mapper, Modifier::OmpxHoldModifier}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::MapType, Modifier::MapTypeModifier, Modifier::Mapper, Modifier::OmpxHoldModifier}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::MapType, Modifier::MapTypeModifier, Modifier::Mapper, Modifier::OmpxHoldModifier}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlwaysModifier, Modifier::CloseModifier, Modifier::DeleteModifier, Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::MapType, Modifier::Mapper, Modifier::OmpxHoldModifier, Modifier::PresentModifier, Modifier::RefModifier, Modifier::SelfModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AttachModifier, Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::MapType, Modifier::Mapper, Modifier::OmpxHoldModifier, Modifier::RefModifier}}},
+        {Version(45), {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::MapType, Modifier::MapTypeModifier, Modifier::OmpxHoldModifier}}},
+        {Version(50), {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::MapType, Modifier::MapTypeModifier, Modifier::Mapper, Modifier::OmpxHoldModifier}}},
+        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::MapType, Modifier::MapTypeModifier, Modifier::Mapper, Modifier::OmpxHoldModifier}}},
+        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::MapType, Modifier::MapTypeModifier, Modifier::Mapper, Modifier::OmpxHoldModifier}}},
+        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlwaysModifier, Modifier::CloseModifier, Modifier::DeleteModifier, Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::MapType, Modifier::Mapper, Modifier::OmpxHoldModifier, Modifier::PresentModifier, Modifier::RefModifier, Modifier::SelfModifier}}},
+        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AttachModifier, Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::MapType, Modifier::Mapper, Modifier::OmpxHoldModifier, Modifier::RefModifier}}},
       }
     ),
   },
@@ -864,11 +864,11 @@
     descriptor::Clause(
       "match",
       {
-        {50, {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(50), {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -877,8 +877,8 @@
     descriptor::Clause(
       "memscope",
       {
-        {60, {{{Property::Unique}}, "memscope", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "memscope", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(60), {{{Property::Unique}}, "memscope", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "memscope", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -887,12 +887,12 @@
     descriptor::Clause(
       "mergeable",
       {
-        {45, {{{Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "mergeable", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "mergeable", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "mergeable", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "mergeable", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -901,10 +901,10 @@
     descriptor::Clause(
       "message",
       {
-        {51, {{{Property::Unique}}, "message", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "message", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "message", {Directive::OMPD_error, Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "message", {Directive::OMPD_error, Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{Property::Unique}}, "message", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "message", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "message", {Directive::OMPD_error, Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "message", {Directive::OMPD_error, Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -913,10 +913,10 @@
     descriptor::Clause(
       "no_openmp",
       {
-        {51, {{{Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -925,8 +925,8 @@
     descriptor::Clause(
       "no_openmp_constructs",
       {
-        {60, {{{Property::Unique}}, "no_openmp_constructs", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "no_openmp_constructs", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(60), {{{Property::Unique}}, "no_openmp_constructs", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "no_openmp_constructs", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -935,10 +935,10 @@
     descriptor::Clause(
       "no_openmp_routines",
       {
-        {51, {{{Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -947,10 +947,10 @@
     descriptor::Clause(
       "no_parallelism",
       {
-        {51, {{{Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -959,10 +959,10 @@
     descriptor::Clause(
       "nocontext",
       {
-        {51, {{{Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -971,12 +971,12 @@
     descriptor::Clause(
       "nogroup",
       {
-        {45, {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_target_data, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::OutermostLeaf, Property::TaskSynchronizing, Property::Unique}}, "nogroup", {Directive::OMPD_target_data, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_target_data, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::OutermostLeaf, Property::TaskSynchronizing, Property::Unique}}, "nogroup", {Directive::OMPD_target_data, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -985,11 +985,11 @@
     descriptor::Clause(
       "nontemporal",
       {
-        {50, {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(50), {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -998,12 +998,12 @@
     descriptor::Clause(
       "notinbranch",
       {
-        {45, {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1012,10 +1012,10 @@
     descriptor::Clause(
       "novariants",
       {
-        {51, {{{Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1024,12 +1024,12 @@
     descriptor::Clause(
       "nowait",
       {
-        {45, {{{Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DispatchRequirement, Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DispatchRequirement, Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DispatchRequirement, Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DispatchRequirement, Property::EndClause, Property::OutermostLeaf, Property::TaskSynchronizing, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::DispatchRequirement, Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::DispatchRequirement, Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::DispatchRequirement, Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::DispatchRequirement, Property::EndClause, Property::OutermostLeaf, Property::TaskSynchronizing, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1038,12 +1038,12 @@
     descriptor::Clause(
       "num_tasks",
       {
-        {45, {{{Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}}},
-        {52, {{{Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}}},
-        {60, {{{Property::TaskgraphAltering, Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}}},
-        {61, {{{Property::TaskgraphAltering, Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}}},
+        {Version(45), {{{Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}}},
+        {Version(52), {{{Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}}},
+        {Version(60), {{{Property::TaskgraphAltering, Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}}},
+        {Version(61), {{{Property::TaskgraphAltering, Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}}},
       }
     ),
   },
@@ -1052,12 +1052,12 @@
     descriptor::Clause(
       "num_teams",
       {
-        {45, {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LowerBound}}},
-        {51, {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LowerBound}}},
-        {52, {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LowerBound}}},
-        {60, {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LowerBound}}},
-        {61, {{{Property::SpaceConfiguring, Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DimsModifier, Modifier::DirectiveNameModifier, Modifier::LowerBound}}},
+        {Version(45), {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LowerBound}}},
+        {Version(51), {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LowerBound}}},
+        {Version(52), {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LowerBound}}},
+        {Version(60), {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LowerBound}}},
+        {Version(61), {{{Property::SpaceConfiguring, Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DimsModifier, Modifier::DirectiveNameModifier, Modifier::LowerBound}}},
       }
     ),
   },
@@ -1066,12 +1066,12 @@
     descriptor::Clause(
       "num_threads",
       {
-        {45, {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}}},
-        {61, {{{Property::SpaceConfiguring, Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DimsModifier, Modifier::DirectiveNameModifier, Modifier::PrescriptivenessModifier}}},
+        {Version(45), {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}}},
+        {Version(61), {{{Property::SpaceConfiguring, Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DimsModifier, Modifier::DirectiveNameModifier, Modifier::PrescriptivenessModifier}}},
       }
     ),
   },
@@ -1080,11 +1080,11 @@
     descriptor::Clause(
       "order",
       {
-        {50, {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::OrderModifier}}},
-        {52, {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::OrderModifier}}},
-        {60, {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OrderModifier}}},
-        {61, {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OrderModifier}}},
+        {Version(50), {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::OrderModifier}}},
+        {Version(52), {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::OrderModifier}}},
+        {Version(60), {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OrderModifier}}},
+        {Version(61), {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OrderModifier}}},
       }
     ),
   },
@@ -1093,12 +1093,12 @@
     descriptor::Clause(
       "ordered",
       {
-        {45, {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1107,9 +1107,9 @@
     descriptor::Clause(
       "otherwise",
       {
-        {52, {{{Property::Ultimate, Property::Unique}}, "otherwise", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Ultimate, Property::Unique}}, "otherwise", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Ultimate, Property::Unique}}, "otherwise", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(52), {{{Property::Ultimate, Property::Unique}}, "otherwise", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Ultimate, Property::Unique}}, "otherwise", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Ultimate, Property::Unique}}, "otherwise", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1118,10 +1118,10 @@
     descriptor::Clause(
       "partial",
       {
-        {51, {{{Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1130,8 +1130,8 @@
     descriptor::Clause(
       "permutation",
       {
-        {60, {{{Property::Unique}}, "permutation", {Directive::OMPD_interchange}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "permutation", {Directive::OMPD_interchange}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(60), {{{Property::Unique}}, "permutation", {Directive::OMPD_interchange}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "permutation", {Directive::OMPD_interchange}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1140,12 +1140,12 @@
     descriptor::Clause(
       "priority",
       {
-        {45, {{{Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "priority", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "priority", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "priority", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "priority", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1154,12 +1154,12 @@
     descriptor::Clause(
       "private",
       {
-        {45, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1168,12 +1168,12 @@
     descriptor::Clause(
       "proc_bind",
       {
-        {45, {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1182,12 +1182,12 @@
     descriptor::Clause(
       "read",
       {
-        {45, {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1196,12 +1196,12 @@
     descriptor::Clause(
       "reduction",
       {
-        {45, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}}},
-        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier, Modifier::ReductionModifier}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier, Modifier::ReductionModifier}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier, Modifier::ReductionModifier}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OriginalSharingModifier, Modifier::ReductionIdentifier, Modifier::ReductionModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OriginalSharingModifier, Modifier::PerThreadModifier, Modifier::ReductionIdentifier}}},
+        {Version(45), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}}},
+        {Version(50), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier, Modifier::ReductionModifier}}},
+        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier, Modifier::ReductionModifier}}},
+        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier, Modifier::ReductionModifier}}},
+        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OriginalSharingModifier, Modifier::ReductionIdentifier, Modifier::ReductionModifier}}},
+        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OriginalSharingModifier, Modifier::PerThreadModifier, Modifier::ReductionIdentifier}}},
       }
     ),
   },
@@ -1210,11 +1210,11 @@
     descriptor::Clause(
       "relaxed",
       {
-        {50, {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(50), {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1223,11 +1223,11 @@
     descriptor::Clause(
       "release",
       {
-        {50, {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(50), {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1236,8 +1236,8 @@
     descriptor::Clause(
       "replayable",
       {
-        {60, {{{Property::Unique}}, "replayable", {Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "replayable", {Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(60), {{{Property::Unique}}, "replayable", {Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "replayable", {Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1246,11 +1246,11 @@
     descriptor::Clause(
       "reverse_offload",
       {
-        {50, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(50), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1259,12 +1259,12 @@
     descriptor::Clause(
       "safelen",
       {
-        {45, {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1273,8 +1273,8 @@
     descriptor::Clause(
       "safesync",
       {
-        {60, {{{Property::Unique}}, "safesync", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "safesync", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(60), {{{Property::Unique}}, "safesync", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "safesync", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1283,12 +1283,12 @@
     descriptor::Clause(
       "schedule",
       {
-        {45, {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}}},
-        {50, {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}}},
-        {51, {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}}},
-        {52, {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}}},
-        {60, {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::DirectiveNameModifier, Modifier::OrderingModifier}}},
-        {61, {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::DirectiveNameModifier, Modifier::OrderingModifier}}},
+        {Version(45), {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}}},
+        {Version(50), {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}}},
+        {Version(51), {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}}},
+        {Version(52), {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}}},
+        {Version(60), {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::DirectiveNameModifier, Modifier::OrderingModifier}}},
+        {Version(61), {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::DirectiveNameModifier, Modifier::OrderingModifier}}},
       }
     ),
   },
@@ -1297,8 +1297,8 @@
     descriptor::Clause(
       "self_maps",
       {
-        {60, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "self_maps", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "self_maps", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(60), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "self_maps", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "self_maps", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1307,12 +1307,12 @@
     descriptor::Clause(
       "seq_cst",
       {
-        {45, {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1321,10 +1321,10 @@
     descriptor::Clause(
       "severity",
       {
-        {51, {{{Property::Unique}}, "severity", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "severity", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "severity", {Directive::OMPD_error, Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "severity", {Directive::OMPD_error, Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{Property::Unique}}, "severity", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "severity", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "severity", {Directive::OMPD_error, Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "severity", {Directive::OMPD_error, Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1333,12 +1333,12 @@
     descriptor::Clause(
       "shared",
       {
-        {45, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1347,12 +1347,12 @@
     descriptor::Clause(
       "simd",
       {
-        {45, {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1361,12 +1361,12 @@
     descriptor::Clause(
       "simdlen",
       {
-        {45, {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ScaledModifier}}},
+        {Version(45), {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ScaledModifier}}},
       }
     ),
   },
@@ -1375,10 +1375,10 @@
     descriptor::Clause(
       "sizes",
       {
-        {51, {{{Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_stripe, Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_stripe, Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::SizesSelector}}},
+        {Version(51), {{{Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_stripe, Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_stripe, Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::SizesSelector}}},
       }
     ),
   },
@@ -1387,11 +1387,11 @@
     descriptor::Clause(
       "task_reduction",
       {
-        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}}},
+        {Version(50), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}}},
+        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}}},
+        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}}},
+        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}}},
+        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}}},
       }
     ),
   },
@@ -1400,12 +1400,12 @@
     descriptor::Clause(
       "thread_limit",
       {
-        {45, {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::IcvModifying, Property::SpaceConfiguring, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DimsModifier, Modifier::DirectiveNameModifier, Modifier::PrescriptivenessModifier}}},
+        {Version(45), {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::IcvModifying, Property::SpaceConfiguring, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DimsModifier, Modifier::DirectiveNameModifier, Modifier::PrescriptivenessModifier}}},
       }
     ),
   },
@@ -1414,12 +1414,12 @@
     descriptor::Clause(
       "threads",
       {
-        {45, {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1428,8 +1428,8 @@
     descriptor::Clause(
       "threadset",
       {
-        {60, {{{Property::Unique}}, "threadset", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "threadset", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(60), {{{Property::Unique}}, "threadset", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "threadset", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1438,12 +1438,12 @@
     descriptor::Clause(
       "to",
       {
-        {45, {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_declare_target, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_declare_target, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Mapper}}},
-        {51, {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_declare_target, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::Mapper, Modifier::MotionModifier}}},
-        {52, {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Expectation, Modifier::Iterator, Modifier::Mapper}}},
-        {60, {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}}},
-        {61, {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}}},
+        {Version(45), {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_declare_target, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_declare_target, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Mapper}}},
+        {Version(51), {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_declare_target, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::Mapper, Modifier::MotionModifier}}},
+        {Version(52), {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Expectation, Modifier::Iterator, Modifier::Mapper}}},
+        {Version(60), {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}}},
+        {Version(61), {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}}},
       }
     ),
   },
@@ -1452,8 +1452,8 @@
     descriptor::Clause(
       "transparent",
       {
-        {60, {{{Property::Unique}}, "transparent", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "transparent", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(60), {{{Property::Unique}}, "transparent", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "transparent", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1462,11 +1462,11 @@
     descriptor::Clause(
       "unified_address",
       {
-        {50, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(50), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1475,11 +1475,11 @@
     descriptor::Clause(
       "unified_shared_memory",
       {
-        {50, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(50), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1488,12 +1488,12 @@
     descriptor::Clause(
       "uniform",
       {
-        {45, {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1502,12 +1502,12 @@
     descriptor::Clause(
       "untied",
       {
-        {45, {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1516,12 +1516,12 @@
     descriptor::Clause(
       "update",
       {
-        {45, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1530,11 +1530,11 @@
     descriptor::Clause(
       "update-depend_objects",
       {
-        {50, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::TaskDependenceType}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::TaskDependenceType}}},
+        {Version(50), {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::TaskDependenceType}}},
+        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::TaskDependenceType}}},
       }
     ),
   },
@@ -1543,10 +1543,10 @@
     descriptor::Clause(
       "use",
       {
-        {51, {{{}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1555,11 +1555,11 @@
     descriptor::Clause(
       "use_device_addr",
       {
-        {50, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(50), {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1568,12 +1568,12 @@
     descriptor::Clause(
       "use_device_ptr",
       {
-        {45, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Fallback}}},
+        {Version(45), {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Fallback}}},
       }
     ),
   },
@@ -1582,11 +1582,11 @@
     descriptor::Clause(
       "uses_allocators",
       {
-        {50, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::MemSpace, Modifier::TraitsArray}}},
-        {60, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::MemSpace, Modifier::TraitsArray}}},
-        {61, {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::MemSpace, Modifier::TraitsArray}}},
+        {Version(50), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::MemSpace, Modifier::TraitsArray}}},
+        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::MemSpace, Modifier::TraitsArray}}},
+        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::MemSpace, Modifier::TraitsArray}}},
       }
     ),
   },
@@ -1595,10 +1595,10 @@
     descriptor::Clause(
       "weak",
       {
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1607,11 +1607,11 @@
     descriptor::Clause(
       "when",
       {
-        {50, {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector}}},
-        {51, {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector}}},
-        {52, {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector}}},
-        {60, {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector, Modifier::DirectiveNameModifier}}},
-        {61, {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector, Modifier::DirectiveNameModifier}}},
+        {Version(50), {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector}}},
+        {Version(51), {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector}}},
+        {Version(52), {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector}}},
+        {Version(60), {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector, Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector, Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1620,12 +1620,12 @@
     descriptor::Clause(
       "write",
       {
-        {45, {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {50, {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {51, {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {52, {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
-        {60, {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
-        {61, {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(45), {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(50), {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}}},
+        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
+        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}}},
       }
     ),
   },
@@ -1636,7 +1636,7 @@
     descriptor::Modifier(
       "access-group",
       {
-        {61, {{{Property::Unique}}, {Clause::OMPC_dyn_groupprivate}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_dyn_groupprivate}}},
       }
     ),
   },
@@ -1645,9 +1645,9 @@
     descriptor::Modifier(
       "adjust-op",
       {
-        {51, {{{Property::Required, Property::Unique}}, {Clause::OMPC_adjust_args}}},
-        {52, {{{Property::Required, Property::Unique}}, {Clause::OMPC_adjust_args}}},
-        {60, {{{Property::Required, Property::Unique}}, {Clause::OMPC_adjust_args}}},
+        {Version(51), {{{Property::Required, Property::Unique}}, {Clause::OMPC_adjust_args}}},
+        {Version(52), {{{Property::Required, Property::Unique}}, {Clause::OMPC_adjust_args}}},
+        {Version(60), {{{Property::Required, Property::Unique}}, {Clause::OMPC_adjust_args}}},
       }
     ),
   },
@@ -1656,10 +1656,10 @@
     descriptor::Modifier(
       "align-modifier",
       {
-        {51, {{{Property::Unique}}, {Clause::OMPC_allocate}}},
-        {52, {{{Property::Unique}}, {Clause::OMPC_allocate}}},
-        {60, {{{Property::Unique}}, {Clause::OMPC_allocate}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(51), {{{Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(52), {{{Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_allocate}}},
       }
     ),
   },
@@ -1668,12 +1668,12 @@
     descriptor::Modifier(
       "alignment",
       {
-        {45, {{{Property::Constant, Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
-        {50, {{{Property::Constant, Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
-        {51, {{{Property::Positive, Property::RegionInvariant, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
-        {52, {{{Property::Positive, Property::RegionInvariant, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
-        {60, {{{Property::Constant, Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
-        {61, {{{Property::Constant, Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
+        {Version(45), {{{Property::Constant, Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
+        {Version(50), {{{Property::Constant, Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
+        {Version(51), {{{Property::Positive, Property::RegionInvariant, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
+        {Version(52), {{{Property::Positive, Property::RegionInvariant, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
+        {Version(60), {{{Property::Constant, Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
+        {Version(61), {{{Property::Constant, Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
       }
     ),
   },
@@ -1682,9 +1682,9 @@
     descriptor::Modifier(
       "allocator-complex-modifier",
       {
-        {52, {{{Property::Unique}}, {Clause::OMPC_allocate}}},
-        {60, {{{Property::Unique}}, {Clause::OMPC_allocate}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(52), {{{Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_allocate}}},
       }
     ),
   },
@@ -1693,11 +1693,11 @@
     descriptor::Modifier(
       "allocator-simple-modifier",
       {
-        {50, {{{Property::Exclusive, Property::Unique}}, {Clause::OMPC_allocate}}},
-        {51, {{{Property::Exclusive, Property::Unique}}, {Clause::OMPC_allocate}}},
-        {52, {{{Property::Exclusive, Property::Unique}}, {Clause::OMPC_allocate}}},
-        {60, {{{Property::Exclusive, Property::Unique}}, {Clause::OMPC_allocate}}},
-        {61, {{{Property::Exclusive, Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(50), {{{Property::Exclusive, Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(51), {{{Property::Exclusive, Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(52), {{{Property::Exclusive, Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(60), {{{Property::Exclusive, Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(61), {{{Property::Exclusive, Property::Unique}}, {Clause::OMPC_allocate}}},
       }
     ),
   },
@@ -1706,8 +1706,8 @@
     descriptor::Modifier(
       "always-modifier",
       {
-        {60, {{{Property::MapTypeModifying, Property::Unique}}, {Clause::OMPC_map}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(60), {{{Property::MapTypeModifying, Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_map}}},
       }
     ),
   },
@@ -1716,7 +1716,7 @@
     descriptor::Modifier(
       "attach-modifier",
       {
-        {61, {{{Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_map}}},
       }
     ),
   },
@@ -1725,8 +1725,8 @@
     descriptor::Modifier(
       "automap-modifier",
       {
-        {60, {{{Property::Unique}}, {Clause::OMPC_enter}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_enter}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_enter}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_enter}}},
       }
     ),
   },
@@ -1735,12 +1735,12 @@
     descriptor::Modifier(
       "chunk-modifier",
       {
-        {45, {{{Property::Unique}}, {Clause::OMPC_schedule}}},
-        {50, {{{Property::Unique}}, {Clause::OMPC_schedule}}},
-        {51, {{{Property::Unique}}, {Clause::OMPC_schedule}}},
-        {52, {{{Property::Unique}}, {Clause::OMPC_schedule}}},
-        {60, {{{Property::Unique}}, {Clause::OMPC_schedule}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(45), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(50), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(51), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(52), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
       }
     ),
   },
@@ -1749,8 +1749,8 @@
     descriptor::Modifier(
       "close-modifier",
       {
-        {60, {{{Property::MapTypeModifying, Property::Unique}}, {Clause::OMPC_map}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(60), {{{Property::MapTypeModifying, Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_map}}},
       }
     ),
   },
@@ -1759,11 +1759,11 @@
     descriptor::Modifier(
       "context-selector",
       {
-        {50, {{{Property::Required, Property::Unique}}, {Clause::OMPC_when}}},
-        {51, {{{Property::Required, Property::Unique}}, {Clause::OMPC_when}}},
-        {52, {{{Property::Required, Property::Unique}}, {Clause::OMPC_when}}},
-        {60, {{{Property::Required, Property::Unique}}, {Clause::OMPC_when}}},
-        {61, {{{Property::Required, Property::Unique}}, {Clause::OMPC_when}}},
+        {Version(50), {{{Property::Required, Property::Unique}}, {Clause::OMPC_when}}},
+        {Version(51), {{{Property::Required, Property::Unique}}, {Clause::OMPC_when}}},
+        {Version(52), {{{Property::Required, Property::Unique}}, {Clause::OMPC_when}}},
+        {Version(60), {{{Property::Required, Property::Unique}}, {Clause::OMPC_when}}},
+        {Version(61), {{{Property::Required, Property::Unique}}, {Clause::OMPC_when}}},
       }
     ),
   },
@@ -1772,7 +1772,7 @@
     descriptor::Modifier(
       "default-modifier",
       {
-        {61, {{{Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_reduction}}},
       }
     ),
   },
@@ -1781,8 +1781,8 @@
     descriptor::Modifier(
       "delete-modifier",
       {
-        {60, {{{Property::MapTypeModifying, Property::Unique}}, {Clause::OMPC_map}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(60), {{{Property::MapTypeModifying, Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_map}}},
       }
     ),
   },
@@ -1791,12 +1791,12 @@
     descriptor::Modifier(
       "dependence-type",
       {
-        {45, {{{Property::Unique}}, {Clause::OMPC_depend}}},
-        {50, {{{Property::Unique}}, {Clause::OMPC_depend}}},
-        {51, {{{Property::Unique}}, {Clause::OMPC_depend}}},
-        {52, {{{Property::Required, Property::Unique}}, {Clause::OMPC_doacross}}},
-        {60, {{{Property::Required, Property::Unique}}, {Clause::OMPC_doacross}}},
-        {61, {{{Property::Required, Property::Unique}}, {Clause::OMPC_doacross}}},
+        {Version(45), {{{Property::Unique}}, {Clause::OMPC_depend}}},
+        {Version(50), {{{Property::Unique}}, {Clause::OMPC_depend}}},
+        {Version(51), {{{Property::Unique}}, {Clause::OMPC_depend}}},
+        {Version(52), {{{Property::Required, Property::Unique}}, {Clause::OMPC_doacross}}},
+        {Version(60), {{{Property::Required, Property::Unique}}, {Clause::OMPC_doacross}}},
+        {Version(61), {{{Property::Required, Property::Unique}}, {Clause::OMPC_doacross}}},
       }
     ),
   },
@@ -1805,8 +1805,8 @@
     descriptor::Modifier(
       "depinfo-modifier",
       {
-        {60, {{{Property::Complex, Property::Unique}}, {Clause::OMPC_init}}},
-        {61, {{{Property::Complex, Property::Unique}}, {Clause::OMPC_init}}},
+        {Version(60), {{{Property::Complex, Property::Unique}}, {Clause::OMPC_init}}},
+        {Version(61), {{{Property::Complex, Property::Unique}}, {Clause::OMPC_init}}},
       }
     ),
   },
@@ -1815,7 +1815,7 @@
     descriptor::Modifier(
       "depobj-modifier",
       {
-        {61, {{{Property::Unique}}, {Clause::OMPC_depend}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_depend}}},
       }
     ),
   },
@@ -1824,11 +1824,11 @@
     descriptor::Modifier(
       "device-modifier",
       {
-        {50, {{{Property::Unique}}, {Clause::OMPC_device}}},
-        {51, {{{Property::Unique}}, {Clause::OMPC_device}}},
-        {52, {{{Property::Unique}}, {Clause::OMPC_device}}},
-        {60, {{{Property::Unique}}, {Clause::OMPC_device}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_device}}},
+        {Version(50), {{{Property::Unique}}, {Clause::OMPC_device}}},
+        {Version(51), {{{Property::Unique}}, {Clause::OMPC_device}}},
+        {Version(52), {{{Property::Unique}}, {Clause::OMPC_device}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_device}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_device}}},
       }
     ),
   },
@@ -1837,7 +1837,7 @@
     descriptor::Modifier(
       "dims-modifier",
       {
-        {61, {{{Property::Unique}}, {Clause::OMPC_num_teams, Clause::OMPC_num_threads, Clause::OMPC_thread_limit}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_num_teams, Clause::OMPC_num_threads, Clause::OMPC_thread_limit}}},
       }
     ),
   },
@@ -1846,12 +1846,12 @@
     descriptor::Modifier(
       "directive-name-modifier",
       {
-        {45, {{{Property::Unique}}, {Clause::OMPC_if}}},
-        {50, {{{Property::Unique}}, {Clause::OMPC_if}}},
-        {51, {{{Property::Unique}}, {Clause::OMPC_if}}},
-        {52, {{{Property::Unique}}, {Clause::OMPC_if}}},
-        {60, {{{Property::Unique}}, {Clause::OMPC_absent, Clause::OMPC_acq_rel, Clause::OMPC_acquire, Clause::OMPC_adjust_args, Clause::OMPC_affinity, Clause::OMPC_align, Clause::OMPC_aligned, Clause::OMPC_allocate, Clause::OMPC_allocator, Clause::OMPC_append_args, Clause::OMPC_apply, Clause::OMPC_at, Clause::OMPC_atomic_default_mem_order, Clause::OMPC_bind, Clause::OMPC_capture, Clause::OMPC_collapse, Clause::OMPC_collector, Clause::OMPC_combiner, Clause::OMPC_compare, Clause::OMPC_contains, Clause::OMPC_copyin, Clause::OMPC_copyprivate, Clause::OMPC_counts, Clause::OMPC_default, Clause::OMPC_defaultmap, Clause::OMPC_depend, Clause::OMPC_destroy, Clause::OMPC_detach, Clause::OMPC_device, Clause::OMPC_device_safesync, Clause::OMPC_device_type, Clause::OMPC_dist_schedule, Clause::OMPC_doacross, Clause::OMPC_dynamic_allocators, Clause::OMPC_enter, Clause::OMPC_exclusive, Clause::OMPC_fail, Clause::OMPC_filter, Clause::OMPC_final, Clause::OMPC_firstprivate, Clause::OMPC_from, Clause::OMPC_full, Clause::OMPC_grainsize, Clause::OMPC_graph_id, Clause::OMPC_graph_reset, Clause::OMPC_has_device_addr, Clause::OMPC_hint, Clause::OMPC_holds, Clause::OMPC_if, Clause::OMPC_in_reduction, Clause::OMPC_inbranch, Clause::OMPC_inclusive, Clause::OMPC_indirect, Clause::OMPC_induction, Clause::OMPC_inductor, Clause::OMPC_init, Clause::OMPC_init_complete, Clause::OMPC_initializer, Clause::OMPC_interop, Clause::OMPC_is_device_ptr, Clause::OMPC_lastprivate, Clause::OMPC_linear, Clause::OMPC_link, Clause::OMPC_local, Clause::OMPC_looprange, Clause::OMPC_map, Clause::OMPC_match, Clause::OMPC_memscope, Clause::OMPC_mergeable, Clause::OMPC_message, Clause::OMPC_no_openmp, Clause::OMPC_no_openmp_constructs, Clause::OMPC_no_openmp_routines, Clause::OMPC_no_parallelism, Clause::OMPC_nocontext, Clause::OMPC_nogroup, Clause::OMPC_nontemporal, Clause::OMPC_notinbranch, Clause::OMPC_novariants, Clause::OMPC_nowait, Clause::OMPC_num_tasks, Clause::OMPC_num_teams, Clause::OMPC_num_threads, Clause::OMPC_order, Clause::OMPC_ordered, Clause::OMPC_otherwise, Clause::OMPC_partial, Clause::OMPC_permutation, Clause::OMPC_priority, Clause::OMPC_private, Clause::OMPC_proc_bind, Clause::OMPC_read, Clause::OMPC_reduction, Clause::OMPC_relaxed, Clause::OMPC_release, Clause::OMPC_replayable, Clause::OMPC_reverse_offload, Clause::OMPC_safelen, Clause::OMPC_safesync, Clause::OMPC_schedule, Clause::OMPC_self_maps, Clause::OMPC_seq_cst, Clause::OMPC_severity, Clause::OMPC_shared, Clause::OMPC_simd, Clause::OMPC_simdlen, Clause::OMPC_sizes, Clause::OMPC_task_reduction, Clause::OMPC_thread_limit, Clause::OMPC_threads, Clause::OMPC_threadset, Clause::OMPC_to, Clause::OMPC_transparent, Clause::OMPC_unified_address, Clause::OMPC_unified_shared_memory, Clause::OMPC_uniform, Clause::OMPC_untied, Clause::OMPC_update, Clause::OMPC_update_depend_objects, Clause::OMPC_use, Clause::OMPC_use_device_addr, Clause::OMPC_use_device_ptr, Clause::OMPC_uses_allocators, Clause::OMPC_weak, Clause::OMPC_when, Clause::OMPC_write}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_absent, Clause::OMPC_acq_rel, Clause::OMPC_acquire, Clause::OMPC_adjust_args, Clause::OMPC_affinity, Clause::OMPC_align, Clause::OMPC_aligned, Clause::OMPC_allocate, Clause::OMPC_allocator, Clause::OMPC_append_args, Clause::OMPC_apply, Clause::OMPC_at, Clause::OMPC_atomic_default_mem_order, Clause::OMPC_bind, Clause::OMPC_capture, Clause::OMPC_collapse, Clause::OMPC_collector, Clause::OMPC_combiner, Clause::OMPC_compare, Clause::OMPC_contains, Clause::OMPC_copyin, Clause::OMPC_copyprivate, Clause::OMPC_counts, Clause::OMPC_default, Clause::OMPC_defaultmap, Clause::OMPC_depend, Clause::OMPC_depth, Clause::OMPC_destroy, Clause::OMPC_detach, Clause::OMPC_device, Clause::OMPC_device_safesync, Clause::OMPC_device_type, Clause::OMPC_dist_schedule, Clause::OMPC_doacross, Clause::OMPC_dyn_groupprivate, Clause::OMPC_dynamic_allocators, Clause::OMPC_enter, Clause::OMPC_exclusive, Clause::OMPC_fail, Clause::OMPC_filter, Clause::OMPC_final, Clause::OMPC_firstprivate, Clause::OMPC_from, Clause::OMPC_full, Clause::OMPC_grainsize, Clause::OMPC_graph_id, Clause::OMPC_graph_reset, Clause::OMPC_has_device_addr, Clause::OMPC_hint, Clause::OMPC_holds, Clause::OMPC_if, Clause::OMPC_in_reduction, Clause::OMPC_inbranch, Clause::OMPC_inclusive, Clause::OMPC_indirect, Clause::OMPC_induction, Clause::OMPC_inductor, Clause::OMPC_init, Clause::OMPC_init_complete, Clause::OMPC_initializer, Clause::OMPC_interop, Clause::OMPC_is_device_ptr, Clause::OMPC_lastprivate, Clause::OMPC_linear, Clause::OMPC_link, Clause::OMPC_local, Clause::OMPC_looprange, Clause::OMPC_map, Clause::OMPC_match, Clause::OMPC_memscope, Clause::OMPC_mergeable, Clause::OMPC_message, Clause::OMPC_no_openmp, Clause::OMPC_no_openmp_constructs, Clause::OMPC_no_openmp_routines, Clause::OMPC_no_parallelism, Clause::OMPC_nocontext, Clause::OMPC_nogroup, Clause::OMPC_nontemporal, Clause::OMPC_notinbranch, Clause::OMPC_novariants, Clause::OMPC_nowait, Clause::OMPC_num_tasks, Clause::OMPC_num_teams, Clause::OMPC_num_threads, Clause::OMPC_order, Clause::OMPC_ordered, Clause::OMPC_otherwise, Clause::OMPC_partial, Clause::OMPC_permutation, Clause::OMPC_priority, Clause::OMPC_private, Clause::OMPC_proc_bind, Clause::OMPC_read, Clause::OMPC_reduction, Clause::OMPC_relaxed, Clause::OMPC_release, Clause::OMPC_replayable, Clause::OMPC_reverse_offload, Clause::OMPC_safelen, Clause::OMPC_safesync, Clause::OMPC_schedule, Clause::OMPC_self_maps, Clause::OMPC_seq_cst, Clause::OMPC_severity, Clause::OMPC_shared, Clause::OMPC_simd, Clause::OMPC_simdlen, Clause::OMPC_sizes, Clause::OMPC_task_reduction, Clause::OMPC_thread_limit, Clause::OMPC_threads, Clause::OMPC_threadset, Clause::OMPC_to, Clause::OMPC_transparent, Clause::OMPC_unified_address, Clause::OMPC_unified_shared_memory, Clause::OMPC_uniform, Clause::OMPC_untied, Clause::OMPC_update, Clause::OMPC_update_depend_objects, Clause::OMPC_use, Clause::OMPC_use_device_addr, Clause::OMPC_use_device_ptr, Clause::OMPC_uses_allocators, Clause::OMPC_weak, Clause::OMPC_when, Clause::OMPC_write}}},
+        {Version(45), {{{Property::Unique}}, {Clause::OMPC_if}}},
+        {Version(50), {{{Property::Unique}}, {Clause::OMPC_if}}},
+        {Version(51), {{{Property::Unique}}, {Clause::OMPC_if}}},
+        {Version(52), {{{Property::Unique}}, {Clause::OMPC_if}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_absent, Clause::OMPC_acq_rel, Clause::OMPC_acquire, Clause::OMPC_adjust_args, Clause::OMPC_affinity, Clause::OMPC_align, Clause::OMPC_aligned, Clause::OMPC_allocate, Clause::OMPC_allocator, Clause::OMPC_append_args, Clause::OMPC_apply, Clause::OMPC_at, Clause::OMPC_atomic_default_mem_order, Clause::OMPC_bind, Clause::OMPC_capture, Clause::OMPC_collapse, Clause::OMPC_collector, Clause::OMPC_combiner, Clause::OMPC_compare, Clause::OMPC_contains, Clause::OMPC_copyin, Clause::OMPC_copyprivate, Clause::OMPC_counts, Clause::OMPC_default, Clause::OMPC_defaultmap, Clause::OMPC_depend, Clause::OMPC_destroy, Clause::OMPC_detach, Clause::OMPC_device, Clause::OMPC_device_safesync, Clause::OMPC_device_type, Clause::OMPC_dist_schedule, Clause::OMPC_doacross, Clause::OMPC_dynamic_allocators, Clause::OMPC_enter, Clause::OMPC_exclusive, Clause::OMPC_fail, Clause::OMPC_filter, Clause::OMPC_final, Clause::OMPC_firstprivate, Clause::OMPC_from, Clause::OMPC_full, Clause::OMPC_grainsize, Clause::OMPC_graph_id, Clause::OMPC_graph_reset, Clause::OMPC_has_device_addr, Clause::OMPC_hint, Clause::OMPC_holds, Clause::OMPC_if, Clause::OMPC_in_reduction, Clause::OMPC_inbranch, Clause::OMPC_inclusive, Clause::OMPC_indirect, Clause::OMPC_induction, Clause::OMPC_inductor, Clause::OMPC_init, Clause::OMPC_init_complete, Clause::OMPC_initializer, Clause::OMPC_interop, Clause::OMPC_is_device_ptr, Clause::OMPC_lastprivate, Clause::OMPC_linear, Clause::OMPC_link, Clause::OMPC_local, Clause::OMPC_looprange, Clause::OMPC_map, Clause::OMPC_match, Clause::OMPC_memscope, Clause::OMPC_mergeable, Clause::OMPC_message, Clause::OMPC_no_openmp, Clause::OMPC_no_openmp_constructs, Clause::OMPC_no_openmp_routines, Clause::OMPC_no_parallelism, Clause::OMPC_nocontext, Clause::OMPC_nogroup, Clause::OMPC_nontemporal, Clause::OMPC_notinbranch, Clause::OMPC_novariants, Clause::OMPC_nowait, Clause::OMPC_num_tasks, Clause::OMPC_num_teams, Clause::OMPC_num_threads, Clause::OMPC_order, Clause::OMPC_ordered, Clause::OMPC_otherwise, Clause::OMPC_partial, Clause::OMPC_permutation, Clause::OMPC_priority, Clause::OMPC_private, Clause::OMPC_proc_bind, Clause::OMPC_read, Clause::OMPC_reduction, Clause::OMPC_relaxed, Clause::OMPC_release, Clause::OMPC_replayable, Clause::OMPC_reverse_offload, Clause::OMPC_safelen, Clause::OMPC_safesync, Clause::OMPC_schedule, Clause::OMPC_self_maps, Clause::OMPC_seq_cst, Clause::OMPC_severity, Clause::OMPC_shared, Clause::OMPC_simd, Clause::OMPC_simdlen, Clause::OMPC_sizes, Clause::OMPC_task_reduction, Clause::OMPC_thread_limit, Clause::OMPC_threads, Clause::OMPC_threadset, Clause::OMPC_to, Clause::OMPC_transparent, Clause::OMPC_unified_address, Clause::OMPC_unified_shared_memory, Clause::OMPC_uniform, Clause::OMPC_untied, Clause::OMPC_update, Clause::OMPC_update_depend_objects, Clause::OMPC_use, Clause::OMPC_use_device_addr, Clause::OMPC_use_device_ptr, Clause::OMPC_uses_allocators, Clause::OMPC_weak, Clause::OMPC_when, Clause::OMPC_write}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_absent, Clause::OMPC_acq_rel, Clause::OMPC_acquire, Clause::OMPC_adjust_args, Clause::OMPC_affinity, Clause::OMPC_align, Clause::OMPC_aligned, Clause::OMPC_allocate, Clause::OMPC_allocator, Clause::OMPC_append_args, Clause::OMPC_apply, Clause::OMPC_at, Clause::OMPC_atomic_default_mem_order, Clause::OMPC_bind, Clause::OMPC_capture, Clause::OMPC_collapse, Clause::OMPC_collector, Clause::OMPC_combiner, Clause::OMPC_compare, Clause::OMPC_contains, Clause::OMPC_copyin, Clause::OMPC_copyprivate, Clause::OMPC_counts, Clause::OMPC_default, Clause::OMPC_defaultmap, Clause::OMPC_depend, Clause::OMPC_depth, Clause::OMPC_destroy, Clause::OMPC_detach, Clause::OMPC_device, Clause::OMPC_device_safesync, Clause::OMPC_device_type, Clause::OMPC_dist_schedule, Clause::OMPC_doacross, Clause::OMPC_dyn_groupprivate, Clause::OMPC_dynamic_allocators, Clause::OMPC_enter, Clause::OMPC_exclusive, Clause::OMPC_fail, Clause::OMPC_filter, Clause::OMPC_final, Clause::OMPC_firstprivate, Clause::OMPC_from, Clause::OMPC_full, Clause::OMPC_grainsize, Clause::OMPC_graph_id, Clause::OMPC_graph_reset, Clause::OMPC_has_device_addr, Clause::OMPC_hint, Clause::OMPC_holds, Clause::OMPC_if, Clause::OMPC_in_reduction, Clause::OMPC_inbranch, Clause::OMPC_inclusive, Clause::OMPC_indirect, Clause::OMPC_induction, Clause::OMPC_inductor, Clause::OMPC_init, Clause::OMPC_init_complete, Clause::OMPC_initializer, Clause::OMPC_interop, Clause::OMPC_is_device_ptr, Clause::OMPC_lastprivate, Clause::OMPC_linear, Clause::OMPC_link, Clause::OMPC_local, Clause::OMPC_looprange, Clause::OMPC_map, Clause::OMPC_match, Clause::OMPC_memscope, Clause::OMPC_mergeable, Clause::OMPC_message, Clause::OMPC_no_openmp, Clause::OMPC_no_openmp_constructs, Clause::OMPC_no_openmp_routines, Clause::OMPC_no_parallelism, Clause::OMPC_nocontext, Clause::OMPC_nogroup, Clause::OMPC_nontemporal, Clause::OMPC_notinbranch, Clause::OMPC_novariants, Clause::OMPC_nowait, Clause::OMPC_num_tasks, Clause::OMPC_num_teams, Clause::OMPC_num_threads, Clause::OMPC_order, Clause::OMPC_ordered, Clause::OMPC_otherwise, Clause::OMPC_partial, Clause::OMPC_permutation, Clause::OMPC_priority, Clause::OMPC_private, Clause::OMPC_proc_bind, Clause::OMPC_read, Clause::OMPC_reduction, Clause::OMPC_relaxed, Clause::OMPC_release, Clause::OMPC_replayable, Clause::OMPC_reverse_offload, Clause::OMPC_safelen, Clause::OMPC_safesync, Clause::OMPC_schedule, Clause::OMPC_self_maps, Clause::OMPC_seq_cst, Clause::OMPC_severity, Clause::OMPC_shared, Clause::OMPC_simd, Clause::OMPC_simdlen, Clause::OMPC_sizes, Clause::OMPC_task_reduction, Clause::OMPC_thread_limit, Clause::OMPC_threads, Clause::OMPC_threadset, Clause::OMPC_to, Clause::OMPC_transparent, Clause::OMPC_unified_address, Clause::OMPC_unified_shared_memory, Clause::OMPC_uniform, Clause::OMPC_untied, Clause::OMPC_update, Clause::OMPC_update_depend_objects, Clause::OMPC_use, Clause::OMPC_use_device_addr, Clause::OMPC_use_device_ptr, Clause::OMPC_uses_allocators, Clause::OMPC_weak, Clause::OMPC_when, Clause::OMPC_write}}},
       }
     ),
   },
@@ -1860,7 +1860,7 @@
     descriptor::Modifier(
       "expectation",
       {
-        {52, {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_to}}},
+        {Version(52), {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_to}}},
       }
     ),
   },
@@ -1869,7 +1869,7 @@
     descriptor::Modifier(
       "fallback",
       {
-        {61, {{{Property::Unique}}, {Clause::OMPC_use_device_ptr}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_use_device_ptr}}},
       }
     ),
   },
@@ -1878,7 +1878,7 @@
     descriptor::Modifier(
       "fallback-modifier",
       {
-        {61, {{{Property::Unique}}, {Clause::OMPC_dyn_groupprivate}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_dyn_groupprivate}}},
       }
     ),
   },
@@ -1887,8 +1887,8 @@
     descriptor::Modifier(
       "induction-identifier",
       {
-        {60, {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_induction}}},
-        {61, {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_induction}}},
+        {Version(60), {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_induction}}},
+        {Version(61), {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_induction}}},
       }
     ),
   },
@@ -1897,8 +1897,8 @@
     descriptor::Modifier(
       "induction-modifier",
       {
-        {60, {{{Property::Unique}}, {Clause::OMPC_induction}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_induction}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_induction}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_induction}}},
       }
     ),
   },
@@ -1907,7 +1907,7 @@
     descriptor::Modifier(
       "inscan-modifier",
       {
-        {61, {{{Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_reduction}}},
       }
     ),
   },
@@ -1916,9 +1916,9 @@
     descriptor::Modifier(
       "interop-type",
       {
-        {51, {{{Property::Repeatable, Property::Required}}, {Clause::OMPC_init}}},
-        {52, {{{Property::Repeatable, Property::Required}}, {Clause::OMPC_init}}},
-        {60, {{{Property::Repeatable}}, {Clause::OMPC_init}}},
+        {Version(51), {{{Property::Repeatable, Property::Required}}, {Clause::OMPC_init}}},
+        {Version(52), {{{Property::Repeatable, Property::Required}}, {Clause::OMPC_init}}},
+        {Version(60), {{{Property::Repeatable}}, {Clause::OMPC_init}}},
       }
     ),
   },
@@ -1927,11 +1927,11 @@
     descriptor::Modifier(
       "iterator",
       {
-        {50, {{{Property::Unique}}, {Clause::OMPC_affinity, Clause::OMPC_depend}}},
-        {51, {{{Property::Unique}}, {Clause::OMPC_affinity, Clause::OMPC_depend, Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
-        {52, {{{Property::Unique}}, {Clause::OMPC_affinity, Clause::OMPC_depend, Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
-        {60, {{{Property::Unique}}, {Clause::OMPC_affinity, Clause::OMPC_depend, Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_affinity, Clause::OMPC_depend, Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
+        {Version(50), {{{Property::Unique}}, {Clause::OMPC_affinity, Clause::OMPC_depend}}},
+        {Version(51), {{{Property::Unique}}, {Clause::OMPC_affinity, Clause::OMPC_depend, Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
+        {Version(52), {{{Property::Unique}}, {Clause::OMPC_affinity, Clause::OMPC_depend, Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_affinity, Clause::OMPC_depend, Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_affinity, Clause::OMPC_depend, Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
       }
     ),
   },
@@ -1940,11 +1940,11 @@
     descriptor::Modifier(
       "lastprivate-modifier",
       {
-        {50, {{{Property::Unique}}, {Clause::OMPC_lastprivate}}},
-        {51, {{{Property::Unique}}, {Clause::OMPC_lastprivate}}},
-        {52, {{{Property::Unique}}, {Clause::OMPC_lastprivate}}},
-        {60, {{{Property::Unique}}, {Clause::OMPC_lastprivate}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_lastprivate}}},
+        {Version(50), {{{Property::Unique}}, {Clause::OMPC_lastprivate}}},
+        {Version(51), {{{Property::Unique}}, {Clause::OMPC_lastprivate}}},
+        {Version(52), {{{Property::Unique}}, {Clause::OMPC_lastprivate}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_lastprivate}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_lastprivate}}},
       }
     ),
   },
@@ -1953,12 +1953,12 @@
     descriptor::Modifier(
       "linear-modifier",
       {
-        {45, {{{Property::Unique}}, {Clause::OMPC_linear}}},
-        {50, {{{Property::Unique}}, {Clause::OMPC_linear}}},
-        {51, {{{Property::Unique}}, {Clause::OMPC_linear}}},
-        {52, {{{Property::Unique}}, {Clause::OMPC_linear}}},
-        {60, {{{Property::Unique}}, {Clause::OMPC_linear}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(45), {{{Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(50), {{{Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(51), {{{Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(52), {{{Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_linear}}},
       }
     ),
   },
@@ -1967,9 +1967,9 @@
     descriptor::Modifier(
       "linear-step",
       {
-        {45, {{{Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
-        {50, {{{Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
-        {51, {{{Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(45), {{{Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(50), {{{Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(51), {{{Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
       }
     ),
   },
@@ -1978,7 +1978,7 @@
     descriptor::Modifier(
       "loc-modifier",
       {
-        {61, {{{Property::Unique}}, {Clause::OMPC_depend}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_depend}}},
       }
     ),
   },
@@ -1987,8 +1987,8 @@
     descriptor::Modifier(
       "loop-modifier",
       {
-        {60, {{{Property::Optional, Property::Unique}}, {Clause::OMPC_apply}}},
-        {61, {{{Property::Optional, Property::Unique}}, {Clause::OMPC_apply}}},
+        {Version(60), {{{Property::Optional, Property::Unique}}, {Clause::OMPC_apply}}},
+        {Version(61), {{{Property::Optional, Property::Unique}}, {Clause::OMPC_apply}}},
       }
     ),
   },
@@ -1997,11 +1997,11 @@
     descriptor::Modifier(
       "lower-bound",
       {
-        {50, {{{Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_num_teams}}},
-        {51, {{{Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_num_teams}}},
-        {52, {{{Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_num_teams}}},
-        {60, {{{Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_num_teams}}},
-        {61, {{{Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_num_teams}}},
+        {Version(50), {{{Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_num_teams}}},
+        {Version(51), {{{Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_num_teams}}},
+        {Version(52), {{{Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_num_teams}}},
+        {Version(60), {{{Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_num_teams}}},
+        {Version(61), {{{Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_num_teams}}},
       }
     ),
   },
@@ -2010,12 +2010,12 @@
     descriptor::Modifier(
       "map-type",
       {
-        {45, {{{Property::Ultimate, Property::Unique}}, {Clause::OMPC_map}}},
-        {50, {{{Property::Ultimate, Property::Unique}}, {Clause::OMPC_map}}},
-        {51, {{{Property::Ultimate, Property::Unique}}, {Clause::OMPC_map}}},
-        {52, {{{Property::Ultimate, Property::Unique}}, {Clause::OMPC_map}}},
-        {60, {{{Property::Unique}}, {Clause::OMPC_map}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(45), {{{Property::Ultimate, Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(50), {{{Property::Ultimate, Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(51), {{{Property::Ultimate, Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(52), {{{Property::Ultimate, Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_map}}},
       }
     ),
   },
@@ -2024,10 +2024,10 @@
     descriptor::Modifier(
       "map-type-modifier",
       {
-        {45, {{{Property::MapTypeModifying, Property::Repeatable}}, {Clause::OMPC_map}}},
-        {50, {{{Property::MapTypeModifying, Property::Repeatable}}, {Clause::OMPC_map}}},
-        {51, {{{Property::MapTypeModifying, Property::Repeatable}}, {Clause::OMPC_map}}},
-        {52, {{{Property::MapTypeModifying, Property::Repeatable}}, {Clause::OMPC_map}}},
+        {Version(45), {{{Property::MapTypeModifying, Property::Repeatable}}, {Clause::OMPC_map}}},
+        {Version(50), {{{Property::MapTypeModifying, Property::Repeatable}}, {Clause::OMPC_map}}},
+        {Version(51), {{{Property::MapTypeModifying, Property::Repeatable}}, {Clause::OMPC_map}}},
+        {Version(52), {{{Property::MapTypeModifying, Property::Repeatable}}, {Clause::OMPC_map}}},
       }
     ),
   },
@@ -2036,11 +2036,11 @@
     descriptor::Modifier(
       "mapper",
       {
-        {50, {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
-        {51, {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
-        {52, {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
-        {60, {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
+        {Version(50), {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
+        {Version(51), {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
+        {Version(52), {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
       }
     ),
   },
@@ -2049,9 +2049,9 @@
     descriptor::Modifier(
       "mem-space",
       {
-        {52, {{{Property::Unique}}, {Clause::OMPC_uses_allocators}}},
-        {60, {{{Property::Unique}}, {Clause::OMPC_uses_allocators}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_uses_allocators}}},
+        {Version(52), {{{Property::Unique}}, {Clause::OMPC_uses_allocators}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_uses_allocators}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_uses_allocators}}},
       }
     ),
   },
@@ -2060,7 +2060,7 @@
     descriptor::Modifier(
       "motion-modifier",
       {
-        {51, {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_to}}},
+        {Version(51), {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_to}}},
       }
     ),
   },
@@ -2069,7 +2069,7 @@
     descriptor::Modifier(
       "need-device-addr",
       {
-        {61, {{{Property::Unique}}, {Clause::OMPC_adjust_args}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_adjust_args}}},
       }
     ),
   },
@@ -2078,7 +2078,7 @@
     descriptor::Modifier(
       "need-device-ptr",
       {
-        {61, {{{Property::Unique}}, {Clause::OMPC_adjust_args}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_adjust_args}}},
       }
     ),
   },
@@ -2087,7 +2087,7 @@
     descriptor::Modifier(
       "noncommutative-modifier",
       {
-        {61, {{{Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_reduction}}},
       }
     ),
   },
@@ -2096,7 +2096,7 @@
     descriptor::Modifier(
       "nothing",
       {
-        {61, {{{Property::Unique}}, {Clause::OMPC_adjust_args}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_adjust_args}}},
       }
     ),
   },
@@ -2105,12 +2105,12 @@
     descriptor::Modifier(
       "ompx-hold-modifier",
       {
-        {45, {{{Property::Unique}}, {Clause::OMPC_map}}},
-        {50, {{{Property::Unique}}, {Clause::OMPC_map}}},
-        {51, {{{Property::Unique}}, {Clause::OMPC_map}}},
-        {52, {{{Property::Unique}}, {Clause::OMPC_map}}},
-        {60, {{{Property::Unique}}, {Clause::OMPC_map}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(45), {{{Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(50), {{{Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(51), {{{Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(52), {{{Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_map}}},
       }
     ),
   },
@@ -2119,7 +2119,7 @@
     descriptor::Modifier(
       "optional-modifier",
       {
-        {61, {{{Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
       }
     ),
   },
@@ -2128,10 +2128,10 @@
     descriptor::Modifier(
       "order-modifier",
       {
-        {51, {{{Property::Unique}}, {Clause::OMPC_order}}},
-        {52, {{{Property::Unique}}, {Clause::OMPC_order}}},
-        {60, {{{Property::Unique}}, {Clause::OMPC_order}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_order}}},
+        {Version(51), {{{Property::Unique}}, {Clause::OMPC_order}}},
+        {Version(52), {{{Property::Unique}}, {Clause::OMPC_order}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_order}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_order}}},
       }
     ),
   },
@@ -2140,12 +2140,12 @@
     descriptor::Modifier(
       "ordering-modifier",
       {
-        {45, {{{Property::Unique}}, {Clause::OMPC_schedule}}},
-        {50, {{{Property::Unique}}, {Clause::OMPC_schedule}}},
-        {51, {{{Property::Unique}}, {Clause::OMPC_schedule}}},
-        {52, {{{Property::Unique}}, {Clause::OMPC_schedule}}},
-        {60, {{{Property::Unique}}, {Clause::OMPC_schedule}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(45), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(50), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(51), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(52), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
       }
     ),
   },
@@ -2154,8 +2154,8 @@
     descriptor::Modifier(
       "original-sharing-modifier",
       {
-        {60, {{{Property::Unique}}, {Clause::OMPC_reduction}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_reduction}}},
       }
     ),
   },
@@ -2164,7 +2164,7 @@
     descriptor::Modifier(
       "per-thread-modifier",
       {
-        {61, {{{Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_reduction}}},
       }
     ),
   },
@@ -2173,8 +2173,8 @@
     descriptor::Modifier(
       "prefer-type",
       {
-        {60, {{{Property::Complex, Property::Unique}}, {Clause::OMPC_init}}},
-        {61, {{{Property::Complex, Property::Unique}}, {Clause::OMPC_init}}},
+        {Version(60), {{{Property::Complex, Property::Unique}}, {Clause::OMPC_init}}},
+        {Version(61), {{{Property::Complex, Property::Unique}}, {Clause::OMPC_init}}},
       }
     ),
   },
@@ -2183,10 +2183,10 @@
     descriptor::Modifier(
       "prescriptiveness",
       {
-        {51, {{{Property::Unique}}, {Clause::OMPC_grainsize, Clause::OMPC_num_tasks}}},
-        {52, {{{Property::Unique}}, {Clause::OMPC_grainsize, Clause::OMPC_num_tasks}}},
-        {60, {{{Property::Unique}}, {Clause::OMPC_grainsize, Clause::OMPC_num_tasks, Clause::OMPC_num_threads}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_grainsize, Clause::OMPC_num_tasks}}},
+        {Version(51), {{{Property::Unique}}, {Clause::OMPC_grainsize, Clause::OMPC_num_tasks}}},
+        {Version(52), {{{Property::Unique}}, {Clause::OMPC_grainsize, Clause::OMPC_num_tasks}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_grainsize, Clause::OMPC_num_tasks, Clause::OMPC_num_threads}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_grainsize, Clause::OMPC_num_tasks}}},
       }
     ),
   },
@@ -2195,7 +2195,7 @@
     descriptor::Modifier(
       "prescriptiveness-modifier",
       {
-        {61, {{{Property::Unique}}, {Clause::OMPC_num_threads, Clause::OMPC_thread_limit}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_num_threads, Clause::OMPC_thread_limit}}},
       }
     ),
   },
@@ -2204,8 +2204,8 @@
     descriptor::Modifier(
       "present-modifier",
       {
-        {60, {{{Property::MapTypeModifying, Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
+        {Version(60), {{{Property::MapTypeModifying, Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
       }
     ),
   },
@@ -2214,12 +2214,12 @@
     descriptor::Modifier(
       "reduction-identifier",
       {
-        {45, {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_reduction}}},
-        {50, {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_in_reduction, Clause::OMPC_reduction, Clause::OMPC_task_reduction}}},
-        {51, {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_in_reduction, Clause::OMPC_reduction, Clause::OMPC_task_reduction}}},
-        {52, {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_in_reduction, Clause::OMPC_reduction, Clause::OMPC_task_reduction}}},
-        {60, {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_in_reduction, Clause::OMPC_reduction, Clause::OMPC_task_reduction}}},
-        {61, {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_in_reduction, Clause::OMPC_reduction, Clause::OMPC_task_reduction}}},
+        {Version(45), {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(50), {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_in_reduction, Clause::OMPC_reduction, Clause::OMPC_task_reduction}}},
+        {Version(51), {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_in_reduction, Clause::OMPC_reduction, Clause::OMPC_task_reduction}}},
+        {Version(52), {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_in_reduction, Clause::OMPC_reduction, Clause::OMPC_task_reduction}}},
+        {Version(60), {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_in_reduction, Clause::OMPC_reduction, Clause::OMPC_task_reduction}}},
+        {Version(61), {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_in_reduction, Clause::OMPC_reduction, Clause::OMPC_task_reduction}}},
       }
     ),
   },
@@ -2228,10 +2228,10 @@
     descriptor::Modifier(
       "reduction-modifier",
       {
-        {50, {{{Property::Unique}}, {Clause::OMPC_reduction}}},
-        {51, {{{Property::Unique}}, {Clause::OMPC_reduction}}},
-        {52, {{{Property::Unique}}, {Clause::OMPC_reduction}}},
-        {60, {{{Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(50), {{{Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(51), {{{Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(52), {{{Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_reduction}}},
       }
     ),
   },
@@ -2240,8 +2240,8 @@
     descriptor::Modifier(
       "ref-modifier",
       {
-        {60, {{{Property::Unique}}, {Clause::OMPC_map}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_map}}},
       }
     ),
   },
@@ -2250,8 +2250,8 @@
     descriptor::Modifier(
       "saved",
       {
-        {60, {{{Property::Unique}}, {Clause::OMPC_firstprivate}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_firstprivate}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_firstprivate}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_firstprivate}}},
       }
     ),
   },
@@ -2260,7 +2260,7 @@
     descriptor::Modifier(
       "scaled-modifier",
       {
-        {61, {{{Property::Unique}}, {Clause::OMPC_simdlen}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_simdlen}}},
       }
     ),
   },
@@ -2269,8 +2269,8 @@
     descriptor::Modifier(
       "self-modifier",
       {
-        {60, {{{Property::MapTypeModifying, Property::Unique}}, {Clause::OMPC_map}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(60), {{{Property::MapTypeModifying, Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_map}}},
       }
     ),
   },
@@ -2279,7 +2279,7 @@
     descriptor::Modifier(
       "sizes-selector",
       {
-        {61, {{{Property::Unique}}, {Clause::OMPC_sizes}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_sizes}}},
       }
     ),
   },
@@ -2288,9 +2288,9 @@
     descriptor::Modifier(
       "step-complex-modifier",
       {
-        {52, {{{Property::Unique}}, {Clause::OMPC_linear}}},
-        {60, {{{Property::Unique}}, {Clause::OMPC_linear}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(52), {{{Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_linear}}},
       }
     ),
   },
@@ -2299,9 +2299,9 @@
     descriptor::Modifier(
       "step-modifier",
       {
-        {52, {{{Property::Required, Property::Unique}}, {}}},
-        {60, {{{Property::Required, Property::Unique}}, {Clause::OMPC_induction}}},
-        {61, {{{Property::Required, Property::Unique}}, {Clause::OMPC_induction}}},
+        {Version(52), {{{Property::Required, Property::Unique}}, {}}},
+        {Version(60), {{{Property::Required, Property::Unique}}, {Clause::OMPC_induction}}},
+        {Version(61), {{{Property::Required, Property::Unique}}, {Clause::OMPC_induction}}},
       }
     ),
   },
@@ -2310,9 +2310,9 @@
     descriptor::Modifier(
       "step-simple-modifier",
       {
-        {52, {{{Property::Exclusive, Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
-        {60, {{{Property::Exclusive, Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
-        {61, {{{Property::Exclusive, Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(52), {{{Property::Exclusive, Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(60), {{{Property::Exclusive, Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(61), {{{Property::Exclusive, Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
       }
     ),
   },
@@ -2321,7 +2321,7 @@
     descriptor::Modifier(
       "target-type",
       {
-        {61, {{{Property::Unique}}, {Clause::OMPC_init}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_init}}},
       }
     ),
   },
@@ -2330,7 +2330,7 @@
     descriptor::Modifier(
       "targetsync-type",
       {
-        {61, {{{Property::Unique}}, {Clause::OMPC_init}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_init}}},
       }
     ),
   },
@@ -2339,12 +2339,12 @@
     descriptor::Modifier(
       "task-dependence-type",
       {
-        {45, {{{Property::Ultimate, Property::Unique}}, {Clause::OMPC_depend}}},
-        {50, {{{Property::Ultimate, Property::Unique}}, {Clause::OMPC_depend}}},
-        {51, {{{Property::Ultimate, Property::Unique}}, {Clause::OMPC_depend}}},
-        {52, {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_depend}}},
-        {60, {{{Property::Unique}}, {Clause::OMPC_depend, Clause::OMPC_update_depend_objects}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_depend, Clause::OMPC_update_depend_objects}}},
+        {Version(45), {{{Property::Ultimate, Property::Unique}}, {Clause::OMPC_depend}}},
+        {Version(50), {{{Property::Ultimate, Property::Unique}}, {Clause::OMPC_depend}}},
+        {Version(51), {{{Property::Ultimate, Property::Unique}}, {Clause::OMPC_depend}}},
+        {Version(52), {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_depend}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_depend, Clause::OMPC_update_depend_objects}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_depend, Clause::OMPC_update_depend_objects}}},
       }
     ),
   },
@@ -2353,7 +2353,7 @@
     descriptor::Modifier(
       "task-modifier",
       {
-        {61, {{{Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_reduction}}},
       }
     ),
   },
@@ -2362,9 +2362,9 @@
     descriptor::Modifier(
       "traits-array",
       {
-        {52, {{{Property::Unique}}, {Clause::OMPC_uses_allocators}}},
-        {60, {{{Property::Unique}}, {Clause::OMPC_uses_allocators}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_uses_allocators}}},
+        {Version(52), {{{Property::Unique}}, {Clause::OMPC_uses_allocators}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_uses_allocators}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_uses_allocators}}},
       }
     ),
   },
@@ -2373,12 +2373,12 @@
     descriptor::Modifier(
       "variable-category",
       {
-        {45, {{{Property::Required, Property::Unique}}, {Clause::OMPC_defaultmap}}},
-        {50, {{{Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
-        {51, {{{Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
-        {52, {{{Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
-        {60, {{{Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
-        {61, {{{Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
+        {Version(45), {{{Property::Required, Property::Unique}}, {Clause::OMPC_defaultmap}}},
+        {Version(50), {{{Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
+        {Version(51), {{{Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
+        {Version(52), {{{Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
+        {Version(60), {{{Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
+        {Version(61), {{{Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
       }
     ),
   },

--- a/llvm/test/TableGen/directive1.td
+++ b/llvm/test/TableGen/directive1.td
@@ -193,7 +193,7 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // CHECK-NEXT:  constexpr unsigned getDirectivePureSince(Directive Dir) {
 // CHECK-NEXT:    switch (Dir) {
 // CHECK-NEXT:    default:
-// CHECK-NEXT:      return 0x7FFFFFFF;
+// CHECK-NEXT:      return unsigned(0x7FFFFFFF);
 // CHECK-NEXT:    } // switch (Dir)
 // CHECK-NEXT:  }
 // CHECK-EMPTY:
@@ -215,7 +215,7 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // CHECK-NEXT:   return getTdlDirectiveKindAndVersions(Str).first;
 // CHECK-NEXT:  }
 // CHECK-EMPTY:
-// CHECK-NEXT:  LLVM_ABI StringRef getTdlDirectiveName(Directive D, unsigned Ver = 0);
+// CHECK-NEXT:  LLVM_ABI StringRef getTdlDirectiveName(Directive D, unsigned V = unsigned(0));
 // CHECK-EMPTY:
 // CHECK-NEXT:  LLVM_ABI std::pair<Clause, directive::VersionRange> getTdlClauseKindAndVersions(StringRef Str);
 // CHECK-EMPTY:
@@ -223,14 +223,14 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // CHECK-NEXT:    return getTdlClauseKindAndVersions(Str).first;
 // CHECK-NEXT:  }
 // CHECK-EMPTY:
-// CHECK-NEXT:  LLVM_ABI StringRef getTdlClauseName(Clause C, unsigned Ver = 0);
+// CHECK-NEXT:  LLVM_ABI StringRef getTdlClauseName(Clause C, unsigned V = unsigned(0));
 // CHECK-EMPTY:
-// CHECK-NEXT:  /// Return true if \p C is a valid clause for \p D in version \p Version.
-// CHECK-NEXT:  LLVM_ABI bool isAllowedClauseForDirective(Directive D, Clause C, unsigned Version);
+// CHECK-NEXT:  /// Return true if \p C is a valid clause for \p D in version \p V.
+// CHECK-NEXT:  LLVM_ABI bool isAllowedClauseForDirective(Directive D, Clause C, unsigned V);
 // CHECK-EMPTY:
 // CHECK-NEXT:  constexpr std::size_t getMaxLeafCount() { return 0; }
 // CHECK-NEXT:  LLVM_ABI bool isAllowedLoopModifier(Directive D, LoopModifier LM);
-// CHECK-NEXT:  LLVM_ABI StringRef getLoopModifierName(LoopModifier LM, unsigned Ver = 0);
+// CHECK-NEXT:  LLVM_ABI StringRef getLoopModifierName(LoopModifier LM, unsigned V = unsigned(0));
 // CHECK-NEXT:  LLVM_ABI AKind getAKind(StringRef Str);
 // CHECK-NEXT:  LLVM_ABI StringRef getTdlAKindName(AKind x);
 // CHECK-EMPTY:
@@ -435,7 +435,7 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // IMPL-NEXT:     .Default({TDLD_dira, All});
 // IMPL-NEXT: }
 // IMPL-EMPTY:
-// IMPL-NEXT:  llvm::StringRef llvm::tdl::getTdlDirectiveName(llvm::tdl::Directive Kind, unsigned Version) {
+// IMPL-NEXT:  llvm::StringRef llvm::tdl::getTdlDirectiveName(llvm::tdl::Directive Kind, unsigned V) {
 // IMPL-NEXT:    switch (Kind) {
 // IMPL-NEXT:      case TDLD_dira:
 // IMPL-NEXT:        return "dira";
@@ -453,7 +453,7 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // IMPL-NEXT:     .Default({TDLC_clauseb, All});
 // IMPL-NEXT: }
 // IMPL-EMPTY:
-// IMPL-NEXT:  llvm::StringRef llvm::tdl::getTdlClauseName(llvm::tdl::Clause Kind, unsigned Version) {
+// IMPL-NEXT:  llvm::StringRef llvm::tdl::getTdlClauseName(llvm::tdl::Clause Kind, unsigned V) {
 // IMPL-NEXT:    switch (Kind) {
 // IMPL-NEXT:      case TDLC_clausea:
 // IMPL-NEXT:        return "clausea";
@@ -464,7 +464,7 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // IMPL-NEXT:            {"clausec", {0, 2147483647}},
 // IMPL-NEXT:            {"ccccccc", {0, 2147483647}},
 // IMPL-NEXT:        };
-// IMPL-NEXT:        return llvm::directive::FindName(TDLC_clausec_spellings, Version);
+// IMPL-NEXT:        return llvm::directive::FindName(TDLC_clausec_spellings, static_cast<unsigned>(V));
 // IMPL-NEXT:      }
 // IMPL-NEXT:    }
 // IMPL-NEXT:    llvm_unreachable("Invalid Tdl Clause kind");
@@ -490,16 +490,16 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // IMPL-NEXT:    llvm_unreachable("Invalid Tdl AKind kind");
 // IMPL-NEXT:  }
 // IMPL-EMPTY:
-// IMPL-NEXT:  bool llvm::tdl::isAllowedClauseForDirective(llvm::tdl::Directive D, llvm::tdl::Clause C, unsigned Version) {
+// IMPL-NEXT:  bool llvm::tdl::isAllowedClauseForDirective(llvm::tdl::Directive D, llvm::tdl::Clause C, unsigned V) {
 // IMPL-NEXT:    assert(unsigned(D) <= Directive_enumSize);
 // IMPL-NEXT:    assert(unsigned(C) <= Clause_enumSize);
 // IMPL-NEXT:    switch (D) {
 // IMPL-NEXT:      case TDLD_dira:
 // IMPL-NEXT:        switch (C) {
 // IMPL-NEXT:          case TDLC_clausea:
-// IMPL-NEXT:            return 1 <= Version && 2147483647 >= Version;
+// IMPL-NEXT:            return V >= 1 && V <= 2147483647;
 // IMPL-NEXT:          case TDLC_clauseb:
-// IMPL-NEXT:            return 1 <= Version && 2147483647 >= Version;
+// IMPL-NEXT:            return V >= 1 && V <= 2147483647;
 // IMPL-NEXT:          default:
 // IMPL-NEXT:            return false;
 // IMPL-NEXT:        }
@@ -518,7 +518,7 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // IMPL-NEXT:    llvm_unreachable("Invalid Tdl Directive kind");
 // IMPL-NEXT:  }
 // IMPL-EMPTY:
-// IMPL-NEXT:  llvm::StringRef llvm::tdl::getLoopModifierName(llvm::tdl::LoopModifier Kind, unsigned Version) {
+// IMPL-NEXT:  llvm::StringRef llvm::tdl::getLoopModifierName(llvm::tdl::LoopModifier Kind, unsigned V) {
 // IMPL-NEXT:    switch (Kind) {
 // IMPL-NEXT:      case flattened:
 // IMPL-NEXT:        return "flattened";

--- a/llvm/test/TableGen/directive2.td
+++ b/llvm/test/TableGen/directive2.td
@@ -158,7 +158,7 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // CHECK-NEXT:  constexpr unsigned getDirectivePureSince(Directive Dir) {
 // CHECK-NEXT:    switch (Dir) {
 // CHECK-NEXT:    default:
-// CHECK-NEXT:      return 0x7FFFFFFF;
+// CHECK-NEXT:      return unsigned(0x7FFFFFFF);
 // CHECK-NEXT:    } // switch (Dir)
 // CHECK-NEXT:  }
 // CHECK-EMPTY:
@@ -180,7 +180,7 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // CHECK-NEXT:    return getTdlDirectiveKindAndVersions(Str).first;
 // CHECK-NEXT:  }
 // CHECK-EMPTY:
-// CHECK-NEXT:  LLVM_ABI StringRef getTdlDirectiveName(Directive D, unsigned Ver = 0);
+// CHECK-NEXT:  LLVM_ABI StringRef getTdlDirectiveName(Directive D, unsigned V = unsigned(0));
 // CHECK-EMPTY:
 // CHECK-NEXT:  LLVM_ABI std::pair<Clause, directive::VersionRange> getTdlClauseKindAndVersions(StringRef Str);
 // CHECK-EMPTY:
@@ -188,14 +188,14 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // CHECK-NEXT:    return getTdlClauseKindAndVersions(Str).first;
 // CHECK-NEXT:  }
 // CHECK-EMPTY:
-// CHECK-NEXT:  LLVM_ABI StringRef getTdlClauseName(Clause C, unsigned Ver = 0);
+// CHECK-NEXT:  LLVM_ABI StringRef getTdlClauseName(Clause C, unsigned V = unsigned(0));
 // CHECK-EMPTY:
-// CHECK-NEXT:  /// Return true if \p C is a valid clause for \p D in version \p Version.
-// CHECK-NEXT:  LLVM_ABI bool isAllowedClauseForDirective(Directive D, Clause C, unsigned Version);
+// CHECK-NEXT:  /// Return true if \p C is a valid clause for \p D in version \p V.
+// CHECK-NEXT:  LLVM_ABI bool isAllowedClauseForDirective(Directive D, Clause C, unsigned V);
 // CHECK-EMPTY:
 // CHECK-NEXT:  constexpr std::size_t getMaxLeafCount() { return 0; }
 // CHECK-NEXT:  LLVM_ABI bool isAllowedLoopModifier(Directive D, LoopModifier LM);
-// CHECK-NEXT:  LLVM_ABI StringRef getLoopModifierName(LoopModifier LM, unsigned Ver = 0);
+// CHECK-NEXT:  LLVM_ABI StringRef getLoopModifierName(LoopModifier LM, unsigned V = unsigned(0));
 // CHECK-EMPTY:
 // CHECK-NEXT:  } // namespace tdl
 // CHECK-EMPTY:
@@ -372,7 +372,7 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // IMPL-NEXT:     .Default({TDLD_dira, All});
 // IMPL-NEXT: }
 // IMPL-EMPTY:
-// IMPL-NEXT:  llvm::StringRef llvm::tdl::getTdlDirectiveName(llvm::tdl::Directive Kind, unsigned Version) {
+// IMPL-NEXT:  llvm::StringRef llvm::tdl::getTdlDirectiveName(llvm::tdl::Directive Kind, unsigned V) {
 // IMPL-NEXT:    switch (Kind) {
 // IMPL-NEXT:      case TDLD_dira:
 // IMPL-NEXT:        return "dira";
@@ -390,7 +390,7 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // IMPL-NEXT:     .Default({TDLC_clauseb, All});
 // IMPL-NEXT: }
 // IMPL-EMPTY:
-// IMPL-NEXT:  llvm::StringRef llvm::tdl::getTdlClauseName(llvm::tdl::Clause Kind, unsigned Version) {
+// IMPL-NEXT:  llvm::StringRef llvm::tdl::getTdlClauseName(llvm::tdl::Clause Kind, unsigned V) {
 // IMPL-NEXT:    switch (Kind) {
 // IMPL-NEXT:      case TDLC_clausea:
 // IMPL-NEXT:        return "clausea";
@@ -404,16 +404,16 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // IMPL-NEXT:    llvm_unreachable("Invalid Tdl Clause kind");
 // IMPL-NEXT:  }
 // IMPL-EMPTY:
-// IMPL-NEXT:  bool llvm::tdl::isAllowedClauseForDirective(llvm::tdl::Directive D, llvm::tdl::Clause C, unsigned Version) {
+// IMPL-NEXT:  bool llvm::tdl::isAllowedClauseForDirective(llvm::tdl::Directive D, llvm::tdl::Clause C, unsigned V) {
 // IMPL-NEXT:    assert(unsigned(D) <= Directive_enumSize);
 // IMPL-NEXT:    assert(unsigned(C) <= Clause_enumSize);
 // IMPL-NEXT:    switch (D) {
 // IMPL-NEXT:      case TDLD_dira:
 // IMPL-NEXT:        switch (C) {
 // IMPL-NEXT:          case TDLC_clausea:
-// IMPL-NEXT:            return 2 <= Version && 4 >= Version;
+// IMPL-NEXT:            return V >= 2 && V <= 4;
 // IMPL-NEXT:          case TDLC_clauseb:
-// IMPL-NEXT:            return 2 <= Version && 2147483647 >= Version;
+// IMPL-NEXT:            return V >= 2 && V <= 2147483647;
 // IMPL-NEXT:          default:
 // IMPL-NEXT:            return false;
 // IMPL-NEXT:        }
@@ -432,7 +432,7 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // IMPL-NEXT:    llvm_unreachable("Invalid Tdl Directive kind");
 // IMPL-NEXT:  }
 // IMPL-EMPTY:
-// IMPL-NEXT:  llvm::StringRef llvm::tdl::getLoopModifierName(llvm::tdl::LoopModifier Kind, unsigned Version) {
+// IMPL-NEXT:  llvm::StringRef llvm::tdl::getLoopModifierName(llvm::tdl::LoopModifier Kind, unsigned V) {
 // IMPL-NEXT:    switch (Kind) {
 // IMPL-NEXT:      case flattened:
 // IMPL-NEXT:        return "flattened";

--- a/llvm/unittests/Frontend/OpenMPDecompositionTest.cpp
+++ b/llvm/unittests/Frontend/OpenMPDecompositionTest.cpp
@@ -332,7 +332,7 @@ protected:
   void TearDown() override {}
 
   omp::Helper Helper;
-  uint32_t AnyVersion = 999;
+  llvm::omp::Version AnyVersion = llvm::omp::Version(999);
 };
 
 // PRIVATE

--- a/llvm/unittests/Frontend/OpenMPDirectiveNameParserTest.cpp
+++ b/llvm/unittests/Frontend/OpenMPDirectiveNameParserTest.cpp
@@ -98,7 +98,7 @@ INSTANTIATE_TEST_SUITE_P(DirectiveNameParserTest, Tokenize,
 
 // Test parsing of valid names.
 
-using ValueType = std::tuple<omp::Directive, unsigned>;
+using ValueType = std::tuple<omp::Directive, omp::Version>;
 
 class ParseValid : public testing::TestWithParam<ValueType> {};
 
@@ -126,8 +126,9 @@ TEST_P(ParseValid, T) {
 static std::string
 getParamName2(const testing::TestParamInfo<ParseValid::ParamType> &Info) {
   auto [DirId, Version] = Info.param;
-  std::string Name = omp::getOpenMPDirectiveName(DirId, Version).str() + "v" +
-                     std::to_string(Version);
+  std::string Name =
+      omp::getOpenMPDirectiveName(DirId, Version).str() + "v" +
+      std::to_string(static_cast<omp::Version::value_type>(Version));
   return prepareParamName(Name);
 }
 

--- a/llvm/unittests/Frontend/OpenMPDirectiveNameTest.cpp
+++ b/llvm/unittests/Frontend/OpenMPDirectiveNameTest.cpp
@@ -54,19 +54,19 @@ const DenseMap<Directive, StringRef> &Expected60() {
   return Names;
 }
 
-class VersionTest : public testing::TestWithParam<unsigned> {
+class VersionTest : public testing::TestWithParam<Version> {
 public:
   void SetUp() override {
-    Version = GetParam();
+    V = GetParam();
 
-    if (Version < 60)
+    if (V < 60)
       KindToName = &Expected52();
     else
       KindToName = &Expected60();
   }
 
   const DenseMap<Directive, StringRef> *KindToName;
-  unsigned Version;
+  Version V;
 };
 
 INSTANTIATE_TEST_SUITE_P(OpenMPDirectiveNames, VersionTest,
@@ -74,7 +74,7 @@ INSTANTIATE_TEST_SUITE_P(OpenMPDirectiveNames, VersionTest,
 
 TEST_P(VersionTest, DirectiveName) {
   for (auto [Kind, Name] : *KindToName)
-    ASSERT_EQ(Name, getOpenMPDirectiveName(Kind, Version));
+    ASSERT_EQ(Name, getOpenMPDirectiveName(Kind, V));
 }
 
 TEST(OpenMPDirectiveNames, DirectiveKind52) {

--- a/llvm/unittests/Frontend/OpenMPParsingTest.cpp
+++ b/llvm/unittests/Frontend/OpenMPParsingTest.cpp
@@ -45,13 +45,15 @@ TEST(OpenMPParsingTest, getOpenMPClauseName) {
 }
 
 TEST(OpenMPParsingTest, isAllowedClauseForDirective) {
-  EXPECT_TRUE(isAllowedClauseForDirective(OMPD_for, OMPC_schedule, 30));
-  EXPECT_FALSE(isAllowedClauseForDirective(OMPD_for, OMPC_num_teams, 30));
+  EXPECT_TRUE(
+      isAllowedClauseForDirective(OMPD_for, OMPC_schedule, Version(30)));
+  EXPECT_FALSE(
+      isAllowedClauseForDirective(OMPD_for, OMPC_num_teams, Version(30)));
 
-  EXPECT_FALSE(isAllowedClauseForDirective(OMPD_for, OMPC_order, 30));
-  EXPECT_FALSE(isAllowedClauseForDirective(OMPD_for, OMPC_order, 45));
-  EXPECT_TRUE(isAllowedClauseForDirective(OMPD_for, OMPC_order, 50));
-  EXPECT_TRUE(isAllowedClauseForDirective(OMPD_for, OMPC_order, 51));
+  EXPECT_FALSE(isAllowedClauseForDirective(OMPD_for, OMPC_order, Version(30)));
+  EXPECT_FALSE(isAllowedClauseForDirective(OMPD_for, OMPC_order, Version(45)));
+  EXPECT_TRUE(isAllowedClauseForDirective(OMPD_for, OMPC_order, Version(50)));
+  EXPECT_TRUE(isAllowedClauseForDirective(OMPD_for, OMPC_order, Version(51)));
 }
 
 TEST(OpenMPParsingTest, getOrderKind) {

--- a/llvm/utils/TableGen/Basic/DirectiveEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/DirectiveEmitter.cpp
@@ -37,6 +37,13 @@ enum class Frontend { LLVM, Flang, Clang };
 static void emitDirectivesConstexprImpl(const DirectiveLanguage &DirLang,
                                         raw_ostream &OS);
 
+static StringRef getVersionType(const DirectiveLanguage &DirLang) {
+  if (DirLang.getName() == "OpenMP") {
+    return "Version";
+  }
+  return "unsigned";
+}
+
 static StringRef getFESpelling(Frontend FE) {
   switch (FE) {
   case Frontend::LLVM:
@@ -324,6 +331,8 @@ static void emitDirectivesDecl(const RecordKeeper &Records, raw_ostream &OS) {
     emitDirectivesConstexprImpl(DirLang, OS);
 
     // Generic function signatures
+    StringRef VersionType = getVersionType(DirLang);
+
     OS << "\n";
     OS << "// Enumeration helper functions\n";
 
@@ -335,8 +344,8 @@ static void emitDirectivesDecl(const RecordKeeper &Records, raw_ostream &OS) {
     OS << "}\n";
     OS << "\n";
 
-    OS << "LLVM_ABI StringRef get" << Lang
-       << "DirectiveName(Directive D, unsigned Ver = 0);\n";
+    OS << "LLVM_ABI StringRef get" << Lang << "DirectiveName(Directive D, "
+       << VersionType << " V = " << VersionType << "(0));\n";
     OS << "\n";
 
     OS << "LLVM_ABI std::pair<Clause, directive::VersionRange> get" << Lang
@@ -348,21 +357,21 @@ static void emitDirectivesDecl(const RecordKeeper &Records, raw_ostream &OS) {
     OS << "}\n";
     OS << "\n";
 
-    OS << "LLVM_ABI StringRef get" << Lang
-       << "ClauseName(Clause C, unsigned Ver = 0);\n";
+    OS << "LLVM_ABI StringRef get" << Lang << "ClauseName(Clause C, "
+       << VersionType << " V = " << VersionType << "(0));\n";
     OS << "\n";
 
     OS << "/// Return true if \\p C is a valid clause for \\p D in version \\p "
-       << "Version.\n";
+       << "V.\n";
     OS << "LLVM_ABI bool isAllowedClauseForDirective(Directive D, "
-       << "Clause C, unsigned Version);\n";
+       << "Clause C, " << VersionType << " V);\n";
     OS << "\n";
     OS << "constexpr std::size_t getMaxLeafCount() { return "
        << getMaxLeafCount(DirLang) << "; }\n";
     OS << "LLVM_ABI bool isAllowedLoopModifier(Directive D, LoopModifier "
           "LM);\n";
-    OS << "LLVM_ABI StringRef getLoopModifierName(LoopModifier LM, unsigned "
-          "Ver = 0);\n";
+    OS << "LLVM_ABI StringRef getLoopModifierName(LoopModifier LM, "
+       << VersionType << " V = " << VersionType << "(0));\n";
     OS << EnumHelperFuncs;
   } // close DirLangNS
 
@@ -398,7 +407,7 @@ static void generateGetName(ArrayRef<const Record *> Records, raw_ostream &OS,
   std::string Qual = getQualifier(DirLang);
   OS << "\n";
   OS << "llvm::StringRef " << Qual << "get" << LangName << Enum << "Name("
-     << Qual << Enum << " Kind, unsigned Version) {\n";
+     << Qual << Enum << " Kind, " << getVersionType(DirLang) << " V) {\n";
   OS << "  switch (Kind) {\n";
   for (const Record *R : Records) {
     BaseRecord Rec(R);
@@ -420,7 +429,7 @@ static void generateGetName(ArrayRef<const Record *> Records, raw_ostream &OS,
       }
       OS << "      };\n";
       OS << "      return llvm::directive::FindName(" << SpellingsName
-         << ", Version);\n";
+         << ", static_cast<unsigned>(V));\n";
       OS << "    }\n";
     }
   }
@@ -555,8 +564,8 @@ static void generateCaseForVersionedClauses(ArrayRef<const Record *> VerClauses,
         getIdentifierName(VerClause.getClause().getRecord(), Prefix);
     if (Cases.insert(Name).second) {
       OS << "        case " << Name << ":\n";
-      OS << "          return " << VerClause.getMinVersion()
-         << " <= Version && " << VerClause.getMaxVersion() << " >= Version;\n";
+      OS << "          return V >= " << VerClause.getMinVersion()
+         << " && V <= " << VerClause.getMaxVersion() << ";\n";
     }
   }
 }
@@ -568,7 +577,8 @@ static void generateIsAllowedClause(const DirectiveLanguage &DirLang,
 
   OS << "\n";
   OS << "bool " << Qual << "isAllowedClauseForDirective(" << Qual
-     << "Directive D, " << Qual << "Clause C, unsigned Version) {\n";
+     << "Directive D, " << Qual << "Clause C, " << getVersionType(DirLang)
+     << " V) {\n";
   OS << "  assert(unsigned(D) <= Directive_enumSize);\n";
   OS << "  assert(unsigned(C) <= Clause_enumSize);\n";
 
@@ -904,7 +914,9 @@ static void generateGetDirectivePureSince(const DirectiveLanguage &DirLang,
   // Must match the sentinel in DirectiveBase.td and in
   // OmpStructureChecker::CheckDirectiveInPureProcedure.
   constexpr int NeverPure = 0x7FFFFFFF;
-  OS << "constexpr unsigned getDirectivePureSince(Directive Dir) {\n";
+  StringRef VersionType = getVersionType(DirLang);
+  OS << "constexpr " << VersionType
+     << " getDirectivePureSince(Directive Dir) {\n";
   OS << "  switch (Dir) {\n";
 
   StringRef Prefix = DirLang.getDirectivePrefix();
@@ -915,10 +927,10 @@ static void generateGetDirectivePureSince(const DirectiveLanguage &DirLang,
     if (PureSince == NeverPure)
       continue;
     OS << "  case " << getIdentifierName(R, Prefix) << ":\n";
-    OS << "    return " << PureSince << ";\n";
+    OS << "    return " << VersionType << "(" << PureSince << ");\n";
   }
   OS << "  default:\n";
-  OS << "    return 0x7FFFFFFF;\n";
+  OS << "    return " << VersionType << "(0x7FFFFFFF);\n";
   OS << "  } // switch (Dir)\n";
   OS << "}\n";
 }
@@ -1445,7 +1457,7 @@ void emitDirectivesBasicImpl(const DirectiveLanguage &DirLang,
   // StringRef get<enumClauseValue>Name(<enumClauseValue>) ; value -> string
   generateGetClauseVal(DirLang, OS);
 
-  // isAllowedClauseForDirective(Directive D, Clause C, unsigned Version)
+  // isAllowedClauseForDirective(Directive D, Clause C, Version V)
   generateIsAllowedClause(DirLang, OS);
 
   // isAllowedLoopModifier(Directive D, LoopModifier LM)

--- a/llvm/utils/TableGen/Basic/DirectiveEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/DirectiveEmitter.cpp
@@ -38,9 +38,8 @@ static void emitDirectivesConstexprImpl(const DirectiveLanguage &DirLang,
                                         raw_ostream &OS);
 
 static StringRef getVersionType(const DirectiveLanguage &DirLang) {
-  if (DirLang.getName() == "OpenMP") {
+  if (DirLang.getName() == "OpenMP")
     return "Version";
-  }
   return "unsigned";
 }
 
@@ -281,7 +280,8 @@ static void emitDirectivesDecl(const RecordKeeper &Records, raw_ostream &OS) {
   OS << "#include \"llvm/ADT/Sequence.h\"\n";
   OS << "#include \"llvm/ADT/STLExtras.h\"\n";
   OS << "#include \"llvm/ADT/StringRef.h\"\n";
-  OS << "#include \"llvm/Frontend/Directive/Spelling.h\"\n";
+  if (DirLang.getName() == "OpenMP")
+    OS << "#include \"llvm/Frontend/OpenMP/OMPVersion.h\"\n";
   OS << "#include \"llvm/Support/Compiler.h\"\n";
   OS << "#include <cstddef>\n"; // for size_t
   OS << "#include <utility>\n"; // for std::pair

--- a/llvm/utils/TableGen/Basic/DirectiveEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/DirectiveEmitter.cpp
@@ -280,6 +280,7 @@ static void emitDirectivesDecl(const RecordKeeper &Records, raw_ostream &OS) {
   OS << "#include \"llvm/ADT/Sequence.h\"\n";
   OS << "#include \"llvm/ADT/STLExtras.h\"\n";
   OS << "#include \"llvm/ADT/StringRef.h\"\n";
+  OS << "#include \"llvm/Frontend/Directive/Spelling.h\"\n";
   if (DirLang.getName() == "OpenMP")
     OS << "#include \"llvm/Frontend/OpenMP/OMPVersion.h\"\n";
   OS << "#include \"llvm/Support/Compiler.h\"\n";


### PR DESCRIPTION
It's unsigned now. Giving it a separate type would make the code clearer,
and it would make it easier to change the effective type if it's ever
needed.