### PR TITLE
[Clang][Parser] Reject unbalanced unknown attribute arguments 

### DIFF
--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -826,6 +826,8 @@ def err_using_attribute_ns_conflict : Error<
   "attribute with scope specifier cannot follow default scope specifier">;
 def err_attributes_not_allowed : Error<"an attribute list cannot appear here">;
 def err_keyword_not_allowed : Error<"%0 cannot appear here">;
+def ext_unbalanced_attribute_args : ExtWarn<
+  "attribute argument list is not a balanced token sequence">, InGroup<Pedantic>;
 def ext_cxx11_attr_placement : ExtWarn<
   "ISO C++ does not allow %select{an attribute list|%0}1 to appear here">,
   InGroup<DiagGroup<"cxx-attribute-extension">>;

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -827,7 +827,8 @@ def err_using_attribute_ns_conflict : Error<
 def err_attributes_not_allowed : Error<"an attribute list cannot appear here">;
 def err_keyword_not_allowed : Error<"%0 cannot appear here">;
 def ext_unbalanced_attribute_args : ExtWarn<
-  "attribute argument list is not a balanced token sequence">, InGroup<Pedantic>;
+  "attribute argument list is not a balanced token sequence">,
+  InGroup<DiagGroup<"unbalanced-attribute-args">>;
 def ext_cxx11_attr_placement : ExtWarn<
   "ISO C++ does not allow %select{an attribute list|%0}1 to appear here">,
   InGroup<DiagGroup<"cxx-attribute-extension">>;

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -570,7 +570,9 @@ public:
     StopAtSemi = 1 << 0, ///< Stop skipping at semicolon
     /// Stop skipping at specified token, but don't skip the token itself
     StopBeforeMatch = 1 << 1,
-    StopAtCodeCompletion = 1 << 2 ///< Stop at code completion
+    StopAtCodeCompletion = 1 << 2, ///< Stop at code completion
+    /// Do not swallow an unmatched ')', ']', or '}'.
+    StopAtUnbalanced = 1 << 3
   };
 
   friend constexpr SkipUntilFlags operator|(SkipUntilFlags L,

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -4582,7 +4582,7 @@ bool Parser::ParseCXX11AttributeArgs(
     // Eat the left paren, then skip to the ending right paren.
     ConsumeParen();
     if (!SkipUntil(tok::r_paren, StopAtUnbalanced)) {
-      Diag(Tok, diag::err_expected) << tok::r_paren;
+      Diag(Tok, diag::ext_unbalanced_attribute_args);
       SkipUntil(tok::r_paren, StopAtSemi);
     }
     return false;

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -4581,7 +4581,10 @@ bool Parser::ParseCXX11AttributeArgs(
                     ScopeName, AttrName, getTargetInfo(), getLangOpts())) {
     // Eat the left paren, then skip to the ending right paren.
     ConsumeParen();
-    SkipUntil(tok::r_paren);
+    if (!SkipUntil(tok::r_paren, StopAtUnbalanced)) {
+      Diag(Tok, diag::err_expected) << tok::r_paren;
+      SkipUntil(tok::r_paren, StopAtSemi);
+    }
     return false;
   }
 

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -394,16 +394,22 @@ bool Parser::SkipUntil(ArrayRef<tok::TokenKind> Toks, SkipUntilFlags Flags) {
     case tok::r_paren:
       if (ParenCount && !isFirstTokenSkipped)
         return false;  // Matches something.
+      if (HasFlagsSet(Flags, StopAtUnbalanced))
+        return false;
       ConsumeParen();
       break;
     case tok::r_square:
       if (BracketCount && !isFirstTokenSkipped)
         return false;  // Matches something.
+      if (HasFlagsSet(Flags, StopAtUnbalanced))
+        return false;
       ConsumeBracket();
       break;
     case tok::r_brace:
       if (BraceCount && !isFirstTokenSkipped)
         return false;  // Matches something.
+      if (HasFlagsSet(Flags, StopAtUnbalanced))
+        return false;
       ConsumeBrace();
       break;
 

--- a/clang/test/Parser/cxx11-unbalanced-attr-args.cpp
+++ b/clang/test/Parser/cxx11-unbalanced-attr-args.cpp
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++11 %s
+// RUN: %clang_cc1 -fsyntax-only -verify -x c -std=c23 %s
+
+[[X1(])]]; // expected-error {{expected ')'}} expected-warning {{unknown attribute 'X1' ignored}}
+[[X1(})]]; // expected-error {{expected ')'}} expected-warning {{unknown attribute 'X1' ignored}}
+[[X1]]; // expected-warning {{unknown attribute 'X1' ignored}}
+[[X1()]]; // expected-warning {{unknown attribute 'X1' ignored}}

--- a/clang/test/Parser/cxx11-unbalanced-attr-args.cpp
+++ b/clang/test/Parser/cxx11-unbalanced-attr-args.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fsyntax-only -verify -std=c++11 %s
 // RUN: %clang_cc1 -fsyntax-only -verify -x c -std=c23 %s
 
-[[X1(])]]; // expected-error {{expected ')'}} expected-warning {{unknown attribute 'X1' ignored}}
-[[X1(})]]; // expected-error {{expected ')'}} expected-warning {{unknown attribute 'X1' ignored}}
+[[X1(])]]; // expected-warning {{attribute argument list is not a balanced token sequence}} expected-warning {{unknown attribute 'X1' ignored}}
+[[X1(})]]; // expected-warning {{attribute argument list is not a balanced token sequence}} expected-warning {{unknown attribute 'X1' ignored}}
 [[X1]]; // expected-warning {{unknown attribute 'X1' ignored}}
 [[X1()]]; // expected-warning {{unknown attribute 'X1' ignored}}


### PR DESCRIPTION
This came up in #183473. Clang accepts invalid code like:

  [[X1(])]];
  [[X1(})]];

The attribute argument clause must be a balanced-token-seq. GCC, MSVC,
and EDG diagnose this. For unknown attributes we do not parse the
arguments; we skip to the closing `)`. SkipUntil treats a leading
unmatched `]` or `}` as a spurious closer and swallows it, so we never
emit an error.

This adds an opt-in SkipUntil flag, StopAtUnbalanced, which does not
consume an unmatched `)`, `]`, or `}`. It is used only when skipping
arguments of an unknown C++11 / C23 attribute. Other SkipUntil call
sites are unchanged.

Well-formed unknown attributes still skip the same way. We only refuse
to swallow an unmatched closer, then diagnose expected ')'.

Test covers [[X1(])]] / [[X1(})]] (error) and [[X1]] / [[X1()]]
(warning only), in C++11 and C23.
