### PR TITLE
[AMDGPU] Add register allocation handoff intrinsic

### DIFF
--- a/llvm/docs/LangRef.md
+++ b/llvm/docs/LangRef.md
@@ -26514,6 +26514,59 @@ attach various forms of information to operands that dominate specific
 uses.  It is not meant for general use, only for building temporary
 renaming forms that require value splits at certain points.
 
+(int_experimental_regalloc_handoff)=
+
+#### '`llvm.experimental.regalloc.handoff`' Intrinsic
+
+##### Syntax:
+
+This intrinsic operates on ``i32`` values.
+
+```
+declare i32 @llvm.experimental.regalloc.handoff(i32 %value, metadata %constraint)
+```
+
+##### Overview:
+
+The `llvm.experimental.regalloc.handoff` intrinsic marks a producer-selected
+register-allocation boundary with a target-specific constraint. It is a
+bitwise identity operation. A supporting target preserves every potentially
+executed call that carries a constraint it accepts until register allocation.
+
+##### Arguments:
+
+The value argument and result are ``i32``. An accepted constraint is encoded as
+a metadata node containing exactly one metadata string. Other metadata forms
+are unsupported constraints and use the identity fallback described below.
+
+##### Semantics:
+
+The result is bitwise identical to the argument. Poison remains poison and
+`undef` retains its ordinary semantics; this intrinsic is not a `freeze`
+operation.
+
+Each accepted call is a distinct compiler-visible allocation event. Before
+target-specific lowering, generic transformations must preserve the dynamic
+executions of every potentially executed call. They may not merge distinct
+call sites, introduce an execution by speculation, or remove an execution
+merely because its result is unused or its arguments are identical. They may
+delete unreachable calls or clone and replace a call when doing so preserves
+its dynamic executions; each surviving clone is then a separate allocation
+event. The intrinsic does not access program-visible memory. Its
+compiler-visible allocation effect is modeled as an access to inaccessible
+memory so that it remains distinct without clobbering ordinary loads or stores.
+
+A target that does not accept the constraint lowers the call to the identity
+operation before instruction selection. The allocation effect does not change
+the program's value semantics.
+
+For AMDGPU, the accepted constraint strings are `amdgpu.vgpr`, which requests a
+32-bit VGPR, and `amdgpu.agpr`, which requests a 32-bit AGPR on subtargets that
+support MAI/AGPR instructions. `amdgpu.agpr` is an identity operation on other
+AMDGPU subtargets. Each accepted request starts a distinct outgoing virtual
+register interval in the requested class. Compatible incoming and outgoing
+intervals may still receive the same physical register.
+
 (type.test)=
 
 #### '`llvm.type.test`' Intrinsic

--- a/llvm/include/llvm/CodeGen/MachineInstr.h
+++ b/llvm/include/llvm/CodeGen/MachineInstr.h
@@ -116,9 +116,9 @@ public:
                              // known to be exact.
     NoFPExcept = 1 << 14,    // Instruction does not raise
                              // floatint-point exceptions.
-    NoMerge = 1 << 15,       // Passes that drop source location info
-                             // (e.g. branch folding) should skip
-                             // this instruction.
+    NoMerge = 1 << 15,       // Passes must not merge this instruction with
+                             // another occurrence or drop its source location.
+                             // isSafeToMove also returns false.
     Unpredictable = 1 << 16, // Instruction with unpredictable condition.
     NoConvergent = 1 << 17,  // Call does not require convergence guarantees.
     NonNeg = 1 << 18,        // The operand is non-negative.

--- a/llvm/include/llvm/CodeGen/PreISelIntrinsicLowering.h
+++ b/llvm/include/llvm/CodeGen/PreISelIntrinsicLowering.h
@@ -20,11 +20,20 @@ namespace llvm {
 class Module;
 class TargetMachine;
 
+enum class PreISelIntrinsicLoweringMode {
+  All,
+  RegAllocHandoffOnly,
+};
+
 struct PreISelIntrinsicLoweringPass
     : RequiredPassInfoMixin<PreISelIntrinsicLoweringPass> {
   const TargetMachine *TM;
+  PreISelIntrinsicLoweringMode Mode;
 
-  PreISelIntrinsicLoweringPass(const TargetMachine *TM) : TM(TM) {}
+  PreISelIntrinsicLoweringPass(
+      const TargetMachine *TM,
+      PreISelIntrinsicLoweringMode Mode = PreISelIntrinsicLoweringMode::All)
+      : TM(TM), Mode(Mode) {}
   LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };
 

--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -4779,6 +4779,12 @@ public:
     return false;
   }
 
