### PR TITLE
[analyzer][NFC] Fix typo in `exploredAllPaths` variable & predicate

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -82,9 +82,10 @@ private:
   /// usually because it could not reason about something.
   BlocksAborted blocksAborted;
 
-  /// Whether the single-TU phase ran out of budget with work left over.
+  /// Whether the single-TU phase completed the exploration of all paths
+  /// within its budget limit.
   /// The CTU phase replaces \c WList, so this has to be remembered separately.
-  bool exploredAllSTUPaths = false;
+  bool ExploredAllSTUPaths = false;
 
   /// The information about functions shared by the whole translation unit.
   /// (This data is owned by AnalysisConsumer.)
@@ -151,8 +152,8 @@ public:
   bool wasBlockAborted() const { return !blocksAborted.empty(); }
   bool wasBlocksExhausted() const { return !blocksExhausted.empty(); }
   bool hasExploredAllPaths() const {
-    return wasBlocksExhausted() || WList->hasWork() || exploredAllSTUPaths ||
-           wasBlockAborted();
+    return !wasBlocksExhausted() && !WList->hasWork() && ExploredAllSTUPaths &&
+           !wasBlockAborted();
   }
 
   /// Inform the CoreEngine that a basic block was aborted because

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -84,7 +84,7 @@ private:
 
   /// Whether the single-TU phase ran out of budget with work left over.
   /// The CTU phase replaces \c WList, so this has to be remembered separately.
-  bool notExploredAllSTUPaths = false;
+  bool exploredAllSTUPaths = false;
 
   /// The information about functions shared by the whole translation unit.
   /// (This data is owned by AnalysisConsumer.)
@@ -150,8 +150,8 @@ public:
   // Functions for external checking of whether we have unfinished work.
   bool wasBlockAborted() const { return !blocksAborted.empty(); }
   bool wasBlocksExhausted() const { return !blocksExhausted.empty(); }
