### PR TITLE
[libc][math] Fix `quick_add`  incorrect exponent

### DIFF
--- a/libc/src/__support/FPUtil/dyadic_float.h
+++ b/libc/src/__support/FPUtil/dyadic_float.h
@@ -140,12 +140,10 @@ template <size_t Bits> struct DyadicFloat {
   // Used for aligning exponents.  Output might not be normalized.
   LIBC_INLINE constexpr DyadicFloat &shift_left(unsigned shift_length) {
     exponent -= static_cast<int>(shift_length);
-    if (shift_length < Bits) {
+    if (shift_length < Bits)
       mantissa <<= shift_length;
-    } else {
-      exponent = 0;
+    else
       mantissa = MantissaType(0);
-    }
     return *this;
   }
 

--- a/libc/src/__support/FPUtil/dyadic_float.h
+++ b/libc/src/__support/FPUtil/dyadic_float.h
@@ -139,8 +139,8 @@ template <size_t Bits> struct DyadicFloat {
 
   // Used for aligning exponents.  Output might not be normalized.
   LIBC_INLINE constexpr DyadicFloat &shift_left(unsigned shift_length) {
+    exponent -= static_cast<int>(shift_length);
     if (shift_length < Bits) {
-      exponent -= static_cast<int>(shift_length);
       mantissa <<= shift_length;
     } else {
       exponent = 0;

--- a/libc/src/__support/FPUtil/dyadic_float.h
+++ b/libc/src/__support/FPUtil/dyadic_float.h
@@ -151,13 +151,11 @@ template <size_t Bits> struct DyadicFloat {
 
   // Used for aligning exponents.  Output might not be normalized.
   LIBC_INLINE constexpr DyadicFloat &shift_right(unsigned shift_length) {
-    if (shift_length < Bits) {
-      exponent += static_cast<int>(shift_length);
+    exponent += static_cast<int>(shift_length);
+    if (shift_length < Bits)
       mantissa >>= shift_length;
-    } else {
-      exponent = 0;
+    else
       mantissa = MantissaType(0);
-    }
     return *this;
   }
 

--- a/libc/test/src/__support/FPUtil/dyadic_float_test.cpp
+++ b/libc/test/src/__support/FPUtil/dyadic_float_test.cpp
@@ -44,6 +44,18 @@ TEST(LlvmLibcDyadicFloatTest, QuickAdd) {
 
   Float192 z = quick_add(x, y);
   EXPECT_FP_EQ_ALL_ROUNDING(double(x) + double(y), double(z));
+
+  DFloat128 a(0x1.0p0);
+  ASSERT_FP_EQ(0x1.0p0, double(a));
+
+  DFloat128 b(0x1.0p128);
+  ASSERT_FP_EQ(0x1.0p128, double(b));
+
+  DFloat128 c1 = quick_add(a, b);
+  EXPECT_FP_EQ(double(a) + double(b), double(c1));
+
+  DFloat128 c2 = quick_add(b, a);
+  EXPECT_FP_EQ(double(b) + double(a), double(c2));
 }
 
 TEST(LlvmLibcDyadicFloatTest, QuickMul) {


### PR DESCRIPTION
Fixes #220140

Failure from the test added 
```sh
 FAILURE
Failed to match double(c1) against LIBC_NAMESPACE::testing::getMatcher< LIBC_NAMESPACE::testing::TestCond::EQ>(double(a) + double(b)).
Expected floating point value: 0x47F0000000000000 = (S: 0, E: 0x047F, M: 0x0000000000000000)
Actual floating point value: 0x3FF0000000000000 = (S: 0, E: 0x03FF, M: 0x0000000000000000)
```