### PR TITLE
[DebugInfo] Don't re-extract a childless unit DIE

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
@@ -508,6 +508,12 @@ Error DWARFUnit::tryExtractDIEsIfNeeded(bool CUDieOnly) {
   if ((CUDieOnly && !DieArray.empty()) || DieArray.size() > 1)
     return Error::success(); // Already parsed.
 
+  // A childless unit DIE is a complete DieArray on its own, so the size check
+  // above misses it. Re-extracting reallocates the vector and dangles every
+  // outstanding DWARFDie.
+  if (DieArray.size() == 1 && !DieArray.front().hasChildren())
+    return Error::success();
+
   bool HasCUDie = !DieArray.empty();
   extractDIEsToVector(!HasCUDie, !CUDieOnly, DieArray);
 

--- a/llvm/test/tools/dsymutil/X86/update-modules.test
+++ b/llvm/test/tools/dsymutil/X86/update-modules.test
@@ -1,0 +1,10 @@
+Update mode keeps the clang module skeleton units in the compile unit list, so
+the linker clones units whose DIE array holds nothing but the unit DIE.
+
+RUN: dsymutil --update --linker classic -f -oso-prepend-path=%p/../Inputs/modules \
+RUN:   -y %p/dummy-debug-map.map -o - \
+RUN:     | llvm-dwarfdump --debug-info - | FileCheck %s
+
+CHECK: DW_AT_name ("modules.m")
+CHECK: DW_AT_GNU_dwo_name ("/Foo.pcm")
+CHECK: DW_AT_GNU_dwo_name ("./Bar.pcm")


### PR DESCRIPTION
tryExtractDIEsIfNeeded treats a DieArray with one entry as not yet fully parsed, but that's wrong for a unit DIE without children. In this case we try to re-parse and reallocate the DieArray, dangling the existing DWARFDie.

Assisted-by: Claude