### PR TITLE
[AMDGPU][GlobalISel] Avoid 64-bit width V_BFE

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeHelper.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeHelper.cpp
@@ -769,9 +769,13 @@ bool RegBankLegalizeHelper::lowerV_BFE(MachineInstr &MI) {
     }
     B.buildMergeLikeInstr(Dst, {Lo, Hi});
   } else {
-    auto Amt = B.buildConstant(VgprRB_I32, WidthImm - 32);
     // SHRSrc Hi|Lo: ??????sy|yyyyyyyl -> sssssssy|yyyyyyyl
-    auto Hi = B.buildInstr(BFXOpc, {VgprRB_I32}, {SHRSrcHi, Zero, Amt});
+    Register Hi = SHRSrcHi;
+    // V_BFE masks its width to 5 bits, so 64 would extract zero bits.
+    if (WidthImm < 64) {
+      auto Amt = B.buildConstant(VgprRB_I32, WidthImm - 32);
+      Hi = B.buildInstr(BFXOpc, {VgprRB_I32}, {SHRSrcHi, Zero, Amt}).getReg(0);
+    }
     B.buildMergeLikeInstr(Dst, {SHRSrcLo, Hi});
   }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/llvm.amdgcn.sbfe.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/llvm.amdgcn.sbfe.ll
@@ -58,6 +58,16 @@ define i64 @v_bfe_i64_arg_arg_imm_width_33(i64 %src0, i32 %src1) #0 {
   ret i64 %bfe_i64
 }
 
+define i64 @v_bfe_i64_arg_arg_imm_width_64(i64 %src0, i32 %src1) #0 {
+; GFX6-LABEL: v_bfe_i64_arg_arg_imm_width_64:
+; GFX6:       ; %bb.0:
+; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX6-NEXT:    v_ashr_i64 v[0:1], v[0:1], v2
+; GFX6-NEXT:    s_setpc_b64 s[30:31]
+  %bfe_i64 = call i64 @llvm.amdgcn.sbfe.i64(i64 %src0, i32 %src1, i32 64)
+  ret i64 %bfe_i64
+}
+
 define amdgpu_ps i64 @s_bfe_i64_arg_arg_arg(i64 inreg %src0, i32 inreg %src1, i32 inreg %src2) #0 {
 ; GFX6-LABEL: s_bfe_i64_arg_arg_arg:
 ; GFX6:       ; %bb.0:

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/llvm.amdgcn.ubfe.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/llvm.amdgcn.ubfe.ll
@@ -58,6 +58,16 @@ define i64 @v_bfe_i64_arg_arg_imm_width_33(i64 %src0, i32 %src1) #0 {
   ret i64 %bfe_i64
 }
 
+define i64 @v_bfe_i64_arg_arg_imm_width_64(i64 %src0, i32 %src1) #0 {
+; GFX6-LABEL: v_bfe_i64_arg_arg_imm_width_64:
+; GFX6:       ; %bb.0:
+; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX6-NEXT:    v_lshr_b64 v[0:1], v[0:1], v2
+; GFX6-NEXT:    s_setpc_b64 s[30:31]
+  %bfe_i64 = call i64 @llvm.amdgcn.ubfe.i64(i64 %src0, i32 %src1, i32 64)
+  ret i64 %bfe_i64
+}
+
 define amdgpu_ps i64 @s_bfe_i64_arg_arg_arg(i64 inreg %src0, i32 inreg %src1, i32 inreg %src2) #0 {
 ; GFX6-LABEL: s_bfe_i64_arg_arg_arg:
 ; GFX6:       ; %bb.0:


### PR DESCRIPTION
V_BFE masks its width operand to 5 bits, so extracting the high half with width 64-32 zeroed it instead of passing it through