### PR TITLE
workflows/release-binaries: Improve Windows installer

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -503,6 +503,12 @@ if(WIN32 AND NOT UNIX)
     # cabinet itself, and CAB supports only MSZIP/LZX/Quantum, so an MSI cannot
     # use LZMA the way the NSIS generator does.
     set(CPACK_WIX_LIGHT_EXTRA_FLAGS "-sval" "-dcl:high")
+    # Make the LLVM installation available for all users.
+    set(CPACK_WIX_INSTALL_SCOPE "perMachine")
+    # Identifies the LLVM product line accross all versions. Must not be changed.
+    # Ensures previous installations are uninstalled and do not live side by
+    # side.
+    set(CPACK_WIX_UPGRADE_GUID "B08613CD-8BD0-4FB6-8937-621936604DE3")
   endif()
 endif()
 include(CPack)

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -503,8 +503,15 @@ if(WIN32 AND NOT UNIX)
     # cabinet itself, and CAB supports only MSZIP/LZX/Quantum, so an MSI cannot
     # use LZMA the way the NSIS generator does.
     set(CPACK_WIX_LIGHT_EXTRA_FLAGS "-sval" "-dcl:high")
-    # Make the LLVM installation available for all users.
-    set(CPACK_WIX_INSTALL_SCOPE "perMachine")
+    # Make the LLVM installation available for all users.  CPack only gained
+    # CPACK_WIX_INSTALL_SCOPE in CMake 3.29, so inject the equivalent ALLUSERS
+    # property when packaging with an older CMake supported by LLVM.
+    if(CMAKE_VERSION VERSION_LESS "3.29")
+      list(APPEND CPACK_WIX_PATCH_FILE
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/WiXPerMachinePatch.xml")
+    else()
+      set(CPACK_WIX_INSTALL_SCOPE "perMachine")
+    endif()
     # Identifies the LLVM product line accross all versions. Must not be changed.
     # Ensures previous installations are uninstalled and do not live side by
     # side.

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -513,9 +513,10 @@ if(WIN32 AND NOT UNIX)
     else()
       set(CPACK_WIX_INSTALL_SCOPE "perMachine")
     endif()
-    # Identifies the LLVM product line accross all versions. Must not be changed.
-    # Ensures previous installations are uninstalled and do not live side by
-    # side.
+    # Permanent WiX UpgradeCode for official LLVM MSI packages. Windows Installer
+    # uses this value to recognize related releases and remove an older LLVM
+    # installation during an upgrade. It must remain identical across all future
+    # releases and release branches. DO NOT regenerate or change this GUID.
     set(CPACK_WIX_UPGRADE_GUID "B08613CD-8BD0-4FB6-8937-621936604DE3")
   endif()
 endif()

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -506,6 +506,7 @@ if(WIN32 AND NOT UNIX)
     # Make the LLVM installation available for all users.  CPack only gained
     # CPACK_WIX_INSTALL_SCOPE in CMake 3.29, so inject the equivalent ALLUSERS
     # property when packaging with an older CMake supported by LLVM.
+    # TODO: remove after transition to CMake 3.31.
     if(CMAKE_VERSION VERSION_LESS "3.29")
       list(APPEND CPACK_WIX_PATCH_FILE
         "${CMAKE_CURRENT_SOURCE_DIR}/cmake/WiXPerMachinePatch.xml")

--- a/llvm/cmake/WiXPerMachinePatch.xml
+++ b/llvm/cmake/WiXPerMachinePatch.xml
@@ -1,0 +1,5 @@
+<CPackWiXPatch>
+  <CPackWiXFragment Id="#PRODUCT">
+    <Property Id="ALLUSERS" Value="1"/>
+  </CPackWiXFragment>
+</CPackWiXPatch>

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -150,6 +150,12 @@ Makes programs 10x faster by doing Special New Thing.
   `LLVM_ALL_EXPERIMENTAL_TARGETS` to `LLVM_ALL_TARGETS`. It is now built by
   default and no longer requires `LLVM_EXPERIMENTAL_TARGETS_TO_BUILD`.
 
+### Changes to the Windows installer
+
+* The project has migrated to MSI installers. Previous installations of LLVM,
+  prior (and including) 23.1.0, must be manually uninstalled first, before
+  installing this new release.
+
 ### Changes to TableGen
 
 * `!cond` operator short-circuits at the first `true` condition.  Subsequent
@@ -226,10 +232,6 @@ Makes programs 10x faster by doing Special New Thing.
   the WebAssembly `memory.copy` and `memory.fill` instructions.
 
 ### Changes to the Windows Target
-
-* The project has migrated to MSI installers. Previous installations of LLVM,
-  prior (and including) 23.1.0, must be manually uninstalled first, before
-  installing this new release.
 
 ### Changes to the X86 Backend
 

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -227,6 +227,10 @@ Makes programs 10x faster by doing Special New Thing.
 
 ### Changes to the Windows Target
 
+* The project has migrated to MSI installers. Previous installations of LLVM,
+  prior (and including) 23.1.0, must be manually uninstalled first, before
+  installing this new release.
+
 ### Changes to the X86 Backend
 
 ### Changes to the OCaml bindings

--- a/llvm/utils/release/build_llvm_release.bat
+++ b/llvm/utils/release/build_llvm_release.bat
@@ -284,6 +284,7 @@ ninja check-lld || exit /b 1
 REM ninja check-runtimes || exit /b 1
 REM ninja check-clang-tools || exit /b 1
 ninja package || exit /b 1
+call :verify_msi_upgrade_code || exit /b 1
 cd ..
 
 exit /b 0
@@ -377,6 +378,7 @@ REM ninja check-flang || exit /b 1
 REM ninja check-mlir || exit /b 1
 REM ninja check-lldb || exit /b 1
 ninja package || exit /b 1
+call :verify_msi_upgrade_code || exit /b 1
 
 :: generate tarball with install toolchain only off
 if "%arch%"=="amd64" (
@@ -415,6 +417,42 @@ set PATH=%PYTHONHOME%;%PATH%
 
 set "VSCMD_START_DIR=%build_dir%"
 
+exit /b 0
+
+::=============================================================================
+
+::==============================================================================
+:: Verify that the generated MSI has LLVM's permanent UpgradeCode.
+::==============================================================================
+:verify_msi_upgrade_code
+set "expected_upgrade_code=B08613CD-8BD0-4FB6-8937-621936604DE3"
+set "msi_path="
+for %%f in (*.msi) do (
+  if defined msi_path (
+    echo Found more than one MSI in %cd%; cannot determine which one to verify.
+    exit /b 1
+  )
+  set "msi_path=%%~ff"
+)
+if not defined msi_path (
+  echo No MSI found in %cd%.
+  exit /b 1
+)
+
+set "wix_source=%TEMP%\llvm-msi-%RANDOM%.wxs"
+dark.exe -nologo -o "%wix_source%" "%msi_path%"
+if errorlevel 1 (
+  echo Failed to decompile "%msi_path%".
+  exit /b 1
+)
+findstr /i /c:"%expected_upgrade_code%" "%wix_source%" >nul
+if errorlevel 1 (
+  echo "%msi_path%" does not have the expected UpgradeCode %expected_upgrade_code%.
+  del /q "%wix_source%"
+  exit /b 1
+)
+del /q "%wix_source%"
+echo Verified MSI UpgradeCode: %expected_upgrade_code%
 exit /b 0
 
 ::=============================================================================

--- a/llvm/utils/release/build_llvm_release.bat
+++ b/llvm/utils/release/build_llvm_release.bat
@@ -425,6 +425,7 @@ exit /b 0
 :: Verify that the generated MSI has LLVM's permanent UpgradeCode.
 ::==============================================================================
 :verify_msi_upgrade_code
+:: This code has to match the value in llvm/CMakeLists.txt
 set "expected_upgrade_code=B08613CD-8BD0-4FB6-8937-621936604DE3"
 set "msi_path="
 for %%f in (*.msi) do (
@@ -439,19 +440,28 @@ if not defined msi_path (
   exit /b 1
 )
 
-set "wix_source=%TEMP%\llvm-msi-%RANDOM%.wxs"
-dark.exe -nologo -o "%wix_source%" "%msi_path%"
-if errorlevel 1 (
-  echo Failed to decompile "%msi_path%".
+:: Query the MSI's UpgradeCode through the Windows Installer COM API. WiX's
+:: dark.exe would do this too, but it is deprecated and removed in newer WiX.
+set "msi_query=SELECT Value FROM Property WHERE Property='UpgradeCode'"
+set "ps_cmd=$i = New-Object -ComObject WindowsInstaller.Installer;"
+set "ps_cmd=%ps_cmd% $db = $i.OpenDatabase($env:msi_path, 0);"
+set "ps_cmd=%ps_cmd% $v = $db.OpenView($env:msi_query);"
+set "ps_cmd=%ps_cmd% $v.Execute();"
+set "ps_cmd=%ps_cmd% $v.Fetch().StringData(1).Trim('{', '}')"
+
+set "actual_upgrade_code="
+for /f %%i in ('powershell -NoProfile -Command "%ps_cmd%"') do (
+  set "actual_upgrade_code=%%i"
+)
+if not defined actual_upgrade_code (
+  echo Failed to read the UpgradeCode from "%msi_path%".
   exit /b 1
 )
-findstr /i /c:"%expected_upgrade_code%" "%wix_source%" >nul
-if errorlevel 1 (
-  echo "%msi_path%" does not have the expected UpgradeCode %expected_upgrade_code%.
-  del /q "%wix_source%"
+if /i not "%actual_upgrade_code%"=="%expected_upgrade_code%" (
+  echo Unexpected UpgradeCode %actual_upgrade_code% in "%msi_path%".
+  echo Expected %expected_upgrade_code%.
   exit /b 1
 )
-del /q "%wix_source%"
 echo Verified MSI UpgradeCode: %expected_upgrade_code%
 exit /b 0
 


### PR DESCRIPTION
The Windows WiX installer was missing two things for its setup:
1. The "product ID" which is used to uninstall any previous installed LLVM versions. This avoids having versions living side-by-side with each new release. I've reused the same GUID as the current 23.1.0 Win64 installer, to continue that "line" of product. The AArch64 installation and any prior LLVM version (NSIS) before 23.1.0 will need to be uninstalled manually, if we want to avoid side-by-side installatin.
2. A "per machine" scope which avoids messy installations which are installed globally, but cannot be uninstalled globally, and available only for the current user. After this PR, the installation is available / uninstallable to all users on the machine.

Since LLVM currently requires cmake 3.20 for building, and hasn't been bumped yet to 3.31, also provide a workaround for the WiX scope setup.

Added a release note to signify that users would need to uninstall the previous versions manually.

Assisted by Claude Opus 5.