### PR TITLE
[mlir][tosa] Add assembly format for CONST

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
+++ b/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
@@ -2598,6 +2598,10 @@ def Tosa_ConstOp : Tosa_Op<"const", [ConstantLike, Pure,
 
   let hasFolder = 1;
   let hasVerifier = 1;
+
+  let assemblyFormat =
+      "operands `values` `(` $values `)` attr-dict `:` "
+      "functional-type(operands, results)";
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/test/Conversion/TosaToSPIRVTosa/graph-constant-mark.mlir
+++ b/mlir/test/Conversion/TosaToSPIRVTosa/graph-constant-mark.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: func.func @large_const
 func.func @large_const() -> tensor<17xi32> {
-  // CHECK: "tosa.const"() <{values = {{.*}}> {grapharm.graph_constant_id = 0 : i32} : () -> tensor<17xi32>
+  // CHECK: tosa.const values({{.*}}) {grapharm.graph_constant_id = 0 : i32} : () -> tensor<17xi32>
   %res = "tosa.const"() <{values = dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]> : tensor<17xi32>}> : () -> tensor<17xi32>
   return %res : tensor<17xi32>
 }
@@ -38,9 +38,9 @@ func.func @small_const_shape() -> !tosa.shape<32> {
 
 // CHECK-LABEL: func.func @mixed_large_constants
 func.func @mixed_large_constants() -> (tensor<17xi32>, tensor<18xi32>, !tosa.shape<33>) {
-  // CHECK: "tosa.const"() <{values = {{.*}}> {grapharm.graph_constant_id = 0 : i32} : () -> tensor<17xi32>
+  // CHECK: tosa.const values({{.*}}) {grapharm.graph_constant_id = 0 : i32} : () -> tensor<17xi32>
   %const0 = "tosa.const"() <{values = dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]> : tensor<17xi32>}> : () -> tensor<17xi32>
-  // CHECK: "tosa.const"() <{values = {{.*}}> {grapharm.graph_constant_id = 1 : i32} : () -> tensor<18xi32>
+  // CHECK: tosa.const values({{.*}}) {grapharm.graph_constant_id = 1 : i32} : () -> tensor<18xi32>
   %const1 = "tosa.const"() <{values = dense<[20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37]> : tensor<18xi32>}> : () -> tensor<18xi32>
   // CHECK: tosa.const_shape {grapharm.graph_constant_id = 2 : i32, values = {{.*}}} : () -> !tosa.shape<33>
   %shape = "tosa.const_shape"() <{values = dense<[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33]> : tensor<33xindex>}> : () -> !tosa.shape<33>

--- a/mlir/test/Dialect/Tosa/canonicalize.mlir
+++ b/mlir/test/Dialect/Tosa/canonicalize.mlir
@@ -11,7 +11,7 @@ func.func @argmax_nofold(%arg0: tensor<?x1xf32>) -> tensor<1xi32> {
 
 // CHECK-LABEL: @test_argmax_fold_i64_index
 func.func @test_argmax_fold_i64_index(%arg0: tensor<1xi8>) -> tensor<i64> {
-  // CHECK: "tosa.const"() <{values = dense<0> : tensor<i64>}> : () -> tensor<i64>
+  // CHECK: tosa.const values(dense<0> : tensor<i64>) : () -> tensor<i64>
   %0 = tosa.argmax %arg0 {axis = 0 : i32} : (tensor<1xi8>) -> tensor<i64>
   return %0 : tensor<i64>
 }
@@ -532,7 +532,7 @@ func.func @pad_noop_type_mismatch_nofold(%arg0: tensor<10xf32>) -> tensor<?xf32>
 
 // CHECK-LABEL: @pad_determine_val_i32
 func.func @pad_determine_val_i32(%arg0: tensor<?x?xi32>, %arg1 : tensor<2x2xi32>) -> tensor<?x?xi32> {
-  // CHECK-DAG: %[[ZERO:.+]] = "tosa.const"() <{values = dense<0> : tensor<1xi32>}
+  // CHECK-DAG: %[[ZERO:.+]] = tosa.const values(dense<0> : tensor<1xi32>)
   // CHECK-DAG: %[[PADDING:.+]] = tosa.const_shape {values = dense<[1, 0, 0, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
   // CHECK: tosa.pad %arg0, %[[PADDING]], %[[ZERO]]
   %pad_const = "tosa.const"() {values = dense<0> : tensor<1xi32>} : () -> tensor<1xi32>
@@ -545,7 +545,7 @@ func.func @pad_determine_val_i32(%arg0: tensor<?x?xi32>, %arg1 : tensor<2x2xi32>
 
 // CHECK-LABEL: @pad_determine_val_f32
 func.func @pad_determine_val_f32(%arg0: tensor<?x?xf32>, %arg1 : tensor<2x2xi32>) -> tensor<?x?xf32> {
-  // CHECK-DAG: %[[ZERO:.+]] = "tosa.const"() <{values = dense<3.140000e+00> : tensor<1xf32>}
+  // CHECK-DAG: %[[ZERO:.+]] = tosa.const values(dense<3.140000e+00> : tensor<1xf32>)
   // CHECK-DAG: %[[PADDING:.+]] = tosa.const_shape {values = dense<[1, 0, 0, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
   // CHECK: tosa.pad %arg0, %[[PADDING]], %[[ZERO]]
   %pad_const = "tosa.const"() {values = dense<3.14> : tensor<1xf32>} : () -> tensor<1xf32>
@@ -558,7 +558,7 @@ func.func @pad_determine_val_f32(%arg0: tensor<?x?xf32>, %arg1 : tensor<2x2xi32>
 
 // CHECK-LABEL: @pad_determine_val_quant
 func.func @pad_determine_val_quant(%arg0: tensor<?x?xi32>, %arg1 : tensor<2x2xi32>) -> tensor<?x?xi32> {
-  // CHECK-DAG: %[[ZERO:.+]] = "tosa.const"() <{values = dense<3> : tensor<1xi32>}
+  // CHECK-DAG: %[[ZERO:.+]] = tosa.const values(dense<3> : tensor<1xi32>)
   // CHECK-DAG: %[[PADDING:.+]] = tosa.const_shape {values = dense<[1, 0, 0, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
   // CHECK: tosa.pad %arg0, %[[PADDING]], %[[ZERO]]
   %pad_const = "tosa.const"() {values =dense<3> : tensor<1xi32>} : () -> tensor<1xi32>
@@ -725,7 +725,7 @@ func.func @reshape_canonicalize_double(%arg0: tensor<?x10xf32>) -> tensor<?x5xf3
 
 // CHECK-LABEL: @reshape_canonicalize_const
 func.func @reshape_canonicalize_const() -> tensor<1x5xi32> {
-  // CHECK: %[[VAR0:.+]] = "tosa.const"() <{values = dense<{{\[\[}}0, 1, 2, 3, 4]]> : tensor<1x5xi32>}
+  // CHECK: %[[VAR0:.+]] = tosa.const values(dense<{{\[\[}}0, 1, 2, 3, 4]]> : tensor<1x5xi32>)
   // CHECK: return %[[VAR0]]
   %0 = "tosa.const"() {values = dense<[0, 1, 2, 3, 4]> : tensor<5xi32>} : () -> tensor<5xi32>
   %1 = "tosa.const_shape"() {values = dense<[1, 5]> : tensor<2xindex>} : () -> !tosa.shape<2>
@@ -748,8 +748,8 @@ func.func @reshape_canonicalize_const_dynamic() -> tensor<1x?xi32> {
 
 // CHECK-LABEL: @reshape_canonicalize_const_splat
 func.func @reshape_canonicalize_const_splat() -> (tensor<10xi32>, tensor<1x10xi32>) {
-  // CHECK-DAG: %[[VAR0:.+]] = "tosa.const"() <{values = dense<0> : tensor<10xi32>}
-  // CHECK-DAG: %[[VAR1:.+]] = "tosa.const"() <{values = dense<0> : tensor<1x10xi32>}
+  // CHECK-DAG: %[[VAR0:.+]] = tosa.const values(dense<0> : tensor<10xi32>)
+  // CHECK-DAG: %[[VAR1:.+]] = tosa.const values(dense<0> : tensor<1x10xi32>)
   // CHECK: return %[[VAR0]], %[[VAR1]]
   %0 = "tosa.const"() {values = dense<0> : tensor<10xi32>} : () -> tensor<10xi32>
   %2 = "tosa.const_shape"() {values = dense<[1, 10]> : tensor<2xindex>} : () -> !tosa.shape<2>
@@ -773,7 +773,7 @@ func.func @reshape_canonicalize_const_sparse() -> (tensor<3xi32>, tensor<1x3xi32
 // CHECK-LABEL: @reshape_canonicalize_quant_nofold
 func.func @reshape_canonicalize_quant_nofold() -> (tensor<1x3x!quant.uniform<i8:f32, 1.000000e+00>>) {
   // disabled folding for quantized element types
-  // CHECK{LITERAL}: "tosa.const"() <{values = dense<[1, 2, 3]> : tensor<3xi8>}> : () -> tensor<3x!quant.uniform<i8:f32, 1.000000e+00>>
+  // CHECK{LITERAL}: tosa.const values(dense<[1, 2, 3]> : tensor<3xi8>) : () -> tensor<3x!quant.uniform<i8:f32, 1.000000e+00>>
   // CHECK{LITERAL}: tosa.reshape %0, %1 : (tensor<3x!quant.uniform<i8:f32, 1.000000e+00>>, !tosa.shape<2>) -> tensor<1x3x!quant.uniform<i8:f32, 1.000000e+00>>
   %0 = "tosa.const"() {values = dense<[1, 2, 3]> : tensor<3xi8>} : ()-> tensor<3x!quant.uniform<i8:f32, 1.000000e+00>>
   %2 = "tosa.const_shape"() {values = dense<[1, 3]> : tensor<2xindex>} : () -> !tosa.shape<2>
@@ -786,7 +786,7 @@ func.func @reshape_canonicalize_quant_nofold() -> (tensor<1x3x!quant.uniform<i8:
 // CHECK-LABEL: @transpose_canonicalize_strip_quant
 func.func @transpose_canonicalize_strip_quant() -> (tensor<2x1x3x!quant.uniform<i8:f32, 1.000000e+00>>) {
   // CHECK-DAG: %[[SHAPE:.*]] = tosa.const_shape {values = dense<[2, 1, 3]> : tensor<3xindex>} : () -> !tosa.shape<3>
-  // CHECK-DAG: %[[CONST:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x2x3xi8>}> : () -> tensor<1x2x3x!quant.uniform<i8:f32, 1.000000e+00>>
+  // CHECK-DAG: %[[CONST:.*]] = tosa.const values(dense<0> : tensor<1x2x3xi8>) : () -> tensor<1x2x3x!quant.uniform<i8:f32, 1.000000e+00>>
   // CHECK: tosa.reshape %[[CONST]], %[[SHAPE]] : (tensor<1x2x3x!quant.uniform<i8:f32, 1.000000e+00>>, !tosa.shape<3>) -> tensor<2x1x3x!quant.uniform<i8:f32, 1.000000e+00>>
   %0 = "tosa.const"() {values = dense<0> : tensor<1x2x3xi8>} : ()-> tensor<1x2x3x!quant.uniform<i8:f32, 1.000000e+00>>
   %1 = tosa.transpose %0 { perms = array<i32: 1, 0, 2> }: (tensor<1x2x3x!quant.uniform<i8:f32, 1.000000e+00>>) -> tensor<2x1x3x!quant.uniform<i8:f32, 1.000000e+00>>
@@ -903,7 +903,7 @@ func.func @transpose_is_reshape_unknown_dim(%arg0: tensor<1x4x?x1xf32>) -> tenso
 // CHECK-LABEL: @single_bit_reshape
 // https://github.com/llvm/llvm-project/issues/55440
 func.func @single_bit_reshape() -> tensor<1xi1> {
-  // CHECK: "tosa.const"() <{values = dense<true> : tensor<1xi1>}
+  // CHECK: tosa.const values(dense<true> : tensor<1xi1>)
   %0 = arith.constant dense<true> : tensor<1x1xi1>
   %2 = "tosa.const_shape"() <{values = dense<1> : tensor<1xindex>}> : () -> !tosa.shape<1>
   %1 = tosa.reshape %0, %2 : (tensor<1x1xi1>, !tosa.shape<1>) -> tensor<1xi1>
@@ -1077,7 +1077,7 @@ func.func @canonicalize_concat_slice_on_non_concat_axis(%arg0 : tensor<1x12x12xf
 // -----
 
 // CHECK-LABEL: @canonicalize_pad_slice_overlap
-// CHECK-DAG: %[[PAD_CONST:.*]] = "tosa.const"() <{values = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
+// CHECK-DAG: %[[PAD_CONST:.*]] = tosa.const values(dense<0.000000e+00> : tensor<1xf32>) : () -> tensor<1xf32>
 // CHECK-DAG: %[[ZERO:.*]] = tosa.const_shape {values = dense<0> : tensor<4xindex>} : () -> !tosa.shape<4>
 // CHECK-DAG: %[[PADDING:.*]] = tosa.const_shape {values = dense<[0, 0, 0, 0, 1, 1, 0, 0]> : tensor<8xindex>}
 // CHECK-DAG: %[[SLICE_SIZE:.*]] = tosa.const_shape  {values = dense<[-1, 14, 18, 3]> : tensor<4xindex>}
@@ -1113,7 +1113,7 @@ func.func @canonicalize_pad_slice_inside(%arg0: tensor<1x16x16x3xf32>) -> tensor
 // -----
 
 // CHECK-LABEL: func @canonicalize_pad_slice_exact
-// CHECK-DAG: %[[PAD_CONST:.*]] = "tosa.const"() <{values = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
+// CHECK-DAG: %[[PAD_CONST:.*]] = tosa.const values(dense<0.000000e+00> : tensor<1xf32>) : () -> tensor<1xf32>
 // CHECK-DAG: %[[ZERO:.*]] = tosa.const_shape {values = dense<0> : tensor<4xindex>} : () -> !tosa.shape<4>
 // CHECK-DAG: %[[PADDING:.*]] = tosa.const_shape {values = dense<[0, 0, 0, 0, 2, 2, 0, 0]> : tensor<8xindex>}
 // CHECK-DAG: %[[SLICE_SIZE:.*]] = tosa.const_shape  {values = dense<[1, 16, 20, 2]> : tensor<4xindex>}
@@ -1249,7 +1249,7 @@ func.func @sub_quant_nofold() -> tensor<!quant.uniform<i8:f32, 3.075740460189990
 // CHECK-LABEL: @greater_quant_fold
 func.func @greater_quant_fold() -> tensor<i1> {
    %0 = "tosa.const"() {values = dense<0> : tensor<i8>} : () -> tensor<!quant.uniform<i8:f32, 3.0757404601899907E-5:-128>>
-   // CHECK: "tosa.const"() <{values = dense<false>
+   // CHECK: tosa.const values(dense<false>
    %2 = "tosa.greater"(%0, %0) : (tensor<!quant.uniform<i8:f32, 3.0757404601899907E-5:-128>>, tensor<!quant.uniform<i8:f32, 3.0757404601899907E-5:-128>>) -> tensor<i1>
    return %2 : tensor<i1>
 }
@@ -1259,7 +1259,7 @@ func.func @greater_quant_fold() -> tensor<i1> {
 // CHECK-LABEL: @greater_equal_quant_fold
 func.func @greater_equal_quant_fold() -> tensor<i1> {
    %0 = "tosa.const"() {values = dense<0> : tensor<i8>} : () -> tensor<!quant.uniform<i8:f32, 3.0757404601899907E-5:-128>>
-   // CHECK: "tosa.const"() <{values = dense<true>
+   // CHECK: tosa.const values(dense<true>
    %2 = "tosa.greater_equal"(%0, %0) : (tensor<!quant.uniform<i8:f32, 3.0757404601899907E-5:-128>>, tensor<!quant.uniform<i8:f32, 3.0757404601899907E-5:-128>>) -> tensor<i1>
    return %2 : tensor<i1>
 }
@@ -1269,7 +1269,7 @@ func.func @greater_equal_quant_fold() -> tensor<i1> {
 // CHECK-LABEL: @equal_quant_fold
 func.func @equal_quant_fold() -> tensor<i1> {
    %0 = "tosa.const"() {values = dense<0> : tensor<i8>} : () -> tensor<!quant.uniform<i8:f32, 3.0757404601899907E-5:-128>>
-   // CHECK: "tosa.const"() <{values = dense<true>
+   // CHECK: tosa.const values(dense<true>
    %2 = "tosa.equal"(%0, %0) : (tensor<!quant.uniform<i8:f32, 3.0757404601899907E-5:-128>>, tensor<!quant.uniform<i8:f32, 3.0757404601899907E-5:-128>>) -> tensor<i1>
    return %2 : tensor<i1>
 }
@@ -1288,7 +1288,7 @@ func.func @cast_quant_nofold() -> tensor<!quant.uniform<i8:f32, 3.07574046018999
 
 // CHECK-LABEL: @reverse_quant_fold
 func.func @reverse_quant_fold() -> tensor<1x!quant.uniform<i8:f32, 3.0757404601899907E-5:-128>> {
-   // CHECK: %[[CST:.*]] = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1x!quant.uniform<i8:f32, 3.0757404601899907E-5:-128>>
+   // CHECK: %[[CST:.*]] = tosa.const values(dense<0> : tensor<1xi8>) : () -> tensor<1x!quant.uniform<i8:f32, 3.0757404601899907E-5:-128>>
    // CHECK: return %[[CST]]
    %0 = "tosa.const"() {values = dense<0> : tensor<1xi8>} : () -> tensor<1x!quant.uniform<i8:f32, 3.0757404601899907E-5:-128>>
    %1 = "tosa.reverse"(%0) { axis = 0 : i32 } : (tensor<1x!quant.uniform<i8:f32, 3.0757404601899907E-5:-128>>) -> tensor<1x!quant.uniform<i8:f32, 3.0757404601899907E-5:-128>>
@@ -1330,7 +1330,7 @@ func.func @reverse_nofold_splat_type_unmatch() -> tensor<*xf32> {
 
 // CHECK-LABEL: @select_quant_fold
 func.func @select_quant_fold() -> tensor<!quant.uniform<i8:f32, 3.0757404601899907E-5:-128>> {
-   // CHECK: %[[CONST_0:.*]] = "tosa.const"() <{values = dense<0> : tensor<i8>}> : () -> tensor<!quant.uniform<i8:f32, 3.0757404601899907E-5:-128>>
+   // CHECK: %[[CONST_0:.*]] = tosa.const values(dense<0> : tensor<i8>) : () -> tensor<!quant.uniform<i8:f32, 3.0757404601899907E-5:-128>>
    // CHECK: return %[[CONST_0]]
    %0 = "tosa.const"() {values = dense<true> : tensor<i1>} : () -> tensor<i1>
    %1 = "tosa.const"() {values = dense<0> : tensor<i8>} : () -> tensor<!quant.uniform<i8:f32, 3.0757404601899907E-5:-128>>
@@ -1356,7 +1356,7 @@ func.func @mul_quant_nofold() -> tensor<1x!quant.uniform<i8:f32, 3.0757404601899
 
 // CHECK-LABEL: @fold_reciprocal
 func.func nested @fold_reciprocal() -> tensor<3x600x1200xf32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<8.620690e-03> : tensor<3x600x1200xf32>}> : () -> tensor<3x600x1200xf32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<8.620690e-03> : tensor<3x600x1200xf32>) : () -> tensor<3x600x1200xf32>
   // CHECK:           return %[[VAL_0]] : tensor<3x600x1200xf32>
   // CHECK:         }
   %0 = "tosa.const"(){ values = dense<116.0>: tensor<3x600x1200xf32> }: () -> tensor<3x600x1200xf32>
@@ -1403,7 +1403,7 @@ func.func @slice_dynamic_size_static_output_canonicalize(%arg0: tensor<2x60x59x?
 // -----
 
 // CHECK-LABEL: @fold_mul_shift
-// CHECK-DAG: "tosa.const"() <{values = dense<1> : tensor<i32>}> : () -> tensor<i32>
+// CHECK-DAG: tosa.const values(dense<1> : tensor<i32>) : () -> tensor<i32>
 func.func @fold_mul_shift() -> tensor<i32> {
     %0 = "tosa.const"() <{values = dense<-23661> : tensor<i32>}> : () -> tensor<i32>
     %1 = "tosa.const"() <{values = dense<-33022> : tensor<i32>}> : () -> tensor<i32>
@@ -1415,7 +1415,7 @@ func.func @fold_mul_shift() -> tensor<i32> {
 // -----
 
 // CHECK-LABEL: @fold_mul_no_shift
-// CHECK-DAG: "tosa.const"() <{values = dense<781333542> : tensor<i32>}> : () -> tensor<i32>
+// CHECK-DAG: tosa.const values(dense<781333542> : tensor<i32>) : () -> tensor<i32>
 func.func @fold_mul_no_shift() -> tensor<i32> {
     %0 = "tosa.const"() <{values = dense<-23661> : tensor<i32>}> : () -> tensor<i32>
     %1 = "tosa.const"() <{values = dense<-33022> : tensor<i32>}> : () -> tensor<i32>
@@ -1427,9 +1427,9 @@ func.func @fold_mul_no_shift() -> tensor<i32> {
 // -----
 
 // CHECK-LABEL: @no_fold_mul_result_exceeds_i32
-// CHECK-DAG: %[[LHS:.*]] = "tosa.const"() <{values = dense<23661> : tensor<i32>}> : () -> tensor<i32>
-// CHECK-DAG: %[[RHS:.*]] = "tosa.const"() <{values = dense<330222> : tensor<i32>}> : () -> tensor<i32>
-// CHECK-DAG: %[[SHIFT:.*]] = "tosa.const"() <{values = dense<1> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK-DAG: %[[LHS:.*]] = tosa.const values(dense<23661> : tensor<i32>) : () -> tensor<i32>
+// CHECK-DAG: %[[RHS:.*]] = tosa.const values(dense<330222> : tensor<i32>) : () -> tensor<i32>
+// CHECK-DAG: %[[SHIFT:.*]] = tosa.const values(dense<1> : tensor<1xi8>) : () -> tensor<1xi8>
 // CHECK: tosa.mul %[[LHS]], %[[RHS]], %[[SHIFT]] : (tensor<i32>, tensor<i32>, tensor<1xi8>) -> tensor<i32>
 func.func @no_fold_mul_result_exceeds_i32() -> tensor<i32> {
     %0 = "tosa.const"() <{values = dense<23661> : tensor<i32>}> : () -> tensor<i32>
@@ -1467,7 +1467,7 @@ func.func @no_fold_intdiv_dynamic_result() -> tensor<?xi32> {
 // -----
 
 // CHECK-LABEL: @test_fold_i1_to_i32_cast
-// CHECK: %[[OUT:.*]] = "tosa.const"() <{values = dense<1> : tensor<i32>}> : () -> tensor<i32>
+// CHECK: %[[OUT:.*]] = tosa.const values(dense<1> : tensor<i32>) : () -> tensor<i32>
 // CHECK: return %[[OUT]] : tensor<i32>
 func.func @test_fold_i1_to_i32_cast() -> tensor<i32> {
   %0 = "tosa.const"() <{values = dense<1> : tensor<i1>}> : () -> tensor<i1>
@@ -1478,7 +1478,7 @@ func.func @test_fold_i1_to_i32_cast() -> tensor<i32> {
 // -----
 
 // CHECK-LABEL: @test_fold_i32_to_i1_cast
-// CHECK: %[[OUT:.*]] = "tosa.const"() <{values = dense<true> : tensor<i1>}> : () -> tensor<i1>
+// CHECK: %[[OUT:.*]] = tosa.const values(dense<true> : tensor<i1>) : () -> tensor<i1>
 // CHECK: return %[[OUT]] : tensor<i1>
 func.func @test_fold_i32_to_i1_cast() -> tensor<i1> {
   %0 = "tosa.const"() <{values = dense<10> : tensor<i32>}> : () -> tensor<i32>

--- a/mlir/test/Dialect/Tosa/constant_folding.mlir
+++ b/mlir/test/Dialect/Tosa/constant_folding.mlir
@@ -113,7 +113,7 @@ func.func @fold_add_splat_i32() -> tensor<10xi32> {
   %one = "tosa.const"() {values = dense<1> : tensor<10xi32>} : () -> tensor<10xi32>
   %two = "tosa.const"() {values = dense<2> : tensor<10xi32>} : () -> tensor<10xi32>
   %add = tosa.add %one, %two : (tensor<10xi32>, tensor<10xi32>) -> tensor<10xi32>
-  // CHECK: %[[THREE:.+]] = "tosa.const"() <{values = dense<3> : tensor<10xi32>}
+  // CHECK: %[[THREE:.+]] = tosa.const values(dense<3> : tensor<10xi32>)
   // CHECK: return %[[THREE]]
   return %add : tensor<10xi32>
 }
@@ -125,7 +125,7 @@ func.func @fold_add_splat_f32() -> tensor<10xf32> {
   %one = "tosa.const"() {values = dense<1.0> : tensor<10xf32>} : () -> tensor<10xf32>
   %two = "tosa.const"() {values = dense<2.0> : tensor<10xf32>} : () -> tensor<10xf32>
   %add = tosa.add %one, %two : (tensor<10xf32>, tensor<10xf32>) -> tensor<10xf32>
-  // CHECK: %[[THREE:.+]] = "tosa.const"() <{values = dense<3.000000e+00>
+  // CHECK: %[[THREE:.+]] = tosa.const values(dense<3.000000e+00>
   // CHECK: return %[[THREE]]
   return %add : tensor<10xf32>
 }
@@ -158,7 +158,7 @@ func.func @fold_add_splat_i32_negative_overflow() -> tensor<10xi32> {
 func.func @fold_add_splat_ui8() -> tensor<10xui8> {
   %one = "tosa.const"() {values = dense<1> : tensor<10xui8>} : () -> tensor<10xui8>
   %two = "tosa.const"() {values = dense<254> : tensor<10xui8>} : () -> tensor<10xui8>
-  // CHECK: "tosa.const"() <{values = dense<255> : tensor<10xui8>}> : () -> tensor<10xui8>
+  // CHECK: tosa.const values(dense<255> : tensor<10xui8>) : () -> tensor<10xui8>
   %add = tosa.add %one, %two : (tensor<10xui8>, tensor<10xui8>) -> tensor<10xui8>
   return %add : tensor<10xui8>
 }
@@ -240,7 +240,7 @@ func.func @no_fold_div_zero_lhs_i32(%arg0: tensor<i32>) -> tensor<i32> {
 func.func @fold_div_zero_lhs_nonzero_splat_rhs_i32() -> tensor<i32> {
   %lhs = "tosa.const"() {values = dense<0> : tensor<i32>} : () -> tensor<i32>
   %rhs = "tosa.const"() {values = dense<2> : tensor<i32>} : () -> tensor<i32>
-  // CHECK: %[[ZERO:.+]] = "tosa.const"() <{values = dense<0>
+  // CHECK: %[[ZERO:.+]] = tosa.const values(dense<0>
   %div = tosa.intdiv %lhs, %rhs : (tensor<i32>, tensor<i32>) -> tensor<i32>
   // CHECK: return %[[ZERO]]
   return %div : tensor<i32>
@@ -312,7 +312,7 @@ func.func @no_fold_dynamic_div_unknown_broadcast_one_rhs(%arg0: tensor<?x4xi32>)
 func.func @fold_div_splat_i32() -> tensor<i32> {
   %lhs = "tosa.const"() {values = dense<10> : tensor<i32>} : () -> tensor<i32>
   %rhs = "tosa.const"() {values = dense<-3> : tensor<i32>} : () -> tensor<i32>
-  // CHECK: %[[SPLAT:.+]] = "tosa.const"() <{values = dense<-3>
+  // CHECK: %[[SPLAT:.+]] = tosa.const values(dense<-3>
   %div = tosa.intdiv %lhs, %rhs : (tensor<i32>, tensor<i32>) -> tensor<i32>
   // CHECK: return %[[SPLAT]]
   return %div : tensor<i32>
@@ -356,7 +356,7 @@ func.func @no_fold_div_zero_lhs_non_splat_rhs_i32() -> tensor<2xi32> {
 // CHECK-LABEL: @fold_mul_zero_rhs_f32
 func.func @fold_mul_zero_rhs_f32(%arg0: tensor<f32>) -> tensor<f32> {
   %zero = "tosa.const"() {values = dense<0.0> : tensor<f32>} : () -> tensor<f32>
-  // CHECK: %[[ZERO:.+]] = "tosa.const"() <{values = dense<0.000000e+00>
+  // CHECK: %[[ZERO:.+]] = tosa.const values(dense<0.000000e+00>
   %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
   %mul = tosa.mul %arg0, %zero, %shift : (tensor<f32>, tensor<f32>, tensor<1xi8>) -> tensor<f32>
   // CHECK: return %[[ZERO]]
@@ -368,7 +368,7 @@ func.func @fold_mul_zero_rhs_f32(%arg0: tensor<f32>) -> tensor<f32> {
 // CHECK-LABEL: @fold_mul_zero_lhs_f32
 func.func @fold_mul_zero_lhs_f32(%arg0: tensor<f32>) -> tensor<f32> {
   %zero = "tosa.const"() {values = dense<0.0> : tensor<f32>} : () -> tensor<f32>
-  // CHECK: %[[ZERO:.+]] = "tosa.const"() <{values = dense<0.000000e+00>
+  // CHECK: %[[ZERO:.+]] = tosa.const values(dense<0.000000e+00>
   %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
   %mul = tosa.mul %zero, %arg0, %shift : (tensor<f32>, tensor<f32>, tensor<1xi8>) -> tensor<f32>
   // CHECK: return %[[ZERO]]
@@ -381,7 +381,7 @@ func.func @fold_mul_zero_lhs_f32(%arg0: tensor<f32>) -> tensor<f32> {
 func.func @fold_mul_zero_rhs_i32(%arg0: tensor<i32>) -> tensor<i32> {
   %zero = "tosa.const"() {values = dense<0> : tensor<i32>} : () -> tensor<i32>
   %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
-  // CHECK: %[[ZERO:.+]] = "tosa.const"() <{values = dense<0>
+  // CHECK: %[[ZERO:.+]] = tosa.const values(dense<0>
   %mul = tosa.mul %arg0, %zero, %shift : (tensor<i32>, tensor<i32>, tensor<1xi8>) -> tensor<i32>
   // CHECK: return %[[ZERO]]
   return %mul : tensor<i32>
@@ -393,7 +393,7 @@ func.func @fold_mul_zero_rhs_i32(%arg0: tensor<i32>) -> tensor<i32> {
 func.func @fold_mul_zero_lhs_i32(%arg0: tensor<i32>) -> tensor<i32> {
   %zero = "tosa.const"() {values = dense<0> : tensor<i32>} : () -> tensor<i32>
   %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
-  // CHECK: %[[ZERO:.+]] = "tosa.const"() <{values = dense<0>
+  // CHECK: %[[ZERO:.+]] = tosa.const values(dense<0>
   %mul = tosa.mul %zero, %arg0, %shift : (tensor<i32>, tensor<i32>, tensor<1xi8>) -> tensor<i32>
   // CHECK: return %[[ZERO]]
   return %mul : tensor<i32>
@@ -527,8 +527,8 @@ func.func @fold_mul_one_int(%arg0: tensor<2x3xi32>) -> tensor<2x3xi32> {
 
 // CHECK-LABEL: @fold_mul_one_int_and_shift
 func.func @fold_mul_one_int_and_shift(%arg0: tensor<2x3xi32>) -> tensor<2x3xi32> {
-  // CHECK-DAG: %[[VAL_1:.*]] = "tosa.const"() <{values = dense<1> : tensor<2x3xi32>}>
-  // CHECK-DAG: %[[VAL_2:.*]] = "tosa.const"() <{values = dense<31> : tensor<1xi8>}>
+  // CHECK-DAG: %[[VAL_1:.*]] = tosa.const values(dense<1> : tensor<2x3xi32>)
+  // CHECK-DAG: %[[VAL_2:.*]] = tosa.const values(dense<31> : tensor<1xi8>)
   // CHECK: %[[VAL_3:.*]] = tosa.mul %arg0, %[[VAL_1]], %[[VAL_2]] : (tensor<2x3xi32>, tensor<2x3xi32>, tensor<1xi8>)
   %ones = "tosa.const"() {values = dense<1> : tensor<2x3xi32>} : () -> tensor<2x3xi32>
   %shift = "tosa.const"() <{values = dense<31> : tensor<1xi8>}> : () -> tensor<1xi8>
@@ -540,7 +540,7 @@ func.func @fold_mul_one_int_and_shift(%arg0: tensor<2x3xi32>) -> tensor<2x3xi32>
 
 // CHECK-LABEL: @fold_mul_zero_broadcast
 func.func @fold_mul_zero_broadcast(%arg0: tensor<2x3xf32>) -> (tensor<2x3xf32>, tensor<2x3xf32>) {
-  // CHECK: %[[ZERO:.*]] = "tosa.const"() <{values = dense<0.000000e+00> : tensor<2x3xf32>}
+  // CHECK: %[[ZERO:.*]] = tosa.const values(dense<0.000000e+00> : tensor<2x3xf32>)
   // CHECK-NOT: tosa.mul
   %zeros = "tosa.const"() {values = dense<0.0> : tensor<1x1xf32>} : () -> tensor<1x1xf32>
   %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
@@ -556,8 +556,8 @@ func.func @fold_mul_zero_broadcast(%arg0: tensor<2x3xf32>) -> (tensor<2x3xf32>, 
 
 // CHECK-LABEL: @fold_mul_zero_dynamic_nofold
 // CHECK-SAME:                    %[[ARG0:.*]]: tensor<?x17xf32>) -> tensor<?x17xf32> {
-// CHECK:           %[[ZERO:.*]] = "tosa.const"() <{values = dense<0.000000e+00> : tensor<1x1xf32>}> : () -> tensor<1x1xf32>
-// CHECK:           %[[SHIFT:.*]] = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           %[[ZERO:.*]] = tosa.const values(dense<0.000000e+00> : tensor<1x1xf32>) : () -> tensor<1x1xf32>
+// CHECK:           %[[SHIFT:.*]] = tosa.const values(dense<0> : tensor<1xi8>) : () -> tensor<1xi8>
 // CHECK:           %[[MUL:.*]] = tosa.mul %[[ARG0]], %[[ZERO]], %[[SHIFT]] : (tensor<?x17xf32>, tensor<1x1xf32>, tensor<1xi8>) -> tensor<?x17xf32>
 // CHECK:           return %[[MUL]]
 func.func @fold_mul_zero_dynamic_nofold(%arg0: tensor<?x17xf32>) -> tensor<?x17xf32> {
@@ -587,7 +587,7 @@ func.func @fold_mul_splat_i8() -> tensor<10xi32> {
   %two = "tosa.const"() {values = dense<32> : tensor<10xi8>} : () -> tensor<10xi8>
   %shift = "tosa.const"() {values = dense<3> : tensor<1xi8>} : () -> tensor<1xi8>
   %mul = tosa.mul %one, %two, %shift : (tensor<10xi8>, tensor<10xi8>, tensor<1xi8>) -> tensor<10xi32>
-  // CHECK: %[[SIXTY_EIGHT:.+]] = "tosa.const"() <{values = dense<68> : tensor<10xi32>}
+  // CHECK: %[[SIXTY_EIGHT:.+]] = tosa.const values(dense<68> : tensor<10xi32>)
   // CHECK: return %[[SIXTY_EIGHT]]
   return %mul : tensor<10xi32>
 }
@@ -600,7 +600,7 @@ func.func @fold_mul_splat_f32() -> tensor<10xf32> {
   %two = "tosa.const"() {values = dense<2.0> : tensor<10xf32>} : () -> tensor<10xf32>
   %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
   %mul = tosa.mul %one, %two, %shift : (tensor<10xf32>, tensor<10xf32>, tensor<1xi8>) -> tensor<10xf32>
-  // CHECK: %[[SIX:.+]] = "tosa.const"() <{values = dense<6.000000e+00> : tensor<10xf32>}
+  // CHECK: %[[SIX:.+]] = tosa.const values(dense<6.000000e+00> : tensor<10xf32>)
   // CHECK: return %[[SIX]]
   return %mul : tensor<10xf32>
 }
@@ -662,7 +662,7 @@ func.func @fold_sub_splat_i32() -> tensor<10xi32> {
   %one = "tosa.const"() {values = dense<1> : tensor<10xi32>} : () -> tensor<10xi32>
   %two = "tosa.const"() {values = dense<2> : tensor<10xi32>} : () -> tensor<10xi32>
   %sub = tosa.sub %one, %two : (tensor<10xi32>, tensor<10xi32>) -> tensor<10xi32>
-  // CHECK: %[[NEGATIVE_ONE:.+]] = "tosa.const"() <{values = dense<-1> : tensor<10xi32>}
+  // CHECK: %[[NEGATIVE_ONE:.+]] = tosa.const values(dense<-1> : tensor<10xi32>)
   // CHECK: return %[[NEGATIVE_ONE]]
   return %sub : tensor<10xi32>
 }
@@ -674,7 +674,7 @@ func.func @fold_sub_splat_f32() -> tensor<10xf32> {
   %one = "tosa.const"() {values = dense<1.0> : tensor<10xf32>} : () -> tensor<10xf32>
   %two = "tosa.const"() {values = dense<2.0> : tensor<10xf32>} : () -> tensor<10xf32>
   %sub = tosa.sub %one, %two : (tensor<10xf32>, tensor<10xf32>) -> tensor<10xf32>
-  // CHECK: %[[NEGATIVE_ONE:.+]] = "tosa.const"() <{values = dense<-1.000000e+00> : tensor<10xf32>}
+  // CHECK: %[[NEGATIVE_ONE:.+]] = tosa.const values(dense<-1.000000e+00> : tensor<10xf32>)
   // CHECK: return %[[NEGATIVE_ONE]]
   return %sub : tensor<10xf32>
 }
@@ -707,7 +707,7 @@ func.func @fold_sub_splat_i32_negative_overflow() -> tensor<10xi32> {
 func.func @fold_sub_splat_ui8() -> tensor<10xui8> {
   %one = "tosa.const"() {values = dense<255> : tensor<10xui8>} : () -> tensor<10xui8>
   %two = "tosa.const"() {values = dense<253> : tensor<10xui8>} : () -> tensor<10xui8>
-  // CHECK: "tosa.const"() <{values = dense<2> : tensor<10xui8>}> : () -> tensor<10xui8>
+  // CHECK: tosa.const values(dense<2> : tensor<10xui8>) : () -> tensor<10xui8>
   %sub = tosa.sub %one, %two : (tensor<10xui8>, tensor<10xui8>) -> tensor<10xui8>
   return %sub : tensor<10xui8>
 }
@@ -733,8 +733,8 @@ func.func @fold_greater_splat_f32() -> (tensor<10xi1>, tensor<10xi1>) {
   %3 = "tosa.const"() {values = dense<2.0> : tensor<10xf32>} : () -> tensor<10xf32>
   %true = tosa.greater %0, %1 : (tensor<10xf32>, tensor<10xf32>) -> tensor<10xi1>
   %false = tosa.greater %2, %3 : (tensor<10xf32>, tensor<10xf32>) -> tensor<10xi1>
-  // CHECK-DAG: %[[TRUE:.+]] = "tosa.const"() <{values = dense<true> : tensor<10xi1>}
-  // CHECK-DAG: %[[FALSE:.+]] = "tosa.const"() <{values = dense<false> : tensor<10xi1>}
+  // CHECK-DAG: %[[TRUE:.+]] = tosa.const values(dense<true> : tensor<10xi1>)
+  // CHECK-DAG: %[[FALSE:.+]] = tosa.const values(dense<false> : tensor<10xi1>)
   // CHECK: return %[[TRUE]], %[[FALSE]]
   return %true, %false : tensor<10xi1>, tensor<10xi1>
 }
@@ -749,8 +749,8 @@ func.func @fold_greater_splat_i32() -> (tensor<10xi1>, tensor<10xi1>) {
   %3 = "tosa.const"() {values = dense<-12> : tensor<10xi32>} : () -> tensor<10xi32>
   %false = tosa.greater %0, %1 : (tensor<10xi32>, tensor<10xi32>) -> tensor<10xi1>
   %true = tosa.greater %2, %3 : (tensor<10xi32>, tensor<10xi32>) -> tensor<10xi1>
-  // CHECK-DAG: %[[FALSE:.+]] = "tosa.const"() <{values = dense<false> : tensor<10xi1>}
-  // CHECK-DAG: %[[TRUE:.+]] = "tosa.const"() <{values = dense<true> : tensor<10xi1>}
+  // CHECK-DAG: %[[FALSE:.+]] = tosa.const values(dense<false> : tensor<10xi1>)
+  // CHECK-DAG: %[[TRUE:.+]] = tosa.const values(dense<true> : tensor<10xi1>)
   // CHECK: return %[[FALSE]], %[[TRUE]]
   return %false, %true : tensor<10xi1>, tensor<10xi1>
 }
@@ -766,8 +766,8 @@ func.func @fold_greater_splat_ui8() -> (tensor<10xi1>, tensor<10xi1>, tensor<10x
   %true = tosa.greater %2, %3 : (tensor<10xui8>, tensor<10xui8>) -> tensor<10xi1>
   %false = tosa.greater %0, %1 : (tensor<10xui8>, tensor<10xui8>) -> tensor<10xi1>
   %false2 = tosa.greater %0, %2 : (tensor<10xui8>, tensor<10xui8>) -> tensor<10xi1>
-  // CHECK-DAG: %[[TRUE:.+]] = "tosa.const"() <{values = dense<true> : tensor<10xi1>}
-  // CHECK-DAG: %[[FALSE:.+]] = "tosa.const"() <{values = dense<false> : tensor<10xi1>}
+  // CHECK-DAG: %[[TRUE:.+]] = tosa.const values(dense<true> : tensor<10xi1>)
+  // CHECK-DAG: %[[FALSE:.+]] = tosa.const values(dense<false> : tensor<10xi1>)
   // CHECK: return %[[TRUE]], %[[FALSE]], %[[FALSE]]
   return %true, %false, %false2 : tensor<10xi1>, tensor<10xi1>, tensor<10xi1>
 }
@@ -782,8 +782,8 @@ func.func @fold_greater_eq_splat_f32() -> (tensor<10xi1>, tensor<10xi1>) {
   %3 = "tosa.const"() {values = dense<2.0> : tensor<10xf32>} : () -> tensor<10xf32>
   %true = tosa.greater_equal %0, %1 : (tensor<10xf32>, tensor<10xf32>) -> tensor<10xi1>
   %false = tosa.greater_equal %2, %3 : (tensor<10xf32>, tensor<10xf32>) -> tensor<10xi1>
-  // CHECK-DAG: %[[TRUE:.+]] = "tosa.const"() <{values = dense<true> : tensor<10xi1>}
-  // CHECK-DAG: %[[FALSE:.+]] = "tosa.const"() <{values = dense<false> : tensor<10xi1>}
+  // CHECK-DAG: %[[TRUE:.+]] = tosa.const values(dense<true> : tensor<10xi1>)
+  // CHECK-DAG: %[[FALSE:.+]] = tosa.const values(dense<false> : tensor<10xi1>)
   // CHECK: return %[[TRUE]], %[[FALSE]]
   return %true, %false : tensor<10xi1>, tensor<10xi1>
 }
@@ -798,8 +798,8 @@ func.func @fold_greater_eq_splat_i32() -> (tensor<10xi1>, tensor<10xi1>) {
   %3 = "tosa.const"() {values = dense<-10> : tensor<10xi32>} : () -> tensor<10xi32>
   %true = tosa.greater_equal %2, %3 : (tensor<10xi32>, tensor<10xi32>) -> tensor<10xi1>
   %false = tosa.greater_equal %0, %1 : (tensor<10xi32>, tensor<10xi32>) -> tensor<10xi1>
-  // CHECK-DAG: %[[TRUE:.+]] = "tosa.const"() <{values = dense<true> : tensor<10xi1>}
-  // CHECK-DAG: %[[FALSE:.+]] = "tosa.const"() <{values = dense<false> : tensor<10xi1>}
+  // CHECK-DAG: %[[TRUE:.+]] = tosa.const values(dense<true> : tensor<10xi1>)
+  // CHECK-DAG: %[[FALSE:.+]] = tosa.const values(dense<false> : tensor<10xi1>)
   // CHECK: return %[[TRUE]], %[[FALSE]]
   return %true, %false : tensor<10xi1>, tensor<10xi1>
 }
@@ -814,8 +814,8 @@ func.func @fold_greater_eq_splat_ui8() -> (tensor<10xi1>, tensor<10xi1>) {
   %3 = "tosa.const"() {values = dense<245> : tensor<10xui8>} : () -> tensor<10xui8>
   %true = tosa.greater_equal %2, %3 : (tensor<10xui8>, tensor<10xui8>) -> tensor<10xi1>
   %false = tosa.greater_equal %0, %1 : (tensor<10xui8>, tensor<10xui8>) -> tensor<10xi1>
-  // CHECK-DAG: %[[TRUE:.+]] = "tosa.const"() <{values = dense<true> : tensor<10xi1>}
-  // CHECK-DAG: %[[FALSE:.+]] = "tosa.const"() <{values = dense<false> : tensor<10xi1>}
+  // CHECK-DAG: %[[TRUE:.+]] = tosa.const values(dense<true> : tensor<10xi1>)
+  // CHECK-DAG: %[[FALSE:.+]] = tosa.const values(dense<false> : tensor<10xi1>)
   // CHECK: return %[[TRUE]], %[[FALSE]]
   return %true, %false : tensor<10xi1>, tensor<10xi1>
 }
@@ -830,8 +830,8 @@ func.func @fold_eq_splat_f32() -> (tensor<10xi1>, tensor<10xi1>) {
   %3 = "tosa.const"() {values = dense<2.0> : tensor<10xf32>} : () -> tensor<10xf32>
   %true = tosa.equal %0, %1 : (tensor<10xf32>, tensor<10xf32>) -> tensor<10xi1>
   %false = tosa.equal %2, %3 : (tensor<10xf32>, tensor<10xf32>) -> tensor<10xi1>
-  // CHECK-DAG: %[[TRUE:.+]] = "tosa.const"() <{values = dense<true> : tensor<10xi1>}
-  // CHECK-DAG: %[[FALSE:.+]] = "tosa.const"() <{values = dense<false> : tensor<10xi1>}
+  // CHECK-DAG: %[[TRUE:.+]] = tosa.const values(dense<true> : tensor<10xi1>)
+  // CHECK-DAG: %[[FALSE:.+]] = tosa.const values(dense<false> : tensor<10xi1>)
   // CHECK: return %[[TRUE]], %[[FALSE]]
   return %true, %false : tensor<10xi1>, tensor<10xi1>
 }
@@ -845,7 +845,7 @@ func.func @fold_compare_nan_f32() -> (tensor<10xi1>, tensor<10xi1>, tensor<10xi1
   %gt = tosa.greater %nan, %one : (tensor<10xf32>, tensor<10xf32>) -> tensor<10xi1>
   %ge = tosa.greater_equal %one, %nan : (tensor<10xf32>, tensor<10xf32>) -> tensor<10xi1>
   %eq = tosa.equal %nan, %nan : (tensor<10xf32>, tensor<10xf32>) -> tensor<10xi1>
-  // CHECK-DAG: %[[FALSE:.+]] = "tosa.const"() <{values = dense<false> : tensor<10xi1>}
+  // CHECK-DAG: %[[FALSE:.+]] = tosa.const values(dense<false> : tensor<10xi1>)
   // CHECK: return %[[FALSE]], %[[FALSE]], %[[FALSE]]
   return %gt, %ge, %eq : tensor<10xi1>, tensor<10xi1>, tensor<10xi1>
 }
@@ -860,8 +860,8 @@ func.func @fold_eq_splat_i32() -> (tensor<10xi1>, tensor<10xi1>) {
   %3 = "tosa.const"() {values = dense<-10> : tensor<10xi32>} : () -> tensor<10xi32>
   %true = tosa.equal %2, %3 : (tensor<10xi32>, tensor<10xi32>) -> tensor<10xi1>
   %false = tosa.equal %0, %1 : (tensor<10xi32>, tensor<10xi32>) -> tensor<10xi1>
-  // CHECK-DAG: %[[TRUE:.+]] = "tosa.const"() <{values = dense<true> : tensor<10xi1>}
-  // CHECK-DAG: %[[FALSE:.+]] = "tosa.const"() <{values = dense<false> : tensor<10xi1>}
+  // CHECK-DAG: %[[TRUE:.+]] = tosa.const values(dense<true> : tensor<10xi1>)
+  // CHECK-DAG: %[[FALSE:.+]] = tosa.const values(dense<false> : tensor<10xi1>)
   // CHECK: return %[[TRUE]], %[[FALSE]]
   return %true, %false : tensor<10xi1>, tensor<10xi1>
 }
@@ -870,7 +870,7 @@ func.func @fold_eq_splat_i32() -> (tensor<10xi1>, tensor<10xi1>) {
 
 // CHECK-LABEL: @fold_eq_i32
 func.func @fold_eq_i32(%arg0 : tensor<10xi32>) -> (tensor<10xi1>) {
-  // CHECK: %[[TRUE:.+]] = "tosa.const"() <{values = dense<true> : tensor<10xi1>}
+  // CHECK: %[[TRUE:.+]] = tosa.const values(dense<true> : tensor<10xi1>)
   %0 = tosa.equal %arg0, %arg0 : (tensor<10xi32>, tensor<10xi32>) -> tensor<10xi1>
   // CHECK: return %[[TRUE]]
   return %0 : tensor<10xi1>
@@ -879,7 +879,7 @@ func.func @fold_eq_i32(%arg0 : tensor<10xi32>) -> (tensor<10xi1>) {
 // -----
 
 func.func @reshape_splat() -> tensor<6x5x4xi32> {
-  // CHECK: %[[SPLAT:.+]] = "tosa.const"() <{values = dense<42> : tensor<6x5x4xi32>}
+  // CHECK: %[[SPLAT:.+]] = tosa.const values(dense<42> : tensor<6x5x4xi32>)
   %splat = "tosa.const"() {values = dense<42> : tensor<4x5x6xi32>} : () -> tensor<4x5x6xi32>
   %const = tosa.const_shape {values = dense<[6, 5, 4]> : tensor<3xindex>} : () -> !tosa.shape<3>
   %reshape = tosa.reshape %splat, %const : (tensor<4x5x6xi32>, !tosa.shape<3>) -> tensor<6x5x4xi32>
@@ -891,7 +891,7 @@ func.func @reshape_splat() -> tensor<6x5x4xi32> {
 
 // CHECK-LABEL: @reshape_dense_resource
 func.func @reshape_dense_resource() -> tensor<4xf32> {
-  // CHECK: %[[RESHAPED:.+]] = "tosa.const"() <{values = dense_resource<reshape_resource> : tensor<4xf32>}> : () -> tensor<4xf32>
+  // CHECK: %[[RESHAPED:.+]] = tosa.const values(dense_resource<reshape_resource> : tensor<4xf32>) : () -> tensor<4xf32>
   %input = "tosa.const"() <{values = dense_resource<reshape_resource> : tensor<2x2xf32>}> : () -> tensor<2x2xf32>
   %shape = tosa.const_shape {values = dense<4> : tensor<1xindex>} : () -> !tosa.shape<1>
   %reshape = tosa.reshape %input, %shape : (tensor<2x2xf32>, !tosa.shape<1>) -> tensor<4xf32>
@@ -910,7 +910,7 @@ func.func @reshape_dense_resource() -> tensor<4xf32> {
 
 // CHECK-LABEL: @slice_splat
 func.func @slice_splat() -> tensor<1x1x1xi32> {
-  // CHECK: %[[SLICE:.+]] = "tosa.const"() <{values = dense<42> : tensor<1x1x1xi32>}
+  // CHECK: %[[SLICE:.+]] = tosa.const values(dense<42> : tensor<1x1x1xi32>)
   %splat = "tosa.const"() {values = dense<42> : tensor<4x5x6xi32>} : () -> tensor<4x5x6xi32>
   %start = tosa.const_shape {values = dense<[1, 2, 3]> : tensor<3xindex>} : () -> !tosa.shape<3>
   %size = tosa.const_shape {values = dense<[1, 1, 1]> : tensor<3xindex>} : () -> !tosa.shape<3>
@@ -925,7 +925,7 @@ func.func @slice_splat() -> tensor<1x1x1xi32> {
 // CHECK-LABEL: @slice_singleton
 func.func @slice_singleton() -> tensor<1x1xi32> {
   %splat = "tosa.const"() {values = dense<[[0, 1, 2], [3, 4, 5], [6, 7 ,8]]> : tensor<3x3xi32>} : () -> tensor<3x3xi32>
-  // CHECK: %[[SLICE:.+]] = "tosa.const"() <{values = dense<4> : tensor<1x1xi32>}
+  // CHECK: %[[SLICE:.+]] = tosa.const values(dense<4> : tensor<1x1xi32>)
   %start = tosa.const_shape {values = dense<[1, 1]> : tensor<2xindex>} : () -> !tosa.shape<2>
   %size = tosa.const_shape {values = dense<[1, 1]> : tensor<2xindex>} : () -> !tosa.shape<2>
   %slice= tosa.slice %splat, %start, %size : (tensor<3x3xi32>, !tosa.shape<2>, !tosa.shape<2>) -> tensor<1x1xi32>
@@ -958,7 +958,7 @@ func.func @test_slice_resource_no_fold() -> tensor<1x1xi32> {
 // CHECK: func.func @cast_float_to_float
 func.func @cast_float_to_float() -> tensor<f16> {
   %splat = "tosa.const"() {values = dense<42.0> : tensor<f32>} : () -> tensor<f32>
-  // CHECK: %[[SPLAT:.+]] = "tosa.const"() <{values = dense<4.200000e+01> : tensor<f16>}
+  // CHECK: %[[SPLAT:.+]] = tosa.const values(dense<4.200000e+01> : tensor<f16>)
   %cast = tosa.cast %splat {input_unsigned = false} : (tensor<f32>) -> tensor<f16>
   // CHECK: return %[[SPLAT]]
   return %cast : tensor<f16>
@@ -969,7 +969,7 @@ func.func @cast_float_to_float() -> tensor<f16> {
 // CHECK: func.func @cast_int_to_float
 func.func @cast_int_to_float() -> tensor<f16> {
   %splat = "tosa.const"() {values = dense<4> : tensor<i32>} : () -> tensor<i32>
-  // CHECK: %[[SPLAT:.+]] = "tosa.const"() <{values = dense<4.000000e+00> : tensor<f16>}
+  // CHECK: %[[SPLAT:.+]] = tosa.const values(dense<4.000000e+00> : tensor<f16>)
   %cast = tosa.cast %splat {input_unsigned = false} : (tensor<i32>) -> tensor<f16>
   // CHECK: return %[[SPLAT]]
   return %cast : tensor<f16>
@@ -980,7 +980,7 @@ func.func @cast_int_to_float() -> tensor<f16> {
 // CHECK: func.func @cast_signless_to_float_input_unsigned
 func.func @cast_signless_to_float_input_unsigned() -> tensor<f16> {
   %splat = "tosa.const"() {values = dense<200> : tensor<i8>} : () -> tensor<i8>
-  // CHECK: %[[SPLAT:.+]] = "tosa.const"() <{values = dense<2.000000e+02> : tensor<f16>}
+  // CHECK: %[[SPLAT:.+]] = tosa.const values(dense<2.000000e+02> : tensor<f16>)
   %cast = tosa.cast %splat {input_unsigned = true} : (tensor<i8>) -> tensor<f16>
   // CHECK: return %[[SPLAT]]
   return %cast : tensor<f16>
@@ -991,7 +991,7 @@ func.func @cast_signless_to_float_input_unsigned() -> tensor<f16> {
 // CHECK: func.func @cast_int_to_int_input_unsigned
 func.func @cast_int_to_int_input_unsigned() -> tensor<i32> {
   %splat = "tosa.const"() {values = dense<200> : tensor<i8>} : () -> tensor<i8>
-  // CHECK: %[[SPLAT:.+]] = "tosa.const"() <{values = dense<200> : tensor<i32>}
+  // CHECK: %[[SPLAT:.+]] = tosa.const values(dense<200> : tensor<i32>)
   %cast = tosa.cast %splat {input_unsigned = true} : (tensor<i8>) -> tensor<i32>
   // CHECK: return %[[SPLAT]]
   return %cast : tensor<i32>
@@ -1002,7 +1002,7 @@ func.func @cast_int_to_int_input_unsigned() -> tensor<i32> {
 // CHECK: func.func @cast_float_to_int
 func.func @cast_float_to_int() -> tensor<i16> {
   %splat = "tosa.const"() {values = dense<-4.0> : tensor<f32>} : () -> tensor<f32>
-  // CHECK: %[[SPLAT:.+]] = "tosa.const"() <{values = dense<-4> : tensor<i16>}
+  // CHECK: %[[SPLAT:.+]] = tosa.const values(dense<-4> : tensor<i16>)
   %cast = tosa.cast %splat {input_unsigned = false} : (tensor<f32>) -> tensor<i16>
   // CHECK: return %[[SPLAT]]
   return %cast : tensor<i16>
@@ -1013,7 +1013,7 @@ func.func @cast_float_to_int() -> tensor<i16> {
 // CHECK: func.func @cast_float_to_int_round
 func.func @cast_float_to_int_round() -> tensor<i16> {
   %splat = "tosa.const"() {values = dense<-3.5> : tensor<f32>} : () -> tensor<f32>
-  // CHECK: %[[SPLAT:.+]] = "tosa.const"() <{values = dense<-4> : tensor<i16>}
+  // CHECK: %[[SPLAT:.+]] = tosa.const values(dense<-4> : tensor<i16>)
   %cast = tosa.cast %splat {input_unsigned = false} : (tensor<f32>) -> tensor<i16>
   // CHECK: return %[[SPLAT]]
   return %cast : tensor<i16>
@@ -1024,7 +1024,7 @@ func.func @cast_float_to_int_round() -> tensor<i16> {
 // CHECK: func.func @cast_float_to_int_saturates_high
 func.func @cast_float_to_int_saturates_high() -> tensor<i8> {
   %splat = "tosa.const"() {values = dense<1.000000e+20> : tensor<f32>} : () -> tensor<f32>
-  // CHECK: %[[SPLAT:.+]] = "tosa.const"() <{values = dense<127> : tensor<i8>}
+  // CHECK: %[[SPLAT:.+]] = tosa.const values(dense<127> : tensor<i8>)
   %cast = tosa.cast %splat {input_unsigned = false} : (tensor<f32>) -> tensor<i8>
   // CHECK: return %[[SPLAT]]
   return %cast : tensor<i8>
@@ -1035,7 +1035,7 @@ func.func @cast_float_to_int_saturates_high() -> tensor<i8> {
 // CHECK: func.func @cast_float_to_int_saturates_low
 func.func @cast_float_to_int_saturates_low() -> tensor<i8> {
   %splat = "tosa.const"() {values = dense<-1.000000e+20> : tensor<f32>} : () -> tensor<f32>
-  // CHECK: %[[SPLAT:.+]] = "tosa.const"() <{values = dense<-128> : tensor<i8>}
+  // CHECK: %[[SPLAT:.+]] = tosa.const values(dense<-128> : tensor<i8>)
   %cast = tosa.cast %splat {input_unsigned = false} : (tensor<f32>) -> tensor<i8>
   // CHECK: return %[[SPLAT]]
   return %cast : tensor<i8>
@@ -1046,7 +1046,7 @@ func.func @cast_float_to_int_saturates_low() -> tensor<i8> {
 // CHECK: func.func @cast_float_to_unsigned_int_saturates_low
 func.func @cast_float_to_unsigned_int_saturates_low() -> tensor<ui8> {
   %splat = "tosa.const"() {values = dense<-1.000000e+20> : tensor<f32>} : () -> tensor<f32>
-  // CHECK: %[[SPLAT:.+]] = "tosa.const"() <{values = dense<0> : tensor<ui8>}
+  // CHECK: %[[SPLAT:.+]] = tosa.const values(dense<0> : tensor<ui8>)
   %cast = tosa.cast %splat {input_unsigned = false} : (tensor<f32>) -> tensor<ui8>
   // CHECK: return %[[SPLAT]]
   return %cast : tensor<ui8>
@@ -1057,7 +1057,7 @@ func.func @cast_float_to_unsigned_int_saturates_low() -> tensor<ui8> {
 // CHECK: func.func @cast_float_to_unsigned_int_saturates_high
 func.func @cast_float_to_unsigned_int_saturates_high() -> tensor<ui8> {
   %splat = "tosa.const"() {values = dense<1.000000e+20> : tensor<f32>} : () -> tensor<f32>
-  // CHECK: %[[SPLAT:.+]] = "tosa.const"() <{values = dense<255> : tensor<ui8>}
+  // CHECK: %[[SPLAT:.+]] = tosa.const values(dense<255> : tensor<ui8>)
   %cast = tosa.cast %splat {input_unsigned = false} : (tensor<f32>) -> tensor<ui8>
   // CHECK: return %[[SPLAT]]
   return %cast : tensor<ui8>
@@ -1068,7 +1068,7 @@ func.func @cast_float_to_unsigned_int_saturates_high() -> tensor<ui8> {
 // CHECK: func.func @cast_int_to_int_trunc
 func.func @cast_int_to_int_trunc() -> tensor<i16> {
   %splat = "tosa.const"() {values = dense<-1> : tensor<i32>} : () -> tensor<i32>
-  // CHECK: %[[SPLAT:.+]] = "tosa.const"() <{values = dense<-1> : tensor<i16>}
+  // CHECK: %[[SPLAT:.+]] = tosa.const values(dense<-1> : tensor<i16>)
   %cast = tosa.cast %splat {input_unsigned = false} : (tensor<i32>) -> tensor<i16>
   // CHECK: return %[[SPLAT]]
   return %cast : tensor<i16>
@@ -1079,7 +1079,7 @@ func.func @cast_int_to_int_trunc() -> tensor<i16> {
 // CHECK: func.func @cast_int_to_int_sign
 func.func @cast_int_to_int_sign() -> tensor<i32> {
   %splat = "tosa.const"() {values = dense<-1> : tensor<i16>} : () -> tensor<i16>
-  // CHECK: %[[SPLAT:.+]] = "tosa.const"() <{values = dense<-1> : tensor<i32>}
+  // CHECK: %[[SPLAT:.+]] = tosa.const values(dense<-1> : tensor<i32>)
   %cast = tosa.cast %splat {input_unsigned = false} : (tensor<i16>) -> tensor<i32>
   // CHECK: return %[[SPLAT]]
   return %cast : tensor<i32>
@@ -1089,7 +1089,7 @@ func.func @cast_int_to_int_sign() -> tensor<i32> {
 
 // CHECK-LABEL: @reverse_splat
 func.func @reverse_splat() -> tensor<10xi32> {
-  // CHECK: %[[SPLAT:.+]] = "tosa.const"() <{values = dense<42> : tensor<10xi32>}
+  // CHECK: %[[SPLAT:.+]] = tosa.const values(dense<42> : tensor<10xi32>)
   %splat = "tosa.const"() {values = dense<42> : tensor<10xi32>} : () -> tensor<10xi32>
   %reverse = tosa.reverse %splat { axis = 0 : i32 } : (tensor<10xi32>) -> tensor<10xi32>
   // CHECK: return %[[SPLAT]]
@@ -1174,7 +1174,7 @@ func.func @no_fold_select_broadcast_same_value(%arg0: tensor<2x2xi1>, %arg1: ten
 
 // CHECK-LABEL: @no_fold_select_broadcast_true_value
 func.func @no_fold_select_broadcast_true_value(%arg0: tensor<1x1xf32>, %arg1: tensor<2x2xf32>) -> tensor<?x?xf32> {
-  // CHECK: %[[CONST:.*]] = "tosa.const"
+  // CHECK: %[[CONST:.*]] = tosa.const
   %0 = "tosa.const"() {values = dense<1> : tensor<2x2xi1>} : () -> tensor<2x2xi1>
   // CHECK: tosa.select %[[CONST]], %arg0, %arg1
   %1 = tosa.select %0, %arg0, %arg1 : (tensor<2x2xi1>, tensor<1x1xf32>, tensor<2x2xf32>) -> tensor<?x?xf32>
@@ -1185,7 +1185,7 @@ func.func @no_fold_select_broadcast_true_value(%arg0: tensor<1x1xf32>, %arg1: te
 
 // CHECK-LABEL: @no_fold_select_broadcast_false_value
 func.func @no_fold_select_broadcast_false_value(%arg0: tensor<2x2xf32>, %arg1: tensor<1x1xf32>) -> tensor<2x2xf32> {
-  // CHECK: %[[CONST:.*]] = "tosa.const"
+  // CHECK: %[[CONST:.*]] = tosa.const
   %0 = "tosa.const"() {values = dense<0> : tensor<2x2xi1>} : () -> tensor<2x2xi1>
   // CHECK: tosa.select %[[CONST]], %arg0, %arg1
   %1 = tosa.select %0, %arg0, %arg1 : (tensor<2x2xi1>, tensor<2x2xf32>, tensor<1x1xf32>) -> tensor<2x2xf32>
@@ -1196,7 +1196,7 @@ func.func @no_fold_select_broadcast_false_value(%arg0: tensor<2x2xf32>, %arg1: t
 
 // CHECK-LABEL: @no_fold_select_unknown_broadcast_true_value_dynamic_operand
 func.func @no_fold_select_unknown_broadcast_true_value_dynamic_operand(%arg0: tensor<2x?xf32>, %arg1: tensor<2x2xf32>) -> tensor<2x?xf32> {
-  // CHECK: %[[CONST:.*]] = "tosa.const"
+  // CHECK: %[[CONST:.*]] = tosa.const
   %0 = "tosa.const"() {values = dense<1> : tensor<2x2xi1>} : () -> tensor<2x2xi1>
   // CHECK: tosa.select %[[CONST]], %arg0, %arg1
   %1 = tosa.select %0, %arg0, %arg1 : (tensor<2x2xi1>, tensor<2x?xf32>, tensor<2x2xf32>) -> tensor<2x?xf32>
@@ -1207,7 +1207,7 @@ func.func @no_fold_select_unknown_broadcast_true_value_dynamic_operand(%arg0: te
 
 // CHECK-LABEL: @no_fold_select_unknown_broadcast_false_value_dynamic_operand
 func.func @no_fold_select_unknown_broadcast_false_value_dynamic_operand(%arg0: tensor<2x?xf32>, %arg1: tensor<2x2xf32>) -> tensor<2x2xf32> {
-  // CHECK: %[[CONST:.*]] = "tosa.const"
+  // CHECK: %[[CONST:.*]] = tosa.const
   %0 = "tosa.const"() {values = dense<0> : tensor<2x2xi1>} : () -> tensor<2x2xi1>
   // CHECK: tosa.select %[[CONST]], %arg0, %arg1
   %1 = tosa.select %0, %arg0, %arg1 : (tensor<2x2xi1>, tensor<2x?xf32>, tensor<2x2xf32>) -> tensor<2x2xf32>

--- a/mlir/test/Dialect/Tosa/ops.mlir
+++ b/mlir/test/Dialect/Tosa/ops.mlir
@@ -1313,7 +1313,7 @@ func.func @test_rescale_i16_rounding_mode(%arg0 : tensor<2xi8>) -> tensor<2xi16>
 // -----
 // CHECK-LABEL: const
 func.func @test_const(%arg0 : index) -> tensor<4xi32> {
-    %0 = "tosa.const"() {values = dense<[3, 0, 1, 2]> : tensor<4xi32>} : () -> tensor<4xi32>
+    %0 = tosa.const values(dense<[3, 0, 1, 2]> : tensor<4xi32>) : () -> tensor<4xi32>
     return %0 : tensor<4xi32>
 }
 

--- a/mlir/test/Dialect/Tosa/tosa-arith-const-to-tosa-const.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-arith-const-to-tosa-const.mlir
@@ -1,7 +1,7 @@
 // RUN: mlir-opt %s --tosa-arith-const-to-tosa-const --split-input-file | FileCheck %s
 
 // CHECK-LABEL: func.func @rewrite_f32_tensor
-// CHECK: %[[CST:.*]] = "tosa.const"() <{values = dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf32>}> : () -> tensor<2xf32>
+// CHECK: %[[CST:.*]] = tosa.const values(dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf32>) : () -> tensor<2xf32>
 // CHECK: return %[[CST]]
 func.func @rewrite_f32_tensor() -> tensor<2xf32> {
   %c = arith.constant dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf32>
@@ -11,7 +11,7 @@ func.func @rewrite_f32_tensor() -> tensor<2xf32> {
 // -----
 
 // CHECK-LABEL: func.func @rewrite_i32_tensor
-// CHECK: %[[CST:.*]] = "tosa.const"() <{values = dense<[1, 0, -1]> : tensor<3xi32>}> : () -> tensor<3xi32>
+// CHECK: %[[CST:.*]] = tosa.const values(dense<[1, 0, -1]> : tensor<3xi32>) : () -> tensor<3xi32>
 // CHECK: return %[[CST]]
 func.func @rewrite_i32_tensor() -> tensor<3xi32> {
   %c = arith.constant dense<[1, 0, -1]> : tensor<3xi32>
@@ -21,7 +21,7 @@ func.func @rewrite_i32_tensor() -> tensor<3xi32> {
 // -----
 
 // CHECK-LABEL: func.func @rewrite_i1_tensor
-// CHECK: %[[CST:.*]] = "tosa.const"() <{values = dense<[true, false]> : tensor<2xi1>}> : () -> tensor<2xi1>
+// CHECK: %[[CST:.*]] = tosa.const values(dense<[true, false]> : tensor<2xi1>) : () -> tensor<2xi1>
 func.func @rewrite_i1_tensor() -> tensor<2xi1> {
   %c = arith.constant dense<[true, false]> : tensor<2xi1>
   return %c : tensor<2xi1>
@@ -30,7 +30,7 @@ func.func @rewrite_i1_tensor() -> tensor<2xi1> {
 // -----
 
 // CHECK-LABEL: func.func @rewrite_rank0_tensor
-// CHECK: %[[CST:.*]] = "tosa.const"() <{values = dense<1.234500e+00> : tensor<f32>}> : () -> tensor<f32>
+// CHECK: %[[CST:.*]] = tosa.const values(dense<1.234500e+00> : tensor<f32>) : () -> tensor<f32>
 func.func @rewrite_rank0_tensor() -> tensor<f32> {
   %c = arith.constant dense<1.234500e+00> : tensor<f32>
   return %c : tensor<f32>
@@ -57,7 +57,7 @@ func.func @preserve_index_tensor() -> tensor<2xindex> {
 // -----
 
 // CHECK-LABEL: func.func @rewrite_resource_tensor
-// CHECK: %[[CST:.*]] = "tosa.const"() <{values = dense_resource<blob1> : tensor<4xf32>}> : () -> tensor<4xf32>
+// CHECK: %[[CST:.*]] = tosa.const values(dense_resource<blob1> : tensor<4xf32>) : () -> tensor<4xf32>
 func.func @rewrite_resource_tensor() -> tensor<4xf32> {
   %c = arith.constant dense_resource<"blob1"> : tensor<4xf32>
   return %c : tensor<4xf32>
@@ -67,7 +67,7 @@ func.func @rewrite_resource_tensor() -> tensor<4xf32> {
 
 
 // CHECK-LABEL: func.func @rewrite_quant_uniform_tensor
-// CHECK: %[[CST:.*]] = "tosa.const"() <{values = dense<["10", "20"]> : tensor<2x!quant.uniform<i8:f32, 5.000000e-01>>}> : () -> tensor<2x!quant.uniform<i8:f32, 5.000000e-01>>
+// CHECK: %[[CST:.*]] = tosa.const values(dense<["10", "20"]> : tensor<2x!quant.uniform<i8:f32, 5.000000e-01>>) : () -> tensor<2x!quant.uniform<i8:f32, 5.000000e-01>>
 func.func @rewrite_quant_uniform_tensor() -> tensor<2x!quant.uniform<i8:f32, 0.5:0>> {
   %c = arith.constant dense<["10", "20"]> : tensor<2x!quant.uniform<i8:f32, 0.5:0>>
   return %c : tensor<2x!quant.uniform<i8:f32, 0.5:0>>
@@ -76,7 +76,7 @@ func.func @rewrite_quant_uniform_tensor() -> tensor<2x!quant.uniform<i8:f32, 0.5
 // -----
 
 // CHECK-LABEL: func.func @rewrite_fp8_tensor
-// CHECK: %[[CST:.*]] = "tosa.const"() <{values = dense<[1.000000e+00, -5.000000e-01]> : tensor<2xf8E4M3FN>}> : () -> tensor<2xf8E4M3FN>
+// CHECK: %[[CST:.*]] = tosa.const values(dense<[1.000000e+00, -5.000000e-01]> : tensor<2xf8E4M3FN>) : () -> tensor<2xf8E4M3FN>
 func.func @rewrite_fp8_tensor() -> tensor<2xf8E4M3FN> {
   %c = arith.constant dense<[1.0, -0.5]> : tensor<2xf8E4M3FN>
   return %c : tensor<2xf8E4M3FN>
@@ -85,7 +85,7 @@ func.func @rewrite_fp8_tensor() -> tensor<2xf8E4M3FN> {
 // -----
 
 // CHECK-LABEL: func.func @rewrite_mxint8_tensor
-// CHECK: %[[CST:.*]] = "tosa.const"() <{values = dense<["0x00", "0x7F"]> : tensor<2x!tosa.mxint8>}> : () -> tensor<2x!tosa.mxint8>
+// CHECK: %[[CST:.*]] = tosa.const values(dense<["0x00", "0x7F"]> : tensor<2x!tosa.mxint8>) : () -> tensor<2x!tosa.mxint8>
 func.func @rewrite_mxint8_tensor() -> tensor<2x!tosa.mxint8> {
   %c = arith.constant dense<["0x00", "0x7F"]> : tensor<2x!tosa.mxint8>
   return %c : tensor<2x!tosa.mxint8>

--- a/mlir/test/Dialect/Tosa/tosa-convert-integer-type-to-signless.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-convert-integer-type-to-signless.mlir
@@ -33,8 +33,8 @@ func.func @test_rescale_input_unsigned(%arg0: tensor<1x1xui16>) -> (tensor<1x1xi
 // -----
 
 // CHECK-LABEL: test_rescale_unsigned_zp
-// CHECK: %[[ZP_IN:.*]] = "tosa.const"() <{values = dense<-2> : tensor<1xi8>}> : () -> tensor<1xi8>
-// CHECK: %[[ZP_OUT:.*]] = "tosa.const"() <{values = dense<2> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK: %[[ZP_IN:.*]] = tosa.const values(dense<-2> : tensor<1xi8>) : () -> tensor<1xi8>
+// CHECK: %[[ZP_OUT:.*]] = tosa.const values(dense<2> : tensor<1xi8>) : () -> tensor<1xi8>
 // CHECK: tosa.rescale %arg0, %0, %1, %[[ZP_IN]], %[[ZP_OUT]] {input_unsigned = true, output_unsigned = false, per_channel = false, rounding_mode = SINGLE_ROUND, scale32 = true} : (tensor<1x1xi8>, tensor<1xi32>, tensor<1xi8>, tensor<1xi8>, tensor<1xi8>)
 func.func @test_rescale_unsigned_zp(%arg0: tensor<1x1xui8>) -> tensor<1x1xi8> {
   %0 = "tosa.const"() <{values = dense<2> : tensor<1xi32>}> : () -> tensor<1xi32>
@@ -57,7 +57,7 @@ func.func @test_unsigned_function_signature(%arg0: tensor<1xui8>, %arg1: tensor<
 // -----
 
 // CHECK-LABEL: test_unsigned_const_data
-// CHECK: "tosa.const"() <{values = dense<[-1, -2, 0, 1, -128]> : tensor<5xi8>}> : () -> tensor<5xi8>
+// CHECK: tosa.const values(dense<[-1, -2, 0, 1, -128]> : tensor<5xi8>) : () -> tensor<5xi8>
 func.func @test_unsigned_const_data() -> tensor<5xui8> {
   %0 = "tosa.const"() <{values = dense<[255, 254, 0, 1, 128]> : tensor<5xui8>}> : () -> tensor<5xui8>
   return %0 : tensor<5xui8>
@@ -66,7 +66,7 @@ func.func @test_unsigned_const_data() -> tensor<5xui8> {
 // -----
 
 // CHECK-LABEL: test_unsigned_const_data_i16
-// CHECK: "tosa.const"() <{values = dense<[-1, -2, 0, 1, -32768]> : tensor<5xi16>}> : () -> tensor<5xi16>
+// CHECK: tosa.const values(dense<[-1, -2, 0, 1, -32768]> : tensor<5xi16>) : () -> tensor<5xi16>
 func.func @test_unsigned_const_data_i16() -> tensor<5xui16> {
   %0 = "tosa.const"() <{values = dense<[65535, 65534, 0, 1, 32768]> : tensor<5xui16>}> : () -> tensor<5xui16>
   return %0 : tensor<5xui16>
@@ -75,7 +75,7 @@ func.func @test_unsigned_const_data_i16() -> tensor<5xui16> {
 // -----
 
 // CHECK-LABEL: test_unsigned_const_data_i32
-// CHECK: "tosa.const"() <{values = dense<[-1, -2, 0, 1, -2147483648]> : tensor<5xi32>}> : () -> tensor<5xi32>
+// CHECK: tosa.const values(dense<[-1, -2, 0, 1, -2147483648]> : tensor<5xi32>) : () -> tensor<5xi32>
 func.func @test_unsigned_const_data_i32() -> tensor<5xui32> {
   %0 = "tosa.const"() <{values = dense<[4294967295, 4294967294, 0, 1, 2147483648]> : tensor<5xui32>}> : () -> tensor<5xui32>
   return %0 : tensor<5xui32>
@@ -84,7 +84,7 @@ func.func @test_unsigned_const_data_i32() -> tensor<5xui32> {
 // -----
 
 // CHECK-LABEL: test_unsigned_const_data_i48
-// CHECK: "tosa.const"() <{values = dense<[-1, -2, 0, 1, -140737488355328]> : tensor<5xi48>}> : () -> tensor<5xi48>
+// CHECK: tosa.const values(dense<[-1, -2, 0, 1, -140737488355328]> : tensor<5xi48>) : () -> tensor<5xi48>
 func.func @test_unsigned_const_data_i48() -> tensor<5xui48> {
   %0 = "tosa.const"() <{values = dense<[281474976710655, 281474976710654, 0, 1, 140737488355328]> : tensor<5xui48>}> : () -> tensor<5xui48>
   return %0 : tensor<5xui48>

--- a/mlir/test/Dialect/Tosa/tosa-decompose-depthwise.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-decompose-depthwise.mlir
@@ -32,12 +32,12 @@ func.func @depthwise_conv2d_as_mul(%arg0: tensor<4x10x10x2xf32>, %arg1: tensor<1
 // CHECK-LABEL: @depthwise_conv2d_as_mul_q
 func.func @depthwise_conv2d_as_mul_q(%arg0: tensor<4x10x10x2xi8>, %arg1: tensor<1x1x2x3xi8>, %arg2: tensor<6xi32>) -> tensor<4x10x10x6xi32> {
   // CHECK-DAG: %[[CONST0:.+]] = tosa.const_shape {values = dense<[4, 10, 10, 2, 1]> : tensor<5xindex>
-  // CHECK-DAG: %[[INPUT_ZP:.+]] = "tosa.const"() <{values = dense<7> : tensor<1x1x1x1x1xi32>}
-  // CHECK-DAG: %[[WEIGHT_ZP:.+]] = "tosa.const"() <{values = dense<11> : tensor<1x1x1x1xi32>}
+  // CHECK-DAG: %[[INPUT_ZP:.+]] = tosa.const values(dense<7> : tensor<1x1x1x1x1xi32>)
+  // CHECK-DAG: %[[WEIGHT_ZP:.+]] = tosa.const values(dense<11> : tensor<1x1x1x1xi32>)
   // CHECK-DAG: %[[CONST3:.+]] = tosa.const_shape {values = dense<[1, 1, 1, 2, 3]> : tensor<5xindex>
   // CHECK-DAG: %[[CONST4:.+]] = tosa.const_shape {values = dense<[4, 10, 10, 6]> : tensor<4xindex>
   // CHECK-DAG: %[[CONST5:.+]] = tosa.const_shape {values = dense<[1, 1, 1, 6]> : tensor<4xindex>
-  // CHECK-DAG: %[[SHIFT:.*]] = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+  // CHECK-DAG: %[[SHIFT:.*]] = tosa.const values(dense<0> : tensor<1xi8>) : () -> tensor<1xi8>
   // CHECK: %[[RESHAPE_I:.+]] = tosa.reshape %arg0, %[[CONST0]]
   // CHECK: %[[CAST_I:.+]] = tosa.cast %[[RESHAPE_I]] : (tensor<4x10x10x2x1xi8>) -> tensor<4x10x10x2x1xi32>
   // CHECK: %[[CAST_W:.+]] = tosa.cast %arg1 : (tensor<1x1x2x3xi8>) -> tensor<1x1x2x3xi32>
@@ -60,11 +60,11 @@ func.func @depthwise_conv2d_as_mul_q(%arg0: tensor<4x10x10x2xi8>, %arg1: tensor<
 func.func @depthwise_conv2d_as_mul_padded(%arg0: tensor<4x10x10x2xf32>, %arg1: tensor<1x1x2x3xf32>, %arg2: tensor<6xf32>) -> tensor<4x12x12x6xf32> {
   // CHECK-DAG: %[[CONST0:.+]] = tosa.const_shape {values = dense<[4, 10, 10, 2, 1]> : tensor<5xindex>}
   // CHECK-DAG: %[[PAD:.+]] = tosa.const_shape  {values = dense<[0, 0, 1, 1, 1, 1, 0, 0, 0, 0]> : tensor<10xindex>} : () -> !tosa.shape<10>
-  // CHECK-DAG: %[[ZERO:.+]] = "tosa.const"() <{values = dense<0.000000e+00> : tensor<1xf32>}
+  // CHECK-DAG: %[[ZERO:.+]] = tosa.const values(dense<0.000000e+00> : tensor<1xf32>)
   // CHECK-DAG: %[[CONST3:.+]] = tosa.const_shape {values = dense<[1, 1, 1, 2, 3]> : tensor<5xindex>}
   // CHECK-DAG: %[[CONST4:.+]] = tosa.const_shape {values = dense<[4, 12, 12, 6]> : tensor<4xindex>}
   // CHECK-DAG: %[[CONST5:.+]] = tosa.const_shape {values = dense<[1, 1, 1, 6]> : tensor<4xindex>}
-  // CHECK-DAG: %[[SHIFT:.*]] = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+  // CHECK-DAG: %[[SHIFT:.*]] = tosa.const values(dense<0> : tensor<1xi8>) : () -> tensor<1xi8>
   // CHECK: %[[RESHAPE_I:.+]] = tosa.reshape %arg0, %[[CONST0]]
   // CHECK: %[[PAD_I:.+]] = tosa.pad %[[RESHAPE_I]], %[[PAD]], %[[ZERO]] : (tensor<4x10x10x2x1xf32>, !tosa.shape<10>, tensor<1xf32>) -> tensor<4x12x12x2x1xf32>
   // CHECK: %[[RESHAPE_ARG1:.+]] = tosa.reshape %arg1, %[[CONST3]]
@@ -106,7 +106,7 @@ func.func @depthwise_conv2d_no_const_zero_point(%arg0: tensor<4x10x10x2xi8>, %ar
 // CHECK-SAME:      %[[BIAS:.*]]: tensor<?xf32>) -> tensor<?x10x10x6xf32> {
 // CHECK:           %[[BIAS_EXPANDED_SHAPE:.*]] = tosa.const_shape  {values = dense<[1, 1, 1, -1]> : tensor<4xindex>} : () -> !tosa.shape<4>
 // CHECK:           %[[RES_EXPANDED_SHAPE:.*]] = tosa.const_shape  {values = dense<[-1, 10, 10, 6]> : tensor<4xindex>} : () -> !tosa.shape<4>
-// CHECK:           %[[MUL_SHIFT:.*]] = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           %[[MUL_SHIFT:.*]] = tosa.const values(dense<0> : tensor<1xi8>) : () -> tensor<1xi8>
 // CHECK:           %[[WTS_EXPANDED_SHAPE:.*]] = tosa.const_shape  {values = dense<[1, 1, 1, 2, 3]> : tensor<5xindex>} : () -> !tosa.shape<5>
 // CHECK:           %[[INP_EXPANDED_SHAPE:.*]] = tosa.const_shape  {values = dense<[-1, 10, 10, 2, 1]> : tensor<5xindex>} : () -> !tosa.shape<5>
 // CHECK:           %[[INP_RESHAPED:.*]] = tosa.reshape %[[INP]], %[[INP_EXPANDED_SHAPE]] : (tensor<?x10x10x2xf32>, !tosa.shape<5>) -> tensor<?x10x10x2x1xf32>

--- a/mlir/test/Dialect/Tosa/tosa-decompose-transpose-conv.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-decompose-transpose-conv.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: @transpose_conv2d
 func.func @transpose_conv2d(%arg0: tensor<2x16x14x3xf32>, %arg1: tensor<5x3x6x3xf32>, %arg2: tensor<5xf32>) -> tensor<2x18x19x5xf32> {
-  // CHECK-DAG: %[[ZP:.+]] = "tosa.const"() <{values = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
+  // CHECK-DAG: %[[ZP:.+]] = tosa.const values(dense<0.000000e+00> : tensor<1xf32>) : () -> tensor<1xf32>
   // CHECK: %[[REV1:.+]] = tosa.reverse %arg1 {axis = 1 : i32}
   // CHECK: %[[REV2:.+]] = tosa.reverse %[[REV1]] {axis = 2 : i32}
   // CHECK: tosa.conv2d %arg0, %[[REV2]], %arg2, %[[ZP]], %[[ZP]]
@@ -17,8 +17,8 @@ func.func @transpose_conv2d(%arg0: tensor<2x16x14x3xf32>, %arg1: tensor<5x3x6x3x
 // CHECK-LABEL: @transpose_conv2d_quantized
 
 func.func @transpose_conv2d_quantized(%arg0: tensor<2x16x14x3xi8>, %arg1: tensor<5x3x6x3xi8>, %arg2: tensor<5xi32>) -> (tensor<2x18x19x5xi32>) {
-  // CHECK-DAG: %[[INPUT_ZP:.+]]  = "tosa.const"() <{values = dense<-6> : tensor<1xi8>}
-  // CHECK-DAG: %[[WEIGHT_ZP:.+]]  = "tosa.const"() <{values = dense<11> : tensor<1xi8>}
+  // CHECK-DAG: %[[INPUT_ZP:.+]]  = tosa.const values(dense<-6> : tensor<1xi8>)
+  // CHECK-DAG: %[[WEIGHT_ZP:.+]]  = tosa.const values(dense<11> : tensor<1xi8>)
   // CHECK: %[[REV1:.+]] = tosa.reverse %arg1 {axis = 1 : i32}
   // CHECK: %[[REV2:.+]] = tosa.reverse %[[REV1]] {axis = 2 : i32}
   // CHECK: tosa.conv2d %arg0, %[[REV2]], %arg2, %[[INPUT_ZP]], %[[WEIGHT_ZP]] {acc_type = i32, dilation = array<i64: 1, 1>, pad = array<i64: 2, 2, 5, 5>, stride = array<i64: 1, 1>}
@@ -32,8 +32,8 @@ func.func @transpose_conv2d_quantized(%arg0: tensor<2x16x14x3xi8>, %arg1: tensor
 
 // CHECK-LABEL: @transpose_conv2d_quantized_padded
 func.func @transpose_conv2d_quantized_padded(%arg0: tensor<2x16x14x3xi8>, %arg1: tensor<5x3x6x3xi8>, %arg2: tensor<5xi32>) -> (tensor<2x21x26x5xi32>) {
-  // CHECK-DAG: %[[INPUT_ZP:.+]] = "tosa.const"() <{values = dense<-22> : tensor<1xi8>}> : () -> tensor<1xi8>
-  // CHECK-DAG: %[[WEIGHT_ZP:.+]] = "tosa.const"() <{values = dense<42> : tensor<1xi8>}> : () -> tensor<1xi8>
+  // CHECK-DAG: %[[INPUT_ZP:.+]] = tosa.const values(dense<-22> : tensor<1xi8>) : () -> tensor<1xi8>
+  // CHECK-DAG: %[[WEIGHT_ZP:.+]] = tosa.const values(dense<42> : tensor<1xi8>) : () -> tensor<1xi8>
   // CHECK-DAG: %[[REV0:.+]] = tosa.reverse %arg1 {axis = 1 : i32}
   // CHECK-DAG: %[[REV1:.+]] = tosa.reverse %[[REV0]] {axis = 2 : i32}
   // CHECK: tosa.conv2d %arg0, %[[REV1]], %arg2, %[[INPUT_ZP]], %[[WEIGHT_ZP]] {acc_type = i32, dilation = array<i64: 1, 1>, pad = array<i64: 3, 4, 8, 9>, stride = array<i64: 1, 1>}
@@ -69,8 +69,8 @@ func.func @transpose_conv2d_strided(%arg0: tensor<2x17x15x3xf32>, %arg1: tensor<
   // CHECK-DAG: %[[NEWINPUT:.+]] = tosa.pad %arg0, %[[PAD]]
 
   // Manipulate the final shape.
-  // CHECK-DAG: %[[ZP:.+]] = "tosa.const"() <{values = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
-  // CHECK-DAG: %[[BIAS:.+]]  = "tosa.const"() <{values = dense<0.000000e+00> : tensor<30xf32>}
+  // CHECK-DAG: %[[ZP:.+]] = tosa.const values(dense<0.000000e+00> : tensor<1xf32>) : () -> tensor<1xf32>
+  // CHECK-DAG: %[[BIAS:.+]]  = tosa.const values(dense<0.000000e+00> : tensor<30xf32>)
   // CHECK-DAG: %[[CONV:.+]] = tosa.conv2d %[[NEWINPUT]], %[[NEWWEIGHT]], %[[BIAS]], %[[ZP]], %[[ZP]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
   // CHECK-DAG: %[[CONST6:.+]] = tosa.const_shape {values = dense<[2, 18, 16, 2, 3, 5]> : tensor<6xindex>}
   // CHECK-DAG: %[[RESHAPE_OUT_1:.+]] = tosa.reshape %[[CONV]], %[[CONST6]]
@@ -93,8 +93,8 @@ func.func @transpose_conv2d_strided(%arg0: tensor<2x17x15x3xf32>, %arg1: tensor<
 
 func.func @transpose_conv2d_strided_quantized(%arg0: tensor<2x17x15x3xi8>, %arg1: tensor<5x3x5x3xi8>, %arg2: tensor<5xi32>) -> (tensor<2x35x47x5xi32>) {
   // Manipulate the weight matrix to handle striding.
-  // CHECK-DAG: %[[INPUT_ZP:.+]] = "tosa.const"() <{values = dense<-22> : tensor<1xi8>}> : () -> tensor<1xi8>
-  // CHECK-DAG: %[[WEIGHT_ZP:.+]] = "tosa.const"() <{values = dense<42> : tensor<1xi8>}> : () -> tensor<1xi8>
+  // CHECK-DAG: %[[INPUT_ZP:.+]] = tosa.const values(dense<-22> : tensor<1xi8>) : () -> tensor<1xi8>
+  // CHECK-DAG: %[[WEIGHT_ZP:.+]] = tosa.const values(dense<42> : tensor<1xi8>) : () -> tensor<1xi8>
   // CHECK-DAG: %[[PADV:.+]]  = tosa.const_shape {values = dense<[0, 0, 0, 1, 0, 1, 0, 0]> : tensor<8xindex>} : () -> !tosa.shape<8>
   // CHECK-DAG: %[[PADW:.+]]  = tosa.pad %arg1, %[[PADV]], %[[WEIGHT_ZP]]
   // CHECK-DAG: %[[CONST1:.+]] = tosa.const_shape {values = dense<[5, 2, 2, 2, 3, 3]> : tensor<6xindex>}
@@ -110,7 +110,7 @@ func.func @transpose_conv2d_strided_quantized(%arg0: tensor<2x17x15x3xi8>, %arg1
   // CHECK-DAG: %[[NEWINPUT:.+]] = tosa.pad %arg0, %[[PAD]], %[[INPUT_ZP]]
 
   // Manipulate the final shape.
-  // CHECK-DAG: %[[BIAS:.+]]  = "tosa.const"() <{values = dense<0> : tensor<30xi32>}
+  // CHECK-DAG: %[[BIAS:.+]]  = tosa.const values(dense<0> : tensor<30xi32>)
   // CHECK-DAG: %[[CONV:.+]] = tosa.conv2d %[[NEWINPUT]], %[[NEWWEIGHT]], %[[BIAS]], %[[INPUT_ZP]], %[[WEIGHT_ZP]] {acc_type = i32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
   // CHECK-DAG: %[[CONST6:.+]] = tosa.const_shape {values = dense<[2, 18, 16, 2, 3, 5]> : tensor<6xindex>}
   // CHECK-DAG: %[[RESHAPE_OUT_1:.+]] = tosa.reshape %[[CONV]], %[[CONST6]]
@@ -135,7 +135,7 @@ func.func @transpose_conv2d_strided_quantized(%arg0: tensor<2x17x15x3xi8>, %arg1
 func.func @transpose_conv2d_strided_quantized_quant_input(%arg0: tensor<2x17x15x3x!quant.uniform<i8:f32, 0.015684274956583977:-1>>, %arg1: tensor<5x3x5x3x!quant.uniform<i8:f32, 0.015684274956583977:-1>>, %arg2: tensor<5xi32>) -> (tensor<2x35x47x5xi32>) {
   // Checks a regression. A typo in `createPadConstTensor` caused the conversion to crash
   // CHECK-DAG: %[[PAD_SHAPE:.+]] = tosa.const_shape {values = dense<[0, 0, 1, 1, 1, 1, 0, 0]> : tensor<8xindex>} : () -> !tosa.shape<8>
-  // CHECK-DAG: %[[PAD_CONST:.+]] = "tosa.const"() <{values = dense<-22> : tensor<1xi8>}> : () -> tensor<1x!quant.uniform<i8:f32, 0.015684274956583977:-1>>
+  // CHECK-DAG: %[[PAD_CONST:.+]] = tosa.const values(dense<-22> : tensor<1xi8>) : () -> tensor<1x!quant.uniform<i8:f32, 0.015684274956583977:-1>>
   // CHECK: %[[PAD:.+]] = tosa.pad %arg0, %[[PAD_SHAPE]], %[[PAD_CONST]] : (tensor<2x17x15x3x!quant.uniform<i8:f32, 0.015684274956583977:-1>>, !tosa.shape<8>, tensor<1x!quant.uniform<i8:f32, 0.015684274956583977:-1>>)
   %input_zp = "tosa.const"() <{values = dense<-22> : tensor<1xi8>}> : () -> tensor<1xi8>
   %weight_zp = "tosa.const"() <{values = dense<42> : tensor<1xi8>}> : () -> tensor<1xi8>
@@ -149,11 +149,11 @@ func.func @transpose_conv2d_strided_quantized_quant_input(%arg0: tensor<2x17x15x
 func.func @transpose_conv2d_strided_overpad(%arg0 : tensor<1x16x1x1xi8>, %arg1 : tensor<1x2x1x1xi8>, %arg2 : tensor<1xi32>) -> (tensor<1x19x2x1xi32>) {
   // CHECK-DAG: %[[WEIGHT_PAD:.+]] = tosa.const_shape {values = dense<[0, 0, 0, 0, 0, 1, 0, 0]> : tensor<8xindex>} : () -> !tosa.shape<8>
   // CHECK-DAG: %[[CONST1:.+]] = tosa.const_shape {values = dense<[1, 2, 1, 1, 2, 1]> : tensor<6xindex>}
-  // CHECK-DAG: %[[INPUT_ZP:.+]] = "tosa.const"() <{values = dense<-103> : tensor<1xi8>}> : () -> tensor<1xi8>
-  // CHECK-DAG: %[[WEIGHT_ZP:.+]] = "tosa.const"() <{values = dense<93> : tensor<1xi8>}> : () -> tensor<1xi8>
+  // CHECK-DAG: %[[INPUT_ZP:.+]] = tosa.const values(dense<-103> : tensor<1xi8>) : () -> tensor<1xi8>
+  // CHECK-DAG: %[[WEIGHT_ZP:.+]] = tosa.const values(dense<93> : tensor<1xi8>) : () -> tensor<1xi8>
   // CHECK-DAG: %[[CONST3:.+]] = tosa.const_shape {values = dense<[2, 2, 1, 1]> : tensor<4xindex>}
   // CHECK-DAG: %[[INPUT_PAD:.+]] = tosa.const_shape {values = dense<[0, 0, 1, 1, 0, 0, 0, 0]> : tensor<8xindex>} : () -> !tosa.shape<8>
-  // CHECK-DAG: %[[ZERO:.+]] = "tosa.const"() <{values = dense<0> : tensor<2xi32>}
+  // CHECK-DAG: %[[ZERO:.+]] = tosa.const values(dense<0> : tensor<2xi32>)
   // CHECK-DAG: %[[CONST6:.+]] = tosa.const_shape {values = dense<[1, 17, 1, 1, 2, 1]> : tensor<6xindex>}
   // CHECK-DAG: %[[CONST8:.+]] = tosa.const_shape {values = dense<[1, 17, 2, 1]> : tensor<4xindex>}
   // CHECK-DAG: %[[RESULT_PAD:.+]] = tosa.const_shape {values = dense<[0, 0, 2, 0, 0, 0, 0, 0]> : tensor<8xindex>} : () -> !tosa.shape<8>

--- a/mlir/test/Dialect/Tosa/tosa-infer-shapes.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-infer-shapes.mlir
@@ -100,10 +100,10 @@ func.func @test_unary_i32(%arg0 : tensor<4xi32>, %arg1 : tensor<2xi8>) -> () {
   // CHECK: tosa.reverse %arg0 {axis = 0 : i32} : (tensor<4xi32>) -> tensor<4xi32>
   %5 = tosa.reverse %arg0 { axis = 0 : i32 } : (tensor<4xi32>) -> tensor<?xi32>
 
-  // CHECK-DAG: %[[MULT:.+]] = "tosa.const"() <{values = dense<[42, 43]> : tensor<2xi16>}> : () -> tensor<2xi16>
-  // CHECK-DAG: %[[SHIFT:.+]] = "tosa.const"() <{values = dense<[14, 15]> : tensor<2xi8>}> : () -> tensor<2xi8>
-  // CHECK-DAG: %[[INPUTZP:.+]] = "tosa.const"() <{values = dense<43> : tensor<1xi8>}> : () -> tensor<1xi8>
-  // CHECK-DAG: %[[OUTPUTZP:.+]] = "tosa.const"() <{values = dense<52> : tensor<1xi8>}> : () -> tensor<1xi8>
+  // CHECK-DAG: %[[MULT:.+]] = tosa.const values(dense<[42, 43]> : tensor<2xi16>) : () -> tensor<2xi16>
+  // CHECK-DAG: %[[SHIFT:.+]] = tosa.const values(dense<[14, 15]> : tensor<2xi8>) : () -> tensor<2xi8>
+  // CHECK-DAG: %[[INPUTZP:.+]] = tosa.const values(dense<43> : tensor<1xi8>) : () -> tensor<1xi8>
+  // CHECK-DAG: %[[OUTPUTZP:.+]] = tosa.const values(dense<52> : tensor<1xi8>) : () -> tensor<1xi8>
   // CHECK: tosa.rescale %arg1, %[[MULT]], %[[SHIFT]], %[[INPUTZP]], %[[OUTPUTZP]] {{.+}} : (tensor<2xi8>, tensor<2xi16>, tensor<2xi8>, tensor<1xi8>, tensor<1xi8>) -> tensor<2xi8>
   %multiplier = "tosa.const"() {values = dense<[42, 43]> : tensor<2xi16>} : () -> tensor<2xi16>
   %shift = "tosa.const"() {values = dense<[14, 15]> : tensor<2xi8>} : () -> tensor<2xi8>
@@ -1892,7 +1892,7 @@ func.func @test_multiple_non_inferrable_consumers(%arg0: tensor<1x2x8xf32>) {
 // -----
 // CHECK-LABEL: test_mul_scalar
 func.func @test_mul_scalar(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<*xf32> {
-  // CHECK: %[[SHIFT:.*]] = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+  // CHECK: %[[SHIFT:.*]] = tosa.const values(dense<0> : tensor<1xi8>) : () -> tensor<1xi8>
   // CHECK: tosa.mul %arg0, %arg1, %[[SHIFT]] : (tensor<f32>, tensor<f32>, tensor<1xi8>) -> tensor<f32>
   %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
   %0 = tosa.mul %arg0, %arg1, %shift : (tensor<f32>, tensor<f32>, tensor<1xi8>) -> tensor<*xf32>

--- a/mlir/test/Dialect/Tosa/tosa-layerwise-constant-fold-dense-resource.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-layerwise-constant-fold-dense-resource.mlir
@@ -26,8 +26,8 @@ func.func @transpose_fold_dense_resource() -> tensor<2x2xf32> {
 func.func @transpose_fold_dense_resource_f8e4m3fn() -> tensor<2x2xf8E4M3FN> {
   %0 = "tosa.const"() <{values = dense_resource<resource> : tensor<2x2xf8E4M3FN>}> : () -> tensor<2x2xf8E4M3FN>
 
-  //               CHECK: %[[CST:.+]] = "tosa.const"() <{
-  // CHECK-SAME{LITERAL}: values = dense<[[1.000000e+00, 3.000000e+00], [2.000000e+00, 4.000000e+00]]> : tensor<2x2xf8E4M3FN>
+  //               CHECK: %[[CST:.+]] = tosa.const values(
+  // CHECK-SAME{LITERAL}: dense<[[1.000000e+00, 3.000000e+00], [2.000000e+00, 4.000000e+00]]> : tensor<2x2xf8E4M3FN>
   %1 = tosa.transpose %0 { perms = array<i32: 1, 0> }: (tensor<2x2xf8E4M3FN>) -> tensor<2x2xf8E4M3FN>
   // CHECK: return %[[CST]]
   return %1 : tensor<2x2xf8E4M3FN>
@@ -46,8 +46,8 @@ func.func @transpose_fold_dense_resource_f8e4m3fn() -> tensor<2x2xf8E4M3FN> {
 func.func @transpose_fold_dense_resource_f8e5m2() -> tensor<2x2xf8E5M2> {
   %0 = "tosa.const"() <{values = dense_resource<resource> : tensor<2x2xf8E5M2>}> : () -> tensor<2x2xf8E5M2>
 
-  //               CHECK: %[[CST:.+]] = "tosa.const"() <{
-  // CHECK-SAME{LITERAL}: values = dense<[[1.000000e+00, 3.000000e+00], [2.000000e+00, 4.000000e+00]]> : tensor<2x2xf8E5M2>
+  //               CHECK: %[[CST:.+]] = tosa.const values(
+  // CHECK-SAME{LITERAL}: dense<[[1.000000e+00, 3.000000e+00], [2.000000e+00, 4.000000e+00]]> : tensor<2x2xf8E5M2>
   %1 = tosa.transpose %0 { perms = array<i32: 1, 0> }: (tensor<2x2xf8E5M2>) -> tensor<2x2xf8E5M2>
   // CHECK: return %[[CST]]
   return %1 : tensor<2x2xf8E5M2>
@@ -66,8 +66,8 @@ func.func @transpose_fold_dense_resource_f8e5m2() -> tensor<2x2xf8E5M2> {
 func.func @transpose_fold_dense_resource_f4e2m1fn() -> tensor<2x2xf4E2M1FN> {
   %0 = "tosa.const"() <{values = dense_resource<resource> : tensor<2x2xf4E2M1FN>}> : () -> tensor<2x2xf4E2M1FN>
 
-  //               CHECK: %[[CST:.+]] = "tosa.const"() <{
-  // CHECK-SAME{LITERAL}: values = dense<[[1.000000e+00, 3.000000e+00], [2.000000e+00, 4.000000e+00]]> : tensor<2x2xf4E2M1FN>
+  //               CHECK: %[[CST:.+]] = tosa.const values(
+  // CHECK-SAME{LITERAL}: dense<[[1.000000e+00, 3.000000e+00], [2.000000e+00, 4.000000e+00]]> : tensor<2x2xf4E2M1FN>
   %1 = tosa.transpose %0 { perms = array<i32: 1, 0> }: (tensor<2x2xf4E2M1FN>) -> tensor<2x2xf4E2M1FN>
   // CHECK: return %[[CST]]
   return %1 : tensor<2x2xf4E2M1FN>
@@ -86,8 +86,8 @@ func.func @transpose_fold_dense_resource_f4e2m1fn() -> tensor<2x2xf4E2M1FN> {
 func.func @transpose_fold_dense_resource_f16() -> tensor<2x2xf16> {
   %0 = "tosa.const"() <{values = dense_resource<resource> : tensor<2x2xf16>}> : () -> tensor<2x2xf16>
 
-  //               CHECK: %[[CST:.+]] = "tosa.const"() <{
-  // CHECK-SAME{LITERAL}: values = dense<[[1.000000e+00, 3.000000e+00], [2.000000e+00, 4.000000e+00]]> : tensor<2x2xf16>
+  //               CHECK: %[[CST:.+]] = tosa.const values(
+  // CHECK-SAME{LITERAL}: dense<[[1.000000e+00, 3.000000e+00], [2.000000e+00, 4.000000e+00]]> : tensor<2x2xf16>
   %1 = tosa.transpose %0 { perms = array<i32: 1, 0> }: (tensor<2x2xf16>) -> tensor<2x2xf16>
   // CHECK: return %[[CST]]
   return %1 : tensor<2x2xf16>
@@ -106,8 +106,8 @@ func.func @transpose_fold_dense_resource_f16() -> tensor<2x2xf16> {
 func.func @transpose_fold_dense_resource_bf16() -> tensor<2x2xbf16> {
   %0 = "tosa.const"() <{values = dense_resource<resource> : tensor<2x2xbf16>}> : () -> tensor<2x2xbf16>
 
-  //               CHECK: %[[CST:.+]] = "tosa.const"() <{
-  // CHECK-SAME{LITERAL}: values = dense<[[1.000000e+00, 3.000000e+00], [2.000000e+00, 4.000000e+00]]> : tensor<2x2xbf16>
+  //               CHECK: %[[CST:.+]] = tosa.const values(
+  // CHECK-SAME{LITERAL}: dense<[[1.000000e+00, 3.000000e+00], [2.000000e+00, 4.000000e+00]]> : tensor<2x2xbf16>
   %1 = tosa.transpose %0 { perms = array<i32: 1, 0> }: (tensor<2x2xbf16>) -> tensor<2x2xbf16>
   // CHECK: return %[[CST]]
   return %1 : tensor<2x2xbf16>
@@ -126,8 +126,8 @@ func.func @transpose_fold_dense_resource_bf16() -> tensor<2x2xbf16> {
 func.func @transpose_fold_dense_resource_f64() -> tensor<2x2xf64> {
   %0 = "tosa.const"() <{values = dense_resource<resource> : tensor<2x2xf64>}> : () -> tensor<2x2xf64>
 
-  //               CHECK: %[[CST:.+]] = "tosa.const"() <{
-  // CHECK-SAME{LITERAL}: values = dense<[[1.000000e+00, 3.000000e+00], [2.000000e+00, 4.000000e+00]]> : tensor<2x2xf64>
+  //               CHECK: %[[CST:.+]] = tosa.const values(
+  // CHECK-SAME{LITERAL}: dense<[[1.000000e+00, 3.000000e+00], [2.000000e+00, 4.000000e+00]]> : tensor<2x2xf64>
   %1 = tosa.transpose %0 { perms = array<i32: 1, 0> }: (tensor<2x2xf64>) -> tensor<2x2xf64>
   // CHECK: return %[[CST]]
   return %1 : tensor<2x2xf64>

--- a/mlir/test/Dialect/Tosa/tosa-layerwise-constant-fold.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-layerwise-constant-fold.mlir
@@ -3,7 +3,7 @@
 
 // CHECK-LABEL: @armax_fold_dim_size_1
 func.func @armax_fold_dim_size_1(%arg0: tensor<2x1x3xf32>) -> tensor<2x3xi32> {
-  // CHECK: "tosa.const"() <{values = dense<0> : tensor<2x3xi32>}> : () -> tensor<2x3xi32>
+  // CHECK: tosa.const values(dense<0> : tensor<2x3xi32>) : () -> tensor<2x3xi32>
   %0 = tosa.argmax %arg0 {axis = 1 : i32}: (tensor<2x1x3xf32>) -> tensor<2x3xi32>
   return %0 : tensor<2x3xi32>
 }
@@ -68,8 +68,8 @@ func.func @reciprocal_nofold_unranked_result() -> tensor<*xf32> {
 // CHECK-LABEL: @transpose_fold_splat
 func.func @transpose_fold_splat() -> tensor<3x2xf32> {
   %input = "tosa.const"() {values = dense<4.0> : tensor<2x3xf32>} : () -> tensor<2x3xf32>
-  //               CHECK: %[[CST:.+]] = "tosa.const"() <{
-  // CHECK-SAME{LITERAL}: values = dense<4.000000e+00> : tensor<3x2xf32>
+  //               CHECK: %[[CST:.+]] = tosa.const values(
+  // CHECK-SAME{LITERAL}: dense<4.000000e+00> : tensor<3x2xf32>
   %1 = tosa.transpose %input { perms = array<i32: 1, 0> }: (tensor<2x3xf32>) -> tensor<3x2xf32>
   // CHECK: return %[[CST]]
   return %1 : tensor<3x2xf32>
@@ -80,8 +80,8 @@ func.func @transpose_fold_splat() -> tensor<3x2xf32> {
 // CHECK-LABEL: @transpose_fold_2d_float
 func.func @transpose_fold_2d_float() -> tensor<3x2xf32> {
   %input = "tosa.const"() {values = dense<[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]> : tensor<2x3xf32>} : () -> tensor<2x3xf32>
-  //               CHECK: %[[CST:.+]] = "tosa.const"() <{
-  // CHECK-SAME{LITERAL}: values = dense<[[0.000000e+00, 3.000000e+00], [1.000000e+00, 4.000000e+00], [2.000000e+00, 5.000000e+00]]> : tensor<3x2xf32>
+  //               CHECK: %[[CST:.+]] = tosa.const values(
+  // CHECK-SAME{LITERAL}: dense<[[0.000000e+00, 3.000000e+00], [1.000000e+00, 4.000000e+00], [2.000000e+00, 5.000000e+00]]> : tensor<3x2xf32>
   %1 = tosa.transpose %input { perms = array<i32: 1, 0> }: (tensor<2x3xf32>) -> tensor<3x2xf32>
   // CHECK: return %[[CST]]
   return %1 : tensor<3x2xf32>
@@ -92,8 +92,8 @@ func.func @transpose_fold_2d_float() -> tensor<3x2xf32> {
 // CHECK-LABEL: @transpose_fold_2d_bool
 func.func @transpose_fold_2d_bool() -> tensor<3x2xi1> {
   %input = "tosa.const"() {values = dense<[[true, false, false], [false, false, true]]> : tensor<2x3xi1>} : () -> tensor<2x3xi1>
-  //               CHECK: %[[CST:.+]] = "tosa.const"() <{
-  // CHECK-SAME{LITERAL}: values = dense<[[true, false], [false, false], [false, true]]> : tensor<3x2xi1>
+  //               CHECK: %[[CST:.+]] = tosa.const values(
+  // CHECK-SAME{LITERAL}: dense<[[true, false], [false, false], [false, true]]> : tensor<3x2xi1>
   %1 = tosa.transpose %input { perms = array<i32: 1, 0> }: (tensor<2x3xi1>) -> tensor<3x2xi1>
   // CHECK: return %[[CST]]
   return %1 : tensor<3x2xi1>
@@ -107,8 +107,8 @@ func.func @transpose_fold_4d_int() -> tensor<3x1x4x2xi32> {
     [[ 0,  1,  2,  3], [ 4,  5,  6,  7], [ 8,  9, 10, 11]],
     [[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]]
   ]]> : tensor<1x2x3x4xi32>} : () -> tensor<1x2x3x4xi32>
-  //               CHECK: %[[CST:.+]] = "tosa.const"() <{
-  // CHECK-SAME{LITERAL}: values = dense<[
+  //               CHECK: %[[CST:.+]] = tosa.const values(
+  // CHECK-SAME{LITERAL}: dense<[
   // CHECK-SAME{LITERAL}:   [[[0, 12], [1, 13], [2, 14], [3, 15]]],
   // CHECK-SAME{LITERAL}:   [[[4, 16], [5, 17], [6, 18], [7, 19]]],
   // CHECK-SAME{LITERAL}:   [[[8, 20], [9, 21], [10, 22], [11, 23]]]
@@ -151,7 +151,7 @@ func.func @transpose_nofold_quantized_types() -> tensor<1x1x2x2x!quant.uniform<i
 
   func.func @reduce_sum_constant() -> tensor<1x3xi32> {
     // CHECK-LABEL:   func.func @reduce_sum_constant() -> tensor<1x3xi32> {
-    // CHECK:    %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}5, 7, 9]]> : tensor<1x3xi32>}> : () -> tensor<1x3xi32>
+    // CHECK:    %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}5, 7, 9]]> : tensor<1x3xi32>) : () -> tensor<1x3xi32>
     // CHECK:         return %[[VAL_0]] : tensor<1x3xi32>
 
     %const = "tosa.const"() {values = dense<[[1,2,3], [4,5,6]]> : tensor<2x3xi32>} : () -> tensor<2x3xi32>
@@ -163,7 +163,7 @@ func.func @transpose_nofold_quantized_types() -> tensor<1x1x2x2x!quant.uniform<i
 
   func.func @reduce_sum_constant() -> tensor<2x1xi32> {
   // CHECK-LABEL:   func.func @reduce_sum_constant() -> tensor<2x1xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}6], [15]]> : tensor<2x1xi32>}> : () -> tensor<2x1xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}6], [15]]> : tensor<2x1xi32>) : () -> tensor<2x1xi32>
   // CHECK:           return %[[VAL_0]] : tensor<2x1xi32>
   // CHECK:         }
     %const = "tosa.const"() <{values = dense<[[1,2,3], [4,5,6]]> : tensor<2x3xi32>}> : () -> tensor<2x3xi32>
@@ -176,7 +176,7 @@ func.func @transpose_nofold_quantized_types() -> tensor<1x1x2x2x!quant.uniform<i
 
 func.func @reduce_sum_constant() -> tensor<3x1xi32> {
   // CHECK-LABEL:   func.func @reduce_sum_constant() -> tensor<3x1xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}6], [15], [24]]> : tensor<3x1xi32>}> : () -> tensor<3x1xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}6], [15], [24]]> : tensor<3x1xi32>) : () -> tensor<3x1xi32>
   // CHECK:           return %[[VAL_0]] : tensor<3x1xi32>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[1, 2, 3], [4, 5, 6], [7, 8, 9]]> : tensor<3x3xi32>}> : () -> tensor<3x3xi32>
@@ -188,7 +188,7 @@ func.func @reduce_sum_constant() -> tensor<3x1xi32> {
 
 func.func @reduce_sum_constant() -> tensor<2x1x4xi32> {
   // CHECK-LABEL:   func.func @reduce_sum_constant() -> tensor<2x1x4xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}[15, 18, 21, 24]], {{\[\[}}51, 54, 57, 60]]]> : tensor<2x1x4xi32>}> : () -> tensor<2x1x4xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}[15, 18, 21, 24]], {{\[\[}}51, 54, 57, 60]]]> : tensor<2x1x4xi32>) : () -> tensor<2x1x4xi32>
   // CHECK:           return %[[VAL_0]] : tensor<2x1x4xi32>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]], [[13, 14, 15, 16], [17, 18, 19, 20], [21, 22, 23, 24]]]> : tensor<2x3x4xi32>}> : () -> tensor<2x3x4xi32>
@@ -200,7 +200,7 @@ func.func @reduce_sum_constant() -> tensor<2x1x4xi32> {
 
 func.func @reduce_sum_constant() -> tensor<1x3x3xi32> {
   // CHECK-LABEL:   func.func @reduce_sum_constant() -> tensor<1x3x3xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}[30, 33, 36], [39, 42, 45], [48, 51, 54]]]> : tensor<1x3x3xi32>}> : () -> tensor<1x3x3xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}[30, 33, 36], [39, 42, 45], [48, 51, 54]]]> : tensor<1x3x3xi32>) : () -> tensor<1x3x3xi32>
   // CHECK:           return %[[VAL_0]] : tensor<1x3x3xi32>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[[1, 2, 3], [4, 5, 6], [7, 8, 9]], [[10, 11, 12], [13, 14, 15], [16, 17, 18]], [[19, 20, 21], [22, 23, 24], [25, 26, 27]]]> : tensor<3x3x3xi32>}> : () -> tensor<3x3x3xi32>
@@ -212,7 +212,7 @@ func.func @reduce_sum_constant() -> tensor<1x3x3xi32> {
 
 func.func @reduce_sum_constant() -> tensor<2x2x2x1xi32> {
   // CHECK-LABEL:   func.func @reduce_sum_constant() -> tensor<2x2x2x1xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}{{\[\[}}3], [7]], {{\[\[}}11], [15]]], {{\[\[}}[19], [23]], {{\[\[}}27], [31]]]]> : tensor<2x2x2x1xi32>}> : () -> tensor<2x2x2x1xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}{{\[\[}}3], [7]], {{\[\[}}11], [15]]], {{\[\[}}[19], [23]], {{\[\[}}27], [31]]]]> : tensor<2x2x2x1xi32>) : () -> tensor<2x2x2x1xi32>
   // CHECK:           return %[[VAL_0]] : tensor<2x2x2x1xi32>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[[[1, 2], [3, 4]], [[5, 6], [7, 8]]], [[[9, 10], [11, 12]], [[13, 14], [15, 16]]]]> : tensor<2x2x2x2xi32>}> : () -> tensor<2x2x2x2xi32>
@@ -224,7 +224,7 @@ func.func @reduce_sum_constant() -> tensor<2x2x2x1xi32> {
 
 func.func @reduce_sum_constant() -> tensor<1x1x1xi32> {
   // CHECK-LABEL:   func.func @reduce_sum_constant() -> tensor<1x1x1xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<42> : tensor<1x1x1xi32>}> : () -> tensor<1x1x1xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<42> : tensor<1x1x1xi32>) : () -> tensor<1x1x1xi32>
   // CHECK:           return %[[VAL_0]] : tensor<1x1x1xi32>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[[42]]]> : tensor<1x1x1xi32>}> : () -> tensor<1x1x1xi32>
@@ -236,7 +236,7 @@ func.func @reduce_sum_constant() -> tensor<1x1x1xi32> {
 
 func.func @reduce_sum_constant() -> tensor<2x3x1x5xi32> {
   // CHECK-LABEL:   func.func @reduce_sum_constant() -> tensor<2x3x1x5xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}{{\[\[}}34, 38, 42, 46, 50]], {{\[\[}}114, 118, 122, 126, 130]], {{\[\[}}194, 198, 202, 206, 210]]], {{\[\[}}[274, 278, 282, 286, 290]], {{\[\[}}354, 358, 362, 366, 370]], {{\[\[}}434, 438, 442, 446, 450]]]]> : tensor<2x3x1x5xi32>}> : () -> tensor<2x3x1x5xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}{{\[\[}}34, 38, 42, 46, 50]], {{\[\[}}114, 118, 122, 126, 130]], {{\[\[}}194, 198, 202, 206, 210]]], {{\[\[}}[274, 278, 282, 286, 290]], {{\[\[}}354, 358, 362, 366, 370]], {{\[\[}}434, 438, 442, 446, 450]]]]> : tensor<2x3x1x5xi32>) : () -> tensor<2x3x1x5xi32>
   // CHECK:           return %[[VAL_0]] : tensor<2x3x1x5xi32>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[[[1, 2, 3, 4, 5], [6, 7, 8, 9, 10], [11, 12, 13, 14, 15], [16, 17, 18, 19, 20]], [[21, 22, 23, 24, 25], [26, 27, 28, 29, 30], [31, 32, 33, 34, 35], [36, 37, 38, 39, 40]], [[41, 42, 43, 44, 45], [46, 47, 48, 49, 50], [51, 52, 53, 54, 55], [56, 57, 58, 59, 60]]], [[[61, 62, 63, 64, 65], [66, 67, 68, 69, 70], [71, 72, 73, 74, 75], [76, 77, 78, 79, 80]], [[81, 82, 83, 84, 85], [86, 87, 88, 89, 90], [91, 92, 93, 94, 95], [96, 97, 98, 99, 100]], [[101, 102, 103, 104, 105], [106, 107, 108, 109, 110], [111, 112, 113, 114, 115], [116, 117, 118, 119, 120]]]]> : tensor<2x3x4x5xi32>}> : () -> tensor<2x3x4x5xi32>
@@ -248,7 +248,7 @@ func.func @reduce_sum_constant() -> tensor<2x3x1x5xi32> {
 
   func.func @reduce_prod_constant() -> tensor<1x3xi32> {
     // CHECK-LABEL:   func.func @reduce_prod_constant() -> tensor<1x3xi32> {
-    // CHECK:    %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}4, 10, 18]]> : tensor<1x3xi32>}> : () -> tensor<1x3xi32>
+    // CHECK:    %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}4, 10, 18]]> : tensor<1x3xi32>) : () -> tensor<1x3xi32>
     // CHECK:         return %[[VAL_0]] : tensor<1x3xi32>
 
     %const = "tosa.const"() <{values = dense<[[1,2,3], [4,5,6]]> : tensor<2x3xi32>}> : () -> tensor<2x3xi32>
@@ -260,7 +260,7 @@ func.func @reduce_sum_constant() -> tensor<2x3x1x5xi32> {
 
   func.func @reduce_prod_constant() -> tensor<2x1xi32> {
   // CHECK-LABEL:   func.func @reduce_prod_constant() -> tensor<2x1xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}6], [120]]> : tensor<2x1xi32>}> : () -> tensor<2x1xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}6], [120]]> : tensor<2x1xi32>) : () -> tensor<2x1xi32>
   // CHECK:           return %[[VAL_0]] : tensor<2x1xi32>
   // CHECK:         }
 
@@ -273,7 +273,7 @@ func.func @reduce_sum_constant() -> tensor<2x3x1x5xi32> {
 
 func.func @reduce_prod_constant() -> tensor<3x1xi32> {
   // CHECK-LABEL:   func.func @reduce_prod_constant() -> tensor<3x1xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}6], [120], [504]]> : tensor<3x1xi32>}> : () -> tensor<3x1xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}6], [120], [504]]> : tensor<3x1xi32>) : () -> tensor<3x1xi32>
   // CHECK:           return %[[VAL_0]] : tensor<3x1xi32>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[1, 2, 3], [4, 5, 6], [7, 8, 9]]> : tensor<3x3xi32>}> : () -> tensor<3x3xi32>
@@ -285,7 +285,7 @@ func.func @reduce_prod_constant() -> tensor<3x1xi32> {
 
 func.func @reduce_prod_constant() -> tensor<2x1x4xi32> {
   // CHECK-LABEL:   func.func @reduce_prod_constant() -> tensor<2x1x4xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}[45, 120, 231, 384]], {{\[\[}}4641, 5544, 6555, 7680]]]> : tensor<2x1x4xi32>}> : () -> tensor<2x1x4xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}[45, 120, 231, 384]], {{\[\[}}4641, 5544, 6555, 7680]]]> : tensor<2x1x4xi32>) : () -> tensor<2x1x4xi32>
   // CHECK:           return %[[VAL_0]] : tensor<2x1x4xi32>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]], [[13, 14, 15, 16], [17, 18, 19, 20], [21, 22, 23, 24]]]> : tensor<2x3x4xi32>}> : () -> tensor<2x3x4xi32>
@@ -297,7 +297,7 @@ func.func @reduce_prod_constant() -> tensor<2x1x4xi32> {
 
 func.func @reduce_prod_constant() -> tensor<1x3x3xi32> {
   // CHECK-LABEL:   func.func @reduce_prod_constant() -> tensor<1x3x3xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}[190, 440, 756], [1144, 1610, 2160], [2800, 3536, 4374]]]> : tensor<1x3x3xi32>}> : () -> tensor<1x3x3xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}[190, 440, 756], [1144, 1610, 2160], [2800, 3536, 4374]]]> : tensor<1x3x3xi32>) : () -> tensor<1x3x3xi32>
   // CHECK:           return %[[VAL_0]] : tensor<1x3x3xi32>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[[1, 2, 3], [4, 5, 6], [7, 8, 9]], [[10, 11, 12], [13, 14, 15], [16, 17, 18]], [[19, 20, 21], [22, 23, 24], [25, 26, 27]]]> : tensor<3x3x3xi32>}> : () -> tensor<3x3x3xi32>
@@ -309,7 +309,7 @@ func.func @reduce_prod_constant() -> tensor<1x3x3xi32> {
 
 func.func @reduce_prod_constant() -> tensor<2x2x2x1xi32> {
   // CHECK-LABEL:   func.func @reduce_prod_constant() -> tensor<2x2x2x1xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}{{\[\[}}2], [12]], {{\[\[}}30], [56]]], {{\[\[}}[90], [132]], {{\[\[}}182], [240]]]]> : tensor<2x2x2x1xi32>}> : () -> tensor<2x2x2x1xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}{{\[\[}}2], [12]], {{\[\[}}30], [56]]], {{\[\[}}[90], [132]], {{\[\[}}182], [240]]]]> : tensor<2x2x2x1xi32>) : () -> tensor<2x2x2x1xi32>
   // CHECK:           return %[[VAL_0]] : tensor<2x2x2x1xi32>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[[[1, 2], [3, 4]], [[5, 6], [7, 8]]], [[[9, 10], [11, 12]], [[13, 14], [15, 16]]]]> : tensor<2x2x2x2xi32>}> : () -> tensor<2x2x2x2xi32>
@@ -321,7 +321,7 @@ func.func @reduce_prod_constant() -> tensor<2x2x2x1xi32> {
 
 func.func @reduce_prod_constant() -> tensor<1x1x1xi32> {
   // CHECK-LABEL:   func.func @reduce_prod_constant() -> tensor<1x1x1xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<42> : tensor<1x1x1xi32>}> : () -> tensor<1x1x1xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<42> : tensor<1x1x1xi32>) : () -> tensor<1x1x1xi32>
   // CHECK:           return %[[VAL_0]] : tensor<1x1x1xi32>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[[42]]]> : tensor<1x1x1xi32>}> : () -> tensor<1x1x1xi32>
@@ -333,7 +333,7 @@ func.func @reduce_prod_constant() -> tensor<1x1x1xi32> {
 
   func.func @reduce_max_constant() -> tensor<1x3xi32> {
     // CHECK-LABEL:   func.func @reduce_max_constant() -> tensor<1x3xi32> {
-    // CHECK:    %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}4, 5, 6]]> : tensor<1x3xi32>}> : () -> tensor<1x3xi32>
+    // CHECK:    %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}4, 5, 6]]> : tensor<1x3xi32>) : () -> tensor<1x3xi32>
     // CHECK:         return %[[VAL_0]] : tensor<1x3xi32>
 
     %const = "tosa.const"() <{values = dense<[[1,2,3], [4,5,6]]> : tensor<2x3xi32>}> : () -> tensor<2x3xi32>
@@ -345,7 +345,7 @@ func.func @reduce_prod_constant() -> tensor<1x1x1xi32> {
 
   func.func @reduce_max_constant() -> tensor<2x1xi32> {
   // CHECK-LABEL:   func.func @reduce_max_constant() -> tensor<2x1xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}3], [6]]> : tensor<2x1xi32>}> : () -> tensor<2x1xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}3], [6]]> : tensor<2x1xi32>) : () -> tensor<2x1xi32>
   // CHECK:           return %[[VAL_0]] : tensor<2x1xi32>
   // CHECK:         }
 
@@ -358,7 +358,7 @@ func.func @reduce_prod_constant() -> tensor<1x1x1xi32> {
 
 func.func @reduce_max_constant() -> tensor<3x1xi32> {
   // CHECK-LABEL:   func.func @reduce_max_constant() -> tensor<3x1xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}3], [6], [9]]> : tensor<3x1xi32>}> : () -> tensor<3x1xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}3], [6], [9]]> : tensor<3x1xi32>) : () -> tensor<3x1xi32>
   // CHECK:           return %[[VAL_0]] : tensor<3x1xi32>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[1, 2, 3], [4, 5, 6], [7, 8, 9]]> : tensor<3x3xi32>}> : () -> tensor<3x3xi32>
@@ -370,7 +370,7 @@ func.func @reduce_max_constant() -> tensor<3x1xi32> {
 
 func.func @reduce_max_constant() -> tensor<2x1x4xi32> {
   // CHECK-LABEL:   func.func @reduce_max_constant() -> tensor<2x1x4xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}[9, 10, 11, 12]], {{\[\[}}21, 22, 23, 24]]]> : tensor<2x1x4xi32>}> : () -> tensor<2x1x4xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}[9, 10, 11, 12]], {{\[\[}}21, 22, 23, 24]]]> : tensor<2x1x4xi32>) : () -> tensor<2x1x4xi32>
   // CHECK:           return %[[VAL_0]] : tensor<2x1x4xi32>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]], [[13, 14, 15, 16], [17, 18, 19, 20], [21, 22, 23, 24]]]> : tensor<2x3x4xi32>}> : () -> tensor<2x3x4xi32>
@@ -382,7 +382,7 @@ func.func @reduce_max_constant() -> tensor<2x1x4xi32> {
 
 func.func @reduce_max_constant() -> tensor<1x3x3xi32> {
   // CHECK-LABEL:   func.func @reduce_max_constant() -> tensor<1x3x3xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}[19, 20, 21], [22, 23, 24], [25, 26, 27]]]> : tensor<1x3x3xi32>}> : () -> tensor<1x3x3xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}[19, 20, 21], [22, 23, 24], [25, 26, 27]]]> : tensor<1x3x3xi32>) : () -> tensor<1x3x3xi32>
   // CHECK:           return %[[VAL_0]] : tensor<1x3x3xi32>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[[1, 2, 3], [4, 5, 6], [7, 8, 9]], [[10, 11, 12], [13, 14, 15], [16, 17, 18]], [[19, 20, 21], [22, 23, 24], [25, 26, 27]]]> : tensor<3x3x3xi32>}> : () -> tensor<3x3x3xi32>
@@ -394,7 +394,7 @@ func.func @reduce_max_constant() -> tensor<1x3x3xi32> {
 
 func.func @reduce_max_constant() -> tensor<2x2x2x1xi32> {
   // CHECK-LABEL:   func.func @reduce_max_constant() -> tensor<2x2x2x1xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}{{\[\[}}2], [4]], {{\[\[}}6], [8]]], {{\[\[}}[10], [12]], {{\[\[}}14], [16]]]]> : tensor<2x2x2x1xi32>}> : () -> tensor<2x2x2x1xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}{{\[\[}}2], [4]], {{\[\[}}6], [8]]], {{\[\[}}[10], [12]], {{\[\[}}14], [16]]]]> : tensor<2x2x2x1xi32>) : () -> tensor<2x2x2x1xi32>
   // CHECK:           return %[[VAL_0]] : tensor<2x2x2x1xi32>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[[[1, 2], [3, 4]], [[5, 6], [7, 8]]], [[[9, 10], [11, 12]], [[13, 14], [15, 16]]]]> : tensor<2x2x2x2xi32>}> : () -> tensor<2x2x2x2xi32>
@@ -406,7 +406,7 @@ func.func @reduce_max_constant() -> tensor<2x2x2x1xi32> {
 
 func.func @reduce_max_constant() -> tensor<1x1x1xi32> {
   // CHECK-LABEL:   func.func @reduce_max_constant() -> tensor<1x1x1xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<42> : tensor<1x1x1xi32>}> : () -> tensor<1x1x1xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<42> : tensor<1x1x1xi32>) : () -> tensor<1x1x1xi32>
   // CHECK:           return %[[VAL_0]] : tensor<1x1x1xi32>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[[42]]]> : tensor<1x1x1xi32>}> : () -> tensor<1x1x1xi32>
@@ -418,7 +418,7 @@ func.func @reduce_max_constant() -> tensor<1x1x1xi32> {
 
 func.func @reduce_max_constant_no_overflow() -> tensor<1xi8> {
   // CHECK-LABEL:   func.func @reduce_max_constant_no_overflow() -> tensor<1xi8> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<120> : tensor<1xi8>}> : () -> tensor<1xi8>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<120> : tensor<1xi8>) : () -> tensor<1xi8>
   // CHECK:           return %[[VAL_0]] : tensor<1xi8>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[-127, 120, -126]> : tensor<3xi8>}> : () -> tensor<3xi8>
@@ -430,7 +430,7 @@ func.func @reduce_max_constant_no_overflow() -> tensor<1xi8> {
 
   func.func @reduce_min_constant() -> tensor<1x3xi32> {
     // CHECK-LABEL:   func.func @reduce_min_constant() -> tensor<1x3xi32> {
-    // CHECK:    %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}1, 2, 3]]> : tensor<1x3xi32>}> : () -> tensor<1x3xi32>
+    // CHECK:    %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}1, 2, 3]]> : tensor<1x3xi32>) : () -> tensor<1x3xi32>
     // CHECK:         return %[[VAL_0]] : tensor<1x3xi32>
     %const = "tosa.const"() <{values = dense<[[1,2,3], [4,5,6]]> : tensor<2x3xi32>}> : () -> tensor<2x3xi32>
     %0 = tosa.reduce_min %const {axis = 0 : i32} : (tensor<2x3xi32>) -> tensor<1x3xi32>
@@ -442,7 +442,7 @@ func.func @reduce_max_constant_no_overflow() -> tensor<1xi8> {
 
   func.func @reduce_min_constant() -> tensor<2x1xi32> {
   // CHECK-LABEL:   func.func @reduce_min_constant() -> tensor<2x1xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}1], [4]]> : tensor<2x1xi32>}> : () -> tensor<2x1xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}1], [4]]> : tensor<2x1xi32>) : () -> tensor<2x1xi32>
   // CHECK:           return %[[VAL_0]] : tensor<2x1xi32>
   // CHECK:         }
 
@@ -455,7 +455,7 @@ func.func @reduce_max_constant_no_overflow() -> tensor<1xi8> {
 
 func.func @reduce_min_constant() -> tensor<3x1xi32> {
   // CHECK-LABEL:   func.func @reduce_min_constant() -> tensor<3x1xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}1], [4], [7]]> : tensor<3x1xi32>}> : () -> tensor<3x1xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}1], [4], [7]]> : tensor<3x1xi32>) : () -> tensor<3x1xi32>
   // CHECK:           return %[[VAL_0]] : tensor<3x1xi32>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[1, 2, 3], [4, 5, 6], [7, 8, 9]]> : tensor<3x3xi32>}> : () -> tensor<3x3xi32>
@@ -467,7 +467,7 @@ func.func @reduce_min_constant() -> tensor<3x1xi32> {
 
 func.func @reduce_min_constant() -> tensor<2x1x4xi32> {
   // CHECK-LABEL:   func.func @reduce_min_constant() -> tensor<2x1x4xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}[1, 2, 3, 4]], {{\[\[}}13, 14, 15, 16]]]> : tensor<2x1x4xi32>}> : () -> tensor<2x1x4xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}[1, 2, 3, 4]], {{\[\[}}13, 14, 15, 16]]]> : tensor<2x1x4xi32>) : () -> tensor<2x1x4xi32>
   // CHECK:           return %[[VAL_0]] : tensor<2x1x4xi32>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]], [[13, 14, 15, 16], [17, 18, 19, 20], [21, 22, 23, 24]]]> : tensor<2x3x4xi32>}> : () -> tensor<2x3x4xi32>
@@ -479,7 +479,7 @@ func.func @reduce_min_constant() -> tensor<2x1x4xi32> {
 
 func.func @reduce_min_constant() -> tensor<1x3x3xi32> {
   // CHECK-LABEL:   func.func @reduce_min_constant() -> tensor<1x3x3xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}[1, 2, 3], [4, 5, 6], [7, 8, 9]]]> : tensor<1x3x3xi32>}> : () -> tensor<1x3x3xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}[1, 2, 3], [4, 5, 6], [7, 8, 9]]]> : tensor<1x3x3xi32>) : () -> tensor<1x3x3xi32>
   // CHECK:           return %[[VAL_0]] : tensor<1x3x3xi32>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[[1, 2, 3], [4, 5, 6], [7, 8, 9]], [[10, 11, 12], [13, 14, 15], [16, 17, 18]], [[19, 20, 21], [22, 23, 24], [25, 26, 27]]]> : tensor<3x3x3xi32>}> : () -> tensor<3x3x3xi32>
@@ -491,7 +491,7 @@ func.func @reduce_min_constant() -> tensor<1x3x3xi32> {
 
 func.func @reduce_min_constant() -> tensor<2x2x2x1xi32> {
   // CHECK-LABEL:   func.func @reduce_min_constant() -> tensor<2x2x2x1xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}{{\[\[}}1], [3]], {{\[\[}}5], [7]]], {{\[\[}}[9], [11]], {{\[\[}}13], [15]]]]> : tensor<2x2x2x1xi32>}> : () -> tensor<2x2x2x1xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}{{\[\[}}1], [3]], {{\[\[}}5], [7]]], {{\[\[}}[9], [11]], {{\[\[}}13], [15]]]]> : tensor<2x2x2x1xi32>) : () -> tensor<2x2x2x1xi32>
   // CHECK:           return %[[VAL_0]] : tensor<2x2x2x1xi32>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[[[1, 2], [3, 4]], [[5, 6], [7, 8]]], [[[9, 10], [11, 12]], [[13, 14], [15, 16]]]]> : tensor<2x2x2x2xi32>}> : () -> tensor<2x2x2x2xi32>
@@ -503,7 +503,7 @@ func.func @reduce_min_constant() -> tensor<2x2x2x1xi32> {
 
 func.func @reduce_min_constant() -> tensor<1x1x1xi32> {
   // CHECK-LABEL:   func.func @reduce_min_constant() -> tensor<1x1x1xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<42> : tensor<1x1x1xi32>}> : () -> tensor<1x1x1xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<42> : tensor<1x1x1xi32>) : () -> tensor<1x1x1xi32>
   // CHECK:           return %[[VAL_0]] : tensor<1x1x1xi32>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[[42]]]> : tensor<1x1x1xi32>}> : () -> tensor<1x1x1xi32>
@@ -515,7 +515,7 @@ func.func @reduce_min_constant() -> tensor<1x1x1xi32> {
 
 func.func @reduce_min_constant_no_overflow() -> tensor<1xi8> {
   // CHECK-LABEL:   func.func @reduce_min_constant_no_overflow() -> tensor<1xi8> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<-127> : tensor<1xi8>}> : () -> tensor<1xi8>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<-127> : tensor<1xi8>) : () -> tensor<1xi8>
   // CHECK:           return %[[VAL_0]] : tensor<1xi8>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[-127, 120, -126]> : tensor<3xi8>}> : () -> tensor<3xi8>
@@ -528,7 +528,7 @@ func.func @reduce_min_constant_no_overflow() -> tensor<1xi8> {
 
 func.func @reduce_any_constant() -> tensor<1x3xi1> {
   // CHECK-LABEL:   func.func @reduce_any_constant() -> tensor<1x3xi1> {
-  // CHECK:    %[[VAL_0:.*]] = "tosa.const"() <{values = dense<true> : tensor<1x3xi1>}> : () -> tensor<1x3xi1>
+  // CHECK:    %[[VAL_0:.*]] = tosa.const values(dense<true> : tensor<1x3xi1>) : () -> tensor<1x3xi1>
   // CHECK:         return %[[VAL_0]] : tensor<1x3xi1>
 
   %const = "tosa.const"() <{values = dense<[[true,true,true], [true,false,true]]> : tensor<2x3xi1>}> : () -> tensor<2x3xi1>
@@ -541,7 +541,7 @@ func.func @reduce_any_constant() -> tensor<1x3xi1> {
 
 func.func @reduce_any_constant() -> tensor<2x1xi1> {
 // CHECK-LABEL:   func.func @reduce_any_constant() -> tensor<2x1xi1> {
-// CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<true> : tensor<2x1xi1>}> : () -> tensor<2x1xi1>
+// CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<true> : tensor<2x1xi1>) : () -> tensor<2x1xi1>
 // CHECK:           return %[[VAL_0]] : tensor<2x1xi1>
 // CHECK:         }
 
@@ -554,7 +554,7 @@ func.func @reduce_any_constant() -> tensor<2x1xi1> {
 
 func.func @reduce_any_constant() -> tensor<3x1xi1> {
   // CHECK-LABEL:   func.func @reduce_any_constant() -> tensor<3x1xi1> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}true], [false], [true]]> : tensor<3x1xi1>}> : () -> tensor<3x1xi1>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}true], [false], [true]]> : tensor<3x1xi1>) : () -> tensor<3x1xi1>
   // CHECK:           return %[[VAL_0]] : tensor<3x1xi1>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[true, false, false], [false, false, false], [false, false, true]]> : tensor<3x3xi1>}> : () -> tensor<3x3xi1>
@@ -566,7 +566,7 @@ func.func @reduce_any_constant() -> tensor<3x1xi1> {
 
 func.func @reduce_any_constant() -> tensor<2x1x4xi1> {
   // CHECK-LABEL:   func.func @reduce_any_constant() -> tensor<2x1x4xi1> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}[true, false, true, true]], {{\[\[}}true, false, true, false]]]> : tensor<2x1x4xi1>}> : () -> tensor<2x1x4xi1>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}[true, false, true, true]], {{\[\[}}true, false, true, false]]]> : tensor<2x1x4xi1>) : () -> tensor<2x1x4xi1>
   // CHECK:           return %[[VAL_0]] : tensor<2x1x4xi1>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[[true, false, false, true], [false, false, true, false], [true, false, true, true]], [[false, false, false, false], [false, false, true, false], [true, false, true, false]]]> : tensor<2x3x4xi1>}> : () -> tensor<2x3x4xi1>
@@ -578,7 +578,7 @@ func.func @reduce_any_constant() -> tensor<2x1x4xi1> {
 
   func.func @reduce_all_constant() -> tensor<1x3xi1> {
   // CHECK-LABEL:   func.func @reduce_all_constant() -> tensor<1x3xi1> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}true, false, true]]> : tensor<1x3xi1>}> : () -> tensor<1x3xi1>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}true, false, true]]> : tensor<1x3xi1>) : () -> tensor<1x3xi1>
   // CHECK:           return %[[VAL_0]] : tensor<1x3xi1>
   // CHECK:         }
     %const = "tosa.const"() <{values = dense<[[true,true,true], [true,false,true]]> : tensor<2x3xi1>}> : () -> tensor<2x3xi1>
@@ -590,7 +590,7 @@ func.func @reduce_any_constant() -> tensor<2x1x4xi1> {
 
   func.func @reduce_all_constant() -> tensor<2x1xi1> {
   // CHECK-LABEL:   func.func @reduce_all_constant() -> tensor<2x1xi1> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}true], [false]]> : tensor<2x1xi1>}> : () -> tensor<2x1xi1>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}true], [false]]> : tensor<2x1xi1>) : () -> tensor<2x1xi1>
   // CHECK:           return %[[VAL_0]] : tensor<2x1xi1>
   // CHECK:         }
     %const = "tosa.const"() <{values = dense<[[true,true,true], [true,false,true]]> : tensor<2x3xi1>}> : () -> tensor<2x3xi1>
@@ -602,7 +602,7 @@ func.func @reduce_any_constant() -> tensor<2x1x4xi1> {
 
 func.func @reduce_all_constant() -> tensor<3x1xi1> {
   // CHECK-LABEL:   func.func @reduce_all_constant() -> tensor<3x1xi1> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<false> : tensor<3x1xi1>}> : () -> tensor<3x1xi1>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<false> : tensor<3x1xi1>) : () -> tensor<3x1xi1>
   // CHECK:           return %[[VAL_0]] : tensor<3x1xi1>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[true, false, false], [false, false, false], [false, false, true]]> : tensor<3x3xi1>}> : () -> tensor<3x3xi1>
@@ -614,7 +614,7 @@ func.func @reduce_all_constant() -> tensor<3x1xi1> {
 
 func.func @reduce_all_constant() -> tensor<2x1x4xi1> {
   // CHECK-LABEL:   func.func @reduce_all_constant() -> tensor<2x1x4xi1> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<false> : tensor<2x1x4xi1>}> : () -> tensor<2x1x4xi1>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<false> : tensor<2x1x4xi1>) : () -> tensor<2x1x4xi1>
   // CHECK:           return %[[VAL_0]] : tensor<2x1x4xi1>
   // CHECK:         }
   %const = "tosa.const"() <{values = dense<[[[true, false, false, true], [false, false, true, false], [true, false, true, true]], [[false, false, false, false], [false, false, true, false], [true, false, true, false]]]> : tensor<2x3x4xi1>}> : () -> tensor<2x3x4xi1>
@@ -626,7 +626,7 @@ func.func @reduce_all_constant() -> tensor<2x1x4xi1> {
 
 func.func @reduce_sum_constant() -> tensor<1x3xi32> {
 // CHECK-LABEL:   func.func @reduce_sum_constant() -> tensor<1x3xi32> {
-// CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<2> : tensor<1x3xi32>}> : () -> tensor<1x3xi32>
+// CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<2> : tensor<1x3xi32>) : () -> tensor<1x3xi32>
 // CHECK:           return %[[VAL_0]] : tensor<1x3xi32>
 // CHECK:         }
   %const = "tosa.const"() <{values = dense<1> : tensor<2x3xi32>}> : () -> tensor<2x3xi32>
@@ -638,8 +638,8 @@ func.func @reduce_sum_constant() -> tensor<1x3xi32> {
 
 func.func @reduce_sum_constant() -> tensor<1x3xi32> {
   // CHECK-LABEL:     func.func @reduce_sum_constant() -> tensor<1x3xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<{{\[\[}}1, 2, 3], [4, 5, 6]]> : tensor<2x3xi32>}> : () -> tensor<2x3xi32>
-  // CHECK:           %[[VAL_1:.*]] = "tosa.const"() <{values = dense<{{\[\[}}1, 2, 3], [4, 5, 7]]> : tensor<2x3xi32>}> : () -> tensor<2x3xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<{{\[\[}}1, 2, 3], [4, 5, 6]]> : tensor<2x3xi32>) : () -> tensor<2x3xi32>
+  // CHECK:           %[[VAL_1:.*]] = tosa.const values(dense<{{\[\[}}1, 2, 3], [4, 5, 7]]> : tensor<2x3xi32>) : () -> tensor<2x3xi32>
   // CHECK:           %[[VAL_2:.*]] = tosa.add %[[VAL_0]], %[[VAL_1]] : (tensor<2x3xi32>, tensor<2x3xi32>) -> tensor<2x3xi32>
   // CHECK:           %[[VAL_3:.*]] = tosa.reduce_sum %[[VAL_2]] {axis = 0 : i32} : (tensor<2x3xi32>) -> tensor<1x3xi32>
   // CHECK:           return %[[VAL_3]] : tensor<1x3xi32>
@@ -654,11 +654,11 @@ func.func @reduce_sum_constant() -> tensor<1x3xi32> {
 
 func.func @reduce_sum_constant_aggressive() -> tensor<1x3xi32> {
   // AGGRESIVE-LABEL: func.func @reduce_sum_constant_aggressive() -> tensor<1x3xi32> {
-  // AGGRESIVE:       %[[VAL_0:.*]] = "tosa.const"() <{values = dense<4> : tensor<1x3xi32>}> : () -> tensor<1x3xi32>
+  // AGGRESIVE:       %[[VAL_0:.*]] = tosa.const values(dense<4> : tensor<1x3xi32>) : () -> tensor<1x3xi32>
   // AGGRESIVE:       return %[[VAL_0:.*]] : tensor<1x3xi32>
 
   // CHECK-LABEL:     func.func @reduce_sum_constant_aggressive() -> tensor<1x3xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<1> : tensor<2x3xi32>}> : () -> tensor<2x3xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<1> : tensor<2x3xi32>) : () -> tensor<2x3xi32>
   // CHECK:           %[[VAL_1:.*]] = tosa.reduce_sum %[[VAL_0]] {axis = 0 : i32} : (tensor<2x3xi32>) -> tensor<1x3xi32>
   // CHECK:           %[[VAL_2:.*]] = tosa.reduce_sum %[[VAL_0]] {axis = 0 : i32} : (tensor<2x3xi32>) -> tensor<1x3xi32>
   // CHECK:           %[[VAL_3:.*]] = tosa.add %[[VAL_1]], %[[VAL_2]] : (tensor<1x3xi32>, tensor<1x3xi32>) -> tensor<1x3xi32>
@@ -675,9 +675,9 @@ func.func @reduce_sum_constant_aggressive() -> tensor<1x3xi32> {
 
 func.func @reduce_sum_constant_aggressive() -> tensor<2x3xi32> {
   // AGGRESIVE-LABEL:     func.func @reduce_sum_constant_aggressive() -> tensor<2x3xi32> {
-  // AGGRESIVE-DAG:       %[[VAL_0:.*]] = "tosa.const"() <{values = dense<2> : tensor<1x2x3xi32>}> : () -> tensor<1x2x3xi32>
-  // AGGRESIVE-DAG:       %[[VAL_1:.*]] = "tosa.const"() <{values = dense<1> : tensor<2x2x3xi32>}> : () -> tensor<2x2x3xi32>
-  // AGGRESIVE-DAG:       %[[VAL_2:.*]] = "tosa.const"() <{values = dense<2> : tensor<2x3xi32>}> : () -> tensor<2x3xi32>
+  // AGGRESIVE-DAG:       %[[VAL_0:.*]] = tosa.const values(dense<2> : tensor<1x2x3xi32>) : () -> tensor<1x2x3xi32>
+  // AGGRESIVE-DAG:       %[[VAL_1:.*]] = tosa.const values(dense<1> : tensor<2x2x3xi32>) : () -> tensor<2x2x3xi32>
+  // AGGRESIVE-DAG:       %[[VAL_2:.*]] = tosa.const values(dense<2> : tensor<2x3xi32>) : () -> tensor<2x3xi32>
   // AGGRESIVE:           %[[VAL_3:.*]] = tosa.argmax %[[VAL_0]] {axis = 1 : i32} : (tensor<1x2x3xi32>) -> tensor<1x3xi32>
   // AGGRESIVE:           %[[VAL_4:.*]] = tosa.argmax %[[VAL_1]] {axis = 0 : i32} : (tensor<2x2x3xi32>) -> tensor<2x3xi32>
   // AGGRESIVE:           %[[VAL_5:.*]] = tosa.add %[[VAL_3]], %[[VAL_2]] : (tensor<1x3xi32>, tensor<2x3xi32>) -> tensor<2x3xi32>
@@ -685,8 +685,8 @@ func.func @reduce_sum_constant_aggressive() -> tensor<2x3xi32> {
   // AGGRESIVE:           return %[[VAL_6]] : tensor<2x3xi32>
 
   // CHECK-LABEL:     func.func @reduce_sum_constant_aggressive() -> tensor<2x3xi32> {
-  // CHECK:           %[[VAL_0:.*]] = "tosa.const"() <{values = dense<1> : tensor<2x2x3xi32>}> : () -> tensor<2x2x3xi32>
-  // CHECK:           %[[VAL_1:.*]] = "tosa.const"() <{values = dense<2> : tensor<2x3xi32>}> : () -> tensor<2x3xi32>
+  // CHECK:           %[[VAL_0:.*]] = tosa.const values(dense<1> : tensor<2x2x3xi32>) : () -> tensor<2x2x3xi32>
+  // CHECK:           %[[VAL_1:.*]] = tosa.const values(dense<2> : tensor<2x3xi32>) : () -> tensor<2x3xi32>
   // CHECK:           %[[VAL_2:.*]] = tosa.reduce_sum %[[VAL_0]] {axis = 0 : i32} : (tensor<2x2x3xi32>) -> tensor<1x2x3xi32>
   // CHECK:           %[[VAL_3:.*]] = tosa.argmax %[[VAL_2]] {axis = 1 : i32} : (tensor<1x2x3xi32>) -> tensor<1x3xi32>
   // CHECK:           %[[VAL_4:.*]] = tosa.argmax %[[VAL_0]] {axis = 0 : i32} : (tensor<2x2x3xi32>) -> tensor<2x3xi32>

--- a/mlir/test/Dialect/Tosa/tosa-narrow-f64-to-f32-aggressive.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-narrow-f64-to-f32-aggressive.mlir
@@ -61,7 +61,7 @@ func.func @test_convert_input_parameters(%arg0: tensor<1x3xf64>) -> tensor<1x3xf
 
 // CHECK-LABEL: test_f64_const
 func.func @test_f64_const() -> tensor<2xf64> {
-  // COMMON: %[[CONST:.*]] = "tosa.const"() <{values = dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf32>}> : () -> tensor<2xf32>
+  // COMMON: %[[CONST:.*]] = tosa.const values(dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf32>) : () -> tensor<2xf32>
   %0 = "tosa.const"() <{values = dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf64>}> : () -> tensor<2xf64>
   // DEFAULT: %[[OUT:.*]] = tosa.cast %[[CONST]] : (tensor<2xf32>) -> tensor<2xf64>
   // DEFAULT: return %[[OUT]] : tensor<2xf64>
@@ -73,7 +73,7 @@ func.func @test_f64_const() -> tensor<2xf64> {
 
 // CHECK-LABEL: test_dense_ressource_f64
 func.func @test_dense_ressource_f64() -> tensor<1x2xf64> {
-  // COMMON: %[[CONST:.*]] = "tosa.const"() <{values = dense_resource<resource> : tensor<1x2xf32>}> : () -> tensor<1x2xf32>
+  // COMMON: %[[CONST:.*]] = tosa.const values(dense_resource<resource> : tensor<1x2xf32>) : () -> tensor<1x2xf32>
   %0 = "tosa.const"() <{values = dense_resource<resource> : tensor<1x2xf64>}> : () -> tensor<1x2xf64>
   // DEFAULT: %[[OUT_CAST:.*]] = tosa.cast %[[CONST]] : (tensor<1x2xf32>) -> tensor<1x2xf64>
   // DEFAULT: return %[[OUT_CAST]] : tensor<1x2xf64>

--- a/mlir/test/Dialect/Tosa/tosa-narrow-f64-to-f32.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-narrow-f64-to-f32.mlir
@@ -21,7 +21,7 @@ func.func @test_f64_identity_chain(%arg0: tensor<1xf64>) -> tensor<1xf64> {
 
 // CHECK-LABEL: test_f64_const
 func.func @test_f64_const() -> tensor<2xf64> {
-  // COMMON: %[[CONST:.*]] = "tosa.const"() <{values = dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf32>}> : () -> tensor<2xf32>
+  // COMMON: %[[CONST:.*]] = tosa.const values(dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf32>) : () -> tensor<2xf32>
   %0 = "tosa.const"() <{values = dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf64>}> : () -> tensor<2xf64>
   // DEFAULT: %[[OUT:.*]] = tosa.cast %[[CONST]] : (tensor<2xf32>) -> tensor<2xf64>
   // DEFAULT: return %[[OUT]] : tensor<2xf64>
@@ -183,7 +183,7 @@ func.func @test_f64_add_diagnostic(%arg0: tensor<13x21x1xf64>, %arg1: tensor<13x
 
 // CHECK-LABEL: test_dense_ressource_f64
 func.func @test_dense_ressource_f64() -> tensor<1x2xf64> {
-  // COMMON: %[[CONST:.*]] = "tosa.const"() <{values = dense_resource<resource> : tensor<1x2xf32>}> : () -> tensor<1x2xf32>
+  // COMMON: %[[CONST:.*]] = tosa.const values(dense_resource<resource> : tensor<1x2xf32>) : () -> tensor<1x2xf32>
   %0 = "tosa.const"() <{values = dense_resource<resource> : tensor<1x2xf64>}> : () -> tensor<1x2xf64>
   // DEFAULT: %[[OUT_CAST:.*]] = tosa.cast %[[CONST]] : (tensor<1x2xf32>) -> tensor<1x2xf64>
   // DEFAULT: return %[[OUT_CAST]] : tensor<1x2xf64>

--- a/mlir/test/Dialect/Tosa/tosa-narrow-i64-to-i32-aggressive.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-narrow-i64-to-i32-aggressive.mlir
@@ -72,7 +72,7 @@ func.func @test_regions(%arg0: tensor<i64>, %arg1: tensor<i64>, %arg2: tensor<i1
 
 // CHECK-LABEL: test_const
 func.func @test_const() -> tensor<2xi64> {
-  // COMMON: %[[CONST:.*]] = "tosa.const"() <{values = dense<[1, 2]> : tensor<2xi32>}> : () -> tensor<2xi32>
+  // COMMON: %[[CONST:.*]] = tosa.const values(dense<[1, 2]> : tensor<2xi32>) : () -> tensor<2xi32>
   %0 = "tosa.const"() <{values = dense<[1, 2]> : tensor<2xi64>}> : () -> tensor<2xi64>
   // DEFAULT: %[[OUT:.*]] = tosa.cast %[[CONST]] : (tensor<2xi32>) -> tensor<2xi64>
   // DEFAULT: return %[[OUT]] : tensor<2xi64>
@@ -93,7 +93,7 @@ func.func @test_clamp_trunc(%arg0: tensor<100xi64>) -> tensor<100xi64> {
 
 // CHECK-LABEL: test_dense_ressource_i64
 func.func @test_dense_ressource_i64() -> tensor<1x2xi64> {
-  // COMMON: %[[CONST:.*]] = "tosa.const"() <{values = dense_resource<resource> : tensor<1x2xi32>}> : () -> tensor<1x2xi32>
+  // COMMON: %[[CONST:.*]] = tosa.const values(dense_resource<resource> : tensor<1x2xi32>) : () -> tensor<1x2xi32>
   %1 = "tosa.const"() <{values = dense_resource<resource> : tensor<1x2xi64>}> : () -> tensor<1x2xi64>
   // DEFAULT: %[[OUT_CAST:.*]] = tosa.cast %[[CONST]] : (tensor<1x2xi32>) -> tensor<1x2xi64>
   // DEFAULT: return %[[OUT_CAST]] : tensor<1x2xi64>

--- a/mlir/test/Dialect/Tosa/tosa-narrow-i64-to-i32.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-narrow-i64-to-i32.mlir
@@ -17,7 +17,7 @@ func.func @test_i64_argmax(%arg0: tensor<1x513x513x19xi8>) -> tensor<1x513x513xi
 
 // CHECK-LABEL: test_i64_const
 func.func @test_i64_const() -> tensor<2xi64> {
-  // COMMON: %[[CONST:.*]] = "tosa.const"() <{values = dense<[1, 2]> : tensor<2xi32>}> : () -> tensor<2xi32>
+  // COMMON: %[[CONST:.*]] = tosa.const values(dense<[1, 2]> : tensor<2xi32>) : () -> tensor<2xi32>
   %0 = "tosa.const"() <{values = dense<[1, 2]> : tensor<2xi64>}> : () -> tensor<2xi64>
   // DEFAULT: %[[OUT:.*]] = tosa.cast %[[CONST]] : (tensor<2xi32>) -> tensor<2xi64>
   // DEFAULT: return %[[OUT]] : tensor<2xi64>
@@ -239,7 +239,7 @@ func.func @test_clamp_min_outside_i32_range(%arg0: tensor<100xi64>) -> tensor<10
 
 // CHECK-LABEL: test_dense_ressource_i64
 func.func @test_dense_ressource_i64() -> tensor<1x2xi64> {
-  // COMMON: %[[CONST:.*]] = "tosa.const"() <{values = dense_resource<resource> : tensor<1x2xi32>}> : () -> tensor<1x2xi32>
+  // COMMON: %[[CONST:.*]] = tosa.const values(dense_resource<resource> : tensor<1x2xi32>) : () -> tensor<1x2xi32>
   %1 = "tosa.const"() <{values = dense_resource<resource> : tensor<1x2xi64>}> : () -> tensor<1x2xi64>
   // DEFAULT: %[[OUT_CAST:.*]] = tosa.cast %[[CONST]] : (tensor<1x2xi32>) -> tensor<1x2xi64>
   // DEFAULT: return %[[OUT_CAST]] : tensor<1x2xi64>

--- a/mlir/test/Dialect/Tosa/tosa-reduce-transposes.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-reduce-transposes.mlir
@@ -114,7 +114,7 @@ func.func @test_torch_conv2d_with_elementwise_in_between(%arg0: tensor<3x3x10x10
 // -----
 
 // CHECK-LABEL: @test_mulop_conversion
-// CHECK-NEXT: %[[SHIFT:.*]] = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK-NEXT: %[[SHIFT:.*]] = tosa.const values(dense<0> : tensor<1xi8>) : () -> tensor<1xi8>
 // CHECK-NEXT: %[[RES:.*]] = tosa.mul %arg0, %arg1, %[[SHIFT]]
 // CHECK-NEXT: return %[[RES]]
 func.func @test_mulop_conversion(%arg0: tensor<1x2x3x4xi32>, %arg1: tensor<1x2x3x4xi32>) -> tensor<1x2x3x4xi32> {
@@ -157,7 +157,7 @@ func.func @test_dynamic_broadcasting_reshape(%arg0: tensor<?xi32>) -> tensor<1x1
 // -----
 
 // CHECK-LABEL: @test_reshape_for_broadcast
-// CHECK-DAG: %[[RESHAPE_INPUT:.*]] = "tosa.const"() <{values = dense<[1, 2, 3, 4]>
+// CHECK-DAG: %[[RESHAPE_INPUT:.*]] = tosa.const values(dense<[1, 2, 3, 4]>
 // CHECK-DAG: %[[SHAPE:.*]] = tosa.const_shape  {values = dense<[4, 1, 1]> : tensor<3xindex>}
 // CHECK: %[[RESHAPE:.*]] = tosa.reshape %[[RESHAPE_INPUT]], %[[SHAPE]] : (tensor<4xi32>, !tosa.shape<3>) -> tensor<4x1x1xi32>
 // CHECK: %[[ADD:.*]] = tosa.add %arg0, %[[RESHAPE]]
@@ -195,11 +195,11 @@ func.func @test_multi_dim_reshape_for_broadcast(%arg0: tensor<1x4x1xi32>, %arg1:
 
 // CHECK-LABEL: @test_resnet18_common_case
 // COM: note that %74 is now represented by %arg2
-// CHECK-DAG: %[[CONST0:.+]] = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
-// CHECK-DAG: %[[VAL_3:.*]] = "tosa.const"() <{values = dense_resource<torch_tensor_64_torch.float32_1> : tensor<64xf32>}> : () -> tensor<64xf32>
-// CHECK-DAG: %[[VAL_4:.*]] = "tosa.const"() <{values = dense_resource<torch_tensor_64_torch.float32> : tensor<64xf32>}> : () -> tensor<64xf32>
-// CHECK-DAG: %[[VAL_5:.*]] = "tosa.const"() <{values = dense<9.99999974E-6> : tensor<1xf32>}> : () -> tensor<1xf32>
-// CHECK-DAG: %[[VAL_6:.*]] = "tosa.const"() <{values = dense<5.000000e-01> : tensor<1xf32>}> : () -> tensor<1xf32>
+// CHECK-DAG: %[[CONST0:.+]] = tosa.const values(dense<0> : tensor<1xi8>) : () -> tensor<1xi8>
+// CHECK-DAG: %[[VAL_3:.*]] = tosa.const values(dense_resource<torch_tensor_64_torch.float32_1> : tensor<64xf32>) : () -> tensor<64xf32>
+// CHECK-DAG: %[[VAL_4:.*]] = tosa.const values(dense_resource<torch_tensor_64_torch.float32> : tensor<64xf32>) : () -> tensor<64xf32>
+// CHECK-DAG: %[[VAL_5:.*]] = tosa.const values(dense<9.99999974E-6> : tensor<1xf32>) : () -> tensor<1xf32>
+// CHECK-DAG: %[[VAL_6:.*]] = tosa.const values(dense<5.000000e-01> : tensor<1xf32>) : () -> tensor<1xf32>
 // CHECK-DAG: %[[VAL_7:.*]] = tosa.add %arg1, %[[VAL_5]] : (tensor<64xf32>, tensor<1xf32>) -> tensor<64xf32>
 // CHECK-DAG: %[[VAL_8:.*]] = tosa.pow %[[VAL_7]], %[[VAL_6]] : (tensor<64xf32>, tensor<1xf32>) -> tensor<64xf32>
 // CHECK-DAG: %[[VAL_9:.*]] = tosa.reciprocal %[[VAL_8]] : (tensor<64xf32>) -> tensor<64xf32>
@@ -383,7 +383,7 @@ func.func @test_direct_use_in_other_transpose_with_same_perms(%arg0: tensor<3x3x
 // -----
 
 // CHECK-LABEL: @test_const_transpose
-// CHECK: %[[NEW:.*]] = "tosa.const"() <{values = dense<0> : tensor<2x3xi32>}> : () -> tensor<2x3xi32>
+// CHECK: %[[NEW:.*]] = tosa.const values(dense<0> : tensor<2x3xi32>) : () -> tensor<2x3xi32>
 // CHECK-NOT: tosa.transpose
 // CHECK: return %[[NEW]]
 func.func @test_const_transpose() -> tensor<2x3xi32> {
@@ -395,7 +395,7 @@ func.func @test_const_transpose() -> tensor<2x3xi32> {
 // -----
 
 // CHECK-LABEL: @test_transpose_tracks_to_const_single_step
-// CHECK: %[[NEW_CONST:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x2x3x4xi32>}> : () -> tensor<1x2x3x4xi32>
+// CHECK: %[[NEW_CONST:.*]] = tosa.const values(dense<0> : tensor<1x2x3x4xi32>) : () -> tensor<1x2x3x4xi32>
 // CHECK: %[[NEW_CLAMP:.*]] = tosa.clamp %[[NEW_CONST]] {max_val = 2147483647 : i32, min_val = 0 : i32} : (tensor<1x2x3x4xi32>) -> tensor<1x2x3x4xi32>
 // CHECK-NOT: tosa.transpose
 // CHECK: return %[[NEW_CLAMP]]
@@ -409,7 +409,7 @@ func.func @test_transpose_tracks_to_const_single_step() -> tensor<1x2x3x4xi32> {
 // -----
 
 // CHECK-LABEL: @test_static_unary_path_to_const
-// CHECK: %[[NEW_CONST:.*]] = "tosa.const"() <{values = dense<1> : tensor<1x2x3x4xi32>}> : () -> tensor<1x2x3x4xi32>
+// CHECK: %[[NEW_CONST:.*]] = tosa.const values(dense<1> : tensor<1x2x3x4xi32>) : () -> tensor<1x2x3x4xi32>
 // CHECK: %[[NEW_CLAMP:.*]] = tosa.clamp %[[NEW_CONST]] {max_val = 2147483647 : i32, min_val = 0 : i32} : (tensor<1x2x3x4xi32>) -> tensor<1x2x3x4xi32>
 // CHECK: %[[NEW_ABS:.*]] = tosa.abs %[[NEW_CLAMP]] : (tensor<1x2x3x4xi32>) -> tensor<1x2x3x4xi32>
 // CHECK: %[[NEW_NOT:.*]] = tosa.bitwise_not %[[NEW_ABS]] : (tensor<1x2x3x4xi32>) -> tensor<1x2x3x4xi32>
@@ -426,9 +426,9 @@ func.func @test_static_unary_path_to_const() -> tensor<1x2x3x4xi32> {
 // -----
 
 // CHECK-LABEL: @test_static_diverges_to_non_splat_const_and_nullifying
-// CHECK: %[[NEW_CONST:.*]] = "tosa.const"()
+// CHECK: %[[NEW_CONST:.*]] = tosa.const values(
 // CHECK-SAME{LITERAL}: dense<[[[[1, 3, 5, 7], [9, 11, 13, 15], [17, 19, 21, 23]], [[2, 4, 6, 8], [10, 12, 14, 16], [18, 20, 22, 24]]]]>
-// CHECK: tensor<1x2x3x4xi32>}> : () -> tensor<1x2x3x4xi32>
+// CHECK: tensor<1x2x3x4xi32>) : () -> tensor<1x2x3x4xi32>
 // CHECK: %[[NEW_CLAMP:.*]] = tosa.clamp %arg0 {max_val = 2147483647 : i32, min_val = 0 : i32} : (tensor<1x2x3x4xi32>) -> tensor<1x2x3x4xi32>
 // CHECK: %[[NEW_ABS:.*]] = tosa.abs %[[NEW_CONST]] : (tensor<1x2x3x4xi32>) -> tensor<1x2x3x4xi32>
 // CHECK: %[[NEW_ADD:.*]] = tosa.add %[[NEW_ABS]], %[[NEW_CLAMP]] : (tensor<1x2x3x4xi32>, tensor<1x2x3x4xi32>) -> tensor<1x2x3x4xi32>
@@ -599,7 +599,7 @@ func.func @test_unimplemented_static_diverges_to_one_nullifying_one_non_nullifyi
 }
 
 // CHECK-LABEL: @test_transpose_bool
-// CHECK: %{{.*}} = "tosa.const"()
+// CHECK: %{{.*}} = tosa.const
 // CHECK-SAME{LITERAL}: dense<[[true, false], [false, false], [false, true]]>
 func.func @test_transpose_bool() -> tensor<3x2xi1> {
   %0 = "tosa.const"() <{values = dense<[[true, false, false], [false, false, true]]> : tensor<2x3xi1>}> : () -> tensor<2x3xi1>
@@ -608,7 +608,7 @@ func.func @test_transpose_bool() -> tensor<3x2xi1> {
 }
 
 // CHECK-LABEL: @test_transpose_i4
-// CHECK: %{{.*}} = "tosa.const"()
+// CHECK: %{{.*}} = tosa.const
 // CHECK-SAME{LITERAL}: dense<[[1, 4], [2, 5], [3, 6]]>
 func.func @test_transpose_i4() -> tensor<3x2xi4> {
   %0 = "tosa.const"() <{values = dense<[[1, 2, 3], [4, 5, 6]]> : tensor<2x3xi4>}> : () -> tensor<2x3xi4>


### PR DESCRIPTION
This commit adds an assembly format for the TOSA CONST operation. Previously, the generic assembly format was used while all other operations had a custom format. It takes advantage of the incoming textual format changes in #217291, to minimise impact to downstream consumers.