### PR TITLE
[libc] Add <unistd.h> functions for user/group ID management.

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -407,6 +407,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.fsync
     libc.src.unistd.ftruncate
     libc.src.unistd.getcwd
+    libc.src.unistd.getegid
     libc.src.unistd.getentropy
     libc.src.unistd.geteuid
     libc.src.unistd.gethostname
@@ -430,7 +431,11 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.readlink
     libc.src.unistd.readlinkat
     libc.src.unistd.rmdir
+    libc.src.unistd.setgid
+    libc.src.unistd.setregid
+    libc.src.unistd.setreuid
     libc.src.unistd.setsid
+    libc.src.unistd.setuid
     libc.src.unistd.sleep
     libc.src.unistd.symlink
     libc.src.unistd.symlinkat

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -240,6 +240,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.fsync
     libc.src.unistd.ftruncate
     libc.src.unistd.getcwd
+    libc.src.unistd.getegid
     libc.src.unistd.getentropy
     libc.src.unistd.geteuid
     libc.src.unistd.gethostname
@@ -260,7 +261,11 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.readlink
     libc.src.unistd.readlinkat
     libc.src.unistd.rmdir
+    libc.src.unistd.setgid
+    libc.src.unistd.setregid
+    libc.src.unistd.setreuid
     libc.src.unistd.setsid
+    libc.src.unistd.setuid
     libc.src.unistd.symlink
     libc.src.unistd.symlinkat
     libc.src.unistd.sysconf

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -437,6 +437,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.fsync
     libc.src.unistd.ftruncate
     libc.src.unistd.getcwd
+    libc.src.unistd.getegid
     libc.src.unistd.getentropy
     libc.src.unistd.geteuid
     libc.src.unistd.gethostname
@@ -460,7 +461,11 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.readlink
     libc.src.unistd.readlinkat
     libc.src.unistd.rmdir
+    libc.src.unistd.setgid
+    libc.src.unistd.setregid
+    libc.src.unistd.setreuid
     libc.src.unistd.setsid
+    libc.src.unistd.setuid
     libc.src.unistd.sleep
     libc.src.unistd.symlink
     libc.src.unistd.symlinkat

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -446,6 +446,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.fsync
     libc.src.unistd.ftruncate
     libc.src.unistd.getcwd
+    libc.src.unistd.getegid
     libc.src.unistd.getentropy
     libc.src.unistd.geteuid
     libc.src.unistd.gethostname
@@ -469,7 +470,11 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.readlink
     libc.src.unistd.readlinkat
     libc.src.unistd.rmdir
+    libc.src.unistd.setgid
+    libc.src.unistd.setregid
+    libc.src.unistd.setreuid
     libc.src.unistd.setsid
+    libc.src.unistd.setuid
     libc.src.unistd.sleep
     libc.src.unistd.symlink
     libc.src.unistd.symlinkat

--- a/libc/include/unistd.yaml
+++ b/libc/include/unistd.yaml
@@ -217,6 +217,12 @@ functions:
     arguments:
       - type: char *
       - type: size_t
+  - name: getegid
+    standards:
+      - posix
+    return_type: gid_t
+    arguments:
+      - type: void
   - name: getentropy
     standards:
       - gnu
@@ -397,12 +403,38 @@ functions:
       - type: const void *__restrict
       - type: void *
       - type: ssize_t
+  - name: setgid
+    standards:
+      - posix
+    return_type: int
+    arguments:
+      - type: gid_t
+  - name: setregid
+    standards:
+      - posix
+    return_type: int
+    arguments:
+      - type: gid_t
+      - type: gid_t
+  - name: setreuid
+    standards:
+      - posix
+    return_type: int
+    arguments:
+      - type: uid_t
+      - type: uid_t
   - name: setsid
     standards:
       - posix
     return_type: pid_t
     arguments:
       - type: void
