### PR TITLE
[AMDGPU] Fix user SGPR accounting when parsing MIR

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -2235,10 +2235,10 @@ bool GCNTargetMachine::parseMachineFunctionInfo(
                              MFI->ArgInfo.FlatScratchInit, 2, 0) ||
        parseAndCheckArgument(YamlMFI.ArgInfo->PrivateSegmentSize,
                              AMDGPU::SGPR_32RegClass,
-                             MFI->ArgInfo.PrivateSegmentSize, 0, 0) ||
+                             MFI->ArgInfo.PrivateSegmentSize, 1, 0) ||
        parseAndCheckArgument(YamlMFI.ArgInfo->LDSKernelId,
-                             AMDGPU::SGPR_32RegClass,
-                             MFI->ArgInfo.LDSKernelId, 0, 1) ||
+                             AMDGPU::SGPR_32RegClass, MFI->ArgInfo.LDSKernelId,
+                             1, 0) ||
        parseAndCheckArgument(YamlMFI.ArgInfo->WorkGroupIDX,
                              AMDGPU::SGPR_32RegClass, MFI->ArgInfo.WorkGroupIDX,
                              0, 1) ||
@@ -2261,14 +2261,14 @@ bool GCNTargetMachine::parseMachineFunctionInfo(
                              AMDGPU::SReg_64RegClass,
                              MFI->ArgInfo.ImplicitBufferPtr, 2, 0) ||
        parseAndCheckArgument(YamlMFI.ArgInfo->WorkItemIDX,
-                             AMDGPU::VGPR_32RegClass,
-                             MFI->ArgInfo.WorkItemIDX, 0, 0) ||
+                             AMDGPU::VGPR_32RegClass, MFI->ArgInfo.WorkItemIDX,
+                             0, 0) ||
        parseAndCheckArgument(YamlMFI.ArgInfo->WorkItemIDY,
-                             AMDGPU::VGPR_32RegClass,
-                             MFI->ArgInfo.WorkItemIDY, 0, 0) ||
+                             AMDGPU::VGPR_32RegClass, MFI->ArgInfo.WorkItemIDY,
+                             0, 0) ||
        parseAndCheckArgument(YamlMFI.ArgInfo->WorkItemIDZ,
-                             AMDGPU::VGPR_32RegClass,
-                             MFI->ArgInfo.WorkItemIDZ, 0, 0)))
+                             AMDGPU::VGPR_32RegClass, MFI->ArgInfo.WorkItemIDZ,
+                             0, 0)))
     return true;
 
   // Parse FirstKernArgPreloadReg separately, since it's a Register,

--- a/llvm/test/CodeGen/MIR/AMDGPU/machine-function-info-user-sgpr-count.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/machine-function-info-user-sgpr-count.mir
@@ -1,0 +1,46 @@
+# RUN: llc -mtriple=amdgpu11.00-amd-amdhsa -start-after=finalize-isel %s -o - | FileCheck %s
+
+# Verify that parsing either special user SGPR preserves the total user SGPR count.
+
+# CHECK-LABEL: .amdhsa_kernel private_segment_size
+# CHECK: .amdhsa_user_sgpr_count 1
+# CHECK-LABEL: .amdhsa_kernel lds_kernel_id
+# CHECK: .amdhsa_user_sgpr_count 1
+
+--- |
+  target triple = "amdgcn-amd-amdhsa"
+
+  define amdgpu_kernel void @private_segment_size() #0 {
+    ret void
+  }
+
+  define amdgpu_kernel void @lds_kernel_id() #0 {
+    ret void
+  }
+
+  attributes #0 = { "amdgpu-no-dispatch-id" "amdgpu-no-dispatch-ptr" "amdgpu-no-implicitarg-ptr" "amdgpu-no-queue-ptr" }
+...
+---
+name:            private_segment_size
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+  argumentInfo:
+    privateSegmentSize: { reg: '$sgpr0' }
+body:             |
+  bb.0:
+    S_ENDPGM 0
+
+...
+---
+name:            lds_kernel_id
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+  argumentInfo:
+    LDSKernelId:     { reg: '$sgpr0' }
+body:             |
+  bb.0:
+    S_ENDPGM 0
+
+...


### PR DESCRIPTION
Count privateSegmentSize and LDSKernelId as user SGPRs to preserve the kernel descriptor count across MIR round trips.

Fixes LCOMPILER-2700.

---

This PR was assisted by AI but I reviewed all the changes.