### PR TITLE
[flang][OpenACC] Release declare-create allocatable on deallocate

### DIFF
--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -258,6 +258,9 @@ static void createDeclareAllocFuncWithArg(mlir::OpBuilder &modBuilder,
   builder.restoreInsertionPoint(crtInsPt);
 }
 
+/// Actions on deallocation are split in two functions: the pre one releases
+/// the data before the host side deallocation, the post one then releases the
+/// descriptor, which is still valid storage at that point.
 template <typename ExitOp>
 static void createDeclareDeallocFuncWithArg(
     mlir::OpBuilder &modBuilder, fir::FirOpBuilder &builder, mlir::Location loc,
@@ -4077,10 +4080,10 @@ static void createDeclareAllocFunc(mlir::OpBuilder &modBuilder,
   modBuilder.setInsertionPointAfter(registerFuncOp);
 }
 
-/// Action to be performed on deallocation are split in two distinct functions.
-/// - Pre deallocation function includes all the action to be performed before
-///   the actual deallocation is done on the host side.
-/// - Post deallocation function includes update to the descriptor.
+/// Generate the pre deallocation function, holding the actions to be performed
+/// before the host side deallocation. No post deallocation function is
+/// generated: a module variable's descriptor is released by the global
+/// destructor, not per deallocation.
 template <typename ExitOp>
 static void createDeclareDeallocFunc(mlir::OpBuilder &modBuilder,
                                      fir::FirOpBuilder &builder,

--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -4090,26 +4090,26 @@ static void createDeclareDeallocFunc(mlir::OpBuilder &modBuilder,
   std::stringstream asFortran;
   asFortran << Fortran::lower::mangle::demangleName(globalOp.getSymName());
 
-  std::stringstream postDeallocFuncName;
-  postDeallocFuncName << globalOp.getSymName().str()
-                      << Fortran::lower::declarePostDeallocSuffix.str();
-  auto postDeallocOp =
-      createDeclareFunc(modBuilder, builder, loc, postDeallocFuncName.str(),
+  // No post-dealloc recipe: it would run after the host storage is freed,
+  // when the descriptor no longer holds the address the mapping is keyed on.
+  std::stringstream preDeallocFuncName;
+  preDeallocFuncName << globalOp.getSymName().str()
+                     << Fortran::lower::declarePreDeallocSuffix.str();
+  auto preDeallocOp =
+      createDeclareFunc(modBuilder, builder, loc, preDeallocFuncName.str(),
                         /*argsTy=*/{}, /*locs=*/{}, /*linkable=*/true);
-
   fir::AddrOfOp addrOp = fir::AddrOfOp::create(
       builder, loc, fir::ReferenceType::get(globalOp.getType()),
       globalOp.getSymbol());
   llvm::SmallVector<mlir::Value> bounds;
-  // End the structured declare region using declare_exit.
   mlir::acc::GetDevicePtrOp descEntryOp =
       createDataEntryOp<mlir::acc::GetDevicePtrOp>(
           builder, loc, addrOp, asFortran, bounds,
-          /*structured=*/false, /*implicit=*/true, clause, addrOp.getType(),
+          /*structured=*/false, /*implicit=*/false, clause, addrOp.getType(),
           /*async=*/{}, /*asyncDeviceTypes=*/{}, /*asyncOnlyDeviceTypes=*/{});
   mlir::acc::DeclareExitOp::create(builder, loc, mlir::Value{},
                                    mlir::ValueRange(descEntryOp.getAccVar()));
-  modBuilder.setInsertionPointAfter(postDeallocOp);
+  modBuilder.setInsertionPointAfter(preDeallocOp);
 }
 
 static std::optional<Fortran::semantics::Symbol::Flag>
@@ -5252,7 +5252,7 @@ void Fortran::lower::declareExternalAccModuleDeclareActionRecipes(
   if (ultimate.test(Flag::AccCreate) || ultimate.test(Flag::AccCopyIn) ||
       ultimate.test(Flag::AccCopyInReadOnly) || ultimate.test(Flag::AccCopy) ||
       ultimate.test(Flag::AccCopyOut) || ultimate.test(Flag::AccDeviceResident))
-    declareExternalRecipe(declarePostDeallocSuffix);
+    declareExternalRecipe(declarePreDeallocSuffix);
 }
 
 void Fortran::lower::attachDeclarePostAllocAction(
@@ -5332,6 +5332,12 @@ void Fortran::lower::attachDeclarePostDeallocAction(
     AbstractConverter &converter, fir::FirOpBuilder &builder,
     const Fortran::semantics::Symbol &sym) {
   if (isUnifiedMemoryMode(converter))
+    return;
+
+  // A module variable has no post-dealloc recipe: it would run once the
+  // descriptor no longer holds the address the mapping is keyed on.
+  if (sym.GetUltimate().owner().kind() ==
+      Fortran::semantics::Scope::Kind::Module)
     return;
 
   if (!sym.test(Fortran::semantics::Symbol::Flag::AccCreate) &&

--- a/flang/test/Lower/OpenACC/acc-declare-allocatable-deallocate.f90
+++ b/flang/test/Lower/OpenACC/acc-declare-allocatable-deallocate.f90
@@ -1,0 +1,33 @@
+! Test !$acc declare create on a module allocatable: the device copy's
+! lifetime follows the host allocation, so it must be released before that
+! allocation is freed.
+
+! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
+! RUN: bbc -fopenacc -emit-hlfir %s -o - | fir-opt --acc-declare-action-conversion -o - | FileCheck %s --check-prefix=CONV
+
+module acc_declare_dealloc_mod
+  integer, allocatable :: data(:)
+  !$acc declare create(data)
+contains
+  subroutine free_data()
+    deallocate(data)
+  end subroutine
+end module
+
+! The deallocation site must reference the pre-dealloc recipe.
+! CHECK-LABEL: func.func @_QMacc_declare_dealloc_modPfree_data()
+! CHECK:         fir.box_addr
+! CHECK-SAME:      acc.declare_action<preDealloc = @_QMacc_declare_dealloc_modEdata_acc_declare_pre_dealloc>
+
+! No post-dealloc recipe is emitted: it would run after the host storage is
+! freed, when the descriptor no longer holds the address the mapping uses.
+! CHECK-NOT: _acc_declare_post_dealloc
+
+! The release happens here, before the host deallocation.
+! CHECK-LABEL: func.func @_QMacc_declare_dealloc_modEdata_acc_declare_pre_dealloc() attributes {acc.declare_action} {
+! CHECK:         %[[ADDR:.*]] = fir.address_of(@_QMacc_declare_dealloc_modEdata)
+! CHECK:         %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[ADDR]]
+! CHECK:         acc.declare_exit dataOperands(%[[DEVPTR]]
+
+! CONV-LABEL: func.func @_QMacc_declare_dealloc_modPfree_data()
+! CONV:         fir.call @_QMacc_declare_dealloc_modEdata_acc_declare_pre_dealloc()

--- a/flang/test/Lower/OpenACC/acc-declare-unified.f90
+++ b/flang/test/Lower/OpenACC/acc-declare-unified.f90
@@ -63,15 +63,12 @@ end subroutine
 
 ! DISCRETE-MOD: acc.declare_action = #acc.declare_action<postAlloc = @_QMacc_declare_unified_modEgarr_acc_declare_post_alloc>
 ! DISCRETE-MOD: acc.declare_action = #acc.declare_action<preDealloc = @_QMacc_declare_unified_modEgarr_acc_declare_pre_dealloc>
-! DISCRETE-MOD: acc.declare_action = #acc.declare_action<postDealloc = @_QMacc_declare_unified_modEgarr_acc_declare_post_dealloc>
 ! DISCRETE-MOD: func.func private @_QMacc_declare_unified_modFalloc_localElarr_acc_declare_post_alloc(
 ! DISCRETE-MOD: func.func private @_QMacc_declare_unified_modFalloc_localElarr_acc_declare_pre_dealloc(
 ! DISCRETE-MOD: func.func private @_QMacc_declare_unified_modFalloc_localElarr_acc_declare_post_dealloc(
 ! DISCRETE-MOD: acc.global_ctor @_QMacc_declare_unified_modEgarr_acc_ctor
 ! DISCRETE-MOD: func.func @_QMacc_declare_unified_modEgarr_acc_declare_post_alloc() attributes {acc.declare_action}
-! DISCRETE-MOD: func.func @_QMacc_declare_unified_modEgarr_acc_declare_post_dealloc() attributes {acc.declare_action}
 ! DISCRETE-MOD: acc.global_dtor @_QMacc_declare_unified_modEgarr_acc_dtor
 
 ! DISCRETE-USE: acc.declare_action = #acc.declare_action<postAlloc = @_QMacc_declare_unified_modEgarr_acc_declare_post_alloc>
 ! DISCRETE-USE: func.func private @_QMacc_declare_unified_modEgarr_acc_declare_post_alloc()
-! DISCRETE-USE: func.func private @_QMacc_declare_unified_modEgarr_acc_declare_post_dealloc()

--- a/flang/test/Lower/OpenACC/acc-declare-use-associated-allocatable.f90
+++ b/flang/test/Lower/OpenACC/acc-declare-use-associated-allocatable.f90
@@ -21,17 +21,19 @@ subroutine use_mod()
   use acc_declare_alloc_mod
   implicit none
   allocate(data(100))
+  deallocate(data)
 end subroutine
 
 ! MOD: func.func @_QMacc_declare_alloc_modEdata_acc_declare_post_alloc() attributes {acc.declare_action} {
 ! MOD: acc.declare_enter
-! MOD: func.func @_QMacc_declare_alloc_modEdata_acc_declare_post_dealloc() attributes {acc.declare_action} {
 
 ! USE: func.func @_QPuse_mod() {
 ! USE: acc.declare_action = #acc.declare_action<postAlloc = @_QMacc_declare_alloc_modEdata_acc_declare_post_alloc>
 ! USE: fir.global @_QMacc_declare_alloc_modEdata {acc.declare = #acc.declare<dataClause = acc_create>
 ! USE: func.func private @_QMacc_declare_alloc_modEdata_acc_declare_post_alloc()
-! USE: func.func private @_QMacc_declare_alloc_modEdata_acc_declare_post_dealloc()
+! USE: func.func private @_QMacc_declare_alloc_modEdata_acc_declare_pre_dealloc()
 ! USE-NOT: acc.declare_enter
 
 ! CONV: fir.call @_QMacc_declare_alloc_modEdata_acc_declare_post_alloc()
+! The release must survive separate compilation.
+! CONV: fir.call @_QMacc_declare_alloc_modEdata_acc_declare_pre_dealloc()

--- a/flang/test/Lower/OpenACC/acc-declare.f90
+++ b/flang/test/Lower/OpenACC/acc-declare.f90
@@ -335,7 +335,6 @@ end module
 
 ! CHECK: fir.store %{{.*}} to %{{.*}} {acc.declare_action = #acc.declare_action<postAlloc = @_QMacc_declare_allocatable_testEdata1_acc_declare_post_alloc>} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK: %{{.*}} = fir.box_addr %{{.*}} {acc.declare_action = #acc.declare_action<preDealloc = @_QMacc_declare_allocatable_testEdata1_acc_declare_pre_dealloc>} : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-! CHECK: fir.store %{{.*}} to %{{.*}} {acc.declare_action = #acc.declare_action<postDealloc = @_QMacc_declare_allocatable_testEdata1_acc_declare_post_dealloc>} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
  
 module acc_declare_allocatable_test
  integer, allocatable :: data1(:)
@@ -408,7 +407,7 @@ end module
 ! CHECK: fir.call @_FortranAAllocatableAllocate({{.*}}) fastmath<contract> {acc.declare_action = #acc.declare_action<postAlloc = @_QMacc_declare_post_action_statEy_acc_declare_post_alloc>} : (!fir.ref<!fir.box<none>>, !fir.ref<i64>, i1, !fir.box<none>, !fir.ref<i8>, i32, {{.*}}) -> i32
 ! CHECK-LABEL: func.func @_QMacc_declare_post_action_statPinit_in_data(
 ! CHECK: fir.call @_FortranAAllocatableAllocate({{.*}}) fastmath<contract> {acc.declare_action = #acc.declare_action<postAlloc = @_QMacc_declare_post_action_statEx_acc_declare_post_alloc>}
-! CHECK: fir.call @_FortranAAllocatableDeallocate({{.*}}) fastmath<contract> {acc.declare_action = #acc.declare_action<preDealloc = @_QMacc_declare_post_action_statEx_acc_declare_pre_dealloc, postDealloc = @_QMacc_declare_post_action_statEx_acc_declare_post_dealloc>}
+! CHECK: fir.call @_FortranAAllocatableDeallocate({{.*}}) fastmath<contract> {acc.declare_action = #acc.declare_action<preDealloc = @_QMacc_declare_post_action_statEx_acc_declare_pre_dealloc>}
 ! CHECK-NOT: acc.terminator {acc.declare_action =
 
 ! CHECK-LABEL: acc.global_ctor @_QMacc_declare_allocatable_testEdata1_acc_ctor {
@@ -425,9 +424,12 @@ end module
 ! CHECK:         return
 ! CHECK:       }
 
-! CHECK-LABEL: func.func @_QMacc_declare_allocatable_testEdata1_acc_declare_post_dealloc() attributes {acc.declare_action} {
+! No post-dealloc recipe: it would run after the host storage is freed, when
+! the descriptor no longer holds the address the mapping uses.
+
+! CHECK-LABEL: func.func @_QMacc_declare_allocatable_testEdata1_acc_declare_pre_dealloc() attributes {acc.declare_action} {
 ! CHECK:         %[[GLOBAL_ADDR:.*]] = fir.address_of(@_QMacc_declare_allocatable_testEdata1) : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:         %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[GLOBAL_ADDR]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) dataClause(acc_create) structured(false) implicit(true) name("data1") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:         %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[GLOBAL_ADDR]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) dataClause(acc_create) structured(false) name("data1") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:         acc.declare_exit dataOperands(%[[DEVPTR]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
 ! CHECK:         return
 ! CHECK:       }


### PR DESCRIPTION
Example:
```fortran
module m
  real(8), allocatable, save :: a(:)
  !$acc declare create(a)
end module

program p
  use m
  do i = 1, 3
     allocate(a(n))
     !$acc update device(a)
     deallocate(a)     ! device buffer is never released: 8*n
  end do               ! bytes leak on every iteration
end program
```

For a declare-create allocatable the device copy's lifetime follows the
host allocation, so it has to be released before that allocation is
freed. Lowering wraps each Fortran DEALLOCATE in two hooks, differing
only in when they run:
```
  call a_acc_declare_pre_dealloc()    ! host storage still allocated
  <host deallocate>                   ! storage freed
  call a_acc_declare_post_dealloc()   ! host storage already gone
```

Both hooks take the same `fir.address_of(@_QMmEa)`, the address of the
descriptor, so at first glance either could do the release. But the
mapping is keyed on the *data* address held inside that descriptor, not
on the descriptor itself. The descriptor's address is a fixed global and
identical in both hooks; its contents are not, because the deallocation
clears the base address. The pre hook therefore reads a live data
address that resolves to the mapping, while the post hook reads a
cleared one that resolves to nothing.

The hooks are attached accordingly, the pre one where the data address
is read while still valid, the post one where the emptied descriptor is
stored back:
```mlir
  %4 = fir.box_addr %3 {acc.declare_action = <preDealloc = ...>}
       fir.store %7 to %2#0 {acc.declare_action = <postDealloc = ...>}
```

For a module allocatable no pre hook was emitted at all and the release
was left to the post hook, which runs too late to resolve anything, so
every allocate/deallocate cycle leaks a device buffer.

Before, with no pre hook emitted:
```mlir
func.func @_QMmEa_acc_declare_post_dealloc()
    attributes {acc.declare_action} {
  %0 = fir.address_of(@_QMmEa) : !fir.ref<!fir.box<...>>
  %1 = acc.getdeviceptr varPtr(%0 : ...) dataClause(acc_create)
         structured(false) implicit(true) name("a") -> ...
  acc.declare_exit dataOperands(%1 : ...)
  return
}
```

After, the release moves to the pre hook and the post hook is gone:
```mlir
func.func @_QMmEa_acc_declare_pre_dealloc()
    attributes {acc.declare_action} {
  %0 = fir.address_of(@_QMmEa) : !fir.ref<!fir.box<...>>
  %1 = acc.getdeviceptr varPtr(%0 : ...) dataClause(acc_create)
         structured(false) name("a") -> ...
  acc.declare_exit dataOperands(%1 : ...)
  return
}
```

This keeps one decrement against the one post-alloc increment. Device
address per iteration of the case above:

| | iter 1 | iter 2 | iter 3 |
|---|---|---|---|
| before | `0x..2fa000` | `0x..302000` | `0x..30a000` |
| after | `0x..2fa000` | `0x..2fa000` | `0x..2fa000` |

A module variable now gets neither a post-dealloc recipe nor a
post-dealloc action, since it could do nothing at the point it runs.
Local variables keep theirs, including a local declared inside a module
subprogram. A using unit declares the pre-dealloc recipe, otherwise the
action attached there names a symbol that does not resolve and the
release is silently dropped for separate compilation.

`acc-declare.f90`, `acc-declare-unified.f90` and
`acc-declare-use-associated-allocatable.f90` asserted the post-dealloc
recipe and action for module variables; those expectations are removed.