### PR TITLE
Revert "[Test] Add missing dependency for llvm-ordergen (#219992)"

### DIFF
--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -192,10 +192,6 @@ if (TARGET llvm-calc-occupancy)
   list(APPEND LLVM_TEST_DEPENDS llvm-calc-occupancy)
 endif ()
 
-if (TARGET llvm-ordergen)
-  list(APPEND LLVM_TEST_DEPENDS llvm-ordergen)
-endif ()
-
 if(LLVM_INCLUDE_EXAMPLES)
   list(APPEND LLVM_TEST_DEPENDS
     Kaleidoscope-Ch3


### PR DESCRIPTION
This reverts commit ae35002188a5c483c3956f3d4a7f026368126655.

This should not have gone upstream.