### PR TITLE
[flang][cuda] Propagate CUDA attrs from parent variable to component deallocs

### DIFF
--- a/flang/lib/Lower/Allocatable.cpp
+++ b/flang/lib/Lower/Allocatable.cpp
@@ -1100,9 +1100,15 @@ void Fortran::lower::genDeallocateStmt(
               Fortran::lower::getTypeDescAddr(converter, loc, *derivedTypeSpec);
         }
     }
-    mlir::Value beginOpValue = genDeallocate(
-        builder, converter, loc, box, errorManager, declaredTypeDesc, &symbol,
-        getCUDAAttrParentSymbol(allocateObject));
+    // ALLOCATE gives the object's own attribute precedence over the parent's;
+    // both sides must match or the allocators differ.
+    const Fortran::semantics::Symbol *cudaSymbol = nullptr;
+    if (!Fortran::semantics::HasCUDAAttr(symbol) &&
+        !Fortran::semantics::HasCUDAComponent(symbol))
+      cudaSymbol = getCUDAAttrParentSymbol(allocateObject);
+    mlir::Value beginOpValue =
+        genDeallocate(builder, converter, loc, box, errorManager,
+                      declaredTypeDesc, &symbol, cudaSymbol);
     preDeallocationAction(converter, builder, beginOpValue, symbol);
   }
   builder.restoreInsertionPoint(insertPt);

--- a/flang/lib/Lower/Allocatable.cpp
+++ b/flang/lib/Lower/Allocatable.cpp
@@ -285,6 +285,52 @@ genMutableBoxValue(Fortran::lower::AbstractConverter &converter,
   return converter.genExprMutableBox(loc, *expr);
 }
 
+/// Search a DataRef for a symbol with CUDA attributes. Returns true and
+/// sets \p sym if found.
+static bool findCUDAAttrInDataRef(const Fortran::parser::DataRef &ref,
+                                  const Fortran::semantics::Symbol *&sym) {
+  return Fortran::common::visit(
+      Fortran::common::visitors{
+          [&](const Fortran::parser::Name &name) {
+            if (name.symbol && Fortran::semantics::HasCUDAAttr(*name.symbol)) {
+              sym = name.symbol;
+              return true;
+            }
+            return false;
+          },
+          [&](const Fortran::common::Indirection<
+              Fortran::parser::StructureComponent> &sc) {
+            if (sc.value().Component().symbol &&
+                Fortran::semantics::HasCUDAAttr(
+                    *sc.value().Component().symbol)) {
+              sym = sc.value().Component().symbol;
+              return true;
+            }
+            return findCUDAAttrInDataRef(sc.value().Base(), sym);
+          },
+          [&](const Fortran::common::Indirection<Fortran::parser::ArrayElement>
+                  &ae) {
+            return findCUDAAttrInDataRef(ae.value().Base(), sym);
+          },
+          [&](const Fortran::common::Indirection<
+              Fortran::parser::CoindexedNamedObject> &) { return false; },
+      },
+      ref.u);
+}
+
+/// When \p allocObj is a structure component (e.g. a%b%c), return the first
+/// parent carrying CUDA attributes, or nullptr when there is none.
+static const Fortran::semantics::Symbol *
+getCUDAAttrParentSymbol(const Fortran::parser::AllocateObject &allocObj) {
+  if (const auto *sc =
+          std::get_if<Fortran::parser::StructureComponent>(&allocObj.u)) {
+    const Fortran::semantics::Symbol *sym = nullptr;
+    if (findCUDAAttrInDataRef(sc->Base(), sym))
+      return sym;
+  }
+  return nullptr;
+}
+
 /// Implement Allocate statement lowering.
 class AllocateStmtHelper {
 public:
@@ -456,49 +502,17 @@ private:
     fir::StoreOp::create(builder, loc, falseConv, pinned);
   }
 
