### PR TITLE
[Clang][Sema] Give calls synthesized by `__builtin_invoke` a valid source range

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -490,10 +490,10 @@ features cannot lower the translation-unit ABI level;
 
 - Fixed a crash when classifying a call to a builtin with dependent arguments,
   such as when the call is used as an `auto` non-type template argument.
-- Fixed a crash in ``__builtin_dump_struct`` when ``-Werror`` promotes
-  format warnings to errors. (#GH211943)
 - Fixed an assertion failure when diagnosing a constant evaluation failure
   inside a member function call synthesized by ``__builtin_invoke``. (#GH185241)
+- Fixed a crash in ``__builtin_dump_struct`` when ``-Werror`` promotes
+  format warnings to errors. (#GH211943)
 
 #### Bug Fixes to Attribute Support
 

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -492,6 +492,9 @@ features cannot lower the translation-unit ABI level;
   such as when the call is used as an `auto` non-type template argument.
 - Fixed a crash in ``__builtin_dump_struct`` when ``-Werror`` promotes
   format warnings to errors. (#GH211943)
+- Fixed an assertion failure when diagnosing a constant evaluation failure
+  inside a member function call synthesized by ``__builtin_invoke``.
+  (#GH185241)
 
 #### Bug Fixes to Attribute Support
 

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -493,8 +493,7 @@ features cannot lower the translation-unit ABI level;
 - Fixed a crash in ``__builtin_dump_struct`` when ``-Werror`` promotes
   format warnings to errors. (#GH211943)
 - Fixed an assertion failure when diagnosing a constant evaluation failure
-  inside a member function call synthesized by ``__builtin_invoke``.
-  (#GH185241)
+  inside a member function call synthesized by ``__builtin_invoke``. (#GH185241)
 
 #### Bug Fixes to Attribute Support
 

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -3015,8 +3015,9 @@ static ExprResult BuiltinInvoke(Sema &S, CallExpr *TheCall) {
     if (MPT->isMemberDataPointer())
       return BinOp;
 
+    // Give the synthesized expression a valid source range for diagnostics.
     auto *MemCall = new (S.Context)
-        ParenExpr(SourceLocation(), SourceLocation(), BinOp.get());
+        ParenExpr(TheCall->getBeginLoc(), TheCall->getRParenLoc(), BinOp.get());
 
     return S.ActOnCallExpr(S.getCurScope(), MemCall, TheCall->getBeginLoc(),
                            Args.drop_front(2), TheCall->getRParenLoc());

--- a/clang/test/SemaCXX/builtin-invoke.cpp
+++ b/clang/test/SemaCXX/builtin-invoke.cpp
@@ -238,3 +238,17 @@ static_assert([]() {
 
   return true;
 }());
+
+namespace GH185241 {
+struct S {
+  constexpr int func() {} // expected-note {{control reached end of constexpr function}}
+};
+
+static_assert([]() { // expected-error {{static assertion expression is not an integral constant expression}} \
+                        expected-note {{in call to '[]() {}.operator()()'}}
+  S s;
+  if (__builtin_invoke(&S::func, s)) // expected-note {{in call to 's.func()'}}
+    return false;
+  return true;
+}());
+} // namespace GH185241


### PR DESCRIPTION
Fixes #185241

When `__builtin_invoke` is called with a pointer to member function, Sema rewrites it into `(obj.*memptr)(args)` and wraps the `.*` expression in a `ParenExpr` that was created without source locations. A call expression takes its begin location from its callee, with the first argument as fallback — so when there are no trailing arguments, the synthesized member call ends up with no valid location at all. The classic constant evaluator stores each call expression's range as the frame's `CallRange` and asserts it is valid while building the "in call to" note chain, so diagnosing any failure inside such a call (here, control flowing off the end of a `constexpr` function) crashed instead of producing the error. The bytecode interpreter only dodges this because it skips invalid ranges when picking a location for the note.

The `ParenExpr` now carries the locations of the `__builtin_invoke` call itself, so the synthesized call maps back to its actual call site like an ordinary call would, and the "in call to" note points at the `__builtin_invoke(...)` expression. This also covers the `std::ref` and pointer object forms, which go through the same node, and the assertion stays as is since it guards a real invariant. I also added the reproducer to the existing `builtin-invoke` test.
