### PR TITLE
[orc-rt] Compile C API headers as C in the unit tests

### DIFF
--- a/orc-rt/CMakeLists.txt
+++ b/orc-rt/CMakeLists.txt
@@ -34,6 +34,11 @@ set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to")
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
+# --- C standard ---
+set(CMAKE_C_STANDARD 11 CACHE STRING "C standard to conform to")
+set(CMAKE_C_STANDARD_REQUIRED YES)
+set(CMAKE_C_EXTENSIONS NO)
+
 # --- Project variables ---
 set(CMAKE_FOLDER "orc-rt")
 set(ORC_RT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})

--- a/orc-rt/test/unit/CMakeLists.txt
+++ b/orc-rt/test/unit/CMakeLists.txt
@@ -14,6 +14,7 @@ endfunction()
 add_orc_rt_unittest(CoreTests
   support/AllocActionTest.cpp
   support/BitmaskEnumTest.cpp
+  support/CAPICompileTest.c
   support/CCallbackTest.cpp
   support/CallableTraitsHelperTest.cpp
   support/CompilerTest.cpp

--- a/orc-rt/test/unit/support/CAPICompileTest.c
+++ b/orc-rt/test/unit/support/CAPICompileTest.c
@@ -1,0 +1,37 @@
+/*===- CAPICompileTest.c - Check that the C API compiles as C -----*- C -*-===*\
+|*                                                                            *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+|*                                                                            *|
+|*===----------------------------------------------------------------------===*|
+|*                                                                            *|
+|* Compiles the public C API headers as C, and exercises the macros in        *|
+|* orc-rt-c/support/Compiler.h from C.                                        *|
+|*                                                                            *|
+|* The companion assertions are in CompilerTest.cpp, which calls the          *|
+|* functions defined here.                                                    *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#include "orc-rt-c/bedrock/Session.h"
+#include "orc-rt-c/support/Compiler.h"
+#include "orc-rt-c/support/CoreTypes.h"
+#include "orc-rt-c/support/Error.h"
+#include "orc-rt-c/support/Logging.h"
+#include "orc-rt-c/support/WrapperFunction.h"
+
+/* ORC_RT_HAS_BUILTIN must be usable in a preprocessor conditional in C, and
+   must agree with the answer the C++ compiler gives for the same builtin. */
+#if ORC_RT_HAS_BUILTIN(__builtin_expect)
+int orc_rt_test_hasBuiltinExpect(void) { return 1; }
+#else
+int orc_rt_test_hasBuiltinExpect(void) { return 0; }
+#endif
+
+/* A builtin no compiler provides must report 0 rather than failing to
+   preprocess. */
+#if ORC_RT_HAS_BUILTIN(__builtin_orc_rt_not_a_real_builtin)
+#error "ORC_RT_HAS_BUILTIN reported support for a nonexistent builtin"
+#endif

--- a/orc-rt/test/unit/support/CompilerTest.cpp
+++ b/orc-rt/test/unit/support/CompilerTest.cpp
@@ -41,3 +41,14 @@ TEST(CompilerDeathTest, UnreachableAborts) {
                "unreachable reached");
 }
 #endif
+
+// Defined in CAPICompileTest.c, which is compiled as C. The value it returns
+// is decided by the preprocessor when that file is built, so comparing it
+// against the answer here checks that ORC_RT_HAS_BUILTIN works in C and agrees
+// across the two languages.
+extern "C" int orc_rt_test_hasBuiltinExpect(void);
+
+TEST(CompilerTest, HasBuiltinAgreesBetweenCAndCxx) {
+  EXPECT_EQ(orc_rt_test_hasBuiltinExpect(),
+            ORC_RT_HAS_BUILTIN(__builtin_expect) ? 1 : 0);
+}


### PR DESCRIPTION
Ensures that the C API headers in orc-rt-c compile as C.

Add CAPICompileTest.c, which includes every public C header and exercises ORC_RT_HAS_BUILTIN from C, plus a CompilerTest case checking that C and C++ agree on the result. Later commits should extend this file as more macros move into orc-rt-c/support/Compiler.h.

Set CMAKE_C_STANDARD alongside the existing CMAKE_CXX_STANDARD in the root CMakeLists.txt. CMAKE_C_EXTENSIONS is off so C sources build as -std=c11 rather than -std=gnu11, keeping GNU extensions out of the public headers.