### PR TITLE
[llvm] Use ValueMap for ValueToGUIDMap

### DIFF
--- a/llvm/include/llvm/IR/Module.h
+++ b/llvm/include/llvm/IR/Module.h
@@ -29,6 +29,7 @@
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/ProfileSummary.h"
 #include "llvm/IR/SymbolTableListTraits.h"
+#include "llvm/IR/ValueMap.h"
 #include "llvm/Support/CBindingWrapping.h"
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/Compiler.h"
@@ -669,7 +670,7 @@ public:
     if (It == ValueToGUIDMap.end())
       return std::nullopt;
 
-    return It->getSecond();
+    return It->second;
   }
 
   void insertGUID(const Value *V, GlobalValue::GUID GUID) {
@@ -684,10 +685,15 @@ public:
   }
 
 private:
+  /// Do not transfer GUID of a value to the value it is being RAUWed with.
+  struct GUIDMapConfig : ValueMapConfig<const Value *> {
+    enum { FollowRAUW = false };
+  };
+
   /// A mapping directly from Value to GUID. Populated from bitcode
   /// (MODULE_CODE_GUIDLIST). Necessary for lazy-loading modules, where we
   /// don't load metadata.
-  DenseMap<const Value *, GlobalValue::GUID> ValueToGUIDMap;
+  ValueMap<const Value *, GlobalValue::GUID, GUIDMapConfig> ValueToGUIDMap;
 
   /// @}
   /// @name Direct access to the globals list, functions list, and symbol table

--- a/llvm/unittests/IR/ModuleTest.cpp
+++ b/llvm/unittests/IR/ModuleTest.cpp
@@ -318,6 +318,30 @@ TEST(ModuleTest, NamedMDList) {
   EXPECT_EQ(M->named_metadata_size(), 2u);
 }
 
+TEST(ModuleTest, ValueToGUIDMap) {
+  LLVMContext Context;
+  Module M("M", Context);
+  Type *Ty = Type::getInt32Ty(Context);
+  Constant *Init = ConstantInt::get(Ty, 0);
+  auto *OldGV = new GlobalVariable(M, Ty, /*isConstant=*/false,
+                                   GlobalValue::InternalLinkage, Init, "old");
+  auto *NewGV = new GlobalVariable(M, Ty, /*isConstant=*/false,
+                                   GlobalValue::InternalLinkage, Init, "new");
+
+  constexpr GlobalValue::GUID GUID = 101;
+  M.insertGUID(OldGV, GUID);
+  ASSERT_EQ(M.getGUID(OldGV), GUID);
+
+  // GUID does not follow RAUW.
+  OldGV->replaceAllUsesWith(NewGV);
+  EXPECT_EQ(M.getGUID(OldGV), GUID);
+  EXPECT_FALSE(M.getGUID(NewGV).has_value());
+
+  // Mapping deleted upon Value deletion (no dangling pointer in map)
+  OldGV->eraseFromParent();
+  EXPECT_FALSE(M.getGUID(OldGV).has_value());
+}
+
 TEST(ModuleTest, GlobalList) {
   // This tests all Module's functions that interact with Module::GlobalList.
   LLVMContext C;


### PR DESCRIPTION
ValueToGUIDMap currently uses a DenseMap which does not properly track the deletion of Values, leaving dangling pointers in the map.

This change fixes this by using ValueMap. FollowRAUW is set to false to match the current behavior of DenseMap.

This bug was discovered by a sanity test for deterministic compilation where, depending on the allocator state, a newly allocated Value could re-use the address of a previously deleted one, incorrectly inheriting the GUID.