### PR TITLE
[clang][mingw] Don't emit `-lssp_nonshared -lssp`

### DIFF
--- a/clang/lib/Driver/ToolChains/MinGW.cpp
+++ b/clang/lib/Driver/ToolChains/MinGW.cpp
@@ -298,13 +298,6 @@ void tools::MinGW::Linker::ConstructJob(Compilation &C, const JobAction &JA,
       if (Args.hasArg(options::OPT_static))
         CmdArgs.push_back("--start-group");
 
-      if (Args.hasArg(options::OPT_fstack_protector) ||
-          Args.hasArg(options::OPT_fstack_protector_strong) ||
-          Args.hasArg(options::OPT_fstack_protector_all)) {
-        CmdArgs.push_back("-lssp_nonshared");
-        CmdArgs.push_back("-lssp");
-      }
-
       if (Args.hasFlag(options::OPT_fopenmp, options::OPT_fopenmp_EQ,
                        options::OPT_fno_openmp, false)) {
         switch (TC.getDriver().getOpenMPRuntime(Args)) {


### PR DESCRIPTION
MinGW-w64 have integrated libssp functionality into `libmingwex.a` since [v11.0.0](https://www.mingw-w64.org/changelog/#v1100-2023-04-28), and doesn't provide seperate `libssp.a` or `libssp_nonshared.a`.