### PR TITLE
[clang-tidy] Fix crash in readability-identifier-naming

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
@@ -1259,7 +1259,7 @@ StyleKind IdentifierNamingCheck::findStyleKind(
     // necessary even if it's not an override. e.g. CRTP.
     for (const CXXBaseSpecifier &Base : Decl->getParent()->bases())
       if (const auto *RD = Base.getType()->getAsCXXRecordDecl();
-          RD && RD->hasMemberName(Decl->getDeclName()))
+          RD && RD->hasDefinition() && RD->hasMemberName(Decl->getDeclName()))
         return SK_Invalid;
 
     if (Decl->isConstexpr() && NamingStyles[SK_ConstexprMethod])

--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -200,6 +200,8 @@ infrastructure are described first, followed by tool-specific sections.
 - Improved {doc}`readability-identifier-naming
   <clang-tidy/checks/readability/identifier-naming>` check:
 
+  - Fixed a crash when a class inherits from a forward-declared base class.
+
   - Fixed a crash when checking forward-declared classes with
     {option}`DefaultHungarianPrefix` enabled.
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming.cpp
@@ -834,3 +834,11 @@ Some_struct g_s1{ .SomeMember = 1 };
 // CHECK-FIXES: Some_struct g_s1{ .some_member = 1 };
 Some_struct g_s2{.SomeMember=1};
 // CHECK-FIXES: Some_struct g_s2{.some_member=1};
+
+template<class t_t>
+struct X {
+  struct B;
+  struct A : public B {
+    virtual void v_Foo() { }
+  };
+};


### PR DESCRIPTION
As requested by @zeyi2, I am splitting my original PR #219781 into two separate ones.

This PR contains the fix for the `readability-identifier-naming` crash. The crash happens because the checker calls `hasMemberName` on a base class without checking if that base class actually has a definition first (like when it's just forward-declared). I added a `RD->hasDefinition()` guard to fix it.

I also moved the test case into the existing `identifier-naming.cpp` file like suggested. (I wrapped the test in `NOLINT` comments so the checker wouldn't fail on the variable names inside the test case itself).

Fixes #213948