### PR TITLE
[CodeGen] Migrate to FoldingSet's typed lookup/insert/erase. NFC

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/CSEInfo.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/CSEInfo.h
@@ -97,22 +97,23 @@ class LLVM_ABI GISelCSEInfo : public GISelChangeObserver {
   void invalidateUniqueMachineInstr(UniqueMachineInstr *UMI);
 
   UniqueMachineInstr *getNodeIfExists(FoldingSetNodeID &ID,
-                                      MachineBasicBlock *MBB, void *&InsertPos);
+                                      MachineBasicBlock *MBB,
+                                      FoldingSetInsertToken &Token);
 
   /// Allocate and construct a new UniqueMachineInstr for MI and return.
   UniqueMachineInstr *getUniqueInstrForMI(const MachineInstr *MI);
 
-  void insertNode(UniqueMachineInstr *UMI, void *InsertPos = nullptr);
+  void insertNode(UniqueMachineInstr *UMI, FoldingSetInsertToken Token = {});
 
   /// Get the MachineInstr(Unique) if it exists already in the CSEMap and the
   /// same MachineBasicBlock.
   MachineInstr *getMachineInstrIfExists(FoldingSetNodeID &ID,
                                         MachineBasicBlock *MBB,
-                                        void *&InsertPos);
+                                        FoldingSetInsertToken &Token);
 
   /// Use this method to allocate a new UniqueMachineInstr for MI and insert it
   /// into the CSEMap. MI should return true for shouldCSE(MI->getOpcode())
-  void insertInstr(MachineInstr *MI, void *InsertPos = nullptr);
+  void insertInstr(MachineInstr *MI, FoldingSetInsertToken Token = {});
 
   bool HandlingRecordedInstrs = false;
 

--- a/llvm/include/llvm/CodeGen/GlobalISel/CSEMIRBuilder.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/CSEMIRBuilder.h
@@ -55,7 +55,7 @@ class LLVM_ABI CSEMIRBuilder : public MachineIRBuilder {
   /// current insertion point and return it. If not found, return Null
   /// MachineInstrBuilder.
   MachineInstrBuilder getDominatingInstrForID(FoldingSetNodeID &ID,
-                                              void *&NodeInsertPos);
+                                              FoldingSetInsertToken &Token);
   /// Simple check if we can CSE (we have the CSEInfo) or if this Opcode is
   /// safe to CSE.
   bool canPerformCSEForOpc(unsigned Opc) const;
@@ -80,9 +80,9 @@ class LLVM_ABI CSEMIRBuilder : public MachineIRBuilder {
                          ArrayRef<SrcOp> SrcOps, std::optional<unsigned> Flags,
                          GISelInstProfileBuilder &B) const;
 
-  // Takes a MachineInstrBuilder and inserts it into the CSEMap using the
-  // NodeInsertPos.
-  MachineInstrBuilder memoizeMI(MachineInstrBuilder MIB, void *NodeInsertPos);
+  // Takes a MachineInstrBuilder and inserts it into the CSEMap using Token.
+  MachineInstrBuilder memoizeMI(MachineInstrBuilder MIB,
+                                FoldingSetInsertToken Token);
 
   // If we have can CSE an instruction, but still need to materialize to a VReg,
   // we emit a copy from the CSE'd inst to the VReg.

--- a/llvm/include/llvm/CodeGen/SelectionDAG.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAG.h
@@ -2744,11 +2744,12 @@ private:
   void InsertNode(SDNode *N);
   bool RemoveNodeFromCSEMaps(SDNode *N);
   void AddModifiedNodeToCSEMaps(SDNode *N);
-  SDNode *FindModifiedNodeSlot(SDNode *N, SDValue Op, void *&InsertPos);
+  SDNode *FindModifiedNodeSlot(SDNode *N, SDValue Op,
+                               FoldingSetInsertToken &InsertToken);
   SDNode *FindModifiedNodeSlot(SDNode *N, SDValue Op1, SDValue Op2,
-                               void *&InsertPos);
+                               FoldingSetInsertToken &InsertToken);
   SDNode *FindModifiedNodeSlot(SDNode *N, ArrayRef<SDValue> Ops,
-                               void *&InsertPos);
+                               FoldingSetInsertToken &InsertToken);
   SDNode *UpdateSDLocOnMergeSDNode(SDNode *N, const SDLoc &loc);
 
   void DeleteNodeNotInCSEMaps(SDNode *N);
@@ -2756,17 +2757,18 @@ private:
 
   void allnodes_clear();
 
-  /// Look up the node specified by ID in CSEMap.  If it exists, return it.  If
-  /// not, return the insertion token that will make insertion faster.  This
-  /// overload is for nodes other than Constant or ConstantFP, use the other one
-  /// for those.
-  SDNode *FindNodeOrInsertPos(const FoldingSetNodeID &ID, void *&InsertPos);
+  /// Look up the node specified by ID in CSEMap. If it exists, return it and
+  /// clear \p InsertToken; otherwise return null and set \p InsertToken for a
+  /// subsequent insert. This overload is for nodes other than Constant or
+  /// ConstantFP, use the other one for those.
+  SDNode *lookupNode(const FoldingSetNodeID &ID,
+                     FoldingSetInsertToken &InsertToken);
 
-  /// Look up the node specified by ID in CSEMap.  If it exists, return it.  If
-  /// not, return the insertion token that will make insertion faster.  Performs
-  /// additional processing for constant nodes.
-  SDNode *FindNodeOrInsertPos(const FoldingSetNodeID &ID, const SDLoc &DL,
-                              void *&InsertPos);
+  /// Look up the node specified by ID in CSEMap. If it exists, return it and
+  /// clear \p InsertToken; otherwise return null and set \p InsertToken for a
+  /// subsequent insert. Performs additional processing for constant nodes.
+  SDNode *lookupNode(const FoldingSetNodeID &ID, const SDLoc &DL,
+                     FoldingSetInsertToken &InsertToken);
 
   /// Maps to auto-CSE operations.
   std::vector<CondCodeSDNode*> CondCodeNodes;

