### PR TITLE
[ADT] Rename FoldingSet's RemoveNode and ComputeHash. NFC

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -4072,7 +4072,7 @@ inline void operator delete[](void *Ptr, const clang::ASTContext &C, size_t) {
 
 template <> struct llvm::DenseMapInfo<llvm::FoldingSetNodeID> {
   static unsigned getHashValue(const FoldingSetNodeID &Val) {
-    return Val.ComputeHash();
+    return Val.computeHash();
   }
 
   static bool isEqual(const FoldingSetNodeID &LHS,
@@ -4082,13 +4082,13 @@ template <> struct llvm::DenseMapInfo<llvm::FoldingSetNodeID> {
 };
 template <> struct llvm::DenseMapInfo<llvm::FoldingSetNodeIDRef> {
   static unsigned getHashValue(FoldingSetNodeIDRef Val) {
-    return Val.ComputeHash();
+    return Val.computeHash();
   }
   static bool isEqual(FoldingSetNodeIDRef LHS, FoldingSetNodeIDRef RHS) {
     return LHS == RHS;
   }
   static unsigned getHashValue(const FoldingSetNodeID &Val) {
-    return Val.ComputeHash();
+    return Val.computeHash();
   }
   static bool isEqual(const FoldingSetNodeID &LHS, FoldingSetNodeIDRef RHS) {
     return LHS == RHS;

--- a/clang/include/clang/Analysis/ProgramPoint.h
+++ b/clang/include/clang/Analysis/ProgramPoint.h
@@ -186,7 +186,7 @@ public:
   unsigned getHashValue() const {
     llvm::FoldingSetNodeID ID;
     Profile(ID);
-    return ID.ComputeHash();
+    return ID.computeHash();
   }
 
   bool operator==(const ProgramPoint & RHS) const {

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConstraintManager.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConstraintManager.h
@@ -391,7 +391,7 @@ protected:
     llvm::FoldingSetNodeID ID;
     NewState->get<ConstraintSMT>().Profile(ID);
 
-    unsigned hash = ID.ComputeHash();
+    unsigned hash = ID.computeHash();
     auto I = Cached.find(hash);
     if (I != Cached.end())
       return I->second;

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -4396,7 +4396,7 @@ CIRGenModule::getOrCreateAnnotationArgs(const AnnotateAttr *attr) {
   for (Expr *e : exprs)
     id.Add(cast<clang::ConstantExpr>(e)->getAPValueResult());
 
-  mlir::ArrayAttr &lookup = annotationArgs[id.ComputeHash()];
+  mlir::ArrayAttr &lookup = annotationArgs[id.computeHash()];
   if (lookup)
     return lookup;
 

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -4258,7 +4258,7 @@ llvm::Constant *CodeGenModule::EmitAnnotationArgs(const AnnotateAttr *Attr) {
   for (Expr *E : Exprs) {
     ID.Add(cast<clang::ConstantExpr>(E)->getAPValueResult());
   }
-  llvm::Constant *&Lookup = AnnotationArgs[ID.ComputeHash()];
+  llvm::Constant *&Lookup = AnnotationArgs[ID.computeHash()];
   if (Lookup)
     return Lookup;
 

--- a/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
+++ b/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
@@ -1594,7 +1594,7 @@ CXXDeductionGuideDecl *Sema::DeclareAggregateDeductionGuideFromInitList(
   ID.AddPointer(Template);
   for (auto &T : ParamTypes)
     T.getCanonicalType().Profile(ID);
-  unsigned Hash = ID.ComputeHash();
+  unsigned Hash = ID.computeHash();
 
   auto Found = AggregateDeductionCandidates.find(Hash);
   if (Found != AggregateDeductionCandidates.end())

--- a/clang/tools/libclang/Indexing.cpp
+++ b/clang/tools/libclang/Indexing.cpp
@@ -103,7 +103,7 @@ namespace llvm {
       ID.AddInteger(UniqueID.getDevice());
       ID.AddInteger(S.getOffset());
       ID.AddInteger(S.getModTime());
-      return ID.ComputeHash();
+      return ID.computeHash();
     }
 
     static bool isEqual(const PPRegion &LHS, const PPRegion &RHS) {

--- a/llvm/include/llvm/ADT/FoldingSet.h
+++ b/llvm/include/llvm/ADT/FoldingSet.h
@@ -179,7 +179,7 @@ public:
   // The hash value is not guaranteed to be deterministic across processes.
   // Never returns NotAHash: FoldingSetBase reserves it for the empty insert
   // token and for a node belonging to no set.
-  unsigned ComputeHash() const {
+  unsigned computeHash() const {
     unsigned Hash =
         static_cast<unsigned>(hash_combine_range(Data, Data + Size));
     return Hash == NotAHash ? 1 : Hash;
@@ -261,8 +261,8 @@ public:
   // Compute a strong hash value for this FoldingSetNodeID, used to lookup the
   // node in the FoldingSetBase. The hash value is not guaranteed to be
   // deterministic across processes.
-  unsigned ComputeHash() const {
-    return FoldingSetNodeIDRef(Bits.data(), Bits.size()).ComputeHash();
+  unsigned computeHash() const {
+    return FoldingSetNodeIDRef(Bits.data(), Bits.size()).computeHash();
   }
 
   // Compute a deterministic hash value across processes that is suitable for
@@ -384,7 +384,7 @@ protected:
 
   /// Remove a node from the folding set, returning true if one
   /// was removed or false if the node was not in the folding set.
-  LLVM_ABI bool RemoveNode(Node *N);
+  LLVM_ABI bool erase(Node *N);
 
   /// Walk the probe chain for \p Hash, offering each node whose cached hash
   /// matches to \p IsMatch. \p IsMatch is a template parameter so that it, and
@@ -486,7 +486,7 @@ public:
 
   /// Remove a node from the folding set, returning true if one
   /// was removed or false if the node was not in the folding set.
-  bool erase(T *N) { return FoldingSetBase::RemoveNode(N); }
+  bool erase(T *N) { return FoldingSetBase::erase(N); }
 
   /// If there is an existing node exactly equal to the specified node,
   /// return it.  Otherwise, insert 'N' and return it instead.
@@ -507,7 +507,7 @@ public:
   /// \p Token; otherwise return null and set \p Token for a subsequent insert.
   T *lookup(const FoldingSetNodeID &ID, FoldingSetInsertToken &Token) {
     return static_cast<T *>(
-        probe(ID.ComputeHash(), Token,
+        probe(ID.computeHash(), Token,
               [&](FoldingSetNode *N) { return nodeEquals(N, ID); }));
   }
 

--- a/llvm/include/llvm/ADT/ImmutableSet.h
+++ b/llvm/include/llvm/ADT/ImmutableSet.h
@@ -326,7 +326,7 @@ private:
     // Compute digest of stored data.
     FoldingSetNodeID ID;
     ImutInfo::Profile(ID,V);
-    digest += ID.ComputeHash();
+    digest += ID.computeHash();
 
     if (R)
       digest += R->computeDigest();

--- a/llvm/lib/Support/FoldingSet.cpp
+++ b/llvm/lib/Support/FoldingSet.cpp
@@ -199,7 +199,7 @@ void FoldingSetBase::insert(Node *N, FoldingSetInsertToken Token) {
   N->setFoldingSetHash(Hash);
 }
 
-bool FoldingSetBase::RemoveNode(Node *N) {
+bool FoldingSetBase::erase(Node *N) {
   uint32_t Hash = N->getFoldingSetHash();
   if (Hash == FoldingSetNodeIDRef::NotAHash)
     return false; // Never inserted.

--- a/llvm/lib/Target/Hexagon/HexagonCommonGEP.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonCommonGEP.cpp
@@ -481,7 +481,7 @@ static unsigned node_hash(GepNode *N) {
     FoldingSetNodeID ID;
     ID.AddPointer(N->Idx);
     ID.AddPointer(N->PTy);
-    return ID.ComputeHash();
+    return ID.computeHash();
 }
 
 static bool node_eq(GepNode *N1, GepNode *N2, NodePairSet &Eq,

--- a/llvm/unittests/ADT/FoldingSet.cpp
+++ b/llvm/unittests/ADT/FoldingSet.cpp
@@ -41,7 +41,7 @@ TEST(FoldingSetTest, UnalignedStringTest) {
   std::string str2 = ">" + str1;
   b.AddString(str2.c_str() + 1);
 
-  EXPECT_EQ(a.ComputeHash(), b.ComputeHash());
+  EXPECT_EQ(a.computeHash(), b.computeHash());
 }
 
 TEST(FoldingSetTest, LongLongComparison) {


### PR DESCRIPTION
Rename `RemoveNode` to erase, matching the public name it implements,
and ComputeHash to computeHash, matching computeStableHash beside it.