### PR TITLE
[lld][ELF] Fix ignored yaml tests

### DIFF
--- a/lld/test/ELF/lit.local.cfg
+++ b/lld/test/ELF/lit.local.cfg
@@ -1,4 +1,4 @@
-config.suffixes = [".test", ".s", ".ll", ".bat"]
+config.suffixes = [".test", ".s", ".ll", ".bat", ".yaml"]
 
 # The environment variable DFLTCC=0 disables use of the hardware compression
 # facility on SystemZ.  When this facility is enabled, slightly different

--- a/utils/bazel/llvm-project-overlay/lld/test/ELF/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lld/test/ELF/BUILD.bazel
@@ -17,6 +17,7 @@ licenses(["notice"])
             "**/*.ll",
             "**/*.s",
             "**/*.test",
+            "**/*.yaml",
         ],
         exclude = ["**/Inputs/**"],
     )


### PR DESCRIPTION
These previously weren't running:

```
  lld :: ELF/gdb-index-invalid-section-index.yaml
  lld :: ELF/invalid/entsize.yaml
```
