### PR TITLE
[libc++] Add _LIBCPP_NO_SANITIZE for std::__assume_aligned

### DIFF
--- a/libcxx/include/__memory/assume_aligned.h
+++ b/libcxx/include/__memory/assume_aligned.h
@@ -23,7 +23,8 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <size_t _Np, class _Tp>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_NO_SANITIZE("cfi-unrelated-cast") _Tp* __assume_aligned(_Tp* __ptr) {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_NO_SANITIZE("cfi-unrelated-cast") _Tp*
+__assume_aligned(_Tp* __ptr) {
   static_assert(_Np != 0 && (_Np & (_Np - 1)) == 0, "std::assume_aligned<N>(p) requires N to be a power of two");
 
   if (__libcpp_is_constant_evaluated()) {

--- a/libcxx/include/__memory/assume_aligned.h
+++ b/libcxx/include/__memory/assume_aligned.h
@@ -23,7 +23,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <size_t _Np, class _Tp>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp* __assume_aligned(_Tp* __ptr) {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_NO_SANITIZE("cfi-unrelated-cast") _Tp* __assume_aligned(_Tp* __ptr) {
   static_assert(_Np != 0 && (_Np & (_Np - 1)) == 0, "std::assume_aligned<N>(p) requires N to be a power of two");
 
   if (__libcpp_is_constant_evaluated()) {


### PR DESCRIPTION
std::assume_aligned takes void* from __builtin_assume_aligned and converts it _Tp* that causes cfi-unrelated-cast to consider it a downcast leading to CFI checks. Since std::find_if calls std::assume_aligned on __last, it will lead to a CFI check that dereferences __last causing a failure. Based on discussion, we can just add _LIBCPP_NO_SANITIZE for cfi-unrelated-cast because the check rejects well-defined behavior.

Fix: https://github.com/llvm/llvm-project/issues/219306