### PR TITLE
[TTI] Cache type legalization costs (NFC).

### DIFF
--- a/llvm/include/llvm/CodeGen/BasicTTIImpl.h
+++ b/llvm/include/llvm/CodeGen/BasicTTIImpl.h
@@ -1044,13 +1044,10 @@ public:
 
   /// Estimate the cost of type-legalization and the legalized type.
   std::pair<InstructionCost, MVT> getTypeLegalizationCost(Type *Ty) const {
-    auto It = TypeLegalizationCostCache.find(Ty);
-    if (It != TypeLegalizationCostCache.end())
-      return It->second;
-
-    std::pair<InstructionCost, MVT> Result = computeTypeLegalizationCost(Ty);
-    TypeLegalizationCostCache[Ty] = Result;
-    return Result;
+    auto [It, Inserted] = TypeLegalizationCostCache.try_emplace(Ty);
+    if (Inserted)
+      It->second = computeTypeLegalizationCost(Ty);
+    return It->second;
   }
 
 private:

--- a/llvm/include/llvm/CodeGen/BasicTTIImpl.h
+++ b/llvm/include/llvm/CodeGen/BasicTTIImpl.h
@@ -1044,6 +1044,17 @@ public:
 
   /// Estimate the cost of type-legalization and the legalized type.
   std::pair<InstructionCost, MVT> getTypeLegalizationCost(Type *Ty) const {
+    auto It = TypeLegalizationCostCache.find(Ty);
+    if (It != TypeLegalizationCostCache.end())
+      return It->second;
+
+    std::pair<InstructionCost, MVT> Result = computeTypeLegalizationCost(Ty);
+    TypeLegalizationCostCache[Ty] = Result;
+    return Result;
+  }
+
+private:
+  std::pair<InstructionCost, MVT> computeTypeLegalizationCost(Type *Ty) const {
     LLVMContext &C = Ty->getContext();
     EVT MTy = getTLI()->getValueType(DL, Ty);
 
@@ -1077,6 +1088,12 @@ public:
     }
   }
 
+  /// Memoizes type legalization cost. The mapping does not depend on the IR, so
+  /// entries stay valid for the lifetime of this object.
+  mutable DenseMap<Type *, std::pair<InstructionCost, MVT>>
+      TypeLegalizationCostCache;
+
+public:
   unsigned getMaxInterleaveFactor(ElementCount VF,
                                   bool HasUnorderedReductions) const override {
     return 1;


### PR DESCRIPTION
Computing type legalization costs is not completely cheap, and can be cached easily, at a slight increase in max RSS in a few cases. Wins are greater on workloads with lots of code elegible for SLP vectorization.

Improves compile-time:
* stage1-O3: -0.12%
* stage1-ReleaseThinLTO: -0.13%
* stage1-ReleaseLTO-g: -0.15%
* stage1-aarch64-O3: -0.08%
* stage2-O3: -0.10%

https://llvm-compile-time-tracker.com/compare.php?from=8cc60b748cc3e423e48517c35e8cfea7d6d6c6b7&to=55d92fccf21782461882953b91ff31490735a5a8&stat=instructions:u