### PR TITLE
[mlir][vector] Reject a 0-d operand in the outerproduct parser

### DIFF
--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -4379,6 +4379,15 @@ ParseResult OuterProductOp::parse(OpAsmParser &parser, OperationState &result) {
   if (!vLHS)
     return parser.emitError(parser.getNameLoc(),
                             "expected vector type for operand #1");
+  // The result type is built below from dimension 0 of the operands, which a
+  // 0-d vector does not have. Only that case has to be caught here; a higher
+  // rank still reaches the verifier, which rejects it with the same wording.
+  if (vLHS.getRank() == 0)
+    return parser.emitError(parser.getNameLoc(),
+                            "expected 1-d vector for operand #1");
+  if (vRHS && vRHS.getRank() == 0)
+    return parser.emitError(parser.getNameLoc(),
+                            "expected 1-d vector for operand #2");
 
   VectorType resType;
   if (vRHS) {

--- a/mlir/test/Dialect/Vector/invalid.mlir
+++ b/mlir/test/Dialect/Vector/invalid.mlir
@@ -251,6 +251,20 @@ func.func @outerproduct_non_vector_operand(%arg0: f32) {
 
 // -----
 
+func.func @outerproduct_zero_rank_lhs(%arg0: vector<f32>, %arg1: vector<4xf32>) {
+  // expected-error@+1 {{expected 1-d vector for operand #1}}
+  %1 = vector.outerproduct %arg0, %arg1 : vector<f32>, vector<4xf32>
+}
+
+// -----
+
+func.func @outerproduct_zero_rank_rhs(%arg0: vector<4xf32>, %arg1: vector<f32>) {
+  // expected-error@+1 {{expected 1-d vector for operand #2}}
+  %1 = vector.outerproduct %arg0, %arg1 : vector<4xf32>, vector<f32>
+}
+
+// -----
+
 func.func @outerproduct_invalid_kind_attr(%arg0 : vector<[4]xf32>, %arg1 : vector<[8]xf32>) {
   // expected-error@+1 {{expected 'kind' attribute of type CombiningKind (e.g. 'vector.kind<add>')}}
   %0 = vector.outerproduct %arg0, %arg1 {kind = "invalid"} : vector<[4]xf32>, vector<[8]xf32>


### PR DESCRIPTION
`vector.outerproduct` builds its result type from dimension 0 of its operands, which a 0-d vector does not have, so `mlir-opt` aborts while parsing, before the verifier gets a chance to report anything:

```mlir
%0 = vector.outerproduct %a, %b : vector<f32>, vector<4xf32>
```

The parser now emits the same diagnostic the verifier already gives for that operand, `expected 1-d vector for operand #1`. Only rank 0 is caught here, rank 2 and above still reach the verifier unchanged.

This PR started out touching three parsers and was narrowed to `outerproduct` at review request. The `transfer_read`/`transfer_write` and `contract` parsers follow as separate PRs.
