### PR TITLE
[C++20] [Modules] Profiling the lambda call operator only

### DIFF
--- a/clang/lib/AST/StmtProfile.cpp
+++ b/clang/lib/AST/StmtProfile.cpp
@@ -2243,7 +2243,11 @@ StmtProfiler::VisitLambdaExpr(const LambdaExpr *S) {
     else if (auto *FD = dyn_cast<FunctionDecl>(SubDecl))
       Call = FD;
 
-    if (!Call)
+    // Ignore implicit conversion functions and __invoke. They are not
+    // part of the lambda signature.
+    // Semantically, it is better to use `getLambdaCallOperator` but that may
+    // not be properly deserialized yet.
+    if (!Call || Call->getOverloadedOperator() != OO_Call)
       continue;
 
     Hasher.AddFunctionDecl(Call, /*SkipBody=*/true);

--- a/clang/test/Modules/pr220187.cppm
+++ b/clang/test/Modules/pr220187.cppm
@@ -1,0 +1,40 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+//
+// RUN: %clang_cc1 -std=c++23 -emit-module-interface %t/runner.cppm -o %t/runner.pcm
+// RUN: %clang_cc1 -std=c++23 -fmodule-file=runner=%t/runner.pcm -fsyntax-only -verify %t/main.cpp
+//
+// Test again with reduced BMI.
+// RUN: %clang_cc1 -std=c++23 -emit-module-interface %t/runner.cppm -o %t/runner.pcm
+// RUN: %clang_cc1 -std=c++23 -fmodule-file=runner=%t/runner.pcm -fsyntax-only -verify %t/main.cpp
+
+//--- shared.hpp
+#pragma once
+
+class Runner {
+public:
+  template <typename V>
+    requires requires { []() {}(); }
+  static void run(const V &value) { (void)value; }
+
+  template <typename V>
+    requires requires { []() {}(); }
+  void runNonStatic(const V &value) { (void)value; }
+};
+
+//--- runner.cppm
+module;
+#include "shared.hpp"
+export module runner;
+export using ::Runner;
+
+//--- main.cpp
+// expected-no-diagnostics
+#include "shared.hpp"
+import runner;
+
+void test() {
+  Runner::run(42);
+  Runner{}.runNonStatic(42);
+}

--- a/clang/test/Modules/pr220187.cppm
+++ b/clang/test/Modules/pr220187.cppm
@@ -6,7 +6,7 @@
 // RUN: %clang_cc1 -std=c++23 -fmodule-file=runner=%t/runner.pcm -fsyntax-only -verify %t/main.cpp
 //
 // Test again with reduced BMI.
-// RUN: %clang_cc1 -std=c++23 -emit-module-interface %t/runner.cppm -o %t/runner.pcm
+// RUN: %clang_cc1 -std=c++23 -emit-reduced-module-interface %t/runner.cppm -o %t/runner.pcm
 // RUN: %clang_cc1 -std=c++23 -fmodule-file=runner=%t/runner.pcm -fsyntax-only -verify %t/main.cpp
 
 //--- shared.hpp


### PR DESCRIPTION
Close https://github.com/llvm/llvm-project/issues/220187

The root cause of the problem is that during the deserialization process some of the implicit functions are out of sync. They will be the same in the end. But at the point of profiling, they are different.

This patch fixes this by profiling the explicit lambda call only, which should be correct too. This was the intention of CXXRecordDecl::getLambdaCallOperator(), but we didn't use it due to deserialization ordering issues.