### PR TITLE
[ORC] Add SymbolStringPtr overloads for recordAddr/recordProxy

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/LookupAndApply.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LookupAndApply.h
@@ -111,6 +111,19 @@ recordAddr(StringRef Name, ExecutorAddr *A,
   };
 }
 
+/// Records the address of the symbol with the given, already-interned name.
+///
+/// If the symbol is weakly referenced and not found then *A is set to null.
+inline LookupPrepareFn
+recordAddr(SymbolStringPtr Name, ExecutorAddr *A,
+           SymbolLookupFlags LF = SymbolLookupFlags::RequiredSymbol) {
+  return [Name = std::move(Name), A,
+          LF](SymbolLookupSet &LS, ExecutionSession &ES) -> LookupApplyFn {
+    LS.add(Name, LF);
+    return [A, Name](const SymbolMap &M) { *A = M.lookup(Name).getAddress(); };
+  };
+}
+
 } // namespace llvm::orc
 
 #endif // LLVM_EXECUTIONENGINE_ORC_LOOKUPANDAPPLY_H

--- a/llvm/include/llvm/ExecutionEngine/Orc/RecordProxy.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RecordProxy.h
@@ -42,6 +42,26 @@ recordProxy(Proxy<FnT> *P, typename Proxy<FnT>::DispatchFn Dispatch,
   };
 }
 
+/// Builds P over the symbol with the given, already-interned name,
+/// dispatching through Dispatch.
+///
+/// If the symbol is weakly referenced and not found then P is left null.
+template <typename FnT>
+LookupPrepareFn
+recordProxy(Proxy<FnT> *P, typename Proxy<FnT>::DispatchFn Dispatch,
+            SymbolStringPtr Name,
+            SymbolLookupFlags LF = SymbolLookupFlags::RequiredSymbol) {
+  return [P, Dispatch, Name = std::move(Name),
+          LF](SymbolLookupSet &LS, ExecutionSession &ES) -> LookupApplyFn {
+    LS.add(Name, LF);
+    return [P, Dispatch, Name](const SymbolMap &M) {
+      auto Sym = M.lookup(Name);
+      *P = Sym.getAddress() ? Proxy<FnT>(Dispatch, Sym.getAddress())
+                            : Proxy<FnT>();
+    };
+  };
+}
+
 /// Builds P from the given spec, using the spec's default controller-interface
 /// name.
 template <typename ProxySpecT, typename FnT>
@@ -58,6 +78,16 @@ LookupPrepareFn
 recordProxy(Proxy<FnT> *P, StringRef Name,
             SymbolLookupFlags LF = SymbolLookupFlags::RequiredSymbol) {
   return recordProxy(P, ProxySpecT::dispatch, Name, LF);
+}
+
+/// Builds P from the given spec, but resolves it under the given,
+/// already-interned name rather than the spec's default controller-interface
+/// name.
+template <typename ProxySpecT, typename FnT>
+LookupPrepareFn
+recordProxy(Proxy<FnT> *P, SymbolStringPtr Name,
+            SymbolLookupFlags LF = SymbolLookupFlags::RequiredSymbol) {
+  return recordProxy(P, ProxySpecT::dispatch, std::move(Name), LF);
 }
 
 } // namespace llvm::orc

--- a/llvm/unittests/ExecutionEngine/Orc/LookupAndApplyTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/LookupAndApplyTest.cpp
@@ -96,6 +96,35 @@ TEST(LookupAndApplyTest, RecordAddrWeaklyReferencedAbsent) {
   cantFail(ES.endSession());
 }
 
