### PR TITLE
[ProfileData] Fix uint8_t loop index truncating bitmap byte count

### DIFF
--- a/llvm/lib/ProfileData/InstrProfReader.cpp
+++ b/llvm/lib/ProfileData/InstrProfReader.cpp
@@ -455,7 +455,7 @@ Error TextInstrProfReader::readNextRecord(NamedInstrProfRecord &Record) {
     if (NumBitmapBytes != 0) {
       // Read each bitmap and fill our internal storage with the values.
       Record.BitmapBytes.reserve(NumBitmapBytes);
-      for (uint8_t I = 0; I < NumBitmapBytes; ++I) {
+      for (uint64_t I = 0; I < NumBitmapBytes; ++I) {
         if (Line.is_at_end())
           return error(instrprof_error::truncated);
         uint8_t BitmapByte;


### PR DESCRIPTION
## Summary

`TextInstrProfReader::readNextRecord` reads a record's bitmap bytes with a
`uint8_t` loop index compared against a `uint64_t` count:

```cpp
for (uint8_t I = 0; I < NumBitmapBytes; ++I) {
```

`NumBitmapBytes` is `uint64_t`, so when a text profile declares more than 255
bitmap bytes the `uint8_t` index wraps around at 256 back to 0 and the
condition `I < NumBitmapBytes` can never become false. The loop then stops only
when the input runs out (via the `is_at_end()` truncation check), so the record
is mis-parsed: the reader runs past the intended `NumBitmapBytes` values and
reports the profile as truncated instead of reading it correctly.

## Fix

Widen the loop index to `uint64_t` to match `NumBitmapBytes`, consistent with the sibling counter loop a few lines above (`for (uint64_t I = 0; I < NumCounters; ++I)`):

```cpp
for (uint64_t I = 0; I < NumBitmapBytes; ++I) {
```

#### Assisted by: Claude

#### I don't have commit access, could you please merge this?