### PR TITLE
[clang][ObjC] Avoid COMDATs for GNU runtime strings on Mach-O

### DIFF
--- a/clang/lib/CodeGen/CGObjCGNU.cpp
+++ b/clang/lib/CodeGen/CGObjCGNU.cpp
@@ -214,7 +214,8 @@ protected:
       llvm::Constant *value = llvm::ConstantDataArray::getString(VMContext,Str);
       auto *GV = new llvm::GlobalVariable(TheModule, value->getType(), true,
               llvm::GlobalValue::LinkOnceODRLinkage, value, name);
-      GV->setComdat(TheModule.getOrInsertComdat(name));
+      if (CGM.supportsCOMDAT())
+        GV->setComdat(TheModule.getOrInsertComdat(name));
       if (Private)
         GV->setVisibility(llvm::GlobalValue::HiddenVisibility);
       ConstStr = GV;

--- a/clang/test/CodeGenObjC/gnu-deterministic-selectors.m
+++ b/clang/test/CodeGenObjC/gnu-deterministic-selectors.m
@@ -1,5 +1,7 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-freebsd -fobjc-runtime=gnustep-1.5 %s -emit-llvm -o - | FileCheck %s
 // RUN: %clang_cc1 -triple x86_64-unknown-freebsd -fobjc-runtime=gcc %s -emit-llvm -o - | FileCheck %s
+// RUN: %if x86-registered-target %{ %clang_cc1 -triple x86_64-apple-darwin -fobjc-runtime=gnustep-1.9 %s -emit-obj -o %t.gnustep.o %}
+// RUN: %if x86-registered-target %{ %clang_cc1 -triple x86_64-apple-darwin -fobjc-runtime=gcc %s -emit-obj -o %t.gcc.o %}
 
 // Check that these selectors are emitted in alphabetical order.
 // The order doesn't actually matter, only that it doesn't vary across runs.


### PR DESCRIPTION
## Summary

- avoid attaching LLVM IR COMDATs to GNU Objective-C runtime strings when the target does not support COMDATs
- preserve the existing COMDAT behavior on supported targets
- add Mach-O object-emission regression coverage for the GCC and GNUstep 1.x runtime paths

This addresses the selector-name backend crash reported in #217260. It intentionally does not claim complete Mach-O support for GNU-family Objective-C runtimes; the section-boundary, linking, and runtime concerns described in that issue remain separate work.

## Testing

- full Clang test suite: 3314 passed
- targeted `llvm-lit` regression test: passed
- reproduced the original failure with the baseline compiler: exit 70, `MachO doesn't support COMDATs`
- verified patched Mach-O object emission for `gcc`, `gnustep-1.7`, and `gnustep-1.9`
- verified Mach-O IR retains `linkonce_odr` without COMDAT
- verified the FreeBSD/ELF control path still emits COMDAT
- `git diff --check`: clean

## AI-assisted contribution

OpenAI Codex assisted with investigation, implementation, and test execution. I reviewed, understood, and approved the submitted changes.