### PR TITLE
[SPIRV] Add missing SampleCubeArray and ImageCubeArray SPIRV capabilities

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -1050,7 +1050,9 @@ void RequirementHandler::initAvailableCapabilitiesForVulkan(
                     Capability::VulkanMemoryModelKHR,
                     Capability::StorageImageExtendedFormats,
                     Capability::StorageImageMultisample,
-                    Capability::ImageMSArray});
+                    Capability::ImageMSArray,
+                    Capability::SampledCubeArray,
+                    Capability::ImageCubeArray});
 
   // Became core in Vulkan 1.2
   if (ST.isAtLeastSPIRVVer(VersionTuple(1, 5))) {

--- a/llvm/test/CodeGen/SPIRV/hlsl-resources/SampleCubeArray.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-resources/SampleCubeArray.ll
@@ -1,0 +1,43 @@
+; RUN: llc -O0 -mtriple=spirv-vulkan-compute %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-vulkan-compute %s -o - -filetype=obj | spirv-val %}
+
+; An arrayed cube image needs SampledCubeArray in addition to Shader.
+; CHECK-DAG: OpCapability Shader
+; CHECK-DAG: OpCapability SampledCubeArray
+
+; CHECK-DAG: %[[float:[0-9]+]] = OpTypeFloat 32
+; CHECK-DAG: %[[v4float:[0-9]+]] = OpTypeVector %[[float]] 4
+; CHECK-DAG: %[[image:[0-9]+]] = OpTypeImage %[[float]] Cube 2 1 0 1 Unknown
+; CHECK-DAG: %[[sampled_image:[0-9]+]] = OpTypeSampledImage %[[image]]
+; CHECK-DAG: %[[sampler:[0-9]+]] = OpTypeSampler
+; CHECK-DAG: %[[lod:[0-9]+]] = OpConstant %[[float]] 0
+
+@.str = private unnamed_addr constant [4 x i8] c"img\00", align 1
+@.str.1 = private unnamed_addr constant [5 x i8] c"samp\00", align 1
+@.str.2 = private unnamed_addr constant [4 x i8] c"out\00", align 1
+
+define void @main() {
+entry:
+  %img = tail call target("spirv.Image", float, 3, 2, 1, 0, 1, 0) @llvm.spv.resource.handlefrombinding.tspirv.Image_f32_3_2_1_0_1_0t(i32 0, i32 0, i32 1, i32 0, ptr @.str)
+  %sampler = tail call target("spirv.Sampler") @llvm.spv.resource.handlefrombinding.tspirv.Samplert(i32 0, i32 1, i32 1, i32 0, ptr @.str.1)
+
+; The coordinate is a 4-vector: xyz select the face direction, w the cube index.
+; CHECK: %[[img_val:[0-9]+]] = OpLoad %[[image]]
+; CHECK: %[[sampler_val:[0-9]+]] = OpLoad %[[sampler]]
+; CHECK: %[[si:[0-9]+]] = OpSampledImage %[[sampled_image]] %[[img_val]] %[[sampler_val]]
+; CHECK: %[[res:[0-9]+]] = OpImageSampleExplicitLod %[[v4float]] %[[si]] %{{[0-9]+}} Lod %[[lod]]
+  %res = call <4 x float> @llvm.spv.resource.samplelevel.v4f32.tspirv.Image_f32_3_2_1_0_1_0t.tspirv.Samplert.v4f32.v3i32(target("spirv.Image", float, 3, 2, 1, 0, 1, 0) %img, target("spirv.Sampler") %sampler, <4 x float> <float 1.0, float 0.0, float 0.0, float 0.0>, float 0.0, <3 x i32> zeroinitializer)
+
+; CHECK: %[[out_handle:[0-9]+]] = OpLoad {{.*}}
+; CHECK: OpImageWrite %[[out_handle]] {{.*}}
+  %out = tail call target("spirv.Image", float, 5, 2, 0, 0, 2, 1) @llvm.spv.resource.handlefrombinding.tspirv.Image_f32_5_2_0_0_2_1t(i32 0, i32 2, i32 1, i32 0, ptr @.str.2)
+  %out_ptr = call ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.Image_f32_5_2_0_0_2_1t(target("spirv.Image", float, 5, 2, 0, 0, 2, 1) %out, i32 0)
+  store <4 x float> %res, ptr addrspace(11) %out_ptr
+  ret void
+}
+
+declare target("spirv.Image", float, 3, 2, 1, 0, 1, 0) @llvm.spv.resource.handlefrombinding.tspirv.Image_f32_3_2_1_0_1_0t(i32, i32, i32, i32, ptr)
+declare target("spirv.Sampler") @llvm.spv.resource.handlefrombinding.tspirv.Samplert(i32, i32, i32, i32, ptr)
+declare <4 x float> @llvm.spv.resource.samplelevel.v4f32.tspirv.Image_f32_3_2_1_0_1_0t.tspirv.Samplert.v4f32.v3i32(target("spirv.Image", float, 3, 2, 1, 0, 1, 0), target("spirv.Sampler"), <4 x float>, float, <3 x i32>)
+declare target("spirv.Image", float, 5, 2, 0, 0, 2, 1) @llvm.spv.resource.handlefrombinding.tspirv.Image_f32_5_2_0_0_2_1t(i32, i32, i32, i32, ptr)
+declare ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.Image_f32_5_2_0_0_2_1t(target("spirv.Image", float, 5, 2, 0, 0, 2, 1), i32)

