### PR TITLE
[clang][x86] Fix _mm_frcz_{ss,sd} to take two arguments

### DIFF
--- a/clang/lib/Headers/xopintrin.h
+++ b/clang/lib/Headers/xopintrin.h
@@ -737,15 +737,17 @@ _mm_comtrue_epi64(__m128i __A, __m128i __B)
                                         (__v8si)(__m256i)(C), (I)))
 
 static __inline__ __m128 __DEFAULT_FN_ATTRS
-_mm_frcz_ss(__m128 __A)
+_mm_frcz_ss(__m128 __A, __m128 __B)
 {
-  return (__m128)__builtin_ia32_vfrczss((__v4sf)__A);
+  __A[0] = ((__v4sf)__builtin_ia32_vfrczss((__v4sf)__B))[0];
+  return __A;
 }
 
 static __inline__ __m128d __DEFAULT_FN_ATTRS
-_mm_frcz_sd(__m128d __A)
+_mm_frcz_sd(__m128d __A, __m128d __B)
 {
-  return (__m128d)__builtin_ia32_vfrczsd((__v2df)__A);
+  __A[0] = ((__v2df)__builtin_ia32_vfrczsd((__v2df)__B))[0];
+  return __A;
 }
 
 static __inline__ __m128 __DEFAULT_FN_ATTRS

--- a/clang/lib/Headers/xopintrin.h
+++ b/clang/lib/Headers/xopintrin.h
@@ -736,16 +736,14 @@ _mm_comtrue_epi64(__m128i __A, __m128i __B)
                                         (__v8sf)(__m256)(Y), \
                                         (__v8si)(__m256i)(C), (I)))
 
-static __inline__ __m128 __DEFAULT_FN_ATTRS
-_mm_frcz_ss(__m128 __A, __m128 __B)
-{
+static __inline__ __m128 __DEFAULT_FN_ATTRS _mm_frcz_ss(__m128 __A,
+                                                        __m128 __B) {
   __A[0] = ((__v4sf)__builtin_ia32_vfrczss((__v4sf)__B))[0];
   return __A;
 }
 
-static __inline__ __m128d __DEFAULT_FN_ATTRS
-_mm_frcz_sd(__m128d __A, __m128d __B)
-{
+static __inline__ __m128d __DEFAULT_FN_ATTRS _mm_frcz_sd(__m128d __A,
+                                                         __m128d __B) {
   __A[0] = ((__v2df)__builtin_ia32_vfrczsd((__v2df)__B))[0];
   return __A;
 }

--- a/clang/test/CodeGen/X86/xop-builtins.c
+++ b/clang/test/CodeGen/X86/xop-builtins.c
@@ -394,16 +394,20 @@ __m256 test_mm256_permute2_ps(__m256 a, __m256 b, __m256i c) {
   return _mm256_permute2_ps(a, b, c, 0);
 }
 
-__m128 test_mm_frcz_ss(__m128 a) {
+__m128 test_mm_frcz_ss(__m128 a, __m128 b) {
   // CHECK-LABEL: test_mm_frcz_ss
   // CHECK: call {{.*}}<4 x float> @llvm.x86.xop.vfrcz.ss(<4 x float> %{{.*}})
-  return _mm_frcz_ss(a);
+  // CHECK: extractelement <4 x float> {{.*}}, i32 0
+  // CHECK: insertelement <4 x float> {{.*}}, float {{.*}}, i32 0
+  return _mm_frcz_ss(a, b);
 }
 
-__m128d test_mm_frcz_sd(__m128d a) {
+__m128d test_mm_frcz_sd(__m128d a, __m128d b) {
   // CHECK-LABEL: test_mm_frcz_sd
   // CHECK: call {{.*}}<2 x double> @llvm.x86.xop.vfrcz.sd(<2 x double> %{{.*}})
-  return _mm_frcz_sd(a);
+  // CHECK: extractelement <2 x double> {{.*}}, i32 0
+  // CHECK: insertelement <2 x double> {{.*}}, double {{.*}}, i32 0
+  return _mm_frcz_sd(a, b);
 }
 
 __m128 test_mm_frcz_ps(__m128 a) {


### PR DESCRIPTION
The _mm_frcz_ss and _mm_frcz_sd intrinsics incorrectly take a single argument in Clang, while GCC and MSVC define them with two arguments.

Preserve the upper elements of the first argument and replace the low element with the result of applying FRCZ to the low element of the second argument.

Fixes #48017