### PR TITLE
[orc-rt] Fix test tools broken by c3a9c64492b.

### DIFF
--- a/orc-rt/test/tools/orc-rt-log-check.cpp
+++ b/orc-rt/test/tools/orc-rt-log-check.cpp
@@ -78,7 +78,7 @@ int main(int argc, char *argv[]) {
                   -1, UID)
         .addFlag("help", "Print help", false, PrintHelp);
 
-    if (auto Err = P.parse(argc, argv)) {
+    if (auto Err = P.parseAsMainArgs(argc, argv)) {
       std::cerr << "error: " << orc_rt::toString(std::move(Err)) << "\n";
       std::cerr << P.formatHelp(argv[0]);
       return 1;

--- a/orc-rt/test/tools/orc-rt-process-info-check.cpp
+++ b/orc-rt/test/tools/orc-rt-process-info-check.cpp
@@ -28,7 +28,7 @@ int main(int argc, char *argv[]) {
                  PrintCPUFeatures)
         .addFlag("help", "Print help", false, PrintHelp);
 
-    if (auto Err = P.parse(argc, argv)) {
+    if (auto Err = P.parseAsMainArgs(argc, argv)) {
       std::cerr << "error: " << orc_rt::toString(std::move(Err)) << "\n";
       std::cerr << P.formatHelp(argv[0]);
       return 1;


### PR DESCRIPTION
Update regression test tools to use the parseAsMainArgs method introduced in c3a9c64492b.