### PR TITLE
[AIX][libc++] Forward-declare locale functions in aix.h when _XOPEN_SOURCE < 700

### DIFF
--- a/libcxx/include/__locale_dir/support/aix.h
+++ b/libcxx/include/__locale_dir/support/aix.h
@@ -25,6 +25,16 @@
 #  include <wctype.h>
 #endif
 
+// Forward declare for _XOPEN_SOURCE=500 and _XOPEN_SOURCE=600
+#if defined(_XOPEN_SOURCE) && _XOPEN_SOURCE < 700
+extern "C" {
+locale_t newlocale(int, const char*, locale_t) noexcept;
+locale_t duplocale(locale_t) noexcept;
+locale_t uselocale(locale_t) noexcept;
+void freelocale(locale_t) noexcept;
+}
+#endif // defined(_XOPEN_SOURCE) && _XOPEN_SOURCE < 700
+
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
 #endif

--- a/libcxx/test/extensions/posix/xopen_source.gen.py
+++ b/libcxx/test/extensions/posix/xopen_source.gen.py
@@ -12,10 +12,6 @@
 #
 # https://llvm.org/PR117630
 
-# The AIX localization support uses some functions as part of their headers that require a
-# recent value of _XOPEN_SOURCE.
-# UNSUPPORTED: LIBCXX-AIX-FIXME
-
 # FreeBSD maps _XOPEN_SOURCE=500 to __ISO_C_VISIBLE=1990 (see <sys/_visible.h>), which hides
 # everything C99 added to the C library, even in C++ mode. libc++ needs some of those
 # additions to provide a conforming library at all.


### PR DESCRIPTION
On AIX, the following locale functions `(uselocale/newlocale/freelocale/duplocale)` are only declared in `usr/include/locale.h` when `_XOPEN_SOURCE > 700`. 

This causes a failure in the test `libcxx/test/extensions/posix/xopen_source.gen.py` which tests `_XOPEN_SOURCE ` against 500, 600 and 700, with the following error:
```
#__locale_dir/support/aix.h:36:72: error: no member named 'uselocale' in the global namespace; did you mean 'setlocale'?
```

The fix here is to forward declare those 4 functions inside `aix.h` and make them visible. 
