### PR TITLE
[mlir][bufferization] Fix crash when returning an allocation twice

### DIFF
--- a/mlir/lib/Dialect/Bufferization/Transforms/BufferResultsToOutParams.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/BufferResultsToOutParams.cpp
@@ -168,7 +168,20 @@ updateReturnOps(func::FuncOp func, ArrayRef<BlockArgument> appendedEntryArgs,
     }
     OpBuilder builder(op);
     SmallVector<SmallVector<Value>> dynamicSizes;
+    SetVector<Operation *> toErase;
+    DenseMap<Value, BlockArgument> primaryArgs;
+    DenseMap<Value, SmallVector<Value>> dynSizes;
     for (auto [orig, arg] : llvm::zip(copyIntoOutParams, appendedEntryArgs)) {
+      auto [it, inserted] = primaryArgs.try_emplace(orig, arg);
+      if (!inserted) {
+        if (auto dynIt = dynSizes.find(orig); dynIt != dynSizes.end())
+          dynamicSizes.push_back(dynIt->second);
+        if (it->second != arg &&
+            failed(options.memCpyFn(builder, op->getLoc(), it->second, arg)))
+          return WalkResult::interrupt();
+        continue;
+      }
+
       bool hoistStaticAllocs =
           options.hoistStaticAllocs &&
           cast<MemRefType>(orig.getType()).hasStaticShape();
@@ -182,13 +195,18 @@ updateReturnOps(func::FuncOp func, ArrayRef<BlockArgument> appendedEntryArgs,
         if (hoistDynamicAllocs) {
           SmallVector<Value> dynamicSize = getDynamicSize(orig, func);
           dynamicSizes.push_back(dynamicSize);
+          dynSizes.try_emplace(orig, std::move(dynamicSize));
         }
-        orig.getDefiningOp()->erase();
+        toErase.insert(orig.getDefiningOp());
       } else {
         if (failed(options.memCpyFn(builder, op.getLoc(), orig, arg)))
           return WalkResult::interrupt();
       }
     }
+
+    for (Operation *eraseOp : toErase)
+      eraseOp->erase();
+
     func::ReturnOp::create(builder, op.getLoc(), keepAsReturnOperands);
     op.erase();
     auto dynamicSizePair =

