### PR TITLE
[CIR][OpenCL][NFC] Add language address-space lowering coverage

### DIFF
--- a/clang/test/CIR/CodeGen/spirv-target-lowering-as.cpp
+++ b/clang/test/CIR/CodeGen/spirv-target-lowering-as.cpp
@@ -1,0 +1,73 @@
+// RUN: %clang_cc1 -triple spirv64-unknown-unknown -fclangir -emit-cir \
+// RUN:   -Wno-deprecated-attributes -mmlir \
+// RUN:   --mlir-print-ir-before=cir-target-lowering \
+// RUN:   %s -o %t.cir 2> %t.pre.cir
+// RUN: FileCheck %s --check-prefix=PRE --input-file=%t.pre.cir
+// RUN: FileCheck %s --check-prefix=POST --input-file=%t.cir
+
+using global_int = int [[clang::opencl_global]];
+using local_int = int [[clang::opencl_local]];
+using constant_int = int [[clang::opencl_constant]];
+using private_int = int [[clang::opencl_private]];
+using generic_int = int [[clang::opencl_generic]];
+using device_int = int [[clang::opencl_global_device]];
+using host_int = int [[clang::opencl_global_host]];
+
+global_int global_value = 0;
+
+// PRE: cir.global {{.*}} lang_address_space(offload_global) @global_value
+// POST: cir.global {{.*}} target_address_space(1) @global_value
+
+void address_spaces(private_int *private_ptr, local_int *local_ptr,
+                    global_int *global_ptr, constant_int *constant_ptr,
+                    generic_int *generic_ptr, device_int *device_ptr,
+                    host_int *host_ptr) {}
+
+// PRE-LABEL: cir.func {{.*}} @_Z14address_spaces
+// PRE-SAME: !cir.ptr<!s32i, lang_address_space(offload_private)>
+// PRE-SAME: !cir.ptr<!s32i, lang_address_space(offload_local)>
+// PRE-SAME: !cir.ptr<!s32i, lang_address_space(offload_global)>
+// PRE-SAME: !cir.ptr<!s32i, lang_address_space(offload_constant)>
+// PRE-SAME: !cir.ptr<!s32i, lang_address_space(offload_generic)>
+// PRE-SAME: !cir.ptr<!s32i, lang_address_space(offload_global_device)>
+// PRE-SAME: !cir.ptr<!s32i, lang_address_space(offload_global_host)>
+
+// POST-LABEL: cir.func {{.*}} @_Z14address_spaces
+// POST-SAME: !cir.ptr<!s32i>
+// POST-SAME: !cir.ptr<!s32i, target_address_space(3)>
+// POST-SAME: !cir.ptr<!s32i, target_address_space(1)>
+// POST-SAME: !cir.ptr<!s32i, target_address_space(2)>
+// POST-SAME: !cir.ptr<!s32i, target_address_space(4)>
+// POST-SAME: !cir.ptr<!s32i, target_address_space(5)>
+// POST-SAME: !cir.ptr<!s32i, target_address_space(6)>
+
+using global_int_ptr = global_int *;
+using global_int_ptr_array = global_int_ptr[4];
+
+void nested_types(global_int_ptr [[clang::opencl_local]] *nested,
+                  global_int_ptr_array [[clang::opencl_constant]] *array) {}
+
+// PRE-LABEL: cir.func {{.*}} @_Z12nested_types
+// PRE-SAME: !cir.ptr<!cir.ptr<!s32i, lang_address_space(offload_global)>, lang_address_space(offload_local)>
+// PRE-SAME: !cir.ptr<!cir.array<!cir.ptr<!s32i, lang_address_space(offload_global)> x 4>, lang_address_space(offload_constant)>
+
+// POST-LABEL: cir.func {{.*}} @_Z12nested_types
+// POST-SAME: !cir.ptr<!cir.ptr<!s32i, target_address_space(1)>, target_address_space(3)>
+// POST-SAME: !cir.ptr<!cir.array<!cir.ptr<!s32i, target_address_space(1)> x 4>, target_address_space(2)>
+
+generic_int *cast_and_global(global_int *ptr) {
+  (void)global_value;
+  return ptr;
+}
+
+// PRE-LABEL: cir.func {{.*}} @_Z15cast_and_global
+// PRE: cir.get_global @global_value : !cir.ptr<!s32i, lang_address_space(offload_global)>
+// PRE: cir.cast address_space
+// PRE-SAME: !cir.ptr<!s32i, lang_address_space(offload_global)>
+// PRE-SAME: !cir.ptr<!s32i, lang_address_space(offload_generic)>
+
+// POST-LABEL: cir.func {{.*}} @_Z15cast_and_global
+// POST: cir.get_global @global_value : !cir.ptr<!s32i, target_address_space(1)>
+// POST: cir.cast address_space
+// POST-SAME: !cir.ptr<!s32i, target_address_space(1)>
+// POST-SAME: !cir.ptr<!s32i, target_address_space(4)>

