### PR TITLE
[AArch64] Fix vector.match lowering with VLS SVE

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -6557,8 +6557,18 @@ static SDValue LowerVectorMatch(SDValue Op, SelectionDAG &DAG) {
           Op1VT.getVectorElementType() == MVT::i16) &&
          "Expected 8-bit or 16-bit characters.");
 
-  SDValue ID =
-      DAG.getTargetConstant(Intrinsic::aarch64_sve_match, DL, MVT::i64);
+  if (Op2VT.getFixedSizeInBits() > 128) {
+    // For VLS SVE fixed-vector types > 128-bit can be legal. These still need
+    // splitting as `match` works per 128-bit segment.
+    auto [NeedleLo, NeedleHi] = DAG.SplitVector(Op2, DL);
+
+    SDValue MatchLo =
+        DAG.getNode(ISD::VECTOR_MATCH, DL, ResVT, Op1, NeedleLo, Mask);
+    SDValue MatchHi =
+        DAG.getNode(ISD::VECTOR_MATCH, DL, ResVT, Op1, NeedleHi, Mask);
+
+    return DAG.getNode(ISD::OR, DL, ResVT, MatchLo, MatchHi);
+  }
 
   // Scalable vector type used to wrap operands.
   // A single container is enough for both operands because ultimately the
@@ -6585,6 +6595,9 @@ static SDValue LowerVectorMatch(SDValue Op, SelectionDAG &DAG) {
     Op2 = DAG.getSplatVector(Op2PromotedVT, DL, Op2);
     Op2 = DAG.getBitcast(OpContainerVT, Op2);
   }
+
+  SDValue ID =
+      DAG.getTargetConstant(Intrinsic::aarch64_sve_match, DL, MVT::i64);
 
   // If the result is scalable, we just need to carry out the MATCH.
   if (ResVT.isScalableVector())

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -6553,9 +6553,9 @@ static SDValue LowerVectorMatch(SDValue Op, SelectionDAG &DAG) {
       !DAG.getTargetLoweringInfo().isTypeLegal(Op1VT))
     return SDValue();
 
-  assert((Op1VT.getVectorElementType() == MVT::i8 ||
-          Op1VT.getVectorElementType() == MVT::i16) &&
-         "Expected 8-bit or 16-bit characters.");
+  if (Op1VT.getVectorElementType() != MVT::i8 &&
+      Op1VT.getVectorElementType() != MVT::i16)
+    return SDValue();
 
   if (Op2VT.getFixedSizeInBits() > 128) {
     // For VLS SVE fixed-vector types > 128-bit can be legal. These still need

--- a/llvm/test/CodeGen/AArch64/intrinsic-vector-match-sve2.ll
+++ b/llvm/test/CodeGen/AArch64/intrinsic-vector-match-sve2.ll
@@ -549,4 +549,49 @@ define <3 x i1> @match_v3i8_v3i1(<3 x i8> %op1, <8 x i8> %op2, <3 x i1> %mask) #
   ret <3 x i1> %r
 }
 
+define <8 x i1> @match_v8i32_v8i32_vscale_range(<8 x i32> %op1, <8 x i32> %op2, <8 x i1> %mask) #0 vscale_range(2, 2) {
+; CHECK-LABEL: match_v8i32_v8i32_vscale_range:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    // kill: def $q3 killed $q3 killed $z2_z3 def $z2_z3
+; CHECK-NEXT:    ptrue p0.s, vl4
+; CHECK-NEXT:    // kill: def $q1 killed $q1 killed $z0_z1 def $z0_z1
+; CHECK-NEXT:    // kill: def $q2 killed $q2 killed $z2_z3 def $z2_z3
+; CHECK-NEXT:    // kill: def $q0 killed $q0 killed $z0_z1 def $z0_z1
+; CHECK-NEXT:    splice z2.s, p0, { z2.s, z3.s }
+; CHECK-NEXT:    splice z0.s, p0, { z0.s, z1.s }
+; CHECK-NEXT:    ptrue p0.s
+; CHECK-NEXT:    mov z1.s, z2.s[1]
+; CHECK-NEXT:    mov z3.s, s2
+; CHECK-NEXT:    mov z5.s, z2.s[2]
+; CHECK-NEXT:    cmpeq p1.s, p0/z, z0.s, z1.s
+; CHECK-NEXT:    cmpeq p2.s, p0/z, z0.s, z3.s
+; CHECK-NEXT:    mov z1.s, z2.s[3]
+; CHECK-NEXT:    cmpeq p3.s, p0/z, z0.s, z5.s
+; CHECK-NEXT:    mov z3.s, z2.s[4]
+; CHECK-NEXT:    mov p1.b, p2/m, p2.b
+; CHECK-NEXT:    cmpeq p2.s, p0/z, z0.s, z1.s
+; CHECK-NEXT:    mov z1.s, z2.s[5]
+; CHECK-NEXT:    sel p1.b, p1, p1.b, p3.b
+; CHECK-NEXT:    cmpeq p3.s, p0/z, z0.s, z3.s
+; CHECK-NEXT:    mov z3.s, z2.s[6]
+; CHECK-NEXT:    sel p1.b, p1, p1.b, p2.b
+; CHECK-NEXT:    cmpeq p2.s, p0/z, z0.s, z1.s
+; CHECK-NEXT:    mov z1.s, z2.s[7]
+; CHECK-NEXT:    sel p1.b, p1, p1.b, p3.b
+; CHECK-NEXT:    cmpeq p3.s, p0/z, z0.s, z3.s
+; CHECK-NEXT:    sel p1.b, p1, p1.b, p2.b
+; CHECK-NEXT:    cmpeq p2.s, p0/z, z0.s, z1.s
+; CHECK-NEXT:    shl v1.8b, v4.8b, #7
+; CHECK-NEXT:    sel p0.b, p1, p1.b, p3.b
+; CHECK-NEXT:    cmlt v1.8b, v1.8b, #0
+; CHECK-NEXT:    sel p0.b, p0, p0.b, p2.b
+; CHECK-NEXT:    mov z0.s, p0/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    uzp1 z0.h, z0.h, z0.h
+; CHECK-NEXT:    uzp1 z0.b, z0.b, z0.b
+; CHECK-NEXT:    and v0.8b, v0.8b, v1.8b
+; CHECK-NEXT:    ret
+  %r = tail call <8 x i1> @llvm.experimental.vector.match(<8 x i32> %op1, <8 x i32> %op2, <8 x i1> %mask)
+  ret <8 x i1> %r
+}
+
 attributes #0 = { "target-features"="+sve2" }

