### PR TITLE
[clang][bytecode][NFC] Reorder Function members

### DIFF
--- a/clang/lib/AST/ByteCode/Function.cpp
+++ b/clang/lib/AST/ByteCode/Function.cpp
@@ -18,8 +18,8 @@ using namespace clang::interp;
 Function::Function(FunctionDeclTy Source, unsigned ArgSize,
                    llvm::SmallVectorImpl<ParamDescriptor> &&ParamDescriptors,
                    bool HasThisPointer, bool HasRVO, bool IsLambdaStaticInvoker)
-    : Kind(FunctionKind::Normal), Source(Source), ArgSize(ArgSize),
-      ParamDescriptors(std::move(ParamDescriptors)), IsValid(false),
+    : Source(Source), ParamDescriptors(std::move(ParamDescriptors)),
+      ArgSize(ArgSize), Kind(FunctionKind::Normal), IsValid(false),
       IsFullyCompiled(false), HasThisPointer(HasThisPointer), HasRVO(HasRVO),
       HasBody(false), Defined(false) {
 

--- a/clang/lib/AST/ByteCode/Function.h
+++ b/clang/lib/AST/ByteCode/Function.h
@@ -237,6 +237,8 @@ public:
   bool isDefined() const { return Defined; }
 
   bool isVariadic() const { return Variadic; }
+  /// Returs the full number of parameters, including implicit instance and RVO
+  /// pointers.
   unsigned getNumParams() const {
     return ParamDescriptors.size() + hasThisPointer() + hasRVO();
   }
@@ -279,22 +281,22 @@ private:
   friend class ByteCodeEmitter;
   friend class Context;
 
-  /// Function Kind.
-  FunctionKind Kind;
   /// Declaration this function was compiled from.
   FunctionDeclTy Source;
-  /// Local area size: storage + metadata.
-  unsigned FrameSize = 0;
-  /// Size of the argument stack.
-  unsigned ArgSize;
   /// Program code.
   llvm::SmallVector<std::byte> Code;
   /// Opcode-to-expression mapping.
   SourceMap SrcMap;
   /// List of block descriptors.
   llvm::SmallVector<Scope, 2> Scopes;
-  /// List of all parameters, including RVO and instance pointer.
+  /// List of all parameters, excluding RVO and instance pointer.
   llvm::SmallVector<ParamDescriptor> ParamDescriptors;
+  /// Local area size: storage + metadata.
+  unsigned FrameSize = 0;
+  /// Size of the argument stack.
+  unsigned ArgSize;
+  /// Function Kind.
+  FunctionKind Kind;
   /// Flag to indicate if the function is valid.
   LLVM_PREFERRED_TYPE(bool)
   unsigned IsValid : 1;


### PR DESCRIPTION
Order them by size to save a few bytes and clarify some comments.