### PR TITLE
[clang-tidy] Handle auto&& in missing-std-forward

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/MissingStdForwardCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/MissingStdForwardCheck.cpp
@@ -28,9 +28,7 @@ AST_MATCHER_P(QualType, possiblyPackExpansionOf,
 AST_MATCHER(ParmVarDecl, isTemplateTypeParameter) {
   const ast_matchers::internal::Matcher<QualType> Inner =
       possiblyPackExpansionOf(
-          qualType(rValueReferenceType(),
-                   references(templateTypeParmType(
-                       hasDeclaration(templateTypeParmDecl()))),
+          qualType(rValueReferenceType(), references(templateTypeParmType()),
                    unless(references(qualType(isConstQualified())))));
   if (!Inner.matches(Node.getType(), Finder, Builder))
     return false;

--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -148,6 +148,10 @@ infrastructure are described first, followed by tool-specific sections.
 - Improved {doc}`cppcoreguidelines-use-enum-class
   <clang-tidy/checks/cppcoreguidelines/use-enum-class>` check by omitting unnamed enums from the `enum class` requirement, as previously the check suggested users an ill-formed fix.
 
+- Improved {doc}`cppcoreguidelines-missing-std-forward
+  <clang-tidy/checks/cppcoreguidelines/missing-std-forward>` check by diagnosing
+  unforwarded `auto&&` parameters in C++20 abbreviated function templates.
+
 - Improved {doc}`misc-const-correctness
   <clang-tidy/checks/misc/const-correctness>` check:
 

--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -141,16 +141,16 @@ infrastructure are described first, followed by tool-specific sections.
   <clang-tidy/checks/bugprone/std-namespace-modification>` when checking
   lambda closure types used as template arguments.
 
+- Improved {doc}`cppcoreguidelines-missing-std-forward
+  <clang-tidy/checks/cppcoreguidelines/missing-std-forward>` check by diagnosing
+  unforwarded `auto&&` parameters in C++20 abbreviated function templates.
+
 - Improved {doc}`cppcoreguidelines-pro-type-member-init
   <clang-tidy/checks/cppcoreguidelines/pro-type-member-init>` check by treating
   `std::array` the same as built-in arrays when `IgnoreArrays` option is enabled.
   
 - Improved {doc}`cppcoreguidelines-use-enum-class
   <clang-tidy/checks/cppcoreguidelines/use-enum-class>` check by omitting unnamed enums from the `enum class` requirement, as previously the check suggested users an ill-formed fix.
-
-- Improved {doc}`cppcoreguidelines-missing-std-forward
-  <clang-tidy/checks/cppcoreguidelines/missing-std-forward>` check by diagnosing
-  unforwarded `auto&&` parameters in C++20 abbreviated function templates.
 
 - Improved {doc}`misc-const-correctness
   <clang-tidy/checks/misc/const-correctness>` check:

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward-cxx20.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward-cxx20.cpp
@@ -1,0 +1,24 @@
+// RUN: %check_clang_tidy -std=c++20-or-later %s cppcoreguidelines-missing-std-forward %t -- -- -fno-delayed-template-parsing
+
+#include <utility>
+
+void does_not_forward_auto(auto &&t) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: forwarding reference parameter 't' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
+  (void)t;
+}
+
+void does_forward_auto(auto &&t) {
+  (void)std::forward<decltype(t)>(t);
+}
+
+void const_auto_rvalue_reference(const auto &&t) {
+  (void)t;
+}
+
+template <typename T>
+void mixed_parameters(T &&t, auto &&u) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: forwarding reference parameter 't' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
+  // CHECK-MESSAGES: :[[@LINE-2]]:37: warning: forwarding reference parameter 'u' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
+  (void)t;
+  (void)u;
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward-cxx20.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward-cxx20.cpp
@@ -3,7 +3,7 @@
 #include <utility>
 
 void does_not_forward_auto(auto &&t) {
-  // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: forwarding reference parameter 't' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
+  // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: forwarding reference parameter 't' is never forwarded inside the function body
   (void)t;
 }
 
@@ -17,8 +17,8 @@ void const_auto_rvalue_reference(const auto &&t) {
 
 template <typename T>
 void mixed_parameters(T &&t, auto &&u) {
-  // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: forwarding reference parameter 't' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
-  // CHECK-MESSAGES: :[[@LINE-2]]:37: warning: forwarding reference parameter 'u' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
+  // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: forwarding reference parameter 't' is never forwarded inside the function body
+  // CHECK-MESSAGES: :[[@LINE-2]]:37: warning: forwarding reference parameter 'u' is never forwarded inside the function body
   (void)t;
   (void)u;
 }


### PR DESCRIPTION
Fixes #142660.

`cppcoreguidelines-missing-std-forward` did not diagnose unforwarded `auto&&` parameters in C++20 abbreviated function templates, even though equivalent explicitly declared `T&&` parameters were diagnosed.

Abbreviated function templates represent `auto` parameters using an implicit `TemplateTypeParmDecl`. The existing `hasDeclaration(templateTypeParmDecl())` matcher does not match this implicit declaration when traversal ignores implicit nodes.

Remove the redundant declaration matcher so that these parameters are handled by the existing template type parameter checks.

Add C++20 regression tests covering:
- unforwarded `auto&&`
- correctly forwarded `auto&&`
- `const auto&&`
- mixed `T&&` and `auto&&` parameters