### PR TITLE
[lld][ELF] Add -nopie as alias to -no-pie

### DIFF
--- a/lld/ELF/Options.td
+++ b/lld/ELF/Options.td
@@ -624,6 +624,7 @@ def: Flag<["-"], "n">, Alias<nmagic>, HelpText<"Alias for --nmagic">;
 def: Flag<["-"], "N">, Alias<omagic>, HelpText<"Alias for --omagic">;
 def: Joined<["--"], "output=">, Alias<o>, HelpText<"Alias for -o">;
 def: Separate<["--"], "output">, Alias<o>, HelpText<"Alias for -o">;
+def: F<"nopie">, Alias<no_pie>, HelpText<"Alias for --no-pie">, Flags<[HelpHidden]>;
 def: F<"pic-executable">, Alias<pie>, HelpText<"Alias for --pie">;
 def: Flag<["-"], "M">, Alias<print_map>, HelpText<"Alias for --print-map">;
 def: Flag<["-"], "r">, Alias<relocatable>, HelpText<"Alias for --relocatable">;

--- a/lld/test/ELF/pie.s
+++ b/lld/test/ELF/pie.s
@@ -51,7 +51,10 @@
 # CHECK:        0x000000006FFFFFFB FLAGS_1 PIE
 
 ## Check -nopie
-# RUN: ld.lld -no-pie %t1.o -o %t2
+# RUN: ld.lld -pie -no-pie %t1.o -o %t2
+# RUN: llvm-readobj --file-headers -r %t2 | FileCheck %s --check-prefix=NOPIE
+
+# RUN: ld.lld -pie -nopie %t1.o -o %t2
 # RUN: llvm-readobj --file-headers -r %t2 | FileCheck %s --check-prefix=NOPIE
 # NOPIE-NOT: Type: SharedObject
 


### PR DESCRIPTION
The non-dashed version is used on OpenBSD. Currently they patch this
change into their LLVM build:

https://github.com/openbsd/ports/blob/a3e140c906801a2ea4a42f2b49658711c2300781/devel/llvm/19/patches/patch-lld_ELF_Options_td#L20

The problem with that is if you want to cross compile to OpenBSD from
Linux / macOS, toolchains will assume you support `-nopie` and then that
flag will be rejected. For example golang:

https://github.com/golang/go/blob/fbea197d327913903d2db36ede886e81d78277e6/src/cmd/link/internal/ld/lib.go#L1504

Today clang supports both spellings and that is handled for OpenBSD, but
it also always passes through `-nopie`.

This spelling was previously added and reverted, but I can't find the
conversation history outside of the commits:

- https://github.com/llvm/llvm-project/commit/82fca768682a68a7b3096f8a93e8f7480ab124d8
- https://github.com/llvm/llvm-project/commit/9060b57e707b3e9231394a617a391f2dff1f6293
