### PR TITLE
[InstCombine] Fold canonicalized form of vecreduce_or(get_active_lane_mask)

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -3581,6 +3581,22 @@ Instruction *InstCombinerImpl::foldICmpBitCast(ICmpInst &Cmp) {
     }
   }
 
+  // Fold the canonicalized form of vector_reduce_or if the arg is
+  // get_active_lane mask.
+  // icmp ne (bitcast <N x i1> to iN (get_active_lane_mask(l, h))), 0 -> 
+  //            icmp ult l, h 
+  // icmp eq (bitcast <N x i1> to iN (get_active_lane_mask(l, h))), 0 -> 
+  //            icmp uge l, h
+  Value *Upper, *Lower;
+  if (match(BCSrcOp, m_Intrinsic<Intrinsic::get_active_lane_mask>(
+                         m_Value(Lower), m_Value(Upper))) &&
+      match(Op1, m_Zero())) {
+    if (Pred == ICmpInst::ICMP_NE)
+      return new ICmpInst(ICmpInst::ICMP_ULT, Lower, Upper);
+    if (Pred == ICmpInst::ICMP_EQ)
+      return new ICmpInst(ICmpInst::ICMP_UGE, Lower, Upper);
+  }
+
   const APInt *C;
   if (!match(Cmp.getOperand(1), m_APInt(C)) || !DstType->isIntegerTy() ||
       !SrcType->isIntOrIntVectorTy())

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -3583,9 +3583,9 @@ Instruction *InstCombinerImpl::foldICmpBitCast(ICmpInst &Cmp) {
 
   // Fold the canonicalized form of vector_reduce_or if the arg is
   // get_active_lane mask.
-  // icmp ne (bitcast <N x i1> to iN (get_active_lane_mask(l, h))), 0 -> 
-  //            icmp ult l, h 
-  // icmp eq (bitcast <N x i1> to iN (get_active_lane_mask(l, h))), 0 -> 
+  // icmp ne (bitcast <N x i1> to iN (get_active_lane_mask(l, h))), 0 ->
+  //            icmp ult l, h
+  // icmp eq (bitcast <N x i1> to iN (get_active_lane_mask(l, h))), 0 ->
   //            icmp uge l, h
   Value *Upper, *Lower;
   if (match(BCSrcOp, m_Intrinsic<Intrinsic::get_active_lane_mask>(

--- a/llvm/test/Transforms/InstCombine/get_active_lane_mask.ll
+++ b/llvm/test/Transforms/InstCombine/get_active_lane_mask.ll
@@ -89,3 +89,130 @@ define <4 x i1> @extract_fixed_from_active_lane_mask() vscale_range(4, 4) {
   ret <4 x i1> %ext
 }
 
+define i1 @vecreduce_or_get_active_lane_mask_v4i1(i32 %a, i32 %b) {
+; CHECK-LABEL: define i1 @vecreduce_or_get_active_lane_mask_v4i1(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]]) {
+; CHECK-NEXT:    [[MASK:%.*]] = call <4 x i1> @llvm.get.active.lane.mask.v4i1.i32(i32 [[A]], i32 [[B]])
+; CHECK-NEXT:    [[TMP1:%.*]] = bitcast <4 x i1> [[MASK]] to i4
+; CHECK-NEXT:    [[RED:%.*]] = icmp ne i4 [[TMP1]], 0
+; CHECK-NEXT:    ret i1 [[RED]]
+;
+  %mask = call <4 x i1> @llvm.get.active.lane.mask.v4i1.i32(i32 %a, i32 %b)
+  %red = call i1 @llvm.vector.reduce.or.i1(<4 x i1> %mask)
+  ret i1 %red
+}
+
+define i1 @vecreduce_or_get_active_lane_mask_v16i1(i32 %a, i32 %b) {
+; CHECK-LABEL: define i1 @vecreduce_or_get_active_lane_mask_v16i1(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]]) {
+; CHECK-NEXT:    [[MASK:%.*]] = call <16 x i1> @llvm.get.active.lane.mask.v16i1.i32(i32 [[A]], i32 [[B]])
+; CHECK-NEXT:    [[TMP1:%.*]] = bitcast <16 x i1> [[MASK]] to i16
+; CHECK-NEXT:    [[RED:%.*]] = icmp ne i16 [[TMP1]], 0
+; CHECK-NEXT:    ret i1 [[RED]]
+;
+  %mask = call <16 x i1> @llvm.get.active.lane.mask.v16i1.i32(i32 %a, i32 %b)
+  %red = call i1 @llvm.vector.reduce.or.i1(<16 x i1> %mask)
+  ret i1 %red
+}
+
+define i1 @vecreduce_or_get_active_lane_mask_v32i1(i32 %a, i32 %b) {
+; CHECK-LABEL: define i1 @vecreduce_or_get_active_lane_mask_v32i1(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]]) {
+; CHECK-NEXT:    [[MASK:%.*]] = call <32 x i1> @llvm.get.active.lane.mask.v32i1.i32(i32 [[A]], i32 [[B]])
+; CHECK-NEXT:    [[TMP1:%.*]] = bitcast <32 x i1> [[MASK]] to i32
+; CHECK-NEXT:    [[RED:%.*]] = icmp ne i32 [[TMP1]], 0
+; CHECK-NEXT:    ret i1 [[RED]]
+;
+  %mask = call <32 x i1> @llvm.get.active.lane.mask.v32i1.i32(i32 %a, i32 %b)
+  %red = call i1 @llvm.vector.reduce.or.i1(<32 x i1> %mask)
+  ret i1 %red
+}
+
+define i1 @vecreduce_or_get_active_lane_mask_v4i1_multiuse(i32 %a, i32 %b) {
+; CHECK-LABEL: define i1 @vecreduce_or_get_active_lane_mask_v4i1_multiuse(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]]) {
+; CHECK-NEXT:    [[MASK:%.*]] = call <4 x i1> @llvm.get.active.lane.mask.v4i1.i32(i32 [[A]], i32 [[B]])
+; CHECK-NEXT:    call void (...) @llvm.fake.use(<4 x i1> [[MASK]])
+; CHECK-NEXT:    [[TMP1:%.*]] = bitcast <4 x i1> [[MASK]] to i4
+; CHECK-NEXT:    [[RED:%.*]] = icmp ne i4 [[TMP1]], 0
+; CHECK-NEXT:    ret i1 [[RED]]
+;
+  %mask = call <4 x i1> @llvm.get.active.lane.mask.v4i1.i32(i32 %a, i32 %b)
+  call void (...) @llvm.fake.use(<4 x i1> %mask)
+  %red = call i1 @llvm.vector.reduce.or.i1(<4 x i1> %mask)
+  ret i1 %red
+}
+
+define i1 @vecreduce_or_get_active_lane_mask_v16i1_multiuse(i32 %a, i32 %b) {
+; CHECK-LABEL: define i1 @vecreduce_or_get_active_lane_mask_v16i1_multiuse(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]]) {
+; CHECK-NEXT:    [[MASK:%.*]] = call <16 x i1> @llvm.get.active.lane.mask.v16i1.i32(i32 [[A]], i32 [[B]])
+; CHECK-NEXT:    call void (...) @llvm.fake.use(<16 x i1> [[MASK]])
+; CHECK-NEXT:    [[TMP1:%.*]] = bitcast <16 x i1> [[MASK]] to i16
+; CHECK-NEXT:    [[RED:%.*]] = icmp ne i16 [[TMP1]], 0
+; CHECK-NEXT:    ret i1 [[RED]]
+;
+  %mask = call <16 x i1> @llvm.get.active.lane.mask.v16i1.i32(i32 %a, i32 %b)
+  call void (...) @llvm.fake.use(<16 x i1> %mask)
+  %red = call i1 @llvm.vector.reduce.or.i1(<16 x i1> %mask)
+  ret i1 %red
+}
+
+define i1 @vecreduce_or_get_active_lane_mask_v32i1_multiuse(i32 %a, i32 %b) {
+; CHECK-LABEL: define i1 @vecreduce_or_get_active_lane_mask_v32i1_multiuse(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]]) {
+; CHECK-NEXT:    [[MASK:%.*]] = call <32 x i1> @llvm.get.active.lane.mask.v32i1.i32(i32 [[A]], i32 [[B]])
+; CHECK-NEXT:    call void (...) @llvm.fake.use(<32 x i1> [[MASK]])
+; CHECK-NEXT:    [[TMP1:%.*]] = bitcast <32 x i1> [[MASK]] to i32
+; CHECK-NEXT:    [[RED:%.*]] = icmp ne i32 [[TMP1]], 0
+; CHECK-NEXT:    ret i1 [[RED]]
+;
+  %mask = call <32 x i1> @llvm.get.active.lane.mask.v32i1.i32(i32 %a, i32 %b)
+  call void (...) @llvm.fake.use(<32 x i1> %mask)
+  %red = call i1 @llvm.vector.reduce.or.i1(<32 x i1> %mask)
+  ret i1 %red
+}
+
+define i8 @vecreduce_or_zext_get_active_lane_mask_v4i1(i32 %a, i32 %b) {
+; CHECK-LABEL: define i8 @vecreduce_or_zext_get_active_lane_mask_v4i1(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]]) {
+; CHECK-NEXT:    [[MASK:%.*]] = call <4 x i1> @llvm.get.active.lane.mask.v4i1.i32(i32 [[A]], i32 [[B]])
+; CHECK-NEXT:    [[TMP1:%.*]] = bitcast <4 x i1> [[MASK]] to i4
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp ne i4 [[TMP1]], 0
+; CHECK-NEXT:    [[RED:%.*]] = zext i1 [[TMP2]] to i8
+; CHECK-NEXT:    ret i8 [[RED]]
+;
+  %mask = call <4 x i1> @llvm.get.active.lane.mask.v4i1.i32(i32 %a, i32 %b)
+  %ext = zext <4 x i1> %mask to <4 x i8>
+  %red = call i8 @llvm.vector.reduce.or.v4i8(<4 x i8> %ext)
+  ret i8 %red
+}
+
+define i8 @vecreduce_or_sext_get_active_lane_mask_v4i1(i32 %a, i32 %b) {
+; CHECK-LABEL: define i8 @vecreduce_or_sext_get_active_lane_mask_v4i1(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]]) {
+; CHECK-NEXT:    [[MASK:%.*]] = call <4 x i1> @llvm.get.active.lane.mask.v4i1.i32(i32 [[A]], i32 [[B]])
+; CHECK-NEXT:    [[TMP1:%.*]] = bitcast <4 x i1> [[MASK]] to i4
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp ne i4 [[TMP1]], 0
+; CHECK-NEXT:    [[RED:%.*]] = sext i1 [[TMP2]] to i8
+; CHECK-NEXT:    ret i8 [[RED]]
+;
+  %mask = call <4 x i1> @llvm.get.active.lane.mask.v4i1.i32(i32 %a, i32 %b)
+  %ext = sext <4 x i1> %mask to <4 x i8>
+  %red = call i8 @llvm.vector.reduce.or.v4i8(<4 x i8> %ext)
+  ret i8 %red
+}
+
+define i1 @bitcast_inverted_condition_v32i1(i32 %a, i32 %b) {
+; CHECK-LABEL: define i1 @bitcast_inverted_condition_v32i1(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]]) {
+; CHECK-NEXT:    [[MASK:%.*]] = call <32 x i1> @llvm.get.active.lane.mask.v32i1.i32(i32 [[A]], i32 [[B]])
+; CHECK-NEXT:    [[CAST:%.*]] = bitcast <32 x i1> [[MASK]] to i32
+; CHECK-NEXT:    [[RED:%.*]] = icmp eq i32 [[CAST]], 0
+; CHECK-NEXT:    ret i1 [[RED]]
+;
+  %mask = call <32 x i1> @llvm.get.active.lane.mask.v32i1.i32(i32 %a, i32 %b)
+  %cast = bitcast <32 x i1> %mask to i32
+  %red = icmp eq i32 %cast, 0
+  ret i1 %red
+}

