### PR TITLE
[ADT][SelectionDAG] Unique SDNodes in a UniquingSet

### DIFF
--- a/llvm/include/llvm/ADT/FoldingSet.h
+++ b/llvm/include/llvm/ADT/FoldingSet.h
@@ -259,18 +259,17 @@ public:
   /// object to be used to compute a new profile.
   inline void clear() { Bits.clear(); }
 
+  /// The accumulated profile, valid until this object is next modified.
+  FoldingSetNodeIDRef getRef() const { return {Bits.data(), Bits.size()}; }
+
   // Compute a strong hash value for this FoldingSetNodeID, used to lookup the
   // node in the FoldingSetBase. The hash value is not guaranteed to be
   // deterministic across processes.
-  unsigned computeHash() const {
-    return FoldingSetNodeIDRef(Bits.data(), Bits.size()).computeHash();
-  }
+  unsigned computeHash() const { return getRef().computeHash(); }
 
   // Compute a deterministic hash value across processes that is suitable for
   // on-disk serialization.
-  unsigned computeStableHash() const {
-    return FoldingSetNodeIDRef(Bits.data(), Bits.size()).computeStableHash();
-  }
+  unsigned computeStableHash() const { return getRef().computeStableHash(); }
 
   /// operator== - Used to compare two nodes to each other.
   bool operator==(const FoldingSetNodeID &RHS) const {
@@ -696,6 +695,9 @@ template <typename T> struct UniquingSetInfo {
   static unsigned getHashValue(const KeyTy &Key) {
     return DenseMapInfo<KeyTy>::getHashValue(Key);
   }
+  static bool isEqual(const KeyTy &Key, const T &N) {
+    return Key == N.getKey();
+  }
 };
 
 /// A uniquing set that compares nodes against a typed key rather than a
@@ -709,7 +711,11 @@ template <typename T> struct UniquingSetInfo {
 ///   using KeyTy = ...;
 ///   static KeyTy getKey(const T &N);
 ///   static unsigned getHashValue(const KeyTy &K);
+///   static bool isEqual(const KeyTy &K, const T &N);
 /// \endcode
+///
+/// Override isEqual when comparing a key against a node's fields is cheaper
+/// than building a key from the node, which is what the default does.
 ///
 /// Derive \p Info from UniquingSetInfo<T> to override only the hash.  The
 /// default Info needs \p T complete wherever UniquingSet<T> is instantiated;
@@ -745,7 +751,7 @@ public:
   /// token for insert().
   T *lookup(const KeyTy &Key, FoldingSetInsertToken &Token) {
     return static_cast<T *>(probe(hashKey(Key), Token, [&](Node *N) {
-      return Key == Info::getKey(*static_cast<T *>(N));
+      return Info::isEqual(Key, *static_cast<T *>(N));
     }));
   }
 
@@ -756,6 +762,17 @@ public:
     assert(makeInsertToken(hashKey(Info::getKey(*N))) == Token &&
            "N does not key as the lookup that produced Token did");
     FoldingSetBase::insert(N, Token);
+  }
+
+  /// Look \p N up by its own key, inserting it if absent, and return the node
+  /// in the set.  Out of line so that callers do not inherit the key's inline
+  /// storage; some of them recurse.
+  LLVM_ATTRIBUTE_NOINLINE T *getOrInsert(T *N) {
+    FoldingSetInsertToken Token;
+    if (T *E = lookup(Info::getKey(*N), Token))
+      return E;
+    FoldingSetBase::insert(N, Token);
+    return N;
   }
 
   /// Remove \p N, returning whether it was present.

--- a/llvm/include/llvm/CodeGen/SelectionDAG.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAG.h
@@ -99,6 +99,51 @@ using SSAContext = GenericSSAContext<Function>;
 template <typename T> class GenericUniformityInfo;
 using UniformityInfo = GenericUniformityInfo<SSAContext>;
 
+/// The key SelectionDAG uniques SDNodes by.  \p Tail carries the opcode
+/// specific data, which most opcodes do not have, still serialized; a lookup
+/// site appends it through the FoldingSetNodeID-shaped forwarders below.
+struct SDNodeKey {
+  unsigned Opcode;
+  const EVT *VTs;
+  ArrayRef<SDValue> Ops;
+  FoldingSetNodeID Tail;
+  /// Backs \p Ops when the key is built from a node; empty otherwise.  No
+  /// inline capacity: only that one path pays for the storage.
+  SmallVector<SDValue, 0> OpStorage;
+
+  SDNodeKey(unsigned Opcode, SDVTList VTList, ArrayRef<SDValue> Ops)
+      : Opcode(Opcode), VTs(VTList.VTs), Ops(Ops) {}
+  LLVM_ABI explicit SDNodeKey(const SDNode &N);
+
+  SDNodeKey(const SDNodeKey &) = delete;
+  SDNodeKey &operator=(const SDNodeKey &) = delete;
+
+  // Forward to FoldingSetNodeID's own overload set, so a lookup site resolves
+  // the same way it did when profiling into one.
+  template <typename T> void AddInteger(T I) { Tail.AddInteger(I); }
+  void AddBoolean(bool B) { Tail.AddBoolean(B); }
+  void AddPointer(const void *P) { Tail.AddPointer(P); }
+};
+
+struct SDNodeKeyInfo {
+  using KeyTy = SDNodeKey;
+
+  static KeyTy getKey(const SDNode &N) { return SDNodeKey(N); }
+
+  static unsigned getHashValue(const KeyTy &Key) {
+    unsigned H = detail::combineHashValue(
+        Key.Opcode, DenseMapInfo<const EVT *>::getHashValue(Key.VTs));
+    for (const SDValue &Op : Key.Ops)
+      H = detail::combineHashValue(H, DenseMapInfo<SDValue>::getHashValue(Op));
+    FoldingSetNodeIDRef Tail = Key.Tail.getRef();
+    for (unsigned Word : ArrayRef(Tail.getData(), Tail.getSize()))
+      H = detail::combineHashValue(H, Word);
+    return H;
+  }
+
+  LLVM_ABI static bool isEqual(const KeyTy &Key, const SDNode &N);
+};
+
 template <> struct ilist_alloc_traits<SDNode> {
   static void deleteNode(SDNode *) {
     llvm_unreachable("ilist_traits<SDNode> shouldn't see a deleteNode call!");
@@ -247,7 +292,7 @@ class SelectionDAG {
 
   /// This structure is used to memoize nodes, automatically performing
   /// CSE with existing nodes when a duplicate is requested.
-  FoldingSet<SDNode> CSEMap;
+  UniquingSet<SDNode, SDNodeKeyInfo> CSEMap;
 
   /// Pool allocation for machine-opcode SDNode operands.
   BumpPtrAllocator OperandAllocator;
@@ -2761,13 +2806,12 @@ private:
   /// clear \p InsertToken; otherwise return null and set \p InsertToken for a
   /// subsequent insert. This overload is for nodes other than Constant or
   /// ConstantFP, use the other one for those.
-  SDNode *lookupNode(const FoldingSetNodeID &ID,
-                     FoldingSetInsertToken &InsertToken);
+  SDNode *lookupNode(const SDNodeKey &Key, FoldingSetInsertToken &InsertToken);
 
   /// Look up the node specified by ID in CSEMap. If it exists, return it and
   /// clear \p InsertToken; otherwise return null and set \p InsertToken for a
   /// subsequent insert. Performs additional processing for constant nodes.
-  SDNode *lookupNode(const FoldingSetNodeID &ID, const SDLoc &DL,
+  SDNode *lookupNode(const SDNodeKey &Key, const SDLoc &DL,
                      FoldingSetInsertToken &InsertToken);
 
   /// Maps to auto-CSE operations.

--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -1210,9 +1210,6 @@ public:
   LLVM_ABI void dumprWithDepth(const SelectionDAG *G = nullptr,
                                unsigned depth = 100) const;
 
-  /// Gather unique data for the node.
-  LLVM_ABI void Profile(FoldingSetNodeID &ID) const;
-
   /// This method should only be used by the SDUse class.
   void addUse(SDUse &U) { U.addToList(&UseList); }
 

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -747,44 +747,8 @@ ISD::CondCode ISD::getSetCCAndOperation(ISD::CondCode Op1, ISD::CondCode Op2,
 }
 
 //===----------------------------------------------------------------------===//
-//                           SDNode Profile Support
+//                            SDNode Key Support
 //===----------------------------------------------------------------------===//
-
-/// AddNodeIDOpcode - Add the node opcode to the NodeID data.
-static void AddNodeIDOpcode(FoldingSetNodeID &ID, unsigned OpC)  {
-  ID.AddInteger(OpC);
-}
-
-/// AddNodeIDValueTypes - Value type lists are intern'd so we can represent them
-/// solely with their pointer.
-static void AddNodeIDValueTypes(FoldingSetNodeID &ID, SDVTList VTList) {
-  ID.AddPointer(VTList.VTs);
-}
-
-/// AddNodeIDOperands - Various routines for adding operands to the NodeID data.
-static void AddNodeIDOperands(FoldingSetNodeID &ID,
-                              ArrayRef<SDValue> Ops) {
-  for (const auto &Op : Ops) {
-    ID.AddPointer(Op.getNode());
-    ID.AddInteger(Op.getResNo());
-  }
-}
-
-/// AddNodeIDOperands - Various routines for adding operands to the NodeID data.
-static void AddNodeIDOperands(FoldingSetNodeID &ID,
-                              ArrayRef<SDUse> Ops) {
-  for (const auto &Op : Ops) {
-    ID.AddPointer(Op.getNode());
-    ID.AddInteger(Op.getResNo());
-  }
-}
-
-static void AddNodeIDNode(FoldingSetNodeID &ID, unsigned OpC,
-                          SDVTList VTList, ArrayRef<SDValue> OpList) {
-  AddNodeIDOpcode(ID, OpC);
-  AddNodeIDValueTypes(ID, VTList);
-  AddNodeIDOperands(ID, OpList);
-}
 
 /// If this is an SDNode with special info, add this info to the NodeID data.
 /// MorphNodeTo passes the opcode \p N is becoming, so \p Opc may differ from
@@ -1032,17 +996,62 @@ static void AddNodeIDCustom(FoldingSetNodeID &ID, const SDNode *N,
   }
 }
 
-/// AddNodeIDNode - Generic routine for adding a nodes info to the NodeID
-/// data.
-static void AddNodeIDNode(FoldingSetNodeID &ID, const SDNode *N) {
-  AddNodeIDOpcode(ID, N->getOpcode());
-  // Add the return value info.
-  AddNodeIDValueTypes(ID, N->getVTList());
-  // Add the operand info.
-  AddNodeIDOperands(ID, N->ops());
+SDNodeKey::SDNodeKey(const SDNode &N)
+    : Opcode(N.getOpcode()), VTs(N.getVTList().VTs),
+      OpStorage(N.op_begin(), N.op_end()) {
+  Ops = OpStorage;
+  AddNodeIDCustom(Tail, &N, N.getOpcode());
+}
 
-  // Handle SDNode leafs with special info.
+#ifndef NDEBUG
+/// Serialize a node the way SDNodes were uniqued before SDNodeKey, to
+/// cross-check the typed comparison against.  Deliberately reads the node
+/// rather than going through SDNodeKey, so the key constructor is checked too
+/// and not used as its own oracle.
+static void AddNodeIDNode(FoldingSetNodeID &ID, const SDNode *N) {
+  ID.AddInteger(N->getOpcode());
+  ID.AddPointer(N->getVTList().VTs);
+  for (const SDUse &Op : N->ops()) {
+    ID.AddPointer(Op.getNode());
+    ID.AddInteger(Op.getResNo());
+  }
   AddNodeIDCustom(ID, N, N->getOpcode());
+}
+
+static void AddNodeIDNode(FoldingSetNodeID &ID, const SDNodeKey &Key) {
+  ID.AddInteger(Key.Opcode);
+  ID.AddPointer(Key.VTs);
+  for (const SDValue &Op : Key.Ops) {
+    ID.AddPointer(Op.getNode());
+    ID.AddInteger(Op.getResNo());
+  }
+  ID.AddNodeID(Key.Tail);
+}
+#endif
+
+static bool keyMatches(const SDNodeKey &Key, const SDNode &N) {
+  if (N.getOpcode() != Key.Opcode || N.getVTList().VTs != Key.VTs)
+    return false;
+  if (!llvm::equal(N.ops(), Key.Ops))
+    return false;
+  // Build only what AddNodeIDCustom would have added, which is nothing for
+  // most opcodes, rather than the whole profile.
+  FoldingSetNodeID Tail;
+  AddNodeIDCustom(Tail, &N, N.getOpcode());
+  return Tail == Key.Tail;
+}
+
+bool SDNodeKeyInfo::isEqual(const SDNodeKey &Key, const SDNode &N) {
+  bool Result = keyMatches(Key, N);
+
+#ifndef NDEBUG
+  FoldingSetNodeID NodeProfile, KeyProfile;
+  AddNodeIDNode(NodeProfile, &N);
+  AddNodeIDNode(KeyProfile, Key);
+  assert((NodeProfile == KeyProfile) == Result &&
+         "SDNodeKey equality disagrees with profile");
+#endif
+  return Result;
 }
 
 //===----------------------------------------------------------------------===//
@@ -1384,9 +1393,8 @@ SDNode *SelectionDAG::FindModifiedNodeSlot(SDNode *N, SDValue Op,
     return nullptr;
 
   SDValue Ops[] = { Op };
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, N->getOpcode(), N->getVTList(), Ops);
-  AddNodeIDCustom(ID, N, N->getOpcode());
+  SDNodeKey ID(N->getOpcode(), N->getVTList(), Ops);
+  AddNodeIDCustom(ID.Tail, N, N->getOpcode());
   SDNode *Node = lookupNode(ID, SDLoc(N), InsertToken);
   if (Node)
     Node->intersectFlagsWith(N->getFlags());
@@ -1403,9 +1411,8 @@ SDNode *SelectionDAG::FindModifiedNodeSlot(SDNode *N, SDValue Op1, SDValue Op2,
     return nullptr;
 
   SDValue Ops[] = { Op1, Op2 };
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, N->getOpcode(), N->getVTList(), Ops);
-  AddNodeIDCustom(ID, N, N->getOpcode());
+  SDNodeKey ID(N->getOpcode(), N->getVTList(), Ops);
+  AddNodeIDCustom(ID.Tail, N, N->getOpcode());
   SDNode *Node = lookupNode(ID, SDLoc(N), InsertToken);
   if (Node)
     Node->intersectFlagsWith(N->getFlags());
@@ -1421,9 +1428,8 @@ SDNode *SelectionDAG::FindModifiedNodeSlot(SDNode *N, ArrayRef<SDValue> Ops,
   if (doNotCSE(N))
     return nullptr;
 
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, N->getOpcode(), N->getVTList(), Ops);
-  AddNodeIDCustom(ID, N, N->getOpcode());
+  SDNodeKey ID(N->getOpcode(), N->getVTList(), Ops);
+  AddNodeIDCustom(ID.Tail, N, N->getOpcode());
   SDNode *Node = lookupNode(ID, SDLoc(N), InsertToken);
   if (Node)
     Node->intersectFlagsWith(N->getFlags());
@@ -1489,9 +1495,9 @@ void SelectionDAG::allnodes_clear() {
 #endif
 }
 
-SDNode *SelectionDAG::lookupNode(const FoldingSetNodeID &ID,
+SDNode *SelectionDAG::lookupNode(const SDNodeKey &Key,
                                  FoldingSetInsertToken &InsertToken) {
-  SDNode *N = CSEMap.lookup(ID, InsertToken);
+  SDNode *N = CSEMap.lookup(Key, InsertToken);
   if (N) {
     switch (N->getOpcode()) {
     default: break;
@@ -1504,9 +1510,9 @@ SDNode *SelectionDAG::lookupNode(const FoldingSetNodeID &ID,
   return N;
 }
 
-SDNode *SelectionDAG::lookupNode(const FoldingSetNodeID &ID, const SDLoc &DL,
+SDNode *SelectionDAG::lookupNode(const SDNodeKey &Key, const SDLoc &DL,
                                  FoldingSetInsertToken &InsertToken) {
-  SDNode *N = CSEMap.lookup(ID, InsertToken);
+  SDNode *N = CSEMap.lookup(Key, InsertToken);
   if (N) {
     switch (N->getOpcode()) {
     case ISD::Constant:
@@ -1812,8 +1818,7 @@ SDValue SelectionDAG::getConstant(const ConstantInt &Val, const SDLoc &DL,
          "APInt size does not match type size!");
   unsigned Opc = isT ? ISD::TargetConstant : ISD::Constant;
   SDVTList VTs = getVTList(EltVT);
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, Opc, VTs, {});
+  SDNodeKey ID(Opc, VTs, {});
   ID.AddPointer(Elt);
   ID.AddBoolean(isO);
   FoldingSetInsertToken InsertToken;
@@ -1894,8 +1899,7 @@ SDValue SelectionDAG::getConstantFP(const ConstantFP &V, const SDLoc &DL,
   // we don't have issues with SNANs.
   unsigned Opc = isTarget ? ISD::TargetConstantFP : ISD::ConstantFP;
   SDVTList VTs = getVTList(EltVT);
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, Opc, VTs, {});
+  SDNodeKey ID(Opc, VTs, {});
   ID.AddPointer(Elt);
   FoldingSetInsertToken InsertToken;
   SDNode *N = nullptr;
@@ -1952,8 +1956,7 @@ SDValue SelectionDAG::getGlobalAddress(const GlobalValue *GV, const SDLoc &DL,
     Opc = isTargetGA ? ISD::TargetGlobalAddress : ISD::GlobalAddress;
 
   SDVTList VTs = getVTList(VT);
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, Opc, VTs, {});
+  SDNodeKey ID(Opc, VTs, {});
   ID.AddPointer(GV);
   ID.AddInteger(Offset);
   ID.AddInteger(TargetFlags);
@@ -1970,8 +1973,7 @@ SDValue SelectionDAG::getGlobalAddress(const GlobalValue *GV, const SDLoc &DL,
 
 SDValue SelectionDAG::getDeactivationSymbol(const GlobalValue *GV) {
   SDVTList VTs = getVTList(MVT::Untyped);
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::DEACTIVATION_SYMBOL, VTs, {});
+  SDNodeKey ID(ISD::DEACTIVATION_SYMBOL, VTs, {});
   ID.AddPointer(GV);
   FoldingSetInsertToken InsertToken;
   if (SDNode *E = lookupNode(ID, SDLoc(), InsertToken))
@@ -1986,8 +1988,7 @@ SDValue SelectionDAG::getDeactivationSymbol(const GlobalValue *GV) {
 SDValue SelectionDAG::getFrameIndex(int FI, EVT VT, bool isTarget) {
   unsigned Opc = isTarget ? ISD::TargetFrameIndex : ISD::FrameIndex;
   SDVTList VTs = getVTList(VT);
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, Opc, VTs, {});
+  SDNodeKey ID(Opc, VTs, {});
   ID.AddInteger(FI);
   FoldingSetInsertToken InsertToken;
   if (SDNode *E = lookupNode(ID, InsertToken))
@@ -2005,8 +2006,7 @@ SDValue SelectionDAG::getJumpTable(int JTI, EVT VT, bool isTarget,
          "Cannot set target flags on target-independent jump tables");
   unsigned Opc = isTarget ? ISD::TargetJumpTable : ISD::JumpTable;
   SDVTList VTs = getVTList(VT);
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, Opc, VTs, {});
+  SDNodeKey ID(Opc, VTs, {});
   ID.AddInteger(JTI);
   ID.AddInteger(TargetFlags);
   FoldingSetInsertToken InsertToken;
@@ -2037,8 +2037,7 @@ SDValue SelectionDAG::getConstantPool(const Constant *C, EVT VT,
                     : getDataLayout().getPrefTypeAlign(C->getType());
   unsigned Opc = isTarget ? ISD::TargetConstantPool : ISD::ConstantPool;
   SDVTList VTs = getVTList(VT);
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, Opc, VTs, {});
+  SDNodeKey ID(Opc, VTs, {});
   ID.AddInteger(Alignment->value());
   ID.AddInteger(Offset);
   ID.AddPointer(C);
@@ -2065,11 +2064,10 @@ SDValue SelectionDAG::getConstantPool(MachineConstantPoolValue *C, EVT VT,
     Alignment = getDataLayout().getPrefTypeAlign(C->getType());
   unsigned Opc = isTarget ? ISD::TargetConstantPool : ISD::ConstantPool;
   SDVTList VTs = getVTList(VT);
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, Opc, VTs, {});
+  SDNodeKey ID(Opc, VTs, {});
   ID.AddInteger(Alignment->value());
   ID.AddInteger(Offset);
-  C->addSelectionDAGCSEId(ID);
+  C->addSelectionDAGCSEId(ID.Tail);
   ID.AddInteger(TargetFlags);
   FoldingSetInsertToken InsertToken;
   if (SDNode *E = lookupNode(ID, InsertToken))
@@ -2083,8 +2081,7 @@ SDValue SelectionDAG::getConstantPool(MachineConstantPoolValue *C, EVT VT,
 }
 
 SDValue SelectionDAG::getBasicBlock(MachineBasicBlock *MBB) {
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::BasicBlock, getVTList(MVT::Other), {});
+  SDNodeKey ID(ISD::BasicBlock, getVTList(MVT::Other), {});
   ID.AddPointer(MBB);
   FoldingSetInsertToken InsertToken;
   if (SDNode *E = lookupNode(ID, InsertToken))
@@ -2385,9 +2382,8 @@ SDValue SelectionDAG::getVectorShuffle(EVT VT, const SDLoc &dl, SDValue N1,
   }
 
   SDVTList VTs = getVTList(VT);
-  FoldingSetNodeID ID;
   SDValue Ops[2] = { N1, N2 };
-  AddNodeIDNode(ID, ISD::VECTOR_SHUFFLE, VTs, Ops);
+  SDNodeKey ID(ISD::VECTOR_SHUFFLE, VTs, Ops);
   for (int i = 0; i != NElts; ++i)
     ID.AddInteger(MaskVec[i]);
 
@@ -2424,8 +2420,7 @@ SDValue SelectionDAG::getCommutedVectorShuffle(const ShuffleVectorSDNode &SV) {
 
 SDValue SelectionDAG::getRegister(Register Reg, EVT VT) {
   SDVTList VTs = getVTList(VT);
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::Register, VTs, {});
+  SDNodeKey ID(ISD::Register, VTs, {});
   ID.AddInteger(Reg.id());
   FoldingSetInsertToken InsertToken;
   if (SDNode *E = lookupNode(ID, InsertToken))
@@ -2439,8 +2434,7 @@ SDValue SelectionDAG::getRegister(Register Reg, EVT VT) {
 }
 
 SDValue SelectionDAG::getRegisterMask(const uint32_t *RegMask) {
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::RegisterMask, getVTList(MVT::Untyped), {});
+  SDNodeKey ID(ISD::RegisterMask, getVTList(MVT::Untyped), {});
   ID.AddPointer(RegMask);
   FoldingSetInsertToken InsertToken;
   if (SDNode *E = lookupNode(ID, InsertToken))
@@ -2459,9 +2453,8 @@ SDValue SelectionDAG::getEHLabel(const SDLoc &dl, SDValue Root,
 
 SDValue SelectionDAG::getLabelNode(unsigned Opcode, const SDLoc &dl,
                                    SDValue Root, MCSymbol *Label) {
-  FoldingSetNodeID ID;
   SDValue Ops[] = { Root };
-  AddNodeIDNode(ID, Opcode, getVTList(MVT::Other), Ops);
+  SDNodeKey ID(Opcode, getVTList(MVT::Other), Ops);
   ID.AddPointer(Label);
   FoldingSetInsertToken InsertToken;
   if (SDNode *E = lookupNode(ID, InsertToken))
@@ -2482,8 +2475,7 @@ SDValue SelectionDAG::getBlockAddress(const BlockAddress *BA, EVT VT,
   unsigned Opc = isTarget ? ISD::TargetBlockAddress : ISD::BlockAddress;
   SDVTList VTs = getVTList(VT);
 
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, Opc, VTs, {});
+  SDNodeKey ID(Opc, VTs, {});
   ID.AddPointer(BA);
   ID.AddInteger(Offset);
   ID.AddInteger(TargetFlags);
@@ -2498,8 +2490,7 @@ SDValue SelectionDAG::getBlockAddress(const BlockAddress *BA, EVT VT,
 }
 
 SDValue SelectionDAG::getSrcValue(const Value *V) {
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::SRCVALUE, getVTList(MVT::Other), {});
+  SDNodeKey ID(ISD::SRCVALUE, getVTList(MVT::Other), {});
   ID.AddPointer(V);
 
   FoldingSetInsertToken InsertToken;
@@ -2513,8 +2504,7 @@ SDValue SelectionDAG::getSrcValue(const Value *V) {
 }
 
 SDValue SelectionDAG::getMDNode(const MDNode *MD) {
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::MDNODE_SDNODE, getVTList(MVT::Other), {});
+  SDNodeKey ID(ISD::MDNODE_SDNODE, getVTList(MVT::Other), {});
   ID.AddPointer(MD);
 
   FoldingSetInsertToken InsertToken;
@@ -2538,8 +2528,7 @@ SDValue SelectionDAG::getAddrSpaceCast(const SDLoc &dl, EVT VT, SDValue Ptr,
                                        unsigned SrcAS, unsigned DestAS) {
   SDVTList VTs = getVTList(VT);
   SDValue Ops[] = {Ptr};
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::ADDRSPACECAST, VTs, Ops);
+  SDNodeKey ID(ISD::ADDRSPACECAST, VTs, Ops);
   ID.AddInteger(SrcAS);
   ID.AddInteger(DestAS);
 
@@ -7035,8 +7024,7 @@ static SDValue foldCONCAT_VECTORS(const SDLoc &DL, EVT VT,
 /// Gets or creates the specified node.
 SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT) {
   SDVTList VTs = getVTList(VT);
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, Opcode, VTs, {});
+  SDNodeKey ID(Opcode, VTs, {});
   FoldingSetInsertToken InsertToken;
   if (SDNode *E = lookupNode(ID, DL, InsertToken))
     return SDValue(E, 0);
@@ -7432,8 +7420,7 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
   SDVTList VTs = getVTList(VT);
   SDValue Ops[] = {N1};
   if (VT != MVT::Glue) { // Don't CSE glue producing nodes
-    FoldingSetNodeID ID;
-    AddNodeIDNode(ID, Opcode, VTs, Ops);
+    SDNodeKey ID(Opcode, VTs, Ops);
     FoldingSetInsertToken InsertToken;
     if (SDNode *E = lookupNode(ID, DL, InsertToken)) {
       E->intersectFlagsWith(Flags);
@@ -8356,8 +8343,8 @@ SDValue SelectionDAG::getAssertAlign(const SDLoc &DL, SDValue Val, Align A) {
     return Val;
 
   SDVTList VTs = getVTList(Val.getValueType());
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::AssertAlign, VTs, {Val});
+  SDValue Ops[] = {Val};
+  SDNodeKey ID(ISD::AssertAlign, VTs, Ops);
   ID.AddInteger(A.value());
 
   FoldingSetInsertToken InsertToken;
@@ -8959,8 +8946,7 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
   SDVTList VTs = getVTList(VT);
   SDValue Ops[] = {N1, N2};
   if (VT != MVT::Glue) {
-    FoldingSetNodeID ID;
-    AddNodeIDNode(ID, Opcode, VTs, Ops);
+    SDNodeKey ID(Opcode, VTs, Ops);
     FoldingSetInsertToken InsertToken;
     if (SDNode *E = lookupNode(ID, DL, InsertToken)) {
       E->intersectFlagsWith(Flags);
@@ -9223,8 +9209,7 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
   SDVTList VTs = getVTList(VT);
   SDValue Ops[] = {N1, N2, N3};
   if (VT != MVT::Glue) {
-    FoldingSetNodeID ID;
-    AddNodeIDNode(ID, Opcode, VTs, Ops);
+    SDNodeKey ID(Opcode, VTs, Ops);
     FoldingSetInsertToken InsertToken;
     if (SDNode *E = lookupNode(ID, DL, InsertToken)) {
       E->intersectFlagsWith(Flags);
@@ -10463,8 +10448,7 @@ SDValue SelectionDAG::getAtomic(unsigned Opcode, const SDLoc &dl, EVT MemVT,
                                 SDVTList VTList, ArrayRef<SDValue> Ops,
                                 MachineMemOperand *MMO,
                                 ISD::LoadExtType ExtType) {
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, Opcode, VTList, Ops);
+  SDNodeKey ID(Opcode, VTList, Ops);
   ID.AddInteger(MemVT.getRawBits());
   ID.AddInteger(getSyntheticNodeSubclassData<AtomicSDNode>(
       dl.getIROrder(), Opcode, VTList, MemVT, MMO, ExtType));
@@ -10610,8 +10594,7 @@ SDValue SelectionDAG::getMemIntrinsicNode(unsigned Opcode, const SDLoc &dl,
   // Memoize the node unless it returns a glue result.
   MemIntrinsicSDNode *N;
   if (VTList.VTs[VTList.NumVTs-1] != MVT::Glue) {
-    FoldingSetNodeID ID;
-    AddNodeIDNode(ID, Opcode, VTList, Ops);
+    SDNodeKey ID(Opcode, VTList, Ops);
     ID.AddInteger(getSyntheticNodeSubclassData<MemIntrinsicSDNode>(
         Opcode, dl.getIROrder(), VTList, MemVT, MemRefs));
     ID.AddInteger(MemVT.getRawBits());
@@ -10650,8 +10633,7 @@ SDValue SelectionDAG::getLifetimeNode(bool IsStart, const SDLoc &dl,
                     getTargetLoweringInfo().getFrameIndexTy(getDataLayout()),
                     true)};
 
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, Opcode, VTs, Ops);
+  SDNodeKey ID(Opcode, VTs, Ops);
   FoldingSetInsertToken InsertToken;
   if (SDNode *E = lookupNode(ID, dl, InsertToken))
     return SDValue(E, 0);
@@ -10672,8 +10654,7 @@ SDValue SelectionDAG::getPseudoProbeNode(const SDLoc &Dl, SDValue Chain,
   const unsigned Opcode = ISD::PSEUDO_PROBE;
   const auto VTs = getVTList(MVT::Other);
   SDValue Ops[] = {Chain};
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, Opcode, VTs, Ops);
+  SDNodeKey ID(Opcode, VTs, Ops);
   ID.AddInteger(Guid);
   ID.AddInteger(Index);
   ID.AddInteger(Attr);
@@ -10788,8 +10769,7 @@ SDValue SelectionDAG::getLoad(ISD::MemIndexedMode AM, ISD::LoadExtType ExtType,
   SDVTList VTs = Indexed ?
     getVTList(VT, Ptr.getValueType(), MVT::Other) : getVTList(VT, MVT::Other);
   SDValue Ops[] = { Chain, Ptr, Offset };
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::LOAD, VTs, Ops);
+  SDNodeKey ID(ISD::LOAD, VTs, Ops);
   ID.AddInteger(MemVT.getRawBits());
   ID.AddInteger(getSyntheticNodeSubclassData<LoadSDNode>(
       dl.getIROrder(), VTs, AM, ExtType, MemVT, MMO));
@@ -10920,8 +10900,7 @@ SDValue SelectionDAG::getStore(SDValue Chain, const SDLoc &dl, SDValue Val,
   SDVTList VTs = Indexed ? getVTList(Ptr.getValueType(), MVT::Other)
                          : getVTList(MVT::Other);
   SDValue Ops[] = {Chain, Val, Ptr, Offset};
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::STORE, VTs, Ops);
+  SDNodeKey ID(ISD::STORE, VTs, Ops);
   ID.AddInteger(SVT.getRawBits());
   ID.AddInteger(getSyntheticNodeSubclassData<StoreSDNode>(
       dl.getIROrder(), VTs, AM, IsTruncating, SVT, MMO));
@@ -11038,8 +11017,7 @@ SDValue SelectionDAG::getLoadVP(ISD::MemIndexedMode AM,
   SDVTList VTs = Indexed ? getVTList(VT, Ptr.getValueType(), MVT::Other)
                          : getVTList(VT, MVT::Other);
   SDValue Ops[] = {Chain, Ptr, Offset, Mask, EVL};
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::VP_LOAD, VTs, Ops);
+  SDNodeKey ID(ISD::VP_LOAD, VTs, Ops);
   ID.AddInteger(MemVT.getRawBits());
   ID.AddInteger(getSyntheticNodeSubclassData<VPLoadSDNode>(
       dl.getIROrder(), VTs, AM, ExtType, IsExpanding, MemVT, MMO));
@@ -11138,8 +11116,7 @@ SDValue SelectionDAG::getStoreVP(SDValue Chain, const SDLoc &dl, SDValue Val,
   SDVTList VTs = Indexed ? getVTList(Ptr.getValueType(), MVT::Other)
                          : getVTList(MVT::Other);
   SDValue Ops[] = {Chain, Val, Ptr, Offset, Mask, EVL};
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::VP_STORE, VTs, Ops);
+  SDNodeKey ID(ISD::VP_STORE, VTs, Ops);
   ID.AddInteger(MemVT.getRawBits());
   ID.AddInteger(getSyntheticNodeSubclassData<VPStoreSDNode>(
       dl.getIROrder(), VTs, AM, IsTruncating, IsCompressing, MemVT, MMO));
@@ -11208,8 +11185,7 @@ SDValue SelectionDAG::getTruncStoreVP(SDValue Chain, const SDLoc &dl,
   SDVTList VTs = getVTList(MVT::Other);
   SDValue Undef = getPOISON(Ptr.getValueType());
   SDValue Ops[] = {Chain, Val, Ptr, Undef, Mask, EVL};
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::VP_STORE, VTs, Ops);
+  SDNodeKey ID(ISD::VP_STORE, VTs, Ops);
   ID.AddInteger(SVT.getRawBits());
   ID.AddInteger(getSyntheticNodeSubclassData<VPStoreSDNode>(
       dl.getIROrder(), VTs, ISD::UNINDEXED, true, IsCompressing, SVT, MMO));
@@ -11241,8 +11217,7 @@ SDValue SelectionDAG::getIndexedStoreVP(SDValue OrigStore, const SDLoc &dl,
   SDVTList VTs = getVTList(Base.getValueType(), MVT::Other);
   SDValue Ops[] = {ST->getChain(), ST->getValue(), Base,
                    Offset,         ST->getMask(),  ST->getVectorLength()};
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::VP_STORE, VTs, Ops);
+  SDNodeKey ID(ISD::VP_STORE, VTs, Ops);
   ID.AddInteger(ST->getMemoryVT().getRawBits());
   ID.AddInteger(ST->getRawSubclassData());
   ID.AddInteger(ST->getPointerInfo().getAddrSpace());
@@ -11274,8 +11249,7 @@ SDValue SelectionDAG::getStridedLoadVP(
   SDValue Ops[] = {Chain, Ptr, Offset, Stride, Mask, EVL};
   SDVTList VTs = Indexed ? getVTList(VT, Ptr.getValueType(), MVT::Other)
                          : getVTList(VT, MVT::Other);
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::EXPERIMENTAL_VP_STRIDED_LOAD, VTs, Ops);
+  SDNodeKey ID(ISD::EXPERIMENTAL_VP_STRIDED_LOAD, VTs, Ops);
   ID.AddInteger(MemVT.getRawBits());
   ID.AddInteger(getSyntheticNodeSubclassData<VPStridedLoadSDNode>(
       DL.getIROrder(), VTs, AM, ExtType, IsExpanding, MemVT, MMO));
@@ -11331,8 +11305,7 @@ SDValue SelectionDAG::getStridedStoreVP(SDValue Chain, const SDLoc &DL,
   SDVTList VTs = Indexed ? getVTList(Ptr.getValueType(), MVT::Other)
                          : getVTList(MVT::Other);
   SDValue Ops[] = {Chain, Val, Ptr, Offset, Stride, Mask, EVL};
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::EXPERIMENTAL_VP_STRIDED_STORE, VTs, Ops);
+  SDNodeKey ID(ISD::EXPERIMENTAL_VP_STRIDED_STORE, VTs, Ops);
   ID.AddInteger(MemVT.getRawBits());
   ID.AddInteger(getSyntheticNodeSubclassData<VPStridedStoreSDNode>(
       DL.getIROrder(), VTs, AM, IsTruncating, IsCompressing, MemVT, MMO));
@@ -11380,8 +11353,7 @@ SDValue SelectionDAG::getTruncStridedStoreVP(SDValue Chain, const SDLoc &DL,
   SDVTList VTs = getVTList(MVT::Other);
   SDValue Undef = getPOISON(Ptr.getValueType());
   SDValue Ops[] = {Chain, Val, Ptr, Undef, Stride, Mask, EVL};
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::EXPERIMENTAL_VP_STRIDED_STORE, VTs, Ops);
+  SDNodeKey ID(ISD::EXPERIMENTAL_VP_STRIDED_STORE, VTs, Ops);
   ID.AddInteger(SVT.getRawBits());
   ID.AddInteger(getSyntheticNodeSubclassData<VPStridedStoreSDNode>(
       DL.getIROrder(), VTs, ISD::UNINDEXED, true, IsCompressing, SVT, MMO));
@@ -11408,8 +11380,7 @@ SDValue SelectionDAG::getGatherVP(SDVTList VTs, EVT VT, const SDLoc &dl,
                                   ISD::MemIndexType IndexType) {
   assert(Ops.size() == 6 && "Incompatible number of operands");
 
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::VP_GATHER, VTs, Ops);
+  SDNodeKey ID(ISD::VP_GATHER, VTs, Ops);
   ID.AddInteger(VT.getRawBits());
   ID.AddInteger(getSyntheticNodeSubclassData<VPGatherSDNode>(
       dl.getIROrder(), VTs, VT, MMO, IndexType));
@@ -11452,8 +11423,7 @@ SDValue SelectionDAG::getScatterVP(SDVTList VTs, EVT VT, const SDLoc &dl,
                                    ISD::MemIndexType IndexType) {
   assert(Ops.size() == 7 && "Incompatible number of operands");
 
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::VP_SCATTER, VTs, Ops);
+  SDNodeKey ID(ISD::VP_SCATTER, VTs, Ops);
   ID.AddInteger(VT.getRawBits());
   ID.AddInteger(getSyntheticNodeSubclassData<VPScatterSDNode>(
       dl.getIROrder(), VTs, VT, MMO, IndexType));
@@ -11502,8 +11472,7 @@ SDValue SelectionDAG::getMaskedLoad(EVT VT, const SDLoc &dl, SDValue Chain,
   SDVTList VTs = Indexed ? getVTList(VT, Base.getValueType(), MVT::Other)
                          : getVTList(VT, MVT::Other);
   SDValue Ops[] = {Chain, Base, Offset, Mask, PassThru};
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::MLOAD, VTs, Ops);
+  SDNodeKey ID(ISD::MLOAD, VTs, Ops);
   ID.AddInteger(MemVT.getRawBits());
   ID.AddInteger(getSyntheticNodeSubclassData<MaskedLoadSDNode>(
       dl.getIROrder(), VTs, AM, ExtTy, isExpanding, MemVT, MMO));
@@ -11551,8 +11520,7 @@ SDValue SelectionDAG::getMaskedStore(SDValue Chain, const SDLoc &dl,
   SDVTList VTs = Indexed ? getVTList(Base.getValueType(), MVT::Other)
                          : getVTList(MVT::Other);
   SDValue Ops[] = {Chain, Val, Base, Offset, Mask};
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::MSTORE, VTs, Ops);
+  SDNodeKey ID(ISD::MSTORE, VTs, Ops);
   ID.AddInteger(MemVT.getRawBits());
   ID.AddInteger(getSyntheticNodeSubclassData<MaskedStoreSDNode>(
       dl.getIROrder(), VTs, AM, IsTruncating, IsCompressing, MemVT, MMO));
@@ -11593,8 +11561,7 @@ SDValue SelectionDAG::getMaskedGather(SDVTList VTs, EVT MemVT, const SDLoc &dl,
                                       ISD::LoadExtType ExtTy) {
   assert(Ops.size() == 6 && "Incompatible number of operands");
 
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::MGATHER, VTs, Ops);
+  SDNodeKey ID(ISD::MGATHER, VTs, Ops);
   ID.AddInteger(MemVT.getRawBits());
   ID.AddInteger(getSyntheticNodeSubclassData<MaskedGatherSDNode>(
       dl.getIROrder(), VTs, MemVT, MMO, IndexType, ExtTy));
@@ -11640,8 +11607,7 @@ SDValue SelectionDAG::getMaskedScatter(SDVTList VTs, EVT MemVT, const SDLoc &dl,
                                        bool IsTrunc) {
   assert(Ops.size() == 6 && "Incompatible number of operands");
 
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::MSCATTER, VTs, Ops);
+  SDNodeKey ID(ISD::MSCATTER, VTs, Ops);
   ID.AddInteger(MemVT.getRawBits());
   ID.AddInteger(getSyntheticNodeSubclassData<MaskedScatterSDNode>(
       dl.getIROrder(), VTs, MemVT, MMO, IndexType, IsTrunc));
@@ -11685,8 +11651,7 @@ SDValue SelectionDAG::getMaskedHistogram(SDVTList VTs, EVT MemVT,
                                          ISD::MemIndexType IndexType) {
   assert(Ops.size() == 7 && "Incompatible number of operands");
 
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::EXPERIMENTAL_VECTOR_HISTOGRAM, VTs, Ops);
+  SDNodeKey ID(ISD::EXPERIMENTAL_VECTOR_HISTOGRAM, VTs, Ops);
   ID.AddInteger(MemVT.getRawBits());
   ID.AddInteger(getSyntheticNodeSubclassData<MaskedHistogramSDNode>(
       dl.getIROrder(), VTs, MemVT, MMO, IndexType));
@@ -11722,8 +11687,7 @@ SDValue SelectionDAG::getLoadFFVP(EVT VT, const SDLoc &DL, SDValue Chain,
                                   MachineMemOperand *MMO) {
   SDVTList VTs = getVTList(VT, EVL.getValueType(), MVT::Other);
   SDValue Ops[] = {Chain, Ptr, Mask, EVL};
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::VP_LOAD_FF, VTs, Ops);
+  SDNodeKey ID(ISD::VP_LOAD_FF, VTs, Ops);
   ID.AddInteger(VT.getRawBits());
   ID.AddInteger(getSyntheticNodeSubclassData<VPLoadFFSDNode>(DL.getIROrder(),
                                                              VTs, VT, MMO));
@@ -11750,8 +11714,7 @@ SDValue SelectionDAG::getGetFPEnv(SDValue Chain, const SDLoc &dl, SDValue Ptr,
   assert(Chain.getValueType() == MVT::Other && "Invalid chain type");
   SDVTList VTs = getVTList(MVT::Other);
   SDValue Ops[] = {Chain, Ptr};
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::GET_FPENV_MEM, VTs, Ops);
+  SDNodeKey ID(ISD::GET_FPENV_MEM, VTs, Ops);
   ID.AddInteger(MemVT.getRawBits());
   ID.AddInteger(getSyntheticNodeSubclassData<FPStateAccessSDNode>(
       ISD::GET_FPENV_MEM, dl.getIROrder(), VTs, MemVT, MMO));
@@ -11777,8 +11740,7 @@ SDValue SelectionDAG::getSetFPEnv(SDValue Chain, const SDLoc &dl, SDValue Ptr,
   assert(Chain.getValueType() == MVT::Other && "Invalid chain type");
   SDVTList VTs = getVTList(MVT::Other);
   SDValue Ops[] = {Chain, Ptr};
-  FoldingSetNodeID ID;
-  AddNodeIDNode(ID, ISD::SET_FPENV_MEM, VTs, Ops);
+  SDNodeKey ID(ISD::SET_FPENV_MEM, VTs, Ops);
   ID.AddInteger(MemVT.getRawBits());
   ID.AddInteger(getSyntheticNodeSubclassData<FPStateAccessSDNode>(
       ISD::SET_FPENV_MEM, dl.getIROrder(), VTs, MemVT, MMO));
@@ -12003,8 +11965,7 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
   SDVTList VTs = getVTList(VT);
 
   if (VT != MVT::Glue) {
-    FoldingSetNodeID ID;
-    AddNodeIDNode(ID, Opcode, VTs, Ops);
+    SDNodeKey ID(Opcode, VTs, Ops);
     FoldingSetInsertToken InsertToken;
 
     if (SDNode *E = lookupNode(ID, DL, InsertToken)) {
@@ -12200,8 +12161,7 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList,
   // Memoize the node unless it returns a glue result.
   SDNode *N;
   if (VTList.VTs[VTList.NumVTs-1] != MVT::Glue) {
-    FoldingSetNodeID ID;
-    AddNodeIDNode(ID, Opcode, VTList, Ops);
+    SDNodeKey ID(Opcode, VTList, Ops);
     FoldingSetInsertToken InsertToken;
     if (SDNode *E = lookupNode(ID, DL, InsertToken)) {
       E->intersectFlagsWith(Flags);
@@ -12553,9 +12513,8 @@ SDNode *SelectionDAG::MorphNodeTo(SDNode *N, unsigned Opc,
   // If an identical node already exists, use it.
   FoldingSetInsertToken InsertToken;
   if (VTs.VTs[VTs.NumVTs-1] != MVT::Glue) {
-    FoldingSetNodeID ID;
-    AddNodeIDNode(ID, Opc, VTs, Ops);
-    AddNodeIDCustom(ID, N, Opc);
+    SDNodeKey ID(Opc, VTs, Ops);
+    AddNodeIDCustom(ID.Tail, N, Opc);
     if (SDNode *ON = lookupNode(ID, SDLoc(N), InsertToken))
       return UpdateSDLocOnMergeSDNode(ON, SDLoc(N));
   }
@@ -12746,8 +12705,7 @@ MachineSDNode *SelectionDAG::getMachineNode(unsigned Opcode, const SDLoc &DL,
   FoldingSetInsertToken InsertToken;
 
   if (DoCSE) {
-    FoldingSetNodeID ID;
-    AddNodeIDNode(ID, ~Opcode, VTs, Ops);
+    SDNodeKey ID(~Opcode, VTs, Ops);
     if (SDNode *E = lookupNode(ID, DL, InsertToken)) {
       return cast<MachineSDNode>(UpdateSDLocOnMergeSDNode(E, DL));
     }
@@ -12804,8 +12762,7 @@ SDNode *SelectionDAG::getNodeIfExists(unsigned Opcode, SDVTList VTList,
     return nullptr;
 
   auto Lookup = [&](ArrayRef<SDValue> LookupOps) -> SDNode * {
-    FoldingSetNodeID ID;
-    AddNodeIDNode(ID, Opcode, VTList, LookupOps);
+    SDNodeKey ID(Opcode, VTList, LookupOps);
     FoldingSetInsertToken InsertToken;
     if (SDNode *E = lookupNode(ID, InsertToken)) {
       E->intersectFlagsWith(Flags);
@@ -12827,8 +12784,7 @@ SDNode *SelectionDAG::getNodeIfExists(unsigned Opcode, SDVTList VTList,
 bool SelectionDAG::doesNodeExist(unsigned Opcode, SDVTList VTList,
                                  ArrayRef<SDValue> Ops) {
   if (VTList.VTs[VTList.NumVTs - 1] != MVT::Glue) {
-    FoldingSetNodeID ID;
-    AddNodeIDNode(ID, Opcode, VTList, Ops);
+    SDNodeKey ID(Opcode, VTList, Ops);
     FoldingSetInsertToken InsertToken;
     if (lookupNode(ID, SDLoc(), InsertToken))
       return true;
@@ -14067,12 +14023,6 @@ MemSDNode::MemSDNode(
           TypeSize::isKnownLE(memvt.getStoreSize(),
                               getMemOperand()->getSize().getValue())) &&
          "Size mismatch!");
-}
-
-/// Profile - Gather unique data for the node.
-///
-void SDNode::Profile(FoldingSetNodeID &ID) const {
-  AddNodeIDNode(ID, this);
 }
 
 namespace {

--- a/llvm/unittests/ADT/FoldingSet.cpp
+++ b/llvm/unittests/ADT/FoldingSet.cpp
@@ -644,8 +644,8 @@ static_assert(std::is_same_v<UniquingSetInfo<RefKeyNode>::KeyTy,
                              std::pair<unsigned, unsigned>>,
               "KeyTy must decay to a value type");
 
-// A node with no getKey(): the Info supplies the three-member contract itself,
-// and the key aliases storage owned by the node.
+// A node with no getKey(): the Info supplies the whole contract itself, and the
+// key aliases storage owned by the node.
 struct VectorNode : FoldingSetNode {
   SmallVector<unsigned, 4> Elts;
   explicit VectorNode(ArrayRef<unsigned> E) : Elts(E) {}
@@ -659,6 +659,10 @@ struct VectorNodeInfo {
     for (unsigned E : Key)
       H = detail::combineHashValue(H, DenseMapInfo<unsigned>::getHashValue(E));
     return H;
+  }
+  // Compare against the node's storage rather than building a key from it.
+  static bool isEqual(const KeyTy &Key, const VectorNode &N) {
+    return Key == KeyTy(N.Elts);
   }
 };
 


### PR DESCRIPTION
CSEMap keys SDNodes by a serialized FoldingSetNodeID. Every lookup
profiles the opcode, the VT list and the operands into a buffer, and
every probe rebuilds the candidate's whole profile to compare against
it.

UniquingSet compared a key against Info::getKey(*N), building a key from
the candidate on every probe. Add isEqual to the Info contract,
defaulting to that comparison, and expose a FoldingSetNodeID's
accumulated words as a FoldingSetNodeIDRef so an Info that carries one
can hash it.

Key nodes by SDNodeKey, which holds those fields directly and leaves
only what AddNodeIDCustom contributes serialized in a tail, which is
empty for most opcodes. A lookup site keeps its ID.AddXxx lines: the key
forwards them to the tail. isEqual matches the key against a candidate's
fields and builds only the tail; an assertions build cross-checks the
result against the profile both would have had.

Aided by Opus 5