### PR TITLE
[flang][acc] Extend coverage for offload target verifier

### DIFF
--- a/flang/include/flang/Optimizer/OpenACC/Support/FIROpenACCUtils.h
+++ b/flang/include/flang/Optimizer/OpenACC/Support/FIROpenACCUtils.h
@@ -16,6 +16,7 @@
 #include "mlir/Dialect/OpenACC/OpenACC.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/IR/Region.h"
 #include "mlir/IR/Value.h"
 #include <string>
 
@@ -98,6 +99,16 @@ createOrGetReductionRecipe(mlir::OpBuilder &builder, mlir::Location loc,
 /// \param stripDeclare If true (default), also strips declare operations
 /// \return The original value after stripping all intermediate operations
 mlir::Value getOriginalDef(mlir::Value value, bool stripDeclare = true);
+
+/// Returns true if \p symbol, used by \p user, is valid in an OpenACC offload
+/// region for FIR. When \p definingOpPtr is provided, it is set to the
+/// defining operation of \p symbol if one is found.
+bool isValidSymbolUse(mlir::Operation *user, mlir::SymbolRefAttr symbol,
+                      mlir::Operation **definingOpPtr = nullptr);
+
+/// Returns true if \p val may be used from OpenACC region \p region without
+/// further implicit data mapping.
+bool isValidValueUse(mlir::Value val, mlir::Region &region);
 
 } // namespace acc
 } // namespace fir

