### PR TITLE
[lldb] Restrict the simple readline to python 3.8

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Python/PythonReadline.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/PythonReadline.h
@@ -24,11 +24,11 @@
 // and backported to 3.8 point release (don't know the exact version).
 // TODO: remove LLDB_USE_LIBEDIT_READLINE_COMPACT_MODULE when
 // LLDB_MINIMUM_PYTHON_VERSION is greater than 3.8.
-#if PY_VERSION_HEX < 0x03090000
+#if PY_VERSION_HEX < 0x03090000 || LLDB_ENABLE_PYTHON_LIMITED_API
 #define LLDB_USE_LIBEDIT_READLINE_COMPAT_MODULE 1
 
 PyMODINIT_FUNC initlldb_readline(void);
-#endif // PY_VERSION_HEX < 0x03090000
+#endif // PY_VERSION_HEX < 0x03090000 || LLDB_ENABLE_PYTHON_LIMITED_API
 
 #endif
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/PythonReadline.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/PythonReadline.h
@@ -11,17 +11,24 @@
 
 #include "lldb/Host/Config.h"
 
+// No need to hack into Python's readline module if libedit isn't used.
 #if LLDB_ENABLE_LIBEDIT && defined(__linux__)
 // NOTE: Since Python may define some pre-processor definitions which affect the
 // standard headers on some systems, you must include Python.h before any
 // standard headers are included.
-#include "Python.h"
+#include <Python.h>
 
-// no need to hack into Python's readline module if libedit isn't used.
-//
+// The symbol conflict bug was fixed in python 3.9 here
+// https://github.com/python/cpython/issues/82815 commit
+// https://github.com/python/cpython/commit/7105319ada2e663659020cbe9fdf7ff38f421ab2
+// and backported to 3.8 point release (don't know the exact version).
+// TODO: remove LLDB_USE_LIBEDIT_READLINE_COMPACT_MODULE when
+// LLDB_MINIMUM_PYTHON_VERSION is greater than 3.8.
+#if PY_VERSION_HEX < 0x03090000
 #define LLDB_USE_LIBEDIT_READLINE_COMPAT_MODULE 1
 
 PyMODINIT_FUNC initlldb_readline(void);
+#endif // PY_VERSION_HEX < 0x03090000
 
 #endif
 


### PR DESCRIPTION
The simple readline does not handling signals properly and easily crashes lldb. Especially the more common ones:
  `SIGINT` -> keyboard interrupt.
 `SIGTSTP` -> stop typed at terminal with `fg`.
  and `SINWINCH` -> window size change).

Use the normal readline on linux for python version greater than 3.8 because the bug no longer exist since commit (https://github.com/python/cpython/commit/7105319ada2e663659020cbe9fdf7ff38f421ab2) in 3.9.