### PR TITLE
[mlir][Pass] Remove unused PassExecutionAction field

### DIFF
--- a/mlir/include/mlir/Pass/Pass.h
+++ b/mlir/include/mlir/Pass/Pass.h
@@ -529,10 +529,6 @@ public:
   /// lifetime of the pass, and so this class is therefore unsafe to keep past
   /// the lifetime of the `executeAction` call.
   const Pass &pass;
-
-  /// The base op for this pass. For an OperationPass<ModuleOp>, we would have a
-  /// ModuleOp here.
-  Operation *op;
 };
 
 } // namespace mlir


### PR DESCRIPTION
PassExecutionAction::getOp derives the current operation from the action context. The separate op field is never initialized or read, so remove it.

Found by Coverity.

Assisted-by: Codex