### PR TITLE
[CMake] Add an uninstall target

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1584,6 +1584,18 @@ llvm_distribution_add_targets()
 process_llvm_pass_plugins(GEN_CONFIG)
 include(CoverageReport)
 
+# Guarded so that this doesn't collide with an "uninstall" target some other
+# project already defines, in builds that embed LLVM as a subdirectory.
+if(NOT TARGET uninstall)
+  configure_file(
+    "${LLVM_CMAKE_DIR}/cmake_uninstall.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+    @ONLY)
+  add_custom_target(uninstall
+    COMMAND "${CMAKE_COMMAND}" -P
+            "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
+endif()
+
 # This allows us to deploy the Universal CRT DLLs by passing -DCMAKE_INSTALL_UCRT_LIBRARIES=ON to CMake
 if (MSVC AND CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows" AND CMAKE_INSTALL_UCRT_LIBRARIES)
   include(InstallRequiredSystemLibraries)

--- a/llvm/cmake/modules/cmake_uninstall.cmake.in
+++ b/llvm/cmake/modules/cmake_uninstall.cmake.in
@@ -1,0 +1,20 @@
+if(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR
+    "Cannot find install manifest: "
+    "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+endif()
+
+file(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  set(full_path "$ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "${full_path}" OR EXISTS "${full_path}")
+    message(STATUS "Uninstalling ${full_path}")
+    file(REMOVE "${full_path}")
+    if(IS_SYMLINK "${full_path}" OR EXISTS "${full_path}")
+      message(FATAL_ERROR "Problem when removing ${full_path}")
+    endif()
+  else()
+    message(STATUS "File ${full_path} does not exist.")
+  endif()
+endforeach()

--- a/llvm/docs/CMake.md
+++ b/llvm/docs/CMake.md
@@ -1092,6 +1092,22 @@ things to go wrong. They are also unstable across LLVM versions.
     *CMAKE_INSTALL_PREFIX*. Only matters if *LLVM_INSTALL_UTILS* is enabled.
     Defaults to *LLVM_TOOLS_INSTALL_DIR*.
 
+## Uninstalling
+
+Once you have installed LLVM (e.g. via `ninja install`), you can remove the
+installed files again with the `uninstall` target:
+
+``` console
+$ ninja uninstall
+```
+
+This works by replaying `install_manifest.txt` (written into the build
+directory by CMake as part of `install`) and removing each file it lists, so
+it only ever removes files that were actually installed -- it won't touch
+anything you created by hand in the install prefix. It also means it can
+only be run from the same build directory `install` was run from, and only
+after at least one successful `install`.
+
 ## CMake Caches
 
 Recently, LLVM and Clang have been adding some more complicated build system


### PR DESCRIPTION
Adds the standard CMake-wiki uninstall recipe: a configured cmake_uninstall.cmake script that replays install_manifest.txt and removes each listed file, wired up as a ninja/make "uninstall" target in the top-level CMakeLists.txt. Guarded with `if(NOT TARGET uninstall)` so it doesn't collide with a target of the same name in builds that embed LLVM as a subdirectory of another project.

Verified with a real install/uninstall cycle against a scratch prefix: files installed via `install()` are correctly removed by `uninstall`, and running `uninstall` a second time (nothing left to remove) is a clean no-op rather than an error.

Fixes https://github.com/llvm/llvm-project/issues/5387.

Assisted-by: Claude Sonnet 5