### PR TITLE
[SelectionDAG] Fix CSE keys that disagree with SDNode::Profile

### DIFF
--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -757,6 +757,11 @@ public:
   /// corresponding to a MachineInstr opcode.
   bool isMachineOpcode() const { return NodeType < 0; }
 
+  /// As above, for an opcode not held by a node.
+  static bool isMachineOpcode(unsigned Opc) {
+    return static_cast<int32_t>(Opc) < 0;
+  }
+
   /// This may only be called if isMachineOpcode returns
   /// true. It returns the MachineInstr opcode value that the node's opcode
   /// corresponds to.
@@ -1639,6 +1644,8 @@ public:
     case ISD::ATOMIC_LOAD_FMIN:
     case ISD::ATOMIC_LOAD_FMAXIMUM:
     case ISD::ATOMIC_LOAD_FMINIMUM:
+    case ISD::ATOMIC_LOAD_FMAXIMUMNUM:
+    case ISD::ATOMIC_LOAD_FMINIMUMNUM:
     case ISD::ATOMIC_LOAD_UINC_WRAP:
     case ISD::ATOMIC_LOAD_UDEC_WRAP:
     case ISD::ATOMIC_LOAD_USUB_COND:
@@ -1727,6 +1734,8 @@ public:
            N->getOpcode() == ISD::ATOMIC_LOAD_FMIN ||
            N->getOpcode() == ISD::ATOMIC_LOAD_FMAXIMUM ||
            N->getOpcode() == ISD::ATOMIC_LOAD_FMINIMUM ||
+           N->getOpcode() == ISD::ATOMIC_LOAD_FMAXIMUMNUM ||
+           N->getOpcode() == ISD::ATOMIC_LOAD_FMINIMUMNUM ||
            N->getOpcode() == ISD::ATOMIC_LOAD_UINC_WRAP ||
            N->getOpcode() == ISD::ATOMIC_LOAD_UDEC_WRAP ||
            N->getOpcode() == ISD::ATOMIC_LOAD_USUB_COND ||

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -787,8 +787,16 @@ static void AddNodeIDNode(FoldingSetNodeID &ID, unsigned OpC,
 }
 
 /// If this is an SDNode with special info, add this info to the NodeID data.
