### PR TITLE
Add Instruction::user_iterator.

### DIFF
--- a/llvm/include/llvm/IR/Instruction.h
+++ b/llvm/include/llvm/IR/Instruction.h
@@ -197,8 +197,43 @@ public:
 
   /// Specialize the methods defined in Value, as we know that an instruction
   /// can only be used by other instructions.
-  Instruction       *user_back()       { return cast<Instruction>(*user_begin());}
-  const Instruction *user_back() const { return cast<Instruction>(*user_begin());}
+  using user_iterator = user_iterator_impl<Instruction>;
+  using const_user_iterator = user_iterator_impl<const Instruction>;
+  user_iterator materialized_user_begin() {
+    assert(hasUseList());
+    return user_iterator(UseList);
+  }
+  const_user_iterator materialized_user_begin() const {
+    assert(hasUseList());
+    return const_user_iterator(UseList);
+  }
+  user_iterator user_begin() {
+    assertModuleIsMaterialized();
+    return materialized_user_begin();
+  }
+  const_user_iterator user_begin() const {
+    assertModuleIsMaterialized();
+    return materialized_user_begin();
+  }
+  user_iterator user_end() { return user_iterator(); }
+  const_user_iterator user_end() const { return const_user_iterator(); }
+
+  iterator_range<user_iterator> materialized_users() {
+    return make_range(materialized_user_begin(), user_end());
+  }
+  iterator_range<const_user_iterator> materialized_users() const {
+    return make_range(materialized_user_begin(), user_end());
+  }
+  iterator_range<user_iterator> users() {
+    assertModuleIsMaterialized();
+    return materialized_users();
+  }
+  iterator_range<const_user_iterator> users() const {
+    assertModuleIsMaterialized();
+    return materialized_users();
+  }
+  Instruction *user_back() { return *user_begin(); }
+  const Instruction *user_back() const { return *user_begin(); }
 
   /// Return the module owning the function this instruction belongs to
   /// or nullptr it the function does not have a module.

--- a/llvm/include/llvm/IR/Value.h
+++ b/llvm/include/llvm/IR/Value.h
@@ -116,8 +116,11 @@ protected:
 
 private:
   Type *VTy;
+
+protected:
   Use *UseList = nullptr;
 
+private:
   friend class ValueAsMetadata; // Allow access to IsUsedByMD.
   friend class ValueHandleBase; // Allow access to HasValueHandle.
 
@@ -165,11 +168,13 @@ private:
     }
   };
 
+protected:
   template <typename UserTy> // UserTy == 'User' or 'const User'
   class user_iterator_impl {
     use_iterator_impl<Use> UI;
     explicit user_iterator_impl(Use *U) : UI(U) {}
     friend class Value;
+    friend class Instruction;
 
   public:
     using iterator_category = std::forward_iterator_tag;
@@ -198,9 +203,7 @@ private:
     }
 
     // Retrieve a pointer to the current User.
-    UserTy *operator*() const {
-      return UI->getUser();
-    }
+    UserTy *operator*() const { return cast<UserTy>(UI->getUser()); }
 
     UserTy *operator->() const { return operator*(); }
 
@@ -211,7 +214,6 @@ private:
     Use &getUse() const { return *UI; }
   };
 
-protected:
   LLVM_ABI Value(Type *Ty, unsigned scid);
 
   /// Value's destructor should be virtual by design, but that would require

