### PR TITLE
[CodeGen] Unsized token-like target extension types in GlobalISel

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -971,7 +971,9 @@ ArrayRef<Register> IRTranslatorImpl::getOrCreateVRegs(const Value &Val) {
   auto *VRegs = VMap.getVRegs(Val);
   auto *Offsets = VMap.getOffsets(Val);
 
-  if (!Val.getType()->isTokenTy())
+  // Unsized token-like target extension types are represented by a zero-sized
+  // vreg like `token`; sized token-like types follow the normal path.
+  if (!Val.getType()->isTokenLikeTy())
     assert(Val.getType()->isSized() &&
            "Don't know how to create an empty vreg");
 

--- a/llvm/lib/CodeGen/LowLevelTypeUtils.cpp
+++ b/llvm/lib/CodeGen/LowLevelTypeUtils.cpp
@@ -75,7 +75,10 @@ LLT llvm::getLLTForType(Type &Ty, const DataLayout &DL) {
     return LLT::scalar(SizeInBits);
   }
 
-  if (Ty.isTokenTy())
+  // Only unsized token-like target extension types have no machine
+  // representation. Sized target extension types must not lose layout
+  // information by being represented as `token`.
+  if (!Ty.isSized() && Ty.isTokenLikeTy())
     return LLT::token();
 
   return LLT();

--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -1019,6 +1019,12 @@ Expected<TargetExtType *> TargetExtType::checkParams(TargetExtType *TTy) {
                              "and at most one integer parameter");
   }
 
+  if (TTy->Name == "llvm.test.tokenlike" &&
+      (TTy->getNumTypeParameters() > 1 || TTy->getNumIntParameters() != 0))
+    return createStringError("target extension type llvm.test.tokenlike "
+                             "should have at most one type parameter and no "
+                             "integer parameters");
+
   return TTy;
 }
 
@@ -1125,6 +1131,11 @@ static TargetTypeInfo getTargetTypeInfo(const TargetExtType *Ty) {
     return TargetTypeInfo(Type::getInt32Ty(C), TargetExtType::CanBeLocal,
                           TargetExtType::CanBeVectorElement);
   }
+  if (Name == "llvm.test.tokenlike")
+    return TargetTypeInfo(Ty->getNumTypeParameters() == 0
+                              ? Type::getVoidTy(C)
+                              : Ty->getTypeParameter(0),
+                          TargetExtType::IsTokenLike);
 
   // Opaque types in the WebAssembly name space.
   if (Name == "wasm.funcref" || Name == "wasm.externref")

--- a/llvm/test/CodeGen/Generic/GlobalISel/irtranslator-token-like-types.ll
+++ b/llvm/test/CodeGen/Generic/GlobalISel/irtranslator-token-like-types.ll
@@ -1,0 +1,23 @@
+; REQUIRES: x86-registered-target
+;
+; RUN: llc -mtriple=x86_64-linux-gnu -O0 -global-isel \
+; RUN:   -stop-after=irtranslator -verify-machineinstrs %s -o - | FileCheck %s
+
+declare target("llvm.test.tokenlike", i64) @llvm.ssa.copy.tllvm.test.tokenlike_i64t(target("llvm.test.tokenlike", i64) returned)
+declare target("llvm.test.tokenlike") @llvm.ssa.copy.tllvm.test.tokenliket(target("llvm.test.tokenlike") returned)
+
+define void @sized_token_like() {
+  ; CHECK-LABEL: name: sized_token_like
+  ; CHECK: [[POISON:%[0-9]+]]:_(s64) = G_IMPLICIT_DEF
+  ; CHECK-NEXT: %{{[0-9]+}}:_(s64) = G_INTRINSIC intrinsic(@llvm.ssa.copy), [[POISON]](s64)
+  %handle = call target("llvm.test.tokenlike", i64) @llvm.ssa.copy.tllvm.test.tokenlike_i64t(target("llvm.test.tokenlike", i64) poison)
+  ret void
+}
+
+define void @unsized_token_like() {
+  ; CHECK-LABEL: name: unsized_token_like
+  ; CHECK: [[POISON:%[0-9]+]]:_(s0) = G_IMPLICIT_DEF
+  ; CHECK-NEXT: %{{[0-9]+}}:_(s0) = G_INTRINSIC intrinsic(@llvm.ssa.copy), [[POISON]](s0)
+  %mark = call target("llvm.test.tokenlike") @llvm.ssa.copy.tllvm.test.tokenliket(target("llvm.test.tokenlike") poison)
+  ret void
+}


### PR DESCRIPTION
An unsized target-type with IsTokenLike property should be lowered to LLT::token() since it has no machine representation. Sized token-like types continue to be lowered to sized non-token types.

This may be seen as a lossy translation, but note that even the semantics of pure tokens is not enforced in MIR. It is possible to create a PHI or Select in MIR with a token type. So far, it seems that the GlobalISel flow merely depends on transforms being well-behaved enough to not produce such MIR.

Added a type `llvm.test.tokenlike` to be able to test the lowering of both sized and unsized versions.

Assisted-By: AI Code Assistant