### PR TITLE
[Verifier] Forbid operand bundles with label operands

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -4168,6 +4168,9 @@ void Verifier::visitCallBase(CallBase &Call) {
        FoundAttachedCallBundle = false;
   for (unsigned i = 0, e = Call.getNumOperandBundles(); i < e; ++i) {
     OperandBundleUse BU = Call.getOperandBundleAt(i);
+    for (const Value *Input : BU.Inputs)
+      Check(!Input->getType()->isLabelTy(),
+            "Operand bundle operands cannot be labels", Call);
     uint32_t Tag = BU.getTagID();
     if (Tag == LLVMContext::OB_deopt) {
       Check(!FoundDeoptBundle, "Multiple deopt operand bundles", Call);

--- a/llvm/test/Bindings/llvm-c/echo.ll
+++ b/llvm/test/Bindings/llvm-c/echo.ll
@@ -306,7 +306,7 @@ exit:
 
 define void @operandbundles() personality ptr @personalityFn {
   call void @decl() [ "foo"(), "bar\00x"(i32 0, ptr null, token none) ]
-  invoke void @decl() [ "baz"(label %bar) ] to label %foo unwind label %bar
+  invoke void @decl() [ "baz"(i32 0) ] to label %foo unwind label %bar
 foo:
   ret void
 bar:
@@ -398,7 +398,7 @@ define void @test_call_br_02(i32 %input0, i32 %input1) {
 entry:
   ; Multiple indirect destinations, operand bundles, and arguments
   callbr void asm "nop", "r,r,!i,!i"(i32 %input0, i32 %input1)
-    ["op0"(i32 %input1), "op1"(label %bb_02)]
+    ["op0"(i32 %input1), "op1"(i32 %input0)]
     to label %bb_01 [label %bb_03, label %bb_02]
 
 bb_01:

--- a/llvm/test/Verifier/operand-bundles.ll
+++ b/llvm/test/Verifier/operand-bundles.ll
@@ -99,6 +99,15 @@ define void @f_clang_arc_attachedcall() {
   ret void
 }
 
+define void @f_label() {
+; CHECK: Operand bundle operands cannot be labels
+  call void @g() ["bundle"(label %foo)]
+  br label %foo
+
+foo:
+  ret void
+}
+
 declare ptr @llvm.objc.retainAutoreleasedReturnValue(ptr)
 declare ptr @llvm.objc.unsafeClaimAutoreleasedReturnValue(ptr)
 declare ptr @objc_retainAutoreleasedReturnValue(ptr)


### PR DESCRIPTION
These should obviously not be allowed, and break the invariant that labels can only occur (as Uses) inside terminators, which the predecessor iterator relies on.