### PR TITLE
[clang] Migrate remaining FoldingSet users to lookup/insert. NFC

### DIFF
--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -37,6 +37,7 @@
 #include "clang/Basic/Visibility.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/StringRef.h"
@@ -2228,7 +2229,7 @@ private:
   /// \param TemplateArgs the template arguments that produced this
   /// function template specialization from the template.
   ///
-  /// \param InsertPos If non-NULL, the position in the function template
+  /// \param Token If set, the insert token in the function template
   /// specialization set where the function template specialization data will
   /// be inserted.
   ///
@@ -2240,7 +2241,7 @@ private:
   /// specialization was first instantiated.
   void setFunctionTemplateSpecialization(
       ASTContext &C, FunctionTemplateDecl *Template,
-      TemplateArgumentList *TemplateArgs, void *InsertPos,
+      TemplateArgumentList *TemplateArgs, llvm::FoldingSetInsertToken Token,
       TemplateSpecializationKind TSK,
       const TemplateArgumentListInfo *TemplateArgsAsWritten,
       SourceLocation PointOfInstantiation);
@@ -3191,7 +3192,7 @@ public:
   /// \param TemplateArgs the template arguments that produced this
   /// function template specialization from the template.
   ///
-  /// \param InsertPos If non-NULL, the position in the function template
+  /// \param Token If set, the insert token in the function template
   /// specialization set where the function template specialization data will
   /// be inserted.
   ///
@@ -3203,12 +3204,12 @@ public:
   /// specialization was first instantiated.
   void setFunctionTemplateSpecialization(
       FunctionTemplateDecl *Template, TemplateArgumentList *TemplateArgs,
-      void *InsertPos,
+      llvm::FoldingSetInsertToken Token,
       TemplateSpecializationKind TSK = TSK_ImplicitInstantiation,
       TemplateArgumentListInfo *TemplateArgsAsWritten = nullptr,
       SourceLocation PointOfInstantiation = SourceLocation()) {
     setFunctionTemplateSpecialization(getASTContext(), Template, TemplateArgs,
-                                      InsertPos, TSK, TemplateArgsAsWritten,
+                                      Token, TSK, TemplateArgsAsWritten,
                                       PointOfInstantiation);
   }
 

--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -2229,7 +2229,7 @@ private:
   /// \param TemplateArgs the template arguments that produced this
   /// function template specialization from the template.
   ///
-  /// \param Token If set, the insert token in the function template
+  /// \param InsertToken If set, the insert token in the function template
   /// specialization set where the function template specialization data will
   /// be inserted.
   ///
@@ -2241,8 +2241,8 @@ private:
   /// specialization was first instantiated.
   void setFunctionTemplateSpecialization(
       ASTContext &C, FunctionTemplateDecl *Template,
-      TemplateArgumentList *TemplateArgs, llvm::FoldingSetInsertToken Token,
-      TemplateSpecializationKind TSK,
+      TemplateArgumentList *TemplateArgs,
+      llvm::FoldingSetInsertToken InsertToken, TemplateSpecializationKind TSK,
       const TemplateArgumentListInfo *TemplateArgsAsWritten,
       SourceLocation PointOfInstantiation);
 
@@ -3192,7 +3192,7 @@ public:
   /// \param TemplateArgs the template arguments that produced this
   /// function template specialization from the template.
   ///
-  /// \param Token If set, the insert token in the function template
+  /// \param InsertToken If set, the insert token in the function template
   /// specialization set where the function template specialization data will
   /// be inserted.
   ///
@@ -3204,12 +3204,12 @@ public:
   /// specialization was first instantiated.
   void setFunctionTemplateSpecialization(
       FunctionTemplateDecl *Template, TemplateArgumentList *TemplateArgs,
-      llvm::FoldingSetInsertToken Token,
+      llvm::FoldingSetInsertToken InsertToken,
       TemplateSpecializationKind TSK = TSK_ImplicitInstantiation,
       TemplateArgumentListInfo *TemplateArgsAsWritten = nullptr,
       SourceLocation PointOfInstantiation = SourceLocation()) {
     setFunctionTemplateSpecialization(getASTContext(), Template, TemplateArgs,
-                                      Token, TSK, TemplateArgsAsWritten,
+                                      InsertToken, TSK, TemplateArgsAsWritten,
                                       PointOfInstantiation);
   }
 

--- a/clang/include/clang/AST/DeclTemplate.h
+++ b/clang/include/clang/AST/DeclTemplate.h
@@ -778,19 +778,19 @@ protected:
   template <class EntryType, typename... ProfileArguments>
   typename SpecEntryTraits<EntryType>::DeclType *
   findSpecializationImpl(llvm::FoldingSetVector<EntryType> &Specs,
-                         llvm::FoldingSetInsertToken &Token,
+                         llvm::FoldingSetInsertToken &InsertToken,
                          ProfileArguments... ProfileArgs);
 
   template <class EntryType, typename... ProfileArguments>
   typename SpecEntryTraits<EntryType>::DeclType *
   findSpecializationLocally(llvm::FoldingSetVector<EntryType> &Specs,
-                            llvm::FoldingSetInsertToken &Token,
+                            llvm::FoldingSetInsertToken &InsertToken,
                             ProfileArguments... ProfileArgs);
 
   template <class Derived, class EntryType>
   void addSpecializationImpl(llvm::FoldingSetVector<EntryType> &Specs,
                              EntryType *Entry,
-                             llvm::FoldingSetInsertToken Token);
+                             llvm::FoldingSetInsertToken InsertToken);
 
   struct CommonBase {
     CommonBase() : InstantiatedFromMember(nullptr, false) {}
@@ -986,10 +986,11 @@ protected:
 
   /// Add a specialization of this function template.
   ///
-  /// \param Token Insert token, must have been retrieved by an earlier call
+  /// \param InsertToken Insert token, must have been retrieved by an earlier
+  /// call
   ///        to findSpecialization().
   void addSpecialization(FunctionTemplateSpecializationInfo *Info,
-                         llvm::FoldingSetInsertToken Token);
+                         llvm::FoldingSetInsertToken InsertToken);
 
 public:
   friend class ASTDeclReader;
@@ -1032,7 +1033,7 @@ public:
   /// Return the specialization with the provided arguments if it exists,
   /// otherwise return the insertion point.
   FunctionDecl *findSpecialization(ArrayRef<TemplateArgument> Args,
-                                   llvm::FoldingSetInsertToken &Token);
+                                   llvm::FoldingSetInsertToken &InsertToken);
 
   FunctionTemplateDecl *getCanonicalDecl() override {
     return cast<FunctionTemplateDecl>(
@@ -2342,12 +2343,12 @@ public:
   /// otherwise return the insertion point.
   ClassTemplateSpecializationDecl *
   findSpecialization(ArrayRef<TemplateArgument> Args,
-                     llvm::FoldingSetInsertToken &Token);
+                     llvm::FoldingSetInsertToken &InsertToken);
 
   /// Insert the specified specialization knowing that it is not already
-  /// in. Token must be obtained from findSpecialization.
+  /// in. InsertToken must be obtained from findSpecialization.
   void AddSpecialization(ClassTemplateSpecializationDecl *D,
-                         llvm::FoldingSetInsertToken Token);
+                         llvm::FoldingSetInsertToken InsertToken);
 
   ClassTemplateDecl *getCanonicalDecl() override {
     return cast<ClassTemplateDecl>(
@@ -2388,12 +2389,12 @@ public:
   ClassTemplatePartialSpecializationDecl *
   findPartialSpecialization(ArrayRef<TemplateArgument> Args,
                             TemplateParameterList *TPL,
-                            llvm::FoldingSetInsertToken &Token);
+                            llvm::FoldingSetInsertToken &InsertToken);
 
   /// Insert the specified partial specialization knowing that it is not
-  /// already in. Token must be obtained from findPartialSpecialization.
+  /// already in. InsertToken must be obtained from findPartialSpecialization.
   void AddPartialSpecialization(ClassTemplatePartialSpecializationDecl *D,
-                                llvm::FoldingSetInsertToken Token);
+                                llvm::FoldingSetInsertToken InsertToken);
 
   /// Retrieve the partial specializations as an ordered list.
   void getPartialSpecializations(
@@ -3104,12 +3105,12 @@ public:
   /// otherwise return the insertion point.
   VarTemplateSpecializationDecl *
   findSpecialization(ArrayRef<TemplateArgument> Args,
-                     llvm::FoldingSetInsertToken &Token);
+                     llvm::FoldingSetInsertToken &InsertToken);
 
   /// Insert the specified specialization knowing that it is not already
-  /// in. Token must be obtained from findSpecialization.
+  /// in. InsertToken must be obtained from findSpecialization.
   void AddSpecialization(VarTemplateSpecializationDecl *D,
-                         llvm::FoldingSetInsertToken Token);
+                         llvm::FoldingSetInsertToken InsertToken);
 
   VarTemplateDecl *getCanonicalDecl() override {
     return cast<VarTemplateDecl>(RedeclarableTemplateDecl::getCanonicalDecl());
@@ -3148,12 +3149,12 @@ public:
   VarTemplatePartialSpecializationDecl *
   findPartialSpecialization(ArrayRef<TemplateArgument> Args,
                             TemplateParameterList *TPL,
-                            llvm::FoldingSetInsertToken &Token);
+                            llvm::FoldingSetInsertToken &InsertToken);
 
   /// Insert the specified partial specialization knowing that it is not
