### PR TITLE
[clang][bytecode][NFC] reserve() ParamDescriptors

### DIFF
--- a/clang/lib/AST/ByteCode/Context.cpp
+++ b/clang/lib/AST/ByteCode/Context.cpp
@@ -672,7 +672,6 @@ const Function *Context::getOrCreateFunction(const FunctionDecl *FuncDecl) {
   }
   // Set up argument indices.
   unsigned ParamOffset = 0;
-  llvm::SmallVector<Function::ParamDescriptor> ParamDescriptors;
 
   // If the return is not a primitive, a pointer to the storage where the
   // value is initialized in is passed as the first argument. See 'RVO'
@@ -715,6 +714,9 @@ const Function *Context::getOrCreateFunction(const FunctionDecl *FuncDecl) {
 
   // Assign descriptors to all parameters.
   // Composite objects are lowered to pointers.
+  llvm::SmallVector<Function::ParamDescriptor> ParamDescriptors;
+  ParamDescriptors.reserve(FuncDecl->getNumParams());
+
   const auto *FuncProto = FuncDecl->getType()->getAs<FunctionProtoType>();
   unsigned BlockOffset = 0;
   for (auto [ParamIndex, PD] : llvm::enumerate(FuncDecl->parameters())) {


### PR DESCRIPTION
We know the size the vector is going to have in the success case, so reserve that.