### PR TITLE
  [Clang] Fix wording of ref-qualifier overload diagnostic

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -243,6 +243,10 @@ features cannot lower the translation-unit ABI level;
 
 ### Improvements to Clang's diagnostics
 
+- The `cannot overload a member function` diagnostic now describes the previous
+  declaration first, matching the order in which the declarations appear in the
+  source. (#GH219803)
+
 - More consistent rendering of Unicode characters in diagnostic messages.
 
 - Fixed `-Wunused-parameter` to diagnose coroutine parameters that are only

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -1528,7 +1528,7 @@ static bool IsOverloadOrOverrideImpl(Sema &SemaRef, FunctionDecl *New,
     if (!UseMemberUsingDeclRules && (OldMethod->getRefQualifier() == RQ_None ||
                                      NewMethod->getRefQualifier() == RQ_None)) {
       SemaRef.Diag(NewMethod->getLocation(), diag::err_ref_qualifier_overload)
-          << NewMethod->getRefQualifier() << OldMethod->getRefQualifier();
+          << OldMethod->getRefQualifier() << NewMethod->getRefQualifier();
       SemaRef.Diag(OldMethod->getLocation(), diag::note_previous_declaration);
       return true;
     }

--- a/clang/test/CXX/drs/cwg24xx.cpp
+++ b/clang/test/CXX/drs/cwg24xx.cpp
@@ -209,13 +209,13 @@ struct S {
 
 struct T : S {
     virtual void f() &;
-    // expected-error@-1 {{cannot overload a member function with ref-qualifier '&' with a member function without a ref-qualifier}}
+    // expected-error@-1 {{cannot overload a member function without a ref-qualifier with a member function with ref-qualifier '&'}}
     //   expected-note@#cwg2496-f {{previous declaration is here}}
     virtual void g();
-    // expected-error@-1 {{cannot overload a member function without a ref-qualifier with a member function with ref-qualifier '&'}}
+    // expected-error@-1 {{cannot overload a member function with ref-qualifier '&' with a member function without a ref-qualifier}}
     //   expected-note@#cwg2496-g {{previous declaration is here}}
     virtual void h() &&;
-    // expected-error@-1 {{cannot overload a member function with ref-qualifier '&&' with a member function without a ref-qualifier}}
+    // expected-error@-1 {{cannot overload a member function without a ref-qualifier with a member function with ref-qualifier '&&'}}
     //   expected-note@#cwg2496-h {{previous declaration is here}}
     virtual void i();
     virtual void j() &;

--- a/clang/test/CXX/drs/cwg5xx.cpp
+++ b/clang/test/CXX/drs/cwg5xx.cpp
@@ -959,12 +959,12 @@ namespace cwg574 { // cwg574: 3.0
 #elif __cplusplus >= 201103L
     // FIXME: We shouldn't produce the 'cannot overload' diagnostics here.
     friend C &C::operator=(const C&); // #cwg574-test-C
-    // since-cxx11-error@#cwg574-test-C {{cannot overload a member function without a ref-qualifier with a member function with ref-qualifier '&'}}
+    // since-cxx11-error@#cwg574-test-C {{cannot overload a member function with ref-qualifier '&' with a member function without a ref-qualifier}}
     //   since-cxx11-note@#cwg574-C-copy-assign {{previous declaration is here}}
     // since-cxx11-error@#cwg574-test-C {{friend declaration of 'operator=' does not match any declaration in 'cwg574::C'}}
     //   since-cxx11-note@#cwg574-C-copy-assign {{candidate function}}
     friend D &D::operator=(const D&); // #cwg574-test-D
-    // since-cxx11-error@#cwg574-test-D {{cannot overload a member function without a ref-qualifier with a member function with ref-qualifier '&&'}}
+    // since-cxx11-error@#cwg574-test-D {{cannot overload a member function with ref-qualifier '&&' with a member function without a ref-qualifier}}
     //   since-cxx11-note@#cwg574-D-copy-assign {{previous declaration is here}}
     // since-cxx11-error@#cwg574-test-D {{friend declaration of 'operator=' does not match any declaration in 'cwg574::D'}}
     //   since-cxx11-note@#cwg574-D-copy-assign {{candidate function}}

--- a/clang/test/CXX/over/over.load/p2-0x.cpp
+++ b/clang/test/CXX/over/over.load/p2-0x.cpp
@@ -12,16 +12,16 @@ class Y {
   void h() const &; 
   void h() &&; 
   void i() &; // expected-note{{previous declaration}}
-  void i() const; // expected-error{{cannot overload a member function without a ref-qualifier with a member function with ref-qualifier '&'}}
+  void i() const; // expected-error{{cannot overload a member function with ref-qualifier '&' with a member function without a ref-qualifier}}
 
   template<typename T> void f(T*) &;
   template<typename T> void f(T*) &&;
 
   template<typename T> void g(T*) &; // expected-note{{previous declaration}}
-  template<typename T> void g(T*); // expected-error{{cannot overload a member function without a ref-qualifier with a member function with ref-qualifier '&'}}
+  template<typename T> void g(T*); // expected-error{{cannot overload a member function with ref-qualifier '&' with a member function without a ref-qualifier}}
 
   void k(); // expected-note{{previous declaration}}
-  void k() &&; // expected-error{{cannot overload a member function with ref-qualifier '&&' with a member function without a ref-qualifier}}
+  void k() &&; // expected-error{{cannot overload a member function without a ref-qualifier with a member function with ref-qualifier '&&'}}
 };
 
 struct GH76358 {

--- a/clang/test/SemaCXX/cxx1y-contextual-conversion-tweaks.cpp
+++ b/clang/test/SemaCXX/cxx1y-contextual-conversion-tweaks.cpp
@@ -86,7 +86,7 @@ namespace extended_examples {
   }
 }
 
-//expected-error@71 {{cannot overload a member function without a ref-qualifier with a member function with ref-qualifier '&&'}}
+//expected-error@71 {{cannot overload a member function with ref-qualifier '&&' with a member function without a ref-qualifier}}
 //expected-note@70 {{previous declaration is here}}
 //expected-error@82 {{statement requires expression of integer type ('A2' invalid)}}
 //expected-error@83 {{statement requires expression of integer type ('A3' invalid)}}


### PR DESCRIPTION
  When a member function is redeclared with a conflicting ref-qualifier,
  the diagnostic described the new declaration before the previous
  declaration, which read in the opposite order from the source. For
  example,

    struct C { void f(); };
    void C::f() & {}

  previously produced:

    cannot overload a member function with ref-qualifier '&' with a member
    function without a ref-qualifier

  Swap the two qualifier descriptions so the previous declaration is
  described first, matching source order:

    cannot overload a member function without a ref-qualifier with a member
    function with ref-qualifier '&'

  Fixes #219803