### PR TITLE
[CIR][ABI] Thread indirect-argument address space through call-conv lowering

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/CallConvLoweringPass.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CallConvLoweringPass.cpp
@@ -287,8 +287,14 @@ static mlir::Type abiTypeToCIR(const llvm::abi::Type *ty, MLIRContext *ctx) {
       .Case([&](const llvm::abi::FloatType *fltTy) {
         return cir::getFloatingPointType(*fltTy->getSemantics(), ctx);
       })
-      .Case([&](const llvm::abi::PointerType *) {
-        return cir::PointerType::get(cir::VoidType::get(ctx));
+      .Case([&](const llvm::abi::PointerType *ptrTy) -> mlir::Type {
+        // The pointee is dropped (a coerce pointer is opaque here), but the
+        // address space is preserved so a pointer coerced only in address
+        // space round-trips faithfully.
+        mlir::ptr::MemorySpaceAttrInterface addrSpace;
+        if (unsigned as = ptrTy->getAddrSpace())
+          addrSpace = cir::TargetAddressSpaceAttr::get(ctx, as);
+        return cir::PointerType::get(cir::VoidType::get(ctx), addrSpace);
       })
       .Case([&](const llvm::abi::VectorType *vecTy) -> mlir::Type {
         mlir::Type elemCIR = abiTypeToCIR(vecTy->getElementType(), ctx);
@@ -520,7 +526,8 @@ convertABIArgInfo(const llvm::abi::ArgInfo &info, MLIRContext *ctx,
   }
   if (info.isIndirect())
     return ArgClassification::getIndirect(info.getIndirectAlign(),
-                                          info.getIndirectByVal());
+                                          info.getIndirectByVal(),
+                                          info.getIndirectAddrSpace());
   assert(info.isIgnore() && "Unexpected classification");
   return ArgClassification::getIgnore();
 }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
@@ -53,6 +53,30 @@ using namespace mlir::abi;
 
 namespace {
 
+/// The wire pointer type for an Indirect classification: a pointer to
+/// \p pointeeTy in \p ac.indirectAddrSpace.  A zero address space is the
+/// default space, which produces a pointer with no explicit attribute.
+cir::PointerType indirectPtrType(mlir::Type pointeeTy,
+                                 const ArgClassification &ac) {
+  mlir::ptr::MemorySpaceAttrInterface addrSpace;
+  if (ac.indirectAddrSpace)
+    addrSpace = cir::TargetAddressSpaceAttr::get(pointeeTy.getContext(),
+                                                 ac.indirectAddrSpace);
+  return cir::PointerType::get(pointeeTy, addrSpace);
+}
+
+/// Return \p ptr in \p wantTy, inserting a cir.cast address_space at the
+/// builder's current insertion point when the two differ only in address
+/// space.  A byref/byval pointer whose ABI address space is not the space its
+/// backing alloca lives in needs this cast to stay well-typed.
+mlir::Value castPtrAddrSpace(mlir::OpBuilder &builder, mlir::Location loc,
+                             mlir::Value ptr, cir::PointerType wantTy) {
+  if (ptr.getType() == wantTy)
+    return ptr;
+  return cir::CastOp::create(builder, loc, wantTy, cir::CastKind::address_space,
+                             ptr);
+}
+
 /// Return the coerced RecordType for a Direct classification that should be
 /// flattened into individual scalar arguments, or a null type if the
 /// classification does not call for flattening.
@@ -128,8 +152,9 @@ buildNewArgTypes(ArrayRef<mlir::Type> oldArgTypes,
       break;
     case ArgKind::Indirect:
       // byval and byref both pass a pointer.  Which of the two it is shows up
-      // in the attributes updateArgAttrs applies, not in the type.
-      newArgTypes.push_back(cir::PointerType::get(origTy));
+      // in the attributes updateArgAttrs applies, not in the type.  The ABI
+      // address space (e.g. AMDGPU private for a byref) rides on the type.
+      newArgTypes.push_back(indirectPtrType(origTy, ac));
       break;
     }
   }
@@ -666,11 +691,13 @@ void insertArgCoercion(mlir::FunctionOpInterface funcOp,
       // to adapted (now of the original type != the alloca's pointee type).
       blockArg.replaceAllUsesExcept(adapted, coercionOps);
     } else if (ac.kind == ArgKind::Indirect) {
-      // byval and byref share a !cir.ptr<T> wire type; the llvm.byval vs
-      // llvm.byref distinction is in the attrs applied by updateArgAttrs.
-      // Body lowering differs: byval copies into the callee (load at entry),
-      // while byref must operate on the caller's storage in place.
-      auto ptrTy = cir::PointerType::get(blockArg.getType());
+      // byval and byref share a pointer wire type (in the ABI address space);
+      // the llvm.byval vs llvm.byref distinction is in the attrs applied by
+      // updateArgAttrs.  Body lowering differs: byval copies into the callee
+      // (load at entry), while byref must operate on the caller's storage in
+      // place.
+      mlir::Type bodyPtrTy = cir::PointerType::get(blockArg.getType());
+      auto ptrTy = indirectPtrType(blockArg.getType(), ac);
 
       if (!ac.byVal) {
         // byref: CIRGen spills every by-value parameter into a local alloca
@@ -699,11 +726,21 @@ void insertArgCoercion(mlir::FunctionOpInterface funcOp,
         if (paramStore)
           paramStore->erase();
 
-        // Update the block argument to point to its original type.
+        // Update the block argument to the ABI pointer type.
         blockArg.setType(ptrTy);
 
         if (destAlloca) {
-          destAlloca.getResult().replaceAllUsesWith(blockArg);
+          // The body reads the parameter through the alloca's pointer type,
+          // which lives in the default (alloca) space.  When the ABI pointer
+          // is in another space, cast it back before rewiring the uses so the
+          // body stays well-typed.
+          mlir::Value forBody = blockArg;
+          if (ptrTy != bodyPtrTy) {
+            builder.setInsertionPointToStart(&entry);
+            forBody = castPtrAddrSpace(builder, funcOp.getLoc(), blockArg,
+                                       cast<cir::PointerType>(bodyPtrTy));
+          }
+          destAlloca.getResult().replaceAllUsesWith(forBody);
           destAlloca->erase();
         }
       } else {
@@ -1249,7 +1286,10 @@ CIRABIRewriteContext::rewriteCallSite(mlir::Operation *callOp,
         assert(srcAlloca.getAlignment() >= ac.indirectAlign.value() &&
                "llvm.align on a byref argument must not overstate the "
                "forwarded slot");
-        newArgs.push_back(srcAlloca);
+        // The alloca lives in the default (alloca) space; cast it to the ABI
+        // address space when they differ so the operand matches the wire type.
+        newArgs.push_back(castPtrAddrSpace(builder, call.getLoc(), srcAlloca,
+                                           indirectPtrType(arg.getType(), ac)));
         deadRecordLoads.push_back(srcLoad);
         continue;
       }
@@ -1258,7 +1298,10 @@ CIRABIRewriteContext::rewriteCallSite(mlir::Operation *callOp,
           builder, call.getLoc(), ptrTy, builder.getStringAttr("byval"),
           builder.getI64IntegerAttr(ac.indirectAlign.value()));
       cir::StoreOp::create(builder, call.getLoc(), arg, slot);
-      newArgs.push_back(slot);
+      // The fresh copy is allocated in the default space; cast it to the ABI
+      // address space when they differ so the operand matches the wire type.
+      newArgs.push_back(castPtrAddrSpace(builder, call.getLoc(), slot,
+                                         indirectPtrType(arg.getType(), ac)));
     } else {
       newArgs.push_back(arg);
     }

--- a/clang/test/CIR/Transforms/abi-lowering/indirect-addrspace-arg-attr-lowering.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/indirect-addrspace-arg-attr-lowering.cir
@@ -1,0 +1,86 @@
+// RUN: cir-opt %s -cir-call-conv-lowering="classification-attr=test_classify" \
+// RUN:   | FileCheck %s
+
+// An Indirect classification can name a non-default address space (e.g. AMDGPU
+// private for a byref argument).  The wire pointer takes that target address
+// space, and the rewriter bridges between it and the default (alloca) space
+// with cir.cast address_space rather than a memory round-trip.
+
+!s64i = !cir.int<s, 64>
+!rec_Big = !cir.struct<"Big" {data !s64i, data !s64i, data !s64i}>
+
+#byref_as5 = {
+  return = { kind = "direct" },
+  args   = [ { kind = "indirect", indirect_align = 8, byval = false,
+               indirect_addr_space = 5 } ]
+}
+
+#byval_as5 = {
+  return = { kind = "direct" },
+  args   = [ { kind = "indirect", indirect_align = 8, byval = true,
+               indirect_addr_space = 5 } ]
+}
+
+#passthrough = {
+  return = { kind = "direct" },
+  args   = [ ]
+}
+
+module attributes {
+  cir.triple = "x86_64-unknown-linux-gnu",
+  dlti.dl_spec = #dlti.dl_spec<
+    #dlti.dl_entry<i64, dense<64>: vector<2xi64>>>
+} {
+
+  // byref: the wire pointer is in AS 5; the body reads the parameter through
+  // the alloca's default-space pointer, so the block argument is cast back to
+  // the default space before its uses are rewired.
+  cir.func @takes_byref_as5(%arg0: !rec_Big) attributes { test_classify = #byref_as5 } {
+    %0 = cir.alloca "s" align(8) : !cir.ptr<!rec_Big>
+    cir.store %arg0, %0 : !rec_Big, !cir.ptr<!rec_Big>
+    %1 = cir.load %0 : !cir.ptr<!rec_Big>, !rec_Big
+    cir.return
+  }
+
+  // CHECK: cir.func{{.*}} @takes_byref_as5(%[[A:.*]]: !cir.ptr<!rec_Big, target_address_space(5)> {{{.*}}llvm.byref = !rec_Big{{.*}}})
+  // CHECK: %[[C:.*]] = cir.cast address_space %[[A]] : !cir.ptr<!rec_Big, target_address_space(5)> -> !cir.ptr<!rec_Big>
+  // CHECK: cir.load %[[C]] : !cir.ptr<!rec_Big>, !rec_Big
+
+  // byval: the wire pointer is in AS 5; the callee loads it to get a local
+  // copy of the value.  The load reads straight from the AS-5 pointer.
+  cir.func @takes_byval_as5(%arg0: !rec_Big) attributes { test_classify = #byval_as5 } {
+    %0 = cir.alloca "s" align(8) : !cir.ptr<!rec_Big>
+    cir.store %arg0, %0 : !rec_Big, !cir.ptr<!rec_Big>
+    cir.return
+  }
+
+  // CHECK: cir.func{{.*}} @takes_byval_as5(%[[A:.*]]: !cir.ptr<!rec_Big, target_address_space(5)> {{{.*}}llvm.byval = !rec_Big{{.*}}})
+  // CHECK: %[[V:.*]] = cir.load %[[A]] : !cir.ptr<!rec_Big, target_address_space(5)>, !rec_Big
+
+  // byref call site: the caller's alloca is in the default space, so it is cast
+  // up to AS 5 before being forwarded as the argument.
+  cir.func @call_byref() attributes { test_classify = #passthrough } {
+    %0 = cir.alloca "s" align(8) : !cir.ptr<!rec_Big>
+    %1 = cir.load %0 : !cir.ptr<!rec_Big>, !rec_Big
+    cir.call @takes_byref_as5(%1) : (!rec_Big) -> ()
+    cir.return
+  }
+
+  // CHECK: cir.func{{.*}} @call_byref()
+  // CHECK: %[[S:.*]] = cir.alloca
+  // CHECK: %[[CC:.*]] = cir.cast address_space %[[S]] : !cir.ptr<!rec_Big> -> !cir.ptr<!rec_Big, target_address_space(5)>
+  // CHECK: cir.call @takes_byref_as5(%[[CC]]) : (!cir.ptr<!rec_Big, target_address_space(5)>{{.*}}) -> ()
+
+  // byval call site: a fresh copy is allocated in the default space, filled,
+  // then cast up to AS 5 for the call.
+  cir.func @call_byval(%s: !rec_Big) attributes { test_classify = #passthrough } {
+    cir.call @takes_byval_as5(%s) : (!rec_Big) -> ()
+    cir.return
+  }
+
+  // CHECK: cir.func{{.*}} @call_byval
+  // CHECK: %[[BV:.*]] = cir.alloca {{.*}}byval
+  // CHECK: cir.store %{{.*}}, %[[BV]]
+  // CHECK: %[[CV:.*]] = cir.cast address_space %[[BV]] : !cir.ptr<!rec_Big> -> !cir.ptr<!rec_Big, target_address_space(5)>
+  // CHECK: cir.call @takes_byval_as5(%[[CV]]) : (!cir.ptr<!rec_Big, target_address_space(5)>{{.*}}) -> ()
+}

--- a/mlir/include/mlir/ABI/ABIRewriteContext.h
+++ b/mlir/include/mlir/ABI/ABIRewriteContext.h
@@ -75,6 +75,10 @@ struct ArgClassification {
   /// For Indirect: whether the callee gets ownership (byval).
   bool byVal = false;
 
+  /// For Indirect: the address space the pointer lives in.  0 is the default
+  /// space (no explicit attribute). A non-zero value is a target address space.
+  unsigned indirectAddrSpace = 0;
+
   /// Whether the value is passed as-is, so a rewriter can leave it alone.
   /// Only an uncoerced Direct qualifies.  Extend counts as needing a rewrite
   /// even though it only adds an attribute, because the attribute changes
@@ -87,7 +91,7 @@ struct ArgClassification {
     return kind == other.kind && coercedType == other.coercedType &&
            indirectAlign == other.indirectAlign &&
            signExtend == other.signExtend && canFlatten == other.canFlatten &&
-           byVal == other.byVal;
+           byVal == other.byVal && indirectAddrSpace == other.indirectAddrSpace;
   }
 
   static ArgClassification getDirect(Type coerced = nullptr) {
@@ -103,11 +107,13 @@ struct ArgClassification {
     return c;
   }
 
-  static ArgClassification getIndirect(llvm::Align align, bool byVal = true) {
+  static ArgClassification getIndirect(llvm::Align align, bool byVal = true,
+                                       unsigned addrSpace = 0) {
     ArgClassification c;
     c.kind = ArgKind::Indirect;
     c.indirectAlign = align;
     c.byVal = byVal;
+    c.indirectAddrSpace = addrSpace;
     return c;
   }
 

--- a/mlir/include/mlir/ABI/Targets/Test/TestTarget.h
+++ b/mlir/include/mlir/ABI/Targets/Test/TestTarget.h
@@ -70,17 +70,19 @@ FunctionClassification classify(TypeRange argTypes, Type returnType,
 ///   coerced_type:  TypeAttr.  Required; the extended integer type.
 ///   sign_extend:   BoolAttr.  Defaults to false (zero-extend).
 ///
-/// For kind = "indirect" (indirect_align required, byval optional):
-///   indirect_align: IntegerAttr.  Required; alignment of the pointed-to
-///                   object in bytes.
-///   byval:          BoolAttr.  Defaults to true.
+/// For kind = "indirect" (indirect_align required, byval/addr-space optional):
+///   indirect_align:      IntegerAttr.  Required; alignment of the pointed-to
+///                        object in bytes.
+///   byval:               BoolAttr.  Defaults to true.
+///   indirect_addr_space: IntegerAttr.  Defaults to 0 (the default address
+///                        space); a non-zero value is a target address space.
 ///
 /// For kind = "ignore" / "expand": no extra keys.
 ///
 /// Future schema additions tracked in projects/daily_log.md (Step 0c
 /// field-mapping table).  When we add new fields to ArgClassification
-/// (e.g. direct_offset, extend_kind tristate, indirect_addr_space,
-/// indirect_realign), the corresponding optional keys go here.
+/// (e.g. direct_offset, extend_kind tristate, indirect_realign), the
+/// corresponding optional keys go here.
 ///
 /// Unknown keys cause a parse error (no silent ignore — keeps schema
 /// honest as it grows).

--- a/mlir/lib/ABI/Targets/Test/TestTarget.cpp
+++ b/mlir/lib/ABI/Targets/Test/TestTarget.cpp
@@ -125,8 +125,8 @@ namespace {
 /// set causes a parse error (no silent ignore).  Updated when new
 /// optional keys are added to the schema.
 constexpr StringRef knownArgKeys[] = {
-    "kind",        "coerced_type",   "sign_extend",
-    "can_flatten", "indirect_align", "byval",
+    "kind",  "coerced_type",   "sign_extend",         "can_flatten",
+    "byval", "indirect_align", "indirect_addr_space",
 };
 
 bool isKnownArgKey(StringRef key) {
@@ -151,7 +151,7 @@ parseOne(DictionaryAttr argDict, function_ref<InFlightDiagnostic()> emitError) {
       emitError() << "unknown key '" << na.getName().getValue()
                   << "' in classification dictionary; allowed keys are "
                   << "kind, coerced_type, sign_extend, can_flatten, "
-                  << "indirect_align, byval";
+                  << "indirect_align, byval, indirect_addr_space";
       return std::nullopt;
     }
 
@@ -193,7 +193,11 @@ parseOne(DictionaryAttr argDict, function_ref<InFlightDiagnostic()> emitError) {
     bool byVal = true;
     if (auto bv = argDict.getAs<BoolAttr>("byval"))
       byVal = bv.getValue();
-    return ArgClassification::getIndirect(llvm::Align(align.getInt()), byVal);
+    unsigned addrSpace = 0;
+    if (auto as = argDict.getAs<IntegerAttr>("indirect_addr_space"))
+      addrSpace = as.getInt();
+    return ArgClassification::getIndirect(llvm::Align(align.getInt()), byVal,
+                                          addrSpace);
   }
 
   if (kind == "ignore") {


### PR DESCRIPTION
**Issue:**
- An indirect argument (byval/byref) may need to pass through a pointer in a non-default address space, but the CIR bridge and rewriter dropped it, so the wire pointer always used the default space.

**Fix:**
- Carry the address space from ArgClassification through the bridge into the rewriter, which builds the pointer in that space and bridges to/from the default (alloca) space with cir.cast address_space.

Assisted by: Claude Opus 4.8