+  /// Return true if the target supports the named register-allocation
+  /// handoff constraint.
+  virtual bool supportsRegAllocHandoff(StringRef Constraint) const {
+    return false;
+  }
+
   /// Return true if the target supports swifterror attribute. It optimizes
   /// loads and stores to reading and writing a specific register.
   virtual bool supportSwiftError() const {

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -1025,6 +1025,12 @@ def int_localaddress : DefaultAttrsIntrinsic<[llvm_ptr_ty], [], [IntrNoMem]>;
 // Escapes local variables to allow access from other functions.
 def int_localescape : DefaultAttrsIntrinsic<[], [llvm_vararg_ty]>;
 
+// Carries a register-allocation boundary selected by an IR producer. Targets
+// that do not support the request lower it as an identity operation.
+def int_experimental_regalloc_handoff : DefaultAttrsIntrinsic<
+    [llvm_i32_ty], [llvm_i32_ty, llvm_metadata_ty],
+    [IntrInaccessibleMemOnly, IntrNoMerge, IntrNoCreateUndefOrPoison]>;
+
 // Given a function and the localaddress of a parent frame, returns a pointer
 // to an escaped allocation indicated by the index.
 def int_localrecover : DefaultAttrsIntrinsic<[llvm_ptr_ty],

--- a/llvm/lib/CodeGen/MIRParser/MILexer.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MILexer.cpp
@@ -299,6 +299,7 @@ static MIToken::TokenKind getIdentifierKind(StringRef Identifier) {
       .Case("machine-block-address-taken",
             MIToken::kw_machine_block_address_taken)
       .Case("call-frame-size", MIToken::kw_call_frame_size)
+      .Case("nomerge", MIToken::kw_nomerge)
       .Case("noconvergent", MIToken::kw_noconvergent)
       .Case("mmra", MIToken::kw_mmra)
       .Case("lr-split", MIToken::kw_lr_split)

--- a/llvm/lib/CodeGen/MIRParser/MILexer.h
+++ b/llvm/lib/CodeGen/MIRParser/MILexer.h
@@ -151,6 +151,7 @@ struct MIToken {
     kw_ir_block_address_taken,
     kw_machine_block_address_taken,
     kw_call_frame_size,
+    kw_nomerge,
     kw_noconvergent,
     kw_mmra,
     kw_lr_split,

--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -1382,6 +1382,7 @@ bool MIParser::parseInstruction(unsigned &OpCode, unsigned &Flags) {
          Token.is(MIToken::kw_nsw) ||
          Token.is(MIToken::kw_exact) ||
          Token.is(MIToken::kw_nofpexcept) ||
+         Token.is(MIToken::kw_nomerge) ||
          Token.is(MIToken::kw_noconvergent) ||
          Token.is(MIToken::kw_unpredictable) ||
          Token.is(MIToken::kw_nneg) ||
@@ -1418,6 +1419,8 @@ bool MIParser::parseInstruction(unsigned &OpCode, unsigned &Flags) {
       Flags |= MachineInstr::IsExact;
     if (Token.is(MIToken::kw_nofpexcept))
       Flags |= MachineInstr::NoFPExcept;
+    if (Token.is(MIToken::kw_nomerge))
+      Flags |= MachineInstr::NoMerge;
     if (Token.is(MIToken::kw_unpredictable))
       Flags |= MachineInstr::Unpredictable;
     if (Token.is(MIToken::kw_noconvergent))

--- a/llvm/lib/CodeGen/MachineCSE.cpp
+++ b/llvm/lib/CodeGen/MachineCSE.cpp
@@ -398,7 +398,7 @@ bool MachineCSEImpl::PhysRegDefsReach(MachineInstr *CSMI, MachineInstr *MI,
 bool MachineCSEImpl::isCSECandidate(MachineInstr *MI) {
   if (MI->isPosition() || MI->isPHI() || MI->isImplicitDef() || MI->isKill() ||
       MI->isInlineAsm() || MI->isDebugInstr() || MI->isJumpTableDebugInfo() ||
-      MI->isFakeUse())
+      MI->isFakeUse() || MI->getFlag(MachineInstr::NoMerge))
     return false;
 
   // Ignore copies.

--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -1357,6 +1357,12 @@ bool MachineInstr::isSafeToMove(bool &SawStore) const {
     return false;
   }
 
+  // Keep NoMerge instructions out of passes that use isSafeToMove for motion
+  // or dead-code removal. This deliberately does not set SawStore: other
+  // instructions may still move across them.
+  if (getFlag(MachineInstr::NoMerge))
+    return false;
+
   // Don't touch instructions that have non-trivial invariants.  For example,
   // terminators have to be at the end of a basic block.
   if (isPosition() || isDebugInstr() || isTerminator() ||

--- a/llvm/lib/CodeGen/PreISelIntrinsicLowering.cpp
+++ b/llvm/lib/CodeGen/PreISelIntrinsicLowering.cpp
@@ -109,6 +109,28 @@ template <class T> static bool forEachCall(Function &Intrin, T Callback) {
   return Changed;
 }
 
+static bool lowerRegAllocHandoff(Function &F, const TargetMachine *TM) {
+  if (!TM)
+    return false;
+
+  return forEachCall(F, [&](CallInst *CI) {
+    const auto *ConstraintMD =
+        cast<MetadataAsValue>(CI->getArgOperand(1))->getMetadata();
+    const auto *ConstraintNode = dyn_cast<MDNode>(ConstraintMD);
+    const auto *Constraint =
+        ConstraintNode && ConstraintNode->getNumOperands() == 1
+            ? dyn_cast<MDString>(ConstraintNode->getOperand(0))
+            : nullptr;
+    const TargetLowering *TL =
+        TM->getSubtargetImpl(*CI->getFunction())->getTargetLowering();
+    if (Constraint && TL->supportsRegAllocHandoff(Constraint->getString()))
+      return false;
+    CI->replaceAllUsesWith(CI->getArgOperand(0));
+    CI->eraseFromParent();
+    return true;
+  });
+}
+
 static bool lowerLoadRelative(Function &F) {
   if (F.use_empty())
     return false;
@@ -781,6 +803,9 @@ bool PreISelIntrinsicLowering::lowerIntrinsics(Module &M) const {
     case Intrinsic::objc_sync_exit:
       Changed |= lowerObjCCall(F, RTLIB::impl_objc_sync_exit);
       break;
+    case Intrinsic::experimental_regalloc_handoff:
+      Changed |= lowerRegAllocHandoff(F, TM);
+      break;
     case Intrinsic::acos:
     case Intrinsic::asin:
     case Intrinsic::atan:
@@ -884,6 +909,19 @@ ModulePass *llvm::createPreISelIntrinsicLoweringPass() {
 
 PreservedAnalyses
 PreISelIntrinsicLoweringPass::run(Module &M, ModuleAnalysisManager &MAM) {
+  if (Mode == PreISelIntrinsicLoweringMode::RegAllocHandoffOnly) {
+    // Without a target, support is unknown. Leave the marker for the target's
+    // normal pre-ISel lowering rather than treating it as unsupported.
+    if (!TM)
+      return PreservedAnalyses::all();
+
+    bool Changed = false;
+    for (Function &F : M)
+      if (F.getIntrinsicID() == Intrinsic::experimental_regalloc_handoff)
+        Changed |= lowerRegAllocHandoff(F, TM);
+    return Changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
+  }
+
   const ModuleLibcallLoweringInfo &LibcallLowering =
       MAM.getResult<LibcallLoweringModuleAnalysis>(M);
 

--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -25,6 +25,7 @@
 #include "llvm/Analysis/ProfileSummaryInfo.h"
 #include "llvm/Analysis/ScopedNoAliasAA.h"
 #include "llvm/Analysis/TypeBasedAliasAnalysis.h"
+#include "llvm/CodeGen/PreISelIntrinsicLowering.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/Pass.h"
@@ -1127,6 +1128,9 @@ PassBuilder::buildModuleSimplificationPipeline(OptimizationLevel Level,
   if (PGOOpt && PGOOpt->PseudoProbeForProfiling && !isThinLTOPostLink(Phase))
     MPM.addPass(SampleProfileProbePass(TM));
 
+  MPM.addPass(PreISelIntrinsicLoweringPass(
+      TM, PreISelIntrinsicLoweringMode::RegAllocHandoffOnly));
+
   bool HasSampleProfile = PGOOpt && (PGOOpt->Action == PGOOptions::SampleUse);
 
   // In ThinLTO mode, when flattened profile is used, all the available
@@ -1990,6 +1994,8 @@ ModulePassManager PassBuilder::buildThinLTODefaultPipeline(
     return MPM;
   }
   if (!UseCtxProfile.empty()) {
+    MPM.addPass(PreISelIntrinsicLoweringPass(
+        TM, PreISelIntrinsicLoweringMode::RegAllocHandoffOnly));
     MPM.addPass(
         buildModuleInlinerPipeline(Level, ThinOrFullLTOPhase::ThinLTOPostLink));
   } else {
@@ -2024,6 +2030,10 @@ PassBuilder::buildLTODefaultPipeline(OptimizationLevel Level,
   instructionCountersPass(MPM, /* IsPreOptimization */ true);
 
   invokeFullLinkTimeOptimizationEarlyEPCallbacks(MPM, Level);
+
+  if (Level != OptimizationLevel::O0)
+    MPM.addPass(PreISelIntrinsicLoweringPass(
+        TM, PreISelIntrinsicLoweringMode::RegAllocHandoffOnly));
 
   // If we are invoking this without a summary index noting that we are linking
   // with a library containing the necessary APIs, remove any MemProf related

--- a/llvm/lib/Target/AMDGPU/AMDGPUAttributor.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAttributor.cpp
@@ -1360,6 +1360,20 @@ struct AAAMDGPUMinAGPRAlloc
 
         return true;
       }
+      case Intrinsic::experimental_regalloc_handoff: {
+        const auto *ConstraintMD =
+            dyn_cast<MetadataAsValue>(CB.getArgOperand(1));
+        const auto *ConstraintNode =
+            ConstraintMD ? dyn_cast<MDNode>(ConstraintMD->getMetadata())
+                         : nullptr;
+        const auto *Constraint =
+            ConstraintNode && ConstraintNode->getNumOperands() == 1
+                ? dyn_cast<MDString>(ConstraintNode->getOperand(0))
+                : nullptr;
+        if (Constraint && Constraint->getString() == "amdgpu.agpr")
+          Maximum.takeAssumedMaximum(1);
+        return true;
+      }
       // Trap-like intrinsics such as llvm.trap and llvm.debugtrap do not have
       // the nocallback attribute, so the AMDGPU attributor can conservatively
       // drop all implicitly-known inputs and AGPR allocation information. Make

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
@@ -3263,6 +3263,56 @@ void AMDGPUDAGToDAGISel::SelectInterpP1F16(SDNode *N) {
 void AMDGPUDAGToDAGISel::SelectINTRINSIC_W_CHAIN(SDNode *N) {
   unsigned IntrID = N->getConstantOperandVal(1);
   switch (IntrID) {
+  case Intrinsic::experimental_regalloc_handoff: {
+    const auto *ConstraintNode = dyn_cast<MDNodeSDNode>(N->getOperand(3));
+    const MDString *Constraint =
+        ConstraintNode && ConstraintNode->getMD()->getNumOperands() == 1
+            ? dyn_cast<MDString>(ConstraintNode->getMD()->getOperand(0))
+            : nullptr;
+    StringRef ConstraintName = Constraint ? Constraint->getString() : "";
+    if (!Subtarget->getTargetLowering()->supportsRegAllocHandoff(
+            ConstraintName)) {
+      ReplaceUses(SDValue(N, 0), N->getOperand(2));
+      ReplaceUses(SDValue(N, 1), N->getOperand(0));
+      CurDAG->RemoveDeadNode(N);
+      return;
+    }
+
+    bool IsAGPR = ConstraintName == "amdgpu.agpr";
+    unsigned HandoffOpcode =
+        IsAGPR ? AMDGPU::REGALLOC_HANDOFF_AGPR : AMDGPU::REGALLOC_HANDOFF_VGPR;
+
+    SDLoc DL(N);
+    SDValue AVClass =
+        CurDAG->getTargetConstant(AMDGPU::AV_32RegClassID, DL, MVT::i32);
+    SDValue Src(CurDAG->getMachineNode(TargetOpcode::COPY_TO_REGCLASS, DL,
+                                       MVT::i32, N->getOperand(2), AVClass),
+                0);
+    SDValue HandoffOps[] = {Src, N->getOperand(0)};
+    SDNode *Handoff = CurDAG->getMachineNode(
+        HandoffOpcode, DL, CurDAG->getVTList(MVT::i32, MVT::Other), HandoffOps);
+    CurDAG->addNoMergeSiteInfo(Handoff, true);
+    SDValue Result(Handoff, 0);
+
+    if (!N->isDivergent()) {
+      if (IsAGPR) {
+        SDValue VGPRClass =
+            CurDAG->getTargetConstant(AMDGPU::VGPR_32RegClassID, DL, MVT::i32);
+        Result =
+            SDValue(CurDAG->getMachineNode(TargetOpcode::COPY_TO_REGCLASS, DL,
+                                           MVT::i32, Result, VGPRClass),
+                    0);
+      }
+      Result = SDValue(CurDAG->getMachineNode(AMDGPU::V_READFIRSTLANE_B32, DL,
+                                              MVT::i32, Result),
+                       0);
+    }
+
+    ReplaceUses(SDValue(N, 0), Result);
+    ReplaceUses(SDValue(N, 1), SDValue(Handoff, 1));
+    CurDAG->RemoveDeadNode(N);
+    return;
+  }
   case Intrinsic::amdgcn_ds_append:
   case Intrinsic::amdgcn_ds_consume: {
     if (N->getValueType(0) != MVT::i32)

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankSelect.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankSelect.cpp
@@ -22,6 +22,8 @@
 #include "llvm/CodeGen/GlobalISel/CSEMIRBuilder.h"
 #include "llvm/CodeGen/MachineUniformityAnalysis.h"
 #include "llvm/CodeGen/TargetPassConfig.h"
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/Metadata.h"
 #include "llvm/InitializePasses.h"
 
 #define DEBUG_TYPE "amdgpu-reg-bank-select"
@@ -161,6 +163,37 @@ public:
     }
   }
 
+  Register buildHandoffReadFirstLane(Register Src) {
+    LLT Ty = MRI.getType(Src);
+    Register VgprSrc = MRI.createVirtualRegister(&AMDGPU::VGPR_32RegClass);
+    MRI.setType(VgprSrc, Ty);
+    B.buildCopy(VgprSrc, Src);
+
+    Register Sgpr = MRI.createVirtualRegister(&AMDGPU::SReg_32_XM0RegClass);
+    MRI.setType(Sgpr, Ty);
+    B.buildInstr(AMDGPU::V_READFIRSTLANE_B32, {Sgpr}, {VgprSrc});
+    return Sgpr;
+  }
+
+  bool isSGPR(Register Reg) {
+    if (Reg.isPhysical())
+      return TRI.isSGPRPhysReg(Reg);
+    if (const TargetRegisterClass *RC = MRI.getRegClassOrNull(Reg))
+      return SIRegisterInfo::isSGPRClass(RC);
+    if (const RegisterBank *RB = MRI.getRegBankOrNull(Reg))
+      return RB == SgprRB;
+    return getRegBankToAssign(Reg) == SgprRB;
+  }
+
+  bool isVectorOnly(Register Reg) {
+    if (const TargetRegisterClass *RC = MRI.getRegClassOrNull(Reg))
+      return SIRegisterInfo::hasVectorRegisters(RC) &&
+             !SIRegisterInfo::hasSGPRs(RC);
+    if (const RegisterBank *RB = MRI.getRegBankOrNull(Reg))
+      return RB == VgprRB;
+    return getRegBankToAssign(Reg) == VgprRB;
+  }
+
   // %a = G_ ..., %rc
   // ->
   // %rb:RegBank(s32) = COPY %rc
@@ -168,10 +201,6 @@ public:
   void constrainRegBankUse(MachineInstr &MI, MachineOperand &UseOP,
                            const RegisterBank *RB) {
     Register Reg = UseOP.getReg();
-
-    LLT Ty = MRI.getType(Reg);
-    Register NewReg = MRI.createVirtualRegister({RB, Ty});
-    UseOP.setReg(NewReg);
 
     if (MI.isPHI()) {
       auto DefMI = MRI.getVRegDef(Reg)->getIterator();
@@ -181,7 +210,113 @@ public:
       B.setInstr(MI);
     }
 
+    MachineInstr *DefMI = MRI.getVRegDef(Reg);
+    // The chosen insertion point may be behind this pass's cursor, so repair
+    // a direct scalar handoff use immediately.
+    if (RB == SgprRB && SIInstrInfo::isRegAllocHandoff(DefMI->getOpcode()))
+      Reg = buildHandoffReadFirstLane(Reg);
+
+    Register NewReg = MRI.createVirtualRegister({RB, MRI.getType(Reg)});
     B.buildCopy(NewReg, Reg);
+    UseOP.setReg(NewReg);
+  }
+
+  bool lowerRegAllocHandoff(MachineInstr &MI, bool HasMAIInsts) {
+    if (MI.getOpcode() != AMDGPU::G_INTRINSIC_W_SIDE_EFFECTS ||
+        MI.getNumExplicitOperands() != 4 || !MI.getOperand(1).isIntrinsicID() ||
+        MI.getOperand(1).getIntrinsicID() !=
+            Intrinsic::experimental_regalloc_handoff)
+      return false;
+
+    MachineOperand &DstOp = MI.getOperand(0);
+    MachineOperand &SrcOp = MI.getOperand(2);
+    MachineOperand &ConstraintOp = MI.getOperand(3);
+    if (!DstOp.isReg() || !DstOp.isDef() || !DstOp.getReg().isVirtual() ||
+        !SrcOp.isReg() || !SrcOp.isUse() || !SrcOp.getReg().isVirtual() ||
+        !ConstraintOp.isMetadata())
+      return false;
+
+    const auto *ConstraintNode = dyn_cast<MDNode>(ConstraintOp.getMetadata());
+    const MDString *Constraint =
+        ConstraintNode && ConstraintNode->getNumOperands() == 1
+            ? dyn_cast<MDString>(ConstraintNode->getOperand(0))
+            : nullptr;
+    StringRef ConstraintName = Constraint ? Constraint->getString() : "";
+    const TargetRegisterClass *DstRC = nullptr;
+    unsigned HandoffOpcode = AMDGPU::INSTRUCTION_LIST_END;
+    if (ConstraintName == "amdgpu.vgpr") {
+      DstRC = &AMDGPU::VGPR_32RegClass;
+      HandoffOpcode = AMDGPU::REGALLOC_HANDOFF_VGPR;
+    } else if (ConstraintName == "amdgpu.agpr" && HasMAIInsts) {
+      DstRC = &AMDGPU::AGPR_32RegClass;
+      HandoffOpcode = AMDGPU::REGALLOC_HANDOFF_AGPR;
+    }
+
+    Register Dst = DstOp.getReg();
+    Register Src = SrcOp.getReg();
+    if (MRI.getType(Dst) != LLT::scalar(32) ||
+        MRI.getType(Src) != LLT::scalar(32))
+      return false;
+
+    bool DstConstrained =
+        MRI.getRegClassOrNull(Dst) || MRI.getRegBankOrNull(Dst);
+    if (!DstRC) {
+      if (Dst == Src) {
+        MI.eraseFromParent();
+        return true;
+      }
+
+      if (!DstConstrained) {
+        MRI.replaceRegWith(Dst, Src);
+      } else {
+        B.setInstr(MI);
+        Register CopySrc = Src;
+        if (isSGPR(Dst) && isVectorOnly(Src))
+          CopySrc = buildHandoffReadFirstLane(Src);
+        B.buildCopy(Dst, CopySrc);
+      }
+      MI.eraseFromParent();
+      return true;
+    }
+
+    Register HandoffDst = Dst;
+    if (DstConstrained) {
+      HandoffDst = MRI.createVirtualRegister(DstRC);
+      MRI.setType(HandoffDst, MRI.getType(Dst));
+    } else {
+      MRI.setRegClass(Dst, DstRC);
+    }
+
+    Register AVSrc = MRI.createVirtualRegister(&AMDGPU::AV_32RegClass);
+    MRI.setType(AVSrc, MRI.getType(Src));
+    B.setInstr(MI);
+    B.buildCopy(AVSrc, Src);
+    B.buildInstr(HandoffOpcode, {HandoffDst}, {AVSrc})
+        .setMIFlag(MachineInstr::NoMerge);
+    if (HandoffDst != Dst)
+      B.buildCopy(Dst, HandoffDst);
+    MI.eraseFromParent();
+    return true;
+  }
+
+  bool repairHandoffScalarCopy(MachineInstr &MI) {
+    if (!MI.isCopy() || !MI.getOperand(0).isReg() || !MI.getOperand(1).isReg())
+      return false;
+
+    Register Dst = MI.getOperand(0).getReg();
+    Register Src = MI.getOperand(1).getReg();
+    if (!Src.isVirtual())
+      return false;
+    MachineInstr *SrcDef = MRI.getVRegDef(Src);
+    if (!SrcDef || !SIInstrInfo::isRegAllocHandoff(SrcDef->getOpcode()))
+      return false;
+
+    if (!isSGPR(Dst))
+      return false;
+
+    B.setInstr(MI);
+    MI.getOperand(1).setReg(buildHandoffReadFirstLane(Src));
+    return true;
   }
 };
 
@@ -223,6 +358,25 @@ bool AMDGPURegBankSelect::runOnMachineFunction(MachineFunction &MF) {
   const GCNSubtarget &ST = MF.getSubtarget<GCNSubtarget>();
   RegBankSelectHelper RBSHelper(B, ILMA, MUI, *ST.getRegisterInfo(),
                                 *ST.getRegBankInfo());
+
+  // Lower all handoff markers before ordinary bank assignment. This makes the
+  // exact requested class visible even when a PHI or another use appears
+  // before its defining block in machine layout.
+  for (MachineBasicBlock &MBB : MF) {
+    for (MachineInstr &MI : make_early_inc_range(MBB)) {
+      if (MI.getOpcode() != AMDGPU::G_INTRINSIC_W_SIDE_EFFECTS ||
+          MI.getNumExplicitOperands() < 2 ||
+          !MI.getOperand(1).isIntrinsicID() ||
+          MI.getOperand(1).getIntrinsicID() !=
+              Intrinsic::experimental_regalloc_handoff)
+        continue;
+      if (!RBSHelper.lowerRegAllocHandoff(MI, ST.hasMAIInsts())) {
+        MF.getProperties().setFailedISel();
+        return true;
+      }
+    }
+  }
+
   // Virtual registers at this point don't have register banks.
   // Virtual registers in def and use operands of already inst-selected
   // instruction have register class.
@@ -232,11 +386,15 @@ bool AMDGPURegBankSelect::runOnMachineFunction(MachineFunction &MF) {
       // Vregs in def and use operands of COPY can have either register class
       // or bank. If there is neither on vreg in def operand, assign bank.
       if (MI.isCopy()) {
+        RBSHelper.repairHandoffScalarCopy(MI);
         Register DefReg = getVReg(MI.getOperand(0));
         if (!DefReg.isValid() || MRI.getRegClassOrNull(DefReg))
           continue;
 
-        assert(!MRI.getRegBankOrNull(DefReg));
+        // Scalar handoff repair can insert a banked copy in a predecessor that
+        // has not been visited yet.
+        if (MRI.getRegBankOrNull(DefReg))
+          continue;
         MRI.setRegBank(DefReg, *RBSHelper.getRegBankToAssign(DefReg));
         continue;
       }

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -1167,6 +1167,11 @@ SITargetLowering::SITargetLowering(const TargetMachine &TM,
 
 const GCNSubtarget *SITargetLowering::getSubtarget() const { return Subtarget; }
 
+bool SITargetLowering::supportsRegAllocHandoff(StringRef Constraint) const {
+  return Constraint == "amdgpu.vgpr" ||
+         (Constraint == "amdgpu.agpr" && Subtarget->hasMAIInsts());
+}
+
 ArrayRef<MCPhysReg> SITargetLowering::getRoundingControlRegisters() const {
   static const MCPhysReg RCRegs[] = {AMDGPU::MODE};
   return RCRegs;
@@ -20081,6 +20086,51 @@ void SITargetLowering::finalizeLowering(MachineFunction &MF) const {
     for (auto &MBB : MF) {
       for (auto &MI : MBB) {
         TII->fixImplicitOperands(MI);
+      }
+    }
+  }
+
+  for (MachineBasicBlock &MBB : MF) {
+    for (MachineInstr &MI : MBB) {
+      if (!SIInstrInfo::isRegAllocHandoff(MI.getOpcode()))
+        continue;
+
+      Register Dst = MI.getOperand(0).getReg();
+      if (!Dst.isVirtual())
+        continue;
+      Register PreferredSrc = MI.getOperand(1).getReg();
+      const TargetRegisterClass *DstRC = MRI.getRegClassOrNull(Dst);
+      // Standalone finalize-isel accepts non-SSA MIR. Keep the direct source
+      // hint instead of using the SSA-only getVRegDef in that case.
+      while (MRI.isSSA() && PreferredSrc.isVirtual()) {
+        MachineInstr *Def = MRI.getVRegDef(PreferredSrc);
+        if (!Def || !Def->isCopy() || Def->getOperand(0).getSubReg() ||
+            Def->getOperand(1).getSubReg())
+          break;
+
+        Register CopySrc = Def->getOperand(1).getReg();
+        if (CopySrc.isPhysical()) {
+          if (DstRC && DstRC->contains(CopySrc))
+            PreferredSrc = CopySrc;
+          break;
+        }
+
+        const TargetRegisterClass *CopySrcRC = MRI.getRegClassOrNull(CopySrc);
+        if (!DstRC || !CopySrcRC || !TRI->getCommonSubClass(DstRC, CopySrcRC))
+          break;
+        PreferredSrc = CopySrc;
+      }
+
+      MRI.setSimpleHint(Dst, PreferredSrc);
+      for (MachineOperand &Use : MRI.use_nodbg_operands(Dst)) {
+        MachineInstr *UseMI = Use.getParent();
+        if (!UseMI->isCopy() || &Use != &UseMI->getOperand(1) ||
+            !UseMI->getOperand(0).isReg() || UseMI->getOperand(0).getSubReg() ||
+            !UseMI->getOperand(1).isReg() || UseMI->getOperand(1).getSubReg())
+          continue;
+        Register CopyDst = UseMI->getOperand(0).getReg();
+        if (CopyDst.isVirtual())
+          MRI.setSimpleHint(CopyDst, PreferredSrc);
       }
     }
   }

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.h
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.h
@@ -330,6 +330,8 @@ private:
 public:
   SITargetLowering(const TargetMachine &tm, const GCNSubtarget &STI);
 
+  bool supportsRegAllocHandoff(StringRef Constraint) const override;
+
   const GCNSubtarget *getSubtarget() const;
 
   ArrayRef<MCPhysReg> getRoundingControlRegisters() const override;

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -2041,6 +2041,16 @@ bool SIInstrInfo::expandPostRAPseudo(MachineInstr &MI) const {
 
   switch (MI.getOpcode()) {
   default: return TargetInstrInfo::expandPostRAPseudo(MI);
+  case AMDGPU::REGALLOC_HANDOFF_VGPR:
+  case AMDGPU::REGALLOC_HANDOFF_AGPR:
+    assert(MI.getNumOperands() == 2 && MI.getOperand(0).isReg() &&
+           MI.getOperand(1).isReg());
+    if (MI.getOperand(0).getReg() == MI.getOperand(1).getReg()) {
+      MI.eraseFromParent();
+      return true;
+    }
+    MI.setDesc(get(TargetOpcode::COPY));
+    return false;
   case AMDGPU::S_MOV_B64_term:
     // This is only a terminator to get the correct spill code placement during
     // register allocation.
@@ -5244,6 +5254,10 @@ static Register findImplicitSGPRRead(const MachineInstr &MI) {
 }
 
 static bool shouldReadExec(const MachineInstr &MI) {
+  // This pseudo only guides register allocation; it is not lane-executed.
+  if (SIInstrInfo::isRegAllocHandoff(MI.getOpcode()))
+    return false;
+
   if (SIInstrInfo::isVALU(MI, /*AllowLDSDMA=*/true)) {
     switch (MI.getOpcode()) {
     case AMDGPU::V_READLANE_B32:

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -859,6 +859,11 @@ public:
            Opcode == AMDGPU::S_BARRIER_SIGNAL_ISFIRST_M0;
   }
 
+  static bool isRegAllocHandoff(unsigned Opcode) {
+    return Opcode == AMDGPU::REGALLOC_HANDOFF_VGPR ||
+           Opcode == AMDGPU::REGALLOC_HANDOFF_AGPR;
+  }
+
   static bool isCBranchVCCZRead(const MachineInstr &MI) {
     unsigned Opc = MI.getOpcode();
     return (Opc == AMDGPU::S_CBRANCH_VCCNZ || Opc == AMDGPU::S_CBRANCH_VCCZ) &&

--- a/llvm/lib/Target/AMDGPU/SIInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SIInstructions.td
@@ -224,6 +224,13 @@ def WWM_COPY : SPseudoInstSI <
   let isConvergent = 1;
 }
 
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0, Uses = []<Register> in {
+def REGALLOC_HANDOFF_VGPR
+    : PseudoInstSI<(outs VGPR_32:$dst), (ins AV_32:$src)>;
+def REGALLOC_HANDOFF_AGPR
+    : PseudoInstSI<(outs AGPR_32:$dst), (ins AV_32:$src)>;
+}
+
 def ENTER_STRICT_WWM : SPseudoInstSI <(outs SReg_1:$sdst), (ins i64imm:$src0)> {
   let Uses = [EXEC];
   let Defs = [EXEC, SCC];

--- a/llvm/lib/Target/AMDGPU/SIOptimizeExecMaskingPreRA.cpp
+++ b/llvm/lib/Target/AMDGPU/SIOptimizeExecMaskingPreRA.cpp
@@ -416,7 +416,8 @@ bool SIOptimizeExecMaskingPreRA::run(MachineFunction &MF) {
           }
 
           if (I->mayStore() || I->isBarrier() || I->isCall() ||
-              I->hasUnmodeledSideEffects() || I->hasOrderedMemoryRef())
+              I->hasUnmodeledSideEffects() || I->hasOrderedMemoryRef() ||
+              I->getFlag(MachineInstr::NoMerge))
             break;
 
           LLVM_DEBUG(dbgs()

--- a/llvm/test/Assembler/experimental-regalloc-handoff.ll
+++ b/llvm/test/Assembler/experimental-regalloc-handoff.ll
@@ -1,0 +1,13 @@
+; RUN: llvm-as %s -o - | llvm-dis -o - | FileCheck %s
+
+define i32 @identity_i32(i32 %x) {
+  %y = call i32 @llvm.experimental.regalloc.handoff(i32 %x, metadata !0)
+  ret i32 %y
+}
+
+declare i32 @llvm.experimental.regalloc.handoff(i32, metadata)
+
+; CHECK: declare i32 @llvm.experimental.regalloc.handoff(i32, metadata) #[[ATTR:[0-9]+]]
+; CHECK: {{^}}attributes #[[ATTR]] = { nocallback nocreateundeforpoison nofree nomerge nosync nounwind willreturn memory(inaccessiblemem: readwrite) }{{$}}
+
+!0 = !{!"amdgpu.vgpr"}

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/regalloc-handoff-regbankselect.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/regalloc-handoff-regbankselect.mir
@@ -1,0 +1,270 @@
+# RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 \
+# RUN:   -run-pass=amdgpu-reg-bank-select -verify-machineinstrs -o - %s \
+# RUN:   | FileCheck %s
+# RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 \
+# RUN:   -run-pass=amdgpu-reg-bank-select -verify-machineinstrs -o - %s \
+# RUN:   | FileCheck %s --check-prefix=GFX9
+# RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 \
+# RUN:   -run-pass=none -verify-machineinstrs -o /dev/null %s
+# RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 \
+# RUN:   -run-pass=none -verify-machineinstrs -o /dev/null %s
+
+--- |
+  declare i32 @llvm.experimental.regalloc.handoff(i32, metadata)
+
+  define amdgpu_kernel void @vgpr() { ret void }
+  define amdgpu_kernel void @agpr() { ret void }
+  define amdgpu_kernel void @vgpr_to_sgpr() { ret void }
+  define amdgpu_kernel void @agpr_to_sgpr() { ret void }
+  define amdgpu_kernel void @vgpr_uniform_consumer() { ret void }
+  define amdgpu_kernel void @agpr_uniform_consumer() { ret void }
+  define amdgpu_kernel void @gfx900_agpr_identity() { ret void }
+  define amdgpu_kernel void @vgpr_phi_forward() { ret void }
+  define amdgpu_kernel void @agpr_phi_forward() { ret void }
+  define amdgpu_kernel void @phi_backedge() { ret void }
+  define amdgpu_kernel void @classed_vgpr_copy() { ret void }
+  define amdgpu_kernel void @preclassed_agpr_to_sgpr() { ret void }
+
+  !0 = !{!"amdgpu.vgpr"}
+  !1 = !{!"amdgpu.agpr"}
+...
+---
+name: vgpr
+legalized: true
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vgpr
+    ; CHECK: [[SRC:%[0-9]+]]:av_32(s32) = COPY
+    ; CHECK-NEXT: [[DST:%[0-9]+]]:vgpr_32(s32) = nomerge REGALLOC_HANDOFF_VGPR [[SRC]]
+    %0:_(s32) = G_IMPLICIT_DEF
+    %1:_(s32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.experimental.regalloc.handoff), %0, !0
+    S_ENDPGM 0
+...
+---
+name: agpr
+legalized: true
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: agpr
+    ; CHECK: [[SRC:%[0-9]+]]:av_32(s32) = COPY
+    ; CHECK-NEXT: [[DST:%[0-9]+]]:agpr_32(s32) = nomerge REGALLOC_HANDOFF_AGPR [[SRC]]
+    %0:_(s32) = G_IMPLICIT_DEF
+    %1:_(s32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.experimental.regalloc.handoff), %0, !1
+    S_ENDPGM 0
+...
+---
+name: vgpr_to_sgpr
+legalized: true
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vgpr_to_sgpr
+    ; CHECK: [[SRC:%[0-9]+]]:av_32(s32) = COPY
+    ; CHECK-NEXT: [[DST:%[0-9]+]]:vgpr_32(s32) = nomerge REGALLOC_HANDOFF_VGPR [[SRC]]
+    ; CHECK-NEXT: [[VECTOR:%[0-9]+]]:vgpr_32(s32) = COPY [[DST]](s32)
+    ; CHECK-NEXT: [[SCALAR:%[0-9]+]]:sreg_32_xm0(s32) = V_READFIRSTLANE_B32 [[VECTOR]](s32), implicit $exec
+    ; CHECK-NEXT: $sgpr1 = COPY [[SCALAR]](s32)
+    %0:_(s32) = G_IMPLICIT_DEF
+    %1:_(s32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.experimental.regalloc.handoff), %0, !0
+    $sgpr1 = COPY %1
+    S_ENDPGM 0, implicit $sgpr1
+...
+---
+name: agpr_to_sgpr
+legalized: true
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: agpr_to_sgpr
+    ; CHECK: [[SRC:%[0-9]+]]:av_32(s32) = COPY
+    ; CHECK-NEXT: [[DST:%[0-9]+]]:agpr_32(s32) = nomerge REGALLOC_HANDOFF_AGPR [[SRC]]
+    ; CHECK-NEXT: [[VECTOR:%[0-9]+]]:vgpr_32(s32) = COPY [[DST]](s32)
+    ; CHECK-NEXT: [[SCALAR:%[0-9]+]]:sreg_32_xm0(s32) = V_READFIRSTLANE_B32 [[VECTOR]](s32), implicit $exec
+    ; CHECK-NEXT: $sgpr1 = COPY [[SCALAR]](s32)
+    %0:_(s32) = G_IMPLICIT_DEF
+    %1:_(s32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.experimental.regalloc.handoff), %0, !1
+    $sgpr1 = COPY %1
+    S_ENDPGM 0, implicit $sgpr1
+...
+---
+name: vgpr_uniform_consumer
+legalized: true
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vgpr_uniform_consumer
+    ; CHECK: [[HANDOFF:%[0-9]+]]:vgpr_32(s32) = nomerge REGALLOC_HANDOFF_VGPR
+    ; CHECK: G_CONSTANT i32 1
+    ; CHECK-NEXT: [[VECTOR:%[0-9]+]]:vgpr_32(s32) = COPY [[HANDOFF]](s32)
+    ; CHECK-NEXT: [[SCALAR:%[0-9]+]]:sreg_32_xm0(s32) = V_READFIRSTLANE_B32 [[VECTOR]](s32), implicit $exec
+    ; CHECK-NEXT: [[BANK:%[0-9]+]]:sgpr(s32) = COPY [[SCALAR]](s32)
+    ; CHECK: [[SUM:%[0-9]+]]:sgpr(s32) = G_ADD [[BANK]],
+    %0:_(s32) = G_IMPLICIT_DEF
+    %1:_(s32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.experimental.regalloc.handoff), %0, !0
+    %2:_(s32) = G_CONSTANT i32 1
+    %3:_(s32) = G_ADD %1, %2
+    $sgpr1 = COPY %3
+    S_ENDPGM 0, implicit $sgpr1
+...
+---
+name: agpr_uniform_consumer
+legalized: true
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: agpr_uniform_consumer
+    ; CHECK: [[HANDOFF:%[0-9]+]]:agpr_32(s32) = nomerge REGALLOC_HANDOFF_AGPR
+    ; CHECK: G_CONSTANT i32 1
+    ; CHECK-NEXT: [[VECTOR:%[0-9]+]]:vgpr_32(s32) = COPY [[HANDOFF]](s32)
+    ; CHECK-NEXT: [[SCALAR:%[0-9]+]]:sreg_32_xm0(s32) = V_READFIRSTLANE_B32 [[VECTOR]](s32), implicit $exec
+    ; CHECK-NEXT: [[BANK:%[0-9]+]]:sgpr(s32) = COPY [[SCALAR]](s32)
+    ; CHECK: [[SUM:%[0-9]+]]:sgpr(s32) = G_ADD [[BANK]],
+    %0:_(s32) = G_IMPLICIT_DEF
+    %1:_(s32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.experimental.regalloc.handoff), %0, !1
+    %2:_(s32) = G_CONSTANT i32 1
+    %3:_(s32) = G_ADD %1, %2
+    $sgpr1 = COPY %3
+    S_ENDPGM 0, implicit $sgpr1
+...
+---
+name: gfx900_agpr_identity
+legalized: true
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: gfx900_agpr_identity
+    ; CHECK: [[SRC:%[0-9]+]]:av_32(s32) = COPY
+    ; CHECK-NEXT: [[HANDOFF:%[0-9]+]]:agpr_32(s32) = nomerge REGALLOC_HANDOFF_AGPR [[SRC]]
+    ; GFX9-LABEL: name: gfx900_agpr_identity
+    ; GFX9-NOT: agpr_32
+    ; GFX9: [[SRC:%[0-9]+]]:sgpr(s32) = G_IMPLICIT_DEF
+    ; GFX9-NOT: REGALLOC_HANDOFF_
+    ; GFX9: $sgpr1 = COPY [[SRC]](s32)
+    %0:_(s32) = G_IMPLICIT_DEF
+    %1:_(s32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.experimental.regalloc.handoff), %0, !1
+    $sgpr1 = COPY %1
+    S_ENDPGM 0, implicit $sgpr1
+...
+---
+name: vgpr_phi_forward
+legalized: true
+tracksRegLiveness: true
+body: |
+  bb.0:
+    successors: %bb.1
+    ; CHECK-LABEL: name: vgpr_phi_forward
+    ; CHECK: bb.0:
+    ; CHECK: [[HANDOFF:%[0-9]+]]:vgpr_32(s32) = nomerge REGALLOC_HANDOFF_VGPR
+    ; CHECK-NEXT: [[VECTOR:%[0-9]+]]:vgpr_32(s32) = COPY [[HANDOFF]](s32)
+    ; CHECK-NEXT: [[SCALAR:%[0-9]+]]:sreg_32_xm0(s32) = V_READFIRSTLANE_B32 [[VECTOR]](s32), implicit $exec
+    ; CHECK-NEXT: [[BANK:%[0-9]+]]:sgpr(s32) = COPY [[SCALAR]](s32)
+    %0:_(s32) = G_IMPLICIT_DEF
+    %1:_(s32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.experimental.regalloc.handoff), %0, !0
+    S_BRANCH %bb.1
+
+  bb.1:
+    ; CHECK: bb.1:
+    ; CHECK: %{{[0-9]+}}:sgpr(s32) = G_PHI [[BANK]](s32), %bb.0
+    %2:_(s32) = G_PHI %1, %bb.0
+    $sgpr1 = COPY %2
+    S_ENDPGM 0, implicit $sgpr1
+...
+---
+name: agpr_phi_forward
+legalized: true
+tracksRegLiveness: true
+body: |
+  bb.0:
+    successors: %bb.1
+    ; CHECK-LABEL: name: agpr_phi_forward
+    ; CHECK: bb.0:
+    ; CHECK: [[HANDOFF:%[0-9]+]]:agpr_32(s32) = nomerge REGALLOC_HANDOFF_AGPR
+    ; CHECK-NEXT: [[VECTOR:%[0-9]+]]:vgpr_32(s32) = COPY [[HANDOFF]](s32)
+    ; CHECK-NEXT: [[SCALAR:%[0-9]+]]:sreg_32_xm0(s32) = V_READFIRSTLANE_B32 [[VECTOR]](s32), implicit $exec
+    ; CHECK-NEXT: [[BANK:%[0-9]+]]:sgpr(s32) = COPY [[SCALAR]](s32)
+    %0:_(s32) = G_IMPLICIT_DEF
+    %1:_(s32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.experimental.regalloc.handoff), %0, !1
+    S_BRANCH %bb.1
+
+  bb.1:
+    ; CHECK: bb.1:
+    ; CHECK: %{{[0-9]+}}:sgpr(s32) = G_PHI [[BANK]](s32), %bb.0
+    %2:_(s32) = G_PHI %1, %bb.0
+    $sgpr1 = COPY %2
+    S_ENDPGM 0, implicit $sgpr1
+...
+---
+name: phi_backedge
+legalized: true
+tracksRegLiveness: true
+body: |
+  ; The PHI use precedes the handoff definition in layout and consumes it on a
+  ; backedge. Preselection must lower every marker before ordinary bank repair.
+  bb.0:
+    successors: %bb.1
+    %0:_(s32) = G_IMPLICIT_DEF
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.2
+    ; CHECK-LABEL: name: phi_backedge
+    ; CHECK: bb.1:
+    ; CHECK: %{{[0-9]+}}:{{[a-z0-9_]+}}(s32) = G_PHI %0(s32), %bb.0, [[BACK:%[0-9]+]](s32), %bb.2
+    %1:_(s32) = G_PHI %0, %bb.0, %2, %bb.2
+    S_BRANCH %bb.2
+
+  bb.2:
+    successors: %bb.1
+    ; CHECK: [[AV:%[0-9]+]]:av_32(s32) = COPY
+    ; CHECK-NEXT: [[HANDOFF:%[0-9]+]]:vgpr_32(s32) = nomerge REGALLOC_HANDOFF_VGPR [[AV]]
+    ; CHECK-NEXT: [[VECTOR:%[0-9]+]]:vgpr_32(s32) = COPY [[HANDOFF]](s32)
+    ; CHECK-NEXT: [[SCALAR:%[0-9]+]]:sreg_32_xm0(s32) = V_READFIRSTLANE_B32 [[VECTOR]](s32), implicit $exec
+    ; CHECK-NEXT: [[BACK]]:sgpr(s32) = COPY [[SCALAR]](s32)
+    %2:_(s32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.experimental.regalloc.handoff), %1, !0
+    S_BRANCH %bb.1
+...
+---
+name: classed_vgpr_copy
+legalized: true
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; A uniform destination already constrained to a vector class must not be
+    ; mistaken for an unassigned scalar copy.
+    ; CHECK-LABEL: name: classed_vgpr_copy
+    ; CHECK: [[HANDOFF:%[0-9]+]]:vgpr_32(s32) = nomerge REGALLOC_HANDOFF_VGPR
+    ; CHECK-NEXT: [[DST:%[0-9]+]]:vgpr_32(s32) = COPY [[HANDOFF]](s32)
+    ; CHECK-NOT: V_READFIRSTLANE_B32
+    ; CHECK: S_ENDPGM 0, implicit [[DST]]
+    %0:_(s32) = G_IMPLICIT_DEF
+    %1:_(s32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.experimental.regalloc.handoff), %0, !0
+    %2:vgpr_32(s32) = COPY %1
+    S_ENDPGM 0, implicit %2
+...
+---
+name: preclassed_agpr_to_sgpr
+legalized: true
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $vgpr0
+    ; CHECK-LABEL: name: preclassed_agpr_to_sgpr
+    ; CHECK: [[AV:%[0-9]+]]:av_32(s32) = COPY
+    ; CHECK-NEXT: [[HANDOFF:%[0-9]+]]:agpr_32(s32) = nomerge REGALLOC_HANDOFF_AGPR [[AV]]
+    ; CHECK-NEXT: [[VECTOR:%[0-9]+]]:vgpr_32(s32) = COPY [[HANDOFF]](s32)
+    ; CHECK-NEXT: [[SCALAR:%[0-9]+]]:sreg_32_xm0(s32) = V_READFIRSTLANE_B32 [[VECTOR]](s32), implicit $exec
+    ; CHECK-NEXT: [[DST:%[0-9]+]]:sreg_32(s32) = COPY [[SCALAR]](s32)
+    ; CHECK-NEXT: [[SUM:%[0-9]+]]:sreg_32 = S_ADD_U32 [[DST]](s32), [[DST]](s32), implicit-def $scc
+    ; GFX9-LABEL: name: preclassed_agpr_to_sgpr
+    ; GFX9-NOT: REGALLOC_HANDOFF_
+    ; GFX9: [[VECTOR:%[0-9]+]]:vgpr_32(s32) = COPY %{{[0-9]+}}(s32)
+    ; GFX9-NEXT: [[SCALAR:%[0-9]+]]:sreg_32_xm0(s32) = V_READFIRSTLANE_B32 [[VECTOR]](s32), implicit $exec
+    ; GFX9-NEXT: [[DST:%[0-9]+]]:sreg_32(s32) = COPY [[SCALAR]](s32)
+    ; GFX9-NEXT: [[SUM:%[0-9]+]]:sreg_32 = S_ADD_U32 [[DST]](s32), [[DST]](s32), implicit-def $scc
+    %0:vgpr_32(s32) = COPY $vgpr0, implicit $exec
+    %1:sreg_32(s32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.experimental.regalloc.handoff), %0, !1
+    %2:sreg_32 = S_ADD_U32 %1, %1, implicit-def $scc
+    S_ENDPGM 0, implicit %2
+...

--- a/llvm/test/CodeGen/AMDGPU/experimental-regalloc-handoff.ll
+++ b/llvm/test/CodeGen/AMDGPU/experimental-regalloc-handoff.ll
@@ -1,0 +1,157 @@
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -stop-after=finalize-isel \
+; RUN:   -verify-machineinstrs -o - %s | FileCheck %s --check-prefix=DAG
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -stop-after=finalize-isel \
+; RUN:   -verify-machineinstrs -o - %s | FileCheck %s --check-prefix=GFX9
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -global-isel \
+; RUN:   -global-isel-abort=1 -stop-after=irtranslator -o - %s \
+; RUN:   | FileCheck %s --check-prefix=GISEL-IR
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -global-isel \
+; RUN:   -global-isel-abort=1 -stop-after=amdgpu-reg-bank-select \
+; RUN:   -verify-machineinstrs -o - %s | FileCheck %s --check-prefix=GISEL-RBS
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -O0 -global-isel \
+; RUN:   -global-isel-abort=1 -verify-machineinstrs -o - %s \
+; RUN:   | FileCheck %s --check-prefix=FULL
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -O2 -global-isel \
+; RUN:   -global-isel-abort=1 -verify-machineinstrs -o - %s \
+; RUN:   | FileCheck %s --check-prefix=FULL
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -O0 \
+; RUN:   -verify-machineinstrs -o - %s | FileCheck %s --check-prefix=FULL
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -O2 \
+; RUN:   -verify-machineinstrs -o - %s | FileCheck %s --check-prefix=FULL
+
+declare i32 @llvm.amdgcn.workitem.id.x()
+declare i32 @llvm.experimental.regalloc.handoff(i32, metadata)
+
+define amdgpu_kernel void @handoff_vgpr(ptr addrspace(1) %out) {
+; DAG-LABEL: name: handoff_vgpr
+; DAG: [[SRC:%[0-9]+]]:av_32 = COPY
+; DAG-NEXT: [[HANDOFF:%[0-9]+]]:vgpr_32 = nomerge REGALLOC_HANDOFF_VGPR {{(killed )?}}[[SRC]]
+;
+; GISEL-IR-LABEL: name: handoff_vgpr
+; GISEL-IR: %{{[0-9]+}}:_(i32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.experimental.regalloc.handoff), %{{[0-9]+}}(i32), !{{[0-9]+}}
+;
+; GISEL-RBS-LABEL: name: handoff_vgpr
+; GISEL-RBS: [[GSRC:%[0-9]+]]:av_32{{\((s32|i32)\)}} = COPY
+; GISEL-RBS-NEXT: [[GHANDOFF:%[0-9]+]]:vgpr_32{{\((s32|i32)\)}} = nomerge REGALLOC_HANDOFF_VGPR [[GSRC]]
+  %src = call i32 @llvm.amdgcn.workitem.id.x()
+  %dst = call i32 @llvm.experimental.regalloc.handoff(
+      i32 %src, metadata !0)
+  store i32 %dst, ptr addrspace(1) %out
+  ret void
+}
+
+define amdgpu_kernel void @handoff_agpr(ptr addrspace(1) %out) {
+; DAG-LABEL: name: handoff_agpr
+; DAG: [[SRC:%[0-9]+]]:av_32 = COPY
+; DAG-NEXT: [[HANDOFF:%[0-9]+]]:agpr_32 = nomerge REGALLOC_HANDOFF_AGPR {{(killed )?}}[[SRC]]
+;
+; GISEL-IR-LABEL: name: handoff_agpr
+; GISEL-IR: %{{[0-9]+}}:_(i32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.experimental.regalloc.handoff), %{{[0-9]+}}(i32), !{{[0-9]+}}
+;
+; GISEL-RBS-LABEL: name: handoff_agpr
+; GISEL-RBS: [[GSRC:%[0-9]+]]:av_32{{\((s32|i32)\)}} = COPY
+; GISEL-RBS-NEXT: [[GHANDOFF:%[0-9]+]]:agpr_32{{\((s32|i32)\)}} = nomerge REGALLOC_HANDOFF_AGPR [[GSRC]]
+;
+; GFX9-LABEL: name: handoff_agpr
+; GFX9-NOT: REGALLOC_HANDOFF_
+; GFX9: S_ENDPGM
+  %src = call i32 @llvm.amdgcn.workitem.id.x()
+  %dst = call i32 @llvm.experimental.regalloc.handoff(
+      i32 %src, metadata !1)
+  store i32 %dst, ptr addrspace(1) %out
+  ret void
+}
+
+define amdgpu_kernel void @uniform_vgpr(i32 %src) {
+; DAG-LABEL: name: uniform_vgpr
+; DAG: [[SRC:%[0-9]+]]:av_32 = COPY
+; DAG-NEXT: [[HANDOFF:%[0-9]+]]:vgpr_32 = nomerge REGALLOC_HANDOFF_VGPR {{(killed )?}}[[SRC]]
+; DAG-NEXT: [[SCALAR:%[0-9]+]]:sreg_32_xm0 = V_READFIRSTLANE_B32 {{(killed )?}}[[HANDOFF]], implicit $exec
+;
+; FULL-LABEL: uniform_vgpr:
+; FULL: s_endpgm
+  %dst = call i32 @llvm.experimental.regalloc.handoff(
+      i32 %src, metadata !0)
+  call void asm sideeffect "; use $0", "s"(i32 %dst)
+  ret void
+}
+
+define amdgpu_kernel void @uniform_agpr(i32 %src) {
+; DAG-LABEL: name: uniform_agpr
+; DAG: [[SRC:%[0-9]+]]:av_32 = COPY
+; DAG-NEXT: [[HANDOFF:%[0-9]+]]:agpr_32 = nomerge REGALLOC_HANDOFF_AGPR {{(killed )?}}[[SRC]]
+; DAG-NEXT: [[VECTOR:%[0-9]+]]:vgpr_32 = COPY {{(killed )?}}[[HANDOFF]]
+; DAG-NEXT: [[SCALAR:%[0-9]+]]:sreg_32_xm0 = V_READFIRSTLANE_B32 {{(killed )?}}[[VECTOR]], implicit $exec
+;
+; FULL-LABEL: uniform_agpr:
+; FULL: s_endpgm
+  %dst = call i32 @llvm.experimental.regalloc.handoff(
+      i32 %src, metadata !1)
+  call void asm sideeffect "; use $0", "s"(i32 %dst)
+  ret void
+}
+
+define amdgpu_kernel void @uniform_consumer_vgpr(i32 %src) {
+; FULL-LABEL: uniform_consumer_vgpr:
+; FULL: s_endpgm
+  %dst = call i32 @llvm.experimental.regalloc.handoff(
+      i32 %src, metadata !0)
+  %sum = add i32 %dst, 1
+  call void asm sideeffect "; use $0", "s"(i32 %sum)
+  ret void
+}
+
+define amdgpu_kernel void @uniform_consumer_agpr(i32 %src) {
+; FULL-LABEL: uniform_consumer_agpr:
+; FULL: s_endpgm
+  %dst = call i32 @llvm.experimental.regalloc.handoff(
+      i32 %src, metadata !1)
+  %sum = add i32 %dst, 1
+  call void asm sideeffect "; use $0", "s"(i32 %sum)
+  ret void
+}
+
+define amdgpu_kernel void @phi_forward_vgpr(i32 %src, i32 %cond) {
+; FULL-LABEL: phi_forward_vgpr:
+; FULL: s_endpgm
+entry:
+  %dst = call i32 @llvm.experimental.regalloc.handoff(
+      i32 %src, metadata !0)
+  %cmp = icmp ne i32 %cond, 0
+  br i1 %cmp, label %left, label %right
+
+left:
+  br label %merge
+
+right:
+  br label %merge
+
+merge:
+  %value = phi i32 [ %dst, %left ], [ 0, %right ]
+  call void asm sideeffect "; use $0", "s"(i32 %value)
+  ret void
+}
+
+define amdgpu_kernel void @phi_forward_agpr(i32 %src, i32 %cond) {
+; FULL-LABEL: phi_forward_agpr:
+; FULL: s_endpgm
+entry:
+  %dst = call i32 @llvm.experimental.regalloc.handoff(
+      i32 %src, metadata !1)
+  %cmp = icmp ne i32 %cond, 0
+  br i1 %cmp, label %left, label %right
+
+left:
+  br label %merge
+
+right:
+  br label %merge
+
+merge:
+  %value = phi i32 [ %dst, %left ], [ 0, %right ]
+  call void asm sideeffect "; use $0", "s"(i32 %value)
+  ret void
+}
+
+!0 = !{!"amdgpu.vgpr"}
+!1 = !{!"amdgpu.agpr"}

--- a/llvm/test/CodeGen/AMDGPU/regalloc-handoff-affinity.mir
+++ b/llvm/test/CodeGen/AMDGPU/regalloc-handoff-affinity.mir
@@ -1,0 +1,66 @@
+# RUN: split-file %s %t
+# RUN: llc -mtriple=amdgpu9.50-amd-amdhsa -run-pass=finalize-isel \
+# RUN:   -verify-machineinstrs %t/ssa.mir -o - \
+# RUN:   | FileCheck %s --check-prefix=SSA
+# RUN: llc -mtriple=amdgpu9.50-amd-amdhsa -run-pass=finalize-isel \
+# RUN:   -verify-machineinstrs %t/nonssa.mir -o - \
+# RUN:   | FileCheck %s --check-prefix=NONSSA
+# RUN: llc -mtriple=amdgpu9.50-amd-amdhsa -run-pass=finalize-isel \
+# RUN:   -verify-machineinstrs %t/physical.mir -o - \
+# RUN:   | FileCheck %s --check-prefix=PHYS
+
+#--- ssa.mir
+---
+name: copy_chain
+registers:
+  - { id: 0, class: vgpr_32, preferred-register: '' }
+  - { id: 1, class: av_32, preferred-register: '' }
+  - { id: 2, class: vgpr_32, preferred-register: '' }
+  - { id: 3, class: vgpr_32, preferred-register: '' }
+body: |
+  bb.0:
+    ; The source class copy is transparent to the hint, and the result class
+    ; copy inherits that same preference.
+    ; SSA-LABEL: name: copy_chain
+    ; SSA: - { id: 2, class: vgpr_32, preferred-register: '%0'
+    ; SSA-NEXT: - { id: 3, class: vgpr_32, preferred-register: '%0'
+    ; SSA: %2:vgpr_32 = REGALLOC_HANDOFF_VGPR %1
+    ; SSA-NEXT: %3:vgpr_32 = COPY %2
+    %0:vgpr_32 = IMPLICIT_DEF
+    %1:av_32 = COPY %0
+    %2:vgpr_32 = REGALLOC_HANDOFF_VGPR %1
+    %3:vgpr_32 = COPY %2
+    S_ENDPGM 0, implicit %3
+...
+
+#--- nonssa.mir
+---
+name: nonssa
+isSSA: false
+registers:
+  - { id: 0, class: av_32, preferred-register: '' }
+  - { id: 1, class: agpr_32, preferred-register: '' }
+body: |
+  bb.0:
+    ; NONSSA-LABEL: name: nonssa
+    ; NONSSA: - { id: 1, class: agpr_32, preferred-register: '%0'
+    ; NONSSA: %1:agpr_32 = REGALLOC_HANDOFF_AGPR %0
+    %0:av_32 = IMPLICIT_DEF
+    %0:av_32 = IMPLICIT_DEF
+    %1:agpr_32 = REGALLOC_HANDOFF_AGPR %0
+    S_ENDPGM 0, implicit %1
+...
+
+#--- physical.mir
+---
+name: physical_destination
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $vgpr0
+    ; PHYS-LABEL: name: physical_destination
+    ; PHYS: $vgpr1 = REGALLOC_HANDOFF_VGPR $vgpr0
+    ; PHYS-NEXT: S_ENDPGM 0, implicit $vgpr1
+    $vgpr1 = REGALLOC_HANDOFF_VGPR $vgpr0
+    S_ENDPGM 0, implicit $vgpr1
+...

--- a/llvm/test/CodeGen/AMDGPU/regalloc-handoff-load-store-opt.mir
+++ b/llvm/test/CodeGen/AMDGPU/regalloc-handoff-load-store-opt.mir
@@ -1,0 +1,26 @@
+# RUN: llc -mtriple=amdgpu9.0a-amd-amdhsa \
+# RUN:   -run-pass=si-load-store-opt -verify-machineinstrs -o - %s \
+# RUN:   | FileCheck %s
+
+---
+name: handoff_does_not_block_global_load_merge
+tracksRegLiveness: true
+selected: true
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: handoff_does_not_block_global_load_merge
+    ; CHECK: [[ADDR:%[0-9]+]]:vreg_64_align2 = IMPLICIT_DEF
+    ; CHECK-NEXT: [[SRC:%[0-9]+]]:av_32 = IMPLICIT_DEF
+    ; CHECK-NEXT: [[WIDE:%[0-9]+]]:vreg_64_align2 = GLOBAL_LOAD_DWORDX2 [[ADDR]], 0, 0, implicit $exec
+    ; CHECK-NEXT: [[LO:%[0-9]+]]:vgpr_32 = COPY [[WIDE]].sub0
+    ; CHECK-NEXT: [[HI:%[0-9]+]]:vgpr_32 = COPY killed [[WIDE]].sub1
+    ; CHECK-NEXT: [[HANDOFF:%[0-9]+]]:vgpr_32 = nomerge REGALLOC_HANDOFF_VGPR [[SRC]]
+    ; CHECK-NEXT: S_NOP 0, implicit [[LO]], implicit [[HANDOFF]], implicit [[HI]]
+
+    %0:vreg_64_align2 = IMPLICIT_DEF
+    %1:av_32 = IMPLICIT_DEF
+    %2:vgpr_32 = GLOBAL_LOAD_DWORD %0, 0, 0, implicit $exec :: (load (s32) from `ptr addrspace(1) poison`, align 4, addrspace 1)
+    %3:vgpr_32 = nomerge REGALLOC_HANDOFF_VGPR %1
+    %4:vgpr_32 = GLOBAL_LOAD_DWORD %0, 4, 0, implicit $exec :: (load (s32) from `ptr addrspace(1) poison` + 4, align 4, addrspace 1)
+    S_NOP 0, implicit %2, implicit %3, implicit %4
+...

--- a/llvm/test/CodeGen/AMDGPU/regalloc-handoff-machine-cp.mir
+++ b/llvm/test/CodeGen/AMDGPU/regalloc-handoff-machine-cp.mir
@@ -1,0 +1,26 @@
+# RUN: llc -mtriple=amdgpu9.08-amd-amdhsa -run-pass=machine-cp \
+# RUN:   -verify-machineinstrs -o - %s | FileCheck %s
+
+--- |
+  define amdgpu_kernel void @preserve_requested_banks() { ret void }
+...
+---
+name: preserve_requested_banks
+tracksRegLiveness: true
+selected: true
+noVRegs: true
+body: |
+  bb.0:
+    liveins: $vgpr0, $agpr1
+    ; CHECK-LABEL: name: preserve_requested_banks
+    ; CHECK: renamable $agpr0 = REGALLOC_HANDOFF_AGPR renamable $vgpr0
+    ; CHECK-NEXT: renamable $vgpr1 = COPY killed renamable $agpr0
+    ; CHECK-NEXT: renamable $vgpr2 = REGALLOC_HANDOFF_VGPR renamable $agpr1
+    ; CHECK-NEXT: renamable $agpr2 = COPY killed renamable $vgpr2
+    ; CHECK-NEXT: S_ENDPGM 0, implicit $vgpr1, implicit $agpr2
+    renamable $agpr0 = REGALLOC_HANDOFF_AGPR renamable $vgpr0
+    renamable $vgpr1 = COPY killed renamable $agpr0
+    renamable $vgpr2 = REGALLOC_HANDOFF_VGPR renamable $agpr1
+    renamable $agpr2 = COPY killed renamable $vgpr2
+    S_ENDPGM 0, implicit $vgpr1, implicit $agpr2
+...

--- a/llvm/test/CodeGen/AMDGPU/regalloc-handoff-nomerge.ll
+++ b/llvm/test/CodeGen/AMDGPU/regalloc-handoff-nomerge.ll
@@ -1,0 +1,83 @@
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -O2 \
+; RUN:   -stop-after=machine-cse -o - %s | FileCheck %s --check-prefix=CSE
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -O2 \
+; RUN:   -stop-after=early-machinelicm -o - %s | FileCheck %s --check-prefix=LICM
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -O2 \
+; RUN:   -stop-after=register-coalescer -o - %s | FileCheck %s --check-prefix=COALESCE
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -O2 \
+; RUN:   -stop-after=dead-mi-elimination -o - %s | FileCheck %s --check-prefix=DCE
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -O2 -global-isel=1 \
+; RUN:   -global-isel-abort=1 -stop-after=dead-mi-elimination -o - %s \
+; RUN:   | FileCheck %s --check-prefix=DCE
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -O2 \
+; RUN:   -stop-after=si-optimize-exec-masking-pre-ra -o - %s \
+; RUN:   | FileCheck %s --check-prefix=PRERA
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -O2 -global-isel=1 \
+; RUN:   -global-isel-abort=1 -stop-after=si-optimize-exec-masking-pre-ra \
+; RUN:   -o - %s | FileCheck %s --check-prefix=PRERA
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -O0 \
+; RUN:   -stop-after=finalize-isel -o - %s \
+; RUN:   | llc -x=mir -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 \
+; RUN:       -run-pass=machine-cse -verify-machineinstrs -o /dev/null -
+
+define amdgpu_kernel void @preserve_two_handoffs(ptr addrspace(1) %out,
+                                                  i32 %value) {
+; CSE-LABEL: name: preserve_two_handoffs
+; CSE: nomerge REGALLOC_HANDOFF_VGPR
+; CSE: nomerge REGALLOC_HANDOFF_VGPR
+; COALESCE-LABEL: name: preserve_two_handoffs
+; COALESCE: nomerge REGALLOC_HANDOFF_VGPR
+; COALESCE: nomerge REGALLOC_HANDOFF_VGPR
+  %first = call i32 @llvm.experimental.regalloc.handoff(
+      i32 %value, metadata !0)
+  %second = call i32 @llvm.experimental.regalloc.handoff(
+      i32 %value, metadata !0)
+  store volatile i32 %first, ptr addrspace(1) %out
+  %next = getelementptr i32, ptr addrspace(1) %out, i32 1
+  store volatile i32 %second, ptr addrspace(1) %next
+  ret void
+}
+
+define amdgpu_kernel void @preserve_loop_handoffs(ptr addrspace(1) %out,
+                                                   i32 %value, i32 %count) {
+; CSE-LABEL: name: preserve_loop_handoffs
+; COALESCE-LABEL: name: preserve_loop_handoffs
+; LICM-LABEL: name: preserve_loop_handoffs
+; LICM-NOT: REGALLOC_HANDOFF_
+; LICM: bb.3.loop:
+; LICM: nomerge REGALLOC_HANDOFF_VGPR
+; LICM: nomerge REGALLOC_HANDOFF_VGPR
+entry:
+  %positive = icmp sgt i32 %count, 0
+  br i1 %positive, label %loop, label %exit
+
+loop:
+  %i = phi i32 [ 0, %entry ], [ %next, %loop ]
+  %first = call i32 @llvm.experimental.regalloc.handoff(
+      i32 %value, metadata !0)
+  %second = call i32 @llvm.experimental.regalloc.handoff(
+      i32 %value, metadata !0)
+  %sum = add i32 %first, %second
+  %ptr = getelementptr i32, ptr addrspace(1) %out, i32 %i
+  store volatile i32 %sum, ptr addrspace(1) %ptr
+  %next = add nuw nsw i32 %i, 1
+  %done = icmp eq i32 %next, %count
+  br i1 %done, label %exit, label %loop
+
+exit:
+  ret void
+}
+
+define amdgpu_kernel void @preserve_unused_handoff(i32 %value) {
+; DCE-LABEL: name: preserve_unused_handoff
+; DCE: nomerge REGALLOC_HANDOFF_VGPR
+; PRERA-LABEL: name: preserve_unused_handoff
+; PRERA: nomerge REGALLOC_HANDOFF_VGPR
+  %unused = call i32 @llvm.experimental.regalloc.handoff(
+      i32 %value, metadata !0)
+  ret void
+}
+
+declare i32 @llvm.experimental.regalloc.handoff(i32, metadata)
+
+!0 = !{!"amdgpu.vgpr"}

--- a/llvm/test/CodeGen/AMDGPU/regalloc-handoff-postra.mir
+++ b/llvm/test/CodeGen/AMDGPU/regalloc-handoff-postra.mir
@@ -1,0 +1,38 @@
+# RUN: llc -mtriple=amdgpu9.50-amd-amdhsa -run-pass=postrapseudos \
+# RUN:   -verify-machineinstrs -o - %s | FileCheck %s
+
+--- |
+  define void @same_register() { ret void }
+  define void @different_registers() { ret void }
+...
+---
+name: same_register
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $vgpr0
+    ; CHECK-LABEL: name: same_register
+    ; CHECK: bb.0:
+    ; CHECK-NEXT: liveins: $vgpr0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: S_ENDPGM 0, implicit $vgpr0
+    $vgpr0 = REGALLOC_HANDOFF_VGPR $vgpr0
+    S_ENDPGM 0, implicit $vgpr0
+...
+---
+name: different_registers
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $vgpr1, $vgpr3, $agpr1
+    ; CHECK-LABEL: name: different_registers
+    ; CHECK: $vgpr2 = V_MOV_B32_e32 $vgpr1, implicit $exec
+    ; CHECK-NEXT: $agpr0 = V_ACCVGPR_WRITE_B32_e64 $vgpr3, implicit $exec
+    ; CHECK-NEXT: $vgpr4 = V_ACCVGPR_READ_B32_e64 $agpr1, implicit $exec
+    ; CHECK-NEXT: S_ENDPGM 0, implicit $vgpr2, implicit $agpr0, implicit $vgpr4
+    ; CHECK-NOT: REGALLOC_HANDOFF_
+    $vgpr2 = REGALLOC_HANDOFF_VGPR $vgpr1
+    $agpr0 = REGALLOC_HANDOFF_AGPR $vgpr3
+    $vgpr4 = REGALLOC_HANDOFF_VGPR $agpr1
+    S_ENDPGM 0, implicit $vgpr2, implicit $agpr0, implicit $vgpr4
+...

--- a/llvm/test/CodeGen/AMDGPU/regalloc-handoff-sched-group.mir
+++ b/llvm/test/CodeGen/AMDGPU/regalloc-handoff-sched-group.mir
@@ -1,0 +1,20 @@
+# REQUIRES: asserts
+# RUN: llc -mtriple=amdgpu9.08 -run-pass=machine-scheduler \
+# RUN:   -debug-only=igrouplp -o /dev/null %s 2>&1 | FileCheck %s
+
+---
+name: handoff_is_not_pipeline_instruction
+tracksRegLiveness: true
+body: |
+  bb.0:
+    %0:av_32 = IMPLICIT_DEF
+    %1:vgpr_32 = REGALLOC_HANDOFF_VGPR %0
+    SCHED_GROUP_BARRIER 2, 1, 0
+    SCHED_GROUP_BARRIER 4, 1, 1
+    SCHED_GROUP_BARRIER 8, 1, 2
+    S_ENDPGM 0, implicit %1
+...
+
+# CHECK-DAG: For SchedGroup with mask 0x00000002 unable to classify {{%[0-9]+}}:vgpr_32 = REGALLOC_HANDOFF_VGPR {{%[0-9]+}}:av_32
+# CHECK-DAG: For SchedGroup with mask 0x00000004 unable to classify {{%[0-9]+}}:vgpr_32 = REGALLOC_HANDOFF_VGPR {{%[0-9]+}}:av_32
+# CHECK-DAG: For SchedGroup with mask 0x00000008 unable to classify {{%[0-9]+}}:vgpr_32 = REGALLOC_HANDOFF_VGPR {{%[0-9]+}}:av_32

--- a/llvm/test/CodeGen/X86/experimental-regalloc-handoff.ll
+++ b/llvm/test/CodeGen/X86/experimental-regalloc-handoff.ll
@@ -1,0 +1,18 @@
+; RUN: llc -mtriple=x86_64 -O0 < %s | FileCheck %s
+; RUN: llc -mtriple=x86_64 -O2 < %s | FileCheck %s
+; RUN: llc -mtriple=x86_64 -O0 -global-isel=1 -global-isel-abort=1 < %s | FileCheck %s
+
+define i32 @identity_i32(i32 %x) {
+  %y = call i32 @llvm.experimental.regalloc.handoff(i32 %x, metadata !0)
+  ret i32 %y
+}
+
+; CHECK-LABEL: identity_i32:
+; CHECK-NOT:   call
+; CHECK:       movl %edi, %eax
+; CHECK-NOT:   call
+; CHECK-NEXT:  retq
+
+declare i32 @llvm.experimental.regalloc.handoff(i32, metadata)
+
+!0 = !{!"amdgpu.vgpr"}

--- a/llvm/test/Other/new-pm-defaults.ll
+++ b/llvm/test/Other/new-pm-defaults.ll
@@ -84,6 +84,7 @@
 ; CHECK-O: Running pass: Annotation2Metadata
 ; CHECK-O-NEXT: Running pass: ForceFunctionAttrsPass
 ; CHECK-EP-PIPELINE-START-NEXT: Running pass: NoOpModulePass
+; CHECK-O-NEXT: Running pass: PreISelIntrinsicLoweringPass
 ; CHECK-O-NEXT: Running pass: InferFunctionAttrsPass
 ; CHECK-O-NEXT: Running analysis: InnerAnalysisManagerProxy
 ; CHECK-O-NEXT: Running analysis: TargetLibraryAnalysis

--- a/llvm/test/Other/new-pm-lto-defaults.ll
+++ b/llvm/test/Other/new-pm-lto-defaults.ll
@@ -31,7 +31,9 @@
 ; RUN:     | FileCheck %s --check-prefixes=CHECK-O,CHECK-O23,CHECK-EP-CGSCC-LATE
 
 ; CHECK-EP: Running pass: NoOpModulePass
-; CHECK-O: Running pass: CrossDSOCFIPass
+; CHECK-O: Running pass: PreISelIntrinsicLoweringPass
+; CHECK-O-NEXT: Running pass: MemProfRemoveInfo
+; CHECK-O-NEXT: Running pass: CrossDSOCFIPass
 ; CHECK-O-NEXT: Running pass: OpenMPOptPass
 ; CHECK-O-NEXT: Running pass: GlobalDCEPass
 ; CHECK-O-NEXT: Running pass: InferFunctionAttrsPass

--- a/llvm/test/Other/new-pm-thinlto-prelink-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-prelink-defaults.ll
@@ -54,6 +54,7 @@
 ; CHECK-EP-PIPELINE-START-NEXT: Running pass: NoOpModulePass
 ; CHECK-DIS-NEXT: Running analysis: InnerAnalysisManagerProxy
 ; CHECK-DIS-NEXT: Running pass: AddDiscriminatorsPass
+; CHECK-O-NEXT: Running pass: PreISelIntrinsicLoweringPass
 ; CHECK-O-NEXT: Running pass: InferFunctionAttrsPass
 ; CHECK-O-NODIS-NEXT: Running analysis: InnerAnalysisManagerProxy
 ; CHECK-O-NEXT: Running analysis: TargetLibraryAnalysis

--- a/llvm/test/Other/new-pm-thinlto-prelink-pgo-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-prelink-pgo-defaults.ll
@@ -22,6 +22,7 @@
 ; CHECK-O: Running pass: Annotation2Metadata
 ; CHECK-O-NEXT: Running pass: ForceFunctionAttrsPass
 ; CHECK-EP-PIPELINE-START-NEXT: Running pass: NoOpModulePass
+; CHECK-O-NEXT: Running pass: PreISelIntrinsicLoweringPass
 ; CHECK-O-NEXT: Running pass: InferFunctionAttrsPass
 ; CHECK-O-NEXT: Running analysis: InnerAnalysisManagerProxy
 ; CHECK-O-NEXT: Running analysis: TargetLibraryAnalysis

--- a/llvm/test/Other/new-pm-thinlto-prelink-samplepgo-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-prelink-samplepgo-defaults.ll
@@ -22,6 +22,7 @@
 ; CHECK-O-NEXT: Running analysis: InnerAnalysisManagerProxy
 ; CHECK-O-NEXT: Running pass: AddDiscriminatorsPass
 ; CHECK-EP-PIPELINE-START-NEXT: Running pass: NoOpModulePass
+; CHECK-O-NEXT: Running pass: PreISelIntrinsicLoweringPass
 ; CHECK-O-NEXT: Running pass: InferFunctionAttrsPass
 ; CHECK-O-NEXT: Running analysis: TargetLibraryAnalysis
 ; CHECK-O-NEXT: Running pass: CoroEarlyPass

--- a/llvm/test/Transforms/EarlyCSE/regalloc-handoff.ll
+++ b/llvm/test/Transforms/EarlyCSE/regalloc-handoff.ll
@@ -1,0 +1,103 @@
+; RUN: opt -passes=early-cse -S %s | FileCheck %s --check-prefix=CSE
+; RUN: opt -passes=gvn -S %s | FileCheck %s --check-prefix=GVN
+; RUN: opt -passes=simplifycfg -S %s | FileCheck %s --check-prefix=CFG
+
+declare i32 @llvm.experimental.regalloc.handoff(i32, metadata)
+
+define i32 @preserve_distinct_handoffs(i32 %value) {
+; CSE-LABEL: @preserve_distinct_handoffs(
+; CSE-NEXT:    [[FIRST:%.*]] = call i32 @llvm.experimental.regalloc.handoff(i32 [[VALUE:%.*]], metadata [[CONSTRAINT:![0-9]+]])
+; CSE-NEXT:    [[SECOND:%.*]] = call i32 @llvm.experimental.regalloc.handoff(i32 [[VALUE]], metadata [[CONSTRAINT]])
+; CSE-NEXT:    [[SUM:%.*]] = add i32 [[FIRST]], [[SECOND]]
+; CSE-NEXT:    ret i32 [[SUM]]
+;
+  %first = call i32 @llvm.experimental.regalloc.handoff(
+      i32 %value, metadata !0)
+  %second = call i32 @llvm.experimental.regalloc.handoff(
+      i32 %value, metadata !0)
+  %sum = add i32 %first, %second
+  ret i32 %sum
+}
+
+define i32 @preserve_unused_handoff(i32 %value) {
+; CSE-LABEL: @preserve_unused_handoff(
+; CSE-NEXT:    [[HANDOFF:%.*]] = call i32 @llvm.experimental.regalloc.handoff(i32 [[VALUE:%.*]], metadata [[CONSTRAINT:![0-9]+]])
+; CSE-NEXT:    ret i32 [[VALUE]]
+;
+  %handoff = call i32 @llvm.experimental.regalloc.handoff(
+      i32 %value, metadata !0)
+  ret i32 %value
+}
+
+define i32 @preserve_branch_handoffs(i1 %condition, i32 %value) {
+; CFG-LABEL: @preserve_branch_handoffs(
+; CFG:       left:
+; CFG-NEXT:    [[LEFT_VALUE:%.*]] = call i32 @llvm.experimental.regalloc.handoff(i32 [[VALUE:%.*]], metadata [[CONSTRAINT:![0-9]+]])
+; CFG-NEXT:    br label [[MERGE:%.*]]
+; CFG:       right:
+; CFG-NEXT:    [[RIGHT_VALUE:%.*]] = call i32 @llvm.experimental.regalloc.handoff(i32 [[VALUE]], metadata [[CONSTRAINT]])
+; CFG-NEXT:    br label [[MERGE]]
+; CFG:       merge:
+; CFG-NEXT:    [[RESULT:%.*]] = phi i32 [ [[LEFT_VALUE]], [[LEFT:%.*]] ], [ [[RIGHT_VALUE]], [[RIGHT:%.*]] ]
+; CFG-NEXT:    ret i32 [[RESULT]]
+;
+entry:
+  br i1 %condition, label %left, label %right
+
+left:
+  %left.value = call i32 @llvm.experimental.regalloc.handoff(
+      i32 %value, metadata !0)
+  br label %merge
+
+right:
+  %right.value = call i32 @llvm.experimental.regalloc.handoff(
+      i32 %value, metadata !0)
+  br label %merge
+
+merge:
+  %result = phi i32 [ %left.value, %left ], [ %right.value, %right ]
+  ret i32 %result
+}
+
+define i32 @do_not_speculate_handoff(i1 %condition, i32 %value) {
+; CFG-LABEL: @do_not_speculate_handoff(
+; CFG-NEXT:  entry:
+; CFG-NEXT:    br i1 [[CONDITION:%.*]], label [[HANDOFF_BLOCK:%.*]], label [[EXIT:%.*]]
+; CFG:       handoff:
+; CFG-NEXT:    [[HANDOFF:%.*]] = call i32 @llvm.experimental.regalloc.handoff(i32 [[VALUE:%.*]], metadata [[CONSTRAINT:![0-9]+]])
+; CFG-NEXT:    br label [[EXIT]]
+; CFG:       exit:
+; CFG-NEXT:    [[RESULT:%.*]] = phi i32 [ [[VALUE]], [[ENTRY:%.*]] ], [ [[HANDOFF]], [[HANDOFF_BLOCK]] ]
+; CFG-NEXT:    ret i32 [[RESULT]]
+;
+entry:
+  br i1 %condition, label %handoff, label %exit
+
+handoff:
+  %handoff.value = call i32 @llvm.experimental.regalloc.handoff(
+      i32 %value, metadata !0)
+  br label %exit
+
+exit:
+  %result = phi i32 [ %value, %entry ], [ %handoff.value, %handoff ]
+  ret i32 %result
+}
+
+define i32 @does_not_clobber_program_memory(ptr %ptr, i32 %value) {
+; GVN-LABEL: @does_not_clobber_program_memory(
+; GVN-NEXT:    [[BEFORE:%.*]] = load i32, ptr [[PTR:%.*]], align 4
+; GVN-NEXT:    [[HANDOFF:%.*]] = call i32 @llvm.experimental.regalloc.handoff(i32 [[VALUE:%.*]], metadata [[CONSTRAINT:![0-9]+]])
+; GVN-NEXT:    [[LOAD_SUM:%.*]] = add i32 [[BEFORE]], [[BEFORE]]
+; GVN-NEXT:    [[RESULT:%.*]] = add i32 [[LOAD_SUM]], [[HANDOFF]]
+; GVN-NEXT:    ret i32 [[RESULT]]
+;
+  %before = load i32, ptr %ptr
+  %handoff = call i32 @llvm.experimental.regalloc.handoff(
+      i32 %value, metadata !0)
+  %after = load i32, ptr %ptr
+  %load.sum = add i32 %before, %after
+  %result = add i32 %load.sum, %handoff
+  ret i32 %result
+}
+
+!0 = !{!"amdgpu.vgpr"}

--- a/llvm/test/Transforms/PreISelIntrinsicLowering/regalloc-handoff-default-pipeline.ll
+++ b/llvm/test/Transforms/PreISelIntrinsicLowering/regalloc-handoff-default-pipeline.ll
@@ -1,0 +1,89 @@
+; REQUIRES: x86-registered-target, amdgpu-registered-target
+
+; RUN: opt -mtriple=x86_64 -passes='default<O2>' -S %s -o - | FileCheck %s --check-prefix=X86
+; RUN: opt -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -passes='default<O2>' -S %s -o - | FileCheck %s --check-prefix=GFX908
+; RUN: opt -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -passes='default<O2>' -S %s -o - | FileCheck %s --check-prefix=GFX900
+; RUN: opt -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950 -passes='default<O2>' -S %s -o - | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950 -verify-machineinstrs -filetype=null
+; RUN: opt -passes='default<O2>' -S %s -o - | FileCheck %s --check-prefix=NO-TARGET
+; RUN: opt -mtriple=x86_64 -passes='lto<O2>' -S %s -o - | FileCheck %s --check-prefix=X86
+; RUN: opt -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -passes='lto<O2>' -S %s -o - | FileCheck %s --check-prefix=GFX908
+; RUN: opt -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -passes='lto<O2>' -S %s -o - | FileCheck %s --check-prefix=GFX900
+; RUN: opt -passes='lto<O2>' -S %s -o - | FileCheck %s --check-prefix=NO-TARGET
+; RUN: echo 'Contexts: []' | llvm-ctxprof-util fromYAML --input=- --output=%t.ctxprofdata
+; RUN: opt -passes=assign-guid -S %s -o %t.guid.ll
+; RUN: opt -mtriple=x86_64 -use-ctx-profile=%t.ctxprofdata -passes='thinlto<O2>' -S %t.guid.ll -o - | FileCheck %s --check-prefix=X86
+
+define i32 @vgpr(i32 %x) {
+; X86-LABEL: define i32 @vgpr(
+; X86-NEXT:    [[SUM:%.*]] = add i32 [[X:%.*]], 1
+; X86-NEXT:    ret i32 [[SUM]]
+;
+; GFX908-LABEL: define i32 @vgpr(
+; GFX908:       [[HANDOFF:%.*]] = {{(tail )?}}call i32 @llvm.experimental.regalloc.handoff(i32 [[X:%.*]], metadata [[VGPR:![0-9]+]])
+; GFX908-NEXT:  [[SUM:%.*]] = add i32 [[HANDOFF]], 1
+; GFX908-NEXT:  ret i32 [[SUM]]
+;
+; GFX900-LABEL: define i32 @vgpr(
+; GFX900:       [[HANDOFF:%.*]] = {{(tail )?}}call i32 @llvm.experimental.regalloc.handoff(i32 [[X:%.*]], metadata [[VGPR:![0-9]+]])
+; GFX900-NEXT:  [[SUM:%.*]] = add i32 [[HANDOFF]], 1
+; GFX900-NEXT:  ret i32 [[SUM]]
+;
+; NO-TARGET-LABEL: define i32 @vgpr(
+; NO-TARGET:       call i32 @llvm.experimental.regalloc.handoff
+  %handoff = call i32 @llvm.experimental.regalloc.handoff(i32 %x, metadata !0)
+  %sum = add i32 %handoff, 1
+  ret i32 %sum
+}
+
+define i32 @agpr(i32 %x) {
+; X86-LABEL: define i32 @agpr(
+; X86-NEXT:    [[SUM:%.*]] = add i32 [[X:%.*]], 1
+; X86-NEXT:    ret i32 [[SUM]]
+;
+; GFX908-LABEL: define i32 @agpr(
+; GFX908:       [[HANDOFF:%.*]] = {{(tail )?}}call i32 @llvm.experimental.regalloc.handoff(i32 [[X:%.*]], metadata [[AGPR:![0-9]+]])
+; GFX908-NEXT:  [[SUM:%.*]] = add i32 [[HANDOFF]], 1
+; GFX908-NEXT:  ret i32 [[SUM]]
+;
+; GFX900-LABEL: define i32 @agpr(
+; GFX900-NEXT:    [[SUM:%.*]] = add i32 [[X:%.*]], 1
+; GFX900-NEXT:    ret i32 [[SUM]]
+;
+; NO-TARGET-LABEL: define i32 @agpr(
+; NO-TARGET:       call i32 @llvm.experimental.regalloc.handoff
+  %handoff = call i32 @llvm.experimental.regalloc.handoff(i32 %x, metadata !1)
+  %sum = add i32 %handoff, 1
+  ret i32 %sum
+}
+
+define void @unused_agpr_loop(i32 %n) {
+; X86-LABEL: define void @unused_agpr_loop(
+; X86-NEXT:  entry:
+; X86-NEXT:    ret void
+;
+; GFX908-LABEL: define void @unused_agpr_loop(
+; GFX908:       call i32 @llvm.experimental.regalloc.handoff
+; GFX908:       ret void
+;
+; GFX900-LABEL: define void @unused_agpr_loop(
+; GFX900-NEXT:  entry:
+; GFX900-NEXT:    ret void
+entry:
+  %positive = icmp sgt i32 %n, 0
+  br i1 %positive, label %loop, label %exit
+
+loop:
+  %i = phi i32 [ 0, %entry ], [ %next, %loop ]
+  %handoff = call i32 @llvm.experimental.regalloc.handoff(i32 %i, metadata !1)
+  %next = add nuw nsw i32 %i, 1
+  %done = icmp eq i32 %next, %n
+  br i1 %done, label %exit, label %loop
+
+exit:
+  ret void
+}
+
+declare i32 @llvm.experimental.regalloc.handoff(i32, metadata)
+
+!0 = !{!"amdgpu.vgpr"}
+!1 = !{!"amdgpu.agpr"}

--- a/llvm/test/Transforms/PreISelIntrinsicLowering/regalloc-handoff.ll
+++ b/llvm/test/Transforms/PreISelIntrinsicLowering/regalloc-handoff.ll
@@ -1,0 +1,82 @@
+; REQUIRES: x86-registered-target, amdgpu-registered-target
+
+; RUN: opt -mtriple=x86_64 -passes=pre-isel-intrinsic-lowering -S %s -o - | FileCheck %s --check-prefix=FALLBACK
+; RUN: opt -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -passes=pre-isel-intrinsic-lowering -S %s -o - | FileCheck %s --check-prefix=AMD
+; RUN: opt -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -passes=pre-isel-intrinsic-lowering -S %s -o - | FileCheck %s --check-prefix=NO-MAI
+; RUN: opt -passes=pre-isel-intrinsic-lowering -S %s -o - | FileCheck %s --check-prefix=NO-TARGET
+
+define i32 @vgpr(i32 %x) {
+  %y = call i32 @llvm.experimental.regalloc.handoff(i32 %x, metadata !0)
+  ret i32 %y
+}
+
+; FALLBACK-LABEL: define i32 @vgpr
+; FALLBACK-NEXT: ret i32 %x
+; AMD-LABEL: define i32 @vgpr
+; AMD-NEXT: %y = call i32 @llvm.experimental.regalloc.handoff(i32 %x, metadata !0)
+; AMD-NEXT: ret i32 %y
+; NO-MAI-LABEL: define i32 @vgpr
+; NO-MAI-NEXT: %y = call i32 @llvm.experimental.regalloc.handoff(i32 %x, metadata !0)
+; NO-MAI-NEXT: ret i32 %y
+; NO-TARGET-LABEL: define i32 @vgpr
+; NO-TARGET-NEXT: %y = call i32 @llvm.experimental.regalloc.handoff(i32 %x, metadata !0)
+; NO-TARGET-NEXT: ret i32 %y
+
+define i32 @agpr(i32 %x) {
+  %y = call i32 @llvm.experimental.regalloc.handoff(i32 %x, metadata !1)
+  ret i32 %y
+}
+
+; FALLBACK-LABEL: define i32 @agpr
+; FALLBACK-NEXT: ret i32 %x
+; AMD-LABEL: define i32 @agpr
+; AMD-NEXT: %y = call i32 @llvm.experimental.regalloc.handoff(i32 %x, metadata !1)
+; AMD-NEXT: ret i32 %y
+; NO-MAI-LABEL: define i32 @agpr
+; NO-MAI-NEXT: ret i32 %x
+; NO-TARGET-LABEL: define i32 @agpr
+; NO-TARGET-NEXT: %y = call i32 @llvm.experimental.regalloc.handoff(i32 %x, metadata !1)
+; NO-TARGET-NEXT: ret i32 %y
+
+define i32 @unknown(i32 %x) {
+  %y = call i32 @llvm.experimental.regalloc.handoff(i32 %x, metadata !2)
+  ret i32 %y
+}
+
+; FALLBACK-LABEL: define i32 @unknown
+; FALLBACK-NEXT: ret i32 %x
+; AMD-LABEL: define i32 @unknown
+; AMD-NEXT: ret i32 %x
+
+define i32 @empty_constraint(i32 %x) {
+  %y = call i32 @llvm.experimental.regalloc.handoff(i32 %x, metadata !3)
+  ret i32 %y
+}
+
+; AMD-LABEL: define i32 @empty_constraint
+; AMD-NEXT: ret i32 %x
+
+define i32 @multi_element_constraint(i32 %x) {
+  %y = call i32 @llvm.experimental.regalloc.handoff(i32 %x, metadata !4)
+  ret i32 %y
+}
+
+; AMD-LABEL: define i32 @multi_element_constraint
+; AMD-NEXT: ret i32 %x
+
+define i32 @non_string_constraint(i32 %x) {
+  %y = call i32 @llvm.experimental.regalloc.handoff(i32 %x, metadata !5)
+  ret i32 %y
+}
+
+; AMD-LABEL: define i32 @non_string_constraint
+; AMD-NEXT: ret i32 %x
+
+declare i32 @llvm.experimental.regalloc.handoff(i32, metadata)
+
+!0 = !{!"amdgpu.vgpr"}
+!1 = !{!"amdgpu.agpr"}
+!2 = !{!"amdgpu.unknown"}
+!3 = !{}
+!4 = !{!"amdgpu.vgpr", !"extra"}
+!5 = !{i32 0}

--- a/llvm/unittests/CodeGen/MachineInstrTest.cpp
+++ b/llvm/unittests/CodeGen/MachineInstrTest.cpp
@@ -681,4 +681,27 @@ TEST(MachineInstr, EraseFromParentReturnedIteratorBundle) {
   EXPECT_EQ(It2, MBB->end());
 }
 
+TEST(MachineInstr, NoMergeSafeToMove) {
+  LLVMContext Ctx;
+  Module Mod("Module", Ctx);
+  auto MF = createMachineFunction(Ctx, Mod);
+
+  MCInstrDesc PureDesc = {TargetOpcode::COPY, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  MachineInstr *Pure = MF->CreateMachineInstr(PureDesc, DebugLoc());
+  Pure->setFlag(MachineInstr::NoMerge);
+
+  bool SawStore = false;
+  EXPECT_FALSE(Pure->isSafeToMove(SawStore));
+  EXPECT_FALSE(SawStore);
+
+  MCInstrDesc StoreDesc = {TargetOpcode::COPY,     0, 0, 0, 0, 0, 0, 0, 0,
+                           1ULL << MCID::MayStore, 0};
+  MachineInstr *Store = MF->CreateMachineInstr(StoreDesc, DebugLoc());
+  Store->setFlag(MachineInstr::NoMerge);
+
+  SawStore = false;
+  EXPECT_FALSE(Store->isSafeToMove(SawStore));
+  EXPECT_TRUE(SawStore);
+}
+
 } // end namespace


### PR DESCRIPTION
Add `llvm.amdgcn.regalloc.handoff` to carry register allocation requirements through SelectionDAG and GlobalISel.

Preserve nomerge semantics across IR and machine optimizations, teach the AMDGPU Attributor and register-bank pipeline about the handoff, and add end-to-end regression coverage.

Fixes #219377