### PR TITLE
[orc-rt] Add skeleton command-line options parsing to ogre

### DIFF
--- a/orc-rt/tools/ogre/CMakeLists.txt
+++ b/orc-rt/tools/ogre/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_executable(ogre ogre.cpp)
+target_compile_options(ogre PRIVATE ${ORC_RT_COMPILE_FLAGS})
 target_link_libraries(ogre PRIVATE orc-rt-bedrock)

--- a/orc-rt/tools/ogre/ogre.cpp
+++ b/orc-rt/tools/ogre/ogre.cpp
@@ -11,6 +11,50 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "orc-rt-internal/tools/OptionParser.h"
+
+#include <optional>
+#include <stdio.h>
+
+using namespace orc_rt;
+
+struct Options {
+  bool Verbose = false;
+};
+
+static std::optional<Options> parseArgs(int argc, char *argv[]) noexcept {
+  Options O;
+  bool ShowHelp = false;
+
+  OptionParser P;
+  P.addFlag("verbose", "Print verbose output", false, O.Verbose, 'v')
+      .addFlag("help", "Display this help message", false, ShowHelp, 'h');
+
+  auto PrintHelp = [&]() -> std::nullopt_t {
+    const char *ProgName = argc != 0 ? argv[0] : "ogre";
+    fprintf(stderr, "%s usage:\n%s\n", ProgName,
+            P.formatHelp(ProgName).c_str());
+    return std::nullopt;
+  };
+
+  if (auto Err = P.parseAsMainArgs(argc, argv)) {
+    fprintf(stderr, "error: %s\n", toString(std::move(Err)).c_str());
+    return PrintHelp();
+  }
+
+  if (ShowHelp)
+    return PrintHelp();
+
+  return O;
+}
+
 int main(int argc, char *argv[]) {
+  auto Opts = parseArgs(argc, argv);
+  if (!Opts)
+    return 1;
+
+  if (Opts->Verbose)
+    printf("*unintelligible grunts*\n");
+
   return 0;
 }


### PR DESCRIPTION
Just adds --help and --verbose options for now. The set can be extended by adding fields to the Options struct and corresponding rules to the parser.