--- a/flang/lib/Optimizer/OpenACC/Analysis/FIROpenACCSupportAnalysis.cpp
+++ b/flang/lib/Optimizer/OpenACC/Analysis/FIROpenACCSupportAnalysis.cpp
@@ -49,47 +49,11 @@ FIROpenACCSupportAnalysis::emitNYI(Location loc, const Twine &message) {
 bool FIROpenACCSupportAnalysis::isValidSymbolUse(Operation *user,
                                                  SymbolRefAttr symbol,
                                                  Operation **definingOpPtr) {
-  // First check using the default OpenACC utility (recipes, device globals,
-  // acc routine, LLVM intrinsics, declare attribute).
-  Operation *definingOp = nullptr;
-  if (mlir::acc::isValidSymbolUse(user, symbol, &definingOp)) {
-    if (definingOpPtr)
-      *definingOpPtr = definingOp;
-    return true;
-  }
-
-  // Default said no; if we have no defining op, nothing more to check.
-  if (!definingOp)
-    return false;
-  if (definingOpPtr)
-    *definingOpPtr = definingOp;
-
-  // Functions marked as Fortran runtime are valid (GPU version expected
-  // to be offloaded).
-  if (definingOp->hasAttr("fir.runtime"))
-    return true;
-
-  // Functions with CUF device/global/host_device attribute are valid.
-  if (auto cufProcAttr = definingOp->getAttrOfType<cuf::ProcAttributeAttr>(
-          cuf::getProcAttrName())) {
-    if (cufProcAttr.getValue() != cuf::ProcAttribute::Host)
-      return true;
-  }
-
-  return false;
+  return fir::acc::isValidSymbolUse(user, symbol, definingOpPtr);
 }
 
 bool FIROpenACCSupportAnalysis::isValidValueUse(Value v, Region &region) {
-  // First check using the base utility.
-  if (mlir::acc::isValidValueUse(v, region))
-    return true;
-
-  // FIR-specific: fir.logical is a trivial scalar type that can be
-  // passed by value.
-  if (mlir::isa<fir::LogicalType>(v.getType()))
-    return true;
-
-  return false;
+  return fir::acc::isValidValueUse(v, region);
 }
 
 std::optional<mlir::acc::TypeSizeAndAlignment>

--- a/flang/lib/Optimizer/OpenACC/Support/FIROpenACCUtils.cpp
+++ b/flang/lib/Optimizer/OpenACC/Support/FIROpenACCUtils.cpp
@@ -14,7 +14,10 @@
 #include "flang/Optimizer/Builder/BoxValue.h"
 #include "flang/Optimizer/Builder/Complex.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
+#include "flang/Optimizer/Dialect/CUF/Attributes/CUFAttr.h"
+#include "flang/Optimizer/Dialect/CUF/CUFOps.h"
 #include "flang/Optimizer/Dialect/FIRAttr.h"
+#include "flang/Optimizer/Dialect/FIRDialect.h"
 #include "flang/Optimizer/Dialect/FIROps.h"
 #include "flang/Optimizer/Dialect/FIROpsSupport.h"
 #include "flang/Optimizer/Dialect/FIRType.h"
@@ -677,4 +680,111 @@ mlir::Value fir::acc::getOriginalDef(mlir::Value value, bool stripDeclare) {
   }
 
   return currentValue;
+}
+
+static bool isFIRPassByValueScalar(mlir::Type type) {
+  if (auto charTy = mlir::dyn_cast<fir::CharacterType>(type))
+    return charTy.hasConstantLen() && charTy.getLen() == 1;
+  return mlir::isa<fir::LogicalType>(type);
+}
+
+static bool isTriviallyCopyableRecordType(fir::RecordType recType) {
+  for (auto &field : recType.getTypeList()) {
+    mlir::Type fieldType = fir::unwrapRefType(field.second);
+    if (auto nested = mlir::dyn_cast<fir::RecordType>(fieldType)) {
+      if (!isTriviallyCopyableRecordType(nested))
+        return false;
+      continue;
+    }
+    if (fieldType.isIntOrIndexOrFloat() ||
+        mlir::isa<mlir::ComplexType>(fieldType) ||
+        isFIRPassByValueScalar(fieldType))
+      continue;
+    return false;
+  }
+  return true;
+}
+
+static bool isTriviallyCopyableScalarType(mlir::Type type) {
+  mlir::Type baseType = fir::unwrapRefType(type);
+  if (baseType.isIntOrIndexOrFloat() ||
+      mlir::isa<mlir::ComplexType>(baseType) ||
+      isFIRPassByValueScalar(baseType))
+    return true;
+  if (auto recType = mlir::dyn_cast<fir::RecordType>(baseType))
+    return isTriviallyCopyableRecordType(recType);
+  return false;
+}
+
+static bool isCUFKernelRegion(mlir::Region &region) {
+  mlir::Operation *parentOp = region.getParentOp();
+  if (!parentOp)
+    return false;
+  if (mlir::isa<cuf::KernelOp>(parentOp))
+    return true;
+  if (auto computeRegion = mlir::dyn_cast<mlir::acc::ComputeRegionOp>(parentOp))
+    return computeRegion.getOrigin() == cuf::KernelOp::getOperationName();
+  return false;
+}
+
+bool fir::acc::isValidSymbolUse(mlir::Operation *user,
+                                mlir::SymbolRefAttr symbol,
+                                mlir::Operation **definingOpPtr) {
+  // FIR uses `fir.use_stmt` for debugging; referenced symbols are not
+  // guaranteed to be defined in the module.
+  if (mlir::isa_and_nonnull<fir::UseStmtOp>(user))
+    return true;
+
+  mlir::Operation *definingOp = nullptr;
+  if (mlir::acc::isValidSymbolUse(user, symbol, &definingOp)) {
+    if (definingOpPtr)
+      *definingOpPtr = definingOp;
+    return true;
+  }
+
+  if (!definingOp)
+    return false;
+  if (definingOpPtr)
+    *definingOpPtr = definingOp;
+
+  if (definingOp->hasDiscardableAttr(
+          fir::FIROpsDialect::getFirRuntimeAttrName()))
+    return true;
+
+  if (auto cufProcAttr = definingOp->getAttrOfType<cuf::ProcAttributeAttr>(
+          cuf::getProcAttrName())) {
+    if (cufProcAttr.getValue() != cuf::ProcAttribute::Host)
+      return true;
+  }
+
+  return false;
+}
+
+bool fir::acc::isValidValueUse(mlir::Value val, mlir::Region &region) {
+  if (mlir::acc::isValidValueUse(val, region))
+    return true;
+
+  if (isFIRPassByValueScalar(val.getType()))
+    return true;
+
+  // Scalars, and aggregates composed solely of them, are passed by value to a
+  // CUF kernel. Thus they need neither to be device data nor to be mapped.
+  if (isCUFKernelRegion(region) && isTriviallyCopyableScalarType(val.getType()))
+    return true;
+
+  mlir::Type type = val.getType();
+  if (mlir::acc::isPointerLikeType(type) || mlir::acc::isMappableType(type) ||
+      fir::isa_ref_type(type)) {
+    mlir::Value original = fir::acc::getOriginalDef(val, /*stripDeclare=*/true);
+    mlir::Operation *definingOp = original.getDefiningOp();
+    if (!definingOp)
+      return false;
+    if (mlir::isa<ACC_DATA_ENTRY_OPS>(definingOp))
+      return true;
+    if (definingOp->hasDiscardableAttr(cuf::getDataAttrName()) ||
+        definingOp->hasDiscardableAttr("data_attr"))
+      return true;
+  }
+
+  return false;
 }

