### PR TITLE
[llvm][ADT] Remove function_ref equality operator

### DIFF
--- a/llvm/include/llvm/ADT/STLFunctionalExtras.h
+++ b/llvm/include/llvm/ADT/STLFunctionalExtras.h
@@ -70,10 +70,6 @@ public:
   }
 
   explicit operator bool() const { return callback; }
-
-  bool operator==(const function_ref<Ret(Params...)> &Other) const {
-    return callable == Other.callable;
-  }
 };
 
 } // end namespace llvm

--- a/llvm/unittests/ADT/FunctionRefTest.cpp
+++ b/llvm/unittests/ADT/FunctionRefTest.cpp
@@ -27,20 +27,19 @@ TEST(FunctionRefTest, Null) {
   EXPECT_FALSE(F);
 }
 
-TEST(FunctionRefTest, EmptyCopyAndEquality) {
+TEST(FunctionRefTest, DefaultConstructedCopy) {
   function_ref<int()> Empty;
-  function_ref<int()> Null = nullptr;
-  EXPECT_EQ(Empty, Null);
-
   function_ref<int()> Copy = Empty;
+  EXPECT_FALSE(Empty);
   EXPECT_FALSE(Copy);
-  EXPECT_EQ(Empty, Copy);
+
+  function_ref<int()> Null = nullptr;
+  EXPECT_FALSE(Null);
 
   auto L = [] { return 1; };
   function_ref<int()> Assigned = L;
   Assigned = Empty;
   EXPECT_FALSE(Assigned);
-  EXPECT_EQ(Empty, Assigned);
 }
 
 // Ensure that copies of a function_ref copy the underlying state rather than
@@ -73,16 +72,6 @@ TEST(FunctionRefTest, SFINAE) {
   EXPECT_EQ("not a function", returns("boo!"));
   EXPECT_EQ("number", returns([] { return 42; }));
   EXPECT_EQ("string", returns([] { return "hello"; }));
-}
-
-TEST(FunctionRefTest, Equality) {
-  const auto Lambda = []() { return 0; };
-  function_ref<int()> X = Lambda;
-  function_ref<int()> Y = X;
-  EXPECT_EQ(X, Y);
-
-  function_ref<int()> A(Lambda), B(Lambda);
-  EXPECT_EQ(A, B);
 }
 
 } // namespace

--- a/llvm/unittests/ADT/FunctionRefTest.cpp
+++ b/llvm/unittests/ADT/FunctionRefTest.cpp
@@ -32,6 +32,9 @@ TEST(FunctionRefTest, DefaultConstructedCopy) {
   function_ref<int()> Copy = Empty;
   EXPECT_FALSE(Empty);
   EXPECT_FALSE(Copy);
+#if LLVM_MEMORY_SANITIZER_BUILD
+  __msan_check_mem_is_initialized(&Copy, sizeof(Copy));
+#endif
 
   function_ref<int()> Null = nullptr;
   EXPECT_FALSE(Null);


### PR DESCRIPTION
The equality operator no longer has in-tree users.

TableGen replaced its function_ref callback wrapper with its own FnT.

Assisted-by: Codex