### PR TITLE
[clang][test] Make new absurdly_big_struct test more targeted

### DIFF
--- a/clang/test/AST/absurdly_big_struct.cpp
+++ b/clang/test/AST/absurdly_big_struct.cpp
@@ -13,12 +13,11 @@ long long x3() { return sizeof(a::x2); }
 long long x4() { return sizeof(z); }
 
 // On 32-bit architectures, the struct size must be below (1 << 32).
-// This used to crash in CodeGen.
 struct b { // bit32-error {{structure 'b' is too large, which exceeds maximum allowed size of 4294967296 bytes}}
   char c[0xFFFFFFFE];
   char c1[4];
   char c2[2];
 };
 
-long long y(int i) { return __builtin_offsetof(b, c2[i]); }
+long long y() { return __builtin_offsetof(b, c2[0]); }
 


### PR DESCRIPTION
The previous version of `y()` used `c2[i]`, which can't be evaluated at compile-time.
The emitted diagnostic depends on something calling `ASTContext::getASTRecordLayout()` for `b`, which currently happens in the constant evaluator. If the evaluator decides to evaluate `c2[i]` before calling `getASTRecordLayout()`, the test fails since the diagnostic is never emitted.

Fix this by simply using `c2[0]` instead.