### PR TITLE
[RISCV] Disable register overlap for vector indexed loads.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoVPseudos.td
@@ -1898,9 +1898,10 @@ multiclass VPseudoILoad<bit Ordered> {
           defvar idxEMUL = !cast<LMULInfo>("V_" # IdxLInfo);
           defvar Vreg = dataEMUL.vrclass;
           defvar IdxVreg = idxEMUL.vrclass;
-          defvar HasConstraint = !ne(dataEEW, idxEEW);
-          defvar TypeConstraints = 
-            !if(!eq(dataEEW, idxEEW), 1, !if(!gt(dataEEW, idxEEW), !if(!ge(idxEMULOctuple, 8), 3, 1), 2));
+          // Don't allow overlapping registers even though it's allowed by the
+          // spec due to hardware issue on some CPUs.
+          defvar HasConstraint = true;
+          defvar TypeConstraints = 1;
           let VLMul = dataEMUL.value in {
             def "EI" # idxEEW # "_V_" # IdxLInfo # "_" # DataLInfo :
               VPseudoILoadNoMask<Vreg, IdxVreg, idxEEW, idxEMUL.value, Ordered, HasConstraint, TypeConstraints>,

--- a/llvm/test/CodeGen/RISCV/GlobalISel/rvv/vloxei-rv64.ll
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/rvv/vloxei-rv64.ll
@@ -416,7 +416,8 @@ define <vscale x 1 x i64> @intrinsic_vloxei_v_nxv1i64_nxv1i64_nxv1i64(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv1i64_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m1, ta, ma
-; CHECK-NEXT:    vloxei64.v v8, (a0), v8
+; CHECK-NEXT:    vloxei64.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x i64> @llvm.riscv.vloxei.nxv1i64.nxv1i64(
@@ -449,7 +450,8 @@ define <vscale x 2 x i64> @intrinsic_vloxei_v_nxv2i64_nxv2i64_nxv2i64(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv2i64_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m2, ta, ma
-; CHECK-NEXT:    vloxei64.v v8, (a0), v8
+; CHECK-NEXT:    vloxei64.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x i64> @llvm.riscv.vloxei.nxv2i64.nxv2i64(
@@ -482,7 +484,8 @@ define <vscale x 4 x i64> @intrinsic_vloxei_v_nxv4i64_nxv4i64_nxv4i64(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv4i64_nxv4i64_nxv4i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m4, ta, ma
-; CHECK-NEXT:    vloxei64.v v8, (a0), v8
+; CHECK-NEXT:    vloxei64.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x i64> @llvm.riscv.vloxei.nxv4i64.nxv4i64(
@@ -515,7 +518,8 @@ define <vscale x 8 x i64> @intrinsic_vloxei_v_nxv8i64_nxv8i64_nxv8i64(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv8i64_nxv8i64_nxv8i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; CHECK-NEXT:    vloxei64.v v8, (a0), v8
+; CHECK-NEXT:    vloxei64.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x i64> @llvm.riscv.vloxei.nxv8i64.nxv8i64(
@@ -820,7 +824,8 @@ define <vscale x 1 x double> @intrinsic_vloxei_v_nxv1f64_nxv1f64_nxv1i64(ptr %0,
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv1f64_nxv1f64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m1, ta, ma
-; CHECK-NEXT:    vloxei64.v v8, (a0), v8
+; CHECK-NEXT:    vloxei64.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x double> @llvm.riscv.vloxei.nxv1f64.nxv1i64(
@@ -853,7 +858,8 @@ define <vscale x 2 x double> @intrinsic_vloxei_v_nxv2f64_nxv2f64_nxv2i64(ptr %0,
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv2f64_nxv2f64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m2, ta, ma
-; CHECK-NEXT:    vloxei64.v v8, (a0), v8
+; CHECK-NEXT:    vloxei64.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x double> @llvm.riscv.vloxei.nxv2f64.nxv2i64(
@@ -886,7 +892,8 @@ define <vscale x 4 x double> @intrinsic_vloxei_v_nxv4f64_nxv4f64_nxv4i64(ptr %0,
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv4f64_nxv4f64_nxv4i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m4, ta, ma
-; CHECK-NEXT:    vloxei64.v v8, (a0), v8
+; CHECK-NEXT:    vloxei64.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x double> @llvm.riscv.vloxei.nxv4f64.nxv4i64(
@@ -919,7 +926,8 @@ define <vscale x 8 x double> @intrinsic_vloxei_v_nxv8f64_nxv8f64_nxv8i64(ptr %0,
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv8f64_nxv8f64_nxv8i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; CHECK-NEXT:    vloxei64.v v8, (a0), v8
+; CHECK-NEXT:    vloxei64.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x double> @llvm.riscv.vloxei.nxv8f64.nxv8i64(

--- a/llvm/test/CodeGen/RISCV/GlobalISel/rvv/vloxei.ll
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/rvv/vloxei.ll
@@ -348,7 +348,8 @@ define <vscale x 1 x i32> @intrinsic_vloxei_v_nxv1i32_nxv1i32_nxv1i32(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv1i32_nxv1i32_nxv1i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, mf2, ta, ma
-; CHECK-NEXT:    vloxei32.v v8, (a0), v8
+; CHECK-NEXT:    vloxei32.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x i32> @llvm.riscv.vloxei.nxv1i32.nxv1i32(
@@ -381,7 +382,8 @@ define <vscale x 2 x i32> @intrinsic_vloxei_v_nxv2i32_nxv2i32_nxv2i32(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv2i32_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m1, ta, ma
-; CHECK-NEXT:    vloxei32.v v8, (a0), v8
+; CHECK-NEXT:    vloxei32.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x i32> @llvm.riscv.vloxei.nxv2i32.nxv2i32(
@@ -414,7 +416,8 @@ define <vscale x 4 x i32> @intrinsic_vloxei_v_nxv4i32_nxv4i32_nxv4i32(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv4i32_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m2, ta, ma
-; CHECK-NEXT:    vloxei32.v v8, (a0), v8
+; CHECK-NEXT:    vloxei32.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x i32> @llvm.riscv.vloxei.nxv4i32.nxv4i32(
@@ -447,7 +450,8 @@ define <vscale x 8 x i32> @intrinsic_vloxei_v_nxv8i32_nxv8i32_nxv8i32(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv8i32_nxv8i32_nxv8i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m4, ta, ma
-; CHECK-NEXT:    vloxei32.v v8, (a0), v8
+; CHECK-NEXT:    vloxei32.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x i32> @llvm.riscv.vloxei.nxv8i32.nxv8i32(
@@ -480,7 +484,8 @@ define <vscale x 16 x i32> @intrinsic_vloxei_v_nxv16i32_nxv16i32_nxv16i32(ptr %0
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv16i32_nxv16i32_nxv16i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, ta, ma
-; CHECK-NEXT:    vloxei32.v v8, (a0), v8
+; CHECK-NEXT:    vloxei32.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x i32> @llvm.riscv.vloxei.nxv16i32.nxv16i32(
@@ -822,7 +827,8 @@ define <vscale x 1 x float> @intrinsic_vloxei_v_nxv1f32_nxv1f32_nxv1i32(ptr %0, 
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv1f32_nxv1f32_nxv1i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, mf2, ta, ma
-; CHECK-NEXT:    vloxei32.v v8, (a0), v8
+; CHECK-NEXT:    vloxei32.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x float> @llvm.riscv.vloxei.nxv1f32.nxv1i32(
@@ -855,7 +861,8 @@ define <vscale x 2 x float> @intrinsic_vloxei_v_nxv2f32_nxv2f32_nxv2i32(ptr %0, 
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv2f32_nxv2f32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m1, ta, ma
-; CHECK-NEXT:    vloxei32.v v8, (a0), v8
+; CHECK-NEXT:    vloxei32.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x float> @llvm.riscv.vloxei.nxv2f32.nxv2i32(
@@ -888,7 +895,8 @@ define <vscale x 4 x float> @intrinsic_vloxei_v_nxv4f32_nxv4f32_nxv4i32(ptr %0, 
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv4f32_nxv4f32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m2, ta, ma
-; CHECK-NEXT:    vloxei32.v v8, (a0), v8
+; CHECK-NEXT:    vloxei32.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x float> @llvm.riscv.vloxei.nxv4f32.nxv4i32(
@@ -921,7 +929,8 @@ define <vscale x 8 x float> @intrinsic_vloxei_v_nxv8f32_nxv8f32_nxv8i32(ptr %0, 
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv8f32_nxv8f32_nxv8i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m4, ta, ma
-; CHECK-NEXT:    vloxei32.v v8, (a0), v8
+; CHECK-NEXT:    vloxei32.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x float> @llvm.riscv.vloxei.nxv8f32.nxv8i32(
@@ -954,7 +963,8 @@ define <vscale x 16 x float> @intrinsic_vloxei_v_nxv16f32_nxv16f32_nxv16i32(ptr 
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv16f32_nxv16f32_nxv16i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, ta, ma
-; CHECK-NEXT:    vloxei32.v v8, (a0), v8
+; CHECK-NEXT:    vloxei32.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x float> @llvm.riscv.vloxei.nxv16f32.nxv16i32(
@@ -1330,7 +1340,8 @@ define <vscale x 1 x i16> @intrinsic_vloxei_v_nxv1i16_nxv1i16_nxv1i16(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv1i16_nxv1i16_nxv1i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, mf4, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x i16> @llvm.riscv.vloxei.nxv1i16.nxv1i16(
@@ -1363,7 +1374,8 @@ define <vscale x 2 x i16> @intrinsic_vloxei_v_nxv2i16_nxv2i16_nxv2i16(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv2i16_nxv2i16_nxv2i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, mf2, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x i16> @llvm.riscv.vloxei.nxv2i16.nxv2i16(
@@ -1396,7 +1408,8 @@ define <vscale x 4 x i16> @intrinsic_vloxei_v_nxv4i16_nxv4i16_nxv4i16(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv4i16_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m1, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x i16> @llvm.riscv.vloxei.nxv4i16.nxv4i16(
@@ -1429,7 +1442,8 @@ define <vscale x 8 x i16> @intrinsic_vloxei_v_nxv8i16_nxv8i16_nxv8i16(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv8i16_nxv8i16_nxv8i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m2, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x i16> @llvm.riscv.vloxei.nxv8i16.nxv8i16(
@@ -1462,7 +1476,8 @@ define <vscale x 16 x i16> @intrinsic_vloxei_v_nxv16i16_nxv16i16_nxv16i16(ptr %0
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv16i16_nxv16i16_nxv16i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m4, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x i16> @llvm.riscv.vloxei.nxv16i16.nxv16i16(
@@ -1495,7 +1510,8 @@ define <vscale x 32 x i16> @intrinsic_vloxei_v_nxv32i16_nxv32i16_nxv32i16(ptr %0
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv32i16_nxv32i16_nxv32i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m8, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 32 x i16> @llvm.riscv.vloxei.nxv32i16.nxv32i16(
@@ -1840,7 +1856,8 @@ define <vscale x 1 x half> @intrinsic_vloxei_v_nxv1f16_nxv1f16_nxv1i16(ptr %0, <
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv1f16_nxv1f16_nxv1i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, mf4, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x half> @llvm.riscv.vloxei.nxv1f16.nxv1i16(
@@ -1873,7 +1890,8 @@ define <vscale x 2 x half> @intrinsic_vloxei_v_nxv2f16_nxv2f16_nxv2i16(ptr %0, <
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv2f16_nxv2f16_nxv2i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, mf2, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x half> @llvm.riscv.vloxei.nxv2f16.nxv2i16(
@@ -1906,7 +1924,8 @@ define <vscale x 4 x half> @intrinsic_vloxei_v_nxv4f16_nxv4f16_nxv4i16(ptr %0, <
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv4f16_nxv4f16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m1, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x half> @llvm.riscv.vloxei.nxv4f16.nxv4i16(
@@ -1939,7 +1958,8 @@ define <vscale x 8 x half> @intrinsic_vloxei_v_nxv8f16_nxv8f16_nxv8i16(ptr %0, <
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv8f16_nxv8f16_nxv8i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m2, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x half> @llvm.riscv.vloxei.nxv8f16.nxv8i16(
@@ -1972,7 +1992,8 @@ define <vscale x 16 x half> @intrinsic_vloxei_v_nxv16f16_nxv16f16_nxv16i16(ptr %
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv16f16_nxv16f16_nxv16i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m4, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x half> @llvm.riscv.vloxei.nxv16f16.nxv16i16(
@@ -2005,7 +2026,8 @@ define <vscale x 32 x half> @intrinsic_vloxei_v_nxv32f16_nxv32f16_nxv32i16(ptr %
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv32f16_nxv32f16_nxv32i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m8, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 32 x half> @llvm.riscv.vloxei.nxv32f16.nxv32i16(
@@ -2350,7 +2372,8 @@ define <vscale x 1 x i8> @intrinsic_vloxei_v_nxv1i8_nxv1i8_nxv1i8(ptr %0, <vscal
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv1i8_nxv1i8_nxv1i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, mf8, ta, ma
-; CHECK-NEXT:    vloxei8.v v8, (a0), v8
+; CHECK-NEXT:    vloxei8.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x i8> @llvm.riscv.vloxei.nxv1i8.nxv1i8(
@@ -2383,7 +2406,8 @@ define <vscale x 2 x i8> @intrinsic_vloxei_v_nxv2i8_nxv2i8_nxv2i8(ptr %0, <vscal
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv2i8_nxv2i8_nxv2i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, mf4, ta, ma
-; CHECK-NEXT:    vloxei8.v v8, (a0), v8
+; CHECK-NEXT:    vloxei8.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x i8> @llvm.riscv.vloxei.nxv2i8.nxv2i8(
@@ -2416,7 +2440,8 @@ define <vscale x 4 x i8> @intrinsic_vloxei_v_nxv4i8_nxv4i8_nxv4i8(ptr %0, <vscal
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv4i8_nxv4i8_nxv4i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, mf2, ta, ma
-; CHECK-NEXT:    vloxei8.v v8, (a0), v8
+; CHECK-NEXT:    vloxei8.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x i8> @llvm.riscv.vloxei.nxv4i8.nxv4i8(
@@ -2449,7 +2474,8 @@ define <vscale x 8 x i8> @intrinsic_vloxei_v_nxv8i8_nxv8i8_nxv8i8(ptr %0, <vscal
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv8i8_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-NEXT:    vloxei8.v v8, (a0), v8
+; CHECK-NEXT:    vloxei8.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x i8> @llvm.riscv.vloxei.nxv8i8.nxv8i8(
@@ -2482,7 +2508,8 @@ define <vscale x 16 x i8> @intrinsic_vloxei_v_nxv16i8_nxv16i8_nxv16i8(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv16i8_nxv16i8_nxv16i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, m2, ta, ma
-; CHECK-NEXT:    vloxei8.v v8, (a0), v8
+; CHECK-NEXT:    vloxei8.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x i8> @llvm.riscv.vloxei.nxv16i8.nxv16i8(
@@ -2515,7 +2542,8 @@ define <vscale x 32 x i8> @intrinsic_vloxei_v_nxv32i8_nxv32i8_nxv32i8(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv32i8_nxv32i8_nxv32i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, m4, ta, ma
-; CHECK-NEXT:    vloxei8.v v8, (a0), v8
+; CHECK-NEXT:    vloxei8.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 32 x i8> @llvm.riscv.vloxei.nxv32i8.nxv32i8(
@@ -2548,7 +2576,8 @@ define <vscale x 64 x i8> @intrinsic_vloxei_v_nxv64i8_nxv64i8_nxv64i8(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv64i8_nxv64i8_nxv64i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, m8, ta, ma
-; CHECK-NEXT:    vloxei8.v v8, (a0), v8
+; CHECK-NEXT:    vloxei8.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 64 x i8> @llvm.riscv.vloxei.nxv64i8.nxv64i8(

--- a/llvm/test/CodeGen/RISCV/GlobalISel/rvv/vluxei-rv64.ll
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/rvv/vluxei-rv64.ll
@@ -416,7 +416,8 @@ define <vscale x 1 x i64> @intrinsic_vluxei_v_nxv1i64_nxv1i64_nxv1i64(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv1i64_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m1, ta, ma
-; CHECK-NEXT:    vluxei64.v v8, (a0), v8
+; CHECK-NEXT:    vluxei64.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x i64> @llvm.riscv.vluxei.nxv1i64.nxv1i64(
@@ -449,7 +450,8 @@ define <vscale x 2 x i64> @intrinsic_vluxei_v_nxv2i64_nxv2i64_nxv2i64(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv2i64_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m2, ta, ma
-; CHECK-NEXT:    vluxei64.v v8, (a0), v8
+; CHECK-NEXT:    vluxei64.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x i64> @llvm.riscv.vluxei.nxv2i64.nxv2i64(
@@ -482,7 +484,8 @@ define <vscale x 4 x i64> @intrinsic_vluxei_v_nxv4i64_nxv4i64_nxv4i64(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv4i64_nxv4i64_nxv4i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m4, ta, ma
-; CHECK-NEXT:    vluxei64.v v8, (a0), v8
+; CHECK-NEXT:    vluxei64.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x i64> @llvm.riscv.vluxei.nxv4i64.nxv4i64(
@@ -515,7 +518,8 @@ define <vscale x 8 x i64> @intrinsic_vluxei_v_nxv8i64_nxv8i64_nxv8i64(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv8i64_nxv8i64_nxv8i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; CHECK-NEXT:    vluxei64.v v8, (a0), v8
+; CHECK-NEXT:    vluxei64.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x i64> @llvm.riscv.vluxei.nxv8i64.nxv8i64(
@@ -820,7 +824,8 @@ define <vscale x 1 x double> @intrinsic_vluxei_v_nxv1f64_nxv1f64_nxv1i64(ptr %0,
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv1f64_nxv1f64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m1, ta, ma
-; CHECK-NEXT:    vluxei64.v v8, (a0), v8
+; CHECK-NEXT:    vluxei64.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x double> @llvm.riscv.vluxei.nxv1f64.nxv1i64(
@@ -853,7 +858,8 @@ define <vscale x 2 x double> @intrinsic_vluxei_v_nxv2f64_nxv2f64_nxv2i64(ptr %0,
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv2f64_nxv2f64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m2, ta, ma
-; CHECK-NEXT:    vluxei64.v v8, (a0), v8
+; CHECK-NEXT:    vluxei64.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x double> @llvm.riscv.vluxei.nxv2f64.nxv2i64(
@@ -886,7 +892,8 @@ define <vscale x 4 x double> @intrinsic_vluxei_v_nxv4f64_nxv4f64_nxv4i64(ptr %0,
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv4f64_nxv4f64_nxv4i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m4, ta, ma
-; CHECK-NEXT:    vluxei64.v v8, (a0), v8
+; CHECK-NEXT:    vluxei64.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x double> @llvm.riscv.vluxei.nxv4f64.nxv4i64(
@@ -919,7 +926,8 @@ define <vscale x 8 x double> @intrinsic_vluxei_v_nxv8f64_nxv8f64_nxv8i64(ptr %0,
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv8f64_nxv8f64_nxv8i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; CHECK-NEXT:    vluxei64.v v8, (a0), v8
+; CHECK-NEXT:    vluxei64.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x double> @llvm.riscv.vluxei.nxv8f64.nxv8i64(

--- a/llvm/test/CodeGen/RISCV/GlobalISel/rvv/vluxei.ll
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/rvv/vluxei.ll
@@ -348,7 +348,8 @@ define <vscale x 1 x i32> @intrinsic_vluxei_v_nxv1i32_nxv1i32_nxv1i32(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv1i32_nxv1i32_nxv1i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, mf2, ta, ma
-; CHECK-NEXT:    vluxei32.v v8, (a0), v8
+; CHECK-NEXT:    vluxei32.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x i32> @llvm.riscv.vluxei.nxv1i32.nxv1i32(
@@ -381,7 +382,8 @@ define <vscale x 2 x i32> @intrinsic_vluxei_v_nxv2i32_nxv2i32_nxv2i32(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv2i32_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m1, ta, ma
-; CHECK-NEXT:    vluxei32.v v8, (a0), v8
+; CHECK-NEXT:    vluxei32.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x i32> @llvm.riscv.vluxei.nxv2i32.nxv2i32(
@@ -414,7 +416,8 @@ define <vscale x 4 x i32> @intrinsic_vluxei_v_nxv4i32_nxv4i32_nxv4i32(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv4i32_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m2, ta, ma
-; CHECK-NEXT:    vluxei32.v v8, (a0), v8
+; CHECK-NEXT:    vluxei32.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x i32> @llvm.riscv.vluxei.nxv4i32.nxv4i32(
@@ -447,7 +450,8 @@ define <vscale x 8 x i32> @intrinsic_vluxei_v_nxv8i32_nxv8i32_nxv8i32(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv8i32_nxv8i32_nxv8i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m4, ta, ma
-; CHECK-NEXT:    vluxei32.v v8, (a0), v8
+; CHECK-NEXT:    vluxei32.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x i32> @llvm.riscv.vluxei.nxv8i32.nxv8i32(
@@ -480,7 +484,8 @@ define <vscale x 16 x i32> @intrinsic_vluxei_v_nxv16i32_nxv16i32_nxv16i32(ptr %0
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv16i32_nxv16i32_nxv16i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, ta, ma
-; CHECK-NEXT:    vluxei32.v v8, (a0), v8
+; CHECK-NEXT:    vluxei32.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x i32> @llvm.riscv.vluxei.nxv16i32.nxv16i32(
@@ -822,7 +827,8 @@ define <vscale x 1 x float> @intrinsic_vluxei_v_nxv1f32_nxv1f32_nxv1i32(ptr %0, 
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv1f32_nxv1f32_nxv1i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, mf2, ta, ma
-; CHECK-NEXT:    vluxei32.v v8, (a0), v8
+; CHECK-NEXT:    vluxei32.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x float> @llvm.riscv.vluxei.nxv1f32.nxv1i32(
@@ -855,7 +861,8 @@ define <vscale x 2 x float> @intrinsic_vluxei_v_nxv2f32_nxv2f32_nxv2i32(ptr %0, 
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv2f32_nxv2f32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m1, ta, ma
-; CHECK-NEXT:    vluxei32.v v8, (a0), v8
+; CHECK-NEXT:    vluxei32.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x float> @llvm.riscv.vluxei.nxv2f32.nxv2i32(
@@ -888,7 +895,8 @@ define <vscale x 4 x float> @intrinsic_vluxei_v_nxv4f32_nxv4f32_nxv4i32(ptr %0, 
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv4f32_nxv4f32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m2, ta, ma
-; CHECK-NEXT:    vluxei32.v v8, (a0), v8
+; CHECK-NEXT:    vluxei32.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x float> @llvm.riscv.vluxei.nxv4f32.nxv4i32(
@@ -921,7 +929,8 @@ define <vscale x 8 x float> @intrinsic_vluxei_v_nxv8f32_nxv8f32_nxv8i32(ptr %0, 
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv8f32_nxv8f32_nxv8i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m4, ta, ma
-; CHECK-NEXT:    vluxei32.v v8, (a0), v8
+; CHECK-NEXT:    vluxei32.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x float> @llvm.riscv.vluxei.nxv8f32.nxv8i32(
@@ -954,7 +963,8 @@ define <vscale x 16 x float> @intrinsic_vluxei_v_nxv16f32_nxv16f32_nxv16i32(ptr 
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv16f32_nxv16f32_nxv16i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, ta, ma
-; CHECK-NEXT:    vluxei32.v v8, (a0), v8
+; CHECK-NEXT:    vluxei32.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x float> @llvm.riscv.vluxei.nxv16f32.nxv16i32(
@@ -1330,7 +1340,8 @@ define <vscale x 1 x i16> @intrinsic_vluxei_v_nxv1i16_nxv1i16_nxv1i16(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv1i16_nxv1i16_nxv1i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, mf4, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x i16> @llvm.riscv.vluxei.nxv1i16.nxv1i16(
@@ -1363,7 +1374,8 @@ define <vscale x 2 x i16> @intrinsic_vluxei_v_nxv2i16_nxv2i16_nxv2i16(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv2i16_nxv2i16_nxv2i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, mf2, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x i16> @llvm.riscv.vluxei.nxv2i16.nxv2i16(
@@ -1396,7 +1408,8 @@ define <vscale x 4 x i16> @intrinsic_vluxei_v_nxv4i16_nxv4i16_nxv4i16(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv4i16_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m1, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x i16> @llvm.riscv.vluxei.nxv4i16.nxv4i16(
@@ -1429,7 +1442,8 @@ define <vscale x 8 x i16> @intrinsic_vluxei_v_nxv8i16_nxv8i16_nxv8i16(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv8i16_nxv8i16_nxv8i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m2, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x i16> @llvm.riscv.vluxei.nxv8i16.nxv8i16(
@@ -1462,7 +1476,8 @@ define <vscale x 16 x i16> @intrinsic_vluxei_v_nxv16i16_nxv16i16_nxv16i16(ptr %0
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv16i16_nxv16i16_nxv16i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m4, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x i16> @llvm.riscv.vluxei.nxv16i16.nxv16i16(
@@ -1495,7 +1510,8 @@ define <vscale x 32 x i16> @intrinsic_vluxei_v_nxv32i16_nxv32i16_nxv32i16(ptr %0
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv32i16_nxv32i16_nxv32i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m8, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 32 x i16> @llvm.riscv.vluxei.nxv32i16.nxv32i16(
@@ -1840,7 +1856,8 @@ define <vscale x 1 x half> @intrinsic_vluxei_v_nxv1f16_nxv1f16_nxv1i16(ptr %0, <
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv1f16_nxv1f16_nxv1i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, mf4, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x half> @llvm.riscv.vluxei.nxv1f16.nxv1i16(
@@ -1873,7 +1890,8 @@ define <vscale x 2 x half> @intrinsic_vluxei_v_nxv2f16_nxv2f16_nxv2i16(ptr %0, <
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv2f16_nxv2f16_nxv2i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, mf2, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x half> @llvm.riscv.vluxei.nxv2f16.nxv2i16(
@@ -1906,7 +1924,8 @@ define <vscale x 4 x half> @intrinsic_vluxei_v_nxv4f16_nxv4f16_nxv4i16(ptr %0, <
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv4f16_nxv4f16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m1, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x half> @llvm.riscv.vluxei.nxv4f16.nxv4i16(
@@ -1939,7 +1958,8 @@ define <vscale x 8 x half> @intrinsic_vluxei_v_nxv8f16_nxv8f16_nxv8i16(ptr %0, <
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv8f16_nxv8f16_nxv8i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m2, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x half> @llvm.riscv.vluxei.nxv8f16.nxv8i16(
@@ -1972,7 +1992,8 @@ define <vscale x 16 x half> @intrinsic_vluxei_v_nxv16f16_nxv16f16_nxv16i16(ptr %
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv16f16_nxv16f16_nxv16i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m4, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x half> @llvm.riscv.vluxei.nxv16f16.nxv16i16(
@@ -2005,7 +2026,8 @@ define <vscale x 32 x half> @intrinsic_vluxei_v_nxv32f16_nxv32f16_nxv32i16(ptr %
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv32f16_nxv32f16_nxv32i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m8, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 32 x half> @llvm.riscv.vluxei.nxv32f16.nxv32i16(
@@ -2350,7 +2372,8 @@ define <vscale x 1 x i8> @intrinsic_vluxei_v_nxv1i8_nxv1i8_nxv1i8(ptr %0, <vscal
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv1i8_nxv1i8_nxv1i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, mf8, ta, ma
-; CHECK-NEXT:    vluxei8.v v8, (a0), v8
+; CHECK-NEXT:    vluxei8.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x i8> @llvm.riscv.vluxei.nxv1i8.nxv1i8(
@@ -2383,7 +2406,8 @@ define <vscale x 2 x i8> @intrinsic_vluxei_v_nxv2i8_nxv2i8_nxv2i8(ptr %0, <vscal
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv2i8_nxv2i8_nxv2i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, mf4, ta, ma
-; CHECK-NEXT:    vluxei8.v v8, (a0), v8
+; CHECK-NEXT:    vluxei8.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x i8> @llvm.riscv.vluxei.nxv2i8.nxv2i8(
@@ -2416,7 +2440,8 @@ define <vscale x 4 x i8> @intrinsic_vluxei_v_nxv4i8_nxv4i8_nxv4i8(ptr %0, <vscal
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv4i8_nxv4i8_nxv4i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, mf2, ta, ma
-; CHECK-NEXT:    vluxei8.v v8, (a0), v8
+; CHECK-NEXT:    vluxei8.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x i8> @llvm.riscv.vluxei.nxv4i8.nxv4i8(
@@ -2449,7 +2474,8 @@ define <vscale x 8 x i8> @intrinsic_vluxei_v_nxv8i8_nxv8i8_nxv8i8(ptr %0, <vscal
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv8i8_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-NEXT:    vluxei8.v v8, (a0), v8
+; CHECK-NEXT:    vluxei8.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x i8> @llvm.riscv.vluxei.nxv8i8.nxv8i8(
@@ -2482,7 +2508,8 @@ define <vscale x 16 x i8> @intrinsic_vluxei_v_nxv16i8_nxv16i8_nxv16i8(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv16i8_nxv16i8_nxv16i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, m2, ta, ma
-; CHECK-NEXT:    vluxei8.v v8, (a0), v8
+; CHECK-NEXT:    vluxei8.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x i8> @llvm.riscv.vluxei.nxv16i8.nxv16i8(
@@ -2515,7 +2542,8 @@ define <vscale x 32 x i8> @intrinsic_vluxei_v_nxv32i8_nxv32i8_nxv32i8(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv32i8_nxv32i8_nxv32i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, m4, ta, ma
-; CHECK-NEXT:    vluxei8.v v8, (a0), v8
+; CHECK-NEXT:    vluxei8.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 32 x i8> @llvm.riscv.vluxei.nxv32i8.nxv32i8(
@@ -2548,7 +2576,8 @@ define <vscale x 64 x i8> @intrinsic_vluxei_v_nxv64i8_nxv64i8_nxv64i8(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv64i8_nxv64i8_nxv64i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, m8, ta, ma
-; CHECK-NEXT:    vluxei8.v v8, (a0), v8
+; CHECK-NEXT:    vluxei8.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 64 x i8> @llvm.riscv.vluxei.nxv64i8.nxv64i8(

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-masked-gather.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-masked-gather.ll
@@ -2205,7 +2205,8 @@ define <4 x i32> @mgather_truemask_v4i32(<4 x ptr> %ptrs, <4 x i32> %passthru) {
 ; RV32-LABEL: mgather_truemask_v4i32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (zero), v8
+; RV32-NEXT:    vluxei32.v v9, (zero), v8
+; RV32-NEXT:    vmv.v.v v8, v9
 ; RV32-NEXT:    ret
 ;
 ; RV64V-LABEL: mgather_truemask_v4i32:
@@ -3620,7 +3621,8 @@ define <4 x i64> @mgather_truemask_v4i64(<4 x ptr> %ptrs, <4 x i64> %passthru) {
 ; RV64V-LABEL: mgather_truemask_v4i64:
 ; RV64V:       # %bb.0:
 ; RV64V-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
-; RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; RV64V-NEXT:    vluxei64.v v10, (zero), v8
+; RV64V-NEXT:    vmv.v.v v8, v10
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVE32F-LABEL: mgather_truemask_v4i64:
@@ -9358,7 +9360,8 @@ define <4 x float> @mgather_truemask_v4f32(<4 x ptr> %ptrs, <4 x float> %passthr
 ; RV32-LABEL: mgather_truemask_v4f32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (zero), v8
+; RV32-NEXT:    vluxei32.v v9, (zero), v8
+; RV32-NEXT:    vmv.v.v v8, v9
 ; RV32-NEXT:    ret
 ;
 ; RV64V-LABEL: mgather_truemask_v4f32:
@@ -10739,7 +10742,8 @@ define <4 x double> @mgather_truemask_v4f64(<4 x ptr> %ptrs, <4 x double> %passt
 ; RV64V-LABEL: mgather_truemask_v4f64:
 ; RV64V:       # %bb.0:
 ; RV64V-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
-; RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; RV64V-NEXT:    vluxei64.v v10, (zero), v8
+; RV64V-NEXT:    vmv.v.v v8, v10
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVE32F-LABEL: mgather_truemask_v4f64:
@@ -13913,8 +13917,8 @@ define <4 x i32> @mgather_narrow_edge_case(ptr %base) {
 ; RV32-NEXT:    vmv.v.i v0, 5
 ; RV32-NEXT:    li a1, -512
 ; RV32-NEXT:    vmv.v.x v8, a1
-; RV32-NEXT:    vmerge.vim v8, v8, 0, v0
-; RV32-NEXT:    vluxei32.v v8, (a0), v8
+; RV32-NEXT:    vmerge.vim v9, v8, 0, v0
+; RV32-NEXT:    vluxei32.v v8, (a0), v9
 ; RV32-NEXT:    ret
 ;
 ; RV64V-LABEL: mgather_narrow_edge_case:

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vpgather.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vpgather.ll
@@ -557,7 +557,8 @@ define <2 x i32> @vpgather_v2i32(<2 x ptr> %ptrs, <2 x i1> %m, i32 zeroext %evl)
 ; RV32-LABEL: vpgather_v2i32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (zero), v8, v0.t
+; RV32-NEXT:    vluxei32.v v9, (zero), v8, v0.t
+; RV32-NEXT:    vmv1r.v v8, v9
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_v2i32:
@@ -616,7 +617,8 @@ define <4 x i32> @vpgather_v4i32(<4 x ptr> %ptrs, <4 x i1> %m, i32 zeroext %evl)
 ; RV32-LABEL: vpgather_v4i32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (zero), v8, v0.t
+; RV32-NEXT:    vluxei32.v v9, (zero), v8, v0.t
+; RV32-NEXT:    vmv.v.v v8, v9
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_v4i32:
@@ -633,7 +635,8 @@ define <4 x i32> @vpgather_truemask_v4i32(<4 x ptr> %ptrs, i32 zeroext %evl) {
 ; RV32-LABEL: vpgather_truemask_v4i32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (zero), v8
+; RV32-NEXT:    vluxei32.v v9, (zero), v8
+; RV32-NEXT:    vmv.v.v v8, v9
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_truemask_v4i32:
@@ -650,7 +653,8 @@ define <8 x i32> @vpgather_v8i32(<8 x ptr> %ptrs, <8 x i1> %m, i32 zeroext %evl)
 ; RV32-LABEL: vpgather_v8i32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (zero), v8, v0.t
+; RV32-NEXT:    vluxei32.v v10, (zero), v8, v0.t
+; RV32-NEXT:    vmv.v.v v8, v10
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_v8i32:
@@ -668,9 +672,9 @@ define <8 x i32> @vpgather_baseidx_v8i8_v8i32(ptr %base, <8 x i8> %idxs, <8 x i1
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; RV32-NEXT:    vsext.vf4 v10, v8
-; RV32-NEXT:    vsll.vi v8, v10, 2
+; RV32-NEXT:    vsll.vi v10, v10, 2
 ; RV32-NEXT:    vsetvli zero, a1, e32, m2, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (a0), v8, v0.t
+; RV32-NEXT:    vluxei32.v v8, (a0), v10, v0.t
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_baseidx_v8i8_v8i32:
@@ -691,9 +695,9 @@ define <8 x i32> @vpgather_baseidx_sext_v8i8_v8i32(ptr %base, <8 x i8> %idxs, <8
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; RV32-NEXT:    vsext.vf4 v10, v8
-; RV32-NEXT:    vsll.vi v8, v10, 2
+; RV32-NEXT:    vsll.vi v10, v10, 2
 ; RV32-NEXT:    vsetvli zero, a1, e32, m2, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (a0), v8, v0.t
+; RV32-NEXT:    vluxei32.v v8, (a0), v10, v0.t
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_baseidx_sext_v8i8_v8i32:
@@ -809,9 +813,9 @@ define <8 x i32> @vpgather_baseidx_v8i32(ptr %base, <8 x i32> %idxs, <8 x i1> %m
 ; RV32-LABEL: vpgather_baseidx_v8i32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV32-NEXT:    vsll.vi v8, v8, 2
+; RV32-NEXT:    vsll.vi v10, v8, 2
 ; RV32-NEXT:    vsetvli zero, a1, e32, m2, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (a0), v8, v0.t
+; RV32-NEXT:    vluxei32.v v8, (a0), v10, v0.t
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_baseidx_v8i32:
@@ -838,7 +842,8 @@ define <2 x i64> @vpgather_v2i64(<2 x ptr> %ptrs, <2 x i1> %m, i32 zeroext %evl)
 ; RV64-LABEL: vpgather_v2i64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (zero), v8, v0.t
+; RV64-NEXT:    vluxei64.v v9, (zero), v8, v0.t
+; RV64-NEXT:    vmv.v.v v8, v9
 ; RV64-NEXT:    ret
   %v = call <2 x i64> @llvm.vp.gather.v2i64.v2p0(<2 x ptr> %ptrs, <2 x i1> %m, i32 %evl)
   ret <2 x i64> %v
@@ -856,7 +861,8 @@ define <4 x i64> @vpgather_v4i64(<4 x ptr> %ptrs, <4 x i1> %m, i32 zeroext %evl)
 ; RV64-LABEL: vpgather_v4i64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (zero), v8, v0.t
+; RV64-NEXT:    vluxei64.v v10, (zero), v8, v0.t
+; RV64-NEXT:    vmv.v.v v8, v10
 ; RV64-NEXT:    ret
   %v = call <4 x i64> @llvm.vp.gather.v4i64.v4p0(<4 x ptr> %ptrs, <4 x i1> %m, i32 %evl)
   ret <4 x i64> %v
@@ -874,7 +880,8 @@ define <4 x i64> @vpgather_truemask_v4i64(<4 x ptr> %ptrs, i32 zeroext %evl) {
 ; RV64-LABEL: vpgather_truemask_v4i64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (zero), v8
+; RV64-NEXT:    vluxei64.v v10, (zero), v8
+; RV64-NEXT:    vmv.v.v v8, v10
 ; RV64-NEXT:    ret
   %v = call <4 x i64> @llvm.vp.gather.v4i64.v4p0(<4 x ptr> %ptrs, <4 x i1> splat (i1 1), i32 %evl)
   ret <4 x i64> %v
@@ -892,7 +899,8 @@ define <8 x i64> @vpgather_v8i64(<8 x ptr> %ptrs, <8 x i1> %m, i32 zeroext %evl)
 ; RV64-LABEL: vpgather_v8i64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (zero), v8, v0.t
+; RV64-NEXT:    vluxei64.v v12, (zero), v8, v0.t
+; RV64-NEXT:    vmv.v.v v8, v12
 ; RV64-NEXT:    ret
   %v = call <8 x i64> @llvm.vp.gather.v8i64.v8p0(<8 x ptr> %ptrs, <8 x i1> %m, i32 %evl)
   ret <8 x i64> %v
@@ -912,9 +920,9 @@ define <8 x i64> @vpgather_baseidx_v8i8_v8i64(ptr %base, <8 x i8> %idxs, <8 x i1
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetivli zero, 8, e64, m4, ta, ma
 ; RV64-NEXT:    vsext.vf8 v12, v8
-; RV64-NEXT:    vsll.vi v8, v12, 3
+; RV64-NEXT:    vsll.vi v12, v12, 3
 ; RV64-NEXT:    vsetvli zero, a1, e64, m4, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vluxei64.v v8, (a0), v12, v0.t
 ; RV64-NEXT:    ret
   %ptrs = getelementptr inbounds i64, ptr %base, <8 x i8> %idxs
   %v = call <8 x i64> @llvm.vp.gather.v8i64.v8p0(<8 x ptr> %ptrs, <8 x i1> %m, i32 %evl)
@@ -935,9 +943,9 @@ define <8 x i64> @vpgather_baseidx_sext_v8i8_v8i64(ptr %base, <8 x i8> %idxs, <8
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetivli zero, 8, e64, m4, ta, ma
 ; RV64-NEXT:    vsext.vf8 v12, v8
-; RV64-NEXT:    vsll.vi v8, v12, 3
+; RV64-NEXT:    vsll.vi v12, v12, 3
 ; RV64-NEXT:    vsetvli zero, a1, e64, m4, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vluxei64.v v8, (a0), v12, v0.t
 ; RV64-NEXT:    ret
   %eidxs = sext <8 x i8> %idxs to <8 x i64>
   %ptrs = getelementptr inbounds i64, ptr %base, <8 x i64> %eidxs
@@ -983,9 +991,9 @@ define <8 x i64> @vpgather_baseidx_v8i16_v8i64(ptr %base, <8 x i16> %idxs, <8 x 
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetivli zero, 8, e64, m4, ta, ma
 ; RV64-NEXT:    vsext.vf4 v12, v8
-; RV64-NEXT:    vsll.vi v8, v12, 3
+; RV64-NEXT:    vsll.vi v12, v12, 3
 ; RV64-NEXT:    vsetvli zero, a1, e64, m4, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vluxei64.v v8, (a0), v12, v0.t
 ; RV64-NEXT:    ret
   %ptrs = getelementptr inbounds i64, ptr %base, <8 x i16> %idxs
   %v = call <8 x i64> @llvm.vp.gather.v8i64.v8p0(<8 x ptr> %ptrs, <8 x i1> %m, i32 %evl)
@@ -1006,9 +1014,9 @@ define <8 x i64> @vpgather_baseidx_sext_v8i16_v8i64(ptr %base, <8 x i16> %idxs, 
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetivli zero, 8, e64, m4, ta, ma
 ; RV64-NEXT:    vsext.vf4 v12, v8
-; RV64-NEXT:    vsll.vi v8, v12, 3
+; RV64-NEXT:    vsll.vi v12, v12, 3
 ; RV64-NEXT:    vsetvli zero, a1, e64, m4, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vluxei64.v v8, (a0), v12, v0.t
 ; RV64-NEXT:    ret
   %eidxs = sext <8 x i16> %idxs to <8 x i64>
   %ptrs = getelementptr inbounds i64, ptr %base, <8 x i64> %eidxs
@@ -1121,9 +1129,9 @@ define <8 x i64> @vpgather_baseidx_v8i64(ptr %base, <8 x i64> %idxs, <8 x i1> %m
 ; RV64-LABEL: vpgather_baseidx_v8i64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetivli zero, 8, e64, m4, ta, ma
-; RV64-NEXT:    vsll.vi v8, v8, 3
+; RV64-NEXT:    vsll.vi v12, v8, 3
 ; RV64-NEXT:    vsetvli zero, a1, e64, m4, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vluxei64.v v8, (a0), v12, v0.t
 ; RV64-NEXT:    ret
   %ptrs = getelementptr inbounds i64, ptr %base, <8 x i64> %idxs
   %v = call <8 x i64> @llvm.vp.gather.v8i64.v8p0(<8 x ptr> %ptrs, <8 x i1> %m, i32 %evl)
@@ -1460,7 +1468,8 @@ define <2 x float> @vpgather_v2f32(<2 x ptr> %ptrs, <2 x i1> %m, i32 zeroext %ev
 ; RV32-LABEL: vpgather_v2f32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (zero), v8, v0.t
+; RV32-NEXT:    vluxei32.v v9, (zero), v8, v0.t
+; RV32-NEXT:    vmv1r.v v8, v9
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_v2f32:
@@ -1477,7 +1486,8 @@ define <4 x float> @vpgather_v4f32(<4 x ptr> %ptrs, <4 x i1> %m, i32 zeroext %ev
 ; RV32-LABEL: vpgather_v4f32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (zero), v8, v0.t
+; RV32-NEXT:    vluxei32.v v9, (zero), v8, v0.t
+; RV32-NEXT:    vmv.v.v v8, v9
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_v4f32:
@@ -1494,7 +1504,8 @@ define <4 x float> @vpgather_truemask_v4f32(<4 x ptr> %ptrs, i32 zeroext %evl) {
 ; RV32-LABEL: vpgather_truemask_v4f32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (zero), v8
+; RV32-NEXT:    vluxei32.v v9, (zero), v8
+; RV32-NEXT:    vmv.v.v v8, v9
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_truemask_v4f32:
@@ -1511,7 +1522,8 @@ define <8 x float> @vpgather_v8f32(<8 x ptr> %ptrs, <8 x i1> %m, i32 zeroext %ev
 ; RV32-LABEL: vpgather_v8f32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (zero), v8, v0.t
+; RV32-NEXT:    vluxei32.v v10, (zero), v8, v0.t
+; RV32-NEXT:    vmv.v.v v8, v10
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_v8f32:
@@ -1529,9 +1541,9 @@ define <8 x float> @vpgather_baseidx_v8i8_v8f32(ptr %base, <8 x i8> %idxs, <8 x 
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; RV32-NEXT:    vsext.vf4 v10, v8
-; RV32-NEXT:    vsll.vi v8, v10, 2
+; RV32-NEXT:    vsll.vi v10, v10, 2
 ; RV32-NEXT:    vsetvli zero, a1, e32, m2, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (a0), v8, v0.t
+; RV32-NEXT:    vluxei32.v v8, (a0), v10, v0.t
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_baseidx_v8i8_v8f32:
@@ -1552,9 +1564,9 @@ define <8 x float> @vpgather_baseidx_sext_v8i8_v8f32(ptr %base, <8 x i8> %idxs, 
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; RV32-NEXT:    vsext.vf4 v10, v8
-; RV32-NEXT:    vsll.vi v8, v10, 2
+; RV32-NEXT:    vsll.vi v10, v10, 2
 ; RV32-NEXT:    vsetvli zero, a1, e32, m2, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (a0), v8, v0.t
+; RV32-NEXT:    vluxei32.v v8, (a0), v10, v0.t
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_baseidx_sext_v8i8_v8f32:
@@ -1670,9 +1682,9 @@ define <8 x float> @vpgather_baseidx_v8f32(ptr %base, <8 x i32> %idxs, <8 x i1> 
 ; RV32-LABEL: vpgather_baseidx_v8f32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV32-NEXT:    vsll.vi v8, v8, 2
+; RV32-NEXT:    vsll.vi v10, v8, 2
 ; RV32-NEXT:    vsetvli zero, a1, e32, m2, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (a0), v8, v0.t
+; RV32-NEXT:    vluxei32.v v8, (a0), v10, v0.t
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_baseidx_v8f32:
@@ -1699,7 +1711,8 @@ define <2 x double> @vpgather_v2f64(<2 x ptr> %ptrs, <2 x i1> %m, i32 zeroext %e
 ; RV64-LABEL: vpgather_v2f64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (zero), v8, v0.t
+; RV64-NEXT:    vluxei64.v v9, (zero), v8, v0.t
+; RV64-NEXT:    vmv.v.v v8, v9
 ; RV64-NEXT:    ret
   %v = call <2 x double> @llvm.vp.gather.v2f64.v2p0(<2 x ptr> %ptrs, <2 x i1> %m, i32 %evl)
   ret <2 x double> %v
@@ -1717,7 +1730,8 @@ define <4 x double> @vpgather_v4f64(<4 x ptr> %ptrs, <4 x i1> %m, i32 zeroext %e
 ; RV64-LABEL: vpgather_v4f64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (zero), v8, v0.t
+; RV64-NEXT:    vluxei64.v v10, (zero), v8, v0.t
+; RV64-NEXT:    vmv.v.v v8, v10
 ; RV64-NEXT:    ret
   %v = call <4 x double> @llvm.vp.gather.v4f64.v4p0(<4 x ptr> %ptrs, <4 x i1> %m, i32 %evl)
   ret <4 x double> %v
@@ -1735,7 +1749,8 @@ define <4 x double> @vpgather_truemask_v4f64(<4 x ptr> %ptrs, i32 zeroext %evl) 
 ; RV64-LABEL: vpgather_truemask_v4f64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (zero), v8
+; RV64-NEXT:    vluxei64.v v10, (zero), v8
+; RV64-NEXT:    vmv.v.v v8, v10
 ; RV64-NEXT:    ret
   %v = call <4 x double> @llvm.vp.gather.v4f64.v4p0(<4 x ptr> %ptrs, <4 x i1> splat (i1 1), i32 %evl)
   ret <4 x double> %v
@@ -1753,7 +1768,8 @@ define <8 x double> @vpgather_v8f64(<8 x ptr> %ptrs, <8 x i1> %m, i32 zeroext %e
 ; RV64-LABEL: vpgather_v8f64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (zero), v8, v0.t
+; RV64-NEXT:    vluxei64.v v12, (zero), v8, v0.t
+; RV64-NEXT:    vmv.v.v v8, v12
 ; RV64-NEXT:    ret
   %v = call <8 x double> @llvm.vp.gather.v8f64.v8p0(<8 x ptr> %ptrs, <8 x i1> %m, i32 %evl)
   ret <8 x double> %v
@@ -1773,9 +1789,9 @@ define <8 x double> @vpgather_baseidx_v8i8_v8f64(ptr %base, <8 x i8> %idxs, <8 x
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetivli zero, 8, e64, m4, ta, ma
 ; RV64-NEXT:    vsext.vf8 v12, v8
-; RV64-NEXT:    vsll.vi v8, v12, 3
+; RV64-NEXT:    vsll.vi v12, v12, 3
 ; RV64-NEXT:    vsetvli zero, a1, e64, m4, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vluxei64.v v8, (a0), v12, v0.t
 ; RV64-NEXT:    ret
   %ptrs = getelementptr inbounds double, ptr %base, <8 x i8> %idxs
   %v = call <8 x double> @llvm.vp.gather.v8f64.v8p0(<8 x ptr> %ptrs, <8 x i1> %m, i32 %evl)
@@ -1796,9 +1812,9 @@ define <8 x double> @vpgather_baseidx_sext_v8i8_v8f64(ptr %base, <8 x i8> %idxs,
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetivli zero, 8, e64, m4, ta, ma
 ; RV64-NEXT:    vsext.vf8 v12, v8
-; RV64-NEXT:    vsll.vi v8, v12, 3
+; RV64-NEXT:    vsll.vi v12, v12, 3
 ; RV64-NEXT:    vsetvli zero, a1, e64, m4, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vluxei64.v v8, (a0), v12, v0.t
 ; RV64-NEXT:    ret
   %eidxs = sext <8 x i8> %idxs to <8 x i64>
   %ptrs = getelementptr inbounds double, ptr %base, <8 x i64> %eidxs
@@ -1844,9 +1860,9 @@ define <8 x double> @vpgather_baseidx_v8i16_v8f64(ptr %base, <8 x i16> %idxs, <8
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetivli zero, 8, e64, m4, ta, ma
 ; RV64-NEXT:    vsext.vf4 v12, v8
-; RV64-NEXT:    vsll.vi v8, v12, 3
+; RV64-NEXT:    vsll.vi v12, v12, 3
 ; RV64-NEXT:    vsetvli zero, a1, e64, m4, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vluxei64.v v8, (a0), v12, v0.t
 ; RV64-NEXT:    ret
   %ptrs = getelementptr inbounds double, ptr %base, <8 x i16> %idxs
   %v = call <8 x double> @llvm.vp.gather.v8f64.v8p0(<8 x ptr> %ptrs, <8 x i1> %m, i32 %evl)
@@ -1867,9 +1883,9 @@ define <8 x double> @vpgather_baseidx_sext_v8i16_v8f64(ptr %base, <8 x i16> %idx
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetivli zero, 8, e64, m4, ta, ma
 ; RV64-NEXT:    vsext.vf4 v12, v8
-; RV64-NEXT:    vsll.vi v8, v12, 3
+; RV64-NEXT:    vsll.vi v12, v12, 3
 ; RV64-NEXT:    vsetvli zero, a1, e64, m4, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vluxei64.v v8, (a0), v12, v0.t
 ; RV64-NEXT:    ret
   %eidxs = sext <8 x i16> %idxs to <8 x i64>
   %ptrs = getelementptr inbounds double, ptr %base, <8 x i64> %eidxs
@@ -1982,9 +1998,9 @@ define <8 x double> @vpgather_baseidx_v8f64(ptr %base, <8 x i64> %idxs, <8 x i1>
 ; RV64-LABEL: vpgather_baseidx_v8f64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetivli zero, 8, e64, m4, ta, ma
-; RV64-NEXT:    vsll.vi v8, v8, 3
+; RV64-NEXT:    vsll.vi v12, v8, 3
 ; RV64-NEXT:    vsetvli zero, a1, e64, m4, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vluxei64.v v8, (a0), v12, v0.t
 ; RV64-NEXT:    ret
   %ptrs = getelementptr inbounds double, ptr %base, <8 x i64> %idxs
   %v = call <8 x double> @llvm.vp.gather.v8f64.v8p0(<8 x ptr> %ptrs, <8 x i1> %m, i32 %evl)
@@ -2018,6 +2034,14 @@ define <32 x double> @vpgather_v32f64(<32 x ptr> %ptrs, <32 x i1> %m, i32 zeroex
 ;
 ; RV64-LABEL: vpgather_v32f64:
 ; RV64:       # %bb.0:
+; RV64-NEXT:    addi sp, sp, -16
+; RV64-NEXT:    .cfi_def_cfa_offset 16
+; RV64-NEXT:    csrr a1, vlenb
+; RV64-NEXT:    slli a1, a1, 3
+; RV64-NEXT:    sub sp, sp, a1
+; RV64-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x08, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 8 * vlenb
+; RV64-NEXT:    addi a1, sp, 16
+; RV64-NEXT:    vs8r.v v16, (a1) # vscale x 64-byte Folded Spill
 ; RV64-NEXT:    li a2, 16
 ; RV64-NEXT:    mv a1, a0
 ; RV64-NEXT:    bltu a0, a2, .LBB94_2
@@ -2025,15 +2049,24 @@ define <32 x double> @vpgather_v32f64(<32 x ptr> %ptrs, <32 x i1> %m, i32 zeroex
 ; RV64-NEXT:    li a1, 16
 ; RV64-NEXT:  .LBB94_2:
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (zero), v8, v0.t
+; RV64-NEXT:    vluxei64.v v24, (zero), v8, v0.t
 ; RV64-NEXT:    vsetivli zero, 2, e8, mf4, ta, ma
 ; RV64-NEXT:    vslidedown.vi v0, v0, 2
 ; RV64-NEXT:    addi a1, a0, -16
 ; RV64-NEXT:    sltu a0, a0, a1
 ; RV64-NEXT:    addi a0, a0, -1
 ; RV64-NEXT:    and a0, a0, a1
+; RV64-NEXT:    addi a1, sp, 16
+; RV64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
 ; RV64-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v16, (zero), v16, v0.t
+; RV64-NEXT:    vluxei64.v v16, (zero), v8, v0.t
+; RV64-NEXT:    vmv8r.v v8, v24
+; RV64-NEXT:    csrr a0, vlenb
+; RV64-NEXT:    slli a0, a0, 3
+; RV64-NEXT:    add sp, sp, a0
+; RV64-NEXT:    .cfi_def_cfa sp, 16
+; RV64-NEXT:    addi sp, sp, 16
+; RV64-NEXT:    .cfi_def_cfa_offset 0
 ; RV64-NEXT:    ret
   %v = call <32 x double> @llvm.vp.gather.v32f64.v32p0(<32 x ptr> %ptrs, <32 x i1> %m, i32 %evl)
   ret <32 x double> %v
@@ -2072,9 +2105,9 @@ define <32 x double> @vpgather_baseidx_v32i8_v32f64(ptr %base, <32 x i8> %idxs, 
 ; RV64-NEXT:    vslidedown.vi v10, v8, 16
 ; RV64-NEXT:    vsetivli zero, 16, e64, m8, ta, ma
 ; RV64-NEXT:    vsext.vf8 v16, v10
+; RV64-NEXT:    vsll.vi v24, v16, 3
+; RV64-NEXT:    vsext.vf8 v16, v8
 ; RV64-NEXT:    vsll.vi v16, v16, 3
-; RV64-NEXT:    vsext.vf8 v24, v8
-; RV64-NEXT:    vsll.vi v8, v24, 3
 ; RV64-NEXT:    li a3, 16
 ; RV64-NEXT:    mv a2, a1
 ; RV64-NEXT:    bltu a1, a3, .LBB95_2
@@ -2082,7 +2115,7 @@ define <32 x double> @vpgather_baseidx_v32i8_v32f64(ptr %base, <32 x i8> %idxs, 
 ; RV64-NEXT:    li a2, 16
 ; RV64-NEXT:  .LBB95_2:
 ; RV64-NEXT:    vsetvli zero, a2, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vluxei64.v v8, (a0), v16, v0.t
 ; RV64-NEXT:    vsetivli zero, 2, e8, mf4, ta, ma
 ; RV64-NEXT:    vslidedown.vi v0, v0, 2
 ; RV64-NEXT:    addi a2, a1, -16
@@ -2090,7 +2123,7 @@ define <32 x double> @vpgather_baseidx_v32i8_v32f64(ptr %base, <32 x i8> %idxs, 
 ; RV64-NEXT:    addi a1, a1, -1
 ; RV64-NEXT:    and a1, a1, a2
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v16, (a0), v16, v0.t
+; RV64-NEXT:    vluxei64.v v16, (a0), v24, v0.t
 ; RV64-NEXT:    ret
   %ptrs = getelementptr inbounds double, ptr %base, <32 x i8> %idxs
   %v = call <32 x double> @llvm.vp.gather.v32f64.v32p0(<32 x ptr> %ptrs, <32 x i1> %m, i32 %evl)
@@ -2127,13 +2160,13 @@ define <32 x double> @vpgather_baseidx_sext_v32i8_v32f64(ptr %base, <32 x i8> %i
 ; RV64-LABEL: vpgather_baseidx_sext_v32i8_v32f64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetivli zero, 16, e64, m8, ta, ma
-; RV64-NEXT:    vsext.vf8 v24, v8
+; RV64-NEXT:    vsext.vf8 v16, v8
 ; RV64-NEXT:    vsetivli zero, 16, e8, m2, ta, ma
-; RV64-NEXT:    vslidedown.vi v16, v8, 16
+; RV64-NEXT:    vslidedown.vi v24, v8, 16
 ; RV64-NEXT:    vsetivli zero, 16, e64, m8, ta, ma
-; RV64-NEXT:    vsext.vf8 v8, v16
-; RV64-NEXT:    vsll.vi v16, v8, 3
-; RV64-NEXT:    vsll.vi v8, v24, 3
+; RV64-NEXT:    vsext.vf8 v8, v24
+; RV64-NEXT:    vsll.vi v24, v8, 3
+; RV64-NEXT:    vsll.vi v16, v16, 3
 ; RV64-NEXT:    li a3, 16
 ; RV64-NEXT:    mv a2, a1
 ; RV64-NEXT:    bltu a1, a3, .LBB96_2
@@ -2141,7 +2174,7 @@ define <32 x double> @vpgather_baseidx_sext_v32i8_v32f64(ptr %base, <32 x i8> %i
 ; RV64-NEXT:    li a2, 16
 ; RV64-NEXT:  .LBB96_2:
 ; RV64-NEXT:    vsetvli zero, a2, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vluxei64.v v8, (a0), v16, v0.t
 ; RV64-NEXT:    vsetivli zero, 2, e8, mf4, ta, ma
 ; RV64-NEXT:    vslidedown.vi v0, v0, 2
 ; RV64-NEXT:    addi a2, a1, -16
@@ -2149,7 +2182,7 @@ define <32 x double> @vpgather_baseidx_sext_v32i8_v32f64(ptr %base, <32 x i8> %i
 ; RV64-NEXT:    addi a1, a1, -1
 ; RV64-NEXT:    and a1, a1, a2
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v16, (a0), v16, v0.t
+; RV64-NEXT:    vluxei64.v v16, (a0), v24, v0.t
 ; RV64-NEXT:    ret
   %eidxs = sext <32 x i8> %idxs to <32 x i64>
   %ptrs = getelementptr inbounds double, ptr %base, <32 x i64> %eidxs
@@ -2248,9 +2281,9 @@ define <32 x double> @vpgather_baseidx_v32i16_v32f64(ptr %base, <32 x i16> %idxs
 ; RV64-NEXT:    vslidedown.vi v12, v8, 16
 ; RV64-NEXT:    vsetivli zero, 16, e64, m8, ta, ma
 ; RV64-NEXT:    vsext.vf4 v16, v12
+; RV64-NEXT:    vsll.vi v24, v16, 3
+; RV64-NEXT:    vsext.vf4 v16, v8
 ; RV64-NEXT:    vsll.vi v16, v16, 3
-; RV64-NEXT:    vsext.vf4 v24, v8
-; RV64-NEXT:    vsll.vi v8, v24, 3
 ; RV64-NEXT:    li a3, 16
 ; RV64-NEXT:    mv a2, a1
 ; RV64-NEXT:    bltu a1, a3, .LBB98_2
@@ -2258,7 +2291,7 @@ define <32 x double> @vpgather_baseidx_v32i16_v32f64(ptr %base, <32 x i16> %idxs
 ; RV64-NEXT:    li a2, 16
 ; RV64-NEXT:  .LBB98_2:
 ; RV64-NEXT:    vsetvli zero, a2, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vluxei64.v v8, (a0), v16, v0.t
 ; RV64-NEXT:    vsetivli zero, 2, e8, mf4, ta, ma
 ; RV64-NEXT:    vslidedown.vi v0, v0, 2
 ; RV64-NEXT:    addi a2, a1, -16
@@ -2266,7 +2299,7 @@ define <32 x double> @vpgather_baseidx_v32i16_v32f64(ptr %base, <32 x i16> %idxs
 ; RV64-NEXT:    addi a1, a1, -1
 ; RV64-NEXT:    and a1, a1, a2
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v16, (a0), v16, v0.t
+; RV64-NEXT:    vluxei64.v v16, (a0), v24, v0.t
 ; RV64-NEXT:    ret
   %ptrs = getelementptr inbounds double, ptr %base, <32 x i16> %idxs
   %v = call <32 x double> @llvm.vp.gather.v32f64.v32p0(<32 x ptr> %ptrs, <32 x i1> %m, i32 %evl)
@@ -2303,13 +2336,13 @@ define <32 x double> @vpgather_baseidx_sext_v32i16_v32f64(ptr %base, <32 x i16> 
 ; RV64-LABEL: vpgather_baseidx_sext_v32i16_v32f64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetivli zero, 16, e64, m8, ta, ma
-; RV64-NEXT:    vsext.vf4 v24, v8
+; RV64-NEXT:    vsext.vf4 v16, v8
 ; RV64-NEXT:    vsetivli zero, 16, e16, m4, ta, ma
-; RV64-NEXT:    vslidedown.vi v16, v8, 16
+; RV64-NEXT:    vslidedown.vi v24, v8, 16
 ; RV64-NEXT:    vsetivli zero, 16, e64, m8, ta, ma
-; RV64-NEXT:    vsext.vf4 v8, v16
-; RV64-NEXT:    vsll.vi v16, v8, 3
-; RV64-NEXT:    vsll.vi v8, v24, 3
+; RV64-NEXT:    vsext.vf4 v8, v24
+; RV64-NEXT:    vsll.vi v24, v8, 3
+; RV64-NEXT:    vsll.vi v16, v16, 3
 ; RV64-NEXT:    li a3, 16
 ; RV64-NEXT:    mv a2, a1
 ; RV64-NEXT:    bltu a1, a3, .LBB99_2
@@ -2317,7 +2350,7 @@ define <32 x double> @vpgather_baseidx_sext_v32i16_v32f64(ptr %base, <32 x i16> 
 ; RV64-NEXT:    li a2, 16
 ; RV64-NEXT:  .LBB99_2:
 ; RV64-NEXT:    vsetvli zero, a2, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vluxei64.v v8, (a0), v16, v0.t
 ; RV64-NEXT:    vsetivli zero, 2, e8, mf4, ta, ma
 ; RV64-NEXT:    vslidedown.vi v0, v0, 2
 ; RV64-NEXT:    addi a2, a1, -16
@@ -2325,7 +2358,7 @@ define <32 x double> @vpgather_baseidx_sext_v32i16_v32f64(ptr %base, <32 x i16> 
 ; RV64-NEXT:    addi a1, a1, -1
 ; RV64-NEXT:    and a1, a1, a2
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v16, (a0), v16, v0.t
+; RV64-NEXT:    vluxei64.v v16, (a0), v24, v0.t
 ; RV64-NEXT:    ret
   %eidxs = sext <32 x i16> %idxs to <32 x i64>
   %ptrs = getelementptr inbounds double, ptr %base, <32 x i64> %eidxs
@@ -2421,10 +2454,10 @@ define <32 x double> @vpgather_baseidx_v32i32_v32f64(ptr %base, <32 x i32> %idxs
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    li a2, 8
 ; RV64-NEXT:    vsetivli zero, 16, e32, m8, ta, ma
-; RV64-NEXT:    vslidedown.vi v24, v8, 16
+; RV64-NEXT:    vslidedown.vi v16, v8, 16
 ; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV64-NEXT:    vwmulsu.vx v16, v24, a2
-; RV64-NEXT:    vwmulsu.vx v24, v8, a2
+; RV64-NEXT:    vwmulsu.vx v24, v16, a2
+; RV64-NEXT:    vwmulsu.vx v16, v8, a2
 ; RV64-NEXT:    li a3, 16
 ; RV64-NEXT:    mv a2, a1
 ; RV64-NEXT:    bltu a1, a3, .LBB101_2
@@ -2432,7 +2465,7 @@ define <32 x double> @vpgather_baseidx_v32i32_v32f64(ptr %base, <32 x i32> %idxs
 ; RV64-NEXT:    li a2, 16
 ; RV64-NEXT:  .LBB101_2:
 ; RV64-NEXT:    vsetvli zero, a2, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (a0), v24, v0.t
+; RV64-NEXT:    vluxei64.v v8, (a0), v16, v0.t
 ; RV64-NEXT:    vsetivli zero, 2, e8, mf4, ta, ma
 ; RV64-NEXT:    vslidedown.vi v0, v0, 2
 ; RV64-NEXT:    addi a2, a1, -16
@@ -2440,7 +2473,7 @@ define <32 x double> @vpgather_baseidx_v32i32_v32f64(ptr %base, <32 x i32> %idxs
 ; RV64-NEXT:    addi a1, a1, -1
 ; RV64-NEXT:    and a1, a1, a2
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v16, (a0), v16, v0.t
+; RV64-NEXT:    vluxei64.v v16, (a0), v24, v0.t
 ; RV64-NEXT:    ret
   %ptrs = getelementptr inbounds double, ptr %base, <32 x i32> %idxs
   %v = call <32 x double> @llvm.vp.gather.v32f64.v32p0(<32 x ptr> %ptrs, <32 x i1> %m, i32 %evl)
@@ -2477,10 +2510,10 @@ define <32 x double> @vpgather_baseidx_sext_v32i32_v32f64(ptr %base, <32 x i32> 
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    li a2, 8
 ; RV64-NEXT:    vsetivli zero, 16, e32, m8, ta, ma
-; RV64-NEXT:    vslidedown.vi v24, v8, 16
+; RV64-NEXT:    vslidedown.vi v16, v8, 16
 ; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV64-NEXT:    vwmulsu.vx v16, v24, a2
-; RV64-NEXT:    vwmulsu.vx v24, v8, a2
+; RV64-NEXT:    vwmulsu.vx v24, v16, a2
+; RV64-NEXT:    vwmulsu.vx v16, v8, a2
 ; RV64-NEXT:    li a3, 16
 ; RV64-NEXT:    mv a2, a1
 ; RV64-NEXT:    bltu a1, a3, .LBB102_2
@@ -2488,7 +2521,7 @@ define <32 x double> @vpgather_baseidx_sext_v32i32_v32f64(ptr %base, <32 x i32> 
 ; RV64-NEXT:    li a2, 16
 ; RV64-NEXT:  .LBB102_2:
 ; RV64-NEXT:    vsetvli zero, a2, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (a0), v24, v0.t
+; RV64-NEXT:    vluxei64.v v8, (a0), v16, v0.t
 ; RV64-NEXT:    vsetivli zero, 2, e8, mf4, ta, ma
 ; RV64-NEXT:    vslidedown.vi v0, v0, 2
 ; RV64-NEXT:    addi a2, a1, -16
@@ -2496,7 +2529,7 @@ define <32 x double> @vpgather_baseidx_sext_v32i32_v32f64(ptr %base, <32 x i32> 
 ; RV64-NEXT:    addi a1, a1, -1
 ; RV64-NEXT:    and a1, a1, a2
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v16, (a0), v16, v0.t
+; RV64-NEXT:    vluxei64.v v16, (a0), v24, v0.t
 ; RV64-NEXT:    ret
   %eidxs = sext <32 x i32> %idxs to <32 x i64>
   %ptrs = getelementptr inbounds double, ptr %base, <32 x i64> %eidxs
@@ -2534,10 +2567,10 @@ define <32 x double> @vpgather_baseidx_zext_v32i32_v32f64(ptr %base, <32 x i32> 
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    li a2, 8
 ; RV64-NEXT:    vsetivli zero, 16, e32, m8, ta, ma
-; RV64-NEXT:    vslidedown.vi v24, v8, 16
+; RV64-NEXT:    vslidedown.vi v16, v8, 16
 ; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV64-NEXT:    vwmulu.vx v16, v24, a2
-; RV64-NEXT:    vwmulu.vx v24, v8, a2
+; RV64-NEXT:    vwmulu.vx v24, v16, a2
+; RV64-NEXT:    vwmulu.vx v16, v8, a2
 ; RV64-NEXT:    li a3, 16
 ; RV64-NEXT:    mv a2, a1
 ; RV64-NEXT:    bltu a1, a3, .LBB103_2
@@ -2545,7 +2578,7 @@ define <32 x double> @vpgather_baseidx_zext_v32i32_v32f64(ptr %base, <32 x i32> 
 ; RV64-NEXT:    li a2, 16
 ; RV64-NEXT:  .LBB103_2:
 ; RV64-NEXT:    vsetvli zero, a2, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (a0), v24, v0.t
+; RV64-NEXT:    vluxei64.v v8, (a0), v16, v0.t
 ; RV64-NEXT:    vsetivli zero, 2, e8, mf4, ta, ma
 ; RV64-NEXT:    vslidedown.vi v0, v0, 2
 ; RV64-NEXT:    addi a2, a1, -16
@@ -2553,7 +2586,7 @@ define <32 x double> @vpgather_baseidx_zext_v32i32_v32f64(ptr %base, <32 x i32> 
 ; RV64-NEXT:    addi a1, a1, -1
 ; RV64-NEXT:    and a1, a1, a2
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v16, (a0), v16, v0.t
+; RV64-NEXT:    vluxei64.v v16, (a0), v24, v0.t
 ; RV64-NEXT:    ret
   %eidxs = zext <32 x i32> %idxs to <32 x i64>
   %ptrs = getelementptr inbounds double, ptr %base, <32 x i64> %eidxs
@@ -2594,8 +2627,8 @@ define <32 x double> @vpgather_baseidx_v32f64(ptr %base, <32 x i64> %idxs, <32 x
 ; RV64-LABEL: vpgather_baseidx_v32f64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetivli zero, 16, e64, m8, ta, ma
-; RV64-NEXT:    vsll.vi v16, v16, 3
-; RV64-NEXT:    vsll.vi v8, v8, 3
+; RV64-NEXT:    vsll.vi v24, v16, 3
+; RV64-NEXT:    vsll.vi v16, v8, 3
 ; RV64-NEXT:    li a3, 16
 ; RV64-NEXT:    mv a2, a1
 ; RV64-NEXT:    bltu a1, a3, .LBB104_2
@@ -2603,7 +2636,7 @@ define <32 x double> @vpgather_baseidx_v32f64(ptr %base, <32 x i64> %idxs, <32 x
 ; RV64-NEXT:    li a2, 16
 ; RV64-NEXT:  .LBB104_2:
 ; RV64-NEXT:    vsetvli zero, a2, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vluxei64.v v8, (a0), v16, v0.t
 ; RV64-NEXT:    vsetivli zero, 2, e8, mf4, ta, ma
 ; RV64-NEXT:    vslidedown.vi v0, v0, 2
 ; RV64-NEXT:    addi a2, a1, -16
@@ -2611,7 +2644,7 @@ define <32 x double> @vpgather_baseidx_v32f64(ptr %base, <32 x i64> %idxs, <32 x
 ; RV64-NEXT:    addi a1, a1, -1
 ; RV64-NEXT:    and a1, a1, a2
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v16, (a0), v16, v0.t
+; RV64-NEXT:    vluxei64.v v16, (a0), v24, v0.t
 ; RV64-NEXT:    ret
   %ptrs = getelementptr inbounds double, ptr %base, <32 x i64> %idxs
   %v = call <32 x double> @llvm.vp.gather.v32f64.v32p0(<32 x ptr> %ptrs, <32 x i1> %m, i32 %evl)

--- a/llvm/test/CodeGen/RISCV/rvv/mgather-sdnode.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/mgather-sdnode.ll
@@ -652,7 +652,8 @@ define <vscale x 4 x i32> @mgather_truemask_nxv4i32(<vscale x 4 x ptr> %ptrs, <v
 ; RV32-LABEL: mgather_truemask_nxv4i32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli a0, zero, e32, m2, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (zero), v8
+; RV32-NEXT:    vluxei32.v v10, (zero), v8
+; RV32-NEXT:    vmv.v.v v8, v10
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: mgather_truemask_nxv4i32:
@@ -918,7 +919,8 @@ define <vscale x 4 x i64> @mgather_truemask_nxv4i64(<vscale x 4 x ptr> %ptrs, <v
 ; RV64-LABEL: mgather_truemask_nxv4i64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli a0, zero, e64, m4, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (zero), v8
+; RV64-NEXT:    vluxei64.v v12, (zero), v8
+; RV64-NEXT:    vmv.v.v v8, v12
 ; RV64-NEXT:    ret
   %v = call <vscale x 4 x i64> @llvm.masked.gather.nxv4i64.nxv4p0(<vscale x 4 x ptr> %ptrs, i32 8, <vscale x 4 x i1> splat (i1 1), <vscale x 4 x i64> %passthru)
   ret <vscale x 4 x i64> %v
@@ -1673,7 +1675,8 @@ define <vscale x 4 x float> @mgather_truemask_nxv4f32(<vscale x 4 x ptr> %ptrs, 
 ; RV32-LABEL: mgather_truemask_nxv4f32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli a0, zero, e32, m2, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (zero), v8
+; RV32-NEXT:    vluxei32.v v10, (zero), v8
+; RV32-NEXT:    vmv.v.v v8, v10
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: mgather_truemask_nxv4f32:
@@ -1939,7 +1942,8 @@ define <vscale x 4 x double> @mgather_truemask_nxv4f64(<vscale x 4 x ptr> %ptrs,
 ; RV64-LABEL: mgather_truemask_nxv4f64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli a0, zero, e64, m4, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (zero), v8
+; RV64-NEXT:    vluxei64.v v12, (zero), v8
+; RV64-NEXT:    vmv.v.v v8, v12
 ; RV64-NEXT:    ret
   %v = call <vscale x 4 x double> @llvm.masked.gather.nxv4f64.nxv4p0(<vscale x 4 x ptr> %ptrs, i32 8, <vscale x 4 x i1> splat (i1 1), <vscale x 4 x double> %passthru)
   ret <vscale x 4 x double> %v
@@ -2328,10 +2332,10 @@ define <4 x i32> @scalar_prefix(ptr %base, i32 signext %index, <4 x i32> %vecidx
 ; RV32-LABEL: scalar_prefix:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV32-NEXT:    vsll.vi v8, v8, 2
+; RV32-NEXT:    vsll.vi v9, v8, 2
 ; RV32-NEXT:    slli a1, a1, 10
 ; RV32-NEXT:    add a0, a0, a1
-; RV32-NEXT:    vluxei32.v v8, (a0), v8
+; RV32-NEXT:    vluxei32.v v8, (a0), v9
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: scalar_prefix:
@@ -2356,8 +2360,8 @@ define <4 x i32> @scalar_prefix_with_splat(ptr %base, i32 %index, <4 x i32> %vec
 ; RV32-NEXT:    vsll.vi v8, v8, 2
 ; RV32-NEXT:    vsll.vi v9, v9, 10
 ; RV32-NEXT:    vadd.vx v9, v9, a0
-; RV32-NEXT:    vadd.vv v8, v9, v8
-; RV32-NEXT:    vluxei32.v v8, (zero), v8
+; RV32-NEXT:    vadd.vv v9, v9, v8
+; RV32-NEXT:    vluxei32.v v8, (zero), v9
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: scalar_prefix_with_splat:
@@ -2385,10 +2389,10 @@ define <4 x i32> @scalar_prefix_with_constant_splat(ptr %base, <4 x i32> %vecidx
 ; RV32-LABEL: scalar_prefix_with_constant_splat:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV32-NEXT:    vsll.vi v8, v8, 2
+; RV32-NEXT:    vsll.vi v9, v8, 2
 ; RV32-NEXT:    lui a1, 5
 ; RV32-NEXT:    add a0, a0, a1
-; RV32-NEXT:    vluxei32.v v8, (a0), v8
+; RV32-NEXT:    vluxei32.v v8, (a0), v9
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: scalar_prefix_with_constant_splat:
@@ -2413,8 +2417,8 @@ define <4 x i32> @reassociate(ptr %base, i32 %index, <4 x i32> %vecidx) {
 ; RV32-NEXT:    vsll.vi v8, v8, 10
 ; RV32-NEXT:    vsll.vi v9, v9, 2
 ; RV32-NEXT:    vadd.vx v8, v8, a0
-; RV32-NEXT:    vadd.vv v8, v8, v9
-; RV32-NEXT:    vluxei32.v v8, (zero), v8
+; RV32-NEXT:    vadd.vv v9, v8, v9
+; RV32-NEXT:    vluxei32.v v8, (zero), v9
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: reassociate:
@@ -2441,8 +2445,8 @@ define <4 x i32> @reassociate_with_splat(ptr %base, i32 %index, <4 x i32> %vecid
 ; RV32-NEXT:    vsll.vi v8, v8, 10
 ; RV32-NEXT:    vsll.vi v9, v9, 2
 ; RV32-NEXT:    vadd.vx v8, v8, a0
-; RV32-NEXT:    vadd.vv v8, v8, v9
-; RV32-NEXT:    vluxei32.v v8, (zero), v8
+; RV32-NEXT:    vadd.vv v9, v8, v9
+; RV32-NEXT:    vluxei32.v v8, (zero), v9
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: reassociate_with_splat:
@@ -2468,9 +2472,9 @@ define <4 x i32> @reassociate_with_constant_splat(ptr %base, i32 %index, <4 x i3
 ; RV32-LABEL: reassociate_with_constant_splat:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV32-NEXT:    vsll.vi v8, v8, 10
+; RV32-NEXT:    vsll.vi v9, v8, 10
 ; RV32-NEXT:    addi a0, a0, 80
-; RV32-NEXT:    vluxei32.v v8, (a0), v8
+; RV32-NEXT:    vluxei32.v v8, (a0), v9
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: reassociate_with_constant_splat:
@@ -2494,8 +2498,8 @@ define <4 x i32> @diagonal(ptr %base, <4 x i64> %vecidx) {
 ; RV32-NEXT:    vsll.vi v8, v10, 10
 ; RV32-NEXT:    vadd.vx v8, v8, a0
 ; RV32-NEXT:    vsll.vi v9, v10, 2
-; RV32-NEXT:    vadd.vv v8, v8, v9
-; RV32-NEXT:    vluxei32.v v8, (zero), v8
+; RV32-NEXT:    vadd.vv v9, v8, v9
+; RV32-NEXT:    vluxei32.v v8, (zero), v9
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: diagonal:
@@ -2520,8 +2524,8 @@ define <4 x i32> @diagonal_i32(ptr %base, <4 x i32> %vecidx) {
 ; RV32-NEXT:    vsll.vi v9, v8, 10
 ; RV32-NEXT:    vadd.vx v9, v9, a0
 ; RV32-NEXT:    vsll.vi v8, v8, 2
-; RV32-NEXT:    vadd.vv v8, v9, v8
-; RV32-NEXT:    vluxei32.v v8, (zero), v8
+; RV32-NEXT:    vadd.vv v9, v9, v8
+; RV32-NEXT:    vluxei32.v v8, (zero), v9
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: diagonal_i32:

--- a/llvm/test/CodeGen/RISCV/rvv/nontemporal-vp-scalable.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/nontemporal-vp-scalable.ll
@@ -2354,7 +2354,8 @@ define <vscale x 1 x i32> @test_nontemporal_vp_gather_nxv1i32_P1(<vscale x 1 x p
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.p1
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv1r.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv1i32_P1:
@@ -2369,7 +2370,8 @@ define <vscale x 1 x i32> @test_nontemporal_vp_gather_nxv1i32_P1(<vscale x 1 x p
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.p1
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv1r.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 1 x i32> @llvm.vp.gather.nxv1i32.nxv1p0(<vscale x 1 x ptr> %ptrs, <vscale x 1 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !1
   ret <vscale x 1 x i32> %x
@@ -2389,7 +2391,8 @@ define <vscale x 1 x i32> @test_nontemporal_vp_gather_nxv1i32_PALL(<vscale x 1 x
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.pall
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv1r.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv1i32_PALL:
@@ -2404,7 +2407,8 @@ define <vscale x 1 x i32> @test_nontemporal_vp_gather_nxv1i32_PALL(<vscale x 1 x
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.pall
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv1r.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 1 x i32> @llvm.vp.gather.nxv1i32.nxv1p0(<vscale x 1 x ptr> %ptrs, <vscale x 1 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !2
   ret <vscale x 1 x i32> %x
@@ -2424,7 +2428,8 @@ define <vscale x 1 x i32> @test_nontemporal_vp_gather_nxv1i32_S1(<vscale x 1 x p
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.s1
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv1r.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv1i32_S1:
@@ -2439,7 +2444,8 @@ define <vscale x 1 x i32> @test_nontemporal_vp_gather_nxv1i32_S1(<vscale x 1 x p
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.s1
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv1r.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 1 x i32> @llvm.vp.gather.nxv1i32.nxv1p0(<vscale x 1 x ptr> %ptrs, <vscale x 1 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !3
   ret <vscale x 1 x i32> %x
@@ -2459,7 +2465,8 @@ define <vscale x 1 x i32> @test_nontemporal_vp_gather_nxv1i32_ALL(<vscale x 1 x 
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.all
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv1r.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv1i32_ALL:
@@ -2474,7 +2481,8 @@ define <vscale x 1 x i32> @test_nontemporal_vp_gather_nxv1i32_ALL(<vscale x 1 x 
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.all
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv1r.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 1 x i32> @llvm.vp.gather.nxv1i32.nxv1p0(<vscale x 1 x ptr> %ptrs, <vscale x 1 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !4
   ret <vscale x 1 x i32> %x
@@ -2493,7 +2501,8 @@ define <vscale x 1 x i32> @test_nontemporal_vp_gather_nxv1i32_DEFAULT(<vscale x 
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.all
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv1r.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv1i32_DEFAULT:
@@ -2508,7 +2517,8 @@ define <vscale x 1 x i32> @test_nontemporal_vp_gather_nxv1i32_DEFAULT(<vscale x 
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.all
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv1r.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 1 x i32> @llvm.vp.gather.nxv1i32.nxv1p0(<vscale x 1 x ptr> %ptrs, <vscale x 1 x i1> splat(i1 true), i32 %vl), !nontemporal !0
   ret <vscale x 1 x i32> %x
@@ -3340,7 +3350,8 @@ define <vscale x 1 x i64> @test_nontemporal_vp_gather_nxv1i64_P1(<vscale x 1 x p
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv1i64_P1:
@@ -3355,7 +3366,8 @@ define <vscale x 1 x i64> @test_nontemporal_vp_gather_nxv1i64_P1(<vscale x 1 x p
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv1i64_P1:
@@ -3375,7 +3387,8 @@ define <vscale x 1 x i64> @test_nontemporal_vp_gather_nxv1i64_PALL(<vscale x 1 x
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv1i64_PALL:
@@ -3390,7 +3403,8 @@ define <vscale x 1 x i64> @test_nontemporal_vp_gather_nxv1i64_PALL(<vscale x 1 x
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv1i64_PALL:
@@ -3410,7 +3424,8 @@ define <vscale x 1 x i64> @test_nontemporal_vp_gather_nxv1i64_S1(<vscale x 1 x p
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv1i64_S1:
@@ -3425,7 +3440,8 @@ define <vscale x 1 x i64> @test_nontemporal_vp_gather_nxv1i64_S1(<vscale x 1 x p
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv1i64_S1:
@@ -3445,7 +3461,8 @@ define <vscale x 1 x i64> @test_nontemporal_vp_gather_nxv1i64_ALL(<vscale x 1 x 
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv1i64_ALL:
@@ -3460,7 +3477,8 @@ define <vscale x 1 x i64> @test_nontemporal_vp_gather_nxv1i64_ALL(<vscale x 1 x 
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv1i64_ALL:
@@ -3479,7 +3497,8 @@ define <vscale x 1 x i64> @test_nontemporal_vp_gather_nxv1i64_DEFAULT(<vscale x 
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv1i64_DEFAULT:
@@ -3494,7 +3513,8 @@ define <vscale x 1 x i64> @test_nontemporal_vp_gather_nxv1i64_DEFAULT(<vscale x 
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv1i64_DEFAULT:
@@ -4342,7 +4362,8 @@ define <vscale x 1 x float> @test_nontemporal_vp_gather_nxv1f32_P1(<vscale x 1 x
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.p1
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv1r.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv1f32_P1:
@@ -4357,7 +4378,8 @@ define <vscale x 1 x float> @test_nontemporal_vp_gather_nxv1f32_P1(<vscale x 1 x
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.p1
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv1r.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 1 x float> @llvm.vp.gather.nxv1f32.nxv1p0(<vscale x 1 x ptr> %ptrs, <vscale x 1 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !1
   ret <vscale x 1 x float> %x
@@ -4377,7 +4399,8 @@ define <vscale x 1 x float> @test_nontemporal_vp_gather_nxv1f32_PALL(<vscale x 1
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.pall
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv1r.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv1f32_PALL:
@@ -4392,7 +4415,8 @@ define <vscale x 1 x float> @test_nontemporal_vp_gather_nxv1f32_PALL(<vscale x 1
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.pall
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv1r.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 1 x float> @llvm.vp.gather.nxv1f32.nxv1p0(<vscale x 1 x ptr> %ptrs, <vscale x 1 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !2
   ret <vscale x 1 x float> %x
@@ -4412,7 +4436,8 @@ define <vscale x 1 x float> @test_nontemporal_vp_gather_nxv1f32_S1(<vscale x 1 x
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.s1
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv1r.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv1f32_S1:
@@ -4427,7 +4452,8 @@ define <vscale x 1 x float> @test_nontemporal_vp_gather_nxv1f32_S1(<vscale x 1 x
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.s1
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv1r.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 1 x float> @llvm.vp.gather.nxv1f32.nxv1p0(<vscale x 1 x ptr> %ptrs, <vscale x 1 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !3
   ret <vscale x 1 x float> %x
@@ -4447,7 +4473,8 @@ define <vscale x 1 x float> @test_nontemporal_vp_gather_nxv1f32_ALL(<vscale x 1 
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.all
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv1r.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv1f32_ALL:
@@ -4462,7 +4489,8 @@ define <vscale x 1 x float> @test_nontemporal_vp_gather_nxv1f32_ALL(<vscale x 1 
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.all
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv1r.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 1 x float> @llvm.vp.gather.nxv1f32.nxv1p0(<vscale x 1 x ptr> %ptrs, <vscale x 1 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !4
   ret <vscale x 1 x float> %x
@@ -4481,7 +4509,8 @@ define <vscale x 1 x float> @test_nontemporal_vp_gather_nxv1f32_DEFAULT(<vscale 
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.all
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv1r.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv1f32_DEFAULT:
@@ -4496,7 +4525,8 @@ define <vscale x 1 x float> @test_nontemporal_vp_gather_nxv1f32_DEFAULT(<vscale 
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.all
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv1r.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 1 x float> @llvm.vp.gather.nxv1f32.nxv1p0(<vscale x 1 x ptr> %ptrs, <vscale x 1 x i1> splat(i1 true), i32 %vl), !nontemporal !0
   ret <vscale x 1 x float> %x
@@ -5328,7 +5358,8 @@ define <vscale x 1 x double> @test_nontemporal_vp_gather_nxv1f64_P1(<vscale x 1 
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv1f64_P1:
@@ -5343,7 +5374,8 @@ define <vscale x 1 x double> @test_nontemporal_vp_gather_nxv1f64_P1(<vscale x 1 
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv1f64_P1:
@@ -5363,7 +5395,8 @@ define <vscale x 1 x double> @test_nontemporal_vp_gather_nxv1f64_PALL(<vscale x 
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv1f64_PALL:
@@ -5378,7 +5411,8 @@ define <vscale x 1 x double> @test_nontemporal_vp_gather_nxv1f64_PALL(<vscale x 
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv1f64_PALL:
@@ -5398,7 +5432,8 @@ define <vscale x 1 x double> @test_nontemporal_vp_gather_nxv1f64_S1(<vscale x 1 
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv1f64_S1:
@@ -5413,7 +5448,8 @@ define <vscale x 1 x double> @test_nontemporal_vp_gather_nxv1f64_S1(<vscale x 1 
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv1f64_S1:
@@ -5433,7 +5469,8 @@ define <vscale x 1 x double> @test_nontemporal_vp_gather_nxv1f64_ALL(<vscale x 1
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv1f64_ALL:
@@ -5448,7 +5485,8 @@ define <vscale x 1 x double> @test_nontemporal_vp_gather_nxv1f64_ALL(<vscale x 1
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv1f64_ALL:
@@ -5467,7 +5505,8 @@ define <vscale x 1 x double> @test_nontemporal_vp_gather_nxv1f64_DEFAULT(<vscale
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv1f64_DEFAULT:
@@ -5482,7 +5521,8 @@ define <vscale x 1 x double> @test_nontemporal_vp_gather_nxv1f64_DEFAULT(<vscale
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv1f64_DEFAULT:
@@ -8338,7 +8378,8 @@ define <vscale x 2 x i32> @test_nontemporal_vp_gather_nxv2i32_P1(<vscale x 2 x p
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.p1
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv2i32_P1:
@@ -8353,7 +8394,8 @@ define <vscale x 2 x i32> @test_nontemporal_vp_gather_nxv2i32_P1(<vscale x 2 x p
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.p1
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 2 x i32> @llvm.vp.gather.nxv2i32.nxv2p0(<vscale x 2 x ptr> %ptrs, <vscale x 2 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !1
   ret <vscale x 2 x i32> %x
@@ -8373,7 +8415,8 @@ define <vscale x 2 x i32> @test_nontemporal_vp_gather_nxv2i32_PALL(<vscale x 2 x
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.pall
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv2i32_PALL:
@@ -8388,7 +8431,8 @@ define <vscale x 2 x i32> @test_nontemporal_vp_gather_nxv2i32_PALL(<vscale x 2 x
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.pall
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 2 x i32> @llvm.vp.gather.nxv2i32.nxv2p0(<vscale x 2 x ptr> %ptrs, <vscale x 2 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !2
   ret <vscale x 2 x i32> %x
@@ -8408,7 +8452,8 @@ define <vscale x 2 x i32> @test_nontemporal_vp_gather_nxv2i32_S1(<vscale x 2 x p
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.s1
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv2i32_S1:
@@ -8423,7 +8468,8 @@ define <vscale x 2 x i32> @test_nontemporal_vp_gather_nxv2i32_S1(<vscale x 2 x p
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.s1
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 2 x i32> @llvm.vp.gather.nxv2i32.nxv2p0(<vscale x 2 x ptr> %ptrs, <vscale x 2 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !3
   ret <vscale x 2 x i32> %x
@@ -8443,7 +8489,8 @@ define <vscale x 2 x i32> @test_nontemporal_vp_gather_nxv2i32_ALL(<vscale x 2 x 
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.all
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv2i32_ALL:
@@ -8458,7 +8505,8 @@ define <vscale x 2 x i32> @test_nontemporal_vp_gather_nxv2i32_ALL(<vscale x 2 x 
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.all
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 2 x i32> @llvm.vp.gather.nxv2i32.nxv2p0(<vscale x 2 x ptr> %ptrs, <vscale x 2 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !4
   ret <vscale x 2 x i32> %x
@@ -8477,7 +8525,8 @@ define <vscale x 2 x i32> @test_nontemporal_vp_gather_nxv2i32_DEFAULT(<vscale x 
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.all
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv2i32_DEFAULT:
@@ -8492,7 +8541,8 @@ define <vscale x 2 x i32> @test_nontemporal_vp_gather_nxv2i32_DEFAULT(<vscale x 
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.all
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 2 x i32> @llvm.vp.gather.nxv2i32.nxv2p0(<vscale x 2 x ptr> %ptrs, <vscale x 2 x i1> splat(i1 true), i32 %vl), !nontemporal !0
   ret <vscale x 2 x i32> %x
@@ -9324,7 +9374,8 @@ define <vscale x 2 x i64> @test_nontemporal_vp_gather_nxv2i64_P1(<vscale x 2 x p
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v10, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv2i64_P1:
@@ -9340,7 +9391,8 @@ define <vscale x 2 x i64> @test_nontemporal_vp_gather_nxv2i64_P1(<vscale x 2 x p
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v10, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv2i64_P1:
@@ -9361,7 +9413,8 @@ define <vscale x 2 x i64> @test_nontemporal_vp_gather_nxv2i64_PALL(<vscale x 2 x
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v10, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv2i64_PALL:
@@ -9377,7 +9430,8 @@ define <vscale x 2 x i64> @test_nontemporal_vp_gather_nxv2i64_PALL(<vscale x 2 x
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v10, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv2i64_PALL:
@@ -9398,7 +9452,8 @@ define <vscale x 2 x i64> @test_nontemporal_vp_gather_nxv2i64_S1(<vscale x 2 x p
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v10, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv2i64_S1:
@@ -9414,7 +9469,8 @@ define <vscale x 2 x i64> @test_nontemporal_vp_gather_nxv2i64_S1(<vscale x 2 x p
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v10, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv2i64_S1:
@@ -9435,7 +9491,8 @@ define <vscale x 2 x i64> @test_nontemporal_vp_gather_nxv2i64_ALL(<vscale x 2 x 
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v10, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv2i64_ALL:
@@ -9451,7 +9508,8 @@ define <vscale x 2 x i64> @test_nontemporal_vp_gather_nxv2i64_ALL(<vscale x 2 x 
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v10, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv2i64_ALL:
@@ -9471,7 +9529,8 @@ define <vscale x 2 x i64> @test_nontemporal_vp_gather_nxv2i64_DEFAULT(<vscale x 
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v10, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv2i64_DEFAULT:
@@ -9487,7 +9546,8 @@ define <vscale x 2 x i64> @test_nontemporal_vp_gather_nxv2i64_DEFAULT(<vscale x 
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v10, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv2i64_DEFAULT:
@@ -10336,7 +10396,8 @@ define <vscale x 2 x float> @test_nontemporal_vp_gather_nxv2f32_P1(<vscale x 2 x
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.p1
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv2f32_P1:
@@ -10351,7 +10412,8 @@ define <vscale x 2 x float> @test_nontemporal_vp_gather_nxv2f32_P1(<vscale x 2 x
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.p1
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 2 x float> @llvm.vp.gather.nxv2f32.nxv2p0(<vscale x 2 x ptr> %ptrs, <vscale x 2 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !1
   ret <vscale x 2 x float> %x
@@ -10371,7 +10433,8 @@ define <vscale x 2 x float> @test_nontemporal_vp_gather_nxv2f32_PALL(<vscale x 2
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.pall
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv2f32_PALL:
@@ -10386,7 +10449,8 @@ define <vscale x 2 x float> @test_nontemporal_vp_gather_nxv2f32_PALL(<vscale x 2
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.pall
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 2 x float> @llvm.vp.gather.nxv2f32.nxv2p0(<vscale x 2 x ptr> %ptrs, <vscale x 2 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !2
   ret <vscale x 2 x float> %x
@@ -10406,7 +10470,8 @@ define <vscale x 2 x float> @test_nontemporal_vp_gather_nxv2f32_S1(<vscale x 2 x
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.s1
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv2f32_S1:
@@ -10421,7 +10486,8 @@ define <vscale x 2 x float> @test_nontemporal_vp_gather_nxv2f32_S1(<vscale x 2 x
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.s1
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 2 x float> @llvm.vp.gather.nxv2f32.nxv2p0(<vscale x 2 x ptr> %ptrs, <vscale x 2 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !3
   ret <vscale x 2 x float> %x
@@ -10441,7 +10507,8 @@ define <vscale x 2 x float> @test_nontemporal_vp_gather_nxv2f32_ALL(<vscale x 2 
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.all
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv2f32_ALL:
@@ -10456,7 +10523,8 @@ define <vscale x 2 x float> @test_nontemporal_vp_gather_nxv2f32_ALL(<vscale x 2 
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.all
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 2 x float> @llvm.vp.gather.nxv2f32.nxv2p0(<vscale x 2 x ptr> %ptrs, <vscale x 2 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !4
   ret <vscale x 2 x float> %x
@@ -10475,7 +10543,8 @@ define <vscale x 2 x float> @test_nontemporal_vp_gather_nxv2f32_DEFAULT(<vscale 
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.all
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv2f32_DEFAULT:
@@ -10490,7 +10559,8 @@ define <vscale x 2 x float> @test_nontemporal_vp_gather_nxv2f32_DEFAULT(<vscale 
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.all
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 2 x float> @llvm.vp.gather.nxv2f32.nxv2p0(<vscale x 2 x ptr> %ptrs, <vscale x 2 x i1> splat(i1 true), i32 %vl), !nontemporal !0
   ret <vscale x 2 x float> %x
@@ -11322,7 +11392,8 @@ define <vscale x 2 x double> @test_nontemporal_vp_gather_nxv2f64_P1(<vscale x 2 
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v10, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv2f64_P1:
@@ -11338,7 +11409,8 @@ define <vscale x 2 x double> @test_nontemporal_vp_gather_nxv2f64_P1(<vscale x 2 
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v10, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv2f64_P1:
@@ -11359,7 +11431,8 @@ define <vscale x 2 x double> @test_nontemporal_vp_gather_nxv2f64_PALL(<vscale x 
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v10, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv2f64_PALL:
@@ -11375,7 +11448,8 @@ define <vscale x 2 x double> @test_nontemporal_vp_gather_nxv2f64_PALL(<vscale x 
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v10, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv2f64_PALL:
@@ -11396,7 +11470,8 @@ define <vscale x 2 x double> @test_nontemporal_vp_gather_nxv2f64_S1(<vscale x 2 
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v10, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv2f64_S1:
@@ -11412,7 +11487,8 @@ define <vscale x 2 x double> @test_nontemporal_vp_gather_nxv2f64_S1(<vscale x 2 
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v10, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv2f64_S1:
@@ -11433,7 +11509,8 @@ define <vscale x 2 x double> @test_nontemporal_vp_gather_nxv2f64_ALL(<vscale x 2
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v10, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv2f64_ALL:
@@ -11449,7 +11526,8 @@ define <vscale x 2 x double> @test_nontemporal_vp_gather_nxv2f64_ALL(<vscale x 2
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v10, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv2f64_ALL:
@@ -11469,7 +11547,8 @@ define <vscale x 2 x double> @test_nontemporal_vp_gather_nxv2f64_DEFAULT(<vscale
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v10, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv2f64_DEFAULT:
@@ -11485,7 +11564,8 @@ define <vscale x 2 x double> @test_nontemporal_vp_gather_nxv2f64_DEFAULT(<vscale
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v10, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv2f64_DEFAULT:
@@ -14342,7 +14422,8 @@ define <vscale x 4 x i32> @test_nontemporal_vp_gather_nxv4i32_P1(<vscale x 4 x p
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.p1
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v10, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv4i32_P1:
@@ -14357,7 +14438,8 @@ define <vscale x 4 x i32> @test_nontemporal_vp_gather_nxv4i32_P1(<vscale x 4 x p
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.p1
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v10, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 4 x i32> @llvm.vp.gather.nxv4i32.nxv4p0(<vscale x 4 x ptr> %ptrs, <vscale x 4 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !1
   ret <vscale x 4 x i32> %x
@@ -14377,7 +14459,8 @@ define <vscale x 4 x i32> @test_nontemporal_vp_gather_nxv4i32_PALL(<vscale x 4 x
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.pall
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v10, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv4i32_PALL:
@@ -14392,7 +14475,8 @@ define <vscale x 4 x i32> @test_nontemporal_vp_gather_nxv4i32_PALL(<vscale x 4 x
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.pall
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v10, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 4 x i32> @llvm.vp.gather.nxv4i32.nxv4p0(<vscale x 4 x ptr> %ptrs, <vscale x 4 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !2
   ret <vscale x 4 x i32> %x
@@ -14412,7 +14496,8 @@ define <vscale x 4 x i32> @test_nontemporal_vp_gather_nxv4i32_S1(<vscale x 4 x p
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.s1
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v10, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv4i32_S1:
@@ -14427,7 +14512,8 @@ define <vscale x 4 x i32> @test_nontemporal_vp_gather_nxv4i32_S1(<vscale x 4 x p
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.s1
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v10, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 4 x i32> @llvm.vp.gather.nxv4i32.nxv4p0(<vscale x 4 x ptr> %ptrs, <vscale x 4 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !3
   ret <vscale x 4 x i32> %x
@@ -14447,7 +14533,8 @@ define <vscale x 4 x i32> @test_nontemporal_vp_gather_nxv4i32_ALL(<vscale x 4 x 
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.all
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v10, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv4i32_ALL:
@@ -14462,7 +14549,8 @@ define <vscale x 4 x i32> @test_nontemporal_vp_gather_nxv4i32_ALL(<vscale x 4 x 
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.all
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v10, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 4 x i32> @llvm.vp.gather.nxv4i32.nxv4p0(<vscale x 4 x ptr> %ptrs, <vscale x 4 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !4
   ret <vscale x 4 x i32> %x
@@ -14481,7 +14569,8 @@ define <vscale x 4 x i32> @test_nontemporal_vp_gather_nxv4i32_DEFAULT(<vscale x 
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.all
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v10, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv4i32_DEFAULT:
@@ -14496,7 +14585,8 @@ define <vscale x 4 x i32> @test_nontemporal_vp_gather_nxv4i32_DEFAULT(<vscale x 
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.all
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v10, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 4 x i32> @llvm.vp.gather.nxv4i32.nxv4p0(<vscale x 4 x ptr> %ptrs, <vscale x 4 x i1> splat(i1 true), i32 %vl), !nontemporal !0
   ret <vscale x 4 x i32> %x
@@ -15328,7 +15418,8 @@ define <vscale x 4 x i64> @test_nontemporal_vp_gather_nxv4i64_P1(<vscale x 4 x p
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v12, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv4i64_P1:
@@ -15344,7 +15435,8 @@ define <vscale x 4 x i64> @test_nontemporal_vp_gather_nxv4i64_P1(<vscale x 4 x p
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v12, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv4i64_P1:
@@ -15365,7 +15457,8 @@ define <vscale x 4 x i64> @test_nontemporal_vp_gather_nxv4i64_PALL(<vscale x 4 x
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v12, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv4i64_PALL:
@@ -15381,7 +15474,8 @@ define <vscale x 4 x i64> @test_nontemporal_vp_gather_nxv4i64_PALL(<vscale x 4 x
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v12, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv4i64_PALL:
@@ -15402,7 +15496,8 @@ define <vscale x 4 x i64> @test_nontemporal_vp_gather_nxv4i64_S1(<vscale x 4 x p
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v12, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv4i64_S1:
@@ -15418,7 +15513,8 @@ define <vscale x 4 x i64> @test_nontemporal_vp_gather_nxv4i64_S1(<vscale x 4 x p
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v12, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv4i64_S1:
@@ -15439,7 +15535,8 @@ define <vscale x 4 x i64> @test_nontemporal_vp_gather_nxv4i64_ALL(<vscale x 4 x 
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v12, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv4i64_ALL:
@@ -15455,7 +15552,8 @@ define <vscale x 4 x i64> @test_nontemporal_vp_gather_nxv4i64_ALL(<vscale x 4 x 
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v12, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv4i64_ALL:
@@ -15475,7 +15573,8 @@ define <vscale x 4 x i64> @test_nontemporal_vp_gather_nxv4i64_DEFAULT(<vscale x 
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v12, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv4i64_DEFAULT:
@@ -15491,7 +15590,8 @@ define <vscale x 4 x i64> @test_nontemporal_vp_gather_nxv4i64_DEFAULT(<vscale x 
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v12, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv4i64_DEFAULT:
@@ -16340,7 +16440,8 @@ define <vscale x 4 x float> @test_nontemporal_vp_gather_nxv4f32_P1(<vscale x 4 x
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.p1
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v10, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv4f32_P1:
@@ -16355,7 +16456,8 @@ define <vscale x 4 x float> @test_nontemporal_vp_gather_nxv4f32_P1(<vscale x 4 x
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.p1
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v10, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 4 x float> @llvm.vp.gather.nxv4f32.nxv4p0(<vscale x 4 x ptr> %ptrs, <vscale x 4 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !1
   ret <vscale x 4 x float> %x
@@ -16375,7 +16477,8 @@ define <vscale x 4 x float> @test_nontemporal_vp_gather_nxv4f32_PALL(<vscale x 4
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.pall
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v10, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv4f32_PALL:
@@ -16390,7 +16493,8 @@ define <vscale x 4 x float> @test_nontemporal_vp_gather_nxv4f32_PALL(<vscale x 4
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.pall
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v10, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 4 x float> @llvm.vp.gather.nxv4f32.nxv4p0(<vscale x 4 x ptr> %ptrs, <vscale x 4 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !2
   ret <vscale x 4 x float> %x
@@ -16410,7 +16514,8 @@ define <vscale x 4 x float> @test_nontemporal_vp_gather_nxv4f32_S1(<vscale x 4 x
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.s1
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v10, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv4f32_S1:
@@ -16425,7 +16530,8 @@ define <vscale x 4 x float> @test_nontemporal_vp_gather_nxv4f32_S1(<vscale x 4 x
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.s1
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v10, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 4 x float> @llvm.vp.gather.nxv4f32.nxv4p0(<vscale x 4 x ptr> %ptrs, <vscale x 4 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !3
   ret <vscale x 4 x float> %x
@@ -16445,7 +16551,8 @@ define <vscale x 4 x float> @test_nontemporal_vp_gather_nxv4f32_ALL(<vscale x 4 
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.all
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v10, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv4f32_ALL:
@@ -16460,7 +16567,8 @@ define <vscale x 4 x float> @test_nontemporal_vp_gather_nxv4f32_ALL(<vscale x 4 
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.all
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v10, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 4 x float> @llvm.vp.gather.nxv4f32.nxv4p0(<vscale x 4 x ptr> %ptrs, <vscale x 4 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !4
   ret <vscale x 4 x float> %x
@@ -16479,7 +16587,8 @@ define <vscale x 4 x float> @test_nontemporal_vp_gather_nxv4f32_DEFAULT(<vscale 
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.all
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v10, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv4f32_DEFAULT:
@@ -16494,7 +16603,8 @@ define <vscale x 4 x float> @test_nontemporal_vp_gather_nxv4f32_DEFAULT(<vscale 
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.all
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v10, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v10
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 4 x float> @llvm.vp.gather.nxv4f32.nxv4p0(<vscale x 4 x ptr> %ptrs, <vscale x 4 x i1> splat(i1 true), i32 %vl), !nontemporal !0
   ret <vscale x 4 x float> %x
@@ -17326,7 +17436,8 @@ define <vscale x 4 x double> @test_nontemporal_vp_gather_nxv4f64_P1(<vscale x 4 
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v12, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv4f64_P1:
@@ -17342,7 +17453,8 @@ define <vscale x 4 x double> @test_nontemporal_vp_gather_nxv4f64_P1(<vscale x 4 
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v12, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv4f64_P1:
@@ -17363,7 +17475,8 @@ define <vscale x 4 x double> @test_nontemporal_vp_gather_nxv4f64_PALL(<vscale x 
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v12, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv4f64_PALL:
@@ -17379,7 +17492,8 @@ define <vscale x 4 x double> @test_nontemporal_vp_gather_nxv4f64_PALL(<vscale x 
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v12, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv4f64_PALL:
@@ -17400,7 +17514,8 @@ define <vscale x 4 x double> @test_nontemporal_vp_gather_nxv4f64_S1(<vscale x 4 
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v12, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv4f64_S1:
@@ -17416,7 +17531,8 @@ define <vscale x 4 x double> @test_nontemporal_vp_gather_nxv4f64_S1(<vscale x 4 
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v12, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv4f64_S1:
@@ -17437,7 +17553,8 @@ define <vscale x 4 x double> @test_nontemporal_vp_gather_nxv4f64_ALL(<vscale x 4
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v12, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv4f64_ALL:
@@ -17453,7 +17570,8 @@ define <vscale x 4 x double> @test_nontemporal_vp_gather_nxv4f64_ALL(<vscale x 4
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v12, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv4f64_ALL:
@@ -17473,7 +17591,8 @@ define <vscale x 4 x double> @test_nontemporal_vp_gather_nxv4f64_DEFAULT(<vscale
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v12, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv4f64_DEFAULT:
@@ -17489,7 +17608,8 @@ define <vscale x 4 x double> @test_nontemporal_vp_gather_nxv4f64_DEFAULT(<vscale
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v12, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv4f64_DEFAULT:
@@ -20346,7 +20466,8 @@ define <vscale x 8 x i32> @test_nontemporal_vp_gather_nxv8i32_P1(<vscale x 8 x p
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m4, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.p1
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v12, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv8i32_P1:
@@ -20361,7 +20482,8 @@ define <vscale x 8 x i32> @test_nontemporal_vp_gather_nxv8i32_P1(<vscale x 8 x p
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m4, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.p1
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v12, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 8 x i32> @llvm.vp.gather.nxv8i32.nxv8p0(<vscale x 8 x ptr> %ptrs, <vscale x 8 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !1
   ret <vscale x 8 x i32> %x
@@ -20381,7 +20503,8 @@ define <vscale x 8 x i32> @test_nontemporal_vp_gather_nxv8i32_PALL(<vscale x 8 x
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m4, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.pall
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v12, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv8i32_PALL:
@@ -20396,7 +20519,8 @@ define <vscale x 8 x i32> @test_nontemporal_vp_gather_nxv8i32_PALL(<vscale x 8 x
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m4, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.pall
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v12, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 8 x i32> @llvm.vp.gather.nxv8i32.nxv8p0(<vscale x 8 x ptr> %ptrs, <vscale x 8 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !2
   ret <vscale x 8 x i32> %x
@@ -20416,7 +20540,8 @@ define <vscale x 8 x i32> @test_nontemporal_vp_gather_nxv8i32_S1(<vscale x 8 x p
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m4, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.s1
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v12, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv8i32_S1:
@@ -20431,7 +20556,8 @@ define <vscale x 8 x i32> @test_nontemporal_vp_gather_nxv8i32_S1(<vscale x 8 x p
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m4, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.s1
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v12, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 8 x i32> @llvm.vp.gather.nxv8i32.nxv8p0(<vscale x 8 x ptr> %ptrs, <vscale x 8 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !3
   ret <vscale x 8 x i32> %x
@@ -20451,7 +20577,8 @@ define <vscale x 8 x i32> @test_nontemporal_vp_gather_nxv8i32_ALL(<vscale x 8 x 
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m4, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.all
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v12, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv8i32_ALL:
@@ -20466,7 +20593,8 @@ define <vscale x 8 x i32> @test_nontemporal_vp_gather_nxv8i32_ALL(<vscale x 8 x 
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m4, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.all
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v12, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 8 x i32> @llvm.vp.gather.nxv8i32.nxv8p0(<vscale x 8 x ptr> %ptrs, <vscale x 8 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !4
   ret <vscale x 8 x i32> %x
@@ -20485,7 +20613,8 @@ define <vscale x 8 x i32> @test_nontemporal_vp_gather_nxv8i32_DEFAULT(<vscale x 
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m4, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.all
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v12, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv8i32_DEFAULT:
@@ -20500,7 +20629,8 @@ define <vscale x 8 x i32> @test_nontemporal_vp_gather_nxv8i32_DEFAULT(<vscale x 
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m4, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.all
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v12, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 8 x i32> @llvm.vp.gather.nxv8i32.nxv8p0(<vscale x 8 x ptr> %ptrs, <vscale x 8 x i1> splat(i1 true), i32 %vl), !nontemporal !0
   ret <vscale x 8 x i32> %x
@@ -21332,7 +21462,8 @@ define <vscale x 8 x i64> @test_nontemporal_vp_gather_nxv8i64_P1(<vscale x 8 x p
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v16, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv8i64_P1:
@@ -21348,7 +21479,8 @@ define <vscale x 8 x i64> @test_nontemporal_vp_gather_nxv8i64_P1(<vscale x 8 x p
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v16, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv8i64_P1:
@@ -21369,7 +21501,8 @@ define <vscale x 8 x i64> @test_nontemporal_vp_gather_nxv8i64_PALL(<vscale x 8 x
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v16, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv8i64_PALL:
@@ -21385,7 +21518,8 @@ define <vscale x 8 x i64> @test_nontemporal_vp_gather_nxv8i64_PALL(<vscale x 8 x
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v16, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv8i64_PALL:
@@ -21406,7 +21540,8 @@ define <vscale x 8 x i64> @test_nontemporal_vp_gather_nxv8i64_S1(<vscale x 8 x p
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v16, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv8i64_S1:
@@ -21422,7 +21557,8 @@ define <vscale x 8 x i64> @test_nontemporal_vp_gather_nxv8i64_S1(<vscale x 8 x p
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v16, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv8i64_S1:
@@ -21443,7 +21579,8 @@ define <vscale x 8 x i64> @test_nontemporal_vp_gather_nxv8i64_ALL(<vscale x 8 x 
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v16, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv8i64_ALL:
@@ -21459,7 +21596,8 @@ define <vscale x 8 x i64> @test_nontemporal_vp_gather_nxv8i64_ALL(<vscale x 8 x 
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v16, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv8i64_ALL:
@@ -21479,7 +21617,8 @@ define <vscale x 8 x i64> @test_nontemporal_vp_gather_nxv8i64_DEFAULT(<vscale x 
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v16, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv8i64_DEFAULT:
@@ -21495,7 +21634,8 @@ define <vscale x 8 x i64> @test_nontemporal_vp_gather_nxv8i64_DEFAULT(<vscale x 
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v16, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv8i64_DEFAULT:
@@ -22344,7 +22484,8 @@ define <vscale x 8 x float> @test_nontemporal_vp_gather_nxv8f32_P1(<vscale x 8 x
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m4, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.p1
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v12, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv8f32_P1:
@@ -22359,7 +22500,8 @@ define <vscale x 8 x float> @test_nontemporal_vp_gather_nxv8f32_P1(<vscale x 8 x
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m4, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.p1
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v12, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 8 x float> @llvm.vp.gather.nxv8f32.nxv8p0(<vscale x 8 x ptr> %ptrs, <vscale x 8 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !1
   ret <vscale x 8 x float> %x
@@ -22379,7 +22521,8 @@ define <vscale x 8 x float> @test_nontemporal_vp_gather_nxv8f32_PALL(<vscale x 8
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m4, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.pall
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v12, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv8f32_PALL:
@@ -22394,7 +22537,8 @@ define <vscale x 8 x float> @test_nontemporal_vp_gather_nxv8f32_PALL(<vscale x 8
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m4, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.pall
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v12, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 8 x float> @llvm.vp.gather.nxv8f32.nxv8p0(<vscale x 8 x ptr> %ptrs, <vscale x 8 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !2
   ret <vscale x 8 x float> %x
@@ -22414,7 +22558,8 @@ define <vscale x 8 x float> @test_nontemporal_vp_gather_nxv8f32_S1(<vscale x 8 x
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m4, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.s1
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v12, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv8f32_S1:
@@ -22429,7 +22574,8 @@ define <vscale x 8 x float> @test_nontemporal_vp_gather_nxv8f32_S1(<vscale x 8 x
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m4, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.s1
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v12, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 8 x float> @llvm.vp.gather.nxv8f32.nxv8p0(<vscale x 8 x ptr> %ptrs, <vscale x 8 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !3
   ret <vscale x 8 x float> %x
@@ -22449,7 +22595,8 @@ define <vscale x 8 x float> @test_nontemporal_vp_gather_nxv8f32_ALL(<vscale x 8 
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m4, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.all
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v12, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv8f32_ALL:
@@ -22464,7 +22611,8 @@ define <vscale x 8 x float> @test_nontemporal_vp_gather_nxv8f32_ALL(<vscale x 8 
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m4, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.all
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v12, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 8 x float> @llvm.vp.gather.nxv8f32.nxv8p0(<vscale x 8 x ptr> %ptrs, <vscale x 8 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !4
   ret <vscale x 8 x float> %x
@@ -22483,7 +22631,8 @@ define <vscale x 8 x float> @test_nontemporal_vp_gather_nxv8f32_DEFAULT(<vscale 
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m4, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.all
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v12, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv8f32_DEFAULT:
@@ -22498,7 +22647,8 @@ define <vscale x 8 x float> @test_nontemporal_vp_gather_nxv8f32_DEFAULT(<vscale 
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m4, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.all
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v12, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v12
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 8 x float> @llvm.vp.gather.nxv8f32.nxv8p0(<vscale x 8 x ptr> %ptrs, <vscale x 8 x i1> splat(i1 true), i32 %vl), !nontemporal !0
   ret <vscale x 8 x float> %x
@@ -23330,7 +23480,8 @@ define <vscale x 8 x double> @test_nontemporal_vp_gather_nxv8f64_P1(<vscale x 8 
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v16, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv8f64_P1:
@@ -23346,7 +23497,8 @@ define <vscale x 8 x double> @test_nontemporal_vp_gather_nxv8f64_P1(<vscale x 8 
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v16, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv8f64_P1:
@@ -23367,7 +23519,8 @@ define <vscale x 8 x double> @test_nontemporal_vp_gather_nxv8f64_PALL(<vscale x 
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v16, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv8f64_PALL:
@@ -23383,7 +23536,8 @@ define <vscale x 8 x double> @test_nontemporal_vp_gather_nxv8f64_PALL(<vscale x 
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v16, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv8f64_PALL:
@@ -23404,7 +23558,8 @@ define <vscale x 8 x double> @test_nontemporal_vp_gather_nxv8f64_S1(<vscale x 8 
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v16, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv8f64_S1:
@@ -23420,7 +23575,8 @@ define <vscale x 8 x double> @test_nontemporal_vp_gather_nxv8f64_S1(<vscale x 8 
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v16, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv8f64_S1:
@@ -23441,7 +23597,8 @@ define <vscale x 8 x double> @test_nontemporal_vp_gather_nxv8f64_ALL(<vscale x 8
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v16, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv8f64_ALL:
@@ -23457,7 +23614,8 @@ define <vscale x 8 x double> @test_nontemporal_vp_gather_nxv8f64_ALL(<vscale x 8
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v16, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv8f64_ALL:
@@ -23477,7 +23635,8 @@ define <vscale x 8 x double> @test_nontemporal_vp_gather_nxv8f64_DEFAULT(<vscale
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v16, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_nxv8f64_DEFAULT:
@@ -23493,7 +23652,8 @@ define <vscale x 8 x double> @test_nontemporal_vp_gather_nxv8f64_DEFAULT(<vscale
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v16, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_nxv8f64_DEFAULT:
@@ -26882,7 +27042,8 @@ define <vscale x 16 x i32> @test_nontemporal_vp_gather_nxv16i32_P1(<vscale x 16 
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.p1
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v16, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv16i32_P1:
@@ -26909,7 +27070,8 @@ define <vscale x 16 x i32> @test_nontemporal_vp_gather_nxv16i32_P1(<vscale x 16 
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.p1
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v16, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 16 x i32> @llvm.vp.gather.nxv16i32.nxv16p0(<vscale x 16 x ptr> %ptrs, <vscale x 16 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !1
   ret <vscale x 16 x i32> %x
@@ -26941,7 +27103,8 @@ define <vscale x 16 x i32> @test_nontemporal_vp_gather_nxv16i32_PALL(<vscale x 1
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.pall
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v16, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv16i32_PALL:
@@ -26968,7 +27131,8 @@ define <vscale x 16 x i32> @test_nontemporal_vp_gather_nxv16i32_PALL(<vscale x 1
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.pall
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v16, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 16 x i32> @llvm.vp.gather.nxv16i32.nxv16p0(<vscale x 16 x ptr> %ptrs, <vscale x 16 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !2
   ret <vscale x 16 x i32> %x
@@ -27000,7 +27164,8 @@ define <vscale x 16 x i32> @test_nontemporal_vp_gather_nxv16i32_S1(<vscale x 16 
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.s1
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v16, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv16i32_S1:
@@ -27027,7 +27192,8 @@ define <vscale x 16 x i32> @test_nontemporal_vp_gather_nxv16i32_S1(<vscale x 16 
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.s1
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v16, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 16 x i32> @llvm.vp.gather.nxv16i32.nxv16p0(<vscale x 16 x ptr> %ptrs, <vscale x 16 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !3
   ret <vscale x 16 x i32> %x
@@ -27059,7 +27225,8 @@ define <vscale x 16 x i32> @test_nontemporal_vp_gather_nxv16i32_ALL(<vscale x 16
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.all
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v16, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv16i32_ALL:
@@ -27086,7 +27253,8 @@ define <vscale x 16 x i32> @test_nontemporal_vp_gather_nxv16i32_ALL(<vscale x 16
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.all
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v16, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 16 x i32> @llvm.vp.gather.nxv16i32.nxv16p0(<vscale x 16 x ptr> %ptrs, <vscale x 16 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !4
   ret <vscale x 16 x i32> %x
@@ -27117,7 +27285,8 @@ define <vscale x 16 x i32> @test_nontemporal_vp_gather_nxv16i32_DEFAULT(<vscale 
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.all
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v16, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv16i32_DEFAULT:
@@ -27144,7 +27313,8 @@ define <vscale x 16 x i32> @test_nontemporal_vp_gather_nxv16i32_DEFAULT(<vscale 
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.all
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v16, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 16 x i32> @llvm.vp.gather.nxv16i32.nxv16p0(<vscale x 16 x ptr> %ptrs, <vscale x 16 x i1> splat(i1 true), i32 %vl), !nontemporal !0
   ret <vscale x 16 x i32> %x
@@ -28136,7 +28306,8 @@ define <vscale x 16 x float> @test_nontemporal_vp_gather_nxv16f32_P1(<vscale x 1
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.p1
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v16, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv16f32_P1:
@@ -28163,7 +28334,8 @@ define <vscale x 16 x float> @test_nontemporal_vp_gather_nxv16f32_P1(<vscale x 1
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.p1
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v16, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 16 x float> @llvm.vp.gather.nxv16f32.nxv16p0(<vscale x 16 x ptr> %ptrs, <vscale x 16 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !1
   ret <vscale x 16 x float> %x
@@ -28195,7 +28367,8 @@ define <vscale x 16 x float> @test_nontemporal_vp_gather_nxv16f32_PALL(<vscale x
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.pall
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v16, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv16f32_PALL:
@@ -28222,7 +28395,8 @@ define <vscale x 16 x float> @test_nontemporal_vp_gather_nxv16f32_PALL(<vscale x
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.pall
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v16, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 16 x float> @llvm.vp.gather.nxv16f32.nxv16p0(<vscale x 16 x ptr> %ptrs, <vscale x 16 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !2
   ret <vscale x 16 x float> %x
@@ -28254,7 +28428,8 @@ define <vscale x 16 x float> @test_nontemporal_vp_gather_nxv16f32_S1(<vscale x 1
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.s1
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v16, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv16f32_S1:
@@ -28281,7 +28456,8 @@ define <vscale x 16 x float> @test_nontemporal_vp_gather_nxv16f32_S1(<vscale x 1
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.s1
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v16, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 16 x float> @llvm.vp.gather.nxv16f32.nxv16p0(<vscale x 16 x ptr> %ptrs, <vscale x 16 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !3
   ret <vscale x 16 x float> %x
@@ -28313,7 +28489,8 @@ define <vscale x 16 x float> @test_nontemporal_vp_gather_nxv16f32_ALL(<vscale x 
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.all
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v16, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv16f32_ALL:
@@ -28340,7 +28517,8 @@ define <vscale x 16 x float> @test_nontemporal_vp_gather_nxv16f32_ALL(<vscale x 
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.all
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v16, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 16 x float> @llvm.vp.gather.nxv16f32.nxv16p0(<vscale x 16 x ptr> %ptrs, <vscale x 16 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !4
   ret <vscale x 16 x float> %x
@@ -28371,7 +28549,8 @@ define <vscale x 16 x float> @test_nontemporal_vp_gather_nxv16f32_DEFAULT(<vscal
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.all
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v16, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_nxv16f32_DEFAULT:
@@ -28398,7 +28577,8 @@ define <vscale x 16 x float> @test_nontemporal_vp_gather_nxv16f32_DEFAULT(<vscal
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.all
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v16, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v16
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <vscale x 16 x float> @llvm.vp.gather.nxv16f32.nxv16p0(<vscale x 16 x ptr> %ptrs, <vscale x 16 x i1> splat(i1 true), i32 %vl), !nontemporal !0
   ret <vscale x 16 x float> %x

--- a/llvm/test/CodeGen/RISCV/rvv/nontemporal-vp.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/nontemporal-vp.ll
@@ -2354,7 +2354,8 @@ define <4 x i32> @test_nontemporal_vp_gather_v4i32_P1(<4 x ptr> %ptrs, i32 zeroe
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.p1
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_v4i32_P1:
@@ -2369,7 +2370,8 @@ define <4 x i32> @test_nontemporal_vp_gather_v4i32_P1(<4 x ptr> %ptrs, i32 zeroe
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.p1
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <4 x i32> @llvm.vp.gather.v4i32.v4p0(<4 x ptr> %ptrs, <4 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !1
   ret <4 x i32> %x
@@ -2389,7 +2391,8 @@ define <4 x i32> @test_nontemporal_vp_gather_v4i32_PALL(<4 x ptr> %ptrs, i32 zer
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.pall
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_v4i32_PALL:
@@ -2404,7 +2407,8 @@ define <4 x i32> @test_nontemporal_vp_gather_v4i32_PALL(<4 x ptr> %ptrs, i32 zer
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.pall
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <4 x i32> @llvm.vp.gather.v4i32.v4p0(<4 x ptr> %ptrs, <4 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !2
   ret <4 x i32> %x
@@ -2424,7 +2428,8 @@ define <4 x i32> @test_nontemporal_vp_gather_v4i32_S1(<4 x ptr> %ptrs, i32 zeroe
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.s1
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_v4i32_S1:
@@ -2439,7 +2444,8 @@ define <4 x i32> @test_nontemporal_vp_gather_v4i32_S1(<4 x ptr> %ptrs, i32 zeroe
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.s1
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <4 x i32> @llvm.vp.gather.v4i32.v4p0(<4 x ptr> %ptrs, <4 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !3
   ret <4 x i32> %x
@@ -2459,7 +2465,8 @@ define <4 x i32> @test_nontemporal_vp_gather_v4i32_ALL(<4 x ptr> %ptrs, i32 zero
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.all
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_v4i32_ALL:
@@ -2474,7 +2481,8 @@ define <4 x i32> @test_nontemporal_vp_gather_v4i32_ALL(<4 x ptr> %ptrs, i32 zero
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.all
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <4 x i32> @llvm.vp.gather.v4i32.v4p0(<4 x ptr> %ptrs, <4 x i1> splat(i1 true), i32 %vl), !nontemporal !0, !riscv-nontemporal-domain !4
   ret <4 x i32> %x
@@ -2493,7 +2501,8 @@ define <4 x i32> @test_nontemporal_vp_gather_v4i32_DEFAULT(<4 x ptr> %ptrs, i32 
 ; CHECK-RV32V:       # %bb.0:
 ; CHECK-RV32V-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32V-NEXT:    ntl.all
-; CHECK-RV32V-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32V-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32V-NEXT:    ret
 ;
 ; CHECK-RV64VC-LABEL: test_nontemporal_vp_gather_v4i32_DEFAULT:
@@ -2508,7 +2517,8 @@ define <4 x i32> @test_nontemporal_vp_gather_v4i32_DEFAULT(<4 x ptr> %ptrs, i32 
 ; CHECK-RV32VC:       # %bb.0:
 ; CHECK-RV32VC-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
 ; CHECK-RV32VC-NEXT:    c.ntl.all
-; CHECK-RV32VC-NEXT:    vluxei32.v v8, (zero), v8
+; CHECK-RV32VC-NEXT:    vluxei32.v v9, (zero), v8
+; CHECK-RV32VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV32VC-NEXT:    ret
   %x = call <4 x i32> @llvm.vp.gather.v4i32.v4p0(<4 x ptr> %ptrs, <4 x i1> splat(i1 true), i32 %vl), !nontemporal !0
   ret <4 x i32> %x
@@ -3340,7 +3350,8 @@ define <2 x i64> @test_nontemporal_vp_gather_v2i64_P1(<2 x ptr> %ptrs, i32 zeroe
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.p1
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_v2i64_P1:
@@ -3355,7 +3366,8 @@ define <2 x i64> @test_nontemporal_vp_gather_v2i64_P1(<2 x ptr> %ptrs, i32 zeroe
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.p1
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_v2i64_P1:
@@ -3375,7 +3387,8 @@ define <2 x i64> @test_nontemporal_vp_gather_v2i64_PALL(<2 x ptr> %ptrs, i32 zer
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.pall
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_v2i64_PALL:
@@ -3390,7 +3403,8 @@ define <2 x i64> @test_nontemporal_vp_gather_v2i64_PALL(<2 x ptr> %ptrs, i32 zer
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.pall
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_v2i64_PALL:
@@ -3410,7 +3424,8 @@ define <2 x i64> @test_nontemporal_vp_gather_v2i64_S1(<2 x ptr> %ptrs, i32 zeroe
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.s1
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_v2i64_S1:
@@ -3425,7 +3440,8 @@ define <2 x i64> @test_nontemporal_vp_gather_v2i64_S1(<2 x ptr> %ptrs, i32 zeroe
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.s1
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_v2i64_S1:
@@ -3445,7 +3461,8 @@ define <2 x i64> @test_nontemporal_vp_gather_v2i64_ALL(<2 x ptr> %ptrs, i32 zero
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_v2i64_ALL:
@@ -3460,7 +3477,8 @@ define <2 x i64> @test_nontemporal_vp_gather_v2i64_ALL(<2 x ptr> %ptrs, i32 zero
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_v2i64_ALL:
@@ -3479,7 +3497,8 @@ define <2 x i64> @test_nontemporal_vp_gather_v2i64_DEFAULT(<2 x ptr> %ptrs, i32 
 ; CHECK-RV64V:       # %bb.0:
 ; CHECK-RV64V-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64V-NEXT:    ntl.all
-; CHECK-RV64V-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64V-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64V-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64V-NEXT:    ret
 ;
 ; CHECK-RV32V-LABEL: test_nontemporal_vp_gather_v2i64_DEFAULT:
@@ -3494,7 +3513,8 @@ define <2 x i64> @test_nontemporal_vp_gather_v2i64_DEFAULT(<2 x ptr> %ptrs, i32 
 ; CHECK-RV64VC:       # %bb.0:
 ; CHECK-RV64VC-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
 ; CHECK-RV64VC-NEXT:    c.ntl.all
-; CHECK-RV64VC-NEXT:    vluxei64.v v8, (zero), v8
+; CHECK-RV64VC-NEXT:    vluxei64.v v9, (zero), v8
+; CHECK-RV64VC-NEXT:    vmv.v.v v8, v9
 ; CHECK-RV64VC-NEXT:    ret
 ;
 ; CHECK-RV32VC-LABEL: test_nontemporal_vp_gather_v2i64_DEFAULT:

--- a/llvm/test/CodeGen/RISCV/rvv/vloxei-rv64.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vloxei-rv64.ll
@@ -416,7 +416,8 @@ define <vscale x 1 x i64> @intrinsic_vloxei_v_nxv1i64_nxv1i64_nxv1i64(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv1i64_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m1, ta, ma
-; CHECK-NEXT:    vloxei64.v v8, (a0), v8
+; CHECK-NEXT:    vloxei64.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x i64> @llvm.riscv.vloxei.nxv1i64.nxv1i64(
@@ -449,7 +450,8 @@ define <vscale x 2 x i64> @intrinsic_vloxei_v_nxv2i64_nxv2i64_nxv2i64(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv2i64_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m2, ta, ma
-; CHECK-NEXT:    vloxei64.v v8, (a0), v8
+; CHECK-NEXT:    vloxei64.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x i64> @llvm.riscv.vloxei.nxv2i64.nxv2i64(
@@ -482,7 +484,8 @@ define <vscale x 4 x i64> @intrinsic_vloxei_v_nxv4i64_nxv4i64_nxv4i64(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv4i64_nxv4i64_nxv4i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m4, ta, ma
-; CHECK-NEXT:    vloxei64.v v8, (a0), v8
+; CHECK-NEXT:    vloxei64.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x i64> @llvm.riscv.vloxei.nxv4i64.nxv4i64(
@@ -515,7 +518,8 @@ define <vscale x 8 x i64> @intrinsic_vloxei_v_nxv8i64_nxv8i64_nxv8i64(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv8i64_nxv8i64_nxv8i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; CHECK-NEXT:    vloxei64.v v8, (a0), v8
+; CHECK-NEXT:    vloxei64.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x i64> @llvm.riscv.vloxei.nxv8i64.nxv8i64(
@@ -956,7 +960,8 @@ define <vscale x 1 x double> @intrinsic_vloxei_v_nxv1f64_nxv1f64_nxv1i64(ptr %0,
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv1f64_nxv1f64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m1, ta, ma
-; CHECK-NEXT:    vloxei64.v v8, (a0), v8
+; CHECK-NEXT:    vloxei64.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x double> @llvm.riscv.vloxei.nxv1f64.nxv1i64(
@@ -989,7 +994,8 @@ define <vscale x 2 x double> @intrinsic_vloxei_v_nxv2f64_nxv2f64_nxv2i64(ptr %0,
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv2f64_nxv2f64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m2, ta, ma
-; CHECK-NEXT:    vloxei64.v v8, (a0), v8
+; CHECK-NEXT:    vloxei64.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x double> @llvm.riscv.vloxei.nxv2f64.nxv2i64(
@@ -1022,7 +1028,8 @@ define <vscale x 4 x double> @intrinsic_vloxei_v_nxv4f64_nxv4f64_nxv4i64(ptr %0,
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv4f64_nxv4f64_nxv4i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m4, ta, ma
-; CHECK-NEXT:    vloxei64.v v8, (a0), v8
+; CHECK-NEXT:    vloxei64.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x double> @llvm.riscv.vloxei.nxv4f64.nxv4i64(
@@ -1055,7 +1062,8 @@ define <vscale x 8 x double> @intrinsic_vloxei_v_nxv8f64_nxv8f64_nxv8i64(ptr %0,
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv8f64_nxv8f64_nxv8i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; CHECK-NEXT:    vloxei64.v v8, (a0), v8
+; CHECK-NEXT:    vloxei64.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x double> @llvm.riscv.vloxei.nxv8f64.nxv8i64(

--- a/llvm/test/CodeGen/RISCV/rvv/vloxei.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vloxei.ll
@@ -348,7 +348,8 @@ define <vscale x 1 x i32> @intrinsic_vloxei_v_nxv1i32_nxv1i32_nxv1i32(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv1i32_nxv1i32_nxv1i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, mf2, ta, ma
-; CHECK-NEXT:    vloxei32.v v8, (a0), v8
+; CHECK-NEXT:    vloxei32.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x i32> @llvm.riscv.vloxei.nxv1i32.nxv1i32(
@@ -381,7 +382,8 @@ define <vscale x 2 x i32> @intrinsic_vloxei_v_nxv2i32_nxv2i32_nxv2i32(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv2i32_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m1, ta, ma
-; CHECK-NEXT:    vloxei32.v v8, (a0), v8
+; CHECK-NEXT:    vloxei32.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x i32> @llvm.riscv.vloxei.nxv2i32.nxv2i32(
@@ -414,7 +416,8 @@ define <vscale x 4 x i32> @intrinsic_vloxei_v_nxv4i32_nxv4i32_nxv4i32(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv4i32_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m2, ta, ma
-; CHECK-NEXT:    vloxei32.v v8, (a0), v8
+; CHECK-NEXT:    vloxei32.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x i32> @llvm.riscv.vloxei.nxv4i32.nxv4i32(
@@ -447,7 +450,8 @@ define <vscale x 8 x i32> @intrinsic_vloxei_v_nxv8i32_nxv8i32_nxv8i32(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv8i32_nxv8i32_nxv8i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m4, ta, ma
-; CHECK-NEXT:    vloxei32.v v8, (a0), v8
+; CHECK-NEXT:    vloxei32.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x i32> @llvm.riscv.vloxei.nxv8i32.nxv8i32(
@@ -480,7 +484,8 @@ define <vscale x 16 x i32> @intrinsic_vloxei_v_nxv16i32_nxv16i32_nxv16i32(ptr %0
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv16i32_nxv16i32_nxv16i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, ta, ma
-; CHECK-NEXT:    vloxei32.v v8, (a0), v8
+; CHECK-NEXT:    vloxei32.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x i32> @llvm.riscv.vloxei.nxv16i32.nxv16i32(
@@ -819,7 +824,8 @@ define <vscale x 1 x float> @intrinsic_vloxei_v_nxv1f32_nxv1f32_nxv1i32(ptr %0, 
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv1f32_nxv1f32_nxv1i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, mf2, ta, ma
-; CHECK-NEXT:    vloxei32.v v8, (a0), v8
+; CHECK-NEXT:    vloxei32.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x float> @llvm.riscv.vloxei.nxv1f32.nxv1i32(
@@ -852,7 +858,8 @@ define <vscale x 2 x float> @intrinsic_vloxei_v_nxv2f32_nxv2f32_nxv2i32(ptr %0, 
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv2f32_nxv2f32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m1, ta, ma
-; CHECK-NEXT:    vloxei32.v v8, (a0), v8
+; CHECK-NEXT:    vloxei32.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x float> @llvm.riscv.vloxei.nxv2f32.nxv2i32(
@@ -885,7 +892,8 @@ define <vscale x 4 x float> @intrinsic_vloxei_v_nxv4f32_nxv4f32_nxv4i32(ptr %0, 
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv4f32_nxv4f32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m2, ta, ma
-; CHECK-NEXT:    vloxei32.v v8, (a0), v8
+; CHECK-NEXT:    vloxei32.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x float> @llvm.riscv.vloxei.nxv4f32.nxv4i32(
@@ -918,7 +926,8 @@ define <vscale x 8 x float> @intrinsic_vloxei_v_nxv8f32_nxv8f32_nxv8i32(ptr %0, 
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv8f32_nxv8f32_nxv8i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m4, ta, ma
-; CHECK-NEXT:    vloxei32.v v8, (a0), v8
+; CHECK-NEXT:    vloxei32.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x float> @llvm.riscv.vloxei.nxv8f32.nxv8i32(
@@ -951,7 +960,8 @@ define <vscale x 16 x float> @intrinsic_vloxei_v_nxv16f32_nxv16f32_nxv16i32(ptr 
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv16f32_nxv16f32_nxv16i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, ta, ma
-; CHECK-NEXT:    vloxei32.v v8, (a0), v8
+; CHECK-NEXT:    vloxei32.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x float> @llvm.riscv.vloxei.nxv16f32.nxv16i32(
@@ -1324,7 +1334,8 @@ define <vscale x 1 x i16> @intrinsic_vloxei_v_nxv1i16_nxv1i16_nxv1i16(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv1i16_nxv1i16_nxv1i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, mf4, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x i16> @llvm.riscv.vloxei.nxv1i16.nxv1i16(
@@ -1357,7 +1368,8 @@ define <vscale x 2 x i16> @intrinsic_vloxei_v_nxv2i16_nxv2i16_nxv2i16(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv2i16_nxv2i16_nxv2i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, mf2, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x i16> @llvm.riscv.vloxei.nxv2i16.nxv2i16(
@@ -1390,7 +1402,8 @@ define <vscale x 4 x i16> @intrinsic_vloxei_v_nxv4i16_nxv4i16_nxv4i16(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv4i16_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m1, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x i16> @llvm.riscv.vloxei.nxv4i16.nxv4i16(
@@ -1423,7 +1436,8 @@ define <vscale x 8 x i16> @intrinsic_vloxei_v_nxv8i16_nxv8i16_nxv8i16(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv8i16_nxv8i16_nxv8i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m2, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x i16> @llvm.riscv.vloxei.nxv8i16.nxv8i16(
@@ -1456,7 +1470,8 @@ define <vscale x 16 x i16> @intrinsic_vloxei_v_nxv16i16_nxv16i16_nxv16i16(ptr %0
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv16i16_nxv16i16_nxv16i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m4, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x i16> @llvm.riscv.vloxei.nxv16i16.nxv16i16(
@@ -1489,7 +1504,8 @@ define <vscale x 32 x i16> @intrinsic_vloxei_v_nxv32i16_nxv32i16_nxv32i16(ptr %0
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv32i16_nxv32i16_nxv32i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m8, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 32 x i16> @llvm.riscv.vloxei.nxv32i16.nxv32i16(
@@ -1828,7 +1844,8 @@ define <vscale x 1 x half> @intrinsic_vloxei_v_nxv1f16_nxv1f16_nxv1i16(ptr %0, <
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv1f16_nxv1f16_nxv1i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, mf4, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x half> @llvm.riscv.vloxei.nxv1f16.nxv1i16(
@@ -1861,7 +1878,8 @@ define <vscale x 2 x half> @intrinsic_vloxei_v_nxv2f16_nxv2f16_nxv2i16(ptr %0, <
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv2f16_nxv2f16_nxv2i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, mf2, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x half> @llvm.riscv.vloxei.nxv2f16.nxv2i16(
@@ -1894,7 +1912,8 @@ define <vscale x 4 x half> @intrinsic_vloxei_v_nxv4f16_nxv4f16_nxv4i16(ptr %0, <
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv4f16_nxv4f16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m1, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x half> @llvm.riscv.vloxei.nxv4f16.nxv4i16(
@@ -1927,7 +1946,8 @@ define <vscale x 8 x half> @intrinsic_vloxei_v_nxv8f16_nxv8f16_nxv8i16(ptr %0, <
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv8f16_nxv8f16_nxv8i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m2, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x half> @llvm.riscv.vloxei.nxv8f16.nxv8i16(
@@ -1960,7 +1980,8 @@ define <vscale x 16 x half> @intrinsic_vloxei_v_nxv16f16_nxv16f16_nxv16i16(ptr %
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv16f16_nxv16f16_nxv16i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m4, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x half> @llvm.riscv.vloxei.nxv16f16.nxv16i16(
@@ -1993,7 +2014,8 @@ define <vscale x 32 x half> @intrinsic_vloxei_v_nxv32f16_nxv32f16_nxv32i16(ptr %
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv32f16_nxv32f16_nxv32i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m8, ta, ma
-; CHECK-NEXT:    vloxei16.v v8, (a0), v8
+; CHECK-NEXT:    vloxei16.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 32 x half> @llvm.riscv.vloxei.nxv32f16.nxv32i16(
@@ -2332,7 +2354,8 @@ define <vscale x 1 x i8> @intrinsic_vloxei_v_nxv1i8_nxv1i8_nxv1i8(ptr %0, <vscal
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv1i8_nxv1i8_nxv1i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, mf8, ta, ma
-; CHECK-NEXT:    vloxei8.v v8, (a0), v8
+; CHECK-NEXT:    vloxei8.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x i8> @llvm.riscv.vloxei.nxv1i8.nxv1i8(
@@ -2365,7 +2388,8 @@ define <vscale x 2 x i8> @intrinsic_vloxei_v_nxv2i8_nxv2i8_nxv2i8(ptr %0, <vscal
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv2i8_nxv2i8_nxv2i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, mf4, ta, ma
-; CHECK-NEXT:    vloxei8.v v8, (a0), v8
+; CHECK-NEXT:    vloxei8.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x i8> @llvm.riscv.vloxei.nxv2i8.nxv2i8(
@@ -2398,7 +2422,8 @@ define <vscale x 4 x i8> @intrinsic_vloxei_v_nxv4i8_nxv4i8_nxv4i8(ptr %0, <vscal
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv4i8_nxv4i8_nxv4i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, mf2, ta, ma
-; CHECK-NEXT:    vloxei8.v v8, (a0), v8
+; CHECK-NEXT:    vloxei8.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x i8> @llvm.riscv.vloxei.nxv4i8.nxv4i8(
@@ -2431,7 +2456,8 @@ define <vscale x 8 x i8> @intrinsic_vloxei_v_nxv8i8_nxv8i8_nxv8i8(ptr %0, <vscal
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv8i8_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-NEXT:    vloxei8.v v8, (a0), v8
+; CHECK-NEXT:    vloxei8.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x i8> @llvm.riscv.vloxei.nxv8i8.nxv8i8(
@@ -2464,7 +2490,8 @@ define <vscale x 16 x i8> @intrinsic_vloxei_v_nxv16i8_nxv16i8_nxv16i8(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv16i8_nxv16i8_nxv16i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, m2, ta, ma
-; CHECK-NEXT:    vloxei8.v v8, (a0), v8
+; CHECK-NEXT:    vloxei8.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x i8> @llvm.riscv.vloxei.nxv16i8.nxv16i8(
@@ -2497,7 +2524,8 @@ define <vscale x 32 x i8> @intrinsic_vloxei_v_nxv32i8_nxv32i8_nxv32i8(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv32i8_nxv32i8_nxv32i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, m4, ta, ma
-; CHECK-NEXT:    vloxei8.v v8, (a0), v8
+; CHECK-NEXT:    vloxei8.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 32 x i8> @llvm.riscv.vloxei.nxv32i8.nxv32i8(
@@ -2530,7 +2558,8 @@ define <vscale x 64 x i8> @intrinsic_vloxei_v_nxv64i8_nxv64i8_nxv64i8(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vloxei_v_nxv64i8_nxv64i8_nxv64i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, m8, ta, ma
-; CHECK-NEXT:    vloxei8.v v8, (a0), v8
+; CHECK-NEXT:    vloxei8.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 64 x i8> @llvm.riscv.vloxei.nxv64i8.nxv64i8(

--- a/llvm/test/CodeGen/RISCV/rvv/vluxei-rv64.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vluxei-rv64.ll
@@ -416,7 +416,8 @@ define <vscale x 1 x i64> @intrinsic_vluxei_v_nxv1i64_nxv1i64_nxv1i64(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv1i64_nxv1i64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m1, ta, ma
-; CHECK-NEXT:    vluxei64.v v8, (a0), v8
+; CHECK-NEXT:    vluxei64.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x i64> @llvm.riscv.vluxei.nxv1i64.nxv1i64(
@@ -449,7 +450,8 @@ define <vscale x 2 x i64> @intrinsic_vluxei_v_nxv2i64_nxv2i64_nxv2i64(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv2i64_nxv2i64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m2, ta, ma
-; CHECK-NEXT:    vluxei64.v v8, (a0), v8
+; CHECK-NEXT:    vluxei64.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x i64> @llvm.riscv.vluxei.nxv2i64.nxv2i64(
@@ -482,7 +484,8 @@ define <vscale x 4 x i64> @intrinsic_vluxei_v_nxv4i64_nxv4i64_nxv4i64(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv4i64_nxv4i64_nxv4i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m4, ta, ma
-; CHECK-NEXT:    vluxei64.v v8, (a0), v8
+; CHECK-NEXT:    vluxei64.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x i64> @llvm.riscv.vluxei.nxv4i64.nxv4i64(
@@ -515,7 +518,8 @@ define <vscale x 8 x i64> @intrinsic_vluxei_v_nxv8i64_nxv8i64_nxv8i64(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv8i64_nxv8i64_nxv8i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; CHECK-NEXT:    vluxei64.v v8, (a0), v8
+; CHECK-NEXT:    vluxei64.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x i64> @llvm.riscv.vluxei.nxv8i64.nxv8i64(
@@ -956,7 +960,8 @@ define <vscale x 1 x double> @intrinsic_vluxei_v_nxv1f64_nxv1f64_nxv1i64(ptr %0,
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv1f64_nxv1f64_nxv1i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m1, ta, ma
-; CHECK-NEXT:    vluxei64.v v8, (a0), v8
+; CHECK-NEXT:    vluxei64.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x double> @llvm.riscv.vluxei.nxv1f64.nxv1i64(
@@ -989,7 +994,8 @@ define <vscale x 2 x double> @intrinsic_vluxei_v_nxv2f64_nxv2f64_nxv2i64(ptr %0,
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv2f64_nxv2f64_nxv2i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m2, ta, ma
-; CHECK-NEXT:    vluxei64.v v8, (a0), v8
+; CHECK-NEXT:    vluxei64.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x double> @llvm.riscv.vluxei.nxv2f64.nxv2i64(
@@ -1022,7 +1028,8 @@ define <vscale x 4 x double> @intrinsic_vluxei_v_nxv4f64_nxv4f64_nxv4i64(ptr %0,
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv4f64_nxv4f64_nxv4i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m4, ta, ma
-; CHECK-NEXT:    vluxei64.v v8, (a0), v8
+; CHECK-NEXT:    vluxei64.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x double> @llvm.riscv.vluxei.nxv4f64.nxv4i64(
@@ -1055,7 +1062,8 @@ define <vscale x 8 x double> @intrinsic_vluxei_v_nxv8f64_nxv8f64_nxv8i64(ptr %0,
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv8f64_nxv8f64_nxv8i64:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; CHECK-NEXT:    vluxei64.v v8, (a0), v8
+; CHECK-NEXT:    vluxei64.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x double> @llvm.riscv.vluxei.nxv8f64.nxv8i64(

--- a/llvm/test/CodeGen/RISCV/rvv/vluxei.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vluxei.ll
@@ -348,7 +348,8 @@ define <vscale x 1 x i32> @intrinsic_vluxei_v_nxv1i32_nxv1i32_nxv1i32(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv1i32_nxv1i32_nxv1i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, mf2, ta, ma
-; CHECK-NEXT:    vluxei32.v v8, (a0), v8
+; CHECK-NEXT:    vluxei32.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x i32> @llvm.riscv.vluxei.nxv1i32.nxv1i32(
@@ -381,7 +382,8 @@ define <vscale x 2 x i32> @intrinsic_vluxei_v_nxv2i32_nxv2i32_nxv2i32(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv2i32_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m1, ta, ma
-; CHECK-NEXT:    vluxei32.v v8, (a0), v8
+; CHECK-NEXT:    vluxei32.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x i32> @llvm.riscv.vluxei.nxv2i32.nxv2i32(
@@ -414,7 +416,8 @@ define <vscale x 4 x i32> @intrinsic_vluxei_v_nxv4i32_nxv4i32_nxv4i32(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv4i32_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m2, ta, ma
-; CHECK-NEXT:    vluxei32.v v8, (a0), v8
+; CHECK-NEXT:    vluxei32.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x i32> @llvm.riscv.vluxei.nxv4i32.nxv4i32(
@@ -447,7 +450,8 @@ define <vscale x 8 x i32> @intrinsic_vluxei_v_nxv8i32_nxv8i32_nxv8i32(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv8i32_nxv8i32_nxv8i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m4, ta, ma
-; CHECK-NEXT:    vluxei32.v v8, (a0), v8
+; CHECK-NEXT:    vluxei32.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x i32> @llvm.riscv.vluxei.nxv8i32.nxv8i32(
@@ -480,7 +484,8 @@ define <vscale x 16 x i32> @intrinsic_vluxei_v_nxv16i32_nxv16i32_nxv16i32(ptr %0
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv16i32_nxv16i32_nxv16i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, ta, ma
-; CHECK-NEXT:    vluxei32.v v8, (a0), v8
+; CHECK-NEXT:    vluxei32.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x i32> @llvm.riscv.vluxei.nxv16i32.nxv16i32(
@@ -989,7 +994,8 @@ define <vscale x 1 x float> @intrinsic_vluxei_v_nxv1f32_nxv1f32_nxv1i32(ptr %0, 
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv1f32_nxv1f32_nxv1i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, mf2, ta, ma
-; CHECK-NEXT:    vluxei32.v v8, (a0), v8
+; CHECK-NEXT:    vluxei32.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x float> @llvm.riscv.vluxei.nxv1f32.nxv1i32(
@@ -1022,7 +1028,8 @@ define <vscale x 2 x float> @intrinsic_vluxei_v_nxv2f32_nxv2f32_nxv2i32(ptr %0, 
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv2f32_nxv2f32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m1, ta, ma
-; CHECK-NEXT:    vluxei32.v v8, (a0), v8
+; CHECK-NEXT:    vluxei32.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x float> @llvm.riscv.vluxei.nxv2f32.nxv2i32(
@@ -1055,7 +1062,8 @@ define <vscale x 4 x float> @intrinsic_vluxei_v_nxv4f32_nxv4f32_nxv4i32(ptr %0, 
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv4f32_nxv4f32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m2, ta, ma
-; CHECK-NEXT:    vluxei32.v v8, (a0), v8
+; CHECK-NEXT:    vluxei32.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x float> @llvm.riscv.vluxei.nxv4f32.nxv4i32(
@@ -1088,7 +1096,8 @@ define <vscale x 8 x float> @intrinsic_vluxei_v_nxv8f32_nxv8f32_nxv8i32(ptr %0, 
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv8f32_nxv8f32_nxv8i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m4, ta, ma
-; CHECK-NEXT:    vluxei32.v v8, (a0), v8
+; CHECK-NEXT:    vluxei32.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x float> @llvm.riscv.vluxei.nxv8f32.nxv8i32(
@@ -1121,7 +1130,8 @@ define <vscale x 16 x float> @intrinsic_vluxei_v_nxv16f32_nxv16f32_nxv16i32(ptr 
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv16f32_nxv16f32_nxv16i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, ta, ma
-; CHECK-NEXT:    vluxei32.v v8, (a0), v8
+; CHECK-NEXT:    vluxei32.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x float> @llvm.riscv.vluxei.nxv16f32.nxv16i32(
@@ -1494,7 +1504,8 @@ define <vscale x 1 x i16> @intrinsic_vluxei_v_nxv1i16_nxv1i16_nxv1i16(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv1i16_nxv1i16_nxv1i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, mf4, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x i16> @llvm.riscv.vluxei.nxv1i16.nxv1i16(
@@ -1527,7 +1538,8 @@ define <vscale x 2 x i16> @intrinsic_vluxei_v_nxv2i16_nxv2i16_nxv2i16(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv2i16_nxv2i16_nxv2i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, mf2, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x i16> @llvm.riscv.vluxei.nxv2i16.nxv2i16(
@@ -1560,7 +1572,8 @@ define <vscale x 4 x i16> @intrinsic_vluxei_v_nxv4i16_nxv4i16_nxv4i16(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv4i16_nxv4i16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m1, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x i16> @llvm.riscv.vluxei.nxv4i16.nxv4i16(
@@ -1593,7 +1606,8 @@ define <vscale x 8 x i16> @intrinsic_vluxei_v_nxv8i16_nxv8i16_nxv8i16(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv8i16_nxv8i16_nxv8i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m2, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x i16> @llvm.riscv.vluxei.nxv8i16.nxv8i16(
@@ -1626,7 +1640,8 @@ define <vscale x 16 x i16> @intrinsic_vluxei_v_nxv16i16_nxv16i16_nxv16i16(ptr %0
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv16i16_nxv16i16_nxv16i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m4, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x i16> @llvm.riscv.vluxei.nxv16i16.nxv16i16(
@@ -1659,7 +1674,8 @@ define <vscale x 32 x i16> @intrinsic_vluxei_v_nxv32i16_nxv32i16_nxv32i16(ptr %0
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv32i16_nxv32i16_nxv32i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m8, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 32 x i16> @llvm.riscv.vluxei.nxv32i16.nxv32i16(
@@ -1998,7 +2014,8 @@ define <vscale x 1 x half> @intrinsic_vluxei_v_nxv1f16_nxv1f16_nxv1i16(ptr %0, <
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv1f16_nxv1f16_nxv1i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, mf4, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x half> @llvm.riscv.vluxei.nxv1f16.nxv1i16(
@@ -2031,7 +2048,8 @@ define <vscale x 2 x half> @intrinsic_vluxei_v_nxv2f16_nxv2f16_nxv2i16(ptr %0, <
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv2f16_nxv2f16_nxv2i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, mf2, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x half> @llvm.riscv.vluxei.nxv2f16.nxv2i16(
@@ -2064,7 +2082,8 @@ define <vscale x 4 x half> @intrinsic_vluxei_v_nxv4f16_nxv4f16_nxv4i16(ptr %0, <
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv4f16_nxv4f16_nxv4i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m1, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x half> @llvm.riscv.vluxei.nxv4f16.nxv4i16(
@@ -2097,7 +2116,8 @@ define <vscale x 8 x half> @intrinsic_vluxei_v_nxv8f16_nxv8f16_nxv8i16(ptr %0, <
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv8f16_nxv8f16_nxv8i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m2, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x half> @llvm.riscv.vluxei.nxv8f16.nxv8i16(
@@ -2130,7 +2150,8 @@ define <vscale x 16 x half> @intrinsic_vluxei_v_nxv16f16_nxv16f16_nxv16i16(ptr %
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv16f16_nxv16f16_nxv16i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m4, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x half> @llvm.riscv.vluxei.nxv16f16.nxv16i16(
@@ -2163,7 +2184,8 @@ define <vscale x 32 x half> @intrinsic_vluxei_v_nxv32f16_nxv32f16_nxv32i16(ptr %
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv32f16_nxv32f16_nxv32i16:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e16, m8, ta, ma
-; CHECK-NEXT:    vluxei16.v v8, (a0), v8
+; CHECK-NEXT:    vluxei16.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 32 x half> @llvm.riscv.vluxei.nxv32f16.nxv32i16(
@@ -2502,7 +2524,8 @@ define <vscale x 1 x i8> @intrinsic_vluxei_v_nxv1i8_nxv1i8_nxv1i8(ptr %0, <vscal
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv1i8_nxv1i8_nxv1i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, mf8, ta, ma
-; CHECK-NEXT:    vluxei8.v v8, (a0), v8
+; CHECK-NEXT:    vluxei8.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 1 x i8> @llvm.riscv.vluxei.nxv1i8.nxv1i8(
@@ -2535,7 +2558,8 @@ define <vscale x 2 x i8> @intrinsic_vluxei_v_nxv2i8_nxv2i8_nxv2i8(ptr %0, <vscal
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv2i8_nxv2i8_nxv2i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, mf4, ta, ma
-; CHECK-NEXT:    vluxei8.v v8, (a0), v8
+; CHECK-NEXT:    vluxei8.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 2 x i8> @llvm.riscv.vluxei.nxv2i8.nxv2i8(
@@ -2568,7 +2592,8 @@ define <vscale x 4 x i8> @intrinsic_vluxei_v_nxv4i8_nxv4i8_nxv4i8(ptr %0, <vscal
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv4i8_nxv4i8_nxv4i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, mf2, ta, ma
-; CHECK-NEXT:    vluxei8.v v8, (a0), v8
+; CHECK-NEXT:    vluxei8.v v9, (a0), v8
+; CHECK-NEXT:    vmv1r.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 4 x i8> @llvm.riscv.vluxei.nxv4i8.nxv4i8(
@@ -2601,7 +2626,8 @@ define <vscale x 8 x i8> @intrinsic_vluxei_v_nxv8i8_nxv8i8_nxv8i8(ptr %0, <vscal
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv8i8_nxv8i8_nxv8i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
-; CHECK-NEXT:    vluxei8.v v8, (a0), v8
+; CHECK-NEXT:    vluxei8.v v9, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v9
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 8 x i8> @llvm.riscv.vluxei.nxv8i8.nxv8i8(
@@ -2634,7 +2660,8 @@ define <vscale x 16 x i8> @intrinsic_vluxei_v_nxv16i8_nxv16i8_nxv16i8(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv16i8_nxv16i8_nxv16i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, m2, ta, ma
-; CHECK-NEXT:    vluxei8.v v8, (a0), v8
+; CHECK-NEXT:    vluxei8.v v10, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v10
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x i8> @llvm.riscv.vluxei.nxv16i8.nxv16i8(
@@ -2667,7 +2694,8 @@ define <vscale x 32 x i8> @intrinsic_vluxei_v_nxv32i8_nxv32i8_nxv32i8(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv32i8_nxv32i8_nxv32i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, m4, ta, ma
-; CHECK-NEXT:    vluxei8.v v8, (a0), v8
+; CHECK-NEXT:    vluxei8.v v12, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v12
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 32 x i8> @llvm.riscv.vluxei.nxv32i8.nxv32i8(
@@ -2700,7 +2728,8 @@ define <vscale x 64 x i8> @intrinsic_vluxei_v_nxv64i8_nxv64i8_nxv64i8(ptr %0, <v
 ; CHECK-LABEL: intrinsic_vluxei_v_nxv64i8_nxv64i8_nxv64i8:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e8, m8, ta, ma
-; CHECK-NEXT:    vluxei8.v v8, (a0), v8
+; CHECK-NEXT:    vluxei8.v v16, (a0), v8
+; CHECK-NEXT:    vmv.v.v v8, v16
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 64 x i8> @llvm.riscv.vluxei.nxv64i8.nxv64i8(

--- a/llvm/test/CodeGen/RISCV/rvv/vpgather-sdnode.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vpgather-sdnode.ll
@@ -602,7 +602,8 @@ define <vscale x 1 x i32> @vpgather_nxv1i32(<vscale x 1 x ptr> %ptrs, <vscale x 
 ; RV32-LABEL: vpgather_nxv1i32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (zero), v8, v0.t
+; RV32-NEXT:    vluxei32.v v9, (zero), v8, v0.t
+; RV32-NEXT:    vmv1r.v v8, v9
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_nxv1i32:
@@ -619,7 +620,8 @@ define <vscale x 2 x i32> @vpgather_nxv2i32(<vscale x 2 x ptr> %ptrs, <vscale x 
 ; RV32-LABEL: vpgather_nxv2i32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (zero), v8, v0.t
+; RV32-NEXT:    vluxei32.v v9, (zero), v8, v0.t
+; RV32-NEXT:    vmv.v.v v8, v9
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_nxv2i32:
@@ -678,7 +680,8 @@ define <vscale x 4 x i32> @vpgather_nxv4i32(<vscale x 4 x ptr> %ptrs, <vscale x 
 ; RV32-LABEL: vpgather_nxv4i32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (zero), v8, v0.t
+; RV32-NEXT:    vluxei32.v v10, (zero), v8, v0.t
+; RV32-NEXT:    vmv.v.v v8, v10
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_nxv4i32:
@@ -695,7 +698,8 @@ define <vscale x 4 x i32> @vpgather_truemask_nxv4i32(<vscale x 4 x ptr> %ptrs, i
 ; RV32-LABEL: vpgather_truemask_nxv4i32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (zero), v8
+; RV32-NEXT:    vluxei32.v v10, (zero), v8
+; RV32-NEXT:    vmv.v.v v8, v10
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_truemask_nxv4i32:
@@ -712,7 +716,8 @@ define <vscale x 8 x i32> @vpgather_nxv8i32(<vscale x 8 x ptr> %ptrs, <vscale x 
 ; RV32-LABEL: vpgather_nxv8i32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a0, e32, m4, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (zero), v8, v0.t
+; RV32-NEXT:    vluxei32.v v12, (zero), v8, v0.t
+; RV32-NEXT:    vmv.v.v v8, v12
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_nxv8i32:
@@ -730,8 +735,8 @@ define <vscale x 8 x i32> @vpgather_baseidx_nxv8i8_nxv8i32(ptr %base, <vscale x 
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a1, e32, m4, ta, ma
 ; RV32-NEXT:    vsext.vf4 v12, v8
-; RV32-NEXT:    vsll.vi v8, v12, 2
-; RV32-NEXT:    vluxei32.v v8, (a0), v8, v0.t
+; RV32-NEXT:    vsll.vi v12, v12, 2
+; RV32-NEXT:    vluxei32.v v8, (a0), v12, v0.t
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_baseidx_nxv8i8_nxv8i32:
@@ -752,8 +757,8 @@ define <vscale x 8 x i32> @vpgather_baseidx_sext_nxv8i8_nxv8i32(ptr %base, <vsca
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a1, e32, m4, ta, ma
 ; RV32-NEXT:    vsext.vf4 v12, v8
-; RV32-NEXT:    vsll.vi v8, v12, 2
-; RV32-NEXT:    vluxei32.v v8, (a0), v8, v0.t
+; RV32-NEXT:    vsll.vi v12, v12, 2
+; RV32-NEXT:    vluxei32.v v8, (a0), v12, v0.t
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_baseidx_sext_nxv8i8_nxv8i32:
@@ -869,8 +874,8 @@ define <vscale x 8 x i32> @vpgather_baseidx_nxv8i32(ptr %base, <vscale x 8 x i32
 ; RV32-LABEL: vpgather_baseidx_nxv8i32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a1, e32, m4, ta, ma
-; RV32-NEXT:    vsll.vi v8, v8, 2
-; RV32-NEXT:    vluxei32.v v8, (a0), v8, v0.t
+; RV32-NEXT:    vsll.vi v12, v8, 2
+; RV32-NEXT:    vluxei32.v v8, (a0), v12, v0.t
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_baseidx_nxv8i32:
@@ -896,7 +901,8 @@ define <vscale x 1 x i64> @vpgather_nxv1i64(<vscale x 1 x ptr> %ptrs, <vscale x 
 ; RV64-LABEL: vpgather_nxv1i64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (zero), v8, v0.t
+; RV64-NEXT:    vluxei64.v v9, (zero), v8, v0.t
+; RV64-NEXT:    vmv.v.v v8, v9
 ; RV64-NEXT:    ret
   %v = call <vscale x 1 x i64> @llvm.vp.gather.nxv1i64.nxv1p0(<vscale x 1 x ptr> %ptrs, <vscale x 1 x i1> %m, i32 %evl)
   ret <vscale x 1 x i64> %v
@@ -914,7 +920,8 @@ define <vscale x 2 x i64> @vpgather_nxv2i64(<vscale x 2 x ptr> %ptrs, <vscale x 
 ; RV64-LABEL: vpgather_nxv2i64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (zero), v8, v0.t
+; RV64-NEXT:    vluxei64.v v10, (zero), v8, v0.t
+; RV64-NEXT:    vmv.v.v v8, v10
 ; RV64-NEXT:    ret
   %v = call <vscale x 2 x i64> @llvm.vp.gather.nxv2i64.nxv2p0(<vscale x 2 x ptr> %ptrs, <vscale x 2 x i1> %m, i32 %evl)
   ret <vscale x 2 x i64> %v
@@ -932,7 +939,8 @@ define <vscale x 4 x i64> @vpgather_nxv4i64(<vscale x 4 x ptr> %ptrs, <vscale x 
 ; RV64-LABEL: vpgather_nxv4i64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (zero), v8, v0.t
+; RV64-NEXT:    vluxei64.v v12, (zero), v8, v0.t
+; RV64-NEXT:    vmv.v.v v8, v12
 ; RV64-NEXT:    ret
   %v = call <vscale x 4 x i64> @llvm.vp.gather.nxv4i64.nxv4p0(<vscale x 4 x ptr> %ptrs, <vscale x 4 x i1> %m, i32 %evl)
   ret <vscale x 4 x i64> %v
@@ -950,7 +958,8 @@ define <vscale x 4 x i64> @vpgather_truemask_nxv4i64(<vscale x 4 x ptr> %ptrs, i
 ; RV64-LABEL: vpgather_truemask_nxv4i64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (zero), v8
+; RV64-NEXT:    vluxei64.v v12, (zero), v8
+; RV64-NEXT:    vmv.v.v v8, v12
 ; RV64-NEXT:    ret
   %v = call <vscale x 4 x i64> @llvm.vp.gather.nxv4i64.nxv4p0(<vscale x 4 x ptr> %ptrs, <vscale x 4 x i1> splat (i1 1), i32 %evl)
   ret <vscale x 4 x i64> %v
@@ -968,7 +977,8 @@ define <vscale x 8 x i64> @vpgather_nxv8i64(<vscale x 8 x ptr> %ptrs, <vscale x 
 ; RV64-LABEL: vpgather_nxv8i64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (zero), v8, v0.t
+; RV64-NEXT:    vluxei64.v v16, (zero), v8, v0.t
+; RV64-NEXT:    vmv.v.v v8, v16
 ; RV64-NEXT:    ret
   %v = call <vscale x 8 x i64> @llvm.vp.gather.nxv8i64.nxv8p0(<vscale x 8 x ptr> %ptrs, <vscale x 8 x i1> %m, i32 %evl)
   ret <vscale x 8 x i64> %v
@@ -988,8 +998,8 @@ define <vscale x 8 x i64> @vpgather_baseidx_nxv8i8_nxv8i64(ptr %base, <vscale x 
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
 ; RV64-NEXT:    vsext.vf8 v16, v8
-; RV64-NEXT:    vsll.vi v8, v16, 3
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vsll.vi v16, v16, 3
+; RV64-NEXT:    vluxei64.v v8, (a0), v16, v0.t
 ; RV64-NEXT:    ret
   %ptrs = getelementptr inbounds i64, ptr %base, <vscale x 8 x i8> %idxs
   %v = call <vscale x 8 x i64> @llvm.vp.gather.nxv8i64.nxv8p0(<vscale x 8 x ptr> %ptrs, <vscale x 8 x i1> %m, i32 %evl)
@@ -1010,8 +1020,8 @@ define <vscale x 8 x i64> @vpgather_baseidx_sext_nxv8i8_nxv8i64(ptr %base, <vsca
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
 ; RV64-NEXT:    vsext.vf8 v16, v8
-; RV64-NEXT:    vsll.vi v8, v16, 3
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vsll.vi v16, v16, 3
+; RV64-NEXT:    vluxei64.v v8, (a0), v16, v0.t
 ; RV64-NEXT:    ret
   %eidxs = sext <vscale x 8 x i8> %idxs to <vscale x 8 x i64>
   %ptrs = getelementptr inbounds i64, ptr %base, <vscale x 8 x i64> %eidxs
@@ -1057,8 +1067,8 @@ define <vscale x 8 x i64> @vpgather_baseidx_nxv8i16_nxv8i64(ptr %base, <vscale x
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
 ; RV64-NEXT:    vsext.vf4 v16, v8
-; RV64-NEXT:    vsll.vi v8, v16, 3
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vsll.vi v16, v16, 3
+; RV64-NEXT:    vluxei64.v v8, (a0), v16, v0.t
 ; RV64-NEXT:    ret
   %ptrs = getelementptr inbounds i64, ptr %base, <vscale x 8 x i16> %idxs
   %v = call <vscale x 8 x i64> @llvm.vp.gather.nxv8i64.nxv8p0(<vscale x 8 x ptr> %ptrs, <vscale x 8 x i1> %m, i32 %evl)
@@ -1079,8 +1089,8 @@ define <vscale x 8 x i64> @vpgather_baseidx_sext_nxv8i16_nxv8i64(ptr %base, <vsc
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
 ; RV64-NEXT:    vsext.vf4 v16, v8
-; RV64-NEXT:    vsll.vi v8, v16, 3
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vsll.vi v16, v16, 3
+; RV64-NEXT:    vluxei64.v v8, (a0), v16, v0.t
 ; RV64-NEXT:    ret
   %eidxs = sext <vscale x 8 x i16> %idxs to <vscale x 8 x i64>
   %ptrs = getelementptr inbounds i64, ptr %base, <vscale x 8 x i64> %eidxs
@@ -1193,8 +1203,8 @@ define <vscale x 8 x i64> @vpgather_baseidx_nxv8i64(ptr %base, <vscale x 8 x i64
 ; RV64-LABEL: vpgather_baseidx_nxv8i64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; RV64-NEXT:    vsll.vi v8, v8, 3
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vsll.vi v16, v8, 3
+; RV64-NEXT:    vluxei64.v v8, (a0), v16, v0.t
 ; RV64-NEXT:    ret
   %ptrs = getelementptr inbounds i64, ptr %base, <vscale x 8 x i64> %idxs
   %v = call <vscale x 8 x i64> @llvm.vp.gather.nxv8i64.nxv8p0(<vscale x 8 x ptr> %ptrs, <vscale x 8 x i1> %m, i32 %evl)
@@ -1565,7 +1575,8 @@ define <vscale x 1 x float> @vpgather_nxv1f32(<vscale x 1 x ptr> %ptrs, <vscale 
 ; RV32-LABEL: vpgather_nxv1f32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a0, e32, mf2, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (zero), v8, v0.t
+; RV32-NEXT:    vluxei32.v v9, (zero), v8, v0.t
+; RV32-NEXT:    vmv1r.v v8, v9
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_nxv1f32:
@@ -1582,7 +1593,8 @@ define <vscale x 2 x float> @vpgather_nxv2f32(<vscale x 2 x ptr> %ptrs, <vscale 
 ; RV32-LABEL: vpgather_nxv2f32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a0, e32, m1, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (zero), v8, v0.t
+; RV32-NEXT:    vluxei32.v v9, (zero), v8, v0.t
+; RV32-NEXT:    vmv.v.v v8, v9
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_nxv2f32:
@@ -1599,7 +1611,8 @@ define <vscale x 4 x float> @vpgather_nxv4f32(<vscale x 4 x ptr> %ptrs, <vscale 
 ; RV32-LABEL: vpgather_nxv4f32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (zero), v8, v0.t
+; RV32-NEXT:    vluxei32.v v10, (zero), v8, v0.t
+; RV32-NEXT:    vmv.v.v v8, v10
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_nxv4f32:
@@ -1616,7 +1629,8 @@ define <vscale x 4 x float> @vpgather_truemask_nxv4f32(<vscale x 4 x ptr> %ptrs,
 ; RV32-LABEL: vpgather_truemask_nxv4f32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a0, e32, m2, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (zero), v8
+; RV32-NEXT:    vluxei32.v v10, (zero), v8
+; RV32-NEXT:    vmv.v.v v8, v10
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_truemask_nxv4f32:
@@ -1633,7 +1647,8 @@ define <vscale x 8 x float> @vpgather_nxv8f32(<vscale x 8 x ptr> %ptrs, <vscale 
 ; RV32-LABEL: vpgather_nxv8f32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a0, e32, m4, ta, ma
-; RV32-NEXT:    vluxei32.v v8, (zero), v8, v0.t
+; RV32-NEXT:    vluxei32.v v12, (zero), v8, v0.t
+; RV32-NEXT:    vmv.v.v v8, v12
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_nxv8f32:
@@ -1651,8 +1666,8 @@ define <vscale x 8 x float> @vpgather_baseidx_nxv8i8_nxv8f32(ptr %base, <vscale 
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a1, e32, m4, ta, ma
 ; RV32-NEXT:    vsext.vf4 v12, v8
-; RV32-NEXT:    vsll.vi v8, v12, 2
-; RV32-NEXT:    vluxei32.v v8, (a0), v8, v0.t
+; RV32-NEXT:    vsll.vi v12, v12, 2
+; RV32-NEXT:    vluxei32.v v8, (a0), v12, v0.t
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_baseidx_nxv8i8_nxv8f32:
@@ -1673,8 +1688,8 @@ define <vscale x 8 x float> @vpgather_baseidx_sext_nxv8i8_nxv8f32(ptr %base, <vs
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a1, e32, m4, ta, ma
 ; RV32-NEXT:    vsext.vf4 v12, v8
-; RV32-NEXT:    vsll.vi v8, v12, 2
-; RV32-NEXT:    vluxei32.v v8, (a0), v8, v0.t
+; RV32-NEXT:    vsll.vi v12, v12, 2
+; RV32-NEXT:    vluxei32.v v8, (a0), v12, v0.t
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_baseidx_sext_nxv8i8_nxv8f32:
@@ -1790,8 +1805,8 @@ define <vscale x 8 x float> @vpgather_baseidx_nxv8f32(ptr %base, <vscale x 8 x i
 ; RV32-LABEL: vpgather_baseidx_nxv8f32:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    vsetvli zero, a1, e32, m4, ta, ma
-; RV32-NEXT:    vsll.vi v8, v8, 2
-; RV32-NEXT:    vluxei32.v v8, (a0), v8, v0.t
+; RV32-NEXT:    vsll.vi v12, v8, 2
+; RV32-NEXT:    vluxei32.v v8, (a0), v12, v0.t
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_baseidx_nxv8f32:
@@ -1817,7 +1832,8 @@ define <vscale x 1 x double> @vpgather_nxv1f64(<vscale x 1 x ptr> %ptrs, <vscale
 ; RV64-LABEL: vpgather_nxv1f64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a0, e64, m1, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (zero), v8, v0.t
+; RV64-NEXT:    vluxei64.v v9, (zero), v8, v0.t
+; RV64-NEXT:    vmv.v.v v8, v9
 ; RV64-NEXT:    ret
   %v = call <vscale x 1 x double> @llvm.vp.gather.nxv1f64.nxv1p0(<vscale x 1 x ptr> %ptrs, <vscale x 1 x i1> %m, i32 %evl)
   ret <vscale x 1 x double> %v
@@ -1835,7 +1851,8 @@ define <vscale x 2 x double> @vpgather_nxv2f64(<vscale x 2 x ptr> %ptrs, <vscale
 ; RV64-LABEL: vpgather_nxv2f64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a0, e64, m2, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (zero), v8, v0.t
+; RV64-NEXT:    vluxei64.v v10, (zero), v8, v0.t
+; RV64-NEXT:    vmv.v.v v8, v10
 ; RV64-NEXT:    ret
   %v = call <vscale x 2 x double> @llvm.vp.gather.nxv2f64.nxv2p0(<vscale x 2 x ptr> %ptrs, <vscale x 2 x i1> %m, i32 %evl)
   ret <vscale x 2 x double> %v
@@ -1853,7 +1870,8 @@ define <vscale x 4 x double> @vpgather_nxv4f64(<vscale x 4 x ptr> %ptrs, <vscale
 ; RV64-LABEL: vpgather_nxv4f64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (zero), v8, v0.t
+; RV64-NEXT:    vluxei64.v v12, (zero), v8, v0.t
+; RV64-NEXT:    vmv.v.v v8, v12
 ; RV64-NEXT:    ret
   %v = call <vscale x 4 x double> @llvm.vp.gather.nxv4f64.nxv4p0(<vscale x 4 x ptr> %ptrs, <vscale x 4 x i1> %m, i32 %evl)
   ret <vscale x 4 x double> %v
@@ -1871,7 +1889,8 @@ define <vscale x 4 x double> @vpgather_truemask_nxv4f64(<vscale x 4 x ptr> %ptrs
 ; RV64-LABEL: vpgather_truemask_nxv4f64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a0, e64, m4, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (zero), v8
+; RV64-NEXT:    vluxei64.v v12, (zero), v8
+; RV64-NEXT:    vmv.v.v v8, v12
 ; RV64-NEXT:    ret
   %v = call <vscale x 4 x double> @llvm.vp.gather.nxv4f64.nxv4p0(<vscale x 4 x ptr> %ptrs, <vscale x 4 x i1> splat (i1 1), i32 %evl)
   ret <vscale x 4 x double> %v
@@ -1889,7 +1908,8 @@ define <vscale x 6 x double> @vpgather_nxv6f64(<vscale x 6 x ptr> %ptrs, <vscale
 ; RV64-LABEL: vpgather_nxv6f64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (zero), v8, v0.t
+; RV64-NEXT:    vluxei64.v v16, (zero), v8, v0.t
+; RV64-NEXT:    vmv.v.v v8, v16
 ; RV64-NEXT:    ret
   %v = call <vscale x 6 x double> @llvm.vp.gather.nxv6f64.nxv6p0(<vscale x 6 x ptr> %ptrs, <vscale x 6 x i1> %m, i32 %evl)
   ret <vscale x 6 x double> %v
@@ -1909,8 +1929,8 @@ define <vscale x 6 x double> @vpgather_baseidx_nxv6i8_nxv6f64(ptr %base, <vscale
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
 ; RV64-NEXT:    vsext.vf8 v16, v8
-; RV64-NEXT:    vsll.vi v8, v16, 3
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vsll.vi v16, v16, 3
+; RV64-NEXT:    vluxei64.v v8, (a0), v16, v0.t
 ; RV64-NEXT:    ret
   %ptrs = getelementptr inbounds double, ptr %base, <vscale x 6 x i8> %idxs
   %v = call <vscale x 6 x double> @llvm.vp.gather.nxv6f64.nxv6p0(<vscale x 6 x ptr> %ptrs, <vscale x 6 x i1> %m, i32 %evl)
@@ -1931,8 +1951,8 @@ define <vscale x 6 x double> @vpgather_baseidx_sext_nxv6i8_nxv6f64(ptr %base, <v
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
 ; RV64-NEXT:    vsext.vf8 v16, v8
-; RV64-NEXT:    vsll.vi v8, v16, 3
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vsll.vi v16, v16, 3
+; RV64-NEXT:    vluxei64.v v8, (a0), v16, v0.t
 ; RV64-NEXT:    ret
   %eidxs = sext <vscale x 6 x i8> %idxs to <vscale x 6 x i64>
   %ptrs = getelementptr inbounds double, ptr %base, <vscale x 6 x i64> %eidxs
@@ -1978,8 +1998,8 @@ define <vscale x 6 x double> @vpgather_baseidx_nxv6i16_nxv6f64(ptr %base, <vscal
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
 ; RV64-NEXT:    vsext.vf4 v16, v8
-; RV64-NEXT:    vsll.vi v8, v16, 3
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vsll.vi v16, v16, 3
+; RV64-NEXT:    vluxei64.v v8, (a0), v16, v0.t
 ; RV64-NEXT:    ret
   %ptrs = getelementptr inbounds double, ptr %base, <vscale x 6 x i16> %idxs
   %v = call <vscale x 6 x double> @llvm.vp.gather.nxv6f64.nxv6p0(<vscale x 6 x ptr> %ptrs, <vscale x 6 x i1> %m, i32 %evl)
@@ -2000,8 +2020,8 @@ define <vscale x 6 x double> @vpgather_baseidx_sext_nxv6i16_nxv6f64(ptr %base, <
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
 ; RV64-NEXT:    vsext.vf4 v16, v8
-; RV64-NEXT:    vsll.vi v8, v16, 3
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vsll.vi v16, v16, 3
+; RV64-NEXT:    vluxei64.v v8, (a0), v16, v0.t
 ; RV64-NEXT:    ret
   %eidxs = sext <vscale x 6 x i16> %idxs to <vscale x 6 x i64>
   %ptrs = getelementptr inbounds double, ptr %base, <vscale x 6 x i64> %eidxs
@@ -2114,8 +2134,8 @@ define <vscale x 6 x double> @vpgather_baseidx_nxv6f64(ptr %base, <vscale x 6 x 
 ; RV64-LABEL: vpgather_baseidx_nxv6f64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; RV64-NEXT:    vsll.vi v8, v8, 3
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vsll.vi v16, v8, 3
+; RV64-NEXT:    vluxei64.v v8, (a0), v16, v0.t
 ; RV64-NEXT:    ret
   %ptrs = getelementptr inbounds double, ptr %base, <vscale x 6 x i64> %idxs
   %v = call <vscale x 6 x double> @llvm.vp.gather.nxv6f64.nxv6p0(<vscale x 6 x ptr> %ptrs, <vscale x 6 x i1> %m, i32 %evl)
@@ -2134,7 +2154,8 @@ define <vscale x 8 x double> @vpgather_nxv8f64(<vscale x 8 x ptr> %ptrs, <vscale
 ; RV64-LABEL: vpgather_nxv8f64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (zero), v8, v0.t
+; RV64-NEXT:    vluxei64.v v16, (zero), v8, v0.t
+; RV64-NEXT:    vmv.v.v v8, v16
 ; RV64-NEXT:    ret
   %v = call <vscale x 8 x double> @llvm.vp.gather.nxv8f64.nxv8p0(<vscale x 8 x ptr> %ptrs, <vscale x 8 x i1> %m, i32 %evl)
   ret <vscale x 8 x double> %v
@@ -2154,8 +2175,8 @@ define <vscale x 8 x double> @vpgather_baseidx_nxv8i8_nxv8f64(ptr %base, <vscale
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
 ; RV64-NEXT:    vsext.vf8 v16, v8
-; RV64-NEXT:    vsll.vi v8, v16, 3
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vsll.vi v16, v16, 3
+; RV64-NEXT:    vluxei64.v v8, (a0), v16, v0.t
 ; RV64-NEXT:    ret
   %ptrs = getelementptr inbounds double, ptr %base, <vscale x 8 x i8> %idxs
   %v = call <vscale x 8 x double> @llvm.vp.gather.nxv8f64.nxv8p0(<vscale x 8 x ptr> %ptrs, <vscale x 8 x i1> %m, i32 %evl)
@@ -2176,8 +2197,8 @@ define <vscale x 8 x double> @vpgather_baseidx_sext_nxv8i8_nxv8f64(ptr %base, <v
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
 ; RV64-NEXT:    vsext.vf8 v16, v8
-; RV64-NEXT:    vsll.vi v8, v16, 3
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vsll.vi v16, v16, 3
+; RV64-NEXT:    vluxei64.v v8, (a0), v16, v0.t
 ; RV64-NEXT:    ret
   %eidxs = sext <vscale x 8 x i8> %idxs to <vscale x 8 x i64>
   %ptrs = getelementptr inbounds double, ptr %base, <vscale x 8 x i64> %eidxs
@@ -2223,8 +2244,8 @@ define <vscale x 8 x double> @vpgather_baseidx_nxv8i16_nxv8f64(ptr %base, <vscal
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
 ; RV64-NEXT:    vsext.vf4 v16, v8
-; RV64-NEXT:    vsll.vi v8, v16, 3
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vsll.vi v16, v16, 3
+; RV64-NEXT:    vluxei64.v v8, (a0), v16, v0.t
 ; RV64-NEXT:    ret
   %ptrs = getelementptr inbounds double, ptr %base, <vscale x 8 x i16> %idxs
   %v = call <vscale x 8 x double> @llvm.vp.gather.nxv8f64.nxv8p0(<vscale x 8 x ptr> %ptrs, <vscale x 8 x i1> %m, i32 %evl)
@@ -2245,8 +2266,8 @@ define <vscale x 8 x double> @vpgather_baseidx_sext_nxv8i16_nxv8f64(ptr %base, <
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
 ; RV64-NEXT:    vsext.vf4 v16, v8
-; RV64-NEXT:    vsll.vi v8, v16, 3
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vsll.vi v16, v16, 3
+; RV64-NEXT:    vluxei64.v v8, (a0), v16, v0.t
 ; RV64-NEXT:    ret
   %eidxs = sext <vscale x 8 x i16> %idxs to <vscale x 8 x i64>
   %ptrs = getelementptr inbounds double, ptr %base, <vscale x 8 x i64> %eidxs
@@ -2359,8 +2380,8 @@ define <vscale x 8 x double> @vpgather_baseidx_nxv8f64(ptr %base, <vscale x 8 x 
 ; RV64-LABEL: vpgather_baseidx_nxv8f64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
-; RV64-NEXT:    vsll.vi v8, v8, 3
-; RV64-NEXT:    vluxei64.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vsll.vi v16, v8, 3
+; RV64-NEXT:    vluxei64.v v8, (a0), v16, v0.t
 ; RV64-NEXT:    ret
   %ptrs = getelementptr inbounds double, ptr %base, <vscale x 8 x i64> %idxs
   %v = call <vscale x 8 x double> @llvm.vp.gather.nxv8f64.nxv8p0(<vscale x 8 x ptr> %ptrs, <vscale x 8 x i1> %m, i32 %evl)
@@ -2394,7 +2415,7 @@ define <vscale x 16 x double> @vpgather_nxv16f64(<vscale x 16 x ptr> %ptrs, <vsc
 ; RV64-LABEL: vpgather_nxv16f64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli a1, zero, e8, mf4, ta, ma
-; RV64-NEXT:    vmv1r.v v24, v0
+; RV64-NEXT:    vmv1r.v v7, v0
 ; RV64-NEXT:    csrr a1, vlenb
 ; RV64-NEXT:    srli a2, a1, 3
 ; RV64-NEXT:    vslidedown.vx v0, v0, a2
@@ -2403,14 +2424,16 @@ define <vscale x 16 x double> @vpgather_nxv16f64(<vscale x 16 x ptr> %ptrs, <vsc
 ; RV64-NEXT:    addi a3, a3, -1
 ; RV64-NEXT:    and a2, a3, a2
 ; RV64-NEXT:    vsetvli zero, a2, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v16, (zero), v16, v0.t
+; RV64-NEXT:    vluxei64.v v24, (zero), v16, v0.t
 ; RV64-NEXT:    bltu a0, a1, .LBB111_2
 ; RV64-NEXT:  # %bb.1:
 ; RV64-NEXT:    mv a0, a1
 ; RV64-NEXT:  .LBB111_2:
-; RV64-NEXT:    vmv1r.v v0, v24
+; RV64-NEXT:    vmv1r.v v0, v7
 ; RV64-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v8, (zero), v8, v0.t
+; RV64-NEXT:    vluxei64.v v16, (zero), v8, v0.t
+; RV64-NEXT:    vmv.v.v v8, v16
+; RV64-NEXT:    vmv8r.v v16, v24
 ; RV64-NEXT:    ret
   %v = call <vscale x 16 x double> @llvm.vp.gather.nxv16f64.nxv16p0(<vscale x 16 x ptr> %ptrs, <vscale x 16 x i1> %m, i32 %evl)
   ret <vscale x 16 x double> %v
@@ -2444,7 +2467,7 @@ define <vscale x 16 x double> @vpgather_baseidx_nxv16i16_nxv16f64(ptr %base, <vs
 ; RV64-LABEL: vpgather_baseidx_nxv16i16_nxv16f64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli a2, zero, e64, m8, ta, ma
-; RV64-NEXT:    vmv1r.v v12, v0
+; RV64-NEXT:    vmv1r.v v7, v0
 ; RV64-NEXT:    csrr a2, vlenb
 ; RV64-NEXT:    sub a3, a1, a2
 ; RV64-NEXT:    sltu a4, a1, a3
@@ -2453,19 +2476,19 @@ define <vscale x 16 x double> @vpgather_baseidx_nxv16i16_nxv16f64(ptr %base, <vs
 ; RV64-NEXT:    vsext.vf4 v24, v8
 ; RV64-NEXT:    vsetvli zero, a3, e64, m8, ta, ma
 ; RV64-NEXT:    vsext.vf4 v16, v10
-; RV64-NEXT:    vsll.vi v16, v16, 3
+; RV64-NEXT:    vsll.vi v8, v16, 3
 ; RV64-NEXT:    srli a4, a2, 3
 ; RV64-NEXT:    vsetvli a5, zero, e8, mf4, ta, ma
 ; RV64-NEXT:    vslidedown.vx v0, v0, a4
 ; RV64-NEXT:    vsetvli zero, a3, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v16, (a0), v16, v0.t
+; RV64-NEXT:    vluxei64.v v16, (a0), v8, v0.t
 ; RV64-NEXT:    vsetvli a3, zero, e64, m8, ta, ma
 ; RV64-NEXT:    vsll.vi v24, v24, 3
 ; RV64-NEXT:    bltu a1, a2, .LBB112_2
 ; RV64-NEXT:  # %bb.1:
 ; RV64-NEXT:    mv a1, a2
 ; RV64-NEXT:  .LBB112_2:
-; RV64-NEXT:    vmv1r.v v0, v12
+; RV64-NEXT:    vmv1r.v v0, v7
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
 ; RV64-NEXT:    vluxei64.v v8, (a0), v24, v0.t
 ; RV64-NEXT:    ret
@@ -2502,7 +2525,7 @@ define <vscale x 16 x double> @vpgather_baseidx_sext_nxv16i16_nxv16f64(ptr %base
 ; RV64-LABEL: vpgather_baseidx_sext_nxv16i16_nxv16f64:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    vsetvli a2, zero, e64, m8, ta, ma
-; RV64-NEXT:    vmv1r.v v12, v0
+; RV64-NEXT:    vmv1r.v v7, v0
 ; RV64-NEXT:    csrr a2, vlenb
 ; RV64-NEXT:    sub a3, a1, a2
 ; RV64-NEXT:    sltu a4, a1, a3
@@ -2511,19 +2534,19 @@ define <vscale x 16 x double> @vpgather_baseidx_sext_nxv16i16_nxv16f64(ptr %base
 ; RV64-NEXT:    vsext.vf4 v24, v8
 ; RV64-NEXT:    vsetvli zero, a3, e64, m8, ta, ma
 ; RV64-NEXT:    vsext.vf4 v16, v10
-; RV64-NEXT:    vsll.vi v16, v16, 3
+; RV64-NEXT:    vsll.vi v8, v16, 3
 ; RV64-NEXT:    srli a4, a2, 3
 ; RV64-NEXT:    vsetvli a5, zero, e8, mf4, ta, ma
 ; RV64-NEXT:    vslidedown.vx v0, v0, a4
 ; RV64-NEXT:    vsetvli zero, a3, e64, m8, ta, ma
-; RV64-NEXT:    vluxei64.v v16, (a0), v16, v0.t
+; RV64-NEXT:    vluxei64.v v16, (a0), v8, v0.t
 ; RV64-NEXT:    vsetvli a3, zero, e64, m8, ta, ma
 ; RV64-NEXT:    vsll.vi v24, v24, 3
 ; RV64-NEXT:    bltu a1, a2, .LBB113_2
 ; RV64-NEXT:  # %bb.1:
 ; RV64-NEXT:    mv a1, a2
 ; RV64-NEXT:  .LBB113_2:
-; RV64-NEXT:    vmv1r.v v0, v12
+; RV64-NEXT:    vmv1r.v v0, v7
 ; RV64-NEXT:    vsetvli zero, a1, e64, m8, ta, ma
 ; RV64-NEXT:    vluxei64.v v8, (a0), v24, v0.t
 ; RV64-NEXT:    ret
@@ -2593,8 +2616,8 @@ define <vscale x 8 x i16> @vpgather_baseidx_and_nxv8i16_nxv8i16(ptr %base, <vsca
 ; RV32-NEXT:    li a2, 255
 ; RV32-NEXT:    vsetvli zero, a1, e16, m2, ta, ma
 ; RV32-NEXT:    vand.vx v8, v8, a2
-; RV32-NEXT:    vadd.vv v8, v8, v8
-; RV32-NEXT:    vluxei16.v v8, (a0), v8, v0.t
+; RV32-NEXT:    vadd.vv v10, v8, v8
+; RV32-NEXT:    vluxei16.v v8, (a0), v10, v0.t
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vpgather_baseidx_and_nxv8i16_nxv8i16:
@@ -2602,8 +2625,8 @@ define <vscale x 8 x i16> @vpgather_baseidx_and_nxv8i16_nxv8i16(ptr %base, <vsca
 ; RV64-NEXT:    li a2, 255
 ; RV64-NEXT:    vsetvli zero, a1, e16, m2, ta, ma
 ; RV64-NEXT:    vand.vx v8, v8, a2
-; RV64-NEXT:    vadd.vv v8, v8, v8
-; RV64-NEXT:    vluxei16.v v8, (a0), v8, v0.t
+; RV64-NEXT:    vadd.vv v10, v8, v8
+; RV64-NEXT:    vluxei16.v v8, (a0), v10, v0.t
 ; RV64-NEXT:    ret
   %eidxs = and <vscale x 8 x i16> %idxs, splat (i16 255)
   %ptrs = getelementptr inbounds i16, ptr %base, <vscale x 8 x i16> %eidxs


### PR DESCRIPTION
If a trap occurs on an element other than 0, some SiFive cores will write a garbage value to that element and all active elements after it in the destination register before running the trap handler. This is normally allowed by the spec if restarting the instruction would overwrite the elements with the correct results.

For a vector indexed load with overlapping source and destination, writing the later elements with garbage corrupts some of the source indices. This prevents the instruction from restarting correctly once the fault has been handled.

To workaround this issue, we propose to disable overlapping source and destination registers for these instructions in the compiler. We do not anticipate a performance impact from this in most software. At worst this will require a register to be spilled and reloaded. Indexed loads are already expensive on most available hardware and we don't expect this spill to be noticeable in most cases. We have measured Spec2017 on the SpacemiT K1 and saw no regressions.