### PR TITLE
[clang] Diagnose missing members in incomplete CRTP classes

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12528,6 +12528,7 @@ public:
 
   protected:
     Sema &S;
+    bool hadPreviousSFINAEContext() const { return Prev != nullptr; }
     ~SFINAEContextBase() { S.CurrentSFINAEContext = Prev; }
     SFINAEContextBase(const SFINAEContextBase &) = delete;
     SFINAEContextBase &operator=(const SFINAEContextBase &) = delete;
@@ -12536,8 +12537,31 @@ public:
     SFINAETrap *Prev;
   };
 
+  struct ClassInstantiationSFINAEContext {
+    const CXXRecordDecl *Record;
+    bool HadActiveSFINAEContext;
+  };
+
   struct NonSFINAEContext : SFINAEContextBase {
     NonSFINAEContext(Sema &S) : SFINAEContextBase(S, nullptr) {}
+
+    NonSFINAEContext(Sema &S, const CXXRecordDecl *Record)
+        : SFINAEContextBase(S, nullptr),
+          Record(Record->getCanonicalDecl()) {
+      S.ClassInstantiationSFINAEContexts.push_back(
+          {this->Record, hadPreviousSFINAEContext()});
+    }
+
+    ~NonSFINAEContext() {
+      if (!Record)
+        return;
+      assert(!S.ClassInstantiationSFINAEContexts.empty());
+      assert(S.ClassInstantiationSFINAEContexts.back().Record == Record);
+      S.ClassInstantiationSFINAEContexts.pop_back();
+    }
+
+  private:
+    const CXXRecordDecl *Record = nullptr;
   };
 
   /// RAII class used to determine whether SFINAE has
@@ -13725,6 +13749,11 @@ public:
 
   SFINAETrap *CurrentSFINAEContext = nullptr;
 
+  /// Active class instantiations and whether entering each one suspended a
+  /// SFINAE context.
+  SmallVector<ClassInstantiationSFINAEContext, 4>
+      ClassInstantiationSFINAEContexts;
+
   /// The number of \p CodeSynthesisContexts that are not template
   /// instantiations and, therefore, should not be counted as part of the
   /// instantiation depth.
@@ -13794,6 +13823,22 @@ public:
   }
   [[nodiscard]] bool isSFINAEContext() const {
     return CurrentSFINAEContext != nullptr;
+  }
+
+  /// Whether \p Record is being instantiated and a strict descendant class
+  /// instantiation suspended a SFINAE context.
+  [[nodiscard]] bool hasSFINAEContextInDescendantClassInstantiation(
+      const CXXRecordDecl *Record) const {
+    Record = Record->getCanonicalDecl();
+    bool HasSFINAEContext = false;
+    for (auto I = ClassInstantiationSFINAEContexts.rbegin(),
+              E = ClassInstantiationSFINAEContexts.rend();
+         I != E; ++I) {
+      if (I->Record == Record)
+        return HasSFINAEContext;
+      HasSFINAEContext |= I->HadActiveSFINAEContext;
+    }
+    return false;
   }
 
   /// Perform substitution on the type T with a given set of template

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12546,8 +12546,7 @@ public:
     NonSFINAEContext(Sema &S) : SFINAEContextBase(S, nullptr) {}
 
     NonSFINAEContext(Sema &S, const CXXRecordDecl *Record)
