### PR TITLE
PowerPC: Use use_instr_nodbg_begin in PPCReduceCRLogicals

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCReduceCRLogicals.cpp
+++ b/llvm/lib/Target/PowerPC/PPCReduceCRLogicals.cpp
@@ -655,7 +655,7 @@ bool PPCReduceCRLogicals::splitBlockOnBinaryCROp(CRLogicalOpInfo &CRI) {
 
   // Get the branch instruction.
   MachineInstr *Branch =
-    MRI->use_nodbg_begin(CRI.MI->getOperand(0).getReg())->getParent();
+      &*MRI->use_instr_nodbg_begin(CRI.MI->getOperand(0).getReg());
 
   // We want the new block to have no code in it other than the definition
   // of the input to the CR logical and the CR logical itself. So we move


### PR DESCRIPTION
Fetch the using instruction directly through the instruction iterator
instead of dereferencing an operand's parent.

Co-authored-by: Claude (Claude-Opus-4.8)