### PR TITLE
[DirectX] Make DXILDebugInfo report that it Modified the IR

### DIFF
--- a/llvm/include/llvm/IR/BasicBlock.h
+++ b/llvm/include/llvm/IR/BasicBlock.h
@@ -90,7 +90,7 @@ public:
   /// Convert variable location debugging information stored in DbgMarkers and
   /// DbgRecords into the dbg.value intrinsic representation. Sets
   /// IsNewDbgInfoFormat = false.
-  LLVM_ABI void convertFromNewDbgValues();
+  LLVM_ABI bool convertFromNewDbgValues();
 
   unsigned getNumber() const {
     assert(getParent() && "only basic blocks in functions have valid numbers");

--- a/llvm/include/llvm/IR/Function.h
+++ b/llvm/include/llvm/IR/Function.h
@@ -125,7 +125,8 @@ public:
   void convertToNewDbgValues();
 
   /// \see BasicBlock::convertFromNewDbgValues.
-  void convertFromNewDbgValues();
+  /// Returns true if the conversion modified the function's IR.
+  bool convertFromNewDbgValues();
 
 private:
   friend class TargetLibraryInfoImpl;

--- a/llvm/include/llvm/IR/Module.h
+++ b/llvm/include/llvm/IR/Module.h
@@ -270,10 +270,14 @@ public:
   }
 
   /// \see BasicBlock::convertFromNewDbgValues.
-  void convertFromNewDbgValues() {
+  /// Returns true if any function's conversion modified the module.
+  bool convertFromNewDbgValues() {
+    bool Modified = false;
     for (auto &F : *this) {
-      F.convertFromNewDbgValues();
+      if (F.convertFromNewDbgValues())
+        Modified = true;
     }
+    return Modified;
   }
 
   /// The Module constructor. Note that there is no default constructor. You

--- a/llvm/lib/IR/BasicBlock.cpp
+++ b/llvm/lib/IR/BasicBlock.cpp
@@ -86,12 +86,13 @@ void BasicBlock::convertToNewDbgValues() {
   }
 }
 
-void BasicBlock::convertFromNewDbgValues() {
+bool BasicBlock::convertFromNewDbgValues() {
+  bool Modified = false;
   invalidateOrders();
 
   // Iterate over the block, finding instructions annotated with DbgMarkers.
-  // Convert any attached DbgRecords to debug intrinsics and insert ahead of the
-  // instruction.
+  // Convert any attached DbgRecords to debug intrinsics and insert ahead of
+  // the instruction.
   for (auto &Inst : *this) {
     if (!Inst.DebugMarker)
       continue;
@@ -102,12 +103,14 @@ void BasicBlock::convertFromNewDbgValues() {
                       DR.createDebugIntrinsic(getModule(), nullptr));
 
     Marker.eraseFromParent();
+    Modified = true;
   }
 
   // Assume no trailing DbgRecords: we could technically create them at the end
   // of the block, after a terminator, but this would be non-cannonical and
   // indicates that something else is broken somewhere.
   assert(!getTrailingDbgRecords());
+  return Modified;
 }
 
 #ifndef NDEBUG

--- a/llvm/lib/IR/Function.cpp
+++ b/llvm/lib/IR/Function.cpp
@@ -92,10 +92,13 @@ void Function::convertToNewDbgValues() {
   }
 }
 
