### PR TITLE
[mlir] Fix mlir-pdll-lsp-server link.

### DIFF
--- a/mlir/lib/Tools/mlir-pdll-lsp-server/CMakeLists.txt
+++ b/mlir/lib/Tools/mlir-pdll-lsp-server/CMakeLists.txt
@@ -7,6 +7,9 @@ llvm_add_library(MLIRPdllLspServerLib
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Tools/mlir-pdll-lsp-server
 
+  # MLIRPDLLParser needs LLVMTableGen, which is excluded from libLLVM.so.
+  DISABLE_LLVM_LINK_LLVM_DYLIB
+
   LINK_COMPONENTS
   SupportLSP
 


### PR DESCRIPTION
This is the same fix TableGenLspServerLib got in 9e469ced42cd. This addresses the mlir-pdll-lsp-server instance of #152371.

MLIRPdllLspServerLib transitively needs LLVMTableGen, which is not part of libLLVM.so, so MLIRPDLLParser already brings in static LLVMSupport. Linking the dylib here as well gives mlir-pdll-lsp-server two copies of LLVMSupport. Linking still succeeds, but with assertions view-output.test fails. The test trips over the two copies having different Hashing.h seeds, which is a separate defect to be addressed in another PR.

It has not shown up in CI because it needs the dylib and assertions at the same time, which rarely coincide. It also only became reachable once a3a25996b114 moved the LSP transport into libLLVM.so.

Assisted-By: Claude Opus 5