### PR TITLE
[orc-rt] Rename CommandLineParser to OptionParser.

### DIFF
--- a/orc-rt/include/orc-rt-internal/tools/OptionParser.h
+++ b/orc-rt/include/orc-rt-internal/tools/OptionParser.h
@@ -1,4 +1,4 @@
-//===- CommandLine.h ------------------------------------------------------===//
+//===- OptionParser.h -------------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -11,8 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef ORC_RT_INTERNAL_TOOLS_COMMANDLINE_H
-#define ORC_RT_INTERNAL_TOOLS_COMMANDLINE_H
+#ifndef ORC_RT_INTERNAL_TOOLS_OPTIONPARSER_H
+#define ORC_RT_INTERNAL_TOOLS_OPTIONPARSER_H
 
 #include <algorithm>
 #include <charconv>
@@ -75,23 +75,23 @@ template <> inline std::optional<bool> parseValue<bool>(std::string_view Str) {
 }
 } // namespace detail
 
-class CommandLineParser {
+class OptionParser {
 public:
   enum class OptionKind { Flag, Value };
-  CommandLineParser() = default;
+  OptionParser() = default;
 
-  CommandLineParser &addFlag(std::string_view Name, std::string_view Desc,
-                             bool DefaultVal, bool &Val,
-                             std::optional<char> ShortName = std::nullopt) {
+  OptionParser &addFlag(std::string_view Name, std::string_view Desc,
+                        bool DefaultVal, bool &Val,
+                        std::optional<char> ShortName = std::nullopt) {
     return addValue(Name, Desc, DefaultVal, Val, OptionKind::Flag,
                     std::move(ShortName));
   }
 
   template <typename T>
-  CommandLineParser &addValue(std::string_view Name, std::string_view Desc,
-                              T DefaultVal, T &Val,
-                              OptionKind Kind = OptionKind::Value,
-                              std::optional<char> ShortName = std::nullopt) {
+  OptionParser &addValue(std::string_view Name, std::string_view Desc,
+                         T DefaultVal, T &Val,
+                         OptionKind Kind = OptionKind::Value,
+                         std::optional<char> ShortName = std::nullopt) {
     Val = DefaultVal;
     Opts.push_back({.Name = std::string(Name),
                     .ShortName = std::move(ShortName),
@@ -267,4 +267,4 @@ private:
 
 } // namespace orc_rt
 
-#endif // ORC_RT_INTERNAL_TOOLS_COMMANDLINE_H
+#endif // ORC_RT_INTERNAL_TOOLS_OPTIONPARSER_H

--- a/orc-rt/test/tools/orc-rt-log-check.cpp
+++ b/orc-rt/test/tools/orc-rt-log-check.cpp
@@ -25,7 +25,7 @@
 
 #include "orc-rt-c/support/Logging.h"
 
-#include "orc-rt-internal/tools/CommandLine.h"
+#include "orc-rt-internal/tools/OptionParser.h"
 
 #include <iostream>
 
@@ -68,7 +68,7 @@ int main(int argc, char *argv[]) {
   int UID = -1;
 
   {
-    orc_rt::CommandLineParser P;
+    orc_rt::OptionParser P;
     P.addFlag("print-backend", "Print log backend", false, PrintBackend)
         .addFlag("print-enabled-levels", "Print enabled log levels", false,
                  PrintEnabledLevels)

--- a/orc-rt/test/tools/orc-rt-process-info-check.cpp
+++ b/orc-rt/test/tools/orc-rt-process-info-check.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "orc-rt-internal/tools/CommandLine.h"
+#include "orc-rt-internal/tools/OptionParser.h"
 #include "orc-rt/bedrock/ExecutorProcessInfo.h"
 #include <iostream>
 
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   bool PrintHelp = false;
 
   {
-    orc_rt::CommandLineParser P;
+    orc_rt::OptionParser P;
     P.addFlag("print-triple", "Print the detected target triple", false,
               PrintTriple)
         .addFlag("print-page-size", "Print the detected page size", false,

--- a/orc-rt/test/unit/CMakeLists.txt
+++ b/orc-rt/test/unit/CMakeLists.txt
@@ -66,7 +66,7 @@ add_orc_rt_unittest(CoreTests
   bedrock/sps/SimpleNativeMemoryMapSPSCITest.cpp
   bedrock/sps/SimpleRemoteCATest.cpp
 
-  tools/CommandLineTest.cpp
+  tools/OptionParserTest.cpp
 
   DISABLE_LLVM_LINK_LLVM_DYLIB
   )

--- a/orc-rt/test/unit/tools/OptionParserTest.cpp
+++ b/orc-rt/test/unit/tools/OptionParserTest.cpp
@@ -1,4 +1,4 @@
-//===- CommandLineTest.cpp ------------------------------------------------===//
+//===- OptionParserTest.cpp -----------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,39 +6,39 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "orc-rt-internal/tools/CommandLine.h"
+#include "orc-rt-internal/tools/OptionParser.h"
 #include "orc-rt/support/Error.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
 
 using namespace orc_rt;
 
-class CommandLineParserTest : public ::testing::Test {
+class OptionParserTest : public ::testing::Test {
 protected:
   std::string Host;
   int Port = 0;
   bool Verbose = false;
   bool Help = false;
-  CommandLineParser Parser;
+  OptionParser Parser;
 
   void SetUp() override {
     Parser.addValue("host", "Hostname", std::string("localhost"), Host,
-                    CommandLineParser::OptionKind::Value, 'h');
+                    OptionParser::OptionKind::Value, 'h');
     Parser.addFlag("help", "Display this help message", false, Help, '?');
     Parser.addValue("port", "Port number", 8080, Port,
-                    CommandLineParser::OptionKind::Value, 'p');
+                    OptionParser::OptionKind::Value, 'p');
     Parser.addFlag("verbose", "Enable verbose logging", false, Verbose, 'v');
   }
 };
 
-TEST_F(CommandLineParserTest, NoopTest) {
-  CommandLineParser Parser;
+TEST_F(OptionParserTest, NoopTest) {
+  OptionParser Parser;
   const char *Argv[] = {""};
   auto Err = Parser.parse(std::begin(Argv), std::end(Argv));
   EXPECT_FALSE(!!Err);
 }
 
-TEST_F(CommandLineParserTest, ValueRequired) {
+TEST_F(OptionParserTest, ValueRequired) {
   const char *Argv[] = {"--host"};
   auto Err = Parser.parse(std::begin(Argv), std::end(Argv));
   if (!Err) {
@@ -48,7 +48,7 @@ TEST_F(CommandLineParserTest, ValueRequired) {
   }
 }
 
-TEST_F(CommandLineParserTest, UnknownOption) {
+TEST_F(OptionParserTest, UnknownOption) {
   const char *Argv[] = {"--unknown=foo"};
   auto Err = Parser.parse(std::begin(Argv), std::end(Argv));
   if (!Err) {
@@ -58,7 +58,7 @@ TEST_F(CommandLineParserTest, UnknownOption) {
   }
 }
 
-TEST_F(CommandLineParserTest, InvalidInteger) {
+TEST_F(OptionParserTest, InvalidInteger) {
   const char *Argv[] = {"--port=not_a_number"};
   auto Err = Parser.parse(std::begin(Argv), std::end(Argv));
   if (!Err) {
@@ -68,7 +68,7 @@ TEST_F(CommandLineParserTest, InvalidInteger) {
   }
 }
 
-TEST_F(CommandLineParserTest, ParseFullConfiguration) {
+TEST_F(OptionParserTest, ParseFullConfiguration) {
   const char *Argv[] = {"--host=example.com", "--port=8080", "--verbose=true"};
   cantFail(Parser.parse(std::begin(Argv), std::end(Argv)));
   EXPECT_EQ(Host, "example.com");
@@ -76,28 +76,28 @@ TEST_F(CommandLineParserTest, ParseFullConfiguration) {
   EXPECT_EQ(Verbose, true);
 }
 
-TEST_F(CommandLineParserTest, ShortFlagClustering) {
+TEST_F(OptionParserTest, ShortFlagClustering) {
   const char *Argv[] = {"-v?"};
   cantFail(Parser.parse(std::begin(Argv), std::end(Argv)));
   EXPECT_TRUE(Verbose);
   EXPECT_TRUE(Help);
 }
 
-TEST_F(CommandLineParserTest, ShortFlagWithValue) {
+TEST_F(OptionParserTest, ShortFlagWithValue) {
   const char *Argv[] = {"-p", "1234", "-hlocalhost"};
   cantFail(Parser.parse(std::begin(Argv), std::end(Argv)));
   EXPECT_EQ(Port, 1234);
   EXPECT_EQ(Host, "localhost");
 }
 
-TEST_F(CommandLineParserTest, ClusterWithValueAtEnd) {
+TEST_F(OptionParserTest, ClusterWithValueAtEnd) {
   const char *Argv[] = {"-vp9999"};
   cantFail(Parser.parse(std::begin(Argv), std::end(Argv)));
   EXPECT_TRUE(Verbose);
   EXPECT_EQ(Port, 9999);
 }
 
-TEST_F(CommandLineParserTest, DoubleDashTerminatesOptionParsing) {
+TEST_F(OptionParserTest, DoubleDashTerminatesOptionParsing) {
   const char *Argv[] = {"-v", "--", "-p", "1234"};
   cantFail(Parser.parse(std::begin(Argv), std::end(Argv)));
 
@@ -108,13 +108,13 @@ TEST_F(CommandLineParserTest, DoubleDashTerminatesOptionParsing) {
   EXPECT_EQ(Parser.positionals()[1], "1234");
 }
 
-TEST_F(CommandLineParserTest, ParseAsMainWithEmptyArgsSucceeds) {
+TEST_F(OptionParserTest, ParseAsMainWithEmptyArgsSucceeds) {
   const char *Argv[] = {"appname"};
   auto Err = Parser.parseAsMainArgs(std::size(Argv), const_cast<char **>(Argv));
   EXPECT_FALSE(!!Err);
 }
 
-TEST_F(CommandLineParserTest, ParseAsMainWithRegularArgsSucceeds) {
+TEST_F(OptionParserTest, ParseAsMainWithRegularArgsSucceeds) {
   const char *Argv[] = {"appname", "-v", "--", "-p", "1234"};
   cantFail(Parser.parseAsMainArgs(std::size(Argv), const_cast<char **>(Argv)));
 
@@ -125,7 +125,7 @@ TEST_F(CommandLineParserTest, ParseAsMainWithRegularArgsSucceeds) {
   EXPECT_EQ(Parser.positionals()[1], "1234");
 }
 
-TEST_F(CommandLineParserTest, ParseAsMainWithEmplyListFails) {
+TEST_F(OptionParserTest, ParseAsMainWithEmplyListFails) {
   const char *Argv[] = {};
   auto Err = Parser.parseAsMainArgs(0, const_cast<char **>(Argv));
 
@@ -133,7 +133,7 @@ TEST_F(CommandLineParserTest, ParseAsMainWithEmplyListFails) {
   consumeError(std::move(Err));
 }
 
-TEST_F(CommandLineParserTest, PrintHelpAlignmentWithShortFlags) {
+TEST_F(OptionParserTest, PrintHelpAlignmentWithShortFlags) {
   std::string LogFile;
   Parser.addValue("log-file", "Path to log", std::string("out.log"), LogFile);
 


### PR DESCRIPTION
"OptionParser" better describes what the class does: it parses a list of option strings, which need not come from a command line (e.g. options read from a config file, or constructed in a unit test).