### PR TITLE
[mlir] introduce cf.assume

### DIFF
--- a/mlir/include/mlir/Dialect/ControlFlow/IR/ControlFlowOps.td
+++ b/mlir/include/mlir/Dialect/ControlFlow/IR/ControlFlowOps.td
@@ -62,6 +62,36 @@ def AssertOp : CF_Op<"assert",
 }
 
 //===----------------------------------------------------------------------===//
+// AssumeOp
+//===----------------------------------------------------------------------===//
+
+def AssumeOp : CF_Op<"assume"> {
+  let summary = "Assumption operation";
+  let description = [{
+    Assumption operation with a single boolean. This allows analyses to assume
+    the operand is `true` and has no effect at runtime. Unlike the `assert`
+    operation, this does not abort program execution if the operand happens to
+    be `false`. Is is under responsibility of the user to only assume values
+    known to be `true`, the behavior of the program is undefined otherwise.
+
+    Example:
+
+    ```mlir
+    // Assumes %v is even, i.e. the remainder of its division by 2 is 0.
+    %c0 = arith.constant 0 : i32
+    %c2 = arith.constant 2 : i32
+    %rem = arith.remsi %v, %c2 : i32
+    %b = arith.cmpi eq %rem, %c0 : I32
+    cf.assume %b
+    ```
+  }];
+
+  let arguments = (ins I1:$arg);
+
+  let assemblyFormat = "$arg attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
 // BranchOp
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.cpp
+++ b/mlir/lib/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.cpp
@@ -98,6 +98,17 @@ private:
   SymbolTableCollection *symbolTables = nullptr;
 };
 
+struct AssumeOpLowering : public ConvertOpToLLVMPattern<cf::AssumeOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(cf::AssumeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<LLVM::AssumeOp>(op, adaptor.getArg());
+    return success();
+  }
+};
+
 /// Helper function for converting branch ops. This function converts the
 /// signature of the given block. If the new block signature is different from
 /// `expectedTypes`, returns "failure".
@@ -238,6 +249,7 @@ void mlir::cf::populateControlFlowToLLVMConversionPatterns(
     const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
   // clang-format off
   patterns.add<
+      AssumeOpLowering,
       BranchOpLowering,
       CondBranchOpLowering,
       SwitchOpLowering>(converter);

--- a/mlir/test/Conversion/ControlFlowToLLVM/assume.mlir
+++ b/mlir/test/Conversion/ControlFlowToLLVM/assume.mlir
@@ -1,0 +1,9 @@
+// RUN: mlir-opt --convert-cf-to-llvm %s | FileCheck %s
+
+// CHECK-LABEL: @assume
+// CHECK-SAME: %[[ARG:.+]]:
+func.func @assume(%arg: i1) {
+  // CHECK: llvm.intr.assume %[[ARG]]
+  cf.assume %arg
+  return
+}

--- a/mlir/test/Dialect/ControlFlow/ops.mlir
+++ b/mlir/test/Dialect/ControlFlow/ops.mlir
@@ -7,6 +7,13 @@ func.func @assert(%arg : i1) {
   return
 }
 
+// CHECK-LABEL: @assume
+func.func @assume(%arg : i1) {
+  // CHECK: cf.assume %{{.*}}
+  cf.assume %arg
+  return
+}
+
 // CHECK-LABEL: func @switch(
 func.func @switch(%flag : i32, %caseOperand : i32) {
   cf.switch %flag : i32, [


### PR DESCRIPTION
Introduce an "assumption" operation that optimizers can use to assume a boolean value is true. This is complementary to `cf.assert` but does involve the runtime abort.

Exercise this by lowering to the LLVM dialect counterpart.