### PR TITLE
[clang][bytecode][NFC] Use Func->getDecl() instead of getCallee()

### DIFF
--- a/clang/lib/AST/ByteCode/InterpFrame.cpp
+++ b/clang/lib/AST/ByteCode/InterpFrame.cpp
@@ -163,7 +163,7 @@ void InterpFrame::describe(llvm::raw_ostream &OS) const {
 
   const ASTContext &ASTCtx = S.getASTContext();
   const Expr *CallExpr = Caller->getExpr(getRetOpPC());
-  const FunctionDecl *F = getCallee();
+  const FunctionDecl *F = Func->getDecl();
   auto PrintingPolicy = ASTCtx.getPrintingPolicy();
   PrintingPolicy.SuppressLambdaBody = true;
 


### PR DESCRIPTION
We already `assert(Func)` above and use `Func` directly in other places in this function, so just get the `FunctionDecl` from that instead of going through the virtual function.