### PR TITLE
[orc-rt] Add darwin subdir for regression tests.

### DIFF
--- a/orc-rt/test/regression/darwin/check-rt-process-info.test
+++ b/orc-rt/test/regression/darwin/check-rt-process-info.test
@@ -1,5 +1,3 @@
-# REQUIRES: system-darwin
-#
 # RUN: orc-rt-process-info-check --print-triple --print-cpu-features --print-page-size  \
 # RUN:   | FileCheck %s -DVERSION=%macos-product-version
 

--- a/orc-rt/test/regression/darwin/lit.local.cfg
+++ b/orc-rt/test/regression/darwin/lit.local.cfg
@@ -1,0 +1,2 @@
+if "system-darwin" not in config.available_features:
+  config.unsupported = True


### PR DESCRIPTION
All tests in the new subdirectory are implicitly gated on lit's "system-darwin" feature flag.

Move check-rt-process-info.test into the darwin subdirectory and drop its "system-darwin" guard, since it will now be covered by the darwin directory's guard.