--- a/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
@@ -443,9 +443,8 @@ void Dwarf5AccelTableWriter::populateAbbrevsMap() {
           Abbrev.addAttribute({dwarf::DW_IDX_parent, *MaybeParentForm});
         FoldingSetNodeID ID;
         Abbrev.Profile(ID);
-        void *InsertPos;
-        if (DebugNamesAbbrev *Existing =
-                AbbreviationsSet.FindNodeOrInsertPos(ID, InsertPos)) {
+        FoldingSetInsertToken Token;
+        if (DebugNamesAbbrev *Existing = AbbreviationsSet.lookup(ID, Token)) {
           Value->setAbbrevNumber(Existing->getNumber());
           continue;
         }
@@ -453,7 +452,7 @@ void Dwarf5AccelTableWriter::populateAbbrevsMap() {
             new (Alloc) DebugNamesAbbrev(std::move(Abbrev));
         AbbreviationsVector.push_back(NewAbbrev);
         NewAbbrev->setNumber(AbbreviationsVector.size());
-        AbbreviationsSet.InsertNode(NewAbbrev, InsertPos);
+        AbbreviationsSet.insert(NewAbbrev, Token);
         Value->setAbbrevNumber(NewAbbrev->getNumber());
       }
     }

--- a/llvm/lib/CodeGen/AsmPrinter/DIE.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DIE.cpp
@@ -139,9 +139,8 @@ DIEAbbrev &DIEAbbrevSet::uniqueAbbreviation(DIE &Die) {
   DIEAbbrev Abbrev = Die.generateAbbrev();
   Abbrev.Profile(ID);
 
-  void *InsertPos;
-  if (DIEAbbrev *Existing =
-          AbbreviationsSet.FindNodeOrInsertPos(ID, InsertPos)) {
+  FoldingSetInsertToken Token;
+  if (DIEAbbrev *Existing = AbbreviationsSet.lookup(ID, Token)) {
     Die.setAbbrevNumber(Existing->getNumber());
     return *Existing;
   }
@@ -153,7 +152,7 @@ DIEAbbrev &DIEAbbrevSet::uniqueAbbreviation(DIE &Die) {
   Die.setAbbrevNumber(Abbreviations.size());
 
   // Store it for lookup.
-  AbbreviationsSet.InsertNode(New, InsertPos);
+  AbbreviationsSet.insert(New, Token);
   return *New;
 }
 

--- a/llvm/lib/CodeGen/GlobalISel/CSEInfo.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CSEInfo.cpp
@@ -111,16 +111,16 @@ bool GISelCSEInfo::isUniqueMachineInstValid(
 }
 
 void GISelCSEInfo::invalidateUniqueMachineInstr(UniqueMachineInstr *UMI) {
-  bool Removed = CSEMap.RemoveNode(UMI);
+  bool Removed = CSEMap.erase(UMI);
   (void)Removed;
   assert(Removed && "Invalidation called on invalid UMI");
   // FIXME: Should UMI be deallocated/destroyed?
 }
 
-UniqueMachineInstr *GISelCSEInfo::getNodeIfExists(FoldingSetNodeID &ID,
-                                                  MachineBasicBlock *MBB,
-                                                  void *&InsertPos) {
-  auto *Node = CSEMap.FindNodeOrInsertPos(ID, InsertPos);
+UniqueMachineInstr *
+GISelCSEInfo::getNodeIfExists(FoldingSetNodeID &ID, MachineBasicBlock *MBB,
+                              FoldingSetInsertToken &Token) {
+  auto *Node = CSEMap.lookup(ID, Token);
   if (Node) {
     if (!isUniqueMachineInstValid(*Node)) {
       invalidateUniqueMachineInstr(Node);
@@ -133,14 +133,15 @@ UniqueMachineInstr *GISelCSEInfo::getNodeIfExists(FoldingSetNodeID &ID,
   return Node;
 }
 
-void GISelCSEInfo::insertNode(UniqueMachineInstr *UMI, void *InsertPos) {
+void GISelCSEInfo::insertNode(UniqueMachineInstr *UMI,
+                              FoldingSetInsertToken Token) {
   handleRecordedInsts();
   assert(UMI);
   UniqueMachineInstr *MaybeNewNode = UMI;
-  if (InsertPos)
-    CSEMap.InsertNode(UMI, InsertPos);
+  if (Token)
+    CSEMap.insert(UMI, Token);
   else
-    MaybeNewNode = CSEMap.GetOrInsertNode(UMI);
+    MaybeNewNode = CSEMap.getOrInsert(UMI);
   if (MaybeNewNode != UMI) {
     // A similar node exists in the folding set. Let's ignore this one.
     return;
@@ -156,19 +157,20 @@ UniqueMachineInstr *GISelCSEInfo::getUniqueInstrForMI(const MachineInstr *MI) {
   return Node;
 }
 
-void GISelCSEInfo::insertInstr(MachineInstr *MI, void *InsertPos) {
+void GISelCSEInfo::insertInstr(MachineInstr *MI, FoldingSetInsertToken Token) {
   assert(MI);
   // If it exists in temporary insts, remove it.
   TemporaryInsts.remove(MI);
   auto *Node = getUniqueInstrForMI(MI);
-  insertNode(Node, InsertPos);
+  insertNode(Node, Token);
 }
 
-MachineInstr *GISelCSEInfo::getMachineInstrIfExists(FoldingSetNodeID &ID,
-                                                    MachineBasicBlock *MBB,
-                                                    void *&InsertPos) {
+MachineInstr *
+GISelCSEInfo::getMachineInstrIfExists(FoldingSetNodeID &ID,
+                                      MachineBasicBlock *MBB,
+                                      FoldingSetInsertToken &Token) {
   handleRecordedInsts();
-  if (auto *Inst = getNodeIfExists(ID, MBB, InsertPos)) {
+  if (auto *Inst = getNodeIfExists(ID, MBB, Token)) {
     LLVM_DEBUG(dbgs() << "CSEInfo::Found Instr " << *Inst->MI);
     return const_cast<MachineInstr *>(Inst->MI);
   }
@@ -203,7 +205,7 @@ void GISelCSEInfo::handleRecordedInst(MachineInstr *MI) {
     /// We'll reuse the same UniqueMachineInstr to avoid the new
     /// allocation.
     *UMI = UniqueMachineInstr(MI);
-    insertNode(UMI, nullptr);
+    insertNode(UMI);
   } else {
     /// This is a new instruction. Allocate a new UniqueMachineInstr and
     /// Insert.
@@ -287,9 +289,8 @@ Error GISelCSEInfo::verify() {
   for (auto &It : InstrMapping) {
     FoldingSetNodeID TmpID;
     GISelInstProfileBuilder(TmpID, *MRI).addNodeID(It.first);
-    void *InsertPos;
-    UniqueMachineInstr *FoundNode =
-        CSEMap.FindNodeOrInsertPos(TmpID, InsertPos);
+    FoldingSetInsertToken Token;
+    UniqueMachineInstr *FoundNode = CSEMap.lookup(TmpID, Token);
     if (FoundNode != It.second)
       return createStringError(std::errc::not_supported,
                                "CSEMap mismatch, InstrMapping has MIs without "

--- a/llvm/lib/CodeGen/GlobalISel/CSEMIRBuilder.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CSEMIRBuilder.cpp
@@ -35,12 +35,11 @@ bool CSEMIRBuilder::dominates(MachineBasicBlock::const_iterator A,
 
 MachineInstrBuilder
 CSEMIRBuilder::getDominatingInstrForID(FoldingSetNodeID &ID,
-                                       void *&NodeInsertPos) {
+                                       FoldingSetInsertToken &Token) {
   GISelCSEInfo *CSEInfo = getCSEInfo();
   assert(CSEInfo && "Can't get here without setting CSEInfo");
   MachineBasicBlock *CurMBB = &getMBB();
-  MachineInstr *MI =
-      CSEInfo->getMachineInstrIfExists(ID, CurMBB, NodeInsertPos);
+  MachineInstr *MI = CSEInfo->getMachineInstrIfExists(ID, CurMBB, Token);
   if (MI) {
     CSEInfo->countOpcodeHit(MI->getOpcode());
     auto CurrPos = getInsertPt();
@@ -130,11 +129,11 @@ void CSEMIRBuilder::profileEverything(unsigned Opc, ArrayRef<DstOp> DstOps,
 }
 
 MachineInstrBuilder CSEMIRBuilder::memoizeMI(MachineInstrBuilder MIB,
-                                             void *NodeInsertPos) {
+                                             FoldingSetInsertToken Token) {
   assert(canPerformCSEForOpc(MIB->getOpcode()) &&
          "Attempting to CSE illegal op");
   MachineInstr *MIBInstr = MIB;
-  getCSEInfo()->insertInstr(MIBInstr, NodeInsertPos);
+  getCSEInfo()->insertInstr(MIBInstr, Token);
   return MIB;
 }
 
@@ -335,9 +334,9 @@ MachineInstrBuilder CSEMIRBuilder::buildInstr(unsigned Opc,
   }
   FoldingSetNodeID ID;
   GISelInstProfileBuilder ProfBuilder(ID, *getMRI());
-  void *InsertPos = nullptr;
+  FoldingSetInsertToken Token;
   profileEverything(Opc, DstOps, SrcOps, Flag, ProfBuilder);
-  MachineInstrBuilder MIB = getDominatingInstrForID(ID, InsertPos);
+  MachineInstrBuilder MIB = getDominatingInstrForID(ID, Token);
   if (MIB) {
     // Handle generating copies here.
     return generateCopiesIfRequired(DstOps, MIB);
@@ -345,7 +344,7 @@ MachineInstrBuilder CSEMIRBuilder::buildInstr(unsigned Opc,
   // This instruction does not exist in the CSEInfo. Build it and CSE it.
   MachineInstrBuilder NewMIB =
       MachineIRBuilder::buildInstr(Opc, DstOps, SrcOps, Flag);
-  return memoizeMI(NewMIB, InsertPos);
+  return memoizeMI(NewMIB, Token);
 }
 
 MachineInstrBuilder CSEMIRBuilder::buildConstant(const DstOp &Res,
@@ -363,18 +362,18 @@ MachineInstrBuilder CSEMIRBuilder::buildConstant(const DstOp &Res,
 
   FoldingSetNodeID ID;
   GISelInstProfileBuilder ProfBuilder(ID, *getMRI());
-  void *InsertPos = nullptr;
+  FoldingSetInsertToken Token;
   profileMBBOpcode(ProfBuilder, Opc);
   profileDstOp(Res, ProfBuilder);
   ProfBuilder.addNodeIDMachineOperand(MachineOperand::CreateCImm(&Val));
-  MachineInstrBuilder MIB = getDominatingInstrForID(ID, InsertPos);
+  MachineInstrBuilder MIB = getDominatingInstrForID(ID, Token);
   if (MIB) {
     // Handle generating copies here.
     return generateCopiesIfRequired({Res}, MIB);
   }
 
   MachineInstrBuilder NewMIB = MachineIRBuilder::buildConstant(Res, Val);
-  return memoizeMI(NewMIB, InsertPos);
+  return memoizeMI(NewMIB, Token);
 }
 
 MachineInstrBuilder CSEMIRBuilder::buildFConstant(const DstOp &Res,
@@ -392,15 +391,15 @@ MachineInstrBuilder CSEMIRBuilder::buildFConstant(const DstOp &Res,
 
   FoldingSetNodeID ID;
   GISelInstProfileBuilder ProfBuilder(ID, *getMRI());
-  void *InsertPos = nullptr;
+  FoldingSetInsertToken Token;
   profileMBBOpcode(ProfBuilder, Opc);
   profileDstOp(Res, ProfBuilder);
   ProfBuilder.addNodeIDMachineOperand(MachineOperand::CreateFPImm(&Val));
-  MachineInstrBuilder MIB = getDominatingInstrForID(ID, InsertPos);
+  MachineInstrBuilder MIB = getDominatingInstrForID(ID, Token);
   if (MIB) {
     // Handle generating copies here.
     return generateCopiesIfRequired({Res}, MIB);
   }
   MachineInstrBuilder NewMIB = MachineIRBuilder::buildFConstant(Res, Val);
-  return memoizeMI(NewMIB, InsertPos);
+  return memoizeMI(NewMIB, Token);
 }

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -1317,7 +1317,7 @@ bool SelectionDAG::RemoveNodeFromCSEMaps(SDNode *N) {
     // Remove it from the CSE Map.
     assert(N->getOpcode() != ISD::DELETED_NODE && "DELETED_NODE in CSEMap!");
     assert(N->getOpcode() != ISD::EntryToken && "EntryToken in CSEMap!");
-    Erased = CSEMap.RemoveNode(N);
+    Erased = CSEMap.erase(N);
     break;
   }
 #ifndef NDEBUG
@@ -1343,7 +1343,7 @@ SelectionDAG::AddModifiedNodeToCSEMaps(SDNode *N) {
   // For node types that aren't CSE'd, just act as if no identical node
   // already exists.
   if (!doNotCSE(N)) {
-    SDNode *Existing = CSEMap.GetOrInsertNode(N);
+    SDNode *Existing = CSEMap.getOrInsert(N);
     if (Existing != N) {
       // If there was already an existing matching node, use ReplaceAllUsesWith
       // to replace the dead one with the existing one.  This can cause
@@ -1377,7 +1377,7 @@ SelectionDAG::AddModifiedNodeToCSEMaps(SDNode *N) {
 /// return null, otherwise return a pointer to the slot it would take.  If a
 /// node already exists with these operands, the slot will be non-null.
 SDNode *SelectionDAG::FindModifiedNodeSlot(SDNode *N, SDValue Op,
-                                           void *&InsertPos) {
+                                           FoldingSetInsertToken &InsertToken) {
   if (doNotCSE(N))
     return nullptr;
 
@@ -1385,7 +1385,7 @@ SDNode *SelectionDAG::FindModifiedNodeSlot(SDNode *N, SDValue Op,
   FoldingSetNodeID ID;
   AddNodeIDNode(ID, N->getOpcode(), N->getVTList(), Ops);
   AddNodeIDCustom(ID, N);
-  SDNode *Node = FindNodeOrInsertPos(ID, SDLoc(N), InsertPos);
+  SDNode *Node = lookupNode(ID, SDLoc(N), InsertToken);
   if (Node)
     Node->intersectFlagsWith(N->getFlags());
   return Node;
@@ -1395,9 +1395,8 @@ SDNode *SelectionDAG::FindModifiedNodeSlot(SDNode *N, SDValue Op,
 /// were replaced with those specified.  If this node is never memoized,
 /// return null, otherwise return a pointer to the slot it would take.  If a
 /// node already exists with these operands, the slot will be non-null.
-SDNode *SelectionDAG::FindModifiedNodeSlot(SDNode *N,
-                                           SDValue Op1, SDValue Op2,
-                                           void *&InsertPos) {
+SDNode *SelectionDAG::FindModifiedNodeSlot(SDNode *N, SDValue Op1, SDValue Op2,
+                                           FoldingSetInsertToken &InsertToken) {
   if (doNotCSE(N))
     return nullptr;
 
@@ -1405,7 +1404,7 @@ SDNode *SelectionDAG::FindModifiedNodeSlot(SDNode *N,
   FoldingSetNodeID ID;
   AddNodeIDNode(ID, N->getOpcode(), N->getVTList(), Ops);
   AddNodeIDCustom(ID, N);
-  SDNode *Node = FindNodeOrInsertPos(ID, SDLoc(N), InsertPos);
+  SDNode *Node = lookupNode(ID, SDLoc(N), InsertToken);
   if (Node)
     Node->intersectFlagsWith(N->getFlags());
   return Node;
@@ -1416,14 +1415,14 @@ SDNode *SelectionDAG::FindModifiedNodeSlot(SDNode *N,
 /// return null, otherwise return a pointer to the slot it would take.  If a
 /// node already exists with these operands, the slot will be non-null.
 SDNode *SelectionDAG::FindModifiedNodeSlot(SDNode *N, ArrayRef<SDValue> Ops,
-                                           void *&InsertPos) {
+                                           FoldingSetInsertToken &InsertToken) {
   if (doNotCSE(N))
     return nullptr;
 
   FoldingSetNodeID ID;
   AddNodeIDNode(ID, N->getOpcode(), N->getVTList(), Ops);
   AddNodeIDCustom(ID, N);
-  SDNode *Node = FindNodeOrInsertPos(ID, SDLoc(N), InsertPos);
+  SDNode *Node = lookupNode(ID, SDLoc(N), InsertToken);
   if (Node)
     Node->intersectFlagsWith(N->getFlags());
   return Node;
@@ -1488,9 +1487,9 @@ void SelectionDAG::allnodes_clear() {
 #endif
 }
 
-SDNode *SelectionDAG::FindNodeOrInsertPos(const FoldingSetNodeID &ID,
-                                          void *&InsertPos) {
-  SDNode *N = CSEMap.FindNodeOrInsertPos(ID, InsertPos);
+SDNode *SelectionDAG::lookupNode(const FoldingSetNodeID &ID,
+                                 FoldingSetInsertToken &InsertToken) {
+  SDNode *N = CSEMap.lookup(ID, InsertToken);
   if (N) {
     switch (N->getOpcode()) {
     default: break;
@@ -1503,9 +1502,9 @@ SDNode *SelectionDAG::FindNodeOrInsertPos(const FoldingSetNodeID &ID,
   return N;
 }
 
-SDNode *SelectionDAG::FindNodeOrInsertPos(const FoldingSetNodeID &ID,
-                                          const SDLoc &DL, void *&InsertPos) {
-  SDNode *N = CSEMap.FindNodeOrInsertPos(ID, InsertPos);
+SDNode *SelectionDAG::lookupNode(const FoldingSetNodeID &ID, const SDLoc &DL,
+                                 FoldingSetInsertToken &InsertToken) {
+  SDNode *N = CSEMap.lookup(ID, InsertToken);
   if (N) {
     switch (N->getOpcode()) {
     case ISD::Constant:
@@ -1815,9 +1814,9 @@ SDValue SelectionDAG::getConstant(const ConstantInt &Val, const SDLoc &DL,
   AddNodeIDNode(ID, Opc, VTs, {});
   ID.AddPointer(Elt);
   ID.AddBoolean(isO);
-  void *IP = nullptr;
+  FoldingSetInsertToken InsertToken;
   SDNode *N = nullptr;
-  if ((N = FindNodeOrInsertPos(ID, DL, IP)))
+  if ((N = lookupNode(ID, DL, InsertToken)))
     if (!VT.isVector())
       return SDValue(N, 0);
 
@@ -1825,7 +1824,7 @@ SDValue SelectionDAG::getConstant(const ConstantInt &Val, const SDLoc &DL,
     N = newSDNode<ConstantSDNode>(isT, isO, Elt, VTs);
     if (!isT)
       N->setDebugLoc(DL.getDebugLoc());
-    CSEMap.InsertNode(N, IP);
+    CSEMap.insert(N, InsertToken);
     InsertNode(N);
     NewSDValueDbgMsg(SDValue(N, 0), "Creating constant: ", this);
   }
@@ -1896,15 +1895,15 @@ SDValue SelectionDAG::getConstantFP(const ConstantFP &V, const SDLoc &DL,
   FoldingSetNodeID ID;
   AddNodeIDNode(ID, Opc, VTs, {});
   ID.AddPointer(Elt);
-  void *IP = nullptr;
+  FoldingSetInsertToken InsertToken;
   SDNode *N = nullptr;
-  if ((N = FindNodeOrInsertPos(ID, DL, IP)))
+  if ((N = lookupNode(ID, DL, InsertToken)))
     if (!VT.isVector())
       return SDValue(N, 0);
 
   if (!N) {
     N = newSDNode<ConstantFPSDNode>(isTarget, Elt, VTs);
-    CSEMap.InsertNode(N, IP);
+    CSEMap.insert(N, InsertToken);
     InsertNode(N);
   }
 
@@ -1956,14 +1955,14 @@ SDValue SelectionDAG::getGlobalAddress(const GlobalValue *GV, const SDLoc &DL,
   ID.AddPointer(GV);
   ID.AddInteger(Offset);
   ID.AddInteger(TargetFlags);
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, DL, InsertToken))
     return SDValue(E, 0);
 
   auto *N = newSDNode<GlobalAddressSDNode>(
       Opc, DL.getIROrder(), DL.getDebugLoc(), GV, VTs, Offset, TargetFlags);
-  CSEMap.InsertNode(N, IP);
-    InsertNode(N);
+  CSEMap.insert(N, InsertToken);
+  InsertNode(N);
   return SDValue(N, 0);
 }
 
@@ -1972,12 +1971,12 @@ SDValue SelectionDAG::getDeactivationSymbol(const GlobalValue *GV) {
   FoldingSetNodeID ID;
   AddNodeIDNode(ID, ISD::DEACTIVATION_SYMBOL, VTs, {});
   ID.AddPointer(GV);
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, SDLoc(), IP))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, SDLoc(), InsertToken))
     return SDValue(E, 0);
 
   auto *N = newSDNode<DeactivationSymbolSDNode>(GV, VTs);
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   return SDValue(N, 0);
 }
@@ -1988,12 +1987,12 @@ SDValue SelectionDAG::getFrameIndex(int FI, EVT VT, bool isTarget) {
   FoldingSetNodeID ID;
   AddNodeIDNode(ID, Opc, VTs, {});
   ID.AddInteger(FI);
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, IP))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, InsertToken))
     return SDValue(E, 0);
 
   auto *N = newSDNode<FrameIndexSDNode>(FI, VTs, isTarget);
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   return SDValue(N, 0);
 }
@@ -2008,12 +2007,12 @@ SDValue SelectionDAG::getJumpTable(int JTI, EVT VT, bool isTarget,
   AddNodeIDNode(ID, Opc, VTs, {});
   ID.AddInteger(JTI);
   ID.AddInteger(TargetFlags);
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, IP))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, InsertToken))
     return SDValue(E, 0);
 
   auto *N = newSDNode<JumpTableSDNode>(JTI, VTs, isTarget, TargetFlags);
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   return SDValue(N, 0);
 }
@@ -2042,13 +2041,13 @@ SDValue SelectionDAG::getConstantPool(const Constant *C, EVT VT,
   ID.AddInteger(Offset);
   ID.AddPointer(C);
   ID.AddInteger(TargetFlags);
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, IP))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, InsertToken))
     return SDValue(E, 0);
 
   auto *N = newSDNode<ConstantPoolSDNode>(isTarget, C, VTs, Offset, *Alignment,
                                           TargetFlags);
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V = SDValue(N, 0);
   NewSDValueDbgMsg(V, "Creating new constant pool: ", this);
@@ -2070,13 +2069,13 @@ SDValue SelectionDAG::getConstantPool(MachineConstantPoolValue *C, EVT VT,
   ID.AddInteger(Offset);
   C->addSelectionDAGCSEId(ID);
   ID.AddInteger(TargetFlags);
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, IP))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, InsertToken))
     return SDValue(E, 0);
 
   auto *N = newSDNode<ConstantPoolSDNode>(isTarget, C, VTs, Offset, *Alignment,
                                           TargetFlags);
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   return SDValue(N, 0);
 }
@@ -2085,12 +2084,12 @@ SDValue SelectionDAG::getBasicBlock(MachineBasicBlock *MBB) {
   FoldingSetNodeID ID;
   AddNodeIDNode(ID, ISD::BasicBlock, getVTList(MVT::Other), {});
   ID.AddPointer(MBB);
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, IP))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, InsertToken))
     return SDValue(E, 0);
 
   auto *N = newSDNode<BasicBlockSDNode>(MBB);
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   return SDValue(N, 0);
 }
@@ -2390,8 +2389,8 @@ SDValue SelectionDAG::getVectorShuffle(EVT VT, const SDLoc &dl, SDValue N1,
   for (int i = 0; i != NElts; ++i)
     ID.AddInteger(MaskVec[i]);
 
-  void* IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, dl, InsertToken))
     return SDValue(E, 0);
 
   // Allocate the mask array for the node out of the BumpPtrAllocator, since
@@ -2404,7 +2403,7 @@ SDValue SelectionDAG::getVectorShuffle(EVT VT, const SDLoc &dl, SDValue N1,
                                            dl.getDebugLoc(), MaskAlloc);
   createOperands(N, Ops);
 
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V = SDValue(N, 0);
   NewSDValueDbgMsg(V, "Creating new node: ", this);
@@ -2426,13 +2425,13 @@ SDValue SelectionDAG::getRegister(Register Reg, EVT VT) {
   FoldingSetNodeID ID;
   AddNodeIDNode(ID, ISD::Register, VTs, {});
   ID.AddInteger(Reg.id());
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, IP))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, InsertToken))
     return SDValue(E, 0);
 
   auto *N = newSDNode<RegisterSDNode>(Reg, VTs);
   N->SDNodeBits.IsDivergent = TLI->isSDNodeSourceOfDivergence(N, FLI, UA);
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   return SDValue(N, 0);
 }
@@ -2441,12 +2440,12 @@ SDValue SelectionDAG::getRegisterMask(const uint32_t *RegMask) {
   FoldingSetNodeID ID;
   AddNodeIDNode(ID, ISD::RegisterMask, getVTList(MVT::Untyped), {});
   ID.AddPointer(RegMask);
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, IP))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, InsertToken))
     return SDValue(E, 0);
 
   auto *N = newSDNode<RegisterMaskSDNode>(RegMask);
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   return SDValue(N, 0);
 }
@@ -2462,15 +2461,15 @@ SDValue SelectionDAG::getLabelNode(unsigned Opcode, const SDLoc &dl,
   SDValue Ops[] = { Root };
   AddNodeIDNode(ID, Opcode, getVTList(MVT::Other), Ops);
   ID.AddPointer(Label);
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, IP))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, InsertToken))
     return SDValue(E, 0);
 
   auto *N =
       newSDNode<LabelSDNode>(Opcode, dl.getIROrder(), dl.getDebugLoc(), Label);
   createOperands(N, Ops);
 
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   return SDValue(N, 0);
 }
@@ -2486,12 +2485,12 @@ SDValue SelectionDAG::getBlockAddress(const BlockAddress *BA, EVT VT,
   ID.AddPointer(BA);
   ID.AddInteger(Offset);
   ID.AddInteger(TargetFlags);
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, IP))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, InsertToken))
     return SDValue(E, 0);
 
   auto *N = newSDNode<BlockAddressSDNode>(Opc, VTs, BA, Offset, TargetFlags);
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   return SDValue(N, 0);
 }
@@ -2501,12 +2500,12 @@ SDValue SelectionDAG::getSrcValue(const Value *V) {
   AddNodeIDNode(ID, ISD::SRCVALUE, getVTList(MVT::Other), {});
   ID.AddPointer(V);
 
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, IP))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, InsertToken))
     return SDValue(E, 0);
 
   auto *N = newSDNode<SrcValueSDNode>(V);
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   return SDValue(N, 0);
 }
