### PR TITLE
[HLSL] Add Texture3D and RWTexture3D types

### DIFF
--- a/clang/lib/Sema/HLSLExternalSemaSource.cpp
+++ b/clang/lib/Sema/HLSLExternalSemaSource.cpp
@@ -322,6 +322,13 @@ static const TextureTypeInfo TextureTypes[] = {
      /*IsArray=*/false, /*IsROV=*/false,
      TemplateShape::ElementTypeAndSampleCount,
      TexCap::LoadMS | TexCap::Subscript},
+    {"Texture3D", ResourceClass::SRV, ResourceDimension::Dim3D,
+     /*IsArray=*/false, /*IsROV=*/false, TemplateShape::ElementType,
+     TexCap::Load | TexCap::Subscript | TexCap::Mips | TexCap::Sample |
+         TexCap::CalcLOD | TexCap::GetDims},
+    {"RWTexture3D", ResourceClass::UAV, ResourceDimension::Dim3D,
+     /*IsArray=*/false, /*IsROV=*/false, TemplateShape::ElementType,
+     TexCap::LoadRW | TexCap::Subscript | TexCap::GetDims},
     {"TextureCube", ResourceClass::SRV, ResourceDimension::Cube,
      /*IsArray=*/false, /*IsROV=*/false, TemplateShape::ElementType,
      TexCap::Sample | TexCap::SampleCmp | TexCap::CalcLOD | TexCap::Gather |

--- a/clang/test/AST/HLSL/Textures-scalar-AST.hlsl
+++ b/clang/test/AST/HLSL/Textures-scalar-AST.hlsl
@@ -1,32 +1,43 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -ast-dump \
 // RUN:   -disable-llvm-passes -finclude-default-header -DHAS_OFFSET \
-// RUN:   -DHAS_GETDIM_XY -DTEXTURE=Texture2D -DCOORD_TYPE=float2 \
-// RUN:   -DGRAD_TYPE=float2 -DLOD_LOCATION=loc -DOFFSET_ARG="int2(1, 2)" -o - \
-// RUN:   %s \
-// RUN:   | FileCheck %s --check-prefixes=CHECK,TEXEL,OFFSET,GETDIM-XY \
+// RUN:   -DHAS_GETDIM_XY -DHAS_SAMPLE_CMP -DHAS_GATHER -DTEXTURE=Texture2D \
+// RUN:   -DCOORD_TYPE=float2 -DGRAD_TYPE=float2 -DLOD_LOCATION=loc \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -o - %s \
+// RUN:   | FileCheck %s \
+// RUN:   --check-prefixes=CHECK,TEXEL,OFFSET,GETDIM-XY,SAMPLECMP,SAMPLECMP-OFFSET,GATHER,GATHER-OFFSET \
 // RUN:   -DTEXTURE=Texture2D -DDIM_NAME=2D -DDIM=2 -DCOORD_DIM=2 -DLOAD_DIM=3 \
 // RUN:   -DINDEX_TYPE="vector<unsigned int, 2>" -DIS_ARRAY=""
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -ast-dump \
-// RUN:   -disable-llvm-passes -finclude-default-header -DTEXTURE=TextureCube \
-// RUN:   -DCOORD_TYPE=float3 -DGRAD_TYPE=float3 -DLOD_LOCATION=loc -o - %s \
-// RUN:   | FileCheck %s --check-prefixes=CHECK -DTEXTURE=TextureCube \
-// RUN:   -DDIM_NAME=Cube -DDIM=3 -DCOORD_DIM=3 -DIS_ARRAY=""
+// RUN:   -disable-llvm-passes -finclude-default-header -DHAS_SAMPLE_CMP \
+// RUN:   -DHAS_GATHER -DTEXTURE=TextureCube -DCOORD_TYPE=float3 \
+// RUN:   -DGRAD_TYPE=float3 -DLOD_LOCATION=loc -o - %s \
+// RUN:   | FileCheck %s --check-prefixes=CHECK,SAMPLECMP,GATHER \
+// RUN:   -DTEXTURE=TextureCube -DDIM_NAME=Cube -DDIM=3 -DCOORD_DIM=3 \
+// RUN:   -DIS_ARRAY=""
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -ast-dump \
-// RUN:   -disable-llvm-passes -finclude-default-header \
-// RUN:   -DTEXTURE=TextureCubeArray -DCOORD_TYPE=float4 -DGRAD_TYPE=float3 \
-// RUN:   -DLOD_LOCATION=loc.xyz -o - %s \
-// RUN:   | FileCheck %s --check-prefixes=CHECK -DTEXTURE=TextureCubeArray \
-// RUN:   -DDIM_NAME=Cube -DDIM=3 -DCOORD_DIM=4 \
+// RUN:   -disable-llvm-passes -finclude-default-header -DHAS_SAMPLE_CMP \
+// RUN:   -DHAS_GATHER -DTEXTURE=TextureCubeArray -DCOORD_TYPE=float4 \
+// RUN:   -DGRAD_TYPE=float3 -DLOD_LOCATION=loc.xyz -o - %s \
+// RUN:   | FileCheck %s --check-prefixes=CHECK,SAMPLECMP,GATHER \
+// RUN:   -DTEXTURE=TextureCubeArray -DDIM_NAME=Cube -DDIM=3 -DCOORD_DIM=4 \
 // RUN:   -DIS_ARRAY=" [[hlsl::is_array]]"
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -ast-dump \
 // RUN:   -disable-llvm-passes -finclude-default-header -DHAS_OFFSET \
-// RUN:   -DHAS_GETDIM_XY -DTEXTURE=Texture2DArray -DCOORD_TYPE=float3 \
-// RUN:   -DGRAD_TYPE=float2 -DLOD_LOCATION=loc.xy -DOFFSET_ARG="int2(1, 2)" \
-// RUN:   -o - %s \
-// RUN:   | FileCheck %s --check-prefixes=CHECK,ARRAY,TEXEL,OFFSET,GETDIM-XY \
+// RUN:   -DHAS_GETDIM_XY -DHAS_SAMPLE_CMP -DHAS_GATHER \
+// RUN:   -DTEXTURE=Texture2DArray -DCOORD_TYPE=float3 -DGRAD_TYPE=float2 \
+// RUN:   -DLOD_LOCATION=loc.xy -DOFFSET_ARG="int2(1, 2)" -o - %s \
+// RUN:   | FileCheck %s \
+// RUN:   --check-prefixes=CHECK,ARRAY,TEXEL,OFFSET,GETDIM-XY,SAMPLECMP,SAMPLECMP-OFFSET,GATHER,GATHER-OFFSET \
 // RUN:   -DTEXTURE=Texture2DArray -DDIM_NAME=2D -DDIM=2 -DCOORD_DIM=3 \
 // RUN:   -DLOAD_DIM=4 -DINDEX_TYPE="vector<unsigned int, 3>" \
 // RUN:   -DIS_ARRAY=" [[hlsl::is_array]]"
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -ast-dump \
+// RUN:   -disable-llvm-passes -finclude-default-header -DHAS_OFFSET \
+// RUN:   -DTEXTURE=Texture3D -DCOORD_TYPE=float3 -DGRAD_TYPE=float3 \
+// RUN:   -DLOD_LOCATION=loc -DOFFSET_ARG="int3(1, 2, 3)" -o - %s \
+// RUN:   | FileCheck %s --check-prefixes=CHECK,TEXEL,OFFSET \
+// RUN:   -DTEXTURE=Texture3D -DDIM_NAME=3D -DDIM=3 -DCOORD_DIM=3 -DLOAD_DIM=4 \
+// RUN:   -DINDEX_TYPE="vector<unsigned int, 3>" -DIS_ARRAY=""
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
@@ -35,6 +46,9 @@
 //                      have overloads taking an offset
 //   HAS_GETDIM_XY      defined for types that have the width/height
 //                      GetDimensions overloads
+//   HAS_SAMPLE_CMP     defined for types that have the comparison sampling
+//                      methods
+//   HAS_GATHER         defined for types that have the Gather* methods
 //   TEXTURE            resource type name
 //   COORD_TYPE         sample location type (DIM components plus the array
 //                      slice)
@@ -56,6 +70,10 @@
 //   OFFSET             the sampling and gathering methods have offset
 //                      overloads
 //   GETDIM-XY          the width/height GetDimensions overloads exist
+//   SAMPLECMP          the comparison sampling methods exist
+//   SAMPLECMP-OFFSET   the comparison sampling methods have offset overloads
+//   GATHER             the Gather* methods exist
+//   GATHER-OFFSET      the Gather* methods have offset overloads
 //   ARRAY              the resource has an array slice
 //   IS_ARRAY           the [[hlsl::is_array]] attribute on arrayed resources,
 //                      or empty
@@ -67,7 +85,7 @@
 
 // CHECK: CXXRecordDecl {{.*}} SamplerComparisonState definition
 // CHECK: FinalAttr {{.*}} Implicit final
-// CHECK-NEXT: FieldDecl {{.*}} implicit {{.*}} __handle '__hlsl_resource_t
+// CHECK-NEXT: FieldDecl {{.*}} implicit {{.*}}__handle '__hlsl_resource_t
 // CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
 
 // CHECK: ClassTemplateDecl {{.*}} [[TEXTURE]]
@@ -408,129 +426,129 @@
 // OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
 // OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} SampleCmp 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME: {{\[\[}}hlsl::resource_class("SRV"){{\]\]}}[[IS_ARRAY]] {{\[\[}}hlsl::contained_type(element_type){{\]\]}}
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// CHECK-NEXT: AlwaysInlineAttr
+// SAMPLECMP: CXXMethodDecl {{.*}} SampleCmp 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)'
+// SAMPLECMP-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// SAMPLECMP-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// SAMPLECMP-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// SAMPLECMP-NEXT: CompoundStmt
+// SAMPLECMP-NEXT: ReturnStmt
+// SAMPLECMP-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
+// SAMPLECMP-NEXT: CallExpr {{.*}} '<dependent type>'
+// SAMPLECMP-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp' 'void (...) noexcept'
+// SAMPLECMP-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// SAMPLECMP-SAME: {{\[\[}}hlsl::resource_class("SRV"){{\]\]}}[[IS_ARRAY]] {{\[\[}}hlsl::contained_type(element_type){{\]\]}}
+// SAMPLECMP-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// SAMPLECMP-SAME: ' lvalue .__handle
+// SAMPLECMP-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
+// SAMPLECMP-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// SAMPLECMP-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// SAMPLECMP-SAME: ' lvalue .__handle
+// SAMPLECMP-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// SAMPLECMP-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// SAMPLECMP-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// SAMPLECMP-NEXT: AlwaysInlineAttr
 
-// OFFSET: CXXMethodDecl {{.*}} SampleCmp 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: CompoundStmt
-// OFFSET-NEXT: ReturnStmt
-// OFFSET-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
-// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp' 'void (...) noexcept'
-// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// SAMPLECMP-OFFSET: CXXMethodDecl {{.*}} SampleCmp 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: CompoundStmt
+// SAMPLECMP-OFFSET-NEXT: ReturnStmt
+// SAMPLECMP-OFFSET-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
+// SAMPLECMP-OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp' 'void (...) noexcept'
+// SAMPLECMP-OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// SAMPLECMP-OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
-// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// OFFSET-SAME: ' lvalue .__handle
-// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
-// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// OFFSET-SAME: ' lvalue .__handle
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: AlwaysInlineAttr
+// SAMPLECMP-OFFSET-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// SAMPLECMP-OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// SAMPLECMP-OFFSET-SAME: ' lvalue .__handle
+// SAMPLECMP-OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
+// SAMPLECMP-OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// SAMPLECMP-OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// SAMPLECMP-OFFSET-SAME: ' lvalue .__handle
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: AlwaysInlineAttr
 
-// OFFSET: CXXMethodDecl {{.*}} SampleCmp 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>, float)'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Clamp 'float'
-// OFFSET-NEXT: CompoundStmt
-// OFFSET-NEXT: ReturnStmt
-// OFFSET-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
-// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp' 'void (...) noexcept'
-// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// SAMPLECMP-OFFSET: CXXMethodDecl {{.*}} SampleCmp 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>, float)'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} Clamp 'float'
+// SAMPLECMP-OFFSET-NEXT: CompoundStmt
+// SAMPLECMP-OFFSET-NEXT: ReturnStmt
+// SAMPLECMP-OFFSET-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
+// SAMPLECMP-OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp' 'void (...) noexcept'
+// SAMPLECMP-OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// SAMPLECMP-OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
-// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// OFFSET-SAME: ' lvalue .__handle
-// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
-// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// OFFSET-SAME: ' lvalue .__handle
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Clamp' 'float'
-// OFFSET-NEXT: AlwaysInlineAttr
+// SAMPLECMP-OFFSET-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// SAMPLECMP-OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// SAMPLECMP-OFFSET-SAME: ' lvalue .__handle
+// SAMPLECMP-OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
+// SAMPLECMP-OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// SAMPLECMP-OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// SAMPLECMP-OFFSET-SAME: ' lvalue .__handle
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Clamp' 'float'
+// SAMPLECMP-OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} SampleCmpLevelZero 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp_level_zero' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME: {{\[\[}}hlsl::resource_class("SRV"){{\]\]}}[[IS_ARRAY]] {{\[\[}}hlsl::contained_type(element_type){{\]\]}}
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// CHECK-NEXT: AlwaysInlineAttr
+// SAMPLECMP: CXXMethodDecl {{.*}} SampleCmpLevelZero 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)'
+// SAMPLECMP-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// SAMPLECMP-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// SAMPLECMP-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// SAMPLECMP-NEXT: CompoundStmt
+// SAMPLECMP-NEXT: ReturnStmt
+// SAMPLECMP-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
+// SAMPLECMP-NEXT: CallExpr {{.*}} '<dependent type>'
+// SAMPLECMP-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp_level_zero' 'void (...) noexcept'
+// SAMPLECMP-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// SAMPLECMP-SAME: {{\[\[}}hlsl::resource_class("SRV"){{\]\]}}[[IS_ARRAY]] {{\[\[}}hlsl::contained_type(element_type){{\]\]}}
+// SAMPLECMP-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// SAMPLECMP-SAME: ' lvalue .__handle
+// SAMPLECMP-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
+// SAMPLECMP-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// SAMPLECMP-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// SAMPLECMP-SAME: ' lvalue .__handle
+// SAMPLECMP-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// SAMPLECMP-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// SAMPLECMP-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// SAMPLECMP-NEXT: AlwaysInlineAttr
 
-// OFFSET: CXXMethodDecl {{.*}} SampleCmpLevelZero 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: CompoundStmt
-// OFFSET-NEXT: ReturnStmt
-// OFFSET-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
-// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp_level_zero' 'void (...) noexcept'
-// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// SAMPLECMP-OFFSET: CXXMethodDecl {{.*}} SampleCmpLevelZero 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: CompoundStmt
+// SAMPLECMP-OFFSET-NEXT: ReturnStmt
+// SAMPLECMP-OFFSET-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
+// SAMPLECMP-OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp_level_zero' 'void (...) noexcept'
+// SAMPLECMP-OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// SAMPLECMP-OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
-// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// OFFSET-SAME: ' lvalue .__handle
-// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
-// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// OFFSET-SAME: ' lvalue .__handle
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: AlwaysInlineAttr
+// SAMPLECMP-OFFSET-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// SAMPLECMP-OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// SAMPLECMP-OFFSET-SAME: ' lvalue .__handle
+// SAMPLECMP-OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<element_type>' lvalue implicit this
+// SAMPLECMP-OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// SAMPLECMP-OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// SAMPLECMP-OFFSET-SAME: ' lvalue .__handle
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} CalculateLevelOfDetail 'float (hlsl::SamplerState, vector<float, [[DIM]]>)'
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
@@ -658,287 +676,287 @@
 // GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'numberOfLevels' 'float &__restrict'
 // GETDIM-XY-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} Gather 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
