### PR TITLE
[libc++] Make once_flag pointer-sized on MinGW

### DIFF
--- a/libcxx/include/__mutex/once_flag.h
+++ b/libcxx/include/__mutex/once_flag.h
@@ -52,7 +52,7 @@ struct once_flag {
   once_flag(const once_flag&)            = delete;
   once_flag& operator=(const once_flag&) = delete;
 
-#if defined(_LIBCPP_ABI_MICROSOFT)
+#ifdef _WIN32
   typedef uintptr_t _State_type;
 #else
   typedef unsigned long _State_type;


### PR DESCRIPTION
This is ABI breaking on MinGW. However, the impact is deemed small enough that it's acceptable.