### PR TITLE
[sanitizer_common] Disable the fast unwinder on Alpha Linux

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_stacktrace.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_stacktrace.h
@@ -22,12 +22,12 @@ struct BufferedStackTrace;
 
 static const u32 kStackTraceMax = 255;
 
-#if SANITIZER_LINUX && defined(__mips__)
-# define SANITIZER_CAN_FAST_UNWIND 0
+#if SANITIZER_LINUX && (defined(__mips__) || defined(__alpha__))
+#  define SANITIZER_CAN_FAST_UNWIND 0
 #elif SANITIZER_WINDOWS
-# define SANITIZER_CAN_FAST_UNWIND 0
+#  define SANITIZER_CAN_FAST_UNWIND 0
 #else
-# define SANITIZER_CAN_FAST_UNWIND 1
+#  define SANITIZER_CAN_FAST_UNWIND 1
 #endif
 
 // Fast unwind is the only option on Mac for now; we will need to

--- a/compiler-rt/test/asan/TestCases/complete_stack_trace.c
+++ b/compiler-rt/test/asan/TestCases/complete_stack_trace.c
@@ -7,11 +7,6 @@
 // RUN: not %run %t 2>&1 | FileCheck %s
 // REQUIRES: stable-runtime
 
-// On Alpha the fast unwinder walks a frame layout the target does not use, so
-// every trace but the access one stops early. Fixed by
-// https://github.com/llvm/llvm-project/pull/220231.
-// XFAIL: alpha-target-arch
-
 #include <stdlib.h>
 
 char *p;


### PR DESCRIPTION
BufferedStackTrace::UnwindFast walks the stack assuming frame[0] is the caller's frame pointer and frame[1] the return address. Alpha chains neither, so the walk yields a few garbage frames and then stops:
```
  freed by thread T0 here:
      #0 0x020000971274 in free asan_malloc_linux.cpp:51
      #1 0x0200007fa48c  (<unknown module>)
```
Opt Alpha out of the fast unwinder the way Linux/MIPS already is. The _Unwind_Backtrace based unwinder gives complete traces; with it, GCC's g++.dg/asan/deep-stack-uaf-1.C passes on alpha-unknown-linux-gnu.