### PR TITLE
[AMDGPU] Add APIs `getTotalNumVGPRs` and `getAddressableNumVGPRs` to TargetParser

### DIFF
--- a/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
+++ b/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
@@ -215,6 +215,18 @@ LLVM_ABI unsigned getVGPRAllocGranule(GPUKind AK, bool IsWave32);
 LLVM_ABI unsigned getVGPRAllocGranule(Triple::SubArchType SubArch,
                                       bool IsWave32);
 
+/// \returns Number of physical VGPRs, i.e. the size of the register file a
+/// work-group's waves share. \p IsWave32 selects the wavefront size.
+LLVM_ABI unsigned getTotalNumVGPRs(GPUKind AK, bool IsWave32);
+LLVM_ABI unsigned getTotalNumVGPRs(Triple::SubArchType SubArch, bool IsWave32);
+
+/// \returns Number of VGPRs a single wave can address. On a target with a
+/// unified register file this covers the AGPRs as well. This does not account
+/// for dynamic VGPR mode, which caps allocation at a fixed number of blocks.
+LLVM_ABI unsigned getAddressableNumVGPRs(GPUKind AK, bool IsWave32);
+LLVM_ABI unsigned getAddressableNumVGPRs(Triple::SubArchType SubArch,
+                                         bool IsWave32);
+
 /// \returns Maximum LDS in bytes a single work-group can address. This is a
 /// fixed hardware cap and does not depend on how many SIMDs a work-group runs
 /// on.

--- a/llvm/lib/Target/AMDGPU/AMDGPU.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.td
@@ -3244,7 +3244,7 @@ def AMDGPUFrontendVisibleFeatures {
   FeatureSupportsWave32, FeatureFastFMAF32, FeatureFastDenormalF32,
   FeatureSupportsXNACK, FeatureSupportsSRAMECC, FeatureXNACKOnOffModes,
   FeatureSGPRInitBug, FeatureApertureRegs, FeatureGetDoorbellID,
-  FeatureAGPRAlloc, Feature1536VGPRs,
+  FeatureAGPRAlloc, Feature1536VGPRs, Feature1024AddressableVGPRs,
   FeatureHalfAddressablePhysicalLocalMemory,
   ];
 }

