### PR TITLE
[libc][exit] Use LIBC_CONSTINIT macro to allow pre-C++20 compilation

### DIFF
--- a/libc/src/stdlib/CMakeLists.txt
+++ b/libc/src/stdlib/CMakeLists.txt
@@ -782,8 +782,6 @@ add_entrypoint_object(
     atexit.cpp
   HDRS
     atexit.h
-  CXX_STANDARD
-    20 # For constinit
   DEPENDS
     .exit_handler
 )
@@ -794,8 +792,6 @@ add_entrypoint_object(
     at_quick_exit.cpp
   HDRS
     at_quick_exit.h
-  CXX_STANDARD
-    20 # For constinit
   DEPENDS
     .exit_handler
     .atexit

--- a/libc/src/stdlib/at_quick_exit.cpp
+++ b/libc/src/stdlib/at_quick_exit.cpp
@@ -9,12 +9,13 @@
 #include "src/stdlib/at_quick_exit.h"
 #include "hdr/types/atexithandler_t.h"
 #include "src/__support/common.h"
+#include "src/__support/macros/attributes.h"
 #include "src/__support/macros/config.h"
 #include "src/stdlib/exit_handler.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-constinit ExitCallbackList at_quick_exit_callbacks;
+LIBC_CONSTINIT ExitCallbackList at_quick_exit_callbacks;
 
 LLVM_LIBC_FUNCTION(int, at_quick_exit, (__atexithandler_t callback)) {
   return add_atexit_unit(

--- a/libc/src/stdlib/atexit.cpp
+++ b/libc/src/stdlib/atexit.cpp
@@ -9,12 +9,13 @@
 #include "src/stdlib/atexit.h"
 #include "hdr/types/atexithandler_t.h"
 #include "src/__support/common.h"
+#include "src/__support/macros/attributes.h"
 #include "src/__support/macros/config.h"
 #include "src/stdlib/exit_handler.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-constinit ExitCallbackList atexit_callbacks;
+LIBC_CONSTINIT ExitCallbackList atexit_callbacks;
 Mutex handler_list_mtx(/*is_priority_inherit=*/false, /*is_recursive=*/false,
                        /*is_robust=*/false, /*is_pshared=*/false);
 


### PR DESCRIPTION
The `constinit` specifier was added in these files before `LIBC_CONSTINIT` was added to LLVM-libc. This PR updates the `at_quick_exit` and `atexit` entrypoints so they may be compiled pre-C++20.