### PR TITLE
[libc++] Opt `std::*set` out of map key extraction optimization

### DIFF
--- a/libcxx/include/__hash_table
+++ b/libcxx/include/__hash_table
@@ -788,7 +788,7 @@ public:
 
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI pair<iterator, bool> __emplace_unique(_Args&&... __args) {
-    return std::__try_key_extraction<key_type>(
+    return std::__try_key_extraction<key_type, value_type>(
         [this](const key_type& __key, _Args&&... __args2) {
           size_t __hash   = hash_function()(__key);
           size_type __bc  = bucket_count();

--- a/libcxx/include/__tree
+++ b/libcxx/include/__tree
@@ -1074,7 +1074,7 @@ public:
 
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 pair<iterator, bool> __emplace_unique(_Args&&... __args) {
-    return std::__try_key_extraction<key_type>(
+    return std::__try_key_extraction<key_type, value_type>(
         [this](const key_type& __key, _Args&&... __args2) {
           auto [__parent, __child] = __find_equal(__key);
           __node_pointer __r       = std::__static_fancy_pointer_cast<__node_pointer>(__child);
@@ -1105,7 +1105,7 @@ public:
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 pair<iterator, bool>
   __emplace_hint_unique(const_iterator __p, _Args&&... __args) {
-    return std::__try_key_extraction<key_type>(
+    return std::__try_key_extraction<key_type, value_type>(
         [this, __p](const key_type& __key, _Args&&... __args2) {
           __node_base_pointer __dummy;
           auto [__parent, __child] = __find_equal(__p, __dummy, __key);
@@ -1182,7 +1182,7 @@ public:
     using __reference = decltype(*__first);
 
     for (; __first != __last; ++__first) {
-      std::__try_key_extraction<key_type>(
+      std::__try_key_extraction<key_type, value_type>(
           [this, &__max_node](const key_type& __key, __reference&& __val) {
             if (value_comp()(__max_node->__get_value(), __key)) { // __key > __max_node
               __node_holder __nd = __construct_node(std::forward<__reference>(__val));

--- a/libcxx/include/__utility/try_key_extraction.h
+++ b/libcxx/include/__utility/try_key_extraction.h
@@ -27,14 +27,14 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-template <class _KeyT, class _ValT, class _Ret, class _WithKey, class _WithoutKey, class... _Args>
+template <class _KeyT, bool, class _Ret, class _WithKey, class _WithoutKey, class... _Args>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 _Ret
 __try_key_extraction_impl(__priority_tag<0>, _WithKey, _WithoutKey __without_key, _Args&&... __args) {
   return __without_key(std::forward<_Args>(__args)...);
 }
 
 template <class _KeyT,
-          class _ValT,
+          bool,
           class _Ret,
           class _WithKey,
           class _WithoutKey,
@@ -46,12 +46,12 @@ __try_key_extraction_impl(__priority_tag<1>, _WithKey __with_key, _WithoutKey, _
 }
 
 template <class _KeyT,
-          class _ValT,
+          bool __is_map,
           class _Ret,
           class _WithKey,
           class _WithoutKey,
           class _Arg,
-          __enable_if_t<!is_same<_KeyT, _ValT>::value && __is_pair_v<__remove_const_ref_t<_Arg> > &&
+          __enable_if_t<__is_map && __is_pair_v<__remove_const_ref_t<_Arg> > &&
                             is_same<__remove_const_t<typename __remove_const_ref_t<_Arg>::first_type>, _KeyT>::value,
                         int> = 0>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 _Ret
@@ -60,13 +60,13 @@ __try_key_extraction_impl(__priority_tag<1>, _WithKey __with_key, _WithoutKey, _
 }
 
 template <class _KeyT,
-          class _ValT,
+          bool __is_map,
           class _Ret,
           class _WithKey,
           class _WithoutKey,
           class _Arg1,
           class _Arg2,
-          __enable_if_t<!is_same<_KeyT, _ValT>::value && is_same<_KeyT, __remove_const_ref_t<_Arg1> >::value, int> = 0>
+          __enable_if_t<__is_map && is_same<_KeyT, __remove_const_ref_t<_Arg1> >::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 _Ret
 __try_key_extraction_impl(__priority_tag<1>, _WithKey __with_key, _WithoutKey, _Arg1&& __arg1, _Arg2&& __arg2) {
   return __with_key(__arg1, std::forward<_Arg1>(__arg1), std::forward<_Arg2>(__arg2));
@@ -74,14 +74,14 @@ __try_key_extraction_impl(__priority_tag<1>, _WithKey __with_key, _WithoutKey, _
 
 #ifndef _LIBCPP_CXX03_LANG
 template <class _KeyT,
-          class _ValT,
+          bool __is_map,
           class _Ret,
           class _WithKey,
           class _WithoutKey,
           class _PiecewiseConstruct,
           class _Tuple1,
           class _Tuple2,
-          __enable_if_t<!is_same<_KeyT, _ValT>::value &&
+          __enable_if_t<__is_map &&
                             is_same<__remove_const_ref_t<_PiecewiseConstruct>, piecewise_construct_t>::value &&
                             __is_tuple_v<_Tuple1> && tuple_size<_Tuple1>::value == 1 &&
                             is_same<__remove_const_ref_t<typename tuple_element<0, _Tuple1>::type>, _KeyT>::value,
@@ -110,7 +110,7 @@ template <class _KeyT, class _ValT, class _WithKey, class _WithoutKey, class... 
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 decltype(std::declval<_WithoutKey>()(std::declval<_Args>()...))
 __try_key_extraction(_WithKey __with_key, _WithoutKey __without_key, _Args&&... __args) {
   using _Ret = decltype(__without_key(std::forward<_Args>(__args)...));
-  return std::__try_key_extraction_impl<_KeyT, _ValT, _Ret>(
+  return std::__try_key_extraction_impl<_KeyT, !is_same<_KeyT, _ValT>::value, _Ret>(
       __priority_tag<1>(), __with_key, __without_key, std::forward<_Args>(__args)...);
 }
 

--- a/libcxx/include/__utility/try_key_extraction.h
+++ b/libcxx/include/__utility/try_key_extraction.h
@@ -27,13 +27,14 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-template <class _KeyT, class _Ret, class _WithKey, class _WithoutKey, class... _Args>
+template <class _KeyT, class _ValT, class _Ret, class _WithKey, class _WithoutKey, class... _Args>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 _Ret
 __try_key_extraction_impl(__priority_tag<0>, _WithKey, _WithoutKey __without_key, _Args&&... __args) {
   return __without_key(std::forward<_Args>(__args)...);
 }
 
 template <class _KeyT,
+          class _ValT,
           class _Ret,
           class _WithKey,
           class _WithoutKey,
@@ -45,11 +46,12 @@ __try_key_extraction_impl(__priority_tag<1>, _WithKey __with_key, _WithoutKey, _
 }
 
 template <class _KeyT,
+          class _ValT,
           class _Ret,
           class _WithKey,
           class _WithoutKey,
           class _Arg,
-          __enable_if_t<__is_pair_v<__remove_const_ref_t<_Arg> > &&
+          __enable_if_t<!is_same<_KeyT, _ValT>::value && __is_pair_v<__remove_const_ref_t<_Arg> > &&
                             is_same<__remove_const_t<typename __remove_const_ref_t<_Arg>::first_type>, _KeyT>::value,
                         int> = 0>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 _Ret
@@ -58,12 +60,13 @@ __try_key_extraction_impl(__priority_tag<1>, _WithKey __with_key, _WithoutKey, _
 }
 
 template <class _KeyT,
+          class _ValT,
           class _Ret,
           class _WithKey,
           class _WithoutKey,
           class _Arg1,
           class _Arg2,
-          __enable_if_t<is_same<_KeyT, __remove_const_ref_t<_Arg1> >::value, int> = 0>
+          __enable_if_t<!is_same<_KeyT, _ValT>::value && is_same<_KeyT, __remove_const_ref_t<_Arg1> >::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 _Ret
 __try_key_extraction_impl(__priority_tag<1>, _WithKey __with_key, _WithoutKey, _Arg1&& __arg1, _Arg2&& __arg2) {
   return __with_key(__arg1, std::forward<_Arg1>(__arg1), std::forward<_Arg2>(__arg2));
@@ -71,13 +74,15 @@ __try_key_extraction_impl(__priority_tag<1>, _WithKey __with_key, _WithoutKey, _
 
 #ifndef _LIBCPP_CXX03_LANG
 template <class _KeyT,
+          class _ValT,
           class _Ret,
           class _WithKey,
           class _WithoutKey,
           class _PiecewiseConstruct,
           class _Tuple1,
           class _Tuple2,
-          __enable_if_t<is_same<__remove_const_ref_t<_PiecewiseConstruct>, piecewise_construct_t>::value &&
+          __enable_if_t<!is_same<_KeyT, _ValT>::value &&
+                            is_same<__remove_const_ref_t<_PiecewiseConstruct>, piecewise_construct_t>::value &&
                             __is_tuple_v<_Tuple1> && tuple_size<_Tuple1>::value == 1 &&
                             is_same<__remove_const_ref_t<typename tuple_element<0, _Tuple1>::type>, _KeyT>::value,
                         int> = 0>
@@ -101,11 +106,11 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 _Ret __try_key_extraction_im
 // arguments. Otherwise it calls the `__without_key` function with all of the arguments.
 //
 // Both `__with_key` and `__without_key` must take all arguments by reference.
-template <class _KeyT, class _WithKey, class _WithoutKey, class... _Args>
+template <class _KeyT, class _ValT, class _WithKey, class _WithoutKey, class... _Args>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 decltype(std::declval<_WithoutKey>()(std::declval<_Args>()...))
 __try_key_extraction(_WithKey __with_key, _WithoutKey __without_key, _Args&&... __args) {
   using _Ret = decltype(__without_key(std::forward<_Args>(__args)...));
-  return std::__try_key_extraction_impl<_KeyT, _Ret>(
+  return std::__try_key_extraction_impl<_KeyT, _ValT, _Ret>(
       __priority_tag<1>(), __with_key, __without_key, std::forward<_Args>(__args)...);
 }
 

--- a/libcxx/include/__utility/try_key_extraction.h
+++ b/libcxx/include/__utility/try_key_extraction.h
@@ -81,8 +81,7 @@ template <class _KeyT,
           class _PiecewiseConstruct,
           class _Tuple1,
           class _Tuple2,
-          __enable_if_t<__is_map &&
-                            is_same<__remove_const_ref_t<_PiecewiseConstruct>, piecewise_construct_t>::value &&
+          __enable_if_t<__is_map && is_same<__remove_const_ref_t<_PiecewiseConstruct>, piecewise_construct_t>::value &&
                             __is_tuple_v<_Tuple1> && tuple_size<_Tuple1>::value == 1 &&
                             is_same<__remove_const_ref_t<typename tuple_element<0, _Tuple1>::type>, _KeyT>::value,
                         int> = 0>

--- a/libcxx/test/std/containers/associative/set/emplace.pass.cpp
+++ b/libcxx/test/std/containers/associative/set/emplace.pass.cpp
@@ -17,7 +17,6 @@
 
 #include <cassert>
 #include <set>
-#include <string>
 
 #include "../../Emplaceable.h"
 #include "DefaultOnly.h"
@@ -93,15 +92,21 @@ TEST_CONSTEXPR_CXX26 bool test() {
     assert(std::get<1>(res));
     assert(set.begin() == std::get<0>(res));
   }
-  if (!TEST_IS_CONSTANT_EVALUATED) {
-    // Regression test for #220451
+  { // Regression test for https://llvm.org/PR220451.
     // Make sure emplace with multiple arguments doesn't extract the first argument as a key for sets.
-    std::set<std::string> s;
-    s.emplace("foo");
-    auto res = s.emplace(std::string("ofoo"), 1);
+    struct S {
+      const int val;
+      TEST_CONSTEXPR explicit S(int v) : val(v) {}
+      TEST_CONSTEXPR S(const S& s, int offset) : val(s.val + offset) {}
+      TEST_CONSTEXPR bool operator<(const S& other) const { return val < other.val; }
+      TEST_CONSTEXPR bool operator==(const S& other) const { return val == other.val; }
+    };
+    std::set<S> s;
+    s.emplace(2);
+    auto res = s.emplace(S(1), 1);
     assert(!res.second);
     assert(s.size() == 1);
-    assert(*s.begin() == "foo");
+    assert(s.begin()->val == 2);
   }
 
   return true;

--- a/libcxx/test/std/containers/associative/set/emplace.pass.cpp
+++ b/libcxx/test/std/containers/associative/set/emplace.pass.cpp
@@ -17,6 +17,7 @@
 
 #include <cassert>
 #include <set>
+#include <string>
 
 #include "../../Emplaceable.h"
 #include "DefaultOnly.h"
@@ -91,6 +92,15 @@ TEST_CONSTEXPR_CXX26 bool test() {
     auto res = set.emplace(std::pair<MoveOnly, MoveOnly>(2, 4));
     assert(std::get<1>(res));
     assert(set.begin() == std::get<0>(res));
+  }
+  { // Regression test for #220451
+    // Make sure emplace with multiple arguments doesn't extract the first argument as a key for sets.
+    std::set<std::string> s;
+    s.emplace("foo");
+    auto res = s.emplace(std::string("ofoo"), 1);
+    assert(!res.second);
+    assert(s.size() == 1);
+    assert(*s.begin() == "foo");
   }
 
   return true;

--- a/libcxx/test/std/containers/associative/set/emplace.pass.cpp
+++ b/libcxx/test/std/containers/associative/set/emplace.pass.cpp
@@ -93,7 +93,8 @@ TEST_CONSTEXPR_CXX26 bool test() {
     assert(std::get<1>(res));
     assert(set.begin() == std::get<0>(res));
   }
-  { // Regression test for #220451
+  if (!TEST_IS_CONSTANT_EVALUATED) {
+    // Regression test for #220451
     // Make sure emplace with multiple arguments doesn't extract the first argument as a key for sets.
     std::set<std::string> s;
     s.emplace("foo");

--- a/libcxx/test/std/containers/unord/unord.set/emplace.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.set/emplace.pass.cpp
@@ -18,6 +18,7 @@
 //     pair<iterator, bool> emplace(Args&&... args);
 
 #include <cassert>
+#include <string>
 #include <unordered_set>
 
 #include "../../Emplaceable.h"
@@ -74,6 +75,15 @@ int main(int, char**) {
     auto res = set.emplace(std::pair<MoveOnly, MoveOnly>(2, 4));
     assert(std::get<1>(res));
     assert(set.begin() == std::get<0>(res));
+  }
+  { // Regression test for #220451
+    // Make sure emplace with multiple arguments doesn't extract the first argument as a key for unordered sets.
+    std::unordered_set<std::string> s;
+    s.emplace("foo");
+    auto res = s.emplace(std::string("ofoo"), 1);
+    assert(!res.second);
+    assert(s.size() == 1);
+    assert(*s.begin() == "foo");
   }
 
   return 0;

--- a/libcxx/test/std/containers/unord/unord.set/emplace.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.set/emplace.pass.cpp
@@ -76,7 +76,7 @@ int main(int, char**) {
     assert(std::get<1>(res));
     assert(set.begin() == std::get<0>(res));
   }
-  { // Regression test for #220451
+  { // Regression test for https://llvm.org/PR220451.
     // Make sure emplace with multiple arguments doesn't extract the first argument as a key for unordered sets.
     std::unordered_set<std::string> s;
     s.emplace("foo");


### PR DESCRIPTION
PR #154512 (relanded by #155565) removed `__can_extract_map_key`, which had a blanket opt-out for `std::*set`s. The new logic does not have that opt-out, leading to `std::set`s being incorrectly constructed.

The new regression tests demonstrate this, but essentially the idea is:
1. Have `std::set<T> foo;`
2. Call `foo.emplace(some_t, arg_that_influences_comparisons_or_hashes);`
3. The emplace will internally search using `some_t` as the key, *not* `T(some_t, arg_that_influences_comparisons_or_hashes);`

This opts out `std::*set` from this optimization to match previous behavior.

Tests and fix were produced by an LLM. I reviewed them and they seem reasonable to me, though I don't have a strong background in libc++ testing conventions.

(Credit to Deva S, our partner who tracked this down. Unfortunately I don't know his GH handle)

Fixes #220451