### PR TITLE
[nfc][acc] Make two loop utilities non-static and add tests

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCUtilsLoop.h
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCUtilsLoop.h
@@ -76,6 +76,17 @@ scf::ExecuteRegionOp
 convertUnstructuredACCLoopToSCFExecuteRegion(LoopOp loopOp,
                                              RewriterBase &rewriter);
 
+/// Calculate trip count for a loop: (ub - lb + step) / step.
+/// If \p inclusiveUpperbound is false, subtracts 1 from \p ub first.
+/// Operands are cast to index type.
+Value calculateTripCount(OpBuilder &b, Location loc, Value lb, Value ub,
+                         Value step, bool inclusiveUpperbound);
+
+/// Normalize IV uses after converting to normalized loop form (lb=0, step=1).
+/// Replaces uses of \p iv with `iv * origStep + origLB`.
+void normalizeIVUses(OpBuilder &b, Location loc, Value iv, Value origLB,
+                     Value origStep);
+
 /// Record on a collapsed loop how many original loops were folded into it.
 void setCollapseCountAttr(Operation *op, uint64_t count);
 

--- a/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsLoop.cpp
+++ b/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsLoop.cpp
@@ -20,16 +20,15 @@
 #include "mlir/Dialect/SCF/Utils/Utils.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Transforms/RegionUtils.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Support/ErrorHandling.h"
 
 using namespace mlir;
 
