### PR TITLE
[clang][mingw] Don't link to moldname

### DIFF
--- a/clang/lib/Driver/ToolChains/MinGW.cpp
+++ b/clang/lib/Driver/ToolChains/MinGW.cpp
@@ -86,7 +86,6 @@ void tools::MinGW::Linker::AddLibGCC(const ArgList &Args,
   }
 
   if (!NoLibc) {
-    CmdArgs.push_back("-lmoldname");
     CmdArgs.push_back("-lmingwex");
     for (auto Lib : Args.getAllArgValues(options::OPT_l)) {
       if (StringRef(Lib).starts_with("msvcr") ||

--- a/clang/test/Driver/mingw.cpp
+++ b/clang/test/Driver/mingw.cpp
@@ -102,7 +102,6 @@
 // CHECK_MINGW_NOLIBC-NOT: "-lkernel32"
 // CHECK_MINGW_NOLIBC-NOT: "-lmingw32"
 // CHECK_MINGW_NOLIBC-NOT: "-lmingwex"
-// CHECK_MINGW_NOLIBC-NOT: "-lmoldname"
 // CHECK_MINGW_NOLIBC-NOT: "-lmsvcrt"
 // CHECK_MINGW_NOLIBC-NOT: "-lshell32"
 // CHECK_MINGW_NOLIBC-NOT: "-luser32"

--- a/compiler-rt/cmake/config-ix.cmake
+++ b/compiler-rt/cmake/config-ix.cmake
@@ -61,9 +61,9 @@ if (C_SUPPORTS_NODEFAULTLIBS_FLAG)
     else ()
       set(MINGW_RUNTIME gcc_s gcc)
     endif()
-    set(MINGW_LIBRARIES mingw32 ${MINGW_RUNTIME} moldname mingwex msvcrt advapi32
+    set(MINGW_LIBRARIES mingw32 ${MINGW_RUNTIME} mingwex msvcrt advapi32
                         shell32 user32 kernel32 mingw32 ${MINGW_RUNTIME}
-                        moldname mingwex msvcrt)
+                        mingwex msvcrt)
     list(APPEND CMAKE_REQUIRED_LIBRARIES ${MINGW_LIBRARIES})
   endif()
   if (NOT TARGET unwind)

--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -42,8 +42,8 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   if(MINGW)
     # Simplified version of what's set in cmake/config-ix.cmake; not including
     # builtins, which are linked separately.
-    set(MINGW_LIBRARIES mingw32 moldname mingwex msvcrt advapi32 shell32
-                        user32 kernel32 mingw32 moldname mingwex msvcrt)
+    set(MINGW_LIBRARIES mingw32 mingwex msvcrt advapi32 shell32
+                        user32 kernel32 mingw32 mingwex msvcrt)
    endif()
 endif()
 

--- a/compiler-rt/test/builtins/Unit/lit.cfg.py
+++ b/compiler-rt/test/builtins/Unit/lit.cfg.py
@@ -70,7 +70,7 @@ elif config.target_os == "Windows":
         (
             "%librt ",
             base_lib
-            + " -lmingw32 -lmoldname -lmingwex -lmsvcrt -ladvapi32 -lshell32 -luser32 -lkernel32 ",
+            + " -lmingw32 -lmingwex -lmsvcrt -ladvapi32 -lshell32 -luser32 -lkernel32 ",
         )
     )
 else:

--- a/libcxx/cmake/config-ix.cmake
+++ b/libcxx/cmake/config-ix.cmake
@@ -74,9 +74,9 @@ if (NOT CXX_SUPPORTS_NOSTDLIBXX_FLAG AND C_SUPPORTS_NODEFAULTLIBS_FLAG)
     else ()
       set(MINGW_RUNTIME gcc_s gcc)
     endif()
-    set(MINGW_LIBRARIES mingw32 ${MINGW_RUNTIME} moldname mingwex msvcrt advapi32
+    set(MINGW_LIBRARIES mingw32 ${MINGW_RUNTIME} mingwex msvcrt advapi32
                         shell32 user32 kernel32 mingw32 ${MINGW_RUNTIME}
-                        moldname mingwex msvcrt)
+                        mingwex msvcrt)
     list(APPEND CMAKE_REQUIRED_LIBRARIES ${MINGW_LIBRARIES})
   endif()
 endif()

--- a/libcxxabi/cmake/config-ix.cmake
+++ b/libcxxabi/cmake/config-ix.cmake
@@ -64,9 +64,9 @@ if (NOT CXX_SUPPORTS_NOSTDLIBXX_FLAG AND C_SUPPORTS_NODEFAULTLIBS_FLAG)
     else ()
       set(MINGW_RUNTIME gcc_s gcc)
     endif()
-    set(MINGW_LIBRARIES mingw32 ${MINGW_RUNTIME} moldname mingwex msvcrt advapi32
+    set(MINGW_LIBRARIES mingw32 ${MINGW_RUNTIME} mingwex msvcrt advapi32
                         shell32 user32 kernel32 mingw32 ${MINGW_RUNTIME}
-                        moldname mingwex msvcrt)
+                        mingwex msvcrt)
     list(APPEND CMAKE_REQUIRED_LIBRARIES ${MINGW_LIBRARIES})
   endif()
 endif()


### PR DESCRIPTION
libmoldname has been empty and deprecated for a long time.

See also: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=127135