### PR TITLE
[libc][baremetal][BigInt] fix codegen issue for UInt128

### DIFF
--- a/libc/src/__support/big_int.h
+++ b/libc/src/__support/big_int.h
@@ -617,8 +617,19 @@ public:
   }
 
   LIBC_INLINE constexpr BigInt operator*(const BigInt &other) const {
-    // Perform full mul and truncate.
-    return BigInt(ful_mul(other));
+    if constexpr (!Signed && WORD_COUNT == 2) {
+      // Straight-line truncating multiply for the double-word case.
+      BigInt result{};
+      multiword::DoubleWide<word_type> lo_prod =
+          multiword::mul2(val[0], other.val[0]);
+      result.val[0] = multiword::lo(lo_prod);
+      result.val[1] = multiword::hi(lo_prod) + val[0] * other.val[1] +
+                      val[1] * other.val[0];
+      return result;
+    } else {
+      // Perform full mul and truncate.
+      return BigInt(ful_mul(other));
+    }
   }
 
   // Fast hi part of the full product.  The normal product `operator*` returns

--- a/libc/src/__support/big_int.h
+++ b/libc/src/__support/big_int.h
@@ -17,7 +17,7 @@
 #include "src/__support/CPP/type_traits.h"
 #include "src/__support/macros/attributes.h" // LIBC_INLINE
 #include "src/__support/macros/config.h"
-#include "src/__support/macros/optimization.h"        // LIBC_UNLIKELY
+#include "src/__support/macros/optimization.h" // LIBC_UNLIKELY, LIBC_LOOP_UNROLL
 #include "src/__support/macros/properties/compiler.h" // LIBC_COMPILER_IS_CLANG
 #include "src/__support/macros/properties/types.h" // LIBC_TYPES_HAS_INT128, LIBC_TYPES_HAS_INT64
 #include "src/__support/math_extras.h" // add_with_carry, sub_with_borrow
@@ -214,13 +214,23 @@ LIBC_INLINE constexpr word multiply_with_carry(cpp::array<word, O> &dst,
                                                const cpp::array<word, N> &rhs) {
   static_assert(O >= M + N);
   Accumulator<word> acc;
-  for (size_t i = 0; i < O; ++i) {
+  auto step = [&](size_t i) {
     const size_t lower_idx = i < N ? 0 : i - N + 1;
     const size_t upper_idx = i < M ? i : M - 1;
     word carry = 0;
     for (size_t j = lower_idx; j <= upper_idx; ++j)
       carry += mul_add_with_carry(acc, lhs[j], rhs[i - j]);
     dst[i] = acc.advance(carry);
+  };
+  // Unrolling up to 4 words is enough for UInt128, the most used large integer
+  // type; larger integers may bloat the code too much.
+  if constexpr (O <= 4) {
+    LIBC_LOOP_UNROLL
+    for (size_t i = 0; i < O; ++i)
+      step(i);
+  } else {
+    for (size_t i = 0; i < O; ++i)
+      step(i);
   }
   return acc.carry();
 }
@@ -617,19 +627,8 @@ public:
   }
 
   LIBC_INLINE constexpr BigInt operator*(const BigInt &other) const {
-    if constexpr (!Signed && WORD_COUNT == 2) {
-      // Straight-line truncating multiply for the double-word case.
-      BigInt result{};
-      multiword::DoubleWide<word_type> lo_prod =
-          multiword::mul2(val[0], other.val[0]);
-      result.val[0] = multiword::lo(lo_prod);
-      result.val[1] = multiword::hi(lo_prod) + val[0] * other.val[1] +
-                      val[1] * other.val[0];
-      return result;
-    } else {
-      // Perform full mul and truncate.
-      return BigInt(ful_mul(other));
-    }
+    // Perform full mul and truncate.
+    return BigInt(ful_mul(other));
   }
 
   // Fast hi part of the full product.  The normal product `operator*` returns

--- a/libc/src/__support/big_int.h
+++ b/libc/src/__support/big_int.h
@@ -204,6 +204,11 @@ LIBC_INLINE constexpr word scalar_multiply_with_carry(cpp::array<word, N> &dst,
   return acc.carry();
 }
 
+// Products of up to this many words are fully unrolled. 4 words is enough for
+// UInt128, the most used large integer type; larger integers may bloat the code
+// too much.
+LIBC_INLINE_VAR constexpr size_t MUL_UNROLL_MAX_WORDS = 4;
+
 // Multiplication of 'lhs' by 'rhs' into 'dst'. Returns carry.
 // This function is safe to use for signed numbers.
 // https://stackoverflow.com/a/20793834
@@ -222,9 +227,7 @@ LIBC_INLINE constexpr word multiply_with_carry(cpp::array<word, O> &dst,
       carry += mul_add_with_carry(acc, lhs[j], rhs[i - j]);
     dst[i] = acc.advance(carry);
   };
