### PR TITLE
[IR] Use merged cmpxchg ordering in getMemoryEffects()

### DIFF
--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -1099,7 +1099,7 @@ MemoryEffects Instruction::getMemoryEffects() const {
   }
   case Instruction::AtomicCmpXchg: {
     auto *CX = cast<AtomicCmpXchgInst>(this);
-    return GetEffects(ModRefInfo::ModRef, CX->getSuccessOrdering(),
+    return GetEffects(ModRefInfo::ModRef, CX->getMergedOrdering(),
                       CX->isVolatile());
   }
   }

--- a/llvm/test/Transforms/FunctionAttrs/atomic.ll
+++ b/llvm/test/Transforms/FunctionAttrs/atomic.ll
@@ -142,6 +142,17 @@ define void @cmpxchg_acq_rel_arg(ptr %x) {
   ret void
 }
 
+define void @cmpxchg_monotonic_acquire_arg(ptr %x) {
+; CHECK: Function Attrs: mustprogress norecurse nounwind willreturn memory(argmem: readwrite)
+; CHECK-LABEL: define void @cmpxchg_monotonic_acquire_arg(
+; CHECK-SAME: ptr nofree captures(none) [[X:%.*]]) #[[ATTR1]] {
+; CHECK-NEXT:    [[TMP1:%.*]] = cmpxchg ptr [[X]], i32 0, i32 1 monotonic acquire, align 4
+; CHECK-NEXT:    ret void
+;
+  cmpxchg ptr %x, i32 0, i32 1 monotonic acquire
+  ret void
+}
+
 define void @cmpxchg_monotonic_volatile_arg(ptr %x) {
 ; CHECK: Function Attrs: norecurse nounwind memory(argmem: readwrite, inaccessiblemem: readwrite)
 ; CHECK-LABEL: define void @cmpxchg_monotonic_volatile_arg(

--- a/llvm/test/Transforms/FunctionAttrs/atomic.ll
+++ b/llvm/test/Transforms/FunctionAttrs/atomic.ll
@@ -143,9 +143,9 @@ define void @cmpxchg_acq_rel_arg(ptr %x) {
 }
 
 define void @cmpxchg_monotonic_acquire_arg(ptr %x) {
-; CHECK: Function Attrs: mustprogress norecurse nounwind willreturn memory(argmem: readwrite)
+; CHECK: Function Attrs: mustprogress norecurse nounwind willreturn
 ; CHECK-LABEL: define void @cmpxchg_monotonic_acquire_arg(
-; CHECK-SAME: ptr nofree captures(none) [[X:%.*]]) #[[ATTR1]] {
+; CHECK-SAME: ptr nofree captures(none) [[X:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[TMP1:%.*]] = cmpxchg ptr [[X]], i32 0, i32 1 monotonic acquire, align 4
 ; CHECK-NEXT:    ret void
 ;


### PR DESCRIPTION
cmpxchg can have a stronger failure than success ordering, so we should use getMergedOrdering() when computing the memory effects.

I double checked that we intentionally allow failure to be stronger than success since 431e3138a1f3fd2bb7b25e1f4766d935058136f8.

Disclaimer: Issue was identified by AI, and the patch was also generated by it.