### PR TITLE
[VPlan] Add infrastructure for check-first early-exit vectorization.

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -1237,6 +1237,18 @@ static void remapOperands(VPBlockBase *Entry, VPBlockBase *NewEntry,
   }
 }
 
+/// Returns the clone of VPBB Old recorded in Old2NewBlocks, or nullptr when
+/// Old is null.
+static VPBasicBlock *
+remapClonedBlock(const DenseMap<VPBlockBase *, VPBlockBase *> &Old2NewBlocks,
+                 VPBasicBlock *Old) {
+  if (!Old)
+    return nullptr;
+  VPBlockBase *New = Old2NewBlocks.lookup(Old);
+  assert(New && "Check-first block not found in cloned plan.");
+  return cast<VPBasicBlock>(New);
+}
+
 VPlan *VPlan::duplicate() {
   unsigned NumBlocksBeforeCloning = CreatedBlocks.size();
   // Clone blocks.
@@ -1325,6 +1337,25 @@ VPlan *VPlan::duplicate() {
         VPB != NewScalarHeader)
       NewPlan->ExitBlocks.push_back(cast<VPIRBasicBlock>(VPB));
   }
+
+  NewPlan->CheckFirst.UsesMaskedReplay = CheckFirst.UsesMaskedReplay;
+  NewPlan->CheckFirst.InclusiveReplayStores = CheckFirst.InclusiveReplayStores;
+
+  // Map each original block to its clone via a single depth-first traversal.
+  DenseMap<VPBlockBase *, VPBlockBase *> Old2NewBlocks;
+  for (const auto &[OldBB, NewBB] :
+       zip_equal(vp_depth_first_deep(Entry), vp_depth_first_deep(NewEntry)))
+    Old2NewBlocks[OldBB] = NewBB;
+
+  // ExitBlocks must list every exit of the original scalar loop, including
+  // currently unreachable ones, which the traversals above do not reach.
+  for (VPIRBasicBlock *EB : ExitBlocks)
+    if (!Old2NewBlocks.contains(EB))
+      NewPlan->ExitBlocks.push_back(
+          NewPlan->createVPIRBasicBlock(EB->getIRBasicBlock()));
+
+  NewPlan->CheckFirst.ExitBlock =
+      remapClonedBlock(Old2NewBlocks, CheckFirst.ExitBlock);
 
   return NewPlan;
 }

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -86,6 +86,10 @@ enum class UncountableExitStyle {
   /// uncountable exit is taken, then all lanes before the exiting lane will
   /// complete, leaving just the final lane to execute in the scalar tail.
   MaskedHandleExitInScalarLoop,
+  /// Check-first semantics: exit conditions are evaluated at the start of each
+  /// vector iteration before any stores execute. On early exit, the scalar loop
+  /// resumes from the start of the current vector chunk.
+  CheckFirst,
 };
 
 /// VPBlockBase is the building block of the Hierarchical Control-Flow Graph.
