### PR TITLE
[MachineScheduler] Keep live-in physreg copies ahead of inline asm

### DIFF
--- a/llvm/lib/CodeGen/MachineScheduler.cpp
+++ b/llvm/lib/CodeGen/MachineScheduler.cpp
@@ -1130,6 +1130,28 @@ void ScheduleDAGMI::schedule() {
 
 /// Apply each ScheduleDAGMutation step in order.
 void ScheduleDAGMI::postProcessDAG() {
+  // Keep copies of block live-in physical registers ahead of inline asm in
+  // their original scheduling region. Sinking such a copy extends an
+  // unspillable physical register live range across the asm, while keeping it
+  // above the asm lets register allocation spill the virtual register instead.
+  for (SUnit &CopySU : SUnits) {
+    MachineInstr *Copy = CopySU.getInstr();
+    if (!Copy->isCopy())
+      continue;
+
+    Register DstReg = Copy->getOperand(0).getReg();
+    Register SrcReg = Copy->getOperand(1).getReg();
+    if (!DstReg.isVirtual() || !SrcReg.isPhysical() ||
+        !Copy->getParent()->isLiveIn(SrcReg))
+      continue;
+
+    for (SUnit &SU : SUnits) {
+      if (SU.NodeNum <= CopySU.NodeNum || !SU.getInstr()->isInlineAsm())
+        continue;
+      addEdge(&SU, SDep(&CopySU, SDep::Artificial));
+    }
+  }
+
   for (auto &m : Mutations)
     m->apply(this);
 }

--- a/llvm/test/CodeGen/X86/inline-asm-livein-copy.ll
+++ b/llvm/test/CodeGen/X86/inline-asm-livein-copy.ll
@@ -1,0 +1,35 @@
+; RUN: llc -mtriple=x86_64-linux-gnu -O2 -frame-pointer=all < %s | FileCheck %s
+
+@counter = internal global i64 0
+@counter.1 = internal global i64 0
+
+define void @livein_copy(i64 %arg) {
+; CHECK-LABEL: livein_copy:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    pushq %rbp
+; CHECK:         movq %rdi, {{[-0-9]+}}(%rbp) # 8-byte Spill
+; CHECK:         #APP
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    #NO_APP
+; CHECK:         movq {{[-0-9]+}}(%rbp), %{{[a-z0-9]+}} # 8-byte Reload
+; CHECK:         #APP
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    #NO_APP
+; CHECK:         retq
+  %count = load i64, ptr @counter
+  %inc = add i64 %count, 1
+  store i64 %inc, ptr @counter
+  %count.1 = load i64, ptr @counter.1
+  %inc.1 = add i64 %count.1, 1
+  store i64 %inc.1, ptr @counter.1
+  tail call { i64, i64, i64 } asm sideeffect "nop",
+      "=r,=r,=r,0,1,2,~{rax},~{rbx},~{rcx},~{rdx},~{r8},~{r9},~{r10},~{r11},~{r13},~{r14},~{r15},~{memory},~{cc}"
+      (i64 4660, i64 43981, i64 239)
+  %count.2 = load i64, ptr @counter.1
+  %inc.2 = add i64 %count.2, 1
+  store i64 %inc.2, ptr @counter.1
+  tail call { i64, i64, i64 } asm sideeffect "nop",
+      "=r,=r,=r,0,1,2,~{rax},~{rbx},~{rcx},~{rdx},~{r8},~{r9},~{r10},~{r11},~{r13},~{r14},~{r15},~{memory},~{cc}"
+      (i64 6699, i64 15437, i64 %arg)
+  ret void
+}


### PR DESCRIPTION
A block live-in physical register remains unspillable until it is copied to a virtual register. If MachineScheduler sinks that COPY across an inline asm, the physical live range can unnecessarily cross the asm and reduce the registers available for its operands.

Add artificial scheduling dependencies that retain the original ordering between these live-in copies and later inline asm instructions in the same scheduling region. This lets the existing register allocator spill the virtual live range when needed, without introducing a dedicated spill/reload pass.

The regression test covers the scheduler shape and register pressure demonstrated by the reproducer discussed in #206307. This change is intentionally limited to that scheduling behavior.

Related to #206307.

Tests:
- `ninja llc`
- `llvm-lit -sv llvm/test/CodeGen/X86/inline-asm-livein-copy.ll`
- Original C/IR reproducer from #206307 compiled with `llc -O2 -frame-pointer=all`