@@ -2516,12 +2515,12 @@ SDValue SelectionDAG::getMDNode(const MDNode *MD) {
   AddNodeIDNode(ID, ISD::MDNODE_SDNODE, getVTList(MVT::Other), {});
   ID.AddPointer(MD);
 
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, IP))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, InsertToken))
     return SDValue(E, 0);
 
   auto *N = newSDNode<MDNodeSDNode>(MD);
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   return SDValue(N, 0);
 }
@@ -2542,15 +2541,15 @@ SDValue SelectionDAG::getAddrSpaceCast(const SDLoc &dl, EVT VT, SDValue Ptr,
   ID.AddInteger(SrcAS);
   ID.AddInteger(DestAS);
 
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, dl, InsertToken))
     return SDValue(E, 0);
 
   auto *N = newSDNode<AddrSpaceCastSDNode>(dl.getIROrder(), dl.getDebugLoc(),
                                            VTs, SrcAS, DestAS);
   createOperands(N, Ops);
 
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   return SDValue(N, 0);
 }
@@ -7036,12 +7035,12 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT) {
   SDVTList VTs = getVTList(VT);
   FoldingSetNodeID ID;
   AddNodeIDNode(ID, Opcode, VTs, {});
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, DL, InsertToken))
     return SDValue(E, 0);
 
   auto *N = newSDNode<SDNode>(Opcode, DL.getIROrder(), DL.getDebugLoc(), VTs);
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
 
   InsertNode(N);
   SDValue V = SDValue(N, 0);
