### PR TITLE
[clang][Sema] Check conditional branches inside a comma operand

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -492,6 +492,11 @@ features cannot lower the translation-unit ABI level;
   `operator delete`, since such a delete expression never invokes the
   destructor. (#GH65524)
 
+- `-Wimplicit-int-enum-cast` no longer warns about a conditional operator used
+  as the right operand of a comma operator when each branch of the conditional
+  is already of the target enumeration type. The branches are now checked
+  individually, as they are outside of a comma operator. (#GH185400)
+
 ### Improvements to Clang's time-trace
 
 ### Improvements to Coverage Mapping

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -14050,6 +14050,16 @@ static void CheckCommaOperand(
     bool ExtraCheckForImplicitConversion,
     llvm::SmallVectorImpl<AnalyzeImplicitConversionsWorkItem> &WorkList) {
   E = E->IgnoreParenImpCasts();
+
+  // A conditional operand is fed into the context type branch by branch, the
+  // same way CheckConditionalOperand does, so that a conditional whose
+  // branches each convert cleanly is not reported through the type of the
+  // conditional as a whole. CheckConditionalOperator analyzes the
+  // subexpressions itself, so do not add this one to the work list.
+  if (ExtraCheckForImplicitConversion && E->getType() != T)
+    if (auto *CO = dyn_cast<AbstractConditionalOperator>(E))
+      return CheckConditionalOperator(S, CO, CC, T);
+
   WorkList.push_back({E, CC, false});
 
   if (ExtraCheckForImplicitConversion && E->getType() != T)

--- a/clang/test/Sema/implicit-int-enum-conversion.c
+++ b/clang/test/Sema/implicit-int-enum-conversion.c
@@ -72,3 +72,15 @@ enum E1 comma4(void) {
   return ((void)1, 2); // expected-warning {{implicit conversion from 'int' to enumeration type 'enum E1' is invalid in C++}} \
                           cxx-error {{cannot initialize return object of type 'enum E1' with an rvalue of type 'int'}}
 }
+
+// The branches of a conditional operand are each converted to the context
+// type, so a conditional between enumerators of the target type is fine in
+// C++ and must not be diagnosed here either.
+enum E1 comma5(int c) {
+  return ((void)0, c ? E1_One : E1_Zero);
+}
+
+enum E1 comma6(int c) {
+  return ((void)0, c ? E1_One : 2); // expected-warning {{implicit conversion from 'int' to enumeration type 'enum E1' is invalid in C++}} \
+                                       cxx-error {{cannot initialize return object of type 'enum E1' with an rvalue of type 'int'}}
+}

--- a/clang/test/Sema/implicit-int-enum-conversion.c
+++ b/clang/test/Sema/implicit-int-enum-conversion.c
@@ -77,8 +77,14 @@ enum E1 comma4(void) {
 // type, so a conditional between enumerators of the target type is fine in
 // C++ and must not be diagnosed here either.
 enum E1 comma5(int c) {
-  return ((void)0, c ? E1_One : E1_Zero);
+  return ((void)0, c ? E1_One : E1_Zero); // Okay, no conversion in C++
 }
+
+#ifdef __cplusplus
+// In C++ the enumerators already have the enumeration type, so the conditional
+// has type E1 and there is nothing to convert.
+static_assert(__is_same(decltype(true ? E1_One : E1_Zero), E1), "");
+#endif
 
 enum E1 comma6(int c) {
   return ((void)0, c ? E1_One : 2); // expected-warning {{implicit conversion from 'int' to enumeration type 'enum E1' is invalid in C++}} \

--- a/clang/test/Sema/implicit-int-enum-conversion.c
+++ b/clang/test/Sema/implicit-int-enum-conversion.c
@@ -80,12 +80,6 @@ enum E1 comma5(int c) {
   return ((void)0, c ? E1_One : E1_Zero); // Okay, no conversion in C++
 }
 
-#ifdef __cplusplus
-// In C++ the enumerators already have the enumeration type, so the conditional
-// has type E1 and there is nothing to convert.
-static_assert(__is_same(decltype(true ? E1_One : E1_Zero), E1), "");
-#endif
-
 enum E1 comma6(int c) {
   return ((void)0, c ? E1_One : 2); // expected-warning {{implicit conversion from 'int' to enumeration type 'enum E1' is invalid in C++}} \
                                        cxx-error {{cannot initialize return object of type 'enum E1' with an rvalue of type 'int'}}


### PR DESCRIPTION
In C, a conditional between two enumerators has type int, so returning
`(side(), c ? A : B)` from a function returning that enum made
`-Wimplicit-int-enum-cast` claim the code is invalid in C++, even though
compiling it as C++ accepts it. The comma path converted the whole
conditional to the context type, while `CheckConditionalOperand` already
checks conditionals branch by branch.

Give `CheckCommaOperand` the same behavior: recurse into a conditional
right operand so each branch is checked individually. A branch that
genuinely needs the conversion still warns.

Fixes #185400