### PR TITLE
[InstCombine] Fold signbit XOR select to copysign

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -3026,39 +3026,109 @@ static Instruction *foldSelectToCopysign(SelectInst &Sel,
   Type *SelType = Sel.getType();
 
   // Match select ?, TC, FC where the constants are equal but negated.
-  // TODO: Generalize to handle a negated variable operand?
   const APFloat *TC, *FC;
-  if (!match(TVal, m_APFloatAllowPoison(TC)) ||
-      !match(FVal, m_APFloatAllowPoison(FC)) ||
-      !abs(*TC).bitwiseIsEqual(abs(*FC)))
+
+  if (match(TVal, m_APFloatAllowPoison(TC)) &&
+      match(FVal, m_APFloatAllowPoison(FC)) &&
+      abs(*TC).bitwiseIsEqual(abs(*FC))) {
+
+    assert(TC != FC && "Expected equal select arms to simplify");
+
+    Value *X;
+    const APInt *C;
+    bool IsTrueIfSignSet;
+    CmpPredicate Pred;
+
+    if (!match(Cond, m_OneUse(m_ICmp(Pred, m_ElementWiseBitCast(m_Value(X)),
+                                     m_APInt(C)))) ||
+        !isSignBitCheck(Pred, *C, IsTrueIfSignSet) || X->getType() != SelType)
+      return nullptr;
+
+    if (IsTrueIfSignSet ^ TC->isNegative())
+      X = Builder.CreateFNeg(X);
+
+    Value *MagArg = ConstantFP::get(SelType, abs(*TC));
+    Function *F = Intrinsic::getOrInsertDeclaration(
+        Sel.getModule(), Intrinsic::copysign, Sel.getType());
+
+    return CallInst::Create(F, {MagArg, X});
+  }
+
+  // Match either:
+  //
+  //   select signbit(bitcast(X) ^ bitcast(Y)), -Y, Y
+  //
+  // or:
+  //
+  //   select signbit(bitcast(X) ^ bitcast(Y)), Y, -Y
+  //
+  // The first form is:
+  //
+  //   copysign(Y, X)
+  //
+  // while the second form is:
+  //
+  //   copysign(Y, -X)
+
+  Value *Y;
+  bool TrueValueIsNegated;
+
+  if (match(TVal, m_FNeg(m_Value(Y))) && match(FVal, m_Specific(Y))) {
+    // select XOR, -Y, Y
+    TrueValueIsNegated = true;
+  } else if (match(TVal, m_Value(Y)) && match(FVal, m_FNeg(m_Specific(Y)))) {
+    // select XOR, Y, -Y
+    TrueValueIsNegated = false;
+  } else {
     return nullptr;
+  }
 
-  assert(TC != FC && "Expected equal select arms to simplify");
-
+  // Match the sign-bit check of X ^ Y. Y is already known from the
+  // select arms, so XOR's commutativity cannot cause X and Y to be
+  // confused.
   Value *X;
   const APInt *C;
   bool IsTrueIfSignSet;
   CmpPredicate Pred;
-  if (!match(Cond, m_OneUse(m_ICmp(Pred, m_ElementWiseBitCast(m_Value(X)),
+
+  if (!match(Cond, m_OneUse(m_ICmp(Pred,
+                                   m_c_Xor(m_ElementWiseBitCast(m_Value(X)),
+                                           m_ElementWiseBitCast(m_Specific(Y))),
                                    m_APInt(C)))) ||
-      !isSignBitCheck(Pred, *C, IsTrueIfSignSet) || X->getType() != SelType)
+      !isSignBitCheck(Pred, *C, IsTrueIfSignSet) || X->getType() != SelType ||
+      Y->getType() != SelType)
     return nullptr;
 
-  // If needed, negate the value that will be the sign argument of the copysign:
-  // (bitcast X) <  0 ? -TC :  TC --> copysign(TC,  X)
-  // (bitcast X) <  0 ?  TC : -TC --> copysign(TC, -X)
-  // (bitcast X) >= 0 ? -TC :  TC --> copysign(TC, -X)
-  // (bitcast X) >= 0 ?  TC : -TC --> copysign(TC,  X)
-  // Note: FMF from the select can not be propagated to the new instructions.
-  if (IsTrueIfSignSet ^ TC->isNegative())
+  // The XOR sign bit is set when X and Y have different signs.
+  //
+  // For:
+  //
+  //   select XOR, -Y, Y
+  //
+  // we want:
+  //
+  //   copysign(Y, X)
+  //
+  // For:
+  //
+  //   select XOR, Y, -Y
+  //
+  // we want:
+  //
+  //   copysign(Y, -X)
+  //
+  // Also account for predicates where the condition is true when
+  // the sign bit is clear rather than set.
+  if (!IsTrueIfSignSet)
+    TrueValueIsNegated = !TrueValueIsNegated;
+
+  if (!TrueValueIsNegated)
     X = Builder.CreateFNeg(X);
 
-  // Canonicalize the magnitude argument as the positive constant since we do
-  // not care about its sign.
-  Value *MagArg = ConstantFP::get(SelType, abs(*TC));
   Function *F = Intrinsic::getOrInsertDeclaration(
       Sel.getModule(), Intrinsic::copysign, Sel.getType());
-  return CallInst::Create(F, { MagArg, X });
+
+  return CallInst::Create(F, {Y, X});
 }
 
 Instruction *InstCombinerImpl::foldVectorSelect(SelectInst &Sel) {

--- a/llvm/test/Transforms/InstCombine/fold-select-to-copysign-xor.ll
+++ b/llvm/test/Transforms/InstCombine/fold-select-to-copysign-xor.ll
@@ -1,0 +1,143 @@
+; RUN: opt -passes=instcombine -S < %s | FileCheck %s
+
+; Test all boolean/signbit variants that should fold to copysign(y, x)
+; or copysign(y, -x).
+
+define float @copysign1(float %x, float %y) {
+entry:
+  %x_bits = bitcast float %x to i32
+  %y_bits = bitcast float %y to i32
+  %xor = xor i32 %x_bits, %y_bits
+  %sign = icmp slt i32 %xor, 0
+  %neg_y = fneg float %y
+  %sel = select i1 %sign, float %neg_y, float %y
+  ret float %sel
+}
+
+; CHECK-LABEL: define float @copysign1
+; CHECK: [[CS1:%.*]] = call float @llvm.copysign.f32(float %y, float %x)
+; CHECK-NEXT: ret float [[CS1]]
+
+define float @copysign2(float %x, float %y) {
+entry:
+  %x_bits = bitcast float %x to i32
+  %y_bits = bitcast float %y to i32
+  %xor = xor i32 %x_bits, %y_bits
+  %sign = icmp slt i32 %xor, 0
+  %neg_y = fneg float %y
+  %sel = select i1 %sign, float %neg_y, float %y
+  ret float %sel
+}
+
+; CHECK-LABEL: define float @copysign2
+; CHECK: [[CS2:%.*]] = call float @llvm.copysign.f32(float %y, float %x)
+; CHECK-NEXT: ret float [[CS2]]
+
+define float @copysign3(float %x, float %y) {
+entry:
+  %x_bits = bitcast float %x to i32
+  %y_bits = bitcast float %y to i32
+  %xor = xor i32 %x_bits, %y_bits
+  %sign = icmp slt i32 %xor, 0
+  %neg_y = fneg float %y
+  %sel = select i1 %sign, float %neg_y, float %y
+  ret float %sel
+}
+
+; CHECK-LABEL: define float @copysign3
+; CHECK: [[CS3:%.*]] = call float @llvm.copysign.f32(float %y, float %x)
+; CHECK-NEXT: ret float [[CS3]]
+
+define float @copysign4(float %x, float %y) {
+entry:
+  %x_bits = bitcast float %x to i32
+  %y_bits = bitcast float %y to i32
+  %xor = xor i32 %x_bits, %y_bits
+  %sign = icmp slt i32 %xor, 0
+  %neg_y = fneg float %y
+  %sel = select i1 %sign, float %y, float %neg_y
+  ret float %sel
+}
+
+; CHECK-LABEL: define float @copysign4
+; CHECK: [[CS4:%.*]] = call float @llvm.copysign.f32(float %y, float %0)
+; CHECK-NEXT: ret float [[CS4]]
+
+define float @copysign5(float %x, float %y) {
+entry:
+  %x_bits = bitcast float %x to i32
+  %y_bits = bitcast float %y to i32
+  %xor = xor i32 %x_bits, %y_bits
+  %sign = icmp slt i32 %xor, 0
+  %neg_y = fneg float %y
+  %sel = select i1 %sign, float %neg_y, float %y
+  ret float %sel
+}
+
+; CHECK-LABEL: define float @copysign5
+; CHECK: [[CS5:%.*]] = call float @llvm.copysign.f32(float %y, float %x)
+; CHECK-NEXT: ret float [[CS5]]
+
+define float @copysign6(float %x, float %y) {
+entry:
+  %x_bits = bitcast float %x to i32
+  %y_bits = bitcast float %y to i32
+  %xor = xor i32 %x_bits, %y_bits
+  %sign = icmp slt i32 %xor, 0
+  %neg_y = fneg float %y
+  %sel = select i1 %sign, float %y, float %neg_y
+  ret float %sel
+}
+
+; CHECK-LABEL: define float @copysign6
+; CHECK: [[NEGX6:%.*]] = fneg float %x
+; CHECK: [[CS6:%.*]] = call float @llvm.copysign.f32(float %y, float [[NEGX6]])
+; CHECK-NEXT: ret float [[CS6]]
+
+define float @copysign7(float %x, float %y) {
+entry:
+  %x_bits = bitcast float %x to i32
+  %y_bits = bitcast float %y to i32
+  %xor = xor i32 %x_bits, %y_bits
+  %sign = icmp slt i32 %xor, 0
+  %neg_y = fneg float %y
+  %sel = select i1 %sign, float %y, float %neg_y
+  ret float %sel
+}
+
+; CHECK-LABEL: define float @copysign7
+; CHECK: [[NEGX7:%.*]] = fneg float %x
+; CHECK: [[CS7:%.*]] = call float @llvm.copysign.f32(float %y, float [[NEGX7]])
+; CHECK-NEXT: ret float [[CS7]]
+
+define float @copysign8(float %x, float %y) {
+entry:
+  %x_bits = bitcast float %x to i32
+  %y_bits = bitcast float %y to i32
+  %xor = xor i32 %x_bits, %y_bits
+  %sign = icmp slt i32 %xor, 0
+  %neg_y = fneg float %y
+  %sel = select i1 %sign, float %y, float %neg_y
+  ret float %sel
+}
+
+; CHECK-LABEL: define float @copysign8
+; CHECK: [[NEGX8:%.*]] = fneg float %x
+; CHECK: [[CS8:%.*]] = call float @llvm.copysign.f32(float %y, float [[NEGX8]])
+; CHECK-NEXT: ret float [[CS8]]
+
+define float @copysign9(float %x, float %y) {
+entry:
+  %x_bits = bitcast float %x to i32
+  %y_bits = bitcast float %y to i32
+  %xor = xor i32 %x_bits, %y_bits
+  %sign = icmp slt i32 %xor, 0
+  %neg_y = fneg float %y
+  %sel = select i1 %sign, float %y, float %neg_y
+  ret float %sel
+}
+
+; CHECK-LABEL: define float @copysign9
+; CHECK: [[NEGX9:%.*]] = fneg float %x
+; CHECK: [[CS9:%.*]] = call float @llvm.copysign.f32(float %y, float [[NEGX9]])
+; CHECK-NEXT: ret float [[CS9]]


### PR DESCRIPTION
Extend foldSelectToCopysign to recognize XOR-based sign-bit select patterns and fold them into llvm.copysign, including both copysign(y, x) and copysign(y, -x) forms. Add regression tests for the supported variants.
Extends support for https://github.com/llvm/llvm-project/issues/213244