### PR TITLE
[HLSL] Fix initialization of mips' copy of the resource handle

### DIFF
--- a/clang/lib/Sema/HLSLExternalSemaSource.cpp
+++ b/clang/lib/Sema/HLSLExternalSemaSource.cpp
@@ -349,8 +349,16 @@ static BuiltinTypeDeclBuilder setupTextureType(CXXRecordDecl *Decl, Sema &S,
   }
 
   BuiltinTypeDeclBuilder B(S, Decl);
-  B.addTextureHandle(T.RC, T.IsROV, IsArray, Dim, SampleCountExpr)
-      .addDefaultHandleConstructor()
+  B.addTextureHandle(T.RC, T.IsROV, IsArray, Dim, SampleCountExpr);
+
+  // The `mips` member holds a second copy of the resource handle.
+  // addCopyConstructor, addCopyAssignmentOperator and
+  // addStaticInitializationFunctions are what initialize that copy, and they
+  // look the member up by name, so it has to exist before they run.
+  if (T.has(TexCap::Mips))
+    B.addMipsMember(Dim);
+
+  B.addDefaultHandleConstructor()
       .addCopyConstructor()
       .addCopyAssignmentOperator()
       .addStaticInitializationFunctions(false);
@@ -363,8 +371,6 @@ static BuiltinTypeDeclBuilder setupTextureType(CXXRecordDecl *Decl, Sema &S,
     B.addRWTextureLoadMethods(Dim, IsArray);
   if (T.has(TexCap::Subscript))
     B.addArraySubscriptOperators(Dim, IsArray);
-  if (T.has(TexCap::Mips))
-    B.addMipsMember(Dim);
 
   if (T.has(TexCap::Sample))
     B.addSampleMethods(Dim, IsArray)

--- a/clang/test/CodeGenHLSL/resources/Textures-Mips.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-Mips.hlsl
@@ -27,6 +27,19 @@
 
 TEXTURE<float4> t;
 
+// `mips` caches its own copy of the resource handle, so the initializer has to
+// write `__handle` into it as well. Leaving it uninitialized makes
+// `t.mips[N][...]` load from a poison handle.
+// CHECK: define linkonce_odr hidden void @hlsl::[[TEXTURE]]<float vector[4]>::__createFromImplicitBinding(
+// CHECK: %[[NEW_HANDLE:.*]] = call target("dx.Texture", <4 x float>, 0, 0, 0, [[DXIL_TY]]) @llvm.dx.resource.handlefromimplicitbinding
+// CHECK: %[[HANDLE_GEP:.*]] = getelementptr {{.*}} %"class.hlsl::[[TEXTURE]]", ptr %[[TMP:.*]], i32 0, i32 0
+// CHECK: store target("dx.Texture", <4 x float>, 0, 0, 0, [[DXIL_TY]]) %[[NEW_HANDLE]], ptr %[[HANDLE_GEP]]
+// CHECK: %[[HANDLE_GEP2:.*]] = getelementptr {{.*}} %"class.hlsl::[[TEXTURE]]", ptr %[[TMP]], i32 0, i32 0
+// CHECK: %[[HANDLE:.*]] = load target("dx.Texture", <4 x float>, 0, 0, 0, [[DXIL_TY]]), ptr %[[HANDLE_GEP2]]
+// CHECK: %[[MIPS_GEP:.*]] = getelementptr {{.*}} %"class.hlsl::[[TEXTURE]]", ptr %[[TMP]], i32 0, i32 1
+// CHECK: %[[MIPS_HANDLE_GEP:.*]] = getelementptr {{.*}} %"struct.hlsl::[[TEXTURE]]<>::mips_type", ptr %[[MIPS_GEP]], i32 0, i32 0
+// CHECK: store target("dx.Texture", <4 x float>, 0, 0, 0, [[DXIL_TY]]) %[[HANDLE]], ptr %[[MIPS_HANDLE_GEP]]
+
 // CHECK: define internal {{.*}} <4 x float> @test_mips(float vector[[[COORD_DIM]]])(<[[COORD_DIM]] x float> {{.*}} %loc)
 // CHECK: entry:
 // CHECK: %[[LOC_ADDR:.*]] = alloca <[[COORD_DIM]] x float>


### PR DESCRIPTION
This is a fixup to https://github.com/llvm/llvm-project/pull/219561 which left the `mips` member's copy of the resource handle uninitialized due to reordering of  `addCopyConstructor`, `addCopyAssignmentOperator` and `addStaticInitializationFunctions` to before the optional methods.

This PR particularly fixes the following offload test failures:
```
  OffloadTest-clang-d3d12 :: Feature/Textures/Array.mips.OperatorIndex.test
  OffloadTest-clang-d3d12 :: Feature/Textures/mips.OperatorIndex.test
  OffloadTest-clang-d3d12 :: Tools/Offloader/TextureMipLevelValidation.test
  OffloadTest-clang-vk :: Feature/Textures/Array.mips.OperatorIndex.test
  OffloadTest-clang-vk :: Feature/Textures/mips.OperatorIndex.test
```

Assisted by: Claude Opus 5