### PR TITLE
[SystemZ] XPLINK64: keep CCAssignToRegAndStack rule for bare i32 args

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZCallingConv.td
+++ b/llvm/lib/Target/SystemZ/SystemZCallingConv.td
@@ -242,9 +242,9 @@ def CC_SystemZ_XPLINK64 : CallingConv<[
   // If i128 is not legal, such values are already split into two i64 here,
   // so we have to use a custom handler.
   CCIfType<[i64], CCCustom<"CC_SystemZ_I128Indirect">>,
-  // The first 3 integer arguments are passed in registers R1D-R3D.
-  // The rest will be passed in the user area. The address offset of the user
-  // area can be found in register R4D.
+  // The first 3 integer arguments are passed in registers R1-R3.
+  // The rest will be passed in the user area.
+  CCIfType<[i32], CCAssignToRegAndStack<[R1L, R2L, R3L], 8, 8>>,
   CCIfType<[i64], CCAssignToRegAndStack<[R1D, R2D, R3D], 8, 8>>,
 
   // The first 8 named vector arguments are passed in V24-V31. Sub-128 vectors

--- a/llvm/test/CodeGen/SystemZ/zos-xplink64-bare-i32-arg.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-xplink64-bare-i32-arg.ll
@@ -1,0 +1,37 @@
+; Test that bare i32 formal arguments (without signext/zeroext, e.g. struct
+; coercions or sitofp sources) are correctly assigned to R1L/R2L/R3L under
+; the XPLINK64 calling convention.
+;
+; Bare i32 arguments (no extend flags) must be assigned to R1L/R2L/R3L by
+; the CCIfType<[i32], CCAssignToRegAndStack<[R1L,R2L,R3L],8,8>> rule in
+; CC_SystemZ_XPLINK64; without that rule they fall through to the stack
+; fallback, producing a load from the parameter area instead of a register
+; reference.
+;
+; RUN: llc < %s -mtriple=s390x-ibm-zos | FileCheck %s
+
+; Bare i32 passed to sitofp.  Correct: cefbr 0,1 (R1 is the source).
+; Without the i32 rule: l 0,<offset>(4) then cefbr 0,0 (stack load).
+define float @sitofp_bare_i32(i32 %x) {
+; CHECK-LABEL: sitofp_bare_i32 DS 0H
+; CHECK: cefbr 0,1
+  %r = sitofp i32 %x to float
+  ret float %r
+}
+
+; Bare i32 passed to sitofp (double).  Correct: cdfbr 0,1.
+define double @sitofp_bare_i32_double(i32 %x) {
+; CHECK-LABEL: sitofp_bare_i32_double DS 0H
+; CHECK: cdfbr 0,1
+  %r = sitofp i32 %x to double
+  ret double %r
+}
+
+; Two bare i32 arguments compared.  Correct: cr 1,2 (register compare).
+; Without the i32 rule: two stack loads then a memory/register compare.
+define i1 @cmp_bare_i32(i32 %a, i32 %b) {
+; CHECK-LABEL: cmp_bare_i32 DS 0H
+; CHECK: cr 1,2
+  %r = icmp eq i32 %a, %b
+  ret i1 %r
+}


### PR DESCRIPTION
Bare i32 arguments (no signext/zeroext, e.g. sitofp sources or
struct-coerced i32s) must be assigned to R1L/R2L/R3L by the
CCAssignToRegAndStack rule in CC_SystemZ_XPLINK64.
Without that rule they fall through to the stack fallback,
producing wrong codegen (stack loads instead of register references).

This test demonstrates the regression caused by removing the
CCIfType<[i32], CCAssignToRegAndStack<[R1L,R2L,R3L],8,8>> rule
from CC_SystemZ_XPLINK64 and serves as justification for keeping it.

This is a pre-existing independent issue extracted from #206833 per reviewer request.