### PR TITLE
[DirectX] Don't expect specific zlib compressed size

### DIFF
--- a/llvm/test/CodeGen/DirectX/ContainerData/SourceInfo-Compressed.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/SourceInfo-Compressed.ll
@@ -3,13 +3,13 @@
 ; RUN: llvm-pdbutil pdb2yaml --dxcontainer %t.pdb | FileCheck %s --check-prefix=DXC
 ; REQUIRES: zlib
 
-; CHECK: @dx.srci = private constant [348 x i8] c"{{.*}}", section "SRCI", align 4
+; CHECK: @dx.srci = private constant [{{[0-9]+}} x i8] c"{{.*}}", section "SRCI", align 4
 
 ; DXC:      - Name:            SRCI
-; DXC-NEXT:   Size:            348
+; DXC-NEXT:   Size:            {{[0-9]+}}
 ; DXC-NEXT:   SourceInfo:
 ; DXC-NEXT:     Header:
-; DXC-NEXT:       AlignedSizeInBytes: 348
+; DXC-NEXT:       AlignedSizeInBytes: {{[0-9]+}}
 ; DXC-NEXT:       Flags:           0
 ; DXC-NEXT:       SectionCount:    3
 ; DXC-NEXT:     Names:
@@ -39,14 +39,14 @@
 ; DXC-NEXT:           FileName:        'C:\b.hlsl'
 ; DXC-NEXT:     Contents:
 ; DXC-NEXT:       SectionHeader:
-; DXC-NEXT:         AlignedSizeInBytes: 124
+; DXC-NEXT:         AlignedSizeInBytes: {{[0-9]+}}
 ; DXC-NEXT:         Flags:           0
 ; DXC-NEXT:         Type:            SourceContents
 ; DXC-NEXT:       Header:
-; DXC-NEXT:         AlignedSizeInBytes: 116
+; DXC-NEXT:         AlignedSizeInBytes: {{[0-9]+}}
 ; DXC-NEXT:         Flags:           0
 ; DXC-NEXT:         Type:            Zlib
-; DXC-NEXT:         EntriesSizeInBytes: 96
+; DXC-NEXT:         EntriesSizeInBytes: {{[0-9]+}}
 ; DXC-NEXT:         UncompressedEntriesSizeInBytes: 164
 ; DXC-NEXT:         Count:           3
 ; DXC-NEXT:       Entries:


### PR DESCRIPTION
The precise size may differ based on the zlib implementation.