### PR TITLE
[CIR] Support direct-in-registers aggregates and array coercions in call-conv lowering

### DIFF
--- a/clang/include/clang/CIR/Dialect/Passes.h
+++ b/clang/include/clang/CIR/Dialect/Passes.h
@@ -20,7 +20,7 @@ namespace cir {
 /// The ABI target whose calling-convention rules drive CallConvLowering.
 /// None is the unset state used when the pass runs in classification-attr
 /// mode instead of selecting a target.
-enum class CallConvTarget { None, Test, X86_64 };
+enum class CallConvTarget { None, Test, X86_64, AMDGPU };
 } // namespace cir
 
 namespace clang {

--- a/clang/include/clang/CIR/Dialect/Passes.td
+++ b/clang/include/clang/CIR/Dialect/Passes.td
@@ -246,7 +246,9 @@ def CallConvLowering : Pass<"cir-call-conv-lowering", "mlir::ModuleOp"> {
              clEnumValN(cir::CallConvTarget::Test, "test",
                         "MLIR test ABI target"),
              clEnumValN(cir::CallConvTarget::X86_64, "x86_64",
-                        "x86_64 System V")
+                        "x86_64 System V"),
+             clEnumValN(cir::CallConvTarget::AMDGPU, "amdgpu",
+                        "AMDGPU")
            )}]>,
     Option<"classificationAttr", "classification-attr", "std::string",
            /*default=*/"\"\"",

--- a/clang/lib/CIR/Dialect/Transforms/CallConvLoweringPass.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CallConvLoweringPass.cpp
@@ -297,6 +297,12 @@ static mlir::Type abiTypeToCIR(const llvm::abi::Type *ty, MLIRContext *ctx) {
         return cir::VectorType::get(elemCIR,
                                     vecTy->getNumElements().getFixedValue());
       })
