### PR TITLE
[nfc][acc] Expose castPointerLikeType API

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCUtilsType.h
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCUtilsType.h
@@ -19,8 +19,11 @@
 
 namespace mlir {
 class DataLayout;
+class Location;
 class ModuleOp;
+class OpBuilder;
 class Type;
+class Value;
 
 namespace acc {
 
@@ -49,6 +52,12 @@ getTypeSizeAndAlignment(Type ty, ModuleOp module, const DataLayout &dl,
 std::optional<TypeSizeAndAlignment>
 getTypeSizeAndAlignment(Type ty, ModuleOp module,
                         OpenACCSupport *support = nullptr);
+
+/// Cast \p value to \p resultType via PointerLikeType::genCast when needed.
+/// Returns \p value unchanged if types already match. Emits an error and
+/// returns \p value if no cast can be generated.
+Value castPointerLikeTypeIfNeeded(OpBuilder &builder, Location loc, Value value,
+                                  Type resultType);
 
 } // namespace acc
 } // namespace mlir

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -103,6 +103,7 @@
 #include "mlir/Dialect/OpenACC/OpenACCUtilsCG.h"
 #include "mlir/Dialect/OpenACC/OpenACCUtilsGPU.h"
 #include "mlir/Dialect/OpenACC/OpenACCUtilsReduction.h"
+#include "mlir/Dialect/OpenACC/OpenACCUtilsType.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Block.h"
 #include "mlir/IR/BuiltinAttributeInterfaces.h"
@@ -360,24 +361,6 @@ static Value unwrapMemRefConversion(Value v) {
     break;
   }
   return v;
-}
-
-/// Casts between pointer-like private types when lowering requires it.
-static Value castPointerLikeTypeIfNeeded(OpBuilder &builder, Location loc,
-                                         Value value, Type resultType) {
-  if (value.getType() == resultType)
-    return value;
-  if (PointerLikeType ptrLike = dyn_cast<PointerLikeType>(value.getType())) {
-    if (Value casted = ptrLike.genCast(builder, loc, value, resultType))
-      return casted;
-  }
-  if (PointerLikeType ptrLike = dyn_cast<PointerLikeType>(resultType)) {
-    if (Value casted = ptrLike.genCast(builder, loc, value, resultType))
-      return casted;
-  }
-  emitError(loc) << "unsupported pointer-like type cast from "
-                 << value.getType() << " to " << resultType;
-  return value;
 }
 
 /// Walks back from a memref use to its defining `acc.private_local`, if any,

--- a/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsType.cpp
+++ b/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsType.cpp
@@ -10,7 +10,9 @@
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/OpenACC/Analysis/OpenACCSupport.h"
+#include "mlir/Dialect/OpenACC/OpenACC.h"
 #include "mlir/Dialect/OpenACC/OpenACCUtilsCG.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Interfaces/DataLayoutInterfaces.h"
