### PR TITLE
[CodeView] Fix filename canonicalization to use sys::path::remove_dots

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
@@ -144,6 +144,8 @@ StringRef CodeViewDebug::getFullFilepath(const DIFile *File) {
 
   // If this is a Unix-style path, just use it as is. Don't try to canonicalize
   // it textually because one of the path components could be a symlink.
+  // FIXME: This heuristic doesn't work for relative paths. Should we use the
+  // style from the target platform?
   if (Dir.starts_with("/") || Filename.starts_with("/")) {
     if (llvm::sys::path::is_absolute(Filename, llvm::sys::path::Style::posix))
       return Filename;
@@ -158,44 +160,17 @@ StringRef CodeViewDebug::getFullFilepath(const DIFile *File) {
   // operates on full paths.  We could change Clang to emit full paths too, but
   // that would increase the IR size and probably not needed for other users.
   // For now, just concatenate and canonicalize the path here.
-  if (Filename.find(':') == 1)
-    Filepath = std::string(Filename);
-  else
-    Filepath = (Dir + "\\" + Filename).str();
-
-  // Canonicalize the path.  We have to do it textually because we may no longer
-  // have access the file in the filesystem.
-  // First, replace all slashes with backslashes.
-  llvm::replace(Filepath, '/', '\\');
-
-  // Remove all "\.\" with "\".
-  size_t Cursor = 0;
-  while ((Cursor = Filepath.find("\\.\\", Cursor)) != std::string::npos)
-    Filepath.erase(Cursor, 2);
-
-  // Replace all "\XXX\..\" with "\".  Don't try too hard though as the original
-  // path should be well-formatted, e.g. start with a drive letter, etc.
-  Cursor = 0;
-  while ((Cursor = Filepath.find("\\..\\", Cursor)) != std::string::npos) {
-    // Something's wrong if the path starts with "\..\", abort.
-    if (Cursor == 0)
-      break;
-
-    size_t PrevSlash = Filepath.rfind('\\', Cursor - 1);
-    if (PrevSlash == std::string::npos)
-      // Something's wrong, abort.
-      break;
-
-    Filepath.erase(PrevSlash, Cursor + 3 - PrevSlash);
-    // The next ".." might be following the one we've just erased.
-    Cursor = PrevSlash;
+  SmallString<256> CanonFilepath;
+  if (llvm::sys::path::is_absolute(Filename, llvm::sys::path::Style::windows)) {
+    CanonFilepath = Filename;
+  } else {
+    CanonFilepath = Dir;
+    llvm::sys::path::append(CanonFilepath, llvm::sys::path::Style::windows,
+                            Filename);
   }
-
-  // Remove all duplicate backslashes.
-  Cursor = 0;
-  while ((Cursor = Filepath.find("\\\\", Cursor)) != std::string::npos)
-    Filepath.erase(Cursor, 1);
-
+  llvm::sys::path::remove_dots(CanonFilepath, /*remove_dot_dot=*/true,
+                               llvm::sys::path::Style::windows);
+  Filepath = CanonFilepath.str();
   return Filepath;
 }
 

--- a/llvm/test/DebugInfo/COFF/filename.ll
+++ b/llvm/test/DebugInfo/COFF/filename.ll
@@ -1,0 +1,88 @@
+; RUN: sed -e 's|_FILENAME_|/abs/path/to/test.cpp|;s|_DIR_|/ignored/directory|' %s > %t
+; RUN: llc -filetype=obj -o - %t | llvm-readobj --codeview - | FileCheck %s -check-prefixes CHECK,CHECK-POSIX
+;
+; RUN: sed -e 's|_FILENAME_|test.cpp|;s|_DIR_|/abs/path/to|' %s > %t
+; RUN: llc -filetype=obj -o - %t | llvm-readobj --codeview - | FileCheck %s -check-prefixes CHECK,CHECK-POSIX
+;
+; RUN: sed -e 's|_FILENAME_|./to/to2/../test.cpp|;s|_DIR_|/abs/path/subdir/../|' %s > %t
+; RUN: llc -filetype=obj -o - %t | llvm-readobj --codeview - | FileCheck %s -check-prefixes CHECK,CHECK-POSIX-DOTS
+;
+; Windows - paths are canonicalized
+; RUN: sed -e 's|_FILENAME_|test.cpp|;s|_DIR_|rel/path/to/|' %s > %t
+; RUN: llc -filetype=obj -o - %t | llvm-readobj --codeview - | FileCheck %s -check-prefixes CHECK,CHECK-WIN-REL
+;
+; RUN: sed -e 's|_FILENAME_|test.cpp|;s|_DIR_|C:/abs/path/to|' %s > %t
+; RUN: llc -filetype=obj -o - %t | llvm-readobj --codeview - | FileCheck %s -check-prefixes CHECK,CHECK-WIN-DRV
+;
+; RUN: sed -e 's|_FILENAME_|C:/abs/path/to/test.cpp|;s|_DIR_|X:/ignored/directory/|' %s > %t
+; RUN: llc -filetype=obj -o - %t | llvm-readobj --codeview - | FileCheck %s -check-prefixes CHECK,CHECK-WIN-DRV
+;
+; RUN: sed -e 's|_FILENAME_|./subdir/../test.cpp|;s|_DIR_|C:/ignored/../abs/path/to/|' %s > %t
+; RUN: llc -filetype=obj -o - %t | llvm-readobj --codeview - | FileCheck %s -check-prefixes CHECK,CHECK-WIN-DRV
+;
+; RUN: sed -e 's|_FILENAME_|./../test.cpp|;s|_DIR_|C:/abs/path/to/subdir|' %s > %t
+; RUN: llc -filetype=obj -o - %t | llvm-readobj --codeview - | FileCheck %s -check-prefixes CHECK,CHECK-WIN-DRV
+;
+; RUN: sed -e 's|_FILENAME_|./../test.cpp|' -e 's|_DIR_|<BSLASH><BSLASH>servername/path/to/subdir/|' -e 's|<BSLASH>|\\\\|g' %s > %t
+; RUN: llc -filetype=obj -o - %t | llvm-readobj --codeview - | FileCheck %s -check-prefixes CHECK,CHECK-WIN-UNC
+;
+; RUN: sed -e 's|_FILENAME_|<BSLASH><BSLASH>servername/path/to/subdir/../test.cpp|' -e 's|_DIR_|X:/ignored/directory|' -e 's|<BSLASH>|\\\\|g' %s > %t
+; RUN: llc -filetype=obj -o - %t | llvm-readobj --codeview - | FileCheck %s -check-prefixes CHECK,CHECK-WIN-UNC
+;
+; RUN: sed -e 's|_FILENAME_|./../test.cpp|' -e 's|_DIR_|<BSLASH><BSLASH>\?<BSLASH>C:/long/path/to/subdir/|' -e 's|<BSLASH>|\\\\|g' %s > %t
+; RUN: llc -filetype=obj -o - %t | llvm-readobj --codeview - | FileCheck %s -check-prefixes CHECK,CHECK-WIN-EXT
+;
+; RUN: sed -e 's|_FILENAME_|<BSLASH><BSLASH>\?<BSLASH>C:/long/path/to/subdir/../test.cpp|' -e 's|_DIR_|X:/ignored/directory|' -e 's|<BSLASH>|\\\\|g' %s > %t
+; RUN: llc -filetype=obj -o - %t | llvm-readobj --codeview - | FileCheck %s -check-prefixes CHECK,CHECK-WIN-EXT
+
+; C++ source to regenerate:
+; # 1 "_FILENAME_"
+; void f() {}
+;
+; $clang++ --target=x86_64-pc-windows-msvc -g -O0 -fdebug-compilation-dir=_DIR_
+
+; CHECK: FunctionLineTable [
+; CHECK-NEXT:   LinkageName: ?f@@YAXXZ
+; CHECK-NEXT:   Flags:
+; CHECK-NEXT:   CodeSize:
+; CHECK-NEXT:   FilenameSegment [
+;
+; CHECK-POSIX-NEXT:     Filename: /abs/path/to/test.cpp (0x0)
+; CHECK-POSIX-DOTS-NEXT:     Filename: /abs/path/subdir/.././to/to2/../test.cpp (0x0)
+;
+; CHECK-WIN-REL-NEXT:     Filename: rel\path\to\test.cpp (0x0)
+; CHECK-WIN-DRV-NEXT:     Filename: C:\abs\path\to\test.cpp (0x0)
+; CHECK-WIN-UNC-NEXT:     Filename: \\servername\path\to\test.cpp (0x0)
+; CHECK-WIN-EXT-NEXT:     Filename: \\?\C:\long\path\to\test.cpp (0x0)
+
+; ModuleID = '/app/example.cpp'
+source_filename = "/app/example.cpp"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc19.33.0"
+
+; Function Attrs: mustprogress noinline nounwind optnone uwtable
+define dso_local void @"?f@@YAXXZ"() #0 !dbg !9 {
+entry:
+  ret void, !dbg !13
+}
+
+attributes #0 = { mustprogress noinline nounwind optnone uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
+!llvm.ident = !{!8}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 22.1.0 (https://github.com/llvm/llvm-project.git 4434dabb69916856b824f68a64b029c67175e532)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "/app/example.cpp", directory: "_DIR_", checksumkind: CSK_MD5, checksum: "6607a2818b39ced0f66b5fb380b775dc")
+!2 = !{i32 2, !"CodeView", i32 1}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 2}
+!5 = !{i32 8, !"PIC Level", i32 2}
+!6 = !{i32 7, !"uwtable", i32 2}
+!7 = !{i32 1, !"MaxTLSAlign", i32 65536}
+!8 = !{!"clang version 22.1.0 (https://github.com/llvm/llvm-project.git 4434dabb69916856b824f68a64b029c67175e532)"}
+!9 = distinct !DISubprogram(name: "f", linkageName: "?f@@YAXXZ", scope: !10, file: !10, line: 1, type: !11, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0)
+!10 = !DIFile(filename: "_FILENAME_", directory: "_DIR_")
+!11 = !DISubroutineType(types: !12)
+!12 = !{null}
+!13 = !DILocation(line: 1, scope: !9)

--- a/llvm/test/DebugInfo/COFF/filename.ll
+++ b/llvm/test/DebugInfo/COFF/filename.ll
@@ -17,22 +17,25 @@
 ; RUN: sed -e 's|_FILENAME_|C:/abs/path/to/test.cpp|;s|_DIR_|X:/ignored/directory/|' %s > %t
 ; RUN: llc -filetype=obj -o - %t | llvm-readobj --codeview - | FileCheck %s -check-prefixes CHECK,CHECK-WIN-DRV
 ;
-; RUN: sed -e 's|_FILENAME_|./subdir/../test.cpp|;s|_DIR_|C:/ignored/../abs/path/to/|' %s > %t
+; RUN: sed -e 's|_FILENAME_|./skipped_subdir2/../test.cpp|;s|_DIR_|C:/skipped_subdir1/../abs/path/to/|' %s > %t
 ; RUN: llc -filetype=obj -o - %t | llvm-readobj --codeview - | FileCheck %s -check-prefixes CHECK,CHECK-WIN-DRV
 ;
-; RUN: sed -e 's|_FILENAME_|./../test.cpp|;s|_DIR_|C:/abs/path/to/subdir|' %s > %t
+; RUN: sed -e 's|_FILENAME_|./skipped_subdir2//../test.cpp|;s|_DIR_|C:/skipped_subdir1//../abs/path/to/|' %s > %t
 ; RUN: llc -filetype=obj -o - %t | llvm-readobj --codeview - | FileCheck %s -check-prefixes CHECK,CHECK-WIN-DRV
 ;
-; RUN: sed -e 's|_FILENAME_|./../test.cpp|' -e 's|_DIR_|<BSLASH><BSLASH>servername/path/to/subdir/|' -e 's|<BSLASH>|\\\\|g' %s > %t
+; RUN: sed -e 's|_FILENAME_|./../test.cpp|;s|_DIR_|C:/abs/path/to/skipped_subdir|' %s > %t
+; RUN: llc -filetype=obj -o - %t | llvm-readobj --codeview - | FileCheck %s -check-prefixes CHECK,CHECK-WIN-DRV
+;
+; RUN: sed -e 's|_FILENAME_|./../test.cpp|' -e 's|_DIR_|<BSLASH><BSLASH>servername/path/to/skipped_subdir/|' -e 's|<BSLASH>|\\\\|g' %s > %t
 ; RUN: llc -filetype=obj -o - %t | llvm-readobj --codeview - | FileCheck %s -check-prefixes CHECK,CHECK-WIN-UNC
 ;
-; RUN: sed -e 's|_FILENAME_|<BSLASH><BSLASH>servername/path/to/subdir/../test.cpp|' -e 's|_DIR_|X:/ignored/directory|' -e 's|<BSLASH>|\\\\|g' %s > %t
+; RUN: sed -e 's|_FILENAME_|<BSLASH><BSLASH>servername/path/to/skipped_subdir/../test.cpp|' -e 's|_DIR_|X:/ignored/directory|' -e 's|<BSLASH>|\\\\|g' %s > %t
 ; RUN: llc -filetype=obj -o - %t | llvm-readobj --codeview - | FileCheck %s -check-prefixes CHECK,CHECK-WIN-UNC
 ;
-; RUN: sed -e 's|_FILENAME_|./../test.cpp|' -e 's|_DIR_|<BSLASH><BSLASH>\?<BSLASH>C:/long/path/to/subdir/|' -e 's|<BSLASH>|\\\\|g' %s > %t
+; RUN: sed -e 's|_FILENAME_|./../test.cpp|' -e 's|_DIR_|<BSLASH><BSLASH>\?<BSLASH>C:/long/path/to/skipped_subdir/|' -e 's|<BSLASH>|\\\\|g' %s > %t
 ; RUN: llc -filetype=obj -o - %t | llvm-readobj --codeview - | FileCheck %s -check-prefixes CHECK,CHECK-WIN-EXT
 ;
-; RUN: sed -e 's|_FILENAME_|<BSLASH><BSLASH>\?<BSLASH>C:/long/path/to/subdir/../test.cpp|' -e 's|_DIR_|X:/ignored/directory|' -e 's|<BSLASH>|\\\\|g' %s > %t
+; RUN: sed -e 's|_FILENAME_|<BSLASH><BSLASH>\?<BSLASH>C:/long/path/to/skipped_subdir/../test.cpp|' -e 's|_DIR_|X:/ignored/directory|' -e 's|<BSLASH>|\\\\|g' %s > %t
 ; RUN: llc -filetype=obj -o - %t | llvm-readobj --codeview - | FileCheck %s -check-prefixes CHECK,CHECK-WIN-EXT
 
 ; C++ source to regenerate:

--- a/llvm/test/DebugInfo/COFF/filename.ll
+++ b/llvm/test/DebugInfo/COFF/filename.ll
@@ -73,14 +73,14 @@ attributes #0 = { mustprogress noinline nounwind optnone uwtable "min-legal-vect
 !llvm.ident = !{!8}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 22.1.0 (https://github.com/llvm/llvm-project.git 4434dabb69916856b824f68a64b029c67175e532)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
-!1 = !DIFile(filename: "/app/example.cpp", directory: "_DIR_", checksumkind: CSK_MD5, checksum: "6607a2818b39ced0f66b5fb380b775dc")
+!1 = !DIFile(filename: "/app/example.cpp", directory: "_DIR_")
 !2 = !{i32 2, !"CodeView", i32 1}
 !3 = !{i32 2, !"Debug Info Version", i32 3}
 !4 = !{i32 1, !"wchar_size", i32 2}
 !5 = !{i32 8, !"PIC Level", i32 2}
 !6 = !{i32 7, !"uwtable", i32 2}
 !7 = !{i32 1, !"MaxTLSAlign", i32 65536}
-!8 = !{!"clang version 22.1.0 (https://github.com/llvm/llvm-project.git 4434dabb69916856b824f68a64b029c67175e532)"}
+!8 = !{!"clang version 22.1.0 (https://github.com/llvm/llvm-project.git)"}
 !9 = distinct !DISubprogram(name: "f", linkageName: "?f@@YAXXZ", scope: !10, file: !10, line: 1, type: !11, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0)
 !10 = !DIFile(filename: "_FILENAME_", directory: "_DIR_")
 !11 = !DISubroutineType(types: !12)


### PR DESCRIPTION
The custom implementation that was used was much simpler and limited than remove_dots. For example, there was no support for network paths. There was also a bug when simplifying double dots preceded with a double separator, considering the empty space between the separators as a directory, so `a\b\\..\c` would be simplified into `a\b\c` instead of `a\c`.

Should fix #59878

Assisted-by: Claude Code