### PR TITLE
[flang] Fix link error in shared library builds

### DIFF
--- a/flang/include/flang/Frontend/CompilerInstance.h
+++ b/flang/include/flang/Frontend/CompilerInstance.h
@@ -111,8 +111,8 @@ class CompilerInstance {
   /// @}
 
 public:
-  explicit CompilerInstance(std::shared_ptr<CompilerInvocation> invocation =
-                                std::make_shared<CompilerInvocation>());
+  CompilerInstance();
+  explicit CompilerInstance(std::shared_ptr<CompilerInvocation> invocation);
 
   ~CompilerInstance();
 

--- a/flang/lib/Frontend/CompilerInstance.cpp
+++ b/flang/lib/Frontend/CompilerInstance.cpp
@@ -33,6 +33,9 @@
 
 using namespace Fortran::frontend;
 
+CompilerInstance::CompilerInstance()
+    : CompilerInstance(std::make_shared<CompilerInvocation>()) {}
+
 CompilerInstance::CompilerInstance(
     std::shared_ptr<CompilerInvocation> invocation)
     : invocation(std::move(invocation)),


### PR DESCRIPTION
Since #218917 / 813bdb184af716091bb927070063a3e065124d33.

Errors of the form:
/usr/bin/ld: <...>/build/./lib/libFortranLower.so.24.0git: error adding symbols: DSO missing from command line

My changes to the constructor changed dependencies. I could either add a dependency on that library,
or refactor it a bit to avoid it.

I don't know if linking that library is a good idea, so I'm going the latter.