### PR TITLE
[AMDGPU] Keep unresolved callees in cyclic resource usage max

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.cpp
@@ -112,11 +112,15 @@ MCSymbol *MCResourceInfo::getMaxNamedBarrierSymbol(MCContext &OutContext) {
 //   all be populated, started at RecSym).
 // - Shape of the resource symbol's MCExpr (`max` args are order agnostic):
 //   RecSym.MCExpr := max(<constant>+, <callee_symbol>*)
+// Unresolved cycle members are kept as symbolic max args instead of dropped.
 const MCExpr *MCResourceInfo::flattenedCycleMax(MCSymbol *RecSym,
+                                                MCSymbol *AssigneeSym,
                                                 ResourceInfoKind RIK,
                                                 MCContext &OutContext) {
   SmallPtrSet<const MCExpr *, 8> Seen;
   SmallVector<const MCExpr *, 8> WorkList;
+  SmallPtrSet<const MCSymbol *, 8> SeenUnassigned;
+  SmallVector<const MCExpr *, 8> Unassigned;
   int64_t Maximum = 0;
 
   const MCExpr *RecExpr = RecSym->getVariableValue();
@@ -165,6 +169,9 @@ const MCExpr *MCResourceInfo::flattenedCycleMax(MCSymbol *RecSym,
         const MCExpr *SymVal = SymRef.getVariableValue();
         if (Seen.insert(SymVal).second)
           WorkList.push_back(SymVal);
+      } else if (&SymRef != AssigneeSym &&
+                 SeenUnassigned.insert(&SymRef).second) {
+        Unassigned.push_back(CurExpr);
       }
       break;
     }
@@ -182,7 +189,12 @@ const MCExpr *MCResourceInfo::flattenedCycleMax(MCSymbol *RecSym,
   LLVM_DEBUG(dbgs() << "MCResUse:   " << RecSym->getName()
                     << ": Using flattened max: << " << Maximum << '\n');
 
-  return MCConstantExpr::create(Maximum, OutContext);
+  const MCExpr *MaxConst = MCConstantExpr::create(Maximum, OutContext);
+  if (Unassigned.empty())
+    return MaxConst;
+
+  Unassigned.insert(Unassigned.begin(), MaxConst);
+  return AMDGPUMCExpr::createMax(Unassigned, OutContext);
 }
 
 void MCResourceInfo::assignResourceInfoExpr(
@@ -231,7 +243,8 @@ void MCResourceInfo::assignResourceInfoExpr(
         case RIK_NumVGPR:
         case RIK_NumSGPR:
         case RIK_NumAGPR:
-          ArgExprs.push_back(flattenedCycleMax(CalleeValSym, RIK, OutContext));
+          ArgExprs.push_back(
+              flattenedCycleMax(CalleeValSym, Sym, RIK, OutContext));
           break;
         case RIK_NumNamedBarrier:
           ArgExprs.push_back(MCSymbolRefExpr::create(

--- a/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.cpp
@@ -193,6 +193,7 @@ const MCExpr *MCResourceInfo::flattenedCycleMax(MCSymbol *RecSym,
     return MaxConst;
 
   SmallVector<const MCExpr *, 8> MaxArgs;
+  MaxArgs.reserve(Unassigned.size() + 1);
   MaxArgs.push_back(MaxConst);
   for (const MCSymbol *Sym : Unassigned)
     MaxArgs.push_back(MCSymbolRefExpr::create(Sym, OutContext));

--- a/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.cpp
@@ -15,6 +15,7 @@
 #include "AMDGPUMCResourceInfo.h"
 #include "SIMachineFunctionInfo.h"
 #include "Utils/AMDGPUBaseInfo.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCContext.h"
@@ -119,8 +120,7 @@ const MCExpr *MCResourceInfo::flattenedCycleMax(MCSymbol *RecSym,
                                                 MCContext &OutContext) {
   SmallPtrSet<const MCExpr *, 8> Seen;
   SmallVector<const MCExpr *, 8> WorkList;
-  SmallPtrSet<const MCSymbol *, 8> SeenUnassigned;
-  SmallVector<const MCExpr *, 8> Unassigned;
+  SmallSetVector<const MCSymbol *, 8> Unassigned;
   int64_t Maximum = 0;
 
   const MCExpr *RecExpr = RecSym->getVariableValue();
@@ -169,9 +169,8 @@ const MCExpr *MCResourceInfo::flattenedCycleMax(MCSymbol *RecSym,
         const MCExpr *SymVal = SymRef.getVariableValue();
         if (Seen.insert(SymVal).second)
           WorkList.push_back(SymVal);
-      } else if (&SymRef != AssigneeSym &&
-                 SeenUnassigned.insert(&SymRef).second) {
-        Unassigned.push_back(CurExpr);
+      } else if (&SymRef != AssigneeSym) {
+        Unassigned.insert(&SymRef);
       }
       break;
     }
@@ -193,8 +192,11 @@ const MCExpr *MCResourceInfo::flattenedCycleMax(MCSymbol *RecSym,
   if (Unassigned.empty())
     return MaxConst;
 
-  Unassigned.insert(Unassigned.begin(), MaxConst);
-  return AMDGPUMCExpr::createMax(Unassigned, OutContext);
+  SmallVector<const MCExpr *, 8> MaxArgs;
+  MaxArgs.push_back(MaxConst);
+  for (const MCSymbol *Sym : Unassigned)
+    MaxArgs.push_back(MCSymbolRefExpr::create(Sym, OutContext));
+  return AMDGPUMCExpr::createMax(MaxArgs, OutContext);
 }
 
 void MCResourceInfo::assignResourceInfoExpr(

--- a/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.h
@@ -62,9 +62,9 @@ private:
 
   // Take flattened max of cyclic function calls' knowns. For example, for
   // a cycle A->B->C->D->A, take max(A, B, C, D) for A and have B, C, D have the
-  // propgated value from A.
-  const MCExpr *flattenedCycleMax(MCSymbol *RecSym, ResourceInfoKind RIK,
-                                  MCContext &OutContext);
+  // propgated value from A. AssigneeSym excludes self-reference.
+  const MCExpr *flattenedCycleMax(MCSymbol *RecSym, MCSymbol *AssigneeSym,
+                                  ResourceInfoKind RIK, MCContext &OutContext);
 
 public:
   MCResourceInfo() = default;

--- a/llvm/test/CodeGen/AMDGPU/recursive-resource-usage-mcexpr.ll
+++ b/llvm/test/CodeGen/AMDGPU/recursive-resource-usage-mcexpr.ll
@@ -167,3 +167,56 @@ define void @D() {
   call void asm sideeffect "", "~{s70}"()
   ret void
 }
+
+; SCC order qux2, baz2, foo2 flattens baz2 before foo2 is assigned.
+; foo2's symbol must stay in the max, not be dropped.
+
+; CHECK-LABEL: {{^}}qux2
+; CHECK: .set .Lqux2.num_vgpr, max(42, .Lbaz2.num_vgpr, .Lfoo2.num_vgpr)
+; CHECK: .set .Lqux2.num_agpr, max(0, .Lbaz2.num_agpr, .Lfoo2.num_agpr)
+; CHECK: .set .Lqux2.numbered_sgpr, max(54, .Lbaz2.numbered_sgpr, .Lfoo2.numbered_sgpr)
+
+; CHECK-LABEL: {{^}}baz2
+; CHECK: .set .Lbaz2.num_vgpr, max(42, max(42, .Lfoo2.num_vgpr))
+; CHECK: .set .Lbaz2.num_agpr, max(0, max(0, .Lfoo2.num_agpr))
+; CHECK: .set .Lbaz2.numbered_sgpr, max(54, max(54, .Lfoo2.numbered_sgpr))
+
+; CHECK-LABEL: {{^}}foo2
+; CHECK: .set .Lfoo2.num_vgpr, max(61, 42)
+; CHECK: .set .Lfoo2.num_agpr, max(31, 0)
+; CHECK: .set .Lfoo2.numbered_sgpr, max(71, 54)
+
+; CHECK-LABEL: {{^}}usebaz2
+; CHECK: .set .Lusebaz2.num_vgpr, max(32, .Lbaz2.num_vgpr)
+; CHECK: .set .Lusebaz2.num_agpr, max(0, .Lbaz2.num_agpr)
+; CHECK: .set .Lusebaz2.numbered_sgpr, max(33, .Lbaz2.numbered_sgpr)
+; CHECK: NumVgprs: 61
+; CHECK: NumAgprs: 31
+; CHECK: TotalNumVgprs: 95
+
+define void @foo2() {
+entry:
+  call void asm sideeffect "", "~{v60},~{a30},~{s70}"()
+  call void @baz2()
+  ret void
+}
+
+define void @qux2() {
+entry:
+  call void @baz2()
+  call void @foo2()
+  ret void
+}
+
+define void @baz2() {
+entry:
+  call void asm sideeffect "", "~{v35}"()
+  call void @qux2()
+  ret void
+}
+
+define amdgpu_kernel void @usebaz2() {
+entry:
+  call void @baz2()
+  ret void
+}


### PR DESCRIPTION
Flattening a call cycle could drop a callee not yet assigned a resource symbol, silently omitting its usage from the max