### PR TITLE
[flang] No longer expect -target-cpu flag for AMDGPU targets

### DIFF
--- a/flang/test/Driver/target-gpu-features.f90
+++ b/flang/test/Driver/target-gpu-features.f90
@@ -7,4 +7,3 @@
 ! RUN: | FileCheck %s -check-prefix=CHECK-AMDGCN
 
 ! CHECK-AMDGCN: "-fc1" "-triple" "amdgpu9.02-amd-amdhsa"
-! CHECK-AMDGCN-SAME: "-target-cpu" "gfx902"


### PR DESCRIPTION
Update a failing test after
https://github.com/llvm/llvm-project/pull/206483.