### PR TITLE
[LLD][COFF] Apply /pdbsourcepath to the linker's own path

### DIFF
--- a/lld/COFF/PDB.cpp
+++ b/lld/COFF/PDB.cpp
@@ -1437,6 +1437,15 @@ void PDBLinker::addCommonLinkerModuleSymbols(
   ebs.Fields.push_back(cwd);
   ebs.Fields.push_back("exe");
   SmallString<64> exe = ctx.config.argv[0];
+  if (!ctx.config.pdbSourcePath.empty()) {
+    SmallString<64> currentPath;
+    if (!sys::fs::current_path(currentPath)) {
+      sys::path::native(exe);
+      sys::path::native(currentPath);
+      sys::path::remove_dots(exe, /*remove_dot_dot=*/true);
+      sys::path::replace_path_prefix(exe, currentPath, ".");
+    }
+  }
   pdbMakeAbsolute(exe);
   ebs.Fields.push_back(exe);
   ebs.Fields.push_back("pdb");

--- a/lld/test/COFF/pdb-linker-exe-path.test
+++ b/lld/test/COFF/pdb-linker-exe-path.test
@@ -1,0 +1,26 @@
+Check that /pdbsourcepath reaches the linker's own path in the linker module's
+env block, so a build that spawns lld-link by absolute path from inside the
+directory it is normalizing away does not record where it ran.
+
+RUN: rm -rf %t
+RUN: mkdir %t
+RUN: cp lld-link %t/lld-link
+RUN: yaml2obj %p/Inputs/pdb1.yaml -o %t/pdb1.obj
+RUN: yaml2obj %p/Inputs/pdb2.yaml -o %t/pdb2.obj
+RUN: cd %t
+
+The linker is named by an absolute path, the way a build system spawns it.
+
+RUN: %t/lld-link /debug /pdbsourcepath:. /entry:main /nodefaultlib \
+RUN:   /out:out.exe /pdb:out.pdb pdb1.obj pdb2.obj
+RUN: llvm-pdbutil dump -symbols out.pdb | FileCheck %s
+
+RUN: rm -f %t/lld-link
+
+CHECK:      S_ENVBLOCK
+CHECK-NEXT: - cwd
+CHECK-NEXT: - .
+CHECK-NEXT: - exe
+CHECK-NEXT: - lld-link
+CHECK-NEXT: - pdb
+CHECK-NEXT: - out.pdb


### PR DESCRIPTION
### Problem

It is not possible to make `lld-link.exe` reproducible when the parent build system command is using an absolute path as `argv[0]`. (e.g Bazel)

### Description

`/pdbsourcepath:<my-path>` sets the root that relative PDB paths are expressed against.

The _cwd_ entry of the linker module's env block honours it, reporting `<my-path>` instead of the current directory absolute path used by the linker execution. Before this commit the same idea is not applied to the _exe_ entry when `argv[0]` is an absolute path, even when the `argy[0]` path is inside the current directory.

With this commit, the `/pdbsourcepath` applies to absolute `argv[0]` too. When `argv[0]` is absolute but sits inside the current directory, the current directory prefix is replaced by the `/pdbsourcepath` value, so exe is expressed like the rest of the PDB.

Some build systems spawn the linker by absolute path. Without this, exe keeps that directory, and under `/Brepro` the same inputs linked from two directories produce two different binaries.

### Example

Let's say without `/pdbsourcepath` the env block looks like this:
```
cwd  D:/project/build/
exe  D:/project/build/bin/lld-link.exe
```

Before this commit, specifying `/pdbsourepath:.` will give the following block:
```
cwd  .
exe  D:/project/build/bin/lld-link.exe
```

With this commit you would get:
```
cwd  .
exe  ./bin/lld-link.exe
```