### PR TITLE
[llvm] Initialize function_ref callable state

### DIFF
--- a/llvm/include/llvm/ADT/STLFunctionalExtras.h
+++ b/llvm/include/llvm/ADT/STLFunctionalExtras.h
@@ -39,7 +39,7 @@ template<typename Fn> class function_ref;
 template <typename Ret, typename... Params>
 class LLVM_GSL_POINTER function_ref<Ret(Params...)> {
   Ret (*callback)(intptr_t callable, Params ...params) = nullptr;
-  intptr_t callable;
+  intptr_t callable = 0;
 
   template<typename Callable>
   static Ret callback_fn(intptr_t callable, Params ...params) {

--- a/llvm/unittests/ADT/FunctionRefTest.cpp
+++ b/llvm/unittests/ADT/FunctionRefTest.cpp
@@ -27,6 +27,22 @@ TEST(FunctionRefTest, Null) {
   EXPECT_FALSE(F);
 }
 
+TEST(FunctionRefTest, EmptyCopyAndEquality) {
+  function_ref<int()> Empty;
+  function_ref<int()> Null = nullptr;
+  EXPECT_EQ(Empty, Null);
+
+  function_ref<int()> Copy = Empty;
+  EXPECT_FALSE(Copy);
+  EXPECT_EQ(Empty, Copy);
+
+  auto L = [] { return 1; };
+  function_ref<int()> Assigned = L;
+  Assigned = Empty;
+  EXPECT_FALSE(Assigned);
+  EXPECT_EQ(Empty, Assigned);
+}
+
 // Ensure that copies of a function_ref copy the underlying state rather than
 // causing one function_ref to chain to the next.
 TEST(FunctionRefTest, Copy) {


### PR DESCRIPTION
An empty function_ref leaves its callable member uninitialized. Implicit copy operations propagate that value and operator== reads it when empty references are compared.

Without the initialization, Valgrind reports the new regression test as:

  Conditional jump or move depends on uninitialised value(s)
  ERROR SUMMARY: 79 errors from 7 contexts

Initialize callable to zero and cover empty construction, copying, assignment, and equality. The same Valgrind run then reports zero errors.

Assisted-by: Codex