### PR TITLE
[WebAssembly] Fix memory operand names for memory.copy in tablegen. NFC

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrBulkMemory.td
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrBulkMemory.td
@@ -56,12 +56,12 @@ defm INIT_A#B :
 
 let mayLoad = 1, mayStore = 1 in
 defm COPY_A#B :
-  BULK_I<(outs), (ins i32imm_op:$src_idx, i32imm_op:$dst_idx,
+  BULK_I<(outs), (ins i32imm_op:$dst_idx, i32imm_op:$src_idx,
                       rc:$dst, rc:$src, rc:$len),
-         (outs), (ins i32imm_op:$src_idx, i32imm_op:$dst_idx),
+         (outs), (ins i32imm_op:$dst_idx, i32imm_op:$src_idx),
          [],
-         "memory.copy\t$src_idx, $dst_idx, $dst, $src, $len",
-         "memory.copy\t$src_idx, $dst_idx", 0x0a>;
+         "memory.copy\t$dst_idx, $src_idx, $dst, $src, $len",
+         "memory.copy\t$dst_idx, $src_idx", 0x0a>;
 
 let mayStore = 1 in
 defm FILL_A#B :
@@ -82,10 +82,10 @@ defm MEMORY_ : BulkMemoryOps<I64, "64">;
 multiclass BulkMemOps<WebAssemblyRegClass rc, string B> {
 
 let usesCustomInserter = 1, isCodeGenOnly = 1, mayLoad = 1, mayStore = 1 in
-defm CPY_A#B : I<(outs), (ins i32imm_op:$src_idx, i32imm_op:$dst_idx,
+defm CPY_A#B : I<(outs), (ins i32imm_op:$dst_idx, i32imm_op:$src_idx,
                               rc:$dst, rc:$src, rc:$len),
-                 (outs), (ins i32imm_op:$src_idx, i32imm_op:$dst_idx),
-                 [(wasm_memcpy (i32 imm:$src_idx), (i32 imm:$dst_idx),
+                 (outs), (ins i32imm_op:$dst_idx, i32imm_op:$src_idx),
+                 [(wasm_memcpy (i32 imm:$dst_idx), (i32 imm:$src_idx),
                    rc:$dst, rc:$src, rc:$len
                  )],
                  "", "", 0>,


### PR DESCRIPTION
The first immediate is the destination memory index and the second is the source memory index according to the WebAssembly specification and `LowerMemcpy` in `WebAssemblyISelLowering.cpp`.