### PR TITLE
[LV] Add tests for epilogue vectorization of folded bypass checks (NFC).

### DIFF
--- a/llvm/test/Transforms/LoopVectorize/VPlan/epilogue-vectorization-printing.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/epilogue-vectorization-printing.ll
@@ -299,3 +299,519 @@ loop:
 exit:
   ret i64 %red.next
 }
+
+; The main vector loop covers all 16 iterations, so the checks bypassing it are
+; constant and fold: the middle block branches to the exit block only and the
+; scalar preheader has no resume phis. The memory runtime check keeps the scalar
+; loop reachable.
+define void @all_iterations_in_main_loop_with_memcheck(ptr %dst, ptr %src) {
+; CHECK-LABEL: VPlan for loop in 'all_iterations_in_main_loop_with_memcheck'
+; CHECK:  VPlan 'Final VPlan for VF={8},UF={1}' {
+; CHECK-NEXT:  Live-in ir<16> = vector-trip-count
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<entry>:
+; CHECK-NEXT:    IR   %src2 = ptrtoaddr ptr %src to i64
+; CHECK-NEXT:    IR   %dst1 = ptrtoaddr ptr %dst to i64
+; CHECK-NEXT:    EMIT branch-on-cond ir<false>
+; CHECK-NEXT:  Successor(s): ir-bb<scalar.ph>, ir-bb<vector.memcheck>
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<vector.memcheck>:
+; CHECK-NEXT:    IR   %0 = sub i64 %dst1, %src2
+; CHECK-NEXT:    IR   %1 = sub i64 %0, 1
+; CHECK-NEXT:    IR   %diff.check = icmp ult i64 %1, 31
+; CHECK-NEXT:    EMIT branch-on-cond ir<%diff.check>
+; CHECK-NEXT:  Successor(s): ir-bb<scalar.ph>, vector.main.loop.iter.check
+; CHECK-EMPTY:
+; CHECK-NEXT:  vector.main.loop.iter.check:
+; CHECK-NEXT:    EMIT branch-on-cond ir<false>
+; CHECK-NEXT:  Successor(s): ir-bb<scalar.ph>, vector.ph
+; CHECK-EMPTY:
+; CHECK-NEXT:  vector.ph:
+; CHECK-NEXT:  Successor(s): vector.body
+; CHECK-EMPTY:
+; CHECK-NEXT:  vector.body:
+; CHECK-NEXT:    EMIT-SCALAR vp<%index> = phi [ ir<0>, vector.ph ], [ vp<%index.next>, vector.body ]
+; CHECK-NEXT:    CLONE ir<%gep.src> = getelementptr inbounds ir<%src>, vp<%index>
+; CHECK-NEXT:    WIDEN ir<%l> = load ir<%gep.src>
+; CHECK-NEXT:    WIDEN ir<%add> = add ir<%l>, ir<1>
+; CHECK-NEXT:    CLONE ir<%gep.dst> = getelementptr inbounds ir<%dst>, vp<%index>
+; CHECK-NEXT:    WIDEN store ir<%gep.dst>, ir<%add>
+; CHECK-NEXT:    EMIT vp<%index.next> = add nuw vp<%index>, ir<8>
+; CHECK-NEXT:    EMIT vp<[[VP4:%[0-9]+]]> = icmp eq vp<%index.next>, ir<16>
+; CHECK-NEXT:    EMIT branch-on-cond vp<[[VP4]]>
+; CHECK-NEXT:  Successor(s): middle.block, vector.body
+; CHECK-EMPTY:
+; CHECK-NEXT:  middle.block:
+; CHECK-NEXT:    EMIT branch-on-cond ir<true>
+; CHECK-NEXT:  Successor(s): ir-bb<exit>, ir-bb<scalar.ph>
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<exit>:
+; CHECK-NEXT:  No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<scalar.ph>:
+; CHECK-NEXT:    EMIT-SCALAR vp<%vec.epilog.resume.val> = phi [ ir<16>, middle.block ], [ ir<0>, ir-bb<entry> ], [ ir<0>, ir-bb<vector.memcheck> ], [ ir<0>, vector.main.loop.iter.check ]
+; CHECK-NEXT:    EMIT-SCALAR vp<[[VP7:%[0-9]+]]> = resume-for-epilogue vp<%vec.epilog.resume.val>, ir<0>
+; CHECK-NEXT:    EMIT-SCALAR vp<[[VP8:%[0-9]+]]> = resume-for-epilogue vp<%vec.epilog.resume.val>, ir<0>
+; CHECK-NEXT:  Successor(s): ir-bb<loop>
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<loop>:
+; CHECK-NEXT:    IR   %iv = phi i64 [ 0, %scalar.ph ], [ %iv.next, %loop ] (extra operand: vp<%vec.epilog.resume.val> from ir-bb<scalar.ph>)
+; CHECK-NEXT:    IR   %gep.src = getelementptr inbounds i32, ptr %src, i64 %iv
+; CHECK-NEXT:    IR   %l = load i32, ptr %gep.src, align 4
+; CHECK-NEXT:    IR   %add = add i32 %l, 1
+; CHECK-NEXT:    IR   %gep.dst = getelementptr inbounds i32, ptr %dst, i64 %iv
+; CHECK-NEXT:    IR   store i32 %add, ptr %gep.dst, align 4
+; CHECK-NEXT:    IR   %iv.next = add i64 %iv, 1
+; CHECK-NEXT:    IR   %ec = icmp eq i64 %iv.next, 16
+; CHECK-NEXT:  No successors
+; CHECK-NEXT:  }
+;
+; CHECK-LABEL: VPlan for loop in 'all_iterations_in_main_loop_with_memcheck'
+; CHECK:  VPlan 'Final VPlan for VF={4},UF={1}' {
+; CHECK-NEXT:  Live-in ir<16> = vector-trip-count
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<vec.epilog.iter.check>:
+; CHECK-NEXT:    IR   %vec.epilog.resume.val = phi i64 [ 16, %middle.block ], [ 0, %iter.check ], [ 0, %vector.memcheck ], [ 0, %vector.main.loop.iter.check ]
+; CHECK-NEXT:    EMIT vp<%min.epilog.iters.check> = icmp ult ir<0>, ir<4>
+; CHECK-NEXT:    EMIT branch-on-cond vp<%min.epilog.iters.check>
+; CHECK-NEXT:  Successor(s): ir-bb<vec.epilog.scalar.ph>, vec.epilog.ph
+; CHECK-EMPTY:
+; CHECK-NEXT:  vec.epilog.ph:
+; CHECK-NEXT:  Successor(s): vec.epilog.vector.body
+; CHECK-EMPTY:
+; CHECK-NEXT:  vec.epilog.vector.body:
+; CHECK-NEXT:    EMIT-SCALAR vp<%index> = phi [ ir<%vec.epilog.resume.val>, vec.epilog.ph ], [ vp<%index.next>, vec.epilog.vector.body ]
+; CHECK-NEXT:    CLONE ir<%gep.src> = getelementptr inbounds ir<%src>, vp<%index>
+; CHECK-NEXT:    WIDEN ir<%l> = load ir<%gep.src>
+; CHECK-NEXT:    WIDEN ir<%add> = add ir<%l>, ir<1>
+; CHECK-NEXT:    CLONE ir<%gep.dst> = getelementptr inbounds ir<%dst>, vp<%index>
+; CHECK-NEXT:    WIDEN store ir<%gep.dst>, ir<%add>
+; CHECK-NEXT:    EMIT vp<%index.next> = add nuw vp<%index>, ir<4>
+; CHECK-NEXT:    EMIT vp<[[VP2:%[0-9]+]]> = icmp eq vp<%index.next>, ir<16>
+; CHECK-NEXT:    EMIT branch-on-cond vp<[[VP2]]>
+; CHECK-NEXT:  Successor(s): vec.epilog.middle.block, vec.epilog.vector.body
+; CHECK-EMPTY:
+; CHECK-NEXT:  vec.epilog.middle.block:
+; CHECK-NEXT:    EMIT branch-on-cond ir<true>
+; CHECK-NEXT:  Successor(s): ir-bb<exit>, ir-bb<vec.epilog.scalar.ph>
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<exit>:
+; CHECK-NEXT:  No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<vec.epilog.scalar.ph>:
+; CHECK-NEXT:    EMIT-SCALAR vp<%bc.resume.val> = phi [ ir<16>, vec.epilog.middle.block ], [ ir<0>, ir-bb<vec.epilog.iter.check> ]
+; CHECK-NEXT:  Successor(s): ir-bb<loop>
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<loop>:
+; CHECK-NEXT:    IR   %iv = phi i64 [ %vec.epilog.resume.val, %vec.epilog.scalar.ph ], [ %iv.next, %loop ] (extra operand: vp<%bc.resume.val> from ir-bb<vec.epilog.scalar.ph>)
+; CHECK-NEXT:    IR   %gep.src = getelementptr inbounds i32, ptr %src, i64 %iv
+; CHECK-NEXT:    IR   %l = load i32, ptr %gep.src, align 4
+; CHECK-NEXT:    IR   %add = add i32 %l, 1
+; CHECK-NEXT:    IR   %gep.dst = getelementptr inbounds i32, ptr %dst, i64 %iv
+; CHECK-NEXT:    IR   store i32 %add, ptr %gep.dst, align 4
+; CHECK-NEXT:    IR   %iv.next = add i64 %iv, 1
+; CHECK-NEXT:    IR   %ec = icmp eq i64 %iv.next, 16
+; CHECK-NEXT:  No successors
+; CHECK-NEXT:  }
+;
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
+  %gep.src = getelementptr inbounds i32, ptr %src, i64 %iv
+  %l = load i32, ptr %gep.src, align 4
+  %add = add i32 %l, 1
+  %gep.dst = getelementptr inbounds i32, ptr %dst, i64 %iv
+  store i32 %add, ptr %gep.dst, align 4
+  %iv.next = add i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, 16
+  br i1 %ec, label %exit, label %loop
+
+exit:
+  ret void
+}
+
+; Same as @all_iterations_in_main_loop_with_memcheck, but the SCEV runtime check
+; keeps the scalar loop reachable.
+define void @all_iterations_in_main_loop_with_scevcheck(ptr %p, i32 %off) {
+; CHECK-LABEL: VPlan for loop in 'all_iterations_in_main_loop_with_scevcheck'
+; CHECK:  VPlan 'Final VPlan for VF={8},UF={1}' {
+; CHECK-NEXT:  Live-in ir<16> = vector-trip-count
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<entry>:
+; CHECK-NEXT:    EMIT branch-on-cond ir<false>
+; CHECK-NEXT:  Successor(s): ir-bb<scalar.ph>, ir-bb<vector.scevcheck>
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<vector.scevcheck>:
+; CHECK-NEXT:    IR   %0 = add i32 %off, 15
+; CHECK-NEXT:    IR   %1 = icmp ult i32 %0, %off
+; CHECK-NEXT:    EMIT branch-on-cond ir<%1>
+; CHECK-NEXT:  Successor(s): ir-bb<scalar.ph>, vector.main.loop.iter.check
+; CHECK-EMPTY:
+; CHECK-NEXT:  vector.main.loop.iter.check:
+; CHECK-NEXT:    EMIT branch-on-cond ir<false>
+; CHECK-NEXT:  Successor(s): ir-bb<scalar.ph>, vector.ph
+; CHECK-EMPTY:
+; CHECK-NEXT:  vector.ph:
+; CHECK-NEXT:    EMIT vp<[[VP4:%[0-9]+]]> = add ir<%off>, ir<16>
+; CHECK-NEXT:  Successor(s): vector.body
+; CHECK-EMPTY:
+; CHECK-NEXT:  vector.body:
+; CHECK-NEXT:    EMIT-SCALAR vp<%index> = phi [ ir<0>, vector.ph ], [ vp<%index.next>, vector.body ]
+; CHECK-NEXT:    EMIT-SCALAR vp<[[VP5:%[0-9]+]]> = trunc vp<%index> to i32
+; CHECK-NEXT:    EMIT vp<[[VP6:%[0-9]+]]> = add ir<%off>, vp<[[VP5]]>
+; CHECK-NEXT:    EMIT-SCALAR ir<%idx> = zext vp<[[VP6]]> to i64
+; CHECK-NEXT:    CLONE ir<%gep> = getelementptr inbounds ir<%p>, ir<%idx>
+; CHECK-NEXT:    WIDEN store ir<%gep>, ir<1>
+; CHECK-NEXT:    EMIT vp<%index.next> = add nuw vp<%index>, ir<8>
+; CHECK-NEXT:    EMIT vp<[[VP7:%[0-9]+]]> = icmp eq vp<%index.next>, ir<16>
+; CHECK-NEXT:    EMIT branch-on-cond vp<[[VP7]]>
+; CHECK-NEXT:  Successor(s): middle.block, vector.body
+; CHECK-EMPTY:
+; CHECK-NEXT:  middle.block:
+; CHECK-NEXT:    EMIT branch-on-cond ir<true>
+; CHECK-NEXT:  Successor(s): ir-bb<exit>, ir-bb<scalar.ph>
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<exit>:
+; CHECK-NEXT:  No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<scalar.ph>:
+; CHECK-NEXT:    EMIT-SCALAR vp<%vec.epilog.resume.val> = phi [ ir<16>, middle.block ], [ ir<0>, ir-bb<entry> ], [ ir<0>, ir-bb<vector.scevcheck> ], [ ir<0>, vector.main.loop.iter.check ]
+; CHECK-NEXT:    EMIT-SCALAR vp<%bc.resume.val> = phi [ vp<[[VP4]]>, middle.block ], [ ir<%off>, ir-bb<entry> ], [ ir<%off>, ir-bb<vector.scevcheck> ], [ ir<%off>, vector.main.loop.iter.check ]
+; CHECK-NEXT:    EMIT-SCALAR vp<[[VP10:%[0-9]+]]> = resume-for-epilogue vp<%vec.epilog.resume.val>, ir<0>
+; CHECK-NEXT:    EMIT-SCALAR vp<[[VP11:%[0-9]+]]> = resume-for-epilogue vp<%vec.epilog.resume.val>, ir<0>
+; CHECK-NEXT:    EMIT-SCALAR vp<[[VP12:%[0-9]+]]> = resume-for-epilogue vp<%bc.resume.val>, ir<%off>
+; CHECK-NEXT:  Successor(s): ir-bb<loop>
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<loop>:
+; CHECK-NEXT:    IR   %iv = phi i64 [ 0, %scalar.ph ], [ %iv.next, %loop ] (extra operand: vp<%vec.epilog.resume.val> from ir-bb<scalar.ph>)
+; CHECK-NEXT:    IR   %iv.narrow = phi i32 [ %off, %scalar.ph ], [ %iv.narrow.next, %loop ] (extra operand: vp<%bc.resume.val> from ir-bb<scalar.ph>)
+; CHECK-NEXT:    IR   %idx = zext i32 %iv.narrow to i64
+; CHECK-NEXT:    IR   %gep = getelementptr inbounds i32, ptr %p, i64 %idx
+; CHECK-NEXT:    IR   store i32 1, ptr %gep, align 4
+; CHECK-NEXT:    IR   %iv.narrow.next = add i32 %iv.narrow, 1
+; CHECK-NEXT:    IR   %iv.next = add i64 %iv, 1
+; CHECK-NEXT:    IR   %ec = icmp eq i64 %iv.next, 16
+; CHECK-NEXT:  No successors
+; CHECK-NEXT:  }
+;
+; CHECK-LABEL: VPlan for loop in 'all_iterations_in_main_loop_with_scevcheck'
+; CHECK:  VPlan 'Final VPlan for VF={4},UF={1}' {
+; CHECK-NEXT:  Live-in ir<16> = vector-trip-count
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<vec.epilog.iter.check>:
+; CHECK-NEXT:    IR   %vec.epilog.resume.val = phi i64 [ 16, %middle.block ], [ 0, %iter.check ], [ 0, %vector.scevcheck ], [ 0, %vector.main.loop.iter.check ]
+; CHECK-NEXT:    IR   %bc.resume.val = phi i32 [ %2, %middle.block ], [ %off, %iter.check ], [ %off, %vector.scevcheck ], [ %off, %vector.main.loop.iter.check ]
+; CHECK-NEXT:    EMIT vp<%min.epilog.iters.check> = icmp ult ir<0>, ir<4>
+; CHECK-NEXT:    EMIT branch-on-cond vp<%min.epilog.iters.check>
+; CHECK-NEXT:  Successor(s): ir-bb<vec.epilog.scalar.ph>, vec.epilog.ph
+; CHECK-EMPTY:
+; CHECK-NEXT:  vec.epilog.ph:
+; CHECK-NEXT:    EMIT vp<[[VP2:%[0-9]+]]> = add ir<%off>, ir<16>
+; CHECK-NEXT:  Successor(s): vec.epilog.vector.body
+; CHECK-EMPTY:
+; CHECK-NEXT:  vec.epilog.vector.body:
+; CHECK-NEXT:    EMIT-SCALAR vp<%index> = phi [ ir<%vec.epilog.resume.val>, vec.epilog.ph ], [ vp<%index.next>, vec.epilog.vector.body ]
+; CHECK-NEXT:    EMIT-SCALAR vp<[[VP3:%[0-9]+]]> = trunc vp<%index> to i32
+; CHECK-NEXT:    EMIT vp<[[VP4:%[0-9]+]]> = add ir<%off>, vp<[[VP3]]>
+; CHECK-NEXT:    EMIT-SCALAR ir<%idx> = zext vp<[[VP4]]> to i64
+; CHECK-NEXT:    CLONE ir<%gep> = getelementptr inbounds ir<%p>, ir<%idx>
+; CHECK-NEXT:    WIDEN store ir<%gep>, ir<1>
+; CHECK-NEXT:    EMIT vp<%index.next> = add nuw vp<%index>, ir<4>
+; CHECK-NEXT:    EMIT vp<[[VP5:%[0-9]+]]> = icmp eq vp<%index.next>, ir<16>
+; CHECK-NEXT:    EMIT branch-on-cond vp<[[VP5]]>
+; CHECK-NEXT:  Successor(s): vec.epilog.middle.block, vec.epilog.vector.body
+; CHECK-EMPTY:
+; CHECK-NEXT:  vec.epilog.middle.block:
+; CHECK-NEXT:    EMIT branch-on-cond ir<true>
+; CHECK-NEXT:  Successor(s): ir-bb<exit>, ir-bb<vec.epilog.scalar.ph>
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<exit>:
+; CHECK-NEXT:  No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<vec.epilog.scalar.ph>:
+; CHECK-NEXT:    EMIT-SCALAR vp<%bc.resume.val> = phi [ ir<16>, vec.epilog.middle.block ], [ ir<0>, ir-bb<vec.epilog.iter.check> ]
+; CHECK-NEXT:    EMIT-SCALAR vp<%bc.resume.val>.1 = phi [ vp<[[VP2]]>, vec.epilog.middle.block ], [ ir<%off>, ir-bb<vec.epilog.iter.check> ]
+; CHECK-NEXT:  Successor(s): ir-bb<loop>
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<loop>:
+; CHECK-NEXT:    IR   %iv = phi i64 [ %vec.epilog.resume.val, %vec.epilog.scalar.ph ], [ %iv.next, %loop ] (extra operand: vp<%bc.resume.val> from ir-bb<vec.epilog.scalar.ph>)
+; CHECK-NEXT:    IR   %iv.narrow = phi i32 [ %bc.resume.val, %vec.epilog.scalar.ph ], [ %iv.narrow.next, %loop ] (extra operand: vp<%bc.resume.val>.1 from ir-bb<vec.epilog.scalar.ph>)
+; CHECK-NEXT:    IR   %idx = zext i32 %iv.narrow to i64
+; CHECK-NEXT:    IR   %gep = getelementptr inbounds i32, ptr %p, i64 %idx
+; CHECK-NEXT:    IR   store i32 1, ptr %gep, align 4
+; CHECK-NEXT:    IR   %iv.narrow.next = add i32 %iv.narrow, 1
+; CHECK-NEXT:    IR   %iv.next = add i64 %iv, 1
+; CHECK-NEXT:    IR   %ec = icmp eq i64 %iv.next, 16
+; CHECK-NEXT:  No successors
+; CHECK-NEXT:  }
+;
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
+  %iv.narrow = phi i32 [ %off, %entry ], [ %iv.narrow.next, %loop ]
+  %idx = zext i32 %iv.narrow to i64
+  %gep = getelementptr inbounds i32, ptr %p, i64 %idx
+  store i32 1, ptr %gep, align 4
+  %iv.narrow.next = add i32 %iv.narrow, 1
+  %iv.next = add i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, 16
+  br i1 %ec, label %exit, label %loop
+
+exit:
+  ret void
+}
+
+; The iteration count check for the main vector loop always bypasses it, so the
+; main vector loop is dead
+define void @dead_main_vector_loop(ptr %dst, i64 %n) {
+; CHECK-LABEL: VPlan for loop in 'dead_main_vector_loop'
+; CHECK:  VPlan 'Final VPlan for VF={8},UF={1}' {
+; CHECK-NEXT:  Live-in ir<%clamped> = original trip-count
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<entry>:
+; CHECK-NEXT:    IR   %clamped = call i64 @llvm.umin.i64(i64 %n, i64 4)
+; CHECK-NEXT:    EMIT vp<%min.iters.check> = icmp ult ir<%clamped>, ir<4>
+; CHECK-NEXT:    EMIT branch-on-cond vp<%min.iters.check>
+; CHECK-NEXT:  Successor(s): ir-bb<scalar.ph>, vector.main.loop.iter.check
+; CHECK-EMPTY:
+; CHECK-NEXT:  vector.main.loop.iter.check:
+; CHECK-NEXT:    EMIT branch-on-cond ir<true>
+; CHECK-NEXT:  Successor(s): ir-bb<scalar.ph>, vector.ph
+; CHECK-EMPTY:
+; CHECK-NEXT:  vector.ph:
+; CHECK-NEXT:    EMIT vp<[[VP4:%[0-9]+]]> = and ir<%clamped>, ir<7>
+; CHECK-NEXT:    EMIT vp<%n.vec> = sub ir<%clamped>, vp<[[VP4]]>
+; CHECK-NEXT:  Successor(s): vector.body
+; CHECK-EMPTY:
+; CHECK-NEXT:  vector.body:
+; CHECK-NEXT:    WIDEN store ir<%dst>, ir<1>
+; CHECK-NEXT:  Successor(s): middle.block
+; CHECK-EMPTY:
+; CHECK-NEXT:  middle.block:
+; CHECK-NEXT:    EMIT vp<%cmp.n> = icmp eq ir<%clamped>, vp<%n.vec>
+; CHECK-NEXT:    EMIT branch-on-cond vp<%cmp.n>
+; CHECK-NEXT:  Successor(s): ir-bb<exit>, ir-bb<scalar.ph>
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<exit>:
+; CHECK-NEXT:  No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<scalar.ph>:
+; CHECK-NEXT:    EMIT-SCALAR vp<%vec.epilog.resume.val> = phi [ vp<%n.vec>, middle.block ], [ ir<0>, ir-bb<entry> ], [ ir<0>, vector.main.loop.iter.check ]
+; CHECK-NEXT:    EMIT-SCALAR vp<[[VP6:%[0-9]+]]> = resume-for-epilogue vp<%vec.epilog.resume.val>, ir<0>
+; CHECK-NEXT:    EMIT-SCALAR vp<[[VP7:%[0-9]+]]> = resume-for-epilogue vp<%vec.epilog.resume.val>, ir<0>
+; CHECK-NEXT:  Successor(s): ir-bb<loop>
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<loop>:
+; CHECK-NEXT:    IR   %iv = phi i64 [ 0, %scalar.ph ], [ %iv.next, %loop ] (extra operand: vp<%vec.epilog.resume.val> from ir-bb<scalar.ph>)
+; CHECK-NEXT:    IR   %gep = getelementptr inbounds i32, ptr %dst, i64 %iv
+; CHECK-NEXT:    IR   store i32 1, ptr %gep, align 4
+; CHECK-NEXT:    IR   %iv.next = add i64 %iv, 1
+; CHECK-NEXT:    IR   %ec = icmp eq i64 %iv.next, %clamped
+; CHECK-NEXT:  No successors
+; CHECK-NEXT:  }
+;
+; CHECK-LABEL: VPlan for loop in 'dead_main_vector_loop'
+; CHECK:  VPlan 'Final VPlan for VF={4},UF={1}' {
+; CHECK-NEXT:  Live-in ir<%clamped> = original trip-count
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<vec.epilog.iter.check>:
+; CHECK-NEXT:    IR   %vec.epilog.resume.val = phi i64 [ %n.vec, %middle.block ], [ 0, %iter.check ], [ 0, %vector.main.loop.iter.check ]
+; CHECK-NEXT:    EMIT vp<%min.epilog.iters.check> = icmp ult ir<%clamped>, ir<4>
+; CHECK-NEXT:    EMIT branch-on-cond vp<%min.epilog.iters.check>
+; CHECK-NEXT:  Successor(s): ir-bb<vec.epilog.scalar.ph>, vec.epilog.ph
+; CHECK-EMPTY:
+; CHECK-NEXT:  vec.epilog.ph:
+; CHECK-NEXT:    EMIT vp<[[VP3:%[0-9]+]]> = and ir<%clamped>, ir<3>
+; CHECK-NEXT:    EMIT vp<%n.vec> = sub ir<%clamped>, vp<[[VP3]]>
+; CHECK-NEXT:  Successor(s): vec.epilog.vector.body
+; CHECK-EMPTY:
+; CHECK-NEXT:  vec.epilog.vector.body:
+; CHECK-NEXT:    CLONE ir<%gep> = getelementptr inbounds ir<%dst>, ir<%vec.epilog.resume.val>
+; CHECK-NEXT:    WIDEN store ir<%gep>, ir<1>
+; CHECK-NEXT:  Successor(s): vec.epilog.middle.block
+; CHECK-EMPTY:
+; CHECK-NEXT:  vec.epilog.middle.block:
+; CHECK-NEXT:    EMIT vp<%cmp.n> = icmp eq ir<%clamped>, vp<%n.vec>
+; CHECK-NEXT:    EMIT branch-on-cond vp<%cmp.n>
+; CHECK-NEXT:  Successor(s): ir-bb<exit>, ir-bb<vec.epilog.scalar.ph>
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<exit>:
+; CHECK-NEXT:  No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<vec.epilog.scalar.ph>:
+; CHECK-NEXT:    EMIT-SCALAR vp<%bc.resume.val> = phi [ vp<%n.vec>, vec.epilog.middle.block ], [ ir<0>, ir-bb<vec.epilog.iter.check> ]
+; CHECK-NEXT:  Successor(s): ir-bb<loop>
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<loop>:
+; CHECK-NEXT:    IR   %iv = phi i64 [ %vec.epilog.resume.val, %vec.epilog.scalar.ph ], [ %iv.next, %loop ] (extra operand: vp<%bc.resume.val> from ir-bb<vec.epilog.scalar.ph>)
+; CHECK-NEXT:    IR   %gep = getelementptr inbounds i32, ptr %dst, i64 %iv
+; CHECK-NEXT:    IR   store i32 1, ptr %gep, align 4
+; CHECK-NEXT:    IR   %iv.next = add i64 %iv, 1
+; CHECK-NEXT:    IR   %ec = icmp eq i64 %iv.next, %clamped
+; CHECK-NEXT:  No successors
+; CHECK-NEXT:  }
+;
+entry:
+  %clamped = call i64 @llvm.umin.i64(i64 %n, i64 4)
+  br label %loop
+
+loop:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
+  %gep = getelementptr inbounds i32, ptr %dst, i64 %iv
+  store i32 1, ptr %gep, align 4
+  %iv.next = add i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, %clamped
+  br i1 %ec, label %exit, label %loop
+
+exit:
+  ret void
+}
+
+; The vectorized loop is nested, so the block the epilogue plan is entered from
+; is the header of the outer loop.
+define i32 @nested_loop(ptr noalias %p, ptr noalias %end, ptr noalias %dst, i64 %m) {
+; CHECK-LABEL: VPlan for loop in 'nested_loop'
+; CHECK:  VPlan 'Final VPlan for VF={8},UF={1}' {
+; CHECK-NEXT:  Live-in ir<%3> = original trip-count
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<outer.header>:
+; CHECK-NEXT:    IR   %j = phi i64 [ 0, %entry ], [ %j.next, %outer.latch ]
+; CHECK-NEXT:    EMIT vp<%min.iters.check> = icmp ult ir<%3>, ir<4>
+; CHECK-NEXT:    EMIT branch-on-cond vp<%min.iters.check>
+; CHECK-NEXT:  Successor(s): ir-bb<scalar.ph>, vector.main.loop.iter.check
+; CHECK-EMPTY:
+; CHECK-NEXT:  vector.main.loop.iter.check:
+; CHECK-NEXT:    EMIT vp<%min.iters.check>.1 = icmp ult ir<%3>, ir<8>
+; CHECK-NEXT:    EMIT branch-on-cond vp<%min.iters.check>.1
+; CHECK-NEXT:  Successor(s): ir-bb<scalar.ph>, vector.ph
+; CHECK-EMPTY:
+; CHECK-NEXT:  vector.ph:
+; CHECK-NEXT:    EMIT vp<[[VP4:%[0-9]+]]> = and ir<%3>, ir<7>
+; CHECK-NEXT:    EMIT vp<%n.vec> = sub ir<%3>, vp<[[VP4]]>
+; CHECK-NEXT:    EMIT vp<[[VP5:%[0-9]+]]> = mul vp<%n.vec>, ir<24>
+; CHECK-NEXT:    EMIT vp<[[VP6:%[0-9]+]]> = ptradd ir<%p>, vp<[[VP5]]>
+; CHECK-NEXT:  Successor(s): vector.body
+; CHECK-EMPTY:
+; CHECK-NEXT:  vector.body:
+; CHECK-NEXT:    EMIT-SCALAR vp<%index> = phi [ ir<0>, vector.ph ], [ vp<%index.next>, vector.body ]
+; CHECK-NEXT:    EMIT vp<[[VP7:%[0-9]+]]> = mul vp<%index>, ir<24>
+; CHECK-NEXT:    vp<[[VP8:%[0-9]+]]> = SCALAR-STEPS vp<[[VP7]]>, ir<24>, ir<8>, ir<7>
+; CHECK-NEXT:    EMIT vp<%next.gep> = ptradd ir<%p>, vp<[[VP8]]>
+; CHECK-NEXT:    CLONE ir<%l> = load vp<%next.gep>
+; CHECK-NEXT:    CLONE store ir<%l>, ir<%dst>
+; CHECK-NEXT:    EMIT vp<%index.next> = add nuw vp<%index>, ir<8>
+; CHECK-NEXT:    EMIT vp<[[VP9:%[0-9]+]]> = icmp eq vp<%index.next>, vp<%n.vec>
+; CHECK-NEXT:    EMIT branch-on-cond vp<[[VP9]]>
+; CHECK-NEXT:  Successor(s): middle.block, vector.body
+; CHECK-EMPTY:
+; CHECK-NEXT:  middle.block:
+; CHECK-NEXT:    EMIT vp<%cmp.n> = icmp eq ir<%3>, vp<%n.vec>
+; CHECK-NEXT:    EMIT branch-on-cond vp<%cmp.n>
+; CHECK-NEXT:  Successor(s): ir-bb<inner.exit>, ir-bb<scalar.ph>
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<inner.exit>:
+; CHECK-NEXT:    IR   %cc = icmp ult i64 %j, 3
+; CHECK-NEXT:  No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<scalar.ph>:
+; CHECK-NEXT:    EMIT-SCALAR vp<%vec.epilog.resume.val> = phi [ vp<%n.vec>, middle.block ], [ ir<0>, ir-bb<outer.header> ], [ ir<0>, vector.main.loop.iter.check ]
+; CHECK-NEXT:    EMIT-SCALAR vp<%bc.resume.val> = phi [ vp<[[VP6]]>, middle.block ], [ ir<%p>, ir-bb<outer.header> ], [ ir<%p>, vector.main.loop.iter.check ]
+; CHECK-NEXT:    EMIT-SCALAR vp<[[VP12:%[0-9]+]]> = resume-for-epilogue vp<%vec.epilog.resume.val>, ir<0>
+; CHECK-NEXT:    EMIT-SCALAR vp<[[VP13:%[0-9]+]]> = resume-for-epilogue vp<%bc.resume.val>, ir<%p>
+; CHECK-NEXT:  Successor(s): ir-bb<loop>
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<loop>:
+; CHECK-NEXT:    IR   %q = phi ptr [ %p, %scalar.ph ], [ %q.next, %loop ] (extra operand: vp<%bc.resume.val> from ir-bb<scalar.ph>)
+; CHECK-NEXT:    IR   %l = load i32, ptr %q, align 8
+; CHECK-NEXT:    IR   store i32 %l, ptr %dst, align 4
+; CHECK-NEXT:    IR   %q.next = getelementptr inbounds nuw i8, ptr %q, i64 24
+; CHECK-NEXT:    IR   %ec = icmp eq ptr %q.next, %end
+; CHECK-NEXT:  No successors
+; CHECK-NEXT:  }
+;
+; CHECK-LABEL: VPlan for loop in 'nested_loop'
+; CHECK:  VPlan 'Final VPlan for VF={4},UF={1}' {
+; CHECK-NEXT:  Live-in ir<%3> = original trip-count
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<vec.epilog.iter.check>:
+; CHECK-NEXT:    IR   %vec.epilog.resume.val = phi i64 [ %n.vec, %middle.block ], [ 0, %iter.check ], [ 0, %vector.main.loop.iter.check ]
+; CHECK-NEXT:    IR   %bc.resume.val = phi ptr [ %6, %middle.block ], [ %p, %iter.check ], [ %p, %vector.main.loop.iter.check ]
+; CHECK-NEXT:    EMIT vp<%min.epilog.iters.check> = icmp ult ir<%4>, ir<4>
+; CHECK-NEXT:    EMIT branch-on-cond vp<%min.epilog.iters.check>
+; CHECK-NEXT:  Successor(s): ir-bb<vec.epilog.scalar.ph>, vec.epilog.ph
+; CHECK-EMPTY:
+; CHECK-NEXT:  vec.epilog.ph:
+; CHECK-NEXT:    EMIT vp<[[VP3:%[0-9]+]]> = and ir<%3>, ir<3>
+; CHECK-NEXT:    EMIT vp<%n.vec> = sub ir<%3>, vp<[[VP3]]>
+; CHECK-NEXT:    EMIT vp<[[VP4:%[0-9]+]]> = mul vp<%n.vec>, ir<24>
+; CHECK-NEXT:    EMIT vp<[[VP5:%[0-9]+]]> = ptradd ir<%p>, vp<[[VP4]]>
+; CHECK-NEXT:  Successor(s): vec.epilog.vector.body
+; CHECK-EMPTY:
+; CHECK-NEXT:  vec.epilog.vector.body:
+; CHECK-NEXT:    EMIT-SCALAR vp<%index> = phi [ ir<%vec.epilog.resume.val>, vec.epilog.ph ], [ vp<%index.next>, vec.epilog.vector.body ]
+; CHECK-NEXT:    EMIT vp<[[VP6:%[0-9]+]]> = mul vp<%index>, ir<24>
+; CHECK-NEXT:    vp<[[VP7:%[0-9]+]]> = SCALAR-STEPS vp<[[VP6]]>, ir<24>, ir<4>, ir<3>
+; CHECK-NEXT:    EMIT vp<%next.gep> = ptradd ir<%p>, vp<[[VP7]]>
+; CHECK-NEXT:    CLONE ir<%l> = load vp<%next.gep>
+; CHECK-NEXT:    CLONE store ir<%l>, ir<%dst>
+; CHECK-NEXT:    EMIT vp<%index.next> = add nuw vp<%index>, ir<4>
+; CHECK-NEXT:    EMIT vp<[[VP8:%[0-9]+]]> = icmp eq vp<%index.next>, vp<%n.vec>
+; CHECK-NEXT:    EMIT branch-on-cond vp<[[VP8]]>
+; CHECK-NEXT:  Successor(s): vec.epilog.middle.block, vec.epilog.vector.body
+; CHECK-EMPTY:
+; CHECK-NEXT:  vec.epilog.middle.block:
+; CHECK-NEXT:    EMIT vp<%cmp.n> = icmp eq ir<%3>, vp<%n.vec>
+; CHECK-NEXT:    EMIT branch-on-cond vp<%cmp.n>
+; CHECK-NEXT:  Successor(s): ir-bb<inner.exit>, ir-bb<vec.epilog.scalar.ph>
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<inner.exit>:
+; CHECK-NEXT:    IR   %cc = icmp ult i64 %j, 3
+; CHECK-NEXT:  No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<vec.epilog.scalar.ph>:
+; CHECK-NEXT:    EMIT-SCALAR vp<%bc.resume.val> = phi [ vp<[[VP5]]>, vec.epilog.middle.block ], [ ir<%p>, ir-bb<vec.epilog.iter.check> ]
+; CHECK-NEXT:  Successor(s): ir-bb<loop>
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<loop>:
+; CHECK-NEXT:    IR   %q = phi ptr [ %bc.resume.val, %vec.epilog.scalar.ph ], [ %q.next, %loop ] (extra operand: vp<%bc.resume.val> from ir-bb<vec.epilog.scalar.ph>)
+; CHECK-NEXT:    IR   %l = load i32, ptr %q, align 8
+; CHECK-NEXT:    IR   store i32 %l, ptr %dst, align 4
+; CHECK-NEXT:    IR   %q.next = getelementptr inbounds nuw i8, ptr %q, i64 24
+; CHECK-NEXT:    IR   %ec = icmp eq ptr %q.next, %end
+; CHECK-NEXT:  No successors
+; CHECK-NEXT:  }
+;
+entry:
+  br label %outer.header
+
+outer.header:
+  %j = phi i64 [ 0, %entry ], [ %j.next, %outer.latch ]
+  br label %loop
+
+loop:
+  %q = phi ptr [ %p, %outer.header ], [ %q.next, %loop ]
+  %l = load i32, ptr %q, align 8
+  store i32 %l, ptr %dst, align 4
+  %q.next = getelementptr inbounds nuw i8, ptr %q, i64 24
+  %ec = icmp eq ptr %q.next, %end
+  br i1 %ec, label %inner.exit, label %loop
+
+inner.exit:
+  %cc = icmp ult i64 %j, 3
+  br i1 %cc, label %outer.latch, label %bail
+
+outer.latch:
+  %j.next = add nuw nsw i64 %j, 1
+  %oc = icmp eq i64 %j.next, %m
+  br i1 %oc, label %done, label %outer.header
+
+bail:
+  ret i32 -1
+
+done:
+  ret i32 0
+}

