### PR TITLE
[Flang][OpenMP] Fix crash on paths where no optional mangler is provided

### DIFF
--- a/flang/lib/Utils/OpenMP.cpp
+++ b/flang/lib/Utils/OpenMP.cpp
@@ -334,7 +334,8 @@ mlir::FlatSymbolRefAttr getOrGenImplicitDefaultDeclareMapper(
     if (auto recType = mlir::dyn_cast<fir::RecordType>(
             fir::getFortranElementType(memberType))) {
       std::string mapperIdName = getCanonicalDefaultDeclareMapperName(recType);
-      mangler(mapperIdName, memberName);
+      if (mangler)
+        mangler(mapperIdName, memberName);
       mapperId = getOrGenImplicitDefaultDeclareMapper(
           firOpBuilder, loc, recType, mapperIdName, mangler);
     }


### PR DESCRIPTION
Currently we will ICE in certain test cases where we run the DoConcurrentConversion or the privatization pass that invokes getOrGenImplicitDefaultDeclareMapper with no provided mapper. As we will still invoke the mapper function without checking it's actually available. Fix this by verifying we have been provided one first before usage, the fall back path of using the getCanonicalDefaultDeclareMapperName results remains the same.