### PR TITLE
clang/AMDGPU: Fix a few tests codegening the dummy target

### DIFF
--- a/clang/test/CodeGenOpenCL/amdgpu-ieee.cl
+++ b/clang/test/CodeGenOpenCL/amdgpu-ieee.cl
@@ -1,30 +1,30 @@
 // REQUIRES: amdgpu-registered-target
 //
-// RUN: %clang_cc1 -triple amdgpu-amd-amdhsa -O0 -emit-llvm -o - %s \
+// RUN: %clang_cc1 -triple amdgpu7.00-amd-amdhsa -O0 -emit-llvm -o - %s \
 // RUN:   -target-feature +dx10-clamp-and-ieee-mode \
 // RUN:   | FileCheck -check-prefixes=COMMON,ON %s
-// RUN: %clang_cc1 -triple amdgpu-amd-amdhsa -O0 -emit-llvm -o - %s \
+// RUN: %clang_cc1 -triple amdgpu7.00-amd-amdhsa -O0 -emit-llvm -o - %s \
 // RUN:   -target-feature +dx10-clamp-and-ieee-mode \
 // RUN:   -mno-amdgpu-ieee -menable-no-nans \
 // RUN:   | FileCheck -check-prefixes=COMMON,OFF %s
-// RUN: %clang_cc1 -triple amdgpu-amd-amdhsa -O0 -emit-llvm -o - %s \
+// RUN: %clang_cc1 -triple amdgpu7.00-amd-amdhsa -O0 -emit-llvm -o - %s \
 // RUN:   -target-feature +dx10-clamp-and-ieee-mode \
 // RUN:   -mno-amdgpu-ieee -cl-fast-relaxed-math -menable-no-nans \
 // RUN:   | FileCheck -check-prefixes=COMMON,OFF %s
 
 // Check AMDGCN ISA generation.
 
-// RUN: %clang_cc1 -triple amdgpu-amd-amdhsa -O3 -S -o - %s \
+// RUN: %clang_cc1 -triple amdgpu7.00-amd-amdhsa -O3 -S -o - %s \
 // RUN:   -target-feature +dx10-clamp-and-ieee-mode \
 // RUN:   | FileCheck -check-prefixes=ISA-ON %s
-// RUN: %clang_cc1 -triple amdgpu-amd-amdhsa -O3 -S -o - %s \
+// RUN: %clang_cc1 -triple amdgpu7.00-amd-amdhsa -O3 -S -o - %s \
 // RUN:   -target-feature +dx10-clamp-and-ieee-mode \
 // RUN:   -mno-amdgpu-ieee -menable-no-nans \
 // RUN:   | FileCheck -check-prefixes=ISA-OFF %s
 
 // Check diagnostics when using -mno-amdgpu-ieee without NoHonorNaNs.
 
-// RUN: not %clang_cc1 -triple amdgpu-amd-amdhsa -O0 -emit-llvm -o - %s \
+// RUN: not %clang_cc1 -triple amdgpu7.00-amd-amdhsa -O0 -emit-llvm -o - %s \
 // RUN:   -mno-amdgpu-ieee 2>&1 | FileCheck -check-prefixes=DIAG %s
 
 // COMMON: define{{.*}} amdgpu_kernel void @kern{{.*}} [[ATTRS1:#[0-9]+]]

--- a/clang/test/CodeGenOpenCL/backend-unsupported-warning.ll
+++ b/clang/test/CodeGenOpenCL/backend-unsupported-warning.ll
@@ -1,12 +1,12 @@
 ; REQUIRES: amdgpu-registered-target
-; RUN: %clang_cc1 -triple amdgpu-amd-amdhsa -S -o - %s 2>&1 | FileCheck %s
+; RUN: %clang_cc1 -triple amdgpu7.00-amd-amdhsa -S -o - %s 2>&1 | FileCheck %s
 
 ; Check that a DiagnosticUnsupported reported as a warning works
 ; correctly, and is not emitted as an error.
 
 ; CHECK: warning: test.c:2:20: in function use_lds_global_in_func i32 (): local memory global used by non-kernel function
 
-target triple = "amdgcn-amd-amdhsa"
+target triple = "amdgpu7.00-amd-amdhsa"
 
 @lds = external addrspace(3) global i32, align 4
 


### PR DESCRIPTION
Use a real target triple name