### PR TITLE
[clang][amdgpu] resolve type mismatch warning in conditional comparison

### DIFF
--- a/clang/lib/Basic/Targets/AMDGPU.cpp
+++ b/clang/lib/Basic/Targets/AMDGPU.cpp
@@ -197,8 +197,10 @@ AMDGPUTargetInfo::AMDGPUTargetInfo(const llvm::Triple &Triple,
                                             Triple.getSubArch())
                                       : llvm::AMDGPU::parseArchAMDGCN(Opts.CPU))
                   : llvm::AMDGPU::parseArchR600(Opts.CPU)),
-      GPUFeatures(Triple.isAMDGCN() ? llvm::AMDGPU::FEATURE_NONE
-                                    : llvm::AMDGPU::getArchAttrR600(GPUKind)) {
+      GPUFeatures(
+          Triple.isAMDGCN()
+              ? llvm::AMDGPU::FEATURE_NONE
+              : static_cast<unsigned>(llvm::AMDGPU::getArchAttrR600(GPUKind))) {
   resetDataLayout();
 
   AddrSpaceMap = &AMDGPUAddrSpaceMap;


### PR DESCRIPTION
The following warning is generated because of a mismatch in the object types.

```bash
/home/xane/Documents/shallowllvm/llvm-project/clang/lib/Basic/Targets/AMDGPU.cpp: In constructor ‘clang::targets::AMDGPUTargetInfo::AMDGPUTargetInfo(const llvm::Triple&, const clang::TargetOptions&)’:
/home/xane/Documents/shallowllvm/llvm-project/clang/lib/Basic/Targets/AMDGPU.cpp:200:37: warning: enumerated mismatch in conditional expression: ‘llvm::AMDGPU::ArchFeatureKind’ vs ‘llvm::AMDGPU::R600FeatureKind’ [-Wenum-compare]
  200 |       GPUFeatures(Triple.isAMDGCN() ? llvm::AMDGPU::FEATURE_NONE
      |                   ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
  201 |                                     : llvm::AMDGPU::getArchAttrR600(GPUKind)) {
      |                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[1/166] Building CXX object tools/clang/lib/CodeGen/CMakeFiles/obj.clangCodeGen.dir/CodeGenPGO.cpp.o^C
```

The type of `GpuFeatures` and return value of `getArchAttrR600()` is ultimately an `unsigned` int value. Static cast the return value of the method to `unsigned` to resolve the warning without any functional or breaking changes.