### PR TITLE
[Clang] Fix false -Wformat-signedness for unsigned bit-field promotions

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -9430,10 +9430,21 @@ static bool isArithmeticArgumentPromotion(Sema &S,
   QualType To = ICE->getType();
   // It's an integer promotion if the destination type is the promoted
   // source type.
-  if (ICE->getCastKind() == CK_IntegralCast &&
-      S.Context.isPromotableIntegerType(From) &&
-      S.Context.getPromotedIntegerType(From) == To)
-    return true;
+  if (ICE->getCastKind() == CK_IntegralCast) {
+    if (S.Context.isPromotableIntegerType(From) &&
+        S.Context.getPromotedIntegerType(From) == To)
+      return true;
+    if (const auto *SubExpr = ICE->getSubExpr()) {
+      QualType Promoted =
+          S.Context.isPromotableBitField(const_cast<Expr *>(SubExpr));
+      if (!Promoted.isNull() && Promoted == To) {
+        QualType FromSigned = S.Context.getCorrespondingSignedType(From);
+        QualType ToSigned = S.Context.getCorrespondingSignedType(To);
+        if (S.Context.getIntegerTypeOrder(FromSigned, ToSigned) <= 0)
+          return true;
+      }
+    }
+  }
   // Look through vector types, since we do default argument promotion for
   // those in OpenCL.
   if (const auto *VecTy = From->getAs<ExtVectorType>())

--- a/clang/test/Sema/format-strings-signedness.c
+++ b/clang/test/Sema/format-strings-signedness.c
@@ -220,3 +220,13 @@ void test_suppress(int x)
 #pragma GCC diagnostic ignored "-Wformat"
     printf("%u", x);
 }
+
+struct {
+  unsigned int bf : 16;
+  unsigned char c;
+} s;
+
+void test_printf_bitfield(void) {
+  printf("%x\n", s.bf); // no-warning
+  printf("%x\n", s.c); // no-warning
+}


### PR DESCRIPTION
isArithmeticArgumentPromotion failed to recognize bit-field integer promotions. It only checked isPromotableIntegerType, which examines the type in isolation (unsigned int — not promotable), missing that a bit-field expression like unsigned int bf : 16 IS promotable to int when its width fits.

This caused a spurious -Wformat-signedness warning for printf("%x", s.bf) where s.bf is an unsigned int : 16 bit-field, while the equivalent printf("%x", s.c) for an unsigned char member was correctly silenced.

Fixes: https://github.com/llvm/llvm-project/issues/155665