### PR TITLE
[flang] Add driver support for x86 -m[option] target feature flags

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -235,7 +235,8 @@ def m_wasm_Features_Group : OptionGroup<"<wasm features group>">,
 def m_wasm_Features_Driver_Group : OptionGroup<"<wasm driver features group>">,
                                    Group<m_Group>, DocName<"WebAssembly Driver">;
 def m_x86_Features_Group : OptionGroup<"<x86 features group>">,
-                           Group<m_Group>, Visibility<[ClangOption, CLOption]>,
+                           Group<m_Group>,
+                           Visibility<[ClangOption, CLOption, FlangOption]>,
                            DocName<"X86">;
 def m_x86_AVX10_Features_Group : OptionGroup<"<x86 AVX10 features group>">,
                                  Group<m_Group>, Visibility<[ClangOption, CLOption]>,
@@ -7539,9 +7540,11 @@ def mno_retpoline_external_thunk : Flag<["-"], "mno-retpoline-external-thunk">, 
 def mvzeroupper : Flag<["-"], "mvzeroupper">, Group<m_x86_Features_Group>;
 def mno_vzeroupper : Flag<["-"], "mno-vzeroupper">, Group<m_x86_Features_Group>;
 def mno_gather : Flag<["-"], "mno-gather">, Group<m_Group>,
-                 HelpText<"Disable generation of gather instructions in auto-vectorization(x86 only)">;
+                 Visibility<[ClangOption, CLOption, FlangOption]>,
+                 HelpText<"Disable generation of gather instructions in auto-vectorization (x86 only)">;
 def mno_scatter : Flag<["-"], "mno-scatter">, Group<m_Group>,
-                  HelpText<"Disable generation of scatter instructions in auto-vectorization(x86 only)">;
+                  Visibility<[ClangOption, CLOption, FlangOption]>,
+                  HelpText<"Disable generation of scatter instructions in auto-vectorization (x86 only)">;
 def mapx_features_EQ : CommaJoined<["-"], "mapx-features=">, Group<m_x86_Features_Group>,
     HelpText<"Enable features of APX">, Values<"egpr,push2pop2,ppx,ndd,ccmp,nf,cf,zu,jmpabs">,  Visibility<[ClangOption, CLOption, FlangOption]>;
 def mno_apx_features_EQ : CommaJoined<["-"], "mno-apx-features=">, Group<m_x86_Features_Group>,

--- a/flang/test/Driver/target-cpu-features.f90
+++ b/flang/test/Driver/target-cpu-features.f90
@@ -1,5 +1,8 @@
 ! Test that -mcpu/march are used and that the -target-cpu and -target-features
 ! are also added to the fc1 command.
+!
+! The X86 section batches m_x86_Features_Group options by ISA family (AMX, SSE,
+! AVX/AVX512, then other). Each family has a matching -mno-* RUN.
 
 ! RUN: %flang --target=aarch64-linux-gnu -mcpu=cortex-a57 -c %s -### 2>&1 \
 ! RUN: | FileCheck %s -check-prefix=CHECK-A57
@@ -87,3 +90,282 @@
 
 ! CHECK-SPARC-VIS: "-fc1" "-triple" "sparc64-{{[^"]+}}"
 ! CHECK-SPARC-VIS-SAME: "-target-feature" "+vis"
