### PR TITLE
[clang][bugfix] Honor FP pragmas in Objective-C method and block bodies

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -3413,7 +3413,7 @@ def StrictFP : InheritableAttr {
   // This attribute has no spellings as it is only ever created implicitly.
   // Function uses strict floating point operations.
   let Spellings = [];
-  let Subjects = SubjectList<[Function]>;
+  let Subjects = SubjectList<[Function, ObjCMethod]>;
   let Documentation = [InternalOnly];
 }
 

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -3413,7 +3413,7 @@ def StrictFP : InheritableAttr {
   // This attribute has no spellings as it is only ever created implicitly.
   // Function uses strict floating point operations.
   let Spellings = [];
-  let Subjects = SubjectList<[Function, ObjCMethod]>;
+  let Subjects = SubjectList<[Function, ObjCMethod, Block]>;
   let Documentation = [InternalOnly];
 }
 

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -1094,7 +1094,7 @@ void CodeGenFunction::StartFunction(GlobalDecl GD, QualType RetTy,
       ToConstrainedExceptMD(getLangOpts().getDefaultExceptionMode());
   Builder.setDefaultConstrainedRounding(RM);
   Builder.setDefaultConstrainedExcept(FPExceptionBehavior);
-  if ((FD && (FD->UsesFPIntrin() || FD->hasAttr<StrictFPAttr>())) ||
+  if ((FD && FD->UsesFPIntrin()) || (D && D->hasAttr<StrictFPAttr>()) ||
       (!FD && (FPExceptionBehavior != llvm::fp::ebIgnore ||
                RM != llvm::RoundingMode::NearestTiesToEven))) {
     Builder.setIsFPConstrained(true);

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -16808,8 +16808,11 @@ Decl *Sema::ActOnFinishFunctionBody(Decl *dcl, Stmt *Body, bool IsInstantiation,
   FunctionScopeInfo *FSI = getCurFunction();
   FunctionDecl *FD = dcl ? dcl->getAsFunction() : nullptr;
 
-  if (FSI->UsesFPIntrin && FD && !FD->hasAttr<StrictFPAttr>())
-    FD->addAttr(StrictFPAttr::CreateImplicit(Context));
+  if (FSI->UsesFPIntrin) {
+    Decl *StrictFPTarget = FD ? cast<Decl>(FD) : dcl;
+    if (StrictFPTarget && !StrictFPTarget->hasAttr<StrictFPAttr>())
+      StrictFPTarget->addAttr(StrictFPAttr::CreateImplicit(Context));
+  }
 
   SourceLocation AnalysisLoc;
   if (Body)

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -17142,6 +17142,10 @@ ExprResult Sema::ActOnBlockStmtExpr(SourceLocation CaretLoc,
 
   maybeAddDeclWithEffects(BD);
 
+  // A block body parsed under a constrained FP environment must be strict-FP.
+  if (BSI->UsesFPIntrin && !BD->hasAttr<StrictFPAttr>())
+    BD->addAttr(StrictFPAttr::CreateImplicit(Context));
+
   if (BSI->HasImplicitReturnType)
     deduceClosureReturnType(*BSI);
 

--- a/clang/test/CodeGen/pragma-fenv_access-block.c
+++ b/clang/test/CodeGen/pragma-fenv_access-block.c
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fblocks -emit-llvm -O0 -o - %s | FileCheck %s
+
+// A block body under an FP-affecting pragma must be emitted in strict-FP mode.
+
+#pragma STDC FENV_ACCESS ON
+
+// CHECK-LABEL: define internal float @__block_in_function_block_invoke
+// CHECK-SAME:  #[[ATTR:[0-9]+]]
+// CHECK:       call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+float block_in_function(float x, float y) {
+  float (^blk)(float, float) = ^float(float a, float b) { return a + b; };
+  return blk(x, y);
+}
+
+// CHECK: attributes #[[ATTR]] = {{.*}} strictfp

--- a/clang/test/CodeGenObjC/pragma-fenv_access.m
+++ b/clang/test/CodeGenObjC/pragma-fenv_access.m
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -triple arm64-apple-macosx -emit-llvm -O0 -o - %s | FileCheck %s
+
+// An FP-affecting pragma in effect over an Objective-C method body must put that
+// body into strict-FP mode, exactly as it does for a plain function body.
+
+#pragma STDC FENV_ACCESS ON
+
+__attribute__((objc_root_class))
+@interface Foo
+@end
+
+@implementation Foo
+// CHECK-LABEL: define internal float @"\01-[Foo add:with:]"
+// CHECK-SAME:  #[[ATTR:[0-9]+]]
+// CHECK:       call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+- (float)add:(float)a with:(float)b {
+  return a + b;
+}
+@end
+
+// CHECK-LABEL: define{{.*}} float @plain_function
+// CHECK-SAME:  #[[ATTR]]
+// CHECK:       call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+float plain_function(float a, float b) {
+  return a + b;
+}
+
+// CHECK: attributes #[[ATTR]] = {{.*}} strictfp


### PR DESCRIPTION
FP pragma state only reached CodeGen via `FunctionDecl`, so `#pragma STDC
FENV_ACCESS ON` was silently dropped over ObjC method and block bodies which
causes an assertion failure.

Attach the implicit `StrictFPAttr` to `ObjCMethodDecl` and `BlockDecl`.

rdar://182750847