### PR TITLE
[clang-format] Remove obsolete code

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -2333,11 +2333,6 @@ private:
     } else if (Current.Previous && Current.Previous->is(TT_InheritanceColon)) {
       Contexts.back().ContextType = Context::InheritanceList;
     } else if (Current.isOneOf(tok::r_paren, tok::greater, tok::comma)) {
-      for (FormatToken *Previous = Current.Previous;
-           Previous && Previous->isOneOf(tok::star, tok::amp);
-           Previous = Previous->Previous) {
-        Previous->setType(TT_PointerOrReference);
-      }
       if (Line.MustBeDeclaration &&
           Contexts.front().ContextType != Context::CtorInitializer) {
         Contexts.back().IsExpression = false;

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -22592,6 +22592,7 @@ TEST_F(FormatTest, DoNotCrashOnInvalidInput) {
   verifyNoCrash(
       "#xxxx??x<xxxxxxx||??x<xxxxxxx and xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
   verifyNoCrash("a &alias & =");
+  verifyNoCrash("(A * B *)");
 }
 
 TEST_F(FormatTest, FormatsTableGenCode) {


### PR DESCRIPTION
All tests pass, it's likely that in the past decade we annotate thos tokens better at another place, and the annotation here was the cause for some triggered asserts (or otherwise misannotations) in the recent past.

Fixes #212870.