-void Function::convertFromNewDbgValues() {
+bool Function::convertFromNewDbgValues() {
+  bool Modified = false;
   for (auto &BB : *this) {
-    BB.convertFromNewDbgValues();
+    if (BB.convertFromNewDbgValues())
+      Modified = true;
   }
+  return Modified;
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/DirectX/DXILPrettyPrinter.cpp
+++ b/llvm/lib/Target/DirectX/DXILPrettyPrinter.cpp
@@ -314,13 +314,11 @@ public:
 } // namespace
 
 static void prettyPrint(raw_ostream &OS, Module &M, const DXILResourceMap &DRM,
-                        DXILResourceTypeMap &DRTM) {
+                        DXILResourceTypeMap &DRTM, const DXILDebugInfoMap &DI) {
   formatted_raw_ostream FOS(OS);
 
   prettyPrintResources(FOS, DRM, DRTM);
-
-  DXILDebugInfoMap DI = DXILDebugInfoPass::run(M);
-
+  
   ModuleSlotTracker MST(&M);
   AbstractSlotTrackerStorage *STS = nullptr;
   unsigned NextMetadataSlot = 0;
@@ -355,7 +353,8 @@ PreservedAnalyses DXILPrettyPrinterPass::run(Module &M,
                                              ModuleAnalysisManager &MAM) {
   const DXILResourceMap &DRM = MAM.getResult<DXILResourceAnalysis>(M);
   DXILResourceTypeMap &DRTM = MAM.getResult<DXILResourceTypeAnalysis>(M);
-  prettyPrint(OS, M, DRM, DRTM);
+  const DXILDebugInfoMap DI = DXILDebugInfoPass::run(M);
+  prettyPrint(OS, M, DRM, DRTM, DI);
   return PreservedAnalyses::none();
 }
 
@@ -391,8 +390,9 @@ bool DXILPrettyPrinterLegacy::runOnModule(Module &M) {
       getAnalysis<DXILResourceWrapperPass>().getResourceMap();
   DXILResourceTypeMap &DRTM =
       getAnalysis<DXILResourceTypeWrapperPass>().getResourceTypeMap();
-  prettyPrint(OS, M, DRM, DRTM);
-  return false;
+  const DXILDebugInfoMap DI = DXILDebugInfoPass::run(M);
+  prettyPrint(OS, M, DRM, DRTM, DI);
+  return DI.Modified;
 }
 
 ModulePass *llvm::createDXILPrettyPrinterLegacyPass(raw_ostream &OS) {

--- a/llvm/lib/Target/DirectX/DXILPrettyPrinter.cpp
+++ b/llvm/lib/Target/DirectX/DXILPrettyPrinter.cpp
@@ -318,7 +318,7 @@ static void prettyPrint(raw_ostream &OS, Module &M, const DXILResourceMap &DRM,
   formatted_raw_ostream FOS(OS);
 
   prettyPrintResources(FOS, DRM, DRTM);
-  
+
   ModuleSlotTracker MST(&M);
   AbstractSlotTrackerStorage *STS = nullptr;
   unsigned NextMetadataSlot = 0;

--- a/llvm/lib/Target/DirectX/DXILWriter/DXILWriterPass.cpp
+++ b/llvm/lib/Target/DirectX/DXILWriter/DXILWriterPass.cpp
@@ -68,7 +68,7 @@ public:
   bool runOnModule(Module &M) override {
     const auto DIMap = DXILDebugInfoPass::run(M);
     WriteDXILToFile(M, OS, DIMap);
-    return false;
+    return DIMap.Modified;
   }
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.setPreservesAll();

--- a/llvm/lib/Target/DirectX/DirectXIRPasses/DXILDebugInfo.cpp
+++ b/llvm/lib/Target/DirectX/DirectXIRPasses/DXILDebugInfo.cpp
@@ -70,6 +70,8 @@ DXILDebugInfoMap DXILDebugInfoPass::run(Module &M) {
   M.convertFromNewDbgValues();
 
   DXILDebugInfoMap Res;
+  // convertFromNewDbgValues() may change IR.
+  Res.Modified = true;
   DebugInfoFinder DIF;
   DIF.processModule(M);
 
@@ -113,6 +115,7 @@ DXILDebugInfoMap DXILDebugInfoPass::run(Module &M) {
           }
           if (auto *DL = dyn_cast<DbgLabelInst>(&I)) {
             DL->eraseFromParent();
+            Res.Modified = true;
             continue;
           }
           // Process both llvm.dbg.value and llvm.dbg.assign here. We convert
@@ -152,6 +155,7 @@ DXILDebugInfoMap DXILDebugInfoPass::run(Module &M) {
               // location, this value is redundant.
               if (DbgValueFragment.first == NextNonDebugInst) {
                 DV->eraseFromParent();
+                Res.Modified = true;
                 continue;
               }
               // If there is a later identical value of the same fragment at a
@@ -162,6 +166,7 @@ DXILDebugInfoMap DXILDebugInfoPass::run(Module &M) {
                   DbgValueFragment.second == DbgValue.second &&
                   DbgValueFragment.second->getValue() == DV->getValue()) {
                 DbgValue.second->eraseFromParent();
+                Res.Modified = true;
               }
             }
             DbgValueInst *NewDV;
@@ -183,6 +188,7 @@ DXILDebugInfoMap DXILDebugInfoPass::run(Module &M) {
               NewDV->setTailCall();
               NewDV->setDebugLoc(DV->getDebugLoc());
               DV->eraseFromParent();
+              Res.Modified = true;
             } else {
               NewDV = DV;
             }
@@ -199,6 +205,7 @@ DXILDebugInfoMap DXILDebugInfoPass::run(Module &M) {
               continue;
             if (isa<UndefValue>(DV->getValue())) {
               DV->eraseFromParent();
+              Res.Modified = true;
               continue;
             }
             DbgVariablesSeen.insert(DV->getVariable());
@@ -216,6 +223,7 @@ DXILDebugInfoMap DXILDebugInfoPass::run(Module &M) {
                                [](Metadata *M) { return isa<DILabel>(M); }),
                 MDs.end());
       SP->replaceRetainedNodes(MDTuple::get(M.getContext(), MDs));
+      Res.Modified = true;
     }
   }
 

--- a/llvm/lib/Target/DirectX/DirectXIRPasses/DXILDebugInfo.cpp
+++ b/llvm/lib/Target/DirectX/DirectXIRPasses/DXILDebugInfo.cpp
@@ -67,11 +67,10 @@ static void replaceDbgValue(Module &M, DXILDebugInfoMap &Res) {
 }
 
 DXILDebugInfoMap DXILDebugInfoPass::run(Module &M) {
-  M.convertFromNewDbgValues();
-
   DXILDebugInfoMap Res;
-  // convertFromNewDbgValues() may change IR.
-  Res.Modified = true;
+  // Convert debug markers back to dbg.value intrinsics. Record whether any
+  // changes were made.
+  Res.Modified = M.convertFromNewDbgValues();
   DebugInfoFinder DIF;
   DIF.processModule(M);
 

--- a/llvm/lib/Target/DirectX/DirectXIRPasses/DXILDebugInfo.h
+++ b/llvm/lib/Target/DirectX/DirectXIRPasses/DXILDebugInfo.h
@@ -39,6 +39,9 @@ public:
   DXILDebugInfoMap(const DXILDebugInfoMap &) = delete;
   DXILDebugInfoMap(DXILDebugInfoMap &&) = default;
 
+  /// Whether the run modified the IR of the module the map was produced for.
+  bool Modified = false;
+
   /// Completely replace one function with another in ValueEnumerator.
   FuncMap FuncReplace;
 


### PR DESCRIPTION

fixes https://github.com/llvm/llvm-project/issues/220241

When Running Expensive Checks the following tests fail: Failed Tests (7):
  LLVM :: CodeGen/DirectX/DebugInfo/dbg-assign.ll
  LLVM :: CodeGen/DirectX/DebugInfo/dbg-declare-undef.ll
  LLVM :: CodeGen/DirectX/DebugInfo/dbg-value-arglist.ll
  LLVM :: CodeGen/DirectX/DebugInfo/dbg-value.ll
  LLVM :: CodeGen/DirectX/DebugInfo/debug-info.ll
  LLVM :: CodeGen/DirectX/DebugInfo/di-label.ll
  LLVM :: CodeGen/DirectX/debug-info.ll

DXILDebugInfo can modify the IR via convertFromNewDbgValues and other places. We need to report these modification. It uses the DXILWriter as its legacy pass, but the writer doesn't know that debuginfo can be modified so update the Writer too so it can report modifications.

The plan is to make DXILDebugInfoMap have a modified field we can check. Just setting this to true all the time fixes the expensive checks issue.