### PR TITLE
[NFC][DirectX] Fix a memory leak in resource access

### DIFF
--- a/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
+++ b/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
@@ -842,29 +842,26 @@ getAccessIndices(Instruction *I, SmallSetVector<Instruction *, 16> &DeadInsts,
         GetPtrPhi->addIncoming(AccessIdx.GetPtrIdx, BB);
       HandlePhi->addIncoming(AccessIdx.HandleIdx, BB);
     }
-
-    if (HasGetPtr)
-      Builder.Insert(GetPtrPhi);
-    else
-      GetPtrPhi = nullptr;
-
-    Builder.Insert(HandlePhi);
-
     DeadInsts.insert(Phi);
 
     Value *GetPtrIdx = GetPtrPhi;
-    Value *HandleIdx = HandlePhi;
-
-    if (GetPtrPhi)
+    if (HasGetPtr) {
       if (Value *ConstantGetPtr = GetPtrPhi->hasConstantValue()) {
         GetPtrIdx = ConstantGetPtr;
-        DeadInsts.insert(GetPtrPhi);
-      }
+        delete GetPtrPhi;
+      } else
+        Builder.Insert(GetPtrPhi);
+    } else {
+      GetPtrIdx = nullptr;
+      delete GetPtrPhi;
+    }
 
+    Value *HandleIdx = HandlePhi;
     if (Value *ConstantHandle = HandlePhi->hasConstantValue()) {
       HandleIdx = ConstantHandle;
-      DeadInsts.insert(HandlePhi);
-    }
+      delete HandlePhi;
+    } else
+      Builder.Insert(HandlePhi);
 
     return {GetPtrIdx, HandleIdx};
   }

--- a/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
+++ b/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
@@ -830,7 +830,9 @@ getAccessIndices(Instruction *I, SmallSetVector<Instruction *, 16> &DeadInsts,
     std::unique_ptr<PHINode> HandlePhi(
         PHINode::Create(Builder.getInt32Ty(), NumEdges));
 
-    // Register a ref to this phi for a recursive phi
+    // Register a ref to this phi for a recursive phi. This is safe to add to
+    // the map even if we end up deleting newly created phi below since we can't
+    // possibly have a constant value if we recursed.
     if (Phi->getType()->isTargetExtTy())
       VisitedPhis[Phi] = HandlePhi.get();
 

--- a/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
+++ b/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
@@ -825,44 +825,43 @@ getAccessIndices(Instruction *I, SmallSetVector<Instruction *, 16> &DeadInsts,
     assert(NumEdges != 0 && "Malformed Phi Node");
 
     IRBuilder<> Builder(Phi);
-    PHINode *GetPtrPhi = PHINode::Create(Builder.getInt32Ty(), NumEdges);
-    PHINode *HandlePhi = PHINode::Create(Builder.getInt32Ty(), NumEdges);
+    std::unique_ptr<PHINode> GetPtrPhi(
+        PHINode::Create(Builder.getInt32Ty(), NumEdges));
+    std::unique_ptr<PHINode> HandlePhi(
+        PHINode::Create(Builder.getInt32Ty(), NumEdges));
 
     // Register a ref to this phi for a recursive phi
     if (Phi->getType()->isTargetExtTy())
-      VisitedPhis[Phi] = HandlePhi;
+      VisitedPhis[Phi] = HandlePhi.get();
 
-    bool HasGetPtr = true;
     for (unsigned Idx = 0; Idx < NumEdges; Idx++) {
       auto *BB = Phi->getIncomingBlock(Idx);
       auto *V = dyn_cast<Instruction>(Phi->getIncomingValue(Idx));
       auto AccessIdx = getAccessIndices(V, DeadInsts, VisitedPhis);
-      HasGetPtr &= AccessIdx.hasGetPtrIdx();
-      if (HasGetPtr)
+      if (AccessIdx.hasGetPtrIdx())
         GetPtrPhi->addIncoming(AccessIdx.GetPtrIdx, BB);
       HandlePhi->addIncoming(AccessIdx.HandleIdx, BB);
     }
-    DeadInsts.insert(Phi);
 
-    Value *GetPtrIdx = GetPtrPhi;
-    if (HasGetPtr) {
-      if (Value *ConstantGetPtr = GetPtrPhi->hasConstantValue()) {
-        GetPtrIdx = ConstantGetPtr;
-        delete GetPtrPhi;
-      } else
-        Builder.Insert(GetPtrPhi);
-    } else {
+    Value *GetPtrIdx;
+    if (GetPtrPhi->getNumIncomingValues() == 0)
       GetPtrIdx = nullptr;
-      delete GetPtrPhi;
+    else if (Value *ConstantGetPtr = GetPtrPhi->hasConstantValue())
+      GetPtrIdx = ConstantGetPtr;
+    else {
+      GetPtrIdx = GetPtrPhi.release();
+      Builder.Insert(GetPtrIdx);
     }
 
-    Value *HandleIdx = HandlePhi;
-    if (Value *ConstantHandle = HandlePhi->hasConstantValue()) {
+    Value *HandleIdx;
+    if (Value *ConstantHandle = HandlePhi->hasConstantValue())
       HandleIdx = ConstantHandle;
-      delete HandlePhi;
-    } else
-      Builder.Insert(HandlePhi);
+    else {
+      HandleIdx = HandlePhi.release();
+      Builder.Insert(HandleIdx);
+    }
 
+    DeadInsts.insert(Phi);
     return {GetPtrIdx, HandleIdx};
   }
 


### PR DESCRIPTION
This code was leaking memory when `HasGetPtr` was false. We would reset `GetPtrPhi` to `nullptr` but we would never delete the `PHINode` we created preemptively.

Fix this by consolidating the logic to handle the case where we don't need a PHI for the getpointer, and simplify by avoiding insertion of the instruction at all if we aren't going to use it.

Leak reported by ASAN:
  https://lab.llvm.org/buildbot/#/builders/24/builds/23635