-  // Unrolling up to 4 words is enough for UInt128, the most used large integer
-  // type; larger integers may bloat the code too much.
-  if constexpr (O <= 4) {
+  if constexpr (O <= MUL_UNROLL_MAX_WORDS) {
     LIBC_LOOP_UNROLL
     for (size_t i = 0; i < O; ++i)
       step(i);

--- a/libc/src/__support/math_extras.h
+++ b/libc/src/__support/math_extras.h
@@ -108,13 +108,17 @@ add_with_carry(T a, T b, T carry_in, T &carry_out) {
   if (!cpp::is_constant_evaluated()) {
 #if __has_builtin(__builtin_addcb)
     RETURN_IF(unsigned char, __builtin_addcb)
-#elif __has_builtin(__builtin_addcs)
+#endif
+#if __has_builtin(__builtin_addcs)
     RETURN_IF(unsigned short, __builtin_addcs)
-#elif __has_builtin(__builtin_addc)
+#endif
+#if __has_builtin(__builtin_addc)
     RETURN_IF(unsigned int, __builtin_addc)
-#elif __has_builtin(__builtin_addcl)
+#endif
+#if __has_builtin(__builtin_addcl)
     RETURN_IF(unsigned long, __builtin_addcl)
-#elif __has_builtin(__builtin_addcll)
+#endif
+#if __has_builtin(__builtin_addcll)
     RETURN_IF(unsigned long long, __builtin_addcll)
 #endif
   }
@@ -134,13 +138,17 @@ sub_with_borrow(T a, T b, T carry_in, T &carry_out) {
   if (!cpp::is_constant_evaluated()) {
 #if __has_builtin(__builtin_subcb)
     RETURN_IF(unsigned char, __builtin_subcb)
-#elif __has_builtin(__builtin_subcs)
+#endif
+#if __has_builtin(__builtin_subcs)
     RETURN_IF(unsigned short, __builtin_subcs)
-#elif __has_builtin(__builtin_subc)
+#endif
+#if __has_builtin(__builtin_subc)
     RETURN_IF(unsigned int, __builtin_subc)
-#elif __has_builtin(__builtin_subcl)
+#endif
+#if __has_builtin(__builtin_subcl)
     RETURN_IF(unsigned long, __builtin_subcl)
-#elif __has_builtin(__builtin_subcll)
+#endif
+#if __has_builtin(__builtin_subcll)
     RETURN_IF(unsigned long long, __builtin_subcll)
 #endif
   }


### PR DESCRIPTION
`BigInt::operator*` always computes the full 2N-word product (`ful_mul`, i.e. `multiword::multiply_with_carry`) and then truncates. In order to scalarize the process to generate efficient code, the loop needs to be fully unrolled, which fails on 32-bit targets for int128 due to LLVM's default threshold. This patch adjust the hint to allow int128 to be unrolled while gating larger integers away.


### 64-bit targets: roughly okay

aarch64 is byte-identical before/after; x86-64 gets one `mov` shorter. After the patch, 128×128→128 (lo/hi in memory):

```asm
; aarch64                          ; x86-64
ldp   x8, x12, [x0]                movq   (%rdi), %r9
ldp   x9, x10, [x1]                movq   (%rsi), %r8
mul   x10, x10, x8                 movq   %r8, %rax
mul   x11, x9, x8                  mulq   %r9
umulh x8, x9, x8                   imulq  8(%rsi), %r9
madd  x9, x9, x12, x10             imulq  8(%rdi), %r8
add   x8, x9, x8                   addq   %r9, %r8
stp   x11, x8, [x2]                addq   %rdx, %r8
ret                                ...
```

### 32-bit targets (e.g. cortex-m85): badly bloated

A 64-byte stack frame, carry selection through IT blocks, and a call into an outlined `ful_mul`. Kernel is the folded multiply (`lo ^ hi` of the `UInt<128>` product):

```asm
; before                           ; after
sub    sp, #64                     umull  r12, lr, r2, r0
mov.w  r12, #0                     umull  r2, r4, r2, r1
strd   r12, r12, [sp, #24]         umull  r0, r5, r3, r0
orrs.w lr, r0, r1                  umaal  r4, r5, r3, r1
it     ne                          adds.w r1, lr, r2
strdne r0, r1, [sp, #16]           adcs   r2, r4, #0
... (5 more stores)                adc    r3, r5, #0
bl     BigInt<128>::ful_mul        adds   r0, r0, r1
ldm    r3, {r0, r1, r2, r3}        adcs   r2, r2, #0
eors   r1, r3                      adc    r1, r3, #0
eors   r0, r2                      eors   r1, r0
add    sp, #64                     eor.w  r0, r2, r12
```

llvm-mca (cortex-m85): **114 → 11 cycles** per folded multiply.

### Benchmarks

| environment | before | after | speedup |
|---|---|---|---|
| EK-RA8M2 (Cortex-M85 r1p1, DWT cycle counter, I-cache on) | 250 cyc/mul | 20 cyc/mul | 12.5× |
| wasm32 under wasmer 7.3, `-U__SIZEOF_INT128__` (see notes) | 0.70 s / 100M muls | 0.28 s | 2.5× |

Bench kernel (dependent chain, identical results before/after):

```cpp
using B = LIBC_NAMESPACE::BigInt<128, false, uint64_t>;
B x = (B(a) << 64) | B(~a);
B y = (B(b) << 64) | B(~b);
for (int i = 0; i < n; i++) {
  x = x * y;
  y.val[0] ^= x.val[1];
}
return x.val[0] ^ x.val[1];
```

### Carry builtin dispatch fix

Additionally, fix a typo in the `add_with_carry` / `sub_with_borrow` builtin dispatch: the `#if`/`#elif` chain over `__has_builtin`.

### Notes

1. Another workaround for such targets is to force-enable native 128-bit integers (clang's `-fforce-enable-int128`)
2. The wasm number above is benched with 128-bit integers forcibly disabled (`-U__SIZEOF_INT128__`), just to check its effect.

---

Guided and reviewed by human

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

