### PR TITLE
[ADT] Allow SmallVector move construction without move assignment

### DIFF
--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -616,6 +616,22 @@ protected:
     RHS.resetToSmall();
   }
 
+  void moveConstructFrom(SmallVectorImpl &&RHS) {
+    assert(this->empty() && "move construction requires an empty vector");
+    if (!RHS.isSmall()) {
+      assignRemote(std::move(RHS));
+      return;
+    }
+
+    // Construct inline elements directly instead of requiring T to be move
+    // assignable through the general move-assignment implementation.
+    size_type RHSSize = RHS.size();
+    reserve(RHSSize);
+    this->uninitialized_move(RHS.begin(), RHS.end(), this->begin());
+    this->set_size(RHSSize);
+    RHS.clear();
+  }
+
   ~SmallVectorImpl() {
     // Subclass has already destructed this vector's elements.
     // If this wasn't grown from the inline copy, deallocate the old space.
@@ -1281,14 +1297,27 @@ public:
     return *this;
   }
 
+  // Reuse the move-assignment instantiation for trivially move-assignable
+  // elements. Calling moveConstructFrom unconditionally would emit an
+  // additional per-T wrapper at -O0, increasing object size.
+  // std::is_move_assignable_v<T> is too broad: it can be a false positive for
+  // types with an unconstrained assignment operator whose body is ill-formed.
   SmallVector(SmallVector &&RHS) : SmallVectorImpl<T>(N) {
-    if (!RHS.empty())
-      SmallVectorImpl<T>::operator=(::std::move(RHS));
+    if (!RHS.empty()) {
+      if constexpr (std::is_trivially_move_assignable_v<T>)
+        SmallVectorImpl<T>::operator=(::std::move(RHS));
+      else
+        this->moveConstructFrom(::std::move(RHS));
+    }
   }
 
   SmallVector(SmallVectorImpl<T> &&RHS) : SmallVectorImpl<T>(N) {
-    if (!RHS.empty())
-      SmallVectorImpl<T>::operator=(::std::move(RHS));
+    if (!RHS.empty()) {
+      if constexpr (std::is_trivially_move_assignable_v<T>)
+        SmallVectorImpl<T>::operator=(::std::move(RHS));
+      else
+        this->moveConstructFrom(::std::move(RHS));
+    }
   }
 
   SmallVector &operator=(SmallVector &&RHS) {

--- a/llvm/unittests/ADT/SmallVectorTest.cpp
+++ b/llvm/unittests/ADT/SmallVectorTest.cpp
@@ -167,6 +167,22 @@ private:
   NonCopyable &operator=(const NonCopyable &) = delete;
 };
 
+struct MoveConstructOnly {
+  explicit MoveConstructOnly(int Value) : Value(Value) {}
+  MoveConstructOnly(MoveConstructOnly &&RHS) : Value(RHS.Value) {
+    RHS.Value = -1;
+  }
+
+  MoveConstructOnly(const MoveConstructOnly &) = delete;
+  MoveConstructOnly &operator=(const MoveConstructOnly &) = delete;
+  MoveConstructOnly &operator=(MoveConstructOnly &&) = delete;
+
+  int Value;
+};
+
+static_assert(std::is_move_constructible_v<MoveConstructOnly>);
+static_assert(!std::is_move_assignable_v<MoveConstructOnly>);
+
 LLVM_ATTRIBUTE_USED void CompileTest() {
   SmallVector<NonCopyable, 0> V;
   V.resize(42);
@@ -175,6 +191,67 @@ LLVM_ATTRIBUTE_USED void CompileTest() {
 TEST(SmallVectorTest, ConstructNonCopyableTest) {
   SmallVector<NonCopyable, 0> V(42);
   EXPECT_EQ(V.size(), (size_t)42);
+}
+
+TEST(SmallVectorTest, MoveConstructNonMoveAssignableInlineElements) {
+  SmallVector<MoveConstructOnly, 2> From;
+  From.emplace_back(1);
+  From.emplace_back(2);
+  const MoveConstructOnly *FromData = From.data();
+
+  SmallVector<MoveConstructOnly, 2> To(std::move(From));
+
+  EXPECT_TRUE(From.empty());
+  ASSERT_EQ(2u, To.size());
+  EXPECT_NE(FromData, To.data());
+  EXPECT_EQ(1, To[0].Value);
+  EXPECT_EQ(2, To[1].Value);
+}
+
+TEST(SmallVectorTest, MoveConstructNonMoveAssignableAllocatedElements) {
+  SmallVector<MoveConstructOnly, 1> From;
+  From.emplace_back(1);
+  From.emplace_back(2);
+  const MoveConstructOnly *FromData = From.data();
+
+  SmallVector<MoveConstructOnly, 1> To(std::move(From));
+
+  EXPECT_TRUE(From.empty());
+  ASSERT_EQ(2u, To.size());
+  EXPECT_EQ(FromData, To.data());
+  EXPECT_EQ(1, To[0].Value);
+  EXPECT_EQ(2, To[1].Value);
+}
+
+TEST(SmallVectorTest, MoveConstructNonMoveAssignableFromSmallVectorImpl) {
+  SmallVector<MoveConstructOnly, 2> From;
+  From.emplace_back(1);
+  From.emplace_back(2);
+
+  SmallVector<MoveConstructOnly, 0> To(
+      std::move(static_cast<SmallVectorImpl<MoveConstructOnly> &>(From)));
+
+  EXPECT_TRUE(From.empty());
+  ASSERT_EQ(2u, To.size());
+  EXPECT_EQ(1, To[0].Value);
+  EXPECT_EQ(2, To[1].Value);
+}
+
+TEST(SmallVectorTest, MoveConstructNestedNonMoveAssignableElements) {
+  SmallVector<MoveConstructOnly, 2> Inner;
+  Inner.emplace_back(1);
+  Inner.emplace_back(2);
+
+  SmallVector<SmallVector<MoveConstructOnly, 2>, 1> From;
+  From.push_back(std::move(Inner));
+
+  SmallVector<SmallVector<MoveConstructOnly, 2>, 1> To(std::move(From));
+
+  EXPECT_TRUE(From.empty());
+  ASSERT_EQ(1u, To.size());
+  ASSERT_EQ(2u, To[0].size());
+  EXPECT_EQ(1, To[0][0].Value);
+  EXPECT_EQ(2, To[0][1].Value);
 }
 
 // Assert that v contains the specified values, in order.


### PR DESCRIPTION
Move-construct inline elements directly instead of using move assignment.

This avoids requiring element types to be move-assignable.

Reland #219934 

The first version routed inline move construction through append(move_iterator, move_iterator). For trivially copyable elements, the iterator adapters bypassed SmallVector's raw-pointer memcpy path and instantiated append, distance, uninitialized_copy, and iterator helpers for each element type. This duplicated move-assignment machinery when it was already instantiated in the same translation unit.

Use the old assignment path only for trivially move-assignable elements. For other elements, reserve storage and use raw-pointer uninitialized_move. This avoids generic iterator machinery and preserves the memcpy fast path.

Do not dispatch on `is_move_assignable_v<T>`. It can report true for an unconstrained assignment operator whose body is ill-formed. A nested `SmallVector<SmallVector<MoveConstructOnly>>` demonstrates that false positive, so cover it alongside inline, allocated, and `SmallVectorImpl` construction.

Assisted-by: Codex