### PR TITLE
Silence an MSVC diagnostic; NFC

### DIFF
--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -129,6 +129,7 @@ unsigned CodeGenTypes::ClangCallConvToLLVMCallConv(CallingConv CC) {
     CC_VLS_CASE(65536)
 #undef CC_VLS_CASE
   }
+  llvm_unreachable("unhandled calling convention");
 }
 
 /// Derives the 'this' type for codegen purposes, i.e. ignoring method CVR


### PR DESCRIPTION
This was emitting a "not all control paths return" diagnostic in MSVC