### PR TITLE
[clang] Fix handling of constexpr static data member template.

### DIFF
--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -2258,8 +2258,6 @@ VarDecl::isThisDeclarationADefinition(ASTContext &C) const {
   // a static data member template outside the containing class?
   if (isStaticDataMember()) {
     if (isOutOfLine() &&
-        !(getCanonicalDecl()->isInline() &&
-          getCanonicalDecl()->isConstexpr()) &&
         (hasInit() ||
          // If the first declaration is out-of-line, this may be an
          // instantiation of an out-of-line partial specialization of a variable

--- a/clang/test/CodeGenCXX/cxx1z-inline-variables.cpp
+++ b/clang/test/CodeGenCXX/cxx1z-inline-variables.cpp
@@ -101,6 +101,22 @@ constexpr int Y<int>::a;
 const int &yib = Y<int>::b;
 // CHECK-NOT: @_ZN1YIiE1cE
 
+namespace PR219796 {
+template<typename> struct A;
+template<>
+struct A<void> {
+    template<int> static int value;
+};
+
+// CHECK: _ZN8PR2197961AIvE5valueILi101EEE = weak_odr constant i32 3
+template<> constexpr int A<void>::value<101> = 3;
+
+const int& f()
+{
+    return A<void>::template value<101>;
+}
+}
+
 // CHECK-LABEL: define {{.*}}global_var_init
 // CHECK: call noundef i32 @_Z1fv
 

--- a/clang/test/SemaCXX/dllimport.cpp
+++ b/clang/test/SemaCXX/dllimport.cpp
@@ -595,9 +595,7 @@ public:
   __declspec(dllimport) static  const  int  StaticConstFieldEqualInit = 1;
   __declspec(dllimport) static  const  int  StaticConstFieldBraceInit{1};
   __declspec(dllimport) constexpr static int ConstexprField = 1;
-#if __cplusplus < 201703L && !defined(MS)
-  // expected-note@+2{{attribute is here}}
-#endif
+  // expected-note@+1{{attribute is here}}
   __declspec(dllimport) constexpr static int ConstexprFieldDef = 1;
 };
 
@@ -643,9 +641,7 @@ inline void ImportMembers::staticInlineDef() {}
 
        int  ImportMembers::StaticFieldDef; // expected-error{{definition of dllimport static field not allowed}}
 const  int  ImportMembers::StaticConstFieldDef = 1; // expected-error{{definition of dllimport static field not allowed}}
-#if __cplusplus < 201703L && !defined(MS)
-// expected-error@+2{{definition of dllimport static field not allowed}}
-#endif
+// expected-error@+1{{definition of dllimport static field not allowed}}
 constexpr int ImportMembers::ConstexprFieldDef;
 
 
@@ -682,10 +678,8 @@ __declspec(dllimport)        void ImportMemberDefs::staticInlineDecl() {}
 
 __declspec(dllimport)        int  ImportMemberDefs::StaticField; // expected-error{{definition of dllimport static field not allowed}} expected-note{{attribute is here}}
 __declspec(dllimport) const  int  ImportMemberDefs::StaticConstField = 1; // expected-error{{definition of dllimport static field not allowed}} expected-note{{attribute is here}}
-#if __cplusplus < 201703L && !defined(MS)
-// expected-error@+3{{definition of dllimport static field not allowed}}
-// expected-note@+2{{attribute is here}}
-#endif
+// expected-error@+2{{definition of dllimport static field not allowed}}
+// expected-note@+1{{attribute is here}}
 __declspec(dllimport) constexpr int ImportMemberDefs::ConstexprField;
 
 
@@ -900,6 +894,9 @@ struct ImportMemberTmpl {
   template<typename T> __declspec(dllimport) static const  int  StaticConstFieldEqualInit = 1;
   template<typename T> __declspec(dllimport) static const  int  StaticConstFieldBraceInit{1};
   template<typename T> __declspec(dllimport) constexpr static int ConstexprField = 1;
+#ifdef MS
+ // expected-note@+2{{attribute is here}}
+#endif
   template<typename T> __declspec(dllimport) constexpr static int ConstexprFieldDef = 1;
 #endif // __has_feature(cxx_variable_templates)
 };
@@ -926,7 +923,7 @@ template<typename T> inline void ImportMemberTmpl::staticInlineDef() {} // expec
 template<typename T>        int  ImportMemberTmpl::StaticFieldDef; // expected-error{{definition of dllimport static field not allowed}}
 template<typename T> const  int  ImportMemberTmpl::StaticConstFieldDef = 1; // expected-error{{definition of dllimport static field not allowed}}
 #ifdef MS
-template<typename T> constexpr int ImportMemberTmpl::ConstexprFieldDef;
+template<typename T> constexpr int ImportMemberTmpl::ConstexprFieldDef; // expected-error{{definition of dllimport static field not allowed}}
 #endif
 #endif // __has_feature(cxx_variable_templates)
 
@@ -1192,9 +1189,7 @@ public:
   __declspec(dllimport) static  const  int  StaticConstFieldEqualInit = 1;
   __declspec(dllimport) static  const  int  StaticConstFieldBraceInit{1};
   __declspec(dllimport) constexpr static int ConstexprField = 1;
-#if __cplusplus < 201703L && !defined(MS)
-  // expected-note@+2{{attribute is here}}
-#endif
+  // expected-note@+1{{attribute is here}}
   __declspec(dllimport) constexpr static int ConstexprFieldDef = 1;
 };
 
@@ -1239,9 +1234,7 @@ template<typename T>        void ImportClassTmplMembers<T>::staticInlineDecl() {
 
 template<typename T>        int  ImportClassTmplMembers<T>::StaticFieldDef; // expected-warning{{definition of dllimport static field}}
 template<typename T> const  int  ImportClassTmplMembers<T>::StaticConstFieldDef = 1; // expected-warning{{definition of dllimport static field}}
-#if __cplusplus < 201703L && !defined(MS)
-// expected-warning@+2{{definition of dllimport static field}}
-#endif
+// expected-warning@+1{{definition of dllimport static field}}
 template<typename T> constexpr int ImportClassTmplMembers<T>::ConstexprFieldDef;
 
 
@@ -1380,7 +1373,7 @@ struct ImportClsTmplMemTmpl {
   template<typename U> __declspec(dllimport) static const  int  StaticConstFieldBraceInit{1};
   template<typename U> __declspec(dllimport) constexpr static int ConstexprField = 1;
 #ifdef MS
-  template<typename U> __declspec(dllimport) constexpr static int ConstexprFieldDef = 1;
+  template<typename U> __declspec(dllimport) constexpr static int ConstexprFieldDef = 1;  // expected-note{{attribute is here}}
 #endif
 #endif // __has_feature(cxx_variable_templates)
 };
@@ -1407,7 +1400,7 @@ template<typename T> template<typename U> inline void ImportClsTmplMemTmpl<T>::s
 template<typename T> template<typename U>        int  ImportClsTmplMemTmpl<T>::StaticFieldDef; // expected-warning{{definition of dllimport static field}}
 template<typename T> template<typename U> const  int  ImportClsTmplMemTmpl<T>::StaticConstFieldDef = 1; // expected-warning{{definition of dllimport static field}}
 #ifdef MS
-template<typename T> template<typename U> constexpr int ImportClsTmplMemTmpl<T>::ConstexprFieldDef;
+template<typename T> template<typename U> constexpr int ImportClsTmplMemTmpl<T>::ConstexprFieldDef; // expected-warning {{definition of dllimport static field}}
 #endif
 #endif // __has_feature(cxx_variable_templates)
 

--- a/clang/test/SemaTemplate/class-template-spec.cpp
+++ b/clang/test/SemaTemplate/class-template-spec.cpp
@@ -1,8 +1,8 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsyntax-only -verify=expected,cxx17orlater -std=c++17 %s
 // RUN: %clang_cc1 -fsyntax-only -verify -std=c++98 %s
 // RUN: %clang_cc1 -fsyntax-only -verify -std=c++11 %s
 // RUN: %clang_cc1 -fsyntax-only -triple x86_64-linux-gnu -verify=expected,cxx14 -std=c++14 %s
-// RUN: %clang_cc1 -fsyntax-only -verify -std=c++26 %s
+// RUN: %clang_cc1 -fsyntax-only -verify=expected,cxx17orlater -std=c++26 %s
 
 template<typename T, typename U = int> struct A; // expected-note {{template is declared here}} \
                                                  // expected-note{{explicitly specialized}}
@@ -259,8 +259,9 @@ namespace VarTemplateNoMember {
   template<> template<typename U> constexpr int S<long>::foo;
   // In C++14, these are definitions, not declarations, so they get a
   // redefinition error.
-  // cxx14-error@+2{{redefinition of 'foo'}}
+  // cxx14-error@+3{{redefinition of 'foo'}}
   // cxx14-note@-4{{previous definition is here}}
+  // cxx17orlater-error@+1 {{must be initialized by a constant expression}}
   template<> template<typename U> constexpr int S<long>::foo;
   // cxx14-error@+2{{redefinition of 'foo'}}
   // cxx14-note@-2{{previous definition is here}}
@@ -272,4 +273,23 @@ namespace VarTemplateNoMember {
   // cxx14-note@-2{{previous definition is here}}
   template<> template<typename U> constexpr int S<long>::foo;
 } // namespace VarTemplateNoMember
+#endif
+
+#if __cplusplus >= 201703L
+namespace ConstexprVarTemplateRedeclared {
+template<typename> struct A;
+struct SS {};
+template<>
+struct A<void> {
+  template<int> static inline SS value = {};
+};
+
+template<> inline constexpr SS A<void>::value<101> = {};
+template<> inline constexpr SS A<void>::value<101>;
+
+const SS& f()
+{
+  return A<void>::value<101>;
+}
+}
 #endif


### PR DESCRIPTION
[temp.expl.spec] says "An explicit specialization of a static data member of a template or an explicit specialization of a static data member template is a definition if the declaration includes an initializer."  The code did not match this rule for constexpr variables.  The check in question was only supposed to match the cases from [depr.static.constexpr].

Fixes #219796