### PR TITLE
[SLP] Fix-up profile metadata for runtime alias checks

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -69,6 +69,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/MDBuilder.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Operator.h"
 #include "llvm/IR/PatternMatch.h"
@@ -25509,10 +25510,12 @@ void BoUpSLP::versionBlocksForRuntimeChecks() {
   CondBrInst *Guard = ChkBuilder.CreateCondBr(Cond, ScalarBB, VecBB);
   // The scalar fallback is taken only when the runtime alias check detects a
   // conflict, which is expected to be rare, so bias the guard towards the
-  // vector path. Only annotate profiled functions, to avoid injecting profile
-  // data into functions that have none.
-  if (!ProfcheckDisableMetadataFixes && Fn->getEntryCount())
-    setBranchWeights(*Guard, {1, 127}, /*IsExpected=*/false);
+  // vector path.
+  if (!ProfcheckDisableMetadataFixes)
+    setBranchWeights(
+        *Guard,
+        {MDBuilder::kUnlikelyBranchWeight, MDBuilder::kLikelyBranchWeight},
+        /*IsExpected=*/false);
 
   // The continuation block is the new predecessor of the original successors.
   for (BasicBlock *Succ : successors(Term))

--- a/llvm/test/Transforms/SLPVectorizer/AArch64/runtime-alias-checks-scheduled-order.ll
+++ b/llvm/test/Transforms/SLPVectorizer/AArch64/runtime-alias-checks-scheduled-order.ll
@@ -17,7 +17,7 @@ define fastcc void @versioned_block_preserves_scheduled_order(ptr %LARc, ptr %LA
 ; CHECK-NEXT:    [[RT_BOUND1:%.*]] = icmp ult i64 [[LARC2]], [[TMP1]]
 ; CHECK-NEXT:    [[RT_CONFLICT:%.*]] = and i1 [[RT_BOUND0]], [[RT_BOUND1]]
 ; CHECK-NEXT:    [[RT_GUARD:%.*]] = freeze i1 [[RT_CONFLICT]]
-; CHECK-NEXT:    br i1 [[RT_GUARD]], label %[[ENTRY_RTSCALAR:.*]], label %[[ENTRY_RTVEC:.*]]
+; CHECK-NEXT:    br i1 [[RT_GUARD]], label %[[ENTRY_RTSCALAR:.*]], label %[[ENTRY_RTVEC:.*]], !prof [[PROF0:![0-9]+]]
 ; CHECK:       [[ENTRY_RTVEC]]:
 ; CHECK-NEXT:    [[INCDEC_PTR92:%.*]] = getelementptr i8, ptr [[LARPP]], i64 4
 ; CHECK-NEXT:    [[TMP3:%.*]] = load i16, ptr [[LARC]], align 2
@@ -104,7 +104,7 @@ define void @versioned_block_check_reuses_no_body_scalars(ptr %arg, ptr nofree r
 ; CHECK-NEXT:    [[RT_BOUND1:%.*]] = icmp ult i64 [[ARG21]], [[TMP1]]
 ; CHECK-NEXT:    [[RT_CONFLICT:%.*]] = and i1 [[RT_BOUND0]], [[RT_BOUND1]]
 ; CHECK-NEXT:    [[RT_GUARD:%.*]] = freeze i1 [[RT_CONFLICT]]
-; CHECK-NEXT:    br i1 [[RT_GUARD]], label %[[ENTRY_RTSCALAR:.*]], label %[[ENTRY_RTVEC:.*]]
+; CHECK-NEXT:    br i1 [[RT_GUARD]], label %[[ENTRY_RTSCALAR:.*]], label %[[ENTRY_RTVEC:.*]], !prof [[PROF0]]
 ; CHECK:       [[ENTRY_RTVEC]]:
 ; CHECK-NEXT:    [[GEP4_1:%.*]] = getelementptr i8, ptr [[ARG]], i64 4
 ; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <2 x ptr> poison, ptr [[ARG]], i64 0
@@ -316,3 +316,6 @@ declare i16 @llvm.sadd.sat.i16(i16, i16) #0
 attributes #0 = { nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none) }
 
 uselistorder ptr @llvm.sadd.sat.i16, { 2, 1, 0 }
+;.
+; CHECK: [[PROF0]] = !{!"branch_weights", i32 1, i32 1048575}
+;.

--- a/llvm/test/Transforms/SLPVectorizer/X86/runtime-alias-checks.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/runtime-alias-checks.ll
@@ -23,7 +23,7 @@ define void @test(ptr %dst, ptr %x, ptr %y) {
 ; CHECK-NEXT:    [[RT_CONFLICT13:%.*]] = and i1 [[RT_BOUND011]], [[RT_BOUND112]]
 ; CHECK-NEXT:    [[RT_CONFLICT_ALL:%.*]] = or i1 [[RT_CONFLICT]], [[RT_CONFLICT13]]
 ; CHECK-NEXT:    [[RT_GUARD:%.*]] = freeze i1 [[RT_CONFLICT_ALL]]
-; CHECK-NEXT:    br i1 [[RT_GUARD]], label %[[ENTRY_RTSCALAR:.*]], label %[[ENTRY_RTVEC:.*]]
+; CHECK-NEXT:    br i1 [[RT_GUARD]], label %[[ENTRY_RTSCALAR:.*]], label %[[ENTRY_RTVEC:.*]], !prof [[PROF0:![0-9]+]]
 ; CHECK:       [[ENTRY_RTVEC]]:
 ; CHECK-NEXT:    [[TMP3:%.*]] = load <4 x double>, ptr [[X]], align 8
 ; CHECK-NEXT:    [[TMP4:%.*]] = load <4 x double>, ptr [[Y]], align 8
@@ -228,7 +228,7 @@ define void @test_dup_switch_successor(ptr %dst, ptr %x, ptr %y, i32 %cond) {
 ; CHECK-NEXT:    [[RT_CONFLICT13:%.*]] = and i1 [[RT_BOUND011]], [[RT_BOUND112]]
 ; CHECK-NEXT:    [[RT_CONFLICT_ALL:%.*]] = or i1 [[RT_CONFLICT]], [[RT_CONFLICT13]]
 ; CHECK-NEXT:    [[RT_GUARD:%.*]] = freeze i1 [[RT_CONFLICT_ALL]]
-; CHECK-NEXT:    br i1 [[RT_GUARD]], label %[[ENTRY_RTSCALAR:.*]], label %[[ENTRY_RTVEC:.*]]
+; CHECK-NEXT:    br i1 [[RT_GUARD]], label %[[ENTRY_RTSCALAR:.*]], label %[[ENTRY_RTVEC:.*]], !prof [[PROF0]]
 ; CHECK:       [[EXIT:.*]]:
 ; CHECK-NEXT:    ret void
 ; CHECK:       [[ENTRY_RTVEC]]:
@@ -1132,7 +1132,7 @@ define void @versioned_block_with_loop_defined_base(ptr %arg, ptr %arg1, ptr %ar
 ; CHECK-NEXT:    [[RT_BOUND1:%.*]] = icmp ult i64 [[PHI_LCSSA1]], [[TMP1]]
 ; CHECK-NEXT:    [[RT_CONFLICT:%.*]] = and i1 [[RT_BOUND0]], [[RT_BOUND1]]
 ; CHECK-NEXT:    [[RT_GUARD:%.*]] = freeze i1 [[RT_CONFLICT]]
-; CHECK-NEXT:    br i1 [[RT_GUARD]], label %[[BBL9_RTSCALAR:.*]], label %[[BBL9_RTVEC:.*]]
+; CHECK-NEXT:    br i1 [[RT_GUARD]], label %[[BBL9_RTSCALAR:.*]], label %[[BBL9_RTVEC:.*]], !prof [[PROF0]]
 ; CHECK:       [[BBL9_RTVEC]]:
 ; CHECK-NEXT:    [[TMP2:%.*]] = load <16 x i8>, ptr [[PHI_LCSSA]], align 1
 ; CHECK-NEXT:    store <16 x i8> [[TMP2]], ptr [[ARG2]], align 1
@@ -1363,3 +1363,6 @@ bbl9:
   store i8 %load53, ptr %gep54, align 1
   ret void
 }
+;.
+; CHECK: [[PROF0]] = !{!"branch_weights", i32 1, i32 1048575}
+;.


### PR DESCRIPTION
This makes two main changes
* Adds profile information regardless of whether or not the function is profile. This data is still useful even when little else is profiled. e.g., it helps ensure that registers are spilt in the cold block rather than the hot one.
* Switches to using MDBuilder's branch weight designations. The named values make the meaning of the code clearer and this is the standard way to denote cold code in the compiler absent additional information about the specific frequency here.