### PR TITLE
[mlir][OpenACC] Reject unsupported routine bind attributes

### DIFF
--- a/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
@@ -4741,18 +4741,22 @@ static ParseResult parseBindName(OpAsmParser &parser,
   llvm::SmallVector<mlir::Attribute> deviceStrTypeAttrs;
 
   if (failed(parser.parseCommaSeparatedList([&]() {
+        llvm::SMLoc attrLoc = parser.getCurrentLocation();
         mlir::Attribute newAttr;
         bool isSymbolRefAttr;
-        auto parseResult = parser.parseAttribute(newAttr);
+        if (parser.parseAttribute(newAttr))
+          return failure();
         if (auto symbolRefAttr = dyn_cast<mlir::SymbolRefAttr>(newAttr)) {
           bindIdNameAttrs.push_back(symbolRefAttr);
           isSymbolRefAttr = true;
         } else if (auto stringAttr = dyn_cast<mlir::StringAttr>(newAttr)) {
           bindStrNameAttrs.push_back(stringAttr);
           isSymbolRefAttr = false;
-        }
-        if (parseResult)
+        } else {
+          parser.emitError(attrLoc,
+                           "expected symbol reference or string attribute");
           return failure();
+        }
         if (failed(parser.parseOptionalLSquare())) {
           if (isSymbolRefAttr) {
             deviceIdTypeAttrs.push_back(mlir::acc::DeviceTypeAttr::get(

--- a/mlir/test/Dialect/OpenACC/invalid.mlir
+++ b/mlir/test/Dialect/OpenACC/invalid.mlir
@@ -127,6 +127,14 @@ acc.loop vector(%i64value: i64, %i64value: i64) {
 
 // -----
 
+func.func @acc_routine_bind() {
+  return
+}
+// expected-error@+1 {{expected symbol reference or string attribute}}
+acc.routine @acc_routine_bind_rout func(@acc_routine_bind) bind(42 : i64)
+
+// -----
+
 func.func @acc_routine_parallelism() -> () {
   return
 }


### PR DESCRIPTION
Require each routine bind item to be a symbol reference or string attribute. Other successfully parsed attributes left the kind discriminator uninitialized and were silently dropped.

Found by Coverity.

Assisted-by: Codex