### PR TITLE
[lldb][test] Fix RegisterTypeBuilder tests on Arm 32-bit

### DIFF
--- a/lldb/unittests/Target/RegisterTypeBuilderClangTest.cpp
+++ b/lldb/unittests/Target/RegisterTypeBuilderClangTest.cpp
@@ -14,6 +14,7 @@
 #include "lldb/Core/Debugger.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/HostInfo.h"
+#include "lldb/Target/Target.h"
 #include "lldb/Utility/ArchSpec.h"
 #include "lldb/Utility/RegisterInfo.h"
 #include "lldb/Utility/RegisterType.h"
@@ -39,10 +40,14 @@ protected:
     std::call_once(TestUtilities::g_debugger_initialize_flag,
                    []() { Debugger::Initialize(nullptr); });
     ArchSpec host_arch("x86_64-pc-linux");
+    m_default_arch = Target::GetDefaultArchitecture();
+    Target::SetDefaultArchitecture(host_arch);
     Platform::SetHostPlatform(
         platform_linux::PlatformLinux::CreateInstance(true, &host_arch));
     m_debugger_sp = Debugger::CreateInstance();
   }
+
+  void TearDown() override { Target::SetDefaultArchitecture(m_default_arch); }
 
   static RegisterInfo MakeRegisterInfo(const RegisterType &type,
                                        uint32_t byte_size) {
@@ -54,6 +59,7 @@ protected:
   }
 
   DebuggerSP m_debugger_sp;
+  ArchSpec m_default_arch;
 };
 
 TEST_F(RegisterTypeBuilderClangTest, ReusesCachedType) {


### PR DESCRIPTION
By setting the target triple to x86_64 Linux (same as the fake platform), so we are always using the x86_64 types.

Fixes #218725 / bc2a795648a3b3412fb833db4f879dae3d604275.

There were two failure points:
* Pointer sizes, easily fixed by using sizeof(void*).
* Bfloat type being valid but not having a size. I think that's because for it to have a size on Arm you'd have to have the bf16 feature enabled.

And I could work around both of those but it would make the tests more complex for a detail we're not actually concerned about here.

Also it's confusing to see a triple set in one thing and not used in another, so we should make that
consistent regardless.