### PR TITLE
[lldb] Drop the trailing separator from the qWasmGlobal instance suffix

### DIFF
--- a/lldb/docs/resources/lldbgdbremote.md
+++ b/lldb/docs/resources/lldbgdbremote.md
@@ -2680,7 +2680,7 @@ global together with the module instance to read it from. A stub that advertises
 `qWasmInstance+` requires that module instance to be named explicitly:
 
 ```
-send packet: $qWasmGlobal:2;instance:16;#32
+send packet: $qWasmGlobal:2;instance:16#f7
 read packet: $e0030100#b9
 ```
 
@@ -2713,7 +2713,7 @@ send packet: qSupported:xmlRegisters=i386,arm,mips
 read packet: qXfer:libraries:read+;qWasmInstance+;PacketSize=1000
 ```
 
-An instance is named with a `;instance:<id>;` suffix in place of a frame index,
+An instance is named with a `;instance:<id>` suffix in place of a frame index,
 in which the id is encoded as base 10. `qWasmGlobal` is the only packet that
 carries it today, because a global is the only Wasm state with no address to
 identify its instance. A later query for instance-scoped state carries the same

--- a/lldb/source/Plugins/Process/wasm/ProcessWasm.cpp
+++ b/lldb/source/Plugins/Process/wasm/ProcessWasm.cpp
@@ -249,7 +249,7 @@ ProcessWasm::GetWasmVariable(WasmVirtualRegisterKinds kind,
 llvm::Expected<lldb::DataBufferSP>
 ProcessWasm::GetWasmGlobalForModule(uint32_t module_id, uint32_t index) {
   return SendWasmValueQuery(
-      llvm::formatv("qWasmGlobal:{0};instance:{1};", index, module_id).str());
+      llvm::formatv("qWasmGlobal:{0};instance:{1}", index, module_id).str());
 }
 
 llvm::Expected<lldb::DataBufferSP>

--- a/lldb/test/API/functionalities/gdb_remote_client/TestWasm.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestWasm.py
@@ -96,7 +96,7 @@ def global_read_packet(global_index, module_id=MODULE_ID):
     """
     The packet that reads a global from the module instance holding it.
     """
-    return f"qWasmGlobal:{global_index};{INSTANCE_KEY}{module_id};"
+    return f"qWasmGlobal:{global_index};{INSTANCE_KEY}{module_id}"
 
 
 def format_register_value(val):
@@ -205,7 +205,7 @@ class MyResponder(MockGDBServerResponder):
         Read a global. A client that can name the instance holding it does so
         with the instance suffix, and one that cannot names a frame.
 
-        Format: qWasmGlobal:index;instance:id; or
+        Format: qWasmGlobal:index;instance:id or
                 qWasmGlobal:frame_index;index
         """
         first, _, rest = packet.split(":", 1)[1].partition(";")
@@ -217,7 +217,7 @@ class MyResponder(MockGDBServerResponder):
             # The global index space belongs to the instance, so an index only
             # names a global together with the instance it indexes. Another
             # instance's globals answer a different question.
-            module = self.module_with_id(int(rest[len(INSTANCE_KEY) :].rstrip(";")))
+            module = self.module_with_id(int(rest[len(INSTANCE_KEY) :]))
             if module is None:
                 return "E04"
             return module.encode_global(int(first))


### PR DESCRIPTION
The instance suffix was spelled ";instance:<id>;", which ends a packet with a separator that separates nothing. Spell it ";instance:<id>" and avoid the redundant semicolon.