### PR TITLE
[MachineFunction] Print type when printing constant pool value.

### DIFF
--- a/llvm/lib/CodeGen/MachineFunction.cpp
+++ b/llvm/lib/CodeGen/MachineFunction.cpp
@@ -1658,7 +1658,7 @@ void MachineConstantPool::print(raw_ostream &OS) const {
     if (Constants[i].isMachineConstantPoolEntry())
       Constants[i].Val.MachineCPVal->print(OS);
     else
-      Constants[i].Val.ConstVal->printAsOperand(OS, /*PrintType=*/false);
+      Constants[i].Val.ConstVal->printAsOperand(OS);
     OS << ", align=" << Constants[i].getAlign().value();
     OS << "\n";
   }


### PR DESCRIPTION
Previously we printed something like `cp#2: splat (i8 -8), align=64` which doesn't give any indication of total size.

This would have made debugging https://github.com/llvm/llvm-project/pull/220448 easier.