### PR TITLE
[KnownFPClass] Refactor direct access to KnownFPClasses [NFC]

### DIFF
--- a/llvm/include/llvm/Support/KnownFPClass.h
+++ b/llvm/include/llvm/Support/KnownFPClass.h
@@ -25,10 +25,13 @@ struct fltSemantics;
 struct KnownBits;
 
 struct KnownFPClass {
-  /// Floating-point classes the value could be one of.
-  FPClassTest KnownFPClasses = fcAllFlags;
-
+  FPClassTest KnownFPClassesValue = fcAllFlags;
   std::optional<bool> SignBitValue;
+
+  /// Floating-point classes the value could be one of.
+  FPClassTest getKnownFPClasses() const { return KnownFPClassesValue; }
+
+  void setKnownFPClasses(FPClassTest Classes) { KnownFPClassesValue = Classes; }
 
   /// std::nullopt if the sign bit is unknown, true if the sign bit is
   /// definitely set or false if the sign bit is definitely unset.
@@ -37,23 +40,23 @@ struct KnownFPClass {
   void setSignBit(std::optional<bool> Sign) { SignBitValue = Sign; }
 
   KnownFPClass(FPClassTest Known = fcAllFlags, std::optional<bool> Sign = {})
-      : KnownFPClasses(Known), SignBitValue(Sign) {}
+      : KnownFPClassesValue(Known), SignBitValue(Sign) {}
   LLVM_ABI KnownFPClass(const APFloat &C);
 
   bool operator==(KnownFPClass Other) const {
-    return KnownFPClasses == Other.KnownFPClasses &&
+    return getKnownFPClasses() == Other.getKnownFPClasses() &&
            getSignBit() == Other.getSignBit();
   }
 
   /// Return true if it's known this can never be one of the mask entries.
   bool isKnownNever(FPClassTest Mask) const {
-    return (KnownFPClasses & Mask) == fcNone;
+    return (getKnownFPClasses() & Mask) == fcNone;
   }
 
   bool isKnownAlways(FPClassTest Mask) const { return isKnownNever(~Mask); }
 
   bool isUnknown() const {
-    return KnownFPClasses == fcAllFlags && !getSignBit();
+    return getKnownFPClasses() == fcAllFlags && !getSignBit();
   }
 
   /// Return true if it's known this can never be a nan.
@@ -158,7 +161,7 @@ struct KnownFPClass {
   }
 
   KnownFPClass intersectWith(const KnownFPClass &RHS) const {
-    return KnownFPClass(KnownFPClasses | RHS.KnownFPClasses,
+    return KnownFPClass(getKnownFPClasses() | RHS.getKnownFPClasses(),
                         getSignBit() == RHS.getSignBit() ? getSignBit()
                                                          : std::nullopt);
   }
@@ -170,11 +173,12 @@ struct KnownFPClass {
     else if (!getSignBit() && RHS.getSignBit())
       MergedSignBit = RHS.getSignBit();
 
-    return KnownFPClass(KnownFPClasses & RHS.KnownFPClasses, MergedSignBit);
+    return KnownFPClass(getKnownFPClasses() & RHS.getKnownFPClasses(),
+                        MergedSignBit);
   }
 
   KnownFPClass &operator|=(const KnownFPClass &RHS) {
-    KnownFPClasses = KnownFPClasses | RHS.KnownFPClasses;
+    setKnownFPClasses(getKnownFPClasses() | RHS.getKnownFPClasses());
 
     if (getSignBit() != RHS.getSignBit())
       setSignBit(std::nullopt);
@@ -182,7 +186,7 @@ struct KnownFPClass {
   }
 
   void knownNot(FPClassTest RuleOut) {
-    KnownFPClasses = KnownFPClasses & ~RuleOut;
+    setKnownFPClasses(getKnownFPClasses() & ~RuleOut);
     if (isKnownNever(fcNan) && !getSignBit()) {
       if (isKnownNever(fcNegative))
         setSignBit(false);
@@ -192,7 +196,7 @@ struct KnownFPClass {
   }
 
   void fneg() {
-    KnownFPClasses = llvm::fneg(KnownFPClasses);
+    setKnownFPClasses(llvm::fneg(getKnownFPClasses()));
     if (std::optional<bool> Sign = getSignBit())
       setSignBit(!*Sign);
   }
@@ -204,17 +208,17 @@ struct KnownFPClass {
   }
 
   void fabs() {
-    if (KnownFPClasses & fcNegZero)
-      KnownFPClasses |= fcPosZero;
+    if (getKnownFPClasses() & fcNegZero)
+      setKnownFPClasses(getKnownFPClasses() | fcPosZero);
 
-    if (KnownFPClasses & fcNegInf)
-      KnownFPClasses |= fcPosInf;
+    if (getKnownFPClasses() & fcNegInf)
+      setKnownFPClasses(getKnownFPClasses() | fcPosInf);
 
-    if (KnownFPClasses & fcNegSubnormal)
-      KnownFPClasses |= fcPosSubnormal;
+    if (getKnownFPClasses() & fcNegSubnormal)
+      setKnownFPClasses(getKnownFPClasses() | fcPosSubnormal);
 
-    if (KnownFPClasses & fcNegNormal)
-      KnownFPClasses |= fcPosNormal;
+    if (getKnownFPClasses() & fcNegNormal)
+      setKnownFPClasses(getKnownFPClasses() | fcPosNormal);
 
     signBitMustBeZero();
   }
@@ -366,27 +370,27 @@ struct KnownFPClass {
 
   /// Assume the sign bit is zero.
   void signBitMustBeZero() {
-    KnownFPClasses &= (fcPositive | fcNan);
+    setKnownFPClasses(getKnownFPClasses() & (fcPositive | fcNan));
     setSignBit(false);
   }
 
   /// Assume the sign bit is one.
   void signBitMustBeOne() {
-    KnownFPClasses &= (fcNegative | fcNan);
+    setKnownFPClasses(getKnownFPClasses() & (fcNegative | fcNan));
     setSignBit(true);
   }
 
   void copysign(const KnownFPClass &Sign) {
     // Don't know anything about the sign of the source. Expand the possible set
     // to its opposite sign pair.
-    if (KnownFPClasses & fcZero)
-      KnownFPClasses |= fcZero;
-    if (KnownFPClasses & fcSubnormal)
-      KnownFPClasses |= fcSubnormal;
-    if (KnownFPClasses & fcNormal)
-      KnownFPClasses |= fcNormal;
-    if (KnownFPClasses & fcInf)
-      KnownFPClasses |= fcInf;
+    if (getKnownFPClasses() & fcZero)
+      setKnownFPClasses(getKnownFPClasses() | fcZero);
+    if (getKnownFPClasses() & fcSubnormal)
+      setKnownFPClasses(getKnownFPClasses() | fcSubnormal);
+    if (getKnownFPClasses() & fcNormal)
+      setKnownFPClasses(getKnownFPClasses() | fcNormal);
+    if (getKnownFPClasses() & fcInf)
+      setKnownFPClasses(getKnownFPClasses() | fcInf);
 
     // Sign bit is exactly preserved even for nans.
     setSignBit(Sign.getSignBit());
@@ -394,10 +398,10 @@ struct KnownFPClass {
     // Clear sign bits based on the input sign mask.
     if (Sign.isKnownNever(fcPositive | fcNan) ||
         (getSignBit() && *getSignBit()))
-      KnownFPClasses &= (fcNegative | fcNan);
+      setKnownFPClasses(getKnownFPClasses() & (fcNegative | fcNan));
     if (Sign.isKnownNever(fcNegative | fcNan) ||
         (getSignBit() && !*getSignBit()))
-      KnownFPClasses &= (fcPositive | fcNan);
+      setKnownFPClasses(getKnownFPClasses() & (fcPositive | fcNan));
   }
 
   static KnownFPClass copysign(const KnownFPClass &KnownMag,

--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -4284,9 +4284,9 @@ static Value *simplifyFCmpInst(CmpPredicate Pred, Value *LHS, Value *RHS,
     auto [ClassVal, ClassTest] = fcmpToClassTest(Pred, *ParentF, LHS, C);
     if (ClassVal) {
       FullKnownClassLHS = computeLHSClass();
-      if ((FullKnownClassLHS->KnownFPClasses & ClassTest) == fcNone)
+      if ((FullKnownClassLHS->getKnownFPClasses() & ClassTest) == fcNone)
         return getFalse(RetTy);
-      if ((FullKnownClassLHS->KnownFPClasses & ~ClassTest) == fcNone)
+      if ((FullKnownClassLHS->getKnownFPClasses() & ~ClassTest) == fcNone)
         return getTrue(RetTy);
     }
   }

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -5186,13 +5186,13 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
   }
 
   if (isa<ConstantAggregateZero>(V)) {
-    Known.KnownFPClasses = fcPosZero;
+    Known.setKnownFPClasses(fcPosZero);
     Known.setSignBit(false);
     return;
   }
 
   if (isa<PoisonValue>(V)) {
-    Known.KnownFPClasses = fcNone;
+    Known.setKnownFPClasses(fcNone);
     Known.setSignBit(false);
     return;
   }
@@ -5201,7 +5201,7 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
   auto *VFVTy = dyn_cast<FixedVectorType>(V->getType());
   const Constant *CV = dyn_cast<Constant>(V);
   if (VFVTy && CV) {
-    Known.KnownFPClasses = fcNone;
+    Known.setKnownFPClasses(fcNone);
     bool SignBitAllZero = true;
     bool SignBitAllOne = true;
 
@@ -5225,7 +5225,7 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
       }
 
       const APFloat &C = CElt->getValueAPF();
-      Known.KnownFPClasses |= C.classify();
+      Known.setKnownFPClasses(Known.getKnownFPClasses() | C.classify());
       if (C.isNegative())
         SignBitAllZero = false;
       else
@@ -5237,7 +5237,7 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
   }
 
   if (const auto *CDS = dyn_cast<ConstantDataSequential>(V)) {
-    Known.KnownFPClasses = fcNone;
+    Known.setKnownFPClasses(fcNone);
     for (size_t I = 0, E = CDS->getNumElements(); I != E; ++I)
       Known |= CDS->getElementAsAPFloat(I).classify();
     return;
@@ -5245,7 +5245,7 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
 
   if (const auto *CA = dyn_cast<ConstantAggregate>(V)) {
     // TODO: Handle complex aggregates
-    Known.KnownFPClasses = fcNone;
+    Known.setKnownFPClasses(fcNone);
     for (const Use &Op : CA->operands()) {
       auto *CFP = dyn_cast<ConstantFP>(Op.get());
       if (!CFP) {
@@ -5274,7 +5274,7 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
   }
 
   KnownFPClass AssumedClasses = computeKnownFPClassFromContext(V, Q);
-  KnownNotFromFlags |= ~AssumedClasses.KnownFPClasses;
+  KnownNotFromFlags |= ~AssumedClasses.getKnownFPClasses();
 
   // We no longer need to find out about these bits from inputs if we can
   // assume this from flags/attributes.
@@ -5726,7 +5726,7 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
 
       const Value *ExpArg = II->getArgOperand(1);
       ConstantRange ExpKnownRange =
-          ((KnownSrc.KnownFPClasses & ExpInfoMask) != fcNone)
+          ((KnownSrc.getKnownFPClasses() & ExpInfoMask) != fcNone)
               ? computeConstantRange(ExpArg, /*ForSigned=*/true, Q, Depth + 1)
               : ConstantRange::getFull(
                     ExpArg->getType()->getScalarSizeInBits());
@@ -6014,7 +6014,7 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
     if (Op->getOperand(0) == Op->getOperand(1) &&
         isGuaranteedNotToBeUndef(Op->getOperand(0), Q.AC, Q.CxtI, Q.DT)) {
       // X / X is always exactly 1.0 or a NaN.
-      Known.KnownFPClasses = fcNan | fcPosNormal;
+      Known.setKnownFPClasses(fcNan | fcPosNormal);
 
       if (!WantNan)
         break;
@@ -6063,7 +6063,7 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
     if (Op->getOperand(0) == Op->getOperand(1) &&
         isGuaranteedNotToBeUndef(Op->getOperand(0), Q.AC, Q.CxtI, Q.DT)) {
       // X % X is always exactly [+-]0.0 or a NaN.
-      Known.KnownFPClasses = fcNan | fcZero;
+      Known.setKnownFPClasses(fcNan | fcZero);
 
       if (!WantNan)
         break;
@@ -6216,7 +6216,7 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
       if (Known.isUnknown())
         break;
     } else {
-      Known.KnownFPClasses = fcNone;
+      Known.setKnownFPClasses(fcNone);
     }
 
     // Do we need anymore elements from Vec?
@@ -6252,7 +6252,7 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
       if (Known.isUnknown())
         break;
     } else {
-      Known.KnownFPClasses = fcNone;
+      Known.setKnownFPClasses(fcNone);
     }
 
     if (!!DemandedRHS) {
@@ -6339,7 +6339,7 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
           Known |= KnownSrc;
         }
 
-        if (Known.KnownFPClasses == fcAllFlags)
+        if (Known.getKnownFPClasses() == fcAllFlags)
           break;
       }
     }
@@ -6454,9 +6454,9 @@ llvm::computeKnownFPClass(const Value *V, const APInt &DemandedElts,
       computeKnownFPClass(V, DemandedElts, InterestedClasses, SQ, Depth);
 
   if (FMF.noNaNs())
-    Result.KnownFPClasses &= ~fcNan;
+    Result.setKnownFPClasses(Result.getKnownFPClasses() & ~fcNan);
   if (FMF.noInfs())
-    Result.KnownFPClasses &= ~fcInf;
+    Result.setKnownFPClasses(Result.getKnownFPClasses() & ~fcInf);
   return Result;
 }
 

--- a/llvm/lib/CodeGen/GlobalISel/GISelValueTracking.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/GISelValueTracking.cpp
@@ -1198,17 +1198,17 @@ void GISelValueTracking::computeKnownFPClass(Register R,
     switch (Cst->getKind()) {
     case GFConstant::GFConstantKind::Scalar: {
       auto APF = Cst->getScalarValue();
-      Known.KnownFPClasses = APF.classify();
+      Known.setKnownFPClasses(APF.classify());
       Known.setSignBit(APF.isNegative());
       break;
     }
     case GFConstant::GFConstantKind::FixedVector: {
-      Known.KnownFPClasses = fcNone;
+      Known.setKnownFPClasses(fcNone);
       bool SignBitAllZero = true;
       bool SignBitAllOne = true;
 
       for (auto C : *Cst) {
-        Known.KnownFPClasses |= C.classify();
+        Known.setKnownFPClasses(Known.getKnownFPClasses() | C.classify());
         if (C.isNegative())
           SignBitAllZero = false;
         else
@@ -1304,11 +1304,11 @@ void GISelValueTracking::computeKnownFPClass(Register R,
     KnownFPClass Known2;
     computeKnownFPClass(LHS, DemandedElts, InterestedClasses & FilterLHS, Known,
                         Depth + 1);
-    Known.KnownFPClasses &= FilterLHS;
+    Known.setKnownFPClasses(Known.getKnownFPClasses() & FilterLHS);
 
     computeKnownFPClass(RHS, DemandedElts, InterestedClasses & FilterRHS,
                         Known2, Depth + 1);
-    Known2.KnownFPClasses &= FilterRHS;
+    Known2.setKnownFPClasses(Known2.getKnownFPClasses() & FilterRHS);
 
     Known |= Known2;
     break;
@@ -1710,7 +1710,7 @@ void GISelValueTracking::computeKnownFPClass(Register R,
     // Can refine inf/zero handling based on the exponent operand.
     const FPClassTest ExpInfoMask = fcZero | fcSubnormal | fcInf;
     KnownBits ExpBits;
-    if ((KnownSrc.KnownFPClasses & ExpInfoMask) != fcNone) {
+    if ((KnownSrc.getKnownFPClasses() & ExpInfoMask) != fcNone) {
       Register ExpReg = MI.getOperand(2).getReg();
       LLT ExpTy = MRI.getType(ExpReg);
       ExpBits = getKnownBits(
@@ -1824,7 +1824,7 @@ void GISelValueTracking::computeKnownFPClass(Register R,
 
     if (LHS == RHS && isGuaranteedNotToBeUndef(LHS, MRI, Depth + 1)) {
       // X / X is always exactly 1.0 or a NaN.
-      Known.KnownFPClasses = fcPosNormal | fcNan;
+      Known.setKnownFPClasses(fcPosNormal | fcNan);
 
       if (!WantNan)
         break;
@@ -1869,7 +1869,7 @@ void GISelValueTracking::computeKnownFPClass(Register R,
 
     if (LHS == RHS && isGuaranteedNotToBeUndef(LHS, MRI, Depth + 1)) {
       // X % X is always exactly [+-]0.0 or a NaN.
-      Known.KnownFPClasses = fcZero | fcNan;
+      Known.setKnownFPClasses(fcZero | fcNan);
 
       if (!WantNan)
         break;
@@ -2077,7 +2077,7 @@ void GISelValueTracking::computeKnownFPClass(Register R,
       if (Known.isUnknown())
         break;
     } else {
-      Known.KnownFPClasses = fcNone;
+      Known.setKnownFPClasses(fcNone);
     }
 
     // Do we need anymore elements from Vec?
@@ -2116,7 +2116,7 @@ void GISelValueTracking::computeKnownFPClass(Register R,
       if (Known.isUnknown())
         break;
     } else {
-      Known.KnownFPClasses = fcNone;
+      Known.setKnownFPClasses(fcNone);
     }
 
     if (!!DemandedRHS) {
@@ -2195,9 +2195,9 @@ KnownFPClass GISelValueTracking::computeKnownFPClass(
       computeKnownFPClass(R, DemandedElts, InterestedClasses, Depth);
 
   if (Flags & MachineInstr::MIFlag::FmNoNans)
-    Result.KnownFPClasses &= ~fcNan;
+    Result.setKnownFPClasses(Result.getKnownFPClasses() & ~fcNan);
   if (Flags & MachineInstr::MIFlag::FmNoInfs)
-    Result.KnownFPClasses &= ~fcInf;
+    Result.setKnownFPClasses(Result.getKnownFPClasses() & ~fcInf);
   return Result;
 }
 

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -16958,16 +16958,16 @@ SDValue DAGCombiner::visitIS_FPCLASS(SDNode *N) {
   KnownFPClass Known = DAG.computeKnownFPClass(Src, Mask);
 
   // All possible classes are within the mask: result is always true.
-  if ((~Mask & Known.KnownFPClasses) == fcNone)
+  if ((~Mask & Known.getKnownFPClasses()) == fcNone)
     return DAG.getBoolConstant(true, DL, VT, Src.getValueType());
 
   // Clear test bits we know must be false from the source value.
   // fp_class (nnan x), qnan|snan|other -> fp_class (nnan x), other
   // fp_class (ninf x), ninf|pinf|other -> fp_class (ninf x), other
-  if ((Mask & Known.KnownFPClasses) != Mask) {
+  if ((Mask & Known.getKnownFPClasses()) != Mask) {
     return DAG.getNode(
         ISD::IS_FPCLASS, DL, VT, Src,
-        DAG.getTargetConstant(Mask & Known.KnownFPClasses, DL, MVT::i32),
+        DAG.getTargetConstant(Mask & Known.getKnownFPClasses(), DL, MVT::i32),
         N->getFlags());
   }
 

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -6182,7 +6182,7 @@ KnownFPClass SelectionDAG::computeKnownFPClass(SDValue Op,
   unsigned Opcode = Op.getOpcode();
   switch (Opcode) {
   case ISD::POISON: {
-    Known.KnownFPClasses = fcNone;
+    Known.setKnownFPClasses(fcNone);
     Known.setSignBit(false);
     break;
   }
@@ -6225,7 +6225,7 @@ KnownFPClass SelectionDAG::computeKnownFPClass(SDValue Op,
                                     Depth + 1);
       } else {
         // Out of bounds index is poison.
-        Known.KnownFPClasses = fcNone;
+        Known.setKnownFPClasses(fcNone);
       }
     } else {
       Known = computeKnownFPClass(Src, InterestedClasses, Depth + 1);
@@ -6273,7 +6273,7 @@ KnownFPClass SelectionDAG::computeKnownFPClass(SDValue Op,
                                 InterestedClasses, Depth + 1);
     FPClassTest AssertedClasses =
         static_cast<FPClassTest>(Op->getConstantOperandVal(1));
-    Known.KnownFPClasses &= ~AssertedClasses;
+    Known.setKnownFPClasses(Known.getKnownFPClasses() & ~AssertedClasses);
     break;
   }
   case ISD::EXTRACT_SUBVECTOR: {

--- a/llvm/lib/Support/KnownFPClass.cpp
+++ b/llvm/lib/Support/KnownFPClass.cpp
@@ -18,7 +18,8 @@
 
 using namespace llvm;
 
-KnownFPClass::KnownFPClass(const APFloat &C) : KnownFPClasses(C.classify()) {
+KnownFPClass::KnownFPClass(const APFloat &C)
+    : KnownFPClassesValue(C.classify()) {
   setSignBit(C.isNegative());
 }
 
@@ -68,7 +69,7 @@ bool KnownFPClass::isKnownNeverLogicalPosZero(DenormalMode Mode) const {
 
 void KnownFPClass::propagateDenormal(const KnownFPClass &Src,
                                      DenormalMode Mode) {
-  KnownFPClasses = Src.KnownFPClasses;
+  setKnownFPClasses(Src.getKnownFPClasses());
   // If we aren't assuming the source can't be a zero, we don't have to check if
   // a denormal input could be flushed.
   if (!Src.isKnownNeverPosZero() && !Src.isKnownNeverNegZero())
@@ -79,17 +80,17 @@ void KnownFPClass::propagateDenormal(const KnownFPClass &Src,
     return;
 
   if (!Src.isKnownNeverPosSubnormal() && Mode != DenormalMode::getIEEE())
-    KnownFPClasses |= fcPosZero;
+    setKnownFPClasses(getKnownFPClasses() | fcPosZero);
 
   if (!Src.isKnownNeverNegSubnormal() && Mode != DenormalMode::getIEEE()) {
     if (Mode != DenormalMode::getPositiveZero())
-      KnownFPClasses |= fcNegZero;
+      setKnownFPClasses(getKnownFPClasses() | fcNegZero);
 
     if (Mode.Input == DenormalMode::PositiveZero ||
         Mode.Output == DenormalMode::PositiveZero ||
         Mode.Input == DenormalMode::Dynamic ||
         Mode.Output == DenormalMode::Dynamic)
-      KnownFPClasses |= fcPosZero;
+      setKnownFPClasses(getKnownFPClasses() | fcPosZero);
   }
 }
 
@@ -110,20 +111,20 @@ KnownFPClass KnownFPClass::minMaxLike(const KnownFPClass &LHS_,
 
   if (Kind == MinMaxKind::maxnum || Kind == MinMaxKind::maximumnum) {
     if (KnownLHS.isKnownNeverNaN())
-      Known.knownNot(orderedStrictlyLess(KnownLHS.KnownFPClasses));
+      Known.knownNot(orderedStrictlyLess(KnownLHS.getKnownFPClasses()));
     if (KnownRHS.isKnownNeverNaN())
-      Known.knownNot(orderedStrictlyLess(KnownRHS.KnownFPClasses));
+      Known.knownNot(orderedStrictlyLess(KnownRHS.getKnownFPClasses()));
   } else if (Kind == MinMaxKind::maximum) {
-    Known.knownNot(orderedStrictlyLess(KnownLHS.KnownFPClasses) |
-                   orderedStrictlyLess(KnownRHS.KnownFPClasses));
+    Known.knownNot(orderedStrictlyLess(KnownLHS.getKnownFPClasses()) |
+                   orderedStrictlyLess(KnownRHS.getKnownFPClasses()));
   } else if (Kind == MinMaxKind::minnum || Kind == MinMaxKind::minimumnum) {
     if (KnownLHS.isKnownNeverNaN())
-      Known.knownNot(orderedStrictlyGreater(KnownLHS.KnownFPClasses));
+      Known.knownNot(orderedStrictlyGreater(KnownLHS.getKnownFPClasses()));
     if (KnownRHS.isKnownNeverNaN())
-      Known.knownNot(orderedStrictlyGreater(KnownRHS.KnownFPClasses));
+      Known.knownNot(orderedStrictlyGreater(KnownRHS.getKnownFPClasses()));
   } else if (Kind == MinMaxKind::minimum) {
-    Known.knownNot(orderedStrictlyGreater(KnownLHS.KnownFPClasses) |
-                   orderedStrictlyGreater(KnownRHS.KnownFPClasses));
+    Known.knownNot(orderedStrictlyGreater(KnownLHS.getKnownFPClasses()) |
+                   orderedStrictlyGreater(KnownRHS.getKnownFPClasses()));
   } else
     llvm_unreachable("unhandled intrinsic");
 
@@ -134,10 +135,10 @@ KnownFPClass KnownFPClass::minMaxLike(const KnownFPClass &LHS_,
   // subtargets on AMDGPU the min/max instructions would not flush the
   // output and return the original value.
   //
-  if ((Known.KnownFPClasses & fcZero) != fcNone &&
+  if ((Known.getKnownFPClasses() & fcZero) != fcNone &&
       !Known.isKnownNeverSubnormal()) {
     if (Mode != DenormalMode::getIEEE())
-      Known.KnownFPClasses |= fcZero;
+      Known.setKnownFPClasses(Known.getKnownFPClasses() | fcZero);
   }
 
   if (Known.isKnownNeverNaN()) {
@@ -184,7 +185,7 @@ KnownFPClass KnownFPClass::canonicalize(const KnownFPClass &KnownSrc,
 
   // Canonicalize may flush denormals to zero, so we have to consider the
   // denormal mode to preserve known-not-0 knowledge.
-  Known.KnownFPClasses = KnownSrc.KnownFPClasses | fcZero | fcQNan;
+  Known.setKnownFPClasses(KnownSrc.getKnownFPClasses() | fcZero | fcQNan);
 
   // Stronger version of propagateNaN
   // Canonicalize is guaranteed to quiet signaling nans.
@@ -297,7 +298,7 @@ KnownFPClass KnownFPClass::bitcast(const fltSemantics &FltSemantics,
 
 KnownBits KnownFPClass::toKnownBits(const fltSemantics &FltSemantics) const {
   KnownBits Known(FltSemantics.sizeInBits);
-  const FPClassTest FPClasses = KnownFPClasses;
+  const FPClassTest FPClasses = getKnownFPClasses();
 
   // Return unknown if poison.
   if (FPClasses == fcNone)
@@ -813,10 +814,10 @@ KnownFPClass KnownFPClass::fpext(const KnownFPClass &KnownSrc,
 
   // All subnormal inputs should be in the normal range in the result type.
   if (APFloat::isRepresentableAsNormalIn(SrcTy, DstTy)) {
-    if (Known.KnownFPClasses & fcPosSubnormal)
-      Known.KnownFPClasses |= fcPosNormal;
-    if (Known.KnownFPClasses & fcNegSubnormal)
-      Known.KnownFPClasses |= fcNegNormal;
+    if (Known.getKnownFPClasses() & fcPosSubnormal)
+      Known.setKnownFPClasses(Known.getKnownFPClasses() | fcPosNormal);
+    if (Known.getKnownFPClasses() & fcNegSubnormal)
+      Known.setKnownFPClasses(Known.getKnownFPClasses() | fcNegNormal);
     Known.knownNot(fcSubnormal);
   }
 

--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -10530,7 +10530,7 @@ struct AANoFPClassImpl : AANoFPClass {
       SimplifyQuery Q(DL, TLI, DT, AC, CtxI);
 
       KnownFPClass KnownFPClass = computeKnownFPClass(&V, fcAllFlags, Q);
-      addKnownBits(~KnownFPClass.KnownFPClasses);
+      addKnownBits(~KnownFPClass.getKnownFPClasses());
     }
 
     if (CtxI)

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -1201,9 +1201,9 @@ Instruction *InstCombinerImpl::foldIntrinsicIsFPClass(IntrinsicInst &II) {
   // Clear test bits we know must be false from the source value.
   // fp_class (nnan x), qnan|snan|other -> fp_class (nnan x), other
   // fp_class (ninf x), ninf|pinf|other -> fp_class (ninf x), other
-  if ((Mask & Known.KnownFPClasses) != Mask) {
+  if ((Mask & Known.getKnownFPClasses()) != Mask) {
     II.setArgOperand(
-        1, ConstantInt::get(Src1->getType(), Mask & Known.KnownFPClasses));
+        1, ConstantInt::get(Src1->getType(), Mask & Known.getKnownFPClasses()));
     return &II;
   }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -2183,7 +2183,7 @@ static Value *simplifyDemandedFPClassResult(Instruction *FPOp,
                                             FPClassTest DemandedMask,
                                             KnownFPClass &Known,
                                             ArrayRef<KnownFPClass> KnownSrcs) {
-  FPClassTest ValidResults = DemandedMask & Known.KnownFPClasses;
+  FPClassTest ValidResults = DemandedMask & Known.getKnownFPClasses();
   Constant *SingleVal = getFPClassConstant(FPOp->getType(), ValidResults,
                                            /*IsCanonicalizing=*/true);
   if (SingleVal)
@@ -2266,13 +2266,15 @@ simplifyDemandedFPClassMinMax(KnownFPClass &Known, Intrinsic::ID IID,
 
     // If one operand is known greater than the other, it must be that
     // operand unless the other is a nan.
-    if (cannotOrderStrictlyLess(KnownLHS.KnownFPClasses,
-                                KnownRHS.KnownFPClasses, OrderedZeroSign) &&
+    if (cannotOrderStrictlyLess(KnownLHS.getKnownFPClasses(),
+                                KnownRHS.getKnownFPClasses(),
+                                OrderedZeroSign) &&
         KnownRHS.isKnownNever(fcNan))
       return CI->getArgOperand(0);
 
-    if (cannotOrderStrictlyGreater(KnownLHS.KnownFPClasses,
-                                   KnownRHS.KnownFPClasses, OrderedZeroSign) &&
+    if (cannotOrderStrictlyGreater(KnownLHS.getKnownFPClasses(),
+                                   KnownRHS.getKnownFPClasses(),
+                                   OrderedZeroSign) &&
         KnownLHS.isKnownNever(fcNan))
       return CI->getArgOperand(1);
 
@@ -2283,13 +2285,15 @@ simplifyDemandedFPClassMinMax(KnownFPClass &Known, Intrinsic::ID IID,
 
     // If one operand is known less than the other, it must be that operand
     // unless the other is a nan.
-    if (cannotOrderStrictlyGreater(KnownLHS.KnownFPClasses,
-                                   KnownRHS.KnownFPClasses, OrderedZeroSign) &&
+    if (cannotOrderStrictlyGreater(KnownLHS.getKnownFPClasses(),
+                                   KnownRHS.getKnownFPClasses(),
+                                   OrderedZeroSign) &&
         KnownRHS.isKnownNever(fcNan))
       return CI->getArgOperand(0);
 
-    if (cannotOrderStrictlyLess(KnownLHS.KnownFPClasses,
-                                KnownRHS.KnownFPClasses, OrderedZeroSign) &&
+    if (cannotOrderStrictlyLess(KnownLHS.getKnownFPClasses(),
+                                KnownRHS.getKnownFPClasses(),
+                                OrderedZeroSign) &&
         KnownLHS.isKnownNever(fcNan))
       return CI->getArgOperand(1);
 
@@ -2300,13 +2304,15 @@ simplifyDemandedFPClassMinMax(KnownFPClass &Known, Intrinsic::ID IID,
     OpKind = IID == Intrinsic::maxnum ? KnownFPClass::MinMaxKind::maxnum
                                       : KnownFPClass::MinMaxKind::maximumnum;
 
-    if (cannotOrderStrictlyLess(KnownLHS.KnownFPClasses,
-                                KnownRHS.KnownFPClasses, OrderedZeroSign) &&
+    if (cannotOrderStrictlyLess(KnownLHS.getKnownFPClasses(),
+                                KnownRHS.getKnownFPClasses(),
+                                OrderedZeroSign) &&
         KnownLHS.isKnownNever(fcNan))
       return CI->getArgOperand(0);
 
-    if (cannotOrderStrictlyGreater(KnownLHS.KnownFPClasses,
-                                   KnownRHS.KnownFPClasses, OrderedZeroSign) &&
+    if (cannotOrderStrictlyGreater(KnownLHS.getKnownFPClasses(),
+                                   KnownRHS.getKnownFPClasses(),
+                                   OrderedZeroSign) &&
         KnownRHS.isKnownNever(fcNan))
       return CI->getArgOperand(1);
 
@@ -2317,13 +2323,15 @@ simplifyDemandedFPClassMinMax(KnownFPClass &Known, Intrinsic::ID IID,
     OpKind = IID == Intrinsic::minnum ? KnownFPClass::MinMaxKind::minnum
                                       : KnownFPClass::MinMaxKind::minimumnum;
 
-    if (cannotOrderStrictlyGreater(KnownLHS.KnownFPClasses,
-                                   KnownRHS.KnownFPClasses, OrderedZeroSign) &&
+    if (cannotOrderStrictlyGreater(KnownLHS.getKnownFPClasses(),
+                                   KnownRHS.getKnownFPClasses(),
+                                   OrderedZeroSign) &&
         KnownLHS.isKnownNever(fcNan))
       return CI->getArgOperand(0);
 
-    if (cannotOrderStrictlyLess(KnownLHS.KnownFPClasses,
-                                KnownRHS.KnownFPClasses, OrderedZeroSign) &&
+    if (cannotOrderStrictlyLess(KnownLHS.getKnownFPClasses(),
+                                KnownRHS.getKnownFPClasses(),
+                                OrderedZeroSign) &&
         KnownRHS.isKnownNever(fcNan))
       return CI->getArgOperand(1);
 
@@ -2338,7 +2346,7 @@ simplifyDemandedFPClassMinMax(KnownFPClass &Known, Intrinsic::ID IID,
   Known = KnownFPClass::minMaxLike(KnownLHS, KnownRHS, OpKind, Mode);
   Known.knownNot(~DemandedMask);
 
-  return getFPClassConstant(CI->getType(), Known.KnownFPClasses,
+  return getFPClassConstant(CI->getType(), Known.getKnownFPClasses(),
                             /*IsCanonicalizing=*/true);
 }
 
@@ -2516,7 +2524,7 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
 
     Known.knownNot(~DemandedMask);
 
-    if (Constant *SingleVal = getFPClassConstant(VTy, Known.KnownFPClasses,
+    if (Constant *SingleVal = getFPClassConstant(VTy, Known.getKnownFPClasses(),
                                                  /*IsCanonicalizing=*/true))
       return SingleVal;
 
@@ -2535,7 +2543,7 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
       return I->getOperand(0);
 
     FastMathFlags InferredFMF = inferFastMathValueFlags(
-        FMF, Known.KnownFPClasses, {KnownLHS, KnownRHS});
+        FMF, Known.getKnownFPClasses(), {KnownLHS, KnownRHS});
     if (InferredFMF != FMF) {
       I->setFastMathFlags(InferredFMF);
       return I;
@@ -2586,7 +2594,7 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
       Known = KnownFPClass::square(KnownLHS, Mode);
       Known.knownNot(~DemandedMask);
 
-      if (Constant *Folded = getFPClassConstant(VTy, Known.KnownFPClasses,
+      if (Constant *Folded = getFPClassConstant(VTy, Known.getKnownFPClasses(),
                                                 /*IsCanonicalizing=*/true))
         return Folded;
 
@@ -2704,12 +2712,12 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
     Known = KnownFPClass::fmul(KnownLHS, KnownRHS, Mode);
     Known.knownNot(~DemandedMask);
 
-    if (Constant *SingleVal = getFPClassConstant(VTy, Known.KnownFPClasses,
+    if (Constant *SingleVal = getFPClassConstant(VTy, Known.getKnownFPClasses(),
                                                  /*IsCanonicalizing=*/true))
       return SingleVal;
 
     FastMathFlags InferredFMF = inferFastMathValueFlags(
-        FMF, Known.KnownFPClasses, {KnownLHS, KnownRHS});
+        FMF, Known.getKnownFPClasses(), {KnownLHS, KnownRHS});
     if (InferredFMF != FMF) {
       I->setFastMathFlags(InferredFMF);
       return I;
@@ -2845,12 +2853,12 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
     Known = KnownFPClass::fdiv(KnownLHS, KnownRHS, Mode);
     Known.knownNot(~DemandedMask);
 
-    if (Constant *SingleVal = getFPClassConstant(VTy, Known.KnownFPClasses,
+    if (Constant *SingleVal = getFPClassConstant(VTy, Known.getKnownFPClasses(),
                                                  /*IsCanonicalizing=*/true))
       return SingleVal;
 
     FastMathFlags InferredFMF = inferFastMathValueFlags(
-        FMF, Known.KnownFPClasses, {KnownLHS, KnownRHS});
+        FMF, Known.getKnownFPClasses(), {KnownLHS, KnownRHS});
     if (InferredFMF != FMF) {
       I->setFastMathFlags(InferredFMF);
       return I;
@@ -3027,7 +3035,7 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
 
       auto *FPOp = cast<FPMathOperator>(CI);
 
-      FPClassTest ValidResults = DemandedMask & Known.KnownFPClasses;
+      FPClassTest ValidResults = DemandedMask & Known.getKnownFPClasses();
       FastMathFlags InferredFMF = FMF;
 
       if (!FMF.noSignedZeros()) {
@@ -3238,7 +3246,7 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
       Known = KnownFPClass::sqrt(KnownSrc, Mode);
       Known.knownNot(~DemandedMask);
 
-      if (Known.KnownFPClasses == fcZero) {
+      if (Known.getKnownFPClasses() == fcZero) {
         if (FMF.noSignedZeros())
           return ConstantFP::getZero(VTy);
         IRBuilderBase::InsertPointGuard Guard(Builder);
@@ -3344,8 +3352,9 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
 
       Known.knownNot(~DemandedMask);
 
-      if (Constant *SingleVal = getFPClassConstant(VTy, Known.KnownFPClasses,
-                                                   /*IsCanonicalizing=*/true))
+      if (Constant *SingleVal =
+              getFPClassConstant(VTy, Known.getKnownFPClasses(),
+                                 /*IsCanonicalizing=*/true))
         return SingleVal;
 
       if ((IID == Intrinsic::trunc || IsRoundNearestOrTrunc) &&
@@ -3360,7 +3369,7 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
       }
 
       FastMathFlags InferredFMF =
-          inferFastMathValueFlags(FMF, Known.KnownFPClasses, KnownSrc);
+          inferFastMathValueFlags(FMF, Known.getKnownFPClasses(), KnownSrc);
       if (InferredFMF != FMF) {
         CI->dropUBImplyingAttrsAndMetadata();
         CI->setFastMathFlags(InferredFMF);
@@ -3416,7 +3425,8 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
         Known = KnownFPClass::canonicalize(KnownSrc, Mode);
         Known.knownNot(~DemandedMask);
 
-        if (Constant *SingleVal = getFPClassConstant(VTy, Known.KnownFPClasses))
+        if (Constant *SingleVal =
+                getFPClassConstant(VTy, Known.getKnownFPClasses()))
           return SingleVal;
 
         // For IEEE handling, there is only a bit change for nan inputs, so we
@@ -3429,7 +3439,7 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
           return CI->getArgOperand(0);
 
         FastMathFlags InferredFMF =
-            inferFastMathValueFlags(FMF, Known.KnownFPClasses, KnownSrc);
+            inferFastMathValueFlags(FMF, Known.getKnownFPClasses(), KnownSrc);
         if (InferredFMF != FMF) {
           CI->dropUBImplyingAttrsAndMetadata();
           CI->setFastMathFlags(InferredFMF);
@@ -3536,10 +3546,10 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
           DenormalMode Mode = F.getDenormalMode(EltTy->getFltSemantics());
 
           Known = KnownFPClass::frexp_mant(KnownSrc, Mode);
-          Known.KnownFPClasses &= DemandedMask;
+          Known.setKnownFPClasses(Known.getKnownFPClasses() & DemandedMask);
 
           if (Constant *SingleVal =
-                  getFPClassConstant(VTy, Known.KnownFPClasses,
+                  getFPClassConstant(VTy, Known.getKnownFPClasses(),
                                      /*IsCanonicalizing=*/true))
             return SingleVal;
 
@@ -3607,7 +3617,7 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
     break;
   }
 
-  return getFPClassConstant(VTy, Known.KnownFPClasses);
+  return getFPClassConstant(VTy, Known.getKnownFPClasses());
 }
 
 /// Helper routine of SimplifyDemandedUseFPClass. It computes Known
@@ -3745,7 +3755,7 @@ Value *InstCombinerImpl::SimplifyMultipleUseDemandedFPClass(
     break;
   }
 
-  return getFPClassConstant(I->getType(), Known.KnownFPClasses);
+  return getFPClassConstant(I->getType(), Known.getKnownFPClasses());
 }
 
 bool InstCombinerImpl::SimplifyDemandedFPClass(Instruction *I, unsigned OpNo,
@@ -3771,7 +3781,7 @@ bool InstCombinerImpl::SimplifyDemandedFPClass(Instruction *I, unsigned OpNo,
     Known = computeKnownFPClass(V, fcAllFlags, SQ, Depth);
     Known.knownNot(~DemandedMask);
 
-    if (Known.KnownFPClasses == fcNone) {
+    if (Known.getKnownFPClasses() == fcNone) {
       if (isa<PoisonValue>(V))
         return false;
       replaceUse(U, PoisonValue::get(VTy));
@@ -3784,7 +3794,7 @@ bool InstCombinerImpl::SimplifyDemandedFPClass(Instruction *I, unsigned OpNo,
     if (isa<Constant>(V))
       return false;
 
-    Value *FoldedToConst = getFPClassConstant(VTy, Known.KnownFPClasses);
+    Value *FoldedToConst = getFPClassConstant(VTy, Known.getKnownFPClasses());
     if (!FoldedToConst || FoldedToConst == V)
       return false;
 

--- a/llvm/unittests/Analysis/ValueTrackingTest.cpp
+++ b/llvm/unittests/Analysis/ValueTrackingTest.cpp
@@ -126,7 +126,7 @@ protected:
       TestVal = A;
 
     KnownFPClass Known = computeKnownFPClass(TestVal, M->getDataLayout());
-    EXPECT_EQ(KnownTrue, Known.KnownFPClasses);
+    EXPECT_EQ(KnownTrue, Known.getKnownFPClasses());
     EXPECT_EQ(SignBitKnown, Known.getSignBit());
   }
 };
@@ -1917,7 +1917,8 @@ TEST_F(ComputeKnownFPClassTest, PowUseRHSToRuleOutNegativeResults) {
                 "}\n");
 
   KnownFPClass Known = computeKnownFPClass(A, M->getDataLayout(), fcNegative);
-  EXPECT_EQ(~(fcNegNormal | fcNegSubnormal | fcNegZero), Known.KnownFPClasses);
+  EXPECT_EQ(~(fcNegNormal | fcNegSubnormal | fcNegZero),
+            Known.getKnownFPClasses());
 }
 
 TEST_F(ComputeKnownFPClassTest, PowiInfFirst) {
@@ -2008,7 +2009,7 @@ TEST_F(ComputeKnownFPClassTest, Atan2DemandXSign) {
   // requires us to pass more than just InterestedClasses, which is the purpose
   // of this test.
   KnownFPClass Known = computeKnownFPClass(A, M->getDataLayout(), fcPosZero);
-  EXPECT_EQ(fcNan | fcNormal, Known.KnownFPClasses);
+  EXPECT_EQ(fcNan | fcNormal, Known.getKnownFPClasses());
 }
 
 TEST_F(ComputeKnownFPClassTest, Phi) {
@@ -2354,13 +2355,13 @@ TEST_F(ComputeKnownFPClassTest, SqrtNszSignBit) {
     KnownFPClass UseInstrInfo =
         computeKnownFPClass(A, M->getDataLayout(), fcAllFlags, nullptr, nullptr,
                             nullptr, nullptr, /*UseInstrInfo=*/true);
-    EXPECT_EQ(SqrtMask, UseInstrInfo.KnownFPClasses);
+    EXPECT_EQ(SqrtMask, UseInstrInfo.getKnownFPClasses());
     EXPECT_EQ(std::nullopt, UseInstrInfo.getSignBit());
 
     KnownFPClass NoUseInstrInfo =
         computeKnownFPClass(A, M->getDataLayout(), fcAllFlags, nullptr, nullptr,
                             nullptr, nullptr, /*UseInstrInfo=*/false);
-    EXPECT_EQ(SqrtMask, NoUseInstrInfo.KnownFPClasses);
+    EXPECT_EQ(SqrtMask, NoUseInstrInfo.getKnownFPClasses());
     EXPECT_EQ(std::nullopt, NoUseInstrInfo.getSignBit());
   }
 
@@ -2368,13 +2369,13 @@ TEST_F(ComputeKnownFPClassTest, SqrtNszSignBit) {
     KnownFPClass UseInstrInfoNSZ =
         computeKnownFPClass(A2, M->getDataLayout(), fcAllFlags, nullptr,
                             nullptr, nullptr, nullptr, /*UseInstrInfo=*/true);
-    EXPECT_EQ(NszSqrtMask, UseInstrInfoNSZ.KnownFPClasses);
+    EXPECT_EQ(NszSqrtMask, UseInstrInfoNSZ.getKnownFPClasses());
     EXPECT_EQ(std::nullopt, UseInstrInfoNSZ.getSignBit());
 
     KnownFPClass NoUseInstrInfoNSZ =
         computeKnownFPClass(A2, M->getDataLayout(), fcAllFlags, nullptr,
                             nullptr, nullptr, nullptr, /*UseInstrInfo=*/false);
-    EXPECT_EQ(SqrtMask, NoUseInstrInfoNSZ.KnownFPClasses);
+    EXPECT_EQ(SqrtMask, NoUseInstrInfoNSZ.getKnownFPClasses());
     EXPECT_EQ(std::nullopt, NoUseInstrInfoNSZ.getSignBit());
   }
 
@@ -2383,14 +2384,14 @@ TEST_F(ComputeKnownFPClassTest, SqrtNszSignBit) {
         computeKnownFPClass(A3, M->getDataLayout(), fcAllFlags, nullptr,
                             nullptr, nullptr, nullptr, /*UseInstrInfo=*/true);
     EXPECT_EQ(fcPosInf | fcPosNormal | fcZero | fcQNan,
-              UseInstrInfoNoNan.KnownFPClasses);
+              UseInstrInfoNoNan.getKnownFPClasses());
     EXPECT_EQ(std::nullopt, UseInstrInfoNoNan.getSignBit());
 
     KnownFPClass NoUseInstrInfoNoNan =
         computeKnownFPClass(A3, M->getDataLayout(), fcAllFlags, nullptr,
                             nullptr, nullptr, nullptr, /*UseInstrInfo=*/false);
     EXPECT_EQ(fcPosNormal | fcPosInf | fcZero | fcQNan,
-              NoUseInstrInfoNoNan.KnownFPClasses);
+              NoUseInstrInfoNoNan.getKnownFPClasses());
     EXPECT_EQ(std::nullopt, NoUseInstrInfoNoNan.getSignBit());
   }
 
@@ -2399,14 +2400,14 @@ TEST_F(ComputeKnownFPClassTest, SqrtNszSignBit) {
         computeKnownFPClass(A4, M->getDataLayout(), fcAllFlags, nullptr,
                             nullptr, nullptr, nullptr, /*UseInstrInfo=*/true);
     EXPECT_EQ(fcPosInf | fcPosNormal | fcPosZero | fcQNan,
-              UseInstrInfoNSZNoNan.KnownFPClasses);
+              UseInstrInfoNSZNoNan.getKnownFPClasses());
     EXPECT_EQ(std::nullopt, UseInstrInfoNSZNoNan.getSignBit());
 
     KnownFPClass NoUseInstrInfoNSZNoNan =
         computeKnownFPClass(A4, M->getDataLayout(), fcAllFlags, nullptr,
                             nullptr, nullptr, nullptr, /*UseInstrInfo=*/false);
     EXPECT_EQ(fcPosInf | fcPosNormal | fcZero | fcQNan,
-              NoUseInstrInfoNSZNoNan.KnownFPClasses);
+              NoUseInstrInfoNSZNoNan.getKnownFPClasses());
     EXPECT_EQ(std::nullopt, NoUseInstrInfoNSZNoNan.getSignBit());
   }
 }
@@ -2425,7 +2426,7 @@ TEST_F(ComputeKnownFPClassTest, Constants) {
     KnownFPClass ConstAggZero = computeKnownFPClass(
         ConstantAggregateZero::get(V4F32), M->getDataLayout(), fcAllFlags);
 
-    EXPECT_EQ(fcPosZero, ConstAggZero.KnownFPClasses);
+    EXPECT_EQ(fcPosZero, ConstAggZero.getKnownFPClasses());
     ASSERT_TRUE(ConstAggZero.getSignBit());
     EXPECT_FALSE(*ConstAggZero.getSignBit());
   }
@@ -2433,14 +2434,14 @@ TEST_F(ComputeKnownFPClassTest, Constants) {
   {
     KnownFPClass Undef = computeKnownFPClass(UndefValue::get(F32),
                                              M->getDataLayout(), fcAllFlags);
-    EXPECT_EQ(fcAllFlags, Undef.KnownFPClasses);
+    EXPECT_EQ(fcAllFlags, Undef.getKnownFPClasses());
     EXPECT_FALSE(Undef.getSignBit());
   }
 
   {
     KnownFPClass Poison = computeKnownFPClass(PoisonValue::get(F32),
                                               M->getDataLayout(), fcAllFlags);
-    EXPECT_EQ(fcNone, Poison.KnownFPClasses);
+    EXPECT_EQ(fcNone, Poison.getKnownFPClasses());
     ASSERT_TRUE(Poison.getSignBit());
     EXPECT_FALSE(*Poison.getSignBit());
   }
@@ -2453,7 +2454,7 @@ TEST_F(ComputeKnownFPClassTest, Constants) {
     KnownFPClass PartiallyPoison =
         computeKnownFPClass(ConstantVector::get({ZeroF32, PoisonF32}),
                             M->getDataLayout(), fcAllFlags);
-    EXPECT_EQ(fcPosZero, PartiallyPoison.KnownFPClasses);
+    EXPECT_EQ(fcPosZero, PartiallyPoison.getKnownFPClasses());
     ASSERT_TRUE(PartiallyPoison.getSignBit());
     EXPECT_FALSE(*PartiallyPoison.getSignBit());
   }
@@ -2466,7 +2467,7 @@ TEST_F(ComputeKnownFPClassTest, Constants) {
     KnownFPClass PartiallyPoison =
         computeKnownFPClass(ConstantVector::get({NegZeroF32, PoisonF32}),
                             M->getDataLayout(), fcAllFlags);
-    EXPECT_EQ(fcNegZero, PartiallyPoison.KnownFPClasses);
+    EXPECT_EQ(fcNegZero, PartiallyPoison.getKnownFPClasses());
     ASSERT_TRUE(PartiallyPoison.getSignBit());
     EXPECT_TRUE(*PartiallyPoison.getSignBit());
   }
@@ -2479,7 +2480,7 @@ TEST_F(ComputeKnownFPClassTest, Constants) {
     KnownFPClass PartiallyPoison =
         computeKnownFPClass(ConstantVector::get({PoisonF32, NegZeroF32}),
                             M->getDataLayout(), fcAllFlags);
-    EXPECT_EQ(fcNegZero, PartiallyPoison.KnownFPClasses);
+    EXPECT_EQ(fcNegZero, PartiallyPoison.getKnownFPClasses());
     EXPECT_TRUE(PartiallyPoison.getSignBit());
   }
 }

--- a/llvm/unittests/CodeGen/GlobalISel/KnownFPClassTest.cpp
+++ b/llvm/unittests/CodeGen/GlobalISel/KnownFPClassTest.cpp
@@ -27,7 +27,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCstPosZero) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPosZero, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosZero, Known.getKnownFPClasses());
   EXPECT_EQ(false, Known.getSignBit());
 }
 
@@ -45,7 +45,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCstNegZero) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcNegZero, Known.KnownFPClasses);
+  EXPECT_EQ(fcNegZero, Known.getKnownFPClasses());
   EXPECT_EQ(true, Known.getSignBit());
 }
 
@@ -67,7 +67,7 @@ TEST_F(AArch64GISelMITest, TestFPClassUndef) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcAllFlags, Known.KnownFPClasses);
+  EXPECT_EQ(fcAllFlags, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -92,7 +92,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCstVecNegZero) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcNegZero, Known.KnownFPClasses);
+  EXPECT_EQ(fcNegZero, Known.getKnownFPClasses());
   EXPECT_EQ(true, Known.getSignBit());
 }
 
@@ -115,7 +115,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCstZeroFPExt) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPosZero, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosZero, Known.getKnownFPClasses());
   EXPECT_EQ(false, Known.getSignBit());
 }
 
@@ -141,7 +141,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCstVecZeroFPExt) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPosZero, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosZero, Known.getKnownFPClasses());
   EXPECT_EQ(false, Known.getSignBit());
 }
 
@@ -164,7 +164,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCstZeroFPTrunc) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPosFinite | fcNegZero, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosFinite | fcNegZero, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -190,7 +190,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCstVecZeroFPTrunc) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPosFinite | fcNegZero, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosFinite | fcNegZero, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -216,7 +216,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSelectPos0) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPosZero, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosZero, Known.getKnownFPClasses());
   EXPECT_EQ(false, Known.getSignBit());
 }
 
@@ -242,7 +242,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSelectNeg0) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcNegZero, Known.KnownFPClasses);
+  EXPECT_EQ(fcNegZero, Known.getKnownFPClasses());
   EXPECT_EQ(true, Known.getSignBit());
 }
 
@@ -268,7 +268,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSelectPosOrNeg0) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcZero, Known.KnownFPClasses);
+  EXPECT_EQ(fcZero, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -294,7 +294,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSelectPosInf) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPosInf, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosInf, Known.getKnownFPClasses());
   EXPECT_EQ(false, Known.getSignBit());
 }
 
@@ -320,7 +320,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSelectNegInf) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcNegInf, Known.KnownFPClasses);
+  EXPECT_EQ(fcNegInf, Known.getKnownFPClasses());
   EXPECT_EQ(true, Known.getSignBit());
 }
 
@@ -346,7 +346,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSelectPosOrNegInf) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcInf, Known.KnownFPClasses);
+  EXPECT_EQ(fcInf, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -372,7 +372,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSelectNNaN) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(~fcNan, Known.KnownFPClasses);
+  EXPECT_EQ(~fcNan, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -398,7 +398,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSelectNInf) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(~fcInf, Known.KnownFPClasses);
+  EXPECT_EQ(~fcInf, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -424,7 +424,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSelectNNaNNInf) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(~(fcNan | fcInf), Known.KnownFPClasses);
+  EXPECT_EQ(~(fcNan | fcInf), Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -448,7 +448,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFNegNInf) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(~fcInf, Known.KnownFPClasses);
+  EXPECT_EQ(~fcInf, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -472,7 +472,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFabsUnknown) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPositive | fcNan, Known.KnownFPClasses);
+  EXPECT_EQ(fcPositive | fcNan, Known.getKnownFPClasses());
   EXPECT_EQ(false, Known.getSignBit());
 }
 
@@ -496,7 +496,7 @@ TEST_F(AArch64GISelMITest, TestFPClassVecFabsUnknown) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPositive | fcNan, Known.KnownFPClasses);
+  EXPECT_EQ(fcPositive | fcNan, Known.getKnownFPClasses());
   EXPECT_EQ(false, Known.getSignBit());
 }
 
@@ -521,7 +521,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFnegFabs) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcNegative | fcNan, Known.KnownFPClasses);
+  EXPECT_EQ(fcNegative | fcNan, Known.getKnownFPClasses());
   EXPECT_EQ(true, Known.getSignBit());
 }
 
@@ -546,7 +546,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFnegFabsNInf) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcNegFinite | fcNan, Known.KnownFPClasses);
+  EXPECT_EQ(fcNegFinite | fcNan, Known.getKnownFPClasses());
   EXPECT_EQ(true, Known.getSignBit());
 }
 
@@ -571,7 +571,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFnegFabsNNan) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcNegative, Known.KnownFPClasses);
+  EXPECT_EQ(fcNegative, Known.getKnownFPClasses());
   EXPECT_EQ(true, Known.getSignBit());
 }
 
@@ -597,7 +597,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCopySignNNanSrc0) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(~fcNan, Known.KnownFPClasses);
+  EXPECT_EQ(~fcNan, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -623,7 +623,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCopySignNInfSrc0_NegSign) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcNan | fcNegZero | fcNegNormal, Known.KnownFPClasses);
+  EXPECT_EQ(fcNan | fcNegZero | fcNegNormal, Known.getKnownFPClasses());
   EXPECT_EQ(true, Known.getSignBit());
 }
 
@@ -649,7 +649,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCopySignNInfSrc0_PosSign) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcNan | fcPosZero | fcPosNormal, Known.KnownFPClasses);
+  EXPECT_EQ(fcNan | fcPosZero | fcPosNormal, Known.getKnownFPClasses());
   EXPECT_EQ(false, Known.getSignBit());
 }
 
@@ -673,7 +673,7 @@ TEST_F(AArch64GISelMITest, TestFPClassUIToFP) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPosZero | fcPosNormal, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosZero | fcPosNormal, Known.getKnownFPClasses());
   EXPECT_EQ(false, Known.getSignBit());
 }
 
@@ -697,7 +697,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSIToFP) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPosNormal | fcNegNormal | fcPosZero, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosNormal | fcNegNormal | fcPosZero, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -722,7 +722,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFAdd) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcAllFlags, Known.KnownFPClasses);
+  EXPECT_EQ(fcAllFlags, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -747,7 +747,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFAdd_Zero) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcAllFlags & ~fcNegZero, Known.KnownFPClasses);
+  EXPECT_EQ(fcAllFlags & ~fcNegZero, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -772,7 +772,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFAdd_NegZero) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcAllFlags, Known.KnownFPClasses);
+  EXPECT_EQ(fcAllFlags, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -797,7 +797,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFstrictAdd_Zero) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcAllFlags & ~fcNegZero, Known.KnownFPClasses);
+  EXPECT_EQ(fcAllFlags & ~fcNegZero, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -822,7 +822,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFMul) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPositive | fcNan, Known.KnownFPClasses);
+  EXPECT_EQ(fcPositive | fcNan, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -848,7 +848,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFMulZero) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPosZero, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosZero, Known.getKnownFPClasses());
   EXPECT_EQ(false, Known.getSignBit());
 }
 
