### PR TITLE
[ADT] Exit doFind on an empty map, not just an unallocated one

### DIFF
--- a/llvm/include/llvm/ADT/DenseMap.h
+++ b/llvm/include/llvm/ADT/DenseMap.h
@@ -721,9 +721,10 @@ private:
 
   template <typename LookupKeyT>
   const BucketT *doFind(const LookupKeyT &Val) const {
-    auto [BucketsPtr, U, NumBuckets] = getRep();
-    if (NumBuckets == 0)
+    // Tighter than NumBuckets == 0: catches emptied and small-mode maps.
+    if (getNumEntries() == 0)
       return nullptr;
+    auto [BucketsPtr, U, NumBuckets] = getRep();
 
     const unsigned Mask = NumBuckets - 1;
     unsigned BucketNo = KeyInfoT::getHashValue(Val) & Mask;

--- a/llvm/include/llvm/ADT/DenseMap.h
+++ b/llvm/include/llvm/ADT/DenseMap.h
@@ -721,8 +721,7 @@ private:
 
   template <typename LookupKeyT>
   const BucketT *doFind(const LookupKeyT &Val) const {
-    // Tighter than NumBuckets == 0: catches emptied and small-mode maps.
-    if (getNumEntries() == 0)
+    if (empty())
       return nullptr;
     auto [BucketsPtr, U, NumBuckets] = getRep();
 


### PR DESCRIPTION
`doFind` exits early only when no buckets were ever allocated. A map that
had entries and lost them keeps its bucket array. `NumBuckets` is then not
zero, so every lookup hashes the key and probes.

For a `SmallDenseMap` in small mode, `NumBuckets` is the template parameter
`InlineBuckets`, a nonzero constant. The existing check can never fire for
those maps. An empty one hashes and probes on every lookup.

`getNumEntries() == 0` covers both cases. It also subsumes the old check.
There are no entries without buckets, so `Mask = NumBuckets - 1` is still
safe. It is one test either way, so non-empty lookups are unchanged. The
check goes before `getRep()`. Keeping it after costs 0.158% on clang, so
those loads are not sunk past the branch.

| workload | instructions:u |
|---|---:|
| clang compiling 600 LLVM/Clang/MLIR translation units | **-0.028%** |
| `mlir-opt` canonicalize/cse over 1060 `mlir/test` files >4KB | **-0.291%** |

Three interleaved runs each. Ranges do not overlap. Exit codes are
identical on all 1448 candidate `mlir/test` files.

Adding `LLVM_UNLIKELY` to the branch is a regression, not a win. It takes
clang from -0.133% to -0.007%. Once this is the first check, an empty map
is the common case, not the rare one.