### PR TITLE
[BOLT] Preserve dynamic relocations for LSDA type tables

### DIFF
--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -582,6 +582,33 @@ private:
   /// addressing.
   LSDATypeTableTy LSDATypeAddressTable;
 
+public:
+  /// An LSDA type table entry whose value comes from a dynamic relocation
+  /// instead of being resolved at link time, e.g. a DW_EH_PE_absptr entry
+  /// naming a typeinfo from a shared library under -z notext. The entry reads
+  /// as zero in the input.
+  struct LSDATypeTableDynRelocTy {
+    Relocation Rel;
+    uint64_t InputAddress = 0;
+    /// One label per emitted copy of the type table.
+    SmallVector<MCSymbol *, 2> OutputLabels;
+  };
+
+  /// Keyed by the entry's index in LSDATypeTable.
+  using LSDATypeTableDynRelocsTy = std::map<unsigned, LSDATypeTableDynRelocTy>;
+
+  LSDATypeTableDynRelocsTy &getLSDATypeTableDynRelocs() {
+    return LSDATypeTableDynRelocs;
+  }
+
+  /// Return true if any LSDA type table entry comes from a dynamic relocation.
+  bool hasLSDATypeTableDynRelocs() const {
+    return !LSDATypeTableDynRelocs.empty();
+  }
+
+private:
+  LSDATypeTableDynRelocsTy LSDATypeTableDynRelocs;
+
   /// Marking for the beginnings of language-specific data areas for each
   /// fragment of the function.
   SmallVector<MCSymbol *, 0> LSDASymbols;

