### PR TITLE
[SPARC] Preserve inline asm relocation modifiers

### DIFF
--- a/llvm/lib/Target/Sparc/SparcAsmPrinter.cpp
+++ b/llvm/lib/Target/Sparc/SparcAsmPrinter.cpp
@@ -66,6 +66,7 @@ public:
                        const char *ExtraCode, raw_ostream &O) override;
   bool PrintAsmMemoryOperand(const MachineInstr *MI, unsigned OpNo,
                              const char *ExtraCode, raw_ostream &O) override;
+  void PrintSymbolOperand(const MachineOperand &MO, raw_ostream &O) override;
 
   void LowerGETPCXAndEmitMCInsts(const MachineInstr *MI,
                                  const MCSubtargetInfo &STI);
@@ -415,6 +416,17 @@ void SparcAsmPrinter::printOperand(const MachineInstr *MI, int opNum,
   default:
     llvm_unreachable("<unknown operand type>");
   }
+}
+
+void SparcAsmPrinter::PrintSymbolOperand(const MachineOperand &MO,
+                                         raw_ostream &O) {
+  const unsigned RelType = MO.getTargetFlags();
+  StringRef Specifier = Sparc::getSpecifierName(RelType);
+  if (!Specifier.empty())
+    O << '%' << Specifier << '(';
+  AsmPrinter::PrintSymbolOperand(MO, O);
+  if (!Specifier.empty())
+    O << ')';
 }
 
 void SparcAsmPrinter::printMemOperand(const MachineInstr *MI, int opNum,

--- a/llvm/test/CodeGen/SPARC/inlineasm-global-memory.ll
+++ b/llvm/test/CodeGen/SPARC/inlineasm-global-memory.ll
@@ -1,6 +1,4 @@
 ; RUN: llc -mtriple=sparc < %s | FileCheck %s
-; RUN: llc -mtriple=sparc -filetype=obj < %s -o %t
-; RUN: llvm-objdump -r %t | FileCheck %s --check-prefix=RELOC
 
 @fsr_storage = global i32 0, align 4
 
@@ -9,9 +7,6 @@
 ; CHECK:       st %fsr, [%[[HI]]+%lo(fsr_storage)]
 ; CHECK-NEXT:  ld [%[[HI]]+%lo(fsr_storage)], %{{[gilo][0-7]}}
 
-; RELOC:      R_SPARC_HI22 fsr_storage
-; RELOC-NEXT: R_SPARC_LO10 fsr_storage
-; RELOC-NOT:  R_SPARC_13 fsr_storage
 define i32 @get_fsr() {
 entry:
   %fsr = call i32 asm sideeffect "st\09%fsr, $1\0A\09ld\09$1, $0", "=r,*m"(ptr elementtype(i32) @fsr_storage)

--- a/llvm/test/CodeGen/SPARC/inlineasm-global-memory.ll
+++ b/llvm/test/CodeGen/SPARC/inlineasm-global-memory.ll
@@ -1,0 +1,19 @@
+; RUN: llc -mtriple=sparc < %s | FileCheck %s
+; RUN: llc -mtriple=sparc -filetype=obj < %s -o %t
+; RUN: llvm-objdump -r %t | FileCheck %s --check-prefix=RELOC
+
+@fsr_storage = global i32 0, align 4
+
+; CHECK-LABEL: get_fsr:
+; CHECK:       sethi %hi(fsr_storage), %[[HI:[gilo][0-7]]]
+; CHECK:       st %fsr, [%[[HI]]+%lo(fsr_storage)]
+; CHECK-NEXT:  ld [%[[HI]]+%lo(fsr_storage)], %{{[gilo][0-7]}}
+
+; RELOC:      R_SPARC_HI22 fsr_storage
+; RELOC-NEXT: R_SPARC_LO10 fsr_storage
+; RELOC-NOT:  R_SPARC_13 fsr_storage
+define i32 @get_fsr() {
+entry:
+  %fsr = call i32 asm sideeffect "st\09%fsr, $1\0A\09ld\09$1, $0", "=r,*m"(ptr elementtype(i32) @fsr_storage)
+  ret i32 %fsr
+}


### PR DESCRIPTION
Make sure that inline assembly that references a global symbol gets the correct relocation.

sethi %hi(fsr_storage), %i0
st %fsr, [%i0+fsr_storage]
ld [%i0+fsr_storage], %i0
-->
sethi %hi(fsr_storage), %i0
st %fsr, [%i0+%lo(fsr_storage)]
ld [%i0+%lo(fsr_storage)], %i0
