### PR TITLE
[Clang] Put compat diagnostics in the pedantic group iff ext_warn==false

### DIFF
--- a/clang/include/clang/Basic/Diagnostic.td
+++ b/clang/include/clang/Basic/Diagnostic.td
@@ -224,8 +224,8 @@ multiclass CompatWarning<
                     !strconcat(message, " incompatible with C++98"),
                     !strconcat(message, " incompatible with ", lang, " standards before ", lang, std_ver_name))>,
         InGroup<!cast<DiagGroup>(!if(is_cxx_11,
-                                     prefix#"98Compat",
-                                     prefix#"Pre"#diag_group_ver_str#"Compat"))>,
+                                     !strconcat(prefix, "98Compat", !if(ext_warn, "", "Pedantic")),
+                                     !strconcat(prefix, "Pre", diag_group_ver_str, "Compat", !if(ext_warn, "", "Pedantic"))))>,
         DefaultIgnore;
 
     def : CompatWarningId<

--- a/clang/include/clang/Basic/DiagnosticLexKinds.td
+++ b/clang/include/clang/Basic/DiagnosticLexKinds.td
@@ -15,6 +15,14 @@ let Component = "Lex", CategoryName = "Lexical or Preprocessor Issue" in {
 defm c23_pp_directive : C23Compat<
   "use of a '#%select{<BUG IF SEEN>|elifdef|elifndef}0' directive is", /*ext_warn*/true>;
 
+// C++11 compatibility with C++98.
+defm empty_fnmacro_arg : CXX11Compat<
+  "empty macro arguments are", /*ext_warn*/false>;
+
+// C++17 compatibility with C++14 and earlier.
+defm hex_literal : CXX17Compat<
+  "hexadecimal floating literals are", /*ext_warn*/false>;
+
 // C++23 compatibility with C++20 and earlier.
 defm cxx23_pp_directive : CXX23Compat<
   "use of a '#%select{<BUG IF SEEN>|elifdef|elifndef}0' directive is">;
@@ -260,12 +268,6 @@ def err_hex_constant_requires : Error<
   "%select{an exponent|a significand}1">;
 def ext_hex_constant_invalid : Extension<
   "hexadecimal floating constants are a C99 feature">, InGroup<C99>;
-def ext_hex_literal_invalid : Extension<
-  "hexadecimal floating literals are a C++17 feature">, InGroup<CXX17>;
-def warn_cxx17_hex_literal : Warning<
-  "hexadecimal floating literals are incompatible with "
-  "C++ standards before C++17">,
-  InGroup<CXXPre17CompatPedantic>, DefaultIgnore;
 def ext_octal_literal : Extension<
   "octal integer literals are a C2y extension">, InGroup<C2y>;
 def ext_cpp_octal_literal : Extension<
@@ -545,9 +547,6 @@ def warn_cxx17_compat_missing_varargs_arg : Warning<
   InGroup<CXXPre20Compat>, DefaultIgnore;
 def ext_empty_fnmacro_arg : Extension<
   "empty macro arguments are a C99 feature">, InGroup<C99>;
-def warn_cxx98_compat_empty_fnmacro_arg : Warning<
-  "empty macro arguments are incompatible with C++98">,
-  InGroup<CXX98CompatPedantic>, DefaultIgnore;
 def note_macro_here : Note<"macro %0 defined here">;
 def note_macro_expansion_here : Note<"expansion of macro %0 requested here">;
 

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -46,6 +46,9 @@ defm nonstatic_member_init : CXX11Compat<
 defm alias_declaration : CXX11Compat<"alias declarations are">;
 defm override_control_keyword : CXX11Compat<"'%0' keyword is">;
 defm inline_namespace : CXX11Compat<"inline namespaces are">;
+defm extern_template : CXX11Compat<"extern templates are", /*ext_warn*/false>;
+defm cxx_enumerator_list_comma : CXX11Compat<
+  "commas at the end of enumerator lists are", /*ext_warn*/false>;
 
 // C++14 compatibility with C++11 and earlier.
 defm decltype_auto_type_specifier : CXX14Compat<
@@ -184,12 +187,6 @@ def ext_c99_compound_literal : Extension<
 def ext_enumerator_list_comma_c : Extension<
   "commas at the end of enumerator lists are a C99-specific "
   "feature">, InGroup<C99>;
-def ext_enumerator_list_comma_cxx : Extension<
-  "commas at the end of enumerator lists are a C++11 extension">,
-  InGroup<CXX11>;
-def warn_cxx98_compat_enumerator_list_comma : Warning<
-  "commas at the end of enumerator lists are incompatible with C++98">,
-  InGroup<CXX98CompatPedantic>, DefaultIgnore;
 def err_enumerator_list_missing_comma : Error<
   "missing ',' between enumerators">;
 def err_enumerator_unnamed_no_def : Error<
@@ -877,11 +874,6 @@ def err_cxx26_template_template_params
     : Error<"%select{variable template|concept}0 template parameter is a C++2c "
             "extension">;
 
-def ext_extern_template : Extension<
-  "extern templates are a C++11 extension">, InGroup<CXX11>;
-def warn_cxx98_compat_extern_template : Warning<
-  "extern templates are incompatible with C++98">,
-  InGroup<CXX98CompatPedantic>, DefaultIgnore;
 def warn_static_inline_explicit_inst_ignored : Warning<
   "ignoring '%select{static|inline}0' keyword on explicit template "
   "instantiation">, InGroup<DiagGroup<"static-inline-explicit-instantiation">>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -38,6 +38,12 @@ defm template_outside_of_template : CXX11Compat<
   "use of 'template' keyword outside of a template is">;
 defm explicit_conversion_functions : CXX11Compat<
   "explicit conversion functions are">;
+defm cast_fn_obj : CXX11Compat<
+  "cast between pointer-to-function and pointer-to-object is",
+  /*ext_warn*/false>;
+defm array_size_conversion : CXX11Compat<
+  "implicit conversion from array size expression of type %0 to "
+  "%select{integral|enumeration}1 type %2 is", /*ext_warn*/false>;
 
 // C++14 compatibility with C++11 and earlier.
 defm constexpr_type_definition : CXX14Compat<
@@ -8544,14 +8550,9 @@ def ext_bad_cxx_cast_qualifiers_away_incoherent : ExtWarn<
 def err_bad_const_cast_dest : Error<
   "%select{const_cast||||C-style cast|functional-style cast|}0 to %2, "
   "which is not a reference, pointer-to-object, or pointer-to-data-member">;
-def ext_cast_fn_obj : Extension<
-  "cast between pointer-to-function and pointer-to-object is an extension">;
 def ext_ms_cast_fn_obj : ExtWarn<
   "static_cast between pointer-to-function and pointer-to-object is a "
   "Microsoft extension">, InGroup<MicrosoftCast>;
-def warn_cxx98_compat_cast_fn_obj : Warning<
-  "cast between pointer-to-function and pointer-to-object is incompatible with C++98">,
-  InGroup<CXX98CompatPedantic>, DefaultIgnore;
 def err_bad_reinterpret_cast_small_int : Error<
   "cast from pointer to smaller type %2 loses information">;
 def err_bad_cxx_cast_vector_to_scalar_different_size : Error<
@@ -8651,14 +8652,6 @@ def note_array_size_conversion : Note<
 def err_array_size_ambiguous_conversion : Error<
   "ambiguous conversion of array size expression of type %0 to an integral or "
   "enumeration type">;
-def ext_array_size_conversion : Extension<
-  "implicit conversion from array size expression of type %0 to "
-  "%select{integral|enumeration}1 type %2 is a C++11 extension">,
-  InGroup<CXX11>;
-def warn_cxx98_compat_array_size_conversion : Warning<
-  "implicit conversion from array size expression of type %0 to "
-  "%select{integral|enumeration}1 type %2 is incompatible with C++98">,
-  InGroup<CXX98CompatPedantic>, DefaultIgnore;
 def err_address_space_qualified_new : Error<
   "'new' cannot allocate objects of type %0 in address space '%1'">;
 def err_address_space_qualified_delete : Error<

--- a/clang/lib/Lex/LiteralSupport.cpp
+++ b/clang/lib/Lex/LiteralSupport.cpp
@@ -1439,10 +1439,10 @@ void NumericLiteralParser::ParseNumberStartingWithZero(SourceLocation TokLoc) {
 
       if (!LangOpts.HexFloats)
         Diags.Report(TokLoc, LangOpts.CPlusPlus
-                                 ? diag::ext_hex_literal_invalid
+                                 ? diag::compat_pre_cxx17_hex_literal
                                  : diag::ext_hex_constant_invalid);
       else if (LangOpts.CPlusPlus17)
-        Diags.Report(TokLoc, diag::warn_cxx17_hex_literal);
+        Diags.Report(TokLoc, diag::compat_cxx17_hex_literal);
     } else if (saw_period) {
       Diags.Report(Lexer::AdvanceToTokenCharacter(TokLoc, s - ThisTokBegin, SM,
                                                   LangOpts),

--- a/clang/lib/Lex/PPMacroExpansion.cpp
+++ b/clang/lib/Lex/PPMacroExpansion.cpp
@@ -854,10 +854,12 @@ MacroArgs *Preprocessor::ReadMacroCallArgumentList(Token &MacroName,
 
     // Empty arguments are standard in C99 and C++0x, and are supported as an
     // extension in other modes.
-    if (ArgTokens.size() == ArgTokenStart && !getLangOpts().C99)
-      Diag(Tok, getLangOpts().CPlusPlus11
-                    ? diag::warn_cxx98_compat_empty_fnmacro_arg
-                    : diag::ext_empty_fnmacro_arg);
+    if (ArgTokens.size() == ArgTokenStart && !getLangOpts().C99) {
+      if (getLangOpts().CPlusPlus)
+        DiagCompat(Tok, diag_compat::empty_fnmacro_arg);
+      else
+        Diag(Tok, diag::ext_empty_fnmacro_arg);
+    }
 
     // Add a marker EOF token to the end of the token list for this argument.
     Token EOFTok;

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -5528,14 +5528,12 @@ void Parser::ParseEnumBody(SourceLocation StartLoc, Decl *EnumDecl,
 
     // If comma is followed by r_brace, emit appropriate warning.
     if (Tok.is(tok::r_brace) && CommaLoc.isValid()) {
-      if (!getLangOpts().C99 && !getLangOpts().CPlusPlus11)
-        Diag(CommaLoc, getLangOpts().CPlusPlus ?
-               diag::ext_enumerator_list_comma_cxx :
-               diag::ext_enumerator_list_comma_c)
-          << FixItHint::CreateRemoval(CommaLoc);
-      else if (getLangOpts().CPlusPlus11)
-        Diag(CommaLoc, diag::warn_cxx98_compat_enumerator_list_comma)
-          << FixItHint::CreateRemoval(CommaLoc);
+      if (getLangOpts().CPlusPlus)
+        DiagCompat(CommaLoc, diag_compat::cxx_enumerator_list_comma)
+            << FixItHint::CreateRemoval(CommaLoc);
+      else if (!getLangOpts().C99)
+        Diag(CommaLoc, diag::ext_enumerator_list_comma_c)
+            << FixItHint::CreateRemoval(CommaLoc);
       break;
     }
   }

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -968,9 +968,8 @@ Parser::ParseExternalDeclaration(ParsedAttributes &Attrs,
       // Extern templates
       SourceLocation ExternLoc = ConsumeToken();
       SourceLocation TemplateLoc = ConsumeToken();
-      Diag(ExternLoc, getLangOpts().CPlusPlus11 ?
-             diag::warn_cxx98_compat_extern_template :
-             diag::ext_extern_template) << SourceRange(ExternLoc, TemplateLoc);
+      DiagCompat(ExternLoc, diag_compat::extern_template)
+          << SourceRange(ExternLoc, TemplateLoc);
       SourceLocation DeclEnd;
       return ParseExplicitInstantiation(DeclaratorContext::File, ExternLoc,
                                         TemplateLoc, DeclEnd, Attrs);

--- a/clang/lib/Sema/SemaCast.cpp
+++ b/clang/lib/Sema/SemaCast.cpp
@@ -2612,19 +2612,13 @@ static TryCastResult TryReinterpretCast(Sema &Self, ExprResult &SrcExpr,
     // casting the return value of dlsym() and GetProcAddress().
     // FIXME: Conditionally-supported behavior should be configurable in the
     // TargetInfo or similar.
-    Self.Diag(OpRange.getBegin(),
-              Self.getLangOpts().CPlusPlus11 ?
-                diag::warn_cxx98_compat_cast_fn_obj : diag::ext_cast_fn_obj)
-      << OpRange;
+    Self.DiagCompat(OpRange.getBegin(), diag_compat::cast_fn_obj) << OpRange;
     return SuccessResult;
   }
 
   if (DestType->isFunctionPointerType()) {
     // See above.
-    Self.Diag(OpRange.getBegin(),
-              Self.getLangOpts().CPlusPlus11 ?
-                diag::warn_cxx98_compat_cast_fn_obj : diag::ext_cast_fn_obj)
-      << OpRange;
+    Self.DiagCompat(OpRange.getBegin(), diag_compat::cast_fn_obj) << OpRange;
     return SuccessResult;
   }
 

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -2319,7 +2319,7 @@ ExprResult Sema::BuildCXXNew(SourceRange Range, bool UseGlobal,
 
       if (!ConvertedSize.isInvalid() && (*ArraySize)->getType()->isRecordType())
         // Diagnose the compatibility of this conversion.
-        Diag(StartLoc, diag::warn_cxx98_compat_array_size_conversion)
+        Diag(StartLoc, diag::compat_cxx11_array_size_conversion)
           << (*ArraySize)->getType() << 0 << "'size_t'";
     } else {
       class SizeConvertDiagnoser : public ICEConvertDiagnoser {
@@ -2368,11 +2368,8 @@ ExprResult Sema::BuildCXXNew(SourceRange Range, bool UseGlobal,
         SemaDiagnosticBuilder diagnoseConversion(Sema &S, SourceLocation Loc,
                                                  QualType T,
                                                  QualType ConvTy) override {
-          return S.Diag(Loc,
-                        S.getLangOpts().CPlusPlus11
-                          ? diag::warn_cxx98_compat_array_size_conversion
-                          : diag::ext_array_size_conversion)
-                   << T << ConvTy->isEnumeralType() << ConvTy;
+          return S.DiagCompat(Loc, diag_compat::array_size_conversion)
+                 << T << ConvTy->isEnumeralType() << ConvTy;
         }
       } SizeDiagnoser(*ArraySize);
 

--- a/clang/test/C/C23/n2508.c
+++ b/clang/test/C/C23/n2508.c
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -verify -std=c23 %s
 // RUN: %clang_cc1 -verify=pedantic -std=c11 -pedantic %s
-// RUN: %clang_cc1 -verify=compat -std=c23 -Wpre-c23-compat %s
+// RUN: %clang_cc1 -verify=compat -std=c23 -Wpre-c23-compat-pedantic %s
 
 // expected-no-diagnostics
 

--- a/clang/test/C/C2y/n3259.c
+++ b/clang/test/C/C2y/n3259.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple=x86_64 -std=c2y -Wall -pedantic -Wno-unused -Wpre-c2y-compat -verify=pre-c2y %s -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 -triple=x86_64 -std=c2y -Wall -pedantic -Wno-unused -Wpre-c2y-compat-pedantic -verify=pre-c2y %s -emit-llvm -o - | FileCheck %s
 // RUN: %clang_cc1 -triple=x86_64 -std=c23 -Wall -pedantic -Wno-unused %s -verify -emit-llvm -o - | FileCheck %s
 
 /* WG14 N3259: Yes

--- a/clang/test/C/C2y/n3260.c
+++ b/clang/test/C/C2y/n3260.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -verify -std=c2y -Wall -pedantic -Wpre-c2y-compat %s
+// RUN: %clang_cc1 -verify -std=c2y -Wall -pedantic -Wpre-c2y-compat-pedantic %s
 // RUN: %clang_cc1 -verify=pre-c2y -std=c23 -Wall -pedantic %s
 
 /* WG14 N3260: Clang 17

--- a/clang/test/C/C2y/n3273.c
+++ b/clang/test/C/C2y/n3273.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -verify -std=c2y -Wall -pedantic -Wpre-c2y-compat %s
+// RUN: %clang_cc1 -verify -std=c2y -Wall -pedantic -Wpre-c2y-compat-pedantic %s
 // RUN: %clang_cc1 -verify=pre-c2y -std=c23 -Wall -pedantic %s
 
 /* WG14 N3273: Clang 3.5
@@ -11,4 +11,3 @@ static_assert(
                      */
   alignof(int)
 );
-

--- a/clang/test/C/C2y/n3298.c
+++ b/clang/test/C/C2y/n3298.c
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -verify=ped -std=c23 -Wall -pedantic %s
 // RUN: %clang_cc1 -verify=yay -std=c2y -Wall -pedantic %s
-// RUN: %clang_cc1 -verify=pre -std=c2y -Wpre-c2y-compat -Wall -pedantic %s
+// RUN: %clang_cc1 -verify=pre -std=c2y -Wpre-c2y-compat-pedantic -Wall -pedantic %s
 // RUN: %clang_cc1 -verify=gnu -Wall -Wgnu -x c++ %s
 // RUN: %clang_cc1 -verify=yay -Wall -Wgnu -Wno-gnu-imaginary-constant -x c++ %s
 
@@ -101,4 +101,3 @@ static_assert(_Generic(12.0Jl, _Complex long double : 1, default : 0)); /* gnu-w
                                                                            ped-warning {{imaginary constants are a C2y extension}}
                                                                            pre-warning {{imaginary constants are incompatible with C standards before C2y}}
                                                                          */
-

--- a/clang/test/C/C2y/n3353.c
+++ b/clang/test/C/C2y/n3353.c
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -verify=expected,c2y,c -pedantic -std=c2y -Wno-gnu-line-marker %s
-// RUN: %clang_cc1 -verify=expected,c2y,compat -Wpre-c2y-compat -std=c2y -Wno-gnu-line-marker %s
+// RUN: %clang_cc1 -verify=expected,c2y,compat -Wpre-c2y-compat-pedantic -std=c2y -Wno-gnu-line-marker %s
 // RUN: %clang_cc1 -verify=expected,ext,c -pedantic -std=c23 -Wno-gnu-line-marker %s
 // RUN: %clang_cc1 -verify=expected,cpp -pedantic -x c++ -Wno-c11-extensions -Wno-gnu-line-marker %s
 

--- a/clang/test/C/C2y/n3409.c
+++ b/clang/test/C/C2y/n3409.c
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -verify -std=c2y -pedantic -Wno-unused %s
-// RUN: %clang_cc1 -verify=expected,pre-c2y -std=c2y -Wpre-c2y-compat -Wno-unused %s
+// RUN: %clang_cc1 -verify=expected,pre-c2y -std=c2y -Wpre-c2y-compat-pedantic -Wno-unused %s
 // RUN: %clang_cc1 -verify=expected,ext -std=c23 -pedantic -Wno-unused %s
 
 /* WG14 N3409: Clang 21

--- a/clang/test/CXX/drs/cwg1xx.cpp
+++ b/clang/test/CXX/drs/cwg1xx.cpp
@@ -632,7 +632,7 @@ namespace example3 {
 struct Base {
 private:
   static const int i = 10; // #cwg138-ex3-Base-i
-  
+
 public:
   struct Data;
   // Elaborated type specifier is not the sole constituent of declaration,
@@ -646,7 +646,7 @@ public:
   };
 };
 struct Data {
-  void f() {  
+  void f() {
     int i2 = Base::i;
     // expected-error@-1 {{'i' is a private member of 'cwg138::example3::Base'}}
     //   expected-note@#cwg138-ex3-Base-i {{declared private here}}
@@ -1415,9 +1415,9 @@ namespace cwg194 { // cwg194: 2.7
 namespace cwg195 { // cwg195: 2.7
   void f();
   int *p = (int*)&f;
-  // cxx98-error@-1 {{cast between pointer-to-function and pointer-to-object is an extension}}
+  // cxx98-error@-1 {{cast between pointer-to-function and pointer-to-object is a C++11 extension}}
   void (*q)() = (void(*)())&p;
-  // cxx98-error@-1 {{cast between pointer-to-function and pointer-to-object is an extension}}
+  // cxx98-error@-1 {{cast between pointer-to-function and pointer-to-object is a C++11 extension}}
 } // namespace cwg195
 
 namespace cwg197 { // cwg197: 2.7

--- a/clang/test/CXX/drs/cwg5xx.cpp
+++ b/clang/test/CXX/drs/cwg5xx.cpp
@@ -904,9 +904,9 @@ namespace cwg573 { // cwg573: no
   void *a;
   int *b = reinterpret_cast<int*>(a);
   void (*c)() = reinterpret_cast<void(*)()>(a);
-  // cxx98-error@-1 {{cast between pointer-to-function and pointer-to-object is an extension}}
+  // cxx98-error@-1 {{cast between pointer-to-function and pointer-to-object is a C++11 extension}}
   void *d = reinterpret_cast<void*>(c);
-  // cxx98-error@-1 {{cast between pointer-to-function and pointer-to-object is an extension}}
+  // cxx98-error@-1 {{cast between pointer-to-function and pointer-to-object is a C++11 extension}}
   void f() { delete a; }
   // cxx98-23-error@-1 {{cannot delete expression with pointer-to-'void' type 'void *'}}
   // since-cxx26-error@-2 {{cannot delete pointer to incomplete type 'void'}}

--- a/clang/test/Lexer/cxx2c-raw-strings.cpp
+++ b/clang/test/Lexer/cxx2c-raw-strings.cpp
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -std=c++11 -fsyntax-only -verify=precxx26,expected -Wc++26-extensions %s
-// RUN: %clang_cc1 -std=c++2c -fsyntax-only -verify=cxx26,expected -Wpre-c++26-compat %s
+// RUN: %clang_cc1 -std=c++2c -fsyntax-only -verify=cxx26,expected -Wpre-c++26-compat-pedantic %s
 
 int main() {
   (void) R"abc`@$(foobar)abc`@$";

--- a/clang/test/Lexer/hexfloat.cpp
+++ b/clang/test/Lexer/hexfloat.cpp
@@ -1,19 +1,13 @@
-// RUN: %clang_cc1 -std=c++98 -fsyntax-only -verify -pedantic %s
-// RUN: %clang_cc1 -std=c++11 -fsyntax-only -verify -pedantic %s
-// RUN: %clang_cc1 -std=c++14 -fsyntax-only -verify -pedantic %s
+// RUN: %clang_cc1 -std=c++98 -fsyntax-only -verify=expected,cxx17-ext -pedantic %s
+// RUN: %clang_cc1 -std=c++11 -fsyntax-only -verify=expected,cxx17-ext -pedantic %s
+// RUN: %clang_cc1 -std=c++14 -fsyntax-only -verify=expected,cxx17-ext -pedantic %s
 // RUN: %clang_cc1 -std=c++17 -fsyntax-only -verify -pedantic %s
 double e = 0x.p0; // expected-error-re {{hexadecimal floating {{constant|literal}} requires a significand}}
 
-float f = 0x1p+1;
-double d = 0x.2p2;
-float g = 0x1.2p2;
-double h = 0x1.p2;
-#if __cplusplus <= 201402L
-// expected-warning@-5 {{hexadecimal floating literals are a C++17 feature}}
-// expected-warning@-5 {{hexadecimal floating literals are a C++17 feature}}
-// expected-warning@-5 {{hexadecimal floating literals are a C++17 feature}}
-// expected-warning@-5 {{hexadecimal floating literals are a C++17 feature}}
-#endif
+float f = 0x1p+1;  // cxx17-ext-warning {{hexadecimal floating literals are a C++17 extension}}
+double d = 0x.2p2; // cxx17-ext-warning {{hexadecimal floating literals are a C++17 extension}}
+float g = 0x1.2p2; // cxx17-ext-warning {{hexadecimal floating literals are a C++17 extension}}
+double h = 0x1.p2; // cxx17-ext-warning {{hexadecimal floating literals are a C++17 extension}}
 
 // PR12717: In order to minimally diverge from the C++ standard, we do not lex
 // 'p[+-]' as part of a pp-number unless the token starts 0x and doesn't contain

--- a/clang/test/Misc/warning-flags.c
+++ b/clang/test/Misc/warning-flags.c
@@ -79,4 +79,4 @@ CHECK-NEXT:   warn_weak_import
 
 The list of warnings in -Wpedantic should NEVER grow.
 
-CHECK: Number in -Wpedantic (not covered by other -W flags): 24
+CHECK: Number in -Wpedantic (not covered by other -W flags): 23

--- a/clang/test/Parser/cxx2c-delete-with-message.cpp
+++ b/clang/test/Parser/cxx2c-delete-with-message.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -std=c++17 -fsyntax-only -verify=expected,pre26 %s
 // RUN: %clang_cc1 -std=c++17 -fsyntax-only -verify=expected,pre26-pedantic -pedantic %s
-// RUN: %clang_cc1 -std=c++2c -fsyntax-only -verify=expected,compat -Wpre-c++26-compat %s
+// RUN: %clang_cc1 -std=c++2c -fsyntax-only -verify=expected,compat -Wpre-c++26-compat-pedantic %s
 // RUN: %clang_cc1 -std=c++2c -fsyntax-only -verify %s
 
 struct S {

--- a/clang/test/Sema/c2x-attr.c
+++ b/clang/test/Sema/c2x-attr.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -std=c2x -Wpre-c2x-compat -verify=pre-c2x %s
+// RUN: %clang_cc1 -fsyntax-only -std=c2x -Wpre-c2x-compat-pedantic -verify=pre-c2x %s
 // RUN: %clang_cc1 -fsyntax-only -std=c17 -Wc2x-extensions -verify=c2x-ext %s
 
 [[]] void func(); // pre-c2x-warning {{[[]] attributes are incompatible with C standards before C23}}

--- a/clang/test/Sema/fixed-enum.c
+++ b/clang/test/Sema/fixed-enum.c
@@ -5,9 +5,9 @@
 // RUN: %clang_cc1 -pedantic    -std=c11 -xc -DC11 -verify %s
 // RUN: %clang_cc1 -Weverything -std=c11 -xc -fms-extensions -DMS -verify %s
 // RUN: %clang_cc1 -Weverything -std=c2x -xc -DC23 -verify %s
-// RUN: %clang_cc1 -pedantic    -std=c2x -xc -DC23 -verify -Wpre-c23-compat %s
+// RUN: %clang_cc1 -pedantic    -std=c2x -xc -DC23 -verify -Wpre-c23-compat-pedantic %s
 // RUN: %clang_cc1 -Weverything -std=c23 -xc -DC23 -verify %s
-// RUN: %clang_cc1 -pedantic    -std=c23 -xc -DC23 -verify -Wpre-c23-compat %s
+// RUN: %clang_cc1 -pedantic    -std=c23 -xc -DC23 -verify -Wpre-c23-compat-pedantic %s
 // RUN: %clang_cc1 -Weverything -std=c23 -xc -fms-extensions -DC23 -verify %s
 
 enum X : int {e};

--- a/clang/test/Sema/for.c
+++ b/clang/test/Sema/for.c
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -verify=c11 -std=c11 -pedantic %s
-// RUN: %clang_cc1 -fsyntax-only -verify=c23 -std=c23 -Wpre-c23-compat %s
+// RUN: %clang_cc1 -fsyntax-only -verify=c23 -std=c23 -Wpre-c23-compat-pedantic %s
 
 // Check C99 6.8.5p3
 void b1 (void) { for (void (*f) (void);;); }

--- a/clang/test/Sema/pre-c2x-restrict-qualifier.c
+++ b/clang/test/Sema/pre-c2x-restrict-qualifier.c
@@ -1,17 +1,17 @@
 // RUN: %clang_cc1 -std=c23 -fsyntax-only -verify %s
 // RUN: %clang_cc1 -std=c17 -fsyntax-only -pedantic -verify=pedantic,expected %s
-// RUN: %clang_cc1 -std=c2x -fsyntax-only -Wpre-c2x-compat -verify=c2x-compat,expected %s
+// RUN: %clang_cc1 -std=c2x -fsyntax-only -Wpre-c2x-compat-pedantic -verify=c23,expected %s
 
 typedef int (*T1)[2];
 restrict T1 t1;
 
 typedef int *T2[2];
 restrict T2 t2;         // pedantic-warning {{'restrict' qualifier on an array of pointers is a C23 extension}} \
-                        // c2x-compat-warning {{'restrict' qualifier on an array of pointers is incompatible with C standards before C23}}
+                        // c23-warning {{'restrict' qualifier on an array of pointers is incompatible with C standards before C23}}
 
 typedef int *T3[2][2];
 restrict T3 t3;         // pedantic-warning {{'restrict' qualifier on an array of pointers is a C23 extension}} \
-                        // c2x-compat-warning {{'restrict' qualifier on an array of pointers is incompatible with C standards before C23}}
+                        // c23-warning {{'restrict' qualifier on an array of pointers is incompatible with C standards before C23}}
 
 typedef int (*t4)();    // pedantic-warning {{a function declaration without a prototype is deprecated in all versions of C}}
 typedef t4 t5[2];

--- a/clang/test/SemaCXX/cxx98-compat-pedantic.cpp
+++ b/clang/test/SemaCXX/cxx98-compat-pedantic.cpp
@@ -21,6 +21,9 @@ enum Enum {
   Enum_value, // expected-warning {{commas at the end of enumerator lists are incompatible with C++98}}
 };
 
+enum EnumFixed : int { // expected-warning {{enumeration types with a fixed underlying type are incompatible with C++98}}
+};
+
 void *dlsym();
 void (*FnPtr)() = (void(*)())dlsym(); // expected-warning {{cast between pointer-to-function and pointer-to-object is incompatible with C++98}}
 void *FnVoidPtr = (void*)&dlsym; // expected-warning {{cast between pointer-to-function and pointer-to-object is incompatible with C++98}}
@@ -74,3 +77,5 @@ namespace CopyCtorIssues {
 #endif
   const Deleted &d = Deleted(); // expected-warning {{copying variable of type 'Deleted' when binding a reference to a temporary would invoke a deleted constructor in C++98}}
 }
+
+int with_attribute [[ ]]; // expected-warning {{[[]] attributes are incompatible with C++98}}

--- a/clang/test/SemaCXX/cxx98-compat.cpp
+++ b/clang/test/SemaCXX/cxx98-compat.cpp
@@ -35,7 +35,6 @@ template<int ...I>  // expected-warning {{variadic templates are incompatible wi
 class Variadic3 {};
 
 alignas(8) int with_alignas; // expected-warning {{'alignas' is incompatible with C++98}}
-int with_attribute [[ ]]; // expected-warning {{[[]] attributes are incompatible with C++98}}
 
 void Literals() {
   (void)u8"str"; // expected-warning {{unicode literals are incompatible with C++98}}
@@ -96,9 +95,6 @@ struct DelayedDefaultArgumentParseInitList {
 };
 
 int operator""_hello(const char *); // expected-warning {{literal operators are incompatible with C++98}}
-
-enum EnumFixed : int { // expected-warning {{enumeration types with a fixed underlying type are incompatible with C++98}}
-};
 
 enum class EnumScoped { // expected-warning {{scoped enumerations are incompatible with C++98}}
 };

--- a/clang/test/SemaCXX/reinterpret-fn-obj-pedantic.cpp
+++ b/clang/test/SemaCXX/reinterpret-fn-obj-pedantic.cpp
@@ -4,6 +4,6 @@ void fnptrs()
 {
   typedef void (*fnptr)();
   fnptr fp = 0;
-  void *vp = reinterpret_cast<void*>(fp); // expected-warning {{cast between pointer-to-function and pointer-to-object is an extension}}
-  (void)reinterpret_cast<fnptr>(vp); // expected-warning {{cast between pointer-to-function and pointer-to-object is an extension}}
+  void *vp = reinterpret_cast<void*>(fp); // expected-warning {{cast between pointer-to-function and pointer-to-object is a C++11 extension}}
+  (void)reinterpret_cast<fnptr>(vp); // expected-warning {{cast between pointer-to-function and pointer-to-object is a C++11 extension}}
 }


### PR DESCRIPTION
The `compat-pedantic` groups are supposed to be used if a given extension is only diagnosed in `-Wpedantic`. Update the compat diagnostics to reflect this and move various diagnostics that already adhere to this pattern to compat diagnostics.
