### PR TITLE
AMDGPU: Warn if trying to codegen without a subarch

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
@@ -385,7 +385,26 @@ void AMDGPUAsmPrinter::emitGlobalVariable(const GlobalVariable *GV) {
 }
 
 bool AMDGPUAsmPrinter::doInitialization(Module &M) {
-  const llvm::Triple &TT = M.getTargetTriple();
+  const Triple &TT = M.getTargetTriple();
+  if (TT.getSubArch() == Triple::NoSubArch) {
+    Triple::SubArchType SubArch =
+        AMDGPU::getSubArch(AMDGPU::parseArchAMDGCN(getGlobalSTI()->getCPU()));
+    if (SubArch != Triple::NoSubArch) {
+      Triple Fixed(TT);
+      Fixed.setArch(Triple::amdgpu, SubArch);
+      M.getContext().diagnose(DiagnosticInfoGeneric(
+          "codegen with no subarch in the target triple is deprecated and will "
+          "become an error; use the target triple '" +
+              Fixed.str() + "' instead",
+          DS_Warning));
+    } else {
+      M.getContext().diagnose(DiagnosticInfoGeneric(
+          "codegen with no subarch in the target triple is deprecated and will "
+          "become an error",
+          DS_Warning));
+    }
+  }
+
   CodeObjectVersion = AMDGPU::getAMDHSACodeObjectVersion(M);
 
   if (TT.getOS() == Triple::AMDHSA) {

--- a/llvm/test/CodeGen/AMDGPU/codegen-no-subarch-warn.ll
+++ b/llvm/test/CodeGen/AMDGPU/codegen-no-subarch-warn.ll
@@ -1,0 +1,16 @@
+; A target triple with no subarch still codegens, but is deprecated. Check that
+; the warning fires and names the replacement triple derived from -mcpu.
+
+; RUN: llc -mtriple=amdgcn -mcpu=gfx900 -filetype=null %s 2>&1 | FileCheck %s
+; RUN: llc -mtriple=amdgpu -mcpu=gfx900 -filetype=null %s 2>&1 | FileCheck %s
+
+; Without -mcpu there is no subarch to suggest, so the warning omits a triple.
+; RUN: llc -mtriple=amdgcn -filetype=null %s 2>&1 | FileCheck -check-prefix=NOCPU %s
+
+; CHECK: warning: codegen with no subarch in the target triple is deprecated and will become an error; use the target triple 'amdgpu9.00--' instead{{$}}
+
+; NOCPU: warning: codegen with no subarch in the target triple is deprecated and will become an error{{$}}
+
+define amdgpu_kernel void @kernel() {
+  ret void
+}


### PR DESCRIPTION
Warn if using the legacy amdgcn name, or amdgpu without a
specified subarch. This is to push all the non-clang frontends
to update to the new system, but this should turn into an error
in the next release.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>