### PR TITLE
[GlobalsAA] Fix handling of optnone functions

### DIFF
--- a/llvm/lib/Analysis/GlobalsModRef.cpp
+++ b/llvm/lib/Analysis/GlobalsModRef.cpp
@@ -498,9 +498,9 @@ void GlobalsAAResult::AnalyzeCallGraph(CallGraph &CG, Module &M) {
     const std::vector<CallGraphNode *> &SCC = *I;
     assert(!SCC.empty() && "SCC with no functions?");
 
-    Function *F = SCC[0]->getFunction();
+    Function *FirstF = SCC[0]->getFunction();
 
-    if (!F || !F->isDefinitionExact()) {
+    if (!FirstF || !FirstF->isDefinitionExact()) {
       // Calls externally or not exact - can't say anything useful. Remove any
       // existing function records (may have been created when scanning
       // globals).
@@ -509,8 +509,8 @@ void GlobalsAAResult::AnalyzeCallGraph(CallGraph &CG, Module &M) {
       continue;
     }
 
-    FunctionInfo &FI = FunctionInfos[F];
-    Handles.emplace_front(*this, F);
+    FunctionInfo &FI = FunctionInfos[FirstF];
+    Handles.emplace_front(*this, FirstF);
     Handles.front().I = Handles.begin();
     bool KnowNothing = false;
 
@@ -529,6 +529,7 @@ void GlobalsAAResult::AnalyzeCallGraph(CallGraph &CG, Module &M) {
     // Collect the mod/ref properties due to called functions.  We only compute
     // one mod-ref set.
     for (unsigned i = 0, e = SCC.size(); i != e && !KnowNothing; ++i) {
+      Function *F = SCC[i]->getFunction();
       if (!F) {
         KnowNothing = true;
         break;

--- a/llvm/test/Analysis/GlobalsModRef/optnone-scc.ll
+++ b/llvm/test/Analysis/GlobalsModRef/optnone-scc.ll
@@ -27,7 +27,7 @@ define internal void @B() noinline {
 }
 
 ; CHECK-LABEL: Function: main
-; CHECK: NoModRef:  Ptr: i32* @g	<->  call void @A()
+; CHECK: Both ModRef:  Ptr: i32* @g	<->  call void @A()
 define i32 @main() {
   store i32 1, ptr @g
   call void @A()

--- a/llvm/test/Analysis/GlobalsModRef/optnone-scc.ll
+++ b/llvm/test/Analysis/GlobalsModRef/optnone-scc.ll
@@ -1,0 +1,36 @@
+; RUN: opt < %s -passes='require<globals-aa>,aa-eval' -print-all-alias-modref-info -disable-output 2>&1 | FileCheck %s
+
+; Make sure memory effects of optnone functions in an SCC are correctly
+; handled.
+
+@g = internal global i32 0
+@ctl = global i32 0
+
+define internal void @A() noinline optnone {
+entry:
+  store i32 42, ptr @g
+  %c = load i32, ptr @ctl
+  %t = icmp ne i32 %c, 0
+  br i1 %t, label %rec, label %done
+
+rec:
+  call void @B()
+  br label %done
+
+done:
+  ret void
+}
+
+define internal void @B() noinline {
+  call void @A()
+  ret void
+}
+
+; CHECK-LABEL: Function: main
+; CHECK: NoModRef:  Ptr: i32* @g	<->  call void @A()
+define i32 @main() {
+  store i32 1, ptr @g
+  call void @A()
+  %v = load i32, ptr @g
+  ret i32 %v
+}


### PR DESCRIPTION
For optnone functions, we want to fall back to the memory effects implied by attributes. However, the code that did this repeatedly checked only the first function in the SCC, instead of all functions.

Disclaimer: Test case is AI generated, rest is my own.