### PR TITLE
[mlir] Remove unnecessary allow-unregistered-dialect flags

### DIFF
--- a/mlir/test/Analysis/DataFlow/integer-divisibility.mlir
+++ b/mlir/test/Analysis/DataFlow/integer-divisibility.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt --split-input-file --test-int-divisibility-analysis --allow-unregistered-dialect %s | FileCheck %s
+// RUN: mlir-opt --split-input-file --test-int-divisibility-analysis %s | FileCheck %s
 
 // CHECK-LABEL: @constant
 func.func @constant() -> index {

--- a/mlir/test/Conversion/ComplexToROCDLLibraryCalls/complex-to-rocdl-library-calls.mlir
+++ b/mlir/test/Conversion/ComplexToROCDLLibraryCalls/complex-to-rocdl-library-calls.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --allow-unregistered-dialect -convert-complex-to-rocdl-library-calls | FileCheck %s
+// RUN: mlir-opt %s -convert-complex-to-rocdl-library-calls | FileCheck %s
 
 // CHECK-DAG: @__ocml_cabs_f32(complex<f32>) -> f32
 // CHECK-DAG: @__ocml_cabs_f64(complex<f64>) -> f64

--- a/mlir/test/Conversion/MemRefToSPIRV/map-storage-class-vk.mlir
+++ b/mlir/test/Conversion/MemRefToSPIRV/map-storage-class-vk.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt --allow-unregistered-dialect --map-memref-spirv-storage-class='client-api=vulkan' %s | FileCheck %s
+// RUN: mlir-opt --map-memref-spirv-storage-class='client-api=vulkan' %s | FileCheck %s
 
 // Vulkan Specific Mappings:
 //   8 -> UniformConstant
@@ -14,14 +14,14 @@
 // CHECK-LABEL: func @test_vk_specific_memory_spaces
 func.func @test_vk_specific_memory_spaces() {
   // CHECK: memref<4xi32, #spirv.storage_class<UniformConstant>>
-  %1 = "dialect.memref_producer"() : () -> (memref<4xi32, 8>)
+  %1 = "test.memref_producer"() : () -> (memref<4xi32, 8>)
   // CHECK: memref<4xi32, #spirv.storage_class<Input>>
-  %2 = "dialect.memref_producer"() : () -> (memref<4xi32, 9>)
+  %2 = "test.memref_producer"() : () -> (memref<4xi32, 9>)
   // CHECK: memref<4xi32, #spirv.storage_class<Output>>
-  %3 = "dialect.memref_producer"() : () -> (memref<4xi32, 10>)
+  %3 = "test.memref_producer"() : () -> (memref<4xi32, 10>)
   // CHECK: memref<4xi32, #spirv.storage_class<PhysicalStorageBuffer>>
-  %4 = "dialect.memref_producer"() : () -> (memref<4xi32, 11>)
+  %4 = "test.memref_producer"() : () -> (memref<4xi32, 11>)
   // CHECK: memref<4xi32, #spirv.storage_class<Image>>
-  %5 = "dialect.memref_producer"() : () -> (memref<4xi32, 12>)
+  %5 = "test.memref_producer"() : () -> (memref<4xi32, 12>)
   return
 }

--- a/mlir/test/Dialect/Bufferization/Transforms/OwnershipBasedBufferDeallocation/dealloc-function-boundaries.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/OwnershipBasedBufferDeallocation/dealloc-function-boundaries.mlir
@@ -1,6 +1,6 @@
-// RUN: mlir-opt --allow-unregistered-dialect -verify-diagnostics -ownership-based-buffer-deallocation=private-function-dynamic-ownership=false \
+// RUN: mlir-opt -verify-diagnostics -ownership-based-buffer-deallocation=private-function-dynamic-ownership=false \
 // RUN:  --buffer-deallocation-simplification -split-input-file %s | FileCheck %s
-// RUN: mlir-opt --allow-unregistered-dialect -verify-diagnostics -ownership-based-buffer-deallocation=private-function-dynamic-ownership=true \
+// RUN: mlir-opt -verify-diagnostics -ownership-based-buffer-deallocation=private-function-dynamic-ownership=true \
 // RUN:  --buffer-deallocation-simplification -split-input-file %s | FileCheck %s --check-prefix=CHECK-DYNAMIC
 
 // RUN: mlir-opt %s -buffer-deallocation-pipeline --split-input-file > /dev/null

--- a/mlir/test/Dialect/GPU/bufferization-buffer-deallocation.mlir
+++ b/mlir/test/Dialect/GPU/bufferization-buffer-deallocation.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s -buffer-deallocation-pipeline --allow-unregistered-dialect | FileCheck %s
+// RUN: mlir-opt %s -buffer-deallocation-pipeline | FileCheck %s
 
 func.func @gpu_launch() {
   %c1 = arith.constant 1 : index

--- a/mlir/test/Dialect/GPU/subgroup-reduce-lowering.mlir
+++ b/mlir/test/Dialect/GPU/subgroup-reduce-lowering.mlir
@@ -1,16 +1,16 @@
-// RUN: mlir-opt  --allow-unregistered-dialect \
+// RUN: mlir-opt \
 // RUN:   --test-gpu-subgroup-reduce-lowering %s \
 // RUN:   | FileCheck %s --check-prefix=CHECK-SUB
 
-// RUN: mlir-opt --allow-unregistered-dialect \
+// RUN: mlir-opt \
 // RUN:   --test-gpu-subgroup-reduce-lowering="expand-to-shuffles" %s \
 // RUN:   | FileCheck %s --check-prefix=CHECK-SHFL
 
-// RUN: mlir-opt --allow-unregistered-dialect \
+// RUN: mlir-opt \
 // RUN:   --test-gpu-subgroup-reduce-lowering="expand-to-shuffles target=gfx942" %s \
 // RUN:   | FileCheck %s --check-prefixes=CHECK-GFX,CHECK-GFX9
 
-// RUN: mlir-opt --allow-unregistered-dialect \
+// RUN: mlir-opt \
 // RUN:   --test-gpu-subgroup-reduce-lowering="expand-to-shuffles target=gfx1030" %s \
 // RUN:   | FileCheck %s --check-prefixes=CHECK-GFX,CHECK-GFX10
 
@@ -442,4 +442,3 @@ gpu.module @kernels {
     gpu.return
   }
 }
-

--- a/mlir/test/Dialect/LLVMIR/dereferenceable-invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/dereferenceable-invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt --allow-unregistered-dialect -split-input-file -verify-diagnostics %s
+// RUN: mlir-opt -split-input-file -verify-diagnostics %s
 
 llvm.func @deref(%arg0: !llvm.ptr) {
     // expected-error @below {{op expected op to return a single LLVM pointer type}}

--- a/mlir/test/Dialect/LLVMIR/types-invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/types-invalid.mlir
@@ -1,133 +1,133 @@
-// RUN: mlir-opt --allow-unregistered-dialect -split-input-file -verify-diagnostics %s
+// RUN: mlir-opt -split-input-file -verify-diagnostics %s
 
 func.func @array_of_void() {
   // expected-error @+1 {{invalid array element type}}
-  "some.op"() : () -> !llvm.array<4 x void>
+  "test.some_op"() : () -> !llvm.array<4 x void>
 }
 
 // -----
 
 func.func @function_returning_function() {
   // expected-error @+1 {{invalid function result type}}
-  "some.op"() : () -> !llvm.func<func<void ()> ()>
+  "test.some_op"() : () -> !llvm.func<func<void ()> ()>
 }
 
 // -----
 
 func.func @function_taking_opaque_struct() {
   // expected-error @+1 {{invalid function argument type}}
-  "some.op"() : () -> !llvm.func<void(struct<"foo", opaque>)>
+  "test.some_op"() : () -> !llvm.func<void(struct<"foo", opaque>)>
 }
 
 // -----
 
 func.func @function_taking_function() {
   // expected-error @+1 {{invalid function argument type}}
-  "some.op"() : () -> !llvm.func<void (func<void ()>)>
+  "test.some_op"() : () -> !llvm.func<void (func<void ()>)>
 }
 
 // -----
 
 func.func @repeated_struct_name() {
-  "some.op"() : () -> !llvm.struct<"a", (ptr)>
+  "test.some_op"() : () -> !llvm.struct<"a", (ptr)>
   // expected-error @+1 {{identified type already used with a different body}}
-  "some.op"() : () -> !llvm.struct<"a", (i32)>
+  "test.some_op"() : () -> !llvm.struct<"a", (i32)>
 }
 
 // -----
 
 func.func @repeated_struct_name_packed() {
-  "some.op"() : () -> !llvm.struct<"a", packed (i32)>
+  "test.some_op"() : () -> !llvm.struct<"a", packed (i32)>
   // expected-error @+1 {{identified type already used with a different body}}
-  "some.op"() : () -> !llvm.struct<"a", (i32)>
+  "test.some_op"() : () -> !llvm.struct<"a", (i32)>
 }
 
 // -----
 
 func.func @repeated_struct_opaque() {
-  "some.op"() : () -> !llvm.struct<"a", opaque>
+  "test.some_op"() : () -> !llvm.struct<"a", opaque>
   // expected-error @+1 {{identified type already used with a different body}}
-  "some.op"() : () -> !llvm.struct<"a", ()>
+  "test.some_op"() : () -> !llvm.struct<"a", ()>
 }
 
 // -----
 
 func.func @repeated_struct_opaque_non_empty() {
-  "some.op"() : () -> !llvm.struct<"a", opaque>
+  "test.some_op"() : () -> !llvm.struct<"a", opaque>
   // expected-error @+1 {{identified type already used with a different body}}
-  "some.op"() : () -> !llvm.struct<"a", (i32, i32)>
+  "test.some_op"() : () -> !llvm.struct<"a", (i32, i32)>
 }
 
 // -----
 
 func.func @repeated_struct_opaque_redefinition() {
-  "some.op"() : () -> !llvm.struct<"a", ()>
+  "test.some_op"() : () -> !llvm.struct<"a", ()>
   // expected-error @+1 {{redeclaring defined struct as opaque}}
-  "some.op"() : () -> !llvm.struct<"a", opaque>
+  "test.some_op"() : () -> !llvm.struct<"a", opaque>
 }
 
 // -----
 
 func.func @struct_literal_opaque() {
   // expected-error @+1 {{only identified structs can be opaque}}
-  "some.op"() : () -> !llvm.struct<opaque>
+  "test.some_op"() : () -> !llvm.struct<opaque>
 }
 
 // -----
 
 func.func @top_level_struct_no_body() {
   // expected-error @below {{struct without a body only allowed in a recursive struct}}
-  "some.op"() : () -> !llvm.struct<"a">
+  "test.some_op"() : () -> !llvm.struct<"a">
 }
 
 // -----
 
 func.func @nested_redefine_attempt() {
   // expected-error @below {{identifier already used for an enclosing struct}}
-  "some.op"() : () -> !llvm.struct<"a", (struct<"a", ()>)>
+  "test.some_op"() : () -> !llvm.struct<"a", (struct<"a", ()>)>
 }
 
 // -----
 
 func.func @unexpected_type() {
   // expected-error @+1 {{unexpected type, expected keyword}}
-  "some.op"() : () -> !llvm.tensor<*xf32>
+  "test.some_op"() : () -> !llvm.tensor<*xf32>
 }
 
 // -----
 
 func.func @unexpected_type() {
   // expected-error @+1 {{unknown LLVM type}}
-  "some.op"() : () -> !llvm.ifoo
+  "test.some_op"() : () -> !llvm.ifoo
 }
 
 // -----
 
 func.func @invalid_di_derived_type_extra_data() {
   // expected-error @+1 {{extraData must be a DINodeAttr or an IntegerAttr}}
-  "some.op"() {attr = #llvm.di_derived_type<tag = DW_TAG_member, sizeInBits = 64, extraData = "not debug info">} : () -> ()
+  "test.some_op"() {attr = #llvm.di_derived_type<tag = DW_TAG_member, sizeInBits = 64, extraData = "not debug info">} : () -> ()
 }
 
 // -----
 
 func.func @explicitly_opaque_struct() {
-  "some.op"() : () -> !llvm.struct<"a", opaque>
+  "test.some_op"() : () -> !llvm.struct<"a", opaque>
   // expected-error @+1 {{identified type already used with a different body}}
-  "some.op"() : () -> !llvm.struct<"a", ()>
+  "test.some_op"() : () -> !llvm.struct<"a", ()>
 }
 
 // -----
 
 func.func @literal_struct_with_void() {
   // expected-error @+1 {{invalid LLVM structure element type}}
-  "some.op"() : () -> !llvm.struct<(void)>
+  "test.some_op"() : () -> !llvm.struct<(void)>
 }
 
 // -----
 
 func.func @identified_struct_with_void() {
   // expected-error @+1 {{invalid LLVM structure element type}}
-  "some.op"() : () -> !llvm.struct<"a", (void)>
+  "test.some_op"() : () -> !llvm.struct<"a", (void)>
 }
 
 // -----
@@ -144,7 +144,7 @@ func.func private @unexpected_type() -> !llvm.f32
 
 func.func private @target_ext_invalid_order() {
   // expected-error @+1 {{failed to parse parameter list for target extension type}}
-  "some.op"() : () -> !llvm.target<"target1", 5, i32, 1>
+  "test.some_op"() : () -> !llvm.target<"target1", 5, i32, 1>
 }
 
 // -----
@@ -152,14 +152,14 @@ func.func private @target_ext_invalid_order() {
 func.func private @target_ext_no_name() {
   // expected-error@below {{expected string}}
   // expected-error@below {{failed to parse LLVMTargetExtType parameter 'extTypeName' which is to be a `::llvm::StringRef`}}
-  "some.op"() : () -> !llvm.target<i32, 42>
+  "test.some_op"() : () -> !llvm.target<i32, 42>
 }
 
 // -----
 
 func.func @byte_invalid_bitwidth() {
     // expected-error@below {{bitwidth must be less than 8388608, but got 8388608}}
-    %0 = "some.op"() : () -> !llvm.byte<8388608>
+    %0 = "test.some_op"() : () -> !llvm.byte<8388608>
     llvm.return
 }
 
@@ -167,6 +167,6 @@ func.func @byte_invalid_bitwidth() {
 
 llvm.func @byte_zero_bitwidth() {
     // expected-error@below {{bitwidth must be greater than 0}}
-    %0 = "some.op"() : () -> !llvm.byte<0>
+    %0 = "test.some_op"() : () -> !llvm.byte<0>
     llvm.return
 }

--- a/mlir/test/Dialect/Linalg/hoisting.mlir
+++ b/mlir/test/Dialect/Linalg/hoisting.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt  -transform-interpreter -canonicalize --split-input-file --allow-unregistered-dialect %s | FileCheck %s
+// RUN: mlir-opt  -transform-interpreter -canonicalize --split-input-file %s | FileCheck %s
 
 ///----------------------------------------------------------------------------------------
 /// Tests for vector.transfer_read + vector.transfer_write pairs
@@ -23,13 +23,13 @@ func.func @hoist_basic_vector_xfer_pair(
 // CHECK:           %[[PAD:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK:           %[[READ:.*]] = vector.transfer_read %[[MEM]][%[[C0]], %[[C0]]], %[[PAD]] : memref<?x?xf32>, vector<1xf32>
 // CHECK:           %[[SCF:.*]] = scf.for %[[I:.*]] = %[[LB]] to %[[UB]] step %[[STEP]] iter_args(%[[INIT:.*]] = %[[READ]]) -> (vector<1xf32>) {
-// CHECK:             %[[VAL_6:.*]] = "val_use"(%[[INIT]]) : (vector<1xf32>) -> vector<1xf32>
+// CHECK:             %[[VAL_6:.*]] = "test.val_use"(%[[INIT]]) : (vector<1xf32>) -> vector<1xf32>
 // CHECK:             scf.yield %[[VAL_6]] : vector<1xf32>
 // CHECK:           }
 // CHECK:           vector.transfer_write %[[SCF]], %[[MEM]][%[[C0]], %[[C0]]] : vector<1xf32>, memref<?x?xf32>
   scf.for %i = %lb to %ub step %step {
       %r0 = vector.transfer_read %mem[%c0, %c0], %pad: memref<?x?xf32>, vector<1xf32>
-      %u0 = "val_use"(%r0) : (vector<1xf32>) -> vector<1xf32>
+      %u0 = "test.val_use"(%r0) : (vector<1xf32>) -> vector<1xf32>
       vector.transfer_write %u0, %mem[%c0, %c0] : vector<1xf32>, memref<?x?xf32>
   }
   return
@@ -66,7 +66,7 @@ func.func @negative_hoist_basic_vector_xfer_pair_extra_write(
 // CHECK:           scf.for %[[I:.*]] = %[[LB]] to %[[UB]] step %[[STEP]] {
 // CHECK:             vector.transfer_write %[[IN]], %[[MEM]][%[[C0]], %[[C0]]] : vector<1xf32>, memref<?x?xf32>
 // CHECK:             %[[READ:.*]] = vector.transfer_read %[[MEM]][%[[C0]], %[[C0]]], %[[PAD]] : memref<?x?xf32>, vector<1xf32>
-// CHECK:             %[[USE:.*]] = "val_use"(%[[READ]]) : (vector<1xf32>) -> vector<1xf32>
+// CHECK:             %[[USE:.*]] = "test.val_use"(%[[READ]]) : (vector<1xf32>) -> vector<1xf32>
 // CHECK:             vector.transfer_write %[[USE]], %[[MEM]][%[[C0]], %[[C0]]] : vector<1xf32>, memref<?x?xf32>
 // CHECK:           }
 
@@ -74,7 +74,7 @@ func.func @negative_hoist_basic_vector_xfer_pair_extra_write(
       vector.transfer_write %in, %mem[%c0, %c0] : vector<1xf32>, memref<?x?xf32>
 
       %r0 = vector.transfer_read %mem[%c0, %c0], %pad: memref<?x?xf32>, vector<1xf32>
-      %u0 = "val_use"(%r0) : (vector<1xf32>) -> vector<1xf32>
+      %u0 = "test.val_use"(%r0) : (vector<1xf32>) -> vector<1xf32>
       vector.transfer_write %u0, %mem[%c0, %c0] : vector<1xf32>, memref<?x?xf32>
   }
   return
@@ -113,7 +113,7 @@ func.func @negative_hoist_basic_vector_xfer_pair_extra_write_into_alias(
 // CHECK:           scf.for %[[I:.*]] = %[[LB]] to %[[UB]] step %[[STEP]] {
 // CHECK:             vector.transfer_write %[[IN]], %[[SV]][%[[C0]], %[[C0]]] {{.*}} : vector<1xf32>, memref<1x1xf32, strided<[?, 1]>>
 // CHECK:             %[[READ:.*]] = vector.transfer_read %[[MEM]][%[[C0]], %[[C0]]], %[[PAD]] : memref<?x?xf32>, vector<1xf32>
-// CHECK:             %[[USE:.*]] = "val_use"(%[[READ]]) : (vector<1xf32>) -> vector<1xf32>
+// CHECK:             %[[USE:.*]] = "test.val_use"(%[[READ]]) : (vector<1xf32>) -> vector<1xf32>
 // CHECK:             vector.transfer_write %[[USE]], %[[MEM]][%[[C0]], %[[C0]]] : vector<1xf32>, memref<?x?xf32>
 // CHECK:           }
 
@@ -122,7 +122,7 @@ func.func @negative_hoist_basic_vector_xfer_pair_extra_write_into_alias(
       vector.transfer_write %in, %sv[%c0, %c0] : vector<1xf32>, memref<1x1xf32, strided<[?, 1]>>
 
       %r0 = vector.transfer_read %mem[%c0, %c0], %pad: memref<?x?xf32>, vector<1xf32>
-      %u0 = "val_use"(%r0) : (vector<1xf32>) -> vector<1xf32>
+      %u0 = "test.val_use"(%r0) : (vector<1xf32>) -> vector<1xf32>
       vector.transfer_write %u0, %mem[%c0, %c0] : vector<1xf32>, memref<?x?xf32>
   }
   return
@@ -160,14 +160,14 @@ func.func @hoist_basic_vector_xfer_pair_with_assume_align(
 // CHECK:           %[[AA:.*]] = memref.assume_alignment %[[MEM]], 4 : memref<?x?xf32>
 // CHECK:           %[[READ:.*]] = vector.transfer_read %[[AA]][%[[C0]], %[[C0]]], %[[PAD]] : memref<?x?xf32>, vector<1xf32>
 // CHECK:           %[[SCF:.*]] = scf.for %[[I:.*]] = %[[LB]] to %[[UB]] step %[[STEP]]  iter_args(%[[INIT:.*]] = %[[READ]]) -> (vector<1xf32>) {
-// CHECK:             %[[USE:.*]] = "val_use"(%[[INIT]]) : (vector<1xf32>) -> vector<1xf32>
+// CHECK:             %[[USE:.*]] = "test.val_use"(%[[INIT]]) : (vector<1xf32>) -> vector<1xf32>
 // CHECK:           }
 // CHECK:           vector.transfer_write %[[SCF]], %[[AA]][%[[C0]], %[[C0]]] : vector<1xf32>, memref<?x?xf32>
 
   %aa = memref.assume_alignment %mem, 4 : memref<?x?xf32>
   scf.for %i = %lb to %ub step %step {
       %r0 = vector.transfer_read %aa[%c0, %c0], %pad: memref<?x?xf32>, vector<1xf32>
-      %u0 = "val_use"(%r0) : (vector<1xf32>) -> vector<1xf32>
+      %u0 = "test.val_use"(%r0) : (vector<1xf32>) -> vector<1xf32>
       vector.transfer_write %u0, %aa[%c0, %c0] : vector<1xf32>, memref<?x?xf32>
   }
   return
@@ -204,14 +204,14 @@ func.func @negative_hoist_basic_vector_xfer_pair_with_assume_align(
 // CHECK:           %[[AA:.*]] = memref.assume_alignment %[[MEM]], 4 : memref<?x?xf32>
 // CHECK:           scf.for %[[I:.*]] = %[[LB]] to %[[UB]] step %[[STEP]] {
 // CHECK:             %[[READ:.*]] = vector.transfer_read %[[AA]][%[[C0]], %[[C0]]], %[[PAD]] : memref<?x?xf32>, vector<1xf32>
-// CHECK:             "mem_use"(%[[MEM]])
+// CHECK:             "test.mem_use"(%[[MEM]])
 // CHECK:             vector.transfer_write %[[READ]], %[[AA]][%[[C0]], %[[C0]]] : vector<1xf32>, memref<?x?xf32>
 // CHECK:           }
 
   %aa = memref.assume_alignment %mem, 4 : memref<?x?xf32>
   scf.for %i = %lb to %ub step %step {
       %r0 = vector.transfer_read %aa[%c0, %c0], %pad: memref<?x?xf32>, vector<1xf32>
-      "mem_use"(%mem) : (memref<?x?xf32>) -> ()
+      "test.mem_use"(%mem) : (memref<?x?xf32>) -> ()
       vector.transfer_write %r0, %aa[%c0, %c0] : vector<1xf32>, memref<?x?xf32>
   }
   return
@@ -248,20 +248,20 @@ func.func @mem_use_outside(%mem: memref<?x?xf32>, %lb : index, %ub : index, %ste
 // CHECK:           scf.for %[[I:.*]] = %[[LB]] to %[[UB]] step %[[STEP]] {
 // CHECK:             %[[READ:.*]] = vector.transfer_read %[[MEM]][%[[I]], %[[I]]], %[[PAD]] : memref<?x?xf32>, vector<1xf32>
 // CHECK:             %[[SCF:.*]] = scf.for %[[J:.*]] = %[[LB]] to %[[UB]] step %[[STEP]] iter_args(%[[VAL_5:.*]] = %[[READ]]) -> (vector<1xf32>) {
-// CHECK:               %[[USE:.*]] = "val_use"(%[[VAL_5]]) : (vector<1xf32>) -> vector<1xf32>
+// CHECK:               %[[USE:.*]] = "test.val_use"(%[[VAL_5]]) : (vector<1xf32>) -> vector<1xf32>
 // CHECK:               scf.yield %[[USE]] : vector<1xf32>
 // CHECK:             }
 // CHECK:             vector.transfer_write %[[SCF]], %[[MEM]][%[[I]], %[[I]]] : vector<1xf32>, memref<?x?xf32>
-// CHECK:             "mem_use"(%[[MEM]]) : (memref<?x?xf32>) -> ()
+// CHECK:             "test.mem_use"(%[[MEM]]) : (memref<?x?xf32>) -> ()
 // CHECK:           }
   scf.for %i = %lb to %ub step %step {
     scf.for %j = %lb to %ub step %step {
       %read = vector.transfer_read %mem[%i, %i], %pad: memref<?x?xf32>, vector<1xf32>
-      %use = "val_use"(%read) : (vector<1xf32>) -> vector<1xf32>
+      %use = "test.val_use"(%read) : (vector<1xf32>) -> vector<1xf32>
       vector.transfer_write %use, %mem[%i, %i] : vector<1xf32>, memref<?x?xf32>
     }
   }
-  "mem_use"(%mem) : (memref<?x?xf32>) -> ()
+  "test.mem_use"(%mem) : (memref<?x?xf32>) -> ()
   return
 }
 
@@ -289,19 +289,19 @@ func.func @mem_use_inside_outer_loop(%mem: memref<?x?xf32>, %lb : index, %ub : i
 // CHECK:           scf.for %[[I:.*]] = %[[LB]] to %[[UB]] step %[[STEP]] {
 // CHECK:             %[[READ:.*]] = vector.transfer_read %[[MEM]]{{\[}}%[[I]], %[[I]]], %[[PAD]] : memref<?x?xf32>, vector<1xf32>
 // CHECK:             %[[SCF:.*]] = scf.for %[[J:.*]] = %[[LB]] to %[[UB]] step %[[STEP]] iter_args(%[[VAL_5:.*]] = %[[READ]]) -> (vector<1xf32>) {
-// CHECK:               %[[USE:.*]] = "val_use"(%[[VAL_5]]) : (vector<1xf32>) -> vector<1xf32>
+// CHECK:               %[[USE:.*]] = "test.val_use"(%[[VAL_5]]) : (vector<1xf32>) -> vector<1xf32>
 // CHECK:               scf.yield %[[USE]] : vector<1xf32>
 // CHECK:             }
 // CHECK:             vector.transfer_write %[[SCF]], %[[MEM]]{{\[}}%[[I]], %[[I]]] : vector<1xf32>, memref<?x?xf32>
-// CHECK:           "mem_use"(%[[MEM]]) : (memref<?x?xf32>) -> ()
+// CHECK:           "test.mem_use"(%[[MEM]]) : (memref<?x?xf32>) -> ()
 // CHECK:           }
   scf.for %i = %lb to %ub step %step {
     scf.for %j = %lb to %ub step %step {
       %read = vector.transfer_read %mem[%i, %i], %pad: memref<?x?xf32>, vector<1xf32>
-      %use = "val_use"(%read) : (vector<1xf32>) -> vector<1xf32>
+      %use = "test.val_use"(%read) : (vector<1xf32>) -> vector<1xf32>
       vector.transfer_write %use, %mem[%i, %i] : vector<1xf32>, memref<?x?xf32>
     }
-    "mem_use"(%mem) : (memref<?x?xf32>) -> ()
+    "test.mem_use"(%mem) : (memref<?x?xf32>) -> ()
   }
   return
 }
@@ -339,16 +339,16 @@ func.func @negative_mem_use_inside_inner_loop_before_write(%mem: memref<?x?xf32>
 // CHECK:           scf.for %[[I:.*]] = %[[LB]] to %[[UB]] step %[[STEP]] {
 // CHECK:             scf.for %[[J:.*]] = %[[LB]] to %[[UB]] step %[[STEP]] {
 // CHECK:               %[[READ:.*]] = vector.transfer_read %[[MEM]][%[[C0]], %[[C0]]], %[[PAD]] : memref<?x?xf32>, vector<1xf32>
-// CHECK:               %[[USE:.*]] = "val_use"(%[[READ]]) : (vector<1xf32>) -> vector<1xf32>
-// CHECK:               "mem_use"(%[[MEM]]) : (memref<?x?xf32>) -> ()
+// CHECK:               %[[USE:.*]] = "test.val_use"(%[[READ]]) : (vector<1xf32>) -> vector<1xf32>
+// CHECK:               "test.mem_use"(%[[MEM]]) : (memref<?x?xf32>) -> ()
 // CHECK:               vector.transfer_write %[[USE]], %[[MEM]][%[[C0]], %[[C0]]] : vector<1xf32>, memref<?x?xf32>
 // CHECK:             }
 // CHECK:           }
   scf.for %i = %lb to %ub step %step {
     scf.for %j = %lb to %ub step %step {
       %read = vector.transfer_read %mem[%c0, %c0], %pad: memref<?x?xf32>, vector<1xf32>
-      %use = "val_use"(%read) : (vector<1xf32>) -> vector<1xf32>
-      "mem_use"(%mem) : (memref<?x?xf32>) -> ()
+      %use = "test.val_use"(%read) : (vector<1xf32>) -> vector<1xf32>
+      "test.mem_use"(%mem) : (memref<?x?xf32>) -> ()
       vector.transfer_write %use, %mem[%c0, %c0] : vector<1xf32>, memref<?x?xf32>
     }
   }
@@ -381,17 +381,17 @@ func.func @negative_mem_use_inside_inner_loop_after_write(%mem: memref<?x?xf32>,
 // CHECK:           scf.for %[[I:.*]] = %[[LB]] to %[[UB]] step %[[STEP]] {
 // CHECK:             scf.for %[[J:.*]] = %[[LB]] to %[[UB]] step %[[STEP]] {
 // CHECK:               %[[READ:.*]] = vector.transfer_read %[[MEM]][%[[C0]], %[[C0]]], %[[PAD]] : memref<?x?xf32>, vector<1xf32>
-// CHECK:               %[[USE:.*]] = "val_use"(%[[READ]]) : (vector<1xf32>) -> vector<1xf32>
+// CHECK:               %[[USE:.*]] = "test.val_use"(%[[READ]]) : (vector<1xf32>) -> vector<1xf32>
 // CHECK:               vector.transfer_write %[[USE]], %[[MEM]][%[[C0]], %[[C0]]] : vector<1xf32>, memref<?x?xf32>
-// CHECK:               "mem_use"(%[[MEM]]) : (memref<?x?xf32>) -> ()
+// CHECK:               "test.mem_use"(%[[MEM]]) : (memref<?x?xf32>) -> ()
 // CHECK:             }
 // CHECK:           }
   scf.for %i = %lb to %ub step %step {
     scf.for %j = %lb to %ub step %step {
       %r3 = vector.transfer_read %mem[%c0, %c0], %pad: memref<?x?xf32>, vector<1xf32>
-      %u3 = "val_use"(%r3) : (vector<1xf32>) -> vector<1xf32>
+      %u3 = "test.val_use"(%r3) : (vector<1xf32>) -> vector<1xf32>
       vector.transfer_write %u3, %mem[%c0, %c0] : vector<1xf32>, memref<?x?xf32>
-      "mem_use"(%mem) : (memref<?x?xf32>) -> ()
+      "test.mem_use"(%mem) : (memref<?x?xf32>) -> ()
     }
   }
   return
@@ -420,17 +420,17 @@ func.func @negative_mem_use_inside_inner_loop_before_read(%mem: memref<?x?xf32>,
 
 // CHECK: scf.for %[[I:.*]] = %[[LB]] to %[[UB]] step %[[STEP]] {
 // CHECK:   scf.for %[[J:.*]] = %[[LB]] to %[[UB]] step %[[STEP]] {
-// CHECK:     "mem_use"(%[[MEM]]) : (memref<?x?xf32>) -> ()
+// CHECK:     "test.mem_use"(%[[MEM]]) : (memref<?x?xf32>) -> ()
 // CHECK:     vector.transfer_read %{{.*}} : memref<?x?xf32>, vector<1xf32>
-// CHECK:     "val_use"(%{{.*}}) : (vector<1xf32>) -> vector<1xf32>
+// CHECK:     "test.val_use"(%{{.*}}) : (vector<1xf32>) -> vector<1xf32>
 // CHECK:     vector.transfer_write %{{.*}} : vector<1xf32>, memref<?x?xf32>
 // CHECK:   }
 // CHECK: }
   scf.for %i = %lb to %ub step %step {
     scf.for %j = %lb to %ub step %step {
-      "mem_use"(%mem) : (memref<?x?xf32>) -> ()
+      "test.mem_use"(%mem) : (memref<?x?xf32>) -> ()
       %read = vector.transfer_read %mem[%c0, %c0], %pad: memref<?x?xf32>, vector<1xf32>
-      %use = "val_use"(%read) : (vector<1xf32>) -> vector<1xf32>
+      %use = "test.val_use"(%read) : (vector<1xf32>) -> vector<1xf32>
       vector.transfer_write %use, %mem[%c0, %c0] : vector<1xf32>, memref<?x?xf32>
     }
   }
@@ -485,14 +485,14 @@ func.func @hoist_vector_transfer_pairs_disjoint(
 //  CHECK-SAME: (vector<3xf32>, vector<3xf32>, vector<4xf32>, vector<4xf32>) {
 // CHECK:     vector.transfer_read %[[MEMREF1]]{{.*}} : memref<?x?xf32>, vector<2xf32>
 // CHECK:     vector.transfer_read %[[MEMREF1]]{{.*}} : memref<?x?xf32>, vector<2xf32>
-// CHECK:     "some_use"(%{{.*}}) : (vector<2xf32>) -> vector<2xf32>
-// CHECK:     "some_use"(%{{.*}}) : (vector<2xf32>) -> vector<2xf32>
-// CHECK:     "some_use"(%{{.*}}) : (vector<3xf32>) -> vector<3xf32>
-// CHECK:     "some_use"(%{{.*}}) : (vector<3xf32>) -> vector<3xf32>
-// CHECK:     "some_use"(%{{.*}}) : (vector<4xf32>) -> vector<4xf32>
-// CHECK:     "some_use"(%{{.*}}) : (vector<4xf32>) -> vector<4xf32>
-// CHECK:     "some_use"(%{{.*}}) : (vector<2xf32>) -> vector<2xf32>
-// CHECK:     "some_use"(%{{.*}}) : (vector<2xf32>) -> vector<2xf32>
+// CHECK:     "test.some_use"(%{{.*}}) : (vector<2xf32>) -> vector<2xf32>
+// CHECK:     "test.some_use"(%{{.*}}) : (vector<2xf32>) -> vector<2xf32>
+// CHECK:     "test.some_use"(%{{.*}}) : (vector<3xf32>) -> vector<3xf32>
+// CHECK:     "test.some_use"(%{{.*}}) : (vector<3xf32>) -> vector<3xf32>
+// CHECK:     "test.some_use"(%{{.*}}) : (vector<4xf32>) -> vector<4xf32>
+// CHECK:     "test.some_use"(%{{.*}}) : (vector<4xf32>) -> vector<4xf32>
+// CHECK:     "test.some_use"(%{{.*}}) : (vector<2xf32>) -> vector<2xf32>
+// CHECK:     "test.some_use"(%{{.*}}) : (vector<2xf32>) -> vector<2xf32>
 // CHECK:     vector.transfer_write %{{.*}}, %[[MEMREF1]]{{.*}} : vector<2xf32>, memref<?x?xf32>
 // CHECK:     vector.transfer_write %{{.*}}, %[[MEMREF1]]{{.*}} : vector<2xf32>, memref<?x?xf32>
 // CHECK:     scf.yield {{.*}} : vector<3xf32>, vector<3xf32>, vector<4xf32>, vector<4xf32>
@@ -513,14 +513,14 @@ func.func @hoist_vector_transfer_pairs_disjoint(
       %r31 = vector.transfer_read %memref3[%c1, %random_index], %cst: memref<?x?xf32>, vector<4xf32>
       %r10 = vector.transfer_read %memref0[%i, %i], %cst: memref<?x?xf32>, vector<2xf32>
       %r11 = vector.transfer_read %memref0[%random_index, %random_index], %cst: memref<?x?xf32>, vector<2xf32>
-      %u00 = "some_use"(%r00) : (vector<2xf32>) -> vector<2xf32>
-      %u01 = "some_use"(%r01) : (vector<2xf32>) -> vector<2xf32>
-      %u20 = "some_use"(%r20) : (vector<3xf32>) -> vector<3xf32>
-      %u21 = "some_use"(%r21) : (vector<3xf32>) -> vector<3xf32>
-      %u30 = "some_use"(%r30) : (vector<4xf32>) -> vector<4xf32>
-      %u31 = "some_use"(%r31) : (vector<4xf32>) -> vector<4xf32>
-      %u10 = "some_use"(%r10) : (vector<2xf32>) -> vector<2xf32>
-      %u11 = "some_use"(%r11) : (vector<2xf32>) -> vector<2xf32>
+      %u00 = "test.some_use"(%r00) : (vector<2xf32>) -> vector<2xf32>
+      %u01 = "test.some_use"(%r01) : (vector<2xf32>) -> vector<2xf32>
+      %u20 = "test.some_use"(%r20) : (vector<3xf32>) -> vector<3xf32>
+      %u21 = "test.some_use"(%r21) : (vector<3xf32>) -> vector<3xf32>
+      %u30 = "test.some_use"(%r30) : (vector<4xf32>) -> vector<4xf32>
+      %u31 = "test.some_use"(%r31) : (vector<4xf32>) -> vector<4xf32>
+      %u10 = "test.some_use"(%r10) : (vector<2xf32>) -> vector<2xf32>
+      %u11 = "test.some_use"(%r11) : (vector<2xf32>) -> vector<2xf32>
       vector.transfer_write %u00, %memref1[%c0, %c0] : vector<2xf32>, memref<?x?xf32>
       vector.transfer_write %u01, %memref1[%c0, %c1] : vector<2xf32>, memref<?x?xf32>
       vector.transfer_write %u20, %memref2[%c0, %c0] : vector<3xf32>, memref<?x?xf32>
@@ -607,7 +607,7 @@ module attributes {transform.with_named_sequence} {
 // CHECK:          scf.for %[[ARG0:.+]] = %[[C0]] to %[[C1024]] step %[[C128]] {
 // CHECK:            %[[D1:.+]] = vector.transfer_read %[[ALLOC_0]][%[[C0]], %[[C0]]], %[[CST]] {in_bounds = [true, true]}
 // CHECK-SAME:         : memref<32x128xf32>, vector<32x128xf32>
-// CHECK:            "some_use"(%[[D0]], %[[D1]], %[[CAST]]) : (vector<32x64xf32>, vector<32x128xf32>, memref<32x128xf32,
+// CHECK:            "test.some_use"(%[[D0]], %[[D1]], %[[CAST]]) : (vector<32x64xf32>, vector<32x128xf32>, memref<32x128xf32,
 // CHECK-SAME:         strided<[128, 1], offset: ?>>) -> ()
 // CHECK:          }
 // CHECK:          memref.dealloc %[[ALLOC]] : memref<32x64xf32>
@@ -623,7 +623,7 @@ func.func @hoist_vector_transfer_read() {
   scf.for %arg0 = %c0 to %c1024 step %c128 {
     %2 = vector.transfer_read %memref2[%c0, %c0], %cst_2 {in_bounds = [true, true]} : memref<32x128xf32>, vector<32x128xf32>
     %3 = vector.transfer_read %memref0[%c0, %c0], %cst_2 {in_bounds = [true, true]} : memref<32x64xf32>, vector<32x64xf32>
-    "some_use"(%3, %2, %subview2) : (vector<32x64xf32>, vector<32x128xf32>, memref<32x128xf32, strided<[128, 1], offset: ?>>) -> ()
+    "test.some_use"(%3, %2, %subview2) : (vector<32x64xf32>, vector<32x128xf32>, memref<32x128xf32, strided<[128, 1], offset: ?>>) -> ()
   }
   memref.dealloc %memref0 : memref<32x64xf32>
   return
@@ -941,7 +941,7 @@ module attributes {transform.with_named_sequence} {
 //         CHECK:   %3 = vector.transfer_read %[[BUFFER]][%[[PLUS1]], %[[I0]]]
 //         CHECK:   %4 = vector.transfer_read %[[BUFFER]][%[[PLUS1]], %[[PLUS4]]]
 // CHECK-COUNT-2:   scf.for %{{.+}} = {{.+}} -> (vector<4xf32>, vector<4xf32>, vector<4xf32>)
-// CHECK-COUNT-3:     "some_use"
+// CHECK-COUNT-3:     "test.some_use"
 // CHECK-COUNT-2:   scf.yield {{.+}} : vector<4xf32>, vector<4xf32>, vector<4xf32>
 //         CHECK:   vector.transfer_write %{{.+}}, %[[BUFFER]][%[[PLUS1]], %[[PLUS4]]]
 //         CHECK:   vector.transfer_write %{{.+}}, %[[BUFFER]][%[[PLUS1]], %[[I0]]]
@@ -960,9 +960,9 @@ func.func @hoist_vector_transfer_pairs_disjoint_dynamic(
       %r1 = vector.transfer_read %buffer[%i1, %i0], %cst: memref<?x?xf32>, vector<4xf32>
       // Non-overlap trailing dim
       %r2 = vector.transfer_read %buffer[%i1, %i2], %cst: memref<?x?xf32>, vector<4xf32>
-      %u0 = "some_use"(%r0) : (vector<4xf32>) -> vector<4xf32>
-      %u1 = "some_use"(%r1) : (vector<4xf32>) -> vector<4xf32>
-      %u2 = "some_use"(%r2) : (vector<4xf32>) -> vector<4xf32>
+      %u0 = "test.some_use"(%r0) : (vector<4xf32>) -> vector<4xf32>
+      %u1 = "test.some_use"(%r1) : (vector<4xf32>) -> vector<4xf32>
+      %u2 = "test.some_use"(%r2) : (vector<4xf32>) -> vector<4xf32>
       vector.transfer_write %u0, %buffer[%i0, %i0] : vector<4xf32>, memref<?x?xf32>
       vector.transfer_write %u1, %buffer[%i1, %i0] : vector<4xf32>, memref<?x?xf32>
       vector.transfer_write %u2, %buffer[%i1, %i2] : vector<4xf32>, memref<?x?xf32>
@@ -1000,8 +1000,8 @@ func.func @hoist_vector_transfer_pairs_overlapping_dynamic(
       %r0 = vector.transfer_read %buffer[%i0, %i0], %cst: memref<?x?xf32>, vector<4xf32>
       // Overlapping range with the above
       %r1 = vector.transfer_read %buffer[%i0, %i1], %cst: memref<?x?xf32>, vector<4xf32>
-      %u0 = "some_use"(%r0) : (vector<4xf32>) -> vector<4xf32>
-      %u1 = "some_use"(%r1) : (vector<4xf32>) -> vector<4xf32>
+      %u0 = "test.some_use"(%r0) : (vector<4xf32>) -> vector<4xf32>
+      %u1 = "test.some_use"(%r1) : (vector<4xf32>) -> vector<4xf32>
       vector.transfer_write %u0, %buffer[%i0, %i0] : vector<4xf32>, memref<?x?xf32>
       vector.transfer_write %u1, %buffer[%i0, %i1] : vector<4xf32>, memref<?x?xf32>
     }
@@ -1042,9 +1042,9 @@ func.func @hoist_vector_transfer_pairs_disjoint_dynamic(
       %r0 = vector.transfer_read %buffer[%i0, %i2], %cst: memref<?x?xf32>, vector<16x8xf32>
       %r1 = vector.transfer_read %buffer[%i0, %i3], %cst: memref<?x?xf32>, vector<16x8xf32>
       %r2 = vector.transfer_read %buffer[%i0, %i4], %cst: memref<?x?xf32>, vector<16x8xf32>
-      %u0 = "some_use"(%r0) : (vector<16x8xf32>) -> vector<16x8xf32>
-      %u1 = "some_use"(%r1) : (vector<16x8xf32>) -> vector<16x8xf32>
-      %u2 = "some_use"(%r2) : (vector<16x8xf32>) -> vector<16x8xf32>
+      %u0 = "test.some_use"(%r0) : (vector<16x8xf32>) -> vector<16x8xf32>
+      %u1 = "test.some_use"(%r1) : (vector<16x8xf32>) -> vector<16x8xf32>
+      %u2 = "test.some_use"(%r2) : (vector<16x8xf32>) -> vector<16x8xf32>
       vector.transfer_write %u2, %buffer[%i0, %i4] : vector<16x8xf32>, memref<?x?xf32>
       vector.transfer_write %u1, %buffer[%i0, %i3] : vector<16x8xf32>, memref<?x?xf32>
       vector.transfer_write %u0, %buffer[%i0, %i2] : vector<16x8xf32>, memref<?x?xf32>
@@ -1071,7 +1071,7 @@ module attributes {transform.with_named_sequence} {
 //       CHECK-SAME: (%{{.+}}: index, %{{.+}}: index, %{{.+}}: index, %[[VEC:.+]]: vector<3x4xf32>) -> vector<3x4xf32> {
 //       CHECK:        %[[EXTRACT:.+]] = vector.extract %[[VEC]][0] : vector<4xf32> from vector<3x4xf32>
 //       CHECK-NEXT:   %[[LOOP:.+]] = scf.for {{.*}} {
-//       CHECK-NEXT:     %[[USE:.+]] = "some_use"({{.*}}) : (vector<4xf32>) -> vector<4xf32>
+//       CHECK-NEXT:     %[[USE:.+]] = "test.some_use"({{.*}}) : (vector<4xf32>) -> vector<4xf32>
 //       CHECK-NEXT:     scf.yield %[[USE]] : vector<4xf32>
 //       CHECK-NEXT:   }
 //       CHECK-NEXT:   %[[BCAST:.+]] = vector.broadcast %[[LOOP]] : vector<4xf32> to vector<3x4xf32>
@@ -1080,7 +1080,7 @@ module attributes {transform.with_named_sequence} {
 func.func @hoist_vector_broadcasts(%lb : index, %ub : index, %step : index, %vec : vector<3x4xf32>) -> vector<3x4xf32> {
   %bcast_vec = scf.for %arg0 = %lb to %ub step %step iter_args(%iarg = %vec) -> vector<3x4xf32> {
     %extract = vector.extract %iarg[0] : vector<4xf32> from vector<3x4xf32>
-    %use = "some_use"(%extract) : (vector<4xf32>) -> vector<4xf32>
+    %use = "test.some_use"(%extract) : (vector<4xf32>) -> vector<4xf32>
     %broadcast = vector.broadcast %use : vector<4xf32> to vector<3x4xf32>
     scf.yield %broadcast : vector<3x4xf32>
   }
@@ -1105,7 +1105,7 @@ module attributes {transform.with_named_sequence} {
 //       CHECK-SAME: (%{{.+}}: index, %{{.+}}: index, %{{.+}}: index, %[[VEC:.+]]: vector<3x4xf32>, %[[POS:.+]]: index) -> vector<3x4xf32> {
 //       CHECK:        %[[EXTRACT:.+]] = vector.extract %[[VEC]][%[[POS]]] : vector<4xf32> from vector<3x4xf32>
 //       CHECK-NEXT:   %[[LOOP:.+]] = scf.for {{.*}} {
-//       CHECK-NEXT:     %[[USE:.+]] = "some_use"({{.*}}) : (vector<4xf32>) -> vector<4xf32>
+//       CHECK-NEXT:     %[[USE:.+]] = "test.some_use"({{.*}}) : (vector<4xf32>) -> vector<4xf32>
 //       CHECK-NEXT:     scf.yield %[[USE]] : vector<4xf32>
 //       CHECK-NEXT:   }
 //       CHECK-NEXT:   %[[BCAST:.+]] = vector.broadcast %[[LOOP]] : vector<4xf32> to vector<3x4xf32>
@@ -1114,7 +1114,7 @@ module attributes {transform.with_named_sequence} {
 func.func @hoist_vector_broadcasts_dynamic(%lb : index, %ub : index, %step : index, %vec : vector<3x4xf32>, %pos: index) -> vector<3x4xf32> {
   %bcast_vec = scf.for %arg0 = %lb to %ub step %step iter_args(%iarg = %vec) -> vector<3x4xf32> {
     %extract = vector.extract %iarg[%pos] : vector<4xf32> from vector<3x4xf32>
-    %use = "some_use"(%extract) : (vector<4xf32>) -> vector<4xf32>
+    %use = "test.some_use"(%extract) : (vector<4xf32>) -> vector<4xf32>
     %broadcast = vector.broadcast %use : vector<4xf32> to vector<3x4xf32>
     scf.yield %broadcast : vector<3x4xf32>
   }
@@ -1141,8 +1141,8 @@ module attributes {transform.with_named_sequence} {
 //       CHECK-DAG:     %[[EXTRACT1:.+]] = vector.extract %[[VEC1]][0] : vector<4xf32> from vector<3x4xf32>
 //       CHECK-DAG:     %[[EXTRACT2:.+]] = vector.extract %[[VEC2]][1] : vector<5xf32> from vector<3x5xf32>
 //       CHECK-NEXT:    %[[LOOP:.+]]:2 = scf.for {{.*}} {
-//       CHECK-DAG:       %[[USE1:.+]] = "some_use1"({{.*}}) : (vector<4xf32>) -> vector<4xf32>
-//       CHECK-DAG:       %[[USE2:.+]] = "some_use2"({{.*}}) : (vector<5xf32>) -> vector<5xf32>
+//       CHECK-DAG:       %[[USE1:.+]] = "test.some_use1"({{.*}}) : (vector<4xf32>) -> vector<4xf32>
+//       CHECK-DAG:       %[[USE2:.+]] = "test.some_use2"({{.*}}) : (vector<5xf32>) -> vector<5xf32>
 //       CHECK-NEXT:      scf.yield %[[USE1]], %[[USE2]]  : vector<4xf32>, vector<5xf32>
 //       CHECK-NEXT:    }
 //       CHECK-DAG:     %[[BCAST1:.+]] = vector.broadcast %[[LOOP]]#0 : vector<4xf32> to vector<3x4xf32>
@@ -1153,8 +1153,8 @@ func.func @hoist_vector_broadcasts_multiple(%lb : index, %ub : index, %step : in
   %bcast_vec:2 = scf.for %arg0 = %lb to %ub step %step iter_args(%iarg = %vec1, %iarg2 = %vec2) -> (vector<3x4xf32>, vector<3x5xf32>) {
     %extract1 = vector.extract %iarg[0] : vector<4xf32> from vector<3x4xf32>
     %extract2 = vector.extract %iarg2[1] : vector<5xf32> from vector<3x5xf32>
-    %use1 = "some_use1"(%extract1) : (vector<4xf32>) -> vector<4xf32>
-    %use2 = "some_use2"(%extract2) : (vector<5xf32>) -> vector<5xf32>
+    %use1 = "test.some_use1"(%extract1) : (vector<4xf32>) -> vector<4xf32>
+    %use2 = "test.some_use2"(%extract2) : (vector<5xf32>) -> vector<5xf32>
     %broadcast1 = vector.broadcast %use1 : vector<4xf32> to vector<3x4xf32>
     %broadcast2 = vector.broadcast %use2 : vector<5xf32> to vector<3x5xf32>
     scf.yield %broadcast1, %broadcast2 : vector<3x4xf32>,vector<3x5xf32>

--- a/mlir/test/Dialect/Linalg/transform-op-insert-slice-to-copy.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-insert-slice-to-copy.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt -transform-interpreter %s --split-input-file --allow-unregistered-dialect | FileCheck %s
+// RUN: mlir-opt -transform-interpreter %s --split-input-file | FileCheck %s
 
 // CHECK-LABEL: func @insert_slice_to_copy
     // CHECK-SAME: %[[I:.*]]: tensor<2x3xf32>
@@ -119,7 +119,7 @@ module attributes {transform.with_named_sequence} {
 // CHECK-LABEL: func @parallel_insert_slice_to_copy
 func.func @parallel_insert_slice_to_copy(%out : tensor<?x?xf32>, %sz0: index, %sz1: index) {
   %0 = scf.forall (%arg0, %arg1) in (27, 8) shared_outs(%arg2 = %out) -> (tensor<?x?xf32>) {
-    %t = "make_me_a_tensor"() : () -> (tensor<?x?xf32> )
+    %t = "test.make_me_a_tensor"() : () -> (tensor<?x?xf32> )
 
     //      CHECK: tensor.extract_slice
     //      CHECK: linalg.copy

--- a/mlir/test/Dialect/Linalg/transform-op-linalg-copy-to-memref.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-linalg-copy-to-memref.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt -transform-interpreter %s --split-input-file --allow-unregistered-dialect -verify-diagnostics | FileCheck %s
+// RUN: mlir-opt -transform-interpreter %s --split-input-file -verify-diagnostics | FileCheck %s
 
 // CHECK:  func.func @linalg_copy_to_memref_copy(%[[INPUT:.*]]: memref<128x64xf32>, %[[OUTPUT:.*]]: memref<128x64xf32>) {
 // CHECK:    memref.copy %[[INPUT]], %[[OUTPUT]] : memref<128x64xf32> to memref<128x64xf32>

--- a/mlir/test/Dialect/MLProgram/attrs.mlir
+++ b/mlir/test/Dialect/MLProgram/attrs.mlir
@@ -1,7 +1,7 @@
-// RUN: mlir-opt %s --allow-unregistered-dialect | mlir-opt --allow-unregistered-dialect | FileCheck %s
+// RUN: mlir-opt %s | mlir-opt | FileCheck %s
 
 // CHECK: #ml_program.extern : i32
-"unregistered.attributes"() {
+"test.attributes"() {
   value = #ml_program.extern : i32
 } : () -> ()
 

--- a/mlir/test/Dialect/MLProgram/ops.mlir
+++ b/mlir/test/Dialect/MLProgram/ops.mlir
@@ -1,5 +1,5 @@
-// RUN: mlir-opt %s --allow-unregistered-dialect | mlir-opt --allow-unregistered-dialect | FileCheck %s
-// RUN: mlir-opt %s --allow-unregistered-dialect --mlir-print-op-generic | mlir-opt --allow-unregistered-dialect | FileCheck %s
+// RUN: mlir-opt %s | mlir-opt | FileCheck %s
+// RUN: mlir-opt %s --mlir-print-op-generic | mlir-opt | FileCheck %s
 
 // CHECK-LABEL: ml_program.func private @extern_func
 ml_program.func private @extern_func(i32) -> i32
@@ -15,8 +15,8 @@ ml_program.subgraph private @extern_subgraph(i32) -> i32
 // CHECK-LABEL: ml_program.subgraph @compute_subgraph
 ml_program.subgraph @compute_subgraph(%arg0 : i32) -> i32 {
   %token = ml_program.token
-  %1 = "unregistered.dummy"(%0, %token) : (i32, !ml_program.token) -> i32
-  %0 = "unregistered.dummy"(%arg0) : (i32) -> i32
+  %1 = "test.dummy"(%0, %token) : (i32, !ml_program.token) -> i32
+  %0 = "test.dummy"(%arg0) : (i32) -> i32
   ml_program.output %0 : i32
 }
 

--- a/mlir/test/Dialect/MLProgram/pipeline-globals.mlir
+++ b/mlir/test/Dialect/MLProgram/pipeline-globals.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt -split-input-file -pass-pipeline="builtin.module(mlprogram-pipeline-globals)" --allow-unregistered-dialect %s
+// RUN: mlir-opt -split-input-file -pass-pipeline="builtin.module(mlprogram-pipeline-globals)" %s
 
 // CHECK-LABEL: @global_variable
 ml_program.global private mutable @global_variable(dense<4> : tensor<4xi32>) : tensor<4xi32>
@@ -10,8 +10,8 @@ func.func @global_double_load() {
   %0 = ml_program.global_load @global_variable : tensor<4xi32>
   %1 = ml_program.global_load @global_variable : tensor<4xi32>
 
-  // CHECK: %[[DUMMY:.+]] = "unregistered.dummy"(%[[LOAD]], %[[LOAD]])
-  %2 = "unregistered.dummy"(%0, %1) : (tensor<4xi32>, tensor<4xi32>) -> (tensor<4xi32>)
+  // CHECK: %[[DUMMY:.+]] = "test.dummy"(%[[LOAD]], %[[LOAD]])
+  %2 = "test.dummy"(%0, %1) : (tensor<4xi32>, tensor<4xi32>) -> (tensor<4xi32>)
 
   // CHECK: ml_program.global_store @global_variable %[[DUMMY]]
   ml_program.global_store @global_variable = %2 : tensor<4xi32>
@@ -28,8 +28,8 @@ func.func @global_double_store() {
   // CHECK: %[[LOAD:.+]] = ml_program.global_load @global_variable
   %0 = ml_program.global_load @global_variable : tensor<4xi32>
 
-  // CHECK: %[[DUMMY:.+]] = "unregistered.dummy"(%[[LOAD]])
-  %1 = "unregistered.dummy"(%0) : (tensor<4xi32>) -> (tensor<4xi32>)
+  // CHECK: %[[DUMMY:.+]] = "test.dummy"(%[[LOAD]])
+  %1 = "test.dummy"(%0) : (tensor<4xi32>) -> (tensor<4xi32>)
 
   // CHECK: ml_program.global_store @global_variable %[[DUMMY]]
   ml_program.global_store @global_variable = %1 : tensor<4xi32>
@@ -49,12 +49,12 @@ func.func @global_store_load() {
   // CHECK: %[[LOAD:.+]] = ml_program.global_load @global_variable
   %0 = ml_program.global_load @global_variable : tensor<4xi32>
 
-  // CHECK: %[[DUMMY:.+]] = "unregistered.dummy"(%[[LOAD]])
-  // CHECK: %[[DUMMY2:.+]] = "unregistered.dummy"(%[[DUMMY2]])
-  %1 = "unregistered.dummy"(%0) : (tensor<4xi32>) -> (tensor<4xi32>)
+  // CHECK: %[[DUMMY:.+]] = "test.dummy"(%[[LOAD]])
+  // CHECK: %[[DUMMY2:.+]] = "test.dummy"(%[[DUMMY2]])
+  %1 = "test.dummy"(%0) : (tensor<4xi32>) -> (tensor<4xi32>)
   ml_program.global_store @global_variable = %1 : tensor<4xi32>
   %2 = ml_program.global_load @global_variable : tensor<4xi32>
-  %3 = "unregistered.dummy"(%2) : (tensor<4xi32>) -> (tensor<4xi32>)
+  %3 = "test.dummy"(%2) : (tensor<4xi32>) -> (tensor<4xi32>)
 
   // CHECK: ml_program.global_store @global_variable %[[DUMMY2]]
   ml_program.global_store @global_variable = %3 : tensor<4xi32>
@@ -71,26 +71,26 @@ func.func @global_store_load_region() {
   // CHECK: %[[LOAD:.+]] = ml_program.global_load @global_variable
   %0 = ml_program.global_load @global_variable : tensor<4xi32>
 
-  // CHECK: %[[DUMMY:.+]] = "unregistered.dummy"(%[[LOAD]])
-  %1 = "unregistered.dummy"(%0) : (tensor<4xi32>) -> (tensor<4xi32>)
+  // CHECK: %[[DUMMY:.+]] = "test.dummy"(%[[LOAD]])
+  %1 = "test.dummy"(%0) : (tensor<4xi32>) -> (tensor<4xi32>)
 
   // CHECK: ml_program.global_store @global_variable %[[DUMMY]]
   ml_program.global_store @global_variable = %1 : tensor<4xi32>
 
-  // CHECK: "unregistered.dummy2"
-  "unregistered.dummy2"() ({
+  // CHECK: "test.dummy2"
+  "test.dummy2"() ({
     ^bb():
     %cst = arith.constant dense<0> : tensor<4xi32>
     // CHECK: ml_program.global_store @global_variable
     ml_program.global_store @global_variable = %cst : tensor<4xi32>
-    "unregistered.terminator"() : () -> ()
+    "test.terminator"() : () -> ()
   }) : () -> ()
 
   // CHECK: %[[LOAD:.+]] ml_program.global_load @global_variable
   %2 = ml_program.global_load @global_variable : tensor<4xi32>
 
-  // CHECK: %[[DUMMY2:.+]] = "unregistered.dummy"(%[[LOAD]])
-  %3 = "unregistered.dummy"(%2) : (tensor<4xi32>) -> (tensor<4xi32>)
+  // CHECK: %[[DUMMY2:.+]] = "test.dummy"(%[[LOAD]])
+  %3 = "test.dummy"(%2) : (tensor<4xi32>) -> (tensor<4xi32>)
 
   // CHECK: ml_program.global_store @global_variable %[[DUMMY2]]
   ml_program.global_store @global_variable = %3 : tensor<4xi32>
@@ -115,8 +115,8 @@ func.func @call_global_store() {
   // CHECK: %[[LOAD:.+]] = ml_program.global_load @global_variable
   %0 = ml_program.global_load @global_variable : tensor<4xi32>
 
-  // CHECK: %[[DUMMY:.+]] = "unregistered.dummy"(%[[LOAD]])
-  %1 = "unregistered.dummy"(%0) : (tensor<4xi32>) -> (tensor<4xi32>)
+  // CHECK: %[[DUMMY:.+]] = "test.dummy"(%[[LOAD]])
+  %1 = "test.dummy"(%0) : (tensor<4xi32>) -> (tensor<4xi32>)
 
   // CHECK: ml_program.global_store @global_variable %[[DUMMY]]
   ml_program.global_store @global_variable = %1 : tensor<4xi32>
@@ -125,8 +125,8 @@ func.func @call_global_store() {
   // CHECK: %[[LOAD:.+]] ml_program.global_load @global_variable
   %2 = ml_program.global_load @global_variable : tensor<4xi32>
 
-  // CHECK: %[[DUMMY:.+]] = "unregistered.dummy"(%[[LOAD]])
-  %3 = "unregistered.dummy"(%2) : (tensor<4xi32>) -> (tensor<4xi32>)
+  // CHECK: %[[DUMMY:.+]] = "test.dummy"(%[[LOAD]])
+  %3 = "test.dummy"(%2) : (tensor<4xi32>) -> (tensor<4xi32>)
 
   // CHECK: ml_program.global_store @global_variable %[[DUMMY]]
   ml_program.global_store @global_variable = %3 : tensor<4xi32>
@@ -158,8 +158,8 @@ func.func @call_indirect_store() {
   // CHECK: %[[LOAD:.+]] = ml_program.global_load @global_variable
   %0 = ml_program.global_load @global_variable : tensor<4xi32>
 
-  // CHECK: %[[DUMMY:.+]] = "unregistered.dummy"(%[[LOAD]])
-  %1 = "unregistered.dummy"(%0) : (tensor<4xi32>) -> (tensor<4xi32>)
+  // CHECK: %[[DUMMY:.+]] = "test.dummy"(%[[LOAD]])
+  %1 = "test.dummy"(%0) : (tensor<4xi32>) -> (tensor<4xi32>)
 
   // CHECK: ml_program.global_store @global_variable %[[DUMMY]]
   ml_program.global_store @global_variable = %1 : tensor<4xi32>
@@ -168,8 +168,8 @@ func.func @call_indirect_store() {
   // CHECK: %[[LOAD:.+]] ml_program.global_load @global_variable
   %2 = ml_program.global_load @global_variable : tensor<4xi32>
 
-  // CHECK: %[[DUMMY:.+]] = "unregistered.dummy"(%[[LOAD]])
-  %3 = "unregistered.dummy"(%2) : (tensor<4xi32>) -> (tensor<4xi32>)
+  // CHECK: %[[DUMMY:.+]] = "test.dummy"(%[[LOAD]])
+  %3 = "test.dummy"(%2) : (tensor<4xi32>) -> (tensor<4xi32>)
 
   // CHECK: ml_program.global_store @global_variable %[[DUMMY]]
   ml_program.global_store @global_variable = %3 : tensor<4xi32>
@@ -192,7 +192,7 @@ func.func @interrupt_indirect() -> tensor<4xi32> {
 // CHECK-LABEL: @interrupt
 func.func @interrupt() {
   %0 = call @interrupt_indirect() : () -> (tensor<4xi32>)
-  "unregistered.dummy"(%0) : (tensor<4xi32>) -> ()
+  "test.dummy"(%0) : (tensor<4xi32>) -> ()
   func.return
 }
 
@@ -201,16 +201,16 @@ func.func @call_indirect_load() {
   // CHECK: %[[LOAD:.+]] = ml_program.global_load @global_variable
   %0 = ml_program.global_load @global_variable : tensor<4xi32>
 
-  // CHECK: %[[DUMMY:.+]] = "unregistered.dummy"(%[[LOAD]])
-  %1 = "unregistered.dummy"(%0) : (tensor<4xi32>) -> (tensor<4xi32>)
+  // CHECK: %[[DUMMY:.+]] = "test.dummy"(%[[LOAD]])
+  %1 = "test.dummy"(%0) : (tensor<4xi32>) -> (tensor<4xi32>)
 
   // CHECK: ml_program.global_store @global_variable %[[DUMMY]]
   ml_program.global_store @global_variable = %1 : tensor<4xi32>
   call @interrupt() : () -> ()
 
-  // CHECK: %[[DUMMY:.+]] = "unregistered.dummy"(%[[LOAD]])
+  // CHECK: %[[DUMMY:.+]] = "test.dummy"(%[[LOAD]])
   %2 = ml_program.global_load @global_variable : tensor<4xi32>
-  %3 = "unregistered.dummy"(%2) : (tensor<4xi32>) -> (tensor<4xi32>)
+  %3 = "test.dummy"(%2) : (tensor<4xi32>) -> (tensor<4xi32>)
 
   // CHECK: ml_program.global_store @global_variable %[[DUMMY]]
   ml_program.global_store @global_variable = %3 : tensor<4xi32>
@@ -249,8 +249,8 @@ func.func @call_recursive() {
   // CHECK: %[[LOAD:.+]] = ml_program.global_load @global_variable
   %0 = ml_program.global_load @global_variable : tensor<4xi32>
 
-  // CHECK: %[[DUMMY:.+]] = "unregistered.dummy"(%[[LOAD]])
-  %1 = "unregistered.dummy"(%0) : (tensor<4xi32>) -> (tensor<4xi32>)
+  // CHECK: %[[DUMMY:.+]] = "test.dummy"(%[[LOAD]])
+  %1 = "test.dummy"(%0) : (tensor<4xi32>) -> (tensor<4xi32>)
 
   // CHECK: ml_program.global_store @global_variable %[[DUMMY]]
   ml_program.global_store @global_variable = %1 : tensor<4xi32>
@@ -259,8 +259,8 @@ func.func @call_recursive() {
   // CHECK: %[[LOAD:.+]] ml_program.global_load @global_variable
   %2 = ml_program.global_load @global_variable : tensor<4xi32>
 
-  // CHECK: %[[DUMMY:.+]] = "unregistered.dummy"(%[[LOAD]])
-  %3 = "unregistered.dummy"(%2) : (tensor<4xi32>) -> (tensor<4xi32>)
+  // CHECK: %[[DUMMY:.+]] = "test.dummy"(%[[LOAD]])
+  %3 = "test.dummy"(%2) : (tensor<4xi32>) -> (tensor<4xi32>)
 
   // CHECK: ml_program.global_store @global_variable %[[DUMMY]]
   ml_program.global_store @global_variable = %3 : tensor<4xi32>

--- a/mlir/test/Dialect/SCF/transform-op-take-assumed-branch.mlir
+++ b/mlir/test/Dialect/SCF/transform-op-take-assumed-branch.mlir
@@ -1,8 +1,8 @@
-// RUN: mlir-opt %s -transform-interpreter -split-input-file -verify-diagnostics --allow-unregistered-dialect | FileCheck %s
+// RUN: mlir-opt %s -transform-interpreter -split-input-file -verify-diagnostics | FileCheck %s
 
 func.func @if_no_else(%cond: i1, %a: index, %b: memref<?xf32>, %c: i8) {
   scf.if %cond {
-    "some_op"(%cond, %b) : (i1, memref<?xf32>) -> ()
+    "test.some_op"(%cond, %b) : (i1, memref<?xf32>) -> ()
     scf.yield
   }
   return
@@ -24,7 +24,7 @@ module attributes {transform.with_named_sequence} {
 // CHECK-LABEL: if_no_else
 func.func @if_no_else(%cond: i1, %a: index, %b: memref<?xf32>, %c: i8) {
   scf.if %cond {
-    "some_op"(%cond, %b) : (i1, memref<?xf32>) -> ()
+    "test.some_op"(%cond, %b) : (i1, memref<?xf32>) -> ()
     scf.yield
   }
   return
@@ -34,7 +34,7 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
     %if = transform.structured.match ops{["scf.if"]} in %arg1
       : (!transform.any_op) -> !transform.any_op
-    %some_op = transform.structured.match ops{["some_op"]} in %arg1
+    %some_op = transform.structured.match ops{["test.some_op"]} in %arg1
       : (!transform.any_op) -> !transform.any_op
 
     transform.scf.take_assumed_branch %if : (!transform.any_op) -> ()

--- a/mlir/test/Dialect/Tensor/fold-tensor-subset-ops.mlir
+++ b/mlir/test/Dialect/Tensor/fold-tensor-subset-ops.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt -fold-tensor-subset-ops -split-input-file --allow-unregistered-dialect %s | FileCheck %s
+// RUN: mlir-opt -fold-tensor-subset-ops -split-input-file %s | FileCheck %s
 
 func.func @fold_vector_transfer_read_with_rank_reduced_extract_slice(
     %arg0 : tensor<?x?x?xf32>,
@@ -399,9 +399,9 @@ func.func @parallel_insert_slice_of_insert_slice_dynamic(
 
   // CHECK: scf.forall {{.*}} shared_outs(%[[out:.*]] = %[[t]]
   %0 = scf.forall (%arg0, %arg1) in (27, 8) shared_outs(%arg2 = %t) -> (tensor<12x34xf32>) {
-    // CHECK: %[[tt:.*]] = "make_me_a_tensor"() : () -> tensor<?x?xf32>
-    %tt = "make_me_a_tensor"() : () -> tensor<?x?xf32>
-    %tt2 = "make_me_another_tensor"() : () -> tensor<?x?xf32>
+    // CHECK: %[[tt:.*]] = "test.make_me_a_tensor"() : () -> tensor<?x?xf32>
+    %tt = "test.make_me_a_tensor"() : () -> tensor<?x?xf32>
+    %tt2 = "test.make_me_another_tensor"() : () -> tensor<?x?xf32>
     %inserted_slice = tensor.insert_slice %tt into %tt2[%o1, 0] [%sz0, %sz1] [1, 1] : tensor<?x?xf32> into tensor<?x?xf32>
 
     //      CHECK: %[[add:.*]] = affine.apply #[[$map]]()[%[[o1]], %[[o0]]]

--- a/mlir/test/Dialect/Tosa/tosa-infer-shapes.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-infer-shapes.mlir
@@ -1,5 +1,5 @@
-// RUN: mlir-opt --split-input-file --verify-diagnostics --tosa-infer-shapes --allow-unregistered-dialect %s | FileCheck %s --allow-unused-prefixes --check-prefixes=CHECK,DEFAULT
-// RUN: mlir-opt --split-input-file --verify-diagnostics --tosa-infer-shapes="convert-function-boundaries" --allow-unregistered-dialect %s | FileCheck %s --allow-unused-prefixes --check-prefixes=CHECK,FUNCBOUND
+// RUN: mlir-opt --split-input-file --verify-diagnostics --tosa-infer-shapes %s | FileCheck %s --allow-unused-prefixes --check-prefixes=CHECK,DEFAULT
+// RUN: mlir-opt --split-input-file --verify-diagnostics --tosa-infer-shapes="convert-function-boundaries" %s | FileCheck %s --allow-unused-prefixes --check-prefixes=CHECK,FUNCBOUND
 
 // CHECK-LABEL: @test_return
 func.func @test_return(%arg0 : tensor<4xf32>) -> tensor<*xf32> {
@@ -1657,8 +1657,8 @@ func.func @while_dont_crash(%arg0 : tensor<i32>) -> (tensor<*xi32>) {
     // CHECK-SAME: (tensor<i32>, tensor<i32>) -> tensor<i32>
     %3 = tosa.add %arg1, %arg1 : (tensor<*xi32>, tensor<*xi32>) -> tensor<*xi32>
     // CHECK: %[[CAST:.+]] = tensor.cast %{{.*}} : tensor<i32> to tensor<*xi32>
-    // CHECK: "use"(%[[CAST]]) : (tensor<*xi32>) -> ()
-    "use"(%3) : (tensor<*xi32>) -> ()
+    // CHECK: "test.use"(%[[CAST]]) : (tensor<*xi32>) -> ()
+    "test.use"(%3) : (tensor<*xi32>) -> ()
     tosa.yield %3 : tensor<*xi32>
   }
   // DEFAULT: %[[CAST:.+]] = tensor.cast
@@ -1708,8 +1708,8 @@ func.func @while_dont_crash_nested(%arg0 : tensor<i32>) -> (tensor<*xi32>) {
       // CHECK-SAME: (tensor<i32>, tensor<i32>) -> tensor<i32>
       %4 = tosa.add %arg2, %arg2 : (tensor<*xi32>, tensor<*xi32>) -> tensor<*xi32>
       // CHECK: %[[CAST:.+]] = tensor.cast %{{.*}} : tensor<i32> to tensor<*xi32>
-      // CHECK: "use"(%[[CAST]]) : (tensor<*xi32>) -> ()
-      "use"(%4) : (tensor<*xi32>) -> ()
+      // CHECK: "test.use"(%[[CAST]]) : (tensor<*xi32>) -> ()
+      "test.use"(%4) : (tensor<*xi32>) -> ()
       // CHECK:      tosa.yield
       // CHECK-SAME: tensor<i32>
       tosa.yield %4 : tensor<*xi32>

--- a/mlir/test/Dialect/Transform/test-interpreter-debug.mlir
+++ b/mlir/test/Dialect/Transform/test-interpreter-debug.mlir
@@ -1,7 +1,7 @@
 // RUN: mlir-opt %s --pass-pipeline="builtin.module(transform-interpreter{\
 // RUN:         debug-payload-root-tag=payload \
 // RUN:         entry-point=transform})" \
-// RUN:   --allow-unregistered-dialect --split-input-file --verify-diagnostics
+// RUN:   --split-input-file --verify-diagnostics
 
 // expected-error @below {{could not find the operation with transform.target_tag="payload" attribute}}
 module attributes {transform.with_named_sequence} {

--- a/mlir/test/Dialect/Transform/test-interpreter-printing.mlir
+++ b/mlir/test/Dialect/Transform/test-interpreter-printing.mlir
@@ -1,6 +1,6 @@
-// RUN: mlir-opt %s --transform-interpreter --allow-unregistered-dialect --verify-diagnostics | FileCheck %s
+// RUN: mlir-opt %s --transform-interpreter --verify-diagnostics | FileCheck %s
 
-// RUN: mlir-opt %s --transform-interpreter --allow-unregistered-dialect --verify-diagnostics \
+// RUN: mlir-opt %s --transform-interpreter --verify-diagnostics \
 // RUN:   --mlir-print-debuginfo | FileCheck %s --check-prefix=CHECK-LOC
 
 func.func @nested_ops() {

--- a/mlir/test/Dialect/Vector/test-create-broadcast.mlir
+++ b/mlir/test/Dialect/Vector/test-create-broadcast.mlir
@@ -1,7 +1,7 @@
-// RUN: mlir-opt %s --test-create-vector-broadcast --allow-unregistered-dialect --split-input-file | FileCheck %s
+// RUN: mlir-opt %s --test-create-vector-broadcast --split-input-file | FileCheck %s
 
 func.func @foo(%a : f32) -> vector<1x2xf32> {
-  %0 = "test_create_broadcast"(%a) {broadcast_dims = array<i64: 0, 1>} : (f32) -> vector<1x2xf32>
+  %0 = "test.create_broadcast"(%a) {broadcast_dims = array<i64: 0, 1>} : (f32) -> vector<1x2xf32>
   // CHECK: vector.broadcast {{.*}} : f32 to vector<1x2xf32>
   // CHECK-NOT: vector.transpose
   return %0:  vector<1x2xf32>
@@ -10,7 +10,7 @@ func.func @foo(%a : f32) -> vector<1x2xf32> {
 // -----
 
 func.func @foo(%a : vector<2x2xf32>) -> vector<2x2x3xf32> {
-  %0 = "test_create_broadcast"(%a) {broadcast_dims = array<i64: 2>} 
+  %0 = "test.create_broadcast"(%a) {broadcast_dims = array<i64: 2>}
     : (vector<2x2xf32>) -> vector<2x2x3xf32>
   // CHECK: vector.broadcast {{.*}} : vector<2x2xf32> to vector<3x2x2xf32>
   // CHECK: vector.transpose {{.*}}, [1, 2, 0] : vector<3x2x2xf32> to vector<2x2x3xf32>
@@ -20,7 +20,7 @@ func.func @foo(%a : vector<2x2xf32>) -> vector<2x2x3xf32> {
 // -----
 
 func.func @foo(%a : vector<3x3xf32>) -> vector<4x3x3xf32> {
-  %0 = "test_create_broadcast"(%a) {broadcast_dims = array<i64: 0>} 
+  %0 = "test.create_broadcast"(%a) {broadcast_dims = array<i64: 0>}
     : (vector<3x3xf32>) -> vector<4x3x3xf32>
   // CHECK: vector.broadcast {{.*}} : vector<3x3xf32> to vector<4x3x3xf32>
   // CHECK-NOT: vector.transpose
@@ -30,7 +30,7 @@ func.func @foo(%a : vector<3x3xf32>) -> vector<4x3x3xf32> {
 // -----
 
 func.func @foo(%a : vector<2x4xf32>) -> vector<1x2x3x4x5xf32> {
-  %0 = "test_create_broadcast"(%a) {broadcast_dims = array<i64: 0, 2, 4>} 
+  %0 = "test.create_broadcast"(%a) {broadcast_dims = array<i64: 0, 2, 4>}
     : (vector<2x4xf32>) -> vector<1x2x3x4x5xf32>
   // CHECK: vector.broadcast {{.*}} : vector<2x4xf32> to vector<1x3x5x2x4xf32>
   // CHECK: vector.transpose {{.*}}, [0, 3, 1, 4, 2] : vector<1x3x5x2x4xf32> to vector<1x2x3x4x5xf32>

--- a/mlir/test/Dialect/Vector/vector-warp-distribute.mlir
+++ b/mlir/test/Dialect/Vector/vector-warp-distribute.mlir
@@ -1,18 +1,18 @@
-// RUN: mlir-opt %s --allow-unregistered-dialect --split-input-file \
+// RUN: mlir-opt %s --split-input-file \
 // RUN:   --test-vector-warp-distribute=rewrite-warp-ops-to-scf-if | FileCheck %s --check-prefix=CHECK-SCF-IF
 
-// RUN: mlir-opt %s --allow-unregistered-dialect --split-input-file \
+// RUN: mlir-opt %s --split-input-file \
 // RUN:   --test-vector-warp-distribute="hoist-uniform" | FileCheck --check-prefixes=CHECK-HOIST %s
 
-// RUN: mlir-opt %s --allow-unregistered-dialect --split-input-file \
+// RUN: mlir-opt %s --split-input-file \
 // RUN:   --test-vector-warp-distribute="hoist-uniform distribute-transfer-write max-transfer-write-elements=4" \
 // RUN:   | FileCheck --check-prefixes=CHECK-D %s
 
-// RUN: mlir-opt %s --allow-unregistered-dialect --split-input-file \
+// RUN: mlir-opt %s --split-input-file \
 // RUN:  --test-vector-warp-distribute=propagate-distribution --canonicalize \
 // RUN:  | FileCheck --check-prefixes=CHECK-PROP %s
 
-// RUN: mlir-opt %s --allow-unregistered-dialect --split-input-file \
+// RUN: mlir-opt %s --split-input-file \
 // RUN:   --test-vector-warp-distribute="hoist-uniform distribute-transfer-write propagate-distribution" \
 // RUN:   --canonicalize | FileCheck --check-prefixes=CHECK-DIST-AND-PROP %s
 
@@ -49,10 +49,10 @@ func.func @rewrite_warp_op_to_scf_if(%laneid: index,
     ^bb0(%arg0: vector<128xf32>, %arg1: vector<256xf32>):
 //       CHECK-SCF-IF:     %[[arg1:.*]] = vector.transfer_read %[[buffer_v1]][%[[c0]]], %{{.*}} {in_bounds = [true]} : memref<256xf32, 3>, vector<256xf32>
 //       CHECK-SCF-IF:     %[[arg0:.*]] = vector.transfer_read %[[buffer_v0]][%[[c0]]], %{{.*}} {in_bounds = [true]} : memref<128xf32, 3>, vector<128xf32>
-//       CHECK-SCF-IF:     %[[def_0:.*]] = "some_def"(%[[arg0]]) : (vector<128xf32>) -> vector<32xf32>
-//       CHECK-SCF-IF:     %[[def_1:.*]] = "some_def"(%[[arg1]]) : (vector<256xf32>) -> vector<64xf32>
-    %2 = "some_def"(%arg0) : (vector<128xf32>) -> vector<32xf32>
-    %3 = "some_def"(%arg1) : (vector<256xf32>) -> vector<64xf32>
+//       CHECK-SCF-IF:     %[[def_0:.*]] = "test.some_def"(%[[arg0]]) : (vector<128xf32>) -> vector<32xf32>
+//       CHECK-SCF-IF:     %[[def_1:.*]] = "test.some_def"(%[[arg1]]) : (vector<256xf32>) -> vector<64xf32>
+    %2 = "test.some_def"(%arg0) : (vector<128xf32>) -> vector<32xf32>
+    %3 = "test.some_def"(%arg1) : (vector<256xf32>) -> vector<64xf32>
 //       CHECK-SCF-IF:     vector.transfer_write %[[def_0]], %[[buffer_def_0]][%[[c0]]]
 //       CHECK-SCF-IF:     vector.transfer_write %[[def_1]], %[[buffer_def_1]][%[[c0]]]
     gpu.yield %2, %3 : vector<32xf32>, vector<64xf32>
@@ -62,10 +62,10 @@ func.func @rewrite_warp_op_to_scf_if(%laneid: index,
 //       CHECK-SCF-IF:   %[[o1:.*]] = affine.apply #[[$TIMES2]]()[%[[laneid]]]
 //       CHECK-SCF-IF:   %[[r1:.*]] = vector.transfer_read %[[buffer_def_1]][%[[o1]]], %{{.*}} {in_bounds = [true]} : memref<64xf32, 3>, vector<2xf32>
 //       CHECK-SCF-IF:   %[[r0:.*]] = vector.transfer_read %[[buffer_def_0]][%[[laneid]]], %{{.*}} {in_bounds = [true]} : memref<32xf32, 3>, vector<1xf32>
-//       CHECK-SCF-IF:   "some_use"(%[[r0]]) : (vector<1xf32>) -> ()
-//       CHECK-SCF-IF:   "some_use"(%[[r1]]) : (vector<2xf32>) -> ()
-  "some_use"(%r#0) : (vector<1xf32>) -> ()
-  "some_use"(%r#1) : (vector<2xf32>) -> ()
+//       CHECK-SCF-IF:   "test.some_use"(%[[r0]]) : (vector<1xf32>) -> ()
+//       CHECK-SCF-IF:   "test.some_use"(%[[r1]]) : (vector<2xf32>) -> ()
+  "test.some_use"(%r#0) : (vector<1xf32>) -> ()
+  "test.some_use"(%r#1) : (vector<2xf32>) -> ()
   return
 }
 
@@ -229,9 +229,9 @@ func.func @warp_dead_result(%laneid: index) -> (vector<1xf32>) {
   // CHECK-PROP: %[[R:.*]] = gpu.warp_execute_on_lane_0(%{{.*}})[32] -> (vector<1xf32>)
   %r:3 = gpu.warp_execute_on_lane_0(%laneid)[32] ->
     (vector<1xf32>, vector<1xf32>, vector<1xf32>) {
-    %2 = "some_def"() : () -> (vector<32xf32>)
-    %3 = "some_def"() : () -> (vector<32xf32>)
-    %4 = "some_def"() : () -> (vector<32xf32>)
+    %2 = "test.some_def"() : () -> (vector<32xf32>)
+    %3 = "test.some_def"() : () -> (vector<32xf32>)
+    %4 = "test.some_def"() : () -> (vector<32xf32>)
   // CHECK-PROP:   gpu.yield %{{.*}} : vector<32xf32>
     gpu.yield %2, %3, %4 : vector<32xf32>, vector<32xf32>, vector<32xf32>
   }
@@ -266,15 +266,15 @@ func.func @warp_propagate_elementwise(%laneid: index, %dest: memref<1024xf32>) {
   // CHECK-PROP: %[[R:.*]]:4 = gpu.warp_execute_on_lane_0(%{{.*}})[32] -> (vector<1xf32>, vector<1xf32>, vector<2xf32>, vector<2xf32>)
   %r:2 = gpu.warp_execute_on_lane_0(%laneid)[32] ->
     (vector<1xf32>, vector<2xf32>) {
-    // CHECK-PROP: %[[V0:.*]] = "some_def"() : () -> vector<32xf32>
-    // CHECK-PROP: %[[V1:.*]] = "some_def"() : () -> vector<32xf32>
-    // CHECK-PROP: %[[V2:.*]] = "some_def"() : () -> vector<64xf32>
-    // CHECK-PROP: %[[V3:.*]] = "some_def"() : () -> vector<64xf32>
+    // CHECK-PROP: %[[V0:.*]] = "test.some_def"() : () -> vector<32xf32>
+    // CHECK-PROP: %[[V1:.*]] = "test.some_def"() : () -> vector<32xf32>
+    // CHECK-PROP: %[[V2:.*]] = "test.some_def"() : () -> vector<64xf32>
+    // CHECK-PROP: %[[V3:.*]] = "test.some_def"() : () -> vector<64xf32>
     // CHECK-PROP: gpu.yield %[[V0]], %[[V1]], %[[V2]], %[[V3]] : vector<32xf32>, vector<32xf32>, vector<64xf32>, vector<64xf32>
-    %2 = "some_def"() : () -> (vector<32xf32>)
-    %3 = "some_def"() : () -> (vector<32xf32>)
-    %4 = "some_def"() : () -> (vector<64xf32>)
-    %5 = "some_def"() : () -> (vector<64xf32>)
+    %2 = "test.some_def"() : () -> (vector<32xf32>)
+    %3 = "test.some_def"() : () -> (vector<32xf32>)
+    %4 = "test.some_def"() : () -> (vector<64xf32>)
+    %5 = "test.some_def"() : () -> (vector<64xf32>)
     %6 = arith.addf %2, %3 : vector<32xf32>
     %7 = arith.addf %4, %5 : vector<64xf32>
     gpu.yield %6, %7 : vector<32xf32>, vector<64xf32>
@@ -293,15 +293,15 @@ func.func @warp_propagate_elementwise(%laneid: index, %dest: memref<1024xf32>) {
 
 // CHECK-PROP-LABEL: func @warp_propagate_scalar_arith(
 //       CHECK-PROP:   %[[r:.*]]:2 = gpu.warp_execute_on_lane_0{{.*}} {
-//       CHECK-PROP:     %[[some_def0:.*]] = "some_def"
-//       CHECK-PROP:     %[[some_def1:.*]] = "some_def"
+//       CHECK-PROP:     %[[some_def0:.*]] = "test.some_def"
+//       CHECK-PROP:     %[[some_def1:.*]] = "test.some_def"
 //       CHECK-PROP:     gpu.yield %[[some_def0]], %[[some_def1]]
 //       CHECK-PROP:   }
 //       CHECK-PROP:   arith.addf %[[r]]#0, %[[r]]#1 : f32
 func.func @warp_propagate_scalar_arith(%laneid: index) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (f32) {
-    %0 = "some_def"() : () -> (f32)
-    %1 = "some_def"() : () -> (f32)
+    %0 = "test.some_def"() : () -> (f32)
+    %1 = "test.some_def"() : () -> (f32)
     %2 = arith.addf %0, %1 : f32
     gpu.yield %2 : f32
   }
@@ -356,12 +356,12 @@ func.func @warp_propagate_read(%laneid: index, %src: memref<1024xf32>, %dest: me
 
 // CHECK-PROP-LABEL: func @fold_vector_broadcast(
 //       CHECK-PROP:   %[[r:.*]] = gpu.warp_execute_on_lane_0{{.*}} -> (vector<1xf32>)
-//       CHECK-PROP:     %[[some_def:.*]] = "some_def"
+//       CHECK-PROP:     %[[some_def:.*]] = "test.some_def"
 //       CHECK-PROP:     gpu.yield %[[some_def]] : vector<1xf32>
 //       CHECK-PROP:   vector.print %[[r]] : vector<1xf32>
 func.func @fold_vector_broadcast(%laneid: index) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (vector<1xf32>) {
-    %0 = "some_def"() : () -> (vector<1xf32>)
+    %0 = "test.some_def"() : () -> (vector<1xf32>)
     %1 = vector.broadcast %0 : vector<1xf32> to vector<32xf32>
     gpu.yield %1 : vector<32xf32>
   }
@@ -373,13 +373,13 @@ func.func @fold_vector_broadcast(%laneid: index) {
 
 // CHECK-PROP-LABEL: func @extract_vector_broadcast(
 //       CHECK-PROP:   %[[r:.*]] = gpu.warp_execute_on_lane_0{{.*}} -> (vector<1xf32>)
-//       CHECK-PROP:     %[[some_def:.*]] = "some_def"
+//       CHECK-PROP:     %[[some_def:.*]] = "test.some_def"
 //       CHECK-PROP:     gpu.yield %[[some_def]] : vector<1xf32>
 //       CHECK-PROP:   %[[broadcasted:.*]] = vector.broadcast %[[r]] : vector<1xf32> to vector<2xf32>
 //       CHECK-PROP:   vector.print %[[broadcasted]] : vector<2xf32>
 func.func @extract_vector_broadcast(%laneid: index) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (vector<2xf32>) {
-    %0 = "some_def"() : () -> (vector<1xf32>)
+    %0 = "test.some_def"() : () -> (vector<1xf32>)
     %1 = vector.broadcast %0 : vector<1xf32> to vector<64xf32>
     gpu.yield %1 : vector<64xf32>
   }
@@ -391,13 +391,13 @@ func.func @extract_vector_broadcast(%laneid: index) {
 
 // CHECK-PROP-LABEL: func @extract_scalar_vector_broadcast(
 //       CHECK-PROP:   %[[r:.*]] = gpu.warp_execute_on_lane_0{{.*}} -> (f32)
-//       CHECK-PROP:     %[[some_def:.*]] = "some_def"
+//       CHECK-PROP:     %[[some_def:.*]] = "test.some_def"
 //       CHECK-PROP:     gpu.yield %[[some_def]] : f32
 //       CHECK-PROP:   %[[broadcasted:.*]] = vector.broadcast %[[r]] : f32 to vector<2xf32>
 //       CHECK-PROP:   vector.print %[[broadcasted]] : vector<2xf32>
 func.func @extract_scalar_vector_broadcast(%laneid: index) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (vector<2xf32>) {
-    %0 = "some_def"() : () -> (f32)
+    %0 = "test.some_def"() : () -> (f32)
     %1 = vector.broadcast %0 : f32 to vector<64xf32>
     gpu.yield %1 : vector<64xf32>
   }
@@ -409,33 +409,33 @@ func.func @extract_scalar_vector_broadcast(%laneid: index) {
 
 // CHECK-PROP-LABEL:   func @warp_scf_for(
 // CHECK-PROP: %[[INI:.*]] = gpu.warp_execute_on_lane_0(%{{.*}})[32] -> (vector<4xf32>) {
-// CHECK-PROP:   %[[INI1:.*]] = "some_def"() : () -> vector<128xf32>
+// CHECK-PROP:   %[[INI1:.*]] = "test.some_def"() : () -> vector<128xf32>
 // CHECK-PROP:   gpu.yield %[[INI1]] : vector<128xf32>
 // CHECK-PROP: }
 // CHECK-PROP: %[[F:.*]] = scf.for %[[IT:.+]] = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%[[FARG:.*]] = %[[INI]]) -> (vector<4xf32>) {
 // CHECK-PROP:   %[[A:.*]] = arith.addi %[[IT]], %{{.*}} : index
 // CHECK-PROP:   %[[W:.*]] = gpu.warp_execute_on_lane_0(%{{.*}})[32] args(%[[FARG]] : vector<4xf32>) -> (vector<4xf32>) {
 // CHECK-PROP:    ^bb0(%[[ARG:.*]]: vector<128xf32>):
-// CHECK-PROP:      %[[ACC:.*]] = "some_def"(%[[A]], %[[ARG]]) : (index, vector<128xf32>) -> vector<128xf32>
+// CHECK-PROP:      %[[ACC:.*]] = "test.some_def"(%[[A]], %[[ARG]]) : (index, vector<128xf32>) -> vector<128xf32>
 // CHECK-PROP:      gpu.yield %[[ACC]] : vector<128xf32>
 // CHECK-PROP:   }
 // CHECK-PROP:   scf.yield %[[W]] : vector<4xf32>
 // CHECK-PROP: }
-// CHECK-PROP: "some_use"(%[[F]]) : (vector<4xf32>) -> ()
+// CHECK-PROP: "test.some_use"(%[[F]]) : (vector<4xf32>) -> ()
 func.func @warp_scf_for(%arg0: index) {
   %c128 = arith.constant 128 : index
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
   %0 = gpu.warp_execute_on_lane_0(%arg0)[32] -> (vector<4xf32>) {
-    %ini = "some_def"() : () -> (vector<128xf32>)
+    %ini = "test.some_def"() : () -> (vector<128xf32>)
     %3 = scf.for %arg3 = %c0 to %c128 step %c1 iter_args(%arg4 = %ini) -> (vector<128xf32>) {
       %add = arith.addi %arg3, %c1 : index
-      %acc = "some_def"(%add, %arg4) : (index, vector<128xf32>) -> (vector<128xf32>)
+      %acc = "test.some_def"(%add, %arg4) : (index, vector<128xf32>) -> (vector<128xf32>)
       scf.yield %acc : vector<128xf32>
     }
     gpu.yield %3 : vector<128xf32>
   }
-  "some_use"(%0) : (vector<4xf32>) -> ()
+  "test.some_use"(%0) : (vector<4xf32>) -> ()
   return
 }
 
@@ -443,33 +443,33 @@ func.func @warp_scf_for(%arg0: index) {
 
 // CHECK-PROP-LABEL:   func @warp_scf_for_use_from_above(
 // CHECK-PROP: %[[INI:.*]]:2 = gpu.warp_execute_on_lane_0(%{{.*}})[32] -> (vector<4xf32>, vector<4xf32>) {
-// CHECK-PROP:   %[[INI1:.*]] = "some_def"() : () -> vector<128xf32>
-// CHECK-PROP:   %[[USE:.*]] = "some_def_above"() : () -> vector<128xf32>
+// CHECK-PROP:   %[[INI1:.*]] = "test.some_def"() : () -> vector<128xf32>
+// CHECK-PROP:   %[[USE:.*]] = "test.some_def_above"() : () -> vector<128xf32>
 // CHECK-PROP:   gpu.yield %[[INI1]], %[[USE]] : vector<128xf32>, vector<128xf32>
 // CHECK-PROP: }
 // CHECK-PROP: %[[F:.*]] = scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%[[FARG:.*]] = %[[INI]]#0) -> (vector<4xf32>) {
 // CHECK-PROP:   %[[W:.*]] = gpu.warp_execute_on_lane_0(%{{.*}})[32] args(%[[FARG]], %[[INI]]#1 : vector<4xf32>, vector<4xf32>) -> (vector<4xf32>) {
 // CHECK-PROP:    ^bb0(%[[ARG0:.*]]: vector<128xf32>, %[[ARG1:.*]]: vector<128xf32>):
-// CHECK-PROP:      %[[ACC:.*]] = "some_def"(%[[ARG0]], %[[ARG1]]) : (vector<128xf32>, vector<128xf32>) -> vector<128xf32>
+// CHECK-PROP:      %[[ACC:.*]] = "test.some_def"(%[[ARG0]], %[[ARG1]]) : (vector<128xf32>, vector<128xf32>) -> vector<128xf32>
 // CHECK-PROP:      gpu.yield %[[ACC]] : vector<128xf32>
 // CHECK-PROP:   }
 // CHECK-PROP:   scf.yield %[[W]] : vector<4xf32>
 // CHECK-PROP: }
-// CHECK-PROP: "some_use"(%[[F]]) : (vector<4xf32>) -> ()
+// CHECK-PROP: "test.some_use"(%[[F]]) : (vector<4xf32>) -> ()
 func.func @warp_scf_for_use_from_above(%arg0: index) {
   %c128 = arith.constant 128 : index
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
   %0 = gpu.warp_execute_on_lane_0(%arg0)[32] -> (vector<4xf32>) {
-    %ini = "some_def"() : () -> (vector<128xf32>)
-    %use_from_above = "some_def_above"() : () -> (vector<128xf32>)
+    %ini = "test.some_def"() : () -> (vector<128xf32>)
+    %use_from_above = "test.some_def_above"() : () -> (vector<128xf32>)
     %3 = scf.for %arg3 = %c0 to %c128 step %c1 iter_args(%arg4 = %ini) -> (vector<128xf32>) {
-      %acc = "some_def"(%arg4, %use_from_above) : (vector<128xf32>, vector<128xf32>) -> (vector<128xf32>)
+      %acc = "test.some_def"(%arg4, %use_from_above) : (vector<128xf32>, vector<128xf32>) -> (vector<128xf32>)
       scf.yield %acc : vector<128xf32>
     }
     gpu.yield %3 : vector<128xf32>
   }
-  "some_use"(%0) : (vector<4xf32>) -> ()
+  "test.some_use"(%0) : (vector<4xf32>) -> ()
   return
 }
 
@@ -478,7 +478,7 @@ func.func @warp_scf_for_use_from_above(%arg0: index) {
 // CHECK-PROP:          (%{{.*}}: index, %[[ARG1:[a-zA-Z0-9]+]]: index) {
 // CHECK-PROP:          %[[W:.*]] = gpu.warp_execute_on_lane_0(%{{.*}})[32] args(%[[ARG1]] : index) -> (vector<4xf32>) {
 // CHECK-PROP:          ^bb0(%{{.*}}: index):
-// CHECK-PROP:            %[[T2:.*]] = "some_def"() : () -> vector<128xf32>
+// CHECK-PROP:            %[[T2:.*]] = "test.some_def"() : () -> vector<128xf32>
 // CHECK-PROP:            gpu.yield %[[T2]] : vector<128xf32>
 // CHECK-PROP:          }
 // CHECK-PROP:          %[[FOR:.*]] = scf.for %{{.*}} to %[[ARG1]] step %{{.*}} iter_args(%{{.*}}) -> (vector<4xf32>) {
@@ -489,7 +489,7 @@ func.func @warp_scf_for_use_from_above(%arg0: index) {
 // CHECK-PROP:            }
 // CHECK-PROP:            scf.yield %[[W2]] : vector<4xf32>
 // CHECK-PROP:          }
-// CHECK-PROP:          "some_use"(%[[FOR]]) : (vector<4xf32>) -> ()
+// CHECK-PROP:          "test.some_use"(%[[FOR]]) : (vector<4xf32>) -> ()
 // CHECK-PROP:          return
 func.func @warp_scf_for_local_loop_bounds(%arg0: index, %bound: index) {
   %c1 = arith.constant 1 : index
@@ -497,14 +497,14 @@ func.func @warp_scf_for_local_loop_bounds(%arg0: index, %bound: index) {
   %0 = gpu.warp_execute_on_lane_0(%arg0)[32]
     args(%bound : index) -> (vector<4xf32>) {
     ^bb0(%arg1: index):
-    %ini = "some_def"() : () -> (vector<128xf32>)
+    %ini = "test.some_def"() : () -> (vector<128xf32>)
     %3 = scf.for %arg3 = %c0 to %arg1 step %c1 iter_args(%arg4 = %ini) -> (vector<128xf32>) {
-      %acc = "some_def"(%arg4) : (vector<128xf32>) -> (vector<128xf32>)
+      %acc = "test.some_def"(%arg4) : (vector<128xf32>) -> (vector<128xf32>)
       scf.yield %acc : vector<128xf32>
     }
     gpu.yield %3 : vector<128xf32>
   }
-  "some_use"(%0) : (vector<4xf32>) -> ()
+  "test.some_use"(%0) : (vector<4xf32>) -> ()
   return
 }
 
@@ -512,37 +512,37 @@ func.func @warp_scf_for_local_loop_bounds(%arg0: index, %bound: index) {
 
 // CHECK-PROP-LABEL:   func @warp_scf_for_swap(
 // CHECK-PROP: %[[INI:.*]]:2 = gpu.warp_execute_on_lane_0(%{{.*}})[32] -> (vector<4xf32>, vector<4xf32>) {
-// CHECK-PROP:   %[[INI1:.*]] = "some_def"() : () -> vector<128xf32>
-// CHECK-PROP:   %[[INI2:.*]] = "some_def"() : () -> vector<128xf32>
+// CHECK-PROP:   %[[INI1:.*]] = "test.some_def"() : () -> vector<128xf32>
+// CHECK-PROP:   %[[INI2:.*]] = "test.some_def"() : () -> vector<128xf32>
 // CHECK-PROP:   gpu.yield %[[INI1]], %[[INI2]] : vector<128xf32>, vector<128xf32>
 // CHECK-PROP: }
 // CHECK-PROP: %[[F:.*]]:2 = scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%[[FARG1:.*]] = %[[INI]]#0, %[[FARG2:.*]] = %[[INI]]#1) -> (vector<4xf32>, vector<4xf32>) {
 // CHECK-PROP:   %[[W:.*]]:2 = gpu.warp_execute_on_lane_0(%{{.*}})[32] args(%[[FARG1]], %[[FARG2]] : vector<4xf32>, vector<4xf32>) -> (vector<4xf32>, vector<4xf32>) {
 // CHECK-PROP:    ^bb0(%[[ARG1:.*]]: vector<128xf32>, %[[ARG2:.*]]: vector<128xf32>):
-// CHECK-PROP:      %[[ACC1:.*]] = "some_def"(%[[ARG1]]) : (vector<128xf32>) -> vector<128xf32>
-// CHECK-PROP:      %[[ACC2:.*]] = "some_def"(%[[ARG2]]) : (vector<128xf32>) -> vector<128xf32>
+// CHECK-PROP:      %[[ACC1:.*]] = "test.some_def"(%[[ARG1]]) : (vector<128xf32>) -> vector<128xf32>
+// CHECK-PROP:      %[[ACC2:.*]] = "test.some_def"(%[[ARG2]]) : (vector<128xf32>) -> vector<128xf32>
 // CHECK-PROP:      gpu.yield %[[ACC2]], %[[ACC1]] : vector<128xf32>, vector<128xf32>
 // CHECK-PROP:   }
 // CHECK-PROP:   scf.yield %[[W]]#0, %[[W]]#1 : vector<4xf32>, vector<4xf32>
 // CHECK-PROP: }
-// CHECK-PROP: "some_use"(%[[F]]#0) : (vector<4xf32>) -> ()
-// CHECK-PROP: "some_use"(%[[F]]#1) : (vector<4xf32>) -> ()
+// CHECK-PROP: "test.some_use"(%[[F]]#0) : (vector<4xf32>) -> ()
+// CHECK-PROP: "test.some_use"(%[[F]]#1) : (vector<4xf32>) -> ()
 func.func @warp_scf_for_swap(%arg0: index) {
   %c128 = arith.constant 128 : index
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
   %0:2 = gpu.warp_execute_on_lane_0(%arg0)[32] -> (vector<4xf32>, vector<4xf32>) {
-    %ini1 = "some_def"() : () -> (vector<128xf32>)
-    %ini2 = "some_def"() : () -> (vector<128xf32>)
+    %ini1 = "test.some_def"() : () -> (vector<128xf32>)
+    %ini2 = "test.some_def"() : () -> (vector<128xf32>)
     %3:2 = scf.for %arg3 = %c0 to %c128 step %c1 iter_args(%arg4 = %ini1, %arg5 = %ini2) -> (vector<128xf32>, vector<128xf32>) {
-      %acc1 = "some_def"(%arg4) : (vector<128xf32>) -> (vector<128xf32>)
-      %acc2 = "some_def"(%arg5) : (vector<128xf32>) -> (vector<128xf32>)
+      %acc1 = "test.some_def"(%arg4) : (vector<128xf32>) -> (vector<128xf32>)
+      %acc2 = "test.some_def"(%arg5) : (vector<128xf32>) -> (vector<128xf32>)
       scf.yield %acc2, %acc1 : vector<128xf32>, vector<128xf32>
     }
     gpu.yield %3#0, %3#1 : vector<128xf32>, vector<128xf32>
   }
-  "some_use"(%0#0) : (vector<4xf32>) -> ()
-  "some_use"(%0#1) : (vector<4xf32>) -> ()
+  "test.some_use"(%0#0) : (vector<4xf32>) -> ()
+  "test.some_use"(%0#1) : (vector<4xf32>) -> ()
   return
 }
 
@@ -551,7 +551,7 @@ func.func @warp_scf_for_swap(%arg0: index) {
 // CHECK-PROP-LABEL:   func @warp_scf_for_swap_no_yield(
 // CHECK-PROP:           scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
 // CHECK-PROP-NEXT:        gpu.warp_execute_on_lane_0(%{{.*}})[32] {
-// CHECK-PROP-NEXT:          "some_op"() : () -> ()
+// CHECK-PROP-NEXT:          "test.some_op"() : () -> ()
 // CHECK-PROP-NEXT:        }
 // CHECK-PROP-NEXT:      }
 func.func @warp_scf_for_swap_no_yield(%arg0: index) {
@@ -560,7 +560,7 @@ func.func @warp_scf_for_swap_no_yield(%arg0: index) {
   %c0 = arith.constant 0 : index
   gpu.warp_execute_on_lane_0(%arg0)[32] {
     scf.for %arg3 = %c0 to %c128 step %c1 {
-      "some_op"() : () -> ()
+      "test.some_op"() : () -> ()
     }
   }
   return
@@ -570,13 +570,13 @@ func.func @warp_scf_for_swap_no_yield(%arg0: index) {
 // scf.for result is not distributed in this case.
 // CHECK-PROP-LABEL:   func @warp_scf_for_broadcasted_result(
 // CHECK-PROP:  %[[W0:.*]] = gpu.warp_execute_on_lane_0(%{{.*}})[32] -> (vector<1xf32>) {
-// CHECK-PROP:    %[[INI:.*]] = "some_def"() : () -> vector<1xf32>
+// CHECK-PROP:    %[[INI:.*]] = "test.some_def"() : () -> vector<1xf32>
 // CHECK-PROP:    gpu.yield %[[INI]] : vector<1xf32>
 // CHECK-PROP:  }
 // CHECK-PROP:  %[[F:.*]] = scf.for {{.*}} iter_args(%[[ARG2:.*]] = %[[W0]]) -> (vector<1xf32>) {
 // CHECK-PROP:    %[[W1:.*]] = gpu.warp_execute_on_lane_0(%{{.*}})[32] args(%[[ARG2]] : vector<1xf32>) -> (vector<1xf32>) {
 // CHECK-PROP:    ^bb0(%{{.*}}: vector<1xf32>):
-// CHECK-PROP:      %[[T0:.*]] = "some_op"(%{{.*}}) : (vector<1xf32>) -> vector<1xf32>
+// CHECK-PROP:      %[[T0:.*]] = "test.some_op"(%{{.*}}) : (vector<1xf32>) -> vector<1xf32>
 // CHECK-PROP:      gpu.yield %[[T0]] : vector<1xf32>
 // CHECK-PROP:    }
 // CHECK-PROP:    scf.yield %[[W1]] : vector<1xf32>
@@ -585,9 +585,9 @@ func.func @warp_scf_for_broadcasted_result(%arg0: index) -> vector<1xf32> {
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
   %2 = gpu.warp_execute_on_lane_0(%arg0)[32] -> (vector<1xf32>) {
-    %ini = "some_def"() : () -> (vector<1xf32>)
+    %ini = "test.some_def"() : () -> (vector<1xf32>)
     %0 = scf.for %arg3 = %c0 to %c128 step %c1 iter_args(%arg4 = %ini) -> (vector<1xf32>) {
-      %1 = "some_op"(%arg4) : (vector<1xf32>) -> (vector<1xf32>)
+      %1 = "test.some_op"(%arg4) : (vector<1xf32>) -> (vector<1xf32>)
       scf.yield %1 : vector<1xf32>
     }
     gpu.yield %0 : vector<1xf32>
@@ -603,7 +603,7 @@ func.func @warp_scf_for_broadcasted_result(%arg0: index) -> vector<1xf32> {
 
 // CHECK-PROP-LABEL:   func @warp_scf_for_multiple_yield(
 //       CHECK-PROP:   gpu.warp_execute_on_lane_0(%{{.*}})[32] -> (vector<1xf32>) {
-//  CHECK-PROP-NEXT:     "some_def"() : () -> vector<32xf32>
+//  CHECK-PROP-NEXT:     "test.some_def"() : () -> vector<32xf32>
 //  CHECK-PROP-NEXT:     gpu.yield %{{.*}} : vector<32xf32>
 //  CHECK-PROP-NEXT:   }
 //   CHECK-PROP-NOT:   gpu.warp_execute_on_lane_0
@@ -625,7 +625,7 @@ func.func @warp_scf_for_multiple_yield(%arg0: index, %arg1: memref<?xf32>, %arg2
   %cst = arith.constant 0.000000e+00 : f32
   %0:3 = gpu.warp_execute_on_lane_0(%arg0)[32] ->
   (vector<1xf32>, vector<4xf32>, vector<4xf32>) {
-    %def = "some_def"() : () -> (vector<32xf32>)
+    %def = "test.some_def"() : () -> (vector<32xf32>)
     %r1 = vector.transfer_read %arg2[%c0], %cst {in_bounds = [true]} : memref<?xf32>, vector<128xf32>
     %r2 = vector.transfer_read %arg2[%c128], %cst {in_bounds = [true]} : memref<?xf32>, vector<128xf32>
     %3:2 = scf.for %arg3 = %c0 to %c128 step %c1 iter_args(%arg4 = %r1, %arg5 = %r2)
@@ -644,86 +644,86 @@ func.func @warp_scf_for_multiple_yield(%arg0: index, %arg1: memref<?xf32>, %arg2
   vector.transfer_write %0#1, %arg2[%1] {in_bounds = [true]} : vector<4xf32>, memref<?xf32>
   %2 = affine.apply #map2()[%arg0]
   vector.transfer_write %0#2, %arg2[%2] {in_bounds = [true]} : vector<4xf32>, memref<?xf32>
-  "some_use"(%0#0) : (vector<1xf32>) -> ()
+  "test.some_use"(%0#0) : (vector<1xf32>) -> ()
   return
 }
 
 // -----
 // CHECK-PROP-LABEL: func.func @warp_scf_for_unused_for_result(
 //       CHECK-PROP: %[[W0:.*]]:2 = gpu.warp_execute_on_lane_0(%{{.*}})[32] -> (vector<4xf32>, vector<4xf32>) {
-//       CHECK-PROP:  %[[INI0:.*]] = "some_def"() : () -> vector<128xf32>
-//       CHECK-PROP:  %[[INI1:.*]] = "some_def"() : () -> vector<128xf32>
+//       CHECK-PROP:  %[[INI0:.*]] = "test.some_def"() : () -> vector<128xf32>
+//       CHECK-PROP:  %[[INI1:.*]] = "test.some_def"() : () -> vector<128xf32>
 //       CHECK-PROP:  gpu.yield %[[INI0]], %[[INI1]] : vector<128xf32>, vector<128xf32>
 //       CHECK-PROP: }
 //       CHECK-PROP: %[[F:.*]]:2 = scf.for %{{.*}} iter_args(%{{.*}} = %[[W0]]#0, %{{.*}} = %[[W0]]#1) -> (vector<4xf32>, vector<4xf32>) {
 //       CHECK-PROP:  %[[W1:.*]]:2 = gpu.warp_execute_on_lane_0(%{{.*}})[32] args(%{{.*}} : vector<4xf32>, vector<4xf32>) -> (vector<4xf32>, vector<4xf32>) {
-//       CHECK-PROP:    %[[ACC0:.*]] = "some_def"(%{{.*}}) : (vector<128xf32>, index) -> vector<128xf32>
-//       CHECK-PROP:    %[[ACC1:.*]] = "some_def"(%{{.*}}) : (index, vector<128xf32>, vector<128xf32>) -> vector<128xf32>
+//       CHECK-PROP:    %[[ACC0:.*]] = "test.some_def"(%{{.*}}) : (vector<128xf32>, index) -> vector<128xf32>
+//       CHECK-PROP:    %[[ACC1:.*]] = "test.some_def"(%{{.*}}) : (index, vector<128xf32>, vector<128xf32>) -> vector<128xf32>
 //       CHECK-PROP:    gpu.yield %[[ACC1]], %[[ACC0]] : vector<128xf32>, vector<128xf32>
 //       CHECK-PROP:  }
 //       CHECK-PROP:  scf.yield %[[W1]]#0, %[[W1]]#1 : vector<4xf32>, vector<4xf32>
 //       CHECK-PROP: }
-//       CHECK-PROP: "some_use"(%[[F]]#0) : (vector<4xf32>) -> ()
+//       CHECK-PROP: "test.some_use"(%[[F]]#0) : (vector<4xf32>) -> ()
 func.func @warp_scf_for_unused_for_result(%arg0: index) {
   %c128 = arith.constant 128 : index
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
   %0 = gpu.warp_execute_on_lane_0(%arg0)[32] -> (vector<4xf32>) {
-    %ini = "some_def"() : () -> (vector<128xf32>)
-    %ini1 = "some_def"() : () -> (vector<128xf32>)
+    %ini = "test.some_def"() : () -> (vector<128xf32>)
+    %ini1 = "test.some_def"() : () -> (vector<128xf32>)
     %3:2 = scf.for %arg3 = %c0 to %c128 step %c1 iter_args(%arg4 = %ini, %arg5 = %ini1) -> (vector<128xf32>, vector<128xf32>) {
       %add = arith.addi %arg3, %c1 : index
-      %1  = "some_def"(%arg5, %add) : (vector<128xf32>, index) -> (vector<128xf32>)
-      %acc = "some_def"(%add, %arg4, %1) : (index, vector<128xf32>, vector<128xf32>) -> (vector<128xf32>)
+      %1  = "test.some_def"(%arg5, %add) : (vector<128xf32>, index) -> (vector<128xf32>)
+      %acc = "test.some_def"(%add, %arg4, %1) : (index, vector<128xf32>, vector<128xf32>) -> (vector<128xf32>)
       scf.yield %acc, %1 : vector<128xf32>, vector<128xf32>
     }
     gpu.yield %3#0 : vector<128xf32>
   }
-  "some_use"(%0) : (vector<4xf32>) -> ()
+  "test.some_use"(%0) : (vector<4xf32>) -> ()
   return
 }
 
 // -----
 // CHECK-PROP-LABEL: func.func @warp_scf_for_swapped_for_results(
 //       CHECK-PROP:  %[[W0:.*]]:3 = gpu.warp_execute_on_lane_0(%{{.*}})[32] -> (vector<8xf32>, vector<4xf32>, vector<4xf32>) {
-//  CHECK-PROP-NEXT:    %[[INI0:.*]] = "some_def"() : () -> vector<256xf32>
-//  CHECK-PROP-NEXT:    %[[INI1:.*]] = "some_def"() : () -> vector<128xf32>
-//  CHECK-PROP-NEXT:    %[[INI2:.*]] = "some_def"() : () -> vector<128xf32>
+//  CHECK-PROP-NEXT:    %[[INI0:.*]] = "test.some_def"() : () -> vector<256xf32>
+//  CHECK-PROP-NEXT:    %[[INI1:.*]] = "test.some_def"() : () -> vector<128xf32>
+//  CHECK-PROP-NEXT:    %[[INI2:.*]] = "test.some_def"() : () -> vector<128xf32>
 //  CHECK-PROP-NEXT:    gpu.yield %[[INI0]], %[[INI1]], %[[INI2]] : vector<256xf32>, vector<128xf32>, vector<128xf32>
 //  CHECK-PROP-NEXT:  }
 //  CHECK-PROP-NEXT:  %[[F0:.*]]:3 = scf.for {{.*}} iter_args(%{{.*}} = %[[W0]]#0, %{{.*}} = %[[W0]]#1, %{{.*}} = %[[W0]]#2) -> (vector<8xf32>, vector<4xf32>, vector<4xf32>) {
 //  CHECK-PROP-NEXT:    %[[W1:.*]]:3 = gpu.warp_execute_on_lane_0(%{{.*}})[32] args(%{{.*}} :
 //  CHECK-PROP-SAME:        vector<8xf32>, vector<4xf32>, vector<4xf32>) -> (vector<8xf32>, vector<4xf32>, vector<4xf32>) {
 //  CHECK-PROP-NEXT:      ^bb0(%{{.*}}: vector<256xf32>, %{{.*}}: vector<128xf32>, %{{.*}}: vector<128xf32>):
-//  CHECK-PROP-NEXT:        %[[T3:.*]] = "some_def_1"(%{{.*}}) : (vector<256xf32>) -> vector<256xf32>
-//  CHECK-PROP-NEXT:        %[[T4:.*]] = "some_def_2"(%{{.*}}) : (vector<128xf32>) -> vector<128xf32>
-//  CHECK-PROP-NEXT:        %[[T5:.*]] = "some_def_3"(%{{.*}}) : (vector<128xf32>) -> vector<128xf32>
+//  CHECK-PROP-NEXT:        %[[T3:.*]] = "test.some_def_1"(%{{.*}}) : (vector<256xf32>) -> vector<256xf32>
+//  CHECK-PROP-NEXT:        %[[T4:.*]] = "test.some_def_2"(%{{.*}}) : (vector<128xf32>) -> vector<128xf32>
+//  CHECK-PROP-NEXT:        %[[T5:.*]] = "test.some_def_3"(%{{.*}}) : (vector<128xf32>) -> vector<128xf32>
 //  CHECK-PROP-NEXT:        gpu.yield %[[T3]], %[[T4]], %[[T5]] : vector<256xf32>, vector<128xf32>, vector<128xf32>
 //  CHECK-PROP-NEXT:    }
 //  CHECK-PROP-NEXT:    scf.yield %[[W1]]#0, %[[W1]]#1, %[[W1]]#2 : vector<8xf32>, vector<4xf32>, vector<4xf32>
 //  CHECK-PROP-NEXT:  }
-//  CHECK-PROP-NEXT:  "some_use_1"(%[[F0]]#2) : (vector<4xf32>) -> ()
-//  CHECK-PROP-NEXT:  "some_use_2"(%[[F0]]#1) : (vector<4xf32>) -> ()
-//  CHECK-PROP-NEXT:  "some_use_3"(%[[F0]]#0) : (vector<8xf32>) -> ()
+//  CHECK-PROP-NEXT:  "test.some_use_1"(%[[F0]]#2) : (vector<4xf32>) -> ()
+//  CHECK-PROP-NEXT:  "test.some_use_2"(%[[F0]]#1) : (vector<4xf32>) -> ()
+//  CHECK-PROP-NEXT:  "test.some_use_3"(%[[F0]]#0) : (vector<8xf32>) -> ()
 func.func @warp_scf_for_swapped_for_results(%arg0: index) {
   %c128 = arith.constant 128 : index
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
   %0:3 = gpu.warp_execute_on_lane_0(%arg0)[32] -> (vector<4xf32>, vector<4xf32>, vector<8xf32>) {
-    %ini1 = "some_def"() : () -> (vector<256xf32>)
-    %ini2 = "some_def"() : () -> (vector<128xf32>)
-    %ini3 = "some_def"() : () -> (vector<128xf32>)
+    %ini1 = "test.some_def"() : () -> (vector<256xf32>)
+    %ini2 = "test.some_def"() : () -> (vector<128xf32>)
+    %ini3 = "test.some_def"() : () -> (vector<128xf32>)
     %3:3 = scf.for %arg3 = %c0 to %c128 step %c1 iter_args(%arg4 = %ini1, %arg5 = %ini2, %arg6 = %ini3) -> (vector<256xf32>, vector<128xf32>, vector<128xf32>) {
-      %acc1 = "some_def_1"(%arg4) : (vector<256xf32>) -> (vector<256xf32>)
-      %acc2 = "some_def_2"(%arg5) : (vector<128xf32>) -> (vector<128xf32>)
-      %acc3 = "some_def_3"(%arg6) : (vector<128xf32>) -> (vector<128xf32>)
+      %acc1 = "test.some_def_1"(%arg4) : (vector<256xf32>) -> (vector<256xf32>)
+      %acc2 = "test.some_def_2"(%arg5) : (vector<128xf32>) -> (vector<128xf32>)
+      %acc3 = "test.some_def_3"(%arg6) : (vector<128xf32>) -> (vector<128xf32>)
       scf.yield %acc1, %acc2, %acc3 : vector<256xf32>, vector<128xf32>, vector<128xf32>
     }
     gpu.yield %3#2, %3#1, %3#0 : vector<128xf32>, vector<128xf32>, vector<256xf32>
   }
-  "some_use_1"(%0#0) : (vector<4xf32>) -> ()
-  "some_use_2"(%0#1) : (vector<4xf32>) -> ()
-  "some_use_3"(%0#2) : (vector<8xf32>) -> ()
+  "test.some_use_1"(%0#0) : (vector<4xf32>) -> ()
+  "test.some_use_2"(%0#1) : (vector<4xf32>) -> ()
+  "test.some_use_3"(%0#2) : (vector<8xf32>) -> ()
   return
 }
 
@@ -754,7 +754,7 @@ func.func @warp_scf_for_swapped_for_results(%arg0: index) {
 //       CHECK-PROP:   return %[[a4]] : f32
 func.func @vector_reduction(%laneid: index) -> (f32) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (f32) {
-    %0 = "some_def"() : () -> (vector<32xf32>)
+    %0 = "test.some_def"() : () -> (vector<32xf32>)
     %1 = vector.reduction <add>, %0 : vector<32xf32> into f32
     gpu.yield %1 : f32
   }
@@ -768,7 +768,7 @@ func.func @vector_reduction(%laneid: index) -> (f32) {
 //  CHECK-PROP-SAME:    %[[SRC:[a-zA-Z0-9]+]]
 //  CHECK-PROP-SAME:    %[[DEST:[a-zA-Z0-9]+]]
 //       CHECK-PROP:    gpu.warp_execute_on_lane_0(%[[ID]])[32]
-//  CHECK-PROP-NEXT:      "some_def"() : () -> vector<4096xf32>
+//  CHECK-PROP-NEXT:      "test.some_def"() : () -> vector<4096xf32>
 //  CHECK-PROP-NEXT:      %{{.*}} = vector.reduction
 //       CHECK-PROP:      %[[DEF:.*]] = arith.divf %{{.*}}, %{{.*}} : vector<1xf32>
 //   CHECK-PROP-NOT:      gpu.warp_execute_on_lane_0
@@ -782,7 +782,7 @@ func.func @warp_distribute(%arg0: index, %src: memref<128xf32>, %dest: memref<12
   %f0 = arith.constant 0.000000e+00 : f32
   gpu.warp_execute_on_lane_0(%arg0)[32]{
     %cst_1 = arith.constant dense<2.621440e+05> : vector<1xf32>
-    %0 = "some_def"() : () -> (vector<4096xf32>)
+    %0 = "test.some_def"() : () -> (vector<4096xf32>)
     %1 = vector.reduction <add>, %0, %cst : vector<4096xf32> into f32
     %2 = vector.broadcast %1 : f32 to vector<1xf32>
     %3 = arith.divf %2, %cst_1 : vector<1xf32>
@@ -842,7 +842,7 @@ func.func @vector_reduction(%laneid: index, %m0: memref<4x2x32xf32>, %m1: memref
 //       CHECK-PROP:   return %[[a4]] : f32
 func.func @vector_reduction_large(%laneid: index) -> (f32) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (f32) {
-    %0 = "some_def"() : () -> (vector<64xf32>)
+    %0 = "test.some_def"() : () -> (vector<64xf32>)
     %1 = vector.reduction <add>, %0 : vector<64xf32> into f32
     gpu.yield %1 : f32
   }
@@ -877,8 +877,8 @@ func.func @vector_reduction_large(%laneid: index) -> (f32) {
 //       CHECK-PROP:   return %[[a5]] : f32
 func.func @vector_reduction_acc(%laneid: index) -> (f32) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (f32) {
-    %0 = "some_def"() : () -> (vector<64xf32>)
-    %1 = "some_def"() : () -> (f32)
+    %0 = "test.some_def"() : () -> (vector<64xf32>)
+    %1 = "test.some_def"() : () -> (f32)
     %2 = vector.reduction <add>, %0, %1 : vector<64xf32> into f32
     gpu.yield %2 : f32
   }
@@ -891,8 +891,8 @@ func.func @vector_reduction_acc(%laneid: index) -> (f32) {
 func.func @warp_duplicate_yield(%laneid: index) -> (vector<1xf32>, vector<1xf32>) {
   //   CHECK-PROP: %{{.*}}:2 = gpu.warp_execute_on_lane_0(%{{.*}})[32] -> (vector<1xf32>, vector<1xf32>)
   %r:2 = gpu.warp_execute_on_lane_0(%laneid)[32] -> (vector<1xf32>, vector<1xf32>) {
-    %2 = "some_def"() : () -> (vector<32xf32>)
-    %3 = "some_def"() : () -> (vector<32xf32>)
+    %2 = "test.some_def"() : () -> (vector<32xf32>)
+    %3 = "test.some_def"() : () -> (vector<32xf32>)
     %4 = arith.addf %2, %3 : vector<32xf32>
     %5 = arith.addf %2, %2 : vector<32xf32>
 // CHECK-PROP-NOT:   arith.addf
@@ -922,7 +922,7 @@ func.func @warp_constant(%laneid: index) -> (vector<1xf32>) {
 // CHECK-PROP-LABEL: func.func @vector_extract_1d(
 //   CHECK-PROP-DAG:   %[[C5_I32:.*]] = arith.constant 5 : i32
 //       CHECK-PROP:   %[[R:.*]] = gpu.warp_execute_on_lane_0(%{{.*}})[32] -> (vector<2xf32>) {
-//       CHECK-PROP:     %[[V:.*]] = "some_def"() : () -> vector<64xf32>
+//       CHECK-PROP:     %[[V:.*]] = "test.some_def"() : () -> vector<64xf32>
 //       CHECK-PROP:     gpu.yield %[[V]] : vector<64xf32>
 //       CHECK-PROP:   }
 //       CHECK-PROP:   %[[E:.*]] = vector.extract %[[R]][1] : f32 from vector<2xf32>
@@ -930,7 +930,7 @@ func.func @warp_constant(%laneid: index) -> (vector<1xf32>) {
 //       CHECK-PROP:   return %[[SHUFFLED]] : f32
 func.func @vector_extract_1d(%laneid: index) -> (f32) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (f32) {
-    %0 = "some_def"() : () -> (vector<64xf32>)
+    %0 = "test.some_def"() : () -> (vector<64xf32>)
     %1 = vector.extract %0[9] : f32 from vector<64xf32>
     gpu.yield %1 : f32
   }
@@ -941,14 +941,14 @@ func.func @vector_extract_1d(%laneid: index) -> (f32) {
 
 // CHECK-PROP-LABEL: func.func @vector_extract_2d(
 //       CHECK-PROP:   %[[W:.*]] = gpu.warp_execute_on_lane_0(%{{.*}})[32] -> (vector<5x3xf32>) {
-//       CHECK-PROP:     %[[V:.*]] = "some_def"
+//       CHECK-PROP:     %[[V:.*]] = "test.some_def"
 //       CHECK-PROP:     gpu.yield %[[V]] : vector<5x96xf32>
 //       CHECK-PROP:   }
 //       CHECK-PROP:   %[[E:.*]] = vector.extract %[[W]][2] : vector<3xf32> from vector<5x3xf32>
 //       CHECK-PROP:   return %[[E]]
 func.func @vector_extract_2d(%laneid: index) -> (vector<3xf32>) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (vector<3xf32>) {
-    %0 = "some_def"() : () -> (vector<5x96xf32>)
+    %0 = "test.some_def"() : () -> (vector<5x96xf32>)
     %1 = vector.extract %0[2] : vector<96xf32> from vector<5x96xf32>
     gpu.yield %1 : vector<96xf32>
   }
@@ -959,14 +959,14 @@ func.func @vector_extract_2d(%laneid: index) -> (vector<3xf32>) {
 
 // CHECK-PROP-LABEL: func.func @vector_extract_2d_broadcast_scalar(
 //       CHECK-PROP:   %[[W:.*]] = gpu.warp_execute_on_lane_0(%{{.*}})[32] -> (vector<5x96xf32>) {
-//       CHECK-PROP:     %[[V:.*]] = "some_def"
+//       CHECK-PROP:     %[[V:.*]] = "test.some_def"
 //       CHECK-PROP:     gpu.yield %[[V]] : vector<5x96xf32>
 //       CHECK-PROP:   }
 //       CHECK-PROP:   %[[E:.*]] = vector.extract %[[W]][1, 2] : f32 from vector<5x96xf32>
 //       CHECK-PROP:   return %[[E]]
 func.func @vector_extract_2d_broadcast_scalar(%laneid: index) -> (f32) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (f32) {
-    %0 = "some_def"() : () -> (vector<5x96xf32>)
+    %0 = "test.some_def"() : () -> (vector<5x96xf32>)
     %1 = vector.extract %0[1, 2] : f32 from vector<5x96xf32>
     gpu.yield %1 : f32
   }
@@ -977,14 +977,14 @@ func.func @vector_extract_2d_broadcast_scalar(%laneid: index) -> (f32) {
 
 // CHECK-PROP-LABEL: func.func @vector_extract_2d_broadcast(
 //       CHECK-PROP:   %[[W:.*]] = gpu.warp_execute_on_lane_0(%{{.*}})[32] -> (vector<5x96xf32>) {
-//       CHECK-PROP:     %[[V:.*]] = "some_def"
+//       CHECK-PROP:     %[[V:.*]] = "test.some_def"
 //       CHECK-PROP:     gpu.yield %[[V]] : vector<5x96xf32>
 //       CHECK-PROP:   }
 //       CHECK-PROP:   %[[E:.*]] = vector.extract %[[W]][2] : vector<96xf32> from vector<5x96xf32>
 //       CHECK-PROP:   return %[[E]]
 func.func @vector_extract_2d_broadcast(%laneid: index) -> (vector<96xf32>) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (vector<96xf32>) {
-    %0 = "some_def"() : () -> (vector<5x96xf32>)
+    %0 = "test.some_def"() : () -> (vector<5x96xf32>)
     %1 = vector.extract %0[2] : vector<96xf32> from vector<5x96xf32>
     gpu.yield %1 : vector<96xf32>
   }
@@ -995,14 +995,14 @@ func.func @vector_extract_2d_broadcast(%laneid: index) -> (vector<96xf32>) {
 
 // CHECK-PROP-LABEL: func.func @vector_extract_3d(
 //       CHECK-PROP:   %[[W:.*]] = gpu.warp_execute_on_lane_0(%{{.*}})[32] -> (vector<8x4x96xf32>) {
-//       CHECK-PROP:     %[[V:.*]] = "some_def"
+//       CHECK-PROP:     %[[V:.*]] = "test.some_def"
 //       CHECK-PROP:     gpu.yield %[[V]] : vector<8x128x96xf32>
 //       CHECK-PROP:   }
 //       CHECK-PROP:   %[[E:.*]] = vector.extract %[[W]][2] : vector<4x96xf32> from vector<8x4x96xf32>
 //       CHECK-PROP:   return %[[E]]
 func.func @vector_extract_3d(%laneid: index) -> (vector<4x96xf32>) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (vector<4x96xf32>) {
-    %0 = "some_def"() : () -> (vector<8x128x96xf32>)
+    %0 = "test.some_def"() : () -> (vector<8x128x96xf32>)
     %1 = vector.extract %0[2] : vector<128x96xf32> from vector<8x128x96xf32>
     gpu.yield %1 : vector<128x96xf32>
   }
@@ -1013,14 +1013,14 @@ func.func @vector_extract_3d(%laneid: index) -> (vector<4x96xf32>) {
 
 // CHECK-PROP-LABEL: func.func @vector_extract_0d(
 //       CHECK-PROP:   %[[R:.*]] = gpu.warp_execute_on_lane_0(%{{.*}})[32] -> (vector<f32>) {
-//       CHECK-PROP:     %[[V:.*]] = "some_def"() : () -> vector<f32>
+//       CHECK-PROP:     %[[V:.*]] = "test.some_def"() : () -> vector<f32>
 //       CHECK-PROP:     gpu.yield %[[V]] : vector<f32>
 //       CHECK-PROP:   }
 //       CHECK-PROP:   %[[E:.*]] = vector.extract %[[R]][] : f32 from vector<f32>
 //       CHECK-PROP:   return %[[E]] : f32
 func.func @vector_extract_0d(%laneid: index) -> (f32) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (f32) {
-    %0 = "some_def"() : () -> (vector<f32>)
+    %0 = "test.some_def"() : () -> (vector<f32>)
     %1 = vector.extract %0[] : f32 from vector<f32>
     gpu.yield %1 : f32
   }
@@ -1031,14 +1031,14 @@ func.func @vector_extract_0d(%laneid: index) -> (f32) {
 
 // CHECK-PROP-LABEL: func.func @vector_extract_1element(
 //       CHECK-PROP:   %[[R:.*]] = gpu.warp_execute_on_lane_0(%{{.*}})[32] -> (vector<1xf32>) {
-//       CHECK-PROP:     %[[V:.*]] = "some_def"() : () -> vector<1xf32>
+//       CHECK-PROP:     %[[V:.*]] = "test.some_def"() : () -> vector<1xf32>
 //       CHECK-PROP:     gpu.yield %[[V]] : vector<1xf32>
 //       CHECK-PROP:   }
 //       CHECK-PROP:   %[[E:.*]] = vector.extract %[[R]][0] : f32 from vector<1xf32>
 //       CHECK-PROP:   return %[[E]] : f32
 func.func @vector_extract_1element(%laneid: index) -> (f32) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (f32) {
-    %0 = "some_def"() : () -> (vector<1xf32>)
+    %0 = "test.some_def"() : () -> (vector<1xf32>)
     %c0 = arith.constant 0 : index
     %1 = vector.extract %0[%c0] : f32 from vector<1xf32>
     gpu.yield %1 : f32
@@ -1054,7 +1054,7 @@ func.func @vector_extract_1element(%laneid: index) -> (f32) {
 //  CHECK-PROP-SAME:     %[[LANEID:.*]]: index, %[[POS:.*]]: index
 //   CHECK-PROP-DAG:   %[[C32:.*]] = arith.constant 32 : i32
 //       CHECK-PROP:   %[[W:.*]] = gpu.warp_execute_on_lane_0(%{{.*}})[32] -> (vector<3xf32>) {
-//       CHECK-PROP:     %[[V:.*]] = "some_def"
+//       CHECK-PROP:     %[[V:.*]] = "test.some_def"
 //       CHECK-PROP:     gpu.yield %[[V]] : vector<96xf32>
 //       CHECK-PROP:   }
 //       CHECK-PROP:   %[[FROM_LANE:.*]] = affine.apply #[[$map]]()[%[[POS]]]
@@ -1065,7 +1065,7 @@ func.func @vector_extract_1element(%laneid: index) -> (f32) {
 //       CHECK-PROP:   return %[[SHUFFLED]]
 func.func @vector_extract_1d(%laneid: index, %pos: index) -> (f32) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (f32) {
-    %0 = "some_def"() : () -> (vector<96xf32>)
+    %0 = "test.some_def"() : () -> (vector<96xf32>)
     %1 = vector.extract %0[%pos] : f32 from vector<96xf32>
     gpu.yield %1 : f32
   }
@@ -1078,13 +1078,13 @@ func.func @vector_extract_1d(%laneid: index, %pos: index) -> (f32) {
 
 // CHECK-PROP-LABEL: func.func @vector_extract_1d_index(
 //       CHECK-PROP:   gpu.warp_execute_on_lane_0(%{{.*}})[32] -> (index) {
-//       CHECK-PROP:     "some_def"
+//       CHECK-PROP:     "test.some_def"
 //       CHECK-PROP:     vector.extract
 //       CHECK-PROP:     gpu.yield {{.*}} : index
 //       CHECK-PROP:   }
 func.func @vector_extract_1d_index(%laneid: index, %pos: index) -> (index) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (index) {
-    %0 = "some_def"() : () -> (vector<96xindex>)
+    %0 = "test.some_def"() : () -> (vector<96xindex>)
     %1 = vector.extract %0[%pos] : index from vector<96xindex>
     gpu.yield %1 : index
   }
@@ -1164,11 +1164,11 @@ func.func @dont_duplicate_read(
   %cst = arith.constant 0.000000e+00 : f32
 //       CHECK-PROP:   gpu.warp_execute_on_lane_0(%{{.*}})[32] -> (vector<1xf32>) {
 //  CHECK-PROP-NEXT:     vector.transfer_read
-//  CHECK-PROP-NEXT:     "blocking_use"
+//  CHECK-PROP-NEXT:     "test.blocking_use"
 //  CHECK-PROP-NEXT:     gpu.yield
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (vector<1xf32>) {
     %2 = vector.transfer_read %src[%c0], %cst : memref<1024xf32>, vector<32xf32>
-    "blocking_use"(%2) : (vector<32xf32>) -> ()
+    "test.blocking_use"(%2) : (vector<32xf32>) -> ()
     gpu.yield %2 : vector<32xf32>
   }
   return %r : vector<1xf32>
@@ -1185,8 +1185,8 @@ func.func @dedup(%laneid: index, %v0: vector<4xf32>, %v1: vector<4xf32>)
       args(%v0, %v1 : vector<4xf32>, vector<4xf32>) -> (vector<1xf32>, vector<1xf32>) {
     ^bb0(%arg0: vector<128xf32>, %arg1: vector<128xf32>):
 
-    // CHECK-PROP: %[[SINGLE_VAL:.*]] = "some_def"(%{{.*}}) : (vector<128xf32>) -> vector<32xf32>
-    %2 = "some_def"(%arg0) : (vector<128xf32>) -> vector<32xf32>
+    // CHECK-PROP: %[[SINGLE_VAL:.*]] = "test.some_def"(%{{.*}}) : (vector<128xf32>) -> vector<32xf32>
+    %2 = "test.some_def"(%arg0) : (vector<128xf32>) -> vector<32xf32>
 
     // CHECK-PROP: gpu.yield %[[SINGLE_VAL]] : vector<32xf32>
     gpu.yield %2, %2 : vector<32xf32>, vector<32xf32>
@@ -1212,19 +1212,19 @@ func.func @warp_execute_has_broadcast_semantics(%laneid: index, %s0: f32, %v0: v
       // CHECK-SCF-IF: vector.transfer_read {{.*}}[%[[C0]]]{{.*}} {in_bounds = [true]} : memref<1xf32, 3>, vector<1xf32>
       // CHECK-SCF-IF: vector.transfer_read {{.*}}[]{{.*}} : memref<f32, 3>, vector<f32>
       // CHECK-SCF-IF: memref.load {{.*}}[%[[C0]]] : memref<1xf32, 3>
-      // CHECK-SCF-IF: "some_def_0"(%{{.*}}) : (f32) -> f32
-      // CHECK-SCF-IF: "some_def_1"(%{{.*}}) : (vector<f32>) -> vector<f32>
-      // CHECK-SCF-IF: "some_def_1"(%{{.*}}) : (vector<1xf32>) -> vector<1xf32>
-      // CHECK-SCF-IF: "some_def_1"(%{{.*}}) : (vector<1x1xf32>) -> vector<1x1xf32>
+      // CHECK-SCF-IF: "test.some_def_0"(%{{.*}}) : (f32) -> f32
+      // CHECK-SCF-IF: "test.some_def_1"(%{{.*}}) : (vector<f32>) -> vector<f32>
+      // CHECK-SCF-IF: "test.some_def_1"(%{{.*}}) : (vector<1xf32>) -> vector<1xf32>
+      // CHECK-SCF-IF: "test.some_def_1"(%{{.*}}) : (vector<1x1xf32>) -> vector<1x1xf32>
       // CHECK-SCF-IF: memref.store {{.*}}[%[[C0]]] : memref<1xf32, 3>
       // CHECK-SCF-IF: vector.transfer_write {{.*}}[] : vector<f32>, memref<f32, 3>
       // CHECK-SCF-IF: vector.transfer_write {{.*}}[%[[C0]]] {in_bounds = [true]} : vector<1xf32>, memref<1xf32, 3>
       // CHECK-SCF-IF: vector.transfer_write {{.*}}[%[[C0]], %[[C0]]] {in_bounds = [true, true]} : vector<1x1xf32>, memref<1x1xf32, 3>
 
-      %rs0 = "some_def_0"(%bs0) : (f32) -> f32
-      %rv0 = "some_def_1"(%bv0) : (vector<f32>) -> vector<f32>
-      %rv1 = "some_def_1"(%bv1) : (vector<1xf32>) -> vector<1xf32>
-      %rv2 = "some_def_1"(%bv2) : (vector<1x1xf32>) -> vector<1x1xf32>
+      %rs0 = "test.some_def_0"(%bs0) : (f32) -> f32
+      %rv0 = "test.some_def_1"(%bv0) : (vector<f32>) -> vector<f32>
+      %rv1 = "test.some_def_1"(%bv1) : (vector<1xf32>) -> vector<1xf32>
+      %rv2 = "test.some_def_1"(%bv2) : (vector<1x1xf32>) -> vector<1x1xf32>
 
       // CHECK-SCF-IF-NOT: gpu.yield
       gpu.yield %rs0, %rv0, %rv1, %rv2 : f32, vector<f32>, vector<1xf32>, vector<1x1xf32>
@@ -1261,13 +1261,13 @@ func.func @warp_execute_nd_distribute(%laneid: index, %v0: vector<1x64x1xf32>, %
 
   // CHECK-SCF-IF-DAG: %[[SR0:.*]] = vector.transfer_read %{{.*}}[%[[C0]], %[[C0]], %[[C0]]], %{{.*}} {in_bounds = [true, true, true]} : memref<32x64x1xf32, 3>, vector<32x64x1xf32>
   // CHECK-SCF-IF-DAG: %[[SR1:.*]] = vector.transfer_read %{{.*}}[%[[C0]], %[[C0]], %[[C0]]], %{{.*}} {in_bounds = [true, true, true]} : memref<1x64x128xf32, 3>, vector<1x64x128xf32>
-  //     CHECK-SCF-IF: %[[W0:.*]] = "some_def_0"(%[[SR0]]) : (vector<32x64x1xf32>) -> vector<32x64x1xf32>
-  //     CHECK-SCF-IF: %[[W1:.*]] = "some_def_1"(%[[SR1]]) : (vector<1x64x128xf32>) -> vector<1x64x128xf32>
+  //     CHECK-SCF-IF: %[[W0:.*]] = "test.some_def_0"(%[[SR0]]) : (vector<32x64x1xf32>) -> vector<32x64x1xf32>
+  //     CHECK-SCF-IF: %[[W1:.*]] = "test.some_def_1"(%[[SR1]]) : (vector<1x64x128xf32>) -> vector<1x64x128xf32>
   // CHECK-SCF-IF-DAG: vector.transfer_write %[[W0]], %{{.*}}[%[[C0]], %[[C0]], %[[C0]]] {in_bounds = [true, true, true]} : vector<32x64x1xf32>, memref<32x64x1xf32, 3>
   // CHECK-SCF-IF-DAG: vector.transfer_write %[[W1]], %{{.*}}[%[[C0]], %[[C0]], %[[C0]]] {in_bounds = [true, true, true]} : vector<1x64x128xf32>, memref<1x64x128xf32, 3>
 
-      %r0 = "some_def_0"(%arg0) : (vector<32x64x1xf32>) -> vector<32x64x1xf32>
-      %r1 = "some_def_1"(%arg1) : (vector<1x64x128xf32>) -> vector<1x64x128xf32>
+      %r0 = "test.some_def_0"(%arg0) : (vector<32x64x1xf32>) -> vector<32x64x1xf32>
+      %r1 = "test.some_def_1"(%arg1) : (vector<1x64x128xf32>) -> vector<1x64x128xf32>
 
       // CHECK-SCF-IF-NOT: gpu.yield
       gpu.yield %r0, %r1 : vector<32x64x1xf32>, vector<1x64x128xf32>
@@ -1300,8 +1300,8 @@ func.func @warp_execute_nd_distribute(%laneid: index, %v0: vector<1x64x1xf32>, %
 //       CHECK-PROP:   return %[[R]]
 func.func @vector_insert_1d(%laneid: index, %pos: index) -> (vector<3xf32>) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (vector<3xf32>) {
-    %0 = "some_def"() : () -> (vector<96xf32>)
-    %f = "another_def"() : () -> (f32)
+    %0 = "test.some_def"() : () -> (vector<96xf32>)
+    %f = "test.another_def"() : () -> (f32)
     %1 = vector.insert %f, %0[%pos] : f32 into vector<96xf32>
     gpu.yield %1 : vector<96xf32>
   }
@@ -1313,14 +1313,14 @@ func.func @vector_insert_1d(%laneid: index, %pos: index) -> (vector<3xf32>) {
 // CHECK-PROP-LABEL: func @vector_insert_1d_broadcast(
 //  CHECK-PROP-SAME:     %[[LANEID:.*]]: index, %[[POS:.*]]: index
 //       CHECK-PROP:   %[[W:.*]]:2 = gpu.warp_execute_on_lane_0{{.*}} -> (vector<96xf32>, f32)
-//       CHECK-PROP:     %[[VEC:.*]] = "some_def"
-//       CHECK-PROP:     %[[VAL:.*]] = "another_def"
+//       CHECK-PROP:     %[[VEC:.*]] = "test.some_def"
+//       CHECK-PROP:     %[[VAL:.*]] = "test.another_def"
 //       CHECK-PROP:     gpu.yield %[[VEC]], %[[VAL]]
 //       CHECK-PROP:   vector.insert %[[W]]#1, %[[W]]#0 [%[[POS]]] : f32 into vector<96xf32>
 func.func @vector_insert_1d_broadcast(%laneid: index, %pos: index) -> (vector<96xf32>) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (vector<96xf32>) {
-    %0 = "some_def"() : () -> (vector<96xf32>)
-    %f = "another_def"() : () -> (f32)
+    %0 = "test.some_def"() : () -> (vector<96xf32>)
+    %f = "test.another_def"() : () -> (f32)
     %1 = vector.insert %f, %0[%pos] : f32 into vector<96xf32>
     gpu.yield %1 : vector<96xf32>
   }
@@ -1331,14 +1331,14 @@ func.func @vector_insert_1d_broadcast(%laneid: index, %pos: index) -> (vector<96
 
 // CHECK-PROP-LABEL: func @vector_insert_0d(
 //       CHECK-PROP:   %[[W:.*]]:2 = gpu.warp_execute_on_lane_0{{.*}} -> (vector<f32>, f32)
-//       CHECK-PROP:     %[[VEC:.*]] = "some_def"
-//       CHECK-PROP:     %[[VAL:.*]] = "another_def"
+//       CHECK-PROP:     %[[VEC:.*]] = "test.some_def"
+//       CHECK-PROP:     %[[VAL:.*]] = "test.another_def"
 //       CHECK-PROP:     gpu.yield %[[VEC]], %[[VAL]]
 //       CHECK-PROP:   vector.broadcast %[[W]]#1 : f32 to vector<f32>
 func.func @vector_insert_0d(%laneid: index) -> (vector<f32>) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (vector<f32>) {
-    %0 = "some_def"() : () -> (vector<f32>)
-    %f = "another_def"() : () -> (f32)
+    %0 = "test.some_def"() : () -> (vector<f32>)
+    %f = "test.another_def"() : () -> (f32)
     %1 = vector.insert %f, %0[] : f32 into vector<f32>
     gpu.yield %1 : vector<f32>
   }
@@ -1351,8 +1351,8 @@ func.func @vector_insert_0d(%laneid: index) -> (vector<f32>) {
 //  CHECK-PROP-SAME:     %[[LANEID:.*]]: index
 //   CHECK-PROP-DAG:   %[[C26:.*]] = arith.constant 26 : index
 //       CHECK-PROP:   %[[W:.*]]:2 = gpu.warp_execute_on_lane_0{{.*}} -> (vector<3xf32>, f32)
-//       CHECK-PROP:     %[[VEC:.*]] = "some_def"
-//       CHECK-PROP:     %[[VAL:.*]] = "another_def"
+//       CHECK-PROP:     %[[VEC:.*]] = "test.some_def"
+//       CHECK-PROP:     %[[VAL:.*]] = "test.another_def"
 //       CHECK-PROP:     gpu.yield %[[VEC]], %[[VAL]]
 //       CHECK-PROP:   %[[SHOULD_INSERT:.*]] = arith.cmpi eq, %[[LANEID]], %[[C26]]
 //       CHECK-PROP:   %[[R:.*]] = scf.if %[[SHOULD_INSERT]] -> (vector<3xf32>) {
@@ -1364,8 +1364,8 @@ func.func @vector_insert_0d(%laneid: index) -> (vector<f32>) {
 //       CHECK-PROP:   return %[[R]]
 func.func @vector_insert_1d(%laneid: index) -> (vector<3xf32>) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (vector<3xf32>) {
-    %0 = "some_def"() : () -> (vector<96xf32>)
-    %f = "another_def"() : () -> (f32)
+    %0 = "test.some_def"() : () -> (vector<96xf32>)
+    %f = "test.another_def"() : () -> (f32)
     %1 = vector.insert %f, %0[76] : f32 into vector<96xf32>
     gpu.yield %1 : vector<96xf32>
   }
@@ -1377,15 +1377,15 @@ func.func @vector_insert_1d(%laneid: index) -> (vector<3xf32>) {
 // CHECK-PROP-LABEL: func @vector_insert_2d_distr_src(
 //  CHECK-PROP-SAME:     %[[LANEID:.*]]: index
 //       CHECK-PROP:   %[[W:.*]]:2 = gpu.warp_execute_on_lane_0{{.*}} -> (vector<3xf32>, vector<4x3xf32>)
-//       CHECK-PROP:     %[[VEC:.*]] = "some_def"
-//       CHECK-PROP:     %[[VAL:.*]] = "another_def"
+//       CHECK-PROP:     %[[VEC:.*]] = "test.some_def"
+//       CHECK-PROP:     %[[VAL:.*]] = "test.another_def"
 //       CHECK-PROP:     gpu.yield %[[VAL]], %[[VEC]]
 //       CHECK-PROP:   %[[INSERT:.*]] = vector.insert %[[W]]#0, %[[W]]#1 [2] : vector<3xf32> into vector<4x3xf32>
 //       CHECK-PROP:   return %[[INSERT]]
 func.func @vector_insert_2d_distr_src(%laneid: index) -> (vector<4x3xf32>) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (vector<4x3xf32>) {
-    %0 = "some_def"() : () -> (vector<4x96xf32>)
-    %s = "another_def"() : () -> (vector<96xf32>)
+    %0 = "test.some_def"() : () -> (vector<4x96xf32>)
+    %s = "test.another_def"() : () -> (vector<96xf32>)
     %1 = vector.insert %s, %0[2] : vector<96xf32> into vector<4x96xf32>
     gpu.yield %1 : vector<4x96xf32>
   }
@@ -1398,8 +1398,8 @@ func.func @vector_insert_2d_distr_src(%laneid: index) -> (vector<4x3xf32>) {
 //  CHECK-PROP-SAME:     %[[LANEID:.*]]: index
 //       CHECK-PROP:   %[[C19:.*]] = arith.constant 19 : index
 //       CHECK-PROP:   %[[W:.*]]:2 = gpu.warp_execute_on_lane_0{{.*}} -> (vector<96xf32>, vector<4x96xf32>)
-//       CHECK-PROP:     %[[VEC:.*]] = "some_def"
-//       CHECK-PROP:     %[[VAL:.*]] = "another_def"
+//       CHECK-PROP:     %[[VEC:.*]] = "test.some_def"
+//       CHECK-PROP:     %[[VAL:.*]] = "test.another_def"
 //       CHECK-PROP:     gpu.yield %[[VAL]], %[[VEC]]
 //       CHECK-PROP:   %[[SHOULD_INSERT:.*]] = arith.cmpi eq, %[[LANEID]], %[[C19]]
 //       CHECK-PROP:   %[[R:.*]] = scf.if %[[SHOULD_INSERT]] -> (vector<4x96xf32>) {
@@ -1411,8 +1411,8 @@ func.func @vector_insert_2d_distr_src(%laneid: index) -> (vector<4x3xf32>) {
 //       CHECK-PROP:   return %[[R]]
 func.func @vector_insert_2d_distr_pos(%laneid: index) -> (vector<4x96xf32>) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (vector<4x96xf32>) {
-    %0 = "some_def"() : () -> (vector<128x96xf32>)
-    %s = "another_def"() : () -> (vector<96xf32>)
+    %0 = "test.some_def"() : () -> (vector<128x96xf32>)
+    %s = "test.another_def"() : () -> (vector<96xf32>)
     %1 = vector.insert %s, %0[79] : vector<96xf32> into vector<128x96xf32>
     gpu.yield %1 : vector<128x96xf32>
   }
@@ -1424,15 +1424,15 @@ func.func @vector_insert_2d_distr_pos(%laneid: index) -> (vector<4x96xf32>) {
 // CHECK-PROP-LABEL: func @vector_insert_2d_broadcast(
 //  CHECK-PROP-SAME:     %[[LANEID:.*]]: index
 //       CHECK-PROP:   %[[W:.*]]:2 = gpu.warp_execute_on_lane_0{{.*}} -> (vector<96xf32>, vector<4x96xf32>)
-//       CHECK-PROP:     %[[VEC:.*]] = "some_def"
-//       CHECK-PROP:     %[[VAL:.*]] = "another_def"
+//       CHECK-PROP:     %[[VEC:.*]] = "test.some_def"
+//       CHECK-PROP:     %[[VAL:.*]] = "test.another_def"
 //       CHECK-PROP:     gpu.yield %[[VAL]], %[[VEC]]
 //       CHECK-PROP:   %[[INSERT:.*]] = vector.insert %[[W]]#0, %[[W]]#1 [2] : vector<96xf32> into vector<4x96xf32>
 //       CHECK-PROP:   return %[[INSERT]]
 func.func @vector_insert_2d_broadcast(%laneid: index) -> (vector<4x96xf32>) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (vector<4x96xf32>) {
-    %0 = "some_def"() : () -> (vector<4x96xf32>)
-    %s = "another_def"() : () -> (vector<96xf32>)
+    %0 = "test.some_def"() : () -> (vector<4x96xf32>)
+    %s = "test.another_def"() : () -> (vector<96xf32>)
     %1 = vector.insert %s, %0[2] : vector<96xf32> into vector<4x96xf32>
     gpu.yield %1 : vector<4x96xf32>
   }
@@ -1443,14 +1443,14 @@ func.func @vector_insert_2d_broadcast(%laneid: index) -> (vector<4x96xf32>) {
 // CHECK-PROP-LABEL: func.func @vector_extract_strided_slice_2d_distr_inner(
 //  CHECK-RPOP-SAME: %[[LANEID:.*]]: index
 //       CHECK-PROP: %[[W:.*]] = gpu.warp_execute_on_lane_0{{.*}} -> (vector<64x1xf32>) {
-//       CHECK-PROP: %[[VEC:.*]] = "some_def"() : () -> vector<64x32xf32>
+//       CHECK-PROP: %[[VEC:.*]] = "test.some_def"() : () -> vector<64x32xf32>
 //       CHECK-PROP: gpu.yield %[[VEC]] : vector<64x32xf32>
 //       CHECK-PROP: %[[EXTRACT:.*]] = vector.extract_strided_slice %[[W]]
 //  CHECK-PROP-SAME: offsets = [8], sizes = [24], strides = [1] : vector<64x1xf32> to vector<24x1xf32>
 //       CHECK-PROP: return %[[EXTRACT]] : vector<24x1xf32>
 func.func @vector_extract_strided_slice_2d_distr_inner(%laneid: index) -> (vector<24x1xf32>) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (vector<24x1xf32>) {
-    %0 = "some_def"() : () -> (vector<64x32xf32>)
+    %0 = "test.some_def"() : () -> (vector<64x32xf32>)
     %1 = vector.extract_strided_slice %0 offsets = [8], sizes = [24], strides = [1]
       : vector<64x32xf32> to vector<24x32xf32>
     gpu.yield %1 : vector<24x32xf32>
@@ -1462,14 +1462,14 @@ func.func @vector_extract_strided_slice_2d_distr_inner(%laneid: index) -> (vecto
 // CHECK-PROP-LABEL: func.func @vector_extract_strided_slice_2d_distr_outer(
 //  CHECK-PROP-SAME: %[[LANEID:.*]]: index
 //       CHECK-PROP: %[[W:.*]] = gpu.warp_execute_on_lane_0{{.*}} -> (vector<1x64xf32>) {
-//       CHECK-PROP: %[[VEC:.*]] = "some_def"() : () -> vector<32x64xf32>
+//       CHECK-PROP: %[[VEC:.*]] = "test.some_def"() : () -> vector<32x64xf32>
 //       CHECK-PROP: gpu.yield %[[VEC]] : vector<32x64xf32>
 //       CHECK-PROP: %[[EXTRACT:.*]] = vector.extract_strided_slice %[[W]]
 //  CHECK-PROP-SAME: offsets = [0, 12], sizes = [1, 8], strides = [1, 1] : vector<1x64xf32> to vector<1x8xf32>
 //       CHECK-PROP: return %[[EXTRACT]] : vector<1x8xf32>
 func.func @vector_extract_strided_slice_2d_distr_outer(%laneid: index) -> (vector<1x8xf32>) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (vector<1x8xf32>) {
-    %0 = "some_def"() : () -> (vector<32x64xf32>)
+    %0 = "test.some_def"() : () -> (vector<32x64xf32>)
     %1 = vector.extract_strided_slice %0 offsets = [0, 12], sizes = [32, 8], strides = [1, 1]
       : vector<32x64xf32> to vector<32x8xf32>
     gpu.yield %1 : vector<32x8xf32>
@@ -1481,16 +1481,16 @@ func.func @vector_extract_strided_slice_2d_distr_outer(%laneid: index) -> (vecto
 // CHECK-PROP-LABEL: func.func @vector_insert_strided_slice_1d_to_2d(
 //  CHECK-PROP-SAME: %[[LANEID:.*]]: index)
 //       CHECK-PROP: %[[W:.*]]:2 = gpu.warp_execute_on_lane_0({{.*}} -> (vector<1xf32>, vector<64x1xf32>) {
-//       CHECK-PROP: %[[SRC:.*]] = "some_def"() : () -> vector<32xf32>
-//       CHECK-PROP: %[[DEST:.*]] = "some_def"() : () -> vector<64x32xf32>
+//       CHECK-PROP: %[[SRC:.*]] = "test.some_def"() : () -> vector<32xf32>
+//       CHECK-PROP: %[[DEST:.*]] = "test.some_def"() : () -> vector<64x32xf32>
 //       CHECK-PROP: gpu.yield %[[SRC]], %[[DEST]] : vector<32xf32>, vector<64x32xf32>
 //       CHECK-PROP: %[[INSERT:.*]] = vector.insert_strided_slice %[[W]]#0, %[[W]]#1
 //  CHECK-PROP-SAME: offsets = [18, 0], strides = [1] : vector<1xf32> into vector<64x1xf32>
 //       CHECK-PROP: return %[[INSERT]] : vector<64x1xf32>
 func.func @vector_insert_strided_slice_1d_to_2d(%laneid: index) -> (vector<64x1xf32>) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (vector<64x1xf32>) {
-    %0 = "some_def"() : () -> (vector<32xf32>)
-    %1 = "some_def"() : () -> (vector<64x32xf32>)
+    %0 = "test.some_def"() : () -> (vector<32xf32>)
+    %1 = "test.some_def"() : () -> (vector<64x32xf32>)
     %2 = vector.insert_strided_slice %0, %1 offsets = [18, 0], strides = [1]
       : vector<32xf32> into vector<64x32xf32>
     gpu.yield %2 : vector<64x32xf32>
@@ -1502,16 +1502,16 @@ func.func @vector_insert_strided_slice_1d_to_2d(%laneid: index) -> (vector<64x1x
 // CHECK-PROP-LABEL: func.func @vector_insert_strided_slice_2d_to_2d(
 //  CHECK-PROP-SAME: %[[LANEID:.*]]: index)
 //       CHECK-PROP: %[[W:.*]]:2 = gpu.warp_execute_on_lane_0{{.*}} -> (vector<16x1xf32>, vector<64x1xf32>) {
-//       CHECK-PROP: %[[SRC:.*]] = "some_def"() : () -> vector<16x32xf32>
-//       CHECK-PROP: %[[DEST:.*]] = "some_def"() : () -> vector<64x32xf32>
+//       CHECK-PROP: %[[SRC:.*]] = "test.some_def"() : () -> vector<16x32xf32>
+//       CHECK-PROP: %[[DEST:.*]] = "test.some_def"() : () -> vector<64x32xf32>
 //       CHECK-PROP: gpu.yield %[[SRC]], %[[DEST]] : vector<16x32xf32>, vector<64x32xf32>
 //       CHECK-PROP: %[[INSERT:.*]] = vector.insert_strided_slice %[[W]]#0, %[[W]]#1 offsets = [36, 0], strides = [1, 1] :
 //  CHECK-PROP-SAME: vector<16x1xf32> into vector<64x1xf32>
 //       CHECK-PROP: return %[[INSERT]] : vector<64x1xf32>
 func.func @vector_insert_strided_slice_2d_to_2d(%laneid: index) -> (vector<64x1xf32>) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (vector<64x1xf32>) {
-    %0 = "some_def"() : () -> (vector<16x32xf32>)
-    %1 = "some_def"() : () -> (vector<64x32xf32>)
+    %0 = "test.some_def"() : () -> (vector<16x32xf32>)
+    %1 = "test.some_def"() : () -> (vector<64x32xf32>)
     %2 = vector.insert_strided_slice %0, %1 offsets = [36, 0], strides = [1, 1]
       : vector<16x32xf32> into vector<64x32xf32>
     gpu.yield %2 : vector<64x32xf32>
@@ -1570,13 +1570,13 @@ func.func @transfer_read_prop_operands(%in2: vector<1x2xindex>, %ar1 :  memref<1
 
 // CHECK-PROP-LABEL: func @dont_fold_vector_broadcast(
 //       CHECK-PROP:   %[[r:.*]] = gpu.warp_execute_on_lane_0{{.*}} -> (vector<1x2xf32>)
-//       CHECK-PROP:     %[[some_def:.*]] = "some_def"
+//       CHECK-PROP:     %[[some_def:.*]] = "test.some_def"
 //       CHECK-PROP:     %[[broadcast:.*]] = vector.shape_cast %[[some_def]] : vector<64xf32> to vector<1x64xf32>
 //       CHECK-PROP:     gpu.yield %[[broadcast]] : vector<1x64xf32>
 //       CHECK-PROP:   vector.print %[[r]] : vector<1x2xf32>
 func.func @dont_fold_vector_broadcast(%laneid: index) {
   %r = gpu.warp_execute_on_lane_0(%laneid)[32] -> (vector<1x2xf32>) {
-    %0 = "some_def"() : () -> (vector<64xf32>)
+    %0 = "test.some_def"() : () -> (vector<64xf32>)
     %1 = vector.broadcast %0 : vector<64xf32> to vector<1x64xf32>
     gpu.yield %1 : vector<1x64xf32>
   }
@@ -1692,7 +1692,7 @@ func.func @warp_propagate_multi_transfer_read(%laneid: index, %src: memref<4096x
   %f0 = arith.constant 0.000000e+00 : f32
   %r:2 = gpu.warp_execute_on_lane_0(%laneid)[64] -> (vector<1xf32>, vector<1xf32>) {
     %0 = vector.transfer_read %src[%index], %f0 {in_bounds = [true]} : memref<4096xf32>, vector<1xf32>
-    "some_use"(%0) : (vector<1xf32>) -> ()
+    "test.some_use"(%0) : (vector<1xf32>) -> ()
     %1 = vector.transfer_read %src[%index1], %f0 {in_bounds = [true]} : memref<4096xf32>, vector<1xf32>
     gpu.yield %0, %1 : vector<1xf32>, vector<1xf32>
   }
@@ -1702,7 +1702,7 @@ func.func @warp_propagate_multi_transfer_read(%laneid: index, %src: memref<4096x
 // CHECK-PROP-LABEL: func.func @warp_propagate_multi_transfer_read
 //       CHECK-PROP:   gpu.warp_execute_on_lane_0{{.*}} -> (vector<1xf32>)
 //       CHECK-PROP:     %[[INNER_READ:.+]] = vector.transfer_read
-//       CHECK-PROP:     "some_use"(%[[INNER_READ]])
+//       CHECK-PROP:     "test.some_use"(%[[INNER_READ]])
 //       CHECK-PROP:     gpu.yield %[[INNER_READ]] : vector<1xf32>
 //       CHECK-PROP:   vector.transfer_read
 
@@ -1728,10 +1728,10 @@ func.func @warp_propagate_dead_user_multi_read(%laneid: index, %src: memref<4096
 func.func @warp_propagate_masked_write(%laneid: index, %dest: memref<4096xf32>) {
   %c0 = arith.constant 0 : index
   gpu.warp_execute_on_lane_0(%laneid)[32] -> () {
-    %mask = "mask_def_0"() : () -> (vector<4096xi1>)
-    %mask2 = "mask_def_1"() : () -> (vector<32xi1>)
-    %0 = "some_def_0"() : () -> (vector<4096xf32>)
-    %1 = "some_def_1"() : () -> (vector<32xf32>)
+    %mask = "test.mask_def_0"() : () -> (vector<4096xi1>)
+    %mask2 = "test.mask_def_1"() : () -> (vector<32xi1>)
+    %0 = "test.some_def_0"() : () -> (vector<4096xf32>)
+    %1 = "test.some_def_1"() : () -> (vector<32xf32>)
     vector.transfer_write %0, %dest[%c0], %mask : vector<4096xf32>, memref<4096xf32>
     vector.transfer_write %1, %dest[%c0], %mask2 : vector<32xf32>, memref<4096xf32>
     gpu.yield
@@ -1741,10 +1741,10 @@ func.func @warp_propagate_masked_write(%laneid: index, %dest: memref<4096xf32>) 
 
 // CHECK-DIST-AND-PROP-LABEL: func.func @warp_propagate_masked_write(
 //       CHECK-DIST-AND-PROP:   %[[W:.*]]:4 = gpu.warp_execute_on_lane_0(%{{.*}})[32] -> (vector<1xf32>, vector<1xi1>, vector<128xf32>, vector<128xi1>) {
-//       CHECK-DIST-AND-PROP:     %[[M0:.*]] = "mask_def_0"
-//       CHECK-DIST-AND-PROP:     %[[M1:.*]] = "mask_def_1"
-//       CHECK-DIST-AND-PROP:     %[[V0:.*]] = "some_def_0"
-//       CHECK-DIST-AND-PROP:     %[[V1:.*]] = "some_def_1"
+//       CHECK-DIST-AND-PROP:     %[[M0:.*]] = "test.mask_def_0"
+//       CHECK-DIST-AND-PROP:     %[[M1:.*]] = "test.mask_def_1"
+//       CHECK-DIST-AND-PROP:     %[[V0:.*]] = "test.some_def_0"
+//       CHECK-DIST-AND-PROP:     %[[V1:.*]] = "test.some_def_1"
 //       CHECK-DIST-AND-PROP:     gpu.yield %[[V1]], %[[M1]], %[[V0]], %[[M0]]
 //  CHECK-DIST-AND-PROP-SAME:       vector<32xf32>, vector<32xi1>, vector<4096xf32>, vector<4096xi1>
 //       CHECK-DIST-AND-PROP:   }
@@ -1757,9 +1757,9 @@ func.func @warp_propagate_masked_transfer_read(%laneid: index, %src: memref<4096
   %f0 = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index
   %r:2 = gpu.warp_execute_on_lane_0(%laneid)[64] -> (vector<2xf32>, vector<2x2xf32>) {
-    %mask = "mask_def_0"() : () -> (vector<128xi1>)
+    %mask = "test.mask_def_0"() : () -> (vector<128xi1>)
     %0 = vector.transfer_read %src[%c0, %index], %f0, %mask {in_bounds = [true]} : memref<4096x4096xf32>, vector<128xf32>
-    %mask2 = "mask_def_1"() : () -> (vector<128x2xi1>)
+    %mask2 = "test.mask_def_1"() : () -> (vector<128x2xi1>)
     %1 = vector.transfer_read %src[%c0, %index], %f0, %mask2 {in_bounds = [true, true]} : memref<4096x4096xf32>, vector<128x2xf32>
     gpu.yield %0, %1 : vector<128xf32>, vector<128x2xf32>
   }
@@ -1772,8 +1772,8 @@ func.func @warp_propagate_masked_transfer_read(%laneid: index, %src: memref<4096
 //  CHECK-PROP-SAME:   %[[ARG0:.+]]: index, {{.*}}, %[[ARG2:.+]]: index
 //       CHECK-PROP:   %[[C0:.*]] = arith.constant 0 : index
 //       CHECK-PROP:   %[[R:.*]]:2 = gpu.warp_execute_on_lane_0(%{{.*}})[64] -> (vector<2xi1>, vector<2x2xi1>) {
-//       CHECK-PROP:     %[[M0:.*]] = "mask_def_0"
-//       CHECK-PROP:     %[[M1:.*]] = "mask_def_1"
+//       CHECK-PROP:     %[[M0:.*]] = "test.mask_def_0"
+//       CHECK-PROP:     %[[M1:.*]] = "test.mask_def_1"
 //       CHECK-PROP:     gpu.yield %[[M0]], %[[M1]] : vector<128xi1>, vector<128x2xi1>
 //       CHECK-PROP:   }
 //       CHECK-PROP:   %[[DIST_READ_IDX0:.+]] = affine.apply #[[$MAP0]]()[%[[ARG0]]]
@@ -1787,7 +1787,7 @@ func.func @warp_propagate_nontrivial_map_masked_transfer_read(%laneid: index, %s
   %f0 = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index
   %r = gpu.warp_execute_on_lane_0(%laneid)[64] -> (vector<2xf32>) {
-    %mask = "mask_def_0"() : () -> (vector<128xi1>)
+    %mask = "test.mask_def_0"() : () -> (vector<128xi1>)
     %0 = vector.transfer_read %src[%index, %c0], %f0, %mask {in_bounds = [true], permutation_map = affine_map<(d0, d1) -> (d0)>} : memref<4096x4096xf32>, vector<128xf32>
     gpu.yield %0 : vector<128xf32>
   }
@@ -1800,7 +1800,7 @@ func.func @warp_propagate_nontrivial_map_masked_transfer_read(%laneid: index, %s
 //  CHECK-PROP-SAME:   %[[ARG0:.+]]: index, {{.*}}, %[[ARG2:.+]]: index
 //       CHECK-PROP:   %[[C0:.*]] = arith.constant 0 : index
 //       CHECK-PROP:   %[[R:.*]] = gpu.warp_execute_on_lane_0(%{{.*}})[64] -> (vector<2xi1>) {
-//       CHECK-PROP:     %[[M0:.*]] = "mask_def_0"
+//       CHECK-PROP:     %[[M0:.*]] = "test.mask_def_0"
 //       CHECK-PROP:     gpu.yield %[[M0]] : vector<128xi1>
 //       CHECK-PROP:   }
 //       CHECK-PROP:   %[[DIST_READ_IDX0:.+]] = affine.apply #[[$MAP0]]()[%[[ARG2]], %[[ARG0]]]
@@ -1920,7 +1920,7 @@ func.func @warp_propagate_multi_dim_constant_mask(%laneid: index) -> vector<1x2x
 func.func @warp_propagate_nd_write(%laneid: index, %dest: memref<4x1024xf32>) {
   %c0 = arith.constant 0 : index
   gpu.warp_execute_on_lane_0(%laneid)[32] -> () {
-    %0 = "some_def"() : () -> (vector<4x1024xf32>)
+    %0 = "test.some_def"() : () -> (vector<4x1024xf32>)
     vector.transfer_write %0, %dest[%c0, %c0] : vector<4x1024xf32>, memref<4x1024xf32>
     gpu.yield
   }
@@ -1931,7 +1931,7 @@ func.func @warp_propagate_nd_write(%laneid: index, %dest: memref<4x1024xf32>) {
 
 // CHECK-DIST-AND-PROP-LABEL: func.func @warp_propagate_nd_write(
 //       CHECK-DIST-AND-PROP:   %[[W:.*]] = gpu.warp_execute_on_lane_0(%{{.*}})[32] -> (vector<1x128xf32>) {
-//       CHECK-DIST-AND-PROP:     %[[V0:.*]] = "some_def"
+//       CHECK-DIST-AND-PROP:     %[[V0:.*]] = "test.some_def"
 //       CHECK-DIST-AND-PROP:     gpu.yield %[[V0]]
 //  CHECK-DIST-AND-PROP-SAME:       vector<4x1024xf32>
 //       CHECK-DIST-AND-PROP:   }
@@ -1943,23 +1943,23 @@ func.func @warp_propagate_nd_write(%laneid: index, %dest: memref<4x1024xf32>) {
 // -----
 func.func @warp_propagate_duplicated_operands_in_yield(%laneid: index)  {
   %r:3 = gpu.warp_execute_on_lane_0(%laneid)[32] -> (vector<1xf32>, vector<1xf32>, vector<1xf32>) {
-    %0 = "some_def"() : () -> (vector<32xf32>)
-    %1 = "some_other_def"() : () -> (vector<32xf32>)
+    %0 = "test.some_def"() : () -> (vector<32xf32>)
+    %1 = "test.some_other_def"() : () -> (vector<32xf32>)
     %2 = math.exp %1 : vector<32xf32>
     gpu.yield %2, %0, %0 : vector<32xf32>, vector<32xf32>, vector<32xf32>
   }
-  "some_use"(%r#0) : (vector<1xf32>) -> ()
+  "test.some_use"(%r#0) : (vector<1xf32>) -> ()
   return
 }
 
 // CHECK-PROP-LABEL : func.func @warp_propagate_duplicated_operands_in_yield(
 // CHECK-PROP       :   %[[W:.*]] = gpu.warp_execute_on_lane_0(%{{.*}})[32] -> (vector<1xf32>) {
-// CHECK-PROP       :     %{{.*}} = "some_def"() : () -> vector<32xf32>
-// CHECK-PROP       :     %[[T3:.*]] = "some_other_def"() : () -> vector<32xf32>
+// CHECK-PROP       :     %{{.*}} = "test.some_def"() : () -> vector<32xf32>
+// CHECK-PROP       :     %[[T3:.*]] = "test.some_other_def"() : () -> vector<32xf32>
 // CHECK-PROP       :     gpu.yield %[[T3]] : vector<32xf32>
 // CHECK-PROP       :   }
 // CHECK-PROP       :   %[T1:.*] = math.exp %[[W]] : vector<1xf32>
-// CHECK-PROP       :   "some_use"(%[[T1]]) : (vector<1xf32>) -> ()
+// CHECK-PROP       :   "test.some_use"(%[[T1]]) : (vector<1xf32>) -> ()
 
 // -----
 
@@ -2026,15 +2026,15 @@ func.func @warp_scf_if_distribute(%pred : i1)  {
     %seq1 = vector.step : vector<32xindex>
     %seq2 = arith.constant dense<2> : vector<32xindex>
     %0 = scf.if %pred -> (vector<32xf32>) {
-      %1 = "some_op"(%seq1) : (vector<32xindex>) -> (vector<32xf32>)
+      %1 = "test.some_op"(%seq1) : (vector<32xindex>) -> (vector<32xf32>)
       scf.yield %1 : vector<32xf32>
     } else {
-      %2 = "other_op"(%seq2) : (vector<32xindex>) -> (vector<32xf32>)
+      %2 = "test.other_op"(%seq2) : (vector<32xindex>) -> (vector<32xf32>)
       scf.yield %2 : vector<32xf32>
     }
     gpu.yield %0 : vector<32xf32>
   }
-  "some_use"(%0) : (vector<1xf32>) -> ()
+  "test.some_use"(%0) : (vector<1xf32>) -> ()
 
   return
 }
@@ -2047,18 +2047,18 @@ func.func @warp_scf_if_distribute(%pred : i1)  {
 //       CHECK-PROP:    %[[IF_YIELD_DIST:.+]] = scf.if %[[ARG0]] -> (vector<1xf32>) {
 //       CHECK-PROP:    %[[THEN_DIST:.+]] = gpu.warp_execute_on_lane_0(%[[LANE_ID]])[32] args(%[[SEQ1]] : vector<1xindex>) -> (vector<1xf32>) {
 //       CHECK-PROP:        ^bb0(%[[ARG1:.+]]: vector<32xindex>):
-//       CHECK-PROP:        %{{.*}} = "some_op"(%[[ARG1]]) : (vector<32xindex>) -> vector<32xf32>
+//       CHECK-PROP:        %{{.*}} = "test.some_op"(%[[ARG1]]) : (vector<32xindex>) -> vector<32xf32>
 //       CHECK-PROP:        gpu.yield %{{.*}} : vector<32xf32>
 //       CHECK-PROP:      }
 //       CHECK-PROP:      scf.yield %[[THEN_DIST]] : vector<1xf32>
 //       CHECK-PROP:    } else {
 //       CHECK-PROP:      %[[ELSE_DIST:.+]] = gpu.warp_execute_on_lane_0(%[[LANE_ID]])[32] -> (vector<1xf32>) {
-//       CHECK-PROP:        %{{.*}} = "other_op"(%[[SEQ2]]) : (vector<32xindex>) -> vector<32xf32>
+//       CHECK-PROP:        %{{.*}} = "test.other_op"(%[[SEQ2]]) : (vector<32xindex>) -> vector<32xf32>
 //       CHECK-PROP:        gpu.yield %{{.*}} : vector<32xf32>
 //       CHECK-PROP:      }
 //       CHECK-PROP:      scf.yield %[[ELSE_DIST]] : vector<1xf32>
 //       CHECK-PROP:    }
-//       CHECK-PROP:    "some_use"(%[[IF_YIELD_DIST]]) : (vector<1xf32>) -> ()
+//       CHECK-PROP:    "test.some_use"(%[[IF_YIELD_DIST]]) : (vector<1xf32>) -> ()
 //       CHECK-PROP:    return
 //       CHECK-PROP:  }
 
@@ -2066,17 +2066,17 @@ func.func @warp_scf_if_distribute(%pred : i1)  {
 func.func @dedup_unused_result(%laneid : index) -> (vector<1xf32>) {
   %r:3 = gpu.warp_execute_on_lane_0(%laneid)[32] ->
     (vector<1xf32>, vector<2xf32>, vector<1xf32>) {
-    %2 = "some_def"() : () -> (vector<32xf32>)
-    %3 = "some_def"() : () -> (vector<64xf32>)
+    %2 = "test.some_def"() : () -> (vector<32xf32>)
+    %3 = "test.some_def"() : () -> (vector<64xf32>)
     gpu.yield %2, %3, %2 : vector<32xf32>, vector<64xf32>, vector<32xf32>
   }
-  %r0 = "some_use"(%r#2, %r#2) : (vector<1xf32>, vector<1xf32>) -> (vector<1xf32>)
+  %r0 = "test.some_use"(%r#2, %r#2) : (vector<1xf32>, vector<1xf32>) -> (vector<1xf32>)
   return %r0 : vector<1xf32>
 }
 
 // CHECK-PROP: func @dedup_unused_result
 // CHECK-PROP: %[[R:.*]] = gpu.warp_execute_on_lane_0(%arg0)[32] -> (vector<1xf32>)
-// CHECK-PROP:   %[[Y0:.*]] = "some_def"() : () -> vector<32xf32>
-// CHECK-PROP:   %[[Y1:.*]] = "some_def"() : () -> vector<64xf32>
+// CHECK-PROP:   %[[Y0:.*]] = "test.some_def"() : () -> vector<32xf32>
+// CHECK-PROP:   %[[Y1:.*]] = "test.some_def"() : () -> vector<64xf32>
 // CHECK-PROP:   gpu.yield %[[Y0]] : vector<32xf32>
-// CHECK-PROP: "some_use"(%[[R]], %[[R]]) : (vector<1xf32>, vector<1xf32>) -> vector<1xf32>
+// CHECK-PROP: "test.some_use"(%[[R]], %[[R]]) : (vector<1xf32>, vector<1xf32>) -> vector<1xf32>

--- a/mlir/test/Dialect/XeGPU/sg-to-lane-distribute-unit.mlir
+++ b/mlir/test/Dialect/XeGPU/sg-to-lane-distribute-unit.mlir
@@ -1,5 +1,5 @@
 
-// RUN: mlir-opt  --xevm-attach-target='module=xevm_* chip=cri' --allow-unregistered-dialect \
+// RUN: mlir-opt  --xevm-attach-target='module=xevm_* chip=cri' \
 // RUN: --test-xegpu-sg-to-lane-distribute --split-input-file %s | FileCheck %s
 
 
@@ -30,7 +30,7 @@ gpu.func @cerate_nd_tedesc_nonmemref_source(%arg0: ui64) {
 // CHECK: %[[CAST:.*]] = vector.shape_cast %[[LOAD]] : vector<16xf16> to vector<16x1xf16>
 gpu.func @load_nd() {
   %c0 = arith.constant 0 : index
-  %0 = "some_op"() : () -> !xegpu.tensor_desc<16x16xf16>
+  %0 = "test.some_op"() : () -> !xegpu.tensor_desc<16x16xf16>
   %1 = xegpu.load_nd %0[%c0, %c0] <{layout = #xegpu.layout<lane_layout = [1, 16], lane_data = [1, 1]>}>
     : !xegpu.tensor_desc<16x16xf16> -> vector<16x16xf16>
   gpu.return
@@ -42,7 +42,7 @@ gpu.func @load_nd() {
 // CHECK: %[[CAST:.*]] = vector.shape_cast %[[LOAD]] : vector<16xf16> to vector<16x1xf16>
 gpu.func @load_nd_packed() {
   %c0 = arith.constant 0 : index
-  %0 = "some_op"() : () -> !xegpu.tensor_desc<16x16xf16>
+  %0 = "test.some_op"() : () -> !xegpu.tensor_desc<16x16xf16>
   %1 = xegpu.load_nd %0[%c0, %c0] <{layout = #xegpu.layout<lane_layout = [1, 16], lane_data = [2, 1]>}>
     : !xegpu.tensor_desc<16x16xf16> -> vector<16x16xf16>
   gpu.return
@@ -54,7 +54,7 @@ gpu.func @load_nd_packed() {
 // CHECK: %[[CAST:.*]] = vector.shape_cast %[[LOAD]] : vector<8xf32> to vector<1x8xf32>
 gpu.func @load_nd_transpose() {
   %c0 = arith.constant 0 : index
-  %0 = "some_op"() : () -> !xegpu.tensor_desc<16x8xf32>
+  %0 = "test.some_op"() : () -> !xegpu.tensor_desc<16x8xf32>
   %1 = xegpu.load_nd %0[%c0, %c0] <{layout = #xegpu.layout<lane_layout = [16, 1], lane_data = [1, 1]>}>
     : !xegpu.tensor_desc<16x8xf32> -> vector<16x8xf32>
   gpu.return
@@ -67,7 +67,7 @@ gpu.func @load_nd_transpose() {
 // CHECK: %[[CAST:.*]] = vector.shape_cast %[[LOAD]] : vector<16xf16> to vector<1x1x16x1xf16>
 gpu.func @load_nd_packed_4d() {
   %c0 = arith.constant 0 : index
-  %0 = "some_op"() : () -> !xegpu.tensor_desc<1x1x16x16xf16>
+  %0 = "test.some_op"() : () -> !xegpu.tensor_desc<1x1x16x16xf16>
   %1 = xegpu.load_nd %0[%c0, %c0, %c0, %c0] <{layout = #xegpu.layout<lane_layout = [1, 1, 1, 16], lane_data = [1, 1, 2, 1]>}>
     : !xegpu.tensor_desc<1x1x16x16xf16> -> vector<1x1x16x16xf16>
   gpu.return
@@ -80,7 +80,7 @@ gpu.func @load_nd_packed_4d() {
 // CHECK: %[[CAST:.*]] = vector.shape_cast %[[LOAD]] : vector<8xf32> to vector<1x1x1x8xf32>
 gpu.func @load_nd_transpose_4d() {
   %c0 = arith.constant 0 : index
-  %0 = "some_op"() : () -> !xegpu.tensor_desc<1x1x16x8xf32>
+  %0 = "test.some_op"() : () -> !xegpu.tensor_desc<1x1x16x8xf32>
   %1 = xegpu.load_nd %0[%c0, %c0, %c0, %c0] <{layout = #xegpu.layout<lane_layout = [1, 1, 16, 1], lane_data = [1, 1, 1, 1]>}>
     : !xegpu.tensor_desc<1x1x16x8xf32> -> vector<1x1x16x8xf32>
   gpu.return
@@ -92,7 +92,7 @@ gpu.func @load_nd_transpose_4d() {
 // CHECK: %[[CAST:.*]] = vector.shape_cast %[[LOAD]] : vector<64xf16> to vector<64x1xf16>
 gpu.func @load_nd_array_length() {
   %c0 = arith.constant 0 : index
-  %0 = "some_op"() : () -> !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<array_length = 2>>
+  %0 = "test.some_op"() : () -> !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<array_length = 2>>
   %1 = xegpu.load_nd %0[%c0, %c0] <{layout = #xegpu.layout<lane_layout = [1, 16], lane_data = [1, 1]>}>
     : !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<array_length = 2>> -> vector<64x16xf16>
   gpu.return
@@ -106,8 +106,8 @@ gpu.func @load_nd_array_length() {
 // CHECK: xegpu.store_nd %[[CAST3]], %{{.*}}[%[[C0]], %[[C0]]] : vector<16xf16>, !xegpu.tensor_desc<16x16xf16>
 gpu.func @store_nd() {
   %c0 = arith.constant 0 : index
-  %0 = "some_op"() : () -> !xegpu.tensor_desc<16x16xf16>
-  %1 = "some_op"() : () -> !xegpu.tensor_desc<16x16xf16>
+  %0 = "test.some_op"() : () -> !xegpu.tensor_desc<16x16xf16>
+  %1 = "test.some_op"() : () -> !xegpu.tensor_desc<16x16xf16>
   %2 = xegpu.load_nd %0[%c0, %c0] <{layout = #xegpu.layout<lane_layout = [1, 16], lane_data = [1, 1]>}>
     : !xegpu.tensor_desc<16x16xf16> -> vector<16x16xf16>
   xegpu.store_nd %2, %1[%c0, %c0] <{layout = #xegpu.layout<lane_layout = [1, 16], lane_data = [1, 1]>}>
@@ -130,8 +130,8 @@ gpu.func @store_nd() {
 // CHECK: gpu.return
 gpu.func @dpas() {
   %c0 = arith.constant 0 : index
-  %0 = "some_op"() : () -> !xegpu.tensor_desc<8x16xf16>
-  %1 = "some_op"() : () -> !xegpu.tensor_desc<16x16xf16>
+  %0 = "test.some_op"() : () -> !xegpu.tensor_desc<8x16xf16>
+  %1 = "test.some_op"() : () -> !xegpu.tensor_desc<16x16xf16>
   %5 = arith.constant dense<0.0> : vector<8x16xf32>
   %2 = xegpu.load_nd %0[%c0, %c0] <{layout = #xegpu.layout<lane_layout = [1, 16], lane_data = [1, 1]>}>
     : !xegpu.tensor_desc<8x16xf16> -> vector<8x16xf16>
@@ -156,7 +156,7 @@ gpu.func @dpas() {
 gpu.func @elementwise() {
   %c0 = arith.constant 0 : index
   %0 = arith.constant dense<1.0> : vector<16x16xf32>
-  %1 = "some_op"() : () -> !xegpu.tensor_desc<16x16xf32>
+  %1 = "test.some_op"() : () -> !xegpu.tensor_desc<16x16xf32>
   %2 = xegpu.load_nd %1[%c0, %c0] <{layout = #xegpu.layout<lane_layout = [1, 16], lane_data = [1, 1]>}>
     : !xegpu.tensor_desc<16x16xf32> -> vector<16x16xf32>
   %3 = arith.addf %0, %2
@@ -268,7 +268,7 @@ gpu.func @arith_constant_non_splat_2d_vertical_lanedata() {
 // CHECK: gpu.return
 gpu.func @prefetch_nd() {
   %c0 = arith.constant 0 : index
-  %0 = "some_op"() : () -> !xegpu.tensor_desc<16x16xf16>
+  %0 = "test.some_op"() : () -> !xegpu.tensor_desc<16x16xf16>
   xegpu.prefetch_nd %0[%c0, %c0] <{layout = #xegpu.layout<lane_layout = [1, 16], lane_data = [1, 1]>}>
     : !xegpu.tensor_desc<16x16xf16>
   gpu.return
@@ -390,7 +390,7 @@ gpu.func @scatter_ops_with_leading_dims(%src: memref<256xf16>) {
 // CHECK:     %[[FINAL:.*]] = arith.addf %[[ADD4]], %[[CST]] : f32
 gpu.func @vector_reduction() {
   %acc = arith.constant 1.0 : f32
-  %0 = "some_op"() : () -> vector<32xf32>
+  %0 = "test.some_op"() : () -> vector<32xf32>
   %2 = vector.reduction <add>, %0, %acc : vector<32xf32> into f32
   %anchor = xegpu.convert_layout %2
     <{
@@ -568,12 +568,12 @@ gpu.func @vector_multi_reduction_dim0_distributed_dim1_reduction(%laneid: index)
 }
 
 // CHECK-LABEL: gpu.func @vector_transpose
-// CHECK:         %[[SRC:.*]] = "some_op"()
+// CHECK:         %[[SRC:.*]] = "test.some_op"()
 // CHECK:         %[[CAST:.*]] = builtin.unrealized_conversion_cast %[[SRC]] : vector<16x2xf32> to vector<1x2xf32>
 // CHECK-NEXT:    %[[T:.*]] = vector.transpose %[[CAST]], [1, 0] : vector<1x2xf32> to vector<2x1xf32>
 // CHECK-NEXT:    gpu.return
 gpu.func @vector_transpose() {
-  %cst = "some_op"()
+  %cst = "test.some_op"()
     : () -> (vector<16x2xf32>)
   %transpose = vector.transpose %cst, [1, 0]
     : vector<16x2xf32> to vector<2x16xf32>
@@ -585,12 +585,12 @@ gpu.func @vector_transpose() {
 }
 
 // CHECK-LABEL: gpu.func @vector_bitcast
-// CHECK:         %[[SRC:.*]] = "some_op"()
+// CHECK:         %[[SRC:.*]] = "test.some_op"()
 // CHECK:         %[[CAST:.*]] = builtin.unrealized_conversion_cast %[[SRC]] : vector<4x32xi8> to vector<4x2xi8>
 // CHECK-NEXT:    %[[BC:.*]] = vector.bitcast %[[CAST]] : vector<4x2xi8> to vector<4x1xi16>
 // CHECK-NEXT:    gpu.return
 gpu.func @vector_bitcast() {
-  %cst = "some_op"() : () -> (vector<4x32xi8>)
+  %cst = "test.some_op"() : () -> (vector<4x32xi8>)
   %bitcast = vector.bitcast %cst : vector<4x32xi8> to vector<4x16xi16>
   %anchor = xegpu.convert_layout %bitcast
     <{
@@ -743,7 +743,7 @@ gpu.func @vector_multi_reduction_3d_leading_unit_dim_cross_lane() {
 // CHECK-LABEL: gpu.func @vector_extract_from_2d
 // CHECK: %[[EXT:.*]] = vector.extract %{{.*}}[0] : vector<1xf32> from vector<4x1xf32>
 gpu.func @vector_extract_from_2d() {
-  %src = "some_op"() : () -> vector<4x16xf32>
+  %src = "test.some_op"() : () -> vector<4x16xf32>
   %0 = vector.extract %src[0]
     : vector<16xf32> from vector<4x16xf32>
   %cl0 = xegpu.convert_layout %0
@@ -756,7 +756,7 @@ gpu.func @vector_extract_from_2d() {
 // CHECK-LABEL: gpu.func @vector_extract_from_2d_offset2
 // CHECK: %[[EXT:.*]] = vector.extract %{{.*}}[2] : vector<1xf32> from vector<8x1xf32>
 gpu.func @vector_extract_from_2d_offset2() {
-  %src = "some_op"()
+  %src = "test.some_op"()
     : () -> vector<8x16xf32>
   %0 = vector.extract %src[2]
     : vector<16xf32> from vector<8x16xf32>
@@ -770,9 +770,9 @@ gpu.func @vector_extract_from_2d_offset2() {
 // CHECK-LABEL: gpu.func @vector_insert_into_2d
 // CHECK: %[[INS:.*]] = vector.insert %{{.*}}, %{{.*}}[0] : vector<1xf32> into vector<4x1xf32>
 gpu.func @vector_insert_into_2d() {
-  %val = "some_op"()
+  %val = "test.some_op"()
     : () -> vector<16xf32>
-  %dst = "some_op"()
+  %dst = "test.some_op"()
     : () -> vector<4x16xf32>
   %0 = vector.insert %val, %dst[0]
     : vector<16xf32> into vector<4x16xf32>
@@ -786,9 +786,9 @@ gpu.func @vector_insert_into_2d() {
 // CHECK-LABEL: gpu.func @vector_insert_into_2d_offset2
 // CHECK: %[[INS:.*]] = vector.insert %{{.*}}, %{{.*}}[2] : vector<1xf32> into vector<8x1xf32>
 gpu.func @vector_insert_into_2d_offset2() {
-  %val = "some_op"()
+  %val = "test.some_op"()
     : () -> vector<16xf32>
-  %dst = "some_op"()
+  %dst = "test.some_op"()
     : () -> vector<8x16xf32>
   %0 = vector.insert %val, %dst[2]
     : vector<16xf32> into vector<8x16xf32>
@@ -802,7 +802,7 @@ gpu.func @vector_insert_into_2d_offset2() {
 // CHECK-LABEL: gpu.func @vector_extract_strided_slice_distributed_dim_fully_extracted
 // CHECK: %[[ESS:.*]] = vector.extract_strided_slice %{{.*}} offsets = [8, 0], sizes = [8, 1], strides = [1, 1] : vector<24x1xf32> to vector<8x1xf32>
 gpu.func @vector_extract_strided_slice_distributed_dim_fully_extracted() {
-  %0 = "some_op"()
+  %0 = "test.some_op"()
     : () -> vector<24x16xf32>
   %1 = vector.extract_strided_slice %0 offsets = [8, 0], sizes = [8, 16], strides = [1, 1]
     : vector<24x16xf32> to vector<8x16xf32>
@@ -816,7 +816,7 @@ gpu.func @vector_extract_strided_slice_distributed_dim_fully_extracted() {
 // CHECK-LABEL: gpu.func @vector_extract_strided_slice_inner_distributed
 // CHECK: %[[ESS:.*]] = vector.extract_strided_slice %{{.*}} offsets = [8, 3], sizes = [8, 1], strides = [1, 1] : vector<24x4xf32> to vector<8x1xf32>
 gpu.func @vector_extract_strided_slice_inner_distributed() {
-  %0 = "some_op"()
+  %0 = "test.some_op"()
     : () -> vector<24x64xf32>
   %1 = vector.extract_strided_slice %0 offsets = [8, 48], sizes = [8, 16], strides = [1, 1]
     : vector<24x64xf32> to vector<8x16xf32>
@@ -830,7 +830,7 @@ gpu.func @vector_extract_strided_slice_inner_distributed() {
 // CHECK-LABEL: gpu.func @vector_extract_strided_slice_outer_distributed
 // CHECK: %[[ESS:.*]] = vector.extract_strided_slice %{{.*}} offsets = [1, 0], sizes = [1, 16], strides = [1, 1] : vector<2x16xf32> to vector<1x16xf32>
 gpu.func @vector_extract_strided_slice_outer_distributed() {
-  %0 = "some_op"()
+  %0 = "test.some_op"()
     : () -> vector<32x16xf32>
   %1 = vector.extract_strided_slice %0 offsets = [16], sizes = [16], strides = [1]
     : vector<32x16xf32> to vector<16x16xf32>
@@ -844,7 +844,7 @@ gpu.func @vector_extract_strided_slice_outer_distributed() {
 // CHECK-LABEL: gpu.func @vector_extract_strided_slice_1d
 // CHECK: %[[ESS:.*]] = vector.extract_strided_slice %{{.*}} offsets = [1], sizes = [2], strides = [1] : vector<4xf32> to vector<2xf32>
 gpu.func @vector_extract_strided_slice_1d() {
-  %0 = "some_op"()
+  %0 = "test.some_op"()
     : () -> vector<64xf32>
   %1 = vector.extract_strided_slice %0 offsets = [16], sizes = [32], strides = [1]
     : vector<64xf32> to vector<32xf32>
@@ -858,7 +858,7 @@ gpu.func @vector_extract_strided_slice_1d() {
 // CHECK-LABEL: gpu.func @vector_extract_strided_slice_partial_offsets
 // CHECK: %[[ESS:.*]] = vector.extract_strided_slice %{{.*}} offsets = [8, 0], sizes = [8, 1], strides = [1, 1] : vector<24x1xf32> to vector<8x1xf32>
 gpu.func @vector_extract_strided_slice_partial_offsets() {
-  %0 = "some_op"()
+  %0 = "test.some_op"()
     : () -> vector<24x16xf32>
   %1 = vector.extract_strided_slice %0 offsets = [8], sizes = [8], strides = [1]
     : vector<24x16xf32> to vector<8x16xf32>
@@ -883,7 +883,7 @@ gpu.func @vector_extract_strided_slice_partial_offsets() {
 // CHECK:         vector.extract_strided_slice %[[SRC]] offsets = [16, 0], sizes = [8, 1], strides = [1, 1] : vector<32x1xi8> to vector<8x1xi8>
 // CHECK:         vector.extract_strided_slice %[[SRC]] offsets = [24, 0], sizes = [8, 1], strides = [1, 1] : vector<32x1xi8> to vector<8x1xi8>
 gpu.func @convert_layout_repack_lane_data() {
-  %src = "some_op"() : () -> vector<32x16xi8>
+  %src = "test.some_op"() : () -> vector<32x16xi8>
   %cvt = xegpu.convert_layout %src
     <{
       input_layout = #xegpu.layout<lane_layout = [1, 16], lane_data = [4, 1]>,
@@ -923,9 +923,9 @@ gpu.func @convert_layout_repack_lane_data() {
 // CHECK-LABEL: gpu.func @vector_insert_strided_slice_distributed_dim_fully_inserted
 // CHECK: %[[ISS:.*]] = vector.insert_strided_slice %{{.*}}, %{{.*}} offsets = [24, 0], strides = [1, 1] : vector<16x1xf32> into vector<64x1xf32>
 gpu.func @vector_insert_strided_slice_distributed_dim_fully_inserted() {
-  %0 = "some_op"()
+  %0 = "test.some_op"()
     : () -> vector<16x16xf32>
-  %1 = "some_op"()
+  %1 = "test.some_op"()
     : () -> vector<64x16xf32>
   %2 = vector.insert_strided_slice %0, %1 offsets = [24, 0], strides = [1, 1]
     : vector<16x16xf32> into vector<64x16xf32>
@@ -939,9 +939,9 @@ gpu.func @vector_insert_strided_slice_distributed_dim_fully_inserted() {
 // CHECK-LABEL: gpu.func @vector_insert_strided_slice_inner_distributed
 // CHECK: %[[ISS:.*]] = vector.insert_strided_slice %{{.*}}, %{{.*}} offsets = [24, 1], strides = [1, 1] : vector<16x1xf32> into vector<64x2xf32>
 gpu.func @vector_insert_strided_slice_inner_distributed() {
-  %0 = "some_op"()
+  %0 = "test.some_op"()
     : () -> vector<16x16xf32>
-  %1 = "some_op"()
+  %1 = "test.some_op"()
     : () -> vector<64x32xf32>
   %2 = vector.insert_strided_slice %0, %1 offsets = [24, 16], strides = [1, 1]
     : vector<16x16xf32> into vector<64x32xf32>
@@ -955,9 +955,9 @@ gpu.func @vector_insert_strided_slice_inner_distributed() {
 // CHECK-LABEL: gpu.func @vector_insert_strided_slice_outer_distributed
 // CHECK: %[[ISS:.*]] = vector.insert_strided_slice %{{.*}}, %{{.*}} offsets = [2, 4], strides = [1, 1] : vector<1x16xf32> into vector<3x32xf32>
 gpu.func @vector_insert_strided_slice_outer_distributed() {
-  %0 = "some_op"()
+  %0 = "test.some_op"()
     : () -> vector<16x16xf32>
-  %1 = "some_op"()
+  %1 = "test.some_op"()
     : () -> vector<48x32xf32>
   %2 = vector.insert_strided_slice %0, %1 offsets = [32, 4], strides = [1, 1]
     : vector<16x16xf32> into vector<48x32xf32>
@@ -971,9 +971,9 @@ gpu.func @vector_insert_strided_slice_outer_distributed() {
 // CHECK-LABEL: gpu.func @vector_insert_strided_slice_1d
 // CHECK: %[[ISS:.*]] = vector.insert_strided_slice %{{.*}}, %{{.*}} offsets = [1], strides = [1] : vector<1xf32> into vector<3xf32>
 gpu.func @vector_insert_strided_slice_1d() {
-  %0 = "some_op"()
+  %0 = "test.some_op"()
     : () -> vector<16xf32>
-  %1 = "some_op"()
+  %1 = "test.some_op"()
     : () -> vector<48xf32>
   %2 = vector.insert_strided_slice %0, %1 offsets = [16], strides = [1]
     : vector<16xf32> into vector<48xf32>
@@ -987,9 +987,9 @@ gpu.func @vector_insert_strided_slice_1d() {
 // CHECK-LABEL: gpu.func @vector_insert_strided_slice_different_ranks
 // CHECK: %[[ISS:.*]] = vector.insert_strided_slice %{{.*}}, %{{.*}} offsets = [13, 0], strides = [1] : vector<1xf32> into vector<64x1xf32>
 gpu.func @vector_insert_strided_slice_different_ranks() {
-  %0 = "some_op"()
+  %0 = "test.some_op"()
     : () -> vector<16xf32>
-  %1 = "some_op"()
+  %1 = "test.some_op"()
     : () -> vector<64x16xf32>
   %2 = vector.insert_strided_slice %0, %1 offsets = [13, 0], strides = [1]
     : vector<16xf32> into vector<64x16xf32>
@@ -1006,9 +1006,9 @@ gpu.func @vector_insert_strided_slice_different_ranks() {
 // CHECK-LABEL: gpu.func @vector_insert_strided_slice_lane_broadcast_dim
 // CHECK: %[[ISS:.*]] = vector.insert_strided_slice %{{.*}}, %{{.*}} offsets = [0, 0], strides = [1, 1] : vector<1x1xf32> into vector<8x1xf32>
 gpu.func @vector_insert_strided_slice_lane_broadcast_dim() {
-  %0 = "some_op"()
+  %0 = "test.some_op"()
     : () -> vector<1x1xf32>
-  %1 = "some_op"()
+  %1 = "test.some_op"()
     : () -> vector<8x1xf32>
   %2 = vector.insert_strided_slice %0, %1 offsets = [0, 0], strides = [1, 1]
     : vector<1x1xf32> into vector<8x1xf32>
@@ -1023,9 +1023,9 @@ gpu.func @vector_insert_strided_slice_lane_broadcast_dim() {
 // CHECK-LABEL: gpu.func @convert_layout_removed_when_compatible
 // CHECK-NOT: xegpu.convert_layout
 gpu.func @convert_layout_removed_when_compatible() {
-  %0 = "some_op"()
+  %0 = "test.some_op"()
     : () -> vector<16xf32>
-  %2 = "some_op"()
+  %2 = "test.some_op"()
     : () -> vector<1xf32>
   %1 = xegpu.convert_layout %0
     <{input_layout = #xegpu.layout<lane_layout = [16], lane_data = [1]>,
@@ -1048,11 +1048,11 @@ gpu.module @xevm_module {
 // CHECK-LABEL: gpu.func @convert_layout_scalar
 // CHECK-NOT: xegpu.convert_layout
 gpu.func @convert_layout_scalar() {
-  %0 = "some_op"() : () -> f32
+  %0 = "test.some_op"() : () -> f32
   %1 = xegpu.convert_layout %0
     <{target_layout = #xegpu.slice<#xegpu.layout<lane_layout = [16], lane_data = [1]>, dims = [0]>}>
     : f32
-  "some_use"(%1) : (f32) -> ()
+  "test.some_use"(%1) : (f32) -> ()
   gpu.return
 }
 }
@@ -1066,13 +1066,13 @@ gpu.module @xevm_module {
 // CHECK:         %[[S0:.*]] = xegpu.lane_shuffle %[[F]] pack : vector<4xbf16>
 // CHECK:         vector.shape_cast %[[S0]] : vector<4xbf16> to vector<1x4xbf16>
 gpu.func @convert_layout_repack_innermost_lane_data() {
-  %src = "some_op"() : () -> vector<1x64xbf16>
+  %src = "test.some_op"() : () -> vector<1x64xbf16>
   %cvt = xegpu.convert_layout %src
     <{
       input_layout = #xegpu.layout<lane_layout = [1, 16], lane_data = [1, 1]>,
       target_layout = #xegpu.layout<lane_layout = [1, 16], lane_data = [1, 4]>
     }> : vector<1x64xbf16>
-  "some_use"(%cvt) : (vector<1x64xbf16>) -> ()
+  "test.some_use"(%cvt) : (vector<1x64xbf16>) -> ()
   gpu.return
 }
 }
@@ -1084,13 +1084,13 @@ gpu.module @xevm_module {
 // CHECK:         %[[SRC:.*]] = builtin.unrealized_conversion_cast %{{.*}} : vector<64xbf16> to vector<4xbf16>
 // CHECK:         xegpu.lane_shuffle %[[SRC]] pack : vector<4xbf16>
 gpu.func @convert_layout_repack_innermost_lane_data_1d() {
-  %src = "some_op"() : () -> vector<64xbf16>
+  %src = "test.some_op"() : () -> vector<64xbf16>
   %cvt = xegpu.convert_layout %src
     <{
       input_layout = #xegpu.layout<lane_layout = [16], lane_data = [1]>,
       target_layout = #xegpu.layout<lane_layout = [16], lane_data = [4]>
     }> : vector<64xbf16>
-  "some_use"(%cvt) : (vector<64xbf16>) -> ()
+  "test.some_use"(%cvt) : (vector<64xbf16>) -> ()
   gpu.return
 }
 }
@@ -1107,13 +1107,13 @@ gpu.module @xevm_module {
 // CHECK:         vector.insert_strided_slice %[[C0]], %{{.*}} offsets = [0, 0], strides = [1, 1] : vector<4x1xbf16> into vector<4x4xbf16>
 // CHECK-COUNT-3: xegpu.lane_shuffle %{{.*}} unpack : vector<4xbf16>
 gpu.func @convert_layout_repack_second_innermost_lane_data() {
-  %src = "some_op"() : () -> vector<64x4xbf16>
+  %src = "test.some_op"() : () -> vector<64x4xbf16>
   %cvt = xegpu.convert_layout %src
     <{
       input_layout = #xegpu.layout<lane_layout = [16, 1], lane_data = [4, 1]>,
       target_layout = #xegpu.layout<lane_layout = [16, 1], lane_data = [1, 1]>
     }> : vector<64x4xbf16>
-  "some_use"(%cvt) : (vector<64x4xbf16>) -> ()
+  "test.some_use"(%cvt) : (vector<64x4xbf16>) -> ()
   gpu.return
 }
 }
@@ -1127,13 +1127,13 @@ gpu.module @xevm_module {
 // CHECK:         %[[S0:.*]] = xegpu.lane_shuffle %[[F]] pack : vector<4xbf16>
 // CHECK:         vector.shape_cast %[[S0]] : vector<4xbf16> to vector<1x1x4xbf16>
 gpu.func @convert_layout_repack_innermost_lane_data_3d() {
-  %src = "some_op"() : () -> vector<1x1x64xbf16>
+  %src = "test.some_op"() : () -> vector<1x1x64xbf16>
   %cvt = xegpu.convert_layout %src
     <{
       input_layout = #xegpu.layout<lane_layout = [1, 1, 16], lane_data = [1, 1, 1]>,
       target_layout = #xegpu.layout<lane_layout = [1, 1, 16], lane_data = [1, 1, 4]>
     }> : vector<1x1x64xbf16>
-  "some_use"(%cvt) : (vector<1x1x64xbf16>) -> ()
+  "test.some_use"(%cvt) : (vector<1x1x64xbf16>) -> ()
   gpu.return
 }
 }
@@ -1205,11 +1205,11 @@ gpu.func @load_store_matrix_3(%arg0: !xegpu.mem_desc<32x32xf32, #xegpu.mem_layou
 // -----
 gpu.module @xevm_module {
 // CHECK-LABEL: gpu.func @elementwise_wrap_around_dim
-// CHECK: %[[SRC:.*]] = "some_op"()
+// CHECK: %[[SRC:.*]] = "test.some_op"()
 // CHECK: %[[NEG:.*]] = arith.negf %[[SRC]] : vector<16x1xf16>
 // CHECK: gpu.return
 gpu.func @elementwise_wrap_around_dim() {
-  %0 = "some_op"()
+  %0 = "test.some_op"()
     : () -> vector<16x1xf16>
   %1 = arith.negf %0
     : vector<16x1xf16>
@@ -1279,7 +1279,7 @@ gpu.module @xevm_module {
 // CHECK-LABEL: gpu.func @vector_shapecast_rank_increasing
 // CHECK:         %[[SC:.*]] = vector.shape_cast %{{.*}} : vector<1xf32> to vector<1x1xf32>
 gpu.func @vector_shapecast_rank_increasing() {
-  %cst = "some_op"()
+  %cst = "test.some_op"()
     : () -> (vector<16xf32>)
   %cast = vector.shape_cast %cst
     : vector<16xf32> to vector<1x16xf32>
@@ -1296,7 +1296,7 @@ gpu.module @xevm_module {
 // CHECK-LABEL: gpu.func @vector_shapecast_rank_reducing
 // CHECK:         %[[SC:.*]] = vector.shape_cast %{{.*}} : vector<1x1xf32> to vector<1xf32>
 gpu.func @vector_shapecast_rank_reducing() {
-  %cst = "some_op"()
+  %cst = "test.some_op"()
     : () -> (vector<1x16xf32>)
   %cast = vector.shape_cast %cst
     : vector<1x16xf32> to vector<16xf32>
@@ -1313,7 +1313,7 @@ gpu.module @xevm_module {
 // CHECK-LABEL: gpu.func @vector_shapecast_rank_increasing_without_slicing_layout
 // CHECK:         %[[SC:.*]] = vector.shape_cast %{{.*}} : vector<1xf32> to vector<1x1xf32>
 gpu.func @vector_shapecast_rank_increasing_without_slicing_layout() {
-  %cst = "some_op"()
+  %cst = "test.some_op"()
     : () -> (vector<16xf32>)
   %cast = vector.shape_cast %cst
     : vector<16xf32> to vector<1x16xf32>
@@ -1328,11 +1328,11 @@ gpu.func @vector_shapecast_rank_increasing_without_slicing_layout() {
 // -----
 gpu.module @xevm_module {
 // CHECK-LABEL: gpu.func @vector_broadcast_1d_to_2d
-// CHECK: %[[SRC:.*]] = "some_op"()
+// CHECK: %[[SRC:.*]] = "test.some_op"()
 // CHECK: %[[CAST:.*]] = builtin.unrealized_conversion_cast %[[SRC]] : vector<16xf16> to vector<1xf16>
 // CHECK: %[[BCAST:.*]] = vector.broadcast %[[CAST]] : vector<1xf16> to vector<16x1xf16>
 gpu.func @vector_broadcast_1d_to_2d(%laneid: index) {
-  %0 = "some_op"() : () -> vector<16xf16>
+  %0 = "test.some_op"() : () -> vector<16xf16>
   %1 = vector.broadcast %0 : vector<16xf16> to vector<16x16xf16>
   %anchor = xegpu.convert_layout %1
     <{
@@ -1360,17 +1360,17 @@ gpu.func @constant_wrap_around_dim() {
 // -----
 gpu.module @xevm_module {
 // CHECK-LABEL: gpu.func @vector_broadcast_2d_to_3d
-// CHECK: %[[SRC:.*]] = "some_op"()
+// CHECK: %[[SRC:.*]] = "test.some_op"()
 // CHECK: %[[CAST:.*]] = builtin.unrealized_conversion_cast %[[SRC]] : vector<16x16xf16> to vector<16x1xf16>
 // CHECK: %[[BCAST:.*]] = vector.broadcast %[[CAST]] : vector<16x1xf16> to vector<1x16x1xf16>
 gpu.func @vector_broadcast_2d_to_3d(%laneid: index) {
-  %0 = "some_op"() : () -> vector<16x16xf16>
+  %0 = "test.some_op"() : () -> vector<16x16xf16>
   %1 = vector.broadcast %0 : vector<16x16xf16> to vector<1x16x16xf16>
   %2 = xegpu.convert_layout %1
     <{
       target_layout = #xegpu.layout<lane_layout = [1, 1, 16], lane_data = [1, 1, 1]>
     }> : vector<1x16x16xf16>
-  "some_use"(%2) : (vector<1x16x16xf16>) -> ()
+  "test.some_use"(%2) : (vector<1x16x16xf16>) -> ()
   gpu.return
 }
 }
@@ -1378,13 +1378,13 @@ gpu.func @vector_broadcast_2d_to_3d(%laneid: index) {
 // -----
 gpu.module @xevm_module {
 // CHECK-LABEL: gpu.func @vector_broadcast_2d_to_2d_noop
-// CHECK: %[[SRC:.*]] = "some_op"()
+// CHECK: %[[SRC:.*]] = "test.some_op"()
 // CHECK-NOT: vector.broadcast
 gpu.func @vector_broadcast_2d_to_2d_noop(%laneid: index) {
-  %0 = "some_op"() : () -> vector<16x1xf16>
+  %0 = "test.some_op"() : () -> vector<16x1xf16>
   %1 = vector.broadcast %0 : vector<16x1xf16> to vector<16x16xf16>
   %2 = xegpu.convert_layout %1 <{target_layout = #xegpu.layout<lane_layout = [1, 16], lane_data = [1, 1]>}> : vector<16x16xf16>
-  "some_use"(%2) : (vector<16x16xf16>) -> ()
+  "test.some_use"(%2) : (vector<16x16xf16>) -> ()
   gpu.return
 }
 }
@@ -1393,13 +1393,13 @@ gpu.func @vector_broadcast_2d_to_2d_noop(%laneid: index) {
 // Scalar to vector broadcast (with layout)
 gpu.module @xevm_module {
 // CHECK-LABEL: gpu.func @vector_broadcast_scalar_to_vector
-// CHECK: %[[SRC:.*]] = "some_op"()
+// CHECK: %[[SRC:.*]] = "test.some_op"()
 // CHECK: %[[BCAST:.*]] = vector.broadcast %[[SRC]] : f16 to vector<16x1xf16>
 gpu.func @vector_broadcast_scalar_to_vector(%laneid: index) {
-  %0 = "some_op"() : () -> f16
+  %0 = "test.some_op"() : () -> f16
   %1 = vector.broadcast %0 : f16 to vector<16x16xf16>
   %2 = xegpu.convert_layout %1 <{target_layout = #xegpu.layout<lane_layout = [1, 16], lane_data = [1, 1]>}> : vector<16x16xf16>
-  "some_use"(%2) : (vector<16x16xf16>) -> ()
+  "test.some_use"(%2) : (vector<16x16xf16>) -> ()
   gpu.return
 }
 }
@@ -1408,13 +1408,13 @@ gpu.func @vector_broadcast_scalar_to_vector(%laneid: index) {
 // Scalar to vector broadcast (no layout - uniform, should remain unchanged)
 gpu.module @xevm_module {
 // CHECK-LABEL: gpu.func @vector_broadcast_scalar_to_vector_uniform
-// CHECK: %[[SRC:.*]] = "some_op"()
+// CHECK: %[[SRC:.*]] = "test.some_op"()
 // CHECK: %[[BCAST:.*]] = vector.broadcast %[[SRC]] : f16 to vector<16x16xf16>
-// CHECK: "some_use"(%[[BCAST]])
+// CHECK: "test.some_use"(%[[BCAST]])
 gpu.func @vector_broadcast_scalar_to_vector_uniform(%laneid: index) {
-  %0 = "some_op"() : () -> f16
+  %0 = "test.some_op"() : () -> f16
   %1 = vector.broadcast %0 : f16 to vector<16x16xf16>
-  "some_use"(%1) : (vector<16x16xf16>) -> ()
+  "test.some_use"(%1) : (vector<16x16xf16>) -> ()
   gpu.return
 }
 }
@@ -1422,7 +1422,7 @@ gpu.func @vector_broadcast_scalar_to_vector_uniform(%laneid: index) {
 // -----
 gpu.module @xevm_module {
 // CHECK-LABEL: gpu.func @vector_multi_reduction_1d_to_scalar
-// CHECK:     %[[SRC:.*]] = "some_op"() {{.*}} : () -> vector<32xf32>
+// CHECK:     %[[SRC:.*]] = "test.some_op"() {{.*}} : () -> vector<32xf32>
 // CHECK:     %[[DIST:.*]] = builtin.unrealized_conversion_cast %[[SRC]] : vector<32xf32> to vector<2xf32>
 // CHECK:     %[[ACC:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK:     %[[LANE_RED:.*]] = vector.reduction <add>, %[[DIST]] : vector<2xf32> into f32
@@ -1438,7 +1438,7 @@ gpu.module @xevm_module {
 // CHECK:     %[[ADD5:.*]] = arith.addf %[[ADD4]], %[[SHFL5]] : f32
 // CHECK:     %[[FINAL:.*]] = arith.addf %[[ADD5]], %[[ACC]] : f32
 gpu.func @vector_multi_reduction_1d_to_scalar() {
-    %src = "some_op"()
+    %src = "test.some_op"()
       : () -> vector<32xf32>
     %acc = arith.constant 0.0 : f32
     %1 = vector.multi_reduction <add>, %src, %acc

--- a/mlir/test/Dialect/XeGPU/sg-to-lane-distribute.mlir
+++ b/mlir/test/Dialect/XeGPU/sg-to-lane-distribute.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt --allow-unregistered-dialect --xevm-attach-target='module=xevm_* chip=pvc' \
+// RUN: mlir-opt --xevm-attach-target='module=xevm_* chip=pvc' \
 // RUN: --xegpu-sg-to-lane-distribute --split-input-file %s --canonicalize --cse | FileCheck %s
 
 // CHECK-LABEL: gpu.func @gemm

--- a/mlir/test/IR/test-walk-pattern-rewrite-driver.mlir
+++ b/mlir/test/IR/test-walk-pattern-rewrite-driver.mlir
@@ -1,5 +1,5 @@
 // RUN: mlir-opt %s --test-walk-pattern-rewrite-driver="dump-notifications=true" \
-// RUN:   --allow-unregistered-dialect --split-input-file | FileCheck %s
+// RUN:   --split-input-file | FileCheck %s
 
 // Check that newly created operations and blocks may be erased without
 // invalidating the walk, while still forwarding listener notifications.
@@ -116,13 +116,13 @@ func.func @replace_with_new_op() -> i32 {
 // Check that we can erase nested blocks.
 // CHECK-LABEL: func.func @erase_nested_block
 // CHECK:         %[[RES:.+]] = "test.erase_first_block"
-// CHECK-NEXT:    foo.bar
+// CHECK-NEXT:    test.bar
 // CHECK:         return %[[RES]]
 func.func @erase_nested_block() -> i32 {
   %a = "test.erase_first_block"() ({
-    "foo.foo"() : () -> ()
+    "test.foo"() : () -> ()
     ^bb1:
-    "foo.bar"() : () -> ()
+    "test.bar"() : () -> ()
   }): () -> (i32)
   return %a : i32
 }

--- a/mlir/test/Transforms/move-operation-deps.mlir
+++ b/mlir/test/Transforms/move-operation-deps.mlir
@@ -1,23 +1,23 @@
-// RUN: mlir-opt --allow-unregistered-dialect --transform-interpreter --split-input-file --verify-diagnostics %s | FileCheck %s
+// RUN: mlir-opt --transform-interpreter --split-input-file --verify-diagnostics %s | FileCheck %s
 
 // Check simple move of dependent operation before insertion.
 func.func @simple_move(%arg0 : f32) -> f32 {
-  %0 = "before"() : () -> (f32)
+  %0 = "test.before"() : () -> (f32)
   %1 = arith.addf %arg0, %arg0 {moved_op} : f32
-  %2 = "foo"(%1) : (f32) -> (f32)
+  %2 = "test.foo"(%1) : (f32) -> (f32)
   return %2 : f32
 }
 // CHECK-LABEL: func @simple_move(
 //       CHECK:   %[[MOVED:.+]] = arith.addf {{.*}} {moved_op}
-//       CHECK:   %[[BEFORE:.+]] = "before"
-//       CHECK:   %[[FOO:.+]] = "foo"(%[[MOVED]])
+//       CHECK:   %[[BEFORE:.+]] = "test.before"
+//       CHECK:   %[[FOO:.+]] = "test.foo"(%[[MOVED]])
 //       CHECK:   return %[[FOO]]
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
-    %op1 = transform.structured.match ops{["foo"]} in %arg0
+    %op1 = transform.structured.match ops{["test.foo"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
-    %op2 = transform.structured.match ops{["before"]} in %arg0
+    %op2 = transform.structured.match ops{["test.before"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
     transform.test.move_operand_deps %op1 before %op2
         : !transform.any_op, !transform.any_op
@@ -29,25 +29,25 @@ module attributes {transform.with_named_sequence} {
 
 // Move operands that are implicitly captured by the op
 func.func @move_region_dependencies(%arg0 : f32) -> f32 {
-  %0 = "before"() : () -> (f32)
+  %0 = "test.before"() : () -> (f32)
   %1 = arith.addf %arg0, %arg0 {moved_op} : f32
-  %2 = "foo"() ({
+  %2 = "test.foo"() ({
     %3 = arith.mulf %1, %1 : f32
-    "yield"(%3) : (f32) -> ()
+    "test.yield"(%3) : (f32) -> ()
   }) : () -> (f32)
   return %2 : f32
 }
 // CHECK-LABEL: func @move_region_dependencies(
 //       CHECK:   %[[MOVED:.+]] = arith.addf {{.*}} {moved_op}
-//       CHECK:   %[[BEFORE:.+]] = "before"
-//       CHECK:   %[[FOO:.+]] = "foo"
+//       CHECK:   %[[BEFORE:.+]] = "test.before"
+//       CHECK:   %[[FOO:.+]] = "test.foo"
 //       CHECK:   return %[[FOO]]
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
-    %op1 = transform.structured.match ops{["foo"]} in %arg0
+    %op1 = transform.structured.match ops{["test.foo"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
-    %op2 = transform.structured.match ops{["before"]} in %arg0
+    %op2 = transform.structured.match ops{["test.before"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
     transform.test.move_operand_deps %op1 before %op2
         : !transform.any_op, !transform.any_op
@@ -59,13 +59,13 @@ module attributes {transform.with_named_sequence} {
 
 // Move operations in toplogical sort order
 func.func @move_in_topological_sort_order(%arg0 : f32, %arg1 : f32) -> f32 {
-  %0 = "before"() : () -> (f32)
+  %0 = "test.before"() : () -> (f32)
   %1 = arith.addf %arg0, %arg0 {moved_op_1} : f32
   %2 = arith.addf %arg1, %arg1 {moved_op_2} : f32
   %3 = arith.mulf %1, %1 {moved_op_3} : f32
   %4 = arith.mulf %1, %3 {moved_op_4} : f32
   %5 = arith.mulf %2, %2 {moved_op_5} : f32
-  %6 = "foo"(%4, %5) : (f32, f32) -> (f32)
+  %6 = "test.foo"(%4, %5) : (f32, f32) -> (f32)
   return %6 : f32
 }
 // CHECK-LABEL: func @move_in_topological_sort_order(
@@ -74,15 +74,15 @@ func.func @move_in_topological_sort_order(%arg0 : f32, %arg1 : f32) -> f32 {
 //   CHECK-DAG:   %[[MOVED_3:.+]] = arith.mulf %[[MOVED_1]], %[[MOVED_2]] {moved_op_4}
 //   CHECK-DAG:   %[[MOVED_4:.+]] = arith.addf {{.*}} {moved_op_2}
 //   CHECK-DAG:   %[[MOVED_5:.+]] = arith.mulf %[[MOVED_4]], %[[MOVED_4]] {moved_op_5}
-//       CHECK:   %[[BEFORE:.+]] = "before"
-//       CHECK:   %[[FOO:.+]] = "foo"(%[[MOVED_3]], %[[MOVED_5]])
+//       CHECK:   %[[BEFORE:.+]] = "test.before"
+//       CHECK:   %[[FOO:.+]] = "test.foo"(%[[MOVED_3]], %[[MOVED_5]])
 //       CHECK:   return %[[FOO]]
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
-    %op1 = transform.structured.match ops{["foo"]} in %arg0
+    %op1 = transform.structured.match ops{["test.foo"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
-    %op2 = transform.structured.match ops{["before"]} in %arg0
+    %op2 = transform.structured.match ops{["test.before"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
     transform.test.move_operand_deps %op1 before %op2
         : !transform.any_op, !transform.any_op
@@ -94,7 +94,7 @@ module attributes {transform.with_named_sequence} {
 
 func.func @move_region_dependencies(%arg0 : f32) -> f32 {
   %cond = arith.constant true
-  %0 = "before"() : () -> (f32)
+  %0 = "test.before"() : () -> (f32)
   %1 = arith.addf %arg0, %arg0 {moved_op_1} : f32
   %2 = scf.if %cond -> f32 {
     %inner = arith.mulf %1, %1 : f32
@@ -102,8 +102,8 @@ func.func @move_region_dependencies(%arg0 : f32) -> f32 {
   } else {
     scf.yield %1 : f32
   }
-  %3 = "foo"() ({
-    "yield"(%2) : (f32) -> ()
+  %3 = "test.foo"() ({
+    "test.yield"(%2) : (f32) -> ()
   }) : () -> (f32)
   return %3 : f32
 }
@@ -111,15 +111,15 @@ func.func @move_region_dependencies(%arg0 : f32) -> f32 {
 //       CHECK:   arith.constant true
 //       CHECK:   %[[MOVED1:.+]] = arith.addf {{.*}} {moved_op_1}
 //       CHECK:   %[[MOVED2:.+]] = scf.if
-//       CHECK:   "before"
-//       CHECK:   %[[FOO:.+]] = "foo"
+//       CHECK:   "test.before"
+//       CHECK:   %[[FOO:.+]] = "test.foo"
 //       CHECK:   return %[[FOO]]
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
-    %op1 = transform.structured.match ops{["foo"]} in %arg0
+    %op1 = transform.structured.match ops{["test.foo"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
-    %op2 = transform.structured.match ops{["before"]} in %arg0
+    %op2 = transform.structured.match ops{["test.before"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
     transform.test.move_operand_deps %op1 before %op2
         : !transform.any_op, !transform.any_op
@@ -133,34 +133,34 @@ module attributes {transform.with_named_sequence} {
 // computing slices. Verify that this gives expected result.
 func.func @ignore_basic_block_arguments() -> f32 {
 ^bb0():
-  %8 = "test"() : () -> (f32)
+  %8 = "test.test"() : () -> (f32)
   return %8: f32
 ^bb1(%bbArg : f32):
   %cond = arith.constant true
-  %0 = "before"() : () -> (f32)
+  %0 = "test.before"() : () -> (f32)
   %1 = scf.if %cond -> f32 {
     %inner = arith.addf %bbArg, %bbArg : f32
     scf.yield %inner : f32
   } else {
     scf.yield %bbArg : f32
   }
-  %2 = "foo"() ({
-    "yield"(%1) : (f32) -> ()
+  %2 = "test.foo"() ({
+    "test.yield"(%1) : (f32) -> ()
   }) : () -> (f32)
   return %2 : f32
 }
 // CHECK-LABEL: func @ignore_basic_block_arguments()
 //       CHECK:   arith.constant true
 //       CHECK:   %[[MOVED:.+]] = scf.if
-//       CHECK:   "before"
-//       CHECK:   %[[FOO:.+]] = "foo"
+//       CHECK:   "test.before"
+//       CHECK:   %[[FOO:.+]] = "test.foo"
 //       CHECK:   return %[[FOO]]
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
-    %op1 = transform.structured.match ops{["foo"]} in %arg0
+    %op1 = transform.structured.match ops{["test.foo"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
-    %op2 = transform.structured.match ops{["before"]} in %arg0
+    %op2 = transform.structured.match ops{["test.before"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
     transform.test.move_operand_deps %op1 before %op2
         : !transform.any_op, !transform.any_op
@@ -170,17 +170,17 @@ module attributes {transform.with_named_sequence} {
 
 // -----
 
-// Fail when the "before" operation is part of the operation slice.
+// Fail when the "test.before" operation is part of the operation slice.
 func.func @do_not_move_slice() -> f32 {
   %0 = arith.constant {before} 1.0 : f32
   %1 = arith.addf %0, %0 {moved_op} : f32
-  %2 = "foo"(%1) : (f32) -> (f32)
+  %2 = "test.foo"(%1) : (f32) -> (f32)
   return %2 : f32
 }
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
-    %op1 = transform.structured.match ops{["foo"]} in %arg0
+    %op1 = transform.structured.match ops{["test.foo"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
     %op2 = transform.structured.match attributes{before} in %arg0
         : (!transform.any_op) -> !transform.any_op
@@ -193,7 +193,7 @@ module attributes {transform.with_named_sequence} {
 
 // -----
 
-// Fail when the "before" operation is part of the operation slice (computed
+// Fail when the "test.before" operation is part of the operation slice (computed
 // when looking through implicitly captured values).
 func.func @do_not_move_slice_region() -> f32 {
   %cond = arith.constant true
@@ -204,15 +204,15 @@ func.func @do_not_move_slice_region() -> f32 {
   } else {
     scf.yield %0 : f32
   }
-  %2 = "foo"() ({
-    "yield"(%1) : (f32) -> ()
+  %2 = "test.foo"() ({
+    "test.yield"(%1) : (f32) -> ()
   }) : () -> (f32)
   return %2 : f32
 }
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
-    %op1 = transform.structured.match ops{["foo"]} in %arg0
+    %op1 = transform.structured.match ops{["test.foo"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
     %op2 = transform.structured.match attributes{before} in %arg0
         : (!transform.any_op) -> !transform.any_op
@@ -228,18 +228,18 @@ module attributes {transform.with_named_sequence} {
 // Dont move ops when insertion point does not dominate the op
 func.func @do_not_move(%arg0 : f32) -> f32 {
   %1 = arith.addf %arg0, %arg0 {moved_op} : f32
-  %2 = "foo"() ({
-    "yield"(%1) : (f32) -> ()
+  %2 = "test.foo"() ({
+    "test.yield"(%1) : (f32) -> ()
   }) : () -> (f32)
-  %3 = "before"() : () -> f32
+  %3 = "test.before"() : () -> f32
   return %2 : f32
 }
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
-    %op1 = transform.structured.match ops{["foo"]} in %arg0
+    %op1 = transform.structured.match ops{["test.foo"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
-    %op2 = transform.structured.match ops{["before"]} in %arg0
+    %op2 = transform.structured.match ops{["test.before"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
     // expected-remark@+1{{insertion point does not dominate op}}
     transform.test.move_operand_deps %op1 before %op2
@@ -253,17 +253,17 @@ module attributes {transform.with_named_sequence} {
 // Check simple move value definitions before insertion operation.
 func.func @simple_move_values(%arg0 : index) -> index {
   %c0 = arith.constant 0 : index
-  %0 = "before"() : () -> (index)
+  %0 = "test.before"() : () -> (index)
   %1 = arith.addi %arg0, %c0 {"moved_op_1"} : index
   %2 = arith.subi %arg0, %c0 {"moved_op_2"} : index
-  %3 = "foo"(%1, %2) : (index, index) -> (index)
+  %3 = "test.foo"(%1, %2) : (index, index) -> (index)
   return %3 : index
 }
 // CHECK-LABEL: func @simple_move_values(
 //       CHECK:   %[[MOVED1:.+]] = arith.addi {{.*}} {moved_op_1}
 //       CHECK:   %[[MOVED2:.+]] = arith.subi {{.*}} {moved_op_2}
-//       CHECK:   %[[BEFORE:.+]] = "before"
-//       CHECK:   %[[FOO:.+]] = "foo"(%[[MOVED1]], %[[MOVED2]])
+//       CHECK:   %[[BEFORE:.+]] = "test.before"
+//       CHECK:   %[[FOO:.+]] = "test.foo"(%[[MOVED1]], %[[MOVED2]])
 //       CHECK:   return %[[FOO]]
 
 module attributes {transform.with_named_sequence} {
@@ -272,7 +272,7 @@ module attributes {transform.with_named_sequence} {
         : (!transform.any_op) -> !transform.any_op
     %op2 = transform.structured.match ops{["arith.subi"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
-    %op3 = transform.structured.match ops{["before"]} in %arg0
+    %op3 = transform.structured.match ops{["test.before"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
     %v1 = transform.get_result %op1[0] : (!transform.any_op) -> !transform.any_value
     %v2 = transform.get_result %op2[0] : (!transform.any_op) -> !transform.any_value
@@ -286,7 +286,7 @@ module attributes {transform.with_named_sequence} {
 
 // Compute slice including the implicitly captured values.
 func.func @move_region_dependencies_values(%arg0 : index, %cond : i1) -> index {
-  %0 = "before"() : () -> (index)
+  %0 = "test.before"() : () -> (index)
   %1 = arith.addi %arg0, %arg0 {moved_op_1} : index
   %2 = scf.if %cond -> index {
     %3 = arith.muli %1, %1 {inner_op} : index
@@ -300,13 +300,13 @@ func.func @move_region_dependencies_values(%arg0 : index, %cond : i1) -> index {
 //       CHECK:   %[[MOVED1:.+]] = arith.addi {{.*}} {moved_op_1}
 //       CHECK:   scf.if
 //       CHECK:     arith.muli %[[MOVED1]], %[[MOVED1]] {inner_op}
-//       CHECK:   %[[BEFORE:.+]] = "before"
+//       CHECK:   %[[BEFORE:.+]] = "test.before"
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
     %op1 = transform.structured.match ops{["scf.if"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
-    %op2 = transform.structured.match ops{["before"]} in %arg0
+    %op2 = transform.structured.match ops{["test.before"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
     %v1 = transform.get_result %op1[0] : (!transform.any_op) -> !transform.any_value
     transform.test.move_value_defns %v1 before %op2
@@ -319,13 +319,13 @@ module attributes {transform.with_named_sequence} {
 
 // Move operations in toplogical sort order
 func.func @move_values_in_topological_sort_order(%arg0 : index, %arg1 : index) -> index {
-  %0 = "before"() : () -> (index)
+  %0 = "test.before"() : () -> (index)
   %1 = arith.addi %arg0, %arg0 {moved_op_1} : index
   %2 = arith.addi %arg1, %arg1 {moved_op_2} : index
   %3 = arith.muli %1, %1 {moved_op_3} : index
   %4 = arith.andi %1, %3 {moved_op_4} : index
   %5 = arith.subi %2, %2 {moved_op_5} : index
-  %6 = "foo"(%4, %5) : (index, index) -> (index)
+  %6 = "test.foo"(%4, %5) : (index, index) -> (index)
   return %6 : index
 }
 // CHECK-LABEL: func @move_values_in_topological_sort_order(
@@ -334,8 +334,8 @@ func.func @move_values_in_topological_sort_order(%arg0 : index, %arg1 : index) -
 //   CHECK-DAG:   %[[MOVED_3:.+]] = arith.andi %[[MOVED_1]], %[[MOVED_2]] {moved_op_4}
 //   CHECK-DAG:   %[[MOVED_4:.+]] = arith.addi {{.*}} {moved_op_2}
 //   CHECK-DAG:   %[[MOVED_5:.+]] = arith.subi %[[MOVED_4]], %[[MOVED_4]] {moved_op_5}
-//       CHECK:   %[[BEFORE:.+]] = "before"
-//       CHECK:   %[[FOO:.+]] = "foo"(%[[MOVED_3]], %[[MOVED_5]])
+//       CHECK:   %[[BEFORE:.+]] = "test.before"
+//       CHECK:   %[[FOO:.+]] = "test.foo"(%[[MOVED_3]], %[[MOVED_5]])
 //       CHECK:   return %[[FOO]]
 
 module attributes {transform.with_named_sequence} {
@@ -344,7 +344,7 @@ module attributes {transform.with_named_sequence} {
         : (!transform.any_op) -> !transform.any_op
     %op2 = transform.structured.match ops{["arith.subi"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
-    %op3 = transform.structured.match ops{["before"]} in %arg0
+    %op3 = transform.structured.match ops{["test.before"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
     %v1 = transform.get_result %op1[0] : (!transform.any_op) -> !transform.any_value
     %v2 = transform.get_result %op2[0] : (!transform.any_op) -> !transform.any_value
@@ -359,25 +359,25 @@ module attributes {transform.with_named_sequence} {
 // Move only those value definitions that are not dominated by insertion point
 
 func.func @move_only_required_defns(%arg0 : index) -> (index, index, index, index) {
-  %0 = "unmoved_op"() : () -> (index)
-  %1 = "dummy_op"() : () -> (index)
-  %2 = "before"() : () -> (index)
+  %0 = "test.unmoved_op"() : () -> (index)
+  %1 = "test.dummy_op"() : () -> (index)
+  %2 = "test.before"() : () -> (index)
   %3 = arith.addi %arg0, %arg0 {moved_op} : index
   return %0, %1, %2, %3 : index, index, index, index
 }
 // CHECK-LABEL: func @move_only_required_defns(
-//       CHECK:   %[[UNMOVED:.+]] = "unmoved_op"
-//       CHECK:   %[[DUMMY:.+]] = "dummy_op"
+//       CHECK:   %[[UNMOVED:.+]] = "test.unmoved_op"
+//       CHECK:   %[[DUMMY:.+]] = "test.dummy_op"
 //       CHECK:   %[[MOVED:.+]] = arith.addi {{.*}} {moved_op}
-//       CHECK:   %[[BEFORE:.+]] = "before"
+//       CHECK:   %[[BEFORE:.+]] = "test.before"
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
-    %op1 = transform.structured.match ops{["unmoved_op"]} in %arg0
+    %op1 = transform.structured.match ops{["test.unmoved_op"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
-    %op2 = transform.structured.match ops{["dummy_op"]} in %arg0
+    %op2 = transform.structured.match ops{["test.dummy_op"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
-    %op3 = transform.structured.match ops{["before"]} in %arg0
+    %op3 = transform.structured.match ops{["test.before"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
     %op4 = transform.structured.match ops{["arith.addi"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
@@ -394,25 +394,25 @@ module attributes {transform.with_named_sequence} {
 // Move only those value definitions that are not dominated by insertion point (duplicate test)
 
 func.func @move_only_required_defns_2(%arg0 : index) -> (index, index, index, index) {
-  %0 = "unmoved_op"() : () -> (index)
-  %1 = "dummy_op"() : () -> (index)
-  %2 = "before"() : () -> (index)
+  %0 = "test.unmoved_op"() : () -> (index)
+  %1 = "test.dummy_op"() : () -> (index)
+  %2 = "test.before"() : () -> (index)
   %3 = arith.subi %arg0, %arg0 {moved_op} : index
   return %0, %1, %2, %3 : index, index, index, index
 }
 // CHECK-LABEL: func @move_only_required_defns_2(
-//       CHECK:   %[[UNMOVED:.+]] = "unmoved_op"
-//       CHECK:   %[[DUMMY:.+]] = "dummy_op"
+//       CHECK:   %[[UNMOVED:.+]] = "test.unmoved_op"
+//       CHECK:   %[[DUMMY:.+]] = "test.dummy_op"
 //       CHECK:   %[[MOVED:.+]] = arith.subi {{.*}} {moved_op}
-//       CHECK:   %[[BEFORE:.+]] = "before"
+//       CHECK:   %[[BEFORE:.+]] = "test.before"
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
-    %op1 = transform.structured.match ops{["unmoved_op"]} in %arg0
+    %op1 = transform.structured.match ops{["test.unmoved_op"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
-    %op2 = transform.structured.match ops{["dummy_op"]} in %arg0
+    %op2 = transform.structured.match ops{["test.dummy_op"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
-    %op3 = transform.structured.match ops{["before"]} in %arg0
+    %op3 = transform.structured.match ops{["test.before"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
     %op4 = transform.structured.match ops{["arith.subi"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
@@ -428,20 +428,20 @@ module attributes {transform.with_named_sequence} {
 
 // Check handling of block arguments
 func.func @move_with_block_arguments() -> (index, index) {
-  %0 = "unmoved_op"() : () -> (index)
+  %0 = "test.unmoved_op"() : () -> (index)
   cf.br ^bb0(%0 : index)
  ^bb0(%arg0 : index) :
-  %1 = "before"() : () -> (index)
+  %1 = "test.before"() : () -> (index)
   %2 = arith.addi %arg0, %arg0 {moved_op} : index
   return %1, %2 : index, index
 }
 // CHECK-LABEL: func @move_with_block_arguments()
 //       CHECK:   %[[MOVED:.+]] = arith.addi {{.*}} {moved_op}
-//       CHECK:   %[[BEFORE:.+]] = "before"
+//       CHECK:   %[[BEFORE:.+]] = "test.before"
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
-    %op1 = transform.structured.match ops{["before"]} in %arg0
+    %op1 = transform.structured.match ops{["test.before"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
     %op2 = transform.structured.match ops{["arith.addi"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
@@ -457,7 +457,7 @@ module attributes {transform.with_named_sequence} {
 // Successfully move operation between blocks in the same region.
 // The function argument %arg0 dominates all blocks, so the move is valid.
 func.func @move_between_blocks_same_region(%arg0 : index, %cond : i1) -> index {
-  %0 = "before"() : () -> (index)
+  %0 = "test.before"() : () -> (index)
   cf.cond_br %cond, ^bb1, ^bb2(%arg0 : index)
 ^bb1:
   %1 = arith.addi %arg0, %arg0 {to_move} : index
@@ -467,11 +467,11 @@ func.func @move_between_blocks_same_region(%arg0 : index, %cond : i1) -> index {
 }
 // CHECK-LABEL: func @move_between_blocks_same_region
 // CHECK:         %[[MOVED:.+]] = arith.addi {{.*}} {to_move}
-// CHECK:         "before"
+// CHECK:         "test.before"
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
-    %op1 = transform.structured.match ops{["before"]} in %arg0
+    %op1 = transform.structured.match ops{["test.before"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
     %op2 = transform.structured.match attributes{to_move} in %arg0
         : (!transform.any_op) -> !transform.any_op
@@ -491,7 +491,7 @@ module attributes {transform.with_named_sequence} {
 
 // Move multiple values with dependencies out of nested region
 func.func @move_chain_out_of_region(%arg0 : index, %cond : i1) -> index {
-  %0 = "before"() : () -> (index)
+  %0 = "test.before"() : () -> (index)
   %1 = scf.if %cond -> index {
     %2 = arith.addi %arg0, %arg0 {dep1} : index
     %3 = arith.muli %2, %2 {dep2} : index
@@ -506,12 +506,12 @@ func.func @move_chain_out_of_region(%arg0 : index, %cond : i1) -> index {
 //       CHECK:   arith.addi {{.*}} {dep1}
 //       CHECK:   arith.muli {{.*}} {dep2}
 //       CHECK:   arith.subi {{.*}} {to_move}
-//       CHECK:   "before"
+//       CHECK:   "test.before"
 //       CHECK:   scf.if
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
-    %op1 = transform.structured.match ops{["before"]} in %arg0
+    %op1 = transform.structured.match ops{["test.before"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
     %op2 = transform.structured.match attributes{to_move} in %arg0
         : (!transform.any_op) -> !transform.any_op
@@ -526,7 +526,7 @@ module attributes {transform.with_named_sequence} {
 
 // moveValueDefinitions: cannot move when slice has side-effecting ops
 func.func @move_value_defs_side_effecting(%arg0 : memref<index>) -> index {
-  %0 = "before"() : () -> (index)
+  %0 = "test.before"() : () -> (index)
   %1 = memref.load %arg0[] : memref<index>
   %2 = arith.muli %1, %1 {moved_op} : index
   return %2 : index
@@ -534,7 +534,7 @@ func.func @move_value_defs_side_effecting(%arg0 : memref<index>) -> index {
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
-    %op1 = transform.structured.match ops{["before"]} in %arg0
+    %op1 = transform.structured.match ops{["test.before"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
     %op2 = transform.structured.match attributes{moved_op} in %arg0
         : (!transform.any_op) -> !transform.any_op
@@ -550,18 +550,18 @@ module attributes {transform.with_named_sequence} {
 
 // moveOperationDependencies: cannot move when slice has side-effecting ops
 func.func @move_op_deps_side_effecting(%arg0 : memref<index>) -> index {
-  %0 = "before"() : () -> (index)
+  %0 = "test.before"() : () -> (index)
   %1 = memref.load %arg0[] : memref<index>
   %2 = arith.muli %1, %1 {moved_op} : index
-  %3 = "foo"(%2) : (index) -> (index)
+  %3 = "test.foo"(%2) : (index) -> (index)
   return %3 : index
 }
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
-    %op1 = transform.structured.match ops{["foo"]} in %arg0
+    %op1 = transform.structured.match ops{["test.foo"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
-    %op2 = transform.structured.match ops{["before"]} in %arg0
+    %op2 = transform.structured.match ops{["test.before"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
     // expected-remark@+1{{cannot move operation with side-effecting dependencies}}
     transform.test.move_operand_deps %op1 before %op2
@@ -575,11 +575,11 @@ module attributes {transform.with_named_sequence} {
 // Can move op using outer loop's IV when staying within outer loop
 func.func @move_op_using_outer_loop_iv(%lb : index, %ub : index, %step : index) -> index {
   %result = scf.for %outer_iv = %lb to %ub step %step iter_args(%acc = %lb) -> index {
-    %before = "before"() : () -> (index)
+    %before = "test.before"() : () -> (index)
     scf.for %inner_iv = %lb to %ub step %step {
       // Uses outer_iv which dominates within the outer loop body
       %x = arith.addi %outer_iv, %outer_iv {to_move} : index
-      "use"(%x) : (index) -> ()
+      "test.use"(%x) : (index) -> ()
     }
     scf.yield %acc : index
   }
@@ -588,12 +588,12 @@ func.func @move_op_using_outer_loop_iv(%lb : index, %ub : index, %step : index) 
 // CHECK-LABEL: func @move_op_using_outer_loop_iv(
 //       CHECK:   scf.for %[[OUTER_IV:[a-zA-Z0-9_]+]] =
 //       CHECK:     arith.addi %[[OUTER_IV]], %[[OUTER_IV]] {to_move}
-//       CHECK:     "before"
+//       CHECK:     "test.before"
 //       CHECK:     scf.for
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
-    %op1 = transform.structured.match ops{["before"]} in %arg0
+    %op1 = transform.structured.match ops{["test.before"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
     %op2 = transform.structured.match attributes{to_move} in %arg0
         : (!transform.any_op) -> !transform.any_op
@@ -608,7 +608,7 @@ module attributes {transform.with_named_sequence} {
 
 // Move out of doubly nested non-isolated region
 func.func @move_out_of_doubly_nested_region(%arg0 : index, %cond1 : i1, %cond2 : i1) -> index {
-  %0 = "before"() : () -> (index)
+  %0 = "test.before"() : () -> (index)
   %1 = scf.if %cond1 -> index {
     %2 = scf.if %cond2 -> index {
       %3 = arith.addi %arg0, %arg0 {to_move} : index
@@ -624,14 +624,14 @@ func.func @move_out_of_doubly_nested_region(%arg0 : index, %cond1 : i1, %cond2 :
 }
 // CHECK-LABEL: func @move_out_of_doubly_nested_region(
 //       CHECK:   %[[MOVED:.+]] = arith.addi {{.*}} {to_move}
-//       CHECK:   %[[BEFORE:.+]] = "before"
+//       CHECK:   %[[BEFORE:.+]] = "test.before"
 //       CHECK:   scf.if
 //       CHECK:     scf.if
 //       CHECK:       scf.yield %[[MOVED]]
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
-    %op1 = transform.structured.match ops{["before"]} in %arg0
+    %op1 = transform.structured.match ops{["test.before"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
     %op2 = transform.structured.match attributes{to_move} in %arg0
         : (!transform.any_op) -> !transform.any_op
@@ -646,10 +646,10 @@ module attributes {transform.with_named_sequence} {
 
 // Move operand deps out of nested region
 func.func @move_operand_deps_out_of_region(%arg0 : index, %cond : i1) -> index {
-  %0 = "before"() : () -> (index)
+  %0 = "test.before"() : () -> (index)
   %1 = scf.if %cond -> index {
     %2 = arith.addi %arg0, %arg0 {dep} : index
-    %3 = "foo"(%2) {target} : (index) -> (index)
+    %3 = "test.foo"(%2) {target} : (index) -> (index)
     scf.yield %3 : index
   } else {
     scf.yield %arg0 : index
@@ -658,15 +658,15 @@ func.func @move_operand_deps_out_of_region(%arg0 : index, %cond : i1) -> index {
 }
 // CHECK-LABEL: func @move_operand_deps_out_of_region(
 //       CHECK:   %[[DEP:.+]] = arith.addi {{.*}} {dep}
-//       CHECK:   %[[BEFORE:.+]] = "before"
+//       CHECK:   %[[BEFORE:.+]] = "test.before"
 //       CHECK:   scf.if
-//       CHECK:     "foo"(%[[DEP]]) {target}
+//       CHECK:     "test.foo"(%[[DEP]]) {target}
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
-    %op1 = transform.structured.match ops{["foo"]} in %arg0
+    %op1 = transform.structured.match ops{["test.foo"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
-    %op2 = transform.structured.match ops{["before"]} in %arg0
+    %op2 = transform.structured.match ops{["test.before"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
     transform.test.move_operand_deps %op1 before %op2
         : !transform.any_op, !transform.any_op
@@ -678,7 +678,7 @@ module attributes {transform.with_named_sequence} {
 
 // Cannot move op that depends on loop induction variable (block argument)
 func.func @cannot_move_op_using_loop_iv(%arg0 : index, %lb : index, %ub : index, %step : index) -> index {
-  %0 = "before"() : () -> (index)
+  %0 = "test.before"() : () -> (index)
   %1 = scf.for %iv = %lb to %ub step %step iter_args(%acc = %arg0) -> index {
     %2 = arith.addi %iv, %iv {to_move} : index
     %3 = arith.addi %acc, %2 : index
@@ -689,7 +689,7 @@ func.func @cannot_move_op_using_loop_iv(%arg0 : index, %lb : index, %ub : index,
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
-    %op1 = transform.structured.match ops{["before"]} in %arg0
+    %op1 = transform.structured.match ops{["test.before"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
     %op2 = transform.structured.match attributes{to_move} in %arg0
         : (!transform.any_op) -> !transform.any_op
@@ -706,7 +706,7 @@ module attributes {transform.with_named_sequence} {
 // Cannot move out of an isolated-from-above region, even when op is in a
 // non-isolated region nested inside the isolated region
 func.func @cannot_move_out_of_isolated_region(%arg0 : index, %cond : i1) -> index {
-  %0 = "before"() : () -> (index)
+  %0 = "test.before"() : () -> (index)
   %1 = "test.isolated_one_region_op"(%arg0, %cond) ({
     ^bb0(%inner_arg: index, %inner_cond: i1):
       // scf.if is NOT isolated, but it's inside an isolated region
@@ -723,7 +723,7 @@ func.func @cannot_move_out_of_isolated_region(%arg0 : index, %cond : i1) -> inde
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
-    %op1 = transform.structured.match ops{["before"]} in %arg0
+    %op1 = transform.structured.match ops{["test.before"]} in %arg0
         : (!transform.any_op) -> !transform.any_op
     %op2 = transform.structured.match attributes{to_move} in %arg0
         : (!transform.any_op) -> !transform.any_op

--- a/mlir/test/lib/Dialect/Vector/TestVectorTransforms.cpp
+++ b/mlir/test/lib/Dialect/Vector/TestVectorTransforms.cpp
@@ -792,7 +792,7 @@ struct TestCreateVectorBroadcast
 
   void runOnOperation() override {
     getOperation()->walk([](Operation *op) {
-      if (op->getName().getStringRef() != "test_create_broadcast")
+      if (op->getName().getStringRef() != "test.create_broadcast")
         return;
       auto targetShape =
           cast<VectorType>(op->getResult(0).getType()).getShape();

--- a/mlir/test/mlir-translate/verify-only-expected.mlir
+++ b/mlir/test/mlir-translate/verify-only-expected.mlir
@@ -1,24 +1,27 @@
 // Check that verify-diagnostics=only-expected passes with only one actual `expected-error`
-// RUN: mlir-translate %s --allow-unregistered-dialect -verify-diagnostics=only-expected -split-input-file -mlir-to-llvmir
+// RUN: mlir-translate %s -verify-diagnostics=only-expected -split-input-file -mlir-to-llvmir
 
 // Check that verify-diagnostics=all fails because we're missing two `expected-error`
-// RUN: not mlir-translate %s --allow-unregistered-dialect -verify-diagnostics=all -split-input-file -mlir-to-llvmir 2>&1 | FileCheck %s --check-prefix=CHECK-VERIFY-ALL
-// CHECK-VERIFY-ALL: unexpected error: cannot be converted to LLVM IR: missing `LLVMTranslationDialectInterface` registration for dialect for op: simple.terminator1
-// CHECK-VERIFY-ALL: unexpected error: cannot be converted to LLVM IR: missing `LLVMTranslationDialectInterface` registration for dialect for op: simple.terminator3
+// RUN: not mlir-translate %s -verify-diagnostics=all -split-input-file -mlir-to-llvmir 2>&1 | FileCheck %s --check-prefix=CHECK-VERIFY-ALL
+// CHECK-VERIFY-ALL: unexpected error: cannot be converted to LLVM IR: missing `LLVMTranslationDialectInterface` registration for dialect for op: spirv.Undef
+// CHECK-VERIFY-ALL: unexpected error: cannot be converted to LLVM IR: missing `LLVMTranslationDialectInterface` registration for dialect for op: spirv.Undef
 
 llvm.func @trivial() {
-  "simple.terminator1"() : () -> ()
+  %0 = spirv.Undef : i32
+  llvm.return
 }
 
 // -----
 
 llvm.func @trivial() {
-  // expected-error @+1 {{cannot be converted to LLVM IR: missing `LLVMTranslationDialectInterface` registration for dialect for op: simple.terminator2}}
-  "simple.terminator2"() : () -> ()
+  // expected-error @+1 {{cannot be converted to LLVM IR: missing `LLVMTranslationDialectInterface` registration for dialect for op: spirv.Undef}}
+  %0 = spirv.Undef : i32
+  llvm.return
 }
 
 // -----
 
 llvm.func @trivial() {
-  "simple.terminator3"() : () -> ()
+  %0 = spirv.Undef : i32
+  llvm.return
 }


### PR DESCRIPTION
This is bad practice, instead use unknown operations in the test dialect when tests only need placeholders.

Use a registered SPIR-V operation for translation diagnostics.

Assisted-by: Codex