### PR TITLE
[GlobalISel] Remove dead declarations and functions (NFC)

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/CombinerHelper.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/CombinerHelper.h
@@ -850,10 +850,6 @@ public:
   LLVM_ABI bool matchTruncUSatUToFPTOUISat(MachineInstr &MI,
                                            MachineInstr &SrcMI) const;
 
-  /// Try to transform \p MI by using all of the above
-  /// combine functions. Returns true if changed.
-  LLVM_ABI bool tryCombine(MachineInstr &MI) const;
-
   /// Match:
   ///   (G_UMULO x, 2) -> (G_UADDO x, x)
   ///   (G_SMULO x, 2) -> (G_SADDO x, x)

--- a/llvm/include/llvm/CodeGen/GlobalISel/GISelValueTracking.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/GISelValueTracking.h
@@ -76,8 +76,6 @@ public:
   KnownBits getKnownBits(Register R, const APInt &DemandedElts,
                          unsigned Depth = 0);
 
-  // Calls getKnownBits for first operand def of MI.
-  KnownBits getKnownBits(MachineInstr &MI);
   APInt getKnownZeroes(Register R);
   APInt getKnownOnes(Register R);
 
@@ -101,11 +99,6 @@ public:
   bool isKnownNeverZero(Register R, unsigned Depth = 0);
   bool isKnownNeverZero(Register R, const APInt &DemandedElts,
                         unsigned Depth = 0);
-
-  static void computeKnownBitsForAlignment(KnownBits &Known, Align Alignment) {
-    // The low bits are known zero if the pointer is aligned.
-    Known.Zero.setLowBits(Log2(Alignment));
-  }
 
   /// \return The known alignment for the pointer-like value \p R.
   Align computeKnownAlignment(Register R, unsigned Depth = 0);

--- a/llvm/include/llvm/CodeGen/GlobalISel/LegalizerHelper.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegalizerHelper.h
@@ -526,7 +526,6 @@ public:
   LLVM_ABI LegalizeResult lowerRotateWithReverseRotate(MachineInstr &MI);
   LLVM_ABI LegalizeResult lowerRotate(MachineInstr &MI);
 
-  LLVM_ABI LegalizeResult lowerU64ToF32BitOps(MachineInstr &MI);
   LLVM_ABI LegalizeResult lowerU64ToF32WithSITOFP(MachineInstr &MI);
   LLVM_ABI LegalizeResult lowerU64ToF64BitFloatOps(MachineInstr &MI);
   LLVM_ABI LegalizeResult lowerUITOFP(MachineInstr &MI);

--- a/llvm/lib/CodeGen/GlobalISel/GISelValueTracking.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/GISelValueTracking.cpp
@@ -75,12 +75,6 @@ Align GISelValueTracking::computeKnownAlignment(Register R, unsigned Depth) {
   }
 }
 
