### PR TITLE
Hexagon: Use use_instructions in checkHVXUses32/checkHVXUses16

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonXQFloatGenerator.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonXQFloatGenerator.cpp
@@ -366,9 +366,8 @@ bool VectorConvertRemove::checkHVXUses32(MachineInstr *MI,
                                          MachineInstr *UseMI) {
   Register convReg = MI->getOperand(0).getReg();
   // Iterate over all uses of the Def we are analyzing
-  for (auto &MO : make_range(MRI->use_begin(convReg), MRI->use_end())) {
-    MachineInstr *UMI = MO.getParent();
-    if (UMI == UseMI)
+  for (MachineInstr &UMI : MRI->use_instructions(convReg)) {
+    if (&UMI == UseMI)
       continue;
     // Since the convert cannot be deleted, we set the operand as NOT kill
     MI->getOperand(1).setIsKill(false);
@@ -383,9 +382,8 @@ bool VectorConvertRemove::checkHVXUses16(MachineInstr *MI,
                                          MachineInstr *UseMI) {
   Register convReg = MI->getOperand(0).getReg();
   // Iterate over all uses of the Def we are analyzing
-  for (auto &MO : make_range(MRI->use_begin(convReg), MRI->use_end())) {
-    MachineInstr *UMI = MO.getParent();
-    if (UMI == UseMI)
+  for (MachineInstr &UMI : MRI->use_instructions(convReg)) {
+    if (&UMI == UseMI)
       continue;
     // Since the convert cannot be deleted, we set the operand as NOT kill
     MI->getOperand(1).setIsKill(false);


### PR DESCRIPTION
The loops only inspect the using instruction, so iterate instructions
directly instead of operands and their parents.

Co-authored-by: Claude (Claude-Opus-4.8)