### PR TITLE
[flang][acc] Ensure genPrivateVariableInfo looks through data clause

### DIFF
--- a/flang/lib/Optimizer/OpenACC/Support/FIROpenACCTypeInterfaces.cpp
+++ b/flang/lib/Optimizer/OpenACC/Support/FIROpenACCTypeInterfaces.cpp
@@ -543,7 +543,19 @@ OpenACCMappableModel<fir::PointerType>::getTypeCategory(mlir::Type type,
 template <typename Ty>
 mlir::acc::VariableInfoAttr OpenACCMappableModel<Ty>::genPrivateVariableInfo(
     mlir::Type type, mlir::TypedValue<mlir::acc::MappableType> var) const {
-  hlfir::Entity entity{var};
+  // A variable may already be captured by a data clause operation, for
+  // instance when privatization is applied to the result of an earlier
+  // clause. The Fortran properties belong to the variable that operation was
+  // created from, so walk back to it.
+  mlir::Value hostVar = var;
+  while (mlir::Operation *definingOp = hostVar.getDefiningOp()) {
+    mlir::Value clauseVar = mlir::acc::getVar(definingOp);
+    if (!clauseVar)
+      break;
+    hostVar = clauseVar;
+  }
+
+  hlfir::Entity entity{hostVar};
   return fir::OpenACCFortranVariableInfoAttr::get(var.getContext(),
                                                   entity.mayBeOptional());
 }

--- a/flang/test/Fir/OpenACC/recipe-populate-firstprivate.mlir
+++ b/flang/test/Fir/OpenACC/recipe-populate-firstprivate.mlir
@@ -152,3 +152,28 @@ func.func @test_derived() {
   %1:2 = hlfir.declare %var {uniq_name = "load_hlfir"} : (!fir.ref<f32>) -> (!fir.ref<f32>, !fir.ref<f32>)
   return
 }
+
+// -----
+
+// Recipe generation from an acc.firstprivate result must use the host
+// variable's Fortran properties, not the clause result. The host is not
+// OPTIONAL, so the copy region is a direct load/assign.
+// CHECK: acc.firstprivate.recipe @firstprivate_from_clause : !fir.ref<i32> init {
+// CHECK: ^bb0(%{{.*}}: !fir.ref<i32>):
+// CHECK:   %[[ALLOC:.*]] = fir.alloca i32
+// CHECK:   acc.yield %[[ALLOC]] : !fir.ref<i32>
+// CHECK: } copy {
+// CHECK: ^bb0(%[[SRC:.*]]: !fir.ref<i32>, %[[DST:.*]]: !fir.ref<i32>):
+// CHECK-NOT: fir.is_present
+// CHECK:   %[[LOAD:.*]] = fir.load %[[SRC]] : !fir.ref<i32>
+// CHECK:   hlfir.assign %[[LOAD]] to %[[DST]] temporary_lhs : i32, !fir.ref<i32>
+// CHECK:   acc.terminator
+// CHECK: }
+
+func.func @test_from_clause() {
+  %host = fir.alloca i32
+  %fp = acc.firstprivate varPtr(%host : !fir.ref<i32>) name("x") -> !fir.ref<i32> {test.var = "from_clause"}
+  %var = fir.alloca f32
+  %1:2 = hlfir.declare %var {uniq_name = "load_hlfir"} : (!fir.ref<f32>) -> (!fir.ref<f32>, !fir.ref<f32>)
+  return
+}

--- a/flang/test/Fir/OpenACC/recipe-populate-private.mlir
+++ b/flang/test/Fir/OpenACC/recipe-populate-private.mlir
@@ -231,3 +231,23 @@ func.func @test_box_ptr_array() {
   %1:2 = hlfir.declare %var {uniq_name = "load_hlfir"} : (!fir.ref<f32>) -> (!fir.ref<f32>, !fir.ref<f32>)
   return
 }
+
+// -----
+
+// Recipe generation from an acc.copyin result must use the host variable's
+// Fortran properties. The host is not OPTIONAL, so init is a plain alloca.
+// CHECK: acc.private.recipe @private_from_copyin : !fir.ref<i32> init {
+// CHECK: ^bb0(%{{.*}}: !fir.ref<i32>):
+// CHECK-NOT: fir.is_present
+// CHECK:   %[[ALLOC:.*]] = fir.alloca i32
+// CHECK:   acc.yield %[[ALLOC]] : !fir.ref<i32>
+// CHECK: }
+// CHECK-NOT: destroy
+
+func.func @test_from_copyin() {
+  %host = fir.alloca i32
+  %in = acc.copyin varPtr(%host : !fir.ref<i32>) -> !fir.ref<i32> {test.var = "from_copyin"}
+  %var = fir.alloca f32
+  %1:2 = hlfir.declare %var {uniq_name = "load_hlfir"} : (!fir.ref<f32>) -> (!fir.ref<f32>, !fir.ref<f32>)
+  return
+}


### PR DESCRIPTION
This ensure that extracting Fortran variable info looks through the acc data clause to find the host entity.