--- a/llvm/test/CodeGen/AArch64/intrinsic-vector-match-sve2.ll
+++ b/llvm/test/CodeGen/AArch64/intrinsic-vector-match-sve2.ll
@@ -311,6 +311,40 @@ define <vscale x 16 x i1> @match_nxv16i8_v32i8(<vscale x 16 x i8> %op1, <32 x i8
   ret <vscale x 16 x i1> %r
 }
 
+define <vscale x 16 x i1> @match_nxv16i8_v32i8_vscale_range(<vscale x 16 x i8> %op1, <32 x i8> %op2, <vscale x 16 x i1> %mask) #0 vscale_range(2, 2) {
+; CHECK-LABEL: match_nxv16i8_v32i8_vscale_range:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    // kill: def $q2 killed $q2 def $z2
+; CHECK-NEXT:    // kill: def $q1 killed $q1 def $z1
+; CHECK-NEXT:    mov z2.q, q2
+; CHECK-NEXT:    mov z1.q, q1
+; CHECK-NEXT:    match p1.b, p0/z, z0.b, z2.b
+; CHECK-NEXT:    match p2.b, p0/z, z0.b, z1.b
+; CHECK-NEXT:    sel p0.b, p2, p2.b, p1.b
+; CHECK-NEXT:    ret
+  %r = tail call <vscale x 16 x i1> @llvm.experimental.vector.match(<vscale x 16 x i8> %op1, <32 x i8> %op2, <vscale x 16 x i1> %mask)
+  ret <vscale x 16 x i1> %r
+}
+
+define <16 x i1> @match_v16i8_v32i8_vscale_range(<16 x i8> %op1, <32 x i8> %op2, <16 x i1> %mask) #0 vscale_range(2, 2) {
+; CHECK-LABEL: match_v16i8_v32i8_vscale_range:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    shl v3.16b, v3.16b, #7
+; CHECK-NEXT:    ptrue p0.b, vl16
+; CHECK-NEXT:    // kill: def $q2 killed $q2 def $z2
+; CHECK-NEXT:    // kill: def $q1 killed $q1 def $z1
+; CHECK-NEXT:    // kill: def $q0 killed $q0 def $z0
+; CHECK-NEXT:    cmpne p1.b, p0/z, z3.b, #0
+; CHECK-NEXT:    match p0.b, p1/z, z0.b, z2.b
+; CHECK-NEXT:    match p2.b, p1/z, z0.b, z1.b
+; CHECK-NEXT:    mov z0.b, p0/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    mov z1.b, p2/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    orr v0.16b, v1.16b, v0.16b
+; CHECK-NEXT:    ret
+  %r = tail call <16 x i1> @llvm.experimental.vector.match(<16 x i8> %op1, <32 x i8> %op2, <16 x i1> %mask)
+  ret <16 x i1> %r
+}
+
 define <16 x i1> @match_v16i8_v32i8(<16 x i8> %op1, <32 x i8> %op2, <16 x i1> %mask) #0 {
 ; CHECK-LABEL: match_v16i8_v32i8:
 ; CHECK:       // %bb.0:


### PR DESCRIPTION
With `vscale_range()` fixed-vector types > 128-bit can be legal. If these are used as a `vector.match` needle we still need to split them as match works per 128-bit segment.

Also, masks such as `v8i1` become legal for types other than i8 and i16, so we can't assert the source operands are `i8` or `i16`.