### PR TITLE
[libc] Add <unistd.h> functions for process group management.

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -414,6 +414,8 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.geteuid
     libc.src.unistd.gethostname
     libc.src.unistd.getpagesize
+    libc.src.unistd.getpgid
+    libc.src.unistd.getpgrp
     libc.src.unistd.getpid
     libc.src.unistd.getppid
     libc.src.unistd.getsid
@@ -434,6 +436,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.readlinkat
     libc.src.unistd.rmdir
     libc.src.unistd.setgid
+    libc.src.unistd.setpgid
     libc.src.unistd.setregid
     libc.src.unistd.setreuid
     libc.src.unistd.setsid

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -245,6 +245,8 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.geteuid
     libc.src.unistd.gethostname
     libc.src.unistd.getpagesize
+    libc.src.unistd.getpgid
+    libc.src.unistd.getpgrp
     libc.src.unistd.getpid
     libc.src.unistd.getppid
     libc.src.unistd.getsid
@@ -262,6 +264,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.readlinkat
     libc.src.unistd.rmdir
     libc.src.unistd.setgid
+    libc.src.unistd.setpgid
     libc.src.unistd.setregid
     libc.src.unistd.setreuid
     libc.src.unistd.setsid

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -444,6 +444,8 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.geteuid
     libc.src.unistd.gethostname
     libc.src.unistd.getpagesize
+    libc.src.unistd.getpgid
+    libc.src.unistd.getpgrp
     libc.src.unistd.getpid
     libc.src.unistd.getppid
     libc.src.unistd.getsid
@@ -464,6 +466,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.readlinkat
     libc.src.unistd.rmdir
     libc.src.unistd.setgid
+    libc.src.unistd.setpgid
     libc.src.unistd.setregid
     libc.src.unistd.setreuid
     libc.src.unistd.setsid

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -453,6 +453,8 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.geteuid
     libc.src.unistd.gethostname
     libc.src.unistd.getpagesize
+    libc.src.unistd.getpgid
+    libc.src.unistd.getpgrp
     libc.src.unistd.getpid
     libc.src.unistd.getppid
     libc.src.unistd.getsid
@@ -473,6 +475,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.readlinkat
     libc.src.unistd.rmdir
     libc.src.unistd.setgid
+    libc.src.unistd.setpgid
     libc.src.unistd.setregid
     libc.src.unistd.setreuid
     libc.src.unistd.setsid

--- a/libc/include/unistd.yaml
+++ b/libc/include/unistd.yaml
@@ -257,6 +257,18 @@ functions:
       - type: int
       - type: __getoptargv_t
       - type: const char *
+  - name: getpgid
+    standards:
+      - posix
+    return_type: pid_t
+    arguments:
+      - type: pid_t
+  - name: getpgrp
+    standards:
+      - posix
+    return_type: pid_t
+    arguments:
+      - type: void
   - name: getpid
     standards:
       - posix
@@ -409,6 +421,13 @@ functions:
     return_type: int
     arguments:
       - type: gid_t
