### PR TITLE
[Test] Add missing dependency for llvm-ordergen

### DIFF
--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -128,6 +128,7 @@ set(LLVM_TEST_DEPENDS
   llvm-objdump
   llvm-opt-fuzzer
   llvm-opt-report
+  llvm-ordergen
   llvm-offload-binary
   llvm-offload-wrapper
   llvm-otool

--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -128,7 +128,6 @@ set(LLVM_TEST_DEPENDS
   llvm-objdump
   llvm-opt-fuzzer
   llvm-opt-report
-  llvm-ordergen
   llvm-offload-binary
   llvm-offload-wrapper
   llvm-otool
@@ -191,6 +190,10 @@ endif ()
 # Only built when the AMDGPU target is enabled.
 if (TARGET llvm-calc-occupancy)
   list(APPEND LLVM_TEST_DEPENDS llvm-calc-occupancy)
+endif ()
+
+if (TARGET llvm-ordergen)
+  list(APPEND LLVM_TEST_DEPENDS llvm-ordergen)
 endif ()
 
 if(LLVM_INCLUDE_EXAMPLES)


### PR DESCRIPTION
Without this dependency, `llvm-ordergen` is not build when running the tests only, resulting in failures for the tool.