### PR TITLE
[AMDGPU] Expose buffer resource num_records width in TargetParser

### DIFF
--- a/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
+++ b/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
@@ -212,8 +212,8 @@ constexpr unsigned getNumWorkGroupSIMDs(bool FullSIMDMode) {
 /// \returns Minimum number of waves per execution unit.
 constexpr unsigned getMinWavesPerEU() { return 1; }
 
-/// \returns Number of bits in the num_records field is a buffer resource,
-/// or nullopt if the target is too generic to have a fixed value for that.
+/// \returns Number of bits in the num_records field in a buffer resource,
+/// or nullopt if it is not known concretely.
 LLVM_ABI std::optional<unsigned> getBufferResourceNumRecordsWidth(GPUKind AK);
 LLVM_ABI std::optional<unsigned>
 getBufferResourceNumRecordsWidth(Triple::SubArchType SubArch);

--- a/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
+++ b/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
@@ -212,6 +212,12 @@ constexpr unsigned getNumWorkGroupSIMDs(bool FullSIMDMode) {
 /// \returns Minimum number of waves per execution unit.
 constexpr unsigned getMinWavesPerEU() { return 1; }
 
+/// \returns Number of bits in the num_records field is a buffer resource,
+/// or nullopt if the target is too generic to have a fixed value for that.
+LLVM_ABI std::optional<unsigned> getBufferResourceNumRecordsWidth(GPUKind AK);
+LLVM_ABI std::optional<unsigned>
+getBufferResourceNumRecordsWidth(Triple::SubArchType SubArch);
+
 /// \returns Maximum number of waves per execution unit without any kind of
 /// limitation.
 LLVM_ABI unsigned getMaxWavesPerEU(GPUKind AK);

--- a/llvm/lib/Target/AMDGPU/AMDGPU.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.td
@@ -1796,7 +1796,6 @@ def FeatureGFX12 : GCNSubtargetFeatureGeneration<"GFX12",
    FeatureMinimum3Maximum3F32, FeatureMinimum3Maximum3F16,
    FeatureAgentScopeFineGrainedRemoteMemoryAtomics, FeatureFlatOffsetBits24,
    FeatureFlatSignedOffset, FeatureInstCacheLineSize128,
-   Feature32BitNumRecordsBufferResource,
    FeatureMaxWavesPerEU16
   ]
 >;
@@ -2298,6 +2297,7 @@ def FeatureISAVersion11_7_Generic: FeatureSet<
 
 def FeatureISAVersion12 : FeatureSet<
   [FeatureGFX12,
+   Feature32BitNumRecordsBufferResource,
    FeatureSupportsWave64, FeatureSupportsWGP,
    FeatureBackOffBarrier,
    FeatureAddressableLocalMemorySize65536,

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -42,6 +42,7 @@ struct GPUInfo {
   uint8_t MaxWavesPerEU;
   uint32_t MaxHWAddressableLocalMemorySize;
   uint8_t LDSBankCount;
+  uint8_t BufferResourceNumRecordsWidth;
 };
 
 // Per-GPU data for the R600 GPUKinds.
@@ -483,6 +484,18 @@ unsigned AMDGPU::getLDSBankCount(GPUKind AK) {
 
 unsigned AMDGPU::getLDSBankCount(Triple::SubArchType SubArch) {
   return getLDSBankCount(getGPUKindFromSubArch(SubArch));
+}
+
+std::optional<unsigned> AMDGPU::getBufferResourceNumRecordsWidth(GPUKind AK) {
+  const GPUInfo *Info = getAMDGPUInfo(AK);
+  if (!Info)
+    return std::nullopt;
+  return Info->BufferResourceNumRecordsWidth;
+}
+
+std::optional<unsigned>
+AMDGPU::getBufferResourceNumRecordsWidth(Triple::SubArchType SubArch) {
+  return getBufferResourceNumRecordsWidth(getGPUKindFromSubArch(SubArch));
 }
 
 unsigned AMDGPU::getMaxWavesPerEU(GPUKind AK) {

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -488,7 +488,7 @@ unsigned AMDGPU::getLDSBankCount(Triple::SubArchType SubArch) {
 
 std::optional<unsigned> AMDGPU::getBufferResourceNumRecordsWidth(GPUKind AK) {
   const GPUInfo *Info = getAMDGPUInfo(AK);
-  if (!Info)
+  if (!Info || Info->BufferResourceNumRecordsWidth == 0)
     return std::nullopt;
   return Info->BufferResourceNumRecordsWidth;
 }

--- a/llvm/test/TableGen/AMDGPUTargetDefSubArchSpelling.td
+++ b/llvm/test/TableGen/AMDGPUTargetDefSubArchSpelling.td
@@ -44,9 +44,9 @@ def GFX88F : ProcessorModel<"gfx88f", NoSchedModel, []>,
 
 // The GPU table: both the base GPU and the variant share the gfx8 family; the
 // variant uses its own AMDGPUSubArch888A from the spelling.
-// CHECK: {[[#]], Triple::AMDGPUSubArch888, {{.*}}, {8, 8, 8}, [[FAM:[0-9]+]], [[#]], [[#]], [[#]]},
-// CHECK: {[[#]], Triple::AMDGPUSubArch888A, {{.*}}, {8, 8, 8}, [[FAM]], [[#]], [[#]], [[#]]},
-// CHECK: {[[#]], Triple::AMDGPUSubArch88F, {{.*}}, {8, 8, 15}, [[#]], [[#]], [[#]], [[#]]},
+// CHECK: {[[#]], Triple::AMDGPUSubArch888, {{.*}}, {8, 8, 8}, [[FAM:[0-9]+]], [[#]], [[#]], [[#]], [[#]]},
+// CHECK: {[[#]], Triple::AMDGPUSubArch888A, {{.*}}, {8, 8, 8}, [[FAM]], [[#]], [[#]], [[#]], [[#]]},
+// CHECK: {[[#]], Triple::AMDGPUSubArch88F, {{.*}}, {8, 8, 15}, [[#]], [[#]], [[#]], [[#]], [[#]]},
 
 // The subarch-name table maps the variant's own subarch to its triple name.
 // CHECK: {Triple::AMDGPUSubArch888A, [[#]], [[#]]},

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -3220,6 +3220,44 @@ TEST(TargetParserTest, testAMDGPUgetMaxHWAddressableLocalMemorySize) {
             327680u);
 }
 
+TEST(TargetParserTest, testAMDGPUgetBufferResourceNumRecordsWidth) {
+  EXPECT_EQ(AMDGPU::getBufferResourceNumRecordsWidth(AMDGPU::GK_GFX900), 32u);
+  EXPECT_EQ(AMDGPU::getBufferResourceNumRecordsWidth(AMDGPU::GK_GFX1201), 32u);
+  EXPECT_EQ(AMDGPU::getBufferResourceNumRecordsWidth(AMDGPU::GK_GFX1250), 45u);
+
+  // Generic families that agree on resource width behave.
+  EXPECT_EQ(AMDGPU::getBufferResourceNumRecordsWidth(AMDGPU::GK_GFX9_GENERIC),
+            32u);
+
+  EXPECT_EQ(AMDGPU::getBufferResourceNumRecordsWidth(AMDGPU::GK_GENERIC),
+            std::nullopt);
+  EXPECT_EQ(AMDGPU::getBufferResourceNumRecordsWidth(AMDGPU::GK_GENERIC_HSA),
+            std::nullopt);
+
+  EXPECT_EQ(AMDGPU::getBufferResourceNumRecordsWidth(AMDGPU::GK_NONE),
+            std::nullopt);
+  EXPECT_EQ(AMDGPU::getBufferResourceNumRecordsWidth(AMDGPU::GK_R600),
+            std::nullopt);
+
+  EXPECT_EQ(AMDGPU::getBufferResourceNumRecordsWidth(Triple::NoSubArch),
+            std::nullopt);
+
+  SmallVector<StringRef, 0> AllGPUs;
+  AMDGPU::fillValidArchListAMDGCN(AllGPUs, Triple::NoSubArch);
+  ASSERT_FALSE(AllGPUs.empty());
+  for (StringRef Name : AllGPUs) {
+    AMDGPU::GPUKind Kind = AMDGPU::parseArchAMDGCN(Name);
+    std::optional<unsigned> Width =
+        AMDGPU::getBufferResourceNumRecordsWidth(Kind);
+    EXPECT_TRUE(Width.has_value())
+        << "no num_records width for '" << Name << "'";
+    // The two overloads must agree wherever the GPU has a subarch to look up.
+    Triple::SubArchType SubArch = AMDGPU::getSubArch(Kind);
+    EXPECT_EQ(AMDGPU::getBufferResourceNumRecordsWidth(SubArch), Width)
+        << "overloads disagree for '" << Name << "'";
+  }
+}
+
 TEST(TargetParserTest, testAMDGPUgetNumWorkGroupSIMDs) {
   EXPECT_EQ(AMDGPU::getNumWorkGroupSIMDs(true), 4u);
   EXPECT_EQ(AMDGPU::getNumWorkGroupSIMDs(false), 2u);

--- a/llvm/utils/TableGen/Basic/AMDGPUTargetDefEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/AMDGPUTargetDefEmitter.cpp
@@ -610,7 +610,8 @@ emitAMDGPUTable(raw_ostream &OS, const RecordKeeper &RK,
     OS << ", " << Names.GetOrAddStringOffset(Family) << ", "
        << getFeatureValue(R, "MaxWavesPerEU", 10) << ", "
        << getFeatureValue(R, "AddressableLocalMemorySize", 32768) << ", "
-       << getFeatureValue(R, "LDSBankCount", 32) << "},\n";
+       << getFeatureValue(R, "LDSBankCount", 32) << ", "
+       << getFeatureValue(R, "BufferResourceNumRecordsWidth", 32) << "},\n";
   }
   OS << "};\n"
         "#endif // GET_AMDGPU_GPU_TABLE\n\n";

--- a/llvm/utils/TableGen/Basic/AMDGPUTargetDefEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/AMDGPUTargetDefEmitter.cpp
@@ -611,7 +611,7 @@ emitAMDGPUTable(raw_ostream &OS, const RecordKeeper &RK,
        << getFeatureValue(R, "MaxWavesPerEU", 10) << ", "
        << getFeatureValue(R, "AddressableLocalMemorySize", 32768) << ", "
        << getFeatureValue(R, "LDSBankCount", 32) << ", "
-       << getFeatureValue(R, "BufferResourceNumRecordsWidth", 32) << "},\n";
+       << getFeatureValue(R, "BufferResourceNumRecordsWidth", 0) << "},\n";
   }
   OS << "};\n"
         "#endif // GET_AMDGPU_GPU_TABLE\n\n";


### PR DESCRIPTION
This also fixes the conflict in gfx12.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
