### PR TITLE
[SandboxVec][Scheduler][NFC] Rename ScheduleTopItOpt to ScheduleFrontier

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
@@ -314,7 +314,7 @@ class Scheduler {
   /// top-most/bottom-most instruction scheduled. It may get updated after every
   /// trySchedule() attempt, regardless of whether scheduling succeeded or not.
   /// It is nullopt if we have not scheduled before.
-  std::optional<SchedulingPoint> ScheduleTopItOpt;
+  std::optional<SchedulingPoint> ScheduleFrontierOpt;
   // TODO: This is wasting memory in exchange for fast removal using a raw ptr.
   DenseMap<SchedBundle *, std::unique_ptr<SchedBundle>> Bndls;
   /// The BB that we are currently scheduling.
@@ -387,10 +387,10 @@ public:
     // TODO: clear view once it lands.
     DAG.clear();
     ReadyList.clear();
-    ScheduleTopItOpt = std::nullopt;
+    ScheduleFrontierOpt = std::nullopt;
     ScheduledBB = nullptr;
     assert(Bndls.empty() && DAG.empty() && ReadyList.empty() &&
-           !ScheduleTopItOpt && ScheduledBB == nullptr &&
+           !ScheduleFrontierOpt && ScheduledBB == nullptr &&
            "Expected empty state!");
   }
 

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
@@ -82,16 +82,16 @@ void SchedulingPoint::dump() const {
 
 void Scheduler::scheduleAndUpdateReadyList(SchedBundle &Bndl) {
   // Find where we should schedule the instructions.
-  assert(ScheduleTopItOpt && "Should have been set by now!");
+  assert(ScheduleFrontierOpt && "Should have been set by now!");
   auto Where = Dir == SchedDirection::BottomUp
-                   ? ScheduleTopItOpt->getIterator()
-                   : ScheduleTopItOpt->getNext().getIterator();
+                   ? ScheduleFrontierOpt->getIterator()
+                   : ScheduleFrontierOpt->getNext().getIterator();
   // Move all instructions in `Bndl` to `Where`.
   Bndl.cluster(Where);
   // Update the last scheduled bundle.
-  ScheduleTopItOpt = Dir == SchedDirection::BottomUp
-                         ? Bndl.getTop()->getInstruction()->getIterator()
-                         : Bndl.getBot()->getInstruction()->getIterator();
+  ScheduleFrontierOpt = Dir == SchedDirection::BottomUp
+                            ? Bndl.getTop()->getInstruction()->getIterator()
+                            : Bndl.getBot()->getInstruction()->getIterator();
   // Set nodes as "scheduled" and decrement the UnscheduledSuccs/Preds counter
   // of all dependency predecessors/successors.
   for (DGNode *N : Bndl) {
@@ -126,12 +126,13 @@ void Scheduler::notifyCreateInstr(Instruction *I) {
     return;
   // If the instruction is inserted below the top-of-schedule then we mark it as
   // "scheduled".
-  bool IsScheduled = ScheduleTopItOpt &&
-                     ScheduleTopItOpt->getIterator() != I->getParent()->end() &&
-                     ((Dir == SchedDirection::BottomUp &&
-                       (*ScheduleTopItOpt.value()).comesBefore(I)) ||
-                      (Dir == SchedDirection::TopDown &&
-                       I->comesBefore(&*ScheduleTopItOpt.value())));
+  bool IsScheduled =
+      ScheduleFrontierOpt &&
+      ScheduleFrontierOpt->getIterator() != I->getParent()->end() &&
+      ((Dir == SchedDirection::BottomUp &&
+        (*ScheduleFrontierOpt.value()).comesBefore(I)) ||
+       (Dir == SchedDirection::TopDown &&
+        I->comesBefore(&*ScheduleFrontierOpt.value())));
   if (IsScheduled)
     N->setScheduled();
   // If the new instruction is above the top of schedule we need to remove its
@@ -295,11 +296,11 @@ void Scheduler::trimSchedule(ArrayRef<Instruction *> Instrs) {
   // Note: this figure assumes bottom-up scheduling. In top-down we have the
   // top-down mirror image.
   Instruction *TopI = Dir == SchedDirection::BottomUp
-                          ? &*ScheduleTopItOpt.value()
+                          ? &*ScheduleFrontierOpt.value()
                           : VecUtils::getHighest(Instrs);
   Instruction *LowestI = Dir == SchedDirection::BottomUp
                              ? VecUtils::getLowest(Instrs)
-                             : &*ScheduleTopItOpt.value();
+                             : &*ScheduleFrontierOpt.value();
   Interval<Instruction> ResetIntvl(TopI, LowestI);
   // The DAG Nodes contain state like the number of UnscheduledSuccs and the
   // Scheduled flag. We need to reset their state. We need to do this for all
@@ -354,14 +355,14 @@ void Scheduler::assertSameDirection(ArrayRef<Instruction *> Instrs) const {
   case SchedDirection::BottomUp:
     assert(none_of(Instrs,
                    [this](Instruction *I) {
-                     return ScheduleTopItOpt->comesBefore(*I);
+                     return ScheduleFrontierOpt->comesBefore(*I);
                    }) &&
            "Wrong scheduling direction!");
     break;
   case SchedDirection::TopDown:
     assert(all_of(Instrs,
                   [this](Instruction *I) {
-                    return ScheduleTopItOpt->comesBefore(*I);
+                    return ScheduleFrontierOpt->comesBefore(*I);
                   }) &&
            "Wrong scheduling direction!");
     break;
@@ -416,13 +417,13 @@ bool Scheduler::trySchedule(ArrayRef<Instruction *> Instrs) {
     // re-schedule.
     DAG.extend(Instrs);
     trimSchedule(Instrs);
-    ScheduleTopItOpt = GetSchedPoint(Dir, Instrs);
+    ScheduleFrontierOpt = GetSchedPoint(Dir, Instrs);
     return tryScheduleUntil(Instrs);
   case BndlSchedState::NoneScheduled: {
     // TODO: Set the window of the DAG that we are interested in.
-    if (!ScheduleTopItOpt) {
+    if (!ScheduleFrontierOpt) {
       // We start scheduling at the bottom instr of Instrs (top in TopDown).
-      ScheduleTopItOpt = GetSchedPoint(Dir, Instrs);
+      ScheduleFrontierOpt = GetSchedPoint(Dir, Instrs);
     } else {
 #ifndef NDEBUG
       assertSameDirection(Instrs);
@@ -455,8 +456,8 @@ void Scheduler::dump(raw_ostream &OS) const {
   OS << "Dir=" << schedDirectionToStr(Dir) << " "
      << (Dir == SchedDirection::BottomUp ? "Top" : "Bottom")
      << " of schedule: ";
-  if (ScheduleTopItOpt)
-    OS << **ScheduleTopItOpt;
+  if (ScheduleFrontierOpt)
+    OS << **ScheduleFrontierOpt;
   else
     OS << "Empty";
   OS << "\n";


### PR DESCRIPTION
We now have an actual class `SchedulingPoint` for pointing to the top of schedule, so it is no longer an iteraterator as `ScheduleTopItOpt` would imply. We also support both bottom-up and top-down directions so "Top" is no longer a good name.

This patch renames ScheduleTopItOpt to ScheduleFrontier.