### PR TITLE
[orc-rt] Drop the _C_ prefix from ORC_RT_C_FORMAT_PRINTF

### DIFF
--- a/orc-rt/include/orc-rt-c/support/Compiler.h
+++ b/orc-rt/include/orc-rt-c/support/Compiler.h
@@ -74,15 +74,15 @@
 #define ORC_RT_C_NOTHROW
 #endif
 
-/* ORC_RT_C_FORMAT_PRINTF(FmtIdx, FirstArg) marks a function as taking a
+/* ORC_RT_FORMAT_PRINTF(FmtIdx, FirstArg) marks a function as taking a
    printf-style format string at argument position FmtIdx, with the variadic
    arguments beginning at FirstArg, so the compiler can check the format string
    against its arguments. Indices are 1-based. */
 #if defined(__GNUC__) || defined(__clang__)
-#define ORC_RT_C_FORMAT_PRINTF(FmtIdx, FirstArg)                               \
+#define ORC_RT_FORMAT_PRINTF(FmtIdx, FirstArg)                                 \
   __attribute__((format(printf, FmtIdx, FirstArg)))
 #else
-#define ORC_RT_C_FORMAT_PRINTF(FmtIdx, FirstArg)
+#define ORC_RT_FORMAT_PRINTF(FmtIdx, FirstArg)
 #endif
 
 #endif /* ORC_RT_C_SUPPORT_COMPILER_H */

--- a/orc-rt/include/orc-rt-c/support/Logging.h
+++ b/orc-rt/include/orc-rt-c/support/Logging.h
@@ -103,7 +103,7 @@ orc_rt_log_Level orc_rt_log_Level_parse(const char *Str) ORC_RT_C_NOTHROW;
  * to type-check a printf-style format string against its arguments without
  * evaluating them or emitting any code.
  */
-int orc_rt_log_formatCheck(const char *Fmt, ...) ORC_RT_C_FORMAT_PRINTF(1, 2);
+int orc_rt_log_formatCheck(const char *Fmt, ...) ORC_RT_FORMAT_PRINTF(1, 2);
 
 /*
  * A disabled log site. Validates the category token, format string, and
@@ -185,7 +185,7 @@ int orc_rt_log_formatCheck(const char *Fmt, ...) ORC_RT_C_FORMAT_PRINTF(1, 2);
  */
 void orc_rt_log_printf(orc_rt_log_Level Level, orc_rt_log_Category Category,
                        const char *Fmt, ...) ORC_RT_C_NOTHROW
-    ORC_RT_C_FORMAT_PRINTF(3, 4);
+    ORC_RT_FORMAT_PRINTF(3, 4);
 
 /*
  * Each level is compiled in only if it is at or above the ORC_RT_LOG_LEVEL


### PR DESCRIPTION
The macro is not C-specific. Rename it to ORC_RT_FORMAT_PRINTF and update its two uses in Logging.h.