### PR TITLE
[LoopVersioning] Add missing verify-analysis-invalidation=false to test.

### DIFF
--- a/llvm/test/Transforms/LoopVersioning/preserved-analyses.ll
+++ b/llvm/test/Transforms/LoopVersioning/preserved-analyses.ll
@@ -1,5 +1,5 @@
 ; RUN: opt -passes='require<memoryssa>,loop-versioning,require<memoryssa>,require<domtree>,require<loops>,require<scalar-evolution>' \
-; RUN:     -debug-pass-manager -disable-output %s 2>&1 | FileCheck %s
+; RUN:     -verify-analysis-invalidation=false -debug-pass-manager -disable-output %s 2>&1 | FileCheck %s
 
 ; Verify perserved analyses.
 ; RUN: opt -passes='require<memoryssa>,loop-versioning,verify<domtree>,verify<loops>,verify<memoryssa>' \


### PR DESCRIPTION
Add -verify-analysis-invalidation=false to test added in https://github.com/llvm/llvm-project/pull/220537 to fix expensive check failures due to extra verification passes.