### PR TITLE
[VPlan] Fold trivial bitcasts.

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
@@ -560,6 +560,12 @@ inline AllRecipe_match<Instruction::FPExt, Op0_t> m_FPExt(const Op0_t &Op0) {
 }
 
 template <typename Op0_t>
+inline AllRecipe_match<Instruction::BitCast, Op0_t>
+m_BitCast(const Op0_t &Op0) {
+  return m_Unary<Instruction::BitCast, Op0_t>(Op0);
+}
+
+template <typename Op0_t>
 inline AllRecipe_match<Instruction::FNeg, Op0_t> m_FNeg(const Op0_t &Op0) {
   return m_Unary<Instruction::FNeg, Op0_t>(Op0);
 }

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -1280,6 +1280,12 @@ static VPValue *simplifyRecipe(VPSingleDefRecipe *Def) {
       !isa<VPInstruction>(Def) || !Def->getUnderlyingValue();
 
   VPValue *A, *Z;
+
+  // A bitcast to the same type is a no-op.
+  if (match(Def, m_BitCast(m_VPValue(A))) &&
+      Def->getScalarType() == A->getScalarType())
+    return A;
+
   if (match(Def, m_Trunc(m_VPValue(Z, m_ZExtOrSExt(m_VPValue(A)))))) {
     Type *TruncTy = Def->getScalarType();
     Type *ATy = A->getScalarType();

--- a/llvm/test/Transforms/LoopVectorize/SystemZ/load-scalarization-cost-0.ll
+++ b/llvm/test/Transforms/LoopVectorize/SystemZ/load-scalarization-cost-0.ll
@@ -25,5 +25,5 @@ for.end:
   ret void
 
 ; CHECK: Cost of 2 for VF 2: forced scalar   %mul = mul nsw i64 %iv, %s
-; CHECK: Cost of 2 for VF 2: REPLICATE ir<%ld> = load ir<%bct>
+; CHECK: Cost of 2 for VF 2: REPLICATE ir<%ld> = load ir<%gep.src>
 }

--- a/llvm/test/Transforms/LoopVectorize/VPlan/vplan-scev-address-idioms.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/vplan-scev-address-idioms.ll
@@ -21,12 +21,12 @@ define void @bitcast_noop(ptr noalias %A, ptr noalias %B) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    vector.body:
 ; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0]]>
-; CHECK-NEXT:      EMIT-SCALAR ir<%idx> = bitcast ir<%iv> to i64
-; CHECK-NEXT:      EMIT ir<%gep> = getelementptr inbounds ir<%A>, ir<%idx>
-; CHECK-NEXT:      EMIT-SCALAR ir<%l> = load ir<%gep>
+; CHECK-NEXT:      EMIT ir<%gep> = getelementptr inbounds ir<%A>, ir<%iv>
+; CHECK-NEXT:      vp<[[VP4:%[0-9]+]]> = vector-pointer inbounds i32, ir<%gep>, ir<1>
+; CHECK-NEXT:      WIDEN ir<%l> = load vp<[[VP4]]>
 ; CHECK-NEXT:      EMIT ir<%gep.b> = getelementptr inbounds ir<%B>, ir<%iv>
-; CHECK-NEXT:      vp<[[VP4:%[0-9]+]]> = vector-pointer inbounds i32, ir<%gep.b>, ir<1>
-; CHECK-NEXT:      WIDEN store vp<[[VP4]]>, ir<%l>
+; CHECK-NEXT:      vp<[[VP5:%[0-9]+]]> = vector-pointer inbounds i32, ir<%gep.b>, ir<1>
+; CHECK-NEXT:      WIDEN store vp<[[VP5]]>, ir<%l>
 ; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
 ; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv>, ir<100>
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1]]>
@@ -36,7 +36,7 @@ define void @bitcast_noop(ptr noalias %A, ptr noalias %B) {
 ; CHECK-NEXT:  Successor(s): middle.block
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  middle.block:
-; CHECK-NEXT:    EMIT vp<[[VP6:%[0-9]+]]> = exiting-iv-value ir<%iv>
+; CHECK-NEXT:    EMIT vp<[[VP7:%[0-9]+]]> = exiting-iv-value ir<%iv>
 ; CHECK-NEXT:    EMIT vp<%cmp.n> = icmp eq ir<101>, vp<[[VP2]]>
 ; CHECK-NEXT:    EMIT branch-on-cond vp<%cmp.n>
 ; CHECK-NEXT:  Successor(s): ir-bb<exit>, scalar.ph

--- a/llvm/test/Transforms/LoopVectorize/scalarized-bitcast.ll
+++ b/llvm/test/Transforms/LoopVectorize/scalarized-bitcast.ll
@@ -3,10 +3,10 @@
 
 %struct.foo = type { i32, i64 }
 
-; CHECK: Cost of 0 for VF 2: WIDEN-CAST ir<%0> = bitcast ir<%b> to ptr
+; CHECK: Cost of 0 for VF 2: WIDEN-GEP ir<%b> = getelementptr inbounds ir<%in>, ir<%i.012>, ir<1>
 
-; The bitcast below will be scalarized due to the predication in the loop. Bitcasts
-; between pointer types should be treated as free, despite the scalarization.
+; The bitcast below is a no-op between identical pointer types and is folded
+; away, so it costs nothing even though the loop is predicated.
 define void @foo(ptr noalias nocapture %in, ptr noalias nocapture readnone %out, i64 %n) {
 entry:
   br label %for.body


### PR DESCRIPTION
Fold trivial bitcasts in VPlan. This avoids special handling when constructing SCEV expressions (which folds such trivial casts), and ensures we can close the gap between IR-based SCEV analysis and VPlan-based SCEV analysis. This is important going forward to make sure we can replace existing IR analysis without regressions.