### PR TITLE
[lld][ELF] Don't emit dynamic relocations into .gcc_except_table with -znotext

### DIFF
--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -984,14 +984,18 @@ void RelocScan::processAux(RelExpr expr, RelType type, uint64_t offset,
     return;
   }
 
-  // Use a simple -z notext rule that treats all sections except .eh_frame as
-  // writable. GNU ld does not produce dynamic relocations in .eh_frame.
+  // Use a simple -z notext rule that treats all sections except the exception
+  // handling metadata as writable. GNU ld and gold do not produce dynamic
+  // relocations in .eh_frame or .gcc_except_table; they resolve the reference
+  // at link time, with a copy relocation where one is needed.
   //
   // For MIPS, we don't implement GNU ld's DW_EH_PE_absptr to DW_EH_PE_pcrel
   // conversion. We still emit a dynamic relocation.
-  bool canWrite = (sec->flags & SHF_WRITE) ||
-                  !(ctx.arg.zText ||
-                    (isa<EhInputSection>(sec) && ctx.arg.emachine != EM_MIPS));
+  bool isEhMetadata =
+      isa<EhInputSection>(sec) || sec->name.starts_with(".gcc_except_table");
+  bool canWrite =
+      (sec->flags & SHF_WRITE) ||
+      !(ctx.arg.zText || (isEhMetadata && ctx.arg.emachine != EM_MIPS));
   if (canWrite) {
     RelType rel = ctx.target->getDynRel(type);
     if (oneof<R_GOT, RE_LOONGARCH_GOT>(expr) ||

--- a/lld/test/ELF/gcc-except-table-znotext.s
+++ b/lld/test/ELF/gcc-except-table-znotext.s
@@ -1,0 +1,47 @@
+# REQUIRES: x86
+## A symbolic relocation for -z notext in .gcc_except_table could emit a dynamic
+## relocation, but we avoid that and resolve it at link time, using a copy
+## relocation where one is needed. This matches GNU ld and gold, and mirrors the
+## treatment of .eh_frame.
+
+# RUN: rm -rf %t && split-file %s %t && cd %t
+# RUN: llvm-mc -filetype=obj -triple=x86_64 a.s -o a.o
+# RUN: llvm-mc -filetype=obj -triple=x86_64 b.s -o b.o
+# RUN: ld.lld -shared b.o -o b.so -soname b.so
+
+# RUN: ld.lld a.o b.so -o a
+# RUN: llvm-readelf -r a | FileCheck %s
+# RUN: ld.lld -z notext a.o b.so -o a
+# RUN: llvm-readelf -r a | FileCheck %s
+
+## Per-function sections created by -ffunction-sections get the same treatment.
+# RUN: llvm-mc -filetype=obj -triple=x86_64 c.s -o c.o
+# RUN: ld.lld -z notext c.o b.so -o c
+# RUN: llvm-readelf -r c | FileCheck %s
+
+# CHECK:     R_X86_64_COPY {{.*}} obj + 0
+# CHECK-NOT: R_X86_64_64
+
+#--- a.s
+.globl _start
+_start:
+  ret
+
+.section .gcc_except_table,"a",@progbits
+  .quad obj
+
+#--- c.s
+.globl _start
+_start:
+  ret
+
+.section .gcc_except_table._start,"a",@progbits
+  .quad obj
+
+#--- b.s
+.data
+.globl obj
+.type obj, @object
+.size obj, 8
+obj:
+  .quad 0


### PR DESCRIPTION
The -z notext rule already treats .eh_frame as non-writable, so that a symbolic relocation there is resolved at link time -- with a copy relocation where one is needed -- rather than deferred to the loader. The in-tree rationale is that GNU ld does not produce dynamic relocations in .eh_frame.

The same holds for .gcc_except_table, but it was not covered. Linking a non-PIE executable whose LSDA type table uses DW_EH_PE_absptr entries naming typeinfos from a shared library, with -z notext:

| Linker | Dynamic Relocations in `.gcc_except_table` | `R_X86_64_COPY` |
| :--- | :--- | :--- |
| **GNU ld** | 0 | 3 |
| **gold** | 0 | 3 |
| **lld** | 3 | 0 |

Extend the existing carve-out to .gcc_except_table, including the per-function sections -ffunction-sections creates, so lld matches GNU ld and gold.

Assisted-By: Codex