### PR TITLE
[flang][NFC] Allow simplify-region-lite to run on any op

### DIFF
--- a/flang/include/flang/Optimizer/Transforms/Passes.td
+++ b/flang/include/flang/Optimizer/Transforms/Passes.td
@@ -407,7 +407,7 @@ def AddAliasTags : Pass<"fir-add-alias-tags", "mlir::ModuleOp"> {
   let dependentDialects = ["mlir::LLVM::LLVMDialect"];
 }
 
-def SimplifyRegionLite : Pass<"simplify-region-lite", "mlir::ModuleOp"> {
+def SimplifyRegionLite : Pass<"simplify-region-lite"> {
   let summary = "Region simplification";
   let description = [{
     Run region DCE and erase unreachable blocks in regions.

--- a/flang/lib/Optimizer/Transforms/SimplifyRegionLite.cpp
+++ b/flang/lib/Optimizer/Transforms/SimplifyRegionLite.cpp
@@ -9,7 +9,6 @@
 #include "flang/Optimizer/Transforms/Passes.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
-#include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/RegionUtils.h"
 
 namespace fir {
@@ -27,13 +26,12 @@ public:
 } // namespace
 
 void SimplifyRegionLitePass::runOnOperation() {
-  auto op = getOperation();
-  auto regions = op->getRegions();
-  mlir::RewritePatternSet patterns(op.getContext());
+  mlir::Operation *op = getOperation();
+  mlir::MutableArrayRef<mlir::Region> regions = op->getRegions();
   if (regions.empty())
     return;
 
-  mlir::PatternRewriter rewriter(op.getContext());
+  mlir::PatternRewriter rewriter(op->getContext());
   (void)mlir::eraseUnreachableBlocks(rewriter, regions);
   (void)mlir::runRegionDCE(rewriter, regions);
 }


### PR DESCRIPTION
The pass only walks the regions of getOperation(). Pinning it to
ModuleOp forced a single liveness lattice over the whole compile unit
and blocked scheduling it under a nested pass manager. Drop the
ModuleOp constraint so callers can run it per IsolatedFromAbove op.
Existing module-level addPass() uses are unchanged.