### PR TITLE
[LICM] allow hoisting invariant loads when loop cant free

### DIFF
--- a/llvm/lib/Transforms/Scalar/LICM.cpp
+++ b/llvm/lib/Transforms/Scalar/LICM.cpp
@@ -1835,6 +1835,28 @@ static bool isSafeToExecuteUnconditionally(
   bool GuaranteedToExecute =
       SafetyInfo->isGuaranteedToExecute(Inst, DT, CurLoop);
 
+  // Under point-scoped dereferenceability, isSafeToSpeculativelyExecute may
+  // fail
+  // at CtxI (the Preheader) due to conservative willNotFreeBetween checks.
+  // If the loop contains no instructions that can free memory and the load's
+  // address is loop-invariant, the load can be safely hoisted if it is
+  // dereferenceable at loop entry.
+  if (!GuaranteedToExecute && AllowSpeculation) {
+    if (auto *LI = dyn_cast<LoadInst>(&Inst)) {
+      Value *Ptr = LI->getPointerOperand();
+      if (CurLoop->isLoopInvariant(Ptr) && LI->isUnordered()) {
+        BasicBlock *Header = CurLoop->getHeader();
+        // Check if the loop does not contain throwing/freeing calls
+        if (!SafetyInfo->anyBlockMayThrow() && CurLoop->hasDedicatedExits()) {
+          const SimplifyQuery SQ(LI->getDataLayout(), TLI, DT, AC, CtxI);
+          if (isDereferenceableAndAlignedPointer(
+                  Ptr, LI->getType(), LI->getAlign(), SQ, /*IgnoreFree=*/true))
+            return true;
+        }
+      }
+    }
+  }
+
   if (!GuaranteedToExecute) {
     auto *LI = dyn_cast<LoadInst>(&Inst);
     if (LI && CurLoop->isLoopInvariant(LI->getPointerOperand()))

--- a/llvm/test/Transforms/LICM/hoist-speculatable-load.ll
+++ b/llvm/test/Transforms/LICM/hoist-speculatable-load.ll
@@ -66,12 +66,12 @@ define void @f_nofree_nosync(i32 %ptr_i, ptr %ptr2, i1 %cond) nofree nosync {
 ; CHECK-NEXT:    store i32 0, ptr [[PTR2:%.*]], align 4
 ; CHECK-NEXT:    br label [[FOR_BODY_LR_PH]]
 ; CHECK:       for.body.lr.ph:
+; CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[PTR]], align 4
 ; CHECK-NEXT:    br label [[FOR_BODY:%.*]]
 ; CHECK:       for.body:
 ; CHECK-NEXT:    [[I_08:%.*]] = phi i32 [ 0, [[FOR_BODY_LR_PH]] ], [ [[INC:%.*]], [[IF_END:%.*]] ]
 ; CHECK-NEXT:    br i1 [[COND]], label [[IF_END]], label [[IF:%.*]]
 ; CHECK:       if:
-; CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[PTR]], align 4, !invariant.load [[META0]]
 ; CHECK-NEXT:    store i32 [[TMP0]], ptr [[PTR2]], align 4
 ; CHECK-NEXT:    br label [[IF_END]]
 ; CHECK:       if.end:


### PR DESCRIPTION
Details:
- With point scoped dereferenceability, LICM can fail to hoist loop invariant loads because of conservative willNotFreeBween checks (at preheader)
- If the ptr is invariant and the loop can't throw/exit abnormally, then it's safe to assume deallocs cannot occur during loop execution.

This change allows hoisting these loads to the preheader.

(Testing this with our internal benchmarks, we've seen noticeable improvement in performance)