### PR TITLE
[libc++] Make std::call_once synchronization visible to TSan

### DIFF
--- a/libcxx/include/__debug_utils/sanitizers.h
+++ b/libcxx/include/__debug_utils/sanitizers.h
@@ -38,7 +38,7 @@
 #  define _LIBCPP_ENABLE_ASAN_CONTAINER_CHECKS 0
 #endif
 
-#if __has_feature(thread_sanitizer) || defined(__SANITIZE_THREAD__)
+#if __has_feature(thread_sanitizer)
 #  define _LIBCPP_ENABLE_TSAN_ANNOTATIONS 1
 #else
 #  define _LIBCPP_ENABLE_TSAN_ANNOTATIONS 0
@@ -69,13 +69,6 @@ _LIBCPP_EXPORTED_FROM_ABI void __tsan_release(void*);
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-inline _LIBCPP_HIDE_FROM_ABI void __libcpp_tsan_release(void* __addr) {
-#if _LIBCPP_ENABLE_TSAN_ANNOTATIONS
-  ::__tsan_release(__addr);
-#else
-  (void)__addr;
-#endif
-}
 
 // ASan choices
 #if _LIBCPP_ENABLE_ASAN_CONTAINER_CHECKS

--- a/libcxx/include/__debug_utils/sanitizers.h
+++ b/libcxx/include/__debug_utils/sanitizers.h
@@ -38,6 +38,12 @@
 #  define _LIBCPP_ENABLE_ASAN_CONTAINER_CHECKS 0
 #endif
 
+#if __has_feature(thread_sanitizer) || defined(__SANITIZE_THREAD__)
+#  define _LIBCPP_ENABLE_TSAN_ANNOTATIONS 1
+#else
+#  define _LIBCPP_ENABLE_TSAN_ANNOTATIONS 0
+#endif
+
 #if _LIBCPP_INSTRUMENTED_WITH_ASAN && !_LIBCPP_ENABLE_ASAN_CONTAINER_CHECKS
 #  error "We can't disable ASAN container checks when libc++ has been built with ASAN container checks enabled"
 #endif