+  - name: setuid
+    standards:
+      - posix
+    return_type: int
+    arguments:
+      - type: uid_t
   - name: sleep
     standards:
       - posix

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/CMakeLists.txt
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/CMakeLists.txt
@@ -641,6 +641,70 @@ add_header_library(
 )
 
 add_header_library(
+  getegid
+  HDRS
+    getegid.h
+  DEPENDS
+    libc.hdr.types.gid_t
+    libc.include.sys_syscall
+    libc.src.__support.common
+    libc.src.__support.macros.config
+    libc.src.__support.OSUtil.osutil
+)
+
+add_header_library(
+  setuid
+  HDRS
+    setuid.h
+  DEPENDS
+    libc.hdr.types.uid_t
+    libc.include.sys_syscall
+    libc.src.__support.common
+    libc.src.__support.error_or
+    libc.src.__support.macros.config
+    libc.src.__support.OSUtil.osutil
+)
+
+add_header_library(
+  setreuid
+  HDRS
+    setreuid.h
+  DEPENDS
+    libc.hdr.types.uid_t
+    libc.include.sys_syscall
+    libc.src.__support.common
+    libc.src.__support.error_or
+    libc.src.__support.macros.config
+    libc.src.__support.OSUtil.osutil
+)
+
+add_header_library(
+  setgid
+  HDRS
+    setgid.h
+  DEPENDS
+    libc.hdr.types.gid_t
+    libc.include.sys_syscall
+    libc.src.__support.common
+    libc.src.__support.error_or
+    libc.src.__support.macros.config
+    libc.src.__support.OSUtil.osutil
+)
+
+add_header_library(
+  setregid
+  HDRS
+    setregid.h
+  DEPENDS
+    libc.hdr.types.gid_t
+    libc.include.sys_syscall
+    libc.src.__support.common
+    libc.src.__support.error_or
+    libc.src.__support.macros.config
+    libc.src.__support.OSUtil.osutil
+)
+
+add_header_library(
   link
   HDRS
     link.h

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/getegid.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/getegid.h
@@ -15,7 +15,7 @@
 #define LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_GETEGID_H
 
 #include "hdr/types/gid_t.h"
-#include "src/__support/OSUtil/syscall.h" // syscall_impl
+#include "src/__support/OSUtil/linux/syscall.h" // syscall_impl
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 #include <sys/syscall.h> // For syscall numbers

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/getegid.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/getegid.h
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Syscall wrapper for getegid.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_GETEGID_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_GETEGID_H
+
+#include "hdr/types/gid_t.h"
+#include "src/__support/OSUtil/syscall.h" // syscall_impl
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include <sys/syscall.h> // For syscall numbers
+
+namespace LIBC_NAMESPACE_DECL {
+namespace linux_syscalls {
+
+LIBC_INLINE gid_t getegid() {
+  // getegid is expected to always succeed, thus no error checking here.
+  return syscall_impl<gid_t>(SYS_getegid);
+}
+
+} // namespace linux_syscalls
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_GETEGID_H

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/setgid.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/setgid.h
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Syscall wrapper for setgid.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_SETGID_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_SETGID_H
+
+#include "hdr/types/gid_t.h"
+#include "src/__support/OSUtil/linux/syscall.h" // syscall_checked
+#include "src/__support/common.h"
+#include "src/__support/error_or.h"
+#include "src/__support/macros/config.h"
+#include <sys/syscall.h> // For syscall numbers
+
+namespace LIBC_NAMESPACE_DECL {
+namespace linux_syscalls {
+
+LIBC_INLINE ErrorOr<int> setgid(gid_t gid) {
+  return syscall_checked<int>(SYS_setgid, gid);
+}
+
+} // namespace linux_syscalls
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_SETGID_H

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/setregid.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/setregid.h
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Syscall wrapper for setregid.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_SETREGID_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_SETREGID_H
+
+#include "hdr/types/gid_t.h"
+#include "src/__support/OSUtil/linux/syscall.h" // syscall_checked
+#include "src/__support/common.h"
+#include "src/__support/error_or.h"
+#include "src/__support/macros/config.h"
+#include <sys/syscall.h> // For syscall numbers
+
+namespace LIBC_NAMESPACE_DECL {
+namespace linux_syscalls {
+
+LIBC_INLINE ErrorOr<int> setregid(gid_t rgid, gid_t egid) {
+  return syscall_checked<int>(SYS_setregid, rgid, egid);
+}
+
+} // namespace linux_syscalls
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_SETREGID_H

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/setreuid.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/setreuid.h
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Syscall wrapper for setreuid.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_SETREUID_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_SETREUID_H
+
+#include "hdr/types/uid_t.h"
+#include "src/__support/OSUtil/linux/syscall.h" // syscall_checked
+#include "src/__support/common.h"
+#include "src/__support/error_or.h"
+#include "src/__support/macros/config.h"
+#include <sys/syscall.h> // For syscall numbers
+
+namespace LIBC_NAMESPACE_DECL {
+namespace linux_syscalls {
+
+LIBC_INLINE ErrorOr<int> setreuid(uid_t ruid, uid_t euid) {
+  return syscall_checked<int>(SYS_setreuid, ruid, euid);
+}
+
+} // namespace linux_syscalls
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_SETREUID_H

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/setuid.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/setuid.h
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Syscall wrapper for setuid.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_SETUID_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_SETUID_H
+
+#include "hdr/types/uid_t.h"
+#include "src/__support/OSUtil/linux/syscall.h" // syscall_checked
+#include "src/__support/common.h"
+#include "src/__support/error_or.h"
+#include "src/__support/macros/config.h"
+#include <sys/syscall.h> // For syscall numbers
+
+namespace LIBC_NAMESPACE_DECL {
+namespace linux_syscalls {
+
+LIBC_INLINE ErrorOr<int> setuid(uid_t uid) {
+  return syscall_checked<int>(SYS_setuid, uid);
+}
+
+} // namespace linux_syscalls
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_SETUID_H

--- a/libc/src/unistd/CMakeLists.txt
+++ b/libc/src/unistd/CMakeLists.txt
@@ -169,6 +169,13 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  getegid
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.getegid
+)
+
+add_entrypoint_object(
   gethostname
   ALIAS
   DEPENDS
@@ -316,10 +323,38 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  setgid
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.setgid
+)
+
+add_entrypoint_object(
+  setregid
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.setregid
+)
+
+add_entrypoint_object(
+  setreuid
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.setreuid
+)
+
+add_entrypoint_object(
   setsid
   ALIAS
   DEPENDS
     .${LIBC_TARGET_OS}.setsid
+)
+
+add_entrypoint_object(
+  setuid
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.setuid
 )
 
 add_entrypoint_object(

--- a/libc/src/unistd/getegid.h
+++ b/libc/src/unistd/getegid.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for getegid.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_UNISTD_GETEGID_H
+#define LLVM_LIBC_SRC_UNISTD_GETEGID_H
+
+#include "hdr/types/gid_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+gid_t getegid();
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_UNISTD_GETEGID_H

--- a/libc/src/unistd/linux/CMakeLists.txt
+++ b/libc/src/unistd/linux/CMakeLists.txt
@@ -240,6 +240,17 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  getegid
+  SRCS
+    getegid.cpp
+  HDRS
+    ../getegid.h
+  DEPENDS
+    libc.hdr.types.gid_t
+    libc.src.__support.OSUtil.linux.syscall_wrappers.getegid
+)
+
+add_entrypoint_object(
   gethostname
   SRCS
     gethostname.cpp
@@ -542,6 +553,42 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  setgid
+  SRCS
+    setgid.cpp
+  HDRS
+    ../setgid.h
+  DEPENDS
+    libc.hdr.types.gid_t
+    libc.src.__support.OSUtil.linux.syscall_wrappers.setgid
+    libc.src.errno.errno
+)
+
+add_entrypoint_object(
+  setregid
+  SRCS
+    setregid.cpp
+  HDRS
+    ../setregid.h
+  DEPENDS
+    libc.hdr.types.gid_t
+    libc.src.__support.OSUtil.linux.syscall_wrappers.setregid
+    libc.src.errno.errno
+)
+
+add_entrypoint_object(
+  setreuid
+  SRCS
+    setreuid.cpp
+  HDRS
+    ../setreuid.h
+  DEPENDS
+    libc.hdr.types.uid_t
+    libc.src.__support.OSUtil.linux.syscall_wrappers.setreuid
+    libc.src.errno.errno
+)
+
+add_entrypoint_object(
   setsid
   SRCS
     setsid.cpp
@@ -551,6 +598,18 @@ add_entrypoint_object(
     libc.hdr.types.pid_t
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil
+)
+
+add_entrypoint_object(
+  setuid
+  SRCS
+    setuid.cpp
+  HDRS
+    ../setuid.h
+  DEPENDS
+    libc.hdr.types.uid_t
+    libc.src.__support.OSUtil.linux.syscall_wrappers.setuid
+    libc.src.errno.errno
 )
 
 add_entrypoint_object(

--- a/libc/src/unistd/linux/getegid.cpp
+++ b/libc/src/unistd/linux/getegid.cpp
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Linux implementation of getegid.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/unistd/getegid.h"
+
+#include "hdr/types/gid_t.h"
+#include "src/__support/OSUtil/linux/syscall_wrappers/getegid.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(gid_t, getegid, ()) { return linux_syscalls::getegid(); }
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/unistd/linux/setgid.cpp
+++ b/libc/src/unistd/linux/setgid.cpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Linux implementation of setgid.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/unistd/setgid.h"
+
+#include "hdr/types/gid_t.h"
+#include "src/__support/OSUtil/linux/syscall_wrappers/setgid.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, setgid, (gid_t gid)) {
+  auto ret = linux_syscalls::setgid(gid);
+  if (!ret) {
+    libc_errno = ret.error();
+    return -1;
+  }
+  return 0;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/unistd/linux/setregid.cpp
+++ b/libc/src/unistd/linux/setregid.cpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Linux implementation of setregid.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/unistd/setregid.h"
+
+#include "hdr/types/gid_t.h"
+#include "src/__support/OSUtil/linux/syscall_wrappers/setregid.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, setregid, (gid_t rgid, gid_t egid)) {
+  auto ret = linux_syscalls::setregid(rgid, egid);
+  if (!ret) {
+    libc_errno = ret.error();
+    return -1;
+  }
+  return 0;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/unistd/linux/setreuid.cpp
+++ b/libc/src/unistd/linux/setreuid.cpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Linux implementation of setreuid.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/unistd/setreuid.h"
+
+#include "hdr/types/uid_t.h"
+#include "src/__support/OSUtil/linux/syscall_wrappers/setreuid.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, setreuid, (uid_t ruid, uid_t euid)) {
+  auto ret = linux_syscalls::setreuid(ruid, euid);
+  if (!ret) {
+    libc_errno = ret.error();
+    return -1;
+  }
+  return 0;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/unistd/linux/setuid.cpp
+++ b/libc/src/unistd/linux/setuid.cpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Linux implementation of setuid.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/unistd/setuid.h"
+
+#include "hdr/types/uid_t.h"
+#include "src/__support/OSUtil/linux/syscall_wrappers/setuid.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, setuid, (uid_t uid)) {
+  auto ret = linux_syscalls::setuid(uid);
+  if (!ret) {
+    libc_errno = ret.error();
+    return -1;
+  }
+  return 0;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/unistd/setgid.h
+++ b/libc/src/unistd/setgid.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for setgid.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_UNISTD_SETGID_H
+#define LLVM_LIBC_SRC_UNISTD_SETGID_H
+
+#include "hdr/types/gid_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int setgid(gid_t gid);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_UNISTD_SETGID_H

--- a/libc/src/unistd/setregid.h
+++ b/libc/src/unistd/setregid.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for setregid.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_UNISTD_SETREGID_H
+#define LLVM_LIBC_SRC_UNISTD_SETREGID_H
+
+#include "hdr/types/gid_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int setregid(gid_t rgid, gid_t egid);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_UNISTD_SETREGID_H

--- a/libc/src/unistd/setreuid.h
+++ b/libc/src/unistd/setreuid.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for setreuid.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_UNISTD_SETREUID_H
+#define LLVM_LIBC_SRC_UNISTD_SETREUID_H
+
+#include "hdr/types/uid_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int setreuid(uid_t ruid, uid_t euid);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_UNISTD_SETREUID_H

--- a/libc/src/unistd/setuid.h
+++ b/libc/src/unistd/setuid.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for setuid.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_UNISTD_SETUID_H
+#define LLVM_LIBC_SRC_UNISTD_SETUID_H
+
+#include "hdr/types/uid_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int setuid(uid_t uid);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_UNISTD_SETUID_H

--- a/libc/test/src/unistd/CMakeLists.txt
+++ b/libc/test/src/unistd/CMakeLists.txt
@@ -394,6 +394,50 @@ add_libc_test(
 )
 
 add_libc_test(
+  setgid_test
+  SUITE
+    libc_unistd_unittests
+  SRCS
+    setgid_test.cpp
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.src.unistd.getgid
+    libc.src.unistd.setgid
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
+)
+
+add_libc_test(
+  setregid_test
+  SUITE
+    libc_unistd_unittests
+  SRCS
+    setregid_test.cpp
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.src.unistd.getegid
+    libc.src.unistd.getgid
+    libc.src.unistd.setregid
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
+)
+
+add_libc_test(
+  setreuid_test
+  SUITE
+    libc_unistd_unittests
+  SRCS
+    setreuid_test.cpp
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.src.unistd.geteuid
+    libc.src.unistd.getuid
+    libc.src.unistd.setreuid
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
+)
+
+add_libc_test(
   setsid_test
   SUITE
     libc_unistd_unittests
@@ -401,6 +445,20 @@ add_libc_test(
     setsid_test.cpp
   DEPENDS
     libc.src.unistd.setsid
+)
+
+add_libc_test(
+  setuid_test
+  SUITE
+    libc_unistd_unittests
+  SRCS
+    setuid_test.cpp
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.src.unistd.getuid
+    libc.src.unistd.setuid
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_test(
@@ -543,6 +601,16 @@ add_libc_test(
   DEPENDS
     libc.src.unistd.getpagesize
     libc.test.UnitTest.ErrnoCheckingTest
+)
+
+add_libc_test(
+  getegid_test
+  SUITE
+    libc_unistd_unittests
+  SRCS
+    getegid_test.cpp
+  DEPENDS
+    libc.src.unistd.getegid
 )
 
 add_libc_test(

--- a/libc/test/src/unistd/getegid_test.cpp
+++ b/libc/test/src/unistd/getegid_test.cpp
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for getegid.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/unistd/getegid.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcGetEgidTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcGetEgidTest, SmokeTest) {
+  // getegid() always succeeds. Check that it returns a valid GID.
+  ASSERT_GE(LIBC_NAMESPACE::getegid(), static_cast<gid_t>(0));
+}

--- a/libc/test/src/unistd/setgid_test.cpp
+++ b/libc/test/src/unistd/setgid_test.cpp
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for setgid.
+///
+//===----------------------------------------------------------------------===//
+
+#include "hdr/errno_macros.h"
+#include "src/unistd/getgid.h"
+#include "src/unistd/setgid.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/ErrnoSetterMatcher.h"
+#include "test/UnitTest/Test.h"
+
+using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcSetGidTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcSetGidTest, SetCurrentGid) {
+  // Setting the GID to the current real GID is permitted and should succeed.
+  ASSERT_THAT(LIBC_NAMESPACE::setgid(LIBC_NAMESPACE::getgid()), Succeeds());
+}
+
+TEST_F(LlvmLibcSetGidTest, InvalidGid) {
+  ASSERT_THAT(LIBC_NAMESPACE::setgid(static_cast<gid_t>(-1)),
+              Fails(any_of(EINVAL, EPERM)));
+}

--- a/libc/test/src/unistd/setregid_test.cpp
+++ b/libc/test/src/unistd/setregid_test.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for setregid.
+///
+//===----------------------------------------------------------------------===//
+
+#include "hdr/errno_macros.h"
+#include "src/unistd/getegid.h"
+#include "src/unistd/getgid.h"
+#include "src/unistd/setregid.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/ErrnoSetterMatcher.h"
+#include "test/UnitTest/Test.h"
+
+using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcSetReGidTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcSetReGidTest, NoopMinusOne) {
+  // Passing -1 leaves the corresponding ID unchanged and always succeeds.
+  ASSERT_THAT(
+      LIBC_NAMESPACE::setregid(static_cast<gid_t>(-1), static_cast<gid_t>(-1)),
+      Succeeds());
+}
+
+TEST_F(LlvmLibcSetReGidTest, SetCurrentReGid) {
+  // Setting the real and effective GIDs to their current values should succeed.
+  ASSERT_THAT(LIBC_NAMESPACE::setregid(LIBC_NAMESPACE::getgid(),
+                                       LIBC_NAMESPACE::getegid()),
+              Succeeds());
+}
+
+TEST_F(LlvmLibcSetReGidTest, InvalidGid) {
+  ASSERT_THAT(
+      LIBC_NAMESPACE::setregid(static_cast<gid_t>(-2), static_cast<gid_t>(-2)),
+      Fails(any_of(EINVAL, EPERM)));
+}

--- a/libc/test/src/unistd/setreuid_test.cpp
+++ b/libc/test/src/unistd/setreuid_test.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for setreuid.
+///
+//===----------------------------------------------------------------------===//
+
+#include "hdr/errno_macros.h"
+#include "src/unistd/geteuid.h"
+#include "src/unistd/getuid.h"
+#include "src/unistd/setreuid.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/ErrnoSetterMatcher.h"
+#include "test/UnitTest/Test.h"
+
+using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcSetReUidTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcSetReUidTest, NoopMinusOne) {
+  // Passing -1 leaves the corresponding ID unchanged and always succeeds.
+  ASSERT_THAT(
+      LIBC_NAMESPACE::setreuid(static_cast<uid_t>(-1), static_cast<uid_t>(-1)),
+      Succeeds());
+}
+
+TEST_F(LlvmLibcSetReUidTest, SetCurrentReUid) {
+  // Setting the real and effective UIDs to their current values should succeed.
+  ASSERT_THAT(LIBC_NAMESPACE::setreuid(LIBC_NAMESPACE::getuid(),
+                                       LIBC_NAMESPACE::geteuid()),
+              Succeeds());
+}
+
+TEST_F(LlvmLibcSetReUidTest, InvalidUid) {
+  ASSERT_THAT(
+      LIBC_NAMESPACE::setreuid(static_cast<uid_t>(-2), static_cast<uid_t>(-2)),
+      Fails(any_of(EINVAL, EPERM)));
+}

--- a/libc/test/src/unistd/setuid_test.cpp
+++ b/libc/test/src/unistd/setuid_test.cpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for setuid.
+///
+//===----------------------------------------------------------------------===//
+
+#include "hdr/errno_macros.h"
+#include "src/unistd/getuid.h"
+#include "src/unistd/setuid.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/ErrnoSetterMatcher.h"
+#include "test/UnitTest/Test.h"
+
+using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcSetUidTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcSetUidTest, SetCurrentUid) {
+  // Setting the UID to the current real UID is permitted and should succeed.
+  ASSERT_THAT(LIBC_NAMESPACE::setuid(LIBC_NAMESPACE::getuid()), Succeeds());
+}
+
+TEST_F(LlvmLibcSetUidTest, InvalidUid) {
+  // Setting an invalid UID should fail with EINVAL or EPERM.
+  ASSERT_THAT(LIBC_NAMESPACE::setuid(static_cast<uid_t>(-1)),
+              Fails(any_of(EINVAL, EPERM)));
+}


### PR DESCRIPTION
* Add POSIX functions `getegid` (in addition to existing `get(eu|g|s|u)id` ones);
* Add matching POSIX setter functions: `setgid`, `setregid`, `setreuid`, `setuid` (in addition to existing `setsid`);
* Implement these functions on Linux as straightforward syscall wrappers, and enable on Linux platforms;
* Add unit test to sanity-check returned values and verify the expected errno values for invalid arguments (typically EINVAL or EPERM).

Assisted by automated tooling, human-verified.