@@ -7433,8 +7432,8 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
   if (VT != MVT::Glue) { // Don't CSE glue producing nodes
     FoldingSetNodeID ID;
     AddNodeIDNode(ID, Opcode, VTs, Ops);
-    void *IP = nullptr;
-    if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP)) {
+    FoldingSetInsertToken InsertToken;
+    if (SDNode *E = lookupNode(ID, DL, InsertToken)) {
       E->intersectFlagsWith(Flags);
       return SDValue(E, 0);
     }
@@ -7442,7 +7441,7 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
     N = newSDNode<SDNode>(Opcode, DL.getIROrder(), DL.getDebugLoc(), VTs);
     N->setFlags(Flags);
     createOperands(N, Ops);
-    CSEMap.InsertNode(N, IP);
+    CSEMap.insert(N, InsertToken);
   } else {
     N = newSDNode<SDNode>(Opcode, DL.getIROrder(), DL.getDebugLoc(), VTs);
     createOperands(N, Ops);
@@ -8359,15 +8358,15 @@ SDValue SelectionDAG::getAssertAlign(const SDLoc &DL, SDValue Val, Align A) {
   AddNodeIDNode(ID, ISD::AssertAlign, VTs, {Val});
   ID.AddInteger(A.value());
 
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, DL, InsertToken))
     return SDValue(E, 0);
 
   auto *N =
       newSDNode<AssertAlignSDNode>(DL.getIROrder(), DL.getDebugLoc(), VTs, A);
   createOperands(N, {Val});
 
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
 
   SDValue V(N, 0);
