### PR TITLE
[AMDGPU] Sort features by name, add feature-name parsing

### DIFF
--- a/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
+++ b/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
@@ -185,6 +185,17 @@ LLVM_ABI const AMDGPUFeatureBitset &getFeatureBitset(GPUKind AK);
 LLVM_ABI void getFeatureNames(const AMDGPUFeatureBitset &Features,
                               SmallVectorImpl<StringRef> &Names);
 
+/// Returns the feature bit named \p Name (e.g. "dot1-insts"), or nullopt if it
+/// is not a frontend-visible feature. This is the inverse of getFeatureNames.
+LLVM_ABI std::optional<AMDGPUFeature> parseFeature(StringRef Name);
+
+/// Applies a comma-separated list of "+feature"/"-feature" modifiers (an
+/// -mattr-style string) to \p Features. Returns the offending entry if one is
+/// missing its +/- prefix or names an unknown feature, in which case the
+/// preceding entries have already been applied; returns nullopt on success.
+LLVM_ABI std::optional<StringRef>
+applyFeatureModifiers(StringRef Modifiers, AMDGPUFeatureBitset &Features);
+
 /// Append the valid AMDGCN GPU names to \p Values. If \p SubArch is not
 /// NoSubArch, only GPUs compatible with that subarch (see isCPUValidForSubArch)
 /// are appended.

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/TargetParser/AMDGPUTargetParser.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringTable.h"
 #include "llvm/ADT/Twine.h"
@@ -343,6 +344,42 @@ void AMDGPU::getFeatureNames(const AMDGPUFeatureBitset &Features,
     if (Features.test(I))
       Names.push_back(AMDGPUNameStrTab[AMDGPUFeatureNames[I]]);
   }