-static void AddNodeIDCustom(FoldingSetNodeID &ID, const SDNode *N) {
-  switch (N->getOpcode()) {
+/// MorphNodeTo passes the opcode \p N is becoming, so \p Opc may differ from
+/// N->getOpcode() and a case may only cast to a class \p N already is.
+static void AddNodeIDCustom(FoldingSetNodeID &ID, const SDNode *N,
+                            unsigned Opc) {
+  // Machine nodes are uniqued by opcode, value types and operands alone, as in
+  // getMachineNode; MorphNodeTo's clearMemRefs overwrites the fields below.
+  if (SDNode::isMachineOpcode(Opc))
+    return;
+
+  switch (Opc) {
   case ISD::TargetExternalSymbol:
   case ISD::ExternalSymbol:
   case ISD::MCSymbol:
@@ -817,6 +825,13 @@ static void AddNodeIDCustom(FoldingSetNodeID &ID, const SDNode *N) {
   }
   case ISD::BasicBlock:
     ID.AddPointer(cast<BasicBlockSDNode>(N)->getBasicBlock());
+    break;
+  case ISD::EH_LABEL:
+  case ISD::ANNOTATION_LABEL:
+    ID.AddPointer(cast<LabelSDNode>(N)->getLabel());
+    break;
+  case ISD::DEACTIVATION_SYMBOL:
+    ID.AddPointer(cast<DeactivationSymbolSDNode>(N)->getGlobal());
     break;
   case ISD::Register:
     ID.AddInteger(cast<RegisterSDNode>(N)->getReg().id());
@@ -954,35 +969,15 @@ static void AddNodeIDCustom(FoldingSetNodeID &ID, const SDNode *N) {
     ID.AddInteger(MG->getMemOperand()->getFlags());
     break;
   }
-  case ISD::MSCATTER: {
-    const MaskedScatterSDNode *MS = cast<MaskedScatterSDNode>(N);
-    ID.AddInteger(MS->getMemoryVT().getRawBits());
-    ID.AddInteger(MS->getRawSubclassData());
-    ID.AddInteger(MS->getPointerInfo().getAddrSpace());
-    ID.AddInteger(MS->getMemOperand()->getFlags());
-    break;
-  }
-  case ISD::ATOMIC_CMP_SWAP:
-  case ISD::ATOMIC_CMP_SWAP_WITH_SUCCESS:
-  case ISD::ATOMIC_SWAP:
-  case ISD::ATOMIC_LOAD_ADD:
-  case ISD::ATOMIC_LOAD_SUB:
-  case ISD::ATOMIC_LOAD_AND:
-  case ISD::ATOMIC_LOAD_CLR:
-  case ISD::ATOMIC_LOAD_OR:
-  case ISD::ATOMIC_LOAD_XOR:
-  case ISD::ATOMIC_LOAD_NAND:
-  case ISD::ATOMIC_LOAD_MIN:
-  case ISD::ATOMIC_LOAD_MAX:
-  case ISD::ATOMIC_LOAD_UMIN:
-  case ISD::ATOMIC_LOAD_UMAX:
-  case ISD::ATOMIC_LOAD:
-  case ISD::ATOMIC_STORE: {
-    const AtomicSDNode *AT = cast<AtomicSDNode>(N);
-    ID.AddInteger(AT->getMemoryVT().getRawBits());
-    ID.AddInteger(AT->getRawSubclassData());
-    ID.AddInteger(AT->getPointerInfo().getAddrSpace());
-    ID.AddInteger(AT->getMemOperand()->getFlags());
+  case ISD::MSCATTER:
+  case ISD::GET_FPENV_MEM:
+  case ISD::SET_FPENV_MEM:
+  case ISD::EXPERIMENTAL_VECTOR_HISTOGRAM: {
+    const MemSDNode *M = cast<MemSDNode>(N);
+    ID.AddInteger(M->getMemoryVT().getRawBits());
+    ID.AddInteger(M->getRawSubclassData());
+    ID.AddInteger(M->getPointerInfo().getAddrSpace());
+    ID.AddInteger(M->getMemOperand()->getFlags());
     break;
   }
   case ISD::VECTOR_SHUFFLE: {
@@ -1016,7 +1011,14 @@ static void AddNodeIDCustom(FoldingSetNodeID &ID, const SDNode *N) {
   case ISD::MDNODE_SDNODE:
     ID.AddPointer(cast<MDNodeSDNode>(N)->getMD());
     break;
-  } // end switch (N->getOpcode())
+  } // end switch (Opc)
+
+  if (auto *AT = dyn_cast<AtomicSDNode>(N)) {
+    ID.AddInteger(AT->getMemoryVT().getRawBits());
+    ID.AddInteger(AT->getRawSubclassData());
+    ID.AddInteger(AT->getPointerInfo().getAddrSpace());
+    ID.AddInteger(AT->getMemOperand()->getFlags());
+  }
 
   // MemIntrinsic nodes could also have subclass data, address spaces, and flags
   // to check.
@@ -1040,7 +1042,7 @@ static void AddNodeIDNode(FoldingSetNodeID &ID, const SDNode *N) {
   AddNodeIDOperands(ID, N->ops());
 
   // Handle SDNode leafs with special info.
-  AddNodeIDCustom(ID, N);
+  AddNodeIDCustom(ID, N, N->getOpcode());
 }
 
 //===----------------------------------------------------------------------===//
@@ -1384,7 +1386,7 @@ SDNode *SelectionDAG::FindModifiedNodeSlot(SDNode *N, SDValue Op,
   SDValue Ops[] = { Op };
   FoldingSetNodeID ID;
   AddNodeIDNode(ID, N->getOpcode(), N->getVTList(), Ops);
-  AddNodeIDCustom(ID, N);
+  AddNodeIDCustom(ID, N, N->getOpcode());
   SDNode *Node = lookupNode(ID, SDLoc(N), InsertToken);
   if (Node)
     Node->intersectFlagsWith(N->getFlags());
@@ -1403,7 +1405,7 @@ SDNode *SelectionDAG::FindModifiedNodeSlot(SDNode *N, SDValue Op1, SDValue Op2,
   SDValue Ops[] = { Op1, Op2 };
   FoldingSetNodeID ID;
   AddNodeIDNode(ID, N->getOpcode(), N->getVTList(), Ops);
-  AddNodeIDCustom(ID, N);
+  AddNodeIDCustom(ID, N, N->getOpcode());
   SDNode *Node = lookupNode(ID, SDLoc(N), InsertToken);
   if (Node)
     Node->intersectFlagsWith(N->getFlags());
@@ -1421,7 +1423,7 @@ SDNode *SelectionDAG::FindModifiedNodeSlot(SDNode *N, ArrayRef<SDValue> Ops,
 
   FoldingSetNodeID ID;
   AddNodeIDNode(ID, N->getOpcode(), N->getVTList(), Ops);
-  AddNodeIDCustom(ID, N);
+  AddNodeIDCustom(ID, N, N->getOpcode());
   SDNode *Node = lookupNode(ID, SDLoc(N), InsertToken);
   if (Node)
     Node->intersectFlagsWith(N->getFlags());
@@ -10650,7 +10652,6 @@ SDValue SelectionDAG::getLifetimeNode(bool IsStart, const SDLoc &dl,
 
   FoldingSetNodeID ID;
   AddNodeIDNode(ID, Opcode, VTs, Ops);
-  ID.AddInteger(FrameIndex);
   FoldingSetInsertToken InsertToken;
   if (SDNode *E = lookupNode(ID, dl, InsertToken))
     return SDValue(E, 0);
@@ -10675,6 +10676,7 @@ SDValue SelectionDAG::getPseudoProbeNode(const SDLoc &Dl, SDValue Chain,
   AddNodeIDNode(ID, Opcode, VTs, Ops);
   ID.AddInteger(Guid);
   ID.AddInteger(Index);
+  ID.AddInteger(Attr);
   FoldingSetInsertToken InsertToken;
   if (SDNode *E = lookupNode(ID, Dl, InsertToken))
     return SDValue(E, 0);
@@ -11274,7 +11276,7 @@ SDValue SelectionDAG::getStridedLoadVP(
                          : getVTList(VT, MVT::Other);
   FoldingSetNodeID ID;
   AddNodeIDNode(ID, ISD::EXPERIMENTAL_VP_STRIDED_LOAD, VTs, Ops);
-  ID.AddInteger(VT.getRawBits());
+  ID.AddInteger(MemVT.getRawBits());
   ID.AddInteger(getSyntheticNodeSubclassData<VPStridedLoadSDNode>(
       DL.getIROrder(), VTs, AM, ExtType, IsExpanding, MemVT, MMO));
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
@@ -12553,6 +12555,7 @@ SDNode *SelectionDAG::MorphNodeTo(SDNode *N, unsigned Opc,
   if (VTs.VTs[VTs.NumVTs-1] != MVT::Glue) {
     FoldingSetNodeID ID;
     AddNodeIDNode(ID, Opc, VTs, Ops);
+    AddNodeIDCustom(ID, N, Opc);
     if (SDNode *ON = lookupNode(ID, SDLoc(N), InsertToken))
       return UpdateSDLocOnMergeSDNode(ON, SDLoc(N));
   }

--- a/llvm/test/CodeGen/PowerPC/merge_stores_dereferenceable.ll
+++ b/llvm/test/CodeGen/PowerPC/merge_stores_dereferenceable.ll
@@ -8,9 +8,8 @@ define <2 x i64> @func(ptr %pdst) {
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    addi 4, 1, -32
 ; CHECK-NEXT:    lxvd2x 0, 0, 4
-; CHECK-NEXT:    xxswapd 34, 0
-; CHECK-NEXT:    lxvd2x 0, 0, 4
 ; CHECK-NEXT:    stxvd2x 0, 0, 3
+; CHECK-NEXT:    xxswapd 34, 0
 ; CHECK-NEXT:    blr
 entry:
   %a = alloca [4 x i64], align 8

--- a/llvm/unittests/CodeGen/SelectionDAGCSETest.cpp
+++ b/llvm/unittests/CodeGen/SelectionDAGCSETest.cpp
@@ -44,14 +44,11 @@ TEST_F(SelectionDAGCSETest, AtomicRMW) {
                     Val, MMO)
         .getNode();
   };
-  // FIXME: AddNodeIDCustom's atomic opcode list is a second copy of
-  // AtomicSDNode::classof's, stale since ATOMIC_LOAD_FADD.
-  EXPECT_NE(Atomic(), Atomic());
+  EXPECT_EQ(Atomic(), Atomic());
 }
 
 TEST_F(SelectionDAGCSETest, DeactivationSymbol) {
-  // FIXME: AddNodeIDCustom has no DEACTIVATION_SYMBOL case.
-  EXPECT_NE(DAG->getDeactivationSymbol(G).getNode(),
+  EXPECT_EQ(DAG->getDeactivationSymbol(G).getNode(),
             DAG->getDeactivationSymbol(G).getNode());
   EXPECT_NE(DAG->getDeactivationSymbol(G).getNode(),
             DAG->getDeactivationSymbol(AliasedG).getNode());
@@ -60,8 +57,7 @@ TEST_F(SelectionDAGCSETest, DeactivationSymbol) {
 TEST_F(SelectionDAGCSETest, EHLabel) {
   MCSymbol *Sym = MF->getContext().createTempSymbol();
   MCSymbol *Other = MF->getContext().createTempSymbol();
-  // FIXME: AddNodeIDCustom has no EH_LABEL case.
-  EXPECT_NE(DAG->getEHLabel(Loc, getChain(), Sym).getNode(),
+  EXPECT_EQ(DAG->getEHLabel(Loc, getChain(), Sym).getNode(),
             DAG->getEHLabel(Loc, getChain(), Sym).getNode());
   EXPECT_NE(DAG->getEHLabel(Loc, getChain(), Sym).getNode(),
             DAG->getEHLabel(Loc, getChain(), Other).getNode());
@@ -79,26 +75,22 @@ TEST_F(SelectionDAGCSETest, ExtStridedLoadVP) {
                               Stride, Mask, EVL, MVT::v2i32, MMO)
         .getNode();
   };
-  // FIXME: getStridedLoadVP keys on the result type where the case uses the
-  // memory type, so only an extending load misses.
-  EXPECT_NE(Load(), Load());
+  EXPECT_EQ(Load(), Load());
 }
 
 TEST_F(SelectionDAGCSETest, FPEnvMem) {
   SDValue Ptr = DAG->CreateStackTemporary(MVT::i32);
   MachineMemOperand *MMO = getMMO();
-  // FIXME: AddNodeIDCustom has no GET_FPENV_MEM or SET_FPENV_MEM case.
-  EXPECT_NE(DAG->getGetFPEnv(getChain(), Loc, Ptr, MVT::i32, MMO).getNode(),
+  EXPECT_EQ(DAG->getGetFPEnv(getChain(), Loc, Ptr, MVT::i32, MMO).getNode(),
             DAG->getGetFPEnv(getChain(), Loc, Ptr, MVT::i32, MMO).getNode());
-  EXPECT_NE(DAG->getSetFPEnv(getChain(), Loc, Ptr, MVT::i32, MMO).getNode(),
+  EXPECT_EQ(DAG->getSetFPEnv(getChain(), Loc, Ptr, MVT::i32, MMO).getNode(),
             DAG->getSetFPEnv(getChain(), Loc, Ptr, MVT::i32, MMO).getNode());
 }
 
 TEST_F(SelectionDAGCSETest, LifetimeNode) {
   SDValue FIPtr = DAG->CreateStackTemporary(MVT::i32);
   int FI = cast<FrameIndexSDNode>(FIPtr.getNode())->getIndex();
-  // FIXME: getLifetimeNode keys on a frame index operand 1 already carries.
-  EXPECT_NE(DAG->getLifetimeNode(true, Loc, getChain(), FI).getNode(),
+  EXPECT_EQ(DAG->getLifetimeNode(true, Loc, getChain(), FI).getNode(),
             DAG->getLifetimeNode(true, Loc, getChain(), FI).getNode());
 }
 
@@ -111,14 +103,11 @@ TEST_F(SelectionDAGCSETest, MorphMemIntrinsicToMachineNode) {
                   .getNode();
   unsigned Opc = TargetOpcode::COPY;
   ASSERT_EQ(DAG->MorphNodeTo(N, ~Opc, VTs, Ops), N);
-  // FIXME: MorphNodeTo's lookup omits AddNodeIDCustom, so the morphed node is
-  // stored under a key getMachineNode does not build.
-  EXPECT_NE(DAG->getMachineNode(Opc, Loc, VTs, Ops), N);
+  EXPECT_EQ(DAG->getMachineNode(Opc, Loc, VTs, Ops), N);
 }
 
 TEST_F(SelectionDAGCSETest, PseudoProbeNode) {
-  // FIXME: getPseudoProbeNode drops the attributes its case profiles.
-  EXPECT_NE(DAG->getPseudoProbeNode(Loc, getChain(), 1234, 5, 7).getNode(),
+  EXPECT_EQ(DAG->getPseudoProbeNode(Loc, getChain(), 1234, 5, 7).getNode(),
             DAG->getPseudoProbeNode(Loc, getChain(), 1234, 5, 7).getNode());
   EXPECT_NE(DAG->getPseudoProbeNode(Loc, getChain(), 1234, 5, 7).getNode(),
             DAG->getPseudoProbeNode(Loc, getChain(), 1234, 5, 8).getNode());


### PR DESCRIPTION
A getNode helper builds its lookup ID by hand; matching it later
rebuilds one from the node with AddNodeIDCustom.  Where the two disagree
the compare always fails and the node never CSEs.  Fix whichever side is
wrong: the labels, DEACTIVATION_SYMBOL, GET/SET_FPENV_MEM and
EXPERIMENTAL_VECTOR_HISTOGRAM have no case; getLifetimeNode keys on a
frame index operand 1 already carries, getStridedLoadVP on the result
type instead of the memory type, and getPseudoProbeNode drops the
attributes its case profiles.

Ask AtomicSDNode instead of an opcode list stale since ATOMIC_LOAD_FADD,
and add the two opcodes its own classof was missing.

AddNodeIDCustom now takes the opcode to profile under, so MorphNodeTo's
pre-morph lookup keys on what the morph produces.  Machine opcodes
profile nothing: the morph overlays MachineSDNode's memory references on
the fields the MemSDNode checks read.

A duplicate load now CSEs in merge_stores_dereferenceable.ll.

Aided by Opus 5