### PR TITLE
[LoopVectorize] Clear stale CycleAnalysis where BlockFrequencyInfo is requested

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/LoopVectorize.h
+++ b/llvm/include/llvm/Transforms/Vectorize/LoopVectorize.h
@@ -153,7 +153,8 @@ public:
   OptimizationRemarkEmitter *ORE;
   ProfileSummaryInfo *PSI;
   AAResults *AA;
-  FunctionAnalysisManager *FAM = nullptr;
+
+  bool CFGChanged = false;
 
   LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
   LLVM_ABI void

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -8366,6 +8366,7 @@ bool LoopVectorizePass::processLoop(Loop *L) {
 }
 
 LoopVectorizeResult LoopVectorizePass::runImpl(Function &F) {
+  CFGChanged = false;
 
   // Don't attempt if
   // 1. the target claims to have no vector registers, and
@@ -8379,7 +8380,7 @@ LoopVectorizeResult LoopVectorizePass::runImpl(Function &F) {
        TTI->getMaxInterleaveFactor(ElementCount::getFixed(1), true) < 2))
     return LoopVectorizeResult(false, false);
 
-  bool Changed = false, CFGChanged = false;
+  bool Changed = false;
 
   // The vectorizer requires loops to be in simplified form.
   // Since simplification may add new inner loops, it has to run before the
@@ -8412,13 +8413,6 @@ LoopVectorizeResult LoopVectorizePass::runImpl(Function &F) {
 
     if (Changed) {
       LAIs->clear();
-
-      // If CycleAnalysis was cached by a prior pass (e.g. DSE), it now holds
-      // stale pointers to blocks that may have been deleted during
-      // vectorization. Clear it so that BlockFrequencyAnalysis (if requested
-      // for a later loop) recomputes it fresh.
-      if (FAM->getCachedResult<CycleAnalysis>(F))
-        FAM->clearAnalysis<CycleAnalysis>(F);
 
 #ifndef NDEBUG
       if (VerifySCEV)
@@ -8455,8 +8449,10 @@ PreservedAnalyses LoopVectorizePass::run(Function &F,
 
   auto &MAMProxy = AM.getResult<ModuleAnalysisManagerFunctionProxy>(F);
   PSI = MAMProxy.getCachedResult<ProfileSummaryAnalysis>(*F.getParent());
-  FAM = &AM;
-  GetBFI = [&AM, &F]() -> BlockFrequencyInfo & {
+  GetBFI = [this, &AM, &F]() -> BlockFrequencyInfo & {
+    // CycleInfo cached by an earlier pass is invalidated when the CFG changes.
+    if (CFGChanged && AM.getCachedResult<CycleAnalysis>(F))
+      AM.clearAnalysis<CycleAnalysis>(F);
     return AM.getResult<BlockFrequencyAnalysis>(F);
   };
   LoopVectorizeResult Result = runImpl(F);

--- a/llvm/test/Transforms/LoopVectorize/bfi-stale-crash-loop-simplify.ll
+++ b/llvm/test/Transforms/LoopVectorize/bfi-stale-crash-loop-simplify.ll
@@ -1,0 +1,35 @@
+; RUN: opt < %s -passes='require<cycles>,loop-vectorize,print<block-freq>' -disable-output 2>&1 | FileCheck %s
+
+;; Loop simplification changes the CFG before LoopVectorize lazily requests
+;; BlockFrequencyInfo, so the CycleInfo cached by require<cycles> must not be
+;; reused. %second.preheader and %second.backedge exist only after
+;; simplification, so the frequencies below describe the simplified CFG.
+
+; CHECK-LABEL: block-frequency-info: f
+; CHECK-NEXT:  - entry: float = 1.0,
+; CHECK-NEXT:  - latch: float = 32.0,
+; CHECK-NEXT:  - second.preheader: float = 1.0,
+; CHECK-NEXT:  - header: float = 32.0,
+; CHECK-NEXT:  - trap: float = 0.000000014901,
+; CHECK-NEXT:  - second: float = 4096.0,
+; CHECK-NEXT:  - second.backedge: float = 4096.0,
+
+define i16 @f(i1 %c) {
+entry:
+  br label %header
+
+latch:
+  %iv.next = add i16 %iv, 1
+  %done = icmp eq i16 %iv.next, 0
+  br i1 %done, label %second, label %header
+
+header:
+  %iv = phi i16 [ 0, %entry ], [ %iv.next, %latch ]
+  br i1 %c, label %trap, label %latch
+
+trap:
+  unreachable
+
+second:
+  br i1 false, label %second, label %second
+}


### PR DESCRIPTION
The cost model requests BlockFrequencyInfo lazily, after runImpl has
simplified loops and possibly vectorized some of them. A CycleInfo cached by
an earlier pass then describes the original CFG, and BlockFrequencyInfo
asserts `Resolved >= Pred && "unhandled irreducible control flow"'.

Clear it at the request site, gated on the CFGChanged flag the pass already
uses to decide whether CFGAnalyses are preserved. This covers loop
simplification, which runs before the first loop is processed.

Fixes #218392, exposed by BlockFrequencyInfo migrating to CycleAnalysis.

Aided by Opus 5
