### PR TITLE
workflows/pr-code-format: Run the in-tree git-clang-format

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -46,6 +46,9 @@ jobs:
         env:
           GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+          # This runs a release ahead of the pinned clang-format, so it must
+          # not use newly added clang-format options.
+          CLANG_FORMAT_PATH: ./clang/tools/clang-format/git-clang-format
         # Create an empty comments file so the pr-write job doesn't fail.
         run: |
           echo "[]" > comments &&


### PR DESCRIPTION
The container installs git-clang-format from an LLVM release tarball, so
a script fix (#215946) requires an in-tree script.
git-clang-format only uses four options from clang-format.
