### PR TITLE
[TTI] Fix dyn_cast null-check in BasicTTIImpl

### DIFF
--- a/llvm/include/llvm/CodeGen/BasicTTIImpl.h
+++ b/llvm/include/llvm/CodeGen/BasicTTIImpl.h
@@ -3271,7 +3271,7 @@ public:
     // Try to find actual number of parts for non-power-of-2 elements as
     // ceil(num-of-elements/num-of-subtype-elements).
     if (auto *FTp = dyn_cast<FixedVectorType>(Tp);
-        Tp && LT.second.isFixedLengthVector() &&
+        FTp && LT.second.isFixedLengthVector() &&
         !has_single_bit(FTp->getNumElements())) {
       if (auto *SubTp = dyn_cast_if_present<FixedVectorType>(
               EVT(LT.second).getTypeForEVT(Tp->getContext()));


### PR DESCRIPTION
Ought to check the output of `dyn_cast`, not the input.

Introduced in #107273, I don't see any documentation saying this was intentionally added.

My understanding is that `LT.second.isFixedLengthVector()` duplicates this check hence why no crash was ever observed (we would have to legalize a `ScalableVectorType` to a `FixedVectorType`).