### PR TITLE
[Clang] Always apply `-frtlib-add-rpath` if requested

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -1050,10 +1050,8 @@ void ToolChain::addFlangRTLibPath(const ArgList &Args,
                    options::OPT_shared_libflangrt, getTriple().isOSAIX()))
     CmdArgs.push_back(
         getCompilerRTArgString(Args, "runtime", ToolChain::FT_Static, true));
-  else {
+  else
     CmdArgs.push_back("-lflang_rt.runtime");
-    addArchSpecificRPath(*this, Args, CmdArgs);
-  }
 }
 
 // Android target triples contain a target version. If we don't have libraries

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1561,8 +1561,6 @@ bool tools::addOpenMPRuntime(const Compilation &C, ArgStringList &CmdArgs,
   if (IsOffloadingHost)
     CmdArgs.push_back("-lomptarget");
 
-  addArchSpecificRPath(TC, Args, CmdArgs);
-
   addOpenMPRuntimeLibraryPath(TC, Args, CmdArgs);
 
   return true;
@@ -1595,11 +1593,8 @@ static void addSanitizerRuntime(const ToolChain &TC, const ArgList &Args,
   if (IsWhole) CmdArgs.push_back("--whole-archive");
   CmdArgs.push_back(TC.getCompilerRTArgString(
       Args, Sanitizer, IsShared ? ToolChain::FT_Shared : ToolChain::FT_Static));
-  if (IsWhole) CmdArgs.push_back("--no-whole-archive");
-
-  if (IsShared) {
-    addArchSpecificRPath(TC, Args, CmdArgs);
-  }
+  if (IsWhole)
+    CmdArgs.push_back("--no-whole-archive");
 }
 
 // Tries to use a file with the list of dynamic symbols that need to be exported

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1480,7 +1480,9 @@ void tools::addArchSpecificRPath(const ToolChain &TC, const ArgList &Args,
                     options::OPT_fno_rtlib_add_rpath, false))
     return;
 
-  if (TC.getTriple().isOSAIX()) // TODO: AIX doesn't support -rpath option.
+  // Using -rpath is a host ELF/Mach-O linker option.
+  const llvm::Triple &Triple = TC.getTriple();
+  if ((!Triple.isOSBinFormatELF() && !Triple.isOSBinFormatMachO()))
     return;
 
   SmallVector<std::string> CandidateRPaths(TC.getArchSpecificLibPaths());

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -575,9 +575,10 @@ void tools::AddLinkerInputs(const ToolChain &TC, const InputInfoList &Inputs,
         CmdArgs.push_back(Args.MakeArgString("-lm"));
       if (Triple.isOSLinux())
         CmdArgs.push_back(Args.MakeArgString("--pop-state"));
-      addArchSpecificRPath(TC, Args, CmdArgs);
     }
   }