+  - name: setpgid
+    standards:
+      - posix
+    return_type: int
+    arguments:
+      - type: pid_t
+      - type: pid_t
   - name: setregid
     standards:
       - posix

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/CMakeLists.txt
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/CMakeLists.txt
@@ -653,6 +653,19 @@ add_header_library(
 )
 
 add_header_library(
+  getpgid
+  HDRS
+    getpgid.h
+  DEPENDS
+    libc.hdr.types.pid_t
+    libc.include.sys_syscall
+    libc.src.__support.common
+    libc.src.__support.error_or
+    libc.src.__support.macros.config
+    libc.src.__support.OSUtil.osutil
+)
+
+add_header_library(
   setuid
   HDRS
     setuid.h
@@ -697,6 +710,19 @@ add_header_library(
     setregid.h
   DEPENDS
     libc.hdr.types.gid_t
+    libc.include.sys_syscall
+    libc.src.__support.common
+    libc.src.__support.error_or
+    libc.src.__support.macros.config
+    libc.src.__support.OSUtil.osutil
+)
+
+add_header_library(
+  setpgid
+  HDRS
+    setpgid.h
+  DEPENDS
+    libc.hdr.types.pid_t
     libc.include.sys_syscall
     libc.src.__support.common
     libc.src.__support.error_or

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/getpgid.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/getpgid.h
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Syscall wrapper for getpgid.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_GETPGID_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_GETPGID_H
+
+#include "hdr/types/pid_t.h"
+#include "src/__support/OSUtil/linux/syscall.h" // syscall_checked
+#include "src/__support/common.h"
+#include "src/__support/error_or.h"
+#include "src/__support/macros/config.h"
+#include <sys/syscall.h> // For syscall numbers
+
+namespace LIBC_NAMESPACE_DECL {
+namespace linux_syscalls {
+
+LIBC_INLINE ErrorOr<pid_t> getpgid(pid_t pid) {
+  return syscall_checked<pid_t>(SYS_getpgid, pid);
+}
+
+} // namespace linux_syscalls
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_GETPGID_H

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/setpgid.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/setpgid.h
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Syscall wrapper for setpgid.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_SETPGID_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_SETPGID_H
+
+#include "hdr/types/pid_t.h"
+#include "src/__support/OSUtil/linux/syscall.h" // syscall_checked
+#include "src/__support/common.h"
+#include "src/__support/error_or.h"
+#include "src/__support/macros/config.h"
+#include <sys/syscall.h> // For syscall numbers
+
+namespace LIBC_NAMESPACE_DECL {
+namespace linux_syscalls {
+
+LIBC_INLINE ErrorOr<int> setpgid(pid_t pid, pid_t pgid) {
+  return syscall_checked<int>(SYS_setpgid, pid, pgid);
+}
+
+} // namespace linux_syscalls
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_SETPGID_H

--- a/libc/src/unistd/CMakeLists.txt
+++ b/libc/src/unistd/CMakeLists.txt
@@ -190,6 +190,20 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  getpgid
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.getpgid
+)
+
+add_entrypoint_object(
+  getpgrp
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.getpgrp
+)
+
+add_entrypoint_object(
   getpid
   ALIAS
   DEPENDS
@@ -327,6 +341,13 @@ add_entrypoint_object(
   ALIAS
   DEPENDS
     .${LIBC_TARGET_OS}.setgid
+)
+
+add_entrypoint_object(
+  setpgid
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.setpgid
 )
 
 add_entrypoint_object(

--- a/libc/src/unistd/getpgid.h
+++ b/libc/src/unistd/getpgid.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for getpgid.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_UNISTD_GETPGID_H
+#define LLVM_LIBC_SRC_UNISTD_GETPGID_H
+
+#include "hdr/types/pid_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+pid_t getpgid(pid_t pid);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_UNISTD_GETPGID_H

--- a/libc/src/unistd/getpgrp.h
+++ b/libc/src/unistd/getpgrp.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for getpgrp.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_UNISTD_GETPGRP_H
+#define LLVM_LIBC_SRC_UNISTD_GETPGRP_H
+
+#include "hdr/types/pid_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+pid_t getpgrp();
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_UNISTD_GETPGRP_H

--- a/libc/src/unistd/linux/CMakeLists.txt
+++ b/libc/src/unistd/linux/CMakeLists.txt
@@ -310,7 +310,6 @@ add_entrypoint_object(
   DEPENDS
     libc.hdr.types.pid_t
     libc.src.__support.OSUtil.linux.syscall_wrappers.getpgid
-    libc.src.errno.errno
 )
 
 add_entrypoint_object(

--- a/libc/src/unistd/linux/CMakeLists.txt
+++ b/libc/src/unistd/linux/CMakeLists.txt
@@ -290,6 +290,30 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  getpgid
+  SRCS
+    getpgid.cpp
+  HDRS
+    ../getpgid.h
+  DEPENDS
+    libc.hdr.types.pid_t
+    libc.src.__support.OSUtil.linux.syscall_wrappers.getpgid
+    libc.src.errno.errno
+)
+
+add_entrypoint_object(
+  getpgrp
+  SRCS
+    getpgrp.cpp
+  HDRS
+    ../getpgrp.h
+  DEPENDS
+    libc.hdr.types.pid_t
+    libc.src.__support.OSUtil.linux.syscall_wrappers.getpgid
+    libc.src.errno.errno
+)
+
+add_entrypoint_object(
   getpid
   SRCS
     getpid.cpp
@@ -561,6 +585,18 @@ add_entrypoint_object(
   DEPENDS
     libc.hdr.types.gid_t
     libc.src.__support.OSUtil.linux.syscall_wrappers.setgid
+    libc.src.errno.errno
+)
+
+add_entrypoint_object(
+  setpgid
+  SRCS
+    setpgid.cpp
+  HDRS
+    ../setpgid.h
+  DEPENDS
+    libc.hdr.types.pid_t
+    libc.src.__support.OSUtil.linux.syscall_wrappers.setpgid
     libc.src.errno.errno
 )
 

--- a/libc/src/unistd/linux/getpgid.cpp
+++ b/libc/src/unistd/linux/getpgid.cpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Linux implementation of getpgid.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/unistd/getpgid.h"
+
+#include "hdr/types/pid_t.h"
+#include "src/__support/OSUtil/linux/syscall_wrappers/getpgid.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(pid_t, getpgid, (pid_t pid)) {
+  auto ret = linux_syscalls::getpgid(pid);
+  if (!ret) {
+    libc_errno = ret.error();
+    return -1;
+  }
+  return *ret;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/unistd/linux/getpgrp.cpp
+++ b/libc/src/unistd/linux/getpgrp.cpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Linux implementation of getpgrp.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/unistd/getpgrp.h"
+
+#include "hdr/types/pid_t.h"
+#include "src/__support/OSUtil/linux/syscall_wrappers/getpgid.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(pid_t, getpgrp, ()) {
+  auto ret = linux_syscalls::getpgid(0);
+  if (!ret) {
+    libc_errno = ret.error();
+    return -1;
+  }
+  return *ret;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/unistd/linux/getpgrp.cpp
+++ b/libc/src/unistd/linux/getpgrp.cpp
@@ -16,18 +16,16 @@
 #include "hdr/types/pid_t.h"
 #include "src/__support/OSUtil/linux/syscall_wrappers/getpgid.h"
 #include "src/__support/common.h"
-#include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(pid_t, getpgrp, ()) {
   auto ret = linux_syscalls::getpgid(0);
-  if (!ret) {
-    libc_errno = ret.error();
-    return -1;
-  }
-  return *ret;
+  // getpgrp() cannot fail, so we can assume getpgid(0) syscall always
+  // succeeds (which is true on Linux in "normal execution", when simulation
+  // or SECCOMP is not in the picture).
+  return ret.value();
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/unistd/linux/setpgid.cpp
+++ b/libc/src/unistd/linux/setpgid.cpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Linux implementation of setpgid.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/unistd/setpgid.h"
+
+#include "hdr/types/pid_t.h"
+#include "src/__support/OSUtil/linux/syscall_wrappers/setpgid.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, setpgid, (pid_t pid, pid_t pgid)) {
+  auto ret = linux_syscalls::setpgid(pid, pgid);
+  if (!ret) {
+    libc_errno = ret.error();
+    return -1;
+  }
+  return 0;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/unistd/setpgid.h
+++ b/libc/src/unistd/setpgid.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for setpgid.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_UNISTD_SETPGID_H
+#define LLVM_LIBC_SRC_UNISTD_SETPGID_H
+
+#include "hdr/types/pid_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int setpgid(pid_t pid, pid_t pgid);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_UNISTD_SETPGID_H

--- a/libc/test/src/unistd/CMakeLists.txt
+++ b/libc/test/src/unistd/CMakeLists.txt
@@ -408,6 +408,19 @@ add_libc_test(
 )
 
 add_libc_test(
+  setpgid_test
+  SUITE
+    libc_unistd_unittests
+  SRCS
+    setpgid_test.cpp
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.src.unistd.setpgid
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
+)
+
+add_libc_test(
   setregid_test
   SUITE
     libc_unistd_unittests
@@ -631,6 +644,32 @@ add_libc_test(
     getpid_test.cpp
   DEPENDS
     libc.src.unistd.getpid
+)
+
+add_libc_test(
+  getpgid_test
+  SUITE
+    libc_unistd_unittests
+  SRCS
+    getpgid_test.cpp
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.src.unistd.getpgid
+    libc.src.unistd.getpid
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
+)
+
+add_libc_test(
+  getpgrp_test
+  SUITE
+    libc_unistd_unittests
+  SRCS
+    getpgrp_test.cpp
+  DEPENDS
+    libc.src.unistd.getpgid
+    libc.src.unistd.getpgrp
+    libc.test.UnitTest.ErrnoCheckingTest
 )
 
 add_libc_test(

--- a/libc/test/src/unistd/getpgid_test.cpp
+++ b/libc/test/src/unistd/getpgid_test.cpp
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for getpgid.
+///
+//===----------------------------------------------------------------------===//
+
+#include "hdr/errno_macros.h"
+#include "src/unistd/getpgid.h"
+#include "src/unistd/getpid.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/ErrnoSetterMatcher.h"
+#include "test/UnitTest/Test.h"
+
+using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcGetPgidTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcGetPgidTest, GetCurrPGID) {
+  pid_t pgid = LIBC_NAMESPACE::getpgid(0);
+  ASSERT_GT(pgid, 0);
+}
+
+TEST_F(LlvmLibcGetPgidTest, GetSelfPGID) {
+  pid_t pgid_zero = LIBC_NAMESPACE::getpgid(0);
+  pid_t pgid_self = LIBC_NAMESPACE::getpgid(LIBC_NAMESPACE::getpid());
+  ASSERT_GT(pgid_zero, 0);
+  ASSERT_EQ(pgid_zero, pgid_self);
+}
+
+TEST_F(LlvmLibcGetPgidTest, InvalidPID) {
+  ASSERT_THAT(LIBC_NAMESPACE::getpgid(-1), Fails<pid_t>(any_of(ESRCH, EINVAL)));
+}

--- a/libc/test/src/unistd/getpgrp_test.cpp
+++ b/libc/test/src/unistd/getpgrp_test.cpp
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for getpgrp.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/unistd/getpgid.h"
+#include "src/unistd/getpgrp.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcGetPgrpTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcGetPgrpTest, SmokeTest) {
+  // getpgrp() always succeeds. Simply check that it returns a sane value.
+  pid_t pgrp = LIBC_NAMESPACE::getpgrp();
+  ASSERT_GT(pgrp, 0);
+}
+
+TEST_F(LlvmLibcGetPgrpTest, MatchesGetPgidZero) {
+  // getpgrp() is equivalent to getpgid(0).
+  ASSERT_EQ(LIBC_NAMESPACE::getpgrp(), LIBC_NAMESPACE::getpgid(0));
+}

--- a/libc/test/src/unistd/setpgid_test.cpp
+++ b/libc/test/src/unistd/setpgid_test.cpp
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for setpgid.
+///
+//===----------------------------------------------------------------------===//
+
+#include "hdr/errno_macros.h"
+#include "src/unistd/setpgid.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/ErrnoSetterMatcher.h"
+#include "test/UnitTest/Test.h"
+
+using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcSetPgidTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcSetPgidTest, InvalidPid) {
+  ASSERT_THAT(LIBC_NAMESPACE::setpgid(-1, 0), Fails(any_of(ESRCH, EINVAL)));
+}
+
+TEST_F(LlvmLibcSetPgidTest, InvalidPgid) {
+  ASSERT_THAT(LIBC_NAMESPACE::setpgid(0, -1), Fails(EINVAL));
+}
+
+TEST_F(LlvmLibcSetPgidTest, SetpgidZero) {
+  // setpgid(0, 0) sets the process group ID of the calling process to its PID.
+  ASSERT_THAT(LIBC_NAMESPACE::setpgid(0, 0), Succeeds());
+}


### PR DESCRIPTION
* Add POSIX functions `getpgid`, `getpgrp`, and `setpgid` that get/set process group IDs. Defined them `<unistd.h>`
  header and add entrypoints on Linux platforms;
* Implement these functions on Linux as `getpgid`/`setpgid` syscall wrappers.
* Add unit test to sanity-check returned values and validate the expected `errno` values for invalid arguments. Given the
  simplicity of implementation, don't write fork-based tests to validate that the process group management works as
  expected on Linux machines.

Assisted by automated tooling, human-verified.