### PR TITLE
[libc++][chrono] Use requires expression to populate tm_zone in __convert_to_tm

### DIFF
--- a/libcxx/include/__chrono/convert_to_tm.h
+++ b/libcxx/include/__chrono/convert_to_tm.h
@@ -69,9 +69,8 @@ template <class _Tm, class _Date>
   requires(same_as<_Date, chrono::year_month_day> || same_as<_Date, chrono::year_month_day_last>)
 _LIBCPP_HIDE_FROM_ABI _Tm __convert_to_tm(const _Date& __date, chrono::weekday __weekday) {
   _Tm __result = {};
-#  ifdef __GLIBC__
-  __result.tm_zone = "UTC";
-#  endif
+  if constexpr (requires { __result.tm_zone = const_cast<char*>("UTC"); })
+    __result.tm_zone = const_cast<char*>("UTC");
   __result.tm_year = static_cast<int>(__date.year()) - 1900;
   __result.tm_mon  = static_cast<unsigned>(__date.month()) - 1;
   __result.tm_mday = static_cast<unsigned>(__date.day());
@@ -141,9 +140,8 @@ _LIBCPP_HIDE_FROM_ABI _Tm __convert_to_tm(chrono::gps_time<_Duration> __tp) {
 template <class _Tm, class _ChronoT>
 _LIBCPP_HIDE_FROM_ABI _Tm __convert_to_tm(const _ChronoT& __value) {
   _Tm __result = {};
-#  ifdef __GLIBC__
-  __result.tm_zone = "UTC";
-#  endif
+  if constexpr (requires { __result.tm_zone = const_cast<char*>("UTC"); })
+    __result.tm_zone = const_cast<char*>("UTC");
 
   if constexpr (__is_time_point<_ChronoT>) {
     if constexpr (same_as<typename _ChronoT::clock, chrono::file_clock>)

--- a/libcxx/test/libcxx/time/convert_to_tm.pass.cpp
+++ b/libcxx/test/libcxx/time/convert_to_tm.pass.cpp
@@ -10,15 +10,19 @@
 
 // <chrono>
 
+// template <class _Tm, class _Date>
+// _LIBCPP_HIDE_FROM_ABI _Tm __convert_to_tm(const _Date& __date, chrono::weekday __weekday)
+//
 // template <class _Tm, class _ChronoT>
 // _LIBCPP_HIDE_FROM_ABI _Tm __convert_to_tm(const _ChronoT& __value)
 
-// Most of the code is tested indirectly in the chrono formatters. This only
-// tests the hour overflow.
+// Most of the code is tested indirectly in the chrono formatters. This tests
+// the hour overflow and setting tm_zone to "UTC" when supported.
 
 #include <__chrono/convert_to_tm.h>
 #include <chrono>
 #include <cassert>
+#include <ctime>
 #include <format>
 #include <string_view>
 
@@ -28,15 +32,40 @@
 // std::tm uses an int for its integral members. The overflow in the hour
 // conversion can only occur on platforms where sizeof(long) > sizeof(int).
 // Instead emulate this error by using a "tm" with shorts.
-// (The function is already templated to this is quite easy to do,)
+// (The function is already templated, so this is quite easy to do.)
 struct minimal_short_tm {
   short tm_sec;
   short tm_min;
   short tm_hour;
+};
+
+struct tm_with_const_zone {
+  int tm_sec;
+  int tm_min;
+  int tm_hour;
+  int tm_mday;
+  int tm_mon;
+  int tm_year;
+  int tm_wday;
+  int tm_yday;
+  int tm_isdst;
   const char* tm_zone;
 };
 
-int main(int, char**) {
+struct tm_with_char_zone {
+  int tm_sec;
+  int tm_min;
+  int tm_hour;
+  int tm_mday;
+  int tm_mon;
+  int tm_year;
+  int tm_wday;
+  int tm_yday;
+  int tm_isdst;
+  char* tm_zone;
+};
+
+static void test_hour_overflow() {
   { // Test with the maximum number of hours that fit in a short.
     std::chrono::hh_mm_ss time{std::chrono::hours{32767}};
     minimal_short_tm result = std::__convert_to_tm<minimal_short_tm>(time);
@@ -53,11 +82,126 @@ int main(int, char**) {
       assert(false);
     } catch ([[maybe_unused]] const std::format_error& e) {
       LIBCPP_ASSERT(e.what() == std::string_view("Formatting hh_mm_ss, encountered an hour overflow"));
-      return 0;
+      return;
     }
     assert(false);
   }
 #endif // TEST_HAS_NO_EXCEPTIONS
+}
+
+template <class Tm = std::tm>
+static void test_std_tm() {
+  using namespace std::chrono_literals;
+
+  {
+    auto date    = std::chrono::year_month_day{2023y, std::chrono::January, 1d};
+    auto weekday = std::chrono::Sunday;
+    Tm result    = std::__convert_to_tm<Tm>(date, weekday);
+    if constexpr (requires { result.tm_zone; }) {
+      assert(result.tm_zone != nullptr);
+      assert(std::string_view(result.tm_zone) == "UTC");
+    }
+  }
+  {
+    auto date = std::chrono::year_month_day{2023y, std::chrono::January, 1d};
+    Tm result = std::__convert_to_tm<Tm>(date);
+    if constexpr (requires { result.tm_zone; }) {
+      assert(result.tm_zone != nullptr);
+      assert(std::string_view(result.tm_zone) == "UTC");
+    }
+  }
+}
+
+static void test_tm_zone() {
+  using namespace std::chrono_literals;
+
+  // 1. Test __convert_to_tm(date, weekday) overload with tm_with_const_zone and tm_with_char_zone
+  {
+    auto date                 = std::chrono::year_month_day{2023y, std::chrono::January, 1d};
+    auto weekday              = std::chrono::Sunday;
+    tm_with_const_zone result = std::__convert_to_tm<tm_with_const_zone>(date, weekday);
+    assert(result.tm_zone != nullptr);
+    assert(std::string_view(result.tm_zone) == "UTC");
+  }
+  {
+    auto date                = std::chrono::year_month_day{2023y, std::chrono::January, 1d};
+    auto weekday             = std::chrono::Sunday;
+    tm_with_char_zone result = std::__convert_to_tm<tm_with_char_zone>(date, weekday);
+    assert(result.tm_zone != nullptr);
+    assert(std::string_view(result.tm_zone) == "UTC");
+  }
+
+  // 2. Test __convert_to_tm(value) overload with tm_with_const_zone and tm_with_char_zone
+  {
+    auto date                 = std::chrono::year_month_day{2023y, std::chrono::January, 1d};
+    tm_with_const_zone result = std::__convert_to_tm<tm_with_const_zone>(date);
+    assert(result.tm_zone != nullptr);
+    assert(std::string_view(result.tm_zone) == "UTC");
+  }
+  {
+    auto date                = std::chrono::year_month_day{2023y, std::chrono::January, 1d};
+    tm_with_char_zone result = std::__convert_to_tm<tm_with_char_zone>(date);
+    assert(result.tm_zone != nullptr);
+    assert(std::string_view(result.tm_zone) == "UTC");
+  }
+  {
+    std::chrono::sys_days tp  = std::chrono::year_month_day{2023y, std::chrono::January, 1d};
+    tm_with_const_zone result = std::__convert_to_tm<tm_with_const_zone>(tp);
+    assert(result.tm_zone != nullptr);
+    assert(std::string_view(result.tm_zone) == "UTC");
+  }
+  {
+    std::chrono::sys_days tp = std::chrono::year_month_day{2023y, std::chrono::January, 1d};
+    tm_with_char_zone result = std::__convert_to_tm<tm_with_char_zone>(tp);
+    assert(result.tm_zone != nullptr);
+    assert(std::string_view(result.tm_zone) == "UTC");
+  }
+  {
+    std::chrono::hh_mm_ss time{std::chrono::hours{12}};
+    tm_with_const_zone result = std::__convert_to_tm<tm_with_const_zone>(time);
+    assert(result.tm_zone != nullptr);
+    assert(std::string_view(result.tm_zone) == "UTC");
+  }
+  {
+    std::chrono::hh_mm_ss time{std::chrono::hours{12}};
+    tm_with_char_zone result = std::__convert_to_tm<tm_with_char_zone>(time);
+    assert(result.tm_zone != nullptr);
+    assert(std::string_view(result.tm_zone) == "UTC");
+  }
+
+  // 3. Test with std::tm (if std::tm has tm_zone on the target platform)
+  test_std_tm();
+
+  // 4. Test that a type without tm_zone continues to work
+  {
+    auto date    = std::chrono::year_month_day{2023y, std::chrono::January, 1d};
+    auto weekday = std::chrono::Sunday;
+    struct tm_without_zone {
+      int tm_sec;
+      int tm_min;
+      int tm_hour;
+      int tm_mday;
+      int tm_mon;
+      int tm_year;
+      int tm_wday;
+      int tm_yday;
+      int tm_isdst;
+    };
+    tm_without_zone result1 = std::__convert_to_tm<tm_without_zone>(date, weekday);
+    assert(result1.tm_year == 123);
+    assert(result1.tm_mon == 0);
+    assert(result1.tm_mday == 1);
+
+    tm_without_zone result2 = std::__convert_to_tm<tm_without_zone>(date);
+    assert(result2.tm_year == 123);
+    assert(result2.tm_mon == 0);
+    assert(result2.tm_mday == 1);
+  }
+}
+
+int main(int, char**) {
+  test_hour_overflow();
+  test_tm_zone();
 
   return 0;
 }


### PR DESCRIPTION
In __convert_to_tm, tm_zone was previously populated only when __GLIBC__
was defined, which was originally added to avoid compilation errors on
Windows (MSVC) where struct tm does not have a tm_zone member.

However, tm_zone is not specific to glibc; it is a standard BSD
extension (present in Bionic, musl, macOS/Darwin, FreeBSD, NetBSD,
OpenBSD, etc., and standardized in POSIX.1-2024). Guarding with
platforms like Bionic, causing strftime("%Z") to fall back to tzname.

Since convert_to_tm.h is C++20-only and __convert_to_tm is templated
on _Tm, replace #ifdef __GLIBC__ with requires expressions checking if
__result.tm_zone can be assigned const_cast<char*>("UTC"). This is
compatible with both const char* (glibc, Bionic, musl, macOS) and
char* (FreeBSD, OpenBSD) members without triggering -Wwrite-strings
under GCC. On platforms where struct tm lacks tm_zone (such as Windows
MSVC or AIX), the requires expression evaluates to false and
__result.tm_zone is untouched.

Also update minimal_short_tm in convert_to_tm.pass.cpp to remove the
workaround const char* tm_zone member, include `<ctime>`, and add tests
verifying that tm_zone is populated with "UTC" for both const char*
and char* member types (using a template test for std::tm so the tm_zone
check is cleanly discarded during instantiation on platforms without it).

Assisted-by: Gemini
