### PR TITLE
[clang][bytecode][NFC] Remove an unreachable parameter check

### DIFF
--- a/clang/lib/AST/ByteCode/ByteCodeEmitter.cpp
+++ b/clang/lib/AST/ByteCode/ByteCodeEmitter.cpp
@@ -26,11 +26,6 @@ void ByteCodeEmitter::compileFunc(const FunctionDecl *FuncDecl,
   assert(Func);
   assert(FuncDecl->isThisDeclarationADefinition());
 
-  // Manually created functions that haven't been assigned proper
-  // parameters yet.
-  if (!FuncDecl->param_empty() && !FuncDecl->param_begin())
-    return;
-
   // Set up lambda captures.
   if (Func->isLambdaCallOperator()) {
     // Set up lambda capture to closure record field mapping.


### PR DESCRIPTION
We check this both in Context and in ByteCodeEmitter. The latter is not reachable since the former will already not create Function instances for such functions.