--- a/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
@@ -420,7 +420,7 @@ const AMDGPUMCExpr *createOccupancy(unsigned InitOcc, const MCExpr *NumSGPRs,
                                     const GCNSubtarget &STM, MCContext &Ctx) {
   unsigned MaxWaves = STM.getMaxWavesPerEU();
   unsigned Granule = IsaInfo::getVGPRAllocGranule(STM, DynamicVGPRBlockSize);
-  unsigned TargetTotalNumVGPRs = IsaInfo::getTotalNumVGPRs(STM);
+  unsigned TargetTotalNumVGPRs = STM.getTotalNumVGPRs();
 
   // Bake the per-function SGPR budget into the operands so the late-evaluated
   // MCExpr stays arithmetic. The trap reservation in particular is implicit on

--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.h
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.h
@@ -858,7 +858,7 @@ public:
 
   /// \returns Total number of VGPRs supported by the subtarget.
   unsigned getTotalNumVGPRs() const {
-    return AMDGPU::IsaInfo::getTotalNumVGPRs(*this);
+    return AMDGPU::getTotalNumVGPRs(getTargetID().getGPUKind(), isWave32());
   }
 
   /// \returns Addressable number of architectural VGPRs supported by the
@@ -869,7 +869,14 @@ public:
 
   /// \returns Addressable number of VGPRs supported by the subtarget.
   unsigned getAddressableNumVGPRs(unsigned DynamicVGPRBlockSize) const {
-    return AMDGPU::IsaInfo::getAddressableNumVGPRs(*this, DynamicVGPRBlockSize);
+    // Dynamic VGPR mode is a per-kernel mode, so it is not covered by the
+    // TargetParser query.
+    if (DynamicVGPRBlockSize != 0) {
+      return AMDGPU::IsaInfo::getAddressableNumVGPRs(*this,
+                                                     DynamicVGPRBlockSize);
+    }
+    return AMDGPU::getAddressableNumVGPRs(getTargetID().getGPUKind(),
+                                          isWave32());
   }
 
   /// \returns the minimum number of VGPRs that will prevent achieving more than

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -1402,17 +1402,6 @@ unsigned getVGPREncodingGranule(const MCSubtargetInfo &STI,
 
 unsigned getArchVGPRAllocGranule() { return 4; }
 
-unsigned getTotalNumVGPRs(const MCSubtargetInfo &STI) {
-  if (STI.getFeatureBits().test(FeatureGFX90AInsts))
-    return 512;
-  if (!isGFX10Plus(STI))
-    return 256;
-  bool IsWave32 = STI.getFeatureBits().test(FeatureWavefrontSize32);
-  if (STI.getFeatureBits().test(Feature1536VGPRs))
-    return IsWave32 ? 1536 : 768;
-  return IsWave32 ? 1024 : 512;
-}
-
 unsigned getAddressableNumArchVGPRs(const MCSubtargetInfo &STI) {
   const auto &Features = STI.getFeatureBits();
   if (Features.test(Feature1024AddressableVGPRs))
@@ -1437,9 +1426,11 @@ unsigned getAddressableNumVGPRs(const MCSubtargetInfo &STI,
 unsigned getNumWavesPerEUWithNumVGPRs(const MCSubtargetInfo &STI,
                                       unsigned NumVGPRs,
                                       unsigned DynamicVGPRBlockSize) {
+  GPUKind Kind = parseArchAMDGCN(STI.getCPU());
+  bool IsWave32 = STI.getFeatureBits().test(FeatureWavefrontSize32);
   return getNumWavesPerEUWithNumVGPRs(
       NumVGPRs, getVGPRAllocGranule(STI, DynamicVGPRBlockSize),
-      getMaxWavesPerEU(parseArchAMDGCN(STI.getCPU())), getTotalNumVGPRs(STI));
+      getMaxWavesPerEU(Kind), AMDGPU::getTotalNumVGPRs(Kind, IsWave32));
 }
 
 unsigned getNumWavesPerEUWithNumVGPRs(unsigned NumVGPRs, unsigned Granule,
@@ -1485,11 +1476,13 @@ unsigned getMinNumVGPRs(const MCSubtargetInfo &STI, unsigned WavesPerEU,
   if (DynamicVGPREnabled)
     return 0;
 
-  unsigned MaxWavesPerEU = getMaxWavesPerEU(parseArchAMDGCN(STI.getCPU()));
+  GPUKind Kind = parseArchAMDGCN(STI.getCPU());
+  unsigned MaxWavesPerEU = getMaxWavesPerEU(Kind);
   if (WavesPerEU >= MaxWavesPerEU)
     return 0;
 
-  unsigned TotNumVGPRs = getTotalNumVGPRs(STI);
+  unsigned TotNumVGPRs = AMDGPU::getTotalNumVGPRs(
+      Kind, STI.getFeatureBits().test(FeatureWavefrontSize32));
   unsigned AddrsableNumVGPRs =
       getAddressableNumVGPRs(STI, DynamicVGPRBlockSize);
   unsigned Granule = getVGPRAllocGranule(STI, DynamicVGPRBlockSize);
@@ -1512,12 +1505,16 @@ unsigned getMaxNumVGPRs(const MCSubtargetInfo &STI, unsigned WavesPerEU,
                         unsigned DynamicVGPRBlockSize) {
   assert(WavesPerEU != 0);
 
+  unsigned TotNumVGPRs = AMDGPU::getTotalNumVGPRs(
+      parseArchAMDGCN(STI.getCPU()),
+      STI.getFeatureBits().test(FeatureWavefrontSize32));
+
   // In dynamic VGPR mode, WavesPerEU does not imply a VGPR limit.
   bool DynamicVGPREnabled = (DynamicVGPRBlockSize != 0);
   unsigned MaxNumVGPRs =
       DynamicVGPREnabled
-          ? getTotalNumVGPRs(STI)
-          : alignDown(getTotalNumVGPRs(STI) / WavesPerEU,
+          ? TotNumVGPRs
+          : alignDown(TotNumVGPRs / WavesPerEU,
                       getVGPRAllocGranule(STI, DynamicVGPRBlockSize));
   unsigned AddressableNumVGPRs =
       getAddressableNumVGPRs(STI, DynamicVGPRBlockSize);

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
@@ -246,9 +246,6 @@ unsigned getVGPREncodingGranule(
 /// returns the allocation granule for ArchVGPRs.
 unsigned getArchVGPRAllocGranule();
 
-/// \returns Total number of VGPRs for given subtarget \p STI.
-unsigned getTotalNumVGPRs(const MCSubtargetInfo &STI);
-
 /// Maximum number of VGPR blocks that can be allocated in dynamic VGPR mode.
 static constexpr unsigned MaxDynamicVGPRBlocks = 8;
 

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -451,6 +451,36 @@ unsigned AMDGPU::getVGPRAllocGranule(Triple::SubArchType SubArch,
   return getVGPRAllocGranule(getGPUKindFromSubArch(SubArch), IsWave32);
 }
 
+unsigned AMDGPU::getTotalNumVGPRs(GPUKind AK, bool IsWave32) {
+  const AMDGPUFeatureBitset &Features = getFeatureBitset(AK);
+  if (Features.test(FEAT_GFX90A_INSTS))
+    return 512;
+  if (!Features.test(FEAT_GFX10_INSTS))
+    return 256;
+  if (Features.test(FEAT_1536_PHYSICAL_VGPRS))
+    return IsWave32 ? 1536 : 768;
+  return IsWave32 ? 1024 : 512;
+}
+
+unsigned AMDGPU::getTotalNumVGPRs(Triple::SubArchType SubArch, bool IsWave32) {
+  return getTotalNumVGPRs(getGPUKindFromSubArch(SubArch), IsWave32);
+}
+
+unsigned AMDGPU::getAddressableNumVGPRs(GPUKind AK, bool IsWave32) {
+  const AMDGPUFeatureBitset &Features = getFeatureBitset(AK);
+  // The unified register file makes the AGPRs addressable as VGPRs.
+  if (Features.test(FEAT_GFX90A_INSTS))
+    return 512;
+  if (Features.test(FEAT_1024_ADDRESSABLE_VGPRS))
+    return IsWave32 ? 1024 : 512;
+  return 256;
+}
+
+unsigned AMDGPU::getAddressableNumVGPRs(Triple::SubArchType SubArch,
+                                        bool IsWave32) {
+  return getAddressableNumVGPRs(getGPUKindFromSubArch(SubArch), IsWave32);
+}
+
 unsigned AMDGPU::getMaxHWAddressableLocalMemorySize(GPUKind AK) {
   const GPUInfo *Info = getAMDGPUInfo(AK);
   return Info ? Info->MaxHWAddressableLocalMemorySize : 32768;
@@ -494,12 +524,19 @@ StringRef AMDGPU::getCanonicalArchName(const Triple &T, StringRef Arch) {
 // FIXME: This is hacky, we shouldn't have mismatches between the bitset and
 // feature string map.
 static const AMDGPUFeatureBitset FrontendOnlyFeatures = {
-    FEAT_FAST_FMAF,           FEAT_FAST_DENORMAL_F32,
-    FEAT_SUPPORTS_WAVE32,     FEAT_SUPPORTS_WGP,
-    FEAT_XNACK_SUPPORT,       FEAT_SRAMECC_SUPPORT,
-    FEAT_XNACK_ON_OFF_MODES,  FEAT_APERTURE_REGS,
-    FEAT_GET_DOORBELL_ID,     FEAT_AGPR_ALLOC,
-    FEAT_1536_PHYSICAL_VGPRS, FEAT_HALF_ADDRESSABLE_PHYSICAL_LOCAL_MEMORY};
+    FEAT_FAST_FMAF,
+    FEAT_FAST_DENORMAL_F32,
+    FEAT_SUPPORTS_WAVE32,
+    FEAT_SUPPORTS_WGP,
+    FEAT_XNACK_SUPPORT,
+    FEAT_SRAMECC_SUPPORT,
+    FEAT_XNACK_ON_OFF_MODES,
+    FEAT_APERTURE_REGS,
+    FEAT_GET_DOORBELL_ID,
+    FEAT_AGPR_ALLOC,
+    FEAT_1536_PHYSICAL_VGPRS,
+    FEAT_HALF_ADDRESSABLE_PHYSICAL_LOCAL_MEMORY,
+    FEAT_1024_ADDRESSABLE_VGPRS};
 
 // Add a GPU's features (minus the frontend-only ones) to \p Features. With \p
 // Overwrite false, existing entries are kept so user -mattr overrides win.

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -3143,6 +3143,49 @@ TEST(TargetParserTest, testAMDGPUgetVGPRAllocGranule) {
   EXPECT_EQ(AMDGPU::getVGPRAllocGranule(Triple::AMDGPUSubArch1100, true), 24u);
 }
 
+TEST(TargetParserTest, testAMDGPUgetTotalNumVGPRs) {
+  // Pre-gfx10 the file is 256 registers, and gfx90a doubles it by unifying the
+  // AGPRs. From gfx10 on it is split between the waves of a wave64 kernel.
+  EXPECT_EQ(AMDGPU::getTotalNumVGPRs(AMDGPU::GK_GFX600, false), 256u);
+  EXPECT_EQ(AMDGPU::getTotalNumVGPRs(AMDGPU::GK_GFX600, true), 256u);
+
+  EXPECT_EQ(AMDGPU::getTotalNumVGPRs(AMDGPU::GK_GFX90A, false), 512u);
+  EXPECT_EQ(AMDGPU::getTotalNumVGPRs(AMDGPU::GK_GFX90A, true), 512u);
+
+  EXPECT_EQ(AMDGPU::getTotalNumVGPRs(AMDGPU::GK_GFX1030, false), 512u);
+  EXPECT_EQ(AMDGPU::getTotalNumVGPRs(AMDGPU::GK_GFX1030, true), 1024u);
+
+  // gfx11+ has 1536 physical VGPRs.
+  EXPECT_EQ(AMDGPU::getTotalNumVGPRs(AMDGPU::GK_GFX1100, false), 768u);
+  EXPECT_EQ(AMDGPU::getTotalNumVGPRs(AMDGPU::GK_GFX1100, true), 1536u);
+
+  // An unknown GPU falls back to the pre-gfx10 file size.
+  EXPECT_EQ(AMDGPU::getTotalNumVGPRs(AMDGPU::GK_NONE, true), 256u);
+
+  EXPECT_EQ(AMDGPU::getTotalNumVGPRs(Triple::AMDGPUSubArch90A, true), 512u);
+  EXPECT_EQ(AMDGPU::getTotalNumVGPRs(Triple::AMDGPUSubArch1100, true), 1536u);
+}
+
+TEST(TargetParserTest, testAMDGPUgetAddressableNumVGPRs) {
+  // A wave addresses 256 VGPRs, except on gfx90a where the unified file makes
+  // the AGPRs addressable too, and on targets with 1024 addressable VGPRs.
+  EXPECT_EQ(AMDGPU::getAddressableNumVGPRs(AMDGPU::GK_GFX600, false), 256u);
+  EXPECT_EQ(AMDGPU::getAddressableNumVGPRs(AMDGPU::GK_GFX1030, true), 256u);
+
+  EXPECT_EQ(AMDGPU::getAddressableNumVGPRs(AMDGPU::GK_GFX90A, false), 512u);
+  EXPECT_EQ(AMDGPU::getAddressableNumVGPRs(AMDGPU::GK_GFX90A, true), 512u);
+
+  EXPECT_EQ(AMDGPU::getAddressableNumVGPRs(AMDGPU::GK_GFX1250, false), 512u);
+  EXPECT_EQ(AMDGPU::getAddressableNumVGPRs(AMDGPU::GK_GFX1250, true), 1024u);
+
+  EXPECT_EQ(AMDGPU::getAddressableNumVGPRs(AMDGPU::GK_NONE, true), 256u);
+
+  EXPECT_EQ(AMDGPU::getAddressableNumVGPRs(Triple::AMDGPUSubArch90A, true),
+            512u);
+  EXPECT_EQ(AMDGPU::getAddressableNumVGPRs(Triple::AMDGPUSubArch1250, true),
+            1024u);
+}
+
 TEST(TargetParserTest, testAMDGPUgetMaxHWAddressableLocalMemorySize) {
   // The addressable cap is a fixed hardware property, independent of how many
   // SIMDs a work-group runs on.


### PR DESCRIPTION
These align with `getTotalNumSGPRs` and `getAddressableNumSGPRs` that already exist.