### PR TITLE
[lit] Apply --filter-out to GoogleTest shard results

### DIFF
--- a/llvm/utils/lit/lit/formats/googletest.py
+++ b/llvm/utils/lit/lit/formats/googletest.py
@@ -282,7 +282,7 @@ class GoogleTest(TestFormat):
         return cmd
 
     @staticmethod
-    def post_process_shard_results(selected_tests, discovered_tests):
+    def post_process_shard_results(selected_tests, discovered_tests, opts=None):
         def remove_gtest(tests):
             return [t for t in tests if t.gtest_json_file is None]
 
@@ -299,6 +299,7 @@ class GoogleTest(TestFormat):
             start_time = test.result.start or 0.0
 
             has_failure_in_shard = False
+            has_filtered_out_failure = False
 
             # Load json file to retrieve results.
             with open(test.gtest_json_file, encoding="utf-8") as f:
@@ -324,6 +325,20 @@ class GoogleTest(TestFormat):
                         subtest = lit.Test.Test(
                             test.suite, testPath, test.config, test.file_path
                         )
+
+                        # A gtest shard is a single lit test, so --filter-out
+                        # cannot select individual gtest cases at discovery
+                        # time. Apply it here, where the real names are known.
+                        if opts and opts.filter_out.search(subtest.getFullName()):
+                            if "failures" in testinfo:
+                                has_filtered_out_failure = True
+                            res = lit.Test.Result(lit.Test.EXCLUDED, "", 0.0)
+                            res.pid = test.result.pid or 0
+                            res.start = start_time
+                            subtest.setResult(res)
+                            selected_tests.append(subtest)
+                            discovered_tests.append(subtest)
+                            continue
 
                         testname = testcase["name"] + "." + testinfo["name"]
                         header = f"Script:\n--\n%s --gtest_filter=%s\n--\n" % (
@@ -361,7 +376,11 @@ class GoogleTest(TestFormat):
                         discovered_tests.append(subtest)
             os.remove(test.gtest_json_file)
 
-            if not has_failure_in_shard and test.isFailure():
+            if (
+                not has_failure_in_shard
+                and not has_filtered_out_failure
+                and test.isFailure()
+            ):
                 selected_tests.append(test)
                 discovered_tests.append(test)
 

--- a/llvm/utils/lit/lit/formats/googletest.py
+++ b/llvm/utils/lit/lit/formats/googletest.py
@@ -282,7 +282,7 @@ class GoogleTest(TestFormat):
         return cmd
 
     @staticmethod
-    def post_process_shard_results(selected_tests, discovered_tests, opts=None):
+    def post_process_shard_results(selected_tests, discovered_tests, opts):
         def remove_gtest(tests):
             return [t for t in tests if t.gtest_json_file is None]
 
@@ -299,7 +299,6 @@ class GoogleTest(TestFormat):
             start_time = test.result.start or 0.0
 
             has_failure_in_shard = False
-            has_filtered_out_failure = False
 
             # Load json file to retrieve results.
             with open(test.gtest_json_file, encoding="utf-8") as f:
@@ -326,20 +325,6 @@ class GoogleTest(TestFormat):
                             test.suite, testPath, test.config, test.file_path
                         )
 
-                        # A gtest shard is a single lit test, so --filter-out
-                        # cannot select individual gtest cases at discovery
-                        # time. Apply it here, where the real names are known.
-                        if opts and opts.filter_out.search(subtest.getFullName()):
-                            if "failures" in testinfo:
-                                has_filtered_out_failure = True
-                            res = lit.Test.Result(lit.Test.EXCLUDED, "", 0.0)
-                            res.pid = test.result.pid or 0
-                            res.start = start_time
-                            subtest.setResult(res)
-                            selected_tests.append(subtest)
-                            discovered_tests.append(subtest)
-                            continue
-
                         testname = testcase["name"] + "." + testinfo["name"]
                         header = f"Script:\n--\n%s --gtest_filter=%s\n--\n" % (
                             test.file_path,
@@ -347,10 +332,20 @@ class GoogleTest(TestFormat):
                         )
 
                         output = ""