-  /// already in. Token must be obtained from findPartialSpecialization.
+  /// already in. InsertToken must be obtained from findPartialSpecialization.
   void AddPartialSpecialization(VarTemplatePartialSpecializationDecl *D,
-                                llvm::FoldingSetInsertToken Token);
+                                llvm::FoldingSetInsertToken InsertToken);
 
   /// Retrieve the partial specializations as an ordered list.
   void getPartialSpecializations(

--- a/clang/include/clang/AST/DeclTemplate.h
+++ b/clang/include/clang/AST/DeclTemplate.h
@@ -987,8 +987,7 @@ protected:
   /// Add a specialization of this function template.
   ///
   /// \param InsertToken Insert token, must have been retrieved by an earlier
-  /// call
-  ///        to findSpecialization().
+  /// call to findSpecialization().
   void addSpecialization(FunctionTemplateSpecializationInfo *Info,
                          llvm::FoldingSetInsertToken InsertToken);
 

--- a/clang/include/clang/AST/DeclTemplate.h
+++ b/clang/include/clang/AST/DeclTemplate.h
@@ -778,16 +778,19 @@ protected:
   template <class EntryType, typename... ProfileArguments>
   typename SpecEntryTraits<EntryType>::DeclType *
   findSpecializationImpl(llvm::FoldingSetVector<EntryType> &Specs,
-                         void *&InsertPos, ProfileArguments... ProfileArgs);
+                         llvm::FoldingSetInsertToken &Token,
+                         ProfileArguments... ProfileArgs);
 
   template <class EntryType, typename... ProfileArguments>
   typename SpecEntryTraits<EntryType>::DeclType *
   findSpecializationLocally(llvm::FoldingSetVector<EntryType> &Specs,
-                            void *&InsertPos, ProfileArguments... ProfileArgs);
+                            llvm::FoldingSetInsertToken &Token,
+                            ProfileArguments... ProfileArgs);
 
   template <class Derived, class EntryType>
   void addSpecializationImpl(llvm::FoldingSetVector<EntryType> &Specs,
-                             EntryType *Entry, void *InsertPos);
+                             EntryType *Entry,
+                             llvm::FoldingSetInsertToken Token);
 
   struct CommonBase {
     CommonBase() : InstantiatedFromMember(nullptr, false) {}
@@ -983,10 +986,10 @@ protected:
 
   /// Add a specialization of this function template.
   ///
-  /// \param InsertPos Insert position in the FoldingSetVector, must have been
-  ///        retrieved by an earlier call to findSpecialization().
-  void addSpecialization(FunctionTemplateSpecializationInfo* Info,
-                         void *InsertPos);
+  /// \param Token Insert token, must have been retrieved by an earlier call
+  ///        to findSpecialization().
+  void addSpecialization(FunctionTemplateSpecializationInfo *Info,
+                         llvm::FoldingSetInsertToken Token);
 
 public:
   friend class ASTDeclReader;
@@ -1029,7 +1032,7 @@ public:
   /// Return the specialization with the provided arguments if it exists,
   /// otherwise return the insertion point.
   FunctionDecl *findSpecialization(ArrayRef<TemplateArgument> Args,
-                                   void *&InsertPos);
+                                   llvm::FoldingSetInsertToken &Token);
 
   FunctionTemplateDecl *getCanonicalDecl() override {
     return cast<FunctionTemplateDecl>(
@@ -2338,11 +2341,13 @@ public:
   /// Return the specialization with the provided arguments if it exists,
   /// otherwise return the insertion point.
   ClassTemplateSpecializationDecl *
-  findSpecialization(ArrayRef<TemplateArgument> Args, void *&InsertPos);
+  findSpecialization(ArrayRef<TemplateArgument> Args,
+                     llvm::FoldingSetInsertToken &Token);
 
   /// Insert the specified specialization knowing that it is not already
-  /// in. InsertPos must be obtained from findSpecialization.
-  void AddSpecialization(ClassTemplateSpecializationDecl *D, void *InsertPos);
+  /// in. Token must be obtained from findSpecialization.
+  void AddSpecialization(ClassTemplateSpecializationDecl *D,
+                         llvm::FoldingSetInsertToken Token);
 
   ClassTemplateDecl *getCanonicalDecl() override {
     return cast<ClassTemplateDecl>(
@@ -2382,12 +2387,13 @@ public:
   /// exists, otherwise return the insertion point.
   ClassTemplatePartialSpecializationDecl *
   findPartialSpecialization(ArrayRef<TemplateArgument> Args,
-                            TemplateParameterList *TPL, void *&InsertPos);
+                            TemplateParameterList *TPL,
+                            llvm::FoldingSetInsertToken &Token);
 
   /// Insert the specified partial specialization knowing that it is not
-  /// already in. InsertPos must be obtained from findPartialSpecialization.
+  /// already in. Token must be obtained from findPartialSpecialization.
   void AddPartialSpecialization(ClassTemplatePartialSpecializationDecl *D,
-                                void *InsertPos);
+                                llvm::FoldingSetInsertToken Token);
 
   /// Retrieve the partial specializations as an ordered list.
   void getPartialSpecializations(
@@ -3097,11 +3103,13 @@ public:
   /// Return the specialization with the provided arguments if it exists,
   /// otherwise return the insertion point.
   VarTemplateSpecializationDecl *
-  findSpecialization(ArrayRef<TemplateArgument> Args, void *&InsertPos);
+  findSpecialization(ArrayRef<TemplateArgument> Args,
+                     llvm::FoldingSetInsertToken &Token);
 
   /// Insert the specified specialization knowing that it is not already
-  /// in. InsertPos must be obtained from findSpecialization.
-  void AddSpecialization(VarTemplateSpecializationDecl *D, void *InsertPos);
+  /// in. Token must be obtained from findSpecialization.
+  void AddSpecialization(VarTemplateSpecializationDecl *D,
+                         llvm::FoldingSetInsertToken Token);
 
   VarTemplateDecl *getCanonicalDecl() override {
     return cast<VarTemplateDecl>(RedeclarableTemplateDecl::getCanonicalDecl());
@@ -3139,12 +3147,13 @@ public:
   /// exists, otherwise return the insertion point.
   VarTemplatePartialSpecializationDecl *
   findPartialSpecialization(ArrayRef<TemplateArgument> Args,
-                            TemplateParameterList *TPL, void *&InsertPos);
+                            TemplateParameterList *TPL,
+                            llvm::FoldingSetInsertToken &Token);
 
   /// Insert the specified partial specialization knowing that it is not
-  /// already in. InsertPos must be obtained from findPartialSpecialization.
+  /// already in. Token must be obtained from findPartialSpecialization.
   void AddPartialSpecialization(VarTemplatePartialSpecializationDecl *D,
-                                void *InsertPos);
+                                llvm::FoldingSetInsertToken Token);
 
   /// Retrieve the partial specializations as an ordered list.
   void getPartialSpecializations(

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SymbolManager.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SymbolManager.h
@@ -675,11 +675,11 @@ template <typename T, typename... Args>
 const T *SymbolManager::acquire(Args &&...args) {
   llvm::FoldingSetNodeID profile;
   T::Profile(profile, args...);
-  llvm::FoldingSetInsertToken Token;
-  SymExpr *SD = DataSet.lookup(profile, Token);
+  llvm::FoldingSetInsertToken InsertToken;
+  SymExpr *SD = DataSet.lookup(profile, InsertToken);
   if (!SD) {
     SD = Alloc.make<T>(std::forward<Args>(args)...);
-    DataSet.insert(SD, Token);
+    DataSet.insert(SD, InsertToken);
   }
   return cast<T>(SD);
 }

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SymbolManager.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SymbolManager.h
@@ -675,11 +675,11 @@ template <typename T, typename... Args>
 const T *SymbolManager::acquire(Args &&...args) {
   llvm::FoldingSetNodeID profile;
   T::Profile(profile, args...);
-  void *InsertPos;
-  SymExpr *SD = DataSet.FindNodeOrInsertPos(profile, InsertPos);
+  llvm::FoldingSetInsertToken Token;
+  SymExpr *SD = DataSet.lookup(profile, Token);
   if (!SD) {
     SD = Alloc.make<T>(std::forward<Args>(args)...);
-    DataSet.InsertNode(SD, InsertPos);
+    DataSet.insert(SD, Token);
   }
   return cast<T>(SD);
 }

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -3727,7 +3727,7 @@ Error ASTNodeImporter::ImportTemplateInformation(
 
     TemplateSpecializationKind TSK = FTSInfo->getTemplateSpecializationKind();
     ToFD->setFunctionTemplateSpecialization(
-        std::get<0>(*FunctionAndArgsOrErr), ToTAList, /*Token=*/{}, TSK,
+        std::get<0>(*FunctionAndArgsOrErr), ToTAList, /*InsertToken=*/{}, TSK,
         FromTAArgsAsWritten ? &ToTAInfo : nullptr, *POIOrErr);
     return Error::success();
   }
@@ -3769,8 +3769,8 @@ ASTNodeImporter::FindFunctionTemplateSpecialization(FunctionDecl *FromFD) {
   FunctionTemplateDecl *Template;
   TemplateArgsTy ToTemplArgs;
   std::tie(Template, ToTemplArgs) = *FunctionAndArgsOrErr;
-  llvm::FoldingSetInsertToken Token;
-  auto *FoundSpec = Template->findSpecialization(ToTemplArgs, Token);
+  llvm::FoldingSetInsertToken InsertToken;
+  auto *FoundSpec = Template->findSpecialization(ToTemplArgs, InsertToken);
   return FoundSpec;
 }
 
@@ -6368,7 +6368,7 @@ ExpectedDecl ASTNodeImporter::VisitClassTemplateSpecializationDecl(
     return std::move(Err);
   // Try to find an existing specialization with these template arguments and
   // template parameter list.
-  llvm::FoldingSetInsertToken Token;
+  llvm::FoldingSetInsertToken InsertToken;
   ClassTemplateSpecializationDecl *PrevDecl = nullptr;
   ClassTemplatePartialSpecializationDecl *PartialSpec =
             dyn_cast<ClassTemplatePartialSpecializationDecl>(D);
@@ -6381,10 +6381,10 @@ ExpectedDecl ASTNodeImporter::VisitClassTemplateSpecializationDecl(
     if (!ToTPListOrErr)
       return ToTPListOrErr.takeError();
     ToTPList = *ToTPListOrErr;
-    PrevDecl = ClassTemplate->findPartialSpecialization(TemplateArgs,
-                                                        *ToTPListOrErr, Token);
+    PrevDecl = ClassTemplate->findPartialSpecialization(
+        TemplateArgs, *ToTPListOrErr, InsertToken);
   } else
-    PrevDecl = ClassTemplate->findSpecialization(TemplateArgs, Token);
+    PrevDecl = ClassTemplate->findSpecialization(TemplateArgs, InsertToken);
 
   if (PrevDecl) {
     if (IsStructuralMatch(D, PrevDecl)) {
@@ -6445,13 +6445,13 @@ ExpectedDecl ASTNodeImporter::VisitClassTemplateSpecializationDecl(
             cast_or_null<ClassTemplatePartialSpecializationDecl>(PrevDecl)))
       return D2;
 
-    // Update Token, because preceding import calls may have invalidated
+    // Update InsertToken, because preceding import calls may have invalidated
     // it by adding new specializations.
     auto *PartSpec2 = cast<ClassTemplatePartialSpecializationDecl>(D2);
     if (!ClassTemplate->findPartialSpecialization(TemplateArgs, ToTPList,
-                                                  Token))
+                                                  InsertToken))
       // Add this partial specialization to the class template.
-      ClassTemplate->AddPartialSpecialization(PartSpec2, Token);
+      ClassTemplate->AddPartialSpecialization(PartSpec2, InsertToken);
     if (Expected<ClassTemplatePartialSpecializationDecl *> ToInstOrErr =
             import(PartialSpec->getInstantiatedFromMember()))
       PartSpec2->setInstantiatedFromMember(*ToInstOrErr);
@@ -6466,11 +6466,11 @@ ExpectedDecl ASTNodeImporter::VisitClassTemplateSpecializationDecl(
                                 PrevDecl))
       return D2;
 
-    // Update Token, because preceding import calls may have invalidated
+    // Update InsertToken, because preceding import calls may have invalidated
     // it by adding new specializations.
-    if (!ClassTemplate->findSpecialization(TemplateArgs, Token))
+    if (!ClassTemplate->findSpecialization(TemplateArgs, InsertToken))
       // Add this specialization to the class template.
-      ClassTemplate->AddSpecialization(D2, Token);
+      ClassTemplate->AddSpecialization(D2, InsertToken);
   }
 
   D2->setSpecializationKind(D->getSpecializationKind());
@@ -6697,9 +6697,9 @@ ExpectedDecl ASTNodeImporter::VisitVarTemplateSpecializationDecl(
     return std::move(Err);
 
   // Try to find an existing specialization with these template arguments.
-  llvm::FoldingSetInsertToken Token;
+  llvm::FoldingSetInsertToken InsertToken;
   VarTemplateSpecializationDecl *FoundSpecialization =
-      VarTemplate->findSpecialization(TemplateArgs, Token);
+      VarTemplate->findSpecialization(TemplateArgs, InsertToken);
   if (FoundSpecialization) {
     if (IsStructuralMatch(D, FoundSpecialization)) {
       VarDecl *FoundDef = FoundSpecialization->getDefinition();
@@ -6769,10 +6769,10 @@ ExpectedDecl ASTNodeImporter::VisitVarTemplateSpecializationDecl(
       return D2;
   }
 
-  // Update Token, because preceding import calls may have invalidated
+  // Update InsertToken, because preceding import calls may have invalidated
   // it by adding new specializations.
-  if (!VarTemplate->findSpecialization(TemplateArgs, Token))
-    VarTemplate->AddSpecialization(D2, Token);
+  if (!VarTemplate->findSpecialization(TemplateArgs, InsertToken))
+    VarTemplate->AddSpecialization(D2, InsertToken);
 
   QualType T;
   if (Error Err = importInto(T, D->getType()))

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -3727,8 +3727,8 @@ Error ASTNodeImporter::ImportTemplateInformation(
 
     TemplateSpecializationKind TSK = FTSInfo->getTemplateSpecializationKind();
     ToFD->setFunctionTemplateSpecialization(
-        std::get<0>(*FunctionAndArgsOrErr), ToTAList, /* InsertPos= */ nullptr,
-        TSK, FromTAArgsAsWritten ? &ToTAInfo : nullptr, *POIOrErr);
+        std::get<0>(*FunctionAndArgsOrErr), ToTAList, /*Token=*/{}, TSK,
+        FromTAArgsAsWritten ? &ToTAInfo : nullptr, *POIOrErr);
     return Error::success();
   }
 
@@ -3769,8 +3769,8 @@ ASTNodeImporter::FindFunctionTemplateSpecialization(FunctionDecl *FromFD) {
   FunctionTemplateDecl *Template;
   TemplateArgsTy ToTemplArgs;
   std::tie(Template, ToTemplArgs) = *FunctionAndArgsOrErr;
-  void *InsertPos = nullptr;
-  auto *FoundSpec = Template->findSpecialization(ToTemplArgs, InsertPos);
+  llvm::FoldingSetInsertToken Token;
+  auto *FoundSpec = Template->findSpecialization(ToTemplArgs, Token);
   return FoundSpec;
 }
 
@@ -6368,7 +6368,7 @@ ExpectedDecl ASTNodeImporter::VisitClassTemplateSpecializationDecl(
     return std::move(Err);
   // Try to find an existing specialization with these template arguments and
   // template parameter list.
-  void *InsertPos = nullptr;
+  llvm::FoldingSetInsertToken Token;
   ClassTemplateSpecializationDecl *PrevDecl = nullptr;
   ClassTemplatePartialSpecializationDecl *PartialSpec =
             dyn_cast<ClassTemplatePartialSpecializationDecl>(D);
@@ -6382,10 +6382,9 @@ ExpectedDecl ASTNodeImporter::VisitClassTemplateSpecializationDecl(
       return ToTPListOrErr.takeError();
     ToTPList = *ToTPListOrErr;
     PrevDecl = ClassTemplate->findPartialSpecialization(TemplateArgs,
-                                                        *ToTPListOrErr,
-                                                        InsertPos);
+                                                        *ToTPListOrErr, Token);
   } else
-    PrevDecl = ClassTemplate->findSpecialization(TemplateArgs, InsertPos);
+    PrevDecl = ClassTemplate->findSpecialization(TemplateArgs, Token);
 
   if (PrevDecl) {
     if (IsStructuralMatch(D, PrevDecl)) {
@@ -6446,13 +6445,13 @@ ExpectedDecl ASTNodeImporter::VisitClassTemplateSpecializationDecl(
             cast_or_null<ClassTemplatePartialSpecializationDecl>(PrevDecl)))
       return D2;
 
-    // Update InsertPos, because preceding import calls may have invalidated
+    // Update Token, because preceding import calls may have invalidated
     // it by adding new specializations.
     auto *PartSpec2 = cast<ClassTemplatePartialSpecializationDecl>(D2);
     if (!ClassTemplate->findPartialSpecialization(TemplateArgs, ToTPList,
-                                                  InsertPos))
+                                                  Token))
       // Add this partial specialization to the class template.
-      ClassTemplate->AddPartialSpecialization(PartSpec2, InsertPos);
+      ClassTemplate->AddPartialSpecialization(PartSpec2, Token);
     if (Expected<ClassTemplatePartialSpecializationDecl *> ToInstOrErr =
             import(PartialSpec->getInstantiatedFromMember()))
       PartSpec2->setInstantiatedFromMember(*ToInstOrErr);
@@ -6467,11 +6466,11 @@ ExpectedDecl ASTNodeImporter::VisitClassTemplateSpecializationDecl(
                                 PrevDecl))
       return D2;
 
-    // Update InsertPos, because preceding import calls may have invalidated
+    // Update Token, because preceding import calls may have invalidated
     // it by adding new specializations.
-    if (!ClassTemplate->findSpecialization(TemplateArgs, InsertPos))
+    if (!ClassTemplate->findSpecialization(TemplateArgs, Token))
       // Add this specialization to the class template.
-      ClassTemplate->AddSpecialization(D2, InsertPos);
+      ClassTemplate->AddSpecialization(D2, Token);
   }
 
   D2->setSpecializationKind(D->getSpecializationKind());
