### PR TITLE
[Support] Implement getMainExecutable for OpenBSD with getexecpath()

### DIFF
--- a/llvm/lib/Support/CMakeLists.txt
+++ b/llvm/lib/Support/CMakeLists.txt
@@ -1,3 +1,4 @@
+include(CheckFunctionExists)
 include(GetLibraryName)
 
 # Ensure that libSupport does not carry any static global initializer.
@@ -67,6 +68,12 @@ elseif( CMAKE_HOST_UNIX )
   endif()
   if( UNIX AND "${CMAKE_SYSTEM_NAME}" MATCHES "SunOS" )
     set(system_libs ${system_libs} kstat socket)
+  endif()
+  if( UNIX AND "${CMAKE_SYSTEM_NAME}" MATCHES "OpenBSD" )
+    check_function_exists(getexecpath HAVE_GETEXECPATH)
+    if (HAVE_GETEXECPATH)
+      add_compile_definitions(HAVE_GETEXECPATH)
+    endif()
   endif()
   if( FUCHSIA )
     set(system_libs ${system_libs} zircon)

--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -125,7 +125,8 @@ namespace fs {
 
 const file_t kInvalidFile = -1;
 
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) ||     \
+#if defined(__FreeBSD__) || defined(__NetBSD__) ||                             \
+    (defined(__OpenBSD__) && !defined(HAVE_GETEXECPATH)) ||                    \
     defined(__FreeBSD_kernel__) || defined(__linux__) ||                       \
     defined(__CYGWIN__) || defined(__DragonFly__) || defined(_AIX) ||          \
     defined(__GNU__) ||                                                        \
@@ -287,7 +288,16 @@ std::string getMainExecutable(const char *argv0, void *MainAddr) {
   // Fall back to the classical detection.
   if (getprogpath(exe_path, argv0))
     return exe_path;
-#elif defined(__OpenBSD__) || defined(__HAIKU__)
+#elif defined(__OpenBSD__)
+  char exe_path[PATH_MAX];
+#ifdef HAVE_GETEXECPATH
+  if (getexecpath(exe_path, sizeof(exe_path)) == 0)
+    return exe_path;
+#else
+  if (getprogpath(exe_path, argv0) != NULL)
+    return exe_path;
+#endif
+#elif defined(__HAIKU__)
   char exe_path[PATH_MAX];
   // argv[0] only
   if (getprogpath(exe_path, argv0) != NULL)


### PR DESCRIPTION
OpenBSD now has a proper function to retrieve the executable and path.