### PR TITLE
clang/AMDGPU: Diagnose invalid fence sync scope

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -14336,6 +14336,8 @@ def note_amdgpu_named_barrier_reason_inherited : Note<
 // AMDGCN builtins diagnostics
 def err_amdgcn_load_lds_size_invalid_value : Error<"invalid size value">;
 def note_amdgcn_load_lds_size_valid_value : Note<"size must be %select{1, 2, or 4|1, 2, 4, 12 or 16}0">;
+def err_invalid_sync_scope
+    : Error<"unsupported atomic synchronization scope '%0'">;
 def err_amdgcn_processor_is_arg_not_literal
     : Error<"the argument to __builtin_amdgcn_processor_is must be a string "
             "literal">;

--- a/clang/include/clang/Sema/SemaAMDGPU.h
+++ b/clang/include/clang/Sema/SemaAMDGPU.h
@@ -21,6 +21,7 @@ namespace clang {
 class AttributeCommonInfo;
 class Expr;
 class ParsedAttr;
+class TargetInfo;
 
 class SemaAMDGPU : public SemaBase {
   llvm::SmallPtrSet<Expr *, 32> ExpandedPredicates;
@@ -29,7 +30,8 @@ class SemaAMDGPU : public SemaBase {
 public:
   SemaAMDGPU(Sema &S);
 
-  bool CheckAMDGCNBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall);
+  bool CheckAMDGCNBuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
+                                      CallExpr *TheCall);
 
   /// Emits a diagnostic if the \p E is not an atomic ordering encoded in the C
   /// ABI format, or if the atomic ordering is not valid for the operation type

--- a/clang/lib/Sema/SemaAMDGPU.cpp
+++ b/clang/lib/Sema/SemaAMDGPU.cpp
@@ -27,6 +27,7 @@
 #include "llvm/Support/AMDGPUAddrSpace.h"
 #include "llvm/Support/AtomicOrdering.h"
 #include "llvm/TargetParser/AMDGPUTargetParser.h"
+#include "llvm/TargetParser/AtomicScope.h"
 #include <cstdint>
 #include <utility>
 
@@ -34,7 +35,8 @@ namespace clang {
 
 SemaAMDGPU::SemaAMDGPU(Sema &S) : SemaBase(S) {}
 
-bool SemaAMDGPU::CheckAMDGCNBuiltinFunctionCall(unsigned BuiltinID,
+bool SemaAMDGPU::CheckAMDGCNBuiltinFunctionCall(const TargetInfo &TI,
+                                                unsigned BuiltinID,
                                                 CallExpr *TheCall) {
   const auto *FD = SemaRef.getCurFunctionDecl(/*AllowLambda=*/true);
   assert(FD && "AMDGPU builtins should not be used outside of a function");
@@ -151,6 +153,15 @@ bool SemaAMDGPU::CheckAMDGCNBuiltinFunctionCall(unsigned BuiltinID,
     if (!ScopeExpr->EvaluateAsConstantExpr(ScopeResult, getASTContext()))
       return Diag(ScopeExpr->getExprLoc(), diag::err_expr_not_string_literal)
              << ScopeExpr->getType();
+
+    // Reject any string that is not a valid synchronization scope name.
+    std::optional<std::string> ScopeName =
+        ScopeExpr->tryEvaluateString(getASTContext());
+    const llvm::Triple &TT = TI.getTriple();
+    if (ScopeName && !llvm::parseAtomicScopeIRString(TT, *ScopeName)) {
+      return Diag(ScopeExpr->getExprLoc(), diag::err_invalid_sync_scope)
+             << *ScopeName << ScopeExpr->getSourceRange();
+    }
 
     return false;
   }

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -2314,7 +2314,7 @@ bool Sema::CheckTSBuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
   case llvm::Triple::ppc64le:
     return PPC().CheckPPCBuiltinFunctionCall(TI, BuiltinID, TheCall);
   case llvm::Triple::amdgpu:
-    return AMDGPU().CheckAMDGCNBuiltinFunctionCall(BuiltinID, TheCall);
+    return AMDGPU().CheckAMDGCNBuiltinFunctionCall(TI, BuiltinID, TheCall);
   case llvm::Triple::riscv32:
   case llvm::Triple::riscv64:
   case llvm::Triple::riscv32be:

--- a/clang/test/Sema/builtin-amdgcn-fence-failure.cpp
+++ b/clang/test/Sema/builtin-amdgcn-fence-failure.cpp
@@ -1,8 +1,6 @@
 // REQUIRES: amdgpu-registered-target
-// RUN: not %clang_cc1 %s -o - -S -triple=amdgpu-amd-amdhsa 2>&1 | FileCheck %s
+// RUN: %clang_cc1 %s -fsyntax-only -triple=amdgpu-amd-amdhsa -verify
 
 void test_amdgcn_fence_failure() {
-
-  // CHECK: error: Unsupported atomic synchronization scope
-  __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "foobar");
+  __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "foobar"); // expected-error {{unsupported atomic synchronization scope 'foobar'}}
 }

--- a/clang/test/SemaHIP/builtin-amdgcn-fence-scope.hip
+++ b/clang/test/SemaHIP/builtin-amdgcn-fence-scope.hip
@@ -1,0 +1,19 @@
+// REQUIRES: amdgpu-registered-target
+// RUN: %clang_cc1 -fsyntax-only -triple amdgpu7.00-amd-amdhsa -fcuda-is-device -verify %s
+// RUN: %clang_cc1 -fsyntax-only -triple x86_64-unknown-linux-gnu -aux-triple amdgpu7.00-amd-amdhsa -verify %s
+
+// Verify the synchronization scope name is validated against the AMDGPU target
+// on both the device compilation and host.
+
+#define __device__ __attribute__((device))
+
+__device__ void valid_scopes() {
+  __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "agent");
+  __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "workgroup");
+  __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "wavefront");
+  __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "");
+}
+
+__device__ void invalid_scope() {
+  __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "foobar"); // expected-error {{unsupported atomic synchronization scope 'foobar'}}
+}


### PR DESCRIPTION
Reject an unrecognized synchronization scope string passed to
__builtin_amdgcn_fence during semantic analysis instead of relying on
the backend to report it during codegen.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>