### PR TITLE
[SCEV] Apply loop guards to Distance + 1 in howFarToZero.

### DIFF
--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -10798,9 +10798,13 @@ ScalarEvolution::ExitLimit ScalarEvolution::howFarToZero(const SCEV *V,
     const SCEV *DistancePlusOne = getAddExpr(Distance, One);
     if (isLoopEntryGuardedByCond(L, ICmpInst::ICMP_NE, DistancePlusOne, Zero)) {
       // If Distance + 1 doesn't overflow, we can compute the maximum distance
-      // as "unsigned_max(Distance + 1) - 1".
-      ConstantRange CR = getUnsignedRange(DistancePlusOne);
-      MaxBECount = APIntOps::umin(MaxBECount, CR.getUnsignedMax() - 1);
+      // as "unsigned_max(Distance + 1) - 1". Also apply the loop guards to
+      // Distance + 1; the range of Distance itself may be a wrapped set even
+      // when the guards bound Distance + 1 tightly.
+      APInt Max = APIntOps::umin(
+          getUnsignedRangeMax(applyLoopGuards(DistancePlusOne, Guards)),
+          getUnsignedRangeMax(DistancePlusOne));
+      MaxBECount = APIntOps::umin(MaxBECount, Max - 1);
     }
     return ExitLimit(Distance, getConstant(MaxBECount), Distance, false,
                      Predicates);

--- a/llvm/test/Analysis/ScalarEvolution/max-backedge-taken-count-guard-info.ll
+++ b/llvm/test/Analysis/ScalarEvolution/max-backedge-taken-count-guard-info.ll
@@ -1864,7 +1864,7 @@ define void @guarded_distance_plus_one(ptr %dst, i64 %n, i64 %start) {
 ; CHECK-NEXT:    --> {(1 + %start),+,1}<nuw><%loop> U: full-set S: full-set Exits: %n LoopDispositions: { %loop: Computable }
 ; CHECK-NEXT:  Determining loop execution counts for: @guarded_distance_plus_one
 ; CHECK-NEXT:  Loop %loop: backedge-taken count is (-1 + (-1 * %start) + %n)
-; CHECK-NEXT:  Loop %loop: constant max backedge-taken count is i64 -2
+; CHECK-NEXT:  Loop %loop: constant max backedge-taken count is i64 6
 ; CHECK-NEXT:  Loop %loop: symbolic max backedge-taken count is (-1 + (-1 * %start) + %n)
 ; CHECK-NEXT:  Loop %loop: Trip multiple is 1
 ;

--- a/llvm/test/Analysis/ScalarEvolution/max-backedge-taken-count-guard-info.ll
+++ b/llvm/test/Analysis/ScalarEvolution/max-backedge-taken-count-guard-info.ll
@@ -1848,3 +1848,197 @@ loop:
 exit:
   ret void
 }
+
+; The backedge-taken count is (%n - %start - 1), whose guarded range wraps.
+; The bound has to be computed via (%n - %start), which the assume limits to 7.
+define void @guarded_distance_plus_one(ptr %dst, i64 %n, i64 %start) {
+; CHECK-LABEL: 'guarded_distance_plus_one'
+; CHECK-NEXT:  Classifying expressions for: @guarded_distance_plus_one
+; CHECK-NEXT:    %sub = sub i64 %n, %start
+; CHECK-NEXT:    --> ((-1 * %start) + %n) U: full-set S: full-set
+; CHECK-NEXT:    %iv = phi i64 [ %start, %entry ], [ %iv.next, %loop ]
+; CHECK-NEXT:    --> {%start,+,1}<nuw><%loop> U: full-set S: full-set Exits: (-1 + %n) LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:    %gep = getelementptr i8, ptr %dst, i64 %iv
+; CHECK-NEXT:    --> {(%start + %dst),+,1}<nw><%loop> U: full-set S: full-set Exits: (-1 + %n + %dst) LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:    %iv.next = add nuw i64 %iv, 1
+; CHECK-NEXT:    --> {(1 + %start),+,1}<nuw><%loop> U: full-set S: full-set Exits: %n LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:  Determining loop execution counts for: @guarded_distance_plus_one
+; CHECK-NEXT:  Loop %loop: backedge-taken count is (-1 + (-1 * %start) + %n)
+; CHECK-NEXT:  Loop %loop: constant max backedge-taken count is i64 -2
+; CHECK-NEXT:  Loop %loop: symbolic max backedge-taken count is (-1 + (-1 * %start) + %n)
+; CHECK-NEXT:  Loop %loop: Trip multiple is 1
+;
+entry:
+  %sub = sub i64 %n, %start
+  %a = icmp ult i64 %sub, 8
+  call void @llvm.assume(i1 %a)
+  %c = icmp ult i64 %start, %n
+  br i1 %c, label %loop, label %exit
+
+loop:
+  %iv = phi i64 [ %start, %entry ], [ %iv.next, %loop ]
+  %gep = getelementptr i8, ptr %dst, i64 %iv
+  store i8 0, ptr %gep
+  %iv.next = add nuw i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, %n
+  br i1 %ec, label %exit, label %loop
+
+exit:
+  ret void
+}
+
+; (%start u< %n) and (%n u< %start + 8) bound the difference (%n - %start),
+; which cannot wrap, by 7.
+define void @two_sided_guard_bounds_difference(ptr %dst, i64 %n, i64 %start) {
+; CHECK-LABEL: 'two_sided_guard_bounds_difference'
+; CHECK-NEXT:  Classifying expressions for: @two_sided_guard_bounds_difference
+; CHECK-NEXT:    %add = add i64 %start, 8
+; CHECK-NEXT:    --> (8 + %start) U: full-set S: full-set
+; CHECK-NEXT:    %and = and i1 %c.0, %c.1
+; CHECK-NEXT:    --> (%c.1 umin %c.0) U: full-set S: full-set
+; CHECK-NEXT:    %iv = phi i64 [ %start, %entry ], [ %iv.next, %loop ]
+; CHECK-NEXT:    --> {%start,+,1}<nuw><%loop> U: full-set S: full-set Exits: (-1 + %n) LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:    %gep = getelementptr i8, ptr %dst, i64 %iv
+; CHECK-NEXT:    --> {(%start + %dst),+,1}<nw><%loop> U: full-set S: full-set Exits: (-1 + %n + %dst) LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:    %iv.next = add nuw i64 %iv, 1
+; CHECK-NEXT:    --> {(1 + %start),+,1}<nuw><%loop> U: full-set S: full-set Exits: %n LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:  Determining loop execution counts for: @two_sided_guard_bounds_difference
+; CHECK-NEXT:  Loop %loop: backedge-taken count is (-1 + (-1 * %start) + %n)
+; CHECK-NEXT:  Loop %loop: constant max backedge-taken count is i64 -2
+; CHECK-NEXT:  Loop %loop: symbolic max backedge-taken count is (-1 + (-1 * %start) + %n)
+; CHECK-NEXT:  Loop %loop: Trip multiple is 1
+;
+entry:
+  %c.0 = icmp ult i64 %start, %n
+  %add = add i64 %start, 8
+  %c.1 = icmp ult i64 %n, %add
+  %and = and i1 %c.0, %c.1
+  br i1 %and, label %loop, label %exit
+
+loop:
+  %iv = phi i64 [ %start, %entry ], [ %iv.next, %loop ]
+  %gep = getelementptr i8, ptr %dst, i64 %iv
+  store i8 0, ptr %gep
+  %iv.next = add nuw i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, %n
+  br i1 %ec, label %exit, label %loop
+
+exit:
+  ret void
+}
+
+; Same, with a non-strict upper bound: (%n u<= %start + 8) bounds the
+; difference by 8.
+define void @two_sided_guard_bounds_difference_ule(ptr %dst, i64 %n, i64 %start) {
+; CHECK-LABEL: 'two_sided_guard_bounds_difference_ule'
+; CHECK-NEXT:  Classifying expressions for: @two_sided_guard_bounds_difference_ule
+; CHECK-NEXT:    %add = add i64 %start, 8
+; CHECK-NEXT:    --> (8 + %start) U: full-set S: full-set
+; CHECK-NEXT:    %and = and i1 %c.0, %c.1
+; CHECK-NEXT:    --> (%c.1 umin %c.0) U: full-set S: full-set
+; CHECK-NEXT:    %iv = phi i64 [ %start, %entry ], [ %iv.next, %loop ]
+; CHECK-NEXT:    --> {%start,+,1}<nuw><%loop> U: full-set S: full-set Exits: (-1 + %n) LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:    %gep = getelementptr i8, ptr %dst, i64 %iv
+; CHECK-NEXT:    --> {(%start + %dst),+,1}<nw><%loop> U: full-set S: full-set Exits: (-1 + %n + %dst) LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:    %iv.next = add nuw i64 %iv, 1
+; CHECK-NEXT:    --> {(1 + %start),+,1}<nuw><%loop> U: full-set S: full-set Exits: %n LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:  Determining loop execution counts for: @two_sided_guard_bounds_difference_ule
+; CHECK-NEXT:  Loop %loop: backedge-taken count is (-1 + (-1 * %start) + %n)
+; CHECK-NEXT:  Loop %loop: constant max backedge-taken count is i64 -2
+; CHECK-NEXT:  Loop %loop: symbolic max backedge-taken count is (-1 + (-1 * %start) + %n)
+; CHECK-NEXT:  Loop %loop: Trip multiple is 1
+;
+entry:
+  %c.0 = icmp ult i64 %start, %n
+  %add = add i64 %start, 8
+  %c.1 = icmp ule i64 %n, %add
+  %and = and i1 %c.0, %c.1
+  br i1 %and, label %loop, label %exit
+
+loop:
+  %iv = phi i64 [ %start, %entry ], [ %iv.next, %loop ]
+  %gep = getelementptr i8, ptr %dst, i64 %iv
+  store i8 0, ptr %gep
+  %iv.next = add nuw i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, %n
+  br i1 %ec, label %exit, label %loop
+
+exit:
+  ret void
+}
+
+; Without the (%start u< %n) guard, (%n - %start) may wrap and cannot be
+; bounded.
+define void @one_sided_guard_does_not_bound_difference(ptr %dst, i64 %n, i64 %start) {
+; CHECK-LABEL: 'one_sided_guard_does_not_bound_difference'
+; CHECK-NEXT:  Classifying expressions for: @one_sided_guard_does_not_bound_difference
+; CHECK-NEXT:    %add = add i64 %start, 8
+; CHECK-NEXT:    --> (8 + %start) U: full-set S: full-set
+; CHECK-NEXT:    %iv = phi i64 [ %start, %entry ], [ %iv.next, %loop ]
+; CHECK-NEXT:    --> {%start,+,1}<nuw><%loop> U: full-set S: full-set Exits: (-1 + %n) LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:    %gep = getelementptr i8, ptr %dst, i64 %iv
+; CHECK-NEXT:    --> {(%start + %dst),+,1}<nw><%loop> U: full-set S: full-set Exits: (-1 + %n + %dst) LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:    %iv.next = add nuw i64 %iv, 1
+; CHECK-NEXT:    --> {(1 + %start),+,1}<nuw><%loop> U: full-set S: full-set Exits: %n LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:  Determining loop execution counts for: @one_sided_guard_does_not_bound_difference
+; CHECK-NEXT:  Loop %loop: backedge-taken count is (-1 + (-1 * %start) + %n)
+; CHECK-NEXT:  Loop %loop: constant max backedge-taken count is i64 -1
+; CHECK-NEXT:  Loop %loop: symbolic max backedge-taken count is (-1 + (-1 * %start) + %n)
+; CHECK-NEXT:  Loop %loop: Trip multiple is 1
+;
+entry:
+  %add = add i64 %start, 8
+  %c = icmp ult i64 %n, %add
+  br i1 %c, label %loop, label %exit
+
+loop:
+  %iv = phi i64 [ %start, %entry ], [ %iv.next, %loop ]
+  %gep = getelementptr i8, ptr %dst, i64 %iv
+  store i8 0, ptr %gep
+  %iv.next = add nuw i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, %n
+  br i1 %ec, label %exit, label %loop
+
+exit:
+  ret void
+}
+
+; The upper bound is not (%start + constant), so nothing can be derived about
+; (%n - %start).
+define void @two_sided_guard_non_constant_offset(ptr %dst, i64 %n, i64 %start, i64 %off) {
+; CHECK-LABEL: 'two_sided_guard_non_constant_offset'
+; CHECK-NEXT:  Classifying expressions for: @two_sided_guard_non_constant_offset
+; CHECK-NEXT:    %add = add i64 %start, %off
+; CHECK-NEXT:    --> (%start + %off) U: full-set S: full-set
+; CHECK-NEXT:    %and = and i1 %c.0, %c.1
+; CHECK-NEXT:    --> (%c.1 umin %c.0) U: full-set S: full-set
+; CHECK-NEXT:    %iv = phi i64 [ %start, %entry ], [ %iv.next, %loop ]
+; CHECK-NEXT:    --> {%start,+,1}<nuw><%loop> U: full-set S: full-set Exits: (-1 + %n) LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:    %gep = getelementptr i8, ptr %dst, i64 %iv
+; CHECK-NEXT:    --> {(%start + %dst),+,1}<nw><%loop> U: full-set S: full-set Exits: (-1 + %n + %dst) LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:    %iv.next = add nuw i64 %iv, 1
+; CHECK-NEXT:    --> {(1 + %start),+,1}<nuw><%loop> U: full-set S: full-set Exits: %n LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:  Determining loop execution counts for: @two_sided_guard_non_constant_offset
+; CHECK-NEXT:  Loop %loop: backedge-taken count is (-1 + (-1 * %start) + %n)
+; CHECK-NEXT:  Loop %loop: constant max backedge-taken count is i64 -2
+; CHECK-NEXT:  Loop %loop: symbolic max backedge-taken count is (-1 + (-1 * %start) + %n)
+; CHECK-NEXT:  Loop %loop: Trip multiple is 1
+;
+entry:
+  %c.0 = icmp ult i64 %start, %n
+  %add = add i64 %start, %off
+  %c.1 = icmp ult i64 %n, %add
+  %and = and i1 %c.0, %c.1
+  br i1 %and, label %loop, label %exit
+
+loop:
+  %iv = phi i64 [ %start, %entry ], [ %iv.next, %loop ]
+  %gep = getelementptr i8, ptr %dst, i64 %iv
+  store i8 0, ptr %gep
+  %iv.next = add nuw i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, %n
+  br i1 %ec, label %exit, label %loop
+
+exit:
+  ret void
+}

--- a/llvm/test/Transforms/PhaseOrdering/constraint-eliminiation-interactions.ll
+++ b/llvm/test/Transforms/PhaseOrdering/constraint-eliminiation-interactions.ll
@@ -16,7 +16,7 @@ define void @sum_of_induction_and_guard(i8 %n, i8 %j) mustprogress {
 ; CHECK:       [[BODY]]:
 ; CHECK-NEXT:    [[IV_NEXT2:%.*]] = phi i8 [ [[IV_NEXT:%.*]], %[[BODY]] ], [ 11, %[[ENTRY]] ]
 ; CHECK-NEXT:    tail call void @use(i32 1)
-; CHECK-NEXT:    [[IV_NEXT]] = add i8 [[IV_NEXT2]], 1
+; CHECK-NEXT:    [[IV_NEXT]] = add nuw nsw i8 [[IV_NEXT2]], 1
 ; CHECK-NEXT:    [[C_NOT:%.*]] = icmp eq i8 [[IV_NEXT]], [[N]]
 ; CHECK-NEXT:    br i1 [[C_NOT]], label %[[EXIT]], label %[[BODY]]
 ; CHECK:       [[EXIT]]:

--- a/polly/test/ScopInfo/multidim_fortran_srem.ll
+++ b/polly/test/ScopInfo/multidim_fortran_srem.ll
@@ -2,26 +2,13 @@
 target datalayout = "e-p:64:64:64-S128-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f16:16:16-f32:32:32-f64:64:64-f128:128:128-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64"
 
 ; CHECK:      Statements {
-; CHECK-NEXT:     Stmt_bb188
-; CHECK-NEXT:         Domain :=
-; CHECK-NEXT:             [tmp180, tmp177, tmp183, tmp162, tmp157, tmp150, tmp146, tmp140, tmp] -> { Stmt_bb188[i0] : 0 <= i0 <= -3 + tmp183 };
-; CHECK-NEXT:         Schedule :=
-; CHECK-NEXT:             [tmp180, tmp177, tmp183, tmp162, tmp157, tmp150, tmp146, tmp140, tmp] -> { Stmt_bb188[i0] -> [i0, 0, 0, 0] };
-; CHECK-NEXT:         MustWriteAccess :=    [Reduction Type: NONE] [Scalar: 1]
-; CHECK-NEXT:             [tmp180, tmp177, tmp183, tmp162, tmp157, tmp150, tmp146, tmp140, tmp] -> { Stmt_bb188[i0] -> MemRef_tmp192[] };
-; CHECK-NEXT:         MustWriteAccess :=    [Reduction Type: NONE] [Scalar: 1]
-; CHECK-NEXT:             [tmp180, tmp177, tmp183, tmp162, tmp157, tmp150, tmp146, tmp140, tmp] -> { Stmt_bb188[i0] -> MemRef_tmp194[] };
 ; CHECK-NEXT:     Stmt_bb203
 ; CHECK-NEXT:         Domain :=
 ; CHECK-NEXT:             [tmp180, tmp177, tmp183, tmp162, tmp157, tmp150, tmp146, tmp140, tmp] -> { Stmt_bb203[i0, i1, i2] : 0 <= i0 <= -3 + tmp183 and 0 <= i1 <= -3 + tmp180 and 0 <= i2 <= -3 + tmp177 };
 ; CHECK-NEXT:         Schedule :=
-; CHECK-NEXT:             [tmp180, tmp177, tmp183, tmp162, tmp157, tmp150, tmp146, tmp140, tmp] -> { Stmt_bb203[i0, i1, i2] -> [i0, 1, i1, i2] };
-; CHECK-NEXT:         ReadAccess :=    [Reduction Type: NONE] [Scalar: 1]
-; CHECK-NEXT:             [tmp180, tmp177, tmp183, tmp162, tmp157, tmp150, tmp146, tmp140, tmp] -> { Stmt_bb203[i0, i1, i2] -> MemRef_tmp192[] };
+; CHECK-NEXT:             [tmp180, tmp177, tmp183, tmp162, tmp157, tmp150, tmp146, tmp140, tmp] -> { Stmt_bb203[i0, i1, i2] -> [i0, i1, i2] };
 ; CHECK-NEXT:         ReadAccess :=    [Reduction Type: NONE] [Scalar: 0]
 ; CHECK-NEXT:             [tmp180, tmp177, tmp183, tmp162, tmp157, tmp150, tmp146, tmp140, tmp] -> { Stmt_bb203[i0, i1, i2] -> MemRef_tmp173[o0, 1 + i1, 1 + i2] : (-i0 + o0) mod 3 = 0 and 0 <= o0 <= 2 }
-; CHECK-NEXT:         ReadAccess :=    [Reduction Type: NONE] [Scalar: 1]
-; CHECK-NEXT:             [tmp180, tmp177, tmp183, tmp162, tmp157, tmp150, tmp146, tmp140, tmp] -> { Stmt_bb203[i0, i1, i2] -> MemRef_tmp194[] };
 ; CHECK-NEXT:         ReadAccess :=    [Reduction Type: NONE] [Scalar: 0]
 ; CHECK-NEXT:             [tmp180, tmp177, tmp183, tmp162, tmp157, tmp150, tmp146, tmp140, tmp] -> { Stmt_bb203[i0, i1, i2] -> MemRef_tmp173[o0, 1 + i1, 1 + i2] : (1 - i0 + o0) mod 3 = 0 and 0 <= o0 <= 2 }
 ; CHECK-NEXT:         ReadAccess :=    [Reduction Type: NONE] [Scalar: 0]


### PR DESCRIPTION
Apply loop guards on on `Distance + 1` before computing the unsinged
range. This improves results in a number of cases in practice, mostly
additional unrolling and some runtime check simplifications:
https://github.com/dtcxzyw/llvm-opt-benchmark-nightly/pull/1138

Guards have already been collected on this code path, so applying them is cheap.
Compile-time impact is in the noise: https://llvm-compile-time-tracker.com/compare.php?from=918aa38d750cd40d4265c39817fb31efb628f7e1&to=33c51ea1c4748883dfef71bdd1007bd72ec9095f&stat=instructions:u