### PR TITLE
AMDGPU: Move flat work group size constants to AMDGPUTargetParser

### DIFF
--- a/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
+++ b/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
@@ -227,6 +227,15 @@ constexpr unsigned getMinWavesPerEU() { return 1; }
 LLVM_ABI unsigned getMaxWavesPerEU(GPUKind AK);
 LLVM_ABI unsigned getMaxWavesPerEU(Triple::SubArchType SubArch);
 
+/// \returns Minimum flat work group size.
+constexpr unsigned getMinFlatWorkGroupSize() { return 1; }
+
+/// \returns Maximum flat work group size.
+constexpr unsigned getMaxFlatWorkGroupSize() {
+  // Some subtargets allow encoding 2048, but this isn't tested or supported.
+  return 1024;
+}
+
 /// Fills Features map with default values for given target GPU.
 /// \p Features contains overriding target features and this function returns
 /// default target features with entries overridden by \p Features.

--- a/llvm/lib/Target/AMDGPU/AMDGPULowerKernelAttributes.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerKernelAttributes.cpp
@@ -113,7 +113,7 @@ static bool annotateGroupSizeLoadWithRangeMD(LoadInst *Load, bool IsRemainder) {
   MDBuilder MDB(Load->getContext());
   MDNode *Range = MDB.createRange(
       APInt(16, !IsRemainder),
-      APInt(16, AMDGPU::IsaInfo::getMaxFlatWorkGroupSize() + 1 - IsRemainder));
+      APInt(16, AMDGPU::getMaxFlatWorkGroupSize() + 1 - IsRemainder));
   Load->setMetadata(LLVMContext::MD_range, Range);
   return true;
 }

--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.h
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.h
@@ -944,12 +944,12 @@ public:
 
   /// \returns Minimum flat work group size supported by the subtarget.
   unsigned getMinFlatWorkGroupSize() const override {
-    return AMDGPU::IsaInfo::getMinFlatWorkGroupSize(*this);
+    return AMDGPU::getMinFlatWorkGroupSize();
   }
 
   /// \returns Maximum flat work group size supported by the subtarget.
   unsigned getMaxFlatWorkGroupSize() const override {
-    return AMDGPU::IsaInfo::getMaxFlatWorkGroupSize();
+    return AMDGPU::getMaxFlatWorkGroupSize();
   }
 
   /// \returns Number of waves per execution unit required to support the given

--- a/llvm/lib/Target/AMDGPU/R600Subtarget.h
+++ b/llvm/lib/Target/AMDGPU/R600Subtarget.h
@@ -139,12 +139,12 @@ public:
 
   /// \returns Minimum flat work group size supported by the subtarget.
   unsigned getMinFlatWorkGroupSize() const override {
-    return AMDGPU::IsaInfo::getMinFlatWorkGroupSize(*this);
+    return AMDGPU::getMinFlatWorkGroupSize();
   }
 
   /// \returns Maximum flat work group size supported by the subtarget.
   unsigned getMaxFlatWorkGroupSize() const override {
-    return AMDGPU::IsaInfo::getMaxFlatWorkGroupSize();
+    return AMDGPU::getMaxFlatWorkGroupSize();
   }
 
   /// \returns Number of waves per execution unit required to support the given

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -1253,8 +1253,6 @@ unsigned getWavesPerEUForWorkGroup(const MCSubtargetInfo &STI,
                     getNumWorkGroupSIMDs(isFullSIMDMode(STI)));
 }
 
-unsigned getMinFlatWorkGroupSize(const MCSubtargetInfo &STI) { return 1; }
-
 unsigned getWavesPerWorkGroup(const MCSubtargetInfo &STI,
                               unsigned FlatWorkGroupSize) {
   return divideCeil(FlatWorkGroupSize, getWavefrontSize(STI));

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
@@ -193,15 +193,6 @@ unsigned getMaxWorkGroupsPerCU(const MCSubtargetInfo &STI,
 unsigned getWavesPerEUForWorkGroup(const MCSubtargetInfo &STI,
                                    unsigned FlatWorkGroupSize);
 
-/// \returns Minimum flat work group size for given subtarget \p STI.
-unsigned getMinFlatWorkGroupSize(const MCSubtargetInfo &STI);
-
-/// \returns Maximum flat work group size
-constexpr unsigned getMaxFlatWorkGroupSize() {
-  // Some subtargets allow encoding 2048, but this isn't tested or supported.
-  return 1024;
-}
-
 /// \returns Number of waves per work group for given subtarget \p STI and
 /// \p FlatWorkGroupSize.
 unsigned getWavesPerWorkGroup(const MCSubtargetInfo &STI,

--- a/llvm/tools/llvm-calc-occupancy/llvm-calc-occupancy.cpp
+++ b/llvm/tools/llvm-calc-occupancy/llvm-calc-occupancy.cpp
@@ -194,7 +194,7 @@ int main(int argc, char **argv) {
   const MCSubtargetInfo &STI = ST;
 
   // Parse inputs.
-  unsigned WGMin = 1, WGMax = AMDGPU::IsaInfo::getMaxFlatWorkGroupSize();
+  unsigned WGMin = 1, WGMax = AMDGPU::getMaxFlatWorkGroupSize();
   bool WGSpecified = !WGSizeStr.empty();
   if (WGSpecified && !parseWGRange(WGSizeStr, WGMin, WGMax)) {
     WithColor::error(errs(), ToolName)
@@ -221,7 +221,7 @@ int main(int argc, char **argv) {
   unsigned AddrVGPRs =
       AMDGPU::IsaInfo::getAddressableNumVGPRs(STI, DynVGPRBlockSize);
   unsigned AddrSGPRs = ST.getAddressableNumSGPRs();
-  unsigned MaxWGSize = AMDGPU::IsaInfo::getMaxFlatWorkGroupSize();
+  unsigned MaxWGSize = AMDGPU::getMaxFlatWorkGroupSize();
 
   // Warn about inputs that exceed the hardware's physical capacity: such a
   // kernel could not actually launch, so the reported occupancy is only the


### PR DESCRIPTION
getMinFlatWorkGroupSize and getMaxFlatWorkGroupSize are constants that
do not depend on the subtarget. Move them from IsaInfo to
AMDGPUTargetParser so they can be queried without an MCSubtargetInfo.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>