### PR TITLE
[mlir][xegpu] Resolve scf.while "after" region argument layouts

### DIFF
--- a/mlir/include/mlir/Dialect/XeGPU/Utils/XeGPUUtils.h
+++ b/mlir/include/mlir/Dialect/XeGPU/Utils/XeGPUUtils.h
@@ -169,11 +169,20 @@ template <typename T>
 int getLargestDivisor(T dim, ArrayRef<T> candidates,
                       ArrayRef<T> candidateMultiples = {});
 
-/// Retrieves the DistributeLayoutAttr associated with a given Value. For
-/// TensorDescType values, the DistributeLayoutAttr is extracted from the
-/// TensorDescType itself. For other values, it is obtained from the attributes
-/// of the defining operation. Returns nullptr if no DistributeLayoutAttr is
-/// found.
+/// Retrieves the DistributeLayoutAttr associated with a given Value, or nullptr
+/// if none is found. For TensorDescType values it is extracted from the
+/// TensorDescType itself; for an op result, from the attributes of the defining
+/// operation.
+///
+/// A block argument carries no attribute of its own, so it is resolved through
+/// the operand that feeds it:
+///  - an iter_arg of a loop, including scf.while's "before" arguments, resolves
+///    through its tied init operand;
+///  - an scf.while "after" argument is fed by scf.condition rather than by an
+///    init operand. Only a pass-through before region is handled: the forwarded
+///    value must be a "before" argument, and the layout comes from that
+///    argument's tied init operand. If the before region forwards anything
+///    computed, nullptr is returned.
 DistributeLayoutAttr getDistributeLayoutAttr(const Value value);
 
 /// Retrieves the DistributeLayoutAttr associated with a given OpOperand. It

--- a/mlir/lib/Dialect/XeGPU/Transforms/XeGPULayoutImpl.cpp
+++ b/mlir/lib/Dialect/XeGPU/Transforms/XeGPULayoutImpl.cpp
@@ -273,21 +273,19 @@ LogicalResult xegpu::propagateYieldOperandsToRegionResults(
       // Assign the yield operand's layout to the region op result it feeds.
       if (auto result = dyn_cast<OpResult>(successorInput))
         xegpu::setDistributeLayoutAttr(result, successorOperandLayout);
-      // A block argument has no attribute of its own, and scf.while's "after"
-      // arguments are tied to no init operand to borrow one from. Their layout
-      // is only recoverable when the terminator forwards a region argument
-      // unchanged, so that getDistributeLayoutAttr can read it from there. If a
-      // layout is required and the forwarded value is anything else, say so
-      // rather than lowering the region with an unknown layout.
+      // Restrict the input IR: a successor argument that is not tied to an init
+      // operand (scf.while's "after" arguments) must be fed by a pass-through,
+      // because nothing else identifies which value the region carries. Its
+      // layout is then that of the forwarded argument's init operand.
       if (auto arg = dyn_cast<BlockArgument>(successorInput)) {
         auto loop =
             dyn_cast<LoopLikeOpInterface>(arg.getOwner()->getParentOp());
         bool tiedToInit = loop && loop.getTiedLoopInit(arg);
-        if (!tiedToInit && getLayoutOfValue(arg) &&
-            !isa<BlockArgument>(successorOperand->get()))
+        if (!tiedToInit && !isa<BlockArgument>(successorOperand->get()))
           return terminator->emitError(
-              "region argument requires a layout, but the forwarded value is "
-              "not a region argument");
+              "unsupported region structure: the successor argument it feeds "
+              "is not tied to an init operand, so its value must be passed "
+              "through from predecessor region argument.");
       }
     }
   }

