### PR TITLE
[CMake] Special-case HarmonyOS hosts in get_host_triple()

### DIFF
--- a/llvm/cmake/modules/GetHostTriple.cmake
+++ b/llvm/cmake/modules/GetHostTriple.cmake
@@ -1,5 +1,5 @@
 # Returns the host triple.
-# Invokes config.guess
+# Invokes config.guess, except for platforms it cannot identify.
 
 function( get_host_triple var )
   if( MSVC OR CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")
@@ -40,6 +40,44 @@ function( get_host_triple var )
       set( value "powerpc64-ibm-aix" )
     else()
       set( value "powerpc-ibm-aix" )
+    endif()
+  elseif( CMAKE_HOST_SYSTEM_NAME MATCHES "HarmonyOS|OpenHarmony|OHOS" )
+    # config.guess cannot identify HarmonyOS: uname -s reports "HarmonyOS",
+    # which config.guess does not recognize, and its probing is rejected by
+    # the system sandbox. Build the triple from CMake's host detection using
+    # the form clang targets on OHOS (e.g. aarch64-unknown-linux-ohos). CMake
+    # itself may report the host processor as "unknown" because uname -p does,
+    # so fall back to asking uname -m directly.
+    set( TT_MACHINE "${CMAKE_HOST_SYSTEM_PROCESSOR}" )
+    if( NOT TT_MACHINE OR TT_MACHINE STREQUAL "unknown" )
+      find_program( TT_UNAME uname PATHS /bin /usr/bin /usr/local/bin
+        NO_CMAKE_FIND_ROOT_PATH )
+      set( TT_RV 1 )
+      if( TT_UNAME )
+        execute_process( COMMAND ${TT_UNAME} -m
+          RESULT_VARIABLE TT_RV
+          OUTPUT_VARIABLE TT_MACHINE
+          OUTPUT_STRIP_TRAILING_WHITESPACE
+          ERROR_QUIET )
+      endif()
+      if( NOT TT_RV EQUAL 0 )
+        set( TT_MACHINE "" )
+      endif()
+    endif()
+    if( TT_MACHINE MATCHES "aarch64|arm64" )
+      set( value "aarch64-unknown-linux-ohos" )
+    elseif( TT_MACHINE MATCHES "^arm" )
+      set( value "arm-unknown-linux-ohos" )
+    elseif( TT_MACHINE MATCHES "^x86_64" )
+      set( value "x86_64-unknown-linux-ohos" )
+    elseif( TT_MACHINE MATCHES "^riscv64" )
+      set( value "riscv64-unknown-linux-ohos" )
+    elseif( TT_MACHINE MATCHES "^loongarch64" )
+      set( value "loongarch64-unknown-linux-ohos" )
+    else()
+      message( FATAL_ERROR
+        "Failed to determine host triple for ${CMAKE_HOST_SYSTEM_NAME}: "
+        "host processor \"${TT_MACHINE}\" is not supported" )
     endif()
   else()
     if(CMAKE_HOST_SYSTEM_NAME STREQUAL Windows AND NOT MSYS)

--- a/llvm/test/CMake/Inputs/get-host-triple.cmake
+++ b/llvm/test/CMake/Inputs/get-host-triple.cmake
@@ -1,0 +1,25 @@
+# Driver for testing llvm/cmake/modules/GetHostTriple.cmake. It simulates a
+# host platform by setting the variables that CMake's platform detection
+# normally provides, then reports the triple computed by get_host_triple().
+#
+# Usage:
+#   cmake -DSRC_ROOT=<llvm source root>
+#         -DHOST_SYSTEM_NAME=<simulated CMAKE_HOST_SYSTEM_NAME>
+#         -DHOST_SYSTEM_PROCESSOR=<simulated CMAKE_HOST_SYSTEM_PROCESSOR>
+#         -P get-host-triple.cmake
+
+if( NOT SRC_ROOT )
+  message( FATAL_ERROR "SRC_ROOT is not set" )
+endif()
+
+set( CMAKE_HOST_SYSTEM_NAME "${HOST_SYSTEM_NAME}" )
+set( CMAKE_HOST_SYSTEM_PROCESSOR "${HOST_SYSTEM_PROCESSOR}" )
+
+include( "${SRC_ROOT}/cmake/modules/GetHostTriple.cmake" )
+
+function( report_host_triple )
+  get_host_triple( host_triple )
+  message( "host_triple=${host_triple}" )
+endfunction()
+
+report_host_triple()

--- a/llvm/test/CMake/get-host-triple.test
+++ b/llvm/test/CMake/get-host-triple.test
@@ -1,0 +1,28 @@
+# Test get_host_triple() from llvm/cmake/modules/GetHostTriple.cmake for host
+# systems where config.guess cannot be used, such as HarmonyOS: uname -s
+# reports "HarmonyOS", which config.guess does not recognize, and its probing
+# is rejected by the system sandbox. The CMake variables that CMake's platform
+# detection normally provides are simulated via the driver in Inputs.
+
+RUN: %cmake -DSRC_ROOT=%S/../.. -DHOST_SYSTEM_NAME=HarmonyOS -DHOST_SYSTEM_PROCESSOR=aarch64 -P %S/Inputs/get-host-triple.cmake 2>&1 | FileCheck %s --check-prefix=HARMONYOS-AARCH64
+HARMONYOS-AARCH64: host_triple=aarch64-unknown-linux-ohos
+
+RUN: %cmake -DSRC_ROOT=%S/../.. -DHOST_SYSTEM_NAME=HarmonyOS -DHOST_SYSTEM_PROCESSOR=armv7l -P %S/Inputs/get-host-triple.cmake 2>&1 | FileCheck %s --check-prefix=HARMONYOS-ARM
+HARMONYOS-ARM: host_triple=arm-unknown-linux-ohos
+
+RUN: %cmake -DSRC_ROOT=%S/../.. -DHOST_SYSTEM_NAME=HarmonyOS -DHOST_SYSTEM_PROCESSOR=x86_64 -P %S/Inputs/get-host-triple.cmake 2>&1 | FileCheck %s --check-prefix=HARMONYOS-X86_64
+HARMONYOS-X86_64: host_triple=x86_64-unknown-linux-ohos
+
+RUN: %cmake -DSRC_ROOT=%S/../.. -DHOST_SYSTEM_NAME=HarmonyOS -DHOST_SYSTEM_PROCESSOR=riscv64 -P %S/Inputs/get-host-triple.cmake 2>&1 | FileCheck %s --check-prefix=HARMONYOS-RISCV64
+HARMONYOS-RISCV64: host_triple=riscv64-unknown-linux-ohos
+
+RUN: %cmake -DSRC_ROOT=%S/../.. -DHOST_SYSTEM_NAME=HarmonyOS -DHOST_SYSTEM_PROCESSOR=loongarch64 -P %S/Inputs/get-host-triple.cmake 2>&1 | FileCheck %s --check-prefix=HARMONYOS-LOONGARCH64
+HARMONYOS-LOONGARCH64: host_triple=loongarch64-unknown-linux-ohos
+
+# The OpenHarmony and OHOS spellings of the host system name are handled the
+# same way.
+RUN: %cmake -DSRC_ROOT=%S/../.. -DHOST_SYSTEM_NAME=OpenHarmony -DHOST_SYSTEM_PROCESSOR=aarch64 -P %S/Inputs/get-host-triple.cmake 2>&1 | FileCheck %s --check-prefix=OPENHARMONY-AARCH64
+OPENHARMONY-AARCH64: host_triple=aarch64-unknown-linux-ohos
+
+RUN: %cmake -DSRC_ROOT=%S/../.. -DHOST_SYSTEM_NAME=OHOS -DHOST_SYSTEM_PROCESSOR=aarch64 -P %S/Inputs/get-host-triple.cmake 2>&1 | FileCheck %s --check-prefix=OHOS-AARCH64
+OHOS-AARCH64: host_triple=aarch64-unknown-linux-ohos

--- a/llvm/test/CMake/lit.local.cfg
+++ b/llvm/test/CMake/lit.local.cfg
@@ -1,0 +1,1 @@
+config.substitutions.append(("%cmake", "'%s'" % config.host_cmake))

--- a/llvm/test/lit.site.cfg.py.in
+++ b/llvm/test/lit.site.cfg.py.in
@@ -26,6 +26,7 @@ config.ocamlfind_executable = "@OCAMLFIND@"
 config.have_ocamlopt = @HAVE_OCAMLOPT@
 config.ocaml_flags = "@OCAMLFLAGS@"
 config.ptxas_executable = "@PTXAS_EXECUTABLE@"
+config.host_cmake = "@CMAKE_COMMAND@"
 config.enable_assertions = @ENABLE_ASSERTIONS@
 config.targets_to_build = "@TARGETS_TO_BUILD@"
 config.native_target = "@LLVM_NATIVE_ARCH@"


### PR DESCRIPTION
## Summary

Fixes #219653

`config.guess` cannot identify HarmonyOS: `uname -s` reports `HarmonyOS`, which `config.guess` does not recognize, and its probing is rejected by the system sandbox, so configuring LLVM on HarmonyOS fails hard even with `TMPDIR` pointed at a safe location (reproducer in the issue). The current workaround is to hard-code the host triple.

Handle HarmonyOS/OpenHarmony/OHOS hosts in `get_host_triple()` the same way Windows, MinGW, z/OS and AIX are already handled: derive the triple from CMake's host detection in the form clang targets on OHOS, e.g. `aarch64-unknown-linux-ohos` (matching `clang -dumpmachine`), covering the architectures the OHOS toolchain supports (AArch64, ARM, x86_64, RISCV64, LoongArch64).

One subtlety worth noting: on HarmonyOS, `uname -p` succeeds while printing `unknown`, and CMake only retries with `uname -m` when `uname -p` exits non-zero (Modules/CMakeDetermineSystem.cmake), so `CMAKE_HOST_SYSTEM_PROCESSOR` ends up as the literal string `unknown` on real hardware. In that case the module falls back to invoking `uname -m` directly.

## Testing and native configuration validation

Added `llvm/test/CMake/get-host-triple.test`, which drives the module in script mode with simulated CMake host-detection variables through `llvm/test/CMake/Inputs/get-host-triple.cmake`. The seven committed RUN lines cover the five architecture mappings implemented by this patch and the `OpenHarmony` and `OHOS` host-name variants. They do not currently cover the unknown-processor fallback or unsupported-processor error path. Earlier local script-mode CMake runs exercised fallback and error paths; those checks are not committed regression coverage.

**Native HarmonyOS configuration is confirmed for PR head `1f3ea13134a84be3d247afcb7f0cd1007676507d`.** In [the native validation report](https://github.com/llvm/llvm-project/pull/219882#issuecomment-5717697269), @GKxxUCAS tested on a real HarmonyOS 7 PC (MateBook Pro S, HongMeng Kernel 1.13.0, aarch64), with no `LLVM_HOST_TRIPLE` command-line override and no local edits to `GetHostTriple.cmake`.

- LLVM configuration and generation completed with exit code 0 and `LLVM host triple: aarch64-unknown-linux-ohos`.
- The separate `runtimes` configuration with `LLVM_ENABLE_RUNTIMES=compiler-rt` also completed and printed the same host triple.
- `CMAKE_HOST_SYSTEM_PROCESSOR` was the literal `unknown`; the report identifies `TT_UNAME:FILEPATH=/usr/bin/uname` in the cache, confirming the fallback was exercised.
- All seven committed RUN lines passed when executed directly with real FileCheck and the substitutions lit would apply. This was not a `check-llvm` run.

This is reporter-provided native configuration validation, not a full LLVM build or full test-suite result. Testing on my side used simulated script-mode CMake runs, not a HarmonyOS emulator or physical device. Additional committed regression coverage for the fallback and unsupported-processor error remains a suggestion, as does the explicitly optional replacement of the fallback with `cmake_host_system_information(QUERY OS_PLATFORM)`.

---

AI tool usage note (per the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html)): this contribution was prepared with the assistance of an AI coding agent. The author reviewed, verified, and tested all changes (including script-mode cmake runs of the new test harness) and takes full responsibility for this contribution.
