### PR TITLE
Fix Bazel build for e4ef6e5

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -4554,16 +4554,12 @@ cc_library(
 
 cc_library(
     name = "OrcTargetProcess",
-    srcs = glob(
-        [
-            "lib/ExecutionEngine/Orc/TargetProcess/*.cpp",
-            "lib/ExecutionEngine/Orc/TargetProcess/*.h",
-        ],
-        exclude = ["lib/ExecutionEngine/Orc/TargetProcess/OrcRTBootstrap.h"],
-    ),
+    srcs = glob([
+        "lib/ExecutionEngine/Orc/TargetProcess/*.cpp",
+    ]),
     hdrs = glob([
         "include/llvm/ExecutionEngine/Orc/TargetProcess/*.h",
-    ]) + ["lib/ExecutionEngine/Orc/TargetProcess/OrcRTBootstrap.h"],
+    ]),
     copts = llvm_copts,
     linkopts = select({
         "@platforms//os:android": [],


### PR DESCRIPTION
Buildkite error link: https://buildkite.com/llvm-project/upstream-bazel/builds?commit=e4ef6e5ba3c82ec467840774949f38eb7085d7a8