### PR TITLE
[bazel] Fix mlir bazel build failure.

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -10719,6 +10719,7 @@ cc_library(
         ":DialectUtils",
         ":FuncDialect",
         ":FunctionInterfaces",
+        ":GPUDialect",
         ":IR",
         ":LLVMDialect",
         ":MemRefDialect",


### PR DESCRIPTION
Add bazel dependency for mlir that was introduced in https://github.com/llvm/llvm-project/pull/220468