@@ -8960,8 +8959,8 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
   if (VT != MVT::Glue) {
     FoldingSetNodeID ID;
     AddNodeIDNode(ID, Opcode, VTs, Ops);
-    void *IP = nullptr;
-    if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP)) {
+    FoldingSetInsertToken InsertToken;
+    if (SDNode *E = lookupNode(ID, DL, InsertToken)) {
       E->intersectFlagsWith(Flags);
       return SDValue(E, 0);
     }
@@ -8969,7 +8968,7 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
     N = newSDNode<SDNode>(Opcode, DL.getIROrder(), DL.getDebugLoc(), VTs);
     N->setFlags(Flags);
     createOperands(N, Ops);
-    CSEMap.InsertNode(N, IP);
+    CSEMap.insert(N, InsertToken);
   } else {
     N = newSDNode<SDNode>(Opcode, DL.getIROrder(), DL.getDebugLoc(), VTs);
     createOperands(N, Ops);
@@ -9224,8 +9223,8 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
   if (VT != MVT::Glue) {
     FoldingSetNodeID ID;
     AddNodeIDNode(ID, Opcode, VTs, Ops);
-    void *IP = nullptr;
-    if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP)) {
+    FoldingSetInsertToken InsertToken;
+    if (SDNode *E = lookupNode(ID, DL, InsertToken)) {
       E->intersectFlagsWith(Flags);
       return SDValue(E, 0);
     }
@@ -9233,7 +9232,7 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
     N = newSDNode<SDNode>(Opcode, DL.getIROrder(), DL.getDebugLoc(), VTs);
     N->setFlags(Flags);
     createOperands(N, Ops);
-    CSEMap.InsertNode(N, IP);
+    CSEMap.insert(N, InsertToken);
   } else {
     N = newSDNode<SDNode>(Opcode, DL.getIROrder(), DL.getDebugLoc(), VTs);
     createOperands(N, Ops);
@@ -10469,8 +10468,8 @@ SDValue SelectionDAG::getAtomic(unsigned Opcode, const SDLoc &dl, EVT MemVT,
       dl.getIROrder(), Opcode, VTList, MemVT, MMO, ExtType));
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
-  void* IP = nullptr;
-  if (auto *E = cast_or_null<AtomicSDNode>(FindNodeOrInsertPos(ID, dl, IP))) {
+  FoldingSetInsertToken InsertToken;
+  if (auto *E = cast_or_null<AtomicSDNode>(lookupNode(ID, dl, InsertToken))) {
     E->refineAlignment(MMO);
     E->refineMMOMetadata(MMO);
     return SDValue(E, 0);
@@ -10480,7 +10479,7 @@ SDValue SelectionDAG::getAtomic(unsigned Opcode, const SDLoc &dl, EVT MemVT,
                                     VTList, MemVT, MMO, ExtType);
   createOperands(N, Ops);
 
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V(N, 0);
   NewSDValueDbgMsg(V, "Creating new node: ", this);
@@ -10618,8 +10617,8 @@ SDValue SelectionDAG::getMemIntrinsicNode(unsigned Opcode, const SDLoc &dl,
       ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
       ID.AddInteger(MMO->getFlags());
     }
-    void *IP = nullptr;
-    if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP)) {
+    FoldingSetInsertToken InsertToken;
+    if (SDNode *E = lookupNode(ID, dl, InsertToken)) {
       cast<MemIntrinsicSDNode>(E)->refineAlignment(MMOs);
       return SDValue(E, 0);
     }
@@ -10627,7 +10626,7 @@ SDValue SelectionDAG::getMemIntrinsicNode(unsigned Opcode, const SDLoc &dl,
     N = newSDNode<MemIntrinsicSDNode>(Opcode, dl.getIROrder(), dl.getDebugLoc(),
                                       VTList, MemVT, MemRefs);
     createOperands(N, Ops);
-    CSEMap.InsertNode(N, IP);
+    CSEMap.insert(N, InsertToken);
   } else {
     N = newSDNode<MemIntrinsicSDNode>(Opcode, dl.getIROrder(), dl.getDebugLoc(),
                                       VTList, MemVT, MemRefs);
@@ -10652,14 +10651,14 @@ SDValue SelectionDAG::getLifetimeNode(bool IsStart, const SDLoc &dl,
   FoldingSetNodeID ID;
   AddNodeIDNode(ID, Opcode, VTs, Ops);
   ID.AddInteger(FrameIndex);
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, dl, InsertToken))
     return SDValue(E, 0);
 
   LifetimeSDNode *N =
       newSDNode<LifetimeSDNode>(Opcode, dl.getIROrder(), dl.getDebugLoc(), VTs);
   createOperands(N, Ops);
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V(N, 0);
   NewSDValueDbgMsg(V, "Creating new node: ", this);
@@ -10676,14 +10675,14 @@ SDValue SelectionDAG::getPseudoProbeNode(const SDLoc &Dl, SDValue Chain,
   AddNodeIDNode(ID, Opcode, VTs, Ops);
   ID.AddInteger(Guid);
   ID.AddInteger(Index);
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, Dl, IP))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, Dl, InsertToken))
     return SDValue(E, 0);
 
   auto *N = newSDNode<PseudoProbeSDNode>(
       Opcode, Dl.getIROrder(), Dl.getDebugLoc(), VTs, Guid, Index, Attr);
   createOperands(N, Ops);
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V(N, 0);
   NewSDValueDbgMsg(V, "Creating new node: ", this);