@@ -874,7 +874,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFLogNeg) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcNan | fcNegInf | fcPosZero | fcNormal, Known.KnownFPClasses);
+  EXPECT_EQ(fcNan | fcNegInf | fcPosZero | fcNormal, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -897,7 +897,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFLogPosZero) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcNegInf | fcPosZero | fcNormal, Known.KnownFPClasses);
+  EXPECT_EQ(fcNegInf | fcPosZero | fcNormal, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -920,7 +920,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFLogNegZero) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcNegInf | fcPosZero | fcNormal, Known.KnownFPClasses);
+  EXPECT_EQ(fcNegInf | fcPosZero | fcNormal, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -945,7 +945,7 @@ TEST_F(AArch64GISelMITest, TestFPClassCopy) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(~fcNegative, Known.KnownFPClasses);
+  EXPECT_EQ(~fcNegative, Known.getKnownFPClasses());
   EXPECT_EQ(false, Known.getSignBit());
 }
 
@@ -971,7 +971,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSelectIsFPClass) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcZero, Known.KnownFPClasses);
+  EXPECT_EQ(fcZero, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -997,7 +997,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFLDExp) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPositive | fcNan, Known.KnownFPClasses);
+  EXPECT_EQ(fcPositive | fcNan, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -1022,7 +1022,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFPowPos) {
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPositive | fcNan, Known.KnownFPClasses);
+  EXPECT_EQ(fcPositive | fcNan, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
   EXPECT_TRUE(Info.isKnownNeverNaN(SrcReg, true));
 }
