### PR TITLE
[SLP] Don't rely on VectorizableTree in canBuildSplitNode() when called from tryToReduce()

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -31137,6 +31137,8 @@ public:
           // Last chance to try to vectorize alternate node.
           SmallVector<Value *> Op1, Op2;
           BoUpSLP::OrdersType ReorderIndices;
+          // canBuildSplitNode() relies on VectorizableTree(), make sure to
+          // clear here since it may contain leftover state from prior attempts
           V.deleteTree();
           if (MainOp && AltOp &&
               V.canBuildSplitNode(Ops, OpS, Op1, Op2, ReorderIndices)) {

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -2663,8 +2663,7 @@ public:
                          const InstructionsState &LocalState,
                          SmallVectorImpl<Value *> &Op1,
                          SmallVectorImpl<Value *> &Op2,
-                         OrdersType &ReorderIndices,
-                         bool TreeExists = true) const;
+                         OrdersType &ReorderIndices) const;
 
   ~BoUpSLP();
 
@@ -11092,8 +11091,7 @@ bool BoUpSLP::canBuildSplitNode(ArrayRef<Value *> VL,
                                 const InstructionsState &LocalState,
                                 SmallVectorImpl<Value *> &Op1,
                                 SmallVectorImpl<Value *> &Op2,
-                                OrdersType &ReorderIndices,
-                                bool TreeExists) const {
+                                OrdersType &ReorderIndices) const {
   constexpr unsigned SmallNodeSize = 4;
   if (VL.size() <= SmallNodeSize || TTI->preferAlternateOpcodeVectorization() ||
       !SplitAlternateInstructions)
@@ -11213,7 +11211,7 @@ bool BoUpSLP::canBuildSplitNode(ArrayRef<Value *> VL,
         TTI->getArithmeticInstrCost(Opcode1, Op2VecTy, CostKind);
     InstructionCost NewCost =
         NewVecOpsCost + InsertCost +
-        (TreeExists && !VectorizableTree.empty() && getRootNode().hasState() &&
+        (!VectorizableTree.empty() && getRootNode().hasState() &&
                  getRootNode().getOpcode() == Instruction::Store
              ? NewShuffleCost
              : 0);
@@ -31139,9 +31137,9 @@ public:
           // Last chance to try to vectorize alternate node.
           SmallVector<Value *> Op1, Op2;
           BoUpSLP::OrdersType ReorderIndices;
+          V.deleteTree();
           if (MainOp && AltOp &&
-              V.canBuildSplitNode(Ops, OpS, Op1, Op2, ReorderIndices,
-                                  /*TreeExists*/ false)) {
+              V.canBuildSplitNode(Ops, OpS, Op1, Op2, ReorderIndices)) {
             if (LocalReducedVals.empty()) {
               LocalReducedVals.push_back(Ops);
               States.push_back(OpS);

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -2663,7 +2663,8 @@ public:
                          const InstructionsState &LocalState,
                          SmallVectorImpl<Value *> &Op1,
                          SmallVectorImpl<Value *> &Op2,
-                         OrdersType &ReorderIndices) const;
+                         OrdersType &ReorderIndices,
+                         bool TreeExists = true) const;
 
   ~BoUpSLP();
 
@@ -11091,7 +11092,8 @@ bool BoUpSLP::canBuildSplitNode(ArrayRef<Value *> VL,
                                 const InstructionsState &LocalState,
                                 SmallVectorImpl<Value *> &Op1,
                                 SmallVectorImpl<Value *> &Op2,
-                                OrdersType &ReorderIndices) const {
+                                OrdersType &ReorderIndices,
+                                bool TreeExists) const {
   constexpr unsigned SmallNodeSize = 4;
   if (VL.size() <= SmallNodeSize || TTI->preferAlternateOpcodeVectorization() ||
       !SplitAlternateInstructions)
@@ -11211,7 +11213,7 @@ bool BoUpSLP::canBuildSplitNode(ArrayRef<Value *> VL,
         TTI->getArithmeticInstrCost(Opcode1, Op2VecTy, CostKind);
     InstructionCost NewCost =
         NewVecOpsCost + InsertCost +
-        (!VectorizableTree.empty() && getRootNode().hasState() &&
+        (TreeExists && !VectorizableTree.empty() && getRootNode().hasState() &&
                  getRootNode().getOpcode() == Instruction::Store
              ? NewShuffleCost
              : 0);
@@ -31138,7 +31140,8 @@ public:
           SmallVector<Value *> Op1, Op2;
           BoUpSLP::OrdersType ReorderIndices;
           if (MainOp && AltOp &&
-              V.canBuildSplitNode(Ops, OpS, Op1, Op2, ReorderIndices)) {
+              V.canBuildSplitNode(Ops, OpS, Op1, Op2, ReorderIndices,
+                                  /*TreeExists*/ false)) {
             if (LocalReducedVals.empty()) {
               LocalReducedVals.push_back(Ops);
               States.push_back(OpS);

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -31138,7 +31138,7 @@ public:
           SmallVector<Value *> Op1, Op2;
           BoUpSLP::OrdersType ReorderIndices;
           // canBuildSplitNode() relies on VectorizableTree(), make sure to
-          // clear here since it may contain leftover state from prior attempts
+          // clear here since it may contain leftover state from prior attempts.
           V.deleteTree();
           if (MainOp && AltOp &&
               V.canBuildSplitNode(Ops, OpS, Op1, Op2, ReorderIndices)) {


### PR DESCRIPTION
The tree is left-over from the prior vectorization attempt in this case.