### PR TITLE
[lld][MachO] Ignore relocated bytes when folding LSDAs

### DIFF
--- a/lld/MachO/ICF.cpp
+++ b/lld/MachO/ICF.cpp
@@ -91,9 +91,10 @@ ICF::ICF(std::vector<ConcatInputSection *> &inputs) {
 // FIXME(gkm): implement keep-unique attributes
 // FIXME(gkm): implement address-significance tables for MachO object files
 
-static bool isFoldableWithAddendsRemoved(const ConcatInputSection *isec) {
+static bool isFoldableIgnoringRelocatedBytes(const ConcatInputSection *isec) {
   return isCfStringSection(isec) || isClassRefsSection(isec) ||
-         isSelRefsSection(isec) || isEhFrameSection(isec);
+         isSelRefsSection(isec) || isEhFrameSection(isec) ||
+         isGccExceptTabSection(isec);
 }
 
 // Make a normalized copy of a section's bytes by zeroing out the embedded
@@ -117,9 +118,9 @@ static bool compareData(const ConcatInputSection *ia,
     return false;
   if (ia->data == ib->data)
     return true;
-  if (!isFoldableWithAddendsRemoved(ia))
+  if (!isFoldableIgnoringRelocatedBytes(ia))
     return false;
-  assert(isFoldableWithAddendsRemoved(ib));
+  assert(isFoldableIgnoringRelocatedBytes(ib));
 
   SmallVector<uint8_t, 64> bufA, bufB;
   getNormalizedData(ia, bufA);
@@ -629,9 +630,6 @@ void macho::foldIdenticalSections(bool onlyCfStrings) {
     //     safe_thunks logic is applied later at merge time based on the
     //     keepUnique flag.
     //   - Otherwise, keepUnique sections are not foldable.
-    // Happens to match isFoldableWithAddendsRemoved today, but expresses a
-    // different intent (ld64's coalescing semantics, not addend stripping),
-    // so the two may diverge as either list grows.
     bool isSafeThunksCode =
         config->icfLevel == ICFLevel::safe_thunks && isCodeSec;
     bool keepUniqueAllowsFolding =
@@ -639,8 +637,7 @@ void macho::foldIdenticalSections(bool onlyCfStrings) {
 
     // FIXME: consider non-code __text sections as foldable?
     bool isFoldable = (!onlyCfStrings || isCfStringSection(isec)) &&
-                      (isCodeSec || isFoldableWithAddendsRemoved(isec) ||
-                       isGccExceptTabSection(isec)) &&
+                      (isCodeSec || isFoldableIgnoringRelocatedBytes(isec)) &&
                       keepUniqueAllowsFolding && !isec->hasAltEntry &&
                       !isec->shouldOmitFromOutput() && hasFoldableFlags;
     if (isFoldable) {
@@ -666,7 +663,7 @@ void macho::foldIdenticalSections(bool onlyCfStrings) {
   parallelForEach(foldable, [](ConcatInputSection *isec) {
     assert(isec->icfEqClass[0] == 0); // don't overwrite a unique ID!
     uint64_t hash;
-    if (isFoldableWithAddendsRemoved(isec)) {
+    if (isFoldableIgnoringRelocatedBytes(isec)) {
       SmallVector<uint8_t, 64> stackBuf;
       getNormalizedData(isec, stackBuf);
       hash = xxh3_64bits(stackBuf);

--- a/lld/MachO/UnwindInfoSection.cpp
+++ b/lld/MachO/UnwindInfoSection.cpp
@@ -213,6 +213,9 @@ void UnwindInfoSectionImpl::prepare() {
         // to avoid overflowing the 3-personality limit.
         FDE &fde = cast<ObjFile>(d->getFile())->fdes[d->unwindEntry()];
         fde.personality = canonicalizePersonality(fde.personality);
+        // If ICF folded the LSDA, point at the surviving copy.
+        if (fde.lsda)
+          fde.lsda = fde.lsda->canonical();
       }
     }
 }

--- a/lld/test/MachO/icf-lsda-reloc.s
+++ b/lld/test/MachO/icf-lsda-reloc.s
@@ -1,0 +1,302 @@
+# REQUIRES: aarch64
+
+# RUN: llvm-mc -filetype=obj -triple=arm64-apple-macos11 %s -o %t.o
+# RUN: llvm-objdump --macho --reloc --section=__gcc_except_tab %t.o | \
+# RUN:   FileCheck %s --check-prefix=INPUT
+# RUN: %lld -dylib -arch arm64 -platform_version macos 11.0 11.0 \
+# RUN:   -undefined dynamic_lookup --icf=all %t.o -o %t
+# RUN: llvm-objdump --macho --syms --unwind-info --dwarf=frames %t | \
+# RUN:   FileCheck %s
+
+## Modelled on a real-world ObjC object containing identical methods that
+## @catch NSException were not folded because their exception tables were not:
+## the tables reference _OBJC_EHTYPE_$_NSException through PC-relative
+## pointer-to-GOT relocations, so their raw bytes differ by the position of the
+## relocation site. ICF must normalize the relocated bytes to fold the tables,
+## after which the methods fold as well.
+##
+## _f0 and _f1 model those methods: identical bodies, compact unwind, and
+## identical exception tables at different offsets. Both the tables and the
+## functions must fold.
+##
+## _g0 and _g1 use an outlined prologue; the resulting CFI cannot be expressed
+## as compact unwind, so they are unwound via DWARF FDEs. They share an
+## exception table but deliberately have different bodies, so only the table is
+## folded; _g1's FDE and its __unwind_info LSDA entry must then point at the
+## surviving table, not at the folded one. DWARF unwinding is required to
+## exercise this: the LSDA of a compact unwind entry is a relocation that gets
+## canonicalized after ICF, whereas the LSDA of an FDE is resolved to an input
+## section when the FDE is parsed and needs to be canonicalized separately.
+
+## Sanity-check the input: each TType entry is a PC-relative pointer-to-GOT
+## relocation, so the raw bytes of the four tables differ and they can only be
+## folded after normalization. Without this the fold checks below could pass
+## vacuously.
+# INPUT:         Relocation information (__TEXT,__gcc_except_tab) 4 entries
+# INPUT-COUNT-4: PTRTGOT False     _OBJC_EHTYPE_$_NSException
+
+# CHECK-LABEL: SYMBOL TABLE:
+# CHECK: [[#%x,LSDA0:]] l   O __TEXT,__gcc_except_tab GCC_except_table0
+# CHECK: [[#LSDA0]]     l   O __TEXT,__gcc_except_tab GCC_except_table1
+# CHECK: [[#%x,LSDA2:]] l   O __TEXT,__gcc_except_tab GCC_except_table2
+# CHECK: [[#LSDA2]]     l   O __TEXT,__gcc_except_tab GCC_except_table3
+# CHECK: [[#%x,F0:]]    g   F __TEXT,__text _f0
+# CHECK: [[#F0]]        g   F __TEXT,__text _f1
+# CHECK: [[#%x,G0:]]    g   F __TEXT,__text _g0
+# CHECK: [[#%x,G1:]]    g   F __TEXT,__text _g1
+
+# CHECK-LABEL: Contents of __unwind_info section:
+# CHECK:      LSDA descriptors:
+# CHECK-NEXT:   [0]: function offset=0x[[#%.8x,F0]], LSDA offset=0x[[#%.8x,LSDA0]]
+# CHECK-NEXT:   [1]: function offset=0x[[#%.8x,G0]], LSDA offset=0x[[#%.8x,LSDA2]]
+# CHECK-NEXT:   [2]: function offset=0x[[#%.8x,G1]], LSDA offset=0x[[#%.8x,LSDA2]]
+# CHECK:      Second level indices:
+# CHECK:        function offset=0x[[#%.8x,F0]], encoding[{{[0-9]+}}]=0x54000000
+# CHECK-NEXT:   function offset=0x[[#%.8x,G0]], encoding[{{[0-9]+}}]=0x03{{[0-9a-f]+}}
+# CHECK-NEXT:   function offset=0x[[#%.8x,G1]], encoding[{{[0-9]+}}]=0x03{{[0-9a-f]+}}
+
+# CHECK-LABEL: .eh_frame contents:
+# CHECK: FDE cie={{.+}} pc=[[#%.8x,G0]]...{{.+}}
+# CHECK: LSDA Address: [[#%.16x,LSDA2]]
+# CHECK: FDE cie={{.+}} pc=[[#%.8x,G1]]...{{.+}}
+# CHECK: LSDA Address: [[#%.16x,LSDA2]]
+
+.section __TEXT,__text,regular,pure_instructions
+.globl _f0, _f1, _g0, _g1
+.p2align 2
+
+_f0:
+Lfunc_begin0:
+  .cfi_startproc
+  .cfi_personality 155, ___objc_personality_v0
+  .cfi_lsda 16, Lexception0
+  stp x29, x30, [sp, #-16]!
+  mov x29, sp
+  .cfi_def_cfa w29, 16
+  .cfi_offset w30, -8
+  .cfi_offset w29, -16
+Ltmp0:
+  bl _callee0
+Ltmp1:
+  ldp x29, x30, [sp], #16
+  ret
+Ltmp2:
+  bl _objc_begin_catch
+  bl _objc_end_catch
+  ldp x29, x30, [sp], #16
+  ret
+Lfunc_end0:
+  .cfi_endproc
+
+_f1:
+Lfunc_begin1:
+  .cfi_startproc
+  .cfi_personality 155, ___objc_personality_v0
+  .cfi_lsda 16, Lexception1
+  stp x29, x30, [sp, #-16]!
+  mov x29, sp
+  .cfi_def_cfa w29, 16
+  .cfi_offset w30, -8
+  .cfi_offset w29, -16
+Ltmp3:
+  bl _callee0
+Ltmp4:
+  ldp x29, x30, [sp], #16
+  ret
+Ltmp5:
+  bl _objc_begin_catch
+  bl _objc_end_catch
+  ldp x29, x30, [sp], #16
+  ret
+Lfunc_end1:
+  .cfi_endproc
+
+_g0:
+Lfunc_begin2:
+  .cfi_startproc
+  .cfi_personality 155, ___objc_personality_v0
+  .cfi_lsda 16, Lexception2
+  stp x29, x30, [sp, #-16]!
+  bl _OUTLINED_FUNCTION_PROLOG_FRAME32_x30x29x19x20x21x22
+  .cfi_offset w30, -8
+  .cfi_offset w29, -16
+  .cfi_offset w19, -24
+  .cfi_offset w20, -32
+  .cfi_offset w21, -40
+  .cfi_offset w22, -48
+  .cfi_def_cfa w29, 16
+Ltmp6:
+  bl _callee1
+Ltmp7:
+  ldp x29, x30, [sp, #32]
+  ldp x20, x19, [sp, #16]
+  ldp x22, x21, [sp], #48
+  ret
+Ltmp8:
+  bl _objc_begin_catch
+  bl _objc_end_catch
+  ldp x29, x30, [sp, #32]
+  ldp x20, x19, [sp, #16]
+  ldp x22, x21, [sp], #48
+  ret
+Lfunc_end2:
+  .cfi_endproc
+
+_g1:
+Lfunc_begin3:
+  .cfi_startproc
+  .cfi_personality 155, ___objc_personality_v0
+  .cfi_lsda 16, Lexception3
+  stp x29, x30, [sp, #-16]!
+  bl _OUTLINED_FUNCTION_PROLOG_FRAME32_x30x29x19x20x21x22
+  .cfi_offset w30, -8
+  .cfi_offset w29, -16
+  .cfi_offset w19, -24
+  .cfi_offset w20, -32
+  .cfi_offset w21, -40
+  .cfi_offset w22, -48
+  .cfi_def_cfa w29, 16
+Ltmp9:
+  bl _callee2
+Ltmp10:
+  ldp x29, x30, [sp, #32]
+  ldp x20, x19, [sp, #16]
+  ldp x22, x21, [sp], #48
+  ret
+Ltmp11:
+  bl _objc_begin_catch
+  bl _objc_end_catch
+  ldp x29, x30, [sp, #32]
+  ldp x20, x19, [sp, #16]
+  ldp x22, x21, [sp], #48
+  ret
+Lfunc_end3:
+  .cfi_endproc
+
+.section __TEXT,__gcc_except_tab
+.p2align 2
+GCC_except_table0:
+Lexception0:
+  .byte 255                             ; @LPStart Encoding = omit
+  .byte 155                             ; @TType Encoding = indirect pcrel sdata4
+  .uleb128 Lttbase0-Lttbaseref0
+Lttbaseref0:
+  .byte 1                               ; Call site Encoding = uleb128
+  .uleb128 Lcst_end0-Lcst_begin0
+Lcst_begin0:
+  .uleb128 Lfunc_begin0-Lfunc_begin0    ; >> Call Site 1 <<
+  .uleb128 Ltmp0-Lfunc_begin0           ;   Call between Lfunc_begin0 and Ltmp0
+  .byte 0                               ;     has no landing pad
+  .byte 0                               ;   On action: cleanup
+  .uleb128 Ltmp0-Lfunc_begin0           ; >> Call Site 2 <<
+  .uleb128 Ltmp1-Ltmp0                  ;   Call between Ltmp0 and Ltmp1
+  .uleb128 Ltmp2-Lfunc_begin0           ;     jumps to Ltmp2
+  .byte 1                               ;   On action: 1
+  .uleb128 Ltmp1-Lfunc_begin0           ; >> Call Site 3 <<
+  .uleb128 Lfunc_end0-Ltmp1             ;   Call between Ltmp1 and Lfunc_end0
+  .byte 0                               ;     has no landing pad
+  .byte 0                               ;   On action: cleanup
+Lcst_end0:
+  .byte 1                               ; >> Action Record 1 <<
+                                        ;   Catch TypeInfo 1
+  .byte 0                               ;   No further actions
+  .p2align 2
+                                        ; >> Catch TypeInfos <<
+  .long _OBJC_EHTYPE_$_NSException@GOT-. ; TypeInfo 1
+Lttbase0:
+  .p2align 2
+
+GCC_except_table1:
+Lexception1:
+  .byte 255                             ; @LPStart Encoding = omit
+  .byte 155                             ; @TType Encoding = indirect pcrel sdata4
+  .uleb128 Lttbase1-Lttbaseref1
+Lttbaseref1:
+  .byte 1                               ; Call site Encoding = uleb128
+  .uleb128 Lcst_end1-Lcst_begin1
+Lcst_begin1:
+  .uleb128 Lfunc_begin1-Lfunc_begin1    ; >> Call Site 1 <<
+  .uleb128 Ltmp3-Lfunc_begin1           ;   Call between Lfunc_begin1 and Ltmp3
+  .byte 0                               ;     has no landing pad
+  .byte 0                               ;   On action: cleanup
+  .uleb128 Ltmp3-Lfunc_begin1           ; >> Call Site 2 <<
+  .uleb128 Ltmp4-Ltmp3                  ;   Call between Ltmp3 and Ltmp4
+  .uleb128 Ltmp5-Lfunc_begin1           ;     jumps to Ltmp5
+  .byte 1                               ;   On action: 1
+  .uleb128 Ltmp4-Lfunc_begin1           ; >> Call Site 3 <<
+  .uleb128 Lfunc_end1-Ltmp4             ;   Call between Ltmp4 and Lfunc_end1
+  .byte 0                               ;     has no landing pad
+  .byte 0                               ;   On action: cleanup
+Lcst_end1:
+  .byte 1                               ; >> Action Record 1 <<
+                                        ;   Catch TypeInfo 1
+  .byte 0                               ;   No further actions
+  .p2align 2
+                                        ; >> Catch TypeInfos <<
+  .long _OBJC_EHTYPE_$_NSException@GOT-. ; TypeInfo 1
+Lttbase1:
+  .p2align 2
+
+GCC_except_table2:
+Lexception2:
+  .byte 255                             ; @LPStart Encoding = omit
+  .byte 155                             ; @TType Encoding = indirect pcrel sdata4
+  .uleb128 Lttbase2-Lttbaseref2
+Lttbaseref2:
+  .byte 1                               ; Call site Encoding = uleb128
+  .uleb128 Lcst_end2-Lcst_begin2
+Lcst_begin2:
+  .uleb128 Lfunc_begin2-Lfunc_begin2    ; >> Call Site 1 <<
+  .uleb128 Ltmp6-Lfunc_begin2           ;   Call between Lfunc_begin2 and Ltmp6
+  .byte 0                               ;     has no landing pad
+  .byte 0                               ;   On action: cleanup
+  .uleb128 Ltmp6-Lfunc_begin2           ; >> Call Site 2 <<
+  .uleb128 Ltmp7-Ltmp6                  ;   Call between Ltmp6 and Ltmp7
+  .uleb128 Ltmp8-Lfunc_begin2           ;     jumps to Ltmp8
+  .byte 1                               ;   On action: 1
+  .uleb128 Ltmp7-Lfunc_begin2           ; >> Call Site 3 <<
+  .uleb128 Lfunc_end2-Ltmp7             ;   Call between Ltmp7 and Lfunc_end2
+  .byte 0                               ;     has no landing pad
+  .byte 0                               ;   On action: cleanup
+Lcst_end2:
+  .byte 1                               ; >> Action Record 1 <<
+                                        ;   Catch TypeInfo 1
+  .byte 0                               ;   No further actions
+  .p2align 2
+                                        ; >> Catch TypeInfos <<
+  .long _OBJC_EHTYPE_$_NSException@GOT-. ; TypeInfo 1
+Lttbase2:
+  .p2align 2
+
+GCC_except_table3:
+Lexception3:
+  .byte 255                             ; @LPStart Encoding = omit
+  .byte 155                             ; @TType Encoding = indirect pcrel sdata4
+  .uleb128 Lttbase3-Lttbaseref3
+Lttbaseref3:
+  .byte 1                               ; Call site Encoding = uleb128
+  .uleb128 Lcst_end3-Lcst_begin3
+Lcst_begin3:
+  .uleb128 Lfunc_begin3-Lfunc_begin3    ; >> Call Site 1 <<
+  .uleb128 Ltmp9-Lfunc_begin3           ;   Call between Lfunc_begin3 and Ltmp9
+  .byte 0                               ;     has no landing pad
+  .byte 0                               ;   On action: cleanup
+  .uleb128 Ltmp9-Lfunc_begin3           ; >> Call Site 2 <<
+  .uleb128 Ltmp10-Ltmp9                 ;   Call between Ltmp9 and Ltmp10
+  .uleb128 Ltmp11-Lfunc_begin3          ;     jumps to Ltmp11
+  .byte 1                               ;   On action: 1
+  .uleb128 Ltmp10-Lfunc_begin3          ; >> Call Site 3 <<
+  .uleb128 Lfunc_end3-Ltmp10            ;   Call between Ltmp10 and Lfunc_end3
+  .byte 0                               ;     has no landing pad
+  .byte 0                               ;   On action: cleanup
+Lcst_end3:
+  .byte 1                               ; >> Action Record 1 <<
+                                        ;   Catch TypeInfo 1
+  .byte 0                               ;   No further actions
+  .p2align 2
+                                        ; >> Catch TypeInfos <<
+  .long _OBJC_EHTYPE_$_NSException@GOT-. ; TypeInfo 1
+Lttbase3:
+  .p2align 2
+
+.subsections_via_symbols

--- a/lld/test/MachO/icf-lsda-reloc.s
+++ b/lld/test/MachO/icf-lsda-reloc.s
@@ -1,3 +1,19 @@
+## The TType references to _OBJC_EHTYPE_$_NSException are PC-relative
+## pointer-to-GOT relocations: the assembler leaves a meaningless
+## site-dependent value in each TType slot, so identical exception tables
+## differ in their raw bytes and can only be folded by ICF after the relocated
+## fields are normalized. Reduced from a real-world ObjC object.
+##
+## _f0 and _f1 are unwound via compact unwind. Their bodies and (normalized)
+## tables are identical, so the functions fold together with their tables.
+##
+## _g0 and _g1 carry a lone .cfi_offset with no frame, which compact unwind
+## cannot encode, so they get DWARF-mode entries and are unwound via their
+## FDEs. Their bodies differ, so only their tables fold; the FDE's LSDA
+## pointer is resolved when the FDE is parsed and must be canonicalized after
+## ICF, or their __unwind_info LSDA entries would point at the folded-away
+## tables.
+
 # REQUIRES: aarch64
 
 # RUN: llvm-mc -filetype=obj -triple=arm64-apple-macos11 %s -o %t.o
@@ -8,295 +24,78 @@
 # RUN: llvm-objdump --macho --syms --unwind-info --dwarf=frames %t | \
 # RUN:   FileCheck %s
 
-## Modelled on a real-world ObjC object containing identical methods that
-## @catch NSException were not folded because their exception tables were not:
-## the tables reference _OBJC_EHTYPE_$_NSException through PC-relative
-## pointer-to-GOT relocations, so their raw bytes differ by the position of the
-## relocation site. ICF must normalize the relocated bytes to fold the tables,
-## after which the methods fold as well.
-##
-## _f0 and _f1 model those methods: identical bodies, compact unwind, and
-## identical exception tables at different offsets. Both the tables and the
-## functions must fold.
-##
-## _g0 and _g1 use an outlined prologue; the resulting CFI cannot be expressed
-## as compact unwind, so they are unwound via DWARF FDEs. They share an
-## exception table but deliberately have different bodies, so only the table is
-## folded; _g1's FDE and its __unwind_info LSDA entry must then point at the
-## surviving table, not at the folded one. DWARF unwinding is required to
-## exercise this: the LSDA of a compact unwind entry is a relocation that gets
-## canonicalized after ICF, whereas the LSDA of an FDE is resolved to an input
-## section when the FDE is parsed and needs to be canonicalized separately.
-
-## Sanity-check the input: each TType entry is a PC-relative pointer-to-GOT
-## relocation, so the raw bytes of the four tables differ and they can only be
-## folded after normalization. Without this the fold checks below could pass
-## vacuously.
+## Sanity check: the TType entries are relocations, so the tables can only be
+## folded after normalization.
 # INPUT:         Relocation information (__TEXT,__gcc_except_tab) 4 entries
 # INPUT-COUNT-4: PTRTGOT False     _OBJC_EHTYPE_$_NSException
 
 # CHECK-LABEL: SYMBOL TABLE:
-# CHECK: [[#%x,LSDA0:]] l   O __TEXT,__gcc_except_tab GCC_except_table0
-# CHECK: [[#LSDA0]]     l   O __TEXT,__gcc_except_tab GCC_except_table1
-# CHECK: [[#%x,LSDA2:]] l   O __TEXT,__gcc_except_tab GCC_except_table2
-# CHECK: [[#LSDA2]]     l   O __TEXT,__gcc_except_tab GCC_except_table3
-# CHECK: [[#%x,F0:]]    g   F __TEXT,__text _f0
-# CHECK: [[#F0]]        g   F __TEXT,__text _f1
-# CHECK: [[#%x,G0:]]    g   F __TEXT,__text _g0
-# CHECK: [[#%x,G1:]]    g   F __TEXT,__text _g1
+# CHECK: [[#%x,LSDA:]] l   O __TEXT,__gcc_except_tab GCC_except_table0
+# CHECK: [[#LSDA]]     l   O __TEXT,__gcc_except_tab GCC_except_table1
+# CHECK: [[#LSDA]]     l   O __TEXT,__gcc_except_tab GCC_except_table2
+# CHECK: [[#LSDA]]     l   O __TEXT,__gcc_except_tab GCC_except_table3
+# CHECK: [[#%x,F0:]]   g   F __TEXT,__text _f0
+# CHECK: [[#F0]]       g   F __TEXT,__text _f1
+# CHECK: [[#%x,G0:]]   g   F __TEXT,__text _g0
+# CHECK: [[#%x,G1:]]   g   F __TEXT,__text _g1
 
-# CHECK-LABEL: Contents of __unwind_info section:
-# CHECK:      LSDA descriptors:
-# CHECK-NEXT:   [0]: function offset=0x[[#%.8x,F0]], LSDA offset=0x[[#%.8x,LSDA0]]
-# CHECK-NEXT:   [1]: function offset=0x[[#%.8x,G0]], LSDA offset=0x[[#%.8x,LSDA2]]
-# CHECK-NEXT:   [2]: function offset=0x[[#%.8x,G1]], LSDA offset=0x[[#%.8x,LSDA2]]
-# CHECK:      Second level indices:
-# CHECK:        function offset=0x[[#%.8x,F0]], encoding[{{[0-9]+}}]=0x54000000
-# CHECK-NEXT:   function offset=0x[[#%.8x,G0]], encoding[{{[0-9]+}}]=0x03{{[0-9a-f]+}}
-# CHECK-NEXT:   function offset=0x[[#%.8x,G1]], encoding[{{[0-9]+}}]=0x03{{[0-9a-f]+}}
+# CHECK: LSDA descriptors:
+# CHECK-NEXT: [0]: function offset=0x[[#%.8x,F0]], LSDA offset=0x[[#%.8x,LSDA]]
+# CHECK-NEXT: [1]: function offset=0x[[#%.8x,G0]], LSDA offset=0x[[#%.8x,LSDA]]
+# CHECK-NEXT: [2]: function offset=0x[[#%.8x,G1]], LSDA offset=0x[[#%.8x,LSDA]]
 
 # CHECK-LABEL: .eh_frame contents:
 # CHECK: FDE cie={{.+}} pc=[[#%.8x,G0]]...{{.+}}
-# CHECK: LSDA Address: [[#%.16x,LSDA2]]
+# CHECK: LSDA Address: [[#%.16x,LSDA]]
 # CHECK: FDE cie={{.+}} pc=[[#%.8x,G1]]...{{.+}}
-# CHECK: LSDA Address: [[#%.16x,LSDA2]]
+# CHECK: LSDA Address: [[#%.16x,LSDA]]
 
 .section __TEXT,__text,regular,pure_instructions
 .globl _f0, _f1, _g0, _g1
 .p2align 2
-
 _f0:
-Lfunc_begin0:
   .cfi_startproc
   .cfi_personality 155, ___objc_personality_v0
-  .cfi_lsda 16, Lexception0
-  stp x29, x30, [sp, #-16]!
-  mov x29, sp
-  .cfi_def_cfa w29, 16
-  .cfi_offset w30, -8
-  .cfi_offset w29, -16
-Ltmp0:
-  bl _callee0
-Ltmp1:
-  ldp x29, x30, [sp], #16
+  .cfi_lsda 16, GCC_except_table0
   ret
-Ltmp2:
-  bl _objc_begin_catch
-  bl _objc_end_catch
-  ldp x29, x30, [sp], #16
-  ret
-Lfunc_end0:
   .cfi_endproc
 
 _f1:
-Lfunc_begin1:
   .cfi_startproc
   .cfi_personality 155, ___objc_personality_v0
-  .cfi_lsda 16, Lexception1
-  stp x29, x30, [sp, #-16]!
-  mov x29, sp
-  .cfi_def_cfa w29, 16
-  .cfi_offset w30, -8
-  .cfi_offset w29, -16
-Ltmp3:
-  bl _callee0
-Ltmp4:
-  ldp x29, x30, [sp], #16
+  .cfi_lsda 16, GCC_except_table1
   ret
-Ltmp5:
-  bl _objc_begin_catch
-  bl _objc_end_catch
-  ldp x29, x30, [sp], #16
-  ret
-Lfunc_end1:
   .cfi_endproc
 
+## The lone .cfi_offset forces a DWARF-mode unwind entry: compact unwind can
+## only encode callee-saved registers spilled in adjacent pairs below a frame.
 _g0:
-Lfunc_begin2:
   .cfi_startproc
   .cfi_personality 155, ___objc_personality_v0
-  .cfi_lsda 16, Lexception2
-  stp x29, x30, [sp, #-16]!
-  bl _OUTLINED_FUNCTION_PROLOG_FRAME32_x30x29x19x20x21x22
-  .cfi_offset w30, -8
-  .cfi_offset w29, -16
+  .cfi_lsda 16, GCC_except_table2
   .cfi_offset w19, -24
-  .cfi_offset w20, -32
-  .cfi_offset w21, -40
-  .cfi_offset w22, -48
-  .cfi_def_cfa w29, 16
-Ltmp6:
-  bl _callee1
-Ltmp7:
-  ldp x29, x30, [sp, #32]
-  ldp x20, x19, [sp, #16]
-  ldp x22, x21, [sp], #48
+  mov w0, #0
   ret
-Ltmp8:
-  bl _objc_begin_catch
-  bl _objc_end_catch
-  ldp x29, x30, [sp, #32]
-  ldp x20, x19, [sp, #16]
-  ldp x22, x21, [sp], #48
-  ret
-Lfunc_end2:
   .cfi_endproc
 
 _g1:
-Lfunc_begin3:
   .cfi_startproc
   .cfi_personality 155, ___objc_personality_v0
-  .cfi_lsda 16, Lexception3
-  stp x29, x30, [sp, #-16]!
-  bl _OUTLINED_FUNCTION_PROLOG_FRAME32_x30x29x19x20x21x22
-  .cfi_offset w30, -8
-  .cfi_offset w29, -16
+  .cfi_lsda 16, GCC_except_table3
   .cfi_offset w19, -24
-  .cfi_offset w20, -32
-  .cfi_offset w21, -40
-  .cfi_offset w22, -48
-  .cfi_def_cfa w29, 16
-Ltmp9:
-  bl _callee2
-Ltmp10:
-  ldp x29, x30, [sp, #32]
-  ldp x20, x19, [sp, #16]
-  ldp x22, x21, [sp], #48
+  mov w0, #1
   ret
-Ltmp11:
-  bl _objc_begin_catch
-  bl _objc_end_catch
-  ldp x29, x30, [sp, #32]
-  ldp x20, x19, [sp, #16]
-  ldp x22, x21, [sp], #48
-  ret
-Lfunc_end3:
   .cfi_endproc
 
 .section __TEXT,__gcc_except_tab
 .p2align 2
 GCC_except_table0:
-Lexception0:
-  .byte 255                             ; @LPStart Encoding = omit
-  .byte 155                             ; @TType Encoding = indirect pcrel sdata4
-  .uleb128 Lttbase0-Lttbaseref0
-Lttbaseref0:
-  .byte 1                               ; Call site Encoding = uleb128
-  .uleb128 Lcst_end0-Lcst_begin0
-Lcst_begin0:
-  .uleb128 Lfunc_begin0-Lfunc_begin0    ; >> Call Site 1 <<
-  .uleb128 Ltmp0-Lfunc_begin0           ;   Call between Lfunc_begin0 and Ltmp0
-  .byte 0                               ;     has no landing pad
-  .byte 0                               ;   On action: cleanup
-  .uleb128 Ltmp0-Lfunc_begin0           ; >> Call Site 2 <<
-  .uleb128 Ltmp1-Ltmp0                  ;   Call between Ltmp0 and Ltmp1
-  .uleb128 Ltmp2-Lfunc_begin0           ;     jumps to Ltmp2
-  .byte 1                               ;   On action: 1
-  .uleb128 Ltmp1-Lfunc_begin0           ; >> Call Site 3 <<
-  .uleb128 Lfunc_end0-Ltmp1             ;   Call between Ltmp1 and Lfunc_end0
-  .byte 0                               ;     has no landing pad
-  .byte 0                               ;   On action: cleanup
-Lcst_end0:
-  .byte 1                               ; >> Action Record 1 <<
-                                        ;   Catch TypeInfo 1
-  .byte 0                               ;   No further actions
-  .p2align 2
-                                        ; >> Catch TypeInfos <<
-  .long _OBJC_EHTYPE_$_NSException@GOT-. ; TypeInfo 1
-Lttbase0:
-  .p2align 2
-
+  .long _OBJC_EHTYPE_$_NSException@GOT-.
 GCC_except_table1:
-Lexception1:
-  .byte 255                             ; @LPStart Encoding = omit
-  .byte 155                             ; @TType Encoding = indirect pcrel sdata4
-  .uleb128 Lttbase1-Lttbaseref1
-Lttbaseref1:
-  .byte 1                               ; Call site Encoding = uleb128
-  .uleb128 Lcst_end1-Lcst_begin1
-Lcst_begin1:
-  .uleb128 Lfunc_begin1-Lfunc_begin1    ; >> Call Site 1 <<
-  .uleb128 Ltmp3-Lfunc_begin1           ;   Call between Lfunc_begin1 and Ltmp3
-  .byte 0                               ;     has no landing pad
-  .byte 0                               ;   On action: cleanup
-  .uleb128 Ltmp3-Lfunc_begin1           ; >> Call Site 2 <<
-  .uleb128 Ltmp4-Ltmp3                  ;   Call between Ltmp3 and Ltmp4
-  .uleb128 Ltmp5-Lfunc_begin1           ;     jumps to Ltmp5
-  .byte 1                               ;   On action: 1
-  .uleb128 Ltmp4-Lfunc_begin1           ; >> Call Site 3 <<
-  .uleb128 Lfunc_end1-Ltmp4             ;   Call between Ltmp4 and Lfunc_end1
-  .byte 0                               ;     has no landing pad
-  .byte 0                               ;   On action: cleanup
-Lcst_end1:
-  .byte 1                               ; >> Action Record 1 <<
-                                        ;   Catch TypeInfo 1
-  .byte 0                               ;   No further actions
-  .p2align 2
-                                        ; >> Catch TypeInfos <<
-  .long _OBJC_EHTYPE_$_NSException@GOT-. ; TypeInfo 1
-Lttbase1:
-  .p2align 2
-
+  .long _OBJC_EHTYPE_$_NSException@GOT-.
 GCC_except_table2:
-Lexception2:
-  .byte 255                             ; @LPStart Encoding = omit
-  .byte 155                             ; @TType Encoding = indirect pcrel sdata4
-  .uleb128 Lttbase2-Lttbaseref2
-Lttbaseref2:
-  .byte 1                               ; Call site Encoding = uleb128
-  .uleb128 Lcst_end2-Lcst_begin2
-Lcst_begin2:
-  .uleb128 Lfunc_begin2-Lfunc_begin2    ; >> Call Site 1 <<
-  .uleb128 Ltmp6-Lfunc_begin2           ;   Call between Lfunc_begin2 and Ltmp6
-  .byte 0                               ;     has no landing pad
-  .byte 0                               ;   On action: cleanup
-  .uleb128 Ltmp6-Lfunc_begin2           ; >> Call Site 2 <<
-  .uleb128 Ltmp7-Ltmp6                  ;   Call between Ltmp6 and Ltmp7
-  .uleb128 Ltmp8-Lfunc_begin2           ;     jumps to Ltmp8
-  .byte 1                               ;   On action: 1
-  .uleb128 Ltmp7-Lfunc_begin2           ; >> Call Site 3 <<
-  .uleb128 Lfunc_end2-Ltmp7             ;   Call between Ltmp7 and Lfunc_end2
-  .byte 0                               ;     has no landing pad
-  .byte 0                               ;   On action: cleanup
-Lcst_end2:
-  .byte 1                               ; >> Action Record 1 <<
-                                        ;   Catch TypeInfo 1
-  .byte 0                               ;   No further actions
-  .p2align 2
-                                        ; >> Catch TypeInfos <<
-  .long _OBJC_EHTYPE_$_NSException@GOT-. ; TypeInfo 1
-Lttbase2:
-  .p2align 2
-
+  .long _OBJC_EHTYPE_$_NSException@GOT-.
 GCC_except_table3:
-Lexception3:
-  .byte 255                             ; @LPStart Encoding = omit
-  .byte 155                             ; @TType Encoding = indirect pcrel sdata4
-  .uleb128 Lttbase3-Lttbaseref3
-Lttbaseref3:
-  .byte 1                               ; Call site Encoding = uleb128
-  .uleb128 Lcst_end3-Lcst_begin3
-Lcst_begin3:
-  .uleb128 Lfunc_begin3-Lfunc_begin3    ; >> Call Site 1 <<
-  .uleb128 Ltmp9-Lfunc_begin3           ;   Call between Lfunc_begin3 and Ltmp9
-  .byte 0                               ;     has no landing pad
-  .byte 0                               ;   On action: cleanup
-  .uleb128 Ltmp9-Lfunc_begin3           ; >> Call Site 2 <<
-  .uleb128 Ltmp10-Ltmp9                 ;   Call between Ltmp9 and Ltmp10
-  .uleb128 Ltmp11-Lfunc_begin3          ;     jumps to Ltmp11
-  .byte 1                               ;   On action: 1
-  .uleb128 Ltmp10-Lfunc_begin3          ; >> Call Site 3 <<
-  .uleb128 Lfunc_end3-Ltmp10            ;   Call between Ltmp10 and Lfunc_end3
-  .byte 0                               ;     has no landing pad
-  .byte 0                               ;   On action: cleanup
-Lcst_end3:
-  .byte 1                               ; >> Action Record 1 <<
-                                        ;   Catch TypeInfo 1
-  .byte 0                               ;   No further actions
-  .p2align 2
-                                        ; >> Catch TypeInfos <<
-  .long _OBJC_EHTYPE_$_NSException@GOT-. ; TypeInfo 1
-Lttbase3:
-  .p2align 2
+  .long _OBJC_EHTYPE_$_NSException@GOT-.
 
 .subsections_via_symbols


### PR DESCRIPTION
AArch64 exception tables reference type info through PC-relative pointer-to-GOT relocations. The assembler leaves the negated field offset in each relocated field, which the linker ignores, so identical tables differ in their raw bytes and are never folded. Treat __gcc_except_tab like __eh_frame and zero the relocated fields before ICF hashes and compares it.

Folding these LSDAs exposes a latent issue: the LSDA pointer of a DWARF FDE is resolved to an InputSection when the FDE is parsed and is never canonicalized after ICF. A function that is unwound via its FDE and whose LSDA was folded away therefore gets an __unwind_info LSDA entry computed from the dead input section. Fixed it in the same commit.

This patch is LLM-driven, but the issue was observed in production and the test is reduced from the production object.