### PR TITLE
[AMDGPU] Fix LDS bank count for gfx950

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPU.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.td
@@ -1870,7 +1870,7 @@ def FeatureISAVersion7_0_3 : FeatureSet<
 
 def FeatureISAVersion7_0_4 : FeatureSet<
   [FeatureSeaIslands,
-   FeatureLDSBankCount32]>;
+   FeatureLDSBankCount16]>;
 
 def FeatureISAVersion7_0_5 : FeatureSet<
   [FeatureSeaIslands,
@@ -2017,7 +2017,6 @@ def FeatureISAVersion9_4_Common : FeatureSet<
    FeatureGFX940Insts,
    FeatureRequiresAlignedVGPRs,
    FeatureFmaMixInsts,
-   FeatureLDSBankCount32,
    FeatureDLInsts,
    FeatureFmacF64Inst,
    FeatureDot1Insts,
@@ -2059,6 +2058,7 @@ def FeatureISAVersion9_4_Common : FeatureSet<
 def FeatureISAVersion9_5_Common : FeatureSet<
   !listconcat(FeatureISAVersion9_4_Common.Features,
   [FeatureAddressableLocalMemorySize163840,
+   FeatureLDSBankCount64,
    FeatureFP8Insts,
    FeatureFP8ConversionInsts,
    FeatureCvtFP8SDWASrcSel,
@@ -2080,6 +2080,7 @@ def FeatureISAVersion9_4_2 : FeatureSet<
   !listconcat(FeatureISAVersion9_4_Common.Features,
     [
       FeatureAddressableLocalMemorySize65536,
+      FeatureLDSBankCount32,
       FeatureFP8Insts,
       FeatureFP8ConversionInsts,
       FeatureCvtFP8SDWASrcSel,
@@ -2090,6 +2091,7 @@ def FeatureISAVersion9_4_2 : FeatureSet<
 def FeatureISAVersion9_4_Generic : FeatureSet<
   !listconcat(FeatureISAVersion9_4_Common.Features,
     [FeatureAddressableLocalMemorySize65536,
+     FeatureLDSBankCount32,
      FeatureRequiresCOV6])>;
 
 def FeatureISAVersion9_5_0 : FeatureSet<FeatureISAVersion9_5_Common.Features>;

--- a/llvm/lib/Target/AMDGPU/AMDGPU.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.td
@@ -1870,11 +1870,11 @@ def FeatureISAVersion7_0_3 : FeatureSet<
 
 def FeatureISAVersion7_0_4 : FeatureSet<
   [FeatureSeaIslands,
-   FeatureLDSBankCount16]>;
+   FeatureLDSBankCount32]>;
 
 def FeatureISAVersion7_0_5 : FeatureSet<
   [FeatureSeaIslands,
-   FeatureLDSBankCount32]>;
+   FeatureLDSBankCount16]>;
 
 def FeatureISAVersion8_0_Common : FeatureSet<
   [FeatureVolcanicIslands,

--- a/llvm/lib/Target/AMDGPU/AMDGPU.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.td
@@ -1874,7 +1874,7 @@ def FeatureISAVersion7_0_4 : FeatureSet<
 
 def FeatureISAVersion7_0_5 : FeatureSet<
   [FeatureSeaIslands,
-   FeatureLDSBankCount16]>;
+   FeatureLDSBankCount32]>;
 
 def FeatureISAVersion8_0_Common : FeatureSet<
   [FeatureVolcanicIslands,

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -3164,7 +3164,10 @@ TEST(TargetParserTest, testAMDGPUgetNumWorkGroupSIMDs) {
 
 TEST(TargetParserTest, testAMDGPUgetLDSBankCount) {
   EXPECT_EQ(AMDGPU::getLDSBankCount(Triple::AMDGPUSubArch702), 16u);
+  EXPECT_EQ(AMDGPU::getLDSBankCount(Triple::AMDGPUSubArch704), 16u);
   EXPECT_EQ(AMDGPU::getLDSBankCount(Triple::AMDGPUSubArch900), 32u);
+  EXPECT_EQ(AMDGPU::getLDSBankCount(Triple::AMDGPUSubArch942), 32u);
+  EXPECT_EQ(AMDGPU::getLDSBankCount(Triple::AMDGPUSubArch950), 64u);
   EXPECT_EQ(AMDGPU::getLDSBankCount(Triple::AMDGPUSubArch1030), 32u);
   EXPECT_EQ(AMDGPU::getLDSBankCount(Triple::AMDGPUSubArch1200), 32u);
   // gfx12.5 doubled the bank count.
@@ -3172,6 +3175,7 @@ TEST(TargetParserTest, testAMDGPUgetLDSBankCount) {
 
   // The GPUKind overload resolves to the same values.
   EXPECT_EQ(AMDGPU::getLDSBankCount(AMDGPU::GK_GFX900), 32u);
+  EXPECT_EQ(AMDGPU::getLDSBankCount(AMDGPU::GK_GFX950), 64u);
   EXPECT_EQ(AMDGPU::getLDSBankCount(AMDGPU::GK_GFX1250), 64u);
   EXPECT_EQ(AMDGPU::getLDSBankCount(AMDGPU::GK_GFX1251), 64u);
 }

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -3164,7 +3164,6 @@ TEST(TargetParserTest, testAMDGPUgetNumWorkGroupSIMDs) {
 
 TEST(TargetParserTest, testAMDGPUgetLDSBankCount) {
   EXPECT_EQ(AMDGPU::getLDSBankCount(Triple::AMDGPUSubArch702), 16u);
-  EXPECT_EQ(AMDGPU::getLDSBankCount(Triple::AMDGPUSubArch704), 16u);
   EXPECT_EQ(AMDGPU::getLDSBankCount(Triple::AMDGPUSubArch900), 32u);
   EXPECT_EQ(AMDGPU::getLDSBankCount(Triple::AMDGPUSubArch942), 32u);
   EXPECT_EQ(AMDGPU::getLDSBankCount(Triple::AMDGPUSubArch950), 64u);


### PR DESCRIPTION
gfx950 doubled the bank count to 64 along with its larger LDS.

Moving the count out of `FeatureISAVersion9_4_Common` is required because the emitter rejects a GPU whose feature closure sets a field twice.