### PR TITLE
AMDGPU: Add getSubArchFromGPUName utility

### DIFF
--- a/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
+++ b/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
@@ -113,6 +113,11 @@ LLVM_ABI StringRef getArchFamilyNameAMDGCN(GPUKind AK);
 LLVM_ABI StringRef getBaseArchNameAMDGCN(GPUKind AK);
 
 LLVM_ABI Triple::SubArchType getSubArch(GPUKind AK);
+
+/// Returns the preferred subarch for a GPU name \p CPU, or NoSubArch if
+/// unrecognized.
+LLVM_ABI Triple::SubArchType getSubArchFromGPUName(StringRef CPU);
+
 LLVM_ABI Triple::SubArchType getMajorSubArch(Triple::SubArchType SubArch);
 
 /// Return true if subarch \p A is compatible with subarch \p B, i.e. they are

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -171,6 +171,10 @@ Triple::SubArchType llvm::AMDGPU::getSubArch(GPUKind AK) {
   return Info ? Info->SubArch : Triple::SubArchType::NoSubArch;
 }
 
+Triple::SubArchType llvm::AMDGPU::getSubArchFromGPUName(StringRef CPU) {
+  return getSubArch(parseArchAMDGCN(CPU));
+}
+
 StringRef llvm::AMDGPU::getBaseArchNameAMDGCN(GPUKind AK) {
   const GPUInfo *Info = getAMDGPUInfo(AK);
   return Info ? AMDGPUNameStrTab[Info->BaseName] : "";

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -2995,6 +2995,33 @@ TEST(TargetParserTest, testAMDGPUgetGPUKindFromSubArch) {
     EXPECT_EQ(AMDGPU::getGPUKindFromSubArch(Mapping.SubArch), Mapping.Kind);
 }
 
+TEST(TargetParserTest, testAMDGPUgetSubArchFromGPUName) {
+  // Concrete GPU names map to their subarch.
+  EXPECT_EQ(AMDGPU::getSubArchFromGPUName("gfx600"), Triple::AMDGPUSubArch600);
+  EXPECT_EQ(AMDGPU::getSubArchFromGPUName("gfx900"), Triple::AMDGPUSubArch900);
+  EXPECT_EQ(AMDGPU::getSubArchFromGPUName("gfx90a"), Triple::AMDGPUSubArch90A);
+  EXPECT_EQ(AMDGPU::getSubArchFromGPUName("gfx1030"),
+            Triple::AMDGPUSubArch1030);
+  EXPECT_EQ(AMDGPU::getSubArchFromGPUName("gfx1250"),
+            Triple::AMDGPUSubArch1250);
+  EXPECT_EQ(AMDGPU::getSubArchFromGPUName("gfx1250-strict"),
+            Triple::AMDGPUSubArch1250S);
+
+  // A legacy alias resolves to the same subarch as its canonical name.
+  EXPECT_EQ(AMDGPU::getSubArchFromGPUName("tahiti"),
+            AMDGPU::getSubArchFromGPUName("gfx600"));
+
+  // Generic/family names map to their family subarch.
+  EXPECT_EQ(AMDGPU::getSubArchFromGPUName("gfx9-generic"),
+            Triple::AMDGPUSubArch9);
+
+  // Pseudo targets and unrecognized names have no subarch.
+  EXPECT_EQ(AMDGPU::getSubArchFromGPUName("generic"), Triple::NoSubArch);
+  EXPECT_EQ(AMDGPU::getSubArchFromGPUName("generic-hsa"), Triple::NoSubArch);
+  EXPECT_EQ(AMDGPU::getSubArchFromGPUName("not-a-gpu"), Triple::NoSubArch);
+  EXPECT_EQ(AMDGPU::getSubArchFromGPUName(""), Triple::NoSubArch);
+}
+
 TEST(TargetParserTest, testAMDGPUgetIsaVersionFromSubArch) {
   // Concrete subarches map to their exact ISA version.
   EXPECT_EQ(AMDGPU::getIsaVersion(Triple::AMDGPUSubArch600),


### PR DESCRIPTION
Add a utility function to map a GPU name to the correct subarch.
This provides the minimum effort mapping for frontends to convert their
current target name system to produce a subarch triple.

Co-authored-by: Claude (Claude-Opus-4.8)