### PR TITLE
[DWARF] Add DW_MSPACE_LLVM_* memory space encodings

### DIFF
--- a/llvm/include/llvm/BinaryFormat/Dwarf.def
+++ b/llvm/include/llvm/BinaryFormat/Dwarf.def
@@ -26,6 +26,7 @@
       defined HANDLE_DWARF_SECTION || defined HANDLE_DW_IDX ||                 \
       defined HANDLE_DW_END || defined HANDLE_DW_SECT ||                       \
       defined HANDLE_DW_APPLE_ENUM_KIND ||                                     \
+      defined HANDLE_DW_MSPACE ||                                              \
       defined HANDLE_DW_LLVM_LANG_DIALECT ||                                   \
       ( defined HANDLE_DW_ASPACE && defined HANDLE_DW_ASPACE_PRED) )
 #error "Missing macro definition of HANDLE_DW*"
@@ -151,6 +152,10 @@
 
 #ifndef HANDLE_DW_APPLE_ENUM_KIND
 #define HANDLE_DW_APPLE_ENUM_KIND(ID, NAME)
+#endif
+
+#ifndef HANDLE_DW_MSPACE
+#define HANDLE_DW_MSPACE(ID, NAME)
 #endif
 
 #ifndef HANDLE_DW_LLVM_LANG_DIALECT
@@ -660,6 +665,13 @@ HANDLE_DW_AT(0x3e12, LLVM_lane_pc, 0, LLVM)
 HANDLE_DW_AT(0x3e13, LLVM_vector_size, 0, LLVM)
 HANDLE_DW_AT(0x3e14, LLVM_virtual_call_origin, 0, LLVM)
 HANDLE_DW_AT(0x3e15, LLVM_language_dialect, 0, LLVM)
+
+// https://www.llvm.org/docs/AMDGPUDwarfExtensionsForHeterogeneousDebugging.html#a-7-15-memory-space-encodings
+HANDLE_DW_MSPACE(0x0, none)
+HANDLE_DW_MSPACE(0x1, global)
+HANDLE_DW_MSPACE(0x2, constant)
+HANDLE_DW_MSPACE(0x3, group)
+HANDLE_DW_MSPACE(0x4, private)
 
 // https://llvm.org/docs/AMDGPUUsage.html#address-space-identifier
 HANDLE_DW_ASPACE(0x0, none)
@@ -1473,6 +1485,7 @@ HANDLE_DW_SECT(8, RNGLISTS)
 #undef HANDLE_DW_END
 #undef HANDLE_DW_SECT
 #undef HANDLE_DW_APPLE_ENUM_KIND
+#undef HANDLE_DW_MSPACE
 #undef HANDLE_DW_LLVM_LANG_DIALECT
 #undef HANDLE_DW_ASPACE
 #undef HANDLE_DW_ASPACE_PRED

--- a/llvm/include/llvm/BinaryFormat/Dwarf.h
+++ b/llvm/include/llvm/BinaryFormat/Dwarf.h
@@ -848,6 +848,13 @@ enum CallingConvention {
   DW_CC_hi_user = 0xff
 };
 