@@ -1049,7 +1049,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFPowPosNNaN) {
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPositive, Known.KnownFPClasses);
+  EXPECT_EQ(fcPositive, Known.getKnownFPClasses());
   EXPECT_EQ(false, Known.getSignBit());
 }
 
@@ -1074,7 +1074,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFPowIEvenExp) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPositive | fcNan, Known.KnownFPClasses);
+  EXPECT_EQ(fcPositive | fcNan, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -1100,7 +1100,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFPowIPos) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPositive, Known.KnownFPClasses);
+  EXPECT_EQ(fcPositive, Known.getKnownFPClasses());
   EXPECT_EQ(false, Known.getSignBit());
 }
 
@@ -1140,7 +1140,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFPowIInf) {
   Register SrcReg0 = FinalCopy0->getOperand(1).getReg();
   KnownFPClass Known0 = Info.computeKnownFPClass(SrcReg0, fcAllFlags);
   KnownFPClass KnownInf0 = Info.computeKnownFPClass(SrcReg0, fcInf);
-  EXPECT_EQ(~fcInf, Known0.KnownFPClasses);
+  EXPECT_EQ(~fcInf, Known0.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known0.getSignBit());
   EXPECT_TRUE(KnownInf0.isKnownNeverInfinity());
 
@@ -1150,7 +1150,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFPowIInf) {
   Register SrcReg1 = FinalCopy1->getOperand(1).getReg();
   KnownFPClass Known1 = Info.computeKnownFPClass(SrcReg1, fcAllFlags);
   KnownFPClass KnownInf1 = Info.computeKnownFPClass(SrcReg1, fcInf);
-  EXPECT_EQ(fcPositive | fcNan, Known1.KnownFPClasses);
+  EXPECT_EQ(fcPositive | fcNan, Known1.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known1.getSignBit());
   EXPECT_FALSE(KnownInf1.isKnownNeverInfinity());
 
@@ -1160,7 +1160,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFPowIInf) {
   Register SrcReg2 = FinalCopy2->getOperand(1).getReg();
   KnownFPClass Known2 = Info.computeKnownFPClass(SrcReg2, fcAllFlags);
   KnownFPClass KnownInf2 = Info.computeKnownFPClass(SrcReg2, fcInf);
-  EXPECT_EQ(fcPosFinite, Known2.KnownFPClasses);
+  EXPECT_EQ(fcPosFinite, Known2.getKnownFPClasses());
   EXPECT_EQ(false, Known2.getSignBit());
   EXPECT_TRUE(KnownInf2.isKnownNeverInfinity());
 
@@ -1195,7 +1195,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFDiv) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPosNormal | fcNan, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosNormal | fcNan, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -1219,7 +1219,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFDiv_Inf) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPosInf, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosInf, Known.getKnownFPClasses());
   EXPECT_EQ(false, Known.getSignBit());
 }
 
