### PR TITLE
clang/AMDGPU: Use -fsyntax-only in some builtin sema tests

### DIFF
--- a/clang/test/SemaOpenCL/builtins-amdgcn-error-wave64.cl
+++ b/clang/test/SemaOpenCL/builtins-amdgcn-error-wave64.cl
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -triple amdgpu-- -verify -S -o - %s
-// RUN: %clang_cc1 -triple amdgpu10.10-- -target-feature -wavefrontsize64 -verify -S -o - %s
-// RUN: %clang_cc1 -triple amdgpu10.10-- -verify -S -o - %s
+// RUN: %clang_cc1 -triple amdgpu-- -verify -fsyntax-only %s
+// RUN: %clang_cc1 -triple amdgpu10.10-- -target-feature -wavefrontsize64 -verify -fsyntax-only %s
+// RUN: %clang_cc1 -triple amdgpu10.10-- -verify -fsyntax-only %s
 
 // REQUIRES: amdgpu-registered-target
 

--- a/clang/test/SemaOpenCL/builtins-amdgcn-wave32-func-attr.cl
+++ b/clang/test/SemaOpenCL/builtins-amdgcn-wave32-func-attr.cl
@@ -1,8 +1,8 @@
-// RUN: %clang_cc1 -triple amdgpu-- -verify=default -S -o - %s
-// RUN: %clang_cc1 -triple amdgpu9.00-- -verify=gfx9 -S -o - %s
-// RUN: %clang_cc1 -triple amdgpu10.10-- -verify=gfx10 -S -o - %s
-// RUN: not %clang_cc1 -triple amdgpu9.00-- -target-feature -wavefrontsize32 -S -o - %s 2>&1 | FileCheck --check-prefix=GFX9 %s
-// RUN: %clang_cc1 -triple amdgpu10.10-- -target-feature -wavefrontsize32 -verify=gfx10 -S -o - %s
+// RUN: %clang_cc1 -triple amdgpu-- -verify=default -fsyntax-only %s
+// RUN: %clang_cc1 -triple amdgpu9.00-- -verify=gfx9 -fsyntax-only %s
+// RUN: %clang_cc1 -triple amdgpu10.10-- -verify=gfx10 -fsyntax-only %s
+// RUN: not %clang_cc1 -triple amdgpu9.00-- -target-feature -wavefrontsize32 -fsyntax-only %s 2>&1 | FileCheck --check-prefix=GFX9 %s
+// RUN: %clang_cc1 -triple amdgpu10.10-- -target-feature -wavefrontsize32 -verify=gfx10 -fsyntax-only %s
 
 // REQUIRES: amdgpu-registered-target
 


### PR DESCRIPTION
Avoid codegening in sema tests.