### PR TITLE
[lldb] Make TypeSystemClang usage thread-safe

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
@@ -33,6 +33,44 @@
 using namespace lldb_private;
 using namespace clang;
 
+namespace {
+/// RAII lock guard that also tracks whether the ClangASTImporter is in a
+/// nested import call.
+///
+/// Once all imports are done, this RAII also completes all queued
+/// Objective-C interface completions.
+///
+/// \see ClangASTImporter::m_queued_objc_interfaces
+class ImportLock {
+public:
+  ImportLock(ClangASTImporter &importer, std::recursive_mutex &mutex)
+      : m_importer(importer), m_mutex(mutex) {
+    m_mutex.lock();
+    m_importer.m_nested_imports_depth++;
+  }
+
+  ~ImportLock() {
+    assert(m_importer.m_nested_imports_depth > 0 && "Not currently importing?");
+    m_importer.m_nested_imports_depth--;
+
+    bool done_importing = (m_importer.m_nested_imports_depth == 0);
+    m_mutex.unlock();
+    // We are no longer importing anything else and shouldn't hold
+    // any important locks anymore. It is now safe to complete
+    // any Objective-C declarations that we queued.
+    if (done_importing)
+      m_importer.CompleteQueuedObjCInterfaces();
+  }
+
+  ImportLock(const ImportLock &) = delete;
+  ImportLock &operator=(const ImportLock &) = delete;
+
+private:
+  ClangASTImporter &m_importer;
+  std::recursive_mutex &m_mutex;
+};
+} // namespace
+
 CompilerType ClangASTImporter::CopyType(TypeSystemClang &dst_ast,
                                         const CompilerType &src_type) {
   clang::ASTContext &dst_clang_ast = dst_ast.getASTContext();
@@ -641,6 +679,12 @@ bool ClangASTImporter::importRecordLayoutFromOrigin(
   if (origin_record.IsInvalid())
     return false;
 
+  // Lock the origin TypeSystemClang which might be shared between threads.
+  std::optional<ImportLock> origin_guard;
+  if (TypeSystemClang *origin_ast =
+          TypeSystemClang::GetASTContext(&origin_record->getASTContext()))
+    origin_guard.emplace(*this, origin_ast->GetMutex());
+
   std::remove_reference_t<decltype(field_offsets)> origin_field_offsets;
   std::remove_reference_t<decltype(base_offsets)> origin_base_offsets;
   std::remove_reference_t<decltype(vbase_offsets)> origin_virtual_base_offsets;
@@ -825,6 +869,31 @@ bool ClangASTImporter::CompleteTagDeclWithOrigin(clang::TagDecl *decl,
 }
 
 bool ClangASTImporter::CompleteObjCInterfaceDecl(
+    clang::ObjCInterfaceDecl *interface_decl) {
+  if (m_nested_imports_depth > 0) {
+    // We're already importing something and hold locks. Queue up the
+    // completion of the Objective-C interface for later.
+    m_queued_objc_interfaces.insert(interface_decl);
+    return true;
+  }
+
+  return CompleteQueuedObjCInterface(interface_decl);
+}
+
+void ClangASTImporter::CompleteQueuedObjCInterfaces() {
+  // Keep looping until there are no more Objective-C interfaces
+  // that need to be completed. Note that completing an interface
+  // might trigger more completions.
+  while (!m_queued_objc_interfaces.empty()) {
+    llvm::SmallSetVector<clang::ObjCInterfaceDecl *, 4> pending =
+        std::move(m_queued_objc_interfaces);
+    m_queued_objc_interfaces.clear();
+    for (clang::ObjCInterfaceDecl *interface_decl : pending)
+      CompleteQueuedObjCInterface(interface_decl);
+  }
+}
+
+bool ClangASTImporter::CompleteQueuedObjCInterface(
     clang::ObjCInterfaceDecl *interface_decl) {
   DeclOrigin decl_origin = GetDeclOrigin(interface_decl);
 
@@ -1046,6 +1115,12 @@ ClangASTImporter::MapCompleter::~MapCompleter() = default;
 
 llvm::Expected<Decl *>
 ClangASTImporter::ASTImporterDelegate::ImportImpl(Decl *From) {
+  // Lock the origin TypeSystemClang which might be shared between threads.
+  std::optional<ImportLock> source_guard;
+  if (TypeSystemClang *source_ast =
+          TypeSystemClang::GetASTContext(m_source_ctx))
+    source_guard.emplace(m_main, source_ast->GetMutex());
+
   // FIXME: The Minimal import mode of clang::ASTImporter does not correctly
   // import Lambda definitions. Work around this for now by not importing
   // lambdas at all. This is most likely encountered when importing decls from
@@ -1139,6 +1214,12 @@ ClangASTImporter::ASTImporterDelegate::ImportImpl(Decl *From) {
 
 void ClangASTImporter::ASTImporterDelegate::ImportDefinitionTo(
     clang::Decl *to, clang::Decl *from) {
+  // Lock the origin TypeSystemClang which might be shared between threads.
+  std::optional<ImportLock> source_guard;
+  if (TypeSystemClang *source_ast =
+          TypeSystemClang::GetASTContext(m_source_ctx))
+    source_guard.emplace(m_main, source_ast->GetMutex());
+
   Log *log = GetLog(LLDBLog::Expressions);
 
   auto getDeclName = [](Decl const *decl) {

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.h
@@ -30,6 +30,7 @@
 #include "Plugins/ExpressionParser/Clang/CxxModuleHandler.h"
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SetVector.h"
 
 namespace lldb_private {
 
@@ -175,7 +176,19 @@ public:
 
   bool CompleteTagDeclWithOrigin(clang::TagDecl *decl, clang::TagDecl *origin);
 
+  /// Completes the given ObjCInterfaceDecl, unless an import is already in
+  /// progress on this thread (see ImportLock), in which case the completion
+  /// is queued until that import finishes.
+  ///
+  /// Completing an ObjCInterfaceDecl can ask the Objective-C runtime for
+  /// class info that debug info doesn't have, which runs code in the process.
+  /// Doing that while holding a source ASTContext's lock - which, for a
+  /// Module's ASTContext, is also the lock the process's private state thread
+  /// needs to report the resulting stop - deadlocks the two threads.
   bool CompleteObjCInterfaceDecl(clang::ObjCInterfaceDecl *interface_decl);
+
+  /// Completes Objective-C interfaces that have been queued up.
+  void CompleteQueuedObjCInterfaces();
 
   bool CompleteAndFetchChildren(clang::QualType type);
 
@@ -470,11 +483,25 @@ public:
 
   DeclOrigin GetDeclOrigin(const clang::Decl *decl);
 
+  bool CompleteQueuedObjCInterface(clang::ObjCInterfaceDecl *interface_decl);
+
   clang::FileManager m_file_manager;
   typedef llvm::DenseMap<const clang::RecordDecl *, LayoutInfo>
       RecordDeclToLayoutMap;
 
   RecordDeclToLayoutMap m_record_decl_to_layout_map;
+
+  /// ObjCInterfaceDecls that CompleteObjCInterfaceDecl deferred because an
+  /// import was already in progress.
+  ///
+  /// This is necessary as completing an Objective-C interface can trigger
+  /// LLDB to run an utility expression. This expression will likely deadlock
+  /// when we hold any Module lock (or any other lock an expression might
+  /// acquire).
+  llvm::SmallSetVector<clang::ObjCInterfaceDecl *, 4> m_queued_objc_interfaces;
+
+  /// Number of ImportLocks currently active on this ClangASTImporter.
+  unsigned m_nested_imports_depth = 0;
 };
 
 template <class D> class TaggedASTDecl {

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
@@ -140,6 +140,18 @@ bool ClangExpressionDeclMap::WillParse(ExecutionContext &exe_ctx,
       return false;
   }
 
+  // Parsing looks up types in the Objective-C runtime (see
+  // ClangASTSource::FindDeclInObjCRuntime), and the runtime fetches its class
+  // information by running code in the process. Do that here, before parsing
+  // starts, because the lookups happen while clang holds an ASTContext's lock
+  // and running the process from under that lock deadlocks with the threads
+  // that report the stop. This is a no-op unless the process ran since the
+  // information was last fetched.
+  if (Process *process = exe_ctx.GetProcessPtr()) {
+    if (ObjCLanguageRuntime *objc_runtime = ObjCLanguageRuntime::Get(*process))
+      objc_runtime->UpdateISAToDescriptorMap();
+  }
+
   m_parser_vars->m_target_info = GetTargetInfo();
   m_parser_vars->m_materializer = materializer;
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExternalASTSourceCallbacks.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExternalASTSourceCallbacks.cpp
@@ -52,6 +52,9 @@ void ClangExternalASTSourceCallbacks::FindExternalLexicalDecls(
 bool ClangExternalASTSourceCallbacks::FindExternalVisibleDeclsByName(
     const clang::DeclContext *DC, clang::DeclarationName Name,
     const clang::DeclContext *OriginalDC) {
+  // Unlike the callbacks above this one touches the AST directly instead of
+  // going through a TypeSystemClang entry point, so it takes the lock itself.
+  std::lock_guard<std::recursive_mutex> guard(m_ast.GetMutex());
   llvm::SmallVector<clang::NamedDecl *, 4> decls;
   // Objective-C methods are not added into the LookupPtr when they originate
   // from an external source. SetExternalVisibleDeclsForName() adds them.
@@ -66,6 +69,7 @@ bool ClangExternalASTSourceCallbacks::FindExternalVisibleDeclsByName(
 
 OptionalClangModuleID
 ClangExternalASTSourceCallbacks::RegisterModule(clang::Module *module) {
+  std::lock_guard<std::recursive_mutex> guard(m_ast.GetMutex());
   m_modules.push_back(module);
   unsigned id = m_modules.size();
   m_ids.insert({module, id});
@@ -80,6 +84,7 @@ ClangExternalASTSourceCallbacks::getSourceDescriptor(unsigned id) {
 }
 
 clang::Module *ClangExternalASTSourceCallbacks::getModule(unsigned id) {
+  std::lock_guard<std::recursive_mutex> guard(m_ast.GetMutex());
   if (id && id <= m_modules.size())
     return m_modules[id - 1];
   return nullptr;
@@ -87,5 +92,6 @@ clang::Module *ClangExternalASTSourceCallbacks::getModule(unsigned id) {
 
 OptionalClangModuleID
 ClangExternalASTSourceCallbacks::GetIDForModule(clang::Module *module) {
+  std::lock_guard<std::recursive_mutex> guard(m_ast.GetMutex());
   return OptionalClangModuleID(m_ids[module]);
 }

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -1672,6 +1672,7 @@ SymbolFileDWARF::GetCompUnitForDWARFCompUnit(DWARFCompileUnit &dwarf_cu) {
 void SymbolFileDWARF::GetObjCMethods(
     ConstString class_name,
     llvm::function_ref<IterationAction(DWARFDIE die)> callback) {
+  std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
   m_index->GetObjCMethods(class_name, callback);
 }
 
@@ -3120,6 +3121,7 @@ Symbol *SymbolFileDWARF::GetObjCClassSymbol(ConstString objc_class_name) {
 // DIE and we want to try and find a type that has the complete definition.
 TypeSP SymbolFileDWARF::FindCompleteObjCDefinitionTypeForDIE(
     const DWARFDIE &die, ConstString type_name, bool must_be_implementation) {
+  std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
 
   TypeSP type_sp;
 

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -541,7 +541,13 @@ lldb::TypeSystemSP TypeSystemClang::CreateInstance(lldb::LanguageType language,
   if (module) {
     std::string ast_name =
         "ASTContext for '" + module->GetFileSpec().GetPath() + "'";
-    return std::make_shared<TypeSystemClang>(ast_name, triple);
+    auto type_system = std::make_shared<TypeSystemClang>(ast_name, triple);
+    // This ASTContext is filled in by the Module's SymbolFile, which does that
+    // while holding the Module's lock. Guard the ASTContext with that same lock
+    // so that parsing types into it and completing types from it can't deadlock
+    // each other. See TypeSystemClang::GetMutex().
+    type_system->SetSharedMutex(module->GetMutex());
+    return type_system;
   } else if (target && target->IsValid())
     return std::make_shared<ScratchTypeSystemClang>(*target, triple);
   return lldb::TypeSystemSP();
@@ -588,6 +594,7 @@ void TypeSystemClang::Terminate() {
 }
 
 void TypeSystemClang::Finalize() {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   assert(m_ast_up);
   GetASTMap().Erase(m_ast_up.get());
   if (!m_ast_owned)
@@ -604,6 +611,7 @@ void TypeSystemClang::Finalize() {
 }
 
 void TypeSystemClang::setSema(Sema *s) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   // Ensure that the new sema actually belongs to our ASTContext.
   assert(s == nullptr || &s->getASTContext() == m_ast_up.get());
   m_sema = s;
@@ -614,11 +622,13 @@ const char *TypeSystemClang::GetTargetTriple() {
 }
 
 void TypeSystemClang::SetTargetTriple(llvm::StringRef target_triple) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   m_target_triple = target_triple.str();
 }
 
 void TypeSystemClang::SetExternalSource(
     llvm::IntrusiveRefCntPtr<ExternalASTSource> ast_source_sp) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   ASTContext &ast = getASTContext();
   ast.getTranslationUnitDecl()->setHasExternalLexicalStorage(true);
   ast.setExternalSource(std::move(ast_source_sp));
@@ -652,6 +662,7 @@ private:
 };
 
 void TypeSystemClang::CreateASTContext() {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   assert(!m_ast_up);
   m_ast_owned = true;
 
@@ -748,6 +759,7 @@ static inline bool QualTypeMatchesBitSize(const uint64_t bit_size,
 CompilerType
 TypeSystemClang::GetBuiltinTypeForEncodingAndBitSize(Encoding encoding,
                                                      size_t bit_size) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   ASTContext &ast = getASTContext();
 
   if (!ast.VoidPtrTy)
@@ -886,6 +898,7 @@ lldb::BasicType TypeSystemClang::GetBasicTypeEnumeration(llvm::StringRef name) {
 }
 
 uint32_t TypeSystemClang::GetPointerByteSize() {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (m_pointer_byte_size != 0)
     return m_pointer_byte_size;
   auto size_or_err =
@@ -899,6 +912,7 @@ uint32_t TypeSystemClang::GetPointerByteSize() {
 }
 
 CompilerType TypeSystemClang::GetBasicType(lldb::BasicType basic_type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   clang::ASTContext &ast = getASTContext();
 
   lldb::opaque_compiler_type_t clang_type =
@@ -911,6 +925,7 @@ CompilerType TypeSystemClang::GetBasicType(lldb::BasicType basic_type) {
 
 CompilerType TypeSystemClang::GetBuiltinTypeForDWARFEncodingAndBitSize(
     llvm::StringRef type_name, uint32_t dw_ate, uint32_t bit_size) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   ASTContext &ast = getASTContext();
 
   if (!ast.VoidPtrTy)
@@ -1150,6 +1165,7 @@ CompilerType TypeSystemClang::GetBuiltinTypeForDWARFEncodingAndBitSize(
 }
 
 CompilerType TypeSystemClang::GetCStringType(bool is_const) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   ASTContext &ast = getASTContext();
   QualType char_type(ast.CharTy);
 
@@ -1180,6 +1196,7 @@ bool TypeSystemClang::AreTypesSame(CompilerType type1, CompilerType type2,
 }
 
 CompilerType TypeSystemClang::GetTypeForDecl(void *opaque_decl) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!opaque_decl)
     return CompilerType();
 
@@ -1190,12 +1207,14 @@ CompilerType TypeSystemClang::GetTypeForDecl(void *opaque_decl) {
 }
 
 CompilerDeclContext TypeSystemClang::CreateDeclContext(DeclContext *ctx) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   // Check that the DeclContext actually belongs to this ASTContext.
   assert(&ctx->getParentASTContext() == &getASTContext());
   return CompilerDeclContext(this, ctx);
 }
 
 CompilerType TypeSystemClang::GetTypeForDecl(clang::NamedDecl *decl) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (clang::ObjCInterfaceDecl *interface_decl =
       llvm::dyn_cast<clang::ObjCInterfaceDecl>(decl))
     return GetTypeForDecl(interface_decl);
@@ -1207,14 +1226,17 @@ CompilerType TypeSystemClang::GetTypeForDecl(clang::NamedDecl *decl) {
 }
 
 CompilerType TypeSystemClang::GetTypeForDecl(TagDecl *decl) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   return GetType(getASTContext().getCanonicalTagType(decl));
 }
 
 CompilerType TypeSystemClang::GetTypeForDecl(ObjCInterfaceDecl *decl) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   return GetType(getASTContext().getObjCInterfaceType(decl));
 }
 
 CompilerType TypeSystemClang::GetTypeForDecl(clang::ValueDecl *value_decl) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   return GetType(value_decl->getType());
 }
 
@@ -1234,6 +1256,7 @@ OptionalClangModuleID
 TypeSystemClang::GetOrCreateClangModule(llvm::StringRef name,
                                         OptionalClangModuleID parent,
                                         bool is_framework, bool is_explicit) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   // Get the external AST source which holds the modules.
   auto *ast_source = llvm::dyn_cast_or_null<ClangExternalASTSourceCallbacks>(
       getASTContext().getExternalSource());
@@ -1270,6 +1293,7 @@ CompilerType TypeSystemClang::CreateRecordType(
     clang::DeclContext *decl_ctx, OptionalClangModuleID owning_module,
     llvm::StringRef name, int kind, LanguageType language,
     std::optional<ClangASTMetadata> metadata, bool exports_symbols) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   ASTContext &ast = getASTContext();
 
   if (decl_ctx == nullptr)
@@ -1446,6 +1470,7 @@ clang::FunctionTemplateDecl *TypeSystemClang::CreateFunctionTemplateDecl(
 void TypeSystemClang::CreateFunctionTemplateSpecializationInfo(
     FunctionDecl *func_decl, clang::FunctionTemplateDecl *func_tmpl_decl,
     const TemplateParameterInfos &infos) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   TemplateArgumentList *template_args_ptr = TemplateArgumentList::CreateCopy(
       func_decl->getASTContext(), infos.GetArgs());
 
@@ -1624,6 +1649,7 @@ ClassTemplateDecl *TypeSystemClang::CreateClassTemplateDecl(
 
 TemplateTemplateParmDecl *
 TypeSystemClang::CreateTemplateTemplateParmDecl(const char *template_name) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   ASTContext &ast = getASTContext();
 
   auto *decl_ctx = ast.getTranslationUnitDecl();
@@ -1654,6 +1680,7 @@ TypeSystemClang::CreateClassTemplateSpecializationDecl(
     DeclContext *decl_ctx, OptionalClangModuleID owning_module,
     ClassTemplateDecl *class_template_decl, int kind,
     const TemplateParameterInfos &template_param_infos) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   ASTContext &ast = getASTContext();
   llvm::SmallVector<clang::TemplateArgument, 2> args(
       template_param_infos.Size() +
@@ -1697,6 +1724,7 @@ TypeSystemClang::CreateClassTemplateSpecializationDecl(
 
 CompilerType TypeSystemClang::CreateClassTemplateSpecializationType(
     ClassTemplateSpecializationDecl *class_template_specialization_decl) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (class_template_specialization_decl) {
     ASTContext &ast = getASTContext();
     return GetType(ast.getCanonicalTagType(class_template_specialization_decl));
@@ -1750,6 +1778,7 @@ bool TypeSystemClang::CheckOverloadedOperatorKindParameterCount(
 
 bool TypeSystemClang::FieldIsBitfield(FieldDecl *field,
                                       uint32_t &bitfield_bit_size) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   ASTContext &ast = getASTContext();
   if (field == nullptr)
     return false;
@@ -1768,6 +1797,7 @@ bool TypeSystemClang::FieldIsBitfield(FieldDecl *field,
 }
 
 bool TypeSystemClang::RecordHasFields(const RecordDecl *record_decl) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (record_decl == nullptr)
     return false;
 
@@ -1807,6 +1837,7 @@ CompilerType TypeSystemClang::CreateObjCClass(
     llvm::StringRef name, clang::DeclContext *decl_ctx,
     OptionalClangModuleID owning_module, bool isInternal,
     std::optional<ClangASTMetadata> metadata) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   ASTContext &ast = getASTContext();
   assert(!name.empty());
   if (!decl_ctx)
@@ -1826,12 +1857,14 @@ CompilerType TypeSystemClang::CreateObjCClass(
 }
 
 bool TypeSystemClang::BaseSpecifierIsEmpty(const CXXBaseSpecifier *b) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   return !TypeSystemClang::RecordHasFields(b->getType()->getAsCXXRecordDecl());
 }
 
 uint32_t
 TypeSystemClang::GetNumBaseClasses(const CXXRecordDecl *cxx_record_decl,
                                    bool omit_empty_base_classes) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   uint32_t num_bases = 0;
   if (cxx_record_decl) {
     if (omit_empty_base_classes) {
@@ -1918,6 +1951,7 @@ NamespaceDecl *TypeSystemClang::GetUniqueNamespaceDeclaration(
 clang::BlockDecl *
 TypeSystemClang::CreateBlockDeclaration(clang::DeclContext *ctx,
                                         OptionalClangModuleID owning_module) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (ctx) {
     clang::BlockDecl *decl =
         clang::BlockDecl::CreateDeserialized(getASTContext(), GlobalDeclID());
@@ -1968,6 +2002,7 @@ clang::UsingDecl *
 TypeSystemClang::CreateUsingDeclaration(clang::DeclContext *current_decl_ctx,
                                         OptionalClangModuleID owning_module,
                                         clang::NamedDecl *target) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (current_decl_ctx && target) {
     clang::UsingDecl *using_decl = clang::UsingDecl::Create(
         getASTContext(), current_decl_ctx, clang::SourceLocation(),
@@ -2082,6 +2117,7 @@ TypeSystemClang::GetOpaqueCompilerType(clang::ASTContext *ast,
 clang::DeclarationName
 TypeSystemClang::GetDeclarationName(llvm::StringRef name,
                                     const CompilerType &function_clang_type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   clang::OverloadedOperatorKind op_kind = clang::NUM_OVERLOADED_OPERATORS;
   if (!IsOperator(name, op_kind) || op_kind == clang::NUM_OVERLOADED_OPERATORS)
     return DeclarationName(&getASTContext().Idents.get(
@@ -2107,6 +2143,7 @@ TypeSystemClang::GetDeclarationName(llvm::StringRef name,
 }
 
 PrintingPolicy TypeSystemClang::GetTypePrintingPolicy() {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   clang::PrintingPolicy printing_policy(getASTContext().getPrintingPolicy());
   printing_policy.SuppressTagKeyword = true;
   // Inline namespaces are important for some type formatters (e.g., libc++
@@ -2131,6 +2168,7 @@ PrintingPolicy TypeSystemClang::GetTypePrintingPolicy() {
 
 std::string TypeSystemClang::GetTypeNameForDecl(const NamedDecl *named_decl,
                                                 bool qualified) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   clang::PrintingPolicy printing_policy = GetTypePrintingPolicy();
   std::string result;
   llvm::raw_string_ostream os(result);
@@ -2188,6 +2226,7 @@ CompilerType TypeSystemClang::CreateFunctionType(
     const CompilerType &result_type, llvm::ArrayRef<CompilerType> args,
     bool is_variadic, unsigned type_quals, clang::CallingConv cc,
     clang::RefQualifierKind ref_qual) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!result_type || !ClangUtil::IsClangType(result_type))
     return CompilerType(); // invalid return type
 
@@ -2239,6 +2278,7 @@ ParmVarDecl *TypeSystemClang::CreateParameterDeclaration(
 
 CompilerType
 TypeSystemClang::CreateBlockPointerType(const CompilerType &function_type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   QualType block_type = m_ast_up->getBlockPointerType(
       clang::QualType::getFromOpaquePtr(function_type.GetOpaqueQualType()));
 
@@ -2251,6 +2291,7 @@ CompilerType
 TypeSystemClang::CreateArrayType(const CompilerType &element_type,
                                  std::optional<size_t> element_count,
                                  bool is_vector) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!element_type.IsValid())
     return {};
 
@@ -2279,6 +2320,7 @@ CompilerType TypeSystemClang::CreateStructForIdentifier(
     const std::initializer_list<std::pair<const char *, CompilerType>>
         &type_fields,
     bool packed) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   CompilerType type;
   if (!type_name.empty() && (type = GetTypeForIdentifier<clang::CXXRecordDecl>(
                                  getASTContext(), type_name))
@@ -2304,6 +2346,7 @@ CompilerType TypeSystemClang::GetOrCreateStructForIdentifier(
     const std::initializer_list<std::pair<const char *, CompilerType>>
         &type_fields,
     bool packed) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   CompilerType type;
   if ((type = GetTypeForIdentifier<clang::CXXRecordDecl>(getASTContext(),
                                                          type_name))
@@ -2320,6 +2363,7 @@ CompilerType TypeSystemClang::CreateEnumerationType(
     OptionalClangModuleID owning_module, const Declaration &decl,
     const CompilerType &integer_clang_type, bool is_scoped,
     std::optional<clang::EnumExtensibilityAttr::Kind> enum_kind) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   // TODO: Do something intelligent with the Declaration object passed in
   // like maybe filling in the SourceLocation with it...
   ASTContext &ast = getASTContext();
@@ -2351,6 +2395,7 @@ CompilerType TypeSystemClang::CreateEnumerationType(
 
 CompilerType TypeSystemClang::GetIntTypeFromBitSize(size_t bit_size,
                                                     bool is_signed) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   clang::ASTContext &ast = getASTContext();
 
   if (!ast.VoidPtrTy)
@@ -2397,6 +2442,7 @@ CompilerType TypeSystemClang::GetIntTypeFromBitSize(size_t bit_size,
 }
 
 CompilerType TypeSystemClang::GetPointerSizedIntType(bool is_signed) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!getASTContext().VoidPtrTy)
     return {};
 
@@ -2405,6 +2451,7 @@ CompilerType TypeSystemClang::GetPointerSizedIntType(bool is_signed) {
 }
 
 CompilerType TypeSystemClang::GetPointerDiffType(bool is_signed) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   // Check if builtin types are initialized.
   if (!getASTContext().VoidPtrTy)
     return {};
@@ -2499,6 +2546,7 @@ bool TypeSystemClang::GetCompleteDecl(clang::ASTContext *ast,
 
 void TypeSystemClang::SetMetadataAsUserID(const clang::Decl *decl,
                                           user_id_t user_id) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   ClangASTMetadata meta_data;
   meta_data.SetUserID(user_id);
   SetMetadata(decl, meta_data);
@@ -2506,6 +2554,7 @@ void TypeSystemClang::SetMetadataAsUserID(const clang::Decl *decl,
 
 void TypeSystemClang::SetMetadataAsUserID(const clang::Type *type,
                                           user_id_t user_id) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   ClangASTMetadata meta_data;
   meta_data.SetUserID(user_id);
   SetMetadata(type, meta_data);
@@ -2513,16 +2562,19 @@ void TypeSystemClang::SetMetadataAsUserID(const clang::Type *type,
 
 void TypeSystemClang::SetMetadata(const clang::Decl *object,
                                   ClangASTMetadata metadata) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   m_decl_metadata[object] = metadata;
 }
 
 void TypeSystemClang::SetMetadata(const clang::Type *object,
                                   ClangASTMetadata metadata) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   m_type_metadata[object] = metadata;
 }
 
 std::optional<ClangASTMetadata>
 TypeSystemClang::GetMetadata(const clang::Decl *object) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   auto It = m_decl_metadata.find(object);
   if (It != m_decl_metadata.end())
     return It->second;
@@ -2532,6 +2584,7 @@ TypeSystemClang::GetMetadata(const clang::Decl *object) {
 
 std::optional<ClangASTMetadata>
 TypeSystemClang::GetMetadata(const clang::Type *object) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   auto It = m_type_metadata.find(object);
   if (It != m_type_metadata.end())
     return It->second;
@@ -2546,6 +2599,7 @@ TypeSystemClang::GetDeclContextForType(const CompilerType &type) {
 
 CompilerDeclContext
 TypeSystemClang::GetCompilerDeclContextForType(const CompilerType &type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (auto *decl_context = GetDeclContextForType(type))
     return CreateDeclContext(decl_context);
   return CompilerDeclContext();
@@ -2783,11 +2837,13 @@ static bool GetCompleteQualType(const clang::ASTContext *ast,
 
 #ifndef NDEBUG
 bool TypeSystemClang::Verify(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   return !type || llvm::isa<clang::Type>(GetQualType(type).getTypePtr());
 }
 #endif
 
 bool TypeSystemClang::IsAggregateType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   clang::QualType qual_type(RemoveWrappingTypes(GetCanonicalQualType(type)));
 
   const clang::Type::TypeClass type_class = qual_type->getTypeClass();
@@ -2809,6 +2865,7 @@ bool TypeSystemClang::IsAggregateType(lldb::opaque_compiler_type_t type) {
 }
 
 bool TypeSystemClang::IsAnonymousType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   clang::QualType qual_type(RemoveWrappingTypes(GetCanonicalQualType(type)));
 
   const clang::Type::TypeClass type_class = qual_type->getTypeClass();
@@ -2833,6 +2890,7 @@ bool TypeSystemClang::IsAnonymousType(lldb::opaque_compiler_type_t type) {
 bool TypeSystemClang::IsArrayType(lldb::opaque_compiler_type_t type,
                                   CompilerType *element_type_ptr,
                                   uint64_t *size, bool *is_incomplete) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   clang::QualType qual_type(RemoveWrappingTypes(GetCanonicalQualType(type)));
 
   const clang::Type::TypeClass type_class = qual_type->getTypeClass();
@@ -2902,6 +2960,7 @@ bool TypeSystemClang::IsArrayType(lldb::opaque_compiler_type_t type,
 
 bool TypeSystemClang::IsVectorType(lldb::opaque_compiler_type_t type,
                                    CompilerType *element_type, uint64_t *size) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   clang::QualType qual_type(GetCanonicalQualType(type));
 
   const clang::Type::TypeClass type_class = qual_type->getTypeClass();
@@ -2938,6 +2997,7 @@ bool TypeSystemClang::IsVectorType(lldb::opaque_compiler_type_t type,
 
 bool TypeSystemClang::IsRuntimeGeneratedType(
     lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   clang::DeclContext *decl_ctx = GetDeclContextForType(GetQualType(type));
   if (!decl_ctx)
     return false;
@@ -2956,10 +3016,12 @@ bool TypeSystemClang::IsRuntimeGeneratedType(
 }
 
 bool TypeSystemClang::IsCharType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   return GetQualType(type).getUnqualifiedType()->isCharType();
 }
 
 bool TypeSystemClang::IsCompleteType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   // If the type hasn't been lazily completed yet, complete it now so that we
   // can give the caller an accurate answer whether the type actually has a
   // definition. Without completing the type now we would just tell the user
@@ -2969,11 +3031,13 @@ bool TypeSystemClang::IsCompleteType(lldb::opaque_compiler_type_t type) {
 }
 
 bool TypeSystemClang::IsConst(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   return GetQualType(type).isConstQualified();
 }
 
 bool TypeSystemClang::IsCStringType(lldb::opaque_compiler_type_t type,
                                     uint32_t &length) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   CompilerType pointee_or_element_clang_type;
   length = 0;
   Flags type_flags(GetTypeInfo(type, &pointee_or_element_clang_type));
@@ -2998,6 +3062,7 @@ bool TypeSystemClang::IsCStringType(lldb::opaque_compiler_type_t type,
 }
 
 unsigned TypeSystemClang::GetPtrAuthKey(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     clang::QualType qual_type(GetCanonicalQualType(type));
     if (auto pointer_auth = qual_type.getPointerAuth())
@@ -3008,6 +3073,7 @@ unsigned TypeSystemClang::GetPtrAuthKey(lldb::opaque_compiler_type_t type) {
 
 unsigned
 TypeSystemClang::GetPtrAuthDiscriminator(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     clang::QualType qual_type(GetCanonicalQualType(type));
     if (auto pointer_auth = qual_type.getPointerAuth())
@@ -3018,6 +3084,7 @@ TypeSystemClang::GetPtrAuthDiscriminator(lldb::opaque_compiler_type_t type) {
 
 bool TypeSystemClang::GetPtrAuthAddressDiversity(
     lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     clang::QualType qual_type(GetCanonicalQualType(type));
     if (auto pointer_auth = qual_type.getPointerAuth())
@@ -3027,6 +3094,7 @@ bool TypeSystemClang::GetPtrAuthAddressDiversity(
 }
 
 bool TypeSystemClang::IsFunctionType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   auto isFunctionType = [&](clang::QualType qual_type) {
     return qual_type->isFunctionType();
   };
@@ -3038,6 +3106,7 @@ bool TypeSystemClang::IsFunctionType(lldb::opaque_compiler_type_t type) {
 uint32_t
 TypeSystemClang::IsHomogeneousAggregate(lldb::opaque_compiler_type_t type,
                                         CompilerType *base_type_ptr) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return 0;
 
@@ -3120,6 +3189,7 @@ TypeSystemClang::IsHomogeneousAggregate(lldb::opaque_compiler_type_t type,
 
 size_t TypeSystemClang::GetNumberOfFunctionArguments(
     lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     clang::QualType qual_type(GetCanonicalQualType(type));
     const clang::FunctionProtoType *func =
@@ -3133,6 +3203,7 @@ size_t TypeSystemClang::GetNumberOfFunctionArguments(
 CompilerType
 TypeSystemClang::GetFunctionArgumentAtIndex(lldb::opaque_compiler_type_t type,
                                             const size_t index) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     clang::QualType qual_type(GetQualType(type));
     const clang::FunctionProtoType *func =
@@ -3148,6 +3219,7 @@ TypeSystemClang::GetFunctionArgumentAtIndex(lldb::opaque_compiler_type_t type,
 bool TypeSystemClang::IsTypeImpl(
     lldb::opaque_compiler_type_t type,
     llvm::function_ref<bool(clang::QualType)> predicate) const {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
 
@@ -3173,6 +3245,7 @@ bool TypeSystemClang::IsTypeImpl(
 
 bool TypeSystemClang::IsMemberFunctionPointerType(
     lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   auto isMemberFunctionPointerType = [](clang::QualType qual_type) {
     return qual_type->isMemberFunctionPointerType();
   };
@@ -3182,6 +3255,7 @@ bool TypeSystemClang::IsMemberFunctionPointerType(
 
 bool TypeSystemClang::IsMemberDataPointerType(
     lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   auto isMemberDataPointerType = [](clang::QualType qual_type) {
     return qual_type->isMemberDataPointerType();
   };
@@ -3190,6 +3264,7 @@ bool TypeSystemClang::IsMemberDataPointerType(
 }
 
 bool TypeSystemClang::IsFunctionPointerType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   auto isFunctionPointerType = [](clang::QualType qual_type) {
     return qual_type->isFunctionPointerType();
   };
@@ -3200,6 +3275,7 @@ bool TypeSystemClang::IsFunctionPointerType(lldb::opaque_compiler_type_t type) {
 bool TypeSystemClang::IsBlockPointerType(
     lldb::opaque_compiler_type_t type,
     CompilerType *function_pointer_type_ptr) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   auto isBlockPointerType = [&](clang::QualType qual_type) {
     if (qual_type->isBlockPointerType()) {
       if (function_pointer_type_ptr) {
@@ -3221,6 +3297,7 @@ bool TypeSystemClang::IsBlockPointerType(
 
 bool TypeSystemClang::IsIntegerType(lldb::opaque_compiler_type_t type,
                                     bool &is_signed) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return false;
 
@@ -3241,6 +3318,7 @@ bool TypeSystemClang::IsIntegerType(lldb::opaque_compiler_type_t type,
 
 bool TypeSystemClang::IsEnumerationType(lldb::opaque_compiler_type_t type,
                                         bool &is_signed) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     const clang::EnumType *enum_type = llvm::dyn_cast<clang::EnumType>(
         GetCanonicalQualType(type)->getCanonicalTypeInternal());
@@ -3256,6 +3334,7 @@ bool TypeSystemClang::IsEnumerationType(lldb::opaque_compiler_type_t type,
 
 bool TypeSystemClang::IsScopedEnumerationType(
     lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     const clang::EnumType *enum_type = llvm::dyn_cast<clang::EnumType>(
         GetCanonicalQualType(type)->getCanonicalTypeInternal());
@@ -3270,6 +3349,7 @@ bool TypeSystemClang::IsScopedEnumerationType(
 
 bool TypeSystemClang::IsPointerType(lldb::opaque_compiler_type_t type,
                                     CompilerType *pointee_type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
     const clang::Type::TypeClass type_class = qual_type->getTypeClass();
@@ -3323,6 +3403,7 @@ bool TypeSystemClang::IsPointerType(lldb::opaque_compiler_type_t type,
 
 bool TypeSystemClang::IsPointerOrReferenceType(
     lldb::opaque_compiler_type_t type, CompilerType *pointee_type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
     const clang::Type::TypeClass type_class = qual_type->getTypeClass();
@@ -3391,6 +3472,7 @@ bool TypeSystemClang::IsPointerOrReferenceType(
 bool TypeSystemClang::IsReferenceType(lldb::opaque_compiler_type_t type,
                                       CompilerType *pointee_type,
                                       bool *is_rvalue) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
     const clang::Type::TypeClass type_class = qual_type->getTypeClass();
@@ -3425,6 +3507,7 @@ bool TypeSystemClang::IsReferenceType(lldb::opaque_compiler_type_t type,
 }
 
 bool TypeSystemClang::IsFloatingPointType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return false;
 
@@ -3436,6 +3519,7 @@ bool TypeSystemClang::IsFloatingPointType(lldb::opaque_compiler_type_t type) {
 }
 
 bool TypeSystemClang::IsDefined(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return false;
 
@@ -3496,6 +3580,7 @@ bool TypeSystemClang::IsEnumType(lldb::opaque_compiler_type_t type) {
 }
 
 bool TypeSystemClang::IsPolymorphicClass(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     clang::QualType qual_type(GetCanonicalQualType(type));
     const clang::Type::TypeClass type_class = qual_type->getTypeClass();
@@ -3525,6 +3610,7 @@ bool TypeSystemClang::IsPossibleDynamicType(lldb::opaque_compiler_type_t type,
                                             CompilerType *dynamic_pointee_type,
                                             bool check_cplusplus,
                                             bool check_objc) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (dynamic_pointee_type)
     dynamic_pointee_type->Clear();
   if (!type)
@@ -3635,6 +3721,7 @@ bool TypeSystemClang::IsPossibleDynamicType(lldb::opaque_compiler_type_t type,
 }
 
 bool TypeSystemClang::IsScalarType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return false;
 
@@ -3642,6 +3729,7 @@ bool TypeSystemClang::IsScalarType(lldb::opaque_compiler_type_t type) {
 }
 
 bool TypeSystemClang::IsTypedefType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return false;
   return RemoveWrappingTypes(GetQualType(type), {clang::Type::Typedef})
@@ -3649,6 +3737,7 @@ bool TypeSystemClang::IsTypedefType(lldb::opaque_compiler_type_t type) {
 }
 
 bool TypeSystemClang::IsVoidType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return false;
   return GetCanonicalQualType(type)->isVoidType();
@@ -3656,12 +3745,14 @@ bool TypeSystemClang::IsVoidType(lldb::opaque_compiler_type_t type) {
 
 bool TypeSystemClang::HasPointerAuthQualifier(
     lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return false;
   return GetCanonicalQualType(type).getPointerAuth().isPresent();
 }
 
 bool TypeSystemClang::CanPassInRegisters(const CompilerType &type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (auto *record_decl =
       TypeSystemClang::GetAsRecordDecl(type)) {
     return record_decl->canPassInRegisters();
@@ -3670,6 +3761,7 @@ bool TypeSystemClang::CanPassInRegisters(const CompilerType &type) {
 }
 
 bool TypeSystemClang::SupportsLanguage(lldb::LanguageType language) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   return TypeSystemClangSupportsLanguage(language);
 }
 
@@ -3698,6 +3790,7 @@ bool TypeSystemClang::IsCXXClassType(const CompilerType &type) {
 }
 
 bool TypeSystemClang::IsBeingDefined(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return false;
   clang::QualType qual_type(GetCanonicalQualType(type));
@@ -3738,6 +3831,7 @@ bool TypeSystemClang::IsObjCObjectPointerType(const CompilerType &type,
 // Type Completion
 
 bool TypeSystemClang::GetCompleteType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return false;
   return GetCompleteQualType(&getASTContext(), GetQualType(type));
@@ -3745,6 +3839,7 @@ bool TypeSystemClang::GetCompleteType(lldb::opaque_compiler_type_t type) {
 
 ConstString TypeSystemClang::GetTypeName(lldb::opaque_compiler_type_t type,
                                          bool base_only) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return ConstString();
 
@@ -3777,6 +3872,7 @@ ConstString TypeSystemClang::GetTypeName(lldb::opaque_compiler_type_t type,
 
 ConstString
 TypeSystemClang::GetDisplayTypeName(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return ConstString();
 
@@ -3793,6 +3889,7 @@ TypeSystemClang::GetDisplayTypeName(lldb::opaque_compiler_type_t type) {
 uint32_t
 TypeSystemClang::GetTypeInfo(lldb::opaque_compiler_type_t type,
                              CompilerType *pointee_or_element_clang_type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return 0;
 
@@ -4006,6 +4103,7 @@ TypeSystemClang::GetTypeInfo(lldb::opaque_compiler_type_t type,
 
 lldb::LanguageType
 TypeSystemClang::GetMinimumLanguage(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return lldb::eLanguageTypeC;
 
@@ -4090,6 +4188,7 @@ TypeSystemClang::GetMinimumLanguage(lldb::opaque_compiler_type_t type) {
 
 lldb::TypeClass
 TypeSystemClang::GetTypeClass(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return lldb::eTypeClassInvalid;
 
@@ -4236,6 +4335,7 @@ TypeSystemClang::GetTypeClass(lldb::opaque_compiler_type_t type) {
 }
 
 unsigned TypeSystemClang::GetTypeQualifiers(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type)
     return GetQualType(type).getQualifiers().getCVRQualifiers();
   return 0;
@@ -4246,6 +4346,7 @@ unsigned TypeSystemClang::GetTypeQualifiers(lldb::opaque_compiler_type_t type) {
 CompilerType
 TypeSystemClang::GetArrayElementType(lldb::opaque_compiler_type_t type,
                                      ExecutionContextScope *exe_scope) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     clang::QualType qual_type(GetQualType(type));
 
@@ -4262,6 +4363,7 @@ TypeSystemClang::GetArrayElementType(lldb::opaque_compiler_type_t type,
 
 CompilerType TypeSystemClang::GetArrayType(lldb::opaque_compiler_type_t type,
                                            uint64_t size) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     clang::QualType qual_type(GetCanonicalQualType(type));
     clang::ASTContext &ast_ctx = getASTContext();
@@ -4279,6 +4381,7 @@ CompilerType TypeSystemClang::GetArrayType(lldb::opaque_compiler_type_t type,
 
 CompilerType
 TypeSystemClang::GetCanonicalType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type)
     return GetType(GetCanonicalQualType(type));
   return CompilerType();
@@ -4305,6 +4408,7 @@ static clang::QualType GetFullyUnqualifiedType_Impl(clang::ASTContext *ast,
 
 CompilerType
 TypeSystemClang::GetFullyUnqualifiedType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type)
     return GetType(
         GetFullyUnqualifiedType_Impl(&getASTContext(), GetQualType(type)));
@@ -4313,6 +4417,7 @@ TypeSystemClang::GetFullyUnqualifiedType(lldb::opaque_compiler_type_t type) {
 
 CompilerType
 TypeSystemClang::GetEnumerationIntegerType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type)
     return GetEnumerationIntegerType(GetType(GetCanonicalQualType(type)));
   return CompilerType();
@@ -4320,6 +4425,7 @@ TypeSystemClang::GetEnumerationIntegerType(lldb::opaque_compiler_type_t type) {
 
 int TypeSystemClang::GetFunctionArgumentCount(
     lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     const clang::FunctionProtoType *func =
         llvm::dyn_cast<clang::FunctionProtoType>(GetCanonicalQualType(type));
@@ -4331,6 +4437,7 @@ int TypeSystemClang::GetFunctionArgumentCount(
 
 CompilerType TypeSystemClang::GetFunctionArgumentTypeAtIndex(
     lldb::opaque_compiler_type_t type, size_t idx) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     const clang::FunctionProtoType *func =
         llvm::dyn_cast<clang::FunctionProtoType>(GetQualType(type));
@@ -4345,6 +4452,7 @@ CompilerType TypeSystemClang::GetFunctionArgumentTypeAtIndex(
 
 CompilerType
 TypeSystemClang::GetFunctionReturnType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     clang::QualType qual_type(GetQualType(type));
     const clang::FunctionProtoType *func =
@@ -4357,6 +4465,7 @@ TypeSystemClang::GetFunctionReturnType(lldb::opaque_compiler_type_t type) {
 
 size_t
 TypeSystemClang::GetNumMemberFunctions(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   size_t num_functions = 0;
   if (type) {
     clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
@@ -4411,6 +4520,7 @@ TypeSystemClang::GetNumMemberFunctions(lldb::opaque_compiler_type_t type) {
 TypeMemberFunctionImpl
 TypeSystemClang::GetMemberFunctionAtIndex(lldb::opaque_compiler_type_t type,
                                           size_t idx) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   std::string name;
   MemberFunctionKind kind(MemberFunctionKind::eMemberFunctionKindUnknown);
   CompilerType clang_type;
@@ -4521,6 +4631,7 @@ TypeSystemClang::GetMemberFunctionAtIndex(lldb::opaque_compiler_type_t type,
 
 CompilerType
 TypeSystemClang::GetNonReferenceType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type)
     return GetType(GetQualType(type).getNonReferenceType());
   return CompilerType();
@@ -4528,6 +4639,7 @@ TypeSystemClang::GetNonReferenceType(lldb::opaque_compiler_type_t type) {
 
 CompilerType
 TypeSystemClang::GetPointeeType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     clang::QualType qual_type(GetQualType(type));
     return GetType(qual_type.getTypePtr()->getPointeeType());
@@ -4537,6 +4649,7 @@ TypeSystemClang::GetPointeeType(lldb::opaque_compiler_type_t type) {
 
 CompilerType
 TypeSystemClang::GetPointerType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     clang::QualType qual_type(GetQualType(type));
 
@@ -4554,6 +4667,7 @@ TypeSystemClang::GetPointerType(lldb::opaque_compiler_type_t type) {
 
 CompilerType
 TypeSystemClang::GetLValueReferenceType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type)
     return GetType(getASTContext().getLValueReferenceType(GetQualType(type)));
   else
@@ -4562,6 +4676,7 @@ TypeSystemClang::GetLValueReferenceType(lldb::opaque_compiler_type_t type) {
 
 CompilerType
 TypeSystemClang::GetRValueReferenceType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type)
     return GetType(getASTContext().getRValueReferenceType(GetQualType(type)));
   else
@@ -4569,6 +4684,7 @@ TypeSystemClang::GetRValueReferenceType(lldb::opaque_compiler_type_t type) {
 }
 
 CompilerType TypeSystemClang::GetAtomicType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return CompilerType();
   return GetType(getASTContext().getAtomicType(GetQualType(type)));
@@ -4576,6 +4692,7 @@ CompilerType TypeSystemClang::GetAtomicType(lldb::opaque_compiler_type_t type) {
 
 CompilerType
 TypeSystemClang::AddConstModifier(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     clang::QualType result(GetQualType(type));
     result.addConst();
@@ -4587,6 +4704,7 @@ TypeSystemClang::AddConstModifier(lldb::opaque_compiler_type_t type) {
 CompilerType
 TypeSystemClang::AddPtrAuthModifier(lldb::opaque_compiler_type_t type,
                                     uint32_t payload) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     clang::ASTContext &clang_ast = getASTContext();
     auto pauth = PointerAuthQualifier::fromOpaqueValue(payload);
@@ -4599,6 +4717,7 @@ TypeSystemClang::AddPtrAuthModifier(lldb::opaque_compiler_type_t type,
 
 CompilerType
 TypeSystemClang::AddVolatileModifier(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     clang::QualType result(GetQualType(type));
     result.addVolatile();
@@ -4609,6 +4728,7 @@ TypeSystemClang::AddVolatileModifier(lldb::opaque_compiler_type_t type) {
 
 CompilerType
 TypeSystemClang::AddRestrictModifier(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     clang::QualType result(GetQualType(type));
     result.addRestrict();
@@ -4620,6 +4740,7 @@ TypeSystemClang::AddRestrictModifier(lldb::opaque_compiler_type_t type) {
 CompilerType TypeSystemClang::CreateTypedef(
     lldb::opaque_compiler_type_t type, const char *typedef_name,
     const CompilerDeclContext &compiler_decl_ctx, uint32_t payload) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type && typedef_name && typedef_name[0]) {
     clang::ASTContext &clang_ast = getASTContext();
     clang::QualType qual_type(GetQualType(type));
@@ -4664,6 +4785,7 @@ CompilerType TypeSystemClang::CreateTypedef(
 
 CompilerType
 TypeSystemClang::GetTypedefedType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     const clang::TypedefType *typedef_type = llvm::dyn_cast<clang::TypedefType>(
         RemoveWrappingTypes(GetQualType(type), {clang::Type::Typedef}));
@@ -4676,10 +4798,12 @@ TypeSystemClang::GetTypedefedType(lldb::opaque_compiler_type_t type) {
 // Create related types using the current type's AST
 
 CompilerType TypeSystemClang::GetBasicTypeFromAST(lldb::BasicType basic_type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   return TypeSystemClang::GetBasicType(basic_type);
 }
 
 CompilerType TypeSystemClang::CreateGenericFunctionPrototype() {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   clang::ASTContext &ast = getASTContext();
   const FunctionType::ExtInfo generic_ext_info(
     /*noReturn=*/false,
@@ -4697,6 +4821,7 @@ CompilerType TypeSystemClang::CreateGenericFunctionPrototype() {
 
 const llvm::fltSemantics &
 TypeSystemClang::GetFloatTypeSemantics(size_t byte_size, lldb::Format format) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   clang::ASTContext &ast = getASTContext();
   const size_t bit_size = byte_size * 8;
   if (bit_size == ast.getTypeSize(ast.FloatTy))
@@ -4720,6 +4845,7 @@ TypeSystemClang::GetFloatTypeSemantics(size_t byte_size, lldb::Format format) {
 llvm::Expected<uint64_t>
 TypeSystemClang::GetObjCBitSize(QualType qual_type,
                                 ExecutionContextScope *exe_scope) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   assert(qual_type->isObjCObjectOrInterfaceType());
   ExecutionContext exe_ctx(exe_scope);
   if (Process *process = exe_ctx.GetProcessPtr()) {
@@ -4753,6 +4879,7 @@ TypeSystemClang::GetObjCBitSize(QualType qual_type,
 llvm::Expected<uint64_t>
 TypeSystemClang::GetBitSize(lldb::opaque_compiler_type_t type,
                             ExecutionContextScope *exe_scope) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   const bool base_name_only = true;
   if (!GetCompleteType(type))
     return llvm::createStringError(
@@ -4791,12 +4918,14 @@ TypeSystemClang::GetBitSize(lldb::opaque_compiler_type_t type,
 std::optional<size_t>
 TypeSystemClang::GetTypeBitAlign(lldb::opaque_compiler_type_t type,
                                  ExecutionContextScope *exe_scope) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (GetCompleteType(type))
     return getASTContext().getTypeAlign(GetQualType(type));
   return {};
 }
 
 lldb::Encoding TypeSystemClang::GetEncoding(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return lldb::eEncodingInvalid;
 
@@ -5107,6 +5236,7 @@ lldb::Encoding TypeSystemClang::GetEncoding(lldb::opaque_compiler_type_t type) {
 }
 
 lldb::Format TypeSystemClang::GetFormat(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return lldb::eFormatDefault;
 
@@ -5305,6 +5435,7 @@ llvm::Expected<uint32_t>
 TypeSystemClang::GetNumChildren(lldb::opaque_compiler_type_t type,
                                 bool omit_empty_base_classes,
                                 const ExecutionContext *exe_ctx) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return llvm::createStringError("invalid clang type");
 
@@ -5439,6 +5570,7 @@ TypeSystemClang::GetNumChildren(lldb::opaque_compiler_type_t type,
 }
 
 CompilerType TypeSystemClang::GetBuiltinTypeByName(ConstString name) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   StringRef name_ref = name.GetStringRef();
   // We compile the regex only the type name fulfills certain
   // necessary conditions. Otherwise we do not bother.
@@ -5459,6 +5591,7 @@ CompilerType TypeSystemClang::GetBuiltinTypeByName(ConstString name) {
 
 lldb::BasicType
 TypeSystemClang::GetBasicTypeEnumeration(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     clang::QualType qual_type(GetCanonicalQualType(type));
     const clang::Type::TypeClass type_class = qual_type->getTypeClass();
@@ -5539,6 +5672,7 @@ void TypeSystemClang::ForEachEnumerator(
     std::function<bool(const CompilerType &integer_type,
                        ConstString name,
                        const llvm::APSInt &value)> const &callback) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   const clang::EnumType *enum_type =
       llvm::dyn_cast<clang::EnumType>(GetCanonicalQualType(type));
   if (enum_type) {
@@ -5562,6 +5696,7 @@ void TypeSystemClang::ForEachEnumerator(
 #pragma mark Aggregate Types
 
 uint32_t TypeSystemClang::GetNumFields(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return 0;
 
@@ -5679,6 +5814,7 @@ CompilerType TypeSystemClang::GetFieldAtIndex(lldb::opaque_compiler_type_t type,
                                               uint64_t *bit_offset_ptr,
                                               uint32_t *bitfield_bit_size_ptr,
                                               bool *is_bitfield_ptr) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return CompilerType();
 
@@ -5781,6 +5917,7 @@ CompilerType TypeSystemClang::GetFieldAtIndex(lldb::opaque_compiler_type_t type,
 
 uint32_t
 TypeSystemClang::GetNumDirectBaseClasses(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   uint32_t count = 0;
   clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
   const clang::Type::TypeClass type_class = qual_type->getTypeClass();
@@ -5833,6 +5970,7 @@ TypeSystemClang::GetNumDirectBaseClasses(lldb::opaque_compiler_type_t type) {
 
 uint32_t
 TypeSystemClang::GetNumVirtualBaseClasses(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   uint32_t count = 0;
   clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
   const clang::Type::TypeClass type_class = qual_type->getTypeClass();
@@ -5854,6 +5992,7 @@ TypeSystemClang::GetNumVirtualBaseClasses(lldb::opaque_compiler_type_t type) {
 
 CompilerType TypeSystemClang::GetDirectBaseClassAtIndex(
     lldb::opaque_compiler_type_t type, size_t idx, uint32_t *bit_offset_ptr) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
   const clang::Type::TypeClass type_class = qual_type->getTypeClass();
   switch (type_class) {
@@ -5949,6 +6088,7 @@ CompilerType TypeSystemClang::GetDirectBaseClassAtIndex(
 
 CompilerType TypeSystemClang::GetVirtualBaseClassAtIndex(
     lldb::opaque_compiler_type_t type, size_t idx, uint32_t *bit_offset_ptr) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
   const clang::Type::TypeClass type_class = qual_type->getTypeClass();
   switch (type_class) {
@@ -5993,6 +6133,7 @@ CompilerType TypeSystemClang::GetVirtualBaseClassAtIndex(
 CompilerDecl
 TypeSystemClang::GetStaticFieldWithName(lldb::opaque_compiler_type_t type,
                                         llvm::StringRef name) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
   switch (qual_type->getTypeClass()) {
   case clang::Type::Record: {
@@ -6163,6 +6304,7 @@ llvm::Expected<CompilerType> TypeSystemClang::GetDereferencedType(
     lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
     std::string &deref_name, uint32_t &deref_byte_size,
     int32_t &deref_byte_offset, ValueObject *valobj, uint64_t &language_flags) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   bool type_valid = IsPointerOrReferenceType(type, nullptr) ||
                     IsArrayType(type, nullptr, nullptr, nullptr);
   if (!type_valid)
@@ -6185,6 +6327,7 @@ llvm::Expected<CompilerType> TypeSystemClang::GetChildCompilerTypeAtIndex(
     uint32_t &child_bitfield_bit_size, uint32_t &child_bitfield_bit_offset,
     bool &child_is_base_class, bool &child_is_deref_of_parent,
     ValueObject *valobj, uint64_t &language_flags) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return llvm::createStringError("invalid type");
 
@@ -6636,6 +6779,7 @@ uint32_t TypeSystemClang::GetIndexForRecordBase(
     const clang::RecordDecl *record_decl,
     const clang::CXXBaseSpecifier *base_spec,
     bool omit_empty_base_classes) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   uint32_t child_idx = 0;
 
   const clang::CXXRecordDecl *cxx_record_decl =
@@ -6663,6 +6807,7 @@ uint32_t TypeSystemClang::GetIndexForRecordBase(
 uint32_t TypeSystemClang::GetIndexForRecordChild(
     const clang::RecordDecl *record_decl, clang::NamedDecl *canonical_decl,
     bool omit_empty_base_classes) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   uint32_t child_idx = TypeSystemClang::GetNumBaseClasses(
       llvm::dyn_cast<clang::CXXRecordDecl>(record_decl),
       omit_empty_base_classes);
@@ -6713,6 +6858,7 @@ uint32_t TypeSystemClang::GetIndexForRecordChild(
 size_t TypeSystemClang::GetIndexOfChildMemberWithName(
     lldb::opaque_compiler_type_t type, llvm::StringRef name,
     bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type && !name.empty()) {
     clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
     const clang::Type::TypeClass type_class = qual_type->getTypeClass();
@@ -6914,6 +7060,7 @@ llvm::Expected<uint32_t>
 TypeSystemClang::GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
                                          llvm::StringRef name,
                                          bool omit_empty_base_classes) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type && !name.empty()) {
     clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
 
@@ -7051,6 +7198,7 @@ TypeSystemClang::GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
 CompilerType
 TypeSystemClang::GetDirectNestedTypeWithName(lldb::opaque_compiler_type_t type,
                                              llvm::StringRef name) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type || name.empty())
     return CompilerType();
 
@@ -7084,6 +7232,7 @@ TypeSystemClang::GetDirectNestedTypeWithName(lldb::opaque_compiler_type_t type,
 }
 
 bool TypeSystemClang::IsTemplateType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return false;
   CompilerType ct(weak_from_this(), type);
@@ -7097,6 +7246,7 @@ bool TypeSystemClang::IsTemplateType(lldb::opaque_compiler_type_t type) {
 size_t
 TypeSystemClang::GetNumTemplateArguments(lldb::opaque_compiler_type_t type,
                                          bool expand_pack) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return 0;
 
@@ -7136,6 +7286,7 @@ TypeSystemClang::GetNumTemplateArguments(lldb::opaque_compiler_type_t type,
 const clang::ClassTemplateSpecializationDecl *
 TypeSystemClang::GetAsTemplateSpecialization(
     lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return nullptr;
 
@@ -7193,6 +7344,7 @@ GetNthTemplateArgument(const clang::ClassTemplateSpecializationDecl *decl,
 lldb::TemplateArgumentKind
 TypeSystemClang::GetTemplateArgumentKind(lldb::opaque_compiler_type_t type,
                                          size_t arg_idx, bool expand_pack) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   const clang::ClassTemplateSpecializationDecl *template_decl =
       GetAsTemplateSpecialization(type);
   if (!template_decl)
@@ -7239,6 +7391,7 @@ TypeSystemClang::GetTemplateArgumentKind(lldb::opaque_compiler_type_t type,
 CompilerType
 TypeSystemClang::GetTypeTemplateArgument(lldb::opaque_compiler_type_t type,
                                          size_t idx, bool expand_pack) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   const clang::ClassTemplateSpecializationDecl *template_decl =
       GetAsTemplateSpecialization(type);
   if (!template_decl)
@@ -7254,6 +7407,7 @@ TypeSystemClang::GetTypeTemplateArgument(lldb::opaque_compiler_type_t type,
 std::optional<CompilerType::IntegralTemplateArgument>
 TypeSystemClang::GetIntegralTemplateArgument(lldb::opaque_compiler_type_t type,
                                              size_t idx, bool expand_pack) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   const clang::ClassTemplateSpecializationDecl *template_decl =
       GetAsTemplateSpecialization(type);
   if (!template_decl)
@@ -7284,6 +7438,7 @@ TypeSystemClang::GetIntegralTemplateArgument(lldb::opaque_compiler_type_t type,
 }
 
 CompilerType TypeSystemClang::GetTypeForFormatters(void *type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type)
     return ClangUtil::RemoveFastQualifiers(CompilerType(weak_from_this(), type));
   return CompilerType();
@@ -7291,12 +7446,14 @@ CompilerType TypeSystemClang::GetTypeForFormatters(void *type) {
 
 bool TypeSystemClang::IsPromotableIntegerType(
     lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   clang::QualType qual_type(GetCanonicalQualType(type));
   return getASTContext().isPromotableIntegerType(qual_type);
 }
 
 CompilerType
 TypeSystemClang::GetPromotedIntegerType(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!IsPromotableIntegerType(type))
     return CompilerType();
   clang::QualType qual_type(GetCanonicalQualType(type));
@@ -7641,6 +7798,7 @@ llvm::SmallVector<clang::ParmVarDecl *>
 TypeSystemClang::CreateParameterDeclarations(
     clang::FunctionDecl *func, const clang::FunctionProtoType &prototype,
     const llvm::SmallVector<llvm::StringRef> &parameter_names) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   assert(func);
   assert(parameter_names.empty() ||
          parameter_names.size() == prototype.getNumParams());
@@ -7843,6 +8001,7 @@ clang::CXXMethodDecl *TypeSystemClang::AddMethodToCXXRecordType(
 
 void TypeSystemClang::AddMethodOverridesForCXXRecordType(
     lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (auto *record = GetAsCXXRecordDecl(type))
     for (auto *method : record->methods())
       addOverridesForMethod(method);
@@ -7854,6 +8013,7 @@ std::unique_ptr<clang::CXXBaseSpecifier>
 TypeSystemClang::CreateBaseClassSpecifier(lldb::opaque_compiler_type_t type,
                                           AccessType access, bool is_virtual,
                                           bool base_of_class) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return nullptr;
 
@@ -7867,6 +8027,7 @@ TypeSystemClang::CreateBaseClassSpecifier(lldb::opaque_compiler_type_t type,
 bool TypeSystemClang::TransferBaseClasses(
     lldb::opaque_compiler_type_t type,
     std::vector<std::unique_ptr<clang::CXXBaseSpecifier>> bases) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return false;
   clang::CXXRecordDecl *cxx_record_decl = GetAsCXXRecordDecl(type);
@@ -8458,6 +8619,7 @@ clang::EnumConstantDecl *TypeSystemClang::AddEnumerationValueToEnumerationType(
 }
 
 CompilerType TypeSystemClang::GetEnumerationIntegerType(CompilerType type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   clang::QualType qt(ClangUtil::GetQualType(type));
   const clang::Type *clang_type = qt.getTypePtrOrNull();
   const auto *enum_type = llvm::dyn_cast_or_null<clang::EnumType>(clang_type);
@@ -8489,6 +8651,7 @@ TypeSystemClang::CreateMemberPointerType(const CompilerType &type,
 #ifndef NDEBUG
 LLVM_DUMP_METHOD void
 TypeSystemClang::dump(lldb::opaque_compiler_type_t type) const {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return;
   clang::QualType qual_type(GetQualType(type));
@@ -8517,6 +8680,7 @@ struct ScopedASTColor {
 
 void TypeSystemClang::Dump(llvm::raw_ostream &output, llvm::StringRef filter,
                            bool show_color) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   ScopedASTColor colored(getASTContext(), show_color);
 
   auto consumer =
@@ -8532,6 +8696,7 @@ void TypeSystemClang::Dump(llvm::raw_ostream &output, llvm::StringRef filter,
 
 void TypeSystemClang::DumpFromSymbolFile(Stream &s,
                                          llvm::StringRef symbol_name) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   SymbolFile *symfile = GetSymbolFile();
 
   if (!symfile)
@@ -8676,6 +8841,7 @@ bool TypeSystemClang::DumpTypeValue(
     const lldb_private::DataExtractor &data, lldb::offset_t byte_offset,
     size_t byte_size, uint32_t bitfield_bit_size, uint32_t bitfield_bit_offset,
     ExecutionContextScope *exe_scope) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!type)
     return false;
   if (IsAggregateType(type)) {
@@ -8790,6 +8956,7 @@ bool TypeSystemClang::DumpTypeValue(
 
 void TypeSystemClang::DumpTypeDescription(lldb::opaque_compiler_type_t type,
                                           lldb::DescriptionLevel level) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   StreamFile s(stdout, false);
   DumpTypeDescription(type, s, level);
 
@@ -8803,6 +8970,7 @@ void TypeSystemClang::DumpTypeDescription(lldb::opaque_compiler_type_t type,
 void TypeSystemClang::DumpTypeDescription(lldb::opaque_compiler_type_t type,
                                           Stream &s,
                                           lldb::DescriptionLevel level) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     clang::QualType qual_type =
         RemoveWrappingTypes(GetQualType(type), {clang::Type::Typedef});
@@ -8972,6 +9140,7 @@ clang::ClassTemplateDecl *TypeSystemClang::ParseClassTemplateDecl(
 }
 
 void TypeSystemClang::CompleteTagDecl(clang::TagDecl *decl) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   SymbolFile *sym_file = GetSymbolFile();
   if (sym_file) {
     CompilerType clang_type = GetTypeForDecl(decl);
@@ -8982,6 +9151,7 @@ void TypeSystemClang::CompleteTagDecl(clang::TagDecl *decl) {
 
 void TypeSystemClang::CompleteObjCInterfaceDecl(
     clang::ObjCInterfaceDecl *decl) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   SymbolFile *sym_file = GetSymbolFile();
   if (sym_file) {
     CompilerType clang_type = GetTypeForDecl(decl);
@@ -9017,6 +9187,7 @@ bool TypeSystemClang::LayoutRecordType(
         &base_offsets,
     llvm::DenseMap<const clang::CXXRecordDecl *, clang::CharUnits>
         &vbase_offsets) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   lldb_private::ClangASTImporter *importer = nullptr;
   if (m_dwarf_ast_parser_up)
     importer = &m_dwarf_ast_parser_up->GetClangASTImporter();
@@ -9034,6 +9205,7 @@ bool TypeSystemClang::LayoutRecordType(
 // CompilerDecl override functions
 
 ConstString TypeSystemClang::DeclGetName(void *opaque_decl) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (opaque_decl) {
     clang::NamedDecl *nd =
         llvm::dyn_cast<NamedDecl>((clang::Decl *)opaque_decl);
@@ -9059,6 +9231,7 @@ ExtractMangledNameFromFunctionCallLabel(llvm::StringRef label) {
 }
 
 ConstString TypeSystemClang::DeclGetMangledName(void *opaque_decl) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   clang::NamedDecl *nd = llvm::dyn_cast_or_null<clang::NamedDecl>(
       static_cast<clang::Decl *>(opaque_decl));
 
@@ -9099,12 +9272,14 @@ ConstString TypeSystemClang::DeclGetMangledName(void *opaque_decl) {
 }
 
 CompilerDeclContext TypeSystemClang::DeclGetDeclContext(void *opaque_decl) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (opaque_decl)
     return CreateDeclContext(((clang::Decl *)opaque_decl)->getDeclContext());
   return CompilerDeclContext();
 }
 
 CompilerType TypeSystemClang::DeclGetFunctionReturnType(void *opaque_decl) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (clang::FunctionDecl *func_decl =
           llvm::dyn_cast<clang::FunctionDecl>((clang::Decl *)opaque_decl))
     return GetType(func_decl->getReturnType());
@@ -9116,6 +9291,7 @@ CompilerType TypeSystemClang::DeclGetFunctionReturnType(void *opaque_decl) {
 }
 
 size_t TypeSystemClang::DeclGetFunctionNumArguments(void *opaque_decl) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (clang::FunctionDecl *func_decl =
           llvm::dyn_cast<clang::FunctionDecl>((clang::Decl *)opaque_decl))
     return func_decl->param_size();
@@ -9169,6 +9345,7 @@ InsertCompilerContext(TypeSystemClang *ts, clang::DeclContext *decl_ctx,
 
 std::vector<lldb_private::CompilerContext>
 TypeSystemClang::DeclGetCompilerContext(void *opaque_decl) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   std::vector<lldb_private::CompilerContext> context;
   ConstString decl_name = DeclGetName(opaque_decl);
   if (decl_name) {
@@ -9186,6 +9363,7 @@ TypeSystemClang::DeclGetCompilerContext(void *opaque_decl) {
 
 CompilerType TypeSystemClang::DeclGetFunctionArgumentType(void *opaque_decl,
                                                           size_t idx) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (clang::FunctionDecl *func_decl =
           llvm::dyn_cast<clang::FunctionDecl>((clang::Decl *)opaque_decl)) {
     if (idx < func_decl->param_size()) {
@@ -9203,6 +9381,7 @@ CompilerType TypeSystemClang::DeclGetFunctionArgumentType(void *opaque_decl,
 }
 
 Scalar TypeSystemClang::DeclGetConstantValue(void *opaque_decl) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   clang::Decl *decl = static_cast<clang::Decl *>(opaque_decl);
   clang::VarDecl *var_decl = llvm::dyn_cast<clang::VarDecl>(decl);
   if (!var_decl)
@@ -9221,6 +9400,7 @@ Scalar TypeSystemClang::DeclGetConstantValue(void *opaque_decl) {
 
 std::vector<CompilerDecl> TypeSystemClang::DeclContextFindDeclByName(
     void *opaque_decl_ctx, ConstString name, const bool ignore_using_decls) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   std::vector<CompilerDecl> found_decls;
   SymbolFile *symbol_file = GetSymbolFile();
   if (opaque_decl_ctx && symbol_file) {
@@ -9319,6 +9499,7 @@ uint32_t TypeSystemClang::CountDeclLevels(clang::DeclContext *frame_decl_ctx,
                                           clang::DeclContext *child_decl_ctx,
                                           ConstString *child_name,
                                           CompilerType *child_type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   SymbolFile *symbol_file = GetSymbolFile();
   if (frame_decl_ctx && symbol_file) {
     std::set<DeclContext *> searched;
@@ -9398,6 +9579,7 @@ uint32_t TypeSystemClang::CountDeclLevels(clang::DeclContext *frame_decl_ctx,
 }
 
 ConstString TypeSystemClang::DeclContextGetName(void *opaque_decl_ctx) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (opaque_decl_ctx) {
     clang::NamedDecl *named_decl =
         llvm::dyn_cast<clang::NamedDecl>((clang::DeclContext *)opaque_decl_ctx);
@@ -9415,6 +9597,7 @@ ConstString TypeSystemClang::DeclContextGetName(void *opaque_decl_ctx) {
 
 ConstString
 TypeSystemClang::DeclContextGetScopeQualifiedName(void *opaque_decl_ctx) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (opaque_decl_ctx) {
     clang::NamedDecl *named_decl =
         llvm::dyn_cast<clang::NamedDecl>((clang::DeclContext *)opaque_decl_ctx);
@@ -9425,6 +9608,7 @@ TypeSystemClang::DeclContextGetScopeQualifiedName(void *opaque_decl_ctx) {
 }
 
 bool TypeSystemClang::DeclContextIsClassMethod(void *opaque_decl_ctx) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!opaque_decl_ctx)
     return false;
 
@@ -9444,6 +9628,7 @@ bool TypeSystemClang::DeclContextIsClassMethod(void *opaque_decl_ctx) {
 
 std::vector<lldb_private::CompilerContext>
 TypeSystemClang::DeclContextGetCompilerContext(void *opaque_decl_ctx) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   auto *decl_ctx = (clang::DeclContext *)opaque_decl_ctx;
   std::vector<lldb_private::CompilerContext> context;
   InsertCompilerContext(this, decl_ctx, context);
@@ -9452,6 +9637,7 @@ TypeSystemClang::DeclContextGetCompilerContext(void *opaque_decl_ctx) {
 
 bool TypeSystemClang::DeclContextIsContainedInLookup(
     void *opaque_decl_ctx, void *other_opaque_decl_ctx) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   auto *decl_ctx = (clang::DeclContext *)opaque_decl_ctx;
   auto *other = (clang::DeclContext *)other_opaque_decl_ctx;
 
@@ -9479,6 +9665,7 @@ bool TypeSystemClang::DeclContextIsContainedInLookup(
 
 lldb::LanguageType
 TypeSystemClang::DeclContextGetLanguage(void *opaque_decl_ctx) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (!opaque_decl_ctx)
     return eLanguageTypeUnknown;
 
@@ -9623,6 +9810,7 @@ ScratchTypeSystemClang::ScratchTypeSystemClang(Target &target,
 }
 
 void ScratchTypeSystemClang::Finalize() {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   TypeSystemClang::Finalize();
   m_scratch_ast_source_up.reset();
 }
@@ -9663,6 +9851,7 @@ GetNameForIsolatedASTKind(ScratchTypeSystemClang::IsolatedASTKind kind) {
 
 void ScratchTypeSystemClang::Dump(llvm::raw_ostream &output,
                                   llvm::StringRef filter, bool show_color) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   // First dump the main scratch AST.
   output << "State of scratch Clang type system:\n";
   TypeSystemClang::Dump(output, filter, show_color);
@@ -9714,6 +9903,7 @@ FunctionCaller *ScratchTypeSystemClang::GetFunctionCaller(
 std::unique_ptr<UtilityFunction>
 ScratchTypeSystemClang::CreateUtilityFunction(std::string text,
                                               std::string name) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   TargetSP target_sp = m_target_wp.lock();
   if (!target_sp)
     return {};
@@ -9725,11 +9915,13 @@ ScratchTypeSystemClang::CreateUtilityFunction(std::string text,
 
 PersistentExpressionState *
 ScratchTypeSystemClang::GetPersistentExpressionState() {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   return m_persistent_variables.get();
 }
 
 void ScratchTypeSystemClang::ForgetSource(ASTContext *src_ctx,
                                           ClangASTImporter &importer) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   // Remove it as a source from the main AST.
   importer.ForgetSource(&getASTContext(), src_ctx);
   // Remove it as a source from all created sub-ASTs.
@@ -9738,6 +9930,7 @@ void ScratchTypeSystemClang::ForgetSource(ASTContext *src_ctx,
 }
 
 std::unique_ptr<ClangASTSource> ScratchTypeSystemClang::CreateASTSource() {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   return std::make_unique<ClangASTSource>(
       m_target_wp.lock()->shared_from_this(),
       m_persistent_variables->GetClangASTImporter());
@@ -9767,6 +9960,7 @@ TypeSystemClang &ScratchTypeSystemClang::GetIsolatedAST(
 }
 
 bool TypeSystemClang::IsForcefullyCompleted(lldb::opaque_compiler_type_t type) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (type) {
     clang::QualType qual_type(GetQualType(type));
     const clang::RecordType *record_type =
@@ -9782,6 +9976,7 @@ bool TypeSystemClang::IsForcefullyCompleted(lldb::opaque_compiler_type_t type) {
 }
 
 bool TypeSystemClang::SetDeclIsForcefullyCompleted(const clang::TagDecl *td) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (td == nullptr)
     return false;
   std::optional<ClangASTMetadata> metadata = GetMetadata(td);
@@ -9795,6 +9990,7 @@ bool TypeSystemClang::SetDeclIsForcefullyCompleted(const clang::TagDecl *td) {
 }
 
 void TypeSystemClang::LogCreation() const {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
   if (auto *log = GetLog(LLDBLog::Expressions))
     LLDB_LOG(log, "Created new TypeSystem for (ASTContext*){0:x} '{1}'",
              &getASTContext(), getDisplayName());

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -14,6 +14,7 @@
 #include <functional>
 #include <initializer_list>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <set>
 #include <string>
@@ -122,6 +123,14 @@ public:
   typedef void (*CompleteTagDeclCallback)(void *baton, clang::TagDecl *);
   typedef void (*CompleteObjCInterfaceDeclCallback)(void *baton,
                                                     clang::ObjCInterfaceDecl *);
+
+  /// Returns the lock that is used to guard all accesses to this TypeSystem.
+  /// This might return the Module's lock if this TypeSystemClang represents
+  /// Module contents.
+  std::recursive_mutex &GetMutex() const { return *m_mutex_ptr; }
+
+  /// Makes GetMutex() hand out \p mutex instead of this instance's own lock.
+  void SetSharedMutex(std::recursive_mutex &mutex) { m_mutex_ptr = &mutex; }
 
   // llvm casting support
   bool isA(const void *ClassID) const override { return ClassID == &ID; }
@@ -1206,6 +1215,10 @@ private:
 
   // Classes that inherit from TypeSystemClang can see and modify these
   std::string m_target_triple;
+  mutable std::recursive_mutex m_mutex;
+  /// \see SetSharedMutex()
+  /// \see GetMutex()
+  std::recursive_mutex *m_mutex_ptr = &m_mutex;
   std::unique_ptr<clang::ASTContext> m_ast_up;
   std::unique_ptr<clang::LangOptions> m_language_options_up;
   std::unique_ptr<clang::FileManager> m_file_manager_up;

--- a/lldb/test/API/api/multithreaded/TestMultithreaded.py
+++ b/lldb/test/API/api/multithreaded/TestMultithreaded.py
@@ -97,7 +97,26 @@ class SBBreakpointCallbackCase(TestBase):
             inferior_source="deep_stack.cpp",
         )
 
-    def build_and_test(self, sources, test_name, inferior_source="inferior.cpp"):
+    @skipIfRemote
+    # clang-cl does not support throw or catch (llvm.org/pr24538)
+    @skipIfWindows
+    @skipIfHostIncompatibleWithTarget
+    def test_concurrent_expressions_shared_module(self):
+        """Test that expressions for the same module can be evaluated and their
+        results inspected from several threads at the same time.
+        """
+        self.build_and_test(
+            "driver.cpp test_concurrent_expressions.cpp",
+            "test_concurrent_expressions_shared_module",
+            inferior_source="global_struct.cpp",
+        )
+
+    def build_and_test(
+        self,
+        sources,
+        test_name,
+        inferior_source="inferior.cpp",
+    ):
         """Build LLDB test from sources, and run expecting 0 exit code"""
 
         # These tests link against host lldb API.

--- a/lldb/test/API/api/multithreaded/common.h
+++ b/lldb/test/API/api/multithreaded/common.h
@@ -1,13 +1,15 @@
 #ifndef LLDB_TEST_API_COMMON_H
 #define LLDB_TEST_API_COMMON_H
 
-#include <condition_variable>
 #include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cstring>
 #include <exception>
 #include <iostream>
 #include <mutex>
-#include <string>
 #include <queue>
+#include <string>
 
 #include <unistd.h>
 
@@ -19,6 +21,31 @@ struct Exception : public std::exception
   virtual ~Exception() throw () { }
   const char* what() const throw() { return s.c_str(); }
 };
+
+/// Throws an Exception with the given message if 'condition' is false.
+inline void expect(bool condition, const std::string &message) {
+  if (!condition)
+    throw Exception(message);
+}
+
+/// Throws an Exception describing 'what' if 'actual' is null or doesn't equal
+/// the string 'expected'.
+inline void expect_string(const char *actual, const char *expected,
+                          const std::string &what) {
+  if (!actual)
+    throw Exception(what + ": expected '" + expected + "' but got no string");
+  if (std::strcmp(actual, expected) != 0)
+    throw Exception(what + ": expected '" + expected + "' but got '" + actual +
+                    "'");
+}
+
+/// Throws an Exception describing 'what' if 'actual' doesn't equal 'expected'.
+inline void expect_int(int64_t actual, int64_t expected,
+                       const std::string &what) {
+  if (actual != expected)
+    throw Exception(what + ": expected " + std::to_string(expected) +
+                    " but got " + std::to_string(actual));
+}
 
 // Synchronized data structure for listener to send events through
 template<typename T>

--- a/lldb/test/API/api/multithreaded/global_struct.cpp
+++ b/lldb/test/API/api/multithreaded/global_struct.cpp
@@ -1,0 +1,33 @@
+// This is a test program with a global struct that is inspected from several
+// threads at once by test_concurrent_expressions.cpp.
+
+enum Color { eRed = 1, eGreen = 2, eBlue = 3 };
+
+struct Base {
+  int base_field = 1;
+};
+
+struct Data : Base {
+  struct Inner {
+    int inner_field = 20;
+  };
+
+  int i = 42;
+  Inner inner;
+  Color color = eGreen;
+  int array[3] = {1, 2, 3};
+  const char *str = "global struct";
+
+  static int static_field;
+
+  int GetI() const { return i; }
+};
+
+int Data::static_field = 4711;
+
+Data g_data;
+
+int main() {
+  // Touch the members so that nothing is dropped from the debug info.
+  return g_data.GetI() + Data::static_field - 4753;
+}

--- a/lldb/test/API/api/multithreaded/test_concurrent_expressions.cpp
+++ b/lldb/test/API/api/multithreaded/test_concurrent_expressions.cpp
@@ -1,0 +1,309 @@
+
+// LLDB C++ API Test: Evaluate an expression that yields a global struct from
+// several threads at the same time and inspect the resulting SBValue and
+// SBType from each of these threads.
+//
+// All threads debug the same program (and therefore share LLDB's module for
+// it), and every thread also launches its own process.
+
+#include <condition_variable>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "lldb/API/SBBreakpoint.h"
+#include "lldb/API/SBData.h"
+#include "lldb/API/SBDebugger.h"
+#include "lldb/API/SBError.h"
+#include "lldb/API/SBLaunchInfo.h"
+#include "lldb/API/SBProcess.h"
+#include "lldb/API/SBStream.h"
+#include "lldb/API/SBTarget.h"
+#include "lldb/API/SBType.h"
+#include "lldb/API/SBTypeEnumMember.h"
+#include "lldb/API/SBValue.h"
+
+#include "common.h"
+
+using namespace lldb;
+
+namespace {
+
+/// The number of threads used to debug the shared program at the same time.
+const unsigned num_threads = 5;
+
+/// How often each thread evaluates and inspects the expression result.
+const unsigned num_iterations = 5;
+
+/// Blocks until all threads have arrived.
+class Barrier {
+  std::mutex m_mutex;
+  std::condition_variable m_condition;
+  unsigned m_missing;
+
+public:
+  Barrier(unsigned count) : m_missing(count) {}
+
+  void Wait() {
+    std::unique_lock<std::mutex> lock(m_mutex);
+    m_missing--;
+    if (m_missing == 0)
+      m_condition.notify_all();
+    else
+      m_condition.wait(lock, [this] { return m_missing == 0; });
+  }
+};
+
+/// Returns the value of the given SBValue as a signed integer.
+int64_t get_signed(SBValue value, const std::string &what) {
+  expect(value.IsValid(), what + ": value is invalid");
+  SBError error;
+  int64_t result = value.GetValueAsSigned(error, 0);
+  if (error.Fail())
+    throw Exception(what + ": " + error.GetCString());
+  return result;
+}
+
+/// Calls various SBType functions on the type of the global 'g_data' struct.
+void check_struct_type(SBType type) {
+  expect(type.IsValid(), "type of 'g_data' is invalid");
+  expect_string(type.GetName(), "Data", "SBType::GetName");
+  expect_string(type.GetDisplayTypeName(), "Data",
+                "SBType::GetDisplayTypeName");
+  expect(type.GetTypeClass() == eTypeClassStruct, "SBType::GetTypeClass");
+  expect(type.IsAggregateType(), "'Data' should be an aggregate type");
+  expect(type.IsTypeComplete(), "'Data' should be a complete type");
+  expect(!type.IsPointerType(), "'Data' should not be a pointer type");
+  expect(type.GetByteSize() > 0, "'Data' has no byte size");
+  expect(type.GetByteAlign() > 0, "'Data' has no alignment");
+  expect_int(type.GetNumberOfTemplateArguments(), 0,
+             "SBType::GetNumberOfTemplateArguments");
+
+  // Check the fields of the struct.
+  expect_int(type.GetNumberOfFields(), 5, "SBType::GetNumberOfFields");
+  SBTypeMember first_field = type.GetFieldAtIndex(0);
+  expect(first_field.IsValid(), "first field of 'Data' is invalid");
+  expect_string(first_field.GetName(), "i", "name of first field");
+  expect_string(first_field.GetType().GetName(), "int",
+                "type of first field 'i'");
+
+  SBTypeMember array_field = type.GetFieldAtIndex(3);
+  expect_string(array_field.GetName(), "array", "name of fourth field");
+  SBType array_type = array_field.GetType();
+  expect(array_type.IsArrayType(), "'array' should be an array type");
+  expect_string(array_type.GetArrayElementType().GetName(), "int",
+                "element type of 'array'");
+
+  // Check the base class and the nested type.
+  expect_int(type.GetNumberOfDirectBaseClasses(), 1,
+             "SBType::GetNumberOfDirectBaseClasses");
+  expect_string(type.GetDirectBaseClassAtIndex(0).GetName(), "Base",
+                "name of direct base class");
+  expect_int(type.GetNumberOfVirtualBaseClasses(), 0,
+             "SBType::GetNumberOfVirtualBaseClasses");
+  SBType nested_type = type.FindDirectNestedType("Inner");
+  expect(nested_type.IsValid(), "'Data' has no nested type 'Inner'");
+  expect_int(nested_type.GetNumberOfFields(), 1,
+             "number of fields of 'Data::Inner'");
+
+  // Check the static member.
+  SBTypeStaticField static_field = type.GetStaticFieldWithName("static_field");
+  expect(static_field.IsValid(), "'Data' has no static field 'static_field'");
+  expect_string(static_field.GetName(), "static_field",
+                "SBTypeStaticField::GetName");
+  expect_string(static_field.GetType().GetName(), "int",
+                "type of 'Data::static_field'");
+
+  // Check the member function of the struct.
+  bool found_getter = false;
+  for (uint32_t i = 0; i < type.GetNumberOfMemberFunctions(); ++i) {
+    SBTypeMemberFunction func = type.GetMemberFunctionAtIndex(i);
+    expect(func.IsValid(), "invalid member function");
+    const char *func_name = func.GetName();
+    expect(func_name != nullptr, "member function without a name");
+    if (std::strcmp(func_name, "GetI") != 0)
+      continue;
+    found_getter = true;
+    expect(func.GetKind() == eMemberFunctionKindInstanceMethod,
+           "'GetI' should be an instance method");
+    expect_string(func.GetReturnType().GetName(), "int",
+                  "return type of 'GetI'");
+    expect_int(func.GetNumberOfArguments(), 0, "number of arguments of 'GetI'");
+  }
+  expect(found_getter, "'Data' has no member function 'GetI'");
+
+  // Check creating derived types.
+  // This should never race as the types are supposed to be created in the
+  // scratch type system.
+  SBType pointer_type = type.GetPointerType();
+  expect(pointer_type.IsPointerType(), "SBType::GetPointerType");
+  SBType pointee_type = pointer_type.GetPointeeType();
+  expect(pointee_type == type, "pointee type of 'Data *' is not 'Data'");
+  SBType reference_type = type.GetReferenceType();
+  expect(reference_type.IsReferenceType(), "SBType::GetReferenceType");
+  SBType dereferenced_type = reference_type.GetDereferencedType();
+  expect(dereferenced_type == type,
+         "dereferenced type of 'Data &' is not 'Data'");
+  SBType data_array_type = type.GetArrayType(4);
+  expect(data_array_type.IsArrayType(), "SBType::GetArrayType");
+  expect_int(data_array_type.GetByteSize(), 4 * type.GetByteSize(),
+             "byte size of 'Data[4]'");
+  expect_string(type.GetCanonicalType().GetName(), "Data",
+                "SBType::GetCanonicalType");
+  expect(type.GetUnqualifiedType().IsValid(), "SBType::GetUnqualifiedType");
+  expect_string(type.GetBasicType(eBasicTypeInt).GetName(), "int",
+                "SBType::GetBasicType");
+
+  SBStream description;
+  expect(type.GetDescription(description, eDescriptionLevelFull),
+         "SBType::GetDescription failed");
+  expect(description.GetSize() > 0, "SBType::GetDescription gave no output");
+}
+
+/// Calls various SBValue functions on the value of the global 'g_data' struct.
+void check_struct_value(SBValue value, SBTarget &target) {
+  expect(value.IsValid(), "expression result is invalid");
+  SBError error = value.GetError();
+  if (error.Fail())
+    throw Exception(std::string("expression failed: ") + error.GetCString());
+
+  expect(value.GetName() != nullptr, "expression result has no name");
+  expect_string(value.GetTypeName(), "Data", "SBValue::GetTypeName");
+  expect_string(value.GetDisplayTypeName(), "Data",
+                "SBValue::GetDisplayTypeName");
+  expect_int(value.GetByteSize(), value.GetType().GetByteSize(),
+             "byte size of value and its type disagree");
+  expect(value.GetValueType() != eValueTypeInvalid, "SBValue::GetValueType");
+  expect(value.MightHaveChildren(), "a struct should have children");
+  expect(!value.IsSynthetic(), "'g_data' should not have synthetic children");
+  expect(value.GetTarget() == target, "SBValue::GetTarget");
+
+  // The base class and the five members of the struct.
+  expect_int(value.GetNumChildren(), 6, "SBValue::GetNumChildren");
+
+  SBValue base = value.GetChildAtIndex(0);
+  expect_string(base.GetName(), "Base", "name of the base class child");
+  expect_int(get_signed(base.GetChildMemberWithName("base_field"),
+                        "g_data.base_field"),
+             1, "value of 'g_data.base_field'");
+
+  SBValue i = value.GetChildMemberWithName("i");
+  expect(i.IsValid(), "'g_data' has no child 'i'");
+  expect_string(i.GetTypeName(), "int", "type of 'g_data.i'");
+  expect_string(i.GetValue(), "42", "SBValue::GetValue for 'g_data.i'");
+  expect_int(get_signed(i, "g_data.i"), 42, "value of 'g_data.i'");
+  expect_int(value.GetIndexOfChildWithName("i"), 1,
+             "SBValue::GetIndexOfChildWithName");
+  expect(i.AddressOf().IsValid(), "SBValue::AddressOf for 'g_data.i'");
+  expect(i.GetParent().IsValid(), "SBValue::GetParent for 'g_data.i'");
+
+  SBValue inner_field = value.GetValueForExpressionPath(".inner.inner_field");
+  expect_int(get_signed(inner_field, "g_data.inner.inner_field"), 20,
+             "value of 'g_data.inner.inner_field'");
+
+  SBValue color = value.GetChildMemberWithName("color");
+  expect_string(color.GetValue(), "eGreen", "value of 'g_data.color'");
+  expect_int(get_signed(color, "g_data.color"), 2,
+             "integer value of 'g_data.color'");
+  expect_int(color.GetType().GetEnumMembers().GetSize(), 3,
+             "number of enumerators of 'Color'");
+
+  SBValue array = value.GetChildMemberWithName("array");
+  expect_int(array.GetNumChildren(), 3, "number of children of 'g_data.array'");
+  expect_int(get_signed(array.GetChildAtIndex(2), "g_data.array[2]"), 3,
+             "value of 'g_data.array[2]'");
+
+  SBValue str = value.GetChildMemberWithName("str");
+  expect(str.GetType().IsPointerType(), "'g_data.str' should be a pointer");
+  expect_string(str.GetTypeName(), "const char *", "type of 'g_data.str'");
+  expect(str.GetValueAsUnsigned(0) != 0, "'g_data.str' should not be null");
+  expect_string(str.GetType().GetPointeeType().GetName(), "const char",
+                "pointee type of 'g_data.str'");
+
+  SBData data = value.GetData();
+  expect(data.IsValid(), "SBValue::GetData");
+  expect_int(data.GetByteSize(), value.GetByteSize(),
+             "byte size of the data of 'g_data'");
+
+  SBStream description;
+  expect(value.GetDescription(description), "SBValue::GetDescription failed");
+  const char *description_text = description.GetData();
+  expect(description_text && std::strstr(description_text, "i = 42"),
+         "SBValue::GetDescription doesn't mention the value of 'i'");
+
+  expect(value.GetProcess().IsValid(), "SBValue::GetProcess");
+  expect(i.GetLoadAddress() != LLDB_INVALID_ADDRESS,
+         "'g_data.i' has no load address");
+}
+
+/// Creates a target for the given program, evaluates an expression for the
+/// global 'g_data' struct and then inspects the result. Returns an empty
+/// string on success or otherwise a description of the encountered failure.
+std::string evaluate_and_check(SBDebugger &dbg, const std::string &program,
+                               Barrier &barrier) {
+  SBTarget target;
+  SBProcess process;
+  std::string setup_error;
+  try {
+    target = dbg.CreateTarget(program.c_str());
+    expect(target.IsValid(), "invalid target");
+
+    SBBreakpoint bkpt = target.BreakpointCreateByName("main");
+    expect(bkpt.GetNumLocations() > 0, "breakpoint got no locations");
+
+    SBError error;
+    SBLaunchInfo launch_info = target.GetLaunchInfo();
+    process = target.Launch(launch_info, error);
+    if (error.Fail())
+      throw Exception(std::string("failed to launch process: ") +
+                      error.GetCString());
+    expect(process.GetState() == eStateStopped, "process was not stopped");
+  } catch (Exception &e) {
+    setup_error = e.what();
+  }
+
+  // Wait for the other threads so that the expressions below are evaluated at
+  // the same time. This also has to happen when the setup above failed as the
+  // other threads would otherwise wait forever.
+  barrier.Wait();
+
+  std::string error_message = setup_error;
+  if (error_message.empty()) {
+    try {
+      for (unsigned i = 0; i < num_iterations; ++i) {
+        SBValue value = target.EvaluateExpression("g_data");
+        check_struct_value(value, target);
+        check_struct_type(value.GetType());
+      }
+    } catch (Exception &e) {
+      error_message = e.what();
+    }
+  }
+
+  if (process.IsValid())
+    process.Kill();
+  return error_message;
+}
+
+} // namespace
+
+void test(SBDebugger &dbg, std::vector<std::string> args) {
+  dbg.SetAsync(false);
+
+  Barrier barrier(num_threads);
+  // Every thread reports its failure (if any) in its own slot.
+  std::vector<std::string> errors(num_threads);
+  std::vector<std::thread> threads;
+
+  for (unsigned i = 0; i < num_threads; ++i)
+    threads.emplace_back(
+        [&, i]() { errors[i] = evaluate_and_check(dbg, args.at(0), barrier); });
+  for (std::thread &thread : threads)
+    thread.join();
+
+  for (unsigned i = 0; i < num_threads; ++i)
+    if (!errors[i].empty())
+      throw Exception("thread " + std::to_string(i) + ": " + errors[i]);
+}


### PR DESCRIPTION
It's possible that a TypeSystemClang instance is accessed by multiple threads. One possible scenario where this can happen is if multiple Target instances are created in one process, as they all share the same set of lldb_private::Module objects. Each Module has its own TypeSystemClang which is accessed directly via the Type API or the expression parser, and the lack of any locking currently causes various race conditions.

This patch attempts to make the API of TypeSystemClang thread-safe. The largest part of this patch is purely mechanical and adds locks to all TypeSystemClang member functions and some related functions. The actually used lock is the one from the Module, which is necessary as the TypeSystemClang and Module call each other via various indirections. If a TypeSystemClang doesn't belong to a Module object, it just uses its own mutex.

The more complex part is that we now have to delay Objective-C type information fetching so it can't happen while we hold a Module lock. This is necessary as fetching Objective-C runtime data can call a utility function, and the utility expression triggers various machinery in LLDB which then in turn deadlocks trying to aquire the same module lock. To work around this, we slightly delay fetching Objective-C data so it happens once we don't hold anymore Module locks. We pretend for for the duration of the delay that an Objective-C interface is always defined. This isn't very sound, but there isn't really a less invasive way to fix the deadlocks.

The test for this runs several expressions in parallel on the same target, and then exercises various parts of the SBType/SBValue API. Note that the test implicitly depends on variousrecently landed LLDB race condition fixes, and will randomly fail without them.

assisted-by: claude