### PR TITLE
[DirectX][ProfCheck] Add recently enabled test to exclude list

### DIFF
--- a/llvm/utils/profcheck-xfail.txt
+++ b/llvm/utils/profcheck-xfail.txt
@@ -1,4 +1,5 @@
 CodeGen/ARM/sjljeh-swifterror.ll
+CodeGen/DirectX/legalize-i8-alloca.ll
 CodeGen/WinEH/wineh-comdat.ll
 CodeGen/WinEH/wineh-scope-statenumbering.ll
 CodeGen/WinEH/wineh-setjmp.ll


### PR DESCRIPTION
The DirectX enablement PR in #214066 means these tests now run on the profcheck builder. This is an existing issue that has presumably been around for a while, just disable for now to allow more time for a fix.