### PR TITLE
[tsan] Accept a 47-bit VMA for the Go runtime on linux/aarch64

### DIFF
--- a/compiler-rt/lib/tsan/rtl/tsan_platform.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_platform.h
@@ -624,7 +624,7 @@ struct MappingGoPPC64_47 {
   static const uptr kShadowAdd = 0x200000000000ull;
 };
 
-/* Go on linux/aarch64 (48-bit VMA) and darwin/aarch64 (47-bit VMA)
+/* Go on linux/aarch64 (47- and 48-bit VMA) and darwin/aarch64 (47-bit VMA)
 0000 0000 1000 - 0000 1000 0000: executable
 0000 1000 0000 - 00c0 0000 0000: -
 00c0 0000 0000 - 00e0 0000 0000: heap

--- a/compiler-rt/lib/tsan/rtl/tsan_platform_linux.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_platform_linux.cpp
@@ -347,9 +347,9 @@ void InitializePlatformEarly() {
     Die();
   }
 #    else
-  if (vmaSize != 48) {
+  if (vmaSize != 47 && vmaSize != 48) {
     Printf("FATAL: ThreadSanitizer: unsupported VMA range\n");
-    Printf("FATAL: Found %zd - Supported 48\n", vmaSize);
+    Printf("FATAL: Found %zd - Supported 47 and 48\n", vmaSize);
     Die();
   }
 #    endif


### PR DESCRIPTION
The Go arm of the aarch64 VMA check in `InitializePlatformEarly` accepts only 48, so on a kernel with a 47-bit user address space every Go binary built with `-race` dies at startup:

```
FATAL: ThreadSanitizer: unsupported VMA range
FATAL: Found 47 - Supported 48
```

Accept 47 as well. `MappingGoAarch64` already serves 47-bit darwin/arm64, and the ranges Go asks TSan to shadow (the heap hints and the non-PIE data segment) sit inside `kLoAppMem` regardless of VMA size.

Verified on a 47-bit aarch64 host (gVisor, `go1.27.0 linux/arm64`) with Go's `runtime/race` suite.

Fixes #220037

Assisted-by: Claude Code
