### PR TITLE
Revert "[Bazel] Fixes 16a770d (#220089)"

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -601,13 +601,6 @@ cc_library(
 )
 
 cc_library(
-    name = "scalar_headers",
-    hdrs = glob(["include/llvm/Transforms/Scalar/*.h"]),
-    copts = llvm_copts,
-    features = ["-parse_headers"],
-)
-
-cc_library(
     name = "BinaryFormatELF",
     srcs = [
         "include/llvm/TargetParser/Triple.h",
@@ -1793,7 +1786,6 @@ cc_library(
         ":Target",
         ":TargetParser",
         ":config",
-        ":scalar_headers",
     ],
 )
 


### PR DESCRIPTION
This reverts commit ea44cd8c500d1b0302df6673ef42652847e47cd9.

The underlying layering violation that necessitated the original commit has been fixed.