### PR TITLE
Update test CH214128.cpp added in #219799 to work in C++20 mode.

### DIFF
--- a/clang/test/Parser/GH214128.cpp
+++ b/clang/test/Parser/GH214128.cpp
@@ -1,9 +1,15 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -std=c++17 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify %s
 
-i < 0
-// expected-error@-1 {{no template named 'i'}}
-// expected-error@-2 {{expected '>'}}
-// expected-note@-3 {{to match this '<'}}
+i < 0;
+#if __cplusplus <= 201703L
+// expected-error@-2 {{no template named 'i'}}
+#endif
+// expected-error@-4 {{expected '>'}}
+// expected-note@-5 {{to match this '<'}}
+#if __cplusplus > 201703L
+// expected-warning@-7 {{declaration does not declare anything}}
+#endif
 
 void f() {
   struct __is_pod; // expected-warning {{keyword '__is_pod' will be made available as an identifier for the remainder of the translation unit}}


### PR DESCRIPTION
Internally we have changed our compiler to default to C++20 mode instead of C++17 which causes the test added in #219799 to fail.

With the test as it currently is, compiling with C++20 mode gives the following output:
```
GH214128.cpp:3:6: error: expected '>'                                                                
    3 | i < 0                                                                                                                                    
      |      ^                                                                                                                                   
GH214128.cpp:3:3: note: to match this '<'                                                            
    3 | i < 0                                                                                                                                    
      |   ^                                                                                                                                      
GH214128.cpp:8:1: error: expected unqualified-id                                                     
    8 | void f() {                                                                                                                               
      | ^                                                                                                                                        
2 errors generated.
```
Note the error on line 8, this is because there is a missing semi-colon on the statement `i < 0` on line 3. By adding the semicolon at the end of that line, it allows the parser to continue and generate the expected warning in the definition of the function `f()` as well as an additional warning in C++20 mode:
```
GH214128.cpp:3:6: error: expected '>'
    3 | i < 0;
      |      ^
GH214128.cpp:3:3: note: to match this '<'
    3 | i < 0;
      |   ^
GH214128.cpp:3:1: warning: declaration does not declare anything [-Wmissing-declarations]
    3 | i < 0;
      | ^
GH214128.cpp:9:10: warning: keyword '__is_pod' will be made available as an identifier for the remainder of the translation unit [-Wkeyword-compat]
    9 |   struct __is_pod; // expected-warning {{keyword '__is_pod' will be made available as an identifier for the remainder of the translation unit}}
      |          ^
2 warnings and 1 error generated.
```

This change adds the semi-colon at the end of the statement `i < 0`, adjusts the expected errors/warnings/notes for c++17/c++20 modes and explicitly tests both the C++17 and C++20 modes.