### PR TITLE
[mlir][Affine] Account for eliminated stores in fusion cost

### DIFF
--- a/mlir/lib/Dialect/Affine/Utils/LoopFusionUtils.cpp
+++ b/mlir/lib/Dialect/Affine/Utils/LoopFusionUtils.cpp
@@ -596,15 +596,12 @@ bool mlir::affine::getFusionComputeCost(AffineForOp srcForOp,
   if (storeLoadFwdGuaranteed) {
     // Subtract from operation count the loads/store we expect load/store
     // forwarding to remove.
-    unsigned storeCount = 0;
     llvm::SmallDenseSet<Value, 4> storeMemrefs;
     srcForOp.walk([&](AffineWriteOpInterface storeOp) {
       storeMemrefs.insert(storeOp.getMemRef());
-      ++storeCount;
+      if (auto forOp = dyn_cast_or_null<AffineForOp>(storeOp->getParentOp()))
+        --computeCostMap[forOp];
     });
-    // Subtract out any store ops in single-iteration src slice loop nest.
-    if (storeCount > 0)
-      computeCostMap[insertPointParent] = -storeCount;
     // Subtract out any load users of 'storeMemrefs' nested below
     // 'insertPointParent'.
     for (Value memref : storeMemrefs) {

--- a/mlir/test/Dialect/Affine/loop-fusion-3.mlir
+++ b/mlir/test/Dialect/Affine/loop-fusion-3.mlir
@@ -1056,11 +1056,11 @@ func.func @reduce_add_non_innermost(%arg0: memref<64x64xf32, 1>, %arg1: memref<1
   }
   return
 }
-// Test checks the loop structure is preserved after sibling fusion.
-// CHECK:         affine.for
-// CHECK-NEXT:      affine.for
-// CHECK-NEXT:        affine.for
-// CHECK:            affine.for
+// The cost model accounts for eliminated stores and chooses maximal sibling
+// fusion.
+// CHECK-COUNT-3: affine.for
+// CHECK-NOT:     affine.for
+// CHECK:         return
 
 
 

--- a/mlir/test/Dialect/Affine/loop-fusion-compute-cost.mlir
+++ b/mlir/test/Dialect/Affine/loop-fusion-compute-cost.mlir
@@ -1,0 +1,16 @@
+// RUN: mlir-opt %s -test-loop-fusion=test-fusion-compute-cost \
+// RUN:   -verify-diagnostics
+
+func.func @single_iteration_store_load(%input: memref<1xf32>, %value: f32) {
+  affine.for %i = 0 to 1 {
+    affine.store %value, %input[%i] : memref<1xf32>
+  }
+  // expected-remark@below {{fusion compute cost: 1}}
+  affine.for %j = 0 to 1 {
+    affine.for %k = 0 to 1 {
+      %loaded = affine.load %input[%k] : memref<1xf32>
+      %unused = arith.addf %loaded, %loaded : f32
+    }
+  }
+  return
+}

--- a/mlir/test/lib/Dialect/Affine/TestLoopFusion.cpp
+++ b/mlir/test/lib/Dialect/Affine/TestLoopFusion.cpp
@@ -52,6 +52,11 @@ struct TestLoopFusion
       *this, "test-loop-fusion-utilities",
       llvm::cl::desc("Enable testing of loop fusion transformation utilities"),
       llvm::cl::init(false)};
+
+  Option<bool> clTestFusionComputeCost{
+      *this, "test-fusion-compute-cost",
+      llvm::cl::desc("Enable testing of the fusion compute cost"),
+      llvm::cl::init(false)};
 };
 
 } // namespace
@@ -154,6 +159,30 @@ static bool testLoopFusionUtilities(AffineForOp forOpA, AffineForOp forOpB,
   return false;
 }
 
+static LogicalResult testFusionComputeCost(AffineForOp srcForOp,
+                                           AffineForOp dstForOp) {
+  LoopNestStats srcStats;
+  LoopNestStats dstStats;
+  if (!getLoopNestStats(srcForOp, &srcStats) ||
+      !getLoopNestStats(dstForOp, &dstStats))
+    return failure();
+
+  ComputationSliceState slice;
+  slice.ivs.push_back(srcForOp.getInductionVar());
+  slice.lbs.resize(1);
+  slice.ubs.resize(1);
+  slice.lbOperands.resize(1);
+  slice.ubOperands.resize(1);
+  slice.insertPoint = dstForOp.getBody()->begin();
+
+  int64_t computeCost;
+  if (!getFusionComputeCost(srcForOp, srcStats, dstForOp, dstStats, slice,
+                            &computeCost))
+    return failure();
+  dstForOp->emitRemark() << "fusion compute cost: " << computeCost;
+  return success();
+}
+
 using LoopFunc = function_ref<bool(AffineForOp, AffineForOp, unsigned, unsigned,
                                    unsigned, unsigned)>;
 
@@ -197,6 +226,14 @@ void TestLoopFusion::runOnOperation() {
 
   // Gather all AffineForOps by loop depth.
   gatherLoops(getOperation(), depthToLoops);
+
+  if (clTestFusionComputeCost) {
+    if (depthToLoops.empty() || depthToLoops.front().size() != 2 ||
+        failed(testFusionComputeCost(depthToLoops.front()[0],
+                                     depthToLoops.front()[1])))
+      return signalPassFailure();
+    return;
+  }
 
   // Run tests on all combinations of src/dst loop nests in 'depthToLoops'.
   if (clTestDependenceCheck)


### PR DESCRIPTION
Charge eliminated stores to their enclosing source loops when computing a single-iteration fusion slice. The extracted cost utility instead charged the destination insertion loop, where the adjustment was overwritten before use.

Found by Coverity.

Assisted-by: Codex