### PR TITLE
[Offload] Enable the AMDGPU plugin on Linux riscv64 hosts

### DIFF
--- a/offload/CMakeLists.txt
+++ b/offload/CMakeLists.txt
@@ -171,13 +171,16 @@ endif()
 list(APPEND LIBOMPTARGET_PLUGINS_TO_BUILD "host")
 list(REMOVE_DUPLICATES LIBOMPTARGET_PLUGINS_TO_BUILD)
 
-if(NOT (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(ppc64le)|(aarch64)$"
+if(NOT (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(ppc64le)|(aarch64)|(riscv64)$"
         AND CMAKE_SYSTEM_NAME MATCHES "Linux"))
   if("amdgpu" IN_LIST LIBOMPTARGET_PLUGINS_TO_BUILD)
     message(STATUS "Not building AMDGPU plugin: only support AMDGPU in "
-                   "Linux x86_64, ppc64le, or aarch64 hosts")
+                   "Linux x86_64, ppc64le, aarch64, or riscv64 hosts")
     list(REMOVE_ITEM LIBOMPTARGET_PLUGINS_TO_BUILD "amdgpu")
   endif()
+endif()
+if(NOT (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(ppc64le)|(aarch64)$"
+        AND CMAKE_SYSTEM_NAME MATCHES "Linux"))
   if("cuda" IN_LIST LIBOMPTARGET_PLUGINS_TO_BUILD)
     message(STATUS "Not building CUDA plugin: only support CUDA in "
                    "Linux x86_64, ppc64le, or aarch64 hosts")


### PR DESCRIPTION
The AMDGPU plugin is only built on Linux x86_64, ppc64le, and aarch64. That host-CPU whitelist wraps a plugin that talks to the HSA runtime through a portable C API; it is not an ISA-specific code generator. The host plugin already supports riscv64.

Add riscv64 to the AMDGPU whitelist so the plugin can be built on Linux riscv64 hosts. Leave the CUDA plugin on the existing host list; there is no CUDA toolchain on riscv64.