### PR TITLE
[compiler-rt][ORC][COFF] Run initializers outside JD state lock

### DIFF
--- a/compiler-rt/lib/orc/coff_platform.cpp
+++ b/compiler-rt/lib/orc/coff_platform.cpp
@@ -69,6 +69,7 @@ private:
 
     void Reset() { SubsectionsNew = Subsections; }
 
+    std::vector<void (*)(void)> TakeAllNew();
     void RunAllNewAndFlush();
 
   private:
@@ -139,12 +140,19 @@ private:
                             ExecutorAddrRange SEHFrameRange);
 
   Expected<void *> dlopenImpl(std::string_view Path, int Mode);
-  Error dlopenFull(JITDylibState &JDS);
-  Error dlopenInitialize(JITDylibState &JDS, COFFJITDylibDepInfoMap &DepInfo);
+  Error dlopenFull(std::unique_lock<std::recursive_mutex> &JDStatesLock,
+                   JITDylibState &JDS);
+  Error dlopenInitialize(std::unique_lock<std::recursive_mutex> &JDStatesLock,
+                         JITDylibState &JDS, COFFJITDylibDepInfoMap &DepInfo);
 
   Error dlupdateImpl(void *DSOHandle);
-  Error dlupdateFull(JITDylibState &JDS);
-  Error dlupdateInitialize(JITDylibState &JDS);
+  Error dlupdateFull(std::unique_lock<std::recursive_mutex> &JDStatesLock,
+                     JITDylibState &JDS);
+  Error dlupdateInitialize(std::unique_lock<std::recursive_mutex> &JDStatesLock,
+                           JITDylibState &JDS);
+
+  void runInitializers(std::unique_lock<std::recursive_mutex> &JDStatesLock,
+                       JITDylibState &JDS);
 
   Error dlcloseImpl(void *DSOHandle);
   Error dlcloseDeinitialize(JITDylibState &JDS);
@@ -156,6 +164,11 @@ private:
 
   static COFFPlatformRuntimeState *CPS;
 
+  // DyldAPIMutex guards against concurrent entry into key "dyld" API
+  // functions (e.g. dlopen, dlupdate, dlclose).
+  std::recursive_mutex DyldAPIMutex;
+
+  // JDStatesMutex guards the data structures that hold JITDylib state.
   std::recursive_mutex JDStatesMutex;
   std::map<void *, JITDylibState> JDStates;
   struct BlockRange {
@@ -243,14 +256,21 @@ Error COFFPlatformRuntimeState::deregisterJITDylib(void *Header) {
   return Error::success();
 }
 
-void COFFPlatformRuntimeState::XtorSection::RunAllNewAndFlush() {
+std::vector<void (*)()> COFFPlatformRuntimeState::XtorSection::TakeAllNew() {
+  std::vector<void (*)()> Xtors;
   for (auto &Subsection : SubsectionsNew) {
     for (auto &XtorGroup : Subsection)
       for (auto &Xtor : XtorGroup)
         if (Xtor)
-          Xtor();
+          Xtors.push_back(Xtor);
     Subsection.clear();
   }
+  return Xtors;
+}
+
+void COFFPlatformRuntimeState::XtorSection::RunAllNewAndFlush() {
+  for (auto Xtor : TakeAllNew())
+    Xtor();
 }
 
 const char *COFFPlatformRuntimeState::dlerror() { return DLFcnError.c_str(); }
@@ -260,7 +280,7 @@ void *COFFPlatformRuntimeState::dlopen(std::string_view Path, int Mode) {
     std::string S(Path.data(), Path.size());
     printdbg("COFFPlatform::dlopen(\"%s\")\n", S.c_str());
   });
-  std::lock_guard<std::recursive_mutex> Lock(JDStatesMutex);
+  std::lock_guard<std::recursive_mutex> Lock(DyldAPIMutex);
   if (auto H = dlopenImpl(Path, Mode))
     return *H;
   else {
@@ -275,7 +295,7 @@ int COFFPlatformRuntimeState::dlupdate(void *DSOHandle) {
     std::string S;
     printdbg("COFFPlatform::dlupdate(%p) (%s)\n", DSOHandle, S.c_str());
   });
-  std::lock_guard<std::recursive_mutex> Lock(JDStatesMutex);
+  std::lock_guard<std::recursive_mutex> Lock(DyldAPIMutex);
   if (auto Err = dlupdateImpl(DSOHandle)) {
     // FIXME: Make dlerror thread safe.
     DLFcnError = toString(std::move(Err));
@@ -294,7 +314,7 @@ int COFFPlatformRuntimeState::dlclose(void *DSOHandle) {
     } else
       printdbg("COFFPlatform::dlclose(%p) (%s)\n", DSOHandle, "invalid handle");
   });