@@ -6698,9 +6697,9 @@ ExpectedDecl ASTNodeImporter::VisitVarTemplateSpecializationDecl(
     return std::move(Err);
 
   // Try to find an existing specialization with these template arguments.
-  void *InsertPos = nullptr;
+  llvm::FoldingSetInsertToken Token;
   VarTemplateSpecializationDecl *FoundSpecialization =
-      VarTemplate->findSpecialization(TemplateArgs, InsertPos);
+      VarTemplate->findSpecialization(TemplateArgs, Token);
   if (FoundSpecialization) {
     if (IsStructuralMatch(D, FoundSpecialization)) {
       VarDecl *FoundDef = FoundSpecialization->getDefinition();
@@ -6770,10 +6769,10 @@ ExpectedDecl ASTNodeImporter::VisitVarTemplateSpecializationDecl(
       return D2;
   }
 
-  // Update InsertPos, because preceding import calls may have invalidated
+  // Update Token, because preceding import calls may have invalidated
   // it by adding new specializations.
-  if (!VarTemplate->findSpecialization(TemplateArgs, InsertPos))
-    VarTemplate->AddSpecialization(D2, InsertPos);
+  if (!VarTemplate->findSpecialization(TemplateArgs, Token))
+    VarTemplate->AddSpecialization(D2, Token);
 
   QualType T;
   if (Error Err = importInto(T, D->getType()))

--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -7282,9 +7282,9 @@ bool Compiler<Emitter>::emitLambdaStaticInvokerBody(const CXXMethodDecl *MD) {
     const TemplateArgumentList *TAL = MD->getTemplateSpecializationArgs();
     FunctionTemplateDecl *CallOpTemplate =
         LambdaCallOp->getDescribedFunctionTemplate();
-    void *InsertPos = nullptr;
+    llvm::FoldingSetInsertToken Token;
     const FunctionDecl *CorrespondingCallOpSpecialization =
-        CallOpTemplate->findSpecialization(TAL->asArray(), InsertPos);
+        CallOpTemplate->findSpecialization(TAL->asArray(), Token);
     assert(CorrespondingCallOpSpecialization);
     LambdaCallOp = CorrespondingCallOpSpecialization;
   } else {

--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -7282,9 +7282,9 @@ bool Compiler<Emitter>::emitLambdaStaticInvokerBody(const CXXMethodDecl *MD) {
     const TemplateArgumentList *TAL = MD->getTemplateSpecializationArgs();
     FunctionTemplateDecl *CallOpTemplate =
         LambdaCallOp->getDescribedFunctionTemplate();
-    llvm::FoldingSetInsertToken Token;
+    llvm::FoldingSetInsertToken InsertToken;
     const FunctionDecl *CorrespondingCallOpSpecialization =
-        CallOpTemplate->findSpecialization(TAL->asArray(), Token);
+        CallOpTemplate->findSpecialization(TAL->asArray(), InsertToken);
     assert(CorrespondingCallOpSpecialization);
     LambdaCallOp = CorrespondingCallOpSpecialization;
   } else {

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -4393,7 +4393,7 @@ FunctionDecl::getTemplateSpecializationArgsAsWritten() const {
 
 void FunctionDecl::setFunctionTemplateSpecialization(
     ASTContext &C, FunctionTemplateDecl *Template,
-    TemplateArgumentList *TemplateArgs, void *InsertPos,
+    TemplateArgumentList *TemplateArgs, llvm::FoldingSetInsertToken Token,
     TemplateSpecializationKind TSK,
     const TemplateArgumentListInfo *TemplateArgsAsWritten,
     SourceLocation PointOfInstantiation) {
@@ -4413,7 +4413,7 @@ void FunctionDecl::setFunctionTemplateSpecialization(
           dyn_cast_if_present<MemberSpecializationInfo *>(
               TemplateOrSpecialization));
   TemplateOrSpecialization = Info;
-  Template->addSpecialization(Info, InsertPos);
+  Template->addSpecialization(Info, Token);
 }
 
 void FunctionDecl::setDependentTemplateSpecialization(

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -4393,7 +4393,7 @@ FunctionDecl::getTemplateSpecializationArgsAsWritten() const {
 
 void FunctionDecl::setFunctionTemplateSpecialization(
     ASTContext &C, FunctionTemplateDecl *Template,
-    TemplateArgumentList *TemplateArgs, llvm::FoldingSetInsertToken Token,
+    TemplateArgumentList *TemplateArgs, llvm::FoldingSetInsertToken InsertToken,
     TemplateSpecializationKind TSK,
     const TemplateArgumentListInfo *TemplateArgsAsWritten,
     SourceLocation PointOfInstantiation) {
@@ -4413,7 +4413,7 @@ void FunctionDecl::setFunctionTemplateSpecialization(
           dyn_cast_if_present<MemberSpecializationInfo *>(
               TemplateOrSpecialization));
   TemplateOrSpecialization = Info;
-  Template->addSpecialization(Info, Token);
+  Template->addSpecialization(Info, InsertToken);
 }
 
 void FunctionDecl::setDependentTemplateSpecialization(

--- a/clang/lib/AST/DeclTemplate.cpp
+++ b/clang/lib/AST/DeclTemplate.cpp
@@ -376,38 +376,38 @@ bool RedeclarableTemplateDecl::loadLazySpecializationsImpl(
 template <class EntryType, typename... ProfileArguments>
 typename RedeclarableTemplateDecl::SpecEntryTraits<EntryType>::DeclType *
 RedeclarableTemplateDecl::findSpecializationLocally(
-    llvm::FoldingSetVector<EntryType> &Specs, void *&InsertPos,
-    ProfileArguments... ProfileArgs) {
+    llvm::FoldingSetVector<EntryType> &Specs,
+    llvm::FoldingSetInsertToken &Token, ProfileArguments... ProfileArgs) {
   using SETraits = RedeclarableTemplateDecl::SpecEntryTraits<EntryType>;
 
   llvm::FoldingSetNodeID ID;
   EntryType::Profile(ID, ProfileArgs..., getASTContext());
-  EntryType *Entry = Specs.FindNodeOrInsertPos(ID, InsertPos);
+  EntryType *Entry = Specs.lookup(ID, Token);
   return Entry ? SETraits::getDecl(Entry)->getMostRecentDecl() : nullptr;
 }
 
 template <class EntryType, typename... ProfileArguments>
 typename RedeclarableTemplateDecl::SpecEntryTraits<EntryType>::DeclType *
 RedeclarableTemplateDecl::findSpecializationImpl(
-    llvm::FoldingSetVector<EntryType> &Specs, void *&InsertPos,
-    ProfileArguments... ProfileArgs) {
+    llvm::FoldingSetVector<EntryType> &Specs,
+    llvm::FoldingSetInsertToken &Token, ProfileArguments... ProfileArgs) {
 
-  if (auto *Found = findSpecializationLocally(Specs, InsertPos, ProfileArgs...))
+  if (auto *Found = findSpecializationLocally(Specs, Token, ProfileArgs...))
     return Found;
 
   if (!loadLazySpecializationsImpl(ProfileArgs...))
     return nullptr;
 
-  return findSpecializationLocally(Specs, InsertPos, ProfileArgs...);
+  return findSpecializationLocally(Specs, Token, ProfileArgs...);
 }
 
-template<class Derived, class EntryType>
+template <class Derived, class EntryType>
 void RedeclarableTemplateDecl::addSpecializationImpl(
     llvm::FoldingSetVector<EntryType> &Specializations, EntryType *Entry,
-    void *InsertPos) {
+    llvm::FoldingSetInsertToken Token) {
   using SETraits = SpecEntryTraits<EntryType>;
 
-  if (InsertPos) {
+  if (Token) {
 #ifndef NDEBUG
     auto Args = SETraits::getTemplateArgs(Entry);
     // Due to hash collisions, it can happen that we load another template
@@ -415,14 +415,13 @@ void RedeclarableTemplateDecl::addSpecializationImpl(
     // call to findSpecializationImpl does not find a matching Decl for the
     // template arguments.
     loadLazySpecializationsImpl(Args);
-    void *CorrectInsertPos;
-    assert(!findSpecializationImpl(Specializations, CorrectInsertPos, Args) &&
-           InsertPos == CorrectInsertPos &&
-           "given incorrect InsertPos for specialization");
+    llvm::FoldingSetInsertToken CorrectToken;
+    assert(!findSpecializationImpl(Specializations, CorrectToken, Args) &&
+           Token == CorrectToken && "given incorrect Token for specialization");
 #endif
-    Specializations.InsertNode(Entry, InsertPos);
+    Specializations.insert(Entry, Token);
   } else {
-    EntryType *Existing = Specializations.GetOrInsertNode(Entry);
+    EntryType *Existing = Specializations.getOrInsert(Entry);
     (void)Existing;
     assert(SETraits::getDecl(Existing)->isCanonicalDecl() &&
            "non-canonical specialization?");
@@ -474,16 +473,17 @@ FunctionTemplateDecl::getSpecializations() const {
 
 FunctionDecl *
 FunctionTemplateDecl::findSpecialization(ArrayRef<TemplateArgument> Args,
-                                         void *&InsertPos) {
+                                         llvm::FoldingSetInsertToken &Token) {
   auto *Common = getCommonPtr();
-  return findSpecializationImpl(Common->Specializations, InsertPos, Args);
+  return findSpecializationImpl(Common->Specializations, Token, Args);
 }
 
 void FunctionTemplateDecl::addSpecialization(
-      FunctionTemplateSpecializationInfo *Info, void *InsertPos) {
+    FunctionTemplateSpecializationInfo *Info,
+    llvm::FoldingSetInsertToken Token) {
   auto *Common = getCommonPtr();
   addSpecializationImpl<FunctionTemplateDecl>(Common->Specializations, Info,
-                                              InsertPos);
+                                              Token);
 }
 
 void FunctionTemplateDecl::mergePrevDecl(FunctionTemplateDecl *Prev) {
@@ -569,24 +569,22 @@ ClassTemplateDecl::newCommon(ASTContext &C) const {
 
 ClassTemplateSpecializationDecl *
 ClassTemplateDecl::findSpecialization(ArrayRef<TemplateArgument> Args,
-                                      void *&InsertPos) {
+                                      llvm::FoldingSetInsertToken &Token) {
   auto *Common = getCommonPtr();
-  return findSpecializationImpl(Common->Specializations, InsertPos, Args);
+  return findSpecializationImpl(Common->Specializations, Token, Args);
 }
 
 void ClassTemplateDecl::AddSpecialization(ClassTemplateSpecializationDecl *D,
-                                          void *InsertPos) {
+                                          llvm::FoldingSetInsertToken Token) {
   auto *Common = getCommonPtr();
-  addSpecializationImpl<ClassTemplateDecl>(Common->Specializations, D,
-                                           InsertPos);
+  addSpecializationImpl<ClassTemplateDecl>(Common->Specializations, D, Token);
 }
 
 ClassTemplatePartialSpecializationDecl *
 ClassTemplateDecl::findPartialSpecialization(
-    ArrayRef<TemplateArgument> Args,
-    TemplateParameterList *TPL, void *&InsertPos) {
-  return findSpecializationImpl(getPartialSpecializations(), InsertPos, Args,
-                                TPL);
+    ArrayRef<TemplateArgument> Args, TemplateParameterList *TPL,
+    llvm::FoldingSetInsertToken &Token) {
+  return findSpecializationImpl(getPartialSpecializations(), Token, Args, TPL);
 }
 
 void ClassTemplatePartialSpecializationDecl::Profile(
@@ -599,13 +597,13 @@ void ClassTemplatePartialSpecializationDecl::Profile(
 }
 
 void ClassTemplateDecl::AddPartialSpecialization(
-                                      ClassTemplatePartialSpecializationDecl *D,
-                                      void *InsertPos) {
-  if (InsertPos)
-    getPartialSpecializations().InsertNode(D, InsertPos);
+    ClassTemplatePartialSpecializationDecl *D,
+    llvm::FoldingSetInsertToken Token) {
+  if (Token)
+    getPartialSpecializations().insert(D, Token);
   else {
-    ClassTemplatePartialSpecializationDecl *Existing
-      = getPartialSpecializations().GetOrInsertNode(D);
+    ClassTemplatePartialSpecializationDecl *Existing =
+        getPartialSpecializations().getOrInsert(D);
     (void)Existing;
     assert(Existing->isCanonicalDecl() && "Non-canonical specialization?");
   }
@@ -1363,22 +1361,22 @@ VarTemplateDecl::newCommon(ASTContext &C) const {
 
 VarTemplateSpecializationDecl *
 VarTemplateDecl::findSpecialization(ArrayRef<TemplateArgument> Args,
-                                    void *&InsertPos) {
+                                    llvm::FoldingSetInsertToken &Token) {
   auto *Common = getCommonPtr();
-  return findSpecializationImpl(Common->Specializations, InsertPos, Args);
+  return findSpecializationImpl(Common->Specializations, Token, Args);
 }
 
 void VarTemplateDecl::AddSpecialization(VarTemplateSpecializationDecl *D,
-                                        void *InsertPos) {
+                                        llvm::FoldingSetInsertToken Token) {
   auto *Common = getCommonPtr();
-  addSpecializationImpl<VarTemplateDecl>(Common->Specializations, D, InsertPos);
+  addSpecializationImpl<VarTemplateDecl>(Common->Specializations, D, Token);
 }
 
 VarTemplatePartialSpecializationDecl *
 VarTemplateDecl::findPartialSpecialization(ArrayRef<TemplateArgument> Args,
-     TemplateParameterList *TPL, void *&InsertPos) {
-  return findSpecializationImpl(getPartialSpecializations(), InsertPos, Args,
-                                TPL);
+                                           TemplateParameterList *TPL,
+                                           llvm::FoldingSetInsertToken &Token) {
+  return findSpecializationImpl(getPartialSpecializations(), Token, Args, TPL);
 }
 
 void VarTemplatePartialSpecializationDecl::Profile(
@@ -1391,12 +1389,13 @@ void VarTemplatePartialSpecializationDecl::Profile(
 }
 
 void VarTemplateDecl::AddPartialSpecialization(
-    VarTemplatePartialSpecializationDecl *D, void *InsertPos) {
-  if (InsertPos)
-    getPartialSpecializations().InsertNode(D, InsertPos);
+    VarTemplatePartialSpecializationDecl *D,
+    llvm::FoldingSetInsertToken Token) {
+  if (Token)
+    getPartialSpecializations().insert(D, Token);
   else {
     VarTemplatePartialSpecializationDecl *Existing =
-        getPartialSpecializations().GetOrInsertNode(D);
+        getPartialSpecializations().getOrInsert(D);
     (void)Existing;
     assert(Existing->isCanonicalDecl() && "Non-canonical specialization?");
   }

--- a/clang/lib/AST/DeclTemplate.cpp
+++ b/clang/lib/AST/DeclTemplate.cpp
@@ -377,12 +377,12 @@ template <class EntryType, typename... ProfileArguments>
 typename RedeclarableTemplateDecl::SpecEntryTraits<EntryType>::DeclType *
 RedeclarableTemplateDecl::findSpecializationLocally(
     llvm::FoldingSetVector<EntryType> &Specs,
-    llvm::FoldingSetInsertToken &Token, ProfileArguments... ProfileArgs) {
+    llvm::FoldingSetInsertToken &InsertToken, ProfileArguments... ProfileArgs) {
   using SETraits = RedeclarableTemplateDecl::SpecEntryTraits<EntryType>;
 
   llvm::FoldingSetNodeID ID;
   EntryType::Profile(ID, ProfileArgs..., getASTContext());
-  EntryType *Entry = Specs.lookup(ID, Token);
+  EntryType *Entry = Specs.lookup(ID, InsertToken);
   return Entry ? SETraits::getDecl(Entry)->getMostRecentDecl() : nullptr;
 }
 
@@ -390,24 +390,25 @@ template <class EntryType, typename... ProfileArguments>
 typename RedeclarableTemplateDecl::SpecEntryTraits<EntryType>::DeclType *
 RedeclarableTemplateDecl::findSpecializationImpl(
     llvm::FoldingSetVector<EntryType> &Specs,
-    llvm::FoldingSetInsertToken &Token, ProfileArguments... ProfileArgs) {
+    llvm::FoldingSetInsertToken &InsertToken, ProfileArguments... ProfileArgs) {
 
-  if (auto *Found = findSpecializationLocally(Specs, Token, ProfileArgs...))
+  if (auto *Found =
+          findSpecializationLocally(Specs, InsertToken, ProfileArgs...))
     return Found;
 
   if (!loadLazySpecializationsImpl(ProfileArgs...))
     return nullptr;
 
-  return findSpecializationLocally(Specs, Token, ProfileArgs...);
+  return findSpecializationLocally(Specs, InsertToken, ProfileArgs...);
 }
 
 template <class Derived, class EntryType>
 void RedeclarableTemplateDecl::addSpecializationImpl(
     llvm::FoldingSetVector<EntryType> &Specializations, EntryType *Entry,
-    llvm::FoldingSetInsertToken Token) {
+    llvm::FoldingSetInsertToken InsertToken) {
   using SETraits = SpecEntryTraits<EntryType>;
 
-  if (Token) {
+  if (InsertToken) {
 #ifndef NDEBUG
     auto Args = SETraits::getTemplateArgs(Entry);
     // Due to hash collisions, it can happen that we load another template
@@ -417,9 +418,10 @@ void RedeclarableTemplateDecl::addSpecializationImpl(
     loadLazySpecializationsImpl(Args);
     llvm::FoldingSetInsertToken CorrectToken;
     assert(!findSpecializationImpl(Specializations, CorrectToken, Args) &&
-           Token == CorrectToken && "given incorrect Token for specialization");
+           InsertToken == CorrectToken &&
+           "given incorrect InsertToken for specialization");
 #endif
-    Specializations.insert(Entry, Token);
+    Specializations.insert(Entry, InsertToken);
   } else {
     EntryType *Existing = Specializations.getOrInsert(Entry);
     (void)Existing;
@@ -471,19 +473,18 @@ FunctionTemplateDecl::getSpecializations() const {
   return getCommonPtr()->Specializations;
 }
 
-FunctionDecl *
-FunctionTemplateDecl::findSpecialization(ArrayRef<TemplateArgument> Args,
-                                         llvm::FoldingSetInsertToken &Token) {
+FunctionDecl *FunctionTemplateDecl::findSpecialization(
+    ArrayRef<TemplateArgument> Args, llvm::FoldingSetInsertToken &InsertToken) {
   auto *Common = getCommonPtr();
-  return findSpecializationImpl(Common->Specializations, Token, Args);
+  return findSpecializationImpl(Common->Specializations, InsertToken, Args);
 }
 
 void FunctionTemplateDecl::addSpecialization(
     FunctionTemplateSpecializationInfo *Info,
-    llvm::FoldingSetInsertToken Token) {
+    llvm::FoldingSetInsertToken InsertToken) {
   auto *Common = getCommonPtr();
   addSpecializationImpl<FunctionTemplateDecl>(Common->Specializations, Info,
-                                              Token);
+                                              InsertToken);
 }
 
 void FunctionTemplateDecl::mergePrevDecl(FunctionTemplateDecl *Prev) {
@@ -567,24 +568,26 @@ ClassTemplateDecl::newCommon(ASTContext &C) const {
   return CommonPtr;
 }
 
-ClassTemplateSpecializationDecl *
-ClassTemplateDecl::findSpecialization(ArrayRef<TemplateArgument> Args,
-                                      llvm::FoldingSetInsertToken &Token) {
+ClassTemplateSpecializationDecl *ClassTemplateDecl::findSpecialization(
+    ArrayRef<TemplateArgument> Args, llvm::FoldingSetInsertToken &InsertToken) {
   auto *Common = getCommonPtr();
-  return findSpecializationImpl(Common->Specializations, Token, Args);
+  return findSpecializationImpl(Common->Specializations, InsertToken, Args);
 }
 
-void ClassTemplateDecl::AddSpecialization(ClassTemplateSpecializationDecl *D,
-                                          llvm::FoldingSetInsertToken Token) {
+void ClassTemplateDecl::AddSpecialization(
+    ClassTemplateSpecializationDecl *D,
+    llvm::FoldingSetInsertToken InsertToken) {
   auto *Common = getCommonPtr();
-  addSpecializationImpl<ClassTemplateDecl>(Common->Specializations, D, Token);
+  addSpecializationImpl<ClassTemplateDecl>(Common->Specializations, D,
+                                           InsertToken);
 }
 
 ClassTemplatePartialSpecializationDecl *
 ClassTemplateDecl::findPartialSpecialization(
     ArrayRef<TemplateArgument> Args, TemplateParameterList *TPL,
-    llvm::FoldingSetInsertToken &Token) {
-  return findSpecializationImpl(getPartialSpecializations(), Token, Args, TPL);
+    llvm::FoldingSetInsertToken &InsertToken) {
+  return findSpecializationImpl(getPartialSpecializations(), InsertToken, Args,
+                                TPL);
 }
 
 void ClassTemplatePartialSpecializationDecl::Profile(
@@ -598,9 +601,9 @@ void ClassTemplatePartialSpecializationDecl::Profile(
 
 void ClassTemplateDecl::AddPartialSpecialization(
     ClassTemplatePartialSpecializationDecl *D,
-    llvm::FoldingSetInsertToken Token) {
-  if (Token)
-    getPartialSpecializations().insert(D, Token);
+    llvm::FoldingSetInsertToken InsertToken) {
+  if (InsertToken)
+    getPartialSpecializations().insert(D, InsertToken);
   else {
     ClassTemplatePartialSpecializationDecl *Existing =
         getPartialSpecializations().getOrInsert(D);
@@ -1361,22 +1364,24 @@ VarTemplateDecl::newCommon(ASTContext &C) const {
 
 VarTemplateSpecializationDecl *
 VarTemplateDecl::findSpecialization(ArrayRef<TemplateArgument> Args,
-                                    llvm::FoldingSetInsertToken &Token) {
+                                    llvm::FoldingSetInsertToken &InsertToken) {
   auto *Common = getCommonPtr();
-  return findSpecializationImpl(Common->Specializations, Token, Args);
+  return findSpecializationImpl(Common->Specializations, InsertToken, Args);
 }
 
-void VarTemplateDecl::AddSpecialization(VarTemplateSpecializationDecl *D,
-                                        llvm::FoldingSetInsertToken Token) {
+void VarTemplateDecl::AddSpecialization(
+    VarTemplateSpecializationDecl *D, llvm::FoldingSetInsertToken InsertToken) {
   auto *Common = getCommonPtr();
-  addSpecializationImpl<VarTemplateDecl>(Common->Specializations, D, Token);
+  addSpecializationImpl<VarTemplateDecl>(Common->Specializations, D,
+                                         InsertToken);
 }
 
 VarTemplatePartialSpecializationDecl *
-VarTemplateDecl::findPartialSpecialization(ArrayRef<TemplateArgument> Args,
-                                           TemplateParameterList *TPL,
-                                           llvm::FoldingSetInsertToken &Token) {
-  return findSpecializationImpl(getPartialSpecializations(), Token, Args, TPL);
+VarTemplateDecl::findPartialSpecialization(
+    ArrayRef<TemplateArgument> Args, TemplateParameterList *TPL,
+    llvm::FoldingSetInsertToken &InsertToken) {
+  return findSpecializationImpl(getPartialSpecializations(), InsertToken, Args,
+                                TPL);
 }
 
 void VarTemplatePartialSpecializationDecl::Profile(
@@ -1390,9 +1395,9 @@ void VarTemplatePartialSpecializationDecl::Profile(
 
 void VarTemplateDecl::AddPartialSpecialization(
     VarTemplatePartialSpecializationDecl *D,
-    llvm::FoldingSetInsertToken Token) {
-  if (Token)
-    getPartialSpecializations().insert(D, Token);
+    llvm::FoldingSetInsertToken InsertToken) {
+  if (InsertToken)
+    getPartialSpecializations().insert(D, InsertToken);
   else {
     VarTemplatePartialSpecializationDecl *Existing =
         getPartialSpecializations().getOrInsert(D);

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -9018,9 +9018,9 @@ public:
           const TemplateArgumentList *TAL = MD->getTemplateSpecializationArgs();
           FunctionTemplateDecl *CallOpTemplate =
               LambdaCallOp->getDescribedFunctionTemplate();
-          llvm::FoldingSetInsertToken Token;
+          llvm::FoldingSetInsertToken InsertToken;
           FunctionDecl *CorrespondingCallOpSpecialization =
-              CallOpTemplate->findSpecialization(TAL->asArray(), Token);
+              CallOpTemplate->findSpecialization(TAL->asArray(), InsertToken);
           assert(CorrespondingCallOpSpecialization &&
                  "We must always have a function call operator specialization "
                  "that corresponds to our static invoker specialization");

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -9018,9 +9018,9 @@ public:
           const TemplateArgumentList *TAL = MD->getTemplateSpecializationArgs();
           FunctionTemplateDecl *CallOpTemplate =
               LambdaCallOp->getDescribedFunctionTemplate();
-          void *InsertPos = nullptr;
+          llvm::FoldingSetInsertToken Token;
           FunctionDecl *CorrespondingCallOpSpecialization =
-              CallOpTemplate->findSpecialization(TAL->asArray(), InsertPos);
+              CallOpTemplate->findSpecialization(TAL->asArray(), Token);
           assert(CorrespondingCallOpSpecialization &&
                  "We must always have a function call operator specialization "
                  "that corresponds to our static invoker specialization");

--- a/clang/lib/Analysis/AnalysisDeclContext.cpp
+++ b/clang/lib/Analysis/AnalysisDeclContext.cpp
@@ -411,11 +411,11 @@ const StackFrame *StackFrameManager::getStackFrame(
     const Expr *E, const CFGBlock *B, unsigned BlockCount, unsigned StmtIdx) {
   llvm::FoldingSetNodeID ID;
   StackFrame::Profile(ID, Ctx, Parent, Data, E, B, BlockCount, StmtIdx);
-  void *InsertPos;
-  StackFrame *SF = Frames.FindNodeOrInsertPos(ID, InsertPos);
+  llvm::FoldingSetInsertToken Token;
+  StackFrame *SF = Frames.lookup(ID, Token);
   if (!SF) {
     SF = new StackFrame(Ctx, Parent, Data, E, B, BlockCount, StmtIdx, ++NewID);
-    Frames.InsertNode(SF, InsertPos);
+    Frames.insert(SF, Token);
   }
   return SF;
 }

--- a/clang/lib/Analysis/AnalysisDeclContext.cpp
+++ b/clang/lib/Analysis/AnalysisDeclContext.cpp
@@ -411,11 +411,11 @@ const StackFrame *StackFrameManager::getStackFrame(
     const Expr *E, const CFGBlock *B, unsigned BlockCount, unsigned StmtIdx) {
   llvm::FoldingSetNodeID ID;
   StackFrame::Profile(ID, Ctx, Parent, Data, E, B, BlockCount, StmtIdx);
-  llvm::FoldingSetInsertToken Token;
-  StackFrame *SF = Frames.lookup(ID, Token);
+  llvm::FoldingSetInsertToken InsertToken;
+  StackFrame *SF = Frames.lookup(ID, InsertToken);
   if (!SF) {
     SF = new StackFrame(Ctx, Parent, Data, E, B, BlockCount, StmtIdx, ++NewID);
-    Frames.insert(SF, Token);
+    Frames.insert(SF, InsertToken);
   }
   return SF;
 }

--- a/clang/lib/Analysis/LifetimeSafety/Loans.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Loans.cpp
@@ -39,14 +39,13 @@ const PlaceholderBase *
 LoanManager::getOrCreatePlaceholderBase(const ParmVarDecl *PVD) {
   llvm::FoldingSetNodeID ID;
   ID.AddPointer(PVD);
-  void *InsertPos = nullptr;
-  if (PlaceholderBase *Existing =
-          PlaceholderBases.FindNodeOrInsertPos(ID, InsertPos))
+  llvm::FoldingSetInsertToken Token;
+  if (PlaceholderBase *Existing = PlaceholderBases.lookup(ID, Token))
     return Existing;
 
   void *Mem = LoanAllocator.Allocate<PlaceholderBase>();
   PlaceholderBase *NewPB = new (Mem) PlaceholderBase(PVD);
-  PlaceholderBases.InsertNode(NewPB, InsertPos);
+  PlaceholderBases.insert(NewPB, Token);
   return NewPB;
 }
 
@@ -54,14 +53,13 @@ const PlaceholderBase *
 LoanManager::getOrCreatePlaceholderBase(const CXXMethodDecl *MD) {
   llvm::FoldingSetNodeID ID;
   ID.AddPointer(MD);
-  void *InsertPos = nullptr;
-  if (PlaceholderBase *Existing =
-          PlaceholderBases.FindNodeOrInsertPos(ID, InsertPos))
+  llvm::FoldingSetInsertToken Token;
+  if (PlaceholderBase *Existing = PlaceholderBases.lookup(ID, Token))
     return Existing;
 
   void *Mem = LoanAllocator.Allocate<PlaceholderBase>();
   PlaceholderBase *NewPB = new (Mem) PlaceholderBase(MD);
-  PlaceholderBases.InsertNode(NewPB, InsertPos);
+  PlaceholderBases.insert(NewPB, Token);
   return NewPB;
 }
 } // namespace clang::lifetimes::internal

--- a/clang/lib/Analysis/LifetimeSafety/Loans.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Loans.cpp
@@ -39,13 +39,13 @@ const PlaceholderBase *
 LoanManager::getOrCreatePlaceholderBase(const ParmVarDecl *PVD) {
   llvm::FoldingSetNodeID ID;
   ID.AddPointer(PVD);
-  llvm::FoldingSetInsertToken Token;
-  if (PlaceholderBase *Existing = PlaceholderBases.lookup(ID, Token))
+  llvm::FoldingSetInsertToken InsertToken;
+  if (PlaceholderBase *Existing = PlaceholderBases.lookup(ID, InsertToken))
     return Existing;
 
   void *Mem = LoanAllocator.Allocate<PlaceholderBase>();
   PlaceholderBase *NewPB = new (Mem) PlaceholderBase(PVD);
-  PlaceholderBases.insert(NewPB, Token);
+  PlaceholderBases.insert(NewPB, InsertToken);
   return NewPB;
 }
 
@@ -53,13 +53,13 @@ const PlaceholderBase *
 LoanManager::getOrCreatePlaceholderBase(const CXXMethodDecl *MD) {
   llvm::FoldingSetNodeID ID;
   ID.AddPointer(MD);
-  llvm::FoldingSetInsertToken Token;
-  if (PlaceholderBase *Existing = PlaceholderBases.lookup(ID, Token))
+  llvm::FoldingSetInsertToken InsertToken;
+  if (PlaceholderBase *Existing = PlaceholderBases.lookup(ID, InsertToken))
     return Existing;
 
   void *Mem = LoanAllocator.Allocate<PlaceholderBase>();
   PlaceholderBase *NewPB = new (Mem) PlaceholderBase(MD);
-  PlaceholderBases.insert(NewPB, Token);
+  PlaceholderBases.insert(NewPB, InsertToken);
   return NewPB;
 }
 } // namespace clang::lifetimes::internal

--- a/clang/lib/Analysis/PathDiagnostic.cpp
+++ b/clang/lib/Analysis/PathDiagnostic.cpp
@@ -199,9 +199,9 @@ void PathDiagnosticConsumer::HandlePathDiagnostic(
   // Profile the node to see if we already have something matching it
   llvm::FoldingSetNodeID profile;
   D->Profile(profile);
-  llvm::FoldingSetInsertToken Token;
+  llvm::FoldingSetInsertToken InsertToken;
 
-  if (PathDiagnostic *orig = Diags.lookup(profile, Token)) {
+  if (PathDiagnostic *orig = Diags.lookup(profile, InsertToken)) {
     // Keep the PathDiagnostic with the shorter path.
     // Note, the enclosing routine is called in deterministic order, so the
     // results will be consistent between runs (no reason to break ties if the
@@ -437,12 +437,12 @@ void PathDiagnosticConsumer::FilesMade::addDiagnostic(const PathDiagnostic &PD,
                                                       StringRef FileName) {
   llvm::FoldingSetNodeID NodeID;
   NodeID.Add(PD);
-  llvm::FoldingSetInsertToken Token;
-  PDFileEntry *Entry = Set.lookup(NodeID, Token);
+  llvm::FoldingSetInsertToken InsertToken;
+  PDFileEntry *Entry = Set.lookup(NodeID, InsertToken);
   if (!Entry) {
     Entry = Alloc.Allocate<PDFileEntry>();
     Entry = new (Entry) PDFileEntry(NodeID);
-    Set.insert(Entry, Token);
+    Set.insert(Entry, InsertToken);
   }
 
   // Allocate persistent storage for the file name.
@@ -458,8 +458,8 @@ PathDiagnosticConsumer::PDFileEntry::ConsumerFiles *
 PathDiagnosticConsumer::FilesMade::getFiles(const PathDiagnostic &PD) {
   llvm::FoldingSetNodeID NodeID;
   NodeID.Add(PD);
-  llvm::FoldingSetInsertToken Token;
-  PDFileEntry *Entry = Set.lookup(NodeID, Token);
+  llvm::FoldingSetInsertToken InsertToken;
+  PDFileEntry *Entry = Set.lookup(NodeID, InsertToken);
   if (!Entry)
     return nullptr;
   return &Entry->files;

--- a/clang/lib/Analysis/PathDiagnostic.cpp
+++ b/clang/lib/Analysis/PathDiagnostic.cpp
@@ -199,9 +199,9 @@ void PathDiagnosticConsumer::HandlePathDiagnostic(
   // Profile the node to see if we already have something matching it
   llvm::FoldingSetNodeID profile;
   D->Profile(profile);
-  void *InsertPos = nullptr;
+  llvm::FoldingSetInsertToken Token;
 
-  if (PathDiagnostic *orig = Diags.FindNodeOrInsertPos(profile, InsertPos)) {
+  if (PathDiagnostic *orig = Diags.lookup(profile, Token)) {
     // Keep the PathDiagnostic with the shorter path.
     // Note, the enclosing routine is called in deterministic order, so the
     // results will be consistent between runs (no reason to break ties if the
@@ -212,11 +212,11 @@ void PathDiagnosticConsumer::HandlePathDiagnostic(
       return;
 
     assert(orig != D.get());
-    Diags.RemoveNode(orig);
+    Diags.erase(orig);
     delete orig;
   }
 
-  Diags.InsertNode(D.release());
+  Diags.insert(D.release());
 }
 
 static std::optional<bool> comparePath(const PathPieces &X,
@@ -437,12 +437,12 @@ void PathDiagnosticConsumer::FilesMade::addDiagnostic(const PathDiagnostic &PD,
                                                       StringRef FileName) {
   llvm::FoldingSetNodeID NodeID;
   NodeID.Add(PD);
-  void *InsertPos;
-  PDFileEntry *Entry = Set.FindNodeOrInsertPos(NodeID, InsertPos);
+  llvm::FoldingSetInsertToken Token;
+  PDFileEntry *Entry = Set.lookup(NodeID, Token);
   if (!Entry) {
     Entry = Alloc.Allocate<PDFileEntry>();
     Entry = new (Entry) PDFileEntry(NodeID);
-    Set.InsertNode(Entry, InsertPos);
+    Set.insert(Entry, Token);
   }
 
   // Allocate persistent storage for the file name.
@@ -458,8 +458,8 @@ PathDiagnosticConsumer::PDFileEntry::ConsumerFiles *
 PathDiagnosticConsumer::FilesMade::getFiles(const PathDiagnostic &PD) {
   llvm::FoldingSetNodeID NodeID;
   NodeID.Add(PD);
-  void *InsertPos;
-  PDFileEntry *Entry = Set.FindNodeOrInsertPos(NodeID, InsertPos);
+  llvm::FoldingSetInsertToken Token;
+  PDFileEntry *Entry = Set.lookup(NodeID, Token);
   if (!Entry)
     return nullptr;
   return &Entry->files;

--- a/clang/lib/Analysis/RetainSummaryManager.cpp
+++ b/clang/lib/Analysis/RetainSummaryManager.cpp
@@ -120,13 +120,13 @@ RetainSummaryManager::getPersistentSummary(const RetainSummary &OldSumm) {
     ::llvm::FoldingSetNodeID ID;
     OldSumm.Profile(ID);
 
-    llvm::FoldingSetInsertToken Token;
-    CachedSummaryNode *N = SimpleSummaries.lookup(ID, Token);
+    llvm::FoldingSetInsertToken InsertToken;
+    CachedSummaryNode *N = SimpleSummaries.lookup(ID, InsertToken);
 
     if (!N) {
       N = (CachedSummaryNode *) BPAlloc.Allocate<CachedSummaryNode>();
       new (N) CachedSummaryNode(OldSumm);
-      SimpleSummaries.insert(N, Token);
+      SimpleSummaries.insert(N, InsertToken);
     }
 
     return &N->getValue();

--- a/clang/lib/Analysis/RetainSummaryManager.cpp
+++ b/clang/lib/Analysis/RetainSummaryManager.cpp
@@ -120,13 +120,13 @@ RetainSummaryManager::getPersistentSummary(const RetainSummary &OldSumm) {
     ::llvm::FoldingSetNodeID ID;
     OldSumm.Profile(ID);
 
-    void *Pos;
-    CachedSummaryNode *N = SimpleSummaries.FindNodeOrInsertPos(ID, Pos);
+    llvm::FoldingSetInsertToken Token;
+    CachedSummaryNode *N = SimpleSummaries.lookup(ID, Token);
 
     if (!N) {
       N = (CachedSummaryNode *) BPAlloc.Allocate<CachedSummaryNode>();
       new (N) CachedSummaryNode(OldSumm);
-      SimpleSummaries.InsertNode(N, Pos);
+      SimpleSummaries.insert(N, Token);
     }
 
     return &N->getValue();

--- a/clang/lib/Basic/IdentifierTable.cpp
+++ b/clang/lib/Basic/IdentifierTable.cpp
@@ -754,9 +754,8 @@ Selector SelectorTable::getSelector(unsigned nKeys,
   llvm::FoldingSetNodeID ID;
   MultiKeywordSelector::Profile(ID, IIV, nKeys);
 
-  void *InsertPos = nullptr;
-  if (MultiKeywordSelector *SI =
-        SelTabImpl.Table.FindNodeOrInsertPos(ID, InsertPos))
+  llvm::FoldingSetInsertToken Token;
+  if (MultiKeywordSelector *SI = SelTabImpl.Table.lookup(ID, Token))
     return Selector(SI);
 
   // MultiKeywordSelector objects are not allocated with new because they have a
@@ -766,7 +765,7 @@ Selector SelectorTable::getSelector(unsigned nKeys,
       (MultiKeywordSelector *)SelTabImpl.Allocator.Allocate(
           Size, alignof(MultiKeywordSelector));
   new (SI) MultiKeywordSelector(nKeys, IIV);
-  SelTabImpl.Table.InsertNode(SI, InsertPos);
+  SelTabImpl.Table.insert(SI, Token);
   return Selector(SI);
 }
 

--- a/clang/lib/Basic/IdentifierTable.cpp
+++ b/clang/lib/Basic/IdentifierTable.cpp
@@ -754,8 +754,8 @@ Selector SelectorTable::getSelector(unsigned nKeys,
   llvm::FoldingSetNodeID ID;
   MultiKeywordSelector::Profile(ID, IIV, nKeys);
 
-  llvm::FoldingSetInsertToken Token;
-  if (MultiKeywordSelector *SI = SelTabImpl.Table.lookup(ID, Token))
+  llvm::FoldingSetInsertToken InsertToken;
+  if (MultiKeywordSelector *SI = SelTabImpl.Table.lookup(ID, InsertToken))
     return Selector(SI);
 
   // MultiKeywordSelector objects are not allocated with new because they have a
@@ -765,7 +765,7 @@ Selector SelectorTable::getSelector(unsigned nKeys,
       (MultiKeywordSelector *)SelTabImpl.Allocator.Allocate(
           Size, alignof(MultiKeywordSelector));
   new (SI) MultiKeywordSelector(nKeys, IIV);
-  SelTabImpl.Table.insert(SI, Token);
+  SelTabImpl.Table.insert(SI, InsertToken);
   return Selector(SI);
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenClass.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenClass.cpp
@@ -982,9 +982,9 @@ void CIRGenFunction::emitLambdaDelegatingInvokeBody(const CXXMethodDecl *md) {
     const TemplateArgumentList *tal = md->getTemplateSpecializationArgs();
     FunctionTemplateDecl *callOpTemplate =
         callOp->getDescribedFunctionTemplate();
-    void *InsertPos = nullptr;
+    llvm::FoldingSetInsertToken Token;
     FunctionDecl *correspondingCallOpSpecialization =
-        callOpTemplate->findSpecialization(tal->asArray(), InsertPos);
+        callOpTemplate->findSpecialization(tal->asArray(), Token);
     assert(correspondingCallOpSpecialization);
     callOp = cast<CXXMethodDecl>(correspondingCallOpSpecialization);
   }

--- a/clang/lib/CIR/CodeGen/CIRGenClass.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenClass.cpp
@@ -982,9 +982,9 @@ void CIRGenFunction::emitLambdaDelegatingInvokeBody(const CXXMethodDecl *md) {
     const TemplateArgumentList *tal = md->getTemplateSpecializationArgs();
     FunctionTemplateDecl *callOpTemplate =
         callOp->getDescribedFunctionTemplate();
-    llvm::FoldingSetInsertToken Token;
+    llvm::FoldingSetInsertToken InsertToken;
     FunctionDecl *correspondingCallOpSpecialization =
-        callOpTemplate->findSpecialization(tal->asArray(), Token);
+        callOpTemplate->findSpecialization(tal->asArray(), InsertToken);
     assert(correspondingCallOpSpecialization);
     callOp = cast<CXXMethodDecl>(correspondingCallOpSpecialization);
   }

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -764,8 +764,8 @@ const CIRGenFunctionInfo &CIRGenTypes::arrangeCIRFunctionInfo(
   CIRGenFunctionInfo::Profile(id, isInstanceMethod, info, required, returnType,
                               argTypes);
 
-  llvm::FoldingSetInsertToken token;
-  CIRGenFunctionInfo *fi = functionInfos.lookup(id, token);
+  llvm::FoldingSetInsertToken insertToken;
+  CIRGenFunctionInfo *fi = functionInfos.lookup(id, insertToken);
   if (fi) {
     // We found a matching function info based on id. These asserts verify that
     // it really is a match.
@@ -781,7 +781,7 @@ const CIRGenFunctionInfo &CIRGenTypes::arrangeCIRFunctionInfo(
   // Construction the function info. We co-allocate the ArgInfos.
   fi = CIRGenFunctionInfo::create(info, isInstanceMethod, returnType, argTypes,
                                   required);
-  functionInfos.insert(fi, token);
+  functionInfos.insert(fi, insertToken);
 
   return *fi;
 }

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -764,8 +764,8 @@ const CIRGenFunctionInfo &CIRGenTypes::arrangeCIRFunctionInfo(
   CIRGenFunctionInfo::Profile(id, isInstanceMethod, info, required, returnType,
                               argTypes);
 
-  void *insertPos = nullptr;
-  CIRGenFunctionInfo *fi = functionInfos.FindNodeOrInsertPos(id, insertPos);
+  llvm::FoldingSetInsertToken token;
+  CIRGenFunctionInfo *fi = functionInfos.lookup(id, token);
   if (fi) {
     // We found a matching function info based on id. These asserts verify that
     // it really is a match.
@@ -781,7 +781,7 @@ const CIRGenFunctionInfo &CIRGenTypes::arrangeCIRFunctionInfo(
   // Construction the function info. We co-allocate the ArgInfos.
   fi = CIRGenFunctionInfo::create(info, isInstanceMethod, returnType, argTypes,
                                   required);
-  functionInfos.InsertNode(fi, insertPos);
+  functionInfos.insert(fi, token);
 
   return *fi;
 }

--- a/clang/lib/CodeGen/CGBlocks.cpp
+++ b/clang/lib/CodeGen/CGBlocks.cpp
@@ -2509,16 +2509,15 @@ static T *buildByrefHelpers(CodeGenModule &CGM, const BlockByrefInfo &byrefInfo,
   llvm::FoldingSetNodeID id;
   generator.Profile(id);
 
-  void *insertPos;
-  BlockByrefHelpers *node
-    = CGM.ByrefHelpersCache.FindNodeOrInsertPos(id, insertPos);
+  llvm::FoldingSetInsertToken Token;
+  BlockByrefHelpers *node = CGM.ByrefHelpersCache.lookup(id, Token);
   if (node) return static_cast<T*>(node);
 
   generator.CopyHelper = buildByrefCopyHelper(CGM, byrefInfo, generator);
   generator.DisposeHelper = buildByrefDisposeHelper(CGM, byrefInfo, generator);
 
   T *copy = new (CGM.getContext()) T(std::forward<T>(generator));
-  CGM.ByrefHelpersCache.InsertNode(copy, insertPos);
+  CGM.ByrefHelpersCache.insert(copy, Token);
   return copy;
 }
 

--- a/clang/lib/CodeGen/CGBlocks.cpp
+++ b/clang/lib/CodeGen/CGBlocks.cpp
@@ -2509,15 +2509,15 @@ static T *buildByrefHelpers(CodeGenModule &CGM, const BlockByrefInfo &byrefInfo,
   llvm::FoldingSetNodeID id;
   generator.Profile(id);
 
-  llvm::FoldingSetInsertToken Token;
-  BlockByrefHelpers *node = CGM.ByrefHelpersCache.lookup(id, Token);
+  llvm::FoldingSetInsertToken InsertToken;
+  BlockByrefHelpers *node = CGM.ByrefHelpersCache.lookup(id, InsertToken);
   if (node) return static_cast<T*>(node);
 
   generator.CopyHelper = buildByrefCopyHelper(CGM, byrefInfo, generator);
   generator.DisposeHelper = buildByrefDisposeHelper(CGM, byrefInfo, generator);
 
   T *copy = new (CGM.getContext()) T(std::forward<T>(generator));
-  CGM.ByrefHelpersCache.insert(copy, Token);
+  CGM.ByrefHelpersCache.insert(copy, InsertToken);
   return copy;
 }
 

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -1092,8 +1092,8 @@ CGFunctionInfo *CodeGenTypes::findOrInsertCGFunctionInfo(
                           X86ABIAVXLevel, info, paramInfos, required,
                           resultType, argTypes);
 
-  llvm::FoldingSetInsertToken Token;
-  CGFunctionInfo *FI = FunctionInfos.lookup(ID, Token);
+  llvm::FoldingSetInsertToken InsertToken;
+  CGFunctionInfo *FI = FunctionInfos.lookup(ID, InsertToken);
   if (FI)
     return FI;
 
@@ -1103,7 +1103,7 @@ CGFunctionInfo *CodeGenTypes::findOrInsertCGFunctionInfo(
   FI = CGFunctionInfo::create(CC, isInstanceMethod, isChainCall, isDelegateCall,
                               X86ABIAVXLevel, info, paramInfos, resultType,
                               argTypes, required);
-  FunctionInfos.insert(FI, Token);
+  FunctionInfos.insert(FI, InsertToken);
 
   bool inserted = FunctionsBeingProcessed.insert(FI).second;
   (void)inserted;

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -1092,8 +1092,8 @@ CGFunctionInfo *CodeGenTypes::findOrInsertCGFunctionInfo(
                           X86ABIAVXLevel, info, paramInfos, required,
                           resultType, argTypes);
 
-  void *insertPos = nullptr;
-  CGFunctionInfo *FI = FunctionInfos.FindNodeOrInsertPos(ID, insertPos);
+  llvm::FoldingSetInsertToken Token;
+  CGFunctionInfo *FI = FunctionInfos.lookup(ID, Token);
   if (FI)
     return FI;
 
@@ -1103,7 +1103,7 @@ CGFunctionInfo *CodeGenTypes::findOrInsertCGFunctionInfo(
   FI = CGFunctionInfo::create(CC, isInstanceMethod, isChainCall, isDelegateCall,
                               X86ABIAVXLevel, info, paramInfos, resultType,
                               argTypes, required);
-  FunctionInfos.InsertNode(FI, insertPos);
+  FunctionInfos.insert(FI, Token);
 
   bool inserted = FunctionsBeingProcessed.insert(FI).second;
   (void)inserted;

--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -3235,9 +3235,9 @@ void CodeGenFunction::EmitLambdaDelegatingInvokeBody(const CXXMethodDecl *MD,
     const TemplateArgumentList *TAL = MD->getTemplateSpecializationArgs();
     FunctionTemplateDecl *CallOpTemplate =
         CallOp->getDescribedFunctionTemplate();
-    llvm::FoldingSetInsertToken Token;
+    llvm::FoldingSetInsertToken InsertToken;
     FunctionDecl *CorrespondingCallOpSpecialization =
-        CallOpTemplate->findSpecialization(TAL->asArray(), Token);
+        CallOpTemplate->findSpecialization(TAL->asArray(), InsertToken);
     assert(CorrespondingCallOpSpecialization);
     CallOp = cast<CXXMethodDecl>(CorrespondingCallOpSpecialization);
   }

--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -3235,9 +3235,9 @@ void CodeGenFunction::EmitLambdaDelegatingInvokeBody(const CXXMethodDecl *MD,
     const TemplateArgumentList *TAL = MD->getTemplateSpecializationArgs();
     FunctionTemplateDecl *CallOpTemplate =
         CallOp->getDescribedFunctionTemplate();
-    void *InsertPos = nullptr;
+    llvm::FoldingSetInsertToken Token;
     FunctionDecl *CorrespondingCallOpSpecialization =
-        CallOpTemplate->findSpecialization(TAL->asArray(), InsertPos);
+        CallOpTemplate->findSpecialization(TAL->asArray(), Token);
     assert(CorrespondingCallOpSpecialization);
     CallOp = cast<CXXMethodDecl>(CorrespondingCallOpSpecialization);
   }

--- a/clang/lib/Lex/PPMacroExpansion.cpp
+++ b/clang/lib/Lex/PPMacroExpansion.cpp
@@ -134,14 +134,14 @@ ModuleMacro *Preprocessor::addModuleMacro(Module *Mod, IdentifierInfo *II,
   llvm::FoldingSetNodeID ID;
   ModuleMacro::Profile(ID, Mod, II);
 
-  void *InsertPos;
-  if (auto *MM = ModuleMacros.FindNodeOrInsertPos(ID, InsertPos)) {
+  llvm::FoldingSetInsertToken InsertToken;
+  if (auto *MM = ModuleMacros.lookup(ID, InsertToken)) {
     New = false;
     return MM;
   }
 
   auto *MM = ModuleMacro::create(*this, Mod, II, Macro, Overrides);
-  ModuleMacros.InsertNode(MM, InsertPos);
+  ModuleMacros.insert(MM, InsertToken);
 
   // Each overridden macro is now overridden by one more macro.
   bool HidAny = false;
@@ -171,8 +171,8 @@ ModuleMacro *Preprocessor::getModuleMacro(Module *Mod,
   llvm::FoldingSetNodeID ID;
   ModuleMacro::Profile(ID, Mod, II);
 
-  void *InsertPos;
-  return ModuleMacros.FindNodeOrInsertPos(ID, InsertPos);
+  llvm::FoldingSetInsertToken InsertToken;
+  return ModuleMacros.lookup(ID, InsertToken);
 }
 
 void Preprocessor::updateModuleMacroInfo(const IdentifierInfo *II,

--- a/clang/lib/Sema/HLSLExternalSemaSource.cpp
+++ b/clang/lib/Sema/HLSLExternalSemaSource.cpp
@@ -382,7 +382,7 @@ addVectorTexturePartialSpecialization(Sema &S, NamespaceDecl *HLSLNamespace,
 
   // Add the partial specialization to the namespace and the class template.
   HLSLNamespace->addDecl(PartialSpec);
-  TextureTemplate->AddPartialSpecialization(PartialSpec, nullptr);
+  TextureTemplate->AddPartialSpecialization(PartialSpec, {});
 
   return PartialSpec;
 }

--- a/clang/lib/Sema/SemaCXXScopeSpec.cpp
+++ b/clang/lib/Sema/SemaCXXScopeSpec.cpp
@@ -100,9 +100,9 @@ DeclContext *Sema::computeDeclContext(const CXXScopeSpec &SS,
                                return TPL->getDepth() == Depth;
                              });
       if (L != TemplateParamLists.end()) {
-        void *Pos = nullptr;
+        llvm::FoldingSetInsertToken Token;
         PartialSpec = ClassTemplate->findPartialSpecialization(
-            SpecType->template_arguments(), *L, Pos);
+            SpecType->template_arguments(), *L, Token);
       }
     } else {
       // FIXME: The fallback on the search of partial

--- a/clang/lib/Sema/SemaCXXScopeSpec.cpp
+++ b/clang/lib/Sema/SemaCXXScopeSpec.cpp
@@ -100,9 +100,9 @@ DeclContext *Sema::computeDeclContext(const CXXScopeSpec &SS,
                                return TPL->getDepth() == Depth;
                              });
       if (L != TemplateParamLists.end()) {
-        llvm::FoldingSetInsertToken Token;
+        llvm::FoldingSetInsertToken InsertToken;
         PartialSpec = ClassTemplate->findPartialSpecialization(
-            SpecType->template_arguments(), *L, Token);
+            SpecType->template_arguments(), *L, InsertToken);
       }
     } else {
       // FIXME: The fallback on the search of partial

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -3977,9 +3977,9 @@ QualType Sema::CheckTemplateIdType(ElaboratedTypeKeyword Keyword,
                  dyn_cast<ClassTemplateDecl>(Template)) {
     // Find the class template specialization declaration that
     // corresponds to these arguments.
-    void *InsertPos = nullptr;
+    llvm::FoldingSetInsertToken Token;
     ClassTemplateSpecializationDecl *Decl =
-        ClassTemplate->findSpecialization(CTAI.CanonicalConverted, InsertPos);
+        ClassTemplate->findSpecialization(CTAI.CanonicalConverted, Token);
     if (!Decl) {
       // This is the first time we have referenced this class template
       // specialization. Create the canonical declaration and add it to
@@ -3990,7 +3990,7 @@ QualType Sema::CheckTemplateIdType(ElaboratedTypeKeyword Keyword,
           ClassTemplate->getTemplatedDecl()->getBeginLoc(),
           ClassTemplate->getLocation(), ClassTemplate, CTAI.CanonicalConverted,
           CTAI.StrictPackMatch, nullptr);
-      ClassTemplate->AddSpecialization(Decl, InsertPos);
+      ClassTemplate->AddSpecialization(Decl, Token);
       if (ClassTemplate->isOutOfLine())
         Decl->setLexicalDeclContext(ClassTemplate->getLexicalDeclContext());
     }
@@ -4465,15 +4465,14 @@ DeclResult Sema::ActOnVarTemplateSpecialization(
     }
   }
 
-  void *InsertPos = nullptr;
+  llvm::FoldingSetInsertToken Token;
   VarTemplateSpecializationDecl *PrevDecl = nullptr;
 
   if (IsPartialSpecialization)
-    PrevDecl = VarTemplate->findPartialSpecialization(
-        CTAI.CanonicalConverted, TemplateParams, InsertPos);
+    PrevDecl = VarTemplate->findPartialSpecialization(CTAI.CanonicalConverted,
+                                                      TemplateParams, Token);
   else
-    PrevDecl =
-        VarTemplate->findSpecialization(CTAI.CanonicalConverted, InsertPos);
+    PrevDecl = VarTemplate->findSpecialization(CTAI.CanonicalConverted, Token);
 
   VarTemplateSpecializationDecl *Specialization = nullptr;
 
@@ -4504,7 +4503,7 @@ DeclResult Sema::ActOnVarTemplateSpecialization(
     Partial->setTemplateArgsAsWritten(TemplateArgs);
 
     if (!PrevPartial)
-      VarTemplate->AddPartialSpecialization(Partial, InsertPos);
+      VarTemplate->AddPartialSpecialization(Partial, Token);
     Specialization = Partial;
 
     CheckTemplatePartialSpecialization(Partial);
@@ -4517,7 +4516,7 @@ DeclResult Sema::ActOnVarTemplateSpecialization(
     Specialization->setTemplateArgsAsWritten(TemplateArgs);
 
     if (!PrevDecl)
-      VarTemplate->AddSpecialization(Specialization, InsertPos);
+      VarTemplate->AddSpecialization(Specialization, Token);
   }
 
   // C++ [temp.expl.spec]p6:
@@ -4658,9 +4657,9 @@ Sema::CheckVarTemplateId(VarTemplateDecl *Template, SourceLocation TemplateLoc,
 
   // Find the variable template specialization declaration that
   // corresponds to these arguments.
-  void *InsertPos = nullptr;
+  llvm::FoldingSetInsertToken Token;
   if (VarTemplateSpecializationDecl *Spec =
-          Template->findSpecialization(CTAI.CanonicalConverted, InsertPos)) {
+          Template->findSpecialization(CTAI.CanonicalConverted, Token)) {
     checkSpecializationReachability(TemplateNameLoc, Spec);
     if (Spec->getType()->isUndeducedType()) {
       if (ParsingInitForAutoVars.count(Spec))
@@ -8952,15 +8951,15 @@ DeclResult Sema::ActOnClassTemplateSpecialization(
     }
   }
 
-  void *InsertPos = nullptr;
+  llvm::FoldingSetInsertToken Token;
   ClassTemplateSpecializationDecl *PrevDecl = nullptr;
 
   if (isPartialSpecialization)
-    PrevDecl = ClassTemplate->findPartialSpecialization(
-        CTAI.CanonicalConverted, TemplateParams, InsertPos);
+    PrevDecl = ClassTemplate->findPartialSpecialization(CTAI.CanonicalConverted,
+                                                        TemplateParams, Token);
   else
     PrevDecl =
-        ClassTemplate->findSpecialization(CTAI.CanonicalConverted, InsertPos);
+        ClassTemplate->findSpecialization(CTAI.CanonicalConverted, Token);
 
   ClassTemplateSpecializationDecl *Specialization = nullptr;
 
@@ -8986,7 +8985,7 @@ DeclResult Sema::ActOnClassTemplateSpecialization(
     }
 
     if (!PrevDecl)
-      ClassTemplate->AddSpecialization(Specialization, InsertPos);
+      ClassTemplate->AddSpecialization(Specialization, Token);
   } else {
     CanQualType CanonType = CanQualType::CreateUnsafe(
         Context.getCanonicalTemplateSpecializationType(
@@ -9031,7 +9030,7 @@ DeclResult Sema::ActOnClassTemplateSpecialization(
     }
 
     if (!PrevPartial)
-      ClassTemplate->AddPartialSpecialization(Partial, InsertPos);
+      ClassTemplate->AddPartialSpecialization(Partial, Token);
     Specialization = Partial;
 
     // If we are providing an explicit specialization of a member class
@@ -9858,7 +9857,7 @@ bool Sema::CheckFunctionTemplateSpecialization(
   TemplateArgumentList *TemplArgs = TemplateArgumentList::CreateCopy(
       Context, Specialization->getTemplateSpecializationArgs()->asArray());
   FD->setFunctionTemplateSpecialization(
-      Specialization->getPrimaryTemplate(), TemplArgs, /*InsertPos=*/nullptr,
+      Specialization->getPrimaryTemplate(), TemplArgs, /*Token=*/{},
       SpecInfo->getTemplateSpecializationKind(),
       ExplicitTemplateArgs ? &ConvertedTemplateArgs[Specialization] : nullptr);
 
@@ -10356,9 +10355,9 @@ DeclResult Sema::ActOnExplicitInstantiation(
 
   // Find the class template specialization declaration that
   // corresponds to these arguments.
-  void *InsertPos = nullptr;
+  llvm::FoldingSetInsertToken Token;
   ClassTemplateSpecializationDecl *PrevDecl =
-      ClassTemplate->findSpecialization(CTAI.CanonicalConverted, InsertPos);
+      ClassTemplate->findSpecialization(CTAI.CanonicalConverted, Token);
 
   TemplateSpecializationKind PrevDecl_TSK
     = PrevDecl ? PrevDecl->getTemplateSpecializationKind() : TSK_Undeclared;
@@ -10449,7 +10448,7 @@ DeclResult Sema::ActOnExplicitInstantiation(
 
     if (!HasNoEffect && !PrevDecl) {
       // Insert the new specialization.
-      ClassTemplate->AddSpecialization(Specialization, InsertPos);
+      ClassTemplate->AddSpecialization(Specialization, Token);
     }
   }
 

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -3977,9 +3977,9 @@ QualType Sema::CheckTemplateIdType(ElaboratedTypeKeyword Keyword,
                  dyn_cast<ClassTemplateDecl>(Template)) {
     // Find the class template specialization declaration that
     // corresponds to these arguments.
-    llvm::FoldingSetInsertToken Token;
+    llvm::FoldingSetInsertToken InsertToken;
     ClassTemplateSpecializationDecl *Decl =
-        ClassTemplate->findSpecialization(CTAI.CanonicalConverted, Token);
+        ClassTemplate->findSpecialization(CTAI.CanonicalConverted, InsertToken);
     if (!Decl) {
       // This is the first time we have referenced this class template
       // specialization. Create the canonical declaration and add it to
@@ -3990,7 +3990,7 @@ QualType Sema::CheckTemplateIdType(ElaboratedTypeKeyword Keyword,
           ClassTemplate->getTemplatedDecl()->getBeginLoc(),
           ClassTemplate->getLocation(), ClassTemplate, CTAI.CanonicalConverted,
           CTAI.StrictPackMatch, nullptr);
-      ClassTemplate->AddSpecialization(Decl, Token);
+      ClassTemplate->AddSpecialization(Decl, InsertToken);
       if (ClassTemplate->isOutOfLine())
         Decl->setLexicalDeclContext(ClassTemplate->getLexicalDeclContext());
     }
@@ -4465,14 +4465,15 @@ DeclResult Sema::ActOnVarTemplateSpecialization(
     }
   }
 
-  llvm::FoldingSetInsertToken Token;
+  llvm::FoldingSetInsertToken InsertToken;
   VarTemplateSpecializationDecl *PrevDecl = nullptr;
 
   if (IsPartialSpecialization)
-    PrevDecl = VarTemplate->findPartialSpecialization(CTAI.CanonicalConverted,
-                                                      TemplateParams, Token);
+    PrevDecl = VarTemplate->findPartialSpecialization(
+        CTAI.CanonicalConverted, TemplateParams, InsertToken);
   else
-    PrevDecl = VarTemplate->findSpecialization(CTAI.CanonicalConverted, Token);
+    PrevDecl =
+        VarTemplate->findSpecialization(CTAI.CanonicalConverted, InsertToken);
 
   VarTemplateSpecializationDecl *Specialization = nullptr;
 
@@ -4503,7 +4504,7 @@ DeclResult Sema::ActOnVarTemplateSpecialization(
     Partial->setTemplateArgsAsWritten(TemplateArgs);
 
     if (!PrevPartial)
-      VarTemplate->AddPartialSpecialization(Partial, Token);
+      VarTemplate->AddPartialSpecialization(Partial, InsertToken);
     Specialization = Partial;
 
     CheckTemplatePartialSpecialization(Partial);
@@ -4516,7 +4517,7 @@ DeclResult Sema::ActOnVarTemplateSpecialization(
     Specialization->setTemplateArgsAsWritten(TemplateArgs);
 
     if (!PrevDecl)
-      VarTemplate->AddSpecialization(Specialization, Token);
+      VarTemplate->AddSpecialization(Specialization, InsertToken);
   }
 
   // C++ [temp.expl.spec]p6:
@@ -4657,9 +4658,9 @@ Sema::CheckVarTemplateId(VarTemplateDecl *Template, SourceLocation TemplateLoc,
 
   // Find the variable template specialization declaration that
   // corresponds to these arguments.
-  llvm::FoldingSetInsertToken Token;
+  llvm::FoldingSetInsertToken InsertToken;
   if (VarTemplateSpecializationDecl *Spec =
-          Template->findSpecialization(CTAI.CanonicalConverted, Token)) {
+          Template->findSpecialization(CTAI.CanonicalConverted, InsertToken)) {
     checkSpecializationReachability(TemplateNameLoc, Spec);
     if (Spec->getType()->isUndeducedType()) {
       if (ParsingInitForAutoVars.count(Spec))
@@ -8951,15 +8952,15 @@ DeclResult Sema::ActOnClassTemplateSpecialization(
     }
   }
 
-  llvm::FoldingSetInsertToken Token;
+  llvm::FoldingSetInsertToken InsertToken;
   ClassTemplateSpecializationDecl *PrevDecl = nullptr;
 
   if (isPartialSpecialization)
-    PrevDecl = ClassTemplate->findPartialSpecialization(CTAI.CanonicalConverted,
-                                                        TemplateParams, Token);
+    PrevDecl = ClassTemplate->findPartialSpecialization(
+        CTAI.CanonicalConverted, TemplateParams, InsertToken);
   else
     PrevDecl =
-        ClassTemplate->findSpecialization(CTAI.CanonicalConverted, Token);
+        ClassTemplate->findSpecialization(CTAI.CanonicalConverted, InsertToken);
 
   ClassTemplateSpecializationDecl *Specialization = nullptr;
 
@@ -8985,7 +8986,7 @@ DeclResult Sema::ActOnClassTemplateSpecialization(
     }
 
     if (!PrevDecl)
-      ClassTemplate->AddSpecialization(Specialization, Token);
+      ClassTemplate->AddSpecialization(Specialization, InsertToken);
   } else {
     CanQualType CanonType = CanQualType::CreateUnsafe(
         Context.getCanonicalTemplateSpecializationType(
@@ -9030,7 +9031,7 @@ DeclResult Sema::ActOnClassTemplateSpecialization(
     }
 
     if (!PrevPartial)
-      ClassTemplate->AddPartialSpecialization(Partial, Token);
+      ClassTemplate->AddPartialSpecialization(Partial, InsertToken);
     Specialization = Partial;
 
     // If we are providing an explicit specialization of a member class
@@ -9857,7 +9858,7 @@ bool Sema::CheckFunctionTemplateSpecialization(
   TemplateArgumentList *TemplArgs = TemplateArgumentList::CreateCopy(
       Context, Specialization->getTemplateSpecializationArgs()->asArray());
   FD->setFunctionTemplateSpecialization(
-      Specialization->getPrimaryTemplate(), TemplArgs, /*Token=*/{},
+      Specialization->getPrimaryTemplate(), TemplArgs, /*InsertToken=*/{},
       SpecInfo->getTemplateSpecializationKind(),
       ExplicitTemplateArgs ? &ConvertedTemplateArgs[Specialization] : nullptr);
 
@@ -10355,9 +10356,9 @@ DeclResult Sema::ActOnExplicitInstantiation(
 
   // Find the class template specialization declaration that
   // corresponds to these arguments.
-  llvm::FoldingSetInsertToken Token;
+  llvm::FoldingSetInsertToken InsertToken;
   ClassTemplateSpecializationDecl *PrevDecl =
-      ClassTemplate->findSpecialization(CTAI.CanonicalConverted, Token);
+      ClassTemplate->findSpecialization(CTAI.CanonicalConverted, InsertToken);
 
   TemplateSpecializationKind PrevDecl_TSK
     = PrevDecl ? PrevDecl->getTemplateSpecializationKind() : TSK_Undeclared;
@@ -10448,7 +10449,7 @@ DeclResult Sema::ActOnExplicitInstantiation(
 
     if (!HasNoEffect && !PrevDecl) {
       // Insert the new specialization.
-      ClassTemplate->AddSpecialization(Specialization, Token);
+      ClassTemplate->AddSpecialization(Specialization, InsertToken);
     }
   }
 

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -2977,9 +2977,9 @@ Decl *TemplateDeclInstantiator::VisitFunctionDecl(
   if (FunctionTemplate && !TemplateParams) {
     ArrayRef<TemplateArgument> Innermost = TemplateArgs.getInnermost();
 
-    void *InsertPos = nullptr;
-    FunctionDecl *SpecFunc
-      = FunctionTemplate->findSpecialization(Innermost, InsertPos);
+    llvm::FoldingSetInsertToken Token;
+    FunctionDecl *SpecFunc =
+        FunctionTemplate->findSpecialization(Innermost, Token);
 
     // If we already have a function template specialization, return it.
     if (SpecFunc)
@@ -3147,10 +3147,10 @@ Decl *TemplateDeclInstantiator::VisitFunctionDecl(
                  Sema::CodeSynthesisContext::BuildingDeductionGuides) {
     // Record this function template specialization.
     ArrayRef<TemplateArgument> Innermost = TemplateArgs.getInnermost();
-    Function->setFunctionTemplateSpecialization(FunctionTemplate,
-                            TemplateArgumentList::CreateCopy(SemaRef.Context,
-                                                             Innermost),
-                                                /*InsertPos=*/nullptr);
+    Function->setFunctionTemplateSpecialization(
+        FunctionTemplate,
+        TemplateArgumentList::CreateCopy(SemaRef.Context, Innermost),
+        /*Token=*/{});
   } else if (FunctionRewriteKind == RewriteKind::None) {
     if (isFriend && D->isThisDeclarationADefinition()) {
       // Do not connect the friend to the template unless it's actually a
@@ -3351,9 +3351,9 @@ Decl *TemplateDeclInstantiator::VisitCXXMethodDecl(
     // specialization for this particular set of template arguments.
     ArrayRef<TemplateArgument> Innermost = TemplateArgs.getInnermost();
 
-    void *InsertPos = nullptr;
-    FunctionDecl *SpecFunc
-      = FunctionTemplate->findSpecialization(Innermost, InsertPos);
+    llvm::FoldingSetInsertToken Token;
+    FunctionDecl *SpecFunc =
+        FunctionTemplate->findSpecialization(Innermost, Token);
 
     // If we already have a function template specialization, return it.
     if (SpecFunc)
@@ -3557,10 +3557,10 @@ Decl *TemplateDeclInstantiator::VisitCXXMethodDecl(
   } else if (FunctionTemplate) {
     // Record this function template specialization.
     ArrayRef<TemplateArgument> Innermost = TemplateArgs.getInnermost();
-    Method->setFunctionTemplateSpecialization(FunctionTemplate,
-                         TemplateArgumentList::CreateCopy(SemaRef.Context,
-                                                          Innermost),
-                                              /*InsertPos=*/nullptr);
+    Method->setFunctionTemplateSpecialization(
+        FunctionTemplate,
+        TemplateArgumentList::CreateCopy(SemaRef.Context, Innermost),
+        /*Token=*/{});
   } else if (!isFriend && FunctionRewriteKind == RewriteKind::None) {
     // Record that this is an instantiation of a member function.
     Method->setInstantiationOfMemberFunction(D, TSK_ImplicitInstantiation);
@@ -4797,9 +4797,9 @@ TemplateDeclInstantiator::VisitClassTemplateSpecializationDecl(
 
   // Figure out where to insert this class template explicit specialization
   // in the member template's set of class template explicit specializations.
-  void *InsertPos = nullptr;
+  llvm::FoldingSetInsertToken Token;
   ClassTemplateSpecializationDecl *PrevDecl =
-      InstClassTemplate->findSpecialization(CTAI.CanonicalConverted, InsertPos);
+      InstClassTemplate->findSpecialization(CTAI.CanonicalConverted, Token);
 
   // Check whether we've already seen a conflicting instantiation of this
   // declaration (for instance, if there was a prior implicit instantiation).
@@ -4844,7 +4844,7 @@ TemplateDeclInstantiator::VisitClassTemplateSpecializationDecl(
   // Add this partial specialization to the set of class template partial
   // specializations.
   if (!PrevDecl)
-    InstClassTemplate->AddSpecialization(InstD, InsertPos);
+    InstClassTemplate->AddSpecialization(InstD, Token);
 
   // Substitute the nested name specifier, if any.
   if (SubstQualifier(D, InstD))
@@ -4905,9 +4905,9 @@ Decl *TemplateDeclInstantiator::VisitVarTemplateSpecializationDecl(
     return nullptr;
 
   // Check whether we've already seen a declaration of this specialization.
-  void *InsertPos = nullptr;
+  llvm::FoldingSetInsertToken Token;
   VarTemplateSpecializationDecl *PrevDecl =
-      InstVarTemplate->findSpecialization(CTAI.CanonicalConverted, InsertPos);
+      InstVarTemplate->findSpecialization(CTAI.CanonicalConverted, Token);
 
   // Check whether we've already seen a conflicting instantiation of this
   // declaration (for instance, if there was a prior implicit instantiation).
@@ -4950,9 +4950,9 @@ TemplateDeclInstantiator::VisitVarTemplateSpecializationDecl(
       SemaRef.Context, Owner, D->getInnerLocStart(), D->getLocation(),
       VarTemplate, TSI->getType(), TSI, D->getStorageClass(), Converted);
   if (!PrevDecl) {
-    void *InsertPos = nullptr;
-    VarTemplate->findSpecialization(Converted, InsertPos);
-    VarTemplate->AddSpecialization(Var, InsertPos);
+    llvm::FoldingSetInsertToken Token;
+    VarTemplate->findSpecialization(Converted, Token);
+    VarTemplate->AddSpecialization(Var, Token);
   }
 
   if (SemaRef.getLangOpts().OpenCL)
@@ -5249,10 +5249,10 @@ TemplateDeclInstantiator::InstantiateClassTemplatePartialSpecialization(
 
   // Figure out where to insert this class template partial specialization
   // in the member template's set of class template partial specializations.
-  void *InsertPos = nullptr;
+  llvm::FoldingSetInsertToken Token;
   ClassTemplateSpecializationDecl *PrevDecl =
       ClassTemplate->findPartialSpecialization(CTAI.CanonicalConverted,
-                                               InstParams, InsertPos);
+                                               InstParams, Token);
 
   // Create the class template partial specialization declaration.
   ClassTemplatePartialSpecializationDecl *InstPartialSpec =
@@ -5301,7 +5301,7 @@ TemplateDeclInstantiator::InstantiateClassTemplatePartialSpecialization(
   // Add this partial specialization to the set of class template partial
   // specializations.
   ClassTemplate->AddPartialSpecialization(InstPartialSpec,
-                                          /*InsertPos=*/nullptr);
+                                          /*Token=*/{});
   return InstPartialSpec;
 }
 
@@ -5358,10 +5358,10 @@ TemplateDeclInstantiator::InstantiateVarTemplatePartialSpecialization(
 
   // Figure out where to insert this variable template partial specialization
   // in the member template's set of variable template partial specializations.
-  void *InsertPos = nullptr;
+  llvm::FoldingSetInsertToken Token;
   VarTemplateSpecializationDecl *PrevDecl =
       VarTemplate->findPartialSpecialization(CTAI.CanonicalConverted,
-                                             InstParams, InsertPos);
+                                             InstParams, Token);
 
   // Do substitution on the type of the declaration
   TypeSourceInfo *TSI = SemaRef.SubstType(
@@ -5420,7 +5420,7 @@ TemplateDeclInstantiator::InstantiateVarTemplatePartialSpecialization(
 
   // Add this partial specialization to the set of variable template partial
   // specializations. The instantiation of the initializer is not necessary.
-  VarTemplate->AddPartialSpecialization(InstPartialSpec, /*InsertPos=*/nullptr);
+  VarTemplate->AddPartialSpecialization(InstPartialSpec, /*Token=*/{});
 
   SemaRef.BuildVariableInstantiation(InstPartialSpec, PartialSpec, TemplateArgs,
                                      LateAttrs, Owner, StartingScope);

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -2977,9 +2977,9 @@ Decl *TemplateDeclInstantiator::VisitFunctionDecl(
   if (FunctionTemplate && !TemplateParams) {
     ArrayRef<TemplateArgument> Innermost = TemplateArgs.getInnermost();
 
-    llvm::FoldingSetInsertToken Token;
+    llvm::FoldingSetInsertToken InsertToken;
     FunctionDecl *SpecFunc =
-        FunctionTemplate->findSpecialization(Innermost, Token);
+        FunctionTemplate->findSpecialization(Innermost, InsertToken);
 
     // If we already have a function template specialization, return it.
     if (SpecFunc)
@@ -3150,7 +3150,7 @@ Decl *TemplateDeclInstantiator::VisitFunctionDecl(
     Function->setFunctionTemplateSpecialization(
         FunctionTemplate,
         TemplateArgumentList::CreateCopy(SemaRef.Context, Innermost),
-        /*Token=*/{});
+        /*InsertToken=*/{});
   } else if (FunctionRewriteKind == RewriteKind::None) {
     if (isFriend && D->isThisDeclarationADefinition()) {
       // Do not connect the friend to the template unless it's actually a
@@ -3351,9 +3351,9 @@ Decl *TemplateDeclInstantiator::VisitCXXMethodDecl(
     // specialization for this particular set of template arguments.
     ArrayRef<TemplateArgument> Innermost = TemplateArgs.getInnermost();
 
-    llvm::FoldingSetInsertToken Token;
+    llvm::FoldingSetInsertToken InsertToken;
     FunctionDecl *SpecFunc =
-        FunctionTemplate->findSpecialization(Innermost, Token);
+        FunctionTemplate->findSpecialization(Innermost, InsertToken);
 
     // If we already have a function template specialization, return it.
     if (SpecFunc)
@@ -3560,7 +3560,7 @@ Decl *TemplateDeclInstantiator::VisitCXXMethodDecl(
     Method->setFunctionTemplateSpecialization(
         FunctionTemplate,
         TemplateArgumentList::CreateCopy(SemaRef.Context, Innermost),
-        /*Token=*/{});
+        /*InsertToken=*/{});
   } else if (!isFriend && FunctionRewriteKind == RewriteKind::None) {
     // Record that this is an instantiation of a member function.
     Method->setInstantiationOfMemberFunction(D, TSK_ImplicitInstantiation);
@@ -4797,9 +4797,10 @@ TemplateDeclInstantiator::VisitClassTemplateSpecializationDecl(
 
   // Figure out where to insert this class template explicit specialization
   // in the member template's set of class template explicit specializations.
-  llvm::FoldingSetInsertToken Token;
+  llvm::FoldingSetInsertToken InsertToken;
   ClassTemplateSpecializationDecl *PrevDecl =
-      InstClassTemplate->findSpecialization(CTAI.CanonicalConverted, Token);
+      InstClassTemplate->findSpecialization(CTAI.CanonicalConverted,
+                                            InsertToken);
 
   // Check whether we've already seen a conflicting instantiation of this
   // declaration (for instance, if there was a prior implicit instantiation).
@@ -4844,7 +4845,7 @@ TemplateDeclInstantiator::VisitClassTemplateSpecializationDecl(
   // Add this partial specialization to the set of class template partial
   // specializations.
   if (!PrevDecl)
-    InstClassTemplate->AddSpecialization(InstD, Token);
+    InstClassTemplate->AddSpecialization(InstD, InsertToken);
 
   // Substitute the nested name specifier, if any.
   if (SubstQualifier(D, InstD))
@@ -4905,9 +4906,9 @@ Decl *TemplateDeclInstantiator::VisitVarTemplateSpecializationDecl(
     return nullptr;
 
   // Check whether we've already seen a declaration of this specialization.
-  llvm::FoldingSetInsertToken Token;
+  llvm::FoldingSetInsertToken InsertToken;
   VarTemplateSpecializationDecl *PrevDecl =
-      InstVarTemplate->findSpecialization(CTAI.CanonicalConverted, Token);
+      InstVarTemplate->findSpecialization(CTAI.CanonicalConverted, InsertToken);
 
   // Check whether we've already seen a conflicting instantiation of this
   // declaration (for instance, if there was a prior implicit instantiation).
@@ -4950,9 +4951,9 @@ TemplateDeclInstantiator::VisitVarTemplateSpecializationDecl(
       SemaRef.Context, Owner, D->getInnerLocStart(), D->getLocation(),
       VarTemplate, TSI->getType(), TSI, D->getStorageClass(), Converted);
   if (!PrevDecl) {
-    llvm::FoldingSetInsertToken Token;
-    VarTemplate->findSpecialization(Converted, Token);
-    VarTemplate->AddSpecialization(Var, Token);
+    llvm::FoldingSetInsertToken InsertToken;
+    VarTemplate->findSpecialization(Converted, InsertToken);
+    VarTemplate->AddSpecialization(Var, InsertToken);
   }
 
   if (SemaRef.getLangOpts().OpenCL)
@@ -5249,10 +5250,10 @@ TemplateDeclInstantiator::InstantiateClassTemplatePartialSpecialization(
 
   // Figure out where to insert this class template partial specialization
   // in the member template's set of class template partial specializations.
-  llvm::FoldingSetInsertToken Token;
+  llvm::FoldingSetInsertToken InsertToken;
   ClassTemplateSpecializationDecl *PrevDecl =
       ClassTemplate->findPartialSpecialization(CTAI.CanonicalConverted,
-                                               InstParams, Token);
+                                               InstParams, InsertToken);
 
   // Create the class template partial specialization declaration.
   ClassTemplatePartialSpecializationDecl *InstPartialSpec =
@@ -5301,7 +5302,7 @@ TemplateDeclInstantiator::InstantiateClassTemplatePartialSpecialization(
   // Add this partial specialization to the set of class template partial
   // specializations.
   ClassTemplate->AddPartialSpecialization(InstPartialSpec,
-                                          /*Token=*/{});
+                                          /*InsertToken=*/{});
   return InstPartialSpec;
 }
 
@@ -5358,10 +5359,10 @@ TemplateDeclInstantiator::InstantiateVarTemplatePartialSpecialization(
 
   // Figure out where to insert this variable template partial specialization
   // in the member template's set of variable template partial specializations.
-  llvm::FoldingSetInsertToken Token;
+  llvm::FoldingSetInsertToken InsertToken;
   VarTemplateSpecializationDecl *PrevDecl =
       VarTemplate->findPartialSpecialization(CTAI.CanonicalConverted,
-                                             InstParams, Token);
+                                             InstParams, InsertToken);
 
   // Do substitution on the type of the declaration
   TypeSourceInfo *TSI = SemaRef.SubstType(
@@ -5420,7 +5421,7 @@ TemplateDeclInstantiator::InstantiateVarTemplatePartialSpecialization(
 
   // Add this partial specialization to the set of variable template partial
   // specializations. The instantiation of the initializer is not necessary.
-  VarTemplate->AddPartialSpecialization(InstPartialSpec, /*Token=*/{});
+  VarTemplate->AddPartialSpecialization(InstPartialSpec, /*InsertToken=*/{});
 
   SemaRef.BuildVariableInstantiation(InstPartialSpec, PartialSpec, TemplateArgs,
                                      LateAttrs, Owner, StartingScope);

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -983,19 +983,19 @@ void ASTDeclReader::VisitFunctionDecl(FunctionDecl *FD) {
       // The template that contains the specializations set. It's not safe to
       // use getCanonicalDecl on Template since it may still be initializing.
       auto *CanonTemplate = readDeclAs<FunctionTemplateDecl>();
-      // Get the InsertPos by FindNodeOrInsertPos() instead of calling
-      // InsertNode(FTInfo) directly to avoid the getASTContext() call in
+      // Get the insert token by lookup() instead of calling insert(FTInfo)
+      // directly to avoid the getASTContext() call in
       // FunctionTemplateSpecializationInfo's Profile().
       // We avoid getASTContext because a decl in the parent hierarchy may
       // be initializing.
       llvm::FoldingSetNodeID ID;
       FunctionTemplateSpecializationInfo::Profile(ID, TemplArgs, C);
-      void *InsertPos = nullptr;
+      llvm::FoldingSetInsertToken Token;
       FunctionTemplateDecl::Common *CommonPtr = CanonTemplate->getCommonPtr();
       FunctionTemplateSpecializationInfo *ExistingInfo =
-          CommonPtr->Specializations.FindNodeOrInsertPos(ID, InsertPos);
-      if (InsertPos)
-        CommonPtr->Specializations.InsertNode(FTInfo, InsertPos);
+          CommonPtr->Specializations.lookup(ID, Token);
+      if (Token)
+        CommonPtr->Specializations.insert(FTInfo, Token);
       else {
         Existing = ExistingInfo->getFunction();
       }
@@ -1573,7 +1573,7 @@ void ASTDeclReader::VisitMSGuidDecl(MSGuidDecl *D) {
     C = Record.readInt();
 
   // Add this GUID to the AST context's lookup structure, and merge if needed.
-  if (MSGuidDecl *Existing = Reader.getContext().MSGuidDecls.GetOrInsertNode(D))
+  if (MSGuidDecl *Existing = Reader.getContext().MSGuidDecls.getOrInsert(D))
     Reader.getContext().setPrimaryMergedDecl(D, Existing->getCanonicalDecl());
 }
 
@@ -1584,7 +1584,7 @@ void ASTDeclReader::VisitUnnamedGlobalConstantDecl(
 
   // Add this to the AST context's lookup structure, and merge if needed.
   if (UnnamedGlobalConstantDecl *Existing =
-          Reader.getContext().UnnamedGlobalConstantDecls.GetOrInsertNode(D))
+          Reader.getContext().UnnamedGlobalConstantDecls.getOrInsert(D))
     Reader.getContext().setPrimaryMergedDecl(D, Existing->getCanonicalDecl());
 }
 
@@ -1595,7 +1595,7 @@ void ASTDeclReader::VisitTemplateParamObjectDecl(TemplateParamObjectDecl *D) {
   // Add this template parameter object to the AST context's lookup structure,
   // and merge if needed.
   if (TemplateParamObjectDecl *Existing =
-          Reader.getContext().TemplateParamObjectDecls.GetOrInsertNode(D))
+          Reader.getContext().TemplateParamObjectDecls.getOrInsert(D))
     Reader.getContext().setPrimaryMergedDecl(D, Existing->getCanonicalDecl());
 }
 
@@ -2598,11 +2598,12 @@ RedeclarableResult ASTDeclReader::VisitClassTemplateSpecializationDeclImpl(
       // Set this as, or find, the canonical declaration for this specialization
       ClassTemplateSpecializationDecl *CanonSpec;
       if (auto *Partial = dyn_cast<ClassTemplatePartialSpecializationDecl>(D)) {
-        CanonSpec = CanonPattern->getCommonPtr()->PartialSpecializations
-            .GetOrInsertNode(Partial);
+        CanonSpec =
+            CanonPattern->getCommonPtr()->PartialSpecializations.getOrInsert(
+                Partial);
       } else {
         CanonSpec =
-            CanonPattern->getCommonPtr()->Specializations.GetOrInsertNode(D);
+            CanonPattern->getCommonPtr()->Specializations.getOrInsert(D);
       }
       // If there was already a canonical specialization, merge into it.
       if (CanonSpec != D) {
@@ -2713,11 +2714,12 @@ RedeclarableResult ASTDeclReader::VisitVarTemplateSpecializationDeclImpl(
     if (D->isCanonicalDecl()) { // It's kept in the folding set.
       VarTemplateSpecializationDecl *CanonSpec;
       if (auto *Partial = dyn_cast<VarTemplatePartialSpecializationDecl>(D)) {
-        CanonSpec = CanonPattern->getCommonPtr()
-                        ->PartialSpecializations.GetOrInsertNode(Partial);
+        CanonSpec =
+            CanonPattern->getCommonPtr()->PartialSpecializations.getOrInsert(
+                Partial);
       } else {
         CanonSpec =
-            CanonPattern->getCommonPtr()->Specializations.GetOrInsertNode(D);
+            CanonPattern->getCommonPtr()->Specializations.getOrInsert(D);
       }
       // If we already have a matching specialization, merge it.
       if (CanonSpec != D)

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -990,12 +990,12 @@ void ASTDeclReader::VisitFunctionDecl(FunctionDecl *FD) {
       // be initializing.
       llvm::FoldingSetNodeID ID;
       FunctionTemplateSpecializationInfo::Profile(ID, TemplArgs, C);
-      llvm::FoldingSetInsertToken Token;
+      llvm::FoldingSetInsertToken InsertToken;
       FunctionTemplateDecl::Common *CommonPtr = CanonTemplate->getCommonPtr();
       FunctionTemplateSpecializationInfo *ExistingInfo =
-          CommonPtr->Specializations.lookup(ID, Token);
-      if (Token)
-        CommonPtr->Specializations.insert(FTInfo, Token);
+          CommonPtr->Specializations.lookup(ID, InsertToken);
+      if (InsertToken)
+        CommonPtr->Specializations.insert(FTInfo, InsertToken);
       else {
         Existing = ExistingInfo->getFunction();
       }

--- a/clang/lib/StaticAnalyzer/Core/BasicValueFactory.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BasicValueFactory.cpp
@@ -89,16 +89,16 @@ BasicValueFactory::~BasicValueFactory() {
 
 APSIntPtr BasicValueFactory::getValue(const llvm::APSInt &X) {
   llvm::FoldingSetNodeID ID;
-  void *InsertPos;
+  llvm::FoldingSetInsertToken Token;
 
   using FoldNodeTy = llvm::FoldingSetNodeWrapper<llvm::APSInt>;
 
   X.Profile(ID);
-  FoldNodeTy* P = APSIntSet.FindNodeOrInsertPos(ID, InsertPos);
+  FoldNodeTy *P = APSIntSet.lookup(ID, Token);
 
   if (!P) {
     P = new (BPAlloc) FoldNodeTy(X);
-    APSIntSet.InsertNode(P, InsertPos);
+    APSIntSet.insert(P, Token);
   }
 
   // We own the APSInt object. It's safe here.
@@ -126,13 +126,13 @@ BasicValueFactory::getCompoundValData(QualType T,
                                       llvm::ImmutableList<SVal> Vals) {
   llvm::FoldingSetNodeID ID;
   CompoundValData::Profile(ID, T, Vals);
-  void *InsertPos;
+  llvm::FoldingSetInsertToken Token;
 
-  CompoundValData* D = CompoundValDataSet.FindNodeOrInsertPos(ID, InsertPos);
+  CompoundValData *D = CompoundValDataSet.lookup(ID, Token);
 
   if (!D) {
     D = new (BPAlloc) CompoundValData(T, Vals);
-    CompoundValDataSet.InsertNode(D, InsertPos);
+    CompoundValDataSet.insert(D, Token);
   }
 
   return D;
@@ -143,14 +143,13 @@ BasicValueFactory::getLazyCompoundValData(const StoreRef &store,
                                           const TypedValueRegion *region) {
   llvm::FoldingSetNodeID ID;
   LazyCompoundValData::Profile(ID, store, region);
-  void *InsertPos;
+  llvm::FoldingSetInsertToken Token;
 
-  LazyCompoundValData *D =
-    LazyCompoundValDataSet.FindNodeOrInsertPos(ID, InsertPos);
+  LazyCompoundValData *D = LazyCompoundValDataSet.lookup(ID, Token);
 
   if (!D) {
     D = new (BPAlloc) LazyCompoundValData(store, region);
-    LazyCompoundValDataSet.InsertNode(D, InsertPos);
+    LazyCompoundValDataSet.insert(D, Token);
   }
 
   return D;
@@ -160,14 +159,13 @@ const PointerToMemberData *BasicValueFactory::getPointerToMemberData(
     const NamedDecl *ND, llvm::ImmutableList<const CXXBaseSpecifier *> L) {
   llvm::FoldingSetNodeID ID;
   PointerToMemberData::Profile(ID, ND, L);
-  void *InsertPos;
+  llvm::FoldingSetInsertToken Token;
 
-  PointerToMemberData *D =
-      PointerToMemberDataSet.FindNodeOrInsertPos(ID, InsertPos);
+  PointerToMemberData *D = PointerToMemberDataSet.lookup(ID, Token);
 
   if (!D) {
     D = new (BPAlloc) PointerToMemberData(ND, L);
-    PointerToMemberDataSet.InsertNode(D, InsertPos);
+    PointerToMemberDataSet.insert(D, Token);
   }
 
   return D;
@@ -351,7 +349,7 @@ BasicValueFactory::getPersistentSValWithData(const SVal& V, uintptr_t Data) {
   if (!PersistentSVals) PersistentSVals = new PersistentSValsTy();
 
   llvm::FoldingSetNodeID ID;
-  void *InsertPos;
+  llvm::FoldingSetInsertToken Token;
   V.Profile(ID);
   ID.AddPointer((void*) Data);
 
@@ -359,11 +357,11 @@ BasicValueFactory::getPersistentSValWithData(const SVal& V, uintptr_t Data) {
 
   using FoldNodeTy = llvm::FoldingSetNodeWrapper<SValData>;
 
-  FoldNodeTy* P = Map.FindNodeOrInsertPos(ID, InsertPos);
+  FoldNodeTy *P = Map.lookup(ID, Token);
 
   if (!P) {
     P = new (BPAlloc) FoldNodeTy(std::make_pair(V, Data));
-    Map.InsertNode(P, InsertPos);
+    Map.insert(P, Token);
   }
 
   return P->getValue();
@@ -375,7 +373,7 @@ BasicValueFactory::getPersistentSValPair(const SVal& V1, const SVal& V2) {
   if (!PersistentSValPairs) PersistentSValPairs = new PersistentSValPairsTy();
 
   llvm::FoldingSetNodeID ID;
-  void *InsertPos;
+  llvm::FoldingSetInsertToken Token;
   V1.Profile(ID);
   V2.Profile(ID);
 
@@ -383,11 +381,11 @@ BasicValueFactory::getPersistentSValPair(const SVal& V1, const SVal& V2) {
 
   using FoldNodeTy = llvm::FoldingSetNodeWrapper<SValPair>;
 
-  FoldNodeTy* P = Map.FindNodeOrInsertPos(ID, InsertPos);
+  FoldNodeTy *P = Map.lookup(ID, Token);
 
   if (!P) {
     P = new (BPAlloc) FoldNodeTy(std::make_pair(V1, V2));
-    Map.InsertNode(P, InsertPos);
+    Map.insert(P, Token);
   }
 
   return P->getValue();

--- a/clang/lib/StaticAnalyzer/Core/BasicValueFactory.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BasicValueFactory.cpp
@@ -89,16 +89,16 @@ BasicValueFactory::~BasicValueFactory() {
 
 APSIntPtr BasicValueFactory::getValue(const llvm::APSInt &X) {
   llvm::FoldingSetNodeID ID;
-  llvm::FoldingSetInsertToken Token;
+  llvm::FoldingSetInsertToken InsertToken;
 
   using FoldNodeTy = llvm::FoldingSetNodeWrapper<llvm::APSInt>;
 
   X.Profile(ID);
-  FoldNodeTy *P = APSIntSet.lookup(ID, Token);
+  FoldNodeTy *P = APSIntSet.lookup(ID, InsertToken);
 
   if (!P) {
     P = new (BPAlloc) FoldNodeTy(X);
-    APSIntSet.insert(P, Token);
+    APSIntSet.insert(P, InsertToken);
   }
 
   // We own the APSInt object. It's safe here.
@@ -126,13 +126,13 @@ BasicValueFactory::getCompoundValData(QualType T,
                                       llvm::ImmutableList<SVal> Vals) {
   llvm::FoldingSetNodeID ID;
   CompoundValData::Profile(ID, T, Vals);
-  llvm::FoldingSetInsertToken Token;
+  llvm::FoldingSetInsertToken InsertToken;
 
-  CompoundValData *D = CompoundValDataSet.lookup(ID, Token);
+  CompoundValData *D = CompoundValDataSet.lookup(ID, InsertToken);
 
   if (!D) {
     D = new (BPAlloc) CompoundValData(T, Vals);
-    CompoundValDataSet.insert(D, Token);
+    CompoundValDataSet.insert(D, InsertToken);
   }
 
   return D;
@@ -143,13 +143,13 @@ BasicValueFactory::getLazyCompoundValData(const StoreRef &store,
                                           const TypedValueRegion *region) {
   llvm::FoldingSetNodeID ID;
   LazyCompoundValData::Profile(ID, store, region);
-  llvm::FoldingSetInsertToken Token;
+  llvm::FoldingSetInsertToken InsertToken;
 
-  LazyCompoundValData *D = LazyCompoundValDataSet.lookup(ID, Token);
+  LazyCompoundValData *D = LazyCompoundValDataSet.lookup(ID, InsertToken);
 
   if (!D) {
     D = new (BPAlloc) LazyCompoundValData(store, region);
-    LazyCompoundValDataSet.insert(D, Token);
+    LazyCompoundValDataSet.insert(D, InsertToken);
   }
 
   return D;
@@ -159,13 +159,13 @@ const PointerToMemberData *BasicValueFactory::getPointerToMemberData(
     const NamedDecl *ND, llvm::ImmutableList<const CXXBaseSpecifier *> L) {
   llvm::FoldingSetNodeID ID;
   PointerToMemberData::Profile(ID, ND, L);
-  llvm::FoldingSetInsertToken Token;
+  llvm::FoldingSetInsertToken InsertToken;
 
-  PointerToMemberData *D = PointerToMemberDataSet.lookup(ID, Token);
+  PointerToMemberData *D = PointerToMemberDataSet.lookup(ID, InsertToken);
 
   if (!D) {
     D = new (BPAlloc) PointerToMemberData(ND, L);
-    PointerToMemberDataSet.insert(D, Token);
+    PointerToMemberDataSet.insert(D, InsertToken);
   }
 
   return D;
@@ -349,7 +349,7 @@ BasicValueFactory::getPersistentSValWithData(const SVal& V, uintptr_t Data) {
   if (!PersistentSVals) PersistentSVals = new PersistentSValsTy();
 
   llvm::FoldingSetNodeID ID;
-  llvm::FoldingSetInsertToken Token;
+  llvm::FoldingSetInsertToken InsertToken;
   V.Profile(ID);
   ID.AddPointer((void*) Data);
 
@@ -357,11 +357,11 @@ BasicValueFactory::getPersistentSValWithData(const SVal& V, uintptr_t Data) {
 
   using FoldNodeTy = llvm::FoldingSetNodeWrapper<SValData>;
 
-  FoldNodeTy *P = Map.lookup(ID, Token);
+  FoldNodeTy *P = Map.lookup(ID, InsertToken);
 
   if (!P) {
     P = new (BPAlloc) FoldNodeTy(std::make_pair(V, Data));
-    Map.insert(P, Token);
+    Map.insert(P, InsertToken);
   }
 
   return P->getValue();
@@ -373,7 +373,7 @@ BasicValueFactory::getPersistentSValPair(const SVal& V1, const SVal& V2) {
   if (!PersistentSValPairs) PersistentSValPairs = new PersistentSValPairsTy();
 
   llvm::FoldingSetNodeID ID;
-  llvm::FoldingSetInsertToken Token;
+  llvm::FoldingSetInsertToken InsertToken;
   V1.Profile(ID);
   V2.Profile(ID);
 
@@ -381,11 +381,11 @@ BasicValueFactory::getPersistentSValPair(const SVal& V1, const SVal& V2) {
 
   using FoldNodeTy = llvm::FoldingSetNodeWrapper<SValPair>;
 
-  FoldNodeTy *P = Map.lookup(ID, Token);
+  FoldNodeTy *P = Map.lookup(ID, InsertToken);
 
   if (!P) {
     P = new (BPAlloc) FoldNodeTy(std::make_pair(V1, V2));
-    Map.insert(P, Token);
+    Map.insert(P, InsertToken);
   }
 
   return P->getValue();

--- a/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
@@ -2188,8 +2188,8 @@ void PathSensitiveBugReport::addVisitor(
   llvm::FoldingSetNodeID ID;
   visitor->Profile(ID);
 
-  void *InsertPos = nullptr;
-  if (CallbacksSet.FindNodeOrInsertPos(ID, InsertPos)) {
+  llvm::FoldingSetInsertToken Token;
+  if (CallbacksSet.lookup(ID, Token)) {
     return;
   }
 
@@ -2985,12 +2985,12 @@ void BugReporter::emitReport(std::unique_ptr<BugReport> R) {
   R->Profile(ID);
 
   // Lookup the equivance class.  If there isn't one, create it.
-  void *InsertPos;
-  BugReportEquivClass* EQ = EQClasses.FindNodeOrInsertPos(ID, InsertPos);
+  llvm::FoldingSetInsertToken Token;
+  BugReportEquivClass *EQ = EQClasses.lookup(ID, Token);
 
   if (!EQ) {
     EQ = new BugReportEquivClass(std::move(R));
-    EQClasses.InsertNode(EQ, InsertPos);
+    EQClasses.insert(EQ, Token);
     EQClassesVector.push_back(EQ);
   } else
     EQ->AddReport(std::move(R));

--- a/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
@@ -2188,8 +2188,8 @@ void PathSensitiveBugReport::addVisitor(
   llvm::FoldingSetNodeID ID;
   visitor->Profile(ID);
 
-  llvm::FoldingSetInsertToken Token;
-  if (CallbacksSet.lookup(ID, Token)) {
+  llvm::FoldingSetInsertToken InsertToken;
+  if (CallbacksSet.lookup(ID, InsertToken)) {
     return;
   }
 
@@ -2985,12 +2985,12 @@ void BugReporter::emitReport(std::unique_ptr<BugReport> R) {
   R->Profile(ID);
 
   // Lookup the equivance class.  If there isn't one, create it.
-  llvm::FoldingSetInsertToken Token;
-  BugReportEquivClass *EQ = EQClasses.lookup(ID, Token);
+  llvm::FoldingSetInsertToken InsertToken;
+  BugReportEquivClass *EQ = EQClasses.lookup(ID, InsertToken);
 
   if (!EQ) {
     EQ = new BugReportEquivClass(std::move(R));
-    EQClasses.insert(EQ, Token);
+    EQClasses.insert(EQ, InsertToken);
     EQClassesVector.push_back(EQ);
   } else
     EQ->AddReport(std::move(R));

--- a/clang/lib/StaticAnalyzer/Core/ExplodedGraph.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExplodedGraph.cpp
@@ -158,7 +158,7 @@ void ExplodedGraph::collectNode(ExplodedNode *node) {
   pred->replaceSuccessor(succ);
   succ->replacePredecessor(pred);
   FreeNodes.push_back(node);
-  Nodes.RemoveNode(node);
+  Nodes.erase(node);
   --NumNodes;
   node->~ExplodedNode();
 }
@@ -393,10 +393,10 @@ ExplodedNode *ExplodedGraph::getNode(const ProgramPoint &L,
                                      bool* IsNew) {
   // Profile 'State' to determine if we already have an existing node.
   llvm::FoldingSetNodeID profile;
-  void *InsertPos = nullptr;
+  llvm::FoldingSetInsertToken Token;
 
   NodeTy::Profile(profile, L, State, IsSink);
-  NodeTy* V = Nodes.FindNodeOrInsertPos(profile, InsertPos);
+  NodeTy *V = Nodes.lookup(profile, Token);
 
   if (!V) {
     if (!FreeNodes.empty()) {
@@ -415,7 +415,7 @@ ExplodedNode *ExplodedGraph::getNode(const ProgramPoint &L,
       ChangedNodes.push_back(V);
 
     // Insert the node into the node set and return it.
-    Nodes.InsertNode(V, InsertPos);
+    Nodes.insert(V, Token);
 
     if (IsNew) *IsNew = true;
   }

--- a/clang/lib/StaticAnalyzer/Core/ExplodedGraph.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExplodedGraph.cpp
@@ -393,10 +393,10 @@ ExplodedNode *ExplodedGraph::getNode(const ProgramPoint &L,
                                      bool* IsNew) {
   // Profile 'State' to determine if we already have an existing node.
   llvm::FoldingSetNodeID profile;
-  llvm::FoldingSetInsertToken Token;
+  llvm::FoldingSetInsertToken InsertToken;
 
   NodeTy::Profile(profile, L, State, IsSink);
-  NodeTy *V = Nodes.lookup(profile, Token);
+  NodeTy *V = Nodes.lookup(profile, InsertToken);
 
   if (!V) {
     if (!FreeNodes.empty()) {
@@ -415,7 +415,7 @@ ExplodedNode *ExplodedGraph::getNode(const ProgramPoint &L,
       ChangedNodes.push_back(V);
 
     // Insert the node into the node set and return it.
-    Nodes.insert(V, Token);
+    Nodes.insert(V, InsertToken);
 
     if (IsNew) *IsNew = true;
   }

--- a/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
+++ b/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
@@ -76,12 +76,12 @@ RegionTy* MemRegionManager::getSubRegion(const Arg1Ty arg1,
                                          const SuperTy *superRegion) {
   llvm::FoldingSetNodeID ID;
   RegionTy::ProfileRegion(ID, arg1, superRegion);
-  llvm::FoldingSetInsertToken Token;
-  auto *R = cast_or_null<RegionTy>(Regions.lookup(ID, Token));
+  llvm::FoldingSetInsertToken InsertToken;
+  auto *R = cast_or_null<RegionTy>(Regions.lookup(ID, InsertToken));
 
   if (!R) {
     R = new (A) RegionTy(arg1, superRegion);
-    Regions.insert(R, Token);
+    Regions.insert(R, InsertToken);
     assert(!isAReferenceTypedValueRegion(superRegion));
   }
 
@@ -93,12 +93,12 @@ RegionTy* MemRegionManager::getSubRegion(const Arg1Ty arg1, const Arg2Ty arg2,
                                          const SuperTy *superRegion) {
   llvm::FoldingSetNodeID ID;
   RegionTy::ProfileRegion(ID, arg1, arg2, superRegion);
-  llvm::FoldingSetInsertToken Token;
-  auto *R = cast_or_null<RegionTy>(Regions.lookup(ID, Token));
+  llvm::FoldingSetInsertToken InsertToken;
+  auto *R = cast_or_null<RegionTy>(Regions.lookup(ID, InsertToken));
 
   if (!R) {
     R = new (A) RegionTy(arg1, arg2, superRegion);
-    Regions.insert(R, Token);
+    Regions.insert(R, InsertToken);
     assert(!isAReferenceTypedValueRegion(superRegion));
   }
 
@@ -112,12 +112,12 @@ RegionTy* MemRegionManager::getSubRegion(const Arg1Ty arg1, const Arg2Ty arg2,
                                          const SuperTy *superRegion) {
   llvm::FoldingSetNodeID ID;
   RegionTy::ProfileRegion(ID, arg1, arg2, arg3, superRegion);
-  llvm::FoldingSetInsertToken Token;
-  auto *R = cast_or_null<RegionTy>(Regions.lookup(ID, Token));
+  llvm::FoldingSetInsertToken InsertToken;
+  auto *R = cast_or_null<RegionTy>(Regions.lookup(ID, InsertToken));
 
   if (!R) {
     R = new (A) RegionTy(arg1, arg2, arg3, superRegion);
-    Regions.insert(R, Token);
+    Regions.insert(R, InsertToken);
     assert(!isAReferenceTypedValueRegion(superRegion));
   }
 
@@ -1260,13 +1260,13 @@ MemRegionManager::getElementRegion(QualType elementType, NonLoc Idx,
   llvm::FoldingSetNodeID ID;
   ElementRegion::ProfileRegion(ID, T, Idx, superRegion);
 
-  llvm::FoldingSetInsertToken Token;
-  MemRegion *data = Regions.lookup(ID, Token);
+  llvm::FoldingSetInsertToken InsertToken;
+  MemRegion *data = Regions.lookup(ID, InsertToken);
   auto *R = cast_or_null<ElementRegion>(data);
 
   if (!R) {
     R = new (A) ElementRegion(T, Idx, superRegion);
-    Regions.insert(R, Token);
+    Regions.insert(R, InsertToken);
   }
 
   return R;

--- a/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
+++ b/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
@@ -76,12 +76,12 @@ RegionTy* MemRegionManager::getSubRegion(const Arg1Ty arg1,
                                          const SuperTy *superRegion) {
   llvm::FoldingSetNodeID ID;
   RegionTy::ProfileRegion(ID, arg1, superRegion);
-  void *InsertPos;
-  auto *R = cast_or_null<RegionTy>(Regions.FindNodeOrInsertPos(ID, InsertPos));
+  llvm::FoldingSetInsertToken Token;
+  auto *R = cast_or_null<RegionTy>(Regions.lookup(ID, Token));
 
   if (!R) {
     R = new (A) RegionTy(arg1, superRegion);
-    Regions.InsertNode(R, InsertPos);
+    Regions.insert(R, Token);
     assert(!isAReferenceTypedValueRegion(superRegion));
   }
 
@@ -93,12 +93,12 @@ RegionTy* MemRegionManager::getSubRegion(const Arg1Ty arg1, const Arg2Ty arg2,
                                          const SuperTy *superRegion) {
   llvm::FoldingSetNodeID ID;
   RegionTy::ProfileRegion(ID, arg1, arg2, superRegion);
-  void *InsertPos;
-  auto *R = cast_or_null<RegionTy>(Regions.FindNodeOrInsertPos(ID, InsertPos));
+  llvm::FoldingSetInsertToken Token;
+  auto *R = cast_or_null<RegionTy>(Regions.lookup(ID, Token));
 
   if (!R) {
     R = new (A) RegionTy(arg1, arg2, superRegion);
-    Regions.InsertNode(R, InsertPos);
+    Regions.insert(R, Token);
     assert(!isAReferenceTypedValueRegion(superRegion));
   }
 
@@ -112,12 +112,12 @@ RegionTy* MemRegionManager::getSubRegion(const Arg1Ty arg1, const Arg2Ty arg2,
                                          const SuperTy *superRegion) {
   llvm::FoldingSetNodeID ID;
   RegionTy::ProfileRegion(ID, arg1, arg2, arg3, superRegion);
-  void *InsertPos;
-  auto *R = cast_or_null<RegionTy>(Regions.FindNodeOrInsertPos(ID, InsertPos));
+  llvm::FoldingSetInsertToken Token;
+  auto *R = cast_or_null<RegionTy>(Regions.lookup(ID, Token));
 
   if (!R) {
     R = new (A) RegionTy(arg1, arg2, arg3, superRegion);
-    Regions.InsertNode(R, InsertPos);
+    Regions.insert(R, Token);
     assert(!isAReferenceTypedValueRegion(superRegion));
   }
 
@@ -1260,13 +1260,13 @@ MemRegionManager::getElementRegion(QualType elementType, NonLoc Idx,
   llvm::FoldingSetNodeID ID;
   ElementRegion::ProfileRegion(ID, T, Idx, superRegion);
 
-  void *InsertPos;
-  MemRegion* data = Regions.FindNodeOrInsertPos(ID, InsertPos);
+  llvm::FoldingSetInsertToken Token;
+  MemRegion *data = Regions.lookup(ID, Token);
   auto *R = cast_or_null<ElementRegion>(data);
 
   if (!R) {
     R = new (A) ElementRegion(T, Idx, superRegion);
-    Regions.InsertNode(R, InsertPos);
+    Regions.insert(R, Token);
   }
 
   return R;

--- a/clang/lib/StaticAnalyzer/Core/ProgramState.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ProgramState.cpp
@@ -403,9 +403,9 @@ ProgramStateRef ProgramStateManager::getPersistentState(ProgramState &State) {
 
   llvm::FoldingSetNodeID ID;
   State.Profile(ID);
-  llvm::FoldingSetInsertToken Token;
+  llvm::FoldingSetInsertToken InsertToken;
 
-  if (ProgramState *I = StateSet.lookup(ID, Token))
+  if (ProgramState *I = StateSet.lookup(ID, InsertToken))
     return I;
 
   ProgramState *newState = nullptr;
@@ -417,7 +417,7 @@ ProgramStateRef ProgramStateManager::getPersistentState(ProgramState &State) {
     newState = Alloc.Allocate<ProgramState>();
   }
   new (newState) ProgramState(State);
-  StateSet.insert(newState, Token);
+  StateSet.insert(newState, InsertToken);
   return newState;
 }
 

--- a/clang/lib/StaticAnalyzer/Core/ProgramState.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ProgramState.cpp
@@ -36,7 +36,7 @@ void ProgramStateRelease(const ProgramState *state) {
   ProgramState *s = const_cast<ProgramState*>(state);
   if (--s->refCount == 0) {
     ProgramStateManager &Mgr = s->getStateManager();
-    Mgr.StateSet.RemoveNode(s);
+    Mgr.StateSet.erase(s);
     s->~ProgramState();
     Mgr.freeStates.push_back(s);
   }
@@ -403,9 +403,9 @@ ProgramStateRef ProgramStateManager::getPersistentState(ProgramState &State) {
 
   llvm::FoldingSetNodeID ID;
   State.Profile(ID);
-  void *InsertPos;
+  llvm::FoldingSetInsertToken Token;
 
-  if (ProgramState *I = StateSet.FindNodeOrInsertPos(ID, InsertPos))
+  if (ProgramState *I = StateSet.lookup(ID, Token))
     return I;
 
   ProgramState *newState = nullptr;
@@ -417,7 +417,7 @@ ProgramStateRef ProgramStateManager::getPersistentState(ProgramState &State) {
     newState = Alloc.Allocate<ProgramState>();
   }
   new (newState) ProgramState(State);
-  StateSet.InsertNode(newState, InsertPos);
+  StateSet.insert(newState, Token);
   return newState;
 }
 

--- a/clang/lib/StaticAnalyzer/Core/RangeConstraintManager.cpp
+++ b/clang/lib/StaticAnalyzer/Core/RangeConstraintManager.cpp
@@ -323,17 +323,17 @@ RangeSet RangeSet::Factory::getRangeSet(Range From) {
 
 RangeSet RangeSet::Factory::makePersistent(ContainerType &&From) {
   llvm::FoldingSetNodeID ID;
-  llvm::FoldingSetInsertToken Token;
+  llvm::FoldingSetInsertToken InsertToken;
 
   From.Profile(ID);
-  ContainerType *Result = Cache.lookup(ID, Token);
+  ContainerType *Result = Cache.lookup(ID, InsertToken);
 
   if (!Result) {
     // It is cheaper to fully construct the resulting range on stack
     // and move it to the freshly allocated buffer if we don't have
     // a set like this already.
     Result = construct(std::move(From));
-    Cache.insert(Result, Token);
+    Cache.insert(Result, InsertToken);
   }
 
   return Result;

--- a/clang/lib/StaticAnalyzer/Core/RangeConstraintManager.cpp
+++ b/clang/lib/StaticAnalyzer/Core/RangeConstraintManager.cpp
@@ -323,17 +323,17 @@ RangeSet RangeSet::Factory::getRangeSet(Range From) {
 
 RangeSet RangeSet::Factory::makePersistent(ContainerType &&From) {
   llvm::FoldingSetNodeID ID;
-  void *InsertPos;
+  llvm::FoldingSetInsertToken Token;
 
   From.Profile(ID);
-  ContainerType *Result = Cache.FindNodeOrInsertPos(ID, InsertPos);
+  ContainerType *Result = Cache.lookup(ID, Token);
 
   if (!Result) {
     // It is cheaper to fully construct the resulting range on stack
     // and move it to the freshly allocated buffer if we don't have
     // a set like this already.
     Result = construct(std::move(From));
-    Cache.InsertNode(Result, InsertPos);
+    Cache.insert(Result, Token);
   }
 
   return Result;

--- a/clang/unittests/AST/ExternalASTSourceTest.cpp
+++ b/clang/unittests/AST/ExternalASTSourceTest.cpp
@@ -151,7 +151,7 @@ struct LazyTemplatePatterns : TestExternalASTSource {
         ASTTemplateArgumentListInfo::Create(Ctx, ArgsInfo));
 
     TU->addDecl(Partial);
-    Template->AddPartialSpecialization(Partial, nullptr);
+    Template->AddPartialSpecialization(Partial, {});
   }
 
   void CompleteType(TagDecl *Tag) override {

--- a/lldb/source/Plugins/ExpressionParser/Clang/CxxModuleHandler.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/CxxModuleHandler.cpp
@@ -262,9 +262,9 @@ std::optional<Decl *> CxxModuleHandler::tryInstantiateStdTemplate(Decl *d) {
 
   // Find the class template specialization declaration that
   // corresponds to these arguments.
-  void *InsertPos = nullptr;
+  llvm::FoldingSetInsertToken InsertToken;
   ClassTemplateSpecializationDecl *result =
-      new_class_template->findSpecialization(imported_args, InsertPos);
+      new_class_template->findSpecialization(imported_args, InsertToken);
 
   if (result) {
     // We found an existing specialization in the module that fits our arguments
@@ -283,7 +283,7 @@ std::optional<Decl *> CxxModuleHandler::tryInstantiateStdTemplate(Decl *d) {
       td->hasStrictPackMatch(),
       /*PrevDecl=*/nullptr);
 
-  new_class_template->AddSpecialization(result, InsertPos);
+  new_class_template->AddSpecialization(result, InsertToken);
   if (new_class_template->isOutOfLine())
     result->setLexicalDeclContext(
         new_class_template->getLexicalDeclContext());

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -1450,7 +1450,7 @@ void TypeSystemClang::CreateFunctionTemplateSpecializationInfo(
       func_decl->getASTContext(), infos.GetArgs());
 
   func_decl->setFunctionTemplateSpecialization(func_tmpl_decl,
-                                               template_args_ptr, nullptr);
+                                               template_args_ptr, {});
 }
 
 /// Returns true if the given template parameter can represent the given value.
@@ -1673,11 +1673,11 @@ TypeSystemClang::CreateClassTemplateSpecializationDecl(
   class_template_specialization_decl->setInstantiationOf(class_template_decl);
   class_template_specialization_decl->setTemplateArgs(
       TemplateArgumentList::CreateCopy(ast, args));
-  void *insert_pos = nullptr;
-  if (class_template_decl->findSpecialization(args, insert_pos))
+  llvm::FoldingSetInsertToken insert_token;
+  if (class_template_decl->findSpecialization(args, insert_token))
     return nullptr;
   class_template_decl->AddSpecialization(class_template_specialization_decl,
-                                         insert_pos);
+                                         insert_token);
   class_template_specialization_decl->setDeclName(
       class_template_decl->getDeclName());
 


### PR DESCRIPTION
findSpecialization/AddSpecialization and their Decl.h wrappers stop
threading a `void *` through the AST, Sema, Serialization and CodeGen
callers. This is the last user of FoldingSet's `void *` insert position.

LLM-aided