### PR TITLE
[BOLT][DWARF] Fix rewritten location lists and ranges

### DIFF
--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -382,6 +382,14 @@ public:
     return DwarfLineTablesCUMap[CUID];
   }
 
+  unsigned getOutputDwarfFileIndex(unsigned CUID,
+                                   unsigned InputFileIndex) const {
+    const auto It = DwarfLineTablesCUMap.find(CUID);
+    return It == DwarfLineTablesCUMap.end()
+               ? InputFileIndex
+               : It->second.translateFileIndex(InputFileIndex);
+  }
+
   Expected<unsigned> getDwarfFile(StringRef Directory, StringRef FileName,
                                   unsigned FileNumber,
                                   std::optional<MD5::MD5Result> Checksum,

--- a/bolt/include/bolt/Core/DIEBuilder.h
+++ b/bolt/include/bolt/Core/DIEBuilder.h
@@ -17,6 +17,7 @@
 
 #include "bolt/Core/BinaryContext.h"
 #include "bolt/Core/DebugNames.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/CodeGen/DIE.h"
 #include "llvm/DebugInfo/DWARF/DWARFAbbreviationDeclaration.h"
 #include "llvm/DebugInfo/DWARF/DWARFDie.h"
@@ -349,6 +350,13 @@ public:
   }
   /// Finish current DIE construction.
   void finish();
+
+  /// Rewrite base type references in a location expression. During the initial
+  /// rewrite, references are padded so their size remains stable when patched
+  /// after DIE layout is finalized.
+  bool rewriteExpressionReferences(ArrayRef<uint8_t> Input, DWARFUnit &U,
+                                   SmallVectorImpl<uint8_t> &Output,
+                                   bool Patch);
 
   /// Update debug names table.
   void updateDebugNamesTable();

--- a/bolt/include/bolt/Core/DebugData.h
+++ b/bolt/include/bolt/Core/DebugData.h
@@ -587,10 +587,13 @@ public:
 
   /// Writes out location lists and stores internal patches.
   virtual void addList(DIEBuilder &DIEBldr, DIE &Die, DIEValue &AttrInfo,
-                       DebugLocationsVector &LocList);
+                       DebugLocationsVector &LocList, DWARFUnit &Unit);
 
   /// Writes out locations in to a local buffer, and adds Debug Info patches.
   virtual void finalize(DIEBuilder &DIEBldr, DIE &Die);
+
+  /// Updates references in location expressions after DIE layout is finalized.
+  virtual void updateReferences(DIEBuilder &DIEBldr);
 
   /// Return internal buffer.
   virtual std::unique_ptr<DebugBufferVector> getBuffer();
@@ -658,10 +661,12 @@ public:
 
   /// Stores location lists internally to be written out during finalize phase.
   virtual void addList(DIEBuilder &DIEBldr, DIE &Die, DIEValue &AttrInfo,
-                       DebugLocationsVector &LocList) override;
+                       DebugLocationsVector &LocList, DWARFUnit &Unit) override;
 
   /// Writes out locations in to a local buffer and applies debug info patches.
   void finalize(DIEBuilder &DIEBldr, DIE &Die) override;
+
+  void updateReferences(DIEBuilder &DIEBldr) override;
 
   /// Returns CU ID.
   /// For Skeleton CU it is a CU Offset.
@@ -681,6 +686,15 @@ public:
   constexpr static uint32_t InvalidIndex = UINT32_MAX;
 
 private:
+  struct LocExpressionReference {
+    uint64_t Offset;
+    DWARFUnit *Unit;
+    SmallVector<uint8_t, 32> Expression;
+  };
+
+  void writeDWARF5LocList(DIEBuilder &DIEBldr, DIE &Die, DIEValue &AttrInfo,
+                          DebugLocationsVector &LocList, DWARFUnit &Unit);
+
   /// Writes out locations in to a local buffer and applies debug info patches.
   void finalizeDWARF5(DIEBuilder &DIEBldr, DIE &Die);
 
@@ -691,6 +705,7 @@ private:
   std::unique_ptr<DebugBufferVector> LocBodyBuffer;
   std::unique_ptr<raw_svector_ostream> LocBodyStream;
   std::vector<uint64_t> RelativeLocListOffsets;
+  std::vector<LocExpressionReference> LocExpressionReferences;
   uint32_t NumberOfEntries{0};
 };
 

--- a/bolt/include/bolt/Core/DebugData.h
+++ b/bolt/include/bolt/Core/DebugData.h
@@ -833,6 +833,10 @@ private:
   /// Raw data representing complete debug line section for the unit.
   StringRef RawData;
 
+  /// Maps file indexes from the input line table to the indexes assigned while
+  /// rebuilding the output table.
+  std::unordered_map<unsigned, unsigned> InputToOutputFileIndex;
+
   /// DWARF version and format for this line table.
   uint16_t DwarfVersion = 0;
   dwarf::DwarfFormat Format = dwarf::DWARF32;
@@ -853,6 +857,15 @@ public:
     assert(RawData.empty() && "cannot use with raw data");
     return Header.tryGetFile(Directory, FileName, Checksum, Source,
                              DwarfVersion, FileNumber);
+  }
+
+  void mapFileIndex(unsigned InputIndex, unsigned OutputIndex) {
+    InputToOutputFileIndex[InputIndex] = OutputIndex;
+  }
+
+  unsigned translateFileIndex(unsigned InputIndex) const {
+    const auto It = InputToOutputFileIndex.find(InputIndex);
+    return It == InputToOutputFileIndex.end() ? InputIndex : It->second;
   }
 
   /// Return label at the start of the emitted debug line for the unit.

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -2110,8 +2110,10 @@ void BinaryContext::preprocessDebugInfo() {
       std::optional<MD5::MD5Result> Checksum;
       if (DwarfVersion >= 5 && LineTable->Prologue.ContentTypes.HasMD5)
         Checksum = LineTable->Prologue.FileNames[I].Checksum;
-      cantFail(getDwarfFile(Dir, FileName, 0, Checksum, std::nullopt, CUID,
-                            DwarfVersion));
+      const unsigned InputFileIndex = I + Offset;
+      const unsigned OutputFileIndex = cantFail(getDwarfFile(
+          Dir, FileName, 0, Checksum, std::nullopt, CUID, DwarfVersion));
+      BinaryLineTable.mapFileIndex(InputFileIndex, OutputFileIndex);
     }
   }
 