-namespace {
-
 /// Calculate trip count for a loop: (ub - lb + step) / step
 /// If inclusiveUpperbound is false, subtracts 1 from ub first.
-static Value calculateTripCount(OpBuilder &b, Location loc, Value lb, Value ub,
-                                Value step, bool inclusiveUpperbound) {
+Value acc::calculateTripCount(OpBuilder &b, Location loc, Value lb, Value ub,
+                              Value step, bool inclusiveUpperbound) {
   Type type = b.getIndexType();
 
   // Convert original loop arguments to index type
@@ -66,8 +65,8 @@ static void mapACCLoopIVsToSCFIVs(acc::LoopOp accLoop, ValueRange newIVs,
 /// Normalize IV uses after converting to normalized loop form.
 /// For normalized loops (lb=0, step=1), we need to denormalize the IV:
 /// original_iv = new_iv * orig_step + orig_lb
-static void normalizeIVUses(OpBuilder &b, Location loc, Value iv, Value origLB,
-                            Value origStep) {
+void acc::normalizeIVUses(OpBuilder &b, Location loc, Value iv, Value origLB,
+                          Value origStep) {
   Type indexType = b.getIndexType();
   Value lb = getValueOrCreateCastToIndexLike(b, loc, indexType, origLB);
   Value step = getValueOrCreateCastToIndexLike(b, loc, indexType, origStep);
@@ -105,8 +104,6 @@ static void copyLoopAnnotationAttr(Operation *from, Operation *to) {
   if (Attribute ann = from->getDiscardableAttr(LLVM::LoopAnnotationAttr::name))
     to->setDiscardableAttr(LLVM::LoopAnnotationAttr::name, ann);
 }
-
-} // namespace
 
 namespace mlir {
 namespace acc {

--- a/mlir/unittests/Dialect/OpenACC/OpenACCUtilsLoopTest.cpp
+++ b/mlir/unittests/Dialect/OpenACC/OpenACCUtilsLoopTest.cpp
@@ -1127,8 +1127,7 @@ TEST_F(OpenACCUtilsLoopTest, NormalizeIVUsesDenormalizesIV) {
 }
 
 TEST_F(OpenACCUtilsLoopTest, NormalizeIVUsesCastsBoundsToIndex) {
-  SmallVector<Type> argTypes{b.getIndexType(), b.getI32Type(),
-                             b.getI32Type()};
+  SmallVector<Type> argTypes{b.getIndexType(), b.getI32Type(), b.getI32Type()};
   auto [module, funcOp] = createModuleWithFuncArgs(argTypes);
   Block *entry = &funcOp.getBody().front();
   Value iv = entry->getArgument(0);

--- a/mlir/unittests/Dialect/OpenACC/OpenACCUtilsLoopTest.cpp
+++ b/mlir/unittests/Dialect/OpenACC/OpenACCUtilsLoopTest.cpp
@@ -1037,3 +1037,114 @@ TEST_F(OpenACCUtilsLoopTest, CloneACCRegionIntoWithResultReplacement) {
   }
   EXPECT_TRUE(addiUsesReplacement);
 }
+
+//===----------------------------------------------------------------------===//
+// calculateTripCount Tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(OpenACCUtilsLoopTest, CalculateTripCountInclusiveUpperBound) {
+  auto [module, funcOp] = createModuleWithFunc();
+
+  Value tripCount = acc::calculateTripCount(
+      b, loc, createIndexConstant(1), createIndexConstant(10),
+      createIndexConstant(1), /*inclusiveUpperbound=*/true);
+
+  EXPECT_EQ(getConstantIndex(tripCount), 10);
+}
+
+TEST_F(OpenACCUtilsLoopTest, CalculateTripCountExclusiveUpperBound) {
+  auto [module, funcOp] = createModuleWithFunc();
+
+  Value tripCount = acc::calculateTripCount(
+      b, loc, createIndexConstant(0), createIndexConstant(10),
+      createIndexConstant(1), /*inclusiveUpperbound=*/false);
+
+  EXPECT_EQ(getConstantIndex(tripCount), 10);
+}
+
+TEST_F(OpenACCUtilsLoopTest, CalculateTripCountWithStep) {
+  auto [module, funcOp] = createModuleWithFunc();
+
+  Value tripCount = acc::calculateTripCount(
+      b, loc, createIndexConstant(0), createIndexConstant(9),
+      createIndexConstant(2), /*inclusiveUpperbound=*/true);
+
+  EXPECT_EQ(getConstantIndex(tripCount), 5);
+}
+
+TEST_F(OpenACCUtilsLoopTest, CalculateTripCountNegativeStep) {
+  auto [module, funcOp] = createModuleWithFunc();
+
+  Value tripCount = acc::calculateTripCount(
+      b, loc, createIndexConstant(10), createIndexConstant(1),
+      createIndexConstant(-1), /*inclusiveUpperbound=*/true);
+
+  EXPECT_EQ(getConstantIndex(tripCount), 10);
+}
+
+TEST_F(OpenACCUtilsLoopTest, CalculateTripCountCastsOperandsToIndex) {
+  SmallVector<Type> argTypes(3, b.getI32Type());
+  auto [module, funcOp] = createModuleWithFuncArgs(argTypes);
+  Block *entry = &funcOp.getBody().front();
+
+  Value tripCount = acc::calculateTripCount(
+      b, loc, entry->getArgument(0), entry->getArgument(1),
+      entry->getArgument(2), /*inclusiveUpperbound=*/true);
+
+  EXPECT_TRUE(isa<IndexType>(tripCount.getType()));
+  ASSERT_TRUE(tripCount.getDefiningOp<arith::DivSIOp>());
+}
+
+//===----------------------------------------------------------------------===//
+// normalizeIVUses Tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(OpenACCUtilsLoopTest, NormalizeIVUsesDenormalizesIV) {
+  SmallVector<Type> argTypes(1, b.getIndexType());
+  auto [module, funcOp] = createModuleWithFuncArgs(argTypes);
+  Value iv = funcOp.getBody().front().getArgument(0);
+
+  auto useOp = arith::AddIOp::create(b, loc, iv, createIndexConstant(7));
+  b.setInsertionPoint(useOp);
+  Value lb = createIndexConstant(3);
+  Value step = createIndexConstant(4);
+
+  acc::normalizeIVUses(b, loc, iv, lb, step);
+
+  // The use must now read `iv * step + lb` instead of the normalized IV.
+  auto denormalized = useOp.getLhs().getDefiningOp<arith::AddIOp>();
+  ASSERT_TRUE(denormalized);
+  EXPECT_EQ(denormalized.getOverflowFlags(), arith::IntegerOverflowFlags::nsw);
+  EXPECT_EQ(denormalized.getRhs(), lb);
+
+  auto scaled = denormalized.getLhs().getDefiningOp<arith::MulIOp>();
+  ASSERT_TRUE(scaled);
+  EXPECT_EQ(scaled.getOverflowFlags(), arith::IntegerOverflowFlags::nsw);
+  EXPECT_EQ(scaled.getRhs(), step);
+
+  // The ops computing the denormalized value keep reading the original IV.
+  EXPECT_EQ(scaled.getLhs(), iv);
+}
+
+TEST_F(OpenACCUtilsLoopTest, NormalizeIVUsesCastsBoundsToIndex) {
+  SmallVector<Type> argTypes{b.getIndexType(), b.getI32Type(),
+                             b.getI32Type()};
+  auto [module, funcOp] = createModuleWithFuncArgs(argTypes);
+  Block *entry = &funcOp.getBody().front();
+  Value iv = entry->getArgument(0);
+
+  auto useOp = arith::AddIOp::create(b, loc, iv, createIndexConstant(7));
+  b.setInsertionPoint(useOp);
+
+  acc::normalizeIVUses(b, loc, iv, entry->getArgument(1),
+                       entry->getArgument(2));
+
+  auto denormalized = useOp.getLhs().getDefiningOp<arith::AddIOp>();
+  ASSERT_TRUE(denormalized);
+  EXPECT_TRUE(isa<IndexType>(denormalized.getType()));
+  EXPECT_TRUE(denormalized.getRhs().getDefiningOp<arith::IndexCastOp>());
+
+  auto scaled = denormalized.getLhs().getDefiningOp<arith::MulIOp>();
+  ASSERT_TRUE(scaled);
+  EXPECT_TRUE(scaled.getRhs().getDefiningOp<arith::IndexCastOp>());
+}


### PR DESCRIPTION
Updates OpenACCUtilsLoop so that two of the internal helpers are externally callable. Adds unit tests for them.