### PR TITLE
[mlir][sparse] Reject invalid tensor coordinates

### DIFF
--- a/mlir/include/mlir/ExecutionEngine/SparseTensor/File.h
+++ b/mlir/include/mlir/ExecutionEngine/SparseTensor/File.h
@@ -24,7 +24,10 @@
 #include "mlir/ExecutionEngine/SparseTensor/Storage.h"
 #include "mlir/Support/Complex.h"
 
+#include <cctype>
+#include <cerrno>
 #include <fstream>
+#include <limits>
 
 namespace mlir {
 namespace sparse_tensor {
@@ -236,7 +239,35 @@ private:
     char *linePtr = line;
     for (uint64_t dimRank = getRank(), d = 0; d < dimRank; ++d) {
       // Parse the 1-based coordinate.
-      uint64_t c = strtoul(linePtr, &linePtr, 10);
+      while (std::isspace(static_cast<unsigned char>(*linePtr)))
+        ++linePtr;
+      errno = 0;
+      char *coordinateEnd = nullptr;
+      unsigned long long coordinate = strtoull(linePtr, &coordinateEnd, 10);
+      if (*linePtr == '-' || coordinateEnd == linePtr || errno == ERANGE ||
+          coordinate > std::numeric_limits<uint64_t>::max()) {
+        fprintf(stderr,
+                "Cannot parse coordinate for dimension %" PRIu64 " in %s\n", d,
+                filename);
+        exit(1);
+      }
+      linePtr = coordinateEnd;
+      uint64_t c = coordinate;
+      if (c == 0 || c > getDimSizes()[d]) {
+        fprintf(stderr,
+                "Coordinate %" PRIu64 " is out of bounds for dimension %" PRIu64
+                " with size %" PRIu64 " in %s\n",
+                c, d, getDimSizes()[d], filename);
+        exit(1);
+      }
+      if (c - 1 > std::numeric_limits<C>::max()) {
+        fprintf(stderr,
+                "Coordinate %" PRIu64
+                " cannot be represented by the requested coordinate type in "
+                "%s\n",
+                c, filename);
+        exit(1);
+      }
       // Store the 0-based coordinate.
       dimCoords[d] = static_cast<C>(c - 1);
     }

--- a/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_file_coordinates.mlir
+++ b/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_file_coordinates.mlir
@@ -1,0 +1,79 @@
+//--------------------------------------------------------------------------------------------------
+// WHEN CREATING A NEW TEST, PLEASE JUST COPY & PASTE WITHOUT EDITS.
+//
+// Set-up that's shared across all tests in this directory. In principle, this
+// config could be moved to lit.local.cfg. However, there are downstream users that
+//  do not use these LIT config files. Hence why this is kept inline.
+//
+// DEFINE: %{sparsifier_opts} = enable-runtime-library=true
+// DEFINE: %{sparsifier_opts_sve} = enable-arm-sve=true %{sparsifier_opts}
+// DEFINE: %{compile} = mlir-opt %s --sparsifier="%{sparsifier_opts}"
+// DEFINE: %{compile_sve} = mlir-opt %s --sparsifier="%{sparsifier_opts_sve}"
+// DEFINE: %{run_libs} = -shared-libs=%mlir_c_runner_utils,%mlir_runner_utils
+// DEFINE: %{run_libs_sve} = -shared-libs=%native_mlir_runner_utils,%native_mlir_c_runner_utils
+// DEFINE: %{run_opts} = -e main -entry-point-result=void
+// DEFINE: %{run} = mlir-runner %{run_opts} %{run_libs}
+// DEFINE: %{run_sve} = %mcr_aarch64_cmd --march=aarch64 --mattr="+sve" %{run_opts} %{run_libs_sve}
+//
+// DEFINE: %{env} =
+//--------------------------------------------------------------------------------------------------
+
+// REDEFINE: %{sparsifier_opts} = enable-runtime-library=false
+
+// REDEFINE: %{env} = TENSOR0="%mlir_src_dir/test/Integration/data/coordinate_zero.tns"
+// RUN: %{compile} | not env %{env} %{run} 2>&1 | FileCheck %s --check-prefix=ZERO
+// ZERO: Coordinate 0 is out of bounds for dimension 0 with size 4
+
+// REDEFINE: %{env} = TENSOR0="%mlir_src_dir/test/Integration/data/coordinate_above_dimension.tns"
+// RUN: %{compile} | not env %{env} %{run} 2>&1 | FileCheck %s --check-prefix=ABOVE
+// ABOVE: Coordinate 5 is out of bounds for dimension 0 with size 4
+
+// REDEFINE: %{env} = TENSOR0="%mlir_src_dir/test/Integration/data/coordinate_negative.tns"
+// RUN: %{compile} | not env %{env} %{run} 2>&1 | FileCheck %s --check-prefix=NEGATIVE
+// NEGATIVE: Cannot parse coordinate for dimension 0
+
+// REDEFINE: %{env} = TENSOR0="%mlir_src_dir/test/Integration/data/coordinate_overflow.tns"
+// RUN: %{compile} | not env %{env} %{run} 2>&1 | FileCheck %s --check-prefix=OVERFLOW
+// OVERFLOW: Cannot parse coordinate for dimension 0
+
+// REDEFINE: %{env} = TENSOR0="%mlir_src_dir/test/Integration/data/coordinate_narrow.tns"
+// REDEFINE: %{run_opts} = -e main_narrow -entry-point-result=void
+// RUN: %{compile} | not env %{env} %{run} 2>&1 | FileCheck %s --check-prefix=NARROW
+// NARROW: Coordinate 300 cannot be represented by the requested coordinate type
+
+!Filename = !llvm.ptr
+
+#SparseTensor = #sparse_tensor.encoding<{
+  map = (d0, d1) -> (d0 : compressed(nonunique), d1 : singleton)
+}>
+
+#SparseTensor8 = #sparse_tensor.encoding<{
+  map = (d0, d1) -> (d0 : compressed(nonunique), d1 : singleton),
+  crdWidth = 8
+}>
+
+module {
+  func.func private @getTensorFilename(index) -> !Filename
+
+  func.func @main() {
+    %c0 = arith.constant 0 : index
+    %fileName = call @getTensorFilename(%c0) : (index) -> !Filename
+    %tensor = sparse_tensor.new %fileName
+      : !Filename to tensor<4x4xf64, #SparseTensor>
+    sparse_tensor.print %tensor : tensor<4x4xf64, #SparseTensor>
+    bufferization.dealloc_tensor %tensor
+      : tensor<4x4xf64, #SparseTensor>
+    return
+  }
+
+  func.func @main_narrow() {
+    %c0 = arith.constant 0 : index
+    %fileName = call @getTensorFilename(%c0) : (index) -> !Filename
+    %tensor = sparse_tensor.new %fileName
+      : !Filename to tensor<300x1xf64, #SparseTensor8>
+    sparse_tensor.print %tensor : tensor<300x1xf64, #SparseTensor8>
+    bufferization.dealloc_tensor %tensor
+      : tensor<300x1xf64, #SparseTensor8>
+    return
+  }
+}

