### PR TITLE
[libc] Add <unistd.h> functions for managing foreground process group IDs

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -435,6 +435,8 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.symlink
     libc.src.unistd.symlinkat
     libc.src.unistd.sysconf
+    libc.src.unistd.tcgetpgrp
+    libc.src.unistd.tcsetpgrp
     libc.src.unistd.truncate
     libc.src.unistd.unlink
     libc.src.unistd.unlinkat

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -264,6 +264,8 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.symlink
     libc.src.unistd.symlinkat
     libc.src.unistd.sysconf
+    libc.src.unistd.tcgetpgrp
+    libc.src.unistd.tcsetpgrp
     libc.src.unistd.truncate
     libc.src.unistd.unlink
     libc.src.unistd.unlinkat

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -465,6 +465,8 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.symlink
     libc.src.unistd.symlinkat
     libc.src.unistd.sysconf
+    libc.src.unistd.tcgetpgrp
+    libc.src.unistd.tcsetpgrp
     libc.src.unistd.truncate
     libc.src.unistd.unlink
     libc.src.unistd.unlinkat

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -474,6 +474,8 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.symlink
     libc.src.unistd.symlinkat
     libc.src.unistd.sysconf
+    libc.src.unistd.tcgetpgrp
+    libc.src.unistd.tcsetpgrp
     libc.src.unistd.truncate
     libc.src.unistd.unlink
     libc.src.unistd.unlinkat

--- a/libc/include/unistd.yaml
+++ b/libc/include/unistd.yaml
@@ -430,6 +430,19 @@ functions:
     return_type: long
     arguments:
       - type: int
+  - name: tcgetpgrp
+    standards:
+      - posix
+    return_type: pid_t
+    arguments:
+      - type: int
+  - name: tcsetpgrp
+    standards:
+      - posix
+    return_type: int
+    arguments:
+      - type: int
+      - type: pid_t
   - name: truncate
     standards:
       - posix