-// CHECK-NEXT: AlwaysInlineAttr
+// GATHER: CXXMethodDecl {{.*}} Gather 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
+// GATHER-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// GATHER-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: CompoundStmt
+// GATHER-NEXT: ReturnStmt
+// GATHER-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// GATHER-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
+// GATHER-NEXT: AlwaysInlineAttr
 
-// OFFSET: CXXMethodDecl {{.*}} Gather 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
-// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: CompoundStmt
-// OFFSET-NEXT: ReturnStmt
-// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: AlwaysInlineAttr
+// GATHER-OFFSET: CXXMethodDecl {{.*}} Gather 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: CompoundStmt
+// GATHER-OFFSET-NEXT: ReturnStmt
+// GATHER-OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// GATHER-OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherRed 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
-// CHECK-NEXT: AlwaysInlineAttr
+// GATHER: CXXMethodDecl {{.*}} GatherRed 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
+// GATHER-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// GATHER-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: CompoundStmt
+// GATHER-NEXT: ReturnStmt
+// GATHER-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// GATHER-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
+// GATHER-NEXT: AlwaysInlineAttr
 
-// OFFSET: CXXMethodDecl {{.*}} GatherRed 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
-// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: CompoundStmt
-// OFFSET-NEXT: ReturnStmt
-// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: AlwaysInlineAttr
+// GATHER-OFFSET: CXXMethodDecl {{.*}} GatherRed 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: CompoundStmt
+// GATHER-OFFSET-NEXT: ReturnStmt
+// GATHER-OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// GATHER-OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherGreen 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 1
-// CHECK-NEXT: AlwaysInlineAttr
+// GATHER: CXXMethodDecl {{.*}} GatherGreen 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
+// GATHER-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// GATHER-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: CompoundStmt
+// GATHER-NEXT: ReturnStmt
+// GATHER-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// GATHER-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: IntegerLiteral {{.*}} 'unsigned int' 1
+// GATHER-NEXT: AlwaysInlineAttr
 
-// OFFSET: CXXMethodDecl {{.*}} GatherGreen 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
-// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: CompoundStmt
-// OFFSET-NEXT: ReturnStmt
-// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 1
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: AlwaysInlineAttr
+// GATHER-OFFSET: CXXMethodDecl {{.*}} GatherGreen 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: CompoundStmt
+// GATHER-OFFSET-NEXT: ReturnStmt
+// GATHER-OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// GATHER-OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 1
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherBlue 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 2
-// CHECK-NEXT: AlwaysInlineAttr
+// GATHER: CXXMethodDecl {{.*}} GatherBlue 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
+// GATHER-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// GATHER-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: CompoundStmt
+// GATHER-NEXT: ReturnStmt
+// GATHER-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// GATHER-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: IntegerLiteral {{.*}} 'unsigned int' 2
+// GATHER-NEXT: AlwaysInlineAttr
 
-// OFFSET: CXXMethodDecl {{.*}} GatherBlue 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
-// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: CompoundStmt
-// OFFSET-NEXT: ReturnStmt
-// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 2
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: AlwaysInlineAttr
+// GATHER-OFFSET: CXXMethodDecl {{.*}} GatherBlue 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: CompoundStmt
+// GATHER-OFFSET-NEXT: ReturnStmt
+// GATHER-OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// GATHER-OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 2
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherAlpha 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 3
-// CHECK-NEXT: AlwaysInlineAttr
+// GATHER: CXXMethodDecl {{.*}} GatherAlpha 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
+// GATHER-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// GATHER-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: CompoundStmt
+// GATHER-NEXT: ReturnStmt
+// GATHER-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// GATHER-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: IntegerLiteral {{.*}} 'unsigned int' 3
+// GATHER-NEXT: AlwaysInlineAttr
 
-// OFFSET: CXXMethodDecl {{.*}} GatherAlpha 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
-// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: CompoundStmt
-// OFFSET-NEXT: ReturnStmt
-// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 3
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: AlwaysInlineAttr
+// GATHER-OFFSET: CXXMethodDecl {{.*}} GatherAlpha 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: CompoundStmt
+// GATHER-OFFSET-NEXT: ReturnStmt
+// GATHER-OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// GATHER-OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 3
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherCmp 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
-// CHECK-NEXT: AlwaysInlineAttr
+// GATHER: CXXMethodDecl {{.*}} GatherCmp 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)' inline
+// GATHER-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// GATHER-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// GATHER-NEXT: CompoundStmt
+// GATHER-NEXT: ReturnStmt
+// GATHER-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
+// GATHER-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// GATHER-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
+// GATHER-NEXT: AlwaysInlineAttr
 
-// OFFSET: CXXMethodDecl {{.*}} GatherCmp 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)' inline
-// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: CompoundStmt
-// OFFSET-NEXT: ReturnStmt
-// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
-// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: AlwaysInlineAttr
+// GATHER-OFFSET: CXXMethodDecl {{.*}} GatherCmp 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)' inline
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: CompoundStmt
+// GATHER-OFFSET-NEXT: ReturnStmt
+// GATHER-OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
+// GATHER-OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// GATHER-OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherCmpRed 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
-// CHECK-NEXT: AlwaysInlineAttr
+// GATHER: CXXMethodDecl {{.*}} GatherCmpRed 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)' inline
+// GATHER-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// GATHER-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// GATHER-NEXT: CompoundStmt
+// GATHER-NEXT: ReturnStmt
+// GATHER-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
+// GATHER-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// GATHER-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
+// GATHER-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherCmpGreen 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 1
-// CHECK-NEXT: AlwaysInlineAttr
+// GATHER: CXXMethodDecl {{.*}} GatherCmpGreen 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)' inline
+// GATHER-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// GATHER-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// GATHER-NEXT: CompoundStmt
+// GATHER-NEXT: ReturnStmt
+// GATHER-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
+// GATHER-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// GATHER-NEXT: IntegerLiteral {{.*}} 'unsigned int' 1
+// GATHER-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherCmpBlue 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 2
-// CHECK-NEXT: AlwaysInlineAttr
+// GATHER: CXXMethodDecl {{.*}} GatherCmpBlue 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)' inline
+// GATHER-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// GATHER-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// GATHER-NEXT: CompoundStmt
+// GATHER-NEXT: ReturnStmt
+// GATHER-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
+// GATHER-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// GATHER-NEXT: IntegerLiteral {{.*}} 'unsigned int' 2
+// GATHER-NEXT: AlwaysInlineAttr
 
-// OFFSET: CXXMethodDecl {{.*}} GatherCmpAlpha 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)' inline
-// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: CompoundStmt
-// OFFSET-NEXT: ReturnStmt
-// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
-// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 3
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: AlwaysInlineAttr
+// GATHER-OFFSET: CXXMethodDecl {{.*}} GatherCmpAlpha 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)' inline
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: CompoundStmt
+// GATHER-OFFSET-NEXT: ReturnStmt
+// GATHER-OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
+// GATHER-OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// GATHER-OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 3
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: AlwaysInlineAttr
 
 TEXTURE<float> t;
 SamplerState s;