--- a/llvm/test/CodeGen/SPIRV/image_dim.ll
+++ b/llvm/test/CodeGen/SPIRV/image_dim.ll
@@ -13,9 +13,11 @@
 ; RUN: llc -O0 -mtriple=spirv-vulkan-library %t/vulkan.ll -o - | FileCheck %s --check-prefix=CHECK-VULKAN
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-vulkan-library %t/vulkan.ll -o - -filetype=obj | spirv-val %}
 
-;; Vulkan: an arrayed cube image requires SampledCubeArray when it is sampled,
-;;         and ImageCubeArray when it is a storage image. A non-arrayed cube
-;;         image requires neither.
+;; Vulkan: a cube image requires no extra capabilities unless it is arrayed;
+;;         an arrayed cube image requires SampledCubeArray when it is sampled,
+;;         and ImageCubeArray when it is a storage image.
+; RUN: llc -O0 -mtriple=spirv-vulkan-library %t/vulkan-cube.ll -o - | FileCheck %s --check-prefix=CHECK-CUBE
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-vulkan-library %t/vulkan-cube.ll -o - -filetype=obj | spirv-val %}
 ; RUN: llc -O0 -mtriple=spirv-vulkan-library %t/vulkan-cube-sampled.ll -o - | FileCheck %s --check-prefix=CHECK-CUBE-SAMPLED
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-vulkan-library %t/vulkan-cube-sampled.ll -o - -filetype=obj | spirv-val %}
 ; RUN: llc -O0 -mtriple=spirv-vulkan-library %t/vulkan-cube-storage.ll -o - | FileCheck %s --check-prefix=CHECK-CUBE-STORAGE
@@ -28,13 +30,19 @@
 ; CHECK-VULKAN-DAG: OpCapability ImageMSArray
 ; CHECK-VULKAN-NOT: OpCapability ImageCubeArray
 
-;; ImageCubeArray implicitly declares SampledCubeArray, so a module that only
-;; needs the sampled form must not fall back to the storage capability.
+;; A cube image that is not arrayed needs neither cube-array capability,
+;; whether it is sampled or a storage image.
+; CHECK-CUBE-DAG: OpCapability Shader
+; CHECK-CUBE-NOT: OpCapability SampledCubeArray
+; CHECK-CUBE-NOT: OpCapability ImageCubeArray
+
 ; CHECK-CUBE-SAMPLED-DAG: OpCapability Shader
 ; CHECK-CUBE-SAMPLED-DAG: OpCapability SampledCubeArray
+; CHECK-CUBE-SAMPLED-NOT: OpCapability ImageCubeArray
 
 ; CHECK-CUBE-STORAGE-DAG: OpCapability Shader
 ; CHECK-CUBE-STORAGE-DAG: OpCapability ImageCubeArray
