### PR TITLE
[bazel][lldb] Update lldb's BUILD.bazel file to fix failure.

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
@@ -1339,6 +1339,7 @@ cc_library(
         "//lldb:Target",
         "//lldb:TargetHeaders",
         "//lldb:Utility",
+        "//llvm:Support",
     ],
 )
 
@@ -2057,6 +2058,7 @@ cc_library(
         "//lldb:Target",
         "//lldb:TargetHeaders",
         "//lldb:Utility",
+        "//llvm:Support",
     ],
 )
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/216389 introduced some new dependencies for some lldb Plugin builds that were not reflected in the bazel file. This fixes that issue.