### PR TITLE
[bazel] Fixes a26d131

### DIFF
--- a/utils/bazel/llvm-project-overlay/clang/unittests/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang/unittests/BUILD.bazel
@@ -376,6 +376,7 @@ cc_test(
         "//clang:parse",
         "//clang:sema",
         "//clang:tooling",
+        "//llvm:Support",
         "//llvm:TestingAnnotations",
         "//llvm:TestingSupport",
         "//third-party/unittest:gmock",


### PR DESCRIPTION
This fixes a26d1318959d4d06f0881a8d6041e9fc551cd175 (#214121).