### PR TITLE
[clang][bytecode] Keep sourcemaps smaller

### DIFF
--- a/clang/lib/AST/ByteCode/ByteCodeEmitter.cpp
+++ b/clang/lib/AST/ByteCode/ByteCodeEmitter.cpp
@@ -209,9 +209,9 @@ bool ByteCodeEmitter::emitOp(Opcode Op, const Tys &...Args, SourceInfo SI) {
   // The opcode is followed by arguments. The source info is
   // attached to the address after the opcode.
   emit(P, Code, Op, Success);
-  if (LocOverride)
-    SrcMap.push(Code.size(), *LocOverride);
-  else if (SI)
+
+  SI = LocOverride.value_or(SI);
+  if (SrcMap.empty() || SrcMap.back() != SI)
     SrcMap.push(Code.size(), SI);
 
   (..., emit(P, Code, Args, Success));

--- a/clang/lib/AST/ByteCode/InterpFrame.cpp
+++ b/clang/lib/AST/ByteCode/InterpFrame.cpp
@@ -230,8 +230,7 @@ SourceRange InterpFrame::getCallRange() const {
     if (!C->RetPC)
       continue;
     SourceRange CallRange =
-        C->Caller->Func->getSource(C->getRetOpPC() - sizeof(uintptr_t))
-            .getRange();
+        C->Caller->Func->getSource(C->getRetOpPC()).getRange();
     if (CallRange.isValid())
       return CallRange;
   }

--- a/clang/lib/AST/ByteCode/Source.h
+++ b/clang/lib/AST/ByteCode/Source.h
@@ -76,7 +76,7 @@ private:
 /// Describes the statement/declaration an opcode was generated from.
 class SourceInfo final {
 public:
-  SourceInfo() {}
+  SourceInfo() : Source(nullptr) {}
   SourceInfo(const Stmt *E) : Source(E) {}
   SourceInfo(const Decl *D) : Source(D) {}
 
@@ -91,7 +91,9 @@ public:
   }
   const Expr *asExpr() const { return dyn_cast_if_present<Expr>(asStmt()); }
 
-  operator bool() const { return !Source.isNull(); }
+  explicit operator bool() const { return !Source.isNull(); }
+
+  bool operator!=(SourceInfo O) { return Source != O.Source; }
 
 private:
   llvm::PointerUnion<const Decl *, const Stmt *> Source;
@@ -112,13 +114,22 @@ public:
     Infos.push_back(Info);
   }
 
+  bool empty() const { return Offsets.empty(); }
+  SourceInfo back() const { return Infos.back(); }
+
   SourceInfo findSourceForOffset(uint32_t Offset) const {
     assert(!Offsets.empty());
     assert(Offsets.size() == Infos.size());
 #ifndef NDEBUG
     assert(llvm::is_sorted(Offsets));
 #endif
-    const auto *It = llvm::lower_bound(Offsets, Offset);
+
+    // Find the last offset <= Offset.
+    auto *It = llvm::upper_bound(Offsets, Offset);
+    if (It == Offsets.begin())
+      return Infos[0];
+
+    --It;
     return Infos[It - Offsets.begin()];
   }
 };
@@ -127,7 +138,6 @@ public:
 class SourceMapper {
 public:
   virtual ~SourceMapper() {}
-
   /// Returns source information for a given PC in a function.
   virtual SourceInfo getSource(CodePtr PC) const = 0;
 

--- a/clang/test/AST/ByteCode/virtual-bases.cpp
+++ b/clang/test/AST/ByteCode/virtual-bases.cpp
@@ -414,12 +414,11 @@ namespace ConstantDestruction {
     }
   };
 
-  struct X : virtual V { // expected-note {{in call to}}
+  struct X : virtual V {
     constexpr X() : V(true) {}
   };
   constexpr X x; // both-error {{constexpr variable 'x' must have constant destruction}} \
-                 // both-note {{in call to}} \
-                 // ref-note {{in call to}}
+                 // both-note 2{{in call to}}
 }
 
 namespace Offsets {


### PR DESCRIPTION
Only add new entries if they are different than the currently last entry. This means we won't have an entry for _all_ opcodes in the source map anymore.