--- a/libc/src/unistd/CMakeLists.txt
+++ b/libc/src/unistd/CMakeLists.txt
@@ -358,6 +358,20 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  tcgetpgrp
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.tcgetpgrp
+)
+
+add_entrypoint_object(
+  tcsetpgrp
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.tcsetpgrp
+)
+
+add_entrypoint_object(
   truncate
   ALIAS
   DEPENDS

--- a/libc/src/unistd/linux/CMakeLists.txt
+++ b/libc/src/unistd/linux/CMakeLists.txt
@@ -628,6 +628,32 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  tcgetpgrp
+  SRCS
+    tcgetpgrp.cpp
+  HDRS
+    ../tcgetpgrp.h
+  DEPENDS
+    libc.hdr.sys_ioctl_macros
+    libc.hdr.types.pid_t
+    libc.src.__support.OSUtil.linux.syscall_wrappers.ioctl
+    libc.src.errno.errno
+)
+
+add_entrypoint_object(
+  tcsetpgrp
+  SRCS
+    tcsetpgrp.cpp
+  HDRS
+    ../tcsetpgrp.h
+  DEPENDS
+    libc.hdr.sys_ioctl_macros
+    libc.hdr.types.pid_t
+    libc.src.__support.OSUtil.linux.syscall_wrappers.ioctl
+    libc.src.errno.errno
+)
+
+add_entrypoint_object(
   truncate
   SRCS
     truncate.cpp

--- a/libc/src/unistd/linux/tcgetpgrp.cpp
+++ b/libc/src/unistd/linux/tcgetpgrp.cpp
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Linux implementation of tcgetpgrp.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/unistd/tcgetpgrp.h"
+
+#include "hdr/sys_ioctl_macros.h"
+#include "hdr/types/pid_t.h"
+#include "src/__support/OSUtil/linux/syscall_wrappers/ioctl.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(pid_t, tcgetpgrp, (int fd)) {
+  pid_t pgid = 0;
+  auto result = linux_syscalls::ioctl(fd, TIOCGPGRP, &pgid);
+  if (!result.has_value()) {
+    libc_errno = result.error();
+    return -1;
+  }
+  return pgid;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/unistd/linux/tcsetpgrp.cpp
+++ b/libc/src/unistd/linux/tcsetpgrp.cpp
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Linux implementation of tcsetpgrp.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/unistd/tcsetpgrp.h"
+
+#include "hdr/sys_ioctl_macros.h"
+#include "hdr/types/pid_t.h"
+#include "src/__support/OSUtil/linux/syscall_wrappers/ioctl.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, tcsetpgrp, (int fd, pid_t pgid)) {
+  auto result = linux_syscalls::ioctl(fd, TIOCSPGRP, &pgid);
+  if (!result.has_value()) {
+    libc_errno = result.error();
+    return -1;
+  }
+  return 0;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/unistd/tcgetpgrp.h
+++ b/libc/src/unistd/tcgetpgrp.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for tcgetpgrp.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_UNISTD_TCGETPGRP_H
+#define LLVM_LIBC_SRC_UNISTD_TCGETPGRP_H
+
+#include "hdr/types/pid_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+pid_t tcgetpgrp(int fd);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_UNISTD_TCGETPGRP_H

--- a/libc/src/unistd/tcsetpgrp.h
+++ b/libc/src/unistd/tcsetpgrp.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for tcsetpgrp.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_UNISTD_TCSETPGRP_H
+#define LLVM_LIBC_SRC_UNISTD_TCSETPGRP_H
+
+#include "hdr/types/pid_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int tcsetpgrp(int fd, pid_t pgid);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_UNISTD_TCSETPGRP_H

--- a/libc/test/src/unistd/CMakeLists.txt
+++ b/libc/test/src/unistd/CMakeLists.txt
@@ -453,6 +453,40 @@ add_libc_test(
 )
 
 add_libc_test(
+  tcgetpgrp_test
+  SUITE
+    libc_unistd_unittests
+  SRCS
+    tcgetpgrp_test.cpp
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.hdr.fcntl_macros
+    libc.hdr.sys_stat_macros
+    libc.src.fcntl.open
+    libc.src.unistd.close
+    libc.src.unistd.tcgetpgrp
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
+)
+
+add_libc_test(
+  tcsetpgrp_test
+  SUITE
+    libc_unistd_unittests
+  SRCS
+    tcsetpgrp_test.cpp
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.hdr.fcntl_macros
+    libc.hdr.sys_stat_macros
+    libc.src.fcntl.open
+    libc.src.unistd.close
+    libc.src.unistd.tcsetpgrp
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
+)
+
+add_libc_test(
   truncate_test
   SUITE
     libc_unistd_unittests

--- a/libc/test/src/unistd/CMakeLists.txt
+++ b/libc/test/src/unistd/CMakeLists.txt
@@ -465,6 +465,7 @@ add_libc_test(
     libc.src.fcntl.open
     libc.src.unistd.close
     libc.src.unistd.tcgetpgrp
+    libc.src.unistd.unlink
     libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
@@ -482,6 +483,7 @@ add_libc_test(
     libc.src.fcntl.open
     libc.src.unistd.close
     libc.src.unistd.tcsetpgrp
+    libc.src.unistd.unlink
     libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/unistd/tcgetpgrp_test.cpp
+++ b/libc/test/src/unistd/tcgetpgrp_test.cpp
@@ -17,6 +17,7 @@
 #include "src/fcntl/open.h"
 #include "src/unistd/close.h"
 #include "src/unistd/tcgetpgrp.h"
+#include "src/unistd/unlink.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
@@ -24,11 +25,13 @@
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
 using LlvmLibcTcGetPgrpTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-// It's hard to test tcgetpgrp in unit tests, as the test process
-// is not typically associated with a terminal. We can probably achieve
-// this with fork()-ing a child process and creating the pseudo-terminal
-// fixture, but given that tcgetpgrp is a simple ioctl() wrapper (on Linux),
-// this complexity is likely not justified.
+// NOTE: We are not testing the kernel behavior, only how we wire up
+// and wrap kernel syscalls in libc interface (on Linux we wrap ioctl)
+// and propagate errors. It's hard to get good coverage of tcgetpgrp
+// in unit tests, as the test process is not typically associated with
+// a terminal. We can achieve this with fork()-ing a child process
+// and creating the pseudo-terminal fixture, but this complexity is
+// not justified.
 
 TEST_F(LlvmLibcTcGetPgrpTest, BadFd) {
   ASSERT_THAT(LIBC_NAMESPACE::tcgetpgrp(-1), Fails<pid_t>(EBADF));
@@ -42,4 +45,5 @@ TEST_F(LlvmLibcTcGetPgrpTest, NonTerminalFd) {
   ASSERT_GT(fd, 0);
   ASSERT_THAT(LIBC_NAMESPACE::tcgetpgrp(fd), Fails<pid_t>(ENOTTY));
   ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
+  ASSERT_THAT(LIBC_NAMESPACE::unlink(test_file), Succeeds(0));
 }

--- a/libc/test/src/unistd/tcgetpgrp_test.cpp
+++ b/libc/test/src/unistd/tcgetpgrp_test.cpp
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for tcgetpgrp.
+///
+//===----------------------------------------------------------------------===//
+
+#include "hdr/errno_macros.h"
+#include "hdr/fcntl_macros.h"
+#include "hdr/sys_stat_macros.h"
+#include "src/fcntl/open.h"
+#include "src/unistd/close.h"
+#include "src/unistd/tcgetpgrp.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/ErrnoSetterMatcher.h"
+#include "test/UnitTest/Test.h"
+
+using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcTcGetPgrpTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+// It's hard to test tcgetpgrp in unit tests, as the test process
+// is not typically associated with a terminal. We can probably achieve
+// this with fork()-ing a child process and creating the pseudo-terminal
+// fixture, but given that tcgetpgrp is a simple ioctl() wrapper (on Linux),
+// this complexity is likely not justified.
+
+TEST_F(LlvmLibcTcGetPgrpTest, BadFd) {
+  ASSERT_THAT(LIBC_NAMESPACE::tcgetpgrp(-1), Fails<pid_t>(EBADF));
+}
+
+TEST_F(LlvmLibcTcGetPgrpTest, NonTerminalFd) {
+  constexpr const char *FILENAME = "tcgetpgrp.test";
+  auto test_file = libc_make_test_file_path(FILENAME);
+  int fd = LIBC_NAMESPACE::open(test_file, O_WRONLY | O_CREAT, S_IRWXU);
+  ASSERT_ERRNO_SUCCESS();
+  ASSERT_GT(fd, 0);
+  ASSERT_THAT(LIBC_NAMESPACE::tcgetpgrp(fd), Fails<pid_t>(ENOTTY));
+  ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
+}

--- a/libc/test/src/unistd/tcsetpgrp_test.cpp
+++ b/libc/test/src/unistd/tcsetpgrp_test.cpp
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for tcsetpgrp.
+///
+//===----------------------------------------------------------------------===//
+
+#include "hdr/errno_macros.h"
+#include "hdr/fcntl_macros.h"
+#include "hdr/sys_stat_macros.h"
+#include "src/fcntl/open.h"
+#include "src/unistd/close.h"
+#include "src/unistd/tcsetpgrp.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/ErrnoSetterMatcher.h"
+#include "test/UnitTest/Test.h"
+
+using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcTcSetPgrpTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+// It's hard to test tcsetpgrp in unit tests, as the test process
+// is not typically associated with a terminal. We can probably achieve
+// this with fork()-ing a child process and creating the pseudo-terminal
+// fixture, but given that tcsetpgrp is a simple ioctl() wrapper (on Linux),
+// this complexity is likely not justified.
+
+TEST_F(LlvmLibcTcSetPgrpTest, BadFd) {
+  ASSERT_THAT(LIBC_NAMESPACE::tcsetpgrp(-1, 0), Fails(EBADF));
+}
+
+TEST_F(LlvmLibcTcSetPgrpTest, NonTerminalFd) {
+  constexpr const char *FILENAME = "tcsetpgrp.test";
+  auto test_file = libc_make_test_file_path(FILENAME);
+  int fd = LIBC_NAMESPACE::open(test_file, O_WRONLY | O_CREAT, S_IRWXU);
+  ASSERT_ERRNO_SUCCESS();
+  ASSERT_GT(fd, 0);
+  ASSERT_THAT(LIBC_NAMESPACE::tcsetpgrp(fd, 0), Fails(ENOTTY));
+  ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
+}

--- a/libc/test/src/unistd/tcsetpgrp_test.cpp
+++ b/libc/test/src/unistd/tcsetpgrp_test.cpp
@@ -17,6 +17,7 @@
 #include "src/fcntl/open.h"
 #include "src/unistd/close.h"
 #include "src/unistd/tcsetpgrp.h"
+#include "src/unistd/unlink.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
@@ -24,11 +25,13 @@
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
 using LlvmLibcTcSetPgrpTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-// It's hard to test tcsetpgrp in unit tests, as the test process
-// is not typically associated with a terminal. We can probably achieve
-// this with fork()-ing a child process and creating the pseudo-terminal
-// fixture, but given that tcsetpgrp is a simple ioctl() wrapper (on Linux),
-// this complexity is likely not justified.
+// NOTE: We are not testing the kernel behavior, only how we wire up
+// and wrap kernel syscalls in libc interface (on Linux we wrap ioctl)
+// and propagate errors. It's hard to get good coverage of tcgetpgrp
+// in unit tests, as the test process is not typically associated with
+// a terminal. We can achieve this with fork()-ing a child process
+// and creating the pseudo-terminal fixture, but this complexity is
+// not justified.
 
 TEST_F(LlvmLibcTcSetPgrpTest, BadFd) {
   ASSERT_THAT(LIBC_NAMESPACE::tcsetpgrp(-1, 0), Fails(EBADF));
@@ -42,4 +45,5 @@ TEST_F(LlvmLibcTcSetPgrpTest, NonTerminalFd) {
   ASSERT_GT(fd, 0);
   ASSERT_THAT(LIBC_NAMESPACE::tcsetpgrp(fd, 0), Fails(ENOTTY));
   ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
+  ASSERT_THAT(LIBC_NAMESPACE::unlink(test_file), Succeeds(0));
 }


### PR DESCRIPTION
* Add POSIX functions `tcgetpgrp` and `tcsetpgrp` that get/set process group IDs of foreground process groups associated with a terminal;
* Implement these functions as `ioctl` syscall wrappers and enable them on Linux;
* Add unit test to verify the expected errno values for common error cases (`EBADF` / `ENOTTY`),
  but don't verify the "positive" cases, since it's challenging to do in a unit test environment w/o using fork and
  creating pseudo-terminal fixtures.

Assisted by automated tooling, human-verified.