### PR TITLE
[flang][debug] Fix build after fir.global linkage became a typed enum

### DIFF
--- a/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
+++ b/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
@@ -561,7 +561,8 @@ void AddDebugInfoPass::handleGlobalOp(fir::GlobalOp globalOp,
   // declared inside a procedure, is not visible outside this compilation unit.
   // It also needs no linkage name because there is no external symbol for a
   // debugger to match it against.
-  const bool isLocalToUnit = globalOp.getLinkName() == "internal";
+  const bool isLocalToUnit =
+      globalOp.getLinkage() == fir::LinkageEnum::Internal;
   mlir::StringAttr linkageName =
       isLocalToUnit ? mlir::StringAttr()
                     : mlir::StringAttr::get(context, globalOp.getName());


### PR DESCRIPTION
#220243 replaced the string `linkName` on `fir.global` with a typed
`fir::LinkageAttr`, so `GlobalOp::getLinkName()` no longer exists.

It landed 46 minutes before #215369 was merged, and the two changes touch
disjoint sets of files: #220243 never touched `AddDebugInfo.cpp`, and
#215369 added the only `getLinkName()` call in it. They merged cleanly with
no textual conflict, and main is currently unable to build flang:

```
flang/lib/Optimizer/Transforms/AddDebugInfo.cpp:564:39: error:
  'class fir::GlobalOp' has no member named 'getLinkName';
  did you mean 'getLinkage'?
```

Use the typed accessor, matching what #220243 did for the same idiom in
`CUFDeviceGlobal.cpp`.

This is offered in place of reverting #215369 (#220272), since the rest of
that change is unaffected by the rename. `flang/test/Transforms` and
`flang/test/Integration` pass locally.

Made with [Cursor](https://cursor.com)