### PR TITLE
RISCV: Pass instruction and operand index to vectorPseudoHasAllNBitUsers

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVOptWInstrs.cpp
+++ b/llvm/lib/Target/RISCV/RISCVOptWInstrs.cpp
@@ -98,9 +98,8 @@ FunctionPass *llvm::createRISCVOptWInstrsLegacyPass() {
   return new RISCVOptWInstrsLegacy();
 }
 
-static bool vectorPseudoHasAllNBitUsers(const MachineOperand &UserOp,
+static bool vectorPseudoHasAllNBitUsers(const MachineInstr &MI, unsigned OpIdx,
                                         unsigned Bits) {
-  const MachineInstr &MI = *UserOp.getParent();
   unsigned MCOpcode = RISCV::getRVVMCOpcode(MI.getOpcode());
 
   if (!MCOpcode)
@@ -113,7 +112,7 @@ static bool vectorPseudoHasAllNBitUsers(const MachineOperand &UserOp,
   assert(RISCVII::hasVLOp(TSFlags));
   const unsigned Log2SEW = MI.getOperand(RISCVII::getSEWOpNum(MCID)).getImm();
 
-  if (UserOp.getOperandNo() == RISCVII::getVLOpNum(MCID))
+  if (OpIdx == RISCVII::getVLOpNum(MCID))
     return false;
 
   auto NumDemandedBits =
@@ -155,7 +154,7 @@ static bool hasAllNBitUsers(const MachineInstr &OrigMI,
 
       switch (UserMI->getOpcode()) {
       default:
-        if (vectorPseudoHasAllNBitUsers(UserOp, Bits))
+        if (vectorPseudoHasAllNBitUsers(*UserMI, OpIdx, Bits))
           break;
         return false;
 


### PR DESCRIPTION
Take the user instruction and operand index directly instead of a
MachineOperand, so the helper no longer relies on getParent.

Co-authored-by: Claude (Claude-Opus-4.8)