### PR TITLE
[DirectX] Fix -Wunused-variable in release builds

### DIFF
--- a/llvm/lib/Target/DirectX/DXILIntrinsicExpansion.cpp
+++ b/llvm/lib/Target/DirectX/DXILIntrinsicExpansion.cpp
@@ -714,8 +714,7 @@ static Value *expandFunnelShiftIntrinsic(CallInst *Orig) {
 
   IRBuilder<> Builder(Orig);
 
-  unsigned BitWidth = Ty->getScalarSizeInBits();
-  assert(llvm::isPowerOf2_32(BitWidth) &&
+  assert(llvm::isPowerOf2_32(Ty->getScalarSizeInBits()) &&
          "Can't use Mask to compute modulo and inverse");
 
   // Note: if (Shift % BitWidth) == 0 then (BitWidth - Shift) == BitWidth,

--- a/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
+++ b/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
@@ -61,7 +61,7 @@ static Value *traverseGEPOffsets(const DataLayout &DL, IRBuilder<> &Builder,
   Value *Offset = nullptr;
 
   while (Ptr) {
-    if (auto *II = dyn_cast<IntrinsicInst>(Ptr)) {
+    if ([[maybe_unused]] auto *II = dyn_cast<IntrinsicInst>(Ptr)) {
       assert((II->getIntrinsicID() == Intrinsic::dx_resource_getpointer ||
               II->getIntrinsicID() == Intrinsic::dx_resource_getbasepointer) &&
              "Resource access through unexpected intrinsic");


### PR DESCRIPTION
The PR in #214066 enabled the DirectX target which flagged one of our builders that builds with -Wunused-variable in the release configuration. There were some variables only used in asserts. Inline one definition where the meaning is clear and mark another maybe_unused due to the definition having multiple users.