-  /// Search a DataRef for a symbol with CUDA attributes. Returns true and
-  /// sets \p sym if found.
-  static bool findCUDAAttrInDataRef(const Fortran::parser::DataRef &ref,
-                                    const Fortran::semantics::Symbol *&sym) {
-    return Fortran::common::visit(
-        Fortran::common::visitors{
-            [&](const Fortran::parser::Name &name) {
-              if (name.symbol &&
-                  Fortran::semantics::HasCUDAAttr(*name.symbol)) {
-                sym = name.symbol;
-                return true;
-              }
-              return false;
-            },
-            [&](const Fortran::common::Indirection<
-                Fortran::parser::StructureComponent> &sc) {
-              if (sc.value().Component().symbol &&
-                  Fortran::semantics::HasCUDAAttr(
-                      *sc.value().Component().symbol)) {
-                sym = sc.value().Component().symbol;
-                return true;
-              }
-              return findCUDAAttrInDataRef(sc.value().Base(), sym);
-            },
-            [&](const Fortran::common::Indirection<
-                Fortran::parser::ArrayElement> &ae) {
-              return findCUDAAttrInDataRef(ae.value().Base(), sym);
-            },
-            [&](const Fortran::common::Indirection<
-                Fortran::parser::CoindexedNamedObject> &) { return false; },
-        },
-        ref.u);
-  }
-
   /// When the allocate object is a structure component (e.g.,
   /// managed_var(1)%component or a%b%c), walk the DataRef chain and check
   /// whether any parent has CUDA attributes. If so, update \p sym to that
   /// symbol and return true so allocations use its memory space.
   bool propagateCUDAAttrsFromParent(const Allocation &alloc,
                                     const Fortran::semantics::Symbol *&sym) {
-    if (const auto *sc = std::get_if<Fortran::parser::StructureComponent>(
-            &alloc.getAllocObj().u))
-      return findCUDAAttrInDataRef(sc->Base(), sym);
+    if (const Fortran::semantics::Symbol *parent =
+            getCUDAAttrParentSymbol(alloc.getAllocObj())) {
+      sym = parent;
+      return true;
+    }
     return false;
   }
 
@@ -957,8 +971,14 @@ genDeallocate(fir::FirOpBuilder &builder,
               Fortran::lower::AbstractConverter &converter, mlir::Location loc,
               const fir::MutableBoxValue &box, ErrorManager &errorManager,
               mlir::Value declaredTypeDesc = {},
-              const Fortran::semantics::Symbol *symbol = nullptr) {
-  bool isCudaSymbol = symbol && Fortran::semantics::HasCUDAAttr(*symbol);
+              const Fortran::semantics::Symbol *symbol = nullptr,
+              const Fortran::semantics::Symbol *cudaSymbol = nullptr) {
+  // A component inherits its parent's memory space at ALLOCATE, so the
+  // deallocation must use the parent's attribute too.
+  if (!cudaSymbol)
+    cudaSymbol = symbol;
+  bool isCudaSymbol =
+      cudaSymbol && Fortran::semantics::HasCUDAAttr(*cudaSymbol);
   bool isCudaDeviceContext = cuf::isCUDADeviceContext(builder.getRegion());
   // A plain allocatable/pointer under -gpu=mem:unified was given the unified
   // allocator index at ALLOCATE, so its deallocation must go through the
@@ -1002,7 +1022,7 @@ genDeallocate(fir::FirOpBuilder &builder,
     stat =
         genRuntimeDeallocate(builder, loc, box, errorManager, declaredTypeDesc);
   else
-    stat = genCudaDeallocate(builder, loc, box, errorManager, *symbol);
+    stat = genCudaDeallocate(builder, loc, box, errorManager, *cudaSymbol);
   fir::factory::syncMutableBoxFromIRBox(builder, loc, box);
   if (symbol)
     postDeallocationAction(converter, builder, *symbol);
@@ -1081,7 +1101,8 @@ void Fortran::lower::genDeallocateStmt(
         }
     }
     mlir::Value beginOpValue = genDeallocate(
-        builder, converter, loc, box, errorManager, declaredTypeDesc, &symbol);
+        builder, converter, loc, box, errorManager, declaredTypeDesc, &symbol,
+        getCUDAAttrParentSymbol(allocateObject));
     preDeallocationAction(converter, builder, beginOpValue, symbol);
   }
   builder.restoreInsertionPoint(insertPt);

--- a/flang/test/Lower/CUDA/cuda-allocatable-component.cuf
+++ b/flang/test/Lower/CUDA/cuda-allocatable-component.cuf
@@ -1,7 +1,7 @@
 ! RUN: bbc -emit-hlfir -fcuda %s -o - | FileCheck %s
 
-! Test that allocating a component of a CUDA-attributed derived type variable
-! routes through the CUF allocator, not the default (host) allocator.
+! Test that allocating and deallocating a component of a CUDA-attributed derived
+! type variable routes through the CUF allocator, not the default (host) one.
 ! This ensures the component data lives in the same memory space as its parent.
 
 module m
@@ -10,6 +10,9 @@ module m
   end type
   type :: outer_device_type
     type(chunk_type), device, allocatable :: inner(:)
+  end type
+  type :: device_component_type
+    real(8), device, dimension(:,:), allocatable :: arr
   end type
 end module
 
