### PR TITLE
[KnownFPClass] Fix remaining direct accesses to `KnownFPClass.SignBit`

### DIFF
--- a/llvm/unittests/Support/KnownFPClassTest.cpp
+++ b/llvm/unittests/Support/KnownFPClassTest.cpp
@@ -31,7 +31,7 @@ static void expectConstant(const char *SemanticsName, const char *ValueName,
   FPClassTest ExpectedClass =
       Negative ? llvm::fneg(PositiveClass) : PositiveClass;
   EXPECT_EQ(ExpectedClass, Known.KnownFPClasses);
-  EXPECT_EQ(Negative, Known.SignBit);
+  EXPECT_EQ(Negative, Known.getSignBit());
 }
 
 TEST(KnownFPClassTest, BitcastExhaustiveIEEEHalf) {
@@ -44,7 +44,7 @@ TEST(KnownFPClassTest, BitcastExhaustiveIEEEHalf) {
     KnownFPClass Expected(APFloat(Semantics, ValueBits));
 
     ASSERT_EQ(Expected.KnownFPClasses, Known.KnownFPClasses) << RawBits;
-    ASSERT_EQ(Expected.SignBit, Known.SignBit) << RawBits;
+    ASSERT_EQ(Expected.getSignBit(), Known.getSignBit()) << RawBits;
   }
 }
 
@@ -56,7 +56,7 @@ TEST(KnownFPClassTest, BitcastConflict) {
   ASSERT_TRUE(Bits.hasConflict());
   KnownFPClass Known = KnownFPClass::bitcast(Semantics, Bits);
   EXPECT_EQ(fcAllFlags, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST(KnownFPClassTest, BitcastPartialConflict) {
@@ -68,7 +68,7 @@ TEST(KnownFPClassTest, BitcastPartialConflict) {
   ASSERT_TRUE(Bits.hasConflict());
   KnownFPClass Known = KnownFPClass::bitcast(Semantics, Bits);
   EXPECT_EQ(fcAllFlags, Known.KnownFPClasses);
-  EXPECT_EQ(std::nullopt, Known.SignBit);
+  EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
 TEST(KnownFPClassTest, BitcastConstant) {


### PR DESCRIPTION
Fixes post commit failures from https://github.com/llvm/llvm-project/pull/218514