### PR TITLE
[NFC][DirectX] Fix memory leaks exposed by ASAN

### DIFF
--- a/llvm/lib/Target/DirectX/DXILCBufferAccess.cpp
+++ b/llvm/lib/Target/DirectX/DXILCBufferAccess.cpp
@@ -41,7 +41,7 @@ static void replaceUsersOfGlobal(GlobalVariable *Global,
     U.set(Ptr);
   }
 
-  Global->removeFromParent();
+  Global->eraseFromParent();
 }
 
 static bool replaceCBufferAccesses(Module &M) {

--- a/llvm/lib/Target/DirectX/DXILOpLowering.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpLowering.cpp
@@ -274,7 +274,7 @@ public:
     CI->eraseFromParent();
 
     if (NameGlobal && NameGlobal->use_empty())
-      NameGlobal->removeFromParent();
+      NameGlobal->eraseFromParent();
   }
 
   bool hasNonUniformIndex(Value *IndexOp) {

--- a/llvm/lib/Target/DirectX/DirectXTargetMachine.cpp
+++ b/llvm/lib/Target/DirectX/DirectXTargetMachine.cpp
@@ -175,6 +175,12 @@ bool DirectXTargetMachine::addPassesToEmitFile(
     CodeGenFileType FileType, bool DisableVerify,
     MachineModuleInfoWrapperPass *MMIWP) {
   TargetPassConfig *PassConfig = createPassConfig(PM);
+  PM.add(PassConfig);
+
+  if (!MMIWP)
+    MMIWP = new MachineModuleInfoWrapperPass(this);
+  PM.add(MMIWP);
+
   PM.add(createTargetTransformInfoWrapperPass(getTargetIRAnalysis()));
   PassConfig->addCodeGenPrepare();
 
@@ -190,9 +196,6 @@ bool DirectXTargetMachine::addPassesToEmitFile(
       PM.add(createDXContainerGlobalsPass());
       PM.add(createDXContainerPDBPass());
 
-      if (!MMIWP)
-        MMIWP = new MachineModuleInfoWrapperPass(this);
-      PM.add(MMIWP);
       if (addAsmPrinter(PM, Out, DwoOut, FileType,
                         MMIWP->getMMI().getContext()))
         return true;

--- a/llvm/test/CodeGen/DirectX/llc-pipeline.ll
+++ b/llvm/test/CodeGen/DirectX/llc-pipeline.ll
@@ -9,10 +9,11 @@
 ; CHECK-LABEL: Pass Arguments:
 ; CHECK-NEXT: Target Library Information
 ; CHECK-NEXT: Runtime Library Function Analysis
+; CHECK-NEXT: Target Pass Configuration
+; CHECK-NEXT: Machine Module Information
 ; CHECK-NEXT: Target Transform Information
 ; CHECK-NEXT: DXIL Resource Type Analysis
 ; CHECK-O1-NEXT: Assumption Cache Tracker
-; CHECK-OBJ-NEXT: Machine Module Information
 ; CHECK-OBJ-NEXT: Machine Branch Probability Analysis
 ; CHECK-OBJ-NEXT: Create Garbage Collector Module Metadata
 


### PR DESCRIPTION
This PR should fix ASAN errors from https://lab.llvm.org/buildbot/#/builders/52/builds/19811

There are three sources of leaks:

1. TargetPassConfig not being `PM.add()`ed
```
   Direct leak of 136 byte(s) in 1 object(s) allocated from:
     #1 ...createPassConfig(...)      DirectXTargetMachine.cpp:216:10   <- return new DirectXPassConfig(*this, PM);
     #2 ...addPassesToEmitFile(...)   DirectXTargetMachine.cpp:177:34   <- TargetPassConfig *PassConfig = createPassConfig(PM);
   Indirect leak of 144 byte(s) in 1 object(s) allocated from:
     #1 llvm::TargetPassConfig::TargetPassConfig(...)  TargetPassConfig.cpp:604:10  <- Impl = new PassConfigImpl();
     #2 DirectXPassConfig                              DirectXTargetMachine.cpp:112:9
 ```
 
2. MachineModuleInfoWrapperPass not being `PM.add()`ed
```
   Direct leak of 2624 byte(s) in 1 object(s) allocated from:
     #1 compileModule(...)  llc.cpp:786:9    <- new MachineModuleInfoWrapperPass(Target.get());
     ...passed in at llc.cpp:842:19, then dropped unless the obj+complete-pipeline branch ran
 ```
 
 3.  Orphaned GlobalVariables that were detached from the module but got never deleted:
 - llvm/lib/Target/DirectX/DXILCBufferAccess.cpp:44:  `Global->removeFromParent()`;
 - llvm/lib/Target/DirectX/DXILOpLowering.cpp:277: `NameGlobal->removeFromParent()`;
 
```
   opt -S -dxil-cbuffer-access ... CBufferAccess/scalars.ll
     definitely lost: 57 bytes in 3 blocks      (3 name entries)
     indirectly lost: 384 bytes in 3 blocks     (3 × 128-byte GlobalVariable)
```