### PR TITLE
[Clang] Fix crash when expanding an expansion statement after a fatal error

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -525,6 +525,9 @@ features cannot lower the translation-unit ABI level;
   affect C++26 constexpr structured bindings and expansion statements, but
   also affects some uses of plain structured bindings. (#GH211930)
 
+- Fixed an assertion when instantiating the body of a C++26 expansion
+  statement after a fatal error had occurred. (#GH214917)
+
 - Fixed friend declarations sometimes making non-visible default arguments
   incorrectly visible to default argument redefinition checks across modules.
 
@@ -550,9 +553,6 @@ features cannot lower the translation-unit ABI level;
 - Fixed an assertion when an ill-formed qualified member function definition
   inside a union caused the union to be treated as a polymorphic class.
   (#GH213854)
-
-- Fixed an assertion when instantiating the body of a C++26 expansion
-  statement after a fatal error had occurred. (#GH214917)
 
 #### Bug Fixes to AST Handling
 

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -551,6 +551,9 @@ features cannot lower the translation-unit ABI level;
   inside a union caused the union to be treated as a polymorphic class.
   (#GH213854)
 
+- Fixed an assertion when instantiating the body of a C++26 expansion
+  statement after a fatal error had occurred. (#GH214917)
+
 #### Bug Fixes to AST Handling
 
 - Fixed a non-deterministic ordering of unused local typedefs that made

--- a/clang/lib/Sema/SemaExpand.cpp
+++ b/clang/lib/Sema/SemaExpand.cpp
@@ -573,6 +573,8 @@ StmtResult Sema::FinishCXXExpansionStmt(Stmt *Exp, Stmt *Body) {
     NonSFINAEContext _(*this);
     InstantiatingTemplate Inst(*this, Body->getBeginLoc(), Expansion, Arg,
                                Body->getSourceRange());
+    if (Inst.isInvalid())
+      return StmtError();
 
     StmtResult Instantiation = SubstStmt(CombinedBody, MTArgList);
     if (Instantiation.isInvalid())

--- a/clang/test/SemaCXX/GH214917.cpp
+++ b/clang/test/SemaCXX/GH214917.cpp
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 -fsyntax-only -std=c++2c -ferror-limit 1 -verify %s
+
+// GH214917: don't crash expanding an expansion statement after a fatal error.
+
+unknown_type a; // expected-error {{unknown type name 'unknown_type'}}
+unknown_type b;
+// expected-error@* {{too many errors emitted}}
+
+struct V {
+  int i, j;
+};
+
+void bar() {
+  template for (auto i : V{42, 10}) {
+    (void)i;
+  }
+}

--- a/clang/test/SemaCXX/GH214917.cpp
+++ b/clang/test/SemaCXX/GH214917.cpp
@@ -6,12 +6,38 @@ unknown_type a; // expected-error {{unknown type name 'unknown_type'}}
 unknown_type b;
 // expected-error@* {{too many errors emitted}}
 
+struct T {
+  int x, y;
+};
+
+void f() {
+  template for (auto i : T{42, 10}) {
+    (void)i;
+  }
+}
+
+struct S {
+  Foo(Foo &&);
+};
+
+template <int> std { struct tuple_size; };
+
 struct V {
   int i, j;
 };
 
-void bar() {
-  template for (auto i : V{42, 10}) {
-    (void)i;
-  }
-}
+template <> struct std::tuple_size<V> {
+  static const int value = 2;
+};
+template <int I> struct std::tuple_element<I, V> {
+  using type = int;
+};
+
+template <> struct std::tuple_size<V> {
+  static const int value = 2;
+};
+template <int I> struct std::tuple_element<I, V> {
+  using type = int;
+};
+
+void bar() { template for (auto i : V{42, 10}) i += (V.i == 42); }


### PR DESCRIPTION
Fixes #214917

When the error limit is reached, clang emits `fatal error: too many errors emitted` but keeps parsing with diagnostics suppressed. If it then reaches a well-formed `template for`, `FinishCXXExpansionStmt` tries to instantiate the body for each element. The `InstantiatingTemplate` it constructs deliberately refuses to push a `CodeSynthesisContext` after a fatal error and marks itself invalid — but unlike every other instantiation site, this one never checked `isInvalid()` and called `SubstStmt` anyway, hitting the "Cannot perform an instantiation without some context on the instantiation stack" assertion. The junk in the fuzzer reproducer only matters for pushing the error count past the limit; the expansion statement itself is fine, since `V` destructures through its public members.

The fix adds the standard `if (Inst.isInvalid()) return StmtError();` guard before the substitution, so the expansion bails out cleanly like every other caller of `InstantiatingTemplate`. This also covers the other way the constructor can decline to push, exceeding the instantiation depth limit. The assertion itself is untouched.

LLM tools were used for this contribution. I've reviewed, built, and tested the change myself before pushing to GitHub.
