### PR TITLE
[flang-rt] Resolve unit test shared library paths

### DIFF
--- a/flang-rt/unittests/CMakeLists.txt
+++ b/flang-rt/unittests/CMakeLists.txt
@@ -30,6 +30,16 @@ add_dependencies(flang-rt-test-depends
   flang_rt.runtime.unittest
 )
 
+# Unittests are C++ binaries. CMake still treats flang_rt.runtime as a Fortran
+# target, so it appends the Fortran compiler's implicit link libraries, which
+# include -lflang_rt.runtime. When the shared runtime is built, that flag
+# resolves to the shared library in the compiler's resource directory, which is
+# not a loader search path, so record that directory in the RPATH of the
+# unittests.
+if (FLANG_RT_ENABLE_SHARED)
+  list(APPEND CMAKE_BUILD_RPATH "${RUNTIMES_OUTPUT_RESOURCE_LIB_DIR}")
+endif ()
+
 if (CXX_SUPPORTS_SUGGEST_OVERRIDE_FLAG)
   add_compile_options("-Wno-suggest-override")
 endif()


### PR DESCRIPTION
This PR resolves a problem with finding the libflang_rt.runtime.so library when running flang-rt unit tests whose failure looked like:

FAIL: flang-rt-Unit ::
Runtime/CUDA/./FlangCufRuntimeTests/failed_to_discover_tests_from_gtest (1 of 17)
******************** TEST 'flang-rt-Unit ::
Runtime/CUDA/./FlangCufRuntimeTests/failed_to_discover_tests_from_gtest' FAILED ********************

********************
FAIL: flang-rt-Unit ::
Runtime/./RuntimeTests/failed_to_discover_tests_from_gtest (2 of 17) ******************** TEST 'flang-rt-Unit ::
Runtime/./RuntimeTests/failed_to_discover_tests_from_gtest' FAILED ********************

********************
FAIL: flang-rt-OldUnit :: Evaluate/ISO-Fortran-binding.test (3 of 17) ******************** TEST 'flang-rt-OldUnit ::
Evaluate/ISO-Fortran-binding.test' FAILED ******************** PATH_TO_FLANG_RT/unittests/Evaluate/ISO-Fortran-binding.test: error while loading shared libraries: libflang_rt.runtime.so: cannot open shared object file: No such file or directory

********************
FAIL: flang-rt-OldUnit :: Evaluate/reshape.test (4 of 17) ******************** TEST 'flang-rt-OldUnit :: Evaluate/reshape.test' FAILED ********************
PATH_TO_FLANG_RT/unittests/Evaluate/reshape.test: error while loading shared libraries: libflang_rt.runtime.so: cannot open shared object file: No such file or directory

********************
********************
Failed Tests (4):
  flang-rt-OldUnit :: Evaluate/ISO-Fortran-binding.test
  flang-rt-OldUnit :: Evaluate/reshape.test
  flang-rt-Unit ::
Runtime/./RuntimeTests/failed_to_discover_tests_from_gtest
  flang-rt-Unit ::
Runtime/CUDA/./FlangCufRuntimeTests/failed_to_discover_tests_from_gtest