@@ -10794,8 +10793,8 @@ SDValue SelectionDAG::getLoad(ISD::MemIndexedMode AM, ISD::LoadExtType ExtType,
       dl.getIROrder(), VTs, AM, ExtType, MemVT, MMO));
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
-  void *IP = nullptr;
-  if (auto *E = cast_or_null<LoadSDNode>(FindNodeOrInsertPos(ID, dl, IP))) {
+  FoldingSetInsertToken InsertToken;
+  if (auto *E = cast_or_null<LoadSDNode>(lookupNode(ID, dl, InsertToken))) {
     E->refineAlignment(MMO);
     E->refineMMOMetadata(MMO);
     return SDValue(E, 0);
@@ -10804,7 +10803,7 @@ SDValue SelectionDAG::getLoad(ISD::MemIndexedMode AM, ISD::LoadExtType ExtType,
                                   ExtType, MemVT, MMO);
   createOperands(N, Ops);
 
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V(N, 0);
   NewSDValueDbgMsg(V, "Creating new node: ", this);
@@ -10926,8 +10925,8 @@ SDValue SelectionDAG::getStore(SDValue Chain, const SDLoc &dl, SDValue Val,
       dl.getIROrder(), VTs, AM, IsTruncating, SVT, MMO));
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP)) {
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, dl, InsertToken)) {
     cast<StoreSDNode>(E)->refineAlignment(MMO);
     cast<StoreSDNode>(E)->refineMMOMetadata(MMO);
     return SDValue(E, 0);
@@ -10936,7 +10935,7 @@ SDValue SelectionDAG::getStore(SDValue Chain, const SDLoc &dl, SDValue Val,
                                    IsTruncating, SVT, MMO);
   createOperands(N, Ops);
 
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V(N, 0);
   NewSDValueDbgMsg(V, "Creating new node: ", this);
@@ -11044,8 +11043,8 @@ SDValue SelectionDAG::getLoadVP(ISD::MemIndexedMode AM,
       dl.getIROrder(), VTs, AM, ExtType, IsExpanding, MemVT, MMO));
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
-  void *IP = nullptr;
-  if (auto *E = cast_or_null<VPLoadSDNode>(FindNodeOrInsertPos(ID, dl, IP))) {
+  FoldingSetInsertToken InsertToken;
+  if (auto *E = cast_or_null<VPLoadSDNode>(lookupNode(ID, dl, InsertToken))) {
     E->refineAlignment(MMO);
     E->refineMMOMetadata(MMO);
     return SDValue(E, 0);
@@ -11054,7 +11053,7 @@ SDValue SelectionDAG::getLoadVP(ISD::MemIndexedMode AM,
                                     ExtType, IsExpanding, MemVT, MMO);
   createOperands(N, Ops);
 
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V(N, 0);
   NewSDValueDbgMsg(V, "Creating new node: ", this);
@@ -11144,8 +11143,8 @@ SDValue SelectionDAG::getStoreVP(SDValue Chain, const SDLoc &dl, SDValue Val,
       dl.getIROrder(), VTs, AM, IsTruncating, IsCompressing, MemVT, MMO));
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP)) {
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, dl, InsertToken)) {
     cast<VPStoreSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11153,7 +11152,7 @@ SDValue SelectionDAG::getStoreVP(SDValue Chain, const SDLoc &dl, SDValue Val,
                                      IsTruncating, IsCompressing, MemVT, MMO);
   createOperands(N, Ops);
 
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V(N, 0);
   NewSDValueDbgMsg(V, "Creating new node: ", this);
@@ -11214,8 +11213,8 @@ SDValue SelectionDAG::getTruncStoreVP(SDValue Chain, const SDLoc &dl,
       dl.getIROrder(), VTs, ISD::UNINDEXED, true, IsCompressing, SVT, MMO));
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP)) {
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, dl, InsertToken)) {
     cast<VPStoreSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11224,7 +11223,7 @@ SDValue SelectionDAG::getTruncStoreVP(SDValue Chain, const SDLoc &dl,
                                ISD::UNINDEXED, true, IsCompressing, SVT, MMO);
   createOperands(N, Ops);
 
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V(N, 0);
   NewSDValueDbgMsg(V, "Creating new node: ", this);
@@ -11246,8 +11245,8 @@ SDValue SelectionDAG::getIndexedStoreVP(SDValue OrigStore, const SDLoc &dl,
   ID.AddInteger(ST->getRawSubclassData());
   ID.AddInteger(ST->getPointerInfo().getAddrSpace());
   ID.AddInteger(ST->getMemOperand()->getFlags());
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, dl, InsertToken))
     return SDValue(E, 0);
 
   auto *N = newSDNode<VPStoreSDNode>(
@@ -11255,7 +11254,7 @@ SDValue SelectionDAG::getIndexedStoreVP(SDValue OrigStore, const SDLoc &dl,
       ST->isCompressingStore(), ST->getMemoryVT(), ST->getMemOperand());
   createOperands(N, Ops);
 
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V(N, 0);
   NewSDValueDbgMsg(V, "Creating new node: ", this);
@@ -11280,8 +11279,8 @@ SDValue SelectionDAG::getStridedLoadVP(
       DL.getIROrder(), VTs, AM, ExtType, IsExpanding, MemVT, MMO));
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
 
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP)) {
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, DL, InsertToken)) {
     cast<VPStridedLoadSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11290,7 +11289,7 @@ SDValue SelectionDAG::getStridedLoadVP(
       newSDNode<VPStridedLoadSDNode>(DL.getIROrder(), DL.getDebugLoc(), VTs, AM,
                                      ExtType, IsExpanding, MemVT, MMO);
   createOperands(N, Ops);
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V(N, 0);
   NewSDValueDbgMsg(V, "Creating new node: ", this);
@@ -11336,8 +11335,8 @@ SDValue SelectionDAG::getStridedStoreVP(SDValue Chain, const SDLoc &DL,
   ID.AddInteger(getSyntheticNodeSubclassData<VPStridedStoreSDNode>(
       DL.getIROrder(), VTs, AM, IsTruncating, IsCompressing, MemVT, MMO));
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP)) {
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, DL, InsertToken)) {
     cast<VPStridedStoreSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11346,7 +11345,7 @@ SDValue SelectionDAG::getStridedStoreVP(SDValue Chain, const SDLoc &DL,
                                             IsCompressing, MemVT, MMO);
   createOperands(N, Ops);
 
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V(N, 0);
   NewSDValueDbgMsg(V, "Creating new node: ", this);
@@ -11385,8 +11384,8 @@ SDValue SelectionDAG::getTruncStridedStoreVP(SDValue Chain, const SDLoc &DL,
   ID.AddInteger(getSyntheticNodeSubclassData<VPStridedStoreSDNode>(
       DL.getIROrder(), VTs, ISD::UNINDEXED, true, IsCompressing, SVT, MMO));
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP)) {
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, DL, InsertToken)) {
     cast<VPStridedStoreSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11395,7 +11394,7 @@ SDValue SelectionDAG::getTruncStridedStoreVP(SDValue Chain, const SDLoc &DL,
                                             IsCompressing, SVT, MMO);
   createOperands(N, Ops);
 
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V(N, 0);
   NewSDValueDbgMsg(V, "Creating new node: ", this);
@@ -11414,8 +11413,8 @@ SDValue SelectionDAG::getGatherVP(SDVTList VTs, EVT VT, const SDLoc &dl,
       dl.getIROrder(), VTs, VT, MMO, IndexType));
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP)) {
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, dl, InsertToken)) {
     cast<VPGatherSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11438,7 +11437,7 @@ SDValue SelectionDAG::getGatherVP(SDVTList VTs, EVT VT, const SDLoc &dl,
          N->getScale()->getAsAPIntVal().isPowerOf2() &&
          "Scale should be a constant power of 2");
 
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V(N, 0);
   NewSDValueDbgMsg(V, "Creating new node: ", this);
@@ -11458,8 +11457,8 @@ SDValue SelectionDAG::getScatterVP(SDVTList VTs, EVT VT, const SDLoc &dl,
       dl.getIROrder(), VTs, VT, MMO, IndexType));
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP)) {
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, dl, InsertToken)) {
     cast<VPScatterSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11482,7 +11481,7 @@ SDValue SelectionDAG::getScatterVP(SDVTList VTs, EVT VT, const SDLoc &dl,
          N->getScale()->getAsAPIntVal().isPowerOf2() &&
          "Scale should be a constant power of 2");
 
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V(N, 0);
   NewSDValueDbgMsg(V, "Creating new node: ", this);
@@ -11508,8 +11507,8 @@ SDValue SelectionDAG::getMaskedLoad(EVT VT, const SDLoc &dl, SDValue Chain,
       dl.getIROrder(), VTs, AM, ExtTy, isExpanding, MemVT, MMO));
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP)) {
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, dl, InsertToken)) {
     cast<MaskedLoadSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11517,7 +11516,7 @@ SDValue SelectionDAG::getMaskedLoad(EVT VT, const SDLoc &dl, SDValue Chain,
                                         AM, ExtTy, isExpanding, MemVT, MMO);
   createOperands(N, Ops);
 
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V(N, 0);
   NewSDValueDbgMsg(V, "Creating new node: ", this);
@@ -11557,8 +11556,8 @@ SDValue SelectionDAG::getMaskedStore(SDValue Chain, const SDLoc &dl,
       dl.getIROrder(), VTs, AM, IsTruncating, IsCompressing, MemVT, MMO));
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP)) {
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, dl, InsertToken)) {
     cast<MaskedStoreSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11567,7 +11566,7 @@ SDValue SelectionDAG::getMaskedStore(SDValue Chain, const SDLoc &dl,
                                    IsTruncating, IsCompressing, MemVT, MMO);
   createOperands(N, Ops);
 
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V(N, 0);
   NewSDValueDbgMsg(V, "Creating new node: ", this);
@@ -11599,8 +11598,8 @@ SDValue SelectionDAG::getMaskedGather(SDVTList VTs, EVT MemVT, const SDLoc &dl,
       dl.getIROrder(), VTs, MemVT, MMO, IndexType, ExtTy));
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP)) {
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, dl, InsertToken)) {
     cast<MaskedGatherSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11625,7 +11624,7 @@ SDValue SelectionDAG::getMaskedGather(SDVTList VTs, EVT MemVT, const SDLoc &dl,
          N->getScale()->getAsAPIntVal().isPowerOf2() &&
          "Scale should be a constant power of 2");
 
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V(N, 0);
   NewSDValueDbgMsg(V, "Creating new node: ", this);
@@ -11646,8 +11645,8 @@ SDValue SelectionDAG::getMaskedScatter(SDVTList VTs, EVT MemVT, const SDLoc &dl,
       dl.getIROrder(), VTs, MemVT, MMO, IndexType, IsTrunc));
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP)) {
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, dl, InsertToken)) {
     cast<MaskedScatterSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11671,7 +11670,7 @@ SDValue SelectionDAG::getMaskedScatter(SDVTList VTs, EVT MemVT, const SDLoc &dl,
          N->getScale()->getAsAPIntVal().isPowerOf2() &&
          "Scale should be a constant power of 2");
 
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V(N, 0);
   NewSDValueDbgMsg(V, "Creating new node: ", this);
@@ -11691,8 +11690,8 @@ SDValue SelectionDAG::getMaskedHistogram(SDVTList VTs, EVT MemVT,
       dl.getIROrder(), VTs, MemVT, MMO, IndexType));
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP)) {
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, dl, InsertToken)) {
     cast<MaskedGatherSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11709,7 +11708,7 @@ SDValue SelectionDAG::getMaskedHistogram(SDVTList VTs, EVT MemVT,
          "Scale should be a constant power of 2");
   assert(N->getInc().getValueType().isInteger() && "Non integer update value");
 
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V(N, 0);
   NewSDValueDbgMsg(V, "Creating new node: ", this);
@@ -11728,8 +11727,8 @@ SDValue SelectionDAG::getLoadFFVP(EVT VT, const SDLoc &DL, SDValue Chain,
                                                              VTs, VT, MMO));
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP)) {
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, DL, InsertToken)) {
     cast<VPLoadFFSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11737,7 +11736,7 @@ SDValue SelectionDAG::getLoadFFVP(EVT VT, const SDLoc &DL, SDValue Chain,
                                       VT, MMO);
   createOperands(N, Ops);
 
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V(N, 0);
   NewSDValueDbgMsg(V, "Creating new node: ", this);
@@ -11756,15 +11755,15 @@ SDValue SelectionDAG::getGetFPEnv(SDValue Chain, const SDLoc &dl, SDValue Ptr,
       ISD::GET_FPENV_MEM, dl.getIROrder(), VTs, MemVT, MMO));
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, dl, InsertToken))
     return SDValue(E, 0);
 
   auto *N = newSDNode<FPStateAccessSDNode>(ISD::GET_FPENV_MEM, dl.getIROrder(),
                                            dl.getDebugLoc(), VTs, MemVT, MMO);
   createOperands(N, Ops);
 
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V(N, 0);
   NewSDValueDbgMsg(V, "Creating new node: ", this);
