### PR TITLE
[clang][docs] Suppress Sphinx highlighting failure warnings in conf.py

### DIFF
--- a/clang/docs/conf.py
+++ b/clang/docs/conf.py
@@ -272,3 +272,8 @@ texinfo_documents = [
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 # texinfo_show_urls = 'footnote'
+
+# Pygments lexers are sometimes out of date or fail on custom/new Clang C++
+# attributes (e.g. [[clang::...]]). Suppress the warning so the build
+# doesn't abort under -W.
+suppress_warnings = ["misc.highlighting_failure"]


### PR DESCRIPTION
Following the upgrade to Sphinx 8.2 (#219299), Pygments syntax highlighting fallbacks (e.g. on custom C++ attribute syntaxes like `[[clang::...]]`) emit `[misc.highlighting_failure]` warnings when retrying in relaxed mode. Because sphinx-build runs with `-W`, these warnings abort the documentation build.

Mirror the configuration in `llvm/docs/conf.py` by setting `suppress_warnings = ["misc.highlighting_failure"]`.

AI tool usage: An AI assistant was used to help research and draft the documentation updates.