@@ -55,7 +61,21 @@ __sanitizer_verify_double_ended_contiguous_container(const void*, const void*, c
 
 #endif // _LIBCPP_ENABLE_ASAN_CONTAINER_CHECKS
 
+#if _LIBCPP_ENABLE_TSAN_ANNOTATIONS
+extern "C" {
+_LIBCPP_EXPORTED_FROM_ABI void __tsan_release(void*);
+}
+#endif
+
 _LIBCPP_BEGIN_NAMESPACE_STD
+
+inline _LIBCPP_HIDE_FROM_ABI void __libcpp_tsan_release(void* __addr) {
+#if _LIBCPP_ENABLE_TSAN_ANNOTATIONS
+  ::__tsan_release(__addr);
+#else
+  (void)__addr;
+#endif
+}
 
 // ASan choices
 #if _LIBCPP_ENABLE_ASAN_CONTAINER_CHECKS

--- a/libcxx/include/__mutex/once_flag.h
+++ b/libcxx/include/__mutex/once_flag.h
@@ -83,16 +83,14 @@ private:
 template <class _Fp>
 class __call_once_param {
   _Fp& __f_;
-  void* __flag_;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI explicit __call_once_param(_Fp& __f, void* __flag) : __f_(__f), __flag_(__flag) {}
+  _LIBCPP_HIDE_FROM_ABI explicit __call_once_param(_Fp& __f) : __f_(__f) {}
 
   _LIBCPP_HIDE_FROM_ABI void operator()() {
     [&]<size_t... _Indices>(__index_sequence<_Indices...>) -> void {
       std::__invoke(std::get<_Indices>(std::move(__f_))...);
     }(__make_index_sequence<tuple_size<_Fp>::value>());
-    std::__libcpp_tsan_release(__flag_);
   }
 };
 
@@ -101,12 +99,11 @@ public:
 template <class _Fp>
 class __call_once_param {
   _Fp& __f_;
-  void* __flag_;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI explicit __call_once_param(_Fp& __f, void* __flag) : __f_(__f), __flag_(__flag) {}
+  _LIBCPP_HIDE_FROM_ABI explicit __call_once_param(_Fp& __f) : __f_(__f) {}
 
-  _LIBCPP_HIDE_FROM_ABI void operator()() { __f_(); std::__libcpp_tsan_release(__flag_); }
+  _LIBCPP_HIDE_FROM_ABI void operator()() { __f_(); }
 };
 
 #endif
@@ -116,6 +113,22 @@ void _LIBCPP_HIDE_FROM_ABI __call_once_proxy(void* __vp) {
   __call_once_param<_Fp>* __p = static_cast<__call_once_param<_Fp>*>(__vp);
   (*__p)();
 }
+
+#if _LIBCPP_ENABLE_TSAN_ANNOTATIONS
+
+struct __call_once_tsan_param {
+  void* __arg_;
+  void (*__func_)(void*);
+  void* __flag_;
+};
+
+inline _LIBCPP_HIDE_FROM_ABI void __call_once_tsan_proxy(void* __vp) {
+  __call_once_tsan_param* __p = static_cast<__call_once_tsan_param*>(__vp);
+  __p->__func_(__p->__arg_);
+  ::__tsan_release(__p->__flag_);
+}
+
+#endif
 
 _LIBCPP_BEGIN_EXPLICIT_ABI_ANNOTATIONS
 _LIBCPP_EXPORTED_FROM_ABI void __call_once(volatile once_flag::_State_type&, void*, void (*)(void*));
@@ -137,8 +150,16 @@ inline _LIBCPP_HIDE_FROM_ABI void call_once(once_flag& __flag, _Callable&& __fun
   if (__libcpp_acquire_load(&__flag.__state_) != once_flag::_Complete) {
     typedef tuple<_Callable&&, _Args&&...> _Gp;
     _Gp __f(std::forward<_Callable>(__func), std::forward<_Args>(__args)...);
-    __call_once_param<_Gp> __p(__f, std::addressof(__flag.__state_));
+    __call_once_param<_Gp> __p(__f);
+#if _LIBCPP_ENABLE_TSAN_ANNOTATIONS
+    __call_once_tsan_param __tsan_p = {
+        std::addressof(__p),
+        std::addressof(__call_once_proxy<_Gp>),
+        std::addressof(__flag.__state_)};
+    std::__call_once(__flag.__state_, std::addressof(__tsan_p), std::addressof(__call_once_tsan_proxy));
+#else
     std::__call_once(__flag.__state_, std::addressof(__p), std::addressof(__call_once_proxy<_Gp>));
+#endif
   }
 }
 
@@ -147,16 +168,32 @@ inline _LIBCPP_HIDE_FROM_ABI void call_once(once_flag& __flag, _Callable&& __fun
 template <class _Callable>
 inline _LIBCPP_HIDE_FROM_ABI void call_once(once_flag& __flag, _Callable& __func) {
   if (__libcpp_acquire_load(&__flag.__state_) != once_flag::_Complete) {
-    __call_once_param<_Callable> __p(__func, std::addressof(__flag.__state_));
+    __call_once_param<_Callable> __p(__func);
+#if _LIBCPP_ENABLE_TSAN_ANNOTATIONS
+    __call_once_tsan_param __tsan_p = {
+        std::addressof(__p),
+        std::addressof(__call_once_proxy<_Callable>),
+        std::addressof(__flag.__state_)};
+    std::__call_once(__flag.__state_, std::addressof(__tsan_p), std::addressof(__call_once_tsan_proxy));
+#else
     std::__call_once(__flag.__state_, std::addressof(__p), std::addressof(__call_once_proxy<_Callable>));
+#endif
   }
 }
 
 template <class _Callable>
 inline _LIBCPP_HIDE_FROM_ABI void call_once(once_flag& __flag, const _Callable& __func) {
   if (__libcpp_acquire_load(&__flag.__state_) != once_flag::_Complete) {
-    __call_once_param<const _Callable> __p(__func, std::addressof(__flag.__state_));
+    __call_once_param<const _Callable> __p(__func);
+#if _LIBCPP_ENABLE_TSAN_ANNOTATIONS
+    __call_once_tsan_param __tsan_p = {
+        std::addressof(__p),
+        std::addressof(__call_once_proxy<const _Callable>),
+        std::addressof(__flag.__state_)};
+    std::__call_once(__flag.__state_, std::addressof(__tsan_p), std::addressof(__call_once_tsan_proxy));
+#else
     std::__call_once(__flag.__state_, std::addressof(__p), std::addressof(__call_once_proxy<const _Callable>));
+#endif
   }
 }
 

--- a/libcxx/include/__mutex/once_flag.h
+++ b/libcxx/include/__mutex/once_flag.h
@@ -10,6 +10,7 @@
 #define _LIBCPP___MUTEX_ONCE_FLAG_H
 
 #include <__config>
+#include <__debug_utils/sanitizers.h>
 #include <__memory/addressof.h>
 #include <__tuple/tuple_size.h>
 #include <__type_traits/invoke.h>
@@ -82,14 +83,16 @@ private:
 template <class _Fp>
 class __call_once_param {
   _Fp& __f_;
+  void* __flag_;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI explicit __call_once_param(_Fp& __f) : __f_(__f) {}
+  _LIBCPP_HIDE_FROM_ABI explicit __call_once_param(_Fp& __f, void* __flag) : __f_(__f), __flag_(__flag) {}
 
   _LIBCPP_HIDE_FROM_ABI void operator()() {
     [&]<size_t... _Indices>(__index_sequence<_Indices...>) -> void {
       std::__invoke(std::get<_Indices>(std::move(__f_))...);
     }(__make_index_sequence<tuple_size<_Fp>::value>());
+    std::__libcpp_tsan_release(__flag_);
   }
 };
 
@@ -98,11 +101,12 @@ public:
 template <class _Fp>
 class __call_once_param {
   _Fp& __f_;
+  void* __flag_;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI explicit __call_once_param(_Fp& __f) : __f_(__f) {}
+  _LIBCPP_HIDE_FROM_ABI explicit __call_once_param(_Fp& __f, void* __flag) : __f_(__f), __flag_(__flag) {}
 
-  _LIBCPP_HIDE_FROM_ABI void operator()() { __f_(); }
+  _LIBCPP_HIDE_FROM_ABI void operator()() { __f_(); std::__libcpp_tsan_release(__flag_); }
 };
 
 #endif
@@ -133,7 +137,7 @@ inline _LIBCPP_HIDE_FROM_ABI void call_once(once_flag& __flag, _Callable&& __fun
   if (__libcpp_acquire_load(&__flag.__state_) != once_flag::_Complete) {
     typedef tuple<_Callable&&, _Args&&...> _Gp;
     _Gp __f(std::forward<_Callable>(__func), std::forward<_Args>(__args)...);
-    __call_once_param<_Gp> __p(__f);
+    __call_once_param<_Gp> __p(__f, std::addressof(__flag.__state_));
     std::__call_once(__flag.__state_, std::addressof(__p), std::addressof(__call_once_proxy<_Gp>));
   }
 }
@@ -143,7 +147,7 @@ inline _LIBCPP_HIDE_FROM_ABI void call_once(once_flag& __flag, _Callable&& __fun
 template <class _Callable>
 inline _LIBCPP_HIDE_FROM_ABI void call_once(once_flag& __flag, _Callable& __func) {
   if (__libcpp_acquire_load(&__flag.__state_) != once_flag::_Complete) {
-    __call_once_param<_Callable> __p(__func);
+    __call_once_param<_Callable> __p(__func, std::addressof(__flag.__state_));
     std::__call_once(__flag.__state_, std::addressof(__p), std::addressof(__call_once_proxy<_Callable>));
   }
 }
@@ -151,7 +155,7 @@ inline _LIBCPP_HIDE_FROM_ABI void call_once(once_flag& __flag, _Callable& __func
 template <class _Callable>
 inline _LIBCPP_HIDE_FROM_ABI void call_once(once_flag& __flag, const _Callable& __func) {
   if (__libcpp_acquire_load(&__flag.__state_) != once_flag::_Complete) {
-    __call_once_param<const _Callable> __p(__func);
+    __call_once_param<const _Callable> __p(__func, std::addressof(__flag.__state_));
     std::__call_once(__flag.__state_, std::addressof(__p), std::addressof(__call_once_proxy<const _Callable>));
   }
 }

--- a/libcxx/test/std/thread/thread.mutex/thread.once/thread.once.callonce/race.pass.cpp
+++ b/libcxx/test/std/thread/thread.mutex/thread.once/thread.once.callonce/race.pass.cpp
@@ -19,6 +19,7 @@
 // call_once properly synchronizes user state, a data race that was fixed
 // in r280621.
 
+#include <atomic>
 #include <mutex>
 #include <thread>
 #include <cassert>
@@ -27,6 +28,7 @@
 #include "test_macros.h"
 
 std::once_flag flg0;
+std::atomic<bool> initialized(false);
 long global = 0;
 
 void init0()
@@ -37,13 +39,22 @@ void init0()
 void f0()
 {
     std::call_once(flg0, init0);
+    initialized.store(true, std::memory_order_relaxed);
+}
+
+void f1()
+{
+    while (!initialized.load(std::memory_order_relaxed))
+        std::this_thread::yield();
+
+    std::call_once(flg0, init0);
     assert(global == 1);
 }
 
 int main(int, char**)
 {
     std::thread t0 = support::make_test_thread(f0);
-    std::thread t1 = support::make_test_thread(f0);
+    std::thread t1 = support::make_test_thread(f1);
     t0.join();
     t1.join();
     assert(global == 1);


### PR DESCRIPTION
Fixes #216066 

The false positive happens when libc++ itself is not built with TSan.
The acquire is in the header, while the corresponding release is in the libc++ implementation
and is not visible to TSan.

I first tried a Darwin-style `__call_once` interceptor in `compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp`. 
It fixed the shared libc++ case, but not the static one. This change instead adds the TSan release
to the existing callback wrapper in the header, so it works for both static and shared libc++.

The regression test now waits for the first `call_once` to complete before making the second call
so it exercises the failing path deterministically.

Assisted-by: ChatGPT (investigation and patch review)