-  bool hasNotExploredAllPaths() const {
-    return wasBlocksExhausted() || WList->hasWork() || notExploredAllSTUPaths ||
+  bool hasExploredAllPaths() const {
+    return wasBlocksExhausted() || WList->hasWork() || exploredAllSTUPaths ||
            wasBlockAborted();
   }
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -84,7 +84,7 @@ private:
 
   /// Whether the single-TU phase ran out of budget with work left over.
   /// The CTU phase replaces \c WList, so this has to be remembered separately.
-  bool exploredAllSTUPaths = false;
+  bool notExploredAllSTUPaths = false;
 
   /// The information about functions shared by the whole translation unit.
   /// (This data is owned by AnalysisConsumer.)
@@ -150,8 +150,8 @@ public:
   // Functions for external checking of whether we have unfinished work.
   bool wasBlockAborted() const { return !blocksAborted.empty(); }
   bool wasBlocksExhausted() const { return !blocksExhausted.empty(); }
-  bool hasExploredAllPaths() const {
-    return wasBlocksExhausted() || WList->hasWork() || exploredAllSTUPaths ||
+  bool hasNotExploredAllPaths() const {
+    return wasBlocksExhausted() || WList->hasWork() || notExploredAllSTUPaths ||
            wasBlockAborted();
   }
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -467,7 +467,7 @@ public:
   // Functions for external checking of whether we have unfinished work.
   bool wasBlocksExhausted() const { return Engine.wasBlocksExhausted(); }
   bool hasEmptyWorkList() const { return !Engine.getWorkList()->hasWork(); }
-  bool hasExploredAllPaths() const { return Engine.hasExploredAllPaths(); }
+  bool hasNotExploredAllPaths() const { return Engine.hasNotExploredAllPaths(); }
 
   const CoreEngine &getCoreEngine() const { return Engine; }
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -467,7 +467,7 @@ public:
   // Functions for external checking of whether we have unfinished work.
   bool wasBlocksExhausted() const { return Engine.wasBlocksExhausted(); }
   bool hasEmptyWorkList() const { return !Engine.getWorkList()->hasWork(); }
-  bool hasNotExploredAllPaths() const { return Engine.hasNotExploredAllPaths(); }
+  bool hasExploredAllPaths() const { return Engine.hasExploredAllPaths(); }
 
   const CoreEngine &getCoreEngine() const { return Engine; }
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -467,9 +467,7 @@ public:
   // Functions for external checking of whether we have unfinished work.
   bool wasBlocksExhausted() const { return Engine.wasBlocksExhausted(); }
   bool hasEmptyWorkList() const { return !Engine.getWorkList()->hasWork(); }
-  bool hasNotExploredAllPaths() const {
-    return Engine.hasNotExploredAllPaths();
-  }
+  bool hasNotExploredAllPaths() const { return Engine.hasNotExploredAllPaths(); }
 
   const CoreEngine &getCoreEngine() const { return Engine; }
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -467,7 +467,9 @@ public:
   // Functions for external checking of whether we have unfinished work.
   bool wasBlocksExhausted() const { return Engine.wasBlocksExhausted(); }
   bool hasEmptyWorkList() const { return !Engine.getWorkList()->hasWork(); }
-  bool hasNotExploredAllPaths() const { return Engine.hasNotExploredAllPaths(); }
+  bool hasNotExploredAllPaths() const {
+    return Engine.hasNotExploredAllPaths();
+  }
 
   const CoreEngine &getCoreEngine() const { return Engine; }
 

--- a/clang/lib/StaticAnalyzer/Checkers/UnreachableCodeChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/UnreachableCodeChecker.cpp
@@ -51,7 +51,7 @@ void UnreachableCodeChecker::checkEndAnalysis(ExplodedGraph &G,
                                               ExprEngine &Eng) const {
   CFGBlocksSet reachable, visited;
 
-  if (Eng.hasExploredAllPaths())
+  if (!Eng.hasExploredAllPaths())
     return;
 
   const Decl *D = nullptr;

--- a/clang/lib/StaticAnalyzer/Checkers/UnreachableCodeChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/UnreachableCodeChecker.cpp
@@ -51,7 +51,7 @@ void UnreachableCodeChecker::checkEndAnalysis(ExplodedGraph &G,
                                               ExprEngine &Eng) const {
   CFGBlocksSet reachable, visited;
 
-  if (Eng.hasExploredAllPaths())
+  if (Eng.hasNotExploredAllPaths())
     return;
 
   const Decl *D = nullptr;

--- a/clang/lib/StaticAnalyzer/Checkers/UnreachableCodeChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/UnreachableCodeChecker.cpp
@@ -51,7 +51,7 @@ void UnreachableCodeChecker::checkEndAnalysis(ExplodedGraph &G,
                                               ExprEngine &Eng) const {
   CFGBlocksSet reachable, visited;
 
-  if (Eng.hasNotExploredAllPaths())
+  if (Eng.hasExploredAllPaths())
     return;
 
   const Decl *D = nullptr;

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -161,7 +161,7 @@ bool CoreEngine::ExecuteWorkList(const StackFrame *SF, unsigned MaxSteps,
     return MaxSteps - Steps;
   };
   const unsigned STUSteps = ProcessWList(MaxSteps);
-  exploredAllSTUPaths = WList->hasWork();
+  ExploredAllSTUPaths = !WList->hasWork();
 
   if (CTUWList) {
     NumSTUSteps += STUSteps;

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -161,7 +161,7 @@ bool CoreEngine::ExecuteWorkList(const StackFrame *SF, unsigned MaxSteps,
     return MaxSteps - Steps;
   };
   const unsigned STUSteps = ProcessWList(MaxSteps);
-  exploredAllSTUPaths = WList->hasWork();
+  notExploredAllSTUPaths = WList->hasWork();
 
   if (CTUWList) {
     NumSTUSteps += STUSteps;

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -161,7 +161,7 @@ bool CoreEngine::ExecuteWorkList(const StackFrame *SF, unsigned MaxSteps,
     return MaxSteps - Steps;
   };
   const unsigned STUSteps = ProcessWList(MaxSteps);
-  notExploredAllSTUPaths = WList->hasWork();
+  exploredAllSTUPaths = WList->hasWork();
 
   if (CTUWList) {
     NumSTUSteps += STUSteps;


### PR DESCRIPTION
During development of #219225 `hasWorkRemaining` was accidentally renamed to `exploredAllSTUPaths`, but the correct name should contain a `not`, i.e., `notExploredAllSTUPaths` which matches the polarity of `hasWorkRemaining`.

Perform an exhaustive renaming of all occurrences.

--
CPP-8856