### PR TITLE
[AArch64][SVE] Promote unpacked 16-bit floats to legal VECTOR_COMPRESS ops

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -2243,6 +2243,22 @@ AArch64TargetLowering::AArch64TargetLowering(const TargetMachine &TM,
       setOperationAction(ISD::VECTOR_COMPRESS, VT, Custom);
     }
 
+    // Promote nxv4<f16|bf16> to nxv4i32.
+    setOperationPromotedToType(ISD::VECTOR_COMPRESS, MVT::nxv4bf16,
+                               MVT::nxv4i16);
+    setOperationPromotedToType(ISD::VECTOR_COMPRESS, MVT::nxv4f16,
+                               MVT::nxv4i16);
+    setOperationPromotedToType(ISD::VECTOR_COMPRESS, MVT::nxv4i16,
+                               MVT::nxv4i32);
+
+    // Promote nxv2<f16|bf16> to nxv2i64.
+    setOperationPromotedToType(ISD::VECTOR_COMPRESS, MVT::nxv2bf16,
+                               MVT::nxv2i16);
+    setOperationPromotedToType(ISD::VECTOR_COMPRESS, MVT::nxv2f16,
+                               MVT::nxv2i16);
+    setOperationPromotedToType(ISD::VECTOR_COMPRESS, MVT::nxv2i16,
+                               MVT::nxv2i64);
+
     if (Subtarget->hasSVE2p2() || Subtarget->hasSME2p2()) {
       // With +sve2p2/+sme2p2 the full range of vector types are supported.
       for (auto VT :

--- a/llvm/test/CodeGen/AArch64/sve-vector-compress.ll
+++ b/llvm/test/CodeGen/AArch64/sve-vector-compress.ll
@@ -57,6 +57,24 @@ define <vscale x 2 x double> @test_compress_nxv2f64(<vscale x 2 x double> %vec, 
     ret <vscale x 2 x double> %out
 }
 
+define <vscale x 2 x bfloat> @test_compress_nxv2bf16(<vscale x 2 x bfloat> %vec, <vscale x 2 x i1> %mask) {
+; CHECK-LABEL: test_compress_nxv2bf16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    compact z0.d, p0, z0.d
+; CHECK-NEXT:    ret
+    %out = call <vscale x 2 x bfloat> @llvm.experimental.vector.compress(<vscale x 2 x bfloat> %vec, <vscale x 2 x i1> %mask, <vscale x 2 x bfloat> poison)
+    ret <vscale x 2 x bfloat> %out
+}
+
+define <vscale x 2 x half> @test_compress_nxv2f16(<vscale x 2 x half> %vec, <vscale x 2 x i1> %mask) {
+; CHECK-LABEL: test_compress_nxv2f16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    compact z0.d, p0, z0.d
+; CHECK-NEXT:    ret
+    %out = call <vscale x 2 x half> @llvm.experimental.vector.compress(<vscale x 2 x half> %vec, <vscale x 2 x i1> %mask, <vscale x 2 x half> poison)
+    ret <vscale x 2 x half> %out
+}
+
 define <vscale x 4 x i8> @test_compress_nxv4i8(<vscale x 4 x i8> %vec, <vscale x 4 x i1> %mask) {
 ; CHECK-LABEL: test_compress_nxv4i8:
 ; CHECK:       // %bb.0:
@@ -91,6 +109,24 @@ define <vscale x 4 x float> @test_compress_nxv4f32(<vscale x 4 x float> %vec, <v
 ; CHECK-NEXT:    ret
     %out = call <vscale x 4 x float> @llvm.experimental.vector.compress(<vscale x 4 x float> %vec, <vscale x 4 x i1> %mask, <vscale x 4 x float> poison)
     ret <vscale x 4 x float> %out
+}
+
+define <vscale x 4 x bfloat> @test_compress_nxv4bf16(<vscale x 4 x bfloat> %vec, <vscale x 4 x i1> %mask) {
+; CHECK-LABEL: test_compress_nxv4bf16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    compact z0.s, p0, z0.s
+; CHECK-NEXT:    ret
+    %out = call <vscale x 4 x bfloat> @llvm.experimental.vector.compress(<vscale x 4 x bfloat> %vec, <vscale x 4 x i1> %mask, <vscale x 4 x bfloat> poison)
+    ret <vscale x 4 x bfloat> %out
+}
+
+define <vscale x 4 x half> @test_compress_nxv4f16(<vscale x 4 x half> %vec, <vscale x 4 x i1> %mask) {
+; CHECK-LABEL: test_compress_nxv4f16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    compact z0.s, p0, z0.s
+; CHECK-NEXT:    ret
+    %out = call <vscale x 4 x half> @llvm.experimental.vector.compress(<vscale x 4 x half> %vec, <vscale x 4 x i1> %mask, <vscale x 4 x half> poison)
+    ret <vscale x 4 x half> %out
 }
 
 define <vscale x 4 x i4> @test_compress_illegal_element_type(<vscale x 4 x i4> %vec, <vscale x 4 x i1> %mask) {


### PR DESCRIPTION
This patch promotes f16 and bf16 VECTOR_COMPRESS ops for nxv2/nxv4 to 64-bit or 32-bit operations respectively. This allows lowering them via `compact` in SVE1.

Assisted-by: Codex (tests)