### PR TITLE
[libc] Stop printing \0 in stdio/fputc_test.cpp

### DIFF
--- a/libc/test/src/stdio/fputc_test.cpp
+++ b/libc/test/src/stdio/fputc_test.cpp
@@ -18,14 +18,18 @@ TEST(LlvmLibcPutcTest, PrintOut) {
 
   constexpr char simple[] = "A simple string written to stdout\n";
   for (const char &c : simple) {
+    if (!c)
+      break;
     result = LIBC_NAMESPACE::putchar(c);
     EXPECT_GE(result, 0);
   }
 
   constexpr char more[] = "A simple string written to stderr\n";
   for (const char &c : more) {
+    if (!c)
+      break;
     result = LIBC_NAMESPACE::fputc(
         c, reinterpret_cast<FILE *>(LIBC_NAMESPACE::stderr));
+    EXPECT_GE(result, 0);
   }
-  EXPECT_GE(result, 0);
 }


### PR DESCRIPTION
This test defines two strings in the form of constant char[] arrays, and then loops over the characters of each one using a range-for. This iteration includes the implicit terminating \0, which is printed to the output channels along with everything else. This is mildly inconvenient because the presence of a \0 in a log file causes standard tools like `grep` and `less` to default to treating it as binary.

Now each loop breaks before printing the NUL, so the characters sent to the output streams are exactly the same as in fputs_test.cpp.

Also, while I was here, I moved the check of fputc's return value into the loop, so that it's checked on every iteration instead of just the final one, matching the other loop checking putchar. (Surely this was intended all along; there was no comment explaining the difference.)