--- a/bolt/lib/Core/BinaryEmitter.cpp
+++ b/bolt/lib/Core/BinaryEmitter.cpp
@@ -1092,9 +1092,22 @@ void BinaryEmitter::emitLSDA(BinaryFunction &BF, const FunctionFragment &FF) {
     switch (TTypeEncoding & 0x70) {
     default:
       llvm_unreachable("unsupported TTypeEncoding");
-    case dwarf::DW_EH_PE_absptr:
+    case dwarf::DW_EH_PE_absptr: {
+      // Label entries backed by a dynamic relocation so it can be re-created
+      // once the output address is known. Temporary labels are not retained by
+      // the linker, so the symbol has to be named.
+      auto &DynRelocs = BF.getLSDATypeTableDynRelocs();
+      auto DynRelocIt = DynRelocs.find(Index);
+      if (DynRelocIt != DynRelocs.end()) {
+        MCSymbol *SlotLabel = BC.Ctx->getOrCreateSymbol(
+            "__bolt_lsda_tt_entry@" + BF.getOneName() + "/" +
+            Twine(FF.getFragmentNum().get()) + "/" + Twine(Index));
+        Streamer.emitLabel(SlotLabel);
+        DynRelocIt->second.OutputLabels.push_back(SlotLabel);
+      }
       Streamer.emitIntValue(TypeAddress, TTypeEncodingSize);
       break;
+    }
     case dwarf::DW_EH_PE_pcrel: {
       if (TypeAddress) {
         const MCSymbol *TypeSymbol =

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -4540,6 +4540,51 @@ void BinaryFunction::updateOutputValues(const BOLTLinker &Linker) {
   setOutputAddress(SymbolInfo->Address);
   setOutputSize(SymbolInfo->Size);
 
+  // Move the dynamic relocations that supplied LSDA type table entries onto
+  // the re-emitted table. Otherwise the loader keeps patching the original
+  // copy, which is no longer read, and a zero entry means catch-all to the
+  // personality routine.
+  //
+  // The emitted section has no input address, so match it on the output range.
+  auto findOutputSection = [&](uint64_t Address) -> BinarySection * {
+    for (BinarySection &Section : BC.sections()) {
+      const uint64_t Start = Section.getOutputAddress();
+      if (Start && Address >= Start &&
+          Address < Start + Section.getOutputSize())
+        return &Section;
+    }
+    return nullptr;
+  };
+
+  for (auto &KV : getLSDATypeTableDynRelocs()) {
+    LSDATypeTableDynRelocTy &DynReloc = KV.second;
+    if (DynReloc.OutputLabels.empty())
+      continue;
+
+    // The relocation is moved, not copied: .rela.dyn is rewritten in place and
+    // cannot grow. SplitFunctions keeps the EH ranges of such a function in a
+    // single fragment so that only one copy of the table is emitted.
+    assert(DynReloc.OutputLabels.size() == 1 &&
+           "LSDA type table emitted more than once");
+
+    ErrorOr<BinarySection &> InputSection =
+        BC.getSectionForAddress(DynReloc.InputAddress);
+    assert(InputSection && "Cannot find input LSDA section");
+    std::optional<Relocation> Moved = InputSection->takeDynamicRelocationAt(
+        DynReloc.InputAddress - InputSection->getAddress());
+    assert(Moved && "Cannot find LSDA type table dynamic relocation");
+
+    for (MCSymbol *SlotLabel : DynReloc.OutputLabels) {
+      const auto SlotInfo = Linker.lookupSymbolInfo(SlotLabel->getName());
+      assert(SlotInfo && "Cannot find LSDA type table entry symbol");
+      BinarySection *OutputSection = findOutputSection(SlotInfo->Address);
+      assert(OutputSection && "Cannot find emitted LSDA section");
+      OutputSection->addDynamicRelocation(
+          SlotInfo->Address - OutputSection->getOutputAddress(), Moved->Symbol,
+          Moved->Type, Moved->Addend, Moved->Value);
+    }
+  }
+
   if (BC.HasRelocations || isInjected()) {
     if (hasConstantIsland()) {
       const auto IslandLabelSymInfo =

--- a/bolt/lib/Core/Exceptions.cpp
+++ b/bolt/lib/Core/Exceptions.cpp
@@ -339,6 +339,12 @@ Error BinaryFunction::parseLSDA(ArrayRef<uint8_t> LSDASectionData,
     for (unsigned Index = 1; Index <= MaxTypeIndex; ++Index) {
       uint64_t TTEntry = TypeTableStart - Index * TTypeEncodingSize;
       const uint64_t TTEntryAddress = TTEntry + LSDASectionAddress;
+
+      // An entry supplied by a dynamic relocation reads as zero here. Record
+      // it so the relocation can be re-created against the re-emitted table.
+      if (const Relocation *Rel = BC.getDynamicRelocationAt(TTEntryAddress))
+        LSDATypeTableDynRelocs[Index - 1] = {*Rel, TTEntryAddress, {}};
+
       uint64_t TypeAddress =
           *Data.getEncodedPointer(&TTEntry, TTypeEncoding, TTEntryAddress);
       if ((TTypeEncoding & DW_EH_PE_pcrel) && (TypeAddress == TTEntryAddress))

--- a/bolt/lib/Passes/SplitFunctions.cpp
+++ b/bolt/lib/Passes/SplitFunctions.cpp
@@ -703,6 +703,14 @@ struct SplitAll final : public SplitStrategy {
 namespace llvm {
 namespace bolt {
 
+/// Whether the EH ranges of \p BF may span fragments. A function whose LSDA
+/// type table comes from dynamic relocations has to keep its EH call sites in
+/// one fragment: every fragment emits a copy of the table, and .rela.dyn
+/// cannot grow to hold a relocation per copy.
+static bool canSplitEHFor(const BinaryFunction &BF) {
+  return opts::SplitEH && !BF.hasLSDATypeTableDynRelocs();
+}
+
 bool SplitFunctions::shouldOptimize(const BinaryFunction &BF) const {
   // Apply execution count threshold
   if (BF.getKnownExecutionCount() < opts::ExecutionCountThreshold)
@@ -818,7 +826,7 @@ void SplitFunctions::splitFunction(BinaryFunction &BF, SplitStrategy &S) {
       continue;
     }
 
-    if (BF.hasEHRanges() && !opts::SplitEH) {
+    if (BF.hasEHRanges() && !canSplitEHFor(BF)) {
       // We cannot move landing pads (or rather entry points for landing pads).
       if (BB->isLandingPad()) {
         BB->setCanOutline(false);
@@ -861,7 +869,7 @@ void SplitFunctions::splitFunction(BinaryFunction &BF, SplitStrategy &S) {
                                      const BinaryBasicBlock *const B) {
       return A->getFragmentNum() < B->getFragmentNum();
     });
-  } else if (BF.hasEHRanges() && !opts::SplitEH) {
+  } else if (BF.hasEHRanges() && !canSplitEHFor(BF)) {
     // Typically functions with exception handling have landing pads at the end.
     // We cannot move beginning of landing pads, but we can move 0-count blocks
     // comprising landing pads to the end and thus facilitate splitting.

--- a/bolt/test/runtime/X86/exceptions-absptr-ttype-dynrelocs.cpp
+++ b/bolt/test/runtime/X86/exceptions-absptr-ttype-dynrelocs.cpp
@@ -1,0 +1,69 @@
+// RUN: %clangxx %cflags -O1 -fno-pic -flto -fuse-ld=lld -Wl,-q -Wl,-z,notext \
+// RUN:   -Wl,-plugin-opt=-large-eh-encoding %s -o %t.exe
+// RUN: %t.exe
+// RUN: llvm-bolt %t.exe -o %t.bolt --reorder-blocks=ext-tsp
+// RUN: %t.bolt
+
+/// Splitting must not spread the EH ranges of such a function over several
+/// fragments: each fragment emits its own copy of the type table and would
+/// need its own relocations, which .rela.dyn has no room for.
+// RUN: llvm-bolt %t.exe -o %t.split.bolt --reorder-blocks=ext-tsp \
+// RUN:   --split-functions --split-strategy=all --split-eh
+// RUN: %t.split.bolt
+
+// REQUIRES: system-linux
+
+/// Check that BOLT preserves dynamic relocations covering the LSDA type table.
+///
+/// With DW_EH_PE_absptr TType encoding (selected for non-PIC x86-64 under the
+/// large code model, which -large-eh-encoding also opts into), each type table
+/// entry is an 8-byte absolute address. When the referenced typeinfo cannot be
+/// resolved at static link time -- here because -z notext lets the linker place
+/// R_X86_64_64 dynamic relocations in the read-only .gcc_except_table rather
+/// than resolving them -- the entry is left as zero in the file and filled in
+/// by the dynamic loader at startup.
+///
+/// BOLT re-emits .gcc_except_table but copies those entries as plain integers,
+/// so the relocations are not carried over to the new section. The loader then
+/// populates the original copy, which nothing reads, while the live table stays
+/// zero. __gxx_personality_v0 treats a null type table entry as a catch-all, so
+/// the *first* catch clause silently swallows every exception.
+///
+/// Before this is fixed the BOLT-processed binary exits non-zero because
+/// classify() reports "bad_alloc" for a std::invalid_argument.
+
+#include <cstdio>
+#include <cstring>
+#include <new>
+#include <stdexcept>
+
+__attribute__((noinline)) void thrower() {
+  throw std::invalid_argument("payload");
+}
+
+/// bad_alloc is deliberately the first clause: if its type table entry reads as
+/// null it becomes a catch-all and captures the invalid_argument below it.
+__attribute__((noinline)) const char *classify() {
+  try {
+    throw;
+  } catch (const std::bad_alloc &) {
+    return "bad_alloc";
+  } catch (const std::bad_cast &) {
+    return "bad_cast";
+  } catch (const std::invalid_argument &) {
+    return "invalid_argument";
+  } catch (...) {
+    return "other";
+  }
+}
+
+int main() {
+  try {
+    thrower();
+  } catch (...) {
+    const char *Result = classify();
+    std::printf("caught as: %s\n", Result);
+    return std::strcmp(Result, "invalid_argument") == 0 ? 0 : 1;
+  }
+  return 2;
+}


### PR DESCRIPTION
## Motivation
An LSDA type table entry can be supplied by a dynamic relocation instead of being resolved at static link time, for example a `DW_EH_PE_absptr` entry naming a typeinfo from a shared library, in a binary linked with `-z notext`.  Such an entry is zero in the file and filled in by the loader at startup.

## Bug
BOLT re-emitted `.gcc_except_table `with those entries as plain integers and left the relocations pointing at the original section. At run time the loader then populated `.bolt.org.gcc_except_table`, which nothing reads, while the live table stayed zero. Unfortunately, `__gxx_personality_v0` treats a null type table entry as a catch-all, so the first catch clause of the function silently swallows every exception.

We saw this at Meta when applying `-mlarge-eh-encoding` to our binaries which were also BOLT-ified

## Change

Record such relocations while parsing the LSDA, label the corresponding entries of the re-emitted table, and move the relocations onto them once the output addresses are known.

The relocations are moved rather than added, because `.rela.dyn` is rewritten in place and cannot grow. To keep that one-to-one, a function whose type table is populated by dynamic relocations also keeps its EH ranges in a single fragment: splitting emits one copy of the type table per fragment, and each copy would need its own relocations. This reuses the mechanism already used for -split-eh.

Fixes https://github.com/llvm/llvm-project/issues/220298

Assisted-By: Codex

Please also see: https://github.com/llvm/llvm-project/pull/220378