### PR TITLE
[mlir][PDL] Use free-function cast in ProcessDerivedPDLValue::process…

### DIFF
--- a/mlir/include/mlir/IR/PDLPatternMatch.h.inc
+++ b/mlir/include/mlir/IR/PDLPatternMatch.h.inc
@@ -461,9 +461,7 @@ struct ProcessDerivedPDLValue : public ProcessPDLValueBasedOn<T, BaseT> {
   }
   using ProcessPDLValueBasedOn<T, BaseT>::verifyAsArg;
 
-  static T processAsArg(BaseT baseValue) {
-    return baseValue.template cast<T>();
-  }
+  static T processAsArg(BaseT baseValue) { return cast<T>(baseValue); }
   using ProcessPDLValueBasedOn<T, BaseT>::processAsArg;
 
   static void processAsResult(PatternRewriter &, PDLResultList &results,

--- a/mlir/unittests/IR/PatternMatchTest.cpp
+++ b/mlir/unittests/IR/PatternMatchTest.cpp
@@ -53,3 +53,31 @@ TEST(AnOpRewritePatternTest, PatternFuncAttributes) {
             test::OpB::getOperationName());
 }
 } // end anonymous namespace
+
+#if MLIR_ENABLE_PDL_IN_PATTERNMATCH
+namespace {
+FailureOr<StringAttr> derivedValueRewriteFunc(PatternRewriter &rewriter,
+                                              Operation *op, StringAttr attr,
+                                              IntegerType type) {
+  return attr;
+}
+
+LogicalResult derivedValueConstraintFunc(PatternRewriter &rewriter,
+                                         Operation *op, TypeAttr attr) {
+  return success();
+}
+
+TEST(PDLPatternModuleTest, RegisterFunctionsWithDerivedValues) {
+  PDLPatternModule pdlPattern;
+
+  pdlPattern.registerRewriteFunction("rewriter", derivedValueRewriteFunc);
+  pdlPattern.registerConstraintFunction("constraint",
+                                        derivedValueConstraintFunc);
+
+  ASSERT_EQ(pdlPattern.getRewriteFunctions().size(), 1U);
+  ASSERT_TRUE(pdlPattern.getRewriteFunctions().contains("rewriter"));
+  ASSERT_EQ(pdlPattern.getConstraintFunctions().size(), 1U);
+  ASSERT_TRUE(pdlPattern.getConstraintFunctions().contains("constraint"));
+}
+} // end anonymous namespace
+#endif // MLIR_ENABLE_PDL_IN_PATTERNMATCH


### PR DESCRIPTION
`ProcessDerivedPDLValue::processAsArg` still used the `cast` member
function that was removed from Attribute and Type in #135556. Because it
is a member of a class template it is only instantiated when a native PDL
constraint or rewrite function takes a derived attribute or type
parameter, which nothing in-tree does, so the removal did not surface it.
Downstream users hit a hard compile error.

Switch to the free-function form, matching the `Operation *`
specialization below which already does this. The `Operation *` path was
never affected because it overrides `processAsArg`; only derived
attributes and types were broken.

Add a unit test registering rewrite and constraint functions with
`StringAttr`, `IntegerType` and `TypeAttr` parameters

Fixes: #218047 