--- a/llvm/test/Transforms/LoopVectorize/branch-weights.ll
+++ b/llvm/test/Transforms/LoopVectorize/branch-weights.ll
@@ -510,6 +510,117 @@ exit:
   ret void
 }
 
+; The trip count is constant, so the checks bypassing the vector loops fold and
+; the branches they are replaced by carry no weights. Vectorizing 1030
+; iterations by 8 leaves a remainder of 6 for the epilogue vector loop, which by
+; 4 leaves 2 iterations for the scalar loop and by 2 leaves none, folding the
+; branch out of the epilogue middle block in both cases.
+define void @f4(ptr %p) !prof !0 {
+;
+;
+;
+; MAINVF4IC1_EPI4-LABEL: define void @f4(
+; MAINVF4IC1_EPI4-SAME: ptr [[P:%.*]]) !prof [[PROF0]] {
+; MAINVF4IC1_EPI4:  [[ITER_CHECK:.*:]]
+; MAINVF4IC1_EPI4:    br i1 false, label %[[VEC_EPILOG_SCALAR_PH:.*]], label %[[VECTOR_MAIN_LOOP_ITER_CHECK:.*]], !prof [[PROF2]]
+; MAINVF4IC1_EPI4:  [[VECTOR_MAIN_LOOP_ITER_CHECK]]:
+; MAINVF4IC1_EPI4:    br i1 false, label %[[VEC_EPILOG_PH:.*]], label %[[VECTOR_PH:.*]], !prof [[PROF2]]
+; MAINVF4IC1_EPI4:  [[VECTOR_PH]]:
+; MAINVF4IC1_EPI4:    br label %[[VECTOR_BODY:.*]]
+; MAINVF4IC1_EPI4:  [[VECTOR_BODY]]:
+; MAINVF4IC1_EPI4:    [[TMP1:%.*]] = icmp eq i64 [[INDEX_NEXT:%.*]], 1024
+; MAINVF4IC1_EPI4:    br i1 [[TMP1]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !prof [[PROF2]], !llvm.loop [[LOOP29:![0-9]+]]
+; MAINVF4IC1_EPI4:  [[MIDDLE_BLOCK]]:
+; MAINVF4IC1_EPI4:    br i1 false, label %[[EXIT:.*]], label %[[VEC_EPILOG_ITER_CHECK:.*]], !prof [[PROF8]]
+; MAINVF4IC1_EPI4:  [[VEC_EPILOG_ITER_CHECK]]:
+; MAINVF4IC1_EPI4:    br i1 false, label %[[VEC_EPILOG_SCALAR_PH]], label %[[VEC_EPILOG_PH]], !prof [[PROF9]]
+; MAINVF4IC1_EPI4:  [[VEC_EPILOG_PH]]:
+; MAINVF4IC1_EPI4:    br label %[[VEC_EPILOG_VECTOR_BODY:.*]]
+; MAINVF4IC1_EPI4:  [[VEC_EPILOG_VECTOR_BODY]]:
+; MAINVF4IC1_EPI4:    [[TMP3:%.*]] = icmp eq i64 [[INDEX_NEXT2:%.*]], 1028
+; MAINVF4IC1_EPI4:    br i1 [[TMP3]], label %[[VEC_EPILOG_MIDDLE_BLOCK:.*]], label %[[VEC_EPILOG_VECTOR_BODY]], !prof [[PROF10]], !llvm.loop [[LOOP30:![0-9]+]]
+; MAINVF4IC1_EPI4:  [[VEC_EPILOG_MIDDLE_BLOCK]]:
+; MAINVF4IC1_EPI4:    br i1 false, label %[[EXIT]], label %[[VEC_EPILOG_SCALAR_PH]], !prof [[PROF13]]
+; MAINVF4IC1_EPI4:  [[VEC_EPILOG_SCALAR_PH]]:
+; MAINVF4IC1_EPI4:    br label %[[LOOP:.*]]
+; MAINVF4IC1_EPI4:  [[LOOP]]:
+; MAINVF4IC1_EPI4:    [[CMP_LOOP:%.*]] = icmp eq i64 [[IV_NEXT:%.*]], 1030
+; MAINVF4IC1_EPI4:    br i1 [[CMP_LOOP]], label %[[EXIT]], label %[[LOOP]], !prof [[PROF31:![0-9]+]], !llvm.loop [[LOOP32:![0-9]+]]
+; MAINVF4IC1_EPI4:  [[EXIT]]:
+;
+; MAINVF4IC2_EPI4-LABEL: define void @f4(
+; MAINVF4IC2_EPI4-SAME: ptr [[P:%.*]]) !prof [[PROF0]] {
+; MAINVF4IC2_EPI4:  [[ITER_CHECK:.*:]]
+; MAINVF4IC2_EPI4:    br i1 false, label %[[VEC_EPILOG_SCALAR_PH:.*]], label %[[VECTOR_MAIN_LOOP_ITER_CHECK:.*]], !prof [[PROF2]]
+; MAINVF4IC2_EPI4:  [[VECTOR_MAIN_LOOP_ITER_CHECK]]:
+; MAINVF4IC2_EPI4:    br i1 false, label %[[VEC_EPILOG_PH:.*]], label %[[VECTOR_PH:.*]], !prof [[PROF2]]
+; MAINVF4IC2_EPI4:  [[VECTOR_PH]]:
+; MAINVF4IC2_EPI4:    br label %[[VECTOR_BODY:.*]]
+; MAINVF4IC2_EPI4:  [[VECTOR_BODY]]:
+; MAINVF4IC2_EPI4:    [[TMP2:%.*]] = icmp eq i64 [[INDEX_NEXT:%.*]], 1024
+; MAINVF4IC2_EPI4:    br i1 [[TMP2]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !prof [[PROF2]], !llvm.loop [[LOOP29:![0-9]+]]
+; MAINVF4IC2_EPI4:  [[MIDDLE_BLOCK]]:
+; MAINVF4IC2_EPI4:    br i1 false, label %[[EXIT:.*]], label %[[VEC_EPILOG_ITER_CHECK:.*]], !prof [[PROF8]]
+; MAINVF4IC2_EPI4:  [[VEC_EPILOG_ITER_CHECK]]:
+; MAINVF4IC2_EPI4:    br i1 false, label %[[VEC_EPILOG_SCALAR_PH]], label %[[VEC_EPILOG_PH]], !prof [[PROF9]]
+; MAINVF4IC2_EPI4:  [[VEC_EPILOG_PH]]:
+; MAINVF4IC2_EPI4:    br label %[[VEC_EPILOG_VECTOR_BODY:.*]]
+; MAINVF4IC2_EPI4:  [[VEC_EPILOG_VECTOR_BODY]]:
+; MAINVF4IC2_EPI4:    [[TMP4:%.*]] = icmp eq i64 [[INDEX_NEXT2:%.*]], 1028
+; MAINVF4IC2_EPI4:    br i1 [[TMP4]], label %[[VEC_EPILOG_MIDDLE_BLOCK:.*]], label %[[VEC_EPILOG_VECTOR_BODY]], !prof [[PROF10]], !llvm.loop [[LOOP30:![0-9]+]]
+; MAINVF4IC2_EPI4:  [[VEC_EPILOG_MIDDLE_BLOCK]]:
+; MAINVF4IC2_EPI4:    br i1 false, label %[[EXIT]], label %[[VEC_EPILOG_SCALAR_PH]], !prof [[PROF13]]
+; MAINVF4IC2_EPI4:  [[VEC_EPILOG_SCALAR_PH]]:
+; MAINVF4IC2_EPI4:    br label %[[LOOP:.*]]
+; MAINVF4IC2_EPI4:  [[LOOP]]:
+; MAINVF4IC2_EPI4:    [[CMP_LOOP:%.*]] = icmp eq i64 [[IV_NEXT:%.*]], 1030
+; MAINVF4IC2_EPI4:    br i1 [[CMP_LOOP]], label %[[EXIT]], label %[[LOOP]], !prof [[PROF31:![0-9]+]], !llvm.loop [[LOOP32:![0-9]+]]
+; MAINVF4IC2_EPI4:  [[EXIT]]:
+;
+; MAINVF8IC1_EPI2-LABEL: define void @f4(
+; MAINVF8IC1_EPI2-SAME: ptr [[P:%.*]]) !prof [[PROF0]] {
+; MAINVF8IC1_EPI2:  [[ITER_CHECK:.*:]]
+; MAINVF8IC1_EPI2:    br i1 false, label %[[VEC_EPILOG_SCALAR_PH:.*]], label %[[VECTOR_MAIN_LOOP_ITER_CHECK:.*]], !prof [[PROF2]]
+; MAINVF8IC1_EPI2:  [[VECTOR_MAIN_LOOP_ITER_CHECK]]:
+; MAINVF8IC1_EPI2:    br i1 false, label %[[VEC_EPILOG_PH:.*]], label %[[VECTOR_PH:.*]], !prof [[PROF2]]
+; MAINVF8IC1_EPI2:  [[VECTOR_PH]]:
+; MAINVF8IC1_EPI2:    br label %[[VECTOR_BODY:.*]]
+; MAINVF8IC1_EPI2:  [[VECTOR_BODY]]:
+; MAINVF8IC1_EPI2:    [[TMP1:%.*]] = icmp eq i64 [[INDEX_NEXT:%.*]], 1024
+; MAINVF8IC1_EPI2:    br i1 [[TMP1]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !prof [[PROF2]], !llvm.loop [[LOOP29:![0-9]+]]
+; MAINVF8IC1_EPI2:  [[MIDDLE_BLOCK]]:
+; MAINVF8IC1_EPI2:    br i1 false, label %[[EXIT:.*]], label %[[VEC_EPILOG_ITER_CHECK:.*]], !prof [[PROF8]]
+; MAINVF8IC1_EPI2:  [[VEC_EPILOG_ITER_CHECK]]:
+; MAINVF8IC1_EPI2:    br i1 false, label %[[VEC_EPILOG_SCALAR_PH]], label %[[VEC_EPILOG_PH]], !prof [[PROF9]]
+; MAINVF8IC1_EPI2:  [[VEC_EPILOG_PH]]:
+; MAINVF8IC1_EPI2:    br label %[[VEC_EPILOG_VECTOR_BODY:.*]]
+; MAINVF8IC1_EPI2:  [[VEC_EPILOG_VECTOR_BODY]]:
+; MAINVF8IC1_EPI2:    [[TMP3:%.*]] = icmp eq i64 [[INDEX_NEXT2:%.*]], 1030
+; MAINVF8IC1_EPI2:    br i1 [[TMP3]], label %[[VEC_EPILOG_MIDDLE_BLOCK:.*]], label %[[VEC_EPILOG_VECTOR_BODY]], !prof [[PROF16]], !llvm.loop [[LOOP30:![0-9]+]]
+; MAINVF8IC1_EPI2:  [[VEC_EPILOG_MIDDLE_BLOCK]]:
+; MAINVF8IC1_EPI2:    br i1 true, label %[[EXIT]], label %[[VEC_EPILOG_SCALAR_PH]], !prof [[PROF13]]
+; MAINVF8IC1_EPI2:  [[VEC_EPILOG_SCALAR_PH]]:
+; MAINVF8IC1_EPI2:    br label %[[LOOP:.*]]
+; MAINVF8IC1_EPI2:  [[LOOP]]:
+; MAINVF8IC1_EPI2:    [[CMP_LOOP:%.*]] = icmp eq i64 [[IV_NEXT:%.*]], 1030
+; MAINVF8IC1_EPI2:    br i1 [[CMP_LOOP]], label %[[EXIT]], label %[[LOOP]], !prof [[PROF10]], !llvm.loop [[LOOP31:![0-9]+]]
+; MAINVF8IC1_EPI2:  [[EXIT]]:
+;
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
+  %ptr = getelementptr inbounds i32, ptr %p, i64 %iv
+  store i32 0, ptr %ptr
+  %iv.next = add i64 %iv, 1
+  %cmp.loop = icmp eq i64 %iv.next, 1030
+  br i1 %cmp.loop, label %exit, label %loop, !prof !7
+
+exit:
+  ret void
+}
+
 !0 = !{!"function_entry_count", i64 13}
 !1 = !{!"branch_weights", i32 12, i32 1}
 !2 = !{!"branch_weights", i32 1234, i32 1}
@@ -521,6 +632,8 @@ exit:
 ; which on their own would estimate a trip count of 1024.
 !5 = distinct !{!5, !6}
 !6 = !{!"llvm.loop.estimated_trip_count", i32 0}
+; The estimated trip count matches the constant trip count of 1030.
+!7 = !{!"branch_weights", i32 1, i32 1029}
 ;.
 ; MAINVF4IC1_EPI4: [[PROF0]] = !{!"function_entry_count", i64 13}
 ; MAINVF4IC1_EPI4: [[PROF1]] = !{!"branch_weights", i32 12, i32 1}
@@ -551,6 +664,11 @@ exit:
 ; MAINVF4IC1_EPI4: [[LOOP26]] = distinct !{[[LOOP26]], [[META12]], [[META5]], [[META6]]}
 ; MAINVF4IC1_EPI4: [[LOOP27]] = distinct !{[[LOOP27]], [[META12]], [[META5]], [[META6]]}
 ; MAINVF4IC1_EPI4: [[LOOP28]] = distinct !{[[LOOP28]], [[META12]], [[META6]], [[META5]]}
+; MAINVF4IC1_EPI4: [[LOOP29]] = distinct !{[[LOOP29]], [[META5]], [[META6]], [[META23]]}
+; MAINVF4IC1_EPI4: [[LOOP30]] = distinct !{[[LOOP30]], [[META5]], [[META6]], [[META20]]}
+; MAINVF4IC1_EPI4: [[PROF31]] = !{!"branch_weights", i32 1, i32 1}
+; MAINVF4IC1_EPI4: [[LOOP32]] = distinct !{[[LOOP32]], [[META6]], [[META5]], [[META33:![0-9]+]]}
+; MAINVF4IC1_EPI4: [[META33]] = !{!"llvm.loop.estimated_trip_count", i32 2}
 ;.
 ; MAINVF4IC2_EPI4: [[PROF0]] = !{!"function_entry_count", i64 13}
 ; MAINVF4IC2_EPI4: [[PROF1]] = !{!"branch_weights", i32 12, i32 1}
@@ -581,6 +699,11 @@ exit:
 ; MAINVF4IC2_EPI4: [[LOOP26]] = distinct !{[[LOOP26]], [[META12]], [[META5]], [[META6]]}
 ; MAINVF4IC2_EPI4: [[LOOP27]] = distinct !{[[LOOP27]], [[META12]], [[META5]], [[META6]]}
 ; MAINVF4IC2_EPI4: [[LOOP28]] = distinct !{[[LOOP28]], [[META12]], [[META6]], [[META5]]}
+; MAINVF4IC2_EPI4: [[LOOP29]] = distinct !{[[LOOP29]], [[META5]], [[META6]], [[META23]]}
+; MAINVF4IC2_EPI4: [[LOOP30]] = distinct !{[[LOOP30]], [[META5]], [[META6]], [[META20]]}
+; MAINVF4IC2_EPI4: [[PROF31]] = !{!"branch_weights", i32 1, i32 1}
+; MAINVF4IC2_EPI4: [[LOOP32]] = distinct !{[[LOOP32]], [[META6]], [[META5]], [[META33:![0-9]+]]}
+; MAINVF4IC2_EPI4: [[META33]] = !{!"llvm.loop.estimated_trip_count", i32 2}
 ;.
 ; MAINVF8IC1_EPI2: [[PROF0]] = !{!"function_entry_count", i64 13}
 ; MAINVF8IC1_EPI2: [[PROF1]] = !{!"branch_weights", i32 12, i32 1}
@@ -611,4 +734,7 @@ exit:
 ; MAINVF8IC1_EPI2: [[LOOP26]] = distinct !{[[LOOP26]], [[META24]], [[META5]], [[META6]]}
 ; MAINVF8IC1_EPI2: [[LOOP27]] = distinct !{[[LOOP27]], [[META24]], [[META5]], [[META6]]}
 ; MAINVF8IC1_EPI2: [[LOOP28]] = distinct !{[[LOOP28]], [[META24]], [[META6]], [[META5]]}
+; MAINVF8IC1_EPI2: [[LOOP29]] = distinct !{[[LOOP29]], [[META5]], [[META6]], [[META22]]}
+; MAINVF8IC1_EPI2: [[LOOP30]] = distinct !{[[LOOP30]], [[META5]], [[META6]], [[META18]]}
+; MAINVF8IC1_EPI2: [[LOOP31]] = distinct !{[[LOOP31]], [[META6]], [[META5]], [[META24]]}
 ;.


### PR DESCRIPTION
Add vplan printing and branch weights tests with various cases where parts of the epilogue skeleton can be folded.