### PR TITLE
AArch64: Pass instruction to maybeKillChain

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64A57FPLoadBalancing.cpp
+++ b/llvm/lib/Target/AArch64/AArch64A57FPLoadBalancing.cpp
@@ -125,7 +125,7 @@ private:
   void scanInstruction(MachineInstr *MI, unsigned Idx,
                        std::map<unsigned, Chain *> &Active,
                        std::vector<std::unique_ptr<Chain>> &AllChains);
-  void maybeKillChain(MachineOperand &MO, unsigned Idx,
+  void maybeKillChain(MachineInstr &MI, MachineOperand &MO, unsigned Idx,
                       std::map<unsigned, Chain *> &RegChains);
   Color getColor(unsigned Register);
   Chain *getAndEraseNext(Color PreferredColor, std::vector<Chain *> &L);
@@ -631,9 +631,9 @@ void AArch64A57FPLoadBalancingImpl::scanInstruction(
   if (isMul(MI)) {
 
     for (auto &I : MI->uses())
-      maybeKillChain(I, Idx, ActiveChains);
+      maybeKillChain(*MI, I, Idx, ActiveChains);
     for (auto &I : MI->defs())
-      maybeKillChain(I, Idx, ActiveChains);
+      maybeKillChain(*MI, I, Idx, ActiveChains);
 
     // Create a new chain. Multiplies don't require forwarding so can go on any
     // unit.
@@ -653,10 +653,10 @@ void AArch64A57FPLoadBalancingImpl::scanInstruction(
     Register DestReg = MI->getOperand(0).getReg();
     Register AccumReg = MI->getOperand(3).getReg();
 
-    maybeKillChain(MI->getOperand(1), Idx, ActiveChains);
-    maybeKillChain(MI->getOperand(2), Idx, ActiveChains);
+    maybeKillChain(*MI, MI->getOperand(1), Idx, ActiveChains);
+    maybeKillChain(*MI, MI->getOperand(2), Idx, ActiveChains);
     if (DestReg != AccumReg)
-      maybeKillChain(MI->getOperand(0), Idx, ActiveChains);
+      maybeKillChain(*MI, MI->getOperand(0), Idx, ActiveChains);
 
     if (ActiveChains.find(AccumReg) != ActiveChains.end()) {
       LLVM_DEBUG(dbgs() << "Chain found for accumulator register "
@@ -682,7 +682,7 @@ void AArch64A57FPLoadBalancingImpl::scanInstruction(
       LLVM_DEBUG(
           dbgs() << "Cannot add to chain because accumulator operand wasn't "
                  << "marked <kill>!\n");
-      maybeKillChain(MI->getOperand(3), Idx, ActiveChains);
+      maybeKillChain(*MI, MI->getOperand(3), Idx, ActiveChains);
     }
 
     LLVM_DEBUG(dbgs() << "Creating new chain for dest register "
@@ -696,27 +696,24 @@ void AArch64A57FPLoadBalancingImpl::scanInstruction(
     // Non-MUL or MLA instruction. Invalidate any chain in the uses or defs
     // lists.
     for (auto &I : MI->uses())
-      maybeKillChain(I, Idx, ActiveChains);
+      maybeKillChain(*MI, I, Idx, ActiveChains);
     for (auto &I : MI->defs())
-      maybeKillChain(I, Idx, ActiveChains);
-
+      maybeKillChain(*MI, I, Idx, ActiveChains);
   }
 }
 
 void AArch64A57FPLoadBalancingImpl::maybeKillChain(
-    MachineOperand &MO, unsigned Idx,
+    MachineInstr &MI, MachineOperand &MO, unsigned Idx,
     std::map<unsigned, Chain *> &ActiveChains) {
   // Given an operand and the set of active chains (keyed by register),
   // determine if a chain should be ended and remove from ActiveChains.
-  MachineInstr *MI = MO.getParent();
-
   if (MO.isReg()) {
 
     // If this is a KILL of a current chain, record it.
     if (MO.isKill() && ActiveChains.find(MO.getReg()) != ActiveChains.end()) {
       LLVM_DEBUG(dbgs() << "Kill seen for chain " << printReg(MO.getReg(), TRI)
                         << "\n");
-      ActiveChains[MO.getReg()]->setKill(MI, Idx, /*Immutable=*/MO.isTied());
+      ActiveChains[MO.getReg()]->setKill(&MI, Idx, /*Immutable=*/MO.isTied());
     }
     ActiveChains.erase(MO.getReg());
 
@@ -727,7 +724,7 @@ void AArch64A57FPLoadBalancingImpl::maybeKillChain(
       if (MO.clobbersPhysReg(I->first)) {
         LLVM_DEBUG(dbgs() << "Kill (regmask) seen for chain "
                           << printReg(I->first, TRI) << "\n");
-        I->second->setKill(MI, Idx, /*Immutable=*/true);
+        I->second->setKill(&MI, Idx, /*Immutable=*/true);
         ActiveChains.erase(I++);
       } else
         ++I;


### PR DESCRIPTION
Take the containing instruction directly instead of recovering it from
the operand's parent.

Co-authored-by: Claude (Claude-Opus-4.8)