### PR TITLE
[VectorCombine] Avoid calling getTypeSizeInBits on scalable vectors in scalarizeLoadBitcast

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -2300,6 +2300,9 @@ bool VectorCombine::scalarizeLoadBitcast(LoadInst *LI, VectorType *VecTy,
       TTI.getMemoryOpCost(Instruction::Load, VecTy, LI->getAlign(),
                           LI->getPointerAddressSpace(), CostKind);
 
+  if (!isa<FixedVectorType>(VecTy))
+    return false;
+
   Type *TargetScalarType = nullptr;
   unsigned VecBitWidth = DL->getTypeSizeInBits(VecTy);
 

--- a/llvm/test/Transforms/VectorCombine/AArch64/load-bitcast-scalarization.ll
+++ b/llvm/test/Transforms/VectorCombine/AArch64/load-bitcast-scalarization.ll
@@ -134,3 +134,10 @@ define i32 @load_v4i8_mixed_users(ptr %x) {
   %add = add i32 %r1, %r2.ext
   ret i32 %add
 }
+
+; Make sure we don't crash on scalable vectors
+define <vscale x 4 x i32> @scalable_vec(ptr %p) {
+  %a = load <vscale x 8 x i16>, ptr %p
+  %b = bitcast <vscale x 8 x i16> %a to <vscale x 4 x i32>
+  ret <vscale x 4 x i32> %b
+}

--- a/llvm/test/Transforms/VectorCombine/AArch64/load-bitcast-scalarization.ll
+++ b/llvm/test/Transforms/VectorCombine/AArch64/load-bitcast-scalarization.ll
@@ -137,6 +137,12 @@ define i32 @load_v4i8_mixed_users(ptr %x) {
 
 ; Make sure we don't crash on scalable vectors
 define <vscale x 4 x i32> @scalable_vec(ptr %p) {
+; CHECK-LABEL: define <vscale x 4 x i32> @scalable_vec(
+; CHECK-SAME: ptr [[P:%.*]]) {
+; CHECK-NEXT:    [[A:%.*]] = load <vscale x 8 x i16>, ptr [[P]], align 16
+; CHECK-NEXT:    [[B:%.*]] = bitcast <vscale x 8 x i16> [[A]] to <vscale x 4 x i32>
+; CHECK-NEXT:    ret <vscale x 4 x i32> [[B]]
+;
   %a = load <vscale x 8 x i16>, ptr %p
   %b = bitcast <vscale x 8 x i16> %a to <vscale x 4 x i32>
   ret <vscale x 4 x i32> %b


### PR DESCRIPTION
Avoids `LLVM ERROR: Cannot implicitly convert a scalable size to a fixed-width size in TypeSize::operator ScalarTy()`