### PR TITLE
[SROA] Remove pointer bitcast lookthrough for selects

### DIFF
--- a/llvm/lib/Transforms/Scalar/SROA.cpp
+++ b/llvm/lib/Transforms/Scalar/SROA.cpp
@@ -233,8 +233,6 @@ class SROA {
   /// We can do this to a select if its only uses are loads
   /// and if either the operand to the select can be loaded unconditionally,
   ///        or if we are allowed to perform CFG modifications.
-  /// If found an intervening bitcast with a single use of the load,
-  /// allow the promotion.
   static std::optional<RewriteableMemOps>
   isSafeSelectToSpeculate(SelectInst &SI, bool PreserveCFG);
 
@@ -1722,9 +1720,6 @@ SROA::isSafeSelectToSpeculate(SelectInst &SI, bool PreserveCFG) {
   RewriteableMemOps Ops;
 
   for (User *U : SI.users()) {
-    if (auto *BC = dyn_cast<BitCastInst>(U); BC && BC->hasOneUse())
-      U = *BC->user_begin();
-
     if (auto *Store = dyn_cast<StoreInst>(U)) {
       // Note that atomic stores can be transformed; atomic semantics do not
       // have any meaning for a local alloca. Stores are not speculatable,

--- a/llvm/test/Transforms/SROA/select-load.ll
+++ b/llvm/test/Transforms/SROA/select-load.ll
@@ -4,10 +4,9 @@
 
 %st.half = type { half }
 
-; Allow speculateSelectInstLoads to fold load and select
-; even if there is an intervening bitcast.
-define <2 x i16> @test_load_bitcast_select(i1 %cond1, i1 %cond2) {
-; CHECK-LABEL: @test_load_bitcast_select(
+; Allow speculateSelectInstLoads to fold a load of a select.
+define <2 x i16> @test_load_select(i1 %cond1, i1 %cond2) {
+; CHECK-LABEL: @test_load_select(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = bitcast half -nan(0x1FF) to i16
 ; CHECK-NEXT:    [[TMP1:%.*]] = bitcast half 0.000000e+00 to i16
@@ -35,7 +34,7 @@ entry:
 
 %st.args = type { i32, ptr }
 
-; A bitcasted load and a direct load of select.
+; Multiple loads of a select.
 define void @test_multiple_loads_select(i1 %cmp) {
 ; CHECK-LABEL: @test_multiple_loads_select(
 ; CHECK-NEXT:  entry:


### PR DESCRIPTION
`isSafeSelectToSpeculate` finds load users of the select through bitcasts. But bitcasts from pointer to pointer don't happen anymore (or are really uncommon?) after the introduction of opaque pointers. Remove this functionality.

llvm-opt-benchmark shows no perf diff.