### PR TITLE
[Transforms] Add TrackingSSAUpdater wrapper for RAUW-safe SSA value tracking.

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/SSAUpdater.h
+++ b/llvm/include/llvm/Transforms/Utils/SSAUpdater.h
@@ -14,7 +14,9 @@
 #define LLVM_TRANSFORMS_UTILS_SSAUPDATER_H
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/IR/ValueHandle.h"
 #include <string>
 
 namespace llvm {
@@ -136,6 +138,67 @@ public:
 private:
   Value *GetValueAtEndOfBlockInternal(BasicBlock *BB);
   void UpdateDebugValue(Instruction *I, DbgVariableRecord *DbgValue);
+};
+
+/// Wrapper around SSAUpdater that uses TrackingVH to keep available values
+/// up-to-date when the original values are RAUW'd or deleted. The plain
+/// SSAUpdater stores raw Value* pointers that become dangling when a value it
+/// holds is replaced and erased.
+class TrackingSSAUpdater {
+  SSAUpdater Updater;
+  DenseMap<BasicBlock *, TrackingVH<Value>> TrackedVals;
+
+public:
+  explicit TrackingSSAUpdater(
+      SmallVectorImpl<PHINode *> *InsertedPHIs = nullptr)
+      : Updater(InsertedPHIs) {}
+  TrackingSSAUpdater(const TrackingSSAUpdater &) = delete;
+  TrackingSSAUpdater &operator=(const TrackingSSAUpdater &) = delete;
+
+  void Initialize(Type *Ty, StringRef Name) {
+    Updater.Initialize(Ty, Name);
+    TrackedVals.clear();
+  }
+
+  /// Return true if the TrackingSSAUpdater already has a value for the
+  /// specified block.
+  bool HasValueForBlock(BasicBlock *BB) const { return TrackedVals.count(BB); }
+
+  void AddAvailableValue(BasicBlock *BB, Value *V) {
+    assert(BB && "Cannot add available value for nullptr block");
+    assert(V && "Cannot add nullptr as available value");
+    TrackedVals[BB] = TrackingVH<Value>(V);
+    Updater.AddAvailableValue(BB, V);
+  }
+
+  Value *FindValueForBlock(BasicBlock *BB) const {
+    auto It = TrackedVals.find(BB);
+    if (It == TrackedVals.end())
+      return nullptr;
+    Value *Tracked = It->second;
+    Value *Raw = Updater.FindValueForBlock(BB);
+    if (Raw && Raw != Tracked) {
+      const_cast<TrackingSSAUpdater *>(this)->Updater.AddAvailableValue(
+          BB, Tracked);
+    }
+    return Tracked;
+  }
+
+  Value *GetValueInMiddleOfBlock(BasicBlock *BB) {
+    syncAll();
+    return Updater.GetValueInMiddleOfBlock(BB);
+  }
+
+  Value *GetValueAtEndOfBlock(BasicBlock *BB) {
+    syncAll();
+    return Updater.GetValueAtEndOfBlock(BB);
+  }
+
+private:
+  void syncAll() {
+    for (auto &[BB, VH] : TrackedVals)
+      Updater.AddAvailableValue(BB, VH);
+  }
 };
 
 /// Helper class for promoting a collection of loads and stores into SSA

