### PR TITLE
[include-cleaner] Support ObjC @compatibility_alias in WalkAST

### DIFF
--- a/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
+++ b/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
@@ -441,7 +441,27 @@ public:
   // Objective-C support
 
   bool VisitObjCInterfaceTypeLoc(ObjCInterfaceTypeLoc TL) {
-    reportType(TL.getNameLoc(), TL.getIFaceDecl());
+    ObjCInterfaceDecl *IFace = TL.getIFaceDecl();
+    if (!IFace)
+      return true;
+
+    SourceLocation Loc = TL.getNameLoc();
+    ASTContext &Ctx = IFace->getASTContext();
+    StringRef SpelledName =
+        Lexer::getSourceText(CharSourceRange::getTokenRange(Loc),
+                             Ctx.getSourceManager(), Ctx.getLangOpts());
+    if (!SpelledName.empty() && SpelledName != IFace->getName()) {
+      // We may have a @compatibility_alias.
+      for (auto *D : Ctx.getTranslationUnitDecl()->decls()) {
+        if (auto *Alias = dyn_cast<ObjCCompatibleAliasDecl>(D)) {
+          if (Alias->getName() == SpelledName) {
+            report(Loc, Alias);
+            return true;
+          }
+        }
+      }
+    }
+    reportType(Loc, IFace);
     return true;
   }
 

--- a/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
@@ -1120,9 +1120,9 @@ TEST(WalkAST, ObjCCompatibleAliasDecl) {
 
 TEST(WalkAST, ObjCCompatibleAliasUsage) {
   testWalk(R"objc(
-    @interface $explicit^MyClass
+    @interface MyClass
     @end
-    @compatibility_alias AliasName MyClass;
+    $explicit^@compatibility_alias AliasName MyClass;
   )objc",
            R"objc(
     void test() {


### PR DESCRIPTION
When visiting an ObjCInterfaceTypeLoc, check if the spelled name matches a @compatibility_alias. If so, report the alias declaration instead of the underlying interface declaration. This ensures that include-cleaner attributes the usage to the header defining the alias.