### PR TITLE
[OpenCL][NFC] Clean up invalid pipe diagnostics tests

### DIFF
--- a/clang/test/SemaOpenCL/invalid-pipe-builtin-cl2.0.cl
+++ b/clang/test/SemaOpenCL/invalid-pipe-builtin-cl2.0.cl
@@ -1,67 +1,90 @@
-// RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only -cl-std=CL2.0 -cl-ext=+cl_khr_subgroups
+// RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only \
+// RUN:   -cl-std=CL2.0 -cl-ext=+cl_khr_subgroups
 
 #pragma OPENCL EXTENSION cl_khr_subgroups : enable
 
-void test1(read_only pipe int p, global int* ptr){
+void read_pipe_builtins(read_only pipe int p, global int *ptr) {
   int tmp;
   reserve_id_t rid;
 
-  // read/write_pipe
   read_pipe(p, &tmp);
   read_pipe(p, ptr);
-  read_pipe(tmp, p);    // expected-error {{first argument to 'read_pipe' must be a pipe type}}
-  read_pipe(p);   // expected-error {{invalid number of arguments to function: 'read_pipe'}}
+  // expected-error@+1 {{first argument to 'read_pipe' must be a pipe type}}
+  read_pipe(tmp, p);
+  // expected-error@+1 {{invalid number of arguments to function: 'read_pipe'}}
+  read_pipe(p);
   read_pipe(p, rid, tmp, ptr);
-  read_pipe(p, tmp, tmp, ptr);   // expected-error {{invalid argument type to function 'read_pipe' (expecting 'reserve_id_t' having '__private int')}}
-  read_pipe(p, rid, rid, ptr);   // expected-error {{invalid argument type to function 'read_pipe' (expecting 'unsigned int' having '__private reserve_id_t')}}
-  read_pipe(p, tmp);   // expected-error {{invalid argument type to function 'read_pipe' (expecting 'int *' having '__private int')}}
-  write_pipe(p, ptr);    // expected-error {{invalid pipe access modifier (expecting write_only)}}
-  write_pipe(p, rid, tmp, ptr);    // expected-error {{invalid pipe access modifier (expecting write_only)}}
+  // expected-error@+1 {{invalid argument type to function 'read_pipe' (expecting 'reserve_id_t' having '__private int')}}
+  read_pipe(p, tmp, tmp, ptr);
+  // expected-error@+1 {{invalid argument type to function 'read_pipe' (expecting 'unsigned int' having '__private reserve_id_t')}}
+  read_pipe(p, rid, rid, ptr);
+  // expected-error@+1 {{invalid argument type to function 'read_pipe' (expecting 'int *' having '__private int')}}
+  read_pipe(p, tmp);
+  // expected-error@+1 {{invalid pipe access modifier (expecting write_only)}}
+  write_pipe(p, ptr);
+  // expected-error@+1 {{invalid pipe access modifier (expecting write_only)}}
+  write_pipe(p, rid, tmp, ptr);
 
-  // reserve_read/write_pipe
   reserve_read_pipe(p, tmp);
-  reserve_read_pipe(p, ptr);    // expected-error{{invalid argument type to function 'reserve_read_pipe' (expecting 'unsigned int' having '__global int *__private')}}
-  work_group_reserve_read_pipe(tmp, tmp);    // expected-error{{first argument to 'work_group_reserve_read_pipe' must be a pipe type}}
-  sub_group_reserve_write_pipe(p, tmp);    // expected-error{{invalid pipe access modifier (expecting write_only)}}
+  // expected-error@+1 {{invalid argument type to function 'reserve_read_pipe' (expecting 'unsigned int' having '__global int *__private')}}
+  reserve_read_pipe(p, ptr);
+  // expected-error@+1 {{first argument to 'work_group_reserve_read_pipe' must be a pipe type}}
+  work_group_reserve_read_pipe(tmp, tmp);
+  // expected-error@+1 {{invalid pipe access modifier (expecting write_only)}}
+  sub_group_reserve_write_pipe(p, tmp);
 
-  // commit_read/write_pipe
   commit_read_pipe(p, rid);
-  commit_read_pipe(tmp, rid);    // expected-error{{first argument to 'commit_read_pipe' must be a pipe type}}
-  work_group_commit_read_pipe(p, tmp);    // expected-error{{invalid argument type to function 'work_group_commit_read_pipe' (expecting 'reserve_id_t' having '__private int')}}
-  sub_group_commit_write_pipe(p, tmp);    // expected-error{{invalid pipe access modifier (expecting write_only)}}
+  // expected-error@+1 {{first argument to 'commit_read_pipe' must be a pipe type}}
+  commit_read_pipe(tmp, rid);
+  // expected-error@+1 {{invalid argument type to function 'work_group_commit_read_pipe' (expecting 'reserve_id_t' having '__private int')}}
+  work_group_commit_read_pipe(p, tmp);
+  // expected-error@+1 {{invalid pipe access modifier (expecting write_only)}}
+  sub_group_commit_write_pipe(p, tmp);
 }
 
-void test2(write_only pipe int p, global int* ptr){
+void write_pipe_builtins(write_only pipe int p, global int *ptr) {
   int tmp;
   reserve_id_t rid;
 
-  // read/write_pipe
   write_pipe(p, &tmp);
   write_pipe(p, ptr);
-  write_pipe(tmp, p);    // expected-error {{first argument to 'write_pipe' must be a pipe type}}
-  write_pipe(p);   // expected-error {{invalid number of arguments to function: 'write_pipe'}}
+  // expected-error@+1 {{first argument to 'write_pipe' must be a pipe type}}
+  write_pipe(tmp, p);
+  // expected-error@+1 {{invalid number of arguments to function: 'write_pipe'}}
+  write_pipe(p);
   write_pipe(p, rid, tmp, ptr);
-  write_pipe(p, tmp, tmp, ptr);   // expected-error {{invalid argument type to function 'write_pipe' (expecting 'reserve_id_t' having '__private int')}}
-  write_pipe(p, rid, rid, ptr);   // expected-error {{invalid argument type to function 'write_pipe' (expecting 'unsigned int' having '__private reserve_id_t')}}
-  write_pipe(p, tmp);   // expected-error {{invalid argument type to function 'write_pipe' (expecting 'int *' having '__private int')}}
-  read_pipe(p, ptr);    // expected-error {{invalid pipe access modifier (expecting read_only)}}
-  read_pipe(p, rid, tmp, ptr);    // expected-error {{invalid pipe access modifier (expecting read_only)}}
+  // expected-error@+1 {{invalid argument type to function 'write_pipe' (expecting 'reserve_id_t' having '__private int')}}
+  write_pipe(p, tmp, tmp, ptr);
+  // expected-error@+1 {{invalid argument type to function 'write_pipe' (expecting 'unsigned int' having '__private reserve_id_t')}}
+  write_pipe(p, rid, rid, ptr);
+  // expected-error@+1 {{invalid argument type to function 'write_pipe' (expecting 'int *' having '__private int')}}
+  write_pipe(p, tmp);
+  // expected-error@+1 {{invalid pipe access modifier (expecting read_only)}}
+  read_pipe(p, ptr);
+  // expected-error@+1 {{invalid pipe access modifier (expecting read_only)}}
+  read_pipe(p, rid, tmp, ptr);
 
-  // reserve_read/write_pipe
   reserve_write_pipe(p, tmp);
-  reserve_write_pipe(p, ptr);    // expected-error{{invalid argument type to function 'reserve_write_pipe' (expecting 'unsigned int' having '__global int *__private')}}
-  work_group_reserve_write_pipe(tmp, tmp);    // expected-error{{first argument to 'work_group_reserve_write_pipe' must be a pipe type}}
-  sub_group_reserve_read_pipe(p, tmp);    // expected-error{{invalid pipe access modifier (expecting read_only)}}
+  // expected-error@+1 {{invalid argument type to function 'reserve_write_pipe' (expecting 'unsigned int' having '__global int *__private')}}
+  reserve_write_pipe(p, ptr);
+  // expected-error@+1 {{first argument to 'work_group_reserve_write_pipe' must be a pipe type}}
+  work_group_reserve_write_pipe(tmp, tmp);
+  // expected-error@+1 {{invalid pipe access modifier (expecting read_only)}}
+  sub_group_reserve_read_pipe(p, tmp);
 
-  // commit_read/write_pipe
   commit_write_pipe(p, rid);
-  commit_write_pipe(tmp, rid);    // expected-error{{first argument to 'commit_write_pipe' must be a pipe type}}
-  work_group_commit_write_pipe(p, tmp);    // expected-error{{invalid argument type to function 'work_group_commit_write_pipe' (expecting 'reserve_id_t' having '__private int')}}
-  sub_group_commit_read_pipe(p, tmp);    // expected-error{{invalid pipe access modifier (expecting read_only)}}
+  // expected-error@+1 {{first argument to 'commit_write_pipe' must be a pipe type}}
+  commit_write_pipe(tmp, rid);
+  // expected-error@+1 {{invalid argument type to function 'work_group_commit_write_pipe' (expecting 'reserve_id_t' having '__private int')}}
+  work_group_commit_write_pipe(p, tmp);
+  // expected-error@+1 {{invalid pipe access modifier (expecting read_only)}}
+  sub_group_commit_read_pipe(p, tmp);
 }
 
-void test3(void){
+void pipe_query_builtins(void) {
   int tmp;
-  get_pipe_num_packets(tmp);    // expected-error {{first argument to 'get_pipe_num_packets' must be a pipe type}}
-  get_pipe_max_packets(tmp);    // expected-error {{first argument to 'get_pipe_max_packets' must be a pipe type}}
+  // expected-error@+1 {{first argument to 'get_pipe_num_packets' must be a pipe type}}
+  get_pipe_num_packets(tmp);
+  // expected-error@+1 {{first argument to 'get_pipe_max_packets' must be a pipe type}}
+  get_pipe_max_packets(tmp);
 }

--- a/clang/test/SemaOpenCL/invalid-pipes-cl1.2.cl
+++ b/clang/test/SemaOpenCL/invalid-pipes-cl1.2.cl
@@ -1,35 +1,28 @@
-// RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only -cl-std=CL1.2
-// RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only -cl-std=CL3.0 -cl-ext=-all
-// RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only -cl-std=clc++2021 -cl-ext=-all
+// RUN: %clang_cc1 %s -verify=expected,cl12 -pedantic -fsyntax-only \
+// RUN:   -cl-std=CL1.2
+// RUN: %clang_cc1 %s -verify=expected,cl3 -pedantic -fsyntax-only \
+// RUN:   -cl-std=CL3.0 -cl-ext=-all
+// RUN: %clang_cc1 %s -verify=expected,clcpp -pedantic -fsyntax-only \
+// RUN:   -cl-std=clc++2021 -cl-ext=-all
 
-void foo(read_only pipe int p);
-#if __OPENCL_C_VERSION__ > 120
-// expected-error@-2 {{OpenCL C version 3.0 does not support the 'pipe' type qualifier}}
-// expected-error@-3 {{access qualifier can only be used for pipe and image type}}
-#elif defined(__OPENCL_CPP_VERSION__)
-// expected-error@-5 {{C++ for OpenCL version 2021 does not support the 'pipe' type qualifier}}
-// expected-error@-6 {{access qualifier can only be used for pipe and image type}}
-#else
-// expected-error@-8 {{type specifier missing, defaults to 'int'}}
-// expected-error@-9 {{access qualifier can only be used for pipe and image type}}
-// expected-error@-10 {{expected ')'}} expected-note@-10 {{to match this '('}}
-#endif
+// cl3-error@+6 {{OpenCL C version 3.0 does not support the 'pipe' type qualifier}}
+// clcpp-error@+5 {{C++ for OpenCL version 2021 does not support the 'pipe' type qualifier}}
+// cl12-error@+4 {{type specifier missing, defaults to 'int'}}
+// expected-error@+3 {{access qualifier can only be used for pipe and image type}}
+// cl12-error@+2 {{expected ')'}}
+// cl12-note@+1 {{to match this '('}}
+void unavailable_pipe_parameter(read_only pipe int p);
 
-// 'pipe' should be accepted as an identifier.
+// 'pipe' is accepted as an identifier in OpenCL 1.2.
+// cl3-error@+4 {{OpenCL C version 3.0 does not support the 'pipe' type qualifier}}
+// cl3-warning@+3 {{typedef requires a name}}
+// clcpp-error@+2 {{C++ for OpenCL version 2021 does not support the 'pipe' type qualifier}}
+// clcpp-warning@+1 {{typedef requires a name}}
 typedef int pipe;
-#if __OPENCL_C_VERSION__ > 120
-// expected-error@-2 {{OpenCL C version 3.0 does not support the 'pipe' type qualifier}}
-// expected-warning@-3 {{typedef requires a name}}
-#elif defined(__OPENCL_CPP_VERSION__)
-// expected-error@-5 {{C++ for OpenCL version 2021 does not support the 'pipe' type qualifier}}
-// expected-warning@-6 {{typedef requires a name}}
-#endif
 
-void bar(void) {
- reserve_id_t r;
-#if defined(__OPENCL_C_VERSION__)
-// expected-error@-2 {{use of undeclared identifier 'reserve_id_t'}}
-#else
-// expected-error@-4 {{unknown type name 'reserve_id_t'}}
-#endif
+void unavailable_reserve_id_type(void) {
+  // cl12-error@+3 {{use of undeclared identifier 'reserve_id_t'}}
+  // cl3-error@+2 {{use of undeclared identifier 'reserve_id_t'}}
+  // clcpp-error@+1 {{unknown type name 'reserve_id_t'}}
+  reserve_id_t r;
 }

--- a/clang/test/SemaOpenCL/invalid-pipes-cl2.0.cl
+++ b/clang/test/SemaOpenCL/invalid-pipes-cl2.0.cl
@@ -1,59 +1,83 @@
-// RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only -Wno-strict-prototypes -cl-std=CL2.0
-// RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only -Wno-strict-prototypes -cl-std=CL3.0 -cl-ext=+__opencl_c_pipes,+__opencl_c_generic_address_space,+__opencl_c_program_scope_global_variables
-// RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only -Wno-strict-prototypes -cl-std=CL3.0 -cl-ext=+__opencl_c_pipes,+__opencl_c_generic_address_space,-__opencl_c_program_scope_global_variables,-__opencl_c_device_enqueue
-// RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only -cl-std=clc++1.0
-// RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only -cl-std=clc++2021 -cl-ext=+__opencl_c_pipes,+__opencl_c_generic_address_space,+__opencl_c_program_scope_global_variables
-// RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only -cl-std=clc++2021 -cl-ext=+__opencl_c_pipes,+__opencl_c_generic_address_space,-__opencl_c_program_scope_global_variables,-__opencl_c_device_enqueue
+// RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only \
+// RUN:   -Wno-strict-prototypes -cl-std=CL2.0
+// RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only \
+// RUN:   -Wno-strict-prototypes -cl-std=CL3.0 \
+// RUN:   -cl-ext=+__opencl_c_pipes,+__opencl_c_generic_address_space,+__opencl_c_program_scope_global_variables
+// RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only \
+// RUN:   -Wno-strict-prototypes -cl-std=CL3.0 \
+// RUN:   -cl-ext=+__opencl_c_pipes,+__opencl_c_generic_address_space,-__opencl_c_program_scope_global_variables,-__opencl_c_device_enqueue
+// RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only \
+// RUN:   -cl-std=clc++1.0
+// RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only \
+// RUN:   -cl-std=clc++2021 \
+// RUN:   -cl-ext=+__opencl_c_pipes,+__opencl_c_generic_address_space,+__opencl_c_program_scope_global_variables
+// RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only \
+// RUN:   -cl-std=clc++2021 \
+// RUN:   -cl-ext=+__opencl_c_pipes,+__opencl_c_generic_address_space,-__opencl_c_program_scope_global_variables,-__opencl_c_device_enqueue
 
-global pipe int gp;            // expected-error {{type '__global read_only pipe int' can only be used as a function parameter in OpenCL}}
-global reserve_id_t rid;          // expected-error {{the '__global reserve_id_t' type cannot be used to declare a program scope variable}}
+// expected-error@+1 {{type '__global read_only pipe int' can only be used as a function parameter in OpenCL}}
+global pipe int gp;
+// expected-error@+1 {{the '__global reserve_id_t' type cannot be used to declare a program scope variable}}
+global reserve_id_t rid;
 
-extern pipe write_only int get_pipe(void); // expected-error {{'write_only' attribute only applies to parameters and typedefs}}
+// expected-error@+1 {{'write_only' attribute only applies to parameters and typedefs}}
+extern pipe write_only int get_pipe(void);
 #if (__OPENCL_CPP_VERSION__ == 100) || (__OPENCL_C_VERSION__ == 200) || ((__OPENCL_CPP_VERSION__ == 202100 || __OPENCL_C_VERSION__ == 300) && defined(__opencl_c_program_scope_global_variables))
-// expected-error-re@-2{{type '__global write_only pipe int ({{(void)?}})' can only be used as a function parameter in OpenCL}}
+// expected-error-re@-2 {{type '__global write_only pipe int ({{(void)?}})' can only be used as a function parameter in OpenCL}}
 #else
 // FIXME: '__private' here makes no sense since program scope variables feature is not supported, should diagnose as '__global' probably
-// expected-error-re@-5{{type '__private write_only pipe int ({{(void)?}})' can only be used as a function parameter in OpenCL}}
+// expected-error-re@-5 {{type '__private write_only pipe int ({{(void)?}})' can only be used as a function parameter in OpenCL}}
 #endif
 
-global pipe notype1, notype2; // expected-error {{missing actual type specifier for pipe}}
+// expected-error@+1 {{missing actual type specifier for pipe}}
+global pipe notype1, notype2;
 
-kernel void test_invalid_reserved_id(reserve_id_t ID) { // expected-error {{'__private reserve_id_t' cannot be used as the type of a kernel parameter}}
+// expected-error@+1 {{'__private reserve_id_t' cannot be used as the type of a kernel parameter}}
+kernel void invalid_reserved_id_parameter(reserve_id_t ID) {}
+
+// expected-error@+1 {{pipes packet types cannot be of reference type}}
+void pointer_packet_type(pipe int *p) {}
+// expected-error@+1 {{missing actual type specifier for pipe}}
+void missing_packet_type(pipe p) {}
+// expected-error@+1 {{cannot combine with previous 'int' declaration specifier}}
+void misplaced_pipe_specifier(int pipe p) {}
+
+void local_pipe_variable(void) {
+  // expected-error@+1 {{type '__private read_only pipe int' can only be used as a function parameter}}
+  pipe int p;
+  // TODO: Fix parsing of this pipe int (*p).
 }
 
-void test1(pipe int *p) {// expected-error {{pipes packet types cannot be of reference type}}
-}
-void test2(pipe p) {// expected-error {{missing actual type specifier for pipe}}
-}
-void test3(int pipe p) {// expected-error {{cannot combine with previous 'int' declaration specifier}}
-}
-void test4(void) {
-  pipe int p; // expected-error {{type '__private read_only pipe int' can only be used as a function parameter}}
-  //TODO: fix parsing of this pipe int (*p);
-}
-
-void test5(pipe int p) {
-  p+p; // expected-error{{invalid operands to binary expression ('__private read_only pipe int' and '__private read_only pipe int')}}
-  p=p; // expected-error{{invalid operands to binary expression ('__private read_only pipe int' and '__private read_only pipe int')}}
-  &p; // expected-error{{invalid argument type '__private read_only pipe int' to unary expression}}
-  *p; // expected-error{{invalid argument type '__private read_only pipe int' to unary expression}}
+void invalid_pipe_operators(pipe int p) {
+  // expected-error@+1 {{invalid operands to binary expression ('__private read_only pipe int' and '__private read_only pipe int')}}
+  p + p;
+  // expected-error@+1 {{invalid operands to binary expression ('__private read_only pipe int' and '__private read_only pipe int')}}
+  p = p;
+  // expected-error@+1 {{invalid argument type '__private read_only pipe int' to unary expression}}
+  &p;
+  // expected-error@+1 {{invalid argument type '__private read_only pipe int' to unary expression}}
+  *p;
 }
 
 typedef pipe int pipe_int_t;
-pipe_int_t test6(void) {} // expected-error{{declaring function return value of type 'pipe_int_t' (aka 'read_only pipe int') is not allowed}}
+// expected-error@+1 {{declaring function return value of type 'pipe_int_t' (aka 'read_only pipe int') is not allowed}}
+pipe_int_t pipe_return_type(void) {}
 
-bool test_id_comprision(void) {
+bool compare_reserve_ids(void) {
   reserve_id_t id1, id2;
-  return (id1 == id2);          // expected-error {{invalid operands to binary expression ('__private reserve_id_t' and '__private reserve_id_t')}}
+  // expected-error@+1 {{invalid operands to binary expression ('__private reserve_id_t' and '__private reserve_id_t')}}
+  return (id1 == id2);
 }
 
-// Tests ASTContext::mergeTypes rejects this.
+// Pipe parameters with different packet types are incompatible.
 #ifndef __OPENCL_CPP_VERSION__
-int f(pipe int x, int y); // expected-note {{previous declaration is here}}
-int f(x, y) // expected-error {{conflicting types for 'f}}
+// expected-note@+1 {{previous declaration is here}}
+int merge_pipe_parameter_types(pipe int x, int y);
+// expected-error@+1 {{conflicting types for 'merge_pipe_parameter_types'}}
+int merge_pipe_parameter_types(x, y)
 pipe short x;
 int y;
 {
-    return y;
+  return y;
 }
 #endif


### PR DESCRIPTION
Apply consistent spacing and grouping, use descriptive function names, and place diagnostic expectations before the affected lines.

Assisted-by: Codex / GPT-5.6 Sol