--- a/llvm/test/Transforms/InstCombine/get_active_lane_mask.ll
+++ b/llvm/test/Transforms/InstCombine/get_active_lane_mask.ll
@@ -92,9 +92,7 @@ define <4 x i1> @extract_fixed_from_active_lane_mask() vscale_range(4, 4) {
 define i1 @vecreduce_or_get_active_lane_mask_v4i1(i32 %a, i32 %b) {
 ; CHECK-LABEL: define i1 @vecreduce_or_get_active_lane_mask_v4i1(
 ; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]]) {
-; CHECK-NEXT:    [[MASK:%.*]] = call <4 x i1> @llvm.get.active.lane.mask.v4i1.i32(i32 [[A]], i32 [[B]])
-; CHECK-NEXT:    [[TMP1:%.*]] = bitcast <4 x i1> [[MASK]] to i4
-; CHECK-NEXT:    [[RED:%.*]] = icmp ne i4 [[TMP1]], 0
+; CHECK-NEXT:    [[RED:%.*]] = icmp ult i32 [[A]], [[B]]
 ; CHECK-NEXT:    ret i1 [[RED]]
 ;
   %mask = call <4 x i1> @llvm.get.active.lane.mask.v4i1.i32(i32 %a, i32 %b)
@@ -105,9 +103,7 @@ define i1 @vecreduce_or_get_active_lane_mask_v4i1(i32 %a, i32 %b) {
 define i1 @vecreduce_or_get_active_lane_mask_v16i1(i32 %a, i32 %b) {
 ; CHECK-LABEL: define i1 @vecreduce_or_get_active_lane_mask_v16i1(
 ; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]]) {
-; CHECK-NEXT:    [[MASK:%.*]] = call <16 x i1> @llvm.get.active.lane.mask.v16i1.i32(i32 [[A]], i32 [[B]])
-; CHECK-NEXT:    [[TMP1:%.*]] = bitcast <16 x i1> [[MASK]] to i16
-; CHECK-NEXT:    [[RED:%.*]] = icmp ne i16 [[TMP1]], 0
+; CHECK-NEXT:    [[RED:%.*]] = icmp ult i32 [[A]], [[B]]
 ; CHECK-NEXT:    ret i1 [[RED]]
 ;
   %mask = call <16 x i1> @llvm.get.active.lane.mask.v16i1.i32(i32 %a, i32 %b)
@@ -118,9 +114,7 @@ define i1 @vecreduce_or_get_active_lane_mask_v16i1(i32 %a, i32 %b) {
 define i1 @vecreduce_or_get_active_lane_mask_v32i1(i32 %a, i32 %b) {
 ; CHECK-LABEL: define i1 @vecreduce_or_get_active_lane_mask_v32i1(
 ; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]]) {
-; CHECK-NEXT:    [[MASK:%.*]] = call <32 x i1> @llvm.get.active.lane.mask.v32i1.i32(i32 [[A]], i32 [[B]])
-; CHECK-NEXT:    [[TMP1:%.*]] = bitcast <32 x i1> [[MASK]] to i32
-; CHECK-NEXT:    [[RED:%.*]] = icmp ne i32 [[TMP1]], 0
+; CHECK-NEXT:    [[RED:%.*]] = icmp ult i32 [[A]], [[B]]
 ; CHECK-NEXT:    ret i1 [[RED]]
 ;
   %mask = call <32 x i1> @llvm.get.active.lane.mask.v32i1.i32(i32 %a, i32 %b)
@@ -133,8 +127,7 @@ define i1 @vecreduce_or_get_active_lane_mask_v4i1_multiuse(i32 %a, i32 %b) {
 ; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]]) {
 ; CHECK-NEXT:    [[MASK:%.*]] = call <4 x i1> @llvm.get.active.lane.mask.v4i1.i32(i32 [[A]], i32 [[B]])
 ; CHECK-NEXT:    call void (...) @llvm.fake.use(<4 x i1> [[MASK]])
-; CHECK-NEXT:    [[TMP1:%.*]] = bitcast <4 x i1> [[MASK]] to i4
-; CHECK-NEXT:    [[RED:%.*]] = icmp ne i4 [[TMP1]], 0
+; CHECK-NEXT:    [[RED:%.*]] = icmp ult i32 [[A]], [[B]]
 ; CHECK-NEXT:    ret i1 [[RED]]
 ;
   %mask = call <4 x i1> @llvm.get.active.lane.mask.v4i1.i32(i32 %a, i32 %b)
@@ -148,8 +141,7 @@ define i1 @vecreduce_or_get_active_lane_mask_v16i1_multiuse(i32 %a, i32 %b) {
 ; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]]) {
 ; CHECK-NEXT:    [[MASK:%.*]] = call <16 x i1> @llvm.get.active.lane.mask.v16i1.i32(i32 [[A]], i32 [[B]])
 ; CHECK-NEXT:    call void (...) @llvm.fake.use(<16 x i1> [[MASK]])
-; CHECK-NEXT:    [[TMP1:%.*]] = bitcast <16 x i1> [[MASK]] to i16
-; CHECK-NEXT:    [[RED:%.*]] = icmp ne i16 [[TMP1]], 0
+; CHECK-NEXT:    [[RED:%.*]] = icmp ult i32 [[A]], [[B]]
 ; CHECK-NEXT:    ret i1 [[RED]]
 ;
   %mask = call <16 x i1> @llvm.get.active.lane.mask.v16i1.i32(i32 %a, i32 %b)
@@ -163,8 +155,7 @@ define i1 @vecreduce_or_get_active_lane_mask_v32i1_multiuse(i32 %a, i32 %b) {
 ; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]]) {
 ; CHECK-NEXT:    [[MASK:%.*]] = call <32 x i1> @llvm.get.active.lane.mask.v32i1.i32(i32 [[A]], i32 [[B]])
 ; CHECK-NEXT:    call void (...) @llvm.fake.use(<32 x i1> [[MASK]])
-; CHECK-NEXT:    [[TMP1:%.*]] = bitcast <32 x i1> [[MASK]] to i32
-; CHECK-NEXT:    [[RED:%.*]] = icmp ne i32 [[TMP1]], 0
+; CHECK-NEXT:    [[RED:%.*]] = icmp ult i32 [[A]], [[B]]
 ; CHECK-NEXT:    ret i1 [[RED]]
 ;
   %mask = call <32 x i1> @llvm.get.active.lane.mask.v32i1.i32(i32 %a, i32 %b)
@@ -176,9 +167,7 @@ define i1 @vecreduce_or_get_active_lane_mask_v32i1_multiuse(i32 %a, i32 %b) {
 define i8 @vecreduce_or_zext_get_active_lane_mask_v4i1(i32 %a, i32 %b) {
 ; CHECK-LABEL: define i8 @vecreduce_or_zext_get_active_lane_mask_v4i1(
 ; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]]) {
-; CHECK-NEXT:    [[MASK:%.*]] = call <4 x i1> @llvm.get.active.lane.mask.v4i1.i32(i32 [[A]], i32 [[B]])
-; CHECK-NEXT:    [[TMP1:%.*]] = bitcast <4 x i1> [[MASK]] to i4
-; CHECK-NEXT:    [[TMP2:%.*]] = icmp ne i4 [[TMP1]], 0
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp ult i32 [[A]], [[B]]
 ; CHECK-NEXT:    [[RED:%.*]] = zext i1 [[TMP2]] to i8
 ; CHECK-NEXT:    ret i8 [[RED]]
 ;
@@ -191,9 +180,7 @@ define i8 @vecreduce_or_zext_get_active_lane_mask_v4i1(i32 %a, i32 %b) {
 define i8 @vecreduce_or_sext_get_active_lane_mask_v4i1(i32 %a, i32 %b) {
 ; CHECK-LABEL: define i8 @vecreduce_or_sext_get_active_lane_mask_v4i1(
 ; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]]) {
-; CHECK-NEXT:    [[MASK:%.*]] = call <4 x i1> @llvm.get.active.lane.mask.v4i1.i32(i32 [[A]], i32 [[B]])
-; CHECK-NEXT:    [[TMP1:%.*]] = bitcast <4 x i1> [[MASK]] to i4
-; CHECK-NEXT:    [[TMP2:%.*]] = icmp ne i4 [[TMP1]], 0
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp ult i32 [[A]], [[B]]
 ; CHECK-NEXT:    [[RED:%.*]] = sext i1 [[TMP2]] to i8
 ; CHECK-NEXT:    ret i8 [[RED]]
 ;
@@ -206,9 +193,7 @@ define i8 @vecreduce_or_sext_get_active_lane_mask_v4i1(i32 %a, i32 %b) {
 define i1 @bitcast_inverted_condition_v32i1(i32 %a, i32 %b) {
 ; CHECK-LABEL: define i1 @bitcast_inverted_condition_v32i1(
 ; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]]) {
-; CHECK-NEXT:    [[MASK:%.*]] = call <32 x i1> @llvm.get.active.lane.mask.v32i1.i32(i32 [[A]], i32 [[B]])
-; CHECK-NEXT:    [[CAST:%.*]] = bitcast <32 x i1> [[MASK]] to i32
-; CHECK-NEXT:    [[RED:%.*]] = icmp eq i32 [[CAST]], 0
+; CHECK-NEXT:    [[RED:%.*]] = icmp uge i32 [[A]], [[B]]
 ; CHECK-NEXT:    ret i1 [[RED]]
 ;
   %mask = call <32 x i1> @llvm.get.active.lane.mask.v32i1.i32(i32 %a, i32 %b)


### PR DESCRIPTION
get_active_lane_mask is called with lower and upper bounds. We can just compare the bounds themselves.

This change is intended to improve vecreduce_or codegen for fixed-length vectors. vscales deal with vecreduce_or directly. 

https://godbolt.org/z/84sjGGdWe

alive2 doesn't seem to support get_active_lane_mask at the moment.