### PR TITLE
[clang-tidy] Fix infinite loop in misc-multiple-inheritance

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/MultipleInheritanceCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/MultipleInheritanceCheck.cpp
@@ -23,15 +23,15 @@ AST_MATCHER(CXXRecordDecl, hasBases) {
 
 bool MultipleInheritanceCheck::isInterface(const CXXBaseSpecifier &Base) {
   const CXXRecordDecl *const Node = Base.getType()->getAsCXXRecordDecl();
-  if (!Node)
+  if (!Node || !Node->hasDefinition())
     return true;
-
-  assert(Node->isCompleteDefinition());
 
   // Short circuit the lookup if we have analyzed this record before.
   if (const auto CachedValue = InterfaceMap.find(Node);
       CachedValue != InterfaceMap.end())
     return CachedValue->second;
+
+  InterfaceMap.try_emplace(Node, false);
 
   // To be an interface, a class must have...
   const bool CurrentClassIsInterface =
@@ -47,7 +47,7 @@ bool MultipleInheritanceCheck::isInterface(const CXXBaseSpecifier &Base) {
         return M->isUserProvided() && !M->isPureVirtual() && !M->isStatic();
       });
 
-  InterfaceMap.try_emplace(Node, CurrentClassIsInterface);
+  InterfaceMap[Node] = CurrentClassIsInterface;
   return CurrentClassIsInterface;
 }
 

--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -164,6 +164,10 @@ infrastructure are described first, followed by tool-specific sections.
   - Fixed false positives when the pointee is written through a pointer
     assignment, such as `*(p = q) = 0`.
 
+- Fixed an infinite loop in {doc}`misc-multiple-inheritance
+  <clang-tidy/checks/misc/multiple-inheritance>` when checking a class that
+  inherits from itself or has a circular inheritance graph.
+
 - Improved {doc}`misc-redundant-expression
   <clang-tidy/checks/misc/redundant-expression>` by fixing false positives in
   nested expressions involving different macros or a mix of macro and

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/multiple-inheritance.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/multiple-inheritance.cpp
@@ -182,3 +182,9 @@ struct VI : virtual VA { virtual void h() = 0; };
 struct VD : VI, VB {};
 
 } // namespace M
+
+template<class T> struct X {
+  struct B;
+  struct A : public B { virtual void foo() {} };
+};
+template<class T> struct X<T>::B : public A { virtual void foo() {} };


### PR DESCRIPTION
This PR contains the fix for the infinite loop in `misc-multiple-inheritance`. The checker was getting stuck in an infinite cycle when it encountered circular inheritance. I fixed this by adding a visited map (`InterfaceMap.try_emplace(Node, false)`) to break the cycle during the DFS traversal.

Part of #213948.