-  std::lock_guard<std::recursive_mutex> Lock(JDStatesMutex);
+  std::lock_guard<std::recursive_mutex> Lock(DyldAPIMutex);
   if (auto Err = dlcloseImpl(DSOHandle)) {
     // FIXME: Make dlerror thread safe.
     DLFcnError = toString(std::move(Err));
@@ -314,6 +334,8 @@ void *COFFPlatformRuntimeState::dlsym(void *Header, std::string_view Symbol) {
 
 Expected<void *> COFFPlatformRuntimeState::dlopenImpl(std::string_view Path,
                                                       int Mode) {
+  std::unique_lock<std::recursive_mutex> Lock(JDStatesMutex);
+
   // Try to find JITDylib state by name.
   auto *JDS = getJITDylibStateByName(Path);
 
@@ -321,7 +343,7 @@ Expected<void *> COFFPlatformRuntimeState::dlopenImpl(std::string_view Path,
     return make_error<StringError>("No registered JTIDylib for path " +
                                    std::string(Path.data(), Path.size()));
 
-  if (auto Err = dlopenFull(*JDS))
+  if (auto Err = dlopenFull(Lock, *JDS))
     return std::move(Err);
 
   // Bump the ref-count on this dylib.
@@ -331,18 +353,22 @@ Expected<void *> COFFPlatformRuntimeState::dlopenImpl(std::string_view Path,
   return JDS->Header;
 }
 
-Error COFFPlatformRuntimeState::dlopenFull(JITDylibState &JDS) {
+Error COFFPlatformRuntimeState::dlopenFull(
+    std::unique_lock<std::recursive_mutex> &JDStatesLock, JITDylibState &JDS) {
   // Call back to the JIT to push the initializers.
   Expected<COFFJITDylibDepInfoMap> DepInfoMap((COFFJITDylibDepInfoMap()));
+  // Unlock so that we can accept the initializer update.
+  JDStatesLock.unlock();
   if (auto Err = WrapperFunction<SPSExpected<SPSCOFFJITDylibDepInfoMap>(
           SPSExecutorAddr)>::
           call(JITDispatch(&__orc_rt_coff_push_initializers_tag), DepInfoMap,
                ExecutorAddr::fromPtr(JDS.Header)))
     return Err;
+  JDStatesLock.lock();
   if (!DepInfoMap)
     return DepInfoMap.takeError();
 
-  if (auto Err = dlopenInitialize(JDS, *DepInfoMap))
+  if (auto Err = dlopenInitialize(JDStatesLock, JDS, *DepInfoMap))
     return Err;
 
   if (!DepInfoMap->empty()) {
@@ -361,7 +387,8 @@ Error COFFPlatformRuntimeState::dlopenFull(JITDylibState &JDS) {
 }
 
 Error COFFPlatformRuntimeState::dlopenInitialize(
-    JITDylibState &JDS, COFFJITDylibDepInfoMap &DepInfo) {
+    std::unique_lock<std::recursive_mutex> &JDStatesLock, JITDylibState &JDS,
+    COFFJITDylibDepInfoMap &DepInfo) {
   ORC_RT_DEBUG({
     printdbg("COFFPlatformRuntimeState::dlopenInitialize(\"%s\")\n",
              JDS.Name.c_str());
@@ -390,13 +417,11 @@ Error COFFPlatformRuntimeState::dlopenInitialize(
       return make_error<StringError>(ErrStream.str());
     }
     ++DepJDS->LinkedAgainstRefCount;
-    if (auto Err = dlopenInitialize(*DepJDS, DepInfo))
+    if (auto Err = dlopenInitialize(JDStatesLock, *DepJDS, DepInfo))
       return Err;
   }
 
-  // Run static initializers.
-  JDS.CInitSection.RunAllNewAndFlush();
-  JDS.CXXInitSection.RunAllNewAndFlush();
+  runInitializers(JDStatesLock, JDS);
 
   // Decrement old deps.
   for (auto *DepJDS : OldDeps) {
@@ -410,6 +435,8 @@ Error COFFPlatformRuntimeState::dlopenInitialize(
 }
 
 Error COFFPlatformRuntimeState::dlupdateImpl(void *DSOHandle) {
+  std::unique_lock<std::recursive_mutex> Lock(JDStatesMutex);
+
   // Try to find JITDylib state by header.
   auto *JDS = getJITDylibStateByHeader(DSOHandle);
 
@@ -422,43 +449,64 @@ Error COFFPlatformRuntimeState::dlupdateImpl(void *DSOHandle) {
   if (!JDS->referenced())
     return make_error<StringError>("dlupdate failed, JITDylib must be open.");
 
-  if (auto Err = dlupdateFull(*JDS))
+  if (auto Err = dlupdateFull(Lock, *JDS))
     return Err;
 
   return Error::success();
 }
 
-Error COFFPlatformRuntimeState::dlupdateFull(JITDylibState &JDS) {
+Error COFFPlatformRuntimeState::dlupdateFull(
+    std::unique_lock<std::recursive_mutex> &JDStatesLock, JITDylibState &JDS) {
   // Call back to the JIT to push the initializers.
   Expected<COFFJITDylibDepInfoMap> DepInfoMap((COFFJITDylibDepInfoMap()));
+  // Unlock so that we can accept the initializer update.
+  JDStatesLock.unlock();
   if (auto Err = WrapperFunction<SPSExpected<SPSCOFFJITDylibDepInfoMap>(
           SPSExecutorAddr)>::
           call(JITDispatch(&__orc_rt_coff_push_initializers_tag), DepInfoMap,
                ExecutorAddr::fromPtr(JDS.Header)))
     return Err;
+  JDStatesLock.lock();
   if (!DepInfoMap)
     return DepInfoMap.takeError();
 
-  if (auto Err = dlupdateInitialize(JDS))
+  if (auto Err = dlupdateInitialize(JDStatesLock, JDS))
     return Err;
 
   return Error::success();
 }
 
-Error COFFPlatformRuntimeState::dlupdateInitialize(JITDylibState &JDS) {
+Error COFFPlatformRuntimeState::dlupdateInitialize(
+    std::unique_lock<std::recursive_mutex> &JDStatesLock, JITDylibState &JDS) {
   ORC_RT_DEBUG({
     printdbg("COFFPlatformRuntimeState::dlupdateInitialize(\"%s\")\n",
              JDS.Name.c_str());
   });
 
-  // Run static initializers.
-  JDS.CInitSection.RunAllNewAndFlush();
-  JDS.CXXInitSection.RunAllNewAndFlush();
+  runInitializers(JDStatesLock, JDS);
 
   return Error::success();
 }
 
+void COFFPlatformRuntimeState::runInitializers(
+    std::unique_lock<std::recursive_mutex> &JDStatesLock, JITDylibState &JDS) {
+  auto CInits = JDS.CInitSection.TakeAllNew();
+  auto CXXInits = JDS.CXXInitSection.TakeAllNew();
+
+  // Initializers are user code and may re-enter the runtime from another
+  // thread. Extract the pending initializers under the lock, then release it
+  // while running them.
+  JDStatesLock.unlock();
+  for (auto Init : CInits)
+    Init();
+  for (auto Init : CXXInits)
+    Init();
+  JDStatesLock.lock();
+}
+
 Error COFFPlatformRuntimeState::dlcloseImpl(void *DSOHandle) {
+  std::unique_lock<std::recursive_mutex> Lock(JDStatesMutex);
+
   // Try to find JITDylib state by header.
   auto *JDS = getJITDylibStateByHeader(DSOHandle);
 
@@ -756,8 +804,9 @@ struct ThrowInfo {
   void *data;
 };
 
-ORC_RT_INTERFACE void __stdcall __orc_rt_coff_cxx_throw_exception(
-    void *pExceptionObject, ThrowInfo *pThrowInfo) {
+ORC_RT_INTERFACE void __stdcall
+__orc_rt_coff_cxx_throw_exception(void *pExceptionObject,
+                                  ThrowInfo *pThrowInfo) {
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wmultichar"

--- a/compiler-rt/test/orc/TestCases/Windows/x86-64/initializer-reentry.c
+++ b/compiler-rt/test/orc/TestCases/Windows/x86-64/initializer-reentry.c
@@ -1,0 +1,54 @@
+// RUN: %clang_cl -MD -c -o %t %s
+// RUN: %llvm_jitlink %t 2>&1 | FileCheck %s
+// CHECK: Initializer worker completed
+// CHECK-NEXT: Entering main
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <windows.h>
+
+static HANDLE worker_thread;
+static int initializer_timed_out;
+
+static void on_exit(void) {}
+
+static DWORD WINAPI worker(void *context) {
+  (void)context;
+  atexit(on_exit);
+  return 0;
+}
+
+static void initialize(void) {
+  worker_thread = CreateThread(NULL, 0, worker, NULL, 0, NULL);
+  if (!worker_thread) {
+    initializer_timed_out = 1;
+    return;
+  }
+
+  if (WaitForSingleObject(worker_thread, 10000) != WAIT_OBJECT_0) {
+    initializer_timed_out = 1;
+    return;
+  }
+
+  puts("Initializer worker completed");
+  fflush(stdout);
+}
+
+#pragma section(".CRT$XCU", read)
+__declspec(allocate(".CRT$XCU")) void (*initializer)(void) = initialize;
+
+int main(int argc, char *argv[]) {
+  (void)argc;
+  (void)argv;
+
+  if (worker_thread) {
+    WaitForSingleObject(worker_thread, INFINITE);
+    CloseHandle(worker_thread);
+  }
+  if (initializer_timed_out)
+    return 1;
+
+  puts("Entering main");
+  fflush(stdout);
+  return 0;
+}


### PR DESCRIPTION
The COFF platform runtime ran C and C++ initializers while holding `JDStatesMutex`. An initializer can re-enter the runtime from another thread: for example, it can start a worker, wait for it, and have the worker call `atexit`. The worker then blocks in `registerAtExit` waiting for the mutex while the initializer waits for the worker.

Separate serialization of the `dlopen`/`dlupdate`/`dlclose` APIs from protection of the JITDylib state, following the Mach-O runtime's locking structure. A recursive API mutex remains held across each operation, while `JDStatesMutex` protects the state maps and can be released around calls into the controller and user initializers.

Collect pending initializer functions while holding `JDStatesMutex`, release that lock while calling them, and reacquire it afterward. The controller callback that pushes initializer sections is handled the same way. This matches the existing ELF and Mach-O rule that controller callbacks and user initializers do not run under the JITDylib state lock, while retaining serialized COFF loader operations.

Testing: Added `initializer-reentry.c`, compiled it with `clang-cl`, and verified the re-entry scenario with `llvm-jitlink` and the Windows ORC runtime. The existing in-tree Windows ORC lit command cannot currently reach the test body because it combines `-orc-runtime` with `-no-process-syms`; the test is included so it can run once that separate configuration problem is fixed.

Assisted-by: OpenAI Codex
