### PR TITLE
[orc-rt] Move connection state and teardown to SimpleRemoteCA

### DIFF
--- a/orc-rt/include/orc-rt/bedrock/sps/SimpleRemoteCA.h
+++ b/orc-rt/include/orc-rt/bedrock/sps/SimpleRemoteCA.h
@@ -20,6 +20,7 @@
 #include "orc-rt/support/WrapperFunction.h"
 
 #include <mutex>
+#include <optional>
 #include <unordered_map>
 
 namespace orc_rt {
@@ -27,12 +28,21 @@ namespace orc_rt {
 /// ControllerAccess base for the SimpleRemote protocol.
 ///
 /// Implements the protocol semantics -- setup and hang-up message encoding,
-/// message dispatch and validation, pending-call tracking, and completion of
-/// controller calls -- while leaving all wire framing and byte transport,
-/// including sending, to subclasses. Subclasses feed received messages to
-/// handleMessage and build outgoing ones from the Opcode set,
-/// encodeSetupMessage and encodeHangupPayload.
+/// message dispatch and validation, pending-call tracking, connection state and
+/// teardown sequencing -- while leaving wire framing and byte transport to
+/// subclasses. Subclasses feed received messages to handleMessage and implement
+/// two hooks, sendMessage and beginTeardown.
 class SimpleRemoteCA : public Session::ControllerAccess {
+public:
+  void disconnect() final;
+
+  void callController(OnControllerCallReturn OnComplete,
+                      orc_rt_ControllerHandlerTag T,
+                      WrapperFunctionBuffer ArgBytes) final;
+
+  void sendWrapperResult(WrapperFunctionBuffer ResultBytes,
+                         uint64_t CallId) final;
+
 protected:
   /// SimpleRemote message opcodes.
   ///
@@ -44,63 +54,100 @@ protected:
   /// has hung up and the session should end.
   enum class Action { Continue, End };
 
-  /// Returns a display name for Op, for logging.
   static const char *getOpcodeName(Opcode Op) noexcept;
 
   SimpleRemoteCA(Session &S) : ControllerAccess(S) {}
-
-  /// Serializes a setup message from BI and returns its payload. Subclasses
-  /// send this as the first message during connect -- an Opcode::Setup message
-  /// with no sequence number or handler tag.
-  static WrapperFunctionBuffer encodeSetupMessage(const BootstrapInfo &BI);
 
   /// Serializes Err as the payload of a hang-up message.
   ///
   /// A hang-up always carries a serialized Error saying why the session is
   /// ending: a success value for an orderly disconnect, otherwise the reason.
-  /// handleMessage decodes an incoming hang-up through the matching code, so
-  /// the two directions cannot drift apart.
   static WrapperFunctionBuffer encodeHangupPayload(Error Err);
+
+  /// Starts accepting controller calls and sends the setup message. Subclasses
+  /// call this from connect once the transport can carry messages.
+  ///
+  /// Safe to call whether or not the transport has started receiving. A
+  /// transport that has already dropped out and finished teardown gets a no-op:
+  /// the Session has been notified, and no setup is sent.
+  void beginAccepting(const BootstrapInfo &BI);
+
+  /// Completes teardown: drains pending calls, then notifies the Session
+  /// exactly once. Subclasses call this when the transport is finished, however
+  /// teardown began.
+  ///
+  /// Call it exactly once.
+  ///
+  /// Err is the disconnection mode: success for an orderly hang-up from either
+  /// side, otherwise what went wrong. May synchronously destroy *this, so
+  /// nothing may touch it afterwards.
+  void finishTeardown(Error Err);
 
   /// Dispatches a received message. Transports call this once per message,
   /// after de-framing. OpC is the raw wire opcode: this validates it and the
   /// per-opcode header semantics. Transports are responsible only for verifying
   /// that the payload deserializes as the message requires.
   ///
-  /// Every error returned here is terminal for the session: report it via
-  /// notifyDisconnected (as for Action::End, but with the error as the
-  /// disconnection reason) rather than continuing to read.
+  /// Every error returned here is terminal for the session: shut the transport
+  /// down and pass the error to finishTeardown, rather than continuing to read.
+  /// Action::End means the controller hung up cleanly -- shut down and pass
+  /// Error::success().
   ///
   /// Calls may come from any thread, but must be serialized with one another
-  /// and must all complete before failAllPendingCalls: the Result path
-  /// completes a pending call, which is only legal while the managed-code group
-  /// is still open. One racing teardown may hit that assertion, or touch a
-  /// *this that notifyDisconnected has already destroyed.
+  /// and must all complete before finishTeardown: the Result path completes a
+  /// pending call, which is only legal while the managed-code group is still
+  /// open.
   Expected<Action> handleMessage(uint64_t OpC, uint64_t SeqNo, ExecutorAddr Tag,
                                  WrapperFunctionBuffer Payload);
 
-  /// Records OnComplete as awaiting a result and returns the sequence number to
-  /// send the call under. The result is delivered when a matching Result
-  /// message arrives (handleMessage), or the call is failed (see below).
+  /// Hands a framed message to the transport. Called with no lock held, so
+  /// framing or packaging happens off the critical section.
   ///
-  /// SimpleRemoteCA tracks no connection state, so it cannot reject a call
-  /// registered after failAllPendingCalls has run: such a call is never
-  /// drained, and its handler is silently dropped, leaving the caller awaiting
-  /// a result that can no longer arrive. Subclasses must therefore make their
-  /// disconnecting check and this registration atomic with respect to the drain
-  /// -- e.g. both under the lock that publishes the disconnecting state (see
-  /// Session::ControllerAccess::callController).
-  uint64_t registerPendingCall(OnControllerCallReturn OnComplete);
+  /// Best-effort: a transport that has gone away should drop the message rather
+  /// than report anything. A Call's handler is failed by the drain, and a
+  /// Result has no pending call on this side, so nothing is left unsettled.
+  virtual void sendMessage(Opcode Op, uint64_t SeqNo,
+                           orc_rt_ControllerHandlerTag T,
+                           WrapperFunctionBuffer Payload) = 0;
 
-  /// Fails every pending call with a disconnect error -- the disconnect drain.
-  /// Call before notifyDisconnected, while the managed-code group is still open
-  /// (see Session::ControllerAccess::disconnect). Dispatched under a token.
-  void failAllPendingCalls();
+  /// Starts shutting the transport down. Must not block: teardown holds up
+  /// Session detach. Call finishTeardown once the transport is finished.
+  ///
+  /// Called only for a local disconnect, which is orderly by definition, so
+  /// make a best effort to send encodeHangupPayload(Error::success()) as the
+  /// last message before shutting down. Only the transport can place it last.
+  ///
+  /// Teardown the transport initiates instead -- a hang-up from the controller,
+  /// or an error out of handleMessage -- goes straight to finishTeardown,
+  /// having sent its own reason first if it has one.
+  virtual void beginTeardown() = 0;
 
 private:
+  /// Whether the connection will accept new controller calls, and how far
+  /// teardown has progressed. Guarded by M.
+  enum class State {
+    NotConnected, ///< Before beginAccepting, or connect failed.
+    Accepting,    ///< Calls may be registered.
+    TearingDown,  ///< Latched closed; the transport is shutting down.
+    Disconnected, ///< finishTeardown has run; the Session has been notified.
+  };
+
+  /// Registers OnComplete and returns the sequence number to send the call
+  /// under, or nullopt if the connection is no longer accepting calls -- in
+  /// which case OnComplete is untouched and the caller must fail it inline.
+  ///
+  /// The state check and the registration are one critical section, so a call
+  /// racing teardown is either drained by finishTeardown or failed inline:
+  /// never left pending with no result to come.
+  std::optional<uint64_t> tryRegisterCall(OnControllerCallReturn &OnComplete);
+
+  void failAllPendingCalls();
   Error handleResult(uint64_t SeqNo, WrapperFunctionBuffer ResultBytes);
 
+  static WrapperFunctionBuffer encodeSetupMessage(const BootstrapInfo &BI);
+
   std::mutex M;
+  State ConnState = State::NotConnected;
 
   // SeqNo zero is reserved for messages with no pending result (Setup, Hangup).
   uint64_t NextSeqNo = 1;

--- a/orc-rt/lib/bedrock/sps/SimpleRemoteCA.cpp
+++ b/orc-rt/lib/bedrock/sps/SimpleRemoteCA.cpp
@@ -15,9 +15,83 @@
 #include "orc-rt/support/Compiler.h"
 #include "orc-rt/support/sps/SimplePackedSerialization.h"
 
+#include <cassert>
 #include <string>
 
 namespace orc_rt {
+
+void SimpleRemoteCA::disconnect() {
+  {
+    std::scoped_lock<std::mutex> Lock(M);
+    // Not Accepting means teardown is already under way or finished, or the
+    // connection never opened. All are no-ops: the Session tolerates a
+    // disconnect racing a controller-initiated one.
+    if (ConnState != State::Accepting)
+      return;
+    ConnState = State::TearingDown;
+  }
+
+  // The transport sends the hang-up itself, so that it lands after the queue it
+  // is about to discard rather than behind a result that raced this.
+  beginTeardown();
+}
+
+void SimpleRemoteCA::callController(OnControllerCallReturn OnComplete,
+                                    orc_rt_ControllerHandlerTag T,
+                                    WrapperFunctionBuffer ArgBytes) {
+  // Sent outside tryRegisterCall's critical section, so framing and packaging
+  // stay off it. Safe because the Session holds a shared_ptr<ControllerAccess>
+  // across this call, so a teardown racing the send cannot destroy *this.
+  if (auto SeqNo = tryRegisterCall(OnComplete))
+    return sendMessage(Opcode::Call, *SeqNo, T, std::move(ArgBytes));
+
+  // The connection is gone, so no result can arrive. The caller is still on the
+  // stack, so fail the handler there.
+  failControllerCallInline(std::move(OnComplete));
+}
+
+void SimpleRemoteCA::sendWrapperResult(WrapperFunctionBuffer ResultBytes,
+                                       uint64_t CallId) {
+  // No state check: a result has no pending call on this side, so a transport
+  // that has gone away can drop it with nothing left unsettled.
+  sendMessage(Opcode::Result, CallId, nullptr, std::move(ResultBytes));
+}
+
+void SimpleRemoteCA::beginAccepting(const BootstrapInfo &BI) {
+  {
+    std::scoped_lock<std::mutex> Lock(M);
+    // A transport that enabled delivery before calling this can have dropped
+    // out and completed teardown already. The Session has been notified, so
+    // there is nothing left to accept on and nothing to send.
+    if (ConnState == State::Disconnected)
+      return;
+    assert(ConnState == State::NotConnected && "beginAccepting called twice");
+    ConnState = State::Accepting;
+  }
+
+  // State first: a teardown landing in the window then closes an accepting
+  // connection, where sending first would leave this to reopen one teardown had
+  // just closed. A call landing there registers instead of failing spuriously.
+  // Setup may reach a transport that has already gone, which drops it.
+  sendMessage(Opcode::Setup, 0, nullptr, encodeSetupMessage(BI));
+}
+
+void SimpleRemoteCA::finishTeardown(Error Err) {
+  {
+    std::scoped_lock<std::mutex> Lock(M);
+    // Transports owe exactly one call, and both natural implementations give
+    // it: a socket reactor on its way out, and XPC on the single invalidation
+    // event it guarantees.
+    assert(ConnState != State::Disconnected &&
+           "finishTeardown called more than once");
+    ConnState = State::Disconnected;
+  }
+
+  // The drain must precede the notification, while the keepalive group is still
+  // open, or the handlers are dropped rather than dispatched.
+  failAllPendingCalls();
+  notifyDisconnected(std::move(Err));
+}
 
 const char *SimpleRemoteCA::getOpcodeName(Opcode Op) noexcept {
   switch (Op) {
@@ -109,9 +183,11 @@ SimpleRemoteCA::handleMessage(uint64_t OpC, uint64_t SeqNo, ExecutorAddr Tag,
   ORC_RT_UNREACHABLE("Unrecognized opcode");
 }
 
-uint64_t
-SimpleRemoteCA::registerPendingCall(OnControllerCallReturn OnComplete) {
+std::optional<uint64_t>
+SimpleRemoteCA::tryRegisterCall(OnControllerCallReturn &OnComplete) {
   std::scoped_lock<std::mutex> Lock(M);
+  if (ConnState != State::Accepting)
+    return std::nullopt;
   PendingCalls.try_emplace(NextSeqNo, std::move(OnComplete));
   return NextSeqNo++;
 }

--- a/orc-rt/test/unit/bedrock/sps/SimpleRemoteCATest.cpp
+++ b/orc-rt/test/unit/bedrock/sps/SimpleRemoteCATest.cpp
@@ -22,6 +22,7 @@
 
 #include "orc-rt/support/sps/SimplePackedSerialization.h"
 
+#include <deque>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -33,42 +34,81 @@ using namespace orc_rt;
 namespace {
 
 // A SimpleRemoteCA with no real transport. It exposes the protected protocol
-// operations for tests, records outgoing controller calls as pending results,
-// and records the wrapper results the executor produces.
+// operations for tests, records every message the base asks it to send, and
+// completes teardown as soon as the base begins it -- the shortest thing a real
+// transport could do.
 class TestSimpleRemoteCA : public SimpleRemoteCA {
 public:
-  TestSimpleRemoteCA(Session &S, TestSimpleRemoteCA **Self = nullptr)
-      : SimpleRemoteCA(S) {
+  using SimpleRemoteCA::Action;
+  using SimpleRemoteCA::encodeHangupPayload;
+  using SimpleRemoteCA::finishTeardown;
+  using SimpleRemoteCA::handleMessage;
+  using SimpleRemoteCA::Opcode;
+
+  // A message the base handed to the transport.
+  struct Sent {
+    Opcode Op;
+    uint64_t SeqNo;
+    orc_rt_ControllerHandlerTag Tag;
+    WrapperFunctionBuffer Payload;
+  };
+
+  /// Messages is owned by the caller so that it outlives a CA that teardown
+  /// destroys.
+  TestSimpleRemoteCA(Session &S, std::deque<Sent> &Messages,
+                     TestSimpleRemoteCA **Self = nullptr,
+                     bool DropOutDuringConnect = false)
+      : SimpleRemoteCA(S), Messages(Messages),
+        DropOutDuringConnect(DropOutDuringConnect) {
     if (Self)
       *Self = this;
   }
 
-  using SimpleRemoteCA::Action;
-  using SimpleRemoteCA::encodeHangupPayload;
-  using SimpleRemoteCA::encodeSetupMessage;
-  using SimpleRemoteCA::handleMessage;
-  using SimpleRemoteCA::Opcode;
-
-  void connect(BootstrapInfo) override {}
-  void disconnect() override {
-    // Mirror a real transport's teardown order: drain, then notify. A locally
-    // requested disconnect is orderly, so the mode is success.
-    failAllPendingCalls();
-    notifyDisconnected(Error::success());
-  }
-  void callController(OnControllerCallReturn OnComplete,
-                      orc_rt_ControllerHandlerTag,
-                      WrapperFunctionBuffer) override {
-    LastCallSeqNo = registerPendingCall(std::move(OnComplete));
-  }
-  void sendWrapperResult(WrapperFunctionBuffer ResultBytes,
-                         uint64_t CallId) override {
-    WrapperResults.emplace_back(CallId, std::move(ResultBytes));
+  void connect(BootstrapInfo BI) override {
+    // Models a transport that enabled delivery and then dropped out before it
+    // got as far as accepting -- the sanctioned failed-connect path.
+    if (DropOutDuringConnect)
+      finishTeardown(make_error<StringError>("dropped during connect"));
+    beginAccepting(BI);
   }
 
-  uint64_t LastCallSeqNo = 0;
-  std::vector<std::pair<uint64_t, WrapperFunctionBuffer>> WrapperResults;
+  void sendMessage(Opcode Op, uint64_t SeqNo, orc_rt_ControllerHandlerTag Tag,
+                   WrapperFunctionBuffer Payload) override {
+    Messages.push_back(Sent{Op, SeqNo, Tag, std::move(Payload)});
+  }
+
+  void beginTeardown() override {
+    ++TeardownsBegun;
+    // What a transport owes for a local disconnect: an orderly reason, sent
+    // last.
+    sendMessage(Opcode::Hangup, 0, nullptr,
+                encodeHangupPayload(Error::success()));
+    if (FinishTeardownOnBegin)
+      finishTeardown(Error::success());
+  }
+
+  /// Clear to model a transport whose shutdown is asynchronous.
+  bool FinishTeardownOnBegin = true;
+  /// Set to tear down from inside connect, before beginAccepting runs.
+  bool DropOutDuringConnect;
+
+  unsigned TeardownsBegun = 0;
+  // A deque, not a vector: messages() returns pointers into this, and a later
+  // send must not invalidate them.
+  std::deque<Sent> &Messages;
 };
+
+using SentMessages = std::deque<TestSimpleRemoteCA::Sent>;
+
+// Messages of the given opcode, in send order.
+std::vector<const TestSimpleRemoteCA::Sent *>
+messages(const SentMessages &Msgs, TestSimpleRemoteCA::Opcode Op) {
+  std::vector<const TestSimpleRemoteCA::Sent *> Result;
+  for (auto &M : Msgs)
+    if (M.Op == Op)
+      Result.push_back(&M);
+  return Result;
+}
 
 constexpr uint64_t opc(TestSimpleRemoteCA::Opcode Op) {
   return static_cast<uint64_t>(Op);
@@ -98,7 +138,10 @@ TEST(SimpleRemoteCATest, SetupMessageRoundTrips) {
                             SPSSequence<SPSTuple<SPSString, SPSSequence<char>>>,
                             SPSSequence<SPSTuple<SPSString, SPSExecutorAddr>>>;
 
-  Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+  // Declared before the Session: its destructor drives teardown, which
+  // records a hang-up.
+  SentMessages Msgs;
+  Session S(mockExecutorProcessInfo(), inlineDispatch, noErrors);
 
   int SomeSymbol = 0;
   SimpleSymbolTable Symbols;
@@ -108,7 +151,14 @@ TEST(SimpleRemoteCATest, SetupMessageRoundTrips) {
 
   BootstrapInfo BI(S, std::move(Symbols),
                    BootstrapInfo::ValueMap{{"key", "value"}});
-  auto Payload = TestSimpleRemoteCA::encodeSetupMessage(BI);
+
+  // connect sends setup; take the payload from the message the base produced.
+  TestSimpleRemoteCA *CA = nullptr;
+  S.attach<TestSimpleRemoteCA>(std::move(BI), Msgs, &CA);
+  ASSERT_TRUE(CA);
+  auto Setups = messages(Msgs, TestSimpleRemoteCA::Opcode::Setup);
+  ASSERT_EQ(Setups.size(), 1u);
+  auto &Payload = Setups[0]->Payload;
 
   std::string Triple;
   uint64_t PageSize = 0;
@@ -132,7 +182,8 @@ TEST(SimpleRemoteCATest, SetupMessageRoundTrips) {
 
 TEST(SimpleRemoteCATest, HandleMessageRejectsInvalidOpcode) {
   Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
-  TestSimpleRemoteCA CA(S);
+  SentMessages Msgs;
+  TestSimpleRemoteCA CA(S, Msgs);
   expectError(CA.handleMessage(/*OpC=*/99, /*SeqNo=*/0, ExecutorAddr(),
                                WrapperFunctionBuffer()),
               "Invalid opcode 99");
@@ -140,7 +191,8 @@ TEST(SimpleRemoteCATest, HandleMessageRejectsInvalidOpcode) {
 
 TEST(SimpleRemoteCATest, HandleMessageRejectsUnexpectedSetup) {
   Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
-  TestSimpleRemoteCA CA(S);
+  SentMessages Msgs;
+  TestSimpleRemoteCA CA(S, Msgs);
   expectError(CA.handleMessage(opc(TestSimpleRemoteCA::Opcode::Setup), 0,
                                ExecutorAddr(), WrapperFunctionBuffer()),
               "Unexpected Setup message");
@@ -148,7 +200,8 @@ TEST(SimpleRemoteCATest, HandleMessageRejectsUnexpectedSetup) {
 
 TEST(SimpleRemoteCATest, HandleMessageAcceptsWellFormedHangup) {
   Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
-  TestSimpleRemoteCA CA(S);
+  SentMessages Msgs;
+  TestSimpleRemoteCA CA(S, Msgs);
   auto R = CA.handleMessage(
       opc(TestSimpleRemoteCA::Opcode::Hangup), 0, ExecutorAddr(),
       TestSimpleRemoteCA::encodeHangupPayload(Error::success()));
@@ -162,7 +215,8 @@ TEST(SimpleRemoteCATest, HandleMessageReportsHangupReason) {
   // A hang-up carrying a reason ends the session with that reason, rather than
   // reporting a plain End: the reactor turns it into the disconnection error.
   Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
-  TestSimpleRemoteCA CA(S);
+  SentMessages Msgs;
+  TestSimpleRemoteCA CA(S, Msgs);
   expectError(CA.handleMessage(
                   opc(TestSimpleRemoteCA::Opcode::Hangup), 0, ExecutorAddr(),
                   TestSimpleRemoteCA::encodeHangupPayload(
@@ -172,7 +226,8 @@ TEST(SimpleRemoteCATest, HandleMessageReportsHangupReason) {
 
 TEST(SimpleRemoteCATest, HandleMessageRejectsMalformedHangup) {
   Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
-  TestSimpleRemoteCA CA(S);
+  SentMessages Msgs;
+  TestSimpleRemoteCA CA(S, Msgs);
 
   // A hang-up must carry no sequence number and no tag.
   expectError(CA.handleMessage(
@@ -195,7 +250,8 @@ TEST(SimpleRemoteCATest, HandleMessageRejectsMalformedHangup) {
 
 TEST(SimpleRemoteCATest, HandleMessageRejectsResultWithTag) {
   Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
-  TestSimpleRemoteCA CA(S);
+  SentMessages Msgs;
+  TestSimpleRemoteCA CA(S, Msgs);
   expectError(CA.handleMessage(opc(TestSimpleRemoteCA::Opcode::Result),
                                /*SeqNo=*/1, ExecutorAddr(0x1000),
                                WrapperFunctionBuffer()),
@@ -204,7 +260,8 @@ TEST(SimpleRemoteCATest, HandleMessageRejectsResultWithTag) {
 
 TEST(SimpleRemoteCATest, HandleMessageRejectsResultForUnknownSequenceNumber) {
   Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
-  TestSimpleRemoteCA CA(S);
+  SentMessages Msgs;
+  TestSimpleRemoteCA CA(S, Msgs);
   expectError(CA.handleMessage(opc(TestSimpleRemoteCA::Opcode::Result),
                                /*SeqNo=*/7, ExecutorAddr(),
                                WrapperFunctionBuffer::copyFrom("r", 1)),
@@ -212,9 +269,12 @@ TEST(SimpleRemoteCATest, HandleMessageRejectsResultForUnknownSequenceNumber) {
 }
 
 TEST(SimpleRemoteCATest, ResultCompletesPendingCall) {
+  // Declared before the Session: its destructor drives teardown, which
+  // records a hang-up.
+  SentMessages Msgs;
   Session S(mockExecutorProcessInfo(), inlineDispatch, noErrors);
   TestSimpleRemoteCA *CA = nullptr;
-  S.attach<TestSimpleRemoteCA>(BootstrapInfo(S), &CA);
+  S.attach<TestSimpleRemoteCA>(BootstrapInfo(S), Msgs, &CA);
   ASSERT_TRUE(CA);
 
   // Originate a controller call; the test double registers it as pending.
@@ -226,7 +286,9 @@ TEST(SimpleRemoteCATest, ResultCompletesPendingCall) {
       },
       nullptr, WrapperFunctionBuffer());
 
-  uint64_t SeqNo = CA->LastCallSeqNo;
+  auto Calls = messages(Msgs, TestSimpleRemoteCA::Opcode::Call);
+  ASSERT_EQ(Calls.size(), 1u);
+  uint64_t SeqNo = Calls[0]->SeqNo;
   ASSERT_NE(SeqNo, 0u);
   ASSERT_FALSE(Res) << "handler fired before the result arrived";
 
@@ -244,9 +306,12 @@ TEST(SimpleRemoteCATest, ResultCompletesPendingCall) {
 }
 
 TEST(SimpleRemoteCATest, CallDispatchesWrapperAndReturnsResult) {
+  // Declared before the Session: its destructor drives teardown, which
+  // records a hang-up.
+  SentMessages Msgs;
   Session S(mockExecutorProcessInfo(), inlineDispatch, noErrors);
   TestSimpleRemoteCA *CA = nullptr;
-  S.attach<TestSimpleRemoteCA>(BootstrapInfo(S), &CA);
+  S.attach<TestSimpleRemoteCA>(BootstrapInfo(S), Msgs, &CA);
   ASSERT_TRUE(CA);
 
   // A Call names echoWrapper via the tag; SeqNo is the call id.
@@ -259,16 +324,20 @@ TEST(SimpleRemoteCATest, CallDispatchesWrapperAndReturnsResult) {
   else
     EXPECT_EQ(*R, TestSimpleRemoteCA::Action::Continue);
 
-  ASSERT_EQ(CA->WrapperResults.size(), 1u);
-  EXPECT_EQ(CA->WrapperResults[0].first, 42u);
-  auto &Result = CA->WrapperResults[0].second;
+  auto Results = messages(Msgs, TestSimpleRemoteCA::Opcode::Result);
+  ASSERT_EQ(Results.size(), 1u);
+  EXPECT_EQ(Results[0]->SeqNo, 42u);
+  auto &Result = Results[0]->Payload;
   EXPECT_EQ(std::string(Result.data(), Result.size()), "world");
 }
 
 TEST(SimpleRemoteCATest, DisconnectDrainsPendingCalls) {
+  // Declared before the Session: its destructor drives teardown, which
+  // records a hang-up.
+  SentMessages Msgs;
   Session S(mockExecutorProcessInfo(), inlineDispatch, noErrors);
   TestSimpleRemoteCA *CA = nullptr;
-  S.attach<TestSimpleRemoteCA>(BootstrapInfo(S), &CA);
+  S.attach<TestSimpleRemoteCA>(BootstrapInfo(S), Msgs, &CA);
   ASSERT_TRUE(CA);
 
   // A controller call is in flight (no result will arrive).
@@ -279,7 +348,7 @@ TEST(SimpleRemoteCATest, DisconnectDrainsPendingCalls) {
           Err = M;
       },
       nullptr, WrapperFunctionBuffer());
-  ASSERT_NE(CA->LastCallSeqNo, 0u);
+  ASSERT_EQ(messages(Msgs, TestSimpleRemoteCA::Opcode::Call).size(), 1u);
   ASSERT_FALSE(Err) << "handler fired before disconnect";
 
   // Detach drives disconnect, which drains the pending call with a
@@ -288,4 +357,109 @@ TEST(SimpleRemoteCATest, DisconnectDrainsPendingCalls) {
 
   ASSERT_TRUE(Err);
   EXPECT_EQ(*Err, "disconnected");
+}
+
+TEST(SimpleRemoteCATest, CallRacingTeardownFailsInline) {
+  // Teardown has begun but the transport hasn't finished, so the call reaches
+  // the CA and must be failed on the spot rather than left pending -- nothing
+  // will drain it if the drain has already run.
+  // Declared before the Session: its destructor drives teardown, which
+  // records a hang-up.
+  SentMessages Msgs;
+  Session S(mockExecutorProcessInfo(), inlineDispatch, noErrors);
+  TestSimpleRemoteCA *CA = nullptr;
+  S.attach<TestSimpleRemoteCA>(BootstrapInfo(S), Msgs, &CA);
+  ASSERT_TRUE(CA);
+  CA->FinishTeardownOnBegin = false;
+
+  CA->disconnect();
+  ASSERT_EQ(CA->TeardownsBegun, 1u);
+
+  std::optional<std::string> Err;
+  S.callController(
+      [&](WrapperFunctionBuffer R) {
+        if (const char *M = R.getOutOfBandError())
+          Err = M;
+      },
+      nullptr, WrapperFunctionBuffer());
+
+  // The handler ran before callController returned, and nothing was sent.
+  ASSERT_TRUE(Err);
+  EXPECT_EQ(*Err, "disconnected");
+  EXPECT_TRUE(messages(Msgs, TestSimpleRemoteCA::Opcode::Call).empty());
+
+  CA->finishTeardown(Error::success());
+}
+
+TEST(SimpleRemoteCATest, DisconnectIsIdempotentAndDefersNotification) {
+  unsigned Notifications = 0;
+  // Declared before the Session: its destructor drives teardown, which
+  // records a hang-up.
+  SentMessages Msgs;
+  Session S(mockExecutorProcessInfo(), inlineDispatch, noErrors);
+  S.setOnDisconnect([&](Error Err) {
+    ++Notifications;
+    cantFail(std::move(Err));
+  });
+
+  TestSimpleRemoteCA *CA = nullptr;
+  S.attach<TestSimpleRemoteCA>(BootstrapInfo(S), Msgs, &CA);
+  ASSERT_TRUE(CA);
+  CA->FinishTeardownOnBegin = false;
+
+  CA->disconnect();
+  CA->disconnect();
+  EXPECT_EQ(CA->TeardownsBegun, 1u) << "second disconnect was not a no-op";
+  EXPECT_EQ(Notifications, 0u) << "notified before the transport finished";
+
+  // finishTeardown may destroy *CA, so it is the last thing to touch it.
+  CA->finishTeardown(Error::success());
+  EXPECT_EQ(Notifications, 1u);
+}
+
+TEST(SimpleRemoteCATest, TransportInitiatedTeardownNotifiesWithoutHangup) {
+  // A hang-up from the controller, or a transport failure, goes straight to
+  // finishTeardown: the peer already knows, so nothing is sent.
+  unsigned Notifications = 0;
+  // Declared before the Session: its destructor drives teardown, which
+  // records a hang-up.
+  SentMessages Msgs;
+  Session S(mockExecutorProcessInfo(), inlineDispatch, noErrors);
+  S.setOnDisconnect([&](Error Err) {
+    ++Notifications;
+    EXPECT_EQ(toString(std::move(Err)), "controller vanished");
+  });
+
+  TestSimpleRemoteCA *CA = nullptr;
+  S.attach<TestSimpleRemoteCA>(BootstrapInfo(S), Msgs, &CA);
+  ASSERT_TRUE(CA);
+
+  // Nothing sends a hang-up on this path, because beginTeardown never runs.
+  EXPECT_EQ(CA->TeardownsBegun, 0u);
+  CA->finishTeardown(make_error<StringError>("controller vanished"));
+
+  EXPECT_EQ(Notifications, 1u);
+}
+
+TEST(SimpleRemoteCATest, DropOutBeforeAcceptingIsANoOp) {
+  // A transport that enables delivery before calling beginAccepting can lose
+  // the connection first, so beginAccepting has to tolerate running after
+  // teardown has already completed: it accepts nothing and sends nothing.
+  unsigned Notifications = 0;
+  // Declared before the Session: its destructor drives teardown, which
+  // records a hang-up.
+  SentMessages Msgs;
+  Session S(mockExecutorProcessInfo(), inlineDispatch, noErrors);
+  S.setOnDisconnect([&](Error Err) {
+    ++Notifications;
+    EXPECT_EQ(toString(std::move(Err)), "dropped during connect");
+  });
+
+  // Msgs outlives the CA, which is freed as attach returns.
+  TestSimpleRemoteCA *CA = nullptr;
+  S.attach<TestSimpleRemoteCA>(BootstrapInfo(S), Msgs, &CA,
+                               /*DropOutDuringConnect=*/true);
+
+  EXPECT_EQ(Notifications, 1u);
+  EXPECT_TRUE(Msgs.empty()) << "setup was sent after teardown completed";
 }


### PR DESCRIPTION
Shares the connection-state and teardown logic between transports.

SimpleRemoteCA now tracks connection state, so disconnect, callController and sendWrapperResult are final. A controller call either registers under the same lock that publishes the state, or is failed inline on the caller's stack, so it can never be left pending with no result to come. Teardown funnels through finishTeardown, which drains pending calls and then notifies the Session exactly once, however teardown began. registerPendingCall and failAllPendingCalls become private.

Subclasses implement connect plus two hooks. The base calls sendMessage with an opcode, sequence number, tag and payload for the transport to frame and send; it runs with no lock held, so framing stays off the critical section, and is best-effort, so a transport that has gone away can drop the message. beginTeardown stops the transport, sending an orderly hang-up first, and calls finishTeardown once it is done.

beginAccepting publishes the accepting state before sending the setup message, so a call or a teardown arriving while setup is in flight is handled. For a transport that has already dropped out, beginAccepting is a no-op.