--- a/mlir/lib/Dialect/Bufferization/Transforms/BufferResultsToOutParams.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/BufferResultsToOutParams.cpp
@@ -170,24 +170,10 @@ updateReturnOps(func::FuncOp func, ArrayRef<BlockArgument> appendedEntryArgs,
     SmallVector<SmallVector<Value>> dynamicSizes;
     // Map each returned memref to its primary out parameter.
     DenseMap<Value, BlockArgument> primaryArgs;
-    // Cache dynamic sizes by result so duplicate dynamic results can reuse
-    // their sizes when adding entries to `dynamicSizes`.
-    DenseMap<Value, SmallVector<Value>> dynamicSizesCache;
     // Delay erasure until all return operands have been inspected because an
     // allocation may be returned multiple times.
     SetVector<Operation *> toErase;
     for (auto [orig, arg] : llvm::zip(copyIntoOutParams, appendedEntryArgs)) {
-      auto [it, inserted] = primaryArgs.try_emplace(orig, arg);
-      if (!inserted) {
-        if (auto dynIt = dynamicSizesCache.find(orig);
-            dynIt != dynamicSizesCache.end())
-          dynamicSizes.push_back(dynIt->second);
-        if (it->second != arg &&
-            failed(options.memCpyFn(builder, op->getLoc(), it->second, arg)))
-          return WalkResult::interrupt();
-        continue;
-      }
-
       bool hoistStaticAllocs =
           options.hoistStaticAllocs &&
           cast<MemRefType>(orig.getType()).hasStaticShape();
@@ -197,12 +183,22 @@ updateReturnOps(func::FuncOp func, ArrayRef<BlockArgument> appendedEntryArgs,
       if ((hoistStaticAllocs || hoistDynamicAllocs) &&
           isa_and_nonnull<bufferization::AllocationOpInterface>(
               orig.getDefiningOp())) {
-        orig.replaceAllUsesWith(arg);
         if (hoistDynamicAllocs) {
           SmallVector<Value> dynamicSize = getDynamicSize(orig, func);
           dynamicSizes.push_back(dynamicSize);
-          dynamicSizesCache.try_emplace(orig, std::move(dynamicSize));
         }
+
+        auto [it, inserted] = primaryArgs.try_emplace(orig, arg);
+        // Repeated returns of the same allocation reuse the primary out
+        // parameter; copy its contents into the out parameter for this
+        // occurrence.
+        if (!inserted) {
+          if (it->second != arg &&
+              failed(options.memCpyFn(builder, op->getLoc(), it->second, arg)))
+            return WalkResult::interrupt();
+          continue;
+        }
+        orig.replaceAllUsesWith(arg);
         toErase.insert(orig.getDefiningOp());
       } else {
         if (failed(options.memCpyFn(builder, op.getLoc(), orig, arg)))

--- a/mlir/lib/Dialect/Bufferization/Transforms/BufferResultsToOutParams.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/BufferResultsToOutParams.cpp
@@ -168,13 +168,19 @@ updateReturnOps(func::FuncOp func, ArrayRef<BlockArgument> appendedEntryArgs,
     }
     OpBuilder builder(op);
     SmallVector<SmallVector<Value>> dynamicSizes;
-    SetVector<Operation *> toErase;
+    // Map each returned memref to its primary out parameter.
     DenseMap<Value, BlockArgument> primaryArgs;
-    DenseMap<Value, SmallVector<Value>> dynSizes;
+    // Cache dynamic sizes by result so duplicate dynamic results can reuse
+    // their sizes when adding entries to `dynamicSizes`.
+    DenseMap<Value, SmallVector<Value>> dynamicSizesCache;
+    // Delay erasure until all return operands have been inspected because an
+    // allocation may be returned multiple times.
+    SetVector<Operation *> toErase;
     for (auto [orig, arg] : llvm::zip(copyIntoOutParams, appendedEntryArgs)) {
       auto [it, inserted] = primaryArgs.try_emplace(orig, arg);
       if (!inserted) {
-        if (auto dynIt = dynSizes.find(orig); dynIt != dynSizes.end())
+        if (auto dynIt = dynamicSizesCache.find(orig);
+            dynIt != dynamicSizesCache.end())
           dynamicSizes.push_back(dynIt->second);
         if (it->second != arg &&
             failed(options.memCpyFn(builder, op->getLoc(), it->second, arg)))
@@ -195,7 +201,7 @@ updateReturnOps(func::FuncOp func, ArrayRef<BlockArgument> appendedEntryArgs,
         if (hoistDynamicAllocs) {
           SmallVector<Value> dynamicSize = getDynamicSize(orig, func);
           dynamicSizes.push_back(dynamicSize);
-          dynSizes.try_emplace(orig, std::move(dynamicSize));
+          dynamicSizesCache.try_emplace(orig, std::move(dynamicSize));
         }
         toErase.insert(orig.getDefiningOp());
       } else {

--- a/mlir/lib/Dialect/Bufferization/Transforms/BufferResultsToOutParams.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/BufferResultsToOutParams.cpp
@@ -193,14 +193,13 @@ updateReturnOps(func::FuncOp func, ArrayRef<BlockArgument> appendedEntryArgs,
         // parameter; copy its contents into the out parameter for this
         // occurrence.
         if (!inserted) {
-          if (it->second != arg &&
-              failed(options.memCpyFn(builder, op->getLoc(), it->second, arg)))
+          if (failed(options.memCpyFn(builder, op->getLoc(), it->second, arg)))
             return WalkResult::interrupt();
           continue;
         }
         orig.replaceAllUsesWith(arg);
         toErase.insert(orig.getDefiningOp());
-      } else {
+      } else if (orig != arg) {
         if (failed(options.memCpyFn(builder, op.getLoc(), orig, arg)))
           return WalkResult::interrupt();
       }

--- a/mlir/test/Transforms/buffer-results-to-out-params-hosit-dynamic-allocs.mlir
+++ b/mlir/test/Transforms/buffer-results-to-out-params-hosit-dynamic-allocs.mlir
@@ -77,3 +77,31 @@ func.func @complex_alloc_test(%size0 : index, %size1: index) {
 //       CHECK:   call @complex_alloc(%[[size0]], %[[size1]], %[[alloc0]], %[[alloc1]], %[[alloc2]]) : (index, index, memref<?x?xf32>, memref<4xf32>, memref<?xf32>) -> ()
 //       CHECK:   "test.sink"(%[[alloc0]], %[[alloc1]], %[[alloc2]]) : (memref<?x?xf32>, memref<4xf32>, memref<?xf32>) -> ()
 //       CHECK: }
+
+// -----
+
+func.func private @duplicate_dynamic(%size : index)
+    -> (memref<?xf32>, memref<?xf32>) {
+  %alloc = memref.alloc(%size) : memref<?xf32>
+  return %alloc, %alloc : memref<?xf32>, memref<?xf32>
+}
+
+func.func @duplicate_dynamic_test(%size : index) {
+  %alloc0, %alloc1 = call @duplicate_dynamic(%size)
+      : (index) -> (memref<?xf32>, memref<?xf32>)
+  "test.sink"(%alloc0, %alloc1) : (memref<?xf32>, memref<?xf32>) -> ()
+}
+
+// CHECK-LABEL: func.func private @duplicate_dynamic(
+//  CHECK-SAME:   %{{.*}}: index,
+//  CHECK-SAME:   %[[OUT0:.*]]: memref<?xf32>,
+//  CHECK-SAME:   %[[OUT1:.*]]: memref<?xf32>) {
+//       CHECK:   memref.copy %[[OUT0]], %[[OUT1]] : memref<?xf32> to memref<?xf32>
+//       CHECK:   return
+
+// CHECK-LABEL: func.func @duplicate_dynamic_test(
+//  CHECK-SAME:   %[[SIZE:.*]]: index) {
+//       CHECK:   %[[ALLOC0:.*]] = memref.alloc(%[[SIZE]]) : memref<?xf32>
+//       CHECK:   %[[ALLOC1:.*]] = memref.alloc(%[[SIZE]]) : memref<?xf32>
+//       CHECK:   call @duplicate_dynamic(%[[SIZE]], %[[ALLOC0]], %[[ALLOC1]]) : (index, memref<?xf32>, memref<?xf32>) -> ()
+//       CHECK:   "test.sink"(%[[ALLOC0]], %[[ALLOC1]]) : (memref<?xf32>, memref<?xf32>) -> ()

--- a/mlir/test/Transforms/buffer-results-to-out-params-hosit-dynamic-allocs.mlir
+++ b/mlir/test/Transforms/buffer-results-to-out-params-hosit-dynamic-allocs.mlir
@@ -105,3 +105,26 @@ func.func @duplicate_dynamic_test(%size : index) {
 //       CHECK:   %[[ALLOC1:.*]] = memref.alloc(%[[SIZE]]) : memref<?xf32>
 //       CHECK:   call @duplicate_dynamic(%[[SIZE]], %[[ALLOC0]], %[[ALLOC1]]) : (index, memref<?xf32>, memref<?xf32>) -> ()
 //       CHECK:   "test.sink"(%[[ALLOC0]], %[[ALLOC1]]) : (memref<?xf32>, memref<?xf32>) -> ()
+
+// -----
+
+// CHECK-LABEL: func.func private @multiple_dynamic_returns_with_non_alloc(
+// CHECK-SAME:    %[[SIZE:.*]]: index, %[[INPUT:.*]]: memref<?xf32>, %[[COND:.*]]: i1, %[[OUT0:.*]]: memref<?xf32>, %[[OUT1:.*]]: memref<?xf32>) {
+// CHECK:        cf.cond_br %[[COND]], ^[[THEN:.*]], ^[[ELSE:.*]]
+// CHECK:      ^[[THEN]]:
+// CHECK:        memref.copy %[[OUT0]], %[[OUT1]] : memref<?xf32> to memref<?xf32>
+// CHECK:        return
+// CHECK:      ^[[ELSE]]:
+// CHECK:        memref.copy %[[INPUT]], %[[OUT0]] : memref<?xf32> to memref<?xf32>
+// CHECK:        memref.copy %[[INPUT]], %[[OUT1]] : memref<?xf32> to memref<?xf32>
+// CHECK:        return
+func.func private @multiple_dynamic_returns_with_non_alloc(
+    %size: index, %input: memref<?xf32>, %cond: i1)
+    -> (memref<?xf32>, memref<?xf32>) {
+  %a = memref.alloc(%size) : memref<?xf32>
+  cf.cond_br %cond, ^then, ^else
+^then:
+  return %a, %a : memref<?xf32>, memref<?xf32>
+^else:
+  return %input, %input : memref<?xf32>, memref<?xf32>
+}

--- a/mlir/test/Transforms/buffer-results-to-out-params-hosit-static-allocs.mlir
+++ b/mlir/test/Transforms/buffer-results-to-out-params-hosit-static-allocs.mlir
@@ -49,3 +49,14 @@ func.func private @return_arg(%arg0: memref<128x256xf32>, %arg1: memref<128x256x
   "test.source"(%arg0, %arg1)  : (memref<128x256xf32>, memref<128x256xf32>) -> ()
   return %arg0 : memref<128x256xf32>
 }
+
+// CHECK-LABEL: func.func private @duplicate_return_value(
+// CHECK-SAME:    %[[ARG0:.*]]: memref<4xf32>, %[[ARG1:.*]]: memref<4xf32>) {
+// CHECK-NOT:     memref.alloc
+// CHECK:         memref.copy %[[ARG0]], %[[ARG1]] : memref<4xf32> to memref<4xf32>
+// CHECK:         return
+func.func private @duplicate_return_value()
+    -> (memref<4xf32>, memref<4xf32>) {
+  %a = memref.alloc() : memref<4xf32>
+  return %a, %a : memref<4xf32>, memref<4xf32>
+}

--- a/mlir/test/Transforms/buffer-results-to-out-params-hosit-static-allocs.mlir
+++ b/mlir/test/Transforms/buffer-results-to-out-params-hosit-static-allocs.mlir
@@ -60,3 +60,46 @@ func.func private @duplicate_return_value()
   %a = memref.alloc() : memref<4xf32>
   return %a, %a : memref<4xf32>, memref<4xf32>
 }
+
+// -----
+
+// CHECK-LABEL: func.func private @multiple_duplicate_returns(
+// CHECK-SAME:    %[[COND:.*]]: i1, %[[OUT0:.*]]: memref<4xf32>, %[[OUT1:.*]]: memref<4xf32>) {
+// CHECK:        cf.cond_br %[[COND]], ^[[THEN:.*]], ^[[ELSE:.*]]
+// CHECK:      ^[[THEN]]:
+// CHECK:        memref.copy %[[OUT0]], %[[OUT1]] : memref<4xf32> to memref<4xf32>
+// CHECK:        return
+// CHECK:      ^[[ELSE]]:
+// CHECK:        memref.copy %[[OUT0]], %[[OUT1]] : memref<4xf32> to memref<4xf32>
+// CHECK:        return
+func.func private @multiple_duplicate_returns(%cond: i1)
+    -> (memref<4xf32>, memref<4xf32>) {
+  %a = memref.alloc() : memref<4xf32>
+  cf.cond_br %cond, ^then, ^else
+^then:
+  return %a, %a : memref<4xf32>, memref<4xf32>
+^else:
+  return %a, %a : memref<4xf32>, memref<4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func private @multiple_returns_with_non_alloc(
+// CHECK-SAME:    %[[INPUT:.*]]: memref<4xf32>, %{{.*}}: i1, %[[OUT0:.*]]: memref<4xf32>, %[[OUT1:.*]]: memref<4xf32>) {
+// CHECK:        cf.cond_br %{{.*}}, ^[[THEN:.*]], ^[[ELSE:.*]]
+// CHECK:      ^[[THEN]]:
+// CHECK:        memref.copy %[[OUT0]], %[[OUT1]] : memref<4xf32> to memref<4xf32>
+// CHECK:        return
+// CHECK:      ^[[ELSE]]:
+// CHECK:        memref.copy %[[INPUT]], %[[OUT0]] : memref<4xf32> to memref<4xf32>
+// CHECK:        memref.copy %[[INPUT]], %[[OUT1]] : memref<4xf32> to memref<4xf32>
+// CHECK:        return
+func.func private @multiple_returns_with_non_alloc(%input: memref<4xf32>, %cond: i1)
+    -> (memref<4xf32>, memref<4xf32>) {
+  %a = memref.alloc() : memref<4xf32>
+  cf.cond_br %cond, ^then, ^else
+^then:
+  return %a, %a : memref<4xf32>, memref<4xf32>
+^else:
+  return %input, %input : memref<4xf32>, memref<4xf32>
+}


### PR DESCRIPTION
`buffer-results-to-out-params` crashes when a function returns the same allocation twice, e.g. `return %a, %a`:

```mlir
func.func @main() -> (memref<4xf32>, memref<4xf32>) {
  %a = memref.alloc() : memref<4xf32>
  return %a, %a : memref<4xf32>, memref<4xf32>
}
```

In `updateReturnOps` the hoisted alloc is erased inside the loop, so the second occurrence dereferences a dangling `OpResult`. This defers erasure to after the loop, hoists the allocation only once, and emits a `memref.copy` from the primary out-param into the duplicate's out-param. Dynamic sizes are cached so the caller allocates one buffer per occurrence.

Tests cover the static and dynamic hoisting cases.

Fixes #219492.
