### PR TITLE
[OpenMP] Fix crash on malformed iterator clause missing variable identifier

### DIFF
--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -4692,6 +4692,11 @@ ExprResult Parser::ParseOpenMPIteratorsExpr() {
       IdLoc = ConsumeToken();
     } else {
       Diag(Tok, diag::err_expected_unqualified_id) << 0;
+      SkipUntil(tok::comma, tok::r_paren, tok::annot_pragma_openmp_end,
+                StopBeforeMatch);
+      if (Tok.is(tok::comma))
+        ConsumeToken();
+      continue;
     }
 
     // Parse '='.

--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -26766,7 +26766,10 @@ ExprResult SemaOpenMP::ActOnOMPIteratorExpr(Scope *S,
     }
 
     // Iterator declaration.
-    assert(D.DeclIdent && "Identifier expected.");
+    if (!D.DeclIdent) {
+      IsCorrect = false;
+      continue;
+    }
     // Always try to create iterator declarator to avoid extra error messages
     // about unknown declarations use.
     auto *VD =

--- a/clang/test/OpenMP/depobj_messages.cpp
+++ b/clang/test/OpenMP/depobj_messages.cpp
@@ -175,5 +175,7 @@ label1 : {
 #pragma omp depobj depend(in:x) (x) // expected-error {{expected depobj expression}} expected-warning {{extra tokens at the end of '#pragma omp depobj' are ignored}} expected-error {{expected addressable lvalue expression, array element, array section or array shaping expression of non 'omp_depend_t' type}}
 #pragma omp depobj destroy (x) // omp52-error {{expected 'destroy' clause with an argument on '#pragma omp depobj' construct}} expected-error {{expected depobj expression}} expected-warning {{extra tokens at the end of '#pragma omp depobj' are ignored}}
 #pragma omp depobj update(in) (x) // expected-error {{expected depobj expression}} expected-warning {{extra tokens at the end of '#pragma omp depobj' are ignored}}
+#pragma omp depobj(x) depend(iterator(int), in: argc) // expected-error {{expected identifier}}
+#pragma omp depobj(x) depend(iterator(int, int j = 0:10), in: argc) // expected-error {{expected identifier}}
   return tmain(argc); // expected-note {{in instantiation of function template specialization 'tmain<int>' requested here}}
 }


### PR DESCRIPTION
### Summary
Fixes a compiler crash (assertion failure / SIGSEGV) when parsing an OpenMP `iterator` clause that is missing a variable identifier (e.g. `iterator(int)`).

### Root Cause
When parsing malformed iterator declarations, the parser produced `OMPIteratorData` entries with a `nullptr` identifier (`DeclIdent`), which subsequently failed an assertion in `SemaOpenMP.cpp` during AST construction.

### Fix
1. **ParseOpenMP.cpp**: Recover gracefully after diagnosing missing identifiers by skipping to the next delimiter (`comma` or `r_paren`) and skipping item construction.
2. **SemaOpenMP.cpp**: Replace hard `assert(D.DeclIdent)` with a defensive check (`if (!D.DeclIdent)`) to mark the expression invalid (`IsCorrect = false`) if incomplete data reaches Sema.
3. **depobj_messages.cpp**: Add regression tests for invalid iterator syntax.

Fixes #217882