### PR TITLE
[lldb] Use Guarded in CPPLanguageRuntime

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
@@ -806,9 +806,9 @@ CPPLanguageRuntime::GetVTableInfoEntry(ValueObject &in_value, bool check_type) {
 
   // Check our cache first to see if we already have this info
   {
-    std::lock_guard<std::mutex> locker(m_vtable_mutex);
-    auto pos = m_vtable_info_map.find(vtable_addr);
-    if (pos != m_vtable_info_map.end())
+    auto vtable_info_map = m_vtable_info_map.Lock();
+    auto pos = vtable_info_map->find(vtable_addr);
+    if (pos != vtable_info_map->end())
       return pos->second;
   }
 
@@ -830,8 +830,7 @@ CPPLanguageRuntime::GetVTableInfoEntry(ValueObject &in_value, bool check_type) {
           /*info=*/VTableInfo{vtable_addr, symbol},
           /*runtime=*/runtime.get(),
       };
-      std::lock_guard<std::mutex> locker(m_vtable_mutex);
-      m_vtable_info_map[vtable_addr] = entry;
+      (*m_vtable_info_map.Lock())[vtable_addr] = entry;
       return entry;
     }
   }

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.h
@@ -16,6 +16,7 @@
 #include "CommonABIRuntime.h"
 #include "lldb/Core/PluginInterface.h"
 #include "lldb/Target/LanguageRuntime.h"
+#include "lldb/Utility/Locked.h"
 #include "lldb/lldb-private.h"
 
 namespace lldb_private {
@@ -153,8 +154,8 @@ private:
   llvm::Expected<VTableInfoEntry> GetVTableInfoEntry(ValueObject &in_value,
                                                      bool check_type);
 
-  std::map<Address, VTableInfoEntry> m_vtable_info_map;
-  std::mutex m_vtable_mutex;
+  using VTableInfoMap = std::map<Address, VTableInfoEntry>;
+  Guarded<VTableInfoMap, std::mutex> m_vtable_info_map;
 };
 
 } // namespace lldb_private


### PR DESCRIPTION
Use Guarded to make sure m_vtable_info_map cannot be accesses without locking the respective lock.