### PR TITLE
[RISCV] Andes: model fast unaligned accesses

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVProcessors.td
+++ b/llvm/lib/Target/RISCV/RISCVProcessors.td
@@ -998,7 +998,8 @@ def ANDES_AX25 : RISCVProcessorModel<"andes-ax25",
                                       FeatureStdExtC,
                                       FeatureVendorXAndesPerf]>;
 
-defvar Andes45TuneFeatures = [TuneAndes45,
+defvar Andes45TuneFeatures = [FeatureUnalignedScalarMem,
+                              TuneAndes45,
                               TuneNoDefaultUnroll,
                               TuneShortForwardBranchIALU,
                               TunePostRAScheduler];

--- a/llvm/test/CodeGen/RISCV/andes-45-unaligned-scalar-mem.ll
+++ b/llvm/test/CodeGen/RISCV/andes-45-unaligned-scalar-mem.ll
@@ -1,0 +1,15 @@
+; RUN: llc -mtriple=riscv64 -verify-machineinstrs < %s | FileCheck %s
+
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg)
+
+define void @memcpy51(ptr %dst, ptr %src) #0 {
+; CHECK-LABEL: memcpy51:
+; CHECK-NOT: call
+; CHECK: ld
+; CHECK: sd
+; CHECK: ret
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %dst, ptr align 1 %src, i64 51, i1 false)
+  ret void
+}
+
+attributes #0 = { "tune-cpu"="andes-45-series" }


### PR DESCRIPTION
Mark the Andes 45 tuning profile as supporting efficient unaligned scalar loads and stores. This lets fixed-size alignment-one copies lower to scalar instructions instead of a memcpy call. On these in-order cores, where performance is almost synonymous with instruction count, this is a material win.