--- a/mlir/test/Integration/data/coordinate_above_dimension.tns
+++ b/mlir/test/Integration/data/coordinate_above_dimension.tns
@@ -1,0 +1,4 @@
+# Extended FROSTT tensor with an out-of-bounds coordinate.
+2 1
+4 4
+5 1 1.0

--- a/mlir/test/Integration/data/coordinate_narrow.tns
+++ b/mlir/test/Integration/data/coordinate_narrow.tns
@@ -1,0 +1,4 @@
+# Extended FROSTT tensor with a coordinate that does not fit in uint8_t.
+2 1
+300 1
+300 1 1.0

--- a/mlir/test/Integration/data/coordinate_negative.tns
+++ b/mlir/test/Integration/data/coordinate_negative.tns
@@ -1,0 +1,4 @@
+# Extended FROSTT tensor with a negative coordinate.
+2 1
+4 4
+-1 1 1.0

--- a/mlir/test/Integration/data/coordinate_overflow.tns
+++ b/mlir/test/Integration/data/coordinate_overflow.tns
@@ -1,0 +1,4 @@
+# Extended FROSTT tensor with an overflowing coordinate.
+2 1
+4 4
+18446744073709551616 1 1.0

--- a/mlir/test/Integration/data/coordinate_zero.tns
+++ b/mlir/test/Integration/data/coordinate_zero.tns
@@ -1,0 +1,4 @@
+# Extended FROSTT tensor with a zero coordinate.
+2 1
+4 4
+0 1 1.0


### PR DESCRIPTION
Validate each 1-based sparse tensor coordinate before converting it to a zero-based value. Reject zero and out-of-bounds coordinates, malformed or overflowing tokens, and values not representable by the requested coordinate type.

Pre-fix integration regression:

  ZERO: expected string not found in input
  crd[0] : ( 18446744073709551615, 0 )

Found by Coverity.

Assisted-by: Codex