### PR TITLE
[Workflows] Mark miscompilation:undef as uninteresting

### DIFF
--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -86,6 +86,13 @@ class IssueSubscriber:
         self._team_name = "issue-subscribers-{}".format(label_name).lower()
 
     def run(self) -> bool:
+        if self.team_name.endswith("miscompilation:undef"):
+            comment = """
+Undef values are deprecated. Unless this miscompilation is observable in real-world programs, we don't want to fix it.
+"""
+            self.issue.create_comment(comment)
+            return True
+
         team = _get_current_team(self.team_name, self.org.get_teams())
         if not team:
             print(f"couldn't find team named {self.team_name}")


### PR DESCRIPTION
Address comment https://github.com/llvm/llvm-project/issues/218908#issuecomment-5470741016.

Can somebody create a team named `issue-subscribers-miscompilation:undef`?