--- a/clang/test/CIR/CodeGenOpenCL/address-space-conversions.cl
+++ b/clang/test/CIR/CodeGenOpenCL/address-space-conversions.cl
@@ -2,6 +2,12 @@
 // RUN:   -mmlir --mlir-print-ir-before=cir-target-lowering \
 // RUN:   %s -o %t.cir 2> %t.pre.cir
 // RUN: FileCheck %s --check-prefix=CIR --input-file=%t.pre.cir
+// RUN: %clang_cc1 -x cl -triple spirv64-unknown-unknown -cl-std=CL2.0 \
+// RUN:   -fclangir -emit-llvm -O0 %s -o %t.cir.ll
+// RUN: FileCheck %s --check-prefix=LLVM --input-file=%t.cir.ll
+// RUN: %clang_cc1 -x cl -triple spirv64-unknown-unknown -cl-std=CL2.0 \
+// RUN:   -emit-llvm -O0 %s -o %t.ogcg.ll
+// RUN: FileCheck %s --check-prefix=LLVM --input-file=%t.ogcg.ll
 
 void address_space_conversions(global int *global_ptr,
                                generic int *generic_ptr,
@@ -21,3 +27,11 @@ void address_space_conversions(global int *global_ptr,
 // CIR: cir.cast address_space
 // CIR-SAME: !cir.ptr<!s32i, lang_address_space(offload_generic)>
 // CIR-SAME: !cir.ptr<!s32i, lang_address_space(offload_global)>
+
+// LLVM-LABEL: define {{.*}}void @address_space_conversions
+// LLVM-SAME: ptr addrspace(1) noundef
+// LLVM-SAME: ptr addrspace(4) noundef
+// LLVM-SAME: ptr noundef
+// LLVM: addrspacecast ptr addrspace(1) %{{.*}} to ptr addrspace(4)
+// LLVM: addrspacecast ptr %{{.*}} to ptr addrspace(4)
+// LLVM: addrspacecast ptr addrspace(4) %{{.*}} to ptr addrspace(1)

--- a/clang/test/CIR/CodeGenOpenCL/address-spaces.cl
+++ b/clang/test/CIR/CodeGenOpenCL/address-spaces.cl
@@ -2,6 +2,12 @@
 // RUN:   -Wno-deprecated-attributes -mmlir \
 // RUN:   --mlir-print-ir-before=cir-target-lowering %s -o %t.cir 2> %t.pre.cir
 // RUN: FileCheck %s --check-prefix=CIR --input-file=%t.pre.cir
+// RUN: %clang_cc1 -x cl -triple spirv64-unknown-unknown -cl-std=CL2.0 \
+// RUN:   -fclangir -emit-llvm -O0 -Wno-deprecated-attributes %s -o %t.cir.ll
+// RUN: FileCheck %s --check-prefix=LLVM --input-file=%t.cir.ll
+// RUN: %clang_cc1 -x cl -triple spirv64-unknown-unknown -cl-std=CL2.0 \
+// RUN:   -emit-llvm -O0 -Wno-deprecated-attributes %s -o %t.ogcg.ll
+// RUN: FileCheck %s --check-prefix=LLVM --input-file=%t.ogcg.ll
 
 typedef global int *global_int_ptr;
 
@@ -19,6 +25,15 @@ void pointer_types(
 // CIR-SAME: !cir.ptr<!s32i, lang_address_space(offload_generic)>
 // CIR-SAME: !cir.ptr<!s32i, lang_address_space(offload_global_device)>
 // CIR-SAME: !cir.ptr<!s32i, lang_address_space(offload_global_host)>
+
+// LLVM-LABEL: define {{.*}}void @pointer_types
+// LLVM-SAME: ptr noundef
+// LLVM-SAME: ptr addrspace(3) noundef
+// LLVM-SAME: ptr addrspace(1) noundef
+// LLVM-SAME: ptr addrspace(2) noundef
+// LLVM-SAME: ptr addrspace(4) noundef
+// LLVM-SAME: ptr addrspace(5) noundef
+// LLVM-SAME: ptr addrspace(6) noundef
 
 // The outer pointer addresses a private pointer object, whose stored pointer
 // value addresses global memory.
@@ -41,3 +56,9 @@ void local_pointer_value(global int *ptr) {
 // CIR: cir.store {{.*}}, %[[SAVED_ADDR]]
 // CIR-SAME: !cir.ptr<!s32i, lang_address_space(offload_global)>
 // CIR-SAME: !cir.ptr<!cir.ptr<!s32i, lang_address_space(offload_global)>, lang_address_space(offload_private)>
+
+// LLVM-LABEL: define {{.*}}void @local_pointer_value
+// LLVM-SAME: ptr addrspace(1) noundef
+// LLVM: alloca ptr addrspace(1)
+// LLVM: load ptr addrspace(1)
+// LLVM: store ptr addrspace(1)

--- a/clang/test/CIR/Lowering/address-space.cir
+++ b/clang/test/CIR/Lowering/address-space.cir
@@ -42,4 +42,24 @@ module {
     %0 = cir.alloca "arg" align(8) init : !cir.ptr<!cir.ptr<!s32i, target_address_space(0)>>
     cir.return
   }
+
+  // LLVM-LABEL: define ptr addrspace(3) @nested_pointer
+  // LLVM-SAME: ptr addrspace(1) %[[ARG:[0-9]+]]
+  cir.func @nested_pointer(%arg0: !cir.ptr<!cir.ptr<!s32i, target_address_space(3)>, target_address_space(1)>) -> !cir.ptr<!s32i, target_address_space(3)> {
+    // LLVM: %[[INNER:.*]] = load ptr addrspace(3)
+    // LLVM-SAME: ptr addrspace(1) %[[ARG]]
+    %0 = cir.load %arg0 : !cir.ptr<!cir.ptr<!s32i, target_address_space(3)>, target_address_space(1)>, !cir.ptr<!s32i, target_address_space(3)>
+    // LLVM: ret ptr addrspace(3) %[[INNER]]
+    cir.return %0 : !cir.ptr<!s32i, target_address_space(3)>
+  }
+
+  // LLVM-LABEL: define ptr addrspace(2) @address_space_cast
+  // LLVM-SAME: ptr addrspace(1) %[[ARG:[0-9]+]]
+  cir.func @address_space_cast(%arg0: !cir.ptr<!s32i, target_address_space(1)>) -> !cir.ptr<!s32i, target_address_space(2)> {
+    // LLVM: %[[CAST:.*]] = addrspacecast ptr addrspace(1) %[[ARG]]
+    // LLVM-SAME: to ptr addrspace(2)
+    %0 = cir.cast address_space %arg0 : !cir.ptr<!s32i, target_address_space(1)> -> !cir.ptr<!s32i, target_address_space(2)>
+    // LLVM: ret ptr addrspace(2) %[[CAST]]
+    cir.return %0 : !cir.ptr<!s32i, target_address_space(2)>
+  }
 }


### PR DESCRIPTION
Expand coverage for lowering OpenCL language address spaces through target-specific CIR and LLVM IR, including comparison with classic CodeGen.

Assisted-by: Codex / GPT-5.6 Sol