@@ -4823,6 +4827,27 @@ class VPlan {
   /// VPIRBasicBlock wrapping the header of the original scalar loop.
   VPIRBasicBlock *ScalarHeader;
 
+  /// Used for recording the state for check-first early-exit vectorization.
+  /// Everything else the strategy needs is derived from the plan: the cascade
+  /// header is the vector loop entry, the masked replay recipes live in
+  /// ExitBlock, guarded memory operations carry their guard as the recipe's
+  /// mask operand, and the early exit is the exit block left without
+  /// predecessors while the cascade is wired up.
+  struct CheckFirstEarlyExitState {
+    /// Block routing check-first early exits out of the vector loop. Its
+    /// presence also marks the plan as using the check-first strategy.
+    VPBasicBlock *ExitBlock = nullptr;
+
+    /// Whether the exiting chunk is replayed in vector form under a mask,
+    /// rather than being left to the scalar loop.
+    bool UsesMaskedReplay = false;
+
+    /// Stores that precede the exit condition in the original iteration and so
+    /// must also execute for the exiting lane during masked replay.
+    SmallPtrSet<const Instruction *, 4> InclusiveReplayStores;
+  };
+  CheckFirstEarlyExitState CheckFirst;
+
   /// Immutable list of VPIRBasicBlocks wrapping the exit blocks of the original
   /// scalar loop. Note that some exit blocks may be unreachable at the moment,
   /// e.g. if the scalar epilogue always executes.
@@ -4964,6 +4989,50 @@ public:
   VPBasicBlock *getScalarPreheader() const {
     return dyn_cast_or_null<VPBasicBlock>(
         getScalarHeader()->getSinglePredecessor());
+  }
+
+  /// Return the block routing check-first early exits out of the vector loop.
+  /// A non-null result means the plan uses check-first vectorization.
+  VPBasicBlock *getCheckFirstExitBlock() const { return CheckFirst.ExitBlock; }
+
+  void setCheckFirstExitBlock(VPBasicBlock *VPBB) {
+    assert((!CheckFirst.ExitBlock || CheckFirst.ExitBlock == VPBB) &&
+           "CheckFirstExitBlock already set");
+    CheckFirst.ExitBlock = VPBB;
+  }
+
+  /// Return the block holding the masked-replay recipes, which are placed in
+  /// the check-first exit block, or nullptr if the plan replays in the scalar
+  /// loop instead.
+  VPBasicBlock *getCheckFirstMaskedReplayBlock() const {
+    return CheckFirst.UsesMaskedReplay ? CheckFirst.ExitBlock : nullptr;
+  }
+
+  void setCheckFirstUsesMaskedReplay() { CheckFirst.UsesMaskedReplay = true; }
+
+  void addCheckFirstInclusiveReplayStore(const Instruction *I) {
+    CheckFirst.InclusiveReplayStores.insert(I);
+  }
+
+  bool isCheckFirstInclusiveReplayStore(const Instruction *I) const {
+    return CheckFirst.InclusiveReplayStores.contains(I);
+  }
+
+  /// Return the header of the check-first cascade, which is the entry of the
+  /// vector loop. Every cascade block branches to the check-first exit block
+  /// and only the header carries the canonical IV phi, so the header stays
+  /// identifiable once the loop region has been dissolved.
+  VPBasicBlock *getCheckFirstCheckHeaderBlock() const {
+    if (!CheckFirst.ExitBlock)
+      return nullptr;
+    if (const VPRegionBlock *R = getVectorLoopRegion())
+      return cast<VPBasicBlock>(const_cast<VPBlockBase *>(R->getEntry()));
+    for (VPBlockBase *Pred : CheckFirst.ExitBlock->getPredecessors()) {
+      auto *VPBB = cast<VPBasicBlock>(Pred);
+      if (!VPBB->empty() && isa<VPPhi>(&VPBB->front()))
+        return VPBB;
+    }
+    return nullptr;
   }
 
   /// Return the VPIRBasicBlock wrapping the header of the scalar loop.

--- a/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
@@ -462,13 +462,25 @@ static void createLoopRegion(VPlan &Plan, VPBlockBase *HeaderVPB, DebugLoc DL) {
   // Transfer latch's successors to the region.
   VPBlockUtils::transferSuccessors(LatchVPBB, R);
 
+  VPBasicBlock *CheckExitVPBB = Plan.getCheckFirstExitBlock();
+  if (CheckExitVPBB) {
+    assert(CheckExitVPBB->empty() &&
+           "check.exit block should be empty before region creation");
+    assert(CheckExitVPBB->getNumSuccessors() == 0 &&
+           "check.exit should have no successors before temporary edge");
+    VPBlockUtils::connectBlocks(CheckExitVPBB, LatchVPBB);
+  }
+
   VPBlockUtils::connectBlocks(PreheaderVPBB, R);
   R->setEntry(HeaderVPB);
   R->setExiting(LatchVPBB);
 
   // All VPBB's reachable shallowly from HeaderVPB belong to the current region.
-  for (VPBlockBase *VPBB : vp_depth_first_shallow(HeaderVPB))
+  for (VPBlockBase *VPBB : vp_depth_first_shallow(HeaderVPB)) {
+    if (VPBB == Plan.getScalarPreheader())
+      continue;
     VPBB->setParent(R);
+  }
 
   if (!IsOutermost)
     return;
@@ -1302,7 +1314,8 @@ void VPlanTransforms::createLoopRegions(VPlan &Plan, DebugLoc DL) {
 
   VPRegionBlock *TopRegion = Plan.getVectorLoopRegion();
   TopRegion->setName("vector loop");
-  TopRegion->getEntryBasicBlock()->setName("vector.body");
+  TopRegion->getEntryBasicBlock()->setName(
+      Plan.getCheckFirstExitBlock() ? "vector.check" : "vector.body");
 }
 
 void VPlanTransforms::foldTailByMasking(VPlan &Plan) {

--- a/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
@@ -398,6 +398,8 @@ void VPlanTransforms::introduceMasksAndLinearize(VPlan &Plan) {
   // Nested loop regions (outer-loop vectorization) are not supported yet.
   if (Plan.isOuterLoop())
     return;
+  if (Plan.getCheckFirstExitBlock())
+    return;
   VPRegionBlock *LoopRegion = Plan.getVectorLoopRegion();
   // Scan the body of the loop in a topological order to visit each basic block
   // after having visited its predecessor basic blocks.

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -96,6 +96,7 @@ bool VPRecipeBase::mayWriteToMemory() const {
   case VPBlendSC:
   case VPReductionEVLSC:
   case VPReductionSC:
+  case VPVectorEndPointerSC:
   case VPVectorPointerSC:
   case VPWidenCanonicalIVSC:
   case VPWidenCastSC:
@@ -151,6 +152,7 @@ bool VPRecipeBase::mayReadFromMemory() const {
   case VPBlendSC:
   case VPReductionEVLSC:
   case VPReductionSC:
+  case VPVectorEndPointerSC:
   case VPVectorPointerSC:
   case VPWidenCanonicalIVSC:
   case VPWidenCastSC:
@@ -875,9 +877,13 @@ Value *VPInstruction::generate(VPTransformState &State) {
         cast<VPBasicBlock>(getParent()->getSuccessors()[1]);
     BasicBlock *SecondIRSucc = State.CFG.VPBB2IRBB.lookup(SecondVPSucc);
     BasicBlock *IRBB = State.CFG.VPBB2IRBB[getParent()];
-    auto *Br = Builder.CreateCondBr(Cond, IRBB, SecondIRSucc);
+    // Placeholder for a successor. Assigned in connectToPredecessors.
+    auto *Br =
+        Builder.CreateCondBr(Cond, IRBB, SecondIRSucc ? SecondIRSucc : IRBB);
     // First successor is always forward, reset it to nullptr.
     Br->setSuccessor(0, nullptr);
+    if (!SecondIRSucc)
+      Br->setSuccessor(1, nullptr);
     IRBB->getTerminator()->eraseFromParent();
     applyMetadata(*Br);
     return Br;
@@ -1572,6 +1578,11 @@ void VPInstruction::addOperand(VPValue *Op) {
            "matching operand 1's type and i1, respectively");
     break;
   }
+  case Instruction::PHI:
+    assert((getNumOperands() == 0 ||
+            Ty == getOperand(0)->getScalarType()) &&
+           "all incoming values must have the same type");
+    break;
   default:
     llvm_unreachable("opcode does not support growing the operand list "
                      "outside of construction");

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -3203,7 +3203,8 @@ bool VPlanTransforms::handleUncountableEarlyExits(
 
   // Dereferenceability is checked separately for uncountable exit loops with
   // stores, as only the loads contributing to the exit condition need to
-  // be checked.
+  // be checked. ReadOnly needs all loads dereferenceable, whereas CheckFirst
+  // checks only condition-slice loads below.
   if (Style == UncountableExitStyle::ReadOnly &&
       !areAllLoadsDereferenceable(HeaderVPBB, TheLoop, PSE, DT, AC))
     return false;

--- a/llvm/lib/Transforms/Vectorize/VPlanVerifier.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanVerifier.cpp
@@ -310,6 +310,12 @@ bool VPlanVerifier::verifyVPBasicBlock(const VPBasicBlock *VPBB) {
           continue;
         }
 
+        if (VPBasicBlock *CheckExit =
+                VPBB->getPlan()->getCheckFirstExitBlock()) {
+          if (is_contained(CheckExit->getPredecessors(), VPBB))
+            continue;
+        }
+
         errs() << "Use before def!\n";
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
         VPSlotTracker Tracker(VPBB->getPlan());


### PR DESCRIPTION
Adds the VPlan state and APIs required by check-first vectorization of loops with multiple uncountable early exits.