### PR TITLE
[Clang] Fix Crash in Sema::DiagnoseUnguardedAvailability On 'if' With No Condition

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -662,6 +662,8 @@ features cannot lower the translation-unit ABI level;
   declaration. (#GH217489)
 - Fixed an assertion failure when instantiating a block that captures
   `this` via a member access through a dependent base class.
+- Fixed `DiagnoseUnguardedAvailability::TraverseIfStmt` dereferencing a nullptr
+  on `if consteval {}`. (#GH220004)
 
 ### OpenACC Specific Changes
 

--- a/clang/lib/Sema/SemaAvailability.cpp
+++ b/clang/lib/Sema/SemaAvailability.cpp
@@ -1065,7 +1065,11 @@ ExtractedAvailabilityExpr extractAvailabilityExpr(const Expr *IfCond) {
 }
 
 bool DiagnoseUnguardedAvailability::TraverseIfStmt(IfStmt *If) {
-  ExtractedAvailabilityExpr IfCond = extractAvailabilityExpr(If->getCond());
+  Expr *Cond = If->getCond();
+  if (!Cond)
+    return DynamicRecursiveASTVisitor::TraverseIfStmt(If);
+
+  ExtractedAvailabilityExpr IfCond = extractAvailabilityExpr(Cond);
   if (!IfCond.E) {
     // This isn't an availability checking 'if', we can just continue.
     return DynamicRecursiveASTVisitor::TraverseIfStmt(If);

--- a/clang/test/SemaCXX/attr-availability.cpp
+++ b/clang/test/SemaCXX/attr-availability.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -triple x86_64-apple-macosx10.9.0 -std=c++11 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -triple x86_64-apple-macosx10.9.0 -std=c++23 -fsyntax-only -verify %s
 
 __attribute__((availability(macos, introduced = 10.0))) int init10();
 __attribute__((availability(macos, introduced = 11.0))) int init11(); // expected-note 2 {{'init11' has been marked as being introduced in macOS 11.0}}
@@ -19,3 +20,12 @@ struct S : B0, B1 {
   {}
   int i0, i1;
 };
+
+#if __cplusplus >= 202302L
+void ifConsteval() {
+  if (__builtin_available(macos 10.12, *))
+    ;
+  if consteval {
+  }
+}
+#endif


### PR DESCRIPTION
**Problem**
C++ 23 introduced consteval expressions which allows `if` statements to have no condition:
```
if consteval {
}
```
`DiagnoseUnguardedAvailability::TraverseIfStmt` Assumed `If->getCond()` would never return a `nullptr`, causing a `nullptr` dereference.


**Fix**
Added a `nullptr` check to `TraverseIfStmt`, continuing in a way consistent with another check in the function and an associated test which has been checked to fail without the fix.

Fixes #219948