--- a/mlir/lib/Dialect/XeGPU/Transforms/XeGPULayoutImpl.cpp
+++ b/mlir/lib/Dialect/XeGPU/Transforms/XeGPULayoutImpl.cpp
@@ -273,6 +273,22 @@ LogicalResult xegpu::propagateYieldOperandsToRegionResults(
       // Assign the yield operand's layout to the region op result it feeds.
       if (auto result = dyn_cast<OpResult>(successorInput))
         xegpu::setDistributeLayoutAttr(result, successorOperandLayout);
+      // A block argument has no attribute of its own, and scf.while's "after"
+      // arguments are tied to no init operand to borrow one from. Their layout
+      // is only recoverable when the terminator forwards a region argument
+      // unchanged, so that getDistributeLayoutAttr can read it from there. If a
+      // layout is required and the forwarded value is anything else, say so
+      // rather than lowering the region with an unknown layout.
+      if (auto arg = dyn_cast<BlockArgument>(successorInput)) {
+        auto loop =
+            dyn_cast<LoopLikeOpInterface>(arg.getOwner()->getParentOp());
+        bool tiedToInit = loop && loop.getTiedLoopInit(arg);
+        if (!tiedToInit && getLayoutOfValue(arg) &&
+            !isa<BlockArgument>(successorOperand->get()))
+          return terminator->emitError(
+              "region argument requires a layout, but the forwarded value is "
+              "not a region argument");
+      }
     }
   }
   return success();
