### PR TITLE
[Clang][Cygwin] Make -fno-use-init-array default in the driver

### DIFF
--- a/clang/lib/Driver/ToolChains/Cygwin.cpp
+++ b/clang/lib/Driver/ToolChains/Cygwin.cpp
@@ -111,6 +111,12 @@ void Cygwin::AddClangSystemIncludeArgs(const ArgList &DriverArgs,
   addExternCSystemInclude(DriverArgs, CC1Args, SysRoot + "/usr/include/w32api");
 }
 
+void Cygwin::addClangTargetOptions(
+    const ArgList &DriverArgs, ArgStringList &CC1Args, BoundArch BA,
+    Action::OffloadKind DeviceOffloadKind) const {
+  CC1Args.push_back("-fno-use-init-array");
+}
+
 void cygwin::Linker::ConstructJob(Compilation &C, const JobAction &JA,
                                   const InputInfo &Output,
                                   const InputInfoList &Inputs,

--- a/clang/lib/Driver/ToolChains/Cygwin.h
+++ b/clang/lib/Driver/ToolChains/Cygwin.h
@@ -28,6 +28,11 @@ public:
   AddClangSystemIncludeArgs(const llvm::opt::ArgList &DriverArgs,
                             llvm::opt::ArgStringList &CC1Args) const override;
 
+  void
+  addClangTargetOptions(const llvm::opt::ArgList &DriverArgs,
+                        llvm::opt::ArgStringList &CC1Args, BoundArch BA,
+                        Action::OffloadKind DeviceOffloadKind) const override;
+
 protected:
   Tool *buildLinker() const override;
 };

--- a/clang/test/Driver/cygwin.cpp
+++ b/clang/test/Driver/cygwin.cpp
@@ -2,6 +2,7 @@
 // RUN:   -resource-dir=%S/Inputs/resource_dir \
 // RUN:   --stdlib=platform 2>&1 | FileCheck --check-prefix=CHECK %s
 // CHECK:      "-cc1"
+// CHECK-SAME: "-fno-use-init-array"
 // CHECK-SAME: "-resource-dir" "[[RESOURCE:[^"]+]]"
 // CHECK-SAME: "-isysroot" "[[SYSROOT:[^"]+]]"
 // CHECK-SAME: {{^}} "-internal-isystem" "[[SYSROOT]]/usr/lib/gcc/i686-pc-cygwin/10/../../../../include/c++/10"


### PR DESCRIPTION
Cygwin uses the .ctors section for constructors.
We already do the same for the MinGW target (#68571), so align with that.