### PR TITLE
[ADT] Add FoldingSetNodeID-to-FoldingSetNodeIDRef conversion operator (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/FoldingSet.h
+++ b/llvm/include/llvm/ADT/FoldingSet.h
@@ -193,20 +193,23 @@ public:
         reinterpret_cast<const uint8_t *>(Data), sizeof(unsigned) * Size));
   }
 
-  bool operator==(FoldingSetNodeIDRef RHS) const {
-    return Size == RHS.Size &&
-           memcmp(Data, RHS.Data, Size * sizeof(*Data)) == 0;
-  }
-
-  bool operator!=(FoldingSetNodeIDRef RHS) const { return !(*this == RHS); }
-
-  /// Used to compare the "ordering" of two nodes as defined by the
-  /// profiled bits and their ordering defined by memcmp().
-  LLVM_ABI bool operator<(FoldingSetNodeIDRef) const;
-
   const unsigned *getData() const { return Data; }
   size_t getSize() const { return Size; }
 };
+
+inline bool operator==(FoldingSetNodeIDRef LHS, FoldingSetNodeIDRef RHS) {
+  return LHS.getSize() == RHS.getSize() &&
+         memcmp(LHS.getData(), RHS.getData(),
+                LHS.getSize() * sizeof(*LHS.getData())) == 0;
+}
+
+inline bool operator!=(FoldingSetNodeIDRef LHS, FoldingSetNodeIDRef RHS) {
+  return !(LHS == RHS);
+}
+
+/// Used to compare the "ordering" of two nodes as defined by the
+/// profiled bits and their ordering defined by memcmp().
+LLVM_ABI bool operator<(FoldingSetNodeIDRef LHS, FoldingSetNodeIDRef RHS);
 
 //===--------------------------------------------------------------------===//
 /// This class is used to gather all the unique data bits of a node.  When all
@@ -271,23 +274,7 @@ public:
   // on-disk serialization.
   unsigned computeStableHash() const { return getRef().computeStableHash(); }
 
-  /// operator== - Used to compare two nodes to each other.
-  bool operator==(const FoldingSetNodeID &RHS) const {
-    return *this == FoldingSetNodeIDRef(RHS.Bits.data(), RHS.Bits.size());
-  }
-  bool operator==(const FoldingSetNodeIDRef RHS) const {
-    return FoldingSetNodeIDRef(Bits.data(), Bits.size()) == RHS;
-  }
-
-  bool operator!=(const FoldingSetNodeID &RHS) const { return !(*this == RHS); }
-  bool operator!=(const FoldingSetNodeIDRef RHS) const {
-    return !(*this == RHS);
-  }
-
-  /// Used to compare the "ordering" of two nodes as defined by the
-  /// profiled bits and their ordering defined by memcmp().
-  LLVM_ABI bool operator<(const FoldingSetNodeID &RHS) const;
-  LLVM_ABI bool operator<(const FoldingSetNodeIDRef RHS) const;
+  operator FoldingSetNodeIDRef() const { return {Bits.data(), Bits.size()}; }
 
   /// Copy this node's data to a memory region allocated from the
   /// given allocator and return a FoldingSetNodeIDRef describing the

--- a/llvm/lib/Support/FoldingSet.cpp
+++ b/llvm/lib/Support/FoldingSet.cpp
@@ -24,10 +24,11 @@ using namespace llvm;
 //===----------------------------------------------------------------------===//
 // FoldingSetNodeIDRef Implementation
 
-bool FoldingSetNodeIDRef::operator<(FoldingSetNodeIDRef RHS) const {
-  if (Size != RHS.Size)
-    return Size < RHS.Size;
-  return memcmp(Data, RHS.Data, Size * sizeof(*Data)) < 0;
+bool llvm::operator<(FoldingSetNodeIDRef LHS, FoldingSetNodeIDRef RHS) {
+  if (LHS.getSize() != RHS.getSize())
+    return LHS.getSize() < RHS.getSize();
+  return memcmp(LHS.getData(), RHS.getData(),
+                LHS.getSize() * sizeof(*LHS.getData())) < 0;
 }
 
 //===----------------------------------------------------------------------===//
@@ -99,14 +100,6 @@ void FoldingSetNodeID::AddString(StringRef String) {
 
 void FoldingSetNodeID::AddNodeID(const FoldingSetNodeID &ID) {
   Bits.append(ID.Bits.begin(), ID.Bits.end());
-}
-
-bool FoldingSetNodeID::operator<(const FoldingSetNodeID &RHS) const {
-  return *this < FoldingSetNodeIDRef(RHS.Bits.data(), RHS.Bits.size());
-}
-
-bool FoldingSetNodeID::operator<(FoldingSetNodeIDRef RHS) const {
-  return FoldingSetNodeIDRef(Bits.data(), Bits.size()) < RHS;
 }
 
 FoldingSetNodeIDRef


### PR DESCRIPTION
This patch adds a conversion operator from FoldingSetNodeID to
FoldingSetNodeIDRef.

The new conversion operator allows us to compare any combination of
FoldingSetNodeID and FoldingSetNodeIDRef in the FoldingSetNodeIDRef
domain, eliminating the need to duplicate comparison operators on
FoldingSetNodeID and removing forwarding wrappers in FoldingSet.cpp.

Assisted-by: Antigravity
