### PR TITLE
[mlir][IR] Initialize empty AsmResourceBlob mutability

### DIFF
--- a/mlir/include/mlir/IR/AsmState.h
+++ b/mlir/include/mlir/IR/AsmState.h
@@ -179,7 +179,7 @@ private:
   DeleterFn deleter;
 
   /// Whether the data is mutable.
-  bool dataIsMutable;
+  bool dataIsMutable = false;
 
   friend class HeapAsmResourceBlob;
 };

--- a/mlir/unittests/IR/AttributeTest.cpp
+++ b/mlir/unittests/IR/AttributeTest.cpp
@@ -263,6 +263,17 @@ TEST(DenseSplatMapValuesTest, I32ToFalse) {
 } // namespace
 
 //===----------------------------------------------------------------------===//
+// AsmResourceBlob
+//===----------------------------------------------------------------------===//
+
+namespace {
+TEST(AsmResourceBlobTest, DefaultBlobIsImmutable) {
+  AsmResourceBlob blob;
+  EXPECT_FALSE(blob.isMutable());
+}
+} // namespace
+
+//===----------------------------------------------------------------------===//
 // DenseResourceElementsAttr
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
The default constructor leaves dataIsMutable indeterminate even though isMutable may be called on an empty blob. Treat default-constructed blobs as immutable and cover that state with a unit test.

Valgrind pre-fix trace:

```
  Invalid read of size 8
    at testing::Test::Run()
  Invalid write of size 8
  Invalid free() / delete / delete[] / realloc()
  ERROR SUMMARY: 6 errors from 6 contexts
```

Found by Coverity.

Assisted-by: Codex