### PR TITLE
[libc] Clean up some unused includes

### DIFF
--- a/libc/src/signal/linux/kill.cpp
+++ b/libc/src/signal/linux/kill.cpp
@@ -12,7 +12,6 @@
 #include "src/__support/common.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
-#include "src/signal/linux/signal_utils.h"
 
 #include <sys/syscall.h> // For syscall numbers.
 

--- a/libc/src/stdio/remove.h
+++ b/libc/src/stdio/remove.h
@@ -9,7 +9,6 @@
 #ifndef LLVM_LIBC_SRC_STDIO_REMOVE_H
 #define LLVM_LIBC_SRC_STDIO_REMOVE_H
 
-#include "hdr/types/FILE.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/startup/linux/aarch64/tls.cpp
+++ b/libc/startup/linux/aarch64/tls.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "config/app.h"
 #include "hdr/sys_mman_macros.h"
 #include "src/__support/OSUtil/linux/syscall_wrappers/mmap.h"
 #include "src/__support/OSUtil/linux/syscall_wrappers/munmap.h"
@@ -13,7 +14,6 @@
 #include "src/__support/macros/config.h"
 #include "src/__support/threads/thread.h"
 #include "src/string/memory_utils/inline_memcpy.h"
-#include "startup/linux/do_start.h"
 
 #include <arm_acle.h>
 #include <sys/syscall.h>

--- a/libc/startup/linux/riscv/tls.cpp
+++ b/libc/startup/linux/riscv/tls.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "config/app.h"
 #include "hdr/sys_mman_macros.h"
 #include "src/__support/OSUtil/linux/syscall_wrappers/mmap.h"
 #include "src/__support/OSUtil/linux/syscall_wrappers/munmap.h"
@@ -13,7 +14,6 @@
 #include "src/__support/macros/config.h"
 #include "src/__support/threads/thread.h"
 #include "src/string/memory_utils/inline_memcpy.h"
-#include "startup/linux/do_start.h"
 #include <sys/syscall.h>
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/startup/linux/x86_64/tls.cpp
+++ b/libc/startup/linux/x86_64/tls.cpp
@@ -6,13 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "config/app.h"
 #include "hdr/sys_mman_macros.h"
 #include "src/__support/OSUtil/linux/syscall_wrappers/getrandom.h"
 #include "src/__support/OSUtil/linux/syscall_wrappers/mmap.h"
 #include "src/__support/OSUtil/linux/syscall_wrappers/munmap.h"
 #include "src/__support/macros/config.h"
 #include "src/string/memory_utils/inline_memcpy.h"
-#include "startup/linux/do_start.h"
 
 #include <asm/prctl.h>
 #include <sys/syscall.h>


### PR DESCRIPTION
The `CMakeLists.txt` for these already reflect the correct dependencies (e.g. `libc/startup/linux/x86_64/tls.cpp` depends on `libc.config.app_h`, not `do_start`). I was adding some Bazel rules for libc entrypoints and saw these unused deps.