--- a/bolt/lib/Core/BinaryEmitter.cpp
+++ b/bolt/lib/Core/BinaryEmitter.cpp
@@ -679,8 +679,9 @@ SMLoc BinaryEmitter::emitLineInfo(const BinaryFunction &BF, SMLoc NewLoc,
                             MCSymbol &InstrLabel,
                             const DWARFDebugLine::Row &CurrentRow) {
     const uint64_t TargetUnitIndex = TargetCU.getOffset();
-    unsigned TargetFilenum = CurrentRow.File;
     const uint32_t CurrentUnitIndex = RowReference.DwCompileUnitIndex;
+    unsigned TargetFilenum =
+        BC.getOutputDwarfFileIndex(CurrentUnitIndex, CurrentRow.File);
     // If the CU id from the current instruction location does not
     // match the target CU id, it means that we have come across some
     // inlined code (by BOLT).  We must look up the CU for the instruction's

--- a/bolt/lib/Core/DIEBuilder.cpp
+++ b/bolt/lib/Core/DIEBuilder.cpp
@@ -802,6 +802,18 @@ bool DIEBuilder::cloneExpression(const DataExtractor &Data,
   return DoesContainReference;
 }
 
+bool DIEBuilder::rewriteExpressionReferences(ArrayRef<uint8_t> Input,
+                                             DWARFUnit &U,
+                                             SmallVectorImpl<uint8_t> &Output,
+                                             bool Patch) {
+  DataExtractor Data(Input, U.isLittleEndian());
+  DWARFExpression Expression(Data, U.getAddressByteSize(),
+                             U.getFormParams().Format);
+  return cloneExpression(Data, Expression, U, Output,
+                         Patch ? CloneExpressionStage::PATCH
+                               : CloneExpressionStage::INIT);
+}
+
 void DIEBuilder::cloneBlockAttribute(
     DIE &Die, DWARFUnit &U,
     const DWARFAbbreviationDeclaration::AttributeSpec AttrSpec,

--- a/bolt/lib/Core/DIEBuilder.cpp
+++ b/bolt/lib/Core/DIEBuilder.cpp
@@ -903,6 +903,11 @@ void DIEBuilder::cloneScalarAttribute(
     return;
   }
 
+  if (AttrSpec.Attr == dwarf::DW_AT_decl_file ||
+      AttrSpec.Attr == dwarf::DW_AT_call_file)
+    Value =
+        BC.getOutputDwarfFileIndex(InputDIE.getDwarfUnit()->getOffset(), Value);
+
   Die.addValue(getState().DIEAlloc, AttrSpec.Attr, AttrSpec.Form,
                DIEInteger(Value));
 }

--- a/bolt/lib/Core/DebugData.cpp
+++ b/bolt/lib/Core/DebugData.cpp
@@ -613,7 +613,7 @@ void DebugLocWriter::init() {
 }
 
 void DebugLocWriter::addList(DIEBuilder &DIEBldr, DIE &Die, DIEValue &AttrInfo,
-                             DebugLocationsVector &LocList) {
+                             DebugLocationsVector &LocList, DWARFUnit &) {
   if (LocList.empty()) {
     replaceLocValbyForm(DIEBldr, Die, AttrInfo, AttrInfo.getForm(),
                         DebugLocWriter::EmptyListOffset);
@@ -645,6 +645,8 @@ std::unique_ptr<DebugBufferVector> DebugLocWriter::getBuffer() {
 
 // DWARF 4: 2.6.2
 void DebugLocWriter::finalize(DIEBuilder &DIEBldr, DIE &Die) {}
+
+void DebugLocWriter::updateReferences(DIEBuilder &) {}
 
 /// Rebases all pending location list offsets by adding \p Base,
 /// updating the corresponding attributes in each patched DIE.
@@ -715,64 +717,70 @@ static void writeLegacyLocList(DIEValue &AttrInfo,
   replaceLocValbyForm(DIEBldr, Die, AttrInfo, AttrInfo.getForm(), EntryOffset);
 }
 
-static void writeDWARF5LocList(uint32_t &NumberOfEntries, DIEValue &AttrInfo,
-                               DebugLocationsVector &LocList, DIE &Die,
-                               DIEBuilder &DIEBldr, DebugAddrWriter &AddrWriter,
-                               DebugBufferVector &LocBodyBuffer,
-                               std::vector<uint64_t> &RelativeLocListOffsets,
-                               DWARFUnit &CU,
-                               raw_svector_ostream &LocBodyStream) {
-
+void DebugLoclistWriter::writeDWARF5LocList(DIEBuilder &DIEBldr, DIE &Die,
+                                            DIEValue &AttrInfo,
+                                            DebugLocationsVector &LocList,
+                                            DWARFUnit &Unit) {
   replaceLocValbyForm(DIEBldr, Die, AttrInfo, dwarf::DW_FORM_loclistx,
                       NumberOfEntries);
 
-  RelativeLocListOffsets.push_back(LocBodyBuffer.size());
+  RelativeLocListOffsets.push_back(LocBodyBuffer->size());
   ++NumberOfEntries;
   if (LocList.empty()) {
-    writeEmptyListDwarf5(LocBodyStream);
+    writeEmptyListDwarf5(*LocBodyStream);
     return;
   }
 
   auto writeExpression = [&](uint32_t Index) -> void {
     const DebugLocationEntry &Entry = LocList[Index];
-    encodeULEB128(Entry.Expr.size(), LocBodyStream);
-    LocBodyStream << StringRef(
-        reinterpret_cast<const char *>(Entry.Expr.data()), Entry.Expr.size());
+    SmallVector<uint8_t, 32> Expression;
+    const bool HasReference = DIEBldr.rewriteExpressionReferences(
+        Entry.Expr, Unit, Expression, false);
+    const ArrayRef<uint8_t> ExpressionBytes =
+        HasReference ? ArrayRef<uint8_t>(Expression)
+                     : ArrayRef<uint8_t>(Entry.Expr);
+    encodeULEB128(ExpressionBytes.size(), *LocBodyStream);
+    const uint64_t ExpressionOffset = LocBodyBuffer->size();
+    *LocBodyStream << StringRef(
+        reinterpret_cast<const char *>(ExpressionBytes.data()),
+        ExpressionBytes.size());
+    if (HasReference)
+      LocExpressionReferences.push_back(
+          {ExpressionOffset, &Unit, std::move(Expression)});
   };
   for (unsigned I = 0; I < LocList.size();) {
     if (emitWithBase<DebugLocationsVector, dwarf::LoclistEntries,
-                     DebugLocationEntry>(LocBodyStream, LocList, AddrWriter, CU,
-                                         I, dwarf::DW_LLE_base_addressx,
+                     DebugLocationEntry>(*LocBodyStream, LocList, AddrWriter,
+                                         CU, I, dwarf::DW_LLE_base_addressx,
                                          dwarf::DW_LLE_offset_pair,
                                          writeExpression))
       continue;
 
     const DebugLocationEntry &Entry = LocList[I];
-    support::endian::write(LocBodyStream,
+    support::endian::write(*LocBodyStream,
                            static_cast<uint8_t>(dwarf::DW_LLE_startx_length),
                            llvm::endianness::little);
     const uint32_t Index = AddrWriter.getIndexFromAddress(Entry.LowPC, CU);
-    encodeULEB128(Index, LocBodyStream);
-    encodeULEB128(Entry.HighPC - Entry.LowPC, LocBodyStream);
+    encodeULEB128(Index, *LocBodyStream);
+    encodeULEB128(Entry.HighPC - Entry.LowPC, *LocBodyStream);
     writeExpression(I);
     ++I;
   }
 
-  support::endian::write(LocBodyStream,
+  support::endian::write(*LocBodyStream,
                          static_cast<uint8_t>(dwarf::DW_LLE_end_of_list),
                          llvm::endianness::little);
 }
 
 void DebugLoclistWriter::addList(DIEBuilder &DIEBldr, DIE &Die,
                                  DIEValue &AttrInfo,
-                                 DebugLocationsVector &LocList) {
+                                 DebugLocationsVector &LocList,
+                                 DWARFUnit &Unit) {
   if (DwarfVersion < 5)
     writeLegacyLocList(AttrInfo, LocList, DIEBldr, Die, AddrWriter, *LocBuffer,
                        CU, *LocStream);
   else
-    writeDWARF5LocList(NumberOfEntries, AttrInfo, LocList, Die, DIEBldr,
-                       AddrWriter, *LocBodyBuffer, RelativeLocListOffsets, CU,
-                       *LocBodyStream);
+    writeDWARF5LocList(DIEBldr, Die, AttrInfo, LocList, Unit);
 }
 
 void DebugLoclistWriter::finalizeDWARF5(DIEBuilder &DIEBldr, DIE &Die) {
@@ -805,6 +813,10 @@ void DebugLoclistWriter::finalizeDWARF5(DIEBuilder &DIEBldr, DIE &Die) {
   std::unique_ptr<DebugBufferVector> Header =
       getDWARF5Header({Format, SizeOfArraySection + LocBodyBuffer->size(), 5, 8,
                        0, NumberOfEntries});
+  const uint64_t LocBodyOffset =
+      LocBuffer->size() + Header->size() + LocArrayBuffer->size();
+  for (LocExpressionReference &Reference : LocExpressionReferences)
+    Reference.Offset += LocBodyOffset;
   *LocStream << *Header;
   *LocStream << *LocArrayBuffer;
   *LocStream << *LocBodyBuffer;
@@ -830,6 +842,21 @@ void DebugLoclistWriter::finalizeDWARF5(DIEBuilder &DIEBldr, DIE &Die) {
 void DebugLoclistWriter::finalize(DIEBuilder &DIEBldr, DIE &Die) {
   if (DwarfVersion >= 5)
     finalizeDWARF5(DIEBldr, Die);
+}
+
+void DebugLoclistWriter::updateReferences(DIEBuilder &DIEBldr) {
+  for (LocExpressionReference &Reference : LocExpressionReferences) {
+    SmallVector<uint8_t, 32> Expression;
+    const bool HasReference = DIEBldr.rewriteExpressionReferences(
+        Reference.Expression, *Reference.Unit, Expression, true);
+    assert(HasReference && "location expression reference disappeared");
+    assert(Expression.size() == Reference.Expression.size() &&
+           "location expression size changed while patching references");
+    assert(Reference.Offset + Expression.size() <= LocBuffer->size() &&
+           "location expression patch exceeds section buffer");
+    std::copy(Expression.begin(), Expression.end(),
+              LocBuffer->begin() + Reference.Offset);
+  }
 }
 
 static std::string encodeLE(size_t ByteSize, uint64_t NewValue) {

--- a/bolt/lib/Core/DebugData.cpp
+++ b/bolt/lib/Core/DebugData.cpp
@@ -1048,7 +1048,8 @@ static void emitDwarfSetLineAddrAbs(MCStreamer &OS,
 static inline void emitBinaryDwarfLineTable(
     MCStreamer *MCOS, MCDwarfLineTableParams Params,
     const DWARFDebugLine::LineTable *Table,
-    const std::vector<DwarfLineTable::RowSequence> &InputSequences) {
+    const std::vector<DwarfLineTable::RowSequence> &InputSequences,
+    const DwarfLineTable &OutputTable) {
   if (InputSequences.empty())
     return;
 
@@ -1090,8 +1091,9 @@ static inline void emitBinaryDwarfLineTable(
       int64_t LineDelta = static_cast<int64_t>(Row.Line) - LastLine;
       const uint64_t Address = Row.Address.Address;
 
-      if (FileNum != Row.File) {
-        FileNum = Row.File;
+      const unsigned OutputFile = OutputTable.translateFileIndex(Row.File);
+      if (FileNum != OutputFile) {
+        FileNum = OutputFile;
         MCOS->emitInt8(dwarf::DW_LNS_set_file);
         MCOS->emitULEB128IntValue(FileNum);
       }
@@ -1251,7 +1253,7 @@ void DwarfLineTable::emitCU(MCStreamer *MCOS, MCDwarfLineTableParams Params,
     emitDwarfLineTable(MCOS, LineSec.first, LineSec.second);
 
   // Emit line tables for the original code.
-  emitBinaryDwarfLineTable(MCOS, Params, InputTable, InputSequences);
+  emitBinaryDwarfLineTable(MCOS, Params, InputTable, InputSequences, *this);
 
   // This is the end of the section, so set the value of the symbol at the end
   // of this section (that was used in a previous expression).

--- a/bolt/lib/Passes/FixRISCVCallsPass.cpp
+++ b/bolt/lib/Passes/FixRISCVCallsPass.cpp
@@ -49,10 +49,12 @@ void FixRISCVCallsPass::runOnFunction(BinaryFunction &BF) {
         auto *Target = MIB->getTargetSymbol(*II);
         assert(Target && "Cannot find call target");
 
+        MCInst OldAUIPC = *II;
         MCInst OldCall = *NextII;
         auto L = BC.scopeLock();
 
         MIB->createNoop(*II);
+        MIB->moveAnnotations(std::move(OldAUIPC), *II);
 
         if (MIB->isTailCall(*NextII))
           MIB->createTailCall(*NextII, Target, Ctx);

--- a/bolt/lib/Rewrite/DWARFRewriter.cpp
+++ b/bolt/lib/Rewrite/DWARFRewriter.cpp
@@ -516,6 +516,7 @@ static void emitDWOBuilder(const std::string &DWOName,
   // Populate debug_info and debug_abbrev for current dwo into StringRef.
   DWODIEBuilder.generateAbbrevs();
   DWODIEBuilder.finish();
+  LocWriter.updateReferences(DWODIEBuilder);
 
   SmallVector<char, 20> OutBuffer;
   std::shared_ptr<raw_svector_ostream> ObjOS =
@@ -1061,6 +1062,8 @@ void DWARFRewriter::updateDebugInfo() {
     mergePerBucketRanges(*BucketDIEBlder, LocalWriters[Idx], SortedCUs);
     finalizeCompileUnits(*BucketDIEBlder, DIEBlder, *Streamer, OffsetMap,
                          BucketDIEBlder->getProcessedCUs(), *FinalAddrWriter);
+    for (DWARFUnit *CU : BucketDIEBlder->getProcessedCUs())
+      LocListWritersByCU.at(CU->getOffset())->updateReferences(*BucketDIEBlder);
 
     // Release memory for this bucket.
     BucketDIEBlders[Idx].reset();
@@ -1447,7 +1450,7 @@ void DWARFRewriter::updateUnitDebugInfo(
               // information.
               OutputLL = InputLL;
             }
-            DebugLocWriter.addList(DIEBldr, *Die, LocAttrInfo, OutputLL);
+            DebugLocWriter.addList(DIEBldr, *Die, LocAttrInfo, OutputLL, Unit);
           }
         } else {
           assert((doesFormBelongToClass(LocAttrInfo.getForm(),

--- a/bolt/lib/Rewrite/DWARFRewriter.cpp
+++ b/bolt/lib/Rewrite/DWARFRewriter.cpp
@@ -1287,14 +1287,12 @@ void DWARFRewriter::updateUnitDebugInfo(
               std::move(OutputRanges), CachedRanges);
           OutputRanges.clear();
         } else if (OutputRanges.empty()) {
-          OutputRanges.push_back({0, RangesOrError.get().front().HighPC});
+          OutputRanges.push_back({0, 0});
         }
       } else if (!RangesOrError) {
         consumeError(RangesOrError.takeError());
       } else {
-        OutputRanges.push_back({0, !RangesOrError->empty()
-                                       ? RangesOrError.get().front().HighPC
-                                       : 0});
+        OutputRanges.push_back({0, 0});
       }
       DIEValue LowPCVal = Die->findAttribute(dwarf::DW_AT_low_pc);
       DIEValue HighPCVal = Die->findAttribute(dwarf::DW_AT_high_pc);

--- a/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
+++ b/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
@@ -676,11 +676,11 @@ public:
   }
 
   void createNoop(MCInst &Inst) const override {
+    Inst.setOpcode(RISCV::ADDI);
     Inst.clear();
-    Inst = MCInstBuilder(RISCV::ADDI)
-               .addReg(RISCV::X0)
-               .addReg(RISCV::X0)
-               .addImm(0);
+    Inst.addOperand(MCOperand::createReg(RISCV::X0));
+    Inst.addOperand(MCOperand::createReg(RISCV::X0));
+    Inst.addOperand(MCOperand::createImm(0));
   }
 
   void createShortJmp(InstructionListType &Seq, const MCSymbol *Target,

--- a/bolt/test/RISCV/dwarf-scope-call-pair.s
+++ b/bolt/test/RISCV/dwarf-scope-call-pair.s
@@ -1,0 +1,157 @@
+## Check that rewriting an AUIPC/JALR call pair preserves an input offset used
+## as a DWARF lexical-scope boundary. The first call grows from eight to twelve
+## bytes. The parent scope ends at the AUIPC of the second call, while its child
+## ends at the intervening compressed NOP. Losing the AUIPC offset maps the
+## parent's high_pc inside the preceding rewritten call and makes the child
+## extend beyond its parent.
+
+# REQUIRES: system-linux
+
+# RUN: llvm-mc -triple riscv64 -mattr=+c -filetype obj -o %t.o %s
+# RUN: ld.lld --no-relax --emit-relocs -e foo -o %t %t.o
+# RUN: llvm-bolt --update-debug-sections -o %t.bolt %t
+# RUN: llvm-dwarfdump --verify %t.bolt
+# RUN: llvm-objdump -d --no-show-raw-insn %t.bolt > %t.out
+# RUN: llvm-dwarfdump --debug-info %t.bolt >> %t.out
+# RUN: FileCheck %s < %t.out
+
+# CHECK-LABEL: <foo>:
+# CHECK:      nop
+# CHECK-NEXT: auipc
+# CHECK-NEXT: jalr
+# CHECK-NEXT: nop
+# CHECK-NEXT: [[PARENT_END:[0-9a-f]+]]:{{.*}}nop
+# CHECK-NEXT: auipc
+# CHECK-NEXT: jalr
+# CHECK:      DW_TAG_lexical_block
+# CHECK:      DW_AT_low_pc
+# CHECK-NEXT: DW_AT_high_pc {{.*}}0x{{0*}}[[PARENT_END]])
+
+        .text
+        .option norvc
+        .option norelax
+        .globl  foo
+        .p2align 2
+        .type   foo,@function
+foo:
+.Lfoo_begin:
+        call    callee
+        .option rvc
+.Lchild_end:
+        c.nop
+        .option norvc
+.Lparent_end:
+        call    callee
+        ret
+.Lfoo_end:
+        .size   foo, .-foo
+
+        .skip   (1 << 21)
+
+        .globl  callee
+        .p2align 2
+        .type   callee,@function
+callee:
+        ret
+.Lcallee_end:
+        .size   callee, .-callee
+
+        .section .debug_abbrev,"",@progbits
+        .byte   1                       # Abbrev code
+        .byte   17                      # DW_TAG_compile_unit
+        .byte   1                       # DW_CHILDREN_yes
+        .byte   37                      # DW_AT_producer
+        .byte   8                       # DW_FORM_string
+        .byte   17                      # DW_AT_low_pc
+        .byte   1                       # DW_FORM_addr
+        .byte   18                      # DW_AT_high_pc
+        .byte   6                       # DW_FORM_data4
+        .byte   3                       # DW_AT_name
+        .byte   8                       # DW_FORM_string
+        .byte   16                      # DW_AT_stmt_list
+        .byte   23                      # DW_FORM_sec_offset
+        .byte   0
+        .byte   0
+        .byte   2                       # Abbrev code
+        .byte   46                      # DW_TAG_subprogram
+        .byte   1                       # DW_CHILDREN_yes
+        .byte   3                       # DW_AT_name
+        .byte   8                       # DW_FORM_string
+        .byte   17                      # DW_AT_low_pc
+        .byte   1                       # DW_FORM_addr
+        .byte   18                      # DW_AT_high_pc
+        .byte   6                       # DW_FORM_data4
+        .byte   0
+        .byte   0
+        .byte   3                       # Abbrev code
+        .byte   11                      # DW_TAG_lexical_block
+        .byte   1                       # DW_CHILDREN_yes
+        .byte   17                      # DW_AT_low_pc
+        .byte   1                       # DW_FORM_addr
+        .byte   18                      # DW_AT_high_pc
+        .byte   6                       # DW_FORM_data4
+        .byte   0
+        .byte   0
+        .byte   4                       # Abbrev code
+        .byte   11                      # DW_TAG_lexical_block
+        .byte   0                       # DW_CHILDREN_no
+        .byte   17                      # DW_AT_low_pc
+        .byte   1                       # DW_FORM_addr
+        .byte   18                      # DW_AT_high_pc
+        .byte   6                       # DW_FORM_data4
+        .byte   0
+        .byte   0
+        .byte   0
+
+        .section .debug_info,"",@progbits
+.Lcu_begin:
+        .long   .Lcu_end-.Lcu_version
+.Lcu_version:
+        .short  4                       # DWARF version
+        .long   .debug_abbrev
+        .byte   8                       # Address size
+        .byte   1                       # DW_TAG_compile_unit
+        .asciz  "test producer"
+        .quad   .Lfoo_begin
+        .long   .Lcallee_end-.Lfoo_begin
+        .asciz  "dwarf-scope-call-pair.s"
+        .long   .Lline_table_start
+        .byte   2                       # DW_TAG_subprogram
+        .asciz  "foo"
+        .quad   .Lfoo_begin
+        .long   .Lfoo_end-.Lfoo_begin
+        .byte   3                       # Parent lexical block
+        .quad   .Lfoo_begin
+        .long   .Lparent_end-.Lfoo_begin
+        .byte   4                       # Child lexical block
+        .quad   .Lfoo_begin
+        .long   .Lchild_end-.Lfoo_begin
+        .byte   0                       # End parent children
+        .byte   0                       # End subprogram children
+        .byte   0                       # End CU children
+.Lcu_end:
+
+        .section .debug_line,"",@progbits
+.Lline_table_start:
+        .long   .Lline_table_end-.Lline_version
+.Lline_version:
+        .short  4                       # DWARF version
+        .long   .Lline_prologue_end-.Lline_prologue_start
+.Lline_prologue_start:
+        .byte   1                       # Minimum instruction length
+        .byte   1                       # Maximum operations per instruction
+        .byte   1                       # Default is_stmt
+        .byte   -5                      # Line base
+        .byte   14                      # Line range
+        .byte   13                      # Opcode base
+        .byte   0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1
+        .byte   0                       # Include directory terminator
+        .asciz  "dwarf-scope-call-pair.s"
+        .uleb128 0                      # Directory index
+        .uleb128 0                      # Modification time
+        .uleb128 0                      # File size
+        .byte   0                       # File table terminator
+.Lline_prologue_end:
+.Lline_table_end:
+
+        .section ".note.GNU-stack","",@progbits

--- a/bolt/test/X86/Inputs/dwarf5-locexpr-referrence-helper.s
+++ b/bolt/test/X86/Inputs/dwarf5-locexpr-referrence-helper.s
@@ -59,8 +59,12 @@ bar:                                    # @bar
 	.byte	4                               # DW_LLE_offset_pair
 	.uleb128 .Ltmp0-.Lfunc_begin0           #   starting offset
 	.uleb128 .Ltmp1-.Lfunc_begin0           #   ending offset
-	.byte	1                               # Loc expr size
-	.byte	80                              # super-register DW_OP_reg0
+	.uleb128 .Ldebug_loc0_expr_end-.Ldebug_loc0_expr # Loc expr size
+.Ldebug_loc0_expr:
+	.byte	48                              # DW_OP_lit0
+	.byte	168                             # DW_OP_convert
+	.uleb128 .Lbase_type0-.Lcu_begin0
+.Ldebug_loc0_expr_end:
 	.byte	0                               # DW_LLE_end_of_list
 .Ldebug_loc1:
 	.byte	4                               # DW_LLE_offset_pair
@@ -218,10 +222,12 @@ bar:                                    # @bar
 	.long	.Lfunc_end0-.Lfunc_begin0       # DW_AT_high_pc
 	.long	.Laddr_table_base0              # DW_AT_addr_base
 	.long	.Lloclists_table_base0          # DW_AT_loclists_base
+.Lcu0_base_type_char:
 	.byte	2                               # Abbrev [2] 0x27:0x4 DW_TAG_base_type
 	.byte	5                               # DW_AT_name
 	.byte	5                               # DW_AT_encoding
 	.byte	1                               # DW_AT_byte_size
+.Lcu0_base_type_int:
 	.byte	2                               # Abbrev [2] 0x2b:0x4 DW_TAG_base_type
 	.byte	4                               # DW_AT_name
 	.byte	5                               # DW_AT_encoding
@@ -235,34 +241,38 @@ bar:                                    # @bar
 	.byte	1                               # DW_AT_decl_file
 	.byte	7                               # DW_AT_decl_line
                                         # DW_AT_prototyped
-	.long	96                              # DW_AT_type
+	.long	.Lbase_type0-.Lcu_begin0        # DW_AT_type
                                         # DW_AT_external
 	.byte	4                               # Abbrev [4] 0x3e:0x9 DW_TAG_formal_parameter
 	.byte	0                               # DW_AT_location
 	.byte	10                              # DW_AT_name
 	.byte	1                               # DW_AT_decl_file
 	.byte	7                               # DW_AT_decl_line
-	.long	96                              # DW_AT_type
+	.long	.Lbase_type0-.Lcu_begin0        # DW_AT_type
 	.byte	5                               # Abbrev [5] 0x47:0x18 DW_TAG_variable
-	.byte	15                              # DW_AT_location
+	.uleb128 .Linline_expr0_end-.Linline_expr0 # DW_AT_location
+.Linline_expr0:
 	.byte	16
 	.byte	32
 	.byte	48
 	.byte	34
 	.byte	168
-	.asciz	"\247\200\200"
+	.uleb128 .Lcu0_base_type_char-.Lcu_begin0
 	.byte	168
-	.asciz	"\253\200\200"
+	.uleb128 .Lcu0_base_type_int-.Lcu_begin0
 	.byte	159
+.Linline_expr0_end:
 	.byte	11                              # DW_AT_name
 	.byte	1                               # DW_AT_decl_file
 	.byte	9                               # DW_AT_decl_line
-	.long	100                             # DW_AT_type
+	.long	.Lbase_type_int0-.Lcu_begin0    # DW_AT_type
 	.byte	0                               # End Of Children Mark
+.Lbase_type0:
 	.byte	2                               # Abbrev [2] 0x60:0x4 DW_TAG_base_type
 	.byte	8                               # DW_AT_name
 	.byte	6                               # DW_AT_encoding
 	.byte	1                               # DW_AT_byte_size
+.Lbase_type_int0:
 	.byte	2                               # Abbrev [2] 0x64:0x4 DW_TAG_base_type
 	.byte	12                              # DW_AT_name
 	.byte	5                               # DW_AT_encoding
@@ -304,14 +314,14 @@ bar:                                    # @bar
 	.byte	2                               # DW_AT_decl_file
 	.byte	1                               # DW_AT_decl_line
                                         # DW_AT_prototyped
-	.long	.debug_info+96                  # DW_AT_type
+	.long	.Lbase_type0                    # DW_AT_type
                                         # DW_AT_external
 	.byte	7                               # Abbrev [7] 0x3e:0x9 DW_TAG_formal_parameter
 	.byte	1                               # DW_AT_location
 	.byte	10                              # DW_AT_name
 	.byte	2                               # DW_AT_decl_file
 	.byte	1                               # DW_AT_decl_line
-	.long	.debug_info+96                  # DW_AT_type
+	.long	.Lbase_type0                    # DW_AT_type
 	.byte	5                               # Abbrev [5] 0x47:0x18 DW_TAG_variable
 	.byte	15                              # DW_AT_location
 	.byte	16
@@ -326,8 +336,9 @@ bar:                                    # @bar
 	.byte	13                              # DW_AT_name
 	.byte	2                               # DW_AT_decl_file
 	.byte	3                               # DW_AT_decl_line
-	.long	96                              # DW_AT_type
+	.long	.Lbase_type1-.Lcu_begin1        # DW_AT_type
 	.byte	0                               # End Of Children Mark
+.Lbase_type1:
 	.byte	2                               # Abbrev [2] 0x60:0x4 DW_TAG_base_type
 	.byte	14                              # DW_AT_name
 	.byte	5                               # DW_AT_encoding

--- a/bolt/test/X86/dwarf4-deleted-range.s
+++ b/bolt/test/X86/dwarf4-deleted-range.s
@@ -9,6 +9,8 @@
 # CHECK: 		DW_TAG_inlined_subroutine
 # CHECK:      DW_AT_low_pc
 # CHECK-SAME: 0x0000000000000000
+# CHECK:      DW_AT_high_pc
+# CHECK-SAME: 0x0000000000000000
 
 # CHECK:    DW_TAG_GNU_call_site
 # CHECK:      DW_AT_low_pc

--- a/bolt/test/X86/dwarf4-df-inlined-subroutine-lowpc-0.test
+++ b/bolt/test/X86/dwarf4-df-inlined-subroutine-lowpc-0.test
@@ -21,10 +21,10 @@
 ; BOLT-MAIN-SAME: (cu + 0x0043 => {0x00000043} "_Z7doStuffi")
 ; BOLT-MAIN: DW_AT_low_pc [DW_FORM_GNU_addr_index]
 ; BOLT-MAIN-SAME: (indexed (00000003) address = <unresolved>)
-; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x00000015)
+; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x00000000)
 ; BOLT-MAIN: DW_TAG_inlined_subroutine
 ; BOLT-MAIN: DW_AT_abstract_origin [DW_FORM_ref4]
 ; BOLT-MAIN-SAME: (cu + 0x005a => {0x0000005a} "_Z11doStuffSamei")
 ; BOLT-MAIN: DW_AT_low_pc [DW_FORM_GNU_addr_index]
 ; BOLT-MAIN-SAME: (indexed (00000003) address = <unresolved>)
-; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x0000000f)
+; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x00000000)

--- a/bolt/test/X86/dwarf5-debug-line-duplicate-files.s
+++ b/bolt/test/X86/dwarf5-debug-line-duplicate-files.s
@@ -1,0 +1,157 @@
+# REQUIRES: system-linux
+
+# RUN: llvm-mc -filetype=obj -triple x86_64-unknown-linux %s -o %t.o
+# RUN: %clang %cflags %t.o -o %t.exe -Wl,-q
+# RUN: llvm-dwarfdump --show-form --verbose --debug-line %t.exe | FileCheck --check-prefix=PRE %s
+# RUN: llvm-bolt %t.exe -o %t.bolt --update-debug-sections
+# RUN: llvm-dwarfdump --verify %t.bolt
+# RUN: llvm-dwarfdump --show-form --verbose --debug-line --debug-info %t.bolt | FileCheck --check-prefix=POST %s
+
+## BOLT rebuilds processed line tables through MC, which intentionally interns
+## duplicate file entries. Check that references to input file indexes are
+## remapped to the indexes in the rebuilt table.
+
+# PRE: file_names[  0]:
+# PRE-NEXT: name: "main.cpp"
+# PRE: file_names[  1]:
+# PRE-NEXT: name: "main.cpp"
+# PRE: file_names[  2]:
+# PRE-NEXT: name: "header.h"
+
+# POST: DW_AT_name [DW_FORM_string] ("main")
+# POST: DW_AT_decl_file [DW_FORM_data1] ("./header.h")
+# POST: DW_AT_call_file [DW_FORM_data1] ("./header.h")
+# POST: file_names[  0]:
+# POST-NEXT: name: "main.cpp"
+# POST: file_names[  1]:
+# POST-NEXT: name: "header.h"
+# POST-NOT: file_names[  2]:
+# POST: {{0x[0-9a-f]+}}{{ +}}7{{ +}}0{{ +}}1{{ +}}0
+
+        .text
+        .globl  main
+        .p2align 4, 0x90
+        .type   main,@function
+main:
+.Lfunc_begin0:
+        xorl    %eax, %eax
+        retq
+.Lfunc_end0:
+        .size   main, .Lfunc_end0-main
+
+        .section .debug_abbrev,"",@progbits
+        .byte   1                       # Abbrev code
+        .byte   17                      # DW_TAG_compile_unit
+        .byte   1                       # DW_CHILDREN_yes
+        .byte   37                      # DW_AT_producer
+        .byte   8                       # DW_FORM_string
+        .byte   19                      # DW_AT_language
+        .byte   5                       # DW_FORM_data2
+        .byte   3                       # DW_AT_name
+        .byte   8                       # DW_FORM_string
+        .byte   27                      # DW_AT_comp_dir
+        .byte   8                       # DW_FORM_string
+        .byte   16                      # DW_AT_stmt_list
+        .byte   23                      # DW_FORM_sec_offset
+        .byte   17                      # DW_AT_low_pc
+        .byte   1                       # DW_FORM_addr
+        .byte   18                      # DW_AT_high_pc
+        .byte   6                       # DW_FORM_data4
+        .byte   0
+        .byte   0
+        .byte   2                       # Abbrev code
+        .byte   46                      # DW_TAG_subprogram
+        .byte   0                       # DW_CHILDREN_no
+        .byte   17                      # DW_AT_low_pc
+        .byte   1                       # DW_FORM_addr
+        .byte   18                      # DW_AT_high_pc
+        .byte   6                       # DW_FORM_data4
+        .byte   3                       # DW_AT_name
+        .byte   8                       # DW_FORM_string
+        .byte   58                      # DW_AT_decl_file
+        .byte   11                      # DW_FORM_data1
+        .byte   59                      # DW_AT_decl_line
+        .byte   11                      # DW_FORM_data1
+        .byte   88                      # DW_AT_call_file
+        .byte   11                      # DW_FORM_data1
+        .byte   0
+        .byte   0
+        .byte   0
+
+        .section .debug_info,"",@progbits
+.Lcu_begin0:
+        .long   .Ldebug_info_end0-.Ldebug_info_start0
+.Ldebug_info_start0:
+        .short  5                       # DWARF version
+        .byte   1                       # DW_UT_compile
+        .byte   8                       # Address size
+        .long   .debug_abbrev
+        .byte   1                       # DW_TAG_compile_unit
+        .asciz  "test producer"
+        .short  33                      # DW_LANG_C_plus_plus_14
+        .asciz  "main.cpp"
+        .asciz  "."
+        .long   .Lline_table_start0
+        .quad   .Lfunc_begin0
+        .long   .Lfunc_end0-.Lfunc_begin0
+        .byte   2                       # DW_TAG_subprogram
+        .quad   .Lfunc_begin0
+        .long   .Lfunc_end0-.Lfunc_begin0
+        .asciz  "main"
+        .byte   2                       # Input file index for header.h
+        .byte   7
+        .byte   2                       # Input call file index for header.h
+        .byte   0                       # End children
+.Ldebug_info_end0:
+
+        .section .debug_line,"",@progbits
+.Lline_table_start0:
+        .long   .Lline_table_end0-.Lline_table_start1
+.Lline_table_start1:
+        .short  5                       # DWARF version
+        .byte   8                       # Address size
+        .byte   0                       # Segment selector size
+        .long   .Lline_prologue_end0-.Lline_prologue_start0
+.Lline_prologue_start0:
+        .byte   1                       # Minimum instruction length
+        .byte   1                       # Maximum operations per instruction
+        .byte   1                       # Default is_stmt
+        .byte   -5                      # Line base
+        .byte   14                      # Line range
+        .byte   13                      # Opcode base
+        .byte   0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1
+        .byte   1                       # Directory format count
+        .byte   1                       # DW_LNCT_path
+        .byte   8                       # DW_FORM_string
+        .uleb128 1                      # Directory count
+        .asciz  "."
+        .byte   2                       # File format count
+        .byte   1                       # DW_LNCT_path
+        .byte   8                       # DW_FORM_string
+        .byte   2                       # DW_LNCT_directory_index
+        .byte   11                      # DW_FORM_data1
+        .uleb128 3                      # File count
+        .asciz  "main.cpp"
+        .byte   0
+        .asciz  "main.cpp"             # Duplicate root entry
+        .byte   0
+        .asciz  "header.h"
+        .byte   0
+.Lline_prologue_end0:
+        .byte   0                       # DW_LNE_set_address
+        .uleb128 9
+        .byte   2
+        .quad   .Lfunc_begin0
+        .byte   4                       # DW_LNS_set_file
+        .uleb128 2                      # Input file index for header.h
+        .byte   3                       # DW_LNS_advance_line
+        .sleb128 6
+        .byte   1                       # DW_LNS_copy
+        .byte   2                       # DW_LNS_advance_pc
+        .uleb128 .Lfunc_end0-.Lfunc_begin0
+        .byte   0                       # DW_LNE_end_sequence
+        .uleb128 1
+        .byte   1
+.Lline_table_end0:
+
+        .section ".note.GNU-stack","",@progbits

--- a/bolt/test/X86/dwarf5-deleted-range.s
+++ b/bolt/test/X86/dwarf5-deleted-range.s
@@ -5,9 +5,12 @@
 # RUN: llvm-bolt %t.exe -o %t.bolt --update-debug-sections
 # RUN: llvm-dwarfdump --show-children --name=main --debug-info %t.bolt \
 # RUN:   | FileCheck %s
+# RUN: llvm-dwarfdump --verify %t.bolt
 
 # CHECK: 		DW_TAG_inlined_subroutine
 # CHECK:      DW_AT_low_pc
+# CHECK-SAME: 0x0000000000000000
+# CHECK:      DW_AT_high_pc
 # CHECK-SAME: 0x0000000000000000
 
 # CHECK:    DW_TAG_call_site

--- a/bolt/test/X86/dwarf5-df-inlined-subroutine-gc-sections-range.test
+++ b/bolt/test/X86/dwarf5-df-inlined-subroutine-gc-sections-range.test
@@ -94,11 +94,11 @@
 ; BOLT-MAIN: DW_AT_call_line
 ; BOLT-MAIN: DW_AT_call_column
 ; BOLT-MAIN: DW_AT_low_pc [DW_FORM_addrx]  (indexed (00000000) address = <unresolved>)
-; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x0000001a)
+; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x00000000)
 ; BOLT-MAIN: DW_TAG_inlined_subroutine
 ; BOLT-MAIN: DW_AT_abstract_origin [DW_FORM_ref4]  (cu + 0x0072 => {0x00000072} "_Z8doStuff2i")
 ; BOLT-MAIN: DW_AT_call_file
 ; BOLT-MAIN: DW_AT_call_line
 ; BOLT-MAIN: DW_AT_call_column
 ; BOLT-MAIN: DW_AT_low_pc [DW_FORM_addrx]  (indexed (00000000) address = <unresolved>)
-; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x0000002d)
+; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x00000000)

--- a/bolt/test/X86/dwarf5-df-inlined-subroutine-range-0.test
+++ b/bolt/test/X86/dwarf5-df-inlined-subroutine-range-0.test
@@ -21,7 +21,7 @@
 ; BOLT-MAIN: DW_AT_call_line
 ; BOLT-MAIN: DW_AT_call_column
 ; BOLT-MAIN: DW_AT_low_pc [DW_FORM_addrx]  (indexed (00000002) address = <unresolved>)
-; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x0000002d)
+; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x00000000)
 
 ; BOLT-MAIN: DW_TAG_inlined_subroutine
 ; BOLT-MAIN: DW_AT_abstract_origin [DW_FORM_ref4]  (cu + 0x005a => {0x0000005a} "_Z11doStuffSamei")
@@ -29,4 +29,4 @@
 ; BOLT-MAIN: DW_AT_call_line [DW_FORM_data1] (16)
 ; BOLT-MAIN: DW_AT_call_column [DW_FORM_data1] (29)
 ; BOLT-MAIN: DW_AT_low_pc [DW_FORM_addrx]  (indexed (00000002) address = <unresolved>)
-; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x00000042)
+; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x00000000)

--- a/bolt/test/X86/dwarf5-locexpr-referrence.test
+++ b/bolt/test/X86/dwarf5-locexpr-referrence.test
@@ -6,11 +6,15 @@
 # RUN: llvm-bolt %t.exe -o %t.bolt --update-debug-sections --debug-thread-count=4 --cu-processing-batch-size=4
 # RUN: llvm-dwarfdump --show-form --verbose --debug-info %t.bolt | FileCheck --check-prefix=CHECK %s
 # RUN: llvm-dwarfdump --show-form --verbose --debug-addr %t.bolt | FileCheck --check-prefix=CHECKADDR %s
+# RUN: llvm-dwarfdump --verify %t.bolt
 
-## This test checks that we update relative DIE references with DW_OP_convert that are in locexpr
-## and checks the address table is correct.
+## This test checks that we update relative DIE references with DW_OP_convert in
+## location expressions and location lists, and checks the address table.
 
 # CHECK: version = 0x0005
+# CHECK: DW_TAG_formal_parameter
+# CHECK-NEXT: DW_AT_location
+# CHECK-NEXT: DW_OP_lit0, DW_OP_convert
 # CHECK: DW_TAG_variable
 # CHECK-NEXT: DW_AT_location
 # CHECK-SAME: DW_OP_convert (0x00000028 -> 0x00000028)

--- a/bolt/test/X86/dwarf5-split-dwarf4-monolithic.test
+++ b/bolt/test/X86/dwarf5-split-dwarf4-monolithic.test
@@ -184,7 +184,7 @@
 # helper1.cpp
 # POSTCHECK: version = 0x0005
 # POSTCHECK: DW_TAG_skeleton_unit [12]
-# POSTCHECK-NEXT: DW_AT_stmt_list [DW_FORM_sec_offset]  (0x000000fe)
+# POSTCHECK-NEXT: DW_AT_stmt_list [DW_FORM_sec_offset]  (0x000000fa)
 # POSTCHECK-NEXT: DW_AT_str_offsets_base [DW_FORM_sec_offset] (0x00000018)
 # POSTCHECK-NEXT: DW_AT_comp_dir [DW_FORM_strx1]  (indexed (00000000) string = ".")
 # POSTCHECK-NEXT: DW_AT_GNU_pubnames [DW_FORM_flag_present] (true)


### PR DESCRIPTION
## Summary

  BOLT rewrites base-type DIE references in inline DWARF expressions, but
  DWARF v5 location-list expressions were copied verbatim. If rebuilding
  the DIE tree changes its layout, operations such as `DW_OP_convert`
  retain stale CU-relative offsets and produce invalid debug information.

  This change:

  - Reuses `DIEBuilder` expression rewriting for DWARF v5 location lists.
  - Emits fixed-width reference operands while constructing location lists.
  - Records and patches those operands after final DIE layout for split
    DWARF and main CU bucket processing.
  - Represents nested DIEs with no translated output as empty `[0,0)`
    ranges instead of fabricating `[0, original_high_pc)` ranges.
  - Extends DWARF4 and DWARF5 coverage for location-list references,
    deleted ranges, split DWARF, and `llvm-dwarfdump --verify`.

  ## Testing

  - Targeted BOLT DWARF location-list and deleted-range tests.
  - Split-DWARF inline-range regression tests.
  - `llvm-dwarfdump --verify` on the rewritten DWARF v5 output.