+enum MemorySpace {
+#define HANDLE_DW_MSPACE(ID, NAME) DW_MSPACE_LLVM_##NAME = ID,
+#include "llvm/BinaryFormat/Dwarf.def"
+  DW_MSPACE_LLVM_lo_user = 0x8000,
+  DW_MSPACE_LLVM_hi_user = 0xffff
+};
+
 enum AddressSpace {
 #define HANDLE_DW_ASPACE(ID, NAME) DW_ASPACE_LLVM_##NAME = ID,
 #define HANDLE_DW_ASPACE_PRED(ID, NAME, PRED) DW_ASPACE_LLVM_##NAME = ID,
@@ -1110,6 +1117,7 @@ LLVM_ABI StringRef IndexString(unsigned Idx);
 LLVM_ABI StringRef FormatString(DwarfFormat Format);
 LLVM_ABI StringRef FormatString(bool IsDWARF64);
 LLVM_ABI StringRef RLEString(unsigned RLE);
+LLVM_ABI StringRef MemorySpaceString(unsigned MS);
 LLVM_ABI StringRef AddressSpaceString(unsigned AS, const llvm::Triple &TT);
 /// @}
 
@@ -1130,6 +1138,7 @@ LLVM_ABI unsigned getSubOperationEncoding(unsigned OpEncoding,
 LLVM_ABI unsigned getVirtuality(StringRef VirtualityString);
 LLVM_ABI unsigned getEnumKind(StringRef EnumKindString);
 LLVM_ABI unsigned getLanguage(StringRef LanguageString);
+LLVM_ABI unsigned getMemorySpace(StringRef MSString);
 LLVM_ABI unsigned getSourceLanguageName(StringRef SourceLanguageNameString);
 LLVM_ABI unsigned getLanguageDialect(StringRef LanguageDialectString);
 LLVM_ABI unsigned getCallingConvention(StringRef LanguageString);

--- a/llvm/lib/BinaryFormat/Dwarf.cpp
+++ b/llvm/lib/BinaryFormat/Dwarf.cpp
@@ -933,6 +933,8 @@ StringRef llvm::dwarf::AttributeValueString(uint16_t Attr, unsigned Val) {
     return DefaultedMemberString(Val);
   case DW_AT_APPLE_enum_kind:
     return EnumKindString(Val);
+  case DW_AT_LLVM_memory_space:
+    return MemorySpaceString(Val);
   case DW_AT_language_name:
     return SourceLanguageNameString(static_cast<SourceLanguageName>(Val));
   }
@@ -1081,6 +1083,29 @@ StringRef llvm::dwarf::RLEString(unsigned RLE) {
   case DW_RLE_##NAME:                                                          \
     return "DW_RLE_" #NAME;
 #include "llvm/BinaryFormat/Dwarf.def"
+  }
+}
+
+unsigned llvm::dwarf::getMemorySpace(StringRef MSString) {
+  return StringSwitch<unsigned>(MSString)
+#define HANDLE_DW_MSPACE(ID, NAME)                                             \
+  .Case("DW_MSPACE_LLVM_" #NAME, DW_MSPACE_LLVM_##NAME)
+#include "llvm/BinaryFormat/Dwarf.def"
+      .Default(0);
+}
+
+StringRef llvm::dwarf::MemorySpaceString(unsigned MS) {
+  switch (MS) {
+  default:
+    return StringRef();
+#define HANDLE_DW_MSPACE(ID, NAME)                                             \
+  case DW_MSPACE_LLVM_##NAME:                                                  \
+    return "DW_MSPACE_LLVM_" #NAME;
+#include "llvm/BinaryFormat/Dwarf.def"
+  case DW_MSPACE_LLVM_lo_user:
+    return "DW_MSPACE_LLVM_lo_user";
+  case DW_MSPACE_LLVM_hi_user:
+    return "DW_MSPACE_LLVM_hi_user";
   }
 }
 

--- a/llvm/test/tools/llvm-dwarfdump/AMDGPU/DW_AT_LLVM_memory_space.yaml
+++ b/llvm/test/tools/llvm-dwarfdump/AMDGPU/DW_AT_LLVM_memory_space.yaml
@@ -1,0 +1,64 @@
+# Test that DW_AT_LLVM_memory_space values are printed with their symbolic
+# names. Unlike address spaces, memory space encodings are target-independent.
+# Values outside the defined encodings are printed as plain integers.
+
+# RUN: yaml2obj %s | llvm-dwarfdump - | FileCheck %s
+
+# CHECK:      DW_TAG_variable
+# CHECK-NEXT:   DW_AT_LLVM_memory_space (DW_MSPACE_LLVM_none)
+# CHECK:      DW_TAG_variable
+# CHECK-NEXT:   DW_AT_LLVM_memory_space (DW_MSPACE_LLVM_global)
+# CHECK:      DW_TAG_variable
+# CHECK-NEXT:   DW_AT_LLVM_memory_space (DW_MSPACE_LLVM_group)
+# CHECK:      DW_TAG_variable
+# CHECK-NEXT:   DW_AT_LLVM_memory_space (DW_MSPACE_LLVM_private)
+# CHECK:      DW_TAG_variable
+# CHECK-NEXT:   DW_AT_LLVM_memory_space (0x00000007)
+
+--- !ELF
+FileHeader:
+  Class:      ELFCLASS64
+  Data:       ELFDATA2LSB
+  OSABI:      ELFOSABI_AMDGPU_HSA
+  ABIVersion: 0x02
+  Type:       ET_REL
+  Machine:    EM_AMDGPU
+  Flags:      [ EF_AMDGPU_MACH_AMDGCN_GFX900 ]
+DWARF:
+  debug_abbrev:
+    - Table:
+        - Code:     0x00000001
+          Tag:      DW_TAG_compile_unit
+          Children: DW_CHILDREN_yes
+        - Code:     0x00000002
+          Tag:      DW_TAG_variable
+          Children: DW_CHILDREN_no
+          Attributes:
+            - Attribute: DW_AT_LLVM_memory_space
+              Form:      DW_FORM_data4
+  debug_info:
+    - Version:    5
+      UnitType:   DW_UT_compile
+      AbbrOffset: 0
+      AddrSize:   8
+      Entries:
+        - AbbrCode: 0x00000001
+          Values:   []
+        - AbbrCode: 0x00000002
+          Values:
+            - Value: 0x0000000000000000
+        - AbbrCode: 0x00000002
+          Values:
+            - Value: 0x0000000000000001
+        - AbbrCode: 0x00000002
+          Values:
+            - Value: 0x0000000000000003
+        - AbbrCode: 0x00000002
+          Values:
+            - Value: 0x0000000000000004
+        - AbbrCode: 0x00000002
+          Values:
+            - Value: 0x0000000000000007
+        - AbbrCode: 0x00000000
+          Values:   []
+...

--- a/llvm/test/tools/llvm-dwarfdump/AMDGPU/DW_AT_LLVM_memory_space.yaml
+++ b/llvm/test/tools/llvm-dwarfdump/AMDGPU/DW_AT_LLVM_memory_space.yaml
@@ -9,6 +9,8 @@
 # CHECK:      DW_TAG_variable
 # CHECK-NEXT:   DW_AT_LLVM_memory_space (DW_MSPACE_LLVM_global)
 # CHECK:      DW_TAG_variable
+# CHECK-NEXT:   DW_AT_LLVM_memory_space (DW_MSPACE_LLVM_constant)
+# CHECK:      DW_TAG_variable
 # CHECK-NEXT:   DW_AT_LLVM_memory_space (DW_MSPACE_LLVM_group)
 # CHECK:      DW_TAG_variable
 # CHECK-NEXT:   DW_AT_LLVM_memory_space (DW_MSPACE_LLVM_private)
@@ -50,6 +52,9 @@ DWARF:
         - AbbrCode: 0x00000002
           Values:
             - Value: 0x0000000000000001
+        - AbbrCode: 0x00000002
+          Values:
+            - Value: 0x0000000000000002
         - AbbrCode: 0x00000002
           Values:
             - Value: 0x0000000000000003


### PR DESCRIPTION
DW_AT_LLVM_memory_space is already defined in Dwarf.def, and the memory
space encodings it takes are already specified in
docs/AMDGPUDwarfExtensionsForHeterogeneousDebugging.rst, but the values
had no names in the source, so llvm-dwarfdump printed the attribute as a
bare integer.

Add the encodings via a HANDLE_DW_MSPACE macro alongside the existing
HANDLE_DW_ASPACE, define the MemorySpace enum, and add MemorySpaceString
and getMemorySpace. AttributeValueString then resolves the attribute, so
no changes are needed in the DWARF consumers themselves.

Unlike address spaces, memory space encodings are target-independent, so
MemorySpaceString takes no triple.