### PR TITLE
[orc-rt] Don't parse program name in CommandLineParser::parse

### DIFF
--- a/orc-rt/include/orc-rt-internal/tools/CommandLine.h
+++ b/orc-rt/include/orc-rt-internal/tools/CommandLine.h
@@ -152,13 +152,15 @@ public:
     return std::move(OS).str();
   }
 
+  /// Parse an argument list.
+  ///
+  /// Iterators should be over program arguments only, and should not include
+  /// the program name as the first argument.
   template <typename I> orc_rt::Error parse(I Begin, I End) {
     std::for_each(Opts.begin(), Opts.end(),
                   [](const Option &O) { O.Default(); });
     Positionals.clear();
     bool AfterDashDash = false;
-    if (Begin != End)
-      Begin++;
 
     for (auto It = Begin; It != End; ++It) {
       std::string_view Tok(*It);
@@ -206,8 +208,12 @@ public:
     return orc_rt::Error::success();
   }
 
-  orc_rt::Error parse(int argc, char **argv) {
-    return parse(argv, argv + argc);
+  /// Parse main-like args: argc must be >= 1, and argv[0] must contain the
+  /// program name.
+  orc_rt::Error parseAsMainArgs(int argc, char **argv) {
+    if (argc == 0)
+      return make_error<StringError>("no program-name argument in argv[0]");
+    return parse(argv + 1, argv + argc);
   }
 
   const std::vector<std::string> &positionals() const { return Positionals; }

--- a/orc-rt/test/unit/tools/CommandLineTest.cpp
+++ b/orc-rt/test/unit/tools/CommandLineTest.cpp
@@ -33,13 +33,13 @@ protected:
 
 TEST_F(CommandLineParserTest, NoopTest) {
   CommandLineParser Parser;
-  const char *Argv[] = {"appname"};
-  auto Err = Parser.parse(1, const_cast<char **>(Argv));
+  const char *Argv[] = {""};
+  auto Err = Parser.parse(std::begin(Argv), std::end(Argv));
   EXPECT_FALSE(!!Err);
 }
 
 TEST_F(CommandLineParserTest, ValueRequired) {
-  const char *Argv[] = {"appname", "--host"};
+  const char *Argv[] = {"--host"};
   auto Err = Parser.parse(std::begin(Argv), std::end(Argv));
   if (!Err) {
     ADD_FAILURE() << "--host requires a value, shouldn't succeed.";
@@ -49,7 +49,7 @@ TEST_F(CommandLineParserTest, ValueRequired) {
 }
 
 TEST_F(CommandLineParserTest, UnknownOption) {
-  const char *Argv[] = {"appname", "--unknown=foo"};
+  const char *Argv[] = {"--unknown=foo"};
   auto Err = Parser.parse(std::begin(Argv), std::end(Argv));
   if (!Err) {
     ADD_FAILURE() << "unknown option, shouldn't succeed.";
@@ -59,7 +59,7 @@ TEST_F(CommandLineParserTest, UnknownOption) {
 }
 
 TEST_F(CommandLineParserTest, InvalidInteger) {
-  const char *Argv[] = {"appname", "--port=not_a_number"};
+  const char *Argv[] = {"--port=not_a_number"};
   auto Err = Parser.parse(std::begin(Argv), std::end(Argv));
   if (!Err) {
     ADD_FAILURE() << "Invalid integer, shouldn't succeed.";
@@ -69,8 +69,7 @@ TEST_F(CommandLineParserTest, InvalidInteger) {
 }
 
 TEST_F(CommandLineParserTest, ParseFullConfiguration) {
-  const char *Argv[] = {"appname", "--host=example.com", "--port=8080",
-                        "--verbose=true"};
+  const char *Argv[] = {"--host=example.com", "--port=8080", "--verbose=true"};
   cantFail(Parser.parse(std::begin(Argv), std::end(Argv)));
   EXPECT_EQ(Host, "example.com");
   EXPECT_EQ(Port, 8080);
@@ -78,36 +77,60 @@ TEST_F(CommandLineParserTest, ParseFullConfiguration) {
 }
 
 TEST_F(CommandLineParserTest, ShortFlagClustering) {
-  const char *Argv[] = {"appname", "-v?"};
+  const char *Argv[] = {"-v?"};
   cantFail(Parser.parse(std::begin(Argv), std::end(Argv)));
   EXPECT_TRUE(Verbose);
   EXPECT_TRUE(Help);
 }
 
 TEST_F(CommandLineParserTest, ShortFlagWithValue) {
-  const char *Argv[] = {"appname", "-p", "1234", "-hlocalhost"};
+  const char *Argv[] = {"-p", "1234", "-hlocalhost"};
   cantFail(Parser.parse(std::begin(Argv), std::end(Argv)));
   EXPECT_EQ(Port, 1234);
   EXPECT_EQ(Host, "localhost");
 }
 
 TEST_F(CommandLineParserTest, ClusterWithValueAtEnd) {
-  const char *Argv[] = {"appname", "-vp9999"};
+  const char *Argv[] = {"-vp9999"};
   cantFail(Parser.parse(std::begin(Argv), std::end(Argv)));
   EXPECT_TRUE(Verbose);
   EXPECT_EQ(Port, 9999);
 }
 
 TEST_F(CommandLineParserTest, DoubleDashTerminatesOptionParsing) {
-  const char *Argv[] = {"appname", "-v", "--", "-p", "1234"};
-  cantFail(Parser.parse(static_cast<int>(std::size(Argv)),
-                        const_cast<char **>(Argv)));
+  const char *Argv[] = {"-v", "--", "-p", "1234"};
+  cantFail(Parser.parse(std::begin(Argv), std::end(Argv)));
 
   EXPECT_TRUE(Verbose);
   EXPECT_EQ(Port, 8080); // Should remain default
   ASSERT_EQ(Parser.positionals().size(), 2u);
   EXPECT_EQ(Parser.positionals()[0], "-p");
   EXPECT_EQ(Parser.positionals()[1], "1234");
+}
+
+TEST_F(CommandLineParserTest, ParseAsMainWithEmptyArgsSucceeds) {
+  const char *Argv[] = {"appname"};
+  auto Err = Parser.parseAsMainArgs(std::size(Argv), const_cast<char **>(Argv));
+  EXPECT_FALSE(!!Err);
+}
+
+TEST_F(CommandLineParserTest, ParseAsMainWithRegularArgsSucceeds) {
+  const char *Argv[] = {"appname", "-v", "--", "-p", "1234"};
+  cantFail(Parser.parseAsMainArgs(std::size(Argv), const_cast<char **>(Argv)));
+
+  EXPECT_TRUE(Verbose);
+  EXPECT_EQ(Port, 8080); // Should remain default
+  ASSERT_EQ(Parser.positionals().size(), 2u);
+  EXPECT_EQ(Parser.positionals()[0], "-p");
+  EXPECT_EQ(Parser.positionals()[1], "1234");
+}
+
+TEST_F(CommandLineParserTest, ParseAsMainWithEmplyListFails) {
+  const char *Argv[] = {};
+  auto Err = Parser.parseAsMainArgs(0, const_cast<char **>(Argv));
+
+  EXPECT_TRUE(!!Err);
+  consumeError(std::move(Err));
 }
 
 TEST_F(CommandLineParserTest, PrintHelpAlignmentWithShortFlags) {


### PR DESCRIPTION
The iterator-based CommandLineParser::parse method expected a program name as the first argument in the list, but did not do anything with its value (it was simply skipped). Update it to expect argument strings only (no program name as first element) and document the new expectation.

The (argc, argv) overload of parse is renamed to parseAsMainArgs. It still expects a program name as the first argument and will return an Error if it is not present.

This allows CommandLineParser::parse to be used in contexts where there is no natural program name (e.g. in unit tests, and options read from config files).