### PR TITLE
[clang-tidy] Fix false positive in readability-trailing-comma

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/TrailingCommaCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/TrailingCommaCheck.cpp
@@ -122,9 +122,11 @@ void TrailingCommaCheck::checkEnumDecl(const EnumDecl *Enum,
 void TrailingCommaCheck::checkInitListExpr(
     const InitListExpr *InitList, const MatchFinder::MatchResult &Result) {
   // We need to use non-empty syntactic form for correct source locations.
-  if (const InitListExpr *SynInitInitList = InitList->getSyntacticForm();
-      SynInitInitList && SynInitInitList->getNumInits() > 0)
+  if (const InitListExpr *SynInitInitList = InitList->getSyntacticForm()) {
+    if (SynInitInitList->getNumInits() == 0)
+      return;
     InitList = SynInitInitList;
+  }
 
   const bool IsSingleLine = isSingleLine(
       {InitList->getBeginLoc(), InitList->getEndLoc()}, *Result.SourceManager);

--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -218,10 +218,14 @@ infrastructure are described first, followed by tool-specific sections.
   option to allow customizing the set of ignored types.
 
 - Improved {doc}`readability-trailing-comma
-  <clang-tidy/checks/readability/trailing-comma>` check by fixing false
-  positives on designated initializers, where initializer lists synthesized
-  for intermediate subobjects caused the trailing comma of the enclosing
-  list to be incorrectly rewritten.
+  <clang-tidy/checks/readability/trailing-comma>` check:
+
+  - Fixed false positives on designated initializers, where initializer lists
+    synthesized for intermediate subobjects caused the trailing comma of the
+    enclosing list to be incorrectly rewritten.
+
+  - Fixed a false positive on empty brace initializers of types with default
+    member initializers.
 
 - Improved {doc}`readability-use-std-min-max
   <clang-tidy/checks/readability/use-std-min-max>` check by fixing spurious

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/trailing-comma-cxx11.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/trailing-comma-cxx11.cpp
@@ -54,3 +54,13 @@ struct PackSingle {
 
 PackSingle<int> p1;
 PackSingle<int, double, char> p3;
+
+struct WithDefault { int foo = 1; };
+void takesTwo(WithDefault, int);
+
+void emptyInitListWithDefaultMember() {
+  takesTwo(WithDefault{}, 1);
+  int a[] = {1,};
+  // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: initializer list should not have a trailing comma
+  // CHECK-FIXES: int a[] = {1};
+}


### PR DESCRIPTION
Use the syntactic form of an empty InitListExpr instead of falling back to the semantic form.

Fixes #220222