### PR TITLE
[Clang][Cygwin] Set default DWARF version to 4

### DIFF
--- a/clang/lib/Driver/ToolChains/Cygwin.h
+++ b/clang/lib/Driver/ToolChains/Cygwin.h
@@ -33,6 +33,8 @@ public:
                         llvm::opt::ArgStringList &CC1Args, BoundArch BA,
                         Action::OffloadKind DeviceOffloadKind) const override;
 
+  unsigned GetDefaultDwarfVersion() const override { return 4; }
+
 protected:
   Tool *buildLinker() const override;
 };

--- a/clang/test/CodeGen/dwarf-version.c
+++ b/clang/test/CodeGen/dwarf-version.c
@@ -35,8 +35,10 @@
 // RUN: %clang -target i686-pc-windows-msvc -gdwarf -gcodeview -S -emit-llvm -o - %s \
 // RUN:     | FileCheck %s --check-prefixes=VER4,CODEVIEW
 
-// Check what version of dwarf is used for MinGW targets.
+// Check what version of dwarf is used for MinGW/Cygwin targets.
 // RUN: %clang -target i686-pc-windows-gnu -g -S -emit-llvm -o - %s | \
+// RUN:   FileCheck %s --check-prefixes=VER4
+// RUN: %clang -target i686-pc-windows-cygnus -g -S -emit-llvm -o - %s | \
 // RUN:   FileCheck %s --check-prefixes=VER4
 
 // RUN: %clang -target powerpc-ibm-aix-xcoff -g -S -emit-llvm -o - %s | \


### PR DESCRIPTION
Cygwin distribution's GDB doesn't work with DWARF 5.
Do the same as MinGW (6cf64b2d2858dc93c3ec93438bdaca2807847e9b).