-KnownBits GISelValueTracking::getKnownBits(MachineInstr &MI) {
-  assert(MI.getNumExplicitDefs() == 1 &&
-         "expected single return generic instruction");
-  return getKnownBits(MI.getOperand(0).getReg());
-}
-
 KnownBits GISelValueTracking::getKnownBits(Register R) {
   const LLT Ty = MRI.getType(R);
   // Since the number of lanes in a scalable vector is unknown at compile time,

--- a/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
@@ -8431,64 +8431,6 @@ LegalizerHelper::LegalizeResult LegalizerHelper::lowerRotate(MachineInstr &MI) {
   return Legalized;
 }
 
-// Expand s32 = G_UITOFP s64 using bit operations to an IEEE float
-// representation.
-LegalizerHelper::LegalizeResult
-LegalizerHelper::lowerU64ToF32BitOps(MachineInstr &MI) {
-  auto [Dst, Src] = MI.getFirst2Regs();
-  const LLT S64 = LLT::scalar(64);
-  const LLT S32 = LLT::scalar(32);
-  const LLT S1 = LLT::scalar(1);
-
-  assert(MRI.getType(Src) == S64 && MRI.getType(Dst) == S32);
-
-  // unsigned cul2f(ulong u) {
-  //   uint lz = clz(u);
-  //   uint e = (u != 0) ? 127U + 63U - lz : 0;
-  //   u = (u << lz) & 0x7fffffffffffffffUL;
-  //   ulong t = u & 0xffffffffffUL;
-  //   uint v = (e << 23) | (uint)(u >> 40);
-  //   uint r = t > 0x8000000000UL ? 1U : (t == 0x8000000000UL ? v & 1U : 0U);
-  //   return as_float(v + r);
-  // }
-
-  auto Zero32 = MIRBuilder.buildConstant(S32, 0);
-  auto Zero64 = MIRBuilder.buildConstant(S64, 0);
-
-  auto LZ = MIRBuilder.buildCTLZ_ZERO_POISON(S32, Src);
-
-  auto K = MIRBuilder.buildConstant(S32, 127U + 63U);
-  auto Sub = MIRBuilder.buildSub(S32, K, LZ);
-
-  auto NotZero = MIRBuilder.buildICmp(CmpInst::ICMP_NE, S1, Src, Zero64);
-  auto E = MIRBuilder.buildSelect(S32, NotZero, Sub, Zero32);
-
-  auto Mask0 = MIRBuilder.buildConstant(S64, (-1ULL) >> 1);
-  auto ShlLZ = MIRBuilder.buildShl(S64, Src, LZ);
-
-  auto U = MIRBuilder.buildAnd(S64, ShlLZ, Mask0);
-
-  auto Mask1 = MIRBuilder.buildConstant(S64, 0xffffffffffULL);
-  auto T = MIRBuilder.buildAnd(S64, U, Mask1);
-
-  auto UShl = MIRBuilder.buildLShr(S64, U, MIRBuilder.buildConstant(S64, 40));
-  auto ShlE = MIRBuilder.buildShl(S32, E, MIRBuilder.buildConstant(S32, 23));
-  auto V = MIRBuilder.buildOr(S32, ShlE, MIRBuilder.buildTrunc(S32, UShl));
-
-  auto C = MIRBuilder.buildConstant(S64, 0x8000000000ULL);
-  auto RCmp = MIRBuilder.buildICmp(CmpInst::ICMP_UGT, S1, T, C);
-  auto TCmp = MIRBuilder.buildICmp(CmpInst::ICMP_EQ, S1, T, C);
-  auto One = MIRBuilder.buildConstant(S32, 1);
-
-  auto VTrunc1 = MIRBuilder.buildAnd(S32, V, One);
-  auto Select0 = MIRBuilder.buildSelect(S32, TCmp, VTrunc1, Zero32);
-  auto R = MIRBuilder.buildSelect(S32, RCmp, One, Select0);
-  MIRBuilder.buildAdd(Dst, V, R);
-
-  MI.eraseFromParent();
-  return Legalized;
-}
-
 // Expand s32 = G_UITOFP s64 to an IEEE float representation using bit
 // operations and G_SITOFP
 LegalizerHelper::LegalizeResult


### PR DESCRIPTION
CombinerHelper::tryCombine: The corresponding function definition was
removed on September 24, 2023 in commit
bc6e7f057340ab0b995cc17a170e34545a295f03.

GISelValueTracking::getKnownBits(MachineInstr &): Added on August 6, 2019
in commit c8ac029d0ae27b8fd392f216d471ba2730be7fd1 without any callers.

GISelValueTracking::computeKnownBitsForAlignment: The last use was
removed on June 3, 2020 in commit
45e1a22a92bf2c33336ccc02ea4fa3996f60252b.

LegalizerHelper::lowerU64ToF32BitOps: The last use was removed on
September 25, 2024 in commit e9cb44090ff7b3feda386ca1ee1252ab47c0617e.

Assisted-by: Antigravity
