### PR TITLE
[orc-rt] Add ORC_RT_HAS_BUILTIN, stop defining __has_builtin

### DIFF
--- a/orc-rt/include/orc-rt-c/support/Compiler.h
+++ b/orc-rt/include/orc-rt-c/support/Compiler.h
@@ -14,6 +14,19 @@
 #ifndef ORC_RT_C_SUPPORT_COMPILER_H
 #define ORC_RT_C_SUPPORT_COMPILER_H
 
+/* ORC_RT_HAS_BUILTIN(X) expands to 1 if the compiler provides the builtin X,
+   and to 0 otherwise.
+
+   This wraps __has_builtin rather than supplying a fallback definition for it.
+   __has_builtin is a reserved identifier, and defining one from a public header
+   can collide with the compiler's own definition or with other libraries that
+   the client also includes. */
+#if defined(__has_builtin)
+#define ORC_RT_HAS_BUILTIN(X) __has_builtin(X)
+#else
+#define ORC_RT_HAS_BUILTIN(X) 0
+#endif
+
 /* Helper to promote strict prototype warnings to errors */
 #ifdef __clang__
 #define ORC_RT_C_STRICT_PROTOTYPES_BEGIN                                       \

--- a/orc-rt/include/orc-rt-internal/support/sys/CacheControl.h
+++ b/orc-rt/include/orc-rt-internal/support/sys/CacheControl.h
@@ -34,7 +34,7 @@ inline void clear_icache(void *Addr, size_t Size);
 
 #include "orc-rt-internal/support/sys/darwin/CacheControl.h"
 
-#elif __has_builtin(__builtin___clear_cache) || defined(__GNUC__)
+#elif ORC_RT_HAS_BUILTIN(__builtin___clear_cache) || defined(__GNUC__)
 
 namespace orc_rt::sys {
 

--- a/orc-rt/include/orc-rt/support/Compiler.h
+++ b/orc-rt/include/orc-rt/support/Compiler.h
@@ -29,10 +29,6 @@
 // API to be hidden.
 #define ORC_RT_EXPORT ORC_RT_C_EXPORT
 
-#ifndef __has_builtin
-#define __has_builtin(x) 0
-#endif
-
 // Only use __has_cpp_attribute in C++ mode. GCC defines __has_cpp_attribute in
 // C mode, but the :: in __has_cpp_attribute(scoped::attribute) is invalid.
 #ifndef ORC_RT_HAS_CPP_ATTRIBUTE
@@ -43,7 +39,7 @@
 #endif
 #endif
 
-#if __has_builtin(__builtin_expect)
+#if ORC_RT_HAS_BUILTIN(__builtin_expect)
 #define ORC_RT_LIKELY(EXPR) __builtin_expect((bool)(EXPR), true)
 #define ORC_RT_UNLIKELY(EXPR) __builtin_expect((bool)(EXPR), false)
 #else
@@ -61,7 +57,7 @@
 
 // ORC_RT_BUILTIN_UNREACHABLE: an optimizer hint that the current location is
 // not reachable.
-#if __has_builtin(__builtin_unreachable) || defined(__GNUC__)
+#if ORC_RT_HAS_BUILTIN(__builtin_unreachable) || defined(__GNUC__)
 #define ORC_RT_BUILTIN_UNREACHABLE __builtin_unreachable()
 #elif defined(_MSC_VER)
 #define ORC_RT_BUILTIN_UNREACHABLE __assume(false)

--- a/orc-rt/include/orc-rt/support/bit.h
+++ b/orc-rt/include/orc-rt/support/bit.h
@@ -15,6 +15,8 @@
 #ifndef ORC_RT_SUPPORT_BIT_H
 #define ORC_RT_SUPPORT_BIT_H
 
+#include "orc-rt/support/Compiler.h"
+
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -78,7 +80,7 @@ template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
 #endif
   } else if constexpr (sizeof(T) == 4) {
     uint32_t UV = V;
-#if __has_builtin(__builtin_bswap32)
+#if ORC_RT_HAS_BUILTIN(__builtin_bswap32)
     return __builtin_bswap32(UV);
 #elif defined(_MSC_VER) && !defined(_DEBUG)
     return _byteswap_ulong(UV);
@@ -91,7 +93,7 @@ template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
 #endif
   } else if constexpr (sizeof(T) == 8) {
     uint64_t UV = V;
-#if __has_builtin(__builtin_bswap64)
+#if ORC_RT_HAS_BUILTIN(__builtin_bswap64)
     return __builtin_bswap64(UV);
 #elif defined(_MSC_VER) && !defined(_DEBUG)
     return _byteswap_uint64(UV);


### PR DESCRIPTION
orc-rt/support/Compiler.h supplied a fallback definition of __has_builtin for compilers that lack it. __has_builtin is a reserved identifier, and defining one from a public header can collide with the compiler's own definition or with another library the client includes.

Replace it with ORC_RT_HAS_BUILTIN(X) in orc-rt-c/support/Compiler.h, which wraps __has_builtin where it exists and expands to 0 otherwise, and convert the five uses.