### PR TITLE
[lld][test] Use LLVM helpers for input file discovery

### DIFF
--- a/lld/test/Unit/lit.cfg.py
+++ b/lld/test/Unit/lit.cfg.py
@@ -41,7 +41,3 @@ if sys.platform in ["win32", "cygwin"] and os.path.isdir(config.shlibdir):
 # Win32 may use %SYSTEMDRIVE% during file system shell operations, so propagate.
 if sys.platform == "win32" and "SYSTEMDRIVE" in os.environ:
     config.environment["SYSTEMDRIVE"] = os.environ["SYSTEMDRIVE"]
-
-# Expand the LLD source path so that unittests can use associated input files.
-# (see AsLibELF/ROCm.cpp test)
-config.environment["LLD_SRC_DIR"] = config.lld_src_dir

--- a/lld/unittests/AsLibELF/CMakeLists.txt
+++ b/lld/unittests/AsLibELF/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This test covers a more singular case where only one LLD driver is used in the
 # target application executable.
 
-add_lld_unittests(LLDAsLibELFTests
+add_unittest_with_input_files(LLDUnitTests LLDAsLibELFTests
   OutputStream.cpp
   ROCm.cpp
   SomeDrivers.cpp
@@ -12,4 +12,5 @@ target_link_libraries(LLDAsLibELFTests
   PRIVATE
   lldCommon
   lldELF
+  LLVMTestingSupport
 )

--- a/lld/unittests/AsLibELF/OutputStream.cpp
+++ b/lld/unittests/AsLibELF/OutputStream.cpp
@@ -12,16 +12,19 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Testing/Support/SupportHelpers.h"
 #include "gmock/gmock.h"
+
+extern const char *TestMainArgv0;
 
 LLD_HAS_DRIVER(elf)
 
 // With "-o -", the ELF driver writes the output image to the stdoutOS stream
 // passed to link(), so lld used as a library can capture it in a raw_ostream.
 TEST(AsLib, OutputToStream) {
-  llvm::SmallString<256> input(getenv("LLD_SRC_DIR"));
-  llvm::sys::path::append(input, "unittests", "AsLibELF", "Inputs",
-                          "kernel1.o");
+  llvm::SmallString<128> input =
+      llvm::unittest::getInputFileDirectory(TestMainArgv0);
+  llvm::sys::path::append(input, "kernel1.o");
   std::vector<const char *> args{"ld.lld", "-shared", input.c_str(), "-o", "-"};
 
   std::string buf;

--- a/lld/unittests/AsLibELF/ROCm.cpp
+++ b/lld/unittests/AsLibELF/ROCm.cpp
@@ -22,21 +22,10 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/FileUtilities.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Testing/Support/SupportHelpers.h"
 #include "gmock/gmock.h"
-#include <algorithm>
 
-static std::string expand(const char *path) {
-  if (!llvm::StringRef(path).contains("%"))
-    return std::string(path);
-
-  llvm::SmallString<256> thisPath;
-  thisPath.append(getenv("LLD_SRC_DIR"));
-  llvm::sys::path::append(thisPath, "unittests", "AsLibELF");
-
-  std::string expanded(path);
-  expanded.replace(expanded.find("%S"), 2, thisPath.data(), thisPath.size());
-  return expanded;
-}
+extern const char *TestMainArgv0;
 
 LLD_HAS_DRIVER(elf)
 
@@ -47,7 +36,7 @@ static bool lldInvoke(const char *inPath, const char *outPath) {
   return !s.retCode && s.canRunAgain;
 }
 
-static bool runLinker(const char *path) {
+static bool runLinker(llvm::StringRef input) {
   // Create a temp file for HSA code object.
   int tempHsacoFD = -1;
   llvm::SmallString<128> tempHsacoFilename;
@@ -57,18 +46,20 @@ static bool runLinker(const char *path) {
   }
   llvm::FileRemover cleanupHsaco(tempHsacoFilename);
   // Invoke lld. Expect a true return value from lld.
-  std::string expandedPath = expand(path);
-  if (!lldInvoke(expandedPath.data(), tempHsacoFilename.c_str())) {
-    llvm::errs() << "Failed to link: " << expandedPath << "\n";
+  llvm::SmallString<128> inputPath =
+      llvm::unittest::getInputFileDirectory(TestMainArgv0);
+  llvm::sys::path::append(inputPath, input);
+  if (!lldInvoke(inputPath.c_str(), tempHsacoFilename.c_str())) {
+    llvm::errs() << "Failed to link: " << inputPath << "\n";
     return false;
   }
   return true;
 }
 
 TEST(AsLib, ROCm) {
-  EXPECT_TRUE(runLinker("%S/Inputs/kernel1.o"));
-  EXPECT_TRUE(runLinker("%S/Inputs/kernel2.o"));
-  EXPECT_TRUE(runLinker("%S/Inputs/kernel1.o"));
-  EXPECT_TRUE(runLinker("%S/Inputs/kernel2.o"));
+  EXPECT_TRUE(runLinker("kernel1.o"));
+  EXPECT_TRUE(runLinker("kernel2.o"));
+  EXPECT_TRUE(runLinker("kernel1.o"));
+  EXPECT_TRUE(runLinker("kernel2.o"));
 }
 #endif


### PR DESCRIPTION
This was a suggestion on #220340 to avoid the custom env var handling
and use the `getInputFileDirectory` helper from the LLVM support library