@@ -86,6 +88,23 @@ getTypeSizeAndAlignment(Type ty, ModuleOp module, OpenACCSupport *support) {
   if (!dl)
     return std::nullopt;
   return getTypeSizeAndAlignment(ty, module, *dl, support);
+}
+
+Value castPointerLikeTypeIfNeeded(OpBuilder &builder, Location loc, Value value,
+                                  Type resultType) {
+  if (value.getType() == resultType)
+    return value;
+  if (PointerLikeType ptrLike = dyn_cast<PointerLikeType>(value.getType())) {
+    if (Value casted = ptrLike.genCast(builder, loc, value, resultType))
+      return casted;
+  }
+  if (PointerLikeType ptrLike = dyn_cast<PointerLikeType>(resultType)) {
+    if (Value casted = ptrLike.genCast(builder, loc, value, resultType))
+      return casted;
+  }
+  emitError(loc) << "unsupported pointer-like type cast from "
+                 << value.getType() << " to " << resultType;
+  return value;
 }
 
 } // namespace acc

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-private-local-cast.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-private-local-cast.mlir
@@ -1,0 +1,89 @@
+// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(acc-cg-to-gpu))" --split-input-file | FileCheck %s
+
+// Materializing `acc.private_local` casts the storage to the requested surface
+// type. A static per-thread allocation requested as a dynamically shaped memref
+// produces a `memref.cast`.
+
+// CHECK-LABEL: func.func @private_local_surface_cast
+// CHECK:         %[[ALLOCA:.*]] = memref.alloca() : memref<4xf32>
+// CHECK:         %[[CAST:.*]] = memref.cast %[[ALLOCA]] : memref<4xf32> to memref<?xf32>
+// CHECK:         memref.store %{{.*}}, %[[CAST]][%{{.*}}] : memref<?xf32>
+
+func.func @private_local_surface_cast() {
+  %c4 = arith.constant 4 : index
+  %c128 = arith.constant 128 : index
+  %bx = acc.par_width %c4 par_dim(#acc.par_dim<block_x>)
+  %tx = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
+  %priv = acc.privatize par_dims(#acc<par_dims[thread_x]>) : () -> !acc.private_type<memref<4xf32>>
+
+  acc.compute_region launch(%kbx = %bx, %ktx = %tx) ins(%arg = %priv) : (!acc.private_type<memref<4xf32>>) {
+    %c0 = arith.constant 0 : index
+    %f0 = arith.constant 0.0 : f32
+    %local = acc.private_local %arg : (!acc.private_type<memref<4xf32>>) -> memref<?xf32>
+    memref.store %f0, %local[%c0] : memref<?xf32>
+    acc.yield
+  } <{origin = "acc.parallel"}>
+  return
+}
+
+// -----
+
+// Shared memory storage lives in the workgroup address space, so reaching the
+// requested surface type produces a `memref.memory_space_cast`.
+
+// CHECK-LABEL: func.func @private_local_shared_memory_cast
+// CHECK:         %[[SHARED:.*]] = acc.gpu_shared_memory
+// CHECK-SAME:      memref<2xi32, #gpu.address_space<workgroup>>
+// CHECK:         %[[CAST:.*]] = memref.memory_space_cast %[[SHARED]] : memref<2xi32, #gpu.address_space<workgroup>> to memref<2xi32>
+// CHECK:         memref.store %{{.*}}, %[[CAST]][%{{.*}}] : memref<2xi32>
+
+func.func @private_local_shared_memory_cast() {
+  %c1 = arith.constant 1 : index
+  %c5 = arith.constant 5 : index
+  %c32 = arith.constant 32 : index
+  %nw = arith.addi %c1, %c1 : index
+  %block_x = acc.par_width %c5 par_dim(#acc.par_dim<block_x>)
+  %thread_y = acc.par_width %nw par_dim(#acc.par_dim<thread_y>)
+  %thread_x = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
+  acc.kernel_environment {
+    %priv = acc.privatize : () -> !acc.private_type<memref<2xi32>>
+    acc.compute_region launch(%arg0 = %block_x, %arg1 = %thread_y, %arg2 = %thread_x) ins(%arg10 = %priv) : (!acc.private_type<memref<2xi32>>) {
+      %c0 = arith.constant 0 : index
+      %c1_inner = arith.constant 1 : index
+      %c0_i32 = arith.constant 0 : i32
+      scf.parallel (%iv) = (%c0) to (%arg1) step (%c1_inner) {
+        %local = acc.private_local %arg10 : (!acc.private_type<memref<2xi32>>) -> memref<2xi32>
+        memref.store %c0_i32, %local[%c0] : memref<2xi32>
+        scf.reduce
+      } {acc.par_dims = #acc<par_dims[thread_y]>}
+      acc.yield
+    } <{origin = "acc.parallel"}>
+  }
+  return
+}
+
+// -----
+
+// When the storage already has the requested surface type, no cast is emitted.
+
+// CHECK-LABEL: func.func @private_local_no_cast
+// CHECK:         %[[ALLOCA:.*]] = memref.alloca() : memref<4xf32>
+// CHECK-NOT:     memref.cast
+// CHECK:         memref.store %{{.*}}, %[[ALLOCA]][%{{.*}}] : memref<4xf32>
+
+func.func @private_local_no_cast() {
+  %c4 = arith.constant 4 : index
+  %c128 = arith.constant 128 : index
+  %bx = acc.par_width %c4 par_dim(#acc.par_dim<block_x>)
+  %tx = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
+  %priv = acc.privatize par_dims(#acc<par_dims[thread_x]>) : () -> !acc.private_type<memref<4xf32>>
+
+  acc.compute_region launch(%kbx = %bx, %ktx = %tx) ins(%arg = %priv) : (!acc.private_type<memref<4xf32>>) {
+    %c0 = arith.constant 0 : index
+    %f0 = arith.constant 0.0 : f32
+    %local = acc.private_local %arg : (!acc.private_type<memref<4xf32>>) -> memref<4xf32>
+    memref.store %f0, %local[%c0] : memref<4xf32>
+    acc.yield
+  } <{origin = "acc.parallel"}>
+  return
+}

--- a/mlir/unittests/Dialect/OpenACC/OpenACCUtilsTypeTest.cpp
+++ b/mlir/unittests/Dialect/OpenACC/OpenACCUtilsTypeTest.cpp
@@ -11,8 +11,10 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/OpenACC/OpenACC.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OwningOpRef.h"
 #include "mlir/Interfaces/DataLayoutInterfaces.h"
@@ -24,8 +26,8 @@ using namespace mlir::acc;
 class OpenACCUtilsTypeTest : public ::testing::Test {
 protected:
   OpenACCUtilsTypeTest() : b(&context), loc(UnknownLoc::get(&context)) {
-    context.loadDialect<DLTIDialect, func::FuncDialect, memref::MemRefDialect,
-                        LLVM::LLVMDialect>();
+    context.loadDialect<acc::OpenACCDialect, DLTIDialect, func::FuncDialect,
+                        memref::MemRefDialect, LLVM::LLVMDialect>();
   }
 
   MLIRContext context;
@@ -80,4 +82,68 @@ TEST_F(OpenACCUtilsTypeTest, DynamicMemRefReturnsNullopt) {
   OwningOpRef<ModuleOp> module = ModuleOp::create(b, loc);
   auto memrefTy = MemRefType::get({ShapedType::kDynamic}, b.getI32Type());
   EXPECT_FALSE(getTypeSizeAndAlignment(memrefTy, *module).has_value());
+}
+
+//===----------------------------------------------------------------------===//
+// castPointerLikeTypeIfNeeded Tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(OpenACCUtilsTypeTest, CastPointerLikeTypeMatchingTypeIsNoOp) {
+  OwningOpRef<ModuleOp> module = ModuleOp::create(b, loc);
+  b.setInsertionPointToStart(module->getBody());
+
+  auto memrefTy = MemRefType::get({10}, b.getF32Type());
+  Value alloca = memref::AllocaOp::create(b, loc, memrefTy);
+
+  EXPECT_EQ(castPointerLikeTypeIfNeeded(b, loc, alloca, memrefTy), alloca);
+}
+
+TEST_F(OpenACCUtilsTypeTest, CastPointerLikeTypeGeneratesMemRefCast) {
+  OwningOpRef<ModuleOp> module = ModuleOp::create(b, loc);
+  b.setInsertionPointToStart(module->getBody());
+
+  auto memrefTy = MemRefType::get({10}, b.getF32Type());
+  auto dynamicTy = MemRefType::get({ShapedType::kDynamic}, b.getF32Type());
+  Value alloca = memref::AllocaOp::create(b, loc, memrefTy);
+
+  Value casted = castPointerLikeTypeIfNeeded(b, loc, alloca, dynamicTy);
+
+  EXPECT_EQ(casted.getType(), dynamicTy);
+  ASSERT_TRUE(casted.getDefiningOp<memref::CastOp>());
+}
+
+TEST_F(OpenACCUtilsTypeTest, CastPointerLikeTypeGeneratesAddrSpaceCast) {
+  OwningOpRef<ModuleOp> module = ModuleOp::create(b, loc);
+  b.setInsertionPointToStart(module->getBody());
+
+  auto ptrTy = LLVM::LLVMPointerType::get(&context);
+  auto devicePtrTy = LLVM::LLVMPointerType::get(&context, /*addressSpace=*/1);
+  Value one =
+      LLVM::ConstantOp::create(b, loc, b.getI64Type(), b.getI64IntegerAttr(1));
+  Value alloca = LLVM::AllocaOp::create(b, loc, ptrTy, b.getF32Type(), one);
+
+  Value casted = castPointerLikeTypeIfNeeded(b, loc, alloca, devicePtrTy);
+
+  EXPECT_EQ(casted.getType(), devicePtrTy);
+  ASSERT_TRUE(casted.getDefiningOp<LLVM::AddrSpaceCastOp>());
+}
+
+TEST_F(OpenACCUtilsTypeTest, CastPointerLikeTypeUnsupportedEmitsError) {
+  OwningOpRef<ModuleOp> module = ModuleOp::create(b, loc);
+  b.setInsertionPointToStart(module->getBody());
+
+  Value value =
+      LLVM::ConstantOp::create(b, loc, b.getI32Type(), b.getI32IntegerAttr(0));
+
+  std::string diagnostic;
+  ScopedDiagnosticHandler handler(&context, [&](Diagnostic &diag) {
+    diagnostic = diag.str();
+    return success();
+  });
+
+  Value result = castPointerLikeTypeIfNeeded(b, loc, value, b.getF32Type());
+
+  EXPECT_EQ(result, value);
+  EXPECT_EQ(diagnostic, "unsupported pointer-like type cast from 'i32' to "
+                        "'f32'");
 }


### PR DESCRIPTION
Moves utility out of ACCCGToGPU to OpenACCUtilsType. And adds unit tests.