### PR TITLE
[nfc][ProfileData] Fix -Wrange-loop-construct in SampleProfileWriter

### DIFF
--- a/llvm/lib/ProfileData/SampleProfWriter.cpp
+++ b/llvm/lib/ProfileData/SampleProfWriter.cpp
@@ -801,7 +801,7 @@ std::error_code SampleProfileWriterText::writeSample(const FunctionSamples &S) {
       Loc.print(OS);
       OS << ": ";
       OS << kVTableProfPrefix;
-      for (const auto [TypeName, Count] : *Map) {
+      for (const auto &[TypeName, Count] : *Map) {
         OS << TypeName << ":" << Count << " ";
       }
       OS << "\n";
@@ -826,7 +826,7 @@ std::error_code SampleProfileWriterText::writeSample(const FunctionSamples &S) {
       Loc.print(OS);
       OS << ": ";
       OS << kVTableProfPrefix;
-      for (const auto [TypeId, Count] : *Map) {
+      for (const auto &[TypeId, Count] : *Map) {
         OS << TypeId << ":" << Count << " ";
       }
       OS << "\n";


### PR DESCRIPTION
Fixes warnings:
```
SampleProfWriter.cpp:804:12: note: use reference type 'std::pair<llvm::sampleprof::FunctionId, unsigned long> const &' to prevent copying
  804 |       for (const auto [TypeName, Count] : *Map) {
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                       &
  SampleProfWriter.cpp:829:12: note: use reference type 'std::pair<llvm::sampleprof::FunctionId, unsigned long> const &' to prevent copying
  829 |       for (const auto [TypeId, Count] : *Map) {
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                       &
```