### PR TITLE
SystemZ: Avoid using operand parent in AssociatedDataAreaTable::insert

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZXPLINKAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZXPLINKAsmPrinter.cpp
@@ -107,15 +107,15 @@ SystemZXPLINKAsmPrinter::AssociatedDataAreaTable::insert(const MCSymbol *Sym,
 }
 
 uint32_t SystemZXPLINKAsmPrinter::AssociatedDataAreaTable::insert(
-    const MachineOperand MO) {
+    const MachineFunction &MF, const MachineOperand &MO) {
   MCSymbol *Sym;
   if (MO.getType() == MachineOperand::MO_GlobalAddress) {
     const GlobalValue *GV = MO.getGlobal();
-    Sym = MO.getParent()->getMF()->getTarget().getSymbol(GV);
+    Sym = MF.getTarget().getSymbol(GV);
     assert(Sym && "No symbol");
   } else if (MO.getType() == MachineOperand::MO_ExternalSymbol) {
     const char *SymName = MO.getSymbolName();
-    Sym = MO.getParent()->getMF()->getContext().getOrCreateSymbol(SymName);
+    Sym = MF.getContext().getOrCreateSymbol(SymName);
     assert(Sym && "No symbol");
   } else
     llvm_unreachable("Unexpected operand type");
@@ -169,7 +169,7 @@ void SystemZXPLINKAsmPrinter::emitInstruction(const MachineInstr *MI) {
   case SystemZ::ADA_ENTRY: {
     const SystemZSubtarget &Subtarget = MF->getSubtarget<SystemZSubtarget>();
     const SystemZInstrInfo *TII = Subtarget.getInstrInfo();
-    uint32_t Disp = ADATable.insert(MI->getOperand(1));
+    uint32_t Disp = ADATable.insert(*MF, MI->getOperand(1));
     Register TargetReg = MI->getOperand(0).getReg();
 
     Register ADAReg = MI->getOperand(2).getReg();

--- a/llvm/lib/Target/SystemZ/SystemZXPLINKAsmPrinter.h
+++ b/llvm/lib/Target/SystemZ/SystemZXPLINKAsmPrinter.h
@@ -23,7 +23,9 @@
 namespace llvm {
 class MCStreamer;
 class MCSymbolGOFF;
+class MachineFunction;
 class MachineInstr;
+class MachineOperand;
 class Module;
 class raw_ostream;
 
@@ -64,9 +66,10 @@ class LLVM_LIBRARY_VISIBILITY SystemZXPLINKAsmPrinter
     AssociatedDataAreaTable(uint64_t PointerSize) : PointerSize(PointerSize) {}
 
     /// @brief Add a function descriptor to the ADA.
-    /// @param MI Pointer to an ADA_ENTRY instruction.
+    /// @param MF The function containing the ADA_ENTRY instruction.
+    /// @param MO The operand describing the descriptor symbol.
     /// @return The displacement of the descriptor into the ADA.
-    uint32_t insert(const MachineOperand MO);
+    uint32_t insert(const MachineFunction &MF, const MachineOperand &MO);
 
     /// @brief Get the displacement into associated data area (ADA) for a name.
     /// If no displacement is already associated with the name, assign one and


### PR DESCRIPTION
Take the MachineFunction directly to reach the target and context
instead of recovering it through the operand's parent.

Co-authored-by: Claude (Claude-Opus-4.8)