### PR TITLE
[clang][docs] Fix Sphinx 8.2 and MyST build errors in Clang docs

### DIFF
--- a/clang/docs/ControlFlowIntegrityDesign.md
+++ b/clang/docs/ControlFlowIntegrityDesign.md
@@ -279,6 +279,8 @@ The interleaving scheme implemented in LLVM is inspired by
 by Dimitar Bounov, Rami Gökhan Kıcı, and Sorin Lerner, but has its own
 enhancements (more in [Interleave virtual tables]).
 
+[^ivtbl]: [Protecting C++ Dynamic Dispatch Through VTable Interleaving](https://cseweb.ucsd.edu/~lerner/papers/ivtbl-ndss16.pdf). Dimitar Bounov, Rami Gökhan Kıcı, Sorin Lerner.
+
 #### Split virtual table groups into separate virtual tables
 
 The Itanium C++ ABI glues multiple individual virtual tables for a class into a combined virtual table (virtual table group).

--- a/clang/docs/ScalableStaticAnalysis/developer-docs/index.md
+++ b/clang/docs/ScalableStaticAnalysis/developer-docs/index.md
@@ -3,7 +3,7 @@
 ```{toctree}
 :glob: true
 :maxdepth: 2
-:numbered: true
+:numbered:
 
 *
 ```


### PR DESCRIPTION
Commit 66617db9163d bumped Sphinx to 8.2, Docutils to 0.22, and MyST-Parser to 4.0.1.
When building Clang documentation with `-W`, this surfaced two breakages:
1. `ControlFlowIntegrityDesign.md`: Dangling `[^ivtbl]` footnote references without a matching footnote definition, leading to a docutils `ERROR: Too many autonumbered footnote references: only 0 corresponding footnote available` / `ERROR: Unknown target name: "ivtbl"`.
2. `ScalableStaticAnalysis/developer-docs/index.md`: `:numbered: true` caused a `ValueError: invalid literal for int() with base 10: 'true'` in MyST because `:numbered:` takes an integer depth or no argument. Fix it to `:numbered:`.

AI tool usage: An AI assistant was used to help research and draft the documentation updates.