### PR TITLE
[clang][DebugInfo] Emit DIProperty for synthesized Objective-C properties

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -3762,13 +3762,14 @@ llvm::DIType *CGDebugInfo::CreateTypeDefinition(const ObjCInterfaceType *Ty,
     auto *IvarTy = DBuilder.createObjCIVar(FieldName, FieldDefUnit, FieldLine,
                                            FieldSize, FieldAlign, FieldOffset,
                                            Flags, FieldTy, PropertyNode);
-    FieldTy = IvarTy;
-    EltTys.push_back(FieldTy);
+    EltTys.push_back(IvarTy);
 
-    if (SynthesizedProperty)
+    if (SynthesizedProperty) {
+      assert(PUnit && "SynthesizedProperty implies PUnit");
       EltTys.push_back(DBuilder.createProperty(
           SynthesizedProperty->getName(), PUnit, PLine,
           getOrCreateType(SynthesizedProperty->getType(), PUnit), IvarTy));
+    }
   }
 
   llvm::DINodeArray Elements = DBuilder.getOrCreateArray(EltTys);

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -3733,13 +3733,17 @@ llvm::DIType *CGDebugInfo::CreateTypeDefinition(const ObjCInterfaceType *Ty,
       Flags |= llvm::DINode::FlagBitField;
 
     llvm::MDNode *PropertyNode = nullptr;
+    ObjCPropertyDecl *SynthesizedProperty = nullptr;
+    llvm::DIFile *PUnit = nullptr;
+    unsigned PLine = 0;
     if (ObjCImplementationDecl *ImpD = ID->getImplementation()) {
       if (ObjCPropertyImplDecl *PImpD =
               ImpD->FindPropertyImplIvarDecl(Field->getIdentifier())) {
         if (ObjCPropertyDecl *PD = PImpD->getPropertyDecl()) {
+          SynthesizedProperty = PD;
           SourceLocation Loc = PD->getLocation();
-          llvm::DIFile *PUnit = getOrCreateFile(Loc);
-          unsigned PLine = getLineNumber(Loc);
+          PUnit = getOrCreateFile(Loc);
+          PLine = getLineNumber(Loc);
           ObjCMethodDecl *Getter = PImpD->getGetterMethodDecl();
           ObjCMethodDecl *Setter = PImpD->getSetterMethodDecl();
           PropertyNode = DBuilder.createObjCProperty(
@@ -3755,10 +3759,16 @@ llvm::DIType *CGDebugInfo::CreateTypeDefinition(const ObjCInterfaceType *Ty,
         }
       }
     }
-    FieldTy = DBuilder.createObjCIVar(FieldName, FieldDefUnit, FieldLine,
-                                      FieldSize, FieldAlign, FieldOffset, Flags,
-                                      FieldTy, PropertyNode);
+    auto *IvarTy = DBuilder.createObjCIVar(FieldName, FieldDefUnit, FieldLine,
+                                           FieldSize, FieldAlign, FieldOffset,
+                                           Flags, FieldTy, PropertyNode);
+    FieldTy = IvarTy;
     EltTys.push_back(FieldTy);
+
+    if (SynthesizedProperty)
+      EltTys.push_back(DBuilder.createProperty(
+          SynthesizedProperty->getName(), PUnit, PLine,
+          getOrCreateType(SynthesizedProperty->getType(), PUnit), IvarTy));
   }
 
   llvm::DINodeArray Elements = DBuilder.getOrCreateArray(EltTys);

--- a/clang/test/DebugInfo/ObjC/property-backing-storage.m
+++ b/clang/test/DebugInfo/ObjC/property-backing-storage.m
@@ -1,0 +1,49 @@
+// Verifies that, in addition to the legacy DIObjCProperty node, Clang also
+// emits a new DIProperty node whose backing_storage points at the ivar a
+// synthesized property forwards to. Covers the three ways a property can be
+// backed by an ivar:
+//   1. declaredBacking   - @synthesize with a custom ivar name that IS
+//                           declared in the @interface.
+//   2. undeclaredBacking - @synthesize with a custom ivar name that is NOT
+//                           declared; the compiler creates the ivar itself.
+//   3. implicitBacking   - no @synthesize at all; the compiler
+//                           auto-synthesizes both the accessors and a
+//                           default-named ivar (_implicitBacking).
+
+// RUN: %clang_cc1 -emit-llvm -debug-info-kind=limited %s -o - | FileCheck %s
+
+// CHECK-DAG: ![[DECLARED_PROP:[0-9]+]] = !DIObjCProperty(name: "declaredBacking"
+// CHECK-SAME:                                            attributes: 2316
+// CHECK-SAME:                                            type: ![[DECLARED_TY:[0-9]+]]
+// CHECK-DAG: ![[DECLARED_IVAR:[0-9]+]] = !DIDerivedType(tag: DW_TAG_member, name: "_customDeclaredIvar"
+// CHECK-SAME:                                           extraData: ![[DECLARED_PROP]]
+// CHECK-DAG: !DIProperty(name: "declaredBacking", file: !{{[0-9]+}}, line: {{[0-9]+}}, type: ![[DECLARED_TY]], backing_storage: ![[DECLARED_IVAR]])
+//
+// CHECK-DAG: ![[UNDECLARED_PROP:[0-9]+]] = !DIObjCProperty(name: "undeclaredBacking"
+// CHECK-SAME:                                              attributes: 2316
+// CHECK-SAME:                                              type: ![[UNDECLARED_TY:[0-9]+]]
+// CHECK-DAG: ![[UNDECLARED_IVAR:[0-9]+]] = !DIDerivedType(tag: DW_TAG_member, name: "_customUndeclaredIvar"
+// CHECK-SAME:                                             extraData: ![[UNDECLARED_PROP]]
+// CHECK-DAG: !DIProperty(name: "undeclaredBacking", file: !{{[0-9]+}}, line: {{[0-9]+}}, type: ![[UNDECLARED_TY]], backing_storage: ![[UNDECLARED_IVAR]])
+//
+// CHECK-DAG: ![[IMPLICIT_PROP:[0-9]+]] = !DIObjCProperty(name: "implicitBacking"
+// CHECK-SAME:                                            attributes: 2316
+// CHECK-SAME:                                            type: ![[IMPLICIT_TY:[0-9]+]]
+// CHECK-DAG: ![[IMPLICIT_IVAR:[0-9]+]] = !DIDerivedType(tag: DW_TAG_member, name: "_implicitBacking"
+// CHECK-SAME:                                           extraData: ![[IMPLICIT_PROP]]
+// CHECK-DAG: !DIProperty(name: "implicitBacking", file: !{{[0-9]+}}, line: {{[0-9]+}}, type: ![[IMPLICIT_TY]], backing_storage: ![[IMPLICIT_IVAR]])
+
+@interface C {
+  int _customDeclaredIvar;
+}
+@property int declaredBacking;
+@property int undeclaredBacking;
+@property int implicitBacking;
+@end
+
+@implementation C
+@synthesize declaredBacking = _customDeclaredIvar;
+@synthesize undeclaredBacking = _customUndeclaredIvar;
+@end
+
+void foo(C *cptr) {}

--- a/clang/test/DebugInfo/ObjC/property-backing-storage.m
+++ b/clang/test/DebugInfo/ObjC/property-backing-storage.m
@@ -12,18 +12,18 @@
 
 // RUN: %clang_cc1 -emit-llvm -debug-info-kind=limited %s -o - | FileCheck %s
 
-// CHECK-DAG: ![[DECLARED_PROP:[0-9]+]] = !DIObjCProperty(name: "declaredBacking", file: !{{[0-9]+}}, line: {{[0-9]+}}, attributes: 2316, type: ![[INT_TY:[0-9]+]])
-// CHECK-DAG: ![[UNDECLARED_PROP:[0-9]+]] = !DIObjCProperty(name: "undeclaredBacking", file: !{{[0-9]+}}, line: {{[0-9]+}}, attributes: 2316, type: ![[INT_TY]])
-// CHECK-DAG: ![[IMPLICIT_PROP:[0-9]+]] = !DIObjCProperty(name: "implicitBacking", file: !{{[0-9]+}}, line: {{[0-9]+}}, attributes: 2316, type: ![[INT_TY]])
+// CHECK-DAG: ![[DECLARED_PROP:[0-9]+]] = !DIObjCProperty(name: "declaredBacking", file: ![[FILE:[0-9]+]], line: {{[0-9]+}}, attributes: 2316, type: ![[INT_TY:[0-9]+]])
+// CHECK-DAG: ![[UNDECLARED_PROP:[0-9]+]] = !DIObjCProperty(name: "undeclaredBacking", file: ![[FILE]], line: {{[0-9]+}}, attributes: 2316, type: ![[INT_TY]])
+// CHECK-DAG: ![[IMPLICIT_PROP:[0-9]+]] = !DIObjCProperty(name: "implicitBacking", file: ![[FILE]], line: {{[0-9]+}}, attributes: 2316, type: ![[INT_TY]])
 //
-// CHECK-DAG: ![[DECLARED_IVAR:[0-9]+]] = !DIDerivedType(tag: DW_TAG_member, name: "_customDeclaredIvar", {{.*}}extraData: ![[DECLARED_PROP]])
-// CHECK-DAG: !DIProperty(name: "declaredBacking", file: !{{[0-9]+}}, line: {{[0-9]+}}, type: ![[INT_TY]], backing_storage: ![[DECLARED_IVAR]])
+// CHECK-DAG: ![[DECLARED_IVAR:[0-9]+]] = !DIDerivedType(tag: DW_TAG_member, name: "_customDeclaredIvar", {{.*}}file: ![[FILE]], {{.*}}extraData: ![[DECLARED_PROP]])
+// CHECK-DAG: !DIProperty(name: "declaredBacking", file: ![[FILE]], line: {{[0-9]+}}, type: ![[INT_TY]], backing_storage: ![[DECLARED_IVAR]])
 //
-// CHECK-DAG: ![[UNDECLARED_IVAR:[0-9]+]] = !DIDerivedType(tag: DW_TAG_member, name: "_customUndeclaredIvar", {{.*}}extraData: ![[UNDECLARED_PROP]])
-// CHECK-DAG: !DIProperty(name: "undeclaredBacking", file: !{{[0-9]+}}, line: {{[0-9]+}}, type: ![[INT_TY]], backing_storage: ![[UNDECLARED_IVAR]])
+// CHECK-DAG: ![[UNDECLARED_IVAR:[0-9]+]] = !DIDerivedType(tag: DW_TAG_member, name: "_customUndeclaredIvar", {{.*}}file: ![[FILE]], {{.*}}extraData: ![[UNDECLARED_PROP]])
+// CHECK-DAG: !DIProperty(name: "undeclaredBacking", file: ![[FILE]], line: {{[0-9]+}}, type: ![[INT_TY]], backing_storage: ![[UNDECLARED_IVAR]])
 //
-// CHECK-DAG: ![[IMPLICIT_IVAR:[0-9]+]] = !DIDerivedType(tag: DW_TAG_member, name: "_implicitBacking", {{.*}}extraData: ![[IMPLICIT_PROP]])
-// CHECK-DAG: !DIProperty(name: "implicitBacking", file: !{{[0-9]+}}, line: {{[0-9]+}}, type: ![[INT_TY]], backing_storage: ![[IMPLICIT_IVAR]])
+// CHECK-DAG: ![[IMPLICIT_IVAR:[0-9]+]] = !DIDerivedType(tag: DW_TAG_member, name: "_implicitBacking", {{.*}}file: ![[FILE]], {{.*}}extraData: ![[IMPLICIT_PROP]])
+// CHECK-DAG: !DIProperty(name: "implicitBacking", file: ![[FILE]], line: {{[0-9]+}}, type: ![[INT_TY]], backing_storage: ![[IMPLICIT_IVAR]])
 
 @interface C {
   int _customDeclaredIvar;

--- a/clang/test/DebugInfo/ObjC/property-backing-storage.m
+++ b/clang/test/DebugInfo/ObjC/property-backing-storage.m
@@ -12,26 +12,18 @@
 
 // RUN: %clang_cc1 -emit-llvm -debug-info-kind=limited %s -o - | FileCheck %s
 
-// CHECK-DAG: ![[DECLARED_PROP:[0-9]+]] = !DIObjCProperty(name: "declaredBacking"
-// CHECK-SAME:                                            attributes: 2316
-// CHECK-SAME:                                            type: ![[DECLARED_TY:[0-9]+]]
-// CHECK-DAG: ![[DECLARED_IVAR:[0-9]+]] = !DIDerivedType(tag: DW_TAG_member, name: "_customDeclaredIvar"
-// CHECK-SAME:                                           extraData: ![[DECLARED_PROP]]
-// CHECK-DAG: !DIProperty(name: "declaredBacking", file: !{{[0-9]+}}, line: {{[0-9]+}}, type: ![[DECLARED_TY]], backing_storage: ![[DECLARED_IVAR]])
+// CHECK-DAG: ![[DECLARED_PROP:[0-9]+]] = !DIObjCProperty(name: "declaredBacking", file: !{{[0-9]+}}, line: {{[0-9]+}}, attributes: 2316, type: ![[INT_TY:[0-9]+]])
+// CHECK-DAG: ![[UNDECLARED_PROP:[0-9]+]] = !DIObjCProperty(name: "undeclaredBacking", file: !{{[0-9]+}}, line: {{[0-9]+}}, attributes: 2316, type: ![[INT_TY]])
+// CHECK-DAG: ![[IMPLICIT_PROP:[0-9]+]] = !DIObjCProperty(name: "implicitBacking", file: !{{[0-9]+}}, line: {{[0-9]+}}, attributes: 2316, type: ![[INT_TY]])
 //
-// CHECK-DAG: ![[UNDECLARED_PROP:[0-9]+]] = !DIObjCProperty(name: "undeclaredBacking"
-// CHECK-SAME:                                              attributes: 2316
-// CHECK-SAME:                                              type: ![[UNDECLARED_TY:[0-9]+]]
-// CHECK-DAG: ![[UNDECLARED_IVAR:[0-9]+]] = !DIDerivedType(tag: DW_TAG_member, name: "_customUndeclaredIvar"
-// CHECK-SAME:                                             extraData: ![[UNDECLARED_PROP]]
-// CHECK-DAG: !DIProperty(name: "undeclaredBacking", file: !{{[0-9]+}}, line: {{[0-9]+}}, type: ![[UNDECLARED_TY]], backing_storage: ![[UNDECLARED_IVAR]])
+// CHECK-DAG: ![[DECLARED_IVAR:[0-9]+]] = !DIDerivedType(tag: DW_TAG_member, name: "_customDeclaredIvar", {{.*}}extraData: ![[DECLARED_PROP]])
+// CHECK-DAG: !DIProperty(name: "declaredBacking", file: !{{[0-9]+}}, line: {{[0-9]+}}, type: ![[INT_TY]], backing_storage: ![[DECLARED_IVAR]])
 //
-// CHECK-DAG: ![[IMPLICIT_PROP:[0-9]+]] = !DIObjCProperty(name: "implicitBacking"
-// CHECK-SAME:                                            attributes: 2316
-// CHECK-SAME:                                            type: ![[IMPLICIT_TY:[0-9]+]]
-// CHECK-DAG: ![[IMPLICIT_IVAR:[0-9]+]] = !DIDerivedType(tag: DW_TAG_member, name: "_implicitBacking"
-// CHECK-SAME:                                           extraData: ![[IMPLICIT_PROP]]
-// CHECK-DAG: !DIProperty(name: "implicitBacking", file: !{{[0-9]+}}, line: {{[0-9]+}}, type: ![[IMPLICIT_TY]], backing_storage: ![[IMPLICIT_IVAR]])
+// CHECK-DAG: ![[UNDECLARED_IVAR:[0-9]+]] = !DIDerivedType(tag: DW_TAG_member, name: "_customUndeclaredIvar", {{.*}}extraData: ![[UNDECLARED_PROP]])
+// CHECK-DAG: !DIProperty(name: "undeclaredBacking", file: !{{[0-9]+}}, line: {{[0-9]+}}, type: ![[INT_TY]], backing_storage: ![[UNDECLARED_IVAR]])
+//
+// CHECK-DAG: ![[IMPLICIT_IVAR:[0-9]+]] = !DIDerivedType(tag: DW_TAG_member, name: "_implicitBacking", {{.*}}extraData: ![[IMPLICIT_PROP]])
+// CHECK-DAG: !DIProperty(name: "implicitBacking", file: !{{[0-9]+}}, line: {{[0-9]+}}, type: ![[INT_TY]], backing_storage: ![[IMPLICIT_IVAR]])
 
 @interface C {
   int _customDeclaredIvar;


### PR DESCRIPTION
Follow-up to #215776, which added `DW_TAG_property` / `DIProperty` support to LLVM's DebugInfo. This patch teaches Clang's CodeGen to emit the new `DIProperty` node.

In addition to the legacy `DIObjCProperty` node, `CGDebugInfo` now also emits a `DIProperty` node whose `backing_storage` points at the ivar a synthesized property forwards to.

Covered in `clang/test/DebugInfo/ObjC/property-backing-storage.m`:
- `declaredBacking`: `@synthesize` binds to a custom ivar name that IS declared in the `@interface`.
- `undeclaredBacking`: `@synthesize` binds to a custom ivar name that is NOT declared; the compiler creates the ivar itself.
- `implicitBacking`: no `@synthesize` at all; the compiler auto-synthesizes both the accessors and a default-named ivar.