### PR TITLE
[CodeGen] Visit operands inside bundles in DetectDeadLanes

### DIFF
--- a/llvm/lib/CodeGen/DetectDeadLanes.cpp
+++ b/llvm/lib/CodeGen/DetectDeadLanes.cpp
@@ -496,7 +496,7 @@ DetectDeadLanes::modifySubRegisterOperandStatus(const DeadLaneDetector &DLD,
   bool Again = false;
   // Mark operands as dead/unused.
   for (MachineBasicBlock &MBB : MF) {
-    for (MachineInstr &MI : MBB) {
+    for (MachineInstr &MI : MBB.instrs()) {
       for (MachineOperand &MO : MI.operands()) {
         if (!MO.isReg())
           continue;

--- a/llvm/lib/CodeGen/DetectDeadLanes.cpp
+++ b/llvm/lib/CodeGen/DetectDeadLanes.cpp
@@ -27,6 +27,7 @@
 
 #include "llvm/CodeGen/DetectDeadLanes.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBundle.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
 #include "llvm/InitializePasses.h"
@@ -496,31 +497,32 @@ DetectDeadLanes::modifySubRegisterOperandStatus(const DeadLaneDetector &DLD,
   bool Again = false;
   // Mark operands as dead/unused.
   for (MachineBasicBlock &MBB : MF) {
-    for (MachineInstr &MI : MBB.instrs()) {
-      for (MachineOperand &MO : MI.operands()) {
+    for (MachineInstr &MI : MBB) {
+      for (MachineOperand &MO : mi_bundle_ops(MI)) {
         if (!MO.isReg())
           continue;
         Register Reg = MO.getReg();
         if (!Reg.isVirtual())
           continue;
+        const MachineInstr &OpMI = *MO.getParent();
         unsigned RegIdx = Reg.virtRegIndex();
         const DeadLaneDetector::VRegInfo &RegInfo = DLD.getVRegInfo(RegIdx);
         if (MO.isDef() && !MO.isDead() && RegInfo.UsedLanes.none()) {
           LLVM_DEBUG(dbgs()
-                     << "Marking operand '" << MO << "' as dead in " << MI);
+                     << "Marking operand '" << MO << "' as dead in " << OpMI);
           MO.setIsDead();
           Changed = true;
         }
         if (MO.readsReg()) {
           bool CrossCopy = false;
           if (isUndefRegAtInput(MO, RegInfo)) {
-            LLVM_DEBUG(dbgs()
-                       << "Marking operand '" << MO << "' as undef in " << MI);
+            LLVM_DEBUG(dbgs() << "Marking operand '" << MO << "' as undef in "
+                              << OpMI);
             MO.setIsUndef();
             Changed = true;
-          } else if (isUndefInput(DLD, MI, MO, &CrossCopy)) {
-            LLVM_DEBUG(dbgs()
-                       << "Marking operand '" << MO << "' as undef in " << MI);
+          } else if (isUndefInput(DLD, OpMI, MO, &CrossCopy)) {
+            LLVM_DEBUG(dbgs() << "Marking operand '" << MO << "' as undef in "
+                              << OpMI);
             MO.setIsUndef();
             Changed = true;
             if (CrossCopy)

--- a/llvm/test/CodeGen/AMDGPU/detect-dead-lanes.mir
+++ b/llvm/test/CodeGen/AMDGPU/detect-dead-lanes.mir
@@ -402,3 +402,23 @@ body: |
     S_NOP 0, implicit %2.sub2
     S_NOP 0, implicit %2.sub3
 ...
+---
+# Check that operands inside a BUNDLE are visited. MachineBasicBlock's default
+# iterator only walks top-level instructions, so a register referenced both by
+# the BUNDLE header and by a bundled instruction currently gets the undef flag
+# on the header alone, leaving the two disagreeing about whether the bundle
+# reads it.
+# CHECK-LABEL: name: bundle0
+# CHECK: BUNDLE implicit undef %0 {
+# CHECK-NEXT: S_NOP 0, implicit %0
+name: bundle0
+tracksRegLiveness: true
+registers:
+  - { id: 0, class: sreg_32_xm0 }
+body: |
+  bb.0:
+    %0 = IMPLICIT_DEF
+    BUNDLE implicit %0 {
+      S_NOP 0, implicit %0
+    }
+...

--- a/llvm/test/CodeGen/AMDGPU/detect-dead-lanes.mir
+++ b/llvm/test/CodeGen/AMDGPU/detect-dead-lanes.mir
@@ -403,14 +403,12 @@ body: |
     S_NOP 0, implicit %2.sub3
 ...
 ---
-# Check that operands inside a BUNDLE are visited. MachineBasicBlock's default
-# iterator only walks top-level instructions, so a register referenced both by
-# the BUNDLE header and by a bundled instruction currently gets the undef flag
-# on the header alone, leaving the two disagreeing about whether the bundle
-# reads it.
+# Check that operands inside a BUNDLE are visited. A register referenced both
+# by the BUNDLE header and by a bundled instruction must have the undef flag
+# set on both, otherwise the two disagree about whether the bundle reads it.
 # CHECK-LABEL: name: bundle0
 # CHECK: BUNDLE implicit undef %0 {
-# CHECK-NEXT: S_NOP 0, implicit %0
+# CHECK-NEXT: S_NOP 0, implicit undef %0
 name: bundle0
 tracksRegLiveness: true
 registers:

--- a/llvm/test/CodeGen/AMDGPU/detect-dead-lanes.mir
+++ b/llvm/test/CodeGen/AMDGPU/detect-dead-lanes.mir
@@ -406,17 +406,70 @@ body: |
 # Check that operands inside a BUNDLE are visited. A register referenced both
 # by the BUNDLE header and by a bundled instruction must have the undef flag
 # set on both, otherwise the two disagree about whether the bundle reads it.
-# CHECK-LABEL: name: bundle0
+# CHECK-LABEL: name: bundle_undef
 # CHECK: BUNDLE implicit undef %0 {
 # CHECK-NEXT: S_NOP 0, implicit undef %0
-name: bundle0
+name: bundle_undef
 tracksRegLiveness: true
-registers:
-  - { id: 0, class: sreg_32_xm0 }
 body: |
   bb.0:
-    %0 = IMPLICIT_DEF
+    %0:sreg_32_xm0 = IMPLICIT_DEF
     BUNDLE implicit %0 {
       S_NOP 0, implicit %0
+    }
+...
+---
+# Check that an undefined subregister use inside a BUNDLE is marked undef while
+# a defined subregister use is unchanged, and that existing kill flags are
+# preserved.
+# CHECK-LABEL: name: bundle_subregs
+# CHECK: %0:sreg_64 = REG_SEQUENCE $sgpr0, %subreg.sub0
+# CHECK: BUNDLE implicit killed %0.sub0, implicit killed undef %0.sub1 {
+# CHECK-NEXT: S_NOP 0, implicit killed %0.sub0
+# CHECK-NEXT: S_NOP 0, implicit killed undef %0.sub1
+name: bundle_subregs
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $sgpr0
+    %0:sreg_64 = REG_SEQUENCE $sgpr0, %subreg.sub0
+    BUNDLE implicit killed %0.sub0, implicit killed %0.sub1 {
+      S_NOP 0, implicit killed %0.sub0
+      S_NOP 0, implicit killed %0.sub1
+    }
+...
+---
+# Check that unused definitions inside a BUNDLE are marked dead on both the
+# BUNDLE header and the bundled instruction, while used definitions are left
+# unchanged.
+# CHECK-LABEL: name: bundle_defs
+# CHECK: BUNDLE implicit-def %0, implicit-def dead %1 {
+# CHECK-NEXT: S_NOP 0, implicit-def %0
+# CHECK-NEXT: S_NOP 0, implicit-def dead %1
+# CHECK: S_NOP 0, implicit %0.sub0
+name: bundle_defs
+tracksRegLiveness: true
+body: |
+  bb.0:
+    BUNDLE implicit-def %0:sreg_64, implicit-def %1:sreg_64 {
+      S_NOP 0, implicit-def %0
+      S_NOP 0, implicit-def %1
+    }
+    S_NOP 0, implicit %0.sub0
+...
+---
+# Check that a KILL inside a BUNDLE is visited. KILL operands do not count as
+# uses, so the definition becomes dead and the KILL operand becomes undef.
+# CHECK-LABEL: name: bundle_kill
+# CHECK: S_NOP 0, implicit-def dead %0
+# CHECK: BUNDLE implicit undef %0 {
+# CHECK-NEXT: KILL undef %0
+name: bundle_kill
+tracksRegLiveness: true
+body: |
+  bb.0:
+    S_NOP 0, implicit-def %0:sreg_64
+    BUNDLE implicit undef %0 {
+      KILL %0
     }
 ...


### PR DESCRIPTION
`modifySubRegisterOperandStatus` walked each basic block with
`MachineBasicBlock`'s default iterator, which visits only top-level
instructions and steps over the contents of a `BUNDLE`. Dead/undef flags were
therefore only ever updated on the `BUNDLE` header, even though the analysis
half of the pass walks `MRI` use lists and does account for bundle-internal
operands. The pass reasoned about operands it then refused to update.
    
A register referenced both by the header and by a bundled instruction ends up
with the two disagreeing about whether the bundle reads it, and consumers
split on which half they believe: `ScheduleDAGInstrs::buildSchedGraph` and
`LiveIntervals::handleMove` look at the header only, while
`RegisterOperandsCollector` descends into the bundle. The scheduler can then
move a bundle across a dependence it never modelled, and
`RegPressureTracker::recede` asserts on an empty use lane mask.
    
Walk `MBB.instrs()` instead, so the rewrite sees the same operands the analysis
did.