@@ -103,6 +106,22 @@ subroutine device_component_dealloc()
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPdevice_component_dealloc()
+! CHECK: cuf.allocate %{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>> {data_attr = #cuf.cuda<device>} -> i32
+! CHECK-NOT: fir.freemem
+! CHECK: cuf.deallocate %{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>> {data_attr = #cuf.cuda<device>} -> i32
+
+! A component's own attribute wins over the parent's, on both sides.
+subroutine component_attr_wins_over_parent()
+  use m
+  type(device_component_type), managed, allocatable :: x(:)
+  allocate(x(1))
+  allocate(x(1)%arr(10,10))
+  deallocate(x(1)%arr)
+  deallocate(x)
+end subroutine
+
+! CHECK-LABEL: func.func @_QPcomponent_attr_wins_over_parent()
+! CHECK: fir.embox %{{.*}} {allocator_idx = 2 : i32}
 ! CHECK: cuf.allocate %{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>> {data_attr = #cuf.cuda<device>} -> i32
 ! CHECK-NOT: fir.freemem
 ! CHECK: cuf.deallocate %{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>> {data_attr = #cuf.cuda<device>} -> i32

--- a/flang/test/Lower/CUDA/cuda-allocatable-component.cuf
+++ b/flang/test/Lower/CUDA/cuda-allocatable-component.cuf
@@ -74,3 +74,35 @@ end subroutine
 ! CHECK: hlfir.designate %{{.*}}{"arr"} {{.*}} : {{.*}} -> !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>>
 ! CHECK: fir.embox %{{.*}} {allocator_idx = 2 : i32}
 ! CHECK: cuf.allocate %{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>> {data_attr = #cuf.cuda<device>} -> i32
+
+! Deallocating a component uses the parent's memory space.
+subroutine managed_component_dealloc()
+  use m
+  type(chunk_type), managed, allocatable :: chunks(:)
+  allocate(chunks(1))
+  allocate(chunks(1)%arr(10,10))
+  deallocate(chunks(1)%arr)
+  deallocate(chunks)
+end subroutine
+
+! CHECK-LABEL: func.func @_QPmanaged_component_dealloc()
+! CHECK: cuf.allocate %{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>> {data_attr = #cuf.cuda<managed>} -> i32
+! CHECK: hlfir.designate %{{.*}}{"arr"} {{.*}} : {{.*}} -> !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>>
+! CHECK-NOT: fir.freemem
+! CHECK: cuf.deallocate %{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>> {data_attr = #cuf.cuda<managed>} -> i32
+
+! Same for a device component reached through an intermediate parent.
+subroutine device_component_dealloc()
+  use m
+  type(outer_device_type), allocatable :: outer(:)
+  allocate(outer(1))
+  allocate(outer(1)%inner(1))
+  allocate(outer(1)%inner(1)%arr(10,10))
+  deallocate(outer(1)%inner(1)%arr)
+  deallocate(outer)
+end subroutine
+
+! CHECK-LABEL: func.func @_QPdevice_component_dealloc()
+! CHECK: cuf.allocate %{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>> {data_attr = #cuf.cuda<device>} -> i32
+! CHECK-NOT: fir.freemem
+! CHECK: cuf.deallocate %{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>> {data_attr = #cuf.cuda<device>} -> i32


### PR DESCRIPTION
This is a follow up to [#206614](https://github.com/llvm/llvm-project/pull/206614), which made `allocate(foo(i)%arr(...))` inherit `foo`'s CUDA memory attribute, but did not add the equivalent inheritance for `deallocate(foo(i)%arr)`. The deallocation still lowered to an inlined `fir.freemem`, so memory obtained from a CUDA allocator was released with libc `free()`.

The allocate side already walked the `DataRef` chain for a CUDA-attributed parent, but the helpers were private to `AllocateStmtHelper` and unreachable from the deallocate path. This patch hoists `findCUDAAttrInDataRef` to file scope, adds `getCUDAAttrParentSymbol(AllocateObject)` beside it, and reduces the existing member to a thin wrapper. The allocate behavior is unchanged.

`genDeallocate` gains an optional `cudaSymbol` used only for the CUDA decisions (`isCudaSymbol` and the `genCudaDeallocate` call). `genDeallocateStmt` supplies the parent symbol, which is non-null only for a structure component whose parent carries CUDA attributes.

Lowering now emits `cuf.deallocate ... {data_attr = #cuf.cuda<...>}` for the component where it previously emitted `fir.freemem`, with no `fir.freemem` remaining under `-gpu=managed`, `-gpu=pinned` or `-gpu=unified`.

Also extended test coverage in `cuda-allocatable-component.cuf` with a direct `managed` parent and a `device` attribute reached through an intermediate parent.