-                        if testinfo["result"] == "SKIPPED":
+                        if "failures" in testinfo:
+                            # Remember that this shard's non-zero exit code is
+                            # accounted for by a test we know about, even if
+                            # that test ends up excluded just below.
+                            has_failure_in_shard = True
+
+                        # A gtest shard is a single lit test, so --filter-out
+                        # cannot select individual gtest cases at discovery
+                        # time. Apply it here, where the real names are known.
+                        if opts.filter_out.search(subtest.getFullName()):
+                            returnCode = lit.Test.EXCLUDED
+                        elif testinfo["result"] == "SKIPPED":
                             returnCode = lit.Test.SKIPPED
                         elif "failures" in testinfo:
-                            has_failure_in_shard = True
                             returnCode = (
                                 lit.Test.XFAIL
                                 if test.isExpectedToFail()
@@ -376,11 +371,7 @@ class GoogleTest(TestFormat):
                         discovered_tests.append(subtest)
             os.remove(test.gtest_json_file)
 
-            if (
-                not has_failure_in_shard
-                and not has_filtered_out_failure
-                and test.isFailure()
-            ):
+            if not has_failure_in_shard and test.isFailure():
                 selected_tests.append(test)
                 discovered_tests.append(test)
 

--- a/llvm/utils/lit/lit/main.py
+++ b/llvm/utils/lit/lit/main.py
@@ -124,7 +124,7 @@ def main(builtin_params={}):
         record_test_times(selected_tests, lit_config)
 
     selected_tests, discovered_tests = GoogleTest.post_process_shard_results(
-        selected_tests, discovered_tests
+        selected_tests, discovered_tests, opts
     )
 
     if opts.time_tests:

--- a/llvm/utils/lit/tests/googletest-filter-out.py
+++ b/llvm/utils/lit/tests/googletest-filter-out.py
@@ -1,0 +1,13 @@
+# Check that --filter-out applies to tests expanded from a GoogleTest shard.
+# Filtering the failing and unresolved tests should leave a successful run.
+
+# RUN: %{lit} --filter-out 'FirstTest/(subTestB|subTestD)' %{inputs}/googletest-format > %t.out
+# RUN: FileCheck < %t.out %s
+
+# CHECK-NOT: Failed Tests
+# CHECK-NOT: Unresolved Tests
+# CHECK: Total Discovered Tests: 6
+# CHECK-NEXT: {{ *}}Excluded: 2
+# CHECK-NEXT: {{ *}}Skipped : 1
+# CHECK-NEXT: {{ *}}Passed  : 3
+# CHECK-NOT: {{Failed|Unresolved}}

--- a/llvm/utils/lit/tests/googletest-filter-out.py
+++ b/llvm/utils/lit/tests/googletest-filter-out.py
@@ -1,8 +1,7 @@
 # Check that --filter-out applies to tests expanded from a GoogleTest shard.
 # Filtering the failing and unresolved tests should leave a successful run.
 
-# RUN: %{lit} --filter-out 'FirstTest/(subTestB|subTestD)' %{inputs}/googletest-format > %t.out
-# RUN: FileCheck < %t.out %s
+# RUN: %{lit} --filter-out 'FirstTest/(subTestB|subTestD)' %{inputs}/googletest-format | FileCheck %s
 
 # CHECK-NOT: Failed Tests
 # CHECK-NOT: Unresolved Tests


### PR DESCRIPTION
I was a bit optimistic in https://github.com/llvm/llvm-project/pull/219859, the tests passed locally intially, but then didn't. Turns out, `LIT_FILTER_OUT` didn't apply to individual unit tests (GoogleTest) before this PR.

I initially tried to use the `--gtest_filter=POSITIVE_PATTERNS[-NEGATIVE_PATTERNS]` flag for filtering out tests, but it was a bit of a mess. It is easier to just filter out after the test has run, when the individual test names are available. Also mark matching tests as excluded and avoid reporting the parent shard as failed when only filtered tests fail.

Assisted by Claude Opus 5.