### PR TITLE
[gold] Handle absence of gold linker in tests

### DIFF
--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -657,7 +657,7 @@ def have_ld_plugin_support(ld_executable, name):
         return False
 
     # CMake was not able to find the linker executable.
-    if ld_executable.endswith('NOTFOUND'):
+    if ld_executable.endswith("NOTFOUND"):
         return False
 
     ld_cmd = subprocess.Popen(

--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -656,6 +656,10 @@ def have_ld_plugin_support(ld_executable, name):
     ):
         return False
 
+    # CMake was not able to find the linker executable.
+    if ld_executable.endswith('NOTFOUND'):
+        return False
+
     ld_cmd = subprocess.Popen(
         [ld_executable, "--help"], stdout=subprocess.PIPE, env={"LANG": "C"}
     )


### PR DESCRIPTION
If we get a NOTFOUND executable, directly report plugin support
as unavailable, instead of trying to invoke the linker.

This fixes a regression from #130981.