### PR TITLE
[Clang] Fix a regression introduced by #216729.

### DIFF
--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -5351,7 +5351,7 @@ recurse:
       DiagnoseUnsupportedPackIndexTemplateName();
       break;
     }
-    mangleUnresolvedName(NestedNameSpecifier(), DTI->getName(),
+    mangleUnresolvedName(/*NestedNameSpecifier=*/std::nullopt, DTI->getName(),
                          DTI->template_arguments().data(),
                          DTI->getNumTemplateArgs(), Arity);
     break;

--- a/clang/test/CodeGenCXX/mangle-concept-template-param.cpp
+++ b/clang/test/CodeGenCXX/mangle-concept-template-param.cpp
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -verify -std=c++2c -emit-llvm -triple %itanium_abi_triple -o - %s -fclang-abi-compat=latest | FileCheck %s
+// expected-no-diagnostics
+
+// FIXME: Is the empty case case correct? These are not defined by the itanium ABI yet.
+namespace GH218820 {
+// CHECK: define {{.*}}@_ZN8GH2188201fITpTtTyEJEEEvvQfraa1CIiE(
+// CHECK: define {{.*}}@_ZN8GH2188201fIJNS_1CEEEEvvQfraa1CIiE(
+template <template <typename> concept... C>
+void f() requires (C<int> && ...) {}
+
+// CHECK: define {{.*}}@_ZN8GH2188201gITpTtTyEJEEEvvQfraa1VIiE(
+// CHECK: define {{.*}}@_ZN8GH2188201gIJNS_1VEEEEvvQfraa1VIiE(
+template <template <typename> auto... V>
+void g() requires (V<int> && ...) {}
+
+template <typename T>
+concept C = true;
+
+template <typename T>
+constexpr auto V = true;
+
+void h() {
+    f<>();
+    f<C>();
+    g<>();
+    g<V>();
+}
+}


### PR DESCRIPTION
We have a very confusing NNS interface:

```cpp
NestedNameSpecifier() : NestedNameSpecifier(FlagKind::Invalid) {}
NestedNameSpecifier(std::nullopt_t) : StoredOrFlag(0) {}
```

That tripped me up (and that we probably should clean up)

On top of that we were lacking mangling tests for
concept template parameters.

We could use more but the goal of the PR is to address the regression.

Fixes #218820