+}
+
+std::optional<AMDGPUFeature> AMDGPU::parseFeature(StringRef Name) {
+  // The feature bits are emitted in name order, so the names this indexes are
+  // sorted.
+  const StringTable::Offset *It = llvm::lower_bound(
+      AMDGPUFeatureNames, Name, [](StringTable::Offset O, StringRef N) {
+        return AMDGPUNameStrTab[O] < N;
+      });
+  if (It == std::end(AMDGPUFeatureNames) || AMDGPUNameStrTab[*It] != Name)
+    return std::nullopt;
+  return static_cast<AMDGPUFeature>(It - std::begin(AMDGPUFeatureNames));
+}
+
+std::optional<StringRef>
+AMDGPU::applyFeatureModifiers(StringRef Modifiers,
+                              AMDGPUFeatureBitset &Features) {
+  while (!Modifiers.empty()) {
+    StringRef Entry;
+    std::tie(Entry, Modifiers) = Modifiers.split(',');
+    Entry = Entry.trim();
+
+    if (Entry.empty())
+      continue;
+
+    char Sign = Entry.front();
+    std::optional<AMDGPUFeature> Feature = parseFeature(Entry.drop_front());
+    if ((Sign != '+' && Sign != '-') || !Feature)
+      return Entry;
+
+    if (Sign == '+')
+      Features.set(*Feature);
+    else
+      Features.reset(*Feature);
+  }
+  return std::nullopt;
 }
 
 void AMDGPU::fillValidArchListAMDGCN(SmallVectorImpl<StringRef> &Values,

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -2856,6 +2856,58 @@ TEST(TargetParserTest, testAMDGPUgetFeatureBitset) {
   EXPECT_TRUE(Empty.empty());
 }
 
+TEST(TargetParserTest, testAMDGPUParseFeature) {
+  // parseFeature is the inverse of getFeatureNames, so every bit must round
+  // trip. This also covers the sorted-index table the lookup binary searches:
+  // the enum is in declaration order, which is not name order.
+  for (unsigned I = 0; I != AMDGPU::NUM_FEATURES; ++I) {
+    AMDGPU::AMDGPUFeatureBitset Single;
+    Single.set(I);
+    SmallVector<StringRef, 0> Names;
+    AMDGPU::getFeatureNames(Single, Names);
+    ASSERT_EQ(Names.size(), 1u);
+    EXPECT_EQ(AMDGPU::parseFeature(Names[0]),
+              static_cast<AMDGPU::AMDGPUFeature>(I))
+        << "round trip failed for '" << Names[0] << "'";
+  }
+
+  // Catch sorting subtleties.
+  EXPECT_EQ(AMDGPU::parseFeature("dot1-insts"), AMDGPU::FEAT_DOT1_INSTS);
+  EXPECT_EQ(AMDGPU::parseFeature("dot10-insts"), AMDGPU::FEAT_DOT10_INSTS);
+
+  EXPECT_EQ(AMDGPU::parseFeature(""), std::nullopt);
+  EXPECT_EQ(AMDGPU::parseFeature("not-a-feature"), std::nullopt);
+  EXPECT_EQ(AMDGPU::parseFeature("+dot1-insts"), std::nullopt);
+  EXPECT_EQ(AMDGPU::parseFeature("sram-ecc"), std::nullopt);
+}
+
+TEST(TargetParserTest, testAMDGPUApplyFeatureModifiers) {
+  AMDGPU::AMDGPUFeatureBitset Bits =
+      AMDGPU::getFeatureBitset(AMDGPU::GK_GFX900);
+  ASSERT_TRUE(Bits.test(AMDGPU::FEAT_DPP));
+  ASSERT_FALSE(Bits.test(AMDGPU::FEAT_MAI_INSTS));
+
+  EXPECT_EQ(AMDGPU::applyFeatureModifiers("+mai-insts,-dpp", Bits),
+            std::nullopt);
+  EXPECT_TRUE(Bits.test(AMDGPU::FEAT_MAI_INSTS));
+  EXPECT_FALSE(Bits.test(AMDGPU::FEAT_DPP));
+
+  // Whitespace and empty entries are tolerated.
+  EXPECT_EQ(AMDGPU::applyFeatureModifiers(" +dpp , ,", Bits), std::nullopt);
+  EXPECT_TRUE(Bits.test(AMDGPU::FEAT_DPP));
+
+  // An empty modifier list leaves the set alone.
+  AMDGPU::AMDGPUFeatureBitset Before = Bits;
+  EXPECT_EQ(AMDGPU::applyFeatureModifiers("", Bits), std::nullopt);
+  EXPECT_EQ(Bits, Before);
+
+  // A malformed or unknown entry is reported verbatim, sign included.
+  EXPECT_EQ(AMDGPU::applyFeatureModifiers("dpp", Bits), "dpp");
+  EXPECT_EQ(AMDGPU::applyFeatureModifiers("+nonsense", Bits), "+nonsense");
+  EXPECT_EQ(AMDGPU::applyFeatureModifiers("+dpp,~mai-insts", Bits),
+            "~mai-insts");
+}
+
 TEST(TargetParserTest, testAMDGPUfillValidArchListAMDGCN) {
   SmallVector<StringRef, 0> All;
   AMDGPU::fillValidArchListAMDGCN(All, Triple::NoSubArch);

--- a/llvm/utils/TableGen/Basic/AMDGPUTargetDefEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/AMDGPUTargetDefEmitter.cpp
@@ -203,14 +203,20 @@ static void emitFeatureExpr(raw_ostream &OS, const Record *Rec,
     OS << NoneSpelling;
 }
 
-// The frontend-visible features, bit order matching the list. Empty for R600
-// (no AMDGPUFrontendVisibleFeatures def).
+// The frontend-visible features, ordered by name so that a bit's position also
+// orders it in the emitted name table, making that table binary searchable.
+// Empty for R600 (no AMDGPUFrontendVisibleFeatures def).
 static std::vector<const Record *>
 collectFrontendFeatures(const RecordKeeper &RK) {
   const Record *List = RK.getDef("AMDGPUFrontendVisibleFeatures");
   if (!List)
     return {};
-  return List->getValueAsListOfDefs("Features");
+
+  std::vector<const Record *> Features = List->getValueAsListOfDefs("Features");
+  sort(Features, [](const Record *A, const Record *B) {
+    return A->getValueAsString("Name") < B->getValueAsString("Name");
+  });
+  return Features;
 }
 
 // The transitive closure of a GPU's SubtargetFeatures, following the Implies
@@ -448,6 +454,8 @@ emitAMDGPUFeatureEnum(raw_ostream &OS, ArrayRef<const Record *> Features,
 }
 
 // Emit AMDGPUFeatureNames (GET_AMDGPU_FEATURE_NAME_TABLE): bit -> name offset.
+// The bits are in name order, so the strings this indexes are sorted and a
+// name lookup can binary search it.
 static void emitAMDGPUFeatureNames(raw_ostream &OS,
                                    ArrayRef<unsigned> Offsets) {
   if (Offsets.empty())


### PR DESCRIPTION
Emit `AMDGPUFrontendVisibleFeatures` sorted by name so it can be
binary-searched.

Also add an API for mapping feature name(s) to updates to a feature
bitmap, allowing frontends (MLIR in particular) to parse a
`-mattr`-like string.

AI disclosure; Claude wrote this code.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
