### PR TITLE
[libc] Correct hidden attribute on __restore_rt

### DIFF
--- a/libc/src/signal/linux/__restore.cpp
+++ b/libc/src/signal/linux/__restore.cpp
@@ -18,8 +18,7 @@
 namespace LIBC_NAMESPACE_DECL {
 
 extern "C" void __restore_rt()
-    __attribute__((no_sanitize("all"),
-                   hidden));
+    __attribute__((no_sanitize("all"), visibility("hidden")));
 
 extern "C" void __restore_rt() {
   LIBC_NAMESPACE::syscall_impl<long>(SYS_rt_sigreturn);


### PR DESCRIPTION
This PR fixes the syntax for a `hidden` attribute in `__restore_rt`. When compiling with `-Wattributes`, this TU complains about:

```
llvm-project/libc/src/signal/linux/__restore.cpp:20:67: error: unknown attribute 'hidden' ignored [-Werror,-Wunknown-attributes]
   20 | extern "C" void __restore_rt() __attribute__((no_sanitize("all"), hidden));
```
