### PR TITLE
[mlir][IR] Initialize empty dialect resource handles

### DIFF
--- a/mlir/include/mlir/IR/OpImplementation.h
+++ b/mlir/include/mlir/IR/OpImplementation.h
@@ -68,7 +68,7 @@ private:
   /// The type of the resource referenced.
   TypeID opaqueID;
   /// The dialect owning the given resource.
-  Dialect *dialect;
+  Dialect *dialect = nullptr;
 };
 
 /// This class represents a CRTP base class for dialect resource handles. It

--- a/mlir/unittests/IR/CMakeLists.txt
+++ b/mlir/unittests/IR/CMakeLists.txt
@@ -14,6 +14,7 @@ add_mlir_unittest(MLIRIRTests
   LocationTest.cpp
   MLIRContextResetTest.cpp
   MemrefLayoutTest.cpp
+  OpImplementationTest.cpp
   OperationSupportTest.cpp
   PatternMatchTest.cpp
   RemarkTest.cpp  

--- a/mlir/unittests/IR/OpImplementationTest.cpp
+++ b/mlir/unittests/IR/OpImplementationTest.cpp
@@ -1,0 +1,21 @@
+//===- OpImplementationTest.cpp - Operation implementation tests ----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/IR/OpImplementation.h"
+#include "gtest/gtest.h"
+
+using namespace mlir;
+
+namespace {
+TEST(AsmDialectResourceHandleTest, DefaultHandle) {
+  AsmDialectResourceHandle handle;
+  EXPECT_EQ(handle.getResource(), nullptr);
+  EXPECT_EQ(handle.getTypeID(), TypeID::get<void>());
+  EXPECT_EQ(handle.getDialect(), nullptr);
+}
+} // namespace


### PR DESCRIPTION
A default AsmDialectResourceHandle leaves its dialect pointer indeterminate. Initialize the pointer to null and test all default-handle accessors.

Valgrind pre-fix trace:

```
  OpImplementationTest.cpp:19: Failure
  Expected equality of handle.getDialect() and nullptr
  handle.getDialect() was 0x120b508
  1 FAILED TEST
```

Found by Coverity.

Assisted-by: Codex