### PR TITLE
[Github] Restrict issue-write workflow to llvm/llvm-project

### DIFF
--- a/.github/workflows/issue-write.yml
+++ b/.github/workflows/issue-write.yml
@@ -28,7 +28,8 @@ jobs:
       (
         github.event.workflow_run.conclusion == 'success' ||
         github.event.workflow_run.conclusion == 'failure'
-      )
+      ) &&
+      github.repository == 'llvm/llvm-project'
     steps:
       - name: Fetch Sources
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
There were reports in #infrastructure on GitHub of this job failing in forks and people getting notifications from the failures. Follow our CI best practices and prevent this job from running on forks.