### PR TITLE
[libFuzzer] Make -stop_file work with empty files

### DIFF
--- a/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
@@ -880,8 +880,7 @@ void Fuzzer::Loop(std::vector<SizedFile> &CorporaFiles) {
 
   while (true) {
     auto Now = system_clock::now();
-    if (!Options.StopFile.empty() &&
-        !FileToVector(Options.StopFile, 1, false).empty())
+    if (!Options.StopFile.empty() && IsFile(Options.StopFile))
       break;
     if (duration_cast<seconds>(Now - LastCorpusReload).count() >=
         Options.ReloadIntervalSec) {

--- a/compiler-rt/test/fuzzer/stop-file.test
+++ b/compiler-rt/test/fuzzer/stop-file.test
@@ -1,0 +1,12 @@
+RUN: %cpp_compiler %S/AccumulateAllocationsTest.cpp -o %t-AccumulateAllocationsTest
+
+# Fuzzing must stop when the stop file exists, even if the file is empty.
+RUN: rm -f %t.stop_file
+RUN: echo -n "" > %t.stop_file
+RUN: %run %t-AccumulateAllocationsTest -seed=1 -runs=100000 -stop_file=%t.stop_file 2>&1 | FileCheck %s
+CHECK: Done {{[0-9]}} runs
+
+# Fuzzing must not stop when the stop file does not exist.
+RUN: rm -f %t.stop_file
+RUN: %run %t-AccumulateAllocationsTest -seed=1 -runs=10 -stop_file=%t.stop_file 2>&1 | FileCheck %s --check-prefix=NOSTOP
+NOSTOP: Done 10 runs

--- a/compiler-rt/test/fuzzer/stop-file.test
+++ b/compiler-rt/test/fuzzer/stop-file.test
@@ -4,9 +4,9 @@ RUN: %cpp_compiler %S/AccumulateAllocationsTest.cpp -o %t-AccumulateAllocationsT
 RUN: rm -f %t.stop_file
 RUN: echo -n "" > %t.stop_file
 RUN: %run %t-AccumulateAllocationsTest -seed=1 -runs=100000 -stop_file=%t.stop_file 2>&1 | FileCheck %s
-CHECK: Done {{[0-9]}} runs
+CHECK: Done 2 runs
 
 # Fuzzing must not stop when the stop file does not exist.
 RUN: rm -f %t.stop_file
-RUN: %run %t-AccumulateAllocationsTest -seed=1 -runs=10 -stop_file=%t.stop_file 2>&1 | FileCheck %s --check-prefix=NOSTOP
-NOSTOP: Done 10 runs
+RUN: %run %t-AccumulateAllocationsTest -seed=1 -runs=1000 -stop_file=%t.stop_file 2>&1 | FileCheck %s --check-prefix=NOSTOP
+NOSTOP: Done 1000 runs

--- a/compiler-rt/test/fuzzer/stop-file.test
+++ b/compiler-rt/test/fuzzer/stop-file.test
@@ -4,7 +4,7 @@ RUN: %cpp_compiler %S/AccumulateAllocationsTest.cpp -o %t-AccumulateAllocationsT
 RUN: rm -f %t.stop_file
 RUN: echo -n "" > %t.stop_file
 RUN: %run %t-AccumulateAllocationsTest -seed=1 -runs=100000 -stop_file=%t.stop_file 2>&1 | FileCheck %s
-CHECK: Done 2 runs
+CHECK: Done {{[0-9]}} runs
 
 # Fuzzing must not stop when the stop file does not exist.
 RUN: rm -f %t.stop_file


### PR DESCRIPTION
Fixes: https://github.com/llvm/llvm-project/issues/72334. The -stop_file flag is documented as "Stop fuzzing ASAP if this file exists", but the fuzzing loop checked it by reading the file and testing that the result is non-empty. Instead, check for the file's existence with IsFile.