### PR TITLE
[mlir] Disable some tests when the execution engine is disabled

### DIFF
--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -170,8 +170,13 @@ set(MLIR_TEST_DEPENDS ${MLIR_TEST_DEPENDS}
 # useless binaries.
 if(LLVM_ENABLE_PIC AND TARGET ${LLVM_NATIVE_ARCH})
   list(APPEND MLIR_TEST_DEPENDS
-    mlir-runner
     llc
+  )
+endif()
+# The native target may be available but the execution engine may not.
+if(LLVM_ENABLE_PIC AND MLIR_ENABLE_EXECUTION_ENGINE)
+  list(APPEND MLIR_TEST_DEPENDS
+    mlir-runner
     mlir_async_runtime
     mlir-capi-execution-engine-test
     mlir-capi-global-constructors-test


### PR DESCRIPTION
It's possible to have a scenario where the native target is enabled, but the execution engine is not, e.g. when trying to avoid an issue with the execution engine.

In that case, we need to disable the tests that depend on: mlir-runner, mlir_async_runtime, mlir-capi-execution-engine-test, mlir-capi-global-constructors-test, mlir_c_runner_utils, mlir_runner_utils and mlir_float16_utils.