### PR TITLE
MachinePipeliner: Pass instruction to findLoopIncrementValue

### DIFF
--- a/llvm/lib/CodeGen/MachinePipeliner.cpp
+++ b/llvm/lib/CodeGen/MachinePipeliner.cpp
@@ -2932,13 +2932,14 @@ static Register findUniqueOperandDefinedInLoop(const MachineInstr &MI) {
 
 /// When Op is a value that is incremented recursively in a loop and there is a
 /// unique instruction that increments it, returns true and sets Value.
-static bool findLoopIncrementValue(const MachineOperand &Op, int &Value) {
+static bool findLoopIncrementValue(const MachineInstr &MI,
+                                   const MachineOperand &Op, int &Value) {
   if (!Op.isReg() || !Op.getReg().isVirtual())
     return false;
 
   Register OrgReg = Op.getReg();
   Register CurReg = OrgReg;
-  const MachineBasicBlock *LoopBB = Op.getParent()->getParent();
+  const MachineBasicBlock *LoopBB = MI.getParent();
   const MachineRegisterInfo &MRI = LoopBB->getParent()->getRegInfo();
 
   const TargetInstrInfo *TII =
@@ -3026,7 +3027,7 @@ bool SwingSchedulerDAG::computeDelta(const MachineInstr &MI, int &Delta) const {
   if (!BaseOp->isReg())
     return false;
 
-  return findLoopIncrementValue(*BaseOp, Delta);
+  return findLoopIncrementValue(MI, *BaseOp, Delta);
 }
 
 /// Check if we can change the instruction to use an offset value from the


### PR DESCRIPTION
The helper recovered the loop block from the operand's parent instruction.
Pass the containing instruction directly so it no longer depends on
MachineOperand::getParent().

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>