+      .Case([&](const llvm::abi::ArrayType *arrTy) -> mlir::Type {
+        mlir::Type elemCIR = abiTypeToCIR(arrTy->getElementType(), ctx);
+        if (!elemCIR)
+          return nullptr;
+        return cir::ArrayType::get(elemCIR, arrTy->getNumElements());
+      })
       .Case([&](const llvm::abi::RecordType *recTy) -> mlir::Type {
         SmallVector<mlir::Type> fieldTypes;
         fieldTypes.reserve(recTy->getFields().size());
@@ -455,9 +461,11 @@ static const llvm::abi::Type *mapCIRType(mlir::Type type,
 /// split into a tuple of them, and a scalar the classifier widens to fill its
 /// eightbyte.  getDirect keeps canFlatten set so the rewriter can split a
 /// multi-field coerced struct into individual wire arguments.  Any other scalar
-/// passes in its natural CIR type, which a null coercion denotes.  A coercion
-/// this bridge cannot represent yields std::nullopt so the caller reports NYI
-/// rather than silently passing the value unchanged.
+/// passes in its natural CIR type, which a null coercion denotes. An aggregate
+/// with a null coercion is likewise passed directly in registers, which the
+/// target backend splits.  A coercion this bridge cannot represent yields
+/// std::nullopt so the caller reports NYI rather than silently passing the
+/// value unchanged.
 ///
 /// Extend: bool or a sub-register integer needs a signext/zeroext attribute.
 /// The x86_64 classifier (llvm/lib/ABI/Targets/X86.cpp) only returns Extend
@@ -480,6 +488,9 @@ convertABIArgInfo(const llvm::abi::ArgInfo &info, MLIRContext *ctx,
     // The classifier names a coerce type even where it matches the natural
     // type, so a non-null coerce does not by itself mean a rewrite is needed.
     const llvm::abi::Type *coerceAbi = info.getCoerceToType();
+    // A null coerce is always a pass-through.
+    if (!coerceAbi)
+      return ArgClassification::getDirect(nullptr);
     bool isAggregate = isa_and_present<cir::RecordType, cir::ArrayType>(origTy);
     // For a _Complex or a vector the classifier's coerce is only sometimes the
     // natural type, so it has to be read rather than assumed.

--- a/clang/lib/CIR/Dialect/Transforms/CallConvLoweringPass.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CallConvLoweringPass.cpp
@@ -80,7 +80,7 @@ namespace {
 // bit-field access unit, a record holding an empty-for-ABI member that
 // occupies bytes or a zero-sized one off its own alignment, a union no member
 // of which spans its declared size, and a union with an empty-record member
-// are reported NYI by classifyX86_64Function so an unsupported signature
+// are reported NYI by classifyAbiSignature so an unsupported signature
 // fails the pass instead of being misclassified.
 //===----------------------------------------------------------------------===//
 
@@ -142,7 +142,7 @@ static bool reachesNamedBitFieldUnit(mlir::Type ty) {
 /// whose members are all themselves supported, or an array of a supported
 /// element type.  Also a `_Complex`, or a fixed-width vector, of a supported
 /// element type.  Everything else is reported NYI at the reject() choke point
-/// in classifyX86_64Function.
+/// in classifyAbiSignature.
 static bool isSupportedType(mlir::Type ty, const DataLayout &dl) {
   // A pointer is only handled in the default address space (null) or an
   // already-lowered target address space.  A LangAddressSpaceAttr must be
@@ -314,7 +314,7 @@ static mlir::Type abiTypeToCIR(const llvm::abi::Type *ty, MLIRContext *ctx) {
       .Default([](const llvm::abi::Type *) -> mlir::Type { return nullptr; });
 }
 
-/// Map a CIR type to an llvm::abi::Type.  classifyX86_64Function pre-filters
+/// Map a CIR type to an llvm::abi::Type.  classifyAbiSignature pre-filters
 /// the signature, so only the scalar and struct/array types handled here can
 /// reach this function.
 static const llvm::abi::Type *mapCIRType(mlir::Type type,
@@ -442,7 +442,7 @@ static const llvm::abi::Type *mapCIRType(mlir::Type type,
       })
       .Default([](mlir::Type) -> const llvm::abi::Type * {
         llvm_unreachable(
-            "mapCIRType: type not pre-filtered by classifyX86_64Function");
+            "mapCIRType: type not pre-filtered by classifyAbiSignature");
       });
 }
 
@@ -535,20 +535,31 @@ static llvm::abi::RequiredArgs requiredArgs(cir::FuncType fnTy) {
   return llvm::abi::RequiredArgs(fnTy.getNumInputs());
 }
 
-/// Classify an x86_64 SysV signature (return type + argument types) using the
-/// LLVM ABI library.  Shared by the cir.func path, the variadic-call path and
-/// the indirect-call path (the latter classifies from the callee function
+/// Map a cir.func calling convention to the llvm::CallingConv the ABI
+/// classifier keys on.  Only the AMDGPU kernel convention changes
+/// classification today; every other convention is classified as C.
+static llvm::CallingConv::ID abiCallingConv(cir::CallingConv cc) {
+  if (cc == cir::CallingConv::AMDGPUKernel)
+    return llvm::CallingConv::AMDGPU_KERNEL;
+  return llvm::CallingConv::C;
+}
+
+/// Classify a signature (return type + argument types) for \p targetInfo using
+/// the LLVM ABI library.  Shared by the cir.func path, the variadic-call path
+/// and the indirect-call path (the latter classifies from the callee function
 /// pointer's pointee FuncType).  \p required marks where the declared
 /// parameters in \p inputs end.  The classifier treats every argument past that
-/// point as passed through an ellipsis.  Returns std::nullopt and emits an NYI
-/// error via \p emitError if the signature uses a type the bridge does not
-/// handle yet.
-static std::optional<FunctionClassification> classifyX86_64Signature(
-    mlir::Type retCIR, mlir::TypeRange inputs, llvm::abi::RequiredArgs required,
-    MLIRContext *ctx, const DataLayout &dl,
-    mlir::abi::ABITypeMapper &typeMapper,
-    const llvm::abi::TargetInfo &targetInfo, ModuleOp modOp,
-    llvm::function_ref<mlir::InFlightDiagnostic()> emitError) {
+/// point as passed through an ellipsis.  \p callConv selects the ABI convention
+/// (e.g. AMDGPU_KERNEL), which some targets classify differently.  Returns
+/// std::nullopt and emits an NYI error via \p emitError if the signature uses a
+/// type the bridge does not handle yet.
+static std::optional<FunctionClassification>
+classifyAbiSignature(mlir::Type retCIR, mlir::TypeRange inputs,
+                     llvm::abi::RequiredArgs required, MLIRContext *ctx,
+                     const DataLayout &dl, mlir::abi::ABITypeMapper &typeMapper,
+                     const llvm::abi::TargetInfo &targetInfo,
+                     llvm::CallingConv::ID callConv, ModuleOp modOp,
+                     llvm::function_ref<mlir::InFlightDiagnostic()> emitError) {
   assert(retCIR && "signature return type must be non-null");
   assert((!required.allowsOptionalArgs() ||
           required.getNumRequiredArgs() <= inputs.size()) &&
@@ -558,9 +569,8 @@ static std::optional<FunctionClassification> classifyX86_64Signature(
   auto reject = [&](mlir::Type t) -> bool {
     if (isSupportedType(t, dl))
       return false;
-    emitError()
-        << "x86_64 calling-convention lowering not yet implemented for type "
-        << t;
+    emitError() << "calling-convention lowering not yet implemented for type "
+                << t;
     return true;
   };
   if (!voidRet && reject(retCIR))
@@ -576,15 +586,15 @@ static std::optional<FunctionClassification> classifyX86_64Signature(
   for (mlir::Type a : inputs)
     argAbi.push_back(mapCIRType(a, typeMapper, dl, modOp));
 
-  std::unique_ptr<llvm::abi::FunctionInfo> fi = llvm::abi::FunctionInfo::create(
-      llvm::CallingConv::C, retAbi, argAbi, required);
+  std::unique_ptr<llvm::abi::FunctionInfo> fi =
+      llvm::abi::FunctionInfo::create(callConv, retAbi, argAbi, required);
   targetInfo.computeInfo(*fi);
 
   // convertABIArgInfo returns nullopt when the classifier picks a coercion this
   // bridge cannot represent.
   auto nyiCoercion = [&](mlir::Type t) {
-    emitError() << "x86_64 calling-convention lowering not yet "
-                   "implemented for the ABI coercion of type "
+    emitError() << "calling-convention lowering not yet implemented for the "
+                   "ABI coercion of type "
                 << t;
   };
 
@@ -636,19 +646,19 @@ static llvm::abi::X86AVXABILevel funcAvxLevel(cir::FuncOp func,
   return avx ? std::max(base, llvm::abi::X86AVXABILevel::AVX) : base;
 }
 
-/// Classify a cir.func for x86_64 SysV using the LLVM ABI library.  Returns
+/// Classify a cir.func for \p targetInfo using the LLVM ABI library.  Returns
 /// std::nullopt and emits an NYI error if the signature uses a type the bridge
 /// does not handle yet.
 static std::optional<FunctionClassification>
-classifyX86_64Function(cir::FuncOp func, const DataLayout &dl,
-                       mlir::abi::ABITypeMapper &typeMapper,
-                       const llvm::abi::TargetInfo &targetInfo,
-                       ModuleOp modOp) {
+classifyAbiFunction(cir::FuncOp func, const DataLayout &dl,
+                    mlir::abi::ABITypeMapper &typeMapper,
+                    const llvm::abi::TargetInfo &targetInfo, ModuleOp modOp) {
   cir::FuncType fnTy = func.getFunctionType();
-  return classifyX86_64Signature(fnTy.getReturnType(), fnTy.getInputs(),
-                                 requiredArgs(fnTy), func->getContext(), dl,
-                                 typeMapper, targetInfo, modOp,
-                                 [&]() { return func.emitOpError(); });
+  return classifyAbiSignature(fnTy.getReturnType(), fnTy.getInputs(),
+                              requiredArgs(fnTy), func->getContext(), dl,
+                              typeMapper, targetInfo,
+                              abiCallingConv(func.getCallingConv()), modOp,
+                              [&]() { return func.emitOpError(); });
 }
 
 /// Classify a call that passes arguments through an ellipsis.  The callee's
@@ -658,17 +668,19 @@ classifyX86_64Function(cir::FuncOp func, const DataLayout &dl,
 /// small struct is passed in registers early in the list and in memory once
 /// the integer registers are gone.  Classifying from the call's operands
 /// rather than the callee's signature is what makes that accounting right.
-static std::optional<FunctionClassification> classifyX86_64VariadicCall(
-    cir::CIRCallOpInterface call, cir::FuncType calleeTy, const DataLayout &dl,
-    mlir::abi::ABITypeMapper &typeMapper,
-    const llvm::abi::TargetInfo &targetInfo, ModuleOp modOp) {
+static std::optional<FunctionClassification>
+classifyAbiVariadicCall(cir::CIRCallOpInterface call, cir::FuncType calleeTy,
+                        const DataLayout &dl,
+                        mlir::abi::ABITypeMapper &typeMapper,
+                        const llvm::abi::TargetInfo &targetInfo,
+                        llvm::CallingConv::ID callConv, ModuleOp modOp) {
   assert(calleeTy.isVarArg() &&
          "only a variadic callee can take more operands than it declares");
   Operation *op = call.getOperation();
-  return classifyX86_64Signature(
+  return classifyAbiSignature(
       calleeTy.getReturnType(), call.getArgOperands().getTypes(),
       requiredArgs(calleeTy), op->getContext(), dl, typeMapper, targetInfo,
-      modOp, [&]() { return op->emitOpError(); });
+      callConv, modOp, [&]() { return op->emitOpError(); });
 }
 
 #ifndef NDEBUG
@@ -810,10 +822,18 @@ void CallConvLoweringPass::runOnOperation() {
   static constexpr unsigned numAvxLevels =
       static_cast<unsigned>(llvm::abi::X86AVXABILevel::Last) + 1;
   bool isX86 = target == cir::CallConvTarget::X86_64;
-  std::optional<mlir::abi::ABITypeMapper> x86TypeMapper;
+  bool isAMDGPU = target == cir::CallConvTarget::AMDGPU;
+  // The x86_64 and AMDGPU drivers classify with the LLVM ABI library and share
+  // the type mapper; the test and classification-attr drivers do neither.
+  bool useAbiClassifier = isX86 || isAMDGPU;
+  std::optional<mlir::abi::ABITypeMapper> abiTypeMapper;
   std::array<std::unique_ptr<llvm::abi::TargetInfo>, numAvxLevels> x86Targets;
-  if (isX86)
-    x86TypeMapper.emplace(dl);
+  std::unique_ptr<llvm::abi::TargetInfo> amdgpuTarget;
+  if (useAbiClassifier)
+    abiTypeMapper.emplace(dl);
+  if (isAMDGPU)
+    amdgpuTarget =
+        llvm::abi::createAMDGPUTargetInfo(abiTypeMapper->getTypeBuilder());
   auto x86TargetFor =
       [&](llvm::abi::X86AVXABILevel level) -> const llvm::abi::TargetInfo & {
     assert(static_cast<unsigned>(level) < numAvxLevels &&
@@ -822,7 +842,7 @@ void CallConvLoweringPass::runOnOperation() {
         x86Targets[static_cast<unsigned>(level)];
     if (!slot)
       slot = llvm::abi::createX86_64TargetInfo(
-          x86TypeMapper->getTypeBuilder(), level,
+          abiTypeMapper->getTypeBuilder(), level,
           /*Has64BitPointers=*/true, x86AbiCompat);
     return *slot;
   };
@@ -832,6 +852,13 @@ void CallConvLoweringPass::runOnOperation() {
       return baseAvxLevel;
     return funcAvxLevel(func, baseAvxLevel);
   };
+  // The classifier to use for a function/call reached from \p func.  AMDGPU has
+  // a single classifier; x86_64 picks the one matching func's AVX level.
+  auto targetInfoFor = [&](cir::FuncOp func) -> const llvm::abi::TargetInfo & {
+    if (isAMDGPU)
+      return *amdgpuTarget;
+    return x86TargetFor(avxLevelFor(func));
+  };
 
   // Classify every cir.func up front.  No IR mutation happens here, so
   // later walks can consult any function's classification regardless of
@@ -840,9 +867,9 @@ void CallConvLoweringPass::runOnOperation() {
   bool anyFailed = false;
   moduleOp.walk([&](cir::FuncOp f) {
     std::optional<FunctionClassification> fc;
-    if (isX86)
-      fc = classifyX86_64Function(f, dl, *x86TypeMapper,
-                                  x86TargetFor(avxLevelFor(f)), moduleOp);
+    if (useAbiClassifier)
+      fc = classifyAbiFunction(f, dl, *abiTypeMapper, targetInfoFor(f),
+                               moduleOp);
     else
       fc = classifyFunction(f, dl, target, classificationAttr);
     if (!fc) {
@@ -879,11 +906,12 @@ void CallConvLoweringPass::runOnOperation() {
       return;
     callers[callee].push_back(op);
 
-    // Only the x86_64 driver classifies per call site.  Under the other
+    // Only the ABI-library drivers classify per call site.  Under the other
     // drivers the classification comes from a fixed per-function source, so
     // such a call stays short a classification and rewriteCallSite reports it.
     cir::FuncType calleeTy = callee.getFunctionType();
-    if (!isX86 || call.getNumArgOperands() <= calleeTy.getNumInputs())
+    if (!useAbiClassifier ||
+        call.getNumArgOperands() <= calleeTy.getNumInputs())
       return;
     // A callee declared without a prototype also takes more operands than it
     // declares, and the verifier allows it.  Those extra arguments are named
@@ -900,9 +928,9 @@ void CallConvLoweringPass::runOnOperation() {
     // Classic instead arranges every call site from the caller and reports a
     // caller whose level disagrees with its callee in checkFunctionCallABI,
     // which has no equivalent here yet.
-    std::optional<FunctionClassification> fc =
-        classifyX86_64VariadicCall(call, calleeTy, dl, *x86TypeMapper,
-                                   x86TargetFor(avxLevelFor(callee)), moduleOp);
+    std::optional<FunctionClassification> fc = classifyAbiVariadicCall(
+        call, calleeTy, dl, *abiTypeMapper, targetInfoFor(callee),
+        abiCallingConv(callee.getCallingConv()), moduleOp);
     if (!fc) {
       anyFailed = true;
       return;
@@ -995,13 +1023,13 @@ void CallConvLoweringPass::runOnOperation() {
         [&](mlir::TypeRange argTypes) -> std::optional<FunctionClassification> {
       // A callee resolved at run time carries no features of its own, so the
       // level comes from the function containing the call, which is the
-      // declaration classic arranges every call site from.
-      if (isX86)
-        return classifyX86_64Signature(
+      // declaration classic arranges every call site from.  An indirect callee
+      // is an ordinary function pointer, so it uses the C convention.
+      if (useAbiClassifier)
+        return classifyAbiSignature(
             funcTy.getReturnType(), argTypes, requiredArgs(funcTy), ctx, dl,
-            *x86TypeMapper,
-            x86TargetFor(avxLevelFor(c->getParentOfType<cir::FuncOp>())),
-            moduleOp, [&]() { return c->emitOpError(); });
+            *abiTypeMapper, targetInfoFor(c->getParentOfType<cir::FuncOp>()),
+            llvm::CallingConv::C, moduleOp, [&]() { return c->emitOpError(); });
       return withReturnVoidness(
           mlir::abi::test::classify(argTypes, funcTy.getReturnType(), dl),
           funcTy.getReturnType());

--- a/clang/lib/CIR/Lowering/CIRPasses.cpp
+++ b/clang/lib/CIR/Lowering/CIRPasses.cpp
@@ -26,6 +26,8 @@ namespace cir {
 static CallConvTarget getCallConvTarget(const llvm::Triple &triple) {
   if (triple.getArch() == llvm::Triple::x86_64)
     return CallConvTarget::X86_64;
+  if (triple.isAMDGPU())
+    return CallConvTarget::AMDGPU;
   return CallConvTarget::None;
 }
 
@@ -115,8 +117,8 @@ runCIRToCIRPasses(mlir::ModuleOp theModule, mlir::MLIRContext &mlirContext,
   if (enableCallConvLowering) {
     // CallConvLowering rewrites signatures and call sites using the classifier,
     // so it must run after CXXABILowering has lowered C++ ABI types to plain
-    // records the classifier can handle.  Only the x86_64 System V classifier
-    // is implemented; other targets are left unchanged.
+    // records the classifier can handle.  Only the x86_64 System V and AMDGPU
+    // classifiers are implemented; other targets are left unchanged.
     const clang::TargetInfo &targetInfo = astContext.getTargetInfo();
     CallConvTarget target = getCallConvTarget(targetInfo.getTriple());
     if (target != CallConvTarget::None)

--- a/clang/test/CIR/CodeGenHIP/amdgcn-buffer-rsrc-type.hip
+++ b/clang/test/CIR/CodeGenHIP/amdgcn-buffer-rsrc-type.hip
@@ -1,12 +1,16 @@
 #include "../CodeGenCUDA/Inputs/cuda.h"
 
 // REQUIRES: amdgpu-registered-target
+
+// TODO(cir): drop -fno-clangir-call-conv-lowering once CallConvLowering
+// supports the AMDGPU direct-in-registers aggregate return of a buffer
+// resource struct.
 // RUN: %clang_cc1 -triple amdgpu11.00-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN: -fcuda-is-device -emit-cir %s -o %t.cir
+// RUN: -fcuda-is-device -fno-clangir-call-conv-lowering -emit-cir %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 
 // RUN: %clang_cc1 -triple amdgpu11.00-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN: -fcuda-is-device -emit-llvm %s -o %t-cir.ll
+// RUN: -fcuda-is-device -fno-clangir-call-conv-lowering -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
 
 // RUN: %clang_cc1 -triple amdgpu11.00-amd-amdhsa -x hip -std=c++11 \

--- a/clang/test/CIR/CodeGenHIP/amdgcn-buffer-rsrc-type.hip
+++ b/clang/test/CIR/CodeGenHIP/amdgcn-buffer-rsrc-type.hip
@@ -2,15 +2,12 @@
 
 // REQUIRES: amdgpu-registered-target
 
-// TODO(cir): drop -fno-clangir-call-conv-lowering once CallConvLowering
-// supports the AMDGPU direct-in-registers aggregate return of a buffer
-// resource struct.
 // RUN: %clang_cc1 -triple amdgpu11.00-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN: -fcuda-is-device -fno-clangir-call-conv-lowering -emit-cir %s -o %t.cir
+// RUN: -fcuda-is-device -emit-cir %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 
 // RUN: %clang_cc1 -triple amdgpu11.00-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN: -fcuda-is-device -fno-clangir-call-conv-lowering -emit-llvm %s -o %t-cir.ll
+// RUN: -fcuda-is-device -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
 
 // RUN: %clang_cc1 -triple amdgpu11.00-amd-amdhsa -x hip -std=c++11 \

--- a/clang/test/CIR/Transforms/abi-lowering/amdgpu-scalars.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/amdgpu-scalars.cir
@@ -4,10 +4,13 @@
 !s16i = !cir.int<s, 16>
 !u16i = !cir.int<u, 16>
 !s32i = !cir.int<s, 32>
+!u32i = !cir.int<u, 32>
 !s64i = !cir.int<s, 64>
 
 !rec_E0 = !cir.struct<"E0" {}>
 !rec_Pair16 = !cir.struct<"Pair16" {data !s16i, data !s16i}>
+!rec_Pair32 = !cir.struct<"Pair32" {data !s32i, data !s32i}>
+!rec_Triple = !cir.struct<"Triple" {data !s32i, data !s32i, data !s32i}>
 
 module attributes {
   dlti.dl_spec = #dlti.dl_spec<
@@ -94,6 +97,25 @@ module attributes {
   }
 
   // CHECK: cir.func{{.*}} @takes_small(%{{.*}}: !u32i)
+
+  // A 33-64 bit aggregate is packed into a pair of i32 registers, coerced on
+  // the wire to a [2 x i32] array.
+  cir.func @takes_pair32(%arg0: !rec_Pair32) {
+    %0 = cir.alloca "p" align(4) : !cir.ptr<!rec_Pair32>
+    cir.store %arg0, %0 : !rec_Pair32, !cir.ptr<!rec_Pair32>
+    cir.return
+  }
+
+  // CHECK: cir.func{{.*}} @takes_pair32(%{{.*}}: !cir.array<!u32i x 2>)
+
+  // A larger aggregate that still fits the register budget is passed directly
+  // in registers. The signature is left unchanged and the target backend will
+  // split it into registers.
+  cir.func @takes_triple(%arg0: !rec_Triple) {
+    cir.return
+  }
+
+  // CHECK: cir.func{{.*}} @takes_triple(%arg0: !rec_Triple)
 
   // A kernel scalar argument stays Direct: the AMDGPU_KERNEL convention is
   // routed to the kernel classifier and the signature is unchanged.

--- a/clang/test/CIR/Transforms/abi-lowering/amdgpu-scalars.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/amdgpu-scalars.cir
@@ -1,0 +1,105 @@
+// RUN: cir-opt %s -cir-call-conv-lowering=target=amdgpu | FileCheck %s
+
+!s8i = !cir.int<s, 8>
+!s16i = !cir.int<s, 16>
+!u16i = !cir.int<u, 16>
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+
+!rec_E0 = !cir.struct<"E0" {}>
+!rec_Pair16 = !cir.struct<"Pair16" {data !s16i, data !s16i}>
+
+module attributes {
+  dlti.dl_spec = #dlti.dl_spec<
+    #dlti.dl_entry<i1, dense<8>: vector<2xi64>>,
+    #dlti.dl_entry<i8, dense<8>: vector<2xi64>>,
+    #dlti.dl_entry<i16, dense<16>: vector<2xi64>>,
+    #dlti.dl_entry<i32, dense<32>: vector<2xi64>>,
+    #dlti.dl_entry<i64, dense<64>: vector<2xi64>>>
+} {
+
+  // Register-sized integers are Direct: signature and call sites unchanged.
+  cir.func @passthrough(%arg0: !s32i, %arg1: !s64i) -> !s32i {
+    cir.return %arg0 : !s32i
+  }
+
+  // CHECK: cir.func{{.*}} @passthrough(%arg0: !s32i, %arg1: !s64i) -> !s32i
+  // CHECK-NEXT: cir.return %arg0 : !s32i
+
+  // Floating-point scalars are Direct.
+  cir.func @floats(%arg0: !cir.float, %arg1: !cir.double) -> !cir.double {
+    cir.return %arg1 : !cir.double
+  }
+
+  // CHECK: cir.func{{.*}} @floats(%arg0: !cir.float, %arg1: !cir.double) -> !cir.double
+
+  // Pointers are Direct.
+  cir.func @take_ptr(%arg0: !cir.ptr<!s32i>) -> !cir.ptr<!s32i> {
+    cir.return %arg0 : !cir.ptr<!s32i>
+  }
+
+  // CHECK: cir.func{{.*}} @take_ptr(%arg0: !cir.ptr<!s32i>) -> !cir.ptr<!s32i>
+
+  // Signed sub-register integer is sign-extended.
+  cir.func @take_s8(%arg0: !s8i) {
+    cir.return
+  }
+
+  // CHECK: cir.func{{.*}} @take_s8(%arg0: !s8i {llvm.signext})
+
+  // Unsigned sub-register integer is zero-extended.
+  cir.func @take_u16(%arg0: !u16i) {
+    cir.return
+  }
+
+  // CHECK: cir.func{{.*}} @take_u16(%arg0: !u16i {llvm.zeroext})
+
+  // bool is zero-extended.
+  cir.func @take_bool(%arg0: !cir.bool) {
+    cir.return
+  }
+
+  // CHECK: cir.func{{.*}} @take_bool(%arg0: !cir.bool {llvm.zeroext})
+
+  // Call site picks up the same extension attribute on the operand.
+  cir.func @call_s8(%arg0: !s8i) {
+    cir.call @take_s8(%arg0) : (!s8i) -> ()
+    cir.return
+  }
+
+  // CHECK: cir.call @take_s8(%arg0) : (!s8i {llvm.signext}) -> ()
+
+  // A sub-register integer return is also extended, not just arguments.
+  cir.func @ret_s8() -> !s8i {
+    %0 = cir.const #cir.int<0> : !s8i
+    cir.return %0 : !s8i
+  }
+
+  // CHECK: cir.func{{.*}} @ret_s8() -> (!s8i {llvm.signext})
+
+  // A zero-field record classifies as Ignore: the empty argument is dropped
+  // and the real argument shifts down to the first slot.
+  cir.func @take_empty(%arg0: !rec_E0, %arg1: !s32i) -> !s32i {
+    cir.return %arg1 : !s32i
+  }
+
+  // CHECK: cir.func{{.*}} @take_empty(%arg0: !s32i) -> !s32i
+  // CHECK-NEXT: cir.return %arg0 : !s32i
+
+  // A small aggregate (<= 32 bits) is packed into a single i32 register.
+  cir.func @takes_small(%arg0: !rec_Pair16) {
+    %0 = cir.alloca "p" align(4) : !cir.ptr<!rec_Pair16>
+    cir.store %arg0, %0 : !rec_Pair16, !cir.ptr<!rec_Pair16>
+    cir.return
+  }
+
+  // CHECK: cir.func{{.*}} @takes_small(%{{.*}}: !u32i)
+
+  // A kernel scalar argument stays Direct: the AMDGPU_KERNEL convention is
+  // routed to the kernel classifier and the signature is unchanged.
+  cir.func @kernel_scalar(%arg0: !s32i) cc(amdgpu_kernel) {
+    cir.return
+  }
+
+  // CHECK: cir.func{{.*}} @kernel_scalar(%arg0: !s32i){{.*}}cc(amdgpu_kernel)
+}

--- a/clang/test/CIR/Transforms/abi-lowering/x86_64-lang-addrspace-nyi.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/x86_64-lang-addrspace-nyi.cir
@@ -15,4 +15,4 @@ module attributes {
 
 }
 
-// CHECK: op x86_64 calling-convention lowering not yet implemented for type
+// CHECK: op calling-convention lowering not yet implemented for type

--- a/llvm/include/llvm/ABI/TargetInfo.h
+++ b/llvm/include/llvm/ABI/TargetInfo.h
@@ -87,11 +87,17 @@ protected:
   /// return Ty unchanged.
   LLVM_ABI const Type *useFirstFieldIfTransparentUnion(const Type *Ty) const;
 
+  /// If the record reduces to a single scalar element,
+  /// return that element type; otherwise null.
+  LLVM_ABI const Type *isSingleElementStruct(const Type *Ty) const;
+
   /// Apply rules for classifying return types that are common to all targets.
   LLVM_ABI bool maybeCommonClassifyReturnType(FunctionInfo &FI) const;
 };
 
 LLVM_ABI std::unique_ptr<TargetInfo> createBPFTargetInfo(TypeBuilder &TB);
+
+LLVM_ABI std::unique_ptr<TargetInfo> createAMDGPUTargetInfo(TypeBuilder &TB);
 
 /// The AVX ABI level for X86 targets.
 enum class X86AVXABILevel {

--- a/llvm/lib/ABI/CMakeLists.txt
+++ b/llvm/lib/ABI/CMakeLists.txt
@@ -4,6 +4,7 @@ add_llvm_component_library(LLVMABI
   TargetInfo.cpp
   IRTypeMapper.cpp
   Targets/AArch64.cpp
+  Targets/AMDGPU.cpp
   Targets/BPF.cpp
   Targets/X86.cpp
 

--- a/llvm/lib/ABI/TargetInfo.cpp
+++ b/llvm/lib/ABI/TargetInfo.cpp
@@ -63,6 +63,60 @@ const Type *TargetInfo::useFirstFieldIfTransparentUnion(const Type *Ty) const {
   return Ty;
 }
 
+const Type *TargetInfo::isSingleElementStruct(const Type *Ty) const {
+  const auto *RT = dyn_cast<RecordType>(Ty);
+  if (!RT)
+    return nullptr;
+
+  if (RT->hasFlexibleArrayMember())
+    return nullptr;
+
+  const Type *Found = nullptr;
+
+  for (const auto &Base : RT->getBaseClasses()) {
+    const Type *BaseTy = Base.FieldType;
+    const auto *BaseRT = dyn_cast<RecordType>(BaseTy);
+    if (!BaseRT || BaseRT->isEmpty())
+      continue;
+
+    const Type *Elem = isSingleElementStruct(BaseTy);
+    if (!Elem || Found)
+      return nullptr;
+    Found = Elem;
+  }
+
+  for (const auto &FI : RT->getFields()) {
+    if (FI.isEmpty())
+      continue;
+
+    const Type *FTy = FI.FieldType;
+
+    // A single-element array is transparent for this reduction.
+    while (const auto *AT = dyn_cast<ArrayType>(FTy)) {
+      if (AT->getNumElements() != 1)
+        break;
+      FTy = AT->getElementType();
+    }
+
+    const Type *Elem;
+    if (const auto *InnerRT = dyn_cast<RecordType>(FTy))
+      Elem = isSingleElementStruct(InnerRT);
+    else
+      Elem = FTy;
+    if (!Elem || Found)
+      return nullptr;
+    Found = Elem;
+  }
+
+  if (!Found)
+    return nullptr;
+  // The reduced element must cover the whole record (no tail padding).
+  if (Found->getSizeInBits() != Ty->getSizeInBits())
+    return nullptr;
+
+  return Found;
+}
+
 bool TargetInfo::maybeCommonClassifyReturnType(FunctionInfo &FI) const {
   const abi::Type *Ty = FI.getReturnType();
 

--- a/llvm/lib/ABI/Targets/AMDGPU.cpp
+++ b/llvm/lib/ABI/Targets/AMDGPU.cpp
@@ -1,0 +1,248 @@
+//===- AMDGPU.cpp - AMDGPU ABI Implementation ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ABI/FunctionInfo.h"
+#include "llvm/ABI/TargetInfo.h"
+#include "llvm/ABI/Types.h"
+#include "llvm/Support/AMDGPUAddrSpace.h"
+#include "llvm/Support/Alignment.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/TypeSize.h"
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+
+namespace llvm {
+namespace abi {
+
+class AMDGPUTargetInfo : public TargetInfo {
+private:
+  TypeBuilder &TB;
+  static const unsigned MaxNumRegsForArgsRet = 16;
+
+  ArgInfo classifyReturnType(const Type *RetTy) const;
+  ArgInfo classifyKernelArgumentType(const Type *Ty) const;
+  ArgInfo classifyArgumentType(const Type *Ty, bool Variadic,
+                               unsigned &NumRegsLeft) const;
+
+  /// Target-independent fallback, mirroring classic CodeGen's DefaultABIInfo.
+  ArgInfo classifyDefaultType(const Type *Ty, bool IsReturn) const;
+
+  /// Estimate number of registers the type will use when passed in registers.
+  uint64_t numRegsForType(const Type *Ty) const;
+
+public:
+  AMDGPUTargetInfo(TypeBuilder &TypeBuilder, const ABICompatInfo &Compat)
+      : TargetInfo(Compat), TB(TypeBuilder) {}
+
+  void computeInfo(FunctionInfo &FI) const override;
+};
+
+uint64_t AMDGPUTargetInfo::numRegsForType(const Type *Ty) const {
+  uint64_t NumRegs = 0;
+
+  if (const auto *VT = dyn_cast<VectorType>(Ty)) {
+    // Compute from the number of elements. The reported size is based on the
+    // in-memory size, which includes the padding 4th element for 3-vectors.
+    const Type *EltTy = VT->getElementType();
+    uint64_t EltSize = EltTy->getSizeInBits().getFixedValue();
+    unsigned NumElts = VT->getNumElements().getFixedValue();
+
+    // 16-bit element vectors should be passed as packed.
+    if (EltSize == 16)
+      return (NumElts + 1) / 2;
+
+    uint64_t EltNumRegs = (EltSize + 31) / 32;
+    return EltNumRegs * NumElts;
+  }
+
+  if (const auto *RT = dyn_cast<RecordType>(Ty)) {
+    for (const FieldInfo &Field : RT->getFields())
+      NumRegs += numRegsForType(Field.FieldType);
+    return NumRegs;
+  }
+
+  return (Ty->getSizeInBits().getFixedValue() + 31) / 32;
+}
+
+ArgInfo AMDGPUTargetInfo::classifyDefaultType(const Type *Ty,
+                                              bool IsReturn) const {
+  if (IsReturn && Ty->isVoid())
+    return ArgInfo::getIgnore();
+
+  if (isAggregateTypeForABI(Ty)) {
+    if (RecordArgABI RAA = getRecordArgABI(Ty); RAA != RAA_Default)
+      return getNaturalAlignIndirect(Ty, /*ByVal=*/RAA == RAA_DirectInMemory);
+    return getNaturalAlignIndirect(Ty, /*ByVal=*/!IsReturn);
+  }
+
+  if (const auto *IT = dyn_cast<IntegerType>(Ty))
+    if (isPromotableInteger(IT))
+      return ArgInfo::getExtend(Ty);
+
+  return ArgInfo::getDirect();
+}
+
+ArgInfo AMDGPUTargetInfo::classifyReturnType(const Type *RetTy) const {
+  if (RetTy->isVoid())
+    return ArgInfo::getIgnore();
+
+  if (isAggregateTypeForABI(RetTy)) {
+    // Records with non-trivial destructors/copy-constructors should not be
+    // returned by value.
+    if (getRecordArgABI(RetTy) == RAA_Default) {
+      const auto *RT = dyn_cast<RecordType>(RetTy);
+
+      // Ignore empty structs/unions.
+      if (RT && RT->isEmpty())
+        return ArgInfo::getIgnore();
+
+      // Lower single-element structs to just return a regular value.
+      if (const Type *SeltTy = isSingleElementStruct(RetTy))
+        return ArgInfo::getDirect(SeltTy);
+
+      if (RT && RT->hasFlexibleArrayMember())
+        return classifyDefaultType(RetTy, /*IsReturn=*/true);
+
+      // Pack aggregates <= 4 bytes into single VGPR or pair.
+      uint64_t Size = RetTy->getSizeInBits().getFixedValue();
+      if (Size <= 16)
+        return ArgInfo::getDirect(TB.getIntegerType(16, Align(2), false));
+
+      if (Size <= 32)
+        return ArgInfo::getDirect(TB.getIntegerType(32, Align(4), false));
+
+      if (Size <= 64) {
+        const Type *I32Ty = TB.getIntegerType(32, Align(4), false);
+        return ArgInfo::getDirect(TB.getArrayType(I32Ty, 2, /*SizeInBits=*/64));
+      }
+
+      if (numRegsForType(RetTy) <= MaxNumRegsForArgsRet)
+        return ArgInfo::getDirect();
+    }
+  }
+
+  // Otherwise just do the default thing.
+  return classifyDefaultType(RetTy, /*IsReturn=*/true);
+}
+
+/// For kernels all parameters are really passed in a special buffer. It doesn't
+/// make sense to pass anything byval, so everything must be direct.
+ArgInfo AMDGPUTargetInfo::classifyKernelArgumentType(const Type *Ty) const {
+  Ty = useFirstFieldIfTransparentUnion(Ty);
+
+  if (const Type *SeltTy = isSingleElementStruct(Ty))
+    Ty = SeltTy;
+
+  // TODO: Classic coerces HIP scalar pointers from generic to global here; that
+  // depends on LangOptions the ABI library cannot see, so it is skipped.
+  if (isAggregateTypeForABI(Ty))
+    return ArgInfo::getIndirect(Ty->getAlignment(), /*ByVal=*/false,
+                                /*AddrSpace=*/AMDGPUAS::CONSTANT_ADDRESS);
+
+  // TODO: Classic passes CanBeFlattened=false here to keep a struct intact;
+  // ArgInfo cannot model that yet, so a multi-field record coerce may be
+  // flattened.
+  return ArgInfo::getDirect(Ty);
+}
+
+ArgInfo AMDGPUTargetInfo::classifyArgumentType(const Type *Ty, bool Variadic,
+                                               unsigned &NumRegsLeft) const {
+  assert(NumRegsLeft <= MaxNumRegsForArgsRet && "register estimate underflow");
+
+  Ty = useFirstFieldIfTransparentUnion(Ty);
+
+  // TODO: Classic sets CanBeFlattened=false for variadics; not modeled here.
+  if (Variadic)
+    return ArgInfo::getDirect();
+
+  if (isAggregateTypeForABI(Ty)) {
+    // Records with non-trivial destructors/copy-constructors should not be
+    // passed by value.
+    if (RecordArgABI RAA = getRecordArgABI(Ty); RAA != RAA_Default)
+      return ArgInfo::getIndirect(Ty->getAlignment(),
+                                  /*ByVal=*/RAA == RAA_DirectInMemory,
+                                  /*AddrSpace=*/AMDGPUAS::PRIVATE_ADDRESS);
+
+    // Ignore empty structs/unions.
+    if (const auto *RT = dyn_cast<RecordType>(Ty); RT && RT->isEmpty())
+      return ArgInfo::getIgnore();
+
+    // Lower single-element structs to just pass a regular value.
+    if (const Type *SeltTy = isSingleElementStruct(Ty))
+      return ArgInfo::getDirect(SeltTy);
+
+    if (const auto *RT = dyn_cast<RecordType>(Ty);
+        RT && RT->hasFlexibleArrayMember())
+      return classifyDefaultType(Ty, /*IsReturn=*/false);
+
+    // Pack aggregates <= 8 bytes into single VGPR or pair.
+    uint64_t Size = Ty->getSizeInBits().getFixedValue();
+    if (Size <= 64) {
+      unsigned NumRegs = (Size + 31) / 32;
+      NumRegsLeft -= std::min(NumRegsLeft, NumRegs);
+
+      if (Size <= 16)
+        return ArgInfo::getDirect(TB.getIntegerType(16, Align(2), false));
+
+      if (Size <= 32)
+        return ArgInfo::getDirect(TB.getIntegerType(32, Align(4), false));
+
+      const Type *I32Ty = TB.getIntegerType(32, Align(4), false);
+      return ArgInfo::getDirect(TB.getArrayType(I32Ty, 2, /*SizeInBits=*/64));
+    }
+
+    if (NumRegsLeft > 0) {
+      uint64_t NumRegs = numRegsForType(Ty);
+      if (NumRegsLeft >= NumRegs) {
+        NumRegsLeft -= NumRegs;
+        return ArgInfo::getDirect();
+      }
+    }
+
+    // Pass a struct argument by reference rather than by value.
+    return ArgInfo::getIndirect(Ty->getAlignment(), /*ByVal=*/false,
+                                /*AddrSpace=*/AMDGPUAS::PRIVATE_ADDRESS);
+  }
+
+  // Otherwise just do the default thing.
+  ArgInfo AI = classifyDefaultType(Ty, /*IsReturn=*/false);
+  if (!AI.isIndirect()) {
+    uint64_t NumRegs = numRegsForType(Ty);
+    NumRegsLeft -= std::min(NumRegs, uint64_t{NumRegsLeft});
+  }
+
+  return AI;
+}
+
+void AMDGPUTargetInfo::computeInfo(FunctionInfo &FI) const {
+  CallingConv::ID CC = FI.getCallingConvention();
+
+  if (!maybeCommonClassifyReturnType(FI))
+    FI.getReturnInfo() = classifyReturnType(FI.getReturnType());
+
+  unsigned ArgumentIndex = 0;
+  const unsigned NumFixedArguments = FI.getNumRequiredArgs();
+
+  unsigned NumRegsLeft = MaxNumRegsForArgsRet;
+  for (ArgEntry &Arg : FI.arguments()) {
+    if (CC == CallingConv::AMDGPU_KERNEL) {
+      Arg.Info = classifyKernelArgumentType(Arg.ABIType);
+    } else {
+      bool FixedArgument = ArgumentIndex++ < NumFixedArguments;
+      Arg.Info = classifyArgumentType(Arg.ABIType, !FixedArgument, NumRegsLeft);
+    }
+  }
+}
+
+std::unique_ptr<TargetInfo> createAMDGPUTargetInfo(TypeBuilder &TB) {
+  return std::make_unique<AMDGPUTargetInfo>(TB, ABICompatInfo());
+}
+
+} // namespace abi
+} // namespace llvm

--- a/llvm/lib/ABI/Targets/X86.cpp
+++ b/llvm/lib/ABI/Targets/X86.cpp
@@ -100,7 +100,6 @@ private:
   ArgInfo getIndirectReturnResult(const Type *Ty) const;
   const Type *getFPTypeAtOffset(const Type *Ty, unsigned Offset) const;
 
-  const Type *isSingleElementStruct(const Type *Ty) const;
   const Type *getByteVectorType(const Type *Ty) const;
 
   const Type *createPairType(const Type *Lo, const Type *Hi) const;
@@ -1242,60 +1241,6 @@ const Type *X86_64TargetInfo::getByteVectorType(const Type *Ty) const {
 
   return TB.getVectorType(TB.getFloatType(APFloat::IEEEdouble(), Align(8)),
                           ElementCount::getFixed(Size / 64), Align(Size / 8));
-}
-
-// Returns the single element if this is a single-element struct wrapper
-const Type *X86_64TargetInfo::isSingleElementStruct(const Type *Ty) const {
-  const auto *RT = dyn_cast<RecordType>(Ty);
-  if (!RT)
-    return nullptr;
-
-  if (RT->hasFlexibleArrayMember())
-    return nullptr;
-
-  const Type *Found = nullptr;
-
-  for (const auto &Base : RT->getBaseClasses()) {
-    const Type *BaseTy = Base.FieldType;
-    auto *BaseRT = dyn_cast<RecordType>(BaseTy);
-
-    if (!BaseRT || BaseRT->isEmpty())
-      continue;
-
-    const Type *Elem = isSingleElementStruct(BaseTy);
-    if (!Elem || Found)
-      return nullptr;
-    Found = Elem;
-  }
-
-  for (const auto &FI : RT->getFields()) {
-    if (FI.isEmpty())
-      continue;
-
-    const Type *FTy = FI.FieldType;
-
-    while (auto *AT = dyn_cast<ArrayType>(FTy)) {
-      if (AT->getNumElements() != 1)
-        break;
-      FTy = AT->getElementType();
-    }
-
-    const Type *Elem;
-    if (auto *InnerRT = dyn_cast<RecordType>(FTy))
-      Elem = isSingleElementStruct(InnerRT);
-    else
-      Elem = FTy;
-    if (!Elem || Found)
-      return nullptr;
-    Found = Elem;
-  }
-
-  if (!Found)
-    return nullptr;
-  if (Found->getSizeInBits() != Ty->getSizeInBits())
-    return nullptr;
-
-  return Found;
 }
 
 bool X86_64TargetInfo::isIllegalVectorType(const Type *Ty) const {

--- a/llvm/unittests/ABI/AMDGPUTargetInfoTest.cpp
+++ b/llvm/unittests/ABI/AMDGPUTargetInfoTest.cpp
@@ -1,0 +1,274 @@
+//===- AMDGPUTargetInfoTest.cpp - AMDGPU ABI unit tests -------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ABI/FunctionInfo.h"
+#include "llvm/ABI/TargetInfo.h"
+#include "llvm/ABI/Types.h"
+#include "llvm/ADT/APFloat.h"
+#include "llvm/IR/CallingConv.h"
+#include "llvm/Support/AMDGPUAddrSpace.h"
+#include "llvm/Support/Alignment.h"
+#include "llvm/Support/Allocator.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+// RecordFlags' bitmask operators are declared in namespace llvm, so combining
+// two of them needs that namespace visible.
+using namespace llvm;
+
+using ABIType = llvm::abi::Type;
+using llvm::abi::ABICompatInfo;
+using llvm::abi::ArgInfo;
+using llvm::abi::createAMDGPUTargetInfo;
+using llvm::abi::FieldInfo;
+using llvm::abi::FunctionInfo;
+using llvm::abi::RecordFlags;
+using llvm::abi::RequiredArgs;
+using llvm::abi::StructPacking;
+using llvm::abi::TargetInfo;
+using llvm::abi::TypeBuilder;
+
+class AMDGPUTargetInfoTest : public ::testing::Test {
+protected:
+  llvm::BumpPtrAllocator Alloc;
+  TypeBuilder TB;
+  const ABIType *I8;
+  const ABIType *I16;
+  const ABIType *I32;
+  const ABIType *F32;
+  const ABIType *Void;
+  /// An empty class: a record with no fields, one byte wide, register-passable.
+  const ABIType *Empty;
+
+  AMDGPUTargetInfoTest()
+      : TB(Alloc), I8(TB.getIntegerType(8, llvm::Align(1), /*Signed=*/true)),
+        I16(TB.getIntegerType(16, llvm::Align(2), /*Signed=*/true)),
+        I32(TB.getIntegerType(32, llvm::Align(4), /*Signed=*/true)),
+        F32(TB.getFloatType(llvm::APFloat::IEEEsingle(), llvm::Align(4))),
+        Void(TB.getVoidType()),
+        Empty(TB.getRecordType({}, llvm::TypeSize::getFixed(8), llvm::Align(1),
+                               StructPacking::Default, {}, {},
+                               RecordFlags::CanPassInRegisters)) {}
+
+  std::unique_ptr<TargetInfo> target() const {
+    return createAMDGPUTargetInfo(const_cast<TypeBuilder &>(TB));
+  }
+
+  /// A register-passable record with the given fields, size and alignment.
+  const ABIType *recordOf(llvm::ArrayRef<FieldInfo> Fields, uint64_t SizeInBits,
+                          llvm::Align Alignment) {
+    return TB.getRecordType(Fields, llvm::TypeSize::getFixed(SizeInBits),
+                            Alignment, StructPacking::Default, {}, {},
+                            RecordFlags::CanPassInRegisters);
+  }
+
+  /// The argument classification the target computes for a single parameter
+  /// under calling convention \p CC.
+  const ArgInfo &classifyArg(const ABIType *ArgTy,
+                             std::unique_ptr<FunctionInfo> &FI,
+                             std::unique_ptr<TargetInfo> &TI,
+                             CallingConv::ID CC = CallingConv::C) {
+    TI = target();
+    FI = FunctionInfo::create(CC, Void, {ArgTy});
+    TI->computeInfo(*FI);
+    return FI->getArgInfo(0).Info;
+  }
+
+  /// The return classification the target computes for \p RetTy.
+  const ArgInfo &classifyRet(const ABIType *RetTy,
+                             std::unique_ptr<FunctionInfo> &FI,
+                             std::unique_ptr<TargetInfo> &TI) {
+    TI = target();
+    FI = FunctionInfo::create(CallingConv::C, RetTy, {});
+    TI->computeInfo(*FI);
+    return FI->getReturnInfo();
+  }
+};
+
+static void expectUncoercedDirect(const ArgInfo &Info) {
+  ASSERT_TRUE(Info.isDirect());
+  EXPECT_EQ(Info.getCoerceToType(), nullptr);
+}
+
+static void expectDirectInteger(const ArgInfo &Info, unsigned Bits) {
+  ASSERT_TRUE(Info.isDirect());
+  const ABIType *Coerce = Info.getCoerceToType();
+  ASSERT_NE(Coerce, nullptr);
+  const auto *IT = llvm::dyn_cast<llvm::abi::IntegerType>(Coerce);
+  ASSERT_NE(IT, nullptr);
+  EXPECT_EQ(IT->getSizeInBits().getFixedValue(), Bits);
+}
+
+static void expectDirectFloat(const ArgInfo &Info,
+                              const llvm::fltSemantics &Sem) {
+  ASSERT_TRUE(Info.isDirect());
+  const ABIType *Coerce = Info.getCoerceToType();
+  ASSERT_NE(Coerce, nullptr);
+  const auto *FT = llvm::dyn_cast<llvm::abi::FloatType>(Coerce);
+  ASSERT_NE(FT, nullptr);
+  EXPECT_EQ(FT->getSemantics(), &Sem);
+}
+
+// A <= 8-byte aggregate coerces to [2 x i32].
+static void expectDirectI32Pair(const ArgInfo &Info) {
+  ASSERT_TRUE(Info.isDirect());
+  const auto *AT =
+      llvm::dyn_cast_or_null<llvm::abi::ArrayType>(Info.getCoerceToType());
+  ASSERT_NE(AT, nullptr);
+  EXPECT_EQ(AT->getNumElements(), 2u);
+  const auto *IT = llvm::dyn_cast<llvm::abi::IntegerType>(AT->getElementType());
+  ASSERT_NE(IT, nullptr);
+  EXPECT_EQ(IT->getSizeInBits().getFixedValue(), 32u);
+}
+
+static void expectIndirect(const ArgInfo &Info, llvm::Align ExpectedAlign,
+                           bool ByVal, unsigned AddrSpace) {
+  ASSERT_TRUE(Info.isIndirect());
+  EXPECT_EQ(Info.getIndirectAlign(), ExpectedAlign);
+  EXPECT_EQ(Info.getIndirectByVal(), ByVal);
+  EXPECT_EQ(Info.getIndirectAddrSpace(), AddrSpace);
+}
+
+// A 32-bit integer and a pointer-sized scalar pass directly in their own type.
+TEST_F(AMDGPUTargetInfoTest, ScalarPassesDirect) {
+  std::unique_ptr<FunctionInfo> FI;
+  std::unique_ptr<TargetInfo> TI;
+  expectUncoercedDirect(classifyArg(I32, FI, TI));
+  expectUncoercedDirect(classifyArg(F32, FI, TI));
+}
+
+// A sub-word integer is sign/zero extended to fill its register.
+TEST_F(AMDGPUTargetInfoTest, PromotableIntegerExtends) {
+  std::unique_ptr<FunctionInfo> FI;
+  std::unique_ptr<TargetInfo> TI;
+  const ArgInfo &Info = classifyArg(I8, FI, TI);
+  ASSERT_TRUE(Info.isExtend());
+  EXPECT_TRUE(Info.isSignExt());
+}
+
+// Aggregates <= 16/32/64 bits pack into i16 / i32 / [2 x i32].
+TEST_F(AMDGPUTargetInfoTest, SmallAggregatesPackIntoRegisters) {
+  std::unique_ptr<FunctionInfo> FI;
+  std::unique_ptr<TargetInfo> TI;
+
+  const ABIType *S16 =
+      recordOf({FieldInfo(I8, 0), FieldInfo(I8, 8)}, 16, llvm::Align(1));
+  expectDirectInteger(classifyArg(S16, FI, TI), 16);
+
+  const ABIType *S32 =
+      recordOf({FieldInfo(I16, 0), FieldInfo(I16, 16)}, 32, llvm::Align(2));
+  expectDirectInteger(classifyArg(S32, FI, TI), 32);
+
+  const ABIType *S64 =
+      recordOf({FieldInfo(I32, 0), FieldInfo(I32, 32)}, 64, llvm::Align(4));
+  expectDirectI32Pair(classifyArg(S64, FI, TI));
+}
+
+// An empty struct is dropped from the argument list.
+TEST_F(AMDGPUTargetInfoTest, EmptyAggregateIsIgnored) {
+  std::unique_ptr<FunctionInfo> FI;
+  std::unique_ptr<TargetInfo> TI;
+  EXPECT_TRUE(classifyArg(Empty, FI, TI).isIgnore());
+}
+
+// A single-element struct is passed as its inner scalar.
+TEST_F(AMDGPUTargetInfoTest, SingleElementStructUnwraps) {
+  std::unique_ptr<FunctionInfo> FI;
+  std::unique_ptr<TargetInfo> TI;
+  const ABIType *Wrapper = recordOf({FieldInfo(F32, 0)}, 32, llvm::Align(4));
+  expectDirectFloat(classifyArg(Wrapper, FI, TI), llvm::APFloat::IEEEsingle());
+}
+
+// A large aggregate that does not fit the 16-register budget is passed by
+// reference in the private address space.
+TEST_F(AMDGPUTargetInfoTest, OversizedAggregateIsIndirectPrivate) {
+  std::unique_ptr<FunctionInfo> FI;
+  std::unique_ptr<TargetInfo> TI;
+  // Two i32[10] fields => 20 registers, above MaxNumRegsForArgsRet (16).
+  const ABIType *ArrTy = TB.getArrayType(I32, /*NumElements=*/10,
+                                         /*SizeInBits=*/320);
+  const ABIType *Big = recordOf({FieldInfo(ArrTy, 0), FieldInfo(ArrTy, 320)},
+                                640, llvm::Align(4));
+  expectIndirect(classifyArg(Big, FI, TI), llvm::Align(4), /*ByVal=*/false,
+                 llvm::AMDGPUAS::PRIVATE_ADDRESS);
+}
+
+// A record that cannot pass in registers (non-trivial C++ type) is passed
+// indirectly in the private address space.
+TEST_F(AMDGPUTargetInfoTest, NonTrivialRecordIsIndirectPrivate) {
+  std::unique_ptr<FunctionInfo> FI;
+  std::unique_ptr<TargetInfo> TI;
+  const ABIType *CannotPass = TB.getRecordType(
+      {FieldInfo(I32, 0)}, llvm::TypeSize::getFixed(32), llvm::Align(4),
+      StructPacking::Default, {}, {}, RecordFlags::IsCXXRecord);
+  expectIndirect(classifyArg(CannotPass, FI, TI), llvm::Align(4),
+                 /*ByVal=*/false, llvm::AMDGPUAS::PRIVATE_ADDRESS);
+}
+
+// A variadic argument bypasses register packing and passes through unchanged.
+TEST_F(AMDGPUTargetInfoTest, VariadicArgumentPassesDirect) {
+  std::unique_ptr<TargetInfo> TI = target();
+  const ABIType *S16 =
+      recordOf({FieldInfo(I8, 0), FieldInfo(I8, 8)}, 16, llvm::Align(1));
+  // Zero declared parameters, so the sole argument is variadic.
+  std::unique_ptr<FunctionInfo> FI =
+      FunctionInfo::create(CallingConv::C, Void, {S16}, RequiredArgs(0));
+  TI->computeInfo(*FI);
+  expectUncoercedDirect(FI->getArgInfo(0).Info);
+}
+
+// Kernel aggregate arguments are passed by reference in the constant address
+// space (the kernarg segment), never byval.
+TEST_F(AMDGPUTargetInfoTest, KernelAggregateIsIndirectConstant) {
+  std::unique_ptr<FunctionInfo> FI;
+  std::unique_ptr<TargetInfo> TI;
+  const ABIType *S =
+      recordOf({FieldInfo(I32, 0), FieldInfo(I32, 32)}, 64, llvm::Align(4));
+  expectIndirect(classifyArg(S, FI, TI, CallingConv::AMDGPU_KERNEL),
+                 llvm::Align(4), /*ByVal=*/false,
+                 llvm::AMDGPUAS::CONSTANT_ADDRESS);
+}
+
+// Kernel scalar arguments are passed directly.
+TEST_F(AMDGPUTargetInfoTest, KernelScalarIsDirect) {
+  std::unique_ptr<FunctionInfo> FI;
+  std::unique_ptr<TargetInfo> TI;
+  expectDirectInteger(classifyArg(I32, FI, TI, CallingConv::AMDGPU_KERNEL), 32);
+}
+
+// A void return is ignored.
+TEST_F(AMDGPUTargetInfoTest, VoidReturnIsIgnored) {
+  std::unique_ptr<FunctionInfo> FI;
+  std::unique_ptr<TargetInfo> TI;
+  EXPECT_TRUE(classifyRet(Void, FI, TI).isIgnore());
+}
+
+// A <= 8-byte aggregate return packs into [2 x i32].
+TEST_F(AMDGPUTargetInfoTest, SmallAggregateReturnPacks) {
+  std::unique_ptr<FunctionInfo> FI;
+  std::unique_ptr<TargetInfo> TI;
+  const ABIType *S64 =
+      recordOf({FieldInfo(I32, 0), FieldInfo(I32, 32)}, 64, llvm::Align(4));
+  expectDirectI32Pair(classifyRet(S64, FI, TI));
+}
+
+// A record that cannot pass in registers is returned indirectly (sret-style,
+// ByVal=false) via the target-independent return rule.
+TEST_F(AMDGPUTargetInfoTest, NonTrivialRecordReturnIsIndirect) {
+  std::unique_ptr<FunctionInfo> FI;
+  std::unique_ptr<TargetInfo> TI;
+  const ABIType *CannotPass = TB.getRecordType(
+      {FieldInfo(I32, 0)}, llvm::TypeSize::getFixed(32), llvm::Align(4),
+      StructPacking::Default, {}, {}, RecordFlags::IsCXXRecord);
+  const ArgInfo &Info = classifyRet(CannotPass, FI, TI);
+  ASSERT_TRUE(Info.isIndirect());
+  EXPECT_FALSE(Info.getIndirectByVal());
+}
+
+} // namespace

--- a/llvm/unittests/ABI/CMakeLists.txt
+++ b/llvm/unittests/ABI/CMakeLists.txt
@@ -6,5 +6,6 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_unittest(ABITests
   AArch64TargetInfoTest.cpp
+  AMDGPUTargetInfoTest.cpp
   X86TargetInfoTest.cpp
   )


### PR DESCRIPTION
**Summary:**
- The AMDGPU classifier can pass or return an aggregate directly in registers and can pack a 33-64 bit aggregate
into a [2 x i32] register pair. The CallConvLowering bridge handled neither, so such signatures hit the NYI path. Handle both in convertABIArgInfo/abiTypeToCIR.

**Changes:**
- A Direct classification with a null coerce type is now always a pass-through, for aggregates as well as scalars. Previously only scalars were passed through. An aggregate fell into the coercion path and reported NYI.
- `abiTypeToCIR` gains an `ArrayType` case, mapping an `llvm::abi::ArrayType` coerce to a `cir::ArrayType` so the AMDGPU [2 x i32] pack is representable.
- Added cir-opt coverage for 64-bit struct coerced to [2 x i32] and larger struct passed directly in registers.
- Dropped the `-fno-clangir-call-conv-lowering` opt-out from `amdgcn-buffer-rsrc-type.hip`.

Assisted by: Claude Opus 4.8