@@ -2912,9 +2928,10 @@ xegpu::DistributeLayoutAttr xegpu::getConsumerLayoutAt(OpOperand &operand) {
     return xegpu::getDistributeLayoutAttr(operand);
   // Region ops with forwarded operands (scf.for's and scf.while's inits) carry
   // the required operand layout as the layout_operand_N that
-  // propagateRegionArgsToInits back-propagated from the region argument.
-  // TODO: derive that layout from the region argument here instead, so this
-  // function is the only place an operand's required layout comes from.
+  // propagateRegionArgsToInits back-propagated from the region argument. Do not
+  // re-derive it from that argument here: conflict resolution inserts
+  // convert_layout ops as it walks, rewriting the argument's uses, so what
+  // those uses require depends on how far the walk has progressed.
   if (isa<RegionBranchOpInterface>(op))
     return xegpu::getDistributeLayoutAttr(operand);
   // A region terminator requires the layout of the successor input its operand

--- a/mlir/lib/Dialect/XeGPU/Transforms/XeGPUPropagateLayout.cpp
+++ b/mlir/lib/Dialect/XeGPU/Transforms/XeGPUPropagateLayout.cpp
@@ -10,6 +10,7 @@
 #include "mlir/Analysis/DataFlow/SparseAnalysis.h"
 #include "mlir/Analysis/DataFlow/Utils.h"
 #include "mlir/Analysis/DataFlowFramework.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
@@ -1663,11 +1664,7 @@ ResolveLayoutConflicts::resolveVectorConsumer(OpOperand &operand) {
   // silently trusted to region forwarding.
   auto consumerLayout = xegpu::getConsumerLayoutAt(operand);
   if (!consumerLayout) {
-    // TODO: handle scf.while's "after" region arguments. They are tied to no
-    // init operand, so nothing records the layout they require, and the
-    // conflict on the scf.condition operand feeding them is left unresolved
-    // rather than converted.
-    if (isa<RegionBranchTerminatorOpInterface>(consumerOp))
+    if (isa<func::ReturnOp>(consumerOp) || isa<gpu::ReturnOp>(consumerOp))
       return success();
     return consumerOp->emitError(
         "No consumer layout found for vector operand.");

--- a/mlir/lib/Dialect/XeGPU/Utils/XeGPUUtils.cpp
+++ b/mlir/lib/Dialect/XeGPU/Utils/XeGPUUtils.cpp
@@ -23,6 +23,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/ValueRange.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/Support/Casting.h"
@@ -169,10 +170,20 @@ xegpu::DistributeLayoutAttr xegpu::getDistributeLayoutAttr(const Value value) {
 
   if (auto arg = dyn_cast<BlockArgument>(value)) {
     auto *parentOp = arg.getOwner()->getParentOp();
-    if (auto loop = dyn_cast_if_present<LoopLikeOpInterface>(parentOp)) {
-      OpOperand *tiedInit = loop.getTiedLoopInit(arg);
-      if (tiedInit)
+    auto loop = dyn_cast_if_present<LoopLikeOpInterface>(parentOp);
+    if (loop)
+      if (OpOperand *tiedInit = loop.getTiedLoopInit(arg))
         return getTemporaryLayout(*tiedInit);
+    // An scf.while "after" argument is tied to no init operand; scf.condition
+    // feeds it. Only a pass-through is supported: the forwarded value must be
+    // the matching "before" argument, whose tied init operand carries the
+    // layout.
+    if (auto whileOp = dyn_cast_if_present<scf::WhileOp>(parentOp);
+        whileOp && arg.getOwner()->getParent() == &whileOp.getAfter()) {
+      Value forwarded = whileOp.getConditionOp().getArgs()[arg.getArgNumber()];
+      if (auto beforeArg = dyn_cast<BlockArgument>(forwarded))
+        if (OpOperand *tiedInit = whileOp.getTiedLoopInit(beforeArg))
+          return getTemporaryLayout(*tiedInit);
     }
   }
 

--- a/mlir/test/Dialect/XeGPU/propagate-layout-subgroup-invalid.mlir
+++ b/mlir/test/Dialect/XeGPU/propagate-layout-subgroup-invalid.mlir
@@ -94,3 +94,27 @@ gpu.module @entry_kernel {
     gpu.return
   }
 }
+
+// -----
+// scf.while's "after" region argument is tied to no init operand, so its layout
+// is only recoverable when the before region forwards a region argument
+// unchanged. Here scf.condition forwards a freshly loaded value instead, so
+// there is nowhere to attribute the layout the after argument requires.
+gpu.module @test {
+  func.func @while_after_arg_not_pass_through(%src: memref<256x128xf32>, %cond: i1) {
+    %cst = arith.constant dense<0.000000e+00> : vector<256x128xf32>
+    %tdesc = xegpu.create_nd_tdesc %src : memref<256x128xf32> -> !xegpu.tensor_desc<256x128xf32>
+    %0 = scf.while (%before = %cst) : (vector<256x128xf32>) -> vector<256x128xf32> {
+      %loaded = xegpu.load_nd %tdesc[0, 0] : !xegpu.tensor_desc<256x128xf32> -> vector<256x128xf32>
+      // expected-error@+2 {{region argument requires a layout, but the forwarded value is not a region argument}}
+      // expected-error@+1 {{Failed to update operation with the layout.}}
+      scf.condition(%cond) %loaded : vector<256x128xf32>
+    } do {
+    ^bb0(%after: vector<256x128xf32>):
+      xegpu.store_nd %after, %tdesc[0, 0] <{layout = #xegpu.layout<sg_layout = [8, 4], sg_data = [32, 32]>}>
+        : vector<256x128xf32>, !xegpu.tensor_desc<256x128xf32>
+      scf.yield %after : vector<256x128xf32>
+    }
+    return
+  }
+}

--- a/mlir/test/Dialect/XeGPU/propagate-layout-subgroup-invalid.mlir
+++ b/mlir/test/Dialect/XeGPU/propagate-layout-subgroup-invalid.mlir
@@ -106,7 +106,7 @@ gpu.module @test {
     %tdesc = xegpu.create_nd_tdesc %src : memref<256x128xf32> -> !xegpu.tensor_desc<256x128xf32>
     %0 = scf.while (%before = %cst) : (vector<256x128xf32>) -> vector<256x128xf32> {
       %loaded = xegpu.load_nd %tdesc[0, 0] : !xegpu.tensor_desc<256x128xf32> -> vector<256x128xf32>
-      // expected-error@+2 {{region argument requires a layout, but the forwarded value is not a region argument}}
+      // expected-error@+2 {{unsupported region structure: the successor argument it feeds is not tied to an init operand, so its value must be passed through from predecessor region argument.}}
       // expected-error@+1 {{Failed to update operation with the layout.}}
       scf.condition(%cond) %loaded : vector<256x128xf32>
     } do {

--- a/mlir/test/Dialect/XeGPU/resolve-layout-conflicts.mlir
+++ b/mlir/test/Dialect/XeGPU/resolve-layout-conflicts.mlir
@@ -279,25 +279,30 @@ func.func @conflict_nested_loop_carried() {
   return
 }
 
-// TODO: this scf.condition conflict is not resolved yet. The "after" region
-// argument is tied to no init operand, so it carries no layout for this pass to
-// read, and the [16, 16] value is left unconverted. Recording current behavior so
-// a fix surfaces as a test change.
-// CHECK-LABEL: func.func @negative_while_condition_operand
-// CHECK:         %[[V:.*]] = "some_op"() {layout_result_0 = #xegpu.layout<inst_data = [16, 16]>} : () -> vector<16x16xf16>
-// CHECK-NEXT:    scf.condition(%{{.*}}) %[[V]] : vector<16x16xf16>
-// CHECK-NOT:     xegpu.convert_layout
-func.func @negative_while_condition_operand(%cond: i1) {
+// scf.while's "after" region argument is tied to no init operand, but the before
+// region forwards %before unchanged, so %after carries the init operand's layout
+// [8, 16] (layout_operand_0). math.exp wants [16, 16], so the argument is
+// converted on the way in and converted back before the yield.
+// CHECK-LABEL: func.func @conflict_while_pass_through
+// CHECK:         scf.while (%[[BEFORE:.*]] = %{{.*}})
+// CHECK:           scf.condition(%{{.*}}) %[[BEFORE]] : vector<16x16xf16>
+// CHECK:         ^bb0(%[[AFTER:.*]]: vector<16x16xf16>):
+// CHECK-NEXT:      %[[CVT_IN:.*]] = xegpu.convert_layout %[[AFTER]]
+// CHECK-SAME:        <{input_layout = #xegpu.layout<inst_data = [8, 16]>, target_layout = #xegpu.layout<inst_data = [16, 16]>}>
+// CHECK-NEXT:      %[[EXP:.*]] = math.exp %[[CVT_IN]] {layout_result_0 = #xegpu.layout<inst_data = [16, 16]>} : vector<16x16xf16>
+// CHECK-NEXT:      %[[CVT_OUT:.*]] = xegpu.convert_layout %[[EXP]]
+// CHECK-SAME:        <{input_layout = #xegpu.layout<inst_data = [16, 16]>, target_layout = #xegpu.layout<inst_data = [8, 16]>}>
+// CHECK-NEXT:      scf.yield %[[CVT_OUT]] : vector<16x16xf16>
+func.func @conflict_while_pass_through(%cond: i1) {
   %cst = arith.constant {layout_result_0 = #inst_data_8x16} dense<0.0> : vector<16x16xf16>
   %0 = scf.while (%before = %cst) : (vector<16x16xf16>) -> vector<16x16xf16> {
-    %1 = "some_op"() {layout_result_0 = #inst_data_16x16} : () -> vector<16x16xf16>
-    scf.condition(%cond) %1 : vector<16x16xf16>
+    scf.condition(%cond) %before : vector<16x16xf16>
   } do {
   ^bb0(%after: vector<16x16xf16>):
-    %2 = math.exp %after {layout_result_0 = #inst_data_8x16} : vector<16x16xf16>
-    scf.yield %2 : vector<16x16xf16>
+    %1 = math.exp %after {layout_result_0 = #inst_data_16x16} : vector<16x16xf16>
+    scf.yield %1 : vector<16x16xf16>
   } attributes {layout_operand_0 = #inst_data_8x16, layout_result_0 = #inst_data_8x16}
-  %3 = math.exp %0 {layout_result_0 = #inst_data_8x16} : vector<16x16xf16>
+  %2 = math.exp %0 {layout_result_0 = #inst_data_8x16} : vector<16x16xf16>
   return
 }
 


### PR DESCRIPTION
This PR handles the layout conflict resolution and argument layout access for scf.while. It limited the scf.while to pass-through use case: when `scf.condition` forwards a "before" argument unchanged, the "after" argument's layout can be accessed as scf.while's expected operand layout for the init operands. In this way, the handling of scf.for is unified with scf.while, the argument layout can be derived by the loop op's operand's layout. 

assited-by-claude
