### PR TITLE
[AMDGPU] Expose LDS block features to TargetParser

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPU.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.td
@@ -3245,6 +3245,7 @@ def AMDGPUFrontendVisibleFeatures {
   FeatureSupportsXNACK, FeatureSupportsSRAMECC, FeatureXNACKOnOffModes,
   FeatureSGPRInitBug, FeatureApertureRegs, FeatureGetDoorbellID,
   FeatureAGPRAlloc, Feature1536VGPRs,
+  FeatureHalfAddressablePhysicalLocalMemory,
   ];
 }
 

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -494,10 +494,12 @@ StringRef AMDGPU::getCanonicalArchName(const Triple &T, StringRef Arch) {
 // FIXME: This is hacky, we shouldn't have mismatches between the bitset and
 // feature string map.
 static const AMDGPUFeatureBitset FrontendOnlyFeatures = {
-    FEAT_FAST_FMAF,          FEAT_FAST_DENORMAL_F32,  FEAT_SUPPORTS_WAVE32,
-    FEAT_SUPPORTS_WGP,       FEAT_XNACK_SUPPORT,      FEAT_SRAMECC_SUPPORT,
-    FEAT_XNACK_ON_OFF_MODES, FEAT_APERTURE_REGS,      FEAT_GET_DOORBELL_ID,
-    FEAT_AGPR_ALLOC,         FEAT_1536_PHYSICAL_VGPRS};
+    FEAT_FAST_FMAF,           FEAT_FAST_DENORMAL_F32,
+    FEAT_SUPPORTS_WAVE32,     FEAT_SUPPORTS_WGP,
+    FEAT_XNACK_SUPPORT,       FEAT_SRAMECC_SUPPORT,
+    FEAT_XNACK_ON_OFF_MODES,  FEAT_APERTURE_REGS,
+    FEAT_GET_DOORBELL_ID,     FEAT_AGPR_ALLOC,
+    FEAT_1536_PHYSICAL_VGPRS, FEAT_HALF_ADDRESSABLE_PHYSICAL_LOCAL_MEMORY};
 
 // Add a GPU's features (minus the frontend-only ones) to \p Features. With \p
 // Overwrite false, existing entries are kept so user -mattr overrides win.

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -2821,6 +2821,9 @@ TEST(TargetParserTest, testAMDGPUfillAMDGPUFeatureMap) {
 
   EXPECT_TRUE(HasFeature("gfx1250", "smem-prefetch-insts"));
   EXPECT_TRUE(HasFeature("gfx950", "bf16-cvt-insts"));
+
+  // A capability feature is queried through the bitset only.
+  EXPECT_FALSE(HasFeature("gfx1030", "half-addressable-physical-local-memory"));
 }
 
 TEST(TargetParserTest, testAMDGPUgetFeatureBitset) {
@@ -2854,6 +2857,21 @@ TEST(TargetParserTest, testAMDGPUgetFeatureBitset) {
   SmallVector<StringRef, 0> Empty;
   AMDGPU::getFeatureNames(AMDGPU::getFeatureBitset(AMDGPU::GK_NONE), Empty);
   EXPECT_TRUE(Empty.empty());
+}
+
+TEST(TargetParserTest, testAMDGPUHalfAddressableLDSFeature) {
+  auto Has = [](AMDGPU::GPUKind AK) {
+    return AMDGPU::getFeatureBitset(AK).test(
+        AMDGPU::FEAT_HALF_ADDRESSABLE_PHYSICAL_LOCAL_MEMORY);
+  };
+
+  // Only gfx10/11/12 address half of the physical LDS block.
+  EXPECT_FALSE(Has(AMDGPU::GK_GFX900));
+  EXPECT_TRUE(Has(AMDGPU::GK_GFX1030));
+  EXPECT_TRUE(Has(AMDGPU::GK_GFX1100));
+  EXPECT_TRUE(Has(AMDGPU::GK_GFX1200));
+  EXPECT_FALSE(Has(AMDGPU::GK_GFX1250));
+  EXPECT_FALSE(Has(AMDGPU::GK_GFX1310));
 }
 
 TEST(TargetParserTest, testAMDGPUfillValidArchListAMDGCN) {


### PR DESCRIPTION
Add `FeatureHalfAddressablePhysicalLocalMemory` to `AMDGPUFrontendVisibleFeatures` so TargetParser carries them in its per-GPU feature bitset.