-        : SFINAEContextBase(S, nullptr),
-          Record(Record->getCanonicalDecl()) {
+        : SFINAEContextBase(S, nullptr), Record(Record->getCanonicalDecl()) {
       S.ClassInstantiationSFINAEContexts.push_back(
           {this->Record, hadPreviousSFINAEContext()});
     }

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -3067,8 +3067,12 @@ ExprResult Sema::BuildQualifiedDeclarationNameExpr(
     // is invalid because it's derived from an invalid base class, then missing
     // members were likely supposed to be inherited.
     DeclContext *DC = computeDeclContext(SS);
+    // A nested class instantiation may have disabled SFINAE while recursively
+    // looking back into a still-being-defined outer class.
     if (const auto *CD = dyn_cast<CXXRecordDecl>(DC))
-      if (CD->isInvalidDecl() || CD->isBeingDefined())
+      if (CD->isInvalidDecl() ||
+          (CD->isBeingDefined() && !isSFINAEContext() &&
+           hasSFINAEContextInDescendantClassInstantiation(CD)))
         return ExprError();
     Diag(NameInfo.getLoc(), diag::err_no_member)
       << NameInfo.getName() << DC << SS.getRange();

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -3607,7 +3607,7 @@ bool Sema::InstantiateClassImpl(
     Spec->setPointOfInstantiation(PointOfInstantiation);
   }
 
-  NonSFINAEContext _(*this);
+  NonSFINAEContext _(*this, Instantiation);
   InstantiatingTemplate Inst(*this, PointOfInstantiation, Instantiation);
   if (Inst.isInvalid())
     return true;

--- a/clang/test/SemaTemplate/GH220031.cpp
+++ b/clang/test/SemaTemplate/GH220031.cpp
@@ -1,0 +1,106 @@
+// RUN: %clang_cc1 -std=c++11 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify %s
+
+template <bool B>
+struct EnableIf {};
+
+template <>
+struct EnableIf<true> {
+  using type = int;
+};
+
+template <class T, T V>
+struct IntegralConstant {
+  static constexpr T value = V;
+};
+
+namespace NonTemplate {
+
+template <class T>
+// expected-error@+1 {{no member named 'flag'}}
+struct Trait : IntegralConstant<bool, T::flag> {};
+
+template <class D>
+struct CRTP {
+  // expected-note@+1 {{in instantiation of template class}}
+  template <typename EnableIf<Trait<D>::value>::type = 0>
+  void fn() const {}
+};
+
+// expected-note@+1 {{in instantiation of template class}}
+struct Derived : CRTP<Derived> {
+  static constexpr bool flag = true;
+};
+
+} // namespace NonTemplate
+
+namespace Templated {
+
+template <class T>
+// expected-error@+1 {{no member named 'flag'}}
+struct Trait : IntegralConstant<bool, T::flag> {};
+
+template <class D>
+struct CRTP {
+  // expected-note@+1 {{in instantiation of template class}}
+  template <typename EnableIf<Trait<D>::value>::type = 0>
+  void fn() const {}
+};
+
+template <class T>
+// expected-note@+1 {{in instantiation of template class}}
+struct Derived : CRTP<Derived<T>> {};
+
+// expected-note@+1 {{in instantiation of template class}}
+Derived<void> derived;
+
+} // namespace Templated
+
+// Errors in a class body instantiated as a side effect of deduction are not in
+// the immediate context and must not be treated as substitution failures.
+namespace TargetOwnsSFINAE {
+
+template <bool>
+struct Holder {
+  using type = int;
+};
+
+template <class T>
+// expected-error@+1 {{no member named 'flag'}}
+struct Trait : Holder<T::flag> {};
+
+template <class T>
+// expected-note@+1 {{in instantiation of template class}}
+struct Bad : Trait<Bad<T>> {};
+
+template <class T>
+// expected-note@+1 {{in instantiation of template class}}
+typename Bad<T>::type probe(int);
+
+template <class>
+char probe(...);
+
+// expected-note@+1 {{while substituting explicitly-specified template}}
+int x = sizeof(probe<int>(0));
+
+} // namespace TargetOwnsSFINAE
+
+// A lookup performed directly in a live SFINAE context must still select the
+// fallback when the member is declared later in the class.
+namespace LiveSFINAE {
+
+using Yes = char[1];
+using No = char[2];
+
+template <class T, int = T::value>
+No &probe(int);
+
+template <class>
+Yes &probe(...);
+
+struct A {
+  static_assert(sizeof(probe<A>(0)) == sizeof(Yes), "");
+  static constexpr int value = 1;
+};
+
+} // namespace LiveSFINAE


### PR DESCRIPTION
Fixes #220031.

`BuildQualifiedDeclarationNameExpr` currently suppresses every failed qualified lookup into a class that is still being defined. That suppression is needed for GH179118, where a nested SFINAE-driven class instantiation recursively looks back into an outer class, but it also lets the invalid CRTP declaration in #220031 enter the AST and later crash CodeGen.

This change records the active class-instantiation lineage and whether entering each frame directly suspended a live SFINAE context. Silent recovery is retained only when lookup reaches a still-being-defined outer class from a strict descendant class instantiation that suspended SFINAE. Other failed lookups take the existing `err_no_member` path.

The regression coverage includes:

- the original non-template CRTP reproducer;
- a templated missing-member variant that was previously accepted;
- a class instantiated directly under external SFINAE, whose class-body error must remain a hard error;
- lookup under a currently live SFINAE context, which must still select its fallback.

The existing GH179118 regression remains passing in C++11, C++20, and C++2c. The original `-g -S` reproducer now exits with the Sema diagnostic instead of aborting in CodeGen.

Testing:

- `clang -cc1 -std=c++11 -fsyntax-only -verify clang/test/SemaTemplate/GH220031.cpp`
- `clang -cc1 -std=c++20 -fsyntax-only -verify clang/test/SemaTemplate/GH220031.cpp`
- `clang/test/SemaCXX/overload-resolution-deferred-templates.cpp` in C++11, C++20, and C++2c
- `clang/test/SemaCXX/access-base-class.cpp`
- exact #220031 reproducer with `-std=c++20 -g -S -fno-crash-diagnostics`

AI assistance disclosure: AI-assisted tools (OpenAI Codex) were used during investigation, implementation, and test development. I reviewed the proposed change and test evidence and remain responsible for the contribution.