### PR TITLE
[ADT] Allow SmallVector move construction without move assignment

### DIFF
--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -616,6 +616,20 @@ protected:
     RHS.resetToSmall();
   }
 
+  void moveConstructFrom(SmallVectorImpl &&RHS) {
+    assert(this->empty() && "move construction requires an empty vector");
+    if (!RHS.isSmall()) {
+      assignRemote(std::move(RHS));
+      return;
+    }
+
+    // Construct inline elements directly instead of requiring T to be move
+    // assignable through the general move-assignment implementation.
+    append(std::make_move_iterator(RHS.begin()),
+           std::make_move_iterator(RHS.end()));
+    RHS.clear();
+  }
+
   ~SmallVectorImpl() {
     // Subclass has already destructed this vector's elements.
     // If this wasn't grown from the inline copy, deallocate the old space.
@@ -1283,12 +1297,12 @@ public:
 
   SmallVector(SmallVector &&RHS) : SmallVectorImpl<T>(N) {
     if (!RHS.empty())
-      SmallVectorImpl<T>::operator=(::std::move(RHS));
+      this->moveConstructFrom(::std::move(RHS));
   }
 
   SmallVector(SmallVectorImpl<T> &&RHS) : SmallVectorImpl<T>(N) {
     if (!RHS.empty())
-      SmallVectorImpl<T>::operator=(::std::move(RHS));
+      this->moveConstructFrom(::std::move(RHS));
   }
 
   SmallVector &operator=(SmallVector &&RHS) {

--- a/llvm/unittests/ADT/SmallVectorTest.cpp
+++ b/llvm/unittests/ADT/SmallVectorTest.cpp
@@ -167,6 +167,22 @@ private:
   NonCopyable &operator=(const NonCopyable &) = delete;
 };
 
+struct MoveConstructOnly {
+  explicit MoveConstructOnly(int Value) : Value(Value) {}
+  MoveConstructOnly(MoveConstructOnly &&RHS) : Value(RHS.Value) {
+    RHS.Value = -1;
+  }
+
+  MoveConstructOnly(const MoveConstructOnly &) = delete;
+  MoveConstructOnly &operator=(const MoveConstructOnly &) = delete;
+  MoveConstructOnly &operator=(MoveConstructOnly &&) = delete;
+
+  int Value;
+};
+
+static_assert(std::is_move_constructible_v<MoveConstructOnly>);
+static_assert(!std::is_move_assignable_v<MoveConstructOnly>);
+
 LLVM_ATTRIBUTE_USED void CompileTest() {
   SmallVector<NonCopyable, 0> V;
   V.resize(42);
@@ -175,6 +191,50 @@ LLVM_ATTRIBUTE_USED void CompileTest() {
 TEST(SmallVectorTest, ConstructNonCopyableTest) {
   SmallVector<NonCopyable, 0> V(42);
   EXPECT_EQ(V.size(), (size_t)42);
+}
+
+TEST(SmallVectorTest, MoveConstructNonMoveAssignableInlineElements) {
+  SmallVector<MoveConstructOnly, 2> From;
+  From.emplace_back(1);
+  From.emplace_back(2);
+  const MoveConstructOnly *FromData = From.data();
+
+  SmallVector<MoveConstructOnly, 2> To(std::move(From));
+
+  EXPECT_TRUE(From.empty());
+  ASSERT_EQ(2u, To.size());
+  EXPECT_NE(FromData, To.data());
+  EXPECT_EQ(1, To[0].Value);
+  EXPECT_EQ(2, To[1].Value);
+}
+
+TEST(SmallVectorTest, MoveConstructNonMoveAssignableAllocatedElements) {
+  SmallVector<MoveConstructOnly, 1> From;
+  From.emplace_back(1);
+  From.emplace_back(2);
+  const MoveConstructOnly *FromData = From.data();
+
+  SmallVector<MoveConstructOnly, 1> To(std::move(From));
+
+  EXPECT_TRUE(From.empty());
+  ASSERT_EQ(2u, To.size());
+  EXPECT_EQ(FromData, To.data());
+  EXPECT_EQ(1, To[0].Value);
+  EXPECT_EQ(2, To[1].Value);
+}
+
+TEST(SmallVectorTest, MoveConstructNonMoveAssignableFromSmallVectorImpl) {
+  SmallVector<MoveConstructOnly, 2> From;
+  From.emplace_back(1);
+  From.emplace_back(2);
+
+  SmallVector<MoveConstructOnly, 0> To(
+      std::move(static_cast<SmallVectorImpl<MoveConstructOnly> &>(From)));
+
+  EXPECT_TRUE(From.empty());
+  ASSERT_EQ(2u, To.size());
+  EXPECT_EQ(1, To[0].Value);
+  EXPECT_EQ(2, To[1].Value);
 }
 
 // Assert that v contains the specified values, in order.


### PR DESCRIPTION
Move-construct inline elements directly instead of using move assignment.

This avoids requiring element types to be move-assignable, only move-constructible.
Such types at the moment forces us to fall back to std::vector, for no good reason other
than an implementation quirks which is fixed here.

Assisted-by: Codex