@@ -11783,15 +11782,15 @@ SDValue SelectionDAG::getSetFPEnv(SDValue Chain, const SDLoc &dl, SDValue Ptr,
       ISD::SET_FPENV_MEM, dl.getIROrder(), VTs, MemVT, MMO));
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
-  void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *E = lookupNode(ID, dl, InsertToken))
     return SDValue(E, 0);
 
   auto *N = newSDNode<FPStateAccessSDNode>(ISD::SET_FPENV_MEM, dl.getIROrder(),
                                            dl.getDebugLoc(), VTs, MemVT, MMO);
   createOperands(N, Ops);
 
-  CSEMap.InsertNode(N, IP);
+  CSEMap.insert(N, InsertToken);
   InsertNode(N);
   SDValue V(N, 0);
   NewSDValueDbgMsg(V, "Creating new node: ", this);
@@ -12004,9 +12003,9 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
   if (VT != MVT::Glue) {
     FoldingSetNodeID ID;
     AddNodeIDNode(ID, Opcode, VTs, Ops);
-    void *IP = nullptr;
+    FoldingSetInsertToken InsertToken;
 
-    if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP)) {
+    if (SDNode *E = lookupNode(ID, DL, InsertToken)) {
       E->intersectFlagsWith(Flags);
       return SDValue(E, 0);
     }
@@ -12014,7 +12013,7 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
     N = newSDNode<SDNode>(Opcode, DL.getIROrder(), DL.getDebugLoc(), VTs);
     createOperands(N, Ops);
 
-    CSEMap.InsertNode(N, IP);
+    CSEMap.insert(N, InsertToken);
   } else {
     N = newSDNode<SDNode>(Opcode, DL.getIROrder(), DL.getDebugLoc(), VTs);
     createOperands(N, Ops);
@@ -12201,15 +12200,15 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList,
   if (VTList.VTs[VTList.NumVTs-1] != MVT::Glue) {
     FoldingSetNodeID ID;
     AddNodeIDNode(ID, Opcode, VTList, Ops);
-    void *IP = nullptr;
-    if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP)) {
+    FoldingSetInsertToken InsertToken;
+    if (SDNode *E = lookupNode(ID, DL, InsertToken)) {
       E->intersectFlagsWith(Flags);
       return SDValue(E, 0);
     }
 
     N = newSDNode<SDNode>(Opcode, DL.getIROrder(), DL.getDebugLoc(), VTList);
     createOperands(N, Ops);
-    CSEMap.InsertNode(N, IP);
+    CSEMap.insert(N, InsertToken);
   } else {
     N = newSDNode<SDNode>(Opcode, DL.getIROrder(), DL.getDebugLoc(), VTList);
     createOperands(N, Ops);
@@ -12304,21 +12303,22 @@ SDNode *SelectionDAG::UpdateNodeOperands(SDNode *N, SDValue Op) {
   if (Op == N->getOperand(0)) return N;
 
   // See if the modified node already exists.
-  void *InsertPos = nullptr;
-  if (SDNode *Existing = FindModifiedNodeSlot(N, Op, InsertPos))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *Existing = FindModifiedNodeSlot(N, Op, InsertToken))
     return Existing;
 
   // Nope it doesn't.  Remove the node from its current place in the maps.
-  if (InsertPos)
+  if (InsertToken)
     if (!RemoveNodeFromCSEMaps(N))
-      InsertPos = nullptr;
+      InsertToken = {};
 
   // Now we update the operands.
   N->OperandList[0].set(Op);
 
   updateDivergence(N);
   // If this gets put into a CSE map, add it.
-  if (InsertPos) CSEMap.InsertNode(N, InsertPos);
+  if (InsertToken)
+    CSEMap.insert(N, InsertToken);
   return N;
 }
 