+; CHECK-CUBE-STORAGE-NOT: OpCapability SampledCubeArray
 
 ;--- opencl.ll
 define spir_kernel void @test_image_dim(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %image1d, target("spirv.Image", void, 5, 0, 0, 0, 0, 0, 0) %image1d_buffer) {
@@ -62,15 +70,24 @@ define void @test_3d(
 
 attributes #0 = { convergent noinline norecurse "frame-pointer"="all" }
 
-;--- vulkan-cube-sampled.ll
-define void @test_cube_arrayed_sampled(
-  target("spirv.Image", float, 3, 0, 1, 0, 1, 0) %imagecube_arrayed_sampled
+;--- vulkan-cube.ll
+define void @test_cube_sampled(
+  target("spirv.Image", float, 3, 0, 0, 0, 1, 0) %imagecube_sampled
 ) #0 {
   ret void
 }
 
-define void @test_cube_sampled(
-  target("spirv.Image", float, 3, 0, 0, 0, 1, 0) %imagecube_sampled
+define void @test_cube_storage(
+  target("spirv.Image", float, 3, 0, 0, 0, 2, 3) %imagecube_storage
+) #0 {
+  ret void
+}
+
+attributes #0 = { convergent noinline norecurse "frame-pointer"="all" }
+
+;--- vulkan-cube-sampled.ll
+define void @test_cube_arrayed_sampled(
+  target("spirv.Image", float, 3, 0, 1, 0, 1, 0) %imagecube_arrayed_sampled
 ) #0 {
   ret void
 }

--- a/llvm/test/CodeGen/SPIRV/image_dim.ll
+++ b/llvm/test/CodeGen/SPIRV/image_dim.ll
@@ -13,12 +13,28 @@
 ; RUN: llc -O0 -mtriple=spirv-vulkan-library %t/vulkan.ll -o - | FileCheck %s --check-prefix=CHECK-VULKAN
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-vulkan-library %t/vulkan.ll -o - -filetype=obj | spirv-val %}
 
+;; Vulkan: an arrayed cube image requires SampledCubeArray when it is sampled,
+;;         and ImageCubeArray when it is a storage image. A non-arrayed cube
+;;         image requires neither.
+; RUN: llc -O0 -mtriple=spirv-vulkan-library %t/vulkan-cube-sampled.ll -o - | FileCheck %s --check-prefix=CHECK-CUBE-SAMPLED
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-vulkan-library %t/vulkan-cube-sampled.ll -o - -filetype=obj | spirv-val %}
+; RUN: llc -O0 -mtriple=spirv-vulkan-library %t/vulkan-cube-storage.ll -o - | FileCheck %s --check-prefix=CHECK-CUBE-STORAGE
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-vulkan-library %t/vulkan-cube-storage.ll -o - -filetype=obj | spirv-val %}
+
 ; CHECK-OPENCL-DAG: OpCapability Sampled1D
 ; CHECK-OPENCL-DAG: OpCapability SampledBuffer
 
 ; CHECK-VULKAN-DAG: OpCapability StorageImageMultisample
 ; CHECK-VULKAN-DAG: OpCapability ImageMSArray
 ; CHECK-VULKAN-NOT: OpCapability ImageCubeArray
+
+;; ImageCubeArray implicitly declares SampledCubeArray, so a module that only
+;; needs the sampled form must not fall back to the storage capability.
+; CHECK-CUBE-SAMPLED-DAG: OpCapability Shader
+; CHECK-CUBE-SAMPLED-DAG: OpCapability SampledCubeArray
+
+; CHECK-CUBE-STORAGE-DAG: OpCapability Shader
+; CHECK-CUBE-STORAGE-DAG: OpCapability ImageCubeArray
 
 ;--- opencl.ll
 define spir_kernel void @test_image_dim(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %image1d, target("spirv.Image", void, 5, 0, 0, 0, 0, 0, 0) %image1d_buffer) {
@@ -40,6 +56,30 @@ define void @test_2d_ms_arrayed_storage(
 
 define void @test_3d(
   target("spirv.Image", float, 2, 0, 0, 0, 2, 3) %image3d_storage
+) #0 {
+  ret void
+}
+
+attributes #0 = { convergent noinline norecurse "frame-pointer"="all" }
+
+;--- vulkan-cube-sampled.ll
+define void @test_cube_arrayed_sampled(
+  target("spirv.Image", float, 3, 0, 1, 0, 1, 0) %imagecube_arrayed_sampled
+) #0 {
+  ret void
+}
+
+define void @test_cube_sampled(
+  target("spirv.Image", float, 3, 0, 0, 0, 1, 0) %imagecube_sampled
+) #0 {
+  ret void
+}
+
+attributes #0 = { convergent noinline norecurse "frame-pointer"="all" }
+
+;--- vulkan-cube-storage.ll
+define void @test_cube_arrayed_storage(
+  target("spirv.Image", float, 3, 0, 1, 0, 2, 3) %imagecube_arrayed_storage
 ) #0 {
   ret void
 }


### PR DESCRIPTION
This can be considered a fixup to PR #218521

This PR adds missing SPIRV codegen tests for exercising the SampleCubeArray and ImageCubeArray capabilities.

Assisted by: Claude Opus 5