@@ -1246,7 +1246,8 @@ TEST_F(AArch64GISelMITest, TestFPClassFDivSqrt) {
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcAllFlags & ~(fcNegNormal | fcNegSubnormal), Known.KnownFPClasses);
+  EXPECT_EQ(fcAllFlags & ~(fcNegNormal | fcNegSubnormal),
+            Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -1274,7 +1275,8 @@ TEST_F(AArch64GISelMITest, TestFPClassFDivNegSqrtNeg) {
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg, fcPositive);
 
-  EXPECT_EQ(fcAllFlags & ~(fcPosNormal | fcPosSubnormal), Known.KnownFPClasses);
+  EXPECT_EQ(fcAllFlags & ~(fcPosNormal | fcPosSubnormal),
+            Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -1301,7 +1303,7 @@ TEST_F(AArch64GISelMITest, TestFPClassSqrtFDiv) {
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcNan | fcZero | fcPosNormal | fcPosInf, Known.KnownFPClasses);
+  EXPECT_EQ(fcNan | fcZero | fcPosNormal | fcPosInf, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -1326,7 +1328,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFRem) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcZero | fcNan, Known.KnownFPClasses);
+  EXPECT_EQ(fcZero | fcNan, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -1353,7 +1355,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFRemSelf_KnownFiniteNonZero) {
 
   // 2.0 % 2.0 = 0.0 exactly — NaN is impossible since 2.0 is finite and
   // nonzero.
-  EXPECT_EQ(fcZero, Known.KnownFPClasses);
+  EXPECT_EQ(fcZero, Known.getKnownFPClasses());
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassShuffleVec) {
@@ -1378,7 +1380,7 @@ TEST_F(AArch64GISelMITest, TestFPClassShuffleVec) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPosFinite, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosFinite, Known.getKnownFPClasses());
   EXPECT_EQ(false, Known.getSignBit());
 }
 