--- a/flang/test/Transforms/OpenACC/offload-target-verifier.fir
+++ b/flang/test/Transforms/OpenACC/offload-target-verifier.fir
@@ -201,8 +201,25 @@ func.func @test_cuf_kernel_invalid() {
   %c1 = arith.constant 1 : index
   %c1_i32 = arith.constant 1 : i32
   // expected-note @below {{value}}
-  %alloca = fir.alloca f32
+  %alloca = fir.alloca !fir.array<10xf32>
   // expected-warning @below {{1 illegal live-in value(s)}}
+  cuf.kernel<<<%c1_i32, %c1_i32>>> (%arg0 : index) = (%c1 : index) to (%c1 : index) step (%c1 : index) {
+    %coor = fir.coordinate_of %alloca, %arg0 : (!fir.ref<!fir.array<10xf32>>, index) -> !fir.ref<f32>
+    %load = fir.load %coor : !fir.ref<f32>
+    "fir.end"() : () -> ()
+  }
+  return
+}
+
+// -----
+
+// Test cuf.kernel region with host scalar live-in - should pass
+// (scalars are passed by value)
+func.func @test_cuf_kernel_scalar() {
+  %c1 = arith.constant 1 : index
+  %c1_i32 = arith.constant 1 : i32
+  %alloca = fir.alloca f32
+  // expected-remark @below {{passed validity check}}
   cuf.kernel<<<%c1_i32, %c1_i32>>> (%arg0 : index) = (%c1 : index) to (%c1 : index) step (%c1 : index) {
     %load = fir.load %alloca : !fir.ref<f32>
     "fir.end"() : () -> ()
@@ -321,7 +338,7 @@ fir.global @_QMmod1Evar1 : f32 {
 }
 
 func.func @test_use_stmt_no_declare() {
-  // expected-warning @below {{illegal symbol(s): _QMmod1Evar1}}
+  // expected-remark @below {{passed validity check}}
   acc.serial {
     fir.use_stmt "mod1" only_symbols[[@_QMmod1Evar1]]
     acc.yield
@@ -341,6 +358,258 @@ func.func @test_use_stmt_with_declare() {
   // expected-remark @below {{passed validity check}}
   acc.serial {
     fir.use_stmt "mod2" only_symbols[[@_QMmod2Evar2]]
+    acc.yield
+  }
+  return
+}
+
+// -----
+
+// A fir.use_stmt does not require the referenced symbol to have a definition.
+func.func @test_use_stmt_undefined_symbol() {
+  // expected-remark @below {{passed validity check}}
+  acc.serial {
+    fir.use_stmt "mod3" only_symbols[[@_QMmod3Evar3]]
+    acc.yield
+  }
+  return
+}
+
+// -----
+
+// A fir.use_stmt with only a module name has no symbol use to validate.
+func.func @test_use_stmt_module_name() {
+  // expected-remark @below {{passed validity check}}
+  acc.serial {
+    fir.use_stmt "mod4"
+    acc.yield
+  }
+  return
+}
+
+// -----
+
+func.func private @_FortranARuntime() attributes {fir.runtime}
+
+func.func @test_fir_runtime_symbol() {
+  // expected-remark @below {{passed validity check}}
+  acc.serial {
+    fir.call @_FortranARuntime() : () -> ()
+    acc.yield
+  }
+  return
+}
+
+// -----
+
+func.func private @cuf_device_proc() attributes {cuf.proc_attr = #cuf.cuda_proc<device>}
+
+func.func @test_cuf_device_proc() {
+  // expected-remark @below {{passed validity check}}
+  acc.serial {
+    fir.call @cuf_device_proc() : () -> ()
+    acc.yield
+  }
+  return
+}
+
+// -----
+
+func.func private @cuf_global_proc() attributes {cuf.proc_attr = #cuf.cuda_proc<global>}
+
+func.func @test_cuf_global_proc() {
+  // expected-remark @below {{passed validity check}}
+  acc.serial {
+    fir.call @cuf_global_proc() : () -> ()
+    acc.yield
+  }
+  return
+}
+
+// -----
+
+func.func private @cuf_grid_global_proc() attributes {cuf.proc_attr = #cuf.cuda_proc<grid_global>}
+
+func.func @test_cuf_grid_global_proc() {
+  // expected-remark @below {{passed validity check}}
+  acc.serial {
+    fir.call @cuf_grid_global_proc() : () -> ()
+    acc.yield
+  }
+  return
+}
+
+// -----
+
+func.func private @cuf_host_device_proc() attributes {cuf.proc_attr = #cuf.cuda_proc<host_device>}
+
+func.func @test_cuf_host_device_proc() {
+  // expected-remark @below {{passed validity check}}
+  acc.serial {
+    fir.call @cuf_host_device_proc() : () -> ()
+    acc.yield
+  }
+  return
+}
+
+// -----
+
+func.func private @cuf_host_proc() attributes {cuf.proc_attr = #cuf.cuda_proc<host>}
+
+func.func @test_cuf_host_proc() {
+  // expected-warning @below {{illegal symbol(s): cuf_host_proc}}
+  acc.serial {
+    fir.call @cuf_host_proc() : () -> ()
+    acc.yield
+  }
+  return
+}
+
+// -----
+
+func.func @test_undefined_symbol() {
+  // expected-warning @below {{illegal symbol(s): undefined_proc}}
+  acc.serial {
+    fir.call @undefined_proc() : () -> ()
+    acc.yield
+  }
+  return
+}
+
+// -----
+
+// A length-one FIR character is passed by value.
+func.func @test_fir_character_scalar() {
+  %alloca = fir.alloca !fir.char<1,1>
+  %livein = fir.load %alloca : !fir.ref<!fir.char<1,1>>
+  // expected-remark @below {{passed validity check}}
+  acc.serial {
+    %sink = fir.alloca !fir.char<1,1>
+    fir.store %livein to %sink : !fir.ref<!fir.char<1,1>>
+    acc.yield
+  }
+  return
+}
+
+// -----
+
+// A multi-character FIR value is not passed as a scalar.
+func.func @test_fir_character_nonscalar() {
+  %alloca = fir.alloca !fir.char<1,2>
+  // expected-note @below {{value}}
+  %livein = fir.load %alloca : !fir.ref<!fir.char<1,2>>
+  // expected-warning @below {{1 illegal live-in value(s)}}
+  acc.serial {
+    %sink = fir.alloca !fir.char<1,2>
+    fir.store %livein to %sink : !fir.ref<!fir.char<1,2>>
+    acc.yield
+  }
+  return
+}
+
+// -----
+
+// A complex scalar is passed by value to a CUF kernel.
+func.func @test_cuf_kernel_complex_scalar() {
+  %c1 = arith.constant 1 : index
+  %c1_i32 = arith.constant 1 : i32
+  %alloca = fir.alloca complex<f32>
+  // expected-remark @below {{passed validity check}}
+  cuf.kernel<<<%c1_i32, %c1_i32>>> (%arg0 : index) = (%c1 : index) to (%c1 : index) step (%c1 : index) {
+    %load = fir.load %alloca : !fir.ref<complex<f32>>
+    "fir.end"() : () -> ()
+  }
+  return
+}
+
+// -----
+
+// A record composed of scalar fields is passed by value to a CUF kernel.
+func.func @test_cuf_kernel_record_scalar() {
+  %c1 = arith.constant 1 : index
+  %c1_i32 = arith.constant 1 : i32
+  %alloca = fir.alloca !fir.type<_QFTpoint{x:f32,y:i32}>
+  // expected-remark @below {{passed validity check}}
+  cuf.kernel<<<%c1_i32, %c1_i32>>> (%arg0 : index) = (%c1 : index) to (%c1 : index) step (%c1 : index) {
+    %load = fir.load %alloca : !fir.ref<!fir.type<_QFTpoint{x:f32,y:i32}>>
+    "fir.end"() : () -> ()
+  }
+  return
+}
+
+// -----
+
+// Trivially-copyable records may be nested.
+func.func @test_cuf_kernel_nested_record_scalar() {
+  %c1 = arith.constant 1 : index
+  %c1_i32 = arith.constant 1 : i32
+  %alloca = fir.alloca !fir.type<_QFTouter{inner:!fir.type<_QFTinner{x:f32}>,flag:!fir.logical<4>}>
+  // expected-remark @below {{passed validity check}}
+  cuf.kernel<<<%c1_i32, %c1_i32>>> (%arg0 : index) = (%c1 : index) to (%c1 : index) step (%c1 : index) {
+    %load = fir.load %alloca : !fir.ref<!fir.type<_QFTouter{inner:!fir.type<_QFTinner{x:f32}>,flag:!fir.logical<4>}>>
+    "fir.end"() : () -> ()
+  }
+  return
+}
+
+// -----
+
+// A record containing an array is not passed by value.
+func.func @test_cuf_kernel_nonscalar_record() {
+  %c1 = arith.constant 1 : index
+  %c1_i32 = arith.constant 1 : i32
+  // expected-note @below {{value}}
+  %alloca = fir.alloca !fir.type<_QFTwitharray{values:!fir.array<10xf32>}>
+  // expected-warning @below {{1 illegal live-in value(s)}}
+  cuf.kernel<<<%c1_i32, %c1_i32>>> (%arg0 : index) = (%c1 : index) to (%c1 : index) step (%c1 : index) {
+    %load = fir.load %alloca : !fir.ref<!fir.type<_QFTwitharray{values:!fir.array<10xf32>}>>
+    "fir.end"() : () -> ()
+  }
+  return
+}
+
+// -----
+
+// A nested record is not passable by value if any nested field is not.
+func.func @test_cuf_kernel_nested_nonscalar_record() {
+  %c1 = arith.constant 1 : index
+  %c1_i32 = arith.constant 1 : i32
+  // expected-note @below {{value}}
+  %alloca = fir.alloca !fir.type<_QFTbadouter{inner:!fir.type<_QFTbadinner{values:!fir.array<10xf32>}>}>
+  // expected-warning @below {{1 illegal live-in value(s)}}
+  cuf.kernel<<<%c1_i32, %c1_i32>>> (%arg0 : index) = (%c1 : index) to (%c1 : index) step (%c1 : index) {
+    %load = fir.load %alloca : !fir.ref<!fir.type<_QFTbadouter{inner:!fir.type<_QFTbadinner{values:!fir.array<10xf32>}>}>>
+    "fir.end"() : () -> ()
+  }
+  return
+}
+
+// -----
+
+// CUF-originated compute regions use the same scalar live-in rules.
+func.func @test_cuf_compute_region_record_scalar() {
+  %alloca = fir.alloca !fir.type<_QFTcompute_point{x:f32}>
+  %decl = fir.declare %alloca {uniq_name = "_QFEpoint"} : (!fir.ref<!fir.type<_QFTcompute_point{x:f32}>>) -> !fir.ref<!fir.type<_QFTcompute_point{x:f32}>>
+  %blocks = acc.par_width par_dim(#acc.par_dim<block_x>)
+  %threads = acc.par_width par_dim(#acc.par_dim<thread_x>)
+  // expected-remark @below {{passed validity check}}
+  acc.compute_region launch(%arg0 = %blocks, %arg1 = %threads) ins(%arg2 = %decl) : (!fir.ref<!fir.type<_QFTcompute_point{x:f32}>>) {
+    %load = fir.load %arg2 : !fir.ref<!fir.type<_QFTcompute_point{x:f32}>>
+    acc.yield
+  } <{kernel_func_name = @cuf_compute_region_record_scalar, kernel_module_name = @cuda_device_mod, origin = "cuf.kernel"}>
+  return
+}
+
+// -----
+
+// A view of an ACC data-entry value remains valid.
+func.func @test_acc_data_entry_view() {
+  %alloca = fir.alloca f32
+  %copyin = acc.copyin varPtr(%alloca : !fir.ref<f32>) -> !fir.ref<f32>
+  %view = fir.convert %copyin : (!fir.ref<f32>) -> !fir.ptr<f32>
+  // expected-remark @below {{passed validity check}}
+  acc.serial {
+    %load = fir.load %view : !fir.ptr<f32>
     acc.yield
   }
   return

--- a/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtils.cpp
+++ b/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtils.cpp
@@ -8,13 +8,16 @@
 
 #include "mlir/Dialect/OpenACC/OpenACCUtils.h"
 
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/OpenACC/OpenACC.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dominance.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/IR/Intrinsics.h"
@@ -189,9 +192,34 @@ mlir::Value mlir::acc::getBaseEntity(mlir::Value val) {
   return val;
 }
 
+/// Look up `symbol` in the `gpu.module`s of the enclosing module. A
+/// `gpu.module` is its own symbol table, so `lookupNearestSymbolFrom` from a
+/// user outside of it does not find definitions placed inside.
+static mlir::Operation *lookupSymbolInGPUModules(mlir::Operation *user,
+                                                 mlir::SymbolRefAttr symbol) {
+  auto moduleOp = user->getParentOfType<mlir::ModuleOp>();
+  if (!moduleOp)
+    return nullptr;
+  for (auto gpuModule : moduleOp.getOps<mlir::gpu::GPUModuleOp>()) {
+    if (mlir::Operation *op = mlir::SymbolTable::lookupSymbolIn(
+            gpuModule, symbol.getRootReference()))
+      return op;
+  }
+  return nullptr;
+}
+
 bool mlir::acc::isValidSymbolUse(mlir::Operation *user,
                                  mlir::SymbolRefAttr symbol,
                                  mlir::Operation **definingOpPtr) {
+  // A pass may prepare the device-side definition of a symbol inside a
+  // `gpu.module` while the use is still a reference from host IR. Such a
+  // symbol is meant to be used on device, so the use is valid.
+  if (mlir::Operation *gpuOp = lookupSymbolInGPUModules(user, symbol)) {
+    if (definingOpPtr)
+      *definingOpPtr = gpuOp;
+    return true;
+  }
+
   mlir::Operation *definingOp =
       mlir::SymbolTable::lookupNearestSymbolFrom(user, symbol);
 
@@ -203,11 +231,10 @@ bool mlir::acc::isValidSymbolUse(mlir::Operation *user,
   if (definingOpPtr)
     *definingOpPtr = definingOp;
 
-  // Check if the defining op is a recipe (private, reduction, firstprivate).
+  // Check if the defining op is a recipe.
   // Recipes are valid as they get materialized before being offloaded to
   // device. They are only instructions for how to materialize.
-  if (mlir::isa<mlir::acc::PrivateRecipeOp, mlir::acc::ReductionRecipeOp,
-                mlir::acc::FirstprivateRecipeOp>(definingOp))
+  if (mlir::isa<mlir::accomp::RecipeInterface>(definingOp))
     return true;
 
   // Check if the defining op is a global variable that is device data.
@@ -307,6 +334,16 @@ bool mlir::acc::isValidValueUse(mlir::Value val, mlir::Region &region) {
   // If this is device data, it is valid.
   if (isDeviceValue(val))
     return true;
+
+  // Arguments of an enclosing acc routine are already on the device.
+  if (mlir::Operation *parent = region.getParentOp()) {
+    if (auto func = parent->getParentOfType<mlir::FunctionOpInterface>()) {
+      if ((mlir::acc::isAccRoutine(func) ||
+           mlir::acc::isSpecializedAccRoutine(func)) &&
+          llvm::is_contained(func.getArguments(), val))
+        return true;
+    }
+  }
 
   return false;
 }

--- a/mlir/test/Dialect/OpenACC/offload-target-verifier.mlir
+++ b/mlir/test/Dialect/OpenACC/offload-target-verifier.mlir
@@ -279,3 +279,53 @@ func.func @test_acc_specialized_routine() {
   }
   return
 }
+
+// -----
+
+// A call to a function defined in a gpu.module is valid.
+func.func private @device_callee()
+gpu.module @device_mod {
+  gpu.func @device_callee() {
+    gpu.return
+  }
+}
+
+func.func @test_gpu_module_function() {
+  // expected-remark @below {{passed validity check}}
+  acc.serial {
+    func.call @device_callee() : () -> ()
+    acc.yield
+  }
+  return
+}
+
+// -----
+
+// A reference to a global defined in a gpu.module is valid.
+memref.global @device_global : memref<10xf32> = uninitialized
+gpu.module @device_mod {
+  memref.global @device_global : memref<10xf32> = uninitialized
+}
+
+func.func @test_gpu_module_global() {
+  // expected-remark @below {{passed validity check}}
+  acc.serial {
+    %g = memref.get_global @device_global : memref<10xf32>
+    acc.yield
+  }
+  return
+}
+
+// -----
+
+// Arguments of a specialized acc routine are already on the device.
+acc.routine @acc_routine_spec_arg func(@specialized_with_arg) seq
+func.func @specialized_with_arg(%arg0: memref<f32>) attributes {acc.specialized_routine = #acc.specialized_routine<@acc_routine_spec_arg, <seq>, "specialized_with_arg">} {
+  %width = acc.par_width par_dim(#acc.par_dim<sequential>)
+  // expected-remark @below {{passed validity check}}
+  acc.compute_region launch(%arg1 = %width) ins(%arg2 = %arg0) : (memref<f32>) {
+    %load = memref.load %arg2[] : memref<f32>
+    acc.yield
+  } <{origin = "acc.routine"}>
+  return
+}

--- a/mlir/unittests/Dialect/OpenACC/OpenACCUtilsTest.cpp
+++ b/mlir/unittests/Dialect/OpenACC/OpenACCUtilsTest.cpp
@@ -790,6 +790,27 @@ TEST_F(OpenACCUtilsTest, isValidSymbolUseFunctionWithRoutineInfo) {
   EXPECT_NE(definingOp, nullptr);
 }
 
+TEST_F(OpenACCUtilsTest, isValidSymbolUseGPUModuleFunction) {
+  OwningOpRef<ModuleOp> module = ModuleOp::create(loc);
+  OpBuilder::InsertionGuard guard(b);
+  b.setInsertionPointToStart(module->getBody());
+
+  auto gpuModule = gpu::GPUModuleOp::create(b, loc, "device_module");
+  b.setInsertionPointToStart(gpuModule.getBody());
+  auto funcType = b.getFunctionType({}, {});
+  auto gpuFunc = gpu::GPUFuncOp::create(b, loc, "device_callee", funcType,
+                                        TypeRange{}, TypeRange{});
+
+  b.setInsertionPointAfter(gpuModule);
+  auto call =
+      func::CallOp::create(b, loc, "device_callee", TypeRange{}, ValueRange{});
+  Operation *definingOp = nullptr;
+  EXPECT_TRUE(isValidSymbolUse(call.getOperation(),
+                               SymbolRefAttr::get(&context, "device_callee"),
+                               &definingOp));
+  EXPECT_EQ(definingOp, gpuFunc.getOperation());
+}
+
 TEST_F(OpenACCUtilsTest, isValidSymbolUseLLVMIntrinsic) {
   // Create a module to hold the function
   OwningOpRef<ModuleOp> module = ModuleOp::create(loc);
@@ -1720,4 +1741,29 @@ TEST_F(OpenACCUtilsTest, isValidValueUseRegularValue) {
   // Regular value (not device data, not from data op, not private) should be
   // invalid
   EXPECT_FALSE(isValidValueUse(regularVal, serialRegion));
+}
+
+TEST_F(OpenACCUtilsTest, isValidValueUseRoutineArgument) {
+  OwningOpRef<ModuleOp> module = ModuleOp::create(loc);
+  OpBuilder::InsertionGuard guard(b);
+  b.setInsertionPointToStart(module->getBody());
+
+  auto memrefTy = MemRefType::get({10}, b.getI32Type());
+  auto funcType = b.getFunctionType({memrefTy}, {});
+  auto funcOp = func::FuncOp::create(b, loc, "routine_func", funcType);
+  funcOp->setDiscardableAttr(
+      getRoutineInfoAttrName(),
+      RoutineInfoAttr::get(&context,
+                           {SymbolRefAttr::get(&context, "acc_routine")}));
+  Block *entryBlock = funcOp.addEntryBlock();
+  b.setInsertionPointToStart(entryBlock);
+
+  auto serialOp = SerialOp::create(b, loc, TypeRange{}, ValueRange{});
+  Block *serialBlock = b.createBlock(&serialOp.getRegion());
+  b.setInsertionPointToStart(serialBlock);
+  func::CallOp::create(b, loc, "use_arg", TypeRange{},
+                       ValueRange{entryBlock->getArgument(0)});
+
+  EXPECT_TRUE(
+      isValidValueUse(entryBlock->getArgument(0), serialOp.getRegion()));
 }


### PR DESCRIPTION
This PR builds upon acc::isValidSymbolUse and acc::isValidValueUse to ensure that FIR and CUF specific handling is considered.

FIR now provides fir::acc::isValidSymbolUse and
fir::acc::isValidValueUse. Symbol uses treat Fortran runtime and non-host CUDA Fortran procedures as valid, and accept fir.use_stmt references that may have no local definition. Value uses accept FIR scalars that are passed by value, including those reachable through declare and similar wrappers, and allow trivially copyable scalars into CUF kernels.

The OpenACC analysis delegates to these utilities. The dialect helpers are extended so symbols defined in a gpu.module and arguments of an acc routine are treated as already on the device.