### PR TITLE
[compiler-rt] Restrict __gnu_h2f_ieee and __gnu_f2h_ieee to arm32 EABI

### DIFF
--- a/compiler-rt/lib/builtins/extendhfsf2.c
+++ b/compiler-rt/lib/builtins/extendhfsf2.c
@@ -16,13 +16,13 @@ COMPILER_RT_ABI NOINLINE float __extendhfsf2(src_t a) {
   return __extendXfYf2__(a);
 }
 
+#if defined(__ARM_EABI__)
 // arm32-gnueabi-only routine that uses integers in the signature. This should
 // be gnueabi-specific, but LLVM currently emits it on more eabi platforms.
 COMPILER_RT_ABI uint32_t __gnu_h2f_ieee(uint16_t a) {
   return dstToRep(__extendhfsf2(srcFromRep(a)));
 }
 
-#if defined(__ARM_EABI__)
 #if defined(COMPILER_RT_ARMHF_TARGET)
 AEABI_RTABI float __aeabi_h2f(src_t a) { return __extendhfsf2(a); }
 #else

--- a/compiler-rt/lib/builtins/extendhfsf2.c
+++ b/compiler-rt/lib/builtins/extendhfsf2.c
@@ -16,14 +16,16 @@ COMPILER_RT_ABI NOINLINE float __extendhfsf2(src_t a) {
   return __extendXfYf2__(a);
 }
 
+// arm32-gnueabi-only routine that uses integers in the signature. This should
+// be gnueabi-specific, but LLVM currently emits it on more eabi platforms.
+COMPILER_RT_ABI uint32_t __gnu_h2f_ieee(uint16_t a) {
+  return dstToRep(__extendhfsf2(srcFromRep(a)));
+}
+
 #if defined(__ARM_EABI__)
 #if defined(COMPILER_RT_ARMHF_TARGET)
-AEABI_RTABI float __gnu_h2f_ieee(src_t a) { return __extendhfsf2(a); }
 AEABI_RTABI float __aeabi_h2f(src_t a) { return __extendhfsf2(a); }
 #else
-COMPILER_RT_ALIAS(__extendhfsf2, __gnu_h2f_ieee)
 COMPILER_RT_ALIAS(__extendhfsf2, __aeabi_h2f)
 #endif
-#else
-COMPILER_RT_ABI float __gnu_h2f_ieee(src_t a) { return __extendhfsf2(a); }
 #endif

--- a/compiler-rt/lib/builtins/fp_extend.h
+++ b/compiler-rt/lib/builtins/fp_extend.h
@@ -157,13 +157,29 @@ static inline dst_rep_t construct_dst_rep(dst_rep_t sign, dst_rep_t exp, dst_rep
   return (sign << (dstBits - 1)) | (exp << (dstBits - 1 - dstExpBits)) | sigFrac;
 }
 
-// Two helper routines for conversion to and from the representation of
+// Helper routines for conversion to and from the representation of
 // floating-point data as integer values follow.
 
 static inline src_rep_t srcToRep(src_t x) {
   const union {
     src_t f;
     src_rep_t i;
+  } rep = {.f = x};
+  return rep.i;
+}
+
+static inline src_t srcFromRep(src_rep_t x) {
+  const union {
+    src_t f;
+    src_rep_t i;
+  } rep = {.i = x};
+  return rep.f;
+}
+
+static inline dst_rep_t dstToRep(dst_t x) {
+  const union {
+    dst_t f;
+    dst_rep_t i;
   } rep = {.f = x};
   return rep.i;
 }

--- a/compiler-rt/lib/builtins/fp_trunc.h
+++ b/compiler-rt/lib/builtins/fp_trunc.h
@@ -148,13 +148,29 @@ static inline dst_rep_t construct_dst_rep(dst_rep_t sign, dst_rep_t exp, dst_rep
   return result;
 }
 
