### PR TITLE
[Clang][OpenMP] Lower assume directive's holds clause to llvm.assume

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -786,6 +786,9 @@ The `alpha.cplusplus.UseAfterLifetimeEnd` checker was renamed to `alpha.core.Use
 - Mapping of expressions with base-pointers through a user-defined mapper (e.g.
   `map(s.p[0:n])`) now conforms to OpenMP's conditional pointer-attachment,
   matching the behavior of such maps outside a mapper.
+- The `holds` clause on the `assume` directive now lowers side-effect-free
+  conditions to `llvm.assume`, enabling downstream optimizations. Previously
+  the clause was parsed but its condition was discarded without effect.
 
 ### SYCL Support
 

--- a/clang/lib/CodeGen/CGStmtOpenMP.cpp
+++ b/clang/lib/CodeGen/CGStmtOpenMP.cpp
@@ -8926,5 +8926,11 @@ void CodeGenFunction::EmitSimpleOMPExecutableDirective(
 }
 
 void CodeGenFunction::EmitOMPAssumeDirective(const OMPAssumeDirective &S) {
+  for (const auto *C : S.getClausesOfKind<OMPHoldsClause>()) {
+    const Expr *E = C->getExpr();
+    assert(E && "holds clause requires an expression");
+    if (!E->HasSideEffects(getContext()))
+      Builder.CreateAssumption(EvaluateExprAsBool(E));
+  }
   EmitStmt(S.getAssociatedStmt());
 }

--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -26431,6 +26431,9 @@ OMPClause *SemaOpenMP::ActOnOpenMPXBareClause(SourceLocation StartLoc,
 OMPClause *SemaOpenMP::ActOnOpenMPHoldsClause(Expr *E, SourceLocation StartLoc,
                                               SourceLocation LParenLoc,
                                               SourceLocation EndLoc) {
+  if (E->HasSideEffects(getASTContext()))
+    Diag(E->getBeginLoc(), diag::warn_assume_side_effects)
+        << "holds" << E->getSourceRange();
   return new (getASTContext()) OMPHoldsClause(E, StartLoc, LParenLoc, EndLoc);
 }
 

--- a/clang/test/OpenMP/assume_holds_codegen.cpp
+++ b/clang/test/OpenMP/assume_holds_codegen.cpp
@@ -1,0 +1,50 @@
+// RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=60 -x c++ -emit-llvm %s -triple x86_64-unknown-unknown -o - | FileCheck %s
+// expected-no-diagnostics
+
+// CHECK-LABEL: @_Z4testii(
+// CHECK: [[CMP:%.*]] = icmp sgt i32 %{{.*}}, 0
+// CHECK: call void @llvm.assume(i1 [[CMP]])
+void test(int n, int m) {
+  #pragma omp assume holds(n > 0)
+  {
+    m = n + 1;
+  }
+}
+
+// CHECK-LABEL: @_Z12test_complexi(
+// CHECK: [[CMP1:%.*]] = icmp sge i32 %{{.*}}, 10
+// CHECK: br i1 [[CMP1]]
+// CHECK: [[CMP2:%.*]] = icmp eq i32 %{{.*}}, 0
+// CHECK: [[COND:%.*]] = phi i1 [ false, %{{.*}} ], [ [[CMP2]], %{{.*}} ]
+// CHECK: call void @llvm.assume(i1 [[COND]])
+void test_complex(int n) {
+  #pragma omp assume holds(n >= 10 && n % 4 == 0)
+  {
+    for (int i = 0; i < n; i++) {}
+  }
+}
+
+// CHECK-LABEL: @_Z16test_multi_holdsii(
+// CHECK: [[CMPA:%.*]] = icmp ne i32 %{{.*}}, 0
+// CHECK: call void @llvm.assume(i1 [[CMPA]])
+// CHECK: [[CMPB:%.*]] = icmp slt i32 %{{.*}}, 100
+// CHECK: call void @llvm.assume(i1 [[CMPB]])
+void test_multi_holds(int a, int b) {
+  #pragma omp assume holds(a) holds(b < 100)
+  {
+    int c = a + b;
+  }
+}
+
+// CHECK-LABEL: @_Z7test_orii(
+// CHECK: [[CMPA:%.*]] = icmp eq i32 %{{.*}}, 1
+// CHECK: br i1 [[CMPA]]
+// CHECK: [[CMPB:%.*]] = icmp eq i32 %{{.*}}, 2
+// CHECK: [[COND:%.*]] = phi i1 [ true, %{{.*}} ], [ [[CMPB]], %{{.*}} ]
+// CHECK: call void @llvm.assume(i1 [[COND]])
+void test_or(int mode, int x) {
+  #pragma omp assume holds(mode == 1 || mode == 2)
+  {
+    x = mode + 1;
+  }
+}

--- a/clang/test/OpenMP/assume_holds_side_effects.cpp
+++ b/clang/test/OpenMP/assume_holds_side_effects.cpp
@@ -1,0 +1,32 @@
+// RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=60 -x c++ -emit-llvm %s -triple x86_64-unknown-unknown -o - | FileCheck %s
+
+int g;
+int f() { return g++; }
+
+void test_side_effects() {
+  // expected-warning@+1 {{assumption is ignored because it contains (potential) side-effects}}
+  #pragma omp assume holds(f())
+  {
+    g = 1;
+  }
+}
+
+// CHECK-LABEL: @_Z17test_side_effectsv(
+// CHECK-NOT: call void @llvm.assume
+// CHECK-NOT: call{{.*}}@_Z1fv
+// CHECK: store i32 1
+// CHECK: ret void
+
+void test_mixed(int n, int m) {
+  // expected-warning@+1 {{assumption is ignored because it contains (potential) side-effects}}
+  #pragma omp assume holds(n > 0) holds(m++)
+  {
+    g = n;
+  }
+}
+
+// CHECK-LABEL: @_Z10test_mixedii(
+// CHECK: [[CMP:%.*]] = icmp sgt i32 %{{.*}}, 0
+// CHECK: call void @llvm.assume(i1 [[CMP]])
+// CHECK-NOT: call void @llvm.assume(i1
+// CHECK: ret void


### PR DESCRIPTION
Emit `@llvm.assume` for the OpenMP 5.1 `assume` directive's `holds()` clause, enabling downstream optimizations. Previously the clause was parsed but its condition discarded without effect. Side-effectful conditions are skipped with a warning, matching the existing `[[assume]]`/`__builtin_assume` behavior.
  