+// The SymbolStringPtr overload behaves like the StringRef overload for a
+// present, required symbol -- the caller just does the interning itself.
+TEST(LookupAndApplyTest, RecordAddrSymbolStringPtr) {
+  ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
+  auto &JD = ES.getBootstrapJITDylib();
+  defineAddr(JD, "addr_a", ExecutorAddr(AddrAValue));
+
+  ExecutorAddr A;
+  cantFail(lookupAndApply(JD, {recordAddr(ES.intern("addr_a"), &A)}));
+  EXPECT_EQ(A, ExecutorAddr(AddrAValue));
+
+  cantFail(ES.endSession());
+}
+
+// As above, but for a weakly-referenced symbol that is missing: records a
+// null address rather than failing the lookup.
+TEST(LookupAndApplyTest, RecordAddrSymbolStringPtrWeaklyReferencedAbsent) {
+  ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
+
+  ExecutorAddr A(AddrAValue);
+  cantFail(
+      lookupAndApply(ES.getBootstrapJITDylib(),
+                     {recordAddr(ES.intern("absent"), &A,
+                                 SymbolLookupFlags::WeaklyReferencedSymbol)}));
+  EXPECT_EQ(A, ExecutorAddr());
+
+  cantFail(ES.endSession());
+}
+
 // Several prepare functions in one call are all applied, and a single one may
 // contribute more than one symbol.
 TEST(LookupAndApplyTest, MultiplePrepareFns) {

--- a/llvm/unittests/ExecutionEngine/Orc/ProxyTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/ProxyTest.cpp
@@ -256,6 +256,67 @@ TEST(ProxyTest, RecordProxyWeaklyReferencedAbsent) {
   cantFail(ES.endSession());
 }
 
+// recordProxy with an explicitly-supplied dispatch function and an
+// already-interned name -- the SymbolStringPtr counterpart of
+// RecordProxyExplicitDispatch above.
+TEST(ProxyTest, RecordProxySymbolStringPtrExplicitDispatch) {
+  ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
+
+  auto &JD = ES.getBootstrapJITDylib();
+  cantFail(JD.define(absoluteSymbols(
+      {{ES.intern(AddOneSpec::Name),
+        {ExecutorAddr::fromPtr(addOne), JITSymbolFlags::Exported}}})));
+
+  AddOneProxy Call;
+  cantFail(lookupAndApply(
+      JD, {recordProxy(&Call, AddOneDispatch, ES.intern(AddOneSpec::Name))}));
+  ASSERT_TRUE(static_cast<bool>(Call));
+
+  Expected<int32_t> R = Call(ES, 41);
+  ASSERT_THAT_EXPECTED(R, Succeeded());
+  EXPECT_EQ(*R, 42);
+
+  cantFail(ES.endSession());
+}
+
+// recordProxy with a spec but an overridden, already-interned lookup name --
+// the SymbolStringPtr counterpart of RecordProxySpecNameOverride above.
+TEST(ProxyTest, RecordProxySpecSymbolStringPtrNameOverride) {
+  ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
+
+  auto &JD = ES.getBootstrapJITDylib();
+  cantFail(JD.define(absoluteSymbols(
+      {{ES.intern("add_one_alias"),
+        {ExecutorAddr::fromPtr(addOne), JITSymbolFlags::Exported}}})));
+
+  AddOneProxy Call;
+  cantFail(lookupAndApply(
+      JD, {recordProxy<AddOneSpec>(&Call, ES.intern("add_one_alias"))}));
+  ASSERT_TRUE(static_cast<bool>(Call));
+
+  Expected<int32_t> R = Call(ES, 41);
+  ASSERT_THAT_EXPECTED(R, Succeeded());
+  EXPECT_EQ(*R, 42);
+
+  cantFail(ES.endSession());
+}
+
+// lookupAndApply propagates the lookup flags for the SymbolStringPtr
+// overload too: a weakly-referenced recordProxy for a missing symbol yields a
+// null proxy rather than failing the lookup.
+TEST(ProxyTest, RecordProxySymbolStringPtrWeaklyReferencedAbsent) {
+  ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
+
+  AddOneProxy Call;
+  cantFail(lookupAndApply(
+      ES.getBootstrapJITDylib(),
+      {recordProxy<AddOneSpec>(&Call, ES.intern(AddOneSpec::Name),
+                               SymbolLookupFlags::WeaklyReferencedSymbol)}));
+  EXPECT_FALSE(static_cast<bool>(Call));
+
+  cantFail(ES.endSession());
+}
+
 // A callee returning Error delivers its result as Error (not Expected<Error>),
 // through both call operators, for both success and failure.
 TEST(ProxyTest, ErrorReturn) {


### PR DESCRIPTION
Allow clients to pass symbol names as SymbolStringPtrs (in addition to StringRefs).