### PR TITLE
[CIR] Add global offset attribute

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -999,6 +999,64 @@ def CIR_GlobalViewAttr : CIR_ValueLikeAttr<"GlobalView", "global_view"> {
 }
 
 //===----------------------------------------------------------------------===//
+// GlobalOffsetAttr
+//===----------------------------------------------------------------------===//
+
+def CIR_GlobalOffsetAttr : CIR_ValueLikeAttr<"GlobalOffset", "global_offset"> {
+  let summary = "Provides constant access to a byte offset from a global";
+  let description = [{
+    Get the constant address that is `offset` bytes away from the address of
+    global `symbol`. Like `#cir.global_view`, it provides a way to access
+    globals from other globals and always produces a pointer, and the type of
+    the referenced symbol may differ from the type of the attribute.
+
+    Whereas `#cir.global_view` navigates the type of the symbol using
+    subelement indices, this attribute describes a flat displacement in bytes.
+    It is used for the addresses that cannot be described by subelement
+    indices, namely addresses outside of the referenced object, such as the
+    one-past-the-end address of a record, and addresses that do not fall on a
+    subelement boundary. This mirrors the byte offset that classic codegen
+    applies to every constant lvalue.
+
+    Example:
+
+    ```
+    struct S { int x; };
+    S s;
+    S *p = &s + 1;
+    ```
+
+    produces
+
+    ```
+    cir.global external @p = #cir.global_offset<@s, 4> : !cir.ptr<!rec_S>
+    ```
+
+    which lowers to
+
+    ```
+    @p = global ptr getelementptr (i8, ptr @s, i64 4)
+    ```
+  }];
+
+  let parameters = (ins AttributeSelfTypeParameter<"">:$type,
+                        "mlir::FlatSymbolRefAttr":$symbol,
+                        "int64_t":$offset);
+
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "mlir::Type":$type,
+                                        "mlir::FlatSymbolRefAttr":$symbol,
+                                        "int64_t":$offset), [{
+      return $_get(type.getContext(), type, symbol, offset);
+    }]>
+  ];
+
+  let assemblyFormat = [{
+    `<` $symbol `,` $offset `>`
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // VTableAttr
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
@@ -89,11 +89,11 @@ clang::CIRGen::CIRGenBuilderTy::getConstFP(mlir::Location loc, mlir::Type t,
   return cir::ConstantOp::create(*this, loc, cir::FPAttr::get(t, fpVal));
 }
 
-void CIRGenBuilderTy::computeGlobalViewIndicesFromFlatOffset(
+bool CIRGenBuilderTy::computeGlobalViewIndicesFromFlatOffset(
     int64_t offset, mlir::Type ty, cir::CIRDataLayout layout,
     llvm::SmallVectorImpl<int64_t> &indices) {
   if (!offset)
-    return;
+    return true;
 
   // Compute floor-division and a non-negative remainder. A negative flat
   // offset (e.g. from a pointer one element before the start of an array)
@@ -121,7 +121,12 @@ void CIRGenBuilderTy::computeGlobalViewIndicesFromFlatOffset(
             offset = newOffset;
             return arrayTy.getElementType();
           })
-          .Case<cir::RecordType>([&](auto recordTy) {
+          .Case<cir::RecordType>([&](auto recordTy) -> mlir::Type {
+            // A record can only be entered from its start. An offset before
+            // the record, or at or past its end, designates an address outside
+            // of the object, which no member index can reach.
+            if (offset < 0)
+              return {};
             ArrayRef<mlir::Type> elts = recordTy.getMembers();
             int64_t pos = 0;
             for (size_t i = 0; i < elts.size(); ++i) {
@@ -136,7 +141,6 @@ void CIRGenBuilderTy::computeGlobalViewIndicesFromFlatOffset(
               // check below
               if (!recordTy.isUnion())
                 pos = (pos + alignMask) & ~alignMask;
-              assert(offset >= 0);
               if (offset < pos + eltSize) {
                 indices.push_back(i);
                 offset -= pos;
@@ -146,7 +150,7 @@ void CIRGenBuilderTy::computeGlobalViewIndicesFromFlatOffset(
               if (!recordTy.isUnion())
                 pos += eltSize;
             }
-            llvm_unreachable("offset was not found within the record");
+            return {};
           })
           .Case<cir::IntType>([&](cir::IntType intTy) -> mlir::Type {
             // Integer element type: the offset is a flat element count.
@@ -158,16 +162,21 @@ void CIRGenBuilderTy::computeGlobalViewIndicesFromFlatOffset(
             assert(eltSize > 0 && "element size must be positive");
             const auto [index, newOffset] =
                 getIndexAndNewOffset(offset, eltSize);
+            // An integer has no subelements, so an offset into the middle of
+            // one can't be indexed.
+            if (newOffset)
+              return {};
             indices.push_back(index);
             offset = newOffset;
             return intTy;
           })
-          .Default([](mlir::Type) -> mlir::Type {
-            llvm_unreachable("unexpected type");
-          });
+          .Default([](mlir::Type) -> mlir::Type { return {}; });
 
-  assert(subType);
-  computeGlobalViewIndicesFromFlatOffset(offset, subType, layout, indices);
+  if (!subType)
+    return false;
+
+  return computeGlobalViewIndicesFromFlatOffset(offset, subType, layout,
+                                                indices);
 }
 
 uint64_t CIRGenBuilderTy::computeOffsetFromGlobalViewIndices(

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -663,7 +663,13 @@ public:
   // GlobalViewAttr. Ideally we shouldn't deal with low-level offsets at all
   // but currently some parts of Clang AST, which we don't want to touch just
   // yet, return them.
-  void computeGlobalViewIndicesFromFlatOffset(
+  //
+  // Returns false if the offset doesn't designate a subelement of \p ty, which
+  // happens when it lands outside of the object or in the middle of a scalar
+  // member. In that case \p indices is left in an unspecified state and the
+  // caller must describe the address with a byte offset, using a
+  // GlobalOffsetAttr, instead.
+  [[nodiscard]] bool computeGlobalViewIndicesFromFlatOffset(
       int64_t offset, mlir::Type ty, cir::CIRDataLayout layout,
       llvm::SmallVectorImpl<int64_t> &indices);
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
@@ -34,6 +34,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include <functional>
 #include <iterator>
+#include <optional>
 
 using namespace clang;
 using namespace clang::CIRGen;
@@ -715,6 +716,8 @@ struct ConstantLValue {
       : value(nullptr), hasOffsetApplied(false) {}
   /*implicit*/ ConstantLValue(cir::GlobalViewAttr address)
       : value(address), hasOffsetApplied(false) {}
+  /*implicit*/ ConstantLValue(cir::GlobalOffsetAttr address)
+      : value(address), hasOffsetApplied(true) {}
   /*implicit*/ ConstantLValue(cir::BlockAddrInfoAttr address)
       : value(address), hasOffsetApplied(true) {}
 
@@ -758,13 +761,16 @@ private:
   ConstantLValue
   VisitMaterializeTemporaryExpr(const MaterializeTemporaryExpr *e);
 
-  /// Return GEP-like value offset
-  mlir::ArrayAttr getOffset(mlir::Type ty) {
+  /// Return GEP-like value offset, or std::nullopt if the offset doesn't
+  /// designate a subelement of \p ty and must be described as a byte offset.
+  /// A null ArrayAttr means the offset is zero, so no indexing is needed.
+  std::optional<mlir::ArrayAttr> getOffsetIndices(mlir::Type ty) {
     int64_t offset = value.getLValueOffset().getQuantity();
     cir::CIRDataLayout layout(cgm.getModule());
     SmallVector<int64_t, 3> idxVec;
-    cgm.getBuilder().computeGlobalViewIndicesFromFlatOffset(offset, ty, layout,
-                                                            idxVec);
+    if (!cgm.getBuilder().computeGlobalViewIndicesFromFlatOffset(
+            offset, ty, layout, idxVec))
+      return std::nullopt;
 
     llvm::SmallVector<mlir::Attribute, 3> indices;
     for (int64_t i : idxVec) {
@@ -773,7 +779,7 @@ private:
     }
 
     if (indices.empty())
-      return {};
+      return mlir::ArrayAttr{};
     return cgm.getBuilder().getArrayAttr(indices);
   }
 
@@ -785,8 +791,11 @@ private:
         auto baseTy = mlir::cast<cir::PointerType>(gv.getType()).getPointee();
         mlir::Type destTy = cgm.getTypes().convertTypeForMem(destType);
         assert(!gv.getIndices() && "Global view is already indexed");
-        return cir::GlobalViewAttr::get(destTy, gv.getSymbol(),
-                                        getOffset(baseTy));
+        std::optional<mlir::ArrayAttr> indices = getOffsetIndices(baseTy);
+        if (!indices)
+          return cir::GlobalOffsetAttr::get(
+              destTy, gv.getSymbol(), value.getLValueOffset().getQuantity());
+        return cir::GlobalViewAttr::get(destTy, gv.getSymbol(), *indices);
       }
       llvm_unreachable("Unsupported attribute type to offset");
     }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1061,10 +1061,10 @@ static bool isViewOnGlobal(cir::GlobalOp glob, cir::GlobalViewAttr view) {
   return view.getSymbol().getValue() == glob.getSymName();
 }
 
-static cir::GlobalViewAttr createNewGlobalView(CIRGenModule &cgm,
-                                               cir::GlobalOp newGlob,
-                                               cir::GlobalViewAttr attr,
-                                               mlir::Type oldTy) {
+static mlir::Attribute createNewGlobalView(CIRGenModule &cgm,
+                                           cir::GlobalOp newGlob,
+                                           cir::GlobalViewAttr attr,
+                                           mlir::Type oldTy) {
   // If the attribute does not require indexes or it is not a global view on
   // the global we're replacing, keep the original attribute.
   if (!attr.getIndices() || !isViewOnGlobal(newGlob, attr))
@@ -1078,7 +1078,11 @@ static cir::GlobalViewAttr createNewGlobalView(CIRGenModule &cgm,
 
   uint64_t offset =
       bld.computeOffsetFromGlobalViewIndices(layout, oldTy, oldInds);
-  bld.computeGlobalViewIndicesFromFlatOffset(offset, newTy, layout, newInds);
+  if (!bld.computeGlobalViewIndicesFromFlatOffset(offset, newTy, layout,
+                                                  newInds))
+    return cir::GlobalOffsetAttr::get(attr.getType(), attr.getSymbol(),
+                                      static_cast<int64_t>(offset));
+
   cir::PointerType newPtrTy;
 
   if (isa<cir::RecordType>(oldTy))
@@ -1100,6 +1104,11 @@ static mlir::Attribute getNewInitValue(CIRGenModule &cgm, cir::GlobalOp newGlob,
                                        mlir::Attribute oldInit) {
   if (auto oldView = mlir::dyn_cast<cir::GlobalViewAttr>(oldInit))
     return createNewGlobalView(cgm, newGlob, oldView, oldTy);
+
+  // A byte offset from a symbol doesn't depend on the symbol's type, so it
+  // remains valid when the global is replaced.
+  if (mlir::isa<cir::GlobalOffsetAttr>(oldInit))
+    return oldInit;
 
   auto getNewInitElements =
       [&](mlir::ArrayAttr oldElements) -> mlir::ArrayAttr {

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -620,8 +620,8 @@ static LogicalResult checkConstantTypes(mlir::Operation *op, mlir::Type opType,
   if (mlir::isa<cir::BlockAddrDiffAttr, cir::BlockAddrInfoAttr,
                 cir::ConstArrayAttr, cir::ConstVectorAttr,
                 cir::ConstComplexAttr, cir::ConstRecordAttr,
-                cir::GlobalViewAttr, cir::PoisonAttr, cir::TypeInfoAttr,
-                cir::VTableAttr>(attrType))
+                cir::GlobalOffsetAttr, cir::GlobalViewAttr, cir::PoisonAttr,
+                cir::TypeInfoAttr, cir::VTableAttr>(attrType))
     return success();
 
   assert(isa<TypedAttr>(attrType) && "What else could we be looking at here?");

--- a/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
@@ -111,6 +111,9 @@ bool isCXXABIAttributeLegal(const mlir::TypeConverter &tc,
         return tc.isLegal(gva.getType()) &&
                isCXXABIAttributeLegal(tc, gva.getIndices());
       })
+      .Case<cir::GlobalOffsetAttr>([&tc](cir::GlobalOffsetAttr goa) {
+        return tc.isLegal(goa.getType());
+      })
       .Case<cir::VTableAttr>([&tc](cir::VTableAttr vta) {
         return tc.isLegal(vta.getType()) &&
                isCXXABIAttributeLegal(tc, vta.getData());
@@ -208,6 +211,10 @@ mlir::Attribute rewriteAttribute(const mlir::TypeConverter &tc,
             tc.convertType(gva.getType()), gva.getSymbol(),
             mlir::cast<mlir::ArrayAttr>(
                 rewriteAttribute(tc, ctx, gva.getIndices())));
+      })
+      .Case<cir::GlobalOffsetAttr>([&tc](cir::GlobalOffsetAttr goa) {
+        return cir::GlobalOffsetAttr::get(tc.convertType(goa.getType()),
+                                          goa.getSymbol(), goa.getOffset());
       })
       .Case<cir::VTableAttr>([&tc, ctx](cir::VTableAttr vta) {
         return cir::VTableAttr::get(
@@ -491,6 +498,10 @@ static mlir::TypedAttr lowerInitialValue(const LowerModule *lowerModule,
     if (auto gva = mlir::dyn_cast_if_present<cir::GlobalViewAttr>(initVal))
       return cir::GlobalViewAttr::get(convertedTy, gva.getSymbol(),
                                       gva.getIndices());
+
+    if (auto goa = mlir::dyn_cast_if_present<cir::GlobalOffsetAttr>(initVal))
+      return cir::GlobalOffsetAttr::get(convertedTy, goa.getSymbol(),
+                                        goa.getOffset());
 
     if (auto blockAddr =
             mlir::dyn_cast_if_present<cir::BlockAddrInfoAttr>(initVal)) {

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -386,6 +386,16 @@ public:
 #undef GET_CIR_ATTR_TO_VALUE_VISITOR_DECLS
 
 private:
+  struct LoweredGlobalSymbol {
+    mlir::Value addr;
+    mlir::Type sourceType;
+    unsigned addrSpace;
+  };
+
+  LoweredGlobalSymbol getAddressOfSymbol(mlir::FlatSymbolRefAttr symbol);
+  mlir::Value castGlobalAddrToType(mlir::Value addr, mlir::Type attrType,
+                                   mlir::Type sourceType, unsigned addrSpace);
+
   mlir::Operation *parentOp;
   mlir::ConversionPatternRewriter &rewriter;
   mlir::SymbolTableCollection &symbolTables;
@@ -861,26 +871,26 @@ mlir::Value CIRAttrToValue::visitCirAttr(cir::ConstVectorAttr attr) {
                                    mlirValues));
 }
 
-// GlobalViewAttr visitor.
-mlir::Value CIRAttrToValue::visitCirAttr(cir::GlobalViewAttr globalAttr) {
+// GlobalViewAttr / GlobalOffsetAttr visitors.
+CIRAttrToValue::LoweredGlobalSymbol
+CIRAttrToValue::getAddressOfSymbol(mlir::FlatSymbolRefAttr symbol) {
   auto moduleOp = parentOp->getParentOfType<mlir::ModuleOp>();
   mlir::DataLayout dataLayout(moduleOp);
   mlir::Type sourceType;
-  unsigned sourceAddrSpace = 0;
+  unsigned addrSpace = 0;
   llvm::StringRef symName;
-  mlir::Operation *sourceSymbol =
-      symbolTables.lookupSymbolIn(moduleOp, globalAttr.getSymbol());
+  mlir::Operation *sourceSymbol = symbolTables.lookupSymbolIn(moduleOp, symbol);
   if (auto llvmSymbol = dyn_cast<mlir::LLVM::GlobalOp>(sourceSymbol)) {
     sourceType = llvmSymbol.getType();
     symName = llvmSymbol.getSymName();
-    sourceAddrSpace = llvmSymbol.getAddrSpace();
+    addrSpace = llvmSymbol.getAddrSpace();
   } else if (auto cirSymbol = dyn_cast<cir::GlobalOp>(sourceSymbol)) {
     sourceType =
         convertTypeForMemory(*converter, dataLayout, cirSymbol.getSymType());
     symName = cirSymbol.getSymName();
     if (auto targetAS = mlir::dyn_cast_if_present<cir::TargetAddressSpaceAttr>(
             cirSymbol.getAddrSpaceAttr()))
-      sourceAddrSpace = targetAS.getValue();
+      addrSpace = targetAS.getValue();
   } else if (auto llvmFun = dyn_cast<mlir::LLVM::LLVMFuncOp>(sourceSymbol)) {
     sourceType = llvmFun.getFunctionType();
     symName = llvmFun.getSymName();
@@ -895,10 +905,63 @@ mlir::Value CIRAttrToValue::visitCirAttr(cir::GlobalViewAttr globalAttr) {
   }
 
   mlir::Location loc = parentOp->getLoc();
-  mlir::Value addrOp = mlir::LLVM::AddressOfOp::create(
+  mlir::Value addr = mlir::LLVM::AddressOfOp::create(
       rewriter, loc,
-      mlir::LLVM::LLVMPointerType::get(rewriter.getContext(), sourceAddrSpace),
+      mlir::LLVM::LLVMPointerType::get(rewriter.getContext(), addrSpace),
       symName);
+  return {addr, sourceType, addrSpace};
+}
+
+mlir::Value CIRAttrToValue::castGlobalAddrToType(mlir::Value addr,
+                                                 mlir::Type attrType,
+                                                 mlir::Type sourceType,
+                                                 unsigned addrSpace) {
+  mlir::Location loc = parentOp->getLoc();
+
+  // We can have a global view with an integer type in the case of method
+  // pointers. With the Itanium ABI, the #cir.method attribute is lowered to a
+  // #cir.global_view with a pointer-sized integer representing the address of
+  // the method.
+  if (mlir::isa<cir::IntType>(attrType)) {
+    mlir::Type llvmDstTy = converter->convertType(attrType);
+    return mlir::LLVM::PtrToIntOp::create(rewriter, loc, llvmDstTy, addr);
+  }
+
+  if (auto ptrTy = mlir::dyn_cast<cir::PointerType>(attrType)) {
+    auto llvmDstTy = converter->convertType<mlir::LLVM::LLVMPointerType>(ptrTy);
+
+    if (llvmDstTy.getAddressSpace() != addrSpace)
+      addr =
+          mlir::LLVM::AddrSpaceCastOp::create(rewriter, loc, llvmDstTy, addr);
+
+    auto moduleOp = parentOp->getParentOfType<mlir::ModuleOp>();
+    mlir::DataLayout dataLayout(moduleOp);
+    mlir::Type llvmEltTy =
+        convertTypeForMemory(*converter, dataLayout, ptrTy.getPointee());
+
+    // No further cast needed if the pointee type already matches.
+    if (llvmEltTy == sourceType)
+      return addr;
+
+    // With opaque pointers, the pointer type is already correct (either from
+    // the original AddressOfOp or after an addrspacecast) — skip the
+    // redundant bitcast.
+    if (addr.getType() == llvmDstTy)
+      return addr;
+
+    return mlir::LLVM::BitcastOp::create(rewriter, loc, llvmDstTy, addr);
+  }
+
+  if (mlir::isa<cir::VPtrType>(attrType))
+    return addr;
+
+  llvm_unreachable("Expecting pointer or integer type");
+}
+
+mlir::Value CIRAttrToValue::visitCirAttr(cir::GlobalViewAttr globalAttr) {
+  LoweredGlobalSymbol lowered = getAddressOfSymbol(globalAttr.getSymbol());
+  mlir::Value addrOp = lowered.addr;
+  mlir::Type sourceType = lowered.sourceType;
 
   if (globalAttr.getIndices()) {
     llvm::SmallVector<mlir::LLVM::GEPArg> indices;
@@ -913,50 +976,31 @@ mlir::Value CIRAttrToValue::visitCirAttr(cir::GlobalViewAttr globalAttr) {
     }
     mlir::Type resTy = addrOp.getType();
     mlir::Type eltTy = converter->convertType(sourceType);
-    addrOp =
-        mlir::LLVM::GEPOp::create(rewriter, loc, resTy, eltTy, addrOp, indices,
-                                  mlir::LLVM::GEPNoWrapFlags::none);
+    addrOp = mlir::LLVM::GEPOp::create(rewriter, parentOp->getLoc(), resTy,
+                                       eltTy, addrOp, indices,
+                                       mlir::LLVM::GEPNoWrapFlags::none);
   }
 
-  // We can have a global view with an integer type in the case of method
-  // pointers. With the Itanium ABI, the #cir.method attribute is lowered to a
-  // #cir.global_view with a pointer-sized integer representing the address of
-  // the method.
-  if (auto intTy = mlir::dyn_cast<cir::IntType>(globalAttr.getType())) {
-    mlir::Type llvmDstTy = converter->convertType(globalAttr.getType());
-    return mlir::LLVM::PtrToIntOp::create(rewriter, parentOp->getLoc(),
-                                          llvmDstTy, addrOp);
-  }
+  return castGlobalAddrToType(addrOp, globalAttr.getType(), sourceType,
+                              lowered.addrSpace);
+}
 
-  if (auto ptrTy = mlir::dyn_cast<cir::PointerType>(globalAttr.getType())) {
-    auto llvmDstTy = converter->convertType<mlir::LLVM::LLVMPointerType>(ptrTy);
-    unsigned dstAddrSpace = llvmDstTy.getAddressSpace();
+mlir::Value CIRAttrToValue::visitCirAttr(cir::GlobalOffsetAttr globalAttr) {
+  LoweredGlobalSymbol lowered = getAddressOfSymbol(globalAttr.getSymbol());
+  mlir::Value addrOp = lowered.addr;
+  mlir::Location loc = parentOp->getLoc();
 
-    if (sourceAddrSpace != dstAddrSpace)
-      addrOp = mlir::LLVM::AddrSpaceCastOp::create(rewriter, parentOp->getLoc(),
-                                                   llvmDstTy, addrOp);
+  // A displacement in bytes is a GEP through i8, which is what classic
+  // codegen emits for the offset of any constant lvalue.
+  mlir::Value offset = mlir::LLVM::ConstantOp::create(
+      rewriter, loc, rewriter.getI64Type(),
+      rewriter.getI64IntegerAttr(globalAttr.getOffset()));
+  addrOp = mlir::LLVM::GEPOp::create(
+      rewriter, loc, addrOp.getType(), rewriter.getI8Type(), addrOp,
+      mlir::ValueRange{offset}, mlir::LLVM::GEPNoWrapFlags::none);
 
-    mlir::Type llvmEltTy =
-        convertTypeForMemory(*converter, dataLayout, ptrTy.getPointee());
-
-    // No further cast needed if the pointee type already matches.
-    if (llvmEltTy == sourceType)
-      return addrOp;
-
-    // With opaque pointers, the pointer type is already correct (either from
-    // the original AddressOfOp or after an addrspacecast) — skip the
-    // redundant bitcast.
-    if (addrOp.getType() == llvmDstTy)
-      return addrOp;
-
-    return mlir::LLVM::BitcastOp::create(rewriter, parentOp->getLoc(),
-                                         llvmDstTy, addrOp);
-  }
-
-  if (mlir::isa<cir::VPtrType>(globalAttr.getType()))
-    return addrOp;
-
-  llvm_unreachable("Expecting pointer or integer type for GlobalViewAttr");
+  return castGlobalAddrToType(addrOp, globalAttr.getType(), lowered.sourceType,
+                              lowered.addrSpace);
 }
 
 // TypeInfoAttr visitor.
@@ -2460,10 +2504,10 @@ mlir::LogicalResult CIRToLLVMConstantOpLowering::matchAndRewrite(
         return mlir::success();
       }
     }
-    // Lower GlobalViewAttr to llvm.mlir.addressof
-    if (auto gv = mlir::dyn_cast<cir::GlobalViewAttr>(op.getValue())) {
-      auto newOp = lowerCirAttrAsValue(op, gv, rewriter, symbolTables,
-                                       getTypeConverter());
+    // Lower GlobalViewAttr and GlobalOffsetAttr to llvm.mlir.addressof
+    if (mlir::isa<cir::GlobalViewAttr, cir::GlobalOffsetAttr>(op.getValue())) {
+      auto newOp = lowerCirAttrAsValue(op, op.getValue(), rewriter,
+                                       symbolTables, getTypeConverter());
       rewriter.replaceOp(op, newOp);
       return mlir::success();
     }
@@ -2924,12 +2968,11 @@ CIRToLLVMGlobalOpLowering::matchAndRewriteRegionInitializedGlobal(
     cir::GlobalOp op, mlir::Attribute init,
     mlir::ConversionPatternRewriter &rewriter) const {
   // TODO: Generalize this handling when more types are needed here.
-  assert(
-      (isa<cir::BlockAddrDiffAttr, cir::BlockAddrInfoAttr, cir::ConstArrayAttr,
-           cir::ConstRecordAttr, cir::ConstVectorAttr, cir::ConstPtrAttr,
-           cir::ConstComplexAttr, cir::GlobalViewAttr, cir::TypeInfoAttr,
-           cir::UndefAttr, cir::PoisonAttr, cir::VTableAttr, cir::ZeroAttr>(
-          init)));
+  assert((isa<cir::BlockAddrDiffAttr, cir::BlockAddrInfoAttr,
+              cir::ConstArrayAttr, cir::ConstRecordAttr, cir::ConstVectorAttr,
+              cir::ConstPtrAttr, cir::ConstComplexAttr, cir::GlobalOffsetAttr,
+              cir::GlobalViewAttr, cir::TypeInfoAttr, cir::UndefAttr,
+              cir::PoisonAttr, cir::VTableAttr, cir::ZeroAttr>(init)));
 
   // TODO(cir): once LLVM's dialect has proper equivalent attributes this
   // should be updated. For now, we use a custom op to initialize globals
@@ -3061,9 +3104,9 @@ mlir::LogicalResult CIRToLLVMGlobalOpLowering::matchAndRewrite(
     } else if (mlir::isa<cir::BlockAddrDiffAttr, cir::BlockAddrInfoAttr,
                          cir::ConstVectorAttr, cir::ConstRecordAttr,
                          cir::ConstPtrAttr, cir::ConstComplexAttr,
-                         cir::GlobalViewAttr, cir::TypeInfoAttr, cir::UndefAttr,
-                         cir::PoisonAttr, cir::VTableAttr, cir::ZeroAttr>(
-                   init.value())) {
+                         cir::GlobalOffsetAttr, cir::GlobalViewAttr,
+                         cir::TypeInfoAttr, cir::UndefAttr, cir::PoisonAttr,
+                         cir::VTableAttr, cir::ZeroAttr>(init.value())) {
       // TODO(cir): once LLVM's dialect has proper equivalent attributes this
       // should be updated. For now, we use a custom op to initialize globals
       // to the appropriate value.

--- a/clang/test/CIR/CodeGen/global-ptr-flat-offset.c
+++ b/clang/test/CIR/CodeGen/global-ptr-flat-offset.c
@@ -1,0 +1,31 @@
+// RUN: %clang_cc1 -triple=x86_64-linux-gnu -fclangir -emit-cir -o %t.cir %s
+// RUN: FileCheck -check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple=x86_64-linux-gnu -fclangir -emit-llvm -o %t-cir.ll %s
+// RUN: FileCheck -check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple=x86_64-linux-gnu -emit-llvm -o %t.ll %s
+// RUN: FileCheck -check-prefix=LLVM --input-file=%t.ll %s
+
+struct S {
+  int x;
+  int y;
+};
+
+struct S gS;
+
+struct S *past_end = &gS + 1;
+
+struct S *before = &gS - 1;
+
+char *interior = (char *)&gS + 3;
+
+int *member = &gS.y;
+
+// CIR-DAG: cir.global external @past_end = #cir.global_offset<@gS, 8> : !cir.ptr<!rec_S>
+// CIR-DAG: cir.global external @before = #cir.global_offset<@gS, -8> : !cir.ptr<!rec_S>
+// CIR-DAG: cir.global external @interior = #cir.global_offset<@gS, 3> : !cir.ptr<!s8i>
+// CIR-DAG: cir.global external @member = #cir.global_view<@gS, [1 : i32]> : !cir.ptr<!s32i>
+
+// LLVM-DAG: @past_end = global ptr getelementptr {{.*}}(i8, ptr @gS, i64 8)
+// LLVM-DAG: @before = global ptr getelementptr {{.*}}(i8, ptr @gS, i64 -8)
+// LLVM-DAG: @interior = global ptr getelementptr {{.*}}(i8, ptr @gS, i64 3)
+// LLVM-DAG: @member = global ptr getelementptr {{.*}}(i8, ptr @gS, i64 4)

--- a/clang/test/CIR/CodeGen/local-ptr-flat-offset.cpp
+++ b/clang/test/CIR/CodeGen/local-ptr-flat-offset.cpp
@@ -1,0 +1,37 @@
+// RUN: %clang_cc1 -triple=x86_64-linux-gnu -fclangir -emit-cir -o %t.cir %s
+// RUN: FileCheck -check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple=x86_64-linux-gnu -fclangir -emit-llvm -o %t-cir.ll %s
+// RUN: FileCheck -check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple=x86_64-linux-gnu -emit-llvm -o %t.ll %s
+// RUN: FileCheck -check-prefix=LLVM --input-file=%t.ll %s
+
+template <class Iter> struct reverse_iterator {
+  Iter t;
+};
+
+struct S {
+  int x;
+};
+
+S gS;
+
+void use(reverse_iterator<S *> &);
+
+void test() {
+  reverse_iterator<S *> it{&gS + 1};
+  use(it);
+}
+
+// CIR: cir.global "private" constant cir_private @__const._Z4testv.it =
+// CIR-SAME: #cir.const_record<{#cir.global_offset<@gS, 4> : !cir.ptr<!rec_S>}>
+
+// CIR-LABEL: cir.func {{.*}} @_Z4testv()
+// CIR:         %[[IT:.*]] = cir.alloca "it" {{.*}} !cir.ptr<!rec_reverse_iterator{{.*}}>
+// CIR:         %[[CONST:.*]] = cir.get_global @__const._Z4testv.it
+// CIR:         cir.copy %[[CONST]] to %[[IT]]
+
+// LLVM: @__const._Z4testv.it = {{.*}}constant {{.*}}{ ptr getelementptr {{.*}}(i8, ptr @gS, i64 4) }
+
+// LLVM-LABEL: define {{.*}} @_Z4testv()
+// LLVM:         %[[IT:.*]] = alloca %{{.*}}reverse_iterator
+// LLVM:         call void @llvm.memcpy{{.*}}(ptr {{.*}}%[[IT]], ptr {{.*}}@__const._Z4testv.it

--- a/clang/test/CIR/IR/global.cir
+++ b/clang/test/CIR/IR/global.cir
@@ -53,6 +53,9 @@ module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
   cir.global external tls_model = <tls_local_dyn> @tls2 = #cir.int<0> : !s8i
   cir.global external tls_model = <tls_init_exec> @tls3 = #cir.int<0> : !s8i
   cir.global external tls_model = <tls_local_exec> @tls4 = #cir.int<0> : !s8i
+  cir.global external @gi = #cir.int<0> : !s32i
+  cir.global external @gi_past_end = #cir.global_offset<@gi, 4> : !cir.ptr<!s32i>
+  cir.global external @gi_before = #cir.global_offset<@gi, -4> : !cir.ptr<!s32i>
 }
 
 // CHECK: cir.global external @c = #cir.int<0> : !s8i
@@ -95,3 +98,6 @@ module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
 // CHECK: cir.global external tls_model = <tls_local_dyn> @tls2 = #cir.int<0> : !s8i
 // CHECK: cir.global external tls_model = <tls_init_exec> @tls3 = #cir.int<0> : !s8i
 // CHECK: cir.global external tls_model = <tls_local_exec> @tls4 = #cir.int<0> : !s8i
+// CHECK: cir.global external @gi = #cir.int<0> : !s32i
+// CHECK: cir.global external @gi_past_end = #cir.global_offset<@gi, 4> : !cir.ptr<!s32i>
+// CHECK: cir.global external @gi_before = #cir.global_offset<@gi, -4> : !cir.ptr<!s32i>


### PR DESCRIPTION
Previously, if we attempted to compile code that used an offset from a global variable that created a pointer to outside the global or to a location that wasn't the exact start of an element of a global structure, CIR codegen would either assert or hit an unreachable statement. However, there are legal cases where such an offset can be used.

This change introduces a new attribute, GlobalOffsetAttr, that provides a way to describe a raw byte offset from a pointer and uses that attribute to handle cases where we are unable to compute indices for a global view attribute.

Assisted-by: Cursor / various models