### PR TITLE
[AMDGPU] Fix legacy fmin/fmax combines to preserve NaN and zero ties

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/GISelValueTracking.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/GISelValueTracking.h
@@ -160,6 +160,10 @@ public:
   /// Returns true if \p Val can be assumed to never be a signaling NaN.
   bool isKnownNeverSNaN(Register Val) { return isKnownNeverNaN(Val, true); }
 
+  /// Returns true if \p Val can be assumed to never be a zero, accounting for
+  /// denormal flushing of the containing function.
+  bool isKnownNeverLogicalZero(Register Val, unsigned Depth = 0);
+
   // Observer API. No-op for non-caching implementation.
   void erasingInstr(MachineInstr &MI) override {}
   void createdInstr(MachineInstr &MI) override {}

--- a/llvm/lib/CodeGen/GlobalISel/GISelValueTracking.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/GISelValueTracking.cpp
@@ -2298,6 +2298,13 @@ bool GISelValueTracking::isKnownNeverNaN(Register Val, bool SNaN) {
   return FPClass.isKnownNeverNaN();
 }
 
+bool GISelValueTracking::isKnownNeverLogicalZero(Register Val, unsigned Depth) {
+  KnownFPClass Known = computeKnownFPClass(Val, fcZero | fcSubnormal, Depth);
+  LLT Ty = MRI.getType(Val).getScalarType();
+  return Known.isKnownNeverLogicalZero(
+      MF.getDenormalMode(getFltSemanticForLLT(Ty)));
+}
+
 /// Compute number of sign bits for the intersection of \p Src0 and \p Src1
 unsigned GISelValueTracking::computeNumSignBitsMin(Register Src0, Register Src1,
                                                    const APInt &DemandedElts,

--- a/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.cpp
@@ -8,6 +8,7 @@
 
 #include "AMDGPUCombinerHelper.h"
 #include "GCNSubtarget.h"
+#include "llvm/CodeGen/GlobalISel/GISelValueTracking.h"
 #include "llvm/CodeGen/GlobalISel/GenericMachineInstrs.h"
 #include "llvm/CodeGen/GlobalISel/LegalizerInfo.h"
 #include "llvm/CodeGen/GlobalISel/MIPatternMatch.h"
@@ -172,16 +173,13 @@ static bool isConstantCostlierToNegate(MachineInstr &MI, Register Reg,
   return false;
 }
 
-static bool isNonZeroConstantFP(Register Reg, const MachineRegisterInfo &MRI) {
-  std::optional<APFloat> C = isConstantOrConstantSplatVectorFP(Reg, MRI);
-  return C && !C->isZero() && !C->isDenormal();
-}
-
 bool AMDGPUCombinerHelper::canIgnoreLegacyMinMaxTies(const MachineInstr &MI,
                                                      Register LHS,
                                                      Register RHS) const {
-  return mayIgnoreSignedZero(MI) || isNonZeroConstantFP(LHS, MRI) ||
-         isNonZeroConstantFP(RHS, MRI);
+  if (mayIgnoreSignedZero(MI))
+    return true;
+  return VT &&
+         (VT->isKnownNeverLogicalZero(LHS) || VT->isKnownNeverLogicalZero(RHS));
 }
 
 static unsigned inverseMinMax(unsigned Opc) {
@@ -229,12 +227,13 @@ bool AMDGPUCombinerHelper::matchFoldableFneg(MachineInstr &MI,
   switch (MatchInfo->getOpcode()) {
   case AMDGPU::G_AMDGPU_FMIN_LEGACY:
   case AMDGPU::G_AMDGPU_FMAX_LEGACY:
-    // Swapping min<->max flips which operand a signed zero tie selects.
-    if (!canIgnoreLegacyMinMaxTies(*MatchInfo,
-                                   MatchInfo->getOperand(1).getReg(),
-                                   MatchInfo->getOperand(2).getReg()))
+    if (isConstantCostlierToNegate(*MatchInfo,
+                                   MatchInfo->getOperand(2).getReg(), MRI))
       return false;
-    [[fallthrough]];
+    // Swapping min<->max flips which operand a signed zero tie selects.
+    return canIgnoreLegacyMinMaxTies(*MatchInfo,
+                                     MatchInfo->getOperand(1).getReg(),
+                                     MatchInfo->getOperand(2).getReg());
   case AMDGPU::G_FMINNUM:
   case AMDGPU::G_FMAXNUM:
   case AMDGPU::G_FMINNUM_IEEE:

--- a/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.cpp
@@ -142,7 +142,7 @@ static bool allUsesHaveSourceMods(MachineInstr &MI, MachineRegisterInfo &MRI,
   return true;
 }
 
-static bool mayIgnoreSignedZero(MachineInstr &MI) {
+static bool mayIgnoreSignedZero(const MachineInstr &MI) {
   return MI.getFlag(MachineInstr::MIFlag::FmNsz);
 }
 
@@ -170,6 +170,18 @@ static bool isConstantCostlierToNegate(MachineInstr &MI, Register Reg,
       return true;
   }
   return false;
+}
+
+static bool isNonZeroConstantFP(Register Reg, const MachineRegisterInfo &MRI) {
+  std::optional<APFloat> C = isConstantOrConstantSplatVectorFP(Reg, MRI);
+  return C && !C->isZero() && !C->isDenormal();
+}
+
+bool AMDGPUCombinerHelper::canIgnoreLegacyMinMaxTies(const MachineInstr &MI,
+                                                     Register LHS,
+                                                     Register RHS) const {
+  return mayIgnoreSignedZero(MI) || isNonZeroConstantFP(LHS, MRI) ||
+         isNonZeroConstantFP(RHS, MRI);
 }
 
 static unsigned inverseMinMax(unsigned Opc) {
@@ -215,14 +227,20 @@ bool AMDGPUCombinerHelper::matchFoldableFneg(MachineInstr &MI,
   }
 
   switch (MatchInfo->getOpcode()) {
+  case AMDGPU::G_AMDGPU_FMIN_LEGACY:
+  case AMDGPU::G_AMDGPU_FMAX_LEGACY:
+    // Swapping min<->max flips which operand a signed zero tie selects.
+    if (!canIgnoreLegacyMinMaxTies(*MatchInfo,
+                                   MatchInfo->getOperand(1).getReg(),
+                                   MatchInfo->getOperand(2).getReg()))
+      return false;
+    [[fallthrough]];
   case AMDGPU::G_FMINNUM:
   case AMDGPU::G_FMAXNUM:
   case AMDGPU::G_FMINNUM_IEEE:
   case AMDGPU::G_FMAXNUM_IEEE:
   case AMDGPU::G_FMINIMUM:
   case AMDGPU::G_FMAXIMUM:
-  case AMDGPU::G_AMDGPU_FMIN_LEGACY:
-  case AMDGPU::G_AMDGPU_FMAX_LEGACY:
     // 0 doesn't have a negated inline immediate.
     return !isConstantCostlierToNegate(*MatchInfo,
                                        MatchInfo->getOperand(2).getReg(), MRI);

--- a/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.h
@@ -51,7 +51,7 @@ public:
 
   /// fmin_legacy/fmax_legacy select s1 on NaN, and on a +0.0/-0.0 tie (s1 for
   /// min, s0 for max). Returns true if that tie cannot be observed: nsz on
-  /// \p MI, or a nonzero, non-denormal constant in \p LHS or \p RHS.
+  /// \p MI, or a known non-logical-zero \p LHS or \p RHS.
   bool canIgnoreLegacyMinMaxTies(const MachineInstr &MI, Register LHS,
                                  Register RHS) const;
 };

--- a/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.h
@@ -48,6 +48,12 @@ public:
       std::function<void(MachineIRBuilder &)> &MatchInfo) const;
 
   bool matchConstantIs32BitMask(Register Reg) const;
+
+  /// fmin_legacy/fmax_legacy select s1 on NaN, and on a +0.0/-0.0 tie (s1 for
+  /// min, s0 for max). Returns true if that tie cannot be observed: nsz on
+  /// \p MI, or a nonzero, non-denormal constant in \p LHS or \p RHS.
+  bool canIgnoreLegacyMinMaxTies(const MachineInstr &MI, Register LHS,
+                                 Register RHS) const;
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -1679,16 +1679,12 @@ static SDValue peekFPSignOps(SDValue Val) {
   return Val;
 }
 
-static bool isNonZeroConstantFP(SDValue V) {
-  ConstantFPSDNode *C = isConstOrConstSplatFP(V);
-  return C && !C->isZero() && !C->getValueAPF().isDenormal();
-}
-
 // SelectionDAG twin of AMDGPUCombinerHelper::canIgnoreLegacyMinMaxTies.
-static bool canIgnoreLegacyMinMaxTies(SDNodeFlags Flags, SDValue LHS,
+static bool canIgnoreLegacyMinMaxTies(const SelectionDAG &DAG,
+                                      SDNodeFlags Flags, SDValue LHS,
                                       SDValue RHS) {
-  return Flags.hasNoSignedZeros() || isNonZeroConstantFP(LHS) ||
-         isNonZeroConstantFP(RHS);
+  return Flags.hasNoSignedZeros() || DAG.isKnownNeverLogicalZero(LHS) ||
+         DAG.isKnownNeverLogicalZero(RHS);
 }
 
 SDValue AMDGPUTargetLowering::combineFMinMaxLegacyImpl(
@@ -1696,6 +1692,7 @@ SDValue AMDGPUTargetLowering::combineFMinMaxLegacyImpl(
     SDValue False, SDValue CC, SDNodeFlags Flags, DAGCombinerInfo &DCI) const {
   SelectionDAG &DAG = DCI.DAG;
   ISD::CondCode CCOpcode = cast<CondCodeSDNode>(CC)->get();
+  assert(CCOpcode != ISD::SETCC_INVALID && "Invalid setcc condcode!");
 
   switch (CCOpcode) {
   case ISD::SETOLE:
@@ -1712,8 +1709,6 @@ SDValue AMDGPUTargetLowering::combineFMinMaxLegacyImpl(
         !DCI.isCalledByLegalizer())
       return SDValue();
     break;
-  case ISD::SETCC_INVALID:
-    llvm_unreachable("Invalid setcc condcode!");
   default:
     break;
   }
@@ -1722,60 +1717,42 @@ SDValue AMDGPUTargetLowering::combineFMinMaxLegacyImpl(
   if (LHS != True)
     CCOpcode = ISD::getSetCCInverse(CCOpcode, VT);
 
-  // TieHazard: NaN-correct order is the signed zero tie-incorrect one.
   unsigned Opc;
   bool Swap; // Emit (rhs, lhs) instead of (lhs, rhs).
-  bool TieHazard;
   switch (CCOpcode) {
   case ISD::SETOLT:
   case ISD::SETLT:
-    Opc = AMDGPUISD::FMIN_LEGACY;
-    Swap = false;
-    TieHazard = false;
-    break;
-  case ISD::SETULE:
-  case ISD::SETLE:
-    Opc = AMDGPUISD::FMIN_LEGACY;
-    Swap = true;
-    TieHazard = false;
-    break;
-  case ISD::SETOGE:
-  case ISD::SETGE:
-    Opc = AMDGPUISD::FMAX_LEGACY;
-    Swap = false;
-    TieHazard = false;
-    break;
-  case ISD::SETUGT:
-  case ISD::SETGT:
-    Opc = AMDGPUISD::FMAX_LEGACY;
-    Swap = true;
-    TieHazard = false;
-    break;
   case ISD::SETOLE:
     Opc = AMDGPUISD::FMIN_LEGACY;
     Swap = false;
-    TieHazard = true;
     break;
+  case ISD::SETULE:
+  case ISD::SETLE:
   case ISD::SETULT:
     Opc = AMDGPUISD::FMIN_LEGACY;
     Swap = true;
-    TieHazard = true;
     break;
+  case ISD::SETOGE:
+  case ISD::SETGE:
   case ISD::SETOGT:
     Opc = AMDGPUISD::FMAX_LEGACY;
     Swap = false;
-    TieHazard = true;
     break;
+  case ISD::SETUGT:
+  case ISD::SETGT:
   case ISD::SETUGE:
     Opc = AMDGPUISD::FMAX_LEGACY;
     Swap = true;
-    TieHazard = true;
     break;
   default:
     return SDValue();
   }
 
-  if (TieHazard && !canIgnoreLegacyMinMaxTies(Flags, LHS, RHS))
+  // For these predicates the NaN-correct operand order is the signed zero
+  // tie-incorrect one, so the fold needs the tie to be unobservable.
+  if ((CCOpcode == ISD::SETOLE || CCOpcode == ISD::SETULT ||
+       CCOpcode == ISD::SETOGT || CCOpcode == ISD::SETUGE) &&
+      !canIgnoreLegacyMinMaxTies(DAG, Flags, LHS, RHS))
     return SDValue();
 
   if (Swap)
@@ -5357,7 +5334,7 @@ SDValue AMDGPUTargetLowering::performFNegCombine(SDNode *N,
 
     // Swapping min<->max flips which operand a signed zero tie selects.
     if ((Opc == AMDGPUISD::FMIN_LEGACY || Opc == AMDGPUISD::FMAX_LEGACY) &&
-        !canIgnoreLegacyMinMaxTies(N0->getFlags(), LHS, RHS))
+        !canIgnoreLegacyMinMaxTies(DAG, N0->getFlags(), LHS, RHS))
       return SDValue();
 
     SDValue NegLHS = DAG.getNode(ISD::FNEG, SL, VT, LHS);

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -1679,82 +1679,117 @@ static SDValue peekFPSignOps(SDValue Val) {
   return Val;
 }
 
+static bool isNonZeroConstantFP(SDValue V) {
+  ConstantFPSDNode *C = isConstOrConstSplatFP(V);
+  return C && !C->isZero() && !C->getValueAPF().isDenormal();
+}
+
+// SelectionDAG twin of AMDGPUCombinerHelper::canIgnoreLegacyMinMaxTies.
+static bool canIgnoreLegacyMinMaxTies(SDNodeFlags Flags, SDValue LHS,
+                                      SDValue RHS) {
+  return Flags.hasNoSignedZeros() || isNonZeroConstantFP(LHS) ||
+         isNonZeroConstantFP(RHS);
+}
+
 SDValue AMDGPUTargetLowering::combineFMinMaxLegacyImpl(
     const SDLoc &DL, EVT VT, SDValue LHS, SDValue RHS, SDValue True,
-    SDValue False, SDValue CC, DAGCombinerInfo &DCI) const {
+    SDValue False, SDValue CC, SDNodeFlags Flags, DAGCombinerInfo &DCI) const {
   SelectionDAG &DAG = DCI.DAG;
   ISD::CondCode CCOpcode = cast<CondCodeSDNode>(CC)->get();
+
   switch (CCOpcode) {
-  case ISD::SETOEQ:
-  case ISD::SETONE:
-  case ISD::SETUNE:
-  case ISD::SETNE:
-  case ISD::SETUEQ:
-  case ISD::SETEQ:
-  case ISD::SETFALSE:
-  case ISD::SETFALSE2:
-  case ISD::SETTRUE:
-  case ISD::SETTRUE2:
-  case ISD::SETUO:
-  case ISD::SETO:
-    break;
-  case ISD::SETULE:
-  case ISD::SETULT: {
-    if (LHS == True)
-      return DAG.getNode(AMDGPUISD::FMIN_LEGACY, DL, VT, RHS, LHS);
-    return DAG.getNode(AMDGPUISD::FMAX_LEGACY, DL, VT, LHS, RHS);
-  }
   case ISD::SETOLE:
   case ISD::SETOLT:
   case ISD::SETLE:
-  case ISD::SETLT: {
-    // Ordered. Assume ordered for undefined.
-
+  case ISD::SETLT:
+  case ISD::SETOGE:
+  case ISD::SETOGT:
+  case ISD::SETGE:
+  case ISD::SETGT:
     // Only do this after legalization to avoid interfering with other combines
     // which might occur.
     if (DCI.getDAGCombineLevel() < AfterLegalizeDAG &&
         !DCI.isCalledByLegalizer())
       return SDValue();
-
-    // We need to permute the operands to get the correct NaN behavior. The
-    // selected operand is the second one based on the failing compare with NaN,
-    // so permute it based on the compare type the hardware uses.
-    if (LHS == True)
-      return DAG.getNode(AMDGPUISD::FMIN_LEGACY, DL, VT, LHS, RHS);
-    return DAG.getNode(AMDGPUISD::FMAX_LEGACY, DL, VT, RHS, LHS);
-  }
-  case ISD::SETUGE:
-  case ISD::SETUGT: {
-    if (LHS == True)
-      return DAG.getNode(AMDGPUISD::FMAX_LEGACY, DL, VT, RHS, LHS);
-    return DAG.getNode(AMDGPUISD::FMIN_LEGACY, DL, VT, LHS, RHS);
-  }
-  case ISD::SETGT:
-  case ISD::SETGE:
-  case ISD::SETOGE:
-  case ISD::SETOGT: {
-    if (DCI.getDAGCombineLevel() < AfterLegalizeDAG &&
-        !DCI.isCalledByLegalizer())
-      return SDValue();
-
-    if (LHS == True)
-      return DAG.getNode(AMDGPUISD::FMAX_LEGACY, DL, VT, LHS, RHS);
-    return DAG.getNode(AMDGPUISD::FMIN_LEGACY, DL, VT, RHS, LHS);
-  }
+    break;
   case ISD::SETCC_INVALID:
     llvm_unreachable("Invalid setcc condcode!");
+  default:
+    break;
   }
-  return SDValue();
+
+  // Canonicalize so the select returns the compare's LHS on a true predicate.
+  if (LHS != True)
+    CCOpcode = ISD::getSetCCInverse(CCOpcode, VT);
+
+  // TieHazard: NaN-correct order is the signed zero tie-incorrect one.
+  unsigned Opc;
+  bool Swap; // Emit (rhs, lhs) instead of (lhs, rhs).
+  bool TieHazard;
+  switch (CCOpcode) {
+  case ISD::SETOLT:
+  case ISD::SETLT:
+    Opc = AMDGPUISD::FMIN_LEGACY;
+    Swap = false;
+    TieHazard = false;
+    break;
+  case ISD::SETULE:
+  case ISD::SETLE:
+    Opc = AMDGPUISD::FMIN_LEGACY;
+    Swap = true;
+    TieHazard = false;
+    break;
+  case ISD::SETOGE:
+  case ISD::SETGE:
+    Opc = AMDGPUISD::FMAX_LEGACY;
+    Swap = false;
+    TieHazard = false;
+    break;
+  case ISD::SETUGT:
+  case ISD::SETGT:
+    Opc = AMDGPUISD::FMAX_LEGACY;
+    Swap = true;
+    TieHazard = false;
+    break;
+  case ISD::SETOLE:
+    Opc = AMDGPUISD::FMIN_LEGACY;
+    Swap = false;
+    TieHazard = true;
+    break;
+  case ISD::SETULT:
+    Opc = AMDGPUISD::FMIN_LEGACY;
+    Swap = true;
+    TieHazard = true;
+    break;
+  case ISD::SETOGT:
+    Opc = AMDGPUISD::FMAX_LEGACY;
+    Swap = false;
+    TieHazard = true;
+    break;
+  case ISD::SETUGE:
+    Opc = AMDGPUISD::FMAX_LEGACY;
+    Swap = true;
+    TieHazard = true;
+    break;
+  default:
+    return SDValue();
+  }
+
+  if (TieHazard && !canIgnoreLegacyMinMaxTies(Flags, LHS, RHS))
+    return SDValue();
+
+  if (Swap)
+    std::swap(LHS, RHS);
+  return DAG.getNode(Opc, DL, VT, LHS, RHS, Flags);
 }
 
 /// Generate Min/Max node
-SDValue AMDGPUTargetLowering::combineFMinMaxLegacy(const SDLoc &DL, EVT VT,
-                                                   SDValue LHS, SDValue RHS,
-                                                   SDValue True, SDValue False,
-                                                   SDValue CC,
-                                                   DAGCombinerInfo &DCI) const {
+SDValue AMDGPUTargetLowering::combineFMinMaxLegacy(
+    const SDLoc &DL, EVT VT, SDValue LHS, SDValue RHS, SDValue True,
+    SDValue False, SDValue CC, SDNodeFlags Flags, DAGCombinerInfo &DCI) const {
   if ((LHS == True && RHS == False) || (LHS == False && RHS == True))
-    return combineFMinMaxLegacyImpl(DL, VT, LHS, RHS, True, False, CC, DCI);
+    return combineFMinMaxLegacyImpl(DL, VT, LHS, RHS, True, False, CC, Flags,
+                                    DCI);
 
   SelectionDAG &DAG = DCI.DAG;
 
@@ -1775,8 +1810,8 @@ SDValue AMDGPUTargetLowering::combineFMinMaxLegacy(const SDLoc &DL, EVT VT,
   if (LHS == NegTrue && CFalse && CRHS) {
     APFloat NegRHS = neg(CRHS->getValueAPF());
     if (NegRHS == CFalse->getValueAPF()) {
-      SDValue Combined =
-          combineFMinMaxLegacyImpl(DL, VT, LHS, RHS, NegTrue, False, CC, DCI);
+      SDValue Combined = combineFMinMaxLegacyImpl(DL, VT, LHS, RHS, NegTrue,
+                                                  False, CC, Flags, DCI);
       if (Combined)
         return DAG.getNode(ISD::FNEG, DL, VT, Combined);
       return SDValue();
@@ -5113,8 +5148,8 @@ SDValue AMDGPUTargetLowering::performSelectCombine(SDNode *N,
     }
 
     if (VT == MVT::f32 && Subtarget->hasFminFmaxLegacy()) {
-      SDValue MinMax
-        = combineFMinMaxLegacy(SDLoc(N), VT, LHS, RHS, True, False, CC, DCI);
+      SDValue MinMax = combineFMinMaxLegacy(SDLoc(N), VT, LHS, RHS, True, False,
+                                            CC, N->getFlags(), DCI);
       // Revisit this node so we can catch min3/max3/med3 patterns.
       //DCI.AddToWorklist(MinMax.getNode());
       return MinMax;
@@ -5318,6 +5353,11 @@ SDValue AMDGPUTargetLowering::performFNegCombine(SDNode *N,
     // 0 doesn't have a negated inline immediate.
     // TODO: This constant check should be generalized to other operations.
     if (isConstantCostlierToNegate(RHS))
+      return SDValue();
+
+    // Swapping min<->max flips which operand a signed zero tie selects.
+    if ((Opc == AMDGPUISD::FMIN_LEGACY || Opc == AMDGPUISD::FMAX_LEGACY) &&
+        !canIgnoreLegacyMinMaxTies(N0->getFlags(), LHS, RHS))
       return SDValue();
 
     SDValue NegLHS = DAG.getNode(ISD::FNEG, SL, VT, LHS);

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.h
@@ -299,7 +299,7 @@ public:
                                    SDValue CC, SDNodeFlags Flags,
                                    DAGCombinerInfo &DCI) const;
 
-  /// \p Flags must be the select flags, not the compare (a SELECT_CC
+  /// \p Flags must be the select flags, not the compare (SELECT_CC
   /// flags come from the fcmp and say nothing about the selected value).
   SDValue combineFMinMaxLegacy(const SDLoc &DL, EVT VT, SDValue LHS,
                                SDValue RHS, SDValue True, SDValue False,

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.h
@@ -296,11 +296,15 @@ public:
 
   SDValue combineFMinMaxLegacyImpl(const SDLoc &DL, EVT VT, SDValue LHS,
                                    SDValue RHS, SDValue True, SDValue False,
-                                   SDValue CC, DAGCombinerInfo &DCI) const;
+                                   SDValue CC, SDNodeFlags Flags,
+                                   DAGCombinerInfo &DCI) const;
 
+  /// \p Flags must be the select flags, not the compare (a SELECT_CC
+  /// flags come from the fcmp and say nothing about the selected value).
   SDValue combineFMinMaxLegacy(const SDLoc &DL, EVT VT, SDValue LHS,
                                SDValue RHS, SDValue True, SDValue False,
-                               SDValue CC, DAGCombinerInfo &DCI) const;
+                               SDValue CC, SDNodeFlags Flags,
+                               DAGCombinerInfo &DCI) const;
 
   // FIXME: Turn off MergeConsecutiveStores() before Instruction Selection for
   // AMDGPU.  Commit r319036,

--- a/llvm/lib/Target/AMDGPU/AMDGPUPostLegalizerCombiner.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPostLegalizerCombiner.cpp
@@ -177,7 +177,15 @@ bool AMDGPUPostLegalizerCombinerImpl::matchFMinFMaxLegacy(
     Info.Pred = CmpInst::getInversePredicate(Info.Pred);
 
   // Only match </<=/>=/> not ==/!= etc.
-  return Info.Pred != CmpInst::getSwappedPredicate(Info.Pred);
+  if (Info.Pred == CmpInst::getSwappedPredicate(Info.Pred))
+    return false;
+
+  // These predicates pick the signed zero tie-incorrect operand order.
+  if (Info.Pred == CmpInst::FCMP_OLE || Info.Pred == CmpInst::FCMP_ULT ||
+      Info.Pred == CmpInst::FCMP_OGT || Info.Pred == CmpInst::FCMP_UGE)
+    return Helper.canIgnoreLegacyMinMaxTies(MI, Info.LHS, Info.RHS);
+
+  return true;
 }
 
 void AMDGPUPostLegalizerCombinerImpl::applySelectFCmpToFMinFMaxLegacy(

--- a/llvm/lib/Target/AMDGPU/R600ISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/R600ISelLowering.cpp
@@ -810,7 +810,8 @@ SDValue R600TargetLowering::LowerSELECT_CC(SDValue Op, SelectionDAG &DAG) const 
 
   if (VT == MVT::f32) {
     DAGCombinerInfo DCI(DAG, AfterLegalizeVectorOps, true, nullptr);
-    SDValue MinMax = combineFMinMaxLegacy(DL, VT, LHS, RHS, True, False, CC, DCI);
+    SDValue MinMax = combineFMinMaxLegacy(DL, VT, LHS, RHS, True, False, CC,
+                                          SDNodeFlags(), DCI);
     if (MinMax)
       return MinMax;
   }

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/combine-foldable-fneg.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/combine-foldable-fneg.mir
@@ -101,10 +101,9 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $vgpr1
-    ; CHECK-NEXT: [[FNEG:%[0-9]+]]:_(s32) = G_FNEG [[COPY]]
-    ; CHECK-NEXT: [[FNEG1:%[0-9]+]]:_(s32) = G_FNEG [[COPY1]]
-    ; CHECK-NEXT: [[AMDGPU_FMAX_LEGACY:%[0-9]+]]:_(s32) = G_AMDGPU_FMAX_LEGACY [[FNEG]], [[FNEG1]]
-    ; CHECK-NEXT: $vgpr0 = COPY [[AMDGPU_FMAX_LEGACY]](s32)
+    ; CHECK-NEXT: [[AMDGPU_FMIN_LEGACY:%[0-9]+]]:_(s32) = G_AMDGPU_FMIN_LEGACY [[COPY]], [[COPY1]]
+    ; CHECK-NEXT: [[FNEG:%[0-9]+]]:_(s32) = G_FNEG [[AMDGPU_FMIN_LEGACY]]
+    ; CHECK-NEXT: $vgpr0 = COPY [[FNEG]](s32)
     %0:_(s32) = COPY $vgpr0
     %1:_(s32) = COPY $vgpr1
     %2:_(s32) = G_AMDGPU_FMIN_LEGACY %0, %1
@@ -123,10 +122,9 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $vgpr1
-    ; CHECK-NEXT: [[FNEG:%[0-9]+]]:_(s32) = G_FNEG [[COPY]]
-    ; CHECK-NEXT: [[FNEG1:%[0-9]+]]:_(s32) = G_FNEG [[COPY1]]
-    ; CHECK-NEXT: [[AMDGPU_FMIN_LEGACY:%[0-9]+]]:_(s32) = G_AMDGPU_FMIN_LEGACY [[FNEG]], [[FNEG1]]
-    ; CHECK-NEXT: $vgpr0 = COPY [[AMDGPU_FMIN_LEGACY]](s32)
+    ; CHECK-NEXT: [[AMDGPU_FMAX_LEGACY:%[0-9]+]]:_(s32) = G_AMDGPU_FMAX_LEGACY [[COPY]], [[COPY1]]
+    ; CHECK-NEXT: [[FNEG:%[0-9]+]]:_(s32) = G_FNEG [[AMDGPU_FMAX_LEGACY]]
+    ; CHECK-NEXT: $vgpr0 = COPY [[FNEG]](s32)
     %0:_(s32) = COPY $vgpr0
     %1:_(s32) = COPY $vgpr1
     %2:_(s32) = G_AMDGPU_FMAX_LEGACY %0, %1

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fmax_legacy.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fmax_legacy.ll
@@ -284,3 +284,41 @@ define amdgpu_ps float @s_test_fmax_legacy_f32(float inreg %a, float inreg %b) {
   %val = select i1 %cmp, float %a, float %b
   ret float %val
 }
+
+; A nonzero constant operand rules out the signed zero tie.
+define float @v_test_fmax_legacy_ogt_f32_const_rhs(float %a) {
+; GFX6-LABEL: v_test_fmax_legacy_ogt_f32_const_rhs:
+; GFX6:       ; %bb.0:
+; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX6-NEXT:    v_max_legacy_f32_e64 v0, v0, 2.0
+; GFX6-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8-LABEL: v_test_fmax_legacy_ogt_f32_const_rhs:
+; GFX8:       ; %bb.0:
+; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8-NEXT:    v_cmp_lt_f32_e32 vcc, 2.0, v0
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 2.0, v0, vcc
+; GFX8-NEXT:    s_setpc_b64 s[30:31]
+  %cmp = fcmp ogt float %a, 2.0
+  %val = select i1 %cmp, float %a, float 2.0
+  ret float %val
+}
+
+define float @v_test_fmax_legacy_ogt_f32_zero_rhs(float %a) {
+; GFX6-LABEL: v_test_fmax_legacy_ogt_f32_zero_rhs:
+; GFX6:       ; %bb.0:
+; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX6-NEXT:    v_cmp_lt_f32_e32 vcc, 0, v0
+; GFX6-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GFX6-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8-LABEL: v_test_fmax_legacy_ogt_f32_zero_rhs:
+; GFX8:       ; %bb.0:
+; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8-NEXT:    v_cmp_lt_f32_e32 vcc, 0, v0
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GFX8-NEXT:    s_setpc_b64 s[30:31]
+  %cmp = fcmp ogt float %a, 0.0
+  %val = select i1 %cmp, float %a, float 0.0
+  ret float %val
+}

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fmax_legacy.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fmax_legacy.ll
@@ -7,7 +7,8 @@ define float @v_test_fmax_legacy_ogt_f32(float %a, float %b) {
 ; GFX6-LABEL: v_test_fmax_legacy_ogt_f32:
 ; GFX6:       ; %bb.0:
 ; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX6-NEXT:    v_max_legacy_f32_e32 v0, v0, v1
+; GFX6-NEXT:    v_cmp_gt_f32_e32 vcc, v0, v1
+; GFX6-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_test_fmax_legacy_ogt_f32:
@@ -43,7 +44,8 @@ define float @v_test_fmax_legacy_uge_f32(float %a, float %b) {
 ; GFX6-LABEL: v_test_fmax_legacy_uge_f32:
 ; GFX6:       ; %bb.0:
 ; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX6-NEXT:    v_max_legacy_f32_e32 v0, v1, v0
+; GFX6-NEXT:    v_cmp_nlt_f32_e32 vcc, v0, v1
+; GFX6-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_test_fmax_legacy_uge_f32:
@@ -97,7 +99,8 @@ define float @v_test_fmax_legacy_olt_f32(float %a, float %b) {
 ; GFX6-LABEL: v_test_fmax_legacy_olt_f32:
 ; GFX6:       ; %bb.0:
 ; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX6-NEXT:    v_max_legacy_f32_e32 v0, v1, v0
+; GFX6-NEXT:    v_cmp_lt_f32_e32 vcc, v0, v1
+; GFX6-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_test_fmax_legacy_olt_f32:
@@ -115,7 +118,8 @@ define float @v_test_fmax_legacy_ule_f32(float %a, float %b) {
 ; GFX6-LABEL: v_test_fmax_legacy_ule_f32:
 ; GFX6:       ; %bb.0:
 ; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX6-NEXT:    v_max_legacy_f32_e32 v0, v0, v1
+; GFX6-NEXT:    v_cmp_ngt_f32_e32 vcc, v0, v1
+; GFX6-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_test_fmax_legacy_ule_f32:
@@ -239,8 +243,10 @@ define <2 x float> @v_test_fmax_legacy_ogt_v2f32(<2 x float> %a, <2 x float> %b)
 ; GFX6-LABEL: v_test_fmax_legacy_ogt_v2f32:
 ; GFX6:       ; %bb.0:
 ; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX6-NEXT:    v_max_legacy_f32_e32 v0, v0, v2
-; GFX6-NEXT:    v_max_legacy_f32_e32 v1, v1, v3
+; GFX6-NEXT:    v_cmp_gt_f32_e32 vcc, v0, v2
+; GFX6-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX6-NEXT:    v_cmp_gt_f32_e32 vcc, v1, v3
+; GFX6-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_test_fmax_legacy_ogt_v2f32:
@@ -260,7 +266,10 @@ define amdgpu_ps float @s_test_fmax_legacy_f32(float inreg %a, float inreg %b) {
 ; GFX6-LABEL: s_test_fmax_legacy_f32:
 ; GFX6:       ; %bb.0:
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s3
-; GFX6-NEXT:    v_max_legacy_f32_e32 v0, s2, v0
+; GFX6-NEXT:    v_cmp_gt_f32_e32 vcc, s2, v0
+; GFX6-NEXT:    s_or_b64 s[0:1], vcc, vcc
+; GFX6-NEXT:    s_cselect_b32 s0, s2, s3
+; GFX6-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX6-NEXT:    ; return to shader part epilog
 ;
 ; GFX8-LABEL: s_test_fmax_legacy_f32:

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fmin_legacy.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fmin_legacy.ll
@@ -434,3 +434,41 @@ define amdgpu_ps float @s_test_fmin_legacy_f32(float inreg %a, float inreg %b) {
   %val = select i1 %cmp, float %a, float %b
   ret float %val
 }
+
+; A nonzero constant operand rules out the signed zero tie.
+define float @v_test_fmin_legacy_ole_f32_const_rhs(float %a) {
+; GFX6-LABEL: v_test_fmin_legacy_ole_f32_const_rhs:
+; GFX6:       ; %bb.0:
+; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX6-NEXT:    v_min_legacy_f32_e64 v0, v0, 2.0
+; GFX6-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8-LABEL: v_test_fmin_legacy_ole_f32_const_rhs:
+; GFX8:       ; %bb.0:
+; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8-NEXT:    v_cmp_ge_f32_e32 vcc, 2.0, v0
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 2.0, v0, vcc
+; GFX8-NEXT:    s_setpc_b64 s[30:31]
+  %cmp = fcmp ole float %a, 2.0
+  %val = select i1 %cmp, float %a, float 2.0
+  ret float %val
+}
+
+define float @v_test_fmin_legacy_ole_f32_zero_rhs(float %a) {
+; GFX6-LABEL: v_test_fmin_legacy_ole_f32_zero_rhs:
+; GFX6:       ; %bb.0:
+; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX6-NEXT:    v_cmp_ge_f32_e32 vcc, 0, v0
+; GFX6-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GFX6-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8-LABEL: v_test_fmin_legacy_ole_f32_zero_rhs:
+; GFX8:       ; %bb.0:
+; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8-NEXT:    v_cmp_ge_f32_e32 vcc, 0, v0
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GFX8-NEXT:    s_setpc_b64 s[30:31]
+  %cmp = fcmp ole float %a, 0.0
+  %val = select i1 %cmp, float %a, float 0.0
+  ret float %val
+}

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fmin_legacy.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fmin_legacy.ll
@@ -9,7 +9,8 @@ define float @v_test_fmin_legacy_ole_f32(float %a, float %b) {
 ; GFX6-LABEL: v_test_fmin_legacy_ole_f32:
 ; GFX6:       ; %bb.0:
 ; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX6-NEXT:    v_min_legacy_f32_e32 v0, v0, v1
+; GFX6-NEXT:    v_cmp_le_f32_e32 vcc, v0, v1
+; GFX6-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_test_fmin_legacy_ole_f32:
@@ -63,7 +64,8 @@ define float @v_test_fmin_legacy_ult_f32(float %a, float %b) {
 ; GFX6-LABEL: v_test_fmin_legacy_ult_f32:
 ; GFX6:       ; %bb.0:
 ; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX6-NEXT:    v_min_legacy_f32_e32 v0, v1, v0
+; GFX6-NEXT:    v_cmp_nge_f32_e32 vcc, v0, v1
+; GFX6-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_test_fmin_legacy_ult_f32:
@@ -99,7 +101,8 @@ define float @v_test_fmin_legacy_oge_f32(float %a, float %b) {
 ; GFX6-LABEL: v_test_fmin_legacy_oge_f32:
 ; GFX6:       ; %bb.0:
 ; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX6-NEXT:    v_min_legacy_f32_e32 v0, v1, v0
+; GFX6-NEXT:    v_cmp_ge_f32_e32 vcc, v0, v1
+; GFX6-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_test_fmin_legacy_oge_f32:
@@ -135,7 +138,8 @@ define float @v_test_fmin_legacy_ugt_f32(float %a, float %b) {
 ; GFX6-LABEL: v_test_fmin_legacy_ugt_f32:
 ; GFX6:       ; %bb.0:
 ; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX6-NEXT:    v_min_legacy_f32_e32 v0, v0, v1
+; GFX6-NEXT:    v_cmp_nle_f32_e32 vcc, v0, v1
+; GFX6-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_test_fmin_legacy_ugt_f32:
@@ -153,7 +157,8 @@ define float @v_test_fmin_legacy_ole_f32_fneg_lhs(float %a, float %b) {
 ; GFX6-LABEL: v_test_fmin_legacy_ole_f32_fneg_lhs:
 ; GFX6:       ; %bb.0:
 ; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX6-NEXT:    v_min_legacy_f32_e64 v0, -v0, v1
+; GFX6-NEXT:    v_cmp_le_f32_e64 s[4:5], -v0, v1
+; GFX6-NEXT:    v_cndmask_b32_e64 v0, v1, -v0, s[4:5]
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_test_fmin_legacy_ole_f32_fneg_lhs:
@@ -172,7 +177,8 @@ define float @v_test_fmin_legacy_ole_f32_fneg_rhs(float %a, float %b) {
 ; GFX6-LABEL: v_test_fmin_legacy_ole_f32_fneg_rhs:
 ; GFX6:       ; %bb.0:
 ; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX6-NEXT:    v_min_legacy_f32_e64 v0, v0, -v1
+; GFX6-NEXT:    v_cmp_le_f32_e64 s[4:5], v0, -v1
+; GFX6-NEXT:    v_cndmask_b32_e64 v0, -v1, v0, s[4:5]
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_test_fmin_legacy_ole_f32_fneg_rhs:
@@ -387,8 +393,10 @@ define <2 x float> @v_test_fmin_legacy_ole_v2f32(<2 x float> %a, <2 x float> %b)
 ; GFX6-LABEL: v_test_fmin_legacy_ole_v2f32:
 ; GFX6:       ; %bb.0:
 ; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX6-NEXT:    v_min_legacy_f32_e32 v0, v0, v2
-; GFX6-NEXT:    v_min_legacy_f32_e32 v1, v1, v3
+; GFX6-NEXT:    v_cmp_le_f32_e32 vcc, v0, v2
+; GFX6-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX6-NEXT:    v_cmp_le_f32_e32 vcc, v1, v3
+; GFX6-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_test_fmin_legacy_ole_v2f32:
@@ -408,7 +416,10 @@ define amdgpu_ps float @s_test_fmin_legacy_f32(float inreg %a, float inreg %b) {
 ; GFX6-LABEL: s_test_fmin_legacy_f32:
 ; GFX6:       ; %bb.0:
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s3
-; GFX6-NEXT:    v_min_legacy_f32_e32 v0, s2, v0
+; GFX6-NEXT:    v_cmp_le_f32_e32 vcc, s2, v0
+; GFX6-NEXT:    s_or_b64 s[0:1], vcc, vcc
+; GFX6-NEXT:    s_cselect_b32 s0, s2, s3
+; GFX6-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX6-NEXT:    ; return to shader part epilog
 ;
 ; GFX8-LABEL: s_test_fmin_legacy_f32:

--- a/llvm/test/CodeGen/AMDGPU/fmax_legacy.ll
+++ b/llvm/test/CodeGen/AMDGPU/fmax_legacy.ll
@@ -10,12 +10,10 @@ declare i32 @llvm.amdgcn.workitem.id.x() #1
 ; GCN: {{buffer|flat}}_load_dword [[A:v[0-9]+]]
 ; GCN: {{buffer|flat}}_load_dword [[B:v[0-9]+]]
 
-; SI: v_max_legacy_f32_e32 {{v[0-9]+}}, [[B]], [[A]]
+; GCN: v_cmp_nlt_f32_e32 vcc, [[A]], [[B]]
+; GCN: v_cndmask_b32_e32 v{{[0-9]+}}, [[B]], [[A]]
 
-; VI: v_cmp_nlt_f32_e32 vcc, [[A]], [[B]]
-; VI: v_cndmask_b32_e32 v{{[0-9]+}}, [[B]], [[A]]
-
-; EG: MAX
+; EG: SETGT
 define amdgpu_kernel void @test_fmax_legacy_uge_f32(ptr addrspace(1) %out, ptr addrspace(1) %in) #0 {
   %tid = call i32 @llvm.amdgcn.workitem.id.x() #1
   %gep.0 = getelementptr float, ptr addrspace(1) %in, i32 %tid
@@ -197,12 +195,10 @@ define amdgpu_kernel void @test_fmax_legacy_ugt_f32_fast(ptr addrspace(1) %out, 
 ; GCN: {{buffer|flat}}_load_dword [[A:v[0-9]+]]
 ; GCN: {{buffer|flat}}_load_dword [[B:v[0-9]+]]
 
-; SI: v_max_legacy_f32_e32 {{v[0-9]+}}, [[A]], [[B]]
+; GCN: v_cmp_gt_f32_e32 vcc, [[A]], [[B]]
+; GCN: v_cndmask_b32_e32 v{{[0-9]+}}, [[B]], [[A]]
 
-; VI: v_cmp_gt_f32_e32 vcc, [[A]], [[B]]
-; VI: v_cndmask_b32_e32 v{{[0-9]+}}, [[B]], [[A]]
-
-; EG: MAX
+; EG: SETGT
 define amdgpu_kernel void @test_fmax_legacy_ogt_f32(ptr addrspace(1) %out, ptr addrspace(1) %in) #0 {
   %tid = call i32 @llvm.amdgcn.workitem.id.x() #1
   %gep.0 = getelementptr float, ptr addrspace(1) %in, i32 %tid
@@ -241,12 +237,10 @@ define amdgpu_kernel void @test_fmax_legacy_ogt_f32_fast(ptr addrspace(1) %out, 
 ; GCN: {{buffer|flat}}_load_dword [[A:v[0-9]+]]
 ; GCN: {{buffer|flat}}_load_dword [[B:v[0-9]+]]
 
-; SI: v_max_legacy_f32_e32 {{v[0-9]+}}, [[A]], [[B]]
+; GCN: v_cmp_gt_f32_e32 vcc, [[A]], [[B]]
+; GCN: v_cndmask_b32_e32 v{{[0-9]+}}, [[B]], [[A]]
 
-; VI: v_cmp_gt_f32_e32 vcc, [[A]], [[B]]
-; VI: v_cndmask_b32_e32 v{{[0-9]+}}, [[B]], [[A]]
-
-; EG: MAX
+; EG: SETGT
 define amdgpu_kernel void @test_fmax_legacy_ogt_v1f32(ptr addrspace(1) %out, ptr addrspace(1) %in) #0 {
   %tid = call i32 @llvm.amdgcn.workitem.id.x() #1
   %gep.0 = getelementptr <1 x float>, ptr addrspace(1) %in, i32 %tid
@@ -282,18 +276,14 @@ define amdgpu_kernel void @test_fmax_legacy_ogt_v1f32_fast(ptr addrspace(1) %out
 }
 
 ; FUNC-LABEL: {{^}}test_fmax_legacy_ogt_v3f32:
-; SI: v_max_legacy_f32_e32
-; SI: v_max_legacy_f32_e32
-; SI: v_max_legacy_f32_e32
-
-; VI: v_cmp_gt_f32_e32
-; VI: v_cndmask_b32_e32
-; VI: v_cmp_gt_f32_e32
-; VI: v_cndmask_b32_e32
-; VI: v_cmp_gt_f32_e32
-; VI: v_cndmask_b32_e32
-; VI-NOT: v_cmp
-; VI-NOT: v_cndmask
+; GCN: v_cmp_gt_f32_e32
+; GCN: v_cndmask_b32_e32
+; GCN: v_cmp_gt_f32_e32
+; GCN: v_cndmask_b32_e32
+; GCN: v_cmp_gt_f32_e32
+; GCN: v_cndmask_b32_e32
+; GCN-NOT: v_cmp
+; GCN-NOT: v_cndmask
 
 ; GCN-NOT: v_max
 define amdgpu_kernel void @test_fmax_legacy_ogt_v3f32(ptr addrspace(1) %out, ptr addrspace(1) %in) #0 {
@@ -339,7 +329,7 @@ define amdgpu_kernel void @test_fmax_legacy_ogt_v3f32_fast(ptr addrspace(1) %out
 ; GCN-NEXT: v_cndmask_b32
 ; GCN-NOT: v_max_
 
-; EG: MAX
+; EG: SETGT
 define amdgpu_kernel void @test_fmax_legacy_ogt_f32_multi_use(ptr addrspace(1) %out0, ptr addrspace(1) %out1, ptr addrspace(1) %in) #0 {
   %tid = call i32 @llvm.amdgcn.workitem.id.x() #1
   %gep.0 = getelementptr float, ptr addrspace(1) %in, i32 %tid

--- a/llvm/test/CodeGen/AMDGPU/fmed3.ll
+++ b/llvm/test/CodeGen/AMDGPU/fmed3.ll
@@ -9384,17 +9384,16 @@ define float @med3_fmin_legacy(float %a, float %b) #3 {
   ret float %med
 }
 
-; With no-NaN inputs med3 still forms directly.
-define float @med3_fmin_legacy_nnan(float %a, float %b) #3 {
-; SI-SDAG-LABEL: med3_fmin_legacy_nnan:
+; With no-NaN, no-signed-zero inputs med3 still forms directly.
+define float @med3_fmin_legacy_nnan_nsz(float %a, float %b) #3 {
+; SI-SDAG-LABEL: med3_fmin_legacy_nnan_nsz:
 ; SI-SDAG:       ; %bb.0:
 ; SI-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SI-SDAG-NEXT:    v_min_legacy_f32_e32 v0, v0, v1
-; SI-SDAG-NEXT:    v_max_legacy_f32_e32 v0, 2.0, v0
-; SI-SDAG-NEXT:    v_min_legacy_f32_e64 v0, v0, 4.0
+; SI-SDAG-NEXT:    v_min_f32_e32 v0, v0, v1
+; SI-SDAG-NEXT:    v_med3_f32 v0, v0, 2.0, 4.0
 ; SI-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
-; SI-GISEL-LABEL: med3_fmin_legacy_nnan:
+; SI-GISEL-LABEL: med3_fmin_legacy_nnan_nsz:
 ; SI-GISEL:       ; %bb.0:
 ; SI-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-GISEL-NEXT:    v_min_legacy_f32_e32 v0, v0, v1
@@ -9402,18 +9401,14 @@ define float @med3_fmin_legacy_nnan(float %a, float %b) #3 {
 ; SI-GISEL-NEXT:    v_min_legacy_f32_e64 v0, v0, 4.0
 ; SI-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; VI-SDAG-LABEL: med3_fmin_legacy_nnan:
+; VI-SDAG-LABEL: med3_fmin_legacy_nnan_nsz:
 ; VI-SDAG:       ; %bb.0:
 ; VI-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; VI-SDAG-NEXT:    v_cmp_lt_f32_e32 vcc, v0, v1
-; VI-SDAG-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
-; VI-SDAG-NEXT:    v_cmp_lt_f32_e32 vcc, 2.0, v0
-; VI-SDAG-NEXT:    v_cndmask_b32_e32 v0, 2.0, v0, vcc
-; VI-SDAG-NEXT:    v_cmp_gt_f32_e32 vcc, 4.0, v0
-; VI-SDAG-NEXT:    v_cndmask_b32_e32 v0, 4.0, v0, vcc
+; VI-SDAG-NEXT:    v_min_f32_e32 v0, v0, v1
+; VI-SDAG-NEXT:    v_med3_f32 v0, v0, 2.0, 4.0
 ; VI-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
-; VI-GISEL-LABEL: med3_fmin_legacy_nnan:
+; VI-GISEL-LABEL: med3_fmin_legacy_nnan_nsz:
 ; VI-GISEL:       ; %bb.0:
 ; VI-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-GISEL-NEXT:    v_cmp_lt_f32_e32 vcc, v0, v1
@@ -9424,34 +9419,49 @@ define float @med3_fmin_legacy_nnan(float %a, float %b) #3 {
 ; VI-GISEL-NEXT:    v_cndmask_b32_e32 v0, 4.0, v0, vcc
 ; VI-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX9-LABEL: med3_fmin_legacy_nnan:
-; GFX9:       ; %bb.0:
-; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_cmp_lt_f32_e32 vcc, v0, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
-; GFX9-NEXT:    v_cmp_lt_f32_e32 vcc, 2.0, v0
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, 2.0, v0, vcc
-; GFX9-NEXT:    v_cmp_gt_f32_e32 vcc, 4.0, v0
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, 4.0, v0, vcc
-; GFX9-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-SDAG-LABEL: med3_fmin_legacy_nnan_nsz:
+; GFX9-SDAG:       ; %bb.0:
+; GFX9-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-SDAG-NEXT:    v_min_f32_e32 v0, v0, v1
+; GFX9-SDAG-NEXT:    v_med3_f32 v0, v0, 2.0, 4.0
+; GFX9-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX11-LABEL: med3_fmin_legacy_nnan:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_cmp_lt_f32_e32 vcc_lo, v0, v1
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_cmp_lt_f32_e32 vcc_lo, 2.0, v0
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, 2.0, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 4.0, v0
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, 4.0, v0, vcc_lo
-; GFX11-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-GISEL-LABEL: med3_fmin_legacy_nnan_nsz:
+; GFX9-GISEL:       ; %bb.0:
+; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-GISEL-NEXT:    v_cmp_lt_f32_e32 vcc, v0, v1
+; GFX9-GISEL-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX9-GISEL-NEXT:    v_cmp_lt_f32_e32 vcc, 2.0, v0
+; GFX9-GISEL-NEXT:    v_cndmask_b32_e32 v0, 2.0, v0, vcc
+; GFX9-GISEL-NEXT:    v_cmp_gt_f32_e32 vcc, 4.0, v0
+; GFX9-GISEL-NEXT:    v_cndmask_b32_e32 v0, 4.0, v0, vcc
+; GFX9-GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-SDAG-LABEL: med3_fmin_legacy_nnan_nsz:
+; GFX11-SDAG:       ; %bb.0:
+; GFX11-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-SDAG-NEXT:    v_min_f32_e32 v0, v0, v1
+; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-SDAG-NEXT:    v_med3_f32 v0, v0, 2.0, 4.0
+; GFX11-SDAG-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-GISEL-LABEL: med3_fmin_legacy_nnan_nsz:
+; GFX11-GISEL:       ; %bb.0:
+; GFX11-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-GISEL-NEXT:    v_cmp_lt_f32_e32 vcc_lo, v0, v1
+; GFX11-GISEL-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc_lo
+; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX11-GISEL-NEXT:    v_cmp_lt_f32_e32 vcc_lo, 2.0, v0
+; GFX11-GISEL-NEXT:    v_cndmask_b32_e32 v0, 2.0, v0, vcc_lo
+; GFX11-GISEL-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 4.0, v0
+; GFX11-GISEL-NEXT:    v_cndmask_b32_e32 v0, 4.0, v0, vcc_lo
+; GFX11-GISEL-NEXT:    s_setpc_b64 s[30:31]
   %cmp0 = fcmp nnan olt float %a, %b
-  %inner = select nnan i1 %cmp0, float %a, float %b
+  %inner = select nnan nsz i1 %cmp0, float %a, float %b
   %cmp1 = fcmp nnan ogt float %inner, 2.0
-  %max = select nnan i1 %cmp1, float %inner, float 2.0
+  %max = select nnan nsz i1 %cmp1, float %inner, float 2.0
   %cmp2 = fcmp nnan olt float %max, 4.0
-  %med = select nnan i1 %cmp2, float %max, float 4.0
+  %med = select nnan nsz i1 %cmp2, float %max, float 4.0
   ret float %med
 }
 

--- a/llvm/test/CodeGen/AMDGPU/fmed3.ll
+++ b/llvm/test/CodeGen/AMDGPU/fmed3.ll
@@ -9390,7 +9390,8 @@ define float @med3_fmin_legacy_nnan(float %a, float %b) #3 {
 ; SI-SDAG:       ; %bb.0:
 ; SI-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-SDAG-NEXT:    v_min_legacy_f32_e32 v0, v0, v1
-; SI-SDAG-NEXT:    v_med3_f32 v0, v0, 2.0, 4.0
+; SI-SDAG-NEXT:    v_max_legacy_f32_e32 v0, 2.0, v0
+; SI-SDAG-NEXT:    v_min_legacy_f32_e64 v0, v0, 4.0
 ; SI-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SI-GISEL-LABEL: med3_fmin_legacy_nnan:

--- a/llvm/test/CodeGen/AMDGPU/fmin_legacy.ll
+++ b/llvm/test/CodeGen/AMDGPU/fmin_legacy.ll
@@ -81,7 +81,7 @@ define amdgpu_kernel void @s_test_fmin_legacy_ule_f32_fast(ptr addrspace(1) %out
 
 ; VI-DAG: v_add_f32_e64 [[ADD_A:v[0-9]+]], s[[#LOAD + 2]], 1.0
 ; VI-DAG: v_add_f32_e64 [[ADD_B:v[0-9]+]], s[[#LOAD + 3]], 2.0
-; SI: v_min_legacy_f32_e32 {{v[0-9]+}}, [[ADD_A]], [[ADD_B]]
+; SI: v_min_legacy_f32_e32 {{v[0-9]+}}, [[ADD_B]], [[ADD_A]]
 
 ; VI: v_cmp_le_f32_e32 vcc, [[ADD_A]], [[ADD_B]]
 ; VI: v_cndmask_b32_e32 {{v[0-9]+}}, [[ADD_B]], [[ADD_A]], vcc
@@ -161,10 +161,8 @@ define amdgpu_kernel void @test_fmin_legacy_ule_f32_fast(ptr addrspace(1) %out, 
 ; GCN: {{buffer|flat}}_load_dword [[A:v[0-9]+]]
 ; GCN: {{buffer|flat}}_load_dword [[B:v[0-9]+]]
 
-; SI: v_min_legacy_f32_e32 {{v[0-9]+}}, [[A]], [[B]]
-
-; VI: v_cmp_le_f32_e32 vcc, [[A]], [[B]]
-; VI: v_cndmask_b32_e32 v{{[0-9]+}}, [[B]], [[A]]
+; GCN: v_cmp_le_f32_e32 vcc, [[A]], [[B]]
+; GCN: v_cndmask_b32_e32 v{{[0-9]+}}, [[B]], [[A]]
 define amdgpu_kernel void @test_fmin_legacy_ole_f32(ptr addrspace(1) %out, ptr addrspace(1) %in) #0 {
   %tid = call i32 @llvm.amdgcn.workitem.id.x() #1
   %gep.0 = getelementptr float, ptr addrspace(1) %in, i32 %tid
@@ -243,10 +241,8 @@ define amdgpu_kernel void @test_fmin_legacy_olt_f32_fast(ptr addrspace(1) %out, 
 ; GCN: {{buffer|flat}}_load_dword [[A:v[0-9]+]]
 ; GCN: {{buffer|flat}}_load_dword [[B:v[0-9]+]]
 
-; SI: v_min_legacy_f32_e32 {{v[0-9]+}}, [[B]], [[A]]
-
-; VI: v_cmp_nge_f32_e32 vcc, [[A]], [[B]]
-; VI: v_cndmask_b32_e32 v{{[0-9]+}}, [[B]], [[A]]
+; GCN: v_cmp_nge_f32_e32 vcc, [[A]], [[B]]
+; GCN: v_cndmask_b32_e32 v{{[0-9]+}}, [[B]], [[A]]
 define amdgpu_kernel void @test_fmin_legacy_ult_f32(ptr addrspace(1) %out, ptr addrspace(1) %in) #0 {
   %tid = call i32 @llvm.amdgcn.workitem.id.x() #1
   %gep.0 = getelementptr float, ptr addrspace(1) %in, i32 %tid
@@ -284,10 +280,8 @@ define amdgpu_kernel void @test_fmin_legacy_ult_f32_fast(ptr addrspace(1) %out, 
 ; GCN: {{buffer|flat}}_load_dword [[A:v[0-9]+]]
 ; GCN: {{buffer|flat}}_load_dword [[B:v[0-9]+]]
 
-; SI: v_min_legacy_f32_e32 {{v[0-9]+}}, [[B]], [[A]]
-
-; VI: v_cmp_nge_f32_e32 vcc, [[A]], [[B]]
-; VI: v_cndmask_b32_e32 v{{[0-9]+}}, [[B]], [[A]]
+; GCN: v_cmp_nge_f32_e32 vcc, [[A]], [[B]]
+; GCN: v_cndmask_b32_e32 v{{[0-9]+}}, [[B]], [[A]]
 define amdgpu_kernel void @test_fmin_legacy_ult_v1f32(ptr addrspace(1) %out, ptr addrspace(1) %in) #0 {
   %tid = call i32 @llvm.amdgcn.workitem.id.x() #1
   %gep.0 = getelementptr <1 x float>, ptr addrspace(1) %in, i32 %tid
@@ -324,13 +318,10 @@ define amdgpu_kernel void @test_fmin_legacy_ult_v1f32_fast(ptr addrspace(1) %out
 ; FUNC-LABEL: {{^}}test_fmin_legacy_ult_v2f32:
 ; GCN: {{buffer|flat}}_load_dwordx2
 ; GCN: {{buffer|flat}}_load_dwordx2
-; SI: v_min_legacy_f32_e32
-; SI: v_min_legacy_f32_e32
-
-; VI: v_cmp_nge_f32_e32
-; VI: v_cndmask_b32_e32
-; VI: v_cmp_nge_f32_e32
-; VI: v_cndmask_b32_e32
+; GCN: v_cmp_nge_f32_e32
+; GCN: v_cndmask_b32_e32
+; GCN: v_cmp_nge_f32_e32
+; GCN: v_cndmask_b32_e32
 define amdgpu_kernel void @test_fmin_legacy_ult_v2f32(ptr addrspace(1) %out, ptr addrspace(1) %in) #0 {
   %tid = call i32 @llvm.amdgcn.workitem.id.x() #1
   %gep.0 = getelementptr <2 x float>, ptr addrspace(1) %in, i32 %tid
@@ -366,19 +357,14 @@ define amdgpu_kernel void @test_fmin_legacy_ult_v2f32_fast(ptr addrspace(1) %out
 }
 
 ; FUNC-LABEL: {{^}}test_fmin_legacy_ult_v3f32:
-; SI: v_min_legacy_f32_e32
-; SI: v_min_legacy_f32_e32
-; SI: v_min_legacy_f32_e32
-; SI-NOT: v_min_
-
-; VI: v_cmp_nge_f32_e32
-; VI: v_cndmask_b32_e32
-; VI: v_cmp_nge_f32_e32
-; VI: v_cndmask_b32_e32
-; VI: v_cmp_nge_f32_e32
-; VI: v_cndmask_b32_e32
-; VI-NOT: v_cmp
-; VI-NOT: v_cndmask
+; GCN: v_cmp_nge_f32_e32
+; GCN: v_cndmask_b32_e32
+; GCN: v_cmp_nge_f32_e32
+; GCN: v_cndmask_b32_e32
+; GCN: v_cmp_nge_f32_e32
+; GCN: v_cndmask_b32_e32
+; GCN-NOT: v_cmp
+; GCN-NOT: v_cndmask
 define amdgpu_kernel void @test_fmin_legacy_ult_v3f32(ptr addrspace(1) %out, ptr addrspace(1) %in) #0 {
   %tid = call i32 @llvm.amdgcn.workitem.id.x() #1
   %gep.0 = getelementptr <3 x float>, ptr addrspace(1) %in, i32 %tid

--- a/llvm/test/CodeGen/AMDGPU/pv.ll
+++ b/llvm/test/CodeGen/AMDGPU/pv.ll
@@ -1,7 +1,7 @@
 ; RUN: llc -mtriple=r600 < %s | FileCheck %s
 
 ; CHECK: DOT4 * T{{[0-9]\.W}} (MASKED)
-; CHECK: MAX T{{[0-9].[XYZW]}}, 0.0, PV.X
+; CHECK: SETGT * T{{[0-9]\.W}}, 0.0, PV.X
 define amdgpu_vs void @main(<4 x float> inreg %reg0, <4 x float> inreg %reg1, <4 x float> inreg %reg2, <4 x float> inreg %reg3, <4 x float> inreg %reg4, <4 x float> inreg %reg5, <4 x float> inreg %reg6, <4 x float> inreg %reg7) {
 main_body:
   %tmp = extractelement <4 x float> %reg1, i32 0

--- a/llvm/test/CodeGen/AMDGPU/select-flags-to-fmin-fmax.ll
+++ b/llvm/test/CodeGen/AMDGPU/select-flags-to-fmin-fmax.ll
@@ -3107,3 +3107,233 @@ define float @v_test_fmax_legacy_uge_f32_nsz_flag__nnan_srcs(float %arg0, float 
   %val = select nsz i1 %cmp, float %a, float %b
   ret float %val
 }
+
+; A nonzero constant operand rules out the signed zero tie, so the tie hazard
+; predicates fold without nsz.
+define float @v_test_fmin_legacy_ole_f32_const_rhs(float %a) {
+; GFX7-LABEL: v_test_fmin_legacy_ole_f32_const_rhs:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v0, 1.0, v0
+; GFX7-NEXT:    v_min_f32_e32 v0, 2.0, v0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: v_test_fmin_legacy_ole_f32_const_rhs:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_max_f32_e32 v0, v0, v0
+; GFX9-NEXT:    v_min_f32_e32 v0, 2.0, v0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1170-LABEL: v_test_fmin_legacy_ole_f32_const_rhs:
+; GFX1170:       ; %bb.0:
+; GFX1170-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1170-NEXT:    v_max_num_f32_e32 v0, v0, v0
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1170-NEXT:    v_min_num_f32_e32 v0, 2.0, v0
+; GFX1170-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: v_test_fmin_legacy_ole_f32_const_rhs:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_max_num_f32_e32 v0, v0, v0
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12-NEXT:    v_min_num_f32_e32 v0, 2.0, v0
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+  %cmp = fcmp ole float %a, 2.0
+  %val = select i1 %cmp, float %a, float 2.0
+  ret float %val
+}
+
+define float @v_test_fmin_legacy_ole_f32_const_lhs(float %b) {
+; GFX7-LABEL: v_test_fmin_legacy_ole_f32_const_lhs:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_min_legacy_f32_e32 v0, 2.0, v0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: v_test_fmin_legacy_ole_f32_const_lhs:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cmp_nle_f32_e32 vcc, 2.0, v0
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 2.0, v0, vcc
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1170-LABEL: v_test_fmin_legacy_ole_f32_const_lhs:
+; GFX1170:       ; %bb.0:
+; GFX1170-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1170-NEXT:    v_cmp_nle_f32_e32 vcc_lo, 2.0, v0
+; GFX1170-NEXT:    v_cndmask_b32_e32 v0, 2.0, v0, vcc_lo
+; GFX1170-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: v_test_fmin_legacy_ole_f32_const_lhs:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cmp_nle_f32_e32 vcc_lo, 2.0, v0
+; GFX12-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX12-NEXT:    v_cndmask_b32_e32 v0, 2.0, v0, vcc_lo
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+  %cmp = fcmp ole float 2.0, %b
+  %val = select i1 %cmp, float 2.0, float %b
+  ret float %val
+}
+
+define float @v_test_fmin_legacy_ult_f32_const_rhs(float %a) {
+; GFX7-LABEL: v_test_fmin_legacy_ult_f32_const_rhs:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_min_legacy_f32_e32 v0, 2.0, v0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: v_test_fmin_legacy_ult_f32_const_rhs:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cmp_nle_f32_e32 vcc, 2.0, v0
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 2.0, v0, vcc
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1170-LABEL: v_test_fmin_legacy_ult_f32_const_rhs:
+; GFX1170:       ; %bb.0:
+; GFX1170-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1170-NEXT:    v_cmp_nle_f32_e32 vcc_lo, 2.0, v0
+; GFX1170-NEXT:    v_cndmask_b32_e32 v0, 2.0, v0, vcc_lo
+; GFX1170-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: v_test_fmin_legacy_ult_f32_const_rhs:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cmp_nle_f32_e32 vcc_lo, 2.0, v0
+; GFX12-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX12-NEXT:    v_cndmask_b32_e32 v0, 2.0, v0, vcc_lo
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+  %cmp = fcmp ult float %a, 2.0
+  %val = select i1 %cmp, float %a, float 2.0
+  ret float %val
+}
+
+define float @v_test_fmax_legacy_ogt_f32_const_rhs(float %a) {
+; GFX7-LABEL: v_test_fmax_legacy_ogt_f32_const_rhs:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_mul_f32_e32 v0, 1.0, v0
+; GFX7-NEXT:    v_max_f32_e32 v0, 2.0, v0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: v_test_fmax_legacy_ogt_f32_const_rhs:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_max_f32_e32 v0, v0, v0
+; GFX9-NEXT:    v_max_f32_e32 v0, 2.0, v0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1170-LABEL: v_test_fmax_legacy_ogt_f32_const_rhs:
+; GFX1170:       ; %bb.0:
+; GFX1170-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1170-NEXT:    v_max_num_f32_e32 v0, v0, v0
+; GFX1170-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1170-NEXT:    v_max_num_f32_e32 v0, 2.0, v0
+; GFX1170-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: v_test_fmax_legacy_ogt_f32_const_rhs:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_max_num_f32_e32 v0, v0, v0
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12-NEXT:    v_max_num_f32_e32 v0, 2.0, v0
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+  %cmp = fcmp ogt float %a, 2.0
+  %val = select i1 %cmp, float %a, float 2.0
+  ret float %val
+}
+
+define float @v_test_fmax_legacy_uge_f32_const_rhs(float %a) {
+; GFX7-LABEL: v_test_fmax_legacy_uge_f32_const_rhs:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_max_legacy_f32_e32 v0, 2.0, v0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: v_test_fmax_legacy_uge_f32_const_rhs:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cmp_ngt_f32_e32 vcc, 2.0, v0
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 2.0, v0, vcc
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1170-LABEL: v_test_fmax_legacy_uge_f32_const_rhs:
+; GFX1170:       ; %bb.0:
+; GFX1170-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1170-NEXT:    v_cmp_ngt_f32_e32 vcc_lo, 2.0, v0
+; GFX1170-NEXT:    v_cndmask_b32_e32 v0, 2.0, v0, vcc_lo
+; GFX1170-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: v_test_fmax_legacy_uge_f32_const_rhs:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cmp_ngt_f32_e32 vcc_lo, 2.0, v0
+; GFX12-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX12-NEXT:    v_cndmask_b32_e32 v0, 2.0, v0, vcc_lo
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+  %cmp = fcmp uge float %a, 2.0
+  %val = select i1 %cmp, float %a, float 2.0
+  ret float %val
+}
+
+; A zero constant still cannot be folded without nsz.
+define float @v_test_fmin_legacy_ole_f32_zero_rhs(float %a) {
+; GFX7-LABEL: v_test_fmin_legacy_ole_f32_zero_rhs:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cmp_ge_f32_e32 vcc, 0, v0
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: v_test_fmin_legacy_ole_f32_zero_rhs:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cmp_ge_f32_e32 vcc, 0, v0
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1170-LABEL: v_test_fmin_legacy_ole_f32_zero_rhs:
+; GFX1170:       ; %bb.0:
+; GFX1170-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1170-NEXT:    v_cmp_ge_f32_e32 vcc_lo, 0, v0
+; GFX1170-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc_lo
+; GFX1170-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: v_test_fmin_legacy_ole_f32_zero_rhs:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cmp_ge_f32_e32 vcc_lo, 0, v0
+; GFX12-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX12-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc_lo
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+  %cmp = fcmp ole float %a, 0.0
+  %val = select i1 %cmp, float %a, float 0.0
+  ret float %val
+}

--- a/llvm/test/CodeGen/AMDGPU/select-flags-to-fmin-fmax.ll
+++ b/llvm/test/CodeGen/AMDGPU/select-flags-to-fmin-fmax.ll
@@ -159,7 +159,8 @@ define float @v_test_fmax_legacy_uge_f32_safe(float %a, float %b) {
 ; GFX7-LABEL: v_test_fmax_legacy_uge_f32_safe:
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX7-NEXT:    v_max_legacy_f32_e32 v0, v1, v0
+; GFX7-NEXT:    v_cmp_nlt_f32_e32 vcc, v0, v1
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_test_fmax_legacy_uge_f32_safe:
@@ -196,7 +197,8 @@ define float @v_test_fmax_legacy_uge_f32_nnan_flag(float %a, float %b) {
 ; GFX7-LABEL: v_test_fmax_legacy_uge_f32_nnan_flag:
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX7-NEXT:    v_max_legacy_f32_e32 v0, v1, v0
+; GFX7-NEXT:    v_cmp_nlt_f32_e32 vcc, v0, v1
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_test_fmax_legacy_uge_f32_nnan_flag:
@@ -296,6 +298,231 @@ define float @v_test_fmax_legacy_uge_f32_nnan_nsz_flag(float %a, float %b) {
 ; GFX12-NEXT:    s_setpc_b64 s[30:31]
   %cmp = fcmp uge float %a, %b
   %val = select nnan nsz i1 %cmp, float %a, float %b
+  ret float %val
+}
+
+define float @v_test_fmin_legacy_ole_f32_safe(float %a, float %b) {
+; GFX7-LABEL: v_test_fmin_legacy_ole_f32_safe:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cmp_le_f32_e32 vcc, v0, v1
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: v_test_fmin_legacy_ole_f32_safe:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cmp_le_f32_e32 vcc, v0, v1
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1170-LABEL: v_test_fmin_legacy_ole_f32_safe:
+; GFX1170:       ; %bb.0:
+; GFX1170-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1170-NEXT:    v_cmp_le_f32_e32 vcc_lo, v0, v1
+; GFX1170-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc_lo
+; GFX1170-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: v_test_fmin_legacy_ole_f32_safe:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cmp_le_f32_e32 vcc_lo, v0, v1
+; GFX12-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX12-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc_lo
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+  %cmp = fcmp ole float %a, %b
+  %val = select i1 %cmp, float %a, float %b
+  ret float %val
+}
+
+define float @v_test_fmin_legacy_ole_f32_nsz_flag(float %a, float %b) {
+; GFX7-LABEL: v_test_fmin_legacy_ole_f32_nsz_flag:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_min_legacy_f32_e32 v0, v0, v1
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: v_test_fmin_legacy_ole_f32_nsz_flag:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cmp_le_f32_e32 vcc, v0, v1
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1170-LABEL: v_test_fmin_legacy_ole_f32_nsz_flag:
+; GFX1170:       ; %bb.0:
+; GFX1170-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1170-NEXT:    v_cmp_le_f32_e32 vcc_lo, v0, v1
+; GFX1170-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc_lo
+; GFX1170-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: v_test_fmin_legacy_ole_f32_nsz_flag:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cmp_le_f32_e32 vcc_lo, v0, v1
+; GFX12-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX12-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc_lo
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+  %cmp = fcmp ole float %a, %b
+  %val = select nsz i1 %cmp, float %a, float %b
+  ret float %val
+}
+
+define float @v_test_fmin_legacy_ult_f32_safe(float %a, float %b) {
+; GFX7-LABEL: v_test_fmin_legacy_ult_f32_safe:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cmp_nge_f32_e32 vcc, v0, v1
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: v_test_fmin_legacy_ult_f32_safe:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cmp_nge_f32_e32 vcc, v0, v1
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1170-LABEL: v_test_fmin_legacy_ult_f32_safe:
+; GFX1170:       ; %bb.0:
+; GFX1170-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1170-NEXT:    v_cmp_nge_f32_e32 vcc_lo, v0, v1
+; GFX1170-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc_lo
+; GFX1170-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: v_test_fmin_legacy_ult_f32_safe:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cmp_nge_f32_e32 vcc_lo, v0, v1
+; GFX12-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX12-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc_lo
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+  %cmp = fcmp ult float %a, %b
+  %val = select i1 %cmp, float %a, float %b
+  ret float %val
+}
+
+define float @v_test_fmin_legacy_ult_f32_nsz_flag(float %a, float %b) {
+; GFX7-LABEL: v_test_fmin_legacy_ult_f32_nsz_flag:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_min_legacy_f32_e32 v0, v1, v0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: v_test_fmin_legacy_ult_f32_nsz_flag:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cmp_nge_f32_e32 vcc, v0, v1
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1170-LABEL: v_test_fmin_legacy_ult_f32_nsz_flag:
+; GFX1170:       ; %bb.0:
+; GFX1170-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1170-NEXT:    v_cmp_nge_f32_e32 vcc_lo, v0, v1
+; GFX1170-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc_lo
+; GFX1170-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: v_test_fmin_legacy_ult_f32_nsz_flag:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cmp_nge_f32_e32 vcc_lo, v0, v1
+; GFX12-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX12-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc_lo
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+  %cmp = fcmp ult float %a, %b
+  %val = select nsz i1 %cmp, float %a, float %b
+  ret float %val
+}
+
+define float @v_test_fmax_legacy_ogt_f32_safe(float %a, float %b) {
+; GFX7-LABEL: v_test_fmax_legacy_ogt_f32_safe:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cmp_gt_f32_e32 vcc, v0, v1
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: v_test_fmax_legacy_ogt_f32_safe:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cmp_gt_f32_e32 vcc, v0, v1
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1170-LABEL: v_test_fmax_legacy_ogt_f32_safe:
+; GFX1170:       ; %bb.0:
+; GFX1170-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1170-NEXT:    v_cmp_gt_f32_e32 vcc_lo, v0, v1
+; GFX1170-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc_lo
+; GFX1170-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: v_test_fmax_legacy_ogt_f32_safe:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cmp_gt_f32_e32 vcc_lo, v0, v1
+; GFX12-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX12-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc_lo
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+  %cmp = fcmp ogt float %a, %b
+  %val = select i1 %cmp, float %a, float %b
+  ret float %val
+}
+
+define float @v_test_fmax_legacy_ogt_f32_nsz_flag(float %a, float %b) {
+; GFX7-LABEL: v_test_fmax_legacy_ogt_f32_nsz_flag:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_max_legacy_f32_e32 v0, v0, v1
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: v_test_fmax_legacy_ogt_f32_nsz_flag:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cmp_gt_f32_e32 vcc, v0, v1
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1170-LABEL: v_test_fmax_legacy_ogt_f32_nsz_flag:
+; GFX1170:       ; %bb.0:
+; GFX1170-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1170-NEXT:    v_cmp_gt_f32_e32 vcc_lo, v0, v1
+; GFX1170-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc_lo
+; GFX1170-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: v_test_fmax_legacy_ogt_f32_nsz_flag:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cmp_gt_f32_e32 vcc_lo, v0, v1
+; GFX12-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX12-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc_lo
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+  %cmp = fcmp ogt float %a, %b
+  %val = select nsz i1 %cmp, float %a, float %b
   ret float %val
 }
 
@@ -473,8 +700,10 @@ define <2 x float> @v_test_fmax_legacy_uge_v2f32_safe(<2 x float> %a, <2 x float
 ; GFX7-LABEL: v_test_fmax_legacy_uge_v2f32_safe:
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX7-NEXT:    v_max_legacy_f32_e32 v0, v2, v0
-; GFX7-NEXT:    v_max_legacy_f32_e32 v1, v3, v1
+; GFX7-NEXT:    v_cmp_nlt_f32_e32 vcc, v0, v2
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX7-NEXT:    v_cmp_nlt_f32_e32 vcc, v1, v3
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_test_fmax_legacy_uge_v2f32_safe:
@@ -518,8 +747,10 @@ define <2 x float> @v_test_fmax_legacy_uge_v2f32_nnan_flag(<2 x float> %a, <2 x 
 ; GFX7-LABEL: v_test_fmax_legacy_uge_v2f32_nnan_flag:
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX7-NEXT:    v_max_legacy_f32_e32 v0, v2, v0
-; GFX7-NEXT:    v_max_legacy_f32_e32 v1, v3, v1
+; GFX7-NEXT:    v_cmp_nlt_f32_e32 vcc, v0, v2
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX7-NEXT:    v_cmp_nlt_f32_e32 vcc, v1, v3
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_test_fmax_legacy_uge_v2f32_nnan_flag:


### PR DESCRIPTION
These combines could reorder or negate operands in ways that pick the wrong NaN operand or flip the result of a +0.0/-0.0 tie