### PR TITLE
[flang] Warn when an INTENT(IN) dummy is passed to a dummy with no INTENT

### DIFF
--- a/flang/include/flang/Support/Fortran-features.h
+++ b/flang/include/flang/Support/Fortran-features.h
@@ -88,7 +88,7 @@ ENUM_CLASS(UsageWarning, Portability, PointerToUndefinable,
     UsedUndefinedVariable, BadValueInDeadCode, AssumedTypeSizeDummy,
     MisplacedIgnoreTKR, NamelistParameter, ImpureFinalInPure,
     IgnoredNoReallocateLHS, ExperimentalOption, IoImpliedDoIndexConflict,
-    BOZLiteralTruncation)
+    BOZLiteralTruncation, IntentInActualForDefaultIntent)
 
 using LanguageFeatures = EnumSet<LanguageFeature, LanguageFeature_enumSize>;
 using UsageWarnings = EnumSet<UsageWarning, UsageWarning_enumSize>;

--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -836,6 +836,25 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
     }
   }
 
+  // An INTENT(IN) dummy argument must not be defined during the invocation
+  // and execution of its procedure (F'2023 8.5.10 p2), but a dummy argument
+  // with no INTENT attribute may be defined by its procedure.  Passing the
+  // former to the latter is thus a latent violation of INTENT(IN), and the
+  // optimizer is entitled to assume that it doesn't happen.
+  if (dummy.intent == common::Intent::Default && !dummyIsValue && !intrinsic &&
+      !procedure.IsPure() && actualFirstSymbol) {
+    const Symbol &actualRoot{GetAssociationRoot(*actualFirstSymbol)};
+    if (IsIntentIn(actualRoot) && !IsValue(actualRoot)) {
+      if (auto *msg{foldingContext.Warn(
+              common::UsageWarning::IntentInActualForDefaultIntent,
+              "INTENT(IN) dummy argument '%s' is associated with %s, which has no INTENT attribute and could be defined"_warn_en_US,
+              actualRoot.name(), dummyName)}) {
+        msg->Attach(
+            actualRoot.name(), "Declaration of '%s'"_en_US, actualRoot.name());
+      }
+    }
+  }
+
   bool dummyIsContiguous{
       dummy.attrs.test(characteristics::DummyDataObject::Attr::Contiguous)};
   bool actualIsContiguous{IsSimplyContiguous(actual, foldingContext)};

--- a/flang/test/Semantics/call49.f90
+++ b/flang/test/Semantics/call49.f90
@@ -1,0 +1,60 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1 -Wintent-in-actual-for-default-intent -Werror
+
+! An INTENT(IN) dummy argument must not be defined during the execution of its
+! procedure (F'2023 8.5.10 p2); passing one to a dummy argument that has no
+! INTENT attribute risks exactly that.
+
+module m
+  type t
+    integer :: n
+  end type
+ contains
+  subroutine noIntent(n)
+    integer :: n
+  end subroutine
+  subroutine intentIn(n)
+    integer, intent(in) :: n
+  end subroutine
+  subroutine byValue(n)
+    integer, value :: n
+  end subroutine
+  pure subroutine pureSub(n)
+    integer, intent(in) :: n
+  end subroutine
+  subroutine test(k, j, v, arr, dt)
+    integer, intent(in) :: k, arr(:)
+    integer, intent(in out) :: j
+    integer, intent(in), value :: v
+    type(t), intent(in) :: dt
+    !WARNING: INTENT(IN) dummy argument 'k' is associated with dummy argument 'n=', which has no INTENT attribute and could be defined [-Wintent-in-actual-for-default-intent]
+    call noIntent(k)
+    !WARNING: INTENT(IN) dummy argument 'arr' is associated with dummy argument 'n=', which has no INTENT attribute and could be defined [-Wintent-in-actual-for-default-intent]
+    call noIntent(arr(1))
+    !WARNING: INTENT(IN) dummy argument 'dt' is associated with dummy argument 'n=', which has no INTENT attribute and could be defined [-Wintent-in-actual-for-default-intent]
+    call noIntent(dt%n)
+    call intentIn(k) ! ok
+    call byValue(k) ! ok, cannot be defined
+    call pureSub(k) ! ok
+    call noIntent(j) ! ok, INTENT(IN OUT)
+    call noIntent(v) ! ok, VALUE actual is a local copy
+    call noIntent(k + 0) ! ok, not a variable
+   contains
+    subroutine inner
+      !WARNING: INTENT(IN) dummy argument 'k' is associated with dummy argument 'n=', which has no INTENT attribute and could be defined [-Wintent-in-actual-for-default-intent]
+      call noIntent(k) ! host association
+    end subroutine
+  end subroutine
+end module
+
+! The motivating case: the callee's interface is implicit at the point of
+! the call, but its definition is available in the same source file.
+subroutine callsExternal(k)
+  integer, intent(in) :: k
+  !WARNING: INTENT(IN) dummy argument 'k' is associated with dummy argument 'n=', which has no INTENT attribute and could be defined [-Wintent-in-actual-for-default-intent]
+  call externalNoIntent(k)
+end subroutine
+
+subroutine externalNoIntent(n)
+  integer :: n
+  n = 3
+end subroutine


### PR DESCRIPTION
F'2023 8.5.10 paragraph 2 requires that a nonpointer INTENT(IN) dummy argument "shall neither be defined nor become undefined during the invocation and execution of the procedure". A program can violate that requirement without any diagnostic today by passing the INTENT(IN) dummy argument on as an actual argument to a procedure whose corresponding dummy argument has no INTENT attribute: that callee is free to define its dummy argument, and since #207732 flang propagates INTENT(IN) to LLVM as `readonly`, so the optimizer is entitled to assume the definition never happens. The observable result is a program whose answers change with the optimization level, with nothing pointing at the cause.

```fortran
program main
  integer :: kk = 1
  call s(kk)
  print *, kk     ! 1 at -O1, 3 at -O2
 contains
  subroutine s(k)
    intent(in) :: k
    call ss(k)
  end subroutine
end

subroutine ss(k)
  k = 3
end
```

The program above is not conforming, so no diagnostic is required, but it is cheap for us to point at the exact place where the promise is broken:

```
warning: INTENT(IN) dummy argument 'k' is associated with dummy argument 'k=', which has no INTENT attribute and could be defined [-Wintent-in-actual-for-default-intent]
    call ss(k)
            ^
  Declaration of 'k'
  subroutine s(k)
               ^
```

The warning is off by default and is enabled either by `-Wintent-in-actual-for-default-intent` or by `-pedantic`.

Assisted-by: AI