+
+  addArchSpecificRPath(TC, Args, CmdArgs);
 }
 
 const char *tools::getLDMOption(const llvm::Triple &T, const ArgList &Args) {

--- a/clang/lib/Driver/ToolChains/VEToolchain.cpp
+++ b/clang/lib/Driver/ToolChains/VEToolchain.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "VEToolchain.h"
-#include "clang/Driver/CommonArgs.h"
 #include "clang/Driver/Compilation.h"
 #include "clang/Driver/Driver.h"
 #include "clang/Options/Options.h"
@@ -139,8 +138,6 @@ void VEToolChain::AddCXXStdlibLibArgs(const ArgList &Args,
                                       ArgStringList &CmdArgs) const {
   assert((GetCXXStdlibType(Args) == ToolChain::CST_Libcxx) &&
          "Only -lc++ (aka libxx) is supported in this toolchain.");
-
-  tools::addArchSpecificRPath(*this, Args, CmdArgs);
 
   // Add paths for libc++.so and other shared libraries.
   if (std::optional<std::string> Path = getStdlibPath()) {

--- a/clang/test/Driver/arch-specific-libdir-rpath.c
+++ b/clang/test/Driver/arch-specific-libdir-rpath.c
@@ -16,20 +16,11 @@
 // RUN:     -fno-rtlib-add-rpath 2>&1 \
 // RUN:   | FileCheck --check-prefixes=RESDIR,LIBPATH-X86_64,NO-RPATH-X86_64 %s
 //
-// Test that -rpath is added only under the right circumstance even if
-// -frtlib-add-rpath is specified.
-//
-// Add LIBPATH but no RPATH for -fsanitizer=address w/o -shared-libasan
+// Add RPATH if requested.
 // RUN: %clang %s -### --target=x86_64-linux -fsanitize=undefined \
 // RUN:     -resource-dir=%S/Inputs/resource_dir_with_arch_subdir \
 // RUN:     -frtlib-add-rpath 2>&1 \
-// RUN:   | FileCheck --check-prefixes=RESDIR,LIBPATH-X86_64,NO-RPATH-X86_64 %s
-//
-// Add LIBPATH but no RPATH for -fsanitizer=address w/o -shared-libasan
-// RUN: %clang %s -### --target=x86_64-linux -fsanitize=undefined \
-// RUN:     -resource-dir=%S/Inputs/resource_dir_with_arch_subdir \
-// RUN:     -frtlib-add-rpath 2>&1 \
-// RUN:   | FileCheck --check-prefixes=RESDIR,LIBPATH-X86_64,NO-RPATH-X86_64 %s
+// RUN:   | FileCheck --check-prefixes=RESDIR,LIBPATH-X86_64,RPATH-X86_64 %s
 //
 // Add LIBPATH, RPATH for -fsanitize=address -shared-libasan
 // RUN: %clang %s -### --target=x86_64-linux \
@@ -57,23 +48,30 @@
 // RUN:     -frtlib-add-rpath 2>&1 \
 // RUN:   | FileCheck --check-prefixes=RESDIR,LIBPATH-X86_64,RPATH-X86_64 %s
 //
-// Add LIBPATH but no RPATH for ubsan (or any other sanitizer)
+// Add LIBPATH, RPATH for ubsan (or any other sanitizer)
 // RUN: %clang %s -### -fsanitize=undefined --target=x86_64-linux \
 // RUN:     -resource-dir=%S/Inputs/resource_dir_with_arch_subdir \
 // RUN:     -frtlib-add-rpath 2>&1 \
-// RUN:   | FileCheck --check-prefixes=RESDIR,LIBPATH-X86_64,NO-RPATH-X86_64 %s
+// RUN:   | FileCheck --check-prefixes=RESDIR,LIBPATH-X86_64,RPATH-X86_64 %s
 //
-// Add LIBPATH but no RPATH if no sanitizer or runtime is specified
+// Add LIBPATH, RPATH if no sanitizer or runtime is specified
 // RUN: %clang %s -### --target=x86_64-linux \
 // RUN:     -resource-dir=%S/Inputs/resource_dir_with_arch_subdir \
 // RUN:     -frtlib-add-rpath 2>&1 \
-// RUN:   | FileCheck --check-prefixes=RESDIR,LIBPATH-X86_64,NO-RPATH-X86_64 %s
+// RUN:   | FileCheck --check-prefixes=RESDIR,LIBPATH-X86_64,RPATH-X86_64 %s
 //
-// Do not add LIBPATH or RPATH if arch-specific subdir doesn't exist
+// Same for a link-only job, which has no input language.
+// RUN: %clang -c %s -o %t.o
+// RUN: %clang %t.o -### --target=x86_64-linux \
+// RUN:     -resource-dir=%S/Inputs/resource_dir_with_arch_subdir \
+// RUN:     -frtlib-add-rpath 2>&1 \
+// RUN:   | FileCheck --check-prefixes=LINKONLY-X86_64 %s
+//
+// Old-layout lib/linux/<arch> is not used when that subdirectory does not exist.
 // RUN: %clang %s -### --target=x86_64-linux \
 // RUN:     -resource-dir=%S/Inputs/resource_dir \
 // RUN:     -frtlib-add-rpath 2>&1 \
-// RUN:   | FileCheck --check-prefixes=RESDIR,NO-LIBPATH,NO-RPATH %s
+// RUN:   | FileCheck --check-prefixes=RESDIR,NO-LIBPATH-X86_64,NO-RPATH-X86_64 %s
 
 // Test that the driver adds an per-target arch-specific subdirectory in
 // {RESOURCE_DIR}/lib/{triple} to the linker search path and to '-rpath'
@@ -95,8 +93,8 @@
 // LIBPATH-AARCH64: -L[[RESDIR]]{{(/|\\\\)lib(/|\\\\)linux(/|\\\\)aarch64}}
 // RPATH-AARCH64:   "-rpath" "[[RESDIR]]{{(/|\\\\)lib(/|\\\\)linux(/|\\\\)aarch64}}"
 //
-// NO-LIBPATH-NOT: "-L{{[^"]*Inputs(/|\\\\)resource_dir}}"
-// NO-RPATH-NOT:   "-rpath" {{.*(/|\\\\)Inputs(/|\\\\)resource_dir}}
+// LINKONLY-X86_64: -L{{[^"]*}}resource_dir_with_arch_subdir{{(/|\\\\)lib(/|\\\\)linux(/|\\\\)x86_64}}
+// LINKONLY-X86_64: "-rpath" "{{[^"]*}}resource_dir_with_arch_subdir{{(/|\\\\)lib(/|\\\\)linux(/|\\\\)x86_64}}"
 
 // PERTARGET: "-resource-dir" "[[PTRESDIR:[^"]*]]"
 // PERTARGET: -L[[PTRESDIR]]{{(/|\\\\)lib(/|\\\\)x86_64-unknown-linux-gnu}}

--- a/clang/test/Driver/arch-specific-libdir-rpath.c
+++ b/clang/test/Driver/arch-specific-libdir-rpath.c
@@ -72,6 +72,16 @@
 // RUN:     -resource-dir=%S/Inputs/resource_dir \
 // RUN:     -frtlib-add-rpath 2>&1 \
 // RUN:   | FileCheck --check-prefixes=RESDIR,NO-LIBPATH-X86_64,NO-RPATH-X86_64 %s
+//
+// Do not pass -rpath to unsupported linkers.
+// RUN: %clang %s -### --target=x86_64-pc-windows-msvc \
+// RUN:     -resource-dir=%S/Inputs/resource_dir_with_arch_subdir \
+// RUN:     -frtlib-add-rpath 2>&1 \
+// RUN:   | FileCheck --check-prefixes=RESDIR,NO-RPATH-UNSUPPORTED %s
+// RUN: %clang %s -### --target=wasm32-unknown-unknown \
+// RUN:     -resource-dir=%S/Inputs/resource_dir_with_arch_subdir \
+// RUN:     -frtlib-add-rpath 2>&1 \
+// RUN:   | FileCheck --check-prefixes=RESDIR,NO-RPATH-UNSUPPORTED %s
 
 // Test that the driver adds an per-target arch-specific subdirectory in
 // {RESOURCE_DIR}/lib/{triple} to the linker search path and to '-rpath'
@@ -95,6 +105,8 @@
 //
 // LINKONLY-X86_64: -L{{[^"]*}}resource_dir_with_arch_subdir{{(/|\\\\)lib(/|\\\\)linux(/|\\\\)x86_64}}
 // LINKONLY-X86_64: "-rpath" "{{[^"]*}}resource_dir_with_arch_subdir{{(/|\\\\)lib(/|\\\\)linux(/|\\\\)x86_64}}"
+//
+// NO-RPATH-UNSUPPORTED-NOT: "-rpath"
 
 // PERTARGET: "-resource-dir" "[[PTRESDIR:[^"]*]]"
 // PERTARGET: -L[[PTRESDIR]]{{(/|\\\\)lib(/|\\\\)x86_64-unknown-linux-gnu}}

--- a/clang/test/Driver/arch-specific-libdir-rpath.c
+++ b/clang/test/Driver/arch-specific-libdir-rpath.c
@@ -96,18 +96,22 @@
 //
 // LIBPATH-X86_64: -L[[RESDIR]]{{(/|\\\\)lib(/|\\\\)linux(/|\\\\)x86_64}}
 // RPATH-X86_64:   "-rpath" "[[RESDIR]]{{(/|\\\\)lib(/|\\\\)linux(/|\\\\)x86_64}}"
+// RPATH-X86_64-NOT: "-rpath" "[[RESDIR]]{{(/|\\\\)lib(/|\\\\)linux(/|\\\\)x86_64}}"
 //
 // NO-LIBPATH-X86_64-NOT: -L[[RESDIR]]{{(/|\\\\)lib(/|\\\\)linux(/|\\\\)x86_64}}
 // NO-RPATH-X86_64-NOT:   "-rpath" "[[RESDIR]]{{(/|\\\\)lib(/|\\\\)linux(/|\\\\)x86_64}}"
 //
 // LIBPATH-AARCH64: -L[[RESDIR]]{{(/|\\\\)lib(/|\\\\)linux(/|\\\\)aarch64}}
 // RPATH-AARCH64:   "-rpath" "[[RESDIR]]{{(/|\\\\)lib(/|\\\\)linux(/|\\\\)aarch64}}"
+// RPATH-AARCH64-NOT: "-rpath" "[[RESDIR]]{{(/|\\\\)lib(/|\\\\)linux(/|\\\\)aarch64}}"
 //
 // LINKONLY-X86_64: -L{{[^"]*}}resource_dir_with_arch_subdir{{(/|\\\\)lib(/|\\\\)linux(/|\\\\)x86_64}}
 // LINKONLY-X86_64: "-rpath" "{{[^"]*}}resource_dir_with_arch_subdir{{(/|\\\\)lib(/|\\\\)linux(/|\\\\)x86_64}}"
+// LINKONLY-X86_64-NOT: "-rpath" "{{[^"]*}}resource_dir_with_arch_subdir{{(/|\\\\)lib(/|\\\\)linux(/|\\\\)x86_64}}"
 //
 // NO-RPATH-UNSUPPORTED-NOT: "-rpath"
 
 // PERTARGET: "-resource-dir" "[[PTRESDIR:[^"]*]]"
 // PERTARGET: -L[[PTRESDIR]]{{(/|\\\\)lib(/|\\\\)x86_64-unknown-linux-gnu}}
 // PERTARGET:   "-rpath" "[[PTRESDIR]]{{(/|\\\\)lib(/|\\\\)x86_64-unknown-linux-gnu}}"
+// PERTARGET-NOT: "-rpath" "[[PTRESDIR]]{{(/|\\\\)lib(/|\\\\)x86_64-unknown-linux-gnu}}"


### PR DESCRIPTION
Summary:
This path used to try to infer if it was needed by using the language
options. The result was that if you tried to use this on a `.o` link job
you would not get the rpath behavior you would expect.

The reason it was this way stems from the fact that this used to be
implicit behavior, so it was being conservative. At some point one of
the maintainers dictated that we cannot add rpath by default, so we
ended up with this, but still being conservative.

If the user passes `-frtlib-add-rpath`, just add the rpath. Flang does
this already.