--- a/llvm/unittests/Transforms/Utils/CMakeLists.txt
+++ b/llvm/unittests/Transforms/Utils/CMakeLists.txt
@@ -31,6 +31,7 @@ add_llvm_unittest(UtilsTests
   ScalarEvolutionExpanderTest.cpp
   SizeOptsTest.cpp
   SSAUpdaterBulkTest.cpp
+  TrackingSSAUpdaterTest.cpp
   UnrollLoopTest.cpp
   ValueMapperTest.cpp
   ProfDataUtilTest.cpp

--- a/llvm/unittests/Transforms/Utils/TrackingSSAUpdaterTest.cpp
+++ b/llvm/unittests/Transforms/Utils/TrackingSSAUpdaterTest.cpp
@@ -1,0 +1,161 @@
+//===- TrackingSSAUpdaterTest.cpp - Unit tests for TrackingSSAUpdater
+//------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Type.h"
+#include "llvm/Transforms/Utils/SSAUpdater.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+
+// Test that TrackingSSAUpdater follows RAUW and returns the replacement value.
+TEST(TrackingSSAUpdater, RAUWUpdatesAvailableValue) {
+  LLVMContext C;
+  Module M("TrackingSSAUpdaterTest", C);
+  IRBuilder<> B(C);
+  Type *I32Ty = B.getInt32Ty();
+
+  // Create: define void @f(i32 %arg) { entry: %v = add i32 %arg, 1; ret void }
+  auto *F = Function::Create(FunctionType::get(B.getVoidTy(), {I32Ty}, false),
+                             GlobalValue::ExternalLinkage, "f", &M);
+  Argument *Arg = &*F->arg_begin();
+  BasicBlock *Entry = BasicBlock::Create(C, "entry", F);
+  B.SetInsertPoint(Entry);
+  Value *V = B.CreateAdd(Arg, ConstantInt::get(I32Ty, 1), "v");
+  B.CreateRetVoid();
+
+  // Register %v as the available value for Entry.
+  TrackingSSAUpdater Updater;
+  Updater.Initialize(I32Ty, "test");
+  Updater.AddAvailableValue(Entry, V);
+  EXPECT_EQ(Updater.FindValueForBlock(Entry), V);
+  EXPECT_TRUE(Updater.HasValueForBlock(Entry));
+
+  // RAUW %v with a constant.
+  Value *Replacement = ConstantInt::get(I32Ty, 42);
+  V->replaceAllUsesWith(Replacement);
+
+  // TrackingSSAUpdater should now return the replacement.
+  EXPECT_EQ(Updater.FindValueForBlock(Entry), Replacement);
+}
+
+// Test that AddAvailableValue overwrites a previously tracked value.
+TEST(TrackingSSAUpdater, OverwriteAvailableValue) {
+  LLVMContext C;
+  Module M("TrackingSSAUpdaterTest", C);
+  IRBuilder<> B(C);
+  Type *I32Ty = B.getInt32Ty();
+
+  auto *F = Function::Create(FunctionType::get(B.getVoidTy(), false),
+                             GlobalValue::ExternalLinkage, "f", &M);
+  BasicBlock *Entry = BasicBlock::Create(C, "entry", F);
+  B.SetInsertPoint(Entry);
+  B.CreateRetVoid();
+
+  Value *C1 = ConstantInt::get(I32Ty, 1);
+  Value *C2 = ConstantInt::get(I32Ty, 2);
+
+  TrackingSSAUpdater Updater;
+  Updater.Initialize(I32Ty, "test");
+  Updater.AddAvailableValue(Entry, C1);
+  EXPECT_EQ(Updater.FindValueForBlock(Entry), C1);
+
+  Updater.AddAvailableValue(Entry, C2);
+  EXPECT_EQ(Updater.FindValueForBlock(Entry), C2);
+}
+
+// Test that GetValueInMiddleOfBlock returns the RAUW'd value after syncAll.
+TEST(TrackingSSAUpdater, GetValueInMiddleOfBlockAfterRAUW) {
+  LLVMContext C;
+  Module M("TrackingSSAUpdaterTest", C);
+  IRBuilder<> B(C);
+  Type *I32Ty = B.getInt32Ty();
+
+  // Create: define void @f(i32 %arg) { entry: %v = add %arg, 1; br bb2;
+  //                                     bb2: ret void }
+  auto *F = Function::Create(FunctionType::get(B.getVoidTy(), {I32Ty}, false),
+                             GlobalValue::ExternalLinkage, "f", &M);
+  Argument *Arg = &*F->arg_begin();
+  BasicBlock *Entry = BasicBlock::Create(C, "entry", F);
+  BasicBlock *BB2 = BasicBlock::Create(C, "bb2", F);
+
+  B.SetInsertPoint(Entry);
+  Value *V = B.CreateAdd(Arg, ConstantInt::get(I32Ty, 1), "v");
+  B.CreateBr(BB2);
+
+  B.SetInsertPoint(BB2);
+  B.CreateRetVoid();
+
+  // Register %v for Entry.
+  TrackingSSAUpdater Updater;
+  Updater.Initialize(I32Ty, "test");
+  Updater.AddAvailableValue(Entry, V);
+
+  // RAUW %v -> constant.
+  Value *Replacement = ConstantInt::get(I32Ty, 42);
+  V->replaceAllUsesWith(Replacement);
+
+  // GetValueInMiddleOfBlock for BB2 (single predecessor: Entry) should
+  // return the replacement, not the stale pointer.
+  Value *Result = Updater.GetValueInMiddleOfBlock(BB2);
+  EXPECT_EQ(Result, Replacement);
+}
+
+// Test that FindValueForBlock returns nullptr for an unregistered block.
+TEST(TrackingSSAUpdater, FindValueForUnknownBlock) {
+  LLVMContext C;
+  Module M("TrackingSSAUpdaterTest", C);
+  IRBuilder<> B(C);
+  Type *I32Ty = B.getInt32Ty();
+
+  auto *F = Function::Create(FunctionType::get(B.getVoidTy(), false),
+                             GlobalValue::ExternalLinkage, "f", &M);
+  BasicBlock *Entry = BasicBlock::Create(C, "entry", F);
+  BasicBlock *Other = BasicBlock::Create(C, "other", F);
+  B.SetInsertPoint(Entry);
+  B.CreateBr(Other);
+  B.SetInsertPoint(Other);
+  B.CreateRetVoid();
+
+  TrackingSSAUpdater Updater;
+  Updater.Initialize(I32Ty, "test");
+  Updater.AddAvailableValue(Entry, ConstantInt::get(I32Ty, 1));
+
+  EXPECT_EQ(Updater.FindValueForBlock(Other), nullptr);
+  EXPECT_FALSE(Updater.HasValueForBlock(Other));
+}
+
+// Test Initialize clears previous state.
+TEST(TrackingSSAUpdater, InitializeClearsPreviousState) {
+  LLVMContext C;
+  Module M("TrackingSSAUpdaterTest", C);
+  IRBuilder<> B(C);
+  Type *I32Ty = B.getInt32Ty();
+
+  auto *F = Function::Create(FunctionType::get(B.getVoidTy(), false),
+                             GlobalValue::ExternalLinkage, "f", &M);
+  BasicBlock *Entry = BasicBlock::Create(C, "entry", F);
+  B.SetInsertPoint(Entry);
+  B.CreateRetVoid();
+
+  TrackingSSAUpdater Updater;
+  Updater.Initialize(I32Ty, "first");
+  Updater.AddAvailableValue(Entry, ConstantInt::get(I32Ty, 1));
+  EXPECT_TRUE(Updater.HasValueForBlock(Entry));
+
+  // Re-initialize should clear tracked values.
+  Updater.Initialize(I32Ty, "second");
+  EXPECT_FALSE(Updater.HasValueForBlock(Entry));
+}


### PR DESCRIPTION
TrackingSSAUpdater wraps SSAUpdater with a parallel map of TrackingVH<Value> that automatically follows RAUW, preventing dangling pointers when tracked values are replaced and deleted.
First planned use is in AMDGPUPromoteAlloca, where the SSAUpdater can hold a raw pointer to a load instruction that is later RAUW'd and erased.

Assisted-By: cursor (claude).