### PR TITLE
[ADT] Use isComparableWith in StringMap

### DIFF
--- a/llvm/include/llvm/ADT/StringMap.h
+++ b/llvm/include/llvm/ADT/StringMap.h
@@ -514,10 +514,7 @@ public:
 
   friend bool operator==(const StringMapIterBase &LHS,
                          const StringMapIterBase &RHS) {
-    assert((!LHS.getEpochAddress() || LHS.isHandleInSync()) &&
-           "handle not in sync!");
-    assert((!RHS.getEpochAddress() || RHS.isHandleInSync()) &&
-           "handle not in sync!");
+    assert(LHS.isComparableWith(RHS) && "incomparable iterators!");
     return LHS.Ptr == RHS.Ptr;
   }
 

--- a/llvm/unittests/ADT/StringMapTest.cpp
+++ b/llvm/unittests/ADT/StringMapTest.cpp
@@ -889,6 +889,24 @@ TEST(StringMapCustomTest, SwapInvalidatesIterators) {
   Map.swap(Other);
   EXPECT_DEATH((void)It->second, "invalid iterator access");
 }
+
+TEST(StringMapCustomTest, IteratorComparability) {
+  StringMap<int>::iterator I1, I2;
+  EXPECT_EQ(I1, I2);
+
+  StringMap<int> Map1, Map2;
+  Map1["a"] = 1;
+  Map2["b"] = 2;
+  EXPECT_DEATH((void)(Map1.begin() == Map2.begin()), "incomparable iterators");
+}
+
+TEST(StringMapCustomTest, InsertInvalidatesIteratorComparison) {
+  StringMap<int> Map;
+  Map["a"] = 1;
+  auto It = Map.begin();
+  Map["b"] = 2;
+  EXPECT_DEATH((void)(It == Map.end()), "incomparable iterators");
+}
 #endif
 
 } // end anonymous namespace


### PR DESCRIPTION
This patch updates operator== in StringMap to use
DebugEpochBase::HandleBase::isComparableWith, bringing it in line
with DenseMap and FoldingSet.

Assisted-by: Antigravity
