### PR TITLE
[mlir][pygments] Fix op-name highlighting, add low-precision float types

### DIFF
--- a/mlir/utils/pygments/mlir_lexer.py
+++ b/mlir/utils/pygments/mlir_lexer.py
@@ -42,7 +42,6 @@ class MlirLexer(RegexLexer):
 
     tokens = {
         "root": [
-            (r"\s+", Text),
             # Comments
             (r"//.*?$", Comment.Single),
             # operation name with assignment: %... = op.name
@@ -52,6 +51,12 @@ class MlirLexer(RegexLexer):
             ),
             # operation name without result
             (r"^(\s*)([A-Za-z0-9_\.\$\-]+)\b(?=[^<:])", bygroups(Text, Name.Builtin)),
+            # Whitespace. Must come after the anchored operation-name rules
+            # above and be split at the newline: a single `\s+` swallowing a
+            # newline plus the next line's indent leaves the position
+            # mid-line, so `^`-anchored rules never fire again.
+            (r"\n", Text),
+            (r"[ \t]+", Text),
             # Attribute alias definition:  #name =
             (
                 r"^(\s*)(#[_A-Za-z0-9\$\-\.]+)(\b)(\s*=)",
@@ -73,7 +78,12 @@ class MlirLexer(RegexLexer):
             # types by exclamation or builtin names
             (r"![_A-Za-z0-9\$\-\.]+\b", Keyword.Type),
             # NOTE: please sync changes to corresponding builtin type rule in "angled-type"
-            (r"\b(bf16|f16|f32|f64|f80|f128|index|none|(u|s)?i[0-9]+)\b", Keyword.Type),
+            (
+                r"\b(bf16|f16|f32|f64|f80|f128|tf32|index|none"
+                r"|f[0-9]+E[0-9]+M[0-9]+(B[0-9]+)?(FN(UZ|U)?)?"
+                r"|(u|s)?i[0-9]+)\b",
+                Keyword.Type,
+            ),
             # container-like dialect types (tensor<...>, memref<...>, vector<...>)
             (
                 r"\b(complex|memref|tensor|tuple|vector)\s*(<)",
@@ -121,7 +131,9 @@ class MlirLexer(RegexLexer):
             # element / builtin types inside angle brackets (no word-boundary)
             # NOTE: please sync changes to corresponding builtin type rule in "root"
             (
-                r"(?:bf16|f16|f32|f64|f80|f128|index|none|(?:[us]?i[0-9]+))",
+                r"(?:bf16|f16|f32|f64|f80|f128|tf32|index|none"
+                r"|f[0-9]+E[0-9]+M[0-9]+(?:B[0-9]+)?(?:FN(?:UZ|U)?)?"
+                r"|(?:[us]?i[0-9]+))",
                 Keyword.Type,
             ),
             # also allow nested container-like types to be recognized

--- a/mlir/utils/pygments/test_mlir_lexer.py
+++ b/mlir/utils/pygments/test_mlir_lexer.py
@@ -1,0 +1,45 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for mlir_lexer.py. Run with `python -m unittest` from this directory.
+
+Requires Pygments (`pip install Pygments`), as the lexer itself does.
+"""
+
+import unittest
+
+from mlir_lexer import MlirLexer
+from pygments.token import Error, Keyword, Name
+
+# Every builtin float type keyword, per mlir/include/mlir/IR/BuiltinTypes.td.
+FLOAT_TYPES = "bf16 f16 f32 f64 f80 f128 tf32 f8E3M4 f8E4M3 f8E4M3B11FNUZ \
+f8E4M3FN f8E4M3FNUZ f8E5M2 f8E5M2FNUZ f8E8M0FNU f6E2M3FN f6E3M2FN f4E2M1FN".split()
+
+
+def lex(source):
+    """Lex source, dropping whitespace-only tokens."""
+    return [(t, v) for t, v in MlirLexer().get_tokens(source) if v.strip()]
+
+
+class TestMlirLexer(unittest.TestCase):
+    def test_indented_operation_names(self):
+        """Whitespace rules must not consume the indent the op-name rules anchor on."""
+        got = lex("func.func @f() {\n  %0 = arith.constant 1 : i32\n  return\n}\n")
+        self.assertEqual(
+            [v for t, v in got if t is Name.Builtin],
+            ["func.func", "arith.constant", "return"],
+        )
+
+    def test_builtin_float_types(self):
+        """Each float type is one token, bare and as a tensor element type."""
+        for name in FLOAT_TYPES:
+            for source in ("%%0 = a.b %%c : %s\n", "%%0 = a.b %%c : tensor<4x8x%s>\n"):
+                with self.subTest(type=name, source=source):
+                    got = lex(source % name)
+                    self.assertIn((Keyword.Type, name), got)
+                    self.assertEqual([v for t, v in got if t is Error], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two fixes to the MLIR Pygments lexer, plus a small test.

#### Operation names lose their highlighting when indented

The `\s+` rule in the `root` state, added in #206194 to stop Pygments warning about unmatched whitespace, but it sits before the `^(\s*)(name)` rules that give operation names `Name.Builtin`. 

It consumes the indent, so those anchored rules can no longer match.

This moves the rule after the two operation-name rules and splits it at the newline. 

#### The low-precision builtin float types lex as `Error`

The builtin-type rule covers `bf16` through `f128`, so the eleven low-precision floats in `BuiltinTypes.td` (e.g., the float8 family, the OCP MX types) error.

#### Test

`mlir/utils/pygments/test_mlir_lexer.py`, runnable as `python -m unittest` from that directory. 

It fails 25 times against the current lexer and passes with this change.

It is deliberately **not** wired into `check-mlir` (and thus not CI): nothing under `mlir/utils` is.

It could be, but for now it's manual