### PR TITLE
[clang][bytecode][NFC] assert(Func) in InterpFrame ctor

### DIFF
--- a/clang/lib/AST/ByteCode/InterpFrame.cpp
+++ b/clang/lib/AST/ByteCode/InterpFrame.cpp
@@ -32,12 +32,10 @@ InterpFrame::InterpFrame(InterpState &S, const Function *Func,
     : Caller(Caller), S(S), Func(Func), RetPC(RetPC),
       Args(static_cast<char *>(S.Stk.top())), ArgSize(ArgSize),
       Depth(Caller ? Caller->Depth + 1 : 0) {
+  assert(Func);
 #ifndef NDEBUG
   FrameOffset = S.Stk.size();
 #endif
-
-  if (!Func)
-    return;
 
   FuncFlags |= Func->hasRVO() * HasRVOFlag;
   FuncFlags |= Func->hasThisPointer() * HasThisFlag;


### PR DESCRIPTION
`Func` is only null for the bottom frame, which we create using another constructor.