+
+! AMX
+! RUN: %flang --target=x86_64-linux-gnu \
+! RUN:   -mamx-avx512 -mamx-bf16 -mamx-complex -mamx-fp16 -mamx-int8 -mamx-fp8 -mamx-tile -mamx-movrs \
+! RUN:   %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-X86-AMX
+! CHECK-X86-AMX: "-fc1"
+! CHECK-X86-AMX-SAME: "-target-feature" "+amx-avx512"
+! CHECK-X86-AMX-SAME: "-target-feature" "+amx-bf16"
+! CHECK-X86-AMX-SAME: "-target-feature" "+amx-complex"
+! CHECK-X86-AMX-SAME: "-target-feature" "+amx-fp16"
+! CHECK-X86-AMX-SAME: "-target-feature" "+amx-int8"
+! CHECK-X86-AMX-SAME: "-target-feature" "+amx-fp8"
+! CHECK-X86-AMX-SAME: "-target-feature" "+amx-tile"
+! CHECK-X86-AMX-SAME: "-target-feature" "+amx-movrs"
+!
+! RUN: %flang --target=x86_64-linux-gnu \
+! RUN:   -mno-amx-avx512 -mno-amx-bf16 -mno-amx-complex -mno-amx-fp16 -mno-amx-int8 -mno-amx-fp8 -mno-amx-tile -mno-amx-movrs \
+! RUN:   %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-X86-AMX-NEG
+! CHECK-X86-AMX-NEG: "-fc1"
+! CHECK-X86-AMX-NEG-SAME: "-target-feature" "-amx-avx512"
+! CHECK-X86-AMX-NEG-SAME: "-target-feature" "-amx-bf16"
+! CHECK-X86-AMX-NEG-SAME: "-target-feature" "-amx-complex"
+! CHECK-X86-AMX-NEG-SAME: "-target-feature" "-amx-fp16"
+! CHECK-X86-AMX-NEG-SAME: "-target-feature" "-amx-int8"
+! CHECK-X86-AMX-NEG-SAME: "-target-feature" "-amx-fp8"
+! CHECK-X86-AMX-NEG-SAME: "-target-feature" "-amx-tile"
+! CHECK-X86-AMX-NEG-SAME: "-target-feature" "-amx-movrs"
+!
+! SSE
+! RUN: %flang --target=x86_64-linux-gnu \
+! RUN:   -msse -msse2 -msse3 -mssse3 -msse4.1 -msse4.2 -msse4a \
+! RUN:   %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-X86-SSE
+! CHECK-X86-SSE: "-fc1"
+! CHECK-X86-SSE-SAME: "-target-feature" "+sse"
+! CHECK-X86-SSE-SAME: "-target-feature" "+sse2"
+! CHECK-X86-SSE-SAME: "-target-feature" "+sse3"
+! CHECK-X86-SSE-SAME: "-target-feature" "+ssse3"
+! CHECK-X86-SSE-SAME: "-target-feature" "+sse4.1"
+! CHECK-X86-SSE-SAME: "-target-feature" "+sse4.2"
+! CHECK-X86-SSE-SAME: "-target-feature" "+sse4a"
+!
+! RUN: %flang --target=x86_64-linux-gnu \
+! RUN:   -mno-sse -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4.1 -mno-sse4.2 -mno-sse4a \
+! RUN:   %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-X86-SSE-NEG
+! CHECK-X86-SSE-NEG: "-fc1"
+! CHECK-X86-SSE-NEG-SAME: "-target-feature" "-sse"
+! CHECK-X86-SSE-NEG-SAME: "-target-feature" "-sse2"
+! CHECK-X86-SSE-NEG-SAME: "-target-feature" "-sse3"
+! CHECK-X86-SSE-NEG-SAME: "-target-feature" "-ssse3"
+! CHECK-X86-SSE-NEG-SAME: "-target-feature" "-sse4.1"
+! CHECK-X86-SSE-NEG-SAME: "-target-feature" "-sse4.2"
+! CHECK-X86-SSE-NEG-SAME: "-target-feature" "-sse4a"
+!
+! AVX (including AVX10 / AVX512 / AVX-VNNI)
+! RUN: %flang --target=x86_64-linux-gnu \
+! RUN:   -mavx -mavx10.1 -mavx10.2 -mavx2 \
+! RUN:   -mavx512f -mavx512bf16 -mavx512bitalg -mavx512bmm -mavx512bw -mavx512cd -mavx512dq -mavx512fp16 \
+! RUN:   -mavx512ifma -mavx512vbmi -mavx512vbmi2 -mavx512vl -mavx512vnni -mavx512vpopcntdq -mavx512vp2intersect \
+! RUN:   -mavxifma -mavxneconvert -mavxvnniint16 -mavxvnniint8 -mavxvnni \
+! RUN:   %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-X86-AVX
+! CHECK-X86-AVX: "-fc1"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avx"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avx10.1"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avx10.2"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avx2"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avx512f"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avx512bf16"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avx512bitalg"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avx512bmm"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avx512bw"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avx512cd"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avx512dq"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avx512fp16"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avx512ifma"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avx512vbmi"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avx512vbmi2"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avx512vl"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avx512vnni"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avx512vpopcntdq"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avx512vp2intersect"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avxifma"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avxneconvert"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avxvnniint16"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avxvnniint8"
+! CHECK-X86-AVX-SAME: "-target-feature" "+avxvnni"
+!
+! RUN: %flang --target=x86_64-linux-gnu \
+! RUN:   -mno-avx -mno-avx10.1 -mno-avx10.2 -mno-avx2 \
+! RUN:   -mno-avx512f -mno-avx512bf16 -mno-avx512bitalg -mno-avx512bmm -mno-avx512bw -mno-avx512cd -mno-avx512dq -mno-avx512fp16 \
+! RUN:   -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vl -mno-avx512vnni -mno-avx512vpopcntdq -mno-avx512vp2intersect \
+! RUN:   -mno-avxifma -mno-avxneconvert -mno-avxvnniint16 -mno-avxvnniint8 -mno-avxvnni \
+! RUN:   %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-X86-AVX-NEG
+! CHECK-X86-AVX-NEG: "-fc1"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avx"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avx10.1"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avx10.2"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avx2"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avx512f"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avx512bf16"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avx512bitalg"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avx512bmm"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avx512bw"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avx512cd"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avx512dq"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avx512fp16"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avx512ifma"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avx512vbmi"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avx512vbmi2"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avx512vl"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avx512vnni"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avx512vpopcntdq"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avx512vp2intersect"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avxifma"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avxneconvert"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avxvnniint16"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avxvnniint8"
+! CHECK-X86-AVX-NEG-SAME: "-target-feature" "-avxvnni"
+!
+! Remaining m_x86_Features_Group flags.
+! RUN: %flang --target=x86_64-linux-gnu \
+! RUN:   -mx87 -mmmx -mcmpccxadd \
+! RUN:   -madx -maes -mbmi -mbmi2 -mcldemote -mclflushopt -mclwb -mwbnoinvd -mclzero -mcrc32 -mcx16 -menqcmd -mf16c -mfma -mfma4 -mfsgsbase -mfxsr -minvpcid \
+! RUN:   -mgfni -mhreset -mkl -mwidekl -mlwp -mlzcnt -mmovbe -mmovdiri -mmovdir64b -mmovrs -mmwaitx -mpku -mpclmul -mpconfig -mpopcnt -mprefetchi -mprfchw -mptwrite -mraoint -mrdpid -mrdpru -mrdrnd -mrtm -mrdseed -msahf -mserialize -msgx -msha -msha512 -msm3 \
+! RUN:   -msm4 -mtbm -mtsxldtrk -muintr -musermsr -mvaes -mvpclmulqdq -mwaitpkg -mxop -mxsave -mxsavec -mxsaveopt -mxsaves -mshstk -mretpoline-external-thunk -mvzeroupper \
+! RUN:   %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-X86-OTHER
+! CHECK-X86-OTHER: "-fc1"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+x87"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+mmx"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+cmpccxadd"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+adx"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+aes"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+bmi"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+bmi2"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+cldemote"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+clflushopt"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+clwb"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+wbnoinvd"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+clzero"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+crc32"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+cx16"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+enqcmd"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+f16c"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+fma"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+fma4"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+fsgsbase"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+fxsr"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+invpcid"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+gfni"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+hreset"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+kl"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+widekl"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+lwp"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+lzcnt"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+movbe"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+movdiri"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+movdir64b"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+movrs"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+mwaitx"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+pku"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+pclmul"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+pconfig"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+popcnt"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+prefetchi"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+prfchw"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+ptwrite"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+raoint"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+rdpid"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+rdpru"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+rdrnd"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+rtm"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+rdseed"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+sahf"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+serialize"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+sgx"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+sha"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+sha512"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+sm3"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+sm4"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+tbm"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+tsxldtrk"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+uintr"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+usermsr"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+vaes"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+vpclmulqdq"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+waitpkg"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+xop"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+xsave"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+xsavec"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+xsaveopt"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+xsaves"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+shstk"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+retpoline-external-thunk"
+! CHECK-X86-OTHER-SAME: "-target-feature" "+vzeroupper"
+!
+! RUN: %flang --target=x86_64-linux-gnu \
+! RUN:   -mno-x87 -mno-mmx -mno-cmpccxadd \
+! RUN:   -mno-adx -mno-aes -mno-bmi -mno-bmi2 -mno-cldemote -mno-clflushopt -mno-clwb -mno-wbnoinvd -mno-clzero -mno-crc32 -mno-cx16 -mno-enqcmd -mno-f16c -mno-fma -mno-fma4 -mno-fsgsbase -mno-fxsr -mno-invpcid \
+! RUN:   -mno-gfni -mno-hreset -mno-kl -mno-widekl -mno-lwp -mno-lzcnt -mno-movbe -mno-movdiri -mno-movdir64b -mno-movrs -mno-mwaitx -mno-pku -mno-pclmul -mno-pconfig -mno-popcnt -mno-prefetchi -mno-prfchw -mno-ptwrite -mno-raoint -mno-rdpid -mno-rdpru -mno-rdrnd -mno-rtm -mno-rdseed -mno-sahf -mno-serialize -mno-sgx -mno-sha -mno-sha512 -mno-sm3 \
+! RUN:   -mno-sm4 -mno-tbm -mno-tsxldtrk -mno-uintr -mno-usermsr -mno-vaes -mno-vpclmulqdq -mno-waitpkg -mno-xop -mno-xsave -mno-xsavec -mno-xsaveopt -mno-xsaves -mno-shstk -mno-retpoline-external-thunk -mno-vzeroupper \
+! RUN:   %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-X86-OTHER-NEG
+! CHECK-X86-OTHER-NEG: "-fc1"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-x87"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-mmx"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-cmpccxadd"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-adx"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-aes"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-bmi"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-bmi2"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-cldemote"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-clflushopt"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-clwb"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-wbnoinvd"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-clzero"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-crc32"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-cx16"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-enqcmd"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-f16c"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-fma"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-fma4"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-fsgsbase"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-fxsr"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-invpcid"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-gfni"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-hreset"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-kl"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-widekl"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-lwp"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-lzcnt"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-movbe"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-movdiri"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-movdir64b"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-movrs"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-mwaitx"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-pku"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-pclmul"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-pconfig"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-popcnt"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-prefetchi"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-prfchw"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-ptwrite"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-raoint"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-rdpid"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-rdpru"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-rdrnd"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-rtm"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-rdseed"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-sahf"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-serialize"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-sgx"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-sha"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-sha512"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-sm3"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-sm4"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-tbm"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-tsxldtrk"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-uintr"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-usermsr"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-vaes"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-vpclmulqdq"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-waitpkg"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-xop"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-xsave"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-xsavec"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-xsaveopt"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-xsaves"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-shstk"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-retpoline-external-thunk"
+! CHECK-X86-OTHER-NEG-SAME: "-target-feature" "-vzeroupper"
+!
+! RUN: %flang --target=x86_64-linux-gnu -mno-gather -mno-scatter %s -### 2>&1 \
+! RUN:   | FileCheck %s -check-prefix=CHECK-X86-GATHER-SCATTER
+! CHECK-X86-GATHER-SCATTER: "-target-feature" "+prefer-no-gather"
+! CHECK-X86-GATHER-SCATTER-SAME: "-target-feature" "+prefer-no-scatter"
+
+! RUN: not %flang --target=aarch64-linux-gnu -mavx -mcrc32 %s -### 2>&1 \
+! RUN:   | FileCheck %s -check-prefix=CHECK-NONX86
+! CHECK-NONX86: error: unsupported option '-mavx' for target 'aarch64-linux-gnu'
+! CHECK-NONX86: error: unsupported option '-mcrc32' for target 'aarch64-linux-gnu'
+


### PR DESCRIPTION
Added FlangOption visibility to m_x86_Features_Group so flags such as -mavx, -mavx2, and -mavx512f are accepted by flang and forwarded as -target-feature to -fc1 via the shared Clang driver logic.

Also extended target-cpu-features.f90 with grouped driver tests that cover m_x86_Features_Group options, including representative -mno-*, APX cases

Assisted by : Cursor (testcase generation)