### PR TITLE
[dsymutil] Adjust the debug map object filter

### DIFF
--- a/llvm/tools/dsymutil/DebugMap.cpp
+++ b/llvm/tools/dsymutil/DebugMap.cpp
@@ -94,9 +94,8 @@ DebugMapObject &
 DebugMap::addDebugMapObject(StringRef ObjectFilePath,
                             sys::TimePoint<std::chrono::seconds> Timestamp,
                             uint8_t Type) {
-  getObjects().emplace_back(
-      new DebugMapObject(ObjectFilePath, Timestamp, Type));
-  return *getObjects().back();
+  Objects.emplace_back(new DebugMapObject(ObjectFilePath, Timestamp, Type));
+  return *Objects.back();
 }
 
 const DebugMapObject::DebugMapEntry *
@@ -265,7 +264,7 @@ void MappingTraits<dsymutil::DebugMap>::mapping(IO &io,
   io.mapOptional("binary-path", DM.BinaryPath);
   if (void *Ctxt = io.getContext())
     reinterpret_cast<YAMLContext *>(Ctxt)->BinaryTriple = DM.BinaryTriple;
-  io.mapOptional("objects", DM.getObjects());
+  io.mapOptional("objects", DM.Objects);
 }
 
 void MappingTraits<std::unique_ptr<dsymutil::DebugMap>>::mapping(
@@ -276,7 +275,7 @@ void MappingTraits<std::unique_ptr<dsymutil::DebugMap>>::mapping(
   io.mapOptional("binary-path", DM->BinaryPath);
   if (void *Ctxt = io.getContext())
     reinterpret_cast<YAMLContext *>(Ctxt)->BinaryTriple = DM->BinaryTriple;
-  io.mapOptional("objects", DM->getObjects());
+  io.mapOptional("objects", DM->Objects);
 }
 
 MappingTraits<dsymutil::DebugMapObject>::YamlDMO::YamlDMO(

--- a/llvm/tools/dsymutil/DebugMap.h
+++ b/llvm/tools/dsymutil/DebugMap.h
@@ -108,18 +108,12 @@ public:
 ///             DIE.discardSubtree();
 ///     }
 /// }
-class DebugMap : public DebugMapFilter {
+class DebugMap {
   Triple BinaryTriple;
   std::string BinaryPath;
   std::vector<uint8_t> BinaryUUID;
   using ObjectContainer = std::vector<std::unique_ptr<DebugMapObject>>;
-
-  ObjectContainer &getObjects() {
-    return reinterpret_cast<ObjectContainer &>(Objects);
-  }
-  const ObjectContainer &getObjects() const {
-    return reinterpret_cast<const ObjectContainer &>(Objects);
-  }
+  ObjectContainer Objects;
 
   /// For YAML IO support.
   ///@{
@@ -139,9 +133,9 @@ public:
     return make_range(begin(), end());
   }
 
-  const_iterator begin() const { return getObjects().begin(); }
+  const_iterator begin() const { return Objects.begin(); }
 
-  const_iterator end() const { return getObjects().end(); }
+  const_iterator end() const { return Objects.end(); }
 
   unsigned getNumberOfObjects() const { return Objects.size(); }
 


### PR DESCRIPTION
`DebugMap` inherits `DebugMapFilter` only to reuse its `std::vector<std::unique_ptr<DebugMapObjectFilter>>`, then `reinterpret_cast`s that container to `std::vector<std::unique_ptr<DebugMapObject>>` on every access, which is undefined because the two vector instantiations are unrelated types, and GCC rejects it under `-Werror=strict-aliasing` (reported from Gentoo).

Nothing in the tree upcasts a `DebugMap` to a `DebugMapFilter`, so this gives `DebugMap` its own correctly typed member and drops the inheritance, removing both casts and both `getObjects()` overloads; if you would rather keep the sharing, templatising the base as `DebugMapFilterBase<T>` also works.

GCC 15.2 errors: 2 before, 0 after. 169/169 dsymutil lit tests pass.

Fixes #219693
