### PR TITLE
[RISCV][MC] Support CSR names in CFI directives

### DIFF
--- a/llvm/include/llvm/MC/MCParser/MCTargetAsmParser.h
+++ b/llvm/include/llvm/MC/MCParser/MCTargetAsmParser.h
@@ -408,6 +408,11 @@ public:
   virtual bool parseRegister(MCRegister &Reg, SMLoc &StartLoc,
                              SMLoc &EndLoc) = 0;
 
+  /// Parse a register operand in a CFI directive and return its DWARF register
+  /// number. Targets may override this to support register names which do not
+  /// have a corresponding LLVM register.
+  virtual bool parseCFIRegister(int64_t &Reg, SMLoc &StartLoc, SMLoc &EndLoc);
+
   /// tryParseRegister - parse one register if possible
   ///
   /// Check whether a register specification can be parsed at the current

--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -4309,12 +4309,10 @@ bool AsmParser::parseDirectiveCFIEndProc() {
 /// parse register name or number.
 bool AsmParser::parseRegisterOrRegisterNumber(int64_t &Register,
                                               SMLoc DirectiveLoc) {
-  MCRegister RegNo;
-
   if (getLexer().isNot(AsmToken::Integer)) {
-    if (getTargetParser().parseRegister(RegNo, DirectiveLoc, DirectiveLoc))
+    if (getTargetParser().parseCFIRegister(Register, DirectiveLoc,
+                                           DirectiveLoc))
       return true;
-    Register = getContext().getRegisterInfo()->getDwarfRegNum(RegNo, true);
   } else
     return parseAbsoluteExpression(Register);
 

--- a/llvm/lib/MC/MCParser/MCTargetAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/MCTargetAsmParser.cpp
@@ -10,6 +10,7 @@
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCObjectStreamer.h"
 #include "llvm/MC/MCRegister.h"
+#include "llvm/MC/MCRegisterInfo.h"
 
 using namespace llvm;
 
@@ -32,6 +33,15 @@ MCSubtargetInfo &MCTargetAsmParser::copySTI() {
 
 const MCSubtargetInfo &MCTargetAsmParser::getSTI() const {
   return *STI;
+}
+
+bool MCTargetAsmParser::parseCFIRegister(int64_t &Reg, SMLoc &StartLoc,
+                                         SMLoc &EndLoc) {
+  MCRegister LLVMReg;
+  if (parseRegister(LLVMReg, StartLoc, EndLoc))
+    return true;
+  Reg = getContext().getRegisterInfo()->getDwarfRegNum(LLVMReg, true);
+  return false;
 }
 
 ParseStatus MCTargetAsmParser::parseDirective(AsmToken DirectiveID) {

--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -120,6 +120,7 @@ class RISCVAsmParser : public MCTargetAsmParser {
 
   MCRegister matchRegisterNameHelper(StringRef Name) const;
   bool parseRegister(MCRegister &Reg, SMLoc &StartLoc, SMLoc &EndLoc) override;
+  bool parseCFIRegister(int64_t &Reg, SMLoc &StartLoc, SMLoc &EndLoc) override;
   ParseStatus tryParseRegister(MCRegister &Reg, SMLoc &StartLoc,
                                SMLoc &EndLoc) override;
 
@@ -1944,6 +1945,24 @@ bool RISCVAsmParser::parseRegister(MCRegister &Reg, SMLoc &StartLoc,
   if (!tryParseRegister(Reg, StartLoc, EndLoc).isSuccess())
     return Error(StartLoc, "invalid register name");
   return false;
+}
+
+bool RISCVAsmParser::parseCFIRegister(int64_t &Reg, SMLoc &StartLoc,
+                                      SMLoc &EndLoc) {
+  if (getLexer().is(AsmToken::Identifier)) {
+    const AsmToken &Tok = getParser().getTok();
+    if (const auto *SysReg =
+            RISCVSysReg::lookupSysRegByName(Tok.getIdentifier())) {
+      // RISC-V DWARF register numbers for CSRs start at 4096.
+      constexpr int64_t FirstCSRDwarfReg = 4096;
+      Reg = FirstCSRDwarfReg + SysReg->Encoding;
+      StartLoc = Tok.getLoc();
+      EndLoc = Tok.getEndLoc();
+      getParser().Lex();
+      return false;
+    }
+  }
+  return MCTargetAsmParser::parseCFIRegister(Reg, StartLoc, EndLoc);
 }
 
 ParseStatus RISCVAsmParser::tryParseRegister(MCRegister &Reg, SMLoc &StartLoc,

--- a/llvm/test/MC/RISCV/cfi-regs-valid.s
+++ b/llvm/test/MC/RISCV/cfi-regs-valid.s
@@ -69,6 +69,17 @@
 .cfi_endproc
 
 .cfi_startproc
+# CHECK: .cfi_register 64, 4929
+.cfi_register 64, mepc
+# CHECK: .cfi_return_column 4930
+.cfi_return_column mcause
+# CHECK: .cfi_same_value 4416
+.cfi_same_value sscratch
+# CHECK: .cfi_same_value 4099
+.cfi_same_value fcsr
+.cfi_endproc
+
+.cfi_startproc
 # CHECK: .cfi_offset zero, 0
 .cfi_offset zero, 0
 # CHECK: .cfi_offset ra, 8


### PR DESCRIPTION
RISC-V assigns DWARF register numbers 4096 through 8191 to CSRs by adding 4096 to the CSR encoding. The assembler currently parses named CFI operands only as LLVM physical registers, so directives such as `.cfi_register 64, mepc` fail and users must write the raw value `4929` instead. Some CSR names that also exist as LLVM registers, such as `fcsr`, are accepted but resolve to the missing-mapping sentinel `-1` instead of their specified DWARF register number.

Add a target parser hook for CFI register operands and use RISC-V's generated system-register table to resolve CSR names to their standardized DWARF register numbers. The default implementation preserves the existing behavior for other targets.

This fills a gap between two existing pieces of support: named CFI operands are resolved through `MCRegister`, while RISC-V CSR names are modeled separately as system operands. It also avoids adding every CSR to the target register model merely to make its name usable in CFI.

GNU `as`, the assembler used by GCC toolchains, already supports named RISC-V CSRs in CFI directives through its target-specific `tc_riscv_regname_to_dw2regnum` hook. It maps CSR names to `4096 + CSR encoding`; the binutils test suite checks, for example, that `.cfi_offset mepc, ...` encodes DWARF register 4929. Matching that behavior improves source compatibility between the GNU and LLVM assemblers.

Tests cover multiple CSRs and CFI directives on RV32 and RV64.

Tested with:

```
ninja -C build check-llvm-mc
```

## AI tool use

This PR was developed with assistance from OpenAI Codex using the GPT-5.6-sol model with xhigh reasoning effort. The tool assisted with inspecting the motivating downstream change and LLVM history, designing and implementing the parser change, adding tests, running local validation, and drafting this description. The author reviewed the resulting change and remains responsible for its correctness and ongoing review.
