### PR TITLE
workflows/release-binaries: Smaller WiX installer on Windows

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -495,8 +495,14 @@ if(WIN32 AND NOT UNIX)
   endif()
   if(CPACK_GENERATOR STREQUAL "WIX")
     set(CPACK_WIX_PRODUCT_ICON "${CMAKE_CURRENT_SOURCE_DIR}\\\\cmake\\\\nsis_icon.ico")
-    # The WIX installer needs admin privileges unless we use this flag.
-    set(CPACK_WIX_LIGHT_EXTRA_FLAGS "-sval")
+    # -sval: the WIX installer needs admin privileges unless we use this flag.
+    # -dcl:high: light defaults the cabinet to MSZIP (deflate, 32 KiB window),
+    # which captures almost no redundancy between the payload's binaries.  high
+    # selects LZX with a 21-bit (2 MiB) window instead.  That is the strongest
+    # compression available here: Windows Installer has to be able to read the
+    # cabinet itself, and CAB supports only MSZIP/LZX/Quantum, so an MSI cannot
+    # use LZMA the way the NSIS generator does.
+    set(CPACK_WIX_LIGHT_EXTRA_FLAGS "-sval" "-dcl:high")
   endif()
 endif()
 include(CPack)


### PR DESCRIPTION
Reduce WiX installer size by using LZX compression instead of MSZIP previously. Tested on `release/23.x` at commit fdf0409c656cc66c61b14d71c831f2b453c13e19 targetting Win64:

- MSZIP: 779 MiB
- LZX: 613 MiB