### PR TITLE
  [clang-format] Keep empty Java interface/record body on one line

### DIFF
--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -519,9 +519,14 @@ private:
       } else if (TheLine->Last->is(TT_CompoundRequirementLBrace)) {
         ShouldMerge = Style.AllowShortCompoundRequirementOnASingleLine;
       } else if (TheLine->Last->isOneOf(TT_ClassLBrace, TT_StructLBrace,
-                                        TT_UnionLBrace) ||
-                 (TheLine->Last->is(TT_RecordLBrace) && Style.isJava())) {
+                                        TT_UnionLBrace)) {
         return tryMergeRecord(I, E, Limit);
+      } else if (TheLine->Last->is(TT_RecordLBrace) && Style.isJava()) {
+        // Java `interface` and `record` have no dedicated `BraceWrapping.After`
+        // option and are not governed by `AllowShortRecordOnASingleLine`.
+        ShouldMerge = !Style.BraceWrapping.AfterClass ||
+                      (NextLine.First->is(tok::r_brace) &&
+                       !Style.BraceWrapping.SplitEmptyRecord);
       } else if (TheLine->InPPDirective ||
                  TheLine->First->isNoneOf(tok::kw_class, tok::kw_enum,
                                           tok::kw_struct, tok::kw_union)) {

--- a/clang/unittests/Format/FormatTestJava.cpp
+++ b/clang/unittests/Format/FormatTestJava.cpp
@@ -869,6 +869,13 @@ TEST_F(FormatTestJava, BreakAfterRecord) {
                "public record Foo(int i) {}", Style);
 }
 
+TEST_F(FormatTestJava, EmptyRecordBodyOnASingleLine) {
+  auto Style = getGoogleStyle(FormatStyle::LK_Java);
+  verifyFormat("public interface Marker {}", Style);
+  verifyFormat("public record Marker() {}", Style);
+  verifyFormat("public class Marker {}", Style);
+}
+
 } // namespace
 } // namespace test
 } // namespace format


### PR DESCRIPTION
  `AllowShortRecordOnASingleLine` (introduced for C++ records) made
  `LineJoiner::tryFitMultipleLinesInOne` route Java `TT_RecordLBrace`
  lines to `tryMergeRecord`, which only handles C++ class/struct/union
  records. Empty Java `interface` and `record` bodies were therefore no
  longer merged onto a single line, regressing the behavior that
  `BraceWrapping.SplitEmptyRecord: false` previously provided.

  Handle Java records separately and restore the pre-existing
  `SplitEmptyRecord`-based merge.

  Fixes #219711