### PR TITLE
[PPC] Remove code model checking in callsShareTOCBase

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -4904,13 +4904,6 @@ static bool callsShareTOCBase(const Function *Caller,
   if (!CalleeGV->isStrongDefinitionForLinker())
     return false;
 
-  // The medium and large code models are expected to provide a sufficiently
-  // large TOC to provide all data addressing needs of a module with a
-  // single TOC.
-  if (CodeModel::Medium == TM.getCodeModel() ||
-      CodeModel::Large == TM.getCodeModel())
-    return true;
-
   // Any explicitly-specified sections and section prefixes must also match.
   // Also, if we're using -ffunction-sections, then each function is always in
   // a different section (the same is true for COMDAT functions).

--- a/llvm/test/CodeGen/PowerPC/ppc64-blnop.ll
+++ b/llvm/test/CodeGen/PowerPC/ppc64-blnop.ll
@@ -4,6 +4,7 @@
 ; RUN: llc < %s -relocation-model=pic -function-sections -verify-machineinstrs -mtriple=powerpc64-unknown-linux-gnu | FileCheck %s -check-prefix=CHECK-FS
 ; RUN: llc < %s -relocation-model=pic -verify-machineinstrs -mtriple=powerpc64le-unknown-linux-gnu | FileCheck %s
 ; RUN: llc < %s -relocation-model=pic -function-sections -verify-machineinstrs -mtriple=powerpc64le-unknown-linux-gnu | FileCheck %s -check-prefix=CHECK-FS
+; RUN: llc < %s -relocation-model=pic -function-sections -verify-machineinstrs -mtriple=powerpc64le-unknown-linux-gnu -code-model=large | FileCheck %s -check-prefix=CHECK-FS
 ; RUN: llc < %s -relocation-model=pic -verify-machineinstrs -mtriple=powerpc64le-unknown-linux-gnu \
 ; RUN: -code-model=small -mcpu=pwr8 | FileCheck %s -check-prefix=SCM
 
@@ -142,5 +143,15 @@ define void @w_caller(ptr %ptr) {
 ; CHECK-LABEL: w_caller:
 ; CHECK: bl w_callee
 ; CHECK-NEXT: nop
+}
+
+define dso_local void @dl_callee(ptr %ptr) { ret void }
+define dso_local void @dl_caller(ptr %ptr) {
+  call void @dl_callee(ptr %ptr)
+  ret void
+
+; CHECK-FS-LABEL: dl_caller:
+; CHECK-FS: bl dl_callee
+; CHECK-FS-NEXT: nop
 }
 


### PR DESCRIPTION
This is to remove the checking of large/medium code model checking in function callsShareTOCBase. 

There is a situation that we need TOC restored after function call even with large code model. When a file is compiled with -c to generate a regular object, and also compiled to generate a shared object. A function, eg, foo,  is defined in the file. When compiling these two objects and other object with LTO with large code model, currently the NOP instruction is not generated after the call to function foo. The program may fail at runtime depending on the order of objects during linking.