--- a/llvm/lib/Analysis/IVDescriptors.cpp
+++ b/llvm/lib/Analysis/IVDescriptors.cpp
@@ -349,9 +349,9 @@ static RecurrenceDescriptor getMinMaxRecurrence(PHINode *Phi, Loop *TheLoop,
   // that are not intermediate min/max operations (which are handled below).
   // Requires integer min/max, and single-use BackedgeValue (so vectorizer can
   // handle both PHIs together).
-  bool PhiHasInvalidUses = any_of(Phi->users(), [&](User *U) {
+  bool PhiHasInvalidUses = any_of(Phi->users(), [&](Instruction *U) {
     Value *A, *B;
-    return !Chain.contains(U) && TheLoop->contains(cast<Instruction>(U)) &&
+    return !Chain.contains(U) && TheLoop->contains(U) &&
            GetMinMaxRK(U, A, B) == RecurKind::None;
   });
   if (PhiHasInvalidUses) {

--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -1129,7 +1129,8 @@ static void replaceAllUsesWith(Value *Old, Value *New,
                                bool IsHuge) {
   auto *OldI = dyn_cast<Instruction>(Old);
   if (OldI) {
-    for (Value::user_iterator UI = OldI->user_begin(), E = OldI->user_end();
+    for (Instruction::user_iterator UI = OldI->user_begin(),
+                                    E = OldI->user_end();
          UI != E; ++UI) {
       Instruction *User = cast<Instruction>(*UI);
       if (IsHuge)
@@ -1435,7 +1436,7 @@ static bool SinkCast(CastInst *CI) {
   DenseMap<BasicBlock *, CastInst *> InsertedCasts;
 
   bool MadeChange = false;
-  for (Value::user_iterator UI = CI->user_begin(), E = CI->user_end();
+  for (Instruction::user_iterator UI = CI->user_begin(), E = CI->user_end();
        UI != E;) {
     Use &TheUse = UI.getUse();
     Instruction *User = cast<Instruction>(*UI);
@@ -1902,7 +1903,7 @@ static bool sinkCmpExpression(CmpInst *Cmp, const TargetLowering &TLI,
   DenseMap<BasicBlock *, CmpInst *> InsertedCmps;
 
   bool MadeChange = false;
-  for (Value::user_iterator UI = Cmp->user_begin(), E = Cmp->user_end();
+  for (Instruction::user_iterator UI = Cmp->user_begin(), E = Cmp->user_end();
        UI != E;) {
     Use &TheUse = UI.getUse();
     Instruction *User = cast<Instruction>(*UI);
@@ -2335,7 +2336,7 @@ static bool sinkAndCmp0Expression(Instruction *AndI, const TargetLowering &TLI,
   // Push the 'and' into the same block as the icmp 0.  There should only be
   // one (icmp (and, 0)) in each block, since CSE/GVN should have removed any
   // others, so we don't need to keep track of which BBs we insert into.
-  for (Value::user_iterator UI = AndI->user_begin(), E = AndI->user_end();
+  for (Instruction::user_iterator UI = AndI->user_begin(), E = AndI->user_end();
        UI != E;) {
     Use &TheUse = UI.getUse();
     Instruction *User = cast<Instruction>(*UI);
@@ -2394,8 +2395,8 @@ SinkShiftAndTruncate(BinaryOperator *ShiftI, Instruction *User, ConstantInt *CI,
   auto *TruncI = cast<TruncInst>(User);
   bool MadeChange = false;
 
-  for (Value::user_iterator TruncUI = TruncI->user_begin(),
-                            TruncE = TruncI->user_end();
+  for (Instruction::user_iterator TruncUI = TruncI->user_begin(),
+                                  TruncE = TruncI->user_end();
        TruncUI != TruncE;) {
 
     Use &TruncTheUse = TruncUI.getUse();
@@ -2490,7 +2491,8 @@ static bool OptimizeExtractBits(BinaryOperator *ShiftI, ConstantInt *CI,
   bool shiftIsLegal = TLI.isTypeLegal(TLI.getValueType(DL, ShiftI->getType()));
 
   bool MadeChange = false;
-  for (Value::user_iterator UI = ShiftI->user_begin(), E = ShiftI->user_end();
+  for (Instruction::user_iterator UI = ShiftI->user_begin(),
+                                  E = ShiftI->user_end();
        UI != E;) {
     Use &TheUse = UI.getUse();
     Instruction *User = cast<Instruction>(*UI);

--- a/llvm/lib/Target/Hexagon/HexagonCommonGEP.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonCommonGEP.cpp
@@ -357,7 +357,8 @@ void HexagonCommonGEP::processGepInst(GetElementPtrInst *GepI,
   // Collect the list of users of this GEP instruction. Will add it to the
   // last node created for it.
   UseSet Us;
-  for (Value::user_iterator UI = GepI->user_begin(), UE = GepI->user_end();
+  for (Instruction::user_iterator UI = GepI->user_begin(),
+                                  UE = GepI->user_end();
        UI != UE; ++UI) {
     // Check if this gep is used by anything other than other geps that
     // we will process.

--- a/llvm/lib/Transforms/Scalar/LICM.cpp
+++ b/llvm/lib/Transforms/Scalar/LICM.cpp
@@ -1679,7 +1679,8 @@ static bool sink(Instruction &I, LoopInfo *LI, DominatorTree *DT,
   // Iterate over users to be ready for actual sinking. Replace users via
   // unreachable blocks with undef and make all user PHIs trivially replaceable.
   SmallPtrSet<Instruction *, 8> VisitedUsers;
-  for (Value::user_iterator UI = I.user_begin(), UE = I.user_end(); UI != UE;) {
+  for (Instruction::user_iterator UI = I.user_begin(), UE = I.user_end();
+       UI != UE;) {
     auto *User = cast<Instruction>(*UI);
     Use &U = UI.getUse();
     ++UI;

--- a/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
+++ b/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
@@ -1967,7 +1967,7 @@ makeStatepointExplicit(DominatorTree &DT, CallBase *Call,
 // visited values into the visitedLiveValues set, which we will later use them
 // for validation checking.
 static void
-insertRelocationStores(iterator_range<Value::user_iterator> GCRelocs,
+insertRelocationStores(iterator_range<Instruction::user_iterator> GCRelocs,
                        DenseMap<Value *, AllocaInst *> &AllocaMap,
                        DenseSet<Value *> &VisitedLiveValues) {
   for (User *U : GCRelocs) {
@@ -2069,7 +2069,7 @@ static void relocationViaAlloca(
   // gc_result).  This must happen before we update the statepoint with load of
   // alloca otherwise we lose the link between statepoint and old def.
   for (const auto &Info : Records) {
-    Value *Statepoint = Info.StatepointToken;
+    GCStatepointInst *Statepoint = Info.StatepointToken;
 
     // This will be used for consistency check
     DenseSet<Value *> VisitedLiveValues;

--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -602,8 +602,8 @@ void llvm::RecursivelyDeleteTriviallyDeadInstructions(
 /// true when there are no uses or multiple uses that all refer to the same
 /// value.
 static bool areAllUsesEqual(Instruction *I) {
-  Value::user_iterator UI = I->user_begin();
-  Value::user_iterator UE = I->user_end();
+  Instruction::user_iterator UI = I->user_begin();
+  Instruction::user_iterator UE = I->user_end();
   if (UI == UE)
     return true;
 

--- a/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
+++ b/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
@@ -7594,9 +7594,9 @@ TEST_F(OpenMPIRBuilderTest, CreateTaskDepend) {
   // Check for the `DepInfo` array argument
   AllocaInst *DepArray = dyn_cast<AllocaInst>(TaskAllocCall->getOperand(4));
   ASSERT_NE(DepArray, nullptr);
-  Value::user_iterator DepArrayI = DepArray->user_begin();
+  Instruction::user_iterator DepArrayI = DepArray->user_begin();
   ++DepArrayI;
-  Value::user_iterator DepInfoI = DepArrayI->user_begin();
+  Instruction::user_iterator DepInfoI = DepArrayI->user_begin();
   // Check for the `DependKind` flag in the `DepInfo` array
   Value *Flag = findStoredValue<GetElementPtrInst>(*DepInfoI);
   ASSERT_NE(Flag, nullptr);


### PR DESCRIPTION
Users of an Instruction have a special property: they're guaranteed to be Instructions themselves.  Add a specialized iterator to take advantage of this property.

See the change to IVDescriptors.cpp for an example of how this simplifies code.