### PR TITLE
[Analysis] Remove dead declarations in AliasAnalysis and AliasSetTracker (NFC)

### DIFF
--- a/llvm/include/llvm/Analysis/AliasAnalysis.h
+++ b/llvm/include/llvm/Analysis/AliasAnalysis.h
@@ -456,21 +456,6 @@ public:
     return getMemoryEffects(Call).doesNotAccessMemory();
   }
 
-  /// Checks if the specified function is known to never read or write memory.
-  ///
-  /// Note that if the function only reads from known-constant memory, it is
-  /// also legal to return true. Also, function that unwind the stack are legal
-  /// for this predicate.
-  ///
-  /// Many optimizations (such as CSE and LICM) can be performed on such calls
-  /// to such functions without worrying about aliasing properties, and many
-  /// functions have this property (e.g. 'sin' and 'cos').
-  ///
-  /// This property corresponds to the GCC 'const' attribute.
-  bool doesNotAccessMemory(const Function *F) {
-    return getMemoryEffects(F).doesNotAccessMemory();
-  }
-
   /// Checks if the specified call is known to only read from non-volatile
   /// memory (or not access memory at all).
   ///
@@ -482,19 +467,6 @@ public:
   /// This property corresponds to the GCC 'pure' attribute.
   bool onlyReadsMemory(const CallBase *Call) {
     return getMemoryEffects(Call).onlyReadsMemory();
-  }
-
-  /// Checks if the specified function is known to only read from non-volatile
-  /// memory (or not access memory at all).
-  ///
-  /// Functions that unwind the stack are legal for this predicate.
-  ///
-  /// This property allows many common optimizations to be performed in the
-  /// absence of interfering store instructions, such as CSE of strlen calls.
-  ///
-  /// This property corresponds to the GCC 'pure' attribute.
-  bool onlyReadsMemory(const Function *F) {
-    return getMemoryEffects(F).onlyReadsMemory();
   }
 
   /// Check whether or not an instruction may read or write the optionally
@@ -538,12 +510,6 @@ public:
     return callCapturesBefore(I, MemLoc, DT, AAQIP);
   }
 
-  /// A convenience wrapper to synthesize a memory location.
-  ModRefInfo callCapturesBefore(const Instruction *I, const Value *P,
-                                LocationSize Size, DominatorTree *DT) {
-    return callCapturesBefore(I, MemoryLocation(P, Size), DT);
-  }
-
   /// @}
   //===--------------------------------------------------------------------===//
   /// \name Higher level methods for querying mod/ref information.
@@ -554,12 +520,6 @@ public:
   LLVM_ABI bool canBasicBlockModify(const BasicBlock &BB,
                                     const MemoryLocation &Loc);
 
-  /// A convenience wrapper synthesizing a memory location.
-  bool canBasicBlockModify(const BasicBlock &BB, const Value *P,
-                           LocationSize Size) {
-    return canBasicBlockModify(BB, MemoryLocation(P, Size));
-  }
-
   /// Check if it is possible for the execution of the specified instructions
   /// to mod\ref (according to the mode) the location Loc.
   ///
@@ -569,13 +529,6 @@ public:
                                           const Instruction &I2,
                                           const MemoryLocation &Loc,
                                           const ModRefInfo Mode);
-
-  /// A convenience wrapper synthesizing a memory location.
-  bool canInstructionRangeModRef(const Instruction &I1, const Instruction &I2,
-                                 const Value *Ptr, LocationSize Size,
-                                 const ModRefInfo Mode) {
-    return canInstructionRangeModRef(I1, I2, MemoryLocation(Ptr, Size), Mode);
-  }
 
   // CtxI can be nullptr, in which case the query is whether or not the aliasing
   // relationship holds through the entire function.

--- a/llvm/include/llvm/Analysis/AliasSetTracker.h
+++ b/llvm/include/llvm/Analysis/AliasSetTracker.h
@@ -185,8 +185,6 @@ public:
   LLVM_ABI void
   add(Instruction *I); // Dispatch to one of the other add methods...
   LLVM_ABI void add(BasicBlock &BB); // Add all instructions in basic block
-  LLVM_ABI void
-  add(const AliasSetTracker &AST); // Add alias relations from another AST
   LLVM_ABI void addUnknown(Instruction *I);
 
   LLVM_ABI void clear();

--- a/llvm/lib/Analysis/AliasSetTracker.cpp
+++ b/llvm/lib/Analysis/AliasSetTracker.cpp
@@ -426,27 +426,6 @@ void AliasSetTracker::add(BasicBlock &BB) {
     add(&I);
 }
 
-void AliasSetTracker::add(const AliasSetTracker &AST) {
-  assert(&AA == &AST.AA &&
-         "Merging AliasSetTracker objects with different Alias Analyses!");
-
-  // Loop over all of the alias sets in AST, adding the members contained
-  // therein into the current alias sets.  This can cause alias sets to be
-  // merged together in the current AST.
-  for (const AliasSet &AS : AST) {
-    if (AS.Forward)
-      continue; // Ignore forwarding alias sets
-
-    // If there are any call sites in the alias set, add them to this AST.
-    for (Instruction *Inst : AS.UnknownInsts)
-      add(Inst);
-
-    // Loop over all of the memory locations in this alias set.
-    for (const MemoryLocation &ASMemLoc : AS.MemoryLocs)
-      addMemoryLocation(ASMemLoc, AS.Access);
-  }
-}
-
 AliasSet &AliasSetTracker::mergeAllAliasSets() {
   assert(!AliasAnyAS && (TotalAliasSetSize > SaturationThreshold) &&
          "Full merge should happen once, when the saturation threshold is "


### PR DESCRIPTION
AAResults::doesNotAccessMemory(const Function *),
AAResults::onlyReadsMemory(const Function *): The last callers were
removed on December 15, 2004 in commits b17f3e13ec7a and 71d04bce5509
when call sites were migrated to getModRefBehavior (later renamed to
getMemoryEffects).

AAResults::canBasicBlockModify(..., const Value *): Added on
September 14, 2010 in commit 41f14cf3e981ca1eb39d087d4c567098ee56514d
without any callers.

AAResults::callCapturesBefore(..., const Value *): Added on May 14, 2012
in commit a968caf8e024c51cb90872fef60cd529043e25d0 without any callers.

AAResults::canInstructionRangeModRef(..., const Value *): Added on
December 15, 2014 in commit a5599bfd7215e6ded1aad312c192f906d473877a
without any callers.

AliasSetTracker::add(const AliasSetTracker &): Added on March 3, 2003 in
commit c048bb3addb47b8a9b01eb756ce5060db3ee6585 without any callers.

Assisted-by: Antigravity
