### PR TITLE
[Polly][NFC] Fix loop index in C comments of tests with nested loops

### DIFF
--- a/polly/test/ScopDetect/simple_loop_with_param.ll
+++ b/polly/test/ScopDetect/simple_loop_with_param.ll
@@ -2,14 +2,14 @@
 
 ; void f(long A[], long N, long *init_ptr) {
 ;   long i, j;
-;   long i_non_canonical;
+;   long j_non_canonical;
 ;
 ;   for (i = 0; i < N; ++i) {
 ;     init = *init_ptr;
-;     i_non_canonical = init;
-;     for (i = 0; i < N; ++i) {
-;       A[i] = i_non_canonical;
-;       i_non_canonical += 1;
+;     j_non_canonical = init;
+;     for (j = 0; j < N; ++j) {
+;       A[j] = j_non_canonical;
+;       j_non_canonical += 1;
 ;     }
 ;   }
 ; }

--- a/polly/test/ScopDetect/simple_loop_with_param_2.ll
+++ b/polly/test/ScopDetect/simple_loop_with_param_2.ll
@@ -5,8 +5,8 @@
 ;
 ;   for (i = 0; i < N; ++i) {
 ;     init = *init_ptr;
-;     for (i = 0; i < N; ++i) {
-;       A[i] = init + 2;
+;     for (j = 0; j < N; ++j) {
+;       A[j] = init + 2;
 ;     }
 ;   }
 ; }

--- a/polly/test/ScopInfo/inter_bb_scalar_dep.ll
+++ b/polly/test/ScopInfo/inter_bb_scalar_dep.ll
@@ -5,8 +5,8 @@
 ;
 ;   for (i = 0; i < N; ++i) {
 ;     init = *init_ptr;
-;     for (i = 0; i < N; ++i) {
-;       A[i] = init + 2;
+;     for (j = 0; j < N; ++j) {
+;       A[j] = init + 2;
 ;     }
 ;   }
 ; }

--- a/polly/test/ScopInfo/intra_and_inter_bb_scalar_dep.ll
+++ b/polly/test/ScopInfo/intra_and_inter_bb_scalar_dep.ll
@@ -5,9 +5,9 @@
 ;
 ;   for (i = 0; i < N; ++i) {
 ;     init = *init_ptr;
-;     for (i = 0; i < N; ++i) {
+;     for (j = 0; j < N; ++j) {
 ;       init2 = *init_ptr;
-;       A[i] = init + init2;
+;       A[j] = init + init2;
 ;     }
 ;   }
 ; }

--- a/polly/test/ScopInfo/intra_bb_scalar_dep.ll
+++ b/polly/test/ScopInfo/intra_bb_scalar_dep.ll
@@ -4,9 +4,9 @@
 ;   long i, j;
 ;
 ;   for (i = 0; i < N; ++i) {
-;     for (i = 0; i < N; ++i) {
+;     for (j = 0; j < N; ++j) {
 ;       init = *init_ptr;
-;       A[i] = init + 2;
+;       A[j] = init + 2;
 ;     }
 ;   }
 ; }

--- a/polly/test/ScopInfo/tempscop-printing.ll
+++ b/polly/test/ScopInfo/tempscop-printing.ll
@@ -5,8 +5,8 @@
 ;
 ;   for (i = 0; i < N; ++i) {
 ;     init = *init_ptr;
-;     for (i = 0; i < N; ++i) {
-;       A[i] = init + 2;
+;     for (j = 0; j < N; ++j) {
+;       A[j] = init + 2;
 ;     }
 ;   }
 ; }


### PR DESCRIPTION
The C pseudo-code in tests declares `long i, j`, but the inner loop reuses `i` instead of `j`, which would overwrite the outer loop counter and describe a different program than the IR below it.