### PR TITLE
[bazel] Fixes ced97f3

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -3985,6 +3985,7 @@ cc_library(
     includes = ["include"],
     deps = [
         ":ArithUtils",
+        ":ControlFlowInterfaces",
         ":DialectUtils",
         ":GPUDialect",
         ":IR",


### PR DESCRIPTION
This fixes ced97f3b8e9d1d13098e820b6a2b3fba50d948fd (#220094).