### PR TITLE
[ORC] Hoist OrcRTBootstrap.h to fix layering violation

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/OrcRTBootstrap.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/OrcRTBootstrap.h
@@ -6,26 +6,21 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// OrcRTPrelinkImpl provides functions that should be linked into the executor
+// OrcRTBootstrap provides functions that should be linked into the executor
 // to bootstrap common JIT functionality (e.g. memory allocation and memory
 // access).
 //
-// Call rt_impl::addTo to add these functions to a bootstrap symbols map.
-//
-// FIXME: The functionality in this file should probably be moved to an ORC
-// runtime bootstrap library in compiler-rt.
+// Call addTo to add these functions to a bootstrap symbols map.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LIB_EXECUTIONENGINE_ORC_TARGETPROCESS_ORCRTBOOTSTRAP_H
-#define LIB_EXECUTIONENGINE_ORC_TARGETPROCESS_ORCRTBOOTSTRAP_H
+#ifndef LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_ORCRTBOOTSTRAP_H
+#define LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_ORCRTBOOTSTRAP_H
 
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 
-namespace llvm {
-namespace orc {
-namespace rt_bootstrap {
+namespace llvm::orc::rt_bootstrap {
 
 /// Adds executor-side wrappers for the run-as function proxies.
 void addRunAsFunctionWrappersTo(StringMap<ExecutorAddr> &M);
@@ -33,8 +28,6 @@ void addRunAsFunctionWrappersTo(StringMap<ExecutorAddr> &M);
 /// Adds all default target-process bootstrap wrappers.
 void addTo(StringMap<ExecutorAddr> &M);
 
-} // namespace rt_bootstrap
-} // end namespace orc
-} // end namespace llvm
+} // namespace llvm::orc::rt_bootstrap
 
-#endif // LIB_EXECUTIONENGINE_ORC_TARGETPROCESS_ORCRTBOOTSTRAP_H
+#endif // LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_ORCRTBOOTSTRAP_H

--- a/llvm/lib/ExecutionEngine/Orc/SelfExecutorProcessControl.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/SelfExecutorProcessControl.cpp
@@ -14,12 +14,11 @@
 #include "llvm/ExecutionEngine/Orc/InProcessMemoryAccess.h"
 #include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/DefaultHostBootstrapValues.h"
+#include "llvm/ExecutionEngine/Orc/TargetProcess/OrcRTBootstrap.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/TargetExecutionUtils.h"
 #include "llvm/Support/DynamicLibrary.h"
 #include "llvm/Support/Process.h"
 #include "llvm/TargetParser/Host.h"
-
-#include "TargetProcess/OrcRTBootstrap.h"
 
 #define DEBUG_TYPE "orc"
 

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/OrcRTBootstrap.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/OrcRTBootstrap.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "OrcRTBootstrap.h"
+#include "llvm/ExecutionEngine/Orc/TargetProcess/OrcRTBootstrap.h"
 
 #include "llvm/ExecutionEngine/Orc/Shared/SPSCI/CallSPSCI.h"
 #include "llvm/ExecutionEngine/Orc/Shared/SPSCI/MemoryAccessSPSCI.h"

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleRemoteEPCServer.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleRemoteEPCServer.cpp
@@ -14,7 +14,6 @@
 #include "llvm/Support/Process.h"
 #include "llvm/TargetParser/Host.h"
 
-
 #define DEBUG_TYPE "orc"
 
 using namespace llvm::orc::shared;

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleRemoteEPCServer.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleRemoteEPCServer.cpp
@@ -9,11 +9,11 @@
 #include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleRemoteEPCServer.h"
 
 #include "llvm/ExecutionEngine/Orc/TargetProcess/DefaultHostBootstrapValues.h"
+#include "llvm/ExecutionEngine/Orc/TargetProcess/OrcRTBootstrap.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/Process.h"
 #include "llvm/TargetParser/Host.h"
 
-#include "OrcRTBootstrap.h"
 
 #define DEBUG_TYPE "orc"
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/220224 updated SelfExecutorProcessControl to publish JIT bootstrap symbols for running functions after https://github.com/llvm/llvm-project/pull/213265 removed some ExecutorProcessControl runAs* methods. This violated layering rules as it left Orc depending on an internal header from OrcTargetProcess.

Hoist the OrcRTBootstrap.h header into the include directory to fix the layering violation.