### PR TITLE
[clang][bytecode] Add an `ExplicitlyDestroyed` flag to `LocalScope`

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -116,7 +116,7 @@ public:
 
   /// Emit a Destroy op for this scope.
   ~LocalScope() override {
-    if (!Idx)
+    if (!Idx || ExplicitlyDestroyed)
       return;
     this->Ctx->emitDestroy(*Idx, SourceInfo{});
     removeStoredOpaqueValues();
@@ -130,6 +130,7 @@ public:
     // calls to destroyLocals().
     bool Success = this->emitDestructors(E);
     this->Ctx->emitDestroy(*Idx, E);
+    ExplicitlyDestroyed = true;
     return Success;
   }
 
@@ -212,6 +213,7 @@ public:
 
   /// Index of the scope in the chain.
   UnsignedOrNone Idx = std::nullopt;
+  bool ExplicitlyDestroyed = false;
 };
 
 template <class Emitter> class ArrayIndexScope final {


### PR DESCRIPTION
When a local scope has been destroyed via `destroyLocals()`, don't do it again automatically (further calls to `destroyLocals()` keep working, as before).

For
```c++
constexpr void inc4(int &a) {
  char c[1];
  ++a;
}
```
we used to generate:
```
inc4 0x7c6e999e5480
frame size: 64
arg size:   48
rvo:        0
this arg:   0
0     InitScope       0
16    GetParamPtr     0
32    IncPopSint32    1
48    Destroy         0
64    Destroy         0
80    RetVoid
```

and now we generate:
```
inc4 0x7d3b1b1e5480
frame size: 64
arg size:   48
rvo:        0
this arg:   0
0     InitScope       0
16    GetParamPtr     0
32    IncPopSint32    1
48    Destroy         0
64    RetVoid
```