### PR TITLE
[ORC] Register SPS run-as function wrappers with SelfEPC

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/SelfExecutorProcessControl.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/SelfExecutorProcessControl.cpp
@@ -19,6 +19,8 @@
 #include "llvm/Support/Process.h"
 #include "llvm/TargetParser/Host.h"
 
+#include "TargetProcess/OrcRTBootstrap.h"
+
 #define DEBUG_TYPE "orc"
 
 namespace llvm::orc {
@@ -44,6 +46,7 @@ SelfExecutorProcessControl::SelfExecutorProcessControl(
   this->PageSize = PageSize;
 
   addDefaultBootstrapValuesForHostProcess(BootstrapMap, BootstrapSymbols);
+  rt_bootstrap::addRunAsFunctionWrappersTo(BootstrapSymbols);
 
   BootstrapSymbols[rt::DispatchName] =
       ExecutorAddr::fromPtr(jitDispatchViaWrapperFunctionManager);

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/OrcRTBootstrap.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/OrcRTBootstrap.cpp
@@ -156,6 +156,13 @@ runAsInt32Int32FunctionWrapper(const char *ArgData, size_t ArgSize) {
       .release();
 }
 
+void addRunAsFunctionWrappersTo(StringMap<ExecutorAddr> &M) {
+  M[rt::sps_ci::CallInt32Void::Name] =
+      ExecutorAddr::fromPtr(&runAsInt32VoidFunctionWrapper);
+  M[rt::sps_ci::CallInt32Int32::Name] =
+      ExecutorAddr::fromPtr(&runAsInt32Int32FunctionWrapper);
+}
+
 void addTo(StringMap<ExecutorAddr> &M) {
   M[rt::sps_ci::MemWriteUInt8s::Name] = ExecutorAddr::fromPtr(
       &writeUIntsWrapper<tpctypes::UInt8Write,
@@ -188,10 +195,7 @@ void addTo(StringMap<ExecutorAddr> &M) {
   M[rt::sps_ci::MemReadStrings::Name] =
       ExecutorAddr::fromPtr(&readStringsWrapper);
   M[rt::sps_ci::CallMain::Name] = ExecutorAddr::fromPtr(&runAsMainWrapper);
-  M[rt::sps_ci::CallInt32Void::Name] =
-      ExecutorAddr::fromPtr(&runAsInt32VoidFunctionWrapper);
-  M[rt::sps_ci::CallInt32Int32::Name] =
-      ExecutorAddr::fromPtr(&runAsInt32Int32FunctionWrapper);
+  addRunAsFunctionWrappersTo(M);
 }
 
 } // end namespace rt_bootstrap

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/OrcRTBootstrap.h
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/OrcRTBootstrap.h
@@ -27,6 +27,10 @@ namespace llvm {
 namespace orc {
 namespace rt_bootstrap {
 
+/// Adds executor-side wrappers for the run-as function proxies.
+void addRunAsFunctionWrappersTo(StringMap<ExecutorAddr> &M);
+
+/// Adds all default target-process bootstrap wrappers.
 void addTo(StringMap<ExecutorAddr> &M);
 
 } // namespace rt_bootstrap

--- a/llvm/unittests/ExecutionEngine/Orc/SPSProxySpecTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/SPSProxySpecTest.cpp
@@ -15,6 +15,8 @@
 
 #include "llvm/ExecutionEngine/Orc/SPSProxySpec.h"
 #include "llvm/ExecutionEngine/Orc/CallProxiesSPS.h"
+#include "llvm/ExecutionEngine/Orc/LookupAndApply.h"
+#include "llvm/ExecutionEngine/Orc/RecordProxy.h"
 #include "llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h"
 #include "llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h"
 #include "llvm/Support/MSVCErrorWorkarounds.h"
@@ -205,6 +207,33 @@ TEST(SPSProxySpecTest, Int32VoidSync) {
   Expected<int32_t> R = Call(ES, ExecutorAddr::fromPtr(int32VoidTarget));
   ASSERT_THAT_EXPECTED(R, Succeeded());
   EXPECT_EQ(*R, 42);
+
+  cantFail(ES.endSession());
+}
+
+TEST(SPSProxySpecTest, SelfEPCBootstrapRunAsFunctionProxies) {
+  ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
+
+  CallInt32VoidProxy CallInt32Void;
+  CallInt32Int32Proxy CallInt32Int32;
+  if (auto Err = lookupAndApply(
+          ES.getBootstrapJITDylib(),
+          {recordProxy<sps::CallInt32VoidProxySpec>(&CallInt32Void),
+           recordProxy<sps::CallInt32Int32ProxySpec>(&CallInt32Int32)})) {
+    ADD_FAILURE() << toString(std::move(Err));
+    cantFail(ES.endSession());
+    return;
+  }
+
+  Expected<int32_t> VoidResult =
+      CallInt32Void(ES, ExecutorAddr::fromPtr(int32VoidTarget));
+  ASSERT_THAT_EXPECTED(VoidResult, Succeeded());
+  EXPECT_EQ(*VoidResult, 42);
+
+  Expected<int32_t> IntResult =
+      CallInt32Int32(ES, ExecutorAddr::fromPtr(int32Int32Target), 21);
+  ASSERT_THAT_EXPECTED(IntResult, Succeeded());
+  EXPECT_EQ(*IntResult, 42);
 
   cantFail(ES.endSession());
 }


### PR DESCRIPTION
#213265 replaced the direct `ExecutorProcessControl::runAsVoidFunction` and `runAsIntFunction` calls in `COFFPlatform` and `COFFVCRuntimeSupport` with SPS call proxies. The target-process bootstrap registers the corresponding executor-side wrappers for `SimpleRemoteEPC`, but SelfEPC does not register them. In-process clients using these paths therefore fail to resolve:

```text
orc_rt_ci_sps_call_int32_void
orc_rt_ci_sps_call_int32_int32
```

This patch factors registration of the two existing run-as function wrappers out of the complete target-process bootstrap set and adds that narrow set to SelfEPC.

SelfEPC already provides in-process memory access directly, so it does not use the complete bootstrap set, which would also register unnecessary SPS memory access symbols. `SimpleRemoteEPC` continues to call the complete `addTo` helper, so its bootstrap contents are unchanged.

The SPS run-as operations remain experimental. This patch does not add or stabilize them; it supplies the wrappers required by their existing in-tree COFF users. Although the failure was exposed through an in-process COFFPlatform configuration, the missing SelfEPC bootstrap contract is not Windows-specific.

Testing: Added a unit test that resolves and invokes both proxies through the SelfEPC bootstrap JITDylib; the ORC unit suite passes.

Assisted-by: OpenAI Codex