-// End of specialization parameters.  Two helper routines for conversion to and
+// End of specialization parameters.  Helper routines for conversion to and
 // from the representation of floating-point data as integer values follow.
 
 static inline src_rep_t srcToRep(src_t x) {
   const union {
     src_t f;
     src_rep_t i;
+  } rep = {.f = x};
+  return rep.i;
+}
+
+static inline src_t srcFromRep(src_rep_t x) {
+  const union {
+    src_t f;
+    src_rep_t i;
+  } rep = {.i = x};
+  return rep.f;
+}
+
+static inline dst_rep_t dstToRep(dst_t x) {
+  const union {
+    dst_t f;
+    dst_rep_t i;
   } rep = {.f = x};
   return rep.i;
 }

--- a/compiler-rt/lib/builtins/truncsfhf2.c
+++ b/compiler-rt/lib/builtins/truncsfhf2.c
@@ -16,14 +16,16 @@ COMPILER_RT_ABI NOINLINE dst_t __truncsfhf2(float a) {
   return __truncXfYf2__(a);
 }
 
+// arm32-gnueabi-only routine that uses integers in the signature. This should
+// be gnueabi-specific, but LLVM currently emits it on more eabi platforms.
+COMPILER_RT_ABI uint16_t __gnu_f2h_ieee(uint32_t a) {
+  return dstToRep(__truncsfhf2(srcFromRep(a)));
+}
+
 #if defined(__ARM_EABI__)
 #if defined(COMPILER_RT_ARMHF_TARGET)
-AEABI_RTABI dst_t __gnu_f2h_ieee(float a) { return __truncsfhf2(a); }
 AEABI_RTABI dst_t __aeabi_f2h(float a) { return __truncsfhf2(a); }
 #else
-COMPILER_RT_ALIAS(__truncsfhf2, __gnu_f2h_ieee)
 COMPILER_RT_ALIAS(__truncsfhf2, __aeabi_f2h)
 #endif
-#else
-COMPILER_RT_ABI dst_t __gnu_f2h_ieee(float a) { return __truncsfhf2(a); }
 #endif

--- a/compiler-rt/lib/builtins/truncsfhf2.c
+++ b/compiler-rt/lib/builtins/truncsfhf2.c
@@ -16,13 +16,13 @@ COMPILER_RT_ABI NOINLINE dst_t __truncsfhf2(float a) {
   return __truncXfYf2__(a);
 }
 
+#if defined(__ARM_EABI__)
 // arm32-gnueabi-only routine that uses integers in the signature. This should
 // be gnueabi-specific, but LLVM currently emits it on more eabi platforms.
 COMPILER_RT_ABI uint16_t __gnu_f2h_ieee(uint32_t a) {
   return dstToRep(__truncsfhf2(srcFromRep(a)));
 }
 
-#if defined(__ARM_EABI__)
 #if defined(COMPILER_RT_ARMHF_TARGET)
 AEABI_RTABI dst_t __aeabi_f2h(float a) { return __truncsfhf2(a); }
 #else

--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -2608,6 +2608,10 @@ def isNotMachOAndNotTargetAEABI
     : RuntimeLibcallAvailability<(all_of (not IsOSBinFormatMachO),
                                             (not IsTargetAEABI))>;
 
+// Note that these actually pass and return int and short rather than float and
+// _Float16. This happens to work with the AAPCS calling convention where they
+// are treated equally, but may not work on other platforms. __extendhfsf2 and
+// __truncsfhf2 should be used anyway on non-GNUEABIHF targets.
 def GNUEABIHalfConvertCalls :
   LibcallImpls<(add __gnu_f2h_ieee, __gnu_h2f_ieee),
     isNotMachOAndNotTargetAEABI> {


### PR DESCRIPTION
These routines are specific to gnueabi on arm32, so should not be used on other platforms. LLVM used to emit these on more platforms but this has not been the case since cc539138acf7 ("[CodeGen] Use __extendhfsf2 and __truncsfhf2 by default (#126880)"). As they are no longer needed, restrict them to 32-bit Arm with EABI, which matches libgcc.

They cannot be further restricted beacuse LLVM still uses them on arm32-eabi targets where an environment is not specified, such as `armv7-unknown-freebsd`.