@@ -949,11 +967,15 @@ void main(COORD_TYPE loc, float cmp) {
   t.SampleBias(s, loc, 0.0);
   t.SampleGrad(s, loc, (GRAD_TYPE)0, (GRAD_TYPE)0);
   t.SampleLevel(s, loc, 0.0);
+#ifdef HAS_SAMPLE_CMP
   t.SampleCmp(scs, loc, cmp);
   t.SampleCmpLevelZero(scs, loc, cmp);
+#endif
   t.CalculateLevelOfDetail(s, LOD_LOCATION);
   t.CalculateLevelOfDetailUnclamped(s, LOD_LOCATION);
+#ifdef HAS_GATHER
   t.Gather(s, loc);
+#endif
 
 #ifdef HAS_OFFSET
   t.Sample(s, loc, OFFSET_ARG);
@@ -963,9 +985,11 @@ void main(COORD_TYPE loc, float cmp) {
   t.SampleGrad(s, loc, (GRAD_TYPE)0, (GRAD_TYPE)0, OFFSET_ARG);
   t.SampleGrad(s, loc, (GRAD_TYPE)0, (GRAD_TYPE)0, OFFSET_ARG, 1.0);
   t.SampleLevel(s, loc, 0.0, OFFSET_ARG);
+#ifdef HAS_SAMPLE_CMP
   t.SampleCmp(scs, loc, cmp, OFFSET_ARG);
   t.SampleCmp(scs, loc, cmp, OFFSET_ARG, 1.0f);
   t.SampleCmpLevelZero(scs, loc, cmp, OFFSET_ARG);
+#endif
 #endif
 
 #ifdef HAS_GETDIM_XY

--- a/clang/test/AST/HLSL/Textures-scalar-AST.hlsl
+++ b/clang/test/AST/HLSL/Textures-scalar-AST.hlsl
@@ -989,8 +989,8 @@ void main(COORD_TYPE loc, float cmp) {
   t.SampleCmp(scs, loc, cmp, OFFSET_ARG);
   t.SampleCmp(scs, loc, cmp, OFFSET_ARG, 1.0f);
   t.SampleCmpLevelZero(scs, loc, cmp, OFFSET_ARG);
-#endif
-#endif
+#endif // HAS_SAMPLE_CMP
+#endif // HAS_OFFSET
 
 #ifdef HAS_GETDIM_XY
   uint u_w, u_h, u_l;

--- a/clang/test/AST/HLSL/Textures-shorthand-AST.hlsl
+++ b/clang/test/AST/HLSL/Textures-shorthand-AST.hlsl
@@ -14,6 +14,10 @@
 // RUN:   -disable-llvm-passes -finclude-default-header \
 // RUN:   -DTEXTURE=Texture2DArray -o - %s \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2DArray
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -ast-dump \
+// RUN:   -disable-llvm-passes -finclude-default-header -DTEXTURE=Texture3D \
+// RUN:   -o - %s \
+// RUN:   | FileCheck %s -DTEXTURE=Texture3D
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.

--- a/clang/test/AST/HLSL/Textures-vector-AST.hlsl
+++ b/clang/test/AST/HLSL/Textures-vector-AST.hlsl
@@ -1,32 +1,43 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -ast-dump \
 // RUN:   -disable-llvm-passes -finclude-default-header -DHAS_OFFSET \
-// RUN:   -DHAS_GETDIM_XY -DTEXTURE=Texture2D -DCOORD_TYPE=float2 \
-// RUN:   -DGRAD_TYPE=float2 -DLOD_LOCATION=loc -DOFFSET_ARG="int2(1, 2)" -o - \
-// RUN:   %s \
-// RUN:   | FileCheck %s --check-prefixes=CHECK,TEXEL,OFFSET,GETDIM-XY \
+// RUN:   -DHAS_GETDIM_XY -DHAS_SAMPLE_CMP -DHAS_GATHER -DTEXTURE=Texture2D \
+// RUN:   -DCOORD_TYPE=float2 -DGRAD_TYPE=float2 -DLOD_LOCATION=loc \
+// RUN:   -DOFFSET_ARG="int2(1, 2)" -o - %s \
+// RUN:   | FileCheck %s \
+// RUN:   --check-prefixes=CHECK,TEXEL,OFFSET,GETDIM-XY,SAMPLECMP,SAMPLECMP-OFFSET,GATHER,GATHER-OFFSET \
 // RUN:   -DTEXTURE=Texture2D -DDIM_NAME=2D -DDIM=2 -DCOORD_DIM=2 -DLOAD_DIM=3 \
 // RUN:   -DINDEX_TYPE="vector<unsigned int, 2>" -DIS_ARRAY=""
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -ast-dump \
-// RUN:   -disable-llvm-passes -finclude-default-header -DTEXTURE=TextureCube \
-// RUN:   -DCOORD_TYPE=float3 -DGRAD_TYPE=float3 -DLOD_LOCATION=loc -o - %s \
-// RUN:   | FileCheck %s --check-prefixes=CHECK -DTEXTURE=TextureCube \
-// RUN:   -DDIM_NAME=Cube -DDIM=3 -DCOORD_DIM=3 -DIS_ARRAY=""
+// RUN:   -disable-llvm-passes -finclude-default-header -DHAS_SAMPLE_CMP \
+// RUN:   -DHAS_GATHER -DTEXTURE=TextureCube -DCOORD_TYPE=float3 \
+// RUN:   -DGRAD_TYPE=float3 -DLOD_LOCATION=loc -o - %s \
+// RUN:   | FileCheck %s --check-prefixes=CHECK,SAMPLECMP,GATHER \
+// RUN:   -DTEXTURE=TextureCube -DDIM_NAME=Cube -DDIM=3 -DCOORD_DIM=3 \
+// RUN:   -DIS_ARRAY=""
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -ast-dump \
-// RUN:   -disable-llvm-passes -finclude-default-header \
-// RUN:   -DTEXTURE=TextureCubeArray -DCOORD_TYPE=float4 -DGRAD_TYPE=float3 \
-// RUN:   -DLOD_LOCATION=loc.xyz -o - %s \
-// RUN:   | FileCheck %s --check-prefixes=CHECK -DTEXTURE=TextureCubeArray \
-// RUN:   -DDIM_NAME=Cube -DDIM=3 -DCOORD_DIM=4 \
+// RUN:   -disable-llvm-passes -finclude-default-header -DHAS_SAMPLE_CMP \
+// RUN:   -DHAS_GATHER -DTEXTURE=TextureCubeArray -DCOORD_TYPE=float4 \
+// RUN:   -DGRAD_TYPE=float3 -DLOD_LOCATION=loc.xyz -o - %s \
+// RUN:   | FileCheck %s --check-prefixes=CHECK,SAMPLECMP,GATHER \
+// RUN:   -DTEXTURE=TextureCubeArray -DDIM_NAME=Cube -DDIM=3 -DCOORD_DIM=4 \
 // RUN:   -DIS_ARRAY=" [[hlsl::is_array]]"
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -ast-dump \
 // RUN:   -disable-llvm-passes -finclude-default-header -DHAS_OFFSET \
-// RUN:   -DHAS_GETDIM_XY -DTEXTURE=Texture2DArray -DCOORD_TYPE=float3 \
-// RUN:   -DGRAD_TYPE=float2 -DLOD_LOCATION=loc.xy -DOFFSET_ARG="int2(1, 2)" \
-// RUN:   -o - %s \
-// RUN:   | FileCheck %s --check-prefixes=CHECK,ARRAY,TEXEL,OFFSET,GETDIM-XY \
+// RUN:   -DHAS_GETDIM_XY -DHAS_SAMPLE_CMP -DHAS_GATHER \
+// RUN:   -DTEXTURE=Texture2DArray -DCOORD_TYPE=float3 -DGRAD_TYPE=float2 \
+// RUN:   -DLOD_LOCATION=loc.xy -DOFFSET_ARG="int2(1, 2)" -o - %s \
+// RUN:   | FileCheck %s \
+// RUN:   --check-prefixes=CHECK,ARRAY,TEXEL,OFFSET,GETDIM-XY,SAMPLECMP,SAMPLECMP-OFFSET,GATHER,GATHER-OFFSET \
 // RUN:   -DTEXTURE=Texture2DArray -DDIM_NAME=2D -DDIM=2 -DCOORD_DIM=3 \
 // RUN:   -DLOAD_DIM=4 -DINDEX_TYPE="vector<unsigned int, 3>" \
 // RUN:   -DIS_ARRAY=" [[hlsl::is_array]]"
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -ast-dump \
+// RUN:   -disable-llvm-passes -finclude-default-header -DHAS_OFFSET \
+// RUN:   -DTEXTURE=Texture3D -DCOORD_TYPE=float3 -DGRAD_TYPE=float3 \
+// RUN:   -DLOD_LOCATION=loc -DOFFSET_ARG="int3(1, 2, 3)" -o - %s \
+// RUN:   | FileCheck %s --check-prefixes=CHECK,TEXEL,OFFSET \
+// RUN:   -DTEXTURE=Texture3D -DDIM_NAME=3D -DDIM=3 -DCOORD_DIM=3 -DLOAD_DIM=4 \
+// RUN:   -DINDEX_TYPE="vector<unsigned int, 3>" -DIS_ARRAY=""
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
@@ -35,6 +46,9 @@
 //                      have overloads taking an offset
 //   HAS_GETDIM_XY      defined for types that have the width/height
 //                      GetDimensions overloads
+//   HAS_SAMPLE_CMP     defined for types that have the comparison sampling
+//                      methods
+//   HAS_GATHER         defined for types that have the Gather* methods
 //   TEXTURE            resource type name
 //   COORD_TYPE         sample location type (DIM components plus the array
 //                      slice)
@@ -56,6 +70,10 @@
 //   OFFSET             the sampling and gathering methods have offset
 //                      overloads
 //   GETDIM-XY          the width/height GetDimensions overloads exist
+//   SAMPLECMP          the comparison sampling methods exist
+//   SAMPLECMP-OFFSET   the comparison sampling methods have offset overloads
+//   GATHER             the Gather* methods exist
+//   GATHER-OFFSET      the Gather* methods have offset overloads
 //   ARRAY              the resource has an array slice
 //   IS_ARRAY           the [[hlsl::is_array]] attribute on arrayed resources,
 //                      or empty
@@ -67,7 +85,7 @@
 
 // CHECK: CXXRecordDecl {{.*}} SamplerComparisonState definition
 // CHECK: FinalAttr {{.*}} Implicit final
-// CHECK-NEXT: FieldDecl {{.*}} implicit {{.*}} __handle '__hlsl_resource_t
+// CHECK-NEXT: FieldDecl {{.*}} implicit {{.*}}__handle '__hlsl_resource_t
 // CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
 
 // CHECK: ClassTemplateDecl {{.*}} [[TEXTURE]]
@@ -412,129 +430,129 @@
 // OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
 // OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} SampleCmp 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME: {{\[\[}}hlsl::resource_class("SRV"){{\]\]}}[[IS_ARRAY]] {{\[\[}}hlsl::contained_type(vector<element_type, element_count>){{\]\]}}
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// CHECK-NEXT: AlwaysInlineAttr
+// SAMPLECMP: CXXMethodDecl {{.*}} SampleCmp 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)'
+// SAMPLECMP-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// SAMPLECMP-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// SAMPLECMP-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// SAMPLECMP-NEXT: CompoundStmt
+// SAMPLECMP-NEXT: ReturnStmt
+// SAMPLECMP-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
+// SAMPLECMP-NEXT: CallExpr {{.*}} '<dependent type>'
+// SAMPLECMP-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp' 'void (...) noexcept'
+// SAMPLECMP-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// SAMPLECMP-SAME: {{\[\[}}hlsl::resource_class("SRV"){{\]\]}}[[IS_ARRAY]] {{\[\[}}hlsl::contained_type(vector<element_type, element_count>){{\]\]}}
+// SAMPLECMP-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// SAMPLECMP-SAME: ' lvalue .__handle
+// SAMPLECMP-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
+// SAMPLECMP-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// SAMPLECMP-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// SAMPLECMP-SAME: ' lvalue .__handle
+// SAMPLECMP-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// SAMPLECMP-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// SAMPLECMP-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// SAMPLECMP-NEXT: AlwaysInlineAttr
 
-// OFFSET: CXXMethodDecl {{.*}} SampleCmp 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: CompoundStmt
-// OFFSET-NEXT: ReturnStmt
-// OFFSET-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
-// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp' 'void (...) noexcept'
-// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// SAMPLECMP-OFFSET: CXXMethodDecl {{.*}} SampleCmp 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: CompoundStmt
+// SAMPLECMP-OFFSET-NEXT: ReturnStmt
+// SAMPLECMP-OFFSET-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
+// SAMPLECMP-OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp' 'void (...) noexcept'
+// SAMPLECMP-OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// SAMPLECMP-OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
-// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// OFFSET-SAME: ' lvalue .__handle
-// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
-// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// OFFSET-SAME: ' lvalue .__handle
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: AlwaysInlineAttr
+// SAMPLECMP-OFFSET-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
+// SAMPLECMP-OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// SAMPLECMP-OFFSET-SAME: ' lvalue .__handle
+// SAMPLECMP-OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
+// SAMPLECMP-OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// SAMPLECMP-OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// SAMPLECMP-OFFSET-SAME: ' lvalue .__handle
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: AlwaysInlineAttr
 
-// OFFSET: CXXMethodDecl {{.*}} SampleCmp 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>, float)'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Clamp 'float'
-// OFFSET-NEXT: CompoundStmt
-// OFFSET-NEXT: ReturnStmt
-// OFFSET-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
-// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp' 'void (...) noexcept'
-// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// SAMPLECMP-OFFSET: CXXMethodDecl {{.*}} SampleCmp 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>, float)'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} Clamp 'float'
+// SAMPLECMP-OFFSET-NEXT: CompoundStmt
+// SAMPLECMP-OFFSET-NEXT: ReturnStmt
+// SAMPLECMP-OFFSET-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
+// SAMPLECMP-OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp' 'void (...) noexcept'
+// SAMPLECMP-OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// SAMPLECMP-OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
-// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// OFFSET-SAME: ' lvalue .__handle
-// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
-// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// OFFSET-SAME: ' lvalue .__handle
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Clamp' 'float'
-// OFFSET-NEXT: AlwaysInlineAttr
+// SAMPLECMP-OFFSET-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
+// SAMPLECMP-OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// SAMPLECMP-OFFSET-SAME: ' lvalue .__handle
+// SAMPLECMP-OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
+// SAMPLECMP-OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// SAMPLECMP-OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// SAMPLECMP-OFFSET-SAME: ' lvalue .__handle
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'Clamp' 'float'
+// SAMPLECMP-OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} SampleCmpLevelZero 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)'
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp_level_zero' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME: {{\[\[}}hlsl::resource_class("SRV"){{\]\]}}[[IS_ARRAY]] {{\[\[}}hlsl::contained_type(vector<element_type, element_count>){{\]\]}}
-// CHECK-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// CHECK-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// CHECK-SAME: ' lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// CHECK-NEXT: AlwaysInlineAttr
+// SAMPLECMP: CXXMethodDecl {{.*}} SampleCmpLevelZero 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)'
+// SAMPLECMP-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// SAMPLECMP-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// SAMPLECMP-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// SAMPLECMP-NEXT: CompoundStmt
+// SAMPLECMP-NEXT: ReturnStmt
+// SAMPLECMP-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
+// SAMPLECMP-NEXT: CallExpr {{.*}} '<dependent type>'
+// SAMPLECMP-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp_level_zero' 'void (...) noexcept'
+// SAMPLECMP-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// SAMPLECMP-SAME: {{\[\[}}hlsl::resource_class("SRV"){{\]\]}}[[IS_ARRAY]] {{\[\[}}hlsl::contained_type(vector<element_type, element_count>){{\]\]}}
+// SAMPLECMP-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// SAMPLECMP-SAME: ' lvalue .__handle
+// SAMPLECMP-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
+// SAMPLECMP-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// SAMPLECMP-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// SAMPLECMP-SAME: ' lvalue .__handle
+// SAMPLECMP-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// SAMPLECMP-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// SAMPLECMP-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// SAMPLECMP-NEXT: AlwaysInlineAttr
 
-// OFFSET: CXXMethodDecl {{.*}} SampleCmpLevelZero 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: CompoundStmt
-// OFFSET-NEXT: ReturnStmt
-// OFFSET-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
-// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp_level_zero' 'void (...) noexcept'
-// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
+// SAMPLECMP-OFFSET: CXXMethodDecl {{.*}} SampleCmpLevelZero 'float (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// SAMPLECMP-OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: CompoundStmt
+// SAMPLECMP-OFFSET-NEXT: ReturnStmt
+// SAMPLECMP-OFFSET-NEXT: CStyleCastExpr {{.*}} 'float' <Dependent>
+// SAMPLECMP-OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_sample_cmp_level_zero' 'void (...) noexcept'
+// SAMPLECMP-OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// SAMPLECMP-OFFSET-SAME{LITERAL}: [[hlsl::resource_class("SRV")]]
 // ARRAY-SAME{LITERAL}: [[hlsl::is_array]]
-// OFFSET-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
-// OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
-// OFFSET-SAME: ' lvalue .__handle
-// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
-// OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
-// OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
-// OFFSET-SAME: ' lvalue .__handle
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: AlwaysInlineAttr
+// SAMPLECMP-OFFSET-SAME{LITERAL}: [[hlsl::contained_type(vector<element_type, element_count>)]]
+// SAMPLECMP-OFFSET-SAME: {{\[\[}}hlsl::dimension("[[DIM_NAME]]"){{\]\]}}
+// SAMPLECMP-OFFSET-SAME: ' lvalue .__handle
+// SAMPLECMP-OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<vector<element_type, element_count>>' lvalue implicit this
+// SAMPLECMP-OFFSET-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// SAMPLECMP-OFFSET-SAME{LITERAL}: [[hlsl::resource_class("Sampler")]]
+// SAMPLECMP-OFFSET-SAME: ' lvalue .__handle
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// SAMPLECMP-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// SAMPLECMP-OFFSET-NEXT: AlwaysInlineAttr
 
 // CHECK: CXXMethodDecl {{.*}} CalculateLevelOfDetail 'float (hlsl::SamplerState, vector<float, [[DIM]]>)'
 // CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
@@ -658,287 +676,287 @@
 // GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'height' 'float &__restrict'
 // GETDIM-XY-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'numberOfLevels' 'float &__restrict'
 
-// CHECK: CXXMethodDecl {{.*}} Gather 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
-// CHECK-NEXT: AlwaysInlineAttr
+// GATHER: CXXMethodDecl {{.*}} Gather 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
+// GATHER-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// GATHER-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: CompoundStmt
+// GATHER-NEXT: ReturnStmt
+// GATHER-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// GATHER-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
+// GATHER-NEXT: AlwaysInlineAttr
 
-// OFFSET: CXXMethodDecl {{.*}} Gather 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
-// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: CompoundStmt
-// OFFSET-NEXT: ReturnStmt
-// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: AlwaysInlineAttr
+// GATHER-OFFSET: CXXMethodDecl {{.*}} Gather 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: CompoundStmt
+// GATHER-OFFSET-NEXT: ReturnStmt
+// GATHER-OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// GATHER-OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherRed 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
-// CHECK-NEXT: AlwaysInlineAttr
+// GATHER: CXXMethodDecl {{.*}} GatherRed 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
+// GATHER-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// GATHER-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: CompoundStmt
+// GATHER-NEXT: ReturnStmt
+// GATHER-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// GATHER-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
+// GATHER-NEXT: AlwaysInlineAttr
 
-// OFFSET: CXXMethodDecl {{.*}} GatherRed 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
-// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: CompoundStmt
-// OFFSET-NEXT: ReturnStmt
-// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: AlwaysInlineAttr
+// GATHER-OFFSET: CXXMethodDecl {{.*}} GatherRed 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: CompoundStmt
+// GATHER-OFFSET-NEXT: ReturnStmt
+// GATHER-OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// GATHER-OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherGreen 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 1
-// CHECK-NEXT: AlwaysInlineAttr
+// GATHER: CXXMethodDecl {{.*}} GatherGreen 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
+// GATHER-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// GATHER-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: CompoundStmt
+// GATHER-NEXT: ReturnStmt
+// GATHER-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// GATHER-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: IntegerLiteral {{.*}} 'unsigned int' 1
+// GATHER-NEXT: AlwaysInlineAttr
 
-// OFFSET: CXXMethodDecl {{.*}} GatherGreen 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
-// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: CompoundStmt
-// OFFSET-NEXT: ReturnStmt
-// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 1
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: AlwaysInlineAttr
+// GATHER-OFFSET: CXXMethodDecl {{.*}} GatherGreen 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: CompoundStmt
+// GATHER-OFFSET-NEXT: ReturnStmt
+// GATHER-OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// GATHER-OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 1
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherBlue 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 2
-// CHECK-NEXT: AlwaysInlineAttr
+// GATHER: CXXMethodDecl {{.*}} GatherBlue 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
+// GATHER-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// GATHER-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: CompoundStmt
+// GATHER-NEXT: ReturnStmt
+// GATHER-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// GATHER-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: IntegerLiteral {{.*}} 'unsigned int' 2
+// GATHER-NEXT: AlwaysInlineAttr
 
-// OFFSET: CXXMethodDecl {{.*}} GatherBlue 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
-// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: CompoundStmt
-// OFFSET-NEXT: ReturnStmt
-// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 2
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: AlwaysInlineAttr
+// GATHER-OFFSET: CXXMethodDecl {{.*}} GatherBlue 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: CompoundStmt
+// GATHER-OFFSET-NEXT: ReturnStmt
+// GATHER-OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// GATHER-OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 2
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherAlpha 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 3
-// CHECK-NEXT: AlwaysInlineAttr
+// GATHER: CXXMethodDecl {{.*}} GatherAlpha 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>)' inline
+// GATHER-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// GATHER-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: CompoundStmt
+// GATHER-NEXT: ReturnStmt
+// GATHER-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// GATHER-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: IntegerLiteral {{.*}} 'unsigned int' 3
+// GATHER-NEXT: AlwaysInlineAttr
 
-// OFFSET: CXXMethodDecl {{.*}} GatherAlpha 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
-// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: CompoundStmt
-// OFFSET-NEXT: ReturnStmt
-// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
-// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 3
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: AlwaysInlineAttr
+// GATHER-OFFSET: CXXMethodDecl {{.*}} GatherAlpha 'vector<element_type, 4> (hlsl::SamplerState, vector<float, [[COORD_DIM]]>, vector<int, [[DIM]]>)' inline
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerState'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: CompoundStmt
+// GATHER-OFFSET-NEXT: ReturnStmt
+// GATHER-OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<element_type, 4>' <Dependent>
+// GATHER-OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather' 'void (...) noexcept'
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerState'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 3
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherCmp 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
-// CHECK-NEXT: AlwaysInlineAttr
+// GATHER: CXXMethodDecl {{.*}} GatherCmp 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)' inline
+// GATHER-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// GATHER-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// GATHER-NEXT: CompoundStmt
+// GATHER-NEXT: ReturnStmt
+// GATHER-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
+// GATHER-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// GATHER-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
+// GATHER-NEXT: AlwaysInlineAttr
 
-// OFFSET: CXXMethodDecl {{.*}} GatherCmp 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)' inline
-// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: CompoundStmt
-// OFFSET-NEXT: ReturnStmt
-// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
-// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: AlwaysInlineAttr
+// GATHER-OFFSET: CXXMethodDecl {{.*}} GatherCmp 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)' inline
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: CompoundStmt
+// GATHER-OFFSET-NEXT: ReturnStmt
+// GATHER-OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
+// GATHER-OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// GATHER-OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherCmpRed 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
-// CHECK-NEXT: AlwaysInlineAttr
+// GATHER: CXXMethodDecl {{.*}} GatherCmpRed 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)' inline
+// GATHER-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// GATHER-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// GATHER-NEXT: CompoundStmt
+// GATHER-NEXT: ReturnStmt
+// GATHER-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
+// GATHER-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// GATHER-NEXT: IntegerLiteral {{.*}} 'unsigned int' 0
+// GATHER-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherCmpGreen 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 1
-// CHECK-NEXT: AlwaysInlineAttr
+// GATHER: CXXMethodDecl {{.*}} GatherCmpGreen 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)' inline
+// GATHER-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// GATHER-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// GATHER-NEXT: CompoundStmt
+// GATHER-NEXT: ReturnStmt
+// GATHER-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
+// GATHER-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// GATHER-NEXT: IntegerLiteral {{.*}} 'unsigned int' 1
+// GATHER-NEXT: AlwaysInlineAttr
 
-// CHECK: CXXMethodDecl {{.*}} GatherCmpBlue 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)' inline
-// CHECK-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: ReturnStmt
-// CHECK-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
-// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// CHECK-NEXT: MemberExpr {{.*}} lvalue .__handle
-// CHECK-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// CHECK-NEXT: IntegerLiteral {{.*}} 'unsigned int' 2
-// CHECK-NEXT: AlwaysInlineAttr
+// GATHER: CXXMethodDecl {{.*}} GatherCmpBlue 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float)' inline
+// GATHER-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// GATHER-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// GATHER-NEXT: CompoundStmt
+// GATHER-NEXT: ReturnStmt
+// GATHER-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
+// GATHER-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// GATHER-NEXT: IntegerLiteral {{.*}} 'unsigned int' 2
+// GATHER-NEXT: AlwaysInlineAttr
 
-// OFFSET: CXXMethodDecl {{.*}} GatherCmpAlpha 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)' inline
-// OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
-// OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: CompoundStmt
-// OFFSET-NEXT: ReturnStmt
-// OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
-// OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
-// OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
-// OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 3
-// OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
-// OFFSET-NEXT: AlwaysInlineAttr
+// GATHER-OFFSET: CXXMethodDecl {{.*}} GatherCmpAlpha 'vector<float, 4> (hlsl::SamplerComparisonState, vector<float, [[COORD_DIM]]>, float, vector<int, [[DIM]]>)' inline
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Sampler 'hlsl::SamplerComparisonState'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Location 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} CompareValue 'float'
+// GATHER-OFFSET-NEXT: ParmVarDecl {{.*}} Offset 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: CompoundStmt
+// GATHER-OFFSET-NEXT: ReturnStmt
+// GATHER-OFFSET-NEXT: CStyleCastExpr {{.*}} 'vector<float, 4>' <Dependent>
+// GATHER-OFFSET-NEXT: CallExpr {{.*}} '<dependent type>'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_resource_gather_cmp' 'void (...) noexcept'
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: CXXThisExpr {{.*}} 'hlsl::[[TEXTURE]]<{{.*}}>' lvalue implicit this
+// GATHER-OFFSET-NEXT: MemberExpr {{.*}} lvalue .__handle
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'hlsl::SamplerComparisonState' lvalue ParmVar {{.*}} 'Sampler' 'hlsl::SamplerComparisonState'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<float, [[COORD_DIM]]>' lvalue ParmVar {{.*}} 'Location' 'vector<float, [[COORD_DIM]]>'
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'float' lvalue ParmVar {{.*}} 'CompareValue' 'float'
+// GATHER-OFFSET-NEXT: IntegerLiteral {{.*}} 'unsigned int' 3
+// GATHER-OFFSET-NEXT: DeclRefExpr {{.*}} 'vector<int, [[DIM]]>' lvalue ParmVar {{.*}} 'Offset' 'vector<int, [[DIM]]>'
+// GATHER-OFFSET-NEXT: AlwaysInlineAttr
 
 TEXTURE<float4> t;
 SamplerState s;
@@ -949,11 +967,15 @@ void main(COORD_TYPE loc, float cmp) {
   t.SampleBias(s, loc, 0.0);
   t.SampleGrad(s, loc, (GRAD_TYPE)0, (GRAD_TYPE)0);
   t.SampleLevel(s, loc, 0.0);
+#ifdef HAS_SAMPLE_CMP
   t.SampleCmp(scs, loc, cmp);
   t.SampleCmpLevelZero(scs, loc, cmp);
+#endif
   t.CalculateLevelOfDetail(s, LOD_LOCATION);
   t.CalculateLevelOfDetailUnclamped(s, LOD_LOCATION);
+#ifdef HAS_GATHER
   t.Gather(s, loc);
+#endif
 
 #ifdef HAS_OFFSET
   t.Sample(s, loc, OFFSET_ARG);
@@ -963,9 +985,11 @@ void main(COORD_TYPE loc, float cmp) {
   t.SampleGrad(s, loc, (GRAD_TYPE)0, (GRAD_TYPE)0, OFFSET_ARG);
   t.SampleGrad(s, loc, (GRAD_TYPE)0, (GRAD_TYPE)0, OFFSET_ARG, 1.0);
   t.SampleLevel(s, loc, 0.0, OFFSET_ARG);
+#ifdef HAS_SAMPLE_CMP
   t.SampleCmp(scs, loc, cmp, OFFSET_ARG);
   t.SampleCmp(scs, loc, cmp, OFFSET_ARG, 1.0f);
   t.SampleCmpLevelZero(scs, loc, cmp, OFFSET_ARG);
+#endif
 #endif
 
 #ifdef HAS_GETDIM_XY

--- a/clang/test/CodeGenHLSL/resources/Textures-CalculateLevelOfDetail.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-CalculateLevelOfDetail.hlsl
@@ -6,6 +6,12 @@
 // RUN:   -DDXIL_TY=2 -DRW=0 -DDIM=2
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - -DLOD_TYPE=float3 \
+// RUN:   -DTEXTURE=Texture3D %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture3D --check-prefixes=CHECK,DXIL \
+// RUN:   -DDXIL_TY=4 -DRW=0 -DDIM=3
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - -DLOD_TYPE=float3 \
 // RUN:   -DTEXTURE=TextureCube %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=TextureCube --check-prefixes=CHECK,DXIL \
@@ -22,6 +28,12 @@
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2D --check-prefixes=CHECK,SPIRV \
 // RUN:   -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=1 -DDIM=2
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - -DLOD_TYPE=float3 \
+// RUN:   -DTEXTURE=Texture3D %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture3D --check-prefixes=CHECK,SPIRV \
+// RUN:   -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=2 -DDIM=3
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - -DLOD_TYPE=float3 \
 // RUN:   -DTEXTURE=TextureCube %s \

--- a/clang/test/CodeGenHLSL/resources/Textures-Load.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-Load.hlsl
@@ -28,6 +28,15 @@
 // RUN:   -DTEXTURE=Texture2DArray -D#LOAD_DIM=4 -DCOORD_DIM=3 \
 // RUN:   -DCOORD_MASK="<i32 0, i32 1, i32 2>" -DDXIL_TY=7 -DRW=0 -DENTRY_DIM=2 \
 // RUN:   -DDIM=2
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -DENTRY_TYPE=int2 \
+// RUN:   -DHAS_OFFSET -DOFFSET_ARG="int3(1, 1, 1)" -DTEXTURE=Texture3D \
+// RUN:   -DLOAD_ARG="int4(loc, 0, 0)" -o - %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s --check-prefixes=CHECK,SRV,WIDE-LOC,DXIL,DXIL-SRV \
+// RUN:   -DTEXTURE=Texture3D -D#LOAD_DIM=4 -DCOORD_DIM=3 \
+// RUN:   -DCOORD_MASK="<i32 0, i32 1, i32 2>" -DDXIL_TY=4 -DRW=0 \
+// RUN:   -DENTRY_DIM=2 -DDIM=3
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -DENTRY_TYPE=int2 \
 // RUN:   -DHAS_OFFSET -DOFFSET_ARG="int2(1, 1)" -DTEXTURE=Texture2DArray \
@@ -38,6 +47,16 @@
 // RUN:   -DCOORD_MASK="<i32 0, i32 1, i32 2>" -DARRAYED=1 -DSAMPLED=1 \
 // RUN:   -DFORMAT1=0 -DFORMAT3=0 -DFORMAT6=0 -DFORMAT21=0 -DFORMAT24=0 \
 // RUN:   -DFORMAT25=0 -DSPV_DIM=1 -DENTRY_DIM=2 -DDIM=2
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -DENTRY_TYPE=int2 \
+// RUN:   -DHAS_OFFSET -DOFFSET_ARG="int3(1, 1, 1)" -DTEXTURE=Texture3D \
+// RUN:   -DLOAD_ARG="int4(loc, 0, 0)" -o - %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s --check-prefixes=CHECK,SRV,WIDE-LOC,SPIRV,SPIRV-SRV \
+// RUN:   -DTEXTURE=Texture3D -D#LOAD_DIM=4 -DCOORD_DIM=3 \
+// RUN:   -DCOORD_MASK="<i32 0, i32 1, i32 2>" -DARRAYED=0 -DSAMPLED=1 \
+// RUN:   -DFORMAT1=0 -DFORMAT3=0 -DFORMAT6=0 -DFORMAT21=0 -DFORMAT24=0 \
+// RUN:   -DFORMAT25=0 -DSPV_DIM=2 -DENTRY_DIM=2 -DDIM=3
 
 // RWTexture2D
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
@@ -64,6 +83,13 @@
 // RUN:   | FileCheck %s --check-prefixes=CHECK,UAV,WIDE-LOC,DXIL,DXIL-UAV \
 // RUN:   -DTEXTURE=RWTexture2DArray -D#LOAD_DIM=3 -DCOORD_DIM=3 \
 // RUN:   -DDXIL_TY=7 -DRW=1 -DENTRY_DIM=2 -DDIM=2
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -DENTRY_TYPE=int2 \
+// RUN:   -DTEXTURE=RWTexture3D -DLOAD_ARG="int3(loc, 0)" -o - %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s --check-prefixes=CHECK,UAV,WIDE-LOC,DXIL,DXIL-UAV \
+// RUN:   -DTEXTURE=RWTexture3D -D#LOAD_DIM=3 -DCOORD_DIM=3 -DDXIL_TY=4 -DRW=1 \
+// RUN:   -DENTRY_DIM=2 -DDIM=3
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -DENTRY_TYPE=int2 \
 // RUN:   -DTEXTURE=RWTexture2DArray -DLOAD_ARG="int3(loc, 0)" -o - %s \
@@ -73,6 +99,14 @@
 // RUN:   -DARRAYED=1 -DSAMPLED=2 -DFORMAT1=1 -DFORMAT3=3 -DFORMAT6=6 \
 // RUN:   -DFORMAT21=21 -DFORMAT24=24 -DFORMAT25=25 -DSPV_DIM=1 -DENTRY_DIM=2 \
 // RUN:   -DDIM=2
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -DENTRY_TYPE=int2 \
+// RUN:   -DTEXTURE=RWTexture3D -DLOAD_ARG="int3(loc, 0)" -o - %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s --check-prefixes=CHECK,UAV,WIDE-LOC,SPIRV,SPIRV-UAV \
+// RUN:   -DTEXTURE=RWTexture3D -D#LOAD_DIM=3 -DCOORD_DIM=3 -DARRAYED=0 \
+// RUN:   -DSAMPLED=2 -DFORMAT1=1 -DFORMAT3=3 -DFORMAT6=6 -DFORMAT21=21 \
+// RUN:   -DFORMAT24=24 -DFORMAT25=25 -DSPV_DIM=2 -DENTRY_DIM=2 -DDIM=3
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
@@ -267,7 +301,7 @@ int test_load_int(ENTRY_TYPE loc : LOC) {
 
 // CHECK: define linkonce_odr hidden {{.*}} i32 @hlsl::[[TEXTURE]]<int>::Load(int vector[[[#LOAD_DIM]]])(ptr {{.*}} %[[THIS:.*]], <[[#LOAD_DIM]] x i32> {{.*}} %[[LOAD:.*]])
 // DXIL: %[[RES:.*]] = call i32 @llvm.dx.resource.load.level.i32.tdx.Texture_i32_{{.*}}("dx.Texture", i32, [[RW]], 0, 1, [[DXIL_TY]]) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 {{[^,]*}}, <[[DIM]] x i32> zeroinitializer)
-// SPIRV: %[[RES:.*]] = call i32 @llvm.spv.resource.load.level.i32.tspirv.SignedImage_i32_{{.*}}("spirv.SignedImage", i32, 1, 2, [[ARRAYED]], 0, [[SAMPLED]], [[FORMAT24]]) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 {{[^,]*}}, <[[DIM]] x i32> zeroinitializer)
+// SPIRV: %[[RES:.*]] = call i32 @llvm.spv.resource.load.level.i32.tspirv.SignedImage_i32_{{.*}}("spirv.SignedImage", i32, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[FORMAT24]]) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 {{[^,]*}}, <[[DIM]] x i32> zeroinitializer)
 // CHECK: ret i32 %[[RES]]
 
 #ifdef HAS_OFFSET
@@ -281,36 +315,36 @@ int test_load_offset_int(ENTRY_TYPE loc : LOC) {
 
 // SRV: define linkonce_odr hidden {{.*}} i32 @hlsl::[[TEXTURE]]<int>::Load(int vector[[[#LOAD_DIM]]], int vector[[[DIM]]])(ptr {{.*}} %[[THIS:.*]], <[[#LOAD_DIM]] x i32> {{.*}} %[[LOAD:.*]], <[[DIM]] x i32> {{.*}} %[[OFFSET:.*]])
 // DXIL-SRV: %[[RES:.*]] = call i32 @llvm.dx.resource.load.level.i32.tdx.Texture_i32_{{.*}}("dx.Texture", i32, [[RW]], 0, 1, [[DXIL_TY]]) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 %{{.*}}, <[[DIM]] x i32> %{{.*}})
-// SPIRV-SRV: %[[RES:.*]] = call i32 @llvm.spv.resource.load.level.i32.tspirv.SignedImage_i32_{{.*}}("spirv.SignedImage", i32, 1, 2, [[ARRAYED]], 0, [[SAMPLED]], [[FORMAT24]]) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 %{{.*}}, <[[DIM]] x i32> %{{.*}})
+// SPIRV-SRV: %[[RES:.*]] = call i32 @llvm.spv.resource.load.level.i32.tspirv.SignedImage_i32_{{.*}}("spirv.SignedImage", i32, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[FORMAT24]]) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 %{{.*}}, <[[DIM]] x i32> %{{.*}})
 // SRV: ret i32 %[[RES]]
 
 TEXTURE<int2> t_int2;
 
-// CHECK: define hidden {{.*}} <[[DIM]] x i32> @test_load_int2(int vector[[[ENTRY_DIM]]])
-// CHECK: %[[CALL:.*]] = call {{.*}} <[[DIM]] x i32> @hlsl::[[TEXTURE]]<int vector[[[DIM]]]>::Load(int vector[[[#LOAD_DIM]]])(ptr {{.*}} @t_int2, <[[#LOAD_DIM]] x i32> noundef %{{.*}})
-// CHECK: ret <[[DIM]] x i32> %[[CALL]]
+// CHECK: define hidden {{.*}} <2 x i32> @test_load_int2(int vector[[[ENTRY_DIM]]])
+// CHECK: %[[CALL:.*]] = call {{.*}} <2 x i32> @hlsl::[[TEXTURE]]<int vector[2]>::Load(int vector[[[#LOAD_DIM]]])(ptr {{.*}} @t_int2, <[[#LOAD_DIM]] x i32> noundef %{{.*}})
+// CHECK: ret <2 x i32> %[[CALL]]
 int2 test_load_int2(ENTRY_TYPE loc : LOC) {
   return t_int2.Load(LOAD_ARG);
 }
 
-// CHECK: define linkonce_odr hidden {{.*}} <[[DIM]] x i32> @hlsl::[[TEXTURE]]<int vector[[[DIM]]]>::Load(int vector[[[#LOAD_DIM]]])(ptr {{.*}} %[[THIS:.*]], <[[#LOAD_DIM]] x i32> {{.*}} %[[LOAD:.*]])
-// DXIL: %[[RES:.*]] = call <[[DIM]] x i32> @llvm.dx.resource.load.level.v2i32.tdx.Texture_v2i32_{{.*}}("dx.Texture", <[[DIM]] x i32>, [[RW]], 0, 1, [[DXIL_TY]]) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 {{[^,]*}}, <[[DIM]] x i32> zeroinitializer)
-// SPIRV: %[[RES:.*]] = call <[[DIM]] x i32> @llvm.spv.resource.load.level.v2i32.tspirv.SignedImage_i32_{{.*}}("spirv.SignedImage", i32, 1, 2, [[ARRAYED]], 0, [[SAMPLED]], [[FORMAT25]]) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 {{[^,]*}}, <[[DIM]] x i32> zeroinitializer)
-// CHECK: ret <[[DIM]] x i32> %[[RES]]
+// CHECK: define linkonce_odr hidden {{.*}} <2 x i32> @hlsl::[[TEXTURE]]<int vector[2]>::Load(int vector[[[#LOAD_DIM]]])(ptr {{.*}} %[[THIS:.*]], <[[#LOAD_DIM]] x i32> {{.*}} %[[LOAD:.*]])
+// DXIL: %[[RES:.*]] = call <2 x i32> @llvm.dx.resource.load.level.v2i32.tdx.Texture_v2i32_{{.*}}("dx.Texture", <2 x i32>, [[RW]], 0, 1, [[DXIL_TY]]) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 {{[^,]*}}, <[[DIM]] x i32> zeroinitializer)
+// SPIRV: %[[RES:.*]] = call <2 x i32> @llvm.spv.resource.load.level.v2i32.tspirv.SignedImage_i32_{{.*}}("spirv.SignedImage", i32, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[FORMAT25]]) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 {{[^,]*}}, <[[DIM]] x i32> zeroinitializer)
+// CHECK: ret <2 x i32> %[[RES]]
 
 #ifdef HAS_OFFSET
-// SRV: define hidden {{.*}} <[[DIM]] x i32> @test_load_offset_int2(int vector[[[ENTRY_DIM]]])
-// SRV: %[[CALL:.*]] = call {{.*}} <[[DIM]] x i32> @hlsl::[[TEXTURE]]<int vector[[[DIM]]]>::Load(int vector[[[#LOAD_DIM]]], int vector[[[DIM]]])(ptr {{.*}} @t_int2, <[[#LOAD_DIM]] x i32> noundef %{{.*}}, <[[DIM]] x i32> noundef splat (i32 1))
-// SRV: ret <[[DIM]] x i32> %[[CALL]]
+// SRV: define hidden {{.*}} <2 x i32> @test_load_offset_int2(int vector[[[ENTRY_DIM]]])
+// SRV: %[[CALL:.*]] = call {{.*}} <2 x i32> @hlsl::[[TEXTURE]]<int vector[2]>::Load(int vector[[[#LOAD_DIM]]], int vector[[[DIM]]])(ptr {{.*}} @t_int2, <[[#LOAD_DIM]] x i32> noundef %{{.*}}, <[[DIM]] x i32> noundef splat (i32 1))
+// SRV: ret <2 x i32> %[[CALL]]
 int2 test_load_offset_int2(ENTRY_TYPE loc : LOC) {
   return t_int2.Load(LOAD_ARG, OFFSET_ARG);
 }
 #endif
 
-// SRV: define linkonce_odr hidden {{.*}} <[[DIM]] x i32> @hlsl::[[TEXTURE]]<int vector[[[DIM]]]>::Load(int vector[[[#LOAD_DIM]]], int vector[[[DIM]]])(ptr {{.*}} %[[THIS:.*]], <[[#LOAD_DIM]] x i32> {{.*}} %[[LOAD:.*]], <[[DIM]] x i32> {{.*}} %[[OFFSET:.*]])
-// DXIL-SRV: %[[RES:.*]] = call <[[DIM]] x i32> @llvm.dx.resource.load.level.v2i32.tdx.Texture_v2i32_{{.*}}("dx.Texture", <[[DIM]] x i32>, [[RW]], 0, 1, [[DXIL_TY]]) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 %{{.*}}, <[[DIM]] x i32> %{{.*}})
-// SPIRV-SRV: %[[RES:.*]] = call <[[DIM]] x i32> @llvm.spv.resource.load.level.v2i32.tspirv.SignedImage_i32_{{.*}}("spirv.SignedImage", i32, 1, 2, [[ARRAYED]], 0, [[SAMPLED]], [[FORMAT25]]) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 %{{.*}}, <[[DIM]] x i32> %{{.*}})
-// SRV: ret <[[DIM]] x i32> %[[RES]]
+// SRV: define linkonce_odr hidden {{.*}} <2 x i32> @hlsl::[[TEXTURE]]<int vector[2]>::Load(int vector[[[#LOAD_DIM]]], int vector[[[DIM]]])(ptr {{.*}} %[[THIS:.*]], <[[#LOAD_DIM]] x i32> {{.*}} %[[LOAD:.*]], <[[DIM]] x i32> {{.*}} %[[OFFSET:.*]])
+// DXIL-SRV: %[[RES:.*]] = call <2 x i32> @llvm.dx.resource.load.level.v2i32.tdx.Texture_v2i32_{{.*}}("dx.Texture", <2 x i32>, [[RW]], 0, 1, [[DXIL_TY]]) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 %{{.*}}, <[[DIM]] x i32> %{{.*}})
+// SPIRV-SRV: %[[RES:.*]] = call <2 x i32> @llvm.spv.resource.load.level.v2i32.tspirv.SignedImage_i32_{{.*}}("spirv.SignedImage", i32, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[FORMAT25]]) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 %{{.*}}, <[[DIM]] x i32> %{{.*}})
+// SRV: ret <2 x i32> %[[RES]]
 
 TEXTURE<int3> t_int3;
 
@@ -323,7 +357,7 @@ int3 test_load_int3(ENTRY_TYPE loc : LOC) {
 
 // CHECK: define linkonce_odr hidden {{.*}} <3 x i32> @hlsl::[[TEXTURE]]<int vector[3]>::Load(int vector[[[#LOAD_DIM]]])(ptr {{.*}} %[[THIS:.*]], <[[#LOAD_DIM]] x i32> {{.*}} %[[LOAD:.*]])
 // DXIL: %[[RES:.*]] = call <3 x i32> @llvm.dx.resource.load.level.v3i32.tdx.Texture_v3i32_{{.*}}("dx.Texture", <3 x i32>, [[RW]], 0, 1, [[DXIL_TY]]) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 {{[^,]*}}, <[[DIM]] x i32> zeroinitializer)
-// SPIRV: %[[RES:.*]] = call <3 x i32> @llvm.spv.resource.load.level.v3i32.tspirv.SignedImage_i32_{{.*}}("spirv.SignedImage", i32, 1, 2, [[ARRAYED]], 0, [[SAMPLED]], 0) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 {{[^,]*}}, <[[DIM]] x i32> zeroinitializer)
+// SPIRV: %[[RES:.*]] = call <3 x i32> @llvm.spv.resource.load.level.v3i32.tspirv.SignedImage_i32_{{.*}}("spirv.SignedImage", i32, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], 0) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 {{[^,]*}}, <[[DIM]] x i32> zeroinitializer)
 // CHECK: ret <3 x i32> %[[RES]]
 
 #ifdef HAS_OFFSET
@@ -337,7 +371,7 @@ int3 test_load_offset_int3(ENTRY_TYPE loc : LOC) {
 
 // SRV: define linkonce_odr hidden {{.*}} <3 x i32> @hlsl::[[TEXTURE]]<int vector[3]>::Load(int vector[[[#LOAD_DIM]]], int vector[[[DIM]]])(ptr {{.*}} %[[THIS:.*]], <[[#LOAD_DIM]] x i32> {{.*}} %[[LOAD:.*]], <[[DIM]] x i32> {{.*}} %[[OFFSET:.*]])
 // DXIL-SRV: %[[RES:.*]] = call <3 x i32> @llvm.dx.resource.load.level.v3i32.tdx.Texture_v3i32_{{.*}}("dx.Texture", <3 x i32>, [[RW]], 0, 1, [[DXIL_TY]]) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 %{{.*}}, <[[DIM]] x i32> %{{.*}})
-// SPIRV-SRV: %[[RES:.*]] = call <3 x i32> @llvm.spv.resource.load.level.v3i32.tspirv.SignedImage_i32_{{.*}}("spirv.SignedImage", i32, 1, 2, [[ARRAYED]], 0, [[SAMPLED]], 0) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 %{{.*}}, <[[DIM]] x i32> %{{.*}})
+// SPIRV-SRV: %[[RES:.*]] = call <3 x i32> @llvm.spv.resource.load.level.v3i32.tspirv.SignedImage_i32_{{.*}}("spirv.SignedImage", i32, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], 0) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 %{{.*}}, <[[DIM]] x i32> %{{.*}})
 // SRV: ret <3 x i32> %[[RES]]
 
 TEXTURE<int4> t_int4;
@@ -351,7 +385,7 @@ int4 test_load_int4(ENTRY_TYPE loc : LOC) {
 
 // CHECK: define linkonce_odr hidden {{.*}} <4 x i32> @hlsl::[[TEXTURE]]<int vector[4]>::Load(int vector[[[#LOAD_DIM]]])(ptr {{.*}} %[[THIS:.*]], <[[#LOAD_DIM]] x i32> {{.*}} %[[LOAD:.*]])
 // DXIL: %[[RES:.*]] = call <4 x i32> @llvm.dx.resource.load.level.v4i32.tdx.Texture_v4i32_{{.*}}("dx.Texture", <4 x i32>, [[RW]], 0, 1, [[DXIL_TY]]) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 {{[^,]*}}, <[[DIM]] x i32> zeroinitializer)
-// SPIRV: %[[RES:.*]] = call <4 x i32> @llvm.spv.resource.load.level.v4i32.tspirv.SignedImage_i32_{{.*}}("spirv.SignedImage", i32, 1, 2, [[ARRAYED]], 0, [[SAMPLED]], [[FORMAT21]]) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 {{[^,]*}}, <[[DIM]] x i32> zeroinitializer)
+// SPIRV: %[[RES:.*]] = call <4 x i32> @llvm.spv.resource.load.level.v4i32.tspirv.SignedImage_i32_{{.*}}("spirv.SignedImage", i32, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[FORMAT21]]) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 {{[^,]*}}, <[[DIM]] x i32> zeroinitializer)
 // CHECK: ret <4 x i32> %[[RES]]
 
 #ifdef HAS_OFFSET
@@ -365,5 +399,5 @@ int4 test_load_offset_int4(ENTRY_TYPE loc : LOC) {
 
 // SRV: define linkonce_odr hidden {{.*}} <4 x i32> @hlsl::[[TEXTURE]]<int vector[4]>::Load(int vector[[[#LOAD_DIM]]], int vector[[[DIM]]])(ptr {{.*}} %[[THIS:.*]], <[[#LOAD_DIM]] x i32> {{.*}} %[[LOAD:.*]], <[[DIM]] x i32> {{.*}} %[[OFFSET:.*]])
 // DXIL-SRV: %[[RES:.*]] = call <4 x i32> @llvm.dx.resource.load.level.v4i32.tdx.Texture_v4i32_{{.*}}("dx.Texture", <4 x i32>, [[RW]], 0, 1, [[DXIL_TY]]) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 %{{.*}}, <[[DIM]] x i32> %{{.*}})
-// SPIRV-SRV: %[[RES:.*]] = call <4 x i32> @llvm.spv.resource.load.level.v4i32.tspirv.SignedImage_i32_{{.*}}("spirv.SignedImage", i32, 1, 2, [[ARRAYED]], 0, [[SAMPLED]], [[FORMAT21]]) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 %{{.*}}, <[[DIM]] x i32> %{{.*}})
+// SPIRV-SRV: %[[RES:.*]] = call <4 x i32> @llvm.spv.resource.load.level.v4i32.tspirv.SignedImage_i32_{{.*}}("spirv.SignedImage", i32, [[SPV_DIM]], 2, [[ARRAYED]], 0, [[SAMPLED]], [[FORMAT21]]) %{{.*}}, <[[COORD_DIM]] x i32> %{{.*}}, i32 %{{.*}}, <[[DIM]] x i32> %{{.*}})
 // SRV: ret <4 x i32> %[[RES]]

--- a/clang/test/CodeGenHLSL/resources/Textures-Mips.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-Mips.hlsl
@@ -2,14 +2,20 @@
 // RUN:   -disable-llvm-passes -finclude-default-header -hlsl-entry test_mips \
 // RUN:   -DTEXTURE=Texture2D -DCOORD_DIM=2 -o - %s \
 // RUN:   | llvm-cxxfilt \
-// RUN:   | FileCheck %s --check-prefixes=CHECK,NOARRAY -DTEXTURE=Texture2D \
+// RUN:   | FileCheck %s --check-prefixes=CHECK,COORD2 -DTEXTURE=Texture2D \
 // RUN:   -DCOORD_DIM=2 -DLOAD_DIM=3 -DDXIL_TY=2 -DDIM=2
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-pixel -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -hlsl-entry test_mips \
 // RUN:   -DTEXTURE=Texture2DArray -DCOORD_DIM=3 -o - %s \
 // RUN:   | llvm-cxxfilt \
-// RUN:   | FileCheck %s --check-prefixes=CHECK,ARRAY -DTEXTURE=Texture2DArray \
+// RUN:   | FileCheck %s --check-prefixes=CHECK,COORD3 -DTEXTURE=Texture2DArray \
 // RUN:   -DCOORD_DIM=3 -DLOAD_DIM=4 -DDXIL_TY=7 -DDIM=2
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-pixel -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -hlsl-entry test_mips \
+// RUN:   -DTEXTURE=Texture3D -DCOORD_DIM=3 -o - %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s --check-prefixes=CHECK,COORD3 -DTEXTURE=Texture3D \
+// RUN:   -DCOORD_DIM=3 -DLOAD_DIM=4 -DDXIL_TY=4 -DDIM=3
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.
@@ -22,8 +28,9 @@
 //                      location)
 //
 // Check prefixes:
-//   NOARRAY            the resource has no array slice
-//   ARRAY              the resource has an array slice
+//   COORD2             the coordinate has two components
+//   COORD3             the coordinate has three components (an
+//                      array slice or a third resource dimension)
 
 TEXTURE<float4> t;
 
@@ -92,13 +99,13 @@ float4 test_mips(vector<float, COORD_DIM> loc : LOC) : SV_Target {
 // CHECK: %[[COORD_VAL2:.*]] = load <[[COORD_DIM]] x i32>, ptr %[[VEC_TMP]]
 // CHECK: %[[VECEXT2:.*]] = extractelement <[[COORD_DIM]] x i32> %[[COORD_VAL2]], i32 1
 // CHECK: %[[VECINIT3:.*]] = insertelement <[[LOAD_DIM]] x i32> %[[VECINIT]], i32 %[[VECEXT2]], i32 1
-// ARRAY: %[[COORD_VAL3:.*]] = load <3 x i32>, ptr %[[VEC_TMP]]
-// ARRAY: %[[VECEXT3:.*]] = extractelement <3 x i32> %[[COORD_VAL3]], i32 2
-// ARRAY: %[[VECINIT3B:.*]] = insertelement <4 x i32> %[[VECINIT3]], i32 %[[VECEXT3]], i32 2
+// COORD3: %[[COORD_VAL3:.*]] = load <3 x i32>, ptr %[[VEC_TMP]]
+// COORD3: %[[VECEXT3:.*]] = extractelement <3 x i32> %[[COORD_VAL3]], i32 2
+// COORD3: %[[VECINIT3B:.*]] = insertelement <4 x i32> %[[VECINIT3]], i32 %[[VECEXT3]], i32 2
 // CHECK: %[[LEVEL_PTR:.*]] = getelementptr {{.*}} %"struct.hlsl::[[TEXTURE]]<>::mips_slice_type", ptr %[[THIS1]], i32 0, i32 1
 // CHECK: %[[LEVEL_VAL:.*]] = load i32, ptr %[[LEVEL_PTR]]
-// NOARRAY: %[[VECINITL:.*]] = insertelement <3 x i32> %[[VECINIT3]], i32 %[[LEVEL_VAL]], i32 2
-// ARRAY: %[[VECINITL:.*]] = insertelement <4 x i32> %[[VECINIT3B]], i32 %[[LEVEL_VAL]], i32 3
+// COORD2: %[[VECINITL:.*]] = insertelement <3 x i32> %[[VECINIT3]], i32 %[[LEVEL_VAL]], i32 2
+// COORD3: %[[VECINITL:.*]] = insertelement <4 x i32> %[[VECINIT3B]], i32 %[[LEVEL_VAL]], i32 3
 // CHECK: %[[COORD_X:.*]] = shufflevector <[[LOAD_DIM]] x i32> %[[VECINITL]], <[[LOAD_DIM]] x i32> poison, <[[COORD_DIM]] x i32> {{.*}}
 // CHECK: %[[LOD:.*]] = extractelement <[[LOAD_DIM]] x i32> %[[VECINITL]], i64 [[COORD_DIM]]
 // CHECK: %[[RES:.*]] = call {{.*}} <4 x float> @llvm.dx.resource.load.level.v4f32.tdx.Texture_v4f32_0_0_0_[[DXIL_TY]]t.v[[COORD_DIM]]i32.i32.v[[DIM]]i32(target("dx.Texture", <4 x float>, 0, 0, 0, [[DXIL_TY]]) %[[HANDLE]], <[[COORD_DIM]] x i32> %[[COORD_X]], i32 %[[LOD]], <[[DIM]] x i32> zeroinitializer)

--- a/clang/test/CodeGenHLSL/resources/Textures-Sample.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-Sample.hlsl
@@ -8,6 +8,14 @@
 // RUN:   -DDXIL_TY=2 -DRW=0 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int3(1, 2, 3)" -DHAS_OFFSET -DTEXTURE=Texture3D \
+// RUN:   -DCOORD_TYPE=float3 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture3D -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-TEXEL,CHECK-OFFSET,DXIL-OFFSET \
+// RUN:   -DDXIL_TY=4 -DRW=0 -DDIM=3 -DOFFSET_CONST="<i32 1, i32 2, i32 3>"
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
 // RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
@@ -29,6 +37,15 @@
 // RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-TEXEL,CHECK-OFFSET,SPIRV-OFFSET \
 // RUN:   -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=1 -DDIM=2 \
 // RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int3(1, 2, 3)" -DHAS_OFFSET -DTEXTURE=Texture3D \
+// RUN:   -DCOORD_TYPE=float3 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture3D -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-TEXEL,CHECK-OFFSET,SPIRV-OFFSET \
+// RUN:   -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=2 -DDIM=3 \
+// RUN:   -DOFFSET_CONST="<i32 1, i32 2, i32 3>"
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
 // RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \

--- a/clang/test/CodeGenHLSL/resources/Textures-SampleBias.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-SampleBias.hlsl
@@ -8,6 +8,14 @@
 // RUN:   -DDXIL_TY=2 -DRW=0 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int3(1, 2, 3)" -DHAS_OFFSET -DTEXTURE=Texture3D \
+// RUN:   -DCOORD_TYPE=float3 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture3D -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-TEXEL,CHECK-OFFSET,DXIL-OFFSET \
+// RUN:   -DDXIL_TY=4 -DRW=0 -DDIM=3 -DOFFSET_CONST="<i32 1, i32 2, i32 3>"
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
 // RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
@@ -29,6 +37,15 @@
 // RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-TEXEL,CHECK-OFFSET,SPIRV-OFFSET \
 // RUN:   -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=1 -DDIM=2 \
 // RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int3(1, 2, 3)" -DHAS_OFFSET -DTEXTURE=Texture3D \
+// RUN:   -DCOORD_TYPE=float3 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture3D -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-TEXEL,CHECK-OFFSET,SPIRV-OFFSET \
+// RUN:   -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=2 -DDIM=3 \
+// RUN:   -DOFFSET_CONST="<i32 1, i32 2, i32 3>"
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
 // RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \

--- a/clang/test/CodeGenHLSL/resources/Textures-SampleGrad.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-SampleGrad.hlsl
@@ -8,6 +8,14 @@
 // RUN:   -DDXIL_TY=2 -DRW=0 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int3(1, 2, 3)" -DGRAD_TYPE=float3 -DHAS_OFFSET \
+// RUN:   -DTEXTURE=Texture3D -DCOORD_TYPE=float3 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture3D -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-TEXEL,CHECK-OFFSET,DXIL-OFFSET \
+// RUN:   -DDXIL_TY=4 -DRW=0 -DDIM=3 -DOFFSET_CONST="<i32 1, i32 2, i32 3>"
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
 // RUN:   -DGRAD_TYPE=float3 -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
@@ -29,6 +37,15 @@
 // RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-TEXEL,CHECK-OFFSET,SPIRV-OFFSET \
 // RUN:   -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=1 -DDIM=2 \
 // RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int3(1, 2, 3)" -DGRAD_TYPE=float3 -DHAS_OFFSET \
+// RUN:   -DTEXTURE=Texture3D -DCOORD_TYPE=float3 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture3D -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-TEXEL,CHECK-OFFSET,SPIRV-OFFSET \
+// RUN:   -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=2 -DDIM=3 \
+// RUN:   -DOFFSET_CONST="<i32 1, i32 2, i32 3>"
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
 // RUN:   -DGRAD_TYPE=float3 -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \

--- a/clang/test/CodeGenHLSL/resources/Textures-SampleLevel.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-SampleLevel.hlsl
@@ -8,6 +8,14 @@
 // RUN:   -DDXIL_TY=2 -DRW=0 -DDIM=2 -DOFFSET_CONST="<i32 1, i32 2>"
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int3(1, 2, 3)" -DHAS_OFFSET -DTEXTURE=Texture3D \
+// RUN:   -DCOORD_TYPE=float3 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture3D -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,DXIL,DXIL-TEXEL,CHECK-OFFSET,DXIL-OFFSET \
+// RUN:   -DDXIL_TY=4 -DRW=0 -DDIM=3 -DOFFSET_CONST="<i32 1, i32 2, i32 3>"
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
 // RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 \
@@ -27,6 +35,15 @@
 // RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-TEXEL,CHECK-OFFSET,SPIRV-OFFSET \
 // RUN:   -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=1 -DDIM=2 \
 // RUN:   -DOFFSET_CONST="<i32 1, i32 2>"
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -o - \
+// RUN:   -DOFFSET_ARG="int3(1, 2, 3)" -DHAS_OFFSET -DTEXTURE=Texture3D \
+// RUN:   -DCOORD_TYPE=float3 %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture3D -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,SPIRV,SPIRV-TEXEL,CHECK-OFFSET,SPIRV-OFFSET \
+// RUN:   -DARRAYED=0 -DSAMPLED=1 -DIMG_FMT=0 -DSPV_DIM=2 -DDIM=3 \
+// RUN:   -DOFFSET_CONST="<i32 1, i32 2, i32 3>"
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -o - \
 // RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 %s \

--- a/clang/test/CodeGenHLSL/resources/Textures-Subscript.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-Subscript.hlsl
@@ -6,6 +6,14 @@
 // RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 \
 // RUN:   --check-prefixes=CHECK,DXIL -DROV_OR_COUNT=0 \
 // RUN:   -DDXIL_HANDLE=dx.Texture -DDXIL_TY=2 -DRW=0
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -Wno-sign-conversion \
+// RUN:   -DREG0=t0 -DREG1=t1 -DREG2=t2 -DTEXTURE=Texture3D -DCOORD_TYPE=uint3 \
+// RUN:   -o - %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture3D -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,DXIL -DROV_OR_COUNT=0 \
+// RUN:   -DDXIL_HANDLE=dx.Texture -DDXIL_TY=4 -DRW=0
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -Wno-sign-conversion \
 // RUN:   -DREG0=t0 -DREG1=t1 -DREG2=t2 -DTEXTURE=Texture2D -DCOORD_TYPE=uint2 \
@@ -14,6 +22,14 @@
 // RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 \
 // RUN:   --check-prefixes=CHECK,SPIRV -DARRAYED=0 -DMS=0 -DSAMPLED=1 \
 // RUN:   -DFMT_FLOAT4=0 -DFMT_FLOAT=0 -DFMT_INT3=0 -DSPV_DIM=1
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -Wno-sign-conversion \
+// RUN:   -DREG0=t0 -DREG1=t1 -DREG2=t2 -DTEXTURE=Texture3D -DCOORD_TYPE=uint3 \
+// RUN:   -o - %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture3D -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,SPIRV -DARRAYED=0 -DMS=0 -DSAMPLED=1 \
+// RUN:   -DFMT_FLOAT4=0 -DFMT_FLOAT=0 -DFMT_INT3=0 -DSPV_DIM=2
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -Wno-sign-conversion \
 // RUN:   -DREG0=t0 -DREG1=t1 -DREG2=t2 -DTEXTURE=Texture2DArray \
@@ -54,6 +70,14 @@
 // RUN:   | FileCheck %s -DTEXTURE=RWTexture2D -DCOORD_DIM=2 \
 // RUN:   --check-prefixes=CHECK,CHECK-STORE,DXIL -DRW=1 -DROV_OR_COUNT=0 \
 // RUN:   -DDXIL_HANDLE=dx.Texture -DDXIL_TY=2
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -Wno-sign-conversion \
+// RUN:   -DHAS_STORE -DREG0=u0 -DREG1=u1 -DREG2=u2 -DTEXTURE=RWTexture3D \
+// RUN:   -DCOORD_TYPE=uint3 -o - %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=RWTexture3D -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,CHECK-STORE,DXIL -DRW=1 -DROV_OR_COUNT=0 \
+// RUN:   -DDXIL_HANDLE=dx.Texture -DDXIL_TY=4
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -Wno-sign-conversion \
 // RUN:   -DHAS_STORE -DREG0=u0 -DREG1=u1 -DREG2=u2 -DTEXTURE=RWTexture2D \
@@ -62,6 +86,14 @@
 // RUN:   | FileCheck %s -DTEXTURE=RWTexture2D -DCOORD_DIM=2 \
 // RUN:   --check-prefixes=CHECK,CHECK-STORE,SPIRV -DARRAYED=0 -DMS=0 \
 // RUN:   -DSAMPLED=2 -DFMT_FLOAT4=1 -DFMT_FLOAT=3 -DFMT_INT3=0 -DSPV_DIM=1
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -Wno-sign-conversion \
+// RUN:   -DHAS_STORE -DREG0=u0 -DREG1=u1 -DREG2=u2 -DTEXTURE=RWTexture3D \
+// RUN:   -DCOORD_TYPE=uint3 -o - %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=RWTexture3D -DCOORD_DIM=3 \
+// RUN:   --check-prefixes=CHECK,CHECK-STORE,SPIRV -DARRAYED=0 -DMS=0 \
+// RUN:   -DSAMPLED=2 -DFMT_FLOAT4=1 -DFMT_FLOAT=3 -DFMT_INT3=0 -DSPV_DIM=2
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -Wno-sign-conversion \
 // RUN:   -DHAS_STORE -DREG0=u0 -DREG1=u1 -DREG2=u2 -DTEXTURE=RWTexture2DArray \

--- a/clang/test/CodeGenHLSL/resources/Textures-default-explicit-binding.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-default-explicit-binding.hlsl
@@ -5,6 +5,12 @@
 // RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 -DDXIL_TY=2 -DRW=0 \
 // RUN:   --check-prefixes=CHECK,CHECK-TEXEL
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -DTEXTURE=Texture3D \
+// RUN:   -DCOORD_TYPE=float3 -o - %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture3D -DCOORD_DIM=3 -DDXIL_TY=4 -DRW=0 \
+// RUN:   --check-prefixes=CHECK,CHECK-TEXEL
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -DTEXTURE=TextureCube \
 // RUN:   -DCOORD_TYPE=float3 -o - %s \
 // RUN:   | llvm-cxxfilt \
@@ -22,6 +28,12 @@
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=Texture2D -DCOORD_DIM=2 -DARRAYED=0 \
 // RUN:   --check-prefixes=SPIRV,SPIRV-TEXEL -DSPV_DIM=1
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
+// RUN:   -disable-llvm-passes -finclude-default-header -DTEXTURE=Texture3D \
+// RUN:   -DCOORD_TYPE=float3 -o - %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture3D -DCOORD_DIM=3 -DARRAYED=0 \
+// RUN:   --check-prefixes=SPIRV,SPIRV-TEXEL -DSPV_DIM=2
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl -emit-llvm \
 // RUN:   -disable-llvm-passes -finclude-default-header -DTEXTURE=TextureCube \
 // RUN:   -DCOORD_TYPE=float3 -o - %s \

--- a/clang/test/CodeGenHLSL/resources/Textures-default.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-default.hlsl
@@ -5,6 +5,11 @@
 // RUN:   --check-prefixes=CHECK,CHECK-TEXEL
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
 // RUN:   -std=hlsl202x -emit-llvm -disable-llvm-passes \
+// RUN:   -finclude-default-header -DTEXTURE=Texture3D -o - %s \
+// RUN:   | FileCheck %s -DTEXTURE=Texture3D -DDXIL_TY=4 -DRW=0 \
+// RUN:   --check-prefixes=CHECK,CHECK-TEXEL
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
+// RUN:   -std=hlsl202x -emit-llvm -disable-llvm-passes \
 // RUN:   -finclude-default-header -DTEXTURE=TextureCube -o - %s \
 // RUN:   | FileCheck %s -DTEXTURE=TextureCube -DDXIL_TY=5 -DRW=0 \
 // RUN:   --check-prefixes=CHECK,CHECK-NOTEXEL

--- a/clang/test/CodeGenHLSL/resources/Textures-shorthand-contexts.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Textures-shorthand-contexts.hlsl
@@ -6,6 +6,12 @@
 // RUN:   --check-prefixes=CHECK,CHECK-TEXEL
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
 // RUN:   -finclude-default-header -emit-llvm -disable-llvm-passes \
+// RUN:   -DTEXTURE=Texture3D -DCOORD_TYPE=float3 -o - %s \
+// RUN:   | llvm-cxxfilt \
+// RUN:   | FileCheck %s -DTEXTURE=Texture3D -DCOORD_DIM=3 -DDXIL_TY=4 -DRW=0 \
+// RUN:   --check-prefixes=CHECK,CHECK-TEXEL
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
+// RUN:   -finclude-default-header -emit-llvm -disable-llvm-passes \
 // RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 -o - %s \
 // RUN:   | llvm-cxxfilt \
 // RUN:   | FileCheck %s -DTEXTURE=TextureCube -DCOORD_DIM=3 -DDXIL_TY=5 \

--- a/clang/test/SemaHLSL/Resources/Textures-CalculateLevelOfDetail.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-CalculateLevelOfDetail.hlsl
@@ -2,6 +2,9 @@
 // RUN:   -finclude-default-header -fsyntax-only -verify=expected,dim2 \
 // RUN:   -DTEXTURE=Texture2D -DLOD_TYPE=float2 %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library \
+// RUN:   -finclude-default-header -fsyntax-only -verify=expected,dim3 \
+// RUN:   -DTEXTURE=Texture3D -DLOD_TYPE=float3 %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library \
 // RUN:   -finclude-default-header -fsyntax-only -verify=expected,dim2 \
 // RUN:   -DTEXTURE=Texture2DArray -DLOD_TYPE=float2 %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library \

--- a/clang/test/SemaHLSL/Resources/Textures-Load-errors.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-Load-errors.hlsl
@@ -9,6 +9,11 @@
 // RUN:   -DOFFSET_TYPE=int2 -DOFFSET_FLOAT_TYPE=float2 \
 // RUN:   -DWIDE_OFFSET_TYPE=int3 -verify %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
+// RUN:   -finclude-default-header -DTEXTURE=Texture3D -DHAS_OFFSET \
+// RUN:   -DLOAD_TYPE=int4 -DLOAD_FLOAT_TYPE=float4 -DNARROW_LOAD_TYPE=int3 \
+// RUN:   -DOFFSET_TYPE=int3 -DOFFSET_FLOAT_TYPE=float3 \
+// RUN:   -DWIDE_OFFSET_TYPE=int4 -verify %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
 // RUN:   -finclude-default-header -DTEXTURE=RWTexture2D -DLOAD_TYPE=int2 \
 // RUN:   -DLOAD_FLOAT_TYPE=float2 -DNARROW_LOAD_TYPE=int1 \
 // RUN:   -DWIDE_LOAD_TYPE=int3 -DOFFSET_TYPE=int2 -verify %s
@@ -16,6 +21,10 @@
 // RUN:   -finclude-default-header -DTEXTURE=RWTexture2DArray -DLOAD_TYPE=int3 \
 // RUN:   -DLOAD_FLOAT_TYPE=float3 -DNARROW_LOAD_TYPE=int2 \
 // RUN:   -DWIDE_LOAD_TYPE=int4 -DOFFSET_TYPE=int2 -verify %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
+// RUN:   -finclude-default-header -DTEXTURE=RWTexture3D -DLOAD_TYPE=int3 \
+// RUN:   -DLOAD_FLOAT_TYPE=float3 -DNARROW_LOAD_TYPE=int2 \
+// RUN:   -DWIDE_LOAD_TYPE=int4 -DOFFSET_TYPE=int3 -verify %s
 
 // Parameterized over the texture types in the RUN lines above; adding a texture
 // of another dimension only requires new RUN lines.

--- a/clang/test/SemaHLSL/Resources/Textures-SampleBias.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-SampleBias.hlsl
@@ -3,6 +3,10 @@
 // RUN:   -DHAS_OFFSET -DOFFSET_TYPE=int2 -DTEXTURE=Texture2D \
 // RUN:   -DCOORD_TYPE=float2 %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library \
+// RUN:   -finclude-default-header -fsyntax-only -verify=expected,offset,dim3 \
+// RUN:   -DHAS_OFFSET -DOFFSET_TYPE=int3 -DTEXTURE=Texture3D \
+// RUN:   -DCOORD_TYPE=float3 %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library \
 // RUN:   -finclude-default-header -fsyntax-only -verify=expected,offset,dim2 \
 // RUN:   -DHAS_OFFSET -DOFFSET_TYPE=int2 -DTEXTURE=Texture2DArray \
 // RUN:   -DCOORD_TYPE=float3 %s

--- a/clang/test/SemaHLSL/Resources/Textures-SampleGrad.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-SampleGrad.hlsl
@@ -3,6 +3,10 @@
 // RUN:   -DHAS_OFFSET -DOFFSET_TYPE=int2 -DTEXTURE=Texture2D \
 // RUN:   -DCOORD_TYPE=float2 -DGRAD_TYPE=float2 %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library \
+// RUN:   -finclude-default-header -fsyntax-only -verify=expected,offset,dim3 \
+// RUN:   -DHAS_OFFSET -DOFFSET_TYPE=int3 -DTEXTURE=Texture3D \
+// RUN:   -DCOORD_TYPE=float3 -DGRAD_TYPE=float3 %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library \
 // RUN:   -finclude-default-header -fsyntax-only -verify=expected,offset,dim2 \
 // RUN:   -DHAS_OFFSET -DOFFSET_TYPE=int2 -DTEXTURE=Texture2DArray \
 // RUN:   -DCOORD_TYPE=float3 -DGRAD_TYPE=float2 %s

--- a/clang/test/SemaHLSL/Resources/Textures-SampleLevel.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-SampleLevel.hlsl
@@ -3,6 +3,10 @@
 // RUN:   -DHAS_OFFSET -DOFFSET_TYPE=int2 -DTEXTURE=Texture2D \
 // RUN:   -DCOORD_TYPE=float2 %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library \
+// RUN:   -finclude-default-header -fsyntax-only -verify=expected,offset,dim3 \
+// RUN:   -DHAS_OFFSET -DOFFSET_TYPE=int3 -DTEXTURE=Texture3D \
+// RUN:   -DCOORD_TYPE=float3 %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library \
 // RUN:   -finclude-default-header -fsyntax-only -verify=expected,offset,dim2 \
 // RUN:   -DHAS_OFFSET -DOFFSET_TYPE=int2 -DTEXTURE=Texture2DArray \
 // RUN:   -DCOORD_TYPE=float3 %s

--- a/clang/test/SemaHLSL/Resources/Textures-Sema.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-Sema.hlsl
@@ -3,6 +3,10 @@
 // RUN:   -DHAS_OFFSET -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2D \
 // RUN:   -DCOORD_TYPE=float2 %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
+// RUN:   -fsyntax-only -finclude-default-header -verify=expected,offset,dim3 \
+// RUN:   -DHAS_OFFSET -DOFFSET_ARG="int3(1, 2, 3)" -DTEXTURE=Texture3D \
+// RUN:   -DCOORD_TYPE=float3 %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
 // RUN:   -fsyntax-only -finclude-default-header -verify=expected,offset,dim2 \
 // RUN:   -DHAS_OFFSET -DOFFSET_ARG="int2(1, 2)" -DTEXTURE=Texture2DArray \
 // RUN:   -DCOORD_TYPE=float3 %s
@@ -66,8 +70,9 @@ void main(COORD_TYPE loc) {
 
   t.Sample(s, loc, OFFSET_ARG, 1.0);
 
-  // expected-error@+4 {{no matching member function for call to 'Sample'}}
+  // expected-error@+5 {{no matching member function for call to 'Sample'}}
   // dim2-note@*:* {{candidate function not viable: no known conversion from 'SamplerState' to 'vector<int, 2>' (vector of 2 'int' values) for 3rd argument}}
+  // dim3-note@*:* {{candidate function not viable: no known conversion from 'SamplerState' to 'vector<int, 3>' (vector of 3 'int' values) for 3rd argument}}
   // expected-note@*:* {{candidate function not viable: requires 2 arguments, but 3 were provided}}
   // expected-note@*:* {{candidate function not viable: requires 4 arguments, but 3 were provided}}
   t.Sample(s, loc, s);

--- a/clang/test/SemaHLSL/Resources/Textures-Subscript.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-Subscript.hlsl
@@ -8,11 +8,22 @@
 // RUN:   -DWIDE_INDEX_ARG="int4(1, 2, 3, 4)" -DNARROW_INDEX_TYPE=uint2 \
 // RUN:   -DNARROW_INDEX_ARG="uint2(1, 2)" -verify -o - %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
+// RUN:   -finclude-default-header -DTEXTURE=Texture3D -DINDEX_TYPE=uint3 \
+// RUN:   -DINDEX_ARG="uint3(1, 2, 0)" -DWIDE_INDEX_TYPE=int4 \
+// RUN:   -DWIDE_INDEX_ARG="int4(1, 2, 3, 4)" -DNARROW_INDEX_TYPE=uint2 \
+// RUN:   -DNARROW_INDEX_ARG="uint2(1, 2)" -verify -o - %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
 // RUN:   -finclude-default-header -DTEXTURE=RWTexture2D -DHAS_STORE \
 // RUN:   -DINDEX_TYPE=uint2 -DINDEX_ARG="uint2(1, 2)" -DWIDE_INDEX_TYPE=int3 \
 // RUN:   -DWIDE_INDEX_ARG="int3(1, 2, 3)" -verify -o - %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
 // RUN:   -finclude-default-header -DTEXTURE=RWTexture2DArray -DHAS_STORE \
+// RUN:   -DINDEX_TYPE=uint3 -DINDEX_ARG="uint3(1, 2, 0)" \
+// RUN:   -DWIDE_INDEX_TYPE=int4 -DWIDE_INDEX_ARG="int4(1, 2, 3, 4)" \
+// RUN:   -DNARROW_INDEX_TYPE=uint2 -DNARROW_INDEX_ARG="uint2(1, 2)" -verify \
+// RUN:   -o - %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
+// RUN:   -finclude-default-header -DTEXTURE=RWTexture3D -DHAS_STORE \
 // RUN:   -DINDEX_TYPE=uint3 -DINDEX_ARG="uint3(1, 2, 0)" \
 // RUN:   -DWIDE_INDEX_TYPE=int4 -DWIDE_INDEX_ARG="int4(1, 2, 3, 4)" \
 // RUN:   -DNARROW_INDEX_TYPE=uint2 -DNARROW_INDEX_ARG="uint2(1, 2)" -verify \
@@ -23,6 +34,12 @@
 // RUN:   -DWIDE_INDEX_ARG="int3(1, 2, 3)" -verify -o - %s
 // RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl \
 // RUN:   -finclude-default-header -DTEXTURE=RWTexture2DArray -DHAS_STORE \
+// RUN:   -DINDEX_TYPE=uint3 -DINDEX_ARG="uint3(1, 2, 0)" \
+// RUN:   -DWIDE_INDEX_TYPE=int4 -DWIDE_INDEX_ARG="int4(1, 2, 3, 4)" \
+// RUN:   -DNARROW_INDEX_TYPE=uint2 -DNARROW_INDEX_ARG="uint2(1, 2)" -verify \
+// RUN:   -o - %s
+// RUN: %clang_cc1 -triple spirv-vulkan-library -x hlsl \
+// RUN:   -finclude-default-header -DTEXTURE=RWTexture3D -DHAS_STORE \
 // RUN:   -DINDEX_TYPE=uint3 -DINDEX_ARG="uint3(1, 2, 0)" \
 // RUN:   -DWIDE_INDEX_TYPE=int4 -DWIDE_INDEX_ARG="int4(1, 2, 3, 4)" \
 // RUN:   -DNARROW_INDEX_TYPE=uint2 -DNARROW_INDEX_ARG="uint2(1, 2)" -verify \

--- a/clang/test/SemaHLSL/Resources/Textures-declaration-order.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-declaration-order.hlsl
@@ -24,6 +24,10 @@ TextureCube<float> TexCube;
 TextureCube<float2> TexCubeVec;
 TextureCubeArray<float> TexCubeArray;
 TextureCubeArray<float2> TexCubeArrayVec;
+Texture3D<float> Tex3D;
+Texture3D<float2> Tex3DVec;
+RWTexture3D<float> RWTex3D;
+RWTexture3D<float2> RWTex3DVec;
 #else
 Texture2D<float2> Tex2DVec;
 Texture2D<float> Tex2D;
@@ -37,6 +41,10 @@ TextureCube<float2> TexCubeVec;
 TextureCube<float> TexCube;
 TextureCubeArray<float2> TexCubeArrayVec;
 TextureCubeArray<float> TexCubeArray;
+Texture3D<float2> Tex3DVec;
+Texture3D<float> Tex3D;
+RWTexture3D<float2> RWTex3DVec;
+RWTexture3D<float> RWTex3D;
 #endif
 
 SamplerState Samp;
@@ -59,4 +67,9 @@ export void useTextures(float2 UV, float3 UVW, float4 UVWA) {
 
   float CAS = TexCubeArray.Sample(Samp, UVWA);
   float2 CAV = TexCubeArrayVec.Sample(Samp, UVWA);
+
+  float VS = Tex3D.Sample(Samp, UVW);
+  float2 VV = Tex3DVec.Sample(Samp, UVW);
+  RWTex3D[uint3(0, 0, 0)] = VS;
+  RWTex3DVec[uint3(0, 0, 0)] = VV;
 }

--- a/clang/test/SemaHLSL/Resources/Textures-mips-errors.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-mips-errors.hlsl
@@ -3,10 +3,16 @@
 // RUN:   -DTEXTURE=Texture2D -DINDEX_TYPE=int2 -DHAS_MIPS -verify %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
 // RUN:   -emit-llvm-only -disable-llvm-passes -finclude-default-header \
+// RUN:   -DTEXTURE=Texture3D -DINDEX_TYPE=int3 -DHAS_MIPS -verify %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
+// RUN:   -emit-llvm-only -disable-llvm-passes -finclude-default-header \
 // RUN:   -DTEXTURE=Texture2DArray -DINDEX_TYPE=int3 -DHAS_MIPS -verify %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
 // RUN:   -emit-llvm-only -disable-llvm-passes -finclude-default-header \
 // RUN:   -DTEXTURE=RWTexture2D -verify %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
+// RUN:   -emit-llvm-only -disable-llvm-passes -finclude-default-header \
+// RUN:   -DTEXTURE=RWTexture3D -verify %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
 // RUN:   -emit-llvm-only -disable-llvm-passes -finclude-default-header \
 // RUN:   -DTEXTURE=RWTexture2DArray -verify %s

--- a/clang/test/SemaHLSL/Resources/Textures-unsupported-methods-errors.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-unsupported-methods-errors.hlsl
@@ -2,15 +2,22 @@
 // RUN:   -finclude-default-header -DHAS_TEXEL -DTEXTURE=RWTexture2D \
 // RUN:   -DCOORD_TYPE=float2 -DGRAD_TYPE=float2 -DOFFSET_TYPE=int2 -verify %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
+// RUN:   -finclude-default-header -DHAS_TEXEL -DTEXTURE=RWTexture3D \
+// RUN:   -DCOORD_TYPE=float3 -DGRAD_TYPE=float3 -DOFFSET_TYPE=int3 -verify %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
 // RUN:   -finclude-default-header -DHAS_TEXEL -DTEXTURE=RWTexture2DArray \
 // RUN:   -DCOORD_TYPE=float3 -DGRAD_TYPE=float2 -DOFFSET_TYPE=int2 -verify %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
-// RUN:   -finclude-default-header -DHAS_SAMPLE -DHAS_GATHER -DHAS_LOD \
+// RUN:   -finclude-default-header -DHAS_SAMPLE -DHAS_SAMPLE_CMP -DHAS_GATHER -DHAS_LOD \
 // RUN:   -DLOAD_ARG="int4(0, 0, 0, 0)" -DINDEX_ARG="uint3(0, 0, 0)" \
 // RUN:   -DTEXTURE=TextureCube -DCOORD_TYPE=float3 -DOFFSET_TYPE=int3 -verify \
 // RUN:   %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
-// RUN:   -finclude-default-header -DHAS_SAMPLE -DHAS_GATHER -DHAS_LOD \
+// RUN:   -finclude-default-header -DHAS_TEXEL -DHAS_SAMPLE -DHAS_LOD \
+// RUN:   -DTEXTURE=Texture3D -DCOORD_TYPE=float3 -DOFFSET_TYPE=int3 \
+// RUN:   -DGRAD_TYPE=float3 -verify %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl \
+// RUN:   -finclude-default-header -DHAS_SAMPLE -DHAS_SAMPLE_CMP -DHAS_GATHER -DHAS_LOD \
 // RUN:   -DLOAD_ARG="int4(0, 0, 0, 0)" -DINDEX_ARG="uint3(0, 0, 0)" \
 // RUN:   -DTEXTURE=TextureCubeArray -DCOORD_TYPE=float4 -DOFFSET_TYPE=int3 \
 // RUN:   -verify %s
@@ -28,6 +35,8 @@
 //                      dimension
 //   OFFSET_TYPE        offset type, one component per resource dimension
 //   HAS_SAMPLE         defined for types that have the Sample* methods
+//   HAS_SAMPLE_CMP     defined for types that have the comparison sampling
+//                      methods
 //   HAS_GATHER         defined for types that have the Gather* methods
 //   HAS_LOD            defined for types that have CalculateLevelOfDetail*
 //
@@ -50,6 +59,9 @@ void main(COORD_TYPE uv) {
   Tex.SampleBias(Samp, uv, 0.0f);
   // expected-error-re@+1 {{no member named 'SampleGrad' in 'hlsl::{{.*}}Texture}}
   Tex.SampleGrad(Samp, uv, (GRAD_TYPE)0, (GRAD_TYPE)0);
+#endif
+
+#ifndef HAS_SAMPLE_CMP
   // expected-error-re@+1 {{no member named 'SampleCmp' in 'hlsl::{{.*}}Texture}}
   Tex.SampleCmp(SampCmp, uv, compare);
   // expected-error-re@+1 {{no member named 'SampleCmpLevelZero' in 'hlsl::{{.*}}Texture}}


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/194739 and fixes https://github.com/llvm/llvm-project/issues/194743

This PR implements Texture3D and RWTexture3D and adds+modifies tests for the two types.

Assisted by: Claude Opus 5
