### PR TITLE
[mlir][dataflow] Make visitRegionSuccessors overridable

### DIFF
--- a/mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h
+++ b/mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h
@@ -257,6 +257,20 @@ protected:
   visitCallableOperation(CallableOpInterface callable,
                          ArrayRef<AbstractSparseLattice *> argLattices);
 
+  /// Visit a program point `point` with predecessors within a region branch
+  /// operation `branch`, which can either be the entry block of one of the
+  /// regions or the parent operation itself, and set either the argument or
+  /// parent result lattices.
+  /// This method can be overridden to control precisely how the region
+  /// successors of `branch` are visited. For example in order to precisely
+  /// control the order in which predecessor operand lattices are propagated
+  /// from. An override is responsible for visiting all the known predecessors
+  /// and propagating therefrom.
+  virtual void
+  visitRegionSuccessors(ProgramPoint *point, RegionBranchOpInterface branch,
+                        RegionSuccessor successor,
+                        ArrayRef<AbstractSparseLattice *> lattices);
+
 private:
   /// Recursively initialize the analysis on nested operations and blocks.
   LogicalResult initializeRecursively(Operation *op);
@@ -272,20 +286,6 @@ private:
   /// region terminators or callable callsites. Otherwise, the values are
   /// determined from block predecessors.
   void visitBlock(Block *block);
-
-  /// Visit a program point `point` with predecessors within a region branch
-  /// operation `branch`, which can either be the entry block of one of the
-  /// regions or the parent operation itself, and set either the argument or
-  /// parent result lattices.
-  /// This method can be overridden to control precisely how the region
-  /// successors of `branch` are visited. For example in order to precisely
-  /// control the order in which predecessor operand lattices are propagated
-  /// from. An override is responsible for visiting all the known predecessors
-  /// and propagating therefrom.
-  virtual void
-  visitRegionSuccessors(ProgramPoint *point, RegionBranchOpInterface branch,
-                        RegionSuccessor successor,
-                        ArrayRef<AbstractSparseLattice *> lattices);
 };
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
AbstractSparseForwardDataFlowAnalysis::visitRegionSuccessors is virtual and its
comment says it may be overridden to control precisely how the region
successors of a branch are visited, but it is declared in the private section.
An override therefore cannot delegate to the default implementation for the
cases it does not want to handle itself: it has to reimplement all of them.

Move the declaration to the protected section, next to visitCallableOperation
and the other hooks a subclass is meant to override. This is NFC. The only
change is the access level; the declaration, the comment and the default
implementation are untouched. The twin in
AbstractSparseBackwardDataFlowAnalysis is left alone: it is not virtual, so
making it protected would not let an override delegate to it.

The patch that needs it is the next one in this series, "[mlir] Add uniformity
analysis and InferUniformityOpInterface". That analysis overrides the hook for
two cases, joining the uniformity of the operands that steer a region branch
into the branch results, and letting an operation whose results are not the
values yielded from its regions describe those results itself, and needs to
delegate to the base implementation for the rest.

This patch stands alone and depends on no other patch in the series.