### PR TITLE
[compiler-rt] Fix undefined abort for ubsan_minimal GPU targets

### DIFF
--- a/compiler-rt/lib/ubsan_minimal/ubsan_minimal_handlers.cpp
+++ b/compiler-rt/lib/ubsan_minimal/ubsan_minimal_handlers.cpp
@@ -152,6 +152,14 @@ SANITIZER_INTERFACE_WEAK_DEF(void, __ubsan_report_error_fatal, const char *kind,
   __ubsan_report_error(kind, caller);
 }
 
+static void NORETURN die() {
+#if SANITIZER_GPU
+  __builtin_verbose_trap("ubsan", "unrecoverable error");
+#else
+  abort();
+#endif
+}
+
 #if defined(__ANDROID__)
 extern "C" __attribute__((weak)) void android_set_abort_message(const char *);
 static void abort_with_message(const char *kind, uintptr_t caller) {
@@ -159,14 +167,10 @@ static void abort_with_message(const char *kind, uintptr_t caller) {
   format_msg(kind, caller, msg_buf, msg_buf + sizeof(msg_buf));
   if (&android_set_abort_message)
     android_set_abort_message(msg_buf);
-  abort();
-}
-#elif SANITIZER_GPU
-static void abort_with_message(const char *kind, uintptr_t caller) {
-  __builtin_verbose_trap("ubsan", "unrecoverable error");
+  die();
 }
 #else
-static void abort_with_message(const char *kind, uintptr_t caller) { abort(); }
+static void abort_with_message(const char *, uintptr_t) { die(); }
 #endif
 
 #if SANITIZER_DEBUG
@@ -177,7 +181,7 @@ void NORETURN CheckFailed(const char *file, int, const char *cond, u64, u64) {
   message(file);
   message(":?? : "); // FIXME: Show line number.
   message(cond);
-  abort();
+  die();
 }
 } // namespace __sanitizer
 #endif


### PR DESCRIPTION
Summary:
When compiling with debug enabled this would call `abort()`. The minimal
UBSan for GPUs is intentionally written to just depend on `printf`
which most vendors support and aborting is done through hardware traps.
I neglected to update this part because I had not done it with debugging
enabled, just wrap this into a helper function.