@@ -1404,7 +1406,7 @@ TEST_F(AArch64GISelMITest, TestFPClassBuildVec) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPosFinite, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosFinite, Known.getKnownFPClasses());
   EXPECT_EQ(false, Known.getSignBit());
 }
 
@@ -1433,7 +1435,7 @@ TEST_F(AArch64GISelMITest, TestFPClassConcatVec) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPosFinite, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosFinite, Known.getKnownFPClasses());
   EXPECT_EQ(false, Known.getSignBit());
 }
 
@@ -1459,7 +1461,7 @@ TEST_F(AArch64GISelMITest, TestFPClassVecExtractElem) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPosFinite, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosFinite, Known.getKnownFPClasses());
   EXPECT_EQ(false, Known.getSignBit());
 }
 
@@ -1487,7 +1489,7 @@ TEST_F(AArch64GISelMITest, TestFPClassVecInsertElem) {
 
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
 
-  EXPECT_EQ(fcPosFinite, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosFinite, Known.getKnownFPClasses());
   EXPECT_EQ(false, Known.getSignBit());
 }
 
@@ -1506,7 +1508,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFSinh) {
   Register SrcReg = FinalCopy->getOperand(1).getReg();
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
-  EXPECT_EQ(fcAllFlags, Known.KnownFPClasses);
+  EXPECT_EQ(fcAllFlags, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -1527,7 +1529,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFSinhPos) {
   Register SrcReg = FinalCopy->getOperand(1).getReg();
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
-  EXPECT_EQ(fcPositive, Known.KnownFPClasses);
+  EXPECT_EQ(fcPositive, Known.getKnownFPClasses());
   EXPECT_EQ(false, Known.getSignBit());
 }
 
@@ -1547,7 +1549,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFCosh) {
   Register SrcReg = FinalCopy->getOperand(1).getReg();
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
-  EXPECT_EQ(fcPosNormal | fcPosInf | fcNan, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosNormal | fcPosInf | fcNan, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -1568,7 +1570,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFCoshNNaN) {
   Register SrcReg = FinalCopy->getOperand(1).getReg();
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
-  EXPECT_EQ(fcPosNormal | fcPosInf, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosNormal | fcPosInf, Known.getKnownFPClasses());
   EXPECT_EQ(false, Known.getSignBit());
 }
 
@@ -1588,7 +1590,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFTanh) {
   Register SrcReg = FinalCopy->getOperand(1).getReg();
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
-  EXPECT_EQ(fcAllFlags & ~fcInf, Known.KnownFPClasses);
+  EXPECT_EQ(fcAllFlags & ~fcInf, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -1609,7 +1611,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFTanhPos) {
   Register SrcReg = FinalCopy->getOperand(1).getReg();
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
-  EXPECT_EQ(fcPosFinite, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosFinite, Known.getKnownFPClasses());
   EXPECT_EQ(false, Known.getSignBit());
 }
 
@@ -1629,7 +1631,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFAsin) {
   Register SrcReg = FinalCopy->getOperand(1).getReg();
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
-  EXPECT_EQ(fcAllFlags & ~fcInf, Known.KnownFPClasses);
+  EXPECT_EQ(fcAllFlags & ~fcInf, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -1651,7 +1653,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFAsinPos) {
   Register SrcReg = FinalCopy->getOperand(1).getReg();
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
-  EXPECT_EQ(fcPosFinite | fcQNan, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosFinite | fcQNan, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -1671,7 +1673,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFAcos) {
   Register SrcReg = FinalCopy->getOperand(1).getReg();
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
-  EXPECT_EQ(fcPosZero | fcPosNormal | fcNan, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosZero | fcPosNormal | fcNan, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -1693,7 +1695,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFAcosPos) {
   Register SrcReg = FinalCopy->getOperand(1).getReg();
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
-  EXPECT_EQ(fcPosZero | fcPosNormal | fcQNan, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosZero | fcPosNormal | fcQNan, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -1713,7 +1715,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFAtan) {
   Register SrcReg = FinalCopy->getOperand(1).getReg();
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
-  EXPECT_EQ(fcAllFlags & ~fcInf, Known.KnownFPClasses);
+  EXPECT_EQ(fcAllFlags & ~fcInf, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -1734,7 +1736,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFAtanPos) {
   Register SrcReg = FinalCopy->getOperand(1).getReg();
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
-  EXPECT_EQ(fcPosFinite, Known.KnownFPClasses);
+  EXPECT_EQ(fcPosFinite, Known.getKnownFPClasses());
   EXPECT_EQ(false, Known.getSignBit());
 }
 
@@ -1754,7 +1756,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFTan) {
   Register SrcReg = FinalCopy->getOperand(1).getReg();
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
-  EXPECT_EQ(fcAllFlags & ~fcInf, Known.KnownFPClasses);
+  EXPECT_EQ(fcAllFlags & ~fcInf, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -1775,7 +1777,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFTanNNaN) {
   Register SrcReg = FinalCopy->getOperand(1).getReg();
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
-  EXPECT_EQ(fcFinite, Known.KnownFPClasses);
+  EXPECT_EQ(fcFinite, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -1796,7 +1798,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFAtan2) {
   Register SrcReg = FinalCopy->getOperand(1).getReg();
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
-  EXPECT_EQ(fcAllFlags & ~fcInf, Known.KnownFPClasses);
+  EXPECT_EQ(fcAllFlags & ~fcInf, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -1819,7 +1821,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFAtan2NNaN) {
   Register SrcReg = FinalCopy->getOperand(1).getReg();
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
-  EXPECT_EQ(fcFinite, Known.KnownFPClasses);
+  EXPECT_EQ(fcFinite, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -1844,7 +1846,7 @@ TEST_F(AArch64GISelMITest, TestFPClassFMulAbsULEOne) {
   Register SrcReg = FinalCopy->getOperand(1).getReg();
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
-  EXPECT_EQ(~fcInf, Known.KnownFPClasses);
+  EXPECT_EQ(~fcInf, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -1867,6 +1869,6 @@ TEST_F(AArch64GISelMITest, TestFPClassFMASelfSquare) {
   Register SrcReg = FinalCopy->getOperand(1).getReg();
   GISelValueTracking Info(*MF);
   KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
-  EXPECT_EQ(fcNan | fcPosInf | fcPosNormal, Known.KnownFPClasses);
+  EXPECT_EQ(fcNan | fcPosInf | fcPosNormal, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }

--- a/llvm/unittests/Support/KnownFPClassTest.cpp
+++ b/llvm/unittests/Support/KnownFPClassTest.cpp
@@ -30,7 +30,7 @@ static void expectConstant(const char *SemanticsName, const char *ValueName,
       KnownFPClass::bitcast(Semantics, KnownBits::makeConstant(ValueBits));
   FPClassTest ExpectedClass =
       Negative ? llvm::fneg(PositiveClass) : PositiveClass;
-  EXPECT_EQ(ExpectedClass, Known.KnownFPClasses);
+  EXPECT_EQ(ExpectedClass, Known.getKnownFPClasses());
   EXPECT_EQ(Negative, Known.getSignBit());
 }
 
@@ -43,7 +43,8 @@ TEST(KnownFPClassTest, BitcastExhaustiveIEEEHalf) {
         KnownFPClass::bitcast(Semantics, KnownBits::makeConstant(ValueBits));
     KnownFPClass Expected(APFloat(Semantics, ValueBits));
 
-    ASSERT_EQ(Expected.KnownFPClasses, Known.KnownFPClasses) << RawBits;
+    ASSERT_EQ(Expected.getKnownFPClasses(), Known.getKnownFPClasses())
+        << RawBits;
     ASSERT_EQ(Expected.getSignBit(), Known.getSignBit()) << RawBits;
   }
 }
@@ -55,7 +56,7 @@ TEST(KnownFPClassTest, BitcastConflict) {
 
   ASSERT_TRUE(Bits.hasConflict());
   KnownFPClass Known = KnownFPClass::bitcast(Semantics, Bits);
-  EXPECT_EQ(fcAllFlags, Known.KnownFPClasses);
+  EXPECT_EQ(fcAllFlags, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 
@@ -67,7 +68,7 @@ TEST(KnownFPClassTest, BitcastPartialConflict) {
 
   ASSERT_TRUE(Bits.hasConflict());
   KnownFPClass Known = KnownFPClass::bitcast(Semantics, Bits);
-  EXPECT_EQ(fcAllFlags, Known.KnownFPClasses);
+  EXPECT_EQ(fcAllFlags, Known.getKnownFPClasses());
   EXPECT_EQ(std::nullopt, Known.getSignBit());
 }
 

--- a/llvm/unittests/Target/AArch64/AArch64SelectionDAGTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64SelectionDAGTest.cpp
@@ -1684,32 +1684,32 @@ TEST_F(AArch64SelectionDAGTest, ComputeKnownFPClass_ConstantScalar) {
   SDValue PosZero = DAG->getConstantFP(APFloat::getZero(APFloat::IEEEsingle()),
                                        Loc, MVT::f32);
   KnownFPClass Known = DAG->computeKnownFPClass(PosZero, fcAllFlags);
-  EXPECT_EQ(Known.KnownFPClasses, fcPosZero);
+  EXPECT_EQ(Known.getKnownFPClasses(), fcPosZero);
   EXPECT_TRUE(Known.getSignBit().has_value());
   EXPECT_FALSE(*Known.getSignBit());
 
   SDValue NegZero = DAG->getConstantFP(
       APFloat::getZero(APFloat::IEEEsingle(), true), Loc, MVT::f32);
   Known = DAG->computeKnownFPClass(NegZero, fcAllFlags);
-  EXPECT_EQ(Known.KnownFPClasses, fcNegZero);
+  EXPECT_EQ(Known.getKnownFPClasses(), fcNegZero);
   EXPECT_TRUE(Known.getSignBit().has_value());
   EXPECT_TRUE(*Known.getSignBit());
 
   SDValue PosInf =
       DAG->getConstantFP(APFloat::getInf(APFloat::IEEEsingle()), Loc, MVT::f32);
   Known = DAG->computeKnownFPClass(PosInf, fcAllFlags);
-  EXPECT_EQ(Known.KnownFPClasses, fcPosInf);
+  EXPECT_EQ(Known.getKnownFPClasses(), fcPosInf);
   EXPECT_TRUE(Known.getSignBit().has_value());
   EXPECT_FALSE(*Known.getSignBit());
 
   SDValue QNaN = DAG->getConstantFP(APFloat::getQNaN(APFloat::IEEEsingle()),
                                     Loc, MVT::f32);
   Known = DAG->computeKnownFPClass(QNaN, fcAllFlags);
-  EXPECT_EQ(Known.KnownFPClasses, fcQNan);
+  EXPECT_EQ(Known.getKnownFPClasses(), fcQNan);
 
   SDValue One = DAG->getConstantFP(1.0, Loc, MVT::f32);
   Known = DAG->computeKnownFPClass(One, fcAllFlags);
-  EXPECT_EQ(Known.KnownFPClasses, fcPosNormal);
+  EXPECT_EQ(Known.getKnownFPClasses(), fcPosNormal);
   EXPECT_TRUE(Known.getSignBit().has_value());
   EXPECT_FALSE(*Known.getSignBit());
 }
@@ -1725,13 +1725,13 @@ TEST_F(AArch64SelectionDAGTest, ComputeKnownFPClass_BuildVector) {
 
   SDValue VecPosPos = DAG->getBuildVector(VecVT, Loc, {PosOne, PosTwo});
   KnownFPClass Known = DAG->computeKnownFPClass(VecPosPos, fcAllFlags);
-  EXPECT_EQ(Known.KnownFPClasses, fcPosNormal);
+  EXPECT_EQ(Known.getKnownFPClasses(), fcPosNormal);
   EXPECT_TRUE(Known.getSignBit().has_value());
   EXPECT_FALSE(*Known.getSignBit());
 
   SDValue VecPosNeg = DAG->getBuildVector(VecVT, Loc, {PosOne, NegOne});
   Known = DAG->computeKnownFPClass(VecPosNeg, fcAllFlags);
-  EXPECT_EQ(Known.KnownFPClasses, fcPosNormal | fcNegNormal);
+  EXPECT_EQ(Known.getKnownFPClasses(), fcPosNormal | fcNegNormal);
   EXPECT_FALSE(Known.getSignBit().has_value());
 }
 
@@ -1745,24 +1745,24 @@ TEST_F(AArch64SelectionDAGTest, ComputeKnownFPClass_DemandedElts) {
 
   APInt DemandLo(2, 1);
   KnownFPClass Known = DAG->computeKnownFPClass(Vec, DemandLo, fcAllFlags);
-  EXPECT_EQ(Known.KnownFPClasses, fcPosNormal);
+  EXPECT_EQ(Known.getKnownFPClasses(), fcPosNormal);
   EXPECT_TRUE(Known.getSignBit().has_value());
   EXPECT_FALSE(*Known.getSignBit());
 
   APInt DemandHi(2, 2);
   Known = DAG->computeKnownFPClass(Vec, DemandHi, fcAllFlags);
-  EXPECT_EQ(Known.KnownFPClasses, fcNegNormal);
+  EXPECT_EQ(Known.getKnownFPClasses(), fcNegNormal);
   EXPECT_TRUE(Known.getSignBit().has_value());
   EXPECT_TRUE(*Known.getSignBit());
 
   APInt DemandAll(2, 3);
   Known = DAG->computeKnownFPClass(Vec, DemandAll, fcAllFlags);
-  EXPECT_EQ(Known.KnownFPClasses, fcPosNormal | fcNegNormal);
+  EXPECT_EQ(Known.getKnownFPClasses(), fcPosNormal | fcNegNormal);
   EXPECT_FALSE(Known.getSignBit().has_value());
 
   APInt DemandNone(2, 0);
   Known = DAG->computeKnownFPClass(Vec, DemandNone, fcAllFlags);
-  EXPECT_EQ(Known.KnownFPClasses, fcAllFlags);
+  EXPECT_EQ(Known.getKnownFPClasses(), fcAllFlags);
   EXPECT_FALSE(Known.getSignBit().has_value());
 }
 
@@ -1776,12 +1776,12 @@ TEST_F(AArch64SelectionDAGTest, ComputeKnownFPClass_MaxDepth) {
 
   // At depth 0, BUILD_VECTOR of constants is fully analyzed.
   KnownFPClass Known = DAG->computeKnownFPClass(Vec, fcAllFlags, /*Depth=*/0);
-  EXPECT_EQ(Known.KnownFPClasses, fcPosNormal);
+  EXPECT_EQ(Known.getKnownFPClasses(), fcPosNormal);
 
   // At MaxRecursionDepth, the non-constant node bails out as unknown.
   Known = DAG->computeKnownFPClass(Vec, fcAllFlags,
                                    SelectionDAG::MaxRecursionDepth);
-  EXPECT_EQ(Known.KnownFPClasses, fcAllFlags);
+  EXPECT_EQ(Known.getKnownFPClasses(), fcAllFlags);
   EXPECT_FALSE(Known.getSignBit().has_value());
 }
 
@@ -1791,13 +1791,13 @@ TEST_F(AArch64SelectionDAGTest, ComputeKnownFPClass_UndefAndPoison) {
   // UNDEF is unknown — could be any FP class.
   SDValue Undef = DAG->getUNDEF(MVT::f32);
   KnownFPClass Known = DAG->computeKnownFPClass(Undef, fcAllFlags);
-  EXPECT_EQ(Known.KnownFPClasses, fcAllFlags);
+  EXPECT_EQ(Known.getKnownFPClasses(), fcAllFlags);
   EXPECT_FALSE(Known.getSignBit().has_value());
 
   // POISON is fcNone — can be assumed to never be observed.
   SDValue Poison = DAG->getPOISON(MVT::f32);
   Known = DAG->computeKnownFPClass(Poison, fcAllFlags);
-  EXPECT_EQ(Known.KnownFPClasses, fcNone);
+  EXPECT_EQ(Known.getKnownFPClasses(), fcNone);
   EXPECT_TRUE(Known.getSignBit().has_value());
   EXPECT_FALSE(*Known.getSignBit());
 }


### PR DESCRIPTION
Part of https://github.com/llvm/llvm-project/issues/217072

Follow up to https://github.com/llvm/llvm-project/pull/218514

Replaces direct uses of the `KnownFPClasses` field with getters/setters.