### PR TITLE
[KnownFPClass] Remove `propagateNonNan` `PreserveSign` parameter

### DIFF
--- a/llvm/include/llvm/Support/KnownFPClass.h
+++ b/llvm/include/llvm/Support/KnownFPClass.h
@@ -422,13 +422,10 @@ struct KnownFPClass {
   // Propagate knowledge that a non-NaN source implies the result can also not
   // be a NaN. For unconstrained operations, signaling nans are not guaranteed
   // to be quieted but cannot be introduced.
-  void propagateNonNaN(const KnownFPClass &Src, bool PreserveSign = false) {
+  void propagateNonNaN(const KnownFPClass &Src) {
     propagateNonSNaN(Src);
-    if (Src.isKnownNever(fcNan)) {
+    if (Src.isKnownNever(fcNan))
       knownNot(fcNan);
-      if (PreserveSign)
-        setSignBit(Src.getSignBit());
-    }
   }
 
   void propagateNonNaN(const KnownFPClass &LHS, const KnownFPClass &RHS) {

--- a/llvm/lib/Support/KnownFPClass.cpp
+++ b/llvm/lib/Support/KnownFPClass.cpp
@@ -614,7 +614,7 @@ KnownFPClass KnownFPClass::exp(const KnownFPClass &KnownSrc) {
 void KnownFPClass::propagateCanonicalizingSrc(const KnownFPClass &Src,
                                               DenormalMode Mode) {
   propagateDenormal(Src, Mode);
-  propagateNonNaN(Src, /*PreserveSign=*/true);
+  propagateNonNaN(Src);
 }
 
 KnownFPClass KnownFPClass::log(const KnownFPClass &KnownSrc,
@@ -835,7 +835,7 @@ KnownFPClass KnownFPClass::fptrunc(const KnownFPClass &KnownSrc) {
   if (KnownSrc.cannotBeOrderedLessThanZero())
     Known.knownNot(KnownFPClass::OrderedLessThanZeroMask);
 
-  Known.propagateNonNaN(KnownSrc, true);
+  Known.propagateNonNaN(KnownSrc);
 
   // Infinity needs a range check.
   return Known;
@@ -849,7 +849,7 @@ KnownFPClass KnownFPClass::roundToIntegral(const KnownFPClass &KnownSrc,
   // Integer results cannot be subnormal.
   Known.knownNot(fcSubnormal);
 
-  Known.propagateNonNaN(KnownSrc, true);
+  Known.propagateNonNaN(KnownSrc);
 
   // Pass through infinities, except PPC_FP128 is a special case for
   // intrinsics other than trunc.
@@ -901,7 +901,7 @@ KnownFPClass KnownFPClass::ldexp(const KnownFPClass &KnownSrc,
                                  const APInt &ConstantRangeExpMax,
                                  const fltSemantics &Flt, DenormalMode Mode) {
   KnownFPClass Known;
-  Known.propagateNonNaN(KnownSrc, /*PreserveSign=*/true);
+  Known.propagateNonNaN(KnownSrc);
 
   // Sign is preserved, but underflows may produce zeroes.
   if (KnownSrc.isKnownNever(fcNegative))

--- a/llvm/unittests/CodeGen/GlobalISel/KnownFPClassTest.cpp
+++ b/llvm/unittests/CodeGen/GlobalISel/KnownFPClassTest.cpp
@@ -165,7 +165,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCstZeroFPTrunc) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPosFinite | fcNegZero, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.getSignBit());
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassCstVecZeroFPTrunc) {
@@ -191,7 +191,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCstVecZeroFPTrunc) {
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
   EXPECT_EQ(fcPosFinite | fcNegZero, Known.KnownFPClasses);
-  EXPECT_EQ(false, Known.getSignBit());
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassSelectPos0) {


### PR DESCRIPTION
`void propagateNonNaN(const KnownFPClass &Src, bool PreserveSign = false)`
Things work as you would expect if `PreserveSign` is `false`. But when `PreserveSign` is `true`, it does not do what you would expect (I thought it would copy the signbit of `NaN`). If `PreserveSign` is `true`, it will copy `Src.SignBit` if and only if `Src` is never `NaN`, which is counterintuitive. It also does not properly update `KnownFPClasses`, and allows for potentially erroneous states to be generated. Such as `fcNegZero` having a positive sign bit.

I have removed `void propagateNonNaN(const KnownFPClass &Src, bool PreserveSign = false)` and replaced it with just `void propagateNonNaN(const KnownFPClass &Src)`.

This fixes https://github.com/llvm/llvm-project/issues/217127

I discovered this while working on https://github.com/llvm/llvm-project/pull/218514
