### PR TITLE
[BOLT] Fix data race on the shared .dwp DWARF context

### DIFF
--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -343,8 +343,15 @@ public:
   /// unit. Callers must, however, keep a given DWOId to a single thread at a
   /// time -- during parallel rewriting each DWOId belongs to exactly one
   /// bucket -- because opening and releasing both mutate the skeleton unit's
-  /// DWO pointer.
+  /// DWO pointer. With a package, where all split CUs share one context, use
+  /// openSharedDWOContext() before handing those CUs to worker threads.
   std::optional<DWARFUnit *> getDWOCU(uint64_t DWOId);
+
+  /// Open every split CU of a .dwp package up front, from a single thread.
+  ///
+  /// With a package all split CUs share one DWARFContext, and the caches it
+  /// fills in on demand are not all thread-safe. No-op for non-dwp inputs.
+  void openSharedDWOContext();
 
   /// Release the DWO context previously opened for \p DWOId (if any), freeing
   /// its DWARFContext and parsed unit vector. Same threading contract as

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -1830,6 +1830,21 @@ std::optional<DWARFUnit *> BinaryContext::getDWOCU(uint64_t DWOId) {
   return DWOCU;
 }
 
+void BinaryContext::openSharedDWOContext() {
+  if (!UsesDWP)
+    return;
+  DWARFContext *DWOCtx = nullptr;
+  for (auto &KV : DWOIdToSkeletonCU)
+    if (std::optional<DWARFUnit *> DWOCU = getDWOCU(KV.first))
+      DWOCtx = &(*DWOCU)->getContext();
+  if (!DWOCtx)
+    return;
+  // Avoid dwp races on type units needing abbreviations
+  // (buildDWPTypeUnitsForUnit) by making sure all abbreviations are set up.
+  for (const std::unique_ptr<DWARFUnit> &U : DWOCtx->dwo_info_section_units())
+    U->getAbbreviations();
+}
+
 void BinaryContext::releaseDWOCU(uint64_t DWOId) {
   // With a .dwp package every split CU aliases one shared DWARFContext
   if (UsesDWP)

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -1843,6 +1843,9 @@ void BinaryContext::openSharedDWOContext() {
   // (buildDWPTypeUnitsForUnit) by making sure all abbreviations are set up.
   for (const std::unique_ptr<DWARFUnit> &U : DWOCtx->dwo_info_section_units())
     U->getAbbreviations();
+  // DWARF4-equivalent, which keeps split type units in .debug_types.dwo
+  for (const std::unique_ptr<DWARFUnit> &U : DWOCtx->dwo_types_section_units())
+    U->getAbbreviations();
 }
 
 void BinaryContext::releaseDWOCU(uint64_t DWOId) {

--- a/bolt/lib/Rewrite/DWARFRewriter.cpp
+++ b/bolt/lib/Rewrite/DWARFRewriter.cpp
@@ -1027,6 +1027,11 @@ void DWARFRewriter::updateDebugInfo() {
       finalizeTypeSections(DIEBlder, *Streamer, GDBIndexSection);
   SmallVector<SmallVector<DWARFUnit *>> PartVec =
       partitionCUs(*BC.DwCtx, CUSize);
+  // Buckets below run in parallel, and with a .dwp package they all read the
+  // same split DWARF context. Create that context now to avoid a race
+  // (note this is a DWP-only issue, DWOs are safe since each thread operate
+  // on its own DWARF context).
+  BC.openSharedDWOContext();
   const unsigned int ThreadCount =
       std::min(opts::DebugThreadCount, opts::ThreadCount);
   llvm::ThreadPoolInterface &ThreadPool =


### PR DESCRIPTION
As noted by labrinea, 775dc9b8bf58 ("[BOLT] Create and release .dwo DWARF contexts incrementally") releases every DWO context at the end of readDebugInfo, leaving the bucket threads of the DWARF rewrite to re-open them on demand. With a .dwp package that moved the first touch of a shared context into the parallel phase, and multiple threads compete for it, in a race for the abbrev table, causing intermittent failures in dwarf5-ftypes-dwp-input-dwo-output.test.

Open the split CUs of a package up front, from a single thread, and resolve the abbreviation table of every unit in it. This is not relevant for the non-dwp case, which is unaffected.