### PR TITLE
[Offload] Build LLVMOffloadKernel with add_library

### DIFF
--- a/offload/languages/kernel/CMakeLists.txt
+++ b/offload/languages/kernel/CMakeLists.txt
@@ -55,7 +55,7 @@ add_custom_command(
 add_custom_target(LLVMOffloadKernelPerThreadDefaultStream
   DEPENDS ${LLVM_OFFLOAD_KERNEL_PER_THREAD_DEFAULT_STREAM_OBJECT})
 
-add_llvm_library(
+add_library(
   LLVMOffloadKernel SHARED
 
   $<TARGET_OBJECTS:LLVMOffloadKernelCudaRuntimeObjects>
@@ -90,10 +90,14 @@ target_compile_definitions(LLVMOffloadKernel PRIVATE
 )
 
 set_target_properties(LLVMOffloadKernel PROPERTIES
-                      RUNTIME_OUTPUT_DIRECTORY "${LLVM_LIBRARY_OUTPUT_INTDIR}/${OFFLOAD_TARGET_SUBDIR}"
                       POSITION_INDEPENDENT_CODE ON
-                      INSTALL_RPATH "$ORIGIN"
+                      INSTALL_RPATH "${OFFLOAD_INSTALL_RPATH}"
                       BUILD_RPATH "$ORIGIN:${CMAKE_CURRENT_BINARY_DIR}/..")
+if(UNIX AND NOT APPLE)
+  set_target_properties(LLVMOffloadKernel PROPERTIES
+                        SOVERSION "${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}${LLVM_VERSION_SUFFIX}"
+                        VERSION "${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}${LLVM_VERSION_SUFFIX}")
+endif()
 install(TARGETS LLVMOffloadKernel
         COMPONENT offload
         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"


### PR DESCRIPTION
Depending on system and cmake configuration, LLVMOffloadKernel cannot find LLVMOffload when testing because they live in different directories in the build.

This patch aligns LLVMOffloadKernel's library build/install directory configuration with LLVMOffload's, which makes sure it can always be found.

The cause is that llvm_add_library adds some implicit handling which can throw off the directories we need (see 3383f0d6fe01374b91845e7cd3ee949594c4bfc6)