### PR TITLE
[ELF] Omit zero-range FDEs from .eh_frame_hdr

### DIFF
--- a/lld/ELF/EhFrame.cpp
+++ b/lld/ELF/EhFrame.cpp
@@ -139,6 +139,16 @@ bool elf::hasLSDA(const EhSectionPiece &p) {
   return EhReader(p.sec, p.data()).hasLSDA();
 }
 
+// pc_range follows the 4-byte length, 4-byte CIE pointer, and pc_begin, and
+// uses pc_begin's encoding.
+bool elf::hasZeroPcRange(Ctx &ctx, const EhSectionPiece &p, uint8_t enc) {
+  size_t size = getAugPSize(ctx, enc);
+  ArrayRef<uint8_t> d = p.data();
+  if (size == 0 || d.size() < 8 + 2 * size)
+    return false;
+  return llvm::all_of(d.slice(8 + size, size), [](uint8_t c) { return !c; });
+}
+
 StringRef EhReader::getAugmentation() {
   skipBytes(8);
   int version = readByte();

--- a/lld/ELF/EhFrame.cpp
+++ b/lld/ELF/EhFrame.cpp
@@ -142,11 +142,11 @@ bool elf::hasLSDA(const EhSectionPiece &p) {
 // pc_range follows the 4-byte length, 4-byte CIE pointer, and pc_begin, and
 // uses pc_begin's encoding.
 bool elf::hasZeroPcRange(Ctx &ctx, const EhSectionPiece &p, uint8_t enc) {
-  size_t size = getAugPSize(ctx, enc);
+  size_t pSize = getAugPSize(ctx, enc);
   ArrayRef<uint8_t> d = p.data();
-  if (size == 0 || d.size() < 8 + 2 * size)
+  if (pSize == 0 || d.size() < 8 + 2 * pSize)
     return false;
-  return llvm::all_of(d.slice(8 + size, size), [](uint8_t c) { return !c; });
+  return llvm::all_of(d.slice(8 + pSize, pSize), [](uint8_t c) { return !c; });
 }
 
 StringRef EhReader::getAugmentation() {

--- a/lld/ELF/EhFrame.h
+++ b/lld/ELF/EhFrame.h
@@ -12,10 +12,12 @@
 #include "lld/Common/LLVM.h"
 
 namespace lld::elf {
+struct Ctx;
 struct EhSectionPiece;
 
 uint8_t getFdeEncoding(EhSectionPiece *p);
 bool hasLSDA(const EhSectionPiece &p);
+bool hasZeroPcRange(Ctx &ctx, const EhSectionPiece &p, uint8_t enc);
 }
 
 #endif

--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -461,6 +461,10 @@ bool EhFrameHeader::updateAllocSize(Ctx &ctx) {
       continue;
     }
     for (EhSectionPiece *fde : rec->fdes) {
+      // Discard zero-range FDE, otherwise it would displace the FDE of the
+      // next function, which shares its address.
+      if (hasZeroPcRange(ctx, *fde, enc))
+        continue;
       // The FDE has passed `isFdeLive`, so the first relocation's symbol is a
       // live Defined.
       auto *isec = cast<EhInputSection>(fde->sec);

--- a/lld/test/ELF/eh-frame-fde-encoding.s
+++ b/lld/test/ELF/eh-frame-fde-encoding.s
@@ -10,6 +10,8 @@
 # RUN: llvm-mc -filetype=obj -triple=x86_64 udata2.s -o udata2.o
 # RUN: llvm-mc -filetype=obj -triple=x86_64 udata4.s -o udata4.o
 # RUN: llvm-mc -filetype=obj -triple=x86_64 udata8.s -o udata8.o
+# RUN: llvm-mc -filetype=obj -triple=x86_64 uleb128.s -o uleb128.o
+# RUN: llvm-mc -filetype=obj -triple=x86_64 absptr-zero-range.s -o absptr-zero-range.o
 
 # RUN: ld.lld --eh-frame-hdr sdata2.o -o /dev/null
 # RUN: ld.lld --eh-frame-hdr sdata8.o -o /dev/null
@@ -19,6 +21,8 @@
 # RUN: ld.lld --eh-frame-hdr --image-base=0 -Ttext=0x1000 udata2.o -o udata2
 # RUN: ld.lld --eh-frame-hdr --image-base=0 -Ttext=0x2000 sdata4.o -o sdata4
 # RUN: ld.lld --eh-frame-hdr --image-base=0 -Ttext=0x2000 udata4.o -o udata4
+# RUN: ld.lld --eh-frame-hdr --image-base=0 -Ttext=0x1000 uleb128.o -o uleb128
+# RUN: ld.lld --eh-frame-hdr --image-base=0 -Ttext=0x1000 absptr-zero-range.o -o absptr-zero-range
 
 ## absptr/udata2: Also verify .eh_frame content to test relocation with addend.
 ## .eh_frame_hdr initial_location: foo(0x1000)+0x234 - .eh_frame_hdr(0x2004) = 0xfffff230
@@ -45,6 +49,16 @@
 # HDR4-NEXT: 0x00003014 24000000
 # HDR4:      0x00003004 011b033b 10000000 01000000 fcefffff
 # HDR4-NEXT: 0x00003014 24000000
+
+## uleb128: lld does not decode the PC range, so the FDE keeps its entry.
+# RUN: llvm-readelf -x .eh_frame_hdr uleb128 | FileCheck %s --check-prefix=ULEB128
+# ULEB128:      0x00002004 011b033b 10000000 01000000 30f2ffff
+# ULEB128-NEXT: 0x00002014 26000000
+
+## absptr with an 8-byte zero PC range: the FDE is omitted from the table.
+# RUN: llvm-readelf -x .eh_frame_hdr absptr-zero-range | FileCheck %s --check-prefix=ZERO
+# ZERO:      0x00002004 011b033b 10000000 00000000 00000000
+# ZERO-NEXT: 0x00002014 00000000
 
 #--- absptr.s
 ## DW_EH_PE_absptr (0x00) with FDE for verification
@@ -201,3 +215,53 @@ foo:
   .byte 0x04        # DW_EH_PE_udata8
   .quad 0xFFFFFFFFFFFFFFFF
   .byte 0xFF
+
+#--- uleb128.s
+## DW_EH_PE_uleb128 (0x01)
+.text
+.globl foo
+foo:
+  nop
+
+.section .eh_frame,"a",@unwind
+  .long 14          # Size
+  .long 0x00        # ID (CIE)
+  .byte 0x01        # Version
+  .byte 0x52        # Augmentation string: 'R','S','\0'
+  .byte 0x53
+  .byte 0x00
+  .byte 0x01        # Code alignment
+  .byte 0x01        # Data alignment
+  .byte 0x01        # Return address register
+  .byte 0x01        # DW_EH_PE_uleb128
+  .byte 0xFF
+  .byte 0x00
+
+  .long 9           # Size
+  .long 0x16        # CIE offset
+  .long foo + 0x234 # PC begin
+  .byte 0x00        # PC range
+
+#--- absptr-zero-range.s
+## DW_EH_PE_absptr (0x00) with a zero PC range
+.text
+.globl foo
+foo:
+  nop
+
+.section .eh_frame,"a",@unwind
+  .long 12          # Size
+  .long 0x00        # ID (CIE)
+  .byte 0x01        # Version
+  .byte 0x52        # Augmentation string: 'R','\0'
+  .byte 0x00
+  .byte 0x01        # Code alignment
+  .byte 0x01        # Data alignment
+  .byte 0x01        # Return address register
+  .byte 0x00        # DW_EH_PE_absptr
+  .byte 0xFF
+
+  .long 20          # Size
+  .long 0x14        # CIE offset
+  .quad foo + 0x234 # PC begin
+  .quad 0           # PC range

--- a/lld/test/ELF/eh-frame-hdr-zero-range.s
+++ b/lld/test/ELF/eh-frame-hdr-zero-range.s
@@ -1,0 +1,37 @@
+# REQUIRES: x86
+## A zero-sized function shares its address with the next function. Its zero-range
+## FDE is discarded in .eh_frame_hdr so as not to displace the next function's FDE.
+
+# RUN: llvm-mc -filetype=obj -triple=x86_64 %s -o %t.o
+# RUN: ld.lld --eh-frame-hdr %t.o -o %t
+# RUN: llvm-readelf --unwind %t | FileCheck %s
+
+# CHECK:      fde_count: 1
+# CHECK-NEXT: entry 0 {
+# CHECK-NEXT:   initial_location: 0x[[#%x,START:]]
+# CHECK-NEXT:   address: 0x[[#%x,FDE:]]
+# CHECK-NEXT: }
+
+# CHECK:      ] FDE length=
+# CHECK-NEXT:   initial_location: 0x[[#START]]
+# CHECK-NEXT:   address_range: 0x0
+# CHECK:      [0x[[#FDE]]] FDE length=
+# CHECK-NEXT:   initial_location: 0x[[#START]]
+# CHECK-NEXT:   address_range: 0x1
+# CHECK:      ] FDE length=
+# CHECK-NEXT:   initial_location: 0x[[#START+1]]
+# CHECK-NEXT:   address_range: 0x0
+
+f1:
+  .cfi_startproc
+  .cfi_endproc
+
+.globl _start
+_start:
+  .cfi_startproc
+  ret
+  .cfi_endproc
+
+f2:
+  .cfi_startproc
+  .cfi_endproc

--- a/lld/test/ELF/eh-frame-negative-pcrel-sdata2.s
+++ b/lld/test/ELF/eh-frame-negative-pcrel-sdata2.s
@@ -24,10 +24,9 @@
 # CHECK-NEXT:   EntrySize:
 # CHECK-NEXT:   SectionData (
 # CHECK-NEXT:     0000: 10000000 00000000 017A5200 01010101
-# CHECK-NEXT:     0010: 1A000000 0A000000 18000000 E3FFFFFF
-# CHECK-NEXT:     0020: 00000000 0000
-#                       ^
-#   DFFFFFFF = _start(0x1000) - PC(.eh_frame(0x1001) + 0x20)
+# CHECK-NEXT:     0010: 1A000000 08000000 18000000 E3FF0100
+# CHECK-NEXT:     0020: 00000000
+#   E3FF = _start(0x1000) - PC(.eh_frame(0x1001) + 0x1C), followed by a PC range of 1
 
 # CHECK:      Section {
 # CHECK:        Index:
@@ -78,8 +77,8 @@ _start:
   .byte 0x00
   .byte 0x00
 
-  .long 10   # Size
+  .long 8    # Size
   .long 24   # ID
 fde:
-  .long _start - fde
-  .word 0
+  .word _start - fde
+  .word 1

--- a/lld/test/ELF/eh-frame-negative-pcrel-sdata4.s
+++ b/lld/test/ELF/eh-frame-negative-pcrel-sdata4.s
@@ -25,7 +25,7 @@
 # CHECK-NEXT:   SectionData (
 # CHECK-NEXT:     0000: 10000000 00000000 017A5200 01010101
 # CHECK-NEXT:     0010: 1B000000 0C000000 18000000 E3FFFFFF
-# CHECK-NEXT:     0020: 00000000 00000000
+# CHECK-NEXT:     0020: 01000000 00000000
 
 # CHECK:      Section {
 # CHECK:        Index:
@@ -80,4 +80,4 @@ _start:
   .long 24   # ID
 fde:
   .long _start - fde
-  .long 0
+  .long 1


### PR DESCRIPTION
A zero-sized function (e.g. only `__builtin_unreachable()` in the body
when not using -trap-unreachable) shares its address with the next
function, and its zero-range FDE can win the uniquify step, leaving the
next real function impossible to unwind.

Fix #218124 by dropping FDEs with a zero PC range from the search table.