@@ -12330,14 +12330,14 @@ SDNode *SelectionDAG::UpdateNodeOperands(SDNode *N, SDValue Op1, SDValue Op2) {
     return N;   // No operands changed, just return the input node.
 
   // See if the modified node already exists.
-  void *InsertPos = nullptr;
-  if (SDNode *Existing = FindModifiedNodeSlot(N, Op1, Op2, InsertPos))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *Existing = FindModifiedNodeSlot(N, Op1, Op2, InsertToken))
     return Existing;
 
   // Nope it doesn't.  Remove the node from its current place in the maps.
-  if (InsertPos)
+  if (InsertToken)
     if (!RemoveNodeFromCSEMaps(N))
-      InsertPos = nullptr;
+      InsertToken = {};
 
   // Now we update the operands.
   if (N->OperandList[0] != Op1)
@@ -12347,7 +12347,8 @@ SDNode *SelectionDAG::UpdateNodeOperands(SDNode *N, SDValue Op1, SDValue Op2) {
 
   updateDivergence(N);
   // If this gets put into a CSE map, add it.
-  if (InsertPos) CSEMap.InsertNode(N, InsertPos);
+  if (InsertToken)
+    CSEMap.insert(N, InsertToken);
   return N;
 }
 
@@ -12382,14 +12383,14 @@ UpdateNodeOperands(SDNode *N, ArrayRef<SDValue> Ops) {
     return N;
 
   // See if the modified node already exists.
-  void *InsertPos = nullptr;
-  if (SDNode *Existing = FindModifiedNodeSlot(N, Ops, InsertPos))
+  FoldingSetInsertToken InsertToken;
+  if (SDNode *Existing = FindModifiedNodeSlot(N, Ops, InsertToken))
     return Existing;
 
   // Nope it doesn't.  Remove the node from its current place in the maps.
-  if (InsertPos)
+  if (InsertToken)
     if (!RemoveNodeFromCSEMaps(N))
-      InsertPos = nullptr;
+      InsertToken = {};
 
   // Now we update the operands.
   for (unsigned i = 0; i != NumOps; ++i)
@@ -12398,7 +12399,8 @@ UpdateNodeOperands(SDNode *N, ArrayRef<SDValue> Ops) {
 
   updateDivergence(N);
   // If this gets put into a CSE map, add it.
-  if (InsertPos) CSEMap.InsertNode(N, InsertPos);
+  if (InsertToken)
+    CSEMap.insert(N, InsertToken);
   return N;
 }
 
@@ -12547,16 +12549,16 @@ SDNode *SelectionDAG::UpdateSDLocOnMergeSDNode(SDNode *N, const SDLoc &OLoc) {
 SDNode *SelectionDAG::MorphNodeTo(SDNode *N, unsigned Opc,
                                   SDVTList VTs, ArrayRef<SDValue> Ops) {
   // If an identical node already exists, use it.
-  void *IP = nullptr;
+  FoldingSetInsertToken InsertToken;
   if (VTs.VTs[VTs.NumVTs-1] != MVT::Glue) {
     FoldingSetNodeID ID;
     AddNodeIDNode(ID, Opc, VTs, Ops);
-    if (SDNode *ON = FindNodeOrInsertPos(ID, SDLoc(N), IP))
+    if (SDNode *ON = lookupNode(ID, SDLoc(N), InsertToken))
       return UpdateSDLocOnMergeSDNode(ON, SDLoc(N));
   }
 
   if (!RemoveNodeFromCSEMaps(N))
-    IP = nullptr;
+    InsertToken = {};
 
   // Start the morphing.
   N->NodeType = Opc;
@@ -12592,8 +12594,8 @@ SDNode *SelectionDAG::MorphNodeTo(SDNode *N, unsigned Opc,
     RemoveDeadNodes(DeadNodes);
   }
 
-  if (IP)
-    CSEMap.InsertNode(N, IP);   // Memoize the new node.
+  if (InsertToken)
+    CSEMap.insert(N, InsertToken); // Memoize the new node.
   return N;
 }
 
@@ -12738,13 +12740,12 @@ MachineSDNode *SelectionDAG::getMachineNode(unsigned Opcode, const SDLoc &DL,
                                             ArrayRef<SDValue> Ops) {
   bool DoCSE = VTs.VTs[VTs.NumVTs-1] != MVT::Glue;
   MachineSDNode *N;
-  void *IP = nullptr;
+  FoldingSetInsertToken InsertToken;
 
   if (DoCSE) {
     FoldingSetNodeID ID;
     AddNodeIDNode(ID, ~Opcode, VTs, Ops);
-    IP = nullptr;
-    if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP)) {
+    if (SDNode *E = lookupNode(ID, DL, InsertToken)) {
       return cast<MachineSDNode>(UpdateSDLocOnMergeSDNode(E, DL));
     }
   }
@@ -12754,7 +12755,7 @@ MachineSDNode *SelectionDAG::getMachineNode(unsigned Opcode, const SDLoc &DL,
   createOperands(N, Ops);
 
   if (DoCSE)
-    CSEMap.InsertNode(N, IP);
+    CSEMap.insert(N, InsertToken);
 
   InsertNode(N);
   NewSDValueDbgMsg(SDValue(N, 0), "Creating new machine node: ", this);
@@ -12802,8 +12803,8 @@ SDNode *SelectionDAG::getNodeIfExists(unsigned Opcode, SDVTList VTList,
   auto Lookup = [&](ArrayRef<SDValue> LookupOps) -> SDNode * {
     FoldingSetNodeID ID;
     AddNodeIDNode(ID, Opcode, VTList, LookupOps);
-    void *IP = nullptr;
-    if (SDNode *E = FindNodeOrInsertPos(ID, IP)) {
+    FoldingSetInsertToken InsertToken;
+    if (SDNode *E = lookupNode(ID, InsertToken)) {
       E->intersectFlagsWith(Flags);
       return E;
     }
@@ -12825,8 +12826,8 @@ bool SelectionDAG::doesNodeExist(unsigned Opcode, SDVTList VTList,
   if (VTList.VTs[VTList.NumVTs - 1] != MVT::Glue) {
     FoldingSetNodeID ID;
     AddNodeIDNode(ID, Opcode, VTList, Ops);
-    void *IP = nullptr;
-    if (FindNodeOrInsertPos(ID, SDLoc(), IP))
+    FoldingSetInsertToken InsertToken;
+    if (lookupNode(ID, SDLoc(), InsertToken))
       return true;
   }
   return false;


### PR DESCRIPTION
Rename SelectionDAG::FindNodeOrInsertPos to lookupNode and use the new
FoldingSetInsertToken API in place of `void *`.

In SelectionDAG the token